### PR TITLE
OCR: add engine download/update button to llama.cpp settings dialog

### DIFF
--- a/src/ui/Features/Ocr/LlamaCppOcrSettingsViewModel.cs
+++ b/src/ui/Features/Ocr/LlamaCppOcrSettingsViewModel.cs
@@ -20,12 +20,38 @@ public partial class LlamaCppOcrSettingsViewModel : ObservableObject
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }
 
+    private Func<Task>? _redownloadAsync;
+
     [ObservableProperty] private string _url;
     [ObservableProperty] private string _prompt;
     [ObservableProperty] private int _timeoutMinutes;
     [ObservableProperty] private string _engineLabel = string.Empty;
     [ObservableProperty] private IBrush _engineBrush = Brushes.Gray;
-    [ObservableProperty] private bool _isEngineInstalled;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(DownloadButtonLabel))]
+    private bool _isEngineInstalled;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(DownloadButtonLabel))]
+    private DownloadHashManager.UpdateStatus _engineUpdateStatus;
+
+    // "Download" when not installed, "Update" when a newer engine release is available,
+    // otherwise "Re-download".
+    public string DownloadButtonLabel
+    {
+        get
+        {
+            if (!IsEngineInstalled)
+            {
+                return Se.Language.General.Download;
+            }
+
+            return EngineUpdateStatus == DownloadHashManager.UpdateStatus.UpdateAvailable
+                ? Se.Language.General.Update
+                : Se.Language.General.Redownload;
+        }
+    }
 
     public LlamaCppOcrSettingsViewModel()
     {
@@ -34,8 +60,14 @@ public partial class LlamaCppOcrSettingsViewModel : ObservableObject
         _timeoutMinutes = Math.Max(1, Se.Settings.Ocr.LlamaCppOcrTimeoutMinutes);
     }
 
-    public void Initialize()
+    /// <summary>
+    /// <paramref name="redownloadAsync"/> is supplied by the caller so the download runs through the
+    /// same flow the caller already owns (stopping the server first, refreshing its model list and
+    /// status dots afterwards) instead of this dialog duplicating it.
+    /// </summary>
+    public void Initialize(Func<Task> redownloadAsync)
     {
+        _redownloadAsync = redownloadAsync;
         Refresh();
     }
 
@@ -44,12 +76,14 @@ public partial class LlamaCppOcrSettingsViewModel : ObservableObject
         IsEngineInstalled = LlamaCppServerManager.IsEngineInstalled();
         if (!IsEngineInstalled)
         {
+            EngineUpdateStatus = DownloadHashManager.UpdateStatus.Unknown;
             EngineLabel = Se.Language.General.NotInstalled;
             EngineBrush = new SolidColorBrush(Color.FromRgb(0xF4, 0x43, 0x36)); // red
             return;
         }
 
-        switch (LlamaCppUpdateStatus.GetEngineUpdateStatus())
+        EngineUpdateStatus = LlamaCppUpdateStatus.GetEngineUpdateStatus();
+        switch (EngineUpdateStatus)
         {
             case DownloadHashManager.UpdateStatus.UpToDate:
                 EngineLabel = Se.Language.General.UpToDate;
@@ -64,6 +98,18 @@ public partial class LlamaCppOcrSettingsViewModel : ObservableObject
                 EngineBrush = new SolidColorBrush(Color.FromRgb(0x9E, 0x9E, 0x9E)); // grey
                 break;
         }
+    }
+
+    [RelayCommand]
+    private async Task Redownload()
+    {
+        if (_redownloadAsync == null)
+        {
+            return;
+        }
+
+        await _redownloadAsync();
+        Refresh();
     }
 
     [RelayCommand]

--- a/src/ui/Features/Ocr/LlamaCppOcrSettingsWindow.cs
+++ b/src/ui/Features/Ocr/LlamaCppOcrSettingsWindow.cs
@@ -107,9 +107,23 @@ public class LlamaCppOcrSettingsWindow : Window
             BorderBrush = new SolidColorBrush(Color.FromArgb(0x40, 0x80, 0x80, 0x80)),
         };
 
