### PR TITLE
Fix #13548: overlapping subtitles from speech-to-text results

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextPostProcessor.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextPostProcessor.cs
@@ -275,12 +275,16 @@ namespace Nikse.SubtitleEdit.Features.Video.SpeechToText
             const int maxMillisecondsBetweenLines = 100;
             const bool onlyContinuousLines = true;
 
-            if (language == "jp")
+            // Both the Vosk-style codes ("jp"/"cn") and the Whisper codes
+            // ("ja"/"zh") must be handled - engines that report the Whisper
+            // code used to silently fall through to the 86-char Latin cap
+            // (issue #13548).
+            if (language is "jp" or "ja")
             {
                 ParagraphMaxChars = AudioToTextLineMaxCharsJp;
             }
 
-            if (language == "cn" || language == "yue")
+            if (language is "cn" or "zh" or "yue")
             {
                 ParagraphMaxChars = AudioToTextLineMaxCharsCn;
             }

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextTimingFixer.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextTimingFixer.cs
@@ -219,6 +219,64 @@ public static class SpeechToTextTimingFixer
         return s;
     }
 
+    /// <summary>
+    /// Puts transcription results in time order and removes any overlap between
+    /// neighbors.
+    ///
+    /// Engines are supposed to emit segments in order, but a broken slice/chunk
+    /// mapping can send one backwards in time - Crisp ASR + Parakeet did this 18
+    /// times in a 10 minute file (issue #13548), some of them by 10 seconds. The
+    /// merge step in <see cref="SpeechToTextPostProcessor"/> assumes sorted,
+    /// non-overlapping input and fuses gap-free runs, which turns a small
+    /// out-of-order emission into a huge overlapping cue, so this has to run
+    /// before post-processing.
+    ///
+    /// An overlap is resolved by truncating the earlier paragraph at the start of
+    /// the later one; that keeps every line at the time it was actually spoken
+    /// instead of pushing text minutes away from its audio. When two paragraphs
+    /// share a start time the later one is moved instead, since truncating would
+    /// leave nothing of the first.
+    /// </summary>
+    public static Subtitle SortAndRemoveOverlaps(Subtitle subtitle)
+    {
+        var s = new Subtitle(subtitle);
+        if (s.Paragraphs.Count < 2)
+        {
+            return s;
+        }
+
+        s.Paragraphs.Sort((a, b) =>
+        {
+            var byStart = a.StartTime.TotalMilliseconds.CompareTo(b.StartTime.TotalMilliseconds);
+            return byStart != 0 ? byStart : a.EndTime.TotalMilliseconds.CompareTo(b.EndTime.TotalMilliseconds);
+        });
+
+        for (var i = 1; i < s.Paragraphs.Count; i++)
+        {
+            var prev = s.Paragraphs[i - 1];
+            var p = s.Paragraphs[i];
+            if (p.StartTime.TotalMilliseconds >= prev.EndTime.TotalMilliseconds)
+            {
+                continue;
+            }
+
+            if (p.StartTime.TotalMilliseconds > prev.StartTime.TotalMilliseconds)
+            {
+                prev.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds;
+            }
+            else
+            {
+                var durationMs = p.DurationTotalMilliseconds;
+                p.StartTime.TotalMilliseconds = prev.EndTime.TotalMilliseconds;
+                p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + Math.Max(0, durationMs);
+            }
+        }
+
+        s.Renumber();
+
+        return s;
+    }
+
     public static Subtitle ShortenLongDuration(Subtitle subtitle)
     {
         var s = new Subtitle(subtitle);

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -791,6 +791,11 @@ public partial class SpeechToTextViewModel : ObservableObject
                     subtitle.Paragraphs.AddRange(resultTexts
                         .Select(p => new Paragraph(p.Text, (double)p.Start * 1000.0, (double)p.End * 1000.0)).ToList());
 
+                    // The result file is engine output and is not guaranteed to be
+                    // sorted or free of overlaps (issue #13548), so straighten the
+                    // timings out before post-processing merges anything.
+                    subtitle = SpeechToTextTimingFixer.SortAndRemoveOverlaps(subtitle);
+
                     var postProcessedSubtitle = PostProcess(subtitle);
 
                     if (_audioClips != null && ResultAudioClips.Count > 0)
@@ -809,8 +814,9 @@ public partial class SpeechToTextViewModel : ObservableObject
 
                 _outputText.Enqueue("Loading result from STDOUT");
                 var transcribedSubtitleFromStdOut = new Subtitle();
-                transcribedSubtitleFromStdOut.Paragraphs.AddRange(_resultList.OrderBy(p => p.Start)
+                transcribedSubtitleFromStdOut.Paragraphs.AddRange(_resultList
                     .Select(p => new Paragraph(p.Text, (double)p.Start * 1000.0, (double)p.End * 1000.0)).ToList());
+                transcribedSubtitleFromStdOut = SpeechToTextTimingFixer.SortAndRemoveOverlaps(transcribedSubtitleFromStdOut);
                 _loadedFromStdOut = transcribedSubtitleFromStdOut.Paragraphs.Count > 0;
                 await MakeResult(transcribedSubtitleFromStdOut);
             });

