### PR TITLE
Update check: retry like downloads do and log failures

### DIFF
--- a/src/ui/Features/Help/CheckForUpdates/UpdateCheckService.cs
+++ b/src/ui/Features/Help/CheckForUpdates/UpdateCheckService.cs
@@ -24,9 +24,14 @@ public class UpdateCheckService : IUpdateCheckService
     public const string ChannelStable = "Stable";
     public const string ChannelBeta = "Beta";
 
-    private const string ChangeLogUrl1 = "https://raw.githubusercontent.com/SubtitleEdit/subtitleedit/refs/heads/main/change-log.txt";
-    private const string ChangeLogUrl2 = "https://raw.githubusercontent.com/SubtitleEdit/subtitleedit/refs/heads/main/Changelog.txt";
-    private const string ChangeLogUrl3 = "https://raw.githubusercontent.com/SubtitleEdit/subtitleedit/refs/heads/main/ChangeLog.txt";
+    private static readonly string[] ChangeLogUrls =
+    {
+        "https://raw.githubusercontent.com/SubtitleEdit/subtitleedit/refs/heads/main/change-log.txt",
+        // SE 4 changelog file names, kept as fallbacks for compatibility.
+        "https://raw.githubusercontent.com/SubtitleEdit/subtitleedit/refs/heads/main/Changelog.txt",
+        "https://raw.githubusercontent.com/SubtitleEdit/subtitleedit/refs/heads/main/ChangeLog.txt",
+    };
+
     private static readonly Regex UnreleasedChangeLogRegex = new(@"(x(th|st) \w+ \d+|TBD)", RegexOptions.Compiled);
 
     private readonly HttpClient _httpClient;
@@ -78,24 +83,12 @@ public class UpdateCheckService : IUpdateCheckService
         }
     }
 
+    /// <summary>Pause between retry rounds; tests set this to zero.</summary>
+    internal TimeSpan RetryDelay { get; set; } = TimeSpan.FromSeconds(2);
+
     public async Task<UpdateCheckResult> CheckForUpdates()
     {
-        string content;
-        try
-        {
-            content = await _httpClient.GetStringAsync(ChangeLogUrl1);
-        }
-        catch
-        {
-            try
-            {
-                content = await _httpClient.GetStringAsync(ChangeLogUrl2);
-            }
-            catch
-            {
-                content = await _httpClient.GetStringAsync(ChangeLogUrl3);
-            }
-        }
+        var content = await DownloadChangeLogAsync();
 
         var includePrereleases = IncludePrereleases();
         var changeLogText = ParseLatestChangeLog(content, includePrereleases);
@@ -109,6 +102,42 @@ public class UpdateCheckService : IUpdateCheckService
                                     IsNewerThanCurrent(latestVersion) &&
                                     (includePrereleases || !IsPrerelease(latestVersion)),
         };
+    }
+
+    /// <summary>
+    /// Downloads the changelog, retrying once more after a short pause. File downloads
+    /// (DownloadHelper) retry transient failures, which is what keeps them working behind
+    /// flaky corporate proxies - the update check gets the same second chance instead of
+    /// giving up on the first dropped connection. The definitive failure is logged so
+    /// proxy users find the actual exception in error-log.txt.
+    /// </summary>
+    private async Task<string> DownloadChangeLogAsync()
+    {
+        const int maxAttempts = 2;
+        Exception lastException = new HttpRequestException("Update check failed");
+
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            foreach (var url in ChangeLogUrls)
+            {
+                try
+                {
+                    return await _httpClient.GetStringAsync(url);
+                }
+                catch (Exception exception)
+                {
+                    lastException = exception;
+                }
+            }
+
+            if (attempt < maxAttempts)
+            {
+                await Task.Delay(RetryDelay);
+            }
+        }
+
+        Se.LogError(lastException, "Update check could not download the changelog");
+        throw lastException;
     }
 
     public static bool IsNewerThanCurrent(string latestVersion)

--- a/tests/UI/Features/Help/UpdateCheckServiceTests.cs
+++ b/tests/UI/Features/Help/UpdateCheckServiceTests.cs
@@ -1,10 +1,66 @@
 using Nikse.SubtitleEdit.Features.Help.CheckForUpdates;
+using System.Net;
+using System.Net.Http;
 
 namespace Tests.Features.Help;
 
 public class UpdateCheckServiceTests
 {
     private const string Separator = "-----------------------------------------------------------------------------------------------------";
+
+    /// <summary>Fails the first <c>failCount</c> requests, then serves the changelog.</summary>
+    private sealed class FlakyHandler : HttpMessageHandler
+    {
+        private readonly int _failCount;
+        private readonly string _content;
+
+        public int Requests { get; private set; }
+
+        public FlakyHandler(int failCount, string content)
+        {
+            _failCount = failCount;
+            _content = content;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests++;
+            if (Requests <= _failCount)
+            {
+                throw new HttpRequestException("proxy hiccup");
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(_content),
+            });
+        }
+    }
+
+    [Fact]
+    public async Task CheckForUpdates_TransientFailures_SucceedsOnSecondRound()
+    {
+        var changeLog = MakeChangeLog("v999.0.0 (1st of January 2030)\r\n\r\n* Future stuff");
+        var handler = new FlakyHandler(failCount: 3, changeLog); // first round (all three urls) fails
+        var service = new UpdateCheckService(new HttpClient(handler)) { RetryDelay = TimeSpan.Zero };
+
+        var result = await service.CheckForUpdates();
+
+        Assert.Equal(4, handler.Requests);
+        Assert.Equal("v999.0.0", result.LatestVersion);
+        Assert.True(result.IsNewVersionAvailable);
+    }
+
+    [Fact]
+    public async Task CheckForUpdates_AllAttemptsFail_ThrowsLastException()
+    {
+        var handler = new FlakyHandler(failCount: int.MaxValue, string.Empty);
+        var service = new UpdateCheckService(new HttpClient(handler)) { RetryDelay = TimeSpan.Zero };
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => service.CheckForUpdates());
+
+        Assert.Equal(6, handler.Requests); // three urls, two rounds
+    }
 
     private static string MakeChangeLog(params string[] blocks)
     {


### PR DESCRIPTION
A proxy user reports (by mail) that the update check fails in v5.2.0-beta15/17 while dictionary downloads work — even though both hit `raw.githubusercontent.com` through the same proxied typed `HttpClient` (verified: the update-check request tunnels correctly through a local CONNECT proxy using the real `HttpClientFactoryWithProxy` handler).

The behavioral difference between the two paths:

- **Dictionary downloads** go through `DownloadHelper`, which retries up to 5 times with backoff — that is what keeps them alive behind flaky corporate proxies.
- **The update check** tried each changelog url once, gave up on the first dropped connection, and swallowed the exception both in the startup check and in the Check for updates dialog — so there was nothing in error-log.txt to diagnose with.

Changes:

- `UpdateCheckService` retries the changelog urls in a second round after a short pause.
- The definitive failure is logged to error-log.txt, so the next proxy report can include the actual exception (407, timeout, blocked host, …).

Tests: two new tests cover the retry (succeeds on the second round after transient failures; throws after all six attempts). All 18 `UpdateCheckServiceTests` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)