### PR TITLE
llama.cpp translate: stall watchdog, token cap, custom server args, cancel frees VRAM

### DIFF
--- a/src/libuilogic/AutoTranslate/LlamaCppTranslate.cs
+++ b/src/libuilogic/AutoTranslate/LlamaCppTranslate.cs
@@ -70,7 +70,10 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             // No "model" field: llama-server serves the single model it was started with, and for a
             // remote server the user's own llama-server does the same. Sending one would only risk a
             // mismatch with whatever that server has loaded.
-            var input = "{ \"messages\": [{ \"role\": \"user\", \"content\": \"" + encodedUserMessage + "\" }]" + MakeSamplingJson() + "}";
+            // Generous output budget (a translation is roughly source-sized) so a model stuck in a
+            // generation loop runs out of tokens instead of generating until the context fills (#13830).
+            var maxTokens = 200 + 2 * text.Length;
+            var input = "{ \"messages\": [{ \"role\": \"user\", \"content\": \"" + encodedUserMessage + "\" }], \"max_tokens\": " + maxTokens + MakeSamplingJson() + "}";
             var content = new StringContent(input, Encoding.UTF8);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
             var result = await _httpClient.PostAsync(string.Empty, content, cancellationToken);

--- a/src/libuilogic/LlamaCpp/LlamaCppServerManager.cs
+++ b/src/libuilogic/LlamaCpp/LlamaCppServerManager.cs
@@ -302,6 +302,7 @@ public static class LlamaCppServerManager
     private static int _serverPort;
     private static string? _serverModelPath;
     private static int _serverContextSize;
+    private static string _serverExtraArguments = string.Empty;
     private static bool _processExitHooked;
     private static readonly StringBuilder _serverLog = new();
 
@@ -554,10 +555,11 @@ public static class LlamaCppServerManager
     /// </summary>
     public const int DefaultContextSize = 8192;
 
