### PR TITLE
TTS: add IndexTTS 2.5 engine on the audio.cpp runtime

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -160,6 +160,8 @@ using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Qwen3TtsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Qwen3TtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.VibeVoiceCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTtsCrispAsrSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTts25License;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTts25AudioCppSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.CosyVoice3CrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.F5TtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.OmniVoiceCrispAsrSettings;
@@ -275,6 +277,7 @@ public static class DependencyInjectionExtensions
         collection.AddHttpClientWithProxy<IQwen3TtsCrispAsrDownloadService, Qwen3TtsCrispAsrDownloadService>();
         collection.AddHttpClientWithProxy<IVibeVoiceCrispAsrDownloadService, VibeVoiceCrispAsrDownloadService>();
         collection.AddHttpClientWithProxy<IIndexTtsCrispAsrDownloadService, IndexTtsCrispAsrDownloadService>();
+        collection.AddHttpClientWithProxy<IIndexTts25AudioCppDownloadService, IndexTts25AudioCppDownloadService>();
         collection.AddHttpClientWithProxy<ICosyVoice3CrispAsrDownloadService, CosyVoice3CrispAsrDownloadService>();
         collection.AddHttpClientWithProxy<IF5TtsCrispAsrDownloadService, F5TtsCrispAsrDownloadService>();
         collection.AddHttpClientWithProxy<IOmniVoiceCrispAsrDownloadService, OmniVoiceCrispAsrDownloadService>();
@@ -457,6 +460,8 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<Qwen3TtsCrispAsrSettingsViewModel>();
         collection.AddTransient<VibeVoiceCrispAsrSettingsViewModel>();
         collection.AddTransient<IndexTtsCrispAsrSettingsViewModel>();
+        collection.AddTransient<IndexTts25LicenseViewModel>();
+        collection.AddTransient<IndexTts25AudioCppSettingsViewModel>();
         collection.AddTransient<CosyVoice3CrispAsrSettingsViewModel>();
         collection.AddTransient<F5TtsCrispAsrSettingsViewModel>();
         collection.AddTransient<OmniVoiceCrispAsrSettingsViewModel>();

--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -85,6 +85,13 @@ public partial class DownloadTtsViewModel : ObservableObject
     private readonly IQwen3TtsCrispAsrDownloadService _qwen3TtsCrispAsrDownloadService;
     private readonly IVibeVoiceCrispAsrDownloadService _vibeVoiceCrispAsrDownloadService;
     private readonly IIndexTtsCrispAsrDownloadService _indexTtsCrispAsrDownloadService;
+    private readonly IIndexTts25AudioCppDownloadService _indexTts25AudioCppDownloadService;
+    private Task? _downloadTaskIndexTts25AudioCppEngine;
+    private Task? _downloadTaskIndexTts25AudioCppModels;
+    private readonly MemoryStream _downloadStreamIndexTts25AudioCppEngine;
+    private readonly MemoryStream _downloadStreamIndexTts25AudioCppVoices;
+    private Task? _downloadTaskIndexTts25AudioCppVoices;
+    private string _indexTts25AudioCppBackend = IndexTts25AudioCppDownloadService.BackendCpu;
     private readonly ICosyVoice3CrispAsrDownloadService _cosyVoice3CrispAsrDownloadService;
     private readonly IF5TtsCrispAsrDownloadService _f5TtsCrispAsrDownloadService;
     private readonly IVoxCPM2CrispAsrDownloadService _voxCPM2CrispAsrDownloadService;
@@ -121,6 +128,7 @@ public partial class DownloadTtsViewModel : ObservableObject
         IQwen3TtsCrispAsrDownloadService qwen3TtsCrispAsrDownloadService,
         IVibeVoiceCrispAsrDownloadService vibeVoiceCrispAsrDownloadService,
         IIndexTtsCrispAsrDownloadService indexTtsCrispAsrDownloadService,
+        IIndexTts25AudioCppDownloadService indexTts25AudioCppDownloadService,
         ICosyVoice3CrispAsrDownloadService cosyVoice3CrispAsrDownloadService,
         IF5TtsCrispAsrDownloadService f5TtsCrispAsrDownloadService,
         IVoxCPM2CrispAsrDownloadService voxCPM2CrispAsrDownloadService,
@@ -136,6 +144,9 @@ public partial class DownloadTtsViewModel : ObservableObject
         _qwen3TtsCrispAsrDownloadService = qwen3TtsCrispAsrDownloadService;
         _vibeVoiceCrispAsrDownloadService = vibeVoiceCrispAsrDownloadService;
         _indexTtsCrispAsrDownloadService = indexTtsCrispAsrDownloadService;
+        _indexTts25AudioCppDownloadService = indexTts25AudioCppDownloadService;
+        _downloadStreamIndexTts25AudioCppEngine = new MemoryStream();
+        _downloadStreamIndexTts25AudioCppVoices = new MemoryStream();
         _cosyVoice3CrispAsrDownloadService = cosyVoice3CrispAsrDownloadService;
         _f5TtsCrispAsrDownloadService = f5TtsCrispAsrDownloadService;
         _voxCPM2CrispAsrDownloadService = voxCPM2CrispAsrDownloadService;
@@ -772,6 +783,172 @@ public partial class DownloadTtsViewModel : ObservableObject
                 }
                 OkPressed = true;
                 Close();
+            }
+
+            if (_downloadTaskIndexTts25AudioCppEngine is { IsCompletedSuccessfully: true })
+            {
+                _timer.Stop();
+
+                if (_downloadStreamIndexTts25AudioCppEngine.Length == 0)
+                {
+                    ProgressText = Se.Language.General.DownloadFailed;
+                    Error = Se.Language.General.NoDataReceived;
+                    return;
+                }
+
+                var folder = IndexTts25AudioCpp.GetSetEngineFolder();
+                try
+                {
+                    _downloadStreamIndexTts25AudioCppEngine.Position = 0;
+                    // Our archives are flat (binaries, LICENSE, BUILD-INFO.txt at the root) on
+                    // every platform, so no folder level to skip.
+                    _zipUnpacker.UnpackZipStream(_downloadStreamIndexTts25AudioCppEngine, folder, string.Empty, false, new List<string>(), null);
+                    WriteInstalledHashSidecar(folder, _downloadStreamIndexTts25AudioCppEngine, DownloadHashManager.ResolveIndexTts25AudioCppKey(_indexTts25AudioCppBackend));
+                    _downloadStreamIndexTts25AudioCppEngine.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    ProgressText = string.Format(Se.Language.General.UnpackFailed, ex.Message);
+                    Error = ex.Message;
+                    Se.LogError(ex);
+                    return;
+                }
+
+                var serverPath = IndexTts25AudioCpp.GetServerExecutable();
+                if (OperatingSystem.IsLinux())
+                {
+                    if (File.Exists(serverPath))
+                    {
+                        LinuxHelper.MakeExecutable(serverPath);
+                    }
+                }
+                else if (OperatingSystem.IsMacOS())
+                {
+                    if (File.Exists(serverPath))
+                    {
+                        MacHelper.MakeExecutable(serverPath);
+                    }
+                }
+
+                _downloadTaskIndexTts25AudioCppEngine = null;
+                OkPressed = true;
+                Close();
+                return;
+            }
+
+            if (_downloadTaskIndexTts25AudioCppEngine is { IsFaulted: true })
+            {
+                _timer.Stop();
+                var ex = _downloadTaskIndexTts25AudioCppEngine.Exception?.InnerException ?? _downloadTaskIndexTts25AudioCppEngine.Exception;
+                if (ex is OperationCanceledException)
+                {
+                    ProgressText = Se.Language.General.DownloadCanceled;
+                    Close();
+                }
+                else
+                {
+                    ProgressText = Se.Language.General.DownloadFailed;
+                    Error = ex?.Message ?? Se.Language.General.UnknownError;
+                }
+
+                return;
+            }
+
+            if (_downloadTaskIndexTts25AudioCppModels is { IsCompletedSuccessfully: true })
+            {
+                _timer.Stop();
+                _downloadTaskIndexTts25AudioCppModels = null;
+
+                // Chain the shared reference-voice pack (the same voices.zip the other cloning
+                // engines use), so the voice combo is not empty on first run — this engine can
+                // only clone, it has no built-in voices.
+                var voicesFolder = IndexTts25AudioCpp.GetSetVoicesFolder();
+                var voicesAlreadyInstalled = Directory.Exists(voicesFolder)
+                    && Directory.EnumerateFiles(voicesFolder, "*.wav").Any();
+                if (voicesAlreadyInstalled)
+                {
+                    OkPressed = true;
+                    Close();
+                    return;
+                }
+
+                TitleText = string.Format(Se.Language.General.DownloadingX, "IndexTTS 2.5 reference voices");
+                ProgressValue = 0;
+                ProgressText = Se.Language.General.StartingDotDotDot;
+                var voicesProgress = new Progress<float>(number =>
+                {
+                    var percentage = (int)Math.Round(number * 100.0, MidpointRounding.AwayFromZero);
+                    var pctString = percentage.ToString(CultureInfo.InvariantCulture);
+                    ProgressValue = percentage;
+                    ProgressText = string.Format(Se.Language.General.DownloadingXPercent, pctString);
+                });
+                _downloadTaskIndexTts25AudioCppVoices = _qwen3TtsCppDownloadService.DownloadVoices(
+                    _downloadStreamIndexTts25AudioCppVoices, voicesProgress, _cancellationTokenSource.Token);
+                _timer.Start();
+                return;
+            }
+
+            if (_downloadTaskIndexTts25AudioCppVoices is { IsCompletedSuccessfully: true })
+            {
+                _timer.Stop();
+                _downloadTaskIndexTts25AudioCppVoices = null;
+                if (_downloadStreamIndexTts25AudioCppVoices.Length > 0)
+                {
+                    var voicesFolder = IndexTts25AudioCpp.GetSetVoicesFolder();
+                    try
+                    {
+                        _downloadStreamIndexTts25AudioCppVoices.Position = 0;
+                        _zipUnpacker.UnpackZipStream(_downloadStreamIndexTts25AudioCppVoices, voicesFolder, string.Empty, false, new List<string>(), null);
+                        // The pack ships at 16 kHz; IndexTTS clones from 24 kHz references.
+                        ResampleVoicesTo24kHz(voicesFolder);
+                    }
+                    catch (Exception ex)
+                    {
+                        Se.LogError(ex);
+                    }
+
+                    _downloadStreamIndexTts25AudioCppVoices.Dispose();
+                }
+
+                OkPressed = true;
+                Close();
+                return;
+            }
+
+            if (_downloadTaskIndexTts25AudioCppVoices is { IsFaulted: true })
+            {
+                _timer.Stop();
+                _downloadTaskIndexTts25AudioCppVoices = null;
+                if (_cancellationTokenSource.IsCancellationRequested)
+                {
+                    ProgressText = Se.Language.General.DownloadCanceled;
+                    Close();
+                    return;
+                }
+
+                // A missing voice pack is not fatal — the model is already installed and the
+                // user can import their own reference WAV.
+                OkPressed = true;
+                Close();
+                return;
+            }
+
+            if (_downloadTaskIndexTts25AudioCppModels is { IsFaulted: true })
+            {
+                _timer.Stop();
+                var ex = _downloadTaskIndexTts25AudioCppModels.Exception?.InnerException ?? _downloadTaskIndexTts25AudioCppModels.Exception;
+                if (ex is OperationCanceledException)
+                {
+                    ProgressText = Se.Language.General.DownloadCanceled;
+                    Close();
+                }
+                else
+                {
+                    ProgressText = Se.Language.General.DownloadFailed;
+                    Error = ex?.Message ?? Se.Language.General.UnknownError;
+                }
+
+                return;
             }
 
             if (_downloadTaskIndexTtsCrispAsrModels is { IsCompletedSuccessfully: true })
@@ -1900,6 +2077,51 @@ public partial class DownloadTtsViewModel : ObservableObject
 
         _downloadTaskIndexTtsCrispAsrModels =
             _indexTtsCrispAsrDownloadService.DownloadModels(IndexTtsCrispAsr.GetSetModelsFolder(), resolved, downloadProgress, titleProgress, _cancellationTokenSource.Token);
+    }
+
+    /// <summary>
+    /// Downloads the audio.cpp engine archive for the picked backend. The archives are
+    /// .tar.gz on macOS/Linux and .zip on Windows; UnpackZipStream sniffs the gzip magic and
+    /// picks the right reader, so both go through the same call.
+    /// </summary>
+    public void StartDownloadIndexTts25AudioCppEngine(string backend)
+    {
+        _indexTts25AudioCppBackend = backend;
+        TitleText = string.Format(Se.Language.General.DownloadingX, $"audio.cpp ({backend})");
+
+        var downloadProgress = new Progress<float>(number =>
+        {
+            var percentage = (int)Math.Round(number * 100.0, MidpointRounding.AwayFromZero);
+            var pctString = percentage.ToString(CultureInfo.InvariantCulture);
+            ProgressValue = percentage;
+            ProgressText = string.Format(Se.Language.General.DownloadingXPercent, pctString);
+        });
+
+        _downloadTaskIndexTts25AudioCppEngine =
+            _indexTts25AudioCppDownloadService.DownloadEngine(_downloadStreamIndexTts25AudioCppEngine, backend, downloadProgress, _cancellationTokenSource.Token);
+    }
+
+    public void StartDownloadIndexTts25AudioCppModels(string? modelKey = null)
+    {
+        var resolved = IndexTts25AudioCpp.ResolveModelKey(modelKey);
+        var fileName = IndexTts25AudioCpp.GetModelFileName(resolved);
+        TitleText = string.Format(Se.Language.General.DownloadingX, $"IndexTTS 2.5 model ({resolved}): {fileName}");
+
+        var downloadProgress = new Progress<float>(number =>
+        {
+            var percentage = (int)Math.Round(number * 100.0, MidpointRounding.AwayFromZero);
+            var pctString = percentage.ToString(CultureInfo.InvariantCulture);
+            ProgressValue = percentage;
+            ProgressText = string.Format(Se.Language.General.DownloadingXPercent, pctString);
+        });
+
+        var titleProgress = new Action<string>(title =>
+        {
+            Dispatcher.UIThread.Post(() => TitleText = title);
+        });
+
+        _downloadTaskIndexTts25AudioCppModels =
+            _indexTts25AudioCppDownloadService.DownloadModels(resolved, downloadProgress, titleProgress, _cancellationTokenSource.Token);
     }
 
     public void StartDownloadZonosTtsCrispAsrModels()

