### PR TITLE
Allow completion-format translate prompts on every local LLM engine

### DIFF
--- a/docs/features/auto-translate.md
+++ b/docs/features/auto-translate.md
@@ -66,6 +66,32 @@ needs about 20 GB of VRAM to run fully on the GPU — a 24 GB card in practice. 
 put the 12B ahead of the Gemma 3 27B baseline, so the 12B in the download list is already a strong
 choice and the jump to 27B buys less than the size difference suggests.
 
+## Prompts: chat models and completion models
+
+Every local-LLM engine (LM Studio, Ollama, KoboldCpp, llama.cpp, OpenAI Compatible API) has a
+**prompt** you can edit. `{0}` is replaced with the source language and `{1}` with the target
+language, both as English names.
+
+By default the prompt is an instruction and Subtitle Edit appends the subtitle text after it — what
+a chat-tuned model expects.
+
+Some translation models are trained on a *completion* format instead: the text has to sit inside the
+prompt, followed by a cue for the target language. Write `{2}` where the text belongs and Subtitle
+Edit sends the filled-in template as one block instead of appending anything. For example
+[MiLMMT-46](https://huggingface.co/xiaomi-research/MiLMMT-46-12B-v1.0) (Xiaomi's 46-language
+translation model) is trained on:
+
+```
+Translate this from {0} to {1}:
+{0}: {2}
+{1}:
+```
+
+The trailing `{1}:` cue is what makes such a model translate at all — without it, it tends to echo
+the source. Set the model's temperature to 0 where the engine offers it. Curated MiLMMT models in
+the llama.cpp engine's download list carry this prompt already; for LM Studio, KoboldCpp, Ollama or
+your own OpenAI-compatible server, paste it into the engine's prompt field.
+
 ## Engine Configuration
 
 Depending on the selected engine, you may need to provide:

--- a/src/libuilogic/AutoTranslate/KoboldCppTranslate.cs
+++ b/src/libuilogic/AutoTranslate/KoboldCppTranslate.cs
@@ -69,8 +69,9 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             {
                 Configuration.Settings.Tools.KoboldCppPrompt = new ToolsSettings().KoboldCppPrompt;
             }
-            var prompt = string.Format(Configuration.Settings.Tools.KoboldCppPrompt, sourceLanguageCode, targetLanguageCode);
-            var input = "{ " + modelJson + temperatureJson + " \"prompt\": \"" + Json.EncodeJsonText(prompt) + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\", \"stream\": false }";
+            var encodedUserMessage = LlmTranslatePrompt.BuildEncodedUserMessage(
+                Configuration.Settings.Tools.KoboldCppPrompt, sourceLanguageCode, targetLanguageCode, text);
+            var input = "{ " + modelJson + temperatureJson + " \"prompt\": \"" + encodedUserMessage + "\", \"stream\": false }";
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
             var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken).ConfigureAwait(false);

--- a/src/libuilogic/AutoTranslate/LlamaCppTranslate.cs
+++ b/src/libuilogic/AutoTranslate/LlamaCppTranslate.cs
@@ -62,26 +62,10 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
                 template = Configuration.Settings.Tools.LlamaCppPrompt;
             }
 
-            // Placeholders are replaced (not string.Format'ed) so braces in a user-edited prompt
-            // cannot throw. The "codes" this engine receives are already English language names -
-            // ListLanguages() puts the name in TranslationPair.Code - which is what the templates
-            // expect.
-            string encodedUserMessage;
-            if (template.Contains("{2}"))
-            {
-                // Completion-format models (MiLMMT-46): the trained prompt with the text embedded
-                // must reach the model verbatim, real newlines included - under the "<br />"
-                // placeholder encoding the model still translates but starts mirroring placeholder
-                // fragments into its output.
-                encodedUserMessage = Json.EncodeJsonText(BuildCompletionPrompt(template, sourceLanguageCode, targetLanguageCode, text), "\\n");
-            }
-            else
-            {
-                // Historical chat wire format: prompt, a real blank line, then the text - with
-                // line breaks inside either encoded as the "<br />" placeholder (decoded back below).
-                var prompt = template.Replace("{0}", sourceLanguageCode).Replace("{1}", targetLanguageCode);
-                encodedUserMessage = Json.EncodeJsonText(prompt) + "\\n\\n" + Json.EncodeJsonText(text.Trim());
-            }
+            // The "codes" this engine receives are already English language names - ListLanguages()
+            // puts the name in TranslationPair.Code - which is what the templates expect.
+            var encodedUserMessage = LlmTranslatePrompt.BuildEncodedUserMessage(
+                template, sourceLanguageCode, targetLanguageCode, text);
 
             // No "model" field: llama-server serves the single model it was started with, and for a
             // remote server the user's own llama-server does the same. Sending one would only risk a
