### PR TITLE
Fix #13113: make the toolbar frame rate usable like SE 4 legacy

### DIFF
--- a/src/ui/Features/Main/Layout/InitToolbar.cs
+++ b/src/ui/Features/Main/Layout/InitToolbar.cs
@@ -587,6 +587,18 @@ public static class InitToolbar
             };
             stackPanelRight.Children.Add(comboBoxFrameRate);
             comboBoxFrameRate.SelectionChanged += vm.ComboBoxFrameRateSelectionChanged;
+
+            // SE 4 had a "..." button right next to the combo box for reading the frame rate
+            // out of a video file without opening it in the player.
+            stackPanelRight.Children.Add(new Button
+            {
+                Content = "...",
+                Command = vm.GetFrameRateFromVideoFileCommand,
+                Background = Brushes.Transparent,
+                VerticalAlignment = VerticalAlignment.Center,
+                [AutomationProperties.NameProperty] = languageHints.GetFrameRateFromVideoFileHint,
+                [ToolTip.TipProperty] = UiUtil.MakeToolTip(languageHints.GetFrameRateFromVideoFileHint, shortcuts),
+            });
         }
 
         var grid = new Grid

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -864,7 +864,7 @@ public partial class MainViewModel :
             "60",
             "120"
         };
-        SelectedFrameRate = FrameRates[0];
+        SetSelectedFrameRate(Se.Settings.General.CurrentFrameRate);
 
         StatusTextLeft = string.Empty;
         StatusTextRight = string.Empty;
@@ -21725,9 +21725,10 @@ public partial class MainViewModel :
         try
         {
             _mediaInfo = FfmpegMediaInfo2.Parse(videoFileName);
-            SelectedFrameRate = _mediaInfo?.FramesRate.ToString(CultureInfo.InvariantCulture) ?? FrameRates[0];
-            Se.Settings.General.CurrentFrameRate = (double)(_mediaInfo?.FramesRate ?? 23.976m);
-            Configuration.Settings.General.CurrentFrameRate = (double)(_mediaInfo?.FramesRate ?? 23.976m);
+            var videoFrameRate = (double)(_mediaInfo?.FramesRate ?? 23.976m);
+            SetSelectedFrameRate(videoFrameRate);
+            Se.Settings.General.CurrentFrameRate = videoFrameRate;
+            Configuration.Settings.General.CurrentFrameRate = videoFrameRate;
             _updateAudioVisualizer = true;
 
             if (IsFormatAssa)
@@ -21790,6 +21791,51 @@ public partial class MainViewModel :
             Configuration.Settings.General.CurrentFrameRate = frameRate;
             _updateAudioVisualizer = true;
         }
+    }
+
+    /// <summary>
+    /// Shows a frame rate in the toolbar frame rate combo box, adding it to the list first when it
+    /// is not one of the presets.
+    /// </summary>
+    internal void SetSelectedFrameRate(double frameRate)
+    {
+        SelectedFrameRate = FrameRateHelper.SelectInList(FrameRates, frameRate);
+    }
+
+    /// <summary>
+    /// The SE 4 "..." button next to the toolbar frame rate combo box: pick a video file and use
+    /// its frame rate, without opening the video in the player.
+    /// </summary>
+    [RelayCommand]
+    private async Task GetFrameRateFromVideoFile()
+    {
+        var fileName = await _fileHelper.PickOpenVideoFile(Window!, Se.Language.General.OpenVideoFileTitle);
+        if (string.IsNullOrEmpty(fileName))
+        {
+            _shortcutManager.ClearKeys();
+            return;
+        }
+
+        var frameRate = 0.0;
+        try
+        {
+            var mediaInfo = await Task.Run(() => FfmpegMediaInfo2.Parse(fileName));
+            frameRate = (double)mediaInfo.FramesRate;
+        }
+        catch
+        {
+            // Unreadable video file - keep the current frame rate, like SE 4 did.
+        }
+
+        if (frameRate > 0)
+        {
+            SetSelectedFrameRate(frameRate);
+            Se.Settings.General.CurrentFrameRate = frameRate;
+            Configuration.Settings.General.CurrentFrameRate = frameRate;
+            _updateAudioVisualizer = true;
+        }
+
+        _shortcutManager.ClearKeys();
     }
 
     private void LoadAudioTrackMenuItems()

--- a/src/ui/Logic/Config/Language/Main/LanguageMainToolbar.cs
+++ b/src/ui/Logic/Config/Language/Main/LanguageMainToolbar.cs
@@ -32,6 +32,7 @@ public class LanguageMainToolbar
     public string WebVttStylesHint { get; set; }
     public string SsaPropertiesHint { get; set; }
     public string SsaAttachmentsHint { get; set; }
