### PR TITLE
Fix #13619: keep the grid on the row being edited when a row changes height

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -108,6 +108,12 @@ public static partial class InitListViewAndEditBox
         vm.SubtitleGrid = subtitleGrid;
         vm.SubtitleGridDragSelect = new TableViewDragSelect(subtitleGrid, vm.ApplyDragSelectRange);
 
+        // Keep the view on the row being edited when a row changes height (#13619). Rows are
+        // one or two text lines, and the virtualizing panel re-estimates its pixel extent from
+        // the average realized row height - so breaking a line into two grew the estimate and
+        // scrolled the grid tens of rows away from the line the user was editing.
+        TableViewScrollAnchor.Attach(subtitleGrid);
+
         // hack to make drag and drop work on the grid - also on empty rows
         var dropHost = new Border
         {

--- a/src/ui/Logic/TableViewIndexScrollBar.cs
+++ b/src/ui/Logic/TableViewIndexScrollBar.cs
@@ -305,6 +305,10 @@ public sealed class TableViewIndexScrollBar : Grid
         }
 
         _applyingValue = true;
+        // Placing a row at the viewport top realizes rows as it goes, so the extent estimate
+        // moves under the loop below - an anchor restore in the middle of that would drag the
+        // view back to where the thumb just left (#13619).
+        using var anchorSuspended = TableViewScrollAnchor.GetFor(_tableView)?.Suspend();
         try
         {
             if (value <= 0.001)

--- a/src/ui/Logic/TableViewScrollAnchor.cs
+++ b/src/ui/Logic/TableViewScrollAnchor.cs
@@ -1,0 +1,288 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.VisualTree;
+using System;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>
+/// Keeps a <see cref="TableView"/> looking at the same row when the virtualizing panel
+/// re-estimates its pixel extent (issue #13619).
+///
+/// TableView virtualizes with Avalonia's VirtualizingStackPanel, which estimates the total
+/// extent as "realized rows + remaining count x average realized row height". When a realized
+/// row changes height - the subtitle grid's rows are one or two text lines, so breaking a line
+/// grows one - the average goes up, the extent estimate grows with it, and the panel keeps the
+/// pixel *offset* fixed instead of the row the user is looking at. The same offset then maps to
+/// a much earlier row, and the grid scrolls away from the line being edited by roughly
+/// index x (1 - extentBefore / extentAfter) rows - measured at 546 -> 512 for a single row
+/// gaining a second line 546 rows down, and worse the further down the file you are. The user
+/// keeps the selection and the edit box but the row is gone from the view (upstream:
+/// AvaloniaUI/Avalonia #17831, the same estimator behind #13579 and PrePositionScroll).
+///
+/// So: remember the row at the top of the viewport (and how far it is scrolled into), and when
+/// a scroll change reports an extent change that no offset change asked for - a re-estimate,
+/// not a scroll - put that row back where it was. The restore works in row indices, not pixels,
+/// because the pixels are exactly what became unreliable: it uses
+/// <see cref="TableViewExtras.PrePositionScroll"/> plus the same measure-jump-remeasure settle
+/// loop <see cref="TableViewIndexScrollBar"/> uses for its thumb.
+/// </summary>
+public sealed class TableViewScrollAnchor
+{
+    /// <summary>Refinement steps the restore is allowed to take, like PrePositionScroll.</summary>
+    private const int SettlePasses = 3;
+
+    private static readonly AttachedProperty<TableViewScrollAnchor?> InstanceProperty =
+        AvaloniaProperty.RegisterAttached<TableView, TableViewScrollAnchor?>("ScrollAnchorInstance", typeof(TableViewScrollAnchor));
+
+    private readonly TableView _tableView;
+    private ScrollViewer? _scrollViewer;
+
+    // The row at the top of the viewport: the item itself (so an insert above it does not
+    // shift the view by a row), its index as a fallback, the item count that index was valid
+    // for, and its top edge in viewport coordinates - negative while scrolled into.
+    private object? _anchorItem;
+    private int _anchorIndex = -1;
+    private int _anchorItemCount = -1;
+    private double _anchorTop;
+
+    // Restoring the anchor scrolls the view, which reports back as another scroll change.
+    private bool _restoring;
+
+    // Someone else owns the offset for the moment (see Suspend).
+    private int _suspendCount;
+
+    private TableViewScrollAnchor(TableView tableView)
+    {
+        _tableView = tableView;
+
+        if (tableView.IsLoaded)
+        {
+            HookScrollViewer();
+        }
+
+        tableView.Loaded += (_, _) => HookScrollViewer();
+    }
+
+    /// <summary>
+    /// Starts anchoring <paramref name="tableView"/>. Attaching twice returns the first
+    /// anchor instead of stacking a second set of handlers.
+    /// </summary>
+    public static TableViewScrollAnchor Attach(TableView tableView)
+    {
+        if (tableView.GetValue(InstanceProperty) is { } existing)
+        {
+            return existing;
+        }
+
+        var anchor = new TableViewScrollAnchor(tableView);
+        tableView.SetValue(InstanceProperty, anchor);
+        return anchor;
+    }
+
+    /// <summary>The anchor attached to <paramref name="tableView"/>, if any.</summary>
+    public static TableViewScrollAnchor? GetFor(TableView tableView) => tableView.GetValue(InstanceProperty);
+
+    /// <summary>
+    /// Hands the offset to the caller until the returned scope is disposed: the anchor keeps
+    /// following the view but never moves it. Deliberate multi-pass scrolling - the index
+    /// scroll bar placing a row at the viewport top - re-estimates the extent as it realizes
+    /// rows, and an anchor restore in the middle of that would fight it.
+    /// </summary>
+    public IDisposable Suspend()
+    {
+        _suspendCount++;
+        return new SuspendScope(this);
+    }
+
+    private sealed class SuspendScope : IDisposable
+    {
+        private TableViewScrollAnchor? _anchor;
+
+        public SuspendScope(TableViewScrollAnchor anchor) => _anchor = anchor;
+
+        public void Dispose()
+        {
+            if (_anchor is { } anchor)
+            {
+                _anchor = null;
+                anchor._suspendCount--;
+            }
+        }
+    }
+
+    private void HookScrollViewer()
+    {
+        if (_scrollViewer != null)
+        {
+            return;
+        }
+
+        _scrollViewer = _tableView.GetVisualDescendants().OfType<ScrollViewer>().FirstOrDefault();
+        if (_scrollViewer == null)
+        {
+            return;
+        }
+
+        _scrollViewer.ScrollChanged += OnScrollChanged;
+        Remember();
+    }
+
+    /// <summary>
+    /// The visual whose origin is the viewport's top-left corner. The TableView template keeps
+    /// the column header *inside* the ScrollViewer (pinned above the rows), so the ScrollViewer's
+    /// own origin sits a header height above the viewport.
+    /// </summary>
+    private Visual? ViewportOrigin => (Visual?)_scrollViewer?.Presenter ?? _scrollViewer;
+
+    private void OnScrollChanged(object? sender, ScrollChangedEventArgs e)
+    {
+        if (_restoring || _scrollViewer == null)
+        {
+            return;
+        }
+
+        // An extent change with no offset change is the panel re-estimating under the view;
+        // anything else is a scroll, which is the user's (or ScrollIntoView's) business.
+        // At the very top there is nothing to correct - offset 0 always shows row 0.
+        if (_suspendCount == 0 &&
+            Math.Abs(e.ExtentDelta.Y) > 0.5 &&
+            Math.Abs(e.OffsetDelta.Y) < 0.5 &&
+            _scrollViewer.Offset.Y > 0.5)
+        {
+            Restore();
+        }
+
+        Remember();
+    }
+
+    private void Remember()
+    {
+        if (_scrollViewer == null || ViewportOrigin is not { } viewportOrigin)
+        {
+            return;
+        }
+
+        var top = double.MaxValue;
+        Control? anchorRow = null;
+        foreach (var row in _tableView.GetRealizedContainers().OfType<TableViewRow>())
+        {
+            if (row.Bounds.Height <= 0 ||
+                ((Visual)row).TranslatePoint(new Point(0, 0), viewportOrigin)?.Y is not { } rowTop ||
+                rowTop + row.Bounds.Height <= 0.5 ||
+                rowTop >= top)
+            {
+                continue;
+            }
+
+            top = rowTop;
+            anchorRow = row;
+        }
+
+        if (anchorRow == null)
+        {
+            _anchorItem = null;
+            _anchorIndex = -1;
+            _anchorItemCount = -1;
+            return;
+        }
+
+        var index = _tableView.IndexFromContainer(anchorRow);
+        if (index < 0)
+        {
+            return;
+        }
+
+        _anchorIndex = index;
+        _anchorTop = top;
+        _anchorItemCount = _tableView.ItemCount;
+        _anchorItem = index < _tableView.ItemsView.Count ? _tableView.ItemsView[index] : null;
+    }
+
+    /// <summary>
+    /// Where the anchored row lives now, or -1 when there is nothing safe to restore to.
+    /// The item wins over the index so an insert above the anchor keeps the same content in
+    /// view; the index is only trusted when the list is still the same length, so a reload
+    /// (every item replaced) leaves the view alone instead of jumping to a stale row.
+    /// </summary>
+    private int ResolveAnchorIndex()
+    {
+        var count = _tableView.ItemCount;
+        if (count == 0)
+        {
+            return -1;
+        }
+
+        if (_anchorItem != null)
+        {
+            var index = _tableView.ItemsView.IndexOf(_anchorItem);
+            if (index >= 0)
+            {
+                return index;
+            }
+        }
+
+        if (_anchorIndex >= 0 && _anchorIndex < count && count == _anchorItemCount)
+        {
+            return _anchorIndex;
+        }
+
+        return -1;
+    }
+
+    private void Restore()
+    {
+        if (_scrollViewer == null)
+        {
+            return;
+        }
+
+        var index = ResolveAnchorIndex();
+        if (index < 0)
+        {
+            return;
+        }
+
+        _restoring = true;
+        try
+        {
+            // The re-estimate usually leaves the anchor row outside the realized window - it
+            // is what the view jumped away from - so bring it back the cheap way first.
+            if (_tableView.ContainerFromIndex(index) is not { Bounds.Height: > 0 })
+            {
+                TableViewExtras.PrePositionScroll(_tableView, index);
+                _tableView.ScrollIntoView(index);
+                _tableView.UpdateLayout();
+            }
+
+            // Then put its top edge back where it was. Setting the offset makes the panel
+            // re-estimate and re-anchor again, which can nudge the rows by a fraction of a
+            // row - measure and correct until the row stays put.
+            for (var pass = 0; pass < SettlePasses; pass++)
+            {
+                if (_tableView.ContainerFromIndex(index) is not { Bounds.Height: > 0 } row ||
+                    ViewportOrigin is not { } viewportOrigin ||
+                    ((Visual)row).TranslatePoint(new Point(0, 0), viewportOrigin)?.Y is not { } rowTop)
+                {
+                    break;
+                }
+
+                var newY = Math.Clamp(
+                    _scrollViewer.Offset.Y + (rowTop - _anchorTop),
+                    0, Math.Max(0, _scrollViewer.Extent.Height - _scrollViewer.Viewport.Height));
+                if (Math.Abs(newY - _scrollViewer.Offset.Y) < 0.5)
+                {
+                    break;
+                }
+
+                _scrollViewer.Offset = new Vector(_scrollViewer.Offset.X, newY);
+                _tableView.UpdateLayout();
+            }
+        }
+        finally
+        {
+            _restoring = false;
+        }
+    }
+}

--- a/tests/UI/Logic/TableViewScrollAnchorTests.cs
+++ b/tests/UI/Logic/TableViewScrollAnchorTests.cs
@@ -1,0 +1,280 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.VisualTree;
+using Nikse.SubtitleEdit.Logic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// The scroll anchor for variable-height TableView rows (issue #13619): breaking a subtitle
+/// line in two grows that row, the virtualizing panel re-estimates the pixel extent from the
+/// average realized row height, and the unchanged pixel offset then maps to a much earlier
+/// row - so the grid scrolled tens of rows away from the line being edited (measured 546 ->
+/// 512 with a single row gaining a second line). TableViewScrollAnchor puts the row that was
+/// at the top of the viewport back where it was, without pinning ordinary scrolling.
+/// </summary>
+public class TableViewScrollAnchorTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private sealed class Row : INotifyPropertyChanged
+    {
+        private string _text = string.Empty;
+
+        public int Number { get; set; }
+
+        public string Text
+        {
+            get => _text;
+            set
+            {
+                _text = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Text)));
+            }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+    }
+
+    private const int RowCount = 1000;
+
+    // Far enough down the list that the estimate-driven jump is tens of rows, like the file
+    // in the issue (the reporter was on line 552).
+    private const int StartIndex = 551;
+
+    private (Window window, TableView grid, ScrollViewer scrollViewer, ObservableCollection<Row> items) BuildShownGrid(bool attachAnchor = true)
+    {
+        // Every third row has two text lines, so realized row heights vary the way the
+        // subtitle grid's do - the mix that makes the estimated extent move.
+        var items = new ObservableCollection<Row>(Enumerable.Range(1, RowCount)
+            .Select(i => new Row { Number = i, Text = i % 3 == 0 ? $"Line {i}\nsecond line" : $"Line {i}" }));
+
+        var grid = new TableView
+        {
+            ItemsSource = items,
+            Columns =
+            {
+                new TableViewColumn { Header = "#", Binding = new Avalonia.Data.Binding(nameof(Row.Number)) },
+                new TableViewColumn { Header = "Text", Binding = new Avalonia.Data.Binding(nameof(Row.Text)) },
+            },
+        };
+
+        if (attachAnchor)
+        {
+            TableViewScrollAnchor.Attach(grid);
+        }
+
+        var window = new Window { Content = grid, Width = 400, Height = 300 };
+        _windows.Add(window);
+        window.Show();
+        Settle(window);
+
+        var scrollViewer = grid.GetVisualDescendants().OfType<ScrollViewer>().First();
+
+        grid.ScrollIntoView(StartIndex);
+        Settle(window);
+
+        return (window, grid, scrollViewer, items);
+    }
+
+    private static void Settle(Window window)
+    {
+        window.UpdateLayout();
+        AvaloniaHeadlessPlatform.ForceRenderTimerTick();
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+    }
+
+    // The TableView template pins the column header inside the ScrollViewer, so the true
+    // viewport origin is the content presenter, a header height below the ScrollViewer's own.
+    private static Visual ViewportOrigin(ScrollViewer scrollViewer) => (Visual?)scrollViewer.Presenter ?? scrollViewer;
+
+    private static int FirstVisibleIndex(TableView grid, ScrollViewer scrollViewer)
+    {
+        var best = -1;
+        var bestTop = double.MaxValue;
+        foreach (var row in grid.GetRealizedContainers().OfType<TableViewRow>())
+        {
+            var top = ((Visual)row).TranslatePoint(new Point(0, 0), ViewportOrigin(scrollViewer))?.Y;
+            if (top == null || row.Bounds.Height <= 0 || top.Value + row.Bounds.Height <= 0.5 || top.Value >= bestTop)
+            {
+                continue;
+            }
+
+            bestTop = top.Value;
+            best = grid.IndexFromContainer(row);
+        }
+
+        return best;
+    }
+
+    [AvaloniaFact]
+    public void EditedRowGainingASecondLine_KeepsTheViewOnTheSameRow()
+    {
+        var (window, grid, scrollViewer, items) = BuildShownGrid();
+
+        var before = FirstVisibleIndex(grid, scrollViewer);
+        Assert.True(before > 100, "sanity: the test scrolls far enough down for the estimate to matter");
+
+        // The row being edited is broken into two lines - auto break, split at cursor with a
+        // long half, or just typing a line break in the edit box.
+        items[before + 1].Text = "Byl jsem v jeho mysli, Rhiannon.\nZnam ho.";
+        Settle(window);
+
+        Assert.Equal(before, FirstVisibleIndex(grid, scrollViewer));
+    }
+
+    [AvaloniaFact]
+    public void RowGainingASecondLine_KeepsTheEditedRowVisible()
+    {
+        var (window, grid, scrollViewer, items) = BuildShownGrid();
+
+        var edited = FirstVisibleIndex(grid, scrollViewer) + 1;
+        items[edited].Text = "Byl jsem v jeho mysli, Rhiannon.\nZnam ho.";
+        Settle(window);
+
+        // The point of the issue: the line the user is editing must still be on screen.
+        var container = grid.ContainerFromIndex(edited);
+        Assert.NotNull(container);
+
+        var top = ((Visual)container!).TranslatePoint(new Point(0, 0), ViewportOrigin(scrollViewer))?.Y;
+        Assert.NotNull(top);
+        Assert.InRange(top!.Value, -0.5, scrollViewer.Viewport.Height);
+    }
+
+    [AvaloniaFact]
+    public void RowLosingItsSecondLine_KeepsTheViewOnTheSameRow()
+    {
+        // The mirror case - unbreak, or merging two lines into one - shrinks the estimate.
+        var (window, grid, scrollViewer, items) = BuildShownGrid();
+
+        var before = FirstVisibleIndex(grid, scrollViewer);
+        var twoLine = Enumerable.Range(before + 1, 5).First(i => items[i].Text.Contains('\n'));
+
+        items[twoLine].Text = "Byl jsem v jeho mysli, Rhiannon. Znam ho.";
+        Settle(window);
+
+        Assert.Equal(before, FirstVisibleIndex(grid, scrollViewer));
+    }
+
+    [AvaloniaFact]
+    public void SplitInsertingARowBelow_KeepsTheViewOnTheSameRow()
+    {
+        var (window, grid, scrollViewer, items) = BuildShownGrid();
+
+        var before = FirstVisibleIndex(grid, scrollViewer);
+        var split = before + 1;
+
+        // Both halves end up two lines long, so the average - and the estimate - grows.
+        items[split].Text = "Byl jsem v jeho\nmysli, Rhiannon.";
+        items.Insert(split + 1, new Row { Number = items[split].Number + 1, Text = "Znam\nho." });
+        Settle(window);
+
+        Assert.Equal(before, FirstVisibleIndex(grid, scrollViewer));
+    }
+
+    [AvaloniaFact]
+    public void InsertAboveTheAnchor_KeepsTheSameRowInView()
+    {
+        var (window, grid, scrollViewer, items) = BuildShownGrid();
+
+        var before = FirstVisibleIndex(grid, scrollViewer);
+        var anchorItem = items[before];
+
+        for (var i = 0; i < 5; i++)
+        {
+            items.Insert(before, new Row { Number = 0, Text = $"inserted {i}\nabove" });
+        }
+
+        Settle(window);
+
+        // The anchor follows the item, not the index, so the same line stays at the top.
+        Assert.Equal(items.IndexOf(anchorItem), FirstVisibleIndex(grid, scrollViewer));
+    }
+
+    [AvaloniaFact]
+    public void OrdinarysScrolling_StillMovesTheView()
+    {
+        var (window, grid, scrollViewer, _) = BuildShownGrid();
+
+        var before = FirstVisibleIndex(grid, scrollViewer);
+
+        // A few wheel notches' worth of pixels, the same path the wheel drives.
+        for (var i = 0; i < 5; i++)
+        {
+            scrollViewer.Offset = new Vector(scrollViewer.Offset.X, scrollViewer.Offset.Y + 120);
+            Settle(window);
+        }
+
+        Assert.True(FirstVisibleIndex(grid, scrollViewer) > before,
+            "the anchor must follow ordinary scrolling, not pin the view");
+    }
+
+    [AvaloniaFact]
+    public void ScrollIntoView_StillReachesItsTarget()
+    {
+        var (window, grid, scrollViewer, _) = BuildShownGrid();
+
+        foreach (var target in new[] { 900, 100, 0, RowCount - 1 })
+        {
+            TableViewExtras.PrePositionScroll(grid, target);
+            grid.ScrollIntoView(target);
+            Settle(window);
+
+            var container = grid.ContainerFromIndex(target);
+            Assert.NotNull(container);
+
+            var top = ((Visual)container!).TranslatePoint(new Point(0, 0), ViewportOrigin(scrollViewer))?.Y;
+            Assert.NotNull(top);
+            Assert.InRange(top!.Value, -container!.Bounds.Height, scrollViewer.Viewport.Height);
+        }
+    }
+
+    [AvaloniaFact]
+    public void IndexScrollBar_StillPositionsRows_WithAnAnchorAttached()
+    {
+        // The bar's own multi-pass placement re-estimates the extent as it realizes rows;
+        // it suspends the anchor so the restore does not drag the view back.
+        var items = new ObservableCollection<Row>(Enumerable.Range(1, RowCount)
+            .Select(i => new Row { Number = i, Text = i % 3 == 0 ? $"Line {i}\nsecond line" : $"Line {i}" }));
+
+        var grid = new TableView
+        {
+            ItemsSource = items,
+            Columns =
+            {
+                new TableViewColumn { Header = "#", Binding = new Avalonia.Data.Binding(nameof(Row.Number)) },
+                new TableViewColumn { Header = "Text", Binding = new Avalonia.Data.Binding(nameof(Row.Text)) },
+            },
+        };
+
+        TableViewScrollAnchor.Attach(grid);
+        var wrapper = new TableViewIndexScrollBar(grid);
+        var window = new Window { Content = wrapper, Width = 400, Height = 300 };
+        _windows.Add(window);
+        window.Show();
+        Settle(window);
+
+        var scrollViewer = grid.GetVisualDescendants().OfType<ScrollViewer>().First();
+
+        wrapper.BarForTest.Value = 400;
+        wrapper.ApplyPendingForTest();
+        Settle(window);
+
+        Assert.InRange(FirstVisibleIndex(grid, scrollViewer), 399, 401);
+    }
+}


