### PR TITLE
Fix #13773: don't capitalize after "EE.UU." and other doubled abbreviations

### DIFF
--- a/src/libse/Forms/FixCommonErrors/Helper.cs
+++ b/src/libse/Forms/FixCommonErrors/Helper.cs
@@ -19,7 +19,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                 return false;
             }
 
-            if (index - 3 > 0 && char.IsLetterOrDigit(text[index - 1]) && text[index - 2] == '.') // e.g: O.R.
+            if (IsInnerPeriodAbbreviation(text, index)) // e.g: O.R., a.m., EE.UU.
             {
                 return true;
             }
@@ -36,6 +36,54 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             }
 
             return callbacks.GetAbbreviations().Contains(word + ".");
+        }
+
+        /// <summary>How many letters an inner-period abbreviation may have between two periods.</summary>
+        /// <remarks>
+        /// Two covers the doubled-letter plurals ("EE.UU.", "AA.VV."); three is room for the rare
+        /// longer group without letting a real sentence end ("Vino a casa. Ya.") look like one.
+        /// </remarks>
+        private const int MaxInnerPeriodGroupLength = 3;
+
+        /// <summary>
+        /// True for an abbreviation written with a period inside it - "U.S.", "a.m.", and the
+        /// Spanish doubled-letter plurals "EE.UU." / "AA.VV." (#13773). These are recognized by
+        /// shape, so they need no entry in the per-language abbreviation list (an entry could not
+        /// match anyway: the lookup above stops walking at the inner period).
+        /// </summary>
+        private static bool IsInnerPeriodAbbreviation(string text, int index)
+        {
+            // The letters directly before the period at index ("UU" of "EE.UU.").
+            var lastGroupEnd = index - 1;
+            var i = lastGroupEnd;
+            while (i >= 0 && char.IsLetterOrDigit(text[i]))
+            {
+                i--;
+            }
+
+            var lastGroupLength = lastGroupEnd - i;
+            if (lastGroupLength < 1 || lastGroupLength > MaxInnerPeriodGroupLength || i < 0 || text[i] != '.')
+            {
+                return false;
+            }
+
+            // ...and the letters before that inner period ("EE").
+            var firstGroupEnd = i - 1;
+            i = firstGroupEnd;
+            while (i >= 0 && char.IsLetterOrDigit(text[i]))
+            {
+                i--;
+            }
+
+            var firstGroupLength = firstGroupEnd - i;
+            if (firstGroupLength < 1 || firstGroupLength > MaxInnerPeriodGroupLength)
+            {
+                return false;
+            }
+
+            // The whole thing has to start at a word boundary, so a period landing mid-word does
+            // not turn its tail into an abbreviation.
+            return i < 0 || !char.IsLetterOrDigit(text[i]);
         }
 
         /// <summary>

--- a/tests/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterParagraphTest.cs
+++ b/tests/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterParagraphTest.cs
@@ -46,6 +46,13 @@ public class FixStartWithUppercaseLetterAfterParagraphTest
         Assert.Equal("he is asleep.", Fix("It is 5 a.m.", "he is asleep.", "en"));
     }
 
+    // ...including the Spanish doubled-letter plurals, where the group is two letters (#13773).
+    [Fact]
+    public void KeepsLowercaseAfterSpanishDoubledAbbreviation()
+    {
+        Assert.Equal("desde hace años.", Fix("Vivo en EE.UU.", "desde hace años.", "es"));
+    }
+
     // A line ending with a quotation mark is not a paragraph end - the quote is not
     // preceded by sentence-ending punctuation, so the next line continues the sentence.
     // ("\"u\"" is three characters, so this is the pre-existing long-line path - kept as a

--- a/tests/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterPeriodInsideParagraphTest.cs
+++ b/tests/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterPeriodInsideParagraphTest.cs
@@ -67,6 +67,39 @@ public class FixStartWithUppercaseLetterAfterPeriodInsideParagraphTest
         Assert.Equal(input, Fix(input, "nl"));
     }
 
