### PR TITLE
Waveform: respect auto-generate setting when switching audio track

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -7208,10 +7208,17 @@ public partial class MainViewModel :
             return;
         }
 
+        // With a single audio track, toggling lands on the same track - don't reload the waveform.
+        var trackChanged = track.FfIndex != (_audioTrack?.FfIndex ?? -1);
         _audioTrack = track;
         var _ = Task.Run(LoadAudioTrackMenuItems);
 
         ShowStatus(string.Format(Se.Language.Main.AudioTrackIsNowX, track));
+
+        if (trackChanged)
+        {
+            ReloadWaveformForCurrentAudioTrack();
+        }
     }
 
     [RelayCommand]
@@ -7235,21 +7242,32 @@ public partial class MainViewModel :
             var _ = Task.Run(LoadAudioTrackMenuItems);
             ShowStatus(string.Format(Se.Language.Main.AudioTrackIsNowX, _audioTrack));
 
-            if (AudioVisualizer != null)
-            {
-                Dispatcher.UIThread.Post(() =>
-                {
-                    AudioVisualizer.WavePeaks = null;
-                    AudioVisualizer.ShotChanges = new List<double>();
-                });
-            }
-
-            _updateAudioVisualizer = true;
-
-            // Explicit track pick: show this track's waveform now - from cache if present, else
-            // extract it (regardless of the auto-generate-on-open setting).
-            LoadWaveformAndSpectrogram(_videoFileName, forceGenerate: true);
+            ReloadWaveformForCurrentAudioTrack();
         }
+    }
+
+    // After an audio-track switch, show the new track's waveform from cache, extract it if
+    // auto-generate is on, or fall back to the click-to-generate hint so the user decides -
+    // switching track must not start an extraction when auto-generate is off (#13665).
+    private void ReloadWaveformForCurrentAudioTrack()
+    {
+        if (string.IsNullOrEmpty(_videoFileName))
+        {
+            return;
+        }
+
+        if (AudioVisualizer != null)
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                AudioVisualizer.WavePeaks = null;
+                AudioVisualizer.ShotChanges = new List<double>();
+            });
+        }
+
+        _updateAudioVisualizer = true;
+
+        LoadWaveformAndSpectrogram(_videoFileName);
     }
 
     // Set while the waveform toolbar's audio-track combo box is being repopulated/synced in code,
@@ -20645,10 +20663,7 @@ public partial class MainViewModel :
         });
     }
 
-    // forceGenerate: extract even when WaveformAutoGenerate (the auto-on-open preference) is off.
-    // Set for explicit user actions like picking an audio track, where showing that track's waveform
-    // is the whole point - if it isn't cached yet we extract it now (and cache it for next time).
-    private void LoadWaveformAndSpectrogram(string videoFileName, bool forceGenerate = false)
+    private void LoadWaveformAndSpectrogram(string videoFileName)
     {
         var trackNumber = _audioTrack?.FfIndex ?? -1;
         var peakWaveFileName = WavePeakGenerator2.GetPeakWaveFileName(videoFileName, trackNumber);
@@ -20660,10 +20675,10 @@ public partial class MainViewModel :
             AudioVisualizer.ClickToGenerateText = Se.Language.Main.ClickToGenerateWaveform;
         }
 
-        // On video open, WaveformAutoGenerate gates whether we auto-extract; cached peaks still load
-        // via the branch below either way. An explicit request (forceGenerate) always extracts a
-        // missing waveform - e.g. switching audio track in the waveform toolbar picker.
-        if (needToGenerate && (Se.Settings.Waveform.WaveformAutoGenerate || forceGenerate))
+        // WaveformAutoGenerate gates whether we auto-extract (on video open and on audio-track
+        // switch, #13665); cached peaks still load via the branch below either way. When it is
+        // off, the click-to-generate hint lets the user start extraction explicitly.
+        if (needToGenerate && Se.Settings.Waveform.WaveformAutoGenerate)
         {
             StartWaveformExtraction(videoFileName, trackNumber, peakWaveFileName, spectrogramFileName);
         }

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -3457,11 +3457,11 @@ public partial class MainViewModel :
             var audioTracks = mpv.GetAudioTracks();
             var desiredTrack = audioTracks.FirstOrDefault(p => p.Id == recentFile.AudioTrack);
 
-            // Only switch track and regenerate waveform if different from current
+            // Only switch track and reload the waveform if different from current; PickAudioTrack
+            // itself no-ops on the already-active track (and sets _audioTrack on a real switch).
             if (desiredTrack != null && (_audioTrack == null || _audioTrack.Id != desiredTrack.Id))
             {
-                _audioTrack = desiredTrack;
-                var _ = Task.Run(() => PickAudioTrack(_audioTrack));
+                var _ = Task.Run(() => PickAudioTrack(desiredTrack));
             }
         }
     }
@@ -7237,6 +7237,13 @@ public partial class MainViewModel :
 
         if (vp.VideoPlayer is LibMpvDynamicPlayer mpv && parameter is AudioTrackInfo audioTrack)
         {
+            // No-op when the picked track is already active (e.g. re-picking it from the
+            // Video -> Audio tracks menu) so the waveform isn't cleared and reloaded for nothing.
+            if (_audioTrack != null && audioTrack.FfIndex == _audioTrack.FfIndex)
+            {
+                return;
+            }
+
             mpv.SetAudioTrack(audioTrack.Id);
             _audioTrack = audioTrack;
             var _ = Task.Run(LoadAudioTrackMenuItems);


### PR DESCRIPTION
Fixes #13665

In SE5, switching audio track (via Video → Audio tracks or the waveform toolbar's track picker) always started a waveform extraction, even with "auto-generate waveform when opening a video" disabled. The `forceGenerate: true` bypass was introduced deliberately by the per-track picker (#12893), but it also fired for users who just wanted to change what they *hear*, causing surprise multi-minute extractions.

After this change, switching audio track:

- loads the new track's waveform from cache when peak files exist (unchanged),
- extracts it when auto-generate is **on** (unchanged),
- shows the click-to-generate hint when auto-generate is **off** — one click extracts the newly selected track's waveform, since the hint handler already uses `_audioTrack.FfIndex`.

Also aligns the cycle-audio-track shortcut, which previously left the previous track's (now-wrong) waveform on screen: it now goes through the same reload path when the track actually changes (a single-track toggle is a no-op).

The now-unused `forceGenerate` parameter of `LoadWaveformAndSpectrogram` is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)