### PR TITLE
Keep negative time codes instead of zeroing them on selection

### DIFF
--- a/src/ui/Controls/TimeCodeUpDown.cs
+++ b/src/ui/Controls/TimeCodeUpDown.cs
@@ -19,18 +19,25 @@ namespace Nikse.SubtitleEdit.Controls
 {
     public class TimeCodeUpDown : TemplatedControl
     {
-        // Every step (spinner, wheel and Up/Down) applies to the part the caret is on. The caret
-        // starts on the last part, the milliseconds or frames, so a plain spinner click makes the
-        // small adjustment that is wanted almost every time; it used to start on the hours and
-        // jump a whole hour (#12506). The millisecond step size is configurable in Settings.
-        private const int LastPartCaretIndex = 9;
-
         public bool UseVideoOffset { get; set; } = false;
 
         private TextBox? _textBox;
         private ButtonSpinner? _spinner;
         private string _textBuffer = "00:00:00:000";
         private bool _isUpdatingFromValue = false;
+        private bool _minWidthIncludesSign;
+
+        // Every step (spinner, wheel and Up/Down) applies to the part the caret is on. The caret
+        // starts on the last part, the milliseconds or frames, so a plain spinner click makes the
+        // small adjustment that is wanted almost every time; it used to start on the hours and
+        // jump a whole hour (#12506). The millisecond step size is configurable in Settings.
+        // Computed rather than a constant because a negative time code carries a leading minus
+        // (#13695), which shifts every part one to the right, and frame mode has a shorter last part.
+        private int LastPartCaretIndex => LastPartStartIndex(_textBuffer);
+
+        // A negative time code is shown as "-00:00:01,500". Like the separators, the sign is a mask
+        // literal: it is never typed over and the caret skips past it.
+        private int SignOffset => _textBuffer.Length > 0 && _textBuffer[0] == '-' ? 1 : 0;
 
         public static readonly StyledProperty<TimeSpan> ValueProperty =
             AvaloniaProperty.Register<TimeCodeUpDown, TimeSpan>(
@@ -133,8 +140,11 @@ namespace Nikse.SubtitleEdit.Controls
 
         private void UpdateMinWidth()
         {
-            // Measure the sample text
-            var sampleText = "00:00:00:000";
+            // Measure the sample text - with room for the minus sign only while the value actually is
+            // negative, so a negative time code is not clipped (#13695) but every other time box keeps
+            // the width it had.
+            _minWidthIncludesSign = SignOffset > 0;
+            var sampleText = _minWidthIncludesSign ? "-00:00:00:000" : "00:00:00:000";
             var formattedText = new FormattedText(
                 sampleText,
                 System.Globalization.CultureInfo.CurrentCulture,
@@ -175,6 +185,10 @@ namespace Nikse.SubtitleEdit.Controls
                 var newValue = (TimeSpan)change.NewValue!;
                 var clampedValue = Clamp(newValue);
 
+                // Only an out-of-range value is rewritten. Negative time codes are legal - they come
+                // from "adjust all times" with a negative offset - and the value is written straight
+                // back through the two-way binding, so clamping them to zero here destroyed the time
+                // code of every line the user selected (#13695).
                 if (newValue != clampedValue)
                 {
                     SetValue(ValueProperty, clampedValue);
@@ -207,7 +221,7 @@ namespace Nikse.SubtitleEdit.Controls
                     HorizontalAlignment = HorizontalAlignment.Stretch,
                     Width = double.NaN,
                     BorderBrush = Brushes.Transparent,
-                    CaretIndex = LastPartCaretIndex,
+                    CaretIndex = control.LastPartCaretIndex,
                 };
 
                 var grid = new Grid
@@ -275,8 +289,8 @@ namespace Nikse.SubtitleEdit.Controls
                     continue;
                 }
 
-                // Skip separators (colons, commas, dots)
-                while (caret < chars.Length && IsSeparator(chars[caret]))
+                // Skip mask literals (colons, commas, dots and the leading minus)
+                while (caret < chars.Length && IsMaskLiteral(chars[caret], caret))
                 {
                     caret++;
                 }
@@ -292,7 +306,7 @@ namespace Nikse.SubtitleEdit.Controls
 
                 // Move to next editable position
                 caret++;
-                while (caret < chars.Length && IsSeparator(chars[caret]))
+                while (caret < chars.Length && IsMaskLiteral(chars[caret], caret))
                 {
                     caret++;
                 }
@@ -371,6 +385,7 @@ namespace Nikse.SubtitleEdit.Controls
         // A bare number is taken as milliseconds and replaces the whole time code (e.g. "231" ->
         // 00:00:00,231), which is the common paste intent (#12056). Anything with separators is parsed
         // as a full or partial time code ("00:00:05,500", "01:02,300"; frames when in frame mode).
+        // A leading minus makes the value negative, matching what the control now shows (#13695).
         private bool TryParsePastedValue(string? clipboardText, out TimeSpan value)
         {
             value = TimeSpan.Zero;
@@ -386,6 +401,14 @@ namespace Nikse.SubtitleEdit.Controls
                 text = text.Substring(0, newlineIndex).Trim();
             }
 
+            // The sign is taken off here and re-applied at the end: the parts of a time code are
+            // unsigned, and the bare-milliseconds form is parsed with NumberStyles.None.
+            var isNegative = text.StartsWith('-');
+            if (isNegative)
+            {
+                text = text.Substring(1).TrimStart();
+            }
+
             if (text.Length == 0)
             {
                 return false;
@@ -398,7 +421,7 @@ namespace Nikse.SubtitleEdit.Controls
                     return false; // beyond the control's range (max 99:59:59,999) - reject rather than overflow
                 }
 
-                value = RemoveVideoOffset(TimeSpan.FromMilliseconds(milliseconds));
+                value = RemoveVideoOffset(TimeSpan.FromMilliseconds(isNegative ? -milliseconds : milliseconds));
                 return true;
             }
 
@@ -427,11 +450,26 @@ namespace Nikse.SubtitleEdit.Controls
                 return false;
             }
 
-            value = RemoveVideoOffset(TimeSpan.FromMilliseconds(ms));
+            value = RemoveVideoOffset(TimeSpan.FromMilliseconds(isNegative ? -ms : ms));
             return true;
         }
 
         private TimeSpan ParseTime(string text)
+        {
+            // The mask carries the sign as a leading minus; the parts themselves are unsigned, so take
+            // the sign off first and re-apply it to the parsed magnitude (#13695). Without this, editing
+            // a negative time code silently flipped it positive ("-00" parses as 0).
+            var isNegative = text.StartsWith('-');
+            if (isNegative)
+            {
+                text = text.Substring(1);
+            }
+
+            var magnitude = ParseUnsignedTime(text);
+            return RemoveVideoOffset(isNegative ? magnitude.Negate() : magnitude);
+        }
+
+        private static TimeSpan ParseUnsignedTime(string text)
         {
             if (Se.Settings.General.UseFrameMode)
             {
@@ -444,7 +482,7 @@ namespace Nikse.SubtitleEdit.Controls
                     int.TryParse(frameParts[3], out var frames))
                 {
                     var frameMs = SubtitleFormat.FramesToMillisecondsMax999(frames);
-                    return RemoveVideoOffset(new TimeSpan(0, frameHours, frameMinutes, frameSeconds, frameMs));
+                    return new TimeSpan(0, frameHours, frameMinutes, frameSeconds, frameMs);
                 }
 
                 return TimeSpan.Zero;
@@ -453,13 +491,13 @@ namespace Nikse.SubtitleEdit.Controls
             // Try parsing with milliseconds format (00:00:00:000 or 00:00:00.000)
             if (TimeSpan.TryParseExact(text, @"hh\:mm\:ss\:fff", null, out var result))
             {
-                return RemoveVideoOffset(result);
+                return result;
             }
 
             // Try parsing with dot separator for milliseconds
             if (TimeSpan.TryParseExact(text, @"hh\:mm\:ss\.fff", null, out result))
             {
-                return RemoveVideoOffset(result);
+                return result;
             }
 
             // Manual parsing as fallback
@@ -471,7 +509,7 @@ namespace Nikse.SubtitleEdit.Controls
                     int.TryParse(parts[2], out var seconds) &&
                     int.TryParse(parts[3], out var milliseconds))
                 {
-                    return RemoveVideoOffset(new TimeSpan(0, hours, minutes, seconds, milliseconds));
+                    return new TimeSpan(0, hours, minutes, seconds, milliseconds);
                 }
             }
 
