### PR TITLE
AI review: apply in passes instead of apply-and-close

### DIFF
--- a/docs/features/ai-review.md
+++ b/docs/features/ai-review.md
@@ -47,7 +47,9 @@ Each suggestion shows:
 
 Filter the grid with the category chips above it. Press **Apply N fixes** to apply the checked suggestions - this is a single undo step (Ctrl+Z reverts everything).
 
-**Apply does not close the window.** The applied rows disappear from the grid and everything else stays, so a review can be worked through in passes - press *Select none*, tick the suggestions you agree with, apply, then carry on with the rest. Each pass is its own undo step. **Done** closes the window; nothing is pending at that point, since every fix reached the subtitle when you applied it.
+**Apply does not close the window.** The applied rows disappear from the grid and everything else stays, so a review can be worked through in passes - press *Select none*, tick the suggestions you agree with, apply, then carry on with the rest. Each pass is its own undo step.
+
+The buttons next to it are the usual pair: **OK** applies the checked suggestions and closes, so the last pass is a single click, and **Cancel** closes without applying what is still checked. Passes you already applied stay applied - use Ctrl+Z to undo them.
 
 ### Listening to a line
 

--- a/docs/features/ai-review.md
+++ b/docs/features/ai-review.md
@@ -47,6 +47,8 @@ Each suggestion shows:
 
 Filter the grid with the category chips above it. Press **Apply N fixes** to apply the checked suggestions - this is a single undo step (Ctrl+Z reverts everything).
 
+**Apply does not close the window.** The applied rows disappear from the grid and everything else stays, so a review can be worked through in passes - press *Select none*, tick the suggestions you agree with, apply, then carry on with the rest. Each pass is its own undo step. **Done** closes the window; nothing is pending at that point, since every fix reached the subtitle when you applied it.
+
 ### Listening to a line
 
 When a video is loaded, a **Play current** button appears at the bottom left. It plays the selected suggestion's line in the video player and pauses at the end of the line, so you can hear what was actually said before deciding on a fix. Double-clicking a suggestion does the same, as does F5 (or Ctrl/Cmd+Space) - F5 follows your *Play selected lines* shortcut. Space is not used for playback here: it toggles the **Apply** checkbox of the selected row.
@@ -54,6 +56,18 @@ When a video is loaded, a **Play current** button appears at the bottom left. It
 ## Sentences across multiple lines
 
 Lines are grouped into sentence units, so a sentence that continues over several subtitles is always reviewed as a whole, and the model sees a couple of surrounding lines as read-only context. Corrections never move words between lines, so timing and reading speed are unaffected. Suggestions belonging to the same sentence are checked and unchecked together.
+
+## Choosing a model
+
+Any model in the list can proofread, but quality depends on how well it knows *your* language:
+
+- **English** - Llama 3.1 8B is the strongest proofreader of its size; Qwen 3.5 9B and Gemma 4 12B are close.
+- **European languages** (including Danish, Swedish, Norwegian, Finnish and Dutch) - the **EuroLLM 2512** models are trained on all 24 official EU languages and are the best pick here. Take **EuroLLM 22B (IQ4_XS)** if it fits, **EuroLLM 9B** otherwise.
+- **Low-end machines** - Gemma 4 E2B or Phi-4 mini run on almost anything, at a noticeable quality cost.
+
+Rule of thumb: pick the largest model whose download size leaves about 2 GB of VRAM headroom for context. On a 16 GB card that means the 12.3 GB EuroLLM 22B or the 7.6 GB Gemma 4 12B; on 8 GB, a 4-6 GB model such as EuroLLM 9B or Qwen 3.5 4B (Q8_0). A model that does not fit still runs - llama.cpp keeps the rest in system RAM - but much more slowly.
+
+Reviewing is not translating, so a bigger model mostly buys fewer false suggestions, not different categories of fix. If the review produces a lot of noise in your language, try a EuroLLM model before trying a larger one of the same family.
 
 ## The prompt
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1,4 +1,4 @@
-using Nikse.SubtitleEdit.UiLogic.Export;
+﻿using Nikse.SubtitleEdit.UiLogic.Export;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
@@ -7063,16 +7063,36 @@ public partial class MainViewModel :
         // Same filter as GetUpdateSubtitle() below, so index N of the reviewed subtitle is line N
         // here - that mapping is what lets the review window play the line of a suggestion.
         var reviewedLines = Subtitles.Where(s => !s.IsReferenceOnly).ToList();
-        var viewModel = await ShowDialogAsync<AiReviewWindow, AiReviewViewModel>(vm =>
+        // Apply + Done: each Apply pushes the checked fixes into the grid and the review window stays
+        // open with the rest of the suggestions, so a review that took minutes is not spent on one
+        // batch (issue #13807). AI review only rewrites text, so the line count never changes.
+        void ApplyToGrid(Subtitle applied)
         {
-            vm.Initialize(GetUpdateSubtitle(), SelectedSubtitleFormat, MakeReviewLinePlayer(reviewedLines), StopReviewLinePlayback);
-        });
+            // Count the lines this pass actually changed - the status used to report the subtitle's
+            // whole line count, which read as "fixed 1713 lines" for a two-line fix.
+            var changed = 0;
+            for (var i = 0; i < applied.Paragraphs.Count && i < reviewedLines.Count; i++)
+            {
+                if (reviewedLines[i].Text != applied.Paragraphs[i].Text)
+                {
+                    changed++;
+                }
+            }
 
