### PR TITLE
Auto-break: build split candidates over ReadOnlyMemory instead of substrings

### DIFF
--- a/src/libse/Common/MemoryCharExtensions.cs
+++ b/src/libse/Common/MemoryCharExtensions.cs
@@ -1,0 +1,27 @@
+#if NETSTANDARD2_1
+using System;
+
+namespace Nikse.SubtitleEdit.Core.Common
+{
+    /// <summary>
+    /// The ReadOnlyMemory&lt;char&gt;-receiver Trim overloads exist on .NET Core 3.0+
+    /// but are missing from the .NET Standard 2.1 reference assemblies - polyfill them
+    /// on top of the span-receiver overloads, which are available.
+    /// </summary>
+    internal static class MemoryCharExtensions
+    {
+        public static ReadOnlyMemory<char> Trim(this ReadOnlyMemory<char> memory)
+        {
+            var span = memory.Span;
+            var start = span.Length - span.TrimStart().Length;
+            return memory.Slice(start, span.Trim().Length);
+        }
+
+        public static ReadOnlyMemory<char> TrimStart(this ReadOnlyMemory<char> memory, ReadOnlySpan<char> trimChars)
+            => memory.Slice(memory.Length - memory.Span.TrimStart(trimChars).Length);
+
+        public static ReadOnlyMemory<char> TrimEnd(this ReadOnlyMemory<char> memory, ReadOnlySpan<char> trimChars)
+            => memory.Slice(0, memory.Span.TrimEnd(trimChars).Length);
+    }
+}
+#endif

--- a/src/libse/Common/TextSplit.cs
+++ b/src/libse/Common/TextSplit.cs
@@ -12,6 +12,7 @@ namespace Nikse.SubtitleEdit.Core.Common
         private const string EndLineChars = ".!?…؟。？！";
         private const string Commas = ",،，、";
         private static readonly char[] PeriodQuestionExclamation = { '.', '?', '!' };