--- a/tests/UI/Features/Video/SpeechToText/SpeechToTextPostProcessorTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/SpeechToTextPostProcessorTests.cs
@@ -1,3 +1,4 @@
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText;
 
 namespace UITests.Features.Video.SpeechToText;
@@ -34,5 +35,24 @@ public class SpeechToTextPostProcessorTests
     {
         Assert.False(SpeechToTextPostProcessor.IsNonStandardLineTerminationLanguage("en"));
         Assert.False(SpeechToTextPostProcessor.IsNonStandardLineTerminationLanguage("da"));
+    }
+
+    // The merge step used to only know the Vosk codes, so Whisper/Crisp ASR
+    // transcripts merged Japanese and Chinese up to the 86-char Latin cap
+    // (issue #13548).
+    [Theory]
+    [InlineData("jp", 32)]
+    [InlineData("ja", 32)]
+    [InlineData("cn", 36)]
+    [InlineData("zh", 36)]
+    [InlineData("yue", 36)]
+    [InlineData("en", 86)]
+    public void MergeShortLines_UsesTheLineLengthCapForTheLanguage(string languageCode, int expectedMaxChars)
+    {
+        var postProcessor = new SpeechToTextPostProcessor(languageCode);
+
+        postProcessor.MergeShortLines(new Subtitle(), languageCode);
+
+        Assert.Equal(expectedMaxChars, postProcessor.ParagraphMaxChars);
     }
 }

