### PR TITLE
Waveform drag: one undo step per drag, not one per pause

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -430,9 +430,20 @@ public class AudioVisualizer : Control
     /// PointerReleased cannot leave change detection switched off for the rest of the session.
     /// </para>
     /// </summary>
-    public bool IsEditingWithPointer =>
-        _pointerDragActive ||
-        (_lastPointerEditMs != 0 && Environment.TickCount64 - _lastPointerEditMs < 500);
+    public bool IsEditingWithPointer => _pointerDragActive || IsPointerEditSettling;
+
+    /// <summary>
+    /// The timestamp half of <see cref="IsEditingWithPointer"/> on its own: true for 500 ms after
+    /// the last pointer move that rewrote the time codes, whether or not the button is still down.
+    /// <para>
+    /// This is what the on-video preview settle uses. Its cost of acting mid-drag is one wasted
+    /// refresh, not a wrong undo stack, and pausing inside a drag is exactly when the user wants
+    /// to see the frame they are aiming at - so the preview keeps catching up during a held
+    /// pause instead of waiting for the release.
+    /// </para>
+    /// </summary>
+    public bool IsPointerEditSettling =>
+        _lastPointerEditMs != 0 && Environment.TickCount64 - _lastPointerEditMs < 500;
 
     public class PositionEventArgs : EventArgs
     {

--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -405,18 +405,34 @@ public class AudioVisualizer : Control
     // Wall clock of the last pointer-driven time code edit (drag move/resize/new selection).
     private long _lastPointerEditMs;
 
+    // True from the press that starts a move/resize/new-selection until the release (or Escape,
+    // Enter, or a lost pointer capture) that ends it - see IsEditingWithPointer. `volatile`
+    // because the undo change-detection timer reads it from a thread-pool thread while the UI
+    // thread writes it, and a stale `false` there is exactly the missed suppression this fixes.
+    private volatile bool _pointerDragActive;
+
     /// <summary>
     /// True while the user is dragging time codes in the waveform - the pointer twin of
-    /// <c>MainViewModel.IsUserEditing</c>'s keyboard check, with the same 500 ms grace.
-    /// A drag rewrites the paragraph times on every undo change-detection tick, and each
-    /// tick that sees a change deep-copies the whole subtitle, so the drag has to suppress
-    /// detection the way typing does; the settled state is captured once the grace expires
-    /// (issue #13234). Deliberately a timestamp rather than "_interactionMode != None": a
-    /// drag that loses pointer capture without a PointerReleased must not be able to leave
-    /// change detection switched off for the rest of the session.
+    /// <c>MainViewModel.IsUserEditing</c>'s keyboard check, with the same 500 ms grace after
+    /// the drag ends. A drag rewrites the paragraph times on every undo change-detection tick,
+    /// and each tick that sees a change deep-copies the whole subtitle and pushes that
+    /// half-finished state onto the undo stack, so the drag has to suppress detection the way
+    /// typing does; the settled state is captured once the grace expires (issue #13234).
+    /// <para>
+    /// The timestamp alone is not enough: it is stamped only by a pointer move that actually
+    /// rewrote the times, so any half second the button is held without the times changing -
+    /// holding still to listen, or fine-tuning inside one pixel column (a same-X move returns
+    /// before the stamp) - reopened the window and banked an intermediate undo entry. Dragging
+    /// around for a while before releasing then produced a whole stack of them, and undo stepped
+    /// back through the middle of the drag instead of to before it (issue #13636). The live drag
+    /// flag closes that; the timestamp still covers the tail after release, and
+    /// <see cref="OnPointerCaptureLost"/> (plus Escape/Enter) makes sure a drag that never sees a
+    /// PointerReleased cannot leave change detection switched off for the rest of the session.
+    /// </para>
     /// </summary>
     public bool IsEditingWithPointer =>
-        _lastPointerEditMs != 0 && Environment.TickCount64 - _lastPointerEditMs < 500;
+        _pointerDragActive ||
+        (_lastPointerEditMs != 0 && Environment.TickCount64 - _lastPointerEditMs < 500);
 
     public class PositionEventArgs : EventArgs
     {
@@ -485,6 +501,7 @@ public class AudioVisualizer : Control
         PointerExited += OnPointerExited;
         PointerPressed += OnPointerPressed;
         PointerReleased += OnPointerReleased;
+        PointerCaptureLost += OnPointerCaptureLost;
         PointerWheelChanged += OnPointerWheelChanged;
         Tapped += OnTapped;
         DoubleTapped += (sender, e) =>
@@ -520,6 +537,7 @@ public class AudioVisualizer : Control
         if (e.Key == Key.Escape)
         {
             _interactionMode = InteractionMode.None;
+            _pointerDragActive = false;
             NewSelectionParagraph = null;
             InvalidateVisual();
             e.Handled = true;
@@ -533,6 +551,7 @@ public class AudioVisualizer : Control
             }
 
             _interactionMode = InteractionMode.None;
+            _pointerDragActive = false;
             NewSelectionParagraph = null;
             InvalidateVisual();
             e.Handled = true;
@@ -805,6 +824,11 @@ public class AudioVisualizer : Control
 
     private void OnPointerReleased(object? sender, PointerReleasedEventArgs e)
     {
+        // Cleared up front: every path out of this method ends the drag, and several of them
+        // return early. The 500 ms tail in IsEditingWithPointer takes over from here, so the
+        // settled times still get one - and only one - undo snapshot.
+        _pointerDragActive = false;
+
         _isCtrlDown = e.KeyModifiers.HasFlag(KeyModifiers.Control);
         _isShiftDown = e.KeyModifiers.HasFlag(KeyModifiers.Shift);
         _isAltDown = e.KeyModifiers.HasFlag(KeyModifiers.Alt);
@@ -984,6 +1008,9 @@ public class AudioVisualizer : Control
         _startPointerPosition = point;
         _startPointerSeconds = RelativeXPositionToSeconds(point.X);
         _lastDragPointerX = double.NaN;
+        // Set again below once this press is known to start a drag (see IsEditingWithPointer);
+        // the paths that bail out before that are plain clicks and must not hold the flag.
+        _pointerDragActive = false;
 
         // No waveform yet and auto-generate is off: a click generates it on demand.
         if (WavePeaks == null && ShowClickToGenerateHint &&
@@ -1017,6 +1044,7 @@ public class AudioVisualizer : Control
 
             NewSelectionParagraph.StartTime = TimeSpan.FromSeconds(deltaSeconds);
             NewSelectionParagraph.EndTime = TimeSpan.FromSeconds(deltaSeconds);
+            _pointerDragActive = true;
             InvalidateVisual();
             return;
         }
@@ -1130,6 +1158,18 @@ public class AudioVisualizer : Control
                 _interactionMode = InteractionMode.Moving;
             }
         }
+
+        _pointerDragActive = _interactionMode != InteractionMode.None;
+    }
+
+    /// <summary>
+    /// A drag can end without a PointerReleased - the window loses activation, a flyout grabs the
+    /// pointer, the device disappears. Undo change detection must not stay suppressed afterwards,
+    /// so treat losing the capture as the end of the drag (see <see cref="IsEditingWithPointer"/>).
+    /// </summary>
+    private void OnPointerCaptureLost(object? sender, PointerCaptureLostEventArgs e)
+    {
+        _pointerDragActive = false;
     }
 
     private void OnPointerExited(object? sender, PointerEventArgs e)
