### PR TITLE
Fix #13865: stop the batch-convert llama-server, and let users own the launch flags

### DIFF
--- a/src/libuilogic/LlamaCpp/LlamaCppServerManager.cs
+++ b/src/libuilogic/LlamaCpp/LlamaCppServerManager.cs
@@ -303,6 +303,7 @@ public static class LlamaCppServerManager
     private static string? _serverModelPath;
     private static int _serverContextSize;
     private static string _serverExtraArguments = string.Empty;
+    private static bool _serverExtraArgumentsOnly;
     private static bool _processExitHooked;
     private static readonly StringBuilder _serverLog = new();
 
@@ -555,11 +556,18 @@ public static class LlamaCppServerManager
     /// </summary>
     public const int DefaultContextSize = 8192;
 
-    public static async Task EnsureServerRunningAsync(LlamaCppModel model, CancellationToken cancellationToken, int contextSize = DefaultContextSize, string? extraArguments = null)
+    /// <param name="extraArgumentsOnly">
+    /// Launches llama-server with <paramref name="extraArguments"/> instead of SE's curated flags
+    /// (-ngl/-c/-np/--swa-full/--cache-reuse and the chat-template pair), for users who want full
+    /// control over the server configuration. The model, host and port are always passed - SE has
+    /// to know which model it is talking to and where. (#13865)
+    /// </param>
+    public static async Task EnsureServerRunningAsync(LlamaCppModel model, CancellationToken cancellationToken, int contextSize = DefaultContextSize, string? extraArguments = null, bool extraArgumentsOnly = false)
     {
         var extraArgs = extraArguments?.Trim() ?? string.Empty;
+        var argsOnly = extraArgumentsOnly && extraArgs.Length > 0;
         var modelPath = GetModelPath(model.FileName);
-        if (IsServerRunning && _serverModelPath == modelPath && _serverContextSize == contextSize && _serverExtraArguments == extraArgs)
+        if (IsRunningWith(modelPath, contextSize, extraArgs, argsOnly))
         {
             Configuration.Settings.Tools.LlamaCppApiUrl = ApiUrl;
             return;
@@ -568,7 +576,7 @@ public static class LlamaCppServerManager
         await ServerLock.WaitAsync(cancellationToken);
         try
         {
-            if (IsServerRunning && _serverModelPath == modelPath && _serverContextSize == contextSize && _serverExtraArguments == extraArgs)
+            if (IsRunningWith(modelPath, contextSize, extraArgs, argsOnly))
             {
                 Configuration.Settings.Tools.LlamaCppApiUrl = ApiUrl;
                 return;
@@ -611,53 +619,7 @@ public static class LlamaCppServerManager
                 RedirectStandardError = true,
                 RedirectStandardOutput = true,
             };
-            psi.ArgumentList.Add("-m");
-            psi.ArgumentList.Add(modelPath);
-            if (mmprojPath != null)
-            {
-                psi.ArgumentList.Add("--mmproj");
-                psi.ArgumentList.Add(mmprojPath);
-            }
-            psi.ArgumentList.Add("--host");
-            psi.ArgumentList.Add("127.0.0.1");
-            psi.ArgumentList.Add("--port");
-            psi.ArgumentList.Add(port.ToString(CultureInfo.InvariantCulture));
-            // Offload all layers to the GPU when a GPU build is in use; ignored by the CPU build.
-            psi.ArgumentList.Add("-ngl");
-            psi.ArgumentList.Add("99");
-            psi.ArgumentList.Add("-c");
-            psi.ArgumentList.Add(contextSize.ToString(CultureInfo.InvariantCulture));
-            // SE is the server's only client, but llama-server defaults to 4 parallel slots,
-            // which silently splits -c four ways (8192 became 2048 usable tokens per request).
-            psi.ArgumentList.Add("-np");
-            psi.ArgumentList.Add("1");
-            // Keep the full KV cache for sliding-window-attention models (Gemma, Qwen 3.5);
-            // without this their prompt cache only works on byte-identical requests and
-            // cache_prompt reuse is lost entirely. Costs some KV memory at these context sizes.
-            psi.ArgumentList.Add("--swa-full");
-            if (mmprojPath == null)
-            {
-                // Chunk-level KV-cache reuse after the first diverging token; together with the
-                // clients' cache_prompt this keeps repeated prompt prefixes (system prompt,
-                // rolling context) from being re-ingested every request. Auto-disables with a
-                // warning on models whose context cannot shift. Not combined with multimodal -
-                // vision chunks cannot be shifted.
-                psi.ArgumentList.Add("--cache-reuse");
-                psi.ArgumentList.Add("256");
-            }
-            if (model.NoJinja)
-            {
-                psi.ArgumentList.Add("--no-jinja");
-            }
-            if (model.ChatTemplate != null)
-            {
-                psi.ArgumentList.Add("--chat-template");
-                psi.ArgumentList.Add(model.ChatTemplate);
-            }
-
-            // User-supplied llama-server arguments last, so a repeated flag (e.g. -ngl, -c)
-            // overrides SE's value - llama-server applies later arguments over earlier ones.
-            foreach (var arg in SplitCommandLineArguments(extraArgs))
+            foreach (var arg in BuildServerArguments(model, modelPath, mmprojPath, port, contextSize, extraArgs, argsOnly))
             {
                 psi.ArgumentList.Add(arg);
             }
@@ -694,6 +656,7 @@ public static class LlamaCppServerManager
             _serverModelPath = modelPath;
             _serverContextSize = contextSize;
             _serverExtraArguments = extraArgs;
+            _serverExtraArgumentsOnly = argsOnly;
             HookProcessExitOnce();
 
             var deadline = DateTime.UtcNow.AddMinutes(5);
@@ -728,6 +691,88 @@ public static class LlamaCppServerManager
         {
             ServerLock.Release();
         }
+    }
+
+    /// <summary>
+    /// The llama-server command line for one launch. The model, host and port are always ours -
+    /// SE has to know which model it is talking to and where - and the user's own arguments always
+    /// come last, so a repeated flag (e.g. -ngl, -c) overrides SE's value: llama-server applies
+    /// later arguments over earlier ones. <paramref name="argsOnly"/> drops SE's curated tuning
+    /// altogether, for users who want full control; without it a bare switch such as --swa-full
+    /// cannot be turned off at all, since there is nothing to repeat with a different value (#13865).
+    /// </summary>
+    internal static List<string> BuildServerArguments(
+        LlamaCppModel model,
+        string modelPath,
+        string? mmprojPath,
+        int port,
+        int contextSize,
+        string extraArgs,
+        bool argsOnly)
+    {
+        var args = new List<string> { "-m", modelPath };
+        if (mmprojPath != null)
+        {
+            args.Add("--mmproj");
+            args.Add(mmprojPath);
+        }
+
+        args.Add("--host");
+        args.Add("127.0.0.1");
+        args.Add("--port");
+        args.Add(port.ToString(CultureInfo.InvariantCulture));
+
+        if (!argsOnly)
+        {
+            // Offload all layers to the GPU when a GPU build is in use; ignored by the CPU build.
+            args.Add("-ngl");
+            args.Add("99");
+            args.Add("-c");
+            args.Add(contextSize.ToString(CultureInfo.InvariantCulture));
+            // SE is the server's only client, but llama-server defaults to 4 parallel slots,
+            // which silently splits -c four ways (8192 became 2048 usable tokens per request).
+            args.Add("-np");
+            args.Add("1");
+            // Keep the full KV cache for sliding-window-attention models (Gemma, Qwen 3.5);
+            // without this their prompt cache only works on byte-identical requests and
+            // cache_prompt reuse is lost entirely. Costs some KV memory at these context sizes.
+            args.Add("--swa-full");
+            if (mmprojPath == null)
+            {
+                // Chunk-level KV-cache reuse after the first diverging token; together with the
+                // clients' cache_prompt this keeps repeated prompt prefixes (system prompt,
+                // rolling context) from being re-ingested every request. Auto-disables with a
+                // warning on models whose context cannot shift. Not combined with multimodal -
+                // vision chunks cannot be shifted.
+                args.Add("--cache-reuse");
+                args.Add("256");
+            }
+
+            if (model.NoJinja)
+            {
+                args.Add("--no-jinja");
+            }
+
+            if (model.ChatTemplate != null)
+            {
+                args.Add("--chat-template");
+                args.Add(model.ChatTemplate);
+            }
+        }
+
+        args.AddRange(SplitCommandLineArguments(extraArgs));
+        return args;
+    }
+
+    private static bool IsRunningWith(string modelPath, int contextSize, string extraArgs, bool argsOnly)
+    {
+        return IsServerRunning &&
+               _serverModelPath == modelPath &&
+               _serverExtraArguments == extraArgs &&
+               _serverExtraArgumentsOnly == argsOnly &&
+               // With SE's flags suppressed the context size comes from the user's own arguments
+               // (or the server default), so the requested value says nothing about the running one.
+               (argsOnly || _serverContextSize == contextSize);
     }
 
     public static void StopServer()

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -2539,6 +2539,8 @@
     "serverContextSizeTokens": "Server context size (tokens)",
     "extraServerParameters": "Extra server parameters",
     "extraServerParametersHint": "Additional llama-server command-line arguments, e.g. \"-ngl 30 --no-mmap\" - applied when the local server starts",
+    "useOnlyExtraServerParameters": "Use only these parameters",
+    "useOnlyExtraServerParametersHint": "Start llama-server with the parameters above instead of Subtitle Edit's own tuning - only the model, host and port are still set",
     "serverRunningAtX": "Server running at {0}",
     "customPromptHint": "Custom instructions ({0} = source language, {1} = target language); empty = built-in prompt",
     "llamaCppDownloadEngineAndModelPrompt": "llama.cpp requires the llama-server engine and a translation model to be downloaded. Download now?",

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -293,6 +293,11 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
     private readonly IBatchConvertItemSplitter _batchConvertItemSplitter;
     private CancellationToken _cancellationToken;
     private CancellationTokenSource _cancellationTokenSource;
+
+    // True once a batch run in this window has put the SE-managed llama-server to work - the
+    // llama.cpp translate engines in local-server mode, or the llama.cpp OCR engine. Gates the
+    // shutdown so a cancel never kills a server this window did not start. (#13865)
+    private bool _usesLocalLlamaCppServer;
     private CancellationTokenSource _addFilesCancellationTokenSource = new();
     private CancellationTokenSource? _statusClearCts; // supersedes the pending status-clear timer
     private List<string> _encodings;
@@ -515,6 +520,46 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
     {
         _isClosing = true;
         _filesTimer.StopAndDispose(FilesTimerElapsed);
+
+        // A batch left running after its window is gone keeps writing files with no UI to show it
+        // (and would restart the llama-server we are about to kill), so stop it first. (#13865)
+        _cancellationTokenSource.Cancel();
+        _addFilesCancellationTokenSource.Cancel();
+        StopLocalLlamaCppServer();
+    }
+
+    /// <summary>
+    /// Kills the SE-managed llama-server when a batch run is cancelled or this window closes, so
+    /// the model's RAM/VRAM is released right away instead of only at app exit. The Auto-translate
+    /// window keeps a finished run's server warm because it has a stop button and shows the server
+    /// state; the batch window has neither, so a server left behind here is invisible and
+    /// unstoppable (#13865). The next run auto-restarts it.
+    /// </summary>
+    private void StopLocalLlamaCppServer()
+    {
+        if (!_usesLocalLlamaCppServer || !LlamaCppServerManager.IsServerRunning)
+        {
+            return;
+        }
+
+        // Off the UI thread - StopServer kills the process and waits up to 2 s for it to exit.
+        _ = Task.Run(LlamaCppServerManager.StopServer);
+    }
+
+    /// <summary>
+    /// True when <paramref name="config"/> drives the local (SE-managed) llama-server: the
+    /// llama.cpp translate engines unless the user pointed them at their own server, or the
+    /// llama.cpp OCR engine - which always runs locally.
+    /// </summary>
+    private static bool UsesLocalLlamaCppServer(BatchConvertConfig config)
+    {
+        var translate = config.AutoTranslate.IsActive &&
+                        config.AutoTranslate.Translator is LlamaCppTranslate or LlamaCppAdvancedTranslate &&
+                        !Se.Settings.AutoTranslate.LlamaCppUseRemoteServer;
+
+        var ocr = string.Equals(Se.Settings.Tools.BatchConvert.OcrEngine, "llama.cpp", StringComparison.OrdinalIgnoreCase);
+
+        return translate || ocr;
     }
 
     private void UpdateFilteredFiles()
@@ -1021,6 +1066,7 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
     private void Cancel()
     {
         _cancellationTokenSource.Cancel();
+        StopLocalLlamaCppServer();
         IsConverting = false;
         foreach (var batchItem in BatchItems)
         {
@@ -1055,6 +1101,10 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         SaveSettings();
 
         var config = MakeBatchConvertConfig();
+
+        // Set before the ensure-chain below: starting the server is itself the slow part a user
+        // cancels out of, and the shutdown has to know the run owns it by then. (#13865)
+        _usesLocalLlamaCppServer |= UsesLocalLlamaCppServer(config);
 
         if (!await EnsureTranslateApiKeyPresent(config))
         {
@@ -1401,16 +1451,11 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
             return true;
         }
 
-        // Auto-detect: reuse an already-running local server - but not one started with a smaller
-        // context than the selected engine needs (say the advanced engine after an OCR run, or after
-        // the regular engine started the server at the default size). Falling through restarts it
-        // with the right context instead of silently translating in a too-small window.
+        // A server that is already running is reused by EnsureServerRunningAsync below, but only
+        // when its model, context size and launch arguments match what this run asks for. Deciding
+        // that here (as "any running server with a big enough context") reused a server started for
+        // OCR, or one still running with the arguments from before the user edited them (#13865).
         var contextSize = GetLlamaCppContextSize(config.AutoTranslate.Translator);
-        if (LlamaCppServerManager.IsServerRunning && LlamaCppServerManager.RunningContextSize >= contextSize)
-        {
-            Configuration.Settings.Tools.LlamaCppApiUrl = LlamaCppServerManager.ApiUrl;
-            return true;
-        }
 
         // Pick the last-used model, else the first available translate model.
         var models = LlamaCppServerManager.GetAllTranslateModels();
@@ -1436,10 +1481,10 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         // Auto-start the local server - this points Configuration.Settings.Tools.LlamaCppApiUrl at it.
         try
         {
-            var extraArguments = config.AutoTranslate.Translator is LlamaCppAdvancedTranslate
-                ? Se.Settings.AutoTranslate.LlamaCppAdvanced.ServerArguments
-                : null;
-            await LlamaCppServerManager.EnsureServerRunningAsync(model, _cancellationToken, contextSize, extraArguments);
+            var isAdvanced = config.AutoTranslate.Translator is LlamaCppAdvancedTranslate;
+            var extraArguments = isAdvanced ? Se.Settings.AutoTranslate.LlamaCppAdvanced.ServerArguments : null;
+            var extraArgumentsOnly = isAdvanced && Se.Settings.AutoTranslate.LlamaCppAdvanced.ServerArgumentsOnly;
+            await LlamaCppServerManager.EnsureServerRunningAsync(model, _cancellationToken, contextSize, extraArguments, extraArgumentsOnly);
         }
         catch (Exception ex)
         {
@@ -1669,6 +1714,7 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
     private void CancelConvert()
     {
         _cancellationTokenSource.Cancel();
+        StopLocalLlamaCppServer();
         IsConverting = false;
     }
 

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -1162,7 +1162,8 @@ public partial class AutoTranslateViewModel : ObservableObject
                 ? Math.Clamp(Se.Settings.AutoTranslate.LlamaCppAdvanced.ContextSize, 2048, 262144)
                 : LlamaCppServerManager.DefaultContextSize;
             var extraArguments = isAdvanced ? Se.Settings.AutoTranslate.LlamaCppAdvanced.ServerArguments : null;
-            await LlamaCppServerManager.EnsureServerRunningAsync(model, _cancellationTokenSource.Token, contextSize, extraArguments);
+            var extraArgumentsOnly = isAdvanced && Se.Settings.AutoTranslate.LlamaCppAdvanced.ServerArgumentsOnly;
+            await LlamaCppServerManager.EnsureServerRunningAsync(model, _cancellationTokenSource.Token, contextSize, extraArguments, extraArgumentsOnly);
         }
         catch (Exception ex)
         {

--- a/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedSettingsViewModel.cs
+++ b/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedSettingsViewModel.cs
@@ -30,6 +30,7 @@ public partial class LlamaCppAdvancedSettingsViewModel : ObservableObject
     [ObservableProperty] private int _maxTokens;
     [ObservableProperty] private int _contextSize;
     [ObservableProperty] private string _serverArguments = string.Empty;
+    [ObservableProperty] private bool _serverArgumentsOnly;
 
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }
@@ -59,6 +60,7 @@ public partial class LlamaCppAdvancedSettingsViewModel : ObservableObject
         MaxTokens = settings.MaxTokens;
         ContextSize = settings.ContextSize;
         ServerArguments = settings.ServerArguments;
+        ServerArgumentsOnly = settings.ServerArgumentsOnly;
     }
 
     [RelayCommand]
@@ -79,6 +81,7 @@ public partial class LlamaCppAdvancedSettingsViewModel : ObservableObject
         settings.MaxTokens = MaxTokens;
         settings.ContextSize = Math.Clamp(ContextSize, 2048, 262144);
         settings.ServerArguments = ServerArguments?.Trim() ?? string.Empty;
+        settings.ServerArgumentsOnly = ServerArgumentsOnly;
         Se.SaveSettings();
 
         OkPressed = true;

--- a/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedSettingsWindow.cs
+++ b/src/ui/Features/Translate/LlamaCppAdvanced/LlamaCppAdvancedSettingsWindow.cs
@@ -146,7 +146,7 @@ public class LlamaCppAdvancedSettingsWindow : Window
             ColumnSpacing = 12,
             RowSpacing = 10,
         };
-        for (var i = 0; i < 6; i++)
+        for (var i = 0; i < 7; i++)
         {
             grid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) });
         }