-        if (viewModel.OkPressed)
-        {
-            ApplyFixedSubtitle(viewModel.FixedSubtitle, idx, SelectedSubtitleFormat);
-            ShowStatus(string.Format(Se.Language.Main.FixedXLines, viewModel.FixedSubtitle.Paragraphs.Count));
+            ApplyFixedSubtitle(applied, idx, SelectedSubtitleFormat);
+            ShowStatus(string.Format(Se.Language.Main.FixedXLines, changed));
+
+            // Re-fill the same list instance the play hook closed over: with reference-only rows in
+            // the grid, ApplyFixedSubtitle rebuilds it and the rows captured before are detached.
+            var current = Subtitles.Where(s => !s.IsReferenceOnly).ToList();
+            reviewedLines.Clear();
+            reviewedLines.AddRange(current);
         }
+
+        await ShowDialogAsync<AiReviewWindow, AiReviewViewModel>(vm =>
+        {
+            vm.Initialize(GetUpdateSubtitle(), SelectedSubtitleFormat, MakeReviewLinePlayer(reviewedLines), StopReviewLinePlayback, ApplyToGrid);
+        });
     }
 
     [RelayCommand]
@@ -11099,28 +11119,28 @@ public partial class MainViewModel :
             sub.Paragraphs.Add(line.ToParagraph(SelectedSubtitleFormat));
         }
 
-        var result = await ShowDialogAsync<AiReviewWindow, AiReviewViewModel>(vm =>
-            vm.Initialize(sub, SelectedSubtitleFormat, MakeReviewLinePlayer(ordered), StopReviewLinePlayback));
-        if (!result.OkPressed)
+        // Apply + Done, like the whole-file path (issue #13807): AI review only rewrites text, so the
+        // fixed subtitle stays 1:1 with the block sent in and every pass can be written straight back.
+        void ApplyToSelectedLines(Subtitle applied)
         {
-            _shortcutManager.ClearKeys();
-            return;
-        }
-
-        // AI review only rewrites text, so the fixed subtitle is 1:1 with the block sent in.
-        var fixedCount = 0;
-        for (var i = 0; i < result.FixedSubtitle.Paragraphs.Count && i < ordered.Count; i++)
-        {
-            var text = result.FixedSubtitle.Paragraphs[i].Text;
-            if (ordered[i].Text != text)
+            var fixedCount = 0;
+            for (var i = 0; i < applied.Paragraphs.Count && i < ordered.Count; i++)
             {
-                ordered[i].Text = text;
-                fixedCount++;
+                var text = applied.Paragraphs[i].Text;
+                if (ordered[i].Text != text)
+                {
+                    ordered[i].Text = text;
+                    fixedCount++;
+                }
             }
+
+            _updateAudioVisualizer = true;
+            ShowStatus(string.Format(Se.Language.Main.FixedXLines, fixedCount));
         }
 
-        _updateAudioVisualizer = true;
-        ShowStatus(string.Format(Se.Language.Main.FixedXLines, fixedCount));
+        await ShowDialogAsync<AiReviewWindow, AiReviewViewModel>(vm =>
+            vm.Initialize(sub, SelectedSubtitleFormat, MakeReviewLinePlayer(ordered), StopReviewLinePlayback, ApplyToSelectedLines));
+        _shortcutManager.ClearKeys();
     }
 
     [RelayCommand]

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -7063,9 +7063,10 @@ public partial class MainViewModel :
         // Same filter as GetUpdateSubtitle() below, so index N of the reviewed subtitle is line N
         // here - that mapping is what lets the review window play the line of a suggestion.
         var reviewedLines = Subtitles.Where(s => !s.IsReferenceOnly).ToList();
-        // Apply + Done: each Apply pushes the checked fixes into the grid and the review window stays
+        // Apply/Ok: each Apply pushes the checked fixes into the grid and the review window stays
         // open with the rest of the suggestions, so a review that took minutes is not spent on one
-        // batch (issue #13807). AI review only rewrites text, so the line count never changes.
+        // batch (issue #13807); Ok does the same and closes. AI review only rewrites text, so the
+        // line count never changes.
         void ApplyToGrid(Subtitle applied)
         {
             // Count the lines this pass actually changed - the status used to report the subtitle's
@@ -11119,8 +11120,9 @@ public partial class MainViewModel :
             sub.Paragraphs.Add(line.ToParagraph(SelectedSubtitleFormat));
         }
 