--- a/src/ui/Features/Video/TextToSpeech/Engines/IndexTts25AudioCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/IndexTts25AudioCpp.cs
@@ -1,0 +1,874 @@
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// IndexTTS-2.5 (IndexTeam / Bilibili) run through the audio.cpp runtime — a pure C++/ggml
+/// engine, no Python. Zero-shot voice cloning in Chinese, English, Japanese, Spanish and
+/// Arabic, with emotion control and speaking-rate control.
+///
+/// Unlike <see cref="IndexTtsCrispAsr"/> (IndexTTS-1.5 via CrispASR), audio.cpp's server
+/// honours a per-request <c>voice_ref</c>, so switching voice does NOT restart the server —
+/// only a model or backend change does. Everything else follows the same server-mode shape:
+/// one persistent process on a loopback port, OpenAI-style POST /v1/audio/speech.
+///
+/// The model is a single self-describing GGUF (the package spec is embedded), so no sidecar
+/// config/tokenizer files are needed next to it.
+///
+/// Licence note: the audio.cpp binaries are Apache-2.0, but the IndexTTS-2.5 *weights* are
+/// under the bilibili Model Use License, which is not OSI-approved and has to be accepted by
+/// the user before the first download — see <see cref="IsLicenseAccepted"/>.
+/// </summary>
+public class IndexTts25AudioCpp : ITtsEngine
+{
+    public string Name => "IndexTTS 2.5 (audio.cpp)";
+    public string Description => "IndexTTS-2.5 (Bilibili / IndexTeam) voice cloning in 5 languages, via audio.cpp";
+    public bool HasLanguageParameter => true;
+    public bool HasApiKey => false;
+    public bool HasRegion => false;
+    public bool HasModel => true;
+    public bool HasKeyFile => false;
+
+    // The Q8_0 GGUF is the default: same 22.05 kHz output as F16 at 1 GB less on disk. The
+    // "orig" dtype build (7.3 GB) is deliberately not offered — it is a debugging artifact.
+    public const string ModelKeyQ8_0 = "Q8_0 (~3.3 GB)";
+    public const string ModelKeyF16 = "F16 (~4.2 GB)";
+    public const string DefaultModelKey = ModelKeyQ8_0;
+
+    public const string ModelQ8_0FileName = "index-tts2_5-q8_0.gguf";
+    public const string ModelF16FileName = "index-tts2_5-f16.gguf";
+
+    /// <summary>Family name audio.cpp registers IndexTTS2/2.5 under; 2.5 is a variant of it.</summary>
+    public const string FamilyName = "index_tts2";
+
+    /// <summary>Model id used in the generated server config and in each request body.</summary>
+    private const string ServerModelId = "indextts25";
+
+    /// <summary>
+    /// Exact byte sizes on the audio-cpp/audio.cpp-gguf HuggingFace repo. A truncated GGUF is
+    /// the single most common failure here — a download that dies at 71% leaves a file the
+    /// loader rejects with "GGUF tensor data range is out of bounds", so size is checked
+    /// before the server is ever started. Same guard as IndexTtsCrispAsr.ExpectedFileSizes.
+    /// </summary>
+    private static readonly Dictionary<string, long> ExpectedFileSizes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [ModelQ8_0FileName] = 3502955328L,
+        [ModelF16FileName] = 4547355072L,
+    };
+
+    /// <summary>
+    /// Bumping this re-prompts every user with the licence window. Keep it in step with the
+    /// licence text shipped in the accept dialog.
+    /// </summary>
+    public const string LicenseVersion = "bilibili-model-use-license-2026-08";
+
+    public static bool IsLicenseAccepted() =>
+        string.Equals(
+            Se.Settings.Video.TextToSpeech.IndexTts25AudioCppLicenseAccepted,
+            LicenseVersion,
+            StringComparison.Ordinal);
+
+    public static void AcceptLicense() =>
+        Se.Settings.Video.TextToSpeech.IndexTts25AudioCppLicenseAccepted = LicenseVersion;
+
+    public static string ResolveModelKey(string? modelKey)
+    {
+        if (string.IsNullOrEmpty(modelKey))
+        {
+            var saved = Se.Settings.Video.TextToSpeech.IndexTts25AudioCppModel;
+            return string.IsNullOrEmpty(saved) ? DefaultModelKey : ResolveModelKey(saved);
+        }
+
+        return modelKey == ModelKeyF16 ? ModelKeyF16 : ModelKeyQ8_0;
+    }
+
+    public static string GetModelFileName(string? modelKey) =>
+        ResolveModelKey(modelKey) == ModelKeyF16 ? ModelF16FileName : ModelQ8_0FileName;
+
+    private static readonly HttpClient HttpClient = new()
+    {
+        Timeout = TimeSpan.FromMinutes(10),
+    };
+
+    private static readonly SemaphoreSlim ServerLock = new(1, 1);
+    private static Process? _serverProcess;
+    private static int _serverPort;
+    private static string? _serverLaunchCommand;
+    // Only the model and the backend are baked into the running server — voice is per request.
+    private static string? _serverModelKey;
+    private static string? _serverBackend;
+    private static bool _processExitHooked;
+    private static readonly StringBuilder _serverLog = new();
+
+    private static string ServerBaseUrl => $"http://127.0.0.1:{_serverPort}";
+
+    public Task<bool> IsInstalled(string? region) => Task.FromResult(File.Exists(GetServerExecutable()));
+
+    public override string ToString() => Name;
+
+    /// <summary>
+    /// Where the audio.cpp binaries live: <c>&lt;data&gt;/audio.cpp/</c>, a top-level folder like
+    /// CrispASR and llama.cpp. audio.cpp is a whole runtime rather than one model's engine, so
+    /// a second audio.cpp-backed engine reuses this install instead of downloading its own.
+    /// </summary>
+    public static string GetSetEngineFolder()
+    {
+        var folder = Se.AudioCppFolder;
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        return folder;
+    }
+
+    /// <summary>
+    /// Per-engine working folder under TextToSpeech (voices, synthesis output), matching where
+    /// <see cref="IndexTtsCrispAsr"/> keeps its own — the binaries are shared, this is not.
+    /// </summary>
+    public static string GetSetFolder()
+    {
+        if (!Directory.Exists(Se.TextToSpeechFolder))
+        {
+            Directory.CreateDirectory(Se.TextToSpeechFolder);
+        }
+
+        var folder = Path.Combine(Se.TextToSpeechFolder, "IndexTts25AudioCpp");
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        return folder;
+    }
+
+    /// <summary>
+    /// audio.cpp is pointed at a directory, not a file, so the GGUF gets its own folder under
+    /// the shared models root: <c>&lt;data&gt;/audio.cpp/models/IndexTTS2.5-GGUF/</c>.
+    /// </summary>
+    public static string GetSetModelsFolder()
+    {
+        var folder = Path.Combine(GetSetEngineFolder(), "models", "IndexTTS2.5-GGUF");
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        return folder;
+    }
+
+    public static string GetSetVoicesFolder()
+    {
+        var folder = Path.Combine(GetSetFolder(), "voices");
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        SeedVoicesFromQwen3TtsCppIfEmpty(folder);
+        return folder;
+    }
+
+    private static bool _voiceSeedAttempted;
+
+    /// <summary>
+    /// One-time best-effort seed of reference WAVs from the shared voice pack another engine
+    /// already downloaded, so the voice combo is not empty on first run — this engine clones
+    /// only and has no built-in voices. The pack ships at 16 kHz and IndexTTS clones from
+    /// 24 kHz, so resample on seed rather than letting the server upsample per request.
+    /// </summary>
+    private static void SeedVoicesFromQwen3TtsCppIfEmpty(string voicesFolder)
+    {
+        if (_voiceSeedAttempted)
+        {
+            return;
+        }
+
+        _voiceSeedAttempted = true;
+
+        try
+        {
+            if (Directory.EnumerateFiles(voicesFolder, "*.wav").Any())
+            {
+                return;
+            }
+
+            var sourceFolder = Qwen3TtsCpp.GetSetVoicesFolder();
+            if (!Directory.Exists(sourceFolder) || !Directory.EnumerateFiles(sourceFolder, "*.wav").Any())
+            {
+                return;
+            }
+
+            foreach (var src in Directory.GetFiles(sourceFolder, "*.wav"))
+            {
+                var dest = Path.Combine(voicesFolder, Path.GetFileName(src));
+                VoiceSeedHelper.CopyOrResample(src, dest, 24000, "IndexTTS 2.5 (audio.cpp)");
+            }
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, "IndexTTS 2.5 (audio.cpp): voice seeding from the shared voice pack failed");
+        }
+    }
+
+    public static string GetServerExecutable() =>
+        Path.Combine(GetSetEngineFolder(), OperatingSystem.IsWindows() ? "audiocpp_server.exe" : "audiocpp_server");
+
+    public static string GetModelPath(string? modelKey = null) =>
+        Path.Combine(GetSetModelsFolder(), GetModelFileName(modelKey));
+
+    public static bool IsValidLocalModelFile(string path, string fileName)
+    {
+        if (!File.Exists(path))
+        {
+            return false;
+        }
+
+        if (!ExpectedFileSizes.TryGetValue(fileName, out var expected))
+        {
+            return true;
+        }
+
+        try
+        {
+            var info = new FileInfo(path);
+
+            // FileInfo.Length reports the size of the *link* for a symlink, not of its target,
+            // so a symlinked GGUF (a reasonable way to share a 3.3 GB model between apps or
+            // put it on another disk) would look truncated — and the caller deletes files it
+            // considers truncated. Resolve to the final target before measuring.
+            var length = info.ResolveLinkTarget(returnFinalTarget: true) is FileInfo target
+                ? target.Length
+                : info.Length;
+
+            return length == expected;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public static bool AreModelsInstalled(string? modelKey = null) =>
+        IsValidLocalModelFile(GetModelPath(modelKey), GetModelFileName(modelKey));
+
+    public static DownloadHashManager.UpdateStatus GetEngineUpdateStatus()
+    {
+        var exe = GetServerExecutable();
+        if (!File.Exists(exe))
+        {
+            return DownloadHashManager.UpdateStatus.Unknown;
+        }
+
+        var folder = Path.GetDirectoryName(exe);
+        return string.IsNullOrEmpty(folder)
+            ? DownloadHashManager.UpdateStatus.Unknown
+            : DownloadHashManager.GetSidecarStatus(folder);
+    }
+
+    /// <summary>
+    /// ggml backend the installed archive was built for. Stored at install time by
+    /// <see cref="AudioCppDownloadService"/>; falls back to the only backend that can be
+    /// assumed per platform when the marker is missing.
+    /// </summary>
+    public static string GetBackend()
+    {
+        var saved = Se.Settings.Video.TextToSpeech.IndexTts25AudioCppBackend;
+        if (!string.IsNullOrEmpty(saved))
+        {
+            return saved;
+        }
+
+        return OperatingSystem.IsMacOS() ? "metal" : "cpu";
+    }
+
+    public async Task<Voice[]> GetVoices(string language)
+    {
+        var result = new List<Voice>();
+
+        // Voice cloning only — the combo stays empty until the user imports a reference WAV.
+        var voicesFolder = await Task.Run(GetSetVoicesFolder);
+        if (Directory.Exists(voicesFolder))
+        {
+            foreach (var file in Directory.GetFiles(voicesFolder, "*.wav"))
+            {
+                var name = Path.GetFileNameWithoutExtension(file).Replace('_', ' ');
+                result.Add(new Voice(new IndexTtsVoice(name, file)));
+            }
+        }
+
+        return result.ToArray();
+    }
+
+    public bool IsVoiceInstalled(Voice voice) => true;
+
+    public Task<string[]> GetRegions() => Task.FromResult(Array.Empty<string>());
+
+    public Task<string[]> GetModels() => Task.FromResult(new[] { ModelKeyQ8_0, ModelKeyF16 });
+
+    /// <summary>
+    /// The five languages IndexTTS-2.5 was trained on. audio.cpp defaults to "auto", which
+    /// only distinguishes Han-script (zh) from everything else (en) — so ja/es/ar have to be
+    /// selected explicitly or they are synthesised with the wrong language's phonology.
+    /// </summary>
+    public Task<TtsLanguage[]> GetLanguages(Voice voice, string? model) => Task.FromResult(new[]
+    {
+        new TtsLanguage("auto", "Auto"),
+        new TtsLanguage("zh", "Chinese"),
+        new TtsLanguage("en", "English"),
+        new TtsLanguage("ja", "Japanese"),
+        new TtsLanguage("es", "Spanish"),
+        new TtsLanguage("ar", "Arabic"),
+    });
+
+    public Task<Voice[]> RefreshVoices(string language, CancellationToken cancellationToken) =>
+        GetVoices(language);
+
+    public async Task<TtsResult> Speak(
+        string text,
+        string outputFolder,
+        Voice voice,
+        TtsLanguage? language,
+        string? region,
+        string? model,
+        CancellationToken cancellationToken)
+    {
+        if (voice.EngineVoice is not IndexTtsVoice indexVoice)
+        {
+            throw new ArgumentException("Voice is not an IndexTtsVoice");
+        }
+
+        if (string.IsNullOrEmpty(indexVoice.FilePath))
+        {
+            throw new InvalidOperationException(
+                "IndexTTS 2.5 (audio.cpp) requires a reference voice WAV. "
+                + "Import one via the voice settings, then pick it in the voice combo. "
+                + "3-10 s of clean speech works best.");
+        }
+
+        if (!IsLicenseAccepted())
+        {
+            throw new InvalidOperationException(
+                "The IndexTTS-2.5 model licence (bilibili Model Use License) has not been accepted.");
+        }
+
+        var modelKey = ResolveModelKey(model);
+        await EnsureServerRunningAsync(modelKey, cancellationToken);
+
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder), Guid.NewGuid() + ".wav");
+
+        // audio.cpp's OpenAI-style speech payload. Voice cloning goes through `voice_ref`,
+        // which accepts a server-side path object — and unlike CrispASR's indextts backend it
+        // is honoured per request, so no server restart when the user switches voice.
+        var options = new Dictionary<string, object>();
+
+        var languageCode = language?.Code;
+        if (!string.IsNullOrEmpty(languageCode) && !string.Equals(languageCode, "auto", StringComparison.OrdinalIgnoreCase))
+        {
+            options["language"] = languageCode;
+        }
+
+        // >1 slows down, <1 speeds up; the model's own duration control rather than a resample,
+        // so pitch is unaffected.
+        var durationFactor = Math.Clamp(Se.Settings.Video.TextToSpeech.IndexTts25AudioCppDurationFactor, 0.5, 2.0);
+        if (Math.Abs(durationFactor - 1.0) > 0.001)
+        {
+            options["duration_factor"] = durationFactor;
+        }
+
+        var emotion = Se.Settings.Video.TextToSpeech.IndexTts25AudioCppEmotion;
+        if (!string.IsNullOrEmpty(emotion) && !string.Equals(emotion, "none", StringComparison.OrdinalIgnoreCase))
+        {
+            var vector = GetEmotionVector(emotion);
+            if (vector != null)
+            {
+                options["emotion_vector"] = vector;
+                options["emotion_alpha"] = Math.Clamp(Se.Settings.Video.TextToSpeech.IndexTts25AudioCppEmotionAlpha, 0.0, 1.0);
+            }
+        }
+
+        var payload = new Dictionary<string, object>
+        {
+            ["model"] = ServerModelId,
+            ["input"] = text,
+            ["response_format"] = "wav",
+            ["voice_ref"] = new Dictionary<string, object>
+            {
+                ["type"] = "path",
+                ["path"] = indexVoice.FilePath,
+            },
+        };
+
+        if (options.Count > 0)
+        {
+            payload["options"] = options;
+        }
+
+        var body = JsonSerializer.Serialize(payload);
+        using var content = new StringContent(body, Encoding.UTF8, "application/json");
+        Se.WriteToolsLog($"IndexTTS 2.5 (audio.cpp): POST {ServerBaseUrl}/v1/audio/speech (voice={indexVoice}, textLen={text.Length})");
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await HttpClient.PostAsync($"{ServerBaseUrl}/v1/audio/speech", content, cancellationToken);
+        }
+        catch (HttpRequestException ex)
+        {
+            var serverLog = SnapshotServerLog();
+            var launchCommand = _serverLaunchCommand;
+            var died = _serverProcess?.HasExited == true;
+            if (died)
+            {
+                StopServerInternal();
+            }
+
+            var failMsg = $"IndexTTS 2.5 (audio.cpp) request failed — Voice: {indexVoice}, Text: {text}, "
+                + $"RequestJson: {body}, ServerExited: {died}, ServerLog: {serverLog}"
+                + LaunchCmdSuffix(launchCommand);
+            Se.LogError(ex, failMsg);
+            Se.WriteToolsLog(failMsg);
+
+            throw new InvalidOperationException(
+                (died
+                    ? "IndexTTS 2.5 (audio.cpp) — the audiocpp_server process crashed during synthesis."
+                    : "IndexTTS 2.5 (audio.cpp) request failed — the connection to audiocpp_server was dropped.")
+                + (string.IsNullOrEmpty(serverLog) ? string.Empty : $"{Environment.NewLine}Server log:{Environment.NewLine}{serverLog}")
+                + LaunchCmdSuffix(launchCommand),
+                ex);
+        }
+
+        using (response)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorBody = await SafeReadErrorAsync(response, cancellationToken);
+                var serverLog = SnapshotServerLog();
+                var launchCommand = _serverLaunchCommand;
+                var errMsg = $"IndexTTS 2.5 (audio.cpp) server error {(int)response.StatusCode} {response.StatusCode} — "
+                    + $"Voice: {indexVoice}, Text: {text}, RequestJson: {body}, "
+                    + $"ResponseBody: {errorBody}, ServerLog: {serverLog}"
+                    + LaunchCmdSuffix(launchCommand);
+                Se.LogError(errMsg);
+                Se.WriteToolsLog(errMsg);
+                throw new InvalidOperationException(
+                    $"IndexTTS 2.5 (audio.cpp) synthesis failed ({(int)response.StatusCode}): {errorBody}"
+                    + (string.IsNullOrEmpty(serverLog) ? string.Empty : $"{Environment.NewLine}Server log:{Environment.NewLine}{serverLog}")
+                    + LaunchCmdSuffix(launchCommand));
+            }
+
+            await using var fileStream = File.Create(outputFileName);
+            await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+            await contentStream.CopyToAsync(fileStream, cancellationToken);
+        }
+
+        return new TtsResult(outputFileName, text);
+    }
+
+    /// <summary>
+    /// The eight-slot emotion vector IndexTTS-2.5 takes, in the model's own order:
+    /// happy, angry, sad, afraid, disgusted, melancholic, surprised, calm.
+    /// </summary>
+    public static IReadOnlyList<string> EmotionNames { get; } = new[]
+    {
+        "happy", "angry", "sad", "afraid", "disgusted", "melancholic", "surprised", "calm",
+    };
+
+    private static double[]? GetEmotionVector(string emotion)
+    {
+        var index = -1;
+        for (var i = 0; i < EmotionNames.Count; i++)
+        {
+            if (string.Equals(EmotionNames[i], emotion, StringComparison.OrdinalIgnoreCase))
+            {
+                index = i;
+                break;
+            }
+        }
+
+        if (index < 0)
+        {
+            return null;
+        }
+
+        var vector = new double[EmotionNames.Count];
+        vector[index] = 1.0;
+        return vector;
+    }
+
+    private static async Task EnsureServerRunningAsync(string modelKey, CancellationToken ct)
+    {
+        var backend = GetBackend();
+
+        if (_serverProcess is { HasExited: false } && _serverPort != 0
+            && string.Equals(_serverModelKey, modelKey, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(_serverBackend, backend, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        await ServerLock.WaitAsync(ct);
+        try
+        {
+            if (_serverProcess is { HasExited: false } && _serverPort != 0
+                && string.Equals(_serverModelKey, modelKey, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(_serverBackend, backend, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            if (_serverProcess != null)
+            {
+                StopServerInternal();
+            }
+
+            var exe = GetServerExecutable();
+            if (!File.Exists(exe))
+            {
+                throw new FileNotFoundException(
+                    "audio.cpp server not found. Download the IndexTTS 2.5 engine first.", exe);
+            }
+
+            var modelFileName = GetModelFileName(modelKey);
+            var modelPath = GetModelPath(modelKey);
+            if (!IsValidLocalModelFile(modelPath, modelFileName))
+            {
+                throw new FileNotFoundException(
+                    File.Exists(modelPath)
+                        ? $"The IndexTTS-2.5 model file is incomplete: {modelPath}. Delete it and download again."
+                        : $"The IndexTTS-2.5 model file is missing: {modelPath}",
+                    modelPath);
+            }
+
+            // audio.cpp loads one GGUF per model directory, so a directory holding both quants
+            // would be ambiguous. Keep exactly the selected one in place.
+            var port = FindFreeLoopbackPort();
+            var configPath = WriteServerConfig(port, backend, modelKey);
+
+            var psi = new ProcessStartInfo
+            {
+                WorkingDirectory = Path.GetDirectoryName(exe) ?? GetSetEngineFolder(),
+                FileName = exe,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+            };
+            psi.ArgumentList.Add("--config");
+            psi.ArgumentList.Add(configPath);
+
+            var process = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start audiocpp_server (index_tts2)");
+
+            var launchCommand = FormatLaunchCommand(exe, psi.ArgumentList);
+            _serverLaunchCommand = launchCommand;
+            Se.WriteToolsLog($"IndexTTS 2.5 (audio.cpp) server starting — PID: {process.Id}, Cmd: {launchCommand}");
+
+            lock (_serverLog) _serverLog.Clear();
+            process.ErrorDataReceived += (_, e) =>
+            {
+                if (e.Data != null) lock (_serverLog) _serverLog.AppendLine(e.Data);
+            };
+            process.OutputDataReceived += (_, e) =>
+            {
+                if (e.Data != null) lock (_serverLog) _serverLog.AppendLine(e.Data);
+            };
+            process.BeginErrorReadLine();
+            process.BeginOutputReadLine();
+
+            _serverProcess = process;
+            _serverPort = port;
+            _serverModelKey = modelKey;
+            _serverBackend = backend;
+            HookProcessExitOnce();
+
+            // The config uses lazy_load, so /health answers within a second or two — the 3.3 GB
+            // model is only read on the first synthesis request. A long deadline here would just
+            // hide a crash-at-startup (e.g. a Vulkan build on a box with no Vulkan driver, which
+            // dies in the loader with 0xC0000135 before printing anything).
+            var deadline = DateTime.UtcNow.AddMinutes(2);
+            while (DateTime.UtcNow < deadline)
+            {
+                ct.ThrowIfCancellationRequested();
+                if (process.HasExited)
+                {
+                    var tail = SnapshotServerLog();
+                    var exitCode = process.ExitCode;
+                    var exitedLaunchCommand = _serverLaunchCommand;
+                    _serverProcess = null;
+                    _serverPort = 0;
+                    _serverLaunchCommand = null;
+                    _serverModelKey = null;
+                    _serverBackend = null;
+                    throw new InvalidOperationException(
+                        $"audiocpp_server exited during startup (code {exitCode}). "
+                        + DescribeStartupExit(exitCode, backend)
+                        + $" Output: {tail}"
+                        + LaunchCmdSuffix(exitedLaunchCommand));
+                }
+
+                if (await ProbeHealthAsync(port, TimeSpan.FromSeconds(2), ct))
+                {
+                    return;
+                }
+
+                await Task.Delay(TimeSpan.FromSeconds(1), ct);
+            }
+
+            var lastOutput = SnapshotServerLog();
+            var timeoutLaunchCommand = _serverLaunchCommand;
+            StopServerInternal();
+            throw new TimeoutException(
+                $"audiocpp_server did not report healthy within 2 minutes. Last output: {lastOutput}"
+                + LaunchCmdSuffix(timeoutLaunchCommand));
+        }
+        finally
+        {
+            ServerLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Turns the exit codes that mean "this build cannot run on this machine" into an
+    /// actionable message, since the process dies in the loader before it can print anything
+    /// useful of its own:
+    ///  - Windows 0xC0000135 / -1073741515 (STATUS_DLL_NOT_FOUND): a GPU build without its
+    ///    runtime. The Vulkan binaries import vulkan-1.dll (from the GPU driver) at load time.
+    ///  - Linux 127: the dynamic loader could not find a shared library. The Linux CUDA
+    ///    archive does NOT bundle libcudart.so.12 / libcublas.so.12 the way the Windows CUDA
+    ///    zip bundles its DLLs, so it needs a system CUDA 12 runtime.
+    /// </summary>
+    private static string DescribeStartupExit(int exitCode, string backend) => exitCode switch
+    {
+        -1073741515 => $"The {backend} build could not load its GPU runtime library. "
+            + "Re-download the engine and pick the CPU variant.",
+        -1073741795 => "The CPU build uses instructions this processor does not have.",
+        127 when string.Equals(backend, "cuda", StringComparison.OrdinalIgnoreCase) =>
+            "The Linux CUDA build needs the CUDA 12 runtime (libcudart.so.12 and libcublas.so.12) "
+            + "installed on this system. Install the CUDA 12 runtime, or re-download the engine "
+            + "and pick the CPU or Vulkan variant.",
+        127 => $"The {backend} build could not load a shared library it needs.",
+        _ => string.Empty,
+    };
+
+    /// <summary>
+    /// Writes the audio.cpp server config next to the binary. lazy_load keeps startup instant;
+    /// the model is read on first use and then stays resident until the server is stopped.
+    /// </summary>
+    private static string WriteServerConfig(int port, string backend, string modelKey)
+    {
+        var config = new Dictionary<string, object>
+        {
+            ["host"] = "127.0.0.1",
+            ["port"] = port,
+            ["backend"] = backend,
+            ["threads"] = Math.Max(1, Math.Min(8, Environment.ProcessorCount / 2)),
+            ["lazy_load"] = true,
+            ["models"] = new[]
+            {
+                new Dictionary<string, object>
+                {
+                    ["id"] = ServerModelId,
+                    ["family"] = FamilyName,
+                    ["path"] = GetSetModelsFolder(),
+                    ["task"] = "clon",
+                    ["mode"] = "offline",
+                },
+            },
+        };
+
+        var configPath = Path.Combine(GetSetEngineFolder(), "index-tts25-server.json");
+        File.WriteAllText(
+            configPath,
+            JsonSerializer.Serialize(config, new JsonSerializerOptions { WriteIndented = true }),
+            Encoding.UTF8);
+
+        Se.WriteToolsLog($"IndexTTS 2.5 (audio.cpp): server config written to {configPath} (model={modelKey}, backend={backend})");
+        return configPath;
+    }
+
+    private static string FormatLaunchCommand(string exe, System.Collections.ObjectModel.Collection<string> args)
+    {
+        static string Quote(string s) =>
+            !string.IsNullOrEmpty(s) && s.IndexOfAny(new[] { ' ', '\t' }) >= 0
+                ? "\"" + s.Replace("\"", "\\\"") + "\""
+                : s;
+
+        var sb = new StringBuilder(Quote(exe));
+        foreach (var a in args)
+        {
+            sb.Append(' ').Append(Quote(a));
+        }
+
+        return sb.ToString();
+    }
+
+    private static string LaunchCmdSuffix(string? launchCommand) =>
+        string.IsNullOrEmpty(launchCommand)
+            ? string.Empty
+            : $"{Environment.NewLine}Launch command: {launchCommand}";
+
+    private static async Task<string> SafeReadErrorAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        try
+        {
+            return await response.Content.ReadAsStringAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            return $"<failed to read error body: {ex.Message}>";
+        }
+    }
+
+    private static string SnapshotServerLog()
+    {
+        lock (_serverLog)
+        {
+            var s = _serverLog.ToString().TrimEnd();
+            return s.Length > 2000 ? s[^2000..] : s;
+        }
+    }
+
+    private static async Task<bool> ProbeHealthAsync(int port, TimeSpan timeout, CancellationToken ct)
+    {
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(timeout);
+            using var resp = await HttpClient.GetAsync($"http://127.0.0.1:{port}/health", cts.Token);
+            return resp.IsSuccessStatusCode;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static int FindFreeLoopbackPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    private static void HookProcessExitOnce()
+    {
+        if (_processExitHooked)
+        {
+            return;
+        }
+
+        _processExitHooked = true;
+        AppDomain.CurrentDomain.ProcessExit += (_, _) => StopServerInternal();
+    }
+
+    /// <summary>
+    /// Stop the audio.cpp server if running, releasing its ~4.6 GB working set. audio.cpp never
+    /// unloads a model on its own once loaded, so this is the only way the memory comes back.
+    /// </summary>
+    public static void StopServer() => StopServerInternal();
+
+    private static void StopServerInternal()
+    {
+        var p = _serverProcess;
+        _serverProcess = null;
+        _serverPort = 0;
+        _serverLaunchCommand = null;
+        _serverModelKey = null;
+        _serverBackend = null;
+        if (p == null)
+        {
+            return;
+        }
+
+        try
+        {
+            if (!p.HasExited)
+            {
+                p.Kill(entireProcessTree: true);
+                p.WaitForExit(2000);
+            }
+        }
+        catch
+        {
+            // best effort
+        }
+        finally
+        {
+            p.Dispose();
+        }
+    }
+
+    private static string GetUniqueDestinationFileName(string folder, string baseName)
+    {
+        var candidate = Path.Combine(folder, baseName + ".wav");
+        if (!File.Exists(candidate))
+        {
+            return candidate;
+        }
+
+        var number = 1;
+        do
+        {
+            candidate = Path.Combine(folder, $"{baseName}_{number}.wav");
+            number++;
+        } while (File.Exists(candidate));
+
+        return candidate;
+    }
+
+    public bool ImportVoice(string fileName)
+    {
+        if (string.IsNullOrEmpty(fileName) || !File.Exists(fileName))
+        {
+            return false;
+        }
+
+        var voicesFolder = GetSetVoicesFolder();
+        var baseName = Path.GetFileNameWithoutExtension(fileName);
+        var destinationFileName = GetUniqueDestinationFileName(voicesFolder, baseName);
+
+        // audio.cpp resamples the reference itself, but importing at 24 kHz mono keeps the
+        // reference clean and matches what the other IndexTTS engine stores.
+        try
+        {
+            var process = FfmpegGenerator.ConvertToMono24kHzWav(fileName, destinationFileName);
+            if (!process.Start())
+            {
+                return false;
+            }
+
+            process.WaitForExit();
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, "IndexTTS 2.5 (audio.cpp) voice import failed (ffmpeg conversion).");
+            return false;
+        }
+
+        return File.Exists(destinationFileName);
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/IndexTts25AudioCppSettings/IndexTts25AudioCppSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/IndexTts25AudioCppSettings/IndexTts25AudioCppSettingsViewModel.cs
@@ -1,0 +1,285 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTts25AudioCppSettings;
+
+public partial class IndexTts25AudioCppSettingsViewModel : ObservableObject
+{
+    // A SolidColorBrush set as Shape.Fill is parented into that shape's visual tree, so the
+    // same instance can't be shared across bound Ellipses. Fresh brush per assignment.
+    private static IBrush Green() => new SolidColorBrush(Color.FromRgb(0x4C, 0xAF, 0x50));
+    private static IBrush Amber() => new SolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00));
+    private static IBrush Red() => new SolidColorBrush(Color.FromRgb(0xF4, 0x43, 0x36));
+    private static IBrush Grey() => new SolidColorBrush(Color.FromRgb(0x9E, 0x9E, 0x9E));
+
+    /// <summary>Shown in the emotion combo when no emotion conditioning is applied.</summary>
+    public const string EmotionNone = "None";
+
+    private readonly IWindowService _windowService;
+    private readonly IFolderHelper _folderHelper;
+
+    [ObservableProperty] private string _engineLabel = string.Empty;
+    [ObservableProperty] private IBrush _engineBrush = Grey();
+    [ObservableProperty] private string _engineDownloadButtonText = string.Empty;
+    [ObservableProperty] private bool _isEngineInstalled;
+
+    [ObservableProperty] private string _modelQ8_0Label = string.Empty;
+    [ObservableProperty] private IBrush _modelQ8_0Brush = Grey();
+    [ObservableProperty] private string _modelF16Label = string.Empty;
+    [ObservableProperty] private IBrush _modelF16Brush = Grey();
+
+    [ObservableProperty] private string _voicesLabel = string.Empty;
+    [ObservableProperty] private string _modelsFolder = string.Empty;
+    [ObservableProperty] private string _voicesFolder = string.Empty;
+
+    public ObservableCollection<string> Emotions { get; } = new();
+
+    [ObservableProperty] private string _selectedEmotion = EmotionNone;
+    [ObservableProperty] private double _emotionAlpha = 0.8;
+    [ObservableProperty] private double _speed = 1.0;
+
+    /// <summary>
+    /// Whether the emotion strength slider does anything — it is ignored with no emotion set.
+    /// </summary>
+    public bool IsEmotionAlphaEnabled => !IsNone(SelectedEmotion);
+
+    public string EmotionAlphaLabel => $"Emotion strength {EmotionAlpha:0.00}";
+
+    /// <summary>
+    /// The UI talks about speed (right = faster), which is what everyone expects from a
+    /// speaking-rate slider. IndexTTS-2.5 itself takes the reciprocal — `duration_factor`,
+    /// where >1 means a LONGER output and therefore slower speech — so the two are inverted
+    /// on the way in and out. Storing the model's own units keeps the request payload and the
+    /// logs honest; only this dialog deals in speed.
+    /// </summary>
+    public string SpeedLabel => $"Speed {Speed:0.00}x";
+
+    partial void OnSelectedEmotionChanged(string value)
+    {
+        Se.Settings.Video.TextToSpeech.IndexTts25AudioCppEmotion = IsNone(value) ? string.Empty : value.ToLowerInvariant();
+        OnPropertyChanged(nameof(IsEmotionAlphaEnabled));
+    }
+
+    partial void OnEmotionAlphaChanged(double value)
+    {
+        OnPropertyChanged(nameof(EmotionAlphaLabel));
+        Se.Settings.Video.TextToSpeech.IndexTts25AudioCppEmotionAlpha = Math.Clamp(value, 0.0, 1.0);
+    }
+
+    partial void OnSpeedChanged(double value)
+    {
+        OnPropertyChanged(nameof(SpeedLabel));
+        var speed = Math.Clamp(value, 0.5, 2.0);
+        Se.Settings.Video.TextToSpeech.IndexTts25AudioCppDurationFactor = Math.Clamp(1.0 / speed, 0.5, 2.0);
+    }
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    public IndexTts25AudioCppSettingsViewModel(IWindowService windowService, IFolderHelper folderHelper)
+    {
+        _windowService = windowService;
+        _folderHelper = folderHelper;
+    }
+
+    public void Initialize()
+    {
+        Emotions.Clear();
+        Emotions.Add(EmotionNone);
+        foreach (var emotion in IndexTts25AudioCpp.EmotionNames)
+        {
+            Emotions.Add(Capitalize(emotion));
+        }
+
+        var savedEmotion = Se.Settings.Video.TextToSpeech.IndexTts25AudioCppEmotion;
+        SelectedEmotion = string.IsNullOrEmpty(savedEmotion) ? EmotionNone : Capitalize(savedEmotion);
+        EmotionAlpha = Math.Clamp(Se.Settings.Video.TextToSpeech.IndexTts25AudioCppEmotionAlpha, 0.0, 1.0);
+
+        var durationFactor = Math.Clamp(Se.Settings.Video.TextToSpeech.IndexTts25AudioCppDurationFactor, 0.5, 2.0);
+        Speed = Math.Clamp(1.0 / durationFactor, 0.5, 2.0);
+
+        ModelsFolder = IndexTts25AudioCpp.GetSetModelsFolder();
+        VoicesFolder = IndexTts25AudioCpp.GetSetVoicesFolder();
+        Refresh();
+    }
+
+    private void Refresh()
+    {
+        var exe = IndexTts25AudioCpp.GetServerExecutable();
+        IsEngineInstalled = File.Exists(exe);
+
+        var backend = Se.Settings.Video.TextToSpeech.IndexTts25AudioCppBackend;
+        var backendSuffix = string.IsNullOrEmpty(backend) ? string.Empty : $" ({backend})";
+
+        if (!IsEngineInstalled)
+        {
+            EngineLabel = string.Format(Se.Language.Video.TtsEngineNotInstalled, "audio.cpp");
+            EngineBrush = Red();
+            EngineDownloadButtonText = string.Format(Se.Language.General.DownloadX, "audio.cpp");
+        }
+        else if (IndexTts25AudioCpp.GetEngineUpdateStatus() == DownloadHashManager.UpdateStatus.UpdateAvailable)
+        {
+            EngineLabel = string.Format(Se.Language.Video.TtsEngineUpdateAvailable, "audio.cpp" + backendSuffix);
+            EngineBrush = Amber();
+            EngineDownloadButtonText = string.Format(Se.Language.Video.TtsUpdateX, "audio.cpp");
+        }
+        else
+        {
+            EngineLabel = "audio.cpp" + backendSuffix;
+            EngineBrush = Green();
+            EngineDownloadButtonText = string.Format(Se.Language.General.ReDownloadX, "audio.cpp");
+        }
+
+        ApplyModelStatus(
+            IndexTts25AudioCpp.AreModelsInstalled(IndexTts25AudioCpp.ModelKeyQ8_0),
+            label => ModelQ8_0Label = label,
+            brush => ModelQ8_0Brush = brush);
+
+        ApplyModelStatus(
+            IndexTts25AudioCpp.AreModelsInstalled(IndexTts25AudioCpp.ModelKeyF16),
+            label => ModelF16Label = label,
+            brush => ModelF16Brush = brush);
+
+        try
+        {
+            var wavCount = Directory.Exists(VoicesFolder)
+                ? Directory.GetFiles(VoicesFolder, "*.wav").Length
+                : 0;
+            VoicesLabel = wavCount == 0
+                ? "No voices imported"
+                : (wavCount == 1 ? "1 voice imported" : $"{wavCount} voices imported");
+        }
+        catch
+        {
+            VoicesLabel = string.Empty;
+        }
+    }
+
+    /// <summary>
+    /// Unlike the CrispASR engines there is no auto-download fallback: audio.cpp is pointed at
+    /// a model directory and fails if the GGUF is not there, so a missing model is simply
+    /// "Not downloaded" rather than "Auto-download on first use".
+    /// </summary>
+    private static void ApplyModelStatus(bool installed, Action<string> setLabel, Action<IBrush> setBrush)
+    {
+        if (installed)
+        {
+            setLabel("Installed");
+            setBrush(Green());
+            return;
+        }
+
+        setLabel("Not downloaded");
+        setBrush(Grey());
+    }
+
+    private static bool IsNone(string? emotion) =>
+        string.IsNullOrEmpty(emotion) || string.Equals(emotion, EmotionNone, StringComparison.OrdinalIgnoreCase);
+
+    private static string Capitalize(string value) =>
+        string.IsNullOrEmpty(value) ? value : char.ToUpperInvariant(value[0]) + value[1..];
+
+    [RelayCommand]
+    private async Task RedownloadEngine()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        await TtsVoiceInstaller.EnsureAudioCppForIndexTts25(Window, _windowService, forceRedownload: true);
+        Refresh();
+    }
+
+    [RelayCommand]
+    private async Task DownloadModel(string? modelKey)
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var resolved = IndexTts25AudioCpp.ResolveModelKey(modelKey);
+
+        // Same gate as the install flow: nothing is fetched before the model licence is
+        // accepted, including a download started from this dialog.
+        if (!IndexTts25AudioCpp.IsLicenseAccepted())
+        {
+            var licenseResult = await _windowService.ShowDialogAsync<IndexTts25License.IndexTts25LicenseWindow, IndexTts25License.IndexTts25LicenseViewModel>(Window, _ => { });
+            if (!licenseResult.OkPressed || !IndexTts25AudioCpp.IsLicenseAccepted())
+            {
+                return;
+            }
+        }
+
+        await _windowService.ShowDialogAsync<DownloadTts.DownloadTtsWindow, DownloadTts.DownloadTtsViewModel>(
+            Window, vm => vm.StartDownloadIndexTts25AudioCppModels(resolved));
+        Refresh();
+    }
+
+    [RelayCommand]
+    private async Task OpenModelsFolder()
+    {
+        if (Window == null || string.IsNullOrEmpty(ModelsFolder))
+        {
+            return;
+        }
+
+        try
+        {
+            await _folderHelper.OpenFolder(Window, ModelsFolder);
+        }
+        catch
+        {
+            // best-effort UX
+        }
+    }
+
+    [RelayCommand]
+    private async Task OpenVoicesFolder()
+    {
+        if (Window == null || string.IsNullOrEmpty(VoicesFolder))
+        {
+            return;
+        }
+
+        try
+        {
+            await _folderHelper.OpenFolder(Window, VoicesFolder);
+        }
+        catch
+        {
+            // best-effort UX
+        }
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/IndexTts25AudioCppSettings/IndexTts25AudioCppSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/IndexTts25AudioCppSettings/IndexTts25AudioCppSettingsWindow.cs
@@ -1,0 +1,312 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTts25AudioCppSettings;
+
+public class IndexTts25AudioCppSettingsWindow : Window
+{
+    private const int LabelWidth = 150;
+    private const int ValueWidth = 360;
+
+    private readonly IndexTts25AudioCppSettingsViewModel _vm;
+
+    public IndexTts25AudioCppSettingsWindow(IndexTts25AudioCppSettingsViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = Se.Language.Video.IndexTts25SettingsTitle;
+        SizeToContent = SizeToContent.WidthAndHeight;
+        CanResize = false;
+        MinWidth = 620;
+
+        _vm = vm;
+        vm.Window = this;
+        DataContext = vm;
+
+        Content = BuildContent(vm);
+
+        var ok = UiUtil.MakeButtonOk(vm.OkCommand);
+        Activated += delegate { ok.Focus(); };
+    }
+
+    private Border BuildContent(IndexTts25AudioCppSettingsViewModel vm)
+    {
+        var stack = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 14,
+            Children = { BuildHeader(), BuildDetails(vm), BuildActions(vm) },
+        };
+
+        var outerGrid = new Grid { Margin = UiUtil.MakeWindowMargin() };
+        outerGrid.Children.Add(stack);
+
+        return new Border
+        {
+            Child = outerGrid,
+            Padding = new Thickness(4),
+        };
+    }
+
+    private static StackPanel BuildHeader()
+    {
+        var title = new TextBlock
+        {
+            Text = "IndexTTS 2.5 (audio.cpp)",
+            FontSize = 18,
+            FontWeight = FontWeight.SemiBold,
+        };
+
+        var subtitle = new TextBlock
+        {
+            Text = new IndexTts25AudioCpp().Description,
+            FontSize = 12,
+            Opacity = 0.75,
+            Margin = new Thickness(0, 2, 0, 0),
+        };
+
+        return new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 0,
+            Children = { title, subtitle },
+        };
+    }
+
+    private static Border BuildDetails(IndexTts25AudioCppSettingsViewModel vm)
+    {
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(LabelWidth, GridUnitType.Pixel) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // engine
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // Q8_0
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // F16
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // voices
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // emotion
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // emotion strength
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // speed
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // folder
+            },
+            ColumnSpacing = 12,
+            RowSpacing = 10,
+        };
+
+        grid.Add(MakeLabel(Se.Language.General.Engine), 0, 0);
+        var enginePanel = MakeStatusPanel(nameof(vm.EngineBrush), nameof(vm.EngineLabel));
+        var engineButton = UiUtil.MakeButton(string.Empty, vm.RedownloadEngineCommand)
+            .WithIconLeft(IconNames.Download)
+            .WithMarginLeft(12);
+        engineButton.Bind(ContentControl.ContentProperty, new Binding(nameof(vm.EngineDownloadButtonText)));
+        enginePanel.Children.Add(engineButton);
+        grid.Add(enginePanel, 0, 1);
+
+        grid.Add(MakeLabel("Model " + IndexTts25AudioCpp.ModelKeyQ8_0), 1, 0);
+        var q8Panel = MakeStatusPanel(nameof(vm.ModelQ8_0Brush), nameof(vm.ModelQ8_0Label));
+        q8Panel.Children.Add(UiUtil.MakeButton(string.Empty, vm.DownloadModelCommand, IndexTts25AudioCpp.ModelKeyQ8_0)
+            .WithIconLeft(IconNames.Download)
+            .WithMarginLeft(12));
+        grid.Add(q8Panel, 1, 1);
+
+        grid.Add(MakeLabel("Model " + IndexTts25AudioCpp.ModelKeyF16), 2, 0);
+        var f16Panel = MakeStatusPanel(nameof(vm.ModelF16Brush), nameof(vm.ModelF16Label));
+        f16Panel.Children.Add(UiUtil.MakeButton(string.Empty, vm.DownloadModelCommand, IndexTts25AudioCpp.ModelKeyF16)
+            .WithIconLeft(IconNames.Download)
+            .WithMarginLeft(12));
+        grid.Add(f16Panel, 2, 1);
+
+        grid.Add(MakeLabel(Se.Language.Video.Voices), 3, 0);
+        grid.Add(new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.VoicesLabel)),
+        }, 3, 1);
+
+        grid.Add(MakeLabel(Se.Language.Video.IndexTts25Emotion), 4, 0);
+        var emotionCombo = new ComboBox
+        {
+            Width = 200,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!ItemsControl.ItemsSourceProperty] = new Binding(nameof(vm.Emotions)),
+            [!ComboBox.SelectedItemProperty] = new Binding(nameof(vm.SelectedEmotion)),
+        };
+        grid.Add(emotionCombo, 4, 1);
+
+        grid.Add(MakeLabel(Se.Language.Video.IndexTts25EmotionStrength), 5, 0);
+        grid.Add(MakeEmotionAlphaPanel(), 5, 1);
+
+        grid.Add(MakeLabel(Se.Language.General.Speed), 6, 0);
+        grid.Add(MakeSpeedPanel(), 6, 1);
+
+        grid.Add(MakeLabel(Se.Language.General.InstallFolder), 7, 0);
+        grid.Add(new TextBox
+        {
+            IsReadOnly = true,
+            Width = ValueWidth,
+            BorderThickness = new Thickness(0),
+            Background = Brushes.Transparent,
+            Padding = new Thickness(0),
+            VerticalContentAlignment = VerticalAlignment.Center,
+            FontSize = 12,
+            [!TextBox.TextProperty] = new Binding(nameof(vm.ModelsFolder)),
+        }, 7, 1);
+
+        return new Border
+        {
+            Child = grid,
+            Padding = new Thickness(14),
+            CornerRadius = new CornerRadius(6),
+            BorderThickness = new Thickness(1),
+            BorderBrush = new SolidColorBrush(Color.FromArgb(0x40, 0x80, 0x80, 0x80)),
+        };
+    }
+
+    /// <summary>
+    /// Speaking rate, presented the way users expect: right is faster. The engine converts
+    /// this to IndexTTS-2.5's own `duration_factor`, which runs the other way (>1 = longer
+    /// output = slower speech). Range capped at 0.5-2.0, which is what the model supports.
+    /// </summary>
+    private static StackPanel MakeSpeedPanel()
+    {
+        var slider = new Slider
+        {
+            Minimum = 0.5,
+            Maximum = 2.0,
+            Width = 220,
+            TickFrequency = 0.05,
+            IsSnapToTickEnabled = true,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!Slider.ValueProperty] = new Binding(nameof(IndexTts25AudioCppSettingsViewModel.Speed)),
+        };
+        var label = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            Margin = new Thickness(8, 0, 0, 0),
+            Width = 90,
+            [!TextBlock.TextProperty] = new Binding(nameof(IndexTts25AudioCppSettingsViewModel.SpeedLabel)),
+        };
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { slider, label },
+        };
+    }
+
+    /// <summary>
+    /// Emotion blend strength. Disabled while the emotion is "None", since the model ignores
+    /// it without an emotion vector — a live slider that changes nothing reads as a bug.
+    /// </summary>
+    private static StackPanel MakeEmotionAlphaPanel()
+    {
+        var slider = new Slider
+        {
+            Minimum = 0.0,
+            Maximum = 1.0,
+            Width = 220,
+            TickFrequency = 0.05,
+            IsSnapToTickEnabled = true,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!Slider.ValueProperty] = new Binding(nameof(IndexTts25AudioCppSettingsViewModel.EmotionAlpha)),
+            [!IsEnabledProperty] = new Binding(nameof(IndexTts25AudioCppSettingsViewModel.IsEmotionAlphaEnabled)),
+        };
+        var label = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            Margin = new Thickness(8, 0, 0, 0),
+            Width = 150,
+            [!TextBlock.TextProperty] = new Binding(nameof(IndexTts25AudioCppSettingsViewModel.EmotionAlphaLabel)),
+            [!IsEnabledProperty] = new Binding(nameof(IndexTts25AudioCppSettingsViewModel.IsEmotionAlphaEnabled)),
+        };
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { slider, label },
+        };
+    }
+
+    private static StackPanel MakeStatusPanel(string brushBindingPath, string labelBindingPath)
+    {
+        var dot = new Ellipse
+        {
+            Width = 10,
+            Height = 10,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!Shape.FillProperty] = new Binding(brushBindingPath),
+        };
+        var text = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            Margin = new Thickness(8, 0, 0, 0),
+            [!TextBlock.TextProperty] = new Binding(labelBindingPath),
+        };
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { dot, text },
+        };
+    }
+
+    private static Control BuildActions(IndexTts25AudioCppSettingsViewModel vm)
+    {
+        var openModelsFolder = UiUtil.MakeButton(Se.Language.General.OpenContainingFolder, vm.OpenModelsFolderCommand).WithIconLeft(IconNames.FolderOpen);
+        var openVoicesFolder = UiUtil.MakeButton(Se.Language.Video.Voices, vm.OpenVoicesFolderCommand).WithIconLeft(IconNames.FolderOpen);
+        var close = UiUtil.MakeButtonOk(vm.OkCommand);
+
+        var leftPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            Children = { openModelsFolder, openVoicesFolder },
+        };
+
+        var rightPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Spacing = 8,
+            Children = { close },
+        };
+
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+        };
+        grid.Add(leftPanel, 0, 0);
+        grid.Add(rightPanel, 0, 2);
+        return grid;
+    }
+
+    private static TextBlock MakeLabel(string text) => new()
+    {
+        Text = text,
+        Opacity = 0.7,
+        VerticalAlignment = VerticalAlignment.Center,
+    };
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        _vm.OnKeyDown(e);
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/IndexTts25License/IndexTts25LicenseViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/IndexTts25License/IndexTts25LicenseViewModel.cs
@@ -1,0 +1,80 @@
+using Avalonia.Controls;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Logic.Config;
+using System.Diagnostics;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTts25License;
+
+/// <summary>
+/// First-run licence gate for the IndexTTS-2.5 weights. The audio.cpp engine binaries are
+/// Apache-2.0 and need no acceptance, but the model weights are under the bilibili Model Use
+/// License, which is not an OSI-approved open-source licence and puts real conditions on the
+/// user (commercial thresholds, prohibited uses, and a duty to pass the terms downstream).
+/// So this is shown once, before the 3.3 GB download starts, and the answer is remembered per
+/// licence version in <see cref="IndexTts25AudioCpp.LicenseVersion"/>.
+/// </summary>
+public partial class IndexTts25LicenseViewModel : ObservableObject
+{
+    public const string LicenseUrl = "https://huggingface.co/IndexTeam/IndexTTS-2.5/blob/main/LICENSE";
+    public const string ModelUrl = "https://huggingface.co/IndexTeam/IndexTTS-2.5";
+
+    /// <summary>
+    /// Summary of the terms that actually change what a user may do. Deliberately a summary
+    /// with a link to the full text rather than the whole agreement — nobody reads a wall of
+    /// legalese in a modal, and the points below are the ones that bite.
+    /// </summary>
+    public static string[] LicenseSummaryPoints { get; } =
+    {
+        "The model may be used free of charge, including for commercial work, unless your product had over 100 million monthly active users last month or over 1 billion RMB revenue last year — those cases need a separate licence from bilibili.",
+        "Generated audio must not be used to build or improve other AI models, except IndexTTS itself or non-commercial models.",
+        "High-risk deployment (medical, autonomous driving, military, critical infrastructure, large-scale biometric surveillance, automated credit or employment decisions) is prohibited without your own compliance work.",
+        "If you pass the model or anything derived from it to someone else, you must pass these terms on with it.",
+        "The model is provided as is, with no warranty, and bilibili accepts no liability for what is generated.",
+        "You are responsible for having the right to clone any voice you use as a reference. The model does not check consent.",
+    };
+
+    [ObservableProperty] private bool _isAccepted;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    [RelayCommand]
+    private void Accept()
+    {
+        if (!IsAccepted)
+        {
+            return;
+        }
+
+        IndexTts25AudioCpp.AcceptLicense();
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        OkPressed = false;
+        Window?.Close();
+    }
+
+    [RelayCommand]
+    private void OpenLicense() => OpenUrl(LicenseUrl);
+
+    [RelayCommand]
+    private void OpenModelPage() => OpenUrl(ModelUrl);
+
+    private static void OpenUrl(string url)
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+        }
+        catch (System.Exception ex)
+        {
+            Se.LogError(ex, $"IndexTTS 2.5: could not open {url}");
+        }
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/IndexTts25License/IndexTts25LicenseWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/IndexTts25License/IndexTts25LicenseWindow.cs
@@ -1,0 +1,154 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTts25License;
+
+/// <summary>
+/// Shown once before the first IndexTTS-2.5 download. The "accept" button stays disabled
+/// until the checkbox is ticked, so acceptance is a deliberate act rather than a reflex click
+/// on a default-focused OK.
+/// </summary>
+public class IndexTts25LicenseWindow : Window
+{
+    public IndexTts25LicenseWindow(IndexTts25LicenseViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = Se.Language.Video.IndexTts25LicenseTitle;
+        // Explicit width rather than SizeToContent.WidthAndHeight: on macOS the latter makes
+        // text-heavy windows far too wide.
+        Width = 640;
+        SizeToContent = SizeToContent.Height;
+        CanResize = false;
+
+        vm.Window = this;
+        DataContext = vm;
+
+        Content = BuildContent(vm);
+    }
+
+    private static Border BuildContent(IndexTts25LicenseViewModel vm)
+    {
+        var stack = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 14,
+            Children =
+            {
+                BuildHeader(),
+                BuildSummary(),
+                BuildLinks(vm),
+                BuildAcceptRow(vm),
+                BuildActions(vm),
+            },
+        };
+
+        var outerGrid = new Grid { Margin = UiUtil.MakeWindowMargin() };
+        outerGrid.Children.Add(stack);
+
+        return new Border
+        {
+            Child = outerGrid,
+            Padding = new Thickness(4),
+        };
+    }
+
+    private static StackPanel BuildHeader()
+    {
+        var title = new TextBlock
+        {
+            Text = Se.Language.Video.IndexTts25LicenseHeader,
+            FontSize = 18,
+            FontWeight = FontWeight.SemiBold,
+            TextWrapping = TextWrapping.Wrap,
+        };
+
+        var subtitle = new TextBlock
+        {
+            Text = Se.Language.Video.IndexTts25LicenseIntro,
+            FontSize = 12,
+            Opacity = 0.75,
+            TextWrapping = TextWrapping.Wrap,
+            Margin = new Thickness(0, 4, 0, 0),
+        };
+
+        return new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 0,
+            Children = { title, subtitle },
+        };
+    }
+
+    private static Border BuildSummary()
+    {
+        var stack = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 8,
+        };
+
+        foreach (var point in IndexTts25LicenseViewModel.LicenseSummaryPoints)
+        {
+            var row = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Spacing = 8,
+                Children =
+                {
+                    new TextBlock { Text = "•", Opacity = 0.7, VerticalAlignment = VerticalAlignment.Top },
+                    new TextBlock { Text = point, TextWrapping = TextWrapping.Wrap, MaxWidth = 560 },
+                },
+            };
+            stack.Children.Add(row);
+        }
+
+        return new Border
+        {
+            Child = stack,
+            Padding = new Thickness(12),
+            CornerRadius = new CornerRadius(4),
+            BorderThickness = new Thickness(1),
+            BorderBrush = new SolidColorBrush(Color.FromArgb(60, 128, 128, 128)),
+        };
+    }
+
+    private static StackPanel BuildLinks(IndexTts25LicenseViewModel vm)
+    {
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 16,
+            Children =
+            {
+                UiUtil.MakeLink(Se.Language.Video.IndexTts25LicenseReadFullText, vm.OpenLicenseCommand),
+                UiUtil.MakeLink(Se.Language.Video.IndexTts25LicenseModelPage, vm.OpenModelPageCommand),
+            },
+        };
+    }
+
+    private static CheckBox BuildAcceptRow(IndexTts25LicenseViewModel vm)
+    {
+        var checkBox = UiUtil.MakeCheckBox(
+            Se.Language.Video.IndexTts25LicenseAcceptCheckBox,
+            vm,
+            nameof(vm.IsAccepted));
+        return checkBox;
+    }
+
+    private static Control BuildActions(IndexTts25LicenseViewModel vm)
+    {
+        var accept = UiUtil.MakeButton(Se.Language.Video.IndexTts25LicenseAcceptAndDownload, vm.AcceptCommand);
+        // Bound to the checkbox so the download cannot start on an unread licence.
+        accept.Bind(
+            Button.IsEnabledProperty,
+            new Avalonia.Data.Binding(nameof(vm.IsAccepted)));
+
+        var cancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+
+        return UiUtil.MakeButtonBar(accept, cancel);
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -59,6 +59,9 @@ public partial class ReviewSpeechViewModel : ObservableObject
     [ObservableProperty] private bool _isPlayVisible;
     [ObservableProperty] private bool _isStopVisible;
     [ObservableProperty] private bool _isElevenLabsEngineV3Selected;
+    // Whether the picked engine has a settings dialog. The knobs in there (emotion, speed,
+    // instruction) change how a regenerated line sounds, so they belong next to Regenerate.
+    [ObservableProperty] private bool _isEngineSettingsVisible;
     [ObservableProperty] private double _stability;
     [ObservableProperty] private double _similarity;
     [ObservableProperty] private double _speakerBoost;
@@ -1343,6 +1346,17 @@ public partial class ReviewSpeechViewModel : ObservableObject
     // voice/model/instruction with the engine's defaults.
     private bool _suppressEngineRefreshDispatch;
 
+    [RelayCommand]
+    private async Task ShowEngineSettings()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        await TtsEngineSettingsDialog.ShowAsync(SelectedEngine, Window, _windowService);
+    }
+
     public void SelectedEngineChanged()
     {
         if (_suppressEngineRefreshDispatch)
@@ -1359,6 +1373,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
     public async Task SelectedEngineChangedAsync()
     {
         var engine = SelectedEngine;
+        IsEngineSettingsVisible = TtsEngineSettingsDialog.HasSettings(engine);
         if (engine == null)
         {
             return;

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechWindow.cs
@@ -264,6 +264,14 @@ public class ReviewSpeechWindow : Window
 
         var comboBoxEngines = UiUtil.MakeComboBox(vm.Engines, vm, nameof(vm.SelectedEngine)).WithMinWidth(controlMinWidth);
         comboBoxEngines.SelectionChanged += vm.SelectedEngineChanged;
+        var buttonEngineSettings = UiUtil.MakeButton(string.Empty, vm.ShowEngineSettingsCommand)
+            .WithIconLeft(IconNames.Settings)
+            .WithBindIsVisible(nameof(vm.IsEngineSettingsVisible));
+        if (Se.Settings.Appearance.ShowHints)
+        {
+            ToolTip.SetTip(buttonEngineSettings, Se.Language.General.Settings);
+        }
+
         var buttonElevenLabsRest = UiUtil.MakeButton(Se.Language.General.Reset, vm.ElevenLabsResetCommand)
             .WithIconLeft(IconNames.Repeat)
             .WithBindIsVisible(nameof(vm.IsElevenLabsControlsVisible));
@@ -284,6 +292,7 @@ public class ReviewSpeechWindow : Window
                     MinWidth = labelMinWidth,
                 },
                 comboBoxEngines,
+                buttonEngineSettings,
                 buttonElevenLabsRest,
             }
         };

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -25,6 +25,7 @@ using Nikse.SubtitleEdit.Features.Video.TextToSpeech.OmniVoiceCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.VoxCPM2CrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.MossTtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTtsCrispAsrSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTts25AudioCppSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.KokoroTtsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.PiperSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.OmniVoiceSettings;
@@ -224,6 +225,11 @@ public partial class TextToSpeechViewModel : ObservableObject
             // new VibeVoiceCrispAsr(),
             
             new IndexTtsCrispAsr(),
