### PR TITLE
Restore SE4 option to remove blank lines when opening a subtitle

### DIFF
--- a/docs/features/settings.md
+++ b/docs/features/settings.md
@@ -51,6 +51,7 @@ Profiles store subtitle rules and limits. You can switch between profiles for di
 - **Auto-convert to UTF-8** — Automatically convert files to UTF-8
 - **Force CR+LF on save** — Use Windows-style line endings
 - **Auto-trim whitespace** — Remove trailing spaces
+- **Remove blank lines when opening a subtitle** — Drop lines without text when a subtitle file is opened or inserted. Off by default
 
 ## Tools
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -4282,6 +4282,17 @@ public partial class MainViewModel :
             return;
         }
 
+        if (Se.Settings.General.RemoveBlankLinesWhenOpening)
+        {
+            subtitle.RemoveEmptyLines();
+            if (subtitle.Paragraphs.Count == 0)
+            {
+                // Nothing left to insert - the file held blank lines only.
+                _shortcutManager.ClearKeys();
+                return;
+            }
+        }
+
         // Anchor the file at the right-clicked waveform position when opened from the waveform
         // context menu; the current video position is the fallback (SE4 behavior).
         var videoPosition = _waveformContextMenuSeconds ?? vp.Position;
@@ -4341,6 +4352,17 @@ public partial class MainViewModel :
                 MessageBoxButtons.OK, MessageBoxIcon.Error);
             _shortcutManager.ClearKeys();
             return;
+        }
+
+        if (Se.Settings.General.RemoveBlankLinesWhenOpening)
+        {
+            subtitle.RemoveEmptyLines();
+            if (subtitle.Paragraphs.Count == 0)
+            {
+                // Nothing left to insert - the file held blank lines only.
+                _shortcutManager.ClearKeys();
+                return;
+            }
         }
 
         // Keep the file's own time codes so pre-timed subtitles land at their real positions
@@ -13826,11 +13848,25 @@ public partial class MainViewModel :
     [RelayCommand]
     private void RemoveBlankLines()
     {
-        var blankLines = Subtitles.Where(s => string.IsNullOrWhiteSpace(s.Text)).ToList();
+        var count = RemoveBlankLinesFromGrid();
+        if (count > 0)
+        {
+            ShowStatus(string.Format(Se.Language.Main.RemovedXBlankLines, count));
+        }
+    }
+
+    /// <summary>
+    /// Drops every line without text from the grid and renumbers. Returns the number of lines removed.
+    /// Uses the same "blank" rule as <see cref="Subtitle.RemoveEmptyLines"/> so a line holding only
+    /// zero-width or other control characters counts as blank here too.
+    /// </summary>
+    private int RemoveBlankLinesFromGrid()
+    {
+        var blankLines = Subtitles.Where(s => s.Text.IsOnlyControlCharactersOrWhiteSpace()).ToList();
         var count = blankLines.Count;
         if (count == 0)
         {
-            return;
+            return 0;
         }
 
         foreach (var line in blankLines)
@@ -13841,7 +13877,7 @@ public partial class MainViewModel :
         Renumber();
         _updateAudioVisualizer = true;
 
-        ShowStatus(string.Format(Se.Language.Main.RemovedXBlankLines, count));
+        return count;
     }
 
     private SubtitleLineViewModel? _setEndAtKeyUpLine;
@@ -17510,6 +17546,16 @@ public partial class MainViewModel :
             _changeSubtitleHash = GetFastHash();
             ShowStatus(string.Format(Se.Language.General.SubtitleLoadedX, fileName));
             LoadBookmarks();
