### PR TITLE
Fix "key 'DYLD_LIBRARY_PATH' was not present" starting whisper.cpp

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
@@ -3556,7 +3556,7 @@ public partial class SpeechToTextViewModel : ObservableObject
     private static void AddEngineFolderToLibrarySearchPath(ProcessStartInfo startInfo, string engineFolder)
     {
         var variable = OperatingSystem.IsMacOS() ? "DYLD_LIBRARY_PATH" : "LD_LIBRARY_PATH";
-        var existing = startInfo.EnvironmentVariables[variable];
+        var existing = ProcessEnvironmentHelper.GetOrNull(startInfo, variable);
 
         startInfo.EnvironmentVariables[variable] = string.IsNullOrEmpty(existing)
             ? engineFolder
@@ -3816,7 +3816,7 @@ public partial class SpeechToTextViewModel : ObservableObject
             }
         }
 
-        if (OperatingSystem.IsWindows() && process.StartInfo.EnvironmentVariables["Path"] != null)
+        if (OperatingSystem.IsWindows() && ProcessEnvironmentHelper.GetOrNull(process.StartInfo, "Path") != null)
         {
             if (!string.IsNullOrEmpty(Se.Settings.General.FfmpegPath))
             {

--- a/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceTtsCpp.cs
@@ -1,4 +1,4 @@
-using Nikse.SubtitleEdit.Core.Common;
+﻿using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -269,7 +269,7 @@ public class OmniVoiceTtsCpp : ITtsEngine
             {
                 vulkanPath = Logic.VulkanHelper.TryFindBinFolder();
             }
-            if (!string.IsNullOrEmpty(vulkanPath) && psi.EnvironmentVariables["Path"] != null)
+            if (!string.IsNullOrEmpty(vulkanPath) && ProcessEnvironmentHelper.GetOrNull(psi, "Path") != null)
             {
                 psi.EnvironmentVariables["Path"] =
                     psi.EnvironmentVariables["Path"]?.TrimEnd(';') + ";" + vulkanPath;

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCpp.cs
@@ -1,4 +1,4 @@
-using Nikse.SubtitleEdit.Core.Common;
+﻿using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -382,7 +382,7 @@ public class Qwen3TtsCpp : ITtsEngine
                 {
                     vulkanPath = Logic.VulkanHelper.TryFindBinFolder();
                 }
-                if (!string.IsNullOrEmpty(vulkanPath) && psi.EnvironmentVariables["Path"] != null)
+                if (!string.IsNullOrEmpty(vulkanPath) && ProcessEnvironmentHelper.GetOrNull(psi, "Path") != null)
                 {
                     psi.EnvironmentVariables["Path"] =
                         psi.EnvironmentVariables["Path"]?.TrimEnd(';') + ";" + vulkanPath;

--- a/src/ui/Logic/ProcessEnvironmentHelper.cs
+++ b/src/ui/Logic/ProcessEnvironmentHelper.cs
@@ -1,0 +1,23 @@
+using System.Diagnostics;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>
+/// Reading an environment variable off a <see cref="ProcessStartInfo"/> before setting it.
+/// <para>
+/// <c>StartInfo.EnvironmentVariables[name]</c> looks like the .NET Framework API that answered null
+/// for a variable that is not set, but on .NET (Core) that indexer is a wrapper over a generic
+/// dictionary and throws <see cref="System.Collections.Generic.KeyNotFoundException"/> instead. Any
+/// "read the old value, then append to it" code therefore crashes on exactly the machines where the
+/// variable is unset - Speech to text died with "The given key 'DYLD_LIBRARY_PATH' was not present
+/// in the dictionary" on macOS, where nothing sets that variable (issue #13816).
+/// </para>
+/// </summary>
+public static class ProcessEnvironmentHelper
+{
+    /// <summary>The variable's value, or null when the process will not inherit one.</summary>
+    public static string? GetOrNull(ProcessStartInfo startInfo, string name)
+    {
+        return startInfo.Environment.TryGetValue(name, out var value) ? value : null;
+    }
+}

--- a/tests/UI/Logic/ProcessEnvironmentHelperTests.cs
+++ b/tests/UI/Logic/ProcessEnvironmentHelperTests.cs
@@ -1,0 +1,40 @@
+using Nikse.SubtitleEdit.Logic;
+using System.Diagnostics;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// StartInfo.EnvironmentVariables[name] reads like the .NET Framework API that answered null for an
+/// unset variable, but on .NET it throws KeyNotFoundException - which is how Speech to text died
+/// with "The given key 'DYLD_LIBRARY_PATH' was not present in the dictionary" on macOS, where
+/// nothing sets that variable (issue #13816).
+/// </summary>
+public class ProcessEnvironmentHelperTests
+{
+    [Fact]
+    public void GetOrNull_VariableNotSet_ReturnsNull()
+    {
+        var startInfo = new ProcessStartInfo();
+
+        Assert.Null(ProcessEnvironmentHelper.GetOrNull(startInfo, "SE_TEST_DYLD_LIBRARY_PATH"));
+    }
+
+    [Fact]
+    public void GetOrNull_VariableSet_ReturnsTheValue()
+    {
+        var startInfo = new ProcessStartInfo();
+        startInfo.Environment["SE_TEST_DYLD_LIBRARY_PATH"] = "/opt/lib";
+
+        Assert.Equal("/opt/lib", ProcessEnvironmentHelper.GetOrNull(startInfo, "SE_TEST_DYLD_LIBRARY_PATH"));
+    }
+
+    /// <summary>The indexer this helper exists to avoid - pinning why it cannot be used directly.</summary>
+    [Fact]
+    public void EnvironmentVariablesIndexer_UnsetVariable_Throws()
+    {
+        var startInfo = new ProcessStartInfo();
+
+        Assert.Throws<System.Collections.Generic.KeyNotFoundException>(
+            () => startInfo.EnvironmentVariables["SE_TEST_DYLD_LIBRARY_PATH"]);
+    }
+}


### PR DESCRIPTION
Fixes #13816.

### The report

Speech to text with whisper.cpp on macOS fails immediately with:

> Unable to start Whisper CPP: The given key 'DYLD_LIBRARY_PATH' was not present in the dictionary.

while running `whisper-cli` by hand from the same folder works — the executable is fine, Subtitle Edit never gets as far as launching it.

### Cause

`AddEngineFolderToLibrarySearchPath` (added with #13680, to put the engine folder on the loader's search path) reads the current value before appending to it:

```csharp
var existing = startInfo.EnvironmentVariables[variable];
```

That indexer reads like the .NET Framework `StringDictionary` one, which returned **null** for a variable that is not set. On .NET (Core) `ProcessStartInfo.EnvironmentVariables` is a wrapper over a generic dictionary, and its getter **throws `KeyNotFoundException`**. So the code crashes precisely when the variable is unset — which on macOS is every machine, since nothing sets `DYLD_LIBRARY_PATH`. Linux is affected identically whenever `LD_LIBRARY_PATH` is unset; only Windows escaped, because that branch is not taken there.

### Change

`ProcessEnvironmentHelper.GetOrNull` reads through `Environment.TryGetValue`, and the library-path code uses it.

The same read appears three more times as a guard on the Windows GPU-library appends:

```csharp
if (OperatingSystem.IsWindows() && process.StartInfo.EnvironmentVariables["Path"] != null)
```

That condition can never be null — it either returns a value or throws — so it is a guard that does the opposite of what it looks like. Those three (Speech to text, Qwen3 TTS, OmniVoice TTS) now go through the helper as well.

### Testing

`ProcessEnvironmentHelperTests` covers unset → null and set → value, plus a test that pins the raw indexer throwing `KeyNotFoundException`, so the reason this helper exists cannot quietly stop being true. Full UI suite: 3147 passed.

I have no macOS whisper.cpp install with the beta17 layout to reproduce the original dialog end to end; the failing call is exercised directly by the tests instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)