### PR TITLE
AI review: catch batch-wide line shifts, recover their corrections

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "Subtitle Edit",
-  "version": "v5.2.0-beta12",
+  "version": "v5.2.0-beta13",
   "translatedBy": "",
   "cultureName": "en-US",
   "general": {
@@ -1475,6 +1475,7 @@
       "lineX": "Line {0}",
       "linesXToY": "Lines {0}-{1}",
       "largeChangeWarning": "Large change - looks like a rewrite, review carefully",
+      "mismatchWarning": "Does not resemble the original - may belong to a different line",
       "engineError": "The AI engine could not be reached: {0}"
     },
     "aiAssistant": {

--- a/src/ui/Features/Tools/AiReview/AiReviewProtocol.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewProtocol.cs
@@ -80,7 +80,7 @@ public static class AiReviewProtocol
     /// periodically shift their line numbers by one and would otherwise pair a correction with
     /// the wrong "before" line.
     /// </summary>
-    public static List<AiReviewChange> ParseChanges(string responseText, IReadOnlyDictionary<int, string> editableLines)
+    public static List<AiReviewChange> ParseChanges(string responseText, IReadOnlyDictionary<int, string> editableLines, Action<string>? log = null)
     {
         var changes = new List<AiReviewChange>();
         var json = ExtractJsonObject(responseText);
@@ -134,10 +134,30 @@ public static class AiReviewProtocol
             var orig = element.TryGetProperty("orig", out var origElement) && origElement.ValueKind == JsonValueKind.String
                 ? origElement.GetString() ?? string.Empty
                 : string.Empty;
+            var modelNumber = number;
             number = VerifyNumberAgainstEcho(number, orig, text, editableLines);
-            if (number < 0 || !usedNumbers.Add(number))
+            if (number < 0)
             {
-                continue; // echo matches no editable line, or that line already has a change
+                log?.Invoke($"AI review: dropped change for line {modelNumber} - the echoed original matches no line in the batch (echo: \"{orig}\")");
+                continue; // echo matches no editable line
+            }
+
+            if (number != modelNumber)
+            {
+                log?.Invoke($"AI review: remapped change from line {modelNumber} to {number} - the echoed original belongs to line {number}");
+            }
+
+            var echoNumber = number;
+            number = RemapByContent(number, text, editableLines);
+            if (number != echoNumber)
+            {
+                log?.Invoke($"AI review: remapped change from line {echoNumber} to {number} - the correction barely resembles line {echoNumber} but is a near-copy of line {number} (shifted line numbers)");
+            }
+
+            if (!usedNumbers.Add(number))
+            {
+                log?.Invoke($"AI review: dropped change for line {number} - that line already has a change");
+                continue; // that line already has a change
             }
 
             var reason = element.TryGetProperty("reason", out var reasonElement) && reasonElement.ValueKind == JsonValueKind.String
@@ -194,6 +214,40 @@ public static class AiReviewProtocol
         // no exact match anywhere; accept a near-exact echo of line "n" (models often normalize
         // quotes or dashes when copying), otherwise the change points at an unknown line - drop it
         return GetSimilarityPercent(orig, editableLines[number]) >= 90 ? number : -1;
+    }
+
+    /// <summary>
+    /// Content-based fallback for shifted line numbers when the echo failed to catch them -
+    /// small models often copy the corrected text into "orig", and an echo that repeats the
+    /// correction carries no information, so the (wrong) line number gets trusted. A real
+    /// correction keeps most of its line's characters, so a "correction" that barely resembles
+    /// line "n" but is a near-copy of exactly one other line in the batch almost certainly
+    /// belongs to that line: remap it there. Observed in the wild as a clean 3-line shift
+    /// across a whole batch. Ambiguous matches (near-duplicate lines, e.g. song refrains)
+    /// keep the model's number; the view model then flags the low similarity as a warning.
+    /// </summary>
+    private static int RemapByContent(int number, string text, IReadOnlyDictionary<int, string> editableLines)
+    {
+        if (GetSimilarityPercent(text, editableLines[number]) >= 50)
+        {
+            return number; // resembles its own line - a plausible correction
+        }
+
+        var match = -1;
+        foreach (var line in editableLines)
+        {
+            if (line.Key != number && GetSimilarityPercent(text, line.Value) >= 75)
+            {
+                if (match >= 0)
+                {
+                    return number; // ambiguous - leave it, the UI will flag it
+                }
+
+                match = line.Key;
+            }
+        }
+
+        return match >= 0 ? match : number;
     }
 
     /// <summary>

--- a/src/ui/Features/Tools/AiReview/AiReviewViewModel.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewViewModel.cs
@@ -376,16 +376,25 @@ public partial class AiReviewViewModel : ObservableObject
                 var userContent = AiReviewProtocol.BuildUserContent(chunk);
                 var editableLines = chunk.Lines.ToDictionary(x => x.Number, x => x.Text);
 
+                // Guard decisions (remaps/drops) are always written - they are rare, small and
+                // the key evidence when a review pairs a correction with the wrong line. The
+                // full request/reply per chunk respects the tools-log setting.
+                var logGuard = (Action<string>)(s => Se.WriteToolsLog(s, true));
+
                 List<AiReviewChange>? changes = null;
                 try
                 {
+                    Se.WriteToolsLog($"AI review request (lines {chunk.Lines[0].Number}-{chunk.Lines[^1].Number}): {userContent}");
                     var reply = await ChatWithDelayAsync(userContent);
-                    changes = AiReviewProtocol.ParseChanges(reply, editableLines);
+                    Se.WriteToolsLog($"AI review reply (lines {chunk.Lines[0].Number}-{chunk.Lines[^1].Number}): {reply}");
+                    changes = AiReviewProtocol.ParseChanges(reply, editableLines, logGuard);
                     if (changes.Count == 0 && AiReviewProtocol.ExtractJsonObject(reply) == null)
                     {
                         // invalid reply - one retry for this chunk
+                        Se.WriteToolsLog($"AI review: no JSON in reply for lines {chunk.Lines[0].Number}-{chunk.Lines[^1].Number} - retrying once", true);
                         reply = await ChatWithDelayAsync(userContent);
-                        changes = AiReviewProtocol.ParseChanges(reply, editableLines);
+                        Se.WriteToolsLog($"AI review retry reply (lines {chunk.Lines[0].Number}-{chunk.Lines[^1].Number}): {reply}");
+                        changes = AiReviewProtocol.ParseChanges(reply, editableLines, logGuard);
                     }
 
                     consecutiveErrors = 0;
@@ -459,11 +468,16 @@ public partial class AiReviewViewModel : ObservableObject
 
         if (!AiReviewProtocol.TagsMatch(before, after))
         {
+            Se.WriteToolsLog($"AI review: dropped change for line {change.Number} - formatting tags were altered (\"{before}\" -> \"{after}\")", true);
             return; // the model touched formatting tags - not trustworthy, skip
         }
 
+        // A shifted model can copy from anywhere in its batch (a clean 3-line shift across a
+        // whole batch has been seen in the wild), so the copy-source window must cover the
+        // largest batch plus its read-only context lines - not just the closest neighbors.
+        var window = Math.Max(2, Se.Settings.Tools.AiReview.MaxLinesPerBatch) + 6;
         var neighbors = new List<string>();
-        for (var i = Math.Max(0, paragraphIndex - 2); i <= Math.Min(_subtitle.Paragraphs.Count - 1, paragraphIndex + 2); i++)
+        for (var i = Math.Max(0, paragraphIndex - window); i <= Math.Min(_subtitle.Paragraphs.Count - 1, paragraphIndex + window); i++)
         {
             if (i != paragraphIndex && !string.IsNullOrWhiteSpace(_subtitle.Paragraphs[i].Text))
             {
@@ -473,14 +487,24 @@ public partial class AiReviewViewModel : ObservableObject
 
         if (AiReviewProtocol.LooksMisaligned(before, after, neighbors))
         {
+            Se.WriteToolsLog($"AI review: dropped change for line {change.Number} - the \"correction\" is a copy of a nearby line (\"{before}\" -> \"{after}\")", true);
             return; // the "correction" is really a copy of a nearby line - misnumbered by the model
         }
 
         var l = Se.Language.Tools.AiReview;
         var ratio = after.Length / (double)Math.Max(1, before.Length);
-        var isWarning = ratio > 1.4 || ratio < 0.6;
+        var isMismatch = AiReviewProtocol.GetSimilarityPercent(before, after) < 50;
+        var isWarning = ratio > 1.4 || ratio < 0.6 || isMismatch;
         var reason = change.Reason;
-        if (isWarning)
+        if (isMismatch)
+        {
+            // A correction keeps most of its line - a "fix" that barely resembles the line is
+            // usually a misnumbered reply whose copy-source we could not pin down. Never
+            // pre-check those; applying one replaces the line with unrelated text.
+            reason = string.IsNullOrEmpty(reason) ? l.MismatchWarning : $"{l.MismatchWarning} - {reason}";
+            Se.WriteToolsLog($"AI review: flagged change for line {change.Number} - barely resembles the original (\"{before}\" -> \"{after}\")", true);
+        }
+        else if (isWarning)
         {
             reason = string.IsNullOrEmpty(reason) ? l.LargeChangeWarning : $"{l.LargeChangeWarning} - {reason}";
         }

--- a/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
@@ -376,6 +376,9 @@ public class AiReviewWindow : Window
             Height = 6,
             VerticalAlignment = VerticalAlignment.Center,
             [!RangeBase.ValueProperty] = new Binding(nameof(vm.ProgressValue)),
+            // Only meaningful while a review is running - a full bar sitting under a
+            // finished review just looks stuck.
+            [!Visual.IsVisibleProperty] = new Binding(nameof(vm.IsReviewing)),
         };
         var statusText = MakeBoundTextBlock(nameof(vm.StatusText));
         statusText.VerticalAlignment = VerticalAlignment.Center;

--- a/src/ui/Logic/Config/Language/Tools/LanguageAiReview.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageAiReview.cs
@@ -23,6 +23,7 @@ public class LanguageAiReview
     public string LineX { get; set; }
     public string LinesXToY { get; set; }
     public string LargeChangeWarning { get; set; }
+    public string MismatchWarning { get; set; }
     public string EngineError { get; set; }
 
     public LanguageAiReview()
@@ -48,6 +49,7 @@ public class LanguageAiReview
         LineX = "Line {0}";
         LinesXToY = "Lines {0}-{1}";
         LargeChangeWarning = "Large change - looks like a rewrite, review carefully";
+        MismatchWarning = "Does not resemble the original - may belong to a different line";
         EngineError = "The AI engine could not be reached: {0}";
     }
 }

--- a/tests/UI/Features/AiReviewTests.cs
+++ b/tests/UI/Features/AiReviewTests.cs
@@ -274,4 +274,85 @@ public class AiReviewTests
         Assert.NotNull(AiReviewProtocol.ExtractJsonObject("Sure! {\"changes\":[]} Hope that helps."));
         Assert.Null(AiReviewProtocol.ExtractJsonObject("No json here"));
     }
