### PR TITLE
Visual sync: find or open a video when only a subtitle is open

### DIFF
--- a/src/ui/Features/Sync/VisualSync/VisualSyncViewModel.cs
+++ b/src/ui/Features/Sync/VisualSync/VisualSyncViewModel.cs
@@ -16,6 +16,7 @@ using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Nikse.SubtitleEdit.UiLogic.Media;
@@ -42,6 +43,7 @@ public partial class VisualSyncViewModel : ObservableObject
     public ComboBox ComboBoxRight { get; set; }
 
     private readonly IWindowService _windowService;
+    private readonly IFileHelper _fileHelper;
 
     private string? _videoFileName;
     private DispatcherTimer _positionTimer = new DispatcherTimer();
@@ -50,9 +52,10 @@ public partial class VisualSyncViewModel : ObservableObject
     private double _lastManualOffsetSeconds;
     private double _lastManualSpeedFactor = 1.0;
 
-    public VisualSyncViewModel(IWindowService windowService)
+    public VisualSyncViewModel(IWindowService windowService, IFileHelper fileHelper)
     {
         _windowService = windowService;
+        _fileHelper = fileHelper;
 
         Title = string.Empty;
         VideoInfo = string.Empty;
@@ -88,6 +91,18 @@ public partial class VisualSyncViewModel : ObservableObject
         AudioVisualizer? audioVisualizer,
         int audioTrackId = -1)
     {
+        // No video handed down from the main window - look for one next to the subtitle file, the
+        // way SE4's visual sync did. Failing that the dialog is not a dead end: "Open video file..."
+        // is there to pick one. The video stays local to this dialog either way - only time codes
+        // are reported back, so a video found on disk cannot walk over the "auto open video file"
+        // setting in the main window.
+        if (string.IsNullOrEmpty(videoFileName) &&
+            !string.IsNullOrEmpty(subtitleFileName) &&
+            FindVideoFileName.TryFindVideoFileName(subtitleFileName, out var foundVideoFileName))
+        {
+            videoFileName = foundVideoFileName;
+        }
+
         SetVideoInFo(videoFileName);
         Paragraphs = new ObservableCollection<SubtitleDisplayItem>(paragraphs.Select(p => new SubtitleDisplayItem(p)));
         _videoFileName = videoFileName;
@@ -100,7 +115,9 @@ public partial class VisualSyncViewModel : ObservableObject
                 _ = OpenPlayersAsync(videoFileName, audioTrackId);
             }
 
-            if (audioVisualizer != null)
+            // An audio visualizer without peaks is just an empty box - only show it when the main
+            // window actually has a waveform to lend us.
+            if (audioVisualizer?.WavePeaks != null)
             {
                 AudioVisualizerLeft.WavePeaks = audioVisualizer.WavePeaks;
                 AudioVisualizerRight.WavePeaks = audioVisualizer.WavePeaks;
@@ -538,14 +555,14 @@ public partial class VisualSyncViewModel : ObservableObject
     {
         UiUtil.RestoreWindowPosition(Window);
 
-        if (string.IsNullOrEmpty(_videoFileName))
+        // Only the video needs waiting for - the start/end scenes still have to be picked when
+        // there is none, so the combo boxes are not left empty while the user finds a video.
+        if (!string.IsNullOrEmpty(_videoFileName))
         {
-            return;
+            // Wait a bit for video players to finish opening the file (or until they report a duration)
+            await VideoPlayerControlLeft.WaitForPlayersReadyAsync();
+            await VideoPlayerControlRight.WaitForPlayersReadyAsync();
         }
-
-        // Wait a bit for video players to finish opening the file (or until they report a duration)
-        await VideoPlayerControlLeft.WaitForPlayersReadyAsync();
-        await VideoPlayerControlRight.WaitForPlayersReadyAsync();
 
         Dispatcher.UIThread.Post(() =>
         {
@@ -558,6 +575,42 @@ public partial class VisualSyncViewModel : ObservableObject
             SelectedParagraphRightIndex = Paragraphs.Count - 1;
             GoToLeftSubtitle();
             GoToRightSubtitle();
+        });
+    }
+
+    /// <summary>
+    /// Opens a video from inside the dialog, so entering visual sync without one is not a dead end
+    /// - SE4 offered the same button. The video stays local to this dialog; only time codes are
+    /// reported back.
+    /// </summary>
+    [RelayCommand]
+    private async Task OpenVideoFile()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var fileName = await _fileHelper.PickOpenVideoFile(Window, Se.Language.General.OpenVideoFileTitle);
+        if (string.IsNullOrEmpty(fileName) || !File.Exists(fileName))
+        {
+            return;
+        }
+
+        _videoFileName = fileName;
+        SetVideoInFo(fileName);
+
+        await OpenPlayersAsync(fileName, -1);
+        await VideoPlayerControlLeft.WaitForPlayersReadyAsync();
+        await VideoPlayerControlRight.WaitForPlayersReadyAsync();
+
+        // Land the players on the scenes already picked in the combo boxes (OnLoaded seeds them
+        // to the first/last line even without a video), instead of both sitting at zero.
+        Dispatcher.UIThread.Post(() =>
+        {
+            GoToLeftSubtitle();
+            GoToRightSubtitle();
+            _updateAudioVisualizer = true;
         });
     }
 