@@ -189,6 +189,13 @@ public class LlamaCppAdvancedSettingsWindow : Window
         grid.Add(MakeSmallLabel(Se.Language.Translate.ExtraServerParameters), 5, 0);
         grid.Add(serverArguments, 5, 1);
         Grid.SetColumnSpan(serverArguments, 3);
+
+        // Opt out of SE's own launch flags entirely (#13865): appending user arguments last already
+        // overrides anything that takes a value, but a bare switch like --swa-full cannot be undone.
+        var serverArgumentsOnly = UiUtil.MakeCheckBox(Se.Language.Translate.UseOnlyExtraServerParameters, vm, nameof(vm.ServerArgumentsOnly));
+        SetHint(serverArgumentsOnly, Se.Language.Translate.UseOnlyExtraServerParametersHint);
+        grid.Add(serverArgumentsOnly, 6, 1);
+        Grid.SetColumnSpan(serverArgumentsOnly, 3);
 
         return grid;
     }

--- a/src/ui/Logic/Config/Language/Translate/LanguageTranslate.cs
+++ b/src/ui/Logic/Config/Language/Translate/LanguageTranslate.cs
@@ -51,6 +51,8 @@ public class LanguageTranslate
     public string ServerContextSizeTokens { get; set; }
     public string ExtraServerParameters { get; set; }
     public string ExtraServerParametersHint { get; set; }