+
+    // A whole batch shifted by 3 lines, with the echo repeating the corrected text (so it
+    // carries no information) - the field failure behind the "Trouble Mum" screenshot: the
+    // suggestion for line 368 was really the correction of line 365, three lines back.
+    [Fact]
+    public void ParseChanges_ShiftedNumbersUselessEcho_RemappedByContent()
+    {
+        var lines = Lines(
+            (365, "Go! Did I bring her diapers?"),
+            (366, "I'm all set"),
+            (367, "You can pick Paolo up between 5:00 and 6:00 pm."),
+            (368, "I'm staying if you don't mind. I need to watch him."));
+        var reply = """
+            {"changes":[
+              {"n":368,"orig":"Go! Did I bring her diapers","text":"Go! Did I bring her diapers","reason":"x","category":"punctuation"},
+              {"n":369,"orig":"I'm all set.","text":"I'm all set.","reason":"x","category":"punctuation"},
+              {"n":371,"orig":"I'm staying, if you don't mind. I need to watch him.","text":"I'm staying, if you don't mind. I need to watch him.","reason":"x","category":"punctuation"}
+            ]}
+            """;
+
+        var changes = AiReviewProtocol.ParseChanges(reply, lines);
+
+        // 369/371 are not editable numbers and would have been dropped outright; the echo
+        // remap already rescues those. The dangerous one is 368: an editable number whose
+        // echo equals its text - it used to keep the wrong line. Content remap moves it to 365.
+        Assert.Contains(changes, c => c.Number == 365 && c.NewText == "Go! Did I bring her diapers");
+        Assert.DoesNotContain(changes, c => c.Number == 368);
+    }
+
+    [Fact]
+    public void ParseChanges_LegitCorrection_NotRemapped()
+    {
+        // A real correction resembles its own line - it must stay put even when another
+        // line in the batch is similar.
+        var lines = Lines(
+            (10, "We recieved it yesterday."),
+            (11, "We received it today."));
+        var reply = """{"changes":[{"n":10,"text":"We received it yesterday.","reason":"typo","category":"spelling"}]}""";
+
+        var changes = AiReviewProtocol.ParseChanges(reply, lines);
+
+        var change = Assert.Single(changes);
+        Assert.Equal(10, change.Number);
+    }
+
+    [Fact]
+    public void ParseChanges_ContentRemapAmbiguous_KeepsModelNumber()
+    {
+        // Two near-identical lines (song refrain) - remapping would be a guess, so the
+        // model's number is kept and the low own-similarity is flagged in the UI instead.
+        var lines = Lines(
+            (20, "Something completely different here."),
+            (21, "La la la, here we go again!"),
+            (22, "La la la, here we go again"));
+        var reply = """{"changes":[{"n":20,"text":"La la la, here we go again!","reason":"x","category":"punctuation"}]}""";
+
+        var changes = AiReviewProtocol.ParseChanges(reply, lines);
+
+        var change = Assert.Single(changes);
+        Assert.Equal(20, change.Number);
+    }
+
+    [Fact]
+    public void ParseChanges_ContentRemapTargetTaken_DropsDuplicate()
+    {
+        var lines = Lines(
+            (30, "Hello there, my old friend."),
+            (31, "Unrelated text on this line."));
+        var reply = """
+            {"changes":[
+              {"n":30,"text":"Hello there, my old friend!","reason":"x","category":"punctuation"},
+              {"n":31,"text":"Hello there, my old friend!","reason":"x","category":"punctuation"}
+            ]}
+            """;
+
+        var changes = AiReviewProtocol.ParseChanges(reply, lines);
+
+        // the second change remaps onto line 30, which already has one - dropped
+        var change = Assert.Single(changes);
+        Assert.Equal(30, change.Number);
+    }
 }


