### PR TITLE
AI review: show which rows are applied together

### DIFF
--- a/docs/features/ai-review.md
+++ b/docs/features/ai-review.md
@@ -53,7 +53,7 @@ When a video is loaded, a **Play current** button appears at the bottom left. It
 
 ## Sentences across multiple lines
 
-Lines are grouped into sentence units, so a sentence that continues over several subtitles is always reviewed as a whole, and the model sees a couple of surrounding lines as read-only context. Corrections never move words between lines, so timing and reading speed are unaffected. Suggestions belonging to the same sentence are checked and unchecked together.
+Lines are grouped into sentence units, so a sentence that continues over several subtitles is always reviewed as a whole, and the model sees a couple of surrounding lines as read-only context. Corrections never move words between lines, so timing and reading speed are unaffected. Suggestions belonging to the same sentence are checked and unchecked together - such rows carry a link icon next to their checkbox naming the lines they are applied with, and selecting one shows the whole span ("Lines 7-8") in the reason strip below the grid.
 
 ## The prompt
 

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1478,6 +1478,7 @@
       "xNeedACloserLook": "{0} suggestion(s) need a closer look",
       "lineX": "Line {0}",
       "linesXToY": "Lines {0}-{1}",
+      "linkedLinesHint": "{0} are one sentence - they are applied together",
       "largeChangeWarning": "Large change - looks like a rewrite, review carefully",
       "mismatchWarning": "Does not resemble the original - may belong to a different line",
       "engineError": "The AI engine could not be reached: {0}",

--- a/src/ui/Features/Tools/AiReview/AiReviewViewModel.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewViewModel.cs
@@ -178,7 +178,18 @@ public partial class AiReviewViewModel : ObservableObject
 
     partial void OnSelectedSuggestionChanged(ReviewSuggestionItem? value)
     {
-        if (value == null)
+        UpdateReasonText();
+    }
+
+    /// <summary>
+    /// Rebuilds the reason strip for the selected suggestion. Also called while a review is still
+    /// streaming in: SelectionMode.AlwaysSelected picks the first suggestion the moment it arrives,
+    /// and the rest of its sentence unit only shows up in later replies - the strip said "Line 7"
+    /// for a fix that in the end drags line 8 along with it (issue #13775).
+    /// </summary>
+    private void UpdateReasonText()
+    {
+        if (SelectedSuggestion is not { } value)
         {
             ReasonText = string.Empty;
             return;
@@ -562,6 +573,10 @@ public partial class AiReviewViewModel : ObservableObject
             Suggestions.Add(item);
         }
 
+        // A unit only becomes a linked one when its second suggestion arrives, so recompute the
+        // whole set - the earlier rows need the link marker too.
+        ReviewUnitLinks.Update(_allSuggestions);
+        UpdateReasonText();
         UpdateChipCounts();
         UpdateSummary();
     }

--- a/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
@@ -228,12 +228,23 @@ public class AiReviewWindow : Window
                     {
                         Background = Brushes.Transparent,
                         Padding = new Thickness(4),
-                        Child = new CheckBox
+                        Child = new StackPanel
                         {
-                            Focusable = false,
-                            [!ToggleButton.IsCheckedProperty] = new Binding(nameof(ReviewSuggestionItem.IsSelected)),
-                            [!AutomationProperties.NameProperty] = new Binding(nameof(ReviewSuggestionItem.CategoryDisplay)),
+                            Orientation = Orientation.Horizontal,
+                            Spacing = 4,
                             HorizontalAlignment = HorizontalAlignment.Center,
+                            VerticalAlignment = VerticalAlignment.Center,
+                            Children =
+                            {
+                                new CheckBox
+                                {
+                                    Focusable = false,
+                                    [!ToggleButton.IsCheckedProperty] = new Binding(nameof(ReviewSuggestionItem.IsSelected)),
+                                    [!AutomationProperties.NameProperty] = new Binding(nameof(ReviewSuggestionItem.ApplyAccessibleName)),
+                                    VerticalAlignment = VerticalAlignment.Center,
+                                },
+                                MakeLinkedLinesIcon(),
+                            },
                         },
                     }),
                     Width = new GridLength(80), // content-sized (Auto) on the DataGrid; TableView treats Auto as star
@@ -506,6 +517,30 @@ public class AiReviewWindow : Window
         };
         Closing += delegate { vm.OnClosing(); };
         KeyDown += (_, e) => vm.OnKeyDown(e);
