### PR TITLE
STT: find Purfview XXL output via its "Subtitles are written to" message

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -2160,7 +2160,48 @@ public partial class SpeechToTextViewModel : ObservableObject
             candidates.Insert(0, pathFromOutput);
         }
 
+        // Purfview XXL announces where it wrote its result ("Subtitles are written to '<dir>'
+        // directory."). When the user's own parameters carry an "--output_dir" (e.g. "-o source"),
+        // SE does not pass its per-run folder, so the result can land somewhere none of the fixed
+        // candidates cover - e.g. next to the user's video (issue #13505). The announced folder is
+        // authoritative, so probe it first; the file is named after the engine's input.
+        var dirFromOutput = TryFindOutputDirInOutput(outputText);
+        if (!string.IsNullOrEmpty(dirFromOutput))
+        {
+            candidates.Insert(0, Path.Combine(dirFromOutput, Path.GetFileNameWithoutExtension(waveFileName) + ext));
+            if (!string.IsNullOrEmpty(videoFileName))
+            {
+                candidates.Insert(0, Path.Combine(dirFromOutput, Path.GetFileNameWithoutExtension(videoFileName) + ext));
+            }
+        }
+
         return candidates;
+    }
+
+    private static string? TryFindOutputDirInOutput(ConcurrentQueue<string> outputText)
+    {
+        const string findText = "Subtitles are written to '";
+        foreach (var line in outputText)
+        {
+            var idx = line.IndexOf(findText, StringComparison.OrdinalIgnoreCase);
+            if (idx < 0)
+            {
+                continue;
+            }
+
+            var start = idx + findText.Length;
+            var end = line.LastIndexOf('\'');
+            if (end > start)
+            {
+                var dir = line.Substring(start, end - start).Trim();
+                if (Directory.Exists(dir))
+                {
+                    return dir;
+                }
+            }
+        }
+
+        return null;
     }
 
     private static string? TryFindFilePathInOutput(string format, ConcurrentQueue<string> outputText)


### PR DESCRIPTION
Fixes the "subtitle file couldn't be generated, loading from stdout" case reported in https://github.com/SubtitleEdit/subtitleedit/issues/13505#issuecomment-5331758440.

When the user's advanced parameters carry their own `--output_dir` (e.g. `-o source`), SE skips passing its per-run output folder, so Purfview Faster-Whisper-XXL writes its result wherever the user pointed it — e.g. next to the video. None of the fixed result-file candidates cover that location, so SE reported the file as missing and fell back to parsing stdout, even though a valid VTT existed on disk.

XXL announces the destination on stdout:

```
Subtitles are written to 'C:\Videos' directory.
```

This PR parses that line and probes the announced folder (with the engine input's base name) as the first result-file candidate.

(The `.en.vtt` vs `.vtt` naming in the report is not a bug — the on-disk file is XXL's raw output, which never carries a language code; `.en.vtt` was just SE's suggested save name from the "append two-letter language code" setting.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)