### PR TITLE
TTS: survive a crashed local server mid-generation (#13572)

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
@@ -404,9 +404,13 @@ public class ChatterboxTtsCpp : ITtsEngine
             // Connection dropped before a response — typically the server crashed
             // during synth (ggml fault, OOM, etc.). Attach what the server printed
             // so the user/we can see the underlying reason.
+            //
+            // Let the process finish dying first: the fatal lines are still travelling through the
+            // async stderr reader when the socket drops, so snapshotting straight away captured a
+            // log that stopped at the last normal line and said nothing about the crash (#13572).
+            var died = await WaitForServerExitAsync(TimeSpan.FromSeconds(2));
             var serverLog = SnapshotServerLog();
             var launchCommand = _serverLaunchCommand;
-            var died = _serverProcess?.HasExited == true;
             if (died)
             {
                 StopServerInternal();
@@ -417,13 +421,28 @@ public class ChatterboxTtsCpp : ITtsEngine
             Se.LogError(ex, failMsg);
             Se.WriteToolsLog(failMsg);
 
-            var prefix = LooksLikeUpstreamChatterboxCrash(serverLog)
-                ? "Chatterbox TTS hit a CrispASR runtime bug during synthesis (ggml tensor read out of bounds). "
-                  + "This is an upstream issue — please file it at https://github.com/CrispStrobe/CrispASR/issues with the server log below. "
-                  + "The crash reproduces on the CPU and Vulkan builds (chatterbox's T3 step runs on CPU regardless of the build); "
-                  + "the CUDA build may avoid it but is unverified."
-                : "Chatterbox TTS request failed — "
-                  + (died ? "the crispasr server crashed during synthesis." : "the connection to the crispasr server was dropped.");
+            string prefix;
+            if (LooksLikeCudaBackendCrash(serverLog))
+            {
+                prefix = "Chatterbox TTS hit a CrispASR bug in the CUDA backend during synthesis "
+                         + "(CUDA error in ggml_cuda_cpy). Switch CrispASR to the Vulkan build - "
+                         + "Video → Audio to text → engine settings → re-download - which does not run "
+                         + "this code path, or generate one voice per run: the reported crashes all land "
+                         + "on the first step after the cloned voice changes between lines. "
+                         + "Please also report it at https://github.com/CrispStrobe/CrispASR/issues with the server log below.";
+            }
+            else if (LooksLikeUpstreamChatterboxCrash(serverLog))
+            {
+                prefix = "Chatterbox TTS hit a CrispASR runtime bug during synthesis (ggml tensor read out of bounds). "
+                         + "This is an upstream issue — please file it at https://github.com/CrispStrobe/CrispASR/issues with the server log below. "
+                         + "The crash reproduces on the CPU and Vulkan builds (chatterbox's T3 step runs on CPU regardless of the build); "
+                         + "the CUDA build does not hit this one, but has a crash of its own (#13572).";
+            }
+            else
+            {
+                prefix = "Chatterbox TTS request failed — "
+                         + (died ? "the crispasr server crashed during synthesis." : "the connection to the crispasr server was dropped.");
+            }
 
             throw new InvalidOperationException(
                 prefix
@@ -630,6 +649,11 @@ public class ChatterboxTtsCpp : ITtsEngine
                 CreateNoWindow = true,
                 RedirectStandardError = true,
                 RedirectStandardOutput = true,
+                // The server writes UTF-8. Without these the reader decodes it in the OS default
+                // codepage, and non-ASCII text in the captured log - the line being synthesised,
+                // upstream's em dashes - reaches bug reports as mojibake (#13572).
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8,
             };
             psi.ArgumentList.Add("--server");
             psi.ArgumentList.Add("--backend");
@@ -779,6 +803,27 @@ public class ChatterboxTtsCpp : ITtsEngine
         return output.Contains("tensor read out of bounds", StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// The CUDA build's own chatterbox synth crash (#13572), distinct from the CPU/Vulkan assert
+    /// above:
+    /// <code>
+    /// chatterbox[ar]: step=0 tok=3704
+    /// CUDA error: invalid argument
+    ///   current device: 0, in function ggml_cuda_cpy at ggml/src/ggml-cuda/cpy.cu:474
+    ///   cudaMemcpyAsync(src1_ddc, src0_ddc, ggml_nbytes(src0), cudaMemcpyDeviceToDevice, main_stream)
+    /// </code>
+    /// Both reports on that issue crash at the first autoregressive step of the request that
+    /// switches to a different cloned voice, right after the new conditionals are installed - and
+    /// a device-to-device copy failing with "invalid argument" is what a buffer that is not device
+    /// memory looks like. Matched on the ggml function name plus the generic "CUDA error" banner so
+    /// a fault in another op is still recognised as a CUDA one.
+    /// </summary>
+    internal static bool LooksLikeCudaBackendCrash(string output)
+    {
+        return output.Contains("CUDA error", StringComparison.Ordinal)
+               || output.Contains("ggml_cuda_cpy", StringComparison.Ordinal);
+    }
+
     internal static bool LooksLikeCloneReferenceRejected(string output)
     {
         // The chatterbox backend clones from the reference WAV natively and only accepts
@@ -891,6 +936,56 @@ public class ChatterboxTtsCpp : ITtsEngine
     /// TTS window closes, so the four CrispASR-based TTS engines don't pile up in VRAM.
     /// </summary>
     public static void StopServer() => StopServerInternal();
+
+    /// <summary>
+    /// Waits up to <paramref name="timeout"/> for a server believed to have crashed to actually
+    /// exit, and for the last of its output to reach <c>_serverLog</c>. Returns whether it exited.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Process.WaitForExitAsync"/> waits for the redirected stdout/stderr readers to
+    /// reach EOF as well as for the process itself - that drain is the whole point here. The crash
+    /// report in #13572 lost the "CUDA error: invalid argument" line that named the fault, because
+    /// the socket dropped a moment before the reader delivered it. Bounded by the token so a
+    /// reader held open by an inherited handle cannot stall a generation run.
+    /// </remarks>
+    private static async Task<bool> WaitForServerExitAsync(TimeSpan timeout)
+    {
+        var p = _serverProcess;
+        if (p == null)
+        {
+            return false;
+        }
+
+        try
+        {
+            using var cts = new CancellationTokenSource(timeout);
+            await p.WaitForExitAsync(cts.Token);
+            return true;
+        }
+        catch (OperationCanceledException)
+        {
+            // Timed out. The process may still have exited with only the drain outstanding, in
+            // which case this is a crash with a possibly-truncated log rather than a live server.
+            return SafeHasExited(p);
+        }
+        catch
+        {
+            // Disposed or never started - nothing to drain.
+            return false;
+        }
+    }
+
+    private static bool SafeHasExited(Process p)
+    {
+        try
+        {
+            return p.HasExited;
+        }
+        catch
+        {
+            return false;
+        }
+    }
 
     private static void StopServerInternal()
     {

--- a/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
@@ -710,6 +710,11 @@ public class CosyVoice3CrispAsr : ITtsEngine
                 CreateNoWindow = true,
                 RedirectStandardError = true,
                 RedirectStandardOutput = true,
+                // The server writes UTF-8. Without these the reader decodes it in the OS default
+                // codepage, and non-ASCII text in the captured log - the line being synthesised,
+                // upstream's em dashes - reaches bug reports as mojibake (#13572).
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8,
             };
             psi.ArgumentList.Add("--server");
             psi.ArgumentList.Add("--backend");

--- a/src/ui/Features/Video/TextToSpeech/Engines/F5TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/F5TtsCrispAsr.cs
@@ -563,6 +563,11 @@ public class F5TtsCrispAsr : ITtsEngine
                 CreateNoWindow = true,
                 RedirectStandardError = true,
                 RedirectStandardOutput = true,
+                // The server writes UTF-8. Without these the reader decodes it in the OS default
+                // codepage, and non-ASCII text in the captured log - the line being synthesised,
+                // upstream's em dashes - reaches bug reports as mojibake (#13572).
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8,
             };
             psi.ArgumentList.Add("--server");
             psi.ArgumentList.Add("--backend");

--- a/src/ui/Features/Video/TextToSpeech/Engines/IndexTts25AudioCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/IndexTts25AudioCpp.cs
@@ -571,6 +571,11 @@ public class IndexTts25AudioCpp : ITtsEngine
                 CreateNoWindow = true,
                 RedirectStandardError = true,
                 RedirectStandardOutput = true,
+                // The server writes UTF-8. Without these the reader decodes it in the OS default
+                // codepage, and non-ASCII text in the captured log - the line being synthesised,
+                // upstream's em dashes - reaches bug reports as mojibake (#13572).
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8,
             };
             psi.ArgumentList.Add("--config");
             psi.ArgumentList.Add(configPath);

--- a/src/ui/Features/Video/TextToSpeech/Engines/IndexTtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/IndexTtsCrispAsr.cs
@@ -544,6 +544,11 @@ public class IndexTtsCrispAsr : ITtsEngine
                 CreateNoWindow = true,
                 RedirectStandardError = true,
                 RedirectStandardOutput = true,
+                // The server writes UTF-8. Without these the reader decodes it in the OS default
+                // codepage, and non-ASCII text in the captured log - the line being synthesised,
+                // upstream's em dashes - reaches bug reports as mojibake (#13572).
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8,
             };
             psi.ArgumentList.Add("--server");
             psi.ArgumentList.Add("--backend");

--- a/src/ui/Features/Video/TextToSpeech/Engines/KokoroTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/KokoroTtsCpp.cs
@@ -319,6 +319,11 @@ public class KokoroTtsCpp : ITtsEngine
                 CreateNoWindow = true,
                 RedirectStandardError = true,
                 RedirectStandardOutput = true,
+                // The server writes UTF-8. Without these the reader decodes it in the OS default
+                // codepage, and non-ASCII text in the captured log - the line being synthesised,
+                // upstream's em dashes - reaches bug reports as mojibake (#13572).
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8,
             };
             psi.ArgumentList.Add("-m");
             psi.ArgumentList.Add(modelPath);