+    }
+
+    /// <summary>
+    /// The marker on a row whose sentence unit holds more than one suggestion: checking such a row
+    /// also checks its siblings (they are applied as one), which reads as "one click selected two
+    /// rows" without a visible reason (issue #13775). Bound, not built from the item, because a
+    /// unit only becomes linked when a later reply adds its second suggestion.
+    /// </summary>
+    private static Control MakeLinkedLinesIcon()
+    {
+        var icon = new Optris.Icons.Avalonia.Icon
+        {
+            Value = "mdi-link-variant",
+            FontSize = 13,
+            Opacity = 0.7,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        icon.Bind(IsVisibleProperty, new Binding(nameof(ReviewSuggestionItem.IsLinked)));
+        if (Se.Settings.Appearance.ShowHints)
+        {
+            icon.Bind(ToolTip.TipProperty, new Binding(nameof(ReviewSuggestionItem.LinkedLinesText)));
+        }
+
+        return icon;
     }
 
     private static IBrush GetCategoryBrush(ReviewCategory category)

--- a/src/ui/Features/Tools/AiReview/ReviewSuggestionItem.cs
+++ b/src/ui/Features/Tools/AiReview/ReviewSuggestionItem.cs
@@ -8,6 +8,21 @@ public partial class ReviewSuggestionItem : ObservableObject
 {
     [ObservableProperty] private bool _isSelected;
 
+    /// <summary>
+    /// Set when this suggestion shares its sentence unit with another suggestion - the whole unit
+    /// is checked and applied as one, so the row says which lines it drags along with it. Empty
+    /// for a suggestion that stands alone. See <see cref="ReviewUnitLinks"/>.
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsLinked))]
+    [NotifyPropertyChangedFor(nameof(ApplyAccessibleName))]
+    private string _linkedLinesText = string.Empty;
+
+    public bool IsLinked => !string.IsNullOrEmpty(LinkedLinesText);
+
+    /// <summary>Name for the apply checkbox - a screen reader gets the linked lines too, not just the category.</summary>
+    public string ApplyAccessibleName => IsLinked ? $"{CategoryDisplay} - {LinkedLinesText}" : CategoryDisplay;
+
     public int Number { get; init; }
     public int ParagraphIndex { get; init; }
     public int UnitId { get; init; }

--- a/src/ui/Features/Tools/AiReview/ReviewUnitLinks.cs
+++ b/src/ui/Features/Tools/AiReview/ReviewUnitLinks.cs
@@ -1,0 +1,33 @@
+using Nikse.SubtitleEdit.Logic.Config;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Features.Tools.AiReview;
+
+/// <summary>
+/// Marks the suggestions that belong to the same sentence unit (see <see cref="AiReviewChunker"/>).
+/// Such suggestions are checked and applied together - the model rebalances the wording across the
+/// line break, so applying one half of a sentence and not the other leaves duplicated or missing
+/// words. Checking one row therefore also checks its siblings, which looks like a selection bug
+/// unless the rows say why (issue #13775): every suggestion in a multi-line unit gets a
+/// <see cref="ReviewSuggestionItem.LinkedLinesText"/> the grid shows as a link icon and tooltip.
+/// </summary>
+public static class ReviewUnitLinks
+{
+    public static void Update(IReadOnlyList<ReviewSuggestionItem> suggestions)
+    {
+        var l = Se.Language.Tools.AiReview;
+        foreach (var unit in suggestions.GroupBy(s => s.UnitId))
+        {
+            var numbers = unit.Select(s => s.Number).OrderBy(n => n).ToList();
+            var text = numbers.Count > 1
+                ? string.Format(l.LinkedLinesHint, string.Format(l.LinesXToY, numbers[0], numbers[^1]))
+                : string.Empty;
+
+            foreach (var suggestion in unit)
+            {
+                suggestion.LinkedLinesText = text;
+            }
+        }
+    }
+}

--- a/src/ui/Logic/Config/Language/Tools/LanguageAiReview.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageAiReview.cs
@@ -22,6 +22,7 @@ public class LanguageAiReview
     public string XNeedACloserLook { get; set; }
     public string LineX { get; set; }
     public string LinesXToY { get; set; }
+    public string LinkedLinesHint { get; set; }
     public string LargeChangeWarning { get; set; }
     public string MismatchWarning { get; set; }
     public string EngineError { get; set; }
@@ -49,6 +50,7 @@ public class LanguageAiReview
         XNeedACloserLook = "{0} suggestion(s) need a closer look";
         LineX = "Line {0}";
         LinesXToY = "Lines {0}-{1}";
+        LinkedLinesHint = "{0} are one sentence - they are applied together";
         LargeChangeWarning = "Large change - looks like a rewrite, review carefully";
         MismatchWarning = "Does not resemble the original - may belong to a different line";
         EngineError = "The AI engine could not be reached: {0}";