+    public string UseOnlyExtraServerParameters { get; set; }
+    public string UseOnlyExtraServerParametersHint { get; set; }
     public string ServerRunningAtX { get; set; }
     public string CustomPromptHint { get; set; }
     public string LlamaCppDownloadEngineAndModelPrompt { get; set; }
@@ -108,6 +110,8 @@ public class LanguageTranslate
         ServerContextSizeTokens = "Server context size (tokens)";
         ExtraServerParameters = "Extra server parameters";
         ExtraServerParametersHint = "Additional llama-server command-line arguments, e.g. \"-ngl 30 --no-mmap\" - applied when the local server starts";
+        UseOnlyExtraServerParameters = "Use only these parameters";
+        UseOnlyExtraServerParametersHint = "Start llama-server with the parameters above instead of Subtitle Edit's own tuning - only the model, host and port are still set";
         ServerRunningAtX = "Server running at {0}";
         CustomPromptHint = "Custom instructions ({0} = source language, {1} = target language); empty = built-in prompt";
         LlamaCppDownloadEngineAndModelPrompt = "llama.cpp requires the llama-server engine and a translation model to be downloaded. Download now?";

--- a/src/ui/Logic/Config/SeLlamaCppAdvanced.cs
+++ b/src/ui/Logic/Config/SeLlamaCppAdvanced.cs
@@ -25,6 +25,11 @@ public class SeLlamaCppAdvanced
     // (e.g. -ngl) overrides SE's value. Local server mode only (#13830).
     public string ServerArguments { get; set; } = string.Empty;
 