--- a/src/ui/Features/Sync/VisualSync/VisualSyncWindow.cs
+++ b/src/ui/Features/Sync/VisualSync/VisualSyncWindow.cs
@@ -23,12 +23,20 @@ public class VisualSyncWindow : Window
         DataContext = vm;
 
         var labelVideoInfo = UiUtil.MakeLabel(string.Empty).WithBindText(vm, nameof(vm.VideoInfo));
+
+        // Entering visual sync without a video used to be a dead end - two blank players and no
+        // way to load one from here. SE4 had the same button.
+        var buttonOpenVideo = UiUtil.MakeButton(Se.Language.General.OpenVideoFile, vm.OpenVideoFileCommand);
+
         var panelVideo = new StackPanel
         {
             Orientation = Orientation.Horizontal,
+            Spacing = 10,
+            VerticalAlignment = VerticalAlignment.Center,
             Children =
             {
-                labelVideoInfo
+                buttonOpenVideo,
+                labelVideoInfo,
             }
         };
 
@@ -51,6 +59,10 @@ public class VisualSyncWindow : Window
         vm.AudioVisualizerLeft.OnVideoPositionChanged += vm.AudioVisualizerLeftPositionChanged;
         vm.AudioVisualizerLeft.OnPrimarySingleClicked += vm.AudioVisualizerLeft_OnPrimarySingleClicked;
 
+        // IsAudioVisualizerVisible was set but never bound, so the waveform box was drawn as a
+        // grey slab whether or not the main window had any peaks to lend it.
+        vm.AudioVisualizerLeft.WithBindIsVisible(nameof(vm.IsAudioVisualizerVisible));
+
         vm.AudioVisualizerRight = new AudioVisualizer
         {
             Height = 80,
@@ -63,6 +75,7 @@ public class VisualSyncWindow : Window
         };
         vm.AudioVisualizerRight.OnVideoPositionChanged += vm.AudioVisualizerRightPositionChanged;
         vm.AudioVisualizerRight.OnPrimarySingleClicked += vm.AudioVisualizerRight_OnPrimarySingleClicked;
+        vm.AudioVisualizerRight.WithBindIsVisible(nameof(vm.IsAudioVisualizerVisible));
 
         var comboBoxLeft = UiUtil.MakeComboBoxBindText(vm.Paragraphs, vm, nameof(SubtitleDisplayItem.Text), nameof(vm.SelectedParagraphLeftIndex));
         comboBoxLeft.Width = double.NaN;


### PR DESCRIPTION
Fixes the SE4→SE5 regression reported as "the visual sync is not working with subtitle opened."

SE5's Visual Sync only played a video handed down from the main window. With just a subtitle open, the dialog came up as a dead end: two blank players, empty start/end scene combo boxes, no waveform, and no way to load a video from inside the dialog. SE4 both auto-found a movie file next to the subtitle (`TryToFindAndOpenMovieFile` in `VisualSync_Load`) and offered an "Open video file" button.

This restores both, following the same pattern as the Set sync point fix (#13341):

- `Initialize` falls back to `FindVideoFileName.TryFindVideoFileName` next to the subtitle file. The found video stays local to the dialog — only time codes are reported back — so it cannot walk over the "auto open video file" setting in the main window.
- A new "Open video file..." button (top-left, next to the video info label, same placement as Set sync point) opens both players and lands them on the scenes already picked in the combo boxes.
- `OnLoaded` now seeds the start/end scene combo boxes to the first/last line even without a video, instead of returning early and leaving them empty.
- The waveform strips are hidden when the main window has no peaks to lend, instead of drawing grey slabs (`IsAudioVisualizerVisible` was set but never bound — the exact defect Set sync point also had).

Builds clean with 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)