### PR TITLE
Show "Default" in the ASSA storage styles category column

### DIFF
--- a/src/ui/Features/Assa/AssaStylesWindow.cs
+++ b/src/ui/Features/Assa/AssaStylesWindow.cs
@@ -285,7 +285,7 @@ public class AssaStylesWindow : Window
             Header = Se.Language.General.Category,
             CellTheme = UiUtil.TableViewCellTheme,
             HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
-            Binding = new Binding(nameof(StyleDisplay.Category)),
+            Binding = new Binding(nameof(StyleDisplay.CategoryDisplay)),
             Width = new GridLength(120),
         });
         dataGrid.Columns.Add(new SeTableViewColumn

--- a/src/ui/Features/Assa/StyleDisplay.cs
+++ b/src/ui/Features/Assa/StyleDisplay.cs
@@ -34,7 +34,13 @@ public partial class StyleDisplay : ObservableObject
     [ObservableProperty] private BorderStyleItem _borderStyle;
     [ObservableProperty] private bool _isSelected;
     [ObservableProperty] private bool _isDefault;
-    [ObservableProperty] private string _category = string.Empty;
+    [ObservableProperty][NotifyPropertyChangedFor(nameof(CategoryDisplay))] private string _category = string.Empty;
+
+    /// <summary>
+    /// The category as shown in the storage styles table. An empty category is the built-in
+    /// "Default" category - the category combo box names it, so the table column must too.
+    /// </summary>
+    public string CategoryDisplay => string.IsNullOrEmpty(Category) ? Se.Language.General.Default : Category;
 
     private string _fontName = string.Empty;
 

--- a/tests/UI/Features/Assa/AssaStylesViewModelTests.cs
+++ b/tests/UI/Features/Assa/AssaStylesViewModelTests.cs
@@ -184,4 +184,22 @@ public class AssaStylesViewModelTests
             Se.Settings.Assa.StoredStyles.RemoveAll(s => s.Name == "ProjectA-Title");
         }
     }
+
+    /// <summary>
+    /// The storage styles table shows the category column via CategoryDisplay - a style with no
+    /// category belongs to the built-in "Default" category and must say so instead of being blank.
+    /// </summary>
+    [AvaloniaFact]
+    public void StyleDisplay_ShowsDefaultCategoryName()
+    {
+        var style = new StyleDisplay { Category = string.Empty };
+        Assert.Equal(Se.Language.General.Default, style.CategoryDisplay);
+
+        var changed = new List<string?>();
+        style.PropertyChanged += (_, e) => changed.Add(e.PropertyName);
+
+        style.Category = "Project A";
+        Assert.Equal("Project A", style.CategoryDisplay);
+        Assert.Contains(nameof(StyleDisplay.CategoryDisplay), changed);
+    }
 }


### PR DESCRIPTION
In the ASSA styles window, the storage styles table left the **Category** column blank for every style in the built-in Default category — the category is stored as an empty string, while the category combo box above the grid calls it "Default".

Fix: the column now binds to a new `StyleDisplay.CategoryDisplay`, which maps an empty category to the "Default" label. `Category` itself keeps the raw stored value, so what is written back to `Se.Settings.Assa.StoredStyles` / `Se.Settings.Ssa.StoredStyles` is unchanged, and `[NotifyPropertyChangedFor]` makes the cell repaint after "Move to category…", rename, and delete-category.

Regression test added in `tests/UI/Features/Assa/AssaStylesViewModelTests.cs`; the Assa suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)