### PR TITLE
Apply the whole default storage style category when converting to ASSA/SSA

### DIFF
--- a/docs/features/assa-styles.md
+++ b/docs/features/assa-styles.md
@@ -31,6 +31,7 @@ Manage Advanced SubStation Alpha (ASS/SSA) subtitle styles, including file style
 - **To apply a storage style to the current subtitle:** select it in the right panel, choose **Copy to file styles**, then assign that style to the relevant subtitle lines.
 - Copy styles between file and storage.
 - Set a style as the default for new subtitles (this only affects newly created/converted subtitles, not the current one).
+- **Default template:** when a new subtitle is created as ASSA, or an existing subtitle is converted to ASSA (via the format dropdown or *Save as*), the whole category of the default style is copied into the file — so a multi-style template (e.g. dialogue + signs) survives the conversion — and the lines start out on the default style. If no style is marked as default, the styles in the *Default* category are used. SubStation Alpha has its own separate storage styles (**SSA tools** → **Styles...**) that work the same way for conversions to SSA.
 
 ### Style Properties
 - **Font:** Name, size, bold, italic, underline, strikeout. The `...` button opens the font picker with two tabs — **Installed fonts** and **Collected fonts** (fonts gathered in Subtitle Edit's own `Fonts` folder inside the data folder) — the paperclip button picks a font from the subtitle's attachments, and the font button opens the **Font collector**, which shows the fonts the subtitle uses, whether they are available, and can copy them to a folder — including SE's `Fonts` folder. The font combo also lists the collected fonts.

--- a/src/ui/Features/Assa/AssaStyleStorageHelper.cs
+++ b/src/ui/Features/Assa/AssaStyleStorageHelper.cs
@@ -7,27 +7,76 @@ using System.Linq;
 
 namespace Nikse.SubtitleEdit.Features.Assa;
 
+/// <summary>
+/// Applies the styles-storage default to subtitles that are about to use a (Advanced) SubStation
+/// Alpha format. ASSA and SSA keep separate storages (<c>Se.Settings.Assa.StoredStyles</c> /
+/// <c>Se.Settings.Ssa.StoredStyles</c>), so every entry point takes the target format and picks
+/// the matching storage.
+/// </summary>
 public static class AssaStyleStorageHelper
 {
-    /// <summary>
-    /// Returns the ASSA storage style that is marked as default (if any).
-    /// </summary>
-    public static SeAssaStyle? GetDefaultStorageStyle()
+    private static List<SeAssaStyle> GetStorage(SubtitleFormat format)
     {
-        return Se.Settings.Assa.StoredStyles.FirstOrDefault(s => s.IsDefault);
+        return format is SubStationAlpha ? Se.Settings.Ssa.StoredStyles : Se.Settings.Assa.StoredStyles;
     }
 
     /// <summary>
-    /// Decides which style name a new ASSA paragraph should use:
-    /// if the file already defines styles, the first file style is used; otherwise the default
-    /// ASSA storage style (if any) becomes the file's style and is used. Falls back to "Default".
-    /// The subtitle header is updated when the storage default style is applied.
+    /// True when the header already carries SubStation Alpha styles - either variant: a freshly
+    /// format-switched file can hold an ASSA header while the selected format is SSA (and vice
+    /// versa), and both save paths convert the header on write.
     /// </summary>
-    public static string GetStyleNameForNewParagraph(Subtitle subtitle)
+    private static bool HasSsaOrAssaStyles(string? header)
+    {
+        return !string.IsNullOrEmpty(header) &&
+               (header.Contains("[V4+ Styles]", StringComparison.OrdinalIgnoreCase) ||
+                header.Contains("[V4 Styles]", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Returns the storage style that is marked as default (if any) for the given format's storage.
+    /// </summary>
+    public static SeAssaStyle? GetDefaultStorageStyle(SubtitleFormat format)
+    {
+        return GetStorage(format).FirstOrDefault(s => s.IsDefault);
+    }
+
+    /// <summary>
+    /// Returns the storage styles that make up the default template for new/converted ASSA/SSA
+    /// subtitles, mirroring SE 4's "default style storage category" (issue #13653): the whole
+    /// category of the style marked as default - or, when no style is marked, the built-in
+    /// default category (empty category name) - so multi-style templates survive the conversion.
+    /// The default style (marked, or the category's first) is returned first so callers can use
+    /// it for the paragraphs.
+    /// </summary>
+    public static List<SeAssaStyle> GetDefaultStorageStyles(SubtitleFormat format)
+    {
+        var defaultStyle = GetDefaultStorageStyle(format);
+        var category = defaultStyle?.Category ?? string.Empty;
+        var categoryStyles = GetStorage(format)
+            .Where(s => string.Equals(s.Category ?? string.Empty, category, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        if (defaultStyle != null)
+        {
+            categoryStyles.Remove(defaultStyle);
+            categoryStyles.Insert(0, defaultStyle);
+        }
+
+        // styles are written to one styles section, where a duplicate name would be ambiguous
+        var seenNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        return categoryStyles.Where(s => seenNames.Add(s.Name)).ToList();
+    }
+
+    /// <summary>
+    /// Decides which style name a new ASSA/SSA paragraph should use:
+    /// if the file already defines styles, the first file style is used; otherwise the default
+    /// storage styles (if any) become the file's styles and the default one is used.
+    /// Falls back to "Default". The subtitle header is updated when the storage styles are applied.
+    /// </summary>
+    public static string GetStyleNameForNewParagraph(Subtitle subtitle, SubtitleFormat format)
     {
         // if the file already defines styles, use the first one
-        if (!string.IsNullOrEmpty(subtitle.Header) &&
-            subtitle.Header.Contains("[V4+ Styles]", StringComparison.OrdinalIgnoreCase))
+        if (HasSsaOrAssaStyles(subtitle.Header))
         {
             var existingStyles = AdvancedSubStationAlpha.GetStylesFromHeader(subtitle.Header);
             if (existingStyles.Count > 0)
@@ -36,81 +85,91 @@ public static class AssaStyleStorageHelper
             }
         }
 
-        // otherwise use the default ASSA storage style (if any) as the file's style
-        var defaultStorageStyle = GetDefaultStorageStyle();
-        if (defaultStorageStyle != null)
+        // otherwise use the default storage styles (if any) as the file's styles
+        var storageStyles = GetDefaultStorageStyles(format);
+        if (storageStyles.Count > 0)
         {
-            var style = new StyleDisplay(defaultStorageStyle).ToSsaStyle();
-            subtitle.Header = AdvancedSubStationAlpha.GetHeaderAndStylesFromAdvancedSubStationAlpha(
-                AdvancedSubStationAlpha.DefaultHeader, new List<SsaStyle> { style });
-            return style.Name;
+            subtitle.Header = MakeHeaderFromStorageStyles(subtitle.Header, storageStyles, format);
+            return storageStyles[0].Name;
         }
 
         // fall back to the standard default style
         if (string.IsNullOrEmpty(subtitle.Header))
         {
-            subtitle.Header = AdvancedSubStationAlpha.DefaultHeader;
+            subtitle.Header = format is SubStationAlpha
+                ? SubStationAlpha.DefaultHeader
+                : AdvancedSubStationAlpha.DefaultHeader;
         }
 
         return AdvancedSubStationAlpha.GetStylesFromHeader(subtitle.Header).FirstOrDefault() ?? "Default";
     }
 
     /// <summary>
-    /// Applies the default ASSA storage style when a subtitle is about to be saved/converted to a
-    /// target format, but only when the conversion would otherwise lose the user's default style:
-    /// the target must be Advanced SubStation Alpha and the subtitle must not already carry ASSA
-    /// styles (e.g. it came from SRT). Without this, a "Save as" to ASS from a style-less format
-    /// falls back to the hard-coded Arial default instead of the configured default style
-    /// (issue #11788). No-op for other target formats, for subtitles that already have a
-    /// [V4+ Styles] header, or when no default storage style is configured.
+    /// Applies the default storage styles when a subtitle is about to be saved/converted to a
+    /// target format, but only when the conversion would otherwise lose the user's default styles:
+    /// the target must be Advanced SubStation Alpha or SubStation Alpha and the subtitle must not
+    /// already carry SSA/ASSA styles (e.g. it came from SRT). Without this, a "Save as" to ASS
+    /// from a style-less format falls back to the hard-coded Arial default instead of the
+    /// configured default styles (issue #11788). No-op for other target formats, for subtitles
+    /// that already have a styles header, or when no default storage styles are configured.
     /// </summary>
-    /// <returns>True if the default storage style was applied; otherwise false.</returns>
+    /// <returns>True if the default storage styles were applied; otherwise false.</returns>
     public static bool ApplyDefaultStorageStyleForFormatConversion(Subtitle subtitle, SubtitleFormat format)
     {
-        if (subtitle == null || format is not AdvancedSubStationAlpha)
+        if (subtitle == null || format is not (AdvancedSubStationAlpha or SubStationAlpha))
         {
             return false;
         }
 
-        if (!string.IsNullOrEmpty(subtitle.Header) &&
-            subtitle.Header.Contains("[V4+ Styles]", StringComparison.OrdinalIgnoreCase))
+        // an SSA source keeps its own styles when saved as ASSA (and vice versa) - both
+        // ToText implementations convert the foreign header variant on write
+        if (HasSsaOrAssaStyles(subtitle.Header))
         {
             return false;
         }
 
-        return ApplyDefaultStorageStyle(subtitle);
+        return ApplyDefaultStorageStyle(subtitle, format);
     }
 
     /// <summary>
-    /// Applies the default ASSA storage style (if any) to a subtitle that is about to use the
-    /// Advanced SubStation Alpha format - used when creating a new subtitle or converting to ASSA
-    /// from a format without ASSA styles. The default storage style becomes the only style in the
-    /// header and existing paragraphs are re-pointed to it.
+    /// Applies the default storage styles (if any) to a subtitle that is about to use the
+    /// Advanced SubStation Alpha or SubStation Alpha format - used when creating a new subtitle
+    /// or converting from a format without SSA/ASSA styles. Like SE 4's default style storage
+    /// category, the whole default category becomes the file's styles (issue #13653) and existing
+    /// paragraphs are re-pointed to the default style.
     /// </summary>
-    /// <returns>True if a default storage style was applied; otherwise false.</returns>
-    public static bool ApplyDefaultStorageStyle(Subtitle subtitle)
+    /// <returns>True if default storage styles were applied; otherwise false.</returns>
+    public static bool ApplyDefaultStorageStyle(Subtitle subtitle, SubtitleFormat format)
     {
-        var defaultStorageStyle = GetDefaultStorageStyle();
-        if (defaultStorageStyle == null)
+        var storageStyles = GetDefaultStorageStyles(format);
+        if (storageStyles.Count == 0)
         {
             return false;
         }
 
-        var style = new StyleDisplay(defaultStorageStyle).ToSsaStyle();
-
-        var header = subtitle.Header;
-        if (string.IsNullOrEmpty(header) || !header.Contains("[V4+ Styles]", StringComparison.OrdinalIgnoreCase))
-        {
-            header = AdvancedSubStationAlpha.DefaultHeader;
-        }
-
-        subtitle.Header = AdvancedSubStationAlpha.GetHeaderAndStylesFromAdvancedSubStationAlpha(header, new List<SsaStyle> { style });
+        subtitle.Header = MakeHeaderFromStorageStyles(subtitle.Header, storageStyles, format);
 
         foreach (var p in subtitle.Paragraphs)
         {
-            p.Extra = style.Name;
+            p.Extra = storageStyles[0].Name;
         }
 
         return true;
+    }
+
+    private static string MakeHeaderFromStorageStyles(string? existingHeader, List<SeAssaStyle> storageStyles, SubtitleFormat format)
+    {
+        var styles = storageStyles.Select(s => new StyleDisplay(s).ToSsaStyle()).ToList();
+
+        var baseHeader = existingHeader;
+        if (string.IsNullOrEmpty(baseHeader) || !baseHeader.Contains("[V4+ Styles]", StringComparison.OrdinalIgnoreCase))
+        {
+            baseHeader = AdvancedSubStationAlpha.DefaultHeader;
+        }
+
+        var assaHeader = AdvancedSubStationAlpha.GetHeaderAndStylesFromAdvancedSubStationAlpha(baseHeader, styles);
+        return format is SubStationAlpha
+            ? SubStationAlpha.GetHeaderAndStylesFromAdvancedSubStationAlpha(assaHeader, string.Empty)
+            : assaHeader;
     }
 }

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -2406,9 +2406,9 @@ public partial class MainViewModel :
         // (issue #12753). Import paths set _converted = true again *after* their ResetSubtitle() call.
         _converted = false;
         _subtitle = new Subtitle();
-        if (SelectedSubtitleFormat is AdvancedSubStationAlpha)
+        if (SelectedSubtitleFormat is AdvancedSubStationAlpha or SubStationAlpha)
         {
-            AssaStyleStorageHelper.ApplyDefaultStorageStyle(_subtitle);
+            AssaStyleStorageHelper.ApplyDefaultStorageStyle(_subtitle, SelectedSubtitleFormat);
         }
 
         _changeSubtitleHash = GetFastHash();
@@ -25256,18 +25256,18 @@ public partial class MainViewModel :
     }
 
     /// <summary>
-    /// Sets the style of a newly created ASSA paragraph to the default ASSA storage style (if any).
+    /// Sets the style of a newly created ASSA/SSA paragraph to the default storage style (if any).
     /// Used by insert paths that bypass <see cref="IInsertService"/> (e.g. typing the first line or
     /// inserting from a waveform selection).
     /// </summary>
     private void SetDefaultAssaStyleForNewParagraph(SubtitleLineViewModel newParagraph)
     {
-        if (SelectedSubtitleFormat is not AdvancedSubStationAlpha)
+        if (SelectedSubtitleFormat is not (AdvancedSubStationAlpha or SubStationAlpha))
         {
             return;
         }
 
-        newParagraph.Style = AssaStyleStorageHelper.GetStyleNameForNewParagraph(_subtitle);
+        newParagraph.Style = AssaStyleStorageHelper.GetStyleNameForNewParagraph(_subtitle, SelectedSubtitleFormat);
     }
 
     public void AudioVisualizerOnNewSelectionInsert(object sender, ParagraphEventArgs e)
@@ -26200,19 +26200,9 @@ public partial class MainViewModel :
                 Number = 1
             };
 
-            if (SelectedSubtitleFormat is AdvancedSubStationAlpha)
+            if (SelectedSubtitleFormat is AdvancedSubStationAlpha or SubStationAlpha)
             {
-                newSubtitle.Style = AssaStyleStorageHelper.GetStyleNameForNewParagraph(_subtitle);
-            }
-            else if (SelectedSubtitleFormat is SubStationAlpha)
-            {
-                if (string.IsNullOrEmpty(_subtitle.Header))
-                {
-                    _subtitle.Header = AdvancedSubStationAlpha.DefaultHeader;
-                }
-
-                var styles = AdvancedSubStationAlpha.GetStylesFromHeader(_subtitle.Header);
-                newSubtitle.Style = styles.Count > 0 ? styles[0] : "Default";
+                newSubtitle.Style = AssaStyleStorageHelper.GetStyleNameForNewParagraph(_subtitle, SelectedSubtitleFormat);
             }
 
             Subtitles.Add(newSubtitle);
@@ -26281,7 +26271,7 @@ public partial class MainViewModel :
 
                     if (oldFormat is SubStationAlpha)
                     {
-                        if (_subtitle.Header != null && !_subtitle.Header.Contains("[V4+ Styles]"))
+                        if (!string.IsNullOrEmpty(_subtitle.Header) && !_subtitle.Header.Contains("[V4+ Styles]"))
                         {
                             _subtitle.Header =
                                 AdvancedSubStationAlpha.GetHeaderAndStylesFromSubStationAlpha(_subtitle.Header);
@@ -26293,6 +26283,10 @@ public partial class MainViewModel :
                                 }
                             }
                         }
+                        else if (string.IsNullOrEmpty(_subtitle.Header))
+                        {
+                            AssaStyleStorageHelper.ApplyDefaultStorageStyle(_subtitle, format);
+                        }
                     }
                     else if (oldFormat is AdvancedSubStationAlpha && string.IsNullOrEmpty(_subtitle.Header))
                     {
@@ -26300,11 +26294,22 @@ public partial class MainViewModel :
                     }
                     else if (oldFormat is not AdvancedSubStationAlpha)
                     {
-                        // converting from a format without ASSA styles - use the default style from the storage styles (if any)
-                        AssaStyleStorageHelper.ApplyDefaultStorageStyle(_subtitle);
+                        // converting from a format without ASSA styles - use the default styles from the storage (if any)
+                        AssaStyleStorageHelper.ApplyDefaultStorageStyle(_subtitle, format);
                     }
 
                     SetAssaResolution(true);
+                }
+                else if (format is SubStationAlpha)
+                {
+                    // converting from a format without SSA/ASSA styles - use the default styles from
+                    // the SSA storage (if any); an ASSA source with a header keeps its own styles
+                    // (the header is converted on save)
+                    if (oldFormat is not (SubStationAlpha or AdvancedSubStationAlpha) ||
+                        string.IsNullOrEmpty(_subtitle.Header))
+                    {
+                        AssaStyleStorageHelper.ApplyDefaultStorageStyle(_subtitle, format);
+                    }
                 }
 
                 // The rebuild below blanks the original column and drops the reference rows, so an