+    public string GetFrameRateFromVideoFileHint { get; set; }
 
 
     public LanguageMainToolbar()
@@ -66,5 +67,6 @@ public class LanguageMainToolbar
         WebVttStylesHint = "WebVTT style manager";
         SsaPropertiesHint = "Sub Station Alpha properties";
         SsaAttachmentsHint = "Sub Station Alpha attachments";
+        GetFrameRateFromVideoFileHint = "Get frame rate from video file";
     }
 }

--- a/src/ui/Logic/Config/SeAppearance.cs
+++ b/src/ui/Logic/Config/SeAppearance.cs
@@ -153,6 +153,7 @@ public class SeAppearance
         ToolbarShowSourceView = false;
         ToolbarShowHelp = true;
         ToolbarShowEncoding = false;
+        ToolbarShowFrameRate = false;
         ToolbarShowStyleManager = true;
         ToolbarShowProperties = true;
         ToolbarShowAttachments = true;

--- a/src/ui/Logic/FrameRateHelper.cs
+++ b/src/ui/Logic/FrameRateHelper.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Logic;
 
@@ -33,5 +35,30 @@ public static class FrameRateHelper
         }
 
         return closest;
+    }
+
+    /// <summary>
+    /// Returns the item to select in a frame rate combo box, first adding <paramref name="frameRate"/>
+    /// to <paramref name="frameRates"/> when it is not one of the presets: the rate in use can be
+    /// anything (restored from settings, read from a video file) and an item missing from the list
+    /// would just leave the combo box blank. A rate of zero or less - an empty or corrupt setting -
+    /// falls back to the first preset.
+    /// </summary>
+    public static string SelectInList(IList<string> frameRates, double frameRate)
+    {
+        if (frameRate <= 0)
+        {
+            return frameRates[0];
+        }
+
+        // Invariant culture: the list holds "23.976"-style items and the combo box round-trips
+        // the selected item back through double.Parse with the invariant culture too.
+        var text = frameRate.ToString(CultureInfo.InvariantCulture);
+        if (!frameRates.Contains(text))
+        {
+            frameRates.Insert(0, text);
+        }
+
+        return text;
     }
 }

--- a/src/ui/Logic/Se4Setup/Se4SetupApplier.cs
+++ b/src/ui/Logic/Se4Setup/Se4SetupApplier.cs
@@ -1,11 +1,14 @@
 using Avalonia.Media;
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Edit.MultipleReplace;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Options.Shortcuts;
 using Nikse.SubtitleEdit.Logic.Config;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Xml.Linq;
 
 namespace Nikse.SubtitleEdit.Logic.Se4Setup;
 
@@ -43,6 +46,7 @@ public static class Se4SetupApplier
         ApplyReplaceRules(settingsXmlPath, result);
         ApplyClassicTheme();
         ApplyToolbarAndEditBox();
+        ApplyFrameRate(vm, settingsXmlPath);
         ApplyWaveformColors();
         ApplyWaveformToolbar();
         ApplySelectCurrentLineWhilePlaying(vm);
@@ -149,6 +153,72 @@ public static class Se4SetupApplier
         // "<br />" (Settings.General.ListViewLineSeparatorString default). Match that.
         Se.Settings.Appearance.SubtitleGridTextSingleLine = true;
         Se.Settings.Appearance.SubtitleGridTextSingleLineSeparator = "<br />";