+        private static readonly char[] QuoteChars = { '"', '\'' };
 
         public TextSplit(string text, int singleLineMaxLength, string language)
         {
@@ -24,12 +25,12 @@ namespace Nikse.SubtitleEdit.Core.Common
             {
                 if (text[i] == ' ')
                 {
-                    var l1 = text.Substring(0, i).Trim();
-                    var l2 = text.Substring(i + 1).Trim();
+                    var l1 = text.AsMemory(0, i).Trim();
+                    var l2 = text.AsMemory(i + 1).Trim();
 
                     // One result shared by both lists. _splits is a subset of _allSplits, so
                     // building a second identical instance measured the same two lines twice.
-                    var split = new TextSplitResult(new List<string> { l1, l2 });
+                    var split = new TextSplitResult(new List<ReadOnlyMemory<char>> { l1, l2 });
                     _allSplits.Add(split);
                     if (Utilities.CanBreak(text, i, language))
                     {
@@ -38,9 +39,9 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
                 else if ((language == "zh" || language == "ja" || language == "ko") && "，。？、?".Contains(text[i]))
                 {
-                    var l1 = text.Substring(0, i + 1).Trim();
-                    var l2 = text.Substring(i + 1).Trim();
-                    var split = new TextSplitResult(new List<string> { l1, l2 });
+                    var l1 = text.AsMemory(0, i + 1).Trim();
+                    var l2 = text.AsMemory(i + 1).Trim();
+                    var split = new TextSplitResult(new List<ReadOnlyMemory<char>> { l1, l2 });
                     _allSplits.Add(split);
                     _splits.Add(split);
                 }
@@ -148,16 +149,16 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         private static bool EndsWith(TextSplitResult textSplitResult, string chars)
         {
-            var line1 = textSplitResult.Lines[0].TrimEnd('"', '\'');
-            return line1.Length > 0 && chars.Contains(line1[line1.Length - 1]);
+            var line1 = textSplitResult.Lines[0].TrimEnd(QuoteChars).Span;
+            return line1.Length > 0 && chars.Contains(line1[^1]);
         }
 
         private static bool IsDialog(TextSplitResult textSplitResult)
         {
-            var line1 = textSplitResult.Lines[0].TrimEnd('"', '\'');
-            var line2 = textSplitResult.Lines[1].TrimStart('"', '\'');
+            var line1 = textSplitResult.Lines[0].TrimEnd(QuoteChars).Span;
+            var line2 = textSplitResult.Lines[1].TrimStart(QuoteChars).Span;
             return line2.Length > 0 && line1.Length > 0 &&
-                   line2.StartsWith('-') && EndLineChars.Contains(line1[line1.Length - 1]);
+                   line2[0] == '-' && EndLineChars.Contains(line1[^1]);
         }
 
         public static List<string> SplitMulti(string input, int numberOfParts, string language)

--- a/src/libse/Common/TextSplitResult.cs
+++ b/src/libse/Common/TextSplitResult.cs
@@ -6,7 +6,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 {
     public class TextSplitResult
     {
-        public List<string> Lines { get; set; }
+        public List<ReadOnlyMemory<char>> Lines { get; set; }
 
         /// <summary>
         /// Per-line pixel widths. Measured on first read - see <see cref="EnsurePixelsMeasured"/>.
@@ -34,7 +34,7 @@ namespace Nikse.SubtitleEdit.Core.Common
         // These run inside the per-candidate sort keys of TextSplit (one candidate per space in
         // the line), where the LINQ Sum overloads allocated a closure and a boxed enumerator
         // per call - for lists that always hold two elements.
-        private static double SumLengths(List<string> lines)
+        private static double SumLengths(List<ReadOnlyMemory<char>> lines)
         {
             double total = 0;
             for (var i = 0; i < lines.Count; i++)
@@ -91,7 +91,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             }
         }
 
-        public static float GetWidth(string text)
+        public static float GetWidth(ReadOnlyMemory<char> text)
         {
             if (text.Length > 128 || !_fontInitialized)
             {
@@ -100,7 +100,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 
             try
             {
-                return _font.MeasureText(text, _paint);
+                return _font.MeasureText(text.Span, _paint);
             }
             catch
             {
@@ -108,7 +108,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             }
         }
 
-        public TextSplitResult(List<string> lines)
+        public TextSplitResult(List<ReadOnlyMemory<char>> lines)
         {
             Lines = lines;
 
@@ -146,7 +146,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 
             if (Math.Abs(SpaceLengthPixels) < 0.01)
             {
-                SpaceLengthPixels = GetWidth(" ");
+                SpaceLengthPixels = GetWidth(" ".AsMemory());
             }
         }
 
@@ -160,7 +160,7 @@ namespace Nikse.SubtitleEdit.Core.Common
         // the process. And because nothing was added to the list, LengthPixels came back with
         // fewer than two entries, which IsBottomHeavy and DiffFromAveragePixelBottomHeavy index
         // directly.
-        private static float EstimateOrMeasure(string line)
+        private static float EstimateOrMeasure(ReadOnlyMemory<char> line)
             => line.Length > 1000 ? line.Length * 7 : GetWidth(line);
 
         public bool IsLineLengthOkay(int singleLineMaxLength)

--- a/tests/libse/Core/TextSplitLazyPixelTests.cs
+++ b/tests/libse/Core/TextSplitLazyPixelTests.cs
@@ -18,7 +18,7 @@ public class TextSplitLazyPixelTests : IDisposable
     }
 
     private static TextSplitResult Make(string line1, string line2)
-        => new TextSplitResult(new List<string> { line1, line2 });
+        => new TextSplitResult(new List<ReadOnlyMemory<char>> { line1.AsMemory(), line2.AsMemory() });
 
     [Fact]
     public void LengthPixels_IsMeasuredOnFirstRead()


### PR DESCRIPTION
## Summary
- `TextSplit` builds one split candidate per space in the line, taking two trimmed substrings each. The candidate lines now stay `ReadOnlyMemory<char>` slices of the input string, and Skia measures them through its `ReadOnlySpan<char>` overload of `SKFont.MeasureText`, so no per-candidate strings are allocated until the winning split is joined.
- The `ReadOnlyMemory<char>`-receiver `Trim`/`TrimStart`/`TrimEnd` extension overloads are missing from the .NET Standard 2.1 reference assemblies, so `MemoryCharExtensions` polyfills them behind `#if NETSTANDARD2_1` on top of the span-receiver overloads; the net10.0 build keeps using the BCL ones.

## Benchmarks
`TextSplitBenchmarks`, BenchmarkDotNet default job, i7-13700, .NET 10.0.10:

| Benchmark | Mean before | Mean after | Alloc before | Alloc after | Δ alloc |
|---|---|---|---|---|---|
| AutoBreak_Short (control, no TextSplit) | 48.7 ns | 54.2 ns | 0 B | 0 B | — |
| AutoBreak_Medium | 6.70 µs | 7.01 µs | 10,992 B | 7,208 B | **−34%** |
| AutoBreak_Long | 5.46 µs | 4.98 µs | 27,736 B | 13,496 B | **−51%** |
| AutoBreak_Dialog | 4.12 µs | 4.60 µs | 11,296 B | 7,272 B | **−36%** |
| BuildSplitsOnly | 3.33 µs | 2.88 µs | 22,880 B | 10,448 B | **−54%** |

Candidate construction (`BuildSplitsOnly`) is ~13% faster with non-overlapping confidence intervals, and Gen1 promotions on the long line drop from 0.122 to 0.008 per 1k operations. The apparent timing shifts on Medium/Dialog are within run-to-run noise: the control row never reaches `TextSplit` yet moved +11% between runs, which is the machine's drift floor.

## Test plan
- [ ] `dotnet build src/libse/LibSE.csproj` succeeds for both `netstandard2.1` and `net10.0` targets
- [ ] `dotnet test tests/libse/LibSETests.csproj --filter "FullyQualifiedName~TextSplit"` passes (pins measured pixel values, list shape past the measuring cutoff, and resulting line breaks)
- [ ] `dotnet test tests/libse/LibSETests.csproj --filter "FullyQualifiedName~AutoBreak"` passes (end-to-end line breaking through `Utilities.AutoBreakLine`)
- [ ] In the app, auto-break a long line (Edit > Auto-balance lines) and a dialog line — resulting breaks are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)