### PR TITLE
Update libmpv to shinchiro 20260814

### DIFF
--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -322,9 +322,9 @@ jobs:
 
       - name: Download libmpv for Windows
         run: |
-          Invoke-WebRequest -Uri "https://github.com/SubtitleEdit/support-files/releases/download/libmpv-2026-04-21/libmpv2-win64.zip" -OutFile "libmpv2-64.zip"
+          Invoke-WebRequest -Uri "https://github.com/SubtitleEdit/support-files/releases/download/libmpv-2026-08-14/libmpv2-win64.zip" -OutFile "libmpv2-64.zip"
           Expand-Archive -Path "libmpv2-64.zip" -DestinationPath "libmpv-temp"
-          Invoke-WebRequest -Uri "https://github.com/SubtitleEdit/support-files/releases/download/libmpv-2026-04-21/libmpv2-win-arm64.zip" -OutFile "libmpv2-arm64.zip"
+          Invoke-WebRequest -Uri "https://github.com/SubtitleEdit/support-files/releases/download/libmpv-2026-08-14/libmpv2-win-arm64.zip" -OutFile "libmpv2-arm64.zip"
           Expand-Archive -Path "libmpv2-arm64.zip" -DestinationPath "libmpv-arm64-temp"
 
       - name: Publish Windows x64 app

--- a/src/ui/Logic/Download/LibMpvDownloadService .cs
+++ b/src/ui/Logic/Download/LibMpvDownloadService .cs
@@ -17,8 +17,8 @@ public interface ILibMpvDownloadService
 public class LibMpvDownloadService : ILibMpvDownloadService
 {
     private readonly HttpClient _httpClient;
-    private const string WindowsUrl = "https://github.com/SubtitleEdit/support-files/releases/download/libmpv-2026-04-21/libmpv2-win64.zip";
-    private const string WindowsUrlArm = "https://github.com/SubtitleEdit/support-files/releases/download/libmpv-2026-04-21/libmpv2-win-arm64.zip";
+    private const string WindowsUrl = "https://github.com/SubtitleEdit/support-files/releases/download/libmpv-2026-08-14/libmpv2-win64.zip";
+    private const string WindowsUrlArm = "https://github.com/SubtitleEdit/support-files/releases/download/libmpv-2026-08-14/libmpv2-win-arm64.zip";
     private const string MacUrl = "";
     private const string MacUrlArm = "";
 


### PR DESCRIPTION
Bumps the pinned Windows libmpv from the 2026-04-21 build (`mpv v0.41.0-524-g5921fe50b`) to `20260814` (`mpv v0.41.0-923-g7b8915bc1`).

## What was done

The archives are repackaged, so this is not a one-line edit. New `libmpv2-win64.zip` / `libmpv2-win-arm64.zip` were built from the upstream release and published as [`libmpv-2026-08-14`](https://github.com/SubtitleEdit/support-files/releases/tag/libmpv-2026-08-14) on `SubtitleEdit/support-files`; this PR then just repoints the four URLs.

| Leg | Upstream source | PE machine |
|---|---|---|
| x64 | `mpv-dev-x86_64-20260814-git-7b8915bc1d.7z` (non-`v3`) | `0x8664` AMD64 |
| ARM64 | `mpv-dev-aarch64-20260814-git-7b8915bc1d.7z` | `0xAA64` ARM64 |

Each zip contains a single `libmpv-2.dll` at the root, matching the previous archive layout exactly.

## Verified

- PE headers read directly from both DLLs — architectures are matched, so an ARM64 process will not be handed the x64 DLL ([#12087](https://github.com/SubtitleEdit/subtitleedit/issues/12087))
- The non-`v3` x86_64 archive was used, so AVX2 is not required
- Version string in both DLLs is `mpv v0.41.0-923-g7b8915bc1`, matching the upstream `git-7b8915bc1d` revision
- Both new release URLs return HTTP 200

macOS dylibs are harvested separately from the pinned IINA release and are untouched. libmpv has no `DownloadHashManager` entries, so no hash lists needed regenerating.

Fixes #13753

🤖 Generated with [Claude Code](https://claude.com/claude-code)