### PR TITLE
Fix #13865: hand the foreground back to the dialog when the minimize mirror restores

### DIFF
--- a/src/ui/Logic/WindowsService.cs
+++ b/src/ui/Logic/WindowsService.cs
@@ -575,6 +575,10 @@ namespace Nikse.SubtitleEdit.Logic
             // closing the dialog while minimized should bring the owner back.
             var ownerMinimizedByMirror = false;
 
+            // True while the pair is minimized, so the way back up can be told apart from an
+            // ordinary Normal <-> Maximized change and repair the foreground exactly once.
+            var pairMinimized = false;
+
             void OnDialogStateChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
             {
                 if (e.Property != Window.WindowStateProperty || syncing)
@@ -587,6 +591,7 @@ namespace Nikse.SubtitleEdit.Logic
                 {
                     if (dialog.WindowState == WindowState.Minimized)
                     {
+                        pairMinimized = true;
                         if (owner.WindowState != WindowState.Minimized)
                         {
                             ownerRestoreState = owner.WindowState;
@@ -603,6 +608,11 @@ namespace Nikse.SubtitleEdit.Logic
                         }
 
                         ownerMinimizedByMirror = false;
+                        if (pairMinimized)
+                        {
+                            pairMinimized = false;
+                            RepairModalForegroundAfterRestore(dialog);
+                        }
                     }
                 }
                 finally
@@ -623,6 +633,7 @@ namespace Nikse.SubtitleEdit.Logic
                 {
                     if (owner.WindowState == WindowState.Minimized)
                     {
+                        pairMinimized = true;
                         if (dialog.WindowState != WindowState.Minimized)
                         {
                             dialogRestoreState = dialog.WindowState;
@@ -636,6 +647,12 @@ namespace Nikse.SubtitleEdit.Logic
                         if (dialog.WindowState == WindowState.Minimized)
                         {
                             dialog.WindowState = dialogRestoreState;
+                        }
+
+                        if (pairMinimized)
+                        {
+                            pairMinimized = false;
+                            RepairModalForegroundAfterRestore(dialog);
                         }
                     }
                 }
@@ -663,6 +680,47 @@ namespace Nikse.SubtitleEdit.Logic
                     owner.WindowState = ownerRestoreState;
                 }
             });
+        }
+
+        /// <summary>
+        /// Hands the foreground and the keyboard back to <paramref name="dialog"/> after the
+        /// minimize mirror brought the pair back up.
+        ///
+        /// Restoring a window is an activating operation: Avalonia's Win32 backend ends every
+        /// non-minimizing WindowState write with SetFocus + SetForegroundWindow on that window
+        /// (WindowImpl.ShowWindow). So the mirror restoring the owner deliberately puts the OS
+        /// foreground and the keyboard on a window the modal has input-disabled - the #13405
+        /// state all over again: the dialog is drawn on top, Esc is dead, and the dialogs it
+        /// opens come up behind it (#13865). <see cref="EnforceModalForegroundWhileOpen"/> does
+        /// not catch it, because it keys on the owner *becoming* active and the owner has been
+        /// active since the minimize churn - no event fires for the restore at all. So the
+        /// restore repairs the invariant directly, retried on the same short timers the open
+        /// path uses, since the OS is still moving windows around when the first pass runs.
+        /// </summary>
+        private static void RepairModalForegroundAfterRestore(Window dialog)
+        {
+            void Repair()
+            {
+                // Only the top-most dialog may hold the foreground: an inner modal opened over
+                // this one owns it instead, and a lower frame's mirror must not steal it back.
+                if (_modalFrames.Count == 0 || _modalFrames[^1].Dialog != dialog ||
+                    !dialog.IsVisible || dialog.IsClosing() ||
+                    dialog.WindowState == WindowState.Minimized)
+                {
+                    return;
+                }
+
+                if (!dialog.IsActive)
+                {
+                    dialog.Activate();
+                }
+
+                ReclaimKeyboardFocusFromDisabledOwner();
+            }
+
+            Dispatcher.UIThread.Post(Repair, DispatcherPriority.Background);
+            DispatcherTimer.RunOnce(Repair, TimeSpan.FromMilliseconds(150));
+            DispatcherTimer.RunOnce(Repair, TimeSpan.FromMilliseconds(450));
         }
 
         private static WindowState NonMinimized(WindowState state)

--- a/tests/UI/Logic/ModalMinimizeMirroringTests.cs
+++ b/tests/UI/Logic/ModalMinimizeMirroringTests.cs
@@ -38,6 +38,12 @@ public class ModalMinimizeMirroringTests : IDisposable
         return (owner, dialog, dialogTask);
     }
 
+    private static void SimulateOsForegroundMove(Window from, Window to)
+    {
+        RaisePlatformEvent(from, "Deactivated");
+        RaisePlatformEvent(to, "Activated");
+    }
+
     // Raises the platform activation callback the OS raises when it moves foreground - the
     // accessors are internal to Avalonia, so go through reflection (same technique as
     // ModalForegroundEnforcementTests).
@@ -174,6 +180,115 @@ public class ModalMinimizeMirroringTests : IDisposable
 
         Assert.False(dialog.IsActive);
         Assert.Equal(WindowState.Minimized, dialog.WindowState);
