### PR TITLE
Add shortcut for pasting clipboard text to a new waveform selection

### DIFF
--- a/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
@@ -199,6 +199,7 @@ public class LanguageSettingsShortcuts
     public string ChooseSubtitleFormat { get; set; }
     public string TrimWhitespaceSelectedLines { get; set; }
     public string WaveformInsertNewSelection { get; set; }
+    public string WaveformNewSelectionPasteFromClipboard { get; set; }
     public string WaveformHorizontalZoomInCommand { get; set; }
     public string WaveformHorizontalZoomOutCommand { get; set; }
     public string WaveformVerticalZoomInCommand { get; set; }
@@ -458,6 +459,7 @@ public class LanguageSettingsShortcuts
         ChooseSubtitleFormat = "Choose subtitle format";
         TrimWhitespaceSelectedLines = "Trim whitespace (selected lines)";
         WaveformInsertNewSelection = "Waveform insert new selection";
+        WaveformNewSelectionPasteFromClipboard = "Waveform paste clipboard text to new selection";
         WaveformHorizontalZoomInCommand = "Waveform horizontal zoom in";
         WaveformHorizontalZoomOutCommand = "Waveform horizontal zoom out";
         WaveformVerticalZoomInCommand = "Waveform vertical zoom in";

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -423,6 +423,7 @@ public static class ShortcutsMain
         { nameof(MainViewModel.InsertLineBeforeCommand), Se.Language.General.InsertBefore },
         { nameof(MainViewModel.InsertLineAfterCommand), Se.Language.General.InsertAfter },
         { nameof(MainViewModel.WaveformInsertNewSelectionCommand), Se.Language.Options.Shortcuts.WaveformInsertNewSelection },
+        { nameof(MainViewModel.WaveformNewSelectionPasteFromClipboardCommand), Se.Language.Options.Shortcuts.WaveformNewSelectionPasteFromClipboard },
         { nameof(MainViewModel.WaveformInsertAtPositionAndFocusTextBoxCommand), Se.Language.General.InsertAtPositionAndFocusTextBox },
         { nameof(MainViewModel.WaveformInsertAtPositionNoFocusTextBoxCommand), Se.Language.General.InsertAtPositionNoFocusTextBox },
         { nameof(MainViewModel.WaveformPasteFromClipboardCommand), Se.Language.General.WaveformPasteFromClipboard },
@@ -833,6 +834,7 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.InsertLineBeforeCommand, nameof(vm.InsertLineBeforeCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.InsertLineAfterCommand, nameof(vm.InsertLineAfterCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.WaveformInsertNewSelectionCommand, nameof(vm.WaveformInsertNewSelectionCommand), ShortcutCategory.Waveform);
+        AddShortcut(shortcuts, vm.WaveformNewSelectionPasteFromClipboardCommand, nameof(vm.WaveformNewSelectionPasteFromClipboardCommand), ShortcutCategory.Waveform);
         AddShortcut(shortcuts, vm.WaveformInsertAtPositionAndFocusTextBoxCommand, nameof(vm.WaveformInsertAtPositionAndFocusTextBoxCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.WaveformInsertAtPositionNoFocusTextBoxCommand, nameof(vm.WaveformInsertAtPositionNoFocusTextBoxCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.WaveformPasteFromClipboardCommand, nameof(vm.WaveformPasteFromClipboardCommand), ShortcutCategory.Waveform);


### PR DESCRIPTION
Fixes #13832

SE4 had the shortcut **"Add text here (for new selection from clipboard)"**: click-drag a selection in the waveform, hit the shortcut, and a new subtitle spanning exactly that selection is created with the clipboard text.

SE5 already has this exact functionality — `WaveformNewSelectionPasteFromClipboard` ("Paste clipboard text to new selection" in the waveform context menu) — but the command was never registered in the shortcut system, so it couldn't be bound to a key.

This PR registers it as a Waveform-category shortcut named **"Waveform paste clipboard text to new selection"**, with no default key binding (avoids collisions; users assign their own, as in SE4). The handler already no-ops safely when there is no waveform selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)