### PR TITLE
CosyVoice3: offer the RL talker in both quantizations (#13272)

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/CosyVoice3CrispAsrSettings/CosyVoice3CrispAsrSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/CosyVoice3CrispAsrSettings/CosyVoice3CrispAsrSettingsViewModel.cs
@@ -39,6 +39,12 @@ public partial class CosyVoice3CrispAsrSettingsViewModel : ObservableObject
     [ObservableProperty] private string _f16BundleLabel = string.Empty;
     [ObservableProperty] private IBrush _f16BundleBrush = Grey();
 
+    [ObservableProperty] private string _rlQ4KBundleLabel = string.Empty;
+    [ObservableProperty] private IBrush _rlQ4KBundleBrush = Grey();
+
+    [ObservableProperty] private string _rlF16BundleLabel = string.Empty;
+    [ObservableProperty] private IBrush _rlF16BundleBrush = Grey();
+
     [ObservableProperty] private string _presetsLabel = string.Empty;
     [ObservableProperty] private string _voicesLabel = string.Empty;
 
@@ -155,6 +161,18 @@ public partial class CosyVoice3CrispAsrSettingsViewModel : ObservableObject
             IsEngineInstalled,
             label => F16BundleLabel = label,
             brush => F16BundleBrush = brush);
+
+        ApplyModelStatus(
+            CosyVoice3CrispAsr.AreModelsInstalled(CosyVoice3CrispAsr.ModelKeyRlQ4K),
+            IsEngineInstalled,
+            label => RlQ4KBundleLabel = label,
+            brush => RlQ4KBundleBrush = brush);
+
+        ApplyModelStatus(
+            CosyVoice3CrispAsr.AreModelsInstalled(CosyVoice3CrispAsr.ModelKeyRlF16),
+            IsEngineInstalled,
+            label => RlF16BundleLabel = label,
+            brush => RlF16BundleBrush = brush);
 
         try
         {

--- a/src/ui/Features/Video/TextToSpeech/CosyVoice3CrispAsrSettings/CosyVoice3CrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/CosyVoice3CrispAsrSettings/CosyVoice3CrispAsrSettingsWindow.cs
@@ -106,6 +106,8 @@ public class CosyVoice3CrispAsrSettingsWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnSpacing = 12,
             RowSpacing = 10,
@@ -126,31 +128,39 @@ public class CosyVoice3CrispAsrSettingsWindow : Window
         grid.Add(MakeLabel(CosyVoice3CrispAsr.ModelKeyF16), 2, 0);
         grid.Add(MakeStatusPanel(nameof(vm.F16BundleBrush), nameof(vm.F16BundleLabel)), 2, 1);
 
-        grid.Add(MakeLabel(Se.Language.Video.Presets), 3, 0);
+        // The RL talker bundles (#13272) share every companion with the two above - only the LLM
+        // file differs - so an installed RL row means one extra GGUF on disk, not a second bundle.
+        grid.Add(MakeLabel(CosyVoice3CrispAsr.ModelKeyRlQ4K), 3, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.RlQ4KBundleBrush), nameof(vm.RlQ4KBundleLabel)), 3, 1);
+
+        grid.Add(MakeLabel(CosyVoice3CrispAsr.ModelKeyRlF16), 4, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.RlF16BundleBrush), nameof(vm.RlF16BundleLabel)), 4, 1);
+
+        grid.Add(MakeLabel(Se.Language.Video.Presets), 5, 0);
         var presetsText = new TextBlock
         {
             VerticalAlignment = VerticalAlignment.Center,
             FontWeight = FontWeight.SemiBold,
             [!TextBlock.TextProperty] = new Binding(nameof(vm.PresetsLabel)),
         };
-        grid.Add(presetsText, 3, 1);
+        grid.Add(presetsText, 5, 1);
 
