### PR TITLE
Make the original reference editable in place: sticky links, promote-on-type, no time-code lock (#13594)

### DIFF
--- a/docs/features/main-window.md
+++ b/docs/features/main-window.md
@@ -321,6 +321,19 @@ When you open an original subtitle file (**File → Open original subtitle**), t
 <!-- Screenshot: Main window in translation mode -->
 ![Translation Mode](../screenshots/main-translation-mode.png)
 
+### When the original does not line up 1:1
+
+If the original file does not have the same number of lines as the subtitle you are editing, Subtitle Edit asks how to show it:
+
+- **Show only the matching original lines** — the classic side-by-side view. Lines are paired by time codes; original lines with no counterpart are not shown.
+- **Show all original lines** — original lines with no counterpart appear as extra, dimmed rows (without a line number), placed in time order, so you can see exactly what your subtitle is missing.
+
+The dialog also offers an **Allow edit of original subtitle** check box. Left off (the default), the original is a read-only reference: it is never written to, and closing it leaves the file on disk exactly as it was. Both choices are remembered for the next time.
+
+The dimmed rows belong to the original, so they are not saved with your subtitle, and editing commands (delete, merge, export, …) skip them. To adopt a missing line into your subtitle, select it and simply type or paste the translation — the row immediately becomes a normal line, keeping the original line's timings. **Column → Copy text from original to current** in the grid's context menu does the same while also copying the original text over.
+
+Each row remembers which original line it shows, so editing or retiming your own lines never re-shuffles the reference: the dimmed rows only slide to keep time order, and if you delete a row that had adopted a reference line, that line comes back as a dimmed row.
+
 ## Launch Parameters
 
 Subtitle Edit accepts a few command-line arguments at startup, useful for desktop shortcuts, file-manager "Open with…" entries, and sync scripts.

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "Subtitle Edit",
-  "version": "v5.2.0-beta11",
+  "version": "v5.2.0-beta12",
   "translatedBy": "",
   "cultureName": "en-US",
   "general": {
@@ -1022,7 +1022,7 @@
     "allowEditOfOriginalSubtitle": "Allow edit of original subtitle",
     "showAllOriginalLinesX": "Show all original lines ({0} have no match here)",
     "showAllOriginalLinesHint": "The lines with no match are shown as extra rows, so you can see what the translation is missing.",
-    "showAllOriginalLinesNote": "Time codes cannot be changed while these rows are shown",
+    "showAllOriginalLinesNote": "Type in an extra row to add that line to your subtitle",
     "showMatchingOriginalLinesX": "Show only the {0} matching original lines",
     "showMatchingOriginalLinesHint": "The other {0} original lines are not shown anywhere.",
     "showMatchingOriginalLinesNote": "They stay in the file unless you save the original",
@@ -1311,7 +1311,12 @@
       "exportStylesTitle": "Export WebVTT styles",
       "openStyleFileTitle": "Open WebVTT file to import styles from",
       "noStylesToImport": "No styles found in the chosen file",
-      "duplicateStyleNamesX": "Duplicate style names: {0}"
+      "duplicateStyleNamesX": "Duplicate style names: {0}",
+      "cueSettings": "Cue settings for alignment",
+      "cueSettingsHint": "Cue settings written when a line is aligned, e.g. \"line:20%\" for top-center",
+      "useXTimeStamp": "Use X-TIMESTAMP-MAP header value",
+      "mergeLines": "Merge lines with same text on load",
+      "mergeStyleTags": "Merge style tags"
     },
     "compare": "Compare",
     "previousDifference": "Previous difference",
@@ -2518,6 +2523,7 @@
       "autoBackupDeleteAfterDays": "Auto-backup retention (days)",
       "autoConvertToUtf8": "Auto-convert encoding to UTF-8 on open",
       "autoTrimWhiteSpace": "Auto-trim white-space",
+      "removeBlankLinesWhenOpening": "Remove blank lines when opening a subtitle",
       "defaultEncoding": "Default encoding",
       "colorDurationTooShort": "Color duration if too short",
       "colorDurationTooLong": "Color duration if too long",

--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -1945,13 +1945,9 @@ public static partial class InitListViewAndEditBox
         };
         textBox[AutomationProperties.NameProperty] = Se.Language.General.Text;
 
-        // A reference-only row has no translation text to edit - typing would make it a real line.
-        textBox.Bind(TextBox.IsReadOnlyProperty, new Binding(nameof(vm.IsSelectedLineReferenceOnly))
-        {
-            Mode = BindingMode.OneWay,
-            Source = vm
-        });
-
+        // A reference-only row IS editable: typing the missing translation into it is how the line
+        // is adopted from the reference - the first character promotes the row to an ordinary
+        // working line (see MainViewModel.SubtitleTextChanged, #13594).
         textBox.TextChanged += vm.SubtitleTextChanged;
         textBox.GotFocus += (_, _) => vm.SubtitleTextBoxGotFocus();
         textBox.AddHandler(InputElement.PointerPressedEvent, (_, e) => vm.StoreTextEditorPointerArgs(e), RoutingStrategies.Tunnel);

--- a/src/ui/Features/Main/MainHelpers/ImportOriginalHelper.cs
+++ b/src/ui/Features/Main/MainHelpers/ImportOriginalHelper.cs
@@ -20,11 +20,6 @@ public static class ImportOriginalHelper
     /// </param>
     internal record OriginalMatch(Subtitle Projection, List<Paragraph> Unmatched);
 
