### PR TITLE
AI review: play the current line to check a fix

### DIFF
--- a/docs/features/ai-review.md
+++ b/docs/features/ai-review.md
@@ -47,6 +47,10 @@ Each suggestion shows:
 
 Filter the grid with the category chips above it. Press **Apply N fixes** to apply the checked suggestions - this is a single undo step (Ctrl+Z reverts everything).
 
+### Listening to a line
+
+When a video is loaded, a **Play current** button appears at the bottom left. It plays the selected suggestion's line in the video player and pauses at the end of the line, so you can hear what was actually said before deciding on a fix. Double-clicking a suggestion does the same, as does F5 (or Ctrl/Cmd+Space) - F5 follows your *Play selected lines* shortcut. Space is not used for playback here: it toggles the **Apply** checkbox of the selected row.
+
 ## Sentences across multiple lines
 
 Lines are grouped into sentence units, so a sentence that continues over several subtitles is always reviewed as a whole, and the model sees a couple of surrounding lines as read-only context. Corrections never move words between lines, so timing and reading speed are unaffected. Suggestions belonging to the same sentence are checked and unchecked together.

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1476,7 +1476,8 @@
       "linesXToY": "Lines {0}-{1}",
       "largeChangeWarning": "Large change - looks like a rewrite, review carefully",
       "mismatchWarning": "Does not resemble the original - may belong to a different line",
-      "engineError": "The AI engine could not be reached: {0}"
+      "engineError": "The AI engine could not be reached: {0}",
+      "playCurrentLineHint": "Play the selected line in the video player and pause at its end (also double-click a line)"
     },
     "aiAssistant": {
       "title": "AI assistant",

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -6860,7 +6860,14 @@ public partial class MainViewModel :
         }
 
         var idx = SelectedSubtitleIndex ?? 0;
-        var viewModel = await ShowDialogAsync<AiReviewWindow, AiReviewViewModel>(vm => { vm.Initialize(GetUpdateSubtitle(), SelectedSubtitleFormat); });
+
+        // Same filter as GetUpdateSubtitle() below, so index N of the reviewed subtitle is line N
+        // here - that mapping is what lets the review window play the line of a suggestion.
+        var reviewedLines = Subtitles.Where(s => !s.IsReferenceOnly).ToList();
+        var viewModel = await ShowDialogAsync<AiReviewWindow, AiReviewViewModel>(vm =>
+        {
+            vm.Initialize(GetUpdateSubtitle(), SelectedSubtitleFormat, MakeReviewLinePlayer(reviewedLines), StopReviewLinePlayback);
+        });
 
         if (viewModel.OkPressed)
         {
@@ -8003,6 +8010,46 @@ public partial class MainViewModel :
         PinPlayheadTo(item.StartTime.TotalSeconds);
         _playSelectionItem = new PlaySelectionItem([item], item.EndTime, false);
         PlayVideo(vp);
+    }
+
+    /// <summary>
+    /// Builds the "play current line" hook handed to the AI review window: playing a suggestion
+    /// plays the line it belongs to and pauses at its end, so a fix can be checked against the
+    /// audio before it is applied. Null when no video is loaded - the window then hides its play
+    /// button. The list must be in the same order as the reviewed subtitle's paragraphs.
+    /// </summary>
+    private Action<int>? MakeReviewLinePlayer(IReadOnlyList<SubtitleLineViewModel> lines)
+    {
+        if (string.IsNullOrEmpty(_videoFileName))
+        {
+            return null;
+        }
+
+        return index =>
+        {
+            var vp = GetVideoPlayerControl();
+            if (vp == null || index < 0 || index >= lines.Count)
+            {
+                return;
+            }
+
+            PlayLineAndPauseAtEnd(vp, lines[index]);
+        };
+    }
+
+    /// <summary>
+    /// Stops a preview started from a dialog through <see cref="MakeReviewLinePlayer"/>.
+    /// </summary>
+    private void StopReviewLinePlayback()
+    {
+        var vp = GetVideoPlayerControl();
+        if (vp == null)
+        {
+            return;
+        }
+
+        ResetPlaySelection();
+        PauseVideoAndFreezePlayhead(vp);
     }
 
     private bool PlayerSelectedLines(bool loop)