-        // Apply + Done, like the whole-file path (issue #13807): AI review only rewrites text, so the
-        // fixed subtitle stays 1:1 with the block sent in and every pass can be written straight back.
+        // Apply/Ok in passes, like the whole-file path (issue #13807): AI review only rewrites text,
+        // so the fixed subtitle stays 1:1 with the block sent in and every pass can be written
+        // straight back.
         void ApplyToSelectedLines(Subtitle applied)
         {
             var fixedCount = 0;

--- a/src/ui/Features/Tools/AiReview/AiReviewViewModel.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -56,6 +56,17 @@ public partial class AiReviewViewModel : ObservableObject
     [ObservableProperty] private bool _hasWarningNote;
     [ObservableProperty] private bool _isPlayVisible;
 
+    /// <summary>
+    /// True for callers without a live target: Apply writes the fixes, sets <see cref="OkPressed"/>
+    /// and closes, and the second button is a plain Cancel. With a target, Apply keeps the window
+    /// open and that button reads "Done" - nothing is left pending to cancel (issue #13807).
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CloseButtonText))]
+    private bool _isApplyAndClose = true;
+
+    public string CloseButtonText => IsApplyAndClose ? Se.Language.General.Cancel : Se.Language.General.Done;
+
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }
     public Subtitle FixedSubtitle { get; private set; } = new();
@@ -67,6 +78,12 @@ public partial class AiReviewViewModel : ObservableObject
     private string _languageCode = "en";
     private CancellationTokenSource _cancellationTokenSource = new();
     private bool _syncingSelection;
+    private int _appliedCount;
+
+    // Set by callers with a live target (both main-window entry points): "Apply" pushes the checked
+    // fixes to them and the window stays open, so a long review can be worked through in passes
+    // instead of ending at the first Apply (issue #13807).
+    private Action<Subtitle>? _applyCallback;
 
     // Video preview hooks handed in by the caller - they drive the main window's video player.
     // Null when no video is loaded; the play button is then hidden.
@@ -121,15 +138,24 @@ public partial class AiReviewViewModel : ObservableObject
     /// hide the play button. <paramref name="stopPlayback"/> stops such a preview when the window
     /// closes - only ever called when this window actually started playback.
     /// </summary>
+    /// <param name="applyCallback">
+    /// When set, the Apply button hands the fixed subtitle to the caller and leaves the window open
+    /// - the applied suggestions drop out of the list and the rest stay reviewable, so a review that
+    /// took minutes to produce does not have to be run again to apply a second batch (issue #13807).
+    /// Callers without a live target pass null and get the old apply-and-close behavior.
+    /// </param>
     public void Initialize(
         Subtitle subtitle,
         SubtitleFormat? subtitleFormat,
         Action<int>? playLine = null,
-        Action? stopPlayback = null)
+        Action? stopPlayback = null,
+        Action<Subtitle>? applyCallback = null)
     {
         _subtitle = subtitle;
         _playLine = playLine;
         _stopPlayback = stopPlayback;
+        _applyCallback = applyCallback;
+        IsApplyAndClose = applyCallback == null;
         IsPlayVisible = playLine != null;
         _languageCode = LanguageAutoDetect.AutoDetectGoogleLanguage(subtitle);
         LanguageDisplay = GetLanguageDisplayName(_languageCode);
@@ -545,6 +571,17 @@ public partial class AiReviewViewModel : ObservableObject
             IsWarning = isWarning,
             IsSelected = !isWarning,
         };
+        AddSuggestionItem(item);
+    }
+
+    /// <summary>
+    /// Puts a built suggestion into the full list and, when it passes the active category filter,
+    /// into the grid. Review() runs on the UI thread (its awaits resume on the captured context),
+    /// so this is synchronous - posting via the dispatcher made the end-of-review status read a
+    /// stale (possibly empty) suggestion count while the last chunk's items were still queued.
+    /// </summary>
+    internal void AddSuggestionItem(ReviewSuggestionItem item)
+    {
         item.PropertyChanged += (_, e) =>
         {
             if (e.PropertyName == nameof(ReviewSuggestionItem.IsSelected))
@@ -553,9 +590,6 @@ public partial class AiReviewViewModel : ObservableObject
             }
         };
 
