### PR TITLE
Fix #13701: Spanish "clón" OCR rule no longer breaks "ciclón"

### DIFF
--- a/Dictionaries/spa_OCRFixReplaceList.xml
+++ b/Dictionaries/spa_OCRFixReplaceList.xml
@@ -841,8 +841,12 @@
     <!-- Terminaciones ción/sión -->
     <RegEx find="([sc]i)o(n)\b" replaceWith="$1ó$2" />
     <RegEx find="([SC]I)O(N)\b" replaceWith="$1Ó$2" />
-    <!-- "i" en vez de "l" en terminaciones «clón» -->
-    <RegEx find="clón\b" replaceWith="ción" />
+    <!-- "l" en vez de "i" en terminaciones «cclón» y «uclón» (acclón, soluclón).
+         Sin diccionario esta es la única red de seguridad, así que sólo se aplica
+         donde no existe ninguna palabra real: «-cción» y «-ución». El caso general
+         («estaclón», «canclón»...) está más abajo, protegido por el corrector, para
+         no romper palabras reales como «ciclón» o «anticiclón» (#13701). -->
+    <RegEx find="([cu])clón\b" replaceWith="$1ción" />
     <!-- "si" en vez de "sl" -->
     <RegEx find="\b([Ss])(l)\b" replaceWith="$1i" />
     <!-- Para corregir por ej. raclones, perforaclones, opclones, etc -->
@@ -965,5 +969,9 @@
 
     <!-- word-initial ii to ll (iiegar to llegar) -->
     <RegEx find="\bii([a-záéíóúñü]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
+
+    <!-- Terminación «clón» por «ción»: estaclón to estación, canclón to canción (#13701).
+         Palabras reales como «ciclón», «anticiclón» o «choclón» las protege el corrector. -->
+    <RegEx find="\b([A-ZÁÉÍÓÚÑÜa-záéíóúñü]+)clón\b" spellCheck="$1ción" replaceWith="$1ción" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixSpanishClonEndingTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixSpanishClonEndingTests.cs
@@ -1,0 +1,152 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
+using Nikse.SubtitleEdit.Features.SpellCheck;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
+
+namespace UITests.Features.Ocr.FixEngine;
+
+// Issue #13701: the Spanish list fixed the OCR error "clón" -> "ción" with a plain regex that
+// matched ANY word ending in "clón", so real words were destroyed ("ciclón" -> "cición",
+// "anticiclón" -> "anticición"). The general case now lives in the spell-check-gated section
+// (a word that is already in the dictionary is never "fixed"), and the ungated regex is limited
+// to "-cclón"/"-uclón", endings no real Spanish word has.
+// Runs against the shipped Dictionaries/spa_OCRFixReplaceList.xml, not a copy of its rules.
+public class OcrFixSpanishClonEndingTests : IDisposable
+{
+    private readonly Func<string> _originalSpellCheckDictionariesFolder;
+    private readonly string _tempDictionariesFolder;
+
+    public OcrFixSpanishClonEndingTests()
+    {
+        _originalSpellCheckDictionariesFolder = SpellCheckConfig.DictionariesFolder;
+
+        _tempDictionariesFolder = Path.Combine(
+            Path.GetTempPath(),
+            "SeOcrFixSpanishClonTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDictionariesFolder);
+
+        File.Copy(
+            Path.Combine(FindRepoRoot(), "Dictionaries", "spa_OCRFixReplaceList.xml"),
+            Path.Combine(_tempDictionariesFolder, "spa_OCRFixReplaceList.xml"));
+
+        SpellCheckConfig.DictionariesFolder = () => _tempDictionariesFolder;
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "Dictionaries")))
+        {
+            dir = dir.Parent;
+        }
+
+        return dir?.FullName ?? throw new DirectoryNotFoundException("Could not find repo root");
+    }
+
+    [Theory]
+    [InlineData("Se acerca el ciclón Zzyzx.")]
+    [InlineData("Se acerca el anticiclón Zzyzx.")]
+    public void FixOcrErrors_WordThatReallyEndsInClon_IsLeftAlone(string text)
+    {
+        // "Zzyzx" keeps the line from being spelled OK, so every regex rule really runs.
+        var engine = CreateEngine();
+
+        var result = engine.FixOcrErrors(0, text, doTryToGuessUnknownWords: false);
+
+        Assert.Equal(text, result.GetText());
+    }
+
+    [Theory]
+    [InlineData("Vamos a la estaclón.", "Vamos a la estación.")]
+    [InlineData("Canta una canclón.", "Canta una canción.")]
+    public void FixOcrErrors_MisreadCionEnding_IsFixed(string text, string expected)
+    {
+        var engine = CreateEngine();
+
+        var result = engine.FixOcrErrors(0, text, doTryToGuessUnknownWords: false);
+
+        Assert.Equal(expected, result.GetText());
+    }
+
+    [Theory]
+    [InlineData("Entra en acclón Zzyzx.", "Entra en acción Zzyzx.")]
+    [InlineData("Busca una soluclón Zzyzx.", "Busca una solución Zzyzx.")]
+    public void FixOcrErrors_CcionAndUcionEndings_AreFixedWithoutADictionary(string text, string expected)
+    {
+        // No Spanish Hunspell dictionary is installed in this scenario, so the gated rules are
+        // dead - the two endings that no real word uses must still be repaired.
+        var engine = CreateEngine(new EmptySpellChecker());
+
+        var result = engine.FixOcrErrors(0, text, doTryToGuessUnknownWords: false);
+
+        Assert.Equal(expected, result.GetText());
+    }
+
+    [Fact]
+    public void FixOcrErrors_WithoutADictionary_RealClonWordIsLeftAlone()
+    {
+        var engine = CreateEngine(new EmptySpellChecker());
+
+        var result = engine.FixOcrErrors(0, "Se acerca el ciclón.", doTryToGuessUnknownWords: false);
+
+        Assert.Equal("Se acerca el ciclón.", result.GetText());
+    }
+
+    private static IOcrFixEngine CreateEngine(ISpellChecker? spellChecker = null)
+    {
+        IOcrFixEngine engine = new OcrFixEngine(spellChecker ?? new FakeSpanishSpellChecker());
+        engine.Initialize(new Subtitle(), "spa", new SpellCheckDictionaryDisplay());
+        return engine;
+    }
+
+    private sealed class FakeSpanishSpellChecker : ISpellChecker
+    {
+        private static readonly HashSet<string> Words = new(StringComparer.Ordinal)
+        {
+            "se", "acerca", "el", "ciclón", "anticiclón", "vamos", "a", "la", "estación",
+            "canta", "una", "canción", "entra", "en", "acción", "busca", "solución",
+        };
+
+        public bool Initialize(string dictionaryFile, string twoLetterLanguageCode) => true;
+
+        public bool IsWordCorrect(string word)
+        {
+            if (string.IsNullOrWhiteSpace(word))
+            {
+                return true;
+            }
+
+            // Like Hunspell, accept the initial-capitalized form of a lowercase dictionary word.
+            return Words.Contains(word) || Words.Contains(word.ToLowerInvariant());
+        }
+
+        public List<string> GetSuggestions(string word) => new();
+    }
+
+    // Stands in for "no Hunspell dictionary installed for the language".
+    private sealed class EmptySpellChecker : ISpellChecker
+    {
+        public bool Initialize(string dictionaryFile, string twoLetterLanguageCode) => false;
+
+        public bool IsWordCorrect(string word) => string.IsNullOrWhiteSpace(word);
+
+        public List<string> GetSuggestions(string word) => new();
+    }
+
+    public void Dispose()
+    {
+        SpellCheckConfig.DictionariesFolder = _originalSpellCheckDictionariesFolder;
+        try
+        {
+            Directory.Delete(_tempDictionariesFolder, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup.
+        }
+    }
+}


### PR DESCRIPTION
Fixes #13701

## The bug

`Dictionaries/spa_OCRFixReplaceList.xml` had an ungated regex

```xml
<RegEx find="clón\b" replaceWith="ción" />
```

that rewrote **every** word ending in `clón`, not just OCR damage. So "Fix common OCR errors" turned real words into garbage:

- `ciclón` → `cición`
- `anticiclón` → `anticición`
- plus the regional `choclón` / `chanclón` / `canclón` / `carranclón` family

`cl` + vowel is a legal Spanish cluster, so unlike the neighbouring consonant-`l`-consonant rules this one cannot be applied blind.

## The fix

The general case moves to `RegularExpressionsIfSpelledCorrectly`, the section that only replaces a token when the token itself is *not* a dictionary word and the fixed form *is*:

```xml
<RegEx find="\b([A-ZÁÉÍÓÚÑÜa-záéíóúñü]+)clón\b" spellCheck="$1ción" replaceWith="$1ción" />
```

`estaclón` → `estación`, `canclón` → `canción`, while `ciclón` and friends are protected by the dictionary — including regionalisms the reporter's word list can't enumerate, as long as they're in the user's dictionary.

The ungated regex is kept, narrowed to the reporter's suggestion:

```xml
<RegEx find="([cu])clón\b" replaceWith="$1ción" />
```

`-cclón`/`-uclón` are endings no real Spanish word has, so the two most common families (`-cción`: acción, dirección; `-ución`: solución, revolución) are still repaired when no Spanish Hunspell dictionary is installed — that path is dictionary-independent (#12126).

Trade-off worth stating: with **no** Spanish dictionary installed, `estaclón`-type errors (`-ación`, `-nción`, `-ición`) are no longer fixed. Corrupting correct words is the worse failure, and installing the Spanish dictionary restores full coverage.

## Tests

New `tests/UI/Features/Ocr/FixEngine/OcrFixSpanishClonEndingTests.cs` runs the **shipped** `spa_OCRFixReplaceList.xml` through the real fix engine:

- `ciclón` / `anticiclón` untouched (with and without a dictionary) — these 3 fail on the old XML
- `estaclón` → `estación`, `canclón` → `canción` still fixed
- `acclón` → `acción`, `soluclón` → `solución` fixed even with no dictionary

7/7 pass; the full 758-test OCR suite is green.

## On the reporter's second point

Seeing/disabling a shipped rule is already possible: `<lang>_OCRFixReplaceList_User.xml` supports a `<RemovedRegularExpressions>` section that drops a shipped `<RegEx find="...">` by its exact `find` pattern, alongside `<RegularExpressions>` for adding your own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)