### PR TITLE
Fix #13711: let Shift+Delete actually cut in a text box

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -23733,6 +23733,13 @@ public partial class MainViewModel :
     };
 
     /// <summary>
+    /// Editing keys that never type a character, so holding Shift with them is a real chord rather
+    /// than "the same key, shifted" - unlike Shift+A, which is just an uppercase A. Bare Delete and
+    /// Back still edit the text box as usual; only the Shift variants reach shortcut dispatch.
+    /// </summary>
+    private static readonly HashSet<Key> NonTypingEditKeys = [Key.Delete, Key.Back];
+
+    /// <summary>
     /// Activates the main menu bar for keyboard navigation (Windows standard F10; bare Alt is handled
     /// by Avalonia's built-in AccessKeyHandler), remembering the control that had focus so it can be
     /// restored on deactivation. Returns false on platforms with a native menu (macOS), where the
@@ -24467,8 +24474,14 @@ public partial class MainViewModel :
                         }
                     }
 
-                    if (!Se.Settings.Tools.AllowSingleLetterShortcutsInTextbox && !AlwaysAllowedSingleKeyShortcuts.Contains(key) &&
-                        (keyEventArgs.KeyModifiers == KeyModifiers.None || keyEventArgs.KeyModifiers == KeyModifiers.Shift))
+                    // Shift counts as "no modifier" here because Shift+<letter> is just typing an
+                    // uppercase letter - but only for keys that actually type something. Shift with
+                    // an editing key is a real chord (Shift+Delete cut, Shift+Back forward delete),
+                    // and treating it as a bare key made those shipped TextBox shortcuts unreachable:
+                    // Shift+Delete fell through to Avalonia's plain delete instead of cutting (#13711).
+                    var isBareKeyChord = keyEventArgs.KeyModifiers == KeyModifiers.None ||
+                                         (keyEventArgs.KeyModifiers == KeyModifiers.Shift && !NonTypingEditKeys.Contains(key));
+                    if (!Se.Settings.Tools.AllowSingleLetterShortcutsInTextbox && !AlwaysAllowedSingleKeyShortcuts.Contains(key) && isBareKeyChord)
                     {
                         return; // allow single key shortcuts in text input if enabled in settings, or if it's not an allowed single key shortcut
                     }

