### PR TITLE
STT: pin batch/fallback audio extraction to the first audio track

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -3580,7 +3580,7 @@ public partial class SpeechToTextViewModel : ObservableObject
 
         if (_audioTrackNumber < 0)
         {
-            return true; // no track picked - the engine falls back to the first one, exactly like ffmpeg would
+            return true; // no track picked - the engine takes the first audio track, the same one the WAV extraction maps
         }
 
         try
@@ -4122,8 +4122,8 @@ public partial class SpeechToTextViewModel : ObservableObject
     }
 
     /// <summary>
-    /// The "-map" argument for extracting <paramref name="inputFileName"/>'s audio, or an empty
-    /// string to leave the choice to ffmpeg's automatic stream selection.
+    /// The "-map" argument for extracting <paramref name="inputFileName"/>'s audio: the picked
+    /// stream for the file it was picked from, the first audio track for everything else.
     /// </summary>
     /// <remarks>
     /// A stream index only addresses a stream in the file it was read from, so it is applied to
@@ -4135,8 +4135,17 @@ public partial class SpeechToTextViewModel : ObservableObject
     /// stream 0 and video stream 1 (ffmpeg lists streams in container order, and plenty of muxers
     /// put audio first) got "-map 0:1" pointing at its video, which -vn then dropped: "Output file
     /// does not contain any stream", ffmpeg exit -22, and the run aborted with "Generated audio
-    /// file not found" (#13781). Without a map, ffmpeg picks the best audio stream by itself,
-    /// which is what these inputs want anyway.
+    /// file not found" (#13781).
+    ///
+    /// Every other input gets the audio-relative "-map 0:a:0?", which is valid for any stream
+    /// layout. Leaving the choice to ffmpeg's automatic selection is not the same thing: it
+    /// prefers the stream with the default disposition (verified on the bundled ffmpeg 7.1.1 -
+    /// a default-flagged stereo track beats a non-flagged 5.1), while the engines that decode
+    /// the source file themselves take the first audio track in container order - Purfview XXL
+    /// per its author (whisper-standalone-win #185), whisper-ctranslate2 via faster-whisper's
+    /// hardcoded "container.decode(audio=0)". On a file whose default-flagged track is not the
+    /// first, the same batch would transcribe different tracks depending on the engine; mapping
+    /// the first audio track keeps every path on the same one.
     /// </remarks>
     internal static string BuildAudioMapParameter(string inputFileName, int audioTrackNumber, string? audioTrackVideoFileName)
     {
@@ -4144,7 +4153,7 @@ public partial class SpeechToTextViewModel : ObservableObject
             string.IsNullOrEmpty(audioTrackVideoFileName) ||
             !string.Equals(inputFileName, audioTrackVideoFileName, StringComparison.OrdinalIgnoreCase))
         {
-            return string.Empty;
+            return "-map 0:a:0?";
         }
 
         return $"-map 0:{audioTrackNumber}?";

--- a/tests/UI/Features/Video/SpeechToText/SpeechToTextAudioMapTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/SpeechToTextAudioMapTests.cs
@@ -27,25 +27,28 @@ public class SpeechToTextAudioMapTests
         Assert.Equal("-map 0:1?", SpeechToTextViewModel.BuildAudioMapParameter(Video.ToUpperInvariant(), 1, Video));
     }
 
-    // The reported failure: another video in the batch, where stream 1 is video, not audio.
+    // The reported failure: another video in the batch, where stream 1 is video, not audio. The
+    // audio-relative map is valid for any layout, and matches the first-in-container-order track
+    // the source-decoding engines (Purfview XXL, whisper-ctranslate2) pick - ffmpeg's automatic
+    // selection would follow the default disposition instead, which is not always the first track.
     [Fact]
-    public void MapsNothing_ForAnotherFileInTheBatch()
+    public void MapsFirstAudioTrack_ForAnotherFileInTheBatch()
     {
-        Assert.Equal(string.Empty, SpeechToTextViewModel.BuildAudioMapParameter(@"G:\1.mp4", 1, Video));
+        Assert.Equal("-map 0:a:0?", SpeechToTextViewModel.BuildAudioMapParameter(@"G:\1.mp4", 1, Video));
     }
 
     // "Transcribe selected lines" feeds single-stream wav clips cut from the video.
     [Fact]
-    public void MapsNothing_ForADemuxedAudioClip()
+    public void MapsFirstAudioTrack_ForADemuxedAudioClip()
     {
-        Assert.Equal(string.Empty, SpeechToTextViewModel.BuildAudioMapParameter(@"C:\Temp\se_audioclip_x.wav", 1, null));
+        Assert.Equal("-map 0:a:0?", SpeechToTextViewModel.BuildAudioMapParameter(@"C:\Temp\se_audioclip_x.wav", 1, null));
     }
 
-    // No track picked (no video loaded) - ffmpeg selects the audio itself, as before.
+    // No track picked (no video loaded) - first audio track, same as the direct-source engines.
     [Fact]
-    public void MapsNothing_WhenNoTrackWasChosen()
+    public void MapsFirstAudioTrack_WhenNoTrackWasChosen()
     {
-        Assert.Equal(string.Empty, SpeechToTextViewModel.BuildAudioMapParameter(Video, -1, Video));
+        Assert.Equal("-map 0:a:0?", SpeechToTextViewModel.BuildAudioMapParameter(Video, -1, Video));
     }
 
     // Track 0 is a real choice, not "unset" - the reporter's file has its audio there.


### PR DESCRIPTION
Follow-up to #13781/#13784, aligning which audio track every speech-to-text path transcribes on multi-track files.

**The gap:** the no-map fallback from #13781 left stream selection to ffmpeg's automatic choice, which prefers the **default-disposition** track — verified on the bundled ffmpeg 7.1.1, where a default-flagged stereo track beats a non-flagged 5.1. But the two engines that receive the source file directly take the **first audio track in container order**:

- **Purfview Faster-Whisper-XXL**: "It works only on the first audio track" per its author ([whisper-standalone-win #185](https://github.com/Purfview/whisper-standalone-win/discussions/185)); `--ff_track` exists since Apr 2024 but SE doesn't pass it.
- **whisper-ctranslate2**: faster-whisper's `decode_audio` hardcodes `container.decode(audio=0)`. Verified empirically — a two-track mp4 with different speech per track transcribed track 1 even with the default flag on track 2.

So on a file whose default-flagged audio is not the first track, the same batch would transcribe different tracks depending on the engine.

**The fix:** extraction now maps `0:a:0?` for every input the picked stream index does not belong to (batch videos, demuxed `se_audioclip_*.wav` clips, no-track-picked). The audio-relative form is valid for any stream layout, so the #13781 audio-before-video case keeps working — verified against the bundled ffmpeg on three fixtures: default-flag-on-second-track (now picks the first track, matching the engines), audio-first mp4 (no crash), and a plain wav clip. The trailing `?` keeps audio-less files failing the same way as before.

The picked-track path (`-map 0:{n}?` on the file it was picked from) and the source-file gate for XXL/CT2 are unchanged; all 6 `SpeechToTextAudioMapTests` updated and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)