### PR TITLE
IMSC 1.1/Rosetta: keep literal angle brackets, make italics spec-visible, fix cross-line italics

### DIFF
--- a/src/libse/SubtitleFormats/TimedText10.cs
+++ b/src/libse/SubtitleFormats/TimedText10.cs
@@ -99,6 +99,18 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             return false;
         }
 
+        private static readonly Regex UnsupportedAngleBracketRegex = new Regex(@"<(?!(/?(i|b|u)>|font[ >]|/font>|br\s*/?>))", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        /// <summary>
+        /// Escapes '&lt;' characters that do not open a known markup tag, so literal angle
+        /// brackets in subtitle text (e.g. "3 &lt; 5") survive the XML parse instead of making
+        /// it fail - which would strip all brackets from the paragraph.
+        /// </summary>
+        internal static string EscapeUnsupportedAngleBrackets(string text)
+        {
+            return UnsupportedAngleBracketRegex.Replace(text, "&lt;");
+        }
+
         internal static string ConvertToTimeString(TimeCode time)
         {
             return ConvertToTimeString(time, Configuration.Settings.SubtitleSettings.TimedText10TimeCodeFormat);

--- a/src/libse/SubtitleFormats/TimedTextImsc11.cs
+++ b/src/libse/SubtitleFormats/TimedTextImsc11.cs
@@ -27,7 +27,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
     </metadata>
     <styling>
       <style xml:id='style.center' tts:color='#ffffff' tts:opacity='1' tts:fontSize='100%' tts:fontFamily='default' tts:textAlign='center'/>
-      <style xml:id='italic' tts:shear='16.6667%' tts:opacity='1' tts:fontSize='100%' tts:fontFamily='default'/>
+      <style xml:id='italic' tts:fontStyle='italic' tts:shear='16.6667%' tts:opacity='1' tts:fontSize='100%'/>
     </styling>
     <layout>
       <region xml:id='region.topLeft' tts:origin='10% 10%' tts:extent='80% 20%' tts:displayAlign='before' tts:textAlign='start'/>
@@ -298,7 +298,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 text = Utilities.RemoveSsaTags(text);
                 text = string.Join("<br/>", text.SplitToLines());
                 var paragraphContent = new XmlDocument();
-                paragraphContent.LoadXml($"<root>{text.Replace("&", "&amp;")}</root>");
+                paragraphContent.LoadXml($"<root>{TimedText10.EscapeUnsupportedAngleBrackets(text.Replace("&", "&amp;"))}</root>");
                 ConvertParagraphNodeToTtmlNode(paragraphContent.DocumentElement, xml, paragraph);
             }
             catch // Wrong markup, clear it
@@ -733,6 +733,13 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         color = child.Attributes["tts:color"].Value;
                     }
 
+
+                    if (fontFamily == "default")
+                    {
+                        // "default" is the generic IMSC font family (used by SE's own styles) -
+                        // not a real font the user chose, so don't surface it as a <font> tag
+                        fontFamily = null;
+                    }
 
                     // Applying styles
                     if (isItalic)

