### PR TITLE
Extend to shot change: stop at the first cut, and only ever extend

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9766,42 +9766,21 @@ public partial class MainViewModel :
             var idx = Subtitles.IndexOf(line);
             var next = Subtitles.GetOrNull(idx + 1);
 
-            // Leave the configured "out cues" gap before the shot change (Beautify time codes
-            // profile, two frames by default) - same as SE 4.x. Without it the line ends exactly
-            // on the shot change frame. The lookup filters on the gap-adjusted position being
-            // strictly after the current end: GetNextShotChangeMinusGapInMs's frame tolerance
-            // could pick a shot change just BEFORE the end and, after subtracting the gap, move
-            // the end ~2-3 frames backward instead of extending.
-            var outCuesGapMs = TimeCodesBeautifierUtils.GetOutCuesGapMs();
-            var candidateEndMs = AudioVisualizer.ShotChanges
-                .Select(s => s * 1000.0 - outCuesGapMs)
-                .Cast<double?>()
-                .FirstOrDefault(ms => ms > line.EndTime.TotalMilliseconds);
+            var newEndMs = ShotChangesHelper.GetExtendedEndMs(
+                AudioVisualizer.ShotChanges,
+                line.StartTime.TotalMilliseconds,
+                line.EndTime.TotalMilliseconds,
+                next?.StartTime.TotalMilliseconds,
+                TimeCodesBeautifierUtils.GetOutCuesGapMs(),
+                gapMs,
+                maxDurationMs);
 
-            // Upper bound for the new end: the next shot change and, if present, the next
-            // subtitle's start minus the configured gap. Whichever is earlier wins so we never
-            // push the end past either constraint.
-            if (next != null)
-            {
-                var nextStartMinusGapMs = next.StartTime.TotalMilliseconds - gapMs;
-                candidateEndMs = candidateEndMs.HasValue
-                    ? Math.Min(candidateEndMs.Value, nextStartMinusGapMs)
-                    : nextStartMinusGapMs;
-            }
-
-            if (candidateEndMs == null)
+            if (newEndMs == null)
             {
                 continue;
             }
 
-            var newEndMs = candidateEndMs.Value;
-            var newDurationMs = newEndMs - line.StartTime.TotalMilliseconds;
-            if (newDurationMs <= 0 || newDurationMs > maxDurationMs)
-            {
-                continue;
-            }
-
-            line.EndTime = TimeSpan.FromMilliseconds(newEndMs);
+            line.EndTime = TimeSpan.FromMilliseconds(newEndMs.Value);
         }
 
         _updateAudioVisualizer = true;
@@ -9916,50 +9895,24 @@ public partial class MainViewModel :
         {
             var idx = Subtitles.IndexOf(line);
             var prev = Subtitles.GetOrNull(idx - 1);
-            // Cast to nullable so "no match" is null and a real shot change
-            // at t=0 isn't conflated with the default value. Strict `<` so
-            // shot changes at or after the current start can't qualify and
-            // cause "extend to previous" to actually move the start forward.
-            // The shot change gets the configured "in cues" gap (Beautify time
-            // codes profile, two frames by default) so the line starts after the
-            // shot change rather than exactly on it - same as SE 4.x. The strict
-            // comparison applies to the gap-adjusted position: comparing the raw
-            // shot change and adding the gap afterwards could land AFTER the
-            // current start and make "extend to previous" shorten the line.
-            var inCuesGapMs = TimeCodesBeautifierUtils.GetInCuesGapMs();
-            double? candidateStartMs = AudioVisualizer.ShotChanges
-                .Select(s => s * 1000.0 + inCuesGapMs)
-                .Cast<double?>()
-                .LastOrDefault(ms => ms < line.StartTime.TotalMilliseconds);
 
-            // Lower bound for the new start: the previous shot change and, if
-            // present, the previous subtitle's end plus the configured gap.
-            // Whichever is later wins so we never pull the start back past
-            // either constraint.
-            if (prev != null)
-            {
-                var prevEndPlusGapMs = prev.EndTime.TotalMilliseconds + gapMs;
-                candidateStartMs = candidateStartMs.HasValue
-                    ? Math.Max(candidateStartMs.Value, prevEndPlusGapMs)
-                    : prevEndPlusGapMs;
-            }
+            var newStartMs = ShotChangesHelper.GetExtendedStartMs(
+                AudioVisualizer.ShotChanges,
+                line.StartTime.TotalMilliseconds,
+                line.EndTime.TotalMilliseconds,
+                prev?.EndTime.TotalMilliseconds,
+                TimeCodesBeautifierUtils.GetInCuesGapMs(),
+                gapMs,
+                maxDurationMs);
 
-            if (candidateStartMs == null)
+            if (newStartMs == null)
             {
                 continue;
             }
 
-            var newStartMs = candidateStartMs.Value;
-            var newDurationMs = line.EndTime.TotalMilliseconds - newStartMs;
-            if (newDurationMs <= 0 || newDurationMs > maxDurationMs)
-            {
-                continue;
-            }
-
-            // Use SetStartTimeOnly so EndTime stays fixed (the StartTime
-            // setter would otherwise shift EndTime to preserve Duration —
-            // see SubtitleLineViewModel.OnStartTimeChanged).
-            line.SetStartTimeOnly(TimeSpan.FromMilliseconds(newStartMs));
+            // Use SetStartTimeOnly so EndTime stays fixed (the StartTime setter would otherwise
+            // shift EndTime to preserve Duration - see SubtitleLineViewModel.OnStartTimeChanged).
+            line.SetStartTimeOnly(TimeSpan.FromMilliseconds(newStartMs.Value));
         }
 
         _updateAudioVisualizer = true;

