### PR TITLE
Fix CS8604 nullable warning in GetResultFileCandidates

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -2114,7 +2114,7 @@ public partial class SpeechToTextViewModel : ObservableObject
         return true;
     }
 
-    private static List<string> GetResultFileCandidates(string ext, string waveFileName, string videoFileName, string whisperFolder, ConcurrentQueue<string> outputText, string sttTempFolder = "")
+    private static List<string> GetResultFileCandidates(string ext, string waveFileName, string videoFileName, string whisperFolder, ConcurrentQueue<string> outputText, string? sttTempFolder = null)
     {
         var candidates = new List<string>
         {


### PR DESCRIPTION
The only build warning in the UI project: `_sttTempFolder` (nullable) passed to the non-nullable `sttTempFolder` parameter of `GetResultFileCandidates`. The method already guards with `string.IsNullOrEmpty`, so this just makes the parameter `string?`. Build is now warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)