--- a/src/libse/SubtitleFormats/TimedTextImscRosetta.cs
+++ b/src/libse/SubtitleFormats/TimedTextImscRosetta.cs
@@ -231,12 +231,12 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             try
             {
                 text = Utilities.RemoveSsaTags(text);
-                var lines = text.SplitToLines();
+                var lines = BalanceTagsPerLine(text.SplitToLines());
                 for (int i = 0; i < lines.Count; i++)
                 {
                     var line = lines[i];
                     var paragraphContent = new XmlDocument { PreserveWhitespace = true };
-                    paragraphContent.LoadXml($"<root>{line.Replace("&", "&amp;")}</root>");
+                    paragraphContent.LoadXml($"<root>{TimedText10.EscapeUnsupportedAngleBrackets(line.Replace("&", "&amp;"))}</root>");
                     ConvertParagraphNodeToTtmlNode(paragraphContent.DocumentElement, xml, paragraph);
 
                     if (i < lines.Count - 1)
@@ -258,6 +258,47 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
             div.AppendChild(paragraph);
             return div;
+        }
+
+        /// <summary>
+        /// Each line is parsed as its own XML fragment, so an italic/bold tag spanning a
+        /// line break must be closed at the end of one line and reopened on the next -
+        /// otherwise the parse fails and the markup ends up as literal text.
+        /// </summary>
+        private static List<string> BalanceTagsPerLine(List<string> lines)
+        {
+            var result = new List<string>(lines.Count);
+            var italicOpen = false;
+            var boldOpen = false;
+            foreach (var line in lines)
+            {
+                var current = line;
+                if (italicOpen)
+                {
+                    current = "<i>" + current;
+                }
+
+                if (boldOpen)
+                {
+                    current = "<b>" + current;
+                }
+
+                italicOpen = Utilities.CountTagInText(current, "<i>") > Utilities.CountTagInText(current, "</i>");
+                boldOpen = Utilities.CountTagInText(current, "<b>") > Utilities.CountTagInText(current, "</b>");
+                if (italicOpen)
+                {
+                    current += "</i>";
+                }
+
+                if (boldOpen)
+                {
+                    current += "</b>";
+                }
+
+                result.Add(current);
+            }
+
+            return result;
         }
 
         private static void ConvertParagraphNodeToTtmlNode(XmlNode node, XmlDocument ttmlXml, XmlNode ttmlNode)

--- a/tests/libse/SubtitleFormats/ModernBroadcastFormatsSweepTest.cs
+++ b/tests/libse/SubtitleFormats/ModernBroadcastFormatsSweepTest.cs
@@ -1,0 +1,88 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+
+namespace LibSETests.SubtitleFormats;
+
+/// <summary>
+/// Round-trip regression tests from the modern broadcast formats sweep (IMSC 1.1 family).
+/// </summary>
+public class ModernBroadcastFormatsSweepTest
+{
+    private static Subtitle SaveAndReload(SubtitleFormat format, Subtitle subtitle)
+    {
+        var text = format.ToText(subtitle, "test");
+        var loaded = new Subtitle();
+        format.LoadSubtitle(loaded, text.SplitToLines(), null);
+        return loaded;
+    }
+
+    // Literal angle brackets made the paragraph XML parse fail, and the fallback stripped
+    // every '<' and '>' from the text ("3 < 5 > 2" became "3  5  2").
+    [Fact]
+    public void Imsc11KeepsLiteralAngleBrackets()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Math: 3 < 5 > 2.", 1000, 3000));
+
+        var loaded = SaveAndReload(new TimedTextImsc11(), subtitle);
+
+        Assert.Single(loaded.Paragraphs);
+        Assert.Equal("Math: 3 < 5 > 2.", loaded.Paragraphs[0].Text);
+    }
+
+    // The italic style carried tts:fontFamily="default", which the reader surfaced as a
+    // spurious <font face="default"> tag around every italic run.
+    [Fact]
+    public void Imsc11ItalicRoundTripsWithoutFontTag()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Partial <i>italic word</i> here.", 1000, 3000));
+        subtitle.Paragraphs.Add(new Paragraph("<i>Whole line italic.</i>", 4000, 6000));
+
+        var loaded = SaveAndReload(new TimedTextImsc11(), subtitle);
+
+        Assert.Equal(2, loaded.Paragraphs.Count);
+        Assert.Equal("Partial <i>italic word</i> here.", loaded.Paragraphs[0].Text);
+        Assert.Equal("<i>Whole line italic.</i>", loaded.Paragraphs[1].Text);
+    }
+
+    // Italics were expressed only via tts:shear, invisible to spec-compliant readers -
+    // the italic style must carry tts:fontStyle="italic".
+    [Fact]
+    public void Imsc11ItalicStyleUsesFontStyle()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("<i>Italic.</i>", 1000, 3000));
+
+        var text = new TimedTextImsc11().ToText(subtitle, "test");
+
+        Assert.Contains("tts:fontStyle=\"italic\"", text);
+    }
+
+    // Rosetta parses each line as its own XML fragment; an <i> spanning the line break
+    // made the parse fail and the markup ended up as literal "i" text.
+    [Fact]
+    public void RosettaTwoLineItalicRoundTrips()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("<i>Two italic lines" + Environment.NewLine + "both of them.</i>", 1000, 3000));
+
+        var loaded = SaveAndReload(new TimedTextImscRosetta(), subtitle);
+
+        Assert.Single(loaded.Paragraphs);
+        var normalized = loaded.Paragraphs[0].Text.Replace("</i>" + Environment.NewLine + "<i>", Environment.NewLine);
+        Assert.Equal("<i>Two italic lines" + Environment.NewLine + "both of them.</i>", normalized);
+    }
+
+    [Fact]
+    public void RosettaKeepsLiteralAngleBrackets()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Math: 3 < 5 > 2.", 1000, 3000));
+
+        var loaded = SaveAndReload(new TimedTextImscRosetta(), subtitle);
+
+        Assert.Single(loaded.Paragraphs);
+        Assert.Equal("Math: 3 < 5 > 2.", loaded.Paragraphs[0].Text);
+    }
+}


