### PR TITLE
Fix #13777: audio clip extraction progress jumps after SE regains focus

### DIFF
--- a/src/ui/Features/Shared/GetAudioClips/GetAudioClipsViewModel.cs
+++ b/src/ui/Features/Shared/GetAudioClips/GetAudioClipsViewModel.cs
@@ -31,6 +31,7 @@ public partial class GetAudioClipsViewModel : ObservableObject
     private bool _useCenterChannelOnly;
     private readonly CancellationTokenSource _cancellationTokenSource;
     private List<SubtitleLineViewModel> _lines;
+    private int _started;
 
     public GetAudioClipsViewModel()
     {
@@ -66,9 +67,7 @@ public partial class GetAudioClipsViewModel : ObservableObject
             }
 
             count++;
-            var pecentage = (double)count / _lines.Count * 100.0;
-            Progress = pecentage;
-            StatusText = string.Format(Se.Language.General.FileXOfY, count, _lines.Count);
+            ReportProgress(count);
 
             var outputFileName = Path.Combine(Path.GetTempPath(), $"se_audioclip_{Guid.NewGuid()}.wav");
             var process = GetExtractProcess(_videoFileName, line, outputFileName);
@@ -111,6 +110,25 @@ public partial class GetAudioClipsViewModel : ObservableObject
         Close();
     }
 
+    /// <summary>
+    /// Pushes the progress of clip <paramref name="count"/> to the UI.
+    /// </summary>
+    /// <remarks>
+    /// ExtractLines runs on a worker thread, and these two properties are bound to the progress
+    /// bar and the status line - so the assignments have to be marshalled, the same way this class
+    /// already marshals its message box and its Close().
+    /// </remarks>
+    private void ReportProgress(int count)
+    {
+        var percentage = (double)count / _lines.Count * 100.0;
+        var status = string.Format(Se.Language.General.FileXOfY, count, _lines.Count);
+        Dispatcher.UIThread.Post(() =>
+        {
+            Progress = percentage;
+            StatusText = status;
+        });
+    }
+
     private Process GetExtractProcess(string videoFileName, SubtitleLineViewModel line, string outputFileName)
     {
         var arguments = FfmpegGenerator.ExtractAudioClipFromVideoParameters(
@@ -143,9 +161,25 @@ public partial class GetAudioClipsViewModel : ObservableObject
         Close();
     }
 
-    public void StartAudioExtract()
+    /// <summary>
+    /// Starts the extraction, once. Returns false when a run is already going.
+    /// </summary>
+    /// <remarks>
+    /// The window used to start this from its <c>Activated</c> event, which fires again every time
+    /// the user tabs away and back - so a second extraction loop began from line one while the
+    /// first was still running, and the two fought over the progress counter (#13777). The window
+    /// starts it from <c>Loaded</c> now; this guard keeps the invariant with the state it belongs
+    /// to, since a second loop also appends to <see cref="AudioClips"/> from another thread.
+    /// </remarks>
+    public bool StartAudioExtract()
     {
+        if (Interlocked.Exchange(ref _started, 1) != 0)
+        {
+            return false;
+        }
+
         _ = Task.Run(ExtractLines, _cancellationTokenSource.Token);
+        return true;
     }
 
     internal void OnKeyDown(KeyEventArgs e)

--- a/src/ui/Features/Shared/GetAudioClips/GetAudioClipsWindow.cs
+++ b/src/ui/Features/Shared/GetAudioClips/GetAudioClipsWindow.cs
@@ -51,11 +51,11 @@ public class GetAudioClipsWindow : Window
             }
         };
 
-        Activated += delegate
-        {
-            buttonCancel.Focus(); // hack to make OnKeyDown work
-            vm.StartAudioExtract();
-        }; 
+        Activated += delegate { buttonCancel.Focus(); }; // hack to make OnKeyDown work
+
+        // Loaded, not Activated: Activated fires again every time the window regains focus, which
+        // started a second extraction loop from line one on top of the running one (#13777).
+        Loaded += delegate { vm.StartAudioExtract(); };
         KeyDown += (s, e) => vm.OnKeyDown(e);  
     }
 }

--- a/tests/UI/Features/Shared/GetAudioClipsStartOnceTests.cs
+++ b/tests/UI/Features/Shared/GetAudioClipsStartOnceTests.cs
@@ -1,0 +1,38 @@
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Features.Shared.GetAudioClips;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Shared;
+
+/// <summary>
+/// The audio-clip extraction must start exactly once per window. It used to be kicked off from the
+/// window's Activated event, which fires again every time the user tabs away and back - so a second
+/// loop started from line one while the first was still going, and the two overwrote each other's
+/// progress, making the counter jump backwards (#13777).
+/// </summary>
+public class GetAudioClipsStartOnceTests
+{
+    [AvaloniaFact]
+    public void StartAudioExtract_OnlyStartsOneRun()
+    {
+        // No lines and no center-channel probe, so nothing spawns ffmpeg - the guard under test is
+        // synchronous and runs before any of that anyway.
+        var originalCenterChannel = Se.Settings.General.FfmpegUseCenterChannelOnly;
+        Se.Settings.General.FfmpegUseCenterChannelOnly = false;
+        try
+        {
+            var vm = new GetAudioClipsViewModel();
+            vm.Initialize("video.mp4", []);
+
+            Assert.True(vm.StartAudioExtract());
+
+            // Every later activation of the window used to land here.
+            Assert.False(vm.StartAudioExtract());
+            Assert.False(vm.StartAudioExtract());
+        }
+        finally
+        {
+            Se.Settings.General.FfmpegUseCenterChannelOnly = originalCenterChannel;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #13777.

## Root cause

`GetAudioClipsWindow` started the extraction from `Activated`:

```csharp
Activated += delegate
{
    buttonCancel.Focus(); // hack to make OnKeyDown work
    vm.StartAudioExtract();
};
```

`Activated` fires **every time the window becomes active**, not once. So losing focus and clicking back launched a *second* `ExtractLines` loop starting at line one while the first was still running, and the two overwrote each other's `Progress` / `StatusText` — the counter jumps backwards and between values, exactly as reported. It matches the other details too: independent of cue count, and the extraction still finishes because the leading loop completes normally.

Two more consequences of the same double-start: both loops `AudioClips.Add(...)` from different threads (`List<T>` is not thread-safe, and clips get duplicated), and both run the `OkPressed = true; Close();` finish.

This window is the only one in the codebase that starts work from `Activated` — everywhere else the handler just sets focus, and the other `StartDownload`-style calls run from the `ShowDialogAsync` initializer.

## Fix

- Start from `Loaded`, which fires once. `Activated` keeps only the focus hack.
- Guard `StartAudioExtract` with an `Interlocked.Exchange` so a second call can't start a second run whoever makes it — the invariant belongs with the state it protects.
- The loop also assigned the bound `Progress`/`StatusText` **from its worker thread**. Those go through the dispatcher now, the same way this class already marshals its message box and its `Close()`.

## Testing

New `tests/UI/Features/Shared/GetAudioClipsStartOnceTests.cs`: the first `StartAudioExtract()` returns true, later ones return false. It runs with no lines and the center-channel probe off, so nothing spawns ffmpeg.

Build clean; full UI suite 3059 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)