### PR TITLE
Fix Netflix IMSC 1.1 Japanese files without bouten being detected as EBU-TT-D

### DIFF
--- a/src/libse/SubtitleFormats/EbuTtD.cs
+++ b/src/libse/SubtitleFormats/EbuTtD.cs
@@ -74,7 +74,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 return false;
             }
 
-            if (text.Contains("bouten-", StringComparison.Ordinal))
+            if (text.Contains("lang=\"ja\"", StringComparison.Ordinal) && NetflixImsc11Japanese.ContainsJapaneseProfileStyling(text))
             {
                 return false; // Netflix IMSC 1.1 Japanese
             }

--- a/src/libse/SubtitleFormats/NetflixImsc11Japanese.cs
+++ b/src/libse/SubtitleFormats/NetflixImsc11Japanese.cs
@@ -68,6 +68,17 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 ".Replace('\'', '"');
         }
 
+        /// <summary>
+        /// Bouten (emphasis) styles are optional, so also accept the ruby/furigana styling
+        /// attributes from the IMSC 1.1 Japanese profile - these never occur in EBU-TT-D.
+        /// </summary>
+        internal static bool ContainsJapaneseProfileStyling(string text)
+        {
+            return text.Contains("bouten-", StringComparison.Ordinal) ||
+                   text.Contains("tts:ruby=", StringComparison.Ordinal) ||
+                   text.Contains("tts:rubyReserve=", StringComparison.Ordinal);
+        }
+
         public override bool IsMine(List<string> lines, string fileName)
         {
             if (fileName != null && !(fileName.EndsWith(Extension, StringComparison.OrdinalIgnoreCase) || fileName.EndsWith(".xml", StringComparison.OrdinalIgnoreCase)))
@@ -78,7 +89,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var sb = new StringBuilder();
             lines.ForEach(line => sb.AppendLine(line));
             var text = sb.ToString();
-            if (!text.Contains("lang=\"ja\"", StringComparison.Ordinal) || !text.Contains("bouten-", StringComparison.Ordinal))
+            if (!text.Contains("lang=\"ja\"", StringComparison.Ordinal) || !ContainsJapaneseProfileStyling(text))
             {
                 return false;
             }

--- a/tests/libse/SubtitleFormats/NetflixImsc11JapaneseTest.cs
+++ b/tests/libse/SubtitleFormats/NetflixImsc11JapaneseTest.cs
@@ -1,0 +1,69 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+
+namespace LibSETests.SubtitleFormats;
+
+public class NetflixImsc11JapaneseTest
+{
+    private static SubtitleFormat? Detect(string raw)
+    {
+        var lines = raw.SplitToLines();
+        foreach (var candidate in SubtitleFormat.AllSubtitleFormats)
+        {
+            if (candidate.IsMine(lines, "subtitle.xml"))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    // Styling block from https://github.com/SubtitleEdit/subtitleedit/issues/13836 -
+    // a real Netflix IMSC 1.1 Japanese file with ruby/furigana styles but no bouten
+    // (emphasis) styles. It must not be claimed by EBU-TT-D.
+    private const string RubyOnlyDocument = """
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<tt xml:lang="ja" xmlns="http://www.w3.org/ns/ttml" xmlns:tts="http://www.w3.org/ns/ttml#styling" xmlns:ttp="http://www.w3.org/ns/ttml#parameter" xmlns:ebutts="urn:ebu:tt:style" ttp:timeBase="media" ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/imsc1.1/text">
+  <head>
+    <styling>
+      <initial tts:backgroundColor="transparent" tts:color="white" tts:extent="80.000% 80.000%" tts:fontFamily="Japanese" tts:opacity="1.000" tts:origin="10.000% 10.000%" tts:showBackground="whenActive" tts:textOutline="black 0.050em" tts:writingMode="lrtb"/>
+      <style xml:id="style0" tts:fontSize="100.000%" tts:rubyReserve="outside" tts:textAlign="center"/>
+      <style xml:id="style2" tts:fontSize="100.000%" tts:ruby="container"/>
+      <style xml:id="style3" tts:fontSize="100.000%" tts:ruby="base"/>
+      <style xml:id="style4" tts:ruby="text" tts:rubyAlign="center" tts:rubyPosition="outside"/>
+    </styling>
+    <layout>
+      <region xml:id="region0" tts:displayAlign="after" tts:extent="80.000% 80.000%" tts:origin="10.000% 10.000%"/>
+    </layout>
+  </head>
+  <body>
+    <div>
+      <p begin="00:00:01.000" end="00:00:03.000" region="region0" style="style0">こんにちは</p>
+    </div>
+  </body>
+</tt>
+""";
+
+    [Fact]
+    public void DetectsRubyOnlyDocumentAsNetflixImsc11Japanese()
+    {
+        var detected = Detect(RubyOnlyDocument);
+
+        Assert.NotNull(detected);
+        Assert.Equal(new NetflixImsc11Japanese().Name, detected.Name);
+    }
+
+    [Fact]
+    public void OwnOutputStillDetectsAsNetflixImsc11Japanese()
+    {
+        var sub = new Subtitle();
+        sub.Paragraphs.Add(new Paragraph("こんにちは", 1000, 3000));
+        var raw = sub.ToText(new NetflixImsc11Japanese());
+
+        var detected = Detect(raw);
+
+        Assert.NotNull(detected);
+        Assert.Equal(new NetflixImsc11Japanese().Name, detected.Name);
+    }
+}


### PR DESCRIPTION
Fixes #13836

## Problem
`NetflixImsc11Japanese.IsMine` required the literal `bouten-` style id, but bouten (emphasis) styles are optional. A Netflix IMSC 1.1 Japanese file using only ruby/furigana styling failed the check, and was then claimed by `EbuTtD` (which sits earlier in the format list and whose only Netflix-JP escape hatch was the same `bouten-` check).

## Fix
Detection now keys on the IMSC 1.1 Japanese profile styling attributes — `bouten-` style ids, `tts:ruby=`, or `tts:rubyReserve=` — via a shared helper so both formats stay in sync:
- `NetflixImsc11Japanese` accepts a `lang="ja"` document containing any of them.
- `EbuTtD` declines such documents (these attributes never occur in EBU-TT-D).

The `lang="ja"` requirement is kept so plain Japanese TTML/EBU-TT-D files are unaffected.

## Tests
- New detection test using the styling block from the issue (ruby-only, no bouten) — asserts it resolves to Netflix IMSC 1.1 Japanese, not EBU-TT-D.
- Round-trip detection test for the format's own output.
- Full libse suite passes (1360/1360).

🤖 Generated with [Claude Code](https://claude.com/claude-code)