-    public static async Task EnsureServerRunningAsync(LlamaCppModel model, CancellationToken cancellationToken, int contextSize = DefaultContextSize)
+    public static async Task EnsureServerRunningAsync(LlamaCppModel model, CancellationToken cancellationToken, int contextSize = DefaultContextSize, string? extraArguments = null)
     {
+        var extraArgs = extraArguments?.Trim() ?? string.Empty;
         var modelPath = GetModelPath(model.FileName);
-        if (IsServerRunning && _serverModelPath == modelPath && _serverContextSize == contextSize)
+        if (IsServerRunning && _serverModelPath == modelPath && _serverContextSize == contextSize && _serverExtraArguments == extraArgs)
         {
             Configuration.Settings.Tools.LlamaCppApiUrl = ApiUrl;
             return;
@@ -566,7 +568,7 @@ public static class LlamaCppServerManager
         await ServerLock.WaitAsync(cancellationToken);
         try
         {
-            if (IsServerRunning && _serverModelPath == modelPath && _serverContextSize == contextSize)
+            if (IsServerRunning && _serverModelPath == modelPath && _serverContextSize == contextSize && _serverExtraArguments == extraArgs)
             {
                 Configuration.Settings.Tools.LlamaCppApiUrl = ApiUrl;
                 return;
@@ -653,6 +655,13 @@ public static class LlamaCppServerManager
                 psi.ArgumentList.Add(model.ChatTemplate);
             }
 
+            // User-supplied llama-server arguments last, so a repeated flag (e.g. -ngl, -c)
+            // overrides SE's value - llama-server applies later arguments over earlier ones.
+            foreach (var arg in SplitCommandLineArguments(extraArgs))
+            {
+                psi.ArgumentList.Add(arg);
+            }
+
             var process = Process.Start(psi)
                 ?? throw new InvalidOperationException("Failed to start llama-server");
 
@@ -684,6 +693,7 @@ public static class LlamaCppServerManager
             _serverPort = port;
             _serverModelPath = modelPath;
             _serverContextSize = contextSize;
+            _serverExtraArguments = extraArgs;
             HookProcessExitOnce();
 
             var deadline = DateTime.UtcNow.AddMinutes(5);
@@ -784,6 +794,59 @@ public static class LlamaCppServerManager
         {
             return false;
         }
+    }
+
+    /// <summary>
+    /// Splits a user-entered argument string on whitespace, honoring single/double quotes so
+    /// values with spaces survive (e.g. <c>--override-kv "key=str:some value"</c>).
+    /// </summary>
+    internal static List<string> SplitCommandLineArguments(string arguments)
+    {
+        var result = new List<string>();
+        if (string.IsNullOrWhiteSpace(arguments))
+        {
+            return result;
+        }
+
+        var current = new StringBuilder();
+        var quote = '\0';
+        foreach (var ch in arguments)
+        {
+            if (quote != '\0')
+            {
+                if (ch == quote)
+                {
+                    quote = '\0';
+                }
+                else
+                {
+                    current.Append(ch);
+                }
+            }
+            else if (ch == '"' || ch == '\'')
+            {
+                quote = ch;
+            }
+            else if (char.IsWhiteSpace(ch))
+            {
+                if (current.Length > 0)
+                {
+                    result.Add(current.ToString());
+                    current.Clear();
+                }
+            }
+            else
+            {
+                current.Append(ch);
+            }
+        }
+
+        if (current.Length > 0)
+        {
+            result.Add(current.ToString());
+        }
+
+        return result;
     }
 
     private static int FindFreeLoopbackPort()

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -1404,7 +1404,10 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         // Auto-start the local server - this points Configuration.Settings.Tools.LlamaCppApiUrl at it.
         try
         {
-            await LlamaCppServerManager.EnsureServerRunningAsync(model, _cancellationToken, contextSize);
+            var extraArguments = config.AutoTranslate.Translator is LlamaCppAdvancedTranslate
+                ? Se.Settings.AutoTranslate.LlamaCppAdvanced.ServerArguments
+                : null;
+            await LlamaCppServerManager.EnsureServerRunningAsync(model, _cancellationToken, contextSize, extraArguments);
         }
         catch (Exception ex)
         {

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -105,6 +105,7 @@ public partial class AutoTranslateViewModel : ObservableObject
     [ObservableProperty] private bool _llamaCppRemoteToggleIsVisible;
     [ObservableProperty] private bool _llamaCppUseRemoteServer;
     [ObservableProperty] private string _llamaCppServerButtonText = Se.Language.General.StartServer;
+    [ObservableProperty] private string? _llamaCppServerUrlInfo;
     [ObservableProperty] private string _llamaCppDownloadButtonText = string.Empty;
     [ObservableProperty] private string _crispAsrDownloadButtonText = string.Empty;
 
@@ -745,7 +746,31 @@ public partial class AutoTranslateViewModel : ObservableObject
         if (wasTranslating)
         {
             StatusText = Se.Language.Translate.TranslationCancelled;
+            StopLocalLlamaCppServerAfterCancel();
         }
+    }
+
+    /// <summary>
+    /// Cancelling a local llama.cpp translation also stops the SE-managed server, so the model's
+    /// RAM/VRAM is released right away instead of after the app closes (#13830). Only mid-run: a
+    /// server left idle by a completed translation stays warm (Stop server button / app exit).
+    /// The next translate run auto-restarts it.
+    /// </summary>
+    private void StopLocalLlamaCppServerAfterCancel()
+    {
+        if (SelectedAutoTranslator is not (LlamaCppTranslate or LlamaCppAdvancedTranslate) ||
+            LlamaCppUseRemoteServer ||
+            !LlamaCppServerManager.IsServerRunning)
+        {
+            return;
+        }
+
+        // Off the UI thread - StopServer kills the process and waits up to 2 s for it to exit.
+        _ = Task.Run(() =>
+        {
+            LlamaCppServerManager.StopServer();
+            Dispatcher.UIThread.Post(UpdateLlamaCppServerButtonText);
+        });
     }
 
     [RelayCommand]
@@ -961,6 +986,12 @@ public partial class AutoTranslateViewModel : ObservableObject
     private void UpdateLlamaCppServerButtonText()
     {
         LlamaCppServerButtonText = LlamaCppServerManager.IsServerRunning ? Se.Language.General.StopServer : Se.Language.General.StartServer;
+
+        // The SE-managed server runs on a random free port, not the URL from remote-server mode -
+        // surface the live endpoint so the two are not mistaken for each other (#13830).
+        LlamaCppServerUrlInfo = LlamaCppServerManager.IsServerRunning
+            ? string.Format(Se.Language.Translate.ServerRunningAtX, LlamaCppServerManager.ApiUrl)
+            : null;
     }
 
     [RelayCommand]
@@ -1126,10 +1157,12 @@ public partial class AutoTranslateViewModel : ObservableObject
         {
             // The advanced engine stuffs history/synopsis/glossary into every request, so it gets
             // a user-configurable (default larger) server context; everything else keeps the default.
-            var contextSize = SelectedAutoTranslator is LlamaCppAdvancedTranslate
+            var isAdvanced = SelectedAutoTranslator is LlamaCppAdvancedTranslate;
+            var contextSize = isAdvanced
                 ? Math.Clamp(Se.Settings.AutoTranslate.LlamaCppAdvanced.ContextSize, 2048, 262144)
                 : LlamaCppServerManager.DefaultContextSize;
-            await LlamaCppServerManager.EnsureServerRunningAsync(model, _cancellationTokenSource.Token, contextSize);
+            var extraArguments = isAdvanced ? Se.Settings.AutoTranslate.LlamaCppAdvanced.ServerArguments : null;
+            await LlamaCppServerManager.EnsureServerRunningAsync(model, _cancellationTokenSource.Token, contextSize, extraArguments);
         }
         catch (Exception ex)
         {
@@ -2453,8 +2486,13 @@ public partial class AutoTranslateViewModel : ObservableObject
     {
         // The OS close button bypasses the Cancel command - stop a running translation
         // loop so it does not keep calling the translation API against a closed window.
+        var wasTranslating = !IsTranslateEnabled;
         _abort = true;
         _cancellationTokenSource.Cancel();
+        if (wasTranslating)
+        {
+            StopLocalLlamaCppServerAfterCancel();
+        }
     }
 
     internal void OnLoaded()

--- a/src/ui/Features/Translate/AutoTranslateWindow.cs
+++ b/src/ui/Features/Translate/AutoTranslateWindow.cs
@@ -235,6 +235,11 @@ public class AutoTranslateWindow : Window
         var buttonLlamaCppServer = UiUtil.MakeButton(string.Empty, vm.ToggleLlamaCppServerCommand).WithMarginLeft(5);
         buttonLlamaCppServer.Bind(Button.ContentProperty, new Binding(nameof(vm.LlamaCppServerButtonText)));
         buttonLlamaCppServer.Bind(Button.IsVisibleProperty, new Binding(nameof(vm.LlamaCppButtonsAreVisible)));
+        if (Se.Settings.Appearance.ShowHints)
+        {
+            // The local server's live endpoint (random port) - see LlamaCppServerUrlInfo.
+            buttonLlamaCppServer.Bind(ToolTip.TipProperty, new Binding(nameof(vm.LlamaCppServerUrlInfo)));
+        }
 
         var buttonLlamaCppOpenFolder = UiUtil.MakeButton(vm.OpenLlamaCppModelsFolderCommand, IconNames.FolderOpen, Se.Language.General.OpenContainingFolder)
             .WithMarginLeft(5);

--- a/src/ui/Features/Translate/LlamaCppAdvanced/AdvancedTranslatorBase.cs
+++ b/src/ui/Features/Translate/LlamaCppAdvanced/AdvancedTranslatorBase.cs
@@ -123,12 +123,23 @@ public abstract class AdvancedTranslatorBase : IAutoTranslator, IBatchContextTra
         var userContent = LlamaCppAdvancedProtocol.BuildUserContent(history, lines);
         var responseFormat = LlamaCppAdvancedProtocol.BuildResponseFormatJson(lines);
 
+        // Generous output budget for the batch (a translation is roughly source-sized; the JSON
+        // wrapper adds a little per line). Only a fallback: the user's MaxTokens setting wins in
+        // the client. Without any cap a grammar-cornered model generates until the server context
+        // fills (#13830) - with it, the runaway becomes an incomplete reply that the normal
+        // retry/bisection path handles.
+        var defaultMaxTokens = 200;
+        foreach (var line in lines)
+        {
+            defaultMaxTokens += 32 + 2 * line.Text.Length;
+        }
+
         var map = new Dictionary<int, string>();
         for (var attempt = 0; attempt < 2 && !cancellationToken.IsCancellationRequested; attempt++)
         {
             try
             {
-                var reply = await client.ChatAsync(url, systemPrompt, userContent, responseFormat, cancellationToken, GetModel());
+                var reply = await client.ChatAsync(url, systemPrompt, userContent, responseFormat, cancellationToken, GetModel(), defaultMaxTokens);
                 map = LlamaCppAdvancedProtocol.ParseTranslations(reply);
                 if (IsComplete(map, lines))
                 {

--- a/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedClient.cs
+++ b/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedClient.cs
@@ -17,10 +17,22 @@ namespace Nikse.SubtitleEdit.Features.Translate.LlamaCppAdvanced;
 /// reject it (older llama.cpp, Ollama, other OpenAI-compatible endpoints) get a json_object and
 /// finally a plain retry. cache_prompt is set explicitly so llama-server reuses the KV cache for
 /// the stable prompt prefix across batches.
+///
+/// Requests are streamed (SSE) rather than buffered: a grammar-cornered model that generates
+/// forever now trips the inter-token watchdog instead of sitting silent until the HTTP timeout,
+/// and cancelling mid-generation closes the connection, which makes llama-server abort the slot
+/// instead of finishing a reply nobody reads (#13830).
 /// </summary>
 public class LlamaCppAdvancedClient : IDisposable
 {
     private readonly HttpClient _httpClient;
+
+    // Watchdog knobs (internal so tests can shrink them). FirstData covers prompt processing,
+    // which streams nothing - a large context on slow hardware can legitimately take minutes
+    // before the first token. Idle applies between chunks once generation has started.
+    internal static TimeSpan FirstDataTimeout = TimeSpan.FromMinutes(5);
+    internal static TimeSpan IdleTimeout = TimeSpan.FromMinutes(2);
+    internal static TimeSpan TotalTimeout = TimeSpan.FromMinutes(15);
 
     public string Error { get; private set; } = string.Empty;
 
@@ -30,19 +42,22 @@ public class LlamaCppAdvancedClient : IDisposable
         _httpClient.Timeout = TimeSpan.FromMinutes(15);
     }
 
-    public async Task<string> ChatAsync(string url, string systemPrompt, string userContent, string? responseFormatJson, CancellationToken cancellationToken, string? model = null)
+    public async Task<string> ChatAsync(string url, string systemPrompt, string userContent, string? responseFormatJson, CancellationToken cancellationToken, string? model = null, int defaultMaxTokens = -1)
     {
         Error = string.Empty;
 
-        var response = await PostAsync(url, BuildRequestJson(systemPrompt, userContent, responseFormatJson, model), cancellationToken);
-        if (!response.ok && responseFormatJson != null && !cancellationToken.IsCancellationRequested)
+        var response = await PostAsync(url, BuildRequestJson(systemPrompt, userContent, responseFormatJson, model, defaultMaxTokens), cancellationToken);
+
+        // A stall is not a format rejection - retrying the same prompt with a looser format
+        // would just burn another watchdog period, so only the format fallbacks run here.
+        if (!response.ok && !response.stalled && responseFormatJson != null && !cancellationToken.IsCancellationRequested)
         {
-            response = await PostAsync(url, BuildRequestJson(systemPrompt, userContent, "{\"type\":\"json_object\"}", model), cancellationToken);
+            response = await PostAsync(url, BuildRequestJson(systemPrompt, userContent, "{\"type\":\"json_object\"}", model, defaultMaxTokens), cancellationToken);
         }
 
-        if (!response.ok && responseFormatJson != null && !cancellationToken.IsCancellationRequested)
+        if (!response.ok && !response.stalled && responseFormatJson != null && !cancellationToken.IsCancellationRequested)
         {
-            response = await PostAsync(url, BuildRequestJson(systemPrompt, userContent, null, model), cancellationToken);
+            response = await PostAsync(url, BuildRequestJson(systemPrompt, userContent, null, model, defaultMaxTokens), cancellationToken);
         }
 
         if (!response.ok)
@@ -52,7 +67,9 @@ public class LlamaCppAdvancedClient : IDisposable
             throw new HttpRequestException(ShortError(response.body));
         }
 
-        return ExtractContent(response.body);
+        // Streamed replies arrive already assembled from the deltas; a server that ignored
+        // "stream" returns a regular completion object instead.
+        return response.isAssembledContent ? response.body : ExtractContent(response.body);
     }
 
     /// <summary>
@@ -60,7 +77,7 @@ public class LlamaCppAdvancedClient : IDisposable
     /// llama-server serves the single model it was started with, and sending one would only
     /// risk a mismatch). cache_prompt is llama.cpp-specific; other servers ignore it.
     /// </summary>
-    private static string BuildRequestJson(string systemPrompt, string userContent, string? responseFormatJson, string? model)
+    private static string BuildRequestJson(string systemPrompt, string userContent, string? responseFormatJson, string? model, int defaultMaxTokens)
     {
         using var stream = new System.IO.MemoryStream();
         using (var writer = new Utf8JsonWriter(stream))
@@ -71,10 +88,10 @@ public class LlamaCppAdvancedClient : IDisposable
                 writer.WriteString("model", model);
             }
 
-            writer.WriteBoolean("stream", false);
+            writer.WriteBoolean("stream", true);
             writer.WriteBoolean("cache_prompt", true);
 
-            WriteSampling(writer);
+            WriteSampling(writer, defaultMaxTokens);
 
             if (responseFormatJson != null)
             {
@@ -104,9 +121,11 @@ public class LlamaCppAdvancedClient : IDisposable
     /// (persisted as Tools.LlamaCppModel* when the engine was selected), then server defaults -
     /// except temperature, which bottoms out at 0.2: the server default (0.8) drifts terminology
     /// across batches ("the Chief" became three different Danish words in testing), while 0.0-0.2
-    /// stayed consistent with no downside.
+    /// stayed consistent with no downside. max_tokens falls back to the caller's batch-derived
+    /// cap so a looping model runs out of tokens (a retryable failed batch) instead of
+    /// generating until the context fills (#13830).
     /// </summary>
-    private static void WriteSampling(Utf8JsonWriter writer)
+    private static void WriteSampling(Utf8JsonWriter writer, int defaultMaxTokens)
     {
         var advanced = Se.Settings.AutoTranslate.LlamaCppAdvanced;
         var tools = Configuration.Settings.Tools;
@@ -118,7 +137,12 @@ public class LlamaCppAdvancedClient : IDisposable
         WriteNumberIfSet(writer, "top_p", advanced.TopP >= 0 ? advanced.TopP : tools.LlamaCppModelTopP);
         WriteNumberIfSet(writer, "top_k", advanced.TopK >= 0 ? advanced.TopK : tools.LlamaCppModelTopK);
         WriteNumberIfSet(writer, "repeat_penalty", advanced.RepeatPenalty >= 0 ? advanced.RepeatPenalty : tools.LlamaCppModelRepeatPenalty);
-        WriteNumberIfSet(writer, "max_tokens", advanced.MaxTokens > 0 ? advanced.MaxTokens : -1);
+
+        var maxTokens = advanced.MaxTokens > 0 ? advanced.MaxTokens : defaultMaxTokens;
+        if (maxTokens > 0)
+        {
+            writer.WriteNumber("max_tokens", maxTokens);
+        }
     }
 
     private static void WriteNumberIfSet(Utf8JsonWriter writer, string name, double value)
@@ -129,20 +153,122 @@ public class LlamaCppAdvancedClient : IDisposable
         }
     }
 
-    private async Task<(bool ok, string body)> PostAsync(string url, string json, CancellationToken cancellationToken)
+    /// <summary>
+    /// Sends one streamed chat-completions request and assembles the SSE deltas.
+    /// <c>stalled</c> is set when a watchdog aborted the request (no data within the timeout,
+    /// or the total cap was hit) - as opposed to the server rejecting it, which is retryable
+    /// with a different response format. A user cancellation propagates as
+    /// <see cref="OperationCanceledException"/> instead.
+    /// </summary>
+    private async Task<(bool ok, bool stalled, bool isAssembledContent, string body)> PostAsync(string url, string json, CancellationToken cancellationToken)
     {
-        var content = new StringContent(json, Encoding.UTF8);
-        content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+        using var overall = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        overall.CancelAfter(TotalTimeout);
         try
         {
+            // The first-data watchdog also covers the wait for response headers - a wedged server
+            // that accepts the connection but never answers should not get the full total timeout.
+            // Re-armed on every received line; disposing the reader/stream on abort closes the
+            // connection, which is what makes llama-server stop generating.
+            using var idle = CancellationTokenSource.CreateLinkedTokenSource(overall.Token);
+            idle.CancelAfter(FirstDataTimeout);
+
+            var content = new StringContent(json, Encoding.UTF8);
+            content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
             using var request = new HttpRequestMessage(HttpMethod.Post, url) { Content = content };
-            var result = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
-            var body = await result.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-            return (result.IsSuccessStatusCode, body);
+            using var result = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, idle.Token).ConfigureAwait(false);
+            if (!result.IsSuccessStatusCode)
+            {
+                var errorBody = await result.Content.ReadAsStringAsync(idle.Token).ConfigureAwait(false);
+                return (false, false, false, errorBody);
+            }
+
+            await using var stream = await result.Content.ReadAsStreamAsync(idle.Token).ConfigureAwait(false);
+            using var reader = new System.IO.StreamReader(stream, Encoding.UTF8);
+
+            var assembled = new StringBuilder();
+            var raw = new StringBuilder();
+            var sawSseData = false;
+
+            while (true)
+            {
+                var line = await reader.ReadLineAsync(idle.Token).ConfigureAwait(false);
+                if (line == null)
+                {
+                    break;
+                }
+
+                idle.CancelAfter(IdleTimeout);
+                if (!line.StartsWith("data:", StringComparison.Ordinal))
+                {
+                    // Not SSE (a proxy or server that ignored "stream") - keep the raw body so it
+                    // can be parsed as a regular completion object below.
+                    raw.AppendLine(line);
+                    continue;
+                }
+
+                var payload = line.Substring(5).Trim();
+                if (payload == "[DONE]")
+                {
+                    break;
+                }
+
+                sawSseData = true;
+                if (!TryAppendDelta(payload, assembled, out var chunkError))
+                {
+                    return (false, false, false, chunkError);
+                }
+            }
+
+            return sawSseData
+                ? (true, false, true, assembled.ToString())
+                : (true, false, false, raw.ToString());
         }
-        catch (Exception e) when (e is not OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            return (false, e.Message);
+            throw;
+        }
+        catch (OperationCanceledException)
+        {
+            return (false, true, false,
+                "The server stopped sending data (generation looks stalled) and the request was aborted - " +
+                "the model may not fit in GPU memory, or it may be stuck in a generation loop.");
+        }
+        catch (Exception e)
+        {
+            return (false, false, false, e.Message);
+        }
+    }
+
+    /// <summary>Appends one SSE chunk's delta content; returns false on an in-stream error object.</summary>
+    private static bool TryAppendDelta(string payload, StringBuilder assembled, out string error)
+    {
+        error = string.Empty;
+        try
+        {
+            using var doc = JsonDocument.Parse(payload);
+            if (doc.RootElement.TryGetProperty("error", out var errorElement))
+            {
+                error = errorElement.ToString();
+                return false;
+            }
+
+            if (doc.RootElement.TryGetProperty("choices", out var choices) &&
+                choices.ValueKind == JsonValueKind.Array &&
+                choices.GetArrayLength() > 0 &&
+                choices[0].TryGetProperty("delta", out var delta) &&
+                delta.TryGetProperty("content", out var contentElement) &&
+                contentElement.ValueKind == JsonValueKind.String)
+            {
+                assembled.Append(contentElement.GetString());
+            }
+
+            return true;
+        }
+        catch (JsonException)
+        {
+            // Tolerate malformed keep-alive/comment chunks.
+            return true;
         }
     }
 

--- a/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedSettingsViewModel.cs
+++ b/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedSettingsViewModel.cs
@@ -29,6 +29,7 @@ public partial class LlamaCppAdvancedSettingsViewModel : ObservableObject
     [ObservableProperty] private double? _repeatPenalty;
     [ObservableProperty] private int _maxTokens;
     [ObservableProperty] private int _contextSize;
+    [ObservableProperty] private string _serverArguments = string.Empty;
 
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }
@@ -57,6 +58,7 @@ public partial class LlamaCppAdvancedSettingsViewModel : ObservableObject
         RepeatPenalty = settings.RepeatPenalty;
         MaxTokens = settings.MaxTokens;
         ContextSize = settings.ContextSize;
+        ServerArguments = settings.ServerArguments;
     }
 
     [RelayCommand]
@@ -76,6 +78,7 @@ public partial class LlamaCppAdvancedSettingsViewModel : ObservableObject
         settings.RepeatPenalty = RepeatPenalty ?? -1;
         settings.MaxTokens = MaxTokens;
         settings.ContextSize = Math.Clamp(ContextSize, 2048, 262144);
+        settings.ServerArguments = ServerArguments?.Trim() ?? string.Empty;
         Se.SaveSettings();
 
         OkPressed = true;

--- a/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedSettingsWindow.cs
+++ b/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedSettingsWindow.cs
@@ -146,7 +146,7 @@ public class LlamaCppAdvancedSettingsWindow : Window
             ColumnSpacing = 12,
             RowSpacing = 10,
         };
