### PR TITLE
Honour MP4 subtitle edit lists, bibliographic language codes and per-track languages

### DIFF
--- a/src/libse/ContainerFormats/Mp4/Boxes/Edts.cs
+++ b/src/libse/ContainerFormats/Mp4/Boxes/Edts.cs
@@ -1,0 +1,31 @@
+using System.IO;
+
+namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
+{
+    /// <summary>
+    /// Edit Box - container for the track's edit list.
+    /// </summary>
+    public class Edts : Box
+    {
+        public Elst Elst { get; private set; }
+
+        public Edts(Stream fs, ulong maximumLength)
+        {
+            Position = (ulong)fs.Position;
+            while (fs.Position < (long)maximumLength)
+            {
+                if (!InitializeSizeAndName(fs))
+                {
+                    return;
+                }
+
+                if (Name == "elst")
+                {
+                    Elst = new Elst(fs, Size);
+                }
+
+                fs.Seek((long)Position, SeekOrigin.Begin);
+            }
+        }
+    }
+}

--- a/src/libse/ContainerFormats/Mp4/Boxes/Elst.cs
+++ b/src/libse/ContainerFormats/Mp4/Boxes/Elst.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using System.IO;
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
+{
+    /// <summary>
+    /// Edit List Box - maps the track's media timeline onto the presentation timeline.
+    /// A leading "empty" entry (media time -1) delays the track, and a non-zero media
+    /// time on the first real entry skips into the media, i.e. moves it earlier.
+    /// </summary>
+    public class Elst : Box
+    {
+        public class Entry
+        {
+            /// <summary>Duration of the edit, in movie (mvhd) timescale units.</summary>
+            public ulong SegmentDuration { get; set; }
+
+            /// <summary>Start time in the media (mdhd) timescale, or -1 for an empty edit.</summary>
+            public long MediaTime { get; set; }
+        }
+
+        // An edit list this long is either malformed or a frame-accurate splice list no
+        // subtitle track would carry - a plain offset cannot describe it anyway.
+        private const uint MaxEntries = 1000;
+
+        public List<Entry> Entries { get; } = new List<Entry>();
+
+        public Elst(Stream fs, ulong size)
+        {
+            if (size < 16)
+            {
+                return;
+            }
+
+            Buffer = new byte[size - 8];
+            fs.ReadFully(Buffer, 0, Buffer.Length);
+
+            var version = Buffer[0];
+            var entryCount = GetUInt(4);
+            if (entryCount > MaxEntries)
+            {
+                return;
+            }
+
+            var entrySize = version == 1 ? 20 : 12;
+            var index = 8;
+            for (var i = 0; i < entryCount; i++)
+            {
+                if (index + entrySize > Buffer.Length)
+                {
+                    return;
+                }
+
+                if (version == 1)
+                {
+                    Entries.Add(new Entry
+                    {
+                        SegmentDuration = GetUInt64(index),
+                        MediaTime = (long)GetUInt64(index + 8),
+                    });
+                }
+                else
+                {
+                    Entries.Add(new Entry
+                    {
+                        SegmentDuration = GetUInt(index),
+                        MediaTime = GetInt(index + 4),
+                    });
+                }
+
+                index += entrySize;
+            }
+        }
+    }
+}

--- a/src/libse/ContainerFormats/Mp4/Boxes/Mdhd.cs
+++ b/src/libse/ContainerFormats/Mp4/Boxes/Mdhd.cs
@@ -57,7 +57,11 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
         {
             get
             {
-                var language = Iso639Dash2LanguageCode.List.FirstOrDefault(p => p.ThreeLetterCode == Iso639ThreeLetterCode);
+                // mdhd carries either the ISO 639-2/T (terminology) or the 639-2/B
+                // (bibliographic) code - MP4Box writes whatever "lang=" was given, and
+                // "fre"/"ger"/"dut" are as common in the wild as "fra"/"deu"/"nld".
+                var language = Iso639Dash2LanguageCode.List.FirstOrDefault(p =>
+                    p.ThreeLetterCode == Iso639ThreeLetterCode || p.BibliographicCode == Iso639ThreeLetterCode);
                 return language == null ? "Any" : language.EnglishName;
             }
         }

