### PR TITLE
Select and scroll to the pasted lines after a subtitle grid paste

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -16679,8 +16679,20 @@ public partial class MainViewModel :
             idx = Subtitles.Count;
         }
 
-        await SubtitleGridCopyPasteHelper.Paste(Window, Subtitles, idx, SelectedSubtitleFormat);
+        var pastedLines = await SubtitleGridCopyPasteHelper.Paste(Window, Subtitles, idx, SelectedSubtitleFormat);
         Renumber();
+
+        // Select the pasted lines and scroll them into view, like SE4 - otherwise the selection
+        // (and with it the edit box) stayed on the line selected before the paste (#13705).
+        if (pastedLines.Count > 0)
+        {
+            var firstIndex = Subtitles.IndexOf(pastedLines[0]);
+            if (firstIndex >= 0)
+            {
+                SelectAndScrollToRange(firstIndex, firstIndex + pastedLines.Count - 1);
+            }
+        }
+
         _updateAudioVisualizer = true;
         _shortcutManager.ClearKeys();
     }
@@ -17458,6 +17470,59 @@ public partial class MainViewModel :
                 {
                     Dispatcher.UIThread.Post(() => TableViewExtras.FocusRow(SubtitleGrid));
                 }
+            }
+        });
+    }
+
+    /// <summary>
+    /// Selects a contiguous block of rows - e.g. everything a paste just inserted - and scrolls
+    /// the first of them into view, leaving that row as the current one so the edit box shows it.
+    /// </summary>
+    private void SelectAndScrollToRange(int startIndex, int endIndex)
+    {
+        if (startIndex < 0 || startIndex >= Subtitles.Count)
+        {
+            return;
+        }
+
+        endIndex = Math.Clamp(endIndex, startIndex, Subtitles.Count - 1);
+        if (endIndex == startIndex)
+        {
+            SelectAndScrollToRow(startIndex);
+            return;
+        }
+
+        _shiftSelectAnchorIndex = -1;
+        _shiftSelectCurrentIndex = -1;
+
+        // The first pasted row goes in first so it becomes the SelectedItem (the row the edit
+        // box shows), then the rest of the block is added to the selection.
+        SelectGridRange(startIndex, endIndex, startIndex);
+        SubtitleGridSelectionChanged();
+
+        // Avalonia keeps the caret index when the bound text changes - same reset as
+        // SelectAndScrollToRow (#12707), as the edit box now shows another line.
+        EditTextBox.CaretIndex = 0;
+        EditTextBoxOriginal.CaretIndex = 0;
+
+        var itemToScroll = Subtitles[startIndex];
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (!Subtitles.Contains(itemToScroll))
+            {
+                return;
+            }
+
+            TableViewExtras.PrePositionScroll(SubtitleGrid, Subtitles.IndexOf(itemToScroll));
+            SubtitleGrid.ScrollIntoView(itemToScroll);
+
+            if (Se.Settings.General.SubtitleGridCenterSelectedRow)
+            {
+                CenterSelectedRowInSubtitleGrid(itemToScroll);
+            }
+            else
+            {
+                EnsureRowFullyVisibleInSubtitleGrid(itemToScroll);
             }
         });
     }

--- a/src/ui/Logic/SubtitleGridCopyPasteHelper.cs
+++ b/src/ui/Logic/SubtitleGridCopyPasteHelper.cs
@@ -98,12 +98,22 @@ internal static class SubtitleGridCopyPasteHelper
         return text;
     }
 