-        // Review() runs on the UI thread (its awaits resume on the captured context), so add
-        // synchronously - posting via the dispatcher made the end-of-review status read a stale
-        // (possibly empty) suggestion count while the last chunk's items were still queued.
         _allSuggestions.Add(item);
         if (PassesFilter(item))
         {
@@ -753,18 +787,66 @@ public partial class AiReviewViewModel : ObservableObject
     {
         SaveSettings();
 
-        FixedSubtitle = new Subtitle(_subtitle, false);
+        var applied = ApplySelectedSuggestions();
+        FixedSubtitle = applied;
+
+        if (_applyCallback == null)
+        {
+            OkPressed = true;
+            _cancellationTokenSource.Cancel();
+            Window?.Close();
+            return;
+        }
+
+        _applyCallback(applied);
+
+        // Keep working against what the caller now holds, and drop the suggestions that are in it -
+        // an applied row is done, and its "before" text no longer exists in the subtitle.
+        _subtitle = new Subtitle(applied, false);
+        RemoveAppliedSuggestions();
+        StatusText = string.Format(Se.Language.Main.FixedXLines, _appliedCount);
+    }
+
+    /// <summary>
+    /// A copy of the working subtitle with every checked suggestion written into it.
+    /// </summary>
+    private Subtitle ApplySelectedSuggestions()
+    {
+        var applied = new Subtitle(_subtitle, false);
+        _appliedCount = 0;
         foreach (var item in _allSuggestions.Where(s => s.IsSelected))
         {
-            if (item.ParagraphIndex >= 0 && item.ParagraphIndex < FixedSubtitle.Paragraphs.Count)
+            if (item.ParagraphIndex >= 0 && item.ParagraphIndex < applied.Paragraphs.Count)
             {
-                FixedSubtitle.Paragraphs[item.ParagraphIndex].Text = item.After;
+                applied.Paragraphs[item.ParagraphIndex].Text = item.After;
+                _appliedCount++;
             }
         }
 
-        OkPressed = true;
-        _cancellationTokenSource.Cancel();
-        Window?.Close();
+        return applied;
+    }
+
+    /// <summary>
+    /// Drops the suggestions that were just applied from both the full list and the filtered grid,
+    /// then refreshes the chip counts, the summary and the reason strip.
+    /// </summary>
+    private void RemoveAppliedSuggestions()
+    {
+        var applied = _allSuggestions.Where(s => s.IsSelected).ToList();
+        if (applied.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var item in applied)
+        {
+            _allSuggestions.Remove(item);
+            Suggestions.Remove(item);
+        }
+
+        SelectedSuggestion = Suggestions.FirstOrDefault();
+        UpdateChipCounts();
+        UpdateSummary();
     }
 
     [RelayCommand]

--- a/src/ui/Features/Tools/AiReview/AiReviewViewModel.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewViewModel.cs
@@ -57,15 +57,12 @@ public partial class AiReviewViewModel : ObservableObject
     [ObservableProperty] private bool _isPlayVisible;
 
     /// <summary>
-    /// True for callers without a live target: Apply writes the fixes, sets <see cref="OkPressed"/>
-    /// and closes, and the second button is a plain Cancel. With a target, Apply keeps the window
-    /// open and that button reads "Done" - nothing is left pending to cancel (issue #13807).
+    /// True for callers with a live target (both main-window entry points): an "Apply" button is
+    /// shown next to Ok, so the checked fixes can be handed over without closing and a long review
+    /// can be worked through in passes (issue #13807). Callers without a target have nowhere to
+    /// push a pass, so they get the plain Ok/Cancel pair.
     /// </summary>
-    [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(CloseButtonText))]
-    private bool _isApplyAndClose = true;
-
-    public string CloseButtonText => IsApplyAndClose ? Se.Language.General.Cancel : Se.Language.General.Done;
+    [ObservableProperty] private bool _isApplyVisible;
 
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }
@@ -155,7 +152,7 @@ public partial class AiReviewViewModel : ObservableObject
         _playLine = playLine;
         _stopPlayback = stopPlayback;
         _applyCallback = applyCallback;
-        IsApplyAndClose = applyCallback == null;
+        IsApplyVisible = applyCallback != null;
         IsPlayVisible = playLine != null;
         _languageCode = LanguageAutoDetect.AutoDetectGoogleLanguage(subtitle);
         LanguageDisplay = GetLanguageDisplayName(_languageCode);
@@ -653,6 +650,7 @@ public partial class AiReviewViewModel : ObservableObject
         var selected = SelectedCount;
         SummaryText = string.Format(l.XSuggestionsYSelected, _allSuggestions.Count, selected);
         ApplyButtonText = string.Format(l.ApplyXFixes, selected);
+        ApplyCommand.NotifyCanExecuteChanged();
     }
 
     [RelayCommand]
@@ -782,6 +780,10 @@ public partial class AiReviewViewModel : ObservableObject
         await _windowService.ShowDialogAsync<AiReviewPromptWindow, AiReviewPromptViewModel>(Window, vm => vm.Initialize());
     }
 
