### PR TITLE
Fix NRE crash in batch auto-translate when API key is missing

### DIFF
--- a/src/libuilogic/AutoTranslate/DeepLTranslate.cs
+++ b/src/libuilogic/AutoTranslate/DeepLTranslate.cs
@@ -157,6 +157,14 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
 
         public async Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
         {
+            if (_httpClient == null)
+            {
+                // Initialize() bails out without creating the client when the API key or URL is
+                // empty - fail with a readable message instead of a NullReferenceException.
+                Error = $"{StaticName} requires an API key";
+                throw new Exception($"{StaticName} requires an API key - please enter your DeepL API key and try again.");
+            }
+
             int[] retryDelays = { 555, 3007, 7013 };
             HttpResponseMessage result = null!;
             var resultContent = string.Empty;

--- a/src/libuilogic/AutoTranslate/MistralTranslate.cs
+++ b/src/libuilogic/AutoTranslate/MistralTranslate.cs
@@ -72,6 +72,14 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
 
         public async Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
         {
+            if (_httpClient == null)
+            {
+                // Initialize() bails out without creating the client when the API key or URL is
+                // empty - fail with a readable message instead of a NullReferenceException.
+                Error = $"{StaticName} requires an API key";
+                throw new Exception($"{StaticName} requires an API key - please enter your Mistral API key and try again.");
+            }
+
             var model = Configuration.Settings.Tools.AutoTranslateMistralModel;
             if (string.IsNullOrEmpty(model))
             {

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -1056,6 +1056,11 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
 
         var config = MakeBatchConvertConfig();
 
+        if (!await EnsureTranslateApiKeyPresent(config))
+        {
+            return;
+        }
+
         if (!await EnsurePaddleOcrAvailable(config))
         {
             return;
@@ -1347,6 +1352,33 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
     // reuse it, otherwise auto-download the engine + model (prompting) and auto-start the server, so
     // batch translation works without opening the interactive Auto-translate window first. Remote mode
     // (a user-supplied URL) is left untouched.
+    private async Task<bool> EnsureTranslateApiKeyPresent(BatchConvertConfig config)
+    {
+        if (Window == null || !config.AutoTranslate.IsActive || config.AutoTranslate.Translator == null)
+        {
+            return true;
+        }
+
+        // Same guard as the interactive Auto-translate window: an engine whose API key box is
+        // shown (except LibreTranslate, where the key is optional) cannot run with an empty key -
+        // the engine's Initialize() skips creating its HTTP client, and every file would fail
+        // with a NullReferenceException instead of a readable message (#12288).
+        if (AutoTranslateApiKeyIsVisible &&
+            string.IsNullOrWhiteSpace(AutoTranslateApiKey) &&
+            config.AutoTranslate.Translator is not LibreTranslate)
+        {
+            await MessageBox.Show(
+                Window,
+                Se.Language.General.Error,
+                string.Format(Se.Language.General.XRequiresAnApiKey, config.AutoTranslate.Translator.Name),
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            return false;
+        }
+
+        return true;
+    }
+
     private async Task<bool> EnsureLlamaCppAvailable(BatchConvertConfig config)
     {
         if (Window == null)


### PR DESCRIPTION
Fixes the crash reported in https://github.com/SubtitleEdit/subtitleedit/issues/12288#issuecomment-5332324226 — every file in a batch auto-translate run with DeepL failed immediately with a bare `Object reference not set to an instance of an object`.

**Root cause:** `DeepLTranslate.Initialize()` (and `MistralTranslate.Initialize()`) return early without creating the `HttpClient` when the API key or URL is empty, so `Translate()` dereferenced a null client.

**Fix (two layers):**
- `DeepLTranslate`/`MistralTranslate`: when the client was never created, throw a readable "X requires an API key" error (and set `Error`) instead of crashing with an NRE — so the batch log/status says what is actually wrong.
- Batch convert: block the run up front with the same `XRequiresAnApiKey` message box the interactive Auto-translate window already shows when a required API key is empty (LibreTranslate exempted, key optional there — same rule as the interactive window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)