### PR TITLE
Cover the span rewrites from #13606 with tests

### DIFF
--- a/src/libse/Common/FileUtil.cs
+++ b/src/libse/Common/FileUtil.cs
@@ -576,9 +576,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                     return false;
                 }
 
-                // count - 1 keeps the search window the byte-at-a-time loop used: it tested
-                // start offsets up to count - 12, so the last byte it ever looked at was count - 2.
-                return buffer.AsSpan(0, count - 1).IndexOf(MxfHeaderPartitionPackId) >= 0;
+                return buffer.AsSpan(0, count).IndexOf(MxfHeaderPartitionPackId) >= 0;
             }
         }
 

--- a/tests/libse/BluRaySup/SkiaExtEqualityTest.cs
+++ b/tests/libse/BluRaySup/SkiaExtEqualityTest.cs
@@ -1,0 +1,78 @@
+using Nikse.SubtitleEdit.Core.BluRaySup;
+using SkiaSharp;
+
+namespace LibSETests.BluRaySup;
+
+/// <summary>
+/// <see cref="SkiaExt.IsEqualTo(SKBitmap, SKBitmap)"/> compares the two pixmaps in place over a
+/// window sized from the first bitmap's RowBytes, so the cases worth pinning are the ones where
+/// the second buffer is not that big.
+/// </summary>
+public class SkiaExtEqualityTest
+{
+    private static SKBitmap MakeBitmap(int width, int height, SKColorType colorType = SKColorType.Bgra8888)
+    {
+        var bitmap = new SKBitmap(new SKImageInfo(width, height, colorType, SKAlphaType.Unpremul));
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                bitmap.SetPixel(x, y, new SKColor((byte)(x * 8), (byte)(y * 8), 128, 255));
+            }
+        }
+
+        return bitmap;
+    }
+
+    [Fact]
+    public void IsEqualToMatchesIdenticalBitmaps()
+    {
+        using var one = MakeBitmap(8, 4);
+        using var other = MakeBitmap(8, 4);
+
+        Assert.True(one.IsEqualTo(other));
+    }
+
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(3, 2)]
+    [InlineData(7, 3)] // the last pixel of the last row
+    public void IsEqualToRejectsASingleDifferingPixel(int x, int y)
+    {
+        using var one = MakeBitmap(8, 4);
+        using var other = MakeBitmap(8, 4);
+        other.SetPixel(x, y, new SKColor(1, 2, 3, 255));
+
+        Assert.False(one.IsEqualTo(other));
+    }
+
+    [Fact]
+    public void IsEqualToRejectsDifferentDimensions()
+    {
+        using var one = MakeBitmap(8, 4);
+        using var other = MakeBitmap(4, 8);
+
+        Assert.False(one.IsEqualTo(other));
+    }
+
+    [Fact]
+    public void IsEqualToMatchesTwoEmptyBitmaps()
+    {
+        using var one = new SKBitmap(0, 0);
+        using var other = new SKBitmap(0, 0);
+
+        Assert.True(one.IsEqualTo(other));
+    }
+
+    // Equal width and height but a narrower pixel format: RowBytes * Height for the first bitmap
+    // is larger than the whole second buffer. Copying that many bytes out of the second pixmap
+    // used to read past the end of its native allocation.
+    [Fact]
+    public void IsEqualToRejectsBitmapWithNarrowerPixelFormat()
+    {
+        using var one = MakeBitmap(8, 4);
+        using var other = MakeBitmap(8, 4, SKColorType.Rgb565);
+
+        Assert.False(one.IsEqualTo(other));
+    }
+}