+    /// <summary>
+    /// Writes the checked fixes and closes - the Ok half of the Ok/Apply pair, so finishing on the
+    /// last pass is one click rather than Apply followed by a separate close.
+    /// </summary>
     [RelayCommand]
     private void Ok()
     {
@@ -792,12 +794,37 @@ public partial class AiReviewViewModel : ObservableObject
 
         if (_applyCallback == null)
         {
+            // No live target: the caller picks the result up from FixedSubtitle after the dialog.
             OkPressed = true;
-            _cancellationTokenSource.Cancel();
-            Window?.Close();
+        }
+        else
+        {
+            // The callback already delivered the fixes, so OkPressed stays false - a caller that
+            // passes a callback and also reads FixedSubtitle would otherwise apply the pass twice.
+            _applyCallback(applied);
+        }
+
+        _cancellationTokenSource.Cancel();
+        Window?.Close();
+    }
+
+    /// <summary>
+    /// Hands the checked fixes to the caller and leaves the window open: the applied rows drop out
+    /// of the grid, the rest stay reviewable, and the next pass builds on the result - so a review
+    /// that took minutes does not have to be run again to apply a second batch (issue #13807).
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanApply))]
+    private void Apply()
+    {
+        if (_applyCallback == null)
+        {
             return;
         }
 
+        SaveSettings();
+
+        var applied = ApplySelectedSuggestions();
+        FixedSubtitle = applied;
         _applyCallback(applied);
 
         // Keep working against what the caller now holds, and drop the suggestions that are in it -
@@ -806,6 +833,10 @@ public partial class AiReviewViewModel : ObservableObject
         RemoveAppliedSuggestions();
         StatusText = string.Format(Se.Language.Main.FixedXLines, _appliedCount);
     }
+
+    // Nothing checked means Apply would hand the caller an unchanged subtitle - an undo step and a
+    // "fixed 0 lines" status for no change at all.
+    private bool CanApply() => SelectedCount > 0;
 
     /// <summary>
     /// A copy of the working subtitle with every checked suggestion written into it.

--- a/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
@@ -1,4 +1,4 @@
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
@@ -460,7 +460,10 @@ public class AiReviewWindow : Window
         buttonApply.Bind(ContentControl.ContentProperty, new Binding(nameof(vm.ApplyButtonText)));
         buttonApply.WithIconLeft("fa-solid fa-check");
 
+        // "Cancel" only makes sense when Apply is what closes the window; with a live target the
+        // fixes are already in the main grid, so the button reads "Done" (issue #13807).
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        buttonCancel.Bind(ContentControl.ContentProperty, new Binding(nameof(vm.CloseButtonText)));
 
         var bottomBar = new Grid
         {

--- a/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
@@ -456,21 +456,24 @@ public class AiReviewWindow : Window
             .WithIconLeft("fa-solid fa-stop");
         buttonStop.Bind(IsVisibleProperty, new Binding(nameof(vm.IsReviewing)));
 
-        var buttonApply = UiUtil.MakeButton(string.Empty, vm.OkCommand);
+        // Apply/Ok/Cancel, the same shape as Multiple replace: Apply writes the checked fixes and
+        // keeps the window open so the review can be worked through in passes (issue #13807), Ok
+        // writes them and closes, Cancel closes and leaves the unapplied ones behind. Apply is
+        // hidden for callers without a live target - they have nowhere to receive a pass.
+        var buttonApply = UiUtil.MakeButton(string.Empty, vm.ApplyCommand)
+            .WithBindIsVisible(nameof(vm.IsApplyVisible));
         buttonApply.Bind(ContentControl.ContentProperty, new Binding(nameof(vm.ApplyButtonText)));
         buttonApply.WithIconLeft("fa-solid fa-check");
 
-        // "Cancel" only makes sense when Apply is what closes the window; with a live target the
-        // fixes are already in the main grid, so the button reads "Done" (issue #13807).
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
-        buttonCancel.Bind(ContentControl.ContentProperty, new Binding(nameof(vm.CloseButtonText)));
 
         var bottomBar = new Grid
         {
             ColumnDefinitions = new ColumnDefinitions("Auto,*,Auto"),
         };
         bottomBar.Add(leftButtons, 0, 0);
-        bottomBar.Add(UiUtil.MakeButtonBar(buttonReview, buttonStop, buttonApply, buttonCancel), 0, 2);
+        bottomBar.Add(UiUtil.MakeButtonBar(buttonReview, buttonStop, buttonApply, buttonOk, buttonCancel), 0, 2);
 
         // ---------- layout ----------
         var grid = new Grid

--- a/tests/UI/Features/Tools/AiReview/AiReviewApplyTests.cs
+++ b/tests/UI/Features/Tools/AiReview/AiReviewApplyTests.cs
@@ -1,19 +1,22 @@
+using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
+using Avalonia.LogicalTree;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Tools.AiReview;
 using Nikse.SubtitleEdit.Logic;
-using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Windows.Input;
 
 namespace UITests.Features.Tools.AiReview;
 
 /// <summary>
-/// "Apply" used to work like OK: it wrote the checked fixes and closed the window, so applying a
-/// second batch meant running the whole review again - minutes of model time for a subtitle that
-/// needs suggestion-by-suggestion judgement (issue #13807). With a live target the window now stays
-/// open, hands each pass to the caller and drops the rows it applied.
+/// The single button used to work like OK: it wrote the checked fixes and closed the window, so
+/// applying a second batch meant running the whole review again - minutes of model time for a
+/// subtitle that needs suggestion-by-suggestion judgement (issue #13807). The window now offers the
+/// standard Apply/Ok pair: Apply hands a pass to the caller and stays open, dropping the rows it
+/// applied; Ok writes the checked fixes and closes.
 /// </summary>
 public class AiReviewApplyTests
 {
@@ -72,7 +75,7 @@ public class AiReviewApplyTests
             MakeSuggestion(0, "Their going home.", "They're going home."),
             MakeSuggestion(1, "Its to late.", "It's too late."));
 
-        vm.OkCommand.Execute(null);
+        vm.ApplyCommand.Execute(null);
 
         Assert.Single(applied);
         Assert.Equal("They're going home.", applied[0].Paragraphs[0].Text);
@@ -92,7 +95,7 @@ public class AiReviewApplyTests
         second.IsSelected = false;
         AddSuggestions(vm, first, second);
 
-        vm.OkCommand.Execute(null);
+        vm.ApplyCommand.Execute(null);
 
         Assert.Equal(new[] { second }, vm.Suggestions.ToArray());
         Assert.False(second.IsSelected); // the remaining row keeps its own checkbox state
@@ -110,9 +113,9 @@ public class AiReviewApplyTests
         second.IsSelected = false;
         AddSuggestions(vm, first, second);
 
-        vm.OkCommand.Execute(null);
+        vm.ApplyCommand.Execute(null);
         second.IsSelected = true;
-        vm.OkCommand.Execute(null);
+        vm.ApplyCommand.Execute(null);
 
         Assert.Equal(2, applied.Count);
         // The second pass carries the first pass's fix - it is applied to the updated subtitle.
@@ -122,7 +125,7 @@ public class AiReviewApplyTests
     }
 
     [AvaloniaFact]
