### PR TITLE
Name batch auto-translate output after the target language; stop same-language tracks clobbering each other

### DIFF
--- a/docs/reference/command-line.md
+++ b/docs/reference/command-line.md
@@ -293,6 +293,8 @@ seconv movie.sub subrip --time-codes-only
 
 `--translate-to:<language>` machine-translates each file as part of the conversion (after OCR for image sources, before the cleanup operations). Languages are given as a code or English name (`de`, `German`, `da`, `Danish`, …); the source language is auto-detected per file unless `--translate-from` is set.
 
+Translated output is named with the target language code — `way.srt --translate-to:zh-CN` writes `way.zh-CN.srt` (for container tracks the target code replaces the track's own language suffix, since the content leaves in the target language). An explicit `--output-filename` is used as-is.
+
 | Option | Description |
 |---|---|
 | `--translate-to:<lang>` | Target language — enables translation |

--- a/src/seconv/Core/AutoTranslateRunner.cs
+++ b/src/seconv/Core/AutoTranslateRunner.cs
@@ -27,6 +27,33 @@ internal sealed class AutoTranslateRunner
     /// <summary>The resolved local llama.cpp model, exposed for tests.</summary>
     internal LlamaCppModel? LlamaCppModel => _llamaCppModel;
 
+    private string? _targetLanguageCode;
+
+    /// <summary>
+    /// The target language code as the engine knows it ("de", "zh-CN") - --translate-to
+    /// also accepts English names ("German"), and the output file name needs the code.
+    /// Null when the requested language is unknown; TranslateAsync reports that error.
+    /// </summary>
+    public string? TargetLanguageCode
+    {
+        get
+        {
+            if (_targetLanguageCode == null)
+            {
+                try
+                {
+                    _targetLanguageCode = ResolveLanguage(_translator.GetSupportedTargetLanguages(), _options.TranslateTo!, "target").Code;
+                }
+                catch (InvalidOperationException)
+                {
+                    _targetLanguageCode = string.Empty;
+                }
+            }
+
+            return _targetLanguageCode.Length == 0 ? null : _targetLanguageCode;
+        }
+    }
+
     private AutoTranslateRunner(ConversionOptions options, IAutoTranslator translator, LlamaCppModel? llamaCppModel)
     {
         _options = options;

--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -12,9 +12,15 @@ internal class SubtitleConverter
     // configuration fails before the first file is touched.
     private AutoTranslateRunner? _translateRunner;
 
+    // Output names handed out during the current run - --overwrite must only clobber
+    // files from before the run, never output this run just wrote (two "eng" tracks in
+    // one mkv would otherwise silently overwrite each other).
+    private readonly HashSet<string> _usedOutputFileNames = new(StringComparer.OrdinalIgnoreCase);
+
     public async Task<ConversionResult> ConvertAsync(ConversionOptions options)
     {
         var result = new ConversionResult();
+        _usedOutputFileNames.Clear();
 
         try
         {
@@ -73,11 +79,16 @@ internal class SubtitleConverter
                         continue;
                     }
 
+                    // --translate-to rewrites the content's language, so the output name
+                    // carries the target code ("way.zh-CN.srt") instead of the source
+                    // track's - and a plain file no longer collides with its own input.
+                    var translateToSuffix = _translateRunner?.TargetLanguageCode;
+
                     var tracks = ContainerSubtitleLoader.TryLoadTracks(inputFile, options);
                     if (tracks is null)
                     {
                         // Regular single-file path (text or binary subtitle file)
-                        var outputFile = ResolveOutputFileName(inputFile, options);
+                        var outputFile = ResolveOutputFileName(inputFile, options, translateToSuffix, null, _usedOutputFileNames);
                         if (!options.Quiet)
                         {
                             AnsiConsole.MarkupInterpolated($"[dim]{fileIndex}:[/] [cyan]{Path.GetFileName(inputFile)}[/] [dim]->[/] [green]{outputFile}[/]...");
@@ -111,7 +122,7 @@ internal class SubtitleConverter
 
                         foreach (var track in tracks)
                         {
-                            var outputFile = ResolveOutputFileName(inputFile, options, track.LanguageCode, track.TrackNumber);
+                            var outputFile = ResolveOutputFileName(inputFile, options, translateToSuffix ?? track.LanguageCode, track.TrackNumber, _usedOutputFileNames);
                             var trackLabel = track.TrackNumber.HasValue ? $"#{track.TrackNumber.Value} " : string.Empty;
                             var langLabel = string.IsNullOrEmpty(track.LanguageCode) ? string.Empty : $"[{track.LanguageCode}] ";
                             if (!options.Quiet)
@@ -361,7 +372,7 @@ internal class SubtitleConverter
         int fileIndex,
         Func<IReadOnlyList<BitmapSubtitleLoader.BitmapSubtitleItem>> load)
     {
-        var outputFile = ResolveOutputFileName(inputFile, options);
+        var outputFile = ResolveOutputFileName(inputFile, options, usedNames: _usedOutputFileNames);
         if (!options.Quiet)
         {
             AnsiConsole.MarkupInterpolated($"[dim]{fileIndex}:[/] [cyan]{Path.GetFileName(inputFile)}[/] [dim](img→img)→[/] [green]{outputFile}[/]...");
@@ -441,7 +452,7 @@ internal class SubtitleConverter
         {
             var isVobSub = track.CodecId.Equals("S_VOBSUB", StringComparison.OrdinalIgnoreCase);
             var outputFile = ResolveOutputFileName(
-                inputFile, options, ContainerSubtitleLoader.SanitizeLang(track.Language), track.TrackNumber);
+                inputFile, options, ContainerSubtitleLoader.SanitizeLang(track.Language), track.TrackNumber, _usedOutputFileNames);
 
             if (!options.Quiet)
             {
@@ -524,7 +535,7 @@ internal class SubtitleConverter
             // de-duplication fallback for overwrite collisions), so pass the PID *as* the
             // language suffix to keep each PID's output stably named — otherwise multiple
             // PIDs would collide and only differ by an opaque "_2", "_3" rotation.
-            var outputFile = ResolveOutputFileName(inputFile, options, languageSuffix: $"dvb_pid{pid}", trackNumber: pid);
+            var outputFile = ResolveOutputFileName(inputFile, options, languageSuffix: $"dvb_pid{pid}", trackNumber: pid, usedNames: _usedOutputFileNames);
 
             if (!options.Quiet)
             {
@@ -630,7 +641,7 @@ internal class SubtitleConverter
         foreach (var (items, streamNumber) in streams)
         {
             var languageSuffix = allStreams.Count > 1 && streamNumber.HasValue ? $"xsub_track{streamNumber.Value}" : null;
-            var outputFile = ResolveOutputFileName(inputFile, options, languageSuffix, streamNumber);
+            var outputFile = ResolveOutputFileName(inputFile, options, languageSuffix, streamNumber, _usedOutputFileNames);
 
             if (!options.Quiet)
             {
@@ -898,12 +909,16 @@ internal class SubtitleConverter
     /// between the stem and extension (<c>movie.eng.srt</c>). On collision: tries
     /// <c>movie.#&lt;track&gt;.eng.srt</c> first when a track number is given, then
     /// rotates to <c>name_2.ext</c>, <c>name_3.ext</c>, ... up to 9999.
+    /// A name in <paramref name="usedNames"/> was handed out earlier in this run (e.g.
+    /// the first of two "eng" tracks) and always counts as taken - --overwrite only
+    /// clobbers files from before the run, never the run's own output.
     /// </summary>
     internal static string ResolveOutputFileName(
         string inputFile,
         ConversionOptions options,
         string? languageSuffix = null,
-        int? trackNumber = null)
+        int? trackNumber = null,
+        ISet<string>? usedNames = null)
     {
         string baseName;
         if (!string.IsNullOrEmpty(options.OutputFilename))
@@ -927,8 +942,9 @@ internal class SubtitleConverter
             baseName = Path.Combine(outputFolder, stemWithLang + extension);
         }
 
-        if (options.Overwrite || !File.Exists(baseName))
+        if ((options.Overwrite || !File.Exists(baseName)) && usedNames?.Contains(baseName) != true)
         {
+            usedNames?.Add(baseName);
             return baseName;
         }
 
@@ -941,8 +957,9 @@ internal class SubtitleConverter
         {
             var fileName = Path.GetFileNameWithoutExtension(inputFile);
             var withTrack = Path.Combine(dir, $"{fileName}.#{trackNumber.Value}.{languageSuffix}{ext}");
-            if (!File.Exists(withTrack))
+            if ((options.Overwrite || !File.Exists(withTrack)) && usedNames?.Contains(withTrack) != true)
             {
+                usedNames?.Add(withTrack);
                 return withTrack;
             }
         }
@@ -950,8 +967,9 @@ internal class SubtitleConverter
         for (var i = 2; i < 10_000; i++)
         {
             var candidate = Path.Combine(dir, $"{stem}_{i}{ext}");
-            if (!File.Exists(candidate))
+            if (!File.Exists(candidate) && usedNames?.Contains(candidate) != true)
             {
+                usedNames?.Add(candidate);
                 return candidate;
             }
         }

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -279,7 +279,7 @@
     "keepExistingTimeCodes": "Keep existing time codes (do not add video offset)",
     "keyFile": "Key file",
     "language": "Language",
-    "languagePostFix": "Language post-fix (mkv/mp4)",
+    "languagePostFix": "Language post-fix (mkv/mp4/auto-translate)",
     "layer": "Layer",
     "layerFilterOn": "Layer filter on",
     "left": "Left",

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -71,6 +71,11 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
     // "Embed fonts" function does not rescan the font folders for every file.
     private readonly Dictionary<string, List<string>> _fontFilesCache = new(StringComparer.OrdinalIgnoreCase);
 
+    // Output names handed out during the current batch run. A later item must never take
+    // one of these - not even in overwrite mode - or two same-language tracks from one
+    // file would silently clobber each other's output.
+    private readonly HashSet<string> _handedOutOutputFileNames = new(StringComparer.OrdinalIgnoreCase);
+
     public SubtitleFormat Format { get; set; } = new SubRip();
 
     public Encoding Encoding { get; set; } = Encoding.UTF8;
@@ -101,6 +106,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         _config = config;
         _subtitleFormats = SubtitleFormatHelper.GetSubtitleFormatsWithFavoritesAtTop();
         _fontFilesCache.Clear();
+        _handedOutOutputFileNames.Clear();
     }
 
     /// <summary>
@@ -3029,98 +3035,161 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
 
         var targetExtension = extension;
 
-        if (!string.IsNullOrEmpty(item.LanguageCode))
+        var languagePart = GetLanguagePostFix(item);
+        if (languagePart.Length > 0 && fileName.EndsWith(languagePart, StringComparison.InvariantCultureIgnoreCase))
         {
-            if (Se.Settings.Tools.BatchConvert.LanguagePostFix == Se.Language.General.TwoLetterLanguageCode)
-            {
-                var code = item.LanguageCode;
-                if (code.Length == 3)
-                {
-                    code = Iso639Dash2LanguageCode.GetTwoLetterCodeFromThreeLetterCode(code);
-                }
-                else if (code.Length > 3)
-                {
-                    code = Iso639Dash2LanguageCode.GetTwoLetterCodeFromEnglishName(code);
-                }
+            languagePart = string.Empty; // base name already carries the language token
+        }
 
-                if (code.Length == 2 && !fileName.EndsWith("." + code, StringComparison.InvariantCultureIgnoreCase))
-                {
-                    fileName += "." + code;
-                }
+        var outputFileName = Path.Combine(outputFolder, fileName + languagePart + targetExtension);
+        if (!_handedOutOutputFileNames.Contains(outputFileName))
+        {
+            if (targetExtension != string.Empty && !File.Exists(outputFileName) && Directory.Exists(outputFolder))
+            {
+                return TakeOutputFileName(outputFileName);
             }
-            else if (Se.Settings.Tools.BatchConvert.LanguagePostFix == Se.Language.General.ThreeLetterLanguageCode)
-            {
-                var code = item.LanguageCode;
-                if (code.Length == 2)
-                {
-                    code = Iso639Dash2LanguageCode.GetThreeLetterCodeFromTwoLetterCode(code);
-                }
-                else if (code.Length > 3)
-                {
-                    code = Iso639Dash2LanguageCode.GetTwoLetterCodeFromEnglishName(code);
-                    code = Iso639Dash2LanguageCode.GetThreeLetterCodeFromTwoLetterCode(code);
-                }
 
-                if (code.Length == 3 && !fileName.EndsWith("." + code, StringComparison.InvariantCultureIgnoreCase))
-                {
-                    fileName += "." + code;
-                }
+            if (targetExtension == string.Empty)
+            {
+                // Directory output (image exports): an existing folder is written into,
+                // a missing one is created by the export handler - either way the plain
+                // name is fine as long as this run has not used it for another track.
+                return TakeOutputFileName(outputFileName);
             }
-            else if (Se.Settings.Tools.BatchConvert.LanguagePostFix == Se.Language.General.ThreeLetterLanguageCodeBibliographic)
-            {
-                var code = item.LanguageCode;
-                if (code.Length == 2)
-                {
-                    code = Iso639Dash2LanguageCode.GetThreeLetterBibliographicCodeFromTwoLetterCode(code);
-                }
-                else if (code.Length == 3)
-                {
-                    // GetTwoLetterCodeFromThreeLetterCode now matches both /T and /B forms.
-                    var twoLetter = Iso639Dash2LanguageCode.GetTwoLetterCodeFromThreeLetterCode(code);
-                    if (!string.IsNullOrEmpty(twoLetter))
-                    {
-                        code = Iso639Dash2LanguageCode.GetThreeLetterBibliographicCodeFromTwoLetterCode(twoLetter);
-                    }
-                }
-                else if (code.Length > 3)
-                {
-                    code = Iso639Dash2LanguageCode.GetTwoLetterCodeFromEnglishName(code);
-                    code = Iso639Dash2LanguageCode.GetThreeLetterBibliographicCodeFromTwoLetterCode(code);
-                }
 
-                if (code.Length == 3 && !fileName.EndsWith("." + code, StringComparison.InvariantCultureIgnoreCase))
-                {
-                    fileName += "." + code;
-                }
+            if (targetExtension != string.Empty && _config.Overwrite && File.Exists(outputFileName))
+            {
+                File.Delete(outputFileName);
+                return TakeOutputFileName(outputFileName);
             }
         }
 
-        var outputFileName = Path.Combine(outputFolder, fileName + targetExtension);
-        if (targetExtension != string.Empty && !File.Exists(outputFileName) && Directory.Exists(outputFolder))
+        // The name is taken - by an older file, or by another track of this very run
+        // (e.g. two "en" tracks in one mkv - those must not clobber each other, so this
+        // run's own output never falls into the overwrite branch above). Try the track
+        // number first, seconv style: "video.#3.en.srt".
+        if (!string.IsNullOrEmpty(item.TrackNumber) && languagePart.Length > 0)
         {
-            return outputFileName;
+            var withTrack = Path.Combine(outputFolder, fileName + ".#" + item.TrackNumber + languagePart + targetExtension);
+            if (!File.Exists(withTrack) && !Directory.Exists(withTrack) && !_handedOutOutputFileNames.Contains(withTrack))
+            {
+                return TakeOutputFileName(withTrack);
+            }
         }
 
-        if (targetExtension == string.Empty && Directory.Exists(outputFileName))
+        // Counter fallback goes on the base name - "video_2.en.srt" - because the language
+        // token must stay right before the extension for media players to match it.
+        var counter = 2;
+        do
         {
-            return outputFileName;
+            outputFileName = Path.Combine(outputFolder, fileName + $"_{counter}" + languagePart + targetExtension);
+            counter++;
+        } while (File.Exists(outputFileName) || Directory.Exists(outputFileName) || _handedOutOutputFileNames.Contains(outputFileName));
+
+        return TakeOutputFileName(outputFileName);
+    }
+
+    private string TakeOutputFileName(string outputFileName)
+    {
+        _handedOutOutputFileNames.Add(outputFileName);
+        return outputFileName;
+    }
+
+    /// <summary>
+    /// The ".en"-style language token to put before the target extension, or an empty
+    /// string. Auto-translate rewrites the content's language, so when it is active the
+    /// token is the target language - not the source track's - and it also applies to
+    /// plain subtitle files that have no container track language at all (#13707).
+    /// </summary>
+    private string GetLanguagePostFix(BatchConvertItem item)
+    {
+        var languageCode = _config.AutoTranslate.IsActive
+            ? _config.AutoTranslate.TargetLanguage.Code
+            : item.LanguageCode;
+
+        if (string.IsNullOrEmpty(languageCode))
+        {
+            return string.Empty;
         }
 
-        if (targetExtension != string.Empty && _config.Overwrite && File.Exists(outputFileName))
+        // Translator codes can be regional ("zh-CN", "pt-BR") or NLLB-style ("zho_Hans");
+        // the primary subtag carries the language for the two/three-letter mappings.
+        var primary = languageCode.Split('-', '_')[0];
+
+        var code = string.Empty;
+        if (Se.Settings.Tools.BatchConvert.LanguagePostFix == Se.Language.General.TwoLetterLanguageCode)
         {
-            File.Delete(outputFileName);
+            if (primary.Length == 2)
+            {
+                code = primary;
+            }
+            else if (primary.Length == 3)
+            {
+                code = Iso639Dash2LanguageCode.GetTwoLetterCodeFromThreeLetterCode(primary);
+            }
+            else
+            {
+                code = Iso639Dash2LanguageCode.GetTwoLetterCodeFromEnglishName(languageCode);
+            }
+
+            if (code.Length != 2)
+            {
+                code = string.Empty;
+            }
+        }
+        else if (Se.Settings.Tools.BatchConvert.LanguagePostFix == Se.Language.General.ThreeLetterLanguageCode)
+        {
+            if (primary.Length == 2)
+            {
+                code = Iso639Dash2LanguageCode.GetThreeLetterCodeFromTwoLetterCode(primary);
+            }
+            else if (primary.Length == 3)
+            {
+                code = primary;
+            }
+            else
+            {
+                code = Iso639Dash2LanguageCode.GetTwoLetterCodeFromEnglishName(languageCode);
+                code = Iso639Dash2LanguageCode.GetThreeLetterCodeFromTwoLetterCode(code);
+            }
+
+            if (code.Length != 3)
+            {
+                code = string.Empty;
+            }
+        }
+        else if (Se.Settings.Tools.BatchConvert.LanguagePostFix == Se.Language.General.ThreeLetterLanguageCodeBibliographic)
+        {
+            var twoLetter = primary;
+            if (primary.Length == 3)
+            {
+                // GetTwoLetterCodeFromThreeLetterCode matches both /T and /B forms.
+                twoLetter = Iso639Dash2LanguageCode.GetTwoLetterCodeFromThreeLetterCode(primary);
+            }
+            else if (primary.Length != 2)
+            {
+                twoLetter = Iso639Dash2LanguageCode.GetTwoLetterCodeFromEnglishName(languageCode);
+            }
+
+            code = Iso639Dash2LanguageCode.GetThreeLetterBibliographicCodeFromTwoLetterCode(twoLetter);
+            if (code.Length != 3)
+            {
+                code = string.Empty;
+            }
         }
         else
         {
-            var counter = 1;
-            do
-            {
-                outputFileName = Path.Combine(outputFolder, fileName + $"_{counter}" + targetExtension);
-                counter++;
-            } while (File.Exists(outputFileName) || Directory.Exists(outputFileName));
+            return string.Empty; // "No language code"
         }
 
-        return outputFileName;
+        if (code.Length == 0 && _config.AutoTranslate.IsActive)
+        {
+            // A translator code with no ISO 639 mapping (e.g. "fil") still beats no
+            // token at all - it is what media players key on.
+            code = languageCode;
+        }
+
+        return code.Length == 0 ? string.Empty : "." + code;
     }
 
     public bool AllowFix(Paragraph p, string action)

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -1021,7 +1021,7 @@ public class LanguageGeneral
         KeepExistingTimeCodes = "Keep existing time codes (do not add video offset)";
         KeyFile = "Key file";
         Language = "Language";
-        LanguagePostFix = "Language post-fix (mkv/mp4)";
+        LanguagePostFix = "Language post-fix (mkv/mp4/auto-translate)";
         Layer = "Layer";
         LayerFilterOn = "Layer filter on";
         Left = "Left";

--- a/tests/UI/Features/Tools/BatchConvert/BatchConverterOutputNamingTests.cs
+++ b/tests/UI/Features/Tools/BatchConvert/BatchConverterOutputNamingTests.cs
@@ -1,0 +1,117 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Tools.BatchConvert;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.UiLogic.AutoTranslate;
+using Nikse.SubtitleEdit.UiLogic.BatchConvert;
+using Nikse.SubtitleEdit.UiLogic.Translate;
+
+namespace UITests.Features.Tools.BatchConvert;
+
+/// <summary>
+/// Pins the output naming rules of <see cref="BatchConverter"/>: two same-language tracks
+/// from one file must never clobber each other (not even in overwrite mode), and
+/// auto-translate names its output after the target language (#13707) - "way.zh.srt"
+/// instead of the old "way_1.srt" collision rotation.
+/// </summary>
+public class BatchConverterOutputNamingTests
+{
+    private const string InputSrt = @"1
+00:00:01,000 --> 00:00:03,000
+Hello world.
+";
+
+    private sealed class EchoTranslator : IAutoTranslator
+    {
+        public string Name => "Echo";
+        public string Url => string.Empty;
+        public string Error { get; set; } = string.Empty;
+        public int MaxCharacters => 1000;
+        public void Initialize() { }
+        public List<TranslationPair> GetSupportedSourceLanguages() => new() { new TranslationPair("English", "en") };
+        public List<TranslationPair> GetSupportedTargetLanguages() => new() { new TranslationPair("Chinese", "zh-CN") };
+        public Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken) => Task.FromResult(text);
+    }
+
+    private static async Task RunWithLanguagePostFix(string postFix, Func<DirectoryInfo, BatchConverter, Task> test)
+    {
+        var oldPostFix = Se.Settings.Tools.BatchConvert.LanguagePostFix;
+        Se.Settings.Tools.BatchConvert.LanguagePostFix = postFix;
+        var dir = Directory.CreateTempSubdirectory("se-batch-naming-test");
+        try
+        {
+            await test(dir, new BatchConverter(null!, null!, null!));
+        }
+        finally
+        {
+            Se.Settings.Tools.BatchConvert.LanguagePostFix = oldPostFix;
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task TwoSameLanguageTracks_OverwriteOn_SecondGetsTrackNumberName()
+    {
+        await RunWithLanguagePostFix(Se.Language.General.TwoLetterLanguageCode, async (dir, converter) =>
+        {
+            var inputFile = Path.Combine(dir.FullName, "video.mkv");
+            await File.WriteAllTextAsync(inputFile, "x", TestContext.Current.CancellationToken);
+            var outputFolder = Path.Combine(dir.FullName, "out");
+            Directory.CreateDirectory(outputFolder);
+
+            var config = new BatchConvertConfig
+            {
+                SaveInSourceFolder = false,
+                OutputFolder = outputFolder,
+                Overwrite = true,
+                TargetFormatName = SubRip.NameOfFormat,
+            };
+            converter.Initialize(config);
+
+            foreach (var trackNumber in new[] { "3", "4" })
+            {
+                var subtitle = new Subtitle();
+                new SubRip().LoadSubtitle(subtitle, InputSrt.SplitToLines(), inputFile);
+                var item = new BatchConvertItem(inputFile, 1, new SubRip().Name, subtitle)
+                {
+                    LanguageCode = "eng",
+                    TrackNumber = trackNumber,
+                };
+                await converter.Convert(item, TestContext.Current.CancellationToken);
+            }
+
+            Assert.True(File.Exists(Path.Combine(outputFolder, "video.en.srt")), "first track's output is missing");
+            Assert.True(File.Exists(Path.Combine(outputFolder, "video.#4.en.srt")), "second track's output is missing or was clobbered");
+        });
+    }
+
+    [Fact]
+    public async Task AutoTranslate_PlainSrt_IsNamedAfterTargetLanguage()
+    {
+        await RunWithLanguagePostFix(Se.Language.General.TwoLetterLanguageCode, async (dir, converter) =>
+        {
+            var inputFile = Path.Combine(dir.FullName, "way.srt");
+            await File.WriteAllTextAsync(inputFile, InputSrt, TestContext.Current.CancellationToken);
+
+            var config = new BatchConvertConfig
+            {
+                SaveInSourceFolder = true,
+                Overwrite = false,
+                TargetFormatName = SubRip.NameOfFormat,
+            };
+            config.AutoTranslate.IsActive = true;
+            config.AutoTranslate.SourceLanguage = new TranslationPair("English", "en");
+            config.AutoTranslate.TargetLanguage = new TranslationPair("Chinese", "zh-CN");
+            config.AutoTranslate.Translator = new EchoTranslator();
+            converter.Initialize(config);
+
+            var subtitle = Subtitle.Parse(inputFile);
+            var item = new BatchConvertItem(inputFile, new FileInfo(inputFile).Length, new SubRip().Name, subtitle);
+            await converter.Convert(item, TestContext.Current.CancellationToken);
+
+            // The old behavior collided with the input and rotated to "way_1.srt".
+            Assert.True(File.Exists(Path.Combine(dir.FullName, "way.zh.srt")), "translated output is not named after the target language");
+            Assert.False(File.Exists(Path.Combine(dir.FullName, "way_1.srt")), "translated output fell back to the old collision rotation");
+        });
+    }
+}

--- a/tests/seconv/Core/OutputFileNameTest.cs
+++ b/tests/seconv/Core/OutputFileNameTest.cs
@@ -102,6 +102,52 @@ public class OutputFileNameTest : IDisposable
     }
 
     [Fact]
+    public void Resolve_TwoSameLanguageTracksWithOverwrite_SecondGetsTrackName()
+    {
+        var input = Path.Combine(_tempRoot, "video.mkv");
+        File.WriteAllText(input, "");
+        var used = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        var first = SubtitleConverter.ResolveOutputFileName(input, Opts(overwrite: true), "en", 3, used);
+        var second = SubtitleConverter.ResolveOutputFileName(input, Opts(overwrite: true), "en", 4, used);
+
+        Assert.Equal(Path.Combine(_tempRoot, "video.en.vtt"), first);
+        Assert.Equal(Path.Combine(_tempRoot, "video.#4.en.vtt"), second);
+    }
+
+    [Fact]
+    public void Resolve_SameNameTwiceInRunNoTrackNumber_SecondRotates()
+    {
+        var input = Path.Combine(_tempRoot, "video.srt");
+        File.WriteAllText(input, "");
+        var used = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // Nothing on disk yet - only the run's own bookkeeping forces the rotation,
+        // as when the first output has been resolved but not written.
+        var first = SubtitleConverter.ResolveOutputFileName(input, Opts(overwrite: true), usedNames: used);
+        var second = SubtitleConverter.ResolveOutputFileName(input, Opts(overwrite: true), usedNames: used);
+
+        Assert.Equal(Path.Combine(_tempRoot, "video.vtt"), first);
+        Assert.Equal(Path.Combine(_tempRoot, "video_2.vtt"), second);
+    }
+
+    [Fact]
+    public void Resolve_TrackNameTakenByRunAndDiskFull_RotatesPastBoth()
+    {
+        var input = Path.Combine(_tempRoot, "video.mkv");
+        File.WriteAllText(input, "");
+        File.WriteAllText(Path.Combine(_tempRoot, "video.en.vtt"), "preexisting");
+        var used = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            Path.Combine(_tempRoot, "video.#4.en.vtt"),
+        };
+
+        var result = SubtitleConverter.ResolveOutputFileName(input, Opts(overwrite: false), "en", 4, used);
+
+        Assert.Equal(Path.Combine(_tempRoot, "video.en_2.vtt"), result);
+    }
+
+    [Fact]
     public void Resolve_AbsoluteOutputFilename_IgnoresOutputFolder()
     {
         var input = Path.Combine(_tempRoot, "input.srt");


### PR DESCRIPTION
Addresses the request in #13707 ([this comment](https://github.com/SubtitleEdit/subtitleedit/issues/13707#issuecomment-5308196600)) and fixes a silent-overwrite hole for duplicate-language tracks.

## Auto-translate output naming (#13707)

Batch convert with auto-translate wrote `way_1.srt` next to `way.srt` — just the generic collision counter, no hint of the language. Now the *Language post-fix* setting (default: two-letter code) is fed the translation's **target** language whenever auto-translate is active, and it applies to plain subtitle files too, not only mkv/mp4 tracks:

- `way.srt` → translate to Chinese → `way.zh.srt` (or `way.zh-CN.srt` when the code has no two/three-letter mapping — the raw translator code is used rather than dropping the token)
- container tracks translated to another language get the target code instead of the source track's language, since that is what the content actually is

seconv's `--translate-to` does the same: `seconv way.srt subrip --translate-to:zh-CN` now writes `way.zh-CN.srt` (the resolved engine code, so `--translate-to:German` still yields `.de`). Previously the translated output collided with its own input — and with `--overwrite` it *replaced the source file*.

## Two same-language tracks (e.g. two "en" tracks in one mkv)

With overwrite enabled, the second track resolved to the same output name and deleted the first track's freshly written file — in both the UI batch convert and seconv. Output names handed out during a run are now tracked, and overwrite mode only clobbers files from *before* the run, never the run's own output. The duplicate gets the track-number name first, seconv style (`video.#4.en.srt`), falling back to a counter on the base name (`video_2.en.srt`) so the language token stays right before the extension where media players look for it.

Also fixed in passing: directory-style image exports (D-Cinema etc.) to a fresh folder got a spurious `_1` suffix because the counter loop was the only path that could name a non-existing folder.

## Tests

- 3 new seconv `ResolveOutputFileName` tests (same-run overwrite protection, track-number fallback, rotation past both disk and run collisions)
- 2 new UI `BatchConverter` tests (two "en" tracks with overwrite → `video.en.srt` + `video.#4.en.srt`; auto-translate of a plain srt → `way.zh.srt`, no `way_1.srt`)
- Full seconv suite (370) and UI BatchConvert suite (47) pass; `English.json` regenerated for the settings-label tweak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)