--- a/tests/libse/Common/FileUtilTest.cs
+++ b/tests/libse/Common/FileUtilTest.cs
@@ -5,6 +5,8 @@ namespace LibSETests.Common;
 
 public class FileUtilTest
 {
+    private static readonly byte[] MxfHeaderPartitionPackId = { 0x06, 0x0E, 0x2B, 0x34, 0x02, 0x05, 0x01, 0x01, 0x0D, 0x01, 0x02 };
+
     private static byte[] MakeRawPgsSegment(byte segmentType, int payloadSize)
     {
         var segment = new byte[3 + payloadSize];
@@ -72,6 +74,49 @@ public class FileUtilTest
             .ToArray();
 
         WithTempFile(bytes, path => Assert.False(FileUtil.IsRawPgsSegmentStream(path)));
+    }
+
+    // The Header Partition PackId is 11 bytes and may sit anywhere in the first 64 KB, so the
+    // interesting offsets are the two edges of the search window. The byte-at-a-time loop this
+    // replaced stopped at start offset count - 12, which missed a pack ending on the last byte.
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(50)]
+    [InlineData(2048 - 12)]
+    [InlineData(2048 - 11)] // the pack ends on the very last byte read
+    public void IsMaterialExchangeFormatFindsPackIdAtAnyOffset(int offset)
+    {
+        var bytes = new byte[2048];
+        MxfHeaderPartitionPackId.CopyTo(bytes, offset);
+
+        WithTempFile(bytes, path => Assert.True(FileUtil.IsMaterialExchangeFormat(path)));
+    }
+
+    [Fact]
+    public void IsMaterialExchangeFormatRejectsFileWithoutPackId()
+    {
+        var bytes = new byte[2048];
+        for (var i = 0; i < bytes.Length; i++)
+        {
+            bytes[i] = (byte)(i % 251);
+        }
+
+        // A truncated pack (one byte short of the full signature) must not match either.
+        MxfHeaderPartitionPackId.AsSpan(0, MxfHeaderPartitionPackId.Length - 1).CopyTo(bytes.AsSpan(100));
+        bytes[100 + MxfHeaderPartitionPackId.Length - 1] = 0xFF;
+
+        WithTempFile(bytes, path => Assert.False(FileUtil.IsMaterialExchangeFormat(path)));
+    }
+
+    [Fact]
+    public void IsMaterialExchangeFormatRejectsFileShorterThanHundredBytes()
+    {
+        // The pack is there, but a file this short cannot be an MXF - the size guard wins.
+        var bytes = new byte[99];
+        MxfHeaderPartitionPackId.CopyTo(bytes, 0);
+
+        WithTempFile(bytes, path => Assert.False(FileUtil.IsMaterialExchangeFormat(path)));
     }
 
     // The UTF-16LE BOM is FF FE; ReadAllLinesShared used to test FE FF (the UTF-16BE BOM),

