### PR TITLE
ASSA: new lines keep the neighbouring style instead of the first one in the header

### DIFF
--- a/src/ui/Features/Assa/AssaStyleStorageHelper.cs
+++ b/src/ui/Features/Assa/AssaStyleStorageHelper.cs
@@ -68,20 +68,23 @@ public static class AssaStyleStorageHelper
     }
 
     /// <summary>
-    /// Decides which style name a new ASSA/SSA paragraph should use:
-    /// if the file already defines styles, the first file style is used; otherwise the default
-    /// storage styles (if any) become the file's styles and the default one is used.
+    /// Decides which style name a new ASSA/SSA paragraph should use.
+    /// When the file already defines styles, see <see cref="ResolveExistingFileStyle"/>; otherwise
+    /// the default storage styles (if any) become the file's styles and the default one is used.
     /// Falls back to "Default". The subtitle header is updated when the storage styles are applied.
     /// </summary>
-    public static string GetStyleNameForNewParagraph(Subtitle subtitle, SubtitleFormat format)
+    /// <param name="neighborStyle">
+    /// Style of the line the new paragraph is inserted next to, when there is one.
+    /// </param>
+    public static string GetStyleNameForNewParagraph(Subtitle subtitle, SubtitleFormat format, string? neighborStyle = null)
     {
-        // if the file already defines styles, use the first one
+        // if the file already defines styles, pick one of those
         if (HasSsaOrAssaStyles(subtitle.Header))
         {
             var existingStyles = AdvancedSubStationAlpha.GetStylesFromHeader(subtitle.Header);
             if (existingStyles.Count > 0)
             {
-                return existingStyles[0];
+                return ResolveExistingFileStyle(existingStyles, format, neighborStyle);
             }
         }
 
@@ -102,6 +105,33 @@ public static class AssaStyleStorageHelper
         }
 
         return AdvancedSubStationAlpha.GetStylesFromHeader(subtitle.Header).FirstOrDefault() ?? "Default";
+    }
+
+    /// <summary>
+    /// Picks a style for a new paragraph among the styles a file already defines (issue #13677).
+    /// The header order is not a ranking - SE 4 kept the style of the line the new line was
+    /// inserted next to, and just taking the first header style made every new line adopt
+    /// whichever style happened to sit at the top. Order of preference:
+    /// the neighbouring line's style, the style flagged as default in the storage, a style
+    /// literally named "Default", and only then the first style in the header.
+    /// </summary>
+    private static string ResolveExistingFileStyle(List<string> existingStyles, SubtitleFormat format, string? neighborStyle)
+    {
+        return FindStyle(existingStyles, neighborStyle) ??
+               FindStyle(existingStyles, GetDefaultStorageStyle(format)?.Name) ??
+               FindStyle(existingStyles, "Default") ??
+               existingStyles[0];
+    }
+
+    /// <summary>
+    /// Returns the file's spelling of <paramref name="name"/>, or null when the file has no such
+    /// style. Style names are matched case-insensitively, like the rest of the ASSA style lookups.
+    /// </summary>
+    private static string? FindStyle(List<string> existingStyles, string? name)
+    {
+        return string.IsNullOrEmpty(name)
+            ? null
+            : existingStyles.FirstOrDefault(s => s.Equals(name, StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -7953,6 +7953,7 @@ public partial class MainViewModel :
                     {
                         var newLine = new SubtitleLineViewModel(p, SelectedSubtitleFormat);
                         newLine.SetStartTimeKeepDuration(selectedLine.StartTime + p.StartTime.TimeSpan);
+                        newLine.Style = selectedLine.Style; // the lines replace selectedLine, so they keep its style
                         newLines.Add(newLine);
                     }
                 }
@@ -7977,7 +7978,8 @@ public partial class MainViewModel :
 
         foreach (var line in newLines)
         {
-            _insertService.InsertInCorrectPosition(Subtitles, line);
+            var index = _insertService.InsertInCorrectPosition(Subtitles, line);
+            SetDefaultAssaStyleForNewParagraph(line, index);
         }
 
         if (newLines.Count > 0 || deleteLines.Count > 0)
@@ -14377,6 +14379,7 @@ public partial class MainViewModel :
         var newParagraph =
             new SubtitleLineViewModel(new Paragraph(string.Empty, startMs, endMs), SelectedSubtitleFormat);
         var idx = _insertService.InsertInCorrectPosition(Subtitles, newParagraph);
+        SetDefaultAssaStyleForNewParagraph(newParagraph, idx);
         var next = Subtitles.GetOrNull(idx + 1);
         if (next != null)
         {
@@ -15086,7 +15089,8 @@ public partial class MainViewModel :
         }
 
         var newParagraph = AudioVisualizer.NewSelectionParagraph;
-        _insertService.InsertInCorrectPosition(Subtitles, newParagraph);
+        var index = _insertService.InsertInCorrectPosition(Subtitles, newParagraph);
+        SetDefaultAssaStyleForNewParagraph(newParagraph, index);
         AudioVisualizer.NewSelectionParagraph = null;
         SelectAndScrollToSubtitle(newParagraph);
         Renumber();
@@ -15106,7 +15110,8 @@ public partial class MainViewModel :
         }
 
         var newParagraph = AudioVisualizer.NewSelectionParagraph;
-        _insertService.InsertInCorrectPosition(Subtitles, newParagraph);
+        var index = _insertService.InsertInCorrectPosition(Subtitles, newParagraph);
+        SetDefaultAssaStyleForNewParagraph(newParagraph, index);
         AudioVisualizer.NewSelectionParagraph = null;
         SubtitleGrid.SelectedItem = newParagraph;
         SubtitleGrid.ScrollIntoView(newParagraph);
@@ -15138,7 +15143,8 @@ public partial class MainViewModel :
         }
 
         newParagraph.Text = text.Trim();
