### PR TITLE
Waveform perf: fuse 16-bit stereo peak extraction into one SIMD pass

### DIFF
--- a/src/ui/Logic/Media/WaveToVisualizer2.cs
+++ b/src/ui/Logic/Media/WaveToVisualizer2.cs
@@ -675,10 +675,12 @@ public class WavePeakGenerator2 : IDisposable
         }
 
         // Fast path for 16-bit stereo PCM (what SE's own ffmpeg extraction produces for the
-        // waveform) - a span cast instead of a delegate call per channel per sample. A matching
-        // mono fast path was benchmarked at 0.9x the delegate loop (the per-sample work is two
-        // stores either way and the delegate call site is monomorphic) and dropped; mono and
-        // 8/24/32-bit take the generic delegate loop.
+        // waveform) - a fused single-pass SIMD peak over the raw shorts, skipping both the
+        // per-sample delegate dispatch and the intermediate float buffer (benchmarked at ~10x
+        // the two-step span-cast pipeline it replaces). A matching mono fast path was
+        // benchmarked at 0.9x the delegate loop (the per-sample work is two stores either way
+        // and the delegate call site is monomorphic) and dropped; mono and 8/24/32-bit take
+        // the generic delegate loop.
         var fast16Stereo = Header.BytesPerSample == 2 && Header.NumberOfChannels == 2;
 
         while (fileSampleOffset < fileSampleCount)
@@ -704,34 +706,33 @@ public class WavePeakGenerator2 : IDisposable
 
                 if (fast16Stereo)
                 {
-                    ConvertPeakChunk16BitStereo(MemoryMarshal.Cast<byte, short>(data.AsSpan(0, fileReadByteCount)), chunkSamples, sampleAndChannelScale);
+                    peaks.Add(CalculatePeak16BitStereo(MemoryMarshal.Cast<byte, short>(data.AsSpan(0, fileReadByteCount)), sampleAndChannelScale));
+                    continue;
                 }
