### PR TITLE
Tesseract 5.5.0 → 5.5.3, in a version-less data folder

### DIFF
--- a/docs/third-party-components.md
+++ b/docs/third-party-components.md
@@ -31,7 +31,7 @@ Subtitle Edit stores these components in its **Data Folder**.
 | **FFmpeg** | `ffmpeg.exe`, `ffprobe.exe` (optional) | `[Data Folder]/ffmpeg` |
 | **MPV** | `libmpv-2.dll` | `[Data Folder]` (root) |
 | **yt-dlp** | `yt-dlp.exe` | `[Data Folder]` (root) |
-| **Tesseract** | `tesseract.exe`, `tessdata/` folder | `[Data Folder]/Tesseract550` |
+| **Tesseract** | `tesseract.exe`, `tessdata/` folder | `[Data Folder]/Tesseract` |
 | **Whisper CPP** | `whisper-cli.exe`, `Models/` folder | `[Data Folder]/SpeechToText/Cpp` |
 | **Purfview Faster-Whisper XXL** | `faster-whisper-xxl.exe`, `_models/` folder | `[Data Folder]/SpeechToText/Purfview-Faster-Whisper-XXL` |
 | **Crisp ASR** | `crispasr.exe`, `models/` folder | `[Data Folder]/CrispASR` |
