### PR TITLE
Add llama.cpp advanced engine to batch convert

### DIFF
--- a/src/libuilogic/Translate/DoAutoTranslate.cs
+++ b/src/libuilogic/Translate/DoAutoTranslate.cs
@@ -45,6 +45,20 @@ public class DoAutoTranslate
                 rows.Add(new TranslateRow { Number = p.Number, Show = p.StartTime.TimeSpan, Hide = p.EndTime.TimeSpan, Duration = p.Duration.ToShortDisplayString(), Text = p.Text });
             }
 
+            // The "advanced" local-LLM engines run their own batch loop: numbered batches with a
+            // schema-forced JSON reply and rolling context, so MergeAndSplitHelper's merge/split
+            // heuristics are not needed (and would break the line alignment the schema guarantees).
+            if (translator is IBatchContextTranslator batchTranslator)
+            {
+                while (index < subtitle.Paragraphs.Count && !cancellationToken.IsCancellationRequested)
+                {
+                    index += await batchTranslator.TranslateBatchAsync(rows, index, sourceLanguage.Code, targetLanguage.Code, cancellationToken);
+                    Progress?.Invoke(Math.Min(index, subtitle.Paragraphs.Count), subtitle.Paragraphs.Count);
+                }
+
+                return rows.ToList();
+            }
+
             while (index < subtitle.Paragraphs.Count)
             {
                 if (cancellationToken.IsCancellationRequested)

--- a/src/libuilogic/Translate/IBatchContextTranslator.cs
+++ b/src/libuilogic/Translate/IBatchContextTranslator.cs
@@ -1,0 +1,19 @@
+using System.Collections.ObjectModel;
+
+namespace Nikse.SubtitleEdit.UiLogic.Translate;
+
+/// <summary>
+/// An engine that translates whole batches of lines at once with surrounding context, instead of
+/// the line-by-line <see cref="AutoTranslate.IAutoTranslator.Translate"/> call. Implemented by the
+/// "advanced" local-LLM engines, whose numbered-batch protocol guarantees line alignment on its
+/// own - so callers must skip MergeAndSplitHelper's merge/split heuristics (which would break that
+/// alignment) and drive <see cref="TranslateBatchAsync"/> instead.
+/// </summary>
+public interface IBatchContextTranslator
+{
+    /// <summary>
+    /// Translates the next batch starting at <paramref name="index"/>, writing the results into
+    /// the rows, and returns the number of rows translated (always at least 1, or throws).
+    /// </summary>
+    Task<int> TranslateBatchAsync(ObservableCollection<TranslateRow> rows, int index, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken);
+}

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -31,6 +31,7 @@ using Nikse.SubtitleEdit.Features.Tools.BatchConvert.BatchErrorList;
 using Nikse.SubtitleEdit.Features.Tools.FixCommonErrors;
 using Nikse.SubtitleEdit.Features.Tools.RemoveTextForHearingImpaired;
 using Nikse.SubtitleEdit.Features.Translate;
+using Nikse.SubtitleEdit.Features.Translate.LlamaCppAdvanced;
 using Nikse.SubtitleEdit.Logic.LlamaCpp;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
@@ -167,6 +168,7 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
     [ObservableProperty] private ObservableCollection<SpeechToTextModelDisplay> _crispAsrModels = new();
     [ObservableProperty] private SpeechToTextModelDisplay? _selectedCrispAsrModel;
     [ObservableProperty] private bool _crispAsrModelComboIsVisible;
+    [ObservableProperty] private bool _llamaCppAdvancedButtonIsVisible;
 
     // Fix common errors
     [ObservableProperty] private FixCommonErrors.ProfileDisplayItem? _fixCommonErrorsProfile;
@@ -410,6 +412,7 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
             new LibreTranslate(),
             new LmStudioTranslate(),
             new LlamaCppTranslate(),
+            new LlamaCppAdvancedTranslate(),
             new NoLanguageLeftBehindServe(),
             new NoLanguageLeftBehindApi(),
             new DeepLTranslate(),
@@ -1319,7 +1322,8 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
             return true;
         }
 
