### PR TITLE
Batch convert: llama.cpp settings gears, model combo and status dots in auto-translate

### DIFF
--- a/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
@@ -85,12 +85,7 @@ public class AiReviewWindow : Window
             .WithAccessibleName(Se.Language.General.Model);
         // Shared dot template, so the install colours here match auto-translate and the engine
         // settings dialog rather than this window's former bespoke green/grey pair.
-        comboLlamaCppModel.ItemTemplate = StatusDots.ComboItemTemplate<Features.Translate.LlamaCppModelDisplay>(
-            m => m.Model.DisplayName,
-            m => string.IsNullOrEmpty(m.Model.Url)
-                ? (string.IsNullOrEmpty(m.Model.Size) ? Se.Language.General.Custom : $"{Se.Language.General.Custom}, {m.Model.Size}")
-                : (string.IsNullOrEmpty(m.Model.Size) ? null : m.Model.Size),
-            m => m.IsInstalled ? DownloadDotStatus.UpToDate : DownloadDotStatus.NotInstalled);
+        comboLlamaCppModel.ItemTemplate = Features.Translate.AutoTranslateCombos.LlamaCppModelItemTemplate();
 
         comboLlamaCppModel.Bind(IsVisibleProperty, new Binding(nameof(vm.IsLlamaCppVisible)));
 

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -32,11 +32,13 @@ using Nikse.SubtitleEdit.Features.Tools.FixCommonErrors;
 using Nikse.SubtitleEdit.Features.Tools.RemoveTextForHearingImpaired;
 using Nikse.SubtitleEdit.Features.Translate;
 using Nikse.SubtitleEdit.Features.Translate.LlamaCppAdvanced;
+using Nikse.SubtitleEdit.Features.Translate.LlamaCppEngineSettings;
 using Nikse.SubtitleEdit.Logic.LlamaCpp;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
 using Nikse.SubtitleEdit.UiLogic.BatchConvert;
 using Nikse.SubtitleEdit.Logic.Media;
 using System;
@@ -169,6 +171,18 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
     [ObservableProperty] private SpeechToTextModelDisplay? _selectedCrispAsrModel;
     [ObservableProperty] private bool _crispAsrModelComboIsVisible;
     [ObservableProperty] private bool _llamaCppAdvancedButtonIsVisible;
+    [ObservableProperty] private bool _llamaCppSettingsButtonIsVisible;
+    [ObservableProperty] private bool _llamaCppEngineSettingsButtonIsVisible;
+    [ObservableProperty] private ObservableCollection<LlamaCppModelDisplay> _llamaCppModels = new();
+    [ObservableProperty] private LlamaCppModelDisplay? _selectedLlamaCppModel;
+    [ObservableProperty] private bool _llamaCppModelComboIsVisible;
+
+    /// <summary>
+    /// Re-assigns the auto-translate engine combo's item template, set by the view. The dots are a
+    /// snapshot taken when a row is first realised, so this is what refreshes them after a batch run
+    /// has downloaded the llama.cpp engine.
+    /// </summary>
+    internal Action? RefreshAutoTranslateEngineDots { get; set; }
 
     // Fix common errors
     [ObservableProperty] private FixCommonErrors.ProfileDisplayItem? _fixCommonErrorsProfile;
@@ -1376,6 +1390,11 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
             return false;
         }
 
+        // The engine binary and/or the model may just have been downloaded - re-evaluate the
+        // install dots so they do not keep showing "not installed" until the window is reopened.
+        PopulateLlamaCppModels();
+        RefreshAutoTranslateEngineDots?.Invoke();
+
         return true;
     }
 
@@ -2239,6 +2258,72 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
             vm => vm.Initialize());
     }
 