@@ -519,7 +557,7 @@ namespace Nikse.SubtitleEdit.Controls
             else if (e.Key == Key.Left)
             {
                 var newPos = _textBox.CaretIndex - 1;
-                while (newPos >= 0 && IsSeparator(_textBuffer[newPos]))
+                while (newPos >= 0 && IsMaskLiteral(_textBuffer[newPos], newPos))
                 {
                     newPos--;
                 }
@@ -534,7 +572,7 @@ namespace Nikse.SubtitleEdit.Controls
             else if (e.Key == Key.Right)
             {
                 var newPos = _textBox.CaretIndex + 1;
-                while (newPos < _textBuffer.Length && IsSeparator(_textBuffer[newPos]))
+                while (newPos < _textBuffer.Length && IsMaskLiteral(_textBuffer[newPos], newPos))
                 {
                     newPos++;
                 }
@@ -560,7 +598,9 @@ namespace Nikse.SubtitleEdit.Controls
                 return;
             }
 
-            var caret = _textBox.CaretIndex;
+            // Measured from the first digit, so the leading minus of a negative time code does not
+            // shift every part one place to the right (#13695).
+            var caret = _textBox.CaretIndex - SignOffset;
             TimeSpan newVal = Value;
 
             if (caret <= 2)
@@ -600,12 +640,20 @@ namespace Nikse.SubtitleEdit.Controls
 
         private void UpdateText()
         {
+            var oldSignOffset = SignOffset;
             _textBuffer = FormatTime(Value);
             if (_textBox != null)
             {
-                var oldCaret = _textBox.CaretIndex;
+                // Stepping across zero adds or removes the leading minus; move the caret with it so it
+                // stays on the same part of the time code (#13695).
+                var oldCaret = _textBox.CaretIndex + (SignOffset - oldSignOffset);
                 _textBox.Text = _textBuffer;
-                _textBox.CaretIndex = Math.Min(oldCaret, _textBuffer.Length);
+                _textBox.CaretIndex = Math.Clamp(oldCaret, 0, _textBuffer.Length);
+            }
+
+            if (_minWidthIncludesSign != SignOffset > 0)
+            {
+                UpdateMinWidth();
             }
         }
 
@@ -616,10 +664,16 @@ namespace Nikse.SubtitleEdit.Controls
                 time = TimeSpan.FromMilliseconds(time.TotalMilliseconds + Se.Settings.General.CurrentVideoOffsetInMs);
             }
 
