### PR TITLE
Fix the forward-delete default test for non-macOS CI

### DIFF
--- a/tests/UI/Logic/ShortcutsForwardDeleteMigrationTests.cs
+++ b/tests/UI/Logic/ShortcutsForwardDeleteMigrationTests.cs
@@ -6,9 +6,10 @@ namespace UITests.Logic;
 
 /// <summary>
 /// "Text box: Delete selection (no clipboard)" grew into the forward-delete (Delete key) command
-/// - defaulting to Shift+Backspace so Apple keyboards, whose Delete key is only a backspace, get
-/// a real Delete key. The rename is carried into persisted settings by shortcut migration v2 so
-/// user assignments (including a deliberately cleared binding) survive the upgrade.
+/// - defaulting to Shift+Backspace on macOS only, so Apple keyboards, whose Delete key is only a
+/// backspace, get a real Delete key while PC keyboards keep Shift+Backspace as a backspace. The
+/// rename is carried into persisted settings by shortcut migration v2 so user assignments
+/// (including a deliberately cleared binding) survive the upgrade.
 /// </summary>
 public class ShortcutsForwardDeleteMigrationTests
 {
@@ -16,13 +17,22 @@ public class ShortcutsForwardDeleteMigrationTests
     private const string NewName = nameof(MainViewModel.TextBoxDeleteForwardCommand);
 
     [Fact]
-    public void DefaultBindsShiftBackspaceToForwardDelete()
+    public void ForwardDeleteDefaultsToShiftBackspaceOnMacOsOnly()
     {
         // GetDefaultShortcuts only uses the vm parameter for nameof() - never dereferenced.
         var defaults = ShortcutsMain.GetDefaultShortcuts(null!);
 
-        var forwardDelete = defaults.Single(s => s.ActionName == NewName);
-        Assert.Equal(new[] { "Shift", "Back" }, forwardDelete.Keys);
+        var forwardDelete = defaults.SingleOrDefault(s => s.ActionName == NewName);
+        if (OperatingSystem.IsMacOS())
+        {
+            Assert.Equal(new[] { "Shift", "Back" }, forwardDelete!.Keys);
+        }
+        else
+        {
+            // No default off macOS - the command stays bindable in the shortcuts dialog.
+            Assert.Null(forwardDelete);
+        }
+
         Assert.DoesNotContain(defaults, s => s.ActionName == OldName);
     }
 


### PR DESCRIPTION
`main` is red: `UITests.Logic.ShortcutsForwardDeleteMigrationTests.DefaultBindsShiftBackspaceToForwardDelete` fails with `Sequence contains no matching element` on Linux CI (it also fails on Windows, and passes on macOS).

Cause: `11fc9f294` made the Shift+Backspace forward-delete default macOS-only in `ShortcutsMain.GetDefaultShortcuts`, but the test still asserted the binding unconditionally with `.Single(...)`.

The test now asserts the real per-platform contract — the default exists with Shift+Backspace on macOS, and is absent elsewhere (the command is still registered via `AddShortcut`, so Windows/Linux users can bind it manually) — and is renamed to say so. The other three tests in the file are platform-independent and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)