### PR TITLE
Show translation progress in batch convert, and stop progress lingering

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -612,6 +612,7 @@
     "top": "Top",
     "totalAdjustmentX": "Total adjustment: {0}",
     "translate": "Translate",
+    "translatePercentX": "Translating: {0}%",
     "translateRow": "Translate row",
     "translation": "Translation",
     "twoLetterLanguageCode": "Two-letter language code",

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -350,6 +350,17 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             {
                 await RunOcrTesseract(imageSubtitle, item, cancellationToken);
             }
+
+            // OCR is only one step of the run - the item still goes through the convert functions
+            // and the save before it can say "Converted". Leaving the last progress value up would
+            // show a finished-looking "OCR: 100%" for that whole stretch, so put the row back to
+            // the plain working status it started this block with. A runner that deliberately left
+            // a terminal status behind (cancelled, an error, "model likely wrong") keeps it - only
+            // our own percentages are reset.
+            if (IsOcrProgressStatus(item.Status))
+            {
+                item.Status = Se.Language.General.OcrDotDotDot;
+            }
         }
 
         // Run convert functions (remove formatting, etc.)
@@ -691,6 +702,46 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         var text = Nikse.SubtitleEdit.UiLogic.Export.CustomTextFormatter.GenerateCustomText(selectedCustomFormat.ToTemplate(), paragraphsForCustom, item.FileName, string.Empty);
         var path = MakeOutputFileName(item, selectedCustomFormat.Extension);
         await File.WriteAllTextAsync(path, text, cancellationToken);
