### PR TITLE
Fix #13788: main window stuck on screen when a modal dialog is minimized

### DIFF
--- a/src/ui/Logic/WindowsService.cs
+++ b/src/ui/Logic/WindowsService.cs
@@ -243,6 +243,7 @@ namespace Nikse.SubtitleEdit.Logic
             // on the dialog, not just top-of-z-order drawing (#13325/#13405).
             using var undockedSuspension = SuspendUndockedTopmost();
             var foregroundEnforcement = EnforceModalForegroundWhileOpen(dialog, owner);
+            var minimizeMirror = MirrorMinimizeWithOwner(dialog, owner);
 
             _openModalCount++;
             try
@@ -253,6 +254,7 @@ namespace Nikse.SubtitleEdit.Logic
             finally
             {
                 _openModalCount--;
+                minimizeMirror.Dispose();
                 foregroundEnforcement.Dispose();
             }
         }
@@ -442,7 +444,10 @@ namespace Nikse.SubtitleEdit.Logic
 
             void BounceToDialog()
             {
-                if (!disposed && owner.IsActive && !dialog.IsActive && !dialog.IsClosing())
+                // The minimized check: while the dialog (and via MirrorMinimizeWithOwner the
+                // whole pair) is minimized, activation churn must not pop it back up (#13788).
+                if (!disposed && owner.IsActive && !dialog.IsActive && !dialog.IsClosing() &&
+                    dialog.WindowState != WindowState.Minimized)
                 {
                     dialog.Activate();
                 }
@@ -461,7 +466,8 @@ namespace Nikse.SubtitleEdit.Logic
                 // user is in another application), Activate() still requests attention there.
                 Dispatcher.UIThread.Post(() =>
                 {
-                    if (!disposed && dialog.IsVisible && !dialog.IsActive)
+                    if (!disposed && dialog.IsVisible && !dialog.IsActive &&
+                        dialog.WindowState != WindowState.Minimized)
                     {
                         dialog.Activate();
                     }
@@ -537,6 +543,131 @@ namespace Nikse.SubtitleEdit.Logic
                 owner.RemoveHandler(InputElement.KeyUpEvent, OnOwnerKeyInput);
                 owner.RemoveHandler(InputElement.TextInputEvent, OnOwnerKeyInput);
             });
+        }
+
+        /// <summary>
+        /// Minimizes and restores <paramref name="owner"/> together with <paramref name="dialog"/>
+        /// (and vice versa) for as long as the dialog is open.
+        ///
+        /// A modal's owner is input-disabled, so its own caption buttons are dead - on Windows the
+        /// user can minimize e.g. the batch convert dialog from its taskbar button, and the main
+        /// window then stays on screen, unminimizable, blocking the desktop (#13788). While a
+        /// modal is open the owner is unusable on its own, so minimizing either window means "get
+        /// SubtitleEdit out of my way": the whole pair steps aside, and restoring either brings
+        /// both back. Nested modals cascade naturally - the outer frame's dialog is the inner
+        /// frame's owner. The undocked tool windows are independent (never in the owner chain)
+        /// and deliberately not part of the mirror.
+        /// </summary>
+        private static IDisposable MirrorMinimizeWithOwner(Window dialog, Window owner)
+        {
+            // Guards this frame's own writes: setting one window's state fires its PropertyChanged
+            // synchronously, which must not bounce back as a user action. Other frames of a nested
+            // chain have their own flag and do react - that is what makes the cascade work.
+            var syncing = false;
+
+            // Restore targets. A window is never restored to Minimized; if a state was somehow
+            // captured as such, fall back to Normal.
+            var ownerRestoreState = NonMinimized(owner.WindowState);
+            var dialogRestoreState = NonMinimized(dialog.WindowState);
+
+            // True while the owner's minimize came from this mirror (the user minimized the
+            // dialog) rather than from the user minimizing the owner itself. Decides whether
+            // closing the dialog while minimized should bring the owner back.
+            var ownerMinimizedByMirror = false;
+
+            void OnDialogStateChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
+            {
+                if (e.Property != Window.WindowStateProperty || syncing)
+                {
+                    return;
+                }
+
+                syncing = true;
+                try
+                {
+                    if (dialog.WindowState == WindowState.Minimized)
+                    {
+                        if (owner.WindowState != WindowState.Minimized)
+                        {
+                            ownerRestoreState = owner.WindowState;
+                            owner.WindowState = WindowState.Minimized;
+                            ownerMinimizedByMirror = true;
+                        }
+                    }
+                    else
+                    {
+                        dialogRestoreState = dialog.WindowState;
+                        if (owner.WindowState == WindowState.Minimized)
+                        {
+                            owner.WindowState = ownerRestoreState;
+                        }
+
+                        ownerMinimizedByMirror = false;
+                    }
+                }
+                finally
+                {
+                    syncing = false;
+                }
+            }
+
+            void OnOwnerStateChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
+            {
+                if (e.Property != Window.WindowStateProperty || syncing)
+                {
+                    return;
+                }
+
+                syncing = true;
+                try
+                {
+                    if (owner.WindowState == WindowState.Minimized)
+                    {
+                        if (dialog.WindowState != WindowState.Minimized)
+                        {
+                            dialogRestoreState = dialog.WindowState;
+                            dialog.WindowState = WindowState.Minimized;
+                        }
+                    }
+                    else
+                    {
+                        ownerRestoreState = owner.WindowState;
+                        ownerMinimizedByMirror = false;
+                        if (dialog.WindowState == WindowState.Minimized)
+                        {
+                            dialog.WindowState = dialogRestoreState;
+                        }
+                    }
+                }
+                finally
+                {
+                    syncing = false;
+                }
+            }
+
+            dialog.PropertyChanged += OnDialogStateChanged;
+            owner.PropertyChanged += OnOwnerStateChanged;
+
+            return new ActionDisposable(() =>
+            {
+                dialog.PropertyChanged -= OnDialogStateChanged;
+                owner.PropertyChanged -= OnOwnerStateChanged;
+
+                // The dialog closing while the pair is minimized takes its taskbar button with it;
+                // bring the owner back when this mirror minimized it, so the app does not end up
+                // as a minimized main window the user never asked for (and whose -32000 minimized
+                // position would otherwise be persisted on exit). When the user minimized the
+                // owner itself, their choice is left alone.
+                if (ownerMinimizedByMirror && owner.WindowState == WindowState.Minimized)
+                {
+                    owner.WindowState = ownerRestoreState;
+                }
+            });
+        }
+
+        private static WindowState NonMinimized(WindowState state)
+        {
+            return state == WindowState.Minimized ? WindowState.Normal : state;
         }
 
         // The open modals in open order - the last entry is the top-most dialog, the only window

