### PR TITLE
Speed up per-line text scanning hot paths

### DIFF
--- a/src/libse/Common/HtmlUtil.cs
+++ b/src/libse/Common/HtmlUtil.cs
@@ -565,21 +565,36 @@ namespace Nikse.SubtitleEdit.Core.Common
                 int arrayIndex = 0;
                 ReadOnlySpan<char> span = s.AsSpan();
 
+                // Hop from '<' to '<' and bulk-copy the stretch in between instead of
+                // testing every char - most of a subtitle line is plain text.
                 for (var i = 0; i < span.Length;)
                 {
-                    // If we hit an opening bracket, check if it's a target tag
-                    if (span[i] == '<')
+                    var rest = span.Slice(i);
+                    var tagStart = rest.IndexOf('<');
+                    if (tagStart < 0)
                     {
-                        if (TryGetTagLength(span.Slice(i), out int tagLength))
-                        {
-                            i += tagLength;
-                            continue;
-                        }
+                        rest.CopyTo(buffer.Slice(arrayIndex));
+                        arrayIndex += rest.Length;
+                        break;
                     }
 
-                    // Normal character processing
-                    buffer[arrayIndex++] = span[i];
-                    i++;
+                    if (tagStart > 0)
+                    {
+                        rest.Slice(0, tagStart).CopyTo(buffer.Slice(arrayIndex));
+                        arrayIndex += tagStart;
+                        i += tagStart;
+                    }
+
+                    if (TryGetTagLength(span.Slice(i), out int tagLength))
+                    {
+                        i += tagLength;
+                    }
+                    else
+                    {
+                        // A '<' that does not start a known tag is kept as-is
+                        buffer[arrayIndex++] = '<';
+                        i++;
+                    }
                 }
 
                 // Nothing was stripped (e.g. a stray '<' that is not a known tag);

--- a/src/libse/Common/LanguageAutoDetect.cs
+++ b/src/libse/Common/LanguageAutoDetect.cs
@@ -1998,34 +1998,52 @@ namespace Nikse.SubtitleEdit.Core.Common
             couldBeUtf8 = false;
             var utf8Count = 0;
             var i = 0;
-            while (i < buffer.Length - 3)
+            var max = buffer.Length - 3;
+            while (i < max)
             {
                 byte b = buffer[i];
-                if (b > 127)
+                if (b <= 127)
                 {
-                    if (b >= 194 && b <= 223 && buffer[i + 1] >= 128 && buffer[i + 1] <= 191)
-                    { // 2-byte sequence
-                        utf8Count++;
-                        i++;
-                    }
-                    else if (b >= 224 && b <= 239 && buffer[i + 1] >= 128 && buffer[i + 1] <= 191 &&
-                                                     buffer[i + 2] >= 128 && buffer[i + 2] <= 191)
-                    { // 3-byte sequence
-                        utf8Count++;
-                        i += 2;
-                    }
-                    else if (b >= 240 && b <= 244 && buffer[i + 1] >= 128 && buffer[i + 1] <= 191 &&
-                                                     buffer[i + 2] >= 128 && buffer[i + 2] <= 191 &&
-                                                     buffer[i + 3] >= 128 && buffer[i + 3] <= 191)
-                    { // 4-byte sequence
-                        utf8Count++;
-                        i += 3;
-                    }
-                    else
+                    // Called with up to 500 KB of a subtitle file, which is nearly all plain
+                    // ASCII - those bytes only advance the cursor, so jump straight to the
+                    // next byte that actually needs validating.
+#if NET8_0_OR_GREATER
+                    var next = buffer.AsSpan(i + 1).IndexOfAnyExceptInRange((byte)0, (byte)127);
+                    if (next < 0)
                     {
-                        return false;
+                        break;
                     }
+
+                    i += next + 1;
+#else
+                    i++;
+#endif
+                    continue;
                 }
+
+                if (b >= 194 && b <= 223 && buffer[i + 1] >= 128 && buffer[i + 1] <= 191)
+                { // 2-byte sequence
+                    utf8Count++;
+                    i++;
+                }
+                else if (b >= 224 && b <= 239 && buffer[i + 1] >= 128 && buffer[i + 1] <= 191 &&
+                                                 buffer[i + 2] >= 128 && buffer[i + 2] <= 191)
+                { // 3-byte sequence
+                    utf8Count++;
+                    i += 2;
+                }
+                else if (b >= 240 && b <= 244 && buffer[i + 1] >= 128 && buffer[i + 1] <= 191 &&
+                                                 buffer[i + 2] >= 128 && buffer[i + 2] <= 191 &&
+                                                 buffer[i + 3] >= 128 && buffer[i + 3] <= 191)
+                { // 4-byte sequence
+                    utf8Count++;
+                    i += 3;
+                }
+                else
+                {
+                    return false;
+                }
+
                 i++;
             }
 