-                else
-                {
-                    int chunkSampleOffset = 0;
-                    int dataByteOffset = 0;
-                    while (dataByteOffset < fileReadByteCount)
-                    {
-                        float valuePositive = 0F;
-                        float valueNegative = -0F;
-                        for (int iChannel = 0; iChannel < Header.NumberOfChannels; iChannel++)
-                        {
-                            var v = readSampleDataValue(data, ref dataByteOffset);
-                            if (v < 0)
-                            {
-                                valueNegative += v;
-                            }
-                            else
-                            {
-                                valuePositive += v;
-                            }
-                        }
 
-                        chunkSamples[chunkSampleOffset] = valueNegative * sampleAndChannelScale;
-                        chunkSampleOffset++;
-                        chunkSamples[chunkSampleOffset] = valuePositive * sampleAndChannelScale;
-                        chunkSampleOffset++;
+                int chunkSampleOffset = 0;
+                int dataByteOffset = 0;
+                while (dataByteOffset < fileReadByteCount)
+                {
+                    float valuePositive = 0F;
+                    float valueNegative = -0F;
+                    for (int iChannel = 0; iChannel < Header.NumberOfChannels; iChannel++)
+                    {
+                        var v = readSampleDataValue(data, ref dataByteOffset);
+                        if (v < 0)
+                        {
+                            valueNegative += v;
+                        }
+                        else
+                        {
+                            valuePositive += v;
+                        }
                     }
+
+                    chunkSamples[chunkSampleOffset] = valueNegative * sampleAndChannelScale;
+                    chunkSampleOffset++;
+                    chunkSamples[chunkSampleOffset] = valuePositive * sampleAndChannelScale;
+                    chunkSampleOffset++;
                 }
             }
 
@@ -761,11 +762,11 @@ public class WavePeakGenerator2 : IDisposable
     public static WavePeakData2 GenerateEmptyPeaks(string peakFileName, int totalSeconds)
     {
         var peaksPerSecond = Se.Settings.Waveform.WaveformMinimumSampleRate;
-        var peaks = new List<WavePeak2>
+        var totalPeaks = peaksPerSecond * totalSeconds;
+        var peaks = new List<WavePeak2>(totalPeaks + 2)
         {
             new WavePeak2(1000, -1000)
         };
-        var totalPeaks = peaksPerSecond * totalSeconds;
         for (var i = 0; i < totalPeaks; i++)
         {
             peaks.Add(new WavePeak2(1, -1));
@@ -779,58 +780,98 @@ public class WavePeakGenerator2 : IDisposable
             Directory.CreateDirectory(dir);
         }
 
+        // One bulk write of the (Max, Min) short pairs - byte-identical to the old 4-bytes-per-
+        // peak loop (a WavePeak2 is exactly the two little-endian shorts the loop wrote), ~16x
+        // faster on a multi-hour file.
         using (var stream = File.Create(peakFileName))
         {
-            WaveHeader2.WriteHeader(stream, peaksPerSecond, 2, 16, peaks.Count);
-            var buffer = new byte[4];
-            foreach (var peak in peaks)
-            {
-                WriteValue16Bit(buffer, 0, peak.Max);
-                WriteValue16Bit(buffer, 2, peak.Min);
-                stream.Write(buffer, 0, 4);
-            }
+            WriteWaveformData(stream, peaksPerSecond, peaks);
         }
 
         return new WavePeakData2(peaksPerSecond, peaks);
     }
 
     /// <summary>
-    /// One peak chunk's samples for 16-bit stereo PCM: per frame, the negative channel values
-    /// summed into an even slot and the positive ones into the following odd slot (that is the
-    /// contract <see cref="CalculatePeak"/> expects). Span-cast fast path - no per-sample
-    /// delegate dispatch.
+    /// One peak chunk for 16-bit stereo PCM, in a single SIMD pass over the raw interleaved
+    /// shorts: the chunk's peak is max over frames of (posL+posR) and min over frames of
+    /// (negL+negR). Per Vector&lt;short&gt; block, widen to ints, split positive/negative-magnitude
+    /// parts (negating only after widening - negating short.MinValue at short width overflows),
+    /// reinterpret the int vector as longs so each long lane holds one frame's two channel
+    /// values, pair-sum them with mask+shift, and max-accumulate per lane. Bit-identical to the
+    /// old float pipeline (convert + <see cref="CalculatePeak"/>): the int-sum -> float ->
+    /// *scale mapping is weakly monotone (sums are &lt;= 65536, exactly representable in float),
+    /// so taking the max in integer space and scaling once picks the same peak.
     /// </summary>
-    internal static void ConvertPeakChunk16BitStereo(ReadOnlySpan<short> samples, Span<float> chunkSamples, float scale)
+    internal static WavePeak2 CalculatePeak16BitStereo(ReadOnlySpan<short> samples, float scale)
     {
-        var chunkSampleOffset = 0;
-        for (var sIdx = 0; sIdx + 1 < samples.Length; sIdx += 2)
+        var frameSamples = samples.Length & ~1;
+        if (frameSamples == 0)
         {
-            short v1 = samples[sIdx];
-            short v2 = samples[sIdx + 1];
-
-            float pos = 0, neg = 0;
-
-            if (v1 < 0)
-            {
-                neg += v1;
-            }
-            else
-            {
-                pos += v1;
-            }
-
-            if (v2 < 0)
-            {
-                neg += v2;
-            }
-            else
-            {
-                pos += v2;
-            }
-
-            chunkSamples[chunkSampleOffset++] = neg * scale;
-            chunkSamples[chunkSampleOffset++] = pos * scale;
+            return new WavePeak2();
         }
+
+        long maxPos = 0;
+        long maxNegAbs = 0;
+        var i = 0;
+
+        if (Vector.IsHardwareAccelerated && frameSamples >= Vector<short>.Count)
+        {
+            var posMaxVec = Vector<long>.Zero;
+            var negMaxVec = Vector<long>.Zero;
+            var loMask = new Vector<long>(0xFFFFFFFFL);
+            var lastBlockStart = frameSamples - Vector<short>.Count;
+            for (; i <= lastBlockStart; i += Vector<short>.Count)
+            {
+                var v = new Vector<short>(samples.Slice(i));
+                Vector.Widen(v, out var lo, out var hi);
+                AccumulatePairMax(lo, loMask, ref posMaxVec, ref negMaxVec);
+                AccumulatePairMax(hi, loMask, ref posMaxVec, ref negMaxVec);
+            }
+
+            for (var lane = 0; lane < Vector<long>.Count; lane++)
+            {
+                var p = posMaxVec[lane];
+                if (p > maxPos)
+                {
+                    maxPos = p;
+                }
+
+                var n = negMaxVec[lane];
+                if (n > maxNegAbs)
+                {
+                    maxNegAbs = n;
+                }
+            }
+        }
+
+        for (; i < frameSamples; i += 2)
+        {
+            int l = samples[i];
+            int r = samples[i + 1];
+            var pos = (l > 0 ? l : 0) + (r > 0 ? r : 0);
+            var negAbs = (l < 0 ? -l : 0) + (r < 0 ? -r : 0);
+            if (pos > maxPos)
+            {
+                maxPos = pos;
+            }
+
+            if (negAbs > maxNegAbs)
+            {
+                maxNegAbs = negAbs;
+            }
+        }
+
+        var max = maxPos * scale;
+        var min = -(maxNegAbs * scale);
+        return new WavePeak2((short)(short.MaxValue * max), (short)(short.MaxValue * min));
+    }
+
+    private static void AccumulatePairMax(Vector<int> widened, Vector<long> loMask, ref Vector<long> posMaxVec, ref Vector<long> negMaxVec)
+    {
+        var pos = Vector.AsVectorInt64(Vector.Max(widened, Vector<int>.Zero));
+        var neg = Vector.AsVectorInt64(-Vector.Min(widened, Vector<int>.Zero));
+        posMaxVec = Vector.Max(posMaxVec, (pos & loMask) + Vector.ShiftRightLogical(pos, 32));
+        negMaxVec = Vector.Max(negMaxVec, (neg & loMask) + Vector.ShiftRightLogical(neg, 32));
     }
 
     /// <summary>

--- a/tests/UI/Logic/HotPathRound9Tests.cs
+++ b/tests/UI/Logic/HotPathRound9Tests.cs
@@ -7,6 +7,7 @@ using SkiaSharp;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using NikseBitmap = Nikse.SubtitleEdit.Core.Common.NikseBitmap;
 
@@ -101,15 +102,41 @@ public class HotPathRound9Tests
     }
 
     [Theory]