@@ -10360,7 +10407,8 @@ public partial class MainViewModel :
             sub.Paragraphs.Add(line.ToParagraph(SelectedSubtitleFormat));
         }
 
-        var result = await ShowDialogAsync<AiReviewWindow, AiReviewViewModel>(vm => vm.Initialize(sub, SelectedSubtitleFormat));
+        var result = await ShowDialogAsync<AiReviewWindow, AiReviewViewModel>(vm =>
+            vm.Initialize(sub, SelectedSubtitleFormat, MakeReviewLinePlayer(ordered), StopReviewLinePlayback));
         if (!result.OkPressed)
         {
             _shortcutManager.ClearKeys();

--- a/src/ui/Features/Tools/AiReview/AiReviewViewModel.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewViewModel.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Features.Translate;
 using Nikse.SubtitleEdit.Features.Translate.LlamaCppEngineSettings;
@@ -40,7 +41,9 @@ public partial class AiReviewViewModel : ObservableObject
     [ObservableProperty] private string _languageDisplay;
     [ObservableProperty] private ObservableCollection<ReviewFilterChip> _filterChips;
     [ObservableProperty] private ObservableCollection<ReviewSuggestionItem> _suggestions;
-    [ObservableProperty] private ReviewSuggestionItem? _selectedSuggestion;
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(PlayCurrentLineCommand))]
+    private ReviewSuggestionItem? _selectedSuggestion;
     [ObservableProperty] private bool _isReviewing;
     [ObservableProperty] private bool _isNotReviewing = true;
     [ObservableProperty] private double _progressValue;
@@ -51,6 +54,7 @@ public partial class AiReviewViewModel : ObservableObject
     [ObservableProperty] private string _applyButtonText;
     [ObservableProperty] private string _warningNoteText;
     [ObservableProperty] private bool _hasWarningNote;
+    [ObservableProperty] private bool _isPlayVisible;
 
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }
@@ -63,6 +67,12 @@ public partial class AiReviewViewModel : ObservableObject
     private string _languageCode = "en";
     private CancellationTokenSource _cancellationTokenSource = new();
     private bool _syncingSelection;
+
+    // Video preview hooks handed in by the caller - they drive the main window's video player.
+    // Null when no video is loaded; the play button is then hidden.
+    private Action<int>? _playLine;
+    private Action? _stopPlayback;
+    private bool _hasPlayed;
 
     public AiReviewViewModel(IWindowService windowService)
     {
@@ -104,9 +114,23 @@ public partial class AiReviewViewModel : ObservableObject
         UpdateEngineVisibility();
     }
 
-    public void Initialize(Subtitle subtitle, SubtitleFormat? subtitleFormat)
+    /// <summary>
+    /// Sets up the review. <paramref name="playLine"/> plays the line at a paragraph index of
+    /// <paramref name="subtitle"/> in the main video player and pauses at its end, so a suggested
+    /// fix can be checked against the audio before it is applied; pass null (no video loaded) to
+    /// hide the play button. <paramref name="stopPlayback"/> stops such a preview when the window
+    /// closes - only ever called when this window actually started playback.
+    /// </summary>
+    public void Initialize(
+        Subtitle subtitle,
+        SubtitleFormat? subtitleFormat,
+        Action<int>? playLine = null,
+        Action? stopPlayback = null)
     {
         _subtitle = subtitle;
+        _playLine = playLine;
+        _stopPlayback = stopPlayback;
+        IsPlayVisible = playLine != null;
         _languageCode = LanguageAutoDetect.AutoDetectGoogleLanguage(subtitle);
         LanguageDisplay = GetLanguageDisplayName(_languageCode);
     }
@@ -621,6 +645,30 @@ public partial class AiReviewViewModel : ObservableObject
         _cancellationTokenSource.Cancel();
     }
 
+    /// <summary>
+    /// Plays the subtitle line the selected suggestion belongs to in the main video player and
+    /// pauses at its end - the fastest way to judge whether a suggested fix is right.
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanPlayCurrentLine))]
+    private void PlayCurrentLine()
+    {
+        var item = SelectedSuggestion;
+        if (item == null || _playLine == null)
+        {
+            return;
+        }
+
+        _hasPlayed = true;
+        _playLine(item.ParagraphIndex);
+    }
+
+    private bool CanPlayCurrentLine() => SelectedSuggestion != null;
+
+    internal void OnSuggestionsGridDoubleTapped()
+    {
+        PlayCurrentLine();
+    }
+
     [RelayCommand]
     private void SelectAll()
     {
@@ -733,11 +781,35 @@ public partial class AiReviewViewModel : ObservableObject
             e.Handled = true;
             UiUtil.ShowHelp("features/ai-review");
         }