### PR DESCRIPTION
A real-world Qwen 3.5 4B run shifted a whole batch's line numbers by **3**, pairing every correction with the wrong line — and only some rows got the "needs a closer look" flag; three came through **pre-checked** with entirely unrelated text.

## Why all three existing guards missed it

- **Echo guard** (#13628): the model copied the corrected text into `orig`. An echo that repeats the correction carries no information, so the (wrong) line number was trusted.
- **Copy-of-a-neighbor check**: only looked ±2 paragraphs; the copy sources sat 3 lines away.
- **Length-ratio warning**: rows 365 (ratio ≈ 1.0), 367 (0.62) and 373 (1.39) fit inside the loose [0.6, 1.4] bounds.

## The fix, layered

1. **Content-based remap in `ParseChanges`** — the recovery. A "correction" that is < 50% similar to its own line but a ≥ 75% match to exactly one other line in the batch is remapped to that line. A shifted batch now shows its corrections on the right rows instead of hiding or mispairing them. Ambiguous matches (near-duplicate lines, e.g. song refrains) stay put.
2. **Copy-source window widened** for `LooksMisaligned` from ±2 to the whole batch plus its read-only context (max batch + 6).
3. **Safety net**: any suggestion still < 50% similar to its own line is flagged "needs a closer look" and **never pre-checked**, with a new reason text: *"Does not resemble the original - may belong to a different line"*. This alone would have caught all three pre-checked rows in the report.

## Also

- The progress bar now hides when the review finishes (bound to `IsReviewing`) — a full bar under a finished review looked stuck.
- Guard decisions (remaps, drops, mismatch flags) are always written to the tools log; the full per-chunk request/reply JSON is logged when the tools-log setting is on — future mispairing reports become diagnosable.

## Testing

- 4 new protocol tests, including a replay of the observed 3-line shift with a useless echo (fails without the remap).
- Full UI suite green: 2711 passed.
- Manual verification: a fresh review run over the same subtitle that produced the shifted screenshot came back with no mispaired suggestions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)