### PR TITLE
Format coverage fixes from VideoLAN/CCExtractor sample sweep

### DIFF
--- a/src/libse/ContainerFormats/Matroska/MatroskaFile.cs
+++ b/src/libse/ContainerFormats/Matroska/MatroskaFile.cs
@@ -839,23 +839,36 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Matroska
             {
                 var beforeReadElementIdPosition = _stream.Position;
                 var id = (ElementId)ReadVariableLengthUInt(false);
-                if (id == ElementId.None && beforeReadElementIdPosition + 1000 < _stream.Length)
+                if (id == ElementId.None)
                 {
-                    // Error mode: search for start of next cluster, will be very slow
-                    const int maxErrors = 5_000_000;
-                    var errors = 0;
-                    var max = _stream.Length;
-                    while (id != ElementId.Cluster && beforeReadElementIdPosition + 1000 < max)
+                    if (beforeReadElementIdPosition + 1000 < _stream.Length)
                     {
-                        errors++;
-                        if (errors > maxErrors)
+                        // Error mode: search for start of next cluster, will be very slow
+                        const int maxErrors = 5_000_000;
+                        var errors = 0;
+                        var max = _stream.Length;
+                        while (id != ElementId.Cluster && beforeReadElementIdPosition + 1000 < max)
                         {
-                            return; // we give up
-                        }
+                            errors++;
+                            if (errors > maxErrors)
+                            {
+                                return; // we give up
+                            }
 
-                        beforeReadElementIdPosition++;
-                        _stream.Seek(beforeReadElementIdPosition, SeekOrigin.Begin);
-                        id = (ElementId)ReadVariableLengthUInt(false);
+                            beforeReadElementIdPosition++;
+                            _stream.Seek(beforeReadElementIdPosition, SeekOrigin.Begin);
+                            id = (ElementId)ReadVariableLengthUInt(false);
+                        }
+                    }
+
+                    if (id == ElementId.None)
+                    {
+                        // At (or almost at) end of stream and no next element found. A file that
+                        // is truncated mid-cluster (partial download, in-progress recording)
+                        // declares a segment size far beyond the real file size, so the loop
+                        // condition alone never terminates: reads at EOF yield id None and size 0,
+                        // and Seek(0) makes no progress - SE would spin at 100% CPU forever here.
+                        return;
                     }
                 }
 

--- a/src/libse/SubtitleFormats/CcExtractorTimedTranscript.cs
+++ b/src/libse/SubtitleFormats/CcExtractorTimedTranscript.cs
@@ -1,0 +1,95 @@
+﻿using Nikse.SubtitleEdit.Core.Common;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Nikse.SubtitleEdit.Core.SubtitleFormats
+{
+    /// <summary>
+    /// CCExtractor's timed transcript output ("--out=ttxt"):
+    /// 00:00:01,886|00:00:03,820|POP|e guests of Bunny Saunders.
+    /// Start and end time, the CEA-608 caption mode (POP/PAINT/ROLL-UP), then the caption text.
+    /// A multi-line caption is written as consecutive lines with identical time codes.
+    /// </summary>
+    public class CcExtractorTimedTranscript : SubtitleFormat
+    {
+        private static readonly Regex RegexTimeCodes = new Regex(@"^\d\d:\d\d:\d\d[,.]\d\d\d\|\d\d:\d\d:\d\d[,.]\d\d\d\|[^|]*\|", RegexOptions.Compiled);
+
+        public override string Extension => ".ttxt";
+
+        public override string Name => "CCExtractor Timed Transcript";
+
+        public override string ToText(Subtitle subtitle, string title)
+        {
+            const string writeFormat = "{0}|{1}|POP|{2}";
+            var sb = new StringBuilder();
+            foreach (var p in subtitle.Paragraphs)
+            {
+                foreach (var line in p.Text.SplitToLines())
+                {
+                    sb.AppendLine(string.Format(writeFormat, EncodeTimeCode(p.StartTime), EncodeTimeCode(p.EndTime), line));
+                }
+            }
+
+            return sb.ToString().Trim();
+        }
+
+        private static string EncodeTimeCode(TimeCode time)
+        {
+            return $"{time.Hours:00}:{time.Minutes:00}:{time.Seconds:00},{time.Milliseconds:000}";
+        }
+
+        public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
+        {
+            subtitle.Paragraphs.Clear();
+            _errorCount = 0;
+            Paragraph last = null;
+            foreach (var line in lines)
+            {
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    continue;
+                }
+
+                if (!RegexTimeCodes.IsMatch(line))
+                {
+                    _errorCount++;
+                    continue;
+                }
+
+                var parts = line.Split('|');
+                try
+                {
+                    var start = DecodeTimeCode(parts[0]);
+                    var end = DecodeTimeCode(parts[1]);
+                    var text = string.Join("|", parts, 3, parts.Length - 3).Trim();
+                    if (last != null &&
+                        Math.Abs(last.StartTime.TotalMilliseconds - start.TotalMilliseconds) < 0.01 &&
+                        Math.Abs(last.EndTime.TotalMilliseconds - end.TotalMilliseconds) < 0.01)
+                    {
+                        // consecutive lines with the same time codes are one multi-line caption
+                        last.Text = (last.Text + Environment.NewLine + text).Trim();
+                    }
+                    else
+                    {
+                        last = new Paragraph(start, end, text);
+                        subtitle.Paragraphs.Add(last);
+                    }
+                }
+                catch
+                {
+                    _errorCount++;
+                }
+            }
+
+            subtitle.Renumber();
+        }
+
+        private static TimeCode DecodeTimeCode(string s)
+        {
+            var parts = s.Split(':', ',', '.');
+            return new TimeCode(int.Parse(parts[0]), int.Parse(parts[1]), int.Parse(parts[2]), int.Parse(parts[3]));
+        }
+    }
+}