-    internal static Subtitle GetMatchingOriginalLines(ObservableCollection<SubtitleLineViewModel> current, Subtitle original)
-    {
-        return MatchOriginalLines(current, original).Projection;
-    }
-
     internal static OriginalMatch MatchOriginalLines(ObservableCollection<SubtitleLineViewModel> current, Subtitle original)
     {
         var newOriginal = new Subtitle();
@@ -43,14 +38,26 @@ public static class ImportOriginalHelper
         // need a global assignment; this only has to stop the same line being used twice.
         foreach (var line in current)
         {
-            var index = FindOriginalLineIndex(line, original, used);
+            // A leftover reference-only row (an original is being replaced by another) displays a
+            // line of the OLD original - it must not claim a line of the new one. It still emits an
+            // empty projection line to keep the projection index-aligned with the rows.
+            var index = line.IsReferenceOnly ? -1 : FindOriginalLineIndex(line, original, used);
             if (index >= 0)
             {
                 newOriginal.Paragraphs.Add(original.Paragraphs[index]);
                 used[index] = true;
+
+                // The row remembers which original line it displays, and the assignment then
+                // sticks - see SubtitleLineViewModel.ReferenceParagraphId (#13594).
+                line.ReferenceParagraphId = original.Paragraphs[index].Id;
             }
             else
             {
+                if (!line.IsReferenceOnly)
+                {
+                    line.ReferenceParagraphId = null;
+                }
+
                 var emptyLine = new Paragraph
                 {
                     StartTime = TimeCode.FromSeconds(line.StartTime.TotalSeconds),
@@ -78,7 +85,7 @@ public static class ImportOriginalHelper
     /// two rows. A row that finds only used lines gets an empty original, which is the truthful
     /// answer - it has no source line of its own.
     /// </param>
-    private static int FindOriginalLineIndex(SubtitleLineViewModel line, Subtitle original, bool[] used)
+    internal static int FindOriginalLineIndex(SubtitleLineViewModel line, Subtitle original, bool[] used)
     {
         for (var i = 0; i < original.Paragraphs.Count; i++)
         {

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -208,8 +208,9 @@ public partial class MainViewModel :
     private SubtitleLineViewModel? _selectedSubtitle;
 
     /// <summary>
-    /// True while a display-only reference row is selected. The main text box binds its read-only
-    /// state to this - typing into such a row would turn it into a real subtitle line (#13449).
+    /// True while a display-only reference row is selected. The show/hide/duration editors are off
+    /// for such a row (its timings belong to the original file); its text box, though, is open on
+    /// purpose - typing into it adopts the line into the working subtitle (#13594).
     /// </summary>
     public bool IsSelectedLineReferenceOnly => SelectedSubtitle?.IsReferenceOnly == true;
     private List<SubtitleLineViewModel>? _selectedSubtitles;
@@ -267,12 +268,9 @@ public partial class MainViewModel :
     /// The original's lines that have no counterpart in the working subtitle are shown as
     /// display-only rows. Independent of <see cref="IsOriginalReadOnly"/>: with these rows on screen
     /// the grid holds every line of the original exactly once, so editing and saving the original is
-    /// lossless - which is why it may be combined with "Allow edit of original subtitle". Time codes
-    /// are locked while it is on, see <see cref="AreTimeCodesLocked"/>.
+    /// lossless - which is why it may be combined with "Allow edit of original subtitle".
     /// </summary>
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(AreTimeCodesEditable))]
-    [NotifyPropertyChangedFor(nameof(AreTimeCodesLocked))]
     private bool _isShowingOriginalNonMatchingLines;
 
     /// <summary>Whether the original text column may be written to (see <see cref="IsOriginalReadOnly"/>).</summary>
@@ -303,13 +301,13 @@ public partial class MainViewModel :
     private bool _lockTimeCodes;
 
     /// <summary>
-    /// Whether time codes may be changed at all right now. Either the user locked them, or the
-    /// original's non-matching lines are on screen: those rows are placed by matching the original
-    /// against the working lines by time, so retiming a working line would re-match it onto a
-    /// different original line and shuffle the extra rows around under the user (#13449). The mode
-    /// is for reading the original alongside the translation, not for retiming.
+    /// Whether time codes may be changed at all right now - the user's own lock setting. The
+    /// original's non-matching lines being on screen no longer locks anything: each row remembers
+    /// which original line it displays (<see cref="SubtitleLineViewModel.ReferenceParagraphId"/>),
+    /// so retiming a working line cannot re-match it onto a different original line and shuffle
+    /// the extra rows around under the user (#13594).
     /// </summary>
-    public bool AreTimeCodesLocked => LockTimeCodes || IsShowingOriginalNonMatchingLines;
+    public bool AreTimeCodesLocked => LockTimeCodes;
 
     /// <summary>
     /// Whether the show/hide/duration editors accept input: not while time codes are locked, and not
@@ -1513,17 +1511,6 @@ public partial class MainViewModel :
         }
     }
 
-    // AreTimeCodesLocked follows this mode, and the waveform enforces the lock through its own
-    // IsReadOnly - it must follow too, or dragging a paragraph edge would retime lines the lock
-    // exists to protect.
-    partial void OnIsShowingOriginalNonMatchingLinesChanged(bool value)
-    {
-        if (AudioVisualizer != null)
-        {
-            AudioVisualizer.IsReadOnly = AreTimeCodesLocked;
-        }
-    }
-
     [RelayCommand]
     private async Task ShowHelp()
     {
@@ -2585,6 +2572,14 @@ public partial class MainViewModel :
     {
         RemoveReferenceOnlyRows();
 
+        // The caller's match may predate the removal above (opening an original while another was
+        // already showing reference rows), and matching stamps each row with the original line it
+        // displays - so re-derive it against the rows as they are now (#13594).
+        if (match != null)
+        {
+            match = ImportOriginalHelper.MatchOriginalLines(Subtitles, subtitle);
+        }
+
         _subtitleOriginal = subtitle;
         _subtitleFileNameOriginal = fileName;
         IsOriginalReadOnly = isReadOnly;
@@ -2594,6 +2589,11 @@ public partial class MainViewModel :
         for (var i = 0; i < Subtitles.Count && i < rowTexts.Paragraphs.Count; i++)
         {
             Subtitles[i].OriginalText = rowTexts.Paragraphs[i].Text;
+            if (match == null)
+            {
+                // 1:1 - row i displays original line i (a match stamps the rows itself).
+                Subtitles[i].ReferenceParagraphId = rowTexts.Paragraphs[i].Id;
+            }
         }
 
         if (match != null)
@@ -2638,6 +2638,7 @@ public partial class MainViewModel :
                 OriginalText = p.Text,
                 StartTime = TimeSpan.FromMilliseconds(p.StartTime.TotalMilliseconds),
                 EndTime = TimeSpan.FromMilliseconds(p.EndTime.TotalMilliseconds),
+                ReferenceParagraphId = p.Id,
             });
 
             insertAt++;
@@ -2648,16 +2649,28 @@ public partial class MainViewModel :
     }
 
     /// <summary>
-    /// Re-derives what the original contributes to the grid - the original column texts and the
-    /// display-only rows for its non-matching lines - by matching the original against the current
-    /// rows again. Both are a projection, so they go stale whenever the working rows are merged,
-    /// split, deleted or rebuilt wholesale (#13449).
+    /// Brings the original's contribution to the grid - the original column texts and the
+    /// display-only rows for its non-matching lines - back in step with the working rows, without
+    /// disturbing what already lines up. Each row remembers the original line it displays
+    /// (<see cref="SubtitleLineViewModel.ReferenceParagraphId"/>), and that assignment sticks:
+    /// this never re-matches an assigned row onto a different original line, so retiming or
+    /// editing rows cannot shuffle the reference around under the user (#13594). What it does do:
+    ///
+    /// - drop links to original lines that no longer exist, and duplicate links (a copied row);
+    /// - for a read-only original, re-sync the displayed text from the file's lines (the file is
+    ///   authoritative) and bring back a line whose displaying row was deleted as a new
+    ///   display-only row;
+    /// - match rows that display nothing yet against the still-unclaimed original lines - a no-op
+    ///   in the steady state, and the full time-code match after a wholesale grid rebuild (format
+    ///   conversion), where no row carries an assignment;
+    /// - glide the display-only rows back into start-time order after a retime, moving only the
+    ///   rows that are out of place.
     /// </summary>
     /// <param name="capture">
     /// Whether to fold the rows' current original text back into the original first. Needed when the
-    /// original is editable, or the user's edits would be overwritten by the file's text; pass false
-    /// when the caller already captured (the display-only rows are gone by then and their text would
-    /// be lost from the capture).
+    /// original is editable, or the user's edits would be overwritten on the next save; pass false
+    /// when the caller already captured (after a wholesale rebuild the rows no longer hold the
+    /// original's text, and capturing would rebuild the original from empty rows).
     /// </param>
     private void ReapplyOriginalReference(bool capture = true)
     {
@@ -2668,11 +2681,11 @@ public partial class MainViewModel :
             return;
         }
 
-        // The baseline hash covers the rows, so the remap below shifts it even when the original's
-        // content is untouched. Rebaseline afterwards only when the original was clean going in -
-        // an already-dirty original must stay dirty, or its unsaved edits would no longer count as
-        // changes and the app would close without offering to save them. A read-only original has
-        // nothing to save, so it always rebaselines.
+        // The baseline hash covers the rows, so the refresh below can shift it even when the
+        // original's content is untouched (rows brought back or reordered). Rebaseline afterwards
+        // only when the original was clean going in - an already-dirty original must stay dirty, or
+        // its unsaved edits would no longer count as changes and the app would close without
+        // offering to save them. A read-only original has nothing to save, so it always rebaselines.
         var wasDirty = !IsOriginalReadOnly && _changeSubtitleHashOriginal != GetFastHashOriginal();
 
         if (capture)
@@ -2680,18 +2693,96 @@ public partial class MainViewModel :
             CaptureOriginalFromRows();
         }
 