-        for (var i = 0; i < 5; i++)
+        for (var i = 0; i < 6; i++)
         {
             grid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) });
         }
@@ -180,6 +180,15 @@ public class LlamaCppAdvancedSettingsWindow : Window
         grid.Add(MakeSmallLabel(Se.Language.Translate.ServerContextSizeTokens), 4, 0);
         grid.Add(contextSize, 4, 1);
         Grid.SetColumnSpan(contextSize, 3);
+
+        // Free-form llama-server arguments for the SE-managed local server (#13830) - lets users
+        // tune flags SE does not curate (e.g. partial GPU offload on a too-small card).
+        var serverArguments = UiUtil.MakeTextBox(280, vm, nameof(vm.ServerArguments))
+            .WithAccessibleName(Se.Language.Translate.ExtraServerParameters);
+        SetHint(serverArguments, Se.Language.Translate.ExtraServerParametersHint);
+        grid.Add(MakeSmallLabel(Se.Language.Translate.ExtraServerParameters), 5, 0);
+        grid.Add(serverArguments, 5, 1);
+        Grid.SetColumnSpan(serverArguments, 3);
 
         return grid;
     }

--- a/src/ui/Logic/Config/Language/Translate/LanguageTranslate.cs
+++ b/src/ui/Logic/Config/Language/Translate/LanguageTranslate.cs
@@ -49,6 +49,9 @@ public class LanguageTranslate
     public string RepeatPenalty { get; set; }
     public string MaxTokensPerReply { get; set; }
     public string ServerContextSizeTokens { get; set; }