-        _insertService.InsertInCorrectPosition(Subtitles, newParagraph);
+        var index = _insertService.InsertInCorrectPosition(Subtitles, newParagraph);
+        SetDefaultAssaStyleForNewParagraph(newParagraph, index);
         AudioVisualizer.NewSelectionParagraph = null;
         SelectAndScrollToSubtitle(newParagraph);
         Renumber();
@@ -15163,6 +15169,12 @@ public partial class MainViewModel :
         // Paste at the waveform cursor rather than the raw player position - after a right-click
         // the cursor is pinned to the clicked spot while the async player seek may still lag.
         var linesInserted = _pasteFromClipboardHelper.PasteFromClipboard(text, AudioVisualizer.CurrentVideoPositionSeconds * 1000.0, Subtitles, SelectedSubtitleFormat);
+        foreach (var line in linesInserted)
+        {
+            // plain text carries no style - pasted ASSA lines keep the one they came with
+            SetDefaultAssaStyleForNewParagraph(line, Subtitles.IndexOf(line));
+        }
+
         Renumber();
         if (linesInserted.Count == 1)
         {
@@ -15254,6 +15266,7 @@ public partial class MainViewModel :
         RunWithoutChangeDetection(() =>
         {
             var idx = _insertService.InsertInCorrectPosition(Subtitles, newParagraph);
+            SetDefaultAssaStyleForNewParagraph(newParagraph, idx);
             var next = Subtitles.GetOrNull(idx + 1);
             if (next != null)
             {
@@ -15295,6 +15308,7 @@ public partial class MainViewModel :
         RunWithoutChangeDetection(() =>
         {
             var idx = _insertService.InsertInCorrectPosition(Subtitles, newParagraph);
+            SetDefaultAssaStyleForNewParagraph(newParagraph, idx);
             var next = Subtitles.GetOrNull(idx + 1);
             if (next != null)
             {
@@ -15614,6 +15628,7 @@ public partial class MainViewModel :
         RunWithoutChangeDetection(() =>
         {
             var idx = _insertService.InsertInCorrectPosition(Subtitles, newParagraph);
+            SetDefaultAssaStyleForNewParagraph(newParagraph, idx);
             var next = Subtitles.GetOrNull(idx + 1);
             if (next != null &&
                 next.StartTime.TotalMilliseconds < endMs &&
@@ -25306,24 +25321,35 @@ public partial class MainViewModel :
     }
 
     /// <summary>
-    /// Sets the style of a newly created ASSA/SSA paragraph to the default storage style (if any).
-    /// Used by insert paths that bypass <see cref="IInsertService"/> (e.g. typing the first line or
-    /// inserting from a waveform selection).
+    /// Sets the style of a newly created ASSA/SSA paragraph. Used by the insert paths that bypass
+    /// <see cref="IInsertService.InsertBefore"/>/<see cref="IInsertService.InsertAfter"/> - the
+    /// waveform and video-position inserts, and typing the first line of an empty file. Without
+    /// it the line is saved with an empty style, which the writer then resolves to whichever
+    /// style sits first in the header (issue #13677).
     /// </summary>
-    private void SetDefaultAssaStyleForNewParagraph(SubtitleLineViewModel newParagraph)
+    /// <param name="insertedIndex">
+    /// Index the paragraph now occupies, so it can keep the style of the line it landed next to.
+    /// Pass -1 when the paragraph is not in <see cref="Subtitles"/> (yet).
+    /// </param>
+    private void SetDefaultAssaStyleForNewParagraph(SubtitleLineViewModel newParagraph, int insertedIndex = -1)
     {
-        if (SelectedSubtitleFormat is not (AdvancedSubStationAlpha or SubStationAlpha))
+        if (SelectedSubtitleFormat is not (AdvancedSubStationAlpha or SubStationAlpha) ||
+            !string.IsNullOrEmpty(newParagraph.Style))
         {
             return;
         }
 
-        newParagraph.Style = AssaStyleStorageHelper.GetStyleNameForNewParagraph(_subtitle, SelectedSubtitleFormat);
+        var neighbor = insertedIndex >= 0
+            ? Subtitles.GetOrNull(insertedIndex - 1) ?? Subtitles.GetOrNull(insertedIndex + 1)
+            : null;
+
+        newParagraph.Style = AssaStyleStorageHelper.GetStyleNameForNewParagraph(_subtitle, SelectedSubtitleFormat, neighbor?.Style);
     }
 
     public void AudioVisualizerOnNewSelectionInsert(object sender, ParagraphEventArgs e)
     {
-        SetDefaultAssaStyleForNewParagraph(e.Paragraph);
         var index = _insertService.InsertInCorrectPosition(Subtitles, e.Paragraph);
+        SetDefaultAssaStyleForNewParagraph(e.Paragraph, index);
         SelectAndScrollToRow(index);
         Renumber();
         _updateAudioVisualizer = true;
@@ -25540,7 +25566,9 @@ public partial class MainViewModel :
 
                             var newParagraph = new Paragraph(text, segStartMs, segEndMs);
                             var newLine = new SubtitleLineViewModel(newParagraph, SelectedSubtitleFormat);
-                            _insertService.InsertInCorrectPosition(Subtitles, newLine);
+                            newLine.Style = originalLine.Style; // the segments replace originalLine, so they keep its style
+                            var newLineIndex = _insertService.InsertInCorrectPosition(Subtitles, newLine);
+                            SetDefaultAssaStyleForNewParagraph(newLine, newLineIndex);
                         }
 
                         Renumber();

--- a/src/ui/Logic/Config/SeAssa.cs
+++ b/src/ui/Logic/Config/SeAssa.cs
@@ -37,7 +37,9 @@ public class SeAssa
         AutoSetResolution = true;
         AutoSetResolutionConvert = true;
 
-        StoredStyles = new List<SeAssaStyle>();
+        // Seed the storage so a fresh install (and a settings reset) has a default style to
+        // apply to new/converted ASSA subtitles instead of an empty "Styles saved" list.
+        StoredStyles = new List<SeAssaStyle> { SeAssaStyle.MakeStorageDefault() };
         LastOverrideTag = OverrideTagDisplay.List().First().Tag;
         LastOverrideTags = new List<string>();
 

--- a/src/ui/Logic/Config/SeAssaStyle.cs
+++ b/src/ui/Logic/Config/SeAssaStyle.cs
@@ -1,8 +1,48 @@
-﻿using Nikse.SubtitleEdit.Features.Assa;
+﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Assa;
 
 namespace Nikse.SubtitleEdit.Logic.Config;
 public class SeAssaStyle
 {
+    /// <summary>
+    /// The style the styles storage is seeded with on first start and after a settings reset:
+    /// the built-in "Default" style, flagged as the storage default so new and converted ASSA/SSA
+    /// subtitles have something to follow. Built from <see cref="SsaStyle"/>'s own defaults rather
+    /// than a copy of them, and without going through <see cref="StyleDisplay"/> - this runs while
+    /// <see cref="Se.Settings"/> is still being constructed, so it must not touch Se.
+    /// </summary>
+    public static SeAssaStyle MakeStorageDefault()
+    {
+        var style = new SsaStyle();
+        return new SeAssaStyle
+        {
+            Name = style.Name,
+            FontName = style.FontName,
+            FontSize = style.FontSize,
+            ColorPrimary = style.Primary.ToAvaloniaColor().FromColorToHex(),
+            ColorSecondary = style.Secondary.ToAvaloniaColor().FromColorToHex(),
+            ColorOutline = style.Outline.ToAvaloniaColor().FromColorToHex(),
+            ColorShadow = style.Background.ToAvaloniaColor().FromColorToHex(),
+            OutlineWidth = style.OutlineWidth,
+            ShadowWidth = style.ShadowWidth,
+            Bold = style.Bold,
+            Italic = style.Italic,
+            Underline = style.Underline,
+            Strikeout = style.Strikeout,
+            ScaleX = style.ScaleX,
+            ScaleY = style.ScaleY,
+            Spacing = style.Spacing,
+            Angle = style.Angle,
+            Alignment = style.Alignment,
+            MarginLeft = style.MarginLeft,
+            MarginRight = style.MarginRight,
+            MarginVertical = style.MarginVertical,
+            UseOpaqueBox = style.BorderStyle == "4",
+            UseOpaqueBoxPerLine = style.BorderStyle == "3",
+            IsDefault = true,
+        };
+    }
+
     public SeAssaStyle(StyleDisplay style)
     {
         Name = style.Name;

--- a/src/ui/Logic/Config/SeSsa.cs
+++ b/src/ui/Logic/Config/SeSsa.cs
@@ -8,6 +8,8 @@ public class SeSsa
 
     public SeSsa()
     {
-        StoredStyles = new List<SeAssaStyle>();
+        // SSA keeps its own storage - seed it too, so a fresh install (and a settings reset) has
+        // a default style rather than an empty "Styles saved" list.
+        StoredStyles = new List<SeAssaStyle> { SeAssaStyle.MakeStorageDefault() };
     }
 }

--- a/src/ui/Logic/InsertService.cs
+++ b/src/ui/Logic/InsertService.cs
@@ -282,8 +282,9 @@ public class InsertService : IInsertService
                     newParagraph.Actor = c.Actor;
                 }
 
-                // use the first style from the file, or the default storage styles for a new file
-                newParagraph.Style = AssaStyleStorageHelper.GetStyleNameForNewParagraph(subtitle, format);
+                // keep the neighbouring line's style (SE 4 parity - #13677), or the default
+                // storage styles for a file that has none yet
+                newParagraph.Style = AssaStyleStorageHelper.GetStyleNameForNewParagraph(subtitle, format, c?.Style);
             }
         }
     }

--- a/src/ui/Logic/InsertService.cs
+++ b/src/ui/Logic/InsertService.cs
@@ -111,7 +111,7 @@ public class InsertService : IInsertService
             newParagraph.EndTime = TimeSpan.FromMilliseconds(newParagraph.StartTime.TotalMilliseconds + Se.Settings.General.SubtitleMinimumDisplayMilliseconds);
         }
 
-        subtitles.Insert(firstSelectedIndex, newParagraph);
+        subtitles.Insert(ClampInsertIndex(subtitles, firstSelectedIndex), newParagraph);
     }
 
     public void InsertAfter(SubtitleFormat format, Subtitle subtitle, ObservableCollection<SubtitleLineViewModel> subtitles, int? index, string text)
@@ -201,7 +201,21 @@ public class InsertService : IInsertService
             newParagraph.Duration = newParagraph.EndTime - newParagraph.StartTime;
         }
 
-        subtitles.Insert(firstSelectedIndex + 1, newParagraph);
+        subtitles.Insert(ClampInsertIndex(subtitles, firstSelectedIndex + 1), newParagraph);
+    }
+
+    /// <summary>
+    /// Keeps the insert position inside the collection. "Insert after" on an empty subtitle asks
+    /// for index 1, and a stale selection index can point past the end - both used to throw.
+    /// </summary>
+    private static int ClampInsertIndex(ObservableCollection<SubtitleLineViewModel> subtitles, int index)
+    {
+        if (index < 0)
+        {
+            return 0;
+        }
+
+        return index > subtitles.Count ? subtitles.Count : index;
     }
 
     public int InsertInCorrectPosition(ObservableCollection<SubtitleLineViewModel> subtitles, SubtitleLineViewModel paragraph)

--- a/tests/UI/Features/Assa/AssaStyleStorageHelperTests.cs
+++ b/tests/UI/Features/Assa/AssaStyleStorageHelperTests.cs
@@ -31,6 +31,24 @@ public class AssaStyleStorageHelperTests
         };
     }
 
