### PR TITLE
Read Netflix IMSC 1.1 Japanese properly and render it for the video

### DIFF
--- a/src/libse/Common/NetflixImsc11JapaneseToAss.cs
+++ b/src/libse/Common/NetflixImsc11JapaneseToAss.cs
@@ -1,0 +1,636 @@
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace Nikse.SubtitleEdit.Core.Common
+{
+    /// <summary>
+    /// Renders the Japanese profile markup Subtitle Edit uses for "Netflix IMSC 1.1 Japanese"
+    /// (&lt;ruby-*&gt;, &lt;bouten-*&gt;, &lt;horizontalDigit&gt;) as ASSA that libass can actually draw.
+    /// libass knows nothing about ruby, emphasis marks or vertical writing, so each cue is exploded
+    /// into several absolutely positioned render lines: the text itself, plus one line per furigana
+    /// or bouten run placed above (horizontal) or beside (vertical) the character it belongs to.
+    /// The horizontal offset of those extra lines is not measured - the preceding text is repeated
+    /// at {\alpha&amp;FF&amp;} so libass advances the pen itself and the mark lands over the right glyph.
+    ///
+    /// Without this the tags reach libass verbatim and get drawn as literal text (issue #13861).
+    /// Ported from Subtitle Edit 4, with the GDI+ text measuring replaced by a font independent
+    /// estimate and the hard coded 720p metrics scaled to the video size.
+    /// </summary>
+    public static class NetflixImsc11JapaneseToAss
+    {
+        private static string BoutenTagToUnicode(string tag)
+        {
+            switch (tag)
+            {
+                case "bouten-dot-before":
+                case "bouten-dot-after":
+                case "bouten-dot-outside":
+                    return "•";
+                case "bouten-filled-circle-outside":
+                    return "●";
+                case "bouten-open-circle-outside":
+                    return "○";
+                case "bouten-open-dot-outside":
+                    return "◦";
+                case "bouten-filled-sesame-outside":
+                    return "﹅";
+                case "bouten-open-sesame-outside":
+                    return "﹆";
+                case "bouten-auto-outside":
+                case "bouten-auto":
+                    return "﹅";
+                default:
+                    return " ";
+            }
+        }
+
+        /// <summary>
+        /// Subtitle Edit 4's layout constants were eyeballed against 720p with a 40 pixel font;
+        /// keeping that ratio reproduces them exactly at 720p and scales everywhere else.
+        /// </summary>
+        private sealed class Metrics
+        {
+            internal Metrics(int height)
+            {
+                FontSize = Math.Max(20, (int)Math.Round(height / 18.0));
+                RubyFontSize = Math.Max(10, FontSize / 2);
+            }
+
+            internal int FontSize { get; }
+            internal int RubyFontSize { get; }
+
+            /// <summary>Scales a value that was tuned against a 40 pixel font.</summary>
+            internal int Scale(double valueAtFontSize40) => (int)Math.Round(valueAtFontSize40 * FontSize / 40.0);
+
+            internal int LineHeight => Scale(34);
+        }
+
+        /// <summary>
+        /// Japanese text is almost entirely full width, so a character class estimate beats measuring
+        /// with whatever font happens to be installed - and never returns zero for missing CJK glyphs.
+        /// </summary>
+        private static double EstimateTextWidth(string text, int fontSize)
+        {
+            var width = 0.0;
+            foreach (var ch in text)
+            {
+                width += IsFullWidth(ch) ? fontSize : fontSize * 0.5;
+            }
+
+            return width;
+        }
+
+        private static bool IsFullWidth(char ch)
+        {
+            return ch >= 0x1100 && (
+                ch <= 0x115F || // Hangul Jamo
+                ch == 0x2329 || ch == 0x232A ||
+                ch >= 0x2E80 && ch <= 0xA4CF && ch != 0x303F || // CJK radicals, kana, CJK ideographs
+                ch >= 0xAC00 && ch <= 0xD7A3 || // Hangul syllables
+                ch >= 0xF900 && ch <= 0xFAFF || // CJK compatibility ideographs
+                ch >= 0xFE10 && ch <= 0xFE19 || // vertical forms
+                ch >= 0xFE30 && ch <= 0xFE6F || // CJK compatibility forms
+                ch >= 0xFF00 && ch <= 0xFF60 || // full width forms
+                ch >= 0xFFE0 && ch <= 0xFFE6);
+        }
+
+        public static List<Paragraph> SplitToAssRenderLines(Paragraph p, int width, int height)
+        {
+            var metrics = new Metrics(height);
+            if (p.Text.StartsWith("{\\an7}", StringComparison.Ordinal) || p.Text.StartsWith("{\\an9}", StringComparison.Ordinal)) // vertical text
+            {
+                return MakeVerticalParagraphs(p, width, metrics);
+            }
+
+            return MakeHorizontalParagraphs(p, width, height, metrics);
+        }
+
+        private static List<Paragraph> MakeHorizontalParagraphs(Paragraph p, int width, int height, Metrics metrics)
+        {
+            var lines = p.Text.SplitToLines();
+            var adjustment = metrics.LineHeight;
+
+            // Stack the rows upwards from a fixed bottom margin. Only a cue that actually carries
+            // furigana or bouten needs the second row per line - Subtitle Edit 4 reserved it either
+            // way and pushed the last line hard against the bottom edge of the video.
+            var hasMarkRow = p.Text.Contains("<ruby-", StringComparison.Ordinal) || p.Text.Contains("<bouten-", StringComparison.Ordinal);
+            var rowCount = lines.Count * (hasMarkRow ? 2 : 1);
+            var startY = height - metrics.Scale(30) - (rowCount - 1) * adjustment;
+            if (p.Text.StartsWith("{\\an8", StringComparison.Ordinal))
+            {
+                startY = metrics.Scale(40);
+            }
+
+            var list = new List<Paragraph>();
+            var furiganaList = new List<Paragraph>();
+            var rubyOn = false;
+            var italicOn = false;
+
+            // One left edge for the whole cue: the lines are laid out from it with {\an1}, which is
+            // what the region's multiRowAlign="start" asks for, and it keeps the furigana above a
+            // line aligned with the line itself. The block as a whole is centered on its widest line.
+            var blockWidth = 0.0;
+            foreach (var line in lines)
+            {
+                blockWidth = Math.Max(blockWidth, EstimateTextWidth(GetPlainRenderText(line), metrics.FontSize));
+            }
+
+            var startX = (int)Math.Round(width / 2.0 - blockWidth / 2.0);
+            if (startX < 0)
+            {
+                startX = 0;
+            }
+
+            if (p.Text.StartsWith("{\\an5", StringComparison.Ordinal))
+            {
+                startY = (int)Math.Round(height / 2.0 - metrics.FontSize / 2.0);
+            }
+
+            for (var index = 0; index < lines.Count; index++)
+            {
+                var line = lines[index];
+                if (italicOn)
+                {
+                    line = "<i>" + line;
+                }
+
+                var actual = new StringBuilder();
+                var i = 0;
+                while (i < line.Length)
+                {
+                    if (line.Substring(i).StartsWith("{\\", StringComparison.Ordinal))
+                    {
+                        var end = line.IndexOf('}', i);
+                        if (end < 0)
+                        {
+                            break;
+                        }
+
+                        i = end + 1;
+                    }
+                    else if (StartsWithAnyTag(line, i, "<i>", "<u>", "<b>"))
+                    {
+                        actual.Append("{\\i1}");
+                        i += 3;
+                        italicOn = true;
+                    }
+                    else if (StartsWithAnyTag(line, i, "</i>", "</u>", "</b>"))
+                    {
+                        actual.Append("{\\i0}");
+                        i += 4;
+                        italicOn = false;
+                    }
+                    else if (line.Substring(i).StartsWith("<bouten-", StringComparison.Ordinal))
+                    {
+                        var end = line.IndexOf('>', i);
+                        if (end < 0 || end + 1 >= line.Length)
+                        {
+                            break;
+                        }
+
+                        var endTagStart = line.IndexOf("</", end, StringComparison.Ordinal);
+                        if (endTagStart < 0)
+                        {
+                            break;
+                        }
+
+                        var tag = line.Substring(i + 1, end - i - 1);
+                        var text = line.Substring(end + 1, endTagStart - end - 1);
+
+                        foreach (var ch in text)
+                        {
+                            var furiganaChar = BoutenTagToUnicode(tag);
+                            if (!string.IsNullOrWhiteSpace(furiganaChar))
+                            {
+                                furiganaList.Add(new Paragraph($"{{\\alpha&FF&}}{actual}{{\\alpha&0&}}{furiganaChar}", p.StartTime.TotalMilliseconds, p.EndTime.TotalMilliseconds));
+                            }
+
+                            actual.Append(ch);
+                        }
+
+                        var endTagEnd = line.IndexOf('>', endTagStart);
+                        if (endTagEnd < 0)
+                        {
+                            break;
+                        }
+
+                        i = endTagEnd + 1;
+                    }
+                    else if (line.Substring(i).StartsWith("<ruby-container>", StringComparison.Ordinal))
+                    {
+                        if (!TryReadRuby(line, i, out var baseText, out var rubyText, out var rubyTextAfter, out var next))
+                        {
+                            break;
+                        }
+
+                        var preFurigana = string.Empty;
+                        if (actual.Length > 0)
+                        {
+                            preFurigana = $"{{\\alpha&FF&}}{actual.ToString().TrimEnd()}{{\\alpha&0&}}";
+                        }
+
+                        if (!string.IsNullOrWhiteSpace(rubyText))
+                        {
+                            furiganaList.Add(new Paragraph($"{preFurigana}{{\\fs{metrics.RubyFontSize}}}{rubyText}", p.StartTime.TotalMilliseconds, p.EndTime.TotalMilliseconds));
+                        }
+
+                        if (!string.IsNullOrWhiteSpace(rubyTextAfter))
+                        {
+                            furiganaList.Add(new Paragraph($"{preFurigana}{{\\fs{metrics.RubyFontSize}}} {rubyTextAfter}", p.StartTime.TotalMilliseconds, p.EndTime.TotalMilliseconds));
+                        }
+
+                        actual.Append(baseText);
+                        i = next;
+                        rubyOn = true;
+                    }
+                    else
+                    {
+                        actual.Append(line[i]);
+                        i++;
+                    }
+                }
+
+                var actualText = actual.ToString().TrimEnd();
+                var displayBefore = lines.Count == 2 && index == 0 || lines.Count == 1;
+                if (displayBefore && furiganaList.Count > 0)
+                {
+                    foreach (var fp in furiganaList)
+                    {
+                        list.Add(new Paragraph("{\\an1}{\\pos(" + startX + "," + startY + ")}" + fp.Text, p.StartTime.TotalMilliseconds, p.EndTime.TotalMilliseconds));
+                    }
+
+                    startY += adjustment;
+                    if (rubyOn && index == 0 && lines.Count == 2)
+                    {
+                        startY += metrics.Scale(3);
+                    }
+                }
+
+                actualText = "{\\an1}{\\pos(" + startX + "," + startY + ")}" + actualText;
+                list.Add(new Paragraph(actualText, p.StartTime.TotalMilliseconds, p.EndTime.TotalMilliseconds));
+                startY += adjustment;
+
+                if (!displayBefore && furiganaList.Count > 0)
+                {
+                    if (rubyOn && index == 1 && lines.Count == 2)
+                    {
+                        startY = (int)(startY - adjustment * 0.4);
+                    }
+
+                    foreach (var fp in furiganaList)
+                    {
+                        list.Add(new Paragraph("{\\an1}{\\pos(" + startX + "," + startY + ")}" + fp.Text, p.StartTime.TotalMilliseconds, p.EndTime.TotalMilliseconds));
+                    }
+
+                    startY += adjustment;
+                }
+
+                furiganaList.Clear();
+            }
+
+            return list;
+        }
+
+        private static List<Paragraph> MakeVerticalParagraphs(Paragraph p, int width, Metrics metrics)
+        {
+            var lines = p.Text.SplitToLines();
+            var adjustment = metrics.LineHeight;
+            var leftAlign = p.Text.StartsWith("{\\an7}", StringComparison.Ordinal);
+            var startX = leftAlign
+                ? metrics.Scale(9) + lines.Count * 2 * adjustment
+                : width - metrics.Scale(50);
+            var textY = metrics.Scale(40);
+            var furiganaY = metrics.Scale(45);
+
+            var pre = p.Text.Substring(0, 5);
+            var list = new List<Paragraph>();
+            var furiganaList = new List<Paragraph>();
+            var rubyOn = false;
+            var italicOn = false;
+            for (var index = 0; index < lines.Count; index++)
+            {
+                var line = lines[index];
+                var actual = new StringBuilder();
+                var i = 0;
+                if (italicOn)
+                {
+                    line = "<i>" + line;
+                }
+
+                while (i < line.Length)
+                {
+                    if (line.Substring(i).StartsWith("{\\", StringComparison.Ordinal))
+                    {
+                        var end = line.IndexOf('}', i);
+                        if (end < 0)
+                        {
+                            break;
+                        }
+
+                        i = end + 1;
+                    }
+                    else if (StartsWithAnyTag(line, i, "<i>", "<u>", "<b>"))
+                    {
+                        actual.Append("{\\i1}");
+                        i += 3;
+                        italicOn = true;
+                    }
+                    else if (StartsWithAnyTag(line, i, "</i>", "</u>", "</b>"))
+                    {
+                        actual.Append("{\\i0}");
+                        i += 4;
+                        italicOn = false;
+                    }
+                    else if (line.Substring(i).StartsWith("<horizontalDigit>", StringComparison.Ordinal))
+                    {
+                        // Tate-chu-yoko: the digits stay side by side inside the vertical column.
+                        var end = line.IndexOf('>', i);
+                        if (end < 0)
+                        {
+                            break;
+                        }
+
+                        var endTagStart = line.IndexOf("</", end, StringComparison.Ordinal);
+                        if (endTagStart < 0)
+                        {
+                            break;
+                        }
+
+                        actual.Append(line.Substring(end + 1, endTagStart - end - 1));
+                        actual.AppendLine();
+                        i = endTagStart + "</horizontalDigit>".Length;
+                    }
+                    else if (line.Substring(i).StartsWith("</horizontalDigit>", StringComparison.Ordinal))
+                    {
+                        i += "</horizontalDigit>".Length;
+                    }
+                    else if (line.Substring(i).StartsWith("<bouten-", StringComparison.Ordinal))
+                    {
+                        var end = line.IndexOf('>', i);
+                        if (end < 0 || end + 1 >= line.Length)
+                        {
+                            break;
+                        }
+
+                        var endTagStart = line.IndexOf("</", end, StringComparison.Ordinal);
+                        if (endTagStart < 0)
+                        {
+                            break;
+                        }
+
+                        var tag = line.Substring(i + 1, end - i - 1);
+                        var text = line.Substring(end + 1, endTagStart - end - 1);
+                        foreach (var ch in text)
+                        {
+                            var furiganaChar = BoutenTagToUnicode(tag);
+                            if (!string.IsNullOrWhiteSpace(furiganaChar))
+                            {
+                                var preFurigana = string.Empty;
+                                if (actual.Length > 0)
+                                {
+                                    preFurigana = $"{{\\alpha&FF&}}{actual}{{\\alpha&0&}}";
+                                }
+
+                                furiganaList.Add(new Paragraph($"{preFurigana}{furiganaChar}", p.StartTime.TotalMilliseconds, p.EndTime.TotalMilliseconds));
+                            }
+
+                            actual.Append(ch);
+                            actual.AppendLine();
+                        }
+
+                        var endTagEnd = line.IndexOf('>', endTagStart);
+                        if (endTagEnd < 0)
+                        {
+                            break;
+                        }
+
+                        i = endTagEnd + 1;
+                    }
+                    else if (line.Substring(i).StartsWith("<ruby-container>", StringComparison.Ordinal))
+                    {
+                        if (!TryReadRuby(line, i, out var baseText, out var rubyText, out var rubyTextAfter, out var next))
+                        {
+                            break;
+                        }
+
+                        var preFurigana = string.Empty;
+                        if (actual.Length > 0)
+                        {
+                            preFurigana = $"{{\\alpha&FF&}}{actual.ToString().TrimEnd()}{{\\alpha&0&}}";
+                        }
+
+                        if (!string.IsNullOrWhiteSpace(rubyText))
+                        {
+                            furiganaList.Add(new Paragraph($"{preFurigana}{{\\fs{metrics.RubyFontSize}}}{OneCharPerLine(rubyText)}", p.StartTime.TotalMilliseconds, p.EndTime.TotalMilliseconds));
+                        }
+
+                        if (!string.IsNullOrWhiteSpace(rubyTextAfter))
+                        {
+                            furiganaList.Add(new Paragraph($"{preFurigana}{{\\fs{metrics.RubyFontSize}}} {OneCharPerLine(rubyTextAfter)}", p.StartTime.TotalMilliseconds, p.EndTime.TotalMilliseconds));
+                        }
+
+                        foreach (var ch in baseText)
+                        {
+                            actual.Append(ch);
+                            actual.AppendLine();
+                        }
+
+                        i = next;
+                        rubyOn = true;
+                    }
+                    else
+                    {
+                        actual.AppendLine(line[i].ToString());
+                        i++;
+                    }
+                }
+
+                var displayBefore = lines.Count == 2 && index == 0 || lines.Count == 1;
+                if (displayBefore && furiganaList.Count > 0)
+                {
+                    foreach (var fp in furiganaList)
+                    {
+                        list.Add(new Paragraph(pre + "\\pos(" + startX + "," + furiganaY + ")}" + fp.Text.TrimEnd(), p.StartTime.TotalMilliseconds, p.EndTime.TotalMilliseconds));
+                    }
+
+                    startX -= adjustment;
+                    if (rubyOn && index == 0 && lines.Count == 2)
+                    {
+                        startX += leftAlign ? -metrics.Scale(8) : metrics.Scale(16);
+                    }
+                }
+
+                var actualText = pre + "\\pos(" + startX + "," + textY + ")}" + ToVerticalGlyphs(actual.ToString().TrimEnd());
+                list.Add(new Paragraph(actualText, p.StartTime.TotalMilliseconds, p.EndTime.TotalMilliseconds));
+                startX -= adjustment;
+
+                if (!displayBefore && furiganaList.Count > 0)
+                {
+                    if (rubyOn && index == 1 && lines.Count == 2)
+                    {
+                        startX += leftAlign ? metrics.Scale(14) : -metrics.Scale(8);
+                    }
+
+                    foreach (var fp in furiganaList)
+                    {
+                        list.Add(new Paragraph(pre + "\\pos(" + startX + "," + furiganaY + ")}" + fp.Text.TrimEnd(), p.StartTime.TotalMilliseconds, p.EndTime.TotalMilliseconds));
+                    }
+
+                    startX -= adjustment;
+                }
+
+                furiganaList.Clear();
+            }
+
+            return list;
+        }
+
+        /// <summary>Punctuation that has a dedicated rotated glyph when written top to bottom.</summary>
+        private static string ToVerticalGlyphs(string text)
+        {
+            return text
+                .Replace('…', '⋮')
+                .Replace('〈', '︿')
+                .Replace('〉', '﹀')
+                .Replace('—', '︱') // em dash
+                .Replace('⸺', '︱') // double em dash (could not find a vertical double em dash)
+                .Replace('ー', '⏐') // prolonged sound mark
+                .Replace('（', '︵')
+                .Replace('）', '︶');
+        }
+
+        /// <summary>
+        /// The text that actually ends up on the base line - markup gone, and the furigana dropped
+        /// (it is drawn on its own render line, so it must not count towards the line width).
+        /// </summary>
+        private static string GetPlainRenderText(string line)
+        {
+            var withoutRubyText = RubyTextRegex.Replace(line, string.Empty);
+            return NetflixImsc11Japanese.RemoveTags(HtmlUtil.RemoveHtmlTags(withoutRubyText, true));
+        }
+
+        private static readonly System.Text.RegularExpressions.Regex RubyTextRegex =
+            new System.Text.RegularExpressions.Regex("<ruby-text(-italic|-after)?>.*?</ruby-text(-italic|-after)?>", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+        private static string OneCharPerLine(string text)
+        {
+            var sb = new StringBuilder();
+            foreach (var ch in text)
+            {
+                sb.Append(ch);
+                sb.AppendLine();
+            }
+
+            return sb.ToString().TrimEnd();
+        }
+
+        private static bool StartsWithAnyTag(string line, int index, params string[] tags)
+        {
+            foreach (var tag in tags)
+            {
+                if (string.CompareOrdinal(line, index, tag, 0, tag.Length) == 0)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Reads one &lt;ruby-container&gt; run starting at <paramref name="index"/>, returning the base
+        /// text, the furigana, and where parsing should continue.
+        /// </summary>
+        private static bool TryReadRuby(string line, int index, out string baseText, out string rubyText, out string rubyTextAfter, out int next)
+        {
+            baseText = string.Empty;
+            rubyText = string.Empty;
+            rubyTextAfter = string.Empty;
+            next = index;
+
+            var containerEnd = line.IndexOf("</ruby-container>", index, StringComparison.Ordinal);
+            if (containerEnd < 0)
+            {
+                return false;
+            }
+
+            if (!TryReadTagContent(line, index, containerEnd, "ruby-base", out baseText) &&
+                !TryReadTagContent(line, index, containerEnd, "ruby-base-italic", out baseText))
+            {
+                return false;
+            }
+
+            if (!TryReadTagContent(line, index, containerEnd, "ruby-text", out rubyText))
+            {
+                TryReadTagContent(line, index, containerEnd, "ruby-text-italic", out rubyText);
+            }
+
+            TryReadTagContent(line, index, containerEnd, "ruby-text-after", out rubyTextAfter);
+
+            next = containerEnd + "</ruby-container>".Length;
+            return true;
+        }
+
+        private static bool TryReadTagContent(string line, int from, int to, string tagName, out string content)
+        {
+            content = string.Empty;
+            var open = "<" + tagName + ">";
+            var close = "</" + tagName + ">";
+            var start = line.IndexOf(open, from, StringComparison.Ordinal);
+            if (start < 0 || start >= to)
+            {
+                return false;
+            }
+
+            start += open.Length;
+            var end = line.IndexOf(close, start, StringComparison.Ordinal);
+            if (end < 0 || end > to)
+            {
+                return false;
+            }
+
+            content = line.Substring(start, end - start);
+            return true;
+        }
+
+        public static string Convert(Subtitle subtitle, int width, int height)
+        {
+            return ConvertToSubtitle(subtitle, width, height).ToText(new AdvancedSubStationAlpha());
+        }
+
+        /// <summary>
+        /// Same as <see cref="Convert"/>, but stops before serializing so callers can still add to the
+        /// result - the video preview grafts the secondary subtitle onto it.
+        /// </summary>
+        public static Subtitle ConvertToSubtitle(Subtitle subtitle, int width, int height)
+        {
+            if (width <= 0)
+            {
+                width = 1280;
+            }
+
+            if (height <= 0)
+            {
+                height = 720;
+            }
+
+            var metrics = new Metrics(height);
+            var finalSub = new Subtitle();
+            foreach (var paragraph in subtitle.Paragraphs)
+            {
+                finalSub.Paragraphs.AddRange(SplitToAssRenderLines(paragraph, width, height));
+            }
+
+            var style = new SsaStyle { FontSize = metrics.FontSize, Bold = false };
+            var header = string.Format(AdvancedSubStationAlpha.HeaderNoStyles, string.Empty, style.ToRawAss());
+            header = AdvancedSubStationAlpha.AddTagToHeader("PlayResX", "PlayResX: " + width.ToString(CultureInfo.InvariantCulture), "[Script Info]", header);
+            header = AdvancedSubStationAlpha.AddTagToHeader("PlayResY", "PlayResY: " + height.ToString(CultureInfo.InvariantCulture), "[Script Info]", header);
+            finalSub.Header = header;
+
+            return finalSub;
+        }
+    }
+}

--- a/src/libse/SubtitleFormats/NetflixImsc11Japanese.cs
+++ b/src/libse/SubtitleFormats/NetflixImsc11Japanese.cs
@@ -218,7 +218,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             return "bottom-left-justified";
         }
 
-        private static string GetAssStyleFromRegion(string region)
+        private static string GetAssStyleFromRegionName(string region)
         {
             switch (region)
             {
@@ -226,13 +226,176 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 case "force-narrative-example-region": return @"{\an5}";
                 case "left": return @"{\an7}";
                 case "right": return @"{\an9}";
-                default: return string.Empty;
+                default: return null;
             }
         }
 
-        private static List<string> GetStyles()
+        /// <summary>
+        /// Real Netflix documents name their regions "region0", "region1"... - only files authored by
+        /// Subtitle Edit itself use the names above. Fall back to the region attributes so vertical
+        /// (tbrl/tblr) and top/middle placement survive documents written by anything else (issue #13861).
+        /// </summary>
+        private static string GetAssStyleFromRegion(string regionId, XmlDocument xml)
         {
-            return TimedText10.GetStylesFromHeader(GetXmlStructure());
+            var byName = GetAssStyleFromRegionName(regionId);
+            if (byName != null)
+            {
+                return byName;
+            }
+
+            var regionNode = FindNodeById(xml, "region", regionId);
+            if (regionNode == null)
+            {
+                return string.Empty;
+            }
+
+            var displayAlign = GetTtmlStyleValue(xml, regionNode, "tts:displayAlign", includeInitial: true) ?? "after";
+            var writingMode = GetTtmlStyleValue(xml, regionNode, "tts:writingMode", includeInitial: true) ?? "lrtb";
+
+            if (writingMode.StartsWith("tb", StringComparison.Ordinal))
+            {
+                // Vertical writing: the block direction runs sideways, so "displayAlign" picks a
+                // side, not a height. tbrl stacks columns right-to-left, so "before" is the right
+                // edge; tblr is the mirror image. Subtitle Edit's vertical layout only knows the
+                // two corners (see NetflixImsc11JapaneseToAss), so "center" snaps to the start side.
+                var rightToLeft = !writingMode.StartsWith("tblr", StringComparison.Ordinal);
+                var atStart = displayAlign != "after";
+                return rightToLeft == atStart ? @"{\an9}" : @"{\an7}";
+            }
+
+            var originY = ParseRegionPercentY(GetTtmlStyleValue(xml, regionNode, "tts:origin", includeInitial: true)) ?? 10.0;
+            var extentY = ParseRegionPercentY(GetTtmlStyleValue(xml, regionNode, "tts:extent", includeInitial: true)) ?? 80.0;
+            double anchorY;
+            switch (displayAlign)
+            {
+                case "before":
+                    anchorY = originY;
+                    break;
+                case "center":
+                    anchorY = originY + extentY / 2.0;
+                    break;
+                default: // after
+                    anchorY = originY + extentY;
+                    break;
+            }
+
+            if (anchorY <= 33)
+            {
+                return @"{\an8}";
+            }
+
+            if (anchorY < 66)
+            {
+                return @"{\an5}";
+            }
+
+            return string.Empty; // bottom is the default region
+        }
+
+        private static double? ParseRegionPercentY(string originOrExtent)
+        {
+            if (string.IsNullOrEmpty(originOrExtent))
+            {
+                return null;
+            }
+
+            var parts = originOrExtent.Trim().Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length != 2 || !parts[1].EndsWith("%", StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            return double.TryParse(parts[1].TrimEnd('%'), NumberStyles.Float, CultureInfo.InvariantCulture, out var value)
+                ? value
+                : (double?)null;
+        }
+
+        private static XmlNode FindNodeById(XmlDocument xml, string localName, string id)
+        {
+            if (string.IsNullOrEmpty(id) || xml.DocumentElement == null)
+            {
+                return null;
+            }
+
+            try
+            {
+                var nsmgr = new XmlNamespaceManager(xml.NameTable);
+                nsmgr.AddNamespace("ttml", "http://www.w3.org/ns/ttml");
+                foreach (XmlNode node in xml.DocumentElement.SelectNodes("//ttml:" + localName, nsmgr))
+                {
+                    var nodeId = node.Attributes?["xml:id"]?.Value ?? node.Attributes?["id"]?.Value;
+                    if (nodeId == id)
+                    {
+                        return node;
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                System.Diagnostics.Debug.WriteLine(e);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Reads a tts: attribute off an element, following TTML referential styling: the element's own
+        /// attribute wins, then any style it references (a space separated list, later ids win), and -
+        /// only when <paramref name="includeInitial"/> is set - the document's "initial" values.
+        /// Layout attributes want the initial fallback; presentation attributes must not have it, or
+        /// the document-wide default color and font would end up on a &lt;font&gt; tag around every span.
+        /// </summary>
+        private static string GetTtmlStyleValue(XmlDocument xml, XmlNode node, string attributeName, bool includeInitial = false, int depth = 0)
+        {
+            if (node == null || depth > 5)
+            {
+                return null;
+            }
+
+            var own = node.Attributes?[attributeName]?.Value;
+            if (!string.IsNullOrEmpty(own))
+            {
+                return own;
+            }
+
+            var styleRef = node.Attributes?["style"]?.Value;
+            if (!string.IsNullOrEmpty(styleRef))
+            {
+                var ids = styleRef.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                for (var i = ids.Length - 1; i >= 0; i--)
+                {
+                    var value = GetTtmlStyleValue(xml, FindNodeById(xml, "style", ids[i]), attributeName, includeInitial, depth + 1);
+                    if (!string.IsNullOrEmpty(value))
+                    {
+                        return value;
+                    }
+                }
+            }
+
+            if (!includeInitial || depth > 0)
+            {
+                return null;
+            }
+
+            try
+            {
+                var nsmgr = new XmlNamespaceManager(xml.NameTable);
+                nsmgr.AddNamespace("ttml", "http://www.w3.org/ns/ttml");
+                foreach (XmlNode initial in xml.DocumentElement.SelectNodes("//ttml:initial", nsmgr))
+                {
+                    var value = initial.Attributes?[attributeName]?.Value;
+                    if (!string.IsNullOrEmpty(value))
+                    {
+                        return value;
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                System.Diagnostics.Debug.WriteLine(e);
+            }
+
+            return null;
         }
 
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
@@ -306,10 +469,14 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 var region = node.Attributes?["region"];
                 if (region != null)
                 {
-                    assStyle = GetAssStyleFromRegion(region.InnerText);
+                    assStyle = GetAssStyleFromRegion(region.InnerText, xml);
                 }
 
-                var text = assStyle + ReadParagraph(node, xml);
+                // Netflix puts the shear (their italic) for a whole cue on the <p> itself, not on a
+                // span, so a paragraph-level style has to be read too - see issue #13861. It is
+                // inherited by the content instead of wrapping it, so it survives the line breaks.
+                var paragraphStyle = ReadSpanStyle(node, xml);
+                var text = assStyle + ReadParagraph(node, xml, paragraphStyle.IsItalic);
                 var p = new Paragraph(begin, end, text);
                 subtitle.Paragraphs.Add(p);
             }
@@ -317,15 +484,194 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             subtitle.Renumber();
         }
 
-        private static string ReadParagraph(XmlNode node, XmlDocument xml)
+        private sealed class JapaneseSpanStyle
+        {
+            public bool IsItalic { get; set; }
+            public bool IsBold { get; set; }
+            public bool IsUnderlined { get; set; }
+            public string FontFamily { get; set; }
+            public string Color { get; set; }
+            public string Bouten { get; set; }
+            public bool HorizontalDigit { get; set; }
+            public bool RubyContainer { get; set; }
+            public bool RubyBase { get; set; }
+            public bool RubyText { get; set; }
+            public bool RubyTextAfter { get; set; }
+        }
+
+        private static readonly HashSet<string> BoutenStyleNames = new HashSet<string>
+        {
+            "bouten-dot-before",
+            "bouten-dot-after",
+            "bouten-dot-outside",
+            "bouten-filled-circle-outside",
+            "bouten-open-circle-outside",
+            "bouten-open-dot-outside",
+            "bouten-filled-sesame-outside",
+            "bouten-open-sesame-outside",
+            "bouten-auto-outside",
+            "bouten-auto",
+        };
+
+        /// <summary>
+        /// "dot before" -> "bouten-dot-before". Anything outside the profile's vocabulary still gets
+        /// an emphasis mark rather than being dropped silently.
+        /// </summary>
+        private static string BoutenStyleNameFromTextEmphasis(string textEmphasis)
+        {
+            if (string.IsNullOrWhiteSpace(textEmphasis) || textEmphasis == "none")
+            {
+                return null;
+            }
+
+            var name = "bouten-" + string.Join("-", textEmphasis.Trim().Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries));
+            return BoutenStyleNames.Contains(name) ? name : "bouten-auto";
+        }
+
+        private static bool IsShearSet(string shear)
+        {
+            if (string.IsNullOrWhiteSpace(shear))
+            {
+                return false;
+            }
+
+            var value = shear.Trim().TrimEnd('%');
+            return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var percent)
+                ? Math.Abs(percent) > 0.001
+                : true;
+        }
+
+        /// <summary>
+        /// Style ids are only meaningful in documents Subtitle Edit wrote itself - Netflix generates
+        /// "style0", "style1"... - so the real styling has to come off the attributes of the referenced
+        /// style nodes. The named ids are still honored first so our own files keep round-tripping
+        /// even when their style definitions are missing (issue #13861).
+        /// </summary>
+        private static JapaneseSpanStyle ReadSpanStyle(XmlNode node, XmlDocument xml)
+        {
+            var style = new JapaneseSpanStyle();
+
+            var styleRef = node.Attributes?["style"]?.Value;
+            if (!string.IsNullOrEmpty(styleRef))
+            {
+                foreach (var styleName in styleRef.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries))
+                {
+                    ApplyKnownStyleName(styleName, style);
+                }
+            }
+
+            var ruby = GetTtmlStyleValue(xml, node, "tts:ruby");
+            if (ruby == "container")
+            {
+                style.RubyContainer = true;
+            }
+            else if (ruby == "base")
+            {
+                style.RubyBase = true;
+            }
+            else if (ruby == "text")
+            {
+                style.RubyText = true;
+                if (GetTtmlStyleValue(xml, node, "tts:rubyPosition") == "after")
+                {
+                    style.RubyTextAfter = true;
+                }
+            }
+            else if (ruby == "textContainer" || ruby == "baseContainer")
+            {
+                // Grouping wrappers with no text of their own - nothing to mark up.
+            }
+
+            var textEmphasis = BoutenStyleNameFromTextEmphasis(GetTtmlStyleValue(xml, node, "tts:textEmphasis"));
+            if (textEmphasis != null)
+            {
+                style.Bouten = textEmphasis;
+            }
+
+            if (GetTtmlStyleValue(xml, node, "tts:textCombine") == "all")
+            {
+                style.HorizontalDigit = true;
+            }
+
+            // Netflix's Japanese profile has no tts:fontStyle - a slanted cue is expressed as a shear.
+            if (GetTtmlStyleValue(xml, node, "tts:fontStyle") == "italic" || IsShearSet(GetTtmlStyleValue(xml, node, "tts:shear")))
+            {
+                style.IsItalic = true;
+            }
+
+            if (GetTtmlStyleValue(xml, node, "tts:fontWeight") == "bold")
+            {
+                style.IsBold = true;
+            }
+
+            if (GetTtmlStyleValue(xml, node, "tts:textDecoration") == "underline")
+            {
+                style.IsUnderlined = true;
+            }
+
+            var fontFamily = GetTtmlStyleValue(xml, node, "tts:fontFamily");
+            if (!string.IsNullOrEmpty(fontFamily))
+            {
+                style.FontFamily = fontFamily;
+            }
+
+            var color = GetTtmlStyleValue(xml, node, "tts:color");
+            if (!string.IsNullOrEmpty(color))
+            {
+                style.Color = color;
+            }
+
+            return style;
+        }
+
+        private static void ApplyKnownStyleName(string styleName, JapaneseSpanStyle style)
+        {
+            if (BoutenStyleNames.Contains(styleName))
+            {
+                style.Bouten = styleName;
+                return;
+            }
+
+            switch (styleName)
+            {
+                case "italic":
+                    style.IsItalic = true;
+                    break;
+                case "horizontalDigit":
+                    style.HorizontalDigit = true;
+                    break;
+                case "ruby-container":
+                    style.RubyContainer = true;
+                    break;
+                case "ruby-base":
+                    style.RubyBase = true;
+                    break;
+                case "ruby-base-italic":
+                    style.RubyBase = true;
+                    style.IsItalic = true;
+                    break;
+                case "ruby-text":
+                    style.RubyText = true;
+                    break;
+                case "ruby-text-italic":
+                    style.RubyText = true;
+                    style.IsItalic = true;
+                    break;
+                case "ruby-text-after":
+                    style.RubyText = true;
+                    style.RubyTextAfter = true;
+                    break;
+            }
+        }
+
+        private static string ReadParagraph(XmlNode node, XmlDocument xml, bool inheritedItalic)
         {
             var pText = new StringBuilder();
-            var styles = GetStyles();
             foreach (XmlNode child in node.ChildNodes)
             {
                 if (child.NodeType == XmlNodeType.Text)
                 {
-                    pText.Append(child.Value);
+                    AppendMaybeItalic(pText, child.Value, inheritedItalic);
                 }
                 else if (child.Name == "br" || child.Name == "tt:br")
                 {
@@ -333,422 +679,116 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 }
                 else if (child.Name == "#significant-whitespace" || child.Name == "tt:#significant-whitespace")
                 {
-                    pText.Append(child.InnerText);
+                    AppendMaybeItalic(pText, child.InnerText, inheritedItalic);
                 }
                 else if (child.Name == "span" || child.Name == "tt:span")
                 {
-                    bool isItalic = false;
-                    bool isBold = false;
-                    bool isUnderlined = false;
-                    string fontFamily = null;
-                    string color = null;
-                    bool boutenDotBefore = false;
-                    bool boutenDotAfter = false;
-                    bool boutenDotOutside = false;
-                    bool boutenFilledCircleOutside = false;
-                    bool boutenOpenCircleOutside = false;
-                    bool boutenOpenDotOutside = false;
-                    bool boutenFilledSesameOutside = false;
-                    bool boutenOpenSesameOutside = false;
-                    bool boutenAutoOutside = false;
-                    bool boutenAuto = false;
-                    bool horizontalDigit = false;
-                    bool rubyContainer = false;
-                    bool rubyBase = false;
-                    bool rubyBaseItalic = false;
-                    bool rubyText = false;
-                    bool rubyTextAfter = false;
-                    bool rubyTextItalic = false;
-
-                    // Composing styles
-
-                    if (child.Attributes["style"] != null)
+                    var style = ReadSpanStyle(child, xml);
+                    if (inheritedItalic)
                     {
-                        string styleName = child.Attributes["style"].Value;
-                        if (styleName == "bouten-dot-before")
-                        {
-                            boutenDotBefore = true;
-                        }
-                        else if (styleName == "bouten-dot-after")
-                        {
-                            boutenDotAfter = true;
-                        }
-                        else if (styleName == "bouten-dot-outside")
-                        {
-                            boutenDotOutside = true;
-                        }
-                        else if (styleName == "bouten-filled-circle-outside")
-                        {
-                            boutenFilledCircleOutside = true;
-                        }
-                        else if (styleName == "bouten-open-circle-outside")
-                        {
-                            boutenOpenCircleOutside = true;
-                        }
-                        else if (styleName == "bouten-open-dot-outside")
-                        {
-                            boutenOpenDotOutside = true;
-                        }
-                        else if (styleName == "bouten-filled-sesame-outside")
-                        {
-                            boutenFilledSesameOutside = true;
-                        }
-                        else if (styleName == "bouten-open-sesame-outside")
-                        {
-                            boutenOpenSesameOutside = true;
-                        }
-                        else if (styleName == "bouten-auto-outside")
-                        {
-                            boutenAutoOutside = true;
-                        }
-                        else if (styleName == "bouten-auto")
-                        {
-                            boutenAuto = true;
-                        }
-                        else if (styleName == "horizontalDigit")
-                        {
-                            horizontalDigit = true;
-                        }
-                        else if (styleName == "ruby-container")
-                        {
-                            rubyContainer = true;
-                        }
-                        else if (styleName == "ruby-base")
-                        {
-                            rubyBase = true;
-                        }
-                        else if (styleName == "ruby-base-italic")
-                        {
-                            rubyBaseItalic = true;
-                        }
-                        else if (styleName == "ruby-text")
-                        {
-                            rubyText = true;
-                        }
-                        else if (styleName == "ruby-text-after")
-                        {
-                            rubyTextAfter = true;
-                        }
-                        else if (styleName == "ruby-text-italic")
-                        {
-                            rubyTextItalic = true;
-                        }
-                        else if (styles.Contains(styleName))
-                        {
-                            try
-                            {
-                                var nsmgr = new XmlNamespaceManager(xml.NameTable);
-                                nsmgr.AddNamespace("ttml", "http://www.w3.org/ns/ttml");
-                                XmlNode head = xml.DocumentElement.SelectSingleNode("ttml:head", nsmgr);
-                                foreach (XmlNode styleNode in head.SelectNodes("//ttml:style", nsmgr))
-                                {
-                                    string currentStyle = null;
-                                    if (styleNode.Attributes["xml:id"] != null)
-                                    {
-                                        currentStyle = styleNode.Attributes["xml:id"].Value;
-                                    }
-                                    else if (styleNode.Attributes["id"] != null)
-                                    {
-                                        currentStyle = styleNode.Attributes["id"].Value;
-                                    }
-
-                                    if (currentStyle == styleName)
-                                    {
-                                        if (styleNode.Attributes["tts:fontStyle"] != null && styleNode.Attributes["tts:fontStyle"].Value == "italic")
-                                        {
-                                            isItalic = true;
-                                        }
-
-                                        if (styleNode.Attributes["tts:fontWeight"] != null && styleNode.Attributes["tts:fontWeight"].Value == "bold")
-                                        {
-                                            isBold = true;
-                                        }
-
-                                        if (styleNode.Attributes["tts:textDecoration"] != null && styleNode.Attributes["tts:textDecoration"].Value == "underline")
-                                        {
-                                            isUnderlined = true;
-                                        }
-
-                                        if (styleNode.Attributes["tts:fontFamily"] != null)
-                                        {
-                                            fontFamily = styleNode.Attributes["tts:fontFamily"].Value;
-                                        }
-
-                                        if (styleNode.Attributes["tts:color"] != null)
-                                        {
-                                            color = styleNode.Attributes["tts:color"].Value;
-                                        }
-                                    }
-                                }
-                            }
-                            catch (Exception e)
-                            {
-                                System.Diagnostics.Debug.WriteLine(e);
-                            }
-                        }
+                        style.IsItalic = true;
                     }
 
-                    if (child.Attributes["tts:fontStyle"] != null && child.Attributes["tts:fontStyle"].Value == "italic")
-                    {
-                        isItalic = true;
-                    }
-                    else if (child.Attributes["style"] != null && child.Attributes["style"].Value == "italic")
-                    {
-                        isItalic = true;
-                    }
-
-
-                    if (child.Attributes["tts:fontWeight"] != null && child.Attributes["tts:fontWeight"].Value == "bold")
-                    {
-                        isBold = true;
-                    }
-
-                    if (child.Attributes["tts:textDecoration"] != null && child.Attributes["tts:textDecoration"].Value == "underline")
-                    {
-                        isUnderlined = true;
-                    }
-
-                    if (child.Attributes["tts:fontFamily"] != null)
-                    {
-                        fontFamily = child.Attributes["tts:fontFamily"].Value;
-                    }
-
-                    if (child.Attributes["tts:color"] != null)
-                    {
-                        color = child.Attributes["tts:color"].Value;
-                    }
-
-
-                    // Applying styles
-                    if (isItalic)
-                    {
-                        pText.Append("<i>");
-                    }
-
-                    if (isBold)
-                    {
-                        pText.Append("<b>");
-                    }
-
-                    if (isUnderlined)
-                    {
-                        pText.Append("<u>");
-                    }
-
-
-
-                    if (!string.IsNullOrEmpty(fontFamily) || !string.IsNullOrEmpty(color))
-                    {
-                        pText.Append("<font");
-
-                        if (!string.IsNullOrEmpty(fontFamily))
-                        {
-                            pText.Append($" face=\"{fontFamily}\"");
-                        }
-
-                        if (!string.IsNullOrEmpty(color))
-                        {
-                            pText.Append($" color=\"{color}\"");
-                        }
-
-                        pText.Append(">");
-                    }
-
-                    if (boutenDotBefore)
-                    {
-                        pText.Append("<bouten-dot-before>");
-                    }
-
-                    if (boutenDotAfter)
-                    {
-                        pText.Append("<bouten-dot-after>");
-                    }
-
-                    if (boutenDotOutside)
-                    {
-                        pText.Append("<bouten-dot-outside>");
-                    }
-
-                    if (boutenFilledCircleOutside)
-                    {
-                        pText.Append("<bouten-filled-circle-outside>");
-                    }
-
-                    if (boutenOpenCircleOutside)
-                    {
-                        pText.Append("<bouten-open-circle-outside>");
-                    }
-
-                    if (boutenOpenDotOutside)
-                    {
-                        pText.Append("<bouten-open-dot-outside>");
-                    }
-
-                    if (boutenFilledSesameOutside)
-                    {
-                        pText.Append("<bouten-filled-sesame-outside>");
-                    }
-
-                    if (boutenOpenSesameOutside)
-                    {
-                        pText.Append("<bouten-open-sesame-outside>");
-                    }
-
-                    if (boutenAutoOutside)
-                    {
-                        pText.Append("<bouten-auto-outside>");
-                    }
-
-                    if (boutenAuto)
-                    {
-                        pText.Append("<bouten-auto>");
-                    }
-
-                    if (horizontalDigit)
-                    {
-                        pText.Append("<horizontalDigit>");
-                    }
-
-                    if (rubyContainer)
-                    {
-                        pText.Append("<ruby-container>");
-                    }
-
-                    if (rubyBase)
-                    {
-                        pText.Append("<ruby-base>");
-                    }
-
-                    if (rubyBaseItalic)
-                    {
-                        pText.Append("<ruby-base-italic>");
-                    }
-
-                    if (rubyText)
-                    {
-                        pText.Append("<ruby-text>");
-                    }
-
-                    if (rubyTextAfter)
-                    {
-                        pText.Append("<ruby-text-after>");
-                    }
-
-                    if (rubyTextItalic)
-                    {
-                        pText.Append("<ruby-text-italic>");
-                    }
-
-                    pText.Append(ReadParagraph(child, xml));
-
-                    if (!string.IsNullOrEmpty(fontFamily) || !string.IsNullOrEmpty(color))
-                    {
-                        pText.Append("</font>");
-                    }
-
-                    if (isUnderlined)
-                    {
-                        pText.Append("</u>");
-                    }
-
-                    if (isBold)
-                    {
-                        pText.Append("</b>");
-                    }
-
-                    if (isItalic)
-                    {
-                        pText.Append("</i>");
-                    }
-
-                    if (boutenDotBefore)
-                    {
-                        pText.Append("</bouten-dot-before>");
-                    }
-
-                    if (boutenDotAfter)
-                    {
-                        pText.Append("</bouten-dot-after>");
-                    }
-
-                    if (boutenDotOutside)
-                    {
-                        pText.Append("</bouten-dot-outside>");
-                    }
-
-                    if (boutenFilledCircleOutside)
-                    {
-                        pText.Append("</bouten-filled-circle-outside>");
-                    }
-
-                    if (boutenOpenCircleOutside)
-                    {
-                        pText.Append("</bouten-open-circle-outside>");
-                    }
-
-                    if (boutenOpenDotOutside)
-                    {
-                        pText.Append("</bouten-open-dot-outside>");
-                    }
-
-                    if (boutenFilledSesameOutside)
-                    {
-                        pText.Append("</bouten-filled-sesame-outside>");
-                    }
-
-                    if (boutenOpenSesameOutside)
-                    {
-                        pText.Append("</bouten-open-sesame-outside>");
-                    }
-
-                    if (boutenAutoOutside)
-                    {
-                        pText.Append("</bouten-auto-outside>");
-                    }
-
-                    if (boutenAuto)
-                    {
-                        pText.Append("</bouten-auto>");
-                    }
-
-                    if (horizontalDigit)
-                    {
-                        pText.Append("</horizontalDigit>");
-                    }
-
-                    if (rubyBase)
-                    {
-                        pText.Append("</ruby-base>");
-                    }
-
-                    if (rubyBaseItalic)
-                    {
-                        pText.Append("</ruby-base-italic>");
-                    }
-
-                    if (rubyText)
-                    {
-                        pText.Append("</ruby-text>");
-                    }
-
-                    if (rubyTextAfter)
-                    {
-                        pText.Append("</ruby-text-after>");
-                    }
-
-                    if (rubyTextItalic)
-                    {
-                        pText.Append("</ruby-text-italic>");
-                    }
-
-                    if (rubyContainer)
-                    {
-                        pText.Append("</ruby-container>");
-                    }
+                    AppendSpan(pText, child, xml, style);
                 }
             }
 
             return pText.ToString().TrimEnd();
+        }
+
+        private static void AppendMaybeItalic(StringBuilder pText, string text, bool italic)
+        {
+            if (italic && !string.IsNullOrWhiteSpace(text))
+            {
+                pText.Append("<i>").Append(text).Append("</i>");
+                return;
+            }
+
+            pText.Append(text);
+        }
+
+        private static void AppendSpan(StringBuilder pText, XmlNode child, XmlDocument xml, JapaneseSpanStyle style)
+        {
+            // A sheared ruby base/text has its own style name, so it must not also get an <i> around it.
+            var italicViaRubyTag = style.IsItalic && (style.RubyBase || style.RubyText);
+            var italicTag = style.IsItalic && !italicViaRubyTag;
+            var hasFont = !string.IsNullOrEmpty(style.FontFamily) || !string.IsNullOrEmpty(style.Color);
+
+            var openTags = new List<string>();
+            if (italicTag)
+            {
+                openTags.Add("i");
+            }
+
+            if (style.IsBold)
+            {
+                openTags.Add("b");
+            }
+
+            if (style.IsUnderlined)
+            {
+                openTags.Add("u");
+            }
+
+            if (!string.IsNullOrEmpty(style.Bouten))
+            {
+                openTags.Add(style.Bouten);
+            }
+
+            if (style.HorizontalDigit)
+            {
+                openTags.Add("horizontalDigit");
+            }
+
+            if (style.RubyContainer)
+            {
+                openTags.Add("ruby-container");
+            }
+
+            if (style.RubyBase)
+            {
+                openTags.Add(italicViaRubyTag ? "ruby-base-italic" : "ruby-base");
+            }
+
+            if (style.RubyText)
+            {
+                openTags.Add(style.RubyTextAfter ? "ruby-text-after" : italicViaRubyTag ? "ruby-text-italic" : "ruby-text");
+            }
+
+            foreach (var tag in openTags)
+            {
+                pText.Append('<').Append(tag).Append('>');
+            }
+
+            if (hasFont)
+            {
+                pText.Append("<font");
+                if (!string.IsNullOrEmpty(style.FontFamily))
+                {
+                    pText.Append($" face=\"{style.FontFamily}\"");
+                }
+
+                if (!string.IsNullOrEmpty(style.Color))
+                {
+                    pText.Append($" color=\"{style.Color}\"");
+                }
+
+                pText.Append('>');
+            }
+
+            // Italic already emitted here must not be repeated by the children; a sheared ruby
+            // *container* has no tag of its own, so that one does keep inheriting.
+            pText.Append(ReadParagraph(child, xml, style.IsItalic && !italicTag && !italicViaRubyTag));
+
+            if (hasFont)
+            {
+                pText.Append("</font>");
+            }
+
+            for (var i = openTags.Count - 1; i >= 0; i--)
+            {
+                pText.Append("</").Append(openTags[i]).Append('>');
+            }
         }
 
         public static string RemoveTags(string text)

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -17511,6 +17511,22 @@ public partial class MainViewModel :
         }
     }
 
+    /// <summary>
+    /// Rewrites the current subtitle as the ASSA the Japanese profile markup renders to - one cue can
+    /// become several absolutely positioned lines, so the paragraph list is replaced wholesale.
+    /// </summary>
+    private void ConvertNetflixImsc11JapaneseToAssa()
+    {
+        var width = _mediaInfo?.Dimension.Width ?? 1280;
+        var height = _mediaInfo?.Dimension.Height ?? 720;
+        var converted = NetflixImsc11JapaneseToAss.ConvertToSubtitle(_subtitle, width, height);
+        _subtitle.Paragraphs.Clear();
+        _subtitle.Paragraphs.AddRange(converted.Paragraphs);
+        _subtitle.Header = converted.Header;
+        _subtitle.Footer = converted.Footer;
+        _subtitle.Renumber();
+    }
+
     [RelayCommand]
     private async Task SetNewStyleForSelectedLines(string styleName)
     {
@@ -27490,9 +27506,19 @@ public partial class MainViewModel :
                     _subtitleOriginal = GetUpdateSubtitleOriginal();
                 }
 
-                oldFormat.RemoveNativeFormatting(_subtitle, format);
+                if (format is AdvancedSubStationAlpha && oldFormat is NetflixImsc11Japanese)
+                {
+                    // Converting to ASSA is the only way to keep furigana/bouten/vertical writing -
+                    // they become extra positioned lines. RemoveNativeFormatting would just drop the
+                    // tags, so it must not run here (issue #13861).
+                    ConvertNetflixImsc11JapaneseToAssa();
+                }
+                else
+                {
+                    oldFormat.RemoveNativeFormatting(_subtitle, format);
+                }
 
-                if (format is AdvancedSubStationAlpha)
+                if (format is AdvancedSubStationAlpha && oldFormat is not NetflixImsc11Japanese)
                 {
                     if (oldFormat is WebVTT || oldFormat is WebVTTFileWithLineNumber)
                     {

--- a/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
@@ -875,6 +875,15 @@ public partial class BurnInViewModel : ObservableObject
         var subtitle = Subtitle.Parse(subtitleFileName);
         subtitle = GetSubtitleBasedOnCut(subtitle);
 
+        if (subtitle.OriginalFormat is NetflixImsc11Japanese)
+        {
+            // Furigana, bouten and vertical writing become extra positioned render lines - burning
+            // in the raw tags would put them on screen as literal text (issue #13861).
+            var japaneseAssaFileName = Path.Combine(Path.GetTempFileName() + ".ass");
+            File.WriteAllText(japaneseAssaFileName, NetflixImsc11JapaneseToAss.Convert(subtitle, jobItem.Width, jobItem.Height));
+            return japaneseAssaFileName;
+        }
+
         if (!isAssa)
         {
             foreach (var s in subtitle.Paragraphs)
@@ -2310,6 +2319,11 @@ public partial class BurnInViewModel : ObservableObject
         var height = VideoHeight ?? _mediaInfo?.Dimension.Height ?? 1080;
 
         var subtitle = new Subtitle(_subtitle, false);
+        if (_subtitleFormat is NetflixImsc11Japanese)
+        {
+            return NetflixImsc11JapaneseToAss.Convert(subtitle, width, height);
+        }
+
         var isAssa = _subtitleFormat is { Name: AdvancedSubStationAlpha.NameOfFormat };
         if (!isAssa)
         {

--- a/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesViewModel.cs
+++ b/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media;
@@ -645,6 +645,16 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
         }
 
         subtitle = GetSubtitleBasedOnCut(subtitle);
+
+        if (subtitle.OriginalFormat is NetflixImsc11Japanese)
+        {
+            // Furigana, bouten and vertical writing become extra positioned render lines - the raw
+            // tags would otherwise be rendered as literal text (issue #13861).
+            var japaneseJobItem = JobItems[_jobItemIndex];
+            var japaneseAssaFileName = Path.Combine(Path.GetTempFileName() + ".ass");
+            File.WriteAllText(japaneseAssaFileName, NetflixImsc11JapaneseToAss.Convert(subtitle, japaneseJobItem.Width, japaneseJobItem.Height));
+            return japaneseAssaFileName;
+        }
 
         if (!isAssa)
         {
@@ -1349,6 +1359,11 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
         var height = VideoHeight ?? 1080;
 
         var subtitle = new Subtitle(_subtitle, false);
+        if (_subtitleFormat is NetflixImsc11Japanese)
+        {
+            return NetflixImsc11JapaneseToAss.Convert(subtitle, width, height);
+        }
+
         var isAssa = _subtitleFormat is { Name: AdvancedSubStationAlpha.NameOfFormat };
         if (!isAssa)
         {

--- a/src/ui/Logic/Media/MpvReloader.cs
+++ b/src/ui/Logic/Media/MpvReloader.cs
@@ -181,6 +181,16 @@ public class MpvReloader : IMpvReloader
             }
         }
 
+        if (uiFormatType == typeof(NetflixImsc11Japanese))
+        {
+            // Furigana, bouten and vertical writing have no libass equivalent - they have to be
+            // exploded into separately positioned render lines, or the tags show up as literal
+            // text on the video (issue #13861).
+            subtitle = NetflixImsc11JapaneseToAss.ConvertToSubtitle(subtitle, VideoWidth, VideoHeight);
+            SecondarySubtitleMerger.AddSecondarySubtitle(subtitle, subtitleSecondary);
+            return (subtitle, subtitle.ToText(_assFormat), 0, false);
+        }
+
         if (uiFormatType == typeof(WebVTT) || uiFormatType == typeof(WebVTTFileWithLineNumber))
         {
             var defaultStyle = GetMpvPreviewStyle(Se.Settings.Video);

--- a/src/ui/Logic/Media/VlcReloader.cs
+++ b/src/ui/Logic/Media/VlcReloader.cs
@@ -48,7 +48,15 @@ public class VlcReloader : IVlcReloader
 
             SubtitleFormat format = _assFormat;
             string text;
-            if (uiFormatType == typeof(WebVTT) || uiFormatType == typeof(WebVTTFileWithLineNumber))
+            if (uiFormatType == typeof(NetflixImsc11Japanese))
+            {
+                // See MpvReloader - the furigana/bouten/vertical markup has to become positioned
+                // render lines before libass sees it (issue #13861).
+                subtitle = NetflixImsc11JapaneseToAss.ConvertToSubtitle(subtitle, VideoWidth, VideoHeight);
+                SecondarySubtitleMerger.AddSecondarySubtitle(subtitle, subtitleSecondary);
+                text = subtitle.ToText(_assFormat);
+            }
+            else if (uiFormatType == typeof(WebVTT) || uiFormatType == typeof(WebVTTFileWithLineNumber))
             {
                 var defaultStyle = GetMpvPreviewStyle(Se.Settings.Video);
                 defaultStyle.BorderStyle = "3";

--- a/tests/libse/Common/NetflixImsc11JapaneseToAssTest.cs
+++ b/tests/libse/Common/NetflixImsc11JapaneseToAssTest.cs
@@ -1,0 +1,127 @@
+﻿using Nikse.SubtitleEdit.Core.Common;
+
+namespace LibSETests.Common;
+
+public class NetflixImsc11JapaneseToAssTest
+{
+    private static List<string> DialogueLines(Subtitle subtitle, int width = 1280, int height = 720)
+    {
+        return NetflixImsc11JapaneseToAss.Convert(subtitle, width, height)
+            .SplitToLines()
+            .Where(l => l.StartsWith("Dialogue:", StringComparison.Ordinal))
+            .ToList();
+    }
+
+    private static Subtitle SubtitleWith(string text)
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph(text, 1000, 3000));
+        return subtitle;
+    }
+
+    [Fact]
+    public void RubyBecomesItsOwnRenderLineAboveTheBase()
+    {
+        var lines = DialogueLines(SubtitleWith("（バシン）<ruby-container><ruby-base>遅</ruby-base><ruby-text>おく</ruby-text></ruby-container>れた～"));
+
+        Assert.Equal(2, lines.Count);
+
+        // The furigana line repeats the preceding text invisibly so libass advances the pen for us,
+        // then draws the reading at half size.
+        Assert.Contains(@"{\alpha&FF&}（バシン）{\alpha&0&}", lines[0], StringComparison.Ordinal);
+        Assert.EndsWith(@"{\fs20}おく", lines[0], StringComparison.Ordinal);
+
+        // The base line keeps the base text and drops the reading.
+        Assert.EndsWith("（バシン）遅れた～", lines[1], StringComparison.Ordinal);
+
+        // Both sit at the same x, one line height apart, clear of the bottom edge.
+        Assert.Contains(@"{\pos(460,656)}", lines[0], StringComparison.Ordinal);
+        Assert.Contains(@"{\pos(460,690)}", lines[1], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void VerticalCueIsLaidOutOneCharacterPerLine()
+    {
+        var lines = DialogueLines(SubtitleWith(@"{\an9}（兵士）ハッ…"));
+
+        var line = Assert.Single(lines);
+        Assert.Contains(@"{\an9\pos(", line, StringComparison.Ordinal);
+
+        // Brackets, the prolonged sound mark and the ellipsis have dedicated vertical glyphs.
+        Assert.EndsWith(@"︵\N兵\N士\N︶\Nハ\Nッ\N⋮", line, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BoutenBecomesAnEmphasisMarkPerCharacter()
+    {
+        var lines = DialogueLines(SubtitleWith("これは<bouten-filled-sesame-outside>強調</bouten-filled-sesame-outside>です"));
+
+        // One mark line per emphasized character, plus the text itself.
+        Assert.Equal(3, lines.Count);
+        Assert.EndsWith(@"{\alpha&FF&}これは{\alpha&0&}﹅", lines[0], StringComparison.Ordinal);
+        Assert.EndsWith(@"{\alpha&FF&}これは強{\alpha&0&}﹅", lines[1], StringComparison.Ordinal);
+        Assert.EndsWith("これは強調です", lines[2], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NoJapaneseProfileTagSurvivesIntoTheAss()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("<ruby-container><ruby-base>私</ruby-base><ruby-text>わたし</ruby-text></ruby-container>は", 1000, 3000));
+        subtitle.Paragraphs.Add(new Paragraph(@"{\an7}<horizontalDigit>12</horizontalDigit>時", 4000, 6000));
+        subtitle.Paragraphs.Add(new Paragraph("<bouten-auto>だめ</bouten-auto>", 7000, 9000));
+
+        var raw = NetflixImsc11JapaneseToAss.Convert(subtitle, 1280, 720);
+
+        // Anything left behind is drawn by libass as literal text - that is the bug in issue #13861.
+        Assert.DoesNotContain("<ruby", raw, StringComparison.Ordinal);
+        Assert.DoesNotContain("<bouten", raw, StringComparison.Ordinal);
+        Assert.DoesNotContain("<horizontalDigit", raw, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ItalicBecomesAnAssOverrideTag()
+    {
+        var lines = DialogueLines(SubtitleWith("<i>（ナレーション）</i>"));
+
+        var line = Assert.Single(lines);
+        Assert.EndsWith(@"{\i1}（ナレーション）{\i0}", line, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HeaderCarriesThePlayResolutionAndAScaledFont()
+    {
+        var raw = NetflixImsc11JapaneseToAss.Convert(SubtitleWith("テスト"), 1920, 1080);
+
+        Assert.Contains("PlayResX: 1920", raw, StringComparison.Ordinal);
+        Assert.Contains("PlayResY: 1080", raw, StringComparison.Ordinal);
+
+        // Subtitle Edit 4's 40 pixel font was tuned against 720p; 1080p scales to 60.
+        Assert.Contains("Style: Default,Arial,60,", raw, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MultipleLinesShareOneLeftEdge()
+    {
+        var lines = DialogueLines(SubtitleWith("短い" + Environment.NewLine + "ずっと長い行のテキスト"));
+
+        Assert.Equal(2, lines.Count);
+
+        // multiRowAlign="start": the block is centered on its widest line and both lines start there.
+        var x = @"{\pos(420,";
+        Assert.Contains(x, lines[0], StringComparison.Ordinal);
+        Assert.Contains(x, lines[1], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PlainCueIsCenteredNearTheBottom()
+    {
+        var lines = DialogueLines(SubtitleWith("こんにちは"));
+
+        var line = Assert.Single(lines);
+
+        // Five full width characters at font size 40 = 200 wide, centered in 1280, one row up
+        // from the bottom margin.
+        Assert.Contains(@"{\an1}{\pos(540,690)}", line, StringComparison.Ordinal);
+    }
+}

--- a/tests/libse/SubtitleFormats/NetflixImsc11JapaneseTest.cs
+++ b/tests/libse/SubtitleFormats/NetflixImsc11JapaneseTest.cs
@@ -1,4 +1,4 @@
-using Nikse.SubtitleEdit.Core.Common;
+﻿using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 
 namespace LibSETests.SubtitleFormats;
@@ -52,6 +52,133 @@ public class NetflixImsc11JapaneseTest
 
         Assert.NotNull(detected);
         Assert.Equal(new NetflixImsc11Japanese().Name, detected.Name);
+    }
+
+    // The real Netflix document from https://github.com/SubtitleEdit/subtitleedit/issues/13861 -
+    // generated style/region ids ("style0", "region1"), so nothing can be matched by name: ruby,
+    // vertical writing and the shear all have to be read off the attributes.
+    private const string GeneratedIdsDocument = """
+<?xml version="1.0" encoding="utf-8"?>
+<tt ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/imsc1.1/text" xmlns="http://www.w3.org/ns/ttml" xmlns:ebutts="urn:ebu:tt:style" xmlns:ttp="http://www.w3.org/ns/ttml#parameter" xmlns:tts="http://www.w3.org/ns/ttml#styling" ttp:tickRate="10000000" ttp:timeBase="media" xml:lang="ja">
+<head>
+<styling>
+<initial tts:backgroundColor="transparent" tts:color="white" tts:extent="80.000% 80.000%" tts:fontFamily="Japanese" tts:origin="10.000% 10.000%" tts:writingMode="lrtb"/>
+<style xml:id="style0" tts:fontSize="100.000%" tts:rubyReserve="outside" tts:textAlign="center"/>
+<style xml:id="style1" tts:fontSize="100.000%" tts:rubyReserve="outside"/>
+<style xml:id="style2" tts:fontSize="100.000%" tts:ruby="container"/>
+<style xml:id="style3" tts:fontSize="100.000%" tts:ruby="base"/>
+<style xml:id="style4" tts:ruby="text" tts:rubyAlign="center" tts:rubyPosition="outside"/>
+<style xml:id="style5" tts:fontSize="100.000%" tts:rubyReserve="outside" tts:shear="16.670%" tts:textAlign="center"/>
+<style xml:id="style6" tts:fontSize="100.000%" tts:rubyReserve="outside" tts:shear="16.670%"/>
+<style xml:id="style7" tts:fontSize="100.000%" tts:textEmphasis="filled sesame outside"/>
+<style xml:id="style10" tts:fontSize="100.000%" tts:rubyReserve="outside" tts:textAlign="start"/>
+</styling>
+<layout>
+<region xml:id="region0" ebutts:multiRowAlign="start" tts:displayAlign="after" tts:extent="80.000% 80.000%" tts:origin="10.000% 10.000%" tts:writingMode="lrtb"/>
+<region xml:id="region1" ebutts:multiRowAlign="start" tts:displayAlign="before" tts:extent="80.000% 80.000%" tts:origin="10.000% 10.000%" tts:writingMode="tbrl"/>
+<region xml:id="region2" ebutts:multiRowAlign="start" tts:displayAlign="after" tts:extent="80.000% 80.000%" tts:origin="10.000% 10.000%" tts:writingMode="tbrl"/>
+<region xml:id="region3" tts:displayAlign="before" tts:extent="80.000% 20.000%" tts:origin="10.000% 5.000%"/>
+</layout>
+</head>
+<body>
+<div>
+<p begin="00:00:01.000" end="00:00:03.000" region="region0" style="style0"><span style="style1">（バシン）<span style="style2"><span style="style3">遅</span><span style="style4">おく</span></span>れた～</span></p>
+<p begin="00:00:04.000" end="00:00:06.000" region="region1" style="style10"><span style="style1">（兵士）ハッ…</span></p>
+<p begin="00:00:07.000" end="00:00:09.000" region="region0" style="style5"><span style="style6">（ナレーション）</span><br/>ついに 決戦の時は来た</p>
+<p begin="00:00:10.000" end="00:00:12.000" region="region2" style="style0">下から</p>
+<p begin="00:00:13.000" end="00:00:15.000" region="region3" style="style0"><span style="style7">強調</span></p>
+</div>
+</body>
+</tt>
+""";
+
+    private static Subtitle LoadGeneratedIdsDocument()
+    {
+        var lines = GeneratedIdsDocument.SplitToLines();
+        var subtitle = new Subtitle();
+        new NetflixImsc11Japanese().LoadSubtitle(subtitle, lines, "subtitle.xml");
+        return subtitle;
+    }
+
+    [Fact]
+    public void ReadsRubyFromGeneratedStyleIds()
+    {
+        var subtitle = LoadGeneratedIdsDocument();
+
+        Assert.Equal("（バシン）<ruby-container><ruby-base>遅</ruby-base><ruby-text>おく</ruby-text></ruby-container>れた～", subtitle.Paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void ReadsVerticalRegionAsCornerAlignment()
+    {
+        var subtitle = LoadGeneratedIdsDocument();
+
+        // tbrl stacks columns right to left, so displayAlign "before" is the right hand side...
+        Assert.StartsWith(@"{\an9}", subtitle.Paragraphs[1].Text);
+
+        // ...and "after" is the left hand side.
+        Assert.StartsWith(@"{\an7}", subtitle.Paragraphs[3].Text);
+    }
+
+    [Fact]
+    public void ReadsShearOnParagraphStyleAsItalic()
+    {
+        var subtitle = LoadGeneratedIdsDocument();
+
+        // The shear sits on the <p> style, so it has to reach the bare text after the <br/> too.
+        Assert.Equal("<i>（ナレーション）</i>" + Environment.NewLine + "<i>ついに 決戦の時は来た</i>", subtitle.Paragraphs[2].Text);
+    }
+
+    [Fact]
+    public void ReadsTextEmphasisAsBouten()
+    {
+        var subtitle = LoadGeneratedIdsDocument();
+
+        Assert.Equal(@"{\an8}<bouten-filled-sesame-outside>強調</bouten-filled-sesame-outside>", subtitle.Paragraphs[4].Text);
+    }
+
+    [Fact]
+    public void DoesNotInventFontTagsFromInitialStyles()
+    {
+        var subtitle = LoadGeneratedIdsDocument();
+
+        // "initial" carries a document wide color and font family - they are the defaults, not a
+        // per span override, so they must not turn into <font> tags around every line.
+        Assert.All(subtitle.Paragraphs, p => Assert.DoesNotContain("<font", p.Text, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void KeepsOwnStyleNamesWhenRoundTripping()
+    {
+        var sub = new Subtitle();
+        sub.Paragraphs.Add(new Paragraph("<ruby-container><ruby-base>私</ruby-base><ruby-text-after>わたし</ruby-text-after></ruby-container>は<i>元気</i>", 1000, 3000));
+        var raw = sub.ToText(new NetflixImsc11Japanese());
+
+        var reloaded = new Subtitle();
+        new NetflixImsc11Japanese().LoadSubtitle(reloaded, raw.SplitToLines(), "subtitle.xml");
+
+        Assert.Equal(sub.Paragraphs[0].Text, reloaded.Paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void GeneratedIdsDocumentSurvivesAllTheWayToTheAssPreview()
+    {
+        var dialogue = NetflixImsc11JapaneseToAss.Convert(LoadGeneratedIdsDocument(), 1280, 720)
+            .SplitToLines()
+            .Where(l => l.StartsWith("Dialogue:", StringComparison.Ordinal))
+            .ToList();
+
+        // The reading gets its own render line above the base...
+        Assert.Contains(dialogue, l => l.Contains("{\\fs20}おく", StringComparison.Ordinal));
+
+        // ...the vertical cue is stacked one character per line with vertical brackets...
+        Assert.Contains(dialogue, l => l.Contains(@"{\an9\pos(", StringComparison.Ordinal) && l.EndsWith(@"︵\N兵\N士\N︶\Nハ\Nッ\N⋮", StringComparison.Ordinal));
+
+        // ...and the sheared paragraph is italic on both of its lines.
+        Assert.Equal(2, dialogue.Count(l => l.Contains("{\\i1}", StringComparison.Ordinal)));
+
+        // Nothing the video player cannot draw is left in the text.
+        Assert.DoesNotContain(dialogue, l => l.Contains("<ruby", StringComparison.Ordinal) || l.Contains("<bouten", StringComparison.Ordinal));
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #13861

Real Netflix documents name their styles and regions `style0`, `region1`… — only files Subtitle Edit authored itself use the names the reader matched against (`ruby-base`, `bouten-*`, `left`, `right`). So everything in a real Netflix file was dropped on load, which is all three symptoms in the issue at once:

| | Before | After |
|---|---|---|
| Furigana | `（バシン）遅おくれた～` — reading inline after the base | `（バシン）<ruby-container><ruby-base>遅</ruby-base><ruby-text>おく</ruby-text></ruby-container>れた～` |
| `writingMode="tbrl"` region | plain bottom-center line | `{\an9}` / `{\an7}` |
| `tts:shear` on the `<p>` style | upright | `<i>` on every line of the cue |

## Reader

`NetflixImsc11Japanese` now resolves styling from the **attributes** of the loaded document rather than from ids in its own template. It follows TTML referential styling — the element's own attribute, then any style it references, then `<initial>` — with `<initial>` consulted for layout only: taking the document-wide `tts:color`/`tts:fontFamily` from it would wrap every single span in a `<font>` tag.

`tts:ruby`, `tts:rubyPosition`, `tts:textEmphasis`, `tts:textCombine` and `tts:shear` map onto the tags the format already speaks; the `<p>` element's own style is read and inherited by its content (so a cue-level shear survives the `<br/>`); and regions fall back to `displayAlign` × `writingMode` × `origin`/`extent`. The exact ids SE writes itself are still matched first, so its own files round-trip unchanged.

## Renderer

The reader fix alone would make the preview *worse* — libass has no idea what `<ruby-base>` is and draws the tags as literal text. SE 4 had a converter for exactly this (`NetflixImsc11JapaneseToAss`) which was dropped in the move to SE 5; this ports it back.

Each cue becomes several absolutely positioned render lines: the reading or emphasis mark rides on its own line above (or beside) the text, offset by repeating the preceding characters at `{\alpha&FF&}` so libass advances the pen itself, and vertical cues are stacked one character per line with the rotated punctuation glyphs.

Two changes while porting:
- The GDI+ `Graphics.FromHwnd` measuring is gone — it would never have run outside Windows — replaced by a character-class width estimate, which also centers multi-line cues on their widest line instead of on the concatenation of all of them.
- SE 4's hard-coded 720p metrics now scale with the video, and rows stack upward from a bottom margin, so the last line no longer sits hard against the bottom edge.

Wired into the four places that hand ASSA to libass or ffmpeg — mpv preview, VLC preview, burn-in, transparent video — plus the conversion to ASSA, which now keeps the markup instead of stripping it.

## Verified

Rendered the issue's own XML through the reader and converter, then through libass:

| | |
|---|---|
| furigana | reading sits above 遅, cue centered and clear of the bottom edge |
| vertical | top-right column, one character per line, `︵兵士︶ハッ⋮` with vertical brackets and ellipsis |
| shear | both lines italic and centered |

Matches the Sandflow IMSC renderer screenshots in the issue.

14 new tests (reader + converter + one end-to-end). Full suites green: libse 1375, libuilogic 246, seconv 376.

## Not in scope

SE 4 also had authoring UI for this format — a Ruby dialog, a Japanese alignment picker, a Bouten menu and a `MainTextBoxSelectionToRuby` shortcut — none of which exist in SE 5 either. This PR covers reading and rendering; authoring is a separate piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)