+
+            // IndexTTS 2.5 on the audio.cpp runtime (not CrispASR): 5 languages, emotion
+            // control and speaking-rate control, with a per-request reference voice so the
+            // server is not restarted when the voice changes.
+            new IndexTts25AudioCpp(),
             
             // F5-TTS (CrispASR) hidden: CrispASR 0.6.12 has no GPU backend for f5-tts, so
             // synthesis runs the fixed 32-step Euler ODE through a 22-layer DiT + Vocos on
@@ -405,6 +411,10 @@ public partial class TextToSpeechViewModel : ObservableObject
         else if (SelectedEngine is IndexTtsCrispAsr)
         {
             Se.Settings.Video.TextToSpeech.IndexTtsCrispAsrModel = SelectedModel ?? IndexTtsCrispAsr.DefaultModelKey;
+        }
+        else if (SelectedEngine is IndexTts25AudioCpp)
+        {
+            Se.Settings.Video.TextToSpeech.IndexTts25AudioCppModel = SelectedModel ?? IndexTts25AudioCpp.DefaultModelKey;
         }
         else if (SelectedEngine is CosyVoice3CrispAsr)
         {
@@ -1152,6 +1162,10 @@ public partial class TextToSpeechViewModel : ObservableObject
         {
             IndexTtsCrispAsr.StopServer();
         }
+        if (keepAlive is not IndexTts25AudioCpp)
+        {
+            IndexTts25AudioCpp.StopServer();
+        }
         if (keepAlive is not CosyVoice3CrispAsr)
         {
             CosyVoice3CrispAsr.StopServer();
@@ -1347,62 +1361,7 @@ public partial class TextToSpeechViewModel : ObservableObject
     [RelayCommand]
     private async Task ShowEngineSettings()
     {
-        if (SelectedEngine is OmniVoiceTtsCpp)
-        {
-            await _windowService.ShowDialogAsync<OmniVoiceSettingsWindow, OmniVoiceSettingsViewModel>(Window!, vm => vm.Initialize());
-        }
-        else if (SelectedEngine is Qwen3TtsCpp)
-        {
-            await _windowService.ShowDialogAsync<Qwen3TtsSettingsWindow, Qwen3TtsSettingsViewModel>(Window!, vm => vm.Initialize());
-        }
-        else if (SelectedEngine is Qwen3TtsCrispAsr)
-        {
-            await _windowService.ShowDialogAsync<Qwen3TtsCrispAsrSettingsWindow, Qwen3TtsCrispAsrSettingsViewModel>(Window!, vm => vm.Initialize());
-        }
-        else if (SelectedEngine is VibeVoiceCrispAsr)
-        {
-            await _windowService.ShowDialogAsync<VibeVoiceCrispAsrSettingsWindow, VibeVoiceCrispAsrSettingsViewModel>(Window!, vm => vm.Initialize());
-        }
-        else if (SelectedEngine is IndexTtsCrispAsr)
-        {
-            await _windowService.ShowDialogAsync<IndexTtsCrispAsrSettingsWindow, IndexTtsCrispAsrSettingsViewModel>(Window!, vm => vm.Initialize());
-        }
-        else if (SelectedEngine is CosyVoice3CrispAsr)
-        {
-            await _windowService.ShowDialogAsync<CosyVoice3CrispAsrSettingsWindow, CosyVoice3CrispAsrSettingsViewModel>(Window!, vm => vm.Initialize());
-        }
-        else if (SelectedEngine is F5TtsCrispAsr)
-        {
-            await _windowService.ShowDialogAsync<F5TtsCrispAsrSettingsWindow, F5TtsCrispAsrSettingsViewModel>(Window!, vm => vm.Initialize());
-        }
-        else if (SelectedEngine is OmniVoiceCrispAsr)
-        {
-            await _windowService.ShowDialogAsync<OmniVoiceCrispAsrSettingsWindow, OmniVoiceCrispAsrSettingsViewModel>(Window!, vm => vm.Initialize());
-        }
-        else if (SelectedEngine is VoxCPM2CrispAsr)
-        {
-            await _windowService.ShowDialogAsync<VoxCPM2CrispAsrSettingsWindow, VoxCPM2CrispAsrSettingsViewModel>(Window!, vm => vm.Initialize());
-        }
-        else if (SelectedEngine is MossTtsCrispAsr)
-        {
-            await _windowService.ShowDialogAsync<MossTtsCrispAsrSettingsWindow, MossTtsCrispAsrSettingsViewModel>(Window!, vm => vm.Initialize());
-        }
-        else if (SelectedEngine is KokoroTtsCpp)
-        {
-            await _windowService.ShowDialogAsync<KokoroTtsSettingsWindow, KokoroTtsSettingsViewModel>(Window!, vm => vm.Initialize());
-        }
-        else if (SelectedEngine is ChatterboxTtsCpp)
-        {
-            await _windowService.ShowDialogAsync<ChatterboxTtsSettingsWindow, ChatterboxTtsSettingsViewModel>(Window!, vm => vm.Initialize());
-        }
-        else if (SelectedEngine is Piper)
-        {
-            await _windowService.ShowDialogAsync<PiperSettingsWindow, PiperSettingsViewModel>(Window!, vm => vm.Initialize());
-        }
-        else
-        {
-            await _windowService.ShowDialogAsync<ElevenLabsSettingsWindow, ElevenLabsSettingsViewModel>(Window!, vm => { });
-        }
+        await TtsEngineSettingsDialog.ShowAsync(SelectedEngine, Window!, _windowService);
 
         // An engine may have been (re)downloaded inside its settings dialog - re-check the
         // install-status dots in the engine and model combos.
@@ -1469,6 +1428,9 @@ public partial class TextToSpeechViewModel : ObservableObject
                 break;
             case IndexTtsCrispAsr:
                 await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadIndexTtsCrispAsrModels(IndexTtsCrispAsr.ResolveModelKey(SelectedModel)));
+                break;
+            case IndexTts25AudioCpp:
+                await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadIndexTts25AudioCppModels(IndexTts25AudioCpp.ResolveModelKey(SelectedModel)));
                 break;
             case CosyVoice3CrispAsr:
                 await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadCosyVoice3CrispAsrModels(CosyVoice3CrispAsr.ResolveModelKey(SelectedModel)));
