### PR TITLE
Remove a trailing multi-word speaker label - #13681

### DIFF
--- a/src/libse/Forms/RemoveTextForHI.cs
+++ b/src/libse/Forms/RemoveTextForHI.cs
@@ -132,18 +132,19 @@ namespace Nikse.SubtitleEdit.Core.Forms
                 }
             }
 
+            var lines = text.Trim().SplitToLines();
+
             // House 7x01 line 52: and she would like you to do three things:
             // Okay or remove???
             var noTagText = HtmlUtil.RemoveHtmlTags(text);
             if (noTagText.Length > 10 && noTagText.IndexOf(':') == noTagText.Length - 1 && !Utilities.IsAllUppercase(noTagText) &&
-                !EndsWithSpeakerNameLine(text))
+                !IsSpeakerNameLine(lines, lines.Count - 1))
             {
                 return preAssTag + text;
             }
 
             var language = Settings.NameList != null ? Settings.NameList.LanguageName : "en";
             var newText = string.Empty;
-            var lines = text.Trim().SplitToLines();
             var noOfNames = 0;
             var count = 0;
             var removedInFirstLine = false;
@@ -153,7 +154,8 @@ namespace Nikse.SubtitleEdit.Core.Forms
             {
                 var indexOfColon = line.IndexOf(':');
                 var isLastColon = count == lines.Count - 1 && !HtmlUtil.RemoveHtmlTags(line).TrimEnd(':').Contains(':');
-                if (indexOfColon <= 0 || IsInsideBrackets(line, indexOfColon) || (isLastColon && Utilities.CountTagInText(HtmlUtil.RemoveHtmlTags(line), ' ') > 1))
+                if (indexOfColon <= 0 || IsInsideBrackets(line, indexOfColon) ||
+                    (isLastColon && Utilities.CountTagInText(HtmlUtil.RemoveHtmlTags(line), ' ') > 1 && !IsSpeakerNameLine(lines, count)))
                 {
                     newText = (newText + Environment.NewLine + line).Trim();
 
@@ -757,31 +759,51 @@ namespace Nikse.SubtitleEdit.Core.Forms
         }
 
         /// <summary>
-        /// True if the last line is a speaker name on a line of its own, like the "UNA:" in
+        /// True if the line is a speaker name on a line of its own, like the "UNA:" in
         /// "First officer's log." + "Stardate 2122.4." + "UNA:" - as opposed to a sentence
-        /// that just happens to end in a colon.
+        /// that just happens to end in a colon, like "...to do three things:".
         /// </summary>
-        private bool EndsWithSpeakerNameLine(string text)
+        private bool IsSpeakerNameLine(List<string> lines, int index)
         {
-            var lines = text.SplitToLines();
-            if (lines.Count < 2)
+            if (index < 0 || index >= lines.Count)
             {
                 return false;
             }
 
-            // same shape as the last-line check in RemoveColon: the only colon is the last character,
-            // and the line is too short to be a sentence
-            var lastLine = HtmlUtil.RemoveHtmlTags(lines[lines.Count - 1], true).Trim();
-            if (!lastLine.EndsWith(':') || Utilities.CountTagInText(lastLine, ' ') > 1)
+            var line = HtmlUtil.RemoveHtmlTags(lines[index], true).Trim();
+            if (!line.EndsWith(':') || line.TrimEnd(':').Contains(':'))
             {
                 return false;
             }
 
-            var name = lastLine.TrimEnd(':').TrimStart('-', ' ').Trim();
+            var name = line.TrimEnd(':').TrimStart('-', ' ').Trim();
+            if (name.Length == 0 || name.Length > 30)
+            {
+                return false;
+            }
 
-            return name.Length > 0 &&
-                   (Utilities.IsAllUppercase(name) ||
-                    Settings.NameList != null && Settings.NameList.ContainsCaseInsensitive(name, out _));
+            if (!Utilities.IsAllUppercase(name) &&
+                !(Settings.NameList != null && Settings.NameList.ContainsCaseInsensitive(name, out _)))
+            {
+                return false;
+            }
+
+            if (Utilities.CountTagInText(name, ' ') <= 1)
+            {
+                return true;
+            }
+
+            // a label of more than two words, like "MAN ON RADIO:", is easily confused with the tail
+            // of a sentence - only take it when the line before it is a finished sentence, as the
+            // sentence tail would be a continuation of it
+            if (index == 0)
+            {
+                return true;
+            }
+
+            var previous = HtmlUtil.RemoveHtmlTags(lines[index - 1], true).TrimEnd().TrimEnd('"');
+
+            return previous.Length > 0 && ".!?♪♫—".Contains(previous[previous.Length - 1]);
         }
 
         private static string InsertStartDashInLine(string input)

--- a/tests/libse/Forms/RemoveTextForHITest.cs
+++ b/tests/libse/Forms/RemoveTextForHITest.cs
@@ -169,9 +169,32 @@ public class RemoveTextForHITest
     }
 
     [Theory]
