### PR TITLE
Translate: add MiLMMT-46 models to the llama.cpp engine

### DIFF
--- a/src/libuilogic/AutoTranslate/LlamaCppTranslate.cs
+++ b/src/libuilogic/AutoTranslate/LlamaCppTranslate.cs
@@ -51,28 +51,42 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
 
         public async Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
         {
-            string prompt;
-            var modelPrompt = Configuration.Settings.Tools.LlamaCppModelPrompt;
-            if (!string.IsNullOrWhiteSpace(modelPrompt))
-            {
-                // A curated model with its own trained-in prompt (e.g. Hy-MT2). The "codes" this
-                // engine receives are already English language names - ListLanguages() puts the
-                // name in TranslationPair.Code - which is exactly what these templates expect.
-                prompt = string.Format(modelPrompt, sourceLanguageCode, targetLanguageCode);
-            }
-            else
+            var template = Configuration.Settings.Tools.LlamaCppModelPrompt;
+            if (string.IsNullOrWhiteSpace(template))
             {
                 if (string.IsNullOrWhiteSpace(Configuration.Settings.Tools.LlamaCppPrompt))
                 {
                     Configuration.Settings.Tools.LlamaCppPrompt = new ToolsSettings().LlamaCppPrompt;
                 }
-                prompt = string.Format(Configuration.Settings.Tools.LlamaCppPrompt, sourceLanguageCode, targetLanguageCode);
+
+                template = Configuration.Settings.Tools.LlamaCppPrompt;
+            }
+
+            // Placeholders are replaced (not string.Format'ed) so braces in a user-edited prompt
+            // cannot throw. The "codes" this engine receives are already English language names -
+            // ListLanguages() puts the name in TranslationPair.Code - which is what the templates
+            // expect.
+            string encodedUserMessage;
+            if (template.Contains("{2}"))
+            {
+                // Completion-format models (MiLMMT-46): the trained prompt with the text embedded
+                // must reach the model verbatim, real newlines included - under the "<br />"
+                // placeholder encoding the model still translates but starts mirroring placeholder
+                // fragments into its output.
+                encodedUserMessage = Json.EncodeJsonText(BuildCompletionPrompt(template, sourceLanguageCode, targetLanguageCode, text), "\\n");
+            }
+            else
+            {
+                // Historical chat wire format: prompt, a real blank line, then the text - with
+                // line breaks inside either encoded as the "<br />" placeholder (decoded back below).
+                var prompt = template.Replace("{0}", sourceLanguageCode).Replace("{1}", targetLanguageCode);
+                encodedUserMessage = Json.EncodeJsonText(prompt) + "\\n\\n" + Json.EncodeJsonText(text.Trim());
             }
 
             // No "model" field: llama-server serves the single model it was started with, and for a
             // remote server the user's own llama-server does the same. Sending one would only risk a
             // mismatch with whatever that server has loaded.
-            var input = "{ \"messages\": [{ \"role\": \"user\", \"content\": \"" + Json.EncodeJsonText(prompt) + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]" + MakeSamplingJson() + "}";
+            var input = "{ \"messages\": [{ \"role\": \"user\", \"content\": \"" + encodedUserMessage + "\" }]" + MakeSamplingJson() + "}";
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
             var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);
@@ -104,6 +118,21 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             outputText = ChatGptTranslate.RemovePreamble(text, outputText);
             outputText = ChatGptTranslate.DecodeUnicodeEscapes(outputText);
             return outputText.Trim();
+        }
+
+        /// <summary>
+        /// Fills a completion-format prompt template: {0} = source language English name, {1} =
+        /// target language English name, {2} = the text to translate. Models like MiLMMT-46 are
+        /// trained with the text inside the prompt and a trailing target-language cue after it.
+        /// The text is substituted last so braces in subtitle text (ASSA override tags) can never
+        /// hit a placeholder.
+        /// </summary>
+        public static string BuildCompletionPrompt(string template, string sourceLanguageCode, string targetLanguageCode, string text)
+        {
+            return template
+                .Replace("{0}", sourceLanguageCode)
+                .Replace("{1}", targetLanguageCode)
+                .Replace("{2}", text.Trim());
         }
 
         /// <summary>

