### PR TITLE
TTS review: destroy mpv cores off the UI thread in Stop and row playback

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -314,21 +314,29 @@ public partial class ReviewSpeechViewModel : ObservableObject
 
         try
         {
+            // Retire the previous row's core on a worker thread - disposing it inline here runs
+            // mpv_terminate_destroy on the UI thread, and every row-to-row transition (including
+            // the auto-continue timer path) would corrupt state that later blows up as an access
+            // violation in IFrameworkInputPane.Unadvise when a window closes (#13567, #13376).
+            DisposePlayerOffThread();
+
+            Se.WriteToolsLog($"TTS review: creating mpv core to play \"{fileName}\"");
+            LibMpvDynamicPlayer player;
             lock (_playLock)
             {
-                _mpvContext?.Stop();
-                _mpvContext?.Dispose();
-
-                _mpvContext = new LibMpvDynamicPlayer();
-                _mpvContext.LoadLib();
-                var err = _mpvContext.Initialize();
+                player = new LibMpvDynamicPlayer();
+                player.LoadLib();
+                var err = player.Initialize();
                 if (err < 0)
                 {
-                    throw new InvalidOperationException($"Failed to initialize mpv: {_mpvContext.GetErrorString(err)}");
+                    throw new InvalidOperationException($"Failed to initialize mpv: {player.GetErrorString(err)}");
                 }
+
+                _mpvContext = player;
             }
 
-            await _mpvContext.LoadAudio(fileName);
+            // Through the local: a close running now can null the field out from under us.
+            await player.LoadAudio(fileName);
         }
         catch (Exception exception)
         {
@@ -1039,14 +1047,13 @@ public partial class ReviewSpeechViewModel : ObservableObject
     [RelayCommand]
     private void Stop()
     {
+        Se.WriteToolsLog("TTS review: Stop clicked");
         _skipAutoContinue = true;
         _cancellationTokenSource.Cancel();
-        lock (_playLock)
-        {
-            _mpvContext?.Stop();
-            _mpvContext?.Dispose();
-            _mpvContext = null;
-        }
+
+        // Off-thread: an inline Dispose here is mpv_terminate_destroy on the UI thread, the
+        // pattern behind the delayed IFrameworkInputPane.Unadvise crash (#13567, #13376).
+        DisposePlayerOffThread();
 
         _playingRow = null;
         IsPlayVisible = true;
@@ -1056,6 +1063,8 @@ public partial class ReviewSpeechViewModel : ObservableObject
     [RelayCommand]
     private void Ok()
     {
+        Se.WriteToolsLog("TTS review: OK clicked - closing");
+
         // Push any edits the user made to row.Text back into the step results so
         // the caller sees them, then publish the included rows as StepResults.
         foreach (var row in Lines)
@@ -1080,6 +1089,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
     [RelayCommand]
     private void Cancel()
     {
+        Se.WriteToolsLog("TTS review: Cancel clicked - closing");
         Close();
     }
 
@@ -1835,6 +1845,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
             return;
         }
 
+        Se.WriteToolsLog("TTS review: disposing playback player (mpv) on worker thread");
         Task.Run(() =>
         {
             try
@@ -1842,6 +1853,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
                 // Stop first so the core tears down from an idle state instead of mid-playback.
                 player.Stop();
                 player.Dispose();
+                Se.WriteToolsLog("TTS review: playback player (mpv) destroyed");
             }
             catch (Exception ex)
             {
@@ -1857,6 +1869,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
         // still holds it) and skip the temp-file sweep below - the unwinding pipeline may still
         // be writing those files.
         var regenerateInFlight = !IsRegenerateEnabled;
+        Se.WriteToolsLog($"TTS review: window closing (regenerate in flight={regenerateInFlight})");
 
         _skipAutoContinue = true;
         _isClosing = true;

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -2126,7 +2126,12 @@ public partial class TextToSpeechViewModel : ObservableObject
     {
         try
         {
+            // Breadcrumb on both sides of Close(): the reported hard crash (#13567) is a native
+            // access violation inside Window.Close() that no catch can see, so a tools log that
+            // ends between these two lines pinpoints it.
+            Se.WriteToolsLog("TTS window: calling Window.Close()");
             Window?.Close();
+            Se.WriteToolsLog("TTS window: Window.Close() returned");
         }
         catch (Exception ex)
         {
@@ -2169,6 +2174,7 @@ public partial class TextToSpeechViewModel : ObservableObject
                 // Stop first so the core tears down from an idle state instead of mid-playback.
                 player.Stop();
                 player.Dispose();
+                Se.WriteToolsLog("TTS window: audio preview player (mpv) destroyed");
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Follow-up to the #13376 fix, for #13567 (still crashing in beta 14).

The reporter's beta 14 crash has the byte-identical fault offset as the beta 11 report: an access violation during `IFrameworkInputPane.Unadvise` while the TTS window's native window disposes. #13376's off-thread teardown covered the TTS window's voice preview and the review window's `OnClosing`, but two sites in `ReviewSpeechViewModel` still ran `mpv_terminate_destroy` on the UI thread:

- **`Stop()`** disposed the playback core inline.
- **`PlayAudio()`** disposed the *previous* core inline before creating the next one — so playing a second row, or just letting auto-continue advance through rows, tore down a core on the UI thread at every transition.

Both now route through the existing `DisposePlayerOffThread`, and `PlayAudio` adopts the local-variable pattern from `TextToSpeechViewModel.PlayAudio` (no half-initialized player left in `_mpvContext` on init failure, no null-deref race on `LoadAudio`).

Since the crash is machine-specific and uncatchable, this also adds tools-log breadcrumbs: review window play/stop/OK/Cancel/closing, mpv dispose start/finish in both windows, and a line on each side of the TTS window's `Window.Close()` call — a log ending between those two lines pinpoints the native crash.

Tests: `dotnet test tests/UI/UITests.csproj --filter "FullyQualifiedName~TextToSpeech|FullyQualifiedName~ReviewSpeech"` — 171 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)