### PR TITLE
Read the EDLs and XMP markers Adobe tools write, fix Encore/EDL round-trips

### DIFF
--- a/src/libse/SubtitleFormats/AdobeEncoreTabs.cs
+++ b/src/libse/SubtitleFormats/AdobeEncoreTabs.cs
@@ -65,9 +65,15 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 }
                 else
                 {
-                    if (p?.Text.Length < 200)
+                    // Bound by line count, not character count - the old 200-character cap
+                    // silently truncated long (e.g. SDH) cues.
+                    if (p != null && Utilities.GetNumberOfLines(p.Text) < 5)
                     {
                         p.Text = (p.Text + Environment.NewLine + line).Trim();
+                    }
+                    else
+                    {
+                        _errorCount++;
                     }
                 }
             }

--- a/src/libse/SubtitleFormats/AdobePremierePrProj.cs
+++ b/src/libse/SubtitleFormats/AdobePremierePrProj.cs
@@ -34,28 +34,36 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         }
 
         /// <summary>
-        /// Helper method to unpack a .prproj file to a temp xml file
+        /// Unpacks a gzipped .prproj into its XML text (uncompressed project files are
+        /// returned as-is). Returns null when the file is neither.
         /// </summary>
         public static string LoadFromZipFile(string fileName)
         {
-            using (var fileToDecompressAsStream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            try
             {
-                string decompressedFileName = Path.GetTempFileName() + ".xml";
-                using (var decompressedStream = File.Create(decompressedFileName))
+                using (var fileStream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
                 {
-                    using (var decompressionStream = new GZipStream(fileToDecompressAsStream, CompressionMode.Decompress))
+                    var header = new byte[2];
+                    var read = fileStream.Read(header, 0, 2);
+                    fileStream.Position = 0;
+                    if (read == 2 && header[0] == 0x1f && header[1] == 0x8b)
                     {
-                        try
+                        using (var decompressionStream = new GZipStream(fileStream, CompressionMode.Decompress))
+                        using (var reader = new StreamReader(decompressionStream, Encoding.UTF8))
                         {
-                            decompressionStream.CopyTo(decompressedStream);
-                            return decompressedFileName;
-                        }
-                        catch
-                        {
-                            return null;
+                            return reader.ReadToEnd();
                         }
                     }
+
+                    using (var reader = new StreamReader(fileStream, Encoding.UTF8))
+                    {
+                        return reader.ReadToEnd();
+                    }
                 }
+            }
+            catch
+            {
+                return null;
             }
         }
 
@@ -142,8 +150,11 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                                 if (long.TryParse(f.Start, NumberStyles.Integer, CultureInfo.InvariantCulture, out var start) &&
                                     long.TryParse(f.End, NumberStyles.Integer, CultureInfo.InvariantCulture, out var end))
                                 {
-                                    p.StartTime.TotalMilliseconds = start / 200000000.0;
-                                    p.EndTime.TotalMilliseconds = end / 200000000.0;
+                                    // Premiere stores 254016000000 ticks per second, i.e.
+                                    // 254016000 ticks per millisecond (a 4-second clip start
+                                    // is 1016064000000 in a real .prproj)
+                                    p.StartTime.TotalMilliseconds = start / 254016000.0;
+                                    p.EndTime.TotalMilliseconds = end / 254016000.0;
                                 }
                             }
                             subtitle.Paragraphs.Add(p);

--- a/src/libse/SubtitleFormats/Edl.cs
+++ b/src/libse/SubtitleFormats/Edl.cs
@@ -19,33 +19,31 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             var sb = new StringBuilder();
             sb.AppendLine("TITLE: " + title);
-            if (Configuration.Settings.General.CurrentFrameRate % 1.0 > 0.01)
-            {
-                sb.AppendLine("FCM: NON-DROP FRAME");
-            }
-            else
-            {
-                sb.AppendLine("FCM: DROP FRAME");
-            }
+            // Time codes are written with ':' separators and no drop-frame arithmetic, which
+            // is non-drop time code at every frame rate (the old header said DROP FRAME for
+            // integer rates - exactly backwards, and NLEs trust this line).
+            sb.AppendLine("FCM: NON-DROP FRAME");
 
             sb.AppendLine();
             const string writeFormat = "{0:000000}  {1}       {2}     {3}        {4} {5} {6} {7}";
+            var eventNumber = 0;
             for (int index = 0; index < subtitle.Paragraphs.Count; index++)
             {
-                int no = index + 1;
                 var p = subtitle.Paragraphs[index];
                 if (index == 0 && p.StartTime.TotalSeconds > 1)
                 {
                     var start = new TimeCode(p.StartTime.TotalMilliseconds - 1000.0);
                     var end = new TimeCode(p.StartTime.TotalMilliseconds - 1);
-                    sb.AppendLine(string.Format(writeFormat, no, "BL", "V", "C", EncodeTimeCode(start), EncodeTimeCode(end), EncodeTimeCode(start), EncodeTimeCode(end)));
+                    eventNumber++;
+                    sb.AppendLine(string.Format(writeFormat, eventNumber, "BL", "V", "C", EncodeTimeCode(start), EncodeTimeCode(end), EncodeTimeCode(start), EncodeTimeCode(end)));
                     sb.AppendLine();
                 }
                 var text = HtmlUtil.RemoveHtmlTags(p.Text, true);
-                sb.AppendLine(string.Format(writeFormat, no, "AX", "V", "C", EncodeTimeCode(p.StartTime), EncodeTimeCode(p.EndTime), EncodeTimeCode(p.StartTime), EncodeTimeCode(p.EndTime)));
+                eventNumber++;
+                sb.AppendLine(string.Format(writeFormat, eventNumber, "AX", "V", "C", EncodeTimeCode(p.StartTime), EncodeTimeCode(p.EndTime), EncodeTimeCode(p.StartTime), EncodeTimeCode(p.EndTime)));
                 sb.AppendLine(TextPrefix + text);
                 sb.AppendLine();
-                var next = subtitle.GetParagraphOrDefault(no);
+                var next = subtitle.GetParagraphOrDefault(index + 1);
                 if (next != null && next.StartTime.TotalMilliseconds > p.EndTime.TotalMilliseconds + 100)
                 {
                     var start = new TimeCode(p.EndTime.TotalMilliseconds + 1);
@@ -54,7 +52,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     {
                         end = new TimeCode(next.StartTime.TotalMilliseconds - 1);
                     }
-                    sb.AppendLine(string.Format(writeFormat, no, "BL", "V", "C", EncodeTimeCode(start), EncodeTimeCode(end), EncodeTimeCode(start), EncodeTimeCode(end)));
+                    eventNumber++;
+                    sb.AppendLine(string.Format(writeFormat, eventNumber, "BL", "V", "C", EncodeTimeCode(start), EncodeTimeCode(end), EncodeTimeCode(start), EncodeTimeCode(end)));
                     sb.AppendLine();
                 }
             }
@@ -73,12 +72,20 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             Paragraph lastParagraph = null;
             int count = 0;
             var splitChar = new[] { ' ' };
-            foreach (string line in lines)
+            foreach (string rawLine in lines)
             {
+                // NLEs pad event rows with trailing spaces (Premiere, Avid, Nucoda all do)
+                var line = rawLine.TrimEnd();
                 bool isTimeCode = false;
                 if (line.Length > 0)
                 {
                     bool success = false;
+                    if (IsSkippableComment(line))
+                    {
+                        count++;
+                        continue;
+                    }
+
                     if (line.Length > 65 && line.Length < 500 && line.IndexOf(':') > 20)
                     {
                         var match = Regex.Match(line);
@@ -129,13 +136,46 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
             foreach (var paragraph in subtitle.Paragraphs)
             {
-                if (paragraph.Text.StartsWith(TextPrefix, StringComparison.Ordinal))
-                {
-                    paragraph.Text = paragraph.Text.Remove(0, TextPrefix.Length).TrimStart();
-                }
+                paragraph.Text = StripClipNamePrefix(paragraph.Text);
             }
 
             subtitle.Renumber();
+        }
+
+        /// <summary>
+        /// EDL comment/metadata lines that must not leak into the cue text: any "*" comment
+        /// except the clip name (Avid writes "* FROM CLIP: path", Nucoda "* FROM FILE: path",
+        /// screening EDLs "*SOURCE FILE: ..."), and M2 motion-memory lines.
+        /// </summary>
+        private static bool IsSkippableComment(string line)
+        {
+            if (line.StartsWith("M2", StringComparison.Ordinal) && line.Length > 2 && line[2] == ' ')
+            {
+                return true;
+            }
+
+            if (!line.StartsWith('*'))
+            {
+                return false;
+            }
+
+            var body = line.TrimStart('*').TrimStart();
+            return !body.StartsWith("FROM CLIP NAME:", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// The clip name line appears in the wild as "* FROM CLIP NAME: ", "*FROM CLIP NAME: "
+        /// and bare "FROM CLIP NAME: ".
+        /// </summary>
+        private static string StripClipNamePrefix(string text)
+        {
+            var s = text.TrimStart('*').TrimStart();
+            if (s.StartsWith("FROM CLIP NAME:", StringComparison.OrdinalIgnoreCase))
+            {
+                return s.Remove(0, "FROM CLIP NAME:".Length).TrimStart();
+            }
+
+            return text;
         }
 
     }

--- a/src/libse/SubtitleFormats/SubtitleFormat.cs
+++ b/src/libse/SubtitleFormats/SubtitleFormat.cs
@@ -89,6 +89,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     new AdobeAfterEffectsFTME(),
                     new AdobeEncore(),
                     new AdobeEncoreLineTabNewLine(),
+                    new AdobeEncoreLineTabs(),
                     new AdobeEncoreTabs(),
                     new AdobeEncoreWithLineNumbers(),
                     new AdobeEncoreWithLineNumbersNtsc(),

--- a/src/libse/SubtitleFormats/Xmp.cs
+++ b/src/libse/SubtitleFormats/Xmp.cs
@@ -26,7 +26,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
       <xmpDM:Tracks>
         <rdf:Bag>
           <rdf:li rdf:parseType='Resource'>
-            <xmpDM:frameRate>f25</xmpDM:frameRate>
+            <xmpDM:frameRate>" + GetFrameRateString() + @"</xmpDM:frameRate>
             <xmpDM:markers>
               <rdf:Seq>
               </rdf:Seq>
@@ -54,6 +54,63 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
 
             return ToUtf8XmlString(xml);
+        }
+
+        /// <summary>
+        /// xmpDM:frameRate for the marker times we write: "f25" style for integer rates,
+        /// "f24000s1001" style for NTSC rates. The old header hardcoded f25 while the
+        /// marker times were written at the current frame rate, so any other rate gave
+        /// Adobe apps wrong times.
+        /// </summary>
+        private static string GetFrameRateString()
+        {
+            var rate = Configuration.Settings.General.CurrentFrameRate;
+            if (Math.Abs(rate - 23.976) < 0.01)
+            {
+                return "f24000s1001";
+            }
+
+            if (Math.Abs(rate - 29.97) < 0.01)
+            {
+                return "f30000s1001";
+            }
+
+            if (Math.Abs(rate - 59.94) < 0.01)
+            {
+                return "f60000s1001";
+            }
+
+            return "f" + Math.Round(rate).ToString(CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Parses xmpDM:frameRate values like "f25", "f24000s1001" or Premiere's tick-based
+        /// "f254016000000". Returns false when absent/unparseable.
+        /// </summary>
+        public static bool TryParseFrameRate(string input, out double numerator, out double denominator)
+        {
+            numerator = 0;
+            denominator = 1;
+            if (string.IsNullOrEmpty(input) || input.Length < 2 || input[0] != 'f')
+            {
+                return false;
+            }
+
+            var arr = input.Substring(1).Split('s');
+            if (arr.Length > 2 || !long.TryParse(arr[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var num) || num <= 0)
+            {
+                return false;
+            }
+
+            long den = 1;
+            if (arr.Length == 2 && (!long.TryParse(arr[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out den) || den <= 0))
+            {
+                return false;
+            }
+
+            numerator = num;
+            denominator = den;
+            return true;
         }
 
         private XmlNode CreateParagraphElement(XmlDocument xml, Paragraph paragraph)
@@ -114,8 +171,26 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     var textNode = node.SelectSingleNode("xmpDM:comment", namespaceManager);
                     if (startTimeNode != null && durationNode != null && textNode != null)
                     {
-                        double start = FramesToMilliseconds(Convert.ToDouble(startTimeNode.InnerText, CultureInfo.InvariantCulture));
-                        double end = start + FramesToMilliseconds(Convert.ToDouble(durationNode.InnerText, CultureInfo.InvariantCulture));
+                        var startValue = Convert.ToDouble(startTimeNode.InnerText, CultureInfo.InvariantCulture);
+                        var durationValue = Convert.ToDouble(durationNode.InnerText, CultureInfo.InvariantCulture);
+
+                        // Honor the track's declared frame rate - Premiere writes marker
+                        // times as ticks with frameRate "f254016000000", which read as
+                        // frame numbers would be off by ten orders of magnitude.
+                        double start;
+                        double end;
+                        var frameRateNode = node.SelectSingleNode("ancestor::rdf:li/xmpDM:frameRate", namespaceManager);
+                        if (frameRateNode != null && TryParseFrameRate(frameRateNode.InnerText, out var numerator, out var denominator))
+                        {
+                            start = startValue * 1000.0 * denominator / numerator;
+                            end = start + durationValue * 1000.0 * denominator / numerator;
+                        }
+                        else
+                        {
+                            start = FramesToMilliseconds(startValue);
+                            end = start + FramesToMilliseconds(durationValue);
+                        }
+
                         string text = textNode.InnerText;
                         subtitle.Paragraphs.Add(new Paragraph(text, start, end));
                     }

--- a/tests/libse/SubtitleFormats/AdobeFormatsSweepTest.cs
+++ b/tests/libse/SubtitleFormats/AdobeFormatsSweepTest.cs
@@ -1,0 +1,247 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+
+namespace LibSETests.SubtitleFormats;
+
+/// <summary>
+/// Adobe format compatibility sweep - round-trips plus real-world EDL/XMP shapes
+/// (Premiere, Avid and Nucoda EDL exports; Premiere tick-based XMP markers).
+/// </summary>
+public class AdobeFormatsSweepTest
+{
+    private static Subtitle MakeReference()
+    {
+        var s = new Subtitle();
+        s.Paragraphs.Add(new Paragraph("Hello, Adobe world!", 1000, 3000));
+        s.Paragraphs.Add(new Paragraph("Second line" + Environment.NewLine + "with a line break.", 4000, 6500));
+        return s;
+    }
+
+    // NLEs pad EDL event rows with trailing spaces (Premiere, Avid and Nucoda all do) -
+    // the row regex used to demand the last time code at end-of-line, so whole files
+    // fell through to the unknown-format importer as garbage.
+    [Fact]
+    public void EdlToleratesTrailingSpacesOnEventRows()
+    {
+        var lines = new List<string>
+        {
+            "TITLE:   gap test",
+            "FCM: NON-DROP FRAME",
+            "001  SHOT1    V     C        00:10:00:00 00:10:01:00 00:00:00:00 00:00:01:00 ",
+            "FROM CLIP NAME: shot1",
+            "002  SHOT2    V     C        23:00:00:00 23:00:01:00 00:00:01:16 00:00:02:16 ",
+            "FROM CLIP NAME: shot2",
+        };
+        var format = new Edl();
+        Assert.True(format.IsMine(lines, "gap_test.edl"));
+
+        var subtitle = new Subtitle();
+        format.LoadSubtitle(subtitle, lines, "gap_test.edl");
+        Assert.Equal(2, subtitle.Paragraphs.Count);
+        Assert.Equal("shot1", subtitle.Paragraphs[0].Text);
+        Assert.Equal("shot2", subtitle.Paragraphs[1].Text);
+    }
+
+    // Avid writes "* FROM CLIP: path", Nucoda "* FROM FILE: path", screening EDLs
+    // "*SOURCE FILE: ..." - those comment lines must not leak into the cue text, and
+    // the clip name prefix appears with "* ", "*" and no prefix at all.
+    [Fact]
+    public void EdlSkipsCommentLinesAndStripsClipNamePrefixVariants()
+    {
+        var lines = new List<string>
+        {
+            "TITLE:   Avid_Example.01",
+            "001  ZZ100_50 V     C        01:00:04:05 01:00:05:12 00:59:53:11 00:59:54:18",
+            "* FROM CLIP NAME:  take_1",
+            "* FROM CLIP: S:\\path\\to\\ZZ100_501.take_1.0001.exr",
+            "002  ZZ100_50 V     C        01:00:06:13 01:00:08:15 00:59:54:18 00:59:56:20",
+            "*FROM CLIP NAME:  take_2",
+            "*SOURCE FILE: ZZ100_502A.LAY3.01",
+        };
+        var format = new Edl();
+        var subtitle = new Subtitle();
+        format.LoadSubtitle(subtitle, lines, "avid.edl");
+        Assert.Equal(2, subtitle.Paragraphs.Count);
+        Assert.Equal("take_1", subtitle.Paragraphs[0].Text);
+        Assert.Equal("take_2", subtitle.Paragraphs[1].Text);
+    }
+
+    // SE writes ':' time codes with no drop-frame arithmetic - that is non-drop time
+    // code at every rate. The old header said DROP FRAME for integer rates (backwards),
+    // and BL filler events reused the neighboring cue's event number.
+    [Fact]
+    public void EdlWritesNonDropHeaderAndSequentialEventNumbers()
+    {
+        var s = new Subtitle();
+        s.Paragraphs.Add(new Paragraph("One", 5000, 7000));    // >1s start => leading BL
+        s.Paragraphs.Add(new Paragraph("Two", 10000, 12000));  // gap => BL between
+        var raw = new Edl().ToText(s, "title");
+
+        Assert.Contains("FCM: NON-DROP FRAME", raw);
+        Assert.DoesNotContain("DROP FRAME\r\nFCM", raw);
+
+        var eventNumbers = raw.SplitToLines()
+            .Where(l => l.Length > 6 && char.IsDigit(l[0]))
+            .Select(l => int.Parse(l.Substring(0, 6)))
+            .ToList();
+        Assert.Equal(new List<int> { 1, 2, 3, 4 }, eventNumbers);
+
+        var reloaded = new Subtitle();
+        new Edl().LoadSubtitle(reloaded, raw.SplitToLines(), "file.edl");
+        Assert.Equal(2, reloaded.Paragraphs.Count);
+        Assert.Equal("One", reloaded.Paragraphs[0].Text);
+    }
+
+    // The loader used to cap continuation lines at 200 characters of accumulated text,
+    // silently truncating long (e.g. SDH) cues.
+    [Fact]
+    public void AdobeEncoreTabsKeepsLongCues()
+    {
+        var longLine1 = new string('a', 150);
+        var longLine2 = new string('b', 150);
+        var s = new Subtitle();
+        s.Paragraphs.Add(new Paragraph(longLine1 + Environment.NewLine + longLine2, 1000, 3000));
+        var format = new AdobeEncoreTabs();
+        var raw = format.ToText(s, "title");
+
+        var reloaded = new Subtitle();
+        format.LoadSubtitle(reloaded, raw.SplitToLines(), "file.txt");
+        Assert.Single(reloaded.Paragraphs);
+        Assert.Equal(longLine1 + Environment.NewLine + longLine2, reloaded.Paragraphs[0].Text);
+    }
+
+    // AdobeEncoreLineTabs existed but was never registered in AllSubtitleFormats, so its
+    // own file shape had no handler.
+    [Fact]
+    public void AdobeEncoreLineTabsIsRegisteredAndRoundTrips()
+    {
+        var format = new AdobeEncoreLineTabs();
+        var s = new Subtitle();
+        s.Paragraphs.Add(new Paragraph("<i>Italic</i> start", 1000, 3000));
+        s.Paragraphs.Add(new Paragraph("Second line" + Environment.NewLine + "with a line break.", 4000, 6500));
+        var raw = format.ToText(s, "title");
+
+        var parsed = Subtitle.Parse(raw.SplitToLines(), ".txt");
+        Assert.NotNull(parsed);
+        Assert.Equal(format.Name, parsed.OriginalFormat.Name);
+        Assert.Equal(2, parsed.Paragraphs.Count);
+        Assert.Equal("<i>Italic</i> start", parsed.Paragraphs[0].Text);
+        Assert.Equal("Second line" + Environment.NewLine + "with a line break.", parsed.Paragraphs[1].Text);
+    }
+
+    // Premiere stores 254016000000 ticks per second; a real .prproj puts a 4-second
+    // clip start at 1016064000000. The old conversion divided by 200000000 - both the
+    // wrong constant and ~27% off.
+    [Fact]
+    public void AdobePremierePrProjConvertsTicksCorrectly()
+    {
+        var xml = """
+            <PremiereData Version="3">
+              <VideoComponentChain ObjectID="10">
+                <ComponentChain>
+                  <Components>
+                    <Component ObjectRef="20"/>
+                  </Components>
+                </ComponentChain>
+              </VideoComponentChain>
+              <VideoClipTrackItem ObjectID="30">
+                <ClipTrackItem>
+                  <ComponentOwner>
+                    <Components ObjectRef="10"/>
+                  </ComponentOwner>
+                  <TrackItem>
+                    <Start>1016064000000</Start>
+                    <End>1524096000000</End>
+                  </TrackItem>
+                </ClipTrackItem>
+              </VideoClipTrackItem>
+              <VideoFilterComponent ObjectID="20">
+                <Component>
+                  <DisplayName>Text</DisplayName>
+                  <InstanceName>Hello title</InstanceName>
+                </Component>
+              </VideoFilterComponent>
+            </PremiereData>
+            """;
+        var subtitle = new Subtitle();
+        new AdobePremierePrProj().LoadSubtitle(subtitle, xml.SplitToLines(), "x.xml");
+        Assert.Single(subtitle.Paragraphs);
+        Assert.Equal("Hello title", subtitle.Paragraphs[0].Text);
+        Assert.Equal(4000, subtitle.Paragraphs[0].StartTime.TotalMilliseconds, 1.0);
+        Assert.Equal(6000, subtitle.Paragraphs[0].EndTime.TotalMilliseconds, 1.0);
+    }
+
+    // Premiere writes XMP marker times as ticks with frameRate "f254016000000" - read
+    // as frame numbers they would be off by ten orders of magnitude.
+    [Fact]
+    public void XmpHonorsDeclaredTickFrameRate()
+    {
+        var xmp = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <x:xmpmeta xmlns:x="adobe:ns:meta/">
+              <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+                <rdf:Description rdf:about="" xmlns:xmpDM="http://ns.adobe.com/xmp/1.0/DynamicMedia/">
+                  <xmpDM:Tracks>
+                    <rdf:Bag>
+                      <rdf:li rdf:parseType="Resource">
+                        <xmpDM:frameRate>f254016000000</xmpDM:frameRate>
+                        <xmpDM:markers>
+                          <rdf:Seq>
+                            <rdf:li rdf:parseType="Resource">
+                              <xmpDM:startTime>1016064000000</xmpDM:startTime>
+                              <xmpDM:duration>508032000000</xmpDM:duration>
+                              <xmpDM:comment>Marker at four seconds</xmpDM:comment>
+                            </rdf:li>
+                          </rdf:Seq>
+                        </xmpDM:markers>
+                      </rdf:li>
+                    </rdf:Bag>
+                  </xmpDM:Tracks>
+                </rdf:Description>
+              </rdf:RDF>
+            </x:xmpmeta>
+            """;
+        var subtitle = new Subtitle();
+        new Xmp().LoadSubtitle(subtitle, xmp.SplitToLines(), "markers.xmp");
+        Assert.Single(subtitle.Paragraphs);
+        Assert.Equal("Marker at four seconds", subtitle.Paragraphs[0].Text);
+        Assert.Equal(4000, subtitle.Paragraphs[0].StartTime.TotalMilliseconds, 1.0);
+        Assert.Equal(6000, subtitle.Paragraphs[0].EndTime.TotalMilliseconds, 1.0);
+    }
+
+    // The header used to hardcode f25 while the marker times were written at the current
+    // frame rate - Adobe apps then read wrong times at any other rate.
+    [Fact]
+    public void XmpDeclaresTheFrameRateItWritesWith()
+    {
+        var savedRate = Configuration.Settings.General.CurrentFrameRate;
+        try
+        {
+            Configuration.Settings.General.CurrentFrameRate = 29.97;
+            var format = new Xmp();
+            var raw = format.ToText(MakeReference(), "title");
+            Assert.Contains("<xmpDM:frameRate>f30000s1001</xmpDM:frameRate>", raw);
+
+            var reloaded = new Subtitle();
+            format.LoadSubtitle(reloaded, raw.SplitToLines(), "file.xmp");
+            Assert.Equal(2, reloaded.Paragraphs.Count);
+            Assert.Equal(1000, reloaded.Paragraphs[0].StartTime.TotalMilliseconds, 40.0);
+            Assert.Equal(3000, reloaded.Paragraphs[0].EndTime.TotalMilliseconds, 40.0);
+        }
+        finally
+        {
+            Configuration.Settings.General.CurrentFrameRate = savedRate;
+        }
+    }
+
+    [Theory]
+    [InlineData("f25", 25, 1)]
+    [InlineData("f24000s1001", 24000, 1001)]
+    [InlineData("f254016000000", 254016000000, 1)]
+    public void XmpFrameRateParsing(string input, double expectedNumerator, double expectedDenominator)
+    {
+        Assert.True(Xmp.TryParseFrameRate(input, out var numerator, out var denominator));
+        Assert.Equal(expectedNumerator, numerator);
+        Assert.Equal(expectedDenominator, denominator);
+    }
+}


### PR DESCRIPTION
Companion to the Apple sweep (#13719), this time for the Adobe ecosystem: Premiere Pro, Encore, After Effects, and the XMP marker format Premiere/Audition share.

## Method

Every Adobe-family format exported from a reference subtitle and re-imported through `Subtitle.Parse` (the app's own dispatch), plus real-world input: the OpenTimelineIO CMX 3600 test corpus (EDLs exported by **Premiere**, **Avid** and **Nucoda**), a real `.prproj` (which pins Premiere's tick rate: a 4-second clip start is stored as 1016064000000), and a Premiere-shaped tick-based XMP marker file. The After Effects ft-MarkerExporter XML and all five registered Encore variants round-tripped cleanly from the start — the defects were all in EDL, XMP, and the two unregistered classes.

## EDL (Premiere's exchange format)

- **Three of seven real EDLs imported as garbage.** NLEs pad event rows with trailing spaces; the row regex demanded the last time code at end-of-line, so whole files fell through to the unknown-format importer, which turned raw EDL rows into cue text.
- **Comment lines leaked into cue text**: Avid's `* FROM CLIP: path`, Nucoda's `* FROM FILE: path`, screening-EDL `*SOURCE FILE:` and `M2` motion lines are now skipped, and the clip name parses in all three wild prefix variants (`* FROM CLIP NAME:`, `*FROM CLIP NAME:`, bare).
- **The FCM header was inverted**: integer rates wrote `DROP FRAME` and 29.97 wrote `NON-DROP FRAME` — backwards, and NLEs trust this line. SE writes colon time codes with no drop-frame arithmetic, which is non-drop at every rate, so the header now always says `NON-DROP FRAME`.
- **BL filler events reused the neighboring cue's event number**; CMX 3600 numbers events sequentially.

All seven corpus EDLs (plus SE's own export) now import with clean clip-name text and correct record times.

## XMP markers (Premiere / Audition)

Export hardcoded `frameRate f25` while writing marker times at the current frame rate — Adobe apps then read wrong times at any other rate; the header now declares the rate actually used (`f30000s1001` style for NTSC rates). Import ignored the declared frame rate entirely, so real Premiere markers — written as ticks with `frameRate="f254016000000"` — parsed as frame numbers, off by ten orders of magnitude. Both directions now honor `xmpDM:frameRate`; the tick-based fixture imports at exactly 4 s/8 s.

## Encore

- **`AdobeEncoreLineTabs` was complete but never registered** (an SE4 porting omission) — files in its shape (`0001\tHH:MM:SS:FF\t…`) had no handler. Registered next to its siblings; round-trips with italics, no detection contention against the rest of the corpus.
- **`AdobeEncoreTabs` silently truncated cues at 200 characters** of accumulated text; now bounded by line count (≤5, as the EDL reader does) so long SDH cues survive.

## AdobePremierePrProj (left dormant, but no longer wrong)

The class stays unregistered — it only parses CS-era title components, and no public fixture with Premiere text exists to validate a UI wiring against. But its two clear defects are fixed so any future wiring starts correct: the tick conversion divided by 200000000 (~27% off and in the wrong unit; Premiere stores 254016000000 ticks/second, confirmed against the real project file), and the gunzip helper leaked two temp files per call — it now decompresses in memory and passes uncompressed project XML through.

## Tests

11 new tests in `AdobeFormatsSweepTest`: the three real-world EDL shapes, FCM header + sequential event numbers, the Encore truncation and registration fixes, prproj tick conversion against the real-file anchor, tick-based XMP import, XMP declared-rate round-trip, and frame-rate string parsing.

Full solution builds. All suites pass: libse 1260, seconv 376, libuilogic 230, UI 2968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)