+            // A negative time span has negative parts throughout, which TimeCode renders as a single
+            // leading minus.
             TimeCode tc;
             if (time.TotalHours > 99)
             {
                 tc = new TimeCode(99, time.Minutes, time.Seconds, time.Milliseconds);
+            }
+            else if (time.TotalHours < -99)
+            {
+                tc = new TimeCode(-99, time.Minutes, time.Seconds, time.Milliseconds);
             }
             else
             {
@@ -637,9 +691,30 @@ namespace Nikse.SubtitleEdit.Controls
 
         private static bool IsSeparator(char c) => c == ':' || c == ',' || c == '.';
 
+        // Positions the caret cannot edit or land on: the separators and the sign of a negative value.
+        private static bool IsMaskLiteral(char c, int index) => IsSeparator(c) || (index == 0 && c == '-');
+
+        // First character of the last part (milliseconds, or frames in frame mode).
+        private static int LastPartStartIndex(string text)
+        {
+            for (var i = text.Length - 1; i >= 0; i--)
+            {
+                if (IsSeparator(text[i]))
+                {
+                    return i + 1;
+                }
+            }
+
+            return 0;
+        }
+
+        // Negative time codes are allowed (#13695); only values the mask cannot render are pulled back
+        // into range.
         private TimeSpan Clamp(TimeSpan time)
         {
-            return time.TotalMilliseconds < 0 ? TimeSpan.Zero : time;
+            return time.TotalMilliseconds < -TimeCode.MaxTimeTotalMilliseconds
+                ? TimeSpan.FromMilliseconds(-TimeCode.MaxTimeTotalMilliseconds)
+                : time;
         }
     }
 }