@@ -118,21 +102,6 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             outputText = ChatGptTranslate.RemovePreamble(text, outputText);
             outputText = ChatGptTranslate.DecodeUnicodeEscapes(outputText);
             return outputText.Trim();
-        }
-
-        /// <summary>
-        /// Fills a completion-format prompt template: {0} = source language English name, {1} =
-        /// target language English name, {2} = the text to translate. Models like MiLMMT-46 are
-        /// trained with the text inside the prompt and a trailing target-language cue after it.
-        /// The text is substituted last so braces in subtitle text (ASSA override tags) can never
-        /// hit a placeholder.
-        /// </summary>
-        public static string BuildCompletionPrompt(string template, string sourceLanguageCode, string targetLanguageCode, string text)
-        {
-            return template
-                .Replace("{0}", sourceLanguageCode)
-                .Replace("{1}", targetLanguageCode)
-                .Replace("{2}", text.Trim());
         }
 
         /// <summary>

--- a/src/libuilogic/AutoTranslate/LlmTranslatePrompt.cs
+++ b/src/libuilogic/AutoTranslate/LlmTranslatePrompt.cs
@@ -1,0 +1,65 @@
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+
+namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
+{
+    /// <summary>
+    /// Builds the user message the local-LLM translate engines send, in either of the two prompt
+    /// shapes a model can need.
+    /// <para>
+    /// Chat models take an instruction and the text after it, which is the historical wire format:
+    /// the prompt, a real blank line, then the text - line breaks inside either part encoded as the
+    /// "&lt;br /&gt;" placeholder the engines decode again on the way back.
+    /// </para>
+    /// <para>
+    /// Completion-format models are trained on one block of text with the source embedded in it and
+    /// a trailing target-language cue, and they only translate when they get exactly that. A prompt
+    /// carrying <c>{2}</c> is such a template: it is filled in and sent verbatim, with real line
+    /// breaks (under "&lt;br /&gt;" encoding MiLMMT-46 starts mirroring placeholder fragments into
+    /// its output). Issue #13803 - this used to work only with the built-in llama.cpp engine, so the
+    /// same model behind LM Studio, KoboldCpp, Ollama or any OpenAI-compatible server could not be
+    /// prompted correctly.
+    /// </para>
+    /// </summary>
+    public static class LlmTranslatePrompt
+    {
+        /// <summary>
+        /// True when the template embeds the text itself (<c>{2}</c>) rather than expecting it
+        /// appended after the prompt.
+        /// </summary>
+        public static bool IsCompletionTemplate(string template)
+        {
+            return template != null && template.Contains("{2}");
+        }
+
+        /// <summary>
+        /// Fills a completion-format template: {0} = source language English name, {1} = target
+        /// language English name, {2} = the text to translate. Placeholders are replaced rather
+        /// than string.Format'ed, so braces in a user-edited prompt cannot throw, and the text goes
+        /// in last so brace sequences in subtitle text (ASSA override tags) can never hit one.
+        /// </summary>
+        public static string FillCompletionTemplate(string template, string sourceLanguage, string targetLanguage, string text)
+        {
+            return template
+                .Replace("{0}", sourceLanguage)
+                .Replace("{1}", targetLanguage)
+                .Replace("{2}", text.Trim());
+        }
+
+        /// <summary>
+        /// The JSON-encoded content of the user message, ready to drop into a request body.
+        /// </summary>
+        public static string BuildEncodedUserMessage(string template, string sourceLanguage, string targetLanguage, string text)
+        {
+            if (IsCompletionTemplate(template))
+            {
+                return Json.EncodeJsonText(FillCompletionTemplate(template, sourceLanguage, targetLanguage, text), "\\n");
+            }
+
+            var prompt = template
+                .Replace("{0}", sourceLanguage)
+                .Replace("{1}", targetLanguage);
+
+            return Json.EncodeJsonText(prompt) + "\\n\\n" + Json.EncodeJsonText(text.Trim());
+        }
+    }
+}

