### PR TITLE
Chatterbox: versioned V3 models + cross-lingual source_lang

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/ChatterboxTtsSettings/ChatterboxTtsSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ChatterboxTtsSettings/ChatterboxTtsSettingsViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Input;
@@ -42,6 +43,22 @@ public partial class ChatterboxTtsSettingsViewModel : ObservableObject
     /// </summary>
     public ObservableCollection<ChatterboxModelStatusViewModel> Models { get; } = new();
 
+    /// <summary>
+    /// Language spoken in imported reference WAVs, sent as the request's <c>source_lang</c> field
+    /// so cross-lingual cloning engages when the target language differs. "Auto" (empty code)
+    /// sends no field, which leaves the clone speaking the target language with the reference
+    /// language's accent. Chatterbox clones from the WAV alone and never asks for a transcript,
+    /// so unlike CosyVoice3 there is usually nothing to detect this from.
+    /// </summary>
+    public ObservableCollection<TtsLanguage> SourceLanguages { get; } = new(ChatterboxLanguages.All);
+
+    [ObservableProperty] private TtsLanguage? _selectedSourceLanguage;
+
+    partial void OnSelectedSourceLanguageChanged(TtsLanguage? value)
+    {
+        Se.Settings.Video.TextToSpeech.ChatterboxCrispAsrSourceLanguage = value?.Code ?? string.Empty;
+    }
+
     public ChatterboxTtsSettingsViewModel(IWindowService windowService, IFolderHelper folderHelper)
     {
         _windowService = windowService;
@@ -65,6 +82,10 @@ public partial class ChatterboxTtsSettingsViewModel : ObservableObject
     {
         ModelsFolder = ChatterboxTtsCpp.GetSetModelsFolder();
         VoicesFolder = ChatterboxTtsCpp.GetSetVoicesFolder();
+        var savedSourceLanguage = Se.Settings.Video.TextToSpeech.ChatterboxCrispAsrSourceLanguage;
+        SelectedSourceLanguage =
+            SourceLanguages.FirstOrDefault(l => l.Code == savedSourceLanguage && !string.IsNullOrEmpty(l.Code))
+            ?? SourceLanguages.FirstOrDefault();
         Refresh();
     }
 

--- a/src/ui/Features/Video/TextToSpeech/ChatterboxTtsSettings/ChatterboxTtsSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ChatterboxTtsSettings/ChatterboxTtsSettingsWindow.cs
@@ -102,6 +102,8 @@ public class ChatterboxTtsSettingsWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnSpacing = 12,
             RowSpacing = 10,
@@ -132,6 +134,25 @@ public class ChatterboxTtsSettingsWindow : Window
             [!TextBox.TextProperty] = new Binding(nameof(vm.ModelsFolder)),
         };
         grid.Add(folderText, 3, 1);
