### PR TITLE
Add letter spacing to video burn-in/transparent + real libass previews

### DIFF
--- a/src/ui/Features/Assa/AssaStylesViewModel.cs
+++ b/src/ui/Features/Assa/AssaStylesViewModel.cs
@@ -1146,15 +1146,80 @@ public partial class AssaStylesViewModel : ObservableObject, IClosingCleanup
         }
     }
 
+    private int _previewRequestId;
+    private string _lastPreviewSignature = string.Empty;
+
     private void UpdatePreview()
     {
         var style = CurrentStyle;
         if (style == null)
         {
+            _lastPreviewSignature = string.Empty;
             ImagePreview = new SKBitmap(1, 1, true).ToAvaloniaBitmap();
             return;
         }
 
+        // The preview timer polls every 500 ms; only re-render (spawn ffmpeg) when the style
+        // actually changed. Renders via libass so the preview matches playback/burn-in exactly.
+        var ssaStyle = style.ToSsaStyle();
+        var signature = ssaStyle.ToRawAss();
+        if (signature == _lastPreviewSignature)
+        {
+            return;
+        }
+
+        _lastPreviewSignature = signature;
+        var requestId = System.Threading.Interlocked.Increment(ref _previewRequestId);
+        var header = _subtitle.Header;
+
+        Task.Run(() =>
+        {
+            var previewSubtitle = new Subtitle
+            {
+                Header = string.IsNullOrEmpty(header) ? AdvancedSubStationAlpha.DefaultHeader : header,
+            };
+            previewSubtitle.Header = AdvancedSubStationAlpha.GetHeaderAndStylesFromAdvancedSubStationAlpha(
+                previewSubtitle.Header, new List<SsaStyle> { ssaStyle });
+            previewSubtitle.Paragraphs.Add(new Paragraph("This is a test", 0, 2000) { Extra = ssaStyle.Name });
+
+            SKBitmap? bitmap = null;
+            try
+            {
+                bitmap = NonAssaPreviewRenderer.Render(previewSubtitle, 1280, 720);
+            }
+            catch
+            {
+                // Fall back to the Skia preview below
+            }
+
+            if (requestId != _previewRequestId)
+            {
+                bitmap?.Dispose();
+                return;
+            }
+
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (requestId != _previewRequestId)
+                {
+                    bitmap?.Dispose();
+                    return;
+                }
+
+                if (bitmap != null)
+                {
+                    ImagePreview = NonAssaPreviewRenderer.ComposeOnDarkFrame(bitmap).ToAvaloniaBitmap();
+                }
+                else
+                {
+                    UpdatePreviewSkia(style);
+                }
+            });
+        });
+    }
+
+    private void UpdatePreviewSkia(StyleDisplay style)
+    {
         var text = "This is a test";
 
         // Scale the rendered font size to the preview canvas height (~360px) the same way

--- a/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
@@ -45,6 +45,7 @@ public partial class BurnInViewModel : ObservableObject
     [ObservableProperty] private decimal? _selectedFontOutline;
     [ObservableProperty] private string _fontOutlineText;
     [ObservableProperty] private decimal? _selectedFontShadowWidth;
+    [ObservableProperty] private decimal? _selectedFontSpacing;
     [ObservableProperty] private string _fontShadowText;
     [ObservableProperty] private ObservableCollection<FontBoxItem> _fontBoxTypes;
     [ObservableProperty] private FontBoxItem _selectedFontBoxType;
@@ -940,6 +941,7 @@ public partial class BurnInViewModel : ObservableObject
         style.Outline = FontOutlineColor.ToSKColor();
         style.OutlineWidth = SelectedFontOutline ?? 0;
         style.ShadowWidth = SelectedFontShadowWidth ?? 0;
+        style.Spacing = SelectedFontSpacing ?? 0;
         style.Alignment = SelectedFontAlignment.Code;
         style.MarginLeft = FontMarginHorizontal ?? 0;
         style.MarginRight = FontMarginHorizontal ?? 0;
@@ -1376,6 +1378,7 @@ public partial class BurnInViewModel : ObservableObject
         FontIsBold = settings.FontBold;
         SelectedFontOutline = settings.OutlineWidth;
         SelectedFontShadowWidth = settings.ShadowWidth;
+        SelectedFontSpacing = settings.NonAssaSpacing;
         SelectedFontName = settings.FontName;
         FontTextColor = settings.NonAssaTextColor.FromHexToColor();
         FontOutlineColor = settings.NonAssaOutlineColor.FromHexToColor();
@@ -1432,6 +1435,7 @@ public partial class BurnInViewModel : ObservableObject
         settings.FontBold = FontIsBold;
         settings.OutlineWidth = SelectedFontOutline ?? 0;
         settings.ShadowWidth = SelectedFontShadowWidth ?? 0;
+        settings.NonAssaSpacing = SelectedFontSpacing ?? 0;
         settings.FontName = SelectedFontName;
         settings.NonAssaTextColor = FontTextColor.FromColorToHex();
         settings.NonAssaOutlineColor = FontOutlineColor.FromColorToHex();
@@ -1990,6 +1994,8 @@ public partial class BurnInViewModel : ObservableObject
         UpdateNonAssaPreview();
     }
 