--- a/tests/UI/Controls/TimeCodeUpDownNegativeTests.cs
+++ b/tests/UI/Controls/TimeCodeUpDownNegativeTests.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.VisualTree;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Nikse.SubtitleEdit.Controls;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Controls;
+
+// Negative time codes (#13695). "Adjust all times" with a negative offset moves lines before zero,
+// and the editor used to clamp any negative value to zero and write that back through its two-way
+// binding - so every line the user selected had its time code destroyed. The control now shows,
+// edits and steps negative time codes the way SE 4.x did.
+public partial class TimeCodeUpDownNegativeTests
+{
+    public partial class Line : ObservableObject
+    {
+        [ObservableProperty] private TimeSpan _start = TimeSpan.Zero;
+    }
+
+    public partial class Vm : ObservableObject
+    {
+        [ObservableProperty] private Line? _selected;
+    }
+
+    private sealed class TimeCodeSettings : IDisposable
+    {
+        private readonly SettingsScope _scope;
+        private readonly long _videoOffset;
+
+        internal TimeCodeSettings(bool frameMode, int stepMs)
+        {
+            // CurrentVideoOffsetInMs is a field, which SettingsScope (properties only) cannot hold.
+            _scope = new SettingsScope("General.UseFrameMode", "General.TimeCodeUpDownStepMs");
+            _videoOffset = Se.Settings.General.CurrentVideoOffsetInMs;
+
+            Se.Settings.General.UseFrameMode = frameMode;
+            Se.Settings.General.TimeCodeUpDownStepMs = stepMs;
+            Se.Settings.General.CurrentVideoOffsetInMs = 0;
+        }
+
+        public void Dispose()
+        {
+            Se.Settings.General.CurrentVideoOffsetInMs = _videoOffset;
+            _scope.Dispose();
+        }
+    }
+
+    private static TimeCodeSettings MillisecondMode(int stepMs = 100) => new(frameMode: false, stepMs);
+
+    private static TimeCodeSettings FrameMode() => new(frameMode: true, stepMs: 100);
+
+    private static (Window window, TimeCodeUpDown control, TextBox textBox) Show(TimeCodeUpDown control)
+    {
+        var window = new Window { Content = control };
+        window.Show();
+        var textBox = control.GetVisualDescendants().OfType<TextBox>().Single();
+        return (window, control, textBox);
+    }
+
+    // The reported bug: walking a list of lines that start before zero zeroed them one by one.
+    [AvaloniaFact]
+    public void SelectingLinesWithNegativeTimesLeavesThemUnchanged()
+    {
+        using var _ = MillisecondMode();
+
+        var beforeZero = new Line { Start = TimeSpan.FromMilliseconds(-3000) };
+        var alsoBeforeZero = new Line { Start = TimeSpan.FromMilliseconds(-1500) };
+        var afterZero = new Line { Start = TimeSpan.FromMilliseconds(2000) };
+
+        var vm = new Vm();
+        var control = new TimeCodeUpDown { DataContext = vm };
+        control[!TimeCodeUpDown.ValueProperty] =
+            new Binding($"{nameof(Vm.Selected)}.{nameof(Line.Start)}") { Mode = BindingMode.TwoWay };
+        var (_, _, textBox) = Show(control);
+
+        vm.Selected = beforeZero;
+        Assert.Equal(-3000, beforeZero.Start.TotalMilliseconds);
+        Assert.Equal(-3000, control.Value.TotalMilliseconds);
+        Assert.Equal("-00:00:03,000", textBox.Text);
+
+        vm.Selected = alsoBeforeZero;
+        vm.Selected = afterZero;
+        vm.Selected = beforeZero;
+
+        Assert.Equal(-3000, beforeZero.Start.TotalMilliseconds);
+        Assert.Equal(-1500, alsoBeforeZero.Start.TotalMilliseconds);
+        Assert.Equal(2000, afterZero.Start.TotalMilliseconds);
+    }
+
+    // Same write-back, but through the very first binding push when the control is attached.
+    [AvaloniaFact]
+    public void AttachingToANegativeValueDoesNotZeroTheSource()
+    {
+        using var _ = MillisecondMode();
+
+        var line = new Line { Start = TimeSpan.FromMilliseconds(-1500) };
+        var control = new TimeCodeUpDown { DataContext = line };
+        control[!TimeCodeUpDown.ValueProperty] = new Binding(nameof(Line.Start)) { Mode = BindingMode.TwoWay };
+        Show(control);
+
+        Assert.Equal(-1500, line.Start.TotalMilliseconds);
+    }
+
+    // Typing must not eat the sign, and must not flip the value positive ("-00" parses as 0).
+    [AvaloniaFact]
+    public void TypingKeepsTheValueNegative()
+    {
+        using var _ = MillisecondMode();
+
+        var control = new TimeCodeUpDown { Value = TimeSpan.FromMilliseconds(-1500) };
+        var (window, _, textBox) = Show(control);
+
+        textBox.Focus();
+        textBox.CaretIndex = 8; // the seconds part of "-00:00:01,500"
+        window.KeyTextInput("7");
+
+        Assert.Equal("-00:00:07,500", textBox.Text);
+        Assert.Equal(-7500, control.Value.TotalMilliseconds);
+    }
+
+    // The caret lands on the last part, and every part is measured from the first digit - not from
+    // the sign, which used to shift hours/minutes/seconds one place to the right.
+    [AvaloniaFact]
+    public void SteppingAppliesToThePartTheCaretIsOn()
+    {
+        using var _ = MillisecondMode(stepMs: 100);
+
+        var control = new TimeCodeUpDown { Value = TimeSpan.FromMilliseconds(-1500) };
+        var (window, _, textBox) = Show(control);
+
+        textBox.Focus();
+        window.KeyPress(Key.Down, RawInputModifiers.None, PhysicalKey.ArrowDown, null);
+        Assert.Equal(-1600, control.Value.TotalMilliseconds); // milliseconds, not hours
+
+        textBox.CaretIndex = 8; // seconds
+        window.KeyPress(Key.Up, RawInputModifiers.None, PhysicalKey.ArrowUp, null);
+        Assert.Equal(-600, control.Value.TotalMilliseconds);
+    }
+
+    // Stepping across zero adds/removes the sign; the caret must stay on the same part.
+    [AvaloniaFact]
+    public void SteppingAcrossZeroUpdatesSignAndCaret()
+    {
+        using var _ = MillisecondMode(stepMs: 100);
+
+        var control = new TimeCodeUpDown { Value = TimeSpan.FromMilliseconds(-100) };
+        var (window, _, textBox) = Show(control);
+
+        textBox.Focus();
+        var caretOnMilliseconds = textBox.CaretIndex;
+        Assert.Equal(10, caretOnMilliseconds); // "-00:00:00,100"
+
+        window.KeyPress(Key.Up, RawInputModifiers.None, PhysicalKey.ArrowUp, null);
+        Assert.Equal(TimeSpan.Zero, control.Value);
+        Assert.Equal("00:00:00,000", textBox.Text);
+        Assert.Equal(9, textBox.CaretIndex); // still the first millisecond digit
+
+        window.KeyPress(Key.Down, RawInputModifiers.None, PhysicalKey.ArrowDown, null);
+        Assert.Equal(-100, control.Value.TotalMilliseconds);
+        Assert.Equal("-00:00:00,100", textBox.Text);
+        Assert.Equal(10, textBox.CaretIndex);
+    }
+
+    // Left/Right skip the sign like they skip the separators.
+    [AvaloniaFact]
+    public void CaretDoesNotLandOnTheSign()
+    {
+        using var _ = MillisecondMode();
+
+        var control = new TimeCodeUpDown { Value = TimeSpan.FromMilliseconds(-1500) };
+        var (window, _, textBox) = Show(control);
+
+        textBox.Focus();
+        textBox.CaretIndex = 1; // first hour digit of "-00:00:01,500"
+        window.KeyPress(Key.Left, RawInputModifiers.None, PhysicalKey.ArrowLeft, null);
+
+        Assert.Equal(1, textBox.CaretIndex);
+    }
+
+    [AvaloniaFact]
+    public void ValueBelowTheMaskRangeIsClamped()
+    {
+        using var _ = MillisecondMode();
+
+        var control = new TimeCodeUpDown
+        {
+            Value = TimeSpan.FromMilliseconds(-TimeCode.MaxTimeTotalMilliseconds - 5000)
+        };
+        Show(control);
+
+        Assert.Equal(-TimeCode.MaxTimeTotalMilliseconds, control.Value.TotalMilliseconds);
+    }
+
+    [AvaloniaTheory]
+    [InlineData("-00:00:01,500", -1500)]
+    [InlineData("-01:02:03,004", -3723004)]
+    [InlineData("00:00:01,500", 1500)]
+    public void ParsesTheSignOfTheMaskedText(string text, int expectedMs)
+    {
+        using var _ = MillisecondMode();
+
+        var parse = typeof(TimeCodeUpDown).GetMethod("ParseTime", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var value = (TimeSpan)parse.Invoke(new TimeCodeUpDown(), new object?[] { text })!;
+
+        Assert.Equal(expectedMs, (int)value.TotalMilliseconds);
+    }
+
+    // Frame mode has a shorter last part ("-00:00:01:12"), so the sign handling must not assume the
+    // millisecond layout.
+    [AvaloniaFact]
+    public void FrameModeShowsAndParsesNegativeValues()
+    {
+        using var _ = FrameMode();
+
+        var control = new TimeCodeUpDown { Value = TimeSpan.FromMilliseconds(-1500) };
+        var (_, _, textBox) = Show(control);
+
+        Assert.StartsWith("-00:00:01", textBox.Text);
+
+        var parse = typeof(TimeCodeUpDown).GetMethod("ParseTime", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var value = (TimeSpan)parse.Invoke(control, new object?[] { textBox.Text })!;
+        Assert.True(value.TotalMilliseconds < 0, $"expected '{textBox.Text}' to parse as negative");
+    }
+
+    [AvaloniaTheory]
+    [InlineData("-1500", -1500)]
+    [InlineData("-00:00:01,500", -1500)]
+    [InlineData("1500", 1500)]
+    public void PasteAcceptsNegativeValues(string clipboardText, int expectedMs)
+    {
+        using var _ = MillisecondMode();
+
+        var tryParse = typeof(TimeCodeUpDown).GetMethod("TryParsePastedValue", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var args = new object?[] { clipboardText, null };
+        var ok = (bool)tryParse.Invoke(new TimeCodeUpDown(), args)!;
+
+        Assert.True(ok, $"expected '{clipboardText}' to parse");
+        Assert.Equal(expectedMs, (int)((TimeSpan)args[1]!).TotalMilliseconds);
+    }
+}

--- a/tests/UI/Controls/TimeCodeUpDownPasteTests.cs
+++ b/tests/UI/Controls/TimeCodeUpDownPasteTests.cs
@@ -31,6 +31,8 @@ public class TimeCodeUpDownPasteTests
     [InlineData("01:02,300", 62300)]      // mm:ss,fff
     [InlineData("01:00:00,000", 3600000)]
     [InlineData("359999999", 359999999)]  // max in-range milliseconds (99:59:59,999)
+    [InlineData("-5", -5)]                // negative time codes are legal - see #13695
+    [InlineData("-00:00:05,500", -5500)]
     public void ParsesAcceptedInput(string input, int expectedMs)
     {
         var (ok, value) = Parse(input);
@@ -42,7 +44,7 @@ public class TimeCodeUpDownPasteTests
     [InlineData("")]
     [InlineData("   ")]
     [InlineData("abc")]
-    [InlineData("-5")]           // negative not a valid time code
+    [InlineData("-")]            // a sign on its own is not a time code
     [InlineData("5:5")]          // too few parts to be a time code
     [InlineData("360000000")]    // one ms past the max range
     [InlineData("99999999999999999")] // huge bare number: would overflow TimeSpan.FromMilliseconds

--- a/tests/UI/Features/Main/NegativeTimeCodeSelectionTests.cs
+++ b/tests/UI/Features/Main/NegativeTimeCodeSelectionTests.cs
@@ -1,0 +1,120 @@
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Controls;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// Cutting a "previously on..." off the front of a video means adjusting all times by a negative
+/// offset, which legitimately moves the first lines before zero. Selecting such a line then wrote a
+/// zero straight back into it through the start/end editors' two-way binding, so walking the list
+/// zeroed one time code after another (#13695).
+/// </summary>
+public class NegativeTimeCodeSelectionTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private (Window Window, MainViewModel Vm) ShowMainWindowWithLines(int lineCount)
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1400, Height = 900 };
+        _windows.Add(window);
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var vm = (MainViewModel)view.DataContext!;
+        window.SuppressSaveChangesPromptOnClose(vm);
+
+        for (var i = 0; i < lineCount; i++)
+        {
+            vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph($"Line {i + 1}", i * 2000, i * 2000 + 1500), null!)
+            {
+                Number = i + 1,
+            });
+        }
+
+        Settle(window);
+        return (window, vm);
+    }
+
+    private static void Settle(Window window)
+    {
+        for (var pump = 0; pump < 8; pump++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+        }
+    }
+
+    [AvaloniaFact]
+    public void AdjustAllTimesBeforeZero_SurvivesSelectingEveryLine()
+    {
+        var (window, vm) = ShowMainWindowWithLines(4);
+
+        // "Show earlier" by 3 seconds - the first two lines end up before zero.
+        vm.Adjust(TimeSpan.FromSeconds(-3), adjustAll: true, adjustSelectedLines: false, adjustSelectedLinesAndForward: false);
+        Settle(window);
+
+        var expected = vm.Subtitles
+            .Select(p => (Start: p.StartTime, End: p.EndTime))
+            .ToList();
+        Assert.Equal(-3000, expected[0].Start.TotalMilliseconds);
+        Assert.Equal(-1000, expected[1].Start.TotalMilliseconds);
+
+        foreach (var line in vm.Subtitles.ToList())
+        {
+            vm.SelectAndScrollToSubtitle(line);
+            Settle(window);
+        }
+
+        for (var i = 0; i < vm.Subtitles.Count; i++)
+        {
+            Assert.Equal(expected[i].Start, vm.Subtitles[i].StartTime);
+            Assert.Equal(expected[i].End, vm.Subtitles[i].EndTime);
+        }
+    }
+
+    [AvaloniaFact]
+    public void SelectedNegativeLine_IsShownWithItsSignInTheStartTimeEditor()
+    {
+        var (window, vm) = ShowMainWindowWithLines(2);
+
+        vm.Adjust(TimeSpan.FromSeconds(-3), adjustAll: true, adjustSelectedLines: false, adjustSelectedLinesAndForward: false);
+        vm.SelectAndScrollToSubtitle(vm.Subtitles[0]);
+        Settle(window);
+
+        var startTimeEditor = window.GetVisualDescendants()
+            .OfType<TimeCodeUpDown>()
+            .First(c => (string?)AutomationProperties.GetName(c) == Se.Language.General.StartTime);
+        var textBox = startTimeEditor.GetVisualDescendants().OfType<TextBox>().Single();
+
+        Assert.Equal(TimeSpan.FromSeconds(-3), startTimeEditor.Value);
+        Assert.StartsWith("-00:00:03", textBox.Text);
+    }
+}


