### PR TITLE
Normalize pasted line breaks in the subtitle text box (#13591)

### DIFF
--- a/src/libse/Common/StringExtensions.cs
+++ b/src/libse/Common/StringExtensions.cs
@@ -124,6 +124,46 @@ namespace Nikse.SubtitleEdit.Core.Common
         public static List<string> SplitToLines(this string s) => s.SplitToLines(s.Length);
 
         /// <summary>
+        /// Rewrites every line break to <see cref="Environment.NewLine"/>, so text coming from
+        /// the outside (a paste, an API answer) uses the same line break as text SE builds
+        /// itself. The breaks recognized - and the "\r\r\n" as two breaks rule (#8854) - are the
+        /// ones <see cref="SplitToLines(string)"/> splits on, so a normalize-then-split round
+        /// trip keeps the same lines. The input is returned unchanged when it needs no rewrite.
+        /// </summary>
+        public static string NormalizeLineBreaks(this string s)
+        {
+            if (string.IsNullOrEmpty(s))
+            {
+                return s;
+            }
+
+            var index = s.AsSpan().IndexOfAny('\r', '\n', '\u2028');
+            if (index < 0)
+            {
+                return s;
+            }
+
+            var newLine = Environment.NewLine;
+            var sb = new StringBuilder(s.Length + 8);
+            var start = 0;
+            while (index >= 0)
+            {
+                sb.Append(s, start, index - start).Append(newLine);
+
+                start = index + 1;
+                if (s[index] == '\r' && start < s.Length && s[start] == '\n')
+                {
+                    start++;
+                }
+
+                var next = s.AsSpan(start).IndexOfAny('\r', '\n', '\u2028');
+                index = next < 0 ? -1 : start + next;
+            }
+
+            return sb.Append(s, start, s.Length - start).ToString();
+        }
+
+        /// <summary>
         /// Enumerates the lines of <paramref name="s"/> as spans, using the same line break rules
         /// as <see cref="SplitToLines(string)"/>. For callers that only look at each line instead
         /// of keeping it: no list and no string per line is allocated.

--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -2023,6 +2023,10 @@ public static partial class InitListViewAndEditBox
         textBox.IsUndoEnabled = false;
         textBox.ClearSelectionOnLostFocus = false;
 
+        // Pasted text goes straight into the paragraph via the two-way binding, so its line
+        // breaks must be SE's own - see TextBoxPasteNormalizer (#13591).
+        TextBoxPasteNormalizer.NormalizeLineBreaksOnPaste(textBox);
+
         if (appearance.SubtitleTextBoxCenterText)
         {
             textBox.TextAlignment = TextAlignment.Center;

--- a/src/ui/Features/Shared/TextBoxUtils/TextBoxPasteNormalizer.cs
+++ b/src/ui/Features/Shared/TextBoxUtils/TextBoxPasteNormalizer.cs
@@ -1,0 +1,76 @@
+using Avalonia.Controls;
+using Avalonia.Input.Platform;
+using Avalonia.Interactivity;
+using Nikse.SubtitleEdit.Core.Common;
+using System;
+
+namespace Nikse.SubtitleEdit.Features.Shared.TextBoxUtils;
+
+/// <summary>
+/// Makes a text box paste subtitle text with SE's own line break.
+///
+/// Avalonia's <see cref="TextBox"/> inserts the clipboard string verbatim - its only sanitizing
+/// step strips U+007F, and <see cref="TextBox.NewLine"/> is used for the Enter key only. The
+/// Win32 edit control SE4 used normalized pasted line breaks to CRLF by itself, so this never
+/// came up before. Everything else in SE composes subtitle text with
+/// <see cref="Environment.NewLine"/>, so a paste from a LF file leaves a paragraph holding a
+/// line break no other code path produces: tools that rebuild the text then report a change that
+/// renders identically - "Remove text for hearing impaired" listing an untouched line (#13591) -
+/// and line-break-sensitive edits such as merge miss the break they meant to strip.
+/// </summary>
+public static class TextBoxPasteNormalizer
+{
+    /// <summary>
+    /// Takes over paste for <paramref name="textBox"/> so pasted line breaks become
+    /// <see cref="Environment.NewLine"/>. Only for text boxes that edit subtitle text; a box
+    /// showing free-form text (a source view, a log) should paste what the clipboard holds.
+    /// </summary>
+    public static void NormalizeLineBreaksOnPaste(TextBox textBox)
+    {
+        textBox.AddHandler(TextBox.PastingFromClipboardEvent, OnPastingFromClipboard);
+    }
+
+    private static async void OnPastingFromClipboard(object? sender, RoutedEventArgs e)
+    {
+        if (sender is not TextBox textBox)
+        {
+            return;
+        }
+
+        e.Handled = true; // suppress the default paste (must be set before the first await)
+
+        var clipboard = TopLevel.GetTopLevel(textBox)?.Clipboard;
+        if (clipboard == null)
+        {
+            return;
+        }
+
+        string? text;
+        try
+        {
+            text = await clipboard.TryGetTextAsync();
+        }
+        catch (Exception)
+        {
+            return; // clipboard busy/denied - same as Avalonia's own paste, which logs and gives up
+        }
+
+        InsertNormalized(textBox, text);
+    }
+
+    /// <summary>
+    /// Inserts <paramref name="text"/> with SE's line break, replacing the selection.
+    /// </summary>
+    internal static void InsertNormalized(TextBox textBox, string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return;
+        }
+
+        // Assigning SelectedText replaces the selection (or inserts at the caret when there is
+        // none) through the same text input path the built-in paste uses: it takes the undo
+        // snapshot, drops characters the box cannot hold, and leaves a read-only box alone.
+        textBox.SelectedText = text.NormalizeLineBreaks();
+    }
+}

--- a/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedViewModel.cs
+++ b/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedViewModel.cs
@@ -348,7 +348,7 @@ public partial class RemoveTextForHearingImpairedViewModel : ObservableObject, I
         _timer.StopAndDispose(TimerElapsed);
     }
 