-        if (!config.AutoTranslate.IsActive || config.AutoTranslate.Translator is not LlamaCppTranslate)
+        if (!config.AutoTranslate.IsActive ||
+            config.AutoTranslate.Translator is not (LlamaCppTranslate or LlamaCppAdvancedTranslate))
         {
             return true;
         }
@@ -2220,6 +2224,21 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         }
     }
 
+    // Batch size, context history, synopsis/glossary/style and sampling for the advanced engine -
+    // the same window the Auto-translate window opens, editing the same shared settings.
+    [RelayCommand]
+    private async Task ShowLlamaCppAdvancedSettings()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        await _windowService.ShowDialogAsync<LlamaCppAdvancedSettingsWindow, LlamaCppAdvancedSettingsViewModel>(
+            Window,
+            vm => vm.Initialize());
+    }
+
     [RelayCommand]
     private async Task RemoveSelectedFiles()
     {
@@ -2654,7 +2673,7 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
             Configuration.Settings.Tools.LmStudioModel = AutoTranslateModel.Trim();
         }
 
-        if (engineType == typeof(LlamaCppTranslate))
+        if (engineType == typeof(LlamaCppTranslate) || engineType == typeof(LlamaCppAdvancedTranslate))
         {
             if (!string.IsNullOrEmpty(AutoTranslateUrl.Trim()))
             {
@@ -2839,6 +2858,10 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         AutoTranslateModelIsVisible = engine is OllamaTranslate;
         CrispAsrModelComboIsVisible = engine is CrispAsrMadladTranslate;
 
+        // Batch size, context history and the synopsis/glossary/style prompt only exist on the
+        // advanced engine; they apply to local and remote llama-servers alike.
+        LlamaCppAdvancedButtonIsVisible = engine is LlamaCppAdvancedTranslate;
+
         if (engine is CrispAsrMadladTranslate)
         {
             AutoTranslateModel = string.Empty;
@@ -2882,7 +2905,7 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
             AutoTranslateApiKey = string.Empty;
             AutoTranslateApiKeyIsVisible = false;
         }
-        else if (engine is LlamaCppTranslate)
+        else if (engine is LlamaCppTranslate or LlamaCppAdvancedTranslate)
         {
             AutoTranslateModel = string.Empty;
             AutoTranslateModelBrowseIsVisible = false;

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -2754,6 +2754,11 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         Configuration.Settings.Tools.OllamaApiUrl = Se.Settings.AutoTranslate.OllamaUrl;
         Configuration.Settings.Tools.OllamaModel = Se.Settings.AutoTranslate.OllamaModel;
 
+        // The user-edited llama.cpp prompt lives in Se.Settings; without this a batch run would
+        // fall back to the built-in default (a curated model's own prompt still wins - see
+        // LlamaCppServerManager.ApplyTranslatePromptSettings).
+        Configuration.Settings.Tools.LlamaCppPrompt = Se.Settings.AutoTranslate.LlamaCppPrompt;
+
         Configuration.Settings.Tools.AutoTranslateLibreUrl = Se.Settings.AutoTranslate.LibreTranslateUrl;
         Configuration.Settings.Tools.AutoTranslateLibreApiKey = Se.Settings.AutoTranslate.LibreTranslateApiKey;
 

--- a/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewAutoTranslate.cs
+++ b/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewAutoTranslate.cs
@@ -35,13 +35,24 @@ public static class ViewAutoTranslate
         var buttonModel = UiUtil.MakeButtonBrowse(vm.AutoTranslateBrowseModelCommand, nameof(vm.AutoTranslateModelBrowseIsVisible), Se.Language.General.Model).WithMarginLeft(3);
         var labelCrispAsrModel = UiUtil.MakeLabel(Se.Language.General.Model).WithBindVisible(vm, nameof(vm.CrispAsrModelComboIsVisible)).WithMarginLeft(10).WithMarginRight(3);
         var crispAsrModelCombo = UiUtil.MakeComboBox(vm.CrispAsrModels, vm, nameof(vm.SelectedCrispAsrModel), nameof(vm.CrispAsrModelComboIsVisible));
+
+        var buttonAdvanced = UiUtil.MakeButton(Se.Language.Translate.AdvancedDotDotDot, vm.ShowLlamaCppAdvancedSettingsCommand)
+            .WithMarginLeft(10)
+            .WithAccessibleName(Se.Language.Translate.AdvancedSettings);
+        buttonAdvanced.Bind(Button.IsVisibleProperty, new Binding(nameof(vm.LlamaCppAdvancedButtonIsVisible)));
+        if (Se.Settings.Appearance.ShowHints)
+        {
+            ToolTip.SetTip(buttonAdvanced, Se.Language.Translate.AdvancedSettings);
+        }
+
         var panelEngineControls = UiUtil.MakeHorizontalPanel(
             cbEngines,
             labelModel,
             textBoxModel,
             buttonModel,
             labelCrispAsrModel,
-            crispAsrModelCombo);
+            crispAsrModelCombo,
+            buttonAdvanced);
 
         var labelSourceLanguage = UiUtil.MakeLabel(Se.Language.General.From);
         var sourceLangCombo = UiUtil.MakeComboBox(vm.SourceLanguages, vm, nameof(vm.SelectedSourceLanguage));

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -221,6 +221,10 @@ public partial class AutoTranslateViewModel : ObservableObject
         Configuration.Settings.Tools.LmStudioModel = Se.Settings.AutoTranslate.LmStudioModel;
         Configuration.Settings.Tools.LmStudioPrompt = Se.Settings.AutoTranslate.LmStudioPrompt;
 
+        // Only the translate-settings dialog writes the llama.cpp prompt back, so without this the
+        // saved one is lost on the next start (a curated model's own prompt still takes precedence).
+        Configuration.Settings.Tools.LlamaCppPrompt = Se.Settings.AutoTranslate.LlamaCppPrompt;
+
         Configuration.Settings.Tools.GroqApiKey = Se.Settings.AutoTranslate.GroqApiKey;
         Configuration.Settings.Tools.GroqModel = Se.Settings.AutoTranslate.GroqModel;
         Configuration.Settings.Tools.GroqPrompt = Se.Settings.AutoTranslate.GroqPrompt;

--- a/src/ui/Features/Translate/LlamaCppAdvanced/AdvancedTranslatorBase.cs
+++ b/src/ui/Features/Translate/LlamaCppAdvanced/AdvancedTranslatorBase.cs
@@ -15,12 +15,12 @@ namespace Nikse.SubtitleEdit.Features.Translate.LlamaCppAdvanced;
 /// Shared batch/context translation loop of the "advanced" local-LLM engines: sends numbered
 /// batches with a rolling history of already-translated lines plus user-configured
 /// synopsis/glossary/style, and requires a schema-constrained JSON reply so line alignment is
-/// guaranteed. The Auto-translate loop calls <see cref="TranslateBatchAsync"/> directly; the
-/// plain <see cref="Translate"/> path (used for "translate current line") is a context-free
-/// batch of one. Subclasses only supply the endpoint and, where the server needs one, the
-/// model name.
+/// guaranteed. The Auto-translate loop and batch convert both call <see cref="TranslateBatchAsync"/>
+/// (via <see cref="IBatchContextTranslator"/>); the plain <see cref="Translate"/> path (used for
+/// "translate current line") is a context-free batch of one. Subclasses only supply the endpoint
+/// and, where the server needs one, the model name.
 /// </summary>
-public abstract class AdvancedTranslatorBase : IAutoTranslator, IDisposable
+public abstract class AdvancedTranslatorBase : IAutoTranslator, IBatchContextTranslator, IDisposable
 {
     private LlamaCppAdvancedClient? _client;
 

--- a/tests/UI/Features/Tools/BatchConvert/BatchConvertAutoTranslateEngineTests.cs
+++ b/tests/UI/Features/Tools/BatchConvert/BatchConvertAutoTranslateEngineTests.cs
@@ -1,0 +1,55 @@
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.LogicalTree;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Features.Tools.BatchConvert;
+using Nikse.SubtitleEdit.Features.Tools.BatchConvert.FunctionViews;
+using Nikse.SubtitleEdit.Features.Translate.LlamaCppAdvanced;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Tools.BatchConvert;
+
+/// <summary>
+/// Batch convert builds its auto-translate view in code and keeps its own engine list, so an engine
+/// that works in the Auto-translate window can still be missing here - and the "Advanced..." button
+/// is only useful if its visibility actually follows the selected engine.
+/// </summary>
+public class BatchConvertAutoTranslateEngineTests
+{
+    [AvaloniaFact]
+    public void EngineList_ContainsLlamaCppAdvanced()
+    {
+        var viewModel = MakeViewModel();
+
+        Assert.Contains(viewModel.AutoTranslators, t => t is LlamaCppAdvancedTranslate);
+    }
+
+    [AvaloniaFact]
+    public void AdvancedButton_IsShownForLlamaCppAdvancedOnly()
+    {
+        var viewModel = MakeViewModel();
+        var view = ViewAutoTranslate.Make(viewModel);
+
+        var button = view.GetLogicalDescendants().OfType<Button>().FirstOrDefault(b =>
+            AutomationProperties.GetName(b) == Se.Language.Translate.AdvancedSettings);
+        Assert.NotNull(button);
+
+        foreach (var engine in viewModel.AutoTranslators)
+        {
+            viewModel.SelectedAutoTranslator = engine;
+            viewModel.OnAutoTranslatorChanged();
+
+            Assert.Equal(engine is LlamaCppAdvancedTranslate, viewModel.LlamaCppAdvancedButtonIsVisible);
+        }
+    }
+
+    private static BatchConvertViewModel MakeViewModel()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        using var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<BatchConvertViewModel>();
+    }
+}

--- a/tests/libuilogic/Translate/DoAutoTranslateTests.cs
+++ b/tests/libuilogic/Translate/DoAutoTranslateTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.UiLogic.AutoTranslate;
 using Nikse.SubtitleEdit.UiLogic.Translate;
@@ -28,6 +29,46 @@ public class DoAutoTranslateTests
         {
             ReceivedTexts.Add(text);
             return Task.FromResult(Translation(text));
+        }
+    }
+
+    /// <summary>
+    /// Stands in for the "advanced" local-LLM engines: translates whole batches itself and must
+    /// never see the plain per-line <see cref="IAutoTranslator.Translate"/> call.
+    /// </summary>
+    private sealed class FakeBatchTranslator : IAutoTranslator, IBatchContextTranslator
+    {
+        public int BatchSize { get; set; } = 4;
+        public List<int> BatchStartIndexes { get; } = new();
+
+        public string Name => "FakeBatchTranslator";
+        public string Url => "https://example.com";
+        public string Error { get; set; } = string.Empty;
+        public int MaxCharacters => 1500;
+
+        public void Initialize()
+        {
+        }
+
+        public List<TranslationPair> GetSupportedSourceLanguages() => new() { new TranslationPair("English", "en") };
+
+        public List<TranslationPair> GetSupportedTargetLanguages() => new() { new TranslationPair("Danish", "da") };
+
+        public Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
+        {
+            throw new InvalidOperationException("The per-line path must not be used for a batch-context engine");
+        }
+
+        public Task<int> TranslateBatchAsync(ObservableCollection<TranslateRow> rows, int index, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
+        {
+            BatchStartIndexes.Add(index);
+            var count = Math.Min(BatchSize, rows.Count - index);
+            for (var i = 0; i < count; i++)
+            {
+                rows[index + i].TranslatedText = "X" + rows[index + i].Text;
+            }
+
+            return Task.FromResult(count);
         }
     }
 
@@ -84,6 +125,29 @@ public class DoAutoTranslateTests
 
         Assert.Equal(lineCount, rows.Count);
         Assert.All(rows, row => Assert.False(string.IsNullOrEmpty(row.TranslatedText)));
+    }
+
+    [Fact]
+    public async Task BatchContextTranslator_DrivesItsOwnBatchLoop()
+    {
+        var translator = new FakeBatchTranslator { BatchSize = 4 };
+        // Single-line mode is a merge/split setting; the batch engine guarantees line alignment
+        // on its own and keeps batching regardless (same as the Auto-translate window).
+        var doAutoTranslate = new DoAutoTranslate { TranslateEachLineSeparately = true };
+        const int lineCount = 10;
+
+        var rows = await doAutoTranslate.DoTranslate(
+            MakeSubtitle(lineCount),
+            new TranslationPair("English", "en"),
+            new TranslationPair("Danish", "da"),
+            translator,
+            CancellationToken.None);
+
+        Assert.Equal(lineCount, rows.Count);
+        Assert.All(rows, row => Assert.StartsWith("X", row.TranslatedText));
+
+        // 4 + 4 + 2 - the last batch is trimmed to what is left, and no line is sent twice.
+        Assert.Equal(new List<int> { 0, 4, 8 }, translator.BatchStartIndexes);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes the batch-translation half of #13671: batch convert had no way to use custom prompts or generation parameters, because the "llama.cpp advanced (local LLM)" engine was not available there at all.

### What was missing

Batch convert keeps its own eight-engine list and translates through `DoAutoTranslate`, which only knows the per-line `IAutoTranslator.Translate` call. The advanced engine's value — a user-written synopsis/glossary/style prompt, batch size, rolling context of already-translated lines, and sampling settings — lives in a separate batch loop that only the Auto-translate window drove. Listing the engine in batch convert without that loop would have degraded every request to a context-free single line: all of the JSON-schema protocol cost, none of the benefit.

### Changes

- The batch loop is now reachable through a small `IBatchContextTranslator` interface in libuilogic. `DoAutoTranslate` drives it when the engine implements it and skips `MergeAndSplitHelper`'s merge/split heuristics, which the schema-guaranteed line alignment does not need (and which would break it).
- Batch convert lists `llama.cpp advanced (local LLM)` and shows the same **Advanced...** settings window as the Auto-translate window, editing the same shared settings.
- The pre-run gate that auto-detects, downloads and starts a local llama-server now covers the advanced engine too, so a batch run works without opening the Auto-translate window first.
- Fixed alongside: the user-edited llama.cpp prompt never reached a batch run. Only the translate-settings dialog wrote `Configuration.Settings.Tools.LlamaCppPrompt`, and SE5 does not persist those settings, so both batch convert and a freshly started Auto-translate window silently fell back to the built-in default prompt. A curated model's own prompt still takes precedence, as before.

### Verification

- End to end against a local llama-server (TranslateGemma 4B, EN→DA) through the batch convert code path: six lines translated in batches of three, all aligned and in Danish.
- New tests: `DoAutoTranslate` drives the batch loop and never falls back to the per-line path (batches of 4+4+2, no line sent twice), and the batch convert **Advanced...** button reaches the logical tree and is visible for the advanced engine only.
- Full suites green: UI 2807, libuilogic 229, seconv 364.

Still missing in batch convert (not in this PR): the Ollama advanced engine and the cloud engines (ChatGPT, Anthropic, Gemini, Groq, OpenRouter, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)