### PR TITLE
Read float and WAVE_FORMAT_EXTENSIBLE wav files for the waveform

### DIFF
--- a/src/ui/Logic/Media/WaveToVisualizer2.cs
+++ b/src/ui/Logic/Media/WaveToVisualizer2.cs
@@ -21,6 +21,8 @@ public class WaveHeader2
 {
     private const int ConstantHeaderSize = 20;
     public const int AudioFormatPcm = 1;
+    public const int AudioFormatIeeeFloat = 3;
+    private const int AudioFormatExtensible = 0xFFFE;
 
     public string ChunkId { get; private set; }
     public uint ChunkSize { get; private set; }
@@ -90,13 +92,24 @@ public class WaveHeader2
             : new byte[FmtChunkSize];
         _ = stream.Read(fmtBuffer);
 
-        // Parse fmt chunk
-        AudioFormat = BitConverter.ToInt16(fmtBuffer);
+        // Parse fmt chunk. The format tag is unsigned - read as a signed short, WAVE_FORMAT_EXTENSIBLE
+        // (0xFFFE) would arrive as -2 and match nothing.
+        AudioFormat = BitConverter.ToUInt16(fmtBuffer);
         NumberOfChannels = BitConverter.ToInt16(fmtBuffer.Slice(2));
         SampleRate = BitConverter.ToInt32(fmtBuffer.Slice(4));
         ByteRate = BitConverter.ToInt32(fmtBuffer.Slice(8));
         BlockAlign = BitConverter.ToInt16(fmtBuffer.Slice(12));
         BitsPerSample = BitConverter.ToInt16(fmtBuffer.Slice(14));
+
+        // WAVE_FORMAT_EXTENSIBLE only says "the real tag is in the SubFormat GUID", whose first two
+        // bytes hold it. ffmpeg writes this form for more than two channels and for 24-bit, so
+        // without unwrapping it a perfectly ordinary 24-bit or 5.1 wav looks unreadable.
+        // Layout after wBitsPerSample: cbSize (16), wValidBitsPerSample (18), dwChannelMask (20),
+        // SubFormat GUID (24).
+        if (AudioFormat == AudioFormatExtensible && fmtBuffer.Length >= 26)
+        {
+            AudioFormat = BitConverter.ToUInt16(fmtBuffer.Slice(24));
+        }
 
         // Read data chunk header
         Span<byte> dataHeader = stackalloc byte[8];
@@ -595,8 +608,19 @@ public class WavePeakGenerator2 : IDisposable
 
     /// <summary>
     /// Returns true if the current wave file can be processed. Compressed wave files are not supported.
+    /// Both integer PCM and IEEE float samples are read; the float ones come from DAWs, from
+    /// "-c:a pcm_f32le" exports, and from anything that keeps headroom above full scale.
     /// </summary>
-    public bool IsSupported => Header.AudioFormat == WaveHeader2.AudioFormatPcm && Header.Format == "WAVE";
+    public bool IsSupported =>
+        (Header.AudioFormat == WaveHeader2.AudioFormatPcm || IsFloatFormat) && Header.Format == "WAVE";
+
+    /// <summary>
+    /// IEEE float samples are already normalized to -1..1, so they need their own readers and
+    /// their own scale - reading the bit pattern as an integer produces noise, not audio.
+    /// </summary>
+    private bool IsFloatFormat =>
+        Header.AudioFormat == WaveHeader2.AudioFormatIeeeFloat &&
+        (Header.BytesPerSample == 4 || Header.BytesPerSample == 8);
 
     /// <summary>
     /// Generates peaks and saves them to disk.
@@ -946,6 +970,33 @@ public class WavePeakGenerator2 : IDisposable
         return result;
     }
 