+    private int _previewRequestId;
+
     private void UpdateNonAssaPreview()
     {
         if (_loading || !string.IsNullOrEmpty(GetValidationError()))
@@ -1997,13 +2003,75 @@ public partial class BurnInViewModel : ObservableObject
             return;
         }
 
-        var text = "This is a test";
-
         if (_subtitleFormat is { Name: AdvancedSubStationAlpha.NameOfFormat } && !IsBatchMode)
         {
             ImagePreview = new SKBitmap(1, 1, true).ToAvaloniaBitmap();
             return;
         }
+
+        // Render the preview with ffmpeg/libass (same engine as the generated video), debounced
+        // as the numeric up/downs fire on every tick. Falls back to the Skia approximation if
+        // ffmpeg is unavailable.
+        var requestId = System.Threading.Interlocked.Increment(ref _previewRequestId);
+        var width = VideoWidth ?? 0;
+        var height = VideoHeight ?? 0;
+        if (width < 16 || height < 16)
+        {
+            width = 1920;
+            height = 1080;
+        }
+
+        Task.Run(async () =>
+        {
+            await Task.Delay(150);
+            if (requestId != _previewRequestId)
+            {
+                return;
+            }
+
+            var previewSubtitle = new Subtitle();
+            previewSubtitle.Paragraphs.Add(new Paragraph("This is a test", 0, 2000));
+            SetStyleForNonAssa(previewSubtitle, width, height);
+
+            SKBitmap? bitmap = null;
+            try
+            {
+                bitmap = NonAssaPreviewRenderer.Render(previewSubtitle, width, height);
+            }
+            catch
+            {
+                // Fall back to the Skia preview below
+            }
+
+            if (requestId != _previewRequestId)
+            {
+                bitmap?.Dispose();
+                return;
+            }
+
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (requestId != _previewRequestId)
+                {
+                    bitmap?.Dispose();
+                    return;
+                }
+
+                if (bitmap != null)
+                {
+                    ImagePreview = bitmap.CropTransparentColors().ToAvaloniaBitmap();
+                }
+                else
+                {
+                    UpdateNonAssaPreviewSkia();
+                }
+            });
+        });
+    }
+
+    private void UpdateNonAssaPreviewSkia()
+    {
+        var text = "This is a test";
 
 
         var fontSize = (float)CalculateFontSize(VideoWidth ?? 0, VideoHeight ?? 0, FontFactor ?? 0);

--- a/src/ui/Features/Video/BurnIn/BurnInWindow.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInWindow.cs
@@ -406,6 +406,10 @@ public class BurnInWindow : Window
             }
         };
 