@@ -1168,6 +1208,18 @@ public class AudioVisualizer : Control
         if (IsReadOnly)
         {
             return;
+        }
+
+        // Self-heal: a move with no button down means the drag is over, whatever happened to the
+        // release. Belt and braces next to OnPointerCaptureLost so a stuck flag can never keep
+        // undo change detection switched off (see IsEditingWithPointer).
+        if (_pointerDragActive)
+        {
+            var buttons = e.GetCurrentPoint(this).Properties;
+            if (!buttons.IsLeftButtonPressed && !buttons.IsRightButtonPressed && !buttons.IsMiddleButtonPressed)
+            {
+                _pointerDragActive = false;
+            }
         }
 
         var point = e.GetPosition(this);

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -24873,7 +24873,11 @@ public partial class MainViewModel :
         }
 
         // Dragging in the waveform is the pointer equivalent of typing - see IsUserEditing().
-        return AudioVisualizer?.IsEditingWithPointer == true;
+        // Deliberately the 500 ms settle rather than IsEditingWithPointer's whole-drag window:
+        // undo has to skip the entire drag or it records half-finished times (#13636), but the
+        // preview only pays a wasted refresh, and settling during a held pause is precisely when
+        // the user is looking at the frame - so it keeps the pre-#13636 timing.
+        return AudioVisualizer?.IsPointerEditSettling == true;
     }
 
     // Called at ~60 fps from _cursorTimer (fast settle after edits) and every 400 ms from

--- a/src/ui/Logic/UndoRedo/UndoRedoManager.cs
+++ b/src/ui/Logic/UndoRedo/UndoRedoManager.cs
@@ -297,6 +297,15 @@ public sealed class UndoRedoManager : IUndoRedoManager
                 return;
             }
 
+            // Re-check: the user may have started a continuous edit while this tick was hashing
+            // and snapshotting (both marshal to the UI thread). Without this, a tick that slipped
+            // through the gate above right as a waveform drag began recorded a state from a few
+            // frames into the drag - an undo step landing in the middle of the drag (#13636).
+            if (client.IsUserEditing())
+            {
+                return;
+            }
+
             lock (_lock)
             {
                 // Re-validate after the lock release/reacquire window — another

--- a/tests/UI/Controls/AudioVisualizerDragTests.cs
+++ b/tests/UI/Controls/AudioVisualizerDragTests.cs
@@ -144,6 +144,100 @@ public class AudioVisualizerDragTests
         window.Close();
     }
 
