### PR TITLE
Fix #13781: STT aborts on batch videos whose audio is not the picked stream

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -906,7 +906,8 @@
       "ssaStylesHint": "Sub Station Alpha styles",
       "webVttStylesHint": "WebVTT style manager",
       "ssaPropertiesHint": "Sub Station Alpha properties",
-      "ssaAttachmentsHint": "Sub Station Alpha attachments"
+      "ssaAttachmentsHint": "Sub Station Alpha attachments",
+      "getFrameRateFromVideoFileHint": "Get frame rate from video file"
     },
     "waveform": {
       "playPauseHint": "Play / Pause {0}",

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -149,6 +149,10 @@ public partial class SpeechToTextViewModel : ObservableObject
     private string? _videoFileName;
     private string _audioFileName = string.Empty;
     private int _audioTrackNumber;
+
+    // The file _audioTrackNumber was picked from. A stream index only means anything in its own
+    // file, and batch mode reuses this view model for other videos - see GetFfmpegProcess.
+    private string? _audioTrackVideoFileName;
     private readonly List<string> _filesToDelete = new();
     private string? _sttTempFolder;
     private readonly ConcurrentQueue<string> _outputText = new();
@@ -4117,6 +4121,35 @@ public partial class SpeechToTextViewModel : ObservableObject
         return (decimal)(TimeCode.ParseToMilliseconds(timeCode) / 1000.0);
     }
 