@@ -83,7 +83,7 @@ Used to enable mpv to stream online videos (e.g., YouTube, Vimeo, and [many othe
 Used for converting image-based subtitles (Sup/VobSub) to text.
 
 *   **Download:** [UB-Mannheim Tesseract](https://github.com/UB-Mannheim/tesseract/wiki)
-*   **Destination:** `[Data Folder]/Tesseract550`
+*   **Destination:** `[Data Folder]/Tesseract`
 *   **Files:** The content of the installation folder (containing `tesseract.exe` and `tessdata` folder) should be placed here.
 
 ### Whisper CPP (Speech-to-Text)

--- a/src/ui/Features/Ocr/Download/DownloadTesseractViewModel.cs
+++ b/src/ui/Features/Ocr/Download/DownloadTesseractViewModel.cs
@@ -106,8 +106,13 @@ public partial class DownloadTesseractViewModel : ObservableObject, IClosingClea
     private void UnpackTesseract()
     {
         _downloadStream.Position = 0;
+        TesseractDownloadService.RemoveOldWindowsBinaries();
         _zipUnpacker.UnpackZipStream(_downloadStream, Se.TesseractFolder);
         _downloadStream.Dispose();
+
+        // Only stamp the version once the unpack succeeded - otherwise a failed unpack is
+        // recorded as current and the update is never retried.
+        TesseractDownloadService.WriteVersionFile();
     }
 
     private void Close()
@@ -141,7 +146,7 @@ public partial class DownloadTesseractViewModel : ObservableObject, IClosingClea
             StatusText = string.Format(Se.Language.General.DownloadingXPercent, pctString);
         });
 
-        var folder = Se.FfmpegFolder;
+        var folder = Se.TesseractFolder;
         if (!Directory.Exists(folder))
         {
             Directory.CreateDirectory(folder);

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -4354,20 +4354,31 @@ public partial class OcrViewModel : ObservableObject
         if (OperatingSystem.IsWindows())
         {
             var tesseractExe = Path.Combine(Se.TesseractFolder, "tesseract.exe");
-            if (File.Exists(tesseractExe))
+            var isOutdated = TesseractDownloadService.IsWindowsBuildOutdated();
+            var isInstalled = File.Exists(tesseractExe);
+            if (isInstalled && !isOutdated)
             {
                 return true;
             }
 
             var answer = await MessageBox.Show(
                 Window!,
-                "Download Tesseract OCR?",
-                $"{Environment.NewLine}\"Tesseract\" requires downloading Tesseract OCR.{Environment.NewLine}{Environment.NewLine}Download and use Tesseract OCR?",
+                isOutdated ? "Update Tesseract OCR?" : "Download Tesseract OCR?",
+                isOutdated
+                    ? $"{Environment.NewLine}A newer Tesseract OCR ({TesseractDownloadService.WindowsVersion}) is available.{Environment.NewLine}{Environment.NewLine}Download and use it? Your downloaded languages are kept."
+                    : $"{Environment.NewLine}\"Tesseract\" requires downloading Tesseract OCR.{Environment.NewLine}{Environment.NewLine}Download and use Tesseract OCR?",
                 MessageBoxButtons.YesNoCancel,
                 MessageBoxIcon.Question);
 
             if (answer != MessageBoxResult.Yes)
             {
+                // Declining an update must not break OCR - keep running the installed build.
+                if (isInstalled)
+                {
+                    TesseractDownloadService.DeclineWindowsUpdate();
+                    return true;
+                }
+
                 return false;
             }
 

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -188,6 +188,40 @@ public class Se
     public static string CrispEmbedFolder => Path.Combine(OcrFolder, "CrispEmbed");
     public static string VlcFolder => Path.Combine(DataFolder, "VLC");
     public static string SevenZipFolder => Path.Combine(DataFolder, "7Zip");
+    private const string TesseractFolderName = "Tesseract";
+    private const string LegacyTesseractFolderName = "Tesseract550";
+
+    private static readonly Lazy<string> _tesseractDataFolder = new(ResolveTesseractDataFolder);
+
+    // Holds the Tesseract binaries (Windows only) and the downloaded models (all platforms).
+    // The name used to carry the Tesseract version, which orphaned every downloaded model on
+    // each bump - and on macOS/Linux, where the binary comes from brew/apt, models were the
+    // only thing in there. Rename it once, version-less, and move the old folder across.
+    private static string ResolveTesseractDataFolder() => ResolveTesseractDataFolder(DataFolder);
+
+    internal static string ResolveTesseractDataFolder(string dataFolder)
+    {
+        var folder = Path.Combine(dataFolder, TesseractFolderName);
+        var legacyFolder = Path.Combine(dataFolder, LegacyTesseractFolderName);
+        if (Directory.Exists(folder) || !Directory.Exists(legacyFolder))
+        {
+            return folder;
+        }
+
+        try
+        {
+            Directory.Move(legacyFolder, folder);
+        }
+        catch (Exception exception)
+        {
+            // Keep using the old folder rather than silently hiding the models that are in it.
+            SeLogger.Error($"Could not move \"{legacyFolder}\" to \"{folder}\": {exception.Message}");
+            return legacyFolder;
+        }
+
+        return folder;
+    }
+
     private static readonly Lazy<string> _tesseractFolder = new(ResolveTesseractFolder);
     public static string TesseractFolder => _tesseractFolder.Value;
 
@@ -195,7 +229,7 @@ public class Se
     {
         if (OperatingSystem.IsWindows())
         {
-            return Path.Combine(DataFolder, "Tesseract550");
+            return _tesseractDataFolder.Value;
         }
 
         var folders = new List<string>();
@@ -222,7 +256,7 @@ public class Se
             }
         }
 
-        return Path.Combine(DataFolder, "Tesseract550");
+        return _tesseractDataFolder.Value;
     }
 
     private static readonly Lazy<string> _tesseractModelFolder = new(ResolveTesseractModelFolder);
@@ -230,7 +264,7 @@ public class Se
 
     private static string ResolveTesseractModelFolder()
     {
-        var modelFolder = Path.Combine(DataFolder, "Tesseract550", "tessdata");
+        var modelFolder = Path.Combine(_tesseractDataFolder.Value, "tessdata");
         SeedBundledTesseractModels(modelFolder);
         return modelFolder;
     }

--- a/src/ui/Logic/Download/TesseractDownloadService.cs
+++ b/src/ui/Logic/Download/TesseractDownloadService.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Nikse.SubtitleEdit.Logic.Compression;
+using Nikse.SubtitleEdit.Logic.Config;
 
 namespace Nikse.SubtitleEdit.Logic.Download;
 
@@ -16,7 +17,16 @@ public interface ITesseractDownloadService
 public class TesseractDownloadService : ITesseractDownloadService
 {
     private readonly HttpClient _httpClient;
-    private const string WindowsUrl = "https://github.com/SubtitleEdit/support-files/releases/download/tesseract550/Tesseract550.zip";
+    private const string WindowsUrl = "https://github.com/SubtitleEdit/support-files/releases/download/tesseract553/Tesseract553.zip";
+
+    /// <summary>Tesseract version behind <see cref="WindowsUrl"/>; stamped into the install folder.</summary>
+    public const string WindowsVersion = "5.5.3";
+
+    private const string VersionFileName = "version.txt";
+
+    // Set when the user says no to an update, so the prompt does not come back on every OCR run.
+    private static bool _windowsUpdateDeclined;
+
     private readonly IZipUnpacker _zipUnpacker;
 
     public TesseractDownloadService(HttpClient httpClient, IZipUnpacker zipUnpacker)
@@ -45,5 +55,98 @@ public class TesseractDownloadService : ITesseractDownloadService
     public async Task DownloadTesseractModel(string modelUrl, Stream stream, IProgress<float>? progress, CancellationToken cancellationToken)
     {
         await DownloadHelper.DownloadFileAsync(_httpClient, modelUrl, stream, progress, cancellationToken);
+    }
+
+    /// <summary>
+    /// True when Tesseract is installed but older than <see cref="WindowsVersion"/>. Windows only:
+    /// elsewhere the binary comes from brew/apt and is not ours to update.
+    /// </summary>
+    public static bool IsWindowsBuildOutdated()
+    {
+        if (!OperatingSystem.IsWindows() || _windowsUpdateDeclined)
+        {
+            return false;
+        }
+
+        if (!File.Exists(Path.Combine(Se.TesseractFolder, "tesseract.exe")))
+        {
+            return false; // nothing installed - that is a plain download, not an update
+        }
+
+        var versionFileName = Path.Combine(Se.TesseractFolder, VersionFileName);
+        if (!File.Exists(versionFileName))
+        {
+            return true; // installed before SE stamped a version, so pre-5.5.3
+        }
+
+        try
+        {
+            var installed = new SemanticVersion(File.ReadAllText(versionFileName));
+            return installed.IsLessThan(new SemanticVersion(WindowsVersion));
+        }
+        catch (Exception exception)
+        {
+            Se.LogError(exception, $"Could not read Tesseract version from \"{versionFileName}\".");
+            return false; // an unreadable stamp should not nag the user on every OCR run
+        }
+    }
+
+    public static void DeclineWindowsUpdate()
+    {
+        _windowsUpdateDeclined = true;
+    }
+
+    /// <summary>Records the version just unpacked. Call only after a successful unpack.</summary>
+    public static void WriteVersionFile()
+    {
+        try
+        {
+            File.WriteAllText(Path.Combine(Se.TesseractFolder, VersionFileName), WindowsVersion);
+        }
+        catch (Exception exception)
+        {
+            Se.LogError(exception, $"Could not write Tesseract version file in \"{Se.TesseractFolder}\".");
+        }
+    }
+
+    /// <summary>
+    /// Clears the previous binaries so DLLs that 5.5.3 no longer ships (the ICU 75 pair, the
+    /// OpenSSL libcrypto, the pango/cairo set) do not linger. Leaves <c>tessdata</c> alone - the
+    /// user's downloaded models live there.
+    /// </summary>
+    public static void RemoveOldWindowsBinaries()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            // TesseractFolder can be a system bin folder (/usr/bin, brew) on macOS/Linux - never
+            // delete anything there. Only the Windows build is downloaded into a folder we own.
+            return;
+        }
+
+        try
+        {
+            var folder = Se.TesseractFolder;
+            if (!Directory.Exists(folder))
+            {
+                return;
+            }
+
+            // GetFiles, not EnumerateFiles: the list must be materialized before deleting from it.
+            foreach (var fileName in Directory.GetFiles(folder, "*.dll", SearchOption.TopDirectoryOnly))
+            {
+                File.Delete(fileName);
+            }
+
+            var exeFileName = Path.Combine(folder, "tesseract.exe");
+            if (File.Exists(exeFileName))
+            {
+                File.Delete(exeFileName);
+            }
+        }
+        catch (Exception exception)
+        {
+            // Not fatal: the unpack below overwrites everything it ships anyway.
+            Se.LogError(exception, "Could not remove old Tesseract binaries.");
+        }
     }
 }