--- a/src/ui/Features/Video/TextToSpeech/Engines/MossTtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/MossTtsCrispAsr.cs
@@ -655,6 +655,11 @@ public class MossTtsCrispAsr : ITtsEngine
                 CreateNoWindow = true,
                 RedirectStandardError = true,
                 RedirectStandardOutput = true,
+                // The server writes UTF-8. Without these the reader decodes it in the OS default
+                // codepage, and non-ASCII text in the captured log - the line being synthesised,
+                // upstream's em dashes - reaches bug reports as mojibake (#13572).
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8,
             };
             psi.ArgumentList.Add("--server");
             psi.ArgumentList.Add("--backend");

--- a/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceCrispAsr.cs
@@ -600,6 +600,11 @@ public class OmniVoiceCrispAsr : ITtsEngine
                 CreateNoWindow = true,
                 RedirectStandardError = true,
                 RedirectStandardOutput = true,
+                // The server writes UTF-8. Without these the reader decodes it in the OS default
+                // codepage, and non-ASCII text in the captured log - the line being synthesised,
+                // upstream's em dashes - reaches bug reports as mojibake (#13572).
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8,
             };
             psi.ArgumentList.Add("--server");
             psi.ArgumentList.Add("--backend");

--- a/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceTtsCpp.cs
@@ -250,6 +250,11 @@ public class OmniVoiceTtsCpp : ITtsEngine
             CreateNoWindow = true,
             RedirectStandardInput = true,
             RedirectStandardOutput = true,
