### PR TITLE
Keep configured ASSA styles when the resolution is set from the video

### DIFF
--- a/docs/features/assa-resolution-resampler.md
+++ b/docs/features/assa-resolution-resampler.md
@@ -37,3 +37,9 @@ Resample ASSA subtitle styles and positions from one video resolution to another
 |----------|--------|
 | F1 | Show help |
 | Escape | Close dialog |
+
+## Resolution set automatically from the video
+
+With *Options → Settings → ASSA* set to update the resolution automatically, loading a video (or converting to ASS/SSA) writes the video's dimensions into PlayResX / PlayResY, and the styles are resampled to match.
+
+That resampling only applies to a subtitle whose header already named a resolution - a file authored for another picture size. A header without PlayResX / PlayResY is the built-in one, or your default style storage written into it (an OCR result takes that route): there, only the small built-in font sizes (25 and below) are lifted to the video height, and your font size, margins, outline and shadow are kept exactly as configured.

--- a/src/ui/Features/Assa/AssaResolutionResampler/AssaResamplerHelper.cs
+++ b/src/ui/Features/Assa/AssaResolutionResampler/AssaResamplerHelper.cs
@@ -6,6 +6,49 @@ namespace Nikse.SubtitleEdit.Features.Assa.ResolutionResampler;
 
 public static class AssaResamplerHelper
 {
+    /// <summary>
+    /// Font sizes at or below this are the built-in ASSA default (authored against the 288-high
+    /// default resolution) rather than a size anyone picked - see <see cref="ScaleDefaultFontSizes"/>.
+    /// </summary>
+    private const decimal MaxDefaultFontSize = 25;
+
+    /// <summary>
+    /// Lifts the small default font sizes of a header that declares no PlayResX/PlayResY up to the
+    /// video height, the way SE 4 did when it set the resolution of a new subtitle.
+    /// <para>
+    /// Such a header is the built-in one (or the default style storage written into it), which is
+    /// authored against ASSA's 288-high default - a 20pt font there is 7% of the picture height and
+    /// would shrink to 2% the moment PlayResY becomes 1080. Only sizes at or below
+    /// <see cref="MaxDefaultFontSize"/> are touched: a larger size is one the user chose, and
+    /// margins, outline and shadow are never touched at all. Full resampling stays for headers that
+    /// do declare a resolution, where the file really was authored for another picture size
+    /// (issue #13799 - OCR results took the user's stored style and inflated every value in it).
+    /// </para>
+    /// </summary>
+    public static void ScaleDefaultFontSizes(Subtitle subtitle, decimal targetHeight)
+    {
+        if (string.IsNullOrEmpty(subtitle.Header) || targetHeight <= 0)
+        {
+            return;
+        }
+
+        var styles = AdvancedSubStationAlpha.GetSsaStylesFromHeader(subtitle.Header);
+        var changed = false;
+        foreach (var style in styles)
+        {
+            if (style.FontSize > 0 && style.FontSize <= MaxDefaultFontSize)
+            {
+                style.FontSize = AssaResampler.Resample(AdvancedSubStationAlpha.DefaultHeight, targetHeight, style.FontSize);
+                changed = true;
+            }
+        }
+
+        if (changed)
+        {
+            subtitle.Header = AdvancedSubStationAlpha.GetHeaderAndStylesFromAdvancedSubStationAlpha(subtitle.Header, styles);
+        }
+    }
+
     public static void ApplyResampling(
         Subtitle subtitle,
         decimal sourceWidth,

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -21772,30 +21772,45 @@ public partial class MainViewModel :
         var oldHeader = _subtitle.Header;
         _subtitle.Header = AdvancedSubStationAlpha.SetResolution(_subtitle.Header, _mediaInfo.Dimension.Width, _mediaInfo.Dimension.Height);
 
-        if (Se.Settings.Assa.AutoSetResolutionConvert && oldHeader != _subtitle.Header)
+        if (!Se.Settings.Assa.AutoSetResolutionConvert || oldHeader == _subtitle.Header)
         {
-            if (string.IsNullOrEmpty(oldHeader) || !oldHeader.Contains("[V4+ Styles]", StringComparison.OrdinalIgnoreCase))
-            {
-                oldHeader = AdvancedSubStationAlpha.DefaultHeader;
-            }
-
-            var oldWidth = AdvancedSubStationAlpha.DefaultWidth;
-            var oldHeight = AdvancedSubStationAlpha.DefaultHeight;
-
-            var playResX = AdvancedSubStationAlpha.GetTagValueFromHeader("PlayResX", "[Script Info]", oldHeader);
-            if (int.TryParse(playResX, out var width) && width >= 125 && width <= 4096)
-            {
-                oldWidth = width;
-            }
-
-            var playResY = AdvancedSubStationAlpha.GetTagValueFromHeader("PlayResY", "[Script Info]", oldHeader);
-            if (int.TryParse(playResY, out var height) && height >= 125 && height <= 4096)
-            {
-                oldHeight = height;
-            }
-
-            AssaResamplerHelper.ApplyResampling(_subtitle, oldWidth, oldHeight, _mediaInfo.Dimension.Width, _mediaInfo.Dimension.Height, true, true, true, true);
+            return;
         }
+
+        if (string.IsNullOrEmpty(oldHeader) || !oldHeader.Contains("[V4+ Styles]", StringComparison.OrdinalIgnoreCase))
+        {
+            oldHeader = AdvancedSubStationAlpha.DefaultHeader;
+        }
+
+        // A header that names no resolution is not a file authored for another picture size - it is
+        // the built-in header, or the user's default style storage written into it (an OCR result
+        // takes that route). Resampling it scaled every value the user had configured: font size,
+        // margins, outline and shadow all grew by the ratio to the video height (issue #13799).
+        // SE 4 only lifted the small built-in font sizes here, and that is all we do now.
+        if (!TryGetPlayRes(oldHeader, "PlayResX", out var oldWidth) ||
+            !TryGetPlayRes(oldHeader, "PlayResY", out var oldHeight))
+        {
+            AssaResamplerHelper.ScaleDefaultFontSizes(_subtitle, _mediaInfo.Dimension.Height);
+            return;
+        }
+
+        AssaResamplerHelper.ApplyResampling(_subtitle, oldWidth, oldHeight, _mediaInfo.Dimension.Width, _mediaInfo.Dimension.Height, true, true, true, true);
+    }
+
+    /// <summary>
+    /// Reads a PlayResX/PlayResY tag from an ASSA header, ignoring values outside what a picture
+    /// size can be (some files carry a leftover "PlayResX: 0").
+    /// </summary>
+    private static bool TryGetPlayRes(string header, string tag, out int value)
+    {
+        var raw = AdvancedSubStationAlpha.GetTagValueFromHeader(tag, "[Script Info]", header);
+        if (int.TryParse(raw, out value) && value >= 125 && value <= 4096)
+        {
+            return true;
+        }
+
+        value = 0;
+        return false;
     }
 
     internal void ComboBoxFrameRateSelectionChanged(object? sender, SelectionChangedEventArgs e)

--- a/tests/UI/Features/Assa/AssaResamplerDefaultFontSizeTests.cs
+++ b/tests/UI/Features/Assa/AssaResamplerDefaultFontSizeTests.cs
@@ -1,0 +1,116 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Assa.ResolutionResampler;
+using System.Linq;
+
+namespace UITests.Features.Assa;
+
+/// <summary>
+/// Setting the ASSA resolution from the video must not rewrite styles the user configured
+/// (issue #13799): an OCR result gets the default style storage written into a header that names
+/// no PlayResX/PlayResY, and resampling that header scaled font size, margins, outline and shadow
+/// by the ratio to the video height. SE 4 only lifted the small built-in font sizes in this case,
+/// which is what <see cref="AssaResamplerHelper.ScaleDefaultFontSizes"/> does.
+/// </summary>
+public class AssaResamplerDefaultFontSizeTests
+{
+    private static Subtitle MakeSubtitleWithStyle(decimal fontSize)
+    {
+        var style = new SsaStyle
+        {
+            Name = "Test-ASS",
+            FontName = "Courier New",
+            FontSize = fontSize,
+            MarginLeft = 5,
+            MarginRight = 5,
+            MarginVertical = 10,
+            OutlineWidth = 2,
+            ShadowWidth = 1,
+        };
+
+        return new Subtitle
+        {
+            Header = AdvancedSubStationAlpha.GetHeaderAndStylesFromAdvancedSubStationAlpha(
+                AdvancedSubStationAlpha.DefaultHeader,
+                new[] { style }.ToList()),
+        };
+    }
+
+    private static SsaStyle GetStyle(Subtitle subtitle)
+    {
+        return AdvancedSubStationAlpha.GetSsaStylesFromHeader(subtitle.Header).Single(s => s.Name == "Test-ASS");
+    }
+
+    [Fact]
+    public void ScaleDefaultFontSizes_UserPickedSize_LeavesTheWholeStyleAlone()
+    {
+        // The reported style: 30pt with 5/5/10 margins, outline 2, shadow 1. Every one of those
+        // values came back changed (44.6 / 9 / 9 / 15 / 3 / 1.5) before the fix.
+        var subtitle = MakeSubtitleWithStyle(30);
+
+        AssaResamplerHelper.ScaleDefaultFontSizes(subtitle, 1080);
+
+        var style = GetStyle(subtitle);
+        Assert.Equal(30, style.FontSize);
+        Assert.Equal(5, style.MarginLeft);
+        Assert.Equal(5, style.MarginRight);
+        Assert.Equal(10, style.MarginVertical);
+        Assert.Equal(2, style.OutlineWidth);
+        Assert.Equal(1, style.ShadowWidth);
+    }
+
+    [Fact]
+    public void ScaleDefaultFontSizes_BuiltInSize_IsLiftedToTheVideoHeight()
+    {
+        // 20pt against ASSA's 288-high default is 7% of the picture - it has to grow with PlayResY
+        // or the subtitle turns unreadable. Margins and widths still stay put.
+        var subtitle = MakeSubtitleWithStyle(20);
+
+        AssaResamplerHelper.ScaleDefaultFontSizes(subtitle, 1080);
+
+        var style = GetStyle(subtitle);
+        Assert.Equal(75, style.FontSize); // 20 * 1080 / 288
+        Assert.Equal(5, style.MarginLeft);
+        Assert.Equal(10, style.MarginVertical);
+        Assert.Equal(2, style.OutlineWidth);
+        Assert.Equal(1, style.ShadowWidth);
+    }
+
+    [Fact]
+    public void ScaleDefaultFontSizes_AtTheThreshold_IsStillLifted()
+    {
+        var subtitle = MakeSubtitleWithStyle(25);
+
+        AssaResamplerHelper.ScaleDefaultFontSizes(subtitle, 576);
+
+        Assert.Equal(50, GetStyle(subtitle).FontSize); // 25 * 576 / 288
+    }
+
+    [Fact]
+    public void ScaleDefaultFontSizes_NoHeaderOrNoVideoHeight_DoesNothing()
+    {
+        var noHeader = new Subtitle();
+        AssaResamplerHelper.ScaleDefaultFontSizes(noHeader, 1080);
+        Assert.True(string.IsNullOrEmpty(noHeader.Header));
+
+        var subtitle = MakeSubtitleWithStyle(20);
+        AssaResamplerHelper.ScaleDefaultFontSizes(subtitle, 0);
+        Assert.Equal(20, GetStyle(subtitle).FontSize);
+    }
+
+    [Fact]
+    public void ApplyResampling_HeaderWithARealResolution_StillScalesEverything()
+    {
+        // The other branch is untouched: a file authored for 1280x720 still resamples in full.
+        var subtitle = MakeSubtitleWithStyle(30);
+
+        AssaResamplerHelper.ApplyResampling(subtitle, 1280, 720, 1920, 1080);
+
+        var style = GetStyle(subtitle);
+        Assert.Equal(45, style.FontSize);
+        Assert.Equal(8, style.MarginLeft);
+        Assert.Equal(15, style.MarginVertical);
+        Assert.Equal(3, style.OutlineWidth);
+        Assert.Equal(1.5m, style.ShadowWidth);
+    }
+}


### PR DESCRIPTION
Fixes #13799.

### The report

With *Advanced Sub Station Alpha* as default format and a style marked default in the style storage, running OCR and then opening the ASSA styles dialog shows the stored style with different values — font size, margins, border and shadow all larger than configured.

### Cause

An OCR result has no header, so converting to ASS writes the default style storage into the built-in header ([MainViewModel.cs:27330](https://github.com/SubtitleEdit/subtitleedit/blob/main/src/ui/Features/Main/MainViewModel.cs#L27330)) and the next line sets the resolution from the video. That header names no `PlayResX`/`PlayResY`, and `SetAssaResolution` treated the absence as "authored for 384x288" — so `ApplyResampling` scaled font size, margins, outline, shadow and spacing of the style the user had just configured.

### What SE 4 did

`SetAssaResolutionWithChecks` (se4-legacy, `src/ui/Forms/Main.cs:24084`) only ran on an empty header, and in that case rescaled **font size only, and only when `FontSize <= 25`**:

```csharp
if (style.FontSize <= 25)
{
    const int defaultAssaHeight = 288;
    style.FontSize = AssaResampler.Resample(defaultAssaHeight, _videoInfo.Height, style.FontSize);
}
```

The threshold exists to fix the built-in ~20pt default (7% of a 288-high picture, 2% of a 1080-high one) without touching a size anyone picked. Margins, outline and shadow were never touched there.

### Change

`SetAssaResolution` now splits the two cases:

- **No `PlayResX`/`PlayResY` in the header** — the built-in header, or the style storage written into it. `AssaResamplerHelper.ScaleDefaultFontSizes` lifts font sizes of 25 and below to the video height; everything else is left exactly as configured.
- **A real resolution in the header** — unchanged, full resampling: that file genuinely was authored for another picture size.

Setting `PlayResX`/`PlayResY` itself is unchanged, as is the *ASSA tools → Change resolution...* dialog.

### Testing

`AssaResamplerDefaultFontSizeTests` covers the reported style (30pt, margins 5/5/10, outline 2, shadow 1 — nothing changes), the built-in size being lifted (20 → 75 at 1080), the threshold boundary, the no-header/no-video guards, and a control test that a header with a real resolution still resamples in full. Full UI suite passes.

### Not ported

SE 4 also prompted (`AssaResolutionPromptChange`) when a file's own resolution differed from the video instead of resampling silently. That is a separate behaviour change and is left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)