--- a/src/libuilogic/LlamaCpp/LlamaCppServerManager.cs
+++ b/src/libuilogic/LlamaCpp/LlamaCppServerManager.cs
@@ -24,14 +24,21 @@ public sealed record LlamaCppModel(
     string? ChatTemplate = null,
     bool NoJinja = false,
     // Translation prompt this model was trained on ({0} = source language English name,
-    // {1} = target language English name); null = the user's generic llama.cpp prompt.
-    // Needed for Hy-MT2, which answers in Chinese when given the generic prompt.
+    // {1} = target language English name, optional {2} = the text to translate); null = the
+    // user's generic llama.cpp prompt. Needed for Hy-MT2, which answers in Chinese when given
+    // the generic prompt, and for MiLMMT-46, whose completion format embeds the text between
+    // a "{0}: " prefix and a trailing "{1}:" cue.
     string? PromptTemplate = null,
     // Model-recommended sampling; -1 = leave the server default.
     double Temperature = -1,
     double TopP = -1,
     int TopK = -1,
-    double RepeatPenalty = -1);
+    double RepeatPenalty = -1,
+    // Raw-completion translation model with no instruction training (MiLMMT-46): it can only
+    // continue its trained PromptTemplate. Excluded from the advanced engine's model list -
+    // its JSON batch protocol gets back well-formed JSON whose values are the untranslated
+    // source lines, which would be written to the grid as a "successful" batch.
+    bool CompletionOnly = false);
 
 /// <summary>
 /// Manages the local <c>llama-server</c> process used by the llama.cpp auto-translate and OCR
@@ -47,6 +54,14 @@ public static class LlamaCppServerManager
     // the other LLM engines.
     private const string HyMt2PromptTemplate =
         "Translate the following text into {1}. Keep line breaks exactly the same. Note that you should only output the translated result without any additional explanation:";
+
+    // MiLMMT-46's trained raw-completion format (with language English names). The text sits
+    // inside the template ({2}) and the trailing "{1}:" cue is mandatory - without it the model
+    // does not switch language and just echo-loops the source. Its GGUF chat template is a pure
+    // passthrough ("{{ message.content }}", no role markers), so the chat endpoint delivers
+    // this verbatim and no ChatTemplate/NoJinja override is wanted.
+    private const string MiLmMt46PromptTemplate =
+        "Translate this from {0} to {1}:\n{0}: {2}\n{1}:";
 
     public static readonly IReadOnlyList<LlamaCppModel> TranslateModels = new[]
     {
@@ -65,6 +80,23 @@ public static class LlamaCppServerManager
         new LlamaCppModel("TranslateGemma 12B (Q5_K_M)", "translategemma-12b-it-q5_k_m.gguf", "8.5 GB",
             "https://huggingface.co/NikolayKozloff/translategemma-12b-it-Q5_K_M-GGUF/resolve/main/translategemma-12b-it-q5_k_m.gguf",
             ChatTemplate: "gemma", NoJinja: true),
+
+        // MiLMMT-46 v1.0 (Xiaomi, 2026) - Gemma3-based translation-specialized models, 46
+        // languages including Danish/Norwegian/Swedish (the gap in Hy-MT2's coverage); the paper
+        // reports it ahead of TranslateGemma and Hy-MT 1.5. Temperature 0 matches the model
+        // card's greedy-decoding usage. CompletionOnly: see the record field - regular engine only.
+        new LlamaCppModel("MiLMMT-46 4B (Q4_K_M) - 46 languages incl. Nordic", "MiLMMT-46-4B-v1.0.Q4_K_M.gguf", "2.5 GB",
+            "https://huggingface.co/mradermacher/MiLMMT-46-4B-v1.0-GGUF/resolve/main/MiLMMT-46-4B-v1.0.Q4_K_M.gguf",
+            PromptTemplate: MiLmMt46PromptTemplate, Temperature: 0, CompletionOnly: true),
+        new LlamaCppModel("MiLMMT-46 4B (Q8_0) - 46 languages incl. Nordic", "MiLMMT-46-4B-v1.0.Q8_0.gguf", "4.1 GB",
+            "https://huggingface.co/mradermacher/MiLMMT-46-4B-v1.0-GGUF/resolve/main/MiLMMT-46-4B-v1.0.Q8_0.gguf",
+            PromptTemplate: MiLmMt46PromptTemplate, Temperature: 0, CompletionOnly: true),
+        new LlamaCppModel("MiLMMT-46 12B (Q4_K_M) - 46 languages incl. Nordic", "MiLMMT-46-12B-v1.0.Q4_K_M.gguf", "7.3 GB",
+            "https://huggingface.co/mradermacher/MiLMMT-46-12B-v1.0-GGUF/resolve/main/MiLMMT-46-12B-v1.0.Q4_K_M.gguf",
+            PromptTemplate: MiLmMt46PromptTemplate, Temperature: 0, CompletionOnly: true),
+        new LlamaCppModel("MiLMMT-46 12B (Q5_K_M) - 46 languages incl. Nordic", "MiLMMT-46-12B-v1.0.Q5_K_M.gguf", "8.4 GB",
+            "https://huggingface.co/mradermacher/MiLMMT-46-12B-v1.0-GGUF/resolve/main/MiLMMT-46-12B-v1.0.Q5_K_M.gguf",
+            PromptTemplate: MiLmMt46PromptTemplate, Temperature: 0, CompletionOnly: true),
 
         // Gemma 4 (Google, 2026) - 140+ languages, the strongest general model here for translation
         // into non-English targets. NOTE: unlike Gemma 2/3 this must use its own embedded Jinja
@@ -362,6 +394,44 @@ public static class LlamaCppServerManager
     }
 
     /// <summary>
