### PR TITLE
Keep the grid where the user was after replace and blank-line removal

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -14071,16 +14071,21 @@ public partial class MainViewModel :
                 // "Apply" applies the replacements live without closing, so several rounds can be run (#12029).
                 vm.OnApply = (fixedSubtitle, count) =>
                 {
+                    // Replacements are 1:1 with the lines they came from, so stay on the line the
+                    // user was on - jumping to the top on every Apply lost their place, and Apply
+                    // is meant to be used several times in a row (issue #13822).
+                    var selectedIndex = SelectedSubtitleIndex ?? 0;
                     SetSubtitles(fixedSubtitle);
-                    SelectAndScrollToRow(0);
+                    SelectAndScrollToRow(Math.Min(selectedIndex, Subtitles.Count - 1));
                     ShowStatus(string.Format(Se.Language.Main.ReplacedXOccurrences, count));
                 };
             });
 
         if (result.OkPressed)
         {
+            var selectedIndex = SelectedSubtitleIndex ?? 0;
             SetSubtitles(result.FixedSubtitle);
-            SelectAndScrollToRow(0);
+            SelectAndScrollToRow(Math.Min(selectedIndex, Subtitles.Count - 1));
             ShowStatus(string.Format(Se.Language.Main.ReplacedXOccurrences, result.TotalReplaced));
         }
     }
