### PR TITLE
Batch convert: give the advanced llama.cpp engine its configured context size

### DIFF
--- a/src/libuilogic/LlamaCpp/LlamaCppServerManager.cs
+++ b/src/libuilogic/LlamaCpp/LlamaCppServerManager.cs
@@ -309,6 +309,9 @@ public static class LlamaCppServerManager
 
     public static string? RunningModelPath => IsServerRunning ? _serverModelPath : null;
 
+    /// <summary>Context size the running server was started with, or 0 when nothing is running.</summary>
+    public static int RunningContextSize => IsServerRunning ? _serverContextSize : 0;
+
     public static string ApiUrl => $"http://127.0.0.1:{_serverPort}/v1/chat/completions";
 
     public static string GetAndCreateFolder()

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -1351,8 +1351,12 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
             return true;
         }
 
-        // Auto-detect: reuse an already-running local server.
-        if (LlamaCppServerManager.IsServerRunning)
+        // Auto-detect: reuse an already-running local server - but not one started with a smaller
+        // context than the selected engine needs (say the advanced engine after an OCR run, or after
+        // the regular engine started the server at the default size). Falling through restarts it
+        // with the right context instead of silently translating in a too-small window.
+        var contextSize = GetLlamaCppContextSize(config.AutoTranslate.Translator);
+        if (LlamaCppServerManager.IsServerRunning && LlamaCppServerManager.RunningContextSize >= contextSize)
         {
             Configuration.Settings.Tools.LlamaCppApiUrl = LlamaCppServerManager.ApiUrl;
             return true;
@@ -1382,7 +1386,7 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         // Auto-start the local server - this points Configuration.Settings.Tools.LlamaCppApiUrl at it.
         try
         {
-            await LlamaCppServerManager.EnsureServerRunningAsync(model, _cancellationToken);
+            await LlamaCppServerManager.EnsureServerRunningAsync(model, _cancellationToken, contextSize);
         }
         catch (Exception ex)
         {
@@ -1396,6 +1400,19 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         RefreshAutoTranslateEngineDots?.Invoke();
 
         return true;
+    }
+
+    /// <summary>
+    /// The advanced engine stuffs history/synopsis/glossary into every request, so it gets the
+    /// user-configurable (default larger) server context; everything else keeps the default. Same
+    /// rule as <c>AutoTranslateViewModel.EnsureLlamaCppReady</c> - without it a batch run served the
+    /// advanced engine from an 8k window while the interactive window used the configured size.
+    /// </summary>
+    private static int GetLlamaCppContextSize(IAutoTranslator? translator)
+    {
+        return translator is LlamaCppAdvancedTranslate
+            ? Math.Clamp(Se.Settings.AutoTranslate.LlamaCppAdvanced.ContextSize, 2048, 262144)
+            : LlamaCppServerManager.DefaultContextSize;
     }
 
     private static bool IsImageBasedInput(BatchConvertItem item)


### PR DESCRIPTION
Follow-up to #13693.

## Problem

`BatchConvertViewModel.EnsureLlamaCppAvailable` started llama-server with the default 8k context for every engine, while `AutoTranslateViewModel.EnsureLlamaCppReady` passes the user-configured (default larger) size when the **advanced** engine is selected. That engine stuffs rolling history, synopsis and glossary into every request, so the same job was served from a too-small window in batch convert but not interactively.

## Fix

- Pass `GetLlamaCppContextSize(config.AutoTranslate.Translator)` — the configured size clamped to 2048…262144 for `LlamaCppAdvancedTranslate`, the default otherwise. Same rule as the Auto-translate window.
- Don't reuse an already-running server whose context is smaller than the selected engine needs (e.g. one left over from an OCR run, or started at the default by the regular engine). Falling through lets `EnsureServerRunningAsync` restart it — it already restarts on a context mismatch. `LlamaCppServerManager.RunningContextSize` exposes the running size for that check.

seconv was checked and is unaffected: it has no advanced engine (`SupportedEngines` is llamacpp/ollama/lmstudio/libretranslate/nllb-serve/nllb-api). The OCR call site in `BatchConverter` keeps the default deliberately, matching the OCR window.

## Testing

`dotnet build src/ui/UI.csproj` clean. Full `tests/UI` suite: 2882 passed, 1 failure in `WebVttStylePickerViewModelTests.CheckedStylesApplyAsCueClassesOnTheLine` — unrelated to this diff (WebVTT style picker) and passing when run on its own, so it looks order-dependent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)