--- a/src/libse/ContainerFormats/Mp4/Boxes/Trak.cs
+++ b/src/libse/ContainerFormats/Mp4/Boxes/Trak.cs
@@ -9,6 +9,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
     {
         public Mdia Mdia { get; set; }
         public Tkhd Tkhd { get; set; }
+        public Edts Edts { get; set; }
 
         public Trak(Stream fs, ulong maximumLength)
         {
@@ -27,6 +28,10 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
                 else if (Name == "tkhd")
                 {
                     Tkhd = new Tkhd(fs);
+                }
+                else if (Name == "edts")
+                {
+                    Edts = new Edts(fs, Position);
                 }
 
                 fs.Seek((long)Position, SeekOrigin.Begin);

--- a/src/libse/ContainerFormats/Mp4/Mp4Parser.cs
+++ b/src/libse/ContainerFormats/Mp4/Mp4Parser.cs
@@ -218,6 +218,8 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
 
             fs.Close();
 
+            ApplyEditListsToMoovSubtitleTracks();
+
             // Surface the fragmented text tracks (DASH/CMAF subtitle representations, or
             // the subtitle tracks of a muxed fMP4); VttcSubtitle is the first of them.
             foreach (var fragmentedTrack in _fragmentedTextTracks)
@@ -233,6 +235,10 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
 
                 var merged = MergeLinesSameTextUtils.MergeLinesWithSameTextInSubtitle(fragmentedTrack.Subtitle, false, 250);
                 merged.Header = fragmentedTrack.Subtitle.Header;
+                merged.Renumber();
+
+                // The moov track header still carries the edit list for a fragmented track
+                ShiftParagraphs(merged.Paragraphs, GetEditListOffsetMs(FindTrack(fragmentedTrack.TrackId)));
                 merged.Renumber();
 
                 FragmentedSubtitleTracks.Add(new Mp4FragmentedSubtitleTrack
@@ -254,6 +260,95 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4
 
             CheckForTrunCea608();
             CheckForMoovVideoCea608();
+        }
+
+        private void ApplyEditListsToMoovSubtitleTracks()
+        {
+            if (Moov?.Tracks == null)
+            {
+                return;
+            }
+
+            foreach (var trak in Moov.Tracks)
+            {
+                var mdia = trak?.Mdia;
+                if (mdia == null || !(mdia.IsTextSubtitle || mdia.IsVobSubSubtitle))
+                {
+                    continue;
+                }
+
+                var paragraphs = mdia.Minf?.Stbl?.Paragraphs;
+                if (paragraphs == null || paragraphs.Count == 0)
+                {
+                    continue;
+                }
+
+                // A VobSub track's paragraphs are index-paired with its sub pictures, so
+                // dropping one there would misalign every bitmap after it.
+                ShiftParagraphs(paragraphs, GetEditListOffsetMs(trak), dropBeforeZero: mdia.IsTextSubtitle);
+            }
+        }
+
+        /// <summary>
+        /// Offset in milliseconds that the track's edit list (elst) puts between the media
+        /// timeline the samples are timed on and the presentation timeline the player shows.
+        /// Leading empty edits (media time -1) delay the track; a media start time on the
+        /// first real edit moves it earlier. Anything more elaborate than that cannot be
+        /// expressed as a single offset, so only the leading edits are honoured.
+        /// </summary>
+        private double GetEditListOffsetMs(Trak trak)
+        {
+            var entries = trak?.Edts?.Elst?.Entries;
+            if (entries == null || entries.Count == 0)
+            {
+                return 0;
+            }
+
+            var movieTimeScale = Moov?.Mvhd?.TimeScale > 0 ? Moov.Mvhd.TimeScale : 1000UL;
+            var mediaTimeScale = trak.Mdia?.Mdhd?.TimeScale > 0 ? trak.Mdia.Mdhd.TimeScale : movieTimeScale;
+
+            var offsetMs = 0.0;
+            var index = 0;
+            while (index < entries.Count && entries[index].MediaTime < 0)
+            {
+                offsetMs += entries[index].SegmentDuration / (double)movieTimeScale * 1000.0;
+                index++;
+            }
+
+            if (index < entries.Count)
+            {
+                offsetMs -= entries[index].MediaTime / (double)mediaTimeScale * 1000.0;
+            }
+
+            return offsetMs;
+        }
+
+        /// <summary>
+        /// Moves paragraphs onto the presentation timeline. Anything the edit list pushes
+        /// before zero is not presented, so such cues are dropped (or clipped when they
+        /// straddle zero).
+        /// </summary>
+        private static void ShiftParagraphs(List<Paragraph> paragraphs, double offsetMs, bool dropBeforeZero = true)
+        {
+            if (paragraphs == null || Math.Abs(offsetMs) < 0.001)
+            {
+                return;
+            }
+
+            for (var i = paragraphs.Count - 1; i >= 0; i--)
+            {
+                var p = paragraphs[i];
+                var start = p.StartTime.TotalMilliseconds + offsetMs;
+                var end = p.EndTime.TotalMilliseconds + offsetMs;
+                if (end <= 0 && dropBeforeZero)
+                {
+                    paragraphs.RemoveAt(i);
+                    continue;
+                }
+
+                p.StartTime.TotalMilliseconds = start < 0 ? 0 : start;
+                p.EndTime.TotalMilliseconds = end < 0 ? 0 : end;
+            }
         }
 
         private void CheckForMoovVideoCea608()

--- a/src/seconv/Core/ContainerSubtitleLoader.cs
+++ b/src/seconv/Core/ContainerSubtitleLoader.cs
@@ -2,6 +2,7 @@ using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.ContainerFormats.Matroska;
 using Nikse.SubtitleEdit.Core.ContainerFormats.MaterialExchangeFormat;
 using Nikse.SubtitleEdit.Core.ContainerFormats.Mp4;
+using Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes;
 using Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Spectre.Console;
@@ -350,8 +351,7 @@ internal static class ContainerSubtitleLoader
                     var vobSub = ImageOcrLoader.LoadMp4VobSub(track, options);
                     if (vobSub.Paragraphs.Count > 0)
                     {
-                        var vobLang = LanguageAutoDetect.AutoDetectGoogleLanguageOrNull(vobSub) ?? string.Empty;
-                        tracks.Add(new LoadedTrack(vobSub, new SubRip(), vobLang, trackId));
+                        tracks.Add(new LoadedTrack(vobSub, new SubRip(), GetMp4TrackLanguage(track, vobSub), trackId));
                     }
                 }
                 catch (Exception ex)
@@ -369,8 +369,7 @@ internal static class ContainerSubtitleLoader
             var subtitle = new Subtitle();
             subtitle.Paragraphs.AddRange(paragraphs);
             subtitle.Renumber();
-            var lang = LanguageAutoDetect.AutoDetectGoogleLanguageOrNull(subtitle) ?? string.Empty;
-            tracks.Add(new LoadedTrack(subtitle, new SubRip(), lang, trackId));
+            tracks.Add(new LoadedTrack(subtitle, new SubRip(), GetMp4TrackLanguage(track, subtitle), trackId));
         }
 
         if (tracks.Count == 0)
