### PR TITLE
Show the text of tag-heavy lines in the grid's "show formatting" mode

### DIFF
--- a/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
+++ b/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
@@ -19,6 +19,19 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
 {
     private ISpellCheckManager? _spellCheckManager;
 
+    /// <summary>Characters of a line's own text a grid cell ever shows - the rest is an ellipsis.</summary>
+    private const int MaxVisibleLength = 200;
+
+    /// <summary>
+    /// How much of a line is parsed at all in "show formatting" mode. Tags cost nothing on screen
+    /// but still have to be walked, so this only bounds the pathological case; a line of a few
+    /// hundred characters of override tags is ordinary in karaoke and effect files.
+    /// </summary>
+    private const int MaxRawLength = 5000;
+
+    /// <summary>Longest override-tag block whose contents are still parsed into formatting state.</summary>
+    private const int MaxParsedTagLength = 2000;
+
     // Pre-compiled <font> attribute patterns (reused across every grid-row render)
     private static readonly TimeSpan RegexTimeout = TimeSpan.FromMilliseconds(100);
     private static readonly Regex FontColorRegex = new(@"color\s*=\s*[""']?([^""'\s>]+)[""']?", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexTimeout);
@@ -116,17 +129,29 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
             return new InlineCollection();
         }
 
-        // Truncate long strings for performance
-        if (str.Length > 200)
-        {
-            str = str.Substring(0, 197).TrimEnd() + "...";
-        }
-
         var formattingType = Se.Settings.Appearance.SubtitleGridFormattingType;
+
+        // "Show formatting" hides the ASSA/HTML tags and renders what they mean, so the length that
+        // matters is the dialogue, not the markup around it. Truncating the raw string first threw
+        // away the text of exactly the lines this mode is for: a karaoke or effect line carrying a
+        // few hundred characters of {\t(...)} became 197 characters of tag and no words at all
+        // (issue #13824). Only pathological lines are cut here, and the visible text is capped
+        // inside MakeShowFormatting instead.
         if (formattingType == (int)SubtitleGridFormattingTypes.ShowFormatting)
         {
+            if (str.Length > MaxRawLength)
+            {
+                str = str.Substring(0, MaxRawLength);
+            }
+
             var lines = MakeShowFormatting(str);
             return SpellCheckLines(lines);
+        }
+
+        // Truncate long strings for performance
+        if (str.Length > MaxVisibleLength)
+        {
+            str = str.Substring(0, MaxVisibleLength - 3).TrimEnd() + "...";
         }
 
         if (formattingType == (int)SubtitleGridFormattingTypes.ShowTags)
@@ -632,6 +657,7 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
         // Track current formatting state
         var state = new FormattingState();
         var inlines = new InlineCollection();
+        var visibleLength = 0;
 
         // Limit iterations to prevent infinite loops (should never exceed string length)
         var maxIterations = str.Length * 2; // Safety margin
@@ -648,9 +674,17 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
             if (c == '{' && c2 == '\\')
             {
                 var tagEnd = str.IndexOf('}', i + 2);
-                if (tagEnd != -1 && tagEnd - i < 500) // Limit tag length to prevent malicious input
+                if (tagEnd != -1)
                 {
-                    ParseAssaTags(str, i + 1, tagEnd, state); // Content between { and }
+                    // A single block of override tags can be long - the animated karaoke lines in
+                    // issue #13824 run past 300 characters - so length decides how much of it is
+                    // interpreted, never whether it counts as a tag. Printing the braces as text
+                    // is the one outcome nobody wants from a mode whose job is hiding them.
+                    if (tagEnd - i < MaxParsedTagLength)
+                    {
+                        ParseAssaTags(str, i + 1, tagEnd, state); // Content between { and }
+                    }
+
                     i = tagEnd + 1;
                     continue;
                 }
@@ -803,9 +837,18 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
 
             if (textLength > 0)
             {
+                // The cap is on what is shown, not on what was read: hidden tags do not eat into
+                // the line's visible characters (issue #13824).
                 var text = str.Substring(textStart, textLength);
-                var run = CreateFormattedRun(text, state);
-                inlines.Add(run);
+                if (visibleLength + text.Length > MaxVisibleLength)
+                {
+                    var keep = Math.Max(0, MaxVisibleLength - visibleLength - 3);
+                    inlines.Add(CreateFormattedRun(text.Substring(0, keep).TrimEnd() + "...", state));
+                    break;
+                }
+
+                visibleLength += text.Length;
+                inlines.Add(CreateFormattedRun(text, state));
             }
         }
 

--- a/tests/UI/Logic/ValueConverters/ValueConverterTests.cs
+++ b/tests/UI/Logic/ValueConverters/ValueConverterTests.cs
@@ -555,4 +555,44 @@ public class ValueConverterTests
             Se.Language.General.ErrorX = previous;
         }
     }