+            // The server writes UTF-8. Without these the reader decodes it in the OS default
+            // codepage, and non-ASCII text in the captured log - the line being synthesised,
+            // upstream's em dashes - reaches bug reports as mojibake (#13572).
+            StandardOutputEncoding = Encoding.UTF8,
+            StandardErrorEncoding = Encoding.UTF8,
             RedirectStandardError = true,
             StandardInputEncoding = Encoding.UTF8,
         };

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCpp.cs
@@ -360,6 +360,11 @@ public class Qwen3TtsCpp : ITtsEngine
                 CreateNoWindow = true,
                 RedirectStandardError = true,
                 RedirectStandardOutput = true,
+                // The server writes UTF-8. Without these the reader decodes it in the OS default
+                // codepage, and non-ASCII text in the captured log - the line being synthesised,
+                // upstream's em dashes - reaches bug reports as mojibake (#13572).
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8,
             };
             psi.ArgumentList.Add("-m");
             psi.ArgumentList.Add(GetSetModelsFolder());

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
@@ -958,6 +958,11 @@ public class Qwen3TtsCrispAsr : ITtsEngine
                 CreateNoWindow = true,
                 RedirectStandardError = true,
                 RedirectStandardOutput = true,
+                // The server writes UTF-8. Without these the reader decodes it in the OS default
+                // codepage, and non-ASCII text in the captured log - the line being synthesised,
+                // upstream's em dashes - reaches bug reports as mojibake (#13572).
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8,
             };
             psi.ArgumentList.Add("--server");
             psi.ArgumentList.Add("--backend");

