### PR TITLE
Open BDN xml and Final Cut Pro image xmeml from the main window via OCR

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -18433,6 +18433,20 @@ public partial class MainViewModel :
                     }
                 }
 
+                // Image-list xml projects reference png files next to the xml - BDN xml and
+                // Final Cut Pro image xmeml (SE's own "export image based" FCP output). Both
+                // only live in GetTextOtherFormats(), so Subtitle.Parse never finds them;
+                // route through the BDN OCR import like batch convert already does for BDN.
+                if (ext == ".xml")
+                {
+                    var imageListSubtitle = TryLoadImageListXml(fileName);
+                    if (imageListSubtitle != null)
+                    {
+                        ImportAndOcrDost(fileName, imageListSubtitle, skipLoadVideo);
+                        return;
+                    }
+                }
+
                 if (FileUtil.IsSpDvdSup(fileName))
                 {
                     ImportAndOcrSpDvdSup(fileName, skipLoadVideo);
@@ -18967,6 +18981,51 @@ public partial class MainViewModel :
         for (var i = 0; i < Subtitles.Count && i < sub.Paragraphs.Count; i++)
         {
             Subtitles[i].Bookmark = sub.Paragraphs[i].Bookmark;
+        }
+    }
+
+    /// <summary>
+    /// Loads an image-list xml project (BDN xml, or a Final Cut Pro image xmeml where each
+    /// clipitem references a png) whose cues carry image file names for the OCR importer.
+    /// Returns null when the file is neither.
+    /// </summary>
+    private static Subtitle? TryLoadImageListXml(string fileName)
+    {
+        try
+        {
+            var lines = FileUtil.ReadAllLinesShared(fileName, LanguageAutoDetect.GetEncodingFromFile(fileName));
+
+            var bdnXml = new BdnXml();
+            if (bdnXml.IsMine(lines, fileName))
+            {
+                var subtitle = new Subtitle();
+                bdnXml.LoadSubtitle(subtitle, lines, fileName);
+                if (subtitle.Paragraphs.Count > 0)
+                {
+                    subtitle.OriginalFormat = bdnXml;
+                    return subtitle;
+                }
+            }
+
+            // Cheap content gate first - FinalCutProImage has no fast IsMine of its own.
+            if (lines.Any(l => l.Contains("<xmeml", StringComparison.Ordinal)) &&
+                lines.Any(l => l.Contains("<pathurl>", StringComparison.Ordinal)))
+            {
+                var fcpImage = new FinalCutProImage();
+                var subtitle = new Subtitle();
+                fcpImage.LoadSubtitle(subtitle, lines, fileName);
+                if (subtitle.Paragraphs.Count > 0)
+                {
+                    subtitle.OriginalFormat = fcpImage;
+                    return subtitle;
+                }
+            }
+
+            return null;
+        }
+        catch
+        {
+            return null;
         }
     }
 