--- a/tests/UI/Logic/TesseractFolderMigrationTests.cs
+++ b/tests/UI/Logic/TesseractFolderMigrationTests.cs
@@ -1,0 +1,91 @@
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// The Tesseract folder used to be version-stamped ("Tesseract550"), so bumping Tesseract
+/// orphaned every downloaded model - on macOS/Linux, where the binary comes from brew/apt,
+/// the models were the only thing in there. The folder is now version-less and the old one
+/// is moved across once, models included.
+/// </summary>
+public class TesseractFolderMigrationTests : IDisposable
+{
+    private readonly string _dataFolder = Path.Combine(
+        Path.GetTempPath(),
+        "SeTesseractMigrationTests_" + Guid.NewGuid().ToString("N"));
+
+    private string Current => Path.Combine(_dataFolder, "Tesseract");
+    private string Legacy => Path.Combine(_dataFolder, "Tesseract550");
+
+    public TesseractFolderMigrationTests()
+    {
+        Directory.CreateDirectory(_dataFolder);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_dataFolder, true);
+        }
+        catch
+        {
+            // best effort
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public void ReturnsVersionLessFolderOnAFreshInstall()
+    {
+        var folder = Se.ResolveTesseractDataFolder(_dataFolder);
+
+        Assert.Equal(Current, folder);
+        Assert.False(Directory.Exists(Legacy));
+    }
+
+    [Fact]
+    public void MovesTheLegacyFolderAcrossWithTheDownloadedModels()
+    {
+        Directory.CreateDirectory(Path.Combine(Legacy, "tessdata"));
+        File.WriteAllText(Path.Combine(Legacy, "tessdata", "deu.traineddata"), "model");
+        File.WriteAllText(Path.Combine(Legacy, "tesseract.exe"), "binary");
+
+        var folder = Se.ResolveTesseractDataFolder(_dataFolder);
+
+        Assert.Equal(Current, folder);
+        Assert.False(Directory.Exists(Legacy));
+        Assert.Equal("model", File.ReadAllText(Path.Combine(Current, "tessdata", "deu.traineddata")));
+        Assert.True(File.Exists(Path.Combine(Current, "tesseract.exe")));
+    }
+
+    [Fact]
+    public void KeepsTheAlreadyMigratedFolderWhenBothExist()
+    {
+        // An older SE build run in between can recreate the legacy folder; the migrated one wins
+        // rather than being overwritten by it.
+        Directory.CreateDirectory(Path.Combine(Current, "tessdata"));
+        File.WriteAllText(Path.Combine(Current, "tessdata", "eng.traineddata"), "migrated");
+        Directory.CreateDirectory(Path.Combine(Legacy, "tessdata"));
+        File.WriteAllText(Path.Combine(Legacy, "tessdata", "eng.traineddata"), "stale");
+
+        var folder = Se.ResolveTesseractDataFolder(_dataFolder);
+
+        Assert.Equal(Current, folder);
+        Assert.Equal("migrated", File.ReadAllText(Path.Combine(Current, "tessdata", "eng.traineddata")));
+    }
+
+    [Fact]
+    public void IsIdempotent()
+    {
+        Directory.CreateDirectory(Path.Combine(Legacy, "tessdata"));
+        File.WriteAllText(Path.Combine(Legacy, "tessdata", "eng.traineddata"), "model");
+
+        var first = Se.ResolveTesseractDataFolder(_dataFolder);
+        var second = Se.ResolveTesseractDataFolder(_dataFolder);
+
+        Assert.Equal(first, second);
+        Assert.Equal("model", File.ReadAllText(Path.Combine(Current, "tessdata", "eng.traineddata")));
+    }
+}


