### PR TITLE
OCR: fix words with more than one l misread as uppercase I

### DIFF
--- a/Dictionaries/dan_OCRFixReplaceList.xml
+++ b/Dictionaries/dan_OCRFixReplaceList.xml
@@ -795,5 +795,11 @@
 
     <!-- word-initial ii to ll (iiegar to llegar) -->
     <RegEx find="\bii([a-zæøå]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
+
+    <!-- Lowercase l misread as uppercase I (#13660): replace every I in the word, -->
+    <!-- so words with more than one are repaired too (deIectabIe -> delectable,   -->
+    <!-- ExceIIencies -> Excellencies). Words of two letters (AI) are never        -->
+    <!-- touched, and real words (MacIntosh) are kept by the spell check gate.     -->
+    <RegEx find="\b([A-ZÆØÅa-zæøå](?=[a-zæøåI]*I)[a-zæøåI]{2,})\b" replaceAllFrom="I" replaceAllTo="l" spellCheck="$1" replaceWith="$1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/deu_OCRFixReplaceList.xml
+++ b/Dictionaries/deu_OCRFixReplaceList.xml
@@ -7241,5 +7241,11 @@
     <!-- inBerlin → in Berlin -->
     <RegEx find="\bin([A-ZÄÖÜ][a-zäöüß]+)\b" spellCheck="$1" replaceWith="in $1" />
 
+
+    <!-- Lowercase l misread as uppercase I (#13660): replace every I in the word, -->
+    <!-- so words with more than one are repaired too (deIectabIe -> delectable,   -->
+    <!-- ExceIIencies -> Excellencies). Words of two letters (AI) are never        -->
+    <!-- touched, and real words (MacIntosh) are kept by the spell check gate.     -->
+    <RegEx find="\b([A-ZÄÖÜa-zäöüß](?=[a-zäöüßI]*I)[a-zäöüßI]{2,})\b" replaceAllFrom="I" replaceAllTo="l" spellCheck="$1" replaceWith="$1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/eng_OCRFixReplaceList.xml
+++ b/Dictionaries/eng_OCRFixReplaceList.xml
@@ -3429,5 +3429,11 @@
 
 		<!-- word-initial ii to ll (iiegar to llegar) -->
 		<RegEx find="\bii([a-z]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
+
+		<!-- Lowercase l misread as uppercase I (#13660): replace every I in the word, -->
+		<!-- so words with more than one are repaired too (deIectabIe -> delectable,   -->
+		<!-- ExceIIencies -> Excellencies). Words of two letters (AI) are never        -->
+		<!-- touched, and real words (MacIntosh) are kept by the spell check gate.     -->
+		<RegEx find="\b([A-Za-z](?=[a-zI]*I)[a-zI]{2,})\b" replaceAllFrom="I" replaceAllTo="l" spellCheck="$1" replaceWith="$1" />
 	</RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/fin_OCRFixReplaceList.xml
+++ b/Dictionaries/fin_OCRFixReplaceList.xml
@@ -989,6 +989,7 @@
   <PartialWordsAlways />
   <PartialWords>
     <WordPart from="i" to="l" />
+    <WordPart from="I" to="l" />
   </PartialWords>
   <WholeLines>
     <Line from="Katsokaa pa." to="Katsokaapa." />
@@ -1043,5 +1044,11 @@
 
     <!-- word-initial ii to ll (iiegar to llegar) -->
     <RegEx find="\bii([a-zåäö]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
+
+    <!-- Lowercase l misread as uppercase I (#13660): replace every I in the word, -->
+    <!-- so words with more than one are repaired too (deIectabIe -> delectable,   -->
+    <!-- ExceIIencies -> Excellencies). Words of two letters (AI) are never        -->
+    <!-- touched, and real words (MacIntosh) are kept by the spell check gate.     -->
+    <RegEx find="\b([A-ZÅÄÖa-zåäö](?=[a-zåäöI]*I)[a-zåäöI]{2,})\b" replaceAllFrom="I" replaceAllTo="l" spellCheck="$1" replaceWith="$1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/fra_OCRFixReplaceList.xml
+++ b/Dictionaries/fra_OCRFixReplaceList.xml
@@ -248,6 +248,7 @@
   <PartialWordsAlways />
   <PartialWords>
     <WordPart from="i" to="l" />
+    <WordPart from="I" to="l" />
   </PartialWords>
   <WholeLines>
     <Line from="&quot;D'ac:c:ord.&quot;" to="&quot;D'accord.&quot;" />
@@ -386,5 +387,11 @@
 
     <!-- word-initial ii to ll (iiegar to llegar) -->
     <RegEx find="\bii([a-zàâæçéèêëîïôœùûüÿ]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
+
+    <!-- Lowercase l misread as uppercase I (#13660): replace every I in the word, -->
+    <!-- so words with more than one are repaired too (deIectabIe -> delectable,   -->
+    <!-- ExceIIencies -> Excellencies). Words of two letters (AI) are never        -->
+    <!-- touched, and real words (MacIntosh) are kept by the spell check gate.     -->
+    <RegEx find="\b([A-ZÀÂÆÇÉÈÊËÎÏÔŒÙÛÜŸa-zàâæçéèêëîïôœùûüÿ](?=[a-zàâæçéèêëîïôœùûüÿI]*I)[a-zàâæçéèêëîïôœùûüÿI]{2,})\b" replaceAllFrom="I" replaceAllTo="l" spellCheck="$1" replaceWith="$1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/hrb_OCRFixReplaceList.xml
+++ b/Dictionaries/hrb_OCRFixReplaceList.xml
@@ -1225,6 +1225,7 @@
   <PartialWordsAlways />
   <PartialWords>
     <WordPart from="i" to="l" />
+    <WordPart from="I" to="l" />
   </PartialWords>
   <WholeLines />
   <PartialLinesAlways />
@@ -1954,5 +1955,11 @@
 
     <!-- word-initial ii to ll (iiegar to llegar) -->
     <RegEx find="\bii([a-zčćđšž]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
+
+    <!-- Lowercase l misread as uppercase I (#13660): replace every I in the word, -->
+    <!-- so words with more than one are repaired too (deIectabIe -> delectable,   -->
+    <!-- ExceIIencies -> Excellencies). Words of two letters (AI) are never        -->
+    <!-- touched, and real words (MacIntosh) are kept by the spell check gate.     -->
+    <RegEx find="\b([A-ZČĆĐŠŽa-zčćđšž](?=[a-zčćđšžI]*I)[a-zčćđšžI]{2,})\b" replaceAllFrom="I" replaceAllTo="l" spellCheck="$1" replaceWith="$1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/hrv_OCRFixReplaceList.xml
+++ b/Dictionaries/hrv_OCRFixReplaceList.xml
@@ -4121,6 +4121,7 @@
     <WordPart from=")/" to="y" />
     <WordPart from=")'" to="y" />
     <WordPart from="i" to="l" />
+    <WordPart from="I" to="l" />
 </PartialWords>
   <WholeLines />
   <PartialLinesAlways>
@@ -6368,5 +6369,11 @@
 
     <!-- word-initial ii to ll (iiegar to llegar) -->
     <RegEx find="\bii([a-zčćđšž]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
+
+    <!-- Lowercase l misread as uppercase I (#13660): replace every I in the word, -->
+    <!-- so words with more than one are repaired too (deIectabIe -> delectable,   -->
+    <!-- ExceIIencies -> Excellencies). Words of two letters (AI) are never        -->
+    <!-- touched, and real words (MacIntosh) are kept by the spell check gate.     -->
+    <RegEx find="\b([A-ZČĆĐŠŽa-zčćđšž](?=[a-zčćđšžI]*I)[a-zčćđšžI]{2,})\b" replaceAllFrom="I" replaceAllTo="l" spellCheck="$1" replaceWith="$1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/hun_OCRFixReplaceList.xml
+++ b/Dictionaries/hun_OCRFixReplaceList.xml
@@ -12,6 +12,7 @@
   <PartialWordsAlways />
   <PartialWords>
     <WordPart from="i" to="l" />
+    <WordPart from="I" to="l" />
   </PartialWords>
   <WholeLines />
   <PartialLinesAlways />
@@ -44,5 +45,11 @@
 
     <!-- word-initial ii to ll (iiegar to llegar) -->
     <RegEx find="\bii([a-záéíóöőúüű]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
+
+    <!-- Lowercase l misread as uppercase I (#13660): replace every I in the word, -->
+    <!-- so words with more than one are repaired too (deIectabIe -> delectable,   -->
+    <!-- ExceIIencies -> Excellencies). Words of two letters (AI) are never        -->
+    <!-- touched, and real words (MacIntosh) are kept by the spell check gate.     -->
+    <RegEx find="\b([A-ZÁÉÍÓÖŐÚÜŰa-záéíóöőúüű](?=[a-záéíóöőúüűI]*I)[a-záéíóöőúüűI]{2,})\b" replaceAllFrom="I" replaceAllTo="l" spellCheck="$1" replaceWith="$1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/ita_OCRFixReplaceList.xml
+++ b/Dictionaries/ita_OCRFixReplaceList.xml
@@ -77,5 +77,11 @@
 
     <!-- word-initial ii to ll (iiegar to llegar) -->
     <RegEx find="\bii([a-zàèéìòóù]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
+
+    <!-- Lowercase l misread as uppercase I (#13660): replace every I in the word, -->
+    <!-- so words with more than one are repaired too (deIectabIe -> delectable,   -->
+    <!-- ExceIIencies -> Excellencies). Words of two letters (AI) are never        -->
+    <!-- touched, and real words (MacIntosh) are kept by the spell check gate.     -->
+    <RegEx find="\b([A-ZÀÈÉÌÒÓÙa-zàèéìòóù](?=[a-zàèéìòóùI]*I)[a-zàèéìòóùI]{2,})\b" replaceAllFrom="I" replaceAllTo="l" spellCheck="$1" replaceWith="$1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/nld_OCRFixReplaceList.xml
+++ b/Dictionaries/nld_OCRFixReplaceList.xml
@@ -147,6 +147,7 @@
     <!-- If new word(s) exists in spelling dictionary, it is (they are) accepted -->
     <WordPart from="ĳ" to="ij" />
     <WordPart from="i" to="l" />
+    <WordPart from="I" to="l" />
   </PartialWords>
   <WholeLines />
   <PartialLinesAlways />
@@ -359,5 +360,11 @@
 
     <!-- word-initial ii to ll (iiegar to llegar) -->
     <RegEx find="\bii([a-zéèêëïöü]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
+
+    <!-- Lowercase l misread as uppercase I (#13660): replace every I in the word, -->
+    <!-- so words with more than one are repaired too (deIectabIe -> delectable,   -->
+    <!-- ExceIIencies -> Excellencies). Words of two letters (AI) are never        -->
+    <!-- touched, and real words (MacIntosh) are kept by the spell check gate.     -->
+    <RegEx find="\b([A-ZÉÈÊËÏÖÜa-zéèêëïöü](?=[a-zéèêëïöüI]*I)[a-zéèêëïöüI]{2,})\b" replaceAllFrom="I" replaceAllTo="l" spellCheck="$1" replaceWith="$1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/nob_OCRFixReplaceList.xml
+++ b/Dictionaries/nob_OCRFixReplaceList.xml
@@ -195,5 +195,11 @@
 
     <!-- word-initial ii to ll (iiegar to llegar) -->
     <RegEx find="\bii([a-zæøå]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
+
+    <!-- Lowercase l misread as uppercase I (#13660): replace every I in the word, -->
+    <!-- so words with more than one are repaired too (deIectabIe -> delectable,   -->
+    <!-- ExceIIencies -> Excellencies). Words of two letters (AI) are never        -->
+    <!-- touched, and real words (MacIntosh) are kept by the spell check gate.     -->
+    <RegEx find="\b([A-ZÆØÅa-zæøå](?=[a-zæøåI]*I)[a-zæøåI]{2,})\b" replaceAllFrom="I" replaceAllTo="l" spellCheck="$1" replaceWith="$1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/nor_OCRFixReplaceList.xml
+++ b/Dictionaries/nor_OCRFixReplaceList.xml
@@ -192,5 +192,11 @@
 
     <!-- word-initial ii to ll (iiegar to llegar) -->
     <RegEx find="\bii([a-zæøå]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
+
+    <!-- Lowercase l misread as uppercase I (#13660): replace every I in the word, -->
+    <!-- so words with more than one are repaired too (deIectabIe -> delectable,   -->
+    <!-- ExceIIencies -> Excellencies). Words of two letters (AI) are never        -->
+    <!-- touched, and real words (MacIntosh) are kept by the spell check gate.     -->
+    <RegEx find="\b([A-ZÆØÅa-zæøå](?=[a-zæøåI]*I)[a-zæøåI]{2,})\b" replaceAllFrom="I" replaceAllTo="l" spellCheck="$1" replaceWith="$1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/pol_OCRFixReplaceList.xml
+++ b/Dictionaries/pol_OCRFixReplaceList.xml
@@ -11,6 +11,7 @@
     <WordPart from="ą" to="ą " />
     <WordPart from="j" to=" j" />
     <WordPart from="i" to="l" />
+    <WordPart from="I" to="l" />
   </PartialWords>
   <WholeLines />
   <PartialLinesAlways />
@@ -29,5 +30,11 @@
 
     <!-- word-initial ii to ll (iiegar to llegar) -->
     <RegEx find="\bii([a-ząćęłńóśźż]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
+
+    <!-- Lowercase l misread as uppercase I (#13660): replace every I in the word, -->
+    <!-- so words with more than one are repaired too (deIectabIe -> delectable,   -->
+    <!-- ExceIIencies -> Excellencies). Words of two letters (AI) are never        -->
+    <!-- touched, and real words (MacIntosh) are kept by the spell check gate.     -->
+    <RegEx find="\b([A-ZĄĆĘŁŃÓŚŹŻa-ząćęłńóśźż](?=[a-ząćęłńóśźżI]*I)[a-ząćęłńóśźżI]{2,})\b" replaceAllFrom="I" replaceAllTo="l" spellCheck="$1" replaceWith="$1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/por_OCRFixReplaceList.xml
+++ b/Dictionaries/por_OCRFixReplaceList.xml
@@ -469,6 +469,7 @@
   <PartialWordsAlways />
   <PartialWords>
     <WordPart from="i" to="l" />
+    <WordPart from="I" to="l" />
   </PartialWords>
   <WholeLines />
   <PartialLinesAlways />
@@ -542,5 +543,11 @@
 
     <!-- word-initial ii to ll (iiegar to llegar) -->
     <RegEx find="\bii([a-zàáâãçéêíóôõú]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
+
+    <!-- Lowercase l misread as uppercase I (#13660): replace every I in the word, -->
+    <!-- so words with more than one are repaired too (deIectabIe -> delectable,   -->
+    <!-- ExceIIencies -> Excellencies). Words of two letters (AI) are never        -->
+    <!-- touched, and real words (MacIntosh) are kept by the spell check gate.     -->
+    <RegEx find="\b([A-ZÀÁÂÃÇÉÊÍÓÔÕÚa-zàáâãçéêíóôõú](?=[a-zàáâãçéêíóôõúI]*I)[a-zàáâãçéêíóôõúI]{2,})\b" replaceAllFrom="I" replaceAllTo="l" spellCheck="$1" replaceWith="$1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/spa_OCRFixReplaceList.xml
+++ b/Dictionaries/spa_OCRFixReplaceList.xml
@@ -370,6 +370,7 @@
   <PartialWordsAlways />
   <PartialWords>
     <WordPart from="i" to="l" />
+    <WordPart from="I" to="l" />
   </PartialWords>
   <WholeLines>
     <!-- Todas las líneas -->
@@ -973,5 +974,11 @@
     <!-- Terminación «clón» por «ción»: estaclón to estación, canclón to canción (#13701).
          Palabras reales como «ciclón», «anticiclón» o «choclón» las protege el corrector. -->
     <RegEx find="\b([A-ZÁÉÍÓÚÑÜa-záéíóúñü]+)clón\b" spellCheck="$1ción" replaceWith="$1ción" />
+
+    <!-- Lowercase l misread as uppercase I (#13660): replace every I in the word, -->
+    <!-- so words with more than one are repaired too (deIectabIe -> delectable,   -->
+    <!-- ExceIIencies -> Excellencies). Words of two letters (AI) are never        -->
+    <!-- touched, and real words (MacIntosh) are kept by the spell check gate.     -->
+    <RegEx find="\b([A-ZÁÉÍÓÚÑÜa-záéíóúñü](?=[a-záéíóúñüI]*I)[a-záéíóúñüI]{2,})\b" replaceAllFrom="I" replaceAllTo="l" spellCheck="$1" replaceWith="$1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/srp_OCRFixReplaceList.xml
+++ b/Dictionaries/srp_OCRFixReplaceList.xml
@@ -59,6 +59,9 @@
     <WordPart from="lVI" to="M" />
     <WordPart from="IVl" to="M" />
     <WordPart from="lVl" to="M" />
+    <!-- Italic OCR reads l as i or I (#13660) - guesses are kept only if the dictionary confirms them -->
+    <WordPart from="i" to="l" />
+    <WordPart from="I" to="l" />
   </PartialWords>
   <WholeLines />
   <PartialLinesAlways />
@@ -328,4 +331,22 @@
     <!-- <RegEx find="^\.{3}([a-zčđšž&quot;&lt;])" replaceWith="$1" /> -->
     <!-- <RegEx find=" +([.?!])" replaceWith="$1" /> -->
   </RegularExpressions>
+  <RegularExpressionsIfSpelledCorrectly>
+    <!-- Italic l misread as i (#13660): trailing i to l, double ii to ll.  -->
+    <!-- Correct i-words are in the dictionary and protected by the gate.   -->
+    <RegEx find="\b([A-ZČĆĐŠŽa-zčćđšž][a-zčćđšž]*)i\b" spellCheck="$1l" replaceWith="$1l" />
+    <RegEx find="\b([A-ZČĆĐŠŽa-zčćđšž][a-zčćđšž]*)ii([a-zčćđšž]*)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
+
+    <!-- word-initial i to l (iov to lov) -->
+    <RegEx find="\bi([a-zčćđšž]{2,})\b" spellCheck="l$1" replaceWith="l$1" />
+
+    <!-- word-initial ii to ll -->
+    <RegEx find="\bii([a-zčćđšž]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
+
+    <!-- Lowercase l misread as uppercase I (#13660): replace every I in the word, -->
+    <!-- so words with more than one are repaired too (deIectabIe -> delectable,   -->
+    <!-- ExceIIencies -> Excellencies). Words of two letters (AI) are never        -->
+    <!-- touched, and real words (MacIntosh) are kept by the spell check gate.     -->
+    <RegEx find="\b([A-ZČĆĐŠŽa-zčćđšž](?=[a-zčćđšžI]*I)[a-zčćđšžI]{2,})\b" replaceAllFrom="I" replaceAllTo="l" spellCheck="$1" replaceWith="$1" />
+  </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/swe_OCRFixReplaceList.xml
+++ b/Dictionaries/swe_OCRFixReplaceList.xml
@@ -602,5 +602,11 @@
 
     <!-- word-initial ii to ll (iiegar to llegar) -->
     <RegEx find="\bii([a-zåäö]+)\b" spellCheck="ll$1" replaceWith="ll$1" />
+
+    <!-- Lowercase l misread as uppercase I (#13660): replace every I in the word, -->
+    <!-- so words with more than one are repaired too (deIectabIe -> delectable,   -->
+    <!-- ExceIIencies -> Excellencies). Words of two letters (AI) are never        -->
+    <!-- touched, and real words (MacIntosh) are kept by the spell check gate.     -->
+    <RegEx find="\b([A-ZÅÄÖa-zåäö](?=[a-zåäöI]*I)[a-zåäöI]{2,})\b" replaceAllFrom="I" replaceAllTo="l" spellCheck="$1" replaceWith="$1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixUppercaseIForLowercaseLTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixUppercaseIForLowercaseLTests.cs
@@ -1,0 +1,147 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
+using Nikse.SubtitleEdit.Features.SpellCheck;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
+
+namespace UITests.Features.Ocr.FixEngine;
+
+// Issue #13660 (follow-up): binary image compare reads lowercase l as uppercase I, and the shipped
+// lists only had rules for a single I per word ("traiIing"), so words with two of them were left
+// for the spell checker: "deIectabIe", "ExceIIencies". The rule under test replaces every I in the
+// word at once and keeps the result only when the dictionary confirms it.
+public class OcrFixUppercaseIForLowercaseLTests : IDisposable
+{
+    private readonly Func<string> _originalSpellCheckDictionariesFolder;
+    private readonly string _tempDictionariesFolder;
+
+    public OcrFixUppercaseIForLowercaseLTests()
+    {
+        _originalSpellCheckDictionariesFolder = SpellCheckConfig.DictionariesFolder;
+
+        _tempDictionariesFolder = Path.Combine(
+            Path.GetTempPath(),
+            "SeOcrFixUppercaseIForLowercaseLTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDictionariesFolder);
+        SpellCheckConfig.DictionariesFolder = () => _tempDictionariesFolder;
+
+        // The rule as shipped in eng_OCRFixReplaceList.xml.
+        File.WriteAllText(
+            Path.Combine(_tempDictionariesFolder, "eng_OCRFixReplaceList.xml"),
+            "<ReplaceList>" +
+            "<RegularExpressionsIfSpelledCorrectly>" +
+            "<RegEx find=\"\\b([A-Za-z](?=[a-zI]*I)[a-zI]{2,})\\b\" replaceAllFrom=\"I\" replaceAllTo=\"l\" spellCheck=\"$1\" replaceWith=\"$1\" />" +
+            "</RegularExpressionsIfSpelledCorrectly>" +
+            "</ReplaceList>");
+    }
+
+    [Fact]
+    public void FixOcrErrors_TwoUppercaseIsInLowercaseWord_AreBothFixed()
+    {
+        var engine = CreateEngine();
+
+        var result = engine.FixOcrErrors(0, "she smells most deIectabIe.", doTryToGuessUnknownWords: false);
+
+        Assert.Equal("she smells most delectable.", result.GetText());
+    }
+
+    [Fact]
+    public void FixOcrErrors_TwoUppercaseIsInCapitalizedWord_AreBothFixed()
+    {
+        var engine = CreateEngine();
+
+        var result = engine.FixOcrErrors(0, "Would Your ExceIIencies", doTryToGuessUnknownWords: false);
+
+        Assert.Equal("Would Your Excellencies", result.GetText());
+    }
+
+    [Fact]
+    public void FixOcrErrors_UppercaseIsRightAfterFirstLetter_AreFixed()
+    {
+        var engine = CreateEngine();
+
+        // "AII" has no lowercase letter before the first I - the rule must still match.
+        var result = engine.FixOcrErrors(0, "AII of it", doTryToGuessUnknownWords: false);
+
+        Assert.Equal("All of it", result.GetText());
+    }
+
+    [Fact]
+    public void FixOcrErrors_WordWithGenuineUppercaseI_IsLeftAlone()
+    {
+        var engine = CreateEngine();
+
+        // "MacIntosh" is a real word, so the already-spelled-correctly gate protects it.
+        var result = engine.FixOcrErrors(0, "A MacIntosh weII.", doTryToGuessUnknownWords: false);
+
+        Assert.Equal("A MacIntosh well.", result.GetText());
+    }
+
+    [Fact]
+    public void FixOcrErrors_TwoLetterWord_IsLeftAlone()
+    {
+        var engine = CreateEngine();
+
+        // "AI" must not become "Al" even though "Al" is in the dictionary as a name.
+        var result = engine.FixOcrErrors(0, "AI is here", doTryToGuessUnknownWords: false);
+
+        Assert.Equal("AI is here", result.GetText());
+    }
+
+    [Fact]
+    public void FixOcrErrors_ReplacementIsNotAWord_IsLeftAlone()
+    {
+        var engine = CreateEngine();
+
+        var result = engine.FixOcrErrors(0, "ZorbIx is here", doTryToGuessUnknownWords: false);
+
+        Assert.Equal("ZorbIx is here", result.GetText());
+    }
+
+    private static IOcrFixEngine CreateEngine()
+    {
+        IOcrFixEngine engine = new OcrFixEngine(new FakeEnglishSpellChecker());
+        engine.Initialize(new Subtitle(), "eng", new SpellCheckDictionaryDisplay());
+        return engine;
+    }
+
+    private sealed class FakeEnglishSpellChecker : ISpellChecker
+    {
+        private static readonly HashSet<string> Words = new(StringComparer.Ordinal)
+        {
+            "she", "smells", "most", "delectable", "would", "your", "excellencies",
+            "all", "of", "it", "is", "here", "well", "MacIntosh", "Al", "a",
+        };
+
+        public bool Initialize(string dictionaryFile, string twoLetterLanguageCode) => true;
+
+        public bool IsWordCorrect(string word)
+        {
+            if (string.IsNullOrWhiteSpace(word))
+            {
+                return true;
+            }
+
+            // Like Hunspell, accept the initial-capitalized form of a lowercase dictionary word.
+            return Words.Contains(word) || Words.Contains(word.ToLowerInvariant());
+        }
+
+        public List<string> GetSuggestions(string word) => new();
+    }
+
+    public void Dispose()
+    {
+        SpellCheckConfig.DictionariesFolder = _originalSpellCheckDictionariesFolder;
+        try
+        {
+            Directory.Delete(_tempDictionariesFolder, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup.
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #13660 ([comment](https://github.com/SubtitleEdit/subtitleedit/issues/13660#issuecomment-5324896461)): the reporter confirmed the German fixes work, and asked for the same for other languages. Their English screenshots show a *different* confusion than the German italic one - upright text where binary image compare reads lowercase **l** as uppercase **I**:

- `deIectabIe` (delectable)
- `ExceIIencies` (Excellencies)

The `I`→`l` rules already shipped in the lists only handle **one** I per word (`traiIing` → `trailing`, `chaIIenge` → `challenge` as an adjacent pair). Two separate I's, or a double `II` in a capitalized word, matched nothing and went straight to the spell check dialog.

### Change

One extra spell-check-gated rule per Latin-script list that replaces **every** I in the word at once, e.g. for English:

```xml
<RegEx find="\b([A-Za-z](?=[a-zI]*I)[a-zI]{2,})\b" replaceAllFrom="I" replaceAllTo="l" spellCheck="$1" replaceWith="$1" />
```

- The lookahead means the word must contain an I after its first letter, so words that only *start* with a genuine I (`Illinois`, `Ill`) never match.
- `{2,}` keeps the match at three letters or more, so `AI` is never turned into `Al`.
- Both existing gates still apply: a word that is already spelled correctly (`MacIntosh`) is left alone, and the all-I-replaced candidate has to be a real word before it wins.

Languages: dan, deu, eng, fin, fra, hrb, hrv, hun, ita, nld, nob, nor, pol, por, spa, srp, swe (per-language letter classes, taken from the blocks added in #13670).

Two more gaps closed while in there:

- `<PartialWords>` was missing the `I`→`l` pair in fin, fra, hrb, hrv, hun, nld, pol, por and spa (it feeds the unknown-word letter guesser wired up in #13670).
- `srp` had no `RegularExpressionsIfSpelledCorrectly` section at all, so it never got the #13660 `i`→`l` rules the other Latin lists received - added now (Serbian Latin classes; harmless for Cyrillic material since nothing matches).

### Verification

Scratch harness loading the **shipped** XMLs and applying the gated rules against a controlled dictionary - all 17 lists fixed their case and left the negative cases alone:

| | fixed | untouched |
|---|---|---|
| eng | `deIectabIe`→delectable, `ExceIIencies`→Excellencies, `weII`→well, `aII`→all, `coIIege`→college | `MacIntosh`, `AI`, `Taxi`, `Zorbix` |
| deu | `woIIen`→wollen, `VieIIeicht`→Vielleicht, `voII`→voll | `Juni` |
| dan/nob/nor | `stiIIe`→stille, `SkuIIe`→Skulle, `aIIe`→alle | |
| swe | `viIIa`→villa, `AIItid`→Alltid, `fjäIIa`→fjälla | |
| fin | `keIIo`→kello, `SiIIä`→Sillä | |
| nld | `aIIeen`→alleen, `WiIIem`→Willem | |
| fra | `eIIe`→elle, `BeIIe`→Belle, `aIIô`→allô | |
| ita | `beIIa`→bella, `NeIIa`→Nella | |
| spa | `cabaIIo`→caballo, `EIIos`→Ellos | |
| por | `aIcooIizado`→alcoolizado, `FiIoIogia`→Filologia | |
| pol | `maIowaIi`→malowali, `WoIeIi`→Woleli | |
| hun | `KeIIemetlen`→Kellemetlen, `aIkaImas`→alkalmas | |
| hrv/hrb/srp | `posIaIi`→poslali, `MoIiIi`→Molili, `moIi`→moli | |

Tests: new `OcrFixUppercaseIForLowercaseLTests` (6 cases, engine-level through `FixOcrErrors`). Full suites pass - UI 3133 (3127 + 6 new), LibUiLogic 238, seconv 376.

🤖 Generated with [Claude Code](https://claude.com/claude-code)