### PR TITLE
Fix #13622: column shortcuts also work when a text box has focus

### DIFF
--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -762,12 +762,16 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.SubtitleGridCutCommand, nameof(vm.SubtitleGridCutCommand), ShortcutCategory.SubtitleGrid);
         AddShortcut(shortcuts, vm.SubtitleGridCopyCommand, nameof(vm.SubtitleGridCopyCommand), ShortcutCategory.SubtitleGrid);
         AddShortcut(shortcuts, vm.SubtitleGridPasteCommand, nameof(vm.SubtitleGridPasteCommand), ShortcutCategory.SubtitleGrid);
-        AddShortcut(shortcuts, vm.ColumnDeleteTextCommand, nameof(vm.ColumnDeleteTextCommand), ShortcutCategory.SubtitleGrid);
-        AddShortcut(shortcuts, vm.ColumnDeleteTextAndShiftCellsUpCommand, nameof(vm.ColumnDeleteTextAndShiftCellsUpCommand), ShortcutCategory.SubtitleGrid);
-        AddShortcut(shortcuts, vm.ColumnInsertEmptyTextAndShiftCellsDownCommand, nameof(vm.ColumnInsertEmptyTextAndShiftCellsDownCommand), ShortcutCategory.SubtitleGrid);
-        AddShortcut(shortcuts, vm.ColumnPasteFromClipboardCommand, nameof(vm.ColumnPasteFromClipboardCommand), ShortcutCategory.SubtitleGrid);
-        AddShortcut(shortcuts, vm.ColumnTextUpCommand, nameof(vm.ColumnTextUpCommand), ShortcutCategory.SubtitleGrid);
-        AddShortcut(shortcuts, vm.ColumnTextDownCommand, nameof(vm.ColumnTextDownCommand), ShortcutCategory.SubtitleGrid);
+        // Column commands work on the grid selection, not on the caret, so they are safe to run with
+        // either the grid or a text box focused. In SE4 they were context menu "ShortcutKeys", which
+        // WinForms dispatched form-wide via ToolStripManager, so they always fired regardless of
+        // focus (#13622) - "SubtitleGridAndTextBox" restores that.
+        AddShortcut(shortcuts, vm.ColumnDeleteTextCommand, nameof(vm.ColumnDeleteTextCommand), ShortcutCategory.SubtitleGridAndTextBox);
+        AddShortcut(shortcuts, vm.ColumnDeleteTextAndShiftCellsUpCommand, nameof(vm.ColumnDeleteTextAndShiftCellsUpCommand), ShortcutCategory.SubtitleGridAndTextBox);
+        AddShortcut(shortcuts, vm.ColumnInsertEmptyTextAndShiftCellsDownCommand, nameof(vm.ColumnInsertEmptyTextAndShiftCellsDownCommand), ShortcutCategory.SubtitleGridAndTextBox);
+        AddShortcut(shortcuts, vm.ColumnPasteFromClipboardCommand, nameof(vm.ColumnPasteFromClipboardCommand), ShortcutCategory.SubtitleGridAndTextBox);
+        AddShortcut(shortcuts, vm.ColumnTextUpCommand, nameof(vm.ColumnTextUpCommand), ShortcutCategory.SubtitleGridAndTextBox);
+        AddShortcut(shortcuts, vm.ColumnTextDownCommand, nameof(vm.ColumnTextDownCommand), ShortcutCategory.SubtitleGridAndTextBox);
         AddShortcut(shortcuts, vm.ImportPlainTextCommand, nameof(vm.ImportPlainTextCommand), ShortcutCategory.General, ShortcutGroup.File);
         AddShortcut(shortcuts, vm.ExportEbuStlCommand, nameof(vm.ExportEbuStlCommand), ShortcutCategory.General, ShortcutGroup.File);
         AddShortcut(shortcuts, vm.ExportPacCommand, nameof(vm.ExportPacCommand), ShortcutCategory.General, ShortcutGroup.File);


### PR DESCRIPTION
Fixes #13622.

### Problem

The column shortcuts (`Ctrl+Delete` "Column, delete text and shift up", `Ctrl+Insert` "Column, insert text", `Ctrl+Shift+V` "Column, paste") only fire when the subtitle grid has focus. In SE 4 they fired from the grid *and* from the text box.

### Why

They are registered in the `SubtitleGrid` shortcut category:

```csharp
AddShortcut(shortcuts, vm.ColumnPasteFromClipboardCommand, nameof(vm.ColumnPasteFromClipboardCommand), ShortcutCategory.SubtitleGrid);
```

The text-box key handler in `MainViewModel` only dispatches the `TextBox` and `SubtitleGridAndTextBox` categories, so a `SubtitleGrid` command is invisible there.

SE 4 never routed these by focus at all - they were plain `ToolStripMenuItem.ShortcutKeys` on the list-view context menu (`Main.cs:27103-27106` on `se4-legacy`). WinForms hands `ToolStripManager` first crack at every key via `Form.ProcessCmdKey`, which dispatches `ContextMenuStrip` item shortcuts form-wide, before the focused `TextBox` ever sees `WM_KEYDOWN`.

### Fix

Move the six column commands to `ShortcutCategory.SubtitleGridAndTextBox`. They all act on `SubtitleGridSelectedItems` rather than the caret, so running them with a text box focused is well defined - the selection is unchanged by focus moving to the edit box, exactly as in SE 4 (whose handlers read `SubtitleListview1.SelectedItems`).

`ColumnTextUp`/`ColumnTextDown` are included: they were context-menu items with `ShortcutKeys` in SE 4 too, so they had the same focus-independent behavior.

Grid focus is unaffected - that dispatch path already probes `SubtitleGridAndTextBox` right after `SubtitleGrid`.

### Notes

- No settings migration needed: saved shortcuts store only the action name and keys; the category comes from this code table, so existing user assignments pick the change up automatically.
- These commands have no default key binding in SE 5, so this only affects users who assign them (or import from SE 4). For those users the assigned keys are now swallowed in the text box - e.g. `Ctrl+Insert` no longer copies there. SE 4 shadowed the native text box keys the same way; that shadowing is what the report asks for.

### Testing

- `dotnet build src/ui/UI.csproj` - clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
