### PR TITLE
Auto-translate: add reset-to-default button for the prompt

### DIFF
--- a/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedSettingsViewModel.cs
+++ b/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedSettingsViewModel.cs
@@ -88,6 +88,12 @@ public partial class LlamaCppAdvancedSettingsViewModel : ObservableObject
         Window?.Close();
     }
 
+    [RelayCommand]
+    private void ResetPrompt()
+    {
+        Prompt = LlamaCppAdvancedProtocol.DefaultPrompt;
+    }
+
     internal void OnKeyDown(KeyEventArgs e)
     {
         if (e.Key == Key.Escape)

--- a/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedSettingsWindow.cs
+++ b/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedSettingsWindow.cs
@@ -94,7 +94,20 @@ public class LlamaCppAdvancedSettingsWindow : Window
         var promptBox = MakeMultilineTextBox(vm, nameof(vm.Prompt), 56);
         promptBox.PlaceholderText = LlamaCppAdvancedProtocol.DefaultPrompt;
         SetHint(promptBox, Se.Language.Translate.CustomPromptHint);
-        AddRow(grid, 2, Se.Language.Translate.PromptText, promptBox);
+        // The prompt label carries the reset button, so the editor column keeps its full width.
+        var promptLabel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 5,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children =
+            {
+                MakeSmallLabel(Se.Language.Translate.PromptText),
+                UiUtil.MakeButton(vm.ResetPromptCommand, IconNames.Restore, Se.Language.Translate.ResetPromptToDefault),
+            },
+        };
+        grid.Add(promptLabel, 2, 0);
+        grid.Add(promptBox, 2, 1);
 
         AddRow(grid, 3, Se.Language.Translate.PreviousLinesAsContext,
             UiUtil.MakeNumericUpDownInt(0, 50, 12, 120, vm, nameof(vm.HistoryPairs)));

--- a/src/ui/Features/Translate/TranslateSettingsViewModel.cs
+++ b/src/ui/Features/Translate/TranslateSettingsViewModel.cs
@@ -43,6 +43,21 @@ public partial class TranslateSettingsViewModel : ObservableObject
     }
 
     [RelayCommand]
