### PR TITLE
Let a display-only reference row's times be edited - it stays a reference row (#13594)

### DIFF
--- a/docs/features/main-window.md
+++ b/docs/features/main-window.md
@@ -330,7 +330,7 @@ If the original file does not have the same number of lines as the subtitle you 
 
 The dialog also offers an **Allow edit of original subtitle** check box. Left off (the default), the original is a read-only reference: it is never written to, and closing it leaves the file on disk exactly as it was. Both choices are remembered for the next time.
 
-The dimmed rows belong to the original, so they are not saved with your subtitle, and editing commands (delete, merge, export, …) skip them. To adopt a missing line into your subtitle, select it and simply type or paste the translation — the row immediately becomes a normal line, keeping the original line's timings. **Column → Copy text from original to current** in the grid's context menu does the same while also copying the original text over.
+The dimmed rows belong to the original, so they are not saved with your subtitle, and editing commands (delete, merge, export, …) skip them. To adopt a missing line into your subtitle, select it and simply type or paste the translation — the row immediately becomes a normal line, keeping its timings. **Column → Copy text from original to current** in the grid's context menu does the same while also copying the original text over. You can nudge a dimmed row's start/end/duration first (it stays a dimmed reference row until you type text into it), so an adopted line lands with exactly the timing you want.
 
 Each row remembers which original line it shows, so editing or retiming your own lines never re-shuffles the reference: the dimmed rows only slide to keep time order, and if you delete a row that had adopted a reference line, that line comes back as a dimmed row.
 
@@ -338,7 +338,7 @@ Each row remembers which original line it shows, so editing or retiming your own
 
 **File → Edit original subtitle** (visible while an original is open) switches which file you are editing:
 
-- The original's text becomes editable — including a reference that was opened read-only — and a selected dimmed row's timings can be changed (they belong to the original).
+- The original's text becomes editable — including a reference that was opened read-only.
 - The working subtitle's text box goes read-only while the mode is on, so the two sides can't be mixed up. The edit-box label reads *Original text (edit mode)*.
 - Changes to the original are tracked: `Ctrl+S` saves them, and closing the original (or the app) asks about unsaved changes.
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -202,17 +202,7 @@ public partial class MainViewModel :
     IApplyWebVttStyles
 {
     [ObservableProperty] private ObservableCollection<SubtitleLineViewModel> _subtitles;
-    [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(IsSelectedLineReferenceOnly))]
-    [NotifyPropertyChangedFor(nameof(AreTimeCodesEditable))]
-    private SubtitleLineViewModel? _selectedSubtitle;
-
-    /// <summary>
-    /// True while a display-only reference row is selected. The show/hide/duration editors are off
-    /// for such a row (its timings belong to the original file); its text box, though, is open on
-    /// purpose - typing into it adopts the line into the working subtitle (#13594).
-    /// </summary>
-    public bool IsSelectedLineReferenceOnly => SelectedSubtitle?.IsReferenceOnly == true;
+    [ObservableProperty] private SubtitleLineViewModel? _selectedSubtitle;
     private List<SubtitleLineViewModel>? _selectedSubtitles;
     [ObservableProperty] private int? _selectedSubtitleIndex;
 
@@ -275,15 +265,13 @@ public partial class MainViewModel :
 
     /// <summary>
     /// "Edit original" mode (#13594): the original subtitle is the one being worked on - its text
-    /// is writable, a selected display-only row's timings are editable (they are that original
-    /// line's own), and the working subtitle's text box goes read-only so the two sides cannot be
+    /// is writable, and the working subtitle's text box goes read-only so the two sides cannot be
     /// mixed up. Entering makes a read-only original editable with a clean dirty baseline; leaving
     /// returns it to the state it was opened with, prompting to save (or discard) edits that would
     /// otherwise be frozen in a read-only reference. Toggled from the File menu while an original
     /// is open; see <see cref="ToggleEditOriginalMode"/>.
     /// </summary>
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(AreTimeCodesEditable))]
     [NotifyPropertyChangedFor(nameof(OriginalTextLabel))]
     private bool _isEditOriginalMode;
 