+    /// <summary>
+    /// Settings with an empty style storage. A fresh <see cref="Se"/> is seeded with one default
+    /// style (first start / settings reset), which these tests replace with their own fixtures.
+    /// </summary>
+    private static Se MakeSettingsWithEmptyStorage()
+    {
+        var settings = new Se();
+        settings.Assa.StoredStyles.Clear();
+        settings.Ssa.StoredStyles.Clear();
+        return settings;
+    }
+
+    private static string MakeHeaderWithStyles(params string[] styleNames)
+    {
+        var styles = styleNames.Select(n => new SsaStyle { Name = n }).ToList();
+        return AdvancedSubStationAlpha.GetHeaderAndStylesFromAdvancedSubStationAlpha(AdvancedSubStationAlpha.DefaultHeader, styles);
+    }
+
     private static Subtitle MakeSrtSubtitle()
     {
         // SRT has no ASS header and the paragraphs carry no style (Extra).
@@ -46,7 +64,7 @@ public class AssaStyleStorageHelperTests
         var saved = Se.Settings;
         try
         {
-            Se.Settings = new Se();
+            Se.Settings = MakeSettingsWithEmptyStorage();
             Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("Default", "Segoe UI", 90, isDefault: true));
 
             var subtitle = MakeSrtSubtitle();
@@ -74,7 +92,7 @@ public class AssaStyleStorageHelperTests
         var saved = Se.Settings;
         try
         {
-            Se.Settings = new Se();
+            Se.Settings = MakeSettingsWithEmptyStorage();
             // Style name intentionally not "Default" to prove the Dialogue lines follow the header style.
             Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("MyStyle", "Segoe UI", 90, isDefault: true));
 
@@ -116,7 +134,7 @@ public class AssaStyleStorageHelperTests
         var saved = Se.Settings;
         try
         {
-            Se.Settings = new Se();
+            Se.Settings = MakeSettingsWithEmptyStorage();
             // SE 4 semantics (issue #13653): the default style's whole category is the template.
             Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("Sign", "Verdana", 30, isDefault: false, category: "Movie"));
             Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("Speech", "Segoe UI", 90, isDefault: true, category: "Movie"));