+    [InlineData(0)]
     [InlineData(2)]
     [InlineData(380)]
     [InlineData(762)]
-    public void ConvertPeakChunk16BitStereo_MatchesOldLoop(int sampleCount)
+    [InlineData(763)] // odd: trailing sample ignored
+    public void CalculatePeak16BitStereo_MatchesOldTwoStepPipeline(int sampleCount)
     {
         var samples = MakeShorts(sampleCount, seed: sampleCount);
         const float scale = 0.5f / short.MaxValue;
 
-        var expected = new float[sampleCount];
+        var expected = OldTwoStepStereoPeak(samples, scale);
+        var actual = WavePeakGenerator2.CalculatePeak16BitStereo(samples, scale);
+
+        Assert.Equal(expected.Max, actual.Max);
+        Assert.Equal(expected.Min, actual.Min);
+    }
+
+    [Fact]
+    public void CalculatePeak16BitStereo_ShortMinValueDoesNotOverflow()
+    {
+        // Negating short.MinValue at short width overflows; the SIMD path must widen first.
+        var samples = Enumerable.Repeat(short.MinValue, 64).ToArray();
+        const float scale = 0.5f / short.MaxValue;
+
+        var expected = OldTwoStepStereoPeak(samples, scale);
+        var actual = WavePeakGenerator2.CalculatePeak16BitStereo(samples, scale);
+
+        Assert.Equal(expected.Max, actual.Max);
+        Assert.Equal(expected.Min, actual.Min);
+    }
+
+    /// <summary>The old pipeline: scalar convert to per-frame neg/pos floats, then CalculatePeak.</summary>
+    private static WavePeak2 OldTwoStepStereoPeak(short[] samples, float scale)
+    {
+        var chunkSamples = new float[samples.Length + 1];
         var chunkSampleOffset = 0;
         for (var sIdx = 0; sIdx + 1 < samples.Length; sIdx += 2)
         {
@@ -118,14 +145,11 @@ public class HotPathRound9Tests
             float pos = 0, neg = 0;
             if (v1 < 0) { neg += v1; } else { pos += v1; }
             if (v2 < 0) { neg += v2; } else { pos += v2; }
-            expected[chunkSampleOffset++] = neg * scale;
-            expected[chunkSampleOffset++] = pos * scale;
+            chunkSamples[chunkSampleOffset++] = neg * scale;
+            chunkSamples[chunkSampleOffset++] = pos * scale;
         }
 
-        var actual = new float[sampleCount];
-        WavePeakGenerator2.ConvertPeakChunk16BitStereo(samples, actual, scale);
-
-        Assert.Equal(expected, actual);
+        return WavePeakGenerator2.CalculatePeak(chunkSamples, chunkSampleOffset);
     }
 
     [Fact]

