### PR TITLE
Fix Sub Station Alpha (.ssa) style handling

### DIFF
--- a/src/libse/Common/SsaStyle.cs
+++ b/src/libse/Common/SsaStyle.cs
@@ -125,7 +125,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
                 else if (f == "tertiarycolour")
                 {
-                    sb.Append(ColorTranslator.ToWin32(Tertiary));
+                    sb.Append(ColorTranslator.ToWin32(Outline)); // SSA v4's TertiaryColour is the outline color
                 }
                 else if (f == "backcolour")
                 {
@@ -193,7 +193,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
                 else if (f == "alignment")
                 {
-                    sb.Append(Alignment);
+                    sb.Append(AdvancedSubStationAlpha.AssAlignmentToSsaV4Alignment(Alignment));
                 }
                 else if (f == "alphalevel")
                 {
@@ -360,11 +360,13 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
                 else if (f == "tertiarycolour")
                 {
+                    // SSA v4's TertiaryColour is [V4+ Styles]' OutlineColour. Reading it into
+                    // Tertiary only dropped the outline color of every .ssa file. #13734
                     result.Tertiary = AdvancedSubStationAlpha.GetSsaColor(v, SKColors.Yellow);
+                    result.Outline = AdvancedSubStationAlpha.GetSsaColor(v, SKColors.Black);
                 }
                 else if (f == "backcolour")
                 {
-                    result.Outline = AdvancedSubStationAlpha.GetSsaColor(v, SKColors.Black);
                     result.Background = AdvancedSubStationAlpha.GetSsaColor(v, SKColors.Black);
                 }
                 else if (f == "bold")
@@ -377,35 +379,37 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
                 else if (f == "outline")
                 {
-                    if (decimal.TryParse(f, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var number))
+                    // These five parsed the field *name* instead of its value, so outline/shadow
+                    // width and all three margins silently fell back to the defaults. #13734
+                    if (decimal.TryParse(v, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var number))
                     {
                         result.OutlineWidth = number;
                     }
                 }
                 else if (f == "shadow")
                 {
-                    if (decimal.TryParse(f, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var number))
+                    if (decimal.TryParse(v, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var number))
                     {
                         result.ShadowWidth = number;
                     }
                 }
                 else if (f == "marginl")
                 {
-                    if (int.TryParse(f, out var number))
+                    if (int.TryParse(v, NumberStyles.Integer, CultureInfo.InvariantCulture, out var number))
                     {
                         result.MarginLeft = number;
                     }
                 }
                 else if (f == "marginr")
                 {
-                    if (int.TryParse(f, out var number))
+                    if (int.TryParse(v, NumberStyles.Integer, CultureInfo.InvariantCulture, out var number))
                     {
                         result.MarginRight = number;
                     }
                 }
                 else if (f == "marginv")
                 {
-                    if (int.TryParse(f, out var number))
+                    if (int.TryParse(v, NumberStyles.Integer, CultureInfo.InvariantCulture, out var number))
                     {
                         result.MarginVertical = number;
                     }
@@ -416,39 +420,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
                 else if (f == "alignment")
                 {
-                    switch (v)
-                    {
-                        case "1":
-                            result.Alignment = "1"; // bottom left
-                            break;
-                        case "2":
-                            result.Alignment = "2"; // bottom center
-                            break;
-                        case "3":
-                            result.Alignment = "3"; // bottom right
-                            break;
-                        case "9":
-                            result.Alignment = "4"; // middle left
-                            break;
-                        case "10":
-                            result.Alignment = "5"; // middle center
-                            break;
-                        case "11":
-                            result.Alignment = "6"; // middle right
-                            break;
-                        case "5":
-                            result.Alignment = "7"; // top left
-                            break;
-                        case "6":
-                            result.Alignment = "8"; // top center
-                            break;
-                        case "7":
-                            result.Alignment = "9"; // top right
-                            break;
-                        default:
-                            result.Alignment = "2";
-                            break;
-                    }
+                    result.Alignment = AdvancedSubStationAlpha.SsaV4AlignmentToAssAlignment(v);
                 }
             }
 
@@ -475,7 +447,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             return "Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, TertiaryColour, BackColour, Bold, Italic, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, AlphaLevel, Encoding"
                 .Replace(" ", string.Empty)
                 .ToLowerInvariant()
-                .Split();
+                .Split(','); // spaces are already gone, so a whitespace split returned one big field
         }
     }
 }