+    }
+
+    // The hole the restore repair closes (#13865). Minimizing the dialog hands the OS foreground
+    // to the owner, and it keeps it across the restore - Avalonia's Win32 backend ends every
+    // non-minimizing WindowState write with SetFocus + SetForegroundWindow, so the mirror
+    // restoring the owner re-asserts foreground on a window the modal has input-disabled. The
+    // owner has been active since the minimize, so no activation event fires and the lifetime
+    // enforcement (which keys on owner.Activated, and stands down while the dialog is minimized)
+    // never sees the restore: the dialog comes back drawn on top but without foreground or
+    // keyboard, and the dialogs it opens come up behind it.
+    [AvaloniaFact]
+    public void RestoringTheDialog_HandsTheForegroundBackWithoutAnyActivationEvent()
+    {
+        var (owner, dialog, _) = OpenModal();
+
+        dialog.WindowState = WindowState.Minimized;
+        SimulateOsForegroundMove(from: dialog, to: owner);
+        Dispatcher.UIThread.RunJobs();
+        Assert.False(dialog.IsActive);
+
+        // No further activation event: the owner has been active since the minimize.
+        dialog.WindowState = WindowState.Normal;
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(dialog.IsActive);
+    }
+
+    [AvaloniaFact]
+    public void RestoringTheOwner_HandsTheForegroundBackWithoutAnyActivationEvent()
+    {
+        var (owner, dialog, _) = OpenModal();
+
+        owner.WindowState = WindowState.Minimized;
+        SimulateOsForegroundMove(from: dialog, to: owner);
+        Dispatcher.UIThread.RunJobs();
+        Assert.False(dialog.IsActive);
+
+        owner.WindowState = WindowState.Normal;
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(WindowState.Normal, dialog.WindowState);
+        Assert.True(dialog.IsActive);
+    }
+
+    [AvaloniaFact]
+    public void RestoringThePair_PutsTheKeyboardBackInTheDialog()
+    {
+        var (owner, dialog, _) = OpenModal();
+
+        var dialogBox = new TextBox();
+        dialog.Content = dialogBox;
+        var ownerBox = new TextBox();
+        owner.Content = ownerBox;
+        Dispatcher.UIThread.RunJobs();
+        dialogBox.Focus();
+        Dispatcher.UIThread.RunJobs();
+
+        dialog.WindowState = WindowState.Minimized;
+        Dispatcher.UIThread.RunJobs();
+
+        // The restore's SetFocus lands in the input-disabled owner.
+        ownerBox.Focus();
+        dialog.WindowState = WindowState.Normal;
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(dialogBox, dialog.FocusManager?.GetFocusedElement());
+    }
+
+    // Normal <-> Maximized is not a restore - it must not fight the user over the foreground.
+    [AvaloniaFact]
+    public void MaximizingTheDialog_DoesNotTouchTheForeground()
+    {
+        var (owner, dialog, _) = OpenModal();
+
+        SimulateOsForegroundMove(from: dialog, to: owner);
+        RaisePlatformEvent(owner, "Deactivated");
+        Dispatcher.UIThread.RunJobs();
+        Assert.False(dialog.IsActive);
+
+        dialog.WindowState = WindowState.Maximized;
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.False(dialog.IsActive);
+    }
+
+    // A modal opened over the batch window owns the foreground; the lower frame's mirror must
+    // not steal it back when the cascade restores.
+    [AvaloniaFact]
+    public void RestoringANestedChain_LeavesTheForegroundOnTheTopDialog()
+    {
+        var (owner, dialog, _) = OpenModal();
+
+        var topDialog = new Window();
+        _ = WindowService.ShowModalAsync(dialog, topDialog);
+        Dispatcher.UIThread.RunJobs();
+
+        topDialog.WindowState = WindowState.Minimized;
+        RaisePlatformEvent(dialog, "Deactivated");
+        SimulateOsForegroundMove(from: topDialog, to: owner);
+        Dispatcher.UIThread.RunJobs();
+        Assert.False(dialog.IsActive);
+        Assert.False(topDialog.IsActive);
+
+        // The cascade restores all three; only the top dialog may end up with the foreground.
+        topDialog.WindowState = WindowState.Normal;
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(topDialog.IsActive);
+        Assert.False(dialog.IsActive);
     }
 
     [AvaloniaFact]


### PR DESCRIPTION
Part of issue 1 from #13865 (Batch Convert window unresponsive after minimize/restore). This PR ships the **foreground/keyboard repair**; the main fix for the frozen-rendering symptom landed separately in #13877 — the rendering commit was pushed to this branch minutes after this PR was merged.

## What this PR fixes

Restoring a window is an activating operation — Avalonia's Win32 backend ends every non-minimizing `WindowState` write with `SetFocus` + `SetForegroundWindow`:

```csharp
// Avalonia 12.1.1, Avalonia.Win32/WindowImpl.cs - ShowWindow(WindowState, bool activate)
if (!Design.IsDesignMode && activate)
{
    SetFocus(_hwnd);
    SetForegroundWindow(_hwnd);
}
```

So the #13788 minimize mirror restoring the *owner* puts the OS foreground and keyboard on a window the modal has input-disabled — the #13405 state again: the dialog is drawn on top, Esc is dead, and nested dialogs open behind it. `EnforceModalForegroundWhileOpen` cannot catch it: it keys on the owner *becoming* active, and the owner has been active since the minimize churn (where the enforcement deliberately stands down, #13788) — no event fires for the restore at all.

Fix: the restore repairs the invariant directly (activate the dialog, reclaim keyboard focus), on the open path's retry timers, guarded so `Normal ↔ Maximized` is untouched and a nested modal keeps the foreground.

## Tests

Five new cases in `ModalMinimizeMirroringTests`; three fail without the fix (dialog-restored, owner-restored, nested chain). Full UI suite: 3212 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)