--- a/src/ui/Logic/Media/ShotChangesHelper.cs
+++ b/src/ui/Logic/Media/ShotChangesHelper.cs
@@ -1,4 +1,5 @@
-﻿using Nikse.SubtitleEdit.Core.Common;
+﻿using System;
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.Forms;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -213,6 +214,115 @@ public class ShotChangesHelper
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// The end an "extend to next shot change (or next subtitle)" should produce, or null when the
+    /// line must be left alone.
+    /// <para>
+    /// The command exists to give a line as much reading time as possible without letting it cross a
+    /// cut, which fixes the rules (issue #13811):
+    /// </para>
+    /// <list type="number">
+    /// <item>the target is the <b>first</b> shot change at or after the current end - never a later
+    /// one, or the line would span the cut it was supposed to stop at;</item>
+    /// <item>it lands <paramref name="outCuesGapMs"/> before that cut (the beautify profile's out
+    /// cues gap, so this command, the beautifier and the snap commands share one rule);</item>
+    /// <item>it only ever extends - a target at or before the current end means "already where it
+    /// should be", so nothing moves. Shortening a line is not what the user asked for.</item>
+    /// </list>
+    /// <para>
+    /// The next subtitle's start minus <paramref name="minGapMs"/> caps the result (and is the only
+    /// bound when no cut lies ahead - the "or next subtitle" half of the command), and a result
+    /// longer than <paramref name="maxDurationMs"/> is dropped rather than clamped: a clamped end
+    /// would sit in the middle of a shot, which is the opposite of the point.
+    /// </para>
+    /// </summary>
+    public static double? GetExtendedEndMs(
+        IReadOnlyList<double> shotChanges,
+        double startMs,
+        double endMs,
+        double? nextStartMs,
+        double outCuesGapMs,
+        double minGapMs,
+        double maxDurationMs)
+    {
+        double? newEndMs = null;
+        foreach (var shotChange in shotChanges)
+        {
+            var shotChangeMs = shotChange * 1000.0;
+            if (shotChangeMs >= endMs)
+            {
+                newEndMs = shotChangeMs - outCuesGapMs;
+                break;
+            }
+        }
+
+        if (nextStartMs.HasValue)
+        {
+            var nextStartMinusGapMs = nextStartMs.Value - minGapMs;
+            newEndMs = newEndMs.HasValue ? Math.Min(newEndMs.Value, nextStartMinusGapMs) : nextStartMinusGapMs;
+        }
+
+        if (newEndMs == null || newEndMs.Value <= endMs)
+        {
+            return null;
+        }
+
+        var durationMs = newEndMs.Value - startMs;
+        if (durationMs <= 0 || durationMs > maxDurationMs)
+        {
+            return null;
+        }
+
+        return newEndMs;
+    }
+
+    /// <summary>
+    /// The start an "extend to previous shot change" should produce, or null when the line must be
+    /// left alone - <see cref="GetExtendedEndMs"/> mirrored: the <b>last</b> shot change at or before
+    /// the current start, plus the in cues gap so the line starts after the cut rather than on it,
+    /// and only when that moves the start earlier. The previous subtitle's end plus
+    /// <paramref name="minGapMs"/> is the floor.
+    /// </summary>
+    public static double? GetExtendedStartMs(
+        IReadOnlyList<double> shotChanges,
+        double startMs,
+        double endMs,
+        double? previousEndMs,
+        double inCuesGapMs,
+        double minGapMs,
+        double maxDurationMs)
+    {
+        double? newStartMs = null;
+        for (var i = shotChanges.Count - 1; i >= 0; i--)
+        {
+            var shotChangeMs = shotChanges[i] * 1000.0;
+            if (shotChangeMs <= startMs)
+            {
+                newStartMs = shotChangeMs + inCuesGapMs;
+                break;
+            }
+        }
+
+        if (previousEndMs.HasValue)
+        {
+            var previousEndPlusGapMs = previousEndMs.Value + minGapMs;
+            newStartMs = newStartMs.HasValue ? Math.Max(newStartMs.Value, previousEndPlusGapMs) : previousEndPlusGapMs;
+        }
+
+        if (newStartMs == null || newStartMs.Value >= startMs)
+        {
+            return null;
+        }
+
+        var durationMs = endMs - newStartMs.Value;
+        if (durationMs <= 0 || durationMs > maxDurationMs)
+        {
+            return null;
+        }
+
+        return newStartMs;
     }
 
     public static double? GetClosestShotChange(List<double> shotChanges, TimeCode currentTime)