+        var original = _subtitleOriginal;
         _reapplyingReadOnlyReference = true;
         try
         {
-            RemoveReferenceOnlyRows();
-
-            var match = ImportOriginalHelper.MatchOriginalLines(Subtitles, _subtitleOriginal);
-            for (var i = 0; i < Subtitles.Count && i < match.Projection.Paragraphs.Count; i++)
+            // Which original line each id belongs to. Ids are unique per file; claimed lines are
+            // tracked by index so a (rare) id-less paragraph is handled like an unclaimed one.
+            var indexById = new Dictionary<Guid, int>(original.Paragraphs.Count);
+            for (var i = 0; i < original.Paragraphs.Count; i++)
             {
-                Subtitles[i].OriginalText = match.Projection.Paragraphs[i].Text;
+                if (original.Paragraphs[i].Id is { } id)
+                {
+                    indexById[id] = i;
+                }
             }
 
-            InsertReferenceOnlyRows(match.Unmatched);
+            var used = new bool[original.Paragraphs.Count];
+
+            // Pass 1: validate the sticky links. A row whose line vanished (or was already claimed
+            // by an earlier row - a duplicated row copies the link, and the first row wins) loses
+            // it; a display-only row in that state has nothing left to display. For a read-only
+            // original the file is authoritative, so re-sync the displayed text from its line.
+            for (var i = 0; i < Subtitles.Count; i++)
+            {
+                var row = Subtitles[i];
+                if (row.ReferenceParagraphId is not { } id)
+                {
+                    continue;
+                }
+
+                if (indexById.TryGetValue(id, out var index) && !used[index])
+                {
+                    used[index] = true;
+                    if (IsOriginalReadOnly)
+                    {
+                        var p = original.Paragraphs[index];
+                        row.OriginalText = p.Text;
+                        if (row.IsReferenceOnly)
+                        {
+                            row.SetTimes(
+                                TimeSpan.FromMilliseconds(p.StartTime.TotalMilliseconds),
+                                TimeSpan.FromMilliseconds(p.EndTime.TotalMilliseconds));
+                        }
+                    }
+                }
+                else
+                {
+                    row.ReferenceParagraphId = null;
+                    if (row.IsReferenceOnly)
+                    {
+                        Subtitles.RemoveAt(i);
+                        i--;
+                    }
+                }
+            }
+
+            // Pass 2: rows that display nothing yet claim still-unclaimed lines by time code. In
+            // the steady state every row is already linked and this does nothing; after a wholesale
+            // rebuild it is the full match.
+            foreach (var row in Subtitles)
+            {
+                if (row.IsReferenceOnly || row.ReferenceParagraphId != null)
+                {
+                    continue;
+                }
+
+                var index = ImportOriginalHelper.FindOriginalLineIndex(row, original, used);
+                if (index >= 0)
+                {
+                    used[index] = true;
+                    row.ReferenceParagraphId = original.Paragraphs[index].Id;
+                    row.OriginalText = original.Paragraphs[index].Text;
+                }
+            }
+
+            // Pass 3: every original line no row displays comes back as a display-only row.
+            List<Paragraph>? unmatched = null;
+            for (var i = 0; i < original.Paragraphs.Count; i++)
+            {
+                if (!used[i])
+                {
+                    (unmatched ??= new List<Paragraph>()).Add(original.Paragraphs[i]);
+                }
+            }
+
+            if (unmatched != null)
+            {
+                InsertReferenceOnlyRows(unmatched);
+            }
+
+            RepositionReferenceOnlyRows();
         }
         finally
         {
@@ -2704,6 +2795,79 @@ public partial class MainViewModel :
         }
 
         _referenceMappingDirty = false;