@@ -1538,6 +1500,9 @@ public partial class TextToSpeechViewModel : ObservableObject
                 ? DownloadDotStatus.UpToDate
                 : DownloadDotStatus.NotInstalled,
             IndexTtsCrispAsr => IndexTtsCrispAsr.AreModelsInstalled(modelKey)
+                ? DownloadDotStatus.UpToDate
+                : DownloadDotStatus.NotInstalled,
+            IndexTts25AudioCpp => IndexTts25AudioCpp.AreModelsInstalled(modelKey)
                 ? DownloadDotStatus.UpToDate
                 : DownloadDotStatus.NotInstalled,
             CosyVoice3CrispAsr => CosyVoice3CrispAsr.AreModelsInstalled(modelKey)
@@ -3507,6 +3472,16 @@ public partial class TextToSpeechViewModel : ObservableObject
             else if (SelectedEngine is IndexTtsCrispAsr)
             {
                 SelectedModel = Models.FirstOrDefault(p => p == Se.Settings.Video.TextToSpeech.IndexTtsCrispAsrModel);
+                if (string.IsNullOrEmpty(SelectedModel))
+                {
+                    SelectedModel = Models.FirstOrDefault();
+                }
+                IsEngineSettingsVisible = true;
+                IsModelDownloadVisible = true;
+            }
+            else if (SelectedEngine is IndexTts25AudioCpp)
+            {
+                SelectedModel = Models.FirstOrDefault(p => p == Se.Settings.Video.TextToSpeech.IndexTts25AudioCppModel);
                 if (string.IsNullOrEmpty(SelectedModel))
                 {
                     SelectedModel = Models.FirstOrDefault();

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
@@ -184,6 +184,8 @@ public class TextToSpeechWindow : Window
                 return StatusDots.From(engine.IsInstalled(null).Result, VibeVoiceCrispAsr.GetEngineUpdateStatus());
             case IndexTtsCrispAsr:
                 return StatusDots.From(engine.IsInstalled(null).Result, IndexTtsCrispAsr.GetEngineUpdateStatus());
+            case IndexTts25AudioCpp:
+                return StatusDots.From(engine.IsInstalled(null).Result, IndexTts25AudioCpp.GetEngineUpdateStatus());
             case CosyVoice3CrispAsr:
                 return StatusDots.From(engine.IsInstalled(null).Result, CosyVoice3CrispAsr.GetEngineUpdateStatus());
             case F5TtsCrispAsr:

--- a/src/ui/Features/Video/TextToSpeech/TtsEngineInstaller.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsEngineInstaller.cs
@@ -4,6 +4,7 @@ using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DownloadTts;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTts25License;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Download;
@@ -249,6 +250,63 @@ public static class TtsEngineInstaller
 
                 var dlResult = await windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(window, vm => vm.StartDownloadIndexTtsCrispAsrModels(indexModelKey));
                 if (!dlResult.OkPressed || !IndexTtsCrispAsr.AreModelsInstalled(indexModelKey))
+                {
+                    return false;
+                }
+
+                await Dispatcher.UIThread.InvokeAsync(async () =>
+                {
+                    await refreshVoices();
+                });
+                return true;
+            }
+
+            return true;
+        }
+
+        if (engine is IndexTts25AudioCpp)
+        {
+            // The model licence gate comes before anything is fetched: the weights are under
+            // the bilibili Model Use License (not open source), so the user has to accept it
+            // once before the first 3.3 GB download rather than after.
+            if (!IndexTts25AudioCpp.IsLicenseAccepted())
+            {
+                var licenseResult = await windowService.ShowDialogAsync<IndexTts25LicenseWindow, IndexTts25LicenseViewModel>(window, _ => { });
+                if (!licenseResult.OkPressed || !IndexTts25AudioCpp.IsLicenseAccepted())
+                {
+                    await MessageBox.Show(
+                        window,
+                        "IndexTTS 2.5",
+                        $"{Environment.NewLine}{Se.Language.Video.IndexTts25LicenseDeclined}",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Information);
+                    return false;
+                }
+            }
+
+            if (!await TtsVoiceInstaller.EnsureAudioCppForIndexTts25(window, windowService, forceRedownload: false))
+            {
+                return false;
+            }
+
+            var indexTts25ModelKey = IndexTts25AudioCpp.ResolveModelKey(model);
+            if (!IndexTts25AudioCpp.AreModelsInstalled(indexTts25ModelKey))
+            {
+                // Model key already carries its size (e.g. "Q8_0 (~3.3 GB)").
+                var answer = await MessageBox.Show(
+                    window,
+                    "Download IndexTTS 2.5 model?",
+                    $"{Environment.NewLine}\"IndexTTS 2.5 (audio.cpp)\" ({indexTts25ModelKey}) requires a model.{Environment.NewLine}{Environment.NewLine}Download model?",
+                    MessageBoxButtons.YesNoCancel,
+                    MessageBoxIcon.Question);
+
+                if (answer != MessageBoxResult.Yes)
+                {
+                    return false;
+                }
+
+                var dlResult = await windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(window, vm => vm.StartDownloadIndexTts25AudioCppModels(indexTts25ModelKey));
+                if (!dlResult.OkPressed || !IndexTts25AudioCpp.AreModelsInstalled(indexTts25ModelKey))
                 {
                     return false;
                 }

--- a/src/ui/Features/Video/TextToSpeech/TtsEngineSettingsDialog.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsEngineSettingsDialog.cs
@@ -1,0 +1,115 @@
+using Avalonia.Controls;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ChatterboxTtsSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.CosyVoice3CrispAsrSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ElevenLabsSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.F5TtsCrispAsrSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTts25AudioCppSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTtsCrispAsrSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.KokoroTtsSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.MossTtsCrispAsrSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.OmniVoiceCrispAsrSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.OmniVoiceSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.PiperSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Qwen3TtsCrispAsrSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Qwen3TtsSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.VibeVoiceCrispAsrSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.VoxCPM2CrispAsrSettings;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech;
+
+/// <summary>
+/// Per-engine settings dialog routing, shared by the main TTS window and the review window.
+/// The review window regenerates single lines with the same engine, so the knobs that change
+/// how a line sounds (emotion, speed, instruction, ...) have to be reachable from there too —
+/// otherwise a bad take can only be fixed by closing the review and starting over.
+/// </summary>
+public static class TtsEngineSettingsDialog
+{
+    /// <summary>
+    /// Whether this engine has a settings dialog worth showing a button for. Cloud engines
+    /// other than ElevenLabs have nothing to configure here.
+    /// </summary>
+    public static bool HasSettings(ITtsEngine? engine) => engine is
+        OmniVoiceTtsCpp or
+        Qwen3TtsCpp or
+        Qwen3TtsCrispAsr or
+        VibeVoiceCrispAsr or
+        IndexTts25AudioCpp or
+        IndexTtsCrispAsr or
+        CosyVoice3CrispAsr or
+        F5TtsCrispAsr or
+        OmniVoiceCrispAsr or
+        VoxCPM2CrispAsr or
+        MossTtsCrispAsr or
+        KokoroTtsCpp or
+        ChatterboxTtsCpp or
+        Piper or
+        ElevenLabs;
+
+    public static async Task ShowAsync(ITtsEngine? engine, Window window, IWindowService windowService)
+    {
+        if (engine is OmniVoiceTtsCpp)
+        {
+            await windowService.ShowDialogAsync<OmniVoiceSettingsWindow, OmniVoiceSettingsViewModel>(window, vm => vm.Initialize());
+        }
+        else if (engine is Qwen3TtsCpp)
+        {
+            await windowService.ShowDialogAsync<Qwen3TtsSettingsWindow, Qwen3TtsSettingsViewModel>(window, vm => vm.Initialize());
+        }
+        else if (engine is Qwen3TtsCrispAsr)
+        {
+            await windowService.ShowDialogAsync<Qwen3TtsCrispAsrSettingsWindow, Qwen3TtsCrispAsrSettingsViewModel>(window, vm => vm.Initialize());
+        }
+        else if (engine is VibeVoiceCrispAsr)
+        {
+            await windowService.ShowDialogAsync<VibeVoiceCrispAsrSettingsWindow, VibeVoiceCrispAsrSettingsViewModel>(window, vm => vm.Initialize());
+        }
+        else if (engine is IndexTts25AudioCpp)
+        {
+            await windowService.ShowDialogAsync<IndexTts25AudioCppSettingsWindow, IndexTts25AudioCppSettingsViewModel>(window, vm => vm.Initialize());
+        }
+        else if (engine is IndexTtsCrispAsr)
+        {
+            await windowService.ShowDialogAsync<IndexTtsCrispAsrSettingsWindow, IndexTtsCrispAsrSettingsViewModel>(window, vm => vm.Initialize());
+        }
+        else if (engine is CosyVoice3CrispAsr)
+        {
+            await windowService.ShowDialogAsync<CosyVoice3CrispAsrSettingsWindow, CosyVoice3CrispAsrSettingsViewModel>(window, vm => vm.Initialize());
+        }
+        else if (engine is F5TtsCrispAsr)
+        {
+            await windowService.ShowDialogAsync<F5TtsCrispAsrSettingsWindow, F5TtsCrispAsrSettingsViewModel>(window, vm => vm.Initialize());
+        }
+        else if (engine is OmniVoiceCrispAsr)
+        {
+            await windowService.ShowDialogAsync<OmniVoiceCrispAsrSettingsWindow, OmniVoiceCrispAsrSettingsViewModel>(window, vm => vm.Initialize());
+        }
+        else if (engine is VoxCPM2CrispAsr)
+        {
+            await windowService.ShowDialogAsync<VoxCPM2CrispAsrSettingsWindow, VoxCPM2CrispAsrSettingsViewModel>(window, vm => vm.Initialize());
+        }
+        else if (engine is MossTtsCrispAsr)
+        {
+            await windowService.ShowDialogAsync<MossTtsCrispAsrSettingsWindow, MossTtsCrispAsrSettingsViewModel>(window, vm => vm.Initialize());
+        }
+        else if (engine is KokoroTtsCpp)
+        {
+            await windowService.ShowDialogAsync<KokoroTtsSettingsWindow, KokoroTtsSettingsViewModel>(window, vm => vm.Initialize());
+        }
+        else if (engine is ChatterboxTtsCpp)
+        {
+            await windowService.ShowDialogAsync<ChatterboxTtsSettingsWindow, ChatterboxTtsSettingsViewModel>(window, vm => vm.Initialize());
+        }
+        else if (engine is Piper)
+        {
+            await windowService.ShowDialogAsync<PiperSettingsWindow, PiperSettingsViewModel>(window, vm => vm.Initialize());
+        }
+        else
+        {
+            await windowService.ShowDialogAsync<ElevenLabsSettingsWindow, ElevenLabsSettingsViewModel>(window, vm => { });
+        }
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
@@ -7,6 +7,7 @@ using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DownloadTts;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
 using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Download;
 using System;
 using System.IO;
@@ -170,6 +171,124 @@ public static class TtsVoiceInstaller
     /// present in the binary, for example); returning false there triggers a re-download
     /// even when CrispASR itself looks up to date.
     /// </summary>
+    /// <summary>
+    /// Ensures the audio.cpp runtime that IndexTTS 2.5 runs on is installed. Unlike the
+    /// CrispASR engines, these binaries are built by SubtitleEdit itself (upstream ships
+    /// Windows-only prebuilts), and the archive is per backend: Metal on Apple Silicon, and
+    /// CPU / Vulkan / CUDA on Windows and Linux x64.
+    /// </summary>
+    public static async Task<bool> EnsureAudioCppForIndexTts25(Window? window, IWindowService windowService, bool forceRedownload)
+    {
+        if (window == null)
+        {
+            return false;
+        }
+
+        var isInstalled = File.Exists(IndexTts25AudioCpp.GetServerExecutable());
+        if (!forceRedownload && isInstalled)
+        {
+            return true;
+        }
+
+        string backend;
+        if (Configuration.IsRunningOnMac)
+        {
+            if (RuntimeInformation.ProcessArchitecture != Architecture.Arm64)
+            {
+                await MessageBox.Show(
+                    window,
+                    "IndexTTS 2.5",
+                    $"{Environment.NewLine}IndexTTS 2.5 (audio.cpp) requires an Apple Silicon Mac.",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Information);
+                return false;
+            }
+
+            var answer = await MessageBox.Show(
+                window,
+                "Download audio.cpp?",
+                $"{Environment.NewLine}\"IndexTTS 2.5\" runs through the audio.cpp runtime. Download and install now?",
+                MessageBoxButtons.YesNoCancel,
+                MessageBoxIcon.Question);
+
+            if (answer != MessageBoxResult.Yes)
+            {
+                return false;
+            }
+
+            backend = IndexTts25AudioCppDownloadService.BackendMetal;
+        }
+        else if (Configuration.IsRunningOnWindows || Configuration.IsRunningOnLinux)
+        {
+            if (RuntimeInformation.ProcessArchitecture != Architecture.X64)
+            {
+                await MessageBox.Show(
+                    window,
+                    "IndexTTS 2.5",
+                    $"{Environment.NewLine}IndexTTS 2.5 (audio.cpp) is only built for x86-64 on Windows and Linux.",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Information);
+                return false;
+            }
+
+            var variantAnswer = await MessageBox.Show(
+                window,
+                "Download audio.cpp?",
+                $"{Environment.NewLine}\"IndexTTS 2.5\" runs through the audio.cpp runtime. Select a build to download:",
+                MessageBoxButtons.Cancel,
+                MessageBoxIcon.Question,
+                "CPU",
+                "Vulkan",
+                "CUDA");
+
+            if (variantAnswer == MessageBoxResult.None || variantAnswer == MessageBoxResult.Cancel)
+            {
+                return false;
+            }
+
+            backend = variantAnswer switch
+            {
+                MessageBoxResult.Custom2 => IndexTts25AudioCppDownloadService.BackendVulkan,
+                MessageBoxResult.Custom3 => IndexTts25AudioCppDownloadService.BackendCuda,
+                _ => IndexTts25AudioCppDownloadService.BackendCpu,
+            };
+
+            // The GPU builds import their runtime at load time, so a missing driver is not a
+            // slow fallback — the process dies in the loader before printing anything.
+            if (backend == IndexTts25AudioCppDownloadService.BackendVulkan && !VulkanHelper.IsInstalled())
+            {
+                var vulkanAnswer = await MessageBox.Show(
+                    window,
+                    "Vulkan driver may be required",
+                    $"The Vulkan build needs a Vulkan-capable GPU driver.{Environment.NewLine}{Environment.NewLine}Without it audio.cpp cannot start at all. Pick the CPU build instead if you are unsure.{Environment.NewLine}{Environment.NewLine}Continue with Vulkan download?",
+                    MessageBoxButtons.YesNoCancel,
+                    MessageBoxIcon.Question);
+
+                if (vulkanAnswer != MessageBoxResult.Yes)
+                {
+                    return false;
+                }
+            }
+        }
+        else
+        {
+            return false;
+        }
+
+        var dlResult = await windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(
+            window, vm => vm.StartDownloadIndexTts25AudioCppEngine(backend));
+
+        if (!dlResult.OkPressed || !File.Exists(IndexTts25AudioCpp.GetServerExecutable()))
+        {
+            return false;
+        }
+
+        // Remember which archive is on disk: the engine passes this straight to audio.cpp's
+        // server config as the ggml backend.
+        Se.Settings.Video.TextToSpeech.IndexTts25AudioCppBackend = backend;
+        return true;
+    }
+
     private static async Task<bool> EnsureCrispAsrAsync(
         Window? window,
         IWindowService windowService,

--- a/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
@@ -454,6 +454,7 @@ public partial class VoiceSettingsViewModel : ObservableObject
                                || engine.GetType() == typeof(Qwen3TtsCrispAsr)
                                || engine.GetType() == typeof(VibeVoiceCrispAsr)
                                || engine.GetType() == typeof(IndexTtsCrispAsr)
+                               || engine.GetType() == typeof(IndexTts25AudioCpp)
                                || engine.GetType() == typeof(CosyVoice3CrispAsr)
                                || engine.GetType() == typeof(F5TtsCrispAsr)
                                || engine.GetType() == typeof(VoxCPM2CrispAsr)

--- a/src/ui/Logic/Config/Language/Video/LanguageVideo.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageVideo.cs
@@ -63,6 +63,17 @@ public class LanguageVideo
     public string OutputSettingsTitle { get; set; }
     public string TtsCrispAsrSettingsTitle { get; set; }
     public string TtsDownloadEngineTitle { get; set; }
+    public string IndexTts25LicenseTitle { get; set; }
+    public string IndexTts25LicenseHeader { get; set; }
+    public string IndexTts25LicenseIntro { get; set; }
+    public string IndexTts25LicenseReadFullText { get; set; }
+    public string IndexTts25LicenseModelPage { get; set; }
+    public string IndexTts25LicenseAcceptCheckBox { get; set; }
+    public string IndexTts25LicenseAcceptAndDownload { get; set; }
+    public string IndexTts25LicenseDeclined { get; set; }
+    public string IndexTts25SettingsTitle { get; set; }
+    public string IndexTts25Emotion { get; set; }
+    public string IndexTts25EmotionStrength { get; set; }
     public string PickOnlineSubtitleFetching { get; set; }
     public string PickOnlineSubtitleNoneFound { get; set; }
     public string ForcedAligner { get; set; }
@@ -178,5 +189,16 @@ public class LanguageVideo
         OutputSettingsTitle = "Output settings";
         TtsCrispAsrSettingsTitle = "{0} (CrispASR) settings";
         TtsDownloadEngineTitle = "TTS - Download engine";
+        IndexTts25LicenseTitle = "IndexTTS 2.5 - model license";
+        IndexTts25LicenseHeader = "The IndexTTS 2.5 model has its own license";
+        IndexTts25LicenseIntro = "The audio.cpp engine is Apache-2.0, but the IndexTTS 2.5 model weights are licensed by bilibili under terms that are not open source. Please read the main points before downloading.";
+        IndexTts25LicenseReadFullText = "Read the full license";
+        IndexTts25LicenseModelPage = "Model page";
+        IndexTts25LicenseAcceptCheckBox = "I have read and accept the bilibili Model Use License Agreement";
+        IndexTts25LicenseAcceptAndDownload = "Accept and download";
+        IndexTts25LicenseDeclined = "IndexTTS 2.5 cannot be used until the model license is accepted.";
+        IndexTts25SettingsTitle = "IndexTTS 2.5 (audio.cpp) settings";
+        IndexTts25Emotion = "Emotion";
+        IndexTts25EmotionStrength = "Emotion strength";
     }
 }

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -167,6 +167,10 @@ public class Se
     public static string SpeechToTextFolder => Path.Combine(DataFolder, "SpeechToText");
     public static string CrispAsrFolder => Path.Combine(DataFolder, "CrispASR");
     public static string LlamaCppFolder => Path.Combine(DataFolder, "llama.cpp");
+    // audio.cpp is a multi-model runtime (TTS, ASR, VAD, separation), so it sits at the top
+    // level like CrispASR and llama.cpp rather than under a single feature's folder — the
+    // binaries are shared the moment a second audio.cpp-backed engine is added.
+    public static string AudioCppFolder => Path.Combine(DataFolder, "audio.cpp");
     public static string WaveformsFolder => Path.Combine(DataFolder, "Waveforms");
     public static string SpectrogramsFolder => Path.Combine(DataFolder, "Spectrograms");
     public static string ShotChangesFolder => Path.Combine(DataFolder, "ShotChanges");

--- a/src/ui/Logic/Config/SeVideoTextToSpeech.cs
+++ b/src/ui/Logic/Config/SeVideoTextToSpeech.cs
@@ -38,6 +38,18 @@ public class SeVideoTextToSpeech
     public double VibeVoiceCrispAsrSpeed { get; set; }
     public string IndexTtsCrispAsrModel { get; set; }
     public double IndexTtsCrispAsrSpeed { get; set; }
+    public string IndexTts25AudioCppModel { get; set; }
+    // Licence version the user accepted for the IndexTTS-2.5 weights (bilibili Model Use
+    // License, not OSI-approved). Empty until accepted; a version bump re-prompts.
+    public string IndexTts25AudioCppLicenseAccepted { get; set; }
+    // ggml backend of the installed audio.cpp archive: metal, cuda, vulkan or cpu.
+    public string IndexTts25AudioCppBackend { get; set; }
+    // The model's own duration control (>1 slower, <1 faster) rather than a resample, so
+    // pitch is unaffected. Valid range 0.5-2.0.
+    public double IndexTts25AudioCppDurationFactor { get; set; }
+    // One of IndexTts25AudioCpp.EmotionNames, or empty/"none" for no emotion conditioning.
+    public string IndexTts25AudioCppEmotion { get; set; }
+    public double IndexTts25AudioCppEmotionAlpha { get; set; }
     public string CosyVoice3CrispAsrModel { get; set; }
     public double CosyVoice3CrispAsrSpeed { get; set; }
     // Display name of the picked CosyVoice3 target language ("Auto" = plain zero-shot cloning).
@@ -140,6 +152,12 @@ public class SeVideoTextToSpeech
         VibeVoiceCrispAsrSpeed = 1.1;
         IndexTtsCrispAsrModel = "Q8_0 (~870 MB)";
         IndexTtsCrispAsrSpeed = 1.0;
+        IndexTts25AudioCppModel = "Q8_0 (~3.3 GB)";
+        IndexTts25AudioCppLicenseAccepted = string.Empty;
+        IndexTts25AudioCppBackend = string.Empty;
+        IndexTts25AudioCppDurationFactor = 1.0;
+        IndexTts25AudioCppEmotion = string.Empty;
+        IndexTts25AudioCppEmotionAlpha = 0.8;
         CosyVoice3CrispAsrModel = "Q4_K (~1.6 GB total)";
         CosyVoice3CrispAsrSpeed = 1.0;
         CosyVoice3CrispAsrLanguage = string.Empty;

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -187,6 +187,22 @@ public static class DownloadHashManager
         public const string Codec = "IndexTtsCrispAsr.Codec";
     }
 
+    public static class IndexTts25AudioCpp
+    {
+        // SHA-256 of the IndexTTS-2.5 GGUFs on audio-cpp/audio.cpp-gguf (HF LFS oid, confirmed
+        // against a local sha256sum of the Q8_0 file), plus the audio.cpp engine archives we
+        // build ourselves in SubtitleEdit/support-files.
+        public const string ModelQ8_0 = "IndexTts25AudioCpp.ModelQ8_0";
+        public const string ModelF16 = "IndexTts25AudioCpp.ModelF16";
+        public const string EngineMacArm64 = "IndexTts25AudioCpp.EngineMacArm64";
+        public const string EngineWindowsCpu = "IndexTts25AudioCpp.EngineWindowsCpu";
+        public const string EngineWindowsVulkan = "IndexTts25AudioCpp.EngineWindowsVulkan";
+        public const string EngineWindowsCuda = "IndexTts25AudioCpp.EngineWindowsCuda";
+        public const string EngineLinuxCpu = "IndexTts25AudioCpp.EngineLinuxCpu";
+        public const string EngineLinuxVulkan = "IndexTts25AudioCpp.EngineLinuxVulkan";
+        public const string EngineLinuxCuda = "IndexTts25AudioCpp.EngineLinuxCuda";
+    }
+
     public static class ZonosTtsCrispAsr
     {
         // SHA-256 of the Zonos-v0.1 transformer (Q8_0) and the shared DAC 44 kHz codec.
@@ -1585,6 +1601,49 @@ public static class DownloadHashManager
                 "fcba9a322d80ef318da8a17c01e8a5e7f299ccdf881c62a43abf62cb3c104268", // indextts-bigvgan.gguf
             },
 
+            // IndexTTS-2.5 weights, from audio-cpp/audio.cpp-gguf. Q8_0 confirmed by local
+            // sha256sum of the downloaded file; F16 is the HF LFS oid.
+            [IndexTts25AudioCpp.ModelQ8_0] = new[]
+            {
+                "5e827b2072042e4a1b21ccf24a5cb4f71cb1011403067a0a9b039311d8b38628", // index-tts2_5-q8_0.gguf
+            },
+            [IndexTts25AudioCpp.ModelF16] = new[]
+            {
+                "87bed9b82fc8f22119a1a1042332091016c28e37f29b0e93343ccdbfa76ef66a", // index-tts2_5-f16.gguf
+            },
+
+            // audio.cpp engine archives we build in SubtitleEdit/support-files
+            // (audiocpp-indextts25-2026-08-16-r4). Newest first — index 0 is the pinned release,
+            // so anything older prompts an update instead of being treated as current.
+            [IndexTts25AudioCpp.EngineMacArm64] = new[]
+            {
+                "7c23622c3d7d75efe3cec61fff542aab0de5c37a8bdef2be23c55b83cfba967a", // audiocpp-indextts25-macos-arm64.tar.gz
+            },
+            [IndexTts25AudioCpp.EngineWindowsCpu] = new[]
+            {
+                "6b843f9cb5ae8e35f5928a4b49ba95419b3083c6c478e0a5006efe9679f25a72", // audiocpp-indextts25-windows-x86_64-cpu.zip
+            },
+            [IndexTts25AudioCpp.EngineWindowsVulkan] = new[]
+            {
+                "25452a065fa525831436d9934d0e4196d1078f780ff32ac5cd74edb0112d556e", // audiocpp-indextts25-windows-x86_64-vulkan.zip
+            },
+            [IndexTts25AudioCpp.EngineWindowsCuda] = new[]
+            {
+                "af3c6c105ae08951d5cf48ffb0b4dc622831e2794b58dd682f23aeeef2724374", // audiocpp-indextts25-windows-x86_64-cuda.zip
+            },
+            [IndexTts25AudioCpp.EngineLinuxCpu] = new[]
+            {
+                "c9a061f7f0682787ca0b4d0a12f882a027d0db29cb3acbf1dbc9ff0a423ce78a", // audiocpp-indextts25-linux-x86_64.tar.gz
+            },
+            [IndexTts25AudioCpp.EngineLinuxVulkan] = new[]
+            {
+                "742263d8173030a3e6cf4603eb255791d73ea1c4a7b30c5886402a48ef49ed8d", // audiocpp-indextts25-linux-x86_64-vulkan.tar.gz
+            },
+            [IndexTts25AudioCpp.EngineLinuxCuda] = new[]
+            {
+                "4d5839e622c532d8bee9f7a9dcde0d40697009fa0698d27ea4142cea19cf0bcf", // audiocpp-indextts25-linux-x86_64-cuda.tar.gz
+            },
+
             // Zonos TTS (CrispASR) — cstr/zonos-v0.1-transformer-GGUF + cstr/dac-44khz-GGUF.
             // Hashes are HF LFS oid (= SHA-256) pulled from the tree API.
             [ZonosTtsCrispAsr.TalkerQ8_0] = new[]
@@ -2492,6 +2551,40 @@ public static class DownloadHashManager
     /// (Windows-only) variant ("cpu" / "vulkan" / "cuda"). Returns null when the
     /// combination is unknown.
     /// </summary>
+    /// <summary>
+    /// Hash key for the audio.cpp archive that backs IndexTTS 2.5, picked from the platform
+    /// and the backend the user chose at install time. macOS has a single arm64 Metal archive.
+    /// </summary>
+    public static string? ResolveIndexTts25AudioCppKey(string? backend)
+    {
+        if (OperatingSystem.IsMacOS())
+        {
+            return IndexTts25AudioCpp.EngineMacArm64;
+        }
+
+        if (OperatingSystem.IsWindows())
+        {
+            return backend switch
+            {
+                "cuda" => IndexTts25AudioCpp.EngineWindowsCuda,
+                "vulkan" => IndexTts25AudioCpp.EngineWindowsVulkan,
+                _ => IndexTts25AudioCpp.EngineWindowsCpu,
+            };
+        }
+
+        if (OperatingSystem.IsLinux())
+        {
+            return backend switch
+            {
+                "cuda" => IndexTts25AudioCpp.EngineLinuxCuda,
+                "vulkan" => IndexTts25AudioCpp.EngineLinuxVulkan,
+                _ => IndexTts25AudioCpp.EngineLinuxCpu,
+            };
+        }
+
+        return null;
+    }
+
     public static string? ResolveOmniVoiceKey(string? windowsVariant)
     {
         if (OperatingSystem.IsWindows())

--- a/src/ui/Logic/Download/IndexTts25AudioCppDownloadService.cs
+++ b/src/ui/Logic/Download/IndexTts25AudioCppDownloadService.cs
@@ -1,0 +1,227 @@
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.UiLogic;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Logic.Download;
+
+public interface IIndexTts25AudioCppDownloadService
+{
+    /// <summary>Downloads the audio.cpp engine archive for this platform and backend.</summary>
+    Task DownloadEngine(Stream stream, string backend, IProgress<float>? progress, CancellationToken cancellationToken);
+
+    /// <summary>Downloads the selected IndexTTS-2.5 GGUF into audio.cpp's models folder.</summary>
+    Task DownloadModels(string modelKey, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken);
+
+    /// <summary>Backends with an archive for the current platform, best first.</summary>
+    string[] GetAvailableBackends();
+}
+
+/// <summary>
+/// Engine binaries come from SubtitleEdit's own support-files release (built from upstream
+/// audio.cpp by .github/workflows/build-audiocpp-indextts-release.yml, since upstream ships
+/// Windows prebuilts only). Model weights come straight from HuggingFace and are never
+/// redistributed by us — they carry the bilibili Model Use License, which the user accepts in
+/// <see cref="Features.Video.TextToSpeech.IndexTts25License.IndexTts25LicenseWindow"/> first.
+/// </summary>
+public class IndexTts25AudioCppDownloadService : IIndexTts25AudioCppDownloadService
+{
+    private readonly HttpClient _httpClient;
+
+    private const string ReleaseTag = "audiocpp-indextts25-2026-08-16-r4";
+    private const string ReleaseBase =
+        "https://github.com/SubtitleEdit/support-files/releases/download/" + ReleaseTag + "/";
+
+    public const string BackendMetal = "metal";
+    public const string BackendCuda = "cuda";
+    public const string BackendVulkan = "vulkan";
+    public const string BackendCpu = "cpu";
+
+    private static readonly Dictionary<string, string> WindowsArchives = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [BackendCuda] = "audiocpp-indextts25-windows-x86_64-cuda.zip",
+        [BackendVulkan] = "audiocpp-indextts25-windows-x86_64-vulkan.zip",
+        [BackendCpu] = "audiocpp-indextts25-windows-x86_64-cpu.zip",
+    };
+
+    private static readonly Dictionary<string, string> LinuxArchives = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [BackendCuda] = "audiocpp-indextts25-linux-x86_64-cuda.tar.gz",
+        [BackendVulkan] = "audiocpp-indextts25-linux-x86_64-vulkan.tar.gz",
+        [BackendCpu] = "audiocpp-indextts25-linux-x86_64.tar.gz",
+    };
+
+    private const string MacArchive = "audiocpp-indextts25-macos-arm64.tar.gz";
+
+    private static readonly Dictionary<string, string> ModelUrls = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [IndexTts25AudioCpp.ModelQ8_0FileName] =
+            "https://huggingface.co/audio-cpp/audio.cpp-gguf/resolve/main/IndexTTS2.5-GGUF/index-tts2_5-q8_0.gguf",
+        [IndexTts25AudioCpp.ModelF16FileName] =
+            "https://huggingface.co/audio-cpp/audio.cpp-gguf/resolve/main/IndexTTS2.5-GGUF/index-tts2_5-f16.gguf",
+    };
+
+    public IndexTts25AudioCppDownloadService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    /// <summary>
+    /// Backends that have an archive for this platform, best first. macOS is Metal-only (the
+    /// archive is arm64; Intel Macs are not covered). Vulkan and CUDA archives need a driver
+    /// present — the binaries import their GPU runtime at load time and die with 0xC0000135
+    /// when it is missing — so CPU is always offered as the fallback.
+    /// </summary>
+    public string[] GetAvailableBackends()
+    {
+        if (OperatingSystem.IsMacOS())
+        {
+            return new[] { BackendMetal };
+        }
+
+        if (OperatingSystem.IsWindows() || OperatingSystem.IsLinux())
+        {
+            return new[] { BackendCuda, BackendVulkan, BackendCpu };
+        }
+
+        return Array.Empty<string>();
+    }
+
+    public async Task DownloadEngine(Stream stream, string backend, IProgress<float>? progress, CancellationToken cancellationToken)
+    {
+        await DownloadHelper.DownloadFileAsync(_httpClient, GetEngineUrl(backend), stream, progress, cancellationToken);
+    }
+
+    private static string GetEngineUrl(string backend)
+    {
+        if (OperatingSystem.IsMacOS())
+        {
+            if (RuntimeInformation.ProcessArchitecture != Architecture.Arm64)
+            {
+                throw new PlatformNotSupportedException(
+                    "IndexTTS 2.5 (audio.cpp) requires an Apple Silicon Mac.");
+            }
+
+            return ReleaseBase + MacArchive;
+        }
+
+        var archives = OperatingSystem.IsWindows() ? WindowsArchives
+            : OperatingSystem.IsLinux() ? LinuxArchives
+            : throw new PlatformNotSupportedException();
+
+        if (RuntimeInformation.ProcessArchitecture != Architecture.X64)
+        {
+            throw new PlatformNotSupportedException(
+                "IndexTTS 2.5 (audio.cpp) is only built for x86-64 on Windows and Linux.");
+        }
+
+        if (!archives.TryGetValue(backend, out var archive))
+        {
+            archive = archives[BackendCpu];
+        }
+
+        return ReleaseBase + archive;
+    }
+
+    public async Task DownloadModels(string modelKey, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken)
+    {
+        var fileName = IndexTts25AudioCpp.GetModelFileName(modelKey);
+        var finalPath = IndexTts25AudioCpp.GetModelPath(modelKey);
+
+        // A partial GGUF is worse than none: audio.cpp rejects it with "GGUF tensor data range
+        // is out of bounds", which reads like a corrupt model rather than a short download.
+        // Size-check on the threadpool — this runs from the download dialog's init callback.
+        await Task.Run(() => EnsureRemovedIfInvalid(finalPath, fileName), cancellationToken);
+
+        if (IndexTts25AudioCpp.IsValidLocalModelFile(finalPath, fileName))
+        {
+            return;
+        }
+
+        titleProgress?.Invoke($"Downloading IndexTTS 2.5 model: {fileName}");
+
+        var partPath = finalPath + ".part";
+        try
+        {
+            await DownloadHelper.DownloadFileAsync(_httpClient, GetModelUrl(fileName), partPath, progress, cancellationToken);
+            await VerifyFile(partPath, GetHashKey(fileName), fileName, cancellationToken);
+            File.Move(partPath, finalPath);
+        }
+        catch
+        {
+            TryDelete(partPath);
+            throw;
+        }
+    }
+
+    private static string GetModelUrl(string fileName)
+    {
+        if (!ModelUrls.TryGetValue(fileName, out var url))
+        {
+            throw new ArgumentException($"Unknown IndexTTS 2.5 model: {fileName}", nameof(fileName));
+        }
+
+        return url;
+    }
+
+    private static string? GetHashKey(string fileName)
+    {
+        if (string.Equals(fileName, IndexTts25AudioCpp.ModelQ8_0FileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.IndexTts25AudioCpp.ModelQ8_0;
+        }
+
+        if (string.Equals(fileName, IndexTts25AudioCpp.ModelF16FileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.IndexTts25AudioCpp.ModelF16;
+        }
+
+        return null;
+    }
+
+    private static async Task VerifyFile(string filePath, string? key, string fileName, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(key))
+        {
+            return;
+        }
+
+        var expected = DownloadHashManager.GetLatestKnownHash(key);
+        if (string.IsNullOrEmpty(expected))
+        {
+            return;
+        }
+
+        string actual;
+        await using (var stream = File.OpenRead(filePath))
+        {
+            actual = await Sha256Util.ComputeSha256Async(stream, cancellationToken);
+        }
+
+        if (!string.Equals(expected, actual, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new IOException(
+                $"IndexTTS 2.5 model {fileName} failed integrity check (expected SHA-256 {expected}, got {actual}).");
+        }
+    }
+
+    private static void TryDelete(string path)
+    {
+        try { File.Delete(path); } catch { /* best-effort cleanup */ }
+    }
+
+    private static void EnsureRemovedIfInvalid(string path, string fileName)
+    {
+        if (!File.Exists(path) || IndexTts25AudioCpp.IsValidLocalModelFile(path, fileName))
+        {
+            return;
+        }
+
+        TryDelete(path);
+    }
+}


### PR DESCRIPTION
Adds **IndexTTS 2.5** (IndexTeam / Bilibili) as a TTS engine, running on [audio.cpp](https://github.com/0xShug0/audio.cpp) — a pure C++/ggml audio runtime with no Python dependency.

Compared with the existing IndexTTS 1.5 (CrispASR) engine, 2.5 adds Japanese, Spanish and Arabic on top of Chinese and English, plus emotion control and speaking-rate control.

## Model licence

The audio.cpp binaries are Apache-2.0, but the **IndexTTS 2.5 weights are under the bilibili Model Use License**, which is not open source. So a one-time accept window is shown *before* the first download, summarising the terms that actually constrain a user (the 100M MAU / ¥1B revenue threshold, no using output to train other models, high-risk-use ban, pass-terms-downstream duty, no warranty, and that consent for a cloned voice is the user's responsibility) with links to the full text. Accept is disabled until the checkbox is ticked, and the answer is remembered per licence version.

Weights are never redistributed by us — they are fetched from Hugging Face at runtime.

## Binaries

Upstream ships Windows-only prebuilts, so the archives are built from upstream source at a pinned ref by a new workflow in `SubtitleEdit/support-files` and published as `audiocpp-indextts25-2026-08-16-r4`: macOS arm64 (Metal), Windows x64 (CPU / Vulkan / CUDA), Linux x64 (CPU / Vulkan / CUDA). These are composite builds (`--models index_tts2`), so the macOS archive is 8 MB rather than the whole 44-family runtime, and all are built with native-CPU tuning off for portability.

## Notes

- **Voice switching does not restart the server.** audio.cpp honours a per-request `voice_ref`, unlike CrispASR's indextts backend which only reads the reference passed at startup.
- `<data>/audio.cpp/` is a top-level folder like `CrispASR` and `llama.cpp`, since audio.cpp is a whole runtime that a second engine would share.
- The settings dialog shows **Speed** (right = faster) and converts to the model's `duration_factor`, which runs the opposite way (>1 = longer output = slower speech). Settings store the model's own units so request payloads and logs stay honest.
- Reference voices are seeded from the shared voice pack when it is already on disk from another engine; otherwise the pack download is chained after the model.
- The per-engine settings dialog routing is now shared with the review window (`TtsEngineSettingsDialog`), so emotion and speed can be changed before regenerating a line — previously that meant closing review and starting over. This gives *every* engine with a settings dialog a button there, not just this one.

## Verified on an M4

Ran end to end in the app: licence gate, 3.3 GB model download with SHA-256 verification, voice pack seeding (18 voices, resampled to 24 kHz), generation across multiple voices without a server restart, and clean server teardown on app exit.

Protocol and output were checked against a live audio.cpp server before the C# was written — all five languages transcribe back correctly, `duration_factor=1.3` produced exactly 1.30x duration, and the emotion vector and Qwen emotion-text paths both run.

**Performance caveat:** on Apple Silicon this is RTF ~1.6 (10.4 s of audio in 16.9 s), with ~6 s model load and 4.6 GB peak RSS. Upstream's much faster figure is CUDA; the Metal gap is in the CFM and vocoder stages. Fine for a few lines, slow for a feature-length dub.

**Known limitation:** the Linux CUDA archive dynamically links `libcudart.so.12` / `libcublas.so.12` and does not bundle them (the Windows CUDA zip does bundle its DLLs), so it needs a system CUDA 12 runtime. The engine turns the resulting exit code 127 into an actionable message pointing at the CPU/Vulkan variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