+        var buttonRedownload = UiUtil.MakeButton(string.Empty, vm.RedownloadCommand)
+            .WithIconLeftBindText(IconNames.Download, nameof(vm.DownloadButtonLabel));
+        buttonRedownload.VerticalAlignment = VerticalAlignment.Center;
+
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
-        var buttonBar = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+        var buttonBar = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = GridLength.Auto },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = GridLength.Auto },
+            },
+        };
+        buttonBar.Add(buttonRedownload, 0, 0);
+        buttonBar.Add(UiUtil.MakeButtonBar(buttonOk, buttonCancel), 0, 2);
 
         var rootGrid = new Grid
         {

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -1337,11 +1337,48 @@ public partial class OcrViewModel : ObservableObject
             return;
         }
 
-        var result = await _windowService.ShowDialogAsync<LlamaCppOcrSettingsWindow, LlamaCppOcrSettingsViewModel>(Window, vm => vm.Initialize());
+        var result = await _windowService.ShowDialogAsync<LlamaCppOcrSettingsWindow, LlamaCppOcrSettingsViewModel>(Window, vm => vm.Initialize(UpdateLlamaCppOcrEngineAsync));
         if (result.OkPressed)
         {
             LlamaCppUrl = Se.Settings.Ocr.LlamaCppUrl;
         }
+
+        RefreshLlamaCppOcrDots();
+    }
+
+    /// <summary>
+    /// Stops the running llama-server (it holds the binary open and would keep serving a stale build),
+    /// re-downloads the matching llama.cpp build, and refreshes the model list and status indicators.
+    /// Wired to the download button in the llama.cpp OCR settings dialog - the only way to update an
+    /// installed engine from the OCR window, since the model download button never re-fetches the engine.
+    /// </summary>
+    private async Task UpdateLlamaCppOcrEngineAsync()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        LlamaCppServerManager.StopServer();
+        UpdateLlamaCppOcrServerButtonText();
+
+        // Re-download the same backend that is installed (CPU/Vulkan/CUDA all unpack into one
+        // folder); when nothing is installed yet, DownloadAsync falls back to asking the user.
+        var folder = LlamaCppServerManager.GetAndCreateFolder();
+        var variant = LlamaCppServerManager.IsEngineInstalled() && OperatingSystem.IsWindows()
+            ? DownloadHashManager.DetectLlamaCppWindowsVariant(folder)
+            : null;
+
+        var model = SelectedLlamaCppOcrModel?.Model;
+        var downloaded = await LlamaCppDownloadHelper.DownloadAsync(Window, _windowService, model, variant, forceEngineDownload: true);
+        if (downloaded != null)
+        {
+            var selectName = string.IsNullOrEmpty(downloaded) ? model?.FileName : downloaded;
+            SelectedLlamaCppOcrModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppOcrModels, LlamaCppServerManager.OcrModels, selectName);
+        }
+
+        RefreshLlamaCppOcrDots();
+        UpdateLlamaCppOcrServerButtonText();
     }
 
     private void UpdateLlamaCppOcrServerButtonText()


### PR DESCRIPTION
Follow-up to #13656 (see [this comment](https://github.com/SubtitleEdit/subtitleedit/issues/13656#issuecomment-5301727400)): the reporter had an outdated llama.cpp engine flagged in the OCR window but "couldn't upgrade".

The llama.cpp OCR settings dialog showed the amber "Update available" status dot but offered no way to act on it — and the OCR window's download button only fetches models (it never forces an engine re-download), so an installed-but-outdated llama-server could not be updated from the OCR feature at all.

This mirrors the auto-translate engine settings dialog:

- The settings dialog now has a **Download / Update / Re-download** button (label follows install/update state) next to OK/Cancel.
- It routes through `OcrViewModel.UpdateLlamaCppOcrEngineAsync`, which stops the running llama-server first (it holds the binary open), forces the engine download, and refreshes the model list, status dots, and start/stop server button afterwards.
- On Windows, the installed backend variant (CPU/Vulkan/CUDA) is detected from the install folder so the update fetches the same build instead of prompting again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)