### PR TITLE
Use a 64 KB read buffer for MKV files on a network share

### DIFF
--- a/src/libse/ContainerFormats/Matroska/MatroskaFile.cs
+++ b/src/libse/ContainerFormats/Matroska/MatroskaFile.cs
@@ -37,16 +37,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Matroska
         {
             Path = path;
 
-            // Subtitle/track extraction walks the entire cluster structure but only reads a
-            // tiny fraction of a (potentially multi-GB) file: it reads each block's small header
-            // and then seeks past the large video/audio payloads. A big read buffer is
-            // counter-productive here - because the forward skips are usually smaller than the
-            // buffer, FileStream keeps refilling contiguously and ends up pulling almost the
-            // whole file off disk. A small 4 KB (one page) buffer makes the skips fall outside
-            // the buffer so the skipped payloads are never read, cutting cold-open disk I/O by
-            // ~4x (e.g. ~700 MB -> ~175 MB on a 1 GB file) and open time several-fold.
-            // Memory-mapping was measured to be slower here (synchronous page-fault stalls).
-            _stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, 4096);
+            _stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, GetReadBufferSize(path));
 
             // read header
             var headerElement = ReadElement();
@@ -59,6 +50,66 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Matroska
                 {
                     IsValid = true; // matroska file must start with ebml header and segment
                 }
+            }
+        }
+
+        /// <summary>
+        /// Local disk: a small 4 KB (one page) buffer. Subtitle/track extraction walks the whole
+        /// cluster structure but only reads a tiny fraction of a (potentially multi-GB) file - each
+        /// block's small header, then a seek past the large video/audio payload. A big buffer is
+        /// counter-productive there: the forward skips are usually smaller than the buffer, so
+        /// FileStream keeps refilling contiguously and ends up pulling almost the whole file off
+        /// disk. One page makes the skips fall outside the buffer, cutting cold-open I/O ~4x
+        /// (~700 MB -> ~175 MB on a 1 GB file) and open time several-fold (#6772). Memory-mapping
+        /// was measured to be slower here (synchronous page-fault stalls).
+        /// </summary>
+        private const int LocalReadBufferSize = 4096;
+
+        /// <summary>
+        /// Network share: the 64 KB buffer used before #6772. Over SMB the cost is not bytes but
+        /// round-trips - every refill is a synchronous request over the wire - so the one-page
+        /// buffer that wins on local disk turns tens of thousands of small reads into as many
+        /// round-trips, and opening an MKV from a UNC path crawled while the same file on a local
+        /// disk opened instantly (#13609). SE 4 always used this size.
+        /// </summary>
+        private const int NetworkReadBufferSize = 65536;
+
+        private static int GetReadBufferSize(string path)
+        {
+            return IsNetworkPath(path) ? NetworkReadBufferSize : LocalReadBufferSize;
+        }
+
+        /// <summary>
+        /// True for a UNC path or a drive letter mapped to a network share. Anything that cannot be
+        /// determined counts as local, so an unknown path keeps the local-disk optimization.
+        /// </summary>
+        private static bool IsNetworkPath(string path)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(path))
+                {
+                    return false;
+                }
+
+                // \\server\share and the //server/share form .NET also accepts.
+                if (path.StartsWith("\\\\", StringComparison.Ordinal) || path.StartsWith("//", StringComparison.Ordinal))
+                {
+                    return true;
+                }
+
+                // Mapped network drives (Z: -> \\server\share) look local until asked.
+                var root = System.IO.Path.GetPathRoot(path);
+                if (string.IsNullOrEmpty(root) || root.Length < 2 || root[1] != ':')
+                {
+                    return false;
+                }
+
+                return new DriveInfo(root).DriveType == DriveType.Network;
+            }
+            catch
+            {
+                return false;
             }
         }
 


### PR DESCRIPTION
Fixes #13609

### Why 4.0.9 is fast and 5.1.0 is slow

The reporter's comparison straddles `592db55851` ("Speed up large MKV reading and add open progress", #6772, June 2026), which changed one line:

```csharp
- _stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, 65536);
+ _stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, 4096);
```

On local disk that is a solid win, and the reasoning in that commit still holds: extraction walks the whole cluster structure but only reads each block's small header before seeking past the large video/audio payload. With a big buffer the forward skips are usually *smaller* than the buffer, so `FileStream` keeps refilling contiguously and drags almost the entire file off disk — ~700 MB read to extract ~1.7 MB of subtitles from a 1 GB file. One page makes the skips land outside the buffer, cutting that to ~175 MB.

Over SMB the economics invert. The buffer size *is* the network request size, and each refill is a synchronous round-trip. The same walk that costs ~44,000 buffer fills now costs ~44,000 round-trips, and on a LAN at ~1 ms each that is most of a minute of pure latency before any bytes are counted. Locally it stays invisible because the page cache absorbs the small reads — which is exactly the asymmetry reported: UNC very slow, non-UNC almost instantaneous.

SE 4 had no such problem because it always used 64 KB.

### The change

Choose the buffer from the path instead of hard-coding one:

- **UNC path** (`\server\share\…`, or the `//server/share` form .NET also accepts) → 64 KB
- **Drive letter mapped to a network share** (`Z:` → `\server\share`, via `DriveInfo.DriveType == Network`) → 64 KB
- **Everything else** → 4 KB, unchanged

`IsNetworkPath` swallows any failure and answers "local", so an undeterminable path keeps the #6772 optimization rather than losing it.

### Verification

`LibSETests` — 1024 passed, 0 failed. `src/libse` builds clean.

I could not benchmark this: I have no UNC share to test against, so the improvement is reasoned from the access pattern and the round-trip cost, not measured. The reporter has the setup and could confirm on the next beta. What is not in doubt is the cause of the regression — the buffer size changed between the two versions they compared, and it is the only thing in that code path sensitive to whether the file is local or remote.

Worth noting the tradeoff this accepts: on a network path we go back to transferring ~4x more bytes. That is the right trade on a LAN, where round-trips dominate, and it is what SE 4 did. On a slow WAN link neither size will feel good.

🤖 Generated with [Claude Code](https://claude.com/claude-code)