### PR TITLE
Stop a stalled Ubuntu mirror from parking the release build

### DIFF
--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -55,10 +55,30 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      # The Ubuntu archive can stall mid-fetch on GitHub runners: the runner's
+      # mirrorlist fails over from azure.archive.ubuntu.com to archive.ubuntu.com,
+      # and a fallback connection that dies after the response headers never trips
+      # apt's inactivity timeout. On the first v5.2.0-beta18 release run both
+      # flatpak jobs sat on a single "Get: noble-security InRelease" for 39 minutes
+      # (until cancelled) while every other build was already green - and with no
+      # job timeout set, that would have parked the release for up to 6 hours.
+      # Bound each apt call and retry instead of hanging.
       - name: Install flatpak
+        timeout-minutes: 12
         run: |
-          sudo apt-get update
-          sudo apt-get install -y flatpak
+          apt_opts="-o Acquire::Retries=3 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20"
+          for attempt in 1 2 3; do
+            if sudo timeout 180 apt-get update $apt_opts && \
+               sudo timeout 180 apt-get install -y $apt_opts flatpak; then
+              exit 0
+            fi
+            echo "::warning::apt stalled or failed (attempt $attempt/3)"
+            # A killed apt can leave dpkg half-configured; clear it before retrying.
+            sudo dpkg --configure -a || true
+            sleep 15
+          done
+          echo "::error::Could not install flatpak from the Ubuntu archive after 3 attempts"
+          exit 1
 
       # Cache the Freedesktop SDK + dotnet extension so we don't re-download
       # ~6 GB of runtimes on every CI run. Bump the key suffix (-vN) to invalidate.
@@ -159,10 +179,30 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      # The Ubuntu archive can stall mid-fetch on GitHub runners: the runner's
+      # mirrorlist fails over from azure.archive.ubuntu.com to archive.ubuntu.com,
+      # and a fallback connection that dies after the response headers never trips
+      # apt's inactivity timeout. On the first v5.2.0-beta18 release run both
+      # flatpak jobs sat on a single "Get: noble-security InRelease" for 39 minutes
+      # (until cancelled) while every other build was already green - and with no
+      # job timeout set, that would have parked the release for up to 6 hours.
+      # Bound each apt call and retry instead of hanging.
       - name: Install flatpak
+        timeout-minutes: 12
         run: |
-          sudo apt-get update
-          sudo apt-get install -y flatpak
+          apt_opts="-o Acquire::Retries=3 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20"
+          for attempt in 1 2 3; do
+            if sudo timeout 180 apt-get update $apt_opts && \
+               sudo timeout 180 apt-get install -y $apt_opts flatpak; then
+              exit 0
+            fi
+            echo "::warning::apt stalled or failed (attempt $attempt/3)"
+            # A killed apt can leave dpkg half-configured; clear it before retrying.
+            sudo dpkg --configure -a || true
+            sleep 15
+          done
+          echo "::error::Could not install flatpak from the Ubuntu archive after 3 attempts"
+          exit 1
 
       - name: Cache flatpak runtimes
         id: flatpak-cache


### PR DESCRIPTION
The first `v5.2.0-beta18` release run ([32224966475](https://github.com/SubtitleEdit/subtitleedit/actions/runs/32224966475)) had Windows, both macOS builds and Linux green within ~10 minutes, then sat for 39 minutes with both flatpak jobs stuck in "Install flatpak" — until I cancelled it.

The log ends here, with nothing after it:

```
06:49:12  Get:4 https://archive.ubuntu.com/ubuntu noble-backports InRelease [126 kB]
06:49:12  Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
07:28:20  ##[error]The operation was canceled.
```

The runner's mirrorlist had already failed over (`Ign: http://azure.archive.ubuntu.com/...` ×4 rounds) to `archive.ubuntu.com`, and that connection died *after* the response headers — apt had printed the size, so it never went fully idle and the inactivity timeout never fired. Neither the step nor the job set `timeout-minutes`, so this would have held the release for GitHub's 6-hour default. For scale: the same step took 11–47 s in the beta16 and beta17 release runs.

**Change** (identical in both `regenerate-flatpak-nuget-sources` and `regenerate-flathub-nuget-sources`):

- `sudo timeout 180 apt-get …` — `timeout` runs as root so the signal reaches apt itself, not sudo.
- Explicit `Acquire::Retries=3` and 20 s http/https timeouts.
- Up to 3 attempts, with `dpkg --configure -a` between them in case a killed apt left dpkg half-configured.
- `timeout-minutes: 12` on the step, so any remaining hang fails the job in bounded time instead of the default 6 hours.

No mirror rewriting: the fallback host was already the second choice, so forcing either one is not the fix — bounding the wait is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)