### PR TITLE
Resync the waveform cursor to mpv when playback resumes

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -626,6 +626,8 @@ public partial class MainViewModel :
     private const double PlayheadPauseSettleMs = 300; // mpv's reported position lags ~100-200 ms after a pause
     private bool _playheadPausedSettled; // set once mpv's clock has come to rest after a pause and the cursor has landed on it
     private const double PlayheadPausedSettleStableMs = 100; // mpv's position unchanged this long after a pause = its clock is at rest -> snap the cursor there once
+    private bool _playheadResyncOnPlay; // armed while paused: re-seed the estimate from mpv once playback actually moves again
+    private const double PlayheadResyncOnPlayThresholdSeconds = 0.04; // ~one frame; below this the standing residual isn't worth moving the cursor for
     private CancellationTokenSource _videoOpenTokenSource;
     private readonly HashSet<string> _waveformsBeingGenerated = new(StringComparer.OrdinalIgnoreCase);
     private readonly Lock _waveformsBeingGeneratedLock = new();
@@ -25413,6 +25415,15 @@ public partial class MainViewModel :
 
         var nowTimestamp = Stopwatch.GetTimestamp();
 
+        // Any tick with mpv stopped arms a one-shot resync for when playback starts again (see the
+        // resync block in the playing branch). Armed here rather than in PlayVideo so every way of
+        // starting playback is covered - the player's own toolbar button, a click on the video
+        // surface, shortcuts, play-selection - not just the paths that route through the view model.
+        if (!isPlaying)
+        {
+            _playheadResyncOnPlay = true;
+        }
+
         // A fresh user seek (e.g. clicking the waveform) is pinned to the clicked position: mpv
         // applies the pause+seek asynchronously, so for ~100-200 ms vp.VideoPlayer.Position still
         // reports the old spot. Hold the target until mpv's reported position actually arrives (or a
@@ -25445,6 +25456,8 @@ public partial class MainViewModel :
 
             if (isPlaying)
             {
+                // Seeded straight from mpv, so there is no standing residual left to resync.
+                _playheadResyncOnPlay = false;
                 _playheadEstimateSeconds = rawPosition;
                 return rawPosition;
             }
@@ -25486,6 +25499,30 @@ public partial class MainViewModel :
             }
 
             var rawFrozenSeconds = (nowTimestamp - _playheadLastRawChangeTs) / (double)Stopwatch.Frequency;
+
+            // Playback just resumed: re-seed the estimate from mpv's real position, once, on the first
+            // tick where its clock actually moves.
+            //
+            // While paused the cursor deliberately carries a residual: it dead-freezes at the keypress
+            // instant while mpv keeps decoding ~100-200 ms past it, and #12740 leaves that gap alone so
+            // the cursor doesn't drift after the time display has stopped. mpv then resumes from *its*
+            // position, not the cursor's, so without this the cursor starts playback already behind the
+            // audio - and the forward-only drift correction below only closes it at ~1.2x, i.e. half a
+            // second for a 100 ms residual and a full second for 200 ms. That is heard as the speech
+            // starting before the cursor reaches it on the waveform (discussion #10824). A paused seek
+            // adds the same debt from the other end: Position reports the requested target while paused,
+            // so any difference between that and where mpv really landed only shows up once it plays.
+            //
+            // Correcting here rather than at the pause keeps #12740 intact, and a jump at the instant the
+            // cursor starts moving is far less visible than one after it has come to rest.
+            if (_playheadResyncOnPlay && rawChanged)
+            {
+                _playheadResyncOnPlay = false;
+                if (Math.Abs(rawPosition - _playheadEstimateSeconds) > PlayheadResyncOnPlayThresholdSeconds)
+                {
+                    _playheadEstimateSeconds = rawPosition;
+                }
+            }
 
             // Only extrapolate while mpv's clock is actually advancing. After a paused seek mpv's
             // time-pos (and the video) freezes for ~400 ms while it re-primes, then resumes at 1x from


### PR DESCRIPTION
Reported in [discussion #10824](https://github.com/SubtitleEdit/subtitleedit/discussions/10824#discussioncomment-18055480): the speech is audible before the waveform cursor reaches it, intermittently and unpredictably, and replaying the same spot makes it go away.

### What was happening

The waveform cursor is not mpv's position — it is the wall-clock estimate in `UpdatePlayheadEstimate`. Two deliberate design choices combine badly at the *start* of playback:

1. **Pause leaves a standing residual on purpose.** The cursor dead-freezes at the keypress instant, mpv coasts on for ~100–200 ms, and #12740 explicitly does not reconcile that gap so the cursor doesn't drift after the numeric time display has already stopped. It is invisible while paused, because `LibMpvDynamicPlayer.Position` returns the cached requested value rather than mpv's real one.
2. **Resuming doesn't re-seed the estimate.** `PlayVideo` only clears the pause-freeze flag, so mpv resumes from *its* position while the cursor resumes from the frozen one — and the drift correction in the playing branch is forward-only and capped at `elapsed * 0.2`.

At the 16 ms cursor tick that cap is 3.2 ms per tick, i.e. 0.2 s of catch-up per second of playback: **half a second to close a 100 ms residual, a full second for 200 ms.** Anything under the 0.5 s resync threshold never snaps, so it stays in that crawl the whole time. During the crawl the audio runs ahead of the cursor; afterwards it is fine again, which is exactly the "it disappears when I replay it" and "no way to predict when it happens" in the report — the residual depends on how far mpv coasted on the *previous* pause.

A paused seek adds the same debt from the other end: while paused, `Position` reports the requested target, so any difference between that and where mpv really landed only surfaces once it plays.

### The fix

Re-seed the estimate from mpv's real position once, on the first tick after resuming where mpv's clock actually moves and the gap is over ~one frame (0.04 s).

- **Arm** — at the top of `UpdatePlayheadEstimate`, on any tick where mpv reports stopped. Armed there rather than in `PlayVideo` so every way of starting playback is covered: the player's own toolbar button, a click on the video surface, shortcuts, play-selection.
- **Consume** — in the playing branch, gated on `rawChanged` rather than on the `isPlaying` edge, because the first *changed* raw read is the first honest one (the paused cache masks the rest). Placed before the extrapolation block so the tick's normal advance still applies on top.
- **Clear** — the pin branch's playing-arrival already seeds straight from mpv, so it drops the flag instead of snapping twice.

#12740 is untouched: the cursor still dead-freezes at the keypress instant and still does not reconcile while paused. The debt is only settled at the moment the cursor starts moving again, where a jump is masked by the motion itself.

### Notes for review

- The resync is **symmetric** — it will also pull the cursor backward if mpv resumes behind the frozen spot (the "or, if we'd extrapolated ahead, behind" case in the #12740 comment). A cursor running ahead of the audio is the same defect mirrored, and the forward-only rule exists to stop backward *creep* during playback, not a single correction at the play instant. Trivial to make it forward-only if it looks wrong in practice.
- Frame-stepping while paused already snaps the cursor onto the stepped frame, so the residual there is ~0 and the 0.04 s threshold means play-after-frame-step won't jump at all.
- **Not verified visually** — judging a ~100 ms cursor-vs-audio relationship needs the GUI and real playback. Repro to check: click just before a line and press play, and separately pause mid-line and immediately play again (largest wind-down residual).

Builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)