+    public string ExtraServerParameters { get; set; }
+    public string ExtraServerParametersHint { get; set; }
+    public string ServerRunningAtX { get; set; }
     public string CustomPromptHint { get; set; }
     public string LlamaCppDownloadEngineAndModelPrompt { get; set; }
     public string LlamaCppDownloadEnginePrompt { get; set; }
@@ -103,6 +106,9 @@ public class LanguageTranslate
         RepeatPenalty = "Repeat penalty";
         MaxTokensPerReply = "Max tokens per reply";
         ServerContextSizeTokens = "Server context size (tokens)";
+        ExtraServerParameters = "Extra server parameters";
+        ExtraServerParametersHint = "Additional llama-server command-line arguments, e.g. \"-ngl 30 --no-mmap\" - applied when the local server starts";
+        ServerRunningAtX = "Server running at {0}";
         CustomPromptHint = "Custom instructions ({0} = source language, {1} = target language); empty = built-in prompt";
         LlamaCppDownloadEngineAndModelPrompt = "llama.cpp requires the llama-server engine and a translation model to be downloaded. Download now?";
         LlamaCppDownloadEnginePrompt = "llama.cpp requires the llama-server engine to be downloaded. Download now?";

--- a/src/ui/Logic/Config/SeLlamaCppAdvanced.cs
+++ b/src/ui/Logic/Config/SeLlamaCppAdvanced.cs
@@ -21,6 +21,10 @@ public class SeLlamaCppAdvanced
     public int MaxTokens { get; set; } = -1;
     public int ContextSize { get; set; } = 16384;
 
