### PR TITLE
Keep dialog dashes in 3-line "Remove text for HI" - #13681

### DIFF
--- a/src/libse/Forms/RemoveTextForHI.cs
+++ b/src/libse/Forms/RemoveTextForHI.cs
@@ -645,25 +645,27 @@ namespace Nikse.SubtitleEdit.Core.Forms
             else if (noOfNames == 2 && Utilities.GetNumberOfLines(newText) == 3 && Utilities.GetNumberOfLines(text) == 3)
             {
                 var dialogHelper = new DialogSplitMerge { DialogStyle = Configuration.Settings.General.DialogStyle, TwoLetterLanguageCode = language };
-                if (dialogHelper.IsDialog(text.SplitToLines()))
+                if (removedInFirstLine && removedInSecondLine)
                 {
-                    if (removedInFirstLine && removedInSecondLine)
+                    // a name was removed from the start of both of the first two lines,
+                    // so this is a dialog no matter what the third line looks like
+                    var arr = newText.SplitToLines();
+
+                    if (!arr[0].Contains('-') && !arr[0].Contains(':'))
                     {
-                        var arr = newText.SplitToLines();
-
-                        if (!arr[0].Contains('-') && !arr[0].Contains(':'))
-                        {
-                            arr[0] = InsertStartDashInLine(arr[0]);
-                        }
-
-                        if (!arr[1].Contains('-') && !arr[1].Contains(':'))
-                        {
-                            arr[1] = InsertStartDashInLine(arr[1]);
-                        }
-
-                        newText = string.Join(Environment.NewLine, arr);
+                        arr[0] = InsertStartDashInLine(arr[0]);
                     }
-                    else if (!removedInFirstLine && removedInSecondLine)
+
+                    if (!arr[1].Contains('-') && !arr[1].Contains(':'))
+                    {
+                        arr[1] = InsertStartDashInLine(arr[1]);
+                    }
+
+                    newText = string.Join(Environment.NewLine, arr);
+                }
+                else if (dialogHelper.IsDialog(text.SplitToLines()))
+                {
+                    if (!removedInFirstLine && removedInSecondLine)
                     {
                         var arr = newText.SplitToLines();
 

--- a/tests/libse/Forms/RemoveTextForHITest.cs
+++ b/tests/libse/Forms/RemoveTextForHITest.cs
@@ -113,4 +113,24 @@ public class RemoveTextForHITest
 
         Assert.Equal("Hello", remover.RemoveHearImpairedTags("{noise} Hello"));
     }
+
+    // --- Colon: the bug from issue #13681 ---
+
+    [Theory]
+    [InlineData("-UNA: I have it.|-M'BENGA: Good.|Get out of there.")]
+    [InlineData("- UNA: I have it.|- M'BENGA: Good.|Get out of there.")]
+    [InlineData("UNA: I have it.|M'BENGA: Good.|Get out of there.")]
+    public void Colon_ThreeLinesTwoSpeakers_KeepsDialogDashes(string input)
+    {
+        // The second speaker continues on the third line, so the text is not
+        // recognized as a dialog - but two names were removed from the first
+        // two lines, so both lines need a dialog dash.
+        var remover = MakeRemover();
+        remover.Settings.RemoveTextBeforeColon = true;
+
+        var text = input.Replace("|", Environment.NewLine);
+        var expected = "- I have it." + Environment.NewLine + "- Good." + Environment.NewLine + "Get out of there.";
+
+        Assert.Equal(expected, remover.RemoveTextFromHearImpaired(text, "en"));
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/SubtitleEdit/subtitleedit/issues/13681

### Problem

In a 3-line subtitle with two speakers, where the second speaker continues onto the third line, "Remove text for hearing impaired" removed the leading dialog dashes together with the speaker names:

```
-UNA: I have it.        I have it.
-M'BENGA: Good.     ->  Good.
Get out of there.       Get out of there.
```

### Cause

`RemoveColon` re-inserts dialog dashes for 3-line texts only when `DialogSplitMerge.IsDialog` says the original text is a dialog. That detector does not recognize this shape: `IsDialogThreeLinesOneTwo` requires the second line to *not* have a sentence ending (here it is `Good.`), and the remaining 3-line rule requires the third line to start with a dash.

### Fix

When a name was removed from the start of both of the first two lines, there are two speakers by definition — insert the dashes without consulting the dialog detector. The other two sub-cases (name in line 1+3 / line 2+3) keep the existing `IsDialog` gate.

```
-UNA: I have it.        - I have it.
-M'BENGA: Good.     ->  - Good.
Get out of there.       Get out of there.
```

### Tests

Added `Colon_ThreeLinesTwoSpeakers_KeepsDialogDashes` covering `-NAME:`, `- NAME:` and bare `NAME:` input. Full libse (1152), libuilogic (229) and seconv (364) suites pass.

Manually checked neighbouring shapes for regressions (single speaker over 2 lines, `12:30`, `The rule is:`, mid-line names, italics, empty name line) — output unchanged there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)