@@ -378,6 +377,20 @@ internal static class ContainerSubtitleLoader
             throw new InvalidOperationException($"No subtitle tracks in MP4 file: {filePath}");
         }
         return tracks;
+    }
+
+    /// <summary>
+    /// The language the track declares in its media header, auto-detected from the text only
+    /// when there is none. Auto-detecting regardless labelled every track of a multi-language
+    /// file the same, and the per-track output names then collided - a three track eng/fre/deu
+    /// file wrote one "*.en.srt" that the last track won.
+    /// </summary>
+    private static string GetMp4TrackLanguage(Trak track, Subtitle subtitle)
+    {
+        var lang = SanitizeLang(track.Mdia?.Mdhd?.Iso639ThreeLetterCode);
+        return IsUndeclaredLanguage(lang)
+            ? LanguageAutoDetect.AutoDetectGoogleLanguageOrNull(subtitle) ?? string.Empty
+            : lang;
     }
 
     private static List<LoadedTrack> LoadMcc(string filePath)

--- a/tests/libse/Core/ContainerFormats/Mp4/Mp4EditListTest.cs
+++ b/tests/libse/Core/ContainerFormats/Mp4/Mp4EditListTest.cs
@@ -1,0 +1,237 @@
+using System.Linq;
+using System.Text;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.ContainerFormats.Mp4;
+
+namespace LibSETests.Core.ContainerFormats.Mp4;
+
+/// <summary>
+/// A text track's edit list (edts/elst) maps its media timeline onto the presentation
+/// timeline, so a track written with e.g. "MP4Box -add subs.srt:delay=5000" carries an
+/// empty edit that every player honours. Cue times have to move with it.
+/// </summary>
+public class Mp4EditListTest
+{
+    private const uint MovieTimeScale = 600;
+    private const uint MediaTimeScale = 1000;
+
+    [Fact]
+    public void GetParagraphs_EmptyEditEntry_DelaysCues()
+    {
+        // 3000 movie ticks at 600/s = 5 seconds of empty edit
+        var paragraphs = ParseWithEditList(EmptyEdit(3000), NormalEdit(9000, 0));
+
+        Assert.Equal(3, paragraphs.Count);
+        Assert.Equal(5000, paragraphs[0].StartTime.TotalMilliseconds, 1);
+        Assert.Equal(6000, paragraphs[0].EndTime.TotalMilliseconds, 1);
+        Assert.Equal(7000, paragraphs[1].StartTime.TotalMilliseconds, 1);
+        Assert.Equal(9000, paragraphs[2].StartTime.TotalMilliseconds, 1);
+    }
+
+    [Fact]
+    public void GetParagraphs_MediaStartTime_MovesCuesEarlier()
+    {
+        // media_time 2000 at 1000/s = skip the first 2 seconds of media, which is
+        // exactly the first cue - it is never presented, so it is dropped
+        var paragraphs = ParseWithEditList(NormalEdit(4800, 2000));
+
+        Assert.Equal(2, paragraphs.Count);
+        Assert.Equal("Second", paragraphs[0].Text);
+        Assert.Equal(0, paragraphs[0].StartTime.TotalMilliseconds, 1);
+        Assert.Equal(1000, paragraphs[0].EndTime.TotalMilliseconds, 1);
+        Assert.Equal("Third", paragraphs[1].Text);
+        Assert.Equal(2000, paragraphs[1].StartTime.TotalMilliseconds, 1);
+        Assert.Equal(3000, paragraphs[1].EndTime.TotalMilliseconds, 1);
+    }
+
+    [Fact]
+    public void GetParagraphs_MediaStartTimePastACue_DropsThatCue()
+    {
+        // Skipping 3 seconds of media leaves only the last of the three cues - the
+        // second one ends exactly at the edit start, so it never shows either
+        var paragraphs = ParseWithEditList(NormalEdit(1800, 3000));
+
+        Assert.Single(paragraphs);
+        Assert.Equal("Third", paragraphs[0].Text);
+        Assert.Equal(1000, paragraphs[0].StartTime.TotalMilliseconds, 1);
+        Assert.Equal(2000, paragraphs[0].EndTime.TotalMilliseconds, 1);
+    }
+
+    [Fact]
+    public void GetParagraphs_IdentityEditList_LeavesCuesAlone()
+    {
+        var paragraphs = ParseWithEditList(NormalEdit(3600, 0));
+
+        Assert.Equal(3, paragraphs.Count);
+        Assert.Equal(0, paragraphs[0].StartTime.TotalMilliseconds, 1);
+        Assert.Equal(2000, paragraphs[1].StartTime.TotalMilliseconds, 1);
+        Assert.Equal(4000, paragraphs[2].StartTime.TotalMilliseconds, 1);
+    }
+
+    [Fact]
+    public void GetParagraphs_NoEditList_LeavesCuesAlone()
+    {
+        var paragraphs = ParseWithEditList();
+
+        Assert.Equal(3, paragraphs.Count);
+        Assert.Equal(0, paragraphs[0].StartTime.TotalMilliseconds, 1);
+        Assert.Equal(2000, paragraphs[1].StartTime.TotalMilliseconds, 1);
+        Assert.Equal(4000, paragraphs[2].StartTime.TotalMilliseconds, 1);
+    }
+
+    /// <summary>
+    /// MP4Box writes whatever "lang=" it was given, so a French track is as likely to be
+    /// tagged with the ISO 639-2/B code "fre" as with the 639-2/T code "fra".
+    /// </summary>
+    [Theory]
+    [InlineData("fra", "French")]
+    [InlineData("fre", "French")]
+    [InlineData("deu", "German")]
+    [InlineData("ger", "German")]
+    [InlineData("nld", "Dutch")]
+    [InlineData("dut", "Dutch")]
+    [InlineData("eng", "English")]
+    [InlineData("zzz", "Any")]
+    public void LanguageString_BibliographicOrTerminologyCode_ResolvesToEnglishName(string code, string expected)
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllBytes(tempFile, BuildTx3gMp4(PackLanguage(code)));
+            var parser = new MP4Parser(tempFile);
+            Assert.Equal(expected, parser.GetSubtitleTracks()[0].Mdia.Mdhd.LanguageString);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    private static List<Paragraph> ParseWithEditList(params byte[][] editEntries)
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllBytes(tempFile, BuildTx3gMp4(0x55C4, editEntries));
+            var parser = new MP4Parser(tempFile);
+            return parser.GetSubtitleTracks()[0].Mdia.Minf.Stbl.GetParagraphs();
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    private static byte[] EmptyEdit(uint segmentDurationMovieTicks)
+        => Concat(UInt32Be(segmentDurationMovieTicks), UInt32Be(0xFFFFFFFF), UInt32Be(0x00010000));
+
+    private static byte[] NormalEdit(uint segmentDurationMovieTicks, uint mediaTimeMediaTicks)
+        => Concat(UInt32Be(segmentDurationMovieTicks), UInt32Be(mediaTimeMediaTicks), UInt32Be(0x00010000));
+
+    /// <summary>Three 1-second cues at 0, 2 and 4 seconds, optionally behind an edit list.</summary>
+    private static byte[] BuildTx3gMp4(ushort packedLanguage, params byte[][] editEntries)
+    {
+        var samples = new[] { "First", "", "Second", "", "Third", "" };
+        var sampleBytes = samples.Select(s =>
+        {
+            var text = Encoding.UTF8.GetBytes(s);
+            var buf = new byte[2 + text.Length];
+            buf[0] = (byte)(text.Length >> 8);
+            buf[1] = (byte)text.Length;
+            System.Buffer.BlockCopy(text, 0, buf, 2, text.Length);
+            return buf;
+        }).ToArray();
+
+        var ftyp = Box("ftyp", Ascii("isom"), UInt32Be(512), Ascii("isom"), Ascii("iso2"), Ascii("mp41"));
+        var mdat = Box("mdat", Concat(sampleBytes));
+        var sampleDataOffset = (uint)(ftyp.Length + 8);
+
+        var stsd = Box("stsd", new byte[4], UInt32Be(1), Box("tx3g"));
+
+        // 1 s on, 1 s off, repeated - the "off" samples are empty and get dropped
+        var stts = Box("stts",
+            new byte[4],
+            UInt32Be(1),
+            UInt32Be((uint)samples.Length),
+            UInt32Be(1000));
+
+        var stsc = Box("stsc", new byte[4], UInt32Be(1), UInt32Be(1), UInt32Be((uint)samples.Length), UInt32Be(1));
+        var stsz = Box("stsz", new byte[4], UInt32Be(0), UInt32Be((uint)samples.Length),
+            Concat(sampleBytes.Select(b => UInt32Be((uint)b.Length)).ToArray()));
+        var stco = Box("stco", new byte[4], UInt32Be(1), UInt32Be(sampleDataOffset));
+
+        var minf = Box("minf", Box("stbl", stsd, stts, stsc, stsz, stco));
+        var hdlr = Box("hdlr", new byte[4], new byte[4], Ascii("sbtl"), new byte[12], new byte[] { 0 });
+        var mdhd = Box("mdhd",
+            new byte[4],
+            new byte[4],
+            new byte[4],
+            UInt32Be(MediaTimeScale),
+            UInt32Be(1000 * (uint)samples.Length),
+            UInt16Be(packedLanguage),
+            UInt16Be(0));
+
+        var mdia = Box("mdia", hdlr, mdhd, minf);
+        var trak = editEntries.Length == 0
+            ? Box("trak", mdia)
+            : Box("trak", Box("edts", Box("elst", new byte[4], UInt32Be((uint)editEntries.Length), Concat(editEntries))), mdia);
+
+        var mvhd = Box("mvhd",
+            new byte[4],
+            new byte[4],
+            new byte[4],
+            UInt32Be(MovieTimeScale),
+            UInt32Be(MovieTimeScale * 6),
+            new byte[80]);
+
+        return Concat(ftyp, mdat, Box("moov", mvhd, trak));
+    }
+
+    /// <summary>Packs a three letter code the way mdhd does - 5 bits per letter, offset from 0x60.</summary>
+    private static ushort PackLanguage(string code)
+        => (ushort)(((code[0] - 0x60) << 10) | ((code[1] - 0x60) << 5) | (code[2] - 0x60));
+
+    private static byte[] Box(string name, params byte[][] parts)
+    {
+        var total = 8;
+        foreach (var p in parts) total += p.Length;
+        var box = new byte[total];
+        WriteUInt32Be(box, 0, (uint)total);
+        Encoding.ASCII.GetBytes(name, 0, 4, box, 4);
+        var off = 8;
+        foreach (var p in parts)
+        {
+            System.Buffer.BlockCopy(p, 0, box, off, p.Length);
+            off += p.Length;
+        }
+        return box;
+    }
+
+    private static byte[] Concat(params byte[][] parts)
+    {
+        var total = 0;
+        foreach (var p in parts) total += p.Length;
+        var result = new byte[total];
+        var off = 0;
+        foreach (var p in parts)
+        {
+            System.Buffer.BlockCopy(p, 0, result, off, p.Length);
+            off += p.Length;
+        }
+        return result;
+    }
+
+    private static byte[] Ascii(string s) => Encoding.ASCII.GetBytes(s);
+
+    private static byte[] UInt32Be(uint v) => new[] { (byte)(v >> 24), (byte)(v >> 16), (byte)(v >> 8), (byte)v };
+
+    private static byte[] UInt16Be(ushort v) => new[] { (byte)(v >> 8), (byte)v };
+
+    private static void WriteUInt32Be(byte[] dst, int off, uint v)
+    {
+        dst[off] = (byte)(v >> 24);
+        dst[off + 1] = (byte)(v >> 16);
+        dst[off + 2] = (byte)(v >> 8);
+        dst[off + 3] = (byte)v;
+    }
+}