+    // Extra llama-server command-line arguments, appended after SE's own so a repeated flag
+    // (e.g. -ngl) overrides SE's value. Local server mode only (#13830).
+    public string ServerArguments { get; set; } = string.Empty;
+
     public const string FormalityDefault = "Default";
     public const string FormalityFormal = "Formal";
     public const string FormalityInformal = "Informal";


### PR DESCRIPTION
Addresses all three reports in #13830.

### Issue 1 - batch translation stalls at a random percentage

The attached logs show every failure as a user-cancelled HTTP request that never returned: nothing bounded a runaway generation (no `max_tokens` by default, 15-minute HTTP timeout, and up to 3 sequential format-fallback attempts = up to ~45 minutes of apparent freeze per bad batch).

- **Streaming + stall watchdog**: the advanced client now streams the reply (SSE). No first token within 5 minutes, or no data for 2 minutes between chunks, aborts the request with a clear error ("generation looks stalled... model may not fit in GPU memory or be stuck in a loop"). A stall skips the json_object/plain fallbacks - re-running the same doomed prompt with a looser format would just burn another watchdog period.
- **Default `max_tokens` cap** derived from the batch's source text (advanced *and* regular engine), so a grammar-cornered model runs out of tokens - an incomplete reply the existing retry/bisection path recovers from - instead of generating until the context fills. A user-set max tokens value still wins.

