### PR TITLE
Prepare v5.2.0-beta15

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -3,6 +3,43 @@ Subtitle Edit Changelog
 
 -----------------------------------------------------------------------------------------------------
 
+v5.2.0-beta15 (16th of August 2026)
+
+* Add IndexTTS 2.5 as a text to speech engine, with emotion and speaking rate control
+* Add MiLMMT-46 translation models to the llama.cpp translate engine
+* Add HunyuanOCR 1.5 to the llama.cpp OCR model list
+* Add the "llama.cpp advanced" engine to batch convert, with custom prompt and parameters - thx emsb8888-prog
+* Add "Convert colors to dialog", "Snap time codes to frames" and "Add folder..." to batch convert
+* Add a "Play current" button to the AI review window
+* Add a reset-to-default button for the auto-translate prompt
+* Add an engine download/update button to the llama.cpp OCR settings - thx fraternl
+* Ask before the first voice clone in "Text to speech"
+* Open SMPTE-TT files with bitmap captions
+* Show "List shot changes" whenever shot changes exist, and keep edits made in the list
+* Show the errors that could not be fixed in "Fix common errors" - thx radektuma
+* Make "seconv" fail on unknown options, and add --json output everywhere plus --help-json
+* Improve subtitle format detection and reading after a sweep of the VideoLAN/CCExtractor sample files
+* Improve OCR line splitting with an adaptive minimum line height, plus an un-italic retry in nOCR
+* Fix reading of Matroska files on a network share being much slower in beta 14 - thx 1476523
+* Fix whisper.cpp not starting on Linux - thx keremyavuz
+* Fix crash when closing "Text to speech" after reviewing audio - thx cvrle77
+* Fix new lines in ASSA getting the first style in the header instead of the neighbouring one - thx Khaztaroth
+* Fix changing format to Advanced Sub Station Alpha ignoring the default styles storage category - thx windias
+* Fix column paste going to the wrong row when the rows were selected top-to-bottom - thx rosilucia-hub
+* Fix "Remove text for hearing impaired" removing dialog dashes in 3-line subtitles - thx ubeccp6a
+* Fix "Remove text for hearing impaired" with a speaker name on a line of its own - thx ubeccp6a
+* Fix speech to text with Qwen3 ASR failing with a JSON error on comma-decimal locales - thx zielinou
+* Fix switching audio track generating a waveform even with auto-generate off - thx Davanix
+* Fix italic OCR losing word spacing and reading "l" as "i" with binary image compare - thx Miggu82
+* Fix OCR replace lists dropping all but the first "if spelled correctly" section - thx Miggu82
+* Fix six small regressions found in the previous day's changes
+* Update Korean translation - thx 12si27
+* Update Polish translation - thx potplayer-fanpack
+* Update Portuguese (Brazil) translation - thx igorruckert
+* Minor performance improvements in seconv and auto-break
+
+-----------------------------------------------------------------------------------------------------
+
 v5.2.0-beta14 (15th of August 2026)
 
 * Add back .webm output for "burn-in subtitle", add .ts, and offer only containers the codec can use

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "Subtitle Edit",
-  "version": "v5.2.0-beta14",
+  "version": "v5.2.0-beta15",
   "translatedBy": "",
   "cultureName": "en-US",
   "general": {

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -19,7 +19,7 @@ public class Se
     internal const int CurrentMacOsFontMigrationVersion = 1;
     internal const int CurrentShortcutsMigrationVersion = 2;
 
-    public static string Version { get; set; } = "v5.2.0-beta14";
+    public static string Version { get; set; } = "v5.2.0-beta15";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
Bumps the version to `v5.2.0-beta15` in `Se.cs` and the generated `English.json`, and adds the change-log section for the **34 pull requests** merged since the `v5.2.0-beta14` tag.

The entry set was compiled by ancestor-checking every merged PR's merge commit against the `v5.2.0-beta14` tag, so nothing merged after the tag's commit date is missed. Three PRs were folded into shared lines (the two "Remove text for HI" fixes from #13683/#13687/#13690, and the two performance PRs #13651/#13663); everything else is one line per PR.

## Included PRs

**Additions** — #13679 (IndexTTS 2.5), #13664 (MiLMMT-46), #13657 (HunyuanOCR 1.5), #13678, #13648, #13649, #13672, #13662, #13688, #13676, #13652, #13650, #13646

**Fixes** — #13647, #13689, #13684, #13686, #13655, #13685, #13683, #13687, #13690, #13669, #13666, #13670, #13661, #13654

**Improvements / perf** — #13675, #13673, #13651, #13663

**Translations** — #13644 (Korean), #13659 (Polish), #13667 (Portuguese, Brazil)

Note that #13647 reverts the parallel MKV cluster walk that shipped in beta 14, so the beta 15 line reports it as a fix for a beta 14 regression rather than a further improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)