@@ -14932,13 +14937,20 @@ public partial class MainViewModel :
     /// </summary>
     private int RemoveBlankLinesFromGrid()
     {
-        var blankLines = Subtitles.Where(s => s.Text.IsOnlyControlCharactersOrWhiteSpace()).ToList();
-        var count = blankLines.Count;
+        var blank = Subtitles.Select(s => s.Text.IsOnlyControlCharactersOrWhiteSpace()).ToList();
+        var count = blank.Count(b => b);
         if (count == 0)
         {
             return 0;
         }
 
+        // Decide where the selection lands before removing anything: an AlwaysSelected grid picks
+        // a replacement row by itself as rows disappear, and the view follows it to the end of the
+        // list (issue #13822).
+        var survivorIndex = GridSelectionAnchor.PickSurvivorIndex(blank, SelectedSubtitleIndex ?? 0);
+        var survivor = survivorIndex >= 0 ? Subtitles[survivorIndex] : null;
+
+        var blankLines = Subtitles.Where(s => s.Text.IsOnlyControlCharactersOrWhiteSpace()).ToList();
         foreach (var line in blankLines)
         {
             Subtitles.Remove(line);
@@ -14946,6 +14958,11 @@ public partial class MainViewModel :
 
         Renumber();
         _updateAudioVisualizer = true;
+
+        if (survivor != null)
+        {
+            SelectAndScrollToRow(Subtitles.IndexOf(survivor));
+        }
 
         return count;
     }

--- a/src/ui/Logic/GridSelectionAnchor.cs
+++ b/src/ui/Logic/GridSelectionAnchor.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>
+/// Where the selection should land after rows are removed from the subtitle grid.
+/// <para>
+/// Removing rows from a SelectionMode.AlwaysSelected grid makes the control pick a replacement
+/// row on its own, and the view scrolls to wherever that lands - which is how "delete all empty
+/// lines" threw the user to the end of the list (issue #13822). Deciding the row up front keeps
+/// the user where they were working.
+/// </para>
+/// </summary>
+public static class GridSelectionAnchor
+{
+    /// <summary>
+    /// The index - into the list as it is now - of the row to select once the rows flagged in
+    /// <paramref name="isRemoved"/> are gone: the selected row if it survives, else the nearest
+    /// survivor after it, else the nearest one before it. -1 when every row is removed.
+    /// </summary>
+    public static int PickSurvivorIndex(IReadOnlyList<bool> isRemoved, int selectedIndex)
+    {
+        if (isRemoved.Count == 0)
+        {
+            return -1;
+        }
+
+        var start = selectedIndex < 0 ? 0 : selectedIndex;
+        if (start >= isRemoved.Count)
+        {
+            start = isRemoved.Count - 1;
+        }
+
+        for (var i = start; i < isRemoved.Count; i++)
+        {
+            if (!isRemoved[i])
+            {
+                return i;
+            }
+        }
+
+        for (var i = start - 1; i >= 0; i--)
+        {
+            if (!isRemoved[i])
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+}

--- a/tests/UI/Logic/GridSelectionAnchorTests.cs
+++ b/tests/UI/Logic/GridSelectionAnchorTests.cs
@@ -1,0 +1,63 @@
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// "Delete all empty lines" threw the grid to the end of the list: rows were removed one by one
+/// from an AlwaysSelected grid, which picks a replacement row itself and drags the view along
+/// (issue #13822). The row to keep is decided before anything is removed.
+/// </summary>
+public class GridSelectionAnchorTests
+{
+    // false = the row stays, true = it is about to be removed.
+    private static bool[] Rows(params bool[] removed) => removed;
+
+    [Fact]
+    public void SelectedRowSurvives_ItStaysSelected()
+    {
+        var index = GridSelectionAnchor.PickSurvivorIndex(Rows(false, true, false, false), 2);
+
+        Assert.Equal(2, index);
+    }
+
+    [Fact]
+    public void SelectedRowIsRemoved_TheNextSurvivorTakesOver()
+    {
+        var index = GridSelectionAnchor.PickSurvivorIndex(Rows(false, true, true, false), 1);
+
+        Assert.Equal(3, index);
+    }
+
+    // Everything after the selection goes: the user stays as close as possible, just above.
+    [Fact]
+    public void NothingSurvivesAfterTheSelection_TheRowBeforeItTakesOver()
+    {
+        var index = GridSelectionAnchor.PickSurvivorIndex(Rows(false, false, true, true), 3);
+
+        Assert.Equal(1, index);
+    }
+
+    [Fact]
+    public void EverythingIsRemoved_NoSelection()
+    {
+        var index = GridSelectionAnchor.PickSurvivorIndex(Rows(true, true), 0);
+
+        Assert.Equal(-1, index);
+    }
+
+    [Fact]
+    public void EmptyGrid_NoSelection()
+    {
+        Assert.Equal(-1, GridSelectionAnchor.PickSurvivorIndex(Rows(), 0));
+    }
+
+    [Theory]
+    [InlineData(-1)]  // nothing selected
+    [InlineData(99)]  // selection past the end
+    public void SelectionOutsideTheList_FallsBackToASurvivingRow(int selectedIndex)
+    {
+        var index = GridSelectionAnchor.PickSurvivorIndex(Rows(false, true, false), selectedIndex);
+
+        Assert.True(index is 0 or 2);
+    }
+}


### PR DESCRIPTION
Addresses item 1 of #13822.

> Executing multiple find-and-replace operations or deleting all empty lines causes the main list view to jump unexpectedly to either the very beginning or the very end of the list.

Both halves are real, and they have different causes.

### "to the very beginning" — multiple replace

`ShowMultipleReplace` called `SelectAndScrollToRow(0)` after every *Apply* and again on OK. Apply exists precisely so several rounds can be run without closing the dialog (#12029), and each round sent the user back to the top of the file.

The fixed subtitle is built as `new Subtitle(_subtitle, false)` with text assigned per index, so it is 1:1 with the lines it came from — the previously selected index is still the same line, and it is what gets restored.

### "to the very end" — delete all empty lines

`RemoveBlankLinesFromGrid` removed rows one at a time from an `AlwaysSelected` grid. The control picks a replacement row itself as rows disappear, and the view follows it — commonly all the way to the end.

The row to keep is now chosen *before* anything is removed: the selected line if it survives, otherwise the nearest survivor after it, otherwise the one before it. That decision is `GridSelectionAnchor.PickSurvivorIndex`, kept separate from the grid so it can be tested directly.

### Testing

`GridSelectionAnchorTests` covers the survivor rules: selected row survives, selected row removed, nothing surviving after the selection, everything removed, empty grid, and a selection outside the list. Full UI suite: 3151 passed.

### The other two items in the issue

Left out of this PR, deliberately:

- **Ctrl+1 hardcoded to the File menu.** I could not find anything in SE 5 that binds it: no `Key.D1` shortcut outside the layout picker dialog, nothing in the menu code, and no default in `ShortcutsMain`. It may be the desktop environment or a platform accelerator rather than SE. Worth asking the reporter for their OS, and whether it still happens with a fresh settings file.
- **Shift+Enter not remappable in the text box.** That is a feature request against the editor's key handling, not a bug; it needs its own issue and a decision on where such a setting would live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)