### PR TITLE
Keep the waveform responsive while shot changes auto-extract

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -22302,75 +22302,137 @@ public partial class MainViewModel :
 
     private void ExtractShotChanges(string videoFileName, int audioTrackNumber)
     {
-        if (Se.Settings.Waveform.ShotChangesAutoGenerate)
-        {
-            WaveformGeneratingText = Se.Language.Main.ExtractingShotChanges;
-
-            var threshold = Se.Settings.Waveform.ShotChangesSensitivity.ToString(CultureInfo.InvariantCulture);
-            var argumentsFormat = Se.Settings.Video.ShowChangesFFmpegArguments;
-            var arguments = string.Format(argumentsFormat, videoFileName, threshold);
-
-            var ffmpegProcess = FfmpegGenerator.GetProcess(arguments, OutputHandler);
-#pragma warning disable CA1416 // Validate platform compatibility
-            ffmpegProcess.Start();
-#pragma warning restore CA1416 // Validate platform compatibility
-            ffmpegProcess.BeginOutputReadLine();
-            ffmpegProcess.BeginErrorReadLine();
-
-            _ = Task.Run(async () =>
-            {
-                while (!ffmpegProcess.HasExited)
-                {
-                    if (_videoOpenTokenSource.IsCancellationRequested)
-                    {
-                        try
-                        {
-                            ffmpegProcess.Kill(true);
-                        }
-                        catch
-                        {
-                            // ignore
-                        }
-
-                        break;
-                    }
-
-                    // Deliberately NOT the cancellation token: cancel almost always lands
-                    // while this delay is pending, and a token here would throw us out of
-                    // the loop before the Kill above ever runs, orphaning ffmpeg.
-                    await Task.Delay(100, CancellationToken.None).ConfigureAwait(false);
-                }
-
-                if (!_videoOpenTokenSource.IsCancellationRequested && AudioVisualizer != null && AudioVisualizer.ShotChanges != null)
-                {
-                    ShotChangesHelper.SaveShotChanges(videoFileName, AudioVisualizer.ShotChanges, audioTrackNumber);
-                    Dispatcher.UIThread.Post(UpdateShotChangesListMenuItem);
-                }
-            });
-        }
-    }
-
-    private Lock _addShotChangeLock = new Lock();
-
-    private void OutputHandler(object sendingProcess, DataReceivedEventArgs outLine)
-    {
-        if (string.IsNullOrWhiteSpace(outLine.Data))
+        if (!Se.Settings.Waveform.ShotChangesAutoGenerate)
         {
             return;
         }
 
-        var match = ShotChangesViewModel.TimeRegex.Match(outLine.Data);
-        if (match.Success)
+        WaveformGeneratingText = Se.Language.Main.ExtractingShotChanges;
+
+        var threshold = Se.Settings.Waveform.ShotChangesSensitivity.ToString(CultureInfo.InvariantCulture);
+        var argumentsFormat = Se.Settings.Video.ShowChangesFFmpegArguments;
+        var arguments = string.Format(argumentsFormat, videoFileName, threshold);
+
+        // Filled on ffmpeg's stderr callback thread; the UI only ever gets snapshots of it
+        // (see PublishShotChanges). The waveform render loop binary-searches ShotChanges at
+        // ~60 fps, so handing it a list a background thread keeps Add'ing to could tear a
+        // render mid-grow. Per run: a late callback from a superseded extraction lands in
+        // its own dead list, not in the next video's.
+        var collected = new List<double>();
+        DataReceivedEventHandler onFfmpegOutput = (_, outLine) =>
         {
-            var timeCode = match.Value.Replace("pts_time:", string.Empty).Replace(",", ".").Replace("٫", ".").Replace("⠨", ".");
-            if (double.TryParse(timeCode, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var seconds) && seconds > 0.2)
+            if (string.IsNullOrWhiteSpace(outLine.Data))
             {
-                lock (_addShotChangeLock)
+                return;
+            }
+
+            var match = ShotChangesViewModel.TimeRegex.Match(outLine.Data);
+            if (match.Success)
+            {
+                var timeCode = match.Value.Replace("pts_time:", string.Empty).Replace(",", ".").Replace("٫", ".").Replace("⠨", ".");
+                if (double.TryParse(timeCode, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var seconds) && seconds > 0.2)
                 {
-                    AudioVisualizer?.ShotChanges.Add(seconds);
+                    lock (collected)
+                    {
+                        collected.Add(seconds);
+                    }
                 }
             }
+        };
+
+        var ffmpegProcess = FfmpegGenerator.GetProcess(arguments, onFfmpegOutput);
+#pragma warning disable CA1416 // Validate platform compatibility
+        ffmpegProcess.Start();
+        try
+        {
+            // Scene detection decodes every frame of the whole video with all cores. At
+            // normal priority that competes with the UI thread, the waveform render and
+            // mpv for minutes on a long file - this auto-extraction runs silently right
+            // after a video opens, exactly when the user starts editing. Below normal
+            // still gets the idle cores but yields the moment the user does anything.
+            ffmpegProcess.PriorityClass = ProcessPriorityClass.BelowNormal;
         }
+        catch
+        {
+            // Best effort - the process may already have exited.
+        }
+#pragma warning restore CA1416 // Validate platform compatibility
+        ffmpegProcess.BeginOutputReadLine();
+        ffmpegProcess.BeginErrorReadLine();
+
+        _ = Task.Run(async () =>
+        {
+            var publishedCount = 0;
+            while (!ffmpegProcess.HasExited)
+            {
+                if (_videoOpenTokenSource.IsCancellationRequested)
+                {
+                    try
+                    {
+                        ffmpegProcess.Kill(true);
+                    }
+                    catch
+                    {
+                        // ignore
+                    }
+
+                    break;
+                }
+
+                publishedCount = PublishShotChanges(collected, publishedCount);
+
+                // Deliberately NOT the cancellation token: cancel almost always lands
+                // while this delay is pending, and a token here would throw us out of
+                // the loop before the Kill above ever runs, orphaning ffmpeg.
+                await Task.Delay(100, CancellationToken.None).ConfigureAwait(false);
+            }
+
+            if (!_videoOpenTokenSource.IsCancellationRequested)
+            {
+                PublishShotChanges(collected, publishedCount);
+
+                List<double> finalList;
+                lock (collected)
+                {
+                    finalList = new List<double>(collected);
+                }
+
+                ShotChangesHelper.SaveShotChanges(videoFileName, finalList, audioTrackNumber);
+            }
+        });
+    }
+
+    /// <summary>
+    /// Hand the shot changes collected so far to the waveform as a fresh copy, so the marks
+    /// appear while the extraction is still running without the UI ever reading the list the
+    /// callback thread writes to. No-op (returns <paramref name="publishedCount"/>) when
+    /// nothing new arrived since the last publish.
+    /// </summary>
+    private int PublishShotChanges(List<double> collected, int publishedCount)
+    {
+        List<double> snapshot;
+        lock (collected)
+        {
+            if (collected.Count == publishedCount)
+            {
+                return publishedCount;
+            }
+
+            snapshot = new List<double>(collected);
+        }
+
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (AudioVisualizer != null)
+            {
+                AudioVisualizer.ShotChanges = snapshot;
+                _updateAudioVisualizer = true;
+            }
+
+            UpdateShotChangesListMenuItem();
+        });
+
+        return snapshot.Count;
     }
 
     private static void DeleteTempFile(string tempWaveFileName)