+    /// Builds the <see cref="LlamaCppModel"/> for a non-curated <c>*.gguf</c> (dropped into the
+    /// models folder, or passed to seconv by path), inferring the same per-family settings the
+    /// curated entries carry: chat-template flags via <see cref="InferChatTemplate"/>, and for
+    /// MiLMMT quants the trained completion prompt, greedy sampling and the regular-engine-only
+    /// restriction - a self-supplied MiLMMT quant echo-loops the source under any other prompt.
+    /// <paramref name="fileNameOrPath"/> may be a bare file name or a full path (seconv).
+    /// </summary>
+    public static LlamaCppModel CreateCustomModel(string displayName, string fileNameOrPath, string size)
+    {
+        var name = Path.GetFileName(fileNameOrPath);
+        var (chatTemplate, noJinja) = InferChatTemplate(name);
+        var isMiLmMt = name.Contains("milmmt", StringComparison.OrdinalIgnoreCase);
+        return new LlamaCppModel(displayName, fileNameOrPath, size, Url: string.Empty,
+            ChatTemplate: chatTemplate, NoJinja: noJinja,
+            PromptTemplate: isMiLmMt ? MiLmMt46PromptTemplate : null,
+            Temperature: isMiLmMt ? 0 : -1,
+            CompletionOnly: isMiLmMt);
+    }
+
+    /// <summary>
+    /// Points the regular llama.cpp translate engine's per-model settings (trained-in prompt and
+    /// recommended sampling) at the given curated/custom model, or resets them for null (remote
+    /// server / unknown model). Must be called wherever a local translate run picks its model
+    /// (Auto-translate window, batch convert, seconv) - the values persist in settings, so a
+    /// stale prompt from a previously used model would otherwise leak into the next run, and for
+    /// completion-only models (MiLMMT-46) the wrong prompt does not just degrade output, it makes
+    /// the model echo the untranslated source.
+    /// </summary>
+    public static void ApplyTranslatePromptSettings(LlamaCppModel? model)
+    {
+        Configuration.Settings.Tools.LlamaCppModelPrompt = model?.PromptTemplate ?? string.Empty;
+        Configuration.Settings.Tools.LlamaCppModelTemperature = model?.Temperature ?? -1;
+        Configuration.Settings.Tools.LlamaCppModelTopP = model?.TopP ?? -1;
+        Configuration.Settings.Tools.LlamaCppModelTopK = model?.TopK ?? -1;
+        Configuration.Settings.Tools.LlamaCppModelRepeatPenalty = model?.RepeatPenalty ?? -1;
+    }
+
+    /// <summary>
     /// Returns the curated <see cref="TranslateModels"/> plus any other <c>*.gguf</c> the user has
     /// dropped into the llama.cpp models folder. Custom entries are emitted with an empty <c>Url</c>
     /// (no download needed - already on disk), the file name as <c>DisplayName</c>, a
@@ -415,9 +485,7 @@ public static class LlamaCppServerManager
                 }
 
                 var size = FormatFileSize(new FileInfo(path).Length);
-                var (chatTemplate, noJinja) = InferChatTemplate(name);
-                custom.Add(new LlamaCppModel(name, name, size, Url: string.Empty,
-                    ChatTemplate: chatTemplate, NoJinja: noJinja));
+                custom.Add(CreateCustomModel(name, name, size));
             }
         }
         catch