--- a/tests/benchmarks/WaveformGeometryRebuildBenchmarks.cs
+++ b/tests/benchmarks/WaveformGeometryRebuildBenchmarks.cs
@@ -1,0 +1,99 @@
+using Avalonia;
+using Avalonia.Headless;
+using Avalonia.Media;
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// Isolates the waveform geometry rebuild (the per-pixel BuildWaveFormFancy/Classic loops):
+/// every frame jumps the view ~100 s, so the anchored waveform cache misses and Render()
+/// re-runs the full build - a trimmed-down ForcedRebuildFrame from
+/// AudioVisualizerRenderBenchmarks, at one width, kept lean so before/after runs of a
+/// build-loop change are quick. Classic is the drift control for changes that only touch
+/// the fancy loop (its ratio to its own baseline should stay ~1.0).
+/// </summary>
+[MemoryDiagnoser]
+public class WaveformGeometryRebuildBenchmarks
+{
+    private const double HeightPx = 220;
+    private const int WidthPx = 3200;
+    private const int PeaksPerSecond = 126;
+    private const int PeaksLengthSeconds = 3600;
+
+    private static bool _avaloniaInitialized;
+
+    private AudioVisualizer _audioVisualizer = null!;
+    private List<SubtitleLineViewModel> _subtitles = null!;
+    private readonly List<SubtitleLineViewModel> _noSelection = new();
+    private double _viewSeconds;
+    private int _frameIndex;
+
+    [Params(WaveformDrawStyle.Classic, WaveformDrawStyle.Fancy)]
+    public WaveformDrawStyle Style { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        if (!_avaloniaInitialized)
+        {
+            _avaloniaInitialized = true;
+            AppBuilder.Configure<Application>()
+                .UseHeadless(new AvaloniaHeadlessPlatformOptions { UseHeadlessDrawing = false })
+                .UseSkia()
+                .WithInterFont()
+                .SetupWithoutStarting();
+        }
+
+        _audioVisualizer = new AudioVisualizer
+        {
+            WaveformDrawStyle = Style,
+            WavePeaks = MakeSpeechLikePeaks(),
+        };
+        _audioVisualizer.Measure(new Size(WidthPx, HeightPx));
+        _audioVisualizer.Arrange(new Rect(0, 0, WidthPx, HeightPx));
+
+        _subtitles = SubtitleFactory.Make(2000);
+        _viewSeconds = WidthPx / (double)PeaksPerSecond;
+        _frameIndex = 0;
+    }
+
+    [Benchmark]
+    public void RebuildFrame()
+    {
+        _frameIndex++;
+        var startSeconds = (_frameIndex & 1) == 0 ? 100.0 : 200.0;
+        var cursorSeconds = startSeconds + _viewSeconds / 2.0;
+        if (_frameIndex % 3 == 0)
+        {
+            _audioVisualizer.SetPosition(startSeconds, _subtitles, cursorSeconds, -1, _noSelection);
+        }
+        else
+        {
+            _audioVisualizer.StartPositionSeconds = startSeconds;
+            _audioVisualizer.CurrentVideoPositionSeconds = cursorSeconds;
+        }
+
+        var drawingGroup = new DrawingGroup();
+        using var context = drawingGroup.Open();
+        _audioVisualizer.Render(context);
+    }
+
+    private static WavePeakData2 MakeSpeechLikePeaks()
+    {
+        var random = new Random(42);
+        var peaks = new WavePeak2[PeaksPerSecond * PeaksLengthSeconds];
+        for (var i = 0; i < peaks.Length; i++)
+        {
+            var seconds = i / (double)PeaksPerSecond;
+            var inBurst = seconds % 0.5 < 0.3;
+            var amplitude = inBurst ? random.Next(4000, 28000) : random.Next(0, 900);
+            peaks[i] = new WavePeak2((short)amplitude, (short)-random.Next(amplitude / 2, amplitude + 1));
+        }
+
+        return new WavePeakData2(PeaksPerSecond, peaks);
+    }
+}

