### PR TITLE
Add Voxtral speech-to-text backend to Crisp ASR

### DIFF
--- a/src/libuilogic/AudioToText/WhisperChoice.cs
+++ b/src/libuilogic/AudioToText/WhisperChoice.cs
@@ -32,6 +32,7 @@
         public const string CrispAsrMossDiarize = "Crisp ASR MOSS Diarize";
         public const string CrispAsrSenseVoice = "Crisp ASR SenseVoice";
         public const string CrispAsrArk = "Crisp ASR ARK";
+        public const string CrispAsrVoxtral = "Crisp ASR Voxtral";
         public const string OpenAiCompatible = "OpenAI Compatible";
         public const string OpenRouter = "OpenRouter";
         public const string DashScopeQwen3 = "Alibaba Qwen3-ASR";

--- a/src/ui/Assets/SpeechToText/CrispASRVoxtral.txt
+++ b/src/ui/Assets/SpeechToText/CrispASRVoxtral.txt
@@ -1,0 +1,6 @@
+🗣️ Voxtral Mini 3B (Mistral)
+
+Type: Whisper-style audio encoder + Ministral 3B LLM decoder
+Focus: 🌍 English, French, German, Spanish, Italian, Portuguese, Dutch, Hindi
+Extras: no native timestamps - a CTC forced aligner supplies them
+

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngine.cs
@@ -36,6 +36,7 @@ public class CrispAsrEngine : CrispAsrEngineBase
             new CrispAsrKyutai(),
             new CrispAsrSenseVoice(),
             new CrispAsrArk(),
+            new CrispAsrVoxtral(),
         };
 
         SelectedBackend = _backends[0];

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrVoxtral.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrVoxtral.cs
@@ -1,0 +1,155 @@
+using Nikse.SubtitleEdit.UiLogic.AudioToText;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+
+/// <summary>
+/// Mistral's Voxtral Mini 3B speech-LLM via CrispASR's "voxtral" backend (issue #13724).
+/// The backend reports "timestamps-ctc" but not "timestamps-native" in
+/// <c>crispasr --list-backends-json</c>, so <see cref="CrispAsrEngineBase.HasNativeTimestamps"/>
+/// stays false and the forced-aligner combo drops its "built-in" entry - a CTC aligner
+/// is required, not optional.
+/// </summary>
+public class CrispAsrVoxtral : CrispAsrEngineBase
+{
+    public static string StaticName => "Crisp ASR Voxtral";
+    public override string Name => StaticName;
+    public override string Choice => WhisperChoice.CrispAsrVoxtral;
+    public override string Url => "https://github.com/CrispStrobe/CrispASR";
+    public override string BackendName => "voxtral";
+    public override string DefaultLanguage => "en";
+    public override bool IncludeLanguage => true;
+
+    // The eight languages Voxtral Mini 3B is trained on. "auto" is the model's own
+    // prompt-level language detection - the backend has no "language-detect" cap, same
+    // as Qwen3/Mega/GLM, which list an auto entry too.
+    public override List<WhisperLanguage> Languages =>
+        new()
+        {
+            new WhisperLanguage("auto", "Auto detect"),
+            new WhisperLanguage("en", "english"),
+            new WhisperLanguage("fr", "french"),
+            new WhisperLanguage("de", "german"),
+            new WhisperLanguage("es", "spanish"),
+            new WhisperLanguage("it", "italian"),
+            new WhisperLanguage("pt", "portuguese"),
+            new WhisperLanguage("nl", "dutch"),
+            new WhisperLanguage("hi", "hindi"),
+        };
+
+    public override List<WhisperModel> Models =>
+       new()
+       {
+            new WhisperModel
+            {
+                Name = "voxtral-mini-3b-2507-q4_k.gguf",
+                Size = "2.65 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/voxtral-mini-3b-2507-GGUF/resolve/main/voxtral-mini-3b-2507-q4_k.gguf"
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "voxtral-mini-3b-2507-q8_0.gguf",
+                Size = "4.99 GB",
+                Urls =
+                [
+                    "https://huggingface.co/cstr/voxtral-mini-3b-2507-GGUF/resolve/main/voxtral-mini-3b-2507-q8_0.gguf"
+                ],
+            },
+       };
+
+    public override string Extension => string.Empty;
+    public override string UnpackSkipFolder => string.Empty;
+
+    public override bool IsEngineInstalled()
+    {
+        var executableFile = GetExecutable();
+        return File.Exists(executableFile);
+    }
+
+    public override string ToString()
+    {
+        return CrispAsrEngine.GetBackendDisplayName(this);
+    }
+
+    public override string GetAndCreateWhisperFolder()
+    {
+        var folder = Se.CrispAsrFolder;
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        return folder;
+    }
+
+    public override string GetAndCreateWhisperModelFolder(WhisperModel? whisperModel)
+    {
+        var folder = GetAndCreateWhisperFolder();
+        var modelsFolder = Path.Combine(folder, "models");
+        if (!Directory.Exists(modelsFolder))
+        {
+            Directory.CreateDirectory(modelsFolder);
+        }
+
+        return modelsFolder;
+    }
+
+    public override string GetExecutable()
+    {
+        string fullPath = Path.Combine(GetAndCreateWhisperFolder(), GetExecutableFileName());
+        return fullPath;
+    }
+
+    public override bool IsModelInstalled(WhisperModel model)
+    {
+        var modelFile = GetModelForCmdLine(model.Name);
+        if (!File.Exists(modelFile))
+        {
+            return false;
+        }
+
+        return new FileInfo(modelFile).Length > 10_000_000;
+    }
+
+    public override string GetModelForCmdLine(string modelName)
+    {
+        var modelFileName = Path.Combine(GetAndCreateWhisperModelFolder(null), modelName);
+        return modelFileName;
+    }
+
+
+    public override string GetWhisperModelDownloadFileName(WhisperModel whisperModel, string url)
+    {
+        var folder = GetAndCreateWhisperModelFolder(whisperModel);
+        var fileNameOnly = Path.GetFileName(url);
+        var fileName = Path.Combine(folder, fileNameOnly);
+        return fileName;
+    }
+
+    internal static string GetExecutableFileName()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return "crispasr.exe";
+        }
+
+        return "crispasr";
+    }
+
+    public override bool CanBeDownloaded()
+    {
+        return true;
+    }
+
+    public override string CommandLineParameter
+    {
+        get => Se.Settings.Tools.AudioToText.CommandLineParameterCrispAsrVoxtral;
+        set => Se.Settings.Tools.AudioToText.CommandLineParameterCrispAsrVoxtral = value;
+    }
+}