--- a/src/libse/SubtitleFormats/Grid608.cs
+++ b/src/libse/SubtitleFormats/Grid608.cs
@@ -1,0 +1,177 @@
+﻿using Nikse.SubtitleEdit.Core.Common;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Nikse.SubtitleEdit.Core.SubtitleFormats
+{
+    /// <summary>
+    /// CCExtractor's Grid 608 format ("--out=g608", see docs/G608.TXT): SubRip-like blocks where
+    /// each caption is the verbatim 15-row CEA-608 grid. Every row is 96 characters: 32 of text,
+    /// 32 of per-cell color (0-9, 9 = transparent/empty) and 32 of per-cell font
+    /// (R=regular, I=italics, U=underline, B=underline+italics).
+    /// Without this reader the files load as SubRip with 15 rows of grid codes per cue.
+    /// </summary>
+    public class Grid608 : SubtitleFormat
+    {
+        private static readonly Regex RegexTimeCodes = new Regex(@"^\d\d:\d\d:\d\d,\d\d\d --> \d\d:\d\d:\d\d,\d\d\d$", RegexOptions.Compiled);
+        private static readonly Regex RegexGridRow = new Regex(@"^.{32}[0-9E]{32}[RIUBE]{32}\s*$", RegexOptions.Compiled);
+
+        private const int GridRows = 15;
+        private const int GridColumns = 32;
+
+        public override string Extension => ".g608";
+
+        public override string Name => "Grid 608";
+
+        public override bool IsMine(List<string> lines, string fileName)
+        {
+            // require at least one well-formed grid row so plain SubRip files never match
+            if (!lines.Exists(l => l.Length >= 3 * GridColumns && RegexGridRow.IsMatch(l)))
+            {
+                return false;
+            }
+
+            return base.IsMine(lines, fileName);
+        }
+
+        public override string ToText(Subtitle subtitle, string title)
+        {
+            var sb = new StringBuilder();
+            var count = 1;
+            foreach (var p in subtitle.Paragraphs)
+            {
+                sb.AppendLine(count.ToString());
+                sb.AppendLine($"{EncodeTimeCode(p.StartTime)} --> {EncodeTimeCode(p.EndTime)}");
+
+                var textLines = HtmlUtil.RemoveHtmlTags(p.Text, true).SplitToLines();
+                var firstTextRow = Math.Max(0, GridRows - textLines.Count);
+                for (var row = 0; row < GridRows; row++)
+                {
+                    var text = string.Empty;
+                    if (row >= firstTextRow && row - firstTextRow < textLines.Count)
+                    {
+                        text = textLines[row - firstTextRow];
+                        if (text.Length > GridColumns)
+                        {
+                            text = text.Substring(0, GridColumns);
+                        }
+                    }
+
+                    var colors = new StringBuilder(GridColumns);
+                    for (var column = 0; column < GridColumns; column++)
+                    {
+                        colors.Append(column < text.Length && text[column] != ' ' ? '0' : '9');
+                    }
+
+                    sb.AppendLine(text.PadRight(GridColumns) + colors + new string('R', GridColumns));
+                }
+
+                sb.AppendLine();
+                count++;
+            }
+
+            return sb.ToString().Trim();
+        }
+
+        private static string EncodeTimeCode(TimeCode time)
+        {
+            return $"{time.Hours:00}:{time.Minutes:00}:{time.Seconds:00},{time.Milliseconds:000}";
+        }
+
+        public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
+        {
+            subtitle.Paragraphs.Clear();
+            _errorCount = 0;
+
+            Paragraph paragraph = null;
+            var text = new StringBuilder();
+            foreach (var line in lines)
+            {
+                if (RegexTimeCodes.IsMatch(line))
+                {
+                    AddParagraph(subtitle, paragraph, text);
+                    text.Clear();
+                    try
+                    {
+                        var parts = line.Split(new[] { ':', ',', ' ', '-', '>' }, StringSplitOptions.RemoveEmptyEntries);
+                        paragraph = new Paragraph(
+                            new TimeCode(int.Parse(parts[0]), int.Parse(parts[1]), int.Parse(parts[2]), int.Parse(parts[3])),
+                            new TimeCode(int.Parse(parts[4]), int.Parse(parts[5]), int.Parse(parts[6]), int.Parse(parts[7])),
+                            string.Empty);
+                    }
+                    catch
+                    {
+                        _errorCount++;
+                        paragraph = null;
+                    }
+                }
+                else if (paragraph != null && line.Length >= 3 * GridColumns && RegexGridRow.IsMatch(line))
+                {
+                    // CCExtractor writes NUL bytes for grid cells a stream never touched - blanks
+                    var textCells = line.Substring(0, GridColumns).ToCharArray();
+                    for (var column = 0; column < textCells.Length; column++)
+                    {
+                        if (char.IsControl(textCells[column]))
+                        {
+                            textCells[column] = ' ';
+                        }
+                    }
+
+                    var textBlock = new string(textCells);
+                    var rowText = textBlock.Trim();
+                    if (rowText.Length > 0)
+                    {
+                        // whole-row italics is the common case worth keeping (font block: I = italics)
+                        var fontBlock = line.Substring(2 * GridColumns, GridColumns);
+                        var firstCell = 0;
+                        while (firstCell < GridColumns && textBlock[firstCell] == ' ')
+                        {
+                            firstCell++;
+                        }
+
+                        var isItalic = true;
+                        for (var column = 0; column < rowText.Length && isItalic; column++)
+                        {
+                            if (textBlock[firstCell + column] != ' ' && fontBlock[firstCell + column] != 'I' && fontBlock[firstCell + column] != 'B')
+                            {
+                                isItalic = false;
+                            }
+                        }
+
+                        if (text.Length > 0)
+                        {
+                            text.Append(Environment.NewLine);
+                        }
+
+                        text.Append(isItalic ? "<i>" + rowText + "</i>" : rowText);
+                    }
+                }
+                else if (paragraph == null && !string.IsNullOrWhiteSpace(line) && !Utilities.IsInteger(line.Trim()))
+                {
+                    _errorCount++;
+                }
+            }
+
+            AddParagraph(subtitle, paragraph, text);
+            subtitle.Renumber();
+        }
+
+        private static void AddParagraph(Subtitle subtitle, Paragraph paragraph, StringBuilder text)
+        {
+            if (paragraph == null)
+            {
+                return;
+            }
+
+            paragraph.Text = text.ToString()
+                .Replace("</i>" + Environment.NewLine + "<i>", Environment.NewLine)
+                .Trim();
+            if (paragraph.Text.Length > 0)
+            {
+                subtitle.Paragraphs.Add(paragraph);
+            }
+        }
+    }
+}

