### PR TITLE
Add DaVinci Resolve marker EDL import/export

### DIFF
--- a/src/libse/SubtitleFormats/DaVinciResolveMarkerEdl.cs
+++ b/src/libse/SubtitleFormats/DaVinciResolveMarkerEdl.cs
@@ -1,0 +1,148 @@
+using Nikse.SubtitleEdit.Core.Common;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Nikse.SubtitleEdit.Core.SubtitleFormats
+{
+    /// <summary>
+    /// Timeline markers as exported/imported by DaVinci Resolve via
+    /// "Timelines &gt; Export/Import &gt; Timeline Markers to/from EDL".
+    /// Each marker is a one-frame CMX event followed by a comment line:
+    ///   001  001      V     C        01:00:05:00 01:00:05:01 01:00:05:00 01:00:05:01
+    ///    |C:ResolveColorBlue |M:Marker name |D:120
+    /// where C is the marker color, M the marker name and D the duration in frames.
+    /// </summary>
+    public class DaVinciResolveMarkerEdl : SubtitleFormat
+    {
+        private static readonly Regex EventLineRegex = new Regex(@"^\d{1,6}\s+\S+\s+V\s+C\s+(\d\d:\d\d:\d\d[:;]\d\d)\s+(\d\d:\d\d:\d\d[:;]\d\d)\s+(\d\d:\d\d:\d\d[:;]\d\d)\s+(\d\d:\d\d:\d\d[:;]\d\d)\s*$", RegexOptions.Compiled);
+
+        public override string Extension => ".edl";
+
+        public const string NameOfFormat = "DaVinci Resolve Marker EDL";
+
+        public override string Name => NameOfFormat;
+
+        public override bool IsMine(List<string> lines, string fileName)
+        {
+            if (fileName != null && !fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            var hasMarkerLine = false;
+            foreach (var line in lines)
+            {
+                if (line.Contains("|M:", StringComparison.Ordinal))
+                {
+                    hasMarkerLine = true;
+                    break;
+                }
+            }
+
+            if (!hasMarkerLine)
+            {
+                return false;
+            }
+
+            return base.IsMine(lines, fileName);
+        }
+
+        public override string ToText(Subtitle subtitle, string title)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("TITLE: " + title);
+            sb.AppendLine(Configuration.Settings.General.CurrentFrameRate % 1.0 > 0.01 ? "FCM: DROP FRAME" : "FCM: NON-DROP FRAME");
+            sb.AppendLine();
+
+            for (var index = 0; index < subtitle.Paragraphs.Count; index++)
+            {
+                var p = subtitle.Paragraphs[index];
+                var start = EncodeTimeCode(p.StartTime);
+                var startPlusOne = EncodeTimeCode(new TimeCode(p.StartTime.TotalMilliseconds + FramesToMilliseconds(1)));
+                var durationFrames = Math.Max(1, MillisecondsToFrames(p.DurationTotalMilliseconds));
+                var name = HtmlUtil.RemoveHtmlTags(p.Text, true)
+                    .Replace(Environment.NewLine, " ")
+                    .Replace("|", " ")
+                    .Trim();
+
+                sb.AppendLine($"{index + 1:000}  001      V     C        {start} {startPlusOne} {start} {startPlusOne}  ");
+                sb.AppendLine($" |C:ResolveColorBlue |M:{name} |D:{durationFrames.ToString(CultureInfo.InvariantCulture)}");
+                sb.AppendLine();
+            }
+
+            return sb.ToString().Trim() + Environment.NewLine;
+        }
+
+        private static string EncodeTimeCode(TimeCode timeCode)
+        {
+            return $"{timeCode.Hours:00}:{timeCode.Minutes:00}:{timeCode.Seconds:00}:{MillisecondsToFramesMaxFrameRate(timeCode.Milliseconds):00}";
+        }
+
+        public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
+        {
+            _errorCount = 0;
+            subtitle.Paragraphs.Clear();
+            TimeCode pendingStart = null;
+
+            foreach (var rawLine in lines)
+            {
+                var line = rawLine.TrimEnd();
+                var match = EventLineRegex.Match(line);
+                if (match.Success)
+                {
+                    try
+                    {
+                        // Record-in carries the marker's timeline position
+                        pendingStart = DecodeTimeCodeFrames(match.Groups[3].Value.Replace(';', ':'), SplitCharColon);
+                    }
+                    catch
+                    {
+                        pendingStart = null;
+                        _errorCount++;
+                    }
+
+                    continue;
+                }
+
+                var markerIndex = line.IndexOf("|M:", StringComparison.Ordinal);
+                if (markerIndex < 0 || pendingStart == null)
+                {
+                    continue;
+                }
+
+                var durationFrames = 0;
+                var durationIndex = line.LastIndexOf("|D:", StringComparison.Ordinal);
+                string name;
+                if (durationIndex > markerIndex)
+                {
+                    name = line.Substring(markerIndex + 3, durationIndex - markerIndex - 3).Trim();
+                    var durationText = line.Substring(durationIndex + 3).Trim();
+                    int.TryParse(durationText, NumberStyles.Integer, CultureInfo.InvariantCulture, out durationFrames);
+                }
+                else
+                {
+                    name = line.Substring(markerIndex + 3).Trim();
+                }
+
+                var p = new Paragraph(pendingStart, new TimeCode(pendingStart.TotalMilliseconds), name);
+                if (durationFrames > 1)
+                {
+                    p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + FramesToMilliseconds(durationFrames);
+                }
+                else
+                {
+                    // A plain marker is one frame long - give it a readable display time
+                    p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + Utilities.GetOptimalDisplayMilliseconds(name);
+                }
+
+                subtitle.Paragraphs.Add(p);
+                pendingStart = null;
+            }
+
+            subtitle.Renumber();
+        }
+    }
+}