+
+            // SE 4 parity (#13588). This runs after LoadBookmarks because bookmarks are stored by
+            // line index, so they must be applied while the blank lines are still there. The hash is
+            // refreshed afterwards, again like SE 4, so the cleanup alone does not make a freshly
+            // opened file look edited.
+            if (Se.Settings.General.RemoveBlankLinesWhenOpening && RemoveBlankLinesFromGrid() > 0)
+            {
+                _subtitle.RemoveEmptyLines(); // keep the loaded subtitle in step with the grid
+                _changeSubtitleHash = GetFastHash();
+            }
 
             // Restore the last editing position when a file from the recent list is reopened
             // via Explorer/Finder double-click, File > Open, or drag & drop, like SE 4 did

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -276,6 +276,7 @@ public class SettingsPage : UserControl
             MakeCheckboxSetting(Se.Language.Options.Settings.AutoConvertToUtf8, nameof(_vm.AutoConvertToUtf8)),
             MakeCheckboxSetting(Se.Language.Options.Settings.ForceCrLfOnSave, nameof(_vm.ForceCrLfOnSave)),
             MakeCheckboxSetting(Se.Language.Options.Settings.AutoTrimWhiteSpace, nameof(_vm.AutoTrimWhiteSpace)),
+            MakeCheckboxSetting(Se.Language.Options.Settings.RemoveBlankLinesWhenOpening, nameof(_vm.RemoveBlankLinesWhenOpening)),
             new SettingsItem(Se.Language.Options.Settings.DefaultEncoding, () => new ComboBox
             {
                 Width = 200,

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -154,6 +154,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _autoConvertToUtf8;
     [ObservableProperty] private bool _forceCrLfOnSave;
     [ObservableProperty] private bool _autoTrimWhiteSpace;
+    [ObservableProperty] private bool _removeBlankLinesWhenOpening;
 
     [ObservableProperty] private ObservableCollection<string> _subtitleEnterKeyActionTypes;
     [ObservableProperty] private string _selectedSubtitleEnterKeyActionType;
@@ -768,6 +769,7 @@ public partial class SettingsViewModel : ObservableObject
         AutoConvertToUtf8 = general.AutoConvertToUtf8;
         ForceCrLfOnSave = general.ForceCrLfOnSave;
         AutoTrimWhiteSpace = general.AutoTrimWhiteSpace;
+        RemoveBlankLinesWhenOpening = general.RemoveBlankLinesWhenOpening;
 
         SelectedDefaultSubtitleFormat = general.DefaultSubtitleFormat;
         if (!DefaultSubtitleFormats.Contains(SelectedDefaultSubtitleFormat))
@@ -1623,6 +1625,7 @@ public partial class SettingsViewModel : ObservableObject
         general.AutoConvertToUtf8 = AutoConvertToUtf8;
         general.ForceCrLfOnSave = ForceCrLfOnSave;
         general.AutoTrimWhiteSpace = AutoTrimWhiteSpace;
+        general.RemoveBlankLinesWhenOpening = RemoveBlankLinesWhenOpening;
 
         general.DefaultSubtitleFormat = SelectedDefaultSubtitleFormat;
         general.DefaultSaveAsFormat = SelectedSaveSubtitleFormat;

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -100,6 +100,7 @@ public class LanguageSettings
     public string AutoBackupDeleteAfterDays { get; set; }
     public string AutoConvertToUtf8 { get; set; }
     public string AutoTrimWhiteSpace { get; set; }
+    public string RemoveBlankLinesWhenOpening { get; set; }
     public string DefaultEncoding { get; set; }
     public string ColorDurationTooShort { get; set; }
     public string ColorDurationTooLong { get; set; }
@@ -417,6 +418,7 @@ public class LanguageSettings
         AutoBackupDeleteAfterDays = "Auto-backup retention (days)";
         AutoConvertToUtf8 = "Auto-convert encoding to UTF-8 on open";
         AutoTrimWhiteSpace = "Auto-trim white-space";
+        RemoveBlankLinesWhenOpening = "Remove blank lines when opening a subtitle";
         DefaultEncoding = "Default encoding";
         ColorDurationTooShort = "Color duration if too short";
         ColorDurationTooLong = "Color duration if too long";

--- a/src/ui/Logic/Config/SeGeneral.cs
+++ b/src/ui/Logic/Config/SeGeneral.cs
@@ -138,6 +138,12 @@ public class SeGeneral
     public bool WriteAn2Tag { get; set; }
     public bool AutoTrimWhiteSpace { get; set; }
 
+    /// <summary>
+    /// SE 4 parity (#13588): drop lines with no text when a subtitle file is opened or inserted.
+    /// Off by default, like SE 4.
+    /// </summary>
+    public bool RemoveBlankLinesWhenOpening { get; set; }
+
     public long CurrentVideoOffsetInMs = 0;
     public bool CurrentVideoIsSmpte = false;
 

--- a/tests/UI/Features/Main/SubtitleOpenRemoveBlankLinesTests.cs
+++ b/tests/UI/Features/Main/SubtitleOpenRemoveBlankLinesTests.cs
@@ -1,0 +1,156 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// SE 4's "Remove blank lines when opening a subtitle" (issue #13588) restored: opening a file
+/// with the setting on drops the lines that hold no text. Three things have to stay true beyond
+/// the removal itself - the setting must be honored both ways, bookmarks (stored by line index)
+/// must still land on the lines they were saved for, and the cleanup on its own must not make a
+/// freshly opened file look edited.
+/// </summary>
+public class SubtitleOpenRemoveBlankLinesTests : IDisposable
+{
+    // Every window opened by a test is closed again in Dispose: if a test stops early, an
+    // unclosed window would outlive the test and race with the headless session teardown.
+    private readonly List<Window> _windows = new();
+    private readonly string _tempDirectory;
+
+    public SubtitleOpenRemoveBlankLinesTests()
+    {
+        _tempDirectory = Path.Combine(Path.GetTempPath(), "SubtitleEdit.UITests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+    }
+
+    private (Window Window, MainViewModel Vm) ShowEmptyMainWindow()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1400, Height = 900 };
+        _windows.Add(window);
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var vm = (MainViewModel)view.DataContext!;
+        window.SuppressSaveChangesPromptOnClose(vm);
+        return (window, vm);
+    }
+
+    private static void Settle(Window window)
+    {
+        for (var pump = 0; pump < 5; pump++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+        }
+    }
+
+    /// <summary>
+    /// Three cues where the middle one carries no text - the shape of the older subtitles the
+    /// issue is about.
+    /// </summary>
+    private string WriteSrtWithBlankLine(string name)
+    {
+        var fileName = Path.Combine(_tempDirectory, name);
+        File.WriteAllText(fileName,
+            "1" + Environment.NewLine +
+            "00:00:01,000 --> 00:00:02,000" + Environment.NewLine +
+            "Line one" + Environment.NewLine +
+            Environment.NewLine +
+            "2" + Environment.NewLine +
+            "00:00:03,000 --> 00:00:04,000" + Environment.NewLine +
+            Environment.NewLine +
+            "3" + Environment.NewLine +
+            "00:00:05,000 --> 00:00:06,000" + Environment.NewLine +
+            "Line three" + Environment.NewLine);
+        return fileName;
+    }
+
+    [AvaloniaFact]
+    public async Task BlankLinesAreKeptWhenTheSettingIsOff()
+    {
+        using var _ = new SettingsScope("General.RemoveBlankLinesWhenOpening");
+        Se.Settings.General.RemoveBlankLinesWhenOpening = false;
+
+        var (window, vm) = ShowEmptyMainWindow();
+        await vm.SubtitleOpen(WriteSrtWithBlankLine("blank-off.srt"), skipLoadVideo: true);
+        Settle(window);
+
+        Assert.Equal(3, vm.Subtitles.Count);
+        Assert.Equal(string.Empty, vm.Subtitles[1].Text);
+    }
+
+    [AvaloniaFact]
+    public async Task BlankLinesAreRemovedWhenTheSettingIsOn()
+    {
+        using var _ = new SettingsScope("General.RemoveBlankLinesWhenOpening");
+        Se.Settings.General.RemoveBlankLinesWhenOpening = true;
+
+        var (window, vm) = ShowEmptyMainWindow();
+        await vm.SubtitleOpen(WriteSrtWithBlankLine("blank-on.srt"), skipLoadVideo: true);
+        Settle(window);
+
+        Assert.Equal(2, vm.Subtitles.Count);
+        Assert.Equal("Line one", vm.Subtitles[0].Text);
+        Assert.Equal("Line three", vm.Subtitles[1].Text);
+
+        // The remaining lines are renumbered, so the grid does not open on 1, 3.
+        Assert.Equal(new[] { 1, 2 }, vm.Subtitles.Select(s => s.Number).ToArray());
+
+        // Like SE 4: the cleanup alone must not put the file in the "unsaved changes" state,
+        // otherwise closing right after opening asks to save a file the user never touched.
+        Assert.False(vm.HasChanges());
+    }
+
+    [AvaloniaFact]
+    public async Task BookmarksStayOnTheirLineWhenBlankLinesAreRemoved()
+    {
+        using var _ = new SettingsScope("General.RemoveBlankLinesWhenOpening");
+        Se.Settings.General.RemoveBlankLinesWhenOpening = true;
+
+        var fileName = WriteSrtWithBlankLine("blank-bookmark.srt");
+
+        // Bookmarks are stored by line index, so this one belongs to "Line three" - index 2 while
+        // the blank line is still in the file, index 1 once it is gone.
+        File.WriteAllText(fileName + ".SE.bookmarks",
+            "{\"bookmarks\":[" + Environment.NewLine +
+            "{\"idx\":2,\"txt\":\"third\"}" + Environment.NewLine +
+            "]}" + Environment.NewLine);
+
+        var (window, vm) = ShowEmptyMainWindow();
+        await vm.SubtitleOpen(fileName, skipLoadVideo: true);
+        Settle(window);
+
+        Assert.Equal(2, vm.Subtitles.Count);
+        Assert.Null(vm.Subtitles[0].Bookmark);
+        Assert.Equal("third", vm.Subtitles[1].Bookmark);
+    }
+}


### PR DESCRIPTION
Fixes #13588

SE 4 had a General setting that removed text-less lines as a subtitle was opened. SE 5 kept only the manual **Remove blank lines** command, so older subtitles full of blank lines had to be cleaned by hand on every open.

### What this adds

- `General.RemoveBlankLinesWhenOpening` — **off by default**, exactly as in SE 4 (the SE 4 defaults never set it either).
- A checkbox in **Options → Settings → General**, next to *Auto-trim white-space*, with SE 4's wording: *"Remove blank lines when opening a subtitle"*. The string is named after SE 4's `Settings.RemoveBlankLinesWhenOpening` key so existing translations can be carried over.
- The cleanup runs when a subtitle is opened, and when a subtitle file is inserted at the video position or after the selected line — the same three commands SE 4 covered (`Main.cs` 3943 / 34951 / 30037 on `se4-legacy`).

### Notes on the implementation

- **Bookmarks first.** Bookmarks are persisted by line index (`BookmarkPersistence`), so the removal happens after `LoadBookmarks()`; otherwise every bookmark past the first blank line would land on the wrong subtitle. SE 4 ordered it the same way. Covered by a test.
- **No phantom "unsaved changes".** `_changeSubtitleHash` is refreshed after the cleanup, so opening a file and closing it again does not prompt to save something the user never touched (SE 4 behaviour, since it stripped before hashing). Also covered by a test.
- **One helper for both paths.** The manual command and the automatic cleanup now share `RemoveBlankLinesFromGrid()`. This moves the command from `string.IsNullOrWhiteSpace` to `IsOnlyControlCharactersOrWhiteSpace` — the rule `Subtitle.RemoveEmptyLines` uses everywhere else — so a line holding only zero-width or control characters now counts as blank there too.
- The two insert commands bail out if the inserted file turns out to be blank-only, since both index `Paragraphs[0]` afterwards.

### Deliberately not included

- SE 4 also consulted this flag when merging *text from another subtitle* into the current lines and when seeding a new empty translation with `-`. Both align by index, so silently dropping lines there changes what pairs with what; left alone.
- The original/translator subtitle is not touched, as in SE 4 — stripping only one side of a side-by-side pair would desync it.

### Testing

New `tests/UI/Features/Main/SubtitleOpenRemoveBlankLinesTests.cs` (3 tests): setting off keeps blank lines, setting on removes and renumbers them without marking the file changed, and a bookmark saved for the line after a blank one still lands on that line. Existing `UITests.Features.Main` + settings suites pass (125 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)