--- a/src/seconv/Core/AutoTranslateRunner.cs
+++ b/src/seconv/Core/AutoTranslateRunner.cs
@@ -123,14 +123,21 @@ internal sealed class AutoTranslateRunner
     /// </summary>
     public async Task TranslateAsync(Subtitle subtitle, CancellationToken cancellationToken)
     {
-        if (_llamaCppModel != null && !LlamaCppServerManager.IsServerRunning)
+        if (_llamaCppModel != null)
         {
-            if (!_options.Quiet)
-            {
-                Console.WriteLine($"  Starting llama-server with model {Path.GetFileName(_llamaCppModel.FileName)} (stops at exit)...");
-            }
+            // The engine reads the per-model prompt/sampling (e.g. Hy-MT2's or MiLMMT-46's
+            // trained-in prompt) from settings, which nothing in a console run sets otherwise.
+            LlamaCppServerManager.ApplyTranslatePromptSettings(_llamaCppModel);
 
-            await LlamaCppServerManager.EnsureServerRunningAsync(_llamaCppModel, cancellationToken);
+            if (!LlamaCppServerManager.IsServerRunning)
+            {
+                if (!_options.Quiet)
+                {
+                    Console.WriteLine($"  Starting llama-server with model {Path.GetFileName(_llamaCppModel.FileName)} (stops at exit)...");
+                }
+
+                await LlamaCppServerManager.EnsureServerRunningAsync(_llamaCppModel, cancellationToken);
+            }
         }
 
         var sourceCode = _options.TranslateFrom;
@@ -220,9 +227,7 @@ internal sealed class AutoTranslateRunner
                 }
 
                 var fileName = Path.GetFileName(name);
-                var (chatTemplate, noJinja) = LlamaCppServerManager.InferChatTemplate(fileName);
-                return new LlamaCppModel(fileName, Path.GetFullPath(name), string.Empty, Url: string.Empty,
-                    ChatTemplate: chatTemplate, NoJinja: noJinja);
+                return LlamaCppServerManager.CreateCustomModel(fileName, Path.GetFullPath(name), string.Empty);
             }
 
             // Name: match curated + custom models in the models folder (with or without .gguf).

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -1350,6 +1350,11 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
             return true;
         }
 
+        // The engine reads the per-model prompt/sampling from settings; re-point them at the model
+        // picked here, since the last value persisted by the Auto-translate window may belong to a
+        // different model (completion-only models echo untranslated text under the wrong prompt).
+        LlamaCppServerManager.ApplyTranslatePromptSettings(model);
+
         // Auto-download the llama-server binary + model if missing (prompts).
         if (!await LlamaCppDownloadHelper.EnsureReadyAsync(Window, _windowService, model.FileName))
         {

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -390,11 +390,7 @@ public partial class AutoTranslateViewModel : ObservableObject
             // unknown and a custom .gguf carries no template, so both fall back to the generic
             // prompt and server-default sampling.
             var curatedModel = LlamaCppUseRemoteServer ? null : SelectedLlamaCppModel?.Model;
-            Configuration.Settings.Tools.LlamaCppModelPrompt = curatedModel?.PromptTemplate ?? string.Empty;
-            Configuration.Settings.Tools.LlamaCppModelTemperature = curatedModel?.Temperature ?? -1;
-            Configuration.Settings.Tools.LlamaCppModelTopP = curatedModel?.TopP ?? -1;
-            Configuration.Settings.Tools.LlamaCppModelTopK = curatedModel?.TopK ?? -1;
-            Configuration.Settings.Tools.LlamaCppModelRepeatPenalty = curatedModel?.RepeatPenalty ?? -1;
+            LlamaCppServerManager.ApplyTranslatePromptSettings(curatedModel);
         }
 
         if (engineType == typeof(OllamaTranslate))
@@ -994,10 +990,24 @@ public partial class AutoTranslateViewModel : ObservableObject
         if (downloaded != null)
         {
             var selectName = string.IsNullOrEmpty(downloaded) ? model?.FileName : downloaded;
-            SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, LlamaCppServerManager.GetAllTranslateModels(), selectName);
+            SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, GetLlamaCppModelsForEngine(), selectName);
         }
 
         RefreshDownloadDots?.Invoke();
