### PR TITLE
OCR window: index-mapped scrollbar for the subtitle grid

### DIFF
--- a/src/ui/Features/Ocr/OcrWindow.cs
+++ b/src/ui/Features/Ocr/OcrWindow.cs
@@ -575,6 +575,13 @@ public class OcrWindow : Window
                 },
         });
 
+        // Index-mapped scrollbar (#13579), like the main subtitle grid: the native bar is
+        // pixel-mapped and the virtualizing panel estimates its extent from the average
+        // realized row height, so the thumb jumps around while scrolling. Rows here vary
+        // even more than in the main grid - each holds a subtitle bitmap - so hide the
+        // native vertical bar and dock a row-index one beside the grid instead.
+        var scrollBarHost = new TableViewIndexScrollBar(dataGridSubtitle);
+
         // The image thumbnails scale with Ctrl+plus/minus (Image.MaxWidth/MaxHeight are
         // bound to the VM) - keep the pixel-sized image column in step with the zoom.
         var imageColumn = dataGridSubtitle.Columns[dataGridSubtitle.Columns.Count - 2];
@@ -583,6 +590,11 @@ public class OcrWindow : Window
             if (args.PropertyName == nameof(vm.ImageMaxWidth))
             {
                 imageColumn.Width = new GridLength(vm.ImageMaxWidth + cellChrome);
+
+                // Zooming re-measures every row, and the ScrollViewer keeps its pixel
+                // offset - which lands on a different row (zooming out far enough pins the
+                // list to its end). Stay on the row the user was looking at.
+                scrollBarHost.PreserveTopRow();
             }
         };
 
@@ -717,12 +729,7 @@ public class OcrWindow : Window
 
         vm.SubtitleGrid.ContextFlyout = flyout;
 
-        // Index-mapped scrollbar (#13579), like the main subtitle grid: the native bar is
-        // pixel-mapped and the virtualizing panel estimates its extent from the average
-        // realized row height, so the thumb jumps around while scrolling. Rows here vary
-        // even more than in the main grid - each holds a subtitle bitmap - so hide the
-        // native vertical bar and dock a row-index one beside the grid instead.
-        return UiUtil.MakeBorderForControlNoPadding(new TableViewIndexScrollBar(dataGridSubtitle)).WithMarginBottom(5);
+        return UiUtil.MakeBorderForControlNoPadding(scrollBarHost).WithMarginBottom(5);
     }
 
     private static Border MakeEditView(OcrViewModel vm)

--- a/src/ui/Features/Ocr/OcrWindow.cs
+++ b/src/ui/Features/Ocr/OcrWindow.cs
@@ -717,7 +717,12 @@ public class OcrWindow : Window
 
         vm.SubtitleGrid.ContextFlyout = flyout;
 
-        return UiUtil.MakeBorderForControlNoPadding(dataGridSubtitle).WithMarginBottom(5);
+        // Index-mapped scrollbar (#13579), like the main subtitle grid: the native bar is
+        // pixel-mapped and the virtualizing panel estimates its extent from the average
+        // realized row height, so the thumb jumps around while scrolling. Rows here vary
+        // even more than in the main grid - each holds a subtitle bitmap - so hide the
+        // native vertical bar and dock a row-index one beside the grid instead.
+        return UiUtil.MakeBorderForControlNoPadding(new TableViewIndexScrollBar(dataGridSubtitle)).WithMarginBottom(5);
     }
 
     private static Border MakeEditView(OcrViewModel vm)

--- a/src/ui/Logic/TableViewIndexScrollBar.cs
+++ b/src/ui/Logic/TableViewIndexScrollBar.cs
@@ -67,6 +67,9 @@ public sealed class TableViewIndexScrollBar : Grid
     // Non-null only while the left button is held on the trough.
     private TroughHold? _troughHold;
 
+    // Row to put back at the viewport top after a pending row-height change (PreserveTopRow).
+    private double? _preservedRow;
+
     private sealed class TroughHold
     {
         public required DispatcherTimer Timer { get; init; }
@@ -271,6 +274,37 @@ public sealed class TableViewIndexScrollBar : Grid
         }
 
         _syncingBar = false;
