### PR TITLE
Fix #13768: per-line voice cloning hangs on Windows

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/ProcessExtensions.cs
+++ b/src/ui/Features/Video/TextToSpeech/ProcessExtensions.cs
@@ -19,6 +19,7 @@ public static class ProcessExtensions
     public static async Task StartAndWaitAsync(this Process process, CancellationToken cancellationToken)
     {
         process.StartProcess();
+        process.DrainRedirectedOutput();
         try
         {
             await process.WaitForExitAsync(cancellationToken);
@@ -43,6 +44,7 @@ public static class ProcessExtensions
     public static async Task StartAndWaitAsync(this Process process, CancellationToken cancellationToken, TimeSpan timeout)
     {
         process.StartProcess();
+        process.DrainRedirectedOutput();
 
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         timeoutCts.CancelAfter(timeout);
@@ -60,6 +62,38 @@ public static class ProcessExtensions
 
             throw new TimeoutException(
                 $"\"{process.StartInfo.FileName} {process.StartInfo.Arguments}\" did not finish within {timeout.TotalSeconds:0} seconds and was killed.");
+        }
+    }
+
+    /// <summary>
+    /// Starts pumping whichever standard streams the caller redirected, so the child can keep
+    /// writing to them.
+    /// </summary>
+    /// <remarks>
+    /// A redirected stream nobody reads is a pipe that fills up, and the child then blocks forever
+    /// on its next write - <see cref="Process.WaitForExitAsync"/> waits just as long. Windows gives
+    /// an anonymous pipe a 4 KB buffer by default, and ffmpeg spends more than that on its banner
+    /// and stream dump alone, so voice cloning hung on Windows while the same code was fine on
+    /// macOS/Linux with their 64 KB pipes (#13768). Doing it here means a caller cannot forget it;
+    /// the callers that read a stream themselves never use these helpers.
+    /// </remarks>
+    private static void DrainRedirectedOutput(this Process process)
+    {
+        try
+        {
+            if (process.StartInfo.RedirectStandardOutput)
+            {
+                process.BeginOutputReadLine();
+            }
+
+            if (process.StartInfo.RedirectStandardError)
+            {
+                process.BeginErrorReadLine();
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            // Already being read asynchronously - nothing to do, the pipe is being drained.
         }
     }
 

--- a/tests/UI/Features/Video/TextToSpeech/ProcessExtensionsDrainTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/ProcessExtensionsDrainTests.cs
@@ -1,0 +1,105 @@
+using System.Diagnostics;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech;
+
+namespace UITests.Features.Video.TextToSpeech;
+
+/// <summary>
+/// Voice cloning hung on Windows because the ffmpeg processes it starts have both standard
+/// streams redirected and nobody read them: the 4 KB pipe Windows gives an anonymous pipe fills
+/// up on ffmpeg's banner alone, and ffmpeg then blocks forever on its next write while
+/// WaitForExitAsync waits for an exit that never comes (#13768). StartAndWaitAsync now starts
+/// the async read itself.
+/// </summary>
+public class ProcessExtensionsDrainTests
+{
+    [Fact]
+    public async Task StartAndWaitAsync_ReadsRedirectedStandardError()
+    {
+        using var process = ChildWriting("hello-from-stderr", toStandardError: true);
+        var received = new List<string>();
+        process.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data != null)
+            {
+                lock (received)
+                {
+                    received.Add(e.Data);
+                }
+            }
+        };
+
+        await process.StartAndWaitAsync(TestContext.Current.CancellationToken);
+
+        // The events only arrive when the async read was started - which is also what keeps the
+        // pipe from filling up and wedging the child.
+        Assert.Contains("hello-from-stderr", received);
+    }
+
+    [Fact]
+    public async Task StartAndWaitAsync_ReadsRedirectedStandardOutput()
+    {
+        using var process = ChildWriting("hello-from-stdout", toStandardError: false);
+        var received = new List<string>();
+        process.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data != null)
+            {
+                lock (received)
+                {
+                    received.Add(e.Data);
+                }
+            }
+        };
+
+        await process.StartAndWaitAsync(TestContext.Current.CancellationToken);
+
+        Assert.Contains("hello-from-stdout", received);
+    }
+
+    /// <summary>
+    /// More output than any pipe buffer holds: without draining this child can never exit, so the
+    /// timeout overload would kill it and throw instead of returning normally.
+    /// </summary>
+    [Fact]
+    public async Task StartAndWaitAsync_WithTimeout_CompletesForAChildThatOutgrowsThePipeBuffer()
+    {
+        using var process = ChildWritingManyLines(20000);
+        var lines = 0;
+        process.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data != null)
+            {
+                Interlocked.Increment(ref lines);
+            }
+        };
+
+        await process.StartAndWaitAsync(TestContext.Current.CancellationToken, TimeSpan.FromMinutes(1));
+
+        Assert.Equal(0, process.ExitCode);
+        Assert.Equal(20000, lines);
+    }
+
+    private static Process ChildWriting(string text, bool toStandardError) =>
+        Shell(OperatingSystem.IsWindows()
+            ? (toStandardError ? $"echo {text} 1>&2" : $"echo {text}")
+            : (toStandardError ? $"echo {text} >&2" : $"echo {text}"));
+
+    private static Process ChildWritingManyLines(int count) =>
+        Shell(OperatingSystem.IsWindows()
+            ? $"for /L %i in (1,1,{count}) do @echo line-%i-padding-padding-padding-padding"
+            : $"i=1; while [ $i -le {count} ]; do echo line-$i-padding-padding-padding-padding; i=$((i+1)); done");
+
+    private static Process Shell(string command)
+    {
+        var startInfo = OperatingSystem.IsWindows()
+            ? new ProcessStartInfo("cmd.exe", $"/c {command}")
+            : new ProcessStartInfo("/bin/sh", $"-c \"{command}\"");
+
+        startInfo.UseShellExecute = false;
+        startInfo.CreateNoWindow = true;
+        startInfo.RedirectStandardOutput = true;
+        startInfo.RedirectStandardError = true;
+
+        return new Process { StartInfo = startInfo };
+    }
+}