+    }
+
+    // SE 4 kept the frame rate selector in the toolbar behind General/ShowFrameRate and let the
+    // user pick the frame rate new files start at via General/DefaultFrameRate. SE 5 has the same
+    // toolbar combo box (Appearance/ToolbarShowFrameRate) but no options UI for the default, so
+    // both are carried over from the classic Settings.xml when one is present. Doing nothing
+    // without a Settings.xml is correct: SE 4's own defaults (hidden, 23.976) match SE 5's.
+    internal static void ApplyFrameRate(MainViewModel vm, string? settingsXmlPath)
+    {
+        if (settingsXmlPath == null || !File.Exists(settingsXmlPath))
+        {
+            return;
+        }
+
+        string xml;
+        try
+        {
+            xml = File.ReadAllText(settingsXmlPath);
+        }
+        catch
+        {
+            return;
+        }
+
+        ApplyFrameRateFromXml(vm, xml);
+    }
+
+    internal static void ApplyFrameRateFromXml(MainViewModel? vm, string xml)
+    {
+        XDocument doc;
+        try
+        {
+            doc = XDocument.Parse(xml);
+        }
+        catch
+        {
+            return;
+        }
+
+        var general = doc.Descendants().FirstOrDefault(e => e.Name.LocalName == "General");
+        if (general == null)
+        {
+            return;
+        }
+
+        var showFrameRate = general.Elements().FirstOrDefault(e => e.Name.LocalName == "ShowFrameRate")?.Value;
+        if (bool.TryParse(showFrameRate, out var show))
+        {
+            Se.Settings.Appearance.ToolbarShowFrameRate = show;
+        }
+
+        var defaultFrameRate = general.Elements().FirstOrDefault(e => e.Name.LocalName == "DefaultFrameRate")?.Value;
+        if (!double.TryParse(defaultFrameRate, NumberStyles.Float, CultureInfo.InvariantCulture, out var frameRate) ||
+            frameRate < 10 ||
+            frameRate > 200)
+        {
+            // SE 4 wrote this value with the invariant culture but could read back a locale-mangled
+            // one ("23,976" -> 23976), which it clamped too; anything out of range is ignored here.
+            return;
+        }
+
+        Se.Settings.General.DefaultFrameRate = frameRate;
+        Se.Settings.General.CurrentFrameRate = frameRate;
+        Configuration.Settings.General.DefaultFrameRate = frameRate;
+        Configuration.Settings.General.CurrentFrameRate = frameRate;
+        vm?.SetSelectedFrameRate(frameRate);
     }
 
     // The SE 4 waveform look, taken from the classic AudioVisualizer defaults

--- a/tests/UI/Logic/FrameRateToolbarComboTests.cs
+++ b/tests/UI/Logic/FrameRateToolbarComboTests.cs
@@ -1,0 +1,101 @@
+using System.Collections.ObjectModel;
+using System.Globalization;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// The toolbar frame rate combo box used to be hard-coded to the first preset (23.976) at start-up
+/// no matter what the live frame rate was, and a rate outside the preset list - a video with an
+/// unusual rate, or a value restored from settings - selected nothing at all and left the combo box
+/// blank. <see cref="FrameRateHelper.SelectInList"/> owns both cases now.
+/// </summary>
+public class FrameRateToolbarComboTests
+{
+    private static ObservableCollection<string> Presets() => new()
+    {
+        "23.976",
+        "24",
+        "25",
+        "29.97",
+        "30",
+        "50",
+        "59.94",
+        "60",
+        "120",
+    };
+
+    [Theory]
+    [InlineData(23.976, "23.976")]
+    [InlineData(25.0, "25")]
+    [InlineData(29.97, "29.97")]
+    [InlineData(120.0, "120")]
+    public void SelectInList_SelectsPresetWithoutAddingIt(double frameRate, string expected)
+    {
+        var frameRates = Presets();
+
+        var selected = FrameRateHelper.SelectInList(frameRates, frameRate);
+
+        Assert.Equal(expected, selected);
+        Assert.Equal(9, frameRates.Count);
+    }
+
+    [Fact]
+    public void SelectInList_AddsRateThatIsNotAPreset()
+    {
+        var frameRates = Presets();
+
+        var selected = FrameRateHelper.SelectInList(frameRates, 23.98);
+
+        Assert.Equal("23.98", selected);
+        Assert.Equal("23.98", frameRates[0]);
+        Assert.Equal(10, frameRates.Count);
+    }
+
+    [Fact]
+    public void SelectInList_AddsTheSameRateOnlyOnce()
+    {
+        var frameRates = Presets();
+
+        FrameRateHelper.SelectInList(frameRates, 23.98);
+        var selected = FrameRateHelper.SelectInList(frameRates, 23.98);
+
+        Assert.Equal("23.98", selected);
+        Assert.Equal(10, frameRates.Count);
+    }
+
+    // An empty or corrupt setting must not select an empty combo box.
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(-1.0)]
+    public void SelectInList_FallsBackToFirstPresetForNonPositiveRates(double frameRate)
+    {
+        var frameRates = Presets();
+
+        var selected = FrameRateHelper.SelectInList(frameRates, frameRate);
+
+        Assert.Equal("23.976", selected);
+        Assert.Equal(9, frameRates.Count);
+    }
+
+    // The combo box parses the selected item back with the invariant culture, so a Danish (comma
+    // decimal separator) machine must not end up with an unparsable "23,98" item.
+    [Fact]
+    public void SelectInList_UsesInvariantCultureRegardlessOfCurrentCulture()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("da-DK");
+            var frameRates = Presets();
+
+            var selected = FrameRateHelper.SelectInList(frameRates, 23.98);
+
+            Assert.Equal("23.98", selected);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+}