--- a/src/libse/SubtitleFormats/RealTime.cs
+++ b/src/libse/SubtitleFormats/RealTime.cs
@@ -1,12 +1,27 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
     public class RealTime : SubtitleFormat
     {
+        // Cue starts are <time .../> tags; the text a cue shows is everything up to the next
+        // <time .../> tag. Real-world files (RealPlayer captions) use lowercase tags, usually
+        // only a begin= attribute, and timestamps in every short form the RealText spec allows
+        // ("3", "3.5", ".5", "1:20", "1:20s", "0:03:24.8"), so parse permissively.
+        private static readonly Regex RegexTimeTag = new Regex("<time\\s[^>]*begin\\s*=\\s*\"[^\"]*\"[^>]*>", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex RegexBeginAttribute = new Regex("begin\\s*=\\s*\"([^\"]*)\"", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex RegexEndAttribute = new Regex("end\\s*=\\s*\"([^\"]*)\"", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex RegexWindowTag = new Regex("<window[\\s>]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex RegexDurationAttribute = new Regex("duration\\s*=\\s*\"([^\"]*)\"", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex RegexLineBreakTag = new Regex("<(?:br|p|/p|clear)\\s*/?>", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex RegexTag = new Regex("<[^>]+>", RegexOptions.Compiled);
+
         public override string Extension => ".rt";
 
         public override string Name => "RealTime";
@@ -47,49 +62,157 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
         {
-            //<Time begin="0:03:24.8" end="0:03:29.4" /><clear/>Man stjæler ikke fra Chavo, nej.
             subtitle.Paragraphs.Clear();
             _errorCount = 0;
-            foreach (string line in lines)
-            {
-                try
-                {
-                    if (line.Contains("<Time ") && line.Contains(" begin=") && line.Contains("end="))
-                    {
-                        int indexOfBegin = line.IndexOf(" begin=", StringComparison.Ordinal);
-                        int indexOfEnd = line.IndexOf(" end=", StringComparison.Ordinal);
-                        string begin = line.Substring(indexOfBegin + 7, 11);
-                        string end = line.Substring(indexOfEnd + 5, 11);
 
-                        string[] startParts = begin.Split(new[] { ':', '.', '"' }, StringSplitOptions.RemoveEmptyEntries);
-                        string[] endParts = end.Split(new[] { ':', '.', '"' }, StringSplitOptions.RemoveEmptyEntries);
-                        if (startParts.Length == 4 && endParts.Length == 4)
+            var text = string.Join("\n", lines);
+            var matches = RegexTimeTag.Matches(text);
+            if (matches.Count == 0)
+            {
+                // a static caption: one <window duration="..."> with text and no <time> tags
+                var windowMatch = RegexWindowTag.Match(text);
+                var windowTagEnd = windowMatch.Success ? text.IndexOf('>', windowMatch.Index) : -1;
+                if (windowTagEnd >= 0)
+                {
+                    var staticText = ExtractText(text.Substring(windowTagEnd + 1));
+                    if (staticText.Length > 0)
+                    {
+                        var durationMatch = RegexDurationAttribute.Match(text.Substring(windowMatch.Index, windowTagEnd - windowMatch.Index + 1));
+                        var end = durationMatch.Success && TryParseTimeCode(durationMatch.Groups[1].Value, out var duration) && duration > 0
+                            ? duration
+                            : Utilities.GetOptimalDisplayMilliseconds(staticText);
+                        subtitle.Paragraphs.Add(new Paragraph(staticText, 0, end));
+                        subtitle.Renumber();
+                    }
+                }
+
+                return;
+            }
+            for (var i = 0; i < matches.Count; i++)
+            {
+                var match = matches[i];
+                var beginMatch = RegexBeginAttribute.Match(match.Value);
+                if (!TryParseTimeCode(beginMatch.Groups[1].Value, out var startMilliseconds))
+                {
+                    _errorCount++;
+                    continue;
+                }
+
+                var textEndIndex = i + 1 < matches.Count ? matches[i + 1].Index : text.Length;
+                var cueText = ExtractText(text.Substring(match.Index + match.Length, textEndIndex - match.Index - match.Length));
+                if (cueText.Length == 0)
+                {
+                    continue;
+                }
+
+                double endMilliseconds;
+                var endMatch = RegexEndAttribute.Match(match.Value);
+                if (endMatch.Success && TryParseTimeCode(endMatch.Groups[1].Value, out var explicitEnd) && explicitEnd > startMilliseconds)
+                {
+                    endMilliseconds = explicitEnd;
+                }
+                else
+                {
+                    // no end= - the text stays until the next <time> tag replaces/clears it
+                    endMilliseconds = startMilliseconds + Utilities.GetOptimalDisplayMilliseconds(cueText);
+                    if (i + 1 < matches.Count)
+                    {
+                        var nextBeginMatch = RegexBeginAttribute.Match(matches[i + 1].Value);
+                        if (TryParseTimeCode(nextBeginMatch.Groups[1].Value, out var nextStart) &&
+                            nextStart > startMilliseconds &&
+                            nextStart - startMilliseconds <= Configuration.Settings.General.SubtitleMaximumDisplayMilliseconds)
                         {
-                            string text = line.Substring(line.LastIndexOf("/>", StringComparison.Ordinal) + 2);
-                            var p = new Paragraph(DecodeTimeCode(startParts), DecodeTimeCode(endParts), text);
-                            subtitle.Paragraphs.Add(p);
+                            endMilliseconds = nextStart;
                         }
                     }
                 }
-                catch
+
+                subtitle.Paragraphs.Add(new Paragraph(cueText, startMilliseconds, endMilliseconds));
+            }
+
+            // text between the <window> element and the first <time> tag is shown from the start
+            if (matches.Count > 0)
+            {
+                var introText = ExtractText(text.Substring(0, matches[0].Index));
+                if (introText.Length > 0)
                 {
-                    _errorCount++;
+                    var firstBegin = RegexBeginAttribute.Match(matches[0].Value);
+                    var end = TryParseTimeCode(firstBegin.Groups[1].Value, out var firstStart) && firstStart > 0
+                        ? Math.Min(firstStart, Utilities.GetOptimalDisplayMilliseconds(introText))
+                        : Utilities.GetOptimalDisplayMilliseconds(introText);
+                    subtitle.Paragraphs.Insert(0, new Paragraph(introText, 0, end));
                 }
             }
 
+            subtitle.Sort(SubtitleSortCriteria.StartTime);
             subtitle.Renumber();
         }
 
-        private static TimeCode DecodeTimeCode(string[] parts)
+        private static string ExtractText(string s)
         {
-            //[00:06:51.48]
-            var hour = int.Parse(parts[0]);
-            var minutes = int.Parse(parts[1]);
-            var seconds = int.Parse(parts[2]);
-            var millisesonds = int.Parse(parts[3]);
+            s = RegexLineBreakTag.Replace(s, "\n");
+            s = RegexTag.Replace(s, string.Empty);
+            s = System.Net.WebUtility.HtmlDecode(s);
 
-            return new TimeCode(hour, minutes, seconds, millisesonds * 10);
+            var sb = new StringBuilder(s.Length);
+            foreach (var line in s.SplitToLines())
+            {
+                var trimmed = line.Trim();
+                if (trimmed.Length > 0)
+                {
+                    if (sb.Length > 0)
+                    {
+                        sb.Append(Environment.NewLine);
+                    }
+
+                    sb.Append(trimmed);
+                }
+            }
+
+            return sb.ToString();
         }
 
+        /// <summary>
+        /// Parses a RealText timestamp: "dd:hh:mm:ss.xy" where all leading components and the
+        /// fraction are optional ("3", "3.5", ".5", "1:20", "0:03:24.8"), plus an optional
+        /// trailing unit as seen in the wild ("1:20s").
+        /// </summary>
+        private static bool TryParseTimeCode(string s, out double milliseconds)
+        {
+            milliseconds = 0;
+            s = s.Trim().TrimEnd('s', 'S');
+            if (s.Length == 0)
+            {
+                return false;
+            }
+
+            var parts = s.Split(':');
+            if (parts.Length > 4)
+            {
+                return false;
+            }
+
+            double factor = 1000; // seconds
+            double total = 0;
+            for (var i = parts.Length - 1; i >= 0; i--)
+            {
+                var part = parts[i].Trim();
+                if (part.Length == 0)
+                {
+                    part = "0";
+                }
+
+                if (!double.TryParse(part, NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out var value) || value < 0)
+                {
+                    return false;
+                }
+
+                total += value * factor;
+                factor *= i >= parts.Length - 3 ? 60 : 24; // s -> min -> hours -> days
+            }
+
+            milliseconds = total;
+            return true;
+        }
     }
 }

--- a/src/libse/SubtitleFormats/SubtitleFormat.cs
+++ b/src/libse/SubtitleFormats/SubtitleFormat.cs
@@ -167,6 +167,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     new Footage(),
                     new GooglePlayJson(),
                     new GpacTtxt(),
+                    new CcExtractorTimedTranscript(),
+                    new Grid608(),
                     new Gremots(),
                     new HollyStarJson(),
                     new ImageLogicAutocaption(),

--- a/src/libse/SubtitleFormats/TMPlayer.cs
+++ b/src/libse/SubtitleFormats/TMPlayer.cs
@@ -35,7 +35,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     return false;
                 }
             }
-            if (subtitle.Paragraphs.Count > _errorCount)
+            // a file with parse errors must have enough good cues to outweigh them - blank lines
+            // no longer count as errors, so a couple of time-looking rows in a garbage file
+            // would otherwise be claimed (e.g. the malformed SCC log from #12582)
+            if (subtitle.Paragraphs.Count > _errorCount && (_errorCount == 0 || subtitle.Paragraphs.Count > 4))
             {
                 if (new UnknownSubtitle33().IsMine(lines, fileName) || new UnknownSubtitle36().IsMine(lines, fileName))
                 {
@@ -65,6 +68,13 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             _errorCount = 0;
             foreach (string line in lines)
             {
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    // don't count blank separator lines as errors - files saved with "\r\r\n"
+                    // line endings get a blank line after every cue (see SplitToLines/#8854)
+                    continue;
+                }
+
                 bool success = false;
                 if (line.IndexOf(':') > 0 && RegexTimeCodes.IsMatch(line))
                 {

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -17714,6 +17714,18 @@ public partial class MainViewModel :
                 return;
             }
 
+            // a DVD .vob is the same MPEG program stream as a VobSub .sub - extract the subtitle
+            // (SPU) stream directly; a .vob without subtitles falls through to the video handling
+            if (ext == ".vob" && FileUtil.IsVobSub(fileName))
+            {
+                var ok = await ImportSubtitleFromVobSubFile(fileName, videoFileName, skipLoadVideo);
+                if (ok)
+                {
+                    SelectAndScrollToRow(0);
+                    return;
+                }
+            }
+
             if (ext == ".idx")
             {
                 var subFile = Path.ChangeExtension(fileName, ".sub");

--- a/tests/libse/ContainerFormats/MatroskaFileTest.cs
+++ b/tests/libse/ContainerFormats/MatroskaFileTest.cs
@@ -38,4 +38,38 @@ public class MatroskaFileTest
             }
         }
     }
+
+    /// <summary>
+    /// A file truncated mid-cluster (partial download, recording in progress) still declares the
+    /// full segment size in its header, so the cluster walk's end position lies beyond EOF. The
+    /// walk used to spin forever at EOF (id reads yield None, Seek(0) makes no progress) instead
+    /// of returning what it had - opening such a file hung SE at 100% CPU.
+    /// </summary>
+    [Fact]
+    public void TruncatedFileTerminates()
+    {
+        var path = Path.Combine(Directory.GetCurrentDirectory(), "Files", "sample_MKV_SRT.mkv");
+        var bytes = File.ReadAllBytes(path);
+        var tempFileName = Path.GetTempFileName();
+        try
+        {
+            // cut mid-file so the segment (and likely a cluster) extends past EOF
+            using (var fs = new FileStream(tempFileName, FileMode.Create, FileAccess.Write))
+            {
+                fs.Write(bytes, 0, bytes.Length * 6 / 10);
+            }
+
+            using var matroska = new MatroskaFile(tempFileName);
+            Assert.True(matroska.IsValid);
+
+            foreach (var track in matroska.GetTracks(subtitleOnly: true))
+            {
+                matroska.GetSubtitle(track.TrackNumber, null); // must terminate
+            }
+        }
+        finally
+        {
+            File.Delete(tempFileName);
+        }
+    }
 }

--- a/tests/libse/SubtitleFormats/CcExtractorTimedTranscriptTest.cs
+++ b/tests/libse/SubtitleFormats/CcExtractorTimedTranscriptTest.cs
@@ -1,0 +1,63 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace LibSETests.SubtitleFormats;
+
+public class CcExtractorTimedTranscriptTest
+{
+    [Fact]
+    public void LoadSubtitleMergesLinesWithSameTimeCodes()
+    {
+        var format = new CcExtractorTimedTranscript();
+        var subtitle = new Subtitle();
+        var lines = new List<string>
+        {
+            "00:00:01,886|00:00:03,820|POP|e guests of Bunny Saunders.",
+            "00:00:05,489|00:00:07,357|POP|  Very young, of course, to be",
+            "00:00:05,489|00:00:07,357|POP|  directing his first picture.",
+        };
+
+        Assert.True(format.IsMine(lines, null));
+        format.LoadSubtitle(subtitle, lines, null);
+
+        Assert.Equal(2, subtitle.Paragraphs.Count);
+        Assert.Equal("e guests of Bunny Saunders.", subtitle.Paragraphs[0].Text);
+        Assert.Equal(1886, subtitle.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(3820, subtitle.Paragraphs[0].EndTime.TotalMilliseconds);
+        Assert.Equal("Very young, of course, to be" + Environment.NewLine + "directing his first picture.", subtitle.Paragraphs[1].Text);
+    }
+
+    [Fact]
+    public void RoundTripKeepsTextAndTimes()
+    {
+        var format = new CcExtractorTimedTranscript();
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Hello" + Environment.NewLine + "world", 1886, 3820));
+
+        var text = format.ToText(subtitle, "title");
+        var reloaded = new Subtitle();
+        format.LoadSubtitle(reloaded, new List<string>(text.SplitToLines()), null);
+
+        Assert.Single(reloaded.Paragraphs);
+        Assert.Equal("Hello" + Environment.NewLine + "world", reloaded.Paragraphs[0].Text);
+        Assert.Equal(1886, reloaded.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(3820, reloaded.Paragraphs[0].EndTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void IsMineRejectsSubRip()
+    {
+        var format = new CcExtractorTimedTranscript();
+        var lines = new List<string>
+        {
+            "1",
+            "00:00:01,886 --> 00:00:03,820",
+            "Hello world",
+        };
+
+        Assert.False(format.IsMine(lines, null));
+    }
+}

--- a/tests/libse/SubtitleFormats/Grid608Test.cs
+++ b/tests/libse/SubtitleFormats/Grid608Test.cs
@@ -1,0 +1,85 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace LibSETests.SubtitleFormats;
+
+public class Grid608Test
+{
+    private static string GridRow(string text, char font = 'R')
+    {
+        var colors = new char[32];
+        for (var i = 0; i < 32; i++)
+        {
+            colors[i] = i < text.Length && text[i] != ' ' ? '0' : '9';
+        }
+
+        return text.PadRight(32) + new string(colors) + new string(font, 32);
+    }
+
+    [Fact]
+    public void LoadSubtitleReadsTextRowsFromGrid()
+    {
+        var format = new Grid608();
+        var subtitle = new Subtitle();
+        var lines = new List<string> { "1", "00:00:01,886 --> 00:00:03,819" };
+        for (var i = 0; i < 13; i++)
+        {
+            lines.Add(GridRow(string.Empty));
+        }
+
+        lines.Add(GridRow("  - Previously on The Tudors..."));
+        lines.Add(GridRow("  - Your Holy Father offs you"));
+        lines.Add(string.Empty);
+        lines.Add("2");
+        lines.Add("00:00:03,854 --> 00:00:05,454");
+        for (var i = 0; i < 14; i++)
+        {
+            lines.Add(GridRow(string.Empty));
+        }
+
+        lines.Add(GridRow("Ah, yes sir.", 'I'));
+
+        Assert.True(format.IsMine(lines, null));
+        format.LoadSubtitle(subtitle, lines, null);
+
+        Assert.Equal(2, subtitle.Paragraphs.Count);
+        Assert.Equal("- Previously on The Tudors..." + Environment.NewLine + "- Your Holy Father offs you", subtitle.Paragraphs[0].Text);
+        Assert.Equal(1886, subtitle.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(3819, subtitle.Paragraphs[0].EndTime.TotalMilliseconds);
+        Assert.Equal("<i>Ah, yes sir.</i>", subtitle.Paragraphs[1].Text);
+    }
+
+    [Fact]
+    public void IsMineRejectsPlainSubRip()
+    {
+        var format = new Grid608();
+        var lines = new List<string>
+        {
+            "1",
+            "00:00:01,886 --> 00:00:03,820",
+            "Hello world",
+        };
+
+        Assert.False(format.IsMine(lines, null));
+    }
+
+    [Fact]
+    public void RoundTripKeepsTextAndTimes()
+    {
+        var format = new Grid608();
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Hello" + Environment.NewLine + "world", 1886, 3820));
+
+        var text = format.ToText(subtitle, "title");
+        var reloaded = new Subtitle();
+        format.LoadSubtitle(reloaded, new List<string>(text.SplitToLines()), null);
+
+        Assert.Single(reloaded.Paragraphs);
+        Assert.Equal("Hello" + Environment.NewLine + "world", reloaded.Paragraphs[0].Text);
+        Assert.Equal(1886, reloaded.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(3820, reloaded.Paragraphs[0].EndTime.TotalMilliseconds);
+    }
+}

--- a/tests/libse/SubtitleFormats/RealTimeTest.cs
+++ b/tests/libse/SubtitleFormats/RealTimeTest.cs
@@ -1,0 +1,135 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace LibSETests.SubtitleFormats;
+
+public class RealTimeTest
+{
+    [Fact]
+    public void LoadSubtitleReadsRealWorldBeginOnlyCues()
+    {
+        // real RealText files (RealPlayer captions) use lowercase <time> tags with only a
+        // begin= attribute; the text runs until the next <time> tag replaces it
+        var format = new RealTime();
+        var subtitle = new Subtitle();
+        var lines = new List<string>
+        {
+            "<window duration=\"30\" bgcolor=\"yellow\">",
+            "Mary had a little lamb,",
+            "<br/><time begin=\"3\"/>little lamb,",
+            "<br/><time begin=\"6\"/>little lamb.",
+            "<br/><time begin=\"9\"/><clear/>Mary had a little lamb,",
+            "</window>",
+        };
+
+        Assert.True(format.IsMine(lines, null));
+        format.LoadSubtitle(subtitle, lines, null);
+
+        Assert.Equal(4, subtitle.Paragraphs.Count);
+        Assert.Equal("Mary had a little lamb,", subtitle.Paragraphs[0].Text);
+        Assert.Equal(0, subtitle.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal("little lamb,", subtitle.Paragraphs[1].Text);
+        Assert.Equal(3000, subtitle.Paragraphs[1].StartTime.TotalMilliseconds);
+        Assert.Equal(6000, subtitle.Paragraphs[1].EndTime.TotalMilliseconds);
+        Assert.Equal(9000, subtitle.Paragraphs[3].StartTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void LoadSubtitleReadsExplicitEndAndMultiLineText()
+    {
+        var format = new RealTime();
+        var subtitle = new Subtitle();
+        var lines = new List<string>
+        {
+            "<window type=\"generic\" duration=\"01:01:20.17\">",
+            "<font face=\"Verdana\"><center>",
+            " <time begin=\"00:00:05.44\" end=\"00:00:08.5\"/><clear/>FIRST LINE.<br/>",
+            "SECOND LINE.<br/>",
+            " <time begin=\"00:00:09.98\"/><clear/>NEXT CUE.<br/>",
+            "</center></font>",
+            "</window>",
+        };
+
+        format.LoadSubtitle(subtitle, lines, null);
+
+        Assert.Equal(2, subtitle.Paragraphs.Count);
+        Assert.Equal("FIRST LINE." + Environment.NewLine + "SECOND LINE.", subtitle.Paragraphs[0].Text);
+        Assert.Equal(5440, subtitle.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(8500, subtitle.Paragraphs[0].EndTime.TotalMilliseconds);
+        Assert.Equal("NEXT CUE.", subtitle.Paragraphs[1].Text);
+        Assert.Equal(9980, subtitle.Paragraphs[1].StartTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void LoadSubtitleReadsStaticWindowWithoutTimeTags()
+    {
+        var format = new RealTime();
+        var subtitle = new Subtitle();
+        var lines = new List<string>
+        {
+            "<window",
+            "\ttype=\"generic\"",
+            "\tduration=\"5.760\"",
+            ">",
+            "<font size=\"+2\" color=\"white\">",
+            "<center>",
+            "Video Clip Demo",
+            "</center>",
+            "</font>",
+            "</window>",
+        };
+
+        format.LoadSubtitle(subtitle, lines, null);
+
+        Assert.Single(subtitle.Paragraphs);
+        Assert.Equal("Video Clip Demo", subtitle.Paragraphs[0].Text);
+        Assert.Equal(0, subtitle.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(5760, subtitle.Paragraphs[0].EndTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void RoundTripKeepsTextAndTimes()
+    {
+        var format = new RealTime();
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Hello world", 3400, 5800));
+        subtitle.Paragraphs.Add(new Paragraph("Second cue", 6000, 8000));
+
+        var text = format.ToText(subtitle, "title");
+        var reloaded = new Subtitle();
+        format.LoadSubtitle(reloaded, new List<string>(text.SplitToLines()), null);
+
+        Assert.Equal(2, reloaded.Paragraphs.Count);
+        Assert.Equal("Hello world", reloaded.Paragraphs[0].Text);
+        Assert.Equal(3400, reloaded.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(5800, reloaded.Paragraphs[0].EndTime.TotalMilliseconds);
+        Assert.Equal("Second cue", reloaded.Paragraphs[1].Text);
+    }
+
+    [Theory]
+    [InlineData("3", 3000)]
+    [InlineData("3.5", 3500)]
+    [InlineData(".5", 500)]
+    [InlineData("1:20", 80000)]
+    [InlineData("1:20s", 80000)]
+    [InlineData("0:03:24.8", 204800)]
+    public void LoadSubtitleParsesShortTimestampForms(string timestamp, int expectedMilliseconds)
+    {
+        var format = new RealTime();
+        var subtitle = new Subtitle();
+        var lines = new List<string>
+        {
+            "<window duration=\"200:00\">",
+            $"<time begin=\"{timestamp}\"/>Some text",
+            "</window>",
+        };
+
+        format.LoadSubtitle(subtitle, lines, null);
+
+        Assert.Single(subtitle.Paragraphs);
+        Assert.Equal(expectedMilliseconds, subtitle.Paragraphs[0].StartTime.TotalMilliseconds);
+    }
+}

--- a/tests/libse/SubtitleFormats/TMPlayerTest.cs
+++ b/tests/libse/SubtitleFormats/TMPlayerTest.cs
@@ -1,0 +1,30 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System.Collections.Generic;
+using Xunit;
+
+namespace LibSETests.SubtitleFormats;
+
+public class TMPlayerTest
+{
+    [Fact]
+    public void IsMineAcceptsBlankSeparatorLines()
+    {
+        // files saved with "\r\r\n" line endings get a blank line after every cue when split
+        // (see SplitToLines/#8854) - the blanks must not count as parse errors
+        var format = new TMPlayer();
+        var lines = new List<string>();
+        for (var i = 0; i < 10; i++)
+        {
+            lines.Add($"00:00:{i * 5 + 1:00}:Line number {i}");
+            lines.Add(string.Empty);
+        }
+
+        Assert.True(format.IsMine(lines, null));
+
+        var subtitle = new Subtitle();
+        format.LoadSubtitle(subtitle, lines, null);
+        Assert.Equal(10, subtitle.Paragraphs.Count);
+        Assert.Equal("Line number 0", subtitle.Paragraphs[0].Text);
+    }
+}


### PR DESCRIPTION
Ran Subtitle Edit's format detection over the full [VideoLAN subtitle sample corpus](https://streams.videolan.org/samples/sub/) (157 standalone files plus MKV/MP4/WebM/DivX containers) and over every text format CCExtractor can emit (generated with ccextractor 0.96.5 from the corpus' CC-bearing streams, since the CCExtractor sample platform requires a login). Fixes everything that turned out to be an SE bug or an easy gap:

## Bug fixes

- **MatroskaFile: infinite hang on truncated MKV.** A file truncated mid-cluster (partial download, in-progress recording) declares a segment size beyond EOF; the cluster walk in `ReadSegmentCluster` spun forever at EOF at 100% CPU — id reads yield `None`, the error-resync branch is skipped near EOF, and `Seek(0)` makes no progress. Now returns the packets read so far. VLC's `largeres_vobsub.mkv` (41 MB, truncated): hang (>4 min, killed) → 30 ms, all 16 VobSub tracks extract. Regression test truncates the existing MKV test asset.
- **RealTime (.rt) parser matched 0 of 27 real-world samples.** It only recognized SE's own writer output (capital `<Time`, both `begin=`/`end=`, exactly 11-char timestamps). Rewritten to handle real RealText: lowercase tags, begin-only cues (the next `begin` ends the previous cue, clamped to max display time), short timestamp forms (`3`, `3.5`, `.5`, `1:20`, `1:20s`, `0:03:24.8`), static windows without `<time>` tags (window `duration` used), tag stripping/entity decoding. All 27 VideoLAN `.rt` samples now load with correct times; round-trip with SE's writer is covered by tests.
- **TMPlayer rejected files with blank separator lines** (files saved with `\r\r\n` line endings get a blank line per cue via `SplitToLines`, #8854 rule): blanks counted as parse errors and flipped `IsMine`. Blanks are now skipped — and to keep the #12582 malformed-SCC guard intact, a file that *does* have parse errors needs >4 good cues to be claimed (covered by existing seconv test).
- **G608 misdetected as SubRip.** CCExtractor's `--out=g608` grid files loaded as SubRip cues full of `9999…RRRR` attribute rows. New `Grid608` format reads the 32-column text block (with whole-row italics from the font block, NUL-cell tolerance), registered under its own `.g608` extension so it wins the extension-priority pass.

## New coverage

- **`.vob` direct open (UI):** a DVD `.vob` is the same MPEG program stream as a VobSub `.sub`; when it contains an SPU stream it now routes through the VobSub import → OCR, otherwise it falls through to the open-as-video prompt. VLC's `starwarssub*.vob` samples extract fine.
- **CCExtractor timed transcript (`--out=ttxt`)**: `00:00:01,886|00:00:03,820|POP|text`; consecutive lines with identical times merge into one multi-line caption. Reader + writer + tests.

## Verified working already (no change needed)

MicroDVD, SubRip, SubViewer 2.0, MPL2, AQTitle, EBU STL, TurboTitler, WebVTT (incl. MKV/WebM `S_TEXT/WEBVTT` and MakeMKV `D_WEBVTT`), SSA/ASS (standalone + MKV), SAMI, SCC (incl. drop-frame), MacCaption, SMPTE-TT/TTML, EBU-TT-D, MP4 tx3g/DASH-TTML/CMAF, SP-DVD sup, VobSub idx/sub, DivX XSUB, PGS from MKV.

Remaining gaps found in the sweep are listed in the session report (SBT misdetection as YouTube Transcript, MPL1 comma variant, SMPTE-TT inline `smpte:image` bitmaps, USF markup passthrough from MKV, CCExtractor binary formats bin/raw/dvdraw/ccd) — none of them regressions, all pre-existing.

All 1147 libse + 228 libuilogic + 364 seconv tests pass; the 157-file VideoLAN corpus shows only wins, zero detection changes elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)