--- a/src/ui/Features/Video/TextToSpeech/Engines/VibeVoiceCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/VibeVoiceCrispAsr.cs
@@ -525,6 +525,11 @@ public class VibeVoiceCrispAsr : ITtsEngine
                 CreateNoWindow = true,
                 RedirectStandardError = true,
                 RedirectStandardOutput = true,
+                // The server writes UTF-8. Without these the reader decodes it in the OS default
+                // codepage, and non-ASCII text in the captured log - the line being synthesised,
+                // upstream's em dashes - reaches bug reports as mojibake (#13572).
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8,
             };
             psi.ArgumentList.Add("--server");
             psi.ArgumentList.Add("--backend");

--- a/src/ui/Features/Video/TextToSpeech/Engines/VoxCPM2CrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/VoxCPM2CrispAsr.cs
@@ -600,6 +600,11 @@ public class VoxCPM2CrispAsr : ITtsEngine
                 CreateNoWindow = true,
                 RedirectStandardError = true,
                 RedirectStandardOutput = true,
+                // The server writes UTF-8. Without these the reader decodes it in the OS default
+                // codepage, and non-ASCII text in the captured log - the line being synthesised,
+                // upstream's em dashes - reaches bug reports as mojibake (#13572).
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8,
             };
             psi.ArgumentList.Add("--server");
             psi.ArgumentList.Add("--backend");

--- a/src/ui/Features/Video/TextToSpeech/Engines/ZonosTtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ZonosTtsCrispAsr.cs
@@ -506,6 +506,11 @@ public class ZonosTtsCrispAsr : ITtsEngine
                 CreateNoWindow = true,
                 RedirectStandardError = true,
                 RedirectStandardOutput = true,
+                // The server writes UTF-8. Without these the reader decodes it in the OS default
+                // codepage, and non-ASCII text in the captured log - the line being synthesised,
+                // upstream's em dashes - reaches bug reports as mojibake (#13572).
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8,
             };
             psi.ArgumentList.Add("--server");
             psi.ArgumentList.Add("--backend");

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -2560,6 +2560,7 @@ public partial class TextToSpeechViewModel : ObservableObject
             // Distinct failure reasons reported by the engines, so the dialogs below can say *why*
             // segments failed (e.g. the ElevenLabs 429 text) instead of a bare count (#12093).
             var errorMessages = new List<string>();
