### PR TITLE
Fix two "remove text for HI" bugs with speaker names on their own line - #13681

### DIFF
--- a/src/libse/Forms/RemoveTextForHI.cs
+++ b/src/libse/Forms/RemoveTextForHI.cs
@@ -530,7 +530,10 @@ namespace Nikse.SubtitleEdit.Core.Forms
                 count++;
             }
             newText = newText.Trim();
-            if ((noOfNames > 0 || removedInFirstLine) && Utilities.GetNumberOfLines(newText) == 2)
+            // a single name that took up a whole line of its own says nothing about the
+            // speakers of the remaining lines - only names removed from a line that
+            // survived (or a second name) mean there really is a dialog here
+            if ((noOfNames > 1 || removedInFirstLine || removedInSecondLine) && Utilities.GetNumberOfLines(newText) == 2)
             {
                 var indexOfDialogChar = newText.IndexOf('-');
                 var insertDash = true;

--- a/src/libse/Forms/RemoveTextForHI.cs
+++ b/src/libse/Forms/RemoveTextForHI.cs
@@ -135,7 +135,8 @@ namespace Nikse.SubtitleEdit.Core.Forms
             // House 7x01 line 52: and she would like you to do three things:
             // Okay or remove???
             var noTagText = HtmlUtil.RemoveHtmlTags(text);
-            if (noTagText.Length > 10 && noTagText.IndexOf(':') == noTagText.Length - 1 && !Utilities.IsAllUppercase(noTagText))
+            if (noTagText.Length > 10 && noTagText.IndexOf(':') == noTagText.Length - 1 && !Utilities.IsAllUppercase(noTagText) &&
+                !EndsWithSpeakerNameLine(text))
             {
                 return preAssTag + text;
             }
@@ -753,6 +754,34 @@ namespace Nikse.SubtitleEdit.Core.Forms
             }
 
             return preAssTag + newText;
+        }
+
+        /// <summary>
+        /// True if the last line is a speaker name on a line of its own, like the "UNA:" in
+        /// "First officer's log." + "Stardate 2122.4." + "UNA:" - as opposed to a sentence
+        /// that just happens to end in a colon.
+        /// </summary>
+        private bool EndsWithSpeakerNameLine(string text)
+        {
+            var lines = text.SplitToLines();
+            if (lines.Count < 2)
+            {
+                return false;
+            }
+
+            // same shape as the last-line check in RemoveColon: the only colon is the last character,
+            // and the line is too short to be a sentence
+            var lastLine = HtmlUtil.RemoveHtmlTags(lines[lines.Count - 1], true).Trim();
+            if (!lastLine.EndsWith(':') || Utilities.CountTagInText(lastLine, ' ') > 1)
+            {
+                return false;
+            }
+
+            var name = lastLine.TrimEnd(':').TrimStart('-', ' ').Trim();
+
+            return name.Length > 0 &&
+                   (Utilities.IsAllUppercase(name) ||
+                    Settings.NameList != null && Settings.NameList.ContainsCaseInsensitive(name, out _));
         }
 
         private static string InsertStartDashInLine(string input)

--- a/tests/libse/Forms/RemoveTextForHITest.cs
+++ b/tests/libse/Forms/RemoveTextForHITest.cs
@@ -133,4 +133,35 @@ public class RemoveTextForHITest
 
         Assert.Equal(expected, remover.RemoveTextFromHearImpaired(text, "en"));
     }
+
+    [Theory]
+    [InlineData("UNA:|First officer's log.|Stardate 2122.4.", "First officer's log.|Stardate 2122.4.")]
+    [InlineData("MAN ON RADIO:|Come in.|Do you read me?", "Come in.|Do you read me?")]
+    [InlineData("<i>UNA:|First officer's log.|Stardate 2122.4.</i>", "<i>First officer's log.|Stardate 2122.4.</i>")]
+    public void Colon_ThreeLinesNameOnOwnLine_KeepsSingleSpeaker(string input, string expected)
+    {
+        // The name takes up the whole first line, so removing it leaves two lines
+        // from one and the same speaker - no dialog dashes wanted.
+        var remover = MakeRemover();
+        remover.Settings.RemoveTextBeforeColon = true;
+
+        var text = input.Replace("|", Environment.NewLine);
+
+        Assert.Equal(expected.Replace("|", Environment.NewLine), remover.RemoveTextFromHearImpaired(text, "en"));
+    }
+
+    [Theory]
+    [InlineData("UNA:|I have it.|M'BENGA: Good.", "- I have it.|- Good.")]
+    [InlineData("I have it.|M'BENGA: Good.", "- I have it.|- Good.")]
+    public void Colon_NameOnOwnLine_StillDashesRealDialog(string input, string expected)
+    {
+        // A second name was removed from a line that survived, so there really
+        // are two speakers left.
+        var remover = MakeRemover();
+        remover.Settings.RemoveTextBeforeColon = true;
+
+        var text = input.Replace("|", Environment.NewLine);
+
+        Assert.Equal(expected.Replace("|", Environment.NewLine), remover.RemoveTextFromHearImpaired(text, "en"));
+    }
 }

