### PR TITLE
Italian: credit GitGianluc in the translators line

### DIFF
--- a/src/ui/Assets/Languages/Italian.json
+++ b/src/ui/Assets/Languages/Italian.json
@@ -1,7 +1,7 @@
 ﻿{
   "title": "SubtitleEdit",
   "version": "v. 5.1.0",
-  "translatedBy": "v. 31.07.2026 di bovirus",
+  "translatedBy": "v. 31.07.2026 di bovirus - aggiornamenti di GitGianluc",
   "cultureName": "it-IT",
   "general": {
     "abort": "Annulla",


### PR DESCRIPTION
The Italian translation update in #13718 takes its wording from @GitGianluc's alternative translation (#13525), so credit him in the `translatedBy` line shown in About:

```
"v. 31.07.2026 di bovirus - aggiornamenti di GitGianluc"
```

@bovirus stays the maintainer of the file and keeps his own version stamp; `version` and `cultureName` are untouched.

Kept separate from #13718 so that PR stays a pure string change — the two touch different parts of the file and merge independently in either order.

`LanguageJsonFilesTests` + `LanguageFileFormatStringTests`: 34 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)