--- a/tests/UI/Logic/ModalMinimizeMirroringTests.cs
+++ b/tests/UI/Logic/ModalMinimizeMirroringTests.cs
@@ -1,0 +1,193 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Logic;
+
+// A modal's owner is input-disabled, so its own caption buttons are dead - on Windows the user
+// could minimize e.g. the batch convert dialog from its taskbar button, and the main window then
+// stayed on screen, unminimizable, blocking the desktop (#13788). WindowService.ShowModalAsync
+// mirrors minimize/restore between the dialog and its owner: minimizing either sends the whole
+// pair to the taskbar, restoring either brings both back. The undocked tool windows are
+// independent (never in the owner chain) and are not part of the mirror.
+public class ModalMinimizeMirroringTests : IDisposable
+{
+    public ModalMinimizeMirroringTests()
+    {
+        WindowService.ResetUndockedTopmostSuspensionsForTests();
+        WindowService.ResetOpenModalsForTests();
+    }
+
+    public void Dispose()
+    {
+        WindowService.ResetUndockedTopmostSuspensionsForTests();
+        WindowService.ResetOpenModalsForTests();
+    }
+
+    private static (Window Owner, Window Dialog, Task DialogTask) OpenModal(WindowState ownerState = WindowState.Normal)
+    {
+        var owner = new Window { WindowState = ownerState };
+        owner.Show();
+
+        var dialog = new Window();
+        var dialogTask = WindowService.ShowModalAsync(owner, dialog);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(dialog.IsVisible);
+        return (owner, dialog, dialogTask);
+    }
+
+    // Raises the platform activation callback the OS raises when it moves foreground - the
+    // accessors are internal to Avalonia, so go through reflection (same technique as
+    // ModalForegroundEnforcementTests).
+    private static void RaisePlatformEvent(Window window, string callbackName)
+    {
+        var impl = window.PlatformImpl;
+        var property = impl?.GetType()
+            .GetProperties(System.Reflection.BindingFlags.Instance |
+                           System.Reflection.BindingFlags.Public |
+                           System.Reflection.BindingFlags.NonPublic)
+            .FirstOrDefault(p => p.Name == callbackName || p.Name.EndsWith("." + callbackName));
+        Assert.NotNull(property);
+
+        (property.GetValue(impl) as Action)?.Invoke();
+    }
+
+    [AvaloniaFact]
+    public void MinimizingTheDialog_MinimizesTheOwner()
+    {
+        var (owner, dialog, _) = OpenModal();
+
+        dialog.WindowState = WindowState.Minimized;
+
+        Assert.Equal(WindowState.Minimized, owner.WindowState);
+    }
+
+    [AvaloniaFact]
+    public void RestoringTheDialog_RestoresTheOwner()
+    {
+        var (owner, dialog, _) = OpenModal();
+
+        dialog.WindowState = WindowState.Minimized;
+        dialog.WindowState = WindowState.Normal;
+
+        Assert.Equal(WindowState.Normal, owner.WindowState);
+    }
+
+    [AvaloniaFact]
+    public void RestoringTheDialog_RestoresAMaximizedOwnerToMaximized()
+    {
+        var (owner, dialog, _) = OpenModal(WindowState.Maximized);
+
+        dialog.WindowState = WindowState.Minimized;
+        Assert.Equal(WindowState.Minimized, owner.WindowState);
+
+        dialog.WindowState = WindowState.Normal;
+
+        Assert.Equal(WindowState.Maximized, owner.WindowState);
+    }
+
+    [AvaloniaFact]
+    public void MinimizingTheOwner_MinimizesTheDialog()
+    {
+        var (owner, dialog, _) = OpenModal();
+
+        owner.WindowState = WindowState.Minimized;
+
+        Assert.Equal(WindowState.Minimized, dialog.WindowState);
+    }
+
+    [AvaloniaFact]
+    public void RestoringTheOwner_RestoresTheDialog()
+    {
+        var (owner, dialog, _) = OpenModal();
+
+        owner.WindowState = WindowState.Minimized;
+        owner.WindowState = WindowState.Normal;
+
+        Assert.Equal(WindowState.Normal, dialog.WindowState);
+    }
+
+    [AvaloniaFact]
+    public void DialogClosedWhileMinimized_RestoresTheOwner()
+    {
+        var (owner, dialog, dialogTask) = OpenModal();
+
+        // The user minimized the dialog (owner mirror-minimized), then the dialog closes -
+        // e.g. a finished batch job. The dialog's taskbar button is gone, so the owner must
+        // come back rather than stay minimized.
+        dialog.WindowState = WindowState.Minimized;
+        dialog.Close();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(dialogTask.IsCompletedSuccessfully);
+        Assert.Equal(WindowState.Normal, owner.WindowState);
+    }
+
+    [AvaloniaFact]
+    public void DialogClosedAfterTheUserMinimizedTheOwner_LeavesTheOwnerMinimized()
+    {
+        var (owner, dialog, dialogTask) = OpenModal();
+
+        // Here the minimize was the user's explicit action on the owner itself - the close
+        // must not override that choice.
+        owner.WindowState = WindowState.Minimized;
+        dialog.Close();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(dialogTask.IsCompletedSuccessfully);
+        Assert.Equal(WindowState.Minimized, owner.WindowState);
+    }
+
+    [AvaloniaFact]
+    public void NestedModals_MinimizeAndRestoreCascadeThroughTheChain()
+    {
+        var (owner, dialog, _) = OpenModal();
+
+        var topDialog = new Window();
+        _ = WindowService.ShowModalAsync(dialog, topDialog);
+        Dispatcher.UIThread.RunJobs();
+
+        topDialog.WindowState = WindowState.Minimized;
+        Assert.Equal(WindowState.Minimized, dialog.WindowState);
+        Assert.Equal(WindowState.Minimized, owner.WindowState);
+
+        topDialog.WindowState = WindowState.Normal;
+        Assert.Equal(WindowState.Normal, dialog.WindowState);
+        Assert.Equal(WindowState.Normal, owner.WindowState);
+    }
+
+    [AvaloniaFact]
+    public void OwnerActivatedWhileTheDialogIsMinimized_DoesNotPopTheDialogBackUp()
+    {
+        var (owner, dialog, _) = OpenModal();
+
+        dialog.WindowState = WindowState.Minimized;
+
+        // The foreground churn right after the minimize: the OS briefly hands activation to
+        // the owner. The modal foreground enforcement must not answer with dialog.Activate(),
+        // which would restore the window the user just minimized.
+        RaisePlatformEvent(dialog, "Deactivated");
+        RaisePlatformEvent(owner, "Activated");
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.False(dialog.IsActive);
+        Assert.Equal(WindowState.Minimized, dialog.WindowState);
+    }
+
+    [AvaloniaFact]
+    public void MirrorStops_WhenTheDialogCloses()
+    {
+        var (owner, dialog, dialogTask) = OpenModal();
+
+        dialog.Close();
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(dialogTask.IsCompletedSuccessfully);
+
+        // Minimizing the owner after the close must not touch the dead dialog.
+        owner.WindowState = WindowState.Minimized;
+
+        Assert.Equal(WindowState.Normal, dialog.WindowState);
+    }
+}


