### PR TITLE
Prepare v5.2.0-beta17

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -3,6 +3,35 @@ Subtitle Edit Changelog
 
 -----------------------------------------------------------------------------------------------------
 
+v5.2.0-beta17 (18th of August 2026)
+
+* Trim embedded ASSA fonts to the characters actually used (attachments, font collector, batch convert) - thx hisui3393
+* Add show/hide settings for the format specific toolbar icons - thx GrampaWildWilly
+* Add a "Select none" button to the AI review window - thx fraternl
+* Add the CosyVoice3 RL talker models in both quantizations - thx subof
+* Show the subtitle on the video in "Visual sync" and "Set sync point" - thx gabiacas-ops
+* Make the toolbar frame rate usable like the SE 4 one - thx smt-joen
+* Use an index-mapped scrollbar for the subtitle list in the OCR window
+* Update ffmpeg to 9.0.1 (Windows) / 9.0 (macOS arm), Tesseract to 5.5.3, whisper.cpp to v1.9.2, libmpv to shinchiro 20260814, and Paddle OCR standalone to v1.4.0
+* Fix Shift+Delete still not cutting in a text box - thx GrampaWildWilly
+* Fix per-line voice cloning hanging on Windows - thx invio-a11y
+* Fix capitalization after "EE.UU." and other doubled Spanish abbreviations - thx fraternl
+* Fix the Spanish OCR replace rule for "clón" breaking words like "ciclón" - thx fraternl
+* Fix audio clip extraction progress jumping after Subtitle Edit regains focus - thx Davanix
+* Fix speech to text failing on videos where the audio is not the first stream - thx emsb8888-prog
+* Fix speech to text transcribing a different audio track than the engine picks on multi-track files
+* Fix the main window being stuck on screen when a modal dialog is minimized - thx emsb8888-prog
+* Fix text to speech losing the whole run when a local engine crashes mid-generation - thx subof
+* Fix the waveform cursor running ahead of the audio when playback resumes - thx hisui3393
+* Fix ASSA styles from the style storage changing values after OCR - thx FunkyKnilch
+* Update Bulgarian translation - thx jekovcar
+* Update German translation - thx Need74
+* Update Italian translation - thx bovirus, GitGianluc
+* Update Japanese translation - thx hisui3393
+* Update Russian translation - thx jekovcar
+
+-----------------------------------------------------------------------------------------------------
+
 v5.2.0-beta16 (17th of August 2026)
 
 * Add a chapter editor with Matroska/MP4/OGM chapter formats (Video > More > Chapters) - thx alex64-pb

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "Subtitle Edit",
-  "version": "v5.2.0-beta16",
+  "version": "v5.2.0-beta17",
   "translatedBy": "",
   "cultureName": "en-US",
   "general": {

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -19,7 +19,7 @@ public class Se
     internal const int CurrentMacOsFontMigrationVersion = 1;
     internal const int CurrentShortcutsMigrationVersion = 2;
 
-    public static string Version { get; set; } = "v5.2.0-beta16";
+    public static string Version { get; set; } = "v5.2.0-beta17";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
Version bump to `v5.2.0-beta17` plus the change-log section for the **37 pull requests** merged since the `v5.2.0-beta16` tag.

Same three-file shape as the beta16 prep: `Se.cs`, the generated `English.json` (regenerated via `EnglishLanguageFileUpToDateTests`), and `change-log.txt`.

## How the entry set was compiled

Every merged PR was ancestor-checked against `v5.2.0-beta16` (`git merge-base --is-ancestor <merge-sha> v5.2.0-beta16`) rather than read off `git log` or merge timestamps — the beta16 tag commit predates same-day merges, and one PR (#13372) is missing from the `gh pr list` window entirely but is on `main`. Cross-checked against the 37 first-parent merges in `v5.2.0-beta16..HEAD`.

Credits come from each PR's linked issue/discussion author.

## Left out of the change log

| PR | Why |
|---|---|
| #13372 | Internal refactor (StringBuilder helper consolidation) |
| #13757 | Removes dead ChatLLM.cpp code, unreachable since March |
| #13792 | Bug-hunt fixes for defects introduced inside this same window (never shipped) |
| #13794 | CI test fix |

Wording is yours to curate — the goal here was a complete entry set.