### PR DESCRIPTION
Closes #13752.

## Not tested on Windows

I have no Windows machine here and no wine, so `tesseract.exe` has never been executed. The payload is verified structurally (see below), not behaviourally. **Someone should run one OCR pass on Windows before this merges.**

## The repack

The issue pointed at UB-Mannheim for the Windows build, but that is stale — their index and releases stop at `5.4.0.20240606`. The 5.5.3 installer is now hosted on the tesseract repo itself: [`tesseract-ocr-w64-setup-5.5.3.20260724.exe`](https://github.com/tesseract-ocr/tesseract/releases/tag/5.5.3). It is an NSIS package, so `7z x` unpacks it on any OS — no Windows needed to build the zip.

Uploaded to support-files as [tesseract553](https://github.com/SubtitleEdit/support-files/releases/tag/tesseract553) — 21.8 MB, sha256 `fef2dbb1de8f25d660301c17aff107c0d9b0dc99e0d4f0eee938eb7238d7d2dc`.

A file-for-file copy of the 550 layout would have broken, so I picked the contents by parsing the PE import tables transitively from `tesseract.exe`:

- `libicuin75`/`libicuuc75` → `libicuin78`/`libicuuc78`, plus a new 33 MB `libicudt78.dll`
- `libcrypto-3-x64.dll` is gone — the new `libcurl-4.dll` links Schannel (`CRYPT32`/`Secur32`/`bcrypt`), not OpenSSL, so nothing is actually missing
- the closure is 33 DLLs; everything else in the installer (cairo/pango/harfbuzz/fontconfig/freetype/ICU) is reachable only from `text2image` and the other training tools, which SE does not ship. Excluding them keeps the ICU data blob out.
- `osd.traineddata` is not in the installer at all (it downloads language data at install time), so it is carried over byte-for-byte from the 550 zip

Upstream now ships unstripped binaries — `libstdc++-6.dll` is 26.4 MB (was 2.4) and `tesseract.exe` 1.87 MB (was 86 KB). The zip still only grows 20.9 → 21.8 MB, but on-disk goes ~52 → ~57 MB.

## Why the folder is de-versioned rather than renamed to Tesseract553

Two problems the issue's checklist did not cover:

**The rename hits macOS and Linux too.** `TesseractModelFolder` was `DataFolder/Tesseract550/tessdata` on *every* platform. brew/apt users never download the zip but still keep their `.traineddata` there, so a version bump would silently orphan every downloaded model and `LoadActiveTesseractDictionaries` would just render an empty list.

**Without a rename, existing Windows users would never get 5.5.3.** `CheckAndDownloadTesseract` only tested `File.Exists(tesseract.exe)`, so anyone already on 5.5.0 keeps it forever.

So the folder is now just `Tesseract`, with a one-time `Directory.Move` of `Tesseract550` that brings the models along, and the unpacked version is stamped in `version.txt`. Future bumps re-download the binaries and leave `tessdata` untouched — no more folder churn. If the move fails the old folder keeps being used, so models are never hidden.

An out-of-date install is offered an update; declining keeps OCR running on what is installed and does not re-ask for the rest of the session. Stale DLLs from the previous build are removed before unpacking (guarded to Windows — `TesseractFolder` can be `/usr/bin` elsewhere), `tessdata` is left alone.

## Also

- `DownloadTesseractViewModel.StartDownload` created `Se.FfmpegFolder` instead of the tesseract folder — copy-paste bug in the touched flow.
- Confirmed the issue's last point: `DownloadHashManager` has no tesseract entries, nothing to regenerate.

## Tests

4 new migration tests (fresh install, move-with-models, both-folders-exist, idempotency). Full UI suite: 3002 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)