### PR TITLE
Waveform: track the pointer through mid-drag scrolls + skip the per-move geometry rebuild (#13600)

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -344,6 +344,21 @@ public class AudioVisualizer : Control
     private SubtitleLineViewModel? _activeParagraphPrevious;
     private SubtitleLineViewModel? _activeParagraphNext;
     private Point _startPointerPosition;
+
+    // Absolute waveform time under the pointer when the drag started. Drag deltas are computed
+    // as (time under pointer now) - (this anchor), NOT as a pixel delta: when the view scrolls
+    // mid-drag (the position timer jumps the view a screen forward while the video plays, or the
+    // user wheel-scrolls without releasing), a pixel delta would freeze the dragged edge in time
+    // while it visually teleports away from the pointer, killing the SE4 workflow of extending a
+    // cue continuously through auto-scrolls (#13600). With an absolute anchor the scroll itself
+    // moves the dragged time along with the view, so the edge keeps tracking the pointer.
+    private double _startPointerSeconds;
+
+    // Last pointer X processed by an active drag; NaN forces the first move after a press
+    // through. Gaming mice report at up to 1000 Hz while the position only changes at device
+    // pixel granularity, so without this the whole drag pipeline (hit tests, snapping, time
+    // writes, invalidation) re-ran on floods of same-X moves (SE4 had the same guard).
+    private double _lastDragPointerX = double.NaN;
     private double _originalStartSeconds;
     private double _originalEndSeconds;
     private double _originalDurationSeconds;
@@ -967,6 +982,8 @@ public class AudioVisualizer : Control
         e.Handled = true;
         var point = e.GetPosition(this);
         _startPointerPosition = point;
+        _startPointerSeconds = RelativeXPositionToSeconds(point.X);
+        _lastDragPointerX = double.NaN;
 
         // No waveform yet and auto-generate is off: a click generates it on demand.
         if (WavePeaks == null && ShowClickToGenerateHint &&
@@ -1154,9 +1171,18 @@ public class AudioVisualizer : Control
         }
 
         var point = e.GetPosition(this);
-        var properties = e.GetCurrentPoint(this).Properties;
+
+        // Every drag mode below is X-driven, so a move that only changed Y (or a same-position
+        // report from a high-rate mouse) has nothing to do. See _lastDragPointerX.
+        if (_interactionMode != InteractionMode.None && point.X.Equals(_lastDragPointerX))
+        {
+            return;
+        }
+
+        _lastDragPointerX = point.X;
+
         var newP = NewSelectionParagraph;
-        if (_interactionMode == InteractionMode.New && newP != null && properties.IsLeftButtonPressed)
+        if (_interactionMode == InteractionMode.New && newP != null && e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
         {
             var seconds = RelativeXPositionToSeconds(point.X);
 
@@ -1216,7 +1242,13 @@ public class AudioVisualizer : Control
         }
 
         var deltaX = point.X - _startPointerPosition.X;
-        var deltaSeconds = RelativeXPositionToSeconds(deltaX);
+
+        // Absolute-time drag delta (SE4 parity, #13600): measured between the time now under the
+        // pointer and the time that was under it at press. With a static view this equals the
+        // pixel delta times seconds-per-pixel; when the view scrolls mid-drag it additionally
+        // carries the scroll, so the dragged edge keeps following the pointer (see
+        // _startPointerSeconds). deltaX stays pixel-based for the Or-mode direction slop below.
+        var dragDeltaSeconds = RelativeXPositionToSeconds(point.X) - _startPointerSeconds;
 
         if (_interactionMode == InteractionMode.ResizingLeftOr && _activeParagraphPrevious != null)
         {
@@ -1234,6 +1266,10 @@ public class AudioVisualizer : Control
                 _activeParagraph = _activeParagraphPrevious;
                 _originalStartSeconds = _activeParagraph.StartTime.TotalSeconds;
                 _originalEndSeconds = _activeParagraph.EndTime.TotalSeconds;
+                // The originals were just re-captured from the other paragraph, so the drag
+                // anchor must restart from the current pointer position too.
+                _startPointerSeconds = RelativeXPositionToSeconds(point.X);
+                dragDeltaSeconds = 0;
                 _interactionMode = InteractionMode.ResizingRight;
             }
         }
@@ -1253,6 +1289,9 @@ public class AudioVisualizer : Control
                 _activeParagraph = _activeParagraphNext;
                 _originalStartSeconds = _activeParagraph.StartTime.TotalSeconds;
                 _originalEndSeconds = _activeParagraph.EndTime.TotalSeconds;
+                // See the ResizingLeftOr branch above.
+                _startPointerSeconds = RelativeXPositionToSeconds(point.X);
+                dragDeltaSeconds = 0;
                 _interactionMode = InteractionMode.ResizingLeft;
             }
         }