--- a/tests/UI/Logic/Media/ShotChangeExtendTests.cs
+++ b/tests/UI/Logic/Media/ShotChangeExtendTests.cs
@@ -1,0 +1,130 @@
+using Nikse.SubtitleEdit.Logic.Media;
+using System.Collections.Generic;
+
+namespace UITests.Logic.Media;
+
+/// <summary>
+/// The rules behind "extend selected lines to next/previous shot change" (issue #13811). The
+/// command buys reading time without letting a line cross a cut, so: take the first cut at or after
+/// the end (never a later one), stop the configured gap short of it, and never move the cue the
+/// wrong way.
+/// </summary>
+public class ShotChangeExtendTests
+{
+    private const double NoMaxDuration = 100000;
+    private static readonly List<double> ShotChanges = new() { 1.0, 2.0, 5.0 }; // seconds
+
+    [Fact]
+    public void ExtendEnd_StopsTheGapBeforeTheNextShotChange()
+    {
+        var result = ShotChangesHelper.GetExtendedEndMs(
+            ShotChanges, startMs: 100, endMs: 500, nextStartMs: null,
+            outCuesGapMs: 80, minGapMs: 24, maxDurationMs: NoMaxDuration);
+
+        Assert.Equal(920, result); // shot change at 1000 ms, minus the 80 ms out cues gap
+    }
+
+    // Rule 1: the cut the line stops at is the first one ahead. Skipping it - which is what a
+    // "gap-adjusted position must be after the end" filter does when the end already sits inside
+    // the gap zone - extends the line straight across that cut.
+    [Fact]
+    public void ExtendEnd_EndInsideTheGapZone_DoesNotJumpToTheNextShotChange()
+    {
+        var result = ShotChangesHelper.GetExtendedEndMs(
+            ShotChanges, startMs: 100, endMs: 960, nextStartMs: null,
+            outCuesGapMs: 80, minGapMs: 24, maxDurationMs: NoMaxDuration);
+
+        Assert.Null(result); // 920 would shorten the line; 1920 would span the cut at 1000
+    }
+
+    [Fact]
+    public void ExtendEnd_EndExactlyOnAShotChange_LeavesTheLineAlone()
+    {
+        var result = ShotChangesHelper.GetExtendedEndMs(
+            ShotChanges, startMs: 100, endMs: 1000, nextStartMs: null,
+            outCuesGapMs: 0, minGapMs: 24, maxDurationMs: NoMaxDuration);
+
+        Assert.Null(result);
+    }
+
+    // Rule 3: extend means extend. An overlapping next line used to pull the end backwards.
+    [Fact]
+    public void ExtendEnd_NextSubtitleStartsBeforeTheCurrentEnd_DoesNotShorten()
+    {
+        var result = ShotChangesHelper.GetExtendedEndMs(
+            ShotChanges, startMs: 100, endMs: 900, nextStartMs: 800,
+            outCuesGapMs: 0, minGapMs: 24, maxDurationMs: NoMaxDuration);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ExtendEnd_NextSubtitleIsCloserThanTheShotChange_StopsBeforeIt()
+    {
+        var result = ShotChangesHelper.GetExtendedEndMs(
+            ShotChanges, startMs: 100, endMs: 500, nextStartMs: 700,
+            outCuesGapMs: 0, minGapMs: 24, maxDurationMs: NoMaxDuration);
+
+        Assert.Equal(676, result); // 700 - 24 ms minimum gap
+    }
+
+    [Fact]
+    public void ExtendEnd_NoShotChangeAhead_UsesTheNextSubtitle()
+    {
+        var result = ShotChangesHelper.GetExtendedEndMs(
+            ShotChanges, startMs: 5100, endMs: 5200, nextStartMs: 6000,
+            outCuesGapMs: 80, minGapMs: 24, maxDurationMs: NoMaxDuration);
+
+        Assert.Equal(5976, result);
+    }
+
+    [Fact]
+    public void ExtendEnd_ResultLongerThanTheMaximumDuration_IsDropped()
+    {
+        var result = ShotChangesHelper.GetExtendedEndMs(
+            ShotChanges, startMs: 100, endMs: 500, nextStartMs: null,
+            outCuesGapMs: 0, minGapMs: 24, maxDurationMs: 500);
+
+        Assert.Null(result); // 1000 - 100 = 900 ms > 500 ms; a clamped end would sit mid-shot
+    }
+
+    [Fact]
+    public void ExtendStart_StopsTheGapAfterThePreviousShotChange()
+    {
+        var result = ShotChangesHelper.GetExtendedStartMs(
+            ShotChanges, startMs: 2500, endMs: 3000, previousEndMs: null,
+            inCuesGapMs: 40, minGapMs: 24, maxDurationMs: NoMaxDuration);
+
+        Assert.Equal(2040, result); // shot change at 2000 ms, plus the 40 ms in cues gap
+    }
+
+    [Fact]
+    public void ExtendStart_StartInsideTheGapZone_DoesNotJumpToTheEarlierShotChange()
+    {
+        var result = ShotChangesHelper.GetExtendedStartMs(
+            ShotChanges, startMs: 2020, endMs: 3000, previousEndMs: null,
+            inCuesGapMs: 40, minGapMs: 24, maxDurationMs: NoMaxDuration);
+
+        Assert.Null(result); // 2040 would shorten the line; 1040 would span the cut at 2000
+    }
+
+    [Fact]
+    public void ExtendStart_PreviousSubtitleIsCloser_StopsAfterIt()
+    {
+        var result = ShotChangesHelper.GetExtendedStartMs(
+            ShotChanges, startMs: 2500, endMs: 3000, previousEndMs: 2300,
+            inCuesGapMs: 0, minGapMs: 24, maxDurationMs: NoMaxDuration);
+
+        Assert.Equal(2324, result);
+    }
+
+    [Fact]
+    public void ExtendStart_PreviousSubtitleEndsAfterTheCurrentStart_DoesNotShorten()
+    {
+        var result = ShotChangesHelper.GetExtendedStartMs(
+            ShotChanges, startMs: 2500, endMs: 3000, previousEndMs: 2600,
+            inCuesGapMs: 0, minGapMs: 24, maxDurationMs: NoMaxDuration);
+
+        Assert.Null(result);
+    }
+}


### PR DESCRIPTION
Towards #13811.

The point of *Extend selected lines to next/previous shot change* is to buy a line reading time without letting it cross a cut. Two of the rules that follow from that were not held.

### 1. It could extend across the very cut it should stop at

The lookup filtered on the gap-adjusted position being strictly past the current end:

```csharp
.Select(s => s * 1000.0 - outCuesGapMs)
.FirstOrDefault(ms => ms > line.EndTime.TotalMilliseconds);
```

A line ending inside the gap zone before a cut — or exactly on it — fails that test for *that* cut, so the next one was picked and the line was extended straight across the first. With the default profile (out cues gap 0) an end sitting exactly on a cut is enough to trigger it.

The target is now the first shot change at or after the end, always, with the gap taken off afterwards.

### 2. It could move the cue the wrong way

Nothing checked the direction. An overlapping next subtitle (`nextStart - minGap` earlier than the current end) pulled the end *backwards* — shortening the line, which is not what extend means. SE 4 has the same class of bug from the other side: its frame-tolerant lookup pulls the end back by the gap when the line already ends on a cut.

A target at or before the current end (at or after it, going backwards) now leaves the line alone.

### Structure

The arithmetic moved into `ShotChangesHelper.GetExtendedEndMs` / `GetExtendedStartMs`, so both directions read the same and can be tested without a video, a waveform and a grid selection. The clamps that were already right — next/previous subtitle plus the minimum gap, and dropping a result longer than the maximum display duration rather than clamping it mid-shot — are unchanged.

### What this does *not* change

The gap still comes from the beautify profile (`OutCuesGap` / `InCuesGap`), which is **0** in the default profile, so by default a line still ends exactly on the cut. The reporter sees a gap in SE 4 because their SE 4 profile has a non-zero out cues gap (Netflix and SDI presets use 2 frames); SE 4's `Settings.xml` isn't migrated, so SE 5 starts from the zero-gap default. Changing that default would change every beautify run too, so it is left as a separate decision.

### Testing

`ShotChangeExtendTests` covers both directions: the plain gap-before-cut case, the two defects above, next/previous-subtitle clamping, the no-cut-ahead fallback, and the maximum-duration drop. Full UI suite: 3143 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)