### PR TITLE
Update whisper.cpp to v1.9.2

### DIFF
--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -1818,39 +1818,44 @@ public static class DownloadHashManager
             // whatever URL WhisperDownloadService.cs is pinned to.
             [WhisperCpp.WindowsBlas] = new[]
             {
-                "3c319eab3e87f85883e1ff3d14426c0a1986c661c5eb5985e8af431ed9c4f71f", // v1.9.1 (current download URL — fetched directly from ggml-org/whisper.cpp)
+                "ffe5b47ca8e53a7677949f23a9c4641bbec4eee8a5714c3d14b67bb8d7b24a78", // v1.9.2 (current download URL — fetched directly from ggml-org/whisper.cpp)
+                "3c319eab3e87f85883e1ff3d14426c0a1986c661c5eb5985e8af431ed9c4f71f", // v1.9.1
                 "eb4a51548a65c58cb22890066145dfe1026d5bd597c52ef0ccb0477e83159c91", // whispercpp-186 / v1.8.6
                 "4a8a07e14c035bd6c1bcd55dedba5925f982f122d6bc05034f9bbe7e55f5c4b0", // whispercpp-185 / v1.8.5
                 "5f8d6b1bcdf86edf898d21379468ae8329bb783803dab9c5dbc1fa65e7f2da6c", // whispercpp-184 / v1.8.4
             },
             [WhisperCpp.WindowsCuBlas] = new[]
             {
-                "106a2030eff8998e4ef320fe72e263a78449e9040386ee27c41ea80b001b601b", // v1.9.1 (current download URL — fetched directly from ggml-org/whisper.cpp)
+                "443110ddaad70d4290ab2e77179e31cf712035bbc4fad56bb4519a90c917b39c", // v1.9.2 (current download URL — fetched directly from ggml-org/whisper.cpp)
+                "106a2030eff8998e4ef320fe72e263a78449e9040386ee27c41ea80b001b601b", // v1.9.1
                 "63b70c91fe2fd7449865c45f6422ab628439eacc6985d8309c77bfb65cc68a19", // v1.8.6 (fetched directly from ggml-org/whisper.cpp)
                 "ff50101f85a6026d39053771c25b42f5752ac05d5be9ee2e5d2632541adef231", // v1.8.5
                 "b07cff4e59831b227896018facbb6334907bf324a342c84597c44f087823d252", // v1.8.4
             },
             [WhisperCpp.WindowsVulkan] = new[]
             {
-                "3e70fccfab278c7bb7c78efd7d101ba6e507b668ceccf3610b2d1c54d6d9f119", // whispercpp-191 / v1.9.1 (current download URL)
+                "a220f2063bf60c18406beb37d2001d7da6cfd2253d5b38b4c78719a56bedd2c0", // whispercpp-192 / v1.9.2 (current download URL)
+                "3e70fccfab278c7bb7c78efd7d101ba6e507b668ceccf3610b2d1c54d6d9f119", // whispercpp-191 / v1.9.1
                 "27a7e9612a930355e801d7ae45cd926b079bd215ce0527c219d7bd6a5acd4ada", // whispercpp-186 / v1.8.6
                 "8a993d86fbad6cfacf3123be615a692f17e9a19957ddfa6e071c751deaf8df42", // whispercpp-185 / v1.8.5
                 "42f90548f551f525666b96bd734f4ee23e58f82dcc2a1b68c4eba5e453ba7080", // whispercpp-184 / v1.8.4
             },
             [WhisperCpp.MacOs] = new[]
             {
-                "3bbeed3e91cf07657e0d59c38de0cea15a276d59cd07e630951ef42927474983", // whispercpp-191 / v1.9.1 (current download URL)
+                "6654f5b628f59efb04a0ef6e6b8ece06595df1f2acf7635609d32052e7b6c906", // whispercpp-192 / v1.9.2 (current download URL)
+                "3bbeed3e91cf07657e0d59c38de0cea15a276d59cd07e630951ef42927474983", // whispercpp-191 / v1.9.1
                 "9e7fb79d310a17cf992baa883fe1acfec693d2e72aadace784a3b8ac77eb2768", // whispercpp-186 / v1.8.6
                 "49ef4acfaef0b4989885c258f22eb1355592c5f343897508899a2b598cd683bf", // whispercpp-185 / v1.8.5
                 "81dbd530f21a6daf10b1c9cece61d7e56d774e3bcb3d21af4d17299caa532a4d", // whispercpp-184 / v1.8.4
             },
             // whispercpp-184 through -191 shipped whisper-cli without the libwhisper.so.1 /
             // libggml.so.0 it links against, so every one of those installs is broken and the
