### PR TITLE
Make Shift+Delete cut in every text box, not only the main edit boxes

### DIFF
--- a/src/ui/Controls/SyntaxTextEditorControl/SyntaxTextView.cs
+++ b/src/ui/Controls/SyntaxTextEditorControl/SyntaxTextView.cs
@@ -1197,6 +1197,13 @@ public class SyntaxTextView : Control
                 isNavigation = false;
                 Backspace();
                 break;
+            // Shift+Delete is the classic Windows cut gesture. SE adds it to the native TextBox
+            // keymap at startup, but this editor does its own key handling, so mirror it here -
+            // Cut() already no-ops for a read-only view or an empty selection (#13711).
+            case Key.Delete when e.KeyModifiers == KeyModifiers.Shift:
+                isNavigation = false;
+                Cut();
+                break;
             case Key.Delete:
                 isNavigation = false;
                 DeleteForward();

--- a/src/ui/Logic/NativeKeymap.cs
+++ b/src/ui/Logic/NativeKeymap.cs
@@ -1,0 +1,33 @@
+using Avalonia;
+using Avalonia.Input;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>
+/// App-wide additions to Avalonia's platform keymap.
+/// </summary>
+public static class NativeKeymap
+{
+    /// <summary>
+    /// Registers Shift+Delete as a native cut gesture. Avalonia's keymap ships Ctrl+Insert copy
+    /// and Shift+Insert paste on every platform, but not the equally classic Shift+Delete cut, so
+    /// the gesture only worked in the two main-window edit boxes wired through the shortcut
+    /// manager - every other text box silently deleted the selection without copying it (#13711).
+    /// TextBox gates the keymap cut on CanCut, so read-only and password boxes stay untouched.
+    /// Idempotent - safe to call again (e.g. from tests sharing one application).
+    /// </summary>
+    public static void AddShiftDeleteCut()
+    {
+        var hotkeys = Application.Current?.PlatformSettings?.HotkeyConfiguration;
+        if (hotkeys == null)
+        {
+            return;
+        }
+
+        if (!hotkeys.Cut.Any(g => g.Key == Key.Delete && g.KeyModifiers == KeyModifiers.Shift))
+        {
+            hotkeys.Cut.Add(new KeyGesture(Key.Delete, KeyModifiers.Shift));
+        }
+    }
+}

--- a/src/ui/Program.cs
+++ b/src/ui/Program.cs
@@ -367,6 +367,9 @@ namespace Nikse.SubtitleEdit
                     ToolTip.SetIsOpen(control, false);
                 }
             });
+
+            // Shift+Delete cut in every text box, in every window (#13711).
+            NativeKeymap.AddShiftDeleteCut();
         }
 
         private static void SetupNativeMenu(Application app, ClassicDesktopStyleApplicationLifetime lifetime)