-    private void GeneratePreview()
+    internal void GeneratePreview()
     {
         if (_removeTextForHiLib == null)
         {
@@ -371,10 +371,7 @@ public partial class RemoveTextForHearingImpairedViewModel : ObservableObject, I
             var p = _subtitle.Paragraphs[index];
             _removeTextForHiLib.WarningIndex = index - 1;
             var newText = _removeTextForHiLib.RemoveTextFromHearImpaired(p.Text, _subtitle, index, twoLetterIsoLanguageName);
-            // Trim before comparing: RemoveTextFromHearImpaired rebuilds the text and drops
-            // e.g. a trailing empty line, which would otherwise list a "fix" whose before and
-            // after render identically (#13389).
-            if (p.Text.Trim().RemoveChar(' ') != newText.Trim().RemoveChar(' '))
+            if (IsVisibleChange(p.Text, newText))
             {
                 var apply = true;
                 var oldItem = Fixes.FirstOrDefault(f => f.Index == index);
@@ -408,6 +405,22 @@ public partial class RemoveTextForHearingImpairedViewModel : ObservableObject, I
 
         Fixes.Clear();
         Fixes.AddRange(newFixes);
+    }
+
+    /// <summary>
+    /// True when the HI pass changed something the user would actually see in the fix list.
+    /// Trailing white space is ignored: RemoveTextFromHearImpaired rebuilds the text and drops
+    /// e.g. a trailing empty line, which would otherwise list a "fix" whose before and after
+    /// render identically (#13389). Line breaks are compared normalized for the same reason -
+    /// the rebuilt text always uses <see cref="Environment.NewLine"/>, so a paragraph that came
+    /// in with a foreign line break (pasted from a LF file, say) would be listed unchanged
+    /// (#13591).
+    /// </summary>
+    internal static bool IsVisibleChange(string before, string after)
+    {
+        return Flatten(before) != Flatten(after);
+
+        static string Flatten(string text) => text.NormalizeLineBreaks().Trim().RemoveChar(' ');
     }
 
     public RemoveTextForHISettings GetSettings(Subtitle subtitle)

--- a/tests/UI/Features/TextBoxPasteNormalizerTests.cs
+++ b/tests/UI/Features/TextBoxPasteNormalizerTests.cs
@@ -1,0 +1,83 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Shared.TextBoxUtils;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Features;
+
+/// <summary>
+/// Avalonia's text box pastes the clipboard string verbatim, so text copied from a LF file would
+/// leave a paragraph with a line break nothing else in SE produces - and tools that rebuild the
+/// text would then report a change that renders identically (#13591).
+/// </summary>
+public class TextBoxPasteNormalizerTests
+{
+    [AvaloniaTheory]
+    [InlineData("\n")]
+    [InlineData("\r\n")]
+    [InlineData("\r")]
+    public void Paste_InsertsTextWithSeLineBreak(string lineBreak)
+    {
+        var textBox = new TextBox { AcceptsReturn = true, Text = string.Empty };
+
+        TextBoxPasteNormalizer.InsertNormalized(textBox, "first" + lineBreak + "second");
+
+        Assert.Equal("first" + Environment.NewLine + "second", textBox.Text);
+    }
+
+    [AvaloniaFact]
+    public void Paste_ReplacesTheSelection()
+    {
+        var textBox = new TextBox { AcceptsReturn = true, Text = "keep drop", SelectionStart = 5, SelectionEnd = 9 };
+
+        TextBoxPasteNormalizer.InsertNormalized(textBox, "one\ntwo");
+
+        Assert.Equal("keep one" + Environment.NewLine + "two", textBox.Text);
+    }
+
+    [AvaloniaFact]
+    public void Paste_LeavesAReadOnlyBoxAlone()
+    {
+        var textBox = new TextBox { AcceptsReturn = true, Text = "untouched", IsReadOnly = true };
+
+        TextBoxPasteNormalizer.InsertNormalized(textBox, "pasted\ntext");
+
+        Assert.Equal("untouched", textBox.Text);
+    }
+
+    // The wiring: without the handler on the edit text box the whole fix is dead, and nothing else
+    // in the app would notice.
+    [AvaloniaFact]
+    public void MainEditTextBox_TakesOverPaste()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1200, Height = 800 };
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var vm = (MainViewModel)view.DataContext!;
+        try
+        {
+            var e = new RoutedEventArgs(TextBox.PastingFromClipboardEvent);
+            vm.EditTextBox.TextControl.RaiseEvent(e);
+
+            Assert.True(e.Handled);
+        }
+        finally
+        {
+            window.Closing -= vm.OnClosing;
+            window.Close();
+        }
+    }
+}

