### PR TITLE
OCR: adaptive line height, nOCR un-italic retry, replace list section fix

### DIFF
--- a/Dictionaries/dan_OCRFixReplaceList.xml
+++ b/Dictionaries/dan_OCRFixReplaceList.xml
@@ -789,5 +789,11 @@
     <!-- Correct i-words are in the dictionary and protected by the gate.   -->
     <RegEx find="\b([A-ZÆØÅa-zæøå][a-zæøå]*)i\b" spellCheck="$1l" replaceWith="$1l" />
     <RegEx find="\b([A-ZÆØÅa-zæøå][a-zæøå]*)ii([a-zæøå]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
+
+    <!-- word-initial i to l (iove to love, iieber to lieber) -->
+    <RegEx find="\bi([a-zæøå]{2,})\b" spellCheck="l$1" replaceWith="l$1" />
+
+    <!-- word-initial ii to ll (iiegar to llegar) -->
+    <RegEx find="\bii([a-zæøå]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/deu_OCRFixReplaceList.xml
+++ b/Dictionaries/deu_OCRFixReplaceList.xml
@@ -7147,6 +7147,12 @@
     <!-- double ii→ll (soii → soll, woiien → wollen, Müii → Müll) -->
     <RegEx find="\b([A-ZÄÖÜa-zäöüß][a-zäöüß]*)ii([a-zäöüß]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
 
+    <!-- word-initial i to l (iove to love, iieber to lieber) -->
+    <RegEx find="\bi([a-zäöüß]{2,})\b" spellCheck="l$1" replaceWith="l$1" />
+
+    <!-- word-initial ii to ll (iiegar to llegar) -->
+    <RegEx find="\bii([a-zäöüß]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
+
     <!-- ============================================================ -->
     <!-- GERMAN GENITIVE / APOSTROPHE                                 -->
     <!-- Standard German genitive adds -s/-es with NO apostrophe:    -->

--- a/Dictionaries/eng_OCRFixReplaceList.xml
+++ b/Dictionaries/eng_OCRFixReplaceList.xml
@@ -3423,5 +3423,11 @@
 		<!-- Correct i-words are in the dictionary and protected by the gate.   -->
 		<RegEx find="\b([A-Za-z][a-z]*)i\b" spellCheck="$1l" replaceWith="$1l" />
 		<RegEx find="\b([A-Za-z][a-z]*)ii([a-z]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
+
+		<!-- word-initial i to l (iove to love, iieber to lieber) -->
+		<RegEx find="\bi([a-z]{2,})\b" spellCheck="l$1" replaceWith="l$1" />
+
+		<!-- word-initial ii to ll (iiegar to llegar) -->
+		<RegEx find="\bii([a-z]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
 	</RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/fin_OCRFixReplaceList.xml
+++ b/Dictionaries/fin_OCRFixReplaceList.xml
@@ -987,7 +987,9 @@
     <Word from="karkoituksen" to="karkotuksen" />
   </WholeWords>
   <PartialWordsAlways />
-  <PartialWords />
+  <PartialWords>
+    <WordPart from="i" to="l" />
+  </PartialWords>
   <WholeLines>
     <Line from="Katsokaa pa." to="Katsokaapa." />
     <Line from="Mik!&#xD;&#xA;&quot;&quot;e“9iräı" to="Mik!&#xD;&#xA;-Hengitä!" />
@@ -1030,13 +1032,16 @@
   <BeginLines />
   <EndLines />
   <RegularExpressions />
