### PR TITLE
Replace byte-at-a-time hot loops with vectorized span ops

### DIFF
--- a/src/libse/BluRaySup/BluRaySupParser.cs
+++ b/src/libse/BluRaySup/BluRaySupParser.cs
@@ -26,6 +26,7 @@ using System.Collections.Generic;
 using System.IO;
 using System;
 using System.Linq;
+using System.Runtime.InteropServices;
 
 public class BluRayPoint
 {
@@ -287,18 +288,18 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
                     count = maxCount;
                 }
 
-                var r = color.Red;
-                var g = color.Green;
-                var b = color.Blue;
-                var a = color.Alpha;
+                // Pack the four channel bytes in the order they would have been stored one at a
+                // time, then read them back as a uint, so the filled bytes come out identical on
+                // either endianness. idx is always a multiple of 4, so the cast covers the run.
+                Span<byte> pixel = stackalloc byte[4];
+                pixel[0] = color.Red;
+                pixel[1] = color.Green;
+                pixel[2] = color.Blue;
+                pixel[3] = color.Alpha;
 
-                for (var i = 0; i < count; i++)
-                {
-                    pixelSpan[idx++] = r;
-                    pixelSpan[idx++] = g;
-                    pixelSpan[idx++] = b;
-                    pixelSpan[idx++] = a;
-                }
+                MemoryMarshal.Cast<byte, uint>(pixelSpan)
+                    .Slice(idx / 4, count)
+                    .Fill(MemoryMarshal.Read<uint>(pixel));
             }
 
             // Optimized single pixel setter

--- a/src/libse/BluRaySup/SkiaExt.cs
+++ b/src/libse/BluRaySup/SkiaExt.cs
@@ -1,6 +1,5 @@
 ﻿using SkiaSharp;
 using System;
-using System.Runtime.InteropServices;
 
 namespace Nikse.SubtitleEdit.Core.BluRaySup
 {
@@ -117,15 +116,15 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
                 // Get the total byte size of each image
                 var byteSize = pixmap1.RowBytes * bitmap.Height;
 
-                // Allocate byte arrays for the pixel data
-                var pixels1 = new byte[byteSize];
-                var pixels2 = new byte[byteSize];
+                // Compare the pixel buffers in place - no copy needed
+                var pixels1 = pixmap1.GetPixelSpan();
+                var pixels2 = pixmap2.GetPixelSpan();
+                if (pixels1.Length < byteSize || pixels2.Length < byteSize)
+                {
+                    return false;
+                }
 
-                // Copy raw pixel data into the byte arrays
-                Marshal.Copy(pixmap1.GetPixels(), pixels1, 0, byteSize);
-                Marshal.Copy(pixmap2.GetPixels(), pixels2, 0, byteSize);
-
-                return ByteArraysEqual(pixels1, pixels2);
+                return ByteArraysEqual(pixels1.Slice(0, byteSize), pixels2.Slice(0, byteSize));
             }
         }
 

--- a/src/libse/Common/FileUtil.cs
+++ b/src/libse/Common/FileUtil.cs
@@ -557,6 +557,9 @@ namespace Nikse.SubtitleEdit.Core.Common
             }
         }
 
+        //Header Partition PackId
+        private static readonly byte[] MxfHeaderPartitionPackId = { 0x06, 0x0E, 0x2B, 0x34, 0x02, 0x05, 0x01, 0x01, 0x0D, 0x01, 0x02 };
+
         /// <summary>
         /// Checks if file is an MXF file
         /// </summary>
@@ -573,27 +576,10 @@ namespace Nikse.SubtitleEdit.Core.Common
                     return false;
                 }
 
-                for (int i = 0; i < count - 11; i++)
-                {
-                    //Header Partition PackId = 06 0E 2B 34 02 05 01 01 0D 01 02
-                    if (buffer[i + 00] == 0x06 &&
-                        buffer[i + 01] == 0x0E &&
-                        buffer[i + 02] == 0x2B &&
-                        buffer[i + 03] == 0x34 &&
-                        buffer[i + 04] == 0x02 &&
-                        buffer[i + 05] == 0x05 &&
-                        buffer[i + 06] == 0x01 &&
-                        buffer[i + 07] == 0x01 &&
-                        buffer[i + 08] == 0x0D &&
-                        buffer[i + 09] == 0x01 &&
-                        buffer[i + 10] == 0x02)
-                    {
-                        return true;
-                    }
-                }
+                // count - 1 keeps the search window the byte-at-a-time loop used: it tested
+                // start offsets up to count - 12, so the last byte it ever looked at was count - 2.
+                return buffer.AsSpan(0, count - 1).IndexOf(MxfHeaderPartitionPackId) >= 0;
             }
-
-            return false;
         }
 
         /// <summary>

--- a/src/libse/Common/NikseBitmap.cs
+++ b/src/libse/Common/NikseBitmap.cs
@@ -1618,15 +1618,14 @@ namespace Nikse.SubtitleEdit.Core.Common
                 return true;
             }
 
-            for (int i = 0; i < _bitmapData.Length; i++)
+            // The (width, height, byte[]) constructor takes an external buffer, so equal
+            // dimensions do not by themselves guarantee equal buffer lengths.
+            if (_bitmapData.Length != bitmap._bitmapData.Length)
             {
-                if (_bitmapData[i] != bitmap._bitmapData[i])
-                {
-                    return false;
-                }
+                return false;
             }
 
-            return true;
+            return _bitmapData.AsSpan().SequenceEqual(bitmap._bitmapData);
         }
 
         public void SetTransparentTo(SKColor transparent)


### PR DESCRIPTION
## Summary
- `NikseBitmap.IsEqualTo`: byte-at-a-time buffer compare → `SequenceEqual` (called once per CDG packet, thousands per karaoke file); adds a length guard for externally supplied buffers, so mismatched lengths now return false instead of throwing or prefix-matching
- `SkiaExt.IsEqualTo`: drop the two full-bitmap `Marshal.Copy` allocations and compare the pixmap spans in place (runs per adjacent image pair during Blu-ray SUP parse)
- `BluRaySupParser.FillPixels`: fill RLE runs as packed uints via `Span<uint>.Fill` instead of storing R,G,B,A separately per pixel — long runs are most of what a PGS stream contains
- `FileUtil.IsMaterialExchangeFormat`: hand-rolled 11-byte signature match at every offset of a 64 KB buffer → `span.IndexOf(pattern)`, preserving the original loop's exact search window

Verified with differential harnesses against the old code (94k+ combinations covering buffer edges, offsets and signature placements) — byte-identical output and results throughout.

## Benchmarks

A/B vs the branch base commit, same harness binary for both sides, median of 5 samples after warmup (ms/op; Release, net10.0). `FillPixels` is private and exercised only through .sup decode, so it has no standalone row:

| Method | before | after | speedup |
|---|---|---|---|
| NikseBitmap.IsEqualTo (1920×1080) | 3.90 | 0.27 | 14× |
| SkiaExt.IsEqualTo (1920×1080) | 3.00 | 0.24 | 12× |
| IsMaterialExchangeFormat (64 KB, no match) | 0.070 | 0.046 | 1.5× (file open dominates) |

## Test plan
- [ ] `dotnet build src/libse/LibSE.csproj` succeeds for both netstandard2.1 and net10.0
- [ ] `dotnet test tests/libse/LibSETests.csproj` passes
- [ ] Load a Blu-ray .sup and a CDG karaoke file; rendering matches main
- [ ] MXF detection still recognises an .mxf sample

🤖 Generated with [Claude Code](https://claude.com/claude-code)