### PR TITLE
Add HunyuanOCR 1.5 to the llama.cpp OCR model list

### DIFF
--- a/src/libuilogic/LlamaCpp/LlamaCppServerManager.cs
+++ b/src/libuilogic/LlamaCpp/LlamaCppServerManager.cs
@@ -228,6 +228,18 @@ public static class LlamaCppServerManager
             "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.6-GGUF/resolve/main/PaddleOCR-VL-1.6-GGUF.gguf",
             MmprojFileName: "PaddleOCR-VL-1.6-GGUF-mmproj.gguf",
             MmprojUrl: "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.6-GGUF/resolve/main/PaddleOCR-VL-1.6-GGUF-mmproj.gguf"),
+        // HunyuanOCR 1.5 (Tencent, ~1B) - the fastest VLM in this list (~1.6x GLM-OCR per image
+        // on Apple Silicon). Verified 2026-08-15 on the pinned b10310 build, 9-image
+        // EN/DE/FR/ES/IT/ZH/JA/RU subtitle corpus: recognition itself exact in every script,
+        // but two formatting quirks keep it from being the default: it sporadically prefixes a
+        // markdown "# " heading (1/9 images; immune to prompt wording, identical at bf16, and
+        // unstrippable because genuine SDH "# lyrics" hash cues - which it preserves verbatim -
+        // look the same), and it silently drops ♪ note marks. GLM-OCR gets both right.
+        // Q8_0 only: bf16 measured identical on the same corpus while twice the size.
+        new LlamaCppModel("HunyuanOCR 1.5 (Q8_0)", "HunyuanOCR-Q8_0.gguf", "1.3 GB",
+            "https://huggingface.co/ggml-org/HunyuanOCR-GGUF/resolve/main/HunyuanOCR-Q8_0.gguf",
+            MmprojFileName: "mmproj-HunyuanOCR-Q8_0.gguf",
+            MmprojUrl: "https://huggingface.co/ggml-org/HunyuanOCR-GGUF/resolve/main/mmproj-HunyuanOCR-Q8_0.gguf"),
     };
 
     /// <summary>


### PR DESCRIPTION
Adds Tencent's HunyuanOCR 1.5 (ggml-org Q8_0 GGUF + mmproj, 1.3 GB total) as a curated model in the llama.cpp OCR engine. One-list change in `LlamaCppServerManager.OcrModels`, so it shows up in the OCR window, Video OCR, batch convert, and seconv automatically.

## Verification (headless, pinned b10310 llama-server, SE's exact flags/preprocessing/prompt)

9-image subtitle-style corpus (EN, EN two-liner, DE, FR, ES, IT, ZH, JA, RU), scored NFC-normalized with per-line trim:

| model | exact | avg CER | avg ms/image (Apple Silicon) |
|---|---|---|---|
| GLM-OCR Q8_0 (current default) | 9/9 | 0.000 | ~19,100 |
| HunyuanOCR 1.5 Q8_0 | 8/9 | 0.009 | ~11,900 |
| HunyuanOCR 1.5 bf16 | 8/9 | 0.009 | ~14,400 |

Recognition itself is exact in every script — the single miss is a spurious markdown `# ` prefix, not a reading error.

## Why it is not the default

- **Sporadic markdown `# ` heading prefix** (1/9 images). Immune to prompt wording (tested three anti-markdown variants plus Tencent's official `structured_parse` prompt, which was worse — it also loses line breaks). Identical at bf16, so not quant noise. Cannot be stripped safely: the model preserves genuine SDH `# lyrics` hash cues verbatim, and those look identical to the artifact.
- **Drops ♪ note marks entirely** (`♪ text ♪` → `text`). GLM-OCR preserves them.

GLM-OCR stays first in the list; HunyuanOCR is the fast alternative (~1.6× quicker per image) with the caveats documented in the code comment.

Q8_0 only — bf16 measured byte-identical in behavior on the same corpus while twice the size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)