+    // Spanish doubles the letters to make an abbreviation plural - "EE.UU." (Estados Unidos),
+    // "AA.VV.", "RR.HH." - so the group before the inner period is two letters, not one (#13773).
+    [Theory]
+    [InlineData("Vivo en EE.UU. desde hace años.")]
+    [InlineData("Viajé a EE.UU. con ellos.")]
+    [InlineData("Publicado por AA.VV. el año pasado.")]
+    [InlineData("Habla con RR.HH. mañana.")]
+    public void Spanish_KeepsLowercaseAfterDoubledAbbreviation(string input)
+    {
+        Assert.Equal(input, Fix(input, "es"));
+    }
+
+    // An inner-period abbreviation is recognized at the very start of the line too - the old
+    // shape check needed three characters of run-up and silently skipped these.
+    [Theory]
+    [InlineData("U.S. army units arrived.")]
+    [InlineData("EE.UU. envió tropas.")]
+    public void KeepsLowercaseAfterMultiDotAbbreviationAtLineStart(string input)
+    {
+        Assert.Equal(input, Fix(input, "en"));
+    }
+
+    // A real sentence ending is still a sentence ending: two short words around a period are
+    // only an abbreviation when the period sits *inside* the token.
+    [Theory]
+    [InlineData("Vino a casa. ya es tarde.", "Vino a casa. Ya es tarde.")]
+    [InlineData("Se fue. no volvió.", "Se fue. No volvió.")]
+    [InlineData("Es la una. son las dos.", "Es la una. Son las dos.")]
+    public void Spanish_StillCapitalizesAfterASentenceEnding(string input, string expected)
+    {
+        Assert.Equal(expected, Fix(input, "es"));
+    }
+
     // The abbreviation list is matched case insensitively - subtitles use both "Dr." and "dr.".
     [Theory]
     [InlineData("I met dr. smith today.")]


### PR DESCRIPTION
Fixes #13773. Fix common errors capitalizes the word after `EE.UU.`, treating the abbreviation's final period as a sentence ending.

## Root cause

Spanish makes an abbreviation plural by **doubling its letters**: `EE.UU.` (Estados Unidos), `AA.VV.` (autores varios), `RR.HH.` (recursos humanos). So the group before the inner period is two letters, not one.

`Helper.IsAbbreviation` has a shape check for inner-period abbreviations that only looked one character back:

```csharp
if (index - 3 > 0 && char.IsLetterOrDigit(text[index - 1]) && text[index - 2] == '.') // e.g: O.R.
```

For `EE.UU.` the final period has `U` at `index-1` and `U` — not `.` — at `index-2`, so it falls through to the per-language abbreviation list. It can't match there either: the list lookup walks back over letters only and stops at the inner period, so it searches for `"UU."`. Adding `EE.UU.` to `es_abbreviations.xml` would therefore be dead weight (same trap noted for entries containing a space or digit).

Both `FixStartWithUppercaseLetterAfterPeriodInsideParagraph` and `FixStartWithUppercaseLetterAfterParagraph` route through this helper, so mid-line and across-subtitle both misbehaved.

## Fix

Generalized to letter groups of **1–3 characters on both sides** of the inner period, anchored at a word boundary. Three is enough for the rare longer group while staying far away from real sentence endings — `"Se fue. No volvió."` needs the period to sit *inside* the token to qualify, and there it's between two separate words.

It also drops the old `index - 3 > 0` run-up requirement, which silently skipped an inner-period abbreviation at the very start of a line.

## Testing

- 4 doubled-abbreviation cases (`EE.UU.` ×2, `AA.VV.`, `RR.HH.`) mid-line, plus one across two subtitles
- line-start cases
- 3 negative cases asserting a genuine sentence ending is still capitalized

6 of the new assertions fail without the fix. Whole solution green: libse 1332, libuilogic 230, seconv 376, UI 3058 — 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)