+    }
+
+    /// <summary>
+    /// Glides the display-only reference rows back into start-time order among the working rows
+    /// after a retime, touching nothing else: the working rows keep their relative order exactly,
+    /// and a reference row is only removed and re-inserted when it is actually out of place - in
+    /// the common case this method changes nothing at all (#13594).
+    /// </summary>
+    private void RepositionReferenceOnlyRows()
+    {
+        var referenceRows = Subtitles.Where(p => p.IsReferenceOnly).OrderBy(p => p.StartTime).ToList();
+        if (referenceRows.Count == 0)
+        {
+            return;
+        }
+
+        var workingRows = Subtitles.Where(p => !p.IsReferenceOnly).ToList();
+
+        // The desired order: working rows as they are, each reference row after the last working
+        // row that starts at or before it (same rule the initial insert uses).
+        var desired = new List<SubtitleLineViewModel>(Subtitles.Count);
+        var w = 0;
+        foreach (var referenceRow in referenceRows)
+        {
+            while (w < workingRows.Count && workingRows[w].StartTime <= referenceRow.StartTime)
+            {
+                desired.Add(workingRows[w]);
+                w++;
+            }
+
+            desired.Add(referenceRow);
+        }
+
+        while (w < workingRows.Count)
+        {
+            desired.Add(workingRows[w]);
+            w++;
+        }
+
+        // Only reference rows are ever removed and re-inserted: the working rows' relative order is
+        // identical in both sequences, so whenever a slot mismatches, either the row that belongs
+        // there is a reference row (pull it into place), or the row sitting there is a reference
+        // row that belongs further down (park it at the end; the loop places it when it reaches its
+        // own slot). Working rows never move, so the row the user is editing keeps its selection.
+        var moved = false;
+        for (var i = 0; i < desired.Count; i++)
+        {
+            if (ReferenceEquals(Subtitles[i], desired[i]))
+            {
+                continue;
+            }
+
+            moved = true;
+            if (desired[i].IsReferenceOnly)
+            {
+                var from = Subtitles.IndexOf(desired[i]);
+                Subtitles.RemoveAt(from);
+                Subtitles.Insert(i, desired[i]);
+            }
+            else
+            {
+                var blocking = Subtitles[i];
+                Subtitles.RemoveAt(i);
+                Subtitles.Add(blocking);
+                i--; // re-check this slot now that the squatter is gone
+            }
+        }
+
+        if (moved)
+        {
+            Renumber();
+            _updateAudioVisualizer = true;
+        }
     }
 
     /// <summary>
@@ -2727,13 +2891,46 @@ public partial class MainViewModel :
 
         // Capture before the rows go: an editable original keeps its non-matching lines only in them.
         CaptureOriginalFromRows();