@@ -148,7 +166,7 @@ public class AssaStyleStorageHelperTests
         var saved = Se.Settings;
         try
         {
-            Se.Settings = new Se();
+            Se.Settings = MakeSettingsWithEmptyStorage();
             // No style is marked default, but the built-in default category (empty name) holds
             // styles - SE 4 applied those without any flag, so SE 5 does too (issue #13653).
             Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("Narrator", "Segoe UI", 90, isDefault: false));
@@ -175,7 +193,7 @@ public class AssaStyleStorageHelperTests
         var saved = Se.Settings;
         try
         {
-            Se.Settings = new Se();
+            Se.Settings = MakeSettingsWithEmptyStorage();
             Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("Default", "Segoe UI", 90, isDefault: true));
 
             var subtitle = MakeSrtSubtitle();
@@ -197,7 +215,7 @@ public class AssaStyleStorageHelperTests
         var saved = Se.Settings;
         try
         {
-            Se.Settings = new Se();
+            Se.Settings = MakeSettingsWithEmptyStorage();
             Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("Default", "Segoe UI", 90, isDefault: true));
 
             var subtitle = MakeSrtSubtitle();
@@ -221,7 +239,7 @@ public class AssaStyleStorageHelperTests
         var saved = Se.Settings;
         try
         {
-            Se.Settings = new Se();
+            Se.Settings = MakeSettingsWithEmptyStorage();
             Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("Default", "Segoe UI", 90, isDefault: true));
 
             // An SSA file carries [V4 Styles]; saving it as ASSA converts the header on write, so
@@ -247,7 +265,7 @@ public class AssaStyleStorageHelperTests
         var saved = Se.Settings;
         try
         {
-            Se.Settings = new Se();
+            Se.Settings = MakeSettingsWithEmptyStorage();
             // A stored style exists, but none is marked default and none is in the default
             // category - there is nothing to call "the default template".
             Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("Some", "Segoe UI", 90, isDefault: false, category: "TV"));