+    }
+
+    /// <summary>
+    /// True when the status is one of the "OCR: {0}%" progress values the OCR runners write. Used
+    /// to tell our own progress apart from a terminal status a runner deliberately left behind, so
+    /// clearing progress cannot swallow a "Cancelled" or an error. The format string is matched
+    /// rather than hard-coded, since translations move the percent sign and the label.
+    /// </summary>
+    internal static bool IsOcrProgressStatus(string? status)
+    {
+        if (string.IsNullOrEmpty(status))
+        {
+            return false;
+        }
+
+        var format = Se.Language.General.OcrPercentX;
+        var placeholder = format.IndexOf("{0}", StringComparison.Ordinal);
+        if (placeholder < 0)
+        {
+            return false;
+        }
+
+        var prefix = format.AsSpan(0, placeholder);
+        var suffix = format.AsSpan(placeholder + "{0}".Length);
+        if (status.Length <= prefix.Length + suffix.Length ||
+            !status.AsSpan().StartsWith(prefix, StringComparison.Ordinal) ||
+            !status.AsSpan().EndsWith(suffix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        for (var i = prefix.Length; i < status.Length - suffix.Length; i++)
+        {
+            if (!char.IsAsciiDigit(status[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static async Task RunOcrTesseract(IOcrSubtitle imageSubtitles, BatchConvertItem item, CancellationToken cancellationToken)
@@ -1801,7 +1852,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             s = AddFormatting(s);
             s = SplitBreakLongLines(s, Language);
             s = AdjustDisplayDuration(s);
-            s = await AutoTranslate(s, cancellationToken);
+            s = await AutoTranslate(s, item, cancellationToken);
             s = ChangeCasing(s, Language);
             s = OffsetTimeCodes(s);
             s = ChangeFrameRate(s);
@@ -2743,7 +2794,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         return subtitle;
     }
 
-    private async Task<Subtitle> AutoTranslate(Subtitle subtitle, CancellationToken cancellationToken)
+    private async Task<Subtitle> AutoTranslate(Subtitle subtitle, BatchConvertItem item, CancellationToken cancellationToken)
     {
         if (!_config.AutoTranslate.IsActive)
         {
@@ -2769,12 +2820,36 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         Configuration.Settings.Tools.AutoTranslateCrispAsrExe = Se.Settings.AutoTranslate.CrispAsrExe;
         Configuration.Settings.Tools.AutoTranslateCrispAsrModel = Se.Settings.AutoTranslate.CrispAsrModel;
 
+        // Translating one file can take minutes (local LLM engines especially), so report
+        // progress in the item's status column like the OCR runners do - otherwise the whole
+        // batch looks stalled (#13706). Engines forced into single-line mode raise this once
+        // per line, so only push a status update when the whole percent actually changes.
+        var lastPercent = -1;
+        var statusBeforeTranslate = item.Status;
         var doAutoTranslate = new DoAutoTranslate
         {
             TranslateEachLineSeparately = Se.Settings.AutoTranslate.IsTranslateEachLineSeparately(_config.AutoTranslate.Translator.Name),
+            Progress = (done, total) =>
+            {
+                var percent = total > 0 ? done * 100 / total : 0;
+                if (percent != lastPercent)
+                {
+                    lastPercent = percent;
+                    item.Status = string.Format(Se.Language.General.TranslatePercentX, percent);
+                }
+            },
         };
         var translatedSubtitle = await doAutoTranslate.DoTranslate(subtitle, _config.AutoTranslate.SourceLanguage, _config.AutoTranslate.TargetLanguage,
             _config.AutoTranslate.Translator, cancellationToken);
+
+        // Translating is only one step of the run - the item still goes through the remaining
+        // convert functions and the save before it can say "Converted". Leaving the last progress
+        // value up would show a finished-looking "Translating: 100%" for that whole stretch, so put
+        // the row back in the state a non-translating item is in for the rest of the pipeline.
+        if (lastPercent >= 0)
+        {
+            item.Status = statusBeforeTranslate;
+        }
 
         for (var i = 0; i < subtitle.Paragraphs.Count && i < translatedSubtitle.Count; i++)
         {

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -612,6 +612,7 @@ public class LanguageGeneral
     public string Top { get; set; }
     public string TotalAdjustmentX { get; set; }
     public string Translate { get; set; }
+    public string TranslatePercentX { get; set; }
     public string TranslateRow { get; set; }
     public string Translation { get; set; }
     public string TwoLetterLanguageCode { get; set; }
@@ -1354,6 +1355,7 @@ public class LanguageGeneral
         Top = "Top";
         TotalAdjustmentX = "Total adjustment: {0}";
         Translate = "Translate";
+        TranslatePercentX = "Translating: {0}%";
         TranslateRow = "Translate row";
         Translation = "Translation";
         TwoLetterLanguageCode = "Two-letter language code";

--- a/tests/UI/Features/Tools/BatchConvert/BatchConverterAutoTranslateProgressTests.cs
+++ b/tests/UI/Features/Tools/BatchConvert/BatchConverterAutoTranslateProgressTests.cs
@@ -1,0 +1,184 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Tools.BatchConvert;
+using Nikse.SubtitleEdit.UiLogic.AutoTranslate;
+using Nikse.SubtitleEdit.UiLogic.BatchConvert;
+using Nikse.SubtitleEdit.UiLogic.Translate;
+
+namespace UITests.Features.Tools.BatchConvert;
+
+/// <summary>
+/// Translating one file can take minutes, and before #13706 batch convert showed nothing while it
+/// ran - the row just sat there, so a slow engine was indistinguishable from a stalled one. The
+/// converter now feeds <see cref="DoAutoTranslate.Progress"/> into the item status the same way the
+/// OCR runners do, which is only useful if it actually reaches the item and does not flood the UI
+/// with one notification per line on long files.
+/// </summary>
+public class BatchConverterAutoTranslateProgressTests
+{
+    /// <summary>
+    /// Translates one row per call so progress is reported per line - the same path the "advanced"
+    /// local-LLM engines take (<see cref="IBatchContextTranslator"/>), which is the slow case the
+    /// issue was about.
+    /// </summary>
+    private sealed class OneLineAtATimeTranslator : IAutoTranslator, IBatchContextTranslator
+    {
+        public string Name => "Test translator";
+        public string Url => string.Empty;
+        public string Error { get; set; } = string.Empty;
+        public int MaxCharacters => 1000;
+
+        public void Initialize()
+        {
+        }
+
+        public List<TranslationPair> GetSupportedSourceLanguages() => new();
+
+        public List<TranslationPair> GetSupportedTargetLanguages() => new();
+
+        public Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
+        {
+            return Task.FromResult("[t] " + text);
+        }
+
+        public Task<int> TranslateBatchAsync(ObservableCollection<TranslateRow> rows, int index, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
+        {
+            rows[index].TranslatedText = "[t] " + rows[index].Text;
+            return Task.FromResult(1);
+        }
+    }
+
+    private static async Task<List<string>> ConvertAndCollectStatusesAsync(int lineCount)
+    {
+        var dir = Directory.CreateTempSubdirectory("se-translate-progress-test");
+        try
+        {
+            var subtitle = new Subtitle();
+            for (var i = 0; i < lineCount; i++)
+            {
+                subtitle.Paragraphs.Add(new Paragraph("Line " + (i + 1), i * 2000, i * 2000 + 1500));
+            }
+
+            subtitle.Renumber();
+
+            var inputFile = Path.Combine(dir.FullName, "input.srt");
+            await File.WriteAllTextAsync(inputFile, subtitle.ToText(new SubRip()), TestContext.Current.CancellationToken);
+
+            var outputFolder = Path.Combine(dir.FullName, "out");
+            Directory.CreateDirectory(outputFolder);
+
+            var item = new BatchConvertItem(inputFile, new FileInfo(inputFile).Length, new SubRip().Name, subtitle);
+
+            var statuses = new List<string>();
+            item.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName == nameof(BatchConvertItem.Status))
+                {
+                    statuses.Add(item.Status);
+                }
+            };
+
+            var config = new BatchConvertConfig
+            {
+                SaveInSourceFolder = false,
+                OutputFolder = outputFolder,
+                Overwrite = true,
+                TargetFormatName = SubRip.NameOfFormat,
+            };
+            config.AutoTranslate.IsActive = true;
+            config.AutoTranslate.Translator = new OneLineAtATimeTranslator();
+
+            var converter = new BatchConverter(null!, null!, null!);
+            converter.Initialize(config);
+            await converter.Convert(item, TestContext.Current.CancellationToken);
+
+            return statuses;
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Translating_ReportsPercentOnTheItem()
+    {
+        var statuses = await ConvertAndCollectStatusesAsync(4);
+
+        var progress = statuses.Where(s => s.StartsWith("Translating: ", StringComparison.Ordinal)).ToList();
+        Assert.Equal(new[] { "Translating: 25%", "Translating: 50%", "Translating: 75%", "Translating: 100%" }, progress);
+    }
+
+    [Fact]
+    public async Task Translating_DoesNotRepeatTheSamePercent()
+    {
+        // 200 lines is well past one notification per whole percent, so without the guard this
+        // would raise 200 property changes for 100 distinct values.
+        var statuses = await ConvertAndCollectStatusesAsync(200);
+
+        var progress = statuses.Where(s => s.StartsWith("Translating: ", StringComparison.Ordinal)).ToList();
+        Assert.Equal(progress.Distinct().Count(), progress.Count);
+        Assert.Equal("Translating: 100%", progress.Last());
+    }
+
+    [Fact]
+    public async Task Translating_DoesNotLeaveTheRowShowingHundredPercent()
+    {
+        // Translating is one step of many, so the row must not sit on a finished-looking
+        // "Translating: 100%" while the rest of the convert functions and the save run.
+        var statuses = await ConvertAndCollectStatusesAsync(4);
+
+        var lastProgressIndex = statuses.FindLastIndex(s => s.StartsWith("Translating: ", StringComparison.Ordinal));
+        Assert.True(lastProgressIndex >= 0, "no translate progress was reported");
+        Assert.NotEqual(statuses.Count - 1, lastProgressIndex);
+        Assert.Equal("-", statuses[lastProgressIndex + 1]);
+    }
+
+    [Fact]
+    public async Task NoTranslation_ReportsNoTranslateProgress()
+    {
+        var dir = Directory.CreateTempSubdirectory("se-translate-progress-off-test");
+        try
+        {
+            var subtitle = new Subtitle();
+            subtitle.Paragraphs.Add(new Paragraph("Hello", 0, 1500));
+            subtitle.Renumber();
+
+            var inputFile = Path.Combine(dir.FullName, "input.srt");
+            await File.WriteAllTextAsync(inputFile, subtitle.ToText(new SubRip()), TestContext.Current.CancellationToken);
+
+            var outputFolder = Path.Combine(dir.FullName, "out");
+            Directory.CreateDirectory(outputFolder);
+
+            var item = new BatchConvertItem(inputFile, new FileInfo(inputFile).Length, new SubRip().Name, subtitle);
+            var statuses = new List<string>();
+            item.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName == nameof(BatchConvertItem.Status))
+                {
+                    statuses.Add(item.Status);
+                }
+            };
+
+            var config = new BatchConvertConfig
+            {
+                SaveInSourceFolder = false,
+                OutputFolder = outputFolder,
+                Overwrite = true,
+                TargetFormatName = SubRip.NameOfFormat,
+            };
+
+            var converter = new BatchConverter(null!, null!, null!);
+            converter.Initialize(config);
+            await converter.Convert(item, TestContext.Current.CancellationToken);
+
+            Assert.DoesNotContain(statuses, s => s.StartsWith("Translating: ", StringComparison.Ordinal));
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+}

--- a/tests/UI/Features/Tools/BatchConvert/BatchConverterOcrProgressStatusTests.cs
+++ b/tests/UI/Features/Tools/BatchConvert/BatchConverterOcrProgressStatusTests.cs
@@ -1,0 +1,48 @@
+using Nikse.SubtitleEdit.Features.Tools.BatchConvert;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Tools.BatchConvert;
+
+/// <summary>
+/// After OCR finishes, batch convert clears the "OCR: {0}%" progress off the row so it does not sit
+/// on a finished-looking "OCR: 100%" while the convert functions and the save still run (#13706).
+/// That clearing keys off <see cref="BatchConverter.IsOcrProgressStatus"/>, which must not mistake a
+/// terminal status an OCR runner deliberately left behind for progress - swallowing a "Cancelled" or
+/// an error message would be a good deal worse than the cosmetic issue it fixes.
+/// </summary>
+public class BatchConverterOcrProgressStatusTests
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(7)]
+    [InlineData(100)]
+    public void ProgressValues_AreRecognized(int percent)
+    {
+        Assert.True(BatchConverter.IsOcrProgressStatus(string.Format(Se.Language.General.OcrPercentX, percent)));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("-")]
+    [InlineData("Converted")]
+    [InlineData("Cancelled")]
+    [InlineData("Error: engine not reachable")]
+    [InlineData("Preparing OCR...")]
+    [InlineData("OCR: %")]
+    [InlineData("OCR: abc%")]
+    [InlineData("OCR: 50")]
+    [InlineData("50%")]
+    public void NonProgressValues_AreNotRecognized(string? status)
+    {
+        Assert.False(BatchConverter.IsOcrProgressStatus(status));
+    }
+
+    [Fact]
+    public void WorkingStatus_IsNotRecognized()
+    {
+        // The status the row is reset back to must not itself look like progress, or a second pass
+        // over it would be ambiguous.
+        Assert.False(BatchConverter.IsOcrProgressStatus(Se.Language.General.OcrDotDotDot));
+    }
+}


### PR DESCRIPTION
Fixes #13706.

## Translation progress

Batch convert showed nothing while auto-translate ran: the row sat unchanged and the label stayed on `Converting 1 of 4...`, so a slow engine (local LLMs especially) was indistinguishable from a stalled one.

`DoAutoTranslate` already exposes a progress callback and seconv already uses it — batch convert just never set it. It is now wired into the item status the same way the OCR runners do, so the row reads `Translating: 45%`.

Engines forced into single-line mode (NLLB, CrispASR/Madlad) raise the callback once per subtitle line, so the status is only pushed when the whole percent changes — a 2000-line file gets at most 100 notifications instead of 2000.

## Progress no longer lingers

Translating and OCR are each one step of a run that still has the remaining convert functions and the save to go. The last progress value used to stay up for that whole stretch, so a row would show a finished-looking `Translating: 100%` / `OCR: 100%` long before it was done. Both now clear it when the step ends.

For OCR that clearing keys off the `OCR: {0}%` format string rather than a hard-coded prefix (translations move the label and the percent sign), so a terminal status a runner deliberately left behind — `Cancelled`, an error, `model likely wrong` — is never swallowed.

## Tests

- `BatchConverterAutoTranslateProgressTests` — drives a fake `IBatchContextTranslator` (the llama.cpp-advanced path the issue names) through `Convert()`: percent sequence, no repeated percent, no lingering 100%, and a negative control for translate-off. Verified non-vacuous: the two positive tests fail with the wiring removed.
- `BatchConverterOcrProgressStatusTests` — covers the progress/terminal-status discrimination directly, which is where the risk of swallowing a `Cancelled` lives.

Full UI suite: 2920 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)