### PR TITLE
Fix #13682: Ctrl+V pastes over the selected grid lines again

### DIFF
--- a/docs/features/subtitle-grid.md
+++ b/docs/features/subtitle-grid.md
@@ -67,6 +67,15 @@ Right-click a line to access:
 | `Enter` | Go to next line |
 | `Up/Down` | Navigate lines |
 
+### Pasting over several lines
+
+With **one** line selected, `Ctrl+V` inserts the clipboard content below it. With **several** lines selected, the clipboard is pasted *over* the selection instead — handy for translating: copy the lines out, translate them elsewhere, select the same lines here and paste.
+
+- Clipboard holds a subtitle (SRT, ASSA, …): the selected lines are replaced by the pasted ones, time codes included. The number of pasted lines does not have to match the selection.
+- Clipboard holds plain text: one clipboard line goes into each selected line's text, and the time codes are left alone. Clipboard lines that go past the end of the selection are not pasted.
+
+Both are a normal edit, so `Ctrl+Z` undoes them.
+
 ## Formatting Display
 
 The grid can render formatting tags (italic, bold, color, etc.) visually instead of showing the raw tags — enable **Show formatting in grid** in the settings. A shortcut to toggle the formatting mode on the fly can be assigned in **Options → Shortcuts**.

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1017,6 +1017,8 @@
     "youtubeDlOutdatedDownloadNow": "\"yt-dlp\" is outdated and may not work with online videos.\n\nDownload the current version now?",
     "insertUnicodeSymbol": "Insert Unicode symbol",
     "trimmedXLines": "Trimmed {0} subtitle lines",
+    "pastedXLinesOverSelectedLines": "Pasted {0} line(s) over the selected lines",
+    "pastedXOfYLinesOverSelectedLines": "Pasted {0} of {1} line(s) over the selected lines - the rest did not fit the selection",
     "openOriginalDifferentNumberOfSubtitlesXY": "The original subtitle file does not have the same number of subtitles as the current subtitle file.\n\n• Original subtitles: {0}\n• Current subtitles: {1}",
     "originalTextReadOnly": "Original text (read-only)",
     "originalTextEditMode": "Original text (edit mode)",

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -17292,17 +17292,38 @@ public partial class MainViewModel :
             return;
         }
 
+        var text = await ClipboardHelper.GetTextAsync(Window);
+        if (string.IsNullOrEmpty(text))
+        {
+            _shortcutManager.ClearKeys();
+            return;
+        }
+
+        // More than one line selected: paste over the selection instead of adding lines below it -
+        // the translation workflow SE4 had (translate the lines somewhere else, select them here,
+        // Ctrl+V) and which SE5 only offered through "Column > Paste from clipboard" (#13682).
+        var selectedItems = SubtitleGridSelectedItems;
+        if (selectedItems.Count > 1 && PasteOverSelectedLines(selectedItems, text))
+        {
+            _updateAudioVisualizer = true;
+            _shortcutManager.ClearKeys();
+            return;
+        }
+
+        // Insert below the topmost selected row, not below the current one: the current row is the
+        // moving end of a shift-selection, so anchoring there made the paste land below the bottom
+        // row when the rows were picked downwards - see FirstSelectedSubtitleIndex (#13682).
         // No selection: append at the end instead of silently doing nothing - SE4's grid paste
         // covered this state (insert at end), and the Paste helper already supports
         // index >= Count as append (#13200). Empty grid: insert at 0 (the helper handles
         // index 0 with an empty list; a negative index would throw on Insert).
-        var idx = SelectedSubtitleIndex ?? Subtitles.Count;
+        var idx = FirstSelectedSubtitleIndex;
         if (idx < 0 || idx > Subtitles.Count)
         {
             idx = Subtitles.Count;
         }
 
-        var pastedLines = await SubtitleGridCopyPasteHelper.Paste(Window, Subtitles, idx, SelectedSubtitleFormat);
+        var pastedLines = SubtitleGridCopyPasteHelper.PasteText(Subtitles, idx, SelectedSubtitleFormat, text);
         Renumber();
 
         // Select the pasted lines and scroll them into view, like SE4 - otherwise the selection
@@ -17318,6 +17339,81 @@ public partial class MainViewModel :
 
         _updateAudioVisualizer = true;
         _shortcutManager.ClearKeys();