--- a/tests/benchmarks/WaveformPeakSimdBenchmarks.cs
+++ b/tests/benchmarks/WaveformPeakSimdBenchmarks.cs
@@ -1,0 +1,230 @@
+using System.Runtime.InteropServices;
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// Waveform peak extraction, 16-bit stereo PCM (what SE's own ffmpeg extraction produces):
+/// the old two-step pipeline per chunk (a scalar convert writes a float neg/pos pair per
+/// frame, then CalculatePeak SIMD-reduces the floats; the convert is preserved below as the
+/// baseline) against the shipped fused single-pass SIMD peak
+/// (WavePeakGenerator2.CalculatePeak16BitStereo), which never materializes the intermediate
+/// float buffer. See that method for why the integer-space max is bit-identical to the float
+/// pipeline's result; GlobalSetup asserts it over random and adversarial data (including the
+/// short.MinValue negation trap).
+///
+/// Both candidates are exercised chunk-by-chunk (375 frames = 48 kHz / 128 peaks-per-second),
+/// exactly how GeneratePeaks consumes them, over 10 s of speech-like audio per invocation.
+///
+/// Also here: the GenerateEmptyPeaks write shape - one 4-byte stream.Write per peak versus
+/// one bulk span write of the whole peak list (byte-identical output, asserted in setup).
+/// </summary>
+[MemoryDiagnoser]
+public class WaveformPeakSimdBenchmarks
+{
+    private const int ChunkFrames = 375; // 48000 Hz / 128 peaks-per-second
+    private const int Seconds = 10;
+    private const float Scale = 1f / 65536f; // 16-bit stereo: (1/2^15)/2
+
+    private short[] _samples = null!;
+    private float[] _chunkSamples = null!;
+
+    private WavePeak2[] _emptyPeaks = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _samples = MakeSpeechLikeSamples(48000 * Seconds);
+        // A little extra room: the equivalence cases include chunks slightly longer than
+        // ChunkFrames (the benchmark itself only ever uses ChunkFrames-sized chunks).
+        _chunkSamples = new float[(ChunkFrames + 4) * 2];
+
+        // ~40 minutes of empty peaks (126 peaks/s), the shape GenerateEmptyPeaks builds.
+        _emptyPeaks = new WavePeak2[126 * 2400 + 2];
+        _emptyPeaks[0] = new WavePeak2(1000, -1000);
+        for (var i = 1; i < _emptyPeaks.Length - 1; i++)
+        {
+            _emptyPeaks[i] = new WavePeak2(1, -1);
+        }
+
+        _emptyPeaks[^1] = new WavePeak2(1000, -1000);
+
+        AssertEquivalence();
+    }
+
+    private void AssertEquivalence()
+    {
+        // Adversarial chunks: silence, DC extremes, short.MinValue everywhere (the negation
+        // overflow trap), alternating extremes, single frame, odd tails, and random data.
+        var cases = new List<short[]>
+        {
+            new short[ChunkFrames * 2], // silence
+            Enumerable.Repeat(short.MinValue, ChunkFrames * 2).ToArray(),
+            Enumerable.Repeat(short.MaxValue, ChunkFrames * 2).ToArray(),
+            Enumerable.Range(0, ChunkFrames * 2).Select(i => (i & 1) == 0 ? short.MinValue : short.MaxValue).ToArray(),
+            new short[] { short.MinValue, short.MinValue },
+            new short[] { -1, 1 },
+            new short[] { 123, -456, 789, -12, 345 }, // odd length - trailing sample ignored by both
+        };
+
+        var random = new Random(1234);
+        for (var n = 0; n < 200; n++)
+        {
+            var len = random.Next(1, ChunkFrames * 2 + 3);
+            var chunk = new short[len];
+            for (var i = 0; i < len; i++)
+            {
+                chunk[i] = (short)random.Next(short.MinValue, short.MaxValue + 1);
+            }
+
+            cases.Add(chunk);
+        }
+
+        foreach (var chunk in cases)
+        {
+            var expected = CurrentPipeline(chunk);
+            var actual = WavePeakGenerator2.CalculatePeak16BitStereo(chunk, Scale);
+            if (expected.Max != actual.Max || expected.Min != actual.Min)
+            {
+                throw new InvalidOperationException(
+                    $"Peak mismatch for len={chunk.Length}: expected ({expected.Max},{expected.Min}), got ({actual.Max},{actual.Min})");
+            }
+        }
+
+        // Empty-peaks write shapes must produce byte-identical streams.
+        using var perPeak = new MemoryStream();
+        WriteEmptyPeaksPerPeak(perPeak, _emptyPeaks);
+        using var bulk = new MemoryStream();
+        WriteEmptyPeaksBulk(bulk, _emptyPeaks);
+        if (!perPeak.ToArray().AsSpan().SequenceEqual(bulk.ToArray()))
+        {
+            throw new InvalidOperationException("Empty-peaks write shapes differ");
+        }
+    }
+
+    private WavePeak2 CurrentPipeline(ReadOnlySpan<short> chunk)
+    {
+        var frames = chunk.Length / 2;
+        ConvertPeakChunk16BitStereoOld(chunk, _chunkSamples, Scale);
+        return WavePeakGenerator2.CalculatePeak(_chunkSamples, frames * 2);
+    }
+
+    [Benchmark(Baseline = true)]
+    public int PeakChunks_Current()
+    {
+        var acc = 0;
+        var samples = _samples.AsSpan();
+        for (var offset = 0; offset + ChunkFrames * 2 <= samples.Length; offset += ChunkFrames * 2)
+        {
+            var chunk = samples.Slice(offset, ChunkFrames * 2);
+            ConvertPeakChunk16BitStereoOld(chunk, _chunkSamples, Scale);
+            var peak = WavePeakGenerator2.CalculatePeak(_chunkSamples, ChunkFrames * 2);
+            acc += peak.Max + peak.Min;
+        }
+
+        return acc;
+    }
+
+    /// <summary>The old two-step pipeline's convert, preserved here as the baseline.</summary>
+    private static void ConvertPeakChunk16BitStereoOld(ReadOnlySpan<short> samples, Span<float> chunkSamples, float scale)
+    {
+        var chunkSampleOffset = 0;
+        for (var sIdx = 0; sIdx + 1 < samples.Length; sIdx += 2)
+        {
+            short v1 = samples[sIdx];
+            short v2 = samples[sIdx + 1];
+
+            float pos = 0, neg = 0;
+
+            if (v1 < 0)
+            {
+                neg += v1;
+            }
+            else
+            {
+                pos += v1;
+            }
+
+            if (v2 < 0)
+            {
+                neg += v2;
+            }
+            else
+            {
+                pos += v2;
+            }
+
+            chunkSamples[chunkSampleOffset++] = neg * scale;
+            chunkSamples[chunkSampleOffset++] = pos * scale;
+        }
+    }
+
+    [Benchmark]
+    public int PeakChunks_FusedSimd()
+    {
+        var acc = 0;
+        var samples = _samples.AsSpan();
+        for (var offset = 0; offset + ChunkFrames * 2 <= samples.Length; offset += ChunkFrames * 2)
+        {
+            var peak = WavePeakGenerator2.CalculatePeak16BitStereo(samples.Slice(offset, ChunkFrames * 2), Scale);
+            acc += peak.Max + peak.Min;
+        }
+
+        return acc;
+    }
+
+    [Benchmark]
+    public long EmptyPeaksWrite_PerPeak()
+    {
+        using var stream = new MemoryStream(_emptyPeaks.Length * 4);
+        WriteEmptyPeaksPerPeak(stream, _emptyPeaks);
+        return stream.Length;
+    }
+
+    [Benchmark]
+    public long EmptyPeaksWrite_Bulk()
+    {
+        using var stream = new MemoryStream(_emptyPeaks.Length * 4);
+        WriteEmptyPeaksBulk(stream, _emptyPeaks);
+        return stream.Length;
+    }
+
+    /// <summary>Old GenerateEmptyPeaks write shape: 4 bytes per peak.</summary>
+    private static void WriteEmptyPeaksPerPeak(Stream stream, WavePeak2[] peaks)
+    {
+        var buffer = new byte[4];
+        foreach (var peak in peaks)
+        {
+            buffer[0] = (byte)peak.Max;
+            buffer[1] = (byte)(peak.Max >> 8);
+            buffer[2] = (byte)peak.Min;
+            buffer[3] = (byte)(peak.Min >> 8);
+            stream.Write(buffer, 0, 4);
+        }
+    }
+
+    /// <summary>Candidate: one bulk write of the (Max, Min) short pairs.</summary>
+    private static void WriteEmptyPeaksBulk(Stream stream, WavePeak2[] peaks)
+    {
+        stream.Write(MemoryMarshal.AsBytes(peaks.AsSpan()));
+    }
+
+    private static short[] MakeSpeechLikeSamples(int frames)
+    {
+        // Bursts of loud audio separated by near-silence, mirroring
+        // AudioVisualizerRenderBenchmarks.MakeSpeechLikePeaks.
+        var random = new Random(42);
+        var samples = new short[frames * 2];
+        for (var f = 0; f < frames; f++)
+        {
+            var seconds = f / 48000.0;
+            var inBurst = seconds % 0.5 < 0.3;
+            var amplitude = inBurst ? random.Next(4000, 28000) : random.Next(0, 900);
+            samples[f * 2] = (short)(random.Next(2) == 0 ? amplitude : -amplitude);
+            samples[f * 2 + 1] = (short)(random.Next(2) == 0 ? amplitude : -amplitude);
+        }
+
+        return samples;
+    }
+}