-  <PartialWords>
-    <WordPart from="i" to="l" />
-  </PartialWords>
   <RegularExpressionsIfSpelledCorrectly>
     <!-- Italic l misread as i (#13660): trailing i to l, double ii to ll.  -->
     <!-- Correct i-words are in the dictionary and protected by the gate.   -->
     <RegEx find="\b([A-ZÅÄÖa-zåäö][a-zåäö]*)i\b" spellCheck="$1l" replaceWith="$1l" />
     <RegEx find="\b([A-ZÅÄÖa-zåäö][a-zåäö]*)ii([a-zåäö]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
+
+    <!-- word-initial i to l (iove to love, iieber to lieber) -->
+    <RegEx find="\bi([a-zåäö]{2,})\b" spellCheck="l$1" replaceWith="l$1" />
+
+    <!-- word-initial ii to ll (iiegar to llegar) -->
+    <RegEx find="\bii([a-zåäö]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/fra_OCRFixReplaceList.xml
+++ b/Dictionaries/fra_OCRFixReplaceList.xml
@@ -246,7 +246,9 @@
     <Word from="ÿétrangle" to="s'étrangle" />
   </WholeWords>
   <PartialWordsAlways />
-  <PartialWords />
+  <PartialWords>
+    <WordPart from="i" to="l" />
+  </PartialWords>
   <WholeLines>
     <Line from="&quot;D'ac:c:ord.&quot;" to="&quot;D'accord.&quot;" />
     <Line from="“i QUÎ gagne, qui perd," to="ni qui gagne, qui perd," />
@@ -373,13 +375,16 @@
     <RegEx find="\bin([A-Z][a-zæøåöäéèàùâêîôûëïœç]+)\b" spellCheck="$1" replaceWith="in $1" />
 
   </RegularExpressionsIfSpelledCorrectly>
-  <PartialWords>
-    <WordPart from="i" to="l" />
-  </PartialWords>
   <RegularExpressionsIfSpelledCorrectly>
     <!-- Italic l misread as i (#13660): trailing i to l, double ii to ll.  -->
     <!-- Correct i-words are in the dictionary and protected by the gate.   -->
     <RegEx find="\b([A-ZÀÂÆÇÉÈÊËÎÏÔŒÙÛÜŸa-zàâæçéèêëîïôœùûüÿ][a-zàâæçéèêëîïôœùûüÿ]*)i\b" spellCheck="$1l" replaceWith="$1l" />
     <RegEx find="\b([A-ZÀÂÆÇÉÈÊËÎÏÔŒÙÛÜŸa-zàâæçéèêëîïôœùûüÿ][a-zàâæçéèêëîïôœùûüÿ]*)ii([a-zàâæçéèêëîïôœùûüÿ]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
+
+    <!-- word-initial i to l (iove to love, iieber to lieber) -->
+    <RegEx find="\bi([a-zàâæçéèêëîïôœùûüÿ]{2,})\b" spellCheck="l$1" replaceWith="l$1" />
+
+    <!-- word-initial ii to ll (iiegar to llegar) -->
+    <RegEx find="\bii([a-zàâæçéèêëîïôœùûüÿ]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/hrb_OCRFixReplaceList.xml
+++ b/Dictionaries/hrb_OCRFixReplaceList.xml
@@ -1223,7 +1223,9 @@
     <Word from="zvi" to="živi" />
   </WholeWords>
   <PartialWordsAlways />
-  <PartialWords />
+  <PartialWords>
+    <WordPart from="i" to="l" />
+  </PartialWords>
   <WholeLines />
   <PartialLinesAlways />
   <PartialLines>
@@ -1941,13 +1943,16 @@
     <RegEx find="Zurb" replaceWith="Žurb" />
     <RegEx find="zvucen" replaceWith="zvučen" />
   </RegularExpressions>
-  <PartialWords>
-    <WordPart from="i" to="l" />
-  </PartialWords>
   <RegularExpressionsIfSpelledCorrectly>
     <!-- Italic l misread as i (#13660): trailing i to l, double ii to ll.  -->
     <!-- Correct i-words are in the dictionary and protected by the gate.   -->
     <RegEx find="\b([A-ZČĆĐŠŽa-zčćđšž][a-zčćđšž]*)i\b" spellCheck="$1l" replaceWith="$1l" />
     <RegEx find="\b([A-ZČĆĐŠŽa-zčćđšž][a-zčćđšž]*)ii([a-zčćđšž]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
+
+    <!-- word-initial i to l (iove to love, iieber to lieber) -->
+    <RegEx find="\bi([a-zčćđšž]{2,})\b" spellCheck="l$1" replaceWith="l$1" />
+
+    <!-- word-initial ii to ll (iiegar to llegar) -->
+    <RegEx find="\bii([a-zčćđšž]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/hrv_OCRFixReplaceList.xml
+++ b/Dictionaries/hrv_OCRFixReplaceList.xml
@@ -6362,5 +6362,11 @@
     <!-- Correct i-words are in the dictionary and protected by the gate.   -->
     <RegEx find="\b([A-ZČĆĐŠŽa-zčćđšž][a-zčćđšž]*)i\b" spellCheck="$1l" replaceWith="$1l" />
     <RegEx find="\b([A-ZČĆĐŠŽa-zčćđšž][a-zčćđšž]*)ii([a-zčćđšž]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
+
+    <!-- word-initial i to l (iove to love, iieber to lieber) -->
+    <RegEx find="\bi([a-zčćđšž]{2,})\b" spellCheck="l$1" replaceWith="l$1" />
+
+    <!-- word-initial ii to ll (iiegar to llegar) -->
+    <RegEx find="\bii([a-zčćđšž]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/hun_OCRFixReplaceList.xml
+++ b/Dictionaries/hun_OCRFixReplaceList.xml
@@ -10,7 +10,9 @@
     <Word from="tegyéljégre" to="tegyél jégre" />
   </WholeWords>
   <PartialWordsAlways />
-  <PartialWords />
+  <PartialWords>
+    <WordPart from="i" to="l" />
+  </PartialWords>
   <WholeLines />
   <PartialLinesAlways />
   <PartialLines />
@@ -31,13 +33,16 @@
     <RegEx find="\b(?:II|ll)" replaceWith="Il" />
     <RegEx find="([\xf5\xfb])I" replaceWith="$1l" />
   </RegularExpressions>
-  <PartialWords>
-    <WordPart from="i" to="l" />
-  </PartialWords>
   <RegularExpressionsIfSpelledCorrectly>
     <!-- Italic l misread as i (#13660): trailing i to l, double ii to ll.  -->
     <!-- Correct i-words are in the dictionary and protected by the gate.   -->
     <RegEx find="\b([A-ZÁÉÍÓÖŐÚÜŰa-záéíóöőúüű][a-záéíóöőúüű]*)i\b" spellCheck="$1l" replaceWith="$1l" />
     <RegEx find="\b([A-ZÁÉÍÓÖŐÚÜŰa-záéíóöőúüű][a-záéíóöőúüű]*)ii([a-záéíóöőúüű]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
+
+    <!-- word-initial i to l (iove to love, iieber to lieber) -->
+    <RegEx find="\bi([a-záéíóöőúüű]{2,})\b" spellCheck="l$1" replaceWith="l$1" />
+
+    <!-- word-initial ii to ll (iiegar to llegar) -->
+    <RegEx find="\bii([a-záéíóöőúüű]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/ita_OCRFixReplaceList.xml
+++ b/Dictionaries/ita_OCRFixReplaceList.xml
@@ -71,5 +71,11 @@
     <!-- Correct i-words are in the dictionary and protected by the gate.   -->
     <RegEx find="\b([A-ZÀÈÉÌÒÓÙa-zàèéìòóù][a-zàèéìòóù]*)i\b" spellCheck="$1l" replaceWith="$1l" />
     <RegEx find="\b([A-ZÀÈÉÌÒÓÙa-zàèéìòóù][a-zàèéìòóù]*)ii([a-zàèéìòóù]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
+
+    <!-- word-initial i to l (iove to love, iieber to lieber) -->
+    <RegEx find="\bi([a-zàèéìòóù]{2,})\b" spellCheck="l$1" replaceWith="l$1" />
+
+    <!-- word-initial ii to ll (iiegar to llegar) -->
+    <RegEx find="\bii([a-zàèéìòóù]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/nld_OCRFixReplaceList.xml
+++ b/Dictionaries/nld_OCRFixReplaceList.xml
@@ -353,5 +353,11 @@
     <!-- Correct i-words are in the dictionary and protected by the gate.   -->
     <RegEx find="\b([A-ZÉÈÊËÏÖÜa-zéèêëïöü][a-zéèêëïöü]*)i\b" spellCheck="$1l" replaceWith="$1l" />
     <RegEx find="\b([A-ZÉÈÊËÏÖÜa-zéèêëïöü][a-zéèêëïöü]*)ii([a-zéèêëïöü]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
+
+    <!-- word-initial i to l (iove to love, iieber to lieber) -->
+    <RegEx find="\bi([a-zéèêëïöü]{2,})\b" spellCheck="l$1" replaceWith="l$1" />
+
+    <!-- word-initial ii to ll (iiegar to llegar) -->
+    <RegEx find="\bii([a-zéèêëïöü]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/nob_OCRFixReplaceList.xml
+++ b/Dictionaries/nob_OCRFixReplaceList.xml
@@ -189,5 +189,11 @@
     <!-- Correct i-words are in the dictionary and protected by the gate.   -->
     <RegEx find="\b([A-ZÆØÅa-zæøå][a-zæøå]*)i\b" spellCheck="$1l" replaceWith="$1l" />
     <RegEx find="\b([A-ZÆØÅa-zæøå][a-zæøå]*)ii([a-zæøå]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
+
+    <!-- word-initial i to l (iove to love, iieber to lieber) -->
+    <RegEx find="\bi([a-zæøå]{2,})\b" spellCheck="l$1" replaceWith="l$1" />
+
+    <!-- word-initial ii to ll (iiegar to llegar) -->
+    <RegEx find="\bii([a-zæøå]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/nor_OCRFixReplaceList.xml
+++ b/Dictionaries/nor_OCRFixReplaceList.xml
@@ -186,5 +186,11 @@
     <!-- Correct i-words are in the dictionary and protected by the gate.   -->
     <RegEx find="\b([A-ZÆØÅa-zæøå][a-zæøå]*)i\b" spellCheck="$1l" replaceWith="$1l" />
     <RegEx find="\b([A-ZÆØÅa-zæøå][a-zæøå]*)ii([a-zæøå]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
+
+    <!-- word-initial i to l (iove to love, iieber to lieber) -->
+    <RegEx find="\bi([a-zæøå]{2,})\b" spellCheck="l$1" replaceWith="l$1" />
+
+    <!-- word-initial ii to ll (iiegar to llegar) -->
+    <RegEx find="\bii([a-zæøå]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/pol_OCRFixReplaceList.xml
+++ b/Dictionaries/pol_OCRFixReplaceList.xml
@@ -23,5 +23,11 @@
     <!-- Correct i-words are in the dictionary and protected by the gate.   -->
     <RegEx find="\b([A-ZĄĆĘŁŃÓŚŹŻa-ząćęłńóśźż][a-ząćęłńóśźż]*)i\b" spellCheck="$1l" replaceWith="$1l" />
     <RegEx find="\b([A-ZĄĆĘŁŃÓŚŹŻa-ząćęłńóśźż][a-ząćęłńóśźż]*)ii([a-ząćęłńóśźż]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
+
+    <!-- word-initial i to l (iove to love, iieber to lieber) -->
+    <RegEx find="\bi([a-ząćęłńóśźż]{2,})\b" spellCheck="l$1" replaceWith="l$1" />
+
+    <!-- word-initial ii to ll (iiegar to llegar) -->
+    <RegEx find="\bii([a-ząćęłńóśźż]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/por_OCRFixReplaceList.xml
+++ b/Dictionaries/por_OCRFixReplaceList.xml
@@ -467,7 +467,9 @@
     <Word from="zum-zum" to="zunzum" />
   </WholeWords>
   <PartialWordsAlways />
-  <PartialWords />
+  <PartialWords>
+    <WordPart from="i" to="l" />
+  </PartialWords>
   <WholeLines />
   <PartialLinesAlways />
   <PartialLines>
@@ -529,13 +531,16 @@
     <RegEx find="\bkil(ogramas?|ómetros?)" replaceWith="quil$1" />
     <RegEx find="\bKil(ogramas?|ómetros?)" replaceWith="Quil$1" />
   </RegularExpressions>
-  <PartialWords>
-    <WordPart from="i" to="l" />
-  </PartialWords>
   <RegularExpressionsIfSpelledCorrectly>
     <!-- Italic l misread as i (#13660): trailing i to l, double ii to ll.  -->
     <!-- Correct i-words are in the dictionary and protected by the gate.   -->
     <RegEx find="\b([A-ZÀÁÂÃÇÉÊÍÓÔÕÚa-zàáâãçéêíóôõú][a-zàáâãçéêíóôõú]*)i\b" spellCheck="$1l" replaceWith="$1l" />
     <RegEx find="\b([A-ZÀÁÂÃÇÉÊÍÓÔÕÚa-zàáâãçéêíóôõú][a-zàáâãçéêíóôõú]*)ii([a-zàáâãçéêíóôõú]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
+
+    <!-- word-initial i to l (iove to love, iieber to lieber) -->
+    <RegEx find="\bi([a-zàáâãçéêíóôõú]{2,})\b" spellCheck="l$1" replaceWith="l$1" />
+
+    <!-- word-initial ii to ll (iiegar to llegar) -->
+    <RegEx find="\bii([a-zàáâãçéêíóôõú]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/spa_OCRFixReplaceList.xml
+++ b/Dictionaries/spa_OCRFixReplaceList.xml
@@ -368,7 +368,9 @@
     <Word from="Ilámame" to="llámame" />
   </WholeWords>
   <PartialWordsAlways />
-  <PartialWords />
+  <PartialWords>
+    <WordPart from="i" to="l" />
+  </PartialWords>
   <WholeLines>
     <!-- Todas las líneas -->
     <Line from="No" to="No." />
@@ -952,13 +954,16 @@
     <RegEx find="\bIes\b" replaceWith="les" />
     <RegEx find="\bIos\b" replaceWith="los" />
   </RegularExpressions>
-  <PartialWords>
-    <WordPart from="i" to="l" />
-  </PartialWords>
   <RegularExpressionsIfSpelledCorrectly>
     <!-- Italic l misread as i (#13660): trailing i to l, double ii to ll.  -->
     <!-- Correct i-words are in the dictionary and protected by the gate.   -->
     <RegEx find="\b([A-ZÁÉÍÓÚÑÜa-záéíóúñü][a-záéíóúñü]*)i\b" spellCheck="$1l" replaceWith="$1l" />
     <RegEx find="\b([A-ZÁÉÍÓÚÑÜa-záéíóúñü][a-záéíóúñü]*)ii([a-záéíóúñü]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
+
+    <!-- word-initial i to l (iove to love, iieber to lieber) -->
+    <RegEx find="\bi([a-záéíóúñü]{2,})\b" spellCheck="l$1" replaceWith="l$1" />
+
+    <!-- word-initial ii to ll (iiegar to llegar) -->
+    <RegEx find="\bii([a-záéíóúñü]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/swe_OCRFixReplaceList.xml
+++ b/Dictionaries/swe_OCRFixReplaceList.xml
@@ -596,5 +596,11 @@
     <!-- Correct i-words are in the dictionary and protected by the gate.   -->
     <RegEx find="\b([A-ZÅÄÖa-zåäö][a-zåäö]*)i\b" spellCheck="$1l" replaceWith="$1l" />
     <RegEx find="\b([A-ZÅÄÖa-zåäö][a-zåäö]*)ii([a-zåäö]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
+
+    <!-- word-initial i to l (iove to love, iieber to lieber) -->
+    <RegEx find="\bi([a-zåäö]{2,})\b" spellCheck="l$1" replaceWith="l$1" />
+
+    <!-- word-initial ii to ll (iiegar to llegar) -->
+    <RegEx find="\bii([a-zåäö]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/src/libuilogic/Ocr/FixEngine/OcrFixReplaceList2.cs
+++ b/src/libuilogic/Ocr/FixEngine/OcrFixReplaceList2.cs
@@ -226,8 +226,16 @@ namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine
                 return list;
             }
 
-            var node = doc.DocumentElement?.SelectSingleNode(name);
-            if (node != null)
+            // SelectNodes, not SelectSingleNode: several shipped lists contain more than one
+            // section with the same name (often an empty placeholder first), and reading only
+            // the first silently drops every entry in the others.
+            var nodes = doc.DocumentElement?.SelectNodes(name);
+            if (nodes == null)
+            {
+                return list;
+            }
+
+            foreach (XmlNode node in nodes)
             {
                 foreach (XmlNode item in node.ChildNodes)
                 {
@@ -256,8 +264,15 @@ namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine
                 return list;
             }
 
-            var node = doc.DocumentElement?.SelectSingleNode(name);
-            if (node != null)
+            // See LoadReplaceList: duplicate sections must all be read. fin/fra/hrb/hun/por/spa
+            // ship an empty <PartialWords /> placeholder ahead of the real section.
+            var nodes = doc.DocumentElement?.SelectNodes(name);
+            if (nodes == null)
+            {
+                return list;
+            }
+
+            foreach (XmlNode node in nodes)
             {
                 foreach (XmlNode item in node.ChildNodes)
                 {
@@ -286,8 +301,14 @@ namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine
                 return list;
             }
 
-            var node = doc.DocumentElement?.SelectSingleNode(name);
-            if (node != null)
+            // See LoadReplaceList: duplicate sections must all be read.
+            var nodes = doc.DocumentElement?.SelectNodes(name);
+            if (nodes == null)
+            {
+                return list;
+            }
+
+            foreach (XmlNode node in nodes)
             {
                 foreach (XmlNode item in node.ChildNodes)
                 {

--- a/src/libuilogic/Ocr/NOcrDb.cs
+++ b/src/libuilogic/Ocr/NOcrDb.cs
@@ -64,9 +64,10 @@ public class NOcrDb
         private readonly int _maxWrongPixels;
         private readonly bool _deepSeek;
         private readonly bool _lastDitch;
+        private readonly double _italicFactor;
         private readonly int _hashCode;
 
-        public MatchCacheKey(NikseBitmap2 bitmap, int topMargin, bool deepSeek, int maxWrongPixels, bool lastDitch)
+        public MatchCacheKey(NikseBitmap2 bitmap, int topMargin, bool deepSeek, int maxWrongPixels, bool lastDitch, double italicFactor)
         {
             _pixels = bitmap.GetPixelData().ToArray();
             _width = bitmap.Width;
@@ -74,6 +75,7 @@ public class NOcrDb
             _maxWrongPixels = maxWrongPixels;
             _deepSeek = deepSeek;
             _lastDitch = lastDitch;
+            _italicFactor = italicFactor;
 
             // FNV-1a over the pixel bytes plus the match parameters.
             var hash = unchecked((int)2166136261);
@@ -86,6 +88,7 @@ public class NOcrDb
             hash = unchecked((hash ^ _topMargin) * 16777619);
             hash = unchecked((hash ^ _maxWrongPixels) * 16777619);
             hash = unchecked((hash ^ (_deepSeek ? 1 : 0) ^ (_lastDitch ? 2 : 0)) * 16777619);
+            hash = unchecked((hash ^ _italicFactor.GetHashCode()) * 16777619);
             _hashCode = hash;
         }
 
@@ -97,6 +100,7 @@ public class NOcrDb
                    _maxWrongPixels == other._maxWrongPixels &&
                    _deepSeek == other._deepSeek &&
                    _lastDitch == other._lastDitch &&
+                   _italicFactor.Equals(other._italicFactor) &&
                    _pixels.AsSpan().SequenceEqual(other._pixels);
         }
 
@@ -444,14 +448,19 @@ public class NOcrDb
         return new OcrPoint(maximumX - minimumX, maximumY - minimumY);
     }
 
-    public NOcrChar? GetMatch(NikseBitmap2 parentBitmap, List<ImageSplitterItem2> list, ImageSplitterItem2 item, int topMargin, bool deepSeek, int maxWrongPixels, bool lastDitch = false)
+    /// <param name="italicFactor">
+    /// When greater than zero, a glyph that matches nothing upright is de-slanted by this factor
+    /// and matched again; a hit is returned as italic. Italic subtitles otherwise fail to match
+    /// against upright characters. Pass 0 to disable.
+    /// </param>
+    public NOcrChar? GetMatch(NikseBitmap2 parentBitmap, List<ImageSplitterItem2> list, ImageSplitterItem2 item, int topMargin, bool deepSeek, int maxWrongPixels, bool lastDitch = false, double italicFactor = 0)
     {
         if (item.NikseBitmap == null)
         {
             return null;
         }
 
-        var key = new MatchCacheKey(item.NikseBitmap, topMargin, deepSeek, maxWrongPixels, lastDitch);
+        var key = new MatchCacheKey(item.NikseBitmap, topMargin, deepSeek, maxWrongPixels, lastDitch, italicFactor);
         MatchCacheEntry? cached;
         lock (_lock)
         {
@@ -491,6 +500,23 @@ public class NOcrDb
         // GetMatchSingle re-scanned the whole single-character list a second time for every
         // glyph that wasn't an exact match.
         var single = GetMatchSingle(item.NikseBitmap, topMargin, deepSeek, maxWrongPixels, lastDitch, skipExactCheck: true);
+
+        if (single == null && italicFactor > 0)
+        {
+            // Nothing matched upright. Straighten the glyph and try once more - this is how an
+            // italic 'l' stops being read as an 'i'. A hit is italic by construction, so flag a
+            // copy; the database entry itself must stay upright.
+            var unItalic = item.NikseBitmap.UnItalic(italicFactor);
+            if (unItalic.Width > 0 && unItalic.Height > 0)
+            {
+                var italicMatch = GetMatchSingle(unItalic, topMargin, deepSeek, maxWrongPixels, lastDitch);
+                if (italicMatch != null)
+                {
+                    single = new NOcrChar(italicMatch) { Italic = true };
+                }
+            }
+        }
+
         CacheMatch(key, new MatchCacheEntry { SingleMatch = single });
         return single;
     }

--- a/src/libuilogic/Ocr/NikseBitmap2.cs
+++ b/src/libuilogic/Ocr/NikseBitmap2.cs
@@ -560,6 +560,68 @@ public class NikseBitmap2
         return 0;
     }
 
+    /// <summary>
+    /// Removes the slant from an italic glyph by shearing: the top row stays where it is and
+    /// every row below is shifted right in proportion to <paramref name="factor"/>, so a
+    /// right-leaning glyph is straightened. Transparent columns are then cropped off the sides
+    /// so the result can be compared against upright nOCR characters; the top is deliberately
+    /// left alone because callers match using the glyph's original top margin.
+    /// </summary>
+    /// <param name="factor">Slant as a fraction of the height, e.g. 0.2 for ~11 degrees.</param>
+    public NikseBitmap2 UnItalic(double factor)
+    {
+        // The extra 4 columns absorb the per-row rounding, matching what SE 4 reserved.
+        var maxShift = (int)(Height * factor);
+        var newWidth = Width + maxShift + 4;
+        var newWidthX4 = newWidth * 4;
+        var newBitmapData = new byte[Height * newWidthX4];
+        for (var y = 0; y < Height; y++)
+        {
+            var shift = (int)Math.Round(y * factor, MidpointRounding.AwayFromZero);
+            Buffer.BlockCopy(_bitmapData, y * _widthX4, newBitmapData, y * newWidthX4 + shift * 4, _widthX4);
+        }
+
+        return new NikseBitmap2(newWidth, Height, newBitmapData).CropTransparentSides();
+    }
+
+    /// <summary>
+    /// Returns a copy with fully transparent columns removed from the left and right edges.
+    /// Rows are untouched, so any vertical margin the caller tracks stays valid.
+    /// </summary>
+    public NikseBitmap2 CropTransparentSides()
+    {
+        var left = -1;
+        var right = -1;
+        for (var x = 0; x < Width; x++)
+        {
+            for (var y = 0; y < Height; y++)
+            {
+                if (GetAlpha(x, y) != 0)
+                {
+                    if (left < 0)
+                    {
+                        left = x;
+                    }
+
+                    right = x;
+                    break;
+                }
+            }
+        }
+
+        if (left < 0)
+        {
+            return new NikseBitmap2(this); // fully transparent - nothing to crop against
+        }
+
+        if (left == 0 && right == Width - 1)
+        {
+            return new NikseBitmap2(this);
+        }
+
+        return CopyRectangle(new NikseRectangle(left, 0, right - left + 1, Height));
+    }
+
     public void CropTop(int maximumCropping, SKColor transparentColor)
     {
         var done = false;

--- a/src/libuilogic/Ocr/NikseBitmapImageSplitter2.cs
+++ b/src/libuilogic/Ocr/NikseBitmapImageSplitter2.cs
@@ -657,6 +657,15 @@ public class NikseBitmapImageSplitter2
             while (x < bmpWidth)
             {
                 var currentY = y + yChange;
+                if (currentY < 0 || currentY >= bmpHeight)
+                {
+                    // The up/down slides can push the path past the bitmap when minLineHeight is
+                    // small (adaptive values go below 10 for DVD-sized fonts) - treat it like any
+                    // other blocked path instead of reading out of bounds.
+                    started = true;
+                    break;
+                }
+
                 var a1 = bmp.GetAlpha(x, currentY);
                 var a2 = currentY + 1 < bmpHeight ? bmp.GetAlpha(x, currentY + 1) : 0;
 

--- a/src/libuilogic/Ocr/OcrLineHeightTracker.cs
+++ b/src/libuilogic/Ocr/OcrLineHeightTracker.cs
@@ -1,0 +1,69 @@
+namespace Nikse.SubtitleEdit.UiLogic.Ocr;
+
+/// <summary>
+/// Tracks the average glyph height across an OCR run so the line splitter can be given an
+/// adaptive minimum line height (SE 4's GetMinLineHeight/UpdateLineHeights). A hardcoded
+/// value is simultaneously too large for DVD-sized fonts (a whole line fits under it, so
+/// two-line subtitles merge into one) and too small for 4K-sized fonts (the accent band on
+/// top of a line exceeds it and splits off as its own bogus line).
+/// </summary>
+public class OcrLineHeightTracker
+{
+    // Enough samples to be stable; matches SE 4's cap so one long movie doesn't keep summing.
+    private const int MaxSamples = 1000;
+
+    private readonly Lock _lock = new();
+    private long _total;
+    private int _count;
+
+    /// <summary>
+    /// Minimum line height used until enough letters have been seen:
+    /// 25 for Blu-ray sized sources, 12 otherwise (SE 4's values).
+    /// </summary>
+    public int FallbackMinLineHeight { get; set; } = 12;
+
+    public void Update(List<ImageSplitterItem2> letters)
+    {
+        lock (_lock)
+        {
+            if (_count >= MaxSamples)
+            {
+                return;
+            }
+
+            foreach (var letter in letters)
+            {
+                if (letter.NikseBitmap != null)
+                {
+                    _total += letter.NikseBitmap.Height;
+                    _count++;
+                }
+            }
+        }
+    }
+
+    public int GetMinLineHeight()
+    {
+        lock (_lock)
+        {
+            if (_count > 20)
+            {
+                return (int)Math.Round(_total / (double)_count * 0.9);
+            }
+
+            return FallbackMinLineHeight;
+        }
+    }
+
+    /// <summary>
+    /// Average glyph height, or -1 until enough letters have been seen. Passing this to the
+    /// splitter enables its aggressive rescue for lines whose glyphs touch across the gap.
+    /// </summary>
+    public double GetAverageLineHeight()
+    {
+        lock (_lock)
+        {
+            return _count > 20 ? _total / (double)_count : -1;
+        }
+    }
+}

--- a/src/seconv/Core/BinaryOcrOcrEngine.cs
+++ b/src/seconv/Core/BinaryOcrOcrEngine.cs
@@ -11,6 +11,7 @@ namespace SeConv.Core;
 /// </summary>
 internal sealed class BinaryOcrOcrEngine : IOcrEngine
 {
+    private readonly OcrLineHeightTracker _lineHeightTracker = new();
     public string Name => "binaryocr";
 
     private readonly BinaryOcrDb _db;
@@ -48,7 +49,9 @@ internal sealed class BinaryOcrOcrEngine : IOcrEngine
         parent.MakeTwoColor(200);
         parent.CropTop(0, new SKColor(0, 0, 0, 0));
         var letters = NikseBitmapImageSplitter2.SplitBitmapToLettersNew(
-            parent, PixelsAreSpaceDefault, rightToLeft: false, topToBottom: true, minLineHeight: 20, autoHeight: true);
+            parent, PixelsAreSpaceDefault, rightToLeft: false, topToBottom: true,
+            _lineHeightTracker.GetMinLineHeight(), autoHeight: true, _lineHeightTracker.GetAverageLineHeight());
+        _lineHeightTracker.Update(letters);
 
         var matches = new List<BinaryOcrMatcher.CompareMatch>();
         var i = 0;

--- a/src/seconv/Core/NOcrOcrEngine.cs
+++ b/src/seconv/Core/NOcrOcrEngine.cs
@@ -10,6 +10,7 @@ namespace SeConv.Core;
 /// </summary>
 internal sealed class NOcrOcrEngine : IOcrEngine
 {
+    private readonly OcrLineHeightTracker _lineHeightTracker = new();
     public string Name => "nocr";
     private readonly NOcrDb _db;
     private readonly NOcrCaseFixer _caseFixer = new();
@@ -42,7 +43,9 @@ internal sealed class NOcrOcrEngine : IOcrEngine
         parent.MakeTwoColor(200);
         parent.CropTop(0, new SKColor(0, 0, 0, 0));
         var letters = NikseBitmapImageSplitter2.SplitBitmapToLettersNew(
-            parent, PixelsAreSpaceDefault, rightToLeft: false, topToBottom: true, minLineHeight: 20, autoHeight: true);
+            parent, PixelsAreSpaceDefault, rightToLeft: false, topToBottom: true,
+            _lineHeightTracker.GetMinLineHeight(), autoHeight: true, _lineHeightTracker.GetAverageLineHeight());
+        _lineHeightTracker.Update(letters);
 
         var matches = new List<NOcrChar>();
         var i = 0;

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -173,6 +173,7 @@ public partial class OcrViewModel : ObservableObject
     public readonly List<SubtitleLineViewModel> OcredSubtitle;
 
     private IOcrSubtitle? _ocrSubtitle;
+    private OcrLineHeightTracker _lineHeightTracker = new();
     private List<OcrSubtitleItem> _allOcrSubtitleItems = new();
     private string _sourceFileName = string.Empty;
     private Iso639Dash2LanguageCode? _sourceLanguageIso;
@@ -1021,7 +1022,7 @@ public partial class OcrViewModel : ObservableObject
         nBmp.MakeTwoColor(200);
         nBmp.CropTop(0, new SKColor(0, 0, 0, 0));
         var letters =
-            NikseBitmapImageSplitter2.SplitBitmapToLettersNew(nBmp, SelectedNOcrPixelsAreSpace, false, true, 20, true);
+            NikseBitmapImageSplitter2.SplitBitmapToLettersNew(nBmp, SelectedNOcrPixelsAreSpace, false, true, _lineHeightTracker.GetMinLineHeight(), true, _lineHeightTracker.GetAverageLineHeight());
         var matches = new List<NOcrChar?>(new NOcrChar?[letters.Count]);
         var idx = 0;
         while (idx < letters.Count)
@@ -1074,7 +1075,7 @@ public partial class OcrViewModel : ObservableObject
         nBmp.MakeTwoColor(200);
         nBmp.CropTop(0, new SKColor(0, 0, 0, 0));
         var letters =
-            NikseBitmapImageSplitter2.SplitBitmapToLettersNew(nBmp, SelectedNOcrPixelsAreSpace, false, true, 20, true);
+            NikseBitmapImageSplitter2.SplitBitmapToLettersNew(nBmp, SelectedNOcrPixelsAreSpace, false, true, _lineHeightTracker.GetMinLineHeight(), true, _lineHeightTracker.GetAverageLineHeight());
         var matches = new List<BinaryOcrMatcher.CompareMatch?>();
         foreach (var splitterItem in letters)
         {
@@ -2999,14 +3000,16 @@ public partial class OcrViewModel : ObservableObject
             parentBitmap.MakeTwoColor(200);
             parentBitmap.CropTop(0, new SKColor(0, 0, 0, 0));
             var letters = NikseBitmapImageSplitter2.SplitBitmapToLettersNew(parentBitmap, SelectedNOcrPixelsAreSpace,
-                false, true, 20, true);
+                false, true, _lineHeightTracker.GetMinLineHeight(), true, _lineHeightTracker.GetAverageLineHeight());
+            _lineHeightTracker.Update(letters);
             var index = 0;
             while (index < letters.Count)
             {
                 var splitterItem = letters[index];
                 if (splitterItem.NikseBitmap != null)
                 {
-                    var match = _nOcrDb!.GetMatch(parentBitmap, letters, splitterItem, splitterItem.Top, true, SelectedNOcrMaxWrongPixels);
+                    var match = _nOcrDb!.GetMatch(parentBitmap, letters, splitterItem, splitterItem.Top, true, SelectedNOcrMaxWrongPixels,
+                        italicFactor: Se.Settings.Ocr.ItalicFactor);
                     if (match != null)
                     {
                         _nOcrCaseFixer.FixUppercaseLowercaseIssues(splitterItem, match);
@@ -3037,7 +3040,8 @@ public partial class OcrViewModel : ObservableObject
             parentBitmap.MakeTwoColor(200);
             parentBitmap.CropTop(0, new SKColor(0, 0, 0, 0));
             var letters = NikseBitmapImageSplitter2.SplitBitmapToLettersNew(parentBitmap, SelectedNOcrPixelsAreSpace,
-                false, true, 20, true);
+                false, true, _lineHeightTracker.GetMinLineHeight(), true, _lineHeightTracker.GetAverageLineHeight());
+            _lineHeightTracker.Update(letters);
             SelectedOcrSubtitleItem = item;
             var index = 0;
             var matches = new List<NOcrChar>();
@@ -3054,7 +3058,7 @@ public partial class OcrViewModel : ObservableObject
                 else
                 {
                     var match = _nOcrDb!.GetMatch(parentBitmap, letters, splitterItem, splitterItem.Top, true,
-                        SelectedNOcrMaxWrongPixels);
+                        SelectedNOcrMaxWrongPixels, italicFactor: Se.Settings.Ocr.ItalicFactor);
 
                     if (match == null && _nOcrFallbackBinaryOcrDb != null && _nOcrFallbackBinaryOcrMatcher != null)
                     {
@@ -3303,7 +3307,8 @@ public partial class OcrViewModel : ObservableObject
             var parentBitmap = new NikseBitmap2(bitmap);
             parentBitmap.MakeTwoColor(200);
             parentBitmap.CropTop(0, new SKColor(0, 0, 0, 0));
-            var letters = NikseBitmapImageSplitter2.SplitBitmapToLettersNew(parentBitmap, SelectedBinaryOcrPixelsAreSpace, false, true, 20, true);
+            var letters = NikseBitmapImageSplitter2.SplitBitmapToLettersNew(parentBitmap, SelectedBinaryOcrPixelsAreSpace, false, true, _lineHeightTracker.GetMinLineHeight(), true, _lineHeightTracker.GetAverageLineHeight());
+            _lineHeightTracker.Update(letters);
             SelectedOcrSubtitleItem = item;
             var index = 0;
             var matches = new List<BinaryOcrMatcher.CompareMatch>();
@@ -3324,7 +3329,8 @@ public partial class OcrViewModel : ObservableObject
 
                     if (match == null && _binaryOcrFallbackNOcrDb != null)
                     {
-                        var nMatch = _binaryOcrFallbackNOcrDb.GetMatch(parentBitmap, letters, splitterItem, splitterItem.Top, true, SelectedNOcrMaxWrongPixels, lastDitch: true);
+                        var nMatch = _binaryOcrFallbackNOcrDb.GetMatch(parentBitmap, letters, splitterItem, splitterItem.Top, true, SelectedNOcrMaxWrongPixels, lastDitch: true,
+                            italicFactor: Se.Settings.Ocr.ItalicFactor);
                         if (nMatch != null && !string.IsNullOrEmpty(nMatch.Text))
                         {
                             if (nMatch.ExpandCount > 0)
@@ -4666,6 +4672,13 @@ public partial class OcrViewModel : ObservableObject
         _allOcrSubtitleItems = _ocrSubtitle!.MakeOcrSubtitleItems();
         HasForcedSubtitles = _allOcrSubtitleItems.Any(p => p.IsForced);
         OcrSubtitleItems = new ObservableCollection<OcrSubtitleItem>(_allOcrSubtitleItems);
+
+        // New source, new glyph-height statistics (Blu-ray fonts are much larger than DVD's,
+        // so the pre-adaptation fallback differs - SE 4's 25 vs 12).
+        _lineHeightTracker = new OcrLineHeightTracker
+        {
+            FallbackMinLineHeight = _ocrSubtitle is OcrSubtitleBluRay or OcrSubtitleMkvBluRay ? 25 : 12,
+        };
     }
 
     partial void OnShowOnlyForcedChanged(bool value)

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -81,6 +81,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
 
     private readonly INOcrCaseFixer _nOcrCaseFixer;
     private readonly IBinaryOcrMatcher _binaryOcrMatcher;
+    private OcrLineHeightTracker _lineHeightTracker = new();
     private readonly INamesList _namesList;
     private string _namesListFolder = string.Empty;
     private string _namesListLanguage = string.Empty;
@@ -717,6 +718,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
 
     private void RunNOcr(IOcrSubtitle imageSubtitles, BatchConvertItem item, CancellationToken cancellationToken)
     {
+        _lineHeightTracker = new OcrLineHeightTracker { FallbackMinLineHeight = item.Format == FormatBluRaySup ? 25 : 12 };
         var fileName = Path.Combine(Se.OcrFolder, Se.Settings.Ocr.NOcrDatabase + ".nocr");
         var nOcrDb = new NOcrDb(fileName);
         var totalCount = imageSubtitles.Count;
@@ -814,7 +816,8 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         parentBitmap.MakeTwoColor(200);
         parentBitmap.CropTop(0, new SKColor(0, 0, 0, 0));
         var letters = NikseBitmapImageSplitter2.SplitBitmapToLettersNew(parentBitmap, pixelsAreSpace,
-            false, true, 20, true);
+            false, true, _lineHeightTracker.GetMinLineHeight(), true, _lineHeightTracker.GetAverageLineHeight());
+        _lineHeightTracker.Update(letters);
         var index = 0;
         var matches = new List<NOcrChar>();
         var maxErrorPercent = Se.Settings.Ocr.BinaryOcrMaxErrorPercent > 0 ? Se.Settings.Ocr.BinaryOcrMaxErrorPercent : 7.5;
@@ -919,6 +922,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
 
     private void RunBinaryOcr(IOcrSubtitle imageSubtitles, BatchConvertItem item, CancellationToken cancellationToken)
     {
+        _lineHeightTracker = new OcrLineHeightTracker { FallbackMinLineHeight = item.Format == FormatBluRaySup ? 25 : 12 };
         var dbName = string.IsNullOrEmpty(Se.Settings.Tools.BatchConvert.BinaryOcrDatabase)
             ? "Latin"
             : Se.Settings.Tools.BatchConvert.BinaryOcrDatabase;
@@ -1060,7 +1064,8 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         var parentBitmap = new NikseBitmap2(bitmap);
         parentBitmap.MakeTwoColor(200);
         parentBitmap.CropTop(0, new SKColor(0, 0, 0, 0));
-        var letters = NikseBitmapImageSplitter2.SplitBitmapToLettersNew(parentBitmap, pixelsAreSpace, false, true, 20, true);
+        var letters = NikseBitmapImageSplitter2.SplitBitmapToLettersNew(parentBitmap, pixelsAreSpace, false, true, _lineHeightTracker.GetMinLineHeight(), true, _lineHeightTracker.GetAverageLineHeight());
+        _lineHeightTracker.Update(letters);
         var index = 0;
         var matches = new List<BinaryOcrMatcher.CompareMatch>();
         while (index < letters.Count)
@@ -1117,6 +1122,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
 
     private static int? DetectPixelsIsSpace(IOcrSubtitle imageSubtitles, int sampleSize, CancellationToken cancellationToken)
     {
+        var lineHeightTracker = new OcrLineHeightTracker(); // static sweep, so track locally
         var gaps = new List<int>(1024);
         for (var i = 0; i < sampleSize; i++)
         {
@@ -1129,7 +1135,8 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             var parentBitmap = new NikseBitmap2(bitmap);
             parentBitmap.MakeTwoColor(200);
             parentBitmap.CropTop(0, new SKColor(0, 0, 0, 0));
-            var letters = NikseBitmapImageSplitter2.SplitBitmapToLettersNew(parentBitmap, 1, false, true, 20, true);
+            var letters = NikseBitmapImageSplitter2.SplitBitmapToLettersNew(parentBitmap, 1, false, true, lineHeightTracker.GetMinLineHeight(), true, lineHeightTracker.GetAverageLineHeight());
+            lineHeightTracker.Update(letters);
             foreach (var l in letters)
             {
                 if (l.NikseBitmap == null && l.SpecialCharacter == " " && l.SpacePixels > 0)

--- a/src/ui/Logic/Config/SeOcr.cs
+++ b/src/ui/Logic/Config/SeOcr.cs
@@ -35,6 +35,12 @@ public class SeOcr
     public int NOcrNoOfLinesToAutoDraw { get; set; }
     public int NOcrZoomFactor { get; set; }
     public string NOcrLineAlgorithm { get; set; }
+
+    /// <summary>
+    /// Slant, as a fraction of glyph height, used to straighten italic letters before matching
+    /// them again when they match nothing upright. 0 disables the retry.
+    /// </summary>
+    public double ItalicFactor { get; set; }
     public string PaddleOcrMode { get; set; }
     public string PaddleOcrLastLanguage { get; set; }
     public string TesseractLastLanguage { get; set; }
@@ -79,6 +85,7 @@ public class SeOcr
         NOcrNoOfLinesToAutoDraw = 60;
         NOcrZoomFactor = 4;
         NOcrLineAlgorithm = "Random";
+        ItalicFactor = 0.2; // SE 4's default
 
         BinaryOcrPixelsAreSpace = 12;
         BinaryOcrMaxErrorPercent = 7.5;

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixReplaceListPartialWordGuessTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixReplaceListPartialWordGuessTests.cs
@@ -61,6 +61,30 @@ public class OcrFixReplaceListPartialWordGuessTests
     }
 
     [Fact]
+    public void EmptyPlaceholderSection_DoesNotShadowTheRealSection()
+    {
+        // fin/fra/hrb/hun/por/spa ship an empty <PartialWords /> placeholder BEFORE the real
+        // section; reading only the first section silently dropped every entry (same bug class
+        // as #13658, which fixed it for the regex list only).
+        var path = Path.Combine(Path.GetTempPath(), $"guesstest_{Guid.NewGuid():N}_OCRFixReplaceList.xml");
+        File.WriteAllText(path,
+            "<ReplaceList><PartialWords /><OtherStuff /><PartialWords><WordPart from=\"i\" to=\"l\" /></PartialWords></ReplaceList>");
+        OcrFixReplaceList2 replaceList;
+        try
+        {
+            replaceList = new OcrFixReplaceList2(path);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+
+        var guesses = replaceList.CreateGuessesFromLetters("viei", "fra").ToList();
+
+        Assert.Contains("viel", guesses);
+    }
+
+    [Fact]
     public void ExactDuplicatePairs_AreLoadedOnce()
     {
         var replaceList = MakeReplaceList(

--- a/tests/libuilogic/Ocr/NOcrDbItalicRetryTests.cs
+++ b/tests/libuilogic/Ocr/NOcrDbItalicRetryTests.cs
@@ -1,0 +1,91 @@
+using Nikse.SubtitleEdit.UiLogic.Ocr;
+
+namespace LibUiLogicTests.Ocr;
+
+/// <summary>
+/// SE 4 had an "un-italic" retry in nOCR matching: a glyph that matched nothing upright was
+/// de-slanted by the italic factor and matched once more, with a hit returned as italic. The
+/// pass was lost in the SE 5 port, so italic subtitles produced unknown glyph after unknown
+/// glyph (#13660). These tests pin the restored behavior.
+/// </summary>
+public class NOcrDbItalicRetryTests
+{
+    private const double Slant = 0.25;
+
+    private static NikseBitmap2 MakeBar(bool italic)
+    {
+        // A 4x24 vertical bar; the italic variant leans right by Slant (top further right).
+        const int h = 24;
+        const int w = 4;
+        var maxShift = italic ? (int)(h * Slant) : 0;
+        var width = w + maxShift;
+        var data = new byte[width * h * 4];
+        for (var y = 0; y < h; y++)
+        {
+            var shift = italic ? (int)Math.Round((h - 1 - y) * Slant) : 0;
+            for (var x = 0; x < w; x++)
+            {
+                var i = (x + shift + y * width) * 4;
+                data[i] = data[i + 1] = data[i + 2] = data[i + 3] = 255;
+            }
+        }
+
+        return new NikseBitmap2(width, h, data);
+    }
+
+    private static NOcrDb MakeDbWithUprightBar()
+    {
+        var db = new NOcrDb(Path.Combine(Path.GetTempPath(), $"nocr_italic_test_{Guid.NewGuid():N}.nocr"));
+        var ch = new NOcrChar { Text = "l", Width = 4, Height = 24, MarginTop = 0 };
+        // Foreground strokes down the bar, background strokes just outside its corners.
+        ch.LinesForeground.Add(new NOcrLine(new OcrPoint(1, 1), new OcrPoint(1, 22)));
+        ch.LinesForeground.Add(new NOcrLine(new OcrPoint(2, 1), new OcrPoint(2, 22)));
+        db.Add(ch);
+        return db;
+    }
+
+    [Fact]
+    public void UprightBar_MatchesWithoutRetry()
+    {
+        var db = MakeDbWithUprightBar();
+        var bar = MakeBar(italic: false);
+        var item = new ImageSplitterItem2(0, 0, bar);
+        var letters = new List<ImageSplitterItem2> { item };
+
+        var match = db.GetMatch(bar, letters, item, 0, true, 6);
+
+        Assert.NotNull(match);
+        Assert.Equal("l", match.Text);
+        Assert.False(match.Italic);
+    }
+
+    [Fact]
+    public void ItalicBar_FailsUpright_ButMatchesViaUnItalicRetry()
+    {
+        var db = MakeDbWithUprightBar();
+        var bar = MakeBar(italic: true);
+        var item = new ImageSplitterItem2(0, 0, bar);
+        var letters = new List<ImageSplitterItem2> { item };
+
+        var upright = db.GetMatch(bar, letters, item, 0, true, 6);
+        Assert.Null(upright); // slanted glyph matches nothing upright
+
+        var retried = db.GetMatch(bar, letters, item, 0, true, 6, italicFactor: Slant);
+        Assert.NotNull(retried);
+        Assert.Equal("l", retried.Text);
+        Assert.True(retried.Italic); // the retry marks the hit as italic
+    }
+
+    [Fact]
+    public void ItalicRetry_DoesNotMutateTheDatabaseEntry()
+    {
+        var db = MakeDbWithUprightBar();
+        var bar = MakeBar(italic: true);
+        var item = new ImageSplitterItem2(0, 0, bar);
+        var letters = new List<ImageSplitterItem2> { item };
+
+        _ = db.GetMatch(bar, letters, item, 0, true, 6, italicFactor: Slant);
+
+        Assert.False(db.OcrCharacters[0].Italic); // the stored character stays upright
+    }
+}

--- a/tests/libuilogic/Ocr/NikseBitmap2UnItalicTests.cs
+++ b/tests/libuilogic/Ocr/NikseBitmap2UnItalicTests.cs
@@ -1,0 +1,78 @@
+using Nikse.SubtitleEdit.UiLogic.Ocr;
+
+namespace LibUiLogicTests.Ocr;
+
+public class NikseBitmap2UnItalicTests
+{
+    private static NikseBitmap2 MakeSlantedBar(int stemWidth, int height, double slant)
+    {
+        var maxShift = (int)(height * slant);
+        var width = stemWidth + maxShift;
+        var data = new byte[width * height * 4];
+        for (var y = 0; y < height; y++)
+        {
+            var shift = (int)Math.Round((height - 1 - y) * slant); // top leans right
+            for (var x = 0; x < stemWidth; x++)
+            {
+                var i = (x + shift + y * width) * 4;
+                data[i] = data[i + 1] = data[i + 2] = data[i + 3] = 255;
+            }
+        }
+
+        return new NikseBitmap2(width, height, data);
+    }
+
+    [Fact]
+    public void UnItalic_StraightensASlantedBar()
+    {
+        var italic = MakeSlantedBar(3, 20, 0.25);
+        Assert.Equal(8, italic.Width); // sanity: the slant widened the bounding box
+
+        var straight = italic.UnItalic(0.25);
+
+        // Every row's first opaque column must now line up (within 1px of shear rounding).
+        var firstOpaque = new List<int>();
+        for (var y = 0; y < straight.Height; y++)
+        {
+            for (var x = 0; x < straight.Width; x++)
+            {
+                if (straight.GetAlpha(x, y) != 0)
+                {
+                    firstOpaque.Add(x);
+                    break;
+                }
+            }
+        }
+
+        Assert.Equal(straight.Height, firstOpaque.Count); // no row lost its pixels
+        Assert.True(firstOpaque.Max() - firstOpaque.Min() <= 1, "bar is still slanted");
+        Assert.True(straight.Width <= 4, $"transparent slack not cropped: width {straight.Width}");
+    }
+
+    [Fact]
+    public void CropTransparentSides_RemovesOnlyColumns()
+    {
+        var bmp = new NikseBitmap2(10, 6);
+        var data = new byte[10 * 6 * 4];
+        // one opaque pixel at (4, 2)
+        var idx = (4 + 2 * 10) * 4;
+        data[idx] = data[idx + 1] = data[idx + 2] = data[idx + 3] = 255;
+        bmp = new NikseBitmap2(10, 6, data);
+
+        var cropped = bmp.CropTransparentSides();
+
+        Assert.Equal(1, cropped.Width);
+        Assert.Equal(6, cropped.Height); // rows untouched, vertical margin preserved
+        Assert.NotEqual(0, cropped.GetAlpha(0, 2));
+    }
+
+    [Fact]
+    public void CropTransparentSides_FullyTransparent_ReturnsSameSize()
+    {
+        var bmp = new NikseBitmap2(7, 5);
+        var cropped = bmp.CropTransparentSides();
+
+        Assert.Equal(7, cropped.Width);
+        Assert.Equal(5, cropped.Height);
+    }
+}

--- a/tests/libuilogic/Ocr/OcrLineHeightTrackerTests.cs
+++ b/tests/libuilogic/Ocr/OcrLineHeightTrackerTests.cs
@@ -1,0 +1,61 @@
+using Nikse.SubtitleEdit.UiLogic.Ocr;
+
+namespace LibUiLogicTests.Ocr;
+
+/// <summary>
+/// The line splitter's minimum line height was hardcoded to 20, which is simultaneously too
+/// large for DVD-sized fonts (a whole line fits under it, so two-line subtitles merged into a
+/// handful of unreadable blobs) and too small for 4K-sized fonts (the accent band split off as
+/// a bogus extra line). The tracker restores SE 4's adaptive behavior.
+/// </summary>
+public class OcrLineHeightTrackerTests
+{
+    private static ImageSplitterItem2 Letter(int height)
+    {
+        return new ImageSplitterItem2(0, 0, new NikseBitmap2(8, height));
+    }
+
+    [Fact]
+    public void BeforeAdaptation_UsesFallback()
+    {
+        var tracker = new OcrLineHeightTracker { FallbackMinLineHeight = 25 };
+
+        Assert.Equal(25, tracker.GetMinLineHeight());
+        Assert.Equal(-1, tracker.GetAverageLineHeight());
+    }
+
+    [Fact]
+    public void NeedsMoreThanTwentyLetters_ToAdapt()
+    {
+        var tracker = new OcrLineHeightTracker();
+        tracker.Update(Enumerable.Range(0, 20).Select(_ => Letter(40)).ToList());
+
+        Assert.Equal(12, tracker.GetMinLineHeight()); // still the fallback
+        Assert.Equal(-1, tracker.GetAverageLineHeight());
+    }
+
+    [Fact]
+    public void AfterAdaptation_ReturnsNinetyPercentOfAverage()
+    {
+        var tracker = new OcrLineHeightTracker();
+        tracker.Update(Enumerable.Range(0, 30).Select(_ => Letter(40)).ToList());
+
+        Assert.Equal(36, tracker.GetMinLineHeight()); // 40 * 0.9
+        Assert.Equal(40, tracker.GetAverageLineHeight());
+    }
+
+    [Fact]
+    public void SpacesAndNewlines_DoNotCountAsLetters()
+    {
+        var tracker = new OcrLineHeightTracker();
+        var letters = new List<ImageSplitterItem2> { new(" "), new(Environment.NewLine) };
+        for (var i = 0; i < 25; i++)
+        {
+            letters.Add(Letter(30));
+        }
+
+        tracker.Update(letters);
+
+        Assert.Equal(27, tracker.GetMinLineHeight()); // 30 * 0.9, specials ignored
+    }
+}

--- a/tests/libuilogic/Ocr/SplitBitmapAdaptiveLineHeightTests.cs
+++ b/tests/libuilogic/Ocr/SplitBitmapAdaptiveLineHeightTests.cs
@@ -1,0 +1,79 @@
+using Nikse.SubtitleEdit.UiLogic.Ocr;
+
+namespace LibUiLogicTests.Ocr;
+
+/// <summary>
+/// The OCR loops used to pass a hardcoded minLineHeight of 20 to the splitter. A DVD-sized
+/// two-line subtitle (per-line ink height under ~21px) then swallowed the blank gap between
+/// its lines and OCR'ed both lines as a handful of merged blobs. These tests use synthetic
+/// block "text" so they are font-independent, and pin the behavior the adaptive
+/// OcrLineHeightTracker restores.
+/// </summary>
+public class SplitBitmapAdaptiveLineHeightTests
+{
+    /// <summary>Two lines of 3 blocks each; each block 10x14 px, 6 px apart, lines 4 px apart.</summary>
+    private static NikseBitmap2 MakeTwoLineBitmap()
+    {
+        const int blockW = 10, blockH = 14, gapX = 6, gapY = 4, blocks = 3;
+        var width = blocks * blockW + (blocks - 1) * gapX + 2;
+        var height = blockH * 2 + gapY;
+        var data = new byte[width * height * 4];
+
+        void Block(int left, int top)
+        {
+            for (var y = top; y < top + blockH; y++)
+            {
+                for (var x = left; x < left + blockW; x++)
+                {
+                    var i = (x + y * width) * 4;
+                    data[i] = data[i + 1] = data[i + 2] = data[i + 3] = 255;
+                }
+            }
+        }
+
+        for (var b = 0; b < blocks; b++)
+        {
+            Block(1 + b * (blockW + gapX), 0);           // line 1
+            Block(1 + b * (blockW + gapX), blockH + gapY); // line 2
+        }
+
+        return new NikseBitmap2(width, height, data);
+    }
+
+    [Fact]
+    public void DvdSizedTwoLines_AdaptiveMinLineHeight_KeepsTheLineBreak()
+    {
+        var bmp = MakeTwoLineBitmap();
+
+        // 12 = the tracker's pre-adaptation fallback for DVD-sized sources.
+        var items = NikseBitmapImageSplitter2.SplitBitmapToLettersNew(bmp, 3, false, true, 12, true);
+
+        Assert.Equal(6, items.Count(p => p.NikseBitmap != null));
+        Assert.Equal(1, items.Count(p => p.SpecialCharacter == Environment.NewLine));
+    }
+
+    [Fact]
+    public void DvdSizedTwoLines_HardcodedTwenty_MergesThem()
+    {
+        // Documents the defect the adaptive height fixes: with the old hardcoded 20, the same
+        // bitmap loses its line break because each line's 14px ink height fits under the limit.
+        var bmp = MakeTwoLineBitmap();
+
+        var items = NikseBitmapImageSplitter2.SplitBitmapToLettersNew(bmp, 3, false, true, 20, true);
+
+        Assert.Equal(0, items.Count(p => p.SpecialCharacter == Environment.NewLine));
+    }
+
+    [Fact]
+    public void SplitToLinesNew_SmallMinLineHeight_DoesNotThrow()
+    {
+        // The up/down slides in SplitToLinesNew could read out of bounds once minLineHeight
+        // goes below ~10 (now reachable via the adaptive tracker).
+        var bmp = MakeTwoLineBitmap();
+        foreach (var minLineHeight in new[] { 4, 5, 6, 7, 8, 9, 10 })
+        {
+            var items = NikseBitmapImageSplitter2.SplitBitmapToLettersNew(bmp, 3, false, true, minLineHeight, true);
+            Assert.NotEmpty(items);
+        }
+    }
+}


### PR DESCRIPTION
Three OCR quality fixes from a systematic hunt comparing the SE 5 pipeline against SE 4 (`771236c50^`), following up on #13660 / #13670.

### 1. Adaptive minimum line height (both engines, batch convert, seconv)

Every SE 5 splitter call site hardcoded `minLineHeight: 20`; SE 4 used an adaptive `GetMinLineHeight()` (average glyph height × 0.9 after 20 letters, fallback 25 for Blu-ray / 12 otherwise) plus a running average line height. Measured consequences of the hardcoded value (real splitter on synthetic renders):

| scenario | hardcoded 20 | adaptive |
|---|---|---|
| DVD-size two-line sub (14–20px ink height) | **5–7 merged blobs, line break lost** | 17–20 letters + line break |
| 4K line with diacritics (130px font) | accent band splits off as bogus extra line | correct |

The never-passed `averageLineHeight` also left the splitter's aggressive touching-lines rescue (`SplitToLinesAggressive`) unreachable. New shared `OcrLineHeightTracker` (thread-safe — batch OCR runs images in parallel) restores SE 4's behavior everywhere, with per-source fallback (25 Blu-ray / 12 other, SE 4's values). `SplitToLinesNew` gets a bounds guard: its up/down slides read out of bounds for min line heights below ~10, which adaptive values now reach (previously latent; reproduced as `IndexOutOfRangeException`).

### 2. nOCR un-italic retry (issue #13660's engine of choice for italics)

SE 4 de-slanted any glyph that matched nothing upright (`UnItalic`, `ItalicFactor` 0.2) and matched once more, returning the hit as italic — SE 5 lost the pass entirely, so italic lines produced unknown glyph after unknown glyph. Restored: `NikseBitmap2.UnItalic` (row shear + transparent side crop, proven upright within 1px rounding) inside `NOcrDb.GetMatch`, wired to the nOCR loop, the nOCR warm-up, and the binary-compare→nOCR fallback. The italic factor participates in the match cache key. New `ItalicFactor` setting defaults to SE 4's 0.2.

### 3. Replace-list loaders read only the first XML section

`LoadReplaceList` / `LoadReplaceListPairs` / `LoadRegExList` used `SelectSingleNode` — but fin/fra/hrb/hun/por/spa ship an **empty `<PartialWords />` placeholder before the real section**, so the italic `i→l` guesser pairs added in #13670 were silently dead in those six languages (verified: `CreateGuessesFromLetters("viei")` produced nothing; now produces `viel` in all of them). Same bug class as #13658, which fixed only the regex loader. All loaders now read every section.

### Tests

15 new tests: `OcrLineHeightTrackerTests` (4), `NOcrDbItalicRetryTests` (3 — italic bar fails upright, matches via retry as italic, DB entry not mutated), `NikseBitmap2UnItalicTests` (3), `SplitBitmapAdaptiveLineHeightTests` (3 — font-independent synthetic blocks: adaptive keeps the line break, hardcoded 20 documented losing it, no OOB crash at small heights), loader placeholder-section test (1). Full suites green: LibUiLogic 228, UI 2800, seconv 364, libse 1129.

Verified but deliberately left for a follow-up: SE 4's unknown-word guess ladder (`|`→`l`, `$`→`s`, word-initial `Iike`→`like`, `\/`→`V`, dominant-casing, name-canonicalisation — 12 of 17 guesses lost in the port) and the lost previous-line context for sentence-start capitalisation (`FixOcrErrorsViaHardcodedRules` has no SE 5 equivalent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)