@@ -1272,15 +1311,30 @@ public class AudioVisualizer : Control
 
         if (NewSelectionParagraph == _activeParagraph)
         {
-            previous = _displayableParagraphs.LastOrDefault(p => p.StartTime < _activeParagraph.StartTime);
-            next = _displayableParagraphs.FirstOrDefault(p => p.StartTime > _activeParagraph.EndTime);
+            // _displayableParagraphs is sorted by start time; walk it once instead of two LINQ
+            // scans with lambda allocations - this runs on every pointer move of the drag.
+            previous = null;
+            next = null;
+            for (var i = 0; i < _displayableParagraphs.Count; i++)
+            {
+                var p = _displayableParagraphs[i];
+                if (p.StartTime < _activeParagraph.StartTime)
+                {
+                    previous = p;
+                }
+                else if (p.StartTime > _activeParagraph.EndTime)
+                {
+                    next = p;
+                    break;
+                }
+            }
         }
 
         switch (_interactionMode)
         {
             case InteractionMode.Moving:
-                newStart = _originalStartSeconds + deltaSeconds - StartPositionSeconds;
-                newEnd = _originalEndSeconds + deltaSeconds - StartPositionSeconds;
+                newStart = _originalStartSeconds + dragDeltaSeconds;
+                newEnd = _originalEndSeconds + dragDeltaSeconds;
 
                 // Check if the paragraph already overlaps with neighbors
                 bool alreadyOverlapping = false;
@@ -1344,7 +1398,7 @@ public class AudioVisualizer : Control
                 // grabbed line so relative spacing is preserved, and the delta is clamped so
                 // the earliest selected line never moves before zero. Overlap with unselected
                 // neighbours is allowed - the user is repositioning the block as a whole.
-                var shift = SnapToFrame(_originalStartSeconds + deltaSeconds - StartPositionSeconds) - _originalStartSeconds;
+                var shift = SnapToFrame(_originalStartSeconds + dragDeltaSeconds) - _originalStartSeconds;
 
                 var minOriginalStart = double.MaxValue;
                 foreach (var item in _selectionMoveSnapshot)
@@ -1370,8 +1424,8 @@ public class AudioVisualizer : Control
                 break;
             }
             case InteractionMode.ResizeLeftAnd:
-                newStart = _originalStartSeconds + deltaSeconds - StartPositionSeconds;
-                var newPrevEnd = _originalPreviousEndSeconds + deltaSeconds - StartPositionSeconds;
+                newStart = _originalStartSeconds + dragDeltaSeconds;
+                var newPrevEnd = _originalPreviousEndSeconds + dragDeltaSeconds;
                 var snappedLeft = SnapToFrame(newStart);
                 newPrevEnd += snappedLeft - newStart;
                 newStart = snappedLeft;
@@ -1383,8 +1437,8 @@ public class AudioVisualizer : Control
 
                 break;
             case InteractionMode.ResizeRightAnd:
-                newEnd = _originalEndSeconds + deltaSeconds - StartPositionSeconds;
-                var newNextStart = _originalNextStartSeconds + deltaSeconds - StartPositionSeconds;
+                newEnd = _originalEndSeconds + dragDeltaSeconds;
+                var newNextStart = _originalNextStartSeconds + dragDeltaSeconds;
                 var snappedRight = SnapToFrame(newEnd);
                 newNextStart += snappedRight - newEnd;
                 newEnd = snappedRight;
@@ -1396,7 +1450,7 @@ public class AudioVisualizer : Control
 
                 break;
             case InteractionMode.ResizingLeft:
-                newStart = _originalStartSeconds + deltaSeconds - StartPositionSeconds;
+                newStart = _originalStartSeconds + dragDeltaSeconds;
 
                 if (newStart < 0)
                 {
@@ -1437,7 +1491,7 @@ public class AudioVisualizer : Control
 
                 break;
             case InteractionMode.ResizingRight:
-                newEnd = _originalEndSeconds + deltaSeconds - StartPositionSeconds;
+                newEnd = _originalEndSeconds + dragDeltaSeconds;
 
                 var snappedToShotRight = false;
                 if (SnapToShotChanges && !_isShiftDown)
@@ -2370,7 +2424,89 @@ public class AudioVisualizer : Control
                 context.DrawGeometry(null, draw.Pen, draw.Geometry);
             }
         }
