### PR TITLE
Prepare v5.2.0-beta16

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -3,6 +3,42 @@ Subtitle Edit Changelog
 
 -----------------------------------------------------------------------------------------------------
 
+v5.2.0-beta16 (17th of August 2026)
+
+* Add a chapter editor with Matroska/MP4/OGM chapter formats (Video > More > Chapters) - thx alex64-pb
+* Add "Find voices in video and clone them all", plus cloning the voice of each line from the video - thx invio-a11y
+* Add the Voxtral backend to Crisp ASR speech to text - thx AmineI
+* Add "Final Cut Pro Xml Captions" export
+* Add DaVinci Resolve marker EDL import/export
+* Add reading of Adobe Premiere Pro "Markers" panel csv exports
+* Add text box "Copy (alternative)"/"Paste (alternative)" shortcuts, and make Shift+Delete really cut - thx GrampaWildWilly
+* Add .avi/XSUB reading to "seconv"
+* Add reading of IEEE float and WAVE_FORMAT_EXTENSIBLE wav files for the waveform
+* Open BDN xml and Final Cut Pro image xmeml from the main window (via OCR)
+* Show translation progress in batch convert - thx emsb8888-prog
+* Name batch auto-translated files after the target language - thx emsb8888-prog
+* Name forced container tracks with a ".forced" token in "seconv"
+* Update Crisp ASR to v0.8.29, and Chatterbox to the versioned V3 models with cross-lingual voice cloning
+* Improve container support after sweeps of MP4Box, ffmpeg, mkvmerge, TSDuck and Bento4 output
+* Improve broadcast format round-trips (PAC, Cavena 890, SCC, Cheetah, MacCaption, EBU-TT-D, Ayato, CapMaker Plus, IMSC 1.1)
+* Improve Apple format support - read Final Cut Pro captions and current fcpxml versions
+* Improve Adobe format support - read the EDLs and XMP markers Premiere/After Effects write, fix Encore round-trips
+* Fix negative time codes being zeroed when selecting a line - thx DexKen
+* Fix reading of Matroska files on a network share still being slower than in beta 13 - thx 1476523
+* Fix Ctrl+V in the subtitle grid not selecting/scrolling to the pasted lines - thx Davanix
+* Fix Ctrl/Cmd+V not overwriting the selected lines in the subtitle grid - thx rosilucia-hub
+* Fix Sub Station Alpha (.ssa) style colors being written as unreadable 32-bit values - thx schabau
+* Fix speech to text clipping the audio sent to the engine - thx AmineI
+* Fix Faster-Whisper XXL/CTranslate2 getting the extracted wav instead of the source file - thx popoche
+* Fix DVB subtitle timing when a cue starts at the video's first frame
+* Fix the DaVinci Resolve csv "Play" flag being read from the wrong column
+* Update Bulgarian translation - thx jekovcar
+* Update French translation - thx Need74
+* Update Polish translation - thx potplayer-fanpack
+* Update Russian translation - thx jekovcar
+
+-----------------------------------------------------------------------------------------------------
+
 v5.2.0-beta15 (16th of August 2026)
 
 * Add IndexTTS 2.5 as a text to speech engine, with emotion and speaking rate control

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "Subtitle Edit",
-  "version": "v5.2.0-beta15",
+  "version": "v5.2.0-beta16",
   "translatedBy": "",
   "cultureName": "en-US",
   "general": {

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -19,7 +19,7 @@ public class Se
     internal const int CurrentMacOsFontMigrationVersion = 1;
     internal const int CurrentShortcutsMigrationVersion = 2;
 
-    public static string Version { get; set; } = "v5.2.0-beta15";
+    public static string Version { get; set; } = "v5.2.0-beta16";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
Version bump and change-log section for the next beta.

- `src/ui/Logic/Config/Se.cs` and the generated `src/ui/Assets/Languages/English.json`: `v5.2.0-beta15` → `v5.2.0-beta16`
- `change-log.txt`: a new section covering all **38 PRs** merged since the `v5.2.0-beta15` tag

The entry set was compiled by ancestor-checking every merged PR's merge commit against the tag (`git merge-base --is-ancestor <sha> v5.2.0-beta15`), so nothing merged after the tag is missing. Reporters are credited from each PR's linked issue/discussion author. Wording is yours to curate.

Rolled up rather than one line per PR: the container sweeps (#13697, #13699, #13702, #13713), the broadcast/IMSC sweeps (#13725, #13727), the Apple sweep (#13719, #13720, #13723, #13726 — export and the OCR open path kept as their own lines), the Adobe sweep (#13729, #13730, #13731), the two voice-cloning PRs (#13710, #13716) and the CrispASR/Chatterbox bumps (#13736, #13739).

After merging, dispatch **Build and release UI** with `release_tag=v5.2.0-beta16`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)