+
+        // Language spoken in imported reference WAVs — sent as `source_lang` so cross-lingual
+        // cloning engages when the target language differs. Chatterbox clones from the WAV alone
+        // and never asks for a transcript, so there is normally nothing to detect this from.
+        grid.Add(MakeLabel("Reference language"), 4, 0);
+        var sourceLanguageCombo = UiUtil.MakeComboBox(vm.SourceLanguages, vm, nameof(vm.SelectedSourceLanguage));
+        var sourceLanguageHint = new TextBlock
+        {
+            Text = "Language spoken in imported reference WAVs (for cross-lingual cloning).",
+            FontSize = 12,
+            Opacity = 0.75,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(8, 0, 0, 0),
+        };
+        grid.Add(new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { sourceLanguageCombo, sourceLanguageHint },
+        }, 4, 1);
 
         return new Border
         {

--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxLanguages.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxLanguages.cs
@@ -13,10 +13,10 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 /// The codes are ISO 639-1 two-letter IDs. CrispASR's chatterbox backend turns the request's
 /// <c>language</c> field into the <c>[xx]</c> language token it prepends to the T3 prompt —
 /// the same mechanism as its CLI <c>-l</c> flag. This only has an effect on the multilingual
-/// Base GGUFs (2454-token text vocab); see
-/// <see cref="Logic.Download.ChatterboxTtsCppDownloadService.IsLegacyEnglishOnlyModel"/> for how
-/// pre-multilingual files are detected and re-downloaded. Chatterbox Turbo is an English-only
-/// distillation, so <see cref="ChatterboxTtsCpp.GetLanguages"/> offers it "Auto" alone.
+/// Base GGUFs (2454-token text vocab), which is what the versioned <c>chatterbox-v3-*</c> pair
+/// in <see cref="Logic.Download.ChatterboxTtsCppDownloadService"/> guarantees. Chatterbox Turbo
+/// is an English-only distillation, so <see cref="ChatterboxTtsCpp.GetLanguages"/> offers it
+/// "Auto" alone.
 ///
 /// The multilingual tokenizer actually carries a few more tags (bg, cs, hu, ro, sk, ta, vi and
 /// special tags like [ipa]); only the 23 languages ResembleAI ships and documents are listed

--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxLanguages.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxLanguages.cs
@@ -1,3 +1,4 @@
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Linq;
@@ -123,4 +124,59 @@ internal static class ChatterboxLanguages
     public static bool IsSupported(string? code) =>
         !string.IsNullOrWhiteSpace(code)
         && Catalog.Any(l => string.Equals(l.Code, code, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// The language of a cloning reference, sent as the request's <c>source_lang</c> field: the
+    /// explicit "Reference language" pick from the engine settings window first, then a
+    /// best-effort detection over <paramref name="refText"/> (the transcript sidecar beside the
+    /// reference WAV, when the user wrote one).
+    /// </summary>
+    /// <remarks>
+    /// Chatterbox V3 follows upstream's cross-lingual recommendation once it knows what language
+    /// the reference is spoken in: it drops to CFG weight 0, which keeps the speaker's timbre
+    /// while shedding the reference language's accent. Without it an English reference asked for
+    /// German keeps the English accent — the same hole CosyVoice3 had in #13272, and the reason
+    /// the server grew a per-request <c>source_lang</c> in CrispASR v0.8.29 (#329).
+    ///
+    /// Unlike CosyVoice3, Chatterbox clones from the WAV alone and never asks for a transcript,
+    /// so the settings pick is the path most users will take; the sidecar is only read when one
+    /// happens to exist (which is what a reference cut by another SE feature leaves behind).
+    /// </remarks>
+    public static string ResolveSourceLanguageArg(string? refText)
+    {
+        var configured = (Se.Settings.Video.TextToSpeech.ChatterboxCrispAsrSourceLanguage ?? string.Empty).Trim();
+        if (IsSupported(configured))
+        {
+            return configured;
+        }
+
+        return DetectSourceLanguage(refText);
+    }
+
+    /// <summary>
+    /// Best-effort language of <paramref name="refText"/>, or an empty string when it cannot be
+    /// determined or is not one of Chatterbox's 23 languages. Uses the same detector the rest of
+    /// SE uses for subtitle language (function words first, then writing system).
+    /// </summary>
+    public static string DetectSourceLanguage(string? refText)
+    {
+        if (string.IsNullOrWhiteSpace(refText))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var subtitle = new Subtitle();
+            subtitle.Paragraphs.Add(new Paragraph(refText, 0, 0));
+            var detected = LanguageAutoDetect.AutoDetectGoogleLanguageOrNull(subtitle);
+            return IsSupported(detected) ? detected! : string.Empty;
+        }
+        catch
+        {
+            // Detection is an optimization - a failure just means we send no source_lang and the
+            // clone stays plain zero-shot.
+            return string.Empty;
+        }
+    }
 }

--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
@@ -369,11 +369,34 @@ public class ChatterboxTtsCpp : ITtsEngine
             ? string.Empty
             : ChatterboxLanguages.ResolveLanguageArg(language);
 
-        var payload = BuildSpeakPayload(inputText, chatterboxVoice.FilePath, languageArg);
+        // Language the reference recording is spoken in (CrispASR v0.8.29 / #329). The backend
+        // needs BOTH sides before it goes cross-lingual, so without this an English reference
+        // asked for German keeps the English accent. Only meaningful when actually cloning and
+        // when a target language was asked for at all.
+        var sourceLanguageArg = !string.IsNullOrEmpty(chatterboxVoice.FilePath) && !string.IsNullOrEmpty(languageArg)
+            ? ChatterboxLanguages.ResolveSourceLanguageArg(TryReadReferenceTranscript(chatterboxVoice.FilePath))
+            : string.Empty;
+
+        if (string.IsNullOrEmpty(sourceLanguageArg)
+            && !string.IsNullOrEmpty(chatterboxVoice.FilePath)
+            && !string.IsNullOrEmpty(languageArg))
+        {
+            // Target language asked for, reference language unknowable: the clone keeps the
+            // reference's accent and nothing in the 200 response says so. Same wording as the
+            // CosyVoice3 path, which hit this first.
+            Se.WriteToolsLog(
+                $"Chatterbox TTS: target language '{languageArg}' requested for cloned voice "
+                + $"'{chatterboxVoice}', but the language of its reference WAV is unknown. Synthesis "
+                + "stays zero-shot and keeps the reference's accent - set \"Reference language\" in "
+                + "the Chatterbox settings window to enable cross-lingual synthesis.",
+                true);
+        }
+
+        var payload = BuildSpeakPayload(inputText, chatterboxVoice.FilePath, languageArg, sourceLanguageArg);
 
         var body = JsonSerializer.Serialize(payload);
         using var content = new StringContent(body, Encoding.UTF8, "application/json");
-        Se.WriteToolsLog($"Chatterbox TTS: POST {ServerBaseUrl}/v1/audio/speech (voice={chatterboxVoice}, model={modelKey}, textLen={text.Length}, language={(string.IsNullOrEmpty(languageArg) ? "(auto)" : languageArg)})");
+        Se.WriteToolsLog($"Chatterbox TTS: POST {ServerBaseUrl}/v1/audio/speech (voice={chatterboxVoice}, model={modelKey}, textLen={text.Length}, language={(string.IsNullOrEmpty(languageArg) ? "(auto)" : languageArg)}, sourceLanguage={(string.IsNullOrEmpty(sourceLanguageArg) ? "(none)" : sourceLanguageArg)})");
         HttpResponseMessage response;
         try
         {
@@ -465,7 +488,11 @@ public class ChatterboxTtsCpp : ITtsEngine
     /// the one SE engine that hard-requires the attestations. An empty path falls back to the
     /// model's baked default voice, which is not cloning and needs no attestation.
     /// </remarks>
-    internal static Dictionary<string, object> BuildSpeakPayload(string inputText, string? voiceFilePath, string? languageCode = null)
+    internal static Dictionary<string, object> BuildSpeakPayload(
+        string inputText,
+        string? voiceFilePath,
+        string? languageCode = null,
+        string? sourceLanguageCode = null)
     {
         var payload = new Dictionary<string, object>
         {
@@ -478,6 +505,15 @@ public class ChatterboxTtsCpp : ITtsEngine
             payload["language"] = languageCode;
         }
 
+        // Only alongside a reference and a target language: on its own the field says what a
+        // recording that is not being cloned from is spoken in, which is nothing.
+        if (!string.IsNullOrEmpty(sourceLanguageCode)
+            && !string.IsNullOrEmpty(voiceFilePath)
+            && !string.IsNullOrEmpty(languageCode))
+        {
+            payload["source_lang"] = sourceLanguageCode;
+        }
+
         if (!string.IsNullOrEmpty(voiceFilePath))
         {
             payload["voice"] = Path.GetFileName(voiceFilePath);
@@ -485,6 +521,37 @@ public class ChatterboxTtsCpp : ITtsEngine
         }
 
         return payload;
+    }
+
+    /// <summary>
+    /// The spoken text of a reference WAV, read from the <c>.txt</c> sidecar the other cloning
+    /// engines use, or null when there is none. Chatterbox itself never needs the transcript —
+    /// it clones from the audio alone — so this exists only to detect what language the
+    /// reference is in for <c>source_lang</c>.
+    /// </summary>
+    internal static string? TryReadReferenceTranscript(string? referenceWavPath)
+    {
+        if (string.IsNullOrEmpty(referenceWavPath))
+        {
+            return null;
+        }
+
+        try
+        {
+            var sidecar = Path.ChangeExtension(referenceWavPath, ".txt");
+            if (!File.Exists(sidecar))
+            {
+                return null;
+            }
+
+            var text = File.ReadAllText(sidecar).Trim();
+            return string.IsNullOrEmpty(text) ? null : text;
+        }
+        catch
+        {
+            // A sidecar we cannot read is the same as no sidecar - detection just declines.
+            return null;
+        }
     }
 
     /// <summary>

--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
@@ -274,17 +274,14 @@ public class ChatterboxTtsCpp : ITtsEngine
     public static string GetS3GenModelPath(string? modelKey = null) =>
         Path.Combine(GetSetModelsFolder(), ChatterboxTtsCppDownloadService.GetS3GenFileName(ResolveModelKey(modelKey)));
 
-    // Legacy pre-multilingual Base GGUFs (English-only T3, downloaded before upstream's
-    // 2026-06-18 in-place rebuild of cstr/chatterbox-GGUF) count as NOT installed so the
-    // normal "Download models?" prompt re-fetches the multilingual files — without this,
-    // picking a language changes nothing for those users and there is no visible reason why.
+    // A plain existence check is enough now that the Base pair is the versioned chatterbox-v3-*
+    // artifact: the file name pins which weights it is, so nothing on disk can quietly become
+    // something else. The byte-size probe this replaced existed only because upstream rebuilt
+    // the unversioned names in place (English-only -> multilingual) and left the old files
+    // looking installed; users still holding those get them deleted after the V3 download.
     public static bool AreModelsInstalled(string? modelKey = null)
     {
-        var t3Path = GetT3ModelPath(modelKey);
-        var s3genPath = GetS3GenModelPath(modelKey);
-        return File.Exists(t3Path) && File.Exists(s3genPath)
-            && !ChatterboxTtsCppDownloadService.IsLegacyEnglishOnlyModel(t3Path)
-            && !ChatterboxTtsCppDownloadService.IsLegacyEnglishOnlyModel(s3genPath);
+        return File.Exists(GetT3ModelPath(modelKey)) && File.Exists(GetS3GenModelPath(modelKey));
     }
 
     public Task<Voice[]> GetVoices(string language)

--- a/src/ui/Logic/Config/SeVideoTextToSpeech.cs
+++ b/src/ui/Logic/Config/SeVideoTextToSpeech.cs
@@ -73,6 +73,7 @@ public class SeVideoTextToSpeech
     public string OmniVoiceTtsCppInstruction { get; set; }
     public string ChatterboxModel { get; set; }
     public string ChatterboxCrispAsrLanguage { get; set; }
+    public string ChatterboxCrispAsrSourceLanguage { get; set; }
     public string KokoroVoice { get; set; }
     public string GoogleApiKey { get; set; }
     public string GoogleKeyFile { get; set; }
@@ -182,6 +183,7 @@ public class SeVideoTextToSpeech
         OmniVoiceTtsCppInstruction = string.Empty;
         ChatterboxModel = "Base";
         ChatterboxCrispAsrLanguage = string.Empty;
+        ChatterboxCrispAsrSourceLanguage = string.Empty;
         KokoroVoice = "af_maple";
         GoogleApiKey = string.Empty;
         GoogleKeyFile = string.Empty;

--- a/src/ui/Logic/Download/ChatterboxTtsCppDownloadService.cs
+++ b/src/ui/Logic/Download/ChatterboxTtsCppDownloadService.cs
@@ -1,3 +1,4 @@
+using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.IO;
 using System.Net.Http;
@@ -29,12 +30,19 @@ public class ChatterboxTtsCppDownloadService : IChatterboxTtsCppDownloadService
     public static string[] GetAllModelKeys() =>
         new[] { ModelKeyBase, ModelKeyBaseF16, ModelKeyBaseQ4K, ModelKeyTurbo };
 
-    public const string BaseT3FileName = "chatterbox-t3-q8_0.gguf";
-    public const string BaseS3GenFileName = "chatterbox-s3gen-q8_0.gguf";
-    public const string BaseF16T3FileName = "chatterbox-t3-f16.gguf";
-    public const string BaseF16S3GenFileName = "chatterbox-s3gen-f16.gguf";
-    public const string BaseQ4KT3FileName = "chatterbox-t3-q4_k.gguf";
-    public const string BaseQ4KS3GenFileName = "chatterbox-s3gen-q4_k.gguf";
+    // The Base pair is the versioned V3 artifact: upstream's production multilingual checkpoint
+    // (t3_mtl23ls_v3 + the original s3gen), pinned to ResembleAI revision 5bb1f6ee and recorded
+    // as such in the GGUF's own general.source.revision. The unversioned chatterbox-t3-*.gguf
+    // names it replaces are back-compat aliases that upstream reserves the right to rebuild in
+    // place — which is exactly what happened on 2026-06-18 and cost SE a byte-size hack to
+    // detect. A versioned file name is the durable fix: a rebuild lands on a new name instead of
+    // silently changing what is already on disk.
+    public const string BaseT3FileName = "chatterbox-v3-t3-q8_0.gguf";
+    public const string BaseS3GenFileName = "chatterbox-v3-s3gen-q8_0.gguf";
+    public const string BaseF16T3FileName = "chatterbox-v3-t3-f16.gguf";
+    public const string BaseF16S3GenFileName = "chatterbox-v3-s3gen-f16.gguf";
+    public const string BaseQ4KT3FileName = "chatterbox-v3-t3-q4_k.gguf";
+    public const string BaseQ4KS3GenFileName = "chatterbox-v3-s3gen-q4_k.gguf";
     public const string TurboT3FileName = "chatterbox-turbo-t3-q8_0.gguf";
     public const string TurboS3GenFileName = "chatterbox-turbo-s3gen-q8_0.gguf";
 
@@ -77,13 +85,14 @@ public class ChatterboxTtsCppDownloadService : IChatterboxTtsCppDownloadService
 
     /// <summary>
     /// Approximate on-disk size of the T3 + S3Gen pair, for the "download these now?" prompt.
-    /// Measured from the actual files on cstr/chatterbox-GGUF (2026-08-12).
+    /// Measured from the actual files on cstr/chatterbox-GGUF (2026-08-16). The Q4_K pair grew
+    /// with the move to the V3 artifacts - its S3Gen half is 314 MB rather than 255 MB.
     /// </summary>
     public static string GetDownloadSizeText(string? modelKey) => ResolveModelKey(modelKey) switch
     {
         ModelKeyTurbo => "~1 GB",
         ModelKeyBaseF16 => "~1.8 GB",
-        ModelKeyBaseQ4K => "~640 MB",
+        ModelKeyBaseQ4K => "~700 MB",
         _ => "~1 GB",
     };
 
@@ -96,38 +105,44 @@ public class ChatterboxTtsCppDownloadService : IChatterboxTtsCppDownloadService
     public static string GetBackendName(string? modelKey) =>
         ResolveModelKey(modelKey) == ModelKeyTurbo ? "chatterbox-turbo" : "chatterbox";
 
-    // cstr/chatterbox-GGUF was rebuilt IN PLACE around 2026-06-18: the same file names went
-    // from the English-only v1 weights (T3 text vocab 704) to the multilingual weights
-    // (text vocab 2454, with the [de]/[fr]/... language tokens the `language` request field
-    // needs). Anyone who downloaded before the rebuild still has the English-only files and a
-    // bare File.Exists check would keep them forever — language selection then changes nothing
-    // and non-English text comes out as accented gibberish. These are the exact byte sizes of
-    // the legacy files, used to force a re-download; the Turbo repo was not part of the rebuild.
-    private const long LegacyBaseT3Size = 630_177_120;
-    private const long LegacyBaseS3GenSize = 358_278_528;
+    /// <summary>
+    /// The unversioned Base GGUFs the <c>chatterbox-v3-*</c> pair replaced. Nothing reads these
+    /// any more, so they are pure dead weight on disk — up to ~3.4 GB for a user who had all
+    /// three quantizations. Turbo is absent on purpose: it keeps its own unversioned names.
+    /// </summary>
+    private static readonly string[] SupersededBaseFileNames =
+    {
+        "chatterbox-t3-q8_0.gguf",
+        "chatterbox-s3gen-q8_0.gguf",
+        "chatterbox-t3-f16.gguf",
+        "chatterbox-s3gen-f16.gguf",
+        "chatterbox-t3-q4_k.gguf",
+        "chatterbox-s3gen-q4_k.gguf",
+    };
 
     /// <summary>
-    /// True when <paramref name="path"/> is one of the pre-multilingual (English-only) Base
-    /// GGUFs, identified by exact byte size. Such a file works for English synthesis but lacks
-    /// the language tokens, so it is treated as not installed to trigger a re-download.
-    /// Only the q8_0 Base pair was ever shipped English-only; the f16 / q4_k pairs were
-    /// published after the rebuild and their sizes do not collide with these two.
+    /// Deletes the unversioned Base GGUFs once their replacement is in place. Best effort: a file
+    /// that cannot be deleted (in use, read-only) just stays, since it costs disk rather than
+    /// correctness. Only ever called with the replacement already downloaded, so this cannot
+    /// leave the engine without a model.
     /// </summary>
-    public static bool IsLegacyEnglishOnlyModel(string path)
+    public static void RemoveSupersededBaseModels(string modelsFolder, Action<string>? log = null)
     {
-        try
+        foreach (var fileName in SupersededBaseFileNames)
         {
-            if (!File.Exists(path))
+            try
             {
-                return false;
+                var path = Path.Combine(modelsFolder, fileName);
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                    log?.Invoke($"Chatterbox: removed superseded model '{fileName}'");
+                }
             }
-
-            var length = new FileInfo(path).Length;
-            return length == LegacyBaseT3Size || length == LegacyBaseS3GenSize;
-        }
-        catch
-        {
-            return false;
+            catch (Exception exception)
+            {
+                log?.Invoke($"Chatterbox: could not remove superseded model '{fileName}': {exception.Message}");
+            }
         }
     }
 
@@ -147,8 +162,8 @@ public class ChatterboxTtsCppDownloadService : IChatterboxTtsCppDownloadService
 
         var t3Path = Path.Combine(modelsFolder, t3FileName);
         var s3genPath = Path.Combine(modelsFolder, s3genFileName);
-        var needT3 = !File.Exists(t3Path) || IsLegacyEnglishOnlyModel(t3Path);
-        var needS3Gen = !File.Exists(s3genPath) || IsLegacyEnglishOnlyModel(s3genPath);
+        var needT3 = !File.Exists(t3Path);
+        var needS3Gen = !File.Exists(s3genPath);
         var total = (needT3 ? 1 : 0) + (needS3Gen ? 1 : 0);
         var step = 0;
 
@@ -163,6 +178,14 @@ public class ChatterboxTtsCppDownloadService : IChatterboxTtsCppDownloadService
             step++;
             titleProgress?.Invoke($"Downloading Chatterbox TTS models ({step}/{total}): {s3genFileName}");
             await DownloadHelper.DownloadFileAsync(_httpClient, s3genUrl, s3genPath, progress, cancellationToken);
+        }
+
+        // The V3 pair replaced the unversioned Base GGUFs, so once it is on disk the old ones are
+        // unreachable bytes. Only after a successful download of the Base pair - Turbo keeps its
+        // own names, and a failed download must not take the user's existing models with it.
+        if (resolved != ModelKeyTurbo && File.Exists(t3Path) && File.Exists(s3genPath))
+        {
+            RemoveSupersededBaseModels(modelsFolder, message => Se.WriteToolsLog(message));
         }
     }
 }