-        RemoveReferenceOnlyRows();
+
+        // Detach the row instances rather than dropping them: they carry the user's edits (editable
+        // original) and their sticky link to the original line, and putting the same instances back
+        // means the reference does not visibly rebuild after every merge (#13594).
+        var detached = new List<SubtitleLineViewModel>();
+        for (var i = Subtitles.Count - 1; i >= 0; i--)
+        {
+            if (Subtitles[i].IsReferenceOnly)
+            {
+                detached.Add(Subtitles[i]);
+                Subtitles.RemoveAt(i);
+            }
+        }
+
+        detached.Reverse(); // back to grid order
+
         try
         {
             action();
         }
         finally
         {
+            var insertAt = 0;
+            foreach (var row in detached)
+            {
+                while (insertAt < Subtitles.Count &&
+                       Subtitles[insertAt].StartTime <= row.StartTime)
+                {
+                    insertAt++;
+                }
+
+                Subtitles.Insert(insertAt, row);
+                insertAt++;
+            }
+
+            Renumber();
+            _updateAudioVisualizer = true;
+
+            // The action may have deleted or merged rows that displayed original lines; the refresh
+            // brings those lines back (read-only) and re-syncs what is displayed.
             ReapplyOriginalReference(capture: false);
         }
     }
@@ -2759,7 +2956,12 @@ public partial class MainViewModel :
         {
             if (line.IsReferenceOnly || !string.IsNullOrEmpty(line.OriginalText))
             {
-                captured.Paragraphs.Add(line.ToParagraphOriginal(format));
+                var p = line.ToParagraphOriginal(format);
+                captured.Paragraphs.Add(p);
+
+                // The capture creates fresh paragraphs (fresh ids), so re-point the row's sticky
+                // link at the line it just produced, or every link would go stale at once (#13594).
+                line.ReferenceParagraphId = p.Id;
             }
         }
 
@@ -2821,6 +3023,7 @@ public partial class MainViewModel :
             foreach (var line in Subtitles)
             {
                 line.OriginalText = string.Empty;
+                line.ReferenceParagraphId = null;
             }
 
             _changeSubtitleHashOriginal = GetFastHashOriginal();
@@ -2901,6 +3104,7 @@ public partial class MainViewModel :
             // it into an ordinary line - left flagged, it would be dropped from every save by
             // GetUpdateSubtitle and keep its dimmed, read-only appearance.
             subtitle.IsReferenceOnly = false;
+            subtitle.ReferenceParagraphId = null; // the original it pointed into is gone
         }
 
         if (IsShowingOriginalNonMatchingLines)
@@ -5142,7 +5346,10 @@ public partial class MainViewModel :
     [RelayCommand]
     private async Task ColumnCopyTextFromOriginalToCurrent()
     {
-        var selectedItems = SubtitleGridSelectedItems.Cast<SubtitleLineViewModel>().ToList();
+        // With reference: copying the original text into the text column is exactly how a missing
+        // line is adopted from the reference, so display-only rows take part - and become ordinary
+        // working lines in the process (#13594).
+        var selectedItems = SubtitleGridSelectedItemsWithReference;
         if (!ShowColumnOriginalText || selectedItems.Count == 0)
         {
             return;
@@ -5152,6 +5359,10 @@ public partial class MainViewModel :
         foreach (var selectedItem in selectedItems)
         {
             selectedItem.Text = selectedItem.OriginalText;
+            if (selectedItem.IsReferenceOnly && !string.IsNullOrEmpty(selectedItem.Text))
+            {
+                PromoteReferenceOnlyRow(selectedItem);
+            }
         }
 
         _undoRedoManager.StartChangeDetection();
@@ -19327,7 +19538,12 @@ public partial class MainViewModel :
                 continue;
             }
 
-            _subtitleOriginal.Paragraphs.Add(line.ToParagraphOriginal(originalFormat));
+            var p = line.ToParagraphOriginal(originalFormat);
+            _subtitleOriginal.Paragraphs.Add(p);
+
+            // Fresh paragraphs mean fresh ids - keep the row's sticky link pointing at the line it
+            // just produced (see CaptureOriginalFromRows, #13594).
+            line.ReferenceParagraphId = p.Id;
         }
 
         return _subtitleOriginal;
@@ -23846,7 +24062,8 @@ public partial class MainViewModel :
             // A start-time change can reorder the buffer, so it must be rebuilt and re-sorted.
             _waveformSubtitleBufferDirty = true;
 