--- a/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
+++ b/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
@@ -584,34 +584,8 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                     var spacing = ssaStyle.Spacing.ToString(CultureInfo.InvariantCulture);
                     var angle = ssaStyle.Angle.ToString(CultureInfo.InvariantCulture);
 
-                    var newAlignment = "2";
-                    switch (ssaStyle.Alignment)
-                    {
-                        case "1":
-                            newAlignment = "1";
-                            break;
-                        case "3":
-                            newAlignment = "3";
-                            break;
-                        case "9":
-                            newAlignment = "4";
-                            break;
-                        case "10":
-                            newAlignment = "5";
-                            break;
-                        case "11":
-                            newAlignment = "6";
-                            break;
-                        case "5":
-                            newAlignment = "7";
-                            break;
-                        case "6":
-                            newAlignment = "8";
-                            break;
-                        case "7":
-                            newAlignment = "9";
-                            break;
-                    }
+                    // GetSsaStyle already normalized the [V4 Styles] numbering to "an1"-"an9".
+                    var newAlignment = ssaStyle.Alignment;
 
                     ttStyles.Append("Style: ").Append(ssaStyle.Name).Append(',').Append(ssaStyle.FontName).Append(',').Append(ssaStyle.FontSize.ToString("0.#", CultureInfo.InvariantCulture)).Append(',').Append(GetSsaColorString(ssaStyle.Primary)).Append(',').Append(GetSsaColorString(ssaStyle.Secondary)).Append(',').Append(GetSsaColorString(ssaStyle.Outline)).Append(',').Append(GetSsaColorString(ssaStyle.Background)).Append(',').Append(bold).Append(',').Append(italic).Append(',').Append(underline).Append(",0,").Append(scaleX).Append(',').Append(scaleY).Append(',').Append(spacing).Append(',').Append(angle).Append(',').Append(ssaStyle.BorderStyle).Append(',').Append(ssaStyle.OutlineWidth.ToString(CultureInfo.InvariantCulture)).Append(',').Append(ssaStyle.ShadowWidth.ToString(CultureInfo.InvariantCulture)).Append(',').Append(newAlignment).Append(',').Append(ssaStyle.MarginLeft).Append(',').Append(ssaStyle.MarginRight).Append(',').Append(ssaStyle.MarginVertical).AppendLine(",1");
                 }
@@ -2262,6 +2236,14 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                 return ColorUtils.FromArgb(255, temp.Blue, temp.Green, temp.Red);
             }
 
+            // Values above int.MaxValue are the same 32-bit "&HAABBGGRR" word written unsigned
+            // (e.g. 4294967040); without this they fell through to the default color.
+            if (uint.TryParse(f, NumberStyles.Integer, CultureInfo.InvariantCulture, out var unsignedNumber))
+            {
+                var temp = ColorUtils.FromArgb(unchecked((int)unsignedNumber));
+                return ColorUtils.FromArgb(255, temp.Blue, temp.Green, temp.Red);
+            }
+
             return defaultColor;
         }
 
@@ -2717,6 +2699,45 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
             return matched == prefix.Length;
         }
 