+    }
+
+    /// <summary>
+    /// Pastes <paramref name="text"/> over the selected rows and returns true when it did, so
+    /// <see cref="SubtitleGridPaste"/> can fall back to inserting lines. Two clipboards to tell
+    /// apart, both from SE4's Ctrl+V handler:
+    /// <list type="bullet">
+    /// <item>a subtitle format (SRT, ASSA, ...) replaces the selected lines outright - SE4's
+    /// "multiple lines selected - first delete, then insert" - so the pasted time codes are kept
+    /// and the pasted line count does not have to match the selection.</item>
+    /// <item>plain text writes one clipboard line into each selected row's text and leaves the
+    /// time codes alone, which is what "Column &gt; Paste from clipboard &gt; text only + replace
+    /// existing cells" does. A subtitle whose text is two display lines cannot be expressed this
+    /// way; that is what the subtitle-format clipboard above is for.</item>
+    /// </list>
+    /// Everything here is a normal edit, so the automatic change detection makes it undoable.
+    /// </summary>
+    private bool PasteOverSelectedLines(List<SubtitleLineViewModel> selectedItems, string text)
+    {
+        var firstIndex = Subtitles.IndexOf(selectedItems[0]);
+        if (firstIndex < 0)
+        {
+            return false;
+        }
+
+        var clipboardSubtitle = SubtitleGridCopyPasteHelper.ParseClipboardSubtitle(text, SelectedSubtitleFormat);
+        if (clipboardSubtitle is { Paragraphs.Count: > 0 })
+        {
+            foreach (var item in selectedItems)
+            {
+                Subtitles.Remove(item);
+            }
+
+            // Nothing above the topmost selected row was removed, so it is still the row to insert
+            // at - even when the selection had holes in it (ctrl-click).
+            var insertedLines = new List<SubtitleLineViewModel>(clipboardSubtitle.Paragraphs.Count);
+            var index = firstIndex;
+            foreach (var p in clipboardSubtitle.Paragraphs)
+            {
+                var line = new SubtitleLineViewModel(p, SelectedSubtitleFormat);
+                Subtitles.Insert(index, line);
+                insertedLines.Add(line);
+                index++;
+            }
+
+            Renumber();
+            SelectAndScrollToRange(firstIndex, firstIndex + insertedLines.Count - 1);
+            ShowStatus(string.Format(Se.Language.Main.PastedXLinesOverSelectedLines, insertedLines.Count));
+            return true;
+        }
+
+        var lines = text.SplitToLines();
+        // trailing blank lines are an artifact of the copy, not text to paste (same rule as the
+        // column paste); blank lines inside the block are kept, so the lines stay aligned with the
+        // rows they were translated from
+        var lastLineWithText = lines.FindLastIndex(p => !string.IsNullOrWhiteSpace(p));
+        if (lastLineWithText < 0)
+        {
+            return false;
+        }
+
+        var textLineCount = lastLineWithText + 1;
+        var count = Math.Min(textLineCount, selectedItems.Count);
+        for (var i = 0; i < count; i++)
+        {
+            selectedItems[i].Text = lines[i].Trim();
+        }
+
+        // Clipboard lines past the end of the selection are dropped rather than pushed into the
+        // lines below it, which the user did not select - say so instead of silently doing less.
+        ShowStatus(textLineCount > selectedItems.Count
+            ? string.Format(Se.Language.Main.PastedXOfYLinesOverSelectedLines, count, textLineCount)
+            : string.Format(Se.Language.Main.PastedXLinesOverSelectedLines, count));
+
+        return true;
     }
 
     [RelayCommand]

--- a/src/ui/Logic/Config/Language/Main/LanguageMain.cs
+++ b/src/ui/Logic/Config/Language/Main/LanguageMain.cs
@@ -88,6 +88,8 @@ public class LanguageMain
     public string YoutubeDlOutdatedDownloadNow { get; set; }
     public string InsertUnicodeSymbol { get; set; }
     public string TrimmedXLines { get; set; }
+    public string PastedXLinesOverSelectedLines { get; set; }
+    public string PastedXOfYLinesOverSelectedLines { get; set; }
     public string OpenOriginalDifferentNumberOfSubtitlesXY { get; set; }
     public string OriginalTextReadOnly { get; set; }
     public string OriginalTextEditMode { get; set; }