### PR DESCRIPTION
Follow-up to #13725, extending the broadcast sweep to the **modern formats**: Timed Text IMSC 1.1, IMSC Rosetta, Netflix IMSC 1.1 Japanese, Netflix Timed Text, iTunes Timed Text and ARIB B36 — 263 format×battery round-trip runs, with SE's IMSC output additionally cross-checked against **ttconv**, the IMSC reference implementation.

## Fixes

**IMSC 1.1 and Rosetta silently deleted every literal `<` and `>`.** The paragraph text is parsed as an XML fragment; "3 < 5 > 2" fails that parse and the error path stripped all angle brackets ("3  5  2"). Unknown `<` is now escaped before the parse, so literal brackets survive (the Netflix and iTunes writers already handled this).

**IMSC 1.1 italics were invisible to every other tool.** The writer's italic style used only `tts:shear` (a Netflix-Japanese convention) with no `tts:fontStyle` — ttconv rendered SE's italics as plain text. It also carried `tts:fontFamily="default"`, which SE's own reader surfaced as a spurious `<font face="default">` around every italic run on reload. The style now declares `tts:fontStyle="italic"`, and the generic "default" font family is no longer turned into markup on read.

**Rosetta mangled italics spanning a line break into literal text.** Each line is parsed as its own XML fragment, so `<i>` opened on line one made line one invalid — and the fallback turned the markup into literal `i` / `/i` characters in the subtitle. Tags are now rebalanced per line (close at line end, reopen on the next).

## Verified clean

Netflix IMSC 1.1 Japanese (incl. Japanese text and italics), Netflix Timed Text and iTunes Timed Text round-trip cleanly across all batteries (accents, italics, CJK/RTL scripts, timing edges). After the fixes, ttconv parses SE's IMSC 1.1/Rosetta output with zero warnings and sees the italics, escaped brackets, currency signs and Japanese text correctly.

## Notes

ARIB B36 is load-only in SE (`ToText` is not implemented), so no round-trip applies. Netflix Timed Text and iTunes Timed Text write top/center but not left/right alignment — same "left for later" class as SMPTE-TT 2052 and EBU-TT-D from #13725.

## Tests

5 new regression tests in `ModernBroadcastFormatsSweepTest` (angle brackets ×2, italic font-tag pollution, fontStyle presence, Rosetta cross-line italics).

Full solution builds. All suites pass: libse 1254, seconv 376, libuilogic 229, UI 2968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