-            // user needs the -r2 rebuild (issue #13680). They stay listed so an existing install
-            // is still identified rather than reported as unknown.
+            // user needs a newer build (issue #13680; first fixed in whispercpp-191-r2). They stay
+            // listed so an existing install is still identified rather than reported as unknown.
             [WhisperCpp.LinuxVulkan] = new[]
             {
-                "0943f97f58ca98aafa26659e7c4d8d87f474c74f966f0d9ae91491989a32cf2b", // whispercpp-191-r2 / v1.9.1 (current download URL)
+                "ef74909722eca7e422e21ef41a0060d38efadd055398697c17ce12d80c41d467", // whispercpp-192 / v1.9.2 (current download URL)
+                "0943f97f58ca98aafa26659e7c4d8d87f474c74f966f0d9ae91491989a32cf2b", // whispercpp-191-r2 / v1.9.1
                 "7969c5a0ba912d0b0d8aaa2bdf911ca7896ef97a89e293d2596a96022c839e80", // whispercpp-191 / v1.9.1 (missing shared libraries)
                 "10aed3a2b28e5ad40fee8267d554f0824943e50e75bfe7bceb7c16b6e3fe8a45", // whispercpp-186 / v1.8.6 (missing shared libraries)
                 "c385a01228f85764cfd9b6072e078d03e44f151d71ab145e912425e5cc9a7c8e", // whispercpp-185 / v1.8.5 (missing shared libraries)
@@ -1858,7 +1863,8 @@ public static class DownloadHashManager
             },
             [WhisperCpp.LinuxCuda] = new[]
             {
-                "02129bac653d00d85ef110c24c37eb56d5470d4fee432a09f55ac9fbc63ff768", // whispercpp-191-r2 / v1.9.1 (current download URL)
+                "dcf676854f473e9e3f0622b4725fa7123f18313e772002b1d3bb31efe4dc98b9", // whispercpp-192 / v1.9.2 (current download URL)
+                "02129bac653d00d85ef110c24c37eb56d5470d4fee432a09f55ac9fbc63ff768", // whispercpp-191-r2 / v1.9.1
                 "19a232255838c77c9bcddf220292d96dfb62b9a8da1e66ed402961f6a41b1661", // whispercpp-191 / v1.9.1 (missing shared libraries)
                 "b8922f7fc25ff4f602c887655882c4114c005177017335f39181cc0417f0cb03", // whispercpp-186 / v1.8.6 (missing shared libraries)
                 "1aee5fddee30f8486275d3b2bd1d568e92615e7b1b063d46c635cb9f44d7d13b", // whispercpp-185 / v1.8.5 (missing shared libraries)
@@ -1868,28 +1874,32 @@ public static class DownloadHashManager
             // SHA-256 of whisper-cli / whisper-cli.exe extracted from each archive above.
             [WhisperCpp.WindowsBlasExecutable] = new[]
             {
-                "254ee898dd8c3b16fa87583113320dad3f8e3787e15d8f14e245fcb3b487fc39", // v1.9.1 (current download URL — fetched directly from ggml-org/whisper.cpp)
+                "225aa686b74010c0259e8d28763aa89a078a0141091f525779fae6892e8e6097", // v1.9.2 (current download URL — fetched directly from ggml-org/whisper.cpp)
+                "254ee898dd8c3b16fa87583113320dad3f8e3787e15d8f14e245fcb3b487fc39", // v1.9.1
                 "c3ba7358316559cf80ae88e783daeb2f346d617d8074a0bd054998912cde979a", // whispercpp-186 / v1.8.6
                 "6a2e5cbd090c1dacc43461d1fac543e4b13881210f181c6d1e95267ec8c64c64", // whispercpp-185 / v1.8.5
                 "80865086479dfedb0ce8d0c03f061629dd83e9d1e86b14343e5cf9fd01927098", // whispercpp-184 / v1.8.4
             },
             [WhisperCpp.WindowsCuBlasExecutable] = new[]
             {
-                "789fddb0f05c0c28043b3c4f3bcf15a0ae839df24292c60f90c4edb8d02a5ab5", // v1.9.1 (current download URL)
+                "92205834c7e2dfa35fac242fb438c285f70bcf942474f80f7dcf5fdac0d7a6dc", // v1.9.2 (current download URL)
+                "789fddb0f05c0c28043b3c4f3bcf15a0ae839df24292c60f90c4edb8d02a5ab5", // v1.9.1
                 "ae283f6938fbe27aa12ad83bbfa0b4ca772dee21ffb54348eeb87c65eaf88b8a", // v1.8.6
                 "304eef3b9fc30b0b0d74f4ab756b6e5efe7b2f6f88813f79205631d1ebba448d", // v1.8.5
                 "03947f51efb42abc82a0208cb0ead74822eff8e88a41df4c1f4536f6b78188ae", // v1.8.4
             },
             [WhisperCpp.WindowsVulkanExecutable] = new[]
             {
-                "011d5f4d5d58eb2d3d0cafe64fd22d377bc066b2e6d2d91fd5d58c95be0b7244", // whispercpp-191 / v1.9.1 (current download URL)
+                "d003f2229418e8fd59c1e0aee62d7f996a768ad7ebda3da502bbfca2063b84a7", // whispercpp-192 / v1.9.2 (current download URL)
+                "011d5f4d5d58eb2d3d0cafe64fd22d377bc066b2e6d2d91fd5d58c95be0b7244", // whispercpp-191 / v1.9.1
                 "fe6afff595b1c3a08a129c2a9047e6b9d10107acd3964a29f54b5459f6795bd4", // whispercpp-186 / v1.8.6
                 "3d43e45f7b575dcc127d5a1c30bdb9f9f1650576007a31d955917027794672bd", // whispercpp-185 / v1.8.5
                 "69a270fb42b98fc4927e6e9a79bda16ec7bf152825e2af68df09ff99f43479e6", // whispercpp-184 / v1.8.4
             },
             [WhisperCpp.MacOsExecutable] = new[]
             {
-                "278e45caa50d4dc2e92d04e7fa9c19d3439350a7bd0c6bc40cc91b41d5cc72a5", // whispercpp-191 / v1.9.1 (current download URL)
+                "ebaf5389eb619a376023e1ad9684409596dedc16869a59a3234191bb440a96fd", // whispercpp-192 / v1.9.2 (current download URL)
+                "278e45caa50d4dc2e92d04e7fa9c19d3439350a7bd0c6bc40cc91b41d5cc72a5", // whispercpp-191 / v1.9.1
                 "0b9f4894727ece186163e15e07795b70a333c5834e2916c6032ae04e57d3e1e8", // whispercpp-186 / v1.8.6
                 "0fd752e0384484eb3a72ce644135f20963879e80624b23f7f739eda187a23359", // whispercpp-185 / v1.8.5
                 "11d902af004d1e79538f8f801b4a42ac3a21094370c9063f67d885d04dccdd96", // whispercpp-184 / v1.8.4
@@ -1899,7 +1909,8 @@ public static class DownloadHashManager
             // single whisper-cli for both backends. See the note on LinuxVulkanExecutable.
             [WhisperCpp.LinuxVulkanExecutable] = new[]
             {
-                "da61c0c1910c103cf8dea855855f072249689ee2310f375e2b79615cbd012c05", // whispercpp-191-r2 / v1.9.1 (current download URL)
+                "3e142b4a8c99a4d5cf00cdd4e15fb77c2a842dd0bd83f647675fe1d303e91a03", // whispercpp-192 / v1.9.2 (current download URL)
+                "da61c0c1910c103cf8dea855855f072249689ee2310f375e2b79615cbd012c05", // whispercpp-191-r2 / v1.9.1
                 "782fac61b9bcfe8f6db22564bb5a2cda2c22550b9ef38064ec5f188bc86dfe79", // whispercpp-191 / v1.9.1 (missing shared libraries)
                 "5a2343777fe57327c8956d836d1515ac422d2e7f9fd33ce4e7e62cfe4cd33cbd", // whispercpp-186 / v1.8.6 (missing shared libraries)
                 "e9d5318d513f9dc23ae9fe35cd2783e8def5c66642079dc6a5074b9e5f0cd61c", // whispercpp-185 / v1.8.5 (missing shared libraries)
@@ -1907,7 +1918,8 @@ public static class DownloadHashManager
             },
             [WhisperCpp.LinuxCudaExecutable] = new[]
             {
-                "3a4d717745c2d8cf19ca7a954c29c0349a7f158d93a6597bb86e155f0735474a", // whispercpp-191-r2 / v1.9.1 (current download URL)
+                "9c93f819e170d0f00a08c256ac2299f819a8e94f3a6f116bac2657c6ab8de62a", // whispercpp-192 / v1.9.2 (current download URL)
+                "3a4d717745c2d8cf19ca7a954c29c0349a7f158d93a6597bb86e155f0735474a", // whispercpp-191-r2 / v1.9.1
                 "16a838ae67e248020b9bc65b8584fcc113cf18167c9cfc0a2d98e194fa52cf95", // whispercpp-191 / v1.9.1 (missing shared libraries)
                 "330ff60cbabd8e77137000d05905cabca90e299c455a3282948c9edddf28bcd7", // whispercpp-186 / v1.8.6 (missing shared libraries)
                 "33bad46e07f0d9bb64fc03ca8c7047b212482c1f45536290f80bb0fe716c9775", // whispercpp-185 / v1.8.5 (missing shared libraries)

--- a/src/ui/Logic/Download/WhisperDownloadService.cs
+++ b/src/ui/Logic/Download/WhisperDownloadService.cs
@@ -22,20 +22,19 @@ public interface IWhisperDownloadService
 public class WhisperDownloadService : IWhisperDownloadService
 {
     private readonly HttpClient _httpClient;
-    private const string WindowsUrl = "https://github.com/ggml-org/whisper.cpp/releases/download/v1.9.1/whisper-blas-bin-x64.zip";
-    private const string MacArmUrl = "https://github.com/SubtitleEdit/support-files/releases/download/whispercpp-191/whisper-mac.zip";
-    private const string MacX64Url = "https://github.com/SubtitleEdit/support-files/releases/download/whispercpp-191/whisper-mac.zip";
-    // The Linux archives point at whispercpp-191-r2, not whispercpp-191: the original v1.9.1
-    // Linux zips (like v1.8.4 and v1.8.6 before them) shipped whisper-cli without the
-    // libwhisper.so.1 / libggml.so.0 it links against, so the engine died on startup with
-    // "error while loading shared libraries" (issue #13680). The -r2 rebuild is the same
-    // whisper.cpp v1.9.1, repackaged with the libraries under their SONAMEs and $ORIGIN
-    // RPATHs. Windows and macOS were unaffected and still use whispercpp-191.
-    private const string LinuxUrl = "https://github.com/SubtitleEdit/support-files/releases/download/whispercpp-191-r2/whisper-vulkan-linux64.zip";
+    private const string WindowsUrl = "https://github.com/ggml-org/whisper.cpp/releases/download/v1.9.2/whisper-blas-bin-x64.zip";
+    private const string MacArmUrl = "https://github.com/SubtitleEdit/support-files/releases/download/whispercpp-192/whisper-mac.zip";
+    private const string MacX64Url = "https://github.com/SubtitleEdit/support-files/releases/download/whispercpp-192/whisper-mac.zip";
+    // The Linux archives are SE rebuilds (upstream ships no Linux binaries). They must carry
+    // libwhisper.so.1 / libggml.so.0 next to whisper-cli, staged under their SONAMEs with
+    // $ORIGIN RPATHs - whispercpp-184 through -191 shipped without them and the engine died on
+    // startup with "error while loading shared libraries" (issue #13680). The build workflow in
+    // SubtitleEdit/support-files verifies this now, so plain whispercpp-192 is fine here.
+    private const string LinuxUrl = "https://github.com/SubtitleEdit/support-files/releases/download/whispercpp-192/whisper-vulkan-linux64.zip";
 
-    private const string WindowsUrlCuBlass = "https://github.com/ggml-org/whisper.cpp/releases/download/v1.9.1/whisper-cublas-12.4.0-bin-x64.zip";
-    private const string WindowsUrlCppVulkan = "https://github.com/SubtitleEdit/support-files/releases/download/whispercpp-191/whisper-vulkan-x64.zip";
-    private const string LinuxUrlCuBlass = "https://github.com/SubtitleEdit/support-files/releases/download/whispercpp-191-r2/whisper-cuda-linux64.zip";
+    private const string WindowsUrlCuBlass = "https://github.com/ggml-org/whisper.cpp/releases/download/v1.9.2/whisper-cublas-12.4.0-bin-x64.zip";
+    private const string WindowsUrlCppVulkan = "https://github.com/SubtitleEdit/support-files/releases/download/whispercpp-192/whisper-vulkan-x64.zip";
+    private const string LinuxUrlCuBlass = "https://github.com/SubtitleEdit/support-files/releases/download/whispercpp-192/whisper-cuda-linux64.zip";
     
     private const string DownloadUrlConstMe = "https://github.com/Const-me/Whisper/releases/download/1.12.0/cli.zip";
     private const string SileroVadUrl = "https://github.com/SubtitleEdit/support-files/releases/download/whispercpp-184/ggml-silero-v6.2.0.zip";

--- a/tests/UI/Logic/Download/WhisperCppLinuxExecutableHashTests.cs
+++ b/tests/UI/Logic/Download/WhisperCppLinuxExecutableHashTests.cs
@@ -7,8 +7,8 @@ namespace UITests.Logic.Download;
 /// <summary>
 /// Every Linux whisper.cpp build from v1.8.4 to v1.9.1 shipped whisper-cli without the
 /// libwhisper.so.1 it links against, so the engine could not start at all (issue #13680). The
-/// rebuilt whispercpp-191-r2 archives fix that, and these tests pin the path by which an affected
-/// user finds out: an install with no .installed.sha256 sidecar is identified by hashing
+/// rebuilt archives from whispercpp-191-r2 on fix that, and these tests pin the path by which an
+/// affected user finds out: an install with no .installed.sha256 sidecar is identified by hashing
 /// whisper-cli, and a recognised-but-superseded hash is what turns the engine dot amber and
 /// raises the update prompt. If the executable-hash fallback stops resolving on Linux, those
 /// users silently keep a broken engine.
@@ -16,16 +16,18 @@ namespace UITests.Logic.Download;
 public class WhisperCppLinuxExecutableHashTests
 {
     // whisper-cli extracted from whisper-vulkan-linux64.zip / whisper-cuda-linux64.zip
+    private const string VulkanCurrent = "3e142b4a8c99a4d5cf00cdd4e15fb77c2a842dd0bd83f647675fe1d303e91a03";
     private const string VulkanR2 = "da61c0c1910c103cf8dea855855f072249689ee2310f375e2b79615cbd012c05";
     private const string VulkanBroken191 = "782fac61b9bcfe8f6db22564bb5a2cda2c22550b9ef38064ec5f188bc86dfe79";
+    private const string CudaCurrent = "9c93f819e170d0f00a08c256ac2299f819a8e94f3a6f116bac2657c6ab8de62a";
     private const string CudaR2 = "3a4d717745c2d8cf19ca7a954c29c0349a7f158d93a6597bb86e155f0735474a";
     private const string CudaBroken191 = "16a838ae67e248020b9bc65b8584fcc113cf18167c9cfc0a2d98e194fa52cf95";
     private const string Shared184 = "315f46514fc09a4fefe2f7b6ae95cfac5441a03b8be04eed1b5f567d5ccc38de";
 
     [Theory]
-    [InlineData(DownloadHashManager.WhisperCpp.LinuxVulkanExecutable, VulkanR2)]
-    [InlineData(DownloadHashManager.WhisperCpp.LinuxCudaExecutable, CudaR2)]
-    public void GetStatus_RebuiltArchive_IsUpToDate(string key, string hash)
+    [InlineData(DownloadHashManager.WhisperCpp.LinuxVulkanExecutable, VulkanCurrent)]
+    [InlineData(DownloadHashManager.WhisperCpp.LinuxCudaExecutable, CudaCurrent)]
+    public void GetStatus_CurrentArchive_IsUpToDate(string key, string hash)
     {
         Assert.Equal(DownloadHashManager.UpdateStatus.UpToDate, DownloadHashManager.GetStatus(key, hash));
     }
@@ -40,6 +42,16 @@ public class WhisperCppLinuxExecutableHashTests
         Assert.Equal(DownloadHashManager.UpdateStatus.UpdateAvailable, DownloadHashManager.GetStatus(key, hash));
     }
 
+    [Theory]
+    [InlineData(DownloadHashManager.WhisperCpp.LinuxVulkanExecutable, VulkanR2)]
+    [InlineData(DownloadHashManager.WhisperCpp.LinuxCudaExecutable, CudaR2)]
+    public void GetStatus_SupersededButWorkingArchive_OffersUpdate(string key, string hash)
+    {
+        // The -r2 rebuild is a working install, just an older whisper.cpp - it must still be
+        // recognised (not Unknown) so the user gets the normal update prompt.
+        Assert.Equal(DownloadHashManager.UpdateStatus.UpdateAvailable, DownloadHashManager.GetStatus(key, hash));
+    }
+
     [Fact]
     public void GetStatus_VulkanAndCudaHashesAreNotInterchangeable()
     {
@@ -47,10 +59,10 @@ public class WhisperCppLinuxExecutableHashTests
         // must not validate a Vulkan install (v1.8.4 is the documented exception, covered above).
         Assert.Equal(
             DownloadHashManager.UpdateStatus.Unknown,
-            DownloadHashManager.GetStatus(DownloadHashManager.WhisperCpp.LinuxVulkanExecutable, CudaR2));
+            DownloadHashManager.GetStatus(DownloadHashManager.WhisperCpp.LinuxVulkanExecutable, CudaCurrent));
         Assert.Equal(
             DownloadHashManager.UpdateStatus.Unknown,
-            DownloadHashManager.GetStatus(DownloadHashManager.WhisperCpp.LinuxCudaExecutable, VulkanR2));
+            DownloadHashManager.GetStatus(DownloadHashManager.WhisperCpp.LinuxCudaExecutable, VulkanCurrent));
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #13749.

## What changed

- `WhisperDownloadService`: Windows BLAS / cuBLAS now come from the upstream `v1.9.2` tag; mac, Windows-Vulkan, Linux-Vulkan and Linux-CUDA come from the new [`whispercpp-192`](https://github.com/SubtitleEdit/support-files/releases/tag/whispercpp-192) support-files release.
- `DownloadHashManager`: all six `WhisperCpp.*` archive lists and the matching `whisper-cli` / `whisper-cli.exe` lists regenerated with v1.9.2 at index 0. Older entries stay listed so an existing install is recognised (and offered the update) instead of reported as Unknown.
- The Linux executable-hash test now pins v1.9.2 as up-to-date and asserts the working-but-superseded `-r2` hashes still resolve to `UpdateAvailable`.

## Build

The four SE-built archives came from [support-files run 32004756786](https://github.com/SubtitleEdit/support-files/actions/runs/32004756786) (all jobs green, including the Linux loader-verify step added for #13680).

## Verification

- Linux `whisper-cli` in both new zips: `NEEDED libwhisper.so.1` / `libggml.so.0` present in the archive as real files, `RUNPATH $ORIGIN` — the #13680 regression is not back.
- macOS `whisper-cli` is a universal `x86_64 + arm64` binary and transcribes a sample WAV with `tiny.en` on Metal.
- Windows archive hashes computed from the upstream v1.9.2 downloads (670 MB cuBLAS zip included), executable hashes from `whisper-cli.exe` inside each.
- `dotnet test tests/UI/UITests.csproj --filter FullyQualifiedName~WhisperCpp` — 14/14 pass.

## Upstream release notes (v1.9.2)

Token timestamps mapped back to original time when VAD is enabled plus a new API for VAD speech segments, UTF-8-aware `voice_length()` for CJK, VAD argument-parsing fixes, several ggml syncs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)