+    }
+
+    /// <summary>
+    /// The llama.cpp model list for the currently selected engine: everything for the regular
+    /// engine, but no completion-only models (MiLMMT-46) for the advanced engine - they cannot
+    /// follow its JSON batch protocol and reply with well-formed JSON holding the untranslated
+    /// source lines, which would land in the grid as a "successful" batch.
+    /// </summary>
+    private IReadOnlyList<LlamaCppModel> GetLlamaCppModelsForEngine()
+    {
+        var models = LlamaCppServerManager.GetAllTranslateModels();
+        return SelectedAutoTranslator is LlamaCppAdvancedTranslate
+            ? models.Where(m => !m.CompletionOnly).ToList()
+            : models;
     }
 
     /// <summary>
@@ -1105,7 +1115,7 @@ public partial class AutoTranslateViewModel : ObservableObject
             return false;
         }
 
-        SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, LlamaCppServerManager.GetAllTranslateModels(), model.FileName);
+        SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, GetLlamaCppModelsForEngine(), model.FileName);
         RefreshDownloadDots?.Invoke();
 
         try
@@ -1212,7 +1222,7 @@ public partial class AutoTranslateViewModel : ObservableObject
         if (downloaded != null)
         {
             var selectName = string.IsNullOrEmpty(downloaded) ? model?.FileName : downloaded;
-            SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, LlamaCppServerManager.GetAllTranslateModels(), selectName);
+            SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, GetLlamaCppModelsForEngine(), selectName);
         }
 
         RefreshDownloadDots?.Invoke();
@@ -2053,7 +2063,7 @@ public partial class AutoTranslateViewModel : ObservableObject
             LlamaCppModelComboIsVisible = true;
             LlamaCppButtonsAreVisible = true;
             var savedModelName = Path.GetFileName(Se.Settings.AutoTranslate.LlamaCppModel ?? string.Empty);
-            SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, LlamaCppServerManager.GetAllTranslateModels(), savedModelName);
+            SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, GetLlamaCppModelsForEngine(), savedModelName);
             UpdateLlamaCppServerButtonText();
             RefreshEngineUpdateButton();
 