### PR DESCRIPTION
Fixes #13695

Adjusting all times by a negative offset (cutting a "previously on..." off the front of a video) legitimately moves the first lines before zero. Selecting such a line then destroyed its time code: `TimeCodeUpDown` clamped any negative value to zero and wrote that back through its two-way binding to `SelectedSubtitle.StartTimeOnly` / `.EndTime` — so walking the list zeroed one line after another, exactly as reported.

Negative time codes are now shown, edited and stepped the way SE 4.x's `NikseTimeUpDown` did, with the sign as a leading mask literal (`-00:00:01,500`):

- only out-of-range values are rewritten, not negative ones
- the sign is never typed over, and Left/Right skip it
- parts are measured from the first digit, so Up/Down still applies to the part the caret is on, and the caret follows the sign when a step crosses zero
- parsing takes the sign off and re-applies it to the magnitude — `"-00"` parses as `0`, which silently flipped an edited negative time code positive
- paste accepts a leading minus (`-1500`, `-00:00:01,500`)
- the min width makes room for the sign only while the value is negative, so no other time box changes width

`SecondsUpDown` keeps its clamp: that one is the duration field, where negative is genuinely invalid.

### Behaviour change worth a look

Stepping down from `00:00:00,000` now goes negative instead of sticking at zero in every dialog using this control (adjust-all-times amount, set video offset, EBU STL start time, ...). That matches SE 4.x and makes negative video offsets enterable, but it is not limited to the main window — happy to restrict it to subtitle time codes if you'd rather.

### Tests

- `tests/UI/Features/Main/NegativeTimeCodeSelectionTests.cs` — the reported path end-to-end through a hosted main window: adjust all times by -3s, select every line, assert no time code was rewritten and that the start-time editor shows `-00:00:03,000`.
- `tests/UI/Controls/TimeCodeUpDownNegativeTests.cs` — selection round-trip, first binding attach, typing, per-part stepping, stepping across zero (value, text and caret), caret vs. the sign, range clamp, sign parsing, frame mode, negative paste.
- `tests/UI/Controls/TimeCodeUpDownPasteTests.cs` — `-5` moves from rejected to accepted (-5 ms); a bare `-` is still rejected.

Both new test files were checked against the pre-fix code: 11 of the 14 unit cases and both end-to-end cases fail there and pass after. Full UI suite green (2901 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)