### PR TITLE
Fix #13621: STT audio extraction fails with "-map 0:N matches no streams"

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -2468,8 +2468,27 @@ public partial class SpeechToTextViewModel : ObservableObject
                                      "64-bit: " + Environment.Is64BitOperatingSystem + Environment.NewLine +
                                      "ffmpeg exit code: " + _audioExtractProcess.ExitCode + Environment.NewLine +
                                      "ffmpeg log: " + _ffmpegLog);
+
+                // Tell the user - writing to the tools log only left the run looking
+                // frozen: the progress indicator stayed up and no dialog appeared (#13621).
+                var exitCode = _audioExtractProcess.ExitCode;
                 IsTranscribeEnabled = true;
+                HideProgressBar();
+                ProgressText = string.Empty;
                 _audioExtractProcess = null;
+
+                Dispatcher.UIThread.Post(async () =>
+                {
+                    await MessageBox.Show(Window!, Se.Language.General.Error,
+                        $"Could not generate the audio file (ffmpeg exit code {exitCode})." +
+                        Environment.NewLine + "Please check the tools log for the ffmpeg output.");
+
+                    if (Window != null)
+                    {
+                        FileHelper.OpenFileWithDefaultProgram(Se.GetToolsLogFilePath());
+                    }
+                });
+
                 return;
             }
 
@@ -4378,10 +4397,17 @@ public partial class SpeechToTextViewModel : ObservableObject
             return null;
         }
 
+        // The trailing "?" makes the stream map optional (#13621, same fix as in
+        // WaveFileExtractor for #10835). The track index belongs to the video the user
+        // picked it from, but this method also runs on inputs that never had it: the
+        // already-demuxed "se_audioclip_*.wav" clips from "transcribe selected lines",
+        // and any unrelated file added in batch mode. Without the "?", "-map 0:1" on a
+        // single-stream wav aborts ffmpeg ("Stream map '0:1' matches no streams"); with
+        // it, ffmpeg falls back to automatic stream selection and picks the audio.
         var audioParameter = string.Empty;
         if (audioTrackNumber >= 0)
         {
-            audioParameter = $"-map 0:{audioTrackNumber}";
+            audioParameter = $"-map 0:{audioTrackNumber}?";
         }
 
         var fFmpegAudioTranscodeSettings = GetFfmpegTranscodeFormatString(audioFormat, _useCenterChannelOnly);

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -1809,7 +1809,8 @@ public partial class SpeechToTextViewModel : ObservableObject
             var msg = $"Videos converted: " + convertedJobs;
             if (failed > 0)
             {
-                msg += Environment.NewLine + $"Videos failed: " + failed;
+                msg += Environment.NewLine + $"Videos failed: " + failed +
+                       Environment.NewLine + "Please check the tools log for details.";
             }
 
             _timerWhisper.Stop();
@@ -2472,10 +2473,26 @@ public partial class SpeechToTextViewModel : ObservableObject
                 // Tell the user - writing to the tools log only left the run looking
                 // frozen: the progress indicator stayed up and no dialog appeared (#13621).
                 var exitCode = _audioExtractProcess.ExitCode;
+                _audioExtractProcess = null;
+
+                if (IsBatchMode)
+                {
+                    // One unreadable file must not sink the whole batch: mark this job
+                    // failed and move on, exactly like a job whose engine produced no
+                    // text (MakeResult -> StartNext(null)). The closing summary reports
+                    // the failure count, so nothing is swallowed.
+                    if (_batchIndex >= 0 && _batchIndex < _jobItems.Count)
+                    {
+                        _jobItems[_batchIndex].Status = Se.Language.General.Error;
+                    }
+
+                    StartNext(null);
+                    return;
+                }
+
                 IsTranscribeEnabled = true;
                 HideProgressBar();
                 ProgressText = string.Empty;
-                _audioExtractProcess = null;
 
                 Dispatcher.UIThread.Post(async () =>
                 {


### PR DESCRIPTION
Fixes #13621.

## Root cause

"Transcribe selected lines" extracts one `se_audioclip_*.wav` per line and passes the clips to the speech-to-text window along with the **video's** ffmpeg audio stream index (`MainViewModel.cs:7898` → `InitializeBatch(clips, _audioTrack?.FfIndex ?? -1, ...)`). For a normal `0:0 video / 0:1 audio` file that index is `1`.

`GetFfmpegProcess` then appended `-map 0:1` unconditionally, without checking that the *current* input has that stream. The clip is an already-demuxed wav whose only stream is `0:0`, so ffmpeg aborted:

```
Stream map '0:1' matches no streams.
Failed to set value '0:1' for option 'map': Invalid argument
```

Only online engines hit this: local engines short-circuit ffmpeg entirely for a 16 kHz wav, while OpenRouter / OpenAI-compatible engines must transcode to a compressed format to stay under the upload cap, so they always take the broken path.

## Fix

Make the stream map optional — `-map 0:N?` — exactly the fix `WaveFileExtractor` already received for #10835 (commit 8a041d0a3); this call site was never updated.

Verified against the bundled `ffmpeg 8.1` (and 8.1.2 / 4.4.6):

| input | args | result |
|---|---|---|
| single-stream 16 kHz wav | `-map 0:1` | `matches no streams`, no output — reproduces the issue |
| single-stream 16 kHz wav | `-map 0:1?` | falls back to automatic stream selection → valid mp3, byte-identical to the no-map command |
| 2-audio-track mp4 | `-map 0:1?` | maps stream `0:1`, output peaks at 441 Hz (the 440 Hz track) |
| 2-audio-track mp4 | `-map 0:2?` | maps stream `0:2`, output peaks at 1000 Hz (the 1000 Hz track) |

So track selection is preserved where the track exists, and degrades to sane automatic selection where it does not. This also covers batch mode, where the main video's track index was likewise applied to unrelated files added via *Add files* — an index from one file was never valid for another.

## Also: no longer fails silently

When the generated audio file was missing, the handler wrote to the tools log, re-enabled the Transcribe button and returned — no dialog, and `ProgressOpacity` was left at `1`, so the run looked frozen. It now hides the progress indicator and shows the ffmpeg exit code, then opens the tools log (matching the sibling error paths in the same view model).

## Also: one failed file no longer sinks the whole batch

A failed extract ended the entire batch run — the timer stopped, the remaining jobs never started, and the closing summary never appeared. For *transcribe selected lines*, where every line is its own job, the first bad clip killed the run.

The job is now marked failed and the batch continues to the next one, the same way a job whose engine produced no text already does (`MakeResult` → `StartNext(null)`). The per-file dialog is therefore shown only in single-file mode; batch runs report the failure count in the closing summary, which now also points at the tools log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