-        grid.Add(MakeLabel(Se.Language.Video.Voices), 4, 0);
+        grid.Add(MakeLabel(Se.Language.Video.Voices), 6, 0);
         var voicesText = new TextBlock
         {
             VerticalAlignment = VerticalAlignment.Center,
             FontWeight = FontWeight.SemiBold,
             [!TextBlock.TextProperty] = new Binding(nameof(vm.VoicesLabel)),
         };
-        grid.Add(voicesText, 4, 1);
+        grid.Add(voicesText, 6, 1);
 
-        grid.Add(MakeLabel(Se.Language.General.Speed), 5, 0);
-        grid.Add(MakeSpeedPanel(), 5, 1);
+        grid.Add(MakeLabel(Se.Language.General.Speed), 7, 0);
+        grid.Add(MakeSpeedPanel(), 7, 1);
 
         // Language spoken in imported reference WAVs — sent as `source_lang` so cross-lingual
         // cloning engages when the target language differs (the server cannot detect the
         // reference language itself for Latin scripts). Presets carry their own bank language.
-        grid.Add(MakeLabel("Reference language"), 6, 0);
+        grid.Add(MakeLabel("Reference language"), 8, 0);
         var sourceLanguageCombo = UiUtil.MakeComboBox(vm.SourceLanguages, vm, nameof(vm.SelectedSourceLanguage));
         var sourceLanguageHint = new TextBlock
         {
@@ -165,9 +175,9 @@ public class CosyVoice3CrispAsrSettingsWindow : Window
         {
             Orientation = Orientation.Horizontal,
             Children = { sourceLanguageCombo, sourceLanguageHint },
-        }, 6, 1);
+        }, 8, 1);
 
-        grid.Add(MakeLabel(Se.Language.General.InstallFolder), 7, 0);
+        grid.Add(MakeLabel(Se.Language.General.InstallFolder), 9, 0);
         var folderText = new TextBox
         {
             IsReadOnly = true,
@@ -179,7 +189,7 @@ public class CosyVoice3CrispAsrSettingsWindow : Window
             FontSize = 12,
             [!TextBox.TextProperty] = new Binding(nameof(vm.ModelsFolder)),
         };