--- a/src/ui/Logic/Config/SeAudioToText.cs
+++ b/src/ui/Logic/Config/SeAudioToText.cs
@@ -65,6 +65,7 @@ public class SeAudioToText
     public string CommandLineParameterCrispAsrMossDiarize { get; set; } = "--max-len 50 --split-on-punct";
     public string CommandLineParameterCrispAsrSenseVoice { get; set; } = "--max-len 50 --split-on-punct";
     public string CommandLineParameterCrispAsrArk { get; set; } = "--max-len 50 --split-on-punct";
+    public string CommandLineParameterCrispAsrVoxtral { get; set; } = "--max-len 50 --split-on-punct";
     public string CrispAsrForcedAligner { get; set; } = "built-in";
 
     public string WhisperExtraSettingsHistory { get; set; } = string.Empty;

--- a/tests/UI/Features/Video/SpeechToText/Engines/CrispAsrEngineTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/Engines/CrispAsrEngineTests.cs
@@ -13,6 +13,7 @@ public class CrispAsrEngineTests
     [InlineData(WhisperChoice.CrispAsrMega, typeof(CrispAsrMega), "mega-asr")]
     [InlineData(WhisperChoice.CrispAsrFunAsrNano, typeof(CrispAsrFunAsrNano), "funasr")]
     [InlineData(WhisperChoice.CrispAsrGigaAm, typeof(CrispAsrGigaAm), "gigaam")]