--- a/tests/UI/Features/Video/TextToSpeech/Engines/ChatterboxTtsCppTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/ChatterboxTtsCppTests.cs
@@ -301,38 +301,55 @@ public class ChatterboxTtsCppTests
     }
 
     [Fact]
-    public void LegacyEnglishOnlyGguf_IsDetectedBySize()
+    public void RemoveSupersededBaseModels_DeletesTheUnversionedBasePairOnly()
     {
-        // cstr/chatterbox-GGUF was rebuilt in place with multilingual weights; the legacy
-        // English-only files are recognised by exact byte size so they get re-downloaded.
-        // SetLength is metadata-only, so no 630 MB is actually written.
-        var path = Path.Combine(Path.GetTempPath(), $"chatterbox-legacy-test-{Guid.NewGuid():N}.gguf");
+        // The chatterbox-v3-* pair replaced the unversioned Base GGUFs, so those are dead weight
+        // once it is downloaded - up to ~3.4 GB for a user who had all three quantizations.
+        // Turbo keeps its own unversioned names and must survive.
+        var folder = Path.Combine(Path.GetTempPath(), $"chatterbox-cleanup-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(folder);
         try
         {
-            using (var fs = new FileStream(path, FileMode.CreateNew, FileAccess.Write))
+            string[] superseded =
             {
-                fs.SetLength(630_177_120);
+                "chatterbox-t3-q8_0.gguf", "chatterbox-s3gen-q8_0.gguf",
+                "chatterbox-t3-f16.gguf", "chatterbox-s3gen-f16.gguf",
+                "chatterbox-t3-q4_k.gguf", "chatterbox-s3gen-q4_k.gguf",
+            };
+            string[] kept =
+            {
+                "chatterbox-turbo-t3-q8_0.gguf", "chatterbox-turbo-s3gen-q8_0.gguf",
+                ChatterboxTtsCppDownloadService.BaseT3FileName,
+                ChatterboxTtsCppDownloadService.BaseS3GenFileName,
+            };
+
+            foreach (var name in superseded.Concat(kept))
+            {
+                File.WriteAllText(Path.Combine(folder, name), "x");
             }
 
-            Assert.True(Nikse.SubtitleEdit.Logic.Download.ChatterboxTtsCppDownloadService.IsLegacyEnglishOnlyModel(path));
+            ChatterboxTtsCppDownloadService.RemoveSupersededBaseModels(folder);
 
-            using (var fs = new FileStream(path, FileMode.Create, FileAccess.Write))
+            foreach (var name in superseded)
             {
-                fs.SetLength(639_285_952); // the current multilingual T3 — must NOT be flagged
+                Assert.False(File.Exists(Path.Combine(folder, name)), name);
             }
 
-            Assert.False(Nikse.SubtitleEdit.Logic.Download.ChatterboxTtsCppDownloadService.IsLegacyEnglishOnlyModel(path));
+            foreach (var name in kept)
+            {
+                Assert.True(File.Exists(Path.Combine(folder, name)), name);
+            }
         }
         finally
         {
-            File.Delete(path);
+            Directory.Delete(folder, true);
         }
     }
 
     [Theory]
-    [InlineData("Base", "chatterbox-t3-q8_0.gguf", "chatterbox-s3gen-q8_0.gguf", "chatterbox")]
-    [InlineData("Base F16", "chatterbox-t3-f16.gguf", "chatterbox-s3gen-f16.gguf", "chatterbox")]
-    [InlineData("Base Q4_K", "chatterbox-t3-q4_k.gguf", "chatterbox-s3gen-q4_k.gguf", "chatterbox")]
+    [InlineData("Base", "chatterbox-v3-t3-q8_0.gguf", "chatterbox-v3-s3gen-q8_0.gguf", "chatterbox")]
+    [InlineData("Base F16", "chatterbox-v3-t3-f16.gguf", "chatterbox-v3-s3gen-f16.gguf", "chatterbox")]
+    [InlineData("Base Q4_K", "chatterbox-v3-t3-q4_k.gguf", "chatterbox-v3-s3gen-q4_k.gguf", "chatterbox")]
     [InlineData("Turbo", "chatterbox-turbo-t3-q8_0.gguf", "chatterbox-turbo-s3gen-q8_0.gguf", "chatterbox-turbo")]
     public void EachModelKey_MapsToItsOwnGgufPairAndBackend(string modelKey, string t3, string s3gen, string backend)
     {
@@ -375,39 +392,6 @@ public class ChatterboxTtsCppTests
         }).ToList();
         Assert.Equal(files.Count, files.Distinct().Count());
     }