--- a/tests/UI/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedViewModelTests.cs
+++ b/tests/UI/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedViewModelTests.cs
@@ -147,4 +147,42 @@ public class RemoveTextForHearingImpairedViewModelTests
         Assert.True(withShift.Handled);
         Assert.True(vm.Fixes[0].Apply);
     }
+
+    // #13591: the HI pass rebuilds the text with Environment.NewLine, so a paragraph holding a
+    // foreign line break must not be offered as a fix that renders exactly like the original.
+    [Theory]
+    [InlineData("\n")]
+    [InlineData("\r\n")]
+    [InlineData("\r")]
+    public void LineBreakOnlyDifference_IsNotAFix(string lineBreak)
+    {
+        const string first = "I told him to get lost,";
+        const string second = "and when he vanished with the light,";
+
+        Assert.False(RemoveTextForHearingImpairedViewModel.IsVisibleChange(
+            first + lineBreak + second,
+            first + Environment.NewLine + second));
+    }
+
+    [AvaloniaTheory]
+    [InlineData("\n")]
+    [InlineData("\r\n")]
+    public void PlainTextWithAnyLineBreak_GivesNoFixes(string lineBreak)
+    {
+        var vm = Resolve();
+        var sub = new Subtitle();
+        sub.Paragraphs.Add(new Paragraph(
+            "I told him to get lost," + lineBreak + "and when he vanished with the light,", 0, 3000));
+        vm.Initialize(sub, _ => { });
+
+        vm.GeneratePreview();
+
+        Assert.Empty(vm.Fixes);
+    }
+
+    [Fact]
+    public void RealChange_IsStillAFix()
+    {
+        Assert.True(RemoveTextForHearingImpairedViewModel.IsVisibleChange("[door slams]" + Environment.NewLine + "Hello", "Hello"));
+    }
 }