-    public void Apply_WithoutCallback_KeepsTheApplyAndCloseContract()
+    public void Ok_WithoutCallback_KeepsTheApplyAndCloseContract()
     {
         var vm = MakeViewModel();
         vm.Initialize(MakeSubtitle(), null);
@@ -135,15 +138,86 @@ public class AiReviewApplyTests
         Assert.Single(vm.Suggestions); // nothing pruned - the window is closing
     }
 
+    /// <summary>
+    /// Ok is the other half of the pair: it applies the checked fixes through the same callback and
+    /// closes, so the last pass does not need Apply plus a separate close.
+    /// </summary>
     [AvaloniaFact]
-    public void CloseButtonText_FollowsTheApplyMode()
+    public void Ok_WithCallback_AppliesThroughTheCallbackAndCloses()
     {
-        var closing = MakeViewModel();
-        closing.Initialize(MakeSubtitle(), null);
-        Assert.Equal(Se.Language.General.Cancel, closing.CloseButtonText);
+        var applied = new List<Subtitle>();
+        var vm = MakeViewModel();
+        vm.Initialize(MakeSubtitle(), null, null, null, applied.Add);
+        AddSuggestions(vm, MakeSuggestion(1, "Its to late.", "It's too late."));
 
-        var staying = MakeViewModel();
-        staying.Initialize(MakeSubtitle(), null, null, null, _ => { });
-        Assert.Equal(Se.Language.General.Done, staying.CloseButtonText);
+        vm.OkCommand.Execute(null);
+
+        Assert.Single(applied);
+        Assert.Equal("It's too late.", applied[0].Paragraphs[1].Text);
+        // The callback delivered the pass, so the pull-based contract stays off - a caller reading
+        // both would apply the same fixes twice.
+        Assert.False(vm.OkPressed);
+    }
+
+    /// <summary>
+    /// Applying nothing would cost the caller an undo step and a "fixed 0 lines" status for an
+    /// unchanged subtitle, so Apply is disabled until something is checked. Ok stays enabled: with
+    /// no fixes checked it is simply a close.
+    /// </summary>
+    [AvaloniaFact]
+    public void Apply_IsDisabledWhenNothingIsChecked()
+    {
+        var vm = MakeViewModel();
+        vm.Initialize(MakeSubtitle(), null, null, null, _ => { });
+        var suggestion = MakeSuggestion(0, "Their going home.", "They're going home.");
+        AddSuggestions(vm, suggestion);
+        Assert.True(vm.ApplyCommand.CanExecute(null));
+
+        vm.SelectNoneCommand.Execute(null);
+
+        Assert.False(vm.ApplyCommand.CanExecute(null));
+        Assert.True(vm.OkCommand.CanExecute(null));
+    }
+
+    /// <summary>
+    /// Apply only makes sense with somewhere to push a pass to, so callers without a live target
+    /// keep the plain Ok/Cancel pair - and the button bar must follow, not just the view model.
+    /// </summary>
+    [AvaloniaFact]
+    public void ApplyButton_IsShownOnlyForCallersWithALiveTarget()
+    {
+        var inPasses = MakeViewModel();
+        inPasses.Initialize(MakeSubtitle(), null, null, null, _ => { });
+        var windowInPasses = new AiReviewWindow(inPasses);
+        try
+        {
+            Assert.True(inPasses.IsApplyVisible);
+            Assert.True(FindButton(windowInPasses, inPasses.ApplyCommand)?.IsVisible);
+            Assert.NotNull(FindButton(windowInPasses, inPasses.OkCommand));
+            Assert.NotNull(FindButton(windowInPasses, inPasses.CancelCommand));
+        }
+        finally
+        {
+            windowInPasses.Close();
+        }
+
+        var applyAndClose = MakeViewModel();
+        applyAndClose.Initialize(MakeSubtitle(), null);
+        var windowApplyAndClose = new AiReviewWindow(applyAndClose);
+        try
+        {
+            Assert.False(applyAndClose.IsApplyVisible);
+            Assert.False(FindButton(windowApplyAndClose, applyAndClose.ApplyCommand)?.IsVisible);
+            Assert.NotNull(FindButton(windowApplyAndClose, applyAndClose.OkCommand));
+        }
+        finally
+        {
+            windowApplyAndClose.Close();
+        }
+    }
+
+    private static Button? FindButton(Control root, ICommand command)
+    {
+        return root.GetLogicalDescendants().OfType<Button>().FirstOrDefault(b => b.Command == command);
     }
 }