### PR DESCRIPTION
Sweep of Subtitle Edit's MP4 support against every subtitle shape MP4Box/GPAC can generate, and fixes for what it turned up.

## Method

A headless probe referencing `LibSE.csproj` mirrors `MainViewModel.ImportSubtitleFromMp4` (`MP4Parser.GetSubtitleTracks()`, `FragmentedSubtitleTracks`, `TrunCea608/708Subtitle`) and was run over an 83-file corpus built with MP4Box/GPAC 26.02. Every suspicious result was cross-checked against `MP4Box -srt`, `MP4Box -diso` and `ffprobe -show_entries packet=pts_time` before treating it as an SE bug.

Corpus coverage: tx3g / wvtt / stpp / stxt / sbtt from srt, vtt, ttml, ttxt, texml, MicroDVD and SSA sources; subp VobSub; .mp4 / .mov / .3gp / `-ipod` .m4v; `-flat`, `-newfs`, `-inter 0`, `store=tight`; brand, `hdlr` and `stype` overrides; `-frag`; DASH live / onDemand / main / CMAF, concatenated init+segments, onDemand single-file, lone segments; `store=frag|sfrag`, `tfdt_traf`, `nofragdef`, `msn`; 90 kHz media timescales; `ttml_split` / `_zero` / `_dur` / `_cts` / `_embed`; chapters, disabled and alternate-group tracks, `txtflags`, UTF-16 sources, and multi-track files.

