### PR TITLE
Name forced container tracks with the .forced token in seconv

### DIFF
--- a/src/seconv/Core/ContainerSubtitleLoader.cs
+++ b/src/seconv/Core/ContainerSubtitleLoader.cs
@@ -20,7 +20,8 @@ internal static class ContainerSubtitleLoader
         Subtitle Subtitle,
         SubtitleFormat Format,
         string LanguageCode,
-        int? TrackNumber);
+        int? TrackNumber,
+        bool IsForced = false);
 
     /// <summary>
     /// Returns the list of tracks if <paramref name="filePath"/> is a recognised container,
@@ -275,7 +276,7 @@ internal static class ContainerSubtitleLoader
                     var pgsSub = ImageOcrLoader.LoadMatroskaPgs(matroska, track, options);
                     if (pgsSub.Paragraphs.Count > 0)
                     {
-                        tracks.Add(new LoadedTrack(pgsSub, new SubRip(), SanitizeLang(track.Language), track.TrackNumber));
+                        tracks.Add(new LoadedTrack(pgsSub, new SubRip(), SanitizeLang(track.Language), track.TrackNumber, track.IsForced));
                     }
                 }
                 catch (Exception ex)
@@ -292,7 +293,7 @@ internal static class ContainerSubtitleLoader
                     var vobSub = ImageOcrLoader.LoadMatroskaVobSub(matroska, track, options);
                     if (vobSub.Paragraphs.Count > 0)
                     {
-                        tracks.Add(new LoadedTrack(vobSub, new SubRip(), SanitizeLang(track.Language), track.TrackNumber));
+                        tracks.Add(new LoadedTrack(vobSub, new SubRip(), SanitizeLang(track.Language), track.TrackNumber, track.IsForced));
                     }
                 }
                 catch (Exception ex)
@@ -309,7 +310,7 @@ internal static class ContainerSubtitleLoader
                     var dvbSub = ImageOcrLoader.LoadMatroskaDvbSub(matroska, track, options);
                     if (dvbSub.Paragraphs.Count > 0)
                     {
-                        tracks.Add(new LoadedTrack(dvbSub, new SubRip(), SanitizeLang(track.Language), track.TrackNumber));
+                        tracks.Add(new LoadedTrack(dvbSub, new SubRip(), SanitizeLang(track.Language), track.TrackNumber, track.IsForced));
                     }
                 }
                 catch (Exception ex)
@@ -334,7 +335,7 @@ internal static class ContainerSubtitleLoader
             // gets auto-detected instead of an empty language.
             var lang = SanitizeLang(track.Language);
             lang = IsUndeclaredLanguage(lang) ? LanguageAutoDetect.AutoDetectGoogleLanguageOrNull(subtitle) ?? lang : lang;
-            tracks.Add(new LoadedTrack(subtitle, format, lang, track.TrackNumber));
+            tracks.Add(new LoadedTrack(subtitle, format, lang, track.TrackNumber, track.IsForced));
         }
 
         return tracks;
@@ -368,6 +369,14 @@ internal static class ContainerSubtitleLoader
             {
                 continue;
             }
+
+            // tx3g displayFlags is how QuickTime/AVFoundation marks a forced track
+            var isForced = track.Mdia.Minf?.Stbl?.Stsd?.IsForcedSubtitle == true;
+            if (options.ForcedOnly && !isForced)
+            {
+                continue;
+            }
+
             if (track.Mdia.IsVobSubSubtitle)
             {
                 try
@@ -375,7 +384,7 @@ internal static class ContainerSubtitleLoader
                     var vobSub = ImageOcrLoader.LoadMp4VobSub(track, options);
                     if (vobSub.Paragraphs.Count > 0)
                     {
-                        tracks.Add(new LoadedTrack(vobSub, new SubRip(), GetMp4TrackLanguage(track, vobSub), trackId));
+                        tracks.Add(new LoadedTrack(vobSub, new SubRip(), GetMp4TrackLanguage(track, vobSub), trackId, isForced));
                     }
                 }
                 catch (Exception ex)
@@ -393,7 +402,7 @@ internal static class ContainerSubtitleLoader
             var subtitle = new Subtitle();
             subtitle.Paragraphs.AddRange(paragraphs);
             subtitle.Renumber();
-            tracks.Add(new LoadedTrack(subtitle, new SubRip(), GetMp4TrackLanguage(track, subtitle), trackId));
+            tracks.Add(new LoadedTrack(subtitle, new SubRip(), GetMp4TrackLanguage(track, subtitle), trackId, isForced));
         }
 
         if (tracks.Count == 0)

