### PR TITLE
Waveform: drop the per-pointer-move TimeCode allocation in shot-change snapping

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -1458,18 +1458,16 @@ public class AudioVisualizer : Control
                 }
 
                 var snappedToShotLeft = false;
-                if (SnapToShotChanges && !_isShiftDown)
+                if (SnapToShotChanges && !_isShiftDown && _shotChanges.Count > 0)
                 {
-                    var nearestShotChange = ShotChangesHelper.GetClosestShotChange(_shotChanges, TimeCode.FromSeconds(newStart));
-                    if (nearestShotChange != null)
+                    // ClosestTo directly (binary search) - GetClosestShotChange only wraps it
+                    // behind a TimeCode, which is a class, i.e. one allocation per pointer move.
+                    var nearest = _shotChanges.ClosestTo(newStart);
+                    var snapSeconds = GetInCueSnapSeconds();
+                    if (nearest != newStart && Math.Abs(newStart - nearest) < snapSeconds)
                     {
-                        var nearest = (double)nearestShotChange;
-                        var snapSeconds = GetInCueSnapSeconds();
-                        if (nearest != newStart && Math.Abs(newStart - nearest) < snapSeconds)
-                        {
-                            newStart = nearest;
-                            snappedToShotLeft = true;
-                        }
+                        newStart = nearest;
+                        snappedToShotLeft = true;
                     }
                 }
 
@@ -1494,22 +1492,19 @@ public class AudioVisualizer : Control
                 newEnd = _originalEndSeconds + dragDeltaSeconds;
 
                 var snappedToShotRight = false;
-                if (SnapToShotChanges && !_isShiftDown)
+                if (SnapToShotChanges && !_isShiftDown && _shotChanges.Count > 0)
                 {
                     // OUT cues conventionally land one frame BEFORE the shot change so they
                     // don't bleed visually onto the next shot.
                     var fps = Se.Settings.General.CurrentFrameRate;
                     var oneFrameSeconds = fps >= 1 ? 1.0 / fps : 0.0;
-                    var nearestShotChange = ShotChangesHelper.GetClosestShotChange(_shotChanges, TimeCode.FromSeconds(newEnd));
-                    if (nearestShotChange != null)
+                    // ClosestTo directly - see the ResizingLeft branch.
+                    var nearest = _shotChanges.ClosestTo(newEnd);
+                    var snapSeconds = GetOutCueSnapSeconds();
+                    if (nearest != newEnd && Math.Abs(newEnd - nearest + oneFrameSeconds) < snapSeconds)
                     {
-                        var nearest = (double)nearestShotChange;
-                        var snapSeconds = GetOutCueSnapSeconds();
-                        if (nearest != newEnd && Math.Abs(newEnd - nearest + oneFrameSeconds) < snapSeconds)
-                        {
-                            newEnd = nearest - oneFrameSeconds;
-                            snappedToShotRight = true;
-                        }
+                        newEnd = nearest - oneFrameSeconds;
+                        snappedToShotRight = true;
                     }
                 }
 


### PR DESCRIPTION
Follow-up micro-optimization to #13602 (the last one found on the drag path): `ShotChangesHelper.GetClosestShotChange` only wraps `List<double>.ClosestTo` (already a binary search) behind a `TimeCode` parameter — and `TimeCode` is a class, so both resize branches allocated one per pointer move (snap-to-shot-changes is on by default) just to unwrap `.TotalSeconds` again. The resize branches now call `ClosestTo` directly under the existing `Count > 0` guard. Behavior identical; waveform tests pass.

Everything else on the pointer-move and render paths was audited and left alone deliberately: `IndexOf` over ≤250 displayable lines and the settings reads are sub-microsecond, the remaining per-frame loops are already pooled/cached, and skipping renders when the playhead moves less than a pixel was considered and dropped — at default zoom the cursor moves ~2 px per 60 fps tick, so it would save nothing where it matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)