All of the above already parsed correctly. Three defects showed up.

## Fixes

**Edit lists (`edts`/`elst`) were not parsed at all.** A track written with `MP4Box -add subs.srt:delay=5000` carries an empty edit that every player honours; SE loaded its cues 5 seconds early, where MP4Box, ffprobe and mpv all report 6.000. New `Edts`/`Elst` boxes and `Trak.Edts`, with the resulting offset applied in both the progressive path and the fragmented one (the moov track header keeps its edit list after `-frag`). Leading empty edits (media time -1, duration in mvhd ticks) delay the track; the first real entry's media time (in mdhd ticks) pulls it earlier. Cues the edit pushes before zero are not presented and so are dropped — except on VobSub tracks, whose `Stbl.Paragraphs` are index-paired with `Stbl.SubPictures`, where they are clamped instead.

**`Mdhd.LanguageString` matched only the ISO 639-2/T code.** The equally common bibliographic codes (`fre`, `ger`, `dut`, ...) resolved to "Any" in the track picker. It now matches either form.

**seconv ignored the language a progressive MP4 text track declares** and auto-detected it from the text instead. A three-track eng/fre/deu file labelled all three `en` and wrote them to a single `*.en.srt` that the last track won — the English and French output was silently lost. It now prefers the declared mdhd code and falls back to auto-detection only when the track is undeclared, matching what the fragmented and Matroska paths already did.