+    }
+
+    /// <summary>
+    /// Keeps the row at the viewport top where it is across a change that re-measures every
+    /// row - the OCR grid's Ctrl+plus/minus image zoom. The ScrollViewer preserves its
+    /// *pixel* offset when the rows grow or shrink, so the user lands on a different row
+    /// (zooming out far enough even pins the list to the end); in index units the same view
+    /// is simply the same Value, so re-apply it once the new heights have been measured.
+    /// Call it before making the change. Repeated calls while one is pending keep the first
+    /// row, so holding the zoom key down does not drift.
+    /// </summary>
+    public void PreserveTopRow()
+    {
+        if (_preservedRow != null)
+        {
+            return;
+        }
+
+        _preservedRow = _bar.Value;
+
+        // Loaded priority: after the layout pass that applies the new row heights (and so
+        // after ScrollChanged has re-synced Maximum for the clamp below).
+        Dispatcher.UIThread.Post(() =>
+        {
+            var preserved = _preservedRow;
+            _preservedRow = null;
+            if (preserved is { } value && _scrollViewer != null && _tableView.ItemCount > 0)
+            {
+                ApplyBarValue(Math.Clamp(value, 0, _bar.Maximum));
+            }
+        }, DispatcherPriority.Loaded);
     }
 
     private void QueueApply(double value)

--- a/tests/UI/Features/Ocr/OcrTableViewTests.cs
+++ b/tests/UI/Features/Ocr/OcrTableViewTests.cs
@@ -1,11 +1,15 @@
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Headless.XUnit;
+using Avalonia.Layout;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Microsoft.Extensions.DependencyInjection;
 using Nikse.SubtitleEdit;
 using Nikse.SubtitleEdit.Features.Ocr;
 using Nikse.SubtitleEdit.Features.Ocr.OcrSubtitle;
+using Nikse.SubtitleEdit.Logic;
 using SkiaSharp;
 
 namespace UITests.Features.Ocr;
@@ -165,6 +169,56 @@ public class OcrTableViewTests
             .Select(t => t.Text)
             .ToList();
         Assert.Contains("Line 2000", lastRowTexts);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void OcrWindow_UsesIndexMappedScrollBar()
+    {
+        // Same fix as the main subtitle grid (#13579): the rows here hold a bitmap each and
+        // vary even more in height, so the virtualizing panel's pixel-extent estimate - and
+        // with it the native thumb - moves on every scroll. The grid is wrapped in
+        // TableViewIndexScrollBar, which hides the native vertical bar and maps its own to
+        // row indices.
+        var vm = MakeViewModel(500);
+        var window = ShowWindow(vm);
+        var tableView = GetTableView(window);
+
+        var wrapper = window.GetVisualDescendants().OfType<TableViewIndexScrollBar>().Single();
+        var bar = wrapper.BarForTest;
+        var scrollViewer = tableView.GetVisualDescendants().OfType<ScrollViewer>().First();
+
+        var nativeBar = tableView.GetVisualDescendants().OfType<ScrollBar>()
+            .First(s => s.Orientation == Orientation.Vertical && !ReferenceEquals(s, bar));
+        Assert.False(nativeBar.IsVisible, "the native pixel-mapped vertical bar should be hidden");
+
+        // Row units, not pixels: a handful of rows out of 500 are visible, so the maximum
+        // sits just below the row count while the pixel extent is many thousands.
+        Assert.InRange(bar.Maximum, 400, 499);
+        Assert.True(scrollViewer.Extent.Height - scrollViewer.Viewport.Height > bar.Maximum * 2,
+            "sanity: the pixel extent should be far larger than the row-based maximum");
+
+        // The bar drives the view in row indices...
+        bar.Value = 250;
+        wrapper.ApplyPendingForTest();
+        window.UpdateLayout();
+        var row = tableView.ContainerFromIndex(250);
+        Assert.NotNull(row);
+        var viewportOrigin = (Visual?)scrollViewer.Presenter ?? scrollViewer;
+        var top = ((Visual)row!).TranslatePoint(new Point(0, 0), viewportOrigin)!.Value.Y;
+        Assert.InRange(top, -1, 1);
+
+        // ...and scrolling the view drives the bar back, without ever moving backwards.
+        var previous = bar.Value;
+        for (var i = 0; i < 10; i++)
+        {
+            scrollViewer.Offset = new Vector(0, scrollViewer.Offset.Y + 120);
+            window.UpdateLayout();
+            Assert.True(bar.Value >= previous - 0.001,
+                $"thumb moved backwards while scrolling down: {previous} -> {bar.Value}");
+            previous = bar.Value;
+        }
 
         window.Close();
     }

