### PR TITLE
OCR: load all spell-check regex sections; better German I/l rules

### DIFF
--- a/Dictionaries/deu_OCRFixReplaceList.xml
+++ b/Dictionaries/deu_OCRFixReplaceList.xml
@@ -7106,6 +7106,12 @@
     <!-- traIIer → trailer : I→l mid lowercase word -->
     <RegEx find="\b([a-zäöüß]+)I([a-zäöüß]+)\b" spellCheck="$1l$2" replaceWith="$1l$2" />
 
+    <!-- einmaI → einmal : trailing I→l in lowercase word -->
+    <RegEx find="\b([a-zäöüß]+)I\b" spellCheck="$1l" replaceWith="$1l" />
+
+    <!-- voII → voll / SoII → Soll / AII → All : trailing II→ll -->
+    <RegEx find="\b([A-ZÄÖÜa-zäöüß][a-zäöüß]*)II\b" spellCheck="$1ll" replaceWith="$1ll" />
+
     <!-- trailing I→l in capitalised word (e.g. BerlinI → Berlinl) -->
     <RegEx find="\b([A-ZÄÖÜ][a-zäöüß]+)I\b" spellCheck="$1l" replaceWith="$1l" />
 
@@ -7116,11 +7122,13 @@
     <!-- "Ich" starts with I but is only 3 chars — safe minimum is 4 -->
     <RegEx find="\bI([a-zäöüß]{4,})\b" spellCheck="l$1" replaceWith="l$1" />
 
-    <!-- leading l→I before 2+ lowercase chars -->
-    <RegEx find="\bl([a-zäöüß]{2,})\b" spellCheck="I$1" replaceWith="I$1" />
+    <!-- lst → Ist / ln → In / lm → Im : leading l→I before lowercase chars.  -->
+    <!-- Safe with a single following char too: no German word is "l"+letter, -->
+    <!-- and the spellCheck gate only fires when the I-form is a real word.   -->
+    <RegEx find="\bl([a-zäöüß]+)\b" spellCheck="I$1" replaceWith="I$1" />
 
-    <!-- standalone l → I (Roman numerals, list markers) -->
-    <RegEx find="\bl\b" replaceWith="I" />
+    <!-- No standalone \bl\b → I rule: "l" is the German liter abbreviation  -->
+    <!-- (2 l Milch), and an unconditional rule would corrupt it.            -->
 
     <!-- ============================================================ -->
     <!-- GERMAN GENITIVE / APOSTROPHE                                 -->

--- a/src/libuilogic/Ocr/FixEngine/SpellCheckRegex.cs
+++ b/src/libuilogic/Ocr/FixEngine/SpellCheckRegex.cs
@@ -69,12 +69,24 @@ public class SpellCheckRegex
     {
         var list = new List<SpellCheckRegex>();
 
-        var node = doc.DocumentElement?.SelectSingleNode(name);
-        if (node == null)
+        // Several shipped lists (deu/nld/nor) contain more than one section with the same
+        // name - read them all, or every section after the first is silently dropped.
+        var nodes = doc.DocumentElement?.SelectNodes(name);
+        if (nodes == null)
         {
             return list;
         }
 
+        foreach (XmlNode node in nodes)
+        {
+            LoadRegExNodes(node, list);
+        }
+
+        return list;
+    }
+
+    private static void LoadRegExNodes(XmlNode node, List<SpellCheckRegex> list)
+    {
         foreach (XmlNode item in node.ChildNodes)
         {
             var find = item.Attributes?["find"]?.Value;
@@ -104,8 +116,6 @@ public class SpellCheckRegex
                 // ignore
             }
         }