--- a/tests/UI/Features/Tools/AiReview/ReviewUnitLinksTests.cs
+++ b/tests/UI/Features/Tools/AiReview/ReviewUnitLinksTests.cs
@@ -1,0 +1,130 @@
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Tools.AiReview;
+using Nikse.SubtitleEdit.Logic;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UITests.Features.Tools.AiReview;
+
+/// <summary>
+/// Suggestions that share a sentence unit are checked and applied as one, so checking a single row
+/// checks its siblings too - it looked like the grid selected two rows for one click (issue #13775).
+/// These tests pin the marker that explains it: every suggestion in a multi-line unit carries the
+/// line span, a suggestion that stands alone carries nothing.
+/// </summary>
+public class ReviewUnitLinksTests
+{
+    private static ReviewSuggestionItem MakeSuggestion(int number, int unitId)
+    {
+        return new ReviewSuggestionItem
+        {
+            Number = number,
+            ParagraphIndex = number - 1,
+            UnitId = unitId,
+            Category = ReviewCategory.Spelling,
+            Before = "before",
+            After = "after",
+        };
+    }
+
+    [Fact]
+    public void Update_SentenceAcrossTwoLines_MarksBothWithTheLineSpan()
+    {
+        var seven = MakeSuggestion(7, 3);
+        var eight = MakeSuggestion(8, 3);
+
+        ReviewUnitLinks.Update(new List<ReviewSuggestionItem> { seven, eight });
+
+        Assert.True(seven.IsLinked);
+        Assert.True(eight.IsLinked);
+        Assert.Equal(seven.LinkedLinesText, eight.LinkedLinesText);
+        Assert.Contains("7", seven.LinkedLinesText);
+        Assert.Contains("8", seven.LinkedLinesText);
+    }
+
+    [Fact]
+    public void Update_SuggestionAloneInItsUnit_IsNotLinked()
+    {
+        var alone = MakeSuggestion(7, 3);
+        var other = MakeSuggestion(9, 4);
+
+        ReviewUnitLinks.Update(new List<ReviewSuggestionItem> { alone, other });
+
+        Assert.False(alone.IsLinked);
+        Assert.Equal(string.Empty, alone.LinkedLinesText);
+        Assert.False(other.IsLinked);
+    }
+
+    [Fact]
+    public void Update_SiblingArrivesLater_MarksTheEarlierSuggestionToo()
+    {
+        // Replies stream in chunk by chunk: line 7's suggestion exists on its own for a while, and
+        // only a later reply makes its unit a linked one. The earlier row has to pick the marker up.
+        var seven = MakeSuggestion(7, 3);
+        var suggestions = new List<ReviewSuggestionItem> { seven };
+        ReviewUnitLinks.Update(suggestions);
+        Assert.False(seven.IsLinked);
+
+        suggestions.Add(MakeSuggestion(8, 3));
+        ReviewUnitLinks.Update(suggestions);
+
+        Assert.True(seven.IsLinked);
+    }
+
+    [Fact]
+    public void Update_LinkedLinesTextReachesTheAccessibleName()
+    {
+        var seven = MakeSuggestion(7, 3);
+        var eight = MakeSuggestion(8, 3);
+
+        ReviewUnitLinks.Update(new List<ReviewSuggestionItem> { seven, eight });
+
+        Assert.Contains(seven.CategoryDisplay, seven.ApplyAccessibleName);
+        Assert.Contains(seven.LinkedLinesText, seven.ApplyAccessibleName);
+    }
+
+    [AvaloniaFact]
+    public void Window_LinkIcon_ShowsOnLinkedRowsOnly()
+    {
+        var linked = MakeSuggestion(7, 3);
+        var alone = MakeSuggestion(9, 4);
+        ReviewUnitLinks.Update(new List<ReviewSuggestionItem> { linked, MakeSuggestion(8, 3), alone });
+
+        var vm = new AiReviewViewModel(new WindowService(new NullServiceProvider()));
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Line one", 0, 1000));
+        vm.Initialize(subtitle, null);
+        vm.Suggestions.Add(linked);
+        vm.Suggestions.Add(alone);
+
+        var window = new AiReviewWindow(vm);
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+
+            var icons = window.GetVisualDescendants()
+                .OfType<Optris.Icons.Avalonia.Icon>()
+                .Where(i => i.Value == "mdi-link-variant")
+                .ToList();
+
+            Assert.Equal(2, icons.Count); // one per realized row
+            Assert.Contains(icons, i => i.IsVisible && ReferenceEquals(i.DataContext, linked));
+            Assert.Contains(icons, i => !i.IsVisible && ReferenceEquals(i.DataContext, alone));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+}


### PR DESCRIPTION
Fixes #13775.

### What the report was

Checking one suggestion checked a second row too, which looks like a broken grid. It is not: rows 7 and 8 in the report are one sentence unit, and suggestions in the same unit are deliberately checked and applied together (the model rebalances the wording across the line break, so applying one half leaves duplicated or missing words). Nothing in the window said so.

The one thing that *would* have explained it - the reason strip, which prints "Lines 7-8" for a multi-line unit - said "Line 7" instead. It was computed once when the row was selected, and `SelectionMode.AlwaysSelected` picks the first suggestion the moment it arrives, while later chunks are still streaming in; line 8's suggestion did not exist yet.

### Changes

- Rows whose sentence unit holds more than one suggestion get a link icon next to their Apply checkbox, with a tooltip naming the lines: *"Lines 7-8 are one sentence - they are applied together"*. The same text is appended to the checkbox's accessible name.
- The reason strip is recomputed as suggestions stream in, so it names the full span once the unit is complete.
- `docs/features/ai-review.md` describes the marker.

The "Select none" button the report also asks for was added earlier today in 7cab926ab.

### Testing

`ReviewUnitLinksTests` covers the marker (linked unit, lone suggestion, sibling arriving in a later chunk, accessible name) plus a headless window test asserting the icon shows on the linked row only. Full UI suite: 3109 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)