--- a/src/libse/Common/StringExtensions.cs
+++ b/src/libse/Common/StringExtensions.cs
@@ -556,6 +556,36 @@ namespace Nikse.SubtitleEdit.Core.Common
         public static string RemoveControlCharactersButWhiteSpace(this string s)
         {
             var max = s.Length;
+
+            // The removed set is char.IsControl minus CR/LF/TAB, i.e. U+0000-U+0008,
+            // U+000B-U+000C, U+000E-U+001F and U+007F-U+009F; almost no line contains any
+            // of those, so return the original instance without allocating a copy.
+            var span = s.AsSpan();
+#if NET8_0_OR_GREATER
+            if (!span.ContainsAnyInRange('\u0000', '\u0008') &&
+                !span.ContainsAnyInRange('\u000B', '\u000C') &&
+                !span.ContainsAnyInRange('\u000E', '\u001F') &&
+                !span.ContainsAnyInRange('\u007F', '\u009F'))
+            {
+                return s;
+            }
+#else
+            var hasControl = false;
+            foreach (var c in span)
+            {
+                if (char.IsControl(c) && c != '\u000d' && c != '\u000a' && c != '\u0009')
+                {
+                    hasControl = true;
+                    break;
+                }
+            }
+
+            if (!hasControl)
+            {
+                return s;
+            }
+#endif
+
             var newStr = new char[max];
             var newIdx = 0;
             for (int index = 0; index < max; index++)

--- a/src/libse/Common/StringExtensions.cs
+++ b/src/libse/Common/StringExtensions.cs
@@ -220,33 +220,8 @@ namespace Nikse.SubtitleEdit.Core.Common
             // instead of allocating a separator array plus one substring per word.
             var text = HtmlUtil.RemoveHtmlTags(source, true);
             var count = 0;
-            var max = text.Length;
-#if NET8_0_OR_GREATER
-            // Hop from each word start to the next separator instead of testing every char.
-            var span = text.AsSpan();
-            var i = 0;
-            while (i < max)
-            {
-                var wordStart = span.Slice(i).IndexOfAnyExcept(' ', '\n', '\r');
-                if (wordStart < 0)
-                {
-                    break;
-                }
-
-                count++;
-                i += wordStart;
-
-                var separator = span.Slice(i).IndexOfAny(' ', '\n', '\r');
-                if (separator < 0)
-                {
-                    break;
-                }
-
-                i += separator;
-            }
-#else
             var inWord = false;
-            for (var i = 0; i < max; i++)
+            for (var i = 0; i < text.Length; i++)
             {
                 var ch = text[i];
                 if (ch == ' ' || ch == '\n' || ch == '\r')
@@ -259,7 +234,6 @@ namespace Nikse.SubtitleEdit.Core.Common
                     count++;
                 }
             }
-#endif
 
             return count;
         }

--- a/src/libse/Common/StringExtensions.cs
+++ b/src/libse/Common/StringExtensions.cs
@@ -220,8 +220,33 @@ namespace Nikse.SubtitleEdit.Core.Common
             // instead of allocating a separator array plus one substring per word.
             var text = HtmlUtil.RemoveHtmlTags(source, true);
             var count = 0;