+        var labelSpacing = UiUtil.MakeLabel(Se.Language.General.Spacing);
+        var textBoxSpacing = UiUtil.MakeNumericUpDownOneDecimal(-20, 100, 130, vm, nameof(vm.SelectedFontSpacing));
+        textBoxSpacing.ValueChanged += vm.NumericUpDownChanged;
+
         var labelBoxType = UiUtil.MakeLabel(Se.Language.Video.BurnIn.BoxType);
         var comboBoxBoxType = UiUtil.MakeComboBox(vm.FontBoxTypes, vm, nameof(vm.SelectedFontBoxType));
         comboBoxBoxType.SelectionChanged += vm.BoxTypeChanged;
@@ -480,6 +484,7 @@ public class BurnInWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
             {
@@ -512,14 +517,17 @@ public class BurnInWindow : Window
         grid.Add(labelShadow, 5, 0);
         grid.Add(panelShadow, 5, 1);
 
-        grid.Add(labelAlignment, 6, 0);
-        grid.Add(comboBoxAlignment, 6, 1);
+        grid.Add(labelSpacing, 6, 0);
+        grid.Add(textBoxSpacing, 6, 1);
 
-        grid.Add(labelMargin, 7, 0);
-        grid.Add(panelMargin, 7, 1);
+        grid.Add(labelAlignment, 7, 0);
+        grid.Add(comboBoxAlignment, 7, 1);
 
-        grid.Add(labelEffect, 8, 0);
-        grid.Add(panelEffect, 8, 1);
+        grid.Add(labelMargin, 8, 0);
+        grid.Add(panelMargin, 8, 1);
+
+        grid.Add(labelEffect, 9, 0);
+        grid.Add(panelEffect, 9, 1);
 
         var panel = new Grid
         {
@@ -545,8 +553,8 @@ public class BurnInWindow : Window
         }.WithBindVisible(vm, nameof(vm.ShowAssaOnlyBox));
         grid.Add(panel, 0, 0, 9, 2);
 
-        grid.Add(labelLogo, 9, 0);
-        grid.Add(panelLogo, 9, 1);
+        grid.Add(labelLogo, 10, 0);
+        grid.Add(panelLogo, 10, 1);
 
         return UiUtil.MakeBorderForControl(grid).WithMarginBottom(5).WithMarginRight(5);
     }

--- a/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesViewModel.cs
+++ b/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesViewModel.cs
@@ -47,6 +47,7 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
     [ObservableProperty] private decimal? _selectedFontOutline;
     [ObservableProperty] private string _fontOutlineText;
     [ObservableProperty] private decimal? _selectedFontShadowWidth;
+    [ObservableProperty] private decimal? _selectedFontSpacing;
     [ObservableProperty] private string _fontShadowText;
     [ObservableProperty] private ObservableCollection<FontBoxItem> _fontBoxTypes;
     [ObservableProperty] private FontBoxItem _selectedFontBoxType;
@@ -679,6 +680,7 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
         style.Outline = FontOutlineColor.ToSKColor();
         style.OutlineWidth = SelectedFontOutline ?? 0;
         style.ShadowWidth = SelectedFontShadowWidth ?? 0;
+        style.Spacing = SelectedFontSpacing ?? 0;
         style.Alignment = SelectedFontAlignment.Code;
         style.MarginLeft = FontMarginHorizontal ?? 0;
         style.MarginRight = FontMarginHorizontal ?? 0;
@@ -998,6 +1000,7 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
         FontIsBold = settings.FontBold;
         SelectedFontOutline = settings.OutlineWidth;
         SelectedFontShadowWidth = settings.ShadowWidth;
+        SelectedFontSpacing = settings.NonAssaSpacing;
         SelectedFontName = settings.FontName;
         FontTextColor = settings.NonAssaTextColor.FromHexToColor();
         FontOutlineColor = settings.NonAssaOutlineColor.FromHexToColor();
@@ -1022,6 +1025,7 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
         settings.FontBold = FontIsBold;
         settings.OutlineWidth = SelectedFontOutline ?? 0;
         settings.ShadowWidth = SelectedFontShadowWidth ?? 0;
+        settings.NonAssaSpacing = SelectedFontSpacing ?? 0;
         settings.FontName = SelectedFontName;
         settings.NonAssaTextColor = FontTextColor.FromColorToHex();
         settings.NonAssaOutlineColor = FontOutlineColor.FromColorToHex();
