### PR TITLE
Let Crisp ASR users switch VAD off (#13849)

### DIFF
--- a/docs/features/speech-to-text.md
+++ b/docs/features/speech-to-text.md
@@ -90,6 +90,14 @@ Click the **Advanced** button to configure custom command-line arguments for the
 
 Advanced settings are stored per engine, so you can keep separate parameters for Whisper CPP, Qwen3 ASR, Crisp ASR, and other engines.
 
+### Voice activity detection with Crisp ASR Cohere and Mega
+
+For the **Cohere** and **Mega** backends, Subtitle Edit adds `--vad` and the bundled Silero VAD model to the command line by default. Crisp ASR turns VAD on for these models by itself on longer audio, so passing the bundled model mainly keeps Crisp ASR from downloading its own copy in the middle of a transcription.
+
+VAD usually gives tighter timings, but on some material it drops quiet speech and clips the first word of a line. Crisp ASR has no `--no-vad` switch, so VAD is turned off by asking for fixed chunking instead: add `--chunk-seconds 30` (or `-ck 30`) to the advanced parameters, and Subtitle Edit leaves `--vad` out of the command line entirely. Expect the trade-off that comes with it - with VAD off, long stretches of silence or music can produce invented lines.
+
+To keep VAD and only change how it behaves, put `--vad` in the advanced parameters yourself (the **Enable VAD** button fills in the flag and the model path). An explicit `--vad` wins over `--chunk-seconds`, so the two can be combined.
+
 ## Post-Processing Settings
 
 Click the **Post-processing** button to configure:

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -3711,8 +3711,16 @@ public partial class SpeechToTextViewModel : ObservableObject
             var vadPart = string.Empty;
             // Mega-ASR (crispasr 0.6.10) silently writes a zero-byte SRT unless VAD chunking
             // is enabled — the transcription log says it succeeded but no segments are emitted.
+            // Cohere gets the same treatment because crispasr auto-enables VAD for that backend
+            // on long audio anyway; passing the bundled Silero model keeps it from downloading
+            // its own copy into ~/.cache/crispasr mid-transcription.
+            //
+            // --chunk-seconds/-ck in the user's parameters means "no VAD, use fixed chunks" -
+            // that is crispasr's own documented way to switch its auto-VAD back off, and it is
+            // the only way to switch VAD off at all (--vad is a plain flag with no --no-vad).
+            // So it has to suppress our own --vad too, or the user has no opt-out (#13849).
             if (crispAsrEngine is CrispAsrCohere or CrispAsrMega
-                && !Regex.IsMatch(crispArgs ?? string.Empty, @"(^|\s)(--vad|-vm|--vad-model)\b"))
+                && !Regex.IsMatch(crispArgs ?? string.Empty, @"(^|\s)(--vad|-vm|--vad-model|--chunk-seconds|-ck)\b"))
             {
                 var crispFolder = crispAsrEngine.GetAndCreateWhisperFolder();
                 var vadFiles = Directory.Exists(crispFolder)


### PR DESCRIPTION
Fixes #13849.

Subtitle Edit appended `--vad --vad-model <silero>` to every Crisp ASR Cohere/Mega run unless the advanced parameters already mentioned a VAD flag. crispasr has no `--no-vad` (`--vad` is a plain boolean switch), so there was no way to ask for a VAD-free transcription — and the injected flag also overrode crispasr's own documented override, `--chunk-seconds`, which is exactly what the reporter had set.

`--chunk-seconds`/`-ck` in the advanced parameters now suppresses the injection, so it works as the opt-out. Defaults are unchanged: without it, VAD is still enabled with the bundled Silero model, which keeps crispasr from downloading its own copy into `~/.cache/crispasr` mid-transcription. An explicit `--vad` still wins over `--chunk-seconds` for anyone who wants both.

### Measurements

crispasr 0.8.29, `cohere-transcribe.gguf`:

| Material | With VAD | Without VAD |
|---|---|---|
| French read speech, 10 min (LibriVox, Wikisource reference) | WER 7.11%, 6 deletions | WER 7.26%, 2 deletions |
| JFK inaugural, 15 min English (Wikisource reference) | WER 4.84% | WER 4.62% |
| Film clip, 8 min sparse dialogue + music | 52 cues / 209 words | 82 cues / 349 words |
| Speech + 60 s silence + 60 s pink noise | clean | hallucination loop over the noise |
| 40-min file, no VAD | — | 563 cues, ran to the end |

VAD costs a lot of real dialogue on film-style audio and clips line onsets, but turning it off can invent lines over long non-speech stretches — hence an opt-out rather than a changed default.

Verified end-to-end with the reporter's exact parameter string (`--max-len 55 --split-on-punct --chunk-seconds 30 --frequency-penalty 0.5`): zero VAD lines in the crispasr log, full transcript.

Docs: new "Voice activity detection with Crisp ASR Cohere and Mega" section in `docs/features/speech-to-text.md`. No UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)