### PR TITLE
Show the subtitle on the video in the sync dialogs

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -257,6 +257,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<IThemeInitializer, ThemeInitializer>();
         collection.AddTransient<ITtsDownloadService, TtsDownloadService>();
         collection.AddTransient<IUndoRedoManager, UndoRedoManager>();
+        collection.AddTransient<IVideoPreviewSubtitle, VideoPreviewSubtitle>();
         collection.AddTransient<IVlcReloader, VlcReloader>();
         collection.AddTransient<IWindowService, WindowService>();
         collection.AddTransient<IZipUnpacker, ZipUnpacker>();

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -10361,6 +10361,16 @@ public partial class MainViewModel :
         });
     }
 
+    /// <summary>
+    /// What the sync dialogs need to draw the subtitle on their own video the way it is drawn on
+    /// the main one (discussion #13767) - they only get line view models, which carry neither the
+    /// header nor the timing mode.
+    /// </summary>
+    private VideoPreviewSubtitleContext MakeVideoPreviewSubtitleContext()
+    {
+        return new VideoPreviewSubtitleContext(SelectedSubtitleFormat, _subtitle.Header, IsSmpteTimingEnabled);
+    }
+
     [RelayCommand]
     private async Task ShowVisualSync()
     {
@@ -10378,7 +10388,7 @@ public partial class MainViewModel :
         var result = await ShowDialogAsync<VisualSyncWindow, VisualSyncViewModel>(vm =>
         {
             var paragraphs = Subtitles.Select(p => new SubtitleLineViewModel(p)).ToList();
-            vm.Initialize(paragraphs, _videoFileName, _subtitleFileName, AudioVisualizer, _audioTrack?.Id ?? -1);
+            vm.Initialize(paragraphs, _videoFileName, _subtitleFileName, MakeVideoPreviewSubtitleContext(), AudioVisualizer, _audioTrack?.Id ?? -1);
         });
 
         if (result.OkPressed)
@@ -10414,7 +10424,7 @@ public partial class MainViewModel :
         var result = await ShowDialogAsync<VisualSyncWindow, VisualSyncViewModel>(vm =>
         {
             var paragraphs = selectedLines.Select(p => new SubtitleLineViewModel(p)).ToList();
-            vm.Initialize(paragraphs, _videoFileName, _subtitleFileName, AudioVisualizer, _audioTrack?.Id ?? -1);
+            vm.Initialize(paragraphs, _videoFileName, _subtitleFileName, MakeVideoPreviewSubtitleContext(), AudioVisualizer, _audioTrack?.Id ?? -1);
         });
 
         if (!result.OkPressed)
@@ -10510,7 +10520,7 @@ public partial class MainViewModel :
         {
             var selectedItems = SubtitleGridSelectedItems.Cast<SubtitleLineViewModel>().ToList();
             var paragraphs = Subtitles.Select(p => new SubtitleLineViewModel(p)).ToList();
-            vm.Initialize(paragraphs, selectedItems, _videoFileName ?? string.Empty, _subtitleFileName ?? string.Empty, AudioVisualizer);
+            vm.Initialize(paragraphs, selectedItems, _videoFileName ?? string.Empty, _subtitleFileName ?? string.Empty, MakeVideoPreviewSubtitleContext(), AudioVisualizer);
         });
 
         if (result.OkPressed)
@@ -10544,7 +10554,7 @@ public partial class MainViewModel :
         var result = await ShowDialogAsync<PointSyncViaOtherWindow, PointSyncViaOtherViewModel>(vm =>
         {
             var paragraphs = Subtitles.Select(p => new SubtitleLineViewModel(p)).ToList();
-            vm.Initialize(paragraphs, _videoFileName ?? string.Empty, _subtitleFileName ?? string.Empty);
+            vm.Initialize(paragraphs, _videoFileName ?? string.Empty, _subtitleFileName ?? string.Empty, MakeVideoPreviewSubtitleContext());
         });
 
         if (result.OkPressed)

--- a/src/ui/Features/Sync/PointSync/PointSyncViewModel.cs
+++ b/src/ui/Features/Sync/PointSync/PointSyncViewModel.cs
@@ -45,6 +45,9 @@ public partial class PointSyncViewModel : ObservableObject
     private string _videoFileName;
     private AudioVisualizer? _audioVisualizer;
 