--- a/src/libuilogic/AutoTranslate/LmStudioTranslate.cs
+++ b/src/libuilogic/AutoTranslate/LmStudioTranslate.cs
@@ -63,8 +63,9 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             {
                 Configuration.Settings.Tools.LmStudioPrompt = new ToolsSettings().LmStudioPrompt;
             }
-            var prompt = string.Format(Configuration.Settings.Tools.LmStudioPrompt, sourceLanguageCode, targetLanguageCode);
-            var input = "{ " + modelJson + " \"messages\": [{ \"role\": \"user\", \"content\": \"" + Json.EncodeJsonText(prompt) + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]}";
+            var encodedUserMessage = LlmTranslatePrompt.BuildEncodedUserMessage(
+                Configuration.Settings.Tools.LmStudioPrompt, sourceLanguageCode, targetLanguageCode, text);
+            var input = "{ " + modelJson + " \"messages\": [{ \"role\": \"user\", \"content\": \"" + encodedUserMessage + "\" }]}";
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
             var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);

--- a/src/libuilogic/AutoTranslate/OllamaTranslate.cs
+++ b/src/libuilogic/AutoTranslate/OllamaTranslate.cs
@@ -65,11 +65,12 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             {
                 Configuration.Settings.Tools.OllamaPrompt = new ToolsSettings().OllamaPrompt;
             }
-            var prompt = string.Format(Configuration.Settings.Tools.OllamaPrompt, sourceLanguageCode, targetLanguageCode);
-            var input = "{ " + modelJson + " \"prompt\": \"" + Json.EncodeJsonText(prompt) + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\", \"stream\": false }";
+            var encodedUserMessage = LlmTranslatePrompt.BuildEncodedUserMessage(
+                Configuration.Settings.Tools.OllamaPrompt, sourceLanguageCode, targetLanguageCode, text);
+            var input = "{ " + modelJson + " \"prompt\": \"" + encodedUserMessage + "\", \"stream\": false }";
             if (Configuration.Settings.Tools.OllamaApiUrl.TrimEnd('/').EndsWith("v1/chat/completions"))
             {
-                input = "{ " + modelJson + " \"messages\": [{ \"role\": \"user\", \"content\": \"" + Json.EncodeJsonText(prompt) + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]}";
+                input = "{ " + modelJson + " \"messages\": [{ \"role\": \"user\", \"content\": \"" + encodedUserMessage + "\" }]}";
             }
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");

--- a/src/libuilogic/AutoTranslate/OpenAiCompatibleTranslate.cs
+++ b/src/libuilogic/AutoTranslate/OpenAiCompatibleTranslate.cs
@@ -1,4 +1,4 @@
-using Nikse.SubtitleEdit.Core.Common;
+﻿using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.Settings;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.UiLogic.Translate;
@@ -74,8 +74,9 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             {
                 Configuration.Settings.Tools.OpenAiCompatibleTranslatePrompt = new ToolsSettings().OpenAiCompatibleTranslatePrompt;
             }
-            var prompt = string.Format(Configuration.Settings.Tools.OpenAiCompatibleTranslatePrompt, sourceLanguageCode, targetLanguageCode);
-            var input = "{" + modelJson + "\"messages\": [{ \"role\": \"user\", \"content\": \"" + Json.EncodeJsonText(prompt) + "\\n\\n" + Json.EncodeJsonText(text.Trim()) + "\" }]}";
+            var encodedUserMessage = LlmTranslatePrompt.BuildEncodedUserMessage(
+                Configuration.Settings.Tools.OpenAiCompatibleTranslatePrompt, sourceLanguageCode, targetLanguageCode, text);
+            var input = "{" + modelJson + "\"messages\": [{ \"role\": \"user\", \"content\": \"" + encodedUserMessage + "\" }]}";
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
             var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);

--- a/tests/libuilogic/AutoTranslate/LlamaCppTranslateTests.cs
+++ b/tests/libuilogic/AutoTranslate/LlamaCppTranslateTests.cs
@@ -1,4 +1,4 @@
-using Nikse.SubtitleEdit.UiLogic.AutoTranslate;
+﻿using Nikse.SubtitleEdit.UiLogic.AutoTranslate;
 using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
 using System.Linq;
 