--- a/tests/libse/Forms/RemoveTextForHITest.cs
+++ b/tests/libse/Forms/RemoveTextForHITest.cs
@@ -151,6 +151,39 @@ public class RemoveTextForHITest
     }
 
     [Theory]
+    [InlineData("First officer's log.|Stardate 2122.4.|UNA:", "First officer's log.|Stardate 2122.4.")]
+    [InlineData("First officer's log.|Stardate 2122.4.|<i>UNA:</i>", "First officer's log.|Stardate 2122.4.")]
+    [InlineData("First officer's log.|Stardate 2122.4.|- UNA:", "First officer's log.|Stardate 2122.4.")]
+    [InlineData("First officer's log.|Stardate 2122.4.|OLD MAN:", "First officer's log.|Stardate 2122.4.")]
+    [InlineData("First officer's log.|UNA:", "First officer's log.")]
+    public void Colon_TrailingNameOnOwnLine_IsRemoved(string input, string expected)
+    {
+        // The name of the next speaker on a line of its own after the text - the
+        // whole text was left alone before, as its only colon is the last character.
+        var remover = MakeRemover();
+        remover.Settings.RemoveTextBeforeColon = true;
+
+        var text = input.Replace("|", Environment.NewLine);
+
+        Assert.Equal(expected.Replace("|", Environment.NewLine), remover.RemoveTextFromHearImpaired(text, "en"));
+    }
+
+    [Theory]
+    [InlineData("And she would like you to do|three things:")]
+    [InlineData("It was quite a long day|and then he said|something:")]
+    [InlineData("Here is the thing|I wanted to say:")]
+    public void Colon_SentenceEndingInColon_IsKept(string input)
+    {
+        // A sentence that just happens to end in a colon is not a speaker name.
+        var remover = MakeRemover();
+        remover.Settings.RemoveTextBeforeColon = true;
+
+        var text = input.Replace("|", Environment.NewLine);
+
+        Assert.Equal(text, remover.RemoveTextFromHearImpaired(text, "en"));
+    }
+
+    [Theory]
     [InlineData("UNA:|I have it.|M'BENGA: Good.", "- I have it.|- Good.")]
     [InlineData("I have it.|M'BENGA: Good.", "- I have it.|- Good.")]
     public void Colon_NameOnOwnLine_StillDashesRealDialog(string input, string expected)


### PR DESCRIPTION
Two fixes for the "remove text for hearing impaired" edge cases reported in https://github.com/SubtitleEdit/subtitleedit/issues/13681#issuecomment-5305862172. Neither is a regression from #13683 - the same wrong output is produced by the code before that fix.

### 1. No dialog dashes when the name had its own line

A single-speaker 3-line subtitle became a two-speaker dialog when the name took up the whole first line:

| Input | Before | After |
|---|---|---|
| `UNA:`<br>`First officer's log.`<br>`Stardate 2122.4.` | `- First officer's log.`<br>`- Stardate 2122.4.` | `First officer's log.`<br>`Stardate 2122.4.` |

Nothing is left of a name-only line once the name is removed, so 3 lines become 2 and the "two lines means dialog" branch runs. That branch was entered on `noOfNames > 0`, but `removedInFirstLine`/`removedInSecondLine` are only set when the removal leaves text behind - so the two guards that would have suppressed the dash (both gated on `removedInFirstLine`) never fired.

A single name on a line of its own says nothing about who speaks the remaining lines, so the branch now requires either a second name or a name removed from a line that survived. Real dialog still gets its dashes:

```
UNA:                    - I have it.
I have it.          ->  - Good.
M'BENGA: Good.
```

### 2. A trailing speaker name is removed

| Input | Before | After |
|---|---|---|
| `First officer's log.`<br>`Stardate 2122.4.`<br>`UNA:` | unchanged | `First officer's log.`<br>`Stardate 2122.4.` |

`RemoveColon` never even looked at this text: it bails out early when the only colon in the whole text is its last character, to protect sentences that end in a colon (`and she would like you to do three things:`). A speaker name for the next line has the same shape.

The bail-out is now skipped when the last line is a speaker name of its own - the only colon is at the end of the line, the line is too short to be a sentence, and the name is either all uppercase or in the name list. The line-level check inside the loop already uses the same "at most one space" rule, so a multi-word label such as `MAN ON RADIO:` is still kept on the last line.

### Tests

New theories in `RemoveTextForHITest` cover both reported cases, a `MAN ON RADIO:` monologue, italic and dash-prefixed variants, the two-speaker cases that must keep their dashes, and sentences ending in a colon that must be left alone. Full libse (1165) and UI (2826) test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)