--- a/tests/UI/Logic/NativeKeymapShiftDeleteCutTests.cs
+++ b/tests/UI/Logic/NativeKeymapShiftDeleteCutTests.cs
@@ -1,0 +1,187 @@
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Threading;
+using Nikse.SubtitleEdit.Controls.SyntaxTextEditorControl;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// Shift+Delete must cut in EVERY text box, not only the two main-window edit boxes (#13711).
+/// The main-window boxes are covered by the shortcut manager, but Avalonia's native keymap ships
+/// Ctrl+Insert copy and Shift+Insert paste without the matching Shift+Delete cut, so any other
+/// text box (Find/Replace, dialogs, batch convert) silently deleted the selection instead of
+/// cutting it. <see cref="NativeKeymap.AddShiftDeleteCut"/> closes that gap app-wide, and the
+/// source editor - which does its own key handling - mirrors the gesture itself.
+/// </summary>
+public class NativeKeymapShiftDeleteCutTests : IDisposable
+{
+    // Every window opened by a test is closed again in Dispose, so a failing test cannot leak a
+    // window into the shared per-assembly headless session.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private Window Show(Control content)
+    {
+        var window = new Window { Content = content, Width = 600, Height = 400 };
+        _windows.Add(window);
+        window.Show();
+        Settle(window);
+        return window;
+    }
+
+    private static void Settle(Window window)
+    {
+        for (var pump = 0; pump < 5; pump++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+        }
+    }
+
+    /// <summary>
+    /// The cut writes the clipboard from an async continuation, so pump the dispatcher until the
+    /// expected state appears instead of asserting instantly (same pattern as the other headless
+    /// suites - an instant assert is a CI flake under load).
+    /// </summary>
+    private static async Task WaitUntil(Func<bool> condition, string failureMessage, int timeoutMs = 1000)
+    {
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        while (!condition())
+        {
+            if (stopwatch.ElapsedMilliseconds > timeoutMs)
+            {
+                Assert.Fail(failureMessage);
+            }
+
+            Dispatcher.UIThread.RunJobs();
+            await Task.Delay(10);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task ShiftDelete_Cuts_InAPlainWindowTextBox()
+    {
+        var textBox = new TextBox { Text = "Hello world" };
+        var window = Show(textBox);
+        NativeKeymap.AddShiftDeleteCut();
+
+        await ClipboardHelper.SetTextAsync(window, "clipboard before the cut");
+        textBox.Focus();
+        textBox.SelectionStart = 0;
+        textBox.SelectionEnd = "Hello ".Length;
+        Settle(window);
+
+        window.KeyPressQwerty(PhysicalKey.Delete, RawInputModifiers.Shift);
+
+        await WaitUntil(() => textBox.Text == "world",
+            $"expected the selection to be cut away, text is '{textBox.Text}'");
+        await WaitUntil(() => ClipboardHelper.GetTextAsync(window).GetAwaiter().GetResult() == "Hello ",
+            "the cut selection never reached the clipboard - Shift+Delete only deleted");
+    }
+
+    [AvaloniaFact]
+    public async Task Delete_WithoutShift_StillJustDeletes_InAPlainWindowTextBox()
+    {
+        var textBox = new TextBox { Text = "Hello world" };
+        var window = Show(textBox);
+        NativeKeymap.AddShiftDeleteCut();
+
+        await ClipboardHelper.SetTextAsync(window, "clipboard before the delete");
+        textBox.Focus();
+        textBox.SelectionStart = 0;
+        textBox.SelectionEnd = "Hello ".Length;
+        Settle(window);
+
+        window.KeyPressQwerty(PhysicalKey.Delete, RawInputModifiers.None);
+
+        await WaitUntil(() => textBox.Text == "world",
+            $"expected a plain delete of the selection, text is '{textBox.Text}'");
+        Assert.Equal("clipboard before the delete", await ClipboardHelper.GetTextAsync(window));
+    }
+
+    /// <summary>
+    /// The native keymap cut is gated on CanCut, so a read-only box must keep both its text and
+    /// the user's clipboard (the read-only original-subtitle box regression from #13711).
+    /// </summary>
+    [AvaloniaFact]
+    public async Task ShiftDelete_InAReadOnlyTextBox_TouchesNeitherTextNorClipboard()
+    {
+        var textBox = new TextBox { Text = "Hello world", IsReadOnly = true };
+        var window = Show(textBox);
+        NativeKeymap.AddShiftDeleteCut();
+
+        await ClipboardHelper.SetTextAsync(window, "precious clipboard");
+        textBox.Focus();
+        textBox.SelectionStart = 0;
+        textBox.SelectionEnd = "Hello ".Length;
+        Settle(window);
+
+        window.KeyPressQwerty(PhysicalKey.Delete, RawInputModifiers.Shift);
+        Settle(window);
+        await Task.Delay(50);
+        Settle(window);
+
+        Assert.Equal("Hello world", textBox.Text);
+        Assert.Equal("precious clipboard", await ClipboardHelper.GetTextAsync(window));
+    }
+
+    [AvaloniaFact]
+    public async Task ShiftDelete_Cuts_InTheSyntaxTextEditor()
+    {
+        var editor = new SyntaxTextEditor
+        {
+            Text = "Hello world",
+            FontFamily = new FontFamily("Courier New"),
+            FontSize = 12,
+        };
+        var window = Show(editor);
+
+        await ClipboardHelper.SetTextAsync(window, "clipboard before the cut");
+        editor.View.Focus();
+        editor.Select(0, "Hello ".Length);
+        Settle(window);
+
+        window.KeyPress(Key.Delete, RawInputModifiers.Shift, PhysicalKey.Delete, string.Empty);
+
+        await WaitUntil(() => editor.Text == "world",
+            $"expected the selection to be cut away, text is '{editor.Text}'");
+        await WaitUntil(() => ClipboardHelper.GetTextAsync(window).GetAwaiter().GetResult() == "Hello ",
+            "the cut selection never reached the clipboard - Shift+Delete only deleted");
+    }
+
+    [AvaloniaFact]
+    public async Task Delete_WithoutShift_StillJustDeletes_InTheSyntaxTextEditor()
+    {
+        var editor = new SyntaxTextEditor
+        {
+            Text = "Hello world",
+            FontFamily = new FontFamily("Courier New"),
+            FontSize = 12,
+        };
+        var window = Show(editor);
+
+        await ClipboardHelper.SetTextAsync(window, "clipboard before the delete");
+        editor.View.Focus();
+        editor.Select(0, "Hello ".Length);
+        Settle(window);
+
+        window.KeyPress(Key.Delete, RawInputModifiers.None, PhysicalKey.Delete, string.Empty);
+
+        await WaitUntil(() => editor.Text == "world",
+            $"expected a plain delete of the selection, text is '{editor.Text}'");
+        Assert.Equal("clipboard before the delete", await ClipboardHelper.GetTextAsync(window));
+    }
+}


### PR DESCRIPTION
Follow-up to #13711 (beta 17 re-report in [comment 5327666696](https://github.com/SubtitleEdit/subtitleedit/issues/13711#issuecomment-5327666696)): Shift+Delete still deleted without copying to the clipboard.

## Why the earlier fixes weren't enough

The previous fixes route Shift+Delete through the main window's shortcut manager, which only reaches the **two main-window edit boxes**. Everywhere else — Find/Replace, every dialog text box, batch convert, and the source editor (which does its own key handling) — Shift+Delete still fell through to Avalonia's plain `Key.Delete` handling: the selection was deleted, the clipboard untouched.

The tell: every gesture that *does* work for the reporter (Ctrl+X, Ctrl+Insert, Shift+Insert, Ctrl+Z) is in Avalonia's native keymap (verified in Avalonia 12.1.1 sources). Shift+Delete cut is the one classic gesture Avalonia omits, so it was the only one depending on SE's dispatch — and its coverage was spotty.

## Fix

1. **`NativeKeymap.AddShiftDeleteCut()`** (called at startup): appends `Shift+Delete` to `PlatformHotkeyConfiguration.Cut`, so every `TextBox` in every window cuts natively. `TextBox` gates the keymap cut on `CanCut`, so read-only and password boxes keep both their text and the user's clipboard. This also acts as a fallback in the main window if the shortcut dispatch ever misses (unhandled keys bubble to the focused text box).
2. **`SyntaxTextView`**: a `Key.Delete when KeyModifiers == Shift` case that calls `Cut()` (which already no-ops for read-only views and empty selections), placed before the plain forward-delete case. Ctrl+Delete word-delete is unchanged.

## Tests

`NativeKeymapShiftDeleteCutTests` (headless): cut + plain-delete + read-only-untouched for a plain non-main-window `TextBox`, and cut + plain-delete for the syntax editor. Existing `TextBoxShiftDeleteCutTests` and the syntax editor/source view suites still pass (59 tests run locally).

## Caveat for the reporter

If the Delete key being pressed is the **numpad** Del, Windows strips the Shift modifier for numpad keys in both NumLock states — the app never sees the chord, and no app-side fix can help. Worth asking in the thread if this doesn't resolve it (though Shift+Insert working suggests the main-cluster keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)