+    private void ResetPrompt()
+    {
+        if (AutoTranslator == null)
+        {
+            return;
+        }
+
+        var defaultPrompt = GetPrompt(new SeAutoTranslate(), AutoTranslator.GetType());
+        if (defaultPrompt != null)
+        {
+            PromptText = defaultPrompt;
+        }
+    }
+
+    [RelayCommand]
     private async Task Ok()
     {
         if (AutoTranslator == null)
@@ -201,114 +216,92 @@ public partial class TranslateSettingsViewModel : ObservableObject
         PromptIsVisible = true;
 
         var engineType = AutoTranslator.GetType();
-        if (engineType == typeof(ChatGptTranslate))
-        {
-            PromptText = Se.Settings.AutoTranslate.ChatGptPrompt;
-            if (string.IsNullOrWhiteSpace(PromptText))
-            {
-                PromptText = new SeAutoTranslate().ChatGptPrompt;
-            }
-        }
-        else if (engineType == typeof(OpenAiCompatibleTranslate))
-        {
-            PromptText = Se.Settings.AutoTranslate.OpenAiCompatiblePrompt;
-            if (string.IsNullOrWhiteSpace(PromptText))
-            {
-                PromptText = new SeAutoTranslate().OpenAiCompatiblePrompt;
-            }
-        }
-        else if (engineType == typeof(OllamaTranslate))
-        {
-            PromptText = Se.Settings.AutoTranslate.OllamaPrompt;
-            if (string.IsNullOrWhiteSpace(PromptText))
-            {
-                PromptText = new SeAutoTranslate().OllamaPrompt;
-            }
-        }
-        else if (engineType == typeof(LmStudioTranslate))
-        {
-            PromptText = Se.Settings.AutoTranslate.LmStudioPrompt;
-            if (string.IsNullOrWhiteSpace(PromptText))
-            {
-                PromptText = new SeAutoTranslate().LmStudioPrompt;
-            }
-        }
-        else if (engineType == typeof(AnthropicTranslate))
-        {
-            PromptText = Se.Settings.AutoTranslate.AnthropicPrompt;
-            if (string.IsNullOrWhiteSpace(PromptText))
-            {
-                PromptText = new SeAutoTranslate().AnthropicPrompt;
-            }
-        }
-        else if (engineType == typeof(PerplexityTranslate))
-        {
-            PromptText = Se.Settings.AutoTranslate.PerplexityPrompt;
-            if (string.IsNullOrWhiteSpace(PromptText))
-            {
-                PromptText = new SeAutoTranslate().PerplexityPrompt;
-            }
-        }
-        else if (engineType == typeof(GroqTranslate))
-        {
-            PromptText = Se.Settings.AutoTranslate.GroqPrompt;
-            if (string.IsNullOrWhiteSpace(PromptText))
-            {
-                PromptText = new SeAutoTranslate().GroqPrompt;
-            }
-        }
-        else if (engineType == typeof(OpenRouterTranslate))
-        {
-            PromptText = Se.Settings.AutoTranslate.OpenRouterPrompt;
-            if (string.IsNullOrWhiteSpace(PromptText))
-            {
-                PromptText = new SeAutoTranslate().OpenRouterPrompt;
-            }
-        }
-        else if (engineType == typeof(NvidiaTranslate))
-        {
-            PromptText = Se.Settings.AutoTranslate.NvidiaPrompt;
-            if (string.IsNullOrWhiteSpace(PromptText))
-            {
-                PromptText = new SeAutoTranslate().NvidiaPrompt;
-            }
-        }
-        else if (engineType == typeof(MistralTranslate))
-        {
-            PromptText = Se.Settings.AutoTranslate.MistralPrompt;
-            if (string.IsNullOrWhiteSpace(PromptText))
-            {
-                PromptText = new SeAutoTranslate().MistralPrompt;
-            }
-        }
-        else if (engineType == typeof(GeminiTranslate))
-        {
-            PromptText = Se.Settings.AutoTranslate.GeminiPrompt;
-            if (string.IsNullOrWhiteSpace(PromptText))
-            {
-                PromptText = new SeAutoTranslate().GeminiPrompt;
-            }
-        }
-        else if (engineType == typeof(DeepSeekTranslate))
-        {
-            PromptText = Se.Settings.AutoTranslate.DeepSeekPrompt;
-            if (string.IsNullOrWhiteSpace(PromptText))
-            {
-                PromptText = new SeAutoTranslate().DeepSeekPrompt;
-            }
-        }
-        else if (engineType == typeof(LlamaCppTranslate))
-        {
-            PromptText = Se.Settings.AutoTranslate.LlamaCppPrompt;
-            if (string.IsNullOrWhiteSpace(PromptText))
-            {
-                PromptText = new SeAutoTranslate().LlamaCppPrompt;
-            }
-        }
-        else
+        var defaultPrompt = GetPrompt(new SeAutoTranslate(), engineType);
+        if (defaultPrompt == null)
         {
             PromptIsVisible = false;
+            return;
         }
+
+        PromptText = GetPrompt(Se.Settings.AutoTranslate, engineType) ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(PromptText))
+        {
+            PromptText = defaultPrompt;
+        }
+    }
+
+    /// <summary>
+    /// Returns the prompt of the given settings object for the engine, or null if the engine has no prompt.
+    /// Pass a fresh <see cref="SeAutoTranslate"/> for the built-in default, or the current settings for the saved one.
+    /// </summary>
+    private static string? GetPrompt(SeAutoTranslate settings, Type engineType)
+    {
+        if (engineType == typeof(ChatGptTranslate))
+        {
+            return settings.ChatGptPrompt;
+        }
+
+        if (engineType == typeof(OpenAiCompatibleTranslate))
+        {
+            return settings.OpenAiCompatiblePrompt;
+        }
+
+        if (engineType == typeof(OllamaTranslate))
+        {
+            return settings.OllamaPrompt;
+        }
+
+        if (engineType == typeof(LmStudioTranslate))
+        {
+            return settings.LmStudioPrompt;
+        }
+
+        if (engineType == typeof(AnthropicTranslate))
+        {
+            return settings.AnthropicPrompt;
+        }
+
+        if (engineType == typeof(PerplexityTranslate))
+        {
+            return settings.PerplexityPrompt;
+        }
+
+        if (engineType == typeof(GroqTranslate))
+        {
+            return settings.GroqPrompt;
+        }
+
+        if (engineType == typeof(OpenRouterTranslate))
+        {
+            return settings.OpenRouterPrompt;
+        }
+
+        if (engineType == typeof(NvidiaTranslate))
+        {
+            return settings.NvidiaPrompt;
+        }
+
+        if (engineType == typeof(MistralTranslate))
+        {
+            return settings.MistralPrompt;
+        }
+
+        if (engineType == typeof(GeminiTranslate))
+        {
+            return settings.GeminiPrompt;
+        }
+
+        if (engineType == typeof(DeepSeekTranslate))
+        {
+            return settings.DeepSeekPrompt;
+        }
+
+        if (engineType == typeof(LlamaCppTranslate))
+        {
+            return settings.LlamaCppPrompt;
+        }
+
+        return null;
     }
 
     public void OnKeyDown(KeyEventArgs e)