+    // The float readers normalize to the 32-bit integer range so they compose with the shared
+    // scale, and clamp first: float wav files legitimately carry samples past full scale (that is
+    // the point of the format), and an out-of-range float-to-int cast is undefined in C#.
+    private static int ReadValueFloat32(byte[] data, ref int index)
+    {
+        float result = Unsafe.ReadUnaligned<float>(ref data[index]);
+        index += 4;
+        return ScaleFloatSample(result);
+    }
+
+    private static int ReadValueFloat64(byte[] data, ref int index)
+    {
+        double result = Unsafe.ReadUnaligned<double>(ref data[index]);
+        index += 8;
+        return ScaleFloatSample(result);
+    }
+
+    private static int ScaleFloatSample(double value)
+    {
+        if (double.IsNaN(value))
+        {
+            return 0;
+        }
+
+        return (int)(Math.Clamp(value, -1.0, 1.0) * int.MaxValue);
+    }
+
     private static void WriteValue8Bit(byte[] buffer, int offset, int value)
     {
         buffer[offset] = (byte)(value - sbyte.MinValue);
@@ -974,6 +1025,13 @@ public class WavePeakGenerator2 : IDisposable
 
     private double GetSampleScale()
     {
+        // Float samples arrive already normalized to the 32-bit integer range from the readers
+        // above, whatever their storage width, so they take one scale rather than one per width.
+        if (IsFloatFormat)
+        {
+            return 1.0 / int.MaxValue;
+        }
+
         return (1.0 / Math.Pow(2.0, Header.BytesPerSample * 8 - 1));
     }
 
@@ -984,6 +1042,11 @@ public class WavePeakGenerator2 : IDisposable
 
     private ReadSampleDataValue GetSampleDataReader()
     {
+        if (IsFloatFormat)
+        {
+            return Header.BytesPerSample == 8 ? ReadValueFloat64 : ReadValueFloat32;
+        }
+
         switch (Header.BytesPerSample)
         {
             case 1:

--- a/tests/UI/Logic/WavePeakFloatWavTests.cs
+++ b/tests/UI/Logic/WavePeakFloatWavTests.cs
@@ -1,0 +1,149 @@
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// The peak reader used to accept integer PCM only, so a float wav - what DAWs export, and what
+/// "-c:a pcm_f32le" produces - drew a garbage waveform: the sample reader read the float bit
+/// pattern as an int32. These tests pin the float and WAVE_FORMAT_EXTENSIBLE handling by feeding
+/// the same waveform through both encodings and comparing the peaks.
+/// </summary>
+public class WavePeakFloatWavTests
+{
+    private const int SampleRate = 8000;
+    private const int SampleCount = 8000;
+
+    private static float SampleAt(int i)
+    {
+        // Speech-ish: a decaying tone, so peaks vary from chunk to chunk instead of being flat.
+        var t = i / (double)SampleRate;
+        return (float)(Math.Sin(2 * Math.PI * 220 * t) * Math.Exp(-t * 1.5));
+    }
+
+    private static byte[] BuildWav(int audioFormat, int bitsPerSample, Func<int, byte[]> sampleWriter, bool extensible = false)
+    {
+        var stream = new MemoryStream();
+        var writer = new BinaryWriter(stream, Encoding.UTF8);
+        var bytesPerSample = bitsPerSample / 8;
+        var fmtChunkSize = extensible ? 40 : 16;
+        var dataSize = SampleCount * bytesPerSample;
+
+        writer.Write(Encoding.UTF8.GetBytes("RIFF"));
+        writer.Write(20 + fmtChunkSize + dataSize);
+        writer.Write(Encoding.UTF8.GetBytes("WAVE"));
+        writer.Write(Encoding.UTF8.GetBytes("fmt "));
+        writer.Write(fmtChunkSize);
+        writer.Write((short)(extensible ? 0xFFFE : audioFormat));
+        writer.Write((short)1); // mono
+        writer.Write(SampleRate);
+        writer.Write(SampleRate * bytesPerSample);
+        writer.Write((short)bytesPerSample);
+        writer.Write((short)bitsPerSample);
+        if (extensible)
+        {
+            writer.Write((short)22); // cbSize
+            writer.Write((short)bitsPerSample); // wValidBitsPerSample
+            writer.Write(0x4); // dwChannelMask - front center
+            writer.Write((short)audioFormat); // first two bytes of the SubFormat GUID
+            writer.Write(new byte[14]); // rest of the GUID
+        }
+
+        writer.Write(Encoding.UTF8.GetBytes("data"));
+        writer.Write(dataSize);
+        for (var i = 0; i < SampleCount; i++)
+        {
+            writer.Write(sampleWriter(i));
+        }
+
+        writer.Flush();
+        return stream.ToArray();
+    }
+
+    private static byte[] BuildPcm16Wav() =>
+        BuildWav(1, 16, i => BitConverter.GetBytes((short)(SampleAt(i) * short.MaxValue)));
+
+    private static byte[] BuildFloat32Wav() =>
+        BuildWav(3, 32, i => BitConverter.GetBytes(SampleAt(i)));
+
+    private static byte[] BuildFloat64Wav() =>
+        BuildWav(3, 64, i => BitConverter.GetBytes((double)SampleAt(i)));
+
+    private static WavePeakData2 GeneratePeaks(byte[] wav)
+    {
+        using var generator = new WavePeakGenerator2(new MemoryStream(wav));
+        Assert.True(generator.IsSupported);
+        return generator.GeneratePeaks(0, string.Empty);
+    }
+
+    [Fact]
+    public void FloatWavIsSupported()
+    {
+        using var float32 = new WavePeakGenerator2(new MemoryStream(BuildFloat32Wav()));
+        Assert.True(float32.IsSupported);
+
+        using var float64 = new WavePeakGenerator2(new MemoryStream(BuildFloat64Wav()));
+        Assert.True(float64.IsSupported);
+    }
+
+    [Fact]
+    public void ExtensibleWavResolvesItsSubFormat()
+    {
+        // 0xFFFE says nothing on its own - the real tag lives in the SubFormat GUID. ffmpeg writes
+        // this form for 24-bit and for more than two channels.
+        using var extensiblePcm = new WavePeakGenerator2(new MemoryStream(BuildWav(1, 24, i =>
+        {
+            var value = (int)(SampleAt(i) * 8388607);
+            return new[] { (byte)value, (byte)(value >> 8), (byte)(value >> 16) };
+        }, extensible: true)));
+        Assert.True(extensiblePcm.IsSupported);
+        Assert.Equal(WaveHeader2.AudioFormatPcm, extensiblePcm.Header.AudioFormat);
+
+        using var extensibleFloat = new WavePeakGenerator2(new MemoryStream(
+            BuildWav(3, 32, i => BitConverter.GetBytes(SampleAt(i)), extensible: true)));
+        Assert.True(extensibleFloat.IsSupported);
+        Assert.Equal(WaveHeader2.AudioFormatIeeeFloat, extensibleFloat.Header.AudioFormat);
+    }
+
+    [Fact]
+    public void FloatPeaksMatchIntegerPeaks()
+    {
+        var pcmPeaks = GeneratePeaks(BuildPcm16Wav());
+        var float32Peaks = GeneratePeaks(BuildFloat32Wav());
+        var float64Peaks = GeneratePeaks(BuildFloat64Wav());
+
+        Assert.Equal(pcmPeaks.Peaks.Count, float32Peaks.Peaks.Count);
+        Assert.Equal(pcmPeaks.Peaks.Count, float64Peaks.Peaks.Count);
+        Assert.NotEmpty(pcmPeaks.Peaks);
+
+        for (var i = 0; i < pcmPeaks.Peaks.Count; i++)
+        {
+            // Tolerance covers 16-bit quantization of the reference only - a wrongly read float
+            // is off by orders of magnitude, not by a few counts.
+            Assert.True(Math.Abs(pcmPeaks.Peaks[i].Max - float32Peaks.Peaks[i].Max) <= 4,
+                $"peak {i}: pcm max {pcmPeaks.Peaks[i].Max} vs float32 max {float32Peaks.Peaks[i].Max}");
+            Assert.True(Math.Abs(pcmPeaks.Peaks[i].Min - float32Peaks.Peaks[i].Min) <= 4,
+                $"peak {i}: pcm min {pcmPeaks.Peaks[i].Min} vs float32 min {float32Peaks.Peaks[i].Min}");
+            Assert.Equal(float32Peaks.Peaks[i].Max, float64Peaks.Peaks[i].Max);
+            Assert.Equal(float32Peaks.Peaks[i].Min, float64Peaks.Peaks[i].Min);
+        }
+    }
+
+    [Fact]
+    public void FloatSamplesAboveFullScaleAreClamped()
+    {
+        // Float wav keeps headroom above 1.0 - which is exactly why "volume=1.75" into float does
+        // not clip. The reader has to clamp rather than overflow the int cast.
+        var wav = BuildWav(3, 32, i => BitConverter.GetBytes(SampleAt(i) * 2.5f));
+        var peaks = GeneratePeaks(wav);
+
+        foreach (var peak in peaks.Peaks)
+        {
+            Assert.InRange(peak.Max, (short)-short.MaxValue, short.MaxValue);
+            Assert.InRange(peak.Min, (short)-short.MaxValue, short.MaxValue);
+        }
+    }
+}


### PR DESCRIPTION
Came out of #13738, where the suggestion to extract audio as `pcm_f32le` had to be turned down because SE's own peak reader could not read the result. This removes that limitation — and fixes two cases that were already broken for user-supplied files.

## What was rejected

`WavePeakGenerator2` accepted format tag 1 only:

- **IEEE float (tag 3)** — what DAWs export and what `-c:a pcm_f32le` produces. Worse than merely rejected: `ReadValue32Bit` reads an `int32`, so any path skipping the `IsSupported` check drew the float bit pattern as noise.
- **`WAVE_FORMAT_EXTENSIBLE` (tag 0xFFFE)** — which only says "the real tag is in the SubFormat GUID". This is not exotic; ffmpeg writes it routinely:

```
pcm_s16le mono   -> tag 0100
pcm_f32le mono   -> tag 0300
pcm_s24le mono   -> tag feff   (extensible)
pcm_s16le 5.1    -> tag feff   (extensible)
```

So a plain 24-bit wav, or any wav with more than two channels, drew no waveform at all.

## Changes

- Unwrap extensible to its SubFormat tag, and accept IEEE float alongside integer PCM.
- **Read the format tag unsigned.** As a signed short, `0xFFFE` arrives as `-2` and matches nothing — the new tests caught this immediately after the first pass.
- Float readers for 32- and 64-bit samples, normalizing to the 32-bit integer range so they compose with one shared scale regardless of storage width.
- **Clamp before the int cast.** Float wav legitimately carries samples past full scale — a real 16 kHz float export measured here peaks at **+2.57 dB** where the integer version clipped — and an out-of-range float-to-int cast is undefined in C#.

## Tests

`WavePeakFloatWavTests` feeds the same waveform through 16-bit, 32-bit float and 64-bit float encodings and compares the resulting peaks, covers both extensible subformats, and pins the above-full-scale clamping. Also verified against real ffmpeg output — all four files above now report `supported=True` with matching peak counts.

Full UI suite: 2998 passed, 0 failed.

## Note on the extraction command

This makes float extraction *possible*; it does not switch anything to it. With the volume boost gone (#13743) there is no clipping left for float to rescue, 16-bit at 16 kHz is transparent for speech recognition, and s16 is what every engine reads — so the extraction stays as it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)