--- a/tests/UI/Logic/Se4FrameRateImportTests.cs
+++ b/tests/UI/Logic/Se4FrameRateImportTests.cs
@@ -1,0 +1,90 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Se4Setup;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// "Set up like Subtitle Edit 4" reads the classic Settings.xml; the frame rate part of it lives in
+/// &lt;General&gt;: ShowFrameRate decides whether the toolbar frame rate combo box is there, and
+/// DefaultFrameRate is the rate SE 4 started at. Both are global settings, so restore them.
+/// </summary>
+public class Se4FrameRateImportTests : IDisposable
+{
+    private readonly bool _originalShowFrameRate = Se.Settings.Appearance.ToolbarShowFrameRate;
+    private readonly double _originalDefaultFrameRate = Se.Settings.General.DefaultFrameRate;
+    private readonly double _originalCurrentFrameRate = Se.Settings.General.CurrentFrameRate;
+    private readonly double _originalLibSeDefaultFrameRate = Configuration.Settings.General.DefaultFrameRate;
+    private readonly double _originalLibSeCurrentFrameRate = Configuration.Settings.General.CurrentFrameRate;
+
+    public void Dispose()
+    {
+        Se.Settings.Appearance.ToolbarShowFrameRate = _originalShowFrameRate;
+        Se.Settings.General.DefaultFrameRate = _originalDefaultFrameRate;
+        Se.Settings.General.CurrentFrameRate = _originalCurrentFrameRate;
+        Configuration.Settings.General.DefaultFrameRate = _originalLibSeDefaultFrameRate;
+        Configuration.Settings.General.CurrentFrameRate = _originalLibSeCurrentFrameRate;
+    }
+
+    private static string SettingsXml(string general) =>
+        $"<Settings><General>{general}</General></Settings>";
+
+    [Fact]
+    public void ApplyFrameRateFromXml_ImportsShowFrameRateAndDefaultFrameRate()
+    {
+        Se.Settings.Appearance.ToolbarShowFrameRate = false;
+        Se.Settings.General.DefaultFrameRate = 23.976;
+        Se.Settings.General.CurrentFrameRate = 23.976;
+
+        Se4SetupApplier.ApplyFrameRateFromXml(null, SettingsXml("<ShowFrameRate>True</ShowFrameRate><DefaultFrameRate>25</DefaultFrameRate>"));
+
+        Assert.True(Se.Settings.Appearance.ToolbarShowFrameRate);
+        Assert.Equal(25, Se.Settings.General.DefaultFrameRate);
+        Assert.Equal(25, Se.Settings.General.CurrentFrameRate);
+        Assert.Equal(25, Configuration.Settings.General.DefaultFrameRate);
+        Assert.Equal(25, Configuration.Settings.General.CurrentFrameRate);
+    }
+
+    [Fact]
+    public void ApplyFrameRateFromXml_KeepsToolbarHiddenWhenSe4HadItHidden()
+    {
+        Se.Settings.Appearance.ToolbarShowFrameRate = true;
+
+        Se4SetupApplier.ApplyFrameRateFromXml(null, SettingsXml("<ShowFrameRate>False</ShowFrameRate>"));
+
+        Assert.False(Se.Settings.Appearance.ToolbarShowFrameRate);
+    }
+
+    // SE 4 wrote the rate with the invariant culture but could read back a locale-mangled value
+    // ("23,976" -> 23976) and clamped it; out-of-range values are ignored here instead.
+    [Theory]
+    [InlineData("23976")]
+    [InlineData("0")]
+    [InlineData("not a number")]
+    [InlineData("")]
+    public void ApplyFrameRateFromXml_IgnoresOutOfRangeDefaultFrameRate(string value)
+    {
+        Se.Settings.General.DefaultFrameRate = 23.976;
+        Se.Settings.General.CurrentFrameRate = 23.976;
+
+        Se4SetupApplier.ApplyFrameRateFromXml(null, SettingsXml($"<DefaultFrameRate>{value}</DefaultFrameRate>"));
+
+        Assert.Equal(23.976, Se.Settings.General.DefaultFrameRate);
+        Assert.Equal(23.976, Se.Settings.General.CurrentFrameRate);
+    }
+
+    [Theory]
+    [InlineData("<Settings><General></General></Settings>")]
+    [InlineData("<Settings></Settings>")]
+    [InlineData("not xml at all")]
+    public void ApplyFrameRateFromXml_LeavesSettingsAloneWhenThereIsNothingToImport(string xml)
+    {
+        Se.Settings.Appearance.ToolbarShowFrameRate = false;
+        Se.Settings.General.DefaultFrameRate = 23.976;
+
+        Se4SetupApplier.ApplyFrameRateFromXml(null, xml);
+
+        Assert.False(Se.Settings.Appearance.ToolbarShowFrameRate);
+        Assert.Equal(23.976, Se.Settings.General.DefaultFrameRate);
+    }
+}


