### PR TITLE
ffmpeg 9.0.1 (win) / 9.0 (mac arm), and stop passing -vsync

### DIFF
--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -428,6 +428,46 @@ public class Se
     }
 
     /// <summary>
+    /// Drops "-vsync vfr" from a settings file written before ffmpeg 9. ffmpeg 9 removed the
+    /// long-deprecated -vsync option, so it aborts with "Unrecognized option 'vsync'" and shot
+    /// change detection silently finds nothing. The option was a no-op for this command line
+    /// (the output goes to "-f null -"), so removing it changes nothing on older ffmpeg builds.
+    /// A user who has edited the arguments in any other way keeps their own version.
+    /// </summary>
+    internal static void MigrateShotChangesFfmpegArguments(SeVideo video)
+    {
+        var arguments = video.ShowChangesFFmpegArguments;
+        if (string.IsNullOrEmpty(arguments))
+        {
+            return;
+        }
+
+        const string option = "-vsync ";
+        var index = arguments.IndexOf(option, StringComparison.Ordinal);
+        if (index < 0)
+        {
+            return;
+        }
+
+        while (index >= 0)
+        {
+            // -vsync takes a value ("vfr", "0", ...); drop that too, plus the space in front of
+            // the option so the remaining arguments stay separated by single spaces.
+            var end = arguments.IndexOf(' ', index + option.Length);
+            if (end < 0)
+            {
+                end = arguments.Length;
+            }
+
+            var start = index > 0 && arguments[index - 1] == ' ' ? index - 1 : index;
+            arguments = arguments.Remove(start, end - start);
+            index = arguments.IndexOf(option, StringComparison.Ordinal);
+        }
+
+        video.ShowChangesFFmpegArguments = arguments.Trim();
+    }
+
+    /// <summary>
     /// Loads the UI translation named in <see cref="Settings"/>.General.Language into the global
     /// <see cref="Language"/>. Must run before the main window is built: on macOS the native menu
     /// bar is constructed at startup and reads <see cref="Language"/> directly, so the translation
@@ -570,6 +610,8 @@ public class Se
         {
             Settings.Video = new();
         }