--- a/src/ui/Logic/InsertService.cs
+++ b/src/ui/Logic/InsertService.cs
@@ -273,7 +273,7 @@ public class InsertService : IInsertService
                     Language = newParagraph.Language
                 });
             }
-            else if (format.GetType() == typeof(AdvancedSubStationAlpha))
+            else if (format.GetType() == typeof(AdvancedSubStationAlpha) || format.GetType() == typeof(SubStationAlpha))
             {
                 var c = subtitles.GetOrNull(nearestIndex);
                 if (c != null)
@@ -282,8 +282,8 @@ public class InsertService : IInsertService
                     newParagraph.Actor = c.Actor;
                 }
 
-                // use the first style from the file, or the default ASSA storage style for a new file
-                newParagraph.Style = AssaStyleStorageHelper.GetStyleNameForNewParagraph(subtitle);
+                // use the first style from the file, or the default storage styles for a new file
+                newParagraph.Style = AssaStyleStorageHelper.GetStyleNameForNewParagraph(subtitle, format);
             }
         }
     }

--- a/tests/UI/Features/Assa/AssaStyleStorageHelperTests.cs
+++ b/tests/UI/Features/Assa/AssaStyleStorageHelperTests.cs
@@ -7,12 +7,14 @@ using Nikse.SubtitleEdit.Logic.Config;
 namespace UITests.Features.Assa;
 
 /// <summary>