@@ -335,12 +323,13 @@ public partial class MainViewModel :
     public bool AreTimeCodesLocked => LockTimeCodes;
 
     /// <summary>
-    /// Whether the show/hide/duration editors accept input: not while time codes are locked, and
-    /// not on a display-only reference row, whose timings belong to the original file (#13449) -
-    /// unless "Edit original" mode is on, where editing that original line's timings is exactly
-    /// the point (#13594).
+    /// Whether the show/hide/duration editors accept input: only the user's own lock disables
+    /// them. A display-only reference row's editors are open too - nudging its timings before
+    /// typing the translation is part of adopting the line (#13594), the row stays a dimmed
+    /// reference row (only typing text promotes it), and a read-only reference file is still
+    /// never written, so nothing on disk can change.
     /// </summary>
-    public bool AreTimeCodesEditable => !AreTimeCodesLocked && (!IsSelectedLineReferenceOnly || IsEditOriginalMode);
+    public bool AreTimeCodesEditable => !AreTimeCodesLocked;
     [ObservableProperty] private bool _areVideoControlsUndocked;
     [ObservableProperty] private bool _isFormatAssa;
     [ObservableProperty] private bool _isFormatSsa;
@@ -2763,14 +2752,11 @@ public partial class MainViewModel :
                     used[index] = true;
                     if (IsOriginalReadOnly)
                     {
-                        var p = original.Paragraphs[index];
-                        row.OriginalText = p.Text;
-                        if (row.IsReferenceOnly)
-                        {
-                            row.SetTimes(
-                                TimeSpan.FromMilliseconds(p.StartTime.TotalMilliseconds),
-                                TimeSpan.FromMilliseconds(p.EndTime.TotalMilliseconds));
-                        }
+                        // The file's TEXT stays authoritative for a read-only reference. Its times
+                        // deliberately do not: a display-only row's timings may be nudged by the
+                        // user (part of adopting the line, #13594), and the file is never written
+                        // to either way.
+                        row.OriginalText = original.Paragraphs[index].Text;
                     }
                 }
                 else
@@ -25135,11 +25121,6 @@ public partial class MainViewModel :
     {
         row.IsReferenceOnly = false; // observable: the grid drops the dimming and shows the number
         Renumber();
-
-        // The selected row changed nature, so everything derived from "is a reference row selected".
-        OnPropertyChanged(nameof(IsSelectedLineReferenceOnly));
-        OnPropertyChanged(nameof(AreTimeCodesEditable));
-
         _updateAudioVisualizer = true;
     }
 

--- a/tests/UI/Features/Main/MainEditOriginalModeTests.cs
+++ b/tests/UI/Features/Main/MainEditOriginalModeTests.cs
@@ -93,27 +93,29 @@ public class MainEditOriginalModeTests
     }
 
     /// <summary>
-    /// In the mode, a display-only row's timings are editable - they are the original line's own,
-    /// and editing the original is the point. Outside the mode they stay off.
+    /// A display-only row's timings are editable in and out of the mode - only the user's own time
+    /// code lock disables the editors (#13594).
     /// </summary>
     [AvaloniaFact]
-    public void EditOriginalMode_MakesReferenceOnlyRowTimingsEditable()
+    public void ReferenceOnlyRowTimings_AreEditableRegardlessOfTheMode()
     {
         var (window, vm) = CreateMainViewModel();
+        var lockTimeCodes = vm.LockTimeCodes;
         try
         {
             ImportSampleReference(vm, isReadOnly: true);
             vm.SelectedSubtitle = vm.Subtitles.Single(p => p.IsReferenceOnly);
-            Assert.False(vm.AreTimeCodesEditable);
+            Assert.True(vm.AreTimeCodesEditable);
 
             InvokeToggleEditOriginalMode(vm);
             Assert.True(vm.AreTimeCodesEditable);
 
-            InvokeToggleEditOriginalMode(vm);
+            vm.LockTimeCodes = true;
             Assert.False(vm.AreTimeCodesEditable);
         }
         finally
         {
+            vm.LockTimeCodes = lockTimeCodes;
             CloseWindow(window, vm);
         }
     }