## Not fixed here

- A lone `.m4s` without its init segment still assumes timescale 1000, so a 90 kHz segment reads 90x slow. Not knowable from the segment alone; a heuristic would be a separate change.
- seconv still writes two tracks of the *same* language to one file (pre-existing, and true of the Matroska path too).
- VobSub-in-MP4 end times come from sample durations rather than the SPU stop-display command, so they run long.
- Edit lists are applied to subtitle tracks only. CEA-608/708 read off a video track carrying an `elst` is untouched — that path deserves a real capture rather than a synthetic file.

## Not SE bugs (verified against the files)

`gpac -o x.mp4:mediats=90000:store=frag:tfdt_traf` writes `tfdt` in the pre-rescale timescale while `trun` durations are 90 kHz — genuinely malformed, and MP4Box's own reader only survives it by ignoring `tfdt`. GPAC's SSA importer gives every cue a ~1.05 s duration; its `stxt` output drops italics by design; `-add x.scc` produces a proprietary `GMCW` track SE deliberately rejects; and `-crypt` on a text track fails inside GPAC itself.

## Tests

13 new tests in `tests/libse/Core/ContainerFormats/Mp4/Mp4EditListTest.cs` covering empty edits, media start times, cues edited out entirely, identity and absent edit lists, and bibliographic/terminology language codes.

Full solution builds. All suites pass: libse 1186, UI 2883, seconv 364, libuilogic 229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
