### PR TITLE
OCR: fix italic word spacing and l-as-i misreads in binary image compare

### DIFF
--- a/Dictionaries/dan_OCRFixReplaceList.xml
+++ b/Dictionaries/dan_OCRFixReplaceList.xml
@@ -633,6 +633,7 @@
     <WordPart from="n/" to="rv" />
     <WordPart from="Ã" to="Å" />
     <WordPart from="í" to="i" />
+    <WordPart from="i" to="l" />
   </PartialWords>
   <WholeLines />
   <PartialLinesAlways>
@@ -782,5 +783,11 @@
     <!-- inCopenhagen → in Copenhagen -->
     <RegEx find="\bin([A-ZÆØÅ][a-zæøå]+)\b" spellCheck="$1" replaceWith="in $1" />
 
+  </RegularExpressionsIfSpelledCorrectly>
+  <RegularExpressionsIfSpelledCorrectly>
+    <!-- Italic l misread as i (#13660): trailing i to l, double ii to ll.  -->
+    <!-- Correct i-words are in the dictionary and protected by the gate.   -->
+    <RegEx find="\b([A-ZÆØÅa-zæøå][a-zæøå]*)i\b" spellCheck="$1l" replaceWith="$1l" />
+    <RegEx find="\b([A-ZÆØÅa-zæøå][a-zæøå]*)ii([a-zæøå]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/deu_OCRFixReplaceList.xml
+++ b/Dictionaries/deu_OCRFixReplaceList.xml
@@ -6304,6 +6304,8 @@
     <Word from="vial" to="viel" />
     <Word from="Videoiiben/vachung" to="Videoüberwachung" />
     <Word from="Vie/e" to="Viele" />
+    <Word from="Viei" to="Viel" />
+    <Word from="viei" to="viel" />
     <Word from="Vieien" to="Vielen" />
     <Word from="vieiieicht" to="vielleicht" />
     <Word from="vielféltig" to="vielfältig" />
@@ -7025,6 +7027,7 @@
     <WordPart from="f" to="f " />
     <WordPart from="I" to="l" />
     <WordPart from="i" to="t" />
+    <WordPart from="i" to="l" />
     <WordPart from="ii" to="tt" />
     <WordPart from="ii" to="ü" />
     <WordPart from="IVI" to="M" />
@@ -7129,6 +7132,20 @@
 
     <!-- No standalone \bl\b → I rule: "l" is the German liter abbreviation  -->
     <!-- (2 l Milch), and an unconditional rule would corrupt it.            -->
+
+    <!-- ============================================================ -->
+    <!-- ITALIC l MISREAD AS i (#13660)                               -->
+    <!-- Slanted glyphs make binary image compare read l as i:       -->
+    <!--   viel → viei, soll → soii, wollen → woiien                 -->
+    <!-- Correct i-words (Juni/Taxi/Ski) are in the dictionary and   -->
+    <!-- protected by the already-spelled-correctly gate.            -->
+    <!-- ============================================================ -->
+
+    <!-- trailing i→l (viei → viel, Viei → Viel) -->
+    <RegEx find="\b([A-ZÄÖÜa-zäöüß][a-zäöüß]*)i\b" spellCheck="$1l" replaceWith="$1l" />
+
+    <!-- double ii→ll (soii → soll, woiien → wollen, Müii → Müll) -->
+    <RegEx find="\b([A-ZÄÖÜa-zäöüß][a-zäöüß]*)ii([a-zäöüß]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
 
     <!-- ============================================================ -->
     <!-- GERMAN GENITIVE / APOSTROPHE                                 -->

--- a/Dictionaries/eng_OCRFixReplaceList.xml
+++ b/Dictionaries/eng_OCRFixReplaceList.xml
@@ -2855,6 +2855,7 @@
 		<WordPart from="¤" to="o" />
 		<WordPart from="vx/" to="w" />
 		<WordPart from="O" to="Q" />
+		<WordPart from="i" to="l" />
 	</PartialWords>
 	<WholeLines>
 		<!-- Whole lines - including -" etc -->
@@ -3416,5 +3417,11 @@
 		<RegEx find="\b([A-Z]+)l([A-Z]+)\b" spellCheck="$1I$2" replaceWith="$1I$2" />
 		<RegEx find="\b([A-Z][a-zæøåöääöéèàùâêîôûëï]{3,})I([a-zæøåöääöéèàùâêîôûëï]*)\b" spellCheck="$1l$2" replaceWith="$1l$2" />
 		<RegEx find="\b([A-Z][a-zæøåöääöéèàùâêîôûëï]{3,})I\b" spellCheck="$1l" replaceWith="$1l" />
+	</RegularExpressionsIfSpelledCorrectly>
+	<RegularExpressionsIfSpelledCorrectly>
+		<!-- Italic l misread as i (#13660): trailing i to l, double ii to ll.  -->
+		<!-- Correct i-words are in the dictionary and protected by the gate.   -->
+		<RegEx find="\b([A-Za-z][a-z]*)i\b" spellCheck="$1l" replaceWith="$1l" />
+		<RegEx find="\b([A-Za-z][a-z]*)ii([a-z]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
 	</RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/fin_OCRFixReplaceList.xml
+++ b/Dictionaries/fin_OCRFixReplaceList.xml
@@ -1030,4 +1030,13 @@
   <BeginLines />
   <EndLines />
   <RegularExpressions />
+  <PartialWords>
+    <WordPart from="i" to="l" />
+  </PartialWords>
+  <RegularExpressionsIfSpelledCorrectly>
+    <!-- Italic l misread as i (#13660): trailing i to l, double ii to ll.  -->
+    <!-- Correct i-words are in the dictionary and protected by the gate.   -->
+    <RegEx find="\b([A-ZÅÄÖa-zåäö][a-zåäö]*)i\b" spellCheck="$1l" replaceWith="$1l" />
+    <RegEx find="\b([A-ZÅÄÖa-zåäö][a-zåäö]*)ii([a-zåäö]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
+  </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/fra_OCRFixReplaceList.xml
+++ b/Dictionaries/fra_OCRFixReplaceList.xml
@@ -373,4 +373,13 @@
     <RegEx find="\bin([A-Z][a-zæøåöäéèàùâêîôûëïœç]+)\b" spellCheck="$1" replaceWith="in $1" />
 
   </RegularExpressionsIfSpelledCorrectly>
+  <PartialWords>
+    <WordPart from="i" to="l" />
+  </PartialWords>
+  <RegularExpressionsIfSpelledCorrectly>
+    <!-- Italic l misread as i (#13660): trailing i to l, double ii to ll.  -->
+    <!-- Correct i-words are in the dictionary and protected by the gate.   -->
+    <RegEx find="\b([A-ZÀÂÆÇÉÈÊËÎÏÔŒÙÛÜŸa-zàâæçéèêëîïôœùûüÿ][a-zàâæçéèêëîïôœùûüÿ]*)i\b" spellCheck="$1l" replaceWith="$1l" />
+    <RegEx find="\b([A-ZÀÂÆÇÉÈÊËÎÏÔŒÙÛÜŸa-zàâæçéèêëîïôœùûüÿ][a-zàâæçéèêëîïôœùûüÿ]*)ii([a-zàâæçéèêëîïôœùûüÿ]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
+  </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/hrb_OCRFixReplaceList.xml
+++ b/Dictionaries/hrb_OCRFixReplaceList.xml
@@ -1941,4 +1941,13 @@
     <RegEx find="Zurb" replaceWith="Žurb" />
     <RegEx find="zvucen" replaceWith="zvučen" />
   </RegularExpressions>
+  <PartialWords>
+    <WordPart from="i" to="l" />
+  </PartialWords>
+  <RegularExpressionsIfSpelledCorrectly>
+    <!-- Italic l misread as i (#13660): trailing i to l, double ii to ll.  -->
+    <!-- Correct i-words are in the dictionary and protected by the gate.   -->
+    <RegEx find="\b([A-ZČĆĐŠŽa-zčćđšž][a-zčćđšž]*)i\b" spellCheck="$1l" replaceWith="$1l" />
+    <RegEx find="\b([A-ZČĆĐŠŽa-zčćđšž][a-zčćđšž]*)ii([a-zčćđšž]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
+  </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/hrv_OCRFixReplaceList.xml
+++ b/Dictionaries/hrv_OCRFixReplaceList.xml
@@ -4120,6 +4120,7 @@
     <WordPart from="vx/" to="w" />
     <WordPart from=")/" to="y" />
     <WordPart from=")'" to="y" />
+    <WordPart from="i" to="l" />
 </PartialWords>
   <WholeLines />
   <PartialLinesAlways>
@@ -6356,4 +6357,10 @@
     <!-- Skraćenice bez razmaka -->
     <RegEx find="d\. o\.o\." replaceWith="d.o.o." />
   </RegularExpressions>
+  <RegularExpressionsIfSpelledCorrectly>
+    <!-- Italic l misread as i (#13660): trailing i to l, double ii to ll.  -->
+    <!-- Correct i-words are in the dictionary and protected by the gate.   -->
+    <RegEx find="\b([A-ZČĆĐŠŽa-zčćđšž][a-zčćđšž]*)i\b" spellCheck="$1l" replaceWith="$1l" />
+    <RegEx find="\b([A-ZČĆĐŠŽa-zčćđšž][a-zčćđšž]*)ii([a-zčćđšž]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
+  </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/hun_OCRFixReplaceList.xml
+++ b/Dictionaries/hun_OCRFixReplaceList.xml
@@ -31,4 +31,13 @@
     <RegEx find="\b(?:II|ll)" replaceWith="Il" />
     <RegEx find="([\xf5\xfb])I" replaceWith="$1l" />
   </RegularExpressions>
+  <PartialWords>
+    <WordPart from="i" to="l" />
+  </PartialWords>
+  <RegularExpressionsIfSpelledCorrectly>
+    <!-- Italic l misread as i (#13660): trailing i to l, double ii to ll.  -->
+    <!-- Correct i-words are in the dictionary and protected by the gate.   -->
+    <RegEx find="\b([A-ZÁÉÍÓÖŐÚÜŰa-záéíóöőúüű][a-záéíóöőúüű]*)i\b" spellCheck="$1l" replaceWith="$1l" />
+    <RegEx find="\b([A-ZÁÉÍÓÖŐÚÜŰa-záéíóöőúüű][a-záéíóöőúüű]*)ii([a-záéíóöőúüű]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
+  </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/ita_OCRFixReplaceList.xml
+++ b/Dictionaries/ita_OCRFixReplaceList.xml
@@ -53,6 +53,7 @@
     <WordPart from="|" to="l" />
     <WordPart from="¤" to="o" />
     <WordPart from="vx/" to="w" />
+    <WordPart from="i" to="l" />
   </PartialWords>
   <WholeLines />
   <PartialLinesAlways />
@@ -65,4 +66,10 @@
     <RegEx find="\b(I)([àì]|'[ \r\n])\b" replaceWith="l$2" />
     <RegEx find="([\p{Ll},] )(II)\b" replaceWith="$1Il" />  
   </RegularExpressions>
+  <RegularExpressionsIfSpelledCorrectly>
+    <!-- Italic l misread as i (#13660): trailing i to l, double ii to ll.  -->
+    <!-- Correct i-words are in the dictionary and protected by the gate.   -->
+    <RegEx find="\b([A-ZÀÈÉÌÒÓÙa-zàèéìòóù][a-zàèéìòóù]*)i\b" spellCheck="$1l" replaceWith="$1l" />
+    <RegEx find="\b([A-ZÀÈÉÌÒÓÙa-zàèéìòóù][a-zàèéìòóù]*)ii([a-zàèéìòóù]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
+  </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/nld_OCRFixReplaceList.xml
+++ b/Dictionaries/nld_OCRFixReplaceList.xml
@@ -146,6 +146,7 @@
     <!-- Will be used to check words not in dictionary -->
     <!-- If new word(s) exists in spelling dictionary, it is (they are) accepted -->
     <WordPart from="ĳ" to="ij" />
+    <WordPart from="i" to="l" />
   </PartialWords>
   <WholeLines />
   <PartialLinesAlways />
@@ -346,5 +347,11 @@
     <!-- ofLondon → of London -->
     <RegEx find="\bof([A-Z][a-zéèëïóöüij]+)\b" spellCheck="$1" replaceWith="of $1" />
 
+  </RegularExpressionsIfSpelledCorrectly>
+  <RegularExpressionsIfSpelledCorrectly>
+    <!-- Italic l misread as i (#13660): trailing i to l, double ii to ll.  -->
+    <!-- Correct i-words are in the dictionary and protected by the gate.   -->
+    <RegEx find="\b([A-ZÉÈÊËÏÖÜa-zéèêëïöü][a-zéèêëïöü]*)i\b" spellCheck="$1l" replaceWith="$1l" />
+    <RegEx find="\b([A-ZÉÈÊËÏÖÜa-zéèêëïöü][a-zéèêëïöü]*)ii([a-zéèêëïöü]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/nob_OCRFixReplaceList.xml
+++ b/Dictionaries/nob_OCRFixReplaceList.xml
@@ -47,6 +47,7 @@
     <WordPart from="n/" to="rv" />
     <WordPart from="Ã" to="Å" />
     <WordPart from="í" to="i" />
+    <WordPart from="i" to="l" />
   </PartialWords>
   <WholeLines />
   <PartialLinesAlways />
@@ -183,4 +184,10 @@
 
   </RegularExpressionsIfSpelledCorrectly>
   <RegularExpressions />
+  <RegularExpressionsIfSpelledCorrectly>
+    <!-- Italic l misread as i (#13660): trailing i to l, double ii to ll.  -->
+    <!-- Correct i-words are in the dictionary and protected by the gate.   -->
+    <RegEx find="\b([A-ZÆØÅa-zæøå][a-zæøå]*)i\b" spellCheck="$1l" replaceWith="$1l" />
+    <RegEx find="\b([A-ZÆØÅa-zæøå][a-zæøå]*)ii([a-zæøå]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
+  </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/nor_OCRFixReplaceList.xml
+++ b/Dictionaries/nor_OCRFixReplaceList.xml
@@ -34,6 +34,7 @@
     <WordPart from="n/" to="rv" />
     <WordPart from="Ã" to="Å" />
     <WordPart from="í" to="i" />
+    <WordPart from="i" to="l" />
   </PartialWords>
   <WholeLines />
   <PartialLinesAlways />
@@ -179,5 +180,11 @@
     <!-- inOslo → in Oslo -->
     <RegEx find="\bin([A-ZÆØÅ][a-zæøåé]+)\b" spellCheck="$1" replaceWith="in $1" />
 
+  </RegularExpressionsIfSpelledCorrectly>
+  <RegularExpressionsIfSpelledCorrectly>
+    <!-- Italic l misread as i (#13660): trailing i to l, double ii to ll.  -->
+    <!-- Correct i-words are in the dictionary and protected by the gate.   -->
+    <RegEx find="\b([A-ZÆØÅa-zæøå][a-zæøå]*)i\b" spellCheck="$1l" replaceWith="$1l" />
+    <RegEx find="\b([A-ZÆØÅa-zæøå][a-zæøå]*)ii([a-zæøå]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/pol_OCRFixReplaceList.xml
+++ b/Dictionaries/pol_OCRFixReplaceList.xml
@@ -10,6 +10,7 @@
     <WordPart from="f" to="f " />
     <WordPart from="ą" to="ą " />
     <WordPart from="j" to=" j" />
+    <WordPart from="i" to="l" />
   </PartialWords>
   <WholeLines />
   <PartialLinesAlways />
@@ -17,4 +18,10 @@
   <BeginLines />
   <EndLines />
   <RegularExpressions />
+  <RegularExpressionsIfSpelledCorrectly>
+    <!-- Italic l misread as i (#13660): trailing i to l, double ii to ll.  -->
+    <!-- Correct i-words are in the dictionary and protected by the gate.   -->
+    <RegEx find="\b([A-ZĄĆĘŁŃÓŚŹŻa-ząćęłńóśźż][a-ząćęłńóśźż]*)i\b" spellCheck="$1l" replaceWith="$1l" />
+    <RegEx find="\b([A-ZĄĆĘŁŃÓŚŹŻa-ząćęłńóśźż][a-ząćęłńóśźż]*)ii([a-ząćęłńóśźż]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
+  </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/por_OCRFixReplaceList.xml
+++ b/Dictionaries/por_OCRFixReplaceList.xml
@@ -529,4 +529,13 @@
     <RegEx find="\bkil(ogramas?|ómetros?)" replaceWith="quil$1" />
     <RegEx find="\bKil(ogramas?|ómetros?)" replaceWith="Quil$1" />
   </RegularExpressions>
+  <PartialWords>
+    <WordPart from="i" to="l" />
+  </PartialWords>
+  <RegularExpressionsIfSpelledCorrectly>
+    <!-- Italic l misread as i (#13660): trailing i to l, double ii to ll.  -->
+    <!-- Correct i-words are in the dictionary and protected by the gate.   -->
+    <RegEx find="\b([A-ZÀÁÂÃÇÉÊÍÓÔÕÚa-zàáâãçéêíóôõú][a-zàáâãçéêíóôõú]*)i\b" spellCheck="$1l" replaceWith="$1l" />
+    <RegEx find="\b([A-ZÀÁÂÃÇÉÊÍÓÔÕÚa-zàáâãçéêíóôõú][a-zàáâãçéêíóôõú]*)ii([a-zàáâãçéêíóôõú]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
+  </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/spa_OCRFixReplaceList.xml
+++ b/Dictionaries/spa_OCRFixReplaceList.xml
@@ -952,4 +952,13 @@
     <RegEx find="\bIes\b" replaceWith="les" />
     <RegEx find="\bIos\b" replaceWith="los" />
   </RegularExpressions>
+  <PartialWords>
+    <WordPart from="i" to="l" />
+  </PartialWords>
+  <RegularExpressionsIfSpelledCorrectly>
+    <!-- Italic l misread as i (#13660): trailing i to l, double ii to ll.  -->
+    <!-- Correct i-words are in the dictionary and protected by the gate.   -->
+    <RegEx find="\b([A-ZÁÉÍÓÚÑÜa-záéíóúñü][a-záéíóúñü]*)i\b" spellCheck="$1l" replaceWith="$1l" />
+    <RegEx find="\b([A-ZÁÉÍÓÚÑÜa-záéíóúñü][a-záéíóúñü]*)ii([a-záéíóúñü]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
+  </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/swe_OCRFixReplaceList.xml
+++ b/Dictionaries/swe_OCRFixReplaceList.xml
@@ -450,6 +450,7 @@
     <WordPart from="tjag" to="t jag" />
     <WordPart from="ejag" to="e jag" />
     <WordPart from="ärp" to="är p" />
+    <WordPart from="i" to="l" />
   </PartialWords>
   <WholeLines />
   <PartialLinesAlways>
@@ -589,5 +590,11 @@
     <!-- inStockholm → in Stockholm -->
     <RegEx find="\bin([A-ZÅÄÖ][a-zåäöé]+)\b" spellCheck="$1" replaceWith="in $1" />
 
+  </RegularExpressionsIfSpelledCorrectly>
+  <RegularExpressionsIfSpelledCorrectly>
+    <!-- Italic l misread as i (#13660): trailing i to l, double ii to ll.  -->
+    <!-- Correct i-words are in the dictionary and protected by the gate.   -->
+    <RegEx find="\b([A-ZÅÄÖa-zåäö][a-zåäö]*)i\b" spellCheck="$1l" replaceWith="$1l" />
+    <RegEx find="\b([A-ZÅÄÖa-zåäö][a-zåäö]*)ii([a-zåäö]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/src/libuilogic/Ocr/BinaryOcrMatcher.cs
+++ b/src/libuilogic/Ocr/BinaryOcrMatcher.cs
@@ -31,7 +31,7 @@ public class BinaryOcrMatcher : IBinaryOcrMatcher
         public int ExpandCount { get; set; }
         public string? Name { get; set; }
         public NOcrChar? NOcrCharacter { get; set; }
-        public ImageSplitterItem? ImageSplitterItem { get; set; }
+        public ImageSplitterItem2? ImageSplitterItem { get; set; }
         public int X { get; set; }
         public int Y { get; set; }
         public List<ImageSplitterItem>? Extra { get; set; }
@@ -50,7 +50,7 @@ public class BinaryOcrMatcher : IBinaryOcrMatcher
             NOcrCharacter = character;
         }
 
-        public CompareMatch(string text, bool italic, int expandCount, string name, ImageSplitterItem imageSplitterItem)
+        public CompareMatch(string text, bool italic, int expandCount, string name, ImageSplitterItem2 imageSplitterItem)
             : this(text, italic, expandCount, name)
         {
             ImageSplitterItem = imageSplitterItem;

--- a/src/libuilogic/Ocr/FixEngine/OcrFixEngine.cs
+++ b/src/libuilogic/Ocr/FixEngine/OcrFixEngine.cs
@@ -380,6 +380,14 @@ public partial class OcrFixEngine : IOcrFixEngine, IDoSpell
                     }
                 }
 
+                if (w.Length > 4)
+                {
+                    // Substitute the replace list's <PartialWords> pairs (e.g. italic OCR often
+                    // reads 'l' as 'i': "viei" -> "viel"); a guess only wins if the dictionary
+                    // or names list below confirms it.
+                    guesses.AddRange(_ocrFixReplaceList.CreateGuessesFromLetters(result, _threeLetterIsoLanguageName));
+                }
+
                 foreach (var g in guesses)
                 {
                     w = g.Trim('\'', '"', '-');

--- a/src/libuilogic/Ocr/FixEngine/OcrFixReplaceList2.cs
+++ b/src/libuilogic/Ocr/FixEngine/OcrFixReplaceList2.cs
@@ -23,7 +23,11 @@ namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine
         private readonly Dictionary<string, string> _endLineReplaceList;
         private readonly Dictionary<string, string> _wholeLineReplaceList;
         private readonly Dictionary<string, string> _partialWordAlwaysReplaceList;
-        private readonly Dictionary<string, string> _partialWordReplaceList;
+
+        // A list of pairs, not a dictionary: the same OCR artifact can have several valid
+        // readings (deu ships i->t and i->l, ii->tt and ii->ü), and the letter guesser wants
+        // to try them all - each guess is only accepted after a dictionary/names check anyway.
+        private readonly List<KeyValuePair<string, string>> _partialWordReplaceList;
         private readonly Dictionary<string, string> _regExList;
         private readonly List<SpellCheckRegex> _regExSpellCheckList;
         private List<Regex>? _replaceRegExes;
@@ -59,7 +63,7 @@ namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine
             _endLineReplaceList = new Dictionary<string, string>();
             _wholeLineReplaceList = new Dictionary<string, string>();
             _partialWordAlwaysReplaceList = new Dictionary<string, string>();
-            _partialWordReplaceList = new Dictionary<string, string>();
+            _partialWordReplaceList = new List<KeyValuePair<string, string>>();
             _regExList = new Dictionary<string, string>();
 
             var doc = LoadXmlReplaceListDocument();
@@ -67,7 +71,7 @@ namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine
 
             WordReplaceList = LoadReplaceList(doc, "WholeWords");
             _partialWordAlwaysReplaceList = LoadReplaceList(doc, "PartialWordsAlways");
-            _partialWordReplaceList = LoadReplaceList(doc, "PartialWords");
+            _partialWordReplaceList = LoadReplaceListPairs(doc, "PartialWords");
             PartialLineWordBoundaryReplaceList = LoadReplaceList(doc, "PartialLines");
             _partialLineAlwaysReplaceList = LoadReplaceList(doc, "PartialLinesAlways");
             _beginLineReplaceList = LoadReplaceList(doc, "BeginLines");
@@ -108,16 +112,13 @@ namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine
 
             foreach (var kp in LoadReplaceList(userDoc, "RemovedPartialWords"))
             {
-                if (_partialWordReplaceList.ContainsKey(kp.Key))
-                {
-                    _partialWordReplaceList.Remove(kp.Key);
-                }
+                _partialWordReplaceList.RemoveAll(p => p.Key == kp.Key);
             }
-            foreach (var kp in LoadReplaceList(userDoc, "PartialWords"))
+            foreach (var kp in LoadReplaceListPairs(userDoc, "PartialWords"))
             {
-                if (!_partialWordReplaceList.ContainsKey(kp.Key))
+                if (!_partialWordReplaceList.Any(p => p.Key == kp.Key && p.Value == kp.Value))
                 {
-                    _partialWordReplaceList.Add(kp.Key, kp.Value);
+                    _partialWordReplaceList.Add(kp);
                 }
             }
 
@@ -240,6 +241,36 @@ namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine
                     if (to != null && from != null && !list.ContainsKey(from))
                     {
                         list.Add(from, to);
+                    }
+                }
+            }
+
+            return list;
+        }
+
+        private static List<KeyValuePair<string, string>> LoadReplaceListPairs(XmlDocument doc, string name)
+        {
+            var list = new List<KeyValuePair<string, string>>();
+            if (!IsValidXmlDocument(doc, name))
+            {
+                return list;
+            }
+
+            var node = doc.DocumentElement?.SelectSingleNode(name);
+            if (node != null)
+            {
+                foreach (XmlNode item in node.ChildNodes)
+                {
+                    if (!HasValidAttributes(item, false) || item.Attributes == null)
+                    {
+                        continue;
+                    }
+
+                    var to = item.Attributes["to"]?.Value;
+                    var from = item.Attributes["from"]?.Value;
+                    if (to != null && from != null && !list.Any(p => p.Key == from && p.Value == to))
+                    {
+                        list.Add(new KeyValuePair<string, string>(from, to));
                     }
                 }
             }

--- a/src/libuilogic/Ocr/ItalicSpaceFixer.cs
+++ b/src/libuilogic/Ocr/ItalicSpaceFixer.cs
@@ -1,0 +1,167 @@
+namespace Nikse.SubtitleEdit.UiLogic.Ocr;
+
+/// <summary>
+/// Italic glyphs lean over the word gaps, so the letter splitter's straight-column
+/// space detection undercounts them. This re-measures the gaps between matched
+/// glyphs along the italic slant and inserts the spaces that were missed.
+/// Callers should keep the result only if it scores better against the dictionary.
+/// </summary>
+public static class ItalicSpaceFixer
+{
+    public static string GetTextWithMoreSpacesInItalic(
+        List<BinaryOcrMatcher.CompareMatch> matches,
+        List<ImageSplitterItem2> letters,
+        NikseBitmap2 parentBitmap,
+        double unItalicFactor,
+        int pixelsIsSpace)
+    {
+        // Clear all CouldBeSpaceBefore flags
+        foreach (var letter in letters)
+        {
+            letter.CouldBeSpaceBefore = false;
+        }
+
+        // Check for potential spaces in italic text
+        for (var i = 0; i < matches.Count - 1; i++)
+        {
+            var match = matches[i];
+            var matchNext = matches[i + 1];
+            if (!match.Italic || matchNext.Text == "," ||
+                string.IsNullOrWhiteSpace(match.Text) || string.IsNullOrWhiteSpace(matchNext.Text) ||
+                match.ImageSplitterItem == null || matchNext.ImageSplitterItem == null)
+            {
+                continue;
+            }
+
+            var blankVerticalLines = IsVerticalAngledLineTransparent(parentBitmap, match.ImageSplitterItem, matchNext.ImageSplitterItem, unItalicFactor);
+            if (match.Text == "f" || match.Text == "," || matchNext.Text.StartsWith('y') || matchNext.Text.StartsWith('j'))
+            {
+                blankVerticalLines++;
+            }
+
+            if (blankVerticalLines >= pixelsIsSpace)
+            {
+                matchNext.ImageSplitterItem.CouldBeSpaceBefore = true;
+            }
+        }
+
+        // Insert spaces where CouldBeSpaceBefore is true and previous match is italic
+        var j = 1;
+        while (j < matches.Count)
+        {
+            var match = matches[j];
+            var prevMatch = matches[j - 1];
+            if (match.ImageSplitterItem?.CouldBeSpaceBefore == true)
+            {
+                match.ImageSplitterItem.CouldBeSpaceBefore = false;
+                if (prevMatch.Italic)
+                {
+                    matches.Insert(j, new BinaryOcrMatcher.CompareMatch(" ", false, 0, null));
+                    j++; // Skip the inserted space
+                }
+            }
+
+            j++;
+        }
+
+        return ItalicTextMerger.MergeWithItalicTags(matches).Trim();
+    }
+
+    public static string GetTextWithMoreSpacesInItalic(
+        List<NOcrChar> matches,
+        List<ImageSplitterItem2> letters,
+        NikseBitmap2 parentBitmap,
+        double unItalicFactor,
+        int pixelsIsSpace)
+    {
+        // Clear all CouldBeSpaceBefore flags
+        foreach (var letter in letters)
+        {
+            letter.CouldBeSpaceBefore = false;
+        }
+
+        // Check for potential spaces in italic text
+        for (var i = 0; i < matches.Count - 1; i++)
+        {
+            var match = matches[i];
+            var matchNext = matches[i + 1];
+            if (!match.Italic || matchNext.Text == "," ||
+                string.IsNullOrWhiteSpace(match.Text) || string.IsNullOrWhiteSpace(matchNext.Text) ||
+                match.ImageSplitterItem == null || matchNext.ImageSplitterItem == null)
+            {
+                continue;
+            }
+
+            var blankVerticalLines = IsVerticalAngledLineTransparent(parentBitmap, match.ImageSplitterItem, matchNext.ImageSplitterItem, unItalicFactor);
+            if (match.Text == "f" || match.Text == "," || matchNext.Text.StartsWith('y') || matchNext.Text.StartsWith('j'))
+            {
+                blankVerticalLines++;
+            }
+
+            if (blankVerticalLines >= pixelsIsSpace)
+            {
+                matchNext.ImageSplitterItem.CouldBeSpaceBefore = true;
+            }
+        }
+
+        // Insert spaces where CouldBeSpaceBefore is true and previous match is italic
+        var j = 1;
+        while (j < matches.Count)
+        {
+            var match = matches[j];
+            var prevMatch = matches[j - 1];
+            if (match.ImageSplitterItem?.CouldBeSpaceBefore == true)
+            {
+                match.ImageSplitterItem.CouldBeSpaceBefore = false;
+                if (prevMatch.Italic)
+                {
+                    matches.Insert(j, new NOcrChar(" "));
+                    j++; // Skip the inserted space
+                }
+            }
+
+            j++;
+        }
+
+        return ItalicTextMerger.MergeWithItalicTags(matches).Trim();
+    }
+
+    private static int IsVerticalAngledLineTransparent(NikseBitmap2 parentBitmap, ImageSplitterItem2 match, ImageSplitterItem2 next, double unItalicFactor)
+    {
+        if (match.NikseBitmap == null || next.NikseBitmap == null)
+        {
+            return 0;
+        }
+
+        var blanks = 0;
+        var min = match.X + match.NikseBitmap.Width;
+        var max = next.X + next.NikseBitmap.Width / 2;
+        for (var startX = min; startX < max; startX++)
+        {
+            var lineBlank = true;
+            for (var y = match.Y; y < match.Y + match.NikseBitmap.Height; y++)
+            {
+                var x = startX - (y - match.Y) * unItalicFactor;
+                if (x >= 0 && x < parentBitmap.Width && y < parentBitmap.Height)
+                {
+                    var color = parentBitmap.GetPixel((int)Math.Round(x), y);
+                    if (color.Alpha != 0)
+                    {
+                        lineBlank = false;
+                        if (blanks > 0)
+                        {
+                            return blanks;
+                        }
+                    }
+                }
+            }
+
+            if (lineBlank)
+            {
+                blanks++;
+            }
+        }
+
+        return blanks;
+    }
+}

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -3190,7 +3190,7 @@ public partial class OcrViewModel : ObservableObject
             if (ocrFixResultTemp.UnknownWords.Count > 0 && item.Text.Contains("<i>", StringComparison.Ordinal))
             {
                 var unItalicFactor = 0.33;
-                var text = GetTextWithMoreSpacesInItalic(ocrFixResultTemp.UnknownWords, matches, letters, parentBitmap, unItalicFactor, SelectedNOcrPixelsAreSpace);
+                var text = ItalicSpaceFixer.GetTextWithMoreSpacesInItalic(matches, letters, parentBitmap, unItalicFactor, SelectedNOcrPixelsAreSpace);
                 var unItalicItem = new OcrSubtitleItem(item, text);
                 var unItalicResultTemp = OcrFixLine(i, unItalicItem);
                 if (ocrFixResultTemp.UnknownWords.Count > unItalicResultTemp.UnknownWords.Count)
@@ -3253,104 +3253,6 @@ public partial class OcrViewModel : ObservableObject
         return matches;
     }
 
-    private static string GetTextWithMoreSpacesInItalic(
-        List<UnknownWordItem> unknownWords,
-        List<NOcrChar> matches,
-        List<ImageSplitterItem2> letters,
-        NikseBitmap2 parentBitmap,
-        double unItalicFactor,
-        int pixelsIsSpace)
-    {
-        // Clear all CouldBeSpaceBefore flags
-        foreach (var letter in letters)
-        {
-            letter.CouldBeSpaceBefore = false;
-        }
-
-        // Check for potential spaces in italic text
-        for (var i = 0; i < matches.Count - 1; i++)
-        {
-            var match = matches[i];
-            var matchNext = matches[i + 1];
-            if (!match.Italic || matchNext.Text == "," ||
-                string.IsNullOrWhiteSpace(match.Text) || string.IsNullOrWhiteSpace(matchNext.Text) ||
-                match.ImageSplitterItem == null || matchNext.ImageSplitterItem == null)
-            {
-                continue;
-            }
-
-            var blankVerticalLines = IsVerticalAngledLineTransparent(parentBitmap, match.ImageSplitterItem, matchNext.ImageSplitterItem, unItalicFactor);
-            if (match.Text == "f" || match.Text == "," || matchNext.Text.StartsWith('y') || matchNext.Text.StartsWith('j'))
-            {
-                blankVerticalLines++;
-            }
-
-            if (blankVerticalLines >= pixelsIsSpace)
-            {
-                matchNext.ImageSplitterItem.CouldBeSpaceBefore = true;
-            }
-        }
-
-        // Insert spaces where CouldBeSpaceBefore is true and previous match is italic
-        var j = 1;
-        while (j < matches.Count)
-        {
-            var match = matches[j];
-            var prevMatch = matches[j - 1];
-            if (match.ImageSplitterItem?.CouldBeSpaceBefore == true)
-            {
-                match.ImageSplitterItem.CouldBeSpaceBefore = false;
-                if (prevMatch.Italic)
-                {
-                    matches.Insert(j, new NOcrChar(" "));
-                    j++; // Skip the inserted space
-                }
-            }
-
-            j++;
-        }
-
-        return ItalicTextMerger.MergeWithItalicTags(matches).Trim();
-    }
-
-    private static int IsVerticalAngledLineTransparent(NikseBitmap2 parentBitmap, ImageSplitterItem2 match, ImageSplitterItem2 next, double unItalicFactor)
-    {
-        if (match.NikseBitmap == null || next.NikseBitmap == null)
-        {
-            return 0;
-        }
-
-        var blanks = 0;
-        var min = match.X + match.NikseBitmap.Width;
-        var max = next.X + next.NikseBitmap.Width / 2;
-        for (var startX = min; startX < max; startX++)
-        {
-            var lineBlank = true;
-            for (var y = match.Y; y < match.Y + match.NikseBitmap.Height; y++)
-            {
-                var x = startX - (y - match.Y) * unItalicFactor;
-                if (x >= 0 && x < parentBitmap.Width && y < parentBitmap.Height)
-                {
-                    var color = parentBitmap.GetPixel((int)Math.Round(x), y);
-                    if (color.Alpha != 0)
-                    {
-                        lineBlank = false;
-                        if (blanks > 0)
-                        {
-                            return blanks;
-                        }
-                    }
-                }
-            }
-
-            if (lineBlank)
-            {
-                blanks++;
-            }
-        }
-
-        return blanks;
-    }
 
     private void RunBinaryImageCompareOcr(List<int> selectedIndices, CancellationToken cancellationToken)
     {
@@ -3431,7 +3333,7 @@ public partial class OcrViewModel : ObservableObject
                             }
 
                             var text = _nOcrCaseFixer.FixUppercaseLowercaseIssues(splitterItem, nMatch);
-                            matches.Add(new BinaryOcrMatcher.CompareMatch(text, nMatch.Italic, nMatch.ExpandCount, "nOcrFallback"));
+                            matches.Add(new BinaryOcrMatcher.CompareMatch(text, nMatch.Italic, nMatch.ExpandCount, "nOcrFallback") { ImageSplitterItem = splitterItem });
                             index++;
                             continue;
                         }
@@ -3519,7 +3421,7 @@ public partial class OcrViewModel : ObservableObject
                     }
                     else
                     {
-                        matches.Add(new BinaryOcrMatcher.CompareMatch(match.Text, match.Italic, match.ExpandCount, match.Name));
+                        matches.Add(new BinaryOcrMatcher.CompareMatch(match.Text, match.Italic, match.ExpandCount, match.Name) { ImageSplitterItem = splitterItem });
                     }
                 }
 
@@ -3527,7 +3429,26 @@ public partial class OcrViewModel : ObservableObject
             }
 
             item.Text = ItalicTextMerger.MergeWithItalicTags(matches).Trim();
-            var unknownWords = OcrFixLineAndSetText(i, item);
+            var ocrFixResultTemp = OcrFixLine(i, item);
+            if (ocrFixResultTemp.UnknownWords.Count > 0 && item.Text.Contains("<i>", StringComparison.Ordinal))
+            {
+                // Italic glyphs lean over the word gaps, so the straight-column space
+                // detection undercounts them - re-measure along the italic slant and
+                // keep the extra spaces only if the dictionary likes the result better.
+                var unItalicFactor = 0.33;
+                var text = ItalicSpaceFixer.GetTextWithMoreSpacesInItalic(matches, letters, parentBitmap, unItalicFactor, SelectedBinaryOcrPixelsAreSpace);
+                var unItalicItem = new OcrSubtitleItem(item, text);
+                var unItalicResultTemp = OcrFixLine(i, unItalicItem);
+                if (ocrFixResultTemp.UnknownWords.Count > unItalicResultTemp.UnknownWords.Count)
+                {
+                    item.Text = unItalicItem.Text;
+                    item.FixResult = unItalicItem.FixResult;
+                    ocrFixResultTemp = unItalicResultTemp;
+                }
+            }
+
+            SetText(i, item, ocrFixResultTemp);
+            var unknownWords = ocrFixResultTemp.UnknownWords;
 
             _runOnceChars.Clear();
             _skipOnceChars.Clear();

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixReplaceListPartialWordGuessTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixReplaceListPartialWordGuessTests.cs
@@ -1,0 +1,74 @@
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
+
+namespace UITests.Features.Ocr.FixEngine;
+
+// Regression tests for https://github.com/SubtitleEdit/subtitleedit/issues/13660
+// Italic subtitles make binary image compare read 'l' as 'i' ("viel" -> "viei",
+// "Colin" -> "Coiin"). The letter guesser substitutes <PartialWords> pairs into unknown
+// words, so the German list needs an i->l pair - but "i" already maps to "t", and the
+// old Dictionary-backed storage silently dropped every duplicate "from" key (the shipped
+// deu list's ii->ü was dead for the same reason). PartialWords is now a list of pairs.
+public class OcrFixReplaceListPartialWordGuessTests
+{
+    private static OcrFixReplaceList2 MakeReplaceList(string partialWordsXml)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"guesstest_{Guid.NewGuid():N}_OCRFixReplaceList.xml");
+        File.WriteAllText(path, $"<ReplaceList><PartialWords>{partialWordsXml}</PartialWords></ReplaceList>");
+        try
+        {
+            return new OcrFixReplaceList2(path);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void DuplicateFromKeys_AllPairsGenerateGuesses()
+    {
+        var replaceList = MakeReplaceList(
+            "<WordPart from=\"i\" to=\"t\" />" +
+            "<WordPart from=\"i\" to=\"l\" />");
+
+        var guesses = replaceList.CreateGuessesFromLetters("viei", "deu").ToList();
+
+        Assert.Contains("viel", guesses); // italic OCR error, needs i->l
+        Assert.Contains("viet", guesses); // the first mapping must keep working too
+    }
+
+    [Fact]
+    public void ItalicLReadAsI_NameIsGuessed()
+    {
+        var replaceList = MakeReplaceList("<WordPart from=\"i\" to=\"l\" />");
+
+        var guesses = replaceList.CreateGuessesFromLetters("Coiin", "deu").ToList();
+
+        Assert.Contains("Colin", guesses);
+    }
+
+    [Fact]
+    public void ItalicDoubleLReadAsIi_CumulativeGuessCoversBothLetters()
+    {
+        // The guesser's cumulative chain replaces occurrences left to right, so a single
+        // i->l pair also repairs double-l words - no ii->ll entry needed (which would
+        // conflict with the shipped ii->tt / ii->ü pairs).
+        var replaceList = MakeReplaceList("<WordPart from=\"i\" to=\"l\" />");
+
+        var guesses = replaceList.CreateGuessesFromLetters("woiien", "deu").ToList();
+
+        Assert.Contains("wollen", guesses);
+    }
+
+    [Fact]
+    public void ExactDuplicatePairs_AreLoadedOnce()
+    {
+        var replaceList = MakeReplaceList(
+            "<WordPart from=\"i\" to=\"l\" />" +
+            "<WordPart from=\"i\" to=\"l\" />");
+
+        var guesses = replaceList.CreateGuessesFromLetters("viei", "deu").ToList();
+
+        Assert.Equal(guesses.Count, guesses.Distinct().Count());
+    }
+}

--- a/tests/libuilogic/Ocr/ItalicSpaceFixerTests.cs
+++ b/tests/libuilogic/Ocr/ItalicSpaceFixerTests.cs
@@ -1,0 +1,146 @@
+using Nikse.SubtitleEdit.UiLogic.Ocr;
+
+namespace LibUiLogicTests.Ocr;
+
+/// <summary>
+/// Italic glyphs lean over the word gaps, so the letter splitter's straight-column space
+/// detection undercounts them. ItalicSpaceFixer re-measures the gaps along the italic slant
+/// and inserts the spaces that were missed (issue #13660: "hat mir gesagt" OCR'ed as
+/// "hatmirgesagt"). These tests pin the insertion rules for both the binary image compare
+/// matches and the nOCR matches.
+/// </summary>
+public class ItalicSpaceFixerTests
+{
+    private const double UnItalicFactor = 0.33;
+
+    private static NikseBitmap2 MakeBitmap(int width, int height, bool opaque)
+    {
+        var data = new byte[width * height * 4];
+        if (opaque)
+        {
+            for (var i = 0; i < data.Length; i++)
+            {
+                data[i] = 255;
+            }
+        }
+
+        return new NikseBitmap2(width, height, data);
+    }
+
+    private static ImageSplitterItem2 MakeLetter(int x, int width) =>
+        new ImageSplitterItem2(x, 0, MakeBitmap(width, 20, opaque: true));
+
+    private static BinaryOcrMatcher.CompareMatch MakeMatch(string text, bool italic, ImageSplitterItem2 letter) =>
+        new BinaryOcrMatcher.CompareMatch(text, italic, 0, null) { ImageSplitterItem = letter };
+
+    [Fact]
+    public void BinaryMatches_WideTransparentGapInItalic_InsertsSpace()
+    {
+        var parentBitmap = MakeBitmap(60, 30, opaque: false); // fully transparent => whole gap is blank
+        var letterA = MakeLetter(0, 10);
+        var letterB = MakeLetter(30, 10); // gap of 20 >= pixelsIsSpace
+        var letters = new List<ImageSplitterItem2> { letterA, letterB };
+        var matches = new List<BinaryOcrMatcher.CompareMatch>
+        {
+            MakeMatch("a", true, letterA),
+            MakeMatch("b", true, letterB),
+        };
+
+        var text = ItalicSpaceFixer.GetTextWithMoreSpacesInItalic(matches, letters, parentBitmap, UnItalicFactor, 12);
+
+        Assert.Equal("<i>a b</i>", text);
+    }
+
+    [Fact]
+    public void BinaryMatches_GapFilledWithPixels_NoSpaceInserted()
+    {
+        var parentBitmap = MakeBitmap(60, 30, opaque: true); // every angled line hits a pixel
+        var letterA = MakeLetter(0, 10);
+        var letterB = MakeLetter(30, 10);
+        var letters = new List<ImageSplitterItem2> { letterA, letterB };
+        var matches = new List<BinaryOcrMatcher.CompareMatch>
+        {
+            MakeMatch("a", true, letterA),
+            MakeMatch("b", true, letterB),
+        };
+
+        var text = ItalicSpaceFixer.GetTextWithMoreSpacesInItalic(matches, letters, parentBitmap, UnItalicFactor, 12);
+
+        Assert.Equal("<i>ab</i>", text);
+    }
+
+    [Fact]
+    public void BinaryMatches_GapNarrowerThanPixelsIsSpace_NoSpaceInserted()
+    {
+        var parentBitmap = MakeBitmap(60, 30, opaque: false);
+        var letterA = MakeLetter(0, 10);
+        var letterB = MakeLetter(14, 10); // blank range 10..19 => 9 < pixelsIsSpace
+        var letters = new List<ImageSplitterItem2> { letterA, letterB };
+        var matches = new List<BinaryOcrMatcher.CompareMatch>
+        {
+            MakeMatch("a", true, letterA),
+            MakeMatch("b", true, letterB),
+        };
+
+        var text = ItalicSpaceFixer.GetTextWithMoreSpacesInItalic(matches, letters, parentBitmap, UnItalicFactor, 12);
+
+        Assert.Equal("<i>ab</i>", text);
+    }
+
+    [Fact]
+    public void BinaryMatches_NonItalic_NoSpaceInserted()
+    {
+        // The straight-column detection already handles upright text; the fixer must only
+        // touch italic matches.
+        var parentBitmap = MakeBitmap(60, 30, opaque: false);
+        var letterA = MakeLetter(0, 10);
+        var letterB = MakeLetter(30, 10);
+        var letters = new List<ImageSplitterItem2> { letterA, letterB };
+        var matches = new List<BinaryOcrMatcher.CompareMatch>
+        {
+            MakeMatch("a", false, letterA),
+            MakeMatch("b", false, letterB),
+        };
+
+        var text = ItalicSpaceFixer.GetTextWithMoreSpacesInItalic(matches, letters, parentBitmap, UnItalicFactor, 12);
+
+        Assert.Equal("ab", text);
+    }
+
+    [Fact]
+    public void BinaryMatches_ExistingSpaceMatch_NotDoubled()
+    {
+        var parentBitmap = MakeBitmap(90, 30, opaque: false);
+        var letterA = MakeLetter(0, 10);
+        var letterB = MakeLetter(30, 10);
+        var letters = new List<ImageSplitterItem2> { letterA, letterB };
+        var matches = new List<BinaryOcrMatcher.CompareMatch>
+        {
+            MakeMatch("a", true, letterA),
+            new BinaryOcrMatcher.CompareMatch(" ", false, 0, null),
+            MakeMatch("b", true, letterB),
+        };
+
+        var text = ItalicSpaceFixer.GetTextWithMoreSpacesInItalic(matches, letters, parentBitmap, UnItalicFactor, 12);
+
+        Assert.Equal("<i>a b</i>", text);
+    }
+
+    [Fact]
+    public void NOcrMatches_WideTransparentGapInItalic_InsertsSpace()
+    {
+        var parentBitmap = MakeBitmap(60, 30, opaque: false);
+        var letterA = MakeLetter(0, 10);
+        var letterB = MakeLetter(30, 10);
+        var letters = new List<ImageSplitterItem2> { letterA, letterB };
+        var matches = new List<NOcrChar>
+        {
+            new NOcrChar("a") { Italic = true, ImageSplitterItem = letterA },
+            new NOcrChar("b") { Italic = true, ImageSplitterItem = letterB },
+        };
+
+        var text = ItalicSpaceFixer.GetTextWithMoreSpacesInItalic(matches, letters, parentBitmap, UnItalicFactor, 12);
+
+        Assert.Equal("<i>a b</i>", text);
+    }
+}


### PR DESCRIPTION
Fixes #13660 — italic PGS subtitles OCR'ed with binary image compare lost their word spacing (`hat mir gesagt` → `hatmirgesagt`) and read `l` as `i` (`viel` → `viei`, `Colin` → `Coiin`).

### Word spacing (the real SE 5 regression)

Italic glyphs lean over the word gaps, so the letter splitter's straight-vertical-column space detection undercounts them. SE 4 compensated with a rescue pass (`AddItalicCouldBeSpace` in VobSubOcr.cs): when unknown words remained on a line containing `<i>`, it re-measured the gaps along the italic slant (unItalicFactor 0.33), inserted candidate spaces, and kept the result only if the dictionary scored it better. SE 5 ported that pass into the **nOCR loop only** — the binary image compare loop never got it.

- New shared `ItalicSpaceFixer` in LibUiLogic (moved out of `OcrViewModel`, which had the nOCR-typed copy), with a `CompareMatch` overload.
- The binary compare loop now attaches the `ImageSplitterItem2` to each match (SE 4 did; SE 5 dropped it, which is also why the rescue couldn't have run) and runs the same unknown-words-gated rescue as the nOCR loop.
- `CompareMatch.ImageSplitterItem` retyped from the dead libse `ImageSplitterItem` to `ImageSplitterItem2` (the 5-arg ctor was never called; the only reader is a null-check).

### l misread as i

The i/l disambiguation guards in the matcher are faithful SE 4 ports but gate on upright glyph dimensions, so they never fire on italics — same weakness in SE 4, where mature user DBs masked it. What SE 4 *did* have that SE 5 lost: unknown-word guessing via the replace list's `<PartialWords>` letter pairs. `OcrFixReplaceList2.CreateGuessesFromLetters` existed but was never called.

- Wire it into `OcrFixEngine.CheckAndFixWord` (same `word.Length > 4` gate as SE 4, behind the existing "try to guess unknown words" toggle). Guesses only win if the dictionary or names list confirms them — `Coiin` → `Colin` works because names count.
- `<PartialWords>` is now stored as a list of pairs instead of a dictionary: the same artifact legitimately maps to several readings, and the first-wins dictionary silently dropped duplicates (the shipped German `ii→ü` was dead behind `ii→tt`). This lets the new German `i→l` coexist with the existing `i→t`.

### Replace lists

- Whole words: `viei`/`Viei` → `viel`/`Viel`.
- Partial word pair `i→l` for the guesser.
- Two spell-check-gated regex rules (active whenever OCR fixing is on, no guess toggle needed): trailing `i→l` (`viei` → `viel`) and double `ii→ll` (`soii` → `soll`, `woiien` → `wollen`). Verified against the shipped file with a scratch harness: all sample cases fix correctly and correct i-words (`Juni`, `Taxi`) are untouched via the already-spelled-correctly gate.
- Second commit extends the italic `i→l` regex pair and the `i→l` partial-word pair to all other Latin-script lists (dan, eng, fin, fra, hrb, hrv, hun, ita, nld, nob, nor, pol, por, spa, swe), with per-language letter classes; eng/spa/swe verified with the same harness.

### Tests

- `ItalicSpaceFixerTests` (6): insertion on wide slanted gaps, no insertion when the gap has pixels/is narrow/text is upright, no double spaces, nOCR overload parity.
- `OcrFixReplaceListPartialWordGuessTests` (4): duplicate `from` keys all generate guesses, `Coiin`→`Colin`, cumulative chain repairs double-l words from the single `i→l` pair, exact duplicate pairs load once.
- Full suites pass: LibUiLogic 215, UI 2799, seconv 364.

Not covered here (follow-up candidates): the same rescue for the batch-convert and seconv binary OCR paths (they run without a dictionary loaded, which the rescue needs for scoring), and the SE 5 default "number of pixels is space" being 12 where SE 4 shipped 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