-
-        return list;
     }
 }
 

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixGermanReplaceListTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixGermanReplaceListTests.cs
@@ -1,0 +1,134 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
+using Nikse.SubtitleEdit.Features.SpellCheck;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
+
+namespace UITests.Features.Ocr.FixEngine;
+
+// Issue #13658: German OCR kept producing "SpitzeI", "lst" and "ln" (I/l confusion) even though
+// deu_OCRFixReplaceList.xml has spell-check-gated regexes for exactly these errors. The shipped
+// deu/nld/nor lists contain TWO RegularExpressionsIfSpelledCorrectly sections, and the loader
+// only read the first one, so the whole second block was silently dead. The list here mirrors
+// the shipped file's structure: a small first section plus the real rules in a second section.
+public class OcrFixGermanReplaceListTests : IDisposable
+{
+    private readonly Func<string> _originalSpellCheckDictionariesFolder;
+    private readonly string _tempDictionariesFolder;
+
+    public OcrFixGermanReplaceListTests()
+    {
+        _originalSpellCheckDictionariesFolder = SpellCheckConfig.DictionariesFolder;
+
+        _tempDictionariesFolder = Path.Combine(
+            Path.GetTempPath(),
+            "SeOcrFixGermanReplaceListTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDictionariesFolder);
+        SpellCheckConfig.DictionariesFolder = () => _tempDictionariesFolder;
+
+        // Same section layout and I/l rules as the shipped deu_OCRFixReplaceList.xml.
+        File.WriteAllText(
+            Path.Combine(_tempDictionariesFolder, "deu_OCRFixReplaceList.xml"),
+            "<ReplaceList>" +
+            "<RegularExpressionsIfSpelledCorrectly>" +
+            "<RegEx find=\"\\bl([A-Z]+)\\b\" spellCheck=\"I$1\" replaceWith=\"I$1\" />" +
+            "</RegularExpressionsIfSpelledCorrectly>" +
+            "<RegularExpressionsIfSpelledCorrectly>" +
+            "<RegEx find=\"\\b([a-zäöüß]+)I([a-zäöüß]+)\\b\" spellCheck=\"$1l$2\" replaceWith=\"$1l$2\" />" +
+            "<RegEx find=\"\\b([A-ZÄÖÜ][a-zäöüß]+)I\\b\" spellCheck=\"$1l\" replaceWith=\"$1l\" />" +
+            "<RegEx find=\"\\b([a-zäöüß]+)I\\b\" spellCheck=\"$1l\" replaceWith=\"$1l\" />" +
+            "<RegEx find=\"\\b([A-ZÄÖÜa-zäöüß][a-zäöüß]*)II\\b\" spellCheck=\"$1ll\" replaceWith=\"$1ll\" />" +
+            "<RegEx find=\"\\bl([a-zäöüß]+)\\b\" spellCheck=\"I$1\" replaceWith=\"I$1\" />" +
+            "</RegularExpressionsIfSpelledCorrectly>" +
+            "</ReplaceList>");
+    }
+
+    [Fact]
+    public void FixOcrErrors_TrailingUppercaseIInCapitalizedWord_IsFixed()
+    {
+        var engine = CreateEngine();
+
+        var result = engine.FixOcrErrors(0, "Hängen da SpitzeI mit drin?", doTryToGuessUnknownWords: false);
+
+        Assert.Equal("Hängen da Spitzel mit drin?", result.GetText());
+    }
+
+    [Fact]
+    public void FixOcrErrors_LeadingLowercaseLBeforeTwoChars_IsFixed()
+    {
+        var engine = CreateEngine();
+
+        var result = engine.FixOcrErrors(0, "lst da jemand?", doTryToGuessUnknownWords: false);
+
+        Assert.Equal("Ist da jemand?", result.GetText());
+    }
+
+    [Fact]
+    public void FixOcrErrors_LeadingLowercaseLBeforeSingleChar_IsFixed()
+    {
+        var engine = CreateEngine();
+
+        var result = engine.FixOcrErrors(0, "Du? ln Paris?", doTryToGuessUnknownWords: false);
+
+        Assert.Equal("Du? In Paris?", result.GetText());
+    }
+
+    [Fact]
+    public void FixOcrErrors_CorrectGermanWordStartingWithL_IsLeftAlone()
+    {
+        var engine = CreateEngine();
+
+        // "lieben" is a real word - the leading l→I rule must not touch it even though the
+        // line contains another error that makes the regex rules run.
+        var result = engine.FixOcrErrors(0, "Wir lieben SpitzeI.", doTryToGuessUnknownWords: false);
+
+        Assert.Equal("Wir lieben Spitzel.", result.GetText());
+    }
+
+    private static IOcrFixEngine CreateEngine()
+    {
+        IOcrFixEngine engine = new OcrFixEngine(new FakeGermanSpellChecker());
+        engine.Initialize(new Subtitle(), "deu", new SpellCheckDictionaryDisplay());
+        return engine;
+    }
+
+    private sealed class FakeGermanSpellChecker : ISpellChecker
+    {
+        private static readonly HashSet<string> Words = new(StringComparer.Ordinal)
+        {
+            "hängen", "da", "mit", "drin", "ist", "in", "jemand", "du", "wir", "lieben",
+            "Paris", "Spitzel",
+        };
+
+        public bool Initialize(string dictionaryFile, string twoLetterLanguageCode) => true;
+
+        public bool IsWordCorrect(string word)
+        {
+            if (string.IsNullOrWhiteSpace(word))
+            {
+                return true;
+            }
+
+            // Like Hunspell, accept the initial-capitalized form of a lowercase dictionary word.
+            return Words.Contains(word) || Words.Contains(word.ToLowerInvariant());
+        }
+
+        public List<string> GetSuggestions(string word) => new();
+    }
+
+    public void Dispose()
+    {
+        SpellCheckConfig.DictionariesFolder = _originalSpellCheckDictionariesFolder;
+        try
+        {
+            Directory.Delete(_tempDictionariesFolder, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup.
+        }
+    }
+}

--- a/tests/UI/Features/Ocr/FixEngine/SpellCheckRegexTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/SpellCheckRegexTests.cs
@@ -410,6 +410,31 @@ public class SpellCheckRegexTests
     }
 
     [Fact]
+    public void LoadRegExList_DuplicateSections_LoadsRulesFromAllSections()
+    {
+        // The shipped deu/nld/nor lists contain two RegularExpressionsIfSpelledCorrectly
+        // sections; every rule after the first section used to be silently dropped.
+        var doc = new System.Xml.XmlDocument();
+        doc.LoadXml(
+            "<ReplaceList>" +
+            "<RegularExpressionsIfSpelledCorrectly>" +
+            "<RegEx find=\"\\bl([A-Z]+)\\b\" spellCheck=\"I$1\" replaceWith=\"I$1\" />" +
+            "</RegularExpressionsIfSpelledCorrectly>" +
+            "<RegularExpressions />" +
+            "<RegularExpressionsIfSpelledCorrectly>" +
+            "<RegEx find=\"\\b([A-Z][a-z]+)I\\b\" spellCheck=\"$1l\" replaceWith=\"$1l\" />" +
+            "<RegEx find=\"\\bl([a-z]+)\\b\" spellCheck=\"I$1\" replaceWith=\"I$1\" />" +
+            "</RegularExpressionsIfSpelledCorrectly>" +
+            "</ReplaceList>");
+
+        var list = SpellCheckRegex.LoadRegExList(doc, "RegularExpressionsIfSpelledCorrectly");
+
+        Assert.Equal(3, list.Count);
+        Assert.Contains(list, r => r.Find == @"\b([A-Z][a-z]+)I\b");
+        Assert.Contains(list, r => r.Find == @"\bl([a-z]+)\b");
+    }
+
+    [Fact]
     public void Apply_WordNotInDictionary_ShouldNotReplace()
     {
         // Arrange: lXYZ where IXYZ is not in dictionary


### PR DESCRIPTION
Fixes #13658

The reporter's German OCR runs kept producing "SpitzeI" (Spitzel), "lst" (Ist) and "ln" (In) — classic I/l confusion — even though `deu_OCRFixReplaceList.xml` already ships spell-check-gated regexes for exactly these errors.

**Root cause:** the deu/nld/nor lists each contain *two* `<RegularExpressionsIfSpelledCorrectly>` sections, and `SpellCheckRegex.LoadRegExList` used `SelectSingleNode`, so every rule after the first section was silently dropped. For German the entire I/l block (plus genitive, missing-space and ß/ss rules) was dead; the same applied to the large second sections in the Dutch and Norwegian lists.

**Changes**
- `SpellCheckRegex.LoadRegExList` now iterates all sections with the given name (`SelectNodes`), reviving the dead rule blocks in deu/nld/nor.
- German list improvements:
  - leading `l→I` rule relaxed from 2+ to 1+ following lowercase letters, so `ln → In` and `lm → Im` are covered (still gated: only applies when the I-form is a dictionary word and the original is not),
  - new trailing `I→l` rule for all-lowercase words (`einmaI → einmal`),
  - new trailing `II→ll` rule (`voII → voll`, `AII → All`),
  - removed the dead standalone `\bl\b → I` rule — it never loaded (no `spellCheck` attribute), and making it unconditional would corrupt `l` as the German liter abbreviation ("2 l Milch").
- Tests: a loader regression test for duplicate sections, and end-to-end `OcrFixEngine` tests reproducing the three cases from the issue screenshots ("Hängen da SpitzeI mit drin?", "lst da jemand?", "Du? ln Paris?") plus a guard that real l-words ("lieben") are left alone.

All 617 OCR feature tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)