+    // Launch llama-server with ServerArguments instead of SE's curated flags (-ngl/-c/-np/
+    // --swa-full/--cache-reuse and the chat-template pair). Only the model, host and port are
+    // still set by SE. Ignored while ServerArguments is empty. (#13865)
+    public bool ServerArgumentsOnly { get; set; }
+
     public const string FormalityDefault = "Default";
     public const string FormalityFormal = "Formal";
     public const string FormalityInformal = "Informal";

--- a/tests/libuilogic/AutoTranslate/LlamaCppServerArgumentsTests.cs
+++ b/tests/libuilogic/AutoTranslate/LlamaCppServerArgumentsTests.cs
@@ -1,0 +1,75 @@
+using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LibUiLogicTests.AutoTranslate;
+
+/// <summary>
+/// The llama-server launch line: SE's curated tuning, the user's own arguments, and the
+/// "use only these parameters" opt-out from #13865.
+/// </summary>
+public class LlamaCppServerArgumentsTests
+{
+    private static readonly LlamaCppModel PlainModel = new("Test", "test.gguf", "1 GB", "https://example.com/test.gguf");
+
+    private static readonly LlamaCppModel ChatTemplateModel = new(
+        "Test chatml", "test-chatml.gguf", "1 GB", "https://example.com/test-chatml.gguf",
+        ChatTemplate: "chatml", NoJinja: true);
+
+    private static List<string> Build(LlamaCppModel model, string extraArgs, bool argsOnly, string? mmprojPath = null)
+    {
+        return LlamaCppServerManager.BuildServerArguments(model, "/models/test.gguf", mmprojPath, 1234, 8192, extraArgs, argsOnly);
+    }
+
+    [Fact]
+    public void Default_AddsCuratedFlagsAndUserArgumentsLast()
+    {
+        var args = Build(ChatTemplateModel, "-ngl 30 --no-mmap", argsOnly: false);
+
+        Assert.Equal("99", args[args.IndexOf("-ngl") + 1]);
+        Assert.Contains("--swa-full", args);
+        Assert.Contains("--cache-reuse", args);
+        Assert.Contains("--no-jinja", args);
+        Assert.Contains("--chat-template", args);
+
+        // llama-server applies later arguments over earlier ones, so the user's -ngl must come
+        // after SE's - that is what makes a repeated flag an override.
+        Assert.True(args.LastIndexOf("-ngl") > args.IndexOf("-ngl"));
+        Assert.Equal(new[] { "-ngl", "30", "--no-mmap" }, args.TakeLast(3));
+    }
+
+    [Fact]
+    public void ArgumentsOnly_DropsCuratedFlagsButKeepsModelHostAndPort()
+    {
+        var args = Build(ChatTemplateModel, "-ngl 30 --jinja", argsOnly: true);
+
+        Assert.Equal(
+            new[] { "-m", "/models/test.gguf", "--host", "127.0.0.1", "--port", "1234", "-ngl", "30", "--jinja" },
+            args);
+    }
+
+    [Fact]
+    public void ArgumentsOnly_KeepsTheVisionProjector()
+    {
+        var args = Build(PlainModel, "-ngl 0", argsOnly: true, mmprojPath: "/models/mmproj.gguf");
+
+        Assert.Equal(new[] { "--mmproj", "/models/mmproj.gguf" }, args.Skip(2).Take(2));
+        Assert.DoesNotContain("--swa-full", args);
+    }
+
+    [Fact]
+    public void Multimodal_SkipsCacheReuse()
+    {
+        var args = Build(PlainModel, string.Empty, argsOnly: false, mmprojPath: "/models/mmproj.gguf");
+
+        Assert.DoesNotContain("--cache-reuse", args);
+    }
+
+    [Fact]
+    public void QuotedUserArgument_SurvivesAsOneArgument()
+    {
+        var args = Build(PlainModel, "--override-kv \"key=str:some value\"", argsOnly: false);
+
+        Assert.Equal(new[] { "--override-kv", "key=str:some value" }, args.TakeLast(2));
+    }
+}


