### PR TITLE
Add text box copy/paste (alternative) shortcuts, make Shift+Delete cut actually cut

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -16568,10 +16568,15 @@ public partial class MainViewModel :
         EditTextBox.Cut();
     }
 
+    // The "(alternative)" clipboard commands are dispatched through the shortcut manager while
+    // either edit box is focused (their gestures are not in Avalonia's native keymap), so they
+    // must act on the focused box - unlike the primary commands, which the focused control
+    // handles natively and only run from the main text box's context menu.
     [RelayCommand]
     private void TextBoxCut2()
     {
-        EditTextBox.Cut();
+        var textBox = EditTextBoxOriginal.IsFocused ? EditTextBoxOriginal : EditTextBox;
+        textBox.Cut();
     }
 
     [RelayCommand]
@@ -16581,9 +16586,23 @@ public partial class MainViewModel :
     }
 
     [RelayCommand]
+    private void TextBoxCopy2()
+    {
+        var textBox = EditTextBoxOriginal.IsFocused ? EditTextBoxOriginal : EditTextBox;
+        textBox.Copy();
+    }
+
+    [RelayCommand]
     private void TextBoxPaste()
     {
         EditTextBox.Paste();
+    }
+
+    [RelayCommand]
+    private void TextBoxPaste2()
+    {
+        var textBox = EditTextBoxOriginal.IsFocused ? EditTextBoxOriginal : EditTextBox;
+        textBox.Paste();
     }
 
     [RelayCommand]
@@ -23870,9 +23889,10 @@ public partial class MainViewModel :
     // These TextBox-category commands duplicate Avalonia's built-in TextBox key handling and are
     // hardcoded to the primary EditTextBox, so we let the focused control handle them natively
     // instead of routing them through the shortcut manager (they remain for the right-click menu).
+    // The "(alternative)" clipboard commands are NOT skipped: their gestures (e.g. Shift+Delete
+    // for cut) are not in Avalonia's native keymap, so they only work when routed here (#13711).
     private bool IsNativeTextBoxClipboardCommand(IRelayCommand command) =>
         ReferenceEquals(command, TextBoxCutCommand) ||
-        ReferenceEquals(command, TextBoxCut2Command) ||
         ReferenceEquals(command, TextBoxCopyCommand) ||
         ReferenceEquals(command, TextBoxPasteCommand) ||
         ReferenceEquals(command, TextBoxSelectAllCommand);

--- a/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
@@ -99,7 +99,9 @@ public class LanguageSettingsShortcuts
     public string TextBoxCut { get; set; }
     public string TextBoxCut2 { get; set; }
     public string TextBoxPaste { get; set; }
+    public string TextBoxPaste2 { get; set; }
     public string TextBoxCopy { get; set; }
+    public string TextBoxCopy2 { get; set; }
     public string TextBoxSelectAll { get; set; }
     public string SubtitleGridCut { get; set; }
     public string SubtitleGridCopy { get; set; }
@@ -356,7 +358,9 @@ public class LanguageSettingsShortcuts
         TextBoxCut = "Text box: Cut";
         TextBoxCut2 = "Text box: Cut (alternative)";
         TextBoxPaste = "Text box: Paste";
+        TextBoxPaste2 = "Text box: Paste (alternative)";
         TextBoxCopy = "Text box: Copy";
+        TextBoxCopy2 = "Text box: Copy (alternative)";
         TextBoxSelectAll = "Text box: Select all";
         SubtitleGridCut = "Subtitle grid: Cut";
         SubtitleGridCopy = "Subtitle grid: Copy";

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -253,7 +253,9 @@ public static class ShortcutsMain
         { nameof(MainViewModel.TextBoxCutCommand), Se.Language.Options.Shortcuts.TextBoxCut },
         { nameof(MainViewModel.TextBoxCut2Command), Se.Language.Options.Shortcuts.TextBoxCut2 },
         { nameof(MainViewModel.TextBoxPasteCommand), Se.Language.Options.Shortcuts.TextBoxPaste },
+        { nameof(MainViewModel.TextBoxPaste2Command), Se.Language.Options.Shortcuts.TextBoxPaste2 },
         { nameof(MainViewModel.TextBoxCopyCommand), Se.Language.Options.Shortcuts.TextBoxCopy },