-            // Retiming a row can move it onto (or off) a different reference line.
+            // Retiming a row never re-matches it (the link is sticky), but the display-only
+            // reference rows may need to glide back into start-time order around it.
             if (IsShowingOriginalNonMatchingLines && !_reapplyingReadOnlyReference)
             {
                 _referenceMappingDirty = true;
@@ -24425,9 +24642,10 @@ public partial class MainViewModel :
         _slowTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(400) };
         _slowTimer.Tick += (s, e) =>
         {
-            // Re-match the read-only reference against the rows once the edit that invalidated it has
-            // settled. Deliberately debounced here rather than run per edit: matching is O(n*m) over
-            // both files, and a burst of deletes would otherwise pay for it on every single row.
+            // Refresh the reference projection (bring back lines whose row was deleted, glide the
+            // display-only rows into place) once the edit that invalidated it has settled.
+            // Deliberately debounced here rather than run per edit: a burst of deletes would
+            // otherwise pay for the refresh on every single row.
             if (_referenceMappingDirty && !IsUserEditing())
             {
                 ReapplyOriginalReference();
@@ -24728,7 +24946,33 @@ public partial class MainViewModel :
             return;
         }
 
+        // Typing (or pasting) into a display-only reference row is how a line the translation is
+        // missing gets added: the first character promotes the row to an ordinary working line, at
+        // the reference line's timings (#13594). The sticky link stays - the row still displays
+        // that original line, now side by side with its brand-new translation.
+        if (selectedSubtitle.IsReferenceOnly && !string.IsNullOrEmpty(selectedSubtitle.Text))
+        {
+            PromoteReferenceOnlyRow(selectedSubtitle);
+        }
+
         MakeSubtitleTextInfo(selectedSubtitle.Text, selectedSubtitle);
+        _updateAudioVisualizer = true;
+    }
+
+    /// <summary>
+    /// Turns a display-only reference row into an ordinary working line, keeping its timings and
+    /// its link to the original line it displays (#13594). From here on the row is saved with the
+    /// subtitle, takes a number, and its timings are the user's to edit.
+    /// </summary>
+    private void PromoteReferenceOnlyRow(SubtitleLineViewModel row)
+    {
+        row.IsReferenceOnly = false; // observable: the grid drops the dimming and shows the number
+        Renumber();
+
+        // The selected row changed nature, so everything derived from "is a reference row selected".
+        OnPropertyChanged(nameof(IsSelectedLineReferenceOnly));
+        OnPropertyChanged(nameof(AreTimeCodesEditable));
+
         _updateAudioVisualizer = true;
     }
 

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -21,14 +21,27 @@ public partial class SubtitleLineViewModel : ObservableObject
     private int _number;
 
     /// <summary>
-    /// A display-only row: it exists so that a line in the read-only reference original that has no
+    /// A display-only row: it exists so that a line in the reference original that has no
     /// counterpart in the working subtitle is still visible in the grid, side by side with the rest
     /// (issue #13449). It is never part of the working subtitle - it is filtered out of
     /// <see cref="MainViewModel.GetUpdateSubtitle"/> (so it can never be saved), out of the change
     /// hash, out of numbering and out of the waveform. Only <see cref="OriginalText"/> and the time
-    /// codes carry data; <see cref="Text"/> stays empty and cannot be typed into.
+    /// codes carry data; <see cref="Text"/> stays empty until the user types into it, which
+    /// promotes the row to an ordinary working line keeping the reference timings (#13594).
+    /// Observable so the promotion re-renders the row live (dim, number).
     /// </summary>
-    public bool IsReferenceOnly { get; set; }
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(NumberDisplay))]
+    private bool _isReferenceOnly;
+
+    /// <summary>
+    /// The <see cref="Paragraph.Id"/> of the original-subtitle line this row displays - matched
+    /// working rows and reference-only rows alike. The assignment is made once, when the original
+    /// is opened (or the grid rebuilt wholesale), and then sticks: retiming or editing a row never
+    /// re-matches it onto a different original line, so rows do not shuffle around under the user
+    /// (#13594). Null when no original line belongs to this row.
+    /// </summary>
+    public Guid? ReferenceParagraphId { get; set; }
 
     /// <summary>
     /// The number column's text: blank for a reference-only row, which has no number because it is
@@ -159,7 +172,8 @@ public partial class SubtitleLineViewModel : ObservableObject
         NewSection = p.NewSection;
         Forced = p.Forced;
         _bookmark = p.Bookmark;
-        IsReferenceOnly = p.IsReferenceOnly;
+        _isReferenceOnly = p.IsReferenceOnly;
+        ReferenceParagraphId = p.ReferenceParagraphId;
 
         Id = generateNewId ? Guid.NewGuid() : p.Id;
 

--- a/src/ui/Features/Shared/OpenOriginalMismatch/OpenOriginalMismatchViewModel.cs
+++ b/src/ui/Features/Shared/OpenOriginalMismatch/OpenOriginalMismatchViewModel.cs
@@ -16,7 +16,8 @@ public partial class OpenOriginalMismatchViewModel : ObservableObject
 
     /// <summary>
     /// Show the original's non-matching lines as extra, display-only rows. The grid then holds the
-    /// whole original, which is why editing it stays lossless - at the price of locked time codes.
+    /// whole original, which is why editing it stays lossless. Typing into an extra row adopts
+    /// that line into the working subtitle (#13594).
     /// </summary>
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(ShowMatchingLinesOnly))]

--- a/src/ui/Features/Shared/OpenOriginalMismatch/OpenOriginalMismatchWindow.cs
+++ b/src/ui/Features/Shared/OpenOriginalMismatch/OpenOriginalMismatchWindow.cs
@@ -48,7 +48,7 @@ public class OpenOriginalMismatchWindow : Window
             nameof(vm.ShowAllOriginalLinesText),
             nameof(vm.ShowAllOriginalLinesHint),
             nameof(vm.ShowAllOriginalLines),
-            IconNames.LockClock,
+            IconNames.Pencil,
             nameof(vm.ShowAllOriginalLinesNote),
             out _);
 

--- a/src/ui/Logic/Config/Language/Main/LanguageMain.cs
+++ b/src/ui/Logic/Config/Language/Main/LanguageMain.cs
@@ -235,7 +235,7 @@ public class LanguageMain
         AllowEditOfOriginalSubtitle = "Allow edit of original subtitle";
         ShowAllOriginalLinesX = "Show all original lines ({0} have no match here)";
         ShowAllOriginalLinesHint = "The lines with no match are shown as extra rows, so you can see what the translation is missing.";