+    [InlineData(WhisperChoice.CrispAsrVoxtral, typeof(CrispAsrVoxtral), "voxtral")]
     public void TrySelectBackendChoice_SelectsPersistedCrispBackendChoice(string choice, Type backendType, string backendName)
     {
         var engine = new CrispAsrEngine();

--- a/tests/UI/Features/Video/SpeechToText/Engines/CrispAsrHelpTextTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/Engines/CrispAsrHelpTextTests.cs
@@ -38,4 +38,24 @@ public class CrispAsrHelpTextTests
         // From CrispASRParakeet.txt, i.e. the per-backend header rather than only the common text.
         Assert.Contains("Parakeet", helpText);
     }
+
+    /// <summary>
+    /// The fallback above keeps a missing asset from crashing the dialog, which also means it
+    /// hides one: a backend added without its .txt silently shows the shared text only. Every
+    /// backend the picker offers must ship a header of its own.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task GetHelpText_EveryRegisteredBackend_HasItsOwnHeaderAsset()
+    {
+        var common = await new CrispAsrMadlad().GetHelpText();
+
+        foreach (var backend in new CrispAsrEngine().Backends)
+        {
+            var helpText = await backend.GetHelpText();
+
+            Assert.True(
+                helpText.Length > common.Length,
+                $"Backend \"{backend.Name}\" has no help asset - add Assets/SpeechToText/{backend.Name.Replace(" ", string.Empty)}.txt");
+        }
+    }
 }


### PR DESCRIPTION
Closes #13724.

Exposes Mistral's Voxtral Mini 3B in the Crisp ASR backend picker. @AmineI reported it as their best result for non-English recordings and was driving it from the command line; this makes it a normal in-app choice.

### No pin bump needed

The backend is already compiled into the pinned v0.8.28 binary. Verified by downloading that exact release and running `--list-backends-json`:

```
voxtral -> timestamps-ctc, token-confidence, translate, diarize, temperature,
           beam-search, flash-attn, punctuation-toggle, src-tgt-language,
           auto-download, parallel-processors
```

Note `timestamps-ctc` but **not** `timestamps-native`. So the engine keeps the base `HasNativeTimestamps => false`, which makes the forced-aligner combo drop its "Built-in aligner" row and default to Canary CTC. A CTC aligner is required here, not optional — which is exactly the setup the reporter arrived at by hand.

### Verification

Both quants run headlessly against the pinned binary on `jfk.wav`, using SE's own invocation:

```
crispasr --backend voxtral -l en -m <model> -am canary-ctc-aligner-q8_0.gguf \
         -f jfk.wav --output-srt --print-progress --max-len 50 --split-on-punct
```

| | result |
|---|---|
| q4_k (2.65 GB) | transcript matches the model card exactly, 2.1× realtime |
| q8_0 (4.99 GB) | **byte-identical SRT** to q4_k, 2.1× realtime |

Both files hash-checked against their HuggingFace LFS oids. Timestamps span 0.40 → 11.04 s of the 11 s audio. Adding `--force-aligner` changes nothing, confirming SE's existing `-am`-only invocation is right for this backend; `-l auto` also works, so the "Auto detect" row is safe.

Given the history of quants that fail silently — empty transcripts on an early qwen3-asr q4_k, ~1.7× compressed timestamps on moss-diarize q4_k — both quants were checked rather than just the recommended one.

### Known limitation

Voxtral supports Hindi, but SE's aligner zoo has no Hindi entry (Canary CTC, Qwen3, and 12 wav2vec2 languages, none of them `hi`). Since Voxtral has no native timestamps, Hindi word timings would come from a non-Hindi aligner. The seven European languages are all covered. This is a pre-existing gap in the aligner list, not something this change introduces — and dropping Hindi from the language list would only hide a transcription path that does work.

### Changes

Five touchpoints, mirroring how `CrispAsrGranite` is wired, plus tests:

- new `CrispAsrVoxtral.cs` — `BackendName => "voxtral"`, 8 languages + auto, both quants
- new `CrispASRVoxtral.txt` help asset
- one line each in `WhisperChoice.cs`, `CrispAsrEngine.cs`, `SeAudioToText.cs`
- a Voxtral row in the backend-selection theory, and a new test asserting every registered backend ships its own help asset — the `GetHelpText` fallback keeps a missing `.txt` from crashing the dialog, which also means it silently hides one

Build clean; 225 SpeechToText + Settings tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