+    /// <summary>
+    /// The "-map" argument for extracting <paramref name="inputFileName"/>'s audio, or an empty
+    /// string to leave the choice to ffmpeg's automatic stream selection.
+    /// </summary>
+    /// <remarks>
+    /// A stream index only addresses a stream in the file it was read from, so it is applied to
+    /// that file alone: batch mode reuses this view model for other videos, and "transcribe
+    /// selected lines" feeds it already-demuxed "se_audioclip_*.wav" clips.
+    ///
+    /// The trailing "?" (#13621, same fix as in WaveFileExtractor for #10835) only covers stream N
+    /// being *missing* - it does nothing when N exists but is the wrong kind. A file whose audio is
+    /// stream 0 and video stream 1 (ffmpeg lists streams in container order, and plenty of muxers
+    /// put audio first) got "-map 0:1" pointing at its video, which -vn then dropped: "Output file
+    /// does not contain any stream", ffmpeg exit -22, and the run aborted with "Generated audio
+    /// file not found" (#13781). Without a map, ffmpeg picks the best audio stream by itself,
+    /// which is what these inputs want anyway.
+    /// </remarks>
+    internal static string BuildAudioMapParameter(string inputFileName, int audioTrackNumber, string? audioTrackVideoFileName)
+    {
+        if (audioTrackNumber < 0 ||
+            string.IsNullOrEmpty(audioTrackVideoFileName) ||
+            !string.Equals(inputFileName, audioTrackVideoFileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return string.Empty;
+        }
+
+        return $"-map 0:{audioTrackNumber}?";
+    }
+
     private Process? GetFfmpegProcess(string videoFileName, int audioTrackNumber, string outAudioFile, string audioFormat = "wav")
     {
         if (!File.Exists(Se.Settings.General.FfmpegPath) && Configuration.IsRunningOnWindows)
@@ -4124,18 +4157,7 @@ public partial class SpeechToTextViewModel : ObservableObject
             return null;
         }
 
-        // The trailing "?" makes the stream map optional (#13621, same fix as in
-        // WaveFileExtractor for #10835). The track index belongs to the video the user
-        // picked it from, but this method also runs on inputs that never had it: the
-        // already-demuxed "se_audioclip_*.wav" clips from "transcribe selected lines",
-        // and any unrelated file added in batch mode. Without the "?", "-map 0:1" on a
-        // single-stream wav aborts ffmpeg ("Stream map '0:1' matches no streams"); with
-        // it, ffmpeg falls back to automatic stream selection and picks the audio.
-        var audioParameter = string.Empty;
-        if (audioTrackNumber >= 0)
-        {
-            audioParameter = $"-map 0:{audioTrackNumber}?";
-        }
+        var audioParameter = BuildAudioMapParameter(videoFileName, audioTrackNumber, _audioTrackVideoFileName);
 
         var fFmpegAudioTranscodeSettings = GetFfmpegTranscodeFormatString(audioFormat, _useCenterChannelOnly);
 
@@ -4715,6 +4737,7 @@ public partial class SpeechToTextViewModel : ObservableObject
     {
         _videoFileName = videoFileName;
         _audioTrackNumber = audioTrackNumber;
+        _audioTrackVideoFileName = videoFileName;
         TrySelectEngineChoice(preferredEngineChoice);
         if (string.IsNullOrEmpty(_videoFileName) || !File.Exists(_videoFileName))
         {
@@ -4733,6 +4756,10 @@ public partial class SpeechToTextViewModel : ObservableObject
     internal void InitializeBatch(List<AudioClip> audioClips, int audioTrackNumber, bool autoStart, string? language)
     {
         _audioTrackNumber = audioTrackNumber;
+
+        // The clips are already-demuxed single-stream wavs, so the video's stream index does not
+        // address anything in them - leave the owning file unset and let ffmpeg pick the audio.
+        _audioTrackVideoFileName = null;
         IsBatchMode = true;
         _audioClips = audioClips;
         _audioClipsAutoStart = autoStart;

--- a/tests/UI/Features/Video/SpeechToText/SpeechToTextAudioMapTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/SpeechToTextAudioMapTests.cs
@@ -1,0 +1,57 @@
+using Nikse.SubtitleEdit.Features.Video.SpeechToText;
+
+namespace UITests.Features.Video.SpeechToText;
+
+/// <summary>
+/// The audio stream index the user picked belongs to one video. Batch mode reuses the same view
+/// model for other files, and a file whose audio is stream 0 and video stream 1 then got
+/// "-map 0:1" aimed at its video - which -vn dropped, leaving ffmpeg with no streams to write
+/// ("Output file does not contain any stream", exit -22) and the run aborting with "Generated
+/// audio file not found" (#13781). The trailing "?" does not help: stream 1 exists, it is just
+/// the wrong kind.
+/// </summary>
+public class SpeechToTextAudioMapTests
+{
+    private const string Video = @"G:\the-video.mp4";
+
+    [Fact]
+    public void MapsTheChosenTrack_ForTheVideoItWasPickedFrom()
+    {
+        Assert.Equal("-map 0:1?", SpeechToTextViewModel.BuildAudioMapParameter(Video, 1, Video));
+    }
+
+    // Windows paths are case insensitive, and the two strings reach here from different places.
+    [Fact]
+    public void MapsTheChosenTrack_WhenOnlyTheCasingDiffers()
+    {
+        Assert.Equal("-map 0:1?", SpeechToTextViewModel.BuildAudioMapParameter(Video.ToUpperInvariant(), 1, Video));
+    }
+
+    // The reported failure: another video in the batch, where stream 1 is video, not audio.
+    [Fact]
+    public void MapsNothing_ForAnotherFileInTheBatch()
+    {
+        Assert.Equal(string.Empty, SpeechToTextViewModel.BuildAudioMapParameter(@"G:\1.mp4", 1, Video));
+    }
+
+    // "Transcribe selected lines" feeds single-stream wav clips cut from the video.
+    [Fact]
+    public void MapsNothing_ForADemuxedAudioClip()
+    {
+        Assert.Equal(string.Empty, SpeechToTextViewModel.BuildAudioMapParameter(@"C:\Temp\se_audioclip_x.wav", 1, null));
+    }
+
+    // No track picked (no video loaded) - ffmpeg selects the audio itself, as before.
+    [Fact]
+    public void MapsNothing_WhenNoTrackWasChosen()
+    {
+        Assert.Equal(string.Empty, SpeechToTextViewModel.BuildAudioMapParameter(Video, -1, Video));
+    }
+
+    // Track 0 is a real choice, not "unset" - the reporter's file has its audio there.
+    [Fact]
+    public void MapsTrackZero()
+    {
+        Assert.Equal("-map 0:0?", SpeechToTextViewModel.BuildAudioMapParameter(Video, 0, Video));
+    }
+}


### PR DESCRIPTION
Fixes #13781. The user's log has the whole story — the failure is in the **ffmpeg extraction step**, before CrispASR (or any engine) ever runs:

```
Parameters: -i "G:\1.mp4" ... -map 0:1? "...\bb2ae777....wav"
Stream #0:0: Audio: aac ...
Stream #0:1: Video: h264 ...
[out#0/wav] Output file does not contain any stream
ffmpeg exit code: -22
Generated audio file not found: ...
```

## Root cause

`G:\1.mp4` has its streams ordered **audio (0:0) then video (0:1)** — ffmpeg lists streams in container order, and plenty of muxers put audio first. SE remembered stream index 1 as the audio track picked in the main window (correct for *that* video, where 0:1 was the audio) and applied `-map 0:1?` to **every video in the batch**. On this file that selects the H.264 stream, `-vn` drops it, ffmpeg has nothing to write and exits -22, and the run aborts with "Generated audio file not found".

The trailing `?` (added for #13621) only helps when stream N is **missing** — here stream 1 exists, it's just the wrong kind. Reproduced exactly with a synthesized audio-first MP4: `-map 0:1?` → "Output file does not contain any stream"; without the map, ffmpeg auto-selects the audio and the extraction succeeds.

It also explains "some files work fine, but others still abort" on both CrispASR versions — it depends on each file's stream order, not the engine. And it's not new in beta 16; the pattern predates it.

## Fix

The stream index is now applied **only to the file the track was actually picked from** (tracked alongside the index; paths compared case-insensitively for Windows). Every other input — other batch videos, the demuxed `se_audioclip_*.wav` clips from "transcribe selected lines" — gets no `-map`, so ffmpeg's automatic selection picks the best audio stream. The single-video flow with a deliberately chosen track is unchanged.

The mapping decision is extracted into `BuildAudioMapParameter` so it's testable.

## About the CrispASR v0.8.29 half of the report

I A/B'd v0.8.28 vs v0.8.29 on the cohere backend with SE's exact command line — `cohere-transcribe-q4_k.gguf` *and* the full 4.1 GB `cohere-transcribe.gguf`, Metal and `--no-gpu` — all four pairs exit 0 with **byte-identical SRT**. No flags were removed in v0.8.29 and the `cohere` backend listing is unchanged. So I found no engine regression to fix; the reporter's v0.8.29-vs-v0.8.28 difference may need their crispasr log if it persists after this fix.

## Testing

- 6 new tests on `BuildAudioMapParameter`: maps for the owning video (incl. case-differing paths, track 0), empty for another batch file / a demuxed clip / no track picked.
- End-to-end ffmpeg verification of both the failing and fixed command on an audio-first MP4.
- Build clean; full UI suite 3090 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)