--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -122,7 +122,7 @@ internal class SubtitleConverter
 
                         foreach (var track in tracks)
                         {
-                            var outputFile = ResolveOutputFileName(inputFile, options, translateToSuffix ?? track.LanguageCode, track.TrackNumber, _usedOutputFileNames);
+                            var outputFile = ResolveOutputFileName(inputFile, options, AppendForcedToken(translateToSuffix ?? track.LanguageCode, track.IsForced), track.TrackNumber, _usedOutputFileNames);
                             var trackLabel = track.TrackNumber.HasValue ? $"#{track.TrackNumber.Value} " : string.Empty;
                             var langLabel = string.IsNullOrEmpty(track.LanguageCode) ? string.Empty : $"[{track.LanguageCode}] ";
                             if (!options.Quiet)
@@ -452,7 +452,7 @@ internal class SubtitleConverter
         {
             var isVobSub = track.CodecId.Equals("S_VOBSUB", StringComparison.OrdinalIgnoreCase);
             var outputFile = ResolveOutputFileName(
-                inputFile, options, ContainerSubtitleLoader.SanitizeLang(track.Language), track.TrackNumber, _usedOutputFileNames);
+                inputFile, options, AppendForcedToken(ContainerSubtitleLoader.SanitizeLang(track.Language), track.IsForced), track.TrackNumber, _usedOutputFileNames);
 
             if (!options.Quiet)
             {
@@ -901,6 +901,21 @@ internal class SubtitleConverter
             options.PacCodePage,
             options.EbuHeaderFile,
             options);
+    }
+
+    /// <summary>
+    /// Appends the player convention's "forced" name token (<c>movie.eng.forced.srt</c>)
+    /// for forced tracks - MKV forced-display flag, or MP4 tx3g forced displayFlags -
+    /// so a forced track no longer collides with its same-language full track.
+    /// </summary>
+    internal static string? AppendForcedToken(string? languageSuffix, bool isForced)
+    {
+        if (!isForced)
+        {
+            return languageSuffix;
+        }
+
+        return string.IsNullOrEmpty(languageSuffix) ? "forced" : $"{languageSuffix}.forced";
     }
 
     /// <summary>

--- a/tests/seconv/Core/OutputFileNameTest.cs
+++ b/tests/seconv/Core/OutputFileNameTest.cs
@@ -160,4 +160,31 @@ public class OutputFileNameTest : IDisposable
 
         Assert.Equal(absolute, result);
     }
+
+    // Forced tracks (MKV forced flag, MP4 tx3g forced displayFlags) get the player
+    // convention's name token, so they no longer collide with the same-language full track.
+    [Theory]
+    [InlineData("eng", true, "eng.forced")]
+    [InlineData("eng", false, "eng")]
+    [InlineData("", true, "forced")]
+    [InlineData(null, true, "forced")]
+    [InlineData(null, false, null)]
+    public void AppendForcedToken_Cases(string? languageSuffix, bool isForced, string? expected)
+    {
+        Assert.Equal(expected, SubtitleConverter.AppendForcedToken(languageSuffix, isForced));
+    }
+
+    [Fact]
+    public void Resolve_ForcedSuffix_DoesNotCollideWithFullTrack()
+    {
+        var input = Path.Combine(_tempRoot, "video.mp4");
+        File.WriteAllText(input, "");
+        var used = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        var full = SubtitleConverter.ResolveOutputFileName(input, Opts(), SubtitleConverter.AppendForcedToken("eng", false), 2, used);
+        var forced = SubtitleConverter.ResolveOutputFileName(input, Opts(), SubtitleConverter.AppendForcedToken("eng", true), 3, used);
+
+        Assert.Equal(Path.Combine(_tempRoot, "video.eng.vtt"), full);
+        Assert.Equal(Path.Combine(_tempRoot, "video.eng.forced.vtt"), forced);
+    }
 }


### PR DESCRIPTION
Follow-up to #13719, which taught the MP4 parser QuickTime's forced-track displayFlags. seconv now carries a forced flag on loaded container tracks — the Matroska forced-display flag, and the MP4 tx3g `displayFlags` bits (0x80000000/0x40000000) — through to output naming and track selection:

- Forced tracks are named with the player convention's token: `movie.eng.forced.srt`. Previously an MP4 with "English" and "English (forced)" tracks collided on `movie.eng.srt` and fell back to the `movie.#3.eng.srt` disambiguation; now each track gets its meaningful name on the first try. Applies to the text-track path and the MKV bitmap image-to-image path alike.
- `--forced-only` now also selects forced tracks in MP4/MOV input, matching the existing Matroska behavior (it silently processed nothing useful for MP4 before, since no MP4 track ever counted as forced).

Verified end-to-end on both containers: an AVFoundation-authored `.mp4` with a forced tx3g track association writes `avf_forced.eng.srt` + `avf_forced.eng.forced.srt` (the forced file containing exactly the forced cue), and an mkvmerge-built MKV with `--forced-display-flag` writes `mkv_forced.eng.srt` + `mkv_forced.eng.forced.srt`. `--forced-only` on the MP4 converts just the forced track.

Six new naming tests (token cases and the no-collision resolution). All seconv tests pass: 376.

🤖 Generated with [Claude Code](https://claude.com/claude-code)