+
+        if (WaveformDrawStyle == WaveformDrawStyle.Classic)
+        {
+            DrawClassicSelectionOverlay(context, ref renderCtx, offsetPixels);
+        }
     }
+
+    /// <summary>
+    /// Classic style's selected-line coloring: re-stroke the cached waveform geometry with the
+    /// selected pen, clipped to each selected line's visible region. The cached geometry itself
+    /// is selection-independent (see BuildWaveformCacheKey), so this is what keeps a drag of a
+    /// selected line from rebuilding the per-pixel waveform on every pointer move (#13600).
+    /// </summary>
+    private void DrawClassicSelectionOverlay(DrawingContext context, ref RenderContext renderCtx, double offsetPixels)
+    {
+        var selection = AllSelectedParagraphs;
+        if (selection.Count == 0 || _waveformCacheDraws.Count == 0)
+        {
+            return;
+        }
+
+        // Collect the visible selected regions and merge overlaps first: the selected pen is
+        // semi-transparent, so re-stroking an overlap twice would render it more opaque than
+        // the old per-column build (which assigned each column exactly once) ever did.
+        var intervals = _selectionOverlayIntervals;
+        intervals.Clear();
+        var startPositionSeconds = renderCtx.StartPositionSeconds;
+        var width = renderCtx.Width;
+        for (var i = 0; i < selection.Count; i++)
+        {
+            var p = selection[i];
+            double left = SecondsToXPositionOptimized(p.StartTime.TotalSeconds - startPositionSeconds, renderCtx.SampleRate, renderCtx.ZoomFactor);
+            double right = SecondsToXPositionOptimized(p.EndTime.TotalSeconds - startPositionSeconds, renderCtx.SampleRate, renderCtx.ZoomFactor);
+            if (right <= 0 || left >= width || right <= left)
+            {
+                continue;
+            }
+
+            intervals.Add((Math.Max(0, left), Math.Min(width, right)));
+        }
+
+        if (intervals.Count == 0)
+        {
+            return;
+        }
+
+        if (intervals.Count > 1)
+        {
+            intervals.Sort(static (a, b) => a.Left.CompareTo(b.Left));
+        }
+
+        var mergedLeft = intervals[0].Left;
+        var mergedRight = intervals[0].Right;
+        for (var i = 1; i <= intervals.Count; i++)
+        {
+            if (i < intervals.Count && intervals[i].Left <= mergedRight)
+            {
+                mergedRight = Math.Max(mergedRight, intervals[i].Right);
+                continue;
+            }
+
+            // The clip is in live view coordinates and is pushed before the translation, so it
+            // stays put while the translated (anchor-space) geometry scrolls under it.
+            var clipRect = new Rect(mergedLeft, 0, mergedRight - mergedLeft, renderCtx.Height);
+            using (context.PushClip(clipRect))
+            using (context.PushTransform(Matrix.CreateTranslation(-offsetPixels, 0)))
+            {
+                for (var j = 0; j < _waveformCacheDraws.Count; j++)
+                {
+                    context.DrawGeometry(null, _paintPenSelected, _waveformCacheDraws[j].Geometry);
+                }
+            }
+
+            if (i < intervals.Count)
+            {
+                mergedLeft = intervals[i].Left;
+                mergedRight = intervals[i].Right;
+            }
+        }
+    }
+
+    // Pooled buffer for DrawClassicSelectionOverlay's visible selected regions.
+    private readonly List<(double Left, double Right)> _selectionOverlayIntervals = new(16);
 
     private Pen GetCachedFancyWaveformPen(int colorKey, Color color)
     {
@@ -2605,7 +2741,6 @@ public class AudioVisualizer : Control
 
     private void BuildWaveFormClassic(double waveformHeight, double startPositionSeconds, double width, ref RenderContext renderCtx)
     {
-        var isSelectedHelper = _isSelectedHelper;
         var halfWaveformHeight = waveformHeight / 2;
         var div = renderCtx.SampleRate * renderCtx.ZoomFactor;
 
@@ -2628,12 +2763,12 @@ public class AudioVisualizer : Control
         var samplesPerPixel = renderCtx.SampleRate / div;
         var yScaleHalf = verticalZoomFactor / highestPeak * halfWaveformHeight;
 
-        isSelectedHelper.Reset(AllSelectedParagraphs, renderCtx.SampleRate, (int)startSample, (int)(startSample + width * samplesPerPixel));
-
-        var unselectedLines = _classicUnselectedLines;
-        var selectedLines = _classicSelectedLines;
-        unselectedLines.Clear();
-        selectedLines.Clear();
+        // All columns go into ONE geometry, deliberately ignoring the selection: the selected
+        // color is applied at draw time by re-stroking this geometry clipped to the selected
+        // regions (DrawClassicSelectionOverlay). That keeps the cached build independent of the
+        // selection, so dragging a selected line's times never re-runs this loop (#13600).
+        var lines = _classicLines;
+        lines.Clear();
 
         for (var x = 0; x < width; x++)
         {
@@ -2668,24 +2803,14 @@ public class AudioVisualizer : Control
                 yMin = yMax + 1;
             }
 
-            var line = new FancyLine(x, yMax, yMin);
-            if (isSelectedHelper.IsSelected(pos0))
-            {
-                selectedLines.Add(line);
-            }
-            else
-            {
-                unselectedLines.Add(line);
-            }
+            lines.Add(new FancyLine(x, yMax, yMin));
         }
 
-        AddLineBatchToCache(_paintWaveform, unselectedLines);
-        AddLineBatchToCache(_paintPenSelected, selectedLines);
+        AddLineBatchToCache(_paintWaveform, lines);
     }
 
