### PR TITLE
Refresh style preview when switching single/batch mode

### DIFF
--- a/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
@@ -1478,6 +1478,7 @@ public partial class BurnInViewModel : ObservableObject
 
         var isAssa = _subtitleFormat is { Name: AdvancedSubStationAlpha.NameOfFormat };
         ShowAssaOnlyBox = isAssa;
+        UpdateNonAssaPreview();
     }
 
     [RelayCommand]
@@ -1486,6 +1487,7 @@ public partial class BurnInViewModel : ObservableObject
         IsBatchMode = true;
         IsSingleModeVisible = !string.IsNullOrEmpty(_inputVideoFileName);
         ShowAssaOnlyBox = false;
+        UpdateNonAssaPreview();
     }
 
     [RelayCommand]

--- a/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesViewModel.cs
+++ b/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesViewModel.cs
@@ -1043,6 +1043,7 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
     {
         IsBatchMode = false;
         IsSingleModeVisible = false;
+        UpdateNonAssaPreview();
     }
 
     [RelayCommand]
@@ -1050,6 +1051,7 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
     {
         IsBatchMode = true;
         IsSingleModeVisible = !string.IsNullOrEmpty(_inputVideoFileName);
+        UpdateNonAssaPreview();
     }
 
     [RelayCommand]


### PR DESCRIPTION
Follow-up to #13843: switching to batch mode in the burn-in / generate transparent dialogs showed no style preview until a setting was changed, because the ASSA early-out had blanked the preview in single mode and nothing re-rendered on the mode switch. Now the preview refreshes on both single→batch and batch→single.

🤖 Generated with [Claude Code](https://claude.com/claude-code)