### PR TITLE
Prepare v5.2.0-beta14

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -3,6 +3,29 @@ Subtitle Edit Changelog
 
 -----------------------------------------------------------------------------------------------------
 
+v5.2.0-beta14 (15th of August 2026)
+
+* Add back .webm output for "burn-in subtitle", add .ts, and offer only containers the codec can use
+* Let "Visual sync" find or open a video when only a subtitle is open
+* Show install status dots for llama.cpp in the OCR window engine and model lists
+* Fix OCR with llama.cpp returning nothing but blank lines - thx fraternl
+* Fix "AI review" pairing corrections with the wrong lines - thx coreyjv
+* Fix undo stepping back through a waveform drag instead of to before it - thx thelabcat
+* Fix overlapping lines from speech to text with Crisp ASR and Parakeet - thx perkesfurmah-collab
+* Fix the subtitle grid jumping away from the line being edited when a row changes height - thx radektuma
+* Fix column shortcuts not working while the text box has focus - thx SiaL8er
+* Fix speech to text failing to extract audio with "-map 0:1 matches no streams" - thx slothsh
+* Fix "Fix short display time" listing fixes that change nothing - thx Pemicope
+* Fix Google Translate V1 inserting blank lines in multi-line texts - thx radektuma
+* Fix "Keep partial transcription?" discarding the transcribed lines anyway
+* Fix cancelling speech to text not stopping the rest of a batch
+* Fix engine and ffmpeg processes left running after closing the speech to text window
+* Improve reading of Matroska files on a network share further, now walking clusters in parallel - thx 1476523
+* Update German translation - thx Need74
+* Update Japanese translation - thx hisui3393
+
+-----------------------------------------------------------------------------------------------------
+
 v5.2.0-beta13 (14th of August 2026)
 
 * Add an "Edit original" mode, and make the original reference rows editable in place - thx bichitoxxx

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "Subtitle Edit",
-  "version": "v5.2.0-beta13",
+  "version": "v5.2.0-beta14",
   "translatedBy": "",
   "cultureName": "en-US",
   "general": {

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -19,7 +19,7 @@ public class Se
     internal const int CurrentMacOsFontMigrationVersion = 1;
     internal const int CurrentShortcutsMigrationVersion = 2;
 
-    public static string Version { get; set; } = "v5.2.0-beta13";
+    public static string Version { get; set; } = "v5.2.0-beta14";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
Version bump to `v5.2.0-beta14` plus the change-log section for the 18 pull requests merged since the `v5.2.0-beta13` tag.

The entry set was compiled by ancestor-checking every merged PR's merge commit against the tag (`git merge-base --is-ancestor <sha> v5.2.0-beta13`), so nothing is missed to a truncated log or a same-day timestamp. #13573 is excluded — it targeted `se4-legacy`, not `main` — and #13616 is an internal refactor with no user-visible surface.

`English.json` is generated from the `Language*` classes and carries `Se.Version`, so its version line moves with the bump (the regeneration test would otherwise rewrite it on the next run).

## Change-log entries

* Add back .webm output for "burn-in subtitle", add .ts, and offer only containers the codec can use (#13641)
* Let "Visual sync" find or open a video when only a subtitle is open (#13631)
* Show install status dots for llama.cpp in the OCR window engine and model lists (#13639)
* Fix OCR with llama.cpp returning nothing but blank lines - thx fraternl (#13639)
* Fix "AI review" pairing corrections with the wrong lines - thx coreyjv (#13630, #13632)
* Fix undo stepping back through a waveform drag instead of to before it - thx thelabcat (#13642)
* Fix overlapping lines from speech to text with Crisp ASR and Parakeet - thx perkesfurmah-collab (#13626)
* Fix the subtitle grid jumping away from the line being edited when a row changes height - thx radektuma (#13625)
* Fix column shortcuts not working while the text box has focus - thx SiaL8er (#13624)
* Fix speech to text failing to extract audio with "-map 0:1 matches no streams" - thx slothsh (#13623)
* Fix "Fix short display time" listing fixes that change nothing - thx Pemicope (#13620)
* Fix Google Translate V1 inserting blank lines in multi-line texts - thx radektuma (#13618)
* Fix "Keep partial transcription?" discarding the transcribed lines anyway (#13627)
* Fix cancelling speech to text not stopping the rest of a batch (#13627)
* Fix engine and ffmpeg processes left running after closing the speech to text window (#13627)
* Improve reading of Matroska files on a network share further, now walking clusters in parallel - thx 1476523 (#13629)
* Update German translation - thx Need74 (#13635)
* Update Japanese translation - thx hisui3393 (#13640)

🤖 Generated with [Claude Code](https://claude.com/claude-code)