--- a/src/libse/SubtitleFormats/Edl.cs
+++ b/src/libse/SubtitleFormats/Edl.cs
@@ -21,11 +21,12 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             sb.AppendLine("TITLE: " + title);
             if (Configuration.Settings.General.CurrentFrameRate % 1.0 > 0.01)
             {
-                sb.AppendLine("FCM: NON-DROP FRAME");
+                // Fractional NTSC rates (29.97/59.94) use drop-frame time code
+                sb.AppendLine("FCM: DROP FRAME");
             }
             else
             {
-                sb.AppendLine("FCM: DROP FRAME");
+                sb.AppendLine("FCM: NON-DROP FRAME");
             }
 
             sb.AppendLine();

--- a/src/libse/SubtitleFormats/SubtitleFormat.cs
+++ b/src/libse/SubtitleFormats/SubtitleFormat.cs
@@ -135,6 +135,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     new EdiusMarkerList2Ms(),
                     new EdiusMarkerList3Frames(),
                     new EdiusMarkerList3Ms(),
+                    new DaVinciResolveMarkerEdl(), // before Edl - the generic EDL would claim marker files with garbage text
                     new Edl(),
                     new Eeg708(),
                     new ElrPrint(),

--- a/tests/libse/SubtitleFormats/DaVinciResolveMarkerEdlTest.cs
+++ b/tests/libse/SubtitleFormats/DaVinciResolveMarkerEdlTest.cs
@@ -1,0 +1,95 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+
+namespace LibSETests.SubtitleFormats;
+
+public class DaVinciResolveMarkerEdlTest
+{
+    private const string ResolveSample = """
+TITLE: Timeline 1
+FCM: NON-DROP FRAME
+
+001  001      V     C        01:00:05:00 01:00:05:01 01:00:05:00 01:00:05:01
+ |C:ResolveColorCyan |M:First marker |D:120
+
+002  001      V     C        01:00:10:12 01:00:10:13 01:00:10:12 01:00:10:13
+ |C:ResolveColorBlue |M:Second one |D:1
+""";
+
+    [Fact]
+    public void LoadsResolveMarkerExport()
+    {
+        var oldFrameRate = Configuration.Settings.General.CurrentFrameRate;
+        Configuration.Settings.General.CurrentFrameRate = 25;
+        try
+        {
+            var subtitle = new Subtitle();
+            new DaVinciResolveMarkerEdl().LoadSubtitle(subtitle, ResolveSample.SplitToLines(), null);
+
+            Assert.Equal(2, subtitle.Paragraphs.Count);
+            Assert.Equal("First marker", subtitle.Paragraphs[0].Text);
+            Assert.Equal(new TimeCode(1, 0, 5, 0).TotalMilliseconds, subtitle.Paragraphs[0].StartTime.TotalMilliseconds, 3);
+            Assert.Equal(120 * 40, subtitle.Paragraphs[0].DurationTotalMilliseconds, 3); // |D:120 frames at 25 fps
+            Assert.Equal("Second one", subtitle.Paragraphs[1].Text);
+        }
+        finally
+        {
+            Configuration.Settings.General.CurrentFrameRate = oldFrameRate;
+        }
+    }
+
+    [Fact]
+    public void RoundTripsTimesAndText()
+    {
+        var oldFrameRate = Configuration.Settings.General.CurrentFrameRate;
+        Configuration.Settings.General.CurrentFrameRate = 25;
+        try
+        {
+            var subtitle = new Subtitle();
+            subtitle.Paragraphs.Add(new Paragraph("Chapter one starts.", 5000, 8000));
+            subtitle.Paragraphs.Add(new Paragraph("Late marker.", 3600000, 3603000));
+
+            var format = new DaVinciResolveMarkerEdl();
+            var text = format.ToText(subtitle, "Timeline 1");
+            var loaded = new Subtitle();
+            format.LoadSubtitle(loaded, text.SplitToLines(), null);
+
+            Assert.Equal(2, loaded.Paragraphs.Count);
+            Assert.Equal("Chapter one starts.", loaded.Paragraphs[0].Text);
+            Assert.Equal(5000, loaded.Paragraphs[0].StartTime.TotalMilliseconds, 3);
+            Assert.Equal(8000, loaded.Paragraphs[0].EndTime.TotalMilliseconds, 3);
+            Assert.Equal(3600000, loaded.Paragraphs[1].StartTime.TotalMilliseconds, 3);
+        }
+        finally
+        {
+            Configuration.Settings.General.CurrentFrameRate = oldFrameRate;
+        }
+    }
+
+    [Fact]
+    public void MarkerEdlWinsDetectionAndCutListStaysEdl()
+    {
+        var markerLines = ResolveSample.SplitToLines();
+        foreach (var format in SubtitleFormat.AllSubtitleFormats)
+        {
+            if (format.IsMine(markerLines, "markers.edl"))
+            {
+                Assert.Equal(DaVinciResolveMarkerEdl.NameOfFormat, format.Name);
+                break;
+            }
+        }
+
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("A line of text here.", 1000, 3000));
+        subtitle.Paragraphs.Add(new Paragraph("Another line of text.", 4000, 6000));
+        var cutList = new Edl().ToText(subtitle, "t").SplitToLines();
+        foreach (var format in SubtitleFormat.AllSubtitleFormats)
+        {
+            if (format.IsMine(cutList, "cut.edl"))
+            {
+                Assert.Equal(new Edl().Name, format.Name);
+                break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to the DaVinci sweep (#13728): the biggest missing Resolve integration was **timeline markers**.

DaVinci Resolve exchanges timeline markers as an EDL (`Timelines > Export/Import > Timeline Markers to/from EDL`) — one-frame CMX events with a comment line carrying the marker: ` |C:ResolveColorBlue |M:Marker name |D:120` (color, name, duration in frames). The shape is stable across Resolve versions and widely relied on by community tooling.

SE previously had no marker support at all — opening such a file fell into the generic EDL reader, which produced one-frame cues whose *text was the raw `|C:/|M:` comment line*.

## New format: "DaVinci Resolve Marker EDL"

- **Import**: each marker becomes a cue at its timeline position with the `|D:` duration; plain one-frame markers get a readable display time. Enables markers→subtitles workflows (chaptering, QC notes, spotting lists).
- **Export**: each subtitle becomes a marker (`|M:` = text, `|D:` = duration in frames), so a subtitle can be loaded onto a Resolve timeline as markers for spotting.
- Registered ahead of the generic EDL format; a marker file now detects as the new format while ordinary cut-list EDLs still detect as `EDL` (covered by a test).

## Also fixed in passing

The generic EDL export wrote its `FCM:` header inverted — `NON-DROP FRAME` for fractional NTSC rates (29.97) and `DROP FRAME` for integer rates (25). Now the right way around.

## Tests

Three new tests: parsing a Resolve-shaped marker export, full round-trip, and detection precedence vs the generic EDL.

Full solution builds. All suites pass: libse 1259, seconv 376, libuilogic 230, UI 2968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)