### PR TITLE
Remove text for HI: keep Apply checkbox states after partial Apply

### DIFF
--- a/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedViewModel.cs
+++ b/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedViewModel.cs
@@ -217,8 +217,10 @@ public partial class RemoveTextForHearingImpairedViewModel : ObservableObject, I
         _applyCallback?.Invoke(applied);
 
         // Keep iterating against the applied result: re-base the working subtitle and refresh the
-        // preview so already-removed text isn't offered again (#11948).
-        _subtitle = new Subtitle(applied);
+        // preview so already-removed text isn't offered again (#11948). Paragraph ids must survive
+        // the re-base - GeneratePreview carries the checkbox states over by id, and removing whole
+        // lines shifts the indexes (#13839).
+        _subtitle = new Subtitle(applied, generateNewId: false);
         _removeTextForHiLib = new RemoveTextForHI(GetSettings(_subtitle));
         GeneratePreview();
     }
@@ -373,8 +375,10 @@ public partial class RemoveTextForHearingImpairedViewModel : ObservableObject, I
             var newText = _removeTextForHiLib.RemoveTextFromHearImpaired(p.Text, _subtitle, index, twoLetterIsoLanguageName);
             if (IsVisibleChange(p.Text, newText))
             {
+                // Carry the checkbox state over by paragraph id, not by index: applying fixes that
+                // remove whole lines shifts every later index, which re-checked unchecked items (#13839).
                 var apply = true;
-                var oldItem = Fixes.FirstOrDefault(f => f.Index == index);
+                var oldItem = Fixes.FirstOrDefault(f => f.Paragraph.Id == p.Id);
                 if (oldItem != null)
                 {
                     apply = oldItem.Apply;


### PR DESCRIPTION
Fixes #13839

After a partial Apply that removed complete subtitle lines, remaining unchecked fixes came back checked. Two causes, both in `RemoveTextForHearingImpairedViewModel`:

- `GeneratePreview` carried checkbox states over by paragraph **index**, but `Apply` → `RemoveEmptyLines()` shifts every later index, so the lookup matched the wrong item or none at all — and "none" fell into the `apply = true` default.
- The Apply re-base (`new Subtitle(applied)`) generated new paragraph ids, so an id-based match wasn't possible.

Fix: carry the Apply state over by paragraph id, and re-base with `generateNewId: false` so ids stay stable. New fixes (e.g. surfaced by changed settings) still default to checked; text-only applies behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)