### PR TITLE
Fix #13682: column paste anchors on the first selected row

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -419,6 +419,23 @@ public partial class MainViewModel :
     /// </summary>
     public int SubtitleGridSelectedCount => SubtitleGrid.SelectedItems?.Count ?? 0;
 
+    /// <summary>
+    /// Grid index of the topmost selected row, or -1 when nothing editable is selected - SE4's
+    /// <c>FirstSelectedIndex</c>. Commands that write downwards from the selection must start here
+    /// and not at <see cref="SelectedSubtitle"/>: the current row is the moving end of a shift- or
+    /// drag-selection (see <see cref="SelectGridRange"/>), so selecting downwards would put the
+    /// anchor at the *bottom* of the selection while selecting upwards put it at the top - the
+    /// column paste that only worked when the rows were picked bottom-to-top (issue #13682).
+    /// </summary>
+    internal int FirstSelectedSubtitleIndex
+    {
+        get
+        {
+            var selectedItems = SubtitleGridSelectedItems;
+            return selectedItems.Count == 0 ? -1 : Subtitles.IndexOf(selectedItems[0]);
+        }
+    }
+
     private List<SubtitleLineViewModel> GetSelectedSubtitlesInOrder(bool includeReferenceOnly)
     {
         var selected = SubtitleGrid.SelectedItems;
@@ -5465,12 +5482,14 @@ public partial class MainViewModel :
     [RelayCommand]
     private async Task ColumnInsertTextFromSubtitle()
     {
-        if (Window == null || SelectedSubtitle == null)
+        if (Window == null)
         {
             return;
         }
 
-        var idx = Subtitles.IndexOf(SelectedSubtitle);
+        // The texts are written downwards from the first selected row (SE4 parity), so the
+        // selection direction must not matter - see FirstSelectedSubtitleIndex (#13682).
+        var idx = FirstSelectedSubtitleIndex;
         if (idx < 0)
         {
             return;
@@ -5539,12 +5558,16 @@ public partial class MainViewModel :
     [RelayCommand]
     private async Task ColumnPasteFromClipboard()
     {
-        if (Window == null || SelectedSubtitle == null)
+        if (Window == null)
         {
             return;
         }
 
-        var idx = Subtitles.IndexOf(SelectedSubtitle);
+        // The clipboard is pasted downwards from the first selected row (SE4's FirstSelectedIndex),
+        // so the direction the rows were picked in must not matter - see
+        // FirstSelectedSubtitleIndex: anchoring on the current row made a top-to-bottom selection
+        // paste from the bottom row of the selection onto the lines below it (#13682).
+        var idx = FirstSelectedSubtitleIndex;
         if (idx < 0)
         {
             return;

--- a/tests/UI/Features/Main/SubtitleGridSelectionOrderTests.cs
+++ b/tests/UI/Features/Main/SubtitleGridSelectionOrderTests.cs
@@ -145,4 +145,28 @@ public class SubtitleGridSelectionOrderTests : IDisposable
 
         window.Close();
     }
+
+    /// <summary>
+    /// Column commands that write downwards from the selection start at the first selected row, not
+    /// at the current one. Because the current row is the moving end of a shift-selection, anchoring
+    /// on it made "Column &gt; Paste from clipboard &gt; Replace existing cells" work only when the
+    /// rows were picked bottom-to-top: picked top-to-bottom the anchor was the bottom row of the
+    /// selection, so the paste landed there and overwrote the lines below it (issue #13682).
+    /// </summary>
+    [AvaloniaTheory]
+    [InlineData(2, 6)] // downwards - the direction that pasted at the wrong row
+    [InlineData(6, 2)] // upwards
+    public void ShiftClick_KeepsTheFirstSelectedRowAsTheColumnAnchor_InBothDirections(int first, int second)
+    {
+        var (window, vm, grid) = ShowMainWindowWithLines();
+
+        Click(window, grid, first, RawInputModifiers.None);
+        Click(window, grid, second, RawInputModifiers.Shift);
+
+        // The current row is still the row the user stopped on - only the column anchor differs.
+        Assert.Same(vm.Subtitles[second], grid.SelectedItem);
+        Assert.Equal(Math.Min(first, second), vm.FirstSelectedSubtitleIndex);
+
+        window.Close();
+    }
 }


### PR DESCRIPTION
## Problem

Part 2 of #13682: **Column > Paste from clipboard > Replace existing cells** works when the rows are selected bottom-to-top, but pastes at the wrong place when the same rows are selected top-to-bottom.

`ColumnPasteFromClipboard` anchored on `Subtitles.IndexOf(SelectedSubtitle)`. `SelectedSubtitle` is the *moving end* of a shift- or drag-selection — `SelectGridRange` deliberately selects `currentIndex` first so the edit box and waveform follow the row the user stopped on. So:

- picked bottom-to-top → current row is the **top** of the selection → anchor correct, paste works;
- picked top-to-bottom → current row is the **bottom** of the selection → the paste starts there and writes over the lines *below* the selection instead of over the selection itself.

SE4 used `int index = FirstSelectedIndex;` (`4.0.16:src/ui/Forms/Main.cs:33434`), which is direction-independent.

## Fix

New `MainViewModel.FirstSelectedSubtitleIndex` — the topmost selected row, display-only reference rows excluded, `-1` when nothing editable is selected. It is SE4's `FirstSelectedIndex`, built on the already-ordered `SubtitleGridSelectedItems`.

Both column commands that write downwards from the selection now use it:

- `ColumnPasteFromClipboard`
- `ColumnInsertTextFromSubtitle` — same defect, and SE4 anchored it on `FirstSelectedIndex` too (`4.0.16:src/ui/Forms/Main.cs:33726`)

The `SelectedSubtitle == null` guards are gone: the existing `idx < 0` check already covers that, and it now also covers a selection consisting only of display-only reference rows, which the old guard let through.

## Verification

- [x] New theory in `SubtitleGridSelectionOrderTests` shift-clicks in both directions through the real headless grid and asserts the anchor is the first selected row while the current row stays the row the user stopped on
- [x] RED check: with the anchor reverted to `SelectedSubtitle`, the downward case fails and the upward case passes — exactly the asymmetry reported in the issue
- [x] `dotnet build src/ui/UI.csproj` — 0 warnings, 0 errors
- [x] `dotnet test tests/UI/UITests.csproj` — 2809 passed, 0 failed

Two earlier full-suite runs each had one failure (`WebVttStylePickerViewModelTests.CheckedStylesApplyAsCueClassesOnTheLine` on the first), green in isolation and on re-run — the known parallel/shared-settings flake, unrelated to this code.

## Scope

This fixes only part 2 of #13682. Part 1 (restoring SE4's direct Ctrl+V overwrite of the selected lines) is untouched and needs its own change in `SubtitleGridCopyPasteHelper.Paste` — which is also what open PR #13262 edits.

Not addressed here either: the column paste silently truncates when the clipboard has more lines than there are rows below the anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)