+        else if (IsPlayVisible && MatchesPlayShortcut(e))
+        {
+            e.Handled = true;
+            PlayCurrentLine();
+        }
+    }
+
+    /// <summary>
+    /// True when the pressed keys match the user's main-window "play selected lines" (default F5)
+    /// or second play/pause (default Ctrl/Cmd+Space) binding. Bare Space is deliberately not
+    /// included: in this window it toggles the apply checkbox of the selected row.
+    /// </summary>
+    private static bool MatchesPlayShortcut(KeyEventArgs e)
+    {
+        return MainShortcutKeys.Matches(e, nameof(MainViewModel.PlaySelectedLinesWithoutLoopCommand), [nameof(Key.F5)]) ||
+               MainShortcutKeys.Matches(e, nameof(MainViewModel.TogglePlayPause2Command), [MainShortcutKeys.CtrlOrCmd, nameof(Key.Space)]);
     }
 
     internal void OnClosing()
     {
         _cancellationTokenSource.Cancel();
+
+        // Only stop what this window started - a video the user left playing before opening the
+        // review should keep playing.
+        if (_hasPlayed)
+        {
+            _stopPlayback?.Invoke();
+        }
+
         UiUtil.SaveWindowPosition(Window);
     }
 }

--- a/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
@@ -365,6 +365,7 @@ public class AiReviewWindow : Window
         dataGrid.Bind(TableView.SelectedItemProperty, new Binding(nameof(vm.SelectedSuggestion)));
         TableViewExtras.AddSpaceToggle<ReviewSuggestionItem>(dataGrid,
             item => item.IsSelected, (item, v) => item.IsSelected = v);
+        dataGrid.DoubleTapped += (_, _) => vm.OnSuggestionsGridDoubleTapped();
 
         var borderGrid = UiUtil.MakeBorderForControlNoPadding(dataGrid);
 
@@ -428,12 +429,23 @@ public class AiReviewWindow : Window
         summaryText.VerticalAlignment = VerticalAlignment.Center;
         summaryText.Opacity = 0.8;
 