+            _speakRetryFailures = 0;
 
             for (var index = 0; index < _subtitle.Paragraphs.Count; index++)
             {
@@ -2582,11 +2583,8 @@ public partial class TextToSpeechViewModel : ObservableObject
                 // the row's engine isn't CrispASR-backed. Off the UI thread because Kill +
                 // WaitForExit can take a few seconds per stuck process.
                 await Task.Run(() => StopOtherCrispAsrServers(resolution.Engine));
-                var speakResult = await TtsInstructionSwap.RunAsync(
-                    resolution.Engine,
-                    resolution.Instruction,
-                    () => resolution.Engine.Speak(resolution.Text, _waveFolder, resolution.Voice,
-                        language, region, model, cancellationToken));
+                var speakResult = await SpeakOneParagraphAsync(
+                    resolution, language, region, model, cancellationToken);
                 if (speakResult.Error && !string.IsNullOrEmpty(speakResult.ErrorMessage) && !errorMessages.Contains(speakResult.ErrorMessage))
                 {
                     errorMessages.Add(speakResult.ErrorMessage);
@@ -2611,6 +2609,18 @@ public partial class TextToSpeechViewModel : ObservableObject
                 if (cancellationToken.IsCancellationRequested)
                 {
                     return null;
+                }
+
+                // Surviving a crash mid-batch (see SpeakOneParagraphAsync) is worth it because
+                // there is finished work to save. When nothing has succeeded yet and the engine has
+                // now failed a retry twice in a row, it is not crashing - it is not working at all
+                // (missing executable, bad settings), and grinding through the remaining lines only
+                // delays the same error. Stop here; the "failed for all segments" report below
+                // names the reason.
+                if (_speakRetryFailures >= 2 && resultList.TrueForAll(r => string.IsNullOrEmpty(r.CurrentFileName)))
+                {
+                    SeLogger.Error($"TextToSpeech: giving up after {resultList.Count} segments - the engine failed every attempt.");
+                    break;
                 }
             }
             ProgressValue = 100;
@@ -2715,6 +2725,82 @@ public partial class TextToSpeechViewModel : ObservableObject
                 }
             });
             return null;
+        }
+    }
+
+    /// <summary>
+    /// Number of retries in <see cref="SpeakOneParagraphAsync"/> that failed in a row. Reset at the
+    /// start of every generation run.
+    /// </summary>
+    private int _speakRetryFailures;
+
+    /// <summary>
+    /// Synthesises one paragraph, turning an engine that *throws* into an errored
+    /// <see cref="TtsResult"/> instead of letting the failure unwind the whole run.
+    /// </summary>
+    /// <remarks>
+    /// A local-server engine can die in the middle of a batch: CrispASR's chatterbox backend
+    /// crashes on the CUDA build at the first autoregressive step after a voice change (#13572).
+    /// That arrived here as an exception, escaped the generate loop into its catch-all, and
+    /// returned null - so every segment already synthesised (five to ten minutes of work in that
+    /// report) was discarded because of one bad line. Now the line is recorded as failed and the
+    /// run continues; the existing "N of M segments failed - continue?" prompt reports it.
+    ///
+    /// One retry per line, because the engines stop their crashed server on the way out, so the
+    /// retry's Speak() starts a fresh one and a transient crash costs nothing. Retrying stops once
+    /// two retries in a row have also failed: that is a broken engine rather than a transient
+    /// crash, and there is no point paying for a second attempt on every remaining line.
+    /// </remarks>
+    private async Task<TtsResult> SpeakOneParagraphAsync(
+        ResolvedVoice resolution,
+        TtsLanguage? language,
+        string? region,
+        string? model,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await TtsInstructionSwap.RunAsync(
+                resolution.Engine,
+                resolution.Instruction,
+                () => resolution.Engine.Speak(resolution.Text, _waveFolder, resolution.Voice,
+                    language, region, model, cancellationToken));
+        }
+        catch (OperationCanceledException)
+        {
+            throw; // user cancel - not a segment failure
+        }
+        catch (Exception ex)
+        {
+            SeLogger.Error(ex, $"TextToSpeech: engine '{resolution.Engine.Name}' threw while generating a segment.");
+            Se.WriteToolsLog($"TTS generation: engine '{resolution.Engine.Name}' failed on a segment - {ex.Message}", true);
+
+            if (_speakRetryFailures >= 2)
+            {
+                return new TtsResult { Error = true, ErrorMessage = ex.Message };
+            }
+
+            try
+            {
+                var retried = await TtsInstructionSwap.RunAsync(
+                    resolution.Engine,
+                    resolution.Instruction,
+                    () => resolution.Engine.Speak(resolution.Text, _waveFolder, resolution.Voice,
+                        language, region, model, cancellationToken));
+                _speakRetryFailures = 0;
+                Se.WriteToolsLog("TTS generation: the segment succeeded on retry");
+                return retried;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception retryException)
+            {
+                _speakRetryFailures++;
+                SeLogger.Error(retryException, $"TextToSpeech: engine '{resolution.Engine.Name}' threw again on retry.");
+                return new TtsResult { Error = true, ErrorMessage = retryException.Message };
+            }
         }
     }
 

