### PR TITLE
Make WebVTT cue settings configurable again

### DIFF
--- a/src/ui/Features/Files/FormatProperties/WebVttProperties/WebVttPropertiesViewModel.cs
+++ b/src/ui/Features/Files/FormatProperties/WebVttProperties/WebVttPropertiesViewModel.cs
@@ -1,253 +1,84 @@
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Xml.Linq;
 using Avalonia.Controls;
 using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Logic.Config;
-using Nikse.SubtitleEdit.Logic.Media;
 
 namespace Nikse.SubtitleEdit.Features.Files.FormatProperties.WebVttProperties;
 
 public partial class WebVttPropertiesViewModel : ObservableObject
 {
-    [ObservableProperty] private ObservableCollection<string> _languages;
-    [ObservableProperty] private string _selectedLanguage;
-    [ObservableProperty] private string _selectedFontName;
-    [ObservableProperty] private decimal _selectedFontSize;
-    [ObservableProperty] private string _selectedLineHeight;
+    [ObservableProperty] private string _cueAn1;
+    [ObservableProperty] private string _cueAn2;
+    [ObservableProperty] private string _cueAn3;
+    [ObservableProperty] private string _cueAn4;
+    [ObservableProperty] private string _cueAn5;
+    [ObservableProperty] private string _cueAn6;
+    [ObservableProperty] private string _cueAn7;
+    [ObservableProperty] private string _cueAn8;
+    [ObservableProperty] private string _cueAn9;
+    [ObservableProperty] private bool _useXTimestampMap;
+    [ObservableProperty] private bool _mergeLinesWithSameText;
+    [ObservableProperty] private bool _mergeStyleTags;
 
     public Window? Window { get; set; }
 
-    public Subtitle Subtitle { get; set; }
-
     public bool OkPressed { get; private set; }
 
-    private readonly IFileHelper _fileHelper;
-
-    private readonly List<string> _bcp47LanguageTags =
-    [
-        "aeb",
-        "af",
-        "af-NA",
-        "af-ZA",
-        "als",
-    ];
-
-    public WebVttPropertiesViewModel(IFileHelper fileHelper)
+    public WebVttPropertiesViewModel()
     {
-        _fileHelper = fileHelper;
-
-        Languages =
-        [
-            Se.Language.General.Autodetect,
-            .. _bcp47LanguageTags,
-        ];
-        SelectedLanguage = Languages[0];
-
-        SelectedLanguage = string.Empty;
-        SelectedFontName = string.Empty;
-        SelectedFontSize = 5.3m;
-        SelectedLineHeight = string.Empty;
-        Subtitle = new Subtitle();
-        LoadSettings();
-    }
-
-    private void LoadSettings()
-    {
-        SelectedLineHeight = Se.Settings.Formats.RosettaLineHeight;
-
-        var fontSize = Se.Settings.Formats.RosettaFontSize.Replace("rh", string.Empty);
-        if (decimal.TryParse(fontSize, CultureInfo.InvariantCulture, out var d))
-        {
-            SelectedFontSize = d;
-        }
-        else
-        {
-            SelectedFontSize = 5.3m;
-        }
-
-        if (Se.Settings.Formats.RosettaLanguageAutoDetect)
-        {
-            SelectedLanguage = Languages[0];
-        }
-        else
-        {
-            var lang = Languages.FirstOrDefault(l => l == Se.Settings.Formats.RosettaLanguage);
-            SelectedLanguage = lang ?? Languages[0];
-        }
+        var formats = Se.Settings.Formats;
+        _cueAn1 = formats.WebVttCueAn1 ?? string.Empty;
+        _cueAn2 = formats.WebVttCueAn2 ?? string.Empty;
+        _cueAn3 = formats.WebVttCueAn3 ?? string.Empty;
+        _cueAn4 = formats.WebVttCueAn4 ?? string.Empty;
+        _cueAn5 = formats.WebVttCueAn5 ?? string.Empty;
+        _cueAn6 = formats.WebVttCueAn6 ?? string.Empty;
+        _cueAn7 = formats.WebVttCueAn7 ?? string.Empty;
+        _cueAn8 = formats.WebVttCueAn8 ?? string.Empty;
+        _cueAn9 = formats.WebVttCueAn9 ?? string.Empty;
+        _useXTimestampMap = formats.WebVttUseXTimestampMap;
+        _mergeLinesWithSameText = formats.WebVttMergeLinesWithSameText;
+        _mergeStyleTags = !formats.WebVttDoNoMergeTags;
     }
 
     private void SaveSettings()
     {
-        Se.Settings.Formats.RosettaLineHeight = SelectedLineHeight;
-        Se.Settings.Formats.RosettaFontSize = SelectedFontSize.ToString(CultureInfo.InvariantCulture) + "rh";
-
-        if (SelectedLanguage == Languages[0])
-        {
-            Se.Settings.Formats.RosettaLanguageAutoDetect = true;
-            Se.Settings.Formats.RosettaLanguage = "en";
-        }
-        else
-        {
-            Se.Settings.Formats.RosettaLanguageAutoDetect = false;
-            Se.Settings.Formats.RosettaLanguage = SelectedLanguage;
-        }
+        var formats = Se.Settings.Formats;
+        formats.WebVttCueAn1 = CueAn1 ?? string.Empty;
+        formats.WebVttCueAn2 = CueAn2 ?? string.Empty;
+        formats.WebVttCueAn3 = CueAn3 ?? string.Empty;
+        formats.WebVttCueAn4 = CueAn4 ?? string.Empty;
+        formats.WebVttCueAn5 = CueAn5 ?? string.Empty;
+        formats.WebVttCueAn6 = CueAn6 ?? string.Empty;
+        formats.WebVttCueAn7 = CueAn7 ?? string.Empty;
+        formats.WebVttCueAn8 = CueAn8 ?? string.Empty;
+        formats.WebVttCueAn9 = CueAn9 ?? string.Empty;
+        formats.WebVttUseXTimestampMap = UseXTimestampMap;
+        formats.WebVttMergeLinesWithSameText = MergeLinesWithSameText;
+        formats.WebVttDoNoMergeTags = !MergeStyleTags;
 
         Se.SaveSettings();
     }
 
-    public void Initialize(Subtitle subtitle)
-    {
-        Subtitle = subtitle;
-        ReadValuesFromXml(subtitle);
-    }
-
-    private void ReadValuesFromXml(Subtitle subtitle)
-    {
-
-        if (subtitle.Header?.Contains("imsc-rosetta") == true)
-        {
-            ReadValuesFromXml(subtitle.Header);
-        }
-    }
-
-    private void ReadValuesFromXml(string header)
-    {
-        try
-        {
-            var doc = XDocument.Load(new MemoryStream(Encoding.UTF8.GetBytes(header)));
-            XNamespace tt = "http://www.w3.org/ns/ttml";
-            XNamespace ttp = "http://www.w3.org/ns/ttml#parameter";
-            XNamespace tts = "http://www.w3.org/ns/ttml#styling";
-            XNamespace xml = "http://www.w3.org/XML/1998/namespace";
-            var ttElement = doc.Root;
-            if (ttElement != null)
-            {
-                var language = (string?)ttElement.Attribute(xml + "lang");
-                if (!string.IsNullOrEmpty(language))
-                {
-                    var l = Languages.FirstOrDefault(lang => lang == language);
-                    if (l != null)
-                    {
-                        SelectedLanguage = l;
-                    }
-                }
-
-                var rDefault = doc.Descendants(tt + "style").FirstOrDefault(e => (string?)e.Attribute(xml + "id") == "_r_default");
-                if (rDefault != null)
-                {
-                    var fontSize = (string?)rDefault.Attribute(tts + "fontSize");
-                    if (!string.IsNullOrEmpty(fontSize) && fontSize.EndsWith("rh"))
-                    {
-                        fontSize = fontSize.Replace("rh", string.Empty);
-                        if (decimal.TryParse(fontSize, CultureInfo.InvariantCulture, out var d))
-                        {
-                            SelectedFontSize = d;
-                        }
-                    }
-
-                    var lineHeight = (string?)rDefault.Attribute(tts + "lineHeight");
-                    if (!string.IsNullOrEmpty(lineHeight))
-                    {
-                        SelectedLineHeight = lineHeight;
-                    }
-                }
-
-                //var pFont1 = doc.Descendants(tt + "style").FirstOrDefault(e => (string?)e.Attribute(xml + "id") == "p_font1");
-                //if (pFont1 != null)
-                //{
-                //    var fontName = (string?)pFont1.Attribute(tts + "fontFamily");
-                //    if (!string.IsNullOrEmpty(fontName))
-                //    {
-                //        SelectedFontName = fontName;
-                //    }
-                //}
-            }
-        }
-        catch
-        {
-            // ignore
-        }
-    }
-
-    private void WriteValuesToXml(Subtitle subtitle)
-    {
-        try
-        {
-            if (subtitle.Header?.Contains("imsc-rosetta") == true)
-            {
-                var doc = XDocument.Load(new MemoryStream(Encoding.UTF8.GetBytes(subtitle.Header)));
-                XNamespace tt = "http://www.w3.org/ns/ttml";
-                XNamespace ttp = "http://www.w3.org/ns/ttml#parameter";
-                XNamespace tts = "http://www.w3.org/ns/ttml#styling";
-                XNamespace xml = "http://www.w3.org/XML/1998/namespace";
-                var ttElement = doc.Root;
-                if (ttElement != null)
-                {
-                    if (!string.IsNullOrEmpty(SelectedLanguage))
-                    {
-                        ttElement.SetAttributeValue(xml + "lang", SelectedLanguage);
-                    }
-
-                    var rDefault = doc.Descendants(tt + "style").FirstOrDefault(e => (string?)e.Attribute(xml + "id") == "_r_default");
-                    if (rDefault != null)
-                    {
-                        var fontSize = SelectedFontSize.ToString(CultureInfo.InvariantCulture) + "rh";
-                        rDefault.SetAttributeValue(tts + "fontSize", fontSize);
-
-                        if (!string.IsNullOrEmpty(SelectedLineHeight))
-                        {
-                            rDefault.SetAttributeValue(tts + "lineHeight", SelectedLineHeight);
-                        }
-                    }
-
-                    //var pFont1 = doc.Descendants(tt + "style").FirstOrDefault(e => (string?)e.Attribute(xml + "id") == "p_font1");
-                    //if (pFont1 != null && !string.IsNullOrEmpty(SelectedFontName))
-                    //{
-                    //    pFont1.SetAttributeValue(tts + "fontFamily", SelectedFontName);
-                    //}
-                }
-
-                subtitle.Header = doc.ToString();
-            }
-        }
-        catch
-        {
-            // ignore
-        }
-
-    }
-
     [RelayCommand]
-    private async Task Import()
+    private void ResetCueSettings()
     {
-
-        if (Window == null)
-        {
-            return;
-        }
-
-        var fileName = await _fileHelper.PickOpenFile(Window, "Import Rosetta properties", "IMSCR files", ".imscr");
-        if (fileName == null)
-        {
-            return;
-        }
-
-        ReadValuesFromXml(File.ReadAllText(fileName));
+        var defaults = new SeFormats();
+        CueAn1 = defaults.WebVttCueAn1;
+        CueAn2 = defaults.WebVttCueAn2;
+        CueAn3 = defaults.WebVttCueAn3;
+        CueAn4 = defaults.WebVttCueAn4;
+        CueAn5 = defaults.WebVttCueAn5;
+        CueAn6 = defaults.WebVttCueAn6;
+        CueAn7 = defaults.WebVttCueAn7;
+        CueAn8 = defaults.WebVttCueAn8;
+        CueAn9 = defaults.WebVttCueAn9;
     }
 
     [RelayCommand]
     private void Ok()
     {
-        WriteValuesToXml(Subtitle);
         SaveSettings();
         OkPressed = true;
         Window?.Close();

--- a/src/ui/Features/Files/FormatProperties/WebVttProperties/WebVttPropertiesWindow.cs
+++ b/src/ui/Features/Files/FormatProperties/WebVttProperties/WebVttPropertiesWindow.cs
@@ -1,69 +1,83 @@
 using Avalonia.Controls;
 using Avalonia.Layout;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 
 namespace Nikse.SubtitleEdit.Features.Files.FormatProperties.WebVttProperties;
-
 
 public class WebVttPropertiesWindow : Window
 {
     public WebVttPropertiesWindow(WebVttPropertiesViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.File.RosettaProperties;
-        SizeToContent = SizeToContent.WidthAndHeight;
+        Title = string.Format(Se.Language.File.XProperties, new WebVTT().Name);
+        SizeToContent = SizeToContent.Height;
+        Width = 700;
         CanResize = false;
-        MinWidth = 400;
         MinHeight = 200;
         vm.Window = this;
         DataContext = vm;
 
-        var labelWidth = 200;
-        
-        var labelLanguage = UiUtil.MakeLabel(Se.Language.General.Language).WithMinWidth(labelWidth);
-        var comboBoxLanguage = UiUtil.MakeComboBox<string>(vm.Languages, vm, nameof(vm.SelectedLanguage)).WithMinWidth(100);
-        var panelLanguage = new StackPanel
+        var l = Se.Language.File.WebVtt;
+
+        // The cue settings are laid out like the numpad, so {\an7} (top-left) sits top-left etc.
+        var alignmentGrid = new Grid
         {
-            Orientation = Orientation.Horizontal,
-            HorizontalAlignment = HorizontalAlignment.Left,
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            ColumnSpacing = 10,
+            RowSpacing = 10,
+        };
+
+        var textBoxAn7 = MakeCueSetting(alignmentGrid, 0, 0, Se.Language.General.TopLeft, vm, nameof(vm.CueAn7));
+        MakeCueSetting(alignmentGrid, 0, 1, Se.Language.General.TopCenter, vm, nameof(vm.CueAn8));
+        MakeCueSetting(alignmentGrid, 0, 2, Se.Language.General.TopRight, vm, nameof(vm.CueAn9));
+        MakeCueSetting(alignmentGrid, 1, 0, Se.Language.General.MiddleLeft, vm, nameof(vm.CueAn4));
+        MakeCueSetting(alignmentGrid, 1, 1, Se.Language.General.MiddleCenter, vm, nameof(vm.CueAn5));
+        MakeCueSetting(alignmentGrid, 1, 2, Se.Language.General.MiddleRight, vm, nameof(vm.CueAn6));
+        MakeCueSetting(alignmentGrid, 2, 0, Se.Language.General.BottomLeft, vm, nameof(vm.CueAn1));
+        MakeCueSetting(alignmentGrid, 2, 1, Se.Language.General.BottomCenter, vm, nameof(vm.CueAn2));
+        MakeCueSetting(alignmentGrid, 2, 2, Se.Language.General.BottomRight, vm, nameof(vm.CueAn3));
+
+        var alignmentPanel = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 5,
             Children =
             {
-                labelLanguage,
-                comboBoxLanguage,
+                UiUtil.MakeLabel(l.CueSettingsHint),
+                alignmentGrid,
             }
         };
 
-        var labelLineHeight = UiUtil.MakeLabel(Se.Language.General.LineHeight).WithMinWidth(labelWidth);
-        var textBoxLineHeight = UiUtil.MakeTextBox(100, vm, nameof(vm.SelectedLineHeight));
-        var panelLineHeight = new StackPanel
+        var checkBoxPanel = new StackPanel
         {
-            Orientation = Orientation.Horizontal,
+            Orientation = Orientation.Vertical,
             HorizontalAlignment = HorizontalAlignment.Left,
+            Spacing = 5,
             Children =
             {
-                labelLineHeight,
-                textBoxLineHeight,
+                UiUtil.MakeCheckBox(l.UseXTimeStamp, vm, nameof(vm.UseXTimestampMap)),
+                UiUtil.MakeCheckBox(l.MergeLines, vm, nameof(vm.MergeLinesWithSameText)),
+                UiUtil.MakeCheckBox(l.MergeStyleTags, vm, nameof(vm.MergeStyleTags)),
             }
         };
 
-        var labelFontSize = UiUtil.MakeLabel(Se.Language.File.RosettaFontSize).WithMinWidth(labelWidth);
-        var numericUpDownFontSize = UiUtil.MakeNumericUpDownOneDecimal(1, 100, 120, vm, nameof(vm.SelectedFontSize));
-        var panelFontSize = new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-            HorizontalAlignment = HorizontalAlignment.Left,
-            Children =
-            {
-                labelFontSize,
-                numericUpDownFontSize,
-            }
-        };
-
-        var buttonImport = UiUtil.MakeButton(Se.Language.General.ImportDotDotDot, vm.ImportCommand);
+        var buttonReset = UiUtil.MakeButton(Se.Language.General.Reset, vm.ResetCueSettingsCommand);
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
-        var buttonPanel = UiUtil.MakeButtonBar(buttonImport, buttonOk, buttonCancel);
+        var buttonPanel = UiUtil.MakeButtonBar(buttonReset, buttonOk, buttonCancel);
 
         var grid = new Grid
         {
@@ -85,14 +99,35 @@ public class WebVttPropertiesWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
-        grid.Add(panelLanguage, 0);
-        grid.Add(panelLineHeight, 1);
-        grid.Add(panelFontSize, 2);
-        grid.Add(buttonPanel, 5);
+        grid.Add(UiUtil.MakeLabel(l.CueSettings).WithBold(), 0);
+        grid.Add(UiUtil.MakeBorderForControl(alignmentPanel), 1);
+        grid.Add(checkBoxPanel, 2);
+        grid.Add(buttonPanel, 3);
 
         Content = grid;
 
-        Activated += delegate { comboBoxLanguage.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        Activated += delegate { textBoxAn7.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
+    }
+
+    private static TextBox MakeCueSetting(Grid grid, int row, int column, string title, WebVttPropertiesViewModel vm, string propertyName)
+    {
+        var textBox = UiUtil.MakeTextBox(180, vm, propertyName);
+        textBox.HorizontalAlignment = HorizontalAlignment.Stretch;
+
+        var panel = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 2,
+            Children =
+            {
+                UiUtil.MakeLabel(title),
+                textBox,
+            }
+        };
+
+        grid.Add(panel, row, column);
+
+        return textBox;
     }
 }

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -57,6 +57,7 @@ using Nikse.SubtitleEdit.Features.Files.FormatProperties.RosettaProperties;
 using Nikse.SubtitleEdit.Features.Files.FormatProperties.TimedText10Properties;
 using Nikse.SubtitleEdit.Features.Files.FormatProperties.TimedTextImsc11Properties;
 using Nikse.SubtitleEdit.Features.Files.FormatProperties.TmpegEncXmlProperties;
+using Nikse.SubtitleEdit.Features.Files.FormatProperties.WebVttProperties;
 using Nikse.SubtitleEdit.Features.Files.ImportImages;
 using Nikse.SubtitleEdit.Features.Files.ImportCsvXlsxCustomColumns;
 using Nikse.SubtitleEdit.Features.Files.ImportPlainText;
@@ -3190,6 +3191,12 @@ public partial class MainViewModel :
         if (format is TmpegEncXml)
         {
             var result = await ShowDialogAsync<TmpegEncXmlPropertiesWindow, TmpegEncXmlPropertiesViewModel>(vm => { });
+            SetLibSeSettings();
+        }
+
+        if (format is WebVTT or WebVTTFileWithLineNumber)
+        {
+            var result = await ShowDialogAsync<WebVttPropertiesWindow, WebVttPropertiesViewModel>(vm => { });
             SetLibSeSettings();
         }
 
@@ -25744,7 +25751,7 @@ public partial class MainViewModel :
         if (e.AddedItems.Count == 1)
         {
             var format = e.AddedItems[0] as SubtitleFormat;
-            if (format is TimedTextImsc11 or ItunesTimedText or TimedText10 or TimedTextImscRosetta or TmpegEncXml or DCinemaSmpte2007 or DCinemaSmpte2010 or DCinemaSmpte2014 or DCinemaInterop)
+            if (format is TimedTextImsc11 or ItunesTimedText or TimedText10 or TimedTextImscRosetta or TmpegEncXml or DCinemaSmpte2007 or DCinemaSmpte2010 or DCinemaSmpte2014 or DCinemaInterop or WebVTT or WebVTTFileWithLineNumber)
             {
                 IsFilePropertiesVisible = true;
                 FilePropertiesText = string.Format(Se.Language.Main.XPropertiesDotDotDot, format.Name);

--- a/src/ui/Logic/Config/Language/File/LanguageWebVtt.cs
+++ b/src/ui/Logic/Config/Language/File/LanguageWebVtt.cs
@@ -15,6 +15,11 @@ public class LanguageWebVtt
     public string OpenStyleFileTitle { get; set; }
     public string NoStylesToImport { get; set; }
     public string DuplicateStyleNamesX { get; set; }
+    public string CueSettings { get; set; }
+    public string CueSettingsHint { get; set; }
+    public string UseXTimeStamp { get; set; }
+    public string MergeLines { get; set; }
+    public string MergeStyleTags { get; set; }
 
     public LanguageWebVtt()
     {
@@ -31,5 +36,10 @@ public class LanguageWebVtt
         OpenStyleFileTitle = "Open WebVTT file to import styles from";
         NoStylesToImport = "No styles found in the chosen file";
         DuplicateStyleNamesX = "Duplicate style names: {0}";
+        CueSettings = "Cue settings for alignment";
+        CueSettingsHint = "Cue settings written when a line is aligned, e.g. \"line:20%\" for top-center";
+        UseXTimeStamp = "Use X-TIMESTAMP-MAP header value";
+        MergeLines = "Merge lines with same text on load";
+        MergeStyleTags = "Merge style tags";
     }
 }

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -685,6 +685,17 @@ public class Se
         var ss = Configuration.Settings.SubtitleSettings;
         ss.WebVttUseXTimestampMap = Settings.Formats.WebVttUseXTimestampMap;
         ss.WebVttUseMultipleXTimestampMap = Settings.Formats.WebVttUseMultipleXTimestampMap;
+        ss.WebVttMergeLinesWithSameText = Settings.Formats.WebVttMergeLinesWithSameText;
+        ss.WebVttDoNoMergeTags = Settings.Formats.WebVttDoNoMergeTags;
+        ss.WebVttCueAn1 = Settings.Formats.WebVttCueAn1 ?? string.Empty;
+        ss.WebVttCueAn2 = Settings.Formats.WebVttCueAn2 ?? string.Empty;
+        ss.WebVttCueAn3 = Settings.Formats.WebVttCueAn3 ?? string.Empty;
+        ss.WebVttCueAn4 = Settings.Formats.WebVttCueAn4 ?? string.Empty;
+        ss.WebVttCueAn5 = Settings.Formats.WebVttCueAn5 ?? string.Empty;
+        ss.WebVttCueAn6 = Settings.Formats.WebVttCueAn6 ?? string.Empty;
+        ss.WebVttCueAn7 = Settings.Formats.WebVttCueAn7 ?? string.Empty;
+        ss.WebVttCueAn8 = Settings.Formats.WebVttCueAn8 ?? string.Empty;
+        ss.WebVttCueAn9 = Settings.Formats.WebVttCueAn9 ?? string.Empty;
         ss.DCinemaAutoGenerateSubtitleId = dc.DCinemaAutoGenerateSubtitleId;
         ss.DCinemaFontSize = dc.DCinemaFontSize;
         ss.DCinemaBottomMargin = dc.DCinemaBottomMargin;

--- a/src/ui/Logic/Config/SeFormats.cs
+++ b/src/ui/Logic/Config/SeFormats.cs
@@ -17,7 +17,20 @@ public class SeFormats
     // On by default to match the spec; can be turned off for files where the offset is unwanted.
     public bool WebVttUseXTimestampMap { get; set; }
     public bool WebVttUseMultipleXTimestampMap { get; set; }
+    public bool WebVttMergeLinesWithSameText { get; set; }
+    public bool WebVttDoNoMergeTags { get; set; }
 
+    // Cue settings written for each ASSA alignment tag ({\an1} - {\an9}) when saving WebVTT,
+    // e.g. "{\an8}" -> "line:20%". Free text, so any valid cue setting can be used.
+    public string WebVttCueAn1 { get; set; }
+    public string WebVttCueAn2 { get; set; }
+    public string WebVttCueAn3 { get; set; }
+    public string WebVttCueAn4 { get; set; }
+    public string WebVttCueAn5 { get; set; }
+    public string WebVttCueAn6 { get; set; }
+    public string WebVttCueAn7 { get; set; }
+    public string WebVttCueAn8 { get; set; }
+    public string WebVttCueAn9 { get; set; }
 
     public SeFormats()
     {
@@ -34,5 +47,17 @@ public class SeFormats
 
         WebVttUseXTimestampMap = true;
         WebVttUseMultipleXTimestampMap = true;
+        WebVttMergeLinesWithSameText = false;
+        WebVttDoNoMergeTags = false;
+
+        WebVttCueAn1 = "position:20%";
+        WebVttCueAn2 = string.Empty;
+        WebVttCueAn3 = "position:80%";
+        WebVttCueAn4 = "position:20% line:50%";
+        WebVttCueAn5 = "line:50%";
+        WebVttCueAn6 = "position:80% line:50%";
+        WebVttCueAn7 = "position:20% line:20%";
+        WebVttCueAn8 = "line:20%";
+        WebVttCueAn9 = "position:80% line:20%";
     }
 }

--- a/tests/UI/Features/Files/WebVttPropertiesTests.cs
+++ b/tests/UI/Features/Files/WebVttPropertiesTests.cs
@@ -1,0 +1,158 @@
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Files.FormatProperties.WebVttProperties;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Files;
+
+public class WebVttPropertiesTests
+{
+    private static WebVttPropertiesViewModel MakeViewModel()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<WebVttPropertiesViewModel>();
+    }
+
+    [AvaloniaFact]
+    public void Window_OpensWithDefaults()
+    {
+        Se.Settings.Formats = new SeFormats();
+
+        var vm = MakeViewModel();
+        var window = new WebVttPropertiesWindow(vm);
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal("line:20%", vm.CueAn8);
+            Assert.Equal("position:20% line:20%", vm.CueAn7);
+            Assert.Equal(string.Empty, vm.CueAn2);
+            Assert.True(vm.UseXTimestampMap);
+            Assert.True(vm.MergeStyleTags);
+            Assert.False(vm.MergeLinesWithSameText);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Ok_SavesCueSettings()
+    {
+        Se.Settings.Formats = new SeFormats();
+
+        var vm = MakeViewModel();
+        var window = new WebVttPropertiesWindow(vm);
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            vm.CueAn8 = "line:5%";
+            vm.CueAn7 = "position:20% line:5%";
+            vm.MergeStyleTags = false;
+            vm.MergeLinesWithSameText = true;
+
+            vm.OkCommand.Execute(null);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(vm.OkPressed);
+            Assert.Equal("line:5%", Se.Settings.Formats.WebVttCueAn8);
+            Assert.Equal("position:20% line:5%", Se.Settings.Formats.WebVttCueAn7);
+            Assert.True(Se.Settings.Formats.WebVttDoNoMergeTags);
+            Assert.True(Se.Settings.Formats.WebVttMergeLinesWithSameText);
+        }
+        finally
+        {
+            if (!vm.OkPressed)
+            {
+                window.Close();
+            }
+        }
+    }
+
+    [AvaloniaFact]
+    public void Cancel_DoesNotSaveSettings()
+    {
+        Se.Settings.Formats = new SeFormats();
+
+        var vm = MakeViewModel();
+        var window = new WebVttPropertiesWindow(vm);
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        vm.CueAn8 = "line:99%";
+        vm.CancelCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.False(vm.OkPressed);
+        Assert.Equal("line:20%", Se.Settings.Formats.WebVttCueAn8);
+    }
+
+    [AvaloniaFact]
+    public void Reset_RestoresDefaultCueSettings()
+    {
+        Se.Settings.Formats = new SeFormats();
+
+        var vm = MakeViewModel();
+        var window = new WebVttPropertiesWindow(vm);
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            vm.CueAn8 = "line:5%";
+            vm.ResetCueSettingsCommand.Execute(null);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal("line:20%", vm.CueAn8);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void CueSettings_ReachLibSeAndAreWrittenToFile()
+    {
+        Se.Settings.Formats = new SeFormats();
+
+        var vm = MakeViewModel();
+        var window = new WebVttPropertiesWindow(vm);
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            vm.CueAn8 = "line:5%";
+            vm.OkCommand.Execute(null);
+            Dispatcher.UIThread.RunJobs();
+
+            Se.UpdateLibSeSettings();
+            Assert.Equal("line:5%", Configuration.Settings.SubtitleSettings.WebVttCueAn8);
+
+            var subtitle = new Subtitle();
+            subtitle.Paragraphs.Add(new Paragraph("{\\an8}Hello", 1000, 2000));
+            var text = new WebVTT().ToText(subtitle, "test");
+
+            Assert.Contains("line:5%", text);
+            Assert.DoesNotContain("line:20%", text);
+        }
+        finally
+        {
+            if (!vm.OkPressed)
+            {
+                window.Close();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #13586

### The report

Aligning a cue to the top always writes `line:20%`, with no way to change it. In SE 4 this was configurable (the reporter had it at 5%), and searching SE 5's settings for "webvtt" only turns up the X-TIMESTAMP-MAP checkbox.

### What happened

The values themselves survived the rewrite - `WebVTT.GetPositionInfoFromAssTag` still maps each `{\anX}` tag through `SubtitleSettings.WebVttCueAn1..An9`, and `{\an8}` defaults to `line:20%`. What was lost is everything around them:

- SE 4's `Forms/VTT/WebVttProperties` dialog (nine cue-setting boxes + three checkboxes) has an SE 5 counterpart in name only: `WebVttPropertiesViewModel`/`Window` were a copy of the Rosetta dialog and read/wrote `RosettaLineHeight`, `RosettaFontSize` and `RosettaLanguage`.
- Nothing opened it - `FilePropertiesShow` had no WebVTT branch - and the File menu's properties item is hidden for WebVTT.
- Nothing persisted it. SE 5 never saves libse's `Configuration.Settings`, and `SeFormats` carried only the two X-TIMESTAMP-MAP flags, so the cue settings reset to the hardcoded defaults on every launch.

`WebVttMergeLinesWithSameText` and `WebVttDoNoMergeTags` were in the same boat - used by libse, no SE 5 UI, no persistence.

### This PR

- `SeFormats` gains the nine cue settings and the two merge flags (libse's defaults), and `Se.UpdateLibSeSettings` bridges them.
- `WebVttPropertiesViewModel`/`Window` become the real dialog: cue settings laid out like the numpad, the three SE 4 checkboxes, and a Reset that restores the defaults.
- File -> WebVTT properties opens it for `WebVTT` and `WebVTTFileWithLineNumber`.

### Verification

Five new tests in `tests/UI/Features/Files/WebVttPropertiesTests.cs` cover defaults, OK/Cancel, Reset, and the end-to-end path: set top-center to `line:5%`, save, bridge to libse, and confirm a `{\an8}` line is written as `line:5%`. Full UI suite green (2611 tests).

### Note for the reporter

Cues that already carried a `line:` setting when the file was loaded keep their original value on save (that is deliberate - #10209 - so exact positions are not grid-locked). The configured percentage applies once the alignment is re-applied to the line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