--- a/tests/libse/Common/NikseBitmapEqualityTest.cs
+++ b/tests/libse/Common/NikseBitmapEqualityTest.cs
@@ -1,0 +1,72 @@
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace LibSETests.Common;
+
+/// <summary>
+/// <see cref="NikseBitmap.IsEqualTo"/> compares the raw pixel buffers, and the
+/// (width, height, byte[]) constructor takes an externally supplied buffer, so equal dimensions
+/// do not by themselves guarantee equal buffer lengths. CDG rendering calls this once per packet.
+/// </summary>
+public class NikseBitmapEqualityTest
+{
+    private static byte[] MakeBuffer(int length, byte seed = 0)
+    {
+        var buffer = new byte[length];
+        for (var i = 0; i < length; i++)
+        {
+            buffer[i] = (byte)(i * 7 + seed);
+        }
+
+        return buffer;
+    }
+
+    [Fact]
+    public void IsEqualToMatchesIdenticalBuffers()
+    {
+        var one = new NikseBitmap(4, 3, MakeBuffer(4 * 3 * 4));
+        var other = new NikseBitmap(4, 3, MakeBuffer(4 * 3 * 4));
+
+        Assert.True(one.IsEqualTo(other));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(23)]
+    [InlineData(4 * 3 * 4 - 1)] // the very last byte
+    public void IsEqualToRejectsASingleDifferingByte(int index)
+    {
+        var buffer = MakeBuffer(4 * 3 * 4);
+        var changed = MakeBuffer(4 * 3 * 4);
+        changed[index] = (byte)(changed[index] ^ 0xFF);
+
+        Assert.False(new NikseBitmap(4, 3, buffer).IsEqualTo(new NikseBitmap(4, 3, changed)));
+    }
+
+    [Fact]
+    public void IsEqualToRejectsDifferentDimensions()
+    {
+        var one = new NikseBitmap(4, 3, MakeBuffer(4 * 3 * 4));
+        var other = new NikseBitmap(3, 4, MakeBuffer(4 * 3 * 4));
+
+        Assert.False(one.IsEqualTo(other));
+    }
+
+    [Fact]
+    public void IsEqualToMatchesTwoEmptyBitmaps()
+    {
+        Assert.True(new NikseBitmap(0, 0, Array.Empty<byte>()).IsEqualTo(new NikseBitmap(0, 0, Array.Empty<byte>())));
+    }
+
+    // Same dimensions but a shorter buffer on the left used to compare only the shared prefix and
+    // report a match; a shorter buffer on the right threw IndexOutOfRangeException.
+    [Theory]
+    [InlineData(4 * 3 * 4, 4 * 3 * 4 - 4)]
+    [InlineData(4 * 3 * 4 - 4, 4 * 3 * 4)]
+    public void IsEqualToRejectsMismatchedBufferLengths(int leftLength, int rightLength)
+    {
+        var one = new NikseBitmap(4, 3, MakeBuffer(leftLength));
+        var other = new NikseBitmap(4, 3, MakeBuffer(rightLength));
+
+        Assert.False(one.IsEqualTo(other));
+    }
+}


### PR DESCRIPTION
Follow-up to #13606, which replaced four byte-at-a-time hot loops with span ops but shipped without unit tests. Two of those rewrites changed behaviour in cases the old code got wrong, and nothing in the suite pinned that.

## Tests

**`NikseBitmapEqualityTest`** — the `(width, height, byte[])` constructor takes an externally supplied buffer, so equal dimensions do not imply equal buffer lengths. Checked against the pre-#13606 implementation, both mismatched-length cases fail there: the old loop *reported a match* when the left buffer was the shorter of the two (it only compared the shared prefix), and threw `IndexOutOfRangeException` when it was the longer.

**`SkiaExtEqualityTest`** — the compare window is sized from the first bitmap's `RowBytes`, so a second bitmap with the same `Width`/`Height` but a narrower pixel format is smaller than that window. The old `Marshal.Copy` read past the end of its native allocation; the new length guard returns false. This one already returned false before the fix (the out-of-bounds read happened to produce a mismatch rather than a crash), so it pins the behaviour without having been a visible failure.

Both files also cover the ordinary paths — identical buffers, a single differing byte at the first/middle/last position, mismatched dimensions, and the `0x0` early-out.

`FillPixels` gets no direct test: it is private and reachable only through `.sup` decode, so covering it would mean checking a `.sup` fixture into the repo. Its equivalence was established separately over 9,840 combinations of span length, offset and run count — byte-identical output and identical throw behaviour.

## One behaviour fix

`IsMaterialExchangeFormat` searched `buffer.AsSpan(0, count - 1)` with a comment explaining that this reproduced the old loop's upper bound. It does — but that bound was itself off by one: the loop stopped at start offset `count - 12`, so a Header Partition Pack ending on the last byte read was missed. This searches all of `count` instead, which cannot introduce false positives, and drops the comment. `IsMaterialExchangeFormatFindsPackIdAtAnyOffset(offset: 2037)` is the case that fails without it.

## Test plan
- [x] `dotnet test tests/libse/LibSETests.csproj` — 1116 passed, 0 failed
- [x] New tests verified to fail against the pre-#13606 implementations (3 failures: the two length-mismatch cases and the MXF last-byte offset)
- [x] `dotnet build src/libse/LibSE.csproj -c Release` clean on netstandard2.1 and net10.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