@@ -1180,6 +1184,8 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
         UpdateNonAssaPreview();
     }
 
+    private int _previewRequestId;
+
     private void UpdateNonAssaPreview()
     {
         if (_loading || Window == null || !string.IsNullOrEmpty(GetValidationError()))
@@ -1187,13 +1193,75 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
             return;
         }
 
-        var text = "This is a test";
-
         if (_subtitleFormat is { Name: AdvancedSubStationAlpha.NameOfFormat } && !IsBatchMode)
         {
             ImagePreview = new SKBitmap(1, 1).ToAvaloniaBitmap();
             return;
         }
+
+        // Render the preview with ffmpeg/libass (same engine as the generated video), debounced
+        // as the numeric up/downs fire on every tick. Falls back to the Skia approximation if
+        // ffmpeg is unavailable.
+        var requestId = System.Threading.Interlocked.Increment(ref _previewRequestId);
+        var width = VideoWidth ?? 0;
+        var height = VideoHeight ?? 0;
+        if (width < 16 || height < 16)
+        {
+            width = 1920;
+            height = 1080;
+        }
+
+        Task.Run(async () =>
+        {
+            await Task.Delay(150);
+            if (requestId != _previewRequestId)
+            {
+                return;
+            }
+
+            var previewSubtitle = new Subtitle();
+            previewSubtitle.Paragraphs.Add(new Paragraph("This is a test", 0, 2000));
+            SetStyleForNonAssa(previewSubtitle, width, height);
+
+            SKBitmap? bitmap = null;
+            try
+            {
+                bitmap = NonAssaPreviewRenderer.Render(previewSubtitle, width, height);
+            }
+            catch
+            {
+                // Fall back to the Skia preview below
+            }
+
+            if (requestId != _previewRequestId)
+            {
+                bitmap?.Dispose();
+                return;
+            }
+
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (requestId != _previewRequestId)
+                {
+                    bitmap?.Dispose();
+                    return;
+                }
+
+                if (bitmap != null)
+                {
+                    ImagePreview = bitmap.CropTransparentColors().ToAvaloniaBitmap();
+                }
+                else
+                {
+                    UpdateNonAssaPreviewSkia();
+                }
+            });
+        });
+    }
+
+    private void UpdateNonAssaPreviewSkia()
+    {
+        var text = "This is a test";
 
 
         var fontSize = (float)CalculateFontSize(VideoWidth ?? 0, VideoHeight ?? 0, FontFactor ?? 0);

--- a/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesWindow.cs
+++ b/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesWindow.cs
@@ -241,6 +241,10 @@ public class TransparentSubtitlesWindow : Window
             }
         };
 
+        var labelSpacing = UiUtil.MakeLabel(Se.Language.General.Spacing);
+        var textBoxSpacing = UiUtil.MakeNumericUpDownOneDecimal(-20, 100, 130, vm, nameof(vm.SelectedFontSpacing));
+        textBoxSpacing.ValueChanged += vm.NumericUpDownChanged;
+
         var labelBoxType = UiUtil.MakeLabel(Se.Language.Video.BurnIn.BoxType);
         var comboBoxBoxType = UiUtil.MakeComboBox(vm.FontBoxTypes, vm, nameof(vm.SelectedFontBoxType));
         comboBoxBoxType.SelectionChanged += vm.BoxTypeChanged;
@@ -299,6 +303,7 @@ public class TransparentSubtitlesWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
             {
@@ -331,14 +336,17 @@ public class TransparentSubtitlesWindow : Window
         grid.Add(labelShadow, 6, 0);
         grid.Add(panelShadow, 6, 1);
 
-        grid.Add(labelAlignment, 7, 0);
-        grid.Add(comboBoxAlignment, 7, 1);
+        grid.Add(labelSpacing, 7, 0);
+        grid.Add(textBoxSpacing, 7, 1);
 
-        grid.Add(labelMargin, 8, 0);
-        grid.Add(panelMargin, 8, 1);
+        grid.Add(labelAlignment, 8, 0);
+        grid.Add(comboBoxAlignment, 8, 1);
 
-        grid.Add(labelEffect, 9, 0);
-        grid.Add(panelEffect, 9, 1);
+        grid.Add(labelMargin, 9, 0);
+        grid.Add(panelMargin, 9, 1);
+
+        grid.Add(labelEffect, 10, 0);
+        grid.Add(panelEffect, 10, 1);
 
         return UiUtil.MakeBorderForControl(grid).WithMarginBottom(5).WithMarginRight(5);
     }

