### PR TITLE
SE 4 shortcut import: name the shortcuts it skipped

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -3026,6 +3026,8 @@
       "importShortcutsTitle": "Import shortcuts",
       "exportShortcutsTitle": "Export shortcuts",
       "xShortcutsImportedFromY": "{0} shortcuts imported from {1}",
+      "importFromSe4SkippedActions": "Skipped:",
+      "importFromSe4AndXMore": "  ...and {0} more",
       "xShortcutsExportedToY": "{0} shortcuts exported to {1}",
       "importFromSe4": "Import from SE 4...",
       "importFromSe4Title": "Import shortcuts from Subtitle Edit 4",

--- a/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
+++ b/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
@@ -1,4 +1,4 @@
-using Nikse.SubtitleEdit.Features.Main;
+﻿using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
@@ -21,6 +21,49 @@ public static class Se4ShortcutsImporter
         public List<SeShortCut> Shortcuts { get; } = new();
         public int SkippedNoMapping { get; set; }
         public int SkippedEmpty { get; set; }
+
+        /// <summary>
+        /// What the skipped entries were: the SE 4 action, readably, and the keys it was bound to.
+        /// A bare count left the user with no way to find out what they had lost (issue #13818).
+        /// </summary>
+        public List<SkippedShortcut> SkippedNoMappingActions { get; } = new();
+    }
+
+    /// <summary>An SE 4 shortcut with no SE 5 counterpart.</summary>
+    public sealed record SkippedShortcut(string Se4Name, string Keys)
+    {
+        /// <summary>
+        /// The SE 4 setting name as a phrase: "MainAdjustSetStartAndOffsetTheRest" reads as
+        /// "Adjust set start and offset the rest". SE 4's own labels for these actions are not in
+        /// SE 5, and the raw names are still what the user finds in SE 4's Settings.xml.
+        /// </summary>
+        public string DisplayName => SplitCamelCase(Se4Name);
+
+        public override string ToString() => string.IsNullOrEmpty(Keys) ? DisplayName : $"{DisplayName} [{Keys}]";
+
+        private static string SplitCamelCase(string name)
+        {
+            var trimmed = name.StartsWith("Main", StringComparison.Ordinal) && name.Length > 4
+                ? name.Substring(4)
+                : name;
+
+            var sb = new System.Text.StringBuilder(trimmed.Length + 8);
+            for (var i = 0; i < trimmed.Length; i++)
+            {
+                var c = trimmed[i];
+                if (i > 0 && char.IsUpper(c) && !char.IsUpper(trimmed[i - 1]))
+                {
+                    sb.Append(' ');
+                    sb.Append(char.ToLowerInvariant(c));
+                }
+                else
+                {
+                    sb.Append(c);
+                }
+            }
+
+            return sb.ToString();
+        }
     }
 
     // Exposed for tests: every mapped SE 5 command must stay registered in the shortcut
@@ -415,6 +458,7 @@ public static class Se4ShortcutsImporter
             if (!Map.TryGetValue(se4Name, out var se5Name))
             {
                 result.SkippedNoMapping++;
+                result.SkippedNoMappingActions.Add(new SkippedShortcut(se4Name, value.Trim()));
                 continue;
             }
 

--- a/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
@@ -1,3 +1,4 @@
+﻿using System.Text;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -381,6 +382,40 @@ public partial class ShortcutsViewModel : ObservableObject
         }
     }
 