+        // Plays the selected suggestion's line in the main window's video player - hidden when no
+        // video is loaded (the view model gets no play hook then).
+        var buttonPlay = UiUtil.MakeButton(Se.Language.General.PlayCurrent, vm.PlayCurrentLineCommand)
+            .WithIconLeft("fa-solid fa-play");
+        buttonPlay.Bind(IsVisibleProperty, new Binding(nameof(vm.IsPlayVisible)));
+        if (Se.Settings.Appearance.ShowHints)
+        {
+            ToolTip.SetTip(buttonPlay, l.PlayCurrentLineHint);
+        }
+
         var leftButtons = new StackPanel
         {
             Orientation = Orientation.Horizontal,
             Spacing = 5,
             Children =
             {
+                buttonPlay.WithMarginRight(10),
                 summaryText.WithMarginRight(10),
                 UiUtil.MakeButton(Se.Language.General.SelectAll, vm.SelectAllCommand),
                 UiUtil.MakeButton(Se.Language.General.InvertSelection, vm.InvertSelectionCommand),

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -1313,50 +1313,8 @@ public partial class ReviewSpeechViewModel : ObservableObject
     /// </summary>
     private static bool MatchesPlayPauseShortcut(KeyEventArgs e)
     {
-        var cmdOrWin = OperatingSystem.IsMacOS() ? "Win" : "Ctrl";
-        var toggleKeys = Se.Settings.Shortcuts.FirstOrDefault(s => s.ActionName == nameof(MainViewModel.TogglePlayPauseCommand))?.Keys
-                         ?? [nameof(Key.Space)];
-        var toggle2Keys = Se.Settings.Shortcuts.FirstOrDefault(s => s.ActionName == nameof(MainViewModel.TogglePlayPause2Command))?.Keys
-                          ?? [cmdOrWin, nameof(Key.Space)];
-        return MatchesKeys(e, toggleKeys) || MatchesKeys(e, toggle2Keys);
-    }
-
-    // Matches a stored shortcut key list (modifier tokens + one main key) against a key event.
-    // Multi-key non-modifier chords are not supported here - the full ShortcutManager handles
-    // those in the main window; a dialog only needs the simple form.
-    private static bool MatchesKeys(KeyEventArgs e, List<string> keys)
-    {
-        var modifiers = KeyModifiers.None;
-        Key? mainKey = null;
-        foreach (var token in keys)
-        {
-            if (token is "Ctrl" or "Control" or "LeftCtrl" or "RightCtrl")
-            {
-                modifiers |= KeyModifiers.Control;
-            }
-            else if (token is "Alt" or "LeftAlt" or "RightAlt")
-            {
-                modifiers |= KeyModifiers.Alt;
-            }
-            else if (token is "Shift" or "LeftShift" or "RightShift")
-            {
-                modifiers |= KeyModifiers.Shift;
-            }
-            else if (token is "Win" or "Meta" or "LWin" or "RWin" or "Cmd" or "Command")
-            {
-                modifiers |= KeyModifiers.Meta;
-            }
-            else if (Enum.TryParse<Key>(token, out var key) && mainKey == null)
-            {
-                mainKey = key;
-            }
-            else
-            {
-                return false;
-            }
-        }
-
-        return mainKey != null && mainKey == e.Key && e.KeyModifiers == modifiers;
+        return MainShortcutKeys.Matches(e, nameof(MainViewModel.TogglePlayPauseCommand), [nameof(Key.Space)]) ||
+               MainShortcutKeys.Matches(e, nameof(MainViewModel.TogglePlayPause2Command), [MainShortcutKeys.CtrlOrCmd, nameof(Key.Space)]);
     }
 
     private void TogglePlayPauseSelectedRow()

--- a/src/ui/Logic/Config/Language/Tools/LanguageAiReview.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageAiReview.cs
@@ -25,6 +25,7 @@ public class LanguageAiReview
     public string LargeChangeWarning { get; set; }
     public string MismatchWarning { get; set; }
     public string EngineError { get; set; }
+    public string PlayCurrentLineHint { get; set; }
 
     public LanguageAiReview()
     {
@@ -51,5 +52,6 @@ public class LanguageAiReview
         LargeChangeWarning = "Large change - looks like a rewrite, review carefully";
         MismatchWarning = "Does not resemble the original - may belong to a different line";
         EngineError = "The AI engine could not be reached: {0}";
+        PlayCurrentLineHint = "Play the selected line in the video player and pause at its end (also double-click a line)";
     }
 }

--- a/src/ui/Logic/MainShortcutKeys.cs
+++ b/src/ui/Logic/MainShortcutKeys.cs
@@ -1,0 +1,68 @@
+using Avalonia.Input;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>
+/// Matches a key event against the user's main-window shortcut bindings, so a dialog can offer the
+/// same keys as the main window without going through the full ShortcutManager.
+/// </summary>
+public static class MainShortcutKeys
+{
+    /// <summary>The Ctrl/Cmd token as it is stored in the settings shortcut key lists.</summary>
+    public static string CtrlOrCmd => OperatingSystem.IsMacOS() ? "Win" : "Ctrl";
+
+    /// <summary>
+    /// True when the pressed keys match the main-window binding of <paramref name="actionName"/>
+    /// (a MainViewModel command name), falling back to the built-in default keys when the user
+    /// has no binding stored for it.
+    /// </summary>
+    public static bool Matches(KeyEventArgs e, string actionName, IReadOnlyList<string> defaultKeys)
+    {
+        var keys = Se.Settings.Shortcuts.FirstOrDefault(s => s.ActionName == actionName)?.Keys;
+        return MatchesKeys(e, keys ?? defaultKeys);
+    }
+
+    /// <summary>
+    /// Matches a stored shortcut key list (modifier tokens + one main key) against a key event.
+    /// Multi-key non-modifier chords are not supported here - the full ShortcutManager handles
+    /// those in the main window; a dialog only needs the simple form.
+    /// </summary>
+    public static bool MatchesKeys(KeyEventArgs e, IReadOnlyList<string> keys)
+    {
+        var modifiers = KeyModifiers.None;
+        Key? mainKey = null;
+        foreach (var token in keys)
+        {
+            if (token is "Ctrl" or "Control" or "LeftCtrl" or "RightCtrl")
+            {
+                modifiers |= KeyModifiers.Control;
+            }
+            else if (token is "Alt" or "LeftAlt" or "RightAlt")
+            {
+                modifiers |= KeyModifiers.Alt;
+            }
+            else if (token is "Shift" or "LeftShift" or "RightShift")
+            {
+                modifiers |= KeyModifiers.Shift;
+            }
+            else if (token is "Win" or "Meta" or "LWin" or "RWin" or "Cmd" or "Command")
+            {
+                modifiers |= KeyModifiers.Meta;
+            }
+            else if (Enum.TryParse<Key>(token, out var key) && mainKey == null)
+            {
+                mainKey = key;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        return mainKey != null && mainKey == e.Key && e.KeyModifiers == modifiers;
+    }
+}

--- a/tests/UI/Features/Tools/AiReview/AiReviewPlaybackTests.cs
+++ b/tests/UI/Features/Tools/AiReview/AiReviewPlaybackTests.cs
@@ -1,0 +1,181 @@
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.LogicalTree;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Tools.AiReview;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UITests.Features.Tools.AiReview;
+
+/// <summary>
+/// "Play current" in the AI review window drives the main window's video player through the hooks
+/// handed in by Initialize. These tests pin the contract of those hooks: the play button only shows
+/// when a video is loaded, playing asks for the paragraph index the suggestion belongs to, and
+/// closing only stops playback the window itself started.
+/// </summary>
+public class AiReviewPlaybackTests
+{
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private static AiReviewViewModel MakeViewModel()
+    {
+        return new AiReviewViewModel(new WindowService(new NullServiceProvider()));
+    }
+
+    private static Subtitle MakeSubtitle()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Hello there.", 0, 1000));
+        subtitle.Paragraphs.Add(new Paragraph("How are you?", 1500, 2500));
+        return subtitle;
+    }
+
+    private static ReviewSuggestionItem MakeSuggestion(int paragraphIndex)
+    {
+        return new ReviewSuggestionItem
+        {
+            Number = paragraphIndex + 1,
+            ParagraphIndex = paragraphIndex,
+            UnitId = paragraphIndex,
+            Category = ReviewCategory.Spelling,
+            Before = "before",
+            After = "after",
+            Reason = string.Empty,
+        };
+    }
+
+    [AvaloniaFact]
+    public void PlayCurrentLine_PlaysTheParagraphOfTheSelectedSuggestion()
+    {
+        var played = new List<int>();
+        var vm = MakeViewModel();
+        vm.Initialize(MakeSubtitle(), null, played.Add);
+
+        Assert.True(vm.IsPlayVisible);
+
+        vm.SelectedSuggestion = MakeSuggestion(1);
+        vm.PlayCurrentLineCommand.Execute(null);
+
+        Assert.Equal(new[] { 1 }, played);
+    }
+
+    [AvaloniaFact]
+    public void PlayCurrentLine_NoSelection_DoesNothing()
+    {
+        var played = new List<int>();
+        var vm = MakeViewModel();
+        vm.Initialize(MakeSubtitle(), null, played.Add);
+
+        vm.PlayCurrentLineCommand.Execute(null);
+
+        Assert.Empty(played);
+    }
+
+    [AvaloniaFact]
+    public void Initialize_WithoutPlayHook_HidesPlayButton()
+    {
+        var vm = MakeViewModel();
+        vm.Initialize(MakeSubtitle(), null);
+
+        Assert.False(vm.IsPlayVisible);
+
+        // No hook, no crash - the command must stay a no-op rather than throw.
+        vm.SelectedSuggestion = MakeSuggestion(0);
+        vm.PlayCurrentLineCommand.Execute(null);
+    }
+
+    [AvaloniaFact]
+    public void OnClosing_StopsPlaybackOnlyWhenThisWindowStartedIt()
+    {
+        var stopped = 0;
+        var vm = MakeViewModel();
+        vm.Initialize(MakeSubtitle(), null, _ => { }, () => stopped++);
+
+        vm.OnClosing();
+        Assert.Equal(0, stopped);
+
+        vm.SelectedSuggestion = MakeSuggestion(0);
+        vm.PlayCurrentLineCommand.Execute(null);
+        vm.OnClosing();
+        Assert.Equal(1, stopped);
+    }
+
+    [AvaloniaFact]
+    public void OnKeyDown_F5_PlaysSelectedLine()
+    {
+        var played = new List<int>();
+        var vm = MakeViewModel();
+        vm.Initialize(MakeSubtitle(), null, played.Add);
+        vm.SelectedSuggestion = MakeSuggestion(0);
+
+        var e = new KeyEventArgs { Key = Key.F5, KeyModifiers = KeyModifiers.None, RoutedEvent = InputElement.KeyDownEvent };
+        vm.OnKeyDown(e);
+
+        Assert.True(e.Handled);
+        Assert.Equal(new[] { 0 }, played);
+    }
+
+    [AvaloniaFact]
+    public void Window_PlayButton_FollowsIsPlayVisible()
+    {
+        // With a video (a play hook) the button is in the tree and visible...
+        var vmWithVideo = MakeViewModel();
+        vmWithVideo.Initialize(MakeSubtitle(), null, _ => { });
+        var windowWithVideo = new AiReviewWindow(vmWithVideo);
+        try
+        {
+            var button = FindPlayButton(windowWithVideo);
+            Assert.NotNull(button);
+            Assert.True(button!.IsVisible);
+        }
+        finally
+        {
+            windowWithVideo.Close();
+        }
+
+        // ...and without one it is hidden rather than a dead button.
+        var vmNoVideo = MakeViewModel();
+        vmNoVideo.Initialize(MakeSubtitle(), null);
+        var windowNoVideo = new AiReviewWindow(vmNoVideo);
+        try
+        {
+            var button = FindPlayButton(windowNoVideo);
+            Assert.NotNull(button);
+            Assert.False(button!.IsVisible);
+        }
+        finally
+        {
+            windowNoVideo.Close();
+        }
+    }
+
+    private static Button? FindPlayButton(Control root)
+    {
+        return root.GetLogicalDescendants().OfType<Button>()
+            .FirstOrDefault(b => AutomationProperties.GetName(b) == Se.Language.General.PlayCurrent);
+    }
+
+    [AvaloniaFact]
+    public void OnKeyDown_Space_IsLeftToTheGridCheckboxToggle()
+    {
+        var played = new List<int>();
+        var vm = MakeViewModel();
+        vm.Initialize(MakeSubtitle(), null, played.Add);
+        vm.SelectedSuggestion = MakeSuggestion(0);
+
+        var e = new KeyEventArgs { Key = Key.Space, KeyModifiers = KeyModifiers.None, RoutedEvent = InputElement.KeyDownEvent };
+        vm.OnKeyDown(e);
+
+        Assert.False(e.Handled);
+        Assert.Empty(played);
+    }
+}


### PR DESCRIPTION
Judging a suggested fix often needs the audio - "their" vs "there" is not decidable from the text alone. The AI review window can now play the line a suggestion belongs to.

Playback goes through the main window's video player using the same `PlayLineAndPauseAtEnd` the main window uses, so the waveform playhead is pinned and playback parks on the line's last visible frame. No second player instance.

## What's new

- **Play current** button at the bottom left of the AI review window - hidden when no video is loaded, disabled until a suggestion is selected
- Double-click a suggestion to play it
- **F5** (whatever your *play selected lines* binding is) or **Ctrl/Cmd+Space**. Bare Space is deliberately left alone: in this window it toggles the row's Apply checkbox
- Closing the window stops playback only if the window itself started it - a video left playing before the review keeps playing

Both entry points pass the hook (Tools -> AI review..., and right-click -> Selected lines -> AI review...). The paragraph index maps 1:1 to a subtitle line in both: the full-subtitle path filters reference-only rows exactly as `GetUpdateSubtitle()` does, and the selection path reuses the ordered block it built.

## Along the way

The shortcut key matcher that was private to `ReviewSpeechViewModel` moved to `MainShortcutKeys`, so both dialogs share one implementation.

## Testing

7 new headless tests in `AiReviewPlaybackTests`: the play hook contract (index handed out, no-selection no-op, no hook = no crash), the F5-plays / Space-doesn't split, stop-only-if-started, and the button's visibility in the real window tree. Full UI suite green (2771 passed).

End-to-end with a live engine and a video loaded has not been exercised - the playback path itself is the main window's own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)