--- a/tests/UI/Features/Tools/AiReview/AiReviewApplyTests.cs
+++ b/tests/UI/Features/Tools/AiReview/AiReviewApplyTests.cs
@@ -1,0 +1,149 @@
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Tools.AiReview;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UITests.Features.Tools.AiReview;
+
+/// <summary>
+/// "Apply" used to work like OK: it wrote the checked fixes and closed the window, so applying a
+/// second batch meant running the whole review again - minutes of model time for a subtitle that
+/// needs suggestion-by-suggestion judgement (issue #13807). With a live target the window now stays
+/// open, hands each pass to the caller and drops the rows it applied.
+/// </summary>
+public class AiReviewApplyTests
+{
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private static AiReviewViewModel MakeViewModel()
+    {
+        return new AiReviewViewModel(new WindowService(new NullServiceProvider()));
+    }
+
+    private static Subtitle MakeSubtitle()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Their going home.", 0, 1000));
+        subtitle.Paragraphs.Add(new Paragraph("Its to late.", 1500, 2500));
+        subtitle.Paragraphs.Add(new Paragraph("Who's car is that?", 3000, 4000));
+        return subtitle;
+    }
+
+    private static ReviewSuggestionItem MakeSuggestion(int paragraphIndex, string before, string after)
+    {
+        return new ReviewSuggestionItem
+        {
+            Number = paragraphIndex + 1,
+            ParagraphIndex = paragraphIndex,
+            UnitId = paragraphIndex,
+            Category = ReviewCategory.Spelling,
+            Before = before,
+            After = after,
+            IsSelected = true,
+        };
+    }
+
+    /// <summary>
+    /// Fills the view model the way a finished review does: the suggestions the grid shows are the
+    /// public collection, which Apply also prunes.
+    /// </summary>
+    private static void AddSuggestions(AiReviewViewModel vm, params ReviewSuggestionItem[] items)
+    {
+        foreach (var item in items)
+        {
+            vm.AddSuggestionItem(item);
+        }
+    }
+
+    [AvaloniaFact]
+    public void Apply_WithCallback_HandsFixesOverAndKeepsTheWindowOpen()
+    {
+        var applied = new List<Subtitle>();
+        var vm = MakeViewModel();
+        vm.Initialize(MakeSubtitle(), null, null, null, applied.Add);
+        AddSuggestions(vm,
+            MakeSuggestion(0, "Their going home.", "They're going home."),
+            MakeSuggestion(1, "Its to late.", "It's too late."));
+
+        vm.OkCommand.Execute(null);
+
+        Assert.Single(applied);
+        Assert.Equal("They're going home.", applied[0].Paragraphs[0].Text);
+        Assert.Equal("It's too late.", applied[0].Paragraphs[1].Text);
+        Assert.Equal("Who's car is that?", applied[0].Paragraphs[2].Text); // untouched line
+        Assert.False(vm.OkPressed); // OkPressed closes the dialog for callers without a target
+    }
+
+    [AvaloniaFact]
+    public void Apply_WithCallback_DropsTheAppliedRowsAndKeepsTheRest()
+    {
+        var applied = new List<Subtitle>();
+        var vm = MakeViewModel();
+        vm.Initialize(MakeSubtitle(), null, null, null, applied.Add);
+        var first = MakeSuggestion(0, "Their going home.", "They're going home.");
+        var second = MakeSuggestion(2, "Who's car is that?", "Whose car is that?");
+        second.IsSelected = false;
+        AddSuggestions(vm, first, second);
+
+        vm.OkCommand.Execute(null);
+
+        Assert.Equal(new[] { second }, vm.Suggestions.ToArray());
+        Assert.False(second.IsSelected); // the remaining row keeps its own checkbox state
+        Assert.Equal(0, vm.SelectedCount);
+    }
+
+    [AvaloniaFact]
+    public void Apply_SecondPass_BuildsOnTheFirstOne()
+    {
+        var applied = new List<Subtitle>();
+        var vm = MakeViewModel();
+        vm.Initialize(MakeSubtitle(), null, null, null, applied.Add);
+        var first = MakeSuggestion(0, "Their going home.", "They're going home.");
+        var second = MakeSuggestion(2, "Who's car is that?", "Whose car is that?");
+        second.IsSelected = false;
+        AddSuggestions(vm, first, second);
+
+        vm.OkCommand.Execute(null);
+        second.IsSelected = true;
+        vm.OkCommand.Execute(null);
+
+        Assert.Equal(2, applied.Count);
+        // The second pass carries the first pass's fix - it is applied to the updated subtitle.
+        Assert.Equal("They're going home.", applied[1].Paragraphs[0].Text);
+        Assert.Equal("Whose car is that?", applied[1].Paragraphs[2].Text);
+        Assert.Empty(vm.Suggestions);
+    }
+
+    [AvaloniaFact]
+    public void Apply_WithoutCallback_KeepsTheApplyAndCloseContract()
+    {
+        var vm = MakeViewModel();
+        vm.Initialize(MakeSubtitle(), null);
+        AddSuggestions(vm, MakeSuggestion(0, "Their going home.", "They're going home."));
+
+        vm.OkCommand.Execute(null);
+
+        Assert.True(vm.OkPressed);
+        Assert.Equal("They're going home.", vm.FixedSubtitle.Paragraphs[0].Text);
+        Assert.Single(vm.Suggestions); // nothing pruned - the window is closing
+    }
+
+    [AvaloniaFact]
+    public void CloseButtonText_FollowsTheApplyMode()
+    {
+        var closing = MakeViewModel();
+        closing.Initialize(MakeSubtitle(), null);
+        Assert.Equal(Se.Language.General.Cancel, closing.CloseButtonText);
+
+        var staying = MakeViewModel();
+        staying.Initialize(MakeSubtitle(), null, null, null, _ => { });
+        Assert.Equal(Se.Language.General.Done, staying.CloseButtonText);
+    }
+}