-    internal static async Task Paste(Window window, ObservableCollection<SubtitleLineViewModel> subtitles, int index, SubtitleFormat subtitleFormat)
+    /// <summary>
+    /// Pastes the clipboard content into <paramref name="subtitles"/> at <paramref name="index"/>
+    /// and returns the inserted lines in grid order (empty when nothing was pasted), so the caller
+    /// can select and scroll to them like SE4 did (#13705).
+    /// </summary>
+    internal static async Task<List<SubtitleLineViewModel>> Paste(Window window, ObservableCollection<SubtitleLineViewModel> subtitles, int index, SubtitleFormat subtitleFormat)
     {
         var text = await ClipboardHelper.GetTextAsync(window);
+        return PasteText(subtitles, index, subtitleFormat, text);
+    }
+
+    internal static List<SubtitleLineViewModel> PasteText(ObservableCollection<SubtitleLineViewModel> subtitles, int index, SubtitleFormat subtitleFormat, string? text)
+    {
         if (string.IsNullOrEmpty(text))
         {
-            return;
+            return new List<SubtitleLineViewModel>();
         }
 
         var addTimeMilliseconds = (double)0;
@@ -124,8 +134,7 @@ internal static class SubtitleGridCopyPasteHelper
         var subtitle = Subtitle.Parse(lines, subtitleFormat.Extension);
         if (subtitle?.Paragraphs.Count > 0)
         {
-            LoadParagraphs(subtitles, index, subtitleFormat, subtitle);
-            return;
+            return LoadParagraphs(subtitles, index, subtitleFormat, subtitle);
         }
 
         foreach (SubtitleFormat item in SubtitleFormat.AllSubtitleFormats)
@@ -133,12 +142,12 @@ internal static class SubtitleGridCopyPasteHelper
             if (item.IsMine(lines, string.Empty) && subtitle != null)
             {
                 item.LoadSubtitle(subtitle, lines, string.Empty);
-                LoadParagraphs(subtitles, index, subtitleFormat, subtitle);
-                return;
+                return LoadParagraphs(subtitles, index, subtitleFormat, subtitle);
             }
         }
 
         // fallback - plain text
+        var insertedLines = new List<SubtitleLineViewModel>();
         foreach (var line in lines)
         {
             if (!string.IsNullOrWhiteSpace(line))
@@ -150,18 +159,26 @@ internal static class SubtitleGridCopyPasteHelper
                     Text = line.Trim()
                 };
                 subtitles.Insert(index, p);
+                insertedLines.Add(p);
                 index++;
                 addTimeMilliseconds += Se.Settings.General.NewEmptyDefaultMs + Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
             }
         }
+
+        return insertedLines;
     }
 
-    private static void LoadParagraphs(ObservableCollection<SubtitleLineViewModel> subtitles, int index, SubtitleFormat subtitleFormat, Subtitle subtitle)
+    private static List<SubtitleLineViewModel> LoadParagraphs(ObservableCollection<SubtitleLineViewModel> subtitles, int index, SubtitleFormat subtitleFormat, Subtitle subtitle)
     {
+        var insertedLines = new List<SubtitleLineViewModel>(subtitle.Paragraphs.Count);
         foreach (var p in subtitle.Paragraphs)
         {
-            subtitles.Insert(index, new SubtitleLineViewModel(p, subtitleFormat));
+            var line = new SubtitleLineViewModel(p, subtitleFormat);
+            subtitles.Insert(index, line);
+            insertedLines.Add(line);
             index++;
         }
+
+        return insertedLines;
     }
 }