--- a/tests/UI/Features/Ocr/OcrTableViewTests.cs
+++ b/tests/UI/Features/Ocr/OcrTableViewTests.cs
@@ -26,9 +26,13 @@ public class OcrTableViewTests
     {
         public int Count { get; init; }
 
+        // Smaller than the view model's ImageMaxWidth/Height, so the thumbnails are shown at
+        // their natural size; the zoom test asks for a wider one, which the maxes constrain.
+        public SKSizeI BitmapSize { get; init; } = new(120, 40);
+
         public SKBitmap GetBitmap(int index)
         {
-            var bitmap = new SKBitmap(120, 40);
+            var bitmap = new SKBitmap(BitmapSize.Width, BitmapSize.Height);
             using var canvas = new SKCanvas(bitmap);
             canvas.Clear(SKColors.White);
             return bitmap;
@@ -53,14 +57,16 @@ public class OcrTableViewTests
         public SKSizeI GetScreenSize(int index) => new(1920, 1080);
     }
 
-    private static OcrViewModel MakeViewModel(int itemCount)
+    private static OcrViewModel MakeViewModel(int itemCount, SKSizeI? bitmapSize = null)
     {
         var services = new ServiceCollection();
         services.AddSubtitleEditServices();
         var provider = services.BuildServiceProvider();
         var vm = provider.GetRequiredService<OcrViewModel>();
 
-        var source = new FakeOcrSubtitle { Count = itemCount };
+        var source = bitmapSize is { } size
+            ? new FakeOcrSubtitle { Count = itemCount, BitmapSize = size }
+            : new FakeOcrSubtitle { Count = itemCount };
         foreach (var item in source.MakeOcrSubtitleItems())
         {
             item.Text = $"Line {item.Number}";
@@ -72,6 +78,32 @@ public class OcrTableViewTests
 
     private static TableView GetTableView(Window window) =>
         window.GetVisualDescendants().OfType<TableView>().Single();
+
+    /// <summary>Index of the topmost row still inside the viewport. The TableView template
+    /// pins the column header inside the ScrollViewer, so rows are measured against the
+    /// content presenter - the ScrollViewer's own origin is a header height above.</summary>
+    private static int FirstVisibleIndex(TableView grid, ScrollViewer scrollViewer)
+    {
+        var origin = (Visual?)scrollViewer.Presenter ?? scrollViewer;
+        var best = -1;
+        var bestTop = double.MaxValue;
+        foreach (var row in grid.GetRealizedContainers().OfType<TableViewRow>())
+        {
+            var top = ((Visual)row).TranslatePoint(new Point(0, 0), origin)?.Y;
+            if (top == null || row.Bounds.Height <= 0 || top.Value + row.Bounds.Height <= 0.5)
+            {
+                continue;
+            }
+
+            if (top.Value < bestTop)
+            {
+                bestTop = top.Value;
+                best = grid.IndexFromContainer(row);
+            }
+        }
+
+        return best;
+    }
 
     private static OcrWindow ShowWindow(OcrViewModel vm)
     {
@@ -219,6 +251,70 @@ public class OcrTableViewTests
                 $"thumb moved backwards while scrolling down: {previous} -> {bar.Value}");
             previous = bar.Value;
         }
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void OcrWindow_ZoomKeepsTheRowAtTheTop()
+    {
+        // Ctrl+plus/minus re-measures every row (the thumbnails are bound to
+        // ImageMaxWidth/Height), and the ScrollViewer keeps its *pixel* offset across that -
+        // which lands on a different row: zooming in used to drop the user ~80 rows back,
+        // and zooming out far enough pinned the list to its end. The index bar knows which
+        // row was at the top, so it is put back there.
+        var vm = MakeViewModel(500, new SKSizeI(600, 120)); // wide enough for the maxes to bind
+        var window = ShowWindow(vm);
+        var tableView = GetTableView(window);
+        var wrapper = window.GetVisualDescendants().OfType<TableViewIndexScrollBar>().Single();
+        var bar = wrapper.BarForTest;
+        var scrollViewer = tableView.GetVisualDescendants().OfType<ScrollViewer>().First();
+
+        double RowHeight() => tableView.GetRealizedContainers().OfType<TableViewRow>()
+            .Select(r => r.Bounds.Height).DefaultIfEmpty(0).Max();
+
+        void SettleLayout()
+        {
+            // Twice: the first pass measures the new row heights, the second runs the
+            // re-placement PreserveTopRow posted at Loaded priority.
+            for (var i = 0; i < 2; i++)
+            {
+                Dispatcher.UIThread.RunJobs();
+                window.UpdateLayout();
+            }
+        }
+
+        bar.Value = 250;
+        wrapper.ApplyPendingForTest();
+        window.UpdateLayout();
+        Assert.Equal(250, FirstVisibleIndex(tableView, scrollViewer));
+        var heightBefore = RowHeight();
+
+        // Zoom in five notches, like holding Ctrl+plus.
+        for (var i = 0; i < 5; i++)
+        {
+            vm.ImageMaxHeight *= 1.1;
+            vm.ImageMaxWidth *= 1.1;
+        }
+
+        SettleLayout();
+
+        Assert.True(RowHeight() > heightBefore, "sanity: zooming in should make the rows taller");
+        Assert.Equal(250, FirstVisibleIndex(tableView, scrollViewer));
+        Assert.Equal(250, bar.Value, 1);
+
+        // ...and ten notches back out, which shrinks the pixel extent below the old offset.
+        for (var i = 0; i < 10; i++)
+        {
+            vm.ImageMaxHeight *= 0.9;
+            vm.ImageMaxWidth *= 0.9;
+        }
+
+        SettleLayout();
+
+        Assert.True(RowHeight() < heightBefore, "sanity: zooming out should make the rows shorter");
+        Assert.Equal(250, FirstVisibleIndex(tableView, scrollViewer));
+        Assert.Equal(250, bar.Value, 1);
 
         window.Close();
     }


### PR DESCRIPTION
The OCR subtitle grid had the same jumping scrollbar thumb as the main subtitle grid (#13579): Avalonia's `VirtualizingStackPanel` estimates the total pixel extent as *realized rows + remaining × average realized height*, so with variable-height rows the extent — and the native thumb — shifts on every wheel tick. The OCR grid is the worse case: every row holds a subtitle bitmap, so heights vary far more than the main grid's one-vs-two text lines.

## Change

`MakeSubtitleView` now wraps the grid in `TableViewIndexScrollBar`, the same control the main grid already uses. It hides the native pixel-mapped vertical bar and docks a standalone one mapped to row indices:

- `Value` = index of the first visible row (+ the fraction scrolled into it)
- `Maximum` = row count − fully visible rows

Wheel, keyboard and the OCR loop's own `ScrollIntoView` still move the pixel offset; `ScrollChanged` re-derives the thumb. Trough press-and-hold (#12894) and shift+click jump come along with the control.

## Verification

New test `OcrWindow_UsesIndexMappedScrollBar` asserts, on a 500-item OCR window:

- the native vertical bar is hidden and the index bar is the visible one
- `Maximum` is in row units (400–499), while the pixel extent is many times larger
- setting `Value = 250` places row 250 at the viewport top
- scrolling the view down never moves the thumb backwards

779 Ocr/TableView UI tests pass; build clean.

## Not included

The main grid also gets `TableViewScrollAnchor.Attach` (#13619) to hold the view steady when a row changes height. The OCR grid's rows do change height as text lands during OCR, but the OCR loop already scrolls to the current line itself, so an anchor could fight it — left for a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)