### PR DESCRIPTION
Fixes #13807.

### The report

> With AI review the Apply button works like an OK. On top of that, AI review takes a while so you have to do it over again. [...] That's why I asked for a `select None` button earlier. I press that button first, and review the sentences one by one.

Applying one suggestion ended the review. Getting the next one meant re-running the model over the whole subtitle — minutes of work thrown away — which is exactly the workflow the *Select none* button was added for.

### Change

Both main-window entry points (whole file, selected lines) now hand the review window an apply callback, and the button bar is the standard **Apply / OK / Cancel** trio that *Multiple replace* and *Settings* already use:

- **Apply N fixes** pushes the checked fixes to the caller and leaves the window open. The applied rows drop out of the grid, the rest stay reviewable, and the working subtitle is re-based on the result so a later pass builds on the earlier one.
- **OK** applies the checked fixes and closes, so finishing on the last pass is one click rather than *Apply* followed by a separate close. Callers without a live target keep the old pull contract (`OkPressed` + `FixedSubtitle`) and simply don't get an Apply button — they have nowhere to receive a pass.
- **Cancel** closes; passes already applied stay applied (each is its own undo step, so Ctrl+Z reverts them).
- Apply is disabled while nothing is checked — applying an empty selection would cost an undo step and a *"fixed 0 lines"* status for an unchanged subtitle.

The first version of this PR had *Apply + Done* instead (the shape `RemoveTextForHearingImpaired` got in #11948). With no OK, the last pass needed two clicks and *Done* silently discarded whatever was still checked; the Apply/OK pair fixes both, and matches the more common convention in the app.

Also fixed in passing: the whole-file path reported `FixedSubtitle.Paragraphs.Count` as the number of fixed lines, so a two-line fix in the reporter's file showed *"fixed 1713 lines"*. It now counts the lines the pass actually changed.

### Docs

`docs/features/ai-review.md` describes the pass-by-pass workflow and what each button does, and gains a **Choosing a model** section — the same report asks which model to pick. Short version: EuroLLM 2512 for European languages (the reporter is reviewing Dutch), Llama 3.1 8B for English, and pick the largest model that leaves ~2 GB of VRAM for context — on their 16 GB card, EuroLLM 22B (IQ4_XS).

### Testing

`AiReviewApplyTests` covers the Apply pass, pruning of applied rows, a second pass building on the first, OK applying through the callback and closing, the unchanged apply-and-close contract for callers without a target, the disabled-when-nothing-checked rule, and the button bar itself (Apply present and visible only with a live target, OK and Cancel always there). `AddSuggestionItem` was split out of `AddSuggestion` so tests seed suggestions through the same path the review does. Full UI suite: 3134 passed.

### Note

This touches the same window as #13800 (linked-row marker); they are independent but both edit `AiReviewWindow.cs` / `AiReviewViewModel.cs`, so whichever merges second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