### PR DESCRIPTION
Fixes #13768. Reporter picked OmniVoice + "Clone from video (voice of each line)" on a 1-minute video: the progress text reaches "Taking the voice of each line from the video..." and nothing ever happens.

## Root cause

`FfmpegGenerator.GetProcess` sets `RedirectStandardOutput` **and** `RedirectStandardError` unconditionally. Every other caller of it starts the async read:

```csharp
process.Start();
process.BeginOutputReadLine();
process.BeginErrorReadLine();
```

The two voice-clone callers don't — `PerLineVoiceClone.CutClipAsync` (the per-line reference cuts) and the auto-cast concat in `SpeakerReferenceBuilder`. They just `await process.StartAndWaitAsync(...)`.

A redirected pipe nobody reads fills up, and the child then blocks forever on its next write. `WaitForExitAsync` waits exactly as long. `EmbeddedSubtitlesEditMp4ViewModel.cs:476` already documents this exact trap in a comment.

**Why Windows only:** Windows gives an anonymous pipe a 4 KB buffer by default; macOS/Linux give 64 KB. I measured ffmpeg's stderr for the exact clone-reference command — 2963 bytes for a trivial single-track MP4, 3269 with two audio tracks and metadata, on a build whose `configuration:` line is only 1072 bytes. A full Windows ffmpeg build's configuration line is roughly twice that, which puts the banner plus stream dump comfortably over 4 KB. So the same code path is fine on macOS/Linux and wedges on Windows — which is why this shipped.

Four cuts run in parallel, so the whole preparation step stalls, matching "minutes pass and nothing happens" on a 1-minute video.

## Fix

`StartAndWaitAsync` (both overloads) now starts the async read for whichever streams the caller redirected. Fixing it in the helper rather than at the two call sites means the next caller can't forget it; the code that reads a stream itself (`OmniVoiceTtsCpp`, `EdgeTts`, `Piper`, `CrispAsrTtsProvenance`) never goes through these helpers, and the `InvalidOperationException` guard covers a caller that already started reading.

## Testing

New `tests/UI/Features/Video/TextToSpeech/ProcessExtensionsDrainTests.cs` — all three fail without the fix:

- redirected stderr is read (no events fire unless the async read was started)
- redirected stdout is read
- a child writing 20 000 lines completes instead of wedging — without the fix this one **deadlocked for the full 60-second timeout** on macOS, reproducing the bug once the output exceeds even the larger pipe

Build clean; full UI suite 3058 passed, 0 failed.

## Not changed

`PerLineVoiceClone.CutClipAsync` uses the `StartAndWaitAsync` overload without a timeout, so a genuinely wedged ffmpeg would still hang rather than surface as an error. The segment steps in `TextToSpeechViewModel` use the timeout overload for that reason (#12093). Adding one here seemed like a separate call — happy to follow up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)