+        { nameof(MainViewModel.TextBoxCopy2Command), Se.Language.Options.Shortcuts.TextBoxCopy2 },
         { nameof(MainViewModel.TextBoxSelectAllCommand), Se.Language.Options.Shortcuts.TextBoxSelectAll },
         { nameof(MainViewModel.TextBoxRemoveAllFormattingCommand), Se.Language.Options.Shortcuts.TextBoxRemoveAllFormatting },
         { nameof(MainViewModel.TextBoxItalicCommand), Se.Language.Options.Shortcuts.TextBoxItalic },
@@ -606,7 +608,9 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.TextBoxCutCommand, nameof(vm.TextBoxCutCommand), ShortcutCategory.TextBox);
         AddShortcut(shortcuts, vm.TextBoxCut2Command, nameof(vm.TextBoxCut2Command), ShortcutCategory.TextBox);
         AddShortcut(shortcuts, vm.TextBoxPasteCommand, nameof(vm.TextBoxPasteCommand), ShortcutCategory.TextBox);
+        AddShortcut(shortcuts, vm.TextBoxPaste2Command, nameof(vm.TextBoxPaste2Command), ShortcutCategory.TextBox);
         AddShortcut(shortcuts, vm.TextBoxCopyCommand, nameof(vm.TextBoxCopyCommand), ShortcutCategory.TextBox);
+        AddShortcut(shortcuts, vm.TextBoxCopy2Command, nameof(vm.TextBoxCopy2Command), ShortcutCategory.TextBox);
         AddShortcut(shortcuts, vm.TextBoxSelectAllCommand, nameof(vm.TextBoxSelectAllCommand), ShortcutCategory.TextBox);
         AddShortcut(shortcuts, vm.TextBoxRemoveAllFormattingCommand, nameof(vm.TextBoxRemoveAllFormattingCommand), ShortcutCategory.TextBox);
         AddShortcut(shortcuts, vm.TextBoxItalicCommand, nameof(vm.TextBoxItalicCommand), ShortcutCategory.TextBox);
@@ -931,6 +935,9 @@ public static class ShortcutsMain
             new(nameof(vm.ShowSourceViewCommand), [nameof(Avalonia.Input.Key.F2)], ShortcutCategory.General),
             // Forward delete for Apple keyboards, where the Delete key is only a backspace.
             new(nameof(vm.TextBoxDeleteForwardCommand), ["Shift", nameof(Avalonia.Input.Key.Back)], ShortcutCategory.TextBox),
+            // Shift+Delete cut is not in Avalonia's native keymap (unlike Ctrl+Insert copy and
+            // Shift+Insert paste), so the Windows-standard gesture needs a default binding, while
+            // the copy/paste alternatives stay unbound by default (#13711).
             new(nameof(vm.TextBoxCut2Command), ["Shift", nameof(Avalonia.Input.Key.Delete) ], ShortcutCategory.TextBox),
             new(nameof(vm.TextBoxCutCommand), [cmd, nameof(Avalonia.Input.Key.X)], ShortcutCategory.TextBox),
             new(nameof(vm.TextBoxPasteCommand), [cmd, nameof(Avalonia.Input.Key.V)], ShortcutCategory.TextBox),


### PR DESCRIPTION
Addresses #13711.

The issue asked why "Text box: Cut (alternative)" ships with a default Shift+Delete binding while there are no copy/paste alternatives, and suggested unbinding it since the Windows-standard gestures "already work".

Verifying against Avalonia 12.1.1 turned up the opposite of the issue's premise:

- **Ctrl+Insert (copy) and Shift+Insert (paste)** *are* in Avalonia's native TextBox keymap (`PlatformHotkeyConfiguration`, unconditional on all platforms) — that's why they work with no SE binding.
- **Shift+Delete (cut) is *not*** — Avalonia's Cut gesture is only Ctrl/Cmd+X. Worse, SE's existing Shift+Delete binding was inert: `IsNativeTextBoxClipboardCommand` (added for #11906) skipped it so the TextBox handled the key natively — as a plain forward-delete. So Shift+Delete deleted the selection **without copying it to the clipboard**, while looking exactly like a cut. A silent data trap for anyone relying on the Windows-standard gesture.

Changes:

- Route `TextBoxCut2Command` through the shortcut manager again (removed from the native-skip list) and make it act on whichever edit box is focused, so the default Shift+Delete now genuinely cuts — in the original/translation box too.
- Add **Text box: Copy (alternative)** and **Text box: Paste (alternative)** actions (focus-aware), **unbound by default** as the reporter requested — the native keymap already covers Ctrl+Insert/Shift+Insert, and all three alternatives are freely rebindable.
- The remaining asymmetry (cut alternative bound, copy/paste alternatives unbound) mirrors Avalonia's own keymap asymmetry; commented at the default-binding site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)