--- a/tests/libse/Common/NormalizeLineBreaksTest.cs
+++ b/tests/libse/Common/NormalizeLineBreaksTest.cs
@@ -1,0 +1,58 @@
+using Nikse.SubtitleEdit.Core.Common;
+using System;
+using Xunit;
+
+namespace LibSETests.Common;
+
+public class NormalizeLineBreaksTest
+{
+    // #13591: text from the outside (a paste from a LF file) must end up with the same line
+    // break SE builds text with, or tools that rebuild the text report changes that render
+    // identically.
+    [Theory]
+    [InlineData("\n")]
+    [InlineData("\r\n")]
+    [InlineData("\r")]
+    [InlineData("\u2028")]
+    public void AnyLineBreak_BecomesEnvironmentNewLine(string lineBreak)
+    {
+        var text = "I told him to get lost," + lineBreak + "and when he vanished with the light,";
+
+        var result = text.NormalizeLineBreaks();
+
+        Assert.Equal("I told him to get lost," + Environment.NewLine + "and when he vanished with the light,", result);
+    }
+
+    [Fact]
+    public void CrCrLf_StaysTwoLineBreaks()
+    {
+        // "\r\r\n" is deliberately two breaks, same as SplitToLines (#8854).
+        var result = "one\r\r\ntwo".NormalizeLineBreaks();
+
+        Assert.Equal("one" + Environment.NewLine + Environment.NewLine + "two", result);
+    }
+
+    [Fact]
+    public void KeepsEmptyLinesAndTrailingBreak()
+    {
+        var result = "one\n\ntwo\n".NormalizeLineBreaks();
+
+        Assert.Equal($"one{Environment.NewLine}{Environment.NewLine}two{Environment.NewLine}", result);
+    }
+
+    [Fact]
+    public void SameLinesAsSplitToLines()
+    {
+        const string text = "one\rtwo\r\nthree\n\u2028four\r\r\nfive";
+
+        Assert.Equal(text.SplitToLines(), text.NormalizeLineBreaks().SplitToLines());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("no line break here")]
+    public void TextWithoutLineBreak_IsReturnedAsIs(string text)
+    {
+        Assert.Same(text, text.NormalizeLineBreaks());
+    }
+}


### PR DESCRIPTION
Fixes #13591.

### What happens

Pasting text that uses LF line breaks and then running **Remove text for hearing impaired** lists the line as a fix, even though Before and After render identically. The same text pasted with CRLF gives no fix. Saving does not clear it; re-opening the file does. SE4 is unaffected.

### Why

Avalonia's `TextBox` inserts the clipboard string verbatim - its only sanitizing step strips U+007F, and `TextBox.NewLine` applies to the Enter key alone. The Win32 edit control SE4 used normalized pasted breaks to CRLF by itself, so this never came up before. The edit box is bound two-way straight to `SubtitleLineViewModel.Text`, so the lone `\n` lands in the paragraph.

Everything that rebuilds subtitle text composes it with `Environment.NewLine` - `RemoveTextFromHearImpaired` splits with `SplitToLines()` and rejoins with `Environment.NewLine` - so the result differs from the input in the line break alone, and the preview's raw string comparison reports a fix. Re-opening the file clears it because parsing splits and rejoins the lines.

It is not only the HI dialog: `MergeManager` strips `Environment.NewLine` when merging, so an LF-pasted line keeps a break the merge meant to remove.

### The fix

- `TextBoxPasteNormalizer` takes over paste on both subtitle text boxes (text and original) and inserts the clipboard text with SE's own line break. Insertion goes through `SelectedText`, the same text input path the built-in paste uses, so the undo snapshot, the read-only guard and character filtering are unchanged.
- `string.NormalizeLineBreaks()` in `StringExtensions`, next to `SplitToLines` and using the same line break rules (including "\r\r\n" as two breaks, #8854), so a normalize-then-split round trip keeps the same lines.
- Second layer: the HI preview compares before/after with line breaks normalized, so a break-only difference is never offered as a fix no matter how the text got there.

### Tests

- `NormalizeLineBreaksTest` - every break form becomes `Environment.NewLine`, "\r\r\n" stays two breaks, same lines as `SplitToLines`, unchanged text returned as is.
- `TextBoxPasteNormalizerTests` - paste inserts with SE's break, replaces the selection, leaves a read-only box alone, plus a wiring canary that the main edit box actually takes over paste.
- `RemoveTextForHearingImpairedViewModelTests` - the issue's own text with any line break produces no fixes, and a real fix is still reported.

Verified that each new test fails without its half of the fix. Full libse (1033) and UI (2626) suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)