+    /// <summary>How many shortcuts came over, and - by name - which ones did not.
+    /// "16 skipped" on its own left the user no way to find out what they had lost (#13818).</summary>
+    private static string MakeSe4ImportSummary(Se4ShortcutsImporter.ImportResult result, string fileName)
+    {
+        var summary = string.Format(Se.Language.Options.Shortcuts.ImportFromSe4XImportedYSkipped,
+            result.Shortcuts.Count, fileName, result.SkippedNoMapping);
+
+        if (result.SkippedNoMappingActions.Count == 0)
+        {
+            return summary;
+        }
+
+        var sb = new StringBuilder(summary);
+        sb.AppendLine();
+        sb.AppendLine();
+        sb.AppendLine(Se.Language.Options.Shortcuts.ImportFromSe4SkippedActions);
+
+        // A message box is not a list view: name the first few and count the rest, rather than
+        // growing the dialog past the screen on a full SE 4 settings file.
+        const int maxListed = 12;
+        foreach (var skipped in result.SkippedNoMappingActions.Take(maxListed))
+        {
+            sb.AppendLine("  " + skipped);
+        }
+
+        var remaining = result.SkippedNoMappingActions.Count - maxListed;
+        if (remaining > 0)
+        {
+            sb.AppendLine(string.Format(Se.Language.Options.Shortcuts.ImportFromSe4AndXMore, remaining));
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
     [RelayCommand]
     private async Task ImportFromSe4()
     {
@@ -435,10 +470,7 @@ public partial class ShortcutsViewModel : ObservableObject
             }
 
             await MessageBox.Show(Window, Se.Language.General.Information,
-                string.Format(Se.Language.Options.Shortcuts.ImportFromSe4XImportedYSkipped,
-                    importResult.Shortcuts.Count,
-                    System.IO.Path.GetFileName(fileName),
-                    importResult.SkippedNoMapping),
+                MakeSe4ImportSummary(importResult, System.IO.Path.GetFileName(fileName)),
                 MessageBoxButtons.OK, MessageBoxIcon.Information);
         }
         catch (Exception ex)

--- a/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
@@ -188,6 +188,8 @@ public class LanguageSettingsShortcuts
     public string ImportShortcutsTitle { get; set; }
     public string ExportShortcutsTitle { get; set; }
     public string XShortcutsImportedFromY { get; set; }
+    public string ImportFromSe4SkippedActions { get; set; }
+    public string ImportFromSe4AndXMore { get; set; }
     public string XShortcutsExportedToY { get; set; }
     public string ImportFromSe4 { get; set; }
     public string ImportFromSe4Title { get; set; }
@@ -451,6 +453,8 @@ public class LanguageSettingsShortcuts
         ImportFromSe4 = "Import from SE 4...";
         ImportFromSe4Title = "Import shortcuts from Subtitle Edit 4";
         ImportFromSe4XImportedYSkipped = "{0} shortcuts imported from {1} ({2} skipped — no matching SE 5 action)";
+        ImportFromSe4SkippedActions = "Skipped:";
+        ImportFromSe4AndXMore = "  ...and {0} more";
         ImportImageSubtitleForEdit = "Import image-based subtitle for edit";
         ShowPointSyncViaOther = "Show point sync via other subtitle";
         ShowPointSync = "Show point sync";

--- a/tests/UI/Features/Options/Shortcuts/Se4ShortcutsImporterSkippedTests.cs
+++ b/tests/UI/Features/Options/Shortcuts/Se4ShortcutsImporterSkippedTests.cs
@@ -1,0 +1,62 @@
+using Nikse.SubtitleEdit.Features.Options.Shortcuts;
+using System.Linq;
+using Xunit;
+
+namespace UITests.Features.Options.Shortcuts;
+
+/// <summary>
+/// The SE 4 import reported only how many shortcuts it had skipped ("16 skipped - no matching SE 5
+/// action"), which left the user no way to find out which ones (issue #13818). The result now names
+/// them, with the keys they were bound to.
+/// </summary>
+public class Se4ShortcutsImporterSkippedTests
+{
+    private const string Xml = """
+        <Settings>
+          <Shortcuts>
+            <MainFileNew>Control+N</MainFileNew>
+            <MainAdjustSetStartAndOffsetTheRest>Control+Space</MainAdjustSetStartAndOffsetTheRest>
+            <MainVideoFullscreen>Alt+Enter</MainVideoFullscreen>
+            <MainNeverHeardOfThis></MainNeverHeardOfThis>
+          </Shortcuts>
+        </Settings>
+        """;
+
+    [Fact]
+    public void SkippedActions_AreNamedWithTheirKeys()
+    {
+        var result = Se4ShortcutsImporter.ImportFromXml(Xml);
+
+        Assert.Equal(result.SkippedNoMapping, result.SkippedNoMappingActions.Count);
+        Assert.All(result.SkippedNoMappingActions, s => Assert.False(string.IsNullOrWhiteSpace(s.Keys)));
+    }
+
+    [Fact]
+    public void SkippedAction_ReadsAsAPhraseWithoutTheMainPrefix()
+    {
+        var skipped = new Se4ShortcutsImporter.SkippedShortcut("MainAdjustSetStartAndOffsetTheRest", "Control+Space");
+
+        Assert.Equal("Adjust set start and offset the rest", skipped.DisplayName);
+        Assert.Equal("Adjust set start and offset the rest [Control+Space]", skipped.ToString());
+    }
+
+    [Fact]
+    public void MappedShortcuts_AreNotReportedAsSkipped()
+    {
+        var result = Se4ShortcutsImporter.ImportFromXml(Xml);
+
+        Assert.NotEmpty(result.Shortcuts);
+        Assert.DoesNotContain(result.SkippedNoMappingActions, s => s.Se4Name == "MainFileNew");
+    }
+
+    // An action with no keys assigned in SE 4 is nothing the user lost - it counts as empty, and
+    // listing it as "skipped" would bury the ones that matter.
+    [Fact]
+    public void ActionWithoutKeys_IsNotListed()
+    {
+        var result = Se4ShortcutsImporter.ImportFromXml(Xml);
+
+        Assert.DoesNotContain(result.SkippedNoMappingActions, s => s.Se4Name == "MainNeverHeardOfThis");
+        Assert.True(result.SkippedEmpty >= 1);
+    }
+}


### PR DESCRIPTION
Addresses the first part of #13818.

> How can I find out which shortcuts are missing? I'd like to transfer **ALL** the shortcuts from SE4 to SE5.

The import ended at *"80 shortcuts imported from Settings.xml (16 skipped — no matching SE 5 action)"*, and there was no way to learn which 16.

### Change

`ImportResult` now carries the skipped entries, and the dialog names them with the keys they were bound to:

```
80 shortcuts imported from Settings.xml (16 skipped — no matching SE 5 action)

Skipped:
  Adjust set start and offset the rest [Control+Space]
  Video full screen [Alt+Enter]
  ...
```

SE 4's own labels for these actions do not exist in SE 5, so the setting name is split into a phrase (`MainAdjustSetStartAndOffsetTheRest` → *Adjust set start and offset the rest*) — readable, and still close enough to what the user finds in SE 4's `Settings.xml`. The first twelve are listed and the remainder counted, so a full settings file cannot grow the dialog past the screen.

Entries with no keys assigned in SE 4 stay out of the list: nothing was lost there, and they would bury the ones that matter.

### Testing

`Se4ShortcutsImporterSkippedTests` covers the list matching the count, the phrase formatting, mapped shortcuts not being reported as skipped, and unassigned actions being excluded. Full UI suite: 3151 passed.

### Not in this PR

The issue also raises two other things, which are separate work:

- **Lag around shot changes** — needs a repro and a profile; I have not investigated it.
- **Dragging the preview subtitle up and down with the mouse** so it sits on the black bar instead of covering forced-narrative text — a real feature request for the video player overlay, worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)