### PR DESCRIPTION
Fixes #13113. Replaces #13281, which added a "Default frame rate" combo box to Options; SE 5 already has SE 4's toolbar frame rate combo box, it just did not work well enough to be used as one.

## What was wrong

The combo box exists behind Options → Appearance → **"Show frame rate"** (`Appearance.ToolbarShowFrameRate`, [InitToolbar.cs:572](https://github.com/SubtitleEdit/subtitleedit/blob/main/src/ui/Features/Main/Layout/InitToolbar.cs#L572)), but:

1. `MainViewModel` seeded it with `FrameRates[0]` — a hard-coded 23.976 — so the rate persisted in `Settings.json` (`General.CurrentFrameRate`) was never shown after a restart, and a rate that is not one of the nine presets (a video reporting 23.98 fps) selected nothing at all and left the combo box blank.
2. SE 4 had a `...` button next to the combo box (`toolStripButtonGetFrameRate`) to read the frame rate out of a video file without opening the video. SE 5 had no equivalent.
3. `SeAppearance` set every other `ToolbarShow*` default explicitly but not `ToolbarShowFrameRate`.
4. "Set up like Subtitle Edit 4" imported shortcuts, replace rules, theme, waveform and toolbar layout — but ignored SE 4's own `General/ShowFrameRate` and `General/DefaultFrameRate`.

## Changes

- **`FrameRateHelper.SelectInList`** — returns the item to select and inserts the rate at the top of the list when it is not a preset (invariant culture, so a Danish machine does not produce an unparsable `23,98`). Used by the start-up seeding, the video-open path and the new button, so all three behave the same.
- **`MainViewModel`** — the combo box is seeded from `Se.Settings.General.CurrentFrameRate` at start-up instead of a hard-coded preset, so the last used frame rate survives a restart (the second option the reporter of #13113 asked for). Opening a video still overrides it with the video's rate.
- **`GetFrameRateFromVideoFile` command + `...` toolbar button** — picks a video file and takes its frame rate (ffmpeg parse on a background thread), without loading it in the player. An unreadable file keeps the current rate, like SE 4.
- **`Se4SetupApplier.ApplyFrameRate`** — imports `General/ShowFrameRate` → `Appearance.ToolbarShowFrameRate` and `General/DefaultFrameRate` → `General.DefaultFrameRate`/`CurrentFrameRate` (plus the libse copies) from the classic `Settings.xml`. Values outside 10–200 fps are ignored: SE 4 wrote the rate invariant but could read back a locale-mangled `23,976` → `23976`, which it clamped. With no `Settings.xml` nothing is applied — SE 4's own defaults (hidden, 23.976) already match SE 5's.
- **`SeAppearance`** — the missing `ToolbarShowFrameRate = false;` default.

`English.json` is generated from the language classes and is deliberately left untouched; `LanguageMainToolbar.GetFrameRateFromVideoFileHint` is the source.

## Not changed

The combo box stays non-editable. SE 4's was `ComboBoxStyle.DropDown` (you could type any rate); making the SE 5 one editable is a separate change and every other frame-rate combo box in the app is a plain list.

## Verification

- `dotnet build src/ui/UI.csproj` — EXIT:0, 0 warnings, 0 errors.
- Full UI test suite: **3084 passed, 0 failed**, including 18 new tests:
  - `tests/UI/Logic/FrameRateToolbarComboTests.cs` — presets select without growing the list, a non-preset rate is added once and selected, non-positive rates fall back to the first preset, invariant formatting under `da-DK`.
  - `tests/UI/Logic/Se4FrameRateImportTests.cs` — `ShowFrameRate`/`DefaultFrameRate` import into both settings stores, hidden stays hidden, out-of-range/garbage/missing values leave the settings alone.
- Manual path: Options → Appearance → "Show frame rate" → the combo box and the `...` button appear on the right of the toolbar; change the rate, restart, and it is still selected; `...` on a 25 fps file selects 25; opening a 29.97 video selects 29.97.

This PR was created with AI assistance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)