@@ -6,35 +6,6 @@ namespace LibUiLogicTests.AutoTranslate;
 
 public class LlamaCppTranslateTests
 {
-    // MiLMMT-46's completion format: the text sits inside the template and the trailing
-    // "Danish:" cue is what makes the model translate at all - appended-text prompts make it
-    // echo-loop the source instead.
-    [Fact]
-    public void BuildCompletionPrompt_EmbedsTextInsideTemplate()
-    {
-        var result = LlamaCppTranslate.BuildCompletionPrompt(
-            "Translate this from {0} to {1}:\n{0}: {2}\n{1}:", "English", "Danish",
-            "We've lost the signal.\nCheck the antenna on the roof.");
-
-        Assert.Equal(
-            "Translate this from English to Danish:\nEnglish: We've lost the signal.\nCheck the antenna on the roof.\nDanish:",
-            result);
-    }
-
-    // The text is substituted last, so brace sequences in subtitle text (ASSA override tags)
-    // must survive as-is and can never be treated as a placeholder.
-    [Fact]
-    public void BuildCompletionPrompt_TextWithBraces_IsNotReSubstituted()
-    {
-        var result = LlamaCppTranslate.BuildCompletionPrompt(
-            "Translate this from {0} to {1}:\n{0}: {2}\n{1}:", "English", "Danish",
-            @"{\an8}Look {0} up there.");
-
-        Assert.Equal(
-            "Translate this from English to Danish:\nEnglish: {\\an8}Look {0} up there.\nDanish:",
-            result);
-    }
-
     [Fact]
     public void TranslateModels_MiLmMtEntries_AreCompletionOnlyWithEmbeddedTextTemplate()
     {

--- a/tests/libuilogic/AutoTranslate/LlmTranslatePromptTests.cs
+++ b/tests/libuilogic/AutoTranslate/LlmTranslatePromptTests.cs
@@ -1,0 +1,90 @@
+using Nikse.SubtitleEdit.UiLogic.AutoTranslate;
+
+namespace LibUiLogicTests.AutoTranslate;
+
+/// <summary>
+/// The two prompt shapes the local-LLM translate engines send. Completion-format models
+/// (MiLMMT-46) need the text inside the template and a trailing target-language cue, and issue
+/// #13803 is that only the built-in llama.cpp engine could produce it - the same model behind LM
+/// Studio, KoboldCpp, Ollama or an OpenAI-compatible server got the chat shape instead.
+/// </summary>
+public class LlmTranslatePromptTests
+{
+    private const string CompletionTemplate = "Translate this from {0} to {1}:\n{0}: {2}\n{1}:";
+    private const string ChatTemplate = "Translate from {0} to {1}, keep the meaning:";
+
+    [Fact]
+    public void FillCompletionTemplate_EmbedsTextInsideTemplate()
+    {
+        var result = LlmTranslatePrompt.FillCompletionTemplate(
+            CompletionTemplate, "English", "Danish",
+            "We've lost the signal.\nCheck the antenna on the roof.");
+
+        Assert.Equal(
+            "Translate this from English to Danish:\nEnglish: We've lost the signal.\nCheck the antenna on the roof.\nDanish:",
+            result);
+    }
+
+    // The text is substituted last, so brace sequences in subtitle text (ASSA override tags)
+    // must survive as-is and can never be treated as a placeholder.
+    [Fact]
+    public void FillCompletionTemplate_TextWithBraces_IsNotReSubstituted()
+    {
+        var result = LlmTranslatePrompt.FillCompletionTemplate(
+            CompletionTemplate, "English", "Danish", @"{\an8}Look {0} up there.");
+
+        Assert.Equal(
+            "Translate this from English to Danish:\nEnglish: {\\an8}Look {0} up there.\nDanish:",
+            result);
+    }
+
+    [Theory]
+    [InlineData(CompletionTemplate, true)]
+    [InlineData(ChatTemplate, false)]
+    [InlineData(null, false)]
+    public void IsCompletionTemplate_DecidesOnTheTextPlaceholder(string? template, bool expected)
+    {
+        Assert.Equal(expected, LlmTranslatePrompt.IsCompletionTemplate(template!));
+    }
+
+    // Completion prompts go on the wire with real line breaks: under the "<br />" placeholder
+    // encoding MiLMMT-46 still translates but mirrors placeholder fragments into its output.
+    [Fact]
+    public void BuildEncodedUserMessage_CompletionTemplate_IsOneBlockWithRealNewlines()
+    {
+        var result = LlmTranslatePrompt.BuildEncodedUserMessage(
+            CompletionTemplate, "English", "Danish", "Line one.\nLine two.");
+
+        Assert.Equal(
+            "Translate this from English to Danish:\\nEnglish: Line one.\\nLine two.\\nDanish:",
+            result);
+        Assert.DoesNotContain("<br />", result);
+    }
+
+    // The historical chat wire format is unchanged: prompt, a real blank line, then the text,
+    // with line breaks inside either part as the "<br />" placeholder the engines decode back.
+    [Fact]
+    public void BuildEncodedUserMessage_ChatTemplate_KeepsTheHistoricalWireFormat()
+    {
+        var result = LlmTranslatePrompt.BuildEncodedUserMessage(
+            ChatTemplate, "English", "Danish", "Line one.\nLine two.");
+
+        Assert.Equal(
+            "Translate from English to Danish, keep the meaning:\\n\\nLine one.<br />Line two.",
+            result);
+    }
+
+    // The engines used to string.Format the prompt, which throws on any brace the user leaves in
+    // it - including the "{2}" this feature asks them to type.
+    [Theory]
+    [InlineData("Translate {0} to {1} and keep {curly} tags:")]
+    [InlineData("Translate {0} to {1}, answer as {\"text\": \"...\"}:")]
+    public void BuildEncodedUserMessage_BracesInTheUserPrompt_DoNotThrow(string template)
+    {
+        var result = LlmTranslatePrompt.BuildEncodedUserMessage(template, "English", "Danish", "Hello.");
+
+        Assert.Contains("English", result);
+        Assert.Contains("Danish", result);
+        Assert.EndsWith("Hello.", result);
+    }
+}


### PR DESCRIPTION
Fixes #13803.

### The report

The reporter wants to use [MiLMMT-46-12B-v1.0](https://huggingface.co/xiaomi-research/MiLMMT-46-12B-v1.0) through a local LM Studio or KoboldCpp server and asks which prompt settings to use. There was no answer to give: the prompt shape that model needs could not be expressed in those engines.

### Cause

MiLMMT-46 is trained on a completion format — the text sits *inside* the prompt, with a trailing target-language cue that is what makes it translate rather than echo the source:

```
Translate this from English to Danish:
English: We've lost the signal.
Danish:
```

PR #13664 added the `{2}` placeholder for this, but only in `LlamaCppTranslate`. `LmStudioTranslate`, `KoboldCppTranslate`, `OllamaTranslate` and `OpenAiCompatibleTranslate` all did:

```csharp
var prompt = string.Format(settingsPrompt, sourceLanguageCode, targetLanguageCode);
... Json.EncodeJsonText(prompt) + "\\n\\n" + Json.EncodeJsonText(text.Trim())
```

so the text could only ever be appended after the prompt — and `string.Format` threw a `FormatException` the moment anyone typed `{2}` (or any other brace, such as a JSON example) into the prompt field.

### Change

Prompt building moves into `LlmTranslatePrompt`, shared by all five engines:

- a template containing `{2}` is filled in (`{0}` source language, `{1}` target language, `{2}` text) and sent as **one block with real line breaks** — under the `<br />` placeholder encoding MiLMMT mirrors placeholder fragments into its output;
- anything else keeps the historical wire format exactly: prompt, a real blank line, the text, line breaks inside either part as `<br />`;
- placeholders are replaced rather than `string.Format`ed, so braces in a user's prompt can no longer throw.

The text is substituted last, so brace sequences in subtitle text (ASSA override tags) can never land on a placeholder.

`docs/features/auto-translate.md` gains a "Prompts: chat models and completion models" section with the MiLMMT template to paste.

### Testing

`LlmTranslatePromptTests` covers both wire formats, the `{2}` detection, ASSA braces in the text, and the brace-in-prompt case that used to throw. The two prompt tests that lived in `LlamaCppTranslateTests` moved along with the code; its curated-model tests stay. libuilogic 238 passed, UI 3127 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)