### PR TITLE
Speed up OCR/export pixel loops with spans and Vector<T>

### DIFF
--- a/src/libse/BluRaySup/BluRaySupPicture.cs
+++ b/src/libse/BluRaySup/BluRaySupPicture.cs
@@ -122,14 +122,17 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
             }
 
             var transparentColor = (byte)palette[palette.Count - 1];
-            var bytes = new List<byte>();
+            var bytes = new List<byte>(bm.Width * 2);
+            var reader = new BitmapRowReader(bm);
+            var row = new SKColor[bm.Width];
             for (var y = 0; y < bm.Height; y++)
             {
+                reader.ReadRow(y, row);
                 int x;
                 int len;
                 for (x = 0; x < bm.Width; x += len)
                 {
-                    var c = bm.GetPixel(x, y);
+                    var c = row[x];
 
                     byte color;
                     if (c.Alpha == 0)
@@ -147,7 +150,7 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
 
                     for (len = 1; x + len < bm.Width; len++)
                     {
-                        if (bm.GetPixel(x + len, y) != c)
+                        if (row[x + len] != c)
                         {
                             break;
                         }
@@ -213,6 +216,62 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
             return bytes.ToArray();
         }
 
+        /// <summary>
+        /// Hands out whole rows of pixels without a SkiaSharp interop call per pixel. Only color
+        /// types whose bytes <see cref="SKBitmap.GetPixel"/> returns unchanged are read directly:
+        /// premultiplied pixels get un-premultiplied on the way out of GetPixel, and other layouts
+        /// are not four plain BGRA/RGBA bytes, so both keep using GetPixel.
+        /// </summary>
+        private sealed class BitmapRowReader
+        {
+            private readonly SKBitmap _bitmap;
+            private readonly int _redOffset;
+            private readonly int _blueOffset;
+            private readonly bool _direct;
+
+            public BitmapRowReader(SKBitmap bitmap)
+            {
+                _bitmap = bitmap;
+                // Alpha is byte 3 and green byte 1 in both layouts; only red and blue swap.
+                if (bitmap.AlphaType != SKAlphaType.Premul && bitmap.GetPixels() != IntPtr.Zero)
+                {
+                    if (bitmap.ColorType == SKColorType.Bgra8888)
+                    {
+                        _redOffset = 2;
+                        _blueOffset = 0;
+                        _direct = true;
+                    }
+                    else if (bitmap.ColorType == SKColorType.Rgba8888)
+                    {
+                        _redOffset = 0;
+                        _blueOffset = 2;
+                        _direct = true;
+                    }
+                }
+            }
+
+            public unsafe void ReadRow(int y, SKColor[] row)
+            {
+                if (!_direct)
+                {
+                    for (var x = 0; x < row.Length; x++)
+                    {
+                        row[x] = _bitmap.GetPixel(x, y);
+                    }
+
+                    return;
+                }
+
+                var rowBytes = _bitmap.RowBytes;
+                var line = new ReadOnlySpan<byte>((byte*)_bitmap.GetPixels().ToPointer() + (long)y * rowBytes, rowBytes);
+                for (var x = 0; x < row.Length; x++)
+                {
+                    var i = x * 4;
+                    row[x] = new SKColor(line[i + _redOffset], line[i + 1], line[i + _blueOffset], line[i + 3]);
+                }
+            }
+        }
+
         private static byte FindBestMatch(SKColor color, List<SKColor> palette)
         {
             var smallestDiff = 1000;
@@ -252,6 +311,8 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
         {
             var pal = new List<SKColor>(255);
             var lookup = new HashSet<SKColor>(255);
+            var reader = new BitmapRowReader(bitmap);
+            var row = new SKColor[bitmap.Width];
 
             // Add font color as first entry
             pal.Add(fontColor);
@@ -260,9 +321,10 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
             // first we try with exact colors
             for (var y = 0; y < bitmap.Height; y++)
             {
+                reader.ReadRow(y, row);
                 for (var x = 0; x < bitmap.Width; x++)
                 {
-                    var c = bitmap.GetPixel(x, y);
+                    var c = row[x];
                     if (c.Alpha > 0)
                     {
                         if (lookup.Contains(c))
@@ -301,9 +363,10 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
             lookup.Add(fontColor);
             for (var y = 0; y < bitmap.Height; y++)
             {
+                reader.ReadRow(y, row);
                 for (var x = 0; x < bitmap.Width; x++)
                 {
-                    var c = bitmap.GetPixel(x, y);
+                    var c = row[x];
                     if (c.Alpha > 0)
                     {
                         if (lookup.Contains(c))

--- a/src/libse/BluRaySup/SkiaExt.cs
+++ b/src/libse/BluRaySup/SkiaExt.cs
@@ -6,96 +6,55 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
 {
     public static class SkiaExt
     {
+        /// <summary>
+        /// Rows spanned by the first through the last row holding a non-transparent pixel; 0 when
+        /// the bitmap draws nothing.
+        /// </summary>
         public static int GetNonTransparentHeight(this SKBitmap bitmap)
         {
-            var startY = 0;
-            var transparentBottomPixels = 0;
-            for (var y = 0; y < bitmap.Height; y++)
-            {
-                var isLineTransparent = bitmap.IsLineTransparent(y);
-                if (startY == y && isLineTransparent)
-                {
-                    startY++;
-                    continue;
-                }
-
-                if (isLineTransparent)
-                {
-                    transparentBottomPixels++;
-                }
-                else
-                {
-                    transparentBottomPixels = 0;
-                }
-            }
-
-            return bitmap.Height - startY - transparentBottomPixels;
+            var bounds = bitmap.GetNonTransparentBoundsAnyFormat();
+            return bounds.IsEmpty ? 0 : bounds.Bottom - bounds.Top + 1;
         }
 
-        private static bool IsLineTransparent(this SKBitmap bitmap, int y)
-        {
-            // Validate y to ensure it's within the bounds of the bitmap
-            if (y < 0 || y >= bitmap.Height)
-            {
-                throw new ArgumentOutOfRangeException(nameof(y), "The row y is out of bounds.");
-            }
-
-            for (var x = 0; x < bitmap.Width; x++)
-            {
-                var color = bitmap.GetPixel(x, y);
-                if (color.Alpha != 0)
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
+        /// <summary>
+        /// Columns spanned by the first through the last column holding a non-transparent pixel; 0
+        /// when the bitmap draws nothing.
+        /// </summary>
         public static int GetNonTransparentWidth(this SKBitmap bitmap)
         {
-            var startX = 0;
-            var transparentPixelsRight = 0;
-            for (var x = 0; x < bitmap.Width; x++)
-            {
-                var isLineTransparent = bitmap.IsVerticalLineTransparent(x);
-                if (startX == x && isLineTransparent)
-                {
-                    startX++;
-                    continue;
-                }
-
-                if (isLineTransparent)
-                {
-                    transparentPixelsRight++;
-                }
-                else
-                {
-                    transparentPixelsRight = 0;
-                }
-            }
-
-            return bitmap.Width - startX - transparentPixelsRight;
+            var bounds = bitmap.GetNonTransparentBoundsAnyFormat();
+            return bounds.IsEmpty ? 0 : bounds.Right - bounds.Left + 1;
         }
 
-        private static bool IsVerticalLineTransparent(this SKBitmap bitmap, int x)
+        /// <summary>
+        /// <see cref="GetNonTransparentBounds"/> takes alpha to be the fourth byte of a four-byte
+        /// pixel; any other layout has to go through GetPixel, which knows the color type.
+        /// </summary>
+        private static NonTransparentBounds GetNonTransparentBoundsAnyFormat(this SKBitmap bitmap)
         {
-            // Validate y to ensure it's within the bounds of the bitmap
-            if (x < 0 || x >= bitmap.Width)
+            if (bitmap.BytesPerPixel == 4)
             {
-                throw new ArgumentOutOfRangeException(nameof(x), "The column x is out of bounds.");
+                return bitmap.GetNonTransparentBounds();
             }
 
+            var bounds = new NonTransparentBounds { Top = bitmap.Height, Left = bitmap.Width, Right = -1, Bottom = -1 };
             for (var y = 0; y < bitmap.Height; y++)
             {
-                var color = bitmap.GetPixel(x, y);
-                if (color.Alpha != 0)
+                for (var x = 0; x < bitmap.Width; x++)
                 {
-                    return false;
+                    if (bitmap.GetPixel(x, y).Alpha == 0)
+                    {
+                        continue;
+                    }
+
+                    if (y < bounds.Top) { bounds.Top = y; }
+                    if (y > bounds.Bottom) { bounds.Bottom = y; }
+                    if (x < bounds.Left) { bounds.Left = x; }
+                    if (x > bounds.Right) { bounds.Right = x; }
                 }
             }
 
-            return true;
+            return bounds;
         }
 
         public static bool IsEqualTo(this SKBitmap bitmap, SKBitmap other)

--- a/src/libse/BluRaySup/SkiaExt.cs
+++ b/src/libse/BluRaySup/SkiaExt.cs
@@ -28,11 +28,15 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
 
         /// <summary>
         /// <see cref="GetNonTransparentBounds"/> takes alpha to be the fourth byte of a four-byte
-        /// pixel; any other layout has to go through GetPixel, which knows the color type.
+        /// pixel, which only holds for the two plain 8-bit-per-channel layouts: Rgb888x also has
+        /// four bytes but its fourth one is padding GetPixel ignores (it always reports alpha 255),
+        /// and the 1010102 types pack alpha into the top two bits. Any other layout — and a bitmap
+        /// with no pixel storage — has to go through GetPixel, which knows the color type.
         /// </summary>
         private static NonTransparentBounds GetNonTransparentBoundsAnyFormat(this SKBitmap bitmap)
         {
-            if (bitmap.BytesPerPixel == 4)
+            var alphaIsFourthByte = bitmap.ColorType == SKColorType.Bgra8888 || bitmap.ColorType == SKColorType.Rgba8888;
+            if (alphaIsFourthByte && bitmap.GetPixels() != IntPtr.Zero)
             {
                 return bitmap.GetNonTransparentBounds();
             }

--- a/src/libse/Common/NikseBitmap.cs
+++ b/src/libse/Common/NikseBitmap.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Numerics;
 using System.Runtime.InteropServices;
 
 namespace Nikse.SubtitleEdit.Core.Common
@@ -87,20 +88,34 @@ namespace Nikse.SubtitleEdit.Core.Common
             Buffer.BlockCopy(input._bitmapData, 0, _bitmapData, 0, _bitmapData.Length);
         }
 
+        /// <summary>
+        /// One BGRA pixel packed into the uint that <see cref="MemoryMarshal.Cast{TFrom,TTo}(Span{TFrom})"/>
+        /// yields for it. Built through the byte layout so the constant is right on either endianness.
+        /// </summary>
+        private static uint PackBgra(byte blue, byte green, byte red, byte alpha)
+        {
+            Span<byte> bytes = stackalloc byte[4];
+            bytes[0] = blue;
+            bytes[1] = green;
+            bytes[2] = red;
+            bytes[3] = alpha;
+            return MemoryMarshal.Read<uint>(bytes);
+        }
+
         public void ReplaceYellowWithWhite()
         {
-            var buffer = new byte[3];
-            buffer[0] = 255;
-            buffer[1] = 255;
-            buffer[2] = 255;
-            for (int i = 0; i < _bitmapData.Length; i += 4)
+            var keepAlpha = PackBgra(0, 0, 0, 255);
+            var white = PackBgra(255, 255, 255, 0);
+            var data = _bitmapData.AsSpan();
+            var pixels = MemoryMarshal.Cast<byte, uint>(_bitmapData.AsSpan());
+            for (int i = 0, p = 0; p < pixels.Length; i += 4, p++)
             {
-                if (_bitmapData[i + 3] > 200 && // Alpha
-                    _bitmapData[i + 2] > 199 && // Red
-                    _bitmapData[i + 1] > 190 && // Green
-                    _bitmapData[i] < 40) // Blue
+                if (data[i + 3] > 200 && // Alpha
+                    data[i + 2] > 199 && // Red
+                    data[i + 1] > 190 && // Green
+                    data[i] < 40) // Blue
                 {
-                    Buffer.BlockCopy(buffer, 0, _bitmapData, i, 3);
+                    pixels[p] = (pixels[p] & keepAlpha) | white;
                 }
             }
         }
@@ -108,84 +123,69 @@ namespace Nikse.SubtitleEdit.Core.Common
         public void ReplaceColor(int alpha, int red, int green, int blue,
             int alphaTo, int redTo, int greenTo, int blueTo)
         {
-            var buffer = new byte[4];
-            buffer[0] = (byte)blueTo;
-            buffer[1] = (byte)greenTo;
-            buffer[2] = (byte)redTo;
-            buffer[3] = (byte)alphaTo;
-            for (int i = 0; i < _bitmapData.Length; i += 4)
+            if ((uint)alpha > 255 || (uint)red > 255 || (uint)green > 255 || (uint)blue > 255)
             {
-                if (_bitmapData[i + 3] == alpha &&
-                    _bitmapData[i + 2] == red &&
-                    _bitmapData[i + 1] == green &&
-                    _bitmapData[i] == blue)
+                // A channel outside 0-255 can never equal a pixel byte, so nothing would match.
+                return;
+            }
+
+            var from = PackBgra((byte)blue, (byte)green, (byte)red, (byte)alpha);
+            var to = PackBgra((byte)blueTo, (byte)greenTo, (byte)redTo, (byte)alphaTo);
+            var pixels = MemoryMarshal.Cast<byte, uint>(_bitmapData.AsSpan());
+            for (var p = 0; p < pixels.Length; p++)
+            {
+                if (pixels[p] == from)
                 {
-                    Buffer.BlockCopy(buffer, 0, _bitmapData, i, 4);
+                    pixels[p] = to;
                 }
             }
         }
 
         public void InvertColors()
         {
-            for (int i = 0; i < _bitmapData.Length;)
+            var rgb = PackBgra(255, 255, 255, 0);
+            var pixels = MemoryMarshal.Cast<byte, uint>(_bitmapData.AsSpan());
+            for (var p = 0; p < pixels.Length; p++)
             {
-                _bitmapData[i] = (byte)~_bitmapData[i];
-                i++;
-                _bitmapData[i] = (byte)~_bitmapData[i];
-                i++;
-                _bitmapData[i] = (byte)~_bitmapData[i];
-                i += 2;
+                pixels[p] ^= rgb;
             }
         }
 
         public void ReplaceNonWhiteWithTransparent()
         {
-            var buffer = new byte[4];
-            buffer[0] = 0; // B
-            buffer[1] = 0; // G
-            buffer[2] = 0; // R
-            buffer[3] = 0; // A
-            for (int i = 0; i < _bitmapData.Length; i += 4)
+            var data = _bitmapData.AsSpan();
+            var pixels = MemoryMarshal.Cast<byte, uint>(_bitmapData.AsSpan());
+            for (int i = 0, p = 0; p < pixels.Length; i += 4, p++)
             {
-                if (_bitmapData[i + 2] + _bitmapData[i + 1] + _bitmapData[i] < 300)
+                if (data[i + 2] + data[i + 1] + data[i] < 300)
                 {
-                    Buffer.BlockCopy(buffer, 0, _bitmapData, i, 4);
+                    pixels[p] = 0;
                 }
             }
         }
 
         public void ReplaceTransparentWith(SKColor c)
         {
-            var buffer = new byte[4];
-            buffer[0] = c.Blue;
-            buffer[1] = c.Green;
-            buffer[2] = c.Red;
-            buffer[3] = c.Alpha;
-            for (int i = 0; i < _bitmapData.Length; i += 4)
+            var replacement = PackBgra(c.Blue, c.Green, c.Red, c.Alpha);
+            var data = _bitmapData.AsSpan();
+            var pixels = MemoryMarshal.Cast<byte, uint>(_bitmapData.AsSpan());
+            for (int i = 0, p = 0; p < pixels.Length; i += 4, p++)
             {
-                if (_bitmapData[i + 3] < 10)
+                if (data[i + 3] < 10)
                 {
-                    Buffer.BlockCopy(buffer, 0, _bitmapData, i, 4);
+                    pixels[p] = replacement;
                 }
             }
         }
 
         public void MakeOneColor(SKColor c)
         {
-            var buffer = new byte[4];
-            buffer[0] = c.Blue;
-            buffer[1] = c.Green;
-            buffer[2] = c.Red;
-            buffer[3] = c.Alpha;
-
-            var bufferTransparent = new byte[4];
-            bufferTransparent[0] = 0;
-            bufferTransparent[1] = 0;
-            bufferTransparent[2] = 0;
-            bufferTransparent[3] = 0;
-            for (int i = 0; i < _bitmapData.Length; i += 4)
+            var color = PackBgra(c.Blue, c.Green, c.Red, c.Alpha);
+            var data = _bitmapData.AsSpan();
+            var pixels = MemoryMarshal.Cast<byte, uint>(_bitmapData.AsSpan());
+            for (int i = 0, p = 0; p < pixels.Length; i += 4, p++)
             {
-                Buffer.BlockCopy(_bitmapData[i] > 20 ? buffer : bufferTransparent, 0, _bitmapData, i, 4);
+                pixels[p] = data[i] > 20 ? color : 0u;
             }
         }
 
@@ -198,15 +198,63 @@ namespace Nikse.SubtitleEdit.Core.Common
         /// </summary>
         public void MakeBlackAndWhiteForOcr(int brightnessThreshold = 90, int alphaThreshold = 100)
         {
-            var black = new byte[] { 0, 0, 0, 255 };
-            var white = new byte[] { 255, 255, 255, 255 };
-            for (int i = 0; i < _bitmapData.Length; i += 4)
+            var black = PackBgra(0, 0, 0, 255);
+            var white = PackBgra(255, 255, 255, 255);
+            var start = MakeBlackAndWhiteForOcrVector(brightnessThreshold, alphaThreshold, black, white);
+            var data = _bitmapData.AsSpan();
+            var pixels = MemoryMarshal.Cast<byte, uint>(_bitmapData.AsSpan());
+            for (int i = start, p = start / 4; p < pixels.Length; i += 4, p++)
             {
                 // _bitmapData is BGRA: [i]=blue, [i+1]=green, [i+2]=red, [i+3]=alpha.
-                var brightness = Math.Max(_bitmapData[i], Math.Max(_bitmapData[i + 1], _bitmapData[i + 2]));
-                var isText = _bitmapData[i + 3] >= alphaThreshold && brightness >= brightnessThreshold;
-                Buffer.BlockCopy(isText ? black : white, 0, _bitmapData, i, 4);
+                var brightness = Math.Max(data[i], Math.Max(data[i + 1], data[i + 2]));
+                var isText = data[i + 3] >= alphaThreshold && brightness >= brightnessThreshold;
+                pixels[p] = isText ? black : white;
             }
+        }
+
+        /// <summary>
+        /// Vector pass for <see cref="MakeBlackAndWhiteForOcr"/>; returns the number of bytes it
+        /// handled so the caller finishes the tail one pixel at a time. Bails out when a threshold
+        /// falls outside 0-255, since it has to be compared as a byte.
+        /// </summary>
+        private int MakeBlackAndWhiteForOcrVector(int brightnessThreshold, int alphaThreshold, uint black, uint white)
+        {
+            var length = _bitmapData.Length;
+            var step = Vector<byte>.Count;
+            if (!Vector.IsHardwareAccelerated || length < step ||
+                (uint)brightnessThreshold > 255 || (uint)alphaThreshold > 255)
+            {
+                return 0;
+            }
+
+            // One threshold per channel laid out B, G, R, A; Vector<byte>.Count is always a
+            // multiple of four, so the pattern lines up with every pixel in the block.
+            var thresholdBytes = new byte[step];
+            for (var k = 0; k < step; k += 4)
+            {
+                thresholdBytes[k] = (byte)brightnessThreshold;
+                thresholdBytes[k + 1] = (byte)brightnessThreshold;
+                thresholdBytes[k + 2] = (byte)brightnessThreshold;
+                thresholdBytes[k + 3] = (byte)alphaThreshold;
+            }
+
+            var thresholds = new Vector<byte>(thresholdBytes);
+            var rgbMask = new Vector<uint>(PackBgra(255, 255, 255, 0));
+            var alphaMask = new Vector<uint>(PackBgra(0, 0, 0, 255));
+            var blackVector = new Vector<uint>(black);
+            var whiteVector = new Vector<uint>(white);
+
+            var i = 0;
+            for (; i + step <= length; i += step)
+            {
+                var mask = Vector.AsVectorUInt32(Vector.GreaterThanOrEqual(new Vector<byte>(_bitmapData, i), thresholds));
+                // Brightness is the max of B/G/R, so any one of them clearing the threshold is enough.
+                var bright = ~Vector.Equals(mask & rgbMask, Vector<uint>.Zero);
+                var opaque = Vector.Equals(mask & alphaMask, alphaMask);
+                Vector.AsVectorByte(Vector.ConditionalSelect(bright & opaque, blackVector, whiteVector)).CopyTo(_bitmapData, i);
+            }
+
+            return i;
         }
 
         private static SKColor GetOutlineColor(SKColor borderColor)
@@ -1032,15 +1080,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         public void Fill(SKColor color)
         {
-            var buffer = new byte[4];
-            buffer[0] = color.Blue;
-            buffer[1] = color.Green;
-            buffer[2] = color.Red;
-            buffer[3] = color.Alpha;
-            for (int i = 0; i < _bitmapData.Length; i += 4)
-            {
-                Buffer.BlockCopy(buffer, 0, _bitmapData, i, 4);
-            }
+            MemoryMarshal.Cast<byte, uint>(_bitmapData.AsSpan()).Fill(PackBgra(color.Blue, color.Green, color.Red, color.Alpha));
         }
 
         public int GetAlpha(int x, int y)
@@ -1272,15 +1312,16 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         public void GrayScale()
         {
-            for (int i = 0; i < _bitmapData.Length; i += 4)
+            var data = _bitmapData.AsSpan();
+            for (int i = 0; i < data.Length; i += 4)
             {
-                int medium = Convert.ToInt32((_bitmapData[i + 2] + _bitmapData[i + 1] + _bitmapData[i]) * 1.5 / 3.0 + 2);
+                int medium = Convert.ToInt32((data[i + 2] + data[i + 1] + data[i]) * 1.5 / 3.0 + 2);
                 if (medium > byte.MaxValue)
                 {
                     medium = byte.MaxValue;
                 }
 
-                _bitmapData[i + 2] = _bitmapData[i + 1] = _bitmapData[i] = (byte)medium;
+                data[i + 2] = data[i + 1] = data[i] = (byte)medium;
             }
         }
 
@@ -1290,68 +1331,77 @@ namespace Nikse.SubtitleEdit.Core.Common
         /// <param name="minAlpha">Min alpha value, 0=transparent, 255=fully visible</param>
         public void MakeBackgroundTransparent(int minAlpha)
         {
-            var buffer = new byte[4];
-            buffer[0] = 0; // B
-            buffer[1] = 0; // G
-            buffer[2] = 0; // R
-            buffer[3] = 0; // A
-            for (int i = 0; i < _bitmapData.Length; i += 4)
+            var data = _bitmapData.AsSpan();
+            var pixels = MemoryMarshal.Cast<byte, uint>(_bitmapData.AsSpan());
+            for (int i = 0, p = 0; p < pixels.Length; i += 4, p++)
             {
-                if (_bitmapData[i + 3] < minAlpha)
+                if (data[i + 3] < minAlpha)
                 {
-                    Buffer.BlockCopy(buffer, 0, _bitmapData, i, 4);
+                    pixels[p] = 0;
                 }
             }
         }
 
         public void MakeTwoColor(int minRgb)
         {
-            var buffer = new byte[4];
-            buffer[0] = 0; // B
-            buffer[1] = 0; // G
-            buffer[2] = 0; // R
-            buffer[3] = 0; // A
-            var bufferWhite = new byte[4];
-            bufferWhite[0] = 255; // B
-            bufferWhite[1] = 255; // G
-            bufferWhite[2] = 255; // R
-            bufferWhite[3] = 255; // A
-            for (int i = 0; i < _bitmapData.Length; i += 4)
-            {
-                if (_bitmapData[i + 3] < 1 || _bitmapData[i + 0] + _bitmapData[i + 1] + _bitmapData[i + 2] < minRgb)
-                {
-                    Buffer.BlockCopy(buffer, 0, _bitmapData, i, 4);
-                }
-                else
-                {
-                    Buffer.BlockCopy(bufferWhite, 0, _bitmapData, i, 4);
-                }
-            }
+            MakeTwoColorPacked(minRgb, PackBgra(0, 0, 0, 0), PackBgra(255, 255, 255, 255));
         }
 
         public void MakeTwoColor(int minRgb, SKColor background, SKColor foreground)
         {
-            var bufferBackground = new byte[4];
-            bufferBackground[0] = background.Blue; // B
-            bufferBackground[1] = background.Green; // G
-            bufferBackground[2] = background.Red; // R
-            bufferBackground[3] = 255; // A
-            var bufferForeground = new byte[4];
-            bufferForeground[0] = foreground.Blue; // B
-            bufferForeground[1] = foreground.Green; // G
-            bufferForeground[2] = foreground.Red; // R
-            bufferForeground[3] = 255; // A
-            for (int i = 0; i < _bitmapData.Length; i += 4)
+            MakeTwoColorPacked(minRgb,
+                PackBgra(background.Blue, background.Green, background.Red, 255),
+                PackBgra(foreground.Blue, foreground.Green, foreground.Red, 255));
+        }
+
+        private void MakeTwoColorPacked(int minRgb, uint background, uint foreground)
+        {
+            var start = MakeTwoColorVector(minRgb, background, foreground);
+            var data = _bitmapData.AsSpan();
+            var pixels = MemoryMarshal.Cast<byte, uint>(_bitmapData.AsSpan());
+            for (int i = start, p = start / 4; p < pixels.Length; i += 4, p++)
             {
-                if (_bitmapData[i + 3] < 1 || _bitmapData[i + 0] + _bitmapData[i + 1] + _bitmapData[i + 2] < minRgb)
-                {
-                    Buffer.BlockCopy(bufferBackground, 0, _bitmapData, i, 4);
-                }
-                else
-                {
-                    Buffer.BlockCopy(bufferForeground, 0, _bitmapData, i, 4);
-                }
+                pixels[p] = data[i + 3] < 1 || data[i] + data[i + 1] + data[i + 2] < minRgb
+                    ? background
+                    : foreground;
             }
+        }
+
+        /// <summary>
+        /// Vector pass for <see cref="MakeTwoColorPacked"/>; returns the number of bytes it handled
+        /// so the caller finishes the tail one pixel at a time. Little-endian only: it reads the
+        /// channels out of the packed pixel by value, which the byte-order-neutral masks cannot do
+        /// once three of them have to be added together.
+        /// </summary>
+        private int MakeTwoColorVector(int minRgb, uint background, uint foreground)
+        {
+            var length = _bitmapData.Length;
+            var step = Vector<byte>.Count;
+            // The green and red channels come from re-reading the block one and two bytes along,
+            // so those extra bytes have to stay inside the array.
+            if (!Vector.IsHardwareAccelerated || !BitConverter.IsLittleEndian || minRgb < 0 || length < step + 2)
+            {
+                return 0;
+            }
+
+            var lowByte = new Vector<uint>(0x000000FFu);
+            var alphaMask = new Vector<uint>(0xFF000000u);
+            var limit = new Vector<uint>((uint)minRgb);
+            var backgroundVector = new Vector<uint>(background);
+            var foregroundVector = new Vector<uint>(foreground);
+
+            var i = 0;
+            for (; i + step + 2 <= length; i += step)
+            {
+                var raw = Vector.AsVectorUInt32(new Vector<byte>(_bitmapData, i));
+                var green = Vector.AsVectorUInt32(new Vector<byte>(_bitmapData, i + 1)) & lowByte;
+                var red = Vector.AsVectorUInt32(new Vector<byte>(_bitmapData, i + 2)) & lowByte;
+                var sum = (raw & lowByte) + green + red;
+                var isBackground = Vector.Equals(raw & alphaMask, Vector<uint>.Zero) | Vector.LessThan(sum, limit);
+                Vector.AsVectorByte(Vector.ConditionalSelect(isBackground, backgroundVector, foregroundVector)).CopyTo(_bitmapData, i);
+            }
+
+            return i;
         }
 
         private static readonly byte[] EmptyByteArray = new byte[100000];
@@ -1631,65 +1681,62 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         public void SetTransparentTo(SKColor transparent)
         {
-            var buffer = new byte[4];
-            buffer[0] = transparent.Blue;
-            buffer[1] = transparent.Green;
-            buffer[2] = transparent.Red;
-            buffer[3] = transparent.Alpha;
-            for (var i = 0; i < _bitmapData.Length; i += 4)
+            var replacement = PackBgra(transparent.Blue, transparent.Green, transparent.Red, transparent.Alpha);
+            var data = _bitmapData.AsSpan();
+            var pixels = MemoryMarshal.Cast<byte, uint>(_bitmapData.AsSpan());
+            for (int i = 0, p = 0; p < pixels.Length; i += 4, p++)
             {
-                if (_bitmapData[i + 3] == 0)
+                if (data[i + 3] == 0)
                 {
-                    Buffer.BlockCopy(buffer, 0, _bitmapData, i, 4);
+                    pixels[p] = replacement;
                 }
             }
         }
 
-        public void ChangeBrightness(decimal factor)
+        /// <summary>
+        /// Scaled value for every possible channel byte, so the decimal multiply runs 256 times
+        /// instead of once per channel per pixel.
+        /// </summary>
+        private static byte[] BuildScaleTable(decimal factor)
         {
+            var table = new byte[256];
             if (factor > 1)
             {
-                for (int i = 0; i < _bitmapData.Length; i += 4)
+                for (var v = 0; v < table.Length; v++)
                 {
-                    int r = _bitmapData[i + 2];
-                    int g = _bitmapData[i + 1];
-                    int b = _bitmapData[i];
-                    _bitmapData[i + 2] = (byte)Math.Min(byte.MaxValue, (int)(r * factor));
-                    _bitmapData[i + 1] = (byte)Math.Min(byte.MaxValue, (int)(g * factor));
-                    _bitmapData[i] = (byte)Math.Min(byte.MaxValue, (int)(b * factor));
+                    table[v] = (byte)Math.Min(byte.MaxValue, (int)(v * factor));
                 }
             }
             else
             {
-                for (int i = 0; i < _bitmapData.Length; i += 4)
+                for (var v = 0; v < table.Length; v++)
                 {
-                    int r = _bitmapData[i + 2];
-                    int g = _bitmapData[i + 1];
-                    int b = _bitmapData[i];
-                    _bitmapData[i + 2] = (byte)Math.Max(0, (int)(r * factor));
-                    _bitmapData[i + 1] = (byte)Math.Max(0, (int)(g * factor));
-                    _bitmapData[i] = (byte)Math.Max(0, (int)(b * factor));
+                    table[v] = (byte)Math.Max(0, (int)(v * factor));
                 }
+            }
+
+            return table;
+        }
+
+        public void ChangeBrightness(decimal factor)
+        {
+            var scale = BuildScaleTable(factor);
+            var data = _bitmapData.AsSpan();
+            for (int i = 0; i < data.Length; i += 4)
+            {
+                data[i + 2] = scale[data[i + 2]];
+                data[i + 1] = scale[data[i + 1]];
+                data[i] = scale[data[i]];
             }
         }
 
         public void ChangeAlpha(decimal factor)
         {
-            if (factor > 1)
+            var scale = BuildScaleTable(factor);
+            var data = _bitmapData.AsSpan();
+            for (int i = 0; i < data.Length; i += 4)
             {
-                for (int i = 0; i < _bitmapData.Length; i += 4)
-                {
-                    int a = _bitmapData[i + 3];
-                    _bitmapData[i + 3] = (byte)Math.Min(byte.MaxValue, (int)(a * factor));
-                }
-            }
-            else
-            {
-                for (int i = 0; i < _bitmapData.Length; i += 4)
-                {
-                    int a = _bitmapData[i + 3];
-                    _bitmapData[i + 3] = (byte)Math.Max(0, (int)(a * factor));
-                }
+                data[i + 3] = scale[data[i + 3]];
             }
         }
     }

--- a/src/libse/Common/NikseBitmap.cs
+++ b/src/libse/Common/NikseBitmap.cs
@@ -1170,42 +1170,63 @@ namespace Nikse.SubtitleEdit.Core.Common
             var palette = new List<SKColor> { SKColors.Transparent };
             var pixels = new byte[Width * Height];
 
-            for (int y = 0; y < Height; y++)
-            {
-                for (int x = 0; x < Width; x++)
-                {
-                    var c = GetPixel(x, y);
-                    if (c.Alpha < 5)
-                    {
-                        pixels[y * Width + x] = 0;
-                    }
-                    else
-                    {
-                        int index = FindBestMatch(c, palette, out var maxDiff);
+            // Exact-colour shortcut past the linear palette scan. Only outcomes a later scan is
+            // bound to repeat are cached: FindBestMatch stops at the first entry closer than 4 and
+            // the palette only ever grows at the end, so such a hit can never be overtaken; a
+            // colour that was just appended is found by that same early stop from then on; and once
+            // the palette is full at 255 entries nothing more is added, so every result is frozen.
+            // None of those outcomes appends to the palette, so a hit cannot skip an insertion.
+            var seen = new Dictionary<uint, byte>();
+            var data = _bitmapData.AsSpan();
+            var packed = MemoryMarshal.Cast<byte, uint>(_bitmapData.AsSpan());
 
-                        if (index == -1 && palette.Count < 255)
-                        {
-                            index = palette.Count;
-                            palette.Add(c);
-                            pixels[y * Width + x] = (byte)index;
-                        }
-                        else if (palette.Count < 200 && maxDiff > 5)
-                        {
-                            index = palette.Count;
-                            palette.Add(c);
-                            pixels[y * Width + x] = (byte)index;
-                        }
-                        else if (palette.Count < 255 && maxDiff > 15)
-                        {
-                            index = palette.Count;
-                            palette.Add(c);
-                            pixels[y * Width + x] = (byte)index;
-                        }
-                        else if (index >= 0)
-                        {
-                            pixels[y * Width + x] = (byte)index;
-                        }
-                    }
+            for (int p = 0, i = 0; p < pixels.Length; p++, i += 4)
+            {
+                var alpha = data[i + 3];
+                if (alpha < 5)
+                {
+                    pixels[p] = 0;
+                    continue;
+                }
+
+                if (seen.TryGetValue(packed[p], out var known))
+                {
+                    pixels[p] = known;
+                    continue;
+                }
+
+                var c = new SKColor(data[i + 2], data[i + 1], data[i], alpha);
+                var index = FindBestMatch(c, palette, out var maxDiff);
+                byte value;
+                bool repeatable;
+                if (index == -1 && palette.Count < 255)
+                {
+                    value = (byte)palette.Count;
+                    palette.Add(c);
+                    repeatable = true;
+                }
+                else if (palette.Count < 200 && maxDiff > 5)
+                {
+                    value = (byte)palette.Count;
+                    palette.Add(c);
+                    repeatable = true;
+                }
+                else if (palette.Count < 255 && maxDiff > 15)
+                {
+                    value = (byte)palette.Count;
+                    palette.Add(c);
+                    repeatable = true;
+                }
+                else
+                {
+                    value = index >= 0 ? (byte)index : (byte)0;
+                    repeatable = maxDiff < 4 || palette.Count >= 255;
+                }
+
+                pixels[p] = value;
+                if (repeatable)
+                {
+                    seen[packed[p]] = value;
                 }
             }
 

--- a/src/libse/Common/NikseBitmap.cs
+++ b/src/libse/Common/NikseBitmap.cs
@@ -1176,6 +1176,10 @@ namespace Nikse.SubtitleEdit.Core.Common
             // colour that was just appended is found by that same early stop from then on; and once
             // the palette is full at 255 entries nothing more is added, so every result is frozen.
             // None of those outcomes appends to the palette, so a hit cannot skip an insertion.
+            // The cache is capped because a photographic source can hold millions of distinct
+            // colours: past the cap the linear scan simply runs again, so the only thing lost is
+            // the shortcut. Subtitle bitmaps stay far below it.
+            const int maxCachedColors = 1 << 16;
             var seen = new Dictionary<uint, byte>();
             var data = _bitmapData.AsSpan();
             var packed = MemoryMarshal.Cast<byte, uint>(_bitmapData.AsSpan());
@@ -1224,7 +1228,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
 
                 pixels[p] = value;
-                if (repeatable)
+                if (repeatable && seen.Count < maxCachedColors)
                 {
                     seen[packed[p]] = value;
                 }
@@ -1721,18 +1725,24 @@ namespace Nikse.SubtitleEdit.Core.Common
         private static byte[] BuildScaleTable(decimal factor)
         {
             var table = new byte[256];
+
+            // The table covers every channel value, not only the ones the bitmap happens to hold,
+            // so a factor big enough to overflow the multiply or the int cast has to be clamped
+            // first. Nothing is lost by it: from 256 up every non-zero channel already saturates
+            // at 255, and any negative factor already floors at 0.
+            var scale = factor > 256m ? 256m : factor < 0m ? 0m : factor;
             if (factor > 1)
             {
                 for (var v = 0; v < table.Length; v++)
                 {
-                    table[v] = (byte)Math.Min(byte.MaxValue, (int)(v * factor));
+                    table[v] = (byte)Math.Min(byte.MaxValue, (int)(v * scale));
                 }
             }
             else
             {
                 for (var v = 0; v < table.Length; v++)
                 {
-                    table[v] = (byte)Math.Max(0, (int)(v * factor));
+                    table[v] = (byte)Math.Max(0, (int)(v * scale));
                 }
             }
 

--- a/src/libse/Common/VobSubColorIsolation.cs
+++ b/src/libse/Common/VobSubColorIsolation.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using SkiaSharp;
 
 namespace Nikse.SubtitleEdit.Core.Common
@@ -52,32 +53,20 @@ namespace Nikse.SubtitleEdit.Core.Common
             // anti-aliasing tiers that share a hue but differ in coverage still merge.
             var counts = new Dictionary<uint, int>();
             var borderCounts = new Dictionary<uint, int>();
-            for (var y = 0; y < height; y++)
+            var fastPixels = TryGetChannelOffsets(source, out var redOffset, out var blueOffset);
+            if (fastPixels)
             {
-                for (var x = 0; x < width; x++)
-                {
-                    var c = source.GetPixel(x, y);
-                    if (c.Alpha < alphaThreshold)
-                    {
-                        continue;
-                    }
-                    var key = (uint)((c.Red << 16) | (c.Green << 8) | c.Blue);
-                    counts[key] = counts.TryGetValue(key, out var n) ? n + 1 : 1;
-
-                    var nb = 0;
-                    if (x == 0 || source.GetPixel(x - 1, y).Alpha < alphaThreshold) { nb++; }
-                    if (x == width - 1 || source.GetPixel(x + 1, y).Alpha < alphaThreshold) { nb++; }
-                    if (y == 0 || source.GetPixel(x, y - 1).Alpha < alphaThreshold) { nb++; }
-                    if (y == height - 1 || source.GetPixel(x, y + 1).Alpha < alphaThreshold) { nb++; }
-                    if (nb > 0)
-                    {
-                        borderCounts[key] = borderCounts.TryGetValue(key, out var b) ? b + nb : nb;
-                    }
-                }
+                BuildHistogramDirect(source, alphaThreshold, redOffset, blueOffset, counts, borderCounts);
+            }
+            else
+            {
+                BuildHistogramViaGetPixel(source, alphaThreshold, counts, borderCounts);
             }
 
-            using var canvas = new SKCanvas(result);
-            canvas.Clear(SKColors.White);
+            using (var canvas = new SKCanvas(result))
+            {
+                canvas.Clear(SKColors.White);
+            }
 
             if (counts.Count == 0)
             {
@@ -141,18 +130,13 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
             }
 
-            using var paint = new SKPaint { Color = SKColors.Black };
-            for (var y = 0; y < height; y++)
+            if (fastPixels)
             {
-                for (var x = 0; x < width; x++)
-                {
-                    var c = source.GetPixel(x, y);
-                    if (c.Alpha >= alphaThreshold &&
-                        (uint)((c.Red << 16) | (c.Green << 8) | c.Blue) == foreground)
-                    {
-                        canvas.DrawPoint(x, y, paint);
-                    }
-                }
+                PaintForegroundDirect(source, result, alphaThreshold, redOffset, blueOffset, foreground);
+            }
+            else
+            {
+                PaintForegroundViaGetPixel(source, result, alphaThreshold, foreground);
             }
 
             return result;
@@ -178,13 +162,207 @@ namespace Nikse.SubtitleEdit.Core.Common
             var height = source.Height;
             var result = new SKBitmap(new SKImageInfo(width, height, SKColorType.Rgba8888, SKAlphaType.Opaque));
 
-            using var canvas = new SKCanvas(result);
-            canvas.Clear(SKColors.White);
+            using (var canvas = new SKCanvas(result))
+            {
+                canvas.Clear(SKColors.White);
+            }
 
-            using var paint = new SKPaint { Color = SKColors.Black };
+            if (TryGetChannelOffsets(source, out var redOffset, out var blueOffset))
+            {
+                BinarizeDirect(source, result, brightnessThreshold, alphaThreshold, redOffset, blueOffset);
+            }
+            else
+            {
+                BinarizeViaGetPixel(source, result, brightnessThreshold, alphaThreshold);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Byte offsets of red and blue inside a 4-byte pixel for the color types we can read
+        /// raw; green is always byte 1 and alpha always byte 3, so only red/blue swap. Returns
+        /// false when the pixels must go through <see cref="SKBitmap.GetPixel"/> instead:
+        /// premultiplied bitmaps get un-premultiplied by GetPixel, and any other color type has
+        /// a layout this shortcut does not know.
+        /// </summary>
+        private static bool TryGetChannelOffsets(SKBitmap bitmap, out int redOffset, out int blueOffset)
+        {
+            redOffset = 0;
+            blueOffset = 0;
+            if (bitmap.AlphaType == SKAlphaType.Premul || bitmap.GetPixels() == IntPtr.Zero)
+            {
+                return false;
+            }
+
+            switch (bitmap.ColorType)
+            {
+                case SKColorType.Bgra8888:
+                    redOffset = 2;
+                    blueOffset = 0;
+                    return true;
+                case SKColorType.Rgba8888:
+                    redOffset = 0;
+                    blueOffset = 2;
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        private static unsafe void BuildHistogramDirect(SKBitmap source, byte alphaThreshold, int redOffset, int blueOffset, Dictionary<uint, int> counts, Dictionary<uint, int> borderCounts)
+        {
+            var width = source.Width;
+            var height = source.Height;
+            var rowBytes = source.RowBytes;
+            var basePtr = (byte*)source.GetPixels().ToPointer();
+
+            for (var y = 0; y < height; y++)
+            {
+                var row = new ReadOnlySpan<byte>(basePtr + (long)y * rowBytes, rowBytes);
+                var above = y > 0 ? new ReadOnlySpan<byte>(basePtr + (long)(y - 1) * rowBytes, rowBytes) : default;
+                var below = y < height - 1 ? new ReadOnlySpan<byte>(basePtr + (long)(y + 1) * rowBytes, rowBytes) : default;
+
+                for (var x = 0; x < width; x++)
+                {
+                    var i = x * 4;
+                    if (row[i + 3] < alphaThreshold)
+                    {
+                        continue;
+                    }
+
+                    var key = (uint)((row[i + redOffset] << 16) | (row[i + 1] << 8) | row[i + blueOffset]);
+                    counts[key] = counts.TryGetValue(key, out var n) ? n + 1 : 1;
+
+                    var nb = 0;
+                    if (x == 0 || row[i - 4 + 3] < alphaThreshold) { nb++; }
+                    if (x == width - 1 || row[i + 4 + 3] < alphaThreshold) { nb++; }
+                    if (y == 0 || above[i + 3] < alphaThreshold) { nb++; }
+                    if (y == height - 1 || below[i + 3] < alphaThreshold) { nb++; }
+                    if (nb > 0)
+                    {
+                        borderCounts[key] = borderCounts.TryGetValue(key, out var b) ? b + nb : nb;
+                    }
+                }
+            }
+        }
+
+        private static void BuildHistogramViaGetPixel(SKBitmap source, byte alphaThreshold, Dictionary<uint, int> counts, Dictionary<uint, int> borderCounts)
+        {
+            var width = source.Width;
+            var height = source.Height;
             for (var y = 0; y < height; y++)
             {
                 for (var x = 0; x < width; x++)
+                {
+                    var c = source.GetPixel(x, y);
+                    if (c.Alpha < alphaThreshold)
+                    {
+                        continue;
+                    }
+                    var key = (uint)((c.Red << 16) | (c.Green << 8) | c.Blue);
+                    counts[key] = counts.TryGetValue(key, out var n) ? n + 1 : 1;
+
+                    var nb = 0;
+                    if (x == 0 || source.GetPixel(x - 1, y).Alpha < alphaThreshold) { nb++; }
+                    if (x == width - 1 || source.GetPixel(x + 1, y).Alpha < alphaThreshold) { nb++; }
+                    if (y == 0 || source.GetPixel(x, y - 1).Alpha < alphaThreshold) { nb++; }
+                    if (y == height - 1 || source.GetPixel(x, y + 1).Alpha < alphaThreshold) { nb++; }
+                    if (nb > 0)
+                    {
+                        borderCounts[key] = borderCounts.TryGetValue(key, out var b) ? b + nb : nb;
+                    }
+                }
+            }
+        }
+
+        private static unsafe void PaintForegroundDirect(SKBitmap source, SKBitmap result, byte alphaThreshold, int redOffset, int blueOffset, uint foreground)
+        {
+            var width = source.Width;
+            var height = source.Height;
+            var srcRowBytes = source.RowBytes;
+            var srcPtr = (byte*)source.GetPixels().ToPointer();
+            var dstRowBytes = result.RowBytes;
+            var dstPtr = (byte*)result.GetPixels().ToPointer();
+            var black = OpaqueBlack();
+
+            for (var y = 0; y < height; y++)
+            {
+                var row = new ReadOnlySpan<byte>(srcPtr + (long)y * srcRowBytes, srcRowBytes);
+                var dst = new Span<uint>(dstPtr + (long)y * dstRowBytes, width);
+                for (var x = 0; x < width; x++)
+                {
+                    var i = x * 4;
+                    if (row[i + 3] >= alphaThreshold &&
+                        (uint)((row[i + redOffset] << 16) | (row[i + 1] << 8) | row[i + blueOffset]) == foreground)
+                    {
+                        dst[x] = black;
+                    }
+                }
+            }
+        }
+
+        private static void PaintForegroundViaGetPixel(SKBitmap source, SKBitmap result, byte alphaThreshold, uint foreground)
+        {
+            using var canvas = new SKCanvas(result);
+            using var paint = new SKPaint { Color = SKColors.Black };
+            for (var y = 0; y < source.Height; y++)
+            {
+                for (var x = 0; x < source.Width; x++)
+                {
+                    var c = source.GetPixel(x, y);
+                    if (c.Alpha >= alphaThreshold &&
+                        (uint)((c.Red << 16) | (c.Green << 8) | c.Blue) == foreground)
+                    {
+                        canvas.DrawPoint(x, y, paint);
+                    }
+                }
+            }
+        }
+
+        private static unsafe void BinarizeDirect(SKBitmap source, SKBitmap result, int brightnessThreshold, byte alphaThreshold, int redOffset, int blueOffset)
+        {
+            var width = source.Width;
+            var height = source.Height;
+            var srcRowBytes = source.RowBytes;
+            var srcPtr = (byte*)source.GetPixels().ToPointer();
+            var dstRowBytes = result.RowBytes;
+            var dstPtr = (byte*)result.GetPixels().ToPointer();
+            var black = OpaqueBlack();
+
+            for (var y = 0; y < height; y++)
+            {
+                var row = new ReadOnlySpan<byte>(srcPtr + (long)y * srcRowBytes, srcRowBytes);
+                var dst = new Span<uint>(dstPtr + (long)y * dstRowBytes, width);
+                for (var x = 0; x < width; x++)
+                {
+                    var i = x * 4;
+                    if (row[i + 3] < alphaThreshold)
+                    {
+                        continue;
+                    }
+
+                    int red = row[i + redOffset];
+                    int green = row[i + 1];
+                    int blue = row[i + blueOffset];
+                    var brightness = red > green
+                        ? (red > blue ? red : blue)
+                        : (green > blue ? green : blue);
+                    if (brightness >= brightnessThreshold)
+                    {
+                        dst[x] = black;
+                    }
+                }
+            }
+        }
+
+        private static void BinarizeViaGetPixel(SKBitmap source, SKBitmap result, int brightnessThreshold, byte alphaThreshold)
+        {
+            using var canvas = new SKCanvas(result);
+            using var paint = new SKPaint { Color = SKColors.Black };
+            for (var y = 0; y < source.Height; y++)
+            {
+                for (var x = 0; x < source.Width; x++)
                 {
                     var c = source.GetPixel(x, y);
                     if (c.Alpha < alphaThreshold)
@@ -201,8 +379,17 @@ namespace Nikse.SubtitleEdit.Core.Common
                     }
                 }
             }
+        }
 
-            return result;
+        /// <summary>
+        /// Opaque black as one packed pixel of the Rgba8888 result bitmap (bytes 0, 0, 0, 255),
+        /// built through the byte layout so the constant is correct on either endianness.
+        /// </summary>
+        private static uint OpaqueBlack()
+        {
+            Span<byte> bytes = stackalloc byte[4];
+            bytes[3] = 255;
+            return MemoryMarshal.Read<uint>(bytes);
         }
     }
 }

--- a/tests/libse/BluRaySup/SkiaExtTrimTest.cs
+++ b/tests/libse/BluRaySup/SkiaExtTrimTest.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Nikse.SubtitleEdit.Core.BluRaySup;
 using SkiaSharp;
 
@@ -131,5 +132,46 @@ public class SkiaExtTrimTest
         Assert.Equal(5, cropped.Height);
         Assert.Equal(255, cropped.GetPixel(2, 2).Alpha);
         Assert.Equal(0, cropped.GetPixel(0, 0).Alpha);
+    }
+
+    [Fact]
+    public void GetNonTransparentHeightAndWidth_SpanTheDrawnPixels()
+    {
+        using var bitmap = MakeBitmap(40, 20, (6, 3, 255), (31, 14, 255));
+
+        Assert.Equal(14 - 3 + 1, bitmap.GetNonTransparentHeight());
+        Assert.Equal(31 - 6 + 1, bitmap.GetNonTransparentWidth());
+    }
+
+    [Fact]
+    public void GetNonTransparentHeightAndWidth_FullyTransparentIsZero()
+    {
+        using var bitmap = MakeBitmap(33, 9);
+
+        Assert.Equal(0, bitmap.GetNonTransparentHeight());
+        Assert.Equal(0, bitmap.GetNonTransparentWidth());
+    }
+
+    // Rgb888x is four bytes per pixel but has no alpha channel: the fourth byte is padding that
+    // GetPixel ignores, so every pixel is opaque no matter what that byte holds. Reading it as
+    // alpha would call a bitmap with zeroed padding empty.
+    [Fact]
+    public void GetNonTransparentHeightAndWidth_Rgb888xHasNoAlphaByte()
+    {
+        using var bitmap = new SKBitmap(new SKImageInfo(6, 4, SKColorType.Rgb888x, SKAlphaType.Opaque));
+        var pixels = new byte[bitmap.ByteCount];
+        for (var i = 0; i < pixels.Length; i += 4)
+        {
+            pixels[i] = 200;     // R
+            pixels[i + 1] = 100; // G
+            pixels[i + 2] = 50;  // B
+            pixels[i + 3] = 0;   // padding, not alpha
+        }
+
+        Marshal.Copy(pixels, 0, bitmap.GetPixels(), pixels.Length);
+
+        Assert.Equal(255, bitmap.GetPixel(0, 0).Alpha);
+        Assert.Equal(4, bitmap.GetNonTransparentHeight());
+        Assert.Equal(6, bitmap.GetNonTransparentWidth());
     }
 }


### PR DESCRIPTION
## Summary
- VobSubColorIsolation: replace up to 5 `SKBitmap.GetPixel` interop calls per pixel (pixel + 4 neighbours) and per-pixel `DrawPoint` rendering with row-span reads and direct pixel writes; gated to non-premultiplied Bgra8888/Rgba8888 with the original GetPixel path kept as fallback for other layouts
- NikseBitmap: fourteen whole-buffer BGRA loops now write one packed uint per pixel instead of a 4-byte `Buffer.BlockCopy`; `MakeBlackAndWhiteForOcr` and `MakeTwoColor` additionally get a `System.Numerics.Vector<T>` pass (netstandard2.1-compatible, endian-safe packed constants, scalar tail)
- SkiaExt: `GetNonTransparentHeight`/`GetNonTransparentWidth` reuse the existing pointer-based `GetNonTransparentBounds` scan instead of per-pixel `GetPixel` (the width scan was column-major on top of the interop cost)
- `ConvertTo8BitsPerPixel`: exact-colour dictionary cache in front of the linear palette scan; only provably-stable outcomes are cached, so palette contents, insertion order and the index buffer are unchanged
- BluRaySupPicture: RLE encode and both palette passes read whole rows via a small row reader instead of calling `GetPixel` per pixel of every run

Output is bit-identical everywhere: each change was verified against the original implementation with byte-comparison harnesses (all colour types incl. premul fallbacks, exhaustive 256-threshold and 767-minRgb sweeps for the Vector paths, palette + RLE byte comparison for the sup encoder).

## Benchmarks

A/B vs the branch base commit, same harness binary for both sides, median of 5 samples after warmup (ms/op; 1920×1080 bitmaps, 1920×200 for the VobSub/palette rows; Release, net10.0, AVX2):

| Method | before | after | speedup |
|---|---|---|---|
| SkiaExt.GetNonTransparentHeight+Width | 55.76 | 0.54 | 104× |
| VobSubColorIsolation.BinarizeForOcr | 34.60 | 0.71 | 49× |
| NikseBitmap.MakeBlackAndWhiteForOcr | 10.00 | 0.29 | 35× |
| NikseBitmap.Fill | 7.97 | 0.35 | 23× |
| NikseBitmap.MakeTwoColor(300) | 9.84 | 0.56 | 18× |
| VobSubColorIsolation.Isolate | 23.17 | 2.89 | 8× |
| NikseBitmap.ConvertTo8BitsPerPixel | 6.54 | 1.56 | 4.2× |
| NikseBitmap.InvertColors | 2.27 | 0.75 | 3.0× |
| NikseBitmap.GrayScale | 7.37 | 6.64 | 1.1× (float math kept verbatim; only memory access changed) |

## Test plan
- [ ] `dotnet build src/libse/LibSE.csproj` succeeds for both netstandard2.1 and net10.0
- [ ] `dotnet test tests/libse/LibSETests.csproj` passes
- [ ] `dotnet test tests/seconv/SeConvTests.csproj` passes (covers ImageToImage, VobSubColorIsolation, VobSub extraction, OCR)
- [ ] Batch-OCR a VobSub sample and export a Blu-ray .sup; output matches main byte-for-byte

🤖 Generated with [Claude Code](https://claude.com/claude-code)