### PR TITLE
Csv DaVinci: fix Play flag read from wrong column

### DIFF
--- a/src/libse/SubtitleFormats/CsvDaVinci.cs
+++ b/src/libse/SubtitleFormats/CsvDaVinci.cs
@@ -31,7 +31,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         p.EndTime.ToHHMMSSFF(),
                         actor,
                         text,
-                        bool.TryParse(p.Effect, out var s) ? s.ToString().ToUpperInvariant() : "False"));
+                        bool.TryParse(p.Effect, out var s) && s ? "True" : "False"));
             }
 
             return sb.ToString().Trim();
@@ -49,7 +49,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     var p = new Paragraph(start, end, line.Text)
                     {
                         Actor = line.Character,
-                        Effect = line.Play.ToString().ToUpperInvariant()
+                        Effect = line.Play ? "True" : "False"
                     };
                     subtitle.Paragraphs.Add(p);
                 }
@@ -126,7 +126,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     csvLine.Text = fields[textIndex];
                 }
 
-                if (playIndex < fields.Count && bool.TryParse(fields[textIndex], out var doPlay))
+                if (playIndex < fields.Count && bool.TryParse(fields[playIndex], out var doPlay))
                 {
                     csvLine.Play = doPlay;
                 }

--- a/tests/libse/SubtitleFormats/CsvDaVinciTest.cs
+++ b/tests/libse/SubtitleFormats/CsvDaVinciTest.cs
@@ -1,0 +1,48 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+
+namespace LibSETests.SubtitleFormats;
+
+public class CsvDaVinciTest
+{
+    private static Subtitle SaveAndReload(Subtitle subtitle)
+    {
+        var format = new CsvDaVinci();
+        var text = format.ToText(subtitle, "test");
+        var loaded = new Subtitle();
+        format.LoadSubtitle(loaded, text.SplitToLines(), null);
+        return loaded;
+    }
+
+    // The reader parsed the Play flag out of the text column instead of the play column,
+    // so an exported "True" always read back as "False".
+    [Fact]
+    public void PlayFlagRoundTrips()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Plays audio.", 1000, 3000) { Effect = "True" });
+        subtitle.Paragraphs.Add(new Paragraph("Does not.", 4000, 6000));
+
+        var loaded = SaveAndReload(subtitle);
+
+        Assert.Equal(2, loaded.Paragraphs.Count);
+        Assert.Equal("True", loaded.Paragraphs[0].Effect);
+        Assert.Equal("False", loaded.Paragraphs[1].Effect);
+    }
+
+    [Fact]
+    public void ActorMultiLineAndQuotesRoundTrip()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Two lines here" + Environment.NewLine + "second line.", 1000, 3000) { Actor = "Anna" });
+        subtitle.Paragraphs.Add(new Paragraph("Quote \"inside\" text, and, commas.", 4000, 6000) { Actor = "Bob" });
+
+        var loaded = SaveAndReload(subtitle);
+
+        Assert.Equal(2, loaded.Paragraphs.Count);
+        Assert.Equal("Two lines here" + Environment.NewLine + "second line.", loaded.Paragraphs[0].Text);
+        Assert.Equal("Anna", loaded.Paragraphs[0].Actor);
+        Assert.Equal("Quote \"inside\" text, and, commas.", loaded.Paragraphs[1].Text);
+        Assert.Equal("Bob", loaded.Paragraphs[1].Actor);
+    }
+}


### PR DESCRIPTION
Round-trip sweep of the DaVinci Resolve subtitle CSV format (follow-up to #13725/#13727).

The reader parsed the Play flag with `bool.TryParse(fields[textIndex])` — the **text** column — so an exported `"True"` always read back as `"False"`. It now reads the play column. The writer also emitted mixed casing (`TRUE` for parsed values, `False` for the default); both sides now use `True`/`False` consistently.

Everything else round-trips clean across the full battery (accents, CJK/RTL scripts, multi-line quoted fields, embedded quotes/commas, Character column, timing edges) — 16 format×battery runs plus detection. Resolve itself isn't installed here, so no live app validation; the schema matches the sample-derived implementation.

Two regression tests added. libse suite passes (1256).

🤖 Generated with [Claude Code](https://claude.com/claude-code)