### PR TITLE
seconv: fail on unknown options, add --json everywhere and --help-json

### DIFF
--- a/docs/reference/command-line.md
+++ b/docs/reference/command-line.md
@@ -40,6 +40,13 @@ seconv "*.srt,*.ass" subrip --input-folder:./in
 
 Options accept either `--option:value`, `--option=value`, or `--option value`. The colon form is shown throughout this page.
 
+An unrecognised option is an error, never a silent no-op: `seconv` exits 1 and suggests the closest real option rather than converting the file without the operation you asked for.
+
+```console
+$ seconv movie.srt subrip --remove-formating
+Error: Unknown option '--remove-formating'. Did you mean '--remove-formatting'?
+```
+
 ### Quick examples
 
 ```bash
@@ -77,8 +84,34 @@ seconv list-rf-rules        # list remove-formatting rule IDs
 seconv dump-settings        # print a full --settings JSON with libse defaults
 seconv info <file>          # print format/encoding/duration/language for a file
 seconv lint <pattern>       # validate subtitle(s); exit 1 if issues found
-seconv --help               # show help
+seconv --help               # show help (same text as -h, /? and /help)
+seconv --help-json          # print the whole command-line schema as JSON
 seconv --version            # print version and exit
+```
+
+### Machine-readable output
+
+Every subcommand above accepts `--json`, and so does a conversion run. Scripts and agents should prefer it: the tables are hundreds of box-drawing lines, while the JSON gives you the exact tokens each option accepts.
+
+```bash
+seconv formats --json | jq -r '.formats[] | select(.inputOnly | not) | .id'
+seconv list-fce-rules --json | jq -r '.rules[].id'
+seconv list-ocr-engines --json | jq -r '.engines[] | select(.ready) | .id'
+```
+
+In `formats --json`, `id` is the token `--format` matches on (the display name with spaces removed); `name` is the human-readable name; `inputOnly` marks formats that can be loaded but not used as a conversion target.
+
+`seconv --help-json` describes the command line itself — every option with its aliases, type (`flag`, `string`, `integer`, `number`), whether it is an operation, its closed value set where it has one, and the subcommand that enumerates valid values otherwise. It is reflected off the parser, so it cannot drift from the options actually accepted.
+
+```bash
+seconv --help-json | jq -r '.options[] | select(.group == "operation") | .name'
+seconv --help-json | jq -r '.options[] | select(.discover) | "\(.name)\t\(.discover)"'
+```
+
+Under `--json`, stdout is always a single JSON document — on success *and* on failure. A usage error (unknown option, bad value, no files matched) comes back in the same envelope as a failed conversion, with the message in `errors`:
+
+```json
+{ "success": false, "totalFiles": 0, "files": [], "errors": ["Unknown option '--bogus'."], "warnings": [] }
 ```
 
 ### Inspect & validate
@@ -441,7 +474,7 @@ seconv *.srt subrip --settings:my.json --profile:broadcast --remove-text-for-hi
 |---|---|
 | `--quiet` / `-q` | Suppress per-file progress and the parameters table; only print the final summary |
 | `--verbose` / `-v` | Print extra diagnostic information, including full exception details (stack traces) on errors |
-| `--json` | Emit per-file results as JSON to stdout (suppresses Spectre output) |
+| `--json` | Emit per-file results as JSON to stdout (suppresses Spectre output). Also accepted by every subcommand. Failures use the same envelope, so stdout is always one JSON document |
 
 ## Operations
 
@@ -618,14 +651,16 @@ This mirrors the desktop app, where batch convert's *Remove formatting* function
 | `plaintext`, `text`, `txt` | Plain text (HTML stripped) |
 | `customtext`, `customtextformat` | Custom-templated text (requires `--custom-format`) |
 
-Run `seconv formats` for the full catalog (380+ entries, including input-only formats like Matroska, MP4, and MCC).
+Run `seconv formats` for the full catalog (380+ entries, including input-only formats like Matroska, MP4, and MCC), or `seconv formats --json` for the machine-readable list whose `id` field is exactly what `--format` accepts.
 
 ## Exit codes
 
 | Code | Meaning |
 |---|---|
 | `0` | Conversion succeeded for all matched files |
-| `1` | Any error: validation failure, parse error, OCR engine missing, invalid `--settings` file, or one or more files failed to convert |
+| `1` | Any error: bad usage, unknown option, rejected option value, no files matched, parse error, OCR engine missing, invalid `--settings` file, or one or more files failed to convert |
+
+There are only these two. Every failure path — including argument parsing — exits 1.
 
 ## Legacy syntax
 

--- a/src/seconv/Commands/ConvertCommand.cs
+++ b/src/seconv/Commands/ConvertCommand.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using SeConv.Core;
+using SeConv.Helpers;
 
 namespace SeConv.Commands;
 
@@ -399,14 +400,15 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
             // Validate input
             if (settings.Pattern.Length == 0)
             {
-                AnsiConsole.MarkupLine("[red]Error: Pattern is required[/]");
-                return 1;
+                return Fail(settings, "Pattern is required.");
             }
 
             if (string.IsNullOrWhiteSpace(settings.Format))
             {
-                AnsiConsole.MarkupLine("[red]Error: Format is required. Use --format <name> or pass it as the second positional argument (e.g. seconv *.srt sami)[/]");
-                return 1;
+                return Fail(
+                    settings,
+                    "Format is required. Use --format <name> or pass it as the second positional argument (e.g. seconv *.srt sami). " +
+                    "List the valid names with: seconv formats --json");
             }
 
             // Validate --ocr-engine: tesseract | nocr | binaryocr | ollama | llamacpp | paddle
@@ -414,10 +416,10 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
             if (!string.IsNullOrWhiteSpace(settings.OcrEngine) &&
                 !supportedEngines.Contains(settings.OcrEngine, StringComparer.OrdinalIgnoreCase))
             {
-                AnsiConsole.MarkupLine(
-                    $"[red]Error: OCR engine '{settings.OcrEngine.EscapeMarkup()}' is not supported (pass via --ocr-engine). " +
-                    "Use one of: tesseract, nocr, binaryocr, ollama, llamacpp, paddle.[/]");
-                return 1;
+                return Fail(
+                    settings,
+                    $"OCR engine '{settings.OcrEngine}' is not supported (pass via --ocr-engine). " +
+                    "Use one of: tesseract, nocr, binaryocr, ollama, llamacpp, paddle.");
             }
 
             // --ocr-model/--ocr-url only apply to the llama.cpp OCR engine - fail fast instead
@@ -426,8 +428,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                                 settings.OcrEngine.Trim().ToLowerInvariant() is "llamacpp" or "llama.cpp" or "llama";
             if ((!string.IsNullOrWhiteSpace(settings.OcrModel) || !string.IsNullOrWhiteSpace(settings.OcrUrl)) && !isLlamaCppOcr)
             {
-                AnsiConsole.MarkupLine("[red]Error: --ocr-model/--ocr-url require --ocr-engine:llamacpp.[/]");
-                return 1;
+                return Fail(settings, "--ocr-model/--ocr-url require --ocr-engine:llamacpp.");
             }
 
             // Validate the translate options: --translate-to is the trigger, the rest refine it.
@@ -437,18 +438,17 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                  !string.IsNullOrWhiteSpace(settings.TranslateUrl) ||
                  !string.IsNullOrWhiteSpace(settings.TranslateModel)))
             {
-                AnsiConsole.MarkupLine("[red]Error: --translate-from/--translate-engine/--translate-url/--translate-model require --translate-to:<language>.[/]");
-                return 1;
+                return Fail(settings, "--translate-from/--translate-engine/--translate-url/--translate-model require --translate-to:<language>.");
             }
 
             if (!string.IsNullOrWhiteSpace(settings.TranslateEngine) &&
                 !AutoTranslateRunner.SupportedEngines.Contains(settings.TranslateEngine.Trim(), StringComparer.OrdinalIgnoreCase) &&
                 !settings.TranslateEngine.Trim().Equals("llama.cpp", StringComparison.OrdinalIgnoreCase))
             {
-                AnsiConsole.MarkupLine(
-                    $"[red]Error: Translate engine '{settings.TranslateEngine.EscapeMarkup()}' is not supported (pass via --translate-engine). " +
-                    $"Use one of: {string.Join(", ", AutoTranslateRunner.SupportedEngines)}.[/]");
-                return 1;
+                return Fail(
+                    settings,
+                    $"Translate engine '{settings.TranslateEngine}' is not supported (pass via --translate-engine). " +
+                    $"Use one of: {string.Join(", ", AutoTranslateRunner.SupportedEngines)}.");
             }
 
             // Fail fast on a typo in --encoding so we don't silently substitute UTF-8 and
@@ -458,10 +458,10 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 !LibSEIntegration.IsSourceEncodingSentinel(settings.Encoding) &&
                 !LibSEIntegration.TryGetEncoding(settings.Encoding, out _))
             {
-                AnsiConsole.MarkupLine(
-                    $"[red]Error: Unknown encoding '{settings.Encoding.EscapeMarkup()}' for --encoding.[/]");
-                AnsiConsole.MarkupLine("[dim]Use 'seconv list-encodings' to see supported encodings, or 'source' to keep the input file's encoding.[/]");
-                return 1;
+                return Fail(
+                    settings,
+                    $"Unknown encoding '{settings.Encoding}' for --encoding. " +
+                    "List the supported encodings with: seconv list-encodings --json. Use 'source' to keep the input file's encoding.");
             }
 
             // Fail fast on a typo in --input-encoding-fallback so we don't silently substitute
@@ -469,10 +469,10 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
             if (!string.IsNullOrWhiteSpace(settings.InputEncodingFallback) &&
                 !LibSEIntegration.TryGetEncoding(settings.InputEncodingFallback, out _))
             {
-                AnsiConsole.MarkupLine(
-                    $"[red]Error: Unknown encoding '{settings.InputEncodingFallback.EscapeMarkup()}' for --input-encoding-fallback.[/]");
-                AnsiConsole.MarkupLine("[dim]Use 'seconv list-encodings' to see supported encodings.[/]");
-                return 1;
+                return Fail(
+                    settings,
+                    $"Unknown encoding '{settings.InputEncodingFallback}' for --input-encoding-fallback. " +
+                    "List the supported encodings with: seconv list-encodings --json");
             }
 
             // Load --settings:path.json overrides into libse Configuration before any conversion.
@@ -509,14 +509,12 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 }
                 catch (Exception ex)
                 {
-                    AnsiConsole.MarkupLineInterpolated($"[red]Error loading --settings file: {ex.Message}[/]");
-                    return 1;
+                    return Fail(settings, $"Loading --settings file: {ex.Message}");
                 }
             }
             else if (!string.IsNullOrWhiteSpace(settings.Profile))
             {
-                AnsiConsole.MarkupLine("[red]Error: --profile requires --settings:<path.json>[/]");
-                return 1;
+                return Fail(settings, "--profile requires --settings:<path.json>");
             }
 
             // Image styling flags override the settings JSON. Unlike the JSON (which only warns
@@ -524,13 +522,12 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
             var imageStyleError = ApplyImageStyleFlags(settings, imageStyle);
             if (imageStyleError != null)
             {
-                AnsiConsole.MarkupLineInterpolated($"[red]Error: {imageStyleError}[/]");
-                return 1;
+                return Fail(settings, imageStyleError);
             }
 
             // Must run after the --settings JSON is applied: a bare --apply-min-gap takes its
             // value from libse's (possibly overridden) MinimumMillisecondsBetweenLines.
-            if (!TryResolveApplyMinGap(settings, silent, out var applyMinGapMs))
+            if (!TryResolveApplyMinGap(settings, out var applyMinGapMs))
             {
                 return 1;
             }