-/// Regression tests for issue #11788: "Save as" to ASS from a style-less format (e.g. SRT)
-/// must use the user's configured default ASSA style, not the hard-coded Arial default.
+/// Regression tests for issue #11788 ("Save as" to ASS from a style-less format must use the
+/// user's configured default ASSA style, not the hard-coded Arial default) and issue #13653
+/// (converting to ASSA embeds the whole default storage category, like SE 4 - and the same
+/// mechanism works for SSA with its own storage).
 /// </summary>
 public class AssaStyleStorageHelperTests
 {
-    private static SeAssaStyle MakeStoredStyle(string name, string fontName, decimal fontSize, bool isDefault)
+    private static SeAssaStyle MakeStoredStyle(string name, string fontName, decimal fontSize, bool isDefault, string category = "")
     {
         return new SeAssaStyle
         {
@@ -20,6 +22,7 @@ public class AssaStyleStorageHelperTests
             FontName = fontName,
             FontSize = fontSize,
             IsDefault = isDefault,
+            Category = category,
             ColorPrimary = "#FFFFFF",
             ColorSecondary = "#FFFFFF",
             ColorOutline = "#000000",
@@ -108,6 +111,65 @@ public class AssaStyleStorageHelperTests
     }
 
     [Fact]
+    public void SrtToAss_WholeCategoryOfTheDefaultStyleIsApplied()
+    {
+        var saved = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+            // SE 4 semantics (issue #13653): the default style's whole category is the template.
+            Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("Sign", "Verdana", 30, isDefault: false, category: "Movie"));
+            Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("Speech", "Segoe UI", 90, isDefault: true, category: "Movie"));
+            Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("Unrelated", "Courier New", 20, isDefault: false, category: "TV"));
+
+            var subtitle = MakeSrtSubtitle();
+
+            var applied = AssaStyleStorageHelper.ApplyDefaultStorageStyleForFormatConversion(subtitle, new AdvancedSubStationAlpha());
+
+            Assert.True(applied);
+
+            // The default style leads (it is what paragraphs point at), its category siblings
+            // follow, other categories stay out.
+            var styles = AdvancedSubStationAlpha.GetStylesFromHeader(subtitle.Header);
+            Assert.Equal(new[] { "Speech", "Sign" }, styles);
+            Assert.DoesNotContain("Courier New", subtitle.Header);
+
+            Assert.All(subtitle.Paragraphs, p => Assert.Equal("Speech", p.Extra));
+        }
+        finally
+        {
+            Se.Settings = saved;
+        }
+    }
+
+    [Fact]
+    public void SrtToAss_NoDefaultFlag_DefaultCategoryStylesAreApplied()
+    {
+        var saved = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+            // No style is marked default, but the built-in default category (empty name) holds
+            // styles - SE 4 applied those without any flag, so SE 5 does too (issue #13653).
+            Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("Narrator", "Segoe UI", 90, isDefault: false));
+            Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("Sign", "Verdana", 30, isDefault: false));
+            Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("Unrelated", "Courier New", 20, isDefault: false, category: "TV"));
+
+            var subtitle = MakeSrtSubtitle();
+
+            var applied = AssaStyleStorageHelper.ApplyDefaultStorageStyleForFormatConversion(subtitle, new AdvancedSubStationAlpha());
+
+            Assert.True(applied);
+            Assert.Equal(new[] { "Narrator", "Sign" }, AdvancedSubStationAlpha.GetStylesFromHeader(subtitle.Header));
+            Assert.All(subtitle.Paragraphs, p => Assert.Equal("Narrator", p.Extra));
+        }
+        finally
+        {
+            Se.Settings = saved;
+        }
+    }
+
+    [Fact]
     public void NonAssTarget_DoesNothing()
     {
         var saved = Se.Settings;
@@ -154,14 +216,41 @@ public class AssaStyleStorageHelperTests
     }
 
     [Fact]