### PR DESCRIPTION
Fixes #13619.

## The report

Breaking a subtitle line in two left the selection and the edit box on the line, but the grid jumped tens of rows away from it — the reporter was editing line 552 and saw 505 after the break.

From the screenshots the operation was a line break *inside* one cue (start and duration unchanged, no row inserted), not a split into two cues. The fix covers both, plus unbreak and plain typing.

## Cause

TableView virtualizes with Avalonia's `VirtualizingStackPanel`, which estimates the total extent as *realized rows + remaining count × average realized row height*. A realized row changing height moves that average, so the extent estimate grows or shrinks — and the panel keeps the **pixel offset** fixed instead of the row the user is looking at. The same offset then maps to a different row, roughly `index × (1 − extentBefore / extentAfter)` away.

Measured headlessly on a 1000-row grid scrolled to row 546 (one/two-line mix, like the subtitle grid):

| scenario | first visible before → after | offset | extent |
|---|---|---|---|
| visible row gains a 2nd line | 546 → **512** | 23853 → 23853 (unchanged) | 43678 → 46492 |
| split into two 1-line rows | 546 → 546 | unchanged | 43678 → 43716 |
| split where both halves are 2-line | 546 → **512** | unchanged | 43678 → 46538 |

Inserting a row is harmless by itself; it is the height change that does it, and it gets worse the further down the file you are. Anything that changes a visible row's line count hits it — auto break, unbreak, split at cursor when a half is auto-broken, or just typing a line break in the edit box (the edit box binds `Text` two-way).

