### PR TITLE
Fix Delete key after a shift+click range selection that scrolled

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -24965,6 +24965,11 @@ public partial class MainViewModel :
     internal void ApplyDragSelectRange(int anchorIndex, int currentIndex)
     {
         SelectGridRange(Math.Min(anchorIndex, currentIndex), Math.Max(anchorIndex, currentIndex), currentIndex);
+
+        // Auto-scrolling a long drag can unrealize the row that had focus when the drag started,
+        // dropping keyboard focus out of the grid and disabling its shortcuts (#13864).
+        Dispatcher.UIThread.Post(() => TableViewExtras.FocusRow(SubtitleGrid));
+
         SubtitleGridSelectionChanged();
     }
 
@@ -25022,6 +25027,15 @@ public partial class MainViewModel :
                     SelectGridRange(Math.Min(anchor, rowIndex), Math.Max(anchor, rowIndex), rowIndex);
 
                     SubtitleGrid.ScrollIntoView(Subtitles[rowIndex]);
+
+                    // Handling the press ourselves means the TableView never focuses the clicked
+                    // row, so keyboard focus stays on whatever it was - and if the grid was
+                    // scrolled since, that container is unrealized and focus has already been
+                    // dropped out of the grid, which kills every SubtitleGrid shortcut (Delete
+                    // did nothing after a shift+click range that involved scrolling, #13864).
+                    // Same re-focus the shift+arrow path does after layout.
+                    Dispatcher.UIThread.Post(() => TableViewExtras.FocusRow(SubtitleGrid));
+
                     SubtitleGridSelectionChanged();
                     e.Handled = true;
                     return;


### PR DESCRIPTION
Fixes #13864

### The bug

Select a line, scroll the grid, then shift+click another line: the range selects correctly but the **Delete** key does nothing. Delete from the context menu works on the same selection, and shift+arrow range selection (even when it scrolls) works fine.

### Cause

`DeleteSelectedLinesCommand` is bound to bare `Delete` in `ShortcutCategory.SubtitleGrid`, and grid-category shortcuts are only dispatched inside `if (IsSubtitleGridFocused())`.

The first plain click leaves keyboard focus on that row's `TableViewRow` container. Scrolling far enough unrealizes that container, so focus is detached and dropped out of the grid. The shift+click branch in `SubtitleGrid_PointerPressed` then sets `e.Handled = true` — the TableView never gets to focus the clicked row — so focus stays nowhere and every grid shortcut is swallowed. The context menu still worked because it invokes the command directly, with no focus gate.

`HandleShiftArrowSelection` already guards against exactly this (its `TableViewExtras.FocusRow` post, added for shift+Home/End/PageUp/PageDown), which is why the keyboard path was unaffected.

### Fix

Re-focus the moving end of the selection after layout in the shift+click path, mirroring the shift+arrow path. `FocusRow` falls back to focusing the `TableView` itself when the container isn't realized, so focus can never be left stranded.

The same latent bug is fixed in `ApplyDragSelectRange`: a drag-select whose auto-scroll runs past the viewport unrealizes the initially focused row in exactly the same way, so Delete died after a long drag-select too.

Introduced by the DataGrid → TableView conversion (51c6d8ed5), matching the beta17/beta18 reports.

### Testing

Builds clean. Behavior needs a manual check in the app: click a line, scroll down, shift+click a later line, press Delete — the confirm dialog should appear; likewise after a drag-select that auto-scrolls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