-    public void NoDefaultStorageStyle_DoesNothing_PreservingArialFallback()
+    public void SsaSourceSavedAsAss_KeepsItsOwnStyles()
     {
         var saved = Se.Settings;
         try
         {
             Se.Settings = new Se();
-            // A stored style exists but none is marked default.
-            Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("Some", "Segoe UI", 90, isDefault: false));
+            Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("Default", "Segoe UI", 90, isDefault: true));
+
+            // An SSA file carries [V4 Styles]; saving it as ASSA converts the header on write, so
+            // the storage default must not clobber the file's real styles.
+            var subtitle = MakeSrtSubtitle();
+            var existingHeader = SubStationAlpha.DefaultHeader;
+            subtitle.Header = existingHeader;
+
+            var applied = AssaStyleStorageHelper.ApplyDefaultStorageStyleForFormatConversion(subtitle, new AdvancedSubStationAlpha());
+
+            Assert.False(applied);
+            Assert.Equal(existingHeader, subtitle.Header);
+        }
+        finally
+        {
+            Se.Settings = saved;
+        }
+    }
+
+    [Fact]
+    public void NoDefaultFlagAndEmptyDefaultCategory_DoesNothing_PreservingArialFallback()
+    {
+        var saved = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+            // A stored style exists, but none is marked default and none is in the default
+            // category - there is nothing to call "the default template".
+            Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("Some", "Segoe UI", 90, isDefault: false, category: "TV"));
 
             var subtitle = MakeSrtSubtitle();
 