--- a/tests/UI/Features/Main/MainReadOnlyOriginalTests.cs
+++ b/tests/UI/Features/Main/MainReadOnlyOriginalTests.cs
@@ -311,8 +311,8 @@ public class MainReadOnlyOriginalTests
     /// <summary>
     /// Showing the original's non-matching lines no longer locks time codes: each row keeps a
     /// sticky link to the original line it displays, so retiming cannot shuffle the reference
-    /// around under the user (#13594). Only a selected display-only row keeps its editors off -
-    /// its timings belong to the original file.
+    /// around under the user (#13594). Display-only rows included - nudging their timings is part
+    /// of adopting the line, and only the user's own lock disables the editors.
     /// </summary>
     [AvaloniaFact]
     public void ShowingNonMatchingOriginalLines_DoesNotLockTimeCodes()
@@ -328,12 +328,44 @@ public class MainReadOnlyOriginalTests
             Assert.False(vm.AreTimeCodesLocked);
             Assert.False(vm.LockTimeCodes);
 
-            // The show/hide/duration editors still refuse a display-only row.
             vm.SelectedSubtitle = vm.Subtitles.Single(p => p.IsReferenceOnly);
-            Assert.False(vm.AreTimeCodesEditable);
+            Assert.True(vm.AreTimeCodesEditable);
 
             vm.SelectedSubtitle = vm.Subtitles.First(p => !p.IsReferenceOnly);
             Assert.True(vm.AreTimeCodesEditable);
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    /// <summary>
+    /// Retiming a display-only row does not promote it - only typing text does - and the nudged
+    /// times survive the refresh: the file's text stays authoritative for a read-only reference,
+    /// its times deliberately do not (#13594).
+    /// </summary>
+    [AvaloniaFact]
+    public void RetimedReferenceOnlyRow_KeepsItsTimesAndStaysAReferenceRow()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            ImportSampleReference(vm);
+            var referenceRow = vm.Subtitles.Single(p => p.IsReferenceOnly);
+
+            referenceRow.SetTimes(TimeSpan.FromMilliseconds(2500), TimeSpan.FromMilliseconds(4500));
+
+            InvokeReapplyReadOnlyReference(vm);
+
+            var stillReference = Assert.Single(vm.Subtitles, p => p.IsReferenceOnly);
+            Assert.Same(referenceRow, stillReference);
+            Assert.Equal(TimeSpan.FromMilliseconds(2500), stillReference.StartTime);
+            Assert.Equal(TimeSpan.FromMilliseconds(4500), stillReference.EndTime);
+            Assert.Equal("Reference only - no translation", stillReference.OriginalText);
+
+            // Still not part of the working subtitle.
+            Assert.Equal(2, vm.GetUpdateSubtitle().Paragraphs.Count);
         }
         finally
         {


### PR DESCRIPTION
Follow-up to #13595/#13596, from testing: with a reference row selected there is no current line, and the show/hide/duration editors were disabled unless "Edit original" mode was on — blocking the natural adopt-with-adjusted-timing flow (nudge the times first, then type the translation).

- Only the user's own time-code lock disables the editors now; `AreTimeCodesEditable` loses both special cases (which also retires the now-unused `IsSelectedLineReferenceOnly`).
- Retiming a reference row does **not** promote it — the row stays gray/dimmed; only typing text adopts it.
- The refresh keeps the nudged times: for a read-only reference the file's **text** stays authoritative, its **times** deliberately no longer do (the file is never written either way, and reverting a deliberate nudge on the next debounce tick would read as rows moving on their own again).

Tests: rewrote the two affected tests, added `RetimedReferenceOnlyRow_KeepsItsTimesAndStaysAReferenceRow`. Full UI suite: **2648 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)