### PR TITLE
Show old vs new font sizes in the trim fonts confirmation dialog

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -3344,6 +3344,7 @@
     "trimFontsPromptX": "Trim {0} embedded font(s) to only the characters currently used?\n\nText added to the subtitle later may show missing characters, so trim as a final step.",
     "trimFontsNoFontsToTrim": "No embedded fonts to trim.",
     "trimFontsXFontsTrimmedSavedYZ": "{0} font(s) trimmed, saving {1}.\n\n{2}",
+    "trimFontsTotalSavingX": "Total saving: {0}",
     "trimFontsReasonNotTrueType": "only TrueType fonts can be trimmed",
     "trimFontsReasonFontCollection": "font collections are not supported",
     "trimFontsReasonCouldNotParse": "the font could not be read",

--- a/src/ui/Features/Assa/AssaAttachmentsViewModel.cs
+++ b/src/ui/Features/Assa/AssaAttachmentsViewModel.cs
@@ -209,36 +209,61 @@ public partial class AssaAttachmentsViewModel : ObservableObject
             return;
         }
 
-        var answer = await MessageBox.Show(
-            Window,
-            Se.Language.Assa.Attachments,
-            string.Format(Se.Language.Assa.TrimFontsPromptX, fonts.Count),
-            MessageBoxButtons.YesNo,
-            MessageBoxIcon.Question);
+        // Trim up front (nothing is applied yet), so the confirmation can show each
+        // font's old -> new size and the total saving before the user decides.
+        var usedTextLines = AssaFontEmbedder.GetUsedTextLines(_subtitle);
+        long savedBytes = 0;
+        var results = new List<(AssaAttachmentItem Font, FontTrimmer.TrimResult Result)>();
+        var reportLines = new List<string>();
+        foreach (var font in fonts)
+        {
+            var result = FontTrimmer.Trim(font.Bytes, usedTextLines);
+            results.Add((font, result));
+            if (result.Trimmed)
+            {
+                savedBytes += font.Bytes.Length - result.Bytes.Length;
+                reportLines.Add(
+                    $"{font.FileName}: {Utilities.FormatBytesToDisplayFileSize(font.Bytes.Length)} -> " +
+                    Utilities.FormatBytesToDisplayFileSize(result.Bytes.Length));
+            }
+            else
+            {
+                reportLines.Add($"{font.FileName}: {FontTrimmer.GetSkipReasonDisplay(result.SkipReason)}");
+            }
+        }
+
+        var trimmableCount = results.Count(r => r.Result.Trimmed);
+        if (trimmableCount == 0)
+        {
+            await MessageBox.Show(
+                Window,
+                Se.Language.Assa.Attachments,
+                string.Format(
+                    Se.Language.Assa.TrimFontsXFontsTrimmedSavedYZ,
+                    0,
+                    Utilities.FormatBytesToDisplayFileSize(0),
+                    string.Join(Environment.NewLine, reportLines)),
+                MessageBoxButtons.OK);
+            return;
+        }
+
+        var message =
+            string.Format(Se.Language.Assa.TrimFontsPromptX, trimmableCount) + Environment.NewLine + Environment.NewLine +
+            string.Join(Environment.NewLine, reportLines) + Environment.NewLine + Environment.NewLine +
+            string.Format(Se.Language.Assa.TrimFontsTotalSavingX, Utilities.FormatBytesToDisplayFileSize(savedBytes));
+        var answer = await MessageBox.Show(Window, Se.Language.Assa.Attachments, message, MessageBoxButtons.YesNo, MessageBoxIcon.Question);
         if (answer != MessageBoxResult.Yes)
         {
             return;
         }
 
-        var usedTextLines = AssaFontEmbedder.GetUsedTextLines(_subtitle);
         var selectedFileName = SelectedAttachment?.FileName;
-        long savedBytes = 0;
-        var trimmedCount = 0;
-        var reportLines = new List<string>();
-        foreach (var font in fonts)
+        foreach (var (font, result) in results)
         {
-            var result = FontTrimmer.Trim(font.Bytes, usedTextLines);
             if (!result.Trimmed)
             {
-                reportLines.Add($"{font.FileName}: {FontTrimmer.GetSkipReasonDisplay(result.SkipReason)}");
                 continue;
             }
-
-            savedBytes += font.Bytes.Length - result.Bytes.Length;
-            trimmedCount++;
-            reportLines.Add(
-                $"{font.FileName}: {Utilities.FormatBytesToDisplayFileSize(font.Bytes.Length)} -> " +
-                Utilities.FormatBytesToDisplayFileSize(result.Bytes.Length));
 
             // replace the row so the grid picks up the new size (the item is not observable)
             var trimmed = new AssaAttachmentItem
@@ -258,16 +283,6 @@ public partial class AssaAttachmentsViewModel : ObservableObject
         }
 
         UpdatePreview();
-
-        await MessageBox.Show(
-            Window,
-            Se.Language.Assa.Attachments,
-            string.Format(
-                Se.Language.Assa.TrimFontsXFontsTrimmedSavedYZ,
-                trimmedCount,
-                Utilities.FormatBytesToDisplayFileSize(savedBytes),
-                string.Join(Environment.NewLine, reportLines)),
-            MessageBoxButtons.OK);
     }
 
     [RelayCommand]

--- a/src/ui/Logic/Config/Language/Assa/LanguageAssa.cs
+++ b/src/ui/Logic/Config/Language/Assa/LanguageAssa.cs
@@ -69,6 +69,7 @@ public class LanguageAssa
     public string TrimFontsPromptX { get; set; }
     public string TrimFontsNoFontsToTrim { get; set; }
     public string TrimFontsXFontsTrimmedSavedYZ { get; set; }
+    public string TrimFontsTotalSavingX { get; set; }
     public string TrimFontsReasonNotTrueType { get; set; }
     public string TrimFontsReasonFontCollection { get; set; }
     public string TrimFontsReasonCouldNotParse { get; set; }
@@ -307,6 +308,7 @@ public class LanguageAssa
         TrimFontsPromptX = "Trim {0} embedded font(s) to only the characters currently used?\n\nText added to the subtitle later may show missing characters, so trim as a final step.";
         TrimFontsNoFontsToTrim = "No embedded fonts to trim.";
         TrimFontsXFontsTrimmedSavedYZ = "{0} font(s) trimmed, saving {1}.\n\n{2}";
+        TrimFontsTotalSavingX = "Total saving: {0}";
         TrimFontsReasonNotTrueType = "only TrueType fonts can be trimmed";
         TrimFontsReasonFontCollection = "font collections are not supported";
         TrimFontsReasonCouldNotParse = "the font could not be read";


### PR DESCRIPTION
Follow-up to #13760: the *Trim fonts to used characters...* confirmation dialog in the ASSA attachments window now shows what will happen before the user decides.

Trimming is computed up front (nothing is applied until Yes), so the dialog lists per font:

```
Trim 2 embedded font(s) to only the characters currently used?

Text added to the subtitle later may show missing characters, so trim as a final step.

NotoSansJP-Bold.ttf: 8.9 MB -> 312 KB
SomeCffFont.ttf: only TrueType fonts can be trimmed

Total saving: 8.6 MB
```

The separate after-the-fact report dialog is gone (it duplicated this information); when no font can be trimmed at all, an info dialog shows the per-font reasons instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)