### PR DESCRIPTION
Fixes #13788.

### Problem
A modal's owner is input-disabled (`EnableWindow(hwnd, FALSE)` on Windows via Avalonia's `SetEnabled`), so the main window's caption buttons are dead while any tool dialog is open. The user could minimize e.g. the batch convert or batch speech-to-text dialog from its own taskbar button — and the main window then stayed on screen, unminimizable, blocking the desktop.

### Fix
While a modal is open the owner is unusable on its own, so minimizing either window can only mean "get SubtitleEdit out of my way". `WindowService.ShowModalAsync` now mirrors minimize/restore between the dialog and its owner for the dialog's lifetime:

- Minimizing the dialog minimizes the owner too; restoring the dialog restores the owner to the state it had (Normal or Maximized).
- Minimizing the owner (possible on platforms where its buttons stay live) minimizes the dialog; restoring the owner restores the dialog.
- Nested modal chains cascade frame by frame (the outer frame's dialog is the inner frame's owner).
- Closing the dialog while the mirror minimized the owner restores the owner — the dialog's taskbar button is the one that just disappeared. An owner the user minimized themselves stays minimized.
- The undocked video/waveform tool windows are independent (never in the owner chain) and are not part of the mirror.

The modal foreground enforcement (#13325/#13405) gets a matching guard: activation churn right after the minimize must not answer with `dialog.Activate()`, which would pop the window the user just minimized back up.

### Tests
New headless suite `ModalMinimizeMirroringTests` (11 tests) covering both mirror directions, Maximized restore, close-while-minimized both ways, nested cascade, the activation-churn guard, and mirror teardown on close. All 12 existing `ModalForegroundEnforcementTests` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