+    /// <summary>Ages the "last pointer edit" stamp past the 500 ms grace, i.e. simulates half a
+    /// second of a held-down drag in which the time codes did not change.</summary>
+    private static void ExpirePointerEditGrace(AudioVisualizer av)
+    {
+        var field = typeof(AudioVisualizer).GetField("_lastPointerEditMs", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(av, Environment.TickCount64 - 5000);
+    }
+
+    [AvaloniaFact]
+    public void IsEditingWithPointer_StaysTrue_WhenDragPausesMidDrag_Issue13636()
+    {
+        // Undo change detection is suppressed for the whole drag, not just 500 ms after the last
+        // time-code-changing move. Holding still mid-drag (or fine-tuning inside one pixel column,
+        // where the same-X early return never stamps) used to reopen the window, and the next
+        // detection tick banked the half-finished times as an undo entry - so undo stepped back
+        // through the middle of the drag instead of to before it.
+        var (window, av, _) = Open(Line(1, 3));
+
+        window.MouseDown(new Point(378, 100), MouseButton.Left, RawInputModifiers.None);
+        window.MouseMove(new Point(478, 100), RawInputModifiers.LeftMouseButton);
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(av.IsEditingWithPointer);
+
+        ExpirePointerEditGrace(av);
+        Assert.True(av.IsEditingWithPointer);
+
+        window.MouseUp(new Point(478, 100), MouseButton.Left, RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+
+        // Released: only the 500 ms tail is left, and that one has been aged out - so the settled
+        // times are free to be snapshotted, once.
+        Assert.False(av.IsEditingWithPointer);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void IsEditingWithPointer_False_AfterEscapeCancelsDrag()
+    {
+        var (window, av, _) = Open(Line(1, 3));
+
+        window.MouseDown(new Point(378, 100), MouseButton.Left, RawInputModifiers.None);
+        window.MouseMove(new Point(478, 100), RawInputModifiers.LeftMouseButton);
+        Dispatcher.UIThread.RunJobs();
+
+        window.KeyPress(Key.Escape, RawInputModifiers.None, PhysicalKey.Escape, null);
+        Dispatcher.UIThread.RunJobs();
+        ExpirePointerEditGrace(av);
+
+        Assert.False(av.IsEditingWithPointer);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void IsEditingWithPointer_False_WhenPointerMovesWithNoButtonDown()
+    {
+        // Self-heal for a drag that never delivered a release: any later button-less move over the
+        // waveform clears the flag, so change detection can never stay switched off.
+        var (window, av, _) = Open(Line(1, 3));
+
+        window.MouseDown(new Point(378, 100), MouseButton.Left, RawInputModifiers.None);
+        window.MouseMove(new Point(478, 100), RawInputModifiers.LeftMouseButton);
+        Dispatcher.UIThread.RunJobs();
+        ExpirePointerEditGrace(av);
+        Assert.True(av.IsEditingWithPointer);
+
+        window.MouseMove(new Point(500, 100), RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+        ExpirePointerEditGrace(av);
+
+        Assert.False(av.IsEditingWithPointer);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void IsEditingWithPointer_False_ForAPlainClick()
+    {
+        // A press that starts no drag (empty area click on a waveform with no line under it is a
+        // new-selection drag, so click the middle of the line and release without moving) must not
+        // suppress change detection at all.
+        var (window, av, _) = Open(Line(1, 3));
+
+        window.MouseDown(new Point(252, 100), MouseButton.Left, RawInputModifiers.None);
+        Assert.True(av.IsEditingWithPointer); // press established a Moving drag
+        window.MouseUp(new Point(252, 100), MouseButton.Left, RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.False(av.IsEditingWithPointer);
+
+        window.Close();
+    }
+
     private static Geometry FirstCachedWaveformGeometry(AudioVisualizer av)
     {
         var field = typeof(AudioVisualizer).GetField("_waveformCacheDraws", BindingFlags.NonPublic | BindingFlags.Instance)!;

--- a/tests/UI/Controls/AudioVisualizerDragTests.cs
+++ b/tests/UI/Controls/AudioVisualizerDragTests.cs
@@ -170,6 +170,10 @@ public class AudioVisualizerDragTests
         ExpirePointerEditGrace(av);
         Assert.True(av.IsEditingWithPointer);
 
+        // The on-video preview settle keeps the plain 500 ms timing: a wasted refresh mid-drag is
+        // cheap, and a held pause is when the user wants to see the frame they are aiming at.
+        Assert.False(av.IsPointerEditSettling);
+
         window.MouseUp(new Point(478, 100), MouseButton.Left, RawInputModifiers.None);
         Dispatcher.UIThread.RunJobs();
 

--- a/tests/UI/Logic/UndoRedo/UndoRedoManagerTests.cs
+++ b/tests/UI/Logic/UndoRedo/UndoRedoManagerTests.cs
@@ -27,6 +27,25 @@ public class UndoRedoManagerTests
         }
     }
 
+    /// <summary>Starts "editing" while the snapshot is being taken - a drag that begins after the
+    /// tick already passed the IsUserEditing() gate (issue #13636).</summary>
+    private sealed class EditingStartsWhileSnapshottingClient : IUndoRedoClient
+    {
+        private bool _editing;
+
+        public int Hash { get; set; }
+        public SubtitleLineViewModel[] Subtitles { get; set; } = [];
+
+        public int GetFastHash() => Hash;
+        public bool IsUserEditing() => _editing;
+
+        public UndoRedoItem MakeUndoRedoObject(string description)
+        {
+            _editing = true;
+            return MakeItem(description, Hash, Subtitles);
+        }
+    }
+
     private sealed class BlockingHashClient : IUndoRedoClient
     {
         public ManualResetEventSlim HashEntered { get; } = new();
@@ -568,6 +587,25 @@ public class UndoRedoManagerTests
         manager.CheckForChanges(null);
 
         Assert.Equal(0, manager.UndoCount);
+    }
+
+    [Fact]
+    public void CheckForChanges_DoesNotAddEntry_WhenEditStartsDuringSnapshot_Issue13636()
+    {
+        // The gate is re-checked after the snapshot: a tick that passed the check just as a
+        // waveform drag began would otherwise record a state from a few frames into the drag
+        // (hashing and snapshotting both marshal to the busy UI thread), leaving an undo step
+        // in the middle of the drag.
+        var lines = new[] { MakeLine("hello") };
+        var client = new EditingStartsWhileSnapshottingClient { Hash = 2, Subtitles = lines };
+        var manager = new UndoRedoManager();
+        manager.SetupChangeDetection(client, TimeSpan.FromHours(1));
+        manager.StartChangeDetection();
+        manager.Do(MakeItem("initial", 1, [MakeLine("hello", 500)]));
+
+        manager.CheckForChanges(null);
+
+        Assert.Equal(1, manager.UndoCount);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #13636 — dragging a subtitle's edge in the waveform banked several undo steps, so Ctrl+Z stepped back *through* the drag instead of to before it.

## Cause

Undo entries are produced by a polling snapshotter (`UndoRedoManager`, 333 ms tick). The only thing keeping a drag from recording one per tick was a 500 ms afterglow: `AudioVisualizer.IsEditingWithPointer` was `TickCount64 - _lastPointerEditMs < 500`, and `_lastPointerEditMs` is stamped only by a pointer move that actually rewrote the time codes.

So any half second with the button held but the times unchanged reopened the window and the next tick snapshotted the half-finished drag:

- holding still mid-drag (listening, waiting for the video to scrub),
- fine-tuning inside one pixel column — a same-X or vertical-only move early-returns before the stamp,
- plus a tick that passed the gate right as the drag began, since the hash and the snapshot both marshal to the (busy) UI thread and land a few frames in.

## Fix

Gate on the drag itself rather than a timestamp. `_pointerDragActive` is set by the press that establishes a move/resize/new-selection and cleared by:

- `PointerReleased` (up front, since several paths return early),
- Escape / Enter,
- `PointerCaptureLost`,
- any later pointer move over the waveform with no button down.

The timestamp stays as the tail after release, so the settled times still get exactly one snapshot. Those clearing paths are what keeps a drag that never sees a release from leaving change detection switched off — the hazard the timestamp-only version was written to avoid. `CheckForChanges` also re-checks `IsUserEditing()` after taking the snapshot, closing the drag-start race.

The on-video preview settle shares this gate but keeps its old timing: the timestamp half is split out as `IsPointerEditSettling` and `IsUserEditingForPreview` reads that. Undo must skip the whole drag or it records half-finished times; the preview only pays a wasted refresh, and a held pause is exactly when the user wants the frame they are aiming at.

Not an SE4 regression, for what it's worth: SE4's `MakeHistoryForUndoOnlyIfNotRecent` never refreshed `_lastHistoryTicks` on a skipped call, so a continuous SE4 drag banked an entry every 500 ms too.

## Tests

`AudioVisualizerDragTests`: suppression survives an aged-out grace mid-drag (while the preview settle does not), and ends on release / Escape / a button-less move. `UndoRedoManagerTests`: no entry when editing starts during the snapshot. All four fail without the fix; full UI suite green (2716).

🤖 Generated with [Claude Code](https://claude.com/claude-code)