### PR TITLE
perf: skip work five string helpers cannot need

### DIFF
--- a/src/libse/Common/CharLookup.cs
+++ b/src/libse/Common/CharLookup.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+#if NET8_0_OR_GREATER
+using System.Buffers;
+#endif
+
+namespace Nikse.SubtitleEdit.Core.Common
+{
+    /// <summary>
+    /// A character set prepared once per call site.
+    /// <para>
+    /// Several checks in the code base asked "is there anything but these characters here?" by
+    /// building the stripped string with <c>RemoveChar</c> and handing it to
+    /// <c>string.IsNullOrWhiteSpace</c> - an allocation per call for an answer
+    /// that never needed the string. <see cref="StringExtensions.IsOnlyChars"/> and
+    /// <see cref="StringExtensions.IsOnlyCharsOrWhiteSpace"/> answer it directly, and this type
+    /// holds the search structure they scan with, so it is built once instead of per call.
+    /// </para>
+    /// </summary>
+    public sealed class CharLookup
+    {
+        private static readonly char[] WhiteSpaceChars = BuildWhiteSpaceChars();
+
+        private readonly bool[] _ascii;
+        private readonly bool[] _asciiOrWhiteSpace;
+        private readonly char[] _nonAscii;
+        private readonly char[] _nonAsciiOrWhiteSpace;
+#if NET8_0_OR_GREATER
+        private readonly SearchValues<char> _chars;
+        private readonly SearchValues<char> _charsOrWhiteSpace;
+#endif
+
+        private CharLookup(char[] chars)
+        {
+            var withWhiteSpace = new List<char>(chars.Length + WhiteSpaceChars.Length);
+            withWhiteSpace.AddRange(chars);
+            foreach (var ch in WhiteSpaceChars)
+            {
+                if (!withWhiteSpace.Contains(ch))
+                {
+                    withWhiteSpace.Add(ch);
+                }
+            }
+
+            _ascii = BuildAsciiTable(chars, out _nonAscii);
+            _asciiOrWhiteSpace = BuildAsciiTable(withWhiteSpace.ToArray(), out _nonAsciiOrWhiteSpace);
+#if NET8_0_OR_GREATER
+            _chars = SearchValues.Create(chars);
+            _charsOrWhiteSpace = SearchValues.Create(withWhiteSpace.ToArray());
+#endif
+        }
+
+        public static CharLookup Create(params char[] chars) => new CharLookup(chars);
+
+        /// <summary>
+        /// True when every character of <paramref name="value"/> belongs to this set. An empty
+        /// or null string is "only these characters", matching the
+        /// <c>string.IsNullOrEmpty(value.RemoveChar(...))</c> shape this replaces.
+        /// </summary>
+        internal bool IsOnly(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return true;
+            }
+
+#if NET8_0_OR_GREATER
+            return value.AsSpan().IndexOfAnyExcept(_chars) < 0;
+#else
+            return IsOnlyScalar(value, _ascii, _nonAscii);
+#endif
+        }
+
+        /// <summary>
+        /// True when every character of <paramref name="value"/> is either in this set or white
+        /// space - the same answer as <c>string.IsNullOrWhiteSpace(value.RemoveChar(...))</c>.
+        /// </summary>
+        internal bool IsOnlyOrWhiteSpace(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return true;
+            }
+
+#if NET8_0_OR_GREATER
+            return value.AsSpan().IndexOfAnyExcept(_charsOrWhiteSpace) < 0;
+#else
+            return IsOnlyScalar(value, _asciiOrWhiteSpace, _nonAsciiOrWhiteSpace);
+#endif
+        }
+
+        private static bool IsOnlyScalar(string value, bool[] ascii, char[] nonAscii)
+        {
+            for (var i = 0; i < value.Length; i++)
+            {
+                var ch = value[i];
+                if (ch < 128)
+                {
+                    if (!ascii[ch])
+                    {
+                        return false;
+                    }
+
+                    continue;
+                }
+
+                var found = false;
+                for (var j = 0; j < nonAscii.Length; j++)
+                {
+                    if (nonAscii[j] == ch)
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool[] BuildAsciiTable(char[] chars, out char[] nonAscii)
+        {
+            var table = new bool[128];
+            var rest = new List<char>();
+            foreach (var ch in chars)
+            {
+                if (ch < 128)
+                {
+                    table[ch] = true;
+                }
+                else
+                {
+                    rest.Add(ch);
+                }
+            }
+
+            nonAscii = rest.ToArray();
+            return table;
+        }
+
+        private static char[] BuildWhiteSpaceChars()
+        {
+            var list = new List<char>(32);
+            for (var i = 0; i <= char.MaxValue; i++)
+            {
+                var ch = (char)i;
+                if (char.IsWhiteSpace(ch))
+                {
+                    list.Add(ch);
+                }
+            }
+
+            return list.ToArray();
+        }
+    }
+}

--- a/src/libse/Common/HtmlUtil.cs
+++ b/src/libse/Common/HtmlUtil.cs
@@ -1542,6 +1542,14 @@ namespace Nikse.SubtitleEdit.Core.Common
         /// <returns>A new string with color tags removed.</returns>
         public static string RemoveColorTags(string input)
         {
+            // The loop below restarts the regex from index 0 after every hit and rebuilds the
+            // whole string twice per hit, so it is worth not entering it at all: the pattern can
+            // only match "COLOR=" or "color=", and most lines carry neither.
+            if (input.IndexOf("olor", StringComparison.OrdinalIgnoreCase) < 0)
+            {
+                return input.Trim();
+            }
+
             var r = ColorAttributeRegex;
             var s = input;
             var match = r.Match(s);
@@ -1662,11 +1670,48 @@ namespace Nikse.SubtitleEdit.Core.Common
         /// </summary>
         /// <param name="s">The input string from which to remove the alignment tags.</param>
         /// <returns>A new string without ASS and SSA alignment tags.</returns>
+        /// <summary>
+        /// True when <paramref name="s"/> can hold one of the alignment tags
+        /// <see cref="RemoveAssAlignmentTags"/> strips. Every one of its 45 patterns is an 'a'
+        /// directly after '\\' or '{', followed by 1-9 or by 'n' and 1-9, so one scan tells the
+        /// ASSA lines that carry an alignment tag from the far more common ones that only carry
+        /// \pos, \fad, \c and friends - which would otherwise pay all 45 Replace scans.
+        /// </summary>
+        private static bool HasAlignmentTag(string s)
+        {
+            for (var i = 1; i + 1 < s.Length; i++)
+            {
+                if (s[i] != 'a')
+                {
+                    continue;
+                }
+
+                var previous = s[i - 1];
+                if (previous != '\\' && previous != '{')
+                {
+                    continue;
+                }
+
+                var next = s[i + 1];
+                if (next >= '1' && next <= '9')
+                {
+                    return true;
+                }
+
+                if (next == 'n' && i + 2 < s.Length && s[i + 2] >= '1' && s[i + 2] <= '9')
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         public static string RemoveAssAlignmentTags(string s)
         {
             // Every pattern below contains a backslash, so plain text (the common case in
             // batch convert) skips all 45 Replace scans.
-            if (s.IndexOf('\\') < 0)
+            if (s.IndexOf('\\') < 0 || !HasAlignmentTag(s))
             {
                 return s;
             }

--- a/src/libse/Common/PlainTextImporter.cs
+++ b/src/libse/Common/PlainTextImporter.cs
@@ -7,6 +7,9 @@
     {
         public class PlainTextImporter
         {
+            private static readonly CharLookup NonLetterChars =
+                CharLookup.Create('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', ':', '.', ',', '-', '>', '/');
+
             private readonly bool _splitAtBlankLines;
             private readonly bool _removeLinesWithoutLetters;
             private readonly int _numberOfLines;
@@ -368,8 +371,7 @@
 
             public static bool ContainsLetters(string line)
             {
-                if (string.IsNullOrWhiteSpace(line
-                    .RemoveChar('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', ':', '.', ',', '-', '>', '/')))
+                if (line.IsOnlyCharsOrWhiteSpace(NonLetterChars))
                 {
                     return false;
                 }

--- a/src/libse/Common/StringExtensions.cs
+++ b/src/libse/Common/StringExtensions.cs
@@ -511,6 +511,18 @@ namespace Nikse.SubtitleEdit.Core.Common
             return false;
         }
 
+        /// <summary>
+        /// Same answer as <c>string.IsNullOrEmpty(value.RemoveChar(chars))</c>, without building
+        /// the stripped string. Prepare <paramref name="chars"/> once in a static field.
+        /// </summary>
+        public static bool IsOnlyChars(this string value, CharLookup chars) => chars.IsOnly(value);
+
+        /// <summary>
+        /// Same answer as <c>string.IsNullOrWhiteSpace(value.RemoveChar(chars))</c>, without
+        /// building the stripped string. Prepare <paramref name="chars"/> once in a static field.
+        /// </summary>
+        public static bool IsOnlyCharsOrWhiteSpace(this string value, CharLookup chars) => chars.IsOnlyOrWhiteSpace(value);
+
         public static bool ContainsUnicodeControlChars(this string s)
         {
 #if NET8_0_OR_GREATER

--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -57,14 +57,6 @@ namespace Nikse.SubtitleEdit.Core.Common
         private static partial Regex NumberSeparatorNumberRegExGen();
         private static readonly Regex NumberSeparatorNumberRegEx = NumberSeparatorNumberRegExGen();
 
-        [GeneratedRegex("^\\d+$")]
-        private static partial Regex RegexIsNumberGen();
-        private static readonly Regex RegexIsNumber = RegexIsNumberGen();
-
-        [GeneratedRegex("^\\d+x\\d+$")]
-        private static partial Regex RegexIsEpisodeNumberGen();
-        private static readonly Regex RegexIsEpisodeNumber = RegexIsEpisodeNumberGen();
-
         [GeneratedRegex(@"(\d) (\.)")]
         private static partial Regex RegexNumberSpacePeriodGen();
         private static readonly Regex RegexNumberSpacePeriod = RegexNumberSpacePeriodGen();
@@ -94,8 +86,6 @@ namespace Nikse.SubtitleEdit.Core.Common
         private static readonly Regex RegexLetterSpacePeriodSpaceLetter = RegexLetterSpacePeriodSpaceLetterGen();
 #else
         private static readonly Regex NumberSeparatorNumberRegEx = new Regex(@"\b\d+[\.:;] \d+\b", RegexOptions.Compiled);
-        private static readonly Regex RegexIsNumber = new Regex("^\\d+$", RegexOptions.Compiled);
-        private static readonly Regex RegexIsEpisodeNumber = new Regex("^\\d+x\\d+$", RegexOptions.Compiled);
         private static readonly Regex RegexNumberSpacePeriod = new Regex(@"(\d) (\.)", RegexOptions.Compiled);
         private static readonly Regex RegexOrdinalSt = new Regex(@"(1) (st)\b", RegexOptions.Compiled);
         private static readonly Regex RegexOrdinalNd = new Regex(@"(2) (nd)\b", RegexOptions.Compiled);
@@ -126,20 +116,48 @@ namespace Nikse.SubtitleEdit.Core.Common
             return true;
         }
 
+        private static readonly char[] CurrencyAndPercentChars = { '$', '\u00A3', '\u00A5', '%', '*' };
+
+        /// <summary>
+        /// Same answer as the <c>^\d+$</c> and <c>^\d+x\d+$</c> regexes this used to run, without
+        /// the trimmed copy and without entering the regex engine. Two details are kept
+        /// deliberately: <c>\d</c> is <c>\p{Nd}</c>, i.e. <see cref="char.IsDigit(char)"/> and not
+        /// just '0'-'9', and .NET's <c>$</c> also matches immediately before a single trailing
+        /// line feed.
+        /// </summary>
         public static bool IsNumber(string s)
         {
-            s = s.Trim('$', '£', '¥', '%', '*');
-            if (RegexIsNumber.IsMatch(s))
+            var span = s.AsSpan().Trim(CurrencyAndPercentChars.AsSpan());
+            if (span.Length > 0 && span[span.Length - 1] == '\n')
             {
-                return true;
+                span = span.Slice(0, span.Length - 1);
             }
 
-            if (RegexIsEpisodeNumber.IsMatch(s))
+            if (span.Length == 0)
             {
-                return true;
+                return false;
             }
 
-            return false;
+            var separator = -1;
+            for (var i = 0; i < span.Length; i++)
+            {
+                if (char.IsDigit(span[i]))
+                {
+                    continue;
+                }
+
+                if (span[i] == 'x' && separator < 0)
+                {
+                    separator = i;
+                    continue;
+                }
+
+                return false;
+            }
+
+            // All digits: ^\d+$. Otherwise the only non-digit seen was a single 'x', which must
+            // have at least one digit on either side: ^\d+x\d+$.
+            return separator < 0 || (separator > 0 && separator < span.Length - 1);
         }
 
         public static SubtitleFormat GetSubtitleFormatByFriendlyName(string friendlyName)

--- a/src/libse/Forms/FixCommonErrors/FixEmptyLines.cs
+++ b/src/libse/Forms/FixCommonErrors/FixEmptyLines.cs
@@ -6,6 +6,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
 {
     public class FixEmptyLines : IFixCommonError
     {
+        private static readonly CharLookup UnicodeControlCharLookup = CharLookup.Create(StringExtensions.UnicodeControlChars);
+
         public static class Language
         {
             public static string RemovedEmptyLine { get; set; } = "Remove empty line";
@@ -163,7 +165,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             {
                 var p = subtitle.Paragraphs[i];
                 var text = HtmlUtil.RemoveHtmlTags(p.Text, true).Trim();
-                if (callbacks.AllowFix(p, fixAction0) && string.IsNullOrEmpty(text.RemoveControlCharacters().RemoveChar(StringExtensions.UnicodeControlChars)))
+                if (callbacks.AllowFix(p, fixAction0) && text.RemoveControlCharacters().IsOnlyChars(UnicodeControlCharLookup))
                 {
                     subtitle.Paragraphs.RemoveAt(i);
                     emptyLinesRemoved++;

--- a/src/libse/Forms/RemoveInterjection.cs
+++ b/src/libse/Forms/RemoveInterjection.cs
@@ -28,6 +28,8 @@ namespace Nikse.SubtitleEdit.Core.Forms
 
     public class RemoveInterjection
     {
+        private static readonly CharLookup SentenceEndingsAndDashes = CharLookup.Create('.', '?', '!', '-', '\u2014');
+
         // https://github.com/SubtitleEdit/subtitleedit/issues/1421 + https://github.com/SubtitleEdit/subtitleedit/issues/7563
 
         // Cache compiled `\bWORD\b` regexes keyed by interjection. Invoke() is called once per
@@ -600,13 +602,13 @@ namespace Nikse.SubtitleEdit.Core.Forms
 
             if (lines.Count == 2)
             {
-                if (string.IsNullOrWhiteSpace(lines[1].RemoveChar('.', '?', '!', '-', '—')))
+                if (lines[1].IsOnlyCharsOrWhiteSpace(SentenceEndingsAndDashes))
                 {
                     text = lines[0];
                     lines = text.SplitToLines();
                     lineIndexRemoved = 1;
                 }
-                else if (string.IsNullOrWhiteSpace(lines[0].RemoveChar('.', '?', '!', '-', '—')))
+                else if (lines[0].IsOnlyCharsOrWhiteSpace(SentenceEndingsAndDashes))
                 {
                     text = lines[1];
                     lines = text.SplitToLines();

--- a/src/libse/Forms/RemoveTextForHI.cs
+++ b/src/libse/Forms/RemoveTextForHI.cs
@@ -8,6 +8,8 @@ namespace Nikse.SubtitleEdit.Core.Forms
 {
     public class RemoveTextForHI
     {
+        private static readonly CharLookup MusicSymbols = CharLookup.Create('\u266A', '\u266B');
+
         public RemoveTextForHISettings Settings { get; set; }
 
         public List<int> Warnings { get; set; }
@@ -1232,7 +1234,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
 
             if (Settings.RemoveIfOnlyMusicSymbols)
             {
-                if (string.IsNullOrWhiteSpace(HtmlUtil.RemoveHtmlTags(text, true).RemoveChar('♪', '♫')))
+                if (HtmlUtil.RemoveHtmlTags(text, true).IsOnlyCharsOrWhiteSpace(MusicSymbols))
                 {
                     return string.Empty;
                 }

--- a/src/libse/SubtitleFormats/AvidDvd.cs
+++ b/src/libse/SubtitleFormats/AvidDvd.cs
@@ -8,6 +8,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
     public class AvidDvd : SubtitleFormat
     {
+        private static readonly CharLookup TimeCodeChars = CharLookup.Create('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.', ':', ',');
+
         //25    10:03:20:23 10:03:23:05 some text
         //I see, on my way.|New line also.
         //
@@ -105,8 +107,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         {
                             string text = s.Remove(0, arr[0].Length + arr[1].Length + arr[2].Length + 2).Trim();
 
-                            if (string.IsNullOrWhiteSpace(text
-                                .RemoveChar('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.', ':', ',')))
+                            if (text.IsOnlyCharsOrWhiteSpace(TimeCodeChars))
                             {
                                 _errorCount++;
                             }

--- a/src/libse/SubtitleFormats/AvidLocationMarkers.cs
+++ b/src/libse/SubtitleFormats/AvidLocationMarkers.cs
@@ -8,6 +8,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
     public class AvidLocationMarkers : SubtitleFormat
     {
+        private static readonly CharLookup TimeCodeChars = CharLookup.Create('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.', ':', ',');
+
         private static readonly Regex RegexTimeCode = new Regex(@"^\t\d\d:\d\d:\d\d:\d\d\t[A-Z]\d\t[a-z]{3,8}\t", RegexOptions.Compiled);
 
         public override string Extension => ".txt";
@@ -55,8 +57,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         var arr = match.Value.Split('\t');
                         if (arr.Length== 5 && text.Length > 0)
                         {
-                            if (string.IsNullOrWhiteSpace(text
-                                .RemoveChar('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.', ':', ',')))
+                            if (text.IsOnlyCharsOrWhiteSpace(TimeCodeChars))
                             {
                                 _errorCount++;
                             }

--- a/src/libse/SubtitleFormats/Json.cs
+++ b/src/libse/SubtitleFormats/Json.cs
@@ -228,9 +228,42 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             subtitle.Renumber();
         }
 
+        /// <summary>
+        /// Index of <paramref name="tag"/> wrapped in double or single quotes, double quotes
+        /// first - the same answer as the string[] overload of IndexOfAny this replaces, but
+        /// without building the two quoted needles and the array on every tag read.
+        /// </summary>
+        private static int IndexOfQuotedTag(string s, string tag)
+        {
+            var index = IndexOfQuoted(s, tag, '"');
+            return index >= 0 ? index : IndexOfQuoted(s, tag, '\'');
+        }
+
+        private static int IndexOfQuoted(string s, string tag, char quote)
+        {
+            var from = 0;
+            while (from < s.Length)
+            {
+                var index = s.IndexOf(tag, from, StringComparison.Ordinal);
+                if (index < 0 || index + tag.Length >= s.Length)
+                {
+                    return -1;
+                }
+
+                if (index > 0 && s[index - 1] == quote && s[index + tag.Length] == quote)
+                {
+                    return index - 1;
+                }
+
+                from = index + 1;
+            }
+
+            return -1;
+        }
+
         private static bool IsTagArray(string content, string tag)
         {
-            var startIndex = content.IndexOfAny(new[] { "\"" + tag + "\"", "'" + tag + "'" }, StringComparison.Ordinal);
+            var startIndex = IndexOfQuotedTag(content, tag);
             if (startIndex < 0)
             {
                 return false;
@@ -259,7 +292,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public static string ReadTag(string s, string tag)
         {
-            var startIndex = s.IndexOfAny(new[] { "\"" + tag + "\"", "'" + tag + "'" }, StringComparison.Ordinal);
+            var startIndex = IndexOfQuotedTag(s, tag);
             if (startIndex < 0)
             {
                 return null;
@@ -323,7 +356,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             var list = new List<string>();
 
-            var startIndex = s.IndexOfAny(new[] { "\"" + tag + "\"", "'" + tag + "'" }, StringComparison.Ordinal);
+            var startIndex = IndexOfQuotedTag(s, tag);
             if (startIndex < 0)
             {
                 return list;

--- a/src/libse/SubtitleFormats/RxMarker.cs
+++ b/src/libse/SubtitleFormats/RxMarker.cs
@@ -8,6 +8,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
     public class RxMarker : SubtitleFormat
     {
+        private static readonly CharLookup TimeCodeChars = CharLookup.Create('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.', ':', ',');
+
         private static readonly Regex RegexTimeCode = new Regex(@"^Region \d+\t\d\d:\d\d:\d\d:\d\d\.\d\d\t\d\d:\d\d:\d\d:\d\d\.\d\d\t.+$", RegexOptions.Compiled);
 
         public override string Extension => ".txt";
@@ -74,7 +76,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         if (arr.Length >= 3)
                         {
                             var text = s.Remove(0, arr[0].Length + arr[1].Length + arr[2].Length + 2).Trim();
-                            if (string.IsNullOrWhiteSpace(text.RemoveChar('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.', ':', ',')))
+                            if (text.IsOnlyCharsOrWhiteSpace(TimeCodeChars))
                             {
                                 _errorCount++;
                             }

--- a/tests/benchmarks/StringHelperFastPathBenchmarks.cs
+++ b/tests/benchmarks/StringHelperFastPathBenchmarks.cs
@@ -1,0 +1,243 @@
+using System.Text.RegularExpressions;
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// Before/after for the fast paths in this branch. "Before" is a copy of the shape that was
+/// replaced, so both halves run in one process against one build - no stash baseline, and no
+/// chance of the two halves measuring the same code.
+/// </summary>
+[MemoryDiagnoser]
+public class StringHelperFastPathBenchmarks
+{
+    private const string TextLine = "He never came back that night, and nobody ever asked why.";
+    private const string TimeCodeLine = "00:00:12,340 --> 00:00:15,900";
+    private const string ColorLine = "<font color=\"#ff0000\">He never came back that night.</font>";
+    private const string AssaPosLine = "{\\pos(320,240)\\fad(200,200)}He never came back that night.";
+    private const string AssaAlignmentLine = "{\\an8}He never came back that night.";
+    private const string JsonBlob =
+        "{\"events\":[{\"tStartMs\":12340,\"dDurationMs\":3560,\"segs\":[{\"utf8\":\"He never came back\"}]}]}";
+
+    private static readonly char[] TimeCodeChars =
+        { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.', ':', ',' };
+
+    private static readonly CharLookup TimeCodeLookup = CharLookup.Create(TimeCodeChars);
+
+    // ---------------------------------------------------------- "is this only a time code?"
+
+    [Benchmark]
+    public bool IsOnlyTimeCode_Before_TextLine() => string.IsNullOrWhiteSpace(TextLine.RemoveChar(TimeCodeChars));
+
+    [Benchmark]
+    public bool IsOnlyTimeCode_After_TextLine() => TextLine.IsOnlyCharsOrWhiteSpace(TimeCodeLookup);
+
+    [Benchmark]
+    public bool IsOnlyTimeCode_Before_TimeCode() => string.IsNullOrWhiteSpace(TimeCodeLine.RemoveChar(TimeCodeChars));
+
+    [Benchmark]
+    public bool IsOnlyTimeCode_After_TimeCode() => TimeCodeLine.IsOnlyCharsOrWhiteSpace(TimeCodeLookup);
+
+    // ---------------------------------------------------------- HtmlUtil.RemoveColorTags
+
+    private static readonly Regex ColorAttributeRegex =
+        new Regex("[ ]*(COLOR|color|Color)=[\"']*[#\\dA-Za-z]*[\"']*[ ]*", RegexOptions.Compiled);
+
+    private static string RemoveColorTagsBefore(string input)
+    {
+        var r = ColorAttributeRegex;
+        var s = input;
+        var match = r.Match(s);
+        while (match.Success)
+        {
+            s = s.Remove(match.Index, match.Value.Length).Insert(match.Index, " ");
+            if (match.Index > 4)
+            {
+                if (string.Compare(s, match.Index - 5, "<font >", 0, 7, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    s = s.Remove(match.Index - 5, 7);
+                    var endIndex = s.IndexOf("</font>", match.Index - 5, StringComparison.OrdinalIgnoreCase);
+                    if (endIndex >= 0)
+                    {
+                        s = s.Remove(endIndex, 7);
+                    }
+                }
+                else if (s.Length > match.Index + 1 && s[match.Index + 1] == '>')
+                {
+                    s = s.Remove(match.Index, 1);
+                }
+            }
+
+            match = r.Match(s);
+        }
+
+        return s.Trim();
+    }
+
+    [Benchmark]
+    public string RemoveColorTags_Before_TextLine() => RemoveColorTagsBefore(TextLine);
+
+    [Benchmark]
+    public string RemoveColorTags_After_TextLine() => HtmlUtil.RemoveColorTags(TextLine);
+
+    [Benchmark]
+    public string RemoveColorTags_Before_Tagged() => RemoveColorTagsBefore(ColorLine);
+
+    [Benchmark]
+    public string RemoveColorTags_After_Tagged() => HtmlUtil.RemoveColorTags(ColorLine);
+
+    // ---------------------------------------------------------- HtmlUtil.RemoveAssAlignmentTags
+
+    // The literal Replace chain exactly as it was - no needle is built per call, so the
+    // cost measured here is only the 45 scans.
+    private static string RemoveAlignmentBefore(string s)
+    {
+        if (s.IndexOf('\\') < 0)
+        {
+            return s;
+        }
+
+        return s.Replace("{\\an1}", string.Empty)
+            .Replace("{\\an2}", string.Empty)
+            .Replace("{\\an3}", string.Empty)
+            .Replace("{\\an4}", string.Empty)
+            .Replace("{\\an5}", string.Empty)
+            .Replace("{\\an6}", string.Empty)
+            .Replace("{\\an7}", string.Empty)
+            .Replace("{\\an8}", string.Empty)
+            .Replace("{\\an9}", string.Empty)
+            .Replace("{an1\\", "{")
+            .Replace("{an2\\", "{")
+            .Replace("{an3\\", "{")
+            .Replace("{an4\\", "{")
+            .Replace("{an5\\", "{")
+            .Replace("{an6\\", "{")
+            .Replace("{an7\\", "{")
+            .Replace("{an8\\", "{")
+            .Replace("{an9\\", "{")
+            .Replace("\\an1\\", "\\\\")
+            .Replace("\\an2\\", "\\\\")
+            .Replace("\\an3\\", "\\\\")
+            .Replace("\\an4\\", "\\\\")
+            .Replace("\\an5\\", "\\\\")
+            .Replace("\\an6\\", "\\\\")
+            .Replace("\\an7\\", "\\\\")
+            .Replace("\\an8\\", "\\\\")
+            .Replace("\\an9\\", "\\\\")
+            .Replace("\\an1}", "}")
+            .Replace("\\an2}", "}")
+            .Replace("\\an3}", "}")
+            .Replace("\\an4}", "}")
+            .Replace("\\an5}", "}")
+            .Replace("\\an6}", "}")
+            .Replace("\\an7}", "}")
+            .Replace("\\an8}", "}")
+            .Replace("\\an9}", "}")
+            .Replace("{\\a1}", string.Empty)
+            .Replace("{\\a2}", string.Empty)
+            .Replace("{\\a3}", string.Empty)
+            .Replace("{\\a4}", string.Empty)
+            .Replace("{\\a5}", string.Empty)
+            .Replace("{\\a6}", string.Empty)
+            .Replace("{\\a7}", string.Empty)
+            .Replace("{\\a8}", string.Empty)
+            .Replace("{\\a9}", string.Empty);
+    }
+
+    [Benchmark]
+    public string RemoveAlignment_Before_PosOnly() => RemoveAlignmentBefore(AssaPosLine);
+
+    [Benchmark]
+    public string RemoveAlignment_After_PosOnly() => HtmlUtil.RemoveAssAlignmentTags(AssaPosLine);
+
+    [Benchmark]
+    public string RemoveAlignment_Before_Aligned() => RemoveAlignmentBefore(AssaAlignmentLine);
+
+    [Benchmark]
+    public string RemoveAlignment_After_Aligned() => HtmlUtil.RemoveAssAlignmentTags(AssaAlignmentLine);
+
+    // ---------------------------------------------------------- Utilities.IsNumber
+
+    private static readonly Regex RegexIsNumber = new Regex("^\\d+$", RegexOptions.Compiled);
+    private static readonly Regex RegexIsEpisodeNumber = new Regex("^\\d+x\\d+$", RegexOptions.Compiled);
+
+    private static bool IsNumberBefore(string s)
+    {
+        s = s.Trim('$', '\u00A3', '\u00A5', '%', '*');
+        return RegexIsNumber.IsMatch(s) || RegexIsEpisodeNumber.IsMatch(s);
+    }
+
+    [Benchmark]
+    public bool IsNumber_Before_TextLine() => IsNumberBefore(TextLine);
+
+    [Benchmark]
+    public bool IsNumber_After_TextLine() => Utilities.IsNumber(TextLine);
+
+    [Benchmark]
+    public bool IsNumber_Before_Number() => IsNumberBefore("1234");
+
+    [Benchmark]
+    public bool IsNumber_After_Number() => Utilities.IsNumber("1234");
+
+    // ---------------------------------------------------------- Json.ReadTag
+
+    private static int IndexOfAnyBefore(string s, string[] words, StringComparison comparisonType)
+    {
+        for (var i = 0; i < words.Length; i++)
+        {
+            var idx = s.IndexOf(words[i], comparisonType);
+            if (idx >= 0)
+            {
+                return idx;
+            }
+        }
+
+        return -1;
+    }
+
+    // Not a const: the real caller takes the tag as a parameter, and a const here would let
+    // the compiler fold the two quoted needles into literals - erasing what is being measured.
+    private static readonly string TagName = "tStartMs";
+
+    [Benchmark]
+    public int JsonTagLookup_Before()
+    {
+        var tag = TagName;
+        return IndexOfAnyBefore(JsonBlob, new[] { "\"" + tag + "\"", "'" + tag + "'" }, StringComparison.Ordinal);
+    }
+
+    // Same code as the private helper the format now uses - both halves measure only the tag
+    // lookup, which is the part that changed.
+    private static int IndexOfQuotedTag(string s, string tag)
+    {
+        var index = IndexOfQuoted(s, tag, '"');
+        return index >= 0 ? index : IndexOfQuoted(s, tag, '\'');
+    }
+
+    private static int IndexOfQuoted(string s, string tag, char quote)
+    {
+        var from = 0;
+        while (from < s.Length)
+        {
+            var index = s.IndexOf(tag, from, StringComparison.Ordinal);
+            if (index < 0 || index + tag.Length >= s.Length)
+            {
+                return -1;
+            }
+
+            if (index > 0 && s[index - 1] == quote && s[index + tag.Length] == quote)
+            {
+                return index - 1;
+            }
+
+            from = index + 1;
+        }
+
+        return -1;
+    }
+
+    [Benchmark]
+    public int JsonTagLookup_After() => IndexOfQuotedTag(JsonBlob, TagName);
+}

--- a/tests/libse/Common/StringHelperFastPathTest.cs
+++ b/tests/libse/Common/StringHelperFastPathTest.cs
@@ -1,0 +1,280 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+
+namespace Tests.Common;
+
+/// <summary>
+/// Each fast path added here replaced code that produced the same answer the slow way. The tests
+/// below keep a copy of that slow way as the reference and fuzz the two against each other, so a
+/// guard that is too eager (or an equivalence that only holds for the examples someone thought
+/// of) fails here rather than in a subtitle.
+/// </summary>
+public class StringHelperFastPathTest
+{
+    private static readonly char[] Alphabet =
+        " \t\r\n0123456789.:,-></abcXYZ\u00A0\u2028\u3000\u266A\u266B\u2014?!*$\u00A3'\"{}\\an1x".ToCharArray();
+
+    private static IEnumerable<string> Fuzz(int count, int maxLength = 24, int seed = 20260813)
+    {
+        var random = new Random(seed);
+        var buffer = new char[maxLength];
+        for (var n = 0; n < count; n++)
+        {
+            var length = random.Next(0, maxLength + 1);
+            for (var i = 0; i < length; i++)
+            {
+                buffer[i] = Alphabet[random.Next(Alphabet.Length)];
+            }
+
+            yield return new string(buffer, 0, length);
+        }
+    }
+
+    // ---------------------------------------------------------------- IsOnlyChars(OrWhiteSpace)
+
+    private static readonly char[] TimeCodeChars = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.', ':', ',' };
+    private static readonly char[] MusicChars = { '\u266A', '\u266B' };
+    private static readonly char[] InterjectionChars = { '.', '?', '!', '-', '\u2014' };
+
+    private static readonly CharLookup TimeCodeLookup = CharLookup.Create(TimeCodeChars);
+    private static readonly CharLookup MusicLookup = CharLookup.Create(MusicChars);
+    private static readonly CharLookup InterjectionLookup = CharLookup.Create(InterjectionChars);
+
+    [Fact]
+    public void IsOnlyCharsOrWhiteSpaceMatchesRemoveCharThenIsNullOrWhiteSpace()
+    {
+        var sets = new[]
+        {
+            (TimeCodeChars, TimeCodeLookup),
+            (MusicChars, MusicLookup),
+            (InterjectionChars, InterjectionLookup),
+        };
+
+        foreach (var input in Fuzz(20000))
+        {
+            foreach (var (chars, lookup) in sets)
+            {
+                var expected = string.IsNullOrWhiteSpace(input.RemoveChar(chars));
+                Assert.Equal(expected, input.IsOnlyCharsOrWhiteSpace(lookup));
+            }
+        }
+    }
+
+    [Fact]
+    public void IsOnlyCharsMatchesRemoveCharThenIsNullOrEmpty()
+    {
+        var lookup = CharLookup.Create(StringExtensions.UnicodeControlChars);
+        foreach (var input in Fuzz(20000))
+        {
+            var expected = string.IsNullOrEmpty(input.RemoveChar(StringExtensions.UnicodeControlChars));
+            Assert.Equal(expected, input.IsOnlyChars(lookup));
+        }
+    }
+
+    [Fact]
+    public void IsOnlyCharsOrWhiteSpaceAcceptsWhiteSpaceBeyondTheAsciiOnes()
+    {
+        // string.IsNullOrWhiteSpace uses char.IsWhiteSpace, which is far more than ' ' and '\t'.
+        Assert.True("12\u00A0:\u3000\u200034".IsOnlyCharsOrWhiteSpace(TimeCodeLookup));
+        Assert.False("12a34".IsOnlyCharsOrWhiteSpace(TimeCodeLookup));
+    }
+
+    [Fact]
+    public void IsOnlyCharsOrWhiteSpaceTreatsEmptyAsOnlyThose()
+    {
+        Assert.True(string.Empty.IsOnlyCharsOrWhiteSpace(TimeCodeLookup));
+        Assert.True("   ".IsOnlyCharsOrWhiteSpace(TimeCodeLookup));
+        Assert.True(string.Empty.IsOnlyChars(TimeCodeLookup));
+    }
+
+    // ---------------------------------------------------------------- Utilities.IsNumber
+
+    private static readonly Regex ReferenceIsNumber = new Regex("^\\d+$", RegexOptions.Compiled);
+    private static readonly Regex ReferenceIsEpisodeNumber = new Regex("^\\d+x\\d+$", RegexOptions.Compiled);
+
+    private static bool ReferenceIsNumberOrEpisode(string s)
+    {
+        s = s.Trim('$', '\u00A3', '\u00A5', '%', '*');
+        return ReferenceIsNumber.IsMatch(s) || ReferenceIsEpisodeNumber.IsMatch(s);
+    }
+
+    [Fact]
+    public void IsNumberMatchesTheRegexesItReplaced()
+    {
+        foreach (var input in Fuzz(40000))
+        {
+            Assert.Equal(ReferenceIsNumberOrEpisode(input), Utilities.IsNumber(input));
+        }
+    }
+
+    [Fact]
+    public void IsNumberKeepsTheRegexQuirks()
+    {
+        // \d is \p{Nd}, so Arabic-Indic digits count just as they did through the regex.
+        Assert.Equal(ReferenceIsNumberOrEpisode("\u0661\u0662"), Utilities.IsNumber("\u0661\u0662"));
+        Assert.True(Utilities.IsNumber("\u0661\u0662"));
+
+        // .NET's $ also matches right before a single trailing line feed - but not two.
+        Assert.True(Utilities.IsNumber("42\n"));
+        Assert.False(Utilities.IsNumber("42\n\n"));
+        Assert.False(Utilities.IsNumber("42\r\n"));
+
+        Assert.True(Utilities.IsNumber("$42*"));
+        Assert.True(Utilities.IsNumber("1x02"));
+        Assert.False(Utilities.IsNumber("1x"));
+        Assert.False(Utilities.IsNumber("x02"));
+        Assert.False(Utilities.IsNumber("1x2x3"));
+        Assert.False(Utilities.IsNumber(string.Empty));
+        Assert.False(Utilities.IsNumber("42 "));
+    }
+
+    // ---------------------------------------------------------------- HtmlUtil.RemoveColorTags
+
+    private static readonly Regex ColorAttributeRegex =
+        new Regex("[ ]*(COLOR|color|Color)=[\"']*[#\\dA-Za-z]*[\"']*[ ]*", RegexOptions.Compiled);
+
+    private static string ReferenceRemoveColorTags(string input)
+    {
+        var r = ColorAttributeRegex;
+        var s = input;
+        var match = r.Match(s);
+        while (match.Success)
+        {
+            s = s.Remove(match.Index, match.Value.Length).Insert(match.Index, " ");
+            if (match.Index > 4)
+            {
+                if (string.Compare(s, match.Index - 5, "<font >", 0, 7, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    s = s.Remove(match.Index - 5, 7);
+                    var endIndex = s.IndexOf("</font>", match.Index - 5, StringComparison.OrdinalIgnoreCase);
+                    if (endIndex >= 0)
+                    {
+                        s = s.Remove(endIndex, 7);
+                    }
+                    else
+                    {
+                        endIndex = s.IndexOf("< /font>", match.Index - 5, StringComparison.OrdinalIgnoreCase);
+                        if (endIndex >= 0)
+                        {
+                            s = s.Remove(endIndex, 7);
+                        }
+                        else
+                        {
+                            endIndex = s.IndexOf("</ font>", match.Index - 5, StringComparison.OrdinalIgnoreCase);
+                            if (endIndex >= 0)
+                            {
+                                s = s.Remove(endIndex, 7);
+                            }
+                        }
+                    }
+                }
+                else if (s.Length > match.Index + 1 && s[match.Index + 1] == '>')
+                {
+                    s = s.Remove(match.Index, 1);
+                }
+            }
+
+            match = r.Match(s);
+        }
+
+        return s.Trim();
+    }
+
+    [Fact]
+    public void RemoveColorTagsMatchesTheUnguardedLoop()
+    {
+        var cases = new List<string>
+        {
+            "<font color=\"#ff0000\">Hello there.</font>",
+            "<font COLOR='red'>Hello there.</font>",
+            "<font Color=red>Hello</font> and <font color=blue>there</font>",
+            "Hello there.",
+            " color=red without any tag ",
+            "<i>Hello</i>",
+            string.Empty,
+            "   ",
+        };
+        cases.AddRange(Fuzz(5000, 32, seed: 7));
+
+        foreach (var input in cases)
+        {
+            Assert.Equal(ReferenceRemoveColorTags(input), HtmlUtil.RemoveColorTags(input));
+        }
+    }
+
+    // ------------------------------------------------------- HtmlUtil.RemoveAssAlignmentTags
+
+    private static string ReferenceRemoveAssAlignmentTags(string s)
+    {
+        var text = s;
+        for (var digit = '1'; digit <= '9'; digit++)
+        {
+            text = text.Replace("{\\an" + digit + "}", string.Empty);
+        }
+
+        for (var digit = '1'; digit <= '9'; digit++)
+        {
+            text = text.Replace("{an" + digit + "\\", "{");
+        }
+
+        for (var digit = '1'; digit <= '9'; digit++)
+        {
+            text = text.Replace("\\an" + digit + "\\", "\\");
+        }
+
+        for (var digit = '1'; digit <= '9'; digit++)
+        {
+            text = text.Replace("\\an" + digit + "}", "}");
+        }
+
+        for (var digit = '1'; digit <= '9'; digit++)
+        {
+            text = text.Replace("{\\a" + digit + "}", string.Empty);
+        }
+
+        return text;
+    }
+
+    [Fact]
+    public void RemoveAssAlignmentTagsMatchesTheUnguardedReplaceChain()
+    {
+        var cases = new List<string>
+        {
+            "{\\an8}Hello there.",
+            "{\\a5}Hello there.",
+            "{an3\\pos(320,240)}Hello there.",
+            "{\\pos(320,240)\\an1\\fad(200,200)}Hello",
+            "{\\fad(200,200)\\an7}Hello",
+            "{\\pos(320,240)}Hello there.",   // backslash, but no alignment tag
+            "Hello there.",                    // no backslash at all
+            "{\\an0}Hello",                    // 0 is not an alignment
+            "\\a4}",
+            "{\\a9}",
+            string.Empty,
+        };
+        cases.AddRange(Fuzz(20000, 20, seed: 11));
+
+        foreach (var input in cases)
+        {
+            Assert.Equal(ReferenceRemoveAssAlignmentTags(input), HtmlUtil.RemoveAssAlignmentTags(input));
+        }
+    }
+
+    // ---------------------------------------------------------------- Json.ReadTag
+
+    [Fact]
+    public void JsonReadTagFindsQuotedTagsAndIgnoresBareOnes()
+    {
+        Assert.Equal("12340", Json.ReadTag("{\"tStartMs\":12340,\"x\":1}", "tStartMs"));
+        Assert.Equal("12340", Json.ReadTag("{'tStartMs':12340,'x':1}", "tStartMs"));
+        Assert.Null(Json.ReadTag("{\"other\":1}", "tStartMs"));
+
+        // A bare, unquoted occurrence must not be taken for the tag.
+        Assert.Equal("7", Json.ReadTag("{\"note\":\"see tStartMs below\",\"tStartMs\":7}", "tStartMs"));
+
+        // Double quotes win over single quotes, whichever comes first in the text.
+        Assert.Equal("2", Json.ReadTag("{'dur':1,\"dur\":2}", "dur"));
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #13561. Five helpers did work unconditionally that they only need in the uncommon case. Each change keeps the same answer and adds a way to not start.

- **"Is there anything but these characters here?"** — eight checks answered this by building the stripped string with `RemoveChar` and handing it to `string.IsNullOrWhiteSpace`: an allocation per call for an answer that never needed the string. New `CharLookup` prepares the character set once per call site, and `IsOnlyChars` / `IsOnlyCharsOrWhiteSpace` answer directly through `IndexOfAnyExcept`. netstandard2.1 has no `SearchValues`, so it gets a scalar ASCII table instead — the allocation goes away on both targets.
- **`HtmlUtil.RemoveColorTags`** restarted its regex from index 0 after every hit and rebuilt the whole string twice per hit, and nothing stopped a line that cannot match from entering that loop.
- **`HtmlUtil.RemoveAssAlignmentTags`** ran 45 chained `string.Replace` scans for any text containing a backslash — that is, for every real ASSA line. All 45 patterns are an `a` directly after `\` or `{`, followed by 1-9 or by `n` and 1-9, so one scan separates the lines that carry an alignment tag from the far more common ones carrying only `\pos`, `\fad`, `\c`.
- **`Json`** built two quoted needles and a `string[]` on every tag read, and a JSON subtitle is read tag by tag, line by line.
- **`Utilities.IsNumber`** trimmed five currency characters into a fresh string and then entered the regex engine twice.

## Benchmarks

BenchmarkDotNet default job, .NET 10, Apple M4, error bars ±0.1-1.7%. `tests/benchmarks/StringHelperFastPathBenchmarks.cs` keeps a copy of each replaced shape, so both halves run in one process against one build.

| Helper | Case | Before | After | |
|---|---|---:|---:|---|
| "only a time code?" | subtitle line | 38.22 ns / 136 B | **0.66 ns / 0 B** | 58x |
| "only a time code?" | time-code line | 436.72 ns / 32 B | **0.57 ns / 0 B** | 770x |
| `RemoveColorTags` | untagged line | 150.04 ns | **4.76 ns** | 31.5x |
| `RemoveColorTags` | `<font color=...>` | 178.31 ns | 176.65 ns | unchanged |
| `RemoveAssAlignmentTags` | `{\pos\fad}` line | 287.59 ns | **22.81 ns** | 12.6x |
| `RemoveAssAlignmentTags` | `{\an8}` line | 248.39 ns | 251.54 ns | +1.3% |
| `Utilities.IsNumber` | subtitle line | 22.66 ns / 40 B | **4.19 ns / 0 B** | 5.4x |
| `Utilities.IsNumber` | `"1234"` | 17.08 ns / 40 B | **4.84 ns / 0 B** | 3.5x |
| Json tag lookup | one tag | 9.38 ns / 96 B | **3.18 ns / 0 B** | 2.9x |

The two rows that do not improve are the point: when the guard does not fire, the work is the same as before, plus one scan. That is the +1.3% on `{\an8}`.

## Correctness

`tests/libse/Common/StringHelperFastPathTest.cs` keeps a copy of each replaced shape as the reference and fuzzes the two against each other over an alphabet built to hit every guard — including exotic whitespace (NBSP, U+2028, ideographic space), music symbols, em dash and backslash-brace noise. A guard that is too eager fails there rather than in a subtitle.

`IsNumber` had two regex quirks worth keeping, both covered by tests: `\d` is `\p{Nd}` (so Arabic-Indic digits still count), and .NET's `$` also matches immediately before a single trailing line feed.

- All 1091 `LibSETests` pass
- `dotnet build src/libse/LibSE.csproj` clean for netstandard2.1 and net10.0, no new warnings

## Not in this PR

Two more candidates measured during the same pass and deliberately left out:

- `HtmlUtil.EncodeNamed` — a `ContainsAny` fast path looked like a 25x win until I noticed the switch has 85 cases including accented letters, so it only pays off on plain-ASCII text. Needs a different approach.
- `SubtitleFormat.IsMine` parses the whole file into a throwaway `Subtitle`, and the caller then parses the same lines again — an exact 2x on time and allocation for the winning format (521 -> 282 us, 408 -> 204 KB on a 500-line SRT). Contained fix, but it touches the format API and deserves its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