--- a/tests/UI/Features/Main/MainGridPasteSelectionTests.cs
+++ b/tests/UI/Features/Main/MainGridPasteSelectionTests.cs
@@ -1,0 +1,161 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// Ctrl+V in the subtitle grid must leave the pasted lines selected, like SE4 - the selection
+/// (and with it the edit text box) used to stay on the line selected before the paste (#13705).
+/// </summary>
+public class MainGridPasteSelectionTests
+{
+    [AvaloniaFact]
+    public void Paste_SelectsThePastedLine()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Existing one", 1000, 2000);
+            AddLine(vm, "Existing two", 3000, 4000);
+            SelectRow(vm, 0);
+
+            Paste(window, vm, Srt(("Pasted one", "00:00:10,000", "00:00:11,000")));
+
+            Assert.Equal(3, vm.Subtitles.Count);
+            Assert.Equal("Pasted one", vm.Subtitles[1].Text);
+
+            // The pasted line is the selected one, so the edit box shows it.
+            Assert.Same(vm.Subtitles[1], vm.SelectedSubtitle);
+            Assert.Same(vm.Subtitles[1], Assert.Single(vm.SubtitleGridSelectedItems));
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    [AvaloniaFact]
+    public void Paste_SelectsAllPastedLines_WithTheFirstAsTheCurrentRow()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Existing one", 1000, 2000);
+            AddLine(vm, "Existing two", 3000, 4000);
+            SelectRow(vm, 0);
+
+            Paste(window, vm, Srt(
+                ("Pasted one", "00:00:10,000", "00:00:11,000"),
+                ("Pasted two", "00:00:12,000", "00:00:13,000")));
+
+            Assert.Equal(4, vm.Subtitles.Count);
+            var selected = vm.SubtitleGridSelectedItems;
+            Assert.Equal(2, selected.Count);
+            Assert.Same(vm.Subtitles[1], selected[0]);
+            Assert.Same(vm.Subtitles[2], selected[1]);
+            Assert.Same(vm.Subtitles[1], vm.SelectedSubtitle);
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    // Pasting with nothing selected appends at the end (#13200); the appended lines get selected
+    // too, so the grid never keeps pointing at a line the user did not paste.
+    [AvaloniaFact]
+    public void Paste_WithoutSelection_SelectsTheAppendedLine()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Existing one", 1000, 2000);
+            vm.SubtitleGrid.SelectedItem = null;
+            vm.SelectedSubtitleIndex = null;
+            Dispatcher.UIThread.RunJobs();
+
+            Paste(window, vm, Srt(("Pasted one", "00:00:10,000", "00:00:11,000")));
+
+            Assert.Equal(2, vm.Subtitles.Count);
+            Assert.Same(vm.Subtitles[1], vm.SelectedSubtitle);
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    private static void Paste(Window window, MainViewModel vm, string clipboardText)
+    {
+        ClipboardHelper.SetTextAsync(window, clipboardText).GetAwaiter().GetResult();
+        Dispatcher.UIThread.RunJobs();
+
+        vm.SubtitleGridPasteCommand.ExecuteAsync(null).GetAwaiter().GetResult();
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static string Srt(params (string Text, string Start, string End)[] lines)
+    {
+        var sb = new System.Text.StringBuilder();
+        for (var i = 0; i < lines.Length; i++)
+        {
+            sb.AppendLine((i + 1).ToString());
+            sb.AppendLine(lines[i].Start + " --> " + lines[i].End);
+            sb.AppendLine(lines[i].Text);
+            sb.AppendLine();
+        }
+
+        return sb.ToString();
+    }
+
+    private static void SelectRow(MainViewModel vm, int index)
+    {
+        Dispatcher.UIThread.RunJobs();
+        vm.SubtitleGrid.SelectedItem = vm.Subtitles[index];
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static (Window Window, MainViewModel Vm) CreateMainViewModel()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1200, Height = 800 };
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        return (window, (MainViewModel)view.DataContext!);
+    }
+
+    private static void AddLine(MainViewModel vm, string text, int startMs, int endMs)
+    {
+        vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph(text, startMs, endMs), null!)
+        {
+            Number = vm.Subtitles.Count + 1,
+        });
+    }
+
+    private static void CloseWindow(Window window, MainViewModel vm)
+    {
+        foreach (var ownedWindow in window.OwnedWindows.ToArray())
+        {
+            ownedWindow.Close();
+        }
+
+        window.Closing -= vm.OnClosing;
+        if (window.IsVisible)
+        {
+            window.Close();
+        }
+    }
+}

--- a/tests/UI/Logic/SubtitleGridCopyPasteHelperTests.cs
+++ b/tests/UI/Logic/SubtitleGridCopyPasteHelperTests.cs
@@ -1,7 +1,9 @@
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic;
 using System;
+using System.Collections.ObjectModel;
 using System.Linq;
 using Xunit;
 
@@ -115,5 +117,93 @@ public class SubtitleGridCopyPasteHelperTests
         Assert.All(payload.SplitToLines(), l => Assert.True(
             l.TrimStart().StartsWith("Dialogue:", StringComparison.OrdinalIgnoreCase) ||
             l.TrimStart().StartsWith("Comment:", StringComparison.OrdinalIgnoreCase)));