+    /// <summary>
+    /// Installed backend, pinned release and install status for llama.cpp - the same dialog the
+    /// Auto-translate window's gear opens. Its download button routes back through
+    /// <see cref="RedownloadLlamaCppEngineAsync"/> so a running server is stopped first and the
+    /// model list and status dots refresh afterwards.
+    /// </summary>
+    [RelayCommand]
+    private async Task ShowLlamaCppEngineSettings()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        await _windowService.ShowDialogAsync<LlamaCppEngineSettingsWindow, LlamaCppEngineSettingsViewModel>(
+            Window,
+            vm => vm.Initialize(RedownloadLlamaCppEngineAsync));
+
+        PopulateLlamaCppModels();
+        RefreshAutoTranslateEngineDots?.Invoke();
+    }
+
+    private async Task RedownloadLlamaCppEngineAsync()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        LlamaCppServerManager.StopServer();
+
+        // Reuse the installed backend so the user is not re-asked CPU/Vulkan/CUDA on a re-download;
+        // null on a fresh install (or off Windows), which lets DownloadAsync prompt.
+        var variant = OperatingSystem.IsWindows()
+            ? DownloadHashManager.DetectLlamaCppWindowsVariant(LlamaCppServerManager.GetAndCreateFolder())
+            : null;
+
+        await LlamaCppDownloadHelper.DownloadAsync(
+            Window,
+            _windowService,
+            SelectedLlamaCppModel?.Model,
+            variant,
+            forceEngineDownload: true);
+
+        PopulateLlamaCppModels();
+        RefreshAutoTranslateEngineDots?.Invoke(); // the engine binary just changed - amber -> green
+    }
+
+    // Prompt (plus request delay, max bytes and the merge strategy) for the regular llama.cpp
+    // engine - the same window the Auto-translate window's settings button opens, editing the same
+    // shared settings. Its OK writes both Se.Settings.AutoTranslate and Configuration.Settings.Tools,
+    // so a prompt edited here reaches the batch run too.
+    [RelayCommand]
+    private async Task ShowLlamaCppTranslateSettings()
+    {
+        if (Window == null || SelectedAutoTranslator == null)
+        {
+            return;
+        }
+
+        var translator = SelectedAutoTranslator;
+        await _windowService.ShowDialogAsync<TranslateSettingsWindow, TranslateSettingsViewModel>(
+            Window,
+            vm => vm.LoadValues(translator));
+    }
+
     [RelayCommand]
     private async Task RemoveSelectedFiles()
     {
@@ -2727,6 +2812,14 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
                 Configuration.Settings.Tools.AutoTranslateDeepLApiKey = AutoTranslateApiKey.Trim();
                 Se.Settings.AutoTranslate.DeepLApiKey = AutoTranslateApiKey.Trim();
             }
+
+            // DeepLTranslate reads the formality from Configuration.Settings.Tools, which SE5 never
+            // persists - without seeding it here the formality chosen in the Auto-translate window
+            // silently reverts to "default" for a batch run.
+            if (!string.IsNullOrEmpty(Se.Settings.AutoTranslate.DeepLFormality))
+            {
+                Configuration.Settings.Tools.AutoTranslateDeepLFormality = Se.Settings.AutoTranslate.DeepLFormality;
+            }
         }
     }
 
@@ -2851,16 +2944,71 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         Configuration.Settings.Tools.AutoTranslateCrispAsrModel = Se.Settings.AutoTranslate.CrispAsrModel;
     }
 
