### PR TITLE
Fix #13609: keep the 64 KB MKV network read buffer

### DIFF
--- a/src/libse/ContainerFormats/Matroska/MatroskaFile.cs
+++ b/src/libse/ContainerFormats/Matroska/MatroskaFile.cs
@@ -75,10 +75,15 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Matroska
         /// opened instantly (#13609). Reading big and sequentially instead lets read-ahead
         /// pipeline the transfer - measured on the reporter's share, ~900 MB streams in about 4 s
         /// while the sparse walk over the same file took over two minutes.
-        /// 64 KB (#13610) already pulls ~80% of the file over the wire, so a larger buffer costs
-        /// almost no extra bytes while cutting the round-trip count proportionally.
+        /// 64 KB (#13610) is the measured optimum: it already pulls ~80% of the file over the wire,
+        /// so the round-trips are amortized, and the reporter's 901 MB file opened in ~5 s - about
+        /// 180 MB/s against a share that streams at ~225 MB/s, i.e. nearly no headroom left. Going
+        /// to 1 MB was tried and was ~2 s *slower* on that same share: at that size practically
+        /// every forward skip falls inside the buffer, so the whole file is transferred, and each
+        /// seek past the buffer end throws away up to 1 MB of already-fetched data. Bigger only
+        /// buys bytes here, not speed.
         /// </summary>
-        private const int NetworkReadBufferSize = 1024 * 1024;
+        private const int NetworkReadBufferSize = 65536;
 
         private static int GetReadBufferSize(string path)
         {


### PR DESCRIPTION
Beta 15 raised `NetworkReadBufferSize` from 64 KB to 1 MB on the premise that 64 KB already pulls ~80% of the file over the wire, so a bigger buffer would cost almost no extra bytes while cutting the round-trip count 16x. The reporter in #13609 measured beta 15 as **~2 s slower than beta 13** on the same 901 MB file over their DS1621xs+ ([comment](https://github.com/SubtitleEdit/subtitleedit/issues/13609#issuecomment-5306626497)).

**Why 1 MB loses.** At that size practically every forward skip in the cluster walk falls inside the buffer, so the whole file is transferred instead of ~80% of it, and each seek past the buffer end discards up to 1 MB of already-fetched data and refetches it. On a 901 MB file that is 180 MB+ of extra transfer at ~225 MB/s, which is the 2 s.

**And there was no headroom to win.** At 64 KB that file opens in ~5 s, i.e. ~180 MB/s effective against a share that streams at ~225 MB/s. The round-trips are already amortized at 64 KB; a larger buffer could only add bytes, and it did.

Diffing `v5.2.0-beta13..v5.2.0-beta15` confirms the buffer is the only I/O-affecting change between the two - the `ClusterReader` extraction is pure restructuring and the `FindTrackStartInCluster` side-effect fix does not touch reads - so the regression is attributable to the constant alone.

This reverts it to 64 KB and records the measurement in the doc comment, so the buffer is not raised again without a real Windows client and NAS to measure on.

Tested: libse builds clean, the 4 `MatroskaFileTest` extraction tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)