### PR TITLE
Send the source file to XXL and CTranslate2 instead of the extracted WAV (#13738)

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -2282,6 +2282,10 @@ public partial class SpeechToTextViewModel : ObservableObject
         var candidates = new List<string>
         {
             waveFileName + ext,
+            // The engines that read the source file directly are told to write into the extracted
+            // WAV's own per-run folder, and they name the output after their input - so the result
+            // is "<run folder>/<video name><ext>", which none of the other candidates covers.
+            Path.Combine(Path.GetDirectoryName(waveFileName) ?? string.Empty, Path.GetFileNameWithoutExtension(videoFileName) + ext),
             Path.Combine(Directory.GetCurrentDirectory(), Path.GetFileNameWithoutExtension(videoFileName) + ext),
             Path.Combine(Directory.GetCurrentDirectory(), Path.GetFileNameWithoutExtension(waveFileName) + ext),
             Path.Combine(AppContext.BaseDirectory, Path.GetFileNameWithoutExtension(videoFileName) + ext),
@@ -3613,19 +3617,25 @@ public partial class SpeechToTextViewModel : ObservableObject
         _resultList.Clear();
 
         var inputFile = waveFileName;
-        if (!_useCenterChannelOnly &&
-            (engine.Name == WhisperEnginePurfviewFasterWhisperXxl.StaticName) &&
-            (videoFileName.EndsWith(".mkv", StringComparison.OrdinalIgnoreCase) ||
-             videoFileName.EndsWith(".mp4", StringComparison.OrdinalIgnoreCase)) &&
-            _audioTrackNumber < 0)
+        var engineOutputFolder = string.Empty;
+        if (CanEngineReadSourceFileDirectly(engine) && CanSendSourceFileToEngine(videoFileName))
         {
             inputFile = videoFileName;
+        }
+
+        if (!string.Equals(inputFile, waveFileName, StringComparison.OrdinalIgnoreCase))
+        {
+            // Both engines save their output next to the input file, so pointing them at the user's
+            // own media would write "<video>.srt" into that folder - overwriting any subtitle already
+            // sitting there, which SE then deletes again as one of its temp files. Send the output to
+            // the per-run folder instead, the same isolation the extracted WAV gets (#11837).
+            engineOutputFolder = GetSttTempFolder();
         }
 
         try
         {
             _whisperProcess = GetWhisperProcess(engine, inputFile, model.Model.Name, language.Code, DoTranslateToEnglish,
-                OutputHandler);
+                OutputHandler, engineOutputFolder);
         }
         catch (Exception e)
         {
@@ -3706,13 +3716,61 @@ public partial class SpeechToTextViewModel : ObservableObject
             : engineFolder + Path.PathSeparator + existing;
     }
 
+    /// <summary>
+    /// Engines that demux and decode the source media themselves, so they can be pointed at the
+    /// user's original file instead of SE's extracted WAV: Purfview Faster-Whisper-XXL bundles
+    /// ffmpeg, whisper-ctranslate2 bundles PyAV. Verified that the others cannot - whisper.cpp
+    /// answers "failed to read audio data as wav" for an mp4, and CrispASR's own help lists
+    /// flac/mp3/ogg/wav only - so those keep getting the WAV.
+    /// </summary>
+    private static bool CanEngineReadSourceFileDirectly(ISpeechToTextEngine engine)
+    {
+        return engine.Name == WhisperEnginePurfviewFasterWhisperXxl.StaticName ||
+               engine is WhisperEngineCTranslate2;
+    }
+
+    /// <summary>
+    /// True if the source file itself can go to the engine. Neither engine can pick an audio track,
+    /// so a track other than the first one is the one thing only the extracted WAV can express -
+    /// handing over the source file there would silently transcribe the wrong track. SE 4 made the
+    /// same call, though its track number was audio-relative and 0 meant "unspecified", while
+    /// SE 5 stores the global ffmpeg stream index of an always-auto-selected track.
+    /// </summary>
+    private bool CanSendSourceFileToEngine(string videoFileName)
+    {
+        if (_useCenterChannelOnly || string.IsNullOrEmpty(videoFileName) || !File.Exists(videoFileName))
+        {
+            return false;
+        }
+
+        if (_audioTrackNumber < 0)
+        {
+            return true; // no track picked - the engine falls back to the first one, exactly like ffmpeg would
+        }
+
+        try
+        {
+            var audioTracks = FfmpegMediaInfo.Parse(videoFileName).Tracks
+                .Where(t => t.TrackType == FfmpegTrackType.Audio)
+                .ToList();
+
+            return audioTracks.Count > 0 && audioTracks[0].StreamIndex == _audioTrackNumber;
+        }
+        catch (Exception exception)
+        {
+            SeLogger.Error(exception, $"Unable to read audio tracks from: {videoFileName}");
+            return false;
+        }
+    }
+
     private Process GetWhisperProcess(
         ISpeechToTextEngine engine,
         string waveFileName,
         string model,
         string language,
         bool translate,
-        DataReceivedEventHandler? dataReceivedHandler = null)
+        DataReceivedEventHandler? dataReceivedHandler = null,
+        string engineOutputFolder = "")
     {
         if (engine is ChatLlmCppEngine chatLlm)
         {
@@ -3879,8 +3937,20 @@ public partial class SpeechToTextViewModel : ObservableObject
                 : string.Empty;
         }
 
+        // Only set when the engine reads the user's own media instead of the extracted WAV; both
+        // engines accept "--output_dir" (Purfview XXL defaults to the input's folder, ctranslate2
+        // to the working directory). A user who set their own output folder in the extra
+        // parameters keeps it.
+        var outputDirArg = string.Empty;
+        if (!string.IsNullOrEmpty(engineOutputFolder) &&
+            !args.Contains("--output_dir", StringComparison.Ordinal) &&
+            !Regex.IsMatch(args, @"(^|\s)-o(\s|$)"))
+        {
+            outputDirArg = $"--output_dir \"{engineOutputFolder}\" ";
+        }
+
         var parameters =
-            $"{languageArg}--model \"{m}\" {outputSrt}{translateToEnglish}{args} \"{waveFileName}\"{postParams}";
+            $"{languageArg}--model \"{m}\" {outputSrt}{outputDirArg}{translateToEnglish}{args} \"{waveFileName}\"{postParams}";
 
         if (engine is WhisperEngineCTranslate2)
         {


### PR DESCRIPTION
Follow-up to #13743, same issue (#13738) but the cause reported by @popoche: Faster-Whisper XXL transcribing noticeably worse in SE 5 than in SE 4 with the same engine, model and settings.

## Why SE 5 was worse

Both versions already skip the extracted WAV and hand XXL the original media — but only when no audio track is selected, and the track number means different things in the two versions:

| | track number | bypass test | what XXL normally got |
|---|---|---|---|
| SE 4 | audio-relative (`-map 0:a:{n}`), `0` = unspecified | `<= 0` | the original mp4/mkv |
| SE 5 | global ffmpeg stream index, auto-selected on video load — typically `1` | `< 0` | the extracted WAV |

So the SE 5 shortcut never fires in the normal flow, and users were moved onto the WAV path — which, until #13743, was the clipped one.

## Changes

- **XXL and CTranslate2 now get the source file.** Both decode it themselves (XXL bundles ffmpeg, whisper-ctranslate2 bundles PyAV — verified by transcribing an `.mp4` with it directly). The mp4/mkv container check is gone too; both take whatever ffmpeg can demux.
- **Other engines keep the WAV**, because they genuinely cannot read a video: whisper.cpp answers `failed to read audio data as wav`, and CrispASR's own `--help` lists `flac, mp3, ogg, wav`.
- **A selected non-first audio track still routes through ffmpeg.** Neither engine can pick a track, so that is the one thing only the WAV can express; handing over the source file there would silently transcribe the wrong track.
- **`--output_dir` now points at the per-run temp folder** whenever the engine reads the source file, plus the matching result-discovery candidate.

## Why the `--output_dir` part matters

Both engines save output next to their input, so pointing them at the user's media folder writes `<video>.srt` there. I checked what that does with a subtitle already sitting next to the video:

```
before: MyMovie.srt = "PRE-EXISTING USER SUBTITLE"
after:  MyMovie.srt = "Subtitle edit is a free editor for video subtitles."
```

It is overwritten — and SE then adds that path to its temp-file list and deletes it. With `--output_dir` set, the same run leaves `MyMovie.srt` untouched and writes into the run folder, which is the isolation the extracted WAV already had (#11837). A user who set their own output folder in the extra parameters keeps it.

## Follow-up worth considering

The WAV is still extracted before the engine starts, even when it goes unused, so long videos still pay for a full ffmpeg pass. Skipping it touches the progress bar and duration handling, so it is left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)