--- a/src/ui/Logic/Config/SeVideoBurnIn.cs
+++ b/src/ui/Logic/Config/SeVideoBurnIn.cs
@@ -35,6 +35,7 @@ public class SeVideoBurnIn
     public string NonAssaOutlineColor { get; set; }
     public string NonAssaAlignment { get; set; }
     public bool NonAssaFixRtlUnicode { get; set; }
+    public decimal NonAssaSpacing { get; set; }
     public decimal NonAssaMarginVertical { get; set; }
     public decimal NonAssaMarginHorizontal { get; set; }
     public string EmbedOutputExt { get; set; }

--- a/src/ui/Logic/Media/NonAssaPreviewRenderer.cs
+++ b/src/ui/Logic/Media/NonAssaPreviewRenderer.cs
@@ -1,0 +1,54 @@
+using Nikse.SubtitleEdit.Core.Common;
+using SkiaSharp;
+using System.IO;
+
+namespace Nikse.SubtitleEdit.Logic.Media;
+
+/// <summary>
+/// Renders a single-frame libass preview via ffmpeg (lavfi transparent color + subtitles filter),
+/// so the style preview matches the generated video exactly (font metrics, spacing, boxes).
+/// </summary>
+public static class NonAssaPreviewRenderer
+{
+    /// <summary>
+    /// Draws a transparent libass frame on the dark "video frame" background used by style previews.
+    /// </summary>
+    public static SKBitmap ComposeOnDarkFrame(SKBitmap bitmap)
+    {
+        var frame = new SKBitmap(bitmap.Width, bitmap.Height);
+        using var canvas = new SKCanvas(frame);
+        canvas.Clear(new SKColor(40, 40, 40));
+        using (var border = new SKPaint { Color = new SKColor(90, 90, 90), Style = SKPaintStyle.Stroke, StrokeWidth = 2 })
+        {
+            canvas.DrawRect(1, 1, bitmap.Width - 2, bitmap.Height - 2, border);
+        }
+
+        canvas.DrawBitmap(bitmap, 0, 0);
+        return frame;
+    }
+
+    public static SKBitmap? Render(Subtitle subtitle, int width, int height)
+    {
+        var fileName = FfmpegGenerator.GetScreenShotWithSubtitle(subtitle, width, height);
+        if (fileName == null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return SKBitmap.Decode(fileName);
+        }
+        finally
+        {
+            try
+            {
+                File.Delete(fileName);
+            }
+            catch
+            {
+                // Ignore cleanup errors
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds the ability to adjust letter spacing (tracking) when generating transparent subtitle videos, as requested by a user matching the look of legacy overlay software.

- New **Spacing** option (ASSA `\fsp`, style `Spacing` field) in both Video → *Generate video with burned-in subtitles* and *Generate transparent subtitle*, persisted as `NonAssaSpacing`. `SsaStyle.Spacing` already round-tripped through the ASSA writer, so libass honors it directly.
- The "This is a test" style previews in the burn-in, transparent, and ASSA styles dialogs are now rendered by ffmpeg's libass filter over a transparent lavfi source (via the existing `GetScreenShotWithSubtitle` helper) — the same engine that renders the output — so spacing, font metrics, boxes, margins and alignment preview pixel-exact. The old Skia-drawn preview remains as fallback when ffmpeg is unavailable.
- Preview renders are debounced and async with last-request-wins cancellation; the ASSA styles dialog (which polls on a 500 ms timer) only re-renders when the raw style line actually changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)