+            var max = text.Length;
+#if NET8_0_OR_GREATER
+            // Hop from each word start to the next separator instead of testing every char.
+            var span = text.AsSpan();
+            var i = 0;
+            while (i < max)
+            {
+                var wordStart = span.Slice(i).IndexOfAnyExcept(' ', '\n', '\r');
+                if (wordStart < 0)
+                {
+                    break;
+                }
+
+                count++;
+                i += wordStart;
+
+                var separator = span.Slice(i).IndexOfAny(' ', '\n', '\r');
+                if (separator < 0)
+                {
+                    break;
+                }
+
+                i += separator;
+            }
+#else
             var inWord = false;
-            for (var i = 0; i < text.Length; i++)
+            for (var i = 0; i < max; i++)
             {
                 var ch = text[i];
                 if (ch == ' ' || ch == '\n' || ch == '\r')
@@ -234,6 +259,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                     count++;
                 }
             }
+#endif
 
             return count;
         }

--- a/src/libse/Common/TextLengthCalculator/CalcAll.cs
+++ b/src/libse/Common/TextLengthCalculator/CalcAll.cs
@@ -11,35 +11,19 @@ namespace Nikse.SubtitleEdit.Core.Common.TextLengthCalculator
         {
             var s = HtmlUtil.RemoveHtmlTags(text, true);
 
-            // Fast path: runs per grid-row repaint, per keystroke and per waveform frame, so
-            // avoid StringInfo.GetTextElementEnumerator's heap allocation and culture-aware
-            // grapheme walk when it cannot matter. Everything that can make a text element
-            // longer than one char (combining marks, ZWJ, prepend characters, surrogates) or
-            // hit the skip list below (zero-width/BiDi controls) is >= U+0300 - except "\r\n",
-            // whose chars are both controls and thus not counted either way - so counting
-            // non-controls below U+0300 is identical. U+2010-U+2027 (typographic dashes,
-            // curly quotes, ellipsis - common in professional subs) are plain punctuation,
-            // never part of a longer element and not in the skip list, so count them too;
-            // any other char >= U+0300 falls back to the full text-element walk.
-            var simpleLength = 0;
-            var isSimple = true;
-            for (var i = 0; i < s.Length; i++)
+            // Fast path: both chars of the "\r\n" the probe lets through are controls and so
+            // are not counted here either way, matching the element != "\r\n" test below.
+            if (TextElements.AreAllSingleChar(s, out _))
             {
-                var c = s[i];
-                if (c >= '\u0300' && (c < '\u2010' || c > '\u2027'))
+                var simpleLength = 0;
+                foreach (var c in s)
                 {
-                    isSimple = false;
-                    break;
+                    if (!char.IsControl(c))
+                    {
+                        simpleLength++;
+                    }
                 }
 
-                if (!char.IsControl(c))
-                {
-                    simpleLength++;
-                }
-            }
-
-            if (isSimple)
-            {
                 return simpleLength;
             }
 

--- a/src/libse/Common/TextLengthCalculator/CalcAll.cs
+++ b/src/libse/Common/TextLengthCalculator/CalcAll.cs
@@ -11,19 +11,35 @@ namespace Nikse.SubtitleEdit.Core.Common.TextLengthCalculator
         {
             var s = HtmlUtil.RemoveHtmlTags(text, true);
 
-            // Fast path: both chars of the "\r\n" the probe lets through are controls and so
-            // are not counted here either way, matching the element != "\r\n" test below.
-            if (TextElements.AreAllSingleChar(s, out _))
+            // Fast path: runs per grid-row repaint, per keystroke and per waveform frame, so
+            // avoid StringInfo.GetTextElementEnumerator's heap allocation and culture-aware
+            // grapheme walk when it cannot matter. Everything that can make a text element
+            // longer than one char (combining marks, ZWJ, prepend characters, surrogates) or
+            // hit the skip list below (zero-width/BiDi controls) is >= U+0300 - except "\r\n",
+            // whose chars are both controls and thus not counted either way - so counting
+            // non-controls below U+0300 is identical. U+2010-U+2027 (typographic dashes,
+            // curly quotes, ellipsis - common in professional subs) are plain punctuation,
+            // never part of a longer element and not in the skip list, so count them too;
+            // any other char >= U+0300 falls back to the full text-element walk.
+            var simpleLength = 0;
+            var isSimple = true;
+            for (var i = 0; i < s.Length; i++)
             {
-                var simpleLength = 0;
-                foreach (var c in s)
+                var c = s[i];
+                if (c >= '\u0300' && (c < '\u2010' || c > '\u2027'))
                 {
-                    if (!char.IsControl(c))
-                    {
-                        simpleLength++;
-                    }
+                    isSimple = false;
+                    break;
                 }
 
+                if (!char.IsControl(c))
+                {
+                    simpleLength++;
+                }
+            }
+
+            if (isSimple)
+            {
                 return simpleLength;
             }
 

--- a/src/libse/Common/TextLengthCalculator/CalcIncludeCompositionCharacters.cs
+++ b/src/libse/Common/TextLengthCalculator/CalcIncludeCompositionCharacters.cs
@@ -11,6 +11,23 @@ namespace Nikse.SubtitleEdit.Core.Common.TextLengthCalculator
         {
             var s = HtmlUtil.RemoveHtmlTags(text, true);
 
+            // Fast path: the Arabic composition characters excluded below are all >= U+0300
+            // and so cannot pass the probe; "\r\n" can, and this calculator scores a
+            // multi-char element by its length, hence the two per pair.
+            if (TextElements.AreAllSingleChar(s, out var crLfCount))
+            {
+                var simpleLength = 0;
+                foreach (var c in s)
+                {
+                    if (!char.IsControl(c))
+                    {
+                        simpleLength++;
+                    }
+                }
+
+                return simpleLength + crLfCount * 2;
+            }
+
             const char zeroWidthSpace = '\u200B';
             const char zeroWidthNoBreakSpace = '\uFEFF';
             var length = 0;

--- a/src/libse/Common/TextLengthCalculator/CalcIncludeCompositionCharactersNotSpace.cs
+++ b/src/libse/Common/TextLengthCalculator/CalcIncludeCompositionCharactersNotSpace.cs
@@ -11,6 +11,23 @@ namespace Nikse.SubtitleEdit.Core.Common.TextLengthCalculator
         {
             var s = HtmlUtil.RemoveHtmlTags(text, true);
 
+            // Fast path: the Arabic composition characters excluded below are all >= U+0300
+            // and so cannot pass the probe; "\r\n" can, and this calculator scores a
+            // multi-char element by its length, hence the two per pair.
+            if (TextElements.AreAllSingleChar(s, out var crLfCount))
+            {
+                var simpleLength = 0;
+                foreach (var c in s)
+                {
+                    if (!char.IsControl(c) && c != ' ')
+                    {
+                        simpleLength++;
+                    }
+                }
+
+                return simpleLength + crLfCount * 2;
+            }
+
             const char zeroWidthSpace = '\u200B';
             const char zeroWidthNoBreakSpace = '\uFEFF';
             var length = 0;

--- a/src/libse/Common/TextLengthCalculator/CalcNoSpace.cs
+++ b/src/libse/Common/TextLengthCalculator/CalcNoSpace.cs
@@ -11,6 +11,22 @@ namespace Nikse.SubtitleEdit.Core.Common.TextLengthCalculator
         {
             var s = HtmlUtil.RemoveHtmlTags(text, true);
 
+            // Fast path: both chars of the "\r\n" the probe lets through are controls and so
+            // are not counted here either way, matching the element != "\r\n" test below.
+            if (TextElements.AreAllSingleChar(s, out _))
+            {
+                var simpleLength = 0;
+                foreach (var c in s)
+                {
+                    if (!char.IsControl(c) && c != ' ')
+                    {
+                        simpleLength++;
+                    }
+                }
+
+                return simpleLength;
+            }
+
             const char zeroWidthSpace = '\u200B';
             const char zeroWidthNoBreakSpace = '\uFEFF';
             var length = 0;

--- a/src/libse/Common/TextLengthCalculator/CalcNoSpaceOrPunctuation.cs
+++ b/src/libse/Common/TextLengthCalculator/CalcNoSpaceOrPunctuation.cs
@@ -11,51 +11,30 @@ namespace Nikse.SubtitleEdit.Core.Common.TextLengthCalculator
         {
             var s = HtmlUtil.RemoveHtmlTags(text, true);
 
-            const char zeroWidthSpace = '\u200B';
-            const char zeroWidthNoBreakSpace = '\uFEFF';
+            // Fast path: the same test as the single-char branch below, plus one per "\r\n" -
+            // the only multi-char element that can pass the probe, and any multi-char element
+            // counts as one here.
+            if (TextElements.AreAllSingleChar(s, out var crLfCount))
+            {
+                var simpleLength = 0;
+                foreach (var c in s)
+                {
+                    if (IsCounted(c))
+                    {
+                        simpleLength++;
+                    }
+                }
+
+                return simpleLength + crLfCount;
+            }
+
             var length = 0;
             for (var en = StringInfo.GetTextElementEnumerator(s); en.MoveNext();)
             {
                 var element = en.GetTextElement();
                 if (element.Length == 1)
                 {
-                    var ch = element[0];
-                    if (!char.IsControl(ch) &&
-                        ch != ' ' &&
-                        ch != '\t' &&
-                        ch != zeroWidthSpace &&
-                        ch != zeroWidthNoBreakSpace &&
-                        ch != '\u200E' &&
-                        ch != '\u200F' &&
-                        ch != '\u202A' &&
-                        ch != '\u202B' &&
-                        ch != '\u202C' &&
-                        ch != '\u202D' &&
-                        ch != '\u202E' &&
-                        ch != '\u02F8' &&// ˸ Modifier Letter Raised Colon (\u02F8)
-                        ch != '\uFF1A' && // ： Fullwidth Colon (\uFF1A)
-                        ch != '\uFE13' && // ︓ Presentation Form for Vertical Colon (\uFE13)
-                        ch != '\u2043' && // ⁃ Hyphen bullet (\u2043)
-                        ch != '\u2010' && // ‐ Hyphen (\u2010)
-                        ch != '\u2012' && // ‒ Figure dash (\u2012)
-                        ch != '\u2013' && // – En dash (\u2013)
-                        ch != '-' &&
-                        ch != '\'' &&
-                        ch != '"' &&
-                        ch != ':' &&
-                        ch != '(' &&
-                        ch != ')' &&
-                        ch != '{' &&
-                        ch != '}' &&
-                        ch != '[' &&
-                        ch != ']' &&
-                        ch != '…' &&
-                        ch != ',' &&
-                        ch != '.' &&
-                        ch != '!' &&
-                        ch != '?' &&
-                        ch != '¡' &&
-                        ch != '¿')
+                    if (IsCounted(element[0]))
                     {
                         length++;
                     }
@@ -67,6 +46,48 @@ namespace Nikse.SubtitleEdit.Core.Common.TextLengthCalculator
             }
 
             return length;
+        }
+
+        private static bool IsCounted(char ch)
+        {
+            const char zeroWidthSpace = '\u200B';
+            const char zeroWidthNoBreakSpace = '\uFEFF';
+            return !char.IsControl(ch) &&
+                   ch != ' ' &&
+                   ch != '\t' &&
+                   ch != zeroWidthSpace &&
+                   ch != zeroWidthNoBreakSpace &&
+                   ch != '\u200E' &&
+                   ch != '\u200F' &&
+                   ch != '\u202A' &&
+                   ch != '\u202B' &&
+                   ch != '\u202C' &&
+                   ch != '\u202D' &&
+                   ch != '\u202E' &&
+                   ch != '\u02F8' &&// ˸ Modifier Letter Raised Colon (\u02F8)
+                   ch != '\uFF1A' && // ： Fullwidth Colon (\uFF1A)
+                   ch != '\uFE13' && // ︓ Presentation Form for Vertical Colon (\uFE13)
+                   ch != '\u2043' && // ⁃ Hyphen bullet (\u2043)
+                   ch != '\u2010' && // ‐ Hyphen (\u2010)
+                   ch != '\u2012' && // ‒ Figure dash (\u2012)
+                   ch != '\u2013' && // – En dash (\u2013)
+                   ch != '-' &&
+                   ch != '\'' &&
+                   ch != '"' &&
+                   ch != ':' &&
+                   ch != '(' &&
+                   ch != ')' &&
+                   ch != '{' &&
+                   ch != '}' &&
+                   ch != '[' &&
+                   ch != ']' &&
+                   ch != '…' &&
+                   ch != ',' &&
+                   ch != '.' &&
+                   ch != '!' &&
+                   ch != '?' &&
+                   ch != '¡' &&
+                   ch != '¿';
         }
     }
 }

--- a/src/libse/Common/TextLengthCalculator/TextElements.cs
+++ b/src/libse/Common/TextLengthCalculator/TextElements.cs
@@ -1,0 +1,43 @@
+﻿namespace Nikse.SubtitleEdit.Core.Common.TextLengthCalculator
+{
+    internal static class TextElements
+    {
+        /// <summary>
+        /// True when every char of <paramref name="s"/> is a text element of its own, so the
+        /// calculator can count chars directly instead of walking
+        /// StringInfo.GetTextElementEnumerator - which allocates an enumerator plus one string
+        /// per element and runs per grid-row repaint, per keystroke and per waveform frame.
+        /// Everything that can make a text element longer than one char (combining marks, ZWJ,
+        /// prepend characters, surrogates) and everything the calculators skip explicitly
+        /// (zero-width and BiDi controls) is >= U+0300. U+2010-U+2027 (typographic dashes,
+        /// curly quotes, ellipsis - common in professional subtitles) are plain punctuation,
+        /// never part of a longer element, so they stay on the fast path; any other char
+        /// >= U+0300 fails the probe. "\r\n" is the one multi-char element that can survive
+        /// it, and the calculators score that one differently, so it is counted separately.
+        /// </summary>
+        internal static bool AreAllSingleChar(string s, out int crLfCount)
+        {
+            crLfCount = 0;
+            if (s == null)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < s.Length; i++)
+            {
+                var c = s[i];
+                if (c >= '\u0300' && (c < '\u2010' || c > '\u2027'))
+                {
+                    return false;
+                }
+
+                if (c == '\r' && i + 1 < s.Length && s[i + 1] == '\n')
+                {
+                    crLfCount++;
+                }
+            }
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `HtmlUtil.RemoveCommonHtmlTags`: hop between `<` positions with `span.IndexOf` and bulk-copy the clean stretches instead of testing and copying every character (called dozens of times per subtitle line)
- `LanguageAutoDetect.IsUtf8`: skip ASCII runs with `IndexOfAnyExceptInRange` on .NET 8+ instead of walking up to 500 KB byte-by-byte on file open
- `StringExtensions.RemoveControlCharactersButWhiteSpace`: add the early-out its sibling already had — return the original instance when nothing needs removing (the common case on the ASSA save path)
- TextLengthCalculator: lift CalcAll's single-char-element fast path into a shared probe and apply it to CalcNoSpace, both composition calculators and CalcNoSpaceOrPunctuation; CalcAll keeps its original fused single-pass loop (an A/B benchmark showed the split probe was ~25% slower there)

Behavior is unchanged: every rewrite was differentially tested against a verbatim copy of the old code, with identical results throughout — 400k string inputs × 7 function pairs (grapheme clusters, combining marks, BiDi and zero-width controls, surrogate pairs, CRLF) plus 300k raw byte arrays including invalid UTF-8 sequences. 0 diffs.

## Benchmarks

Re-measured with BenchmarkDotNet: verbatim copies of the old and new code compiled into **one** binary so both halves share machine state, default job, corpus of 3000 real subtitle paragraphs. StdDev is under 1% on every row, so these are not noise.

| Method | before | after | speedup |
|---|---|---|---|
| CalcNoSpace.CountCharacters | 1433 µs | 138 µs | **10.4×** (2.7 MB → 0 alloc) |
| IsUtf8 (256 KB buffer) | 68.1 µs | 7.4 µs | **9.2×** |
| RemoveControlCharactersButWhiteSpace | 97.3 µs | 27.5 µs | **3.5×** (583 KB → 0 alloc) |
| RemoveCommonHtmlTags (real tagged lines) | 16.9 µs | 10.5 µs | **1.6×** |
| CalcAll.CountCharacters | — | — | unchanged (fused fast path kept) |

`RemoveCommonHtmlTags` is only reachable when the string contains `<` — `RemoveHtmlTags` returns early otherwise — so it has to be benchmarked on tagged lines; measuring it through the public entry over a mixed corpus dilutes the win to nothing. Across line shapes:

| shape | before | after | |
|---|---|---|---|
| long documentary line | 377 µs | 102 µs | 3.7× |
| full-line `<i>…</i>` | 118 µs | 55.7 µs | 2.1× |
| stray `<` that is not a tag | 98.1 µs | 51.4 µs | 1.9× |
| real tagged lines from sample files | 16.7 µs | 10.5 µs | 1.6× |
| `<font color=…>` | 100.5 µs | 91.2 µs | 1.1× |
| short `<i>Look out!</i>` | 41.6 µs | 39.7 µs | wash |
| dense per-word tags | 106 µs | 265 µs | **2.5× slower** |

Known worst case: word-by-word tagging (karaoke / WebVTT `<c>` runs), where the clean stretches between tags are 1–2 chars and the hop overhead beats the vectorization. Ordinary subtitles win.

### Reverted from this branch

`CountWords` originally hopped separators with `IndexOfAnyExcept`/`IndexOfAny`. Re-measured, that is a **3.7× regression** (51.5 → 192.0 µs), not the "within noise" the first harness reported — measuring the whole `CountWords`, where `HtmlUtil.RemoveHtmlTags` dominates, hid it. Two `IndexOfAny` calls per word lose to a scalar scan when words are the ~4–5 chars typical of Latin subtitles:

| shape | before | after | |
|---|---|---|---|
| "I never thought it would end like this." | 54.1 µs | 229.0 µs | 4.2× slower |
| two-line paragraph | 76.3 µs | 346.6 µs | 4.5× slower |
| "Yes." | 6.7 µs | 10.5 µs | 1.6× slower |
| very long words | 109.0 µs | 98.2 µs | 1.1× faster |
| CJK (no spaces) | 20.3 µs | 10.5 µs | 1.9× faster |

Same match-density rule that made the equivalent rewrite lose in #13593. Reverted in 918eb61.

### Scope notes

- The default `CpsLineLengthStrategy` is `CalcAll`, and every built-in profile uses it, so the calculator fast paths only fire for users who picked a non-default CPS strategy. The rows that affect a default install are `IsUtf8` (once per file open) and `RemoveControlCharactersButWhiteSpace`.
- `CalcCjk`, `CalcCjkNoSpace` and the two `CalcIgnoreArabicDiacritics` variants still use `StringInfo.GetTextElementEnumerator`; the same probe would apply to them as a follow-up.

## Test plan
- [x] `dotnet build src/libse/LibSE.csproj` succeeds
- [x] `dotnet test tests/libse/LibSETests.csproj` passes (1024 tests)
- [x] Differential equivalence vs the old code: 400k string cases + 300k byte cases, 0 diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