-
-    [Fact]
-    public void LegacySizeCheck_DoesNotFlagTheF16OrQ4KPair()
-    {
-        // The legacy English-only sizes are q8_0-specific. If a newly published quantization
-        // ever matched one of them byte-for-byte it would be re-downloaded forever.
-        long[] currentSizes =
-        {
-            1_138_156_192, // chatterbox-t3-f16.gguf
-            649_353_632,   // chatterbox-s3gen-f16.gguf
-            382_171_840,   // chatterbox-t3-q4_k.gguf
-            254_658_880,   // chatterbox-s3gen-q4_k.gguf
-        };
-
-        var path = Path.Combine(Path.GetTempPath(), $"chatterbox-quant-test-{Guid.NewGuid():N}.gguf");
-        try
-        {
-            foreach (var size in currentSizes)
-            {
-                using (var fs = new FileStream(path, FileMode.Create, FileAccess.Write))
-                {
-                    fs.SetLength(size); // metadata-only, nothing is written
-                }
-
-                Assert.False(ChatterboxTtsCppDownloadService.IsLegacyEnglishOnlyModel(path));
-            }
-        }
-        finally
-        {
-            File.Delete(path);
-        }
-    }
-
     private static string WriteTempWav(byte[] bytes)
     {
         var path = Path.Combine(Path.GetTempPath(), $"chatterbox-ref-test-{Guid.NewGuid():N}.wav");

--- a/tests/UI/Features/Video/TextToSpeech/Engines/ChatterboxTtsCppTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/ChatterboxTtsCppTests.cs
@@ -13,6 +13,57 @@ namespace UITests.Features.Video.TextToSpeech.Engines;
 public class ChatterboxTtsCppTests
 {
     [Fact]
+    public void BuildSpeakPayload_CloningWithTargetLanguage_SendsSourceLang()
+    {
+        // Both sides present is what makes the backend go cross-lingual (CrispASR v0.8.29 #329).
+        var payload = ChatterboxTtsCpp.BuildSpeakPayload("hallo", "/voices/Arnold.wav", "de", "en");
+
+        Assert.Equal("de", payload["language"]);
+        Assert.Equal("en", payload["source_lang"]);
+    }
+
+    [Fact]
+    public void BuildSpeakPayload_WithoutTargetLanguage_SendsNoSourceLang()
+    {
+        // The reference language on its own tells the backend nothing to act on.
+        var payload = ChatterboxTtsCpp.BuildSpeakPayload("hello", "/voices/Arnold.wav", string.Empty, "en");
+
+        Assert.False(payload.ContainsKey("source_lang"));
+    }
+
+    [Fact]
+    public void BuildSpeakPayload_WithBakedDefaultVoice_SendsNoSourceLang()
+    {
+        // Nothing is being cloned from, so there is no reference language to declare.
+        var payload = ChatterboxTtsCpp.BuildSpeakPayload("hallo", string.Empty, "de", "en");
+
+        Assert.False(payload.ContainsKey("source_lang"));
+    }
+
+    [Fact]
+    public void TryReadReferenceTranscript_ReadsTheSidecarBesideTheWav()
+    {
+        var wav = Path.Combine(Path.GetTempPath(), $"chatterbox-ref-{Guid.NewGuid():N}.wav");
+        var sidecar = Path.ChangeExtension(wav, ".txt");
+        try
+        {
+            File.WriteAllText(wav, string.Empty);
+            Assert.Null(ChatterboxTtsCpp.TryReadReferenceTranscript(wav));
+
+            File.WriteAllText(sidecar, "  This is what the reference says.  ");
+            Assert.Equal("This is what the reference says.", ChatterboxTtsCpp.TryReadReferenceTranscript(wav));
+
+            File.WriteAllText(sidecar, "   ");
+            Assert.Null(ChatterboxTtsCpp.TryReadReferenceTranscript(wav));
+        }
+        finally
+        {
+            File.Delete(wav);
+            File.Delete(sidecar);
+        }
+    }
+
+    [Fact]
     public void BuildSpeakPayload_KeepsWavExtensionOnVoiceName()
     {
         // The chatterbox backend does not append an extension, and the server needs the .wav to

--- a/tests/UI/Features/Video/TextToSpeech/Engines/CrispAsrTtsLanguagesTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/CrispAsrTtsLanguagesTests.cs
@@ -221,6 +221,41 @@ public class CrispAsrTtsLanguagesTests
     }
 
     [Fact]
+    public void Chatterbox_ResolveSourceLanguageArg_ExplicitPickWinsOverDetection()
+    {
+        // Chatterbox clones from the WAV alone and never asks for a transcript, so the settings
+        // pick is the path most users take - it has to beat whatever a stray sidecar says.
+        using var _ = new ChatterboxReferenceLanguageScope("fr");
+
+        Assert.Equal("fr", ChatterboxLanguages.ResolveSourceLanguageArg(
+            "The quick brown fox is not what it seems, and there is nothing we can do about it."));
+    }
+
+    [Fact]
+    public void Chatterbox_ResolveSourceLanguageArg_NoPick_FallsBackToTheSidecar()
+    {
+        using var _ = new ChatterboxReferenceLanguageScope(string.Empty);
+
+        Assert.Equal("en", ChatterboxLanguages.ResolveSourceLanguageArg(
+            "The quick brown fox is not what it seems, and there is nothing we can do about it."));
+        Assert.Equal("de", ChatterboxLanguages.ResolveSourceLanguageArg(
+            "Ich habe das Buch nicht gelesen, aber es ist mir egal, was du davon hältst."));
+        Assert.Equal(string.Empty, ChatterboxLanguages.ResolveSourceLanguageArg(null));
+    }
+
+    [Fact]
+    public void Chatterbox_DetectSourceLanguage_OutsideItsLanguages_ReturnsEmpty()
+    {
+        // Chatterbox knows 23 languages; Czech is not one of them, and the [cs] tag exists in the
+        // vocab without being advertised as trained - so a detection outside the list is dropped
+        // rather than sent.
+        using var _ = new ChatterboxReferenceLanguageScope(string.Empty);
+
+        Assert.Equal(string.Empty, ChatterboxLanguages.DetectSourceLanguage(
+            "Nečetl jsem tu knihu, ale je mi jedno, co si o tom myslíš ty."));
+    }
+
+    [Fact]
     public void ResolveSourceLanguageArg_NoPick_DetectsPerVoice()
     {
         // One global setting cannot be right for a user with reference WAVs in two languages,
@@ -316,5 +351,24 @@ internal sealed class SavedReferenceLanguageScope : IDisposable
     public void Dispose()
     {
         Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrSourceLanguage = _original;
+    }
+}
+
+/// <summary>
+/// Sets Chatterbox's "Reference language" pick (an ISO code) and restores it afterwards.
+/// </summary>
+internal sealed class ChatterboxReferenceLanguageScope : IDisposable
+{
+    private readonly string _original;
+
+    public ChatterboxReferenceLanguageScope(string code)
+    {
+        _original = Se.Settings.Video.TextToSpeech.ChatterboxCrispAsrSourceLanguage;
+        Se.Settings.Video.TextToSpeech.ChatterboxCrispAsrSourceLanguage = code;
+    }
+
+    public void Dispose()
+    {
+        Se.Settings.Video.TextToSpeech.ChatterboxCrispAsrSourceLanguage = _original;
     }
 }


### PR DESCRIPTION
Two Chatterbox follow-ups to the CrispASR v0.8.29 bump (#13736).

## 1. `source_lang` for cross-lingual cloning

v0.8.29 takes **`source_lang` per request** on `/v1/audio/speech` — the language the cloning reference is spoken in (CrispASR#329; the upstream comment on that code path names a "SubtitleEdit-style client"). The backend needs *both* sides before it goes cross-lingual, so an English reference asked for German kept the English accent. With both, Chatterbox V3 follows upstream's recommendation and drops to CFG weight 0 — keeping the speaker's timbre while shedding the reference language's accent.

SE already had this exact shape for CosyVoice3 (#13272), so this extends it rather than inventing a second mechanism: the explicit **"Reference language"** pick in the engine settings window wins, then a best-effort detection over the reference transcript, and detections outside Chatterbox's 23 languages are dropped rather than sent.

One real difference from CosyVoice3, handled explicitly: Chatterbox clones from the WAV alone and never asks for a transcript, so there is usually nothing to detect from — the `.txt` sidecar is read only when one happens to exist, and the settings pick is the path most users take. When a target language is set on a cloned voice and the reference language stays unknown, the tools log says so, because the request still returns 200 and nothing else would tell the user.

Verified against the v0.8.29 binary: sending `source_lang` produces different, longer audio (5.64 s vs 4.72 s for the same German line) on every Base quantization, so the field is demonstrably honoured.

## 2. The versioned `chatterbox-v3-*` pair

`cstr/chatterbox-GGUF` now publishes `chatterbox-v3-*` beside the unversioned names SE downloaded. These are upstream's pinned production checkpoint (`t3_mtl23ls_v3` + the original `s3gen` at ResembleAI revision `5bb1f6ee`) and they record it in the GGUF — `general.source.url`, `general.source.revision`, `chatterbox.t3.checkpoint`, none of which the unversioned files carry. Tensor data genuinely differs; the S3Gen half also gains a baked `s3.tok._mel_filters`.

**A/B, both q8_0 pairs through SE's exact server-mode invocation**, scored by ASR round-trip WER and median F0 against the reference speaker:

| case | generic | v3 |
|---|---|---|
| `en_default` | WER 0.00, f0 121.5 Hz | WER 0.00, f0 120.5 Hz |
| `de_lang` | WER 0.17, f0 108.9 Hz | WER 0.17, f0 108.8 Hz |
| `en_clone_f` | WER 0.00, f0 176.4 Hz | WER 0.00, f0 176.1 Hz |
| `en_clone_m` | WER 0.00, f0 111.7 Hz | WER 0.00, f0 112.0 Hz |
| `de_clone_f` | WER 0.00, f0 177.2 Hz | WER 0.00, f0 175.0 Hz |

References: female 193.3 Hz, male 115.7 Hz — both pairs track the speaker, and both log `atomic native WAV clone … all 5 conds installed`. The `WER 0.17` rows are the ASR splitting "Untertitel" into two words, not a synthesis defect.

**Output quality is a wash.** The swap is for provenance and durability: the unversioned names are back-compat aliases upstream rebuilds in place, which already happened once (English-only → multilingual, 2026-06-18) and cost SE a byte-size probe to spot a file that had silently become something else. A versioned name cannot do that, so `AreModelsInstalled` goes back to a plain existence check.

The V3 q4_k and f16 pairs were smoke-tested the same way and clone correctly (q4_k f0 170.3/116.6, f16 181.0/114.9). The q4_k pair grew — its S3Gen half is 314 MB rather than 255 MB — so the download prompt now says ~700 MB.

Users who had the old pair get it deleted once the V3 download succeeds, rather than keeping up to ~3.4 GB of files nothing can load any more. Turbo is untouched: it keeps its own unversioned names.

Full UI suite: 2992 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)