### PR TITLE
Refactor: replace profile-name TextBox reference in VMs with focus callback

### DIFF
--- a/src/ui/Features/Files/ExportImageBased/ImageBasedProfileViewModel.cs
+++ b/src/ui/Features/Files/ExportImageBased/ImageBasedProfileViewModel.cs
@@ -1,6 +1,5 @@
 ﻿using Avalonia.Controls;
 using Avalonia.Input;
-using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Shared;
@@ -21,14 +20,13 @@ public partial class ImageBasedProfileViewModel : ObservableObject
 
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }
-    public TextBox ProfileNameTextBox { get; internal set; }
+    public Action? FocusProfileName { get; set; }
 
     public ImageBasedProfileViewModel()
     {
         Profiles = new ObservableCollection<ProfileDisplayItem>();
         SelectedProfile = null;
         IsProfileSelected = true;
-        ProfileNameTextBox = new TextBox();
     }
 
     public void Initialize(ObservableCollection<SeExportImagesProfile> profiles, SeExportImagesProfile? selectedProfile)
@@ -52,8 +50,8 @@ public partial class ImageBasedProfileViewModel : ObservableObject
         Profiles.Add(newProfile);
         SelectedProfile = newProfile;
 
-        Dispatcher.UIThread.Invoke(() => { ProfileNameTextBox.Focus(); });
         IsProfileDeleteEnabled = Profiles.Count > 1;
+        FocusProfileName?.Invoke();
     }
 
     [RelayCommand]

--- a/src/ui/Features/Files/ExportImageBased/ImageBasedProfileWindow.cs
+++ b/src/ui/Features/Files/ExportImageBased/ImageBasedProfileWindow.cs
@@ -109,7 +109,7 @@ public class ImageBasedProfileWindow : Window
         nameBox.KeyDown += vm.ProfileNameTextBoxOnKeyDown;
         editorGrid.Children.Add(nameBox);
         Grid.SetRow(nameBox, 1);
-        vm.ProfileNameTextBox = nameBox;
+        vm.FocusProfileName = () => Avalonia.Threading.Dispatcher.UIThread.Post(() => nameBox.Focus());
 
         var buttonRow = UiUtil.MakeButtonBar(
             UiUtil.MakeButtonOk(vm.OkCommand),

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsProfileViewModel.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsProfileViewModel.cs
@@ -1,6 +1,5 @@
 ﻿using Avalonia.Controls;
 using Avalonia.Input;
-using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -23,7 +22,7 @@ public partial class FixCommonErrorsProfileViewModel : ObservableObject
     public Window? Window { get; set; }
 
     public bool OkPressed { get; private set; }
-    public TextBox ProfileNameTextBox { get; internal set; }
+    public Action? FocusProfileName { get; set; }
 
     private List<FixRuleDisplayItem> _fixRules;
 
@@ -33,7 +32,6 @@ public partial class FixCommonErrorsProfileViewModel : ObservableObject
         Profiles = new ObservableCollection<ProfileDisplayItem>();
         SelectedProfile = null;
         IsProfileSelected = true;
-        ProfileNameTextBox = new TextBox();
     }
 
     public void Initialize(List<FixRuleDisplayItem> allFixRules, string? selectedProfileName)
@@ -69,12 +67,8 @@ public partial class FixCommonErrorsProfileViewModel : ObservableObject
         var newProfile = MakeDefaultProfile("");
         Profiles.Add(newProfile);
         SelectedProfile = newProfile;
-
-        Dispatcher.UIThread.Invoke(() =>
-        {
-            ProfileNameTextBox.Focus();
-            IsProfileDeleteEnabled = Profiles.Count > 1;
-        });
+        IsProfileDeleteEnabled = Profiles.Count > 1;
+        FocusProfileName?.Invoke();
     }
 
     [RelayCommand]

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsProfileWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsProfileWindow.cs
@@ -114,7 +114,7 @@ public class FixCommonErrorsProfileWindow : Window
         nameBox.KeyDown += vm.ProfileNameTextBoxOnKeyDown;
         editorGrid.Children.Add(nameBox);
         Grid.SetRow(nameBox, 1);
-        vm.ProfileNameTextBox = nameBox;
+        vm.FocusProfileName = () => Avalonia.Threading.Dispatcher.UIThread.Post(() => nameBox.Focus());
 
         var buttonRow = UiUtil.MakeButtonBar(
             UiUtil.MakeButtonOk(vm.OkCommand),


### PR DESCRIPTION
## Summary
- Remove the `ProfileNameTextBox` control reference from `FixCommonErrorsProfileViewModel` and `ImageBasedProfileViewModel` (including the placeholder `new TextBox()` in their constructors)
- Replace it with an `Action? FocusProfileName` callback assigned by the window, matching the existing `FocusSearchBox` pattern in the Find/Replace windows
- Windows now post `nameBox.Focus()` to the UI thread dispatcher, preserving the original deferred-focus timing
- Drop the now-unused `Avalonia.Threading` usings from both ViewModels

## Test plan
- [x] Tools → Fix common errors → profiles: click "New profile" — a new empty profile is added and the name textbox receives keyboard focus
- [x] Type a name and press Enter — the dialog saves and closes (Enter-to-OK still works)
- [ ] File → Export image-based format → profiles: click "New profile" — same focus behavior in the name textbox
- [ ] Delete button enable/disable still follows profile count (>1) in both dialogs

🤖 Generated with [Claude Code](https://claude.com/claude-code)