@@ -271,7 +289,7 @@ public class AssaStyleStorageHelperTests
         var saved = Se.Settings;
         try
         {
-            Se.Settings = new Se();
+            Se.Settings = MakeSettingsWithEmptyStorage();
             Se.Settings.Ssa.StoredStyles.Add(MakeStoredStyle("MySsaStyle", "Georgia", 28, isDefault: true));
 
             var subtitle = MakeSrtSubtitle();
@@ -306,7 +324,7 @@ public class AssaStyleStorageHelperTests
         var saved = Se.Settings;
         try
         {
-            Se.Settings = new Se();
+            Se.Settings = MakeSettingsWithEmptyStorage();
             // Only the ASSA storage has a default - an SSA conversion must not pick it up,
             // and vice versa (the two formats keep separate style storages).
             Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("AssaOnly", "Segoe UI", 90, isDefault: true));
@@ -316,7 +334,7 @@ public class AssaStyleStorageHelperTests
             Assert.False(appliedSsa);
             Assert.True(string.IsNullOrEmpty(subtitle.Header));
 
-            Se.Settings = new Se();
+            Se.Settings = MakeSettingsWithEmptyStorage();
             Se.Settings.Ssa.StoredStyles.Add(MakeStoredStyle("SsaOnly", "Georgia", 28, isDefault: true));
 
             subtitle = MakeSrtSubtitle();
@@ -336,7 +354,7 @@ public class AssaStyleStorageHelperTests
         var saved = Se.Settings;
         try
         {
-            Se.Settings = new Se();
+            Se.Settings = MakeSettingsWithEmptyStorage();
 
             // Regression: typing the first line of a new SSA file used to stamp an ASSA
             // (v4.00+/[V4+ Styles]) header onto the SSA subtitle.
@@ -359,7 +377,7 @@ public class AssaStyleStorageHelperTests
         var saved = Se.Settings;
         try
         {
-            Se.Settings = new Se();
+            Se.Settings = MakeSettingsWithEmptyStorage();
             Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("StorageStyle", "Segoe UI", 90, isDefault: true));
 
             // A file that already defines styles wins over the storage default.
@@ -370,6 +388,206 @@ public class AssaStyleStorageHelperTests
             var styleName = AssaStyleStorageHelper.GetStyleNameForNewParagraph(subtitle, new AdvancedSubStationAlpha());
 
             Assert.Equal("StorageStyle", styleName);
+        }
+        finally
+        {
+            Se.Settings = saved;
+        }
+    }
+
+    [Fact]
+    public void FreshSettings_SeedTheStyleStorageWithOneDefaultStyle()
+    {
+        // First start and "Reset settings" both land on a plain new Se() - the storage must not
+        // be empty there, or "Styles saved" shows nothing to make default.
+        var settings = new Se();
+
+        var assaStyle = Assert.Single(settings.Assa.StoredStyles);
+        Assert.Equal("Default", assaStyle.Name);
+        Assert.True(assaStyle.IsDefault);
+        Assert.Equal(string.Empty, assaStyle.Category);
+
+        var ssaStyle = Assert.Single(settings.Ssa.StoredStyles);
+        Assert.Equal("Default", ssaStyle.Name);
+        Assert.True(ssaStyle.IsDefault);
+    }
+
+    [Fact]
+    public void SavedSettings_DoNotGainASecondSeededStyleOnReload()
+    {
+        var saved = Se.Settings;
+        var settingsFileName = Path.Combine(Path.GetTempPath(), "SubtitleEdit.UITests", Guid.NewGuid().ToString("N"), "Settings.json");
+        try
+        {
+            // Deserialization runs the same constructors as a fresh install, so the seeded style
+            // must be replaced by what the file holds - never appended to it.
+            Se.Settings = MakeSettingsWithEmptyStorage();
+            Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("MyStyle", "Segoe UI", 90, isDefault: true));
+            Se.SaveSettings(settingsFileName);
+
+            Se.LoadSettings(settingsFileName);
+
+            var style = Assert.Single(Se.Settings.Assa.StoredStyles);
+            Assert.Equal("MyStyle", style.Name);
+
+            // An emptied storage stays empty too.
+            Assert.Empty(Se.Settings.Ssa.StoredStyles);
+        }
+        finally
+        {
+            Se.Settings = saved;
+            var directory = Path.GetDirectoryName(settingsFileName);
+            if (!string.IsNullOrEmpty(directory) && Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void FreshSettings_SeededStyleMatchesTheBuiltInAssaDefaultStyle()
+    {
+        var saved = Se.Settings;
+        try
+        {
+            // The seed must not change what a fresh install produces: converting to ASSA with the
+            // seeded storage has to yield the same styles as libse's built-in default header.
+            Se.Settings = new Se();
+
+            var subtitle = MakeSrtSubtitle();
+            Assert.True(AssaStyleStorageHelper.ApplyDefaultStorageStyleForFormatConversion(subtitle, new AdvancedSubStationAlpha()));
+
+            var seeded = AdvancedSubStationAlpha.GetSsaStylesFromHeader(subtitle.Header);
+            var builtIn = AdvancedSubStationAlpha.GetSsaStylesFromHeader(AdvancedSubStationAlpha.DefaultHeader);
+
+            Assert.Equal(builtIn.Count, seeded.Count);
+            Assert.Equal(builtIn[0].Name, seeded[0].Name);
+            Assert.Equal(builtIn[0].FontName, seeded[0].FontName);
+            Assert.Equal(builtIn[0].FontSize, seeded[0].FontSize);
+            Assert.Equal(builtIn[0].Primary, seeded[0].Primary);
+            Assert.Equal(builtIn[0].Secondary, seeded[0].Secondary);
+            Assert.Equal(builtIn[0].Outline, seeded[0].Outline);
+            Assert.Equal(builtIn[0].Background, seeded[0].Background);
+            Assert.Equal(builtIn[0].Alignment, seeded[0].Alignment);
+            Assert.Equal(builtIn[0].BorderStyle, seeded[0].BorderStyle);
+            Assert.Equal(builtIn[0].OutlineWidth, seeded[0].OutlineWidth);
+            Assert.Equal(builtIn[0].ShadowWidth, seeded[0].ShadowWidth);
+            Assert.Equal(builtIn[0].MarginLeft, seeded[0].MarginLeft);
+            Assert.Equal(builtIn[0].MarginRight, seeded[0].MarginRight);
+            Assert.Equal(builtIn[0].MarginVertical, seeded[0].MarginVertical);
+            Assert.Equal(builtIn[0].ScaleX, seeded[0].ScaleX);
+            Assert.Equal(builtIn[0].ScaleY, seeded[0].ScaleY);
+        }
+        finally
+        {
+            Se.Settings = saved;
+        }
+    }
+
+    [Fact]
+    public void GetStyleNameForNewParagraph_KeepsTheNeighborStyle()
+    {
+        var saved = Se.Settings;
+        try
+        {
+            Se.Settings = MakeSettingsWithEmptyStorage();
+
+            // SE 4 parity (issue #13677): a new line keeps the style of the line it is inserted
+            // next to, instead of adopting whichever style sits first in the header.
+            var subtitle = new Subtitle { Header = MakeHeaderWithStyles("Julia Lepetit", "Jacob Andrews", "Both", "Default") };
+
+            var styleName = AssaStyleStorageHelper.GetStyleNameForNewParagraph(subtitle, new AdvancedSubStationAlpha(), "Jacob Andrews");
+
+            Assert.Equal("Jacob Andrews", styleName);
+        }
+        finally
+        {
+            Se.Settings = saved;
+        }
+    }
+
+    [Fact]
+    public void GetStyleNameForNewParagraph_NeighborStyleIsMatchedCaseInsensitively()
+    {
+        var saved = Se.Settings;
+        try
+        {
+            Se.Settings = MakeSettingsWithEmptyStorage();
+
+            var subtitle = new Subtitle { Header = MakeHeaderWithStyles("Julia Lepetit", "Jacob Andrews") };
+
+            var styleName = AssaStyleStorageHelper.GetStyleNameForNewParagraph(subtitle, new AdvancedSubStationAlpha(), "jacob andrews");
+
+            // The file's own spelling wins - a Dialogue line must reference the style verbatim.
+            Assert.Equal("Jacob Andrews", styleName);
+        }
+        finally
+        {
+            Se.Settings = saved;
+        }
+    }
+
+    [Fact]
+    public void GetStyleNameForNewParagraph_NoNeighbor_UsesStorageDefaultPresentInTheFile()
+    {
+        var saved = Se.Settings;
+        try
+        {
+            Se.Settings = MakeSettingsWithEmptyStorage();
+            // "Set style as default" in the storage used to be ignored the moment a file had its
+            // own styles - it now decides among them when there is no neighbour to follow (#13677).
+            Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("Both", "Segoe UI", 90, isDefault: true));
+
+            var subtitle = new Subtitle { Header = MakeHeaderWithStyles("Julia Lepetit", "Jacob Andrews", "Both", "Default") };
+
+            var styleName = AssaStyleStorageHelper.GetStyleNameForNewParagraph(subtitle, new AdvancedSubStationAlpha());
+
+            Assert.Equal("Both", styleName);
+        }
+        finally
+        {
+            Se.Settings = saved;
+        }
+    }
+
+    [Fact]
+    public void GetStyleNameForNewParagraph_NoNeighborAndNoStorageMatch_PrefersTheStyleNamedDefault()
+    {
+        var saved = Se.Settings;
+        try
+        {
+            Se.Settings = MakeSettingsWithEmptyStorage();
+            Se.Settings.Assa.StoredStyles.Add(MakeStoredStyle("NotInThisFile", "Segoe UI", 90, isDefault: true));
+
+            // The reported case (#13677): "Default" carries the whole subtitle but sits last, so
+            // every new line used to come out as "Julia Lepetit".
+            var subtitle = new Subtitle { Header = MakeHeaderWithStyles("Julia Lepetit", "Jacob Andrews", "Both", "Default") };
+
+            var styleName = AssaStyleStorageHelper.GetStyleNameForNewParagraph(subtitle, new AdvancedSubStationAlpha());
+
+            Assert.Equal("Default", styleName);
+        }
+        finally
+        {
+            Se.Settings = saved;
+        }
+    }
+
+    [Fact]
+    public void GetStyleNameForNewParagraph_UnknownNeighborAndNoDefaultStyle_FallsBackToFirstHeaderStyle()
+    {
+        var saved = Se.Settings;
+        try
+        {
+            Se.Settings = MakeSettingsWithEmptyStorage();
+
+            // No "Default" style and the neighbour's style was renamed away - the first header
+            // style remains the last resort.
+            var subtitle = new Subtitle { Header = MakeHeaderWithStyles("Julia Lepetit", "Jacob Andrews") };
+
+            var styleName = AssaStyleStorageHelper.GetStyleNameForNewParagraph(subtitle, new AdvancedSubStationAlpha(), "Deleted style");
+
+            Assert.Equal("Julia Lepetit", styleName);
         }
         finally
         {

--- a/tests/UI/Logic/InsertServiceAssaStyleTests.cs
+++ b/tests/UI/Logic/InsertServiceAssaStyleTests.cs
@@ -1,0 +1,194 @@
+using System.Collections.ObjectModel;
+using System.Linq;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// Regression tests for issue #13677: a line inserted into an ASSA file adopted whichever style
+/// sat first in the header instead of keeping the style of the line next to it, so files whose
+/// "Default" style was not listed first got new lines in a foreign style.
+/// </summary>
+public class InsertServiceAssaStyleTests
+{
+    private static string MakeHeaderWithStyles(params string[] styleNames)
+    {
+        var styles = styleNames.Select(n => new SsaStyle { Name = n }).ToList();
+        return AdvancedSubStationAlpha.GetHeaderAndStylesFromAdvancedSubStationAlpha(AdvancedSubStationAlpha.DefaultHeader, styles);
+    }
+
+    private static SubtitleLineViewModel MakeLine(string text, double startMs, double endMs, string style)
+    {
+        return new SubtitleLineViewModel
+        {
+            Text = text,
+            StartTime = System.TimeSpan.FromMilliseconds(startMs),
+            EndTime = System.TimeSpan.FromMilliseconds(endMs),
+            Style = style,
+        };
+    }
+
+    [Fact]
+    public void InsertAfter_Assa_KeepsTheStyleOfTheLineItIsInsertedAfter()
+    {
+        var saved = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+
+            var subtitle = new Subtitle { Header = MakeHeaderWithStyles("Julia Lepetit", "Jacob Andrews", "Both", "Default") };
+            var subtitles = new ObservableCollection<SubtitleLineViewModel>
+            {
+                MakeLine("Yammers, hello.", 1000, 3000, "Default"),
+                MakeLine("It's your boy,", 4000, 6000, "Jacob Andrews"),
+            };
+
+            new InsertService().InsertAfter(new AdvancedSubStationAlpha(), subtitle, subtitles, 1, string.Empty);
+
+            Assert.Equal(3, subtitles.Count);
+            Assert.Equal("Jacob Andrews", subtitles[2].Style);
+        }
+        finally
+        {
+            Se.Settings = saved;
+        }
+    }
+
+    [Fact]
+    public void InsertBefore_Assa_KeepsTheStyleOfTheLineItIsInsertedBefore()
+    {
+        var saved = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+
+            var subtitle = new Subtitle { Header = MakeHeaderWithStyles("Julia Lepetit", "Jacob Andrews", "Both", "Default") };
+            var subtitles = new ObservableCollection<SubtitleLineViewModel>
+            {
+                MakeLine("Yammers, hello.", 4000, 6000, "Default"),
+            };
+
+            new InsertService().InsertBefore(new AdvancedSubStationAlpha(), subtitle, subtitles, 0, string.Empty);
+
+            Assert.Equal(2, subtitles.Count);
+
+            // Without the fix this was "Julia Lepetit" - the first style in the header.
+            Assert.Equal("Default", subtitles[0].Style);
+        }
+        finally
+        {
+            Se.Settings = saved;
+        }
+    }
+
+    [Fact]
+    public void InsertBefore_Assa_EmptyFile_PrefersTheStyleNamedDefaultOverTheFirstHeaderStyle()
+    {
+        var saved = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+
+            // No line to inherit from, and no storage default configured.
+            var subtitle = new Subtitle { Header = MakeHeaderWithStyles("Julia Lepetit", "Jacob Andrews", "Both", "Default") };
+            var subtitles = new ObservableCollection<SubtitleLineViewModel>();
+
+            new InsertService().InsertBefore(new AdvancedSubStationAlpha(), subtitle, subtitles, 0, string.Empty);
+
+            Assert.Single(subtitles);
+            Assert.Equal("Default", subtitles[0].Style);
+        }
+        finally
+        {
+            Se.Settings = saved;
+        }
+    }
+
+    [Fact]
+    public void InsertAfter_Assa_NeighborWithoutStyle_FallsBackToTheStyleNamedDefault()
+    {
+        var saved = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+
+            // A line that was itself inserted before the fix carries no style at all; the new
+            // line must not inherit that emptiness.
+            var subtitle = new Subtitle { Header = MakeHeaderWithStyles("Julia Lepetit", "Jacob Andrews", "Both", "Default") };
+            var subtitles = new ObservableCollection<SubtitleLineViewModel>
+            {
+                MakeLine("Yammers, hello.", 1000, 3000, string.Empty),
+            };
+
+            new InsertService().InsertAfter(new AdvancedSubStationAlpha(), subtitle, subtitles, 0, string.Empty);
+
+            Assert.Equal(2, subtitles.Count);
+            Assert.Equal("Default", subtitles[1].Style);
+        }
+        finally
+        {
+            Se.Settings = saved;
+        }
+    }
+
+    [Fact]
+    public void InsertAfter_Assa_WrittenFileReferencesTheInheritedStyle()
+    {
+        var saved = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+
+            var format = new AdvancedSubStationAlpha();
+            var subtitle = new Subtitle { Header = MakeHeaderWithStyles("Julia Lepetit", "Jacob Andrews", "Both", "Default") };
+            var subtitles = new ObservableCollection<SubtitleLineViewModel>
+            {
+                MakeLine("Yammers, hello.", 1000, 3000, "Both"),
+            };
+
+            new InsertService().InsertAfter(format, subtitle, subtitles, 0, "This is a new line");
+
+            // Mirror the save path: the grid rebuilds the paragraphs, ToParagraph maps Style to Extra.
+            subtitle.Paragraphs.Clear();
+            subtitle.Paragraphs.AddRange(subtitles.Select(s => s.ToParagraph(format)));
+
+            var text = format.ToText(subtitle, string.Empty);
+            var dialogueLines = text.SplitToLines().Where(l => l.StartsWith("Dialogue:")).ToList();
+
+            Assert.Equal(2, dialogueLines.Count);
+            Assert.All(dialogueLines, l => Assert.Equal("Both", l.Split(',')[3]));
+        }
+        finally
+        {
+            Se.Settings = saved;
+        }
+    }
+
+    [Fact]
+    public void InsertAfter_SubRip_LeavesStyleAlone()
+    {
+        var saved = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+
+            var subtitles = new ObservableCollection<SubtitleLineViewModel>
+            {
+                MakeLine("Hello", 1000, 3000, string.Empty),
+            };
+
+            new InsertService().InsertAfter(new SubRip(), new Subtitle(), subtitles, 0, string.Empty);
+
+            Assert.Equal(2, subtitles.Count);
+            Assert.Equal(string.Empty, subtitles[1].Style);
+        }
+        finally
+        {
+            Se.Settings = saved;
+        }
+    }
+}