-        ShowAllOriginalLinesNote = "Time codes cannot be changed while these rows are shown";
+        ShowAllOriginalLinesNote = "Type in an extra row to add that line to your subtitle";
         ShowMatchingOriginalLinesX = "Show only the {0} matching original lines";
         ShowMatchingOriginalLinesHint = "The other {0} original lines are not shown anywhere.";
         ShowMatchingOriginalLinesNote = "They stay in the file unless you save the original";

--- a/tests/UI/Features/Main/MainReadOnlyOriginalTests.cs
+++ b/tests/UI/Features/Main/MainReadOnlyOriginalTests.cs
@@ -309,11 +309,13 @@ public class MainReadOnlyOriginalTests
     }
 
     /// <summary>
-    /// Time codes are locked while the original's non-matching lines are shown: those rows are placed
-    /// by matching on time, so retiming a working line would shuffle them around under the user.
+    /// Showing the original's non-matching lines no longer locks time codes: each row keeps a
+    /// sticky link to the original line it displays, so retiming cannot shuffle the reference
+    /// around under the user (#13594). Only a selected display-only row keeps its editors off -
+    /// its timings belong to the original file.
     /// </summary>
     [AvaloniaFact]
-    public void ShowingNonMatchingOriginalLines_LocksTimeCodes()
+    public void ShowingNonMatchingOriginalLines_DoesNotLockTimeCodes()
     {
         var (window, vm) = CreateMainViewModel();
         try
@@ -323,13 +325,145 @@ public class MainReadOnlyOriginalTests
             ImportSampleReference(vm);
 
             Assert.True(vm.IsShowingOriginalNonMatchingLines);
-            Assert.True(vm.AreTimeCodesLocked);
-            Assert.False(vm.AreTimeCodesEditable);
-            Assert.False(vm.LockTimeCodes); // the user's own lock setting is untouched
-
-            InvokeFileCloseOriginal(vm);
-
             Assert.False(vm.AreTimeCodesLocked);
+            Assert.False(vm.LockTimeCodes);
+
+            // The show/hide/duration editors still refuse a display-only row.
+            vm.SelectedSubtitle = vm.Subtitles.Single(p => p.IsReferenceOnly);
+            Assert.False(vm.AreTimeCodesEditable);
+
+            vm.SelectedSubtitle = vm.Subtitles.First(p => !p.IsReferenceOnly);
+            Assert.True(vm.AreTimeCodesEditable);
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    /// <summary>
+    /// The whole point of the sticky link (#13594): retiming a working line keeps the original
+    /// text it displays, even when the new timing overlaps a different original line - the old
+    /// time-based re-match would have swapped the texts around.
+    /// </summary>
+    [AvaloniaFact]
+    public void RetimedWorkingRow_KeepsItsOriginalLine()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            ImportSampleReference(vm);
+
+            // Retime "Translated one" (displays "Reference one", 0-2000) into the middle of the
+            // reference-only line's span (2000-4000).
+            var retimed = vm.Subtitles.Single(p => p.Text == "Translated one");
+            retimed.SetTimes(TimeSpan.FromMilliseconds(2200), TimeSpan.FromMilliseconds(3800));
+
+            InvokeReapplyReadOnlyReference(vm);
+
+            Assert.Equal("Reference one", retimed.OriginalText);
+            var referenceRow = Assert.Single(vm.Subtitles, p => p.IsReferenceOnly);
+            Assert.Equal("Reference only - no translation", referenceRow.OriginalText);
+            Assert.Equal(3, vm.Subtitles.Count);
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    /// <summary>
+    /// After a retime the display-only rows glide back into start-time order - and only they move;
+    /// the working rows keep their order and identity.
+    /// </summary>
+    [AvaloniaFact]
+    public void RetimedWorkingRow_MakesReferenceRowsGlideIntoPlace()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            ImportSampleReference(vm);
+
+            // "Translated two" (4000-6000) moves before the reference-only row (2000-4000).
+            var retimed = vm.Subtitles.Single(p => p.Text == "Translated two");
+            retimed.SetTimes(TimeSpan.FromMilliseconds(900), TimeSpan.FromMilliseconds(1900));
+
+            InvokeReapplyReadOnlyReference(vm);
+
+            Assert.Equal(
+                new[] { "Translated one", "Translated two", string.Empty },
+                vm.Subtitles.Select(p => p.Text));
+            Assert.True(vm.Subtitles[2].IsReferenceOnly);
+            Assert.Equal("Reference only - no translation", vm.Subtitles[2].OriginalText);
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    /// <summary>
+    /// Typing into a display-only row adopts the missing line: the row becomes an ordinary,
+    /// numbered, saveable working line at the reference line's timings (#13594).
+    /// </summary>
+    [AvaloniaFact]
+    public void TypingIntoReferenceOnlyRow_PromotesItToAWorkingLine()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            ImportSampleReference(vm);
+            var referenceRow = vm.Subtitles.Single(p => p.IsReferenceOnly);
+
+            vm.SelectedSubtitle = referenceRow;
+            referenceRow.Text = "Freshly typed translation";
+            vm.SubtitleTextChanged(null, null!);
+
+            Assert.False(referenceRow.IsReferenceOnly);
+            Assert.Equal(2, referenceRow.Number);
+            Assert.Equal(TimeSpan.FromMilliseconds(2000), referenceRow.StartTime);
+
+            var saved = vm.GetUpdateSubtitle();
+            Assert.Equal(3, saved.Paragraphs.Count);
+            Assert.Equal("Freshly typed translation", saved.Paragraphs[1].Text);
+
+            // The reference itself is untouched, and the refresh does not bring a duplicate row:
+            // the promoted row still displays that original line.
+            InvokeReapplyReadOnlyReference(vm);
+            Assert.Equal(3, vm.Subtitles.Count);
+            Assert.DoesNotContain(vm.Subtitles, p => p.IsReferenceOnly);
+            Assert.Equal("Reference only - no translation", referenceRow.OriginalText);
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    /// <summary>
+    /// Deleting a promoted row hands its original line back to the reference: the line reappears
+    /// as a display-only row on the next refresh, so nothing of the reference is ever lost.
+    /// </summary>
+    [AvaloniaFact]
+    public void DeletingAPromotedRow_BringsTheReferenceLineBack()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            ImportSampleReference(vm);
+            var referenceRow = vm.Subtitles.Single(p => p.IsReferenceOnly);
+
+            vm.SelectedSubtitle = referenceRow;
+            referenceRow.Text = "Typed then deleted";
+            vm.SubtitleTextChanged(null, null!);
+            Assert.False(referenceRow.IsReferenceOnly);
+
+            vm.Subtitles.Remove(referenceRow);
+            InvokeReapplyReadOnlyReference(vm);
+
+            var restored = Assert.Single(vm.Subtitles, p => p.IsReferenceOnly);
+            Assert.Equal("Reference only - no translation", restored.OriginalText);
+            Assert.Equal(3, vm.Subtitles.Count);
         }
         finally
         {
@@ -574,11 +708,11 @@ public class MainReadOnlyOriginalTests
     }
 
     /// <summary>