@@ -169,6 +258,118 @@ public class AssaStyleStorageHelperTests
 
             Assert.False(applied);
             Assert.True(string.IsNullOrEmpty(subtitle.Header));
+        }
+        finally
+        {
+            Se.Settings = saved;
+        }
+    }
+
+    [Fact]
+    public void SrtToSsa_AppliesConfiguredSsaDefaultStyle_NotArial()
+    {
+        var saved = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+            Se.Settings.Ssa.StoredStyles.Add(MakeStoredStyle("MySsaStyle", "Georgia", 28, isDefault: true));
+
+            var subtitle = MakeSrtSubtitle();
+
+            var applied = AssaStyleStorageHelper.ApplyDefaultStorageStyleForFormatConversion(subtitle, new SubStationAlpha());
+
+            Assert.True(applied);
+            Assert.Contains("[V4 Styles]", subtitle.Header);
+            Assert.DoesNotContain("[V4+ Styles]", subtitle.Header);
+            Assert.Contains("Georgia", subtitle.Header);
+            Assert.All(subtitle.Paragraphs, p => Assert.Equal("MySsaStyle", p.Extra));
+
+            // The written SSA file must carry the style and reference it from the Dialogue lines.
+            var text = new SubStationAlpha().ToText(subtitle, string.Empty);
+            Assert.Contains("Style: MySsaStyle,Georgia,28", text);
+            var dialogueLines = text.SplitToLines().Where(l => l.StartsWith("Dialogue:")).ToList();
+            Assert.NotEmpty(dialogueLines);
+            foreach (var line in dialogueLines)
+            {
+                Assert.Equal("MySsaStyle", line.Split(',')[3]);
+            }
+        }
+        finally
+        {
+            Se.Settings = saved;
+        }
+    }
+
+    [Fact]
+    public void SsaAndAssaStoragesAreSeparate()
+    {
+        var saved = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+            // Only the ASSA storage has a default - an SSA conversion must not pick it up,
+            // and vice versa (the two formats keep separate style storages).
+            Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("AssaOnly", "Segoe UI", 90, isDefault: true));
+
+            var subtitle = MakeSrtSubtitle();
+            var appliedSsa = AssaStyleStorageHelper.ApplyDefaultStorageStyleForFormatConversion(subtitle, new SubStationAlpha());
+            Assert.False(appliedSsa);
+            Assert.True(string.IsNullOrEmpty(subtitle.Header));
+
+            Se.Settings = new Se();
+            Se.Settings.Ssa.StoredStyles.Add(MakeStoredStyle("SsaOnly", "Georgia", 28, isDefault: true));
+
+            subtitle = MakeSrtSubtitle();
+            var appliedAssa = AssaStyleStorageHelper.ApplyDefaultStorageStyleForFormatConversion(subtitle, new AdvancedSubStationAlpha());
+            Assert.False(appliedAssa);
+            Assert.True(string.IsNullOrEmpty(subtitle.Header));
+        }
+        finally
+        {
+            Se.Settings = saved;
+        }
+    }
+
+    [Fact]
+    public void GetStyleNameForNewParagraph_SsaWithNoStorage_GetsSsaHeaderNotAssa()
+    {
+        var saved = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+
+            // Regression: typing the first line of a new SSA file used to stamp an ASSA
+            // (v4.00+/[V4+ Styles]) header onto the SSA subtitle.
+            var subtitle = new Subtitle();
+            var styleName = AssaStyleStorageHelper.GetStyleNameForNewParagraph(subtitle, new SubStationAlpha());
+
+            Assert.Equal("Default", styleName);
+            Assert.Contains("[V4 Styles]", subtitle.Header);
+            Assert.DoesNotContain("[V4+ Styles]", subtitle.Header);
+        }
+        finally
+        {
+            Se.Settings = saved;
+        }
+    }
+
+    [Fact]
+    public void GetStyleNameForNewParagraph_UsesExistingFileStyles()
+    {
+        var saved = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+            Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("StorageStyle", "Segoe UI", 90, isDefault: true));
+
+            // A file that already defines styles wins over the storage default.
+            var subtitle = MakeSrtSubtitle();
+            AssaStyleStorageHelper.ApplyDefaultStorageStyle(subtitle, new AdvancedSubStationAlpha());
+            Se.Settings.Assa.StoredStyles[0].Name = "RenamedLater";
+
+            var styleName = AssaStyleStorageHelper.GetStyleNameForNewParagraph(subtitle, new AdvancedSubStationAlpha());
+
+            Assert.Equal("StorageStyle", styleName);
         }
         finally
         {

--- a/tests/UI/Features/Main/FormatDropdownDefaultStyleTests.cs
+++ b/tests/UI/Features/Main/FormatDropdownDefaultStyleTests.cs
@@ -1,0 +1,173 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// Issue #13653: switching the main window's format dropdown to Advanced Sub Station Alpha (or
+/// SubStation Alpha) must adopt the user's default storage styles - the whole default category,
+/// like SE 4 - instead of forcing the hard-coded Arial default. Driven through the real toolbar
+/// ComboBox so the SelectionChanged conversion path is what is under test.
+/// </summary>
+public class FormatDropdownDefaultStyleTests : IDisposable
+{
+    // Every window opened by a test is closed again in Dispose: if a test stops early, an
+    // unclosed window would outlive the test and race with the headless session teardown.
+    private readonly List<Window> _windows = new();
+    private readonly string _tempDirectory;
+    private readonly List<SeAssaStyle> _savedAssaStyles;
+    private readonly List<SeAssaStyle> _savedSsaStyles;
+
+    public FormatDropdownDefaultStyleTests()
+    {
+        _tempDirectory = Path.Combine(Path.GetTempPath(), "SubtitleEdit.UITests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDirectory);
+        _savedAssaStyles = Se.Settings.Assa.StoredStyles.ToList();
+        _savedSsaStyles = Se.Settings.Ssa.StoredStyles.ToList();
+        Se.Settings.Assa.StoredStyles.Clear();
+        Se.Settings.Ssa.StoredStyles.Clear();
+    }
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+
+        Se.Settings.Assa.StoredStyles.Clear();
+        Se.Settings.Assa.StoredStyles.AddRange(_savedAssaStyles);
+        Se.Settings.Ssa.StoredStyles.Clear();
+        Se.Settings.Ssa.StoredStyles.AddRange(_savedSsaStyles);
+
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+    }
+
+    private (Window Window, MainViewModel Vm) ShowEmptyMainWindow()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1400, Height = 900 };
+        _windows.Add(window);
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var vm = (MainViewModel)view.DataContext!;
+        window.SuppressSaveChangesPromptOnClose(vm);
+        return (window, vm);
+    }
+
+    private static void Settle(Window window)
+    {
+        for (var pump = 0; pump < 5; pump++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+        }
+    }
+
+    private string WriteSrt(string name)
+    {
+        var fileName = Path.Combine(_tempDirectory, name);
+        File.WriteAllText(fileName,
+            "1" + Environment.NewLine +
+            "00:00:01,000 --> 00:00:02,000" + Environment.NewLine +
+            "Line one" + Environment.NewLine +
+            Environment.NewLine +
+            "2" + Environment.NewLine +
+            "00:00:03,000 --> 00:00:04,000" + Environment.NewLine +
+            "Line two" + Environment.NewLine);
+        return fileName;
+    }
+
+    private static SeAssaStyle MakeStoredStyle(string name, string fontName, bool isDefault)
+    {
+        return new SeAssaStyle
+        {
+            Name = name,
+            FontName = fontName,
+            FontSize = 42,
+            IsDefault = isDefault,
+            ColorPrimary = "#FFFFFF",
+            ColorSecondary = "#FFFFFF",
+            ColorOutline = "#000000",
+            ColorShadow = "#000000",
+            Alignment = "2",
+        };
+    }
+
+    private static ComboBox FindFormatComboBox(Window window, MainViewModel vm)
+    {
+        var combo = window.GetVisualDescendants().OfType<ComboBox>()
+            .FirstOrDefault(c => ReferenceEquals(c.ItemsSource, vm.SubtitleFormats));
+        Assert.NotNull(combo);
+        return combo!;
+    }
+
+    [AvaloniaFact]
+    public async Task SwitchDropdownToAssa_AppliesWholeDefaultStorageCategory()
+    {
+        // Two styles in the default category, "Speech" flagged - both must reach the file,
+        // with the flagged one on the lines.
+        Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("Sign", "Verdana", isDefault: false));
+        Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("Speech", "Georgia", isDefault: true));
+
+        var (window, vm) = ShowEmptyMainWindow();
+        await vm.SubtitleOpen(WriteSrt("issue13653.srt"), skipLoadVideo: true);
+        Settle(window);
+
+        var combo = FindFormatComboBox(window, vm);
+        combo.SelectedItem = vm.SubtitleFormats.First(f => f is AdvancedSubStationAlpha);
+        Settle(window);
+
+        var subtitle = vm.GetUpdateSubtitle();
+        Assert.Contains("[V4+ Styles]", subtitle.Header);
+        Assert.Equal(new[] { "Speech", "Sign" }, AdvancedSubStationAlpha.GetStylesFromHeader(subtitle.Header));
+        Assert.Contains("Georgia", subtitle.Header);
+        Assert.Contains("Verdana", subtitle.Header);
+        Assert.DoesNotContain("Arial", subtitle.Header);
+        Assert.All(vm.Subtitles, s => Assert.Equal("Speech", s.Style));
+    }
+
+    [AvaloniaFact]
+    public async Task SwitchDropdownToSsa_AppliesSsaDefaultStorageStyle()
+    {
+        // The SSA storage is separate from the ASSA one - and its default must be used for SSA.
+        Se.Settings.Ssa.StoredStyles.Add(MakeStoredStyle("MySsaStyle", "Georgia", isDefault: true));
+        Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("WrongStorage", "Impact", isDefault: true));
+
+        var (window, vm) = ShowEmptyMainWindow();
+        await vm.SubtitleOpen(WriteSrt("issue13653-ssa.srt"), skipLoadVideo: true);
+        Settle(window);
+
+        var combo = FindFormatComboBox(window, vm);
+        combo.SelectedItem = vm.SubtitleFormats.First(f => f is SubStationAlpha);
+        Settle(window);
+
+        var subtitle = vm.GetUpdateSubtitle();
+        Assert.Contains("[V4 Styles]", subtitle.Header);
+        Assert.DoesNotContain("[V4+ Styles]", subtitle.Header);
+        Assert.Contains("Georgia", subtitle.Header);
+        Assert.DoesNotContain("Impact", subtitle.Header);
+        Assert.All(vm.Subtitles, s => Assert.Equal("MySsaStyle", s.Style));
+    }
+}