### PR DESCRIPTION
Fixes the second and third problem reported in #13865. The first one (batch convert unresponsive after minimize/restore) is still being investigated and is not part of this PR.

## llama-server survived a cancelled batch run - and the batch window itself

Batch convert only cancelled its token; nothing ever stopped the server, so the process stayed alive holding its model in RAM/VRAM until the app exited. The Auto-translate window got an after-cancel shutdown in #13830 - this ports it to batch convert, which needs it more: it shows no server state and has no stop button, so a server left behind there is invisible and unreachable.

- `Cancel`, `CancelConvert` and `OnClosingCleanup` now stop the server, gated on a flag so a cancel only ever kills a server *this window's* run put to work (llama.cpp translate in local-server mode, or the llama.cpp OCR engine). The flag is set before the ensure-chain, since a slow server start is exactly what users cancel out of.
- Closing the window also cancels a still-running batch. It was writing files with no UI to show for it, and it would have restarted the server we just killed.

Behaviour note: unlike Auto-translate, batch convert does not keep a finished run's server warm - the next run restarts it.

## Custom parameters could not fully replace SE's own

User arguments are appended last, so anything that takes a value (`-ngl`, `-c`, `-np`, `--chat-template`, ...) was already overridable. A bare switch such as `--swa-full` is not: there is nothing to repeat with a different value. So the advanced settings get a **"Use only these parameters"** checkbox next to the existing parameters box - SE then passes only the model, host and port (it has to know what it is talking to and where) plus the user's arguments.

Also fixed: batch convert reused any running server with a big enough context, without checking the model or the arguments. An edited parameter, or a server started earlier for OCR with a vision model, was silently kept. It now goes through `EnsureServerRunningAsync` like the Auto-translate window does, which restarts on a mismatch. One consequence: reuse needs an exact context-size match, so switching between the regular (8192) and advanced (16384) engines reloads the model - already how Auto-translate behaves.

## Tests

The launch line moved out of `EnsureServerRunningAsync` into an internal `BuildServerArguments`, covered by 5 new tests - including that the user's `-ngl` still lands after SE's in normal mode, that args-only keeps the vision projector, and that a quoted value survives as one argument.

Build clean; UI tests 3207 passed, libuilogic 251 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)