### PR DESCRIPTION
Follows up on a user report that the waveform is slow around shot changes. The render/interaction hot paths (drawing, snapping, cursor pen) were already optimized in earlier perf rounds; the problems were both in the silent auto-extraction that runs after a video opens when **Waveform → auto-generate shot changes** is enabled.

## 1. ffmpeg scene detection now runs at below-normal priority

The extraction decodes every frame of the entire video with `-threads 0` (all cores) at normal process priority — several minutes of 100% CPU on a long file, starting right when the user begins editing, and invisible because the "Extracting shot changes" label is cleared almost immediately by the peaks-generation `finally`. The UI thread, the ~60 fps waveform render and mpv all competed with it, which is exactly what "the waveform got sluggish" feels like.

`ProcessPriorityClass.BelowNormal` (works on Windows/macOS/Linux for lowering) keeps full extraction speed on an idle machine but yields the moment the user does anything.

## 2. Shot changes are published as snapshots instead of mutating the live list

`OutputHandler` ran on ffmpeg's stderr callback thread and did `AudioVisualizer.ShotChanges.Add(seconds)` into the live list for the whole extraction, under a lock no reader takes. The waveform render binary-searches that same `List<double>` at ~60 fps (`DrawShotChanges`, `GetShotChangeIndex`) and drag-snapping reads it per pointer move — a concurrent `Add` that grows the backing array can tear a read: an `ArgumentOutOfRangeException` inside `Render`, or phantom `0.0` entries that break the sorted invariant the binary searches rely on.

Shot changes are now collected into a per-run list owned by the callback thread and posted to the UI thread as fresh copies every 100 ms (reusing the existing watchdog loop), so the marks still appear live during extraction and every other mutation site's convention — replace the list wholesale, never write into a published one — now holds everywhere. The per-run list also stops a late callback from a superseded extraction leaking timestamps into the next video's list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)