### PR DESCRIPTION
A waveform-focused micro-perf round (spectrogram deliberately excluded), verified with BenchmarkDotNet.

## What changed

**1. Fused SIMD peak extraction for 16-bit stereo PCM** — the format SE's own ffmpeg extraction produces, i.e. the path every first video open without cached peaks takes. The old fast path converted every frame into a float neg/pos pair (scalar, branchy) and then SIMD-reduced the floats. The new `CalculatePeak16BitStereo` does one SIMD pass over the raw interleaved shorts: widen to ints, split positive/negative-magnitude parts (negating only after widening — negating `short.MinValue` at short width overflows), reinterpret as longs so each lane holds one frame's L+R, pair-sum with mask+shift, max-accumulate per lane. Bit-identical output: the int-sum → float → ×scale mapping is weakly monotone (sums ≤ 65536 are exact in float), so the integer-space max picks the same peak.

**2. `GenerateEmptyPeaks` bulk write** — one `MemoryMarshal.AsBytes` span write via `WriteWaveformData` instead of 4 bytes per peak (byte-identical file), plus a pre-sized list.

## Numbers (BenchmarkDotNet, Apple M4, in-process toolchain)

| Benchmark | Before | After | Speed-up |
|---|---:|---:|---:|
| Peak extraction, 10 s of 48 kHz stereo | 3,546 µs | 267 µs | **13.3×** |
| Empty-peaks write, ~40 min of peaks | 857 µs | 39 µs | **22×** |

For a 2-hour movie, the CPU part of peak extraction drops from ~2.5 s to ~0.2 s (I/O unchanged).

## Correctness

- Benchmark `GlobalSetup` asserts bit-identical peaks against the old two-step pipeline over 207 adversarial chunks (all-`short.MinValue`, alternating extremes, silence, single frame, odd tails, random).
- New unit tests `CalculatePeak16BitStereo_MatchesOldTwoStepPipeline` + `CalculatePeak16BitStereo_ShortMinValueDoesNotOverflow`; the existing end-to-end `GeneratePeaks_16BitMonoAndStereo_MatchReferenceImplementation` reference test now exercises the fused path. All 29 peak-related tests pass.

## Tried and rejected

A last-key batch memo for `BuildWaveFormFancy`'s per-pixel dictionary lookups showed no measurable whole-frame win (Fancy rebuild frame 680 → 684 µs, Classic control also flat — both within noise), so it was reverted. The lean `WaveformGeometryRebuildBenchmarks` harness used to test it is kept for future build-loop work. The render path itself is already covered by the anchored geometry caches from earlier rounds, and the mono/8/24/32-bit generic delegate loop stays as-is (a mono fast path was previously benchmarked at 0.9× and dropped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)