--- a/src/ui/Features/Translate/TranslateSettingsWindow.cs
+++ b/src/ui/Features/Translate/TranslateSettingsWindow.cs
@@ -58,7 +58,16 @@ public class TranslateSettingsWindow : Window
         maxBytesNumericUpDown.Increment = 100;
         maxBytesNumericUpDown.FormatString = "#,###,##0";
 
-        var labelPrompt = UiUtil.MakeTextBlock(Se.Language.Translate.PromptText, vm, null, nameof(vm.PromptIsVisible));
+        var labelPrompt = UiUtil.MakeTextBlock(Se.Language.Translate.PromptText);
+        var buttonResetPrompt = UiUtil.MakeButton(vm.ResetPromptCommand, IconNames.Restore, Se.Language.Translate.ResetPromptToDefault);
+        var panelPrompt = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            VerticalAlignment = VerticalAlignment.Center,
+            Spacing = 5,
+            Children = { labelPrompt, buttonResetPrompt },
+        }.BindIsVisible(vm, nameof(vm.PromptIsVisible));
+
         var promptTextBox = new TextBox
         {
             AcceptsReturn = true,
@@ -109,10 +118,10 @@ public class TranslateSettingsWindow : Window
         Grid.SetColumn(maxBytesNumericUpDown, 1);
         row++;
 
-        grid.Children.Add(labelPrompt);
-        Grid.SetRow(labelPrompt, row);
-        Grid.SetColumn(labelPrompt, 0);
-        Grid.SetColumnSpan(labelPrompt, 2);
+        grid.Children.Add(panelPrompt);
+        Grid.SetRow(panelPrompt, row);
+        Grid.SetColumn(panelPrompt, 0);
+        Grid.SetColumnSpan(panelPrompt, 2);
         row++;
 
         grid.Children.Add(promptTextBox);

--- a/src/ui/Logic/Config/Language/Translate/LanguageTranslate.cs
+++ b/src/ui/Logic/Config/Language/Translate/LanguageTranslate.cs
@@ -15,6 +15,7 @@ public class LanguageTranslate
     public string DelayInSecondsBetweenRequests { get; set; }
     public string MaxBytesPerRequest { get; set; }
     public string PromptText { get; set; }
+    public string ResetPromptToDefault { get; set; }
     public string TranslateEachLineSeparately { get; set; }
     public string TranslationError { get; set; }
     public string TranslationFailedMessage { get; set; }
@@ -68,6 +69,7 @@ public class LanguageTranslate
         DelayInSecondsBetweenRequests = "Delay in seconds between requests";
         MaxBytesPerRequest = "Max bytes per request";
         PromptText = "Prompt text";
+        ResetPromptToDefault = "Reset prompt to default";
         TranslateEachLineSeparately = "Translate each line separately";
         TranslationError = "Translation error";
         TranslationFailedMessage = "{0} translation failed.";

--- a/src/ui/Logic/IconNames.cs
+++ b/src/ui/Logic/IconNames.cs
@@ -99,6 +99,7 @@ internal class IconNames
     public const string Regex = "mdi-regex";
     public const string Repeat = "mdi-repeat";
     public const string Refresh = "mdi-refresh";
+    public const string Restore = "mdi-restore";
     public const string ScaleBalance = "mdi-scale-balance";
     public const string SetMerge = "mdi-set-merge";
     public const string SetSplit = "mdi-set-split";

--- a/tests/UI/Features/TranslateSettingsResetPromptTests.cs
+++ b/tests/UI/Features/TranslateSettingsResetPromptTests.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.LogicalTree;
+using Nikse.SubtitleEdit.Features.Translate;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.UiLogic.AutoTranslate;
+
+namespace UITests.Features;
+
+/// <summary>
+/// The reset button in auto-translate advanced settings is an icon-only button built in code and only
+/// shown for engines that have a prompt, so a dropped child or a stale visibility binding would not
+/// show up in a build. These tests assert the button reaches the logical tree and that the command
+/// behind it puts the built-in prompt back in the text box.
+/// </summary>
+public class TranslateSettingsResetPromptTests : IDisposable
+{
+    // Every window opened by a test is closed again in Dispose: if a test stops early, an
+    // unclosed window would outlive the test and race with the headless session teardown.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private static Button? FindResetPromptButton(Control root)
+    {
+        return root.GetLogicalDescendants().OfType<Button>().FirstOrDefault(b =>
+            AutomationProperties.GetName(b) == Se.Language.Translate.ResetPromptToDefault);
+    }
+
+    [AvaloniaFact]
+    public void TranslateSettingsWindow_HasVisibleResetPromptButtonForPromptEngine()
+    {
+        var savedPrompt = Se.Settings.AutoTranslate.ChatGptPrompt;
+        try
+        {
+            var vm = new TranslateSettingsViewModel();
+            vm.LoadValues(new ChatGptTranslate());
+            var window = new TranslateSettingsWindow(vm);
+            _windows.Add(window);
+
+            var button = FindResetPromptButton(window);
+
+            Assert.True(vm.PromptIsVisible, "ChatGPT has a prompt, so the prompt row must be visible.");
+            Assert.NotNull(button);
+            Assert.True(button!.IsVisible);
+        }
+        finally
+        {
+            Se.Settings.AutoTranslate.ChatGptPrompt = savedPrompt;
+        }
+    }
+
+    [AvaloniaFact]
+    public void ResetPrompt_PutsBackTheBuiltInPrompt()
+    {
+        var savedPrompt = Se.Settings.AutoTranslate.ChatGptPrompt;
+        try
+        {
+            Se.Settings.AutoTranslate.ChatGptPrompt = "My own prompt from {0} to {1}";
+            var vm = new TranslateSettingsViewModel();
+            vm.LoadValues(new ChatGptTranslate());
+            Assert.Equal("My own prompt from {0} to {1}", vm.PromptText);
+
+            vm.ResetPromptCommand.Execute(null);
+
+            Assert.Equal(new SeAutoTranslate().ChatGptPrompt, vm.PromptText);
+        }
+        finally
+        {
+            Se.Settings.AutoTranslate.ChatGptPrompt = savedPrompt;
+        }
+    }
+
+    /// <summary>
+    /// Engines without a prompt hide the whole prompt row - the reset button must go with it, not
+    /// linger as a button that resets nothing.
+    /// </summary>
+    [AvaloniaFact]
+    public void TranslateSettingsWindow_HidesResetPromptButtonForEngineWithoutPrompt()
+    {
+        var vm = new TranslateSettingsViewModel();
+        vm.LoadValues(new GoogleTranslateV1());
+        var window = new TranslateSettingsWindow(vm);
+        _windows.Add(window);
+
+        Assert.False(vm.PromptIsVisible);
+        var button = FindResetPromptButton(window);
+        Assert.NotNull(button);
+        Assert.False(button!.IsEffectivelyVisible);
+    }
+}


### PR DESCRIPTION
Both prompt editors in auto-translate let you edit the prompt but gave no way back to the built-in text once it was changed. This adds a small ↺ icon button next to each **Prompt text** label:

- **Auto-translate → settings (cog)** — restores the built-in prompt of the currently selected engine (ChatGPT, Anthropic, Gemini, Ollama, llama.cpp, …).
- **Auto-translate → llama.cpp → Advanced…** — fills the box with `LlamaCppAdvancedProtocol.DefaultPrompt` (that box is normally empty, with the default only shown as placeholder text).

Both buttons use `mdi-restore` and carry the accessible name / hint "Reset prompt to default" (new `LanguageTranslate.ResetPromptToDefault` string).

The 13-engine if/else chain in `TranslateSettingsViewModel.LoadValues` is collapsed into one `GetPrompt(settings, engineType)` helper, used for both the saved prompt and the built-in default — the reset command and the loader read the same mapping, so they cannot drift apart.

## Testing

New headless tests in `tests/UI/Features/TranslateSettingsResetPromptTests.cs`:
- the button reaches the logical tree and is visible for an engine with a prompt,
- it is hidden for an engine without one (the whole prompt row hides),
- the command replaces a customized prompt with the built-in default.

All 10 tests in the related filter pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)