### Feature request - custom llama-server parameters

New **Extra server parameters** field in the advanced settings dialog. Passed through to the SE-managed llama-server launch, quote-aware, appended last so a repeated flag (e.g. `-ngl 30` for partial offload on a too-small GPU) overrides SE's value. Changing the value restarts the server; an unchanged value keeps reusing it. Also applied when batch convert uses the advanced engine.

### Issue 2 - port mismatch between settings and tools-log

Working as designed (the managed server always picks a random free port; the URL field only applies in remote-server mode), but now the Start/Stop server button shows the live endpoint as a tooltip so the two can't be mistaken for each other.

### Issue 3 - llama-server keeps running after cancel

Two layers:
- Streaming means cancelling closes the connection mid-generation, and llama-server aborts the slot immediately (verified live - the very next request is served promptly instead of queueing behind an orphaned generation).
- Cancelling a running local llama.cpp translation now also stops the SE-managed server, releasing the model's RAM/VRAM right away; the next run auto-restarts it. A warm server left idle by a *completed* translation is untouched (Stop server button / app exit still apply).

### Testing

Console harness (fake SSE server + real llama-server with Qwen 3.5 4B on Metal), 26 checks, all passing:
- SSE deltas assembled correctly; `stream:true` + default/overridden `max_tokens` in the request JSON
- mid-generation stall aborted by the idle watchdog in seconds; silent server (no headers/no data) aborted by the first-data watchdog; no format fallbacks after a stall
- user cancel propagates fast as `OperationCanceledException`
- json_schema rejection still falls back to json_object; non-SSE servers (proxy ignoring `stream`) still parsed; in-stream error objects surfaced
- argument splitter (quotes, spacing); extra args in the real launch command, same-args reuse vs changed-args restart
- live EN→DA 3-line batch translated via stream; cancel mid-generation frees the slot (next request served immediately); `StopServer` kills the process

Fixes #13830

🤖 Generated with [Claude Code](https://claude.com/claude-code)