+    // Only passed on to "Set sync point", which draws the subtitle on its video (#13767).
+    private VideoPreviewSubtitleContext _previewContext = VideoPreviewSubtitleContext.Default;
+
     public PointSyncViewModel(IFileHelper fileHelper, IWindowService windowService)
     {
         _fileHelper = fileHelper;
@@ -61,8 +64,9 @@ public partial class PointSyncViewModel : ObservableObject
     public void Initialize(
         List<SubtitleLineViewModel> subtitles,
         List<SubtitleLineViewModel> selectedSubtitles,
-        string videoFileName, 
-        string fileName, 
+        string videoFileName,
+        string fileName,
+        VideoPreviewSubtitleContext previewContext,
         AudioVisualizer? audioVisualizer)
     {
         Subtitles.Clear();
@@ -70,6 +74,7 @@ public partial class PointSyncViewModel : ObservableObject
         FileName = fileName;
         _videoFileName = videoFileName;
         _audioVisualizer = audioVisualizer;
+        _previewContext = previewContext;
 
         if (Subtitles.Count > 0)
         {
@@ -93,7 +98,7 @@ public partial class PointSyncViewModel : ObservableObject
 
         var result = await _windowService.ShowDialogAsync<SetSyncPointWindow, SetSyncPointViewModel>(Window, vm =>
         {
-            vm.Initialize(Subtitles.ToList(), SelectedSubtitle, _videoFileName, FileName, _audioVisualizer);
+            vm.Initialize(Subtitles.ToList(), SelectedSubtitle, _videoFileName, FileName, _previewContext, _audioVisualizer);
         });
 
         // Keep a video opened (or found) in there, so the next sync point starts with it loaded -

--- a/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointViewModel.cs
+++ b/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointViewModel.cs
@@ -7,6 +7,7 @@ using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Controls;
 using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
 using Nikse.SubtitleEdit.Controls.VideoPlayer;
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Shared.FindText;
 using Nikse.SubtitleEdit.Logic;
@@ -58,18 +59,21 @@ public partial class SetSyncPointViewModel : ObservableObject
 
     private readonly IWindowService _windowService;
     private readonly IFileHelper _fileHelper;
+    private readonly IVideoPreviewSubtitle _previewSubtitle;
 
     private string? _videoFileName;
     private DispatcherTimer _positionTimer = new DispatcherTimer();
     private List<SubtitleLineViewModel> _subtitleLines = new List<SubtitleLineViewModel>();
+    private VideoPreviewSubtitleContext _previewContext = VideoPreviewSubtitleContext.Default;
     private bool _updateAudioVisualizer;
     private bool _updateTimeCodeFromVideo;
     private bool _timeCodeUpDownFocused;
 
-    public SetSyncPointViewModel(IWindowService windowService, IFileHelper fileHelper)
+    public SetSyncPointViewModel(IWindowService windowService, IFileHelper fileHelper, IVideoPreviewSubtitle previewSubtitle)
     {
         _windowService = windowService;
         _fileHelper = fileHelper;
+        _previewSubtitle = previewSubtitle;
 
         Title = string.Empty;
         VideoInfo = string.Empty;
@@ -90,10 +94,14 @@ public partial class SetSyncPointViewModel : ObservableObject
         SubtitleLineViewModel? selectedSubtitle,
         string? videoFileName,
         string? subtitleFileName,
+        VideoPreviewSubtitleContext previewContext,
         AudioVisualizer? audioVisualizer)
     {
         Paragraphs = new ObservableCollection<SubtitleDisplayItem>(paragraphs.Select(p => new SubtitleDisplayItem(p)));
         _subtitleLines = paragraphs;
+
+        // Carried in so the subtitle drawn on the video looks like the one on the main window's video.
+        _previewContext = previewContext;
 
         // Only a video the caller already had, or one the user picks here, is reported back - a
         // video merely found on disk must not travel up and open in the main window, which would
@@ -188,6 +196,8 @@ public partial class SetSyncPointViewModel : ObservableObject
         {
             UpdateAudioVisualizer(VideoPlayerControl.VideoPlayer, AudioVisualizer, SelectedParagraphIndex);
 
+            RefreshPreviewSubtitle();
+
             // Follow the video position - but leave the time code alone while the user is typing
             // in it (a running video moves on its own, so then the box should still follow).
             // With no video there is nothing to follow and the box is the only input, so the
@@ -205,6 +215,26 @@ public partial class SetSyncPointViewModel : ObservableObject
             }
         };
         _positionTimer.Start();
+    }
+
+    /// <summary>
+    /// The player gets the whole subtitle, so it shows whatever line belongs at the frame it is
+    /// parked on - the point of scrubbing to a scene here (discussion #13767).
+    /// </summary>
+    internal void RefreshPreviewSubtitle()
+    {
+        _previewSubtitle.Refresh(VideoPlayerControl.VideoPlayer, BuildPreviewSubtitle, _previewContext);
+    }
+
+    private Subtitle BuildPreviewSubtitle()
+    {
+        var subtitle = new Subtitle { Header = _previewContext.Header };
+        foreach (var p in Paragraphs)
+        {
+            subtitle.Paragraphs.Add(p.Subtitle.ToParagraph(_previewContext.Format));
+        }
+
+        return subtitle;
     }
 
     private void UpdateAudioVisualizer(
@@ -372,6 +402,10 @@ public partial class SetSyncPointViewModel : ObservableObject
         await VideoPlayerControl.Open(fileName, Math.Max(0, syncPoint.TotalSeconds));
         await VideoPlayerControl.WaitForPlayersReadyAsync();
 
+        // The external subtitle went with the old file (if there was one) - it has to be added to
+        // the new one from scratch, not reloaded into a track that is no longer there.
+        _previewSubtitle.Reset();
+
         // Only now does the player own the sync point - handing it over any earlier would let the
         // timer copy the still-zero position into the time code while the file is loading.
         _videoFileName = fileName;
@@ -447,6 +481,9 @@ public partial class SetSyncPointViewModel : ObservableObject
         UiUtil.SaveWindowPosition(Window);
         _positionTimer.Stop();
         VideoPlayerControl.VideoPlayer.CloseFile();
+
+        // Deletes the temp subtitle file handed to the player.
+        _previewSubtitle.Reset();
     }
 
     [RelayCommand]

--- a/src/ui/Features/Sync/PointSyncViaOther/PointSyncViaOtherViewModel.cs
+++ b/src/ui/Features/Sync/PointSyncViaOther/PointSyncViaOtherViewModel.cs
@@ -53,6 +53,9 @@ public partial class PointSyncViaOtherViewModel : ObservableObject
     private string _videoFileName;
     private List<SubtitleLineViewModel> _originalSubtitles;
 
+    // Only passed on to "Set sync point via video", which draws the subtitle on its video (#13767).
+    private VideoPreviewSubtitleContext _previewContext = VideoPreviewSubtitleContext.Default;
+
     public PointSyncViaOtherViewModel(IFileHelper fileHelper, IWindowService windowService)
     {
         _fileHelper = fileHelper;
@@ -68,13 +71,14 @@ public partial class PointSyncViaOtherViewModel : ObservableObject
         _originalSubtitles = new List<SubtitleLineViewModel>();
     }
 
-    public void Initialize(List<SubtitleLineViewModel> subtitles, string videoFileName, string fileName)
+    public void Initialize(List<SubtitleLineViewModel> subtitles, string videoFileName, string fileName, VideoPreviewSubtitleContext previewContext)
     {
         Subtitles.Clear();
         Subtitles.AddRange(subtitles);
         _originalSubtitles = subtitles.Select(s => new SubtitleLineViewModel(s)).ToList();
         FileName = fileName;
         _videoFileName = videoFileName;
+        _previewContext = previewContext;
 
         if (Subtitles.Count > 0)
         {
@@ -227,7 +231,7 @@ public partial class PointSyncViaOtherViewModel : ObservableObject
 
         var result = await _windowService.ShowDialogAsync<SetSyncPointWindow, SetSyncPointViewModel>(Window, vm =>
         {
-            vm.Initialize(Subtitles.ToList(), left, _videoFileName, FileName, null);
+            vm.Initialize(Subtitles.ToList(), left, _videoFileName, FileName, _previewContext, null);
         });
 
         // Keep a video opened (or found) in there - also when the dialog was cancelled.

--- a/src/ui/Features/Sync/VisualSync/VisualSyncViewModel.cs
+++ b/src/ui/Features/Sync/VisualSync/VisualSyncViewModel.cs
@@ -5,6 +5,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
 using Nikse.SubtitleEdit.Controls.VideoPlayer;
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Features.Shared.FindText;
@@ -45,18 +46,30 @@ public partial class VisualSyncViewModel : ObservableObject
     private readonly IWindowService _windowService;
     private readonly IFileHelper _fileHelper;
 
+    // One per player: each keeps the temp subtitle file it handed to its own player, so a shared
+    // instance would have the two players overwriting each other's file.
+    private readonly IVideoPreviewSubtitle _previewSubtitleLeft;
+    private readonly IVideoPreviewSubtitle _previewSubtitleRight;
+
     private string? _videoFileName;
     private string? _wavePeaksVideoFileName;
     private DispatcherTimer _positionTimer = new DispatcherTimer();
     private List<SubtitleLineViewModel> _subtitleLines = new List<SubtitleLineViewModel>();
+    private VideoPreviewSubtitleContext _previewContext = VideoPreviewSubtitleContext.Default;
     private bool _updateAudioVisualizer;
     private double _lastManualOffsetSeconds;
     private double _lastManualSpeedFactor = 1.0;
 
-    public VisualSyncViewModel(IWindowService windowService, IFileHelper fileHelper)
+    public VisualSyncViewModel(
+        IWindowService windowService,
+        IFileHelper fileHelper,
+        IVideoPreviewSubtitle previewSubtitleLeft,
+        IVideoPreviewSubtitle previewSubtitleRight)
     {
         _windowService = windowService;
         _fileHelper = fileHelper;
+        _previewSubtitleLeft = previewSubtitleLeft;
+        _previewSubtitleRight = previewSubtitleRight;
 
         Title = string.Empty;
         VideoInfo = string.Empty;
@@ -89,6 +102,7 @@ public partial class VisualSyncViewModel : ObservableObject
         List<SubtitleLineViewModel> paragraphs,
         string? videoFileName,
         string? subtitleFileName,
+        VideoPreviewSubtitleContext previewContext,
         AudioVisualizer? audioVisualizer,
         int audioTrackId = -1)
     {
@@ -108,6 +122,10 @@ public partial class VisualSyncViewModel : ObservableObject
         Paragraphs = new ObservableCollection<SubtitleDisplayItem>(paragraphs.Select(p => new SubtitleDisplayItem(p)));
         _videoFileName = videoFileName;
         _subtitleLines = paragraphs;
+
+        // Carried in so the subtitle drawn on the two videos looks like the one on the main
+        // window's video.
+        _previewContext = previewContext;
 
         Dispatcher.UIThread.Post(() =>
         {
@@ -188,6 +206,8 @@ public partial class VisualSyncViewModel : ObservableObject
             UpdateAudioVisualizer(VideoPlayerControlLeft.VideoPlayer, AudioVisualizerLeft, SelectedParagraphLeftIndex);
             UpdateAudioVisualizer(VideoPlayerControlRight.VideoPlayer, AudioVisualizerRight, SelectedParagraphRightIndex);
 
+            RefreshPreviewSubtitles();
+
             if (_updateAudioVisualizer)
             {
                 AudioVisualizerLeft.InvalidateVisual();
@@ -196,6 +216,31 @@ public partial class VisualSyncViewModel : ObservableObject
             }
         };
         _positionTimer.Start();
+    }
+
+    /// <summary>
+    /// Both players get the whole subtitle, so each shows whatever line belongs at the frame it is
+    /// parked on - which is the comparison visual sync is for (discussion #13767).
+    /// </summary>
+    internal void RefreshPreviewSubtitles()
+    {
+        _previewSubtitleLeft.Refresh(VideoPlayerControlLeft.VideoPlayer, BuildPreviewSubtitle, _previewContext);
+        _previewSubtitleRight.Refresh(VideoPlayerControlRight.VideoPlayer, BuildPreviewSubtitle, _previewContext);
+    }
+
+    /// <summary>
+    /// The lines as they stand right now - "Sync" adjusts them in place, so the subtitle on the
+    /// videos follows the new time codes just as SE4's did.
+    /// </summary>
+    private Subtitle BuildPreviewSubtitle()
+    {
+        var subtitle = new Subtitle { Header = _previewContext.Header };
+        foreach (var p in Paragraphs)
+        {
+            subtitle.Paragraphs.Add(p.Subtitle.ToParagraph(_previewContext.Format));
+        }
+
+        return subtitle;
     }
 
     private void UpdateAudioVisualizer(
@@ -424,7 +469,7 @@ public partial class VisualSyncViewModel : ObservableObject
         ApplySync(result.SpeedFactor, result.OffsetSeconds);
     }
 
-    private void ApplySync(double factor, double adjust)
+    internal void ApplySync(double factor, double adjust)
     {
         if (Math.Abs(factor) < 0.000001)
         {
@@ -453,6 +498,10 @@ public partial class VisualSyncViewModel : ObservableObject
                 current.EndTime = TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds - 1);
             }
         }
+
+        // The time codes moved, so the subtitle on both videos has to be pushed again.
+        _previewSubtitleLeft.Invalidate();
+        _previewSubtitleRight.Invalidate();
 
         _updateAudioVisualizer = true;
     }
@@ -519,6 +568,10 @@ public partial class VisualSyncViewModel : ObservableObject
         _positionTimer.Stop();
         VideoPlayerControlLeft.VideoPlayer.CloseFile();
         VideoPlayerControlRight.VideoPlayer.CloseFile();
+
+        // Deletes the temp subtitle files handed to the two players.
+        _previewSubtitleLeft.Reset();
+        _previewSubtitleRight.Reset();
     }
 
     [RelayCommand]
@@ -614,6 +667,11 @@ public partial class VisualSyncViewModel : ObservableObject
         await OpenPlayersAsync(fileName, -1);
         await VideoPlayerControlLeft.WaitForPlayersReadyAsync();
         await VideoPlayerControlRight.WaitForPlayersReadyAsync();
+
+        // The external subtitle went with the old file - it has to be added to the new one from
+        // scratch, not reloaded into a track that is no longer there.
+        _previewSubtitleLeft.Reset();
+        _previewSubtitleRight.Reset();
 
         // Land the players on the scenes already picked in the combo boxes (OnLoaded seeds them
         // to the first/last line even without a video), instead of both sitting at zero.

--- a/src/ui/Logic/Media/IVideoPreviewSubtitle.cs
+++ b/src/ui/Logic/Media/IVideoPreviewSubtitle.cs
@@ -1,0 +1,12 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic.VideoPlayers;
+using System;
+
+namespace Nikse.SubtitleEdit.Logic.Media;
+
+public interface IVideoPreviewSubtitle
+{
+    void Refresh(IVideoPlayer? videoPlayer, Func<Subtitle> getSubtitle, VideoPreviewSubtitleContext context);
+    void Invalidate();
+    void Reset();
+}

--- a/src/ui/Logic/Media/VideoPreviewSubtitle.cs
+++ b/src/ui/Logic/Media/VideoPreviewSubtitle.cs
@@ -1,0 +1,134 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.VideoPlayers;
+using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
+using System;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Logic.Media;
+
+/// <summary>
+/// Draws the subtitle on a dialog's own video player, the way the main window draws it on the main
+/// preview. Dialogs that exist to line a subtitle up against the picture used to show the video
+/// bare, which is exactly the comparison they are for (discussion #13767 - SE4 did show it).
+///
+/// Wraps the same "write a temp ASSA file and hand it to the player" reloaders the main window
+/// uses, plus the retry they need: mpv rejects sub-add until the file is actually playing, and a
+/// swallowed rejection leaves the player without subtitles for good (issue #13407).
+///
+/// One instance per player - the reloaders keep per-player state (temp file, pushed-text memo), so
+/// two players sharing one instance would fight over the same temp file.
+/// </summary>
+public class VideoPreviewSubtitle : IVideoPreviewSubtitle
+{
+    private const int RetryDelayMs = 400;
+
+    private readonly IMpvReloader _mpvReloader;
+    private readonly IVlcReloader _vlcReloader;
+
+    private bool _dirty = true;
+    private bool _busy;
+    private long _retryNotBeforeMs;
+
+    public VideoPreviewSubtitle(IMpvReloader mpvReloader, IVlcReloader vlcReloader)
+    {
+        _mpvReloader = mpvReloader;
+        _vlcReloader = vlcReloader;
+    }
+
+    /// <summary>
+    /// Pushes the subtitle when something has changed since the last push. Meant to be called from
+    /// a dialog's position timer: on the ticks where nothing changed it only reads a flag, so the
+    /// subtitle is serialized once per change instead of once per tick.
+    /// </summary>
+    /// <param name="getSubtitle">
+    /// Builds the subtitle to show. Only called when a push is actually due - the sync dialogs
+    /// rebuild it from their line view models, which is not worth doing several times a second.
+    /// </param>
+    public void Refresh(IVideoPlayer? videoPlayer, Func<Subtitle> getSubtitle, VideoPreviewSubtitleContext context)
+    {
+        if (!_dirty || _busy)
+        {
+            return;
+        }
+
+        // No player, or a player with no file: there is nothing to draw a subtitle on. The dirty
+        // flag stays set, so opening a video pushes right away.
+        if (videoPlayer == null || string.IsNullOrEmpty(videoPlayer.FileName))
+        {
+            return;
+        }
+
+        if (Environment.TickCount64 < _retryNotBeforeMs)
+        {
+            return;
+        }
+
+        if (videoPlayer is LibMpvDynamicPlayer mpv)
+        {
+            var subtitle = getSubtitle();
+            _dirty = false; // only after the snapshot was taken
+            _mpvReloader.SmpteMode = context.SmpteMode;
+            _ = RunRefresh(() => _mpvReloader.RefreshMpv(mpv, subtitle, null, context.Format));
+        }
+        else if (videoPlayer is LibVlcDynamicPlayer vlc)
+        {
+            var subtitle = getSubtitle();
+            _dirty = false;
+            _vlcReloader.SmpteMode = context.SmpteMode;
+            _ = RunRefresh(async () =>
+            {
+                await _vlcReloader.RefreshVlc(vlc, subtitle, null, context.Format);
+                return true;
+            });
+        }
+    }
+
+    /// <summary>
+    /// Re-push on the next <see cref="Refresh"/> - after a sync moved the time codes, for example.
+    /// </summary>
+    public void Invalidate()
+    {
+        _dirty = true;
+    }
+
+    /// <summary>
+    /// Forgets the subtitle handed to the player and deletes the temp file behind it. Use when the
+    /// player was given another video (the old external subtitle is gone with the old file, so it
+    /// has to be added again rather than reloaded) and when the dialog closes.
+    /// </summary>
+    public void Reset()
+    {
+        _mpvReloader.Reset();
+        _vlcReloader.Reset();
+        _dirty = true;
+        _retryNotBeforeMs = 0;
+    }
+
+    private async Task RunRefresh(Func<Task<bool>> refresh)
+    {
+        _busy = true;
+        try
+        {
+            if (!await refresh())
+            {
+                RetryLater();
+            }
+        }
+        catch (Exception exception)
+        {
+            Se.LogError(exception, "Video preview subtitle refresh failed");
+            RetryLater();
+        }
+        finally
+        {
+            _busy = false;
+        }
+    }
+
+    private void RetryLater()
+    {
+        _dirty = true;
+        _retryNotBeforeMs = Environment.TickCount64 + RetryDelayMs;
+    }
+}

--- a/src/ui/Logic/Media/VideoPreviewSubtitleContext.cs
+++ b/src/ui/Logic/Media/VideoPreviewSubtitleContext.cs
@@ -1,0 +1,19 @@
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+
+namespace Nikse.SubtitleEdit.Logic.Media;
+
+/// <summary>
+/// What a dialog needs to draw the subtitle on its own video the way the main window draws it on
+/// the main preview: the format and the header decide how it is rendered (ASSA keeps its styles,
+/// and the header is where libass reads PlayRes from, so \pos lands where it does in the main
+/// window), and SMPTE mode stretches the time codes by the same 0.1% the main preview uses - a
+/// sync dialog showing the subtitle a second off from the main video would defeat its own purpose.
+/// </summary>
+/// <param name="Format">The format the subtitle is being edited as.</param>
+/// <param name="Header">The subtitle's header, or null when the format has none.</param>
+/// <param name="SmpteMode">Whether the main window is in SMPTE timing mode.</param>
+public record VideoPreviewSubtitleContext(SubtitleFormat Format, string? Header, bool SmpteMode)
+{
+    /// <summary>Plain text at ordinary timing - what a dialog has before it is told otherwise.</summary>
+    public static VideoPreviewSubtitleContext Default => new(new SubRip(), null, false);
+}

--- a/tests/UI/Features/Sync/PointSync/PointSyncWindowTests.cs
+++ b/tests/UI/Features/Sync/PointSync/PointSyncWindowTests.cs
@@ -81,7 +81,7 @@ public class PointSyncWindowTests : IDisposable
     {
         var vm = new PointSyncViewModel(new FileHelper(), new WindowService(new NullServiceProvider()));
         var lines = TwoLines();
-        vm.Initialize(lines, new List<SubtitleLineViewModel>(), string.Empty, string.Empty, null);
+        vm.Initialize(lines, new List<SubtitleLineViewModel>(), string.Empty, string.Empty, VideoPreviewSubtitleContext.Default, null);
 
         var window = Track(new PointSyncWindow(vm));
 
@@ -93,9 +93,9 @@ public class PointSyncWindowTests : IDisposable
     {
         // The videoless dialog is just the line picker and the sync point time code - the player,
         // the waveform and "Play 2 secs & back" have nothing to show or do (issue #13341).
-        var vm = new SetSyncPointViewModel(new WindowService(new NullServiceProvider()), new FileHelper());
+        var vm = new SetSyncPointViewModel(new WindowService(new NullServiceProvider()), new FileHelper(), new VideoPreviewSubtitle(new MpvReloader(), new VlcReloader()));
         var lines = TwoLines();
-        vm.Initialize(lines, lines[0], videoFileName: null, subtitleFileName: null, audioVisualizer: null);
+        vm.Initialize(lines, lines[0], videoFileName: null, subtitleFileName: null, previewContext: VideoPreviewSubtitleContext.Default, audioVisualizer: null);
 
         var window = Track(new SetSyncPointWindow(vm));
 
@@ -112,12 +112,12 @@ public class PointSyncWindowTests : IDisposable
     [AvaloniaFact]
     public void SetSyncPointWindow_WithVideo_KeepsThePlayerAndPlaybackButton()
     {
-        var vm = new SetSyncPointViewModel(new WindowService(new NullServiceProvider()), new FileHelper());
+        var vm = new SetSyncPointViewModel(new WindowService(new NullServiceProvider()), new FileHelper(), new VideoPreviewSubtitle(new MpvReloader(), new VlcReloader()));
         var lines = TwoLines();
 
         // A path is enough for the layout decision; nothing opens it here (the open is posted to
         // the dispatcher and this test never pumps it).
-        vm.Initialize(lines, lines[0], videoFileName: "/does/not/exist.mp4", subtitleFileName: null, audioVisualizer: null);
+        vm.Initialize(lines, lines[0], videoFileName: "/does/not/exist.mp4", subtitleFileName: null, previewContext: VideoPreviewSubtitleContext.Default, audioVisualizer: null);
 
         var window = Track(new SetSyncPointWindow(vm));
 
@@ -139,9 +139,9 @@ public class PointSyncWindowTests : IDisposable
             Se.Settings.General.WindowPositions.Add(
                 new SeWindowPosition(nameof(SetSyncPointWindow), false, false, 50, 50, 1100, 900));
 
-            var vm = new SetSyncPointViewModel(new WindowService(new NullServiceProvider()), new FileHelper());
+            var vm = new SetSyncPointViewModel(new WindowService(new NullServiceProvider()), new FileHelper(), new VideoPreviewSubtitle(new MpvReloader(), new VlcReloader()));
             var lines = TwoLines();
-            vm.Initialize(lines, lines[0], videoFileName: null, subtitleFileName: null, audioVisualizer: null);
+            vm.Initialize(lines, lines[0], videoFileName: null, subtitleFileName: null, previewContext: VideoPreviewSubtitleContext.Default, audioVisualizer: null);
 
             var window = Track(new SetSyncPointWindow(vm));
             window.Show();
@@ -165,7 +165,7 @@ public class PointSyncWindowTests : IDisposable
         // The other subtitle stays the usual source, and the video is the fallback for lines it
         // does not cover - so both buttons have to be there.
         var vm = new PointSyncViaOtherViewModel(new FileHelper(), new WindowService(new NullServiceProvider()));
-        vm.Initialize(TwoLines(), string.Empty, string.Empty);
+        vm.Initialize(TwoLines(), string.Empty, string.Empty, VideoPreviewSubtitleContext.Default);
 
         var window = Track(new PointSyncViaOtherWindow(vm));
 

--- a/tests/UI/Features/Sync/PointSync/SetSyncPointViewModelTests.cs
+++ b/tests/UI/Features/Sync/PointSync/SetSyncPointViewModelTests.cs
@@ -21,7 +21,7 @@ public class SetSyncPointViewModelTests
     }
 
     private static SetSyncPointViewModel MakeViewModel()
-        => new(new WindowService(new NullServiceProvider()), new FileHelper());
+        => new(new WindowService(new NullServiceProvider()), new FileHelper(), new VideoPreviewSubtitle(new MpvReloader(), new VlcReloader()));
 
     private static List<SubtitleLineViewModel> ThreeLines()
         => new()
@@ -37,7 +37,7 @@ public class SetSyncPointViewModelTests
         var lines = ThreeLines();
         var vm = MakeViewModel();
 
-        vm.Initialize(lines, lines[1], videoFileName: null, subtitleFileName: null, audioVisualizer: null);
+        vm.Initialize(lines, lines[1], videoFileName: null, subtitleFileName: null, previewContext: VideoPreviewSubtitleContext.Default, audioVisualizer: null);
 
         Assert.Equal(TimeSpan.FromSeconds(30), vm.SyncPointTimeCode);
     }
@@ -48,7 +48,7 @@ public class SetSyncPointViewModelTests
         var lines = ThreeLines();
         var vm = MakeViewModel();
 
-        vm.Initialize(lines, null, videoFileName: null, subtitleFileName: null, audioVisualizer: null);
+        vm.Initialize(lines, null, videoFileName: null, subtitleFileName: null, previewContext: VideoPreviewSubtitleContext.Default, audioVisualizer: null);
 
         Assert.Equal(TimeSpan.FromSeconds(10), vm.SyncPointTimeCode);
     }
@@ -60,7 +60,7 @@ public class SetSyncPointViewModelTests
         // taking the result off the (empty) player instead gave a sync point of zero.
         var lines = ThreeLines();
         var vm = MakeViewModel();
-        vm.Initialize(lines, lines[1], videoFileName: null, subtitleFileName: null, audioVisualizer: null);
+        vm.Initialize(lines, lines[1], videoFileName: null, subtitleFileName: null, previewContext: VideoPreviewSubtitleContext.Default, audioVisualizer: null);
 
         vm.SyncPointTimeCode = TimeSpan.FromSeconds(42.5);
         vm.OkCommand.Execute(null);
@@ -74,7 +74,7 @@ public class SetSyncPointViewModelTests
     {
         var lines = ThreeLines();
         var vm = MakeViewModel();
-        vm.Initialize(lines, lines[1], videoFileName: null, subtitleFileName: null, audioVisualizer: null);
+        vm.Initialize(lines, lines[1], videoFileName: null, subtitleFileName: null, previewContext: VideoPreviewSubtitleContext.Default, audioVisualizer: null);
 
         vm.LeftOneSecondForwardCommand.Execute(null);
         vm.LeftHalfSecondForwardCommand.Execute(null);
@@ -92,7 +92,7 @@ public class SetSyncPointViewModelTests
     {
         var lines = ThreeLines();
         var vm = MakeViewModel();
-        vm.Initialize(lines, lines[0], videoFileName: null, subtitleFileName: null, audioVisualizer: null);
+        vm.Initialize(lines, lines[0], videoFileName: null, subtitleFileName: null, previewContext: VideoPreviewSubtitleContext.Default, audioVisualizer: null);
 
         for (var i = 0; i < 20; i++)
         {
@@ -107,7 +107,7 @@ public class SetSyncPointViewModelTests
     {
         var lines = ThreeLines();
         var vm = MakeViewModel();
-        vm.Initialize(lines, lines[0], videoFileName: null, subtitleFileName: null, audioVisualizer: null);
+        vm.Initialize(lines, lines[0], videoFileName: null, subtitleFileName: null, previewContext: VideoPreviewSubtitleContext.Default, audioVisualizer: null);
 
         vm.SelectedParagraphIndex = 2;
         vm.GoToLeftSubtitleCommand.Execute(null);

--- a/tests/UI/Features/Sync/SyncPreviewDiTests.cs
+++ b/tests/UI/Features/Sync/SyncPreviewDiTests.cs
@@ -1,0 +1,30 @@
+using Avalonia.Headless.XUnit;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Features.Sync.VisualSync;
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace UITests.Features.Sync;
+
+/// <summary>
+/// Visual sync asks for two <see cref="IVideoPreviewSubtitle"/> - one per player. They have to be
+/// two objects: each keeps the temp subtitle file it handed to its own player, so a single shared
+/// instance would have the two players overwriting each other's file.
+/// </summary>
+public class SyncPreviewDiTests
+{
+    [AvaloniaFact]
+    public void Container_GivesVisualSyncOnePreviewPerPlayer()
+    {
+        var collection = new ServiceCollection();
+        collection.AddSubtitleEditServices();
+        using var provider = collection.BuildServiceProvider();
+
+        var first = provider.GetRequiredService<IVideoPreviewSubtitle>();
+        var second = provider.GetRequiredService<IVideoPreviewSubtitle>();
+        Assert.NotSame(first, second);
+
+        var vm = provider.GetRequiredService<VisualSyncViewModel>();
+        Assert.NotNull(vm);
+    }
+}

--- a/tests/UI/Features/Sync/SyncPreviewSubtitleTests.cs
+++ b/tests/UI/Features/Sync/SyncPreviewSubtitleTests.cs
@@ -1,0 +1,166 @@
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Sync.PointSync.SetSyncPoint;
+using Nikse.SubtitleEdit.Features.Sync.VisualSync;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Media;
+using Nikse.SubtitleEdit.Logic.VideoPlayers;
+using System;
+using System.Collections.Generic;
+
+namespace UITests.Features.Sync;
+
+/// <summary>
+/// The sync dialogs draw the subtitle on their own video, the way the main window draws it on the
+/// main preview - they used to show the video bare, which is the comparison they exist for
+/// (discussion #13767). These cover what the dialogs hand to the player: the lines as they stand
+/// right now (so a sync moves them), and the format plus header that give ASSA its styles.
+/// </summary>
+public class SyncPreviewSubtitleTests
+{
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private sealed class FakePreviewSubtitle : IVideoPreviewSubtitle
+    {
+        public int InvalidateCount { get; private set; }
+        public int ResetCount { get; private set; }
+        public VideoPreviewSubtitleContext? Context { get; private set; }
+
+        private Func<Subtitle>? _getSubtitle;
+
+        public void Refresh(IVideoPlayer? videoPlayer, Func<Subtitle> getSubtitle, VideoPreviewSubtitleContext context)
+        {
+            _getSubtitle = getSubtitle;
+            Context = context;
+        }
+
+        public void Invalidate() => InvalidateCount++;
+
+        public void Reset() => ResetCount++;
+
+        /// <summary>The subtitle the dialog offered, built on demand as the real push would.</summary>
+        public Subtitle BuildOffered()
+        {
+            Assert.NotNull(_getSubtitle);
+            return _getSubtitle!();
+        }
+    }
+
+    private static List<SubtitleLineViewModel> ThreeLines()
+        => new()
+        {
+            new() { StartTime = TimeSpan.FromSeconds(10), EndTime = TimeSpan.FromSeconds(12), Text = "One" },
+            new() { StartTime = TimeSpan.FromSeconds(30), EndTime = TimeSpan.FromSeconds(32), Text = "Two" },
+            new() { StartTime = TimeSpan.FromSeconds(50), EndTime = TimeSpan.FromSeconds(52), Text = "Three" },
+        };
+
+    [AvaloniaFact]
+    public void VisualSync_OffersTheWholeSubtitleToBothPlayers()
+    {
+        var left = new FakePreviewSubtitle();
+        var right = new FakePreviewSubtitle();
+        var vm = new VisualSyncViewModel(new WindowService(new NullServiceProvider()), new FileHelper(), left, right);
+        vm.Initialize(ThreeLines(), videoFileName: null, subtitleFileName: null, VideoPreviewSubtitleContext.Default, audioVisualizer: null);
+
+        vm.RefreshPreviewSubtitles();
+
+        foreach (var preview in new[] { left, right })
+        {
+            var subtitle = preview.BuildOffered();
+            Assert.Equal(3, subtitle.Paragraphs.Count);
+            Assert.Equal("One", subtitle.Paragraphs[0].Text);
+            Assert.Equal(10000, subtitle.Paragraphs[0].StartTime.TotalMilliseconds, 3);
+            Assert.Equal("Three", subtitle.Paragraphs[2].Text);
+        }
+    }
+
+    [AvaloniaFact]
+    public void VisualSync_ManualSync_MovesTheSubtitleOnTheVideos()
+    {
+        // The whole point of showing it: after a sync the video has to draw the lines where they
+        // now are, not where they were when the dialog opened.
+        var left = new FakePreviewSubtitle();
+        var right = new FakePreviewSubtitle();
+        var vm = new VisualSyncViewModel(new WindowService(new NullServiceProvider()), new FileHelper(), left, right);
+        vm.Initialize(ThreeLines(), videoFileName: null, subtitleFileName: null, VideoPreviewSubtitleContext.Default, audioVisualizer: null);
+        vm.RefreshPreviewSubtitles();
+
+        vm.ApplySync(1.0, 5.0); // what "Sync" and "Manual sync" both end in
+
+        Assert.Equal(1, left.InvalidateCount);
+        Assert.Equal(1, right.InvalidateCount);
+        Assert.Equal(15000, left.BuildOffered().Paragraphs[0].StartTime.TotalMilliseconds, 3);
+        Assert.Equal(15000, right.BuildOffered().Paragraphs[0].StartTime.TotalMilliseconds, 3);
+    }
+
+    [AvaloniaFact]
+    public void VisualSync_CarriesTheAssaStylesAndHeader()
+    {
+        // Without the header libass has no styles and no PlayRes, so \pos would land against its
+        // own default resolution instead of the video's.
+        const string header = "[Script Info]\r\nPlayResX: 1920\r\nPlayResY: 1080\r\n\r\n[V4+ Styles]\r\n";
+        var lines = ThreeLines();
+        lines[0].Style = "Narrator";
+
+        var left = new FakePreviewSubtitle();
+        var right = new FakePreviewSubtitle();
+        var vm = new VisualSyncViewModel(new WindowService(new NullServiceProvider()), new FileHelper(), left, right);
+        vm.Initialize(lines, videoFileName: null, subtitleFileName: null, new VideoPreviewSubtitleContext(new AdvancedSubStationAlpha(), header, false), audioVisualizer: null);
+
+        vm.RefreshPreviewSubtitles();
+
+        var subtitle = left.BuildOffered();
+        Assert.Equal(header, subtitle.Header);
+        Assert.Equal("Narrator", subtitle.Paragraphs[0].Extra);
+        Assert.IsType<AdvancedSubStationAlpha>(left.Context!.Format);
+    }
+
+    [AvaloniaFact]
+    public void VisualSync_Closing_ReleasesBothTempSubtitleFiles()
+    {
+        var left = new FakePreviewSubtitle();
+        var right = new FakePreviewSubtitle();
+        var vm = new VisualSyncViewModel(new WindowService(new NullServiceProvider()), new FileHelper(), left, right);
+        vm.Initialize(ThreeLines(), videoFileName: null, subtitleFileName: null, VideoPreviewSubtitleContext.Default, audioVisualizer: null);
+
+        vm.OnClosing();
+
+        Assert.Equal(1, left.ResetCount);
+        Assert.Equal(1, right.ResetCount);
+    }
+
+    [AvaloniaFact]
+    public void SetSyncPoint_OffersTheWholeSubtitleWithItsHeader()
+    {
+        const string header = "[Script Info]\r\nPlayResX: 1280\r\n\r\n[V4+ Styles]\r\n";
+        var preview = new FakePreviewSubtitle();
+        var vm = new SetSyncPointViewModel(new WindowService(new NullServiceProvider()), new FileHelper(), preview);
+        var lines = ThreeLines();
+        vm.Initialize(lines, lines[1], videoFileName: null, subtitleFileName: null, new VideoPreviewSubtitleContext(new AdvancedSubStationAlpha(), header, false), audioVisualizer: null);
+
+        vm.RefreshPreviewSubtitle();
+
+        var subtitle = preview.BuildOffered();
+        Assert.Equal(3, subtitle.Paragraphs.Count);
+        Assert.Equal("Two", subtitle.Paragraphs[1].Text);
+        Assert.Equal(header, subtitle.Header);
+    }
+
+    [AvaloniaFact]
+    public void SetSyncPoint_Closing_ReleasesTheTempSubtitleFile()
+    {
+        var preview = new FakePreviewSubtitle();
+        var vm = new SetSyncPointViewModel(new WindowService(new NullServiceProvider()), new FileHelper(), preview);
+        var lines = ThreeLines();
+        vm.Initialize(lines, lines[0], videoFileName: null, subtitleFileName: null, VideoPreviewSubtitleContext.Default, audioVisualizer: null);
+
+        vm.OnClosing();
+
+        Assert.Equal(1, preview.ResetCount);
+    }
+}


### PR DESCRIPTION
Visual sync and "Set sync point" opened their own video players and never gave them a subtitle: the video was bare and the only text was the picker below it — in the two dialogs whose whole job is lining a subtitle up against the picture. Reported in [discussion #13767](https://github.com/SubtitleEdit/subtitleedit/discussions/13767).

Not a regression between betas — SE5's sync dialogs never drew it (the window has been unchanged in that respect since v5.0.0-beta20). SE4 did: `VisualSync.cs` pushed the subtitle to each player on every timer tick and after every seek.

## What this does

Both dialogs hand their player(s) the whole subtitle, so mpv/VLC draws whatever line belongs at the frame each player is parked on — the same mechanism the main window uses for its own preview.

- **`VideoPreviewSubtitle`** (new, `src/ui/Logic/Media`): wraps the existing `IMpvReloader`/`IVlcReloader` (temp ASSA file + `sub-add`/`sub-reload`) with a dirty-flag push and the retry they need — mpv rejects `sub-add` until its core has a file, and a swallowed rejection leaves the player without subtitles for the rest of the session (#13407). Registered transient; one instance per player, since the reloaders keep the temp file and pushed-text memo of their own player.
- **Visual sync**: pushed from the existing 150 ms timer, re-pushed after a sync so the video follows the adjusted time codes (SE4 got that for free by pushing the live paragraphs every tick), reset when another video is opened from inside the dialog and on close so the temp files go away.
- **Set sync point**: the same, with one player. Reached from both Point sync and Point sync via other subtitle, so the context is passed through those two view models.
- **Fidelity**: instead of SE4's plain `SubRip` push, the format, header and SMPTE mode are carried in from the main window as a `VideoPreviewSubtitleContext`. The header is where libass reads the ASSA styles and `PlayResX/Y`, so `\pos` lands where it does on the main video instead of against libass's default resolution; SMPTE mode applies the same 0.1 % stretch the main preview uses, so a sync dialog cannot disagree with the main window's video.

## Testing

Full UI suite green (3111). Seven new tests cover what each dialog offers its player (all lines, ASSA style + header), that a sync invalidates both sides and rebuilds at the new times, that closing releases the temp files, and that DI hands Visual sync two distinct preview instances rather than one shared.

Not verified in a running app — the actual "text appears on both preview frames" check needs a run with a real mpv player.

🤖 Generated with [Claude Code](https://claude.com/claude-code)