-    /// The waveform enforces the time-code lock through its own IsReadOnly, so it must follow the
-    /// lock that showing/closing the non-matching lines toggles.
+    /// The waveform stays editable while the non-matching lines are shown - the sticky links mean
+    /// dragging a paragraph edge cannot shuffle the reference rows onto other lines (#13594).
     /// </summary>
     [AvaloniaFact]
-    public void ShowingNonMatchingOriginalLines_MakesTheWaveformReadOnly()
+    public void ShowingNonMatchingOriginalLines_KeepsTheWaveformEditable()
     {
         var (window, vm) = CreateMainViewModel();
         try
@@ -591,9 +725,6 @@ public class MainReadOnlyOriginalTests
             Assert.False(vm.AudioVisualizer.IsReadOnly);
 
             ImportSampleReference(vm);
-            Assert.True(vm.AudioVisualizer.IsReadOnly);
-
-            InvokeFileCloseOriginal(vm);
             Assert.False(vm.AudioVisualizer.IsReadOnly);
         }
         finally


### PR DESCRIPTION
Fixes the three workflow blockers reported in #13594 (re-open of #13449): missing reference lines could not be added to the translation, rows "moved on their own" after every change, and time codes were locked for the whole file while the reference rows were shown.

## Root cause

All three came from the same design point: the row ↔ original-line mapping was re-derived from time codes (a greedy three-pass match) after every structural change, on a 400 ms debounce. Because the mapping could change at any moment, the reference rows were torn out and re-inserted wholesale (visible churn), and retiming had to be forbidden globally (a retime could re-match rows onto different lines).

## What this PR does

**Sticky links.** Each row now remembers which original line it displays (`SubtitleLineViewModel.ReferenceParagraphId` → `Paragraph.Id`), assigned once when the original is opened. The debounced re-match became a gentle refresh that never touches an assigned row:

- drops stale and duplicate links (deleted lines, duplicated rows — first row wins);
- for a **read-only** original, re-syncs displayed text from the file (it stays authoritative) and brings back a line whose displaying row was deleted, as a new display-only row;
- matches only brand-new rows against only unclaimed lines — a no-op in the steady state, and exactly the full match after a wholesale grid rebuild (format conversion), where no row carries a link yet;
- glides the display-only rows back into start-time order, moving **only** rows that are actually out of place (working rows never move, so selection is never disturbed).

Merge & friends (`WithoutReferenceOnlyRows`) now detach and re-insert the *same row instances* instead of dropping and re-deriving them. The capture paths (`CaptureOriginalFromRows`, `GetUpdateSubtitleOriginal`) re-stamp the links they invalidate, since rebuilding paragraphs means fresh ids.

**Time codes unlocked.** With the mapping pinned, retiming cannot shuffle the reference — `AreTimeCodesLocked` is the user's own lock again and the waveform stays editable. Only a *selected display-only row* keeps its timing editors off: its timings belong to the original file.

**Promote-on-type.** Typing (or pasting) into a display-only row turns it into an ordinary working line at the reference line's timings — the exact "add what's missing" workflow from the issue. **Column → Copy text from original to current** now also works on display-only rows, adopting the line together with its text in one step. Deleting a promoted row hands the line back to the reference (read-only originals lose nothing, ever). `IsReferenceOnly` is observable now, so the promotion drops the dimming and shows the number live.

The mismatch dialog note ("Time codes cannot be changed…") is replaced with the promote hint, and the docs (`docs/features/main-window.md`) describe the whole mode.

## Tests

- 6 new/updated tests: sticky retime keeps the row's original line, reference rows glide (and only they move), promote-on-type produces a numbered saveable line with no duplicate row after refresh, deleting a promoted row restores the reference row, no lock + editable waveform.
- Full UI suite: **2641 passed, 0 failed**.

A follow-up PR adds an explicit "Edit original" mode on top of this (working side read-only, original editable and save-prompted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