--- a/tests/UI/Features/Main/TextBoxShiftDeleteCutTests.cs
+++ b/tests/UI/Features/Main/TextBoxShiftDeleteCutTests.cs
@@ -1,0 +1,168 @@
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// Shift+Delete in a text box must cut, not just delete (#13711). The shipped "Text box: Cut
+/// (alternative)" binding never fired: the single-key guard in OnKeyDownHandler treats Shift as
+/// "no modifier" - true for Shift+&lt;letter&gt;, which is just an uppercase letter, but wrong for
+/// editing keys - so Shift+Delete looked like a bare Delete and returned before the TextBox
+/// category was ever dispatched, leaving Avalonia's plain delete to run.
+/// </summary>
+public class TextBoxShiftDeleteCutTests
+{
+    [AvaloniaFact]
+    public void ShiftDelete_CutsTheSelection_InsteadOfOnlyDeletingIt()
+    {
+        WithShortcut(nameof(MainViewModel.TextBoxCut2Command), ["Shift", nameof(Key.Delete)], () =>
+        {
+            var (window, vm) = ShowMainWindowWithOneLine("Hello world");
+            try
+            {
+                ClipboardHelper.SetTextAsync(window, "clipboard before the cut").GetAwaiter().GetResult();
+                Settle(window);
+
+                vm.EditTextBox.Focus();
+                vm.EditTextBox.Select(0, "Hello ".Length);
+                Settle(window);
+
+                window.KeyPressQwerty(PhysicalKey.Delete, RawInputModifiers.Shift);
+                Settle(window);
+
+                Assert.Equal("world", vm.EditTextBox.Text);
+                Assert.Equal("Hello ", ClipboardHelper.GetTextAsync(window).GetAwaiter().GetResult());
+            }
+            finally
+            {
+                window.Close();
+            }
+        });
+    }
+
+    /// <summary>
+    /// Bare Delete stays plain text editing - the guard only stops treating Shift+Delete as if it
+    /// were the same key, so an unmodified Delete must still delete forward in the text box.
+    /// </summary>
+    [AvaloniaFact]
+    public void Delete_WithoutShift_StillDeletesForwardInTheTextBox()
+    {
+        WithShortcut(nameof(MainViewModel.TextBoxCut2Command), ["Shift", nameof(Key.Delete)], () =>
+        {
+            var (window, vm) = ShowMainWindowWithOneLine("Hello world");
+            try
+            {
+                ClipboardHelper.SetTextAsync(window, "clipboard before the delete").GetAwaiter().GetResult();
+                Settle(window);
+
+                vm.EditTextBox.Focus();
+                vm.EditTextBox.Select(0, "Hello ".Length);
+                Settle(window);
+
+                window.KeyPressQwerty(PhysicalKey.Delete, RawInputModifiers.None);
+                Settle(window);
+
+                Assert.Equal("world", vm.EditTextBox.Text);
+                Assert.Equal("clipboard before the delete", ClipboardHelper.GetTextAsync(window).GetAwaiter().GetResult());
+            }
+            finally
+            {
+                window.Close();
+            }
+        });
+    }
+
+    /// <summary>
+    /// The same guard also swallowed the shipped Shift+Back forward delete (added for Apple
+    /// keyboards, whose Delete key is only a backspace), so that binding never worked either.
+    /// </summary>
+    [AvaloniaFact]
+    public void ShiftBack_DeletesForward_InsteadOfBackspacing()
+    {
+        WithShortcut(nameof(MainViewModel.TextBoxDeleteForwardCommand), ["Shift", nameof(Key.Back)], () =>
+        {
+            var (window, vm) = ShowMainWindowWithOneLine("Hello world");
+            try
+            {
+                vm.EditTextBox.Focus();
+                vm.EditTextBox.CaretIndex = "Hello".Length;
+                Settle(window);
+
+                window.KeyPressQwerty(PhysicalKey.Backspace, RawInputModifiers.Shift);
+                Settle(window);
+
+                // Forward delete removed the space after the caret; a backspace would have
+                // removed the "o" before it.
+                Assert.Equal("Helloworld", vm.EditTextBox.Text);
+            }
+            finally
+            {
+                window.Close();
+            }
+        });
+    }
+
+    /// <summary>
+    /// The settings singleton is shared across the whole test run, so give the action exactly one
+    /// binding - the one under test - and put the original bindings back afterwards.
+    /// </summary>
+    private static void WithShortcut(string actionName, string[] keys, Action test)
+    {
+        var original = Se.Settings.Shortcuts.Where(s => s.ActionName == actionName).ToList();
+        Se.Settings.Shortcuts.RemoveAll(s => s.ActionName == actionName);
+        Se.Settings.Shortcuts.Add(new SeShortCut(actionName, [.. keys]));
+        try
+        {
+            test();
+        }
+        finally
+        {
+            Se.Settings.Shortcuts.RemoveAll(s => s.ActionName == actionName);
+            Se.Settings.Shortcuts.AddRange(original);
+        }
+    }
+
+    private static (Window Window, MainViewModel Vm) ShowMainWindowWithOneLine(string text)
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1400, Height = 900 };
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var vm = (MainViewModel)view.DataContext!;
+        window.SuppressSaveChangesPromptOnClose(vm);
+        vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph(text, 0, 2000), null!) { Number = 1 });
+        Settle(window);
+
+        vm.SelectedSubtitleIndex = 0;
+        vm.SubtitleGrid.SelectedItem = vm.Subtitles[0];
+        Settle(window);
+
+        return (window, vm);
+    }
+
+    private static void Settle(Window window)
+    {
+        for (var pump = 0; pump < 5; pump++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to 9123f044a — GrampaWildWilly reports on #13711 that Shift+Delete in beta 16 *still* just deletes. He's right; that fix removed `TextBoxCut2Command` from the native-clipboard skip list, but the key never got that far.

## Root cause

[MainViewModel.cs:24477](../blob/main/src/ui/Features/Main/MainViewModel.cs#L24477), inside the `IsTextInputFocused()` branch:

```csharp
if (!Se.Settings.Tools.AllowSingleLetterShortcutsInTextbox && !AlwaysAllowedSingleKeyShortcuts.Contains(key) &&
    (keyEventArgs.KeyModifiers == KeyModifiers.None || keyEventArgs.KeyModifiers == KeyModifiers.Shift))
{
    return;
}
```

`ShortcutManager.OnKeyPressed` deliberately skips standalone modifier keys, so pressing Shift+Delete leaves `_activeKeys == { Delete }` and `TryGetSingleActiveKey` succeeds. With `KeyModifiers == Shift`, `Delete` not in `AlwaysAllowedSingleKeyShortcuts`, and "allow single letter shortcuts in text box" off by default, the handler **returns** — before the TextBox category is ever dispatched. Avalonia's plain delete then handles the key.

That's why `Insert` is in the allow-set: it's what makes Shift+Insert work. `Delete` never was.

## Fix

Treating Shift as "no modifier" is right for `Shift+<letter>` (just an uppercase letter) but wrong for keys that don't type anything. `Delete` and `Back` now count as a real chord when Shift is held, so those shortcuts reach dispatch. Bare Delete/Back are unchanged and keep editing the text box.

## Also fixed: Shift+Back

The same guard has been swallowing the shipped `TextBoxDeleteForwardCommand` (Shift+Back, added for Apple keyboards whose Delete key is only a backspace) — it has never fired. It works now.

Worth a look before merging: on Windows, Shift+Backspace natively behaves as a plain backspace, and it will now forward-delete instead. If you'd rather Windows keep the native behavior, the default binding can be made macOS-only — though existing installs already have it persisted in Settings.json, so that would also need a shortcut migration to clear it.

## Testing

New `tests/UI/Features/Main/TextBoxShiftDeleteCutTests.cs`, headless Avalonia through the real key handler:

- Shift+Delete on a selection → text removed **and** on the clipboard (fails without the fix)
- Shift+Back at a caret → deletes forward, not backward (fails without the fix)
- bare Delete → still deletes, clipboard untouched (passes either way; guards the typing path)

Full UI suite: 3053 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)