-        grid.Add(folderText, 7, 1);
+        grid.Add(folderText, 9, 1);
 
         return new Border
         {

--- a/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
@@ -66,12 +66,21 @@ public class CosyVoice3CrispAsr : ITtsEngine
 
     // Two LLM quants — Q4_K is the lightweight default (~1.6 GB total), F16 the reference (~2.5 GB).
     // The label total covers every required companion (flow / hift / s3tok / campplus / voices).
+    // Each quant also comes as an RL talker (#13272): upstream ships two checkpoints for the same
+    // architecture, llm.pt and llm.rl.pt, the latter tuned by the authors for speech quality,
+    // pronunciation accuracy and generation stability. Only the talker differs - flow, HiFT,
+    // CAMPPlus, the speech tokenizer and the voice bank are shared - so an RL pick is the same
+    // bundle with a different LLM file and costs nothing extra beyond that one download.
     public const string ModelKeyQ4K = "Q4_K (~1.6 GB total)";
     public const string ModelKeyF16 = "F16 (~2.5 GB total)";
+    public const string ModelKeyRlQ4K = "RL Q4_K (~1.6 GB total)";
+    public const string ModelKeyRlF16 = "RL F16 (~2.5 GB total)";
     public const string DefaultModelKey = ModelKeyQ4K;
 
     public const string LlmQ4KFileName = "cosyvoice3-llm-q4_k.gguf";
     public const string LlmF16FileName = "cosyvoice3-llm-f16.gguf";
+    public const string LlmRlQ4KFileName = "cosyvoice3-llm-rl-q4_k.gguf";
+    public const string LlmRlF16FileName = "cosyvoice3-llm-rl-f16.gguf";
     public const string FlowF16FileName = "cosyvoice3-flow-f16.gguf";
     public const string HiftF16FileName = "cosyvoice3-hift-f16.gguf";
     public const string S3TokF16FileName = "cosyvoice3-s3tok-f16.gguf";
@@ -96,7 +105,7 @@ public class CosyVoice3CrispAsr : ITtsEngine
     /// </summary>
     public static string[] GetRequiredFileNames(string? modelKey) => new[]
     {
-        ResolveModelKey(modelKey) == ModelKeyF16 ? LlmF16FileName : LlmQ4KFileName,
+        GetLlmFileName(modelKey),
         FlowF16FileName,
         HiftF16FileName,
         S3TokF16FileName,
@@ -126,6 +135,10 @@ public class CosyVoice3CrispAsr : ITtsEngine
     {
         [LlmQ4KFileName] = 383891200L,
         [LlmF16FileName] = 1289653952L,
+        // The RL talkers are the same architecture and quantisation recipe, hence byte-identical
+        // sizes to their non-RL counterparts. The file name is what tells them apart.
+        [LlmRlQ4KFileName] = 383891200L,
+        [LlmRlF16FileName] = 1289653952L,
         [FlowF16FileName] = 665140992L,
         [HiftF16FileName] = 41601888L,
         [S3TokF16FileName] = 484406944L,
@@ -144,6 +157,8 @@ public class CosyVoice3CrispAsr : ITtsEngine
         return modelKey switch
         {
             ModelKeyF16 => ModelKeyF16,
+            ModelKeyRlQ4K => ModelKeyRlQ4K,
+            ModelKeyRlF16 => ModelKeyRlF16,
             _ => ModelKeyQ4K,
         };
     }
@@ -151,6 +166,8 @@ public class CosyVoice3CrispAsr : ITtsEngine
     public static string GetLlmFileName(string? modelKey) => ResolveModelKey(modelKey) switch
     {
         ModelKeyF16 => LlmF16FileName,
+        ModelKeyRlQ4K => LlmRlQ4KFileName,
+        ModelKeyRlF16 => LlmRlF16FileName,
         _ => LlmQ4KFileName,
     };
 
@@ -452,7 +469,7 @@ public class CosyVoice3CrispAsr : ITtsEngine
 
     public Task<string[]> GetRegions() => Task.FromResult(Array.Empty<string>());
 
-    public Task<string[]> GetModels() => Task.FromResult(new[] { ModelKeyQ4K, ModelKeyF16 });
+    public Task<string[]> GetModels() => Task.FromResult(new[] { ModelKeyQ4K, ModelKeyF16, ModelKeyRlQ4K, ModelKeyRlF16 });
 
     public Task<TtsLanguage[]> GetLanguages(Voice voice, string? model) => Task.FromResult(CosyVoice3Languages.All);
 

--- a/src/ui/Logic/Download/CosyVoice3CrispAsrDownloadService.cs
+++ b/src/ui/Logic/Download/CosyVoice3CrispAsrDownloadService.cs
@@ -31,6 +31,8 @@ public class CosyVoice3CrispAsrDownloadService : ICosyVoice3CrispAsrDownloadServ
     {
         [CosyVoice3CrispAsr.LlmQ4KFileName] = RepoBase + CosyVoice3CrispAsr.LlmQ4KFileName,
         [CosyVoice3CrispAsr.LlmF16FileName] = RepoBase + CosyVoice3CrispAsr.LlmF16FileName,
+        [CosyVoice3CrispAsr.LlmRlQ4KFileName] = RepoBase + CosyVoice3CrispAsr.LlmRlQ4KFileName,
+        [CosyVoice3CrispAsr.LlmRlF16FileName] = RepoBase + CosyVoice3CrispAsr.LlmRlF16FileName,
         [CosyVoice3CrispAsr.FlowF16FileName] = RepoBase + CosyVoice3CrispAsr.FlowF16FileName,
         [CosyVoice3CrispAsr.HiftF16FileName] = RepoBase + CosyVoice3CrispAsr.HiftF16FileName,
         [CosyVoice3CrispAsr.S3TokF16FileName] = RepoBase + CosyVoice3CrispAsr.S3TokF16FileName,
@@ -113,6 +115,14 @@ public class CosyVoice3CrispAsrDownloadService : ICosyVoice3CrispAsrDownloadServ
         if (string.Equals(fileName, CosyVoice3CrispAsr.LlmF16FileName, StringComparison.OrdinalIgnoreCase))
         {
             return DownloadHashManager.CosyVoice3CrispAsr.LlmF16;
+        }
+        if (string.Equals(fileName, CosyVoice3CrispAsr.LlmRlQ4KFileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.CosyVoice3CrispAsr.LlmRlQ4K;
+        }
+        if (string.Equals(fileName, CosyVoice3CrispAsr.LlmRlF16FileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.CosyVoice3CrispAsr.LlmRlF16;
         }
         if (string.Equals(fileName, CosyVoice3CrispAsr.FlowF16FileName, StringComparison.OrdinalIgnoreCase))
         {

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -219,6 +219,8 @@ public static class DownloadHashManager
         // crispasr 0.6.12's sibling discovery is hardcoded to those filenames.
         public const string LlmQ4K = "CosyVoice3CrispAsr.LlmQ4K";
         public const string LlmF16 = "CosyVoice3CrispAsr.LlmF16";
+        public const string LlmRlQ4K = "CosyVoice3CrispAsr.LlmRlQ4K";
+        public const string LlmRlF16 = "CosyVoice3CrispAsr.LlmRlF16";
         public const string FlowF16 = "CosyVoice3CrispAsr.FlowF16";
         public const string HiftF16 = "CosyVoice3CrispAsr.HiftF16";
         public const string S3TokF16 = "CosyVoice3CrispAsr.S3TokF16";
@@ -1691,6 +1693,16 @@ public static class DownloadHashManager
             [CosyVoice3CrispAsr.LlmF16] = new[]
             {
                 "f13149e1f695d79dcc707de45b3df58ccaf2ab7eba1dad4168ae2c778efe4e67", // cosyvoice3-llm-f16.gguf
+            },
+            // The RL talkers (upstream llm.rl.pt), uploaded 2026-08-05. Same size as the non-RL
+            // pair, so the hash is the only thing that tells a mixed-up download apart.
+            [CosyVoice3CrispAsr.LlmRlQ4K] = new[]
+            {
+                "6f70770750c3f302a6b1732fc9a02d97f33d86aa77282e46237cff3c55510d60", // cosyvoice3-llm-rl-q4_k.gguf
+            },
+            [CosyVoice3CrispAsr.LlmRlF16] = new[]
+            {
+                "f7d5ace0dde950dc0f0dd53e347d51e6f4304f8181d6ed657d11288b09ca2497", // cosyvoice3-llm-rl-f16.gguf
             },
             [CosyVoice3CrispAsr.FlowF16] = new[]
             {

--- a/tests/UI/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsrModelKeyTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsrModelKeyTests.cs
@@ -1,0 +1,50 @@
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+namespace UITests.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// CosyVoice3 offers the same bundle with four different talkers: two quantisations of upstream's
+/// pre-trained <c>llm.pt</c> and two of its RL-tuned <c>llm.rl.pt</c> (#13272). Only the LLM file
+/// differs between them — every companion (flow / HiFT / s3tok / CAMPPlus / voice bank) is shared —
+/// so the mapping from model key to file name is the whole of what "picking RL" means.
+/// </summary>
+public class CosyVoice3CrispAsrModelKeyTests
+{
+    [Theory]
+    [InlineData(CosyVoice3CrispAsr.ModelKeyQ4K, CosyVoice3CrispAsr.LlmQ4KFileName)]
+    [InlineData(CosyVoice3CrispAsr.ModelKeyF16, CosyVoice3CrispAsr.LlmF16FileName)]
+    [InlineData(CosyVoice3CrispAsr.ModelKeyRlQ4K, CosyVoice3CrispAsr.LlmRlQ4KFileName)]
+    [InlineData(CosyVoice3CrispAsr.ModelKeyRlF16, CosyVoice3CrispAsr.LlmRlF16FileName)]
+    public void EachModelKey_MapsToItsOwnLlmGguf(string modelKey, string expectedLlm)
+    {
+        Assert.Equal(expectedLlm, CosyVoice3CrispAsr.GetLlmFileName(modelKey));
+        Assert.Equal(modelKey, CosyVoice3CrispAsr.ResolveModelKey(modelKey));
+    }
+
+    [Fact]
+    public async Task AllModelKeys_AreOfferedAndDistinct()
+    {
+        var models = await new CosyVoice3CrispAsr().GetModels();
+
+        Assert.Equal(4, models.Length);
+        Assert.Equal(models.Length, models.Distinct().Count());
+        Assert.Contains(CosyVoice3CrispAsr.ModelKeyRlQ4K, models);
+        Assert.Contains(CosyVoice3CrispAsr.ModelKeyRlF16, models);
+    }
+
+    [Theory]
+    [InlineData(CosyVoice3CrispAsr.ModelKeyRlQ4K)]
+    [InlineData(CosyVoice3CrispAsr.ModelKeyRlF16)]
+    public void RlBundle_DiffersFromTheBaseBundleOnlyInTheTalker(string rlModelKey)
+    {
+        var rl = CosyVoice3CrispAsr.GetRequiredFileNames(rlModelKey);
+        var baseline = CosyVoice3CrispAsr.GetRequiredFileNames(CosyVoice3CrispAsr.ModelKeyQ4K);
+
+        // Same six files, and everything after the talker is shared - that is what makes an RL
+        // pick a single extra download for someone who already has a bundle installed.
+        Assert.Equal(baseline.Length, rl.Length);
+        Assert.Equal(baseline.Skip(1), rl.Skip(1));
+        Assert.NotEqual(baseline[0], rl[0]);
+        Assert.Contains("-rl-", rl[0]);
+    }
+}


### PR DESCRIPTION
Requested on #13272: the RL GGUFs that [cstr/cosyvoice3-0.5b-2512-GGUF](https://huggingface.co/cstr/cosyvoice3-0.5b-2512-GGUF) added on 2026-08-05.

## What RL is

Not a new model — upstream ships **two talker checkpoints** for the same Fun-CosyVoice3-0.5B-2512 release: `llm.pt` and `llm.rl.pt`, the latter tuned by the authors for speech quality, pronunciation accuracy and generation stability. Only the talker differs; flow, HiFT, CAMPPlus, the speech tokenizer and the voice bank are shared. So an RL pick is **one extra GGUF** for anyone who already has a bundle installed, not a second 1.6 GB download.

CrispASR also has a `cosyvoice3-tts-rl` backend alias, but it exists only so `-m auto` fetches the RL files. SE stages every GGUF itself and passes explicit paths, so the plain `cosyvoice3-tts` backend loads the RL talker as-is — no backend change here.

## Changes

- `RL Q4_K (~1.6 GB total)` and `RL F16 (~2.5 GB total)` model keys alongside the existing two; `GetLlmFileName` is now the single place the key becomes a file, and `GetRequiredFileNames` goes through it.
- Download URLs, expected sizes, and HF LFS SHA-256 hashes for both RL files. The RL talkers are byte-identical in *size* to their non-RL counterparts (same architecture and quant recipe), so the hash is the only thing that catches a mixed-up download.
- Two more status rows in the CosyVoice3 settings window.
- The default stays the non-RL Q4_K — no existing install changes model.

There is **no q8_0 RL** because the LLM has no q8_0 build at all; the `cosyvoice3-*-q8_0` file in that repo is the flow model.

## Verification

Ran against SE's pinned CrispASR **v0.8.29** (macOS), with the RL Q4_K talker downloaded and SHA-256 checked against the HF LFS oid:

- Loads with the existing companion set, voice bank intact (8 voices).
- English (`fleurs-en`) and Russian both round-trip **verbatim** through `parakeet-tdt-0.6b-v3`, matching the base talker.

An ASR round-trip confirms it loads and speaks correctly; it can't measure the prosody and stability RL is actually tuned for. If it turns out to sound better in practice, flipping the default is a one-line follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)