+
+    // A karaoke/effect line carries a few hundred characters of override tags before its first
+    // word. The 200-character cut used to be applied to the raw string, so "show formatting" -
+    // the mode whose whole job is hiding tags - showed nothing but a truncated tag (issue #13824).
+    [Fact]
+    public void ShowFormatting_LongTagBlockBeforeTheText_StillShowsTheText()
+    {
+        var tag = "{\\an8\\fnCourier New\\b1\\bord5\\fs40\\t(\\fs28)\\shad0\\c&H1CFEFC&\\3c&H8B04E0&" +
+                  "\\t(2275,2276,\\alpha&HFF&)\\t(2850,2851,\\alpha&H00&)\\t(4280,4281,\\alpha&HFF&)" +
+                  "\\t(5144,5145,\\alpha&H00&)\\t(9481,9482,\\c&HE8FEDF&\\3c&HF171F4&)" +
+                  "\\t(9650,9651,\\c&H1CFEFC&\\3c&H8B04E0&)\\t(9900,9901,\\c&HE8FEDF&\\3c&HF171F4&)}";
+        Assert.True(tag.Length > 200, "the fixture must be longer than the old raw cut");
+
+        var inlines = Highlight(tag + "YOUNG LADIES DON'T PLAY", SubtitleGridFormattingTypes.ShowFormatting);
+
+        Assert.Equal("YOUNG LADIES DON'T PLAY", FlatText(inlines));
+    }
+
+    // Hiding the tags must not hide the braces' contents as text either, however long the block is.
+    [Fact]
+    public void ShowFormatting_VeryLongTagBlock_IsStillHidden()
+    {
+        var tag = "{\\t(" + new string('9', 3000) + ")}";
+
+        var inlines = Highlight(tag + "text", SubtitleGridFormattingTypes.ShowFormatting);
+
+        Assert.DoesNotContain("{", FlatText(inlines));
+    }
+
+    // The cap moved onto the visible text, so a genuinely long line still stops at an ellipsis.
+    [Fact]
+    public void ShowFormatting_LongDialogue_IsStillTruncated()
+    {
+        var text = new string('a', 500);
+
+        var flat = FlatText(Highlight(text, SubtitleGridFormattingTypes.ShowFormatting));
+
+        Assert.EndsWith("...", flat);
+        Assert.True(flat.Length <= 200, $"visible length was {flat.Length}");
+    }
 }


### PR DESCRIPTION
Follows from #13824.

The option that request asks for already exists — *Options → Settings → Appearance → "Show formatted (HTML/ASSA) text in subtitle grid" → **Show formatting*** — and it hides override tags while leaving them in the file. It just does not work on the lines the report is about, which is why it reads as missing.

### What happens

`Convert` cut the raw string at 197 characters before any tag was looked at:

```csharp
if (str.Length > 200)
{
    str = str.Substring(0, 197).TrimEnd() + "...";
}
```

The reported line is 321 characters, **283 of them a single `{\t(...)}` block** — so the closing `}` sits at index 282, inside the part that is thrown away. `MakeShowFormatting` then meets `{\`, searches for the brace, gets `tagEnd == -1`, and falls into:

```csharp
// Malformed or overly long tag - treat as regular text
```

so the markup is printed character by character. The mode whose whole job is hiding tags displays 197 characters of tag and none of the dialogue. Verified by running the new test against the current code:

```
Expected: "YOUNG LADIES DON'T PLAY"
Actual:   "{\an8\fnCourier New\b1\bord5\fs40\t(\fs28)\shad0\c"···
```

A second path reaches the same place: the `tagEnd - i < 500` cap sends any single tag block of 500+ characters down that same branch, which karaoke and effect lines exceed routinely.

### Change

- In *show formatting*, the cap applies to the **visible** text rather than the raw string, so hidden tags no longer consume a line's 200 characters. The raw string is bounded at 5000 purely against pathological input.
- The length of a tag block now decides **how much of it is parsed** into formatting state, never **whether it counts as a tag**. An over-long block is skipped like any other — printing braces as text is the one outcome a tag-hiding mode must not produce.
- The other two grid modes (*No formatting*, *Show tags*) keep the 200-character cut exactly as before.

### Testing

Three tests: the reported line renders as its dialogue; a 3000-character tag block is still hidden; a long line of plain dialogue still truncates with an ellipsis at 200 visible characters. `ValueConverterTests` 66 passed, full UI suite 3171 passed.

Point 2 of the issue — hiding lines that consist only of override tags — is not addressed here; that is a grid filter, not a rendering question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)