-    // Pooled buffers for the classic waveform's two pens.
-    private readonly List<FancyLine> _classicUnselectedLines = new(2048);
-    private readonly List<FancyLine> _classicSelectedLines = new(2048);
+    // Pooled column buffer for the classic waveform.
+    private readonly List<FancyLine> _classicLines = new(2048);
 
     // Cached waveform draw ops. Building the waveform is a per-pixel CPU loop that allocates
     // geometry every render; doing it on every cursor tick (CurrentVideoPositionSeconds has
@@ -2765,13 +2890,24 @@ public class AudioVisualizer : Control
 
     private WaveformCacheKey BuildWaveformCacheKey(double waveformHeight, double anchorPixel, ref RenderContext renderCtx)
     {
+        // Classic style paints the selection as a clipped overlay at draw time (see
+        // DrawClassicSelectionOverlay), so its cached geometry does not depend on the selection
+        // at all - keeping the selection times out of the key is what lets a waveform drag of a
+        // selected line replay the cache instead of re-running the per-pixel build on every
+        // pointer move (#13600). The fancy style bakes selection into per-column colors, so it
+        // still keys (and rebuilds) on the selection.
         long selectionHash = 17;
-        var selection = AllSelectedParagraphs;
-        for (var i = 0; i < selection.Count; i++)
+        var selectionCount = 0;
+        if (WaveformDrawStyle != WaveformDrawStyle.Classic)
         {
-            var p = selection[i];
-            selectionHash = selectionHash * 31 + p.StartTime.Ticks;
-            selectionHash = selectionHash * 31 + p.EndTime.Ticks;
+            var selection = AllSelectedParagraphs;
+            selectionCount = selection.Count;
+            for (var i = 0; i < selection.Count; i++)
+            {
+                var p = selection[i];
+                selectionHash = selectionHash * 31 + p.StartTime.Ticks;
+                selectionHash = selectionHash * 31 + p.EndTime.Ticks;
+            }
         }
 
         return new WaveformCacheKey(
@@ -2788,7 +2924,7 @@ public class AudioVisualizer : Control
             ToKeyColor(WaveformColor),
             ToKeyColor(WaveformSelectedColor),
             ToKeyColor(WaveformFancyHighColor),
-            selection.Count,
+            selectionCount,
             selectionHash);
     }
 
@@ -3118,19 +3254,6 @@ public class AudioVisualizer : Control
 
         var currentPositionPos = SecondsToXPositionOptimized(renderCtx.CurrentVideoPositionSeconds - renderCtx.StartPositionSeconds, renderCtx.SampleRate, renderCtx.ZoomFactor);
 
-        var startPositionMilliseconds = renderCtx.StartPositionSeconds * 1000.0;
-        var endPositionMilliseconds = RelativeXPositionToSecondsOptimized(renderCtx.Width, renderCtx.SampleRate, renderCtx.StartPositionSeconds, renderCtx.ZoomFactor) * 1000.0;
-        _paragraphStartPositions.Clear();
-        _paragraphEndPositions.Clear();
-        foreach (var p in _displayableParagraphs)
-        {
-            if (p.EndTime.TotalMilliseconds >= startPositionMilliseconds && p.StartTime.TotalMilliseconds <= endPositionMilliseconds)
-            {
-                _paragraphStartPositions.Add(SecondsToXPositionOptimized(p.StartTime.TotalSeconds - renderCtx.StartPositionSeconds, renderCtx.SampleRate, renderCtx.ZoomFactor));
-                _paragraphEndPositions.Add(SecondsToXPositionOptimized(p.EndTime.TotalSeconds - renderCtx.StartPositionSeconds, renderCtx.SampleRate, renderCtx.ZoomFactor));
-            }
-        }
-
         // The list is sorted, so binary search the first shot change at/after the visible window
         // instead of walking all shot changes before it, and stop once past the right edge.
         var low = 0;