Same estimator as #13579 (thumb jitter) and `PrePositionScroll` (row walking). Upstream: AvaloniaUI/Avalonia#17831.

## The fix

`TableViewScrollAnchor` remembers the row at the top of the viewport and puts it back when a scroll change reports an extent change that **no offset change asked for** — a re-estimate, not a scroll. The restore works in row indices, not pixels, because the pixels are what became unreliable: it reuses `PrePositionScroll` and the same measure-jump-remeasure settle loop `TableViewIndexScrollBar` uses for its thumb.

- Anchors on the **item**, falling back to the index, so an insert above keeps the same content in view. If the anchored item is gone *and* the count changed (a reload), it leaves the view alone rather than jumping to a stale row.
- Not a pin: ordinary scrolling and `ScrollIntoView` are untouched, and offset 0 is skipped (it always maps to row 0).
- `Suspend()` hands the offset to deliberate multi-pass scrolling — the index scroll bar takes it while placing a row at the viewport top, since its own realization moves the estimate and a restore mid-loop would drag the view back.
- Attached to the main subtitle grid only; other grids are unaffected unless attached.

## Tests

`TableViewScrollAnchorTests` — 8 headless tests on a 1000-row grid scrolled to row 551, mirroring the reporter's position. Four fail without the anchor attached (row gaining a line, the edited row leaving the screen, unbreak, split with two-line halves); the rest are controls guarding that ordinary scrolling, `ScrollIntoView` and the index scroll bar still behave.

Full UI suite: 2682 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)