+    // Same setting the Auto-translate window writes, and the one EnsureLlamaCppAvailable reads when
+    // the run starts - so picking a model here decides which one the batch run downloads and serves.
+    partial void OnSelectedLlamaCppModelChanged(LlamaCppModelDisplay? value)
+    {
+        if (value == null)
+        {
+            return;
+        }
+
+        Se.Settings.AutoTranslate.LlamaCppModel = LlamaCppServerManager.GetModelPath(value.Model.FileName);
+    }
+
+    /// <summary>
+    /// Fills the llama.cpp model combo and pre-selects the last-used model, or hides the combo when
+    /// a remote server is configured (it serves whatever model it was started with). Re-filling the
+    /// collection is also what re-evaluates the install dots, so call this again after a download.
+    /// </summary>
+    private void PopulateLlamaCppModels()
+    {
+        if (Se.Settings.AutoTranslate.LlamaCppUseRemoteServer)
+        {
+            // Nothing local to pick or install - the remote server owns both.
+            LlamaCppModelComboIsVisible = false;
+            LlamaCppEngineSettingsButtonIsVisible = false;
+            LlamaCppModels.Clear();
+            SelectedLlamaCppModel = null;
+            return;
+        }
+
+        LlamaCppModelComboIsVisible = true;
+        LlamaCppEngineSettingsButtonIsVisible = true;
+        var savedModelName = Path.GetFileName(Se.Settings.AutoTranslate.LlamaCppModel ?? string.Empty);
+        SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, GetLlamaCppModelsForEngine(), savedModelName);
+    }
+
+    /// <summary>
+    /// The llama.cpp model list for the currently selected engine: everything for the regular
+    /// engine, but no completion-only models (MiLMMT-46) for the advanced engine - they cannot
+    /// follow its JSON batch protocol.
+    /// </summary>
+    private IReadOnlyList<LlamaCppModel> GetLlamaCppModelsForEngine()
+    {
+        var models = LlamaCppServerManager.GetAllTranslateModels();
+        return SelectedAutoTranslator is LlamaCppAdvancedTranslate
+            ? models.Where(m => !m.CompletionOnly).ToList()
+            : models;
+    }
+
     internal void OnAutoTranslatorChanged()
     {
         var engine = SelectedAutoTranslator;
 
         AutoTranslateModelIsVisible = engine is OllamaTranslate;
         CrispAsrModelComboIsVisible = engine is CrispAsrMadladTranslate;
+        // Both turned back on by PopulateLlamaCppModels for a local llama.cpp.
+        LlamaCppModelComboIsVisible = false;
+        LlamaCppEngineSettingsButtonIsVisible = false;
 
         // Batch size, context history and the synopsis/glossary/style prompt only exist on the
         // advanced engine; they apply to local and remote llama-servers alike.
         LlamaCppAdvancedButtonIsVisible = engine is LlamaCppAdvancedTranslate;
+
+        // The regular llama.cpp engine has no advanced window - its prompt (and the shared
+        // delay/max-bytes/merge settings) live in the translate settings dialog instead.
+        LlamaCppSettingsButtonIsVisible = engine is LlamaCppTranslate;
 
         if (engine is CrispAsrMadladTranslate)
         {
@@ -2914,6 +3062,10 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
             AutoTranslateUrlIsVisible = true;
             AutoTranslateApiKey = string.Empty;
             AutoTranslateApiKeyIsVisible = false;
+
+            // A remote server serves whatever model it was started with, so there is nothing to pick
+            // here - same as in the Auto-translate window, which owns that toggle.
+            PopulateLlamaCppModels();
         }
         else if (engine is NoLanguageLeftBehindServe)
         {

--- a/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewAutoTranslate.cs
+++ b/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewAutoTranslate.cs
@@ -1,6 +1,7 @@
 ﻿using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Layout;
+using Nikse.SubtitleEdit.Features.Translate;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 
@@ -30,11 +31,48 @@ public static class ViewAutoTranslate
         cbEngines.Bind(ComboBox.ItemsSourceProperty, new Binding(nameof(vm.AutoTranslators)));
         cbEngines.Bind(ComboBox.SelectedItemProperty, new Binding(nameof(vm.SelectedAutoTranslator)) { Mode = BindingMode.TwoWay });
         cbEngines.SelectionChanged += (s, e) => vm.OnAutoTranslatorChanged();
-        var labelModel = UiUtil.MakeLabel(Se.Language.General.Model).WithBindVisible(vm, nameof(vm.AutoTranslateModelIsVisible)).WithMarginLeft(10).WithMarginRight(3);
+
+        // Install-status dots for the engines Subtitle Edit downloads itself, same as in the
+        // Auto-translate window. Re-assigning the template is what re-evaluates them, so the view
+        // model gets a hook to call after a run has downloaded the engine.
+        cbEngines.ItemTemplate = AutoTranslateCombos.EngineItemTemplate();
+        vm.RefreshAutoTranslateEngineDots = () => cbEngines.ItemTemplate = AutoTranslateCombos.EngineItemTemplate();
+
+        // Model gets a row of its own - the engine row is already crowded with the engine combo and
+        // its settings buttons, and the three model editors (Ollama text box + browse, the CrispASR
+        // combo, the llama.cpp combo) are never visible at the same time, so they share the row.
+        var labelModel = UiUtil.MakeLabel(Se.Language.General.Model).WithBindVisible(vm, nameof(vm.AutoTranslateModelIsVisible));
         var textBoxModel = UiUtil.MakeTextBox(150, vm, nameof(vm.AutoTranslateModel), nameof(vm.AutoTranslateModelIsVisible));
         var buttonModel = UiUtil.MakeButtonBrowse(vm.AutoTranslateBrowseModelCommand, nameof(vm.AutoTranslateModelBrowseIsVisible), Se.Language.General.Model).WithMarginLeft(3);
-        var labelCrispAsrModel = UiUtil.MakeLabel(Se.Language.General.Model).WithBindVisible(vm, nameof(vm.CrispAsrModelComboIsVisible)).WithMarginLeft(10).WithMarginRight(3);
-        var crispAsrModelCombo = UiUtil.MakeComboBox(vm.CrispAsrModels, vm, nameof(vm.SelectedCrispAsrModel), nameof(vm.CrispAsrModelComboIsVisible));
+
+        var labelCrispAsrModel = UiUtil.MakeLabel(Se.Language.General.Model).WithBindVisible(vm, nameof(vm.CrispAsrModelComboIsVisible));
+        var crispAsrModelCombo = UiUtil.MakeComboBox(vm.CrispAsrModels, vm, nameof(vm.SelectedCrispAsrModel), nameof(vm.CrispAsrModelComboIsVisible))
+            .WithAccessibleName(Se.Language.General.Model);
+        crispAsrModelCombo.ItemTemplate = AutoTranslateCombos.CrispAsrModelItemTemplate();
+
+        var labelLlamaCppModel = UiUtil.MakeLabel(Se.Language.General.Model).WithBindVisible(vm, nameof(vm.LlamaCppModelComboIsVisible));
+        var llamaCppModelCombo = UiUtil.MakeComboBox(vm.LlamaCppModels, vm, nameof(vm.SelectedLlamaCppModel), nameof(vm.LlamaCppModelComboIsVisible))
+            .WithWidth(220)
+            .WithAccessibleName(Se.Language.General.Model);
+        llamaCppModelCombo.ItemTemplate = AutoTranslateCombos.LlamaCppModelItemTemplate();
+
+        var panelModelLabels = UiUtil.MakeHorizontalPanel(labelModel, labelCrispAsrModel, labelLlamaCppModel);
+        var panelModelControls = UiUtil.MakeHorizontalPanel(
+            textBoxModel,
+            buttonModel,
+            crispAsrModelCombo,
+            llamaCppModelCombo);
+
+        // Installed backend, pinned release and install state of llama.cpp itself. It sits directly
+        // after the engine combo because it configures the engine, not the model or the prompt.
+        var buttonEngineSettings = UiUtil.MakeButton(vm.ShowLlamaCppEngineSettingsCommand, IconNames.Settings)
+            .WithMarginLeft(5)
+            .WithAccessibleName(Se.Language.General.LlamaCppEngineSettings);
+        buttonEngineSettings.Bind(Button.IsVisibleProperty, new Binding(nameof(vm.LlamaCppEngineSettingsButtonIsVisible)));
+        if (Se.Settings.Appearance.ShowHints)
+        {
+            ToolTip.SetTip(buttonEngineSettings, Se.Language.General.LlamaCppEngineSettings);
+        }
 
         var buttonAdvanced = UiUtil.MakeButton(Se.Language.Translate.AdvancedDotDotDot, vm.ShowLlamaCppAdvancedSettingsCommand)
             .WithMarginLeft(10)
@@ -47,12 +85,29 @@ public static class ViewAutoTranslate
 
         var panelEngineControls = UiUtil.MakeHorizontalPanel(
             cbEngines,
-            labelModel,
-            textBoxModel,
-            buttonModel,
-            labelCrispAsrModel,
-            crispAsrModelCombo,
+            buttonEngineSettings,
             buttonAdvanced);
+
+        // Prompt and the shared request settings for the regular llama.cpp engine (the advanced
+        // engine has its own window instead). Right-aligned and away from the engine gear, the same
+        // way the Auto-translate window separates the two.
+        var buttonSettings = UiUtil.MakeButton(vm.ShowLlamaCppTranslateSettingsCommand, IconNames.Settings)
+            .WithMarginLeft(10)
+            .WithAccessibleName(Se.Language.General.Settings);
+        buttonSettings.HorizontalAlignment = HorizontalAlignment.Right;
+        buttonSettings.VerticalAlignment = VerticalAlignment.Center;
+        buttonSettings.Bind(Button.IsVisibleProperty, new Binding(nameof(vm.LlamaCppSettingsButtonIsVisible)));
+        if (Se.Settings.Appearance.ShowHints)
+        {
+            ToolTip.SetTip(buttonSettings, Se.Language.General.Settings);
+        }
+
+        var panelEngineRow = new Grid
+        {
+            ColumnDefinitions = new ColumnDefinitions("*,Auto"),
+        };
+        panelEngineRow.Add(panelEngineControls, 0, 0);
+        panelEngineRow.Add(buttonSettings, 0, 1);
 
         var labelSourceLanguage = UiUtil.MakeLabel(Se.Language.General.From);
         var sourceLangCombo = UiUtil.MakeComboBox(vm.SourceLanguages, vm, nameof(vm.SelectedSourceLanguage));
@@ -77,6 +132,7 @@ public static class ViewAutoTranslate
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
             {
@@ -92,19 +148,22 @@ public static class ViewAutoTranslate
         grid.Add(labelHeader, 0, 0);
 
         grid.Add(labelEngine, 1, 0);
-        grid.Add(panelEngineControls, 1, 1);
+        grid.Add(panelEngineRow, 1, 1);
 
-        grid.Add(labelSourceLanguage, 2, 0);
-        grid.Add(sourceLangCombo, 2, 1);
+        grid.Add(panelModelLabels, 2, 0);
+        grid.Add(panelModelControls, 2, 1);
 
-        grid.Add(labelTargetLanguage, 3, 0);
-        grid.Add(targetLangCombo, 3, 1);
+        grid.Add(labelSourceLanguage, 3, 0);
+        grid.Add(sourceLangCombo, 3, 1);
 
-        grid.Add(labelUrl, 4, 0);
-        grid.Add(textBoxUrl, 4, 1);
+        grid.Add(labelTargetLanguage, 4, 0);
+        grid.Add(targetLangCombo, 4, 1);
 
-        grid.Add(labelApiKey, 5, 0);
-        grid.Add(textBoxApiKey, 5, 1);
+        grid.Add(labelUrl, 5, 0);
+        grid.Add(textBoxUrl, 5, 1);
+
+        grid.Add(labelApiKey, 6, 0);
+        grid.Add(textBoxApiKey, 6, 1);
 
         return grid;
     }

--- a/src/ui/Features/Translate/AutoTranslateCombos.cs
+++ b/src/ui/Features/Translate/AutoTranslateCombos.cs
@@ -1,0 +1,92 @@
+using Avalonia.Controls.Templates;
+using Nikse.SubtitleEdit.Features.Translate.LlamaCppAdvanced;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
+using Nikse.SubtitleEdit.Logic.LlamaCpp;
+using Nikse.SubtitleEdit.UiLogic.AutoTranslate;
+using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
+
+namespace Nikse.SubtitleEdit.Features.Translate;
+
+/// <summary>
+/// Install-status dot templates for the auto-translate combos (engine, llama.cpp model, CrispASR
+/// model), shared by the Auto-translate window and batch convert so the same list cannot show dots
+/// in one place and plain text in the other.
+/// Each template evaluates its dot when a row is first realised, so re-filling the bound collection
+/// (or re-assigning the template) is what refreshes the dots after a download - see
+/// <see cref="StatusDots.ComboItemTemplate{T}"/>.
+/// </summary>
+public static class AutoTranslateCombos
+{
+    public static FuncDataTemplate<IAutoTranslator> EngineItemTemplate()
+    {
+        return StatusDots.ComboItemTemplate<IAutoTranslator>(
+            translator => translator.Name,
+            _ => null,
+            GetTranslatorDotStatus);
+    }
+
+    public static FuncDataTemplate<LlamaCppModelDisplay> LlamaCppModelItemTemplate()
+    {
+        return StatusDots.ComboItemTemplate<LlamaCppModelDisplay>(
+            model => model.Model.DisplayName,
+            GetLlamaCppModelSize,
+            GetLlamaCppModelDotStatus);
+    }
+
+    public static FuncDataTemplate<SpeechToTextModelDisplay> CrispAsrModelItemTemplate()
+    {
+        return StatusDots.ComboItemTemplate<SpeechToTextModelDisplay>(
+            model => model.Model.Name,
+            model => string.IsNullOrEmpty(model.Model.Size) ? null : model.Model.Size,
+            model => model.Engine.IsModelInstalled(model.Model)
+                ? DownloadDotStatus.UpToDate
+                : DownloadDotStatus.NotInstalled);
+    }
+
+    // Install-status dot for the auto-translate engine combo. Only the two engines that Subtitle
+    // Edit downloads itself - llama.cpp and CrispASR/MADLAD - get a dot; cloud/API translators
+    // (Google, DeepL, ChatGPT, ...) and externally-hosted servers have nothing to install.
+    private static DownloadDotStatus GetTranslatorDotStatus(IAutoTranslator translator)
+    {
+        switch (translator)
+        {
+            case LlamaCppTranslate:
+            case LlamaCppAdvancedTranslate:
+                return StatusDots.From(
+                    LlamaCppServerManager.IsEngineInstalled(),
+                    LlamaCppUpdateStatus.GetEngineUpdateStatus());
+            case CrispAsrMadladTranslate:
+                var crispAsr = new CrispAsrMadlad();
+                if (!crispAsr.IsEngineInstalled())
+                {
+                    return DownloadDotStatus.NotInstalled;
+                }
+
+                return StatusDots.From(true, DownloadHashManager.GetSidecarStatus(crispAsr.GetAndCreateWhisperFolder()));
+            default:
+                return DownloadDotStatus.None;
+        }
+    }
+
+    // A custom *.gguf the user dropped into the models folder has no Url - it is already on disk,
+    // so it shows a green dot and a "custom" size tag rather than a download size.
+    private static string? GetLlamaCppModelSize(LlamaCppModelDisplay model)
+    {
+        if (string.IsNullOrEmpty(model.Model.Url))
+        {
+            var custom = Se.Language.General.Custom;
+            return string.IsNullOrEmpty(model.Model.Size) ? custom : $"{custom}, {model.Model.Size}";
+        }
+
+        return string.IsNullOrEmpty(model.Model.Size) ? null : model.Model.Size;
+    }
+
+    private static DownloadDotStatus GetLlamaCppModelDotStatus(LlamaCppModelDisplay model)
+    {
+        return model.IsInstalled ? DownloadDotStatus.UpToDate : DownloadDotStatus.NotInstalled;
+    }
+}

--- a/src/ui/Features/Translate/AutoTranslateWindow.cs
+++ b/src/ui/Features/Translate/AutoTranslateWindow.cs
@@ -206,60 +206,10 @@ public class AutoTranslateWindow : Window
         return MakeCard(stack);
     }
 
+    // Shared with batch convert's auto-translate view - see AutoTranslateCombos.
     private static FuncDataTemplate<IAutoTranslator> BuildTranslatorItemTemplate()
     {
-        return StatusDots.ComboItemTemplate<IAutoTranslator>(
-            translator => translator.Name,
-            _ => null,
-            GetTranslatorDotStatus);
-    }
-
-    // Install-status dot for the auto-translate engine combo. Only the two engines that Subtitle
-    // Edit downloads itself - llama.cpp and CrispASR/MADLAD - get a dot; cloud/API translators
-    // (Google, DeepL, ChatGPT, ...) and externally-hosted servers have nothing to install.
-    private static DownloadDotStatus GetTranslatorDotStatus(IAutoTranslator translator)
-    {
-        switch (translator)
-        {
-            case LlamaCppTranslate:
-            case LlamaCppAdvancedTranslate:
-                return StatusDots.From(
-                    LlamaCppServerManager.IsEngineInstalled(),
-                    LlamaCppUpdateStatus.GetEngineUpdateStatus());
-            case CrispAsrMadladTranslate:
-                var crispAsr = new CrispAsrMadlad();
-                if (!crispAsr.IsEngineInstalled())
-                {
-                    return DownloadDotStatus.NotInstalled;
-                }
-
-                return StatusDots.From(true, DownloadHashManager.GetSidecarStatus(crispAsr.GetAndCreateWhisperFolder()));
-            default:
-                return DownloadDotStatus.None;
-        }
-    }
-
-    // A custom *.gguf the user dropped into the models folder has no Url - it is already on disk,
-    // so it shows a green dot and a "custom" size tag rather than a download size.
-    private static string? GetLlamaCppModelSize(LlamaCppModelDisplay model)
-    {
-        if (string.IsNullOrEmpty(model.Model.Url))
-        {
-            var custom = Se.Language.General.Custom;
-            return string.IsNullOrEmpty(model.Model.Size) ? custom : $"{custom}, {model.Model.Size}";
-        }
-
-        return string.IsNullOrEmpty(model.Model.Size) ? null : model.Model.Size;
-    }
-
-    private static DownloadDotStatus GetLlamaCppModelDotStatus(LlamaCppModelDisplay model)
-    {
-        if (string.IsNullOrEmpty(model.Model.Url) || LlamaCppServerManager.IsModelInstalled(model.Model))
-        {
-            return DownloadDotStatus.UpToDate;
-        }
-
-        return DownloadDotStatus.NotInstalled;
+        return AutoTranslateCombos.EngineItemTemplate();
     }
 
     private static Border BuildApiConfigCard(AutoTranslateViewModel vm)
@@ -270,19 +220,11 @@ public class AutoTranslateWindow : Window
         buttonDownloadCrispAsr.Bind(Button.IsVisibleProperty, new Binding(nameof(vm.ButtonDownloadIsVisible)));
 
         var crispAsrModelCombo = UiUtil.MakeComboBox(vm.CrispAsrModels, vm, nameof(vm.SelectedCrispAsrModel), nameof(vm.CrispAsrModelComboIsVisible));
-        crispAsrModelCombo.ItemTemplate = StatusDots.ComboItemTemplate<SpeechToTextModelDisplay>(
-            model => model.Model.Name,
-            model => string.IsNullOrEmpty(model.Model.Size) ? null : model.Model.Size,
-            model => model.Engine.IsModelInstalled(model.Model)
-                ? DownloadDotStatus.UpToDate
-                : DownloadDotStatus.NotInstalled);
+        crispAsrModelCombo.ItemTemplate = AutoTranslateCombos.CrispAsrModelItemTemplate();
         crispAsrModelCombo.WithAccessibleName(Se.Language.General.Model);
 
         var llamaCppModelCombo = UiUtil.MakeComboBox(vm.LlamaCppModels, vm, nameof(vm.SelectedLlamaCppModel), nameof(vm.LlamaCppModelComboIsVisible)).WithWidth(220);
-        llamaCppModelCombo.ItemTemplate = StatusDots.ComboItemTemplate<LlamaCppModelDisplay>(
-            model => model.Model.DisplayName,
-            GetLlamaCppModelSize,
-            GetLlamaCppModelDotStatus);
+        llamaCppModelCombo.ItemTemplate = AutoTranslateCombos.LlamaCppModelItemTemplate();
         llamaCppModelCombo.WithAccessibleName(Se.Language.General.Model);
 
         var buttonDownloadLlamaCpp = UiUtil.MakeButton(string.Empty, vm.DownloadLlamaCppCommand)


### PR DESCRIPTION
Batch convert's auto-translate view exposed far less than the interactive Auto-translate window for the same engines. This closes most of that gap for llama.cpp.

## Added

- **Settings gear** (prompt, request delay, max bytes per request, merge strategy) for the regular llama.cpp engine — opens the same `TranslateSettingsWindow` the Auto-translate window's gear opens. Its OK writes both `Se.Settings.AutoTranslate` and `Configuration.Settings.Tools`, so an edited prompt survives a restart *and* reaches the batch run.
- **llama.cpp engine settings gear** (installed backend, pinned release, install state), sitting right after the engine combo. Its download button routes through the same stop-server-then-redownload flow the other callers use.
- **llama.cpp model combo**, so a batch run no longer silently depends on whichever model was last picked in the Auto-translate window. Selecting writes `Se.Settings.AutoTranslate.LlamaCppModel`, which is exactly what `EnsureLlamaCppAvailable` reads when the run starts. Completion-only models (MiLMMT-46) are filtered out for the advanced engine; combo and engine gear hide when a remote server is configured.
- **Install-status dots** on the engine combo, the CrispASR model combo and the new llama.cpp model combo — all three were plain text before. They are re-evaluated after a run (or the engine settings dialog) downloads something, instead of staying grey until the window is reopened.

## Changed

- **Model moved to its own row.** The engine row now holds the engine combo, the engine gear and `Advanced...`, with the translate-settings gear right-aligned — the same separation the Auto-translate window uses.
- The three dot templates moved into `AutoTranslateCombos`, used by the Auto-translate window, batch convert and AI review, so they cannot drift apart.

## Fixed

- **DeepL formality was ignored in batch convert.** `DeepLTranslate` reads `Configuration.Settings.Tools.AutoTranslateDeepLFormality`, only the Auto-translate window seeded it, and SE5 never persists that settings object — so a batch run always fell back to "default" regardless of what the user had chosen. Same class of bug as `LlamaCppPrompt` in #13678.

## Still missing vs. the Auto-translate window

Not addressed here, listed for the record: 18 of the 27 engines are still absent from batch convert (no Google, ChatGPT, Anthropic, Gemini, …), the engine "Update" button, the "use remote server" toggle, the DeepL formality combo, the download/start-server/open-folder buttons (partly covered by the run's auto-download and auto-start), and the settings gear for the other prompt engines (Ollama, LM Studio).

## Testing

`dotnet build src/ui/UI.csproj` clean; full `tests/UI` suite green (2882 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)