### PR TITLE
Keep per-run italic/bold when importing fcpxml titles, write invariant colors

### DIFF
--- a/src/libse/SubtitleFormats/FinalCutProXml15.cs
+++ b/src/libse/SubtitleFormats/FinalCutProXml15.cs
@@ -420,7 +420,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var g = (double)fontColor.Green / byte.MaxValue;
             var b = (double)fontColor.Blue / byte.MaxValue;
             var a = (double)fontColor.Alpha / byte.MaxValue;
-            var result = $"{r:0.######} {g:0.######} {b:0.######} {a:0.######}";
+            // Invariant culture - a comma-decimal locale (da, de, ...) otherwise writes
+            // "0,960784", which Final Cut Pro cannot parse.
+            var result = string.Format(CultureInfo.InvariantCulture, "{0:0.######} {1:0.######} {2:0.######} {3:0.######}", r, g, b, a);
             return result;
         }
 
@@ -457,17 +459,27 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     {
                         try
                         {
-                            var text = GetInnerText(node.ParentNode);
                             var p = new Paragraph();
-                            p.Text = text.Trim();
-                            if (node.ParentNode.InnerXml.Contains("bold=\"1\""))
+                            if (node.SelectNodes("text-style")?.Count > 0)
                             {
-                                p.Text = "<b>" + p.Text + "</b>";
+                                // Styled runs referencing per-title text-style-defs - keep
+                                // the styling per run instead of flattening any italic/bold
+                                // in the title onto the whole paragraph.
+                                p.Text = GetCaptionText(node.ParentNode);
                             }
-
-                            if (node.ParentNode.InnerXml.Contains("italic=\"1\""))
+                            else
                             {
-                                p.Text = "<i>" + p.Text + "</i>";
+                                var text = GetInnerText(node.ParentNode);
+                                p.Text = text.Trim();
+                                if (node.ParentNode.InnerXml.Contains("bold=\"1\""))
+                                {
+                                    p.Text = "<b>" + p.Text + "</b>";
+                                }
+
+                                if (node.ParentNode.InnerXml.Contains("italic=\"1\""))
+                                {
+                                    p.Text = "<i>" + p.Text + "</i>";
+                                }
                             }
 
                             p.StartTime = DecodeTime(node.ParentNode.Attributes["offset"]);

--- a/tests/libse/SubtitleFormats/AppleFormatsSweepTest.cs
+++ b/tests/libse/SubtitleFormats/AppleFormatsSweepTest.cs
@@ -1,6 +1,7 @@
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System.Globalization;
 using System.Text;
 
 namespace LibSETests.SubtitleFormats;
@@ -225,6 +226,42 @@ public class AppleFormatsSweepTest
         Assert.Equal("Final Cut Pro Xml 1.13", parsed.OriginalFormat.Name);
         Assert.Equal(2, parsed.Paragraphs.Count);
         Assert.Equal(1000, parsed.Paragraphs[0].StartTime.TotalMilliseconds, 1.0);
+    }
+
+    // The title export always wrote styled runs, but the importer flattened any italic/bold
+    // in the title onto the whole paragraph.
+    [Fact]
+    public void FinalCutProTitleKeepsPartialItalicBoldOnRoundTrip()
+    {
+        var s = new Subtitle();
+        s.Paragraphs.Add(new Paragraph("<i>Italic</i> and <b>bold</b> text.", 1000, 3000));
+        var format = new FinalCutProXml19();
+        var raw = format.ToText(s, "title");
+
+        var reloaded = new Subtitle();
+        format.LoadSubtitle(reloaded, raw.SplitToLines(), "file.fcpxml");
+        Assert.Single(reloaded.Paragraphs);
+        Assert.Equal("<i>Italic</i> and <b>bold</b> text.", reloaded.Paragraphs[0].Text);
+    }
+
+    // A comma-decimal locale used to write fontColor="0,960784 ..." - Final Cut Pro
+    // cannot parse that.
+    [Fact]
+    public void FinalCutProTitleColorsUseInvariantDecimals()
+    {
+        var savedCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("da-DK");
+            var raw = new FinalCutProXml19().ToText(MakeReference(), "title");
+            var colors = System.Text.RegularExpressions.Regex.Matches(raw, "fontColor=\"[^\"]*\"");
+            Assert.NotEmpty(colors);
+            Assert.All(colors, m => Assert.DoesNotContain(",", m.Value));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = savedCulture;
+        }
     }
 
     // Caption-based export: Final Cut Pro imports these via File > Import > XML as real


### PR DESCRIPTION
Final follow-up from the Apple formats sweep (#13719).

**Per-run styling on import.** The fcpxml title export has always written styled runs correctly — separate `text-style-def`s for the italic and bold spans — but the importer flattened any italic/bold found anywhere in the title onto the whole paragraph, so `<i>Italic</i> and <b>bold</b> text.` round-tripped as `<i><b>Italic and bold text.</b></i>`. Titles containing `text-style` runs are now read through the same per-run reader the caption import uses (resolving each run's `ref` against the title's style defs); titles without runs keep the old whole-paragraph fallback. The styled reference line now survives the round-trip exactly, across the whole 1.5–1.14 family.

**Locale-proof colors.** Found while diffing the export on this (Danish-locale) machine: `ToColorString` formatted with the current culture, so comma-decimal locales wrote `fontColor="0,960784 0,960784 0,960784 1"` — which Final Cut Pro cannot parse. Now formatted with the invariant culture; a repo-wide search found no other culture-sensitive color writes of this shape.

Exports re-validated against Apple's FCPXML DTDs (1.5/1.9/1.14 spot checks). Two new tests: the partial italic/bold round-trip, and a da-DK culture test asserting no comma ever appears in `fontColor`.

Full solution builds. All suites pass: libse 1229, seconv 370, libuilogic 229, UI 2968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)