+    }
+
+    // The pasted lines are what the grid selects and scrolls to afterwards (#13705), so the
+    // paste has to hand them back - in grid order, and as the very objects it inserted.
+    [Fact]
+    public void PasteText_ReturnsInsertedLines_ForSubtitleFormatText()
+    {
+        var format = new SubRip();
+        var subtitles = new ObservableCollection<SubtitleLineViewModel>
+        {
+            new(new Paragraph("Existing one", 1000, 2000), format),
+            new(new Paragraph("Existing two", 3000, 4000), format),
+        };
+
+        var clipboard = format.ToText(BuildSubtitle(("Pasted one", 10000, 11000), ("Pasted two", 12000, 13000)), string.Empty);
+
+        var inserted = SubtitleGridCopyPasteHelper.PasteText(subtitles, 0, format, clipboard);
+
+        Assert.Equal(2, inserted.Count);
+        Assert.Equal(4, subtitles.Count);
+        // Pasted below the selected line, contiguous and in the same order as returned.
+        Assert.Same(subtitles[1], inserted[0]);
+        Assert.Same(subtitles[2], inserted[1]);
+        Assert.Equal("Pasted one", inserted[0].Text);
+        Assert.Equal("Pasted two", inserted[1].Text);
+    }
+
+    [Fact]
+    public void PasteText_ReturnsInsertedLines_ForPlainText()
+    {
+        var format = new SubRip();
+        var subtitles = new ObservableCollection<SubtitleLineViewModel>
+        {
+            new(new Paragraph("Existing one", 1000, 2000), format),
+        };
+
+        var inserted = SubtitleGridCopyPasteHelper.PasteText(subtitles, 0, format, "Hello" + Environment.NewLine + "World");
+
+        Assert.Equal(2, inserted.Count);
+        Assert.Same(subtitles[1], inserted[0]);
+        Assert.Same(subtitles[2], inserted[1]);
+        Assert.Equal("Hello", inserted[0].Text);
+        Assert.Equal("World", inserted[1].Text);
+    }
+
+    // Appending with no selection (index == Count) must still report the appended lines, or
+    // the grid would keep the old selection after a paste into an empty/unselected grid.
+    [Fact]
+    public void PasteText_AppendsAndReturnsInsertedLines_WhenIndexIsCount()
+    {
+        var format = new SubRip();
+        var subtitles = new ObservableCollection<SubtitleLineViewModel>
+        {
+            new(new Paragraph("Existing one", 1000, 2000), format),
+        };
+
+        var clipboard = format.ToText(BuildSubtitle(("Pasted one", 10000, 11000)), string.Empty);
+
+        var inserted = SubtitleGridCopyPasteHelper.PasteText(subtitles, subtitles.Count, format, clipboard);
+
+        var single = Assert.Single(inserted);
+        Assert.Same(subtitles[^1], single);
+        Assert.Equal("Pasted one", single.Text);
+    }
+
+    [Fact]
+    public void PasteText_ReturnsEmpty_ForEmptyClipboard()
+    {
+        var format = new SubRip();
+        var subtitles = new ObservableCollection<SubtitleLineViewModel>
+        {
+            new(new Paragraph("Existing one", 1000, 2000), format),
+        };
+
+        Assert.Empty(SubtitleGridCopyPasteHelper.PasteText(subtitles, 0, format, string.Empty));
+        Assert.Empty(SubtitleGridCopyPasteHelper.PasteText(subtitles, 0, format, null));
+        Assert.Single(subtitles);
+    }
+
+    private static Subtitle BuildSubtitle(params (string Text, int Start, int End)[] paragraphs)
+    {
+        var subtitle = new Subtitle();
+        foreach (var (text, start, end) in paragraphs)
+        {
+            subtitle.Paragraphs.Add(new Paragraph(text, start, end));
+        }
+
+        return subtitle;
     }
 }


### PR DESCRIPTION
Fixes #13705

Ctrl+V in the subtitle grid inserted the clipboard lines but left the selection - and with it the edit text box - on the line that was selected before the paste. SE4 selects the newly pasted lines and scrolls them into view.

### Cause

`SubtitleGridPaste` called `SubtitleGridCopyPasteHelper.Paste(...)`, renumbered, and stopped there. `Paste` returned `Task`, so the caller never learned what was inserted or where, and nothing touched the grid selection. (`SubtitleGridCut` right next to it already re-selects a row after the removal - this was just the gap on the paste side.)

### Fix

- `Paste`/`LoadParagraphs` return the inserted lines in grid order, covering all three insert paths (format parse, format sniff, plain-text fallback). The clipboard read is split out into a testable `PasteText(subtitles, index, format, text)`.
- `SubtitleGridPaste` selects that block and scrolls to it through a new `SelectAndScrollToRange` helper: a single line goes through the existing `SelectAndScrollToRow`; multiple lines use `SelectGridRange` with the first pasted row as the current one (so the edit box shows it), plus the same `PrePositionScroll` / center-or-ensure-visible / caret-reset handling the other jump paths use.

Multi-line pastes select the whole pasted block, and a paste with no selection (which appends at the end) selects the appended lines too.

### Tests

- 4 unit tests on the lines returned by `PasteText` (format text, plain text, append-at-end, empty clipboard).
- 3 headless Avalonia tests driving the real `SubtitleGridPasteCommand` through the clipboard: single-line paste, multi-line paste, paste without a selection. All three fail with the new selection block disabled.
- Full UI suite: 2908 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)