### PR TITLE
Speech to text: don't die when ffmpeg cannot be launched

### DIFF
--- a/src/libuilogic/Media/FfmpegMediaInfo.cs
+++ b/src/libuilogic/Media/FfmpegMediaInfo.cs
@@ -56,8 +56,20 @@ namespace Nikse.SubtitleEdit.UiLogic.Media
                 }
             }
 
-            var log = GetFfmpegLog(videoFileName);
-            return ParseLog(log);
+            try
+            {
+                return ParseLog(GetFfmpegLog(videoFileName));
+            }
+            catch (Exception exception)
+            {
+                // A configured ffmpeg that cannot actually be launched - moved install, stale path,
+                // no permission - used to throw out of here, and callers that only expect media info
+                // died with it: adding a file to Speech to text silently added nothing at all and
+                // Transcribe stopped dead (issue #13820). Empty info means "unknown", which every
+                // caller already handles.
+                SeLogger.Error(exception, "Unable to read media info via ffmpeg for " + videoFileName);
+                return new FfmpegMediaInfo();
+            }
         }
 
         public long GetTotalFrames()

--- a/tests/libuilogic/Media/FfmpegMediaInfoParseTests.cs
+++ b/tests/libuilogic/Media/FfmpegMediaInfoParseTests.cs
@@ -1,0 +1,62 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.UiLogic.Media;
+using System;
+using System.IO;
+
+namespace LibUiLogicTests.Media;
+
+/// <summary>
+/// Reading media info must not take the caller down with it when ffmpeg cannot be launched - a
+/// moved install, a stale configured path, no permission. Speech to text died exactly there: the
+/// Win32 exception escaped Parse, so adding a file added no row and Transcribe stopped dead, with
+/// nothing on screen to explain it (issue #13820).
+/// </summary>
+public class FfmpegMediaInfoParseTests : IDisposable
+{
+    private readonly string _previousLocation;
+    private readonly string _folder;
+
+    public FfmpegMediaInfoParseTests()
+    {
+        _previousLocation = Configuration.Settings.General.FFmpegLocation;
+        _folder = Path.Combine(Path.GetTempPath(), "se-ffmpeg-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_folder);
+    }
+
+    public void Dispose()
+    {
+        Configuration.Settings.General.FFmpegLocation = _previousLocation;
+        if (Directory.Exists(_folder))
+        {
+            Directory.Delete(_folder, true);
+        }
+    }
+
+    [Fact]
+    public void Parse_FfmpegPathDoesNotExist_ReturnsEmptyInfoInsteadOfThrowing()
+    {
+        Configuration.Settings.General.FFmpegLocation = Path.Combine(_folder, "gone", "ffmpeg.exe");
+
+        var info = FfmpegMediaInfo.Parse(Path.Combine(_folder, "video.mkv"));
+
+        Assert.NotNull(info);
+        Assert.Empty(info.Tracks);
+    }
+
+    /// <summary>
+    /// The reported case: a path that passes File.Exists but cannot be started as a process. The
+    /// file here is not an executable, which is the same shape of failure on every platform.
+    /// </summary>
+    [Fact]
+    public void Parse_FfmpegPathIsNotRunnable_ReturnsEmptyInfoInsteadOfThrowing()
+    {
+        var notAnExecutable = Path.Combine(_folder, "ffmpeg.exe");
+        File.WriteAllText(notAnExecutable, "this is not a program");
+        Configuration.Settings.General.FFmpegLocation = notAnExecutable;
+
+        var info = FfmpegMediaInfo.Parse(Path.Combine(_folder, "video.mkv"));
+
+        Assert.NotNull(info);
+        Assert.Empty(info.Tracks);
+    }
+}


### PR DESCRIPTION
Fixes #13820.

### The report

> When I click the Add button to add a file to the list [...] a file picker dialog opens. When I select a file, nothing happens. [...] I click Transcribe, the button goes gray, and nothing happens.

The attached log has the answer, 16 times over:

```
An error occurred trying to start process 'C:\Subtitle Edit V5\ffmpeg\ffmpeg.exe'
with working directory 'C:\Subtitle Edit V5'. The system cannot find the path specified.
Unhandled UI thread exception
   at System.Diagnostics.Process.StartWithCreateProcess(ProcessStartInfo startInfo)
   at ...FfmpegMediaInfo.GetFfmpegLog(String videoFileName)
   at ...FfmpegMediaInfo.Parse(String videoFileName)
   at ...SpeechToTextViewModel.AddFiles(String[] fileNames)
```

Their configured ffmpeg cannot be launched. `Process.Start` throws, the exception escapes `Parse` and `AddFiles` (which has a `try`/`finally`, no `catch`), and ends as an unhandled UI thread exception — so the row is never added and nothing is shown. Transcribe fails the same way further down.

### Change

`FfmpegMediaInfo.Parse` no longer throws when ffmpeg cannot be run. The failure is logged and empty media info returned — what every caller already treats as "unknown". `Parse` is used well beyond this dialog (video load, batch convert, burn-in), and none of those expect an exception either; the Windows guard in front of it only covers a path that does not exist, not one that exists and cannot be started.

No ffmpeg prompting is added inside the dialog: Speech to text is already gated by `MainViewModel.RequireFfmpegOk` at all three entry points that open it (Video → Audio to text, transcribe selected lines, auto cast), the same as every other dialog that needs ffmpeg.

### Testing

`FfmpegMediaInfoParseTests` covers both failure shapes — a path that does not exist, and a path that exists but cannot be started (the reported case) — asserting empty info instead of an exception. libuilogic 240 pass, UI builds clean.

I could not reproduce the reporter's exact Win32 error, since I don't have their install; the tests exercise the code path that threw rather than that specific environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