--- a/tests/UI/Features/Video/SpeechToText/SpeechToTextTimingFixerTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/SpeechToTextTimingFixerTests.cs
@@ -1,0 +1,124 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText;
+
+namespace UITests.Features.Video.SpeechToText;
+
+public class SpeechToTextTimingFixerTests
+{
+    private static Subtitle MakeSubtitle(params (string Text, double StartMs, double EndMs)[] paragraphs)
+    {
+        var subtitle = new Subtitle();
+        foreach (var p in paragraphs)
+        {
+            subtitle.Paragraphs.Add(new Paragraph(p.Text, p.StartMs, p.EndMs));
+        }
+
+        return subtitle;
+    }
+
+    [Fact]
+    public void SortAndRemoveOverlaps_AlreadyInOrder_LeavesTimingsAlone()
+    {
+        var subtitle = MakeSubtitle(
+            ("one", 1000, 2000),
+            ("two", 2000, 3000),
+            ("three", 4000, 5000));
+
+        var result = SpeechToTextTimingFixer.SortAndRemoveOverlaps(subtitle);
+
+        Assert.Equal(new[] { "one", "two", "three" }, result.Paragraphs.Select(p => p.Text));
+        Assert.Equal(new double[] { 1000, 2000, 4000 }, result.Paragraphs.Select(p => p.StartTime.TotalMilliseconds));
+        Assert.Equal(new double[] { 2000, 3000, 5000 }, result.Paragraphs.Select(p => p.EndTime.TotalMilliseconds));
+    }
+
+    [Fact]
+    public void SortAndRemoveOverlaps_OutOfOrderParagraph_IsMovedBackIntoPlace()
+    {
+        // Crisp ASR + Parakeet emits a segment that belongs seconds earlier
+        // (issue #13548).
+        var subtitle = MakeSubtitle(
+            ("late", 42980, 43300),
+            ("early", 33180, 34540));
+
+        var result = SpeechToTextTimingFixer.SortAndRemoveOverlaps(subtitle);
+
+        Assert.Equal(new[] { "early", "late" }, result.Paragraphs.Select(p => p.Text));
+        Assert.Equal(33180, result.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(42980, result.Paragraphs[1].StartTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void SortAndRemoveOverlaps_OverlappingNeighbor_TruncatesTheEarlierParagraph()
+    {
+        var subtitle = MakeSubtitle(
+            ("first", 32659, 43300),
+            ("second", 33180, 35541));
+
+        var result = SpeechToTextTimingFixer.SortAndRemoveOverlaps(subtitle);
+
+        Assert.Equal(33180, result.Paragraphs[0].EndTime.TotalMilliseconds);
+        Assert.Equal(33180, result.Paragraphs[1].StartTime.TotalMilliseconds);
+        Assert.Equal(35541, result.Paragraphs[1].EndTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void SortAndRemoveOverlaps_SharedStartTime_MovesTheLongerParagraphAndKeepsItsDuration()
+    {
+        // Truncating would wipe out the shorter paragraph, so the longer one is
+        // pushed past it instead.
+        var subtitle = MakeSubtitle(
+            ("long", 5000, 6000),
+            ("short", 5000, 5500));
+
+        var result = SpeechToTextTimingFixer.SortAndRemoveOverlaps(subtitle);
+
+        Assert.Equal(new[] { "short", "long" }, result.Paragraphs.Select(p => p.Text));
+        Assert.Equal(5000, result.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(5500, result.Paragraphs[0].EndTime.TotalMilliseconds);
+        Assert.Equal(5500, result.Paragraphs[1].StartTime.TotalMilliseconds);
+        Assert.Equal(6500, result.Paragraphs[1].EndTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void SortAndRemoveOverlaps_ChainOfOverlaps_LeavesNothingOverlapping()
+    {
+        var subtitle = MakeSubtitle(
+            ("a", 1000, 9000),
+            ("b", 2000, 8000),
+            ("c", 3000, 4000),
+            ("d", 3500, 12000));
+
+        var result = SpeechToTextTimingFixer.SortAndRemoveOverlaps(subtitle);
+
+        for (var i = 1; i < result.Paragraphs.Count; i++)
+        {
+            Assert.True(
+                result.Paragraphs[i].StartTime.TotalMilliseconds >= result.Paragraphs[i - 1].EndTime.TotalMilliseconds,
+                $"Paragraph {i} overlaps its predecessor");
+        }
+    }
+
+    [Fact]
+    public void SortAndRemoveOverlaps_SingleParagraph_IsUnchanged()
+    {
+        var subtitle = MakeSubtitle(("only", 1000, 2000));
+
+        var result = SpeechToTextTimingFixer.SortAndRemoveOverlaps(subtitle);
+
+        Assert.Single(result.Paragraphs);
+        Assert.Equal(1000, result.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(2000, result.Paragraphs[0].EndTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void SortAndRemoveOverlaps_DoesNotMutateTheInput()
+    {
+        var subtitle = MakeSubtitle(
+            ("first", 32659, 43300),
+            ("second", 33180, 35541));
+
+        SpeechToTextTimingFixer.SortAndRemoveOverlaps(subtitle);
+
+        Assert.Equal(43300, subtitle.Paragraphs[0].EndTime.TotalMilliseconds);
+    }
+}


### PR DESCRIPTION
Fixes #13548.

## What the reporter saw

Crisp ASR 0.8.28 + Parakeet on a 10 minute Japanese file produced a subtitle with **17 overlapping cues, the largest 10.5 seconds long**.

## Where it comes from

The overlaps are already in Crisp ASR's own stdout, before Subtitle Edit parses anything — 18 of its 289 segments start *before* the previous segment ends. They are backward jumps, not rounding: a segment lands entirely inside a region an earlier one already covered.

```
14   32.660 ->  39.460  まずねただちょっと私似
15   39.460 ->  42.020  てるところがあって1人で
16   42.020 ->  42.980  暮らすのは好き
17   42.980 ->  43.300  なんです。
18   33.180 ->  34.540  日本にもそんないない   <-- jumps back 10.1 s
```

That is an engine bug (a slice/timestamp mapping problem in the VAD-sliced Parakeet path) and needs fixing there too. But Subtitle Edit made it worse and had no guard:

- `GetResultFromSrt` fed the engine's SRT straight through, unsorted — while the stdout *fallback* path right below it did sort.
- `MergeShortLines` fuses runs with ≤100 ms gaps, assuming sorted, non-overlapping input. Segments 14–17 above are gap-free, so they merged into one `32.659 --> 43.300` cue, turning a 0.3 s discrepancy into a 10.1 s overlap.

## The fix

`SpeechToTextTimingFixer.SortAndRemoveOverlaps` sorts transcription results and removes overlaps before post-processing runs. An overlap is resolved by truncating the earlier paragraph at the start of the later one, rather than pushing the later one forward — that keeps every line at the time it was actually spoken instead of displacing text away from its audio.

Replayed against the reporter's data: **0 overlaps remain, no start time moves at all, 19 end times are trimmed.**

Both the SRT path and the stdout fallback now go through the same helper.

## Also in here

`MergeShortLines` picked its line-length cap with `language == "jp"` / `"cn"`, but Whisper and Crisp ASR report **`ja`** and **`zh`** — so Japanese and Chinese silently fell through to the 86-char Latin cap. (`IsNonStandardLineTerminationLanguage` 30 lines above already handles both spellings, which is what makes this look accidental.) In the reporter's file, 10 cues exceed the intended 32-char Japanese cap, the longest at 53.

## Tests

8 new tests; full UI suite green (2695 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)