@@ -3145,6 +3268,27 @@ public class AudioVisualizer : Control
             else
             {
                 high = mid;
+            }
+        }
+
+        // Nothing visible? Then don't pay for the paragraph edge sets below - this runs on
+        // every ~60 fps render whenever the video has shot changes at all.
+        if (low >= _shotChanges.Count ||
+            SecondsToXPositionOptimized(_shotChanges[low] - renderCtx.StartPositionSeconds, renderCtx.SampleRate, renderCtx.ZoomFactor) >= renderCtx.Width)
+        {
+            return;
+        }
+
+        var startPositionMilliseconds = renderCtx.StartPositionSeconds * 1000.0;
+        var endPositionMilliseconds = RelativeXPositionToSecondsOptimized(renderCtx.Width, renderCtx.SampleRate, renderCtx.StartPositionSeconds, renderCtx.ZoomFactor) * 1000.0;
+        _paragraphStartPositions.Clear();
+        _paragraphEndPositions.Clear();
+        foreach (var p in _displayableParagraphs)
+        {
+            if (p.EndTime.TotalMilliseconds >= startPositionMilliseconds && p.StartTime.TotalMilliseconds <= endPositionMilliseconds)
+            {
+                _paragraphStartPositions.Add(SecondsToXPositionOptimized(p.StartTime.TotalSeconds - renderCtx.StartPositionSeconds, renderCtx.SampleRate, renderCtx.ZoomFactor));
+                _paragraphEndPositions.Add(SecondsToXPositionOptimized(p.EndTime.TotalSeconds - renderCtx.StartPositionSeconds, renderCtx.SampleRate, renderCtx.ZoomFactor));
             }
         }
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -24633,7 +24633,10 @@ public partial class MainViewModel :
                 else if (av != null && isPlaying &&
                          (mediaPlayerSeconds > av.EndPositionSeconds || mediaPlayerSeconds < av.StartPositionSeconds))
                 {
-                    av.SetPosition(startPos, subtitle, mediaPlayerSeconds, 0, _selectedSubtitles ?? []);
+                    // -1 like the other branches: passing an index here names the PRIMARY
+                    // selected paragraph, and 0 made this scroll-jump branch mark the file's
+                    // first line as selected in the waveform for one tick.
+                    av.SetPosition(startPos, subtitle, mediaPlayerSeconds, -1, _selectedSubtitles ?? []);
                 }
                 else if (av != null)
                 {

--- a/tests/UI/Controls/AudioVisualizerDragTests.cs
+++ b/tests/UI/Controls/AudioVisualizerDragTests.cs
@@ -1,0 +1,212 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Threading;
+using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace UITests.Controls;
+
+/// <summary>
+/// Waveform drag behavior for issue #13600.
+///
+/// The drag delta is anchored in absolute waveform time, not pixels: when the view scrolls
+/// mid-drag (the position timer jumps the view while the video plays, or the user wheel-scrolls
+/// without releasing), the dragged edge must keep following the pointer - SE4 behaved this way,
+/// and it is what makes "extend an end cue while the video plays" workable without releasing and
+/// re-grabbing the edge once per screenful.
+///
+/// The classic draw style must also not rebuild its cached per-pixel waveform geometry when a
+/// selected line's times change (i.e. on every pointer move of a drag) - the selection is painted
+/// as a clipped overlay instead. The fancy style bakes selection into per-column colors, so it
+/// still rebuilds.
+/// </summary>
+public class AudioVisualizerDragTests
+{
+    private const int SampleRate = 126; // Se.Settings.Waveform.WaveformMinimumSampleRate default
+    private const double WidthPx = 800;
+    private const double HeightPx = 200;
+
+    private static WavePeakData2 MakePeaks(int seconds)
+    {
+        var peaks = new WavePeak2[SampleRate * seconds];
+        for (var i = 0; i < peaks.Length; i++)
+        {
+            peaks[i] = new WavePeak2(8000, -8000);
+        }
+
+        return new WavePeakData2(SampleRate, peaks);
+    }
+
+    private static SubtitleLineViewModel Line(double startSeconds, double endSeconds) => new()
+    {
+        Text = "text",
+        StartTime = TimeSpan.FromSeconds(startSeconds),
+        EndTime = TimeSpan.FromSeconds(endSeconds),
+    };
+
+    private static (Window Window, AudioVisualizer Av, List<SubtitleLineViewModel> Lines) Open(params SubtitleLineViewModel[] lines)
+    {
+        var av = new AudioVisualizer
+        {
+            WavePeaks = MakePeaks(60),
+            Width = WidthPx,
+            Height = HeightPx,
+        };
+
+        var list = new List<SubtitleLineViewModel>(lines);
+        av.SetPosition(0, list, 0, 0, new List<SubtitleLineViewModel>());
+
+        var window = new Window
+        {
+            Width = WidthPx,
+            Height = HeightPx,
+            Content = av,
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        return (window, av, list);
+    }
+
+    [AvaloniaFact]
+    public void ResizeRight_FollowsPointer_WhileViewIsStatic()
+    {
+        // One line 1-3 s; at zoom 1 the right edge sits at x = 3 * 126 = 378.
+        var (window, av, _) = Open(Line(1, 3));
+        var line = av.SelectedParagraph!;
+
+        window.MouseDown(new Point(378, 100), MouseButton.Left, RawInputModifiers.None);
+        window.MouseMove(new Point(478, 100), RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+
+        // +100 px = +100/126 s.
+        Assert.Equal(3 + 100.0 / SampleRate, line.EndTime.TotalSeconds, 2);
+
+        window.MouseUp(new Point(478, 100), MouseButton.Left, RawInputModifiers.None);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void ResizeRight_FollowsScroll_WhenViewScrollsMidDrag()
+    {
+        // The #13600 regression: the view scrolling under an active drag must carry the dragged
+        // edge along with the pointer. With the old pixel-delta math the edge stayed frozen at
+        // the pre-scroll time and the drag went dead at the window border.
+        var (window, av, _) = Open(Line(1, 3));
+        var line = av.SelectedParagraph!;
+
+        window.MouseDown(new Point(378, 100), MouseButton.Left, RawInputModifiers.None);
+        window.MouseMove(new Point(478, 100), RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+
+        // What the position timer does when the playhead crosses the view edge during playback.
+        av.StartPositionSeconds = 2;
+        window.MouseMove(new Point(479, 100), RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+
+        // End = original 3 s + pointer delta (101/126 s) + the 2 s the view scrolled.
+        Assert.Equal(3 + 101.0 / SampleRate + 2, line.EndTime.TotalSeconds, 2);
+
+        window.MouseUp(new Point(479, 100), MouseButton.Left, RawInputModifiers.None);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void MoveWholeLine_FollowsScroll_WhenViewScrollsMidDrag()
+    {
+        var (window, av, _) = Open(Line(1, 3));
+        var line = av.SelectedParagraph!;
+
+        // Grab the middle of the line (x = 2 s * 126 = 252) and drag right.
+        window.MouseDown(new Point(252, 100), MouseButton.Left, RawInputModifiers.None);
+        window.MouseMove(new Point(302, 100), RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal(1 + 50.0 / SampleRate, line.StartTime.TotalSeconds, 2);
+
+        av.StartPositionSeconds = 2;
+        window.MouseMove(new Point(303, 100), RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(1 + 51.0 / SampleRate + 2, line.StartTime.TotalSeconds, 2);
+        Assert.Equal(2, line.Duration.TotalSeconds, 2); // duration preserved by a whole-line move
+
+        window.MouseUp(new Point(303, 100), MouseButton.Left, RawInputModifiers.None);
+        window.Close();
+    }
+
+    private static Geometry FirstCachedWaveformGeometry(AudioVisualizer av)
+    {
+        var field = typeof(AudioVisualizer).GetField("_waveformCacheDraws", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var list = (System.Collections.IList)field.GetValue(av)!;
+        Assert.True(list.Count > 0);
+        var item = (ValueTuple<IPen, Geometry>)list[0]!;
+        return item.Item2;
+    }
+
+    private static void RenderFrame(AudioVisualizer av)
+    {
+        var drawingGroup = new DrawingGroup();
+        using var context = drawingGroup.Open();
+        av.Render(context);
+    }
+
+    private static AudioVisualizer MakeMeasuredVisualizer(WaveformDrawStyle style, out SubtitleLineViewModel selectedLine)
+    {
+        var av = new AudioVisualizer
+        {
+            WaveformDrawStyle = style,
+            WavePeaks = MakePeaks(60),
+        };
+        av.Measure(new Size(WidthPx, HeightPx));
+        av.Arrange(new Rect(0, 0, WidthPx, HeightPx));
+
+        var lines = new List<SubtitleLineViewModel> { Line(1, 3) };
+        av.SetPosition(0, lines, 0, 0, new List<SubtitleLineViewModel>());
+        selectedLine = lines[0];
+        return av;
+    }
+
+    [AvaloniaFact]
+    public void ClassicWaveformCache_SurvivesSelectedTimeChange()
+    {
+        // Dragging a selected line changes its times on every pointer move; the classic style
+        // must replay the cached geometry (selection is a draw-time overlay), not rebuild it.
+        var av = MakeMeasuredVisualizer(WaveformDrawStyle.Classic, out var line);
+
+        RenderFrame(av);
+        var before = FirstCachedWaveformGeometry(av);
+
+        line.EndTime = line.EndTime + TimeSpan.FromSeconds(0.2);
+        RenderFrame(av);
+        var after = FirstCachedWaveformGeometry(av);
+
+        Assert.Same(before, after);
+    }
+
+    [AvaloniaFact]
+    public void FancyWaveformCache_RebuildsOnSelectedTimeChange()
+    {
+        // The fancy style bakes the selection into per-column colors, so a selected-time change
+        // must still invalidate the cached geometry.
+        var av = MakeMeasuredVisualizer(WaveformDrawStyle.Fancy, out var line);
+
+        RenderFrame(av);
+        var before = FirstCachedWaveformGeometry(av);
+
+        line.EndTime = line.EndTime + TimeSpan.FromSeconds(0.2);
+        RenderFrame(av);
+        var after = FirstCachedWaveformGeometry(av);
+
+        Assert.NotSame(before, after);
+    }
+}

--- a/tests/benchmarks/AudioVisualizerRenderBenchmarks.cs
+++ b/tests/benchmarks/AudioVisualizerRenderBenchmarks.cs
@@ -49,6 +49,10 @@ public class AudioVisualizerRenderBenchmarks
     private AudioVisualizer _audioVisualizer = null!;
     private List<SubtitleLineViewModel> _subtitles = null!;
     private readonly List<SubtitleLineViewModel> _noSelection = new();
+    private List<SubtitleLineViewModel> _dragSelection = null!;
+    private SubtitleLineViewModel _draggedLine = null!;
+    private int _draggedIndex;
+    private double _draggedOriginalEndSeconds;
     private double _positionSeconds;
     private double _viewSeconds;
     private int _frameIndex;
@@ -84,6 +88,48 @@ public class AudioVisualizerRenderBenchmarks
         _viewSeconds = WidthPx / (double)PeaksPerSecond; // ZoomFactor is 1.0
         _positionSeconds = 10;
         _frameIndex = 0;
+
+        // A selected line inside the static view for SelectedLineDragFrame.
+        _draggedIndex = _subtitles.FindIndex(p => p.StartTime.TotalSeconds > 12);
+        _draggedLine = _subtitles[_draggedIndex];
+        _draggedOriginalEndSeconds = _draggedLine.EndTime.TotalSeconds;
+        _dragSelection = new List<SubtitleLineViewModel> { _draggedLine };
+    }
+
+    [Benchmark]
+    public void SelectedLineDragFrame()
+    {
+        // What a waveform drag of a selected line looks like to Render (#13600): the view stands
+        // still, the cursor glides, and the selected line's end time moves a little on every
+        // frame (one pointer move). Before the classic style painted selection as a draw-time
+        // overlay, every one of these frames missed the waveform cache (the key hashed the
+        // selection's times) and re-ran the full per-pixel geometry build - i.e. this scenario
+        // cost ForcedRebuildFrame; now (classic) it should cost StaticViewPlaybackFrame.
+        const double viewStart = 10;
+        _positionSeconds += FrameSeconds;
+        if (_positionSeconds > viewStart + _viewSeconds - 1)
+        {
+            _positionSeconds = viewStart + 1;
+        }
+
+        var endSeconds = _draggedLine.EndTime.TotalSeconds + 0.008;
+        if (endSeconds > viewStart + _viewSeconds - 1)
+        {
+            endSeconds = _draggedOriginalEndSeconds;
+        }
+
+        _draggedLine.EndTime = TimeSpan.FromSeconds(endSeconds);
+
+        if (++_frameIndex % 3 == 0)
+        {
+            _audioVisualizer.SetPosition(viewStart, _subtitles, _positionSeconds, _draggedIndex, _dragSelection);
+        }
+        else
+        {
+            _audioVisualizer.CurrentVideoPositionSeconds = _positionSeconds;
+        }
+
+        RenderFrame();
     }
 
     [Benchmark]


### PR DESCRIPTION
Fixes the waveform drag responsiveness regression reported in #13600 ("SE4 was smooth, in SE5 I have to force it a lot to extend the timings"). The reporter's video shows the key workflow: extending a subtitle's end time by dragging its right edge **while the video is playing**.

### 1. Drag deltas are now anchored in absolute waveform time (SE4 parity — the actual complaint)

SE5 computed drags as a pure pixel delta from the press point, so `newEnd = originalEnd + deltaX × secondsPerPixel` — the view scroll position cancels out. SE4 instead set the dragged edge to the **absolute time under the pointer**.

The difference only shows when the view scrolls *mid-drag* — which is exactly what happens in the reporter's workflow: the position timer jumps the view a full screen forward when the playhead crosses the right edge (and wheel scrolling mid-drag does the same). In SE4 the dragged edge kept following the pointer through the scroll, so you could keep extending a cue continuously. In SE5 the edge froze at its pre-scroll time, visually teleported to the far left, and the pointer was already parked at the window border — the drag went dead, forcing release → re-grab the ±5 px edge → drag another screenful, once per screen. With right-hand mobility issues that is painful.

Drags are now anchored to the waveform time under the pointer at press; the delta is recomputed against the live scroll position, so a mid-drag scroll carries the dragged edge along with the pointer. Covered by headless UI tests that press, drag, scroll the view mid-drag, and assert the edge followed (they fail on the old math).

### 2. The classic waveform no longer rebuilds its geometry on every drag move

The waveform's cached geometry was keyed on the *times of the selected lines* (the selected region is drawn in a different color). Dragging a selected line therefore invalidated the cache on **every pointer move**, re-running the full per-pixel build (view width + 256 columns → new `StreamGeometry`) at pointer-move rate, on top of the ~60 fps cursor renders during playback.

The classic style now paints the selection as a draw-time overlay: the cached geometry is selection-independent, drawn once with the normal pen, then re-stroked with the selected pen clipped to the selected lines' visible regions (overlapping regions are merged first so the semi-transparent pen doesn't double-stroke). A drag now replays the cache instead of rebuilding it. The fancy style bakes selection into per-column colors and keeps the old rebuild-on-selection-change behavior.

New benchmark scenario `SelectedLineDragFrame` (a playback frame while a selected line's end time moves every frame, i.e. one drag tick):

| Style / width | drag frame before | drag frame after | static frame (floor) |
| --- | --- | --- | --- |
| Classic 1600 px | 228.5 µs (**1.33× floor**) | 180.8 µs (**1.06×**) | 170.8 µs |
| Classic 3200 px | 382.7 µs (**1.35× floor**) | 302.5 µs (**1.06×**) | 285.7 µs |
| Fancy 1600 px | 303.6 µs (1.67×) | 302.3 µs (1.65×) | 183.3 µs |
| Fancy 3200 px | 485.5 µs (1.64×) | 478.5 µs (1.61×) | 297.7 µs |

(record-only UI-thread cost, `--job short`; the real win is larger since a fresh `StreamGeometry` also forces re-tessellation on the render thread every frame, which the record-only harness deliberately excludes)

### 3. Same-X pointer-move early-out (SE4 parity)

SE4's mouse-move began with `if (oldMouseMoveLastX == e.X) return;`. SE5 processed every report from high-rate mice (125–1000 Hz), re-running hit tests, snapping, time writes and invalidation for moves that didn't change the X position. The same guard is now in place for active drags.

### Related cleanups spotted on the same paths

- The playhead-crossed-view-edge scroll branch passed `0` as the primary selected index to `SetPosition`, marking the file's *first line* as the waveform's selected paragraph for one 50 ms tick; it now passes `-1` like the other branches.
- `DrawShotChanges` built two paragraph-edge hash sets per ~60 fps frame even when no shot change was visible in the view; the sets are now only built when at least one is.
- The drag handler's neighbor lookup for a new-selection drag used two LINQ scans with lambda allocations per pointer move; replaced with a single walk of the sorted list.
- `GetCurrentPoint()` is only called in the branch that needs it.

### Tests

- `AudioVisualizerDragTests` (new, headless + real input pipeline): static drag math unchanged, mid-drag scroll carries the edge (resize + whole-line move), classic cache survives a selected-time change, fancy cache still rebuilds.
- Full UI test suite passes.

Fixes #13600.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