--- a/tests/UI/Logic/InsertServiceAssaStyleTests.cs
+++ b/tests/UI/Logic/InsertServiceAssaStyleTests.cs
@@ -169,6 +169,80 @@ public class InsertServiceAssaStyleTests
     }
 
     [Fact]
+    public void InsertAfter_EmptySubtitle_AppendsInsteadOfThrowing()
+    {
+        var saved = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+
+            // "Insert after" on an empty subtitle asks for index 1 - it used to throw.
+            var subtitle = new Subtitle { Header = MakeHeaderWithStyles("Julia Lepetit", "Default") };
+            var subtitles = new ObservableCollection<SubtitleLineViewModel>();
+
+            new InsertService().InsertAfter(new AdvancedSubStationAlpha(), subtitle, subtitles, null, "Hello");
+
+            var line = Assert.Single(subtitles);
+            Assert.Equal("Hello", line.Text);
+            Assert.Equal("Default", line.Style);
+        }
+        finally
+        {
+            Se.Settings = saved;
+        }
+    }
+
+    [Fact]
+    public void InsertAfter_IndexPastTheEnd_AppendsInsteadOfThrowing()
+    {
+        var saved = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+
+            var subtitle = new Subtitle { Header = MakeHeaderWithStyles("Julia Lepetit", "Default") };
+            var subtitles = new ObservableCollection<SubtitleLineViewModel>
+            {
+                MakeLine("Yammers, hello.", 1000, 3000, "Julia Lepetit"),
+            };
+
+            new InsertService().InsertAfter(new AdvancedSubStationAlpha(), subtitle, subtitles, 7, "Hello");
+
+            Assert.Equal(2, subtitles.Count);
+            Assert.Equal("Hello", subtitles[1].Text);
+        }
+        finally
+        {
+            Se.Settings = saved;
+        }
+    }
+
+    [Fact]
+    public void InsertBefore_IndexPastTheEnd_AppendsInsteadOfThrowing()
+    {
+        var saved = Se.Settings;
+        try
+        {
+            Se.Settings = new Se();
+
+            var subtitle = new Subtitle { Header = MakeHeaderWithStyles("Julia Lepetit", "Default") };
+            var subtitles = new ObservableCollection<SubtitleLineViewModel>
+            {
+                MakeLine("Yammers, hello.", 1000, 3000, "Julia Lepetit"),
+            };
+
+            new InsertService().InsertBefore(new AdvancedSubStationAlpha(), subtitle, subtitles, 7, "Hello");
+
+            Assert.Equal(2, subtitles.Count);
+            Assert.Equal("Hello", subtitles[1].Text);
+        }
+        finally
+        {
+            Se.Settings = saved;
+        }
+    }
+
+    [Fact]
     public void InsertAfter_SubRip_LeavesStyleAlone()
     {
         var saved = Se.Settings;


### PR DESCRIPTION
Fixes #13677.

A line inserted into an ASSA file adopted whichever style sat first in the header, so a file whose `Default` style was not listed first got every new line in a foreign style. In the reported file the style order is `Julia Lepetit, Jacob Andrews, Both, Default` — `Default` carries all 2369 lines but sits last, so new lines came out as `Julia Lepetit`.

## Two causes

**The waveform and video-position inserts never assigned a style.** They go straight to `InsertInCorrectPosition`, which has no style logic, so the line was left with an empty style — visible as a blank Style cell in the reporter's video. `AdvancedSubStationAlpha.ToText` then resolves an empty `Extra` to `styles[0]` on save, even when the header does contain a style named `Default`. SE 4 called `SetStyleForNewParagraph` on these paths; the SE 5 port dropped it.

**The paths that did set a style threw the neighbour away.** `InsertService` copied the neighbour's `Extra` and then overwrote `Style` with the first header style. SE 4's ASSA branch ended at `newParagraph.Extra = c.Extra` — the override line is new in SE 5. The TTML branch right above still inherits correctly, so ASSA was the outlier.

## Changes

- `SetDefaultAssaStyleForNewParagraph` takes the index the line landed at and is now called from the nine insert paths that bypass `IInsertService` — waveform selection inserts, video-position inserts, waveform paste, split-at-position, and both speech-to-text paths (those two inherit the style of the line they replace). It no-ops when the line already has a style.
- `GetStyleNameForNewParagraph` picks, in order: the neighbouring line's style, the style flagged as default in the styles storage, a style named `Default`, and only then the first style in the header. The storage's "Set style as default" flag used to be ignored the moment a file had styles of its own — the second half of the report.
- The ASSA and SSA style storages are seeded with the built-in `Default` style on first start and after a settings reset, so "Styles saved" is not empty and there is something to make default. The seeded style matches libse's built-in default header, so a fresh install converts to ASSA exactly as before.
- Drive-by: `InsertService` clamps the insert index. `InsertAfter` asked for index 1 on an empty subtitle and threw; every caller happens to guard against it today, so it was latent.

## Tests

`tests/UI/Logic/InsertServiceAssaStyleTests.cs` (new) drives the real `InsertService` with the reporter's style list: neighbour inheritance both directions, a blank neighbour falling through to `Default`, the written file's Dialogue fields, SubRip left untouched, and the clamped insert positions.

`AssaStyleStorageHelperTests` covers the new resolution order plus two seeding invariants: the seeded style produces the same styles as libse's built-in default header, and a save/load round-trip keeps one style — proving deserialization replaces the seeded list rather than appending, which would otherwise give every existing user a duplicate `Default` on each launch.

Full UI suite: 2824 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)