### PR TITLE
Fix #13614: Google Translate V1 inserts blank lines in multi-line cues

### DIFF
--- a/src/libuilogic/AutoTranslate/GoogleTranslateV1.cs
+++ b/src/libuilogic/AutoTranslate/GoogleTranslateV1.cs
@@ -244,9 +244,17 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
                 if (lineArr.Count > 0)
                 {
                     var s = lineArr[0].Trim('"');
-                    if (s.EndsWith("\\r\\n", StringComparison.InvariantCulture))
+                    // Google keeps a source line break at a segment's end as an escaped "\r\n",
+                    // "\n" or "\r". AppendLine below re-adds the separator, so a segment still
+                    // carrying its own trailing newline would double into a blank line after
+                    // Regex.Unescape (issue #13614). Strip the trailing newline escape(s) first.
+                    while (s.EndsWith("\\r\\n", StringComparison.Ordinal))
                     {
                         s = s.Remove(s.Length - 4, 4);
+                    }
+                    while (s.EndsWith("\\n", StringComparison.Ordinal) || s.EndsWith("\\r", StringComparison.Ordinal))
+                    {
+                        s = s.Remove(s.Length - 2, 2);
                     }
                     sbAll.AppendLine(s);
                 }

--- a/tests/libuilogic/Translate/GoogleTranslateV1Tests.cs
+++ b/tests/libuilogic/Translate/GoogleTranslateV1Tests.cs
@@ -1,0 +1,51 @@
+using System.Reflection;
+using Nikse.SubtitleEdit.UiLogic.AutoTranslate;
+
+namespace LibUiLogicTests.Translate;
+
+public class GoogleTranslateV1Tests
+{
+    // ConvertJsonObjectToStringLines is private; invoke it directly so the response
+    // parser can be tested without a live network call.
+    private static List<string> ConvertJsonObjectToStringLines(string json)
+    {
+        var method = typeof(GoogleTranslateV1).GetMethod(
+            "ConvertJsonObjectToStringLines",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        return (List<string>)method.Invoke(null, new object[] { json })!;
+    }
+
+    [Fact]
+    public void SegmentWithTrailingEscapedNewline_DoesNotProduceBlankLine()
+    {
+        // Google returns a two-line dialogue cue as two segments; the first segment keeps
+        // the source line break as an escaped trailing "\n". Before the fix for #13614 the
+        // trailing newline survived and AppendLine doubled it into a blank middle line.
+        var json = "[[[\"- Ne.\\n\",\"- No.\\n\",null,null,3],[\"- Přijdeme pozdě.\",\"- We're gonna be late.\",null,null,3]],null,\"en\"]";
+
+        var lines = ConvertJsonObjectToStringLines(json);
+
+        Assert.Equal(new[] { "- Ne.", "- Přijdeme pozdě." }, lines);
+        Assert.DoesNotContain(lines, string.IsNullOrWhiteSpace);
+    }
+
+    [Fact]
+    public void SegmentWithTrailingEscapedCrLf_DoesNotProduceBlankLine()
+    {
+        var json = "[[[\"- Ne.\\r\\n\",\"- No.\\r\\n\",null,null,3],[\"- Přijdeme pozdě.\",\"- We're gonna be late.\",null,null,3]],null,\"en\"]";
+
+        var lines = ConvertJsonObjectToStringLines(json);
+
+        Assert.Equal(new[] { "- Ne.", "- Přijdeme pozdě." }, lines);
+    }
+
+    [Fact]
+    public void SingleSegment_IsReturnedUnchanged()
+    {
+        var json = "[[[\"Ahoj.\",\"Hello.\",null,null,3]],null,\"en\"]";
+
+        var lines = ConvertJsonObjectToStringLines(json);
+
+        Assert.Equal(new[] { "Ahoj." }, lines);
+    }
+}


### PR DESCRIPTION
Google returns a translation as segments, and a segment that ends at a source line break keeps that break as an escaped trailing newline - usually "\n", not "\r\n". ConvertJsonObjectToStringLines only stripped a trailing "\r\n" escape, so a bare "\n" survived and AppendLine added a second break; Regex.Unescape then collapsed the pair into "\n\r\n", a blank line inside the cue.

Strip any trailing newline escape ("\r\n", "\n" or "\r") from each segment before AppendLine re-adds the separator. Mid-segment newlines are untouched, so genuine line breaks are preserved.