+    [InlineData("First officer's log.|Stardate 2122.4.|MAN ON RADIO:", "First officer's log.|Stardate 2122.4.")]
+    [InlineData("First officer's log.|Stardate 2122.4.|<i>MAN ON RADIO:</i>", "First officer's log.|Stardate 2122.4.")]
+    [InlineData("Come in.|Do you read me?|WOMAN ON TV:", "Come in.|Do you read me?")]
+    [InlineData("Come in.|MAN ON RADIO:", "Come in.")]
+    public void Colon_TrailingMultiWordLabel_IsRemoved(string input, string expected)
+    {
+        // A label of more than two words is only taken when the line before it is a
+        // finished sentence - see Colon_TrailingMultiWordLabel_KeptWhenLineContinues.
+        var remover = MakeRemover();
+        remover.Settings.RemoveTextBeforeColon = true;
+
+        var text = input.Replace("|", Environment.NewLine);
+
+        Assert.Equal(expected.Replace("|", Environment.NewLine), remover.RemoveTextFromHearImpaired(text, "en"));
+    }
+
+    [Theory]
     [InlineData("And she would like you to do|three things:")]
     [InlineData("It was quite a long day|and then he said|something:")]
     [InlineData("Here is the thing|I wanted to say:")]
+    // the last line continues the line before it, so it is a sentence, not a label
+    [InlineData("I could hear the|MAN ON RADIO:")]
+    [InlineData("I HAVE A LIST OF|THINGS TO DO:")]
+    // uppercase sentences after a finished sentence - kept by the narrator check
+    [InlineData("HE SAID THIS TO ME.|HERE IS THE LIST:")]
+    [InlineData("IT WAS A LONG DAY.|AND THEN HE SAID THIS:")]
     public void Colon_SentenceEndingInColon_IsKept(string input)
     {
         // A sentence that just happens to end in a colon is not a speaker name.


### PR DESCRIPTION
Follow-up to #13687, which left one gap: a speaker label on the last line was only removed when it was at most two words.

| Input | Before | After |
|---|---|---|
| `First officer's log.`<br>`Stardate 2122.4.`<br>`MAN ON RADIO:` | unchanged | `First officer's log.`<br>`Stardate 2122.4.` |
| `Come in.`<br>`Do you read me?`<br>`WOMAN ON TV:` | unchanged | `Come in.`<br>`Do you read me?` |

`UNA:` and `OLD MAN:` already worked; `MAN ON RADIO:` did not, even though the very same label is removed on any other line.

### Why the word count was there

The "at most one space" rule on the last line was a crude stand-in for "this is too short to be a sentence", protecting texts that end in a colon (`and she would like you to do three things:`). Word count is a poor test for that, so this uses the line before it instead - the tail of a sentence continues the previous line, while a speaker label follows a finished one:

```
I could hear the          First officer's log.
MAN ON RADIO:      vs     Stardate 2122.4.
                          MAN ON RADIO:
   kept                      removed
```

A label of more than two words is now taken only when the previous line ends in sentence-ending punctuation. Everything the label check already required still holds - the only colon is at the end of the line, at most 30 characters, and all uppercase or in the name list - and `ShouldRemoveNarrator` still gets the last word, which is what keeps `HE SAID THIS TO ME.` + `HERE IS THE LIST:` intact.

The same predicate now drives both the early bail-out in `RemoveColon` and the per-line check inside its loop, which previously disagreed about what a label looks like.

### Tests

New theories cover the multi-word labels (plain, italic, two-line, after a question mark), the continuation case that must be kept, and all-caps sentences ending in a colon. Full libse (1173) and UI (2826) test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)