### PR DESCRIPTION
Fixes #13653.

## Problem

Switching the main window's format dropdown to Advanced Sub Station Alpha forced the hard-coded Arial default style instead of the user's own template. The storage-default mechanism from #11788 did work, but only if the user had found the "Set style as default" button — and even then it applied just that one style. SE 4 embedded **every style of the default styles-storage category**, so multi-style templates (dialogue + signs, etc.) worked with no per-style flag at all.

## Fix

`AssaStyleStorageHelper` now builds the default template the SE 4 way: the whole category of the style marked as default — or, when no style is marked, the built-in *Default* category — with the default style first so new/converted lines point at it.

## ASSA/SSA mix-ups fixed along the way

- SSA's styles dialog had its own "Set style as default" button whose flag **nothing consumed**. The helper is now format-aware (`Se.Settings.Ssa` vs `.Assa` storage), and the format dropdown, *Save as*, new-subtitle and insert paths all apply the SSA storage default for SSA the same way they do for ASSA.
- Typing the first line of a new SSA subtitle stamped an **ASSA** (`v4.00+`/`[V4+ Styles]`) header onto the SSA file; it now gets a proper SSA header.
- *Save as* ASS from an SSA source clobbered the file's real styles with the storage default: the already-has-styles guard only knew the `[V4+ Styles]` marker, so an SSA header (`[V4 Styles]`) slipped past it. It now recognizes both (each writer converts the foreign header variant on save).
- Switching SSA → ASSA or ASSA → SSA with an empty header fell back to the hard-coded style instead of the storage default.

## Tests

- Helper unit tests: whole-category embedding, no-flag default-category fallback, separate ASSA/SSA storages, SSA header regression, save-as guard regression (12 tests).
- End-to-end headless tests driving the real toolbar format ComboBox to both ASSA and SSA on an opened SRT.
- Full UI suite: 2788 passed, 0 failed.

Docs: `docs/features/assa-styles.md` updated to describe the category-template semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)