@@ -229,6 +231,8 @@ public class LanguageMain
         YoutubeDlOutdatedDownloadNow = "\"yt-dlp\" is outdated and may not work with online videos.\n\nDownload the current version now?";
         InsertUnicodeSymbol = "Insert Unicode symbol";
         TrimmedXLines = "Trimmed {0} subtitle lines";
+        PastedXLinesOverSelectedLines = "Pasted {0} line(s) over the selected lines";
+        PastedXOfYLinesOverSelectedLines = "Pasted {0} of {1} line(s) over the selected lines - the rest did not fit the selection";
         OpenOriginalDifferentNumberOfSubtitlesXY = "The original subtitle file does not have the same number of subtitles as the current subtitle file.\n\n• Original subtitles: {0}\n• Current subtitles: {1}";
         OriginalTextReadOnly = "Original text (read-only)";
         OriginalTextEditMode = "Original text (edit mode)";

--- a/src/ui/Logic/SubtitleGridCopyPasteHelper.cs
+++ b/src/ui/Logic/SubtitleGridCopyPasteHelper.cs
@@ -99,16 +99,47 @@ internal static class SubtitleGridCopyPasteHelper
     }
 
     /// <summary>
-    /// Pastes the clipboard content into <paramref name="subtitles"/> at <paramref name="index"/>
+    /// Parses clipboard text as a subtitle, or returns null when no format recognizes it - plain
+    /// text lines (translations copied out of a text document) end up here. Both the paste that
+    /// inserts lines and the paste that overwrites the selection have to tell those two apart, so
+    /// they ask the same question here (#13682).
+    /// </summary>
+    internal static Subtitle? ParseClipboardSubtitle(string? text, SubtitleFormat subtitleFormat)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return null;
+        }
+
+        var lines = text.SplitToLines();
+        var subtitle = Subtitle.Parse(lines, subtitleFormat.Extension);
+        if (subtitle == null)
+        {
+            return null;
+        }
+
+        if (subtitle.Paragraphs.Count > 0)
+        {
+            return subtitle;
+        }
+
+        foreach (SubtitleFormat item in SubtitleFormat.AllSubtitleFormats)
+        {
+            if (item.IsMine(lines, string.Empty))
+            {
+                item.LoadSubtitle(subtitle, lines, string.Empty);
+                return subtitle;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Pastes <paramref name="text"/> into <paramref name="subtitles"/> at <paramref name="index"/>
     /// and returns the inserted lines in grid order (empty when nothing was pasted), so the caller
     /// can select and scroll to them like SE4 did (#13705).
     /// </summary>
-    internal static async Task<List<SubtitleLineViewModel>> Paste(Window window, ObservableCollection<SubtitleLineViewModel> subtitles, int index, SubtitleFormat subtitleFormat)
-    {
-        var text = await ClipboardHelper.GetTextAsync(window);
-        return PasteText(subtitles, index, subtitleFormat, text);
-    }
-
     internal static List<SubtitleLineViewModel> PasteText(ObservableCollection<SubtitleLineViewModel> subtitles, int index, SubtitleFormat subtitleFormat, string? text)
     {
         if (string.IsNullOrEmpty(text))
@@ -130,23 +161,14 @@ internal static class SubtitleGridCopyPasteHelper
         }
 
 
-        var lines = text.SplitToLines();
-        var subtitle = Subtitle.Parse(lines, subtitleFormat.Extension);
-        if (subtitle?.Paragraphs.Count > 0)
+        var clipboardSubtitle = ParseClipboardSubtitle(text, subtitleFormat);
+        if (clipboardSubtitle != null)
         {
-            return LoadParagraphs(subtitles, index, subtitleFormat, subtitle);
-        }
-
-        foreach (SubtitleFormat item in SubtitleFormat.AllSubtitleFormats)
-        {
-            if (item.IsMine(lines, string.Empty) && subtitle != null)
-            {
-                item.LoadSubtitle(subtitle, lines, string.Empty);
-                return LoadParagraphs(subtitles, index, subtitleFormat, subtitle);
-            }
+            return LoadParagraphs(subtitles, index, subtitleFormat, clipboardSubtitle);
         }
 
         // fallback - plain text
+        var lines = text.SplitToLines();
         var insertedLines = new List<SubtitleLineViewModel>();
         foreach (var line in lines)
         {

--- a/tests/UI/Features/Main/MainGridPasteSelectionTests.cs
+++ b/tests/UI/Features/Main/MainGridPasteSelectionTests.cs
@@ -91,6 +91,149 @@ public class MainGridPasteSelectionTests
         }
     }
 
+    /// <summary>
+    /// More than one row selected and a subtitle format on the clipboard: the selected lines are
+    /// replaced, not pushed down - SE4's "multiple lines selected - first delete, then insert"
+    /// (#13682). The pasted line count does not have to match the selection.
+    /// </summary>
+    [AvaloniaFact]
+    public void Paste_SubtitleOverMultipleSelectedLines_ReplacesThem()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Keep before", 1000, 2000);
+            AddLine(vm, "Replace one", 3000, 4000);
+            AddLine(vm, "Replace two", 5000, 6000);
+            AddLine(vm, "Replace three", 7000, 8000);
+            AddLine(vm, "Keep after", 9000, 10000);
+            SelectRows(vm, 1, 2, 3);
+
+            Paste(window, vm, Srt(
+                ("Pasted one", "00:00:10,000", "00:00:11,000"),
+                ("Pasted two", "00:00:12,000", "00:00:13,000")));
+
+            Assert.Equal(new[] { "Keep before", "Pasted one", "Pasted two", "Keep after" },
+                vm.Subtitles.Select(p => p.Text).ToArray());
+
+            // the pasted time codes are kept, like SE4
+            Assert.Equal(10000, vm.Subtitles[1].StartTime.TotalMilliseconds);
+            Assert.Equal(13000, vm.Subtitles[2].EndTime.TotalMilliseconds);
+
+            var selected = vm.SubtitleGridSelectedItems;
+            Assert.Equal(2, selected.Count);
+            Assert.Same(vm.Subtitles[1], selected[0]);
+            Assert.Same(vm.Subtitles[2], selected[1]);
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    /// <summary>
+    /// The rows are replaced from the topmost selected one whichever way the selection was made -
+    /// the grid's own SelectedItems follows the order the rows were picked in, and anchoring on
+    /// that made the same paste land in a different place for a bottom-to-top selection (#13682).
+    /// </summary>
+    [AvaloniaFact]
+    public void Paste_SubtitleOverASelectionPickedBottomToTop_ReplacesTheSameLines()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Keep before", 1000, 2000);
+            AddLine(vm, "Replace one", 3000, 4000);
+            AddLine(vm, "Replace two", 5000, 6000);
+            AddLine(vm, "Keep after", 7000, 8000);
+            SelectRows(vm, 2, 1); // bottom row first
+
+            Paste(window, vm, Srt(("Pasted one", "00:00:10,000", "00:00:11,000")));
+
+            Assert.Equal(new[] { "Keep before", "Pasted one", "Keep after" },
+                vm.Subtitles.Select(p => p.Text).ToArray());
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    /// <summary>
+    /// Plain text (translations copied out of a text document) writes one clipboard line into each
+    /// selected row and leaves the time codes alone - what "Column > Paste from clipboard > text
+    /// only + replace existing cells" does, without the menus and the dialog (#13682).
+    /// </summary>
+    [AvaloniaFact]
+    public void Paste_PlainTextOverMultipleSelectedLines_ReplacesTheTextOnly()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Keep before", 1000, 2000);
+            AddLine(vm, "Original one", 3000, 4000);
+            AddLine(vm, "Original two", 5000, 6000);
+            SelectRows(vm, 1, 2);
+
+            Paste(window, vm, "Translated one" + Environment.NewLine + "Translated two" + Environment.NewLine);
+
+            Assert.Equal(new[] { "Keep before", "Translated one", "Translated two" },
+                vm.Subtitles.Select(p => p.Text).ToArray());
+            Assert.Equal(3000, vm.Subtitles[1].StartTime.TotalMilliseconds);
+            Assert.Equal(6000, vm.Subtitles[2].EndTime.TotalMilliseconds);
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    // More clipboard lines than selected rows: the extra lines are dropped rather than written
+    // into lines the user did not select.
+    [AvaloniaFact]
+    public void Paste_PlainTextWithMoreLinesThanSelectedRows_StopsAtTheSelection()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Original one", 1000, 2000);
+            AddLine(vm, "Original two", 3000, 4000);
+            AddLine(vm, "Keep after", 5000, 6000);
+            SelectRows(vm, 0, 1);
+
+            Paste(window, vm, string.Join(Environment.NewLine, "Translated one", "Translated two", "Translated three"));
+
+            Assert.Equal(new[] { "Translated one", "Translated two", "Keep after" },
+                vm.Subtitles.Select(p => p.Text).ToArray());
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    // A single selected row still inserts below it - the SE4 behavior for the everyday paste.
+    [AvaloniaFact]
+    public void Paste_PlainTextWithOneRowSelected_StillInserts()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Original one", 1000, 2000);
+            AddLine(vm, "Original two", 3000, 4000);
+            SelectRow(vm, 0);
+
+            Paste(window, vm, "Pasted text");
+
+            Assert.Equal(new[] { "Original one", "Pasted text", "Original two" },
+                vm.Subtitles.Select(p => p.Text).ToArray());
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
     private static void Paste(Window window, MainViewModel vm, string clipboardText)
     {
         ClipboardHelper.SetTextAsync(window, clipboardText).GetAwaiter().GetResult();
@@ -118,6 +261,26 @@ public class MainGridPasteSelectionTests
     {
         Dispatcher.UIThread.RunJobs();
         vm.SubtitleGrid.SelectedItem = vm.Subtitles[index];
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    /// <summary>
+    /// Selects several rows in the order given - the grid's own SelectedItems keeps that order, so
+    /// passing the rows bottom-to-top reproduces an upwards shift-selection.
+    /// </summary>
+    private static void SelectRows(MainViewModel vm, params int[] indexes)
+    {
+        Dispatcher.UIThread.RunJobs();
+        vm.SubtitleGrid.SelectedItem = vm.Subtitles[indexes[0]];
+        Dispatcher.UIThread.RunJobs();
+
+        var selectedItems = vm.SubtitleGrid.SelectedItems!;
+        selectedItems.Clear();
+        foreach (var index in indexes)
+        {
+            selectedItems.Add(vm.Subtitles[index]);
+        }
+
         Dispatcher.UIThread.RunJobs();
     }
 


### PR DESCRIPTION
Follow-up to `11a6078` for #13682. The column-paste selection-direction bug is fixed and confirmed by the reporter in beta15; this restores the other half of the request: a direct `Ctrl/Cmd+V` that overwrites the selected lines, without going through **Column > Paste from clipboard**.

## The problem

`SubtitleGridPaste` only ever inserted - `SubtitleGridCopyPasteHelper.PasteText` calls `subtitles.Insert(...)` on every path - so pasting with several lines selected added the clipboard below the selection instead of replacing it. The translation workflow (copy the lines out, translate them elsewhere, select them here, paste) needed four menu levels.

## What SE4 did

SE4's Ctrl+V handler (`Main.cs` at tag `4.0.16`) had two ways of pasting over a selection, and both are back:

- **A subtitle format on the clipboard** replaces the selected lines, time codes included - SE4's `// multiple lines selected - first delete, then insert`. The pasted line count does not have to match the selection.
- **Plain text** writes one clipboard line into each selected line's text and leaves the time codes alone - what "Column > Paste from clipboard" does with *text only* + *replace existing cells*. Clipboard lines past the end of the selection are dropped rather than written into lines the user did not select, and the status bar says so.

With **one** line selected, Ctrl+V still inserts below it, as before. Both overwrite paths are ordinary edits, so Ctrl+Z undoes them.

Note for the reporter: the plain-text overwrite is new rather than restored - v4.0.16 inserted plain multi-line text too. It is what actually makes the workflow work when the clipboard is bare translated lines.

## Also fixed

The insert path anchored on `SelectedSubtitleIndex`, the *moving end* of a shift-selection - the same mistake `11a6078` fixed for the column commands - so a top-to-bottom selection pasted below the bottom row of the selection. It now starts at `FirstSelectedSubtitleIndex` like the column commands do.

## Notes

- The "is this clipboard a subtitle?" test moved into `SubtitleGridCopyPasteHelper.ParseClipboardSubtitle` so the insert path and the overwrite path ask the same question; the unused `Paste(window, ...)` wrapper is gone.
- Two new strings in `LanguageMain`; `English.json` regenerated.
- `docs/features/subtitle-grid.md` documents the new behavior.

## Testing

Five new tests in `MainGridPasteSelectionTests`: subtitle-format paste over a multi-row selection, the same selection picked bottom-to-top, plain text over a selection, more clipboard lines than selected rows, and one selected row still inserting. Full UI suite: 2986 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)