--- a/tests/UI/Features/Video/TextToSpeech/Engines/ChatterboxTtsCppTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/ChatterboxTtsCppTests.cs
@@ -300,6 +300,20 @@ public class ChatterboxTtsCppTests
         Assert.Equal(expected, ChatterboxTtsCpp.LooksLikeCloneReferenceRejected(serverLog));
     }
 
+    [Theory]
+    // Verbatim from the crash in #13572 - the CUDA build dying at the first AR step of the
+    // request that switches cloned voice.
+    [InlineData("chatterbox[ar]: step=0 tok=3704\nCUDA error: invalid argument\n  current device: 0, in function ggml_cuda_cpy at D:\\a\\CrispASR\\CrispASR\\ggml\\src\\ggml-cuda\\cpy.cu:474", true)]
+    // A CUDA fault in another op still counts: the advice (use the Vulkan build) is the same.
+    [InlineData("CUDA error: out of memory", true)]
+    // The CPU/Vulkan assert is a different bug with different advice - it must not match here.
+    [InlineData("ggml-backend.cpp:349: GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && \"tensor read out of bounds\") failed", false)]
+    [InlineData("crispasr-server: synthesized 13.4s audio in 6.87s (RTF=0.51)", false)]
+    public void LooksLikeCudaBackendCrash_MatchesOnlyTheCudaFault(string serverLog, bool expected)
+    {
+        Assert.Equal(expected, ChatterboxTtsCpp.LooksLikeCudaBackendCrash(serverLog));
+    }
+
     [Fact]
     public void RemoveSupersededBaseModels_DeletesTheUnversionedBasePairOnly()
     {


### PR DESCRIPTION
Follow-up to the crash reports on #13572, where CrispASR's chatterbox backend dies mid-batch on the CUDA build. The crash itself is upstream; everything here is what SE does around it.

## What changed

**1. A crashed engine no longer discards the whole run.** `Speak` throwing unwound the generate loop into its catch-all, which returned `null` — so every segment already synthesised was thrown away over one bad line (five to ten minutes of work, per the report). Paragraphs now go through `SpeakOneParagraphAsync`, which records a thrown failure as a failed segment and lets the run finish into the existing "N of M segments failed — continue?" prompt.

One retry per line first: the engines stop their crashed server on the way out, so the retry's `Speak` starts a fresh one and a transient crash costs nothing. Retrying stops after two retries in a row fail — that is a broken engine, not a crashing one — and if nothing has succeeded at all by then the run stops instead of grinding through the remaining lines, so a missing executable or bad settings still fails fast.

**2. The crash log now contains the crash.** The failure handler snapshotted the server log before the process had finished dying, so the fatal lines were still in flight in the async stderr reader. The newest report ends at `chatterbox[ar]: step=0 tok=3704` with nothing after it; the cause (`CUDA error: invalid argument` in `ggml_cuda_cpy`) only appeared in an earlier report. It now waits — bounded — for exit and for the readers to drain first.

**3. That CUDA fault is recognised.** Users got the bare "the crispasr server crashed during synthesis". They now get the two things that help: switch CrispASR to the Vulkan build, or keep one cloned voice per run — both reported crashes land on the first autoregressive step of the request that switches cloned voice, right after the new conditionals are installed. The neighbouring ggml-assert message also had a stale claim that the CUDA build "may avoid it but is unverified"; it avoids that one and has this one instead.

**4. Server output is read as UTF-8** across the local-server TTS engines. Without it the log is decoded in the OS default codepage, which is why the Russian line under synthesis reached the issue as `Р‘СѓРґСЊ С‚РѕМЃ ...`. Log-only — the request payload was always UTF-8, and the generated audio was never affected.

## Not addressed here

The CUDA crash itself (upstream, [CrispStrobe/CrispASR](https://github.com/CrispStrobe/CrispASR/issues)) and the need to hand-place Russian stress marks — Chatterbox multilingual V3 has no stress prediction, so that is a model limitation rather than something SE can correct.

## Testing

`dotnet build` clean; 258 TTS tests pass, including four new cases pinning the CUDA matcher against the verbatim crash text and keeping it distinct from the CPU/Vulkan assert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)