### PR TITLE
Add a "Select none" button to the AI review window

### DIFF
--- a/src/ui/Features/Tools/AiReview/AiReviewViewModel.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewViewModel.cs
@@ -676,6 +676,12 @@ public partial class AiReviewViewModel : ObservableObject
     }
 
     [RelayCommand]
+    private void SelectNone()
+    {
+        SetAllSelected(false);
+    }
+
+    [RelayCommand]
     private void InvertSelection()
     {
         _syncingSelection = true;

--- a/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
@@ -443,6 +443,7 @@ public class AiReviewWindow : Window
                 buttonPlay.WithMarginRight(10),
                 summaryText.WithMarginRight(10),
                 UiUtil.MakeButton(Se.Language.General.SelectAll, vm.SelectAllCommand),
+                UiUtil.MakeButton(Se.Language.General.SelectNone, vm.SelectNoneCommand),
                 UiUtil.MakeButton(Se.Language.General.InvertSelection, vm.InvertSelectionCommand),
             },
         };


### PR DESCRIPTION
Part of #13775 — the reporter asked for a "Select none" button.

The AI review window's button bar has **Select all** and **Invert selection** but no way to clear the selection in one action. `SetAllSelected(bool)` already exists (that's what `SelectAll` calls) and `Se.Language.General.SelectNone` is already a translated string, so this is a straight pair with "Select all" — no new strings, no new logic.

## Not in this PR

The issue's headline — "select 1 row selects 2 rows" — is **working as designed**, so I've left it for you to decide on rather than changing it blind:

`OnSuggestionSelectedChanged` deliberately links every suggestion that shares a `UnitId`, and `AiReviewChunker.BuildUnitIds` puts consecutive lines in one unit until a line ends a sentence. So when a sentence is split across subtitles 8 and 9, their two suggestions toggle together — applying half of a rewritten sentence would leave it inconsistent. The design is visible elsewhere in the UI: the reason line already reads "Lines 8 to 9" instead of "Line 8" for a multi-line unit. What's missing is any indication *in the grid* of why a second checkbox moved, which is what makes it read as a bug.

Two things worth a look while you're there:

1. **The link overrides the mismatch guard.** Items with `IsWarning` ship unchecked on purpose ("Never pre-check those; applying one replaces the line with unrelated text", #13632). But the unit link sets `other.IsSelected = item.IsSelected` unconditionally, so checking a safe suggestion silently arms a flagged one in the same unit. Creation order saves the initial state — `IsSelected` is set in the object initializer before `PropertyChanged` is wired — but every later user click goes through the link.
2. The reporter also suggested **not pre-selecting everything by default**. That's a deliberate call in `AddSuggestion` (`IsSelected = !isWarning`), so I left it alone.

## Testing

Build clean; AI review tests 53 passed. No new test: `_allSuggestions` is private and only fills through a real review run, so covering `SelectNone` would mean adding a seam to the view model for two lines that reuse the already-exercised `SetAllSelected` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)