@@ -547,8 +544,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 }
                 catch (ArgumentException ex)
                 {
-                    AnsiConsole.MarkupLineInterpolated($"[red]Error: {ex.Message}[/]");
-                    return 1;
+                    return Fail(settings, ex.Message);
                 }
 
                 // A supplied --fce-language that can't be resolved falls back to auto-detect;
@@ -576,8 +572,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 }
                 catch (ArgumentException ex)
                 {
-                    AnsiConsole.MarkupLineInterpolated($"[red]Error: {ex.Message}[/]");
-                    return 1;
+                    return Fail(settings, ex.Message);
                 }
             }
 
@@ -614,8 +609,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
             // Validate --change-speed (must be > 0; 100 means no change)
             if (settings.ChangeSpeed.HasValue && settings.ChangeSpeed.Value <= 0)
             {
-                AnsiConsole.MarkupLine($"[red]Error: --change-speed must be greater than 0 (got {settings.ChangeSpeed.Value}).[/]");
-                return 1;
+                return Fail(settings, $"--change-speed must be greater than 0 (got {settings.ChangeSpeed.Value}).");
             }
 
             // Parse offset if supplied
@@ -628,8 +622,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 }
                 catch (FormatException ex)
                 {
-                    AnsiConsole.MarkupLineInterpolated($"[red]Error: {ex.Message}[/]");
-                    return 1;
+                    return Fail(settings, ex.Message);
                 }
             }
 
@@ -643,8 +636,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 }
                 catch (FormatException ex)
                 {
-                    AnsiConsole.MarkupLineInterpolated($"[red]Error: {ex.Message}[/]");
-                    return 1;
+                    return Fail(settings, ex.Message);
                 }
             }
 
@@ -658,8 +650,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 }
                 catch (FormatException ex)
                 {
-                    AnsiConsole.MarkupLineInterpolated($"[red]Error: {ex.Message}[/]");
-                    return 1;
+                    return Fail(settings, ex.Message);
                 }
             }
 
@@ -850,18 +841,41 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
         {
             if (settings.Json)
             {
-                Console.Error.WriteLine(System.Text.Json.JsonSerializer.Serialize(new { error = ex.Message }));
+                // The failure envelope goes to stdout like every other --json document: a
+                // caller reading stdout should never have to fall back to stderr to find out
+                // that the run failed.
+                return Fail(settings, ex.InnerException != null
+                    ? $"{ex.Message}: {ex.InnerException.Message}"
+                    : ex.Message);
             }
-            else
+
+            AnsiConsole.MarkupLineInterpolated($"[red]Error: {ex.Message}[/]");
+            if (ex.InnerException != null)
             {
-                AnsiConsole.MarkupLineInterpolated($"[red]Error: {ex.Message}[/]");
-                if (ex.InnerException != null)
-                {
-                    AnsiConsole.MarkupLineInterpolated($"[dim]{ex.InnerException.Message}[/]");
-                }
+                AnsiConsole.MarkupLineInterpolated($"[dim]{ex.InnerException.Message}[/]");
             }
             return 1;
         }
+    }
+
+    /// <summary>
+    /// Reports a validation failure and returns exit code 1. Under <c>--json</c> the message
+    /// goes out in the same envelope a failed conversion uses, so a caller parsing stdout gets
+    /// one document shape on every path instead of JSON on success and plain text on a bad
+    /// option value.
+    /// </summary>
+    private static int Fail(Settings settings, string message)
+    {
+        if (settings.Json)
+        {
+            Console.Out.WriteLine(JsonOut.UsageError(message));
+        }
+        else
+        {
+            AnsiConsole.MarkupLineInterpolated($"[red]Error: {message}[/]");
+        }
+
+        return 1;
     }
 
     private static void PrintWarnings(ConversionResult result)
@@ -914,8 +928,9 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
     /// A bare --apply-min-gap uses libse's MinimumMillisecondsBetweenLines, so it follows the
     /// --settings JSON. Returns false when the value is unusable, after printing the error.
     /// </summary>