--- a/tests/libuilogic/AutoTranslate/LlamaCppTranslateTests.cs
+++ b/tests/libuilogic/AutoTranslate/LlamaCppTranslateTests.cs
@@ -1,0 +1,100 @@
+using Nikse.SubtitleEdit.UiLogic.AutoTranslate;
+using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
+using System.Linq;
+
+namespace LibUiLogicTests.AutoTranslate;
+
+public class LlamaCppTranslateTests
+{
+    // MiLMMT-46's completion format: the text sits inside the template and the trailing
+    // "Danish:" cue is what makes the model translate at all - appended-text prompts make it
+    // echo-loop the source instead.
+    [Fact]
+    public void BuildCompletionPrompt_EmbedsTextInsideTemplate()
+    {
+        var result = LlamaCppTranslate.BuildCompletionPrompt(
+            "Translate this from {0} to {1}:\n{0}: {2}\n{1}:", "English", "Danish",
+            "We've lost the signal.\nCheck the antenna on the roof.");
+
+        Assert.Equal(
+            "Translate this from English to Danish:\nEnglish: We've lost the signal.\nCheck the antenna on the roof.\nDanish:",
+            result);
+    }
+
+    // The text is substituted last, so brace sequences in subtitle text (ASSA override tags)
+    // must survive as-is and can never be treated as a placeholder.
+    [Fact]
+    public void BuildCompletionPrompt_TextWithBraces_IsNotReSubstituted()
+    {
+        var result = LlamaCppTranslate.BuildCompletionPrompt(
+            "Translate this from {0} to {1}:\n{0}: {2}\n{1}:", "English", "Danish",
+            @"{\an8}Look {0} up there.");
+
+        Assert.Equal(
+            "Translate this from English to Danish:\nEnglish: {\\an8}Look {0} up there.\nDanish:",
+            result);
+    }
+
+    [Fact]
+    public void TranslateModels_MiLmMtEntries_AreCompletionOnlyWithEmbeddedTextTemplate()
+    {
+        var models = LlamaCppServerManager.TranslateModels
+            .Where(m => m.FileName.Contains("MiLMMT", System.StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        Assert.NotEmpty(models);
+        foreach (var model in models)
+        {
+            Assert.True(model.CompletionOnly);
+            Assert.NotNull(model.PromptTemplate);
+            Assert.Contains("{2}", model.PromptTemplate);
+            // The GGUF's embedded chat template is a pure passthrough, which is exactly what the
+            // raw-completion format needs - a forced template (e.g. "gemma") would wrap the
+            // prompt in turn tokens the model was never trained on.
+            Assert.Null(model.ChatTemplate);
+            Assert.False(model.NoJinja);
+            Assert.Equal(0, model.Temperature);
+        }
+    }
+
+    [Fact]
+    public void TranslateModels_NonMiLmMtEntries_AreNotCompletionOnly()
+    {
+        foreach (var model in LlamaCppServerManager.TranslateModels
+                     .Where(m => !m.FileName.Contains("MiLMMT", System.StringComparison.OrdinalIgnoreCase)))
+        {
+            Assert.False(model.CompletionOnly);
+        }
+    }
+
+    [Theory]
+    [InlineData("MiLMMT-46-12B-v1.0.i1-Q4_K_M.gguf")]
+    [InlineData("milmmt-46-1b-v0.1-q8_0.gguf")]
+    public void CreateCustomModel_MiLmMtFileName_InfersCompletionPromptAndSampling(string fileName)
+    {
+        var model = LlamaCppServerManager.CreateCustomModel(fileName, fileName, "1.0 GB");
+
+        Assert.True(model.CompletionOnly);
+        Assert.NotNull(model.PromptTemplate);
+        Assert.Contains("{2}", model.PromptTemplate);
+        Assert.Equal(0, model.Temperature);
+        Assert.Null(model.ChatTemplate);
+    }
+
+    [Fact]
+    public void CreateCustomModel_OtherFileNames_KeepChatTemplateInferenceAndNoPrompt()
+    {
+        var gemma = LlamaCppServerManager.CreateCustomModel(
+            "translategemma-27b-it.Q4_K_M.gguf", "translategemma-27b-it.Q4_K_M.gguf", "16 GB");
+        Assert.Equal("gemma", gemma.ChatTemplate);
+        Assert.True(gemma.NoJinja);
+        Assert.Null(gemma.PromptTemplate);
+        Assert.False(gemma.CompletionOnly);
+
+        var plain = LlamaCppServerManager.CreateCustomModel("my-model.gguf", "my-model.gguf", "1 GB");
+        Assert.Null(plain.ChatTemplate);
+        Assert.Null(plain.PromptTemplate);
+        Assert.False(plain.CompletionOnly);
+        Assert.Equal(-1, plain.Temperature);
+    }
+}


### PR DESCRIPTION
Adds Xiaomi's [MiLMMT-46 v1.0](https://huggingface.co/collections/xiaomi-research/milmmt-46) (Gemma3-based MT, 46 languages incl. Danish/Norwegian/Swedish — the gap Hy-MT2 is labeled "no Nordic" for; the [paper](https://huggingface.co/papers/2602.11961) reports it ahead of TranslateGemma) as curated 4B/12B quants for the regular llama.cpp translate engine.

MiLMMT is a raw-completion MT model with no instruction training; it only works in its trained format `Translate this from X to Y:\nX: <text>\nY:` — verified against SE's own llama-server b10310 with the 1B and 4B quants. That drives all four changes:

- **`{2}` placeholder in `PromptTemplate`**: the text is embedded inside the trained prompt (the trailing target-language cue is mandatory — without it the model echo-loops the untranslated source). A `{2}` prompt is sent with real newlines; under the historical `<br />` placeholder encoding the model mirrors stray placeholder fragments into its output. Chat models keep the old wire format byte-for-byte.
- **`CompletionOnly` flag** keeps MiLMMT out of the llama.cpp *advanced* engine's model list: under its JSON batch protocol the 4B returns well-formed JSON whose values are the untranslated English source lines, mispaired with history — it would parse as a successful batch and silently write wrong text.
- **`CreateCustomModel`** infers the trained prompt, greedy sampling and the restriction for self-supplied MiLMMT `.gguf` files (models folder and seconv `--translate-model` paths).
- **`ApplyTranslatePromptSettings`** re-points the per-model prompt/sampling wherever a local run picks its model. Batch convert and seconv previously relied on whatever the Auto-translate window last persisted, so curated trained-in prompts (Hy-MT2, MiLMMT) never applied in console/batch runs or could leak onto a different model.

Verified end-to-end via seconv with MiLMMT-46-4B Q4_K_M (en→da: correct translation, line breaks and italic tags preserved) and TranslateGemma 4B as the chat-path regression. New unit tests cover the completion prompt builder, the curated entries' invariants, and the custom-model inference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)