--- a/tests/libuilogic/Export/ExportHandlerFcpRoundTripTests.cs
+++ b/tests/libuilogic/Export/ExportHandlerFcpRoundTripTests.cs
@@ -1,0 +1,99 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.UiLogic.Export;
+using SkiaSharp;
+
+namespace LibUiLogicTests.Export;
+
+/// <summary>
+/// The "Final Cut Pro + image" export writes an xmeml whose clipitems reference the
+/// exported pngs - FinalCutProImage is the matching importer (the main window routes
+/// image-list xml files to the BDN OCR import through it).
+/// </summary>
+public class ExportHandlerFcpRoundTripTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), "fcp_img_" + Guid.NewGuid().ToString("N"));
+
+    public ExportHandlerFcpRoundTripTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, true); } catch { /* best effort */ }
+    }
+
+    private static ImageParameter Cue(int index, string text, int startMs, int endMs)
+    {
+        var bitmap = new SKBitmap(300, 80);
+        using (var canvas = new SKCanvas(bitmap))
+        {
+            canvas.Clear(SKColors.Transparent);
+            using var paint = new SKPaint { Color = SKColors.White, IsAntialias = true };
+            using var font = new SKFont(SKTypeface.Default, 24);
+            canvas.DrawText(text, 4, 40, font, paint);
+        }
+
+        return new ImageParameter
+        {
+            Text = text,
+            Bitmap = bitmap,
+            StartTime = TimeSpan.FromMilliseconds(startMs),
+            EndTime = TimeSpan.FromMilliseconds(endMs),
+            Index = index,
+            ScreenWidth = 1920,
+            ScreenHeight = 1080,
+            FramesPerSecond = 25.0,
+            Alignment = ExportAlignment.BottomCenter,
+            BottomTopMargin = 50,
+        };
+    }
+
+    [Fact]
+    public void ExportedXmemlRoundTripsThroughFinalCutProImage()
+    {
+        var savedRate = Configuration.Settings.General.CurrentFrameRate;
+        try
+        {
+            Configuration.Settings.General.CurrentFrameRate = 25.0;
+            var cues = new[]
+            {
+                Cue(0, "First image cue", 1000, 3000),
+                Cue(1, "Second image cue", 4000, 6500),
+            };
+
+            var handler = new ExportHandlerFcp();
+            handler.WriteHeader(_dir, cues[0]);
+            foreach (var c in cues)
+            {
+                handler.WriteParagraph(c);
+            }
+
+            handler.WriteFooter();
+
+            var xmlFile = Path.Combine(_dir, "fcpxml_export.xml");
+            Assert.True(File.Exists(xmlFile));
+
+            var format = new FinalCutProImage();
+            var lines = File.ReadAllLines(xmlFile).ToList();
+            var subtitle = new Subtitle();
+            format.LoadSubtitle(subtitle, lines, xmlFile);
+
+            Assert.Equal(2, subtitle.Paragraphs.Count);
+            Assert.Equal(1000, subtitle.Paragraphs[0].StartTime.TotalMilliseconds, 1.0);
+            Assert.Equal(3000, subtitle.Paragraphs[0].EndTime.TotalMilliseconds, 1.0);
+            Assert.Equal(4000, subtitle.Paragraphs[1].StartTime.TotalMilliseconds, 1.0);
+
+            // Each cue references its exported png - resolvable next to the xml, which is
+            // how OcrSubtitleBdn loads the bitmaps for OCR (Extra first, file name fallback).
+            foreach (var p in subtitle.Paragraphs)
+            {
+                var byExtra = Path.Combine(_dir, (p.Extra ?? string.Empty).Replace("file://", string.Empty));
+                var byName = Path.Combine(_dir, p.Text);
+                Assert.True(File.Exists(byExtra) || File.Exists(byName), $"image not found for cue: {p.Text} / {p.Extra}");
+            }
+        }
+        finally
+        {
+            Configuration.Settings.General.CurrentFrameRate = savedRate;
+        }
+    }
+}


### PR DESCRIPTION
Closes out the last follow-up from the Apple formats sweep (#13719): `FinalCutProImage` looked orphaned — it turned out to be registered in `GetTextOtherFormats()` (the image-list family: BDN xml, DOST, ...), with `ExportHandlerFcp` as its writing counterpart, but **no path in the main window could ever reach it**.

The main open flow's fallback chain (SMPTE-TT base64, SP-DVD sup, binary formats, unknown-format importer) never tries the image-list xml formats, so both a Final Cut Pro image xmeml — including the output of SE's own "Final Cut Pro + image" export — and a standalone BDN xml fell through to the unknown-format importer and opened as garbage or not at all. Batch convert already special-cased BDN; the main window now routes both formats to the BDN OCR import (`ImportAndOcrDost`), the same dialog the MP4-embedded image formats already use. A cheap `<xmeml` + `<pathurl>` content gate guards the FCP probe, and BDN keeps its own `<BDN` gate.

No changes to the formats themselves were needed: `FinalCutProImage.LoadSubtitle` parses `ExportHandlerFcp`'s xmeml as-is, and `OcrSubtitleBdn` already resolves each cue's image next to the xml (pathurl first, file-name fallback).

New round-trip test in libuilogic: `ExportHandlerFcp` output (xmeml + PNGs) parses back through `FinalCutProImage` with exact timing and resolvable image references for every cue.

Full solution builds. All suites pass: libse 1229, seconv 376, libuilogic 230, UI 2968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)