-    private static bool TryResolveApplyMinGap(Settings settings, bool silent, out int? gapMs)
+    private static bool TryResolveApplyMinGap(Settings settings, out int? gapMs)
     {
+        var silent = settings.Quiet || settings.Json;
         gapMs = null;
         if (settings.ApplyMinGap?.IsSet != true)
         {
@@ -932,8 +947,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
 
         if (!int.TryParse(raw.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var ms))
         {
-            AnsiConsole.MarkupLineInterpolated(
-                $"[red]Error: --apply-min-gap expects a value in milliseconds, got '{raw}'.[/]");
+            Fail(settings, $"--apply-min-gap expects a value in milliseconds, got '{raw}'.");
             return false;
         }
 

--- a/src/seconv/Commands/FormatsCommand.cs
+++ b/src/seconv/Commands/FormatsCommand.cs
@@ -2,6 +2,7 @@ using Spectre.Console;
 using Spectre.Console.Cli;
 using System.ComponentModel;
 using SeConv.Core;
+using SeConv.Helpers;
 
 namespace SeConv.Commands;
 
@@ -10,14 +11,39 @@ internal sealed class FormatsCommand : Command<FormatsCommand.Settings>
 {
     public sealed class Settings : CommandSettings
     {
+        [CommandOption("--json")]
+        [Description("Emit the format list as JSON to stdout")]
+        public bool Json { get; init; }
     }
 
     protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
+        var formats = LibSEIntegration.GetAvailableFormats();
+
+        if (settings.Json)
+        {
+            JsonOut.Write(new
+            {
+                formats = formats.Select(entry => new
+                {
+                    // 'id' is what --format actually matches on: the name with spaces removed,
+                    // compared case-insensitively. The display name is kept separately so a
+                    // caller never has to derive one from the other.
+                    id = entry.Format.Name.Replace(" ", string.Empty),
+                    name = entry.Format.Name,
+                    extension = entry.Format.Extension,
+                    type = entry.Kind.StartsWith("binary", StringComparison.Ordinal) ? "binary" : "text",
+                    inputOnly = entry.Kind.Contains("(input)", StringComparison.Ordinal),
+                }),
+                total = formats.Count,
+                extraIds = new[] { "customtext", "customtextformat", "plaintext" },
+                note = "Pass 'id' to --format or as the second positional argument. An inputOnly format can be loaded but not used as the conversion target.",
+            });
+            return 0;
+        }
+
         AnsiConsole.MarkupLine("[bold cyan]Available Subtitle Formats[/]");
         AnsiConsole.WriteLine();
-
-        var formats = LibSEIntegration.GetAvailableFormats();
 
         var table = new Table();
         table.Border(TableBorder.Rounded);

--- a/src/seconv/Core/ListHelpers.cs
+++ b/src/seconv/Core/ListHelpers.cs
@@ -2,18 +2,44 @@ using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Spectre.Console;
 using System.Text;
 using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
+using SeConv.Helpers;
 
 namespace SeConv.Core;
 
 /// <summary>
 /// CLI list helpers: <c>seconv list-encodings</c>, <c>seconv list-pac-codepages</c>,
 /// <c>seconv list-ocr-engines</c>. Each prints a formatted reference table to stdout
-/// and returns 0.
+/// and returns 0, or a machine-readable document when <c>--json</c> is passed.
+///
+/// These are the discovery commands a script or agent runs first, so every one of them
+/// accepts <c>--json</c>: the tables are hundreds of box-drawing lines that are expensive
+/// to parse and easy to misread. In JSON, the <c>id</c> field is always the exact token
+/// the corresponding option accepts.
 /// </summary>
 internal static class ListHelpers
 {
-    public static void PrintEncodings()
+    public static void PrintEncodings(bool json = false)
     {
+        var encodingList = Encoding.GetEncodings().OrderBy(e => e.CodePage).ToList();
+
+        if (json)
+        {
+            JsonOut.Write(new
+            {
+                encodings = encodingList.Select(e => new
+                {
+                    id = e.Name,
+                    codePage = e.CodePage,
+                    name = e.Name,
+                    displayName = e.DisplayName,
+                }),
+                total = encodingList.Count,
+                special = new[] { "utf-8", "utf-8-no-bom", "source" },
+                note = "Pass either the code page number or the name to --encoding. 'source' keeps the input file's detected encoding.",
+            });
+            return;
+        }
+
         AnsiConsole.MarkupLine("[bold cyan]Supported encodings (pass via --encoding)[/]");
         AnsiConsole.WriteLine();
         var table = new Table().Border(TableBorder.Rounded);
@@ -21,10 +47,7 @@ internal static class ListHelpers
         table.AddColumn("[green]Name[/]");
         table.AddColumn("[cyan]Description[/]");
 
-        var encodings = Encoding.GetEncodings()
-            .OrderBy(e => e.CodePage)
-            .ToList();
-        foreach (var info in encodings)
+        foreach (var info in encodingList)
         {
             table.AddRow(
                 info.CodePage.ToString(),
@@ -36,15 +59,8 @@ internal static class ListHelpers
         AnsiConsole.MarkupLine($"\n[dim]Pass either the code page number or the name. Special values: utf-8, utf-8-no-bom.[/]");
     }
 
-    public static void PrintPacCodepages()
+    public static void PrintPacCodepages(bool json = false)
     {
-        AnsiConsole.MarkupLine("[bold cyan]PAC code pages (pass via --pac-codepage)[/]");
-        AnsiConsole.WriteLine();
-        var table = new Table().Border(TableBorder.Rounded);
-        table.AddColumn("[yellow]ID[/]");
-        table.AddColumn("[green]Name[/]");
-        table.AddColumn("[cyan]Aliases[/]");
-
         (int id, string name, string aliases)[] rows =
         [
             (Pac.CodePageLatin, "Latin", "0"),
@@ -62,6 +78,30 @@ internal static class ListHelpers
             (Pac.CodePageLatinPortuguese, "LatinPortuguese", "Portuguese, 12"),
         ];
 
+        if (json)
+        {
+            JsonOut.Write(new
+            {
+                codePages = rows.Select(r => new
+                {
+                    id = r.name,
+                    pacId = r.id,
+                    name = r.name,
+                    aliases = r.aliases.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
+                }),
+                total = rows.Length,
+                note = "Pass the name or any alias to --pac-codepage.",
+            });
+            return;
+        }
+
+        AnsiConsole.MarkupLine("[bold cyan]PAC code pages (pass via --pac-codepage)[/]");
+        AnsiConsole.WriteLine();
+        var table = new Table().Border(TableBorder.Rounded);
+        table.AddColumn("[yellow]ID[/]");
+        table.AddColumn("[green]Name[/]");
+        table.AddColumn("[cyan]Aliases[/]");
+
         foreach (var (id, name, aliases) in rows)
         {
             table.AddRow(id.ToString(), $"[green]{name}[/]", $"[cyan]{aliases}[/]");
@@ -70,8 +110,34 @@ internal static class ListHelpers
         AnsiConsole.Write(table);
     }
 
-    public static void PrintFixCommonErrorsRules()
+    public static void PrintFixCommonErrorsRules(bool json = false)
     {
+        var gates = FixCommonErrorsRunner.LanguageGates;
+        var guiLabels = FixCommonErrorsRunner.GuiLabels;
+
+        if (json)
+        {
+            JsonOut.Write(new
+            {
+                rules = FixCommonErrorsRunner.AvailableRuleIds.Select(id => new
+                {
+                    id,
+                    guiLabel = guiLabels.TryGetValue(id, out var label) ? label : null,
+                    languageGate = gates.TryGetValue(id, out var lang) ? lang : null,
+                }),
+                total = FixCommonErrorsRunner.AvailableRuleIds.Count,
+                syntax = new
+                {
+                    all = "--fix-common-errors",
+                    subset = "--fix-common-errors-rules:FixCommas,FixEllipsesStart",
+                    allExcept = "--fix-common-errors-rules:all,-FixDanishLetterI",
+                    forceLanguage = "--fce-language:es",
+                },
+                note = "A language-gated rule runs only when the subtitle's language matches (auto-detected, or forced with --fce-language). Naming a gated rule selects it but does not bypass the gate.",
+            });
+            return;
+        }
+
         AnsiConsole.MarkupLine("[bold cyan]FixCommonErrors rule IDs (pass via --fix-common-errors-rules)[/]");
         AnsiConsole.WriteLine();
         var table = new Table().Border(TableBorder.Rounded);
@@ -79,8 +145,6 @@ internal static class ListHelpers
         table.AddColumn("[yellow]GUI equivalent[/]");
         table.AddColumn("[yellow]Language gate[/]");
 
-        var gates = FixCommonErrorsRunner.LanguageGates;
-        var guiLabels = FixCommonErrorsRunner.GuiLabels;
         foreach (var id in FixCommonErrorsRunner.AvailableRuleIds)
         {
             // GUI equivalent: the checkbox label the desktop Fix Common Errors window shows for
@@ -108,8 +172,29 @@ internal static class ListHelpers
             "  [dim]--fix-common-errors-rules:FixSpanishInvertedQuestionAndExclamationMarks --fce-language:es[/]  [dim]# force a named gated rule[/]");
     }
 
-    public static void PrintRemoveFormattingRules()
+    public static void PrintRemoveFormattingRules(bool json = false)
     {
+        if (json)
+        {
+            JsonOut.Write(new
+            {
+                rules = RemoveFormattingRunner.AvailableRuleIds.Select(id => new
+                {
+                    id,
+                    guiLabel = RemoveFormattingRunner.GuiLabels.TryGetValue(id, out var label) ? label : null,
+                }),
+                total = RemoveFormattingRunner.AvailableRuleIds.Count,
+                syntax = new
+                {
+                    everyTag = "--remove-formatting",
+                    subset = "--remove-formatting-rules:RemoveItalic,RemoveBold",
+                    allExcept = "--remove-formatting-rules:all,-RemoveColor",
+                },
+                note = "Bare --remove-formatting strips every tag wholesale, which is broader than --remove-formatting-rules:all (the union of the rules above). Tags no rule covers, e.g. positioning like {\\pos(..)}, only go away with the bare flag.",
+            });
+            return;
+        }
+
         AnsiConsole.MarkupLine("[bold cyan]Remove-formatting rule IDs (pass via --remove-formatting-rules)[/]");
         AnsiConsole.WriteLine();
         var table = new Table().Border(TableBorder.Rounded);
@@ -140,8 +225,70 @@ internal static class ListHelpers
             "  [dim]--remove-formatting-rules:all,-RemoveColor[/]           [dim]# every named rule except colors[/]");
     }
 
-    public static void PrintOcrEngines()
+    public static void PrintOcrEngines(bool json = false)
     {
+        var tesseractInstalled = TesseractOcrEngine.Detect() is not null;
+        var paddleInstalled = PaddleOcrEngine.Detect() is not null;
+        var llamaCppInstalled = LlamaCppLocal.TryEnsureServerBinary();
+        var llamaCppModelCount = LlamaCppServerManager.OcrModels.Count(LlamaCppServerManager.IsModelInstalled);
+
+        if (json)
+        {
+            // 'ready' is the actionable field: whether this engine can run right now without
+            // further setup. nocr/binaryocr are in-process but need a database file, so they
+            // are only ready once --ocr-db points at one — which this command cannot know.
+            JsonOut.Write(new
+            {
+                engines = new object[]
+                {
+                    new
+                    {
+                        id = "tesseract", aliases = Array.Empty<string>(), type = "subprocess",
+                        isDefault = true, ready = tesseractInstalled,
+                        requires = "`tesseract` binary on PATH",
+                        options = new[] { "--ocr-language" },
+                    },
+                    new
+                    {
+                        id = "nocr", aliases = Array.Empty<string>(), type = "in-process",
+                        isDefault = false, ready = (bool?)null,
+                        requires = "--ocr-db pointing at a .nocr database (e.g. Latin.nocr, under Subtitle Edit's OCR folder)",
+                        options = new[] { "--ocr-db" },
+                    },
+                    new
+                    {
+                        id = "binaryocr", aliases = Array.Empty<string>(), type = "in-process",
+                        isDefault = false, ready = (bool?)null,
+                        requires = "--ocr-db pointing at a .db database (e.g. Latin.db, under Subtitle Edit's OCR folder)",
+                        options = new[] { "--ocr-db" },
+                    },
+                    new
+                    {
+                        id = "ollama", aliases = Array.Empty<string>(), type = "http",
+                        isDefault = false, ready = (bool?)null,
+                        requires = "A running Ollama instance with a vision model",
+                        options = new[] { "--ollama-url", "--ollama-model", "--ocr-language" },
+                    },
+                    new
+                    {
+                        id = "llamacpp", aliases = Array.Empty<string>(), type = "http",
+                        isDefault = false, ready = llamaCppInstalled && llamaCppModelCount > 0,
+                        requires = $"llama-server ({(llamaCppInstalled ? "installed" : "not found")}) plus an OCR model ({llamaCppModelCount} installed) — download via Subtitle Edit's OCR window, or point --ocr-url at a running server",
+                        options = new[] { "--ocr-model", "--ocr-url", "--ocr-language" },
+                    },
+                    new
+                    {
+                        id = "paddle", aliases = new[] { "paddleocr" }, type = "subprocess",
+                        isDefault = false, ready = paddleInstalled,
+                        requires = "`paddleocr` binary on PATH (`pip install paddleocr`)",
+                        options = new[] { "--ocr-language" },
+                    },
+                },
+                note = "Language codes differ per engine: Tesseract uses ISO 639-2 (eng, deu), Paddle uses short codes (en, de), Ollama and llama.cpp take a human-readable language name.",
+            });
+            return;
+        }
+
         AnsiConsole.MarkupLine("[bold cyan]OCR engines (pass via --ocr-engine)[/]");
         AnsiConsole.WriteLine();
         var table = new Table().Border(TableBorder.Rounded);
@@ -149,8 +296,8 @@ internal static class ListHelpers
         table.AddColumn("[green]Type[/]");
         table.AddColumn("[cyan]Requirements[/]");
 
-        var tesseract = TesseractOcrEngine.Detect() is not null ? "installed ✓" : "not on PATH";
-        var paddle = PaddleOcrEngine.Detect() is not null ? "installed ✓" : "not on PATH";
+        var tesseract = tesseractInstalled ? "installed ✓" : "not on PATH";
+        var paddle = paddleInstalled ? "installed ✓" : "not on PATH";
 
         table.AddRow(
             "[green]tesseract[/] (default)",
@@ -169,12 +316,11 @@ internal static class ListHelpers
             "HTTP",
             "Local Ollama with vision model. --ollama-url, --ollama-model");
 
-        var llamaCppServer = LlamaCppLocal.TryEnsureServerBinary() ? "installed ✓" : "not found";
-        var llamaCppModels = LlamaCppServerManager.OcrModels.Count(LlamaCppServerManager.IsModelInstalled);
+        var llamaCppServer = llamaCppInstalled ? "installed ✓" : "not found";
         table.AddRow(
             "[green]llamacpp[/]",
             "HTTP",
-            $"llama-server ({llamaCppServer}) + OCR model ({llamaCppModels} installed) — download via SE's OCR window, or --ocr-url. --ocr-model, --ocr-url");
+            $"llama-server ({llamaCppServer}) + OCR model ({llamaCppModelCount} installed) — download via SE's OCR window, or --ocr-url. --ocr-model, --ocr-url");
         table.AddRow(
             "[green]paddle[/] / [green]paddleocr[/]",
             "subprocess",

--- a/src/seconv/Core/OperationOrderParser.cs
+++ b/src/seconv/Core/OperationOrderParser.cs
@@ -18,7 +18,7 @@ internal static class OperationOrderParser
     // The CLI exposes each as a lowercase-hyphenated flag plus a PascalCase alias; both
     // normalize to the canonical name (lower-cased, dashes removed), so this list doubles
     // as the alias table.
-    private static readonly string[] ToggleOperations =
+    internal static readonly string[] ToggleOperations =
     {
         "ApplyDurationLimits",
         "BalanceLines",

--- a/src/seconv/Helpers/CliSchema.cs
+++ b/src/seconv/Helpers/CliSchema.cs
@@ -1,0 +1,346 @@
+using System.ComponentModel;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using SeConv.Commands;
+using SeConv.Core;
+
+namespace SeConv.Helpers;
+
+/// <summary>
+/// Machine-readable description of the command line, reflected off
+/// <see cref="ConvertCommand.Settings"/> so it cannot drift from the options the parser
+/// actually binds. Drives <c>seconv --help-json</c> and the "did you mean" suggestion
+/// printed for an unknown option.
+/// </summary>
+internal static class CliSchema
+{
+    public const string Version = "5.0.0";
+
+    /// <summary>Schema revision, bumped when the emitted JSON shape changes (not its contents).</summary>
+    public const int SchemaVersion = 1;
+
+    /// <summary>
+    /// Subcommands that read valid values for an option at runtime. An agent that hits an
+    /// "unknown value" error can follow this to the enumeration instead of guessing.
+    /// </summary>
+    private static readonly Dictionary<string, string> DiscoveryCommands = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["--format"] = "seconv formats --json",
+        ["--encoding"] = "seconv list-encodings --json",
+        ["--input-encoding-fallback"] = "seconv list-encodings --json",
+        ["--pac-codepage"] = "seconv list-pac-codepages --json",
+        ["--ocr-engine"] = "seconv list-ocr-engines --json",
+        ["--fix-common-errors-rules"] = "seconv list-fce-rules --json",
+        ["--remove-formatting-rules"] = "seconv list-rf-rules --json",
+        ["--settings"] = "seconv dump-settings",
+    };
+
+    /// <summary>
+    /// Closed value sets, for options whose validator rejects anything else. Kept here rather
+    /// than parsed out of the description text; <c>CliSchemaTest</c> asserts every key still
+    /// names a real option.
+    /// </summary>
+    private static readonly Dictionary<string, string[]> Choices = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["--ocr-engine"] = ["tesseract", "nocr", "binaryocr", "ollama", "llamacpp", "paddle"],
+        ["--translate-engine"] = ["llamacpp", "ollama", "lmstudio", "libretranslate", "nllb-serve", "nllb-api"],
+        ["--box-type"] = ["none", "one-box", "box-per-line"],
+        ["--content-alignment"] = ["left", "center", "right"],
+        ["--alignment"] =
+        [
+            "top-left", "top-center", "top-right",
+            "middle-left", "middle-center", "middle-right",
+            "bottom-left", "bottom-center", "bottom-right",
+        ],
+    };
+
+    /// <summary>
+    /// Value-carrying options that belong to the operations pipeline rather than to output
+    /// configuration. The boolean operations are taken from
+    /// <see cref="OperationOrderParser.ToggleOperations"/> so that half of the grouping
+    /// cannot drift.
+    /// </summary>
+    private static readonly HashSet<string> ValueOperations = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "--apply-min-gap",
+        "--bridge-gaps",
+        "--delete-first",
+        "--delete-last",
+        "--delete-contains",
+        "--fix-common-errors-rules",
+        "--fce-language",
+        "--dictionary-folder",
+        "--remove-formatting-rules",
+    };
+
+    internal sealed record OptionInfo(
+        [property: JsonPropertyName("name")] string Name,
+        [property: JsonPropertyName("aliases")] IReadOnlyList<string> Aliases,
+        [property: JsonPropertyName("type")] string Type,
+        [property: JsonPropertyName("group")] string Group,
+        [property: JsonPropertyName("description")] string Description,
+        [property: JsonPropertyName("choices"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] IReadOnlyList<string>? Choices,
+        [property: JsonPropertyName("discover"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? Discover);
+
+    private static IReadOnlyList<OptionInfo>? _options;
+
+    /// <summary>
+    /// Every option the convert command binds, in declaration order. The first name in a
+    /// Spectre template is the canonical one; the rest are back-compat aliases.
+    /// </summary>
+    public static IReadOnlyList<OptionInfo> Options => _options ??= BuildOptions();
+
+    private static IReadOnlyList<OptionInfo> BuildOptions()
+    {
+        var toggleOperations = new HashSet<string>(
+            OperationOrderParser.ToggleOperations.Select(o => "--" + o.ToLowerInvariant()),
+            StringComparer.OrdinalIgnoreCase);
+
+        var options = new List<OptionInfo>();
+        foreach (var property in typeof(ConvertCommand.Settings).GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            var template = ReadAttributeTemplate(property, "CommandOptionAttribute");
+            if (template is null)
+            {
+                continue;
+            }
+
+            var names = ParseTemplate(template);
+            if (names.Count == 0)
+            {
+                continue;
+            }
+
+            var name = names[0];
+            // A toggle operation's canonical flag is its PascalCase name hyphen-stripped, so
+            // compare on the same footing (--remove-text-for-hi vs RemoveTextForHI).
+            var isOperation = ValueOperations.Contains(name) ||
+                              toggleOperations.Contains("--" + name.TrimStart('-').Replace("-", string.Empty));
+
+            options.Add(new OptionInfo(
+                Name: name,
+                Aliases: names.Skip(1).ToArray(),
+                Type: DescribeType(property.PropertyType),
+                Group: isOperation ? "operation" : "option",
+                Description: ReadDescription(property),
+                Choices: Choices.TryGetValue(name, out var choices) ? choices : null,
+                Discover: DiscoveryCommands.TryGetValue(name, out var discover) ? discover : null));
+        }
+
+        return options;
+    }
+
+    /// <summary>
+    /// Every accepted option token, canonical names and aliases alike. Used to reject
+    /// unknown options with a suggestion rather than a bare parser error.
+    /// </summary>
+    public static IReadOnlyCollection<string> AllTokens =>
+        Options.SelectMany(o => new[] { o.Name }.Concat(o.Aliases)).ToArray();
+
+    /// <summary>
+    /// Best-matching known option for a mistyped one, or null when nothing is close enough.
+    /// The distance budget scales with length so short flags don't match everything, and
+    /// a token that is a prefix/suffix of a real option always matches (e.g. the common
+    /// "--remove-formating" single-letter drop).
+    /// </summary>
+    public static string? SuggestClosest(string unknown)
+    {
+        var needle = "--" + unknown.TrimStart('-', '/');
+        if (needle.Length <= 2)
+        {
+            return null;
+        }
+
+        var budget = Math.Max(2, needle.Length / 4);
+        string? best = null;
+        var bestDistance = int.MaxValue;
+
+        foreach (var candidate in AllTokens)
+        {
+            var distance = Levenshtein(needle, candidate);
+            if (distance < bestDistance && distance <= budget)
+            {
+                bestDistance = distance;
+                best = candidate;
+            }
+        }
+
+        return best;
+    }
+
+    private static int Levenshtein(string a, string b)
+    {
+        // Case-insensitive: the parser accepts --FixCommonErrors as well as --fix-common-errors,
+        // so a casing-only difference should never read as a typo.
+        var previous = new int[b.Length + 1];
+        var current = new int[b.Length + 1];
+        for (var j = 0; j <= b.Length; j++)
+        {
+            previous[j] = j;
+        }
+
+        for (var i = 1; i <= a.Length; i++)
+        {
+            current[0] = i;
+            for (var j = 1; j <= b.Length; j++)
+            {
+                var cost = char.ToLowerInvariant(a[i - 1]) == char.ToLowerInvariant(b[j - 1]) ? 0 : 1;
+                current[j] = Math.Min(Math.Min(current[j - 1] + 1, previous[j] + 1), previous[j - 1] + cost);
+            }
+
+            (previous, current) = (current, previous);
+        }
+
+        return previous[b.Length];
+    }
+
+    /// <summary>
+    /// Reads a Spectre attribute's template through <see cref="CustomAttributeData"/> rather
+    /// than a typed property: the template is a constructor argument, and which properties
+    /// the attribute exposes has changed between Spectre versions.
+    /// </summary>
+    private static string? ReadAttributeTemplate(PropertyInfo property, string attributeTypeName)
+    {
+        foreach (var data in property.GetCustomAttributesData())
+        {
+            if (data.AttributeType.Name != attributeTypeName)
+            {
+                continue;
+            }
+
+            foreach (var argument in data.ConstructorArguments)
+            {
+                if (argument.Value is string template)
+                {
+                    return template;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static string ReadDescription(PropertyInfo property) =>
+        property.GetCustomAttribute<DescriptionAttribute>()?.Description ?? string.Empty;
+
+    /// <summary>
+    /// Splits "--format|-f &lt;VALUE&gt;" into its option names, dropping any value
+    /// placeholder Spectre allows after the names.
+    /// </summary>
+    private static List<string> ParseTemplate(string template)
+    {
+        var names = new List<string>();
+        foreach (var part in template.Split('|', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var name = part;
+            var cut = name.IndexOfAny([' ', '<', '[']);
+            if (cut > 0)
+            {
+                name = name[..cut].TrimEnd();
+            }
+
+            if (name.Length > 0 && name[0] == '-')
+            {
+                names.Add(name);
+            }
+        }
+
+        return names;
+    }
+
+    private static string DescribeType(Type type)
+    {
+        var underlying = Nullable.GetUnderlyingType(type) ?? type;
+
+        if (underlying == typeof(bool))
+        {
+            return "flag";
+        }
+        if (underlying == typeof(int) || underlying == typeof(long))
+        {
+            return "integer";
+        }
+        if (underlying == typeof(double) || underlying == typeof(float) || underlying == typeof(decimal))
+        {
+            return "number";
+        }
+        if (underlying == typeof(string[]))
+        {
+            return "string[]";
+        }
+
+        return "string";
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
+    /// <summary>
+    /// The full command-line schema as JSON: usage, value syntax, exit codes, arguments,
+    /// options and subcommands. Emitted by <c>seconv --help-json</c>.
+    /// </summary>
+    public static string ToJson()
+    {
+        var document = new
+        {
+            name = "seconv",
+            version = Version,
+            schemaVersion = SchemaVersion,
+            description = "Subtitle Edit command line converter: batch convert subtitle files between 380+ formats.",
+            usage = new[]
+            {
+                "seconv <pattern> <format> [options]",
+                "seconv <pattern> --format <name> [options]",
+                "seconv <subcommand> [args]",
+            },
+            valueSyntax = new
+            {
+                accepted = new[] { "--option:value", "--option=value", "--option value" },
+                note = "All three forms are equivalent. Unknown options are an error, not a no-op.",
+            },
+            exitCodes = new[]
+            {
+                new { code = 0, meaning = "All matched files converted successfully (or the subcommand succeeded)" },
+                new { code = 1, meaning = "Any failure: bad usage, unknown option, no files matched, or one or more files failed" },
+            },
+            arguments = new[]
+            {
+                new
+                {
+                    name = "pattern",
+                    type = "string[]",
+                    required = true,
+                    description = "One or more file name patterns. Comma-separated in one argument, or several arguments. Relative to --input-folder when set.",
+                },
+                new
+                {
+                    name = "format",
+                    type = "string",
+                    required = false,
+                    description = "Target format name without spaces, as the second positional argument. Equivalent to --format. Discover with: seconv formats --json",
+                },
+            },
+            options = Options,
+            subcommands = new[]
+            {
+                new { name = "formats", json = true, description = "List every subtitle format. The 'id' field is the exact token --format accepts." },
+                new { name = "list-encodings", json = true, description = "List supported text encodings (--encoding values)." },
+                new { name = "list-pac-codepages", json = true, description = "List PAC code pages (--pac-codepage values)." },
+                new { name = "list-ocr-engines", json = true, description = "List OCR engines (--ocr-engine values) and their installation status." },
+                new { name = "list-fce-rules", json = true, description = "List FixCommonErrors rule IDs (--fix-common-errors-rules values)." },
+                new { name = "list-rf-rules", json = true, description = "List remove-formatting rule IDs (--remove-formatting-rules values)." },
+                new { name = "dump-settings", json = true, description = "Print a full --settings JSON with libse defaults. Always JSON; redirect to a file." },
+                new { name = "info", json = true, description = "Print format / encoding / duration / language for one file. Usage: seconv info <file>" },
+                new { name = "lint", json = true, description = "Validate subtitles; exit 1 if any issues found. Usage: seconv lint <pattern>..." },
+                new { name = "--help-json", json = true, description = "Print this schema." },
+                new { name = "--version", json = false, description = "Print the seconv version and exit." },
+            },
+        };
+
+        return JsonSerializer.Serialize(document, JsonOptions);
+    }
+}

--- a/src/seconv/Helpers/HelpDisplay.cs
+++ b/src/seconv/Helpers/HelpDisplay.cs
@@ -4,168 +4,218 @@ namespace SeConv.Helpers;
 
 internal static class HelpDisplay
 {
-    public static void ShowHelp()
+    public static void ShowHelp() => ShowHelp(AnsiConsole.Console);
+
+    /// <summary>
+    /// Renders the help text to a string at a fixed width. Lets tests assert on the real
+    /// rendered output without recording the global console, which xunit runs in parallel.
+    /// </summary>
+    internal static string Render(int width)
+    {
+        var writer = new StringWriter();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(writer),
+        });
+        console.Profile.Width = width;
+        ShowHelp(console);
+        return writer.ToString();
+    }
+
+    private static void ShowHelp(IAnsiConsole console)
     {
         var rule = new Rule("[bold yellow]Subtitle Edit 5.0 - Batch Converter[/]");
         rule.LeftJustified();
-        AnsiConsole.Write(rule);
-        AnsiConsole.WriteLine();
+        console.Write(rule);
+        console.WriteLine();
 
-        AnsiConsole.MarkupLine("[bold cyan]Usage:[/]");
-        AnsiConsole.MarkupLine("  [green]SubtitleEdit[/] [yellow][[pattern]] [[name-of-format-without-spaces]][/] [blue][[optional-parameters]][/]");
-        AnsiConsole.WriteLine();
+        console.MarkupLine("[bold cyan]Usage:[/]");
+        console.MarkupLine("  [green]seconv[/] [yellow][[pattern]] [[name-of-format-without-spaces]][/] [blue][[optional-parameters]][/]");
+        console.WriteLine();
 
-        ShowSection("Pattern", "One or more file name patterns separated by commas\nRelative patterns are relative to /inputfolder if specified");
+        ShowSection(console, "Pattern", "One or more file name patterns separated by commas\nRelative patterns are relative to --input-folder if specified");
+        ShowSection(console, "Values", "Option values accept all of --option:value, --option=value and --option value.\nAn unrecognised option is an error, never a silent no-op.");
 
-        ShowSection("Optional Parameters", null);
-        ShowParameter("--adjust-duration:<ms>", "Adjust duration in milliseconds");
-        ShowParameter("--assa-style-file:<file name>", "ASSA style file");
-        ShowParameter("--change-speed:<percent>", "Change speed by percent (e.g. 125 = 1.25x faster)");
-        ShowParameter("--ebu-header-file:<file name>", "EBU header file");
-        ShowParameter("--encoding:<encoding name>", "Character encoding (e.g., utf-8, windows-1252, or 'source' to keep the input file's encoding)");
-        ShowParameter("--input-encoding-fallback:<name>", "Assumed input encoding when no BOM and not UTF-8 (skips ANSI guess)");
-        ShowParameter("--forced-only", "Process forced subtitles only");
-        ShowParameter("--fps:<frame rate>", "Frame rate for conversion");
-        ShowParameter("--input-folder:<folder name>", "Input folder path");
-        ShowParameter("--offset:hh:mm:ss:ms", "Time offset");
-        ShowParameter("--output-filename:<file name>", "Output file name (for single file only)");
-        ShowParameter("--output-folder:<folder name>", "Output folder path");
-        ShowParameter("--overwrite", "Overwrite existing files");
-        ShowParameter("--pac-codepage:<code page>", "PAC code page");
-        ShowParameter("--profile:<profile name>", "Profile name");
-        ShowParameter("--renumber:<starting number>", "Renumber subtitles from this number");
-        ShowParameter("--resolution:<width>x<height>", "Video resolution (e.g., 1920x1080)");
-        ShowParameter("--target-fps:<frame rate>", "Target frame rate");
-        ShowParameter("--teletext-only", "Process teletext only");
-        ShowParameter("--teletext-only-page:<page number>", "Teletext page number");
-        ShowParameter("--track-number:<track list>", "Comma separated track number list");
-        ShowParameter("--ocr-engine:<engine>", "OCR engine: tesseract | nocr | binaryocr | ollama | llamacpp | paddle");
-        ShowParameter("--ocr-language:<lang>", "Language for OCR (e.g. eng, deu, spa)");
-        ShowParameter("--ocr-db:<path>", ".nocr (--ocr-engine=nocr) or .db (--ocr-engine=binaryocr)");
-        ShowParameter("--ocr-model:<model>", "llamacpp OCR .gguf file name/path (default: first downloaded OCR model)");
-        ShowParameter("--ocr-url:<url>", "Endpoint of an already-running llama-server for OCR (skips the auto-start)");
-        ShowParameter("--time-codes-only", "Image sources (.sup/VobSub/PGS/DVB) -> text with time codes only; skips OCR");
-        ShowParameter("--no-vobsub-isolate-colors", "Disable VobSub OCR colour isolation (on by default; isolation binarises to black-on-white, dropping outline colours)");
-        ShowParameter("--no-pgs-isolate-colors", "Disable PGS/DVB-sub OCR colour isolation (on by default; isolation binarises to black-on-white so the white glyph fill survives the OCR canvas)");
-        ShowParameter("--ollama-url:<url>", "Ollama API endpoint (default: http://localhost:11434/api/chat)");
-        ShowParameter("--ollama-model:<model>", "Ollama vision model (default: llama3.2-vision)");
-        ShowParameter("--translate-to:<lang>", "Auto-translate to this language (code or English name, e.g. de or German)");
-        ShowParameter("--translate-from:<lang>", "Auto-translate source language (default: auto-detect per file)");
-        ShowParameter("--translate-engine:<engine>", "llamacpp (default; auto-starts a local llama-server) | ollama | lmstudio | libretranslate | nllb-serve | nllb-api");
-        ShowParameter("--translate-url:<url>", "Endpoint of an already-running translate server (llamacpp: skips the auto-start)");
-        ShowParameter("--translate-model:<model>", "Ollama/LM Studio model name, or llamacpp .gguf file name/path");
-        ShowParameter("--multiple-replace:<path.xml>", "SE MultipleSearchAndReplaceGroups XML applied per paragraph");
-        ShowParameter("--custom-format:<path.xml>", "SE CustomFormatItem XML (use with --format customtext)");
-        ShowParameter("--settings:<path.json>", "JSON settings file overriding libse defaults");
-        ShowParameter("--quiet", "Suppress per-file progress; only print the final summary");
-        ShowParameter("--verbose", "Print extra diagnostic information");
-        ShowParameter("--json", "Emit per-file results as JSON (suppresses Spectre output)");
+        ShowSection(console, "Optional Parameters", null);
+        ShowParameter(console, "--adjust-duration:<ms>", "Adjust duration in milliseconds");
+        ShowParameter(console, "--assa-style-file:<file name>", "ASSA style file");
+        ShowParameter(console, "--change-speed:<percent>", "Change speed by percent (e.g. 125 = 1.25x faster)");
+        ShowParameter(console, "--ebu-header-file:<file name>", "EBU header file");
+        ShowParameter(console, "--encoding:<encoding name>", "Character encoding (e.g., utf-8, windows-1252, or 'source' to keep the input file's encoding)");
+        ShowParameter(console, "--input-encoding-fallback:<name>", "Assumed input encoding when no BOM and not UTF-8 (skips ANSI guess)");
+        ShowParameter(console, "--forced-only", "Process forced subtitles only");
+        ShowParameter(console, "--fps:<frame rate>", "Frame rate for conversion");
+        ShowParameter(console, "--input-folder:<folder name>", "Input folder path");
+        ShowParameter(console, "--offset:hh:mm:ss:ms", "Time offset");
+        ShowParameter(console, "--output-filename:<file name>", "Output file name (for single file only)");
+        ShowParameter(console, "--output-folder:<folder name>", "Output folder path");
+        ShowParameter(console, "--overwrite", "Overwrite existing files");
+        ShowParameter(console, "--pac-codepage:<code page>", "PAC code page");
+        ShowParameter(console, "--profile:<profile name>", "Profile name");
+        ShowParameter(console, "--renumber:<starting number>", "Renumber subtitles from this number");
+        ShowParameter(console, "--resolution:<width>x<height>", "Video resolution (e.g., 1920x1080)");
+        ShowParameter(console, "--target-fps:<frame rate>", "Target frame rate");
+        ShowParameter(console, "--teletext-only", "Process teletext only");
+        ShowParameter(console, "--teletext-only-page:<page number>", "Teletext page number");
+        ShowParameter(console, "--track-number:<track list>", "Comma separated track number list");
+        ShowParameter(console, "--ocr-engine:<engine>", "OCR engine: tesseract | nocr | binaryocr | ollama | llamacpp | paddle");
+        ShowParameter(console, "--ocr-language:<lang>", "Language for OCR (e.g. eng, deu, spa)");
+        ShowParameter(console, "--ocr-db:<path>", ".nocr (--ocr-engine=nocr) or .db (--ocr-engine=binaryocr)");
+        ShowParameter(console, "--ocr-model:<model>", "llamacpp OCR .gguf file name/path (default: first downloaded OCR model)");
+        ShowParameter(console, "--ocr-url:<url>", "Endpoint of an already-running llama-server for OCR (skips the auto-start)");
+        ShowParameter(console, "--time-codes-only", "Image sources (.sup/VobSub/PGS/DVB) -> text with time codes only; skips OCR");
+        ShowParameter(console, "--no-vobsub-isolate-colors", "Disable VobSub OCR colour isolation (on by default; isolation binarises to black-on-white, dropping outline colours)");
+        ShowParameter(console, "--no-pgs-isolate-colors", "Disable PGS/DVB-sub OCR colour isolation (on by default; isolation binarises to black-on-white so the white glyph fill survives the OCR canvas)");
+        ShowParameter(console, "--ollama-url:<url>", "Ollama API endpoint (default: http://localhost:11434/api/chat)");
+        ShowParameter(console, "--ollama-model:<model>", "Ollama vision model (default: llama3.2-vision)");
+        ShowParameter(console, "--translate-to:<lang>", "Auto-translate to this language (code or English name, e.g. de or German)");
+        ShowParameter(console, "--translate-from:<lang>", "Auto-translate source language (default: auto-detect per file)");
+        ShowParameter(console, "--translate-engine:<engine>", "llamacpp (default; auto-starts a local llama-server) | ollama | lmstudio | libretranslate | nllb-serve | nllb-api");
+        ShowParameter(console, "--translate-url:<url>", "Endpoint of an already-running translate server (llamacpp: skips the auto-start)");
+        ShowParameter(console, "--translate-model:<model>", "Ollama/LM Studio model name, or llamacpp .gguf file name/path");
+        ShowParameter(console, "--multiple-replace:<path.xml>", "SE MultipleSearchAndReplaceGroups XML applied per paragraph");
+        ShowParameter(console, "--custom-format:<path.xml>", "SE CustomFormatItem XML (use with --format customtext)");
+        ShowParameter(console, "--settings:<path.json>", "JSON settings file overriding libse defaults");
+        ShowParameter(console, "--quiet", "Suppress per-file progress; only print the final summary");
+        ShowParameter(console, "--verbose", "Print extra diagnostic information");
+        ShowParameter(console, "--json", "Emit per-file results as JSON (suppresses Spectre output)");
+
+        console.WriteLine();
+        ShowSection(console, "Plain Text Output", "Apply when the target format is plaintext.");
+        ShowParameter(console, "--plaintext-merge", "Merge all subtitles into one space-separated block (no blank lines)");
+        ShowParameter(console, "--plaintext-unbreak", "Unbreak each subtitle, joining its lines into one");
+        ShowParameter(console, "--plaintext-no-blank-line", "Do not put a blank line between subtitles (default keeps it)");
+
+        console.WriteLine();
+        ShowSection(console, "Image Output", "Apply when the target is an image-based format (e.g. bluraysup, vobsub).");
+        ShowParameter(console, "--font-name:<name>", "Font family name (default: Arial)");
+        ShowParameter(console, "--font-size:<points>", "Font size in points (default: 50)");
+        ShowParameter(console, "--font-color:<colour>", "Text colour as hex (#AARRGGBB/#RRGGBB) or name (default: white)");
+        ShowParameter(console, "--font-bold", "Render text bold");
+        ShowParameter(console, "--outline-color:<colour>", "Outline colour (default: black)");
+        ShowParameter(console, "--outline-width:<px>", "Outline width in pixels (default: 2.5; 0 disables)");
+        ShowParameter(console, "--shadow-color:<colour>", "Shadow colour (default: black)");
+        ShowParameter(console, "--shadow-width:<px>", "Shadow width in pixels (default: 0 = off)");
+        ShowParameter(console, "--background-color:<colour>", "Background box colour, e.g. black or #B4000000. Implies --box-type:one-box unless --box-type is given");
+        ShowParameter(console, "--background-corner-radius:<px>", "Corner radius of the background box (default: 0)");
+        ShowParameter(console, "--box-type:<type>", "Background box style: none | one-box | box-per-line");
+        ShowParameter(console, "--box-padding:<px>", "Box padding in pixels; one value for all sides or left,right,top,bottom (default: 5,5,3,3)");
+        ShowParameter(console, "--line-spacing:<percent>", "Extra gap between lines as percent of line height (default: 0)");
+        ShowParameter(console, "--alignment:<position>", "Screen position, e.g. bottom-center (default), top-left, middle-right");
+        ShowParameter(console, "--content-alignment:<mode>", "Multi-line text justification: left | center (default) | right");
+        ShowParameter(console, "--bottom-top-margin:<px>", "Vertical screen-edge margin in pixels (default: 5% of height)");
+        ShowParameter(console, "--left-right-margin:<px>", "Horizontal screen-edge margin in pixels (default: 5% of width)");
+
+        console.WriteLine();
+        console.MarkupLine("[bold cyan]Operations:[/]");
+        console.MarkupLine("  [dim]Operations are applied in a fixed, sensible order regardless of CLI order.[/]");
+        console.WriteLine();
         
-        AnsiConsole.WriteLine();
-        AnsiConsole.MarkupLine("[bold cyan]Operations:[/]");
-        AnsiConsole.MarkupLine("  [dim]Operations are applied in a fixed, sensible order regardless of CLI order.[/]");
-        AnsiConsole.WriteLine();
-        
-        ShowParameter("--apply-duration-limits", "Apply duration limits");
-        ShowParameter("--apply-min-gap[:<ms>]", "Enforce minimum gap between paragraphs (default: minimumMillisecondsBetweenLines)");
-        ShowParameter("--balance-lines", "Balance line lengths");
-        ShowParameter("--bridge-gaps:<ms>", "Bridge gaps shorter than N ms (extends previous end time)");
-        ShowParameter("--beautify-time-codes", "Beautify time codes");
-        ShowParameter("--convert-colors-to-dialog", "Convert colors to dialog");
-        ShowParameter("--delete-first:<count>", "Delete first N entries");
-        ShowParameter("--delete-last:<count>", "Delete last N entries");
-        ShowParameter("--delete-contains:<word>", "Delete entries containing specified word");
-        ShowParameter("--fix-common-errors", "Fix common subtitle errors (all rules)");
-        ShowParameter("--fix-common-errors-rules:<list>", "FCE rule IDs (csv); supports 'all,-RuleId'. List: seconv list-fce-rules");
-        ShowParameter("--fce-language:<code>", "Force language for FCE language-gated rules (e.g. es or Spanish); default: auto-detect");
-        ShowParameter("--dictionary-folder:<path>", "Hunspell dictionaries + *_OCRFixReplaceList.xml; enables the 'Fix common OCR errors' FCE pass");
-        ShowParameter("--fix-rtl-via-unicode-chars", "Fix RTL via Unicode characters");
-        ShowParameter("--merge-same-texts", "Merge entries with same text");
-        ShowParameter("--merge-same-time-codes", "Merge entries with same time codes");
-        ShowParameter("--merge-short-lines", "Merge short lines");
-        ShowParameter("--redo-casing", "Redo text casing");
-        ShowParameter("--remove-formatting", "Remove all formatting tags");
-        ShowParameter("--remove-formatting-rules:<list>", "Formatting-removal rule IDs (csv); supports 'all,-RuleId'. List: seconv list-rf-rules");
-        ShowParameter("--remove-line-breaks", "Remove line breaks");
-        ShowParameter("--remove-text-for-hi", "Remove text for hearing impaired");
-        ShowParameter("--remove-unicode-control-chars", "Remove Unicode control characters");
-        ShowParameter("--reverse-rtl-start-end", "Reverse RTL start/end");
-        ShowParameter("--split-long-lines", "Split long lines");
+        ShowParameter(console, "--apply-duration-limits", "Apply duration limits");
+        ShowParameter(console, "--apply-min-gap[:<ms>]", "Enforce minimum gap between paragraphs (default: minimumMillisecondsBetweenLines)");
+        ShowParameter(console, "--balance-lines", "Balance line lengths");
+        ShowParameter(console, "--bridge-gaps:<ms>", "Bridge gaps shorter than N ms (extends previous end time)");
+        ShowParameter(console, "--beautify-time-codes", "Beautify time codes");
+        ShowParameter(console, "--convert-colors-to-dialog", "Convert colors to dialog");
+        ShowParameter(console, "--delete-first:<count>", "Delete first N entries");
+        ShowParameter(console, "--delete-last:<count>", "Delete last N entries");
+        ShowParameter(console, "--delete-contains:<word>", "Delete entries containing specified word");
+        ShowParameter(console, "--fix-common-errors", "Fix common subtitle errors (all rules)");
+        ShowParameter(console, "--fix-common-errors-rules:<list>", "FCE rule IDs (csv); supports 'all,-RuleId'. List: seconv list-fce-rules");
+        ShowParameter(console, "--fce-language:<code>", "Force language for FCE language-gated rules (e.g. es or Spanish); default: auto-detect");
+        ShowParameter(console, "--dictionary-folder:<path>", "Hunspell dictionaries + *_OCRFixReplaceList.xml; enables the 'Fix common OCR errors' FCE pass");
+        ShowParameter(console, "--fix-rtl-via-unicode-chars", "Fix RTL via Unicode characters");
+        ShowParameter(console, "--merge-same-texts", "Merge entries with same text");
+        ShowParameter(console, "--merge-same-time-codes", "Merge entries with same time codes");
+        ShowParameter(console, "--merge-short-lines", "Merge short lines");
+        ShowParameter(console, "--redo-casing", "Redo text casing");
+        ShowParameter(console, "--remove-formatting", "Remove all formatting tags");
+        ShowParameter(console, "--remove-formatting-rules:<list>", "Formatting-removal rule IDs (csv); supports 'all,-RuleId'. List: seconv list-rf-rules");
+        ShowParameter(console, "--remove-line-breaks", "Remove line breaks");
+        ShowParameter(console, "--remove-text-for-hi", "Remove text for hearing impaired");
+        ShowParameter(console, "--remove-unicode-control-chars", "Remove Unicode control characters");
+        ShowParameter(console, "--reverse-rtl-start-end", "Reverse RTL start/end");
+        ShowParameter(console, "--split-long-lines", "Split long lines");
 
-        AnsiConsole.WriteLine();
-        ShowSection("Subcommands", null);
-        ShowParameter("--version", "Print the seconv version and exit");
-        ShowParameter("formats", "List all available subtitle formats");
-        ShowParameter("list-encodings", "List all supported text encodings (code page + name)");
-        ShowParameter("list-pac-codepages", "List PAC code pages (--pac-codepage values)");
-        ShowParameter("list-ocr-engines", "List OCR engines + installation status");
-        ShowParameter("list-fce-rules", "List FixCommonErrors rule IDs");
-        ShowParameter("list-rf-rules", "List remove-formatting rule IDs");
-        ShowParameter("dump-settings", "Print a full --settings JSON with libse defaults (redirect to a file)");
-        ShowParameter("info <file>", "Print format / encoding / duration / language info");
-        ShowParameter("lint <pattern>", "Validate subtitle(s); exit 1 if any issues found");
+        console.WriteLine();
+        ShowSection(console, "Subcommands", null);
+        console.MarkupLine("  [dim]Every subcommand below accepts --json for machine-readable output.[/]");
+        console.WriteLine();
+        ShowParameter(console, "--version", "Print the seconv version and exit");
+        ShowParameter(console, "--help-json", "Print the full command-line schema as JSON (options, types, exit codes)");
+        ShowParameter(console, "formats", "List all available subtitle formats");
+        ShowParameter(console, "list-encodings", "List all supported text encodings (code page + name)");
+        ShowParameter(console, "list-pac-codepages", "List PAC code pages (--pac-codepage values)");
+        ShowParameter(console, "list-ocr-engines", "List OCR engines + installation status");
+        ShowParameter(console, "list-fce-rules", "List FixCommonErrors rule IDs");
+        ShowParameter(console, "list-rf-rules", "List remove-formatting rule IDs");
+        ShowParameter(console, "dump-settings", "Print a full --settings JSON with libse defaults (redirect to a file)");
+        ShowParameter(console, "info <file>", "Print format / encoding / duration / language info");
+        ShowParameter(console, "lint <pattern>", "Validate subtitle(s); exit 1 if any issues found");
 
-        AnsiConsole.WriteLine();
-        ShowSection("Examples", null);
-        ShowExample(
+        console.WriteLine();
+        ShowSection(console, "Examples", null);
+        ShowExample(console,
             "seconv *.srt sami",
             "Convert all .srt files to SAMI format");
-        ShowExample(
+        ShowExample(console,
             "seconv sub1.srt subrip --encoding:windows-1252",
             "Convert with specific encoding");
-        ShowExample(
+        ShowExample(console,
             "seconv *.srt subrip --input-encoding-fallback:windows-1250",
             "Bulk convert to UTF-8; assume CP1250 only when input isn't UTF-8");
-        ShowExample(
+        ShowExample(console,
             "seconv *.sub subrip --fps:25 --output-folder:C:\\Temp",
             "Convert frame-based to time-based with FPS");
-        ShowExample(
+        ShowExample(console,
             "seconv movie.mkv subrip --track-number:3",
             "Extract MKV subtitle track #3 to SRT");
-        ShowExample(
+        ShowExample(console,
             "seconv movie.sup subrip --ocr-engine:nocr --ocr-db:Latin.nocr",
             "OCR a Blu-Ray .sup using nOCR");
-        ShowExample(
+        ShowExample(console,
             "seconv movie.sup subrip --ocr-engine:llamacpp",
             "OCR a Blu-Ray .sup via llama.cpp (auto-starts a local llama-server)");
-        ShowExample(
+        ShowExample(console,
             "seconv movie.sup subrip --time-codes-only",
             "Extract only the time codes from a .sup (no OCR; empty text)");
-        ShowExample(
+        ShowExample(console,
             "seconv subs.srt customtext --custom-format:my-template.xml",
             "Render via a custom text format template");
-        ShowExample(
+        ShowExample(console,
             "seconv movie.srt subrip --translate-to:de",
             "Translate to German via a local llama.cpp server (started automatically)");
-        ShowExample(
+        ShowExample(console,
             "seconv movie.srt subrip --translate-to:da --translate-engine:ollama --translate-model:gemma2",
             "Translate to Danish via a running Ollama instance");
-        ShowExample(
+        ShowExample(console,
             "seconv formats",
             "List all available formats");
 
-        AnsiConsole.WriteLine();
+        console.WriteLine();
         var footer = new Panel("[dim]For more information, visit: https://github.com/niksedk/subtitleedit[/]")
         {
             Border = BoxBorder.Rounded,
             BorderStyle = new Style(foreground: Color.Grey)
         };
-        AnsiConsole.Write(footer);
+        console.Write(footer);
     }
 
-    private static void ShowSection(string title, string? description)
+    private static void ShowSection(IAnsiConsole console, string title, string? description)
     {
-        AnsiConsole.MarkupLine($"[bold cyan]{title}:[/]");
+        console.MarkupLine($"[bold cyan]{title}:[/]");
         if (!string.IsNullOrEmpty(description))
         {
-            AnsiConsole.MarkupLine($"  [dim]{description.Replace("\n", "\n  ")}[/]");
+            console.MarkupLine($"  [dim]{description.Replace("\n", "\n  ")}[/]");
         }
-        AnsiConsole.WriteLine();
+        console.WriteLine();
     }
 
     private const int ParamColumnWidth = 42;
 
-    private static void ShowParameter(string param, string description)
+    private static void ShowParameter(IAnsiConsole console, string param, string description)
     {
         // Pad based on the visible length (param.Length) rather than the markup-escaped
         // length: Spectre.Console renders "[[" / "]]" as single chars, so columns drift
@@ -173,25 +223,29 @@ internal static class HelpDisplay
         // Escape literal square brackets ('[' -> '[[') BEFORE turning '<'/'>' into display
         // brackets, so an option like "--apply-min-gap[:<ms>]" doesn't feed Spectre a stray
         // "[:" it reads as a broken markup tag (which threw mid-render and truncated --help).
-        var escapedParam = EscapeForMarkup(param);
-        var escapedDescription = EscapeForMarkup(description);
+        var escapedParam = EscapeParameter(param);
+        var escapedDescription = description.EscapeMarkup();
         var pad = Math.Max(1, ParamColumnWidth - param.Length);
-        AnsiConsole.MarkupLine($"  [yellow]{escapedParam}[/]{new string(' ', pad)}[dim]{escapedDescription}[/]");
+        console.MarkupLine($"  [yellow]{escapedParam}[/]{new string(' ', pad)}[dim]{escapedDescription}[/]");
     }
 
     // Renders literal '[' ']' and the '<value>' convention as visible square brackets.
     // Spectre uses '[[' / ']]' as the escape for a literal '[' / ']', so both the real
     // brackets and the angle-bracket placeholders map onto that same doubled form.
     // Literal-bracket escaping must run first, or the '[[' produced from '<' gets escaped again.
-    private static string EscapeForMarkup(string text) =>
+    //
+    // Only parameter names go through this. Descriptions are plain prose and get ordinary
+    // markup escaping instead: the '>' rewrite turned every arrow in a description into a
+    // stray ']' ("-> text with time codes only" rendered as "-] text with time codes only").
+    private static string EscapeParameter(string text) =>
         text.Replace("[", "[[").Replace("]", "]]")
             .Replace("<", "[[").Replace(">", "]]");
 
-    private static void ShowExample(string command, string description)
+    private static void ShowExample(IAnsiConsole console, string command, string description)
     {
         var escapedCommand = command.Replace("[", "[[").Replace("]", "]]");
-        AnsiConsole.MarkupLine($"  [green]{escapedCommand}[/]");
-        AnsiConsole.MarkupLine($"  [dim]→ {description}[/]");
-        AnsiConsole.WriteLine();
+        console.MarkupLine($"  [green]{escapedCommand}[/]");
+        console.MarkupLine($"  [dim]→ {description}[/]");
+        console.WriteLine();
     }
 }

--- a/src/seconv/Helpers/JsonOut.cs
+++ b/src/seconv/Helpers/JsonOut.cs
@@ -1,0 +1,44 @@
+using System.Text.Encodings.Web;
+using System.Text.Json;
+
+namespace SeConv.Helpers;
+
+/// <summary>
+/// Writes the <c>--json</c> form of a subcommand's output. Everything goes to stdout with
+/// nothing else mixed in, so <c>seconv ... --json | jq</c> parses without pre-filtering;
+/// human-facing notes belong on stderr.
+/// </summary>
+internal static class JsonOut
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        WriteIndented = true,
+        // Relaxed escaping keeps non-ASCII (format names, encoding display names) readable
+        // instead of emitting \uXXXX for every accented character.
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
+    public static void Write(object value) =>
+        Console.Out.WriteLine(JsonSerializer.Serialize(value, Options));
+
+    public static string Serialize(object value) =>
+        JsonSerializer.Serialize(value, Options);
+
+    /// <summary>
+    /// The failure envelope for a run that never got as far as converting a file — bad usage,
+    /// an unknown option, a rejected value. It has the same shape as a normal convert result
+    /// so that a caller parsing stdout gets one document type on every path, rather than JSON
+    /// on success and plain text on a usage error.
+    /// </summary>
+    public static string UsageError(string message) => Serialize(new
+    {
+        success = false,
+        totalFiles = 0,
+        successfulFiles = 0,
+        failedFiles = 0,
+        elapsedMs = 0,
+        files = Array.Empty<object>(),
+        errors = new[] { message },
+        warnings = Array.Empty<string>(),
+    });
+}

--- a/src/seconv/Program.cs
+++ b/src/seconv/Program.cs
@@ -37,8 +37,21 @@ internal class Program
         // (e.g. `seconv *.srt sami`) when --format / -f is not supplied.
         args = TryInjectPositionalFormat(args);
 
-        // Handle /? and /help
-        if (args.Length == 0 || args.Contains("/?") || args.Contains("/help") || args.Contains("--help"))
+        var json = HasJsonFlag(args);
+
+        // --help-json before the plain help check: it prints the machine-readable schema and
+        // must not be swallowed by a looser "did the user ask for help" match.
+        if (args.Any(a => a.TrimStart('/', '-').Equals("help-json", StringComparison.OrdinalIgnoreCase)))
+        {
+            Console.Out.WriteLine(CliSchema.ToJson());
+            return 0;
+        }
+
+        // Handle /?, /help, --help and -h. All four render the same text: two different help
+        // outputs (the hand-written one and Spectre's generated one) gave callers two
+        // different pictures of the same tool.
+        if (args.Length == 0 || args.Contains("/?") || args.Contains("/help") ||
+            args.Contains("--help") || args.Contains("-h"))
         {
             HelpDisplay.ShowHelp();
             return 0;
@@ -50,7 +63,7 @@ internal class Program
                                  args[0].Equals("--formats", StringComparison.OrdinalIgnoreCase)))
         {
             var formatsCommand = new FormatsCommand();
-            return ((ICommand)formatsCommand).ExecuteAsync(null!, new FormatsCommand.Settings(), CancellationToken.None).GetAwaiter().GetResult();
+            return ((ICommand)formatsCommand).ExecuteAsync(null!, new FormatsCommand.Settings { Json = json }, CancellationToken.None).GetAwaiter().GetResult();
         }
 
         // List helpers
@@ -59,28 +72,28 @@ internal class Program
             var first = args[0].TrimStart('/').TrimStart('-');
             if (first.Equals("list-encodings", StringComparison.OrdinalIgnoreCase))
             {
-                ListHelpers.PrintEncodings();
+                ListHelpers.PrintEncodings(json);
                 return 0;
             }
             if (first.Equals("list-pac-codepages", StringComparison.OrdinalIgnoreCase))
             {
-                ListHelpers.PrintPacCodepages();
+                ListHelpers.PrintPacCodepages(json);
                 return 0;
             }
             if (first.Equals("list-ocr-engines", StringComparison.OrdinalIgnoreCase))
             {
-                ListHelpers.PrintOcrEngines();
+                ListHelpers.PrintOcrEngines(json);
                 return 0;
             }
             if (first.Equals("list-fce-rules", StringComparison.OrdinalIgnoreCase))
             {
-                ListHelpers.PrintFixCommonErrorsRules();
+                ListHelpers.PrintFixCommonErrorsRules(json);
                 return 0;
             }
             if (first.Equals("list-rf-rules", StringComparison.OrdinalIgnoreCase) ||
                 first.Equals("list-remove-formatting-rules", StringComparison.OrdinalIgnoreCase))
             {
-                ListHelpers.PrintRemoveFormattingRules();
+                ListHelpers.PrintRemoveFormattingRules(json);
                 return 0;
             }
             if (first.Equals("dump-settings", StringComparison.OrdinalIgnoreCase) ||
@@ -113,25 +126,172 @@ internal class Program
         var app = new CommandApp<ConvertCommand>();
         app.Configure(config =>
         {
-            config.SetApplicationName("SubtitleEdit");
-            config.SetApplicationVersion("5.0.0");
+            config.SetApplicationName("seconv");
+            config.SetApplicationVersion(CliSchema.Version);
 
             config.ValidateExamples();
+
+            // Without strict parsing an unrecognised option is silently dropped: a typo'd or
+            // invented flag produced a "conversion completed successfully" run, exit 0, and an
+            // output file that quietly lacked the requested operation. Failing loudly is the
+            // only way a caller can tell the two apart.
+            config.UseStrictParsing();
+
+            // Take over error rendering so parse failures exit 1 like every other failure
+            // (Spectre's own handler returns -1/255) and can be reported as JSON.
+            config.PropagateExceptions();
         });
 
         try
         {
             return app.Run(args);
         }
+        catch (CommandAppException ex)
+        {
+            return ReportUsageError(DescribeParseFailure(ex, args), json);
+        }
         catch (Exception ex)
         {
-            AnsiConsole.MarkupLineInterpolated($"[red]Fatal error: {ex.Message}[/]");
-            if (ex.InnerException != null)
-            {
-                AnsiConsole.MarkupLineInterpolated($"[red]  {ex.InnerException.Message}[/]");
-            }
-            return 1;
+            var message = ex.InnerException != null
+                ? $"{ex.Message}: {ex.InnerException.Message}"
+                : ex.Message;
+            return ReportUsageError($"Fatal error: {message}", json);
         }
+    }
+
+    /// <summary>
+    /// Prints a usage/parse failure and returns exit code 1. Under <c>--json</c> the error
+    /// goes out in the same envelope a failed conversion uses, so a caller parsing stdout
+    /// never has to handle a sudden switch to plain text.
+    /// </summary>
+    private static int ReportUsageError(string message, bool json)
+    {
+        if (json)
+        {
+            Console.Out.WriteLine(JsonOut.UsageError(message));
+        }
+        else
+        {
+            AnsiConsole.MarkupLineInterpolated($"[red]Error: {message}[/]");
+        }
+
+        return 1;
+    }
+
+    /// <summary>
+    /// Turns a Spectre parse exception into a message a caller can act on: names the offending
+    /// option, suggests the closest real one, and reports the expected type for a value that
+    /// failed to convert (Spectre's own text says "Failed to convert 'x' to Nullable`1").
+    /// </summary>
+    private static string DescribeParseFailure(CommandAppException ex, string[] args)
+    {
+        var unknown = FindUnknownOption(args);
+        if (unknown != null)
+        {
+            var suggestion = CliSchema.SuggestClosest(unknown);
+            var hint = suggestion != null
+                ? $" Did you mean '{suggestion}'?"
+                : " Run 'seconv --help' for the option list, or 'seconv --help-json' for a machine-readable one.";
+            return $"Unknown option '{unknown}'.{hint}";
+        }
+
+        var conversion = System.Text.RegularExpressions.Regex.Match(
+            ex.Message, @"Failed to convert '(?<value>.*)' to ");
+        if (conversion.Success)
+        {
+            var value = conversion.Groups["value"].Value;
+            var (option, type) = FindOptionCarrying(value, args);
+            if (option != null)
+            {
+                return $"Invalid value '{value}' for {option} (expected {type}).";
+            }
+
+            return $"Invalid value '{value}'.";
+        }
+
+        // Spectre renders its own multi-line diagnostic (with the caret pointer) into the
+        // message; keep only the first line so the JSON envelope stays a single string.
+        var firstLine = ex.Message.Split('\n', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+        return (firstLine ?? ex.Message).Trim();
+    }
+
+    /// <summary>
+    /// First option-looking token that is not a known option name or alias. Matching against
+    /// the schema rather than parsing Spectre's message keeps the reported token exactly as
+    /// the caller typed it.
+    /// </summary>
+    internal static string? FindUnknownOption(string[] args)
+    {
+        var known = new HashSet<string>(CliSchema.AllTokens, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var arg in args)
+        {
+            if (!LooksLikeOption(arg))
+            {
+                continue;
+            }
+
+            // Strip an embedded value so --bogus:1 reports as --bogus.
+            var name = arg;
+            var cut = name.IndexOf('=');
+            var colon = name.IndexOf(':', 2);
+            if (colon >= 0 && (cut < 0 || colon < cut))
+            {
+                cut = colon;
+            }
+            if (cut > 0)
+            {
+                name = name[..cut];
+            }
+
+            if (!known.Contains(name) && !name.Equals("--help", StringComparison.OrdinalIgnoreCase))
+            {
+                return name;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Locates the option whose value is <paramref name="value"/>, in either the
+    /// <c>--opt:value</c> / <c>--opt=value</c> or the <c>--opt value</c> form, and returns it
+    /// with the type the schema declares for it.
+    /// </summary>
+    private static (string? Option, string Type) FindOptionCarrying(string value, string[] args)
+    {
+        for (var i = 0; i < args.Length; i++)
+        {
+            var arg = args[i];
+            if (!LooksLikeOption(arg))
+            {
+                continue;
+            }
+
+            string? name = null;
+            var separator = arg.IndexOfAny(['=', ':'], 2);
+            if (separator > 0 && arg[(separator + 1)..] == value)
+            {
+                name = arg[..separator];
+            }
+            else if (i + 1 < args.Length && args[i + 1] == value)
+            {
+                name = arg;
+            }
+
+            if (name == null)
+            {
+                continue;
+            }
+
+            var option = CliSchema.Options.FirstOrDefault(o =>
+                o.Name.Equals(name, StringComparison.OrdinalIgnoreCase) ||
+                o.Aliases.Any(a => a.Equals(name, StringComparison.OrdinalIgnoreCase)));
+
+            return (name, option?.Type ?? "value");
+        }
+
+        return (null, "value");
     }
 
     /// <summary>

--- a/src/seconv/README.md
+++ b/src/seconv/README.md
@@ -40,6 +40,22 @@ seconv dump-settings > my.json                                   # starter --set
 
 Run `seconv` with no arguments for built-in help, or `seconv formats` to list every format.
 
+## Scripting
+
+Every subcommand takes `--json`, and so does a conversion run. Under `--json`, stdout is one
+JSON document on success and on failure alike — a usage error arrives in the same envelope as
+a failed conversion, so nothing has to be parsed out of stderr.
+
+```bash
+seconv --help-json                              # the whole command line as JSON, reflected off the parser
+seconv formats --json | jq -r '.formats[].id'   # exact tokens --format accepts
+seconv movie.srt subrip --json                  # per-file results
+```
+
+An unrecognised option is an error, never a silent no-op: `seconv` exits 1 and names the closest
+real option rather than converting the file without the operation that was asked for. Exit codes
+are only ever 0 (success) or 1 (any failure).
+
 ## Full reference
 
 ➡ **[Command Line (seconv) — full reference](../../docs/reference/command-line.md)**

--- a/tests/seconv/Core/CliSchemaTest.cs
+++ b/tests/seconv/Core/CliSchemaTest.cs
@@ -1,0 +1,125 @@
+using System.Text.Json;
+using SeConv.Helpers;
+using Xunit;
+
+namespace SeConvTests.Core;
+
+/// <summary>
+/// Covers the machine-readable side of the CLI: the schema behind <c>seconv --help-json</c>,
+/// and the unknown-option suggestion that replaced silently ignoring the flag.
+/// </summary>
+public class CliSchemaTest
+{
+    [Fact]
+    public void Options_AreReflectedOffTheSettingsClass()
+    {
+        // The schema exists so it cannot drift from what the parser binds. If someone adds a
+        // [CommandOption] it must appear here with no second edit.
+        var options = CliSchema.Options;
+
+        Assert.NotEmpty(options);
+        Assert.Contains(options, o => o.Name == "--format" && o.Aliases.Contains("-f"));
+        Assert.Contains(options, o => o.Name == "--fps" && o.Type == "number");
+        Assert.Contains(options, o => o.Name == "--renumber" && o.Type == "integer");
+        Assert.Contains(options, o => o.Name == "--overwrite" && o.Type == "flag");
+    }
+
+    [Fact]
+    public void Options_SeparateOperationsFromPlainOptions()
+    {
+        var options = CliSchema.Options;
+
+        Assert.Equal("operation", options.Single(o => o.Name == "--remove-formatting").Group);
+        Assert.Equal("operation", options.Single(o => o.Name == "--split-long-lines").Group);
+        Assert.Equal("operation", options.Single(o => o.Name == "--bridge-gaps").Group);
+        Assert.Equal("option", options.Single(o => o.Name == "--output-folder").Group);
+        Assert.Equal("option", options.Single(o => o.Name == "--encoding").Group);
+    }
+
+    [Fact]
+    public void Options_CarryDiscoveryCommandsAndChoices()
+    {
+        var options = CliSchema.Options;
+
+        Assert.Equal("seconv formats --json", options.Single(o => o.Name == "--format").Discover);
+        Assert.Contains("tesseract", options.Single(o => o.Name == "--ocr-engine").Choices!);
+    }
+
+    [Fact]
+    public void CuratedTables_OnlyNameRealOptions()
+    {
+        // Choices and discovery hints are hand-maintained; a rename elsewhere would otherwise
+        // leave them silently attached to nothing.
+        var known = CliSchema.Options.Select(o => o.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var annotated = CliSchema.Options
+            .Where(o => o.Choices != null || o.Discover != null)
+            .Select(o => o.Name);
+
+        Assert.All(annotated, name => Assert.Contains(name, known));
+        Assert.Contains(CliSchema.Options, o => o.Discover != null);
+    }
+
+    [Theory]
+    [InlineData("--remove-formating", "--remove-formatting")]
+    [InlineData("--output-folder", "--output-folder")]
+    [InlineData("--overwite", "--overwrite")]
+    [InlineData("--fix-common-error", "--fix-common-errors")]
+    public void SuggestClosest_FindsTheIntendedOption(string typo, string expected)
+    {
+        Assert.Equal(expected, CliSchema.SuggestClosest(typo));
+    }
+
+    [Fact]
+    public void SuggestClosest_ReturnsNullForSomethingUnrelated()
+    {
+        Assert.Null(CliSchema.SuggestClosest("--zzzzzzzzzzzzzzzz"));
+    }
+
+    [Fact]
+    public void ToJson_IsValidAndDescribesTheContract()
+    {
+        using var document = JsonDocument.Parse(CliSchema.ToJson());
+        var root = document.RootElement;
+
+        Assert.Equal("seconv", root.GetProperty("name").GetString());
+        Assert.NotEmpty(root.GetProperty("options").EnumerateArray());
+        Assert.NotEmpty(root.GetProperty("subcommands").EnumerateArray());
+
+        // Exit codes are part of the contract a caller scripts against.
+        var codes = root.GetProperty("exitCodes").EnumerateArray().Select(e => e.GetProperty("code").GetInt32());
+        Assert.Equal([0, 1], codes.ToArray());
+
+        // All three value syntaxes are accepted; the schema has to say so, because guessing
+        // wrong used to be indistinguishable from success.
+        var syntax = root.GetProperty("valueSyntax").GetProperty("accepted")
+            .EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains("--option:value", syntax);
+        Assert.Contains("--option=value", syntax);
+        Assert.Contains("--option value", syntax);
+    }
+
+    [Fact]
+    public void FindUnknownOption_IgnoresRealOptionsAndTheirValues()
+    {
+        Assert.Null(SeConv.Program.FindUnknownOption(
+            ["a.srt", "subrip", "--fps", "25", "--output-folder:out", "--overwrite", "--remove-formatting"]));
+    }
+
+    [Theory]
+    [InlineData(new[] { "a.srt", "subrip", "--bogus" }, "--bogus")]
+    [InlineData(new[] { "a.srt", "subrip", "--bogus:1" }, "--bogus")]
+    [InlineData(new[] { "a.srt", "subrip", "--bogus=1" }, "--bogus")]
+    [InlineData(new[] { "a.srt", "subrip", "--overwrite", "-Z" }, "-Z")]
+    public void FindUnknownOption_ReportsTheTokenAsTyped(string[] args, string expected)
+    {
+        Assert.Equal(expected, SeConv.Program.FindUnknownOption(args));
+    }
+
+    [Fact]
+    public void FindUnknownOption_AcceptsLegacySmashedAliases()
+    {
+        // Older scripts pass --outputfolder / --FixCommonErrors; strict parsing must not turn
+        // those into errors.
+        Assert.Null(SeConv.Program.FindUnknownOption(["a.srt", "subrip", "--outputfolder:o", "--FixCommonErrors"]));
+    }
+}

--- a/tests/seconv/Core/HelpDisplayTest.cs
+++ b/tests/seconv/Core/HelpDisplayTest.cs
@@ -1,0 +1,57 @@
+using SeConv.Helpers;
+using Xunit;
+
+namespace SeConvTests.Core;
+
+public class HelpDisplayTest
+{
+    // Wide enough that no assertion below straddles a wrap.
+    private static readonly string Help = HelpDisplay.Render(200);
+
+    [Fact]
+    public void Help_NamesTheActualBinary()
+    {
+        // The usage line said "SubtitleEdit", which is the desktop app, not this executable.
+        Assert.Contains("seconv [pattern]", Help);
+        Assert.DoesNotContain("SubtitleEdit [pattern]", Help);
+    }
+
+    [Fact]
+    public void Help_DoesNotMangleArrowsInDescriptions()
+    {
+        // Descriptions used to run through the '<value>' placeholder escaping, which rewrote
+        // every '>' to ']': "-> text with time codes only" rendered as "-] text ...".
+        Assert.Contains("-> text with time codes only", Help);
+        Assert.DoesNotContain("-] text with time codes only", Help);
+    }
+
+    [Fact]
+    public void Help_StillRendersPlaceholdersAsBrackets()
+    {
+        Assert.Contains("--adjust-duration:[ms]", Help);
+        Assert.Contains("--apply-min-gap[:[ms]]", Help);
+    }
+
+    [Fact]
+    public void Help_DocumentsTheMachineReadableEntryPoints()
+    {
+        Assert.Contains("--help-json", Help);
+        Assert.Contains("--option:value", Help);
+    }
+
+    [Fact]
+    public void Help_ListsEveryOptionTheParserBinds()
+    {
+        // The help text is hand-written while the parser binds attributes, so the two can
+        // drift. Anything bound but undocumented is invisible to a reader of --help.
+        // Aliases are deliberately not listed; only canonical names are checked.
+        var undocumented = CliSchema.Options
+            .Select(o => o.Name)
+            .Where(name => !Help.Contains(name, StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.True(
+            undocumented.Length == 0,
+            $"Options bound by the parser but missing from --help: {string.Join(", ", undocumented)}");
+    }
+}


### PR DESCRIPTION
Makes `seconv` safe to drive from a script or an agent. Three fixes plus a new `--help-json`.

## 1. Unknown options were silently ignored

```console
$ seconv a.srt subrip --remove-formating --overwrite
✓ Conversion completed successfully!    # exit 0 — and the file still has its <i> tags
```

A typo'd or invented flag was indistinguishable from success, which is worse than an error because nothing downstream can detect it. Spectre's `StrictParsing` is off by default; this turns it on and takes over error rendering so a parse failure exits **1** like every other failure instead of Spectre's 255.

```console
$ seconv a.srt subrip --remove-formating
Error: Unknown option '--remove-formating'. Did you mean '--remove-formatting'?    # exit 1
```

A value that fails to convert now reports which option rejected it and what it expected, instead of leaking a .NET type name:

| before | after |
|---|---|
| ``Failed to convert 'notanumber' to Nullable`1`` | `Invalid value 'notanumber' for --fps (expected number).` |

Legacy `/convert` syntax and the smashed-together aliases (`--outputfolder`, `--FixCommonErrors`) still parse — covered by tests.

## 2. `--json` now works everywhere, and is always JSON

`--json` was honoured by `convert`/`info`/`lint` but **silently ignored** by the six discovery subcommands — the ones a caller reaches for first. `seconv formats --json` printed 392 lines of box-drawing table. All of them now emit JSON, keyed so `id` is the exact token the corresponding option accepts:

```bash
seconv formats --json        | jq -r '.formats[] | select(.inputOnly | not) | .id'
seconv list-fce-rules --json | jq -r '.rules[].id'
seconv list-ocr-engines --json | jq -r '.engines[] | select(.ready) | .id'
```

`formats --json` distinguishes `id` (what `--format` matches on) from `name` (the display name) — deriving one from the other was left to the caller before. All 40 ids checked round-trip as `--format` values.

`--json` output is also JSON on *every* path now. Usage and validation errors used to print plain text to stdout, so `seconv ... --json | jq` crashed rather than reading the error. Failures now use the same envelope as a failed conversion:

```json
{ "success": false, "totalFiles": 0, "files": [], "errors": ["Unknown option '--bogus'."], "warnings": [] }
```

Verified across 13 failure paths (bad encoding, bad fps, unknown format, no files matched, bad OCR engine, bad offset/resolution/min-gap, `--profile` without `--settings`, …): all parse as JSON, all exit 1.

## 3. One help text, naming the right binary

`--help` and `-h` rendered two different help texts, and both said `Usage: SubtitleEdit [pattern] ...` — a binary that doesn't exist. They're now the same text, naming `seconv`.

Descriptions no longer run through the `<value>` placeholder escaping, which rewrote every `>` to `]`:

| before | after |
|---|---|
| `Image sources (.sup/VobSub/PGS/DVB) -] text with time codes only` | `... -> text with time codes only` |

## 4. New: `seconv --help-json`

The whole command line as JSON — every option with aliases, type (`flag`/`string`/`integer`/`number`), whether it's an operation, its closed value set where it has one, and otherwise the subcommand that enumerates valid values. Reflected off `ConvertCommand.Settings`, so it cannot drift from what the parser binds.

```bash
seconv --help-json | jq -r '.options[] | select(.discover) | "\(.name)\t\(.discover)"'
# --format         seconv formats --json
# --encoding       seconv list-encodings --json
# --ocr-engine     seconv list-ocr-engines --json
```

A new drift test compares the schema against the hand-written help and immediately found **20 options that were accepted but undocumented** — the whole `--plaintext-*` and image-output (`--font-*`, `--box-*`, `--alignment`, …) families. They're now in `--help`.

## Tests

`tests/seconv` 330/330 pass, including 21 new ones covering the schema, the typo suggestions, unknown-option detection (with legacy aliases exempt), the help fixes, and the drift guard. `HelpDisplay` renders to a fixed-width string for tests rather than recording the global console, which xunit runs in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)