+        /// <summary>
+        /// Maps a Sub Station Alpha v4 alignment (1-3 bottom, 5-7 top, 9-11 middle) to the
+        /// "an1"-"an9" numbering used by Advanced Sub Station Alpha and by SsaStyle.Alignment.
+        /// </summary>
+        public static string SsaV4AlignmentToAssAlignment(string alignment)
+        {
+            switch (alignment)
+            {
+                case "1": return "1"; // bottom left
+                case "3": return "3"; // bottom right
+                case "5": return "7"; // top left
+                case "6": return "8"; // top center
+                case "7": return "9"; // top right
+                case "9": return "4"; // middle left
+                case "10": return "5"; // middle center
+                case "11": return "6"; // middle right
+                default: return "2"; // bottom center
+            }
+        }
+
+        /// <summary>
+        /// The inverse of <see cref="SsaV4AlignmentToAssAlignment"/>.
+        /// </summary>
+        public static string AssAlignmentToSsaV4Alignment(string alignment)
+        {
+            switch (alignment)
+            {
+                case "1": return "1"; // bottom left
+                case "3": return "3"; // bottom right
+                case "4": return "9"; // middle left
+                case "5": return "10"; // middle center
+                case "6": return "11"; // middle right
+                case "7": return "5"; // top left
+                case "8": return "6"; // top center
+                case "9": return "7"; // top right
+                default: return "2"; // bottom center
+            }
+        }
+
         public static SsaStyle GetSsaStyle(string styleName, string header)
         {
             var style = new SsaStyle { Name = styleName };
@@ -2744,6 +2765,8 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
             var spacingIndex = -1;
             var angleIndex = -1;
             var borderStyleIndex = -1;
+            var isSsaV4Format = false;
+            var sawV4PlusSection = false;
 
             if (header == null)
             {
@@ -2757,7 +2780,11 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
             foreach (var lineSpan in header.EnumerateSpanLines())
             {
                 var trimmed = lineSpan.Trim();
-                if (trimmed.StartsWith("format:".AsSpan(), StringComparison.OrdinalIgnoreCase))
+                if (trimmed.Equals("[v4+ styles]".AsSpan(), StringComparison.OrdinalIgnoreCase))
+                {
+                    sawV4PlusSection = true;
+                }
+                else if (trimmed.StartsWith("format:".AsSpan(), StringComparison.OrdinalIgnoreCase))
                 {
                     if (lineSpan.Length > 10)
                     {
@@ -2859,6 +2886,11 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                                 borderStyleIndex = i;
                             }
                         }
+
+                        // "TertiaryColour" without an "OutlineColour" marks a Sub Station Alpha v4
+                        // "[V4 Styles]" format line - unless a "[V4+ Styles]" section said otherwise,
+                        // which a few files in the wild do while still naming the field Tertiary.
+                        isSsaV4Format = tertiaryColourIndex >= 0 && outlineColourIndex < 0 && !sawV4PlusSection;
                     }
                 }
                 else if (StartsWithStyleColonIgnoringSpaces(trimmed))
@@ -2897,6 +2929,11 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                             else if (i == tertiaryColourIndex)
                             {
                                 style.Tertiary = GetSsaColor(f, SKColors.Yellow);
+
+                                // Sub Station Alpha v4's TertiaryColour is what [V4+ Styles] calls
+                                // OutlineColour - keep Outline in sync, or an .ssa file's outline
+                                // color is dropped on every read (nothing else fills Outline). #13734
+                                style.Outline = GetSsaColor(f, SKColors.Black);
                             }
                             else if (i == outlineColourIndex)
                             {
@@ -2938,7 +2975,11 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                             }
                             else if (i == alignmentIndex)
                             {
-                                style.Alignment = f;
+                                // Sub Station Alpha v4 numbers alignment differently from [V4+ Styles]
+                                // (5-7 = top, 9-11 = middle). SsaStyle.Alignment is "an1"-"an9"
+                                // everywhere else, so normalize here instead of leaving every caller
+                                // to guess which dialect the header spoke. #13734
+                                style.Alignment = isSsaV4Format ? SsaV4AlignmentToAssAlignment(f) : f;
                             }
                             else if (i == marginLIndex)
                             {

--- a/src/libse/SubtitleFormats/SubStationAlpha.cs
+++ b/src/libse/SubtitleFormats/SubStationAlpha.cs
@@ -98,13 +98,16 @@ Format: Marked, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
                     boldStyle = "-1"; // -1 = true, 0 is false
                 }
 
-                sb.AppendLine(string.Format(header,
+                // Invariant, or a comma-decimal locale would split a fractional font size/outline
+                // width into two fields and wreck the style line.
+                sb.AppendLine(string.Format(CultureInfo.InvariantCulture,
+                                            header,
                                             title,
                                             style.FontName,
                                             style.FontSize,
                                             ColorTranslator.ToWin32(style.Primary),
                                             ColorTranslator.ToWin32(style.Secondary),
-                                            ColorTranslator.ToWin32(style.Tertiary),
+                                            ColorTranslator.ToWin32(style.Outline), // SSA v4's TertiaryColour is the outline color
                                             ColorTranslator.ToWin32(style.Background),
                                             style.OutlineWidth,
                                             style.ShadowWidth,
@@ -251,41 +254,18 @@ Format: Marked, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
                         italic = "-1";
                     }
 
-                    var newAlignment = "2";
-                    switch (ssaStyle.Alignment)
-                    {
-                        case "1":
-                            newAlignment = "1";
-                            break;
-                        case "3":
-                            newAlignment = "3";
-                            break;
-                        case "4":
-                            newAlignment = "9";
-                            break;
-                        case "5":
-                            newAlignment = "10";
-                            break;
-                        case "6":
-                            newAlignment = "11";
-                            break;
-                        case "7":
-                            newAlignment = "5";
-                            break;
-                        case "8":
-                            newAlignment = "6";
-                            break;
-                        case "9":
-                            newAlignment = "7";
-                            break;
-                    }
+                    var newAlignment = AdvancedSubStationAlpha.AssAlignmentToSsaV4Alignment(ssaStyle.Alignment);
 
                     //Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, TertiaryColour, BackColour, Bold, Italic, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, AlphaLevel, Encoding
-                    const string styleFormat = "Style: {0},{1},{2:0.#},{3},{4},{5},{6},{7},{8},{9},{10},{11},{12},{13},{14},{15},0,1";
+                    const string styleFormat = "Style: {0},{1},{2},{3},{4},{5},{6},{7},{8},{9},{10},{11},{12},{13},{14},{15},0,1";
                     //                                 N   FN  FS  PC  SC  TC  BC  Bo  It  BS  O    Sh   Ali  ML   MR   MV   A Encoding
 
-                    ttStyles.AppendLine(string.Format(styleFormat, ssaStyle.Name, ssaStyle.FontName, ssaStyle.FontSize, ssaStyle.Primary.ToArgb(), ssaStyle.Secondary.ToArgb(),
-                        ssaStyle.Outline.ToArgb(), ssaStyle.Background.ToArgb(), bold, italic, ssaStyle.BorderStyle, ssaStyle.OutlineWidth.ToString(CultureInfo.InvariantCulture), ssaStyle.ShadowWidth.ToString(CultureInfo.InvariantCulture),
+                    // Sub Station Alpha v4 colors are plain "&H00BBGGRR" decimals - no alpha byte
+                    // (ToArgb() wrote e.g. 4294967040 for yellow, which players and SE itself
+                    // reject, so the color was lost on the next open). #13734
+                    ttStyles.AppendLine(string.Format(CultureInfo.InvariantCulture, styleFormat, ssaStyle.Name, ssaStyle.FontName, ssaStyle.FontSize.ToString("0.#", CultureInfo.InvariantCulture),
+                        ColorTranslator.ToWin32(ssaStyle.Primary), ColorTranslator.ToWin32(ssaStyle.Secondary),
+                        ColorTranslator.ToWin32(ssaStyle.Outline), ColorTranslator.ToWin32(ssaStyle.Background), bold, italic, ssaStyle.BorderStyle, ssaStyle.OutlineWidth.ToString(CultureInfo.InvariantCulture), ssaStyle.ShadowWidth.ToString(CultureInfo.InvariantCulture),
                         newAlignment, ssaStyle.MarginLeft, ssaStyle.MarginRight, ssaStyle.MarginVertical));
                 }
                 catch

--- a/src/ui/Features/Ssa/SsaStylesWindow.cs
+++ b/src/ui/Features/Ssa/SsaStylesWindow.cs
@@ -379,14 +379,17 @@ public class SsaStylesWindow : Window
         return grid;
     }
 
+    /// <summary>
+    /// The style editor for "[V4 Styles]". Underline, strikeout, scale, spacing and angle are
+    /// deliberately absent: a Sub Station Alpha v4 style line has no such fields, so editing them
+    /// here would only have thrown the values away on save (#13734). Use .ass for those.
+    /// </summary>
     private static Border MakeSelectedStyleView(SsaStylesViewModel vm)
     {
         var grid = new Grid
         {
             RowDefinitions =
             {
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
@@ -419,25 +422,7 @@ public class SsaStylesWindow : Window
 
         var checkBoxBold = UiUtil.MakeCheckBox(Se.Language.General.Bold, vm, nameof(vm.CurrentStyle) + "." + nameof(StyleDisplay.Bold));
         var checkBoxItalic = UiUtil.MakeCheckBox(Se.Language.General.Italic, vm, nameof(vm.CurrentStyle) + "." + nameof(StyleDisplay.Italic));
-        var checkBoxUnderline = UiUtil.MakeCheckBox(Se.Language.General.Underline, vm, nameof(vm.CurrentStyle) + "." + nameof(StyleDisplay.Underline));
-        var checkBoxStrikeout = UiUtil.MakeCheckBox(Se.Language.General.Strikeout, vm, nameof(vm.CurrentStyle) + "." + nameof(StyleDisplay.Strikeout));
-        var panelFontStyle = UiUtil.MakeHorizontalPanel(checkBoxBold, checkBoxItalic, checkBoxUnderline, checkBoxStrikeout).WithMarginBottom(10);
-
-        var labelScaleX = UiUtil.MakeLabel(Se.Language.Assa.ScaleX).WithMinWidth(60);
-        var numericUpDownScaleX = UiUtil.MakeNumericUpDownOneDecimal(1, 1000, 130, vm, nameof(vm.CurrentStyle) + "." + nameof(StyleDisplay.ScaleX));
-        numericUpDownScaleX.Increment = 1;
-        var labelScaleY = UiUtil.MakeLabel(Se.Language.Assa.ScaleY).WithMinWidth(60);
-        var numericUpDownScaleY = UiUtil.MakeNumericUpDownOneDecimal(1, 1000, 130, vm, nameof(vm.CurrentStyle) + "." + nameof(StyleDisplay.ScaleY));
-        numericUpDownScaleY.Increment = 1;
-        var panelTransform1 = UiUtil.MakeHorizontalPanel(labelScaleX, numericUpDownScaleX, labelScaleY, numericUpDownScaleY);
-
-        var labelSpacing = UiUtil.MakeLabel(Se.Language.Assa.Spacing).WithMinWidth(60);
-        var numericUpDownSpacing = UiUtil.MakeNumericUpDownOneDecimal(-100, 100, 130, vm, nameof(vm.CurrentStyle) + "." + nameof(StyleDisplay.Spacing));
-        numericUpDownSpacing.Increment = 1;
-        var labelAngle = UiUtil.MakeLabel(Se.Language.Assa.Angle).WithMinWidth(60);
-        var numericUpDownAngle = UiUtil.MakeNumericUpDownOneDecimal(-360, 360, 130, vm, nameof(vm.CurrentStyle) + "." + nameof(StyleDisplay.Angle));
-        numericUpDownAngle.Increment = 1;
-        var panelTransform2 = UiUtil.MakeHorizontalPanel(labelSpacing, numericUpDownSpacing, labelAngle, numericUpDownAngle).WithMarginBottom(10);
+        var panelFontStyle = UiUtil.MakeHorizontalPanel(checkBoxBold, checkBoxItalic).WithMarginBottom(10);
 
         var labelColorPrimary = UiUtil.MakeLabel(Se.Language.Assa.Primary);
         var colorPickerPrimary = MakeStyleColorPickerButton(vm, nameof(StyleDisplay.ColorPrimary));
@@ -467,10 +452,8 @@ public class SsaStylesWindow : Window
         grid.Add(panelName, 1, 0);
         grid.Add(panelFont, 2, 0);
         grid.Add(panelFontStyle, 3, 0);
-        grid.Add(panelTransform1, 4, 0);
-        grid.Add(panelTransform2, 5, 0);
-        grid.Add(panelColors, 6, 0);
-        grid.Add(panelMore, 7, 0);
+        grid.Add(panelColors, 4, 0);
+        grid.Add(panelMore, 5, 0);
 
         return UiUtil.MakeBorderForControl(grid).WithMarginBottom(5);
     }

--- a/tests/libse/SubtitleFormats/SubStationAlphaTest.cs
+++ b/tests/libse/SubtitleFormats/SubStationAlphaTest.cs
@@ -1,6 +1,9 @@
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using SkiaSharp;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
 
 namespace LibSETests.SubtitleFormats;
 
@@ -63,5 +66,136 @@ Dialogue: Marked=0,0:20:24.01,0:20:26.44,*Default,NTP,0000,0000,0000,,Du wirst s
         Assert.Contains("[Script Info]", subtitle.Header);
         Assert.Contains("[V4 Styles]", subtitle.Header);
         Assert.DoesNotContain("Dialogue:", subtitle.Header, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string SsaWithStyle(string styleLine) => @"[Script Info]
+; This is a Sub Station Alpha v4 script.
+Title: t
+ScriptType: v4.00
+Collisions: Normal
+PlayDepth: 0
+
+[V4 Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, TertiaryColour, BackColour, Bold, Italic, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, AlphaLevel, Encoding
+" + styleLine + @"
+
+[Events]
+Format: Marked, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+Dialogue: Marked=0,0:00:01.00,0:00:02.00,*Default,NTP,0000,0000,0000,,Hello";
+
+    /// <summary>
+    /// What the styles dialog does on OK: read the styles out of the .ssa header and write them
+    /// straight back. Nothing was edited, so the style line must come back unchanged.
+    /// </summary>
+    private static string StylesDialogRoundTrip(string styleLine)
+    {
+        var subtitle = new Subtitle();
+        new SubStationAlpha().LoadSubtitle(subtitle, new List<string>(SsaWithStyle(styleLine).SplitToLines()), "test.ssa");
+
+        var styles = AdvancedSubStationAlpha.GetSsaStylesFromHeader(subtitle.Header);
+        var assaHeader = AdvancedSubStationAlpha.GetHeaderAndStylesFromAdvancedSubStationAlpha(subtitle.Header, styles);
+        var ssaHeader = SubStationAlpha.GetHeaderAndStylesFromAdvancedSubStationAlpha(assaHeader, string.Empty);
+
+        foreach (var line in ssaHeader.SplitToLines())
+        {
+            if (line.StartsWith("Style:", System.StringComparison.Ordinal))
+            {
+                return line;
+            }
+        }
+
+        return string.Empty;
+    }
+
+    // Issue #13734: colors were written as 32-bit ARGB ("4294967040" for yellow) instead of the
+    // "&H00BBGGRR" decimal SSA v4 uses, so every color was rejected by players and lost on reopen.
+    [Fact]
+    public void StyleColorsSurviveTheStylesDialog()
+    {
+        // yellow primary/secondary, red tertiary (= outline), blue back
+        const string styleLine = "Style: Default,Arial,20,65535,65535,255,16711680,0,0,1,2,3,2,11,12,13,0,1";
+
+        Assert.Equal(styleLine, StylesDialogRoundTrip(styleLine));
+    }
+
+    // Issue #13734: outline width, shadow width and the three margins came back as the defaults.
+    [Fact]
+    public void StyleNumbersSurviveTheStylesDialog()
+    {
+        const string styleLine = "Style: Default,Arial,22,16777215,65535,0,0,-1,-1,3,2,3,2,11,12,13,0,1";
+
+        Assert.Equal(styleLine, StylesDialogRoundTrip(styleLine));
+    }
+
+    // Issue #13734: SSA v4 numbers alignment 5-7 top and 9-11 middle, which was read as if it were
+    // the "an1"-"an9" of [V4+ Styles] - top left came back as middle center, and 10/11 as bottom.
+    [Theory]
+    [InlineData("1")]
+    [InlineData("2")]
+    [InlineData("3")]
+    [InlineData("5")]
+    [InlineData("6")]
+    [InlineData("7")]
+    [InlineData("9")]
+    [InlineData("10")]
+    [InlineData("11")]
+    public void StyleAlignmentSurvivesTheStylesDialog(string alignment)
+    {
+        var styleLine = $"Style: Default,Arial,20,16777215,65535,0,0,0,0,1,1,1,{alignment},10,10,10,0,1";
+
+        Assert.Equal(styleLine, StylesDialogRoundTrip(styleLine));
+    }
+
+    // A comma-decimal locale must not split a fractional font size into two fields.
+    [Fact]
+    public void StyleWithFractionalFontSizeIsWrittenInvariantly()
+    {
+        var oldCulture = Thread.CurrentThread.CurrentCulture;
+        try
+        {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("da-DK");
+            const string styleLine = "Style: Default,Arial,20.5,16777215,65535,0,0,0,0,1,1.5,1,2,10,10,10,0,1";
+
+            Assert.Equal(styleLine, StylesDialogRoundTrip(styleLine));
+        }
+        finally
+        {
+            Thread.CurrentThread.CurrentCulture = oldCulture;
+        }
+    }
+
+    // Converting .ssa to .ass must carry the outline colour (SSA's TertiaryColour) and the
+    // widths/margins over - all of them used to be reset to defaults.
+    [Fact]
+    public void ConvertingToAdvancedSubStationAlphaKeepsStyleValues()
+    {
+        var subtitle = new Subtitle();
+        new SubStationAlpha().LoadSubtitle(
+            subtitle,
+            new List<string>(SsaWithStyle("Style: Default,Arial,20,65535,65535,255,16711680,0,0,1,2,3,6,11,12,13,0,1").SplitToLines()),
+            "test.ssa");
+
+        var assaHeader = AdvancedSubStationAlpha.GetHeaderAndStylesFromSubStationAlpha(subtitle.Header);
+        var style = AdvancedSubStationAlpha.GetSsaStyle("Default", assaHeader);
+
+        Assert.Equal(SKColors.Yellow, style.Primary);
+        Assert.Equal(SKColors.Red, style.Outline);
+        Assert.Equal(SKColors.Blue, style.Background);
+        Assert.Equal(2m, style.OutlineWidth);
+        Assert.Equal(3m, style.ShadowWidth);
+        Assert.Equal(11, style.MarginLeft);
+        Assert.Equal(12, style.MarginRight);
+        Assert.Equal(13, style.MarginVertical);
+        Assert.Equal("8", style.Alignment); // SSA 6 (top center) is "an8"
+    }
+
+    // Files SE already wrote with the too-wide value must not read back as the default color.
+    [Fact]
+    public void OverlyWideColorValueIsStillParsed()
+    {
+        // 4294967040 == 0xFFFFFF00, the 32-bit "&HAABBGGRR" word written unsigned
+        var color = AdvancedSubStationAlpha.GetSsaColor("4294967040", SKColors.White);
+
+        Assert.Equal(SKColors.Cyan, color);
     }
 }


### PR DESCRIPTION
Fixes #13734.

## The reported bug

Setting a style color in an `.ssa` file did not stick, and SE4 flagged the resulting file as broken. SE5 wrote:

```
Style: Default,Arial,20,4294967040,4294967040,4278190080,4278190080,0,0,1,1,1,2,10,10,10,0,1
```

where SE4 writes:

```
Style: Default,Arial,20,65535,65535,0,0,0,0,1,1,1,2,10,10,10,0,1
```

`4294967040` is `Color.ToArgb()` for yellow — a 32-bit `0xAARRGGBB` word. Sub Station Alpha v4 style colors are plain `&H00BBGGRR` decimals with no alpha byte, so players rejected the value, and SE's own reader (`int.TryParse`) could not even parse it back, which is why the picked color disappeared on the next open.

Hunting around that led to five more defects in the same area.

## What is fixed

| | Symptom |
|---|---|
| Colors written as 32-bit ARGB | Every style color unusable and lost on reopen |
| `TertiaryColour` read into `SsaStyle.Tertiary`, which nothing consumes | Outline color of every `.ssa` file dropped on read and on convert to `.ass` |
| SSA v4 alignment (5–7 top, 9–11 middle) read as if it were `an1`–`an9` | Top-left came back as middle-center; 10/11 as bottom-center |
| `SsaStyle.FromRawSsa` parsed the field *name* instead of its value | Outline width, shadow width and all three margins reset to defaults when converting to `.ass` (also used for the mpv/VLC preview) |
| Fractional font size formatted with the current culture | A comma-decimal locale split it into two fields and wrecked the style line |
| `GetSsaColor` rejected values above `int.MaxValue` | Files SE already wrote read back as white |

Along the way the two hand-rolled SSA↔ASS alignment conversion tables (which had drifted out of sync with the reader) are replaced by a shared pair of helpers, `SsaV4AlignmentToAssAlignment` / `AssAlignmentToSsaV4Alignment`.

Also: the `.ssa` styles window no longer offers underline, strikeout, scale X/Y, spacing and angle. A Sub Station Alpha v4 style line has no such fields, so editing them there only threw the values away on save — those belong to `.ass`.

## Verification

A round trip through the styles dialog (read the header, write it straight back) now returns the style line byte-identical, which it did not for any of colors, alignment, margins, widths or a fractional font size. New tests in `SubStationAlphaTest` cover each of those plus the `.ssa` → `.ass` conversion.

Running the reporter's own scenario — open their SE4 file, pick yellow as the text color, save — now produces exactly SE4's line, and the color survives reopening.

All suites pass: libse 1322, libuilogic 230, seconv 376, UI 2981.

🤖 Generated with [Claude Code](https://claude.com/claude-code)