+
+        MigrateShotChangesFfmpegArguments(Settings.Video);
 
         if (Settings.Waveform == null)
         {

--- a/src/ui/Logic/Config/SeVideo.cs
+++ b/src/ui/Logic/Config/SeVideo.cs
@@ -60,7 +60,10 @@ public class SeVideo
         OpenSearchParentFolder = true;
         CutType = Features.Video.CutVideo.CutType.MergeSegments.ToString();
         CutDefaultVideoExtension = ".mkv";
-        ShowChangesFFmpegArguments = "-i \"{0}\" -vf \"select=gt(scene\\,{1}),showinfo\" -threads 0 -vsync vfr -f null -";
+        // No "-vsync vfr": ffmpeg 9 removed the long-deprecated -vsync option and aborts with
+        // "Unrecognized option 'vsync'", so shot change detection found nothing. It never did
+        // anything here anyway - the output is discarded by "-f null -".
+        ShowChangesFFmpegArguments = "-i \"{0}\" -vf \"select=gt(scene\\,{1}),showinfo\" -threads 0 -f null -";
         MoveVideoPositionCustom1Back = 2000; // 2 seconds
         MoveVideoPositionCustom1Forward = 2000; // 2 seconds
         MoveVideoPositionCustom2Back = 5000; // 5 seconds

--- a/src/ui/Logic/Download/FfmpegDownloadService.cs
+++ b/src/ui/Logic/Download/FfmpegDownloadService.cs
@@ -16,9 +16,12 @@ public interface IFfmpegDownloadService
 public class FfmpegDownloadService : IFfmpegDownloadService
 {
     private readonly HttpClient _httpClient;
-    private const string WindowsUrl = "https://github.com/SubtitleEdit/support-files/releases/download/ffmpeg-v9/ffmpeg90.zip";
+    private const string WindowsUrl = "https://github.com/SubtitleEdit/support-files/releases/download/ffmpeg-v9-1/ffmpeg901.zip";
+
+    // Intel is still 8.0: osxexperts.net, where both macOS builds come from, has not published an
+    // Intel build past 8.0.
     private const string MacUrl = "https://github.com/SubtitleEdit/support-files/releases/download/ffmpeg-v8/ffmpeg80intel.zip";
-    private const string MacUrlArm = "https://github.com/SubtitleEdit/support-files/releases/download/ffmpeg-v8/ffmpeg81arm.zip";
+    private const string MacUrlArm = "https://github.com/SubtitleEdit/support-files/releases/download/ffmpeg-v9-1/ffmpeg90arm.zip";
     
     public FfmpegDownloadService(HttpClient httpClient)
     {

--- a/src/ui/Logic/Media/FfmpegGenerator.cs
+++ b/src/ui/Logic/Media/FfmpegGenerator.cs
@@ -499,7 +499,9 @@ public class FfmpegGenerator
             StartInfo =
             {
                 FileName = GetFfmpegLocation(),
-                Arguments = $"-i \"{videoFileName}\" -vf \"select=1\" -vsync vfr \"{outputFileName}\"",
+                // "-vsync vfr" was dropped: ffmpeg 9 removed -vsync and aborts before decoding
+                // anything, and "select=1" already passes every frame through unchanged.
+                Arguments = $"-i \"{videoFileName}\" -vf \"select=1\" \"{outputFileName}\"",
                 UseShellExecute = false,
                 CreateNoWindow = true
             }

--- a/tests/UI/Logic/Config/ShotChangesFfmpegArgumentsMigrationTests.cs
+++ b/tests/UI/Logic/Config/ShotChangesFfmpegArgumentsMigrationTests.cs
@@ -1,0 +1,68 @@
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Logic.Config;
+
+public class ShotChangesFfmpegArgumentsMigrationTests
+{
+    [Fact]
+    public void LegacyArgumentsLoseVsync()
+    {
+        var video = new SeVideo
+        {
+            ShowChangesFFmpegArguments = "-i \"{0}\" -vf \"select=gt(scene\\,{1}),showinfo\" -threads 0 -vsync vfr -f null -",
+        };
+
+        Se.MigrateShotChangesFfmpegArguments(video);
+
+        Assert.Equal("-i \"{0}\" -vf \"select=gt(scene\\,{1}),showinfo\" -threads 0 -f null -", video.ShowChangesFFmpegArguments);
+    }
+
+    [Fact]
+    public void DefaultArgumentsAreUnchanged()
+    {
+        var video = new SeVideo();
+        var expected = video.ShowChangesFFmpegArguments;
+
+        Se.MigrateShotChangesFfmpegArguments(video);
+
+        Assert.DoesNotContain("-vsync", video.ShowChangesFFmpegArguments);
+        Assert.Equal(expected, video.ShowChangesFFmpegArguments);
+    }
+
+    [Theory]
+    [InlineData("-i \"{0}\" -vsync 0 -f null -", "-i \"{0}\" -f null -")]
+    [InlineData("-i \"{0}\" -vsync passthrough -threads 0 -f null -", "-i \"{0}\" -threads 0 -f null -")]
+    [InlineData("-i \"{0}\" -threads 0 -f null - -vsync vfr", "-i \"{0}\" -threads 0 -f null -")]
+    [InlineData("-vsync vfr -i \"{0}\" -f null -", "-i \"{0}\" -f null -")]
+    public void VsyncIsRemovedWithItsValue(string arguments, string expected)
+    {
+        var video = new SeVideo { ShowChangesFFmpegArguments = arguments };
+
+        Se.MigrateShotChangesFfmpegArguments(video);
+
+        Assert.Equal(expected, video.ShowChangesFFmpegArguments);
+    }
+
+    [Fact]
+    public void OtherCustomArgumentsAreKept()
+    {
+        var video = new SeVideo
+        {
+            ShowChangesFFmpegArguments = "-i \"{0}\" -vf \"select=gt(scene\\,{1}),showinfo\" -threads 4 -f null -",
+        };
+
+        Se.MigrateShotChangesFfmpegArguments(video);
+
+        Assert.Equal("-i \"{0}\" -vf \"select=gt(scene\\,{1}),showinfo\" -threads 4 -f null -", video.ShowChangesFFmpegArguments);
+    }
+
+    [Fact]
+    public void EmptyArgumentsAreLeftAlone()
+    {
+        var video = new SeVideo { ShowChangesFFmpegArguments = string.Empty };
+
+        Se.MigrateShotChangesFfmpegArguments(video);
+
+        Assert.Equal(string.Empty, video.ShowChangesFFmpegArguments);
+    }
+}


### PR DESCRIPTION
Closes #13754.

## Version bump

New support-files release [`ffmpeg-v9-1`](https://github.com/SubtitleEdit/support-files/releases/tag/ffmpeg-v9-1), with the source checksums recorded in the release notes the same way `ffmpeg-v9` does:

| Leg | Was | Now | Source |
|---|---|---|---|
| Windows | 9.0 | **9.0.1** | gyan.dev release-essentials, repackaged to `ffmpeg.exe` only |
| macOS ARM | 8.1 | **9.0** | osxexperts.net `ffmpeg9arm.zip`, repackaged without the `__MACOSX` sidecar |
| macOS Intel | 8.0 | 8.0 (unchanged) | osxexperts.net has no Intel build past 8.0 |

Both binaries were verified against the publishers' own SHA-256s, and the repackaged mac binary keeps its exec bit and ad-hoc signature (`codesign -v` passes). The ARM 9.0 build has the same configure flags as the 8.1 build it replaces.

The two macOS legs are still out of step. evermeet.cx does have a 9.0.1 x86_64 build that passes SE's command lines under Rosetta, but that is a new upstream builder, so the Intel leg stays where it is until osxexperts ships 9.

## The bug this turned up

ffmpeg 9 **removed** the long-deprecated `-vsync` option — it now aborts with `Unrecognized option 'vsync'` before decoding anything. SE passed `-vsync vfr` in two places, so on ffmpeg 9 (which Windows users already download today) both silently did nothing:

- **shot change detection** — auto-generate on video open, and the Shot changes dialog — found no shot changes at all
- `FfmpegGenerator.GetScreenShotsForEachFrame` returned an empty frame list

Measured on the same clip with a real cut, `select=gt(scene,0.4),showinfo`:

| | 8.1 | 9.0 |
|---|---|---|
| `-vsync vfr` | 2 cuts | **0 cuts** |
| no option | 2 cuts | 2 cuts |

Dropping the option is enough, and is the portable fix: it was a no-op in the shot change command (output goes to `-f null -`), and `select=1` already passes every frame through. `-fps_mode vfr` also works but needs ffmpeg >= 5.0, which the *system* ffmpeg on older Linux distros may not be.

The shot change arguments are a **persisted user setting**, so changing the default alone would leave every existing settings file broken. `Se.MigrateShotChangesFfmpegArguments` strips `-vsync` and its value on load and leaves any other customization untouched.

## Testing

- New `ShotChangesFfmpegArgumentsMigrationTests` (8 cases: legacy string, default, `-vsync` in leading/trailing/other positions and other values, unrelated customizations, empty) — pass, as does the rest of `Logic.Config` (60 tests).
- The new ARM 9.0 binary was run through SE's actual command lines: waveform extraction (`-ar 24000 -ac 2 -ab 128 -af volume=1.75`), STT extraction, shot detection, subtitle burn-in via `subtitles=`, and per-frame PNG extraction — all fine.
- Diffed the full CLI option list between 8.1 and 9.0: `-vsync` is the only option SE uses that ffmpeg 9 dropped (the others are `-adrift_threshold`, `-filter_complex_script`, `-filter_script`, `-qphist`, `-top`, none of which SE passes).
- Both published assets re-downloaded from their release URLs and re-hashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)