### PR TITLE
Stop clipping the audio sent to speech-to-text (#13738)

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -4266,10 +4266,9 @@ public partial class SpeechToTextViewModel : ObservableObject
 
         //-i indicates the input
         //-vn means no video output
-        //-ar 44100 indicates the sampling frequency.
-        //-ab indicates the bit rate (in this example 160kb/s)
-        //-af volume=1.75 will boot volume... 1.0 is normal
-        //-ac 2 means 2 channels
+        //-ar 16000 indicates the sampling frequency.
+        //-b:a indicates the bit rate (only used for the compressed formats)
+        //-ac 1 means 1 channel (mono)
         // "-map 0:a:0" is the first audio stream, "-map 0:a:1" is the second audio stream
 
         var exeFilePath = Se.Settings.General.FfmpegPath;
@@ -4291,8 +4290,8 @@ public partial class SpeechToTextViewModel : ObservableObject
     }
 
     /// <summary>
-    /// ffmpeg argument template for transcoding the source audio. WAV stays on
-    /// the historical pipeline (lossless 16 kHz mono PCM); the compressed
+    /// ffmpeg argument template for transcoding the source audio. WAV stays
+    /// lossless 16 kHz mono PCM, unmodified apart from the downmix; the compressed
     /// formats target ~32 kbit/s mono at 16 kHz, which is plenty for speech
     /// recognition and keeps a 2-hour video well under OpenAI's 25 MB upload
     /// limit. Opus is shipped inside a webm container because OpenAI accepts
@@ -4301,18 +4300,26 @@ public partial class SpeechToTextViewModel : ObservableObject
     private static string GetFfmpegTranscodeFormatString(string audioFormat, bool useCenterChannelOnly)
     {
         var normalized = string.IsNullOrWhiteSpace(audioFormat) ? "wav" : audioFormat.Trim().ToLowerInvariant();
+
+        // No "volume=1.75" here, unlike the waveform extraction in WaveFileExtractor where the boost
+        // only makes the drawing easier to read. +4.9 dB into 16-bit PCM hard-clips every peak of an
+        // already-mastered source - measured at ~5% of all samples pinned to full scale for speech
+        // peaking at -0.5 dBFS - and that distortion costs recognition accuracy (#13738). The gain
+        // buys nothing in return: whisper's log-mel front end clamps to "max - 8 dB" and rescales,
+        // so a uniform gain is normalized away before the model ever sees it.
         var channelArgs = useCenterChannelOnly
-            ? "-af \"pan=mono|c0=FC,volume=1.75\""
-            : "-ac 1 -af volume=1.75";
+            ? "-af \"pan=mono|c0=FC\""
+            : "-ac 1";
 
         return normalized switch
         {
             "mp3" => "-i \"{0}\" -vn -ar 16000 " + channelArgs + " -c:a libmp3lame -b:a 32k -f mp3 {2} \"{1}\"",
             "m4a" => "-i \"{0}\" -vn -ar 16000 " + channelArgs + " -c:a aac -b:a 32k -f ipod {2} \"{1}\"",
             "webm" => "-i \"{0}\" -vn -ar 16000 " + channelArgs + " -c:a libopus -b:a 28k -f webm {2} \"{1}\"",
-            _ => useCenterChannelOnly
-                ? "-i \"{0}\" -vn -ar 16000 -ab 32k -af volume=1.75 -af \"pan=mono|c0=FC\" -f wav {2} \"{1}\""
-                : "-i \"{0}\" -vn -ar 16000 -ac 1 -ab 32k -af volume=1.75 -f wav {2} \"{1}\"",
+            // pcm_s16le is already ffmpeg's default for wav, but spell it out: SE's own peak reader
+            // (WavePeakGenerator2, shared with MakeWavePeaks) only handles integer PCM, so the sample
+            // format must not drift. "-ab" is dropped - it is a no-op for an uncompressed encoder.
+            _ => "-i \"{0}\" -vn -ar 16000 " + channelArgs + " -c:a pcm_s16le -f wav {2} \"{1}\"",
         };
     }
 

--- a/src/ui/Logic/Media/WaveFileExtractor.cs
+++ b/src/ui/Logic/Media/WaveFileExtractor.cs
@@ -39,7 +39,10 @@ public static class WaveFileExtractor
             if (settings.General.FfmpegUseCenterChannelOnly &&
                 FfmpegMediaInfo.Parse(inputVideoFile).HasFrontCenterAudio(audioTrackNumber))
             {
-                fFmpegWaveTranscodeSettings = "-i \"{0}\" -vn -ar 24000 -ab 128 -af volume=1.75 -af \"pan=mono|c0=FC\" -f wav {2} \"{1}\"";
+                // Both filters go in one "-af" chain: ffmpeg keeps only the last "-af" per output
+                // stream, so the older two-option form silently dropped the volume boost and drew
+                // center-channel waveforms quieter than every other waveform.
+                fFmpegWaveTranscodeSettings = "-i \"{0}\" -vn -ar 24000 -ab 128 -af \"pan=mono|c0=FC,volume=1.75\" -f wav {2} \"{1}\"";
                 encoderName += " FC";
             }
 


### PR DESCRIPTION
Fixes #13738.

## The bug

The speech-to-text extraction ran `-af volume=1.75` (+4.9 dB) and wrote 16-bit integer PCM, so every peak of an already-mastered source **hard-clipped**. Measured on speech peaking at -0.5 dBFS:

| variant | samples pinned at full scale (of 460k) |
|---|---|
| current command | **22,434** |
| boost removed | 2 |

That is broadband harmonic distortion across every loud syllable — and the gain buys nothing in return, because whisper's log-mel front end clamps to `max - 8 dB` and rescales, so a uniform gain is normalized away before the model ever sees it.

Every engine except Purfview Faster-Whisper-XXL reads this WAV (XXL gets the video directly for mp4/mkv when no audio track is picked), which matches the report: standalone faster-whisper on the source `.mp4` is accurate, Subtitle Edit's WAV is not.

## Verification

Run through `whisper-ctranslate2` (faster-whisper, tiny.en), all three inputs derived from one common source so the comparison is honest:

| input | result |
|---|---|
| video, straight to the engine | correct throughout |
| WAV, old command | `…harmonic distortion**,** careful resampling with the **high quality** filter` — sentence break turned into a comma splice, hyphenation lost |
| WAV, new command | matches the video path word for word |

All four output formats (wav/mp3/m4a/webm) in both channel modes were re-run against Subtitle Edit's *own* bundled ffmpeg, not just a system build.

## Changes

1. **Drop `volume=1.75` from speech-to-text extraction.** The boost is untouched in `WaveFileExtractor`, where it exists to make the drawn waveform readable.
2. **Spell out `-c:a pcm_s16le`** for the WAV branch. Already ffmpeg's implicit default, but `WavePeakGenerator2` (shared via `MakeWavePeaks`) handles integer PCM only, so the sample format must not silently drift. Dropped `-ab`, a no-op for an uncompressed encoder.
3. **Merge the two `-af` options into one filter chain.** ffmpeg keeps only the last `-af` per output stream, so the center-channel branches silently discarded the other filter. Harmless in the speech-to-text path now that the boost is gone, but in `WaveFileExtractor` it was dropping the volume boost and drawing center-channel waveforms quieter than every other waveform.

## Deliberately not adopted from the issue

- **`resampler=soxr`** fails outright on the bundled macOS ffmpeg, which is built without libsoxr — `Invalid argument`, zero-byte output, and an error message that never mentions soxr. Measured benefit is 6 dB better alias rejection at -70 dB, far too small to explain word errors.
- **`pcm_f32le`** writes format tag 3; `WavePeakGenerator2.ReadValue32Bit` reads int32, so the speech-to-text waveform would turn to garbage. It also only helped by masking the clipping.
- **`-map 0:a:0`** is already handled — the track is mapped when picked, auto-selected otherwise.

## One thing to watch

Audio now reaches the engines 4.9 dB quieter. Whisper is unaffected (its log-mel normalizes gain away), but Silero VAD in CrispASR is somewhat amplitude-sensitive, so very quiet sources could see slightly different segment boundaries. That still seems the right trade against clipping every loud one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)