### PR TITLE
Fix D-Cinema XML two-line events collapsing into one line

### DIFF
--- a/src/libse/SubtitleFormats/DCinemaInterop.cs
+++ b/src/libse/SubtitleFormats/DCinemaInterop.cs
@@ -556,6 +556,37 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             return s;
         }
 
+        /// <summary>
+        /// Looks up an attribute by name, ignoring case. The SMPTE DCST schemas spell the text
+        /// attributes "Vposition"/"Valign"/"Halign" while the Interop schema spells them
+        /// "VPosition"/"VAlign"/"HAlign" - and some exporters mix the two, which used to make the
+        /// position lookup fail and collapse multi-line subtitles into one line.
+        /// </summary>
+        internal static XmlAttribute GetAttributeIgnoreCase(XmlNode node, string name)
+        {
+            var attributes = node?.Attributes;
+            if (attributes == null)
+            {
+                return null;
+            }
+
+            var attribute = attributes[name];
+            if (attribute != null)
+            {
+                return attribute;
+            }
+
+            foreach (XmlAttribute a in attributes)
+            {
+                if (a.LocalName.Equals(name, StringComparison.OrdinalIgnoreCase))
+                {
+                    return a;
+                }
+            }
+
+            return null;
+        }
+
         public static string GenerateId()
         {
             return Guid.NewGuid().ToString().RemoveChar('-').Insert(8, "-").Insert(13, "-").Insert(18, "-").Insert(23, "-").ToLowerInvariant();
@@ -710,10 +741,11 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         {
                             extra = innerNode.OuterXml;
 
-                            if (innerNode.Attributes["VPosition"] != null)
+                            var vPositionNode = GetAttributeIgnoreCase(innerNode, "VPosition");
+                            if (vPositionNode != null)
                             {
-                                vPosition = innerNode.Attributes["VPosition"].InnerText;
-                                var vAlignmentNode = innerNode.Attributes["VAlign"];
+                                vPosition = vPositionNode.InnerText;
+                                var vAlignmentNode = GetAttributeIgnoreCase(innerNode, "VAlign");
                                 if (vAlignmentNode != null)
                                 {
                                     vAlignment = vAlignmentNode.InnerText;
@@ -735,9 +767,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             var alignRight = false;
                             var alignVTop = false;
                             var alignVCenter = false;
-                            if (innerNode.Attributes["HAlign"] != null)
+                            var hAlignNode = GetAttributeIgnoreCase(innerNode, "HAlign");
+                            if (hAlignNode != null)
                             {
-                                var hAlign = innerNode.Attributes["HAlign"].InnerText;
+                                var hAlign = hAlignNode.InnerText;
                                 if (hAlign == "left")
                                 {
                                     alignLeft = true;
@@ -748,9 +781,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                                 }
                             }
 
-                            if (innerNode.Attributes["VAlign"] != null)
+                            var vAlignNode = GetAttributeIgnoreCase(innerNode, "VAlign");
+                            if (vAlignNode != null)
                             {
-                                var hAlign = innerNode.Attributes["VAlign"].InnerText;
+                                var hAlign = vAlignNode.InnerText;
                                 if (hAlign == "top")
                                 {
                                     alignVTop = true;
@@ -903,9 +937,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
                             foreach (XmlNode innerInnerNode in innerNode)
                             {
-                                if (innerInnerNode.Attributes["VPosition"] != null)
+                                var vPositionNode = GetAttributeIgnoreCase(innerInnerNode, "VPosition");
+                                if (vPositionNode != null)
                                 {
-                                    vPosition = innerInnerNode.Attributes["VPosition"].InnerText;
+                                    vPosition = vPositionNode.InnerText;
                                     if (vPosition != lastVPosition)
                                     {
                                         if (pText.Length > 0 && lastVPosition.Length > 0)

--- a/src/libse/SubtitleFormats/DCinemaSmpte2007.cs
+++ b/src/libse/SubtitleFormats/DCinemaSmpte2007.cs
@@ -618,12 +618,27 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 if (node != null)
                 {
                     ss.CurrentDCinemaEditRate = node.InnerText;
+                    var editRate = node.InnerText.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                    if (editRate.Length == 2 &&
+                        double.TryParse(editRate[0], NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var numerator) &&
+                        double.TryParse(editRate[1], NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var denominator) &&
+                        denominator > 0)
+                    {
+                        _frameRate = numerator / denominator;
+                    }
                 }
 
                 node = xml.DocumentElement.SelectSingleNode("TimeCodeRate");
                 if (node != null)
                 {
                     ss.CurrentDCinemaTimeCodeRate = node.InnerText;
+
+                    // TimeIn/TimeOut count ticks per second at TimeCodeRate - not at the reel edit rate
+                    if (double.TryParse(node.InnerText, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var timeCodeRate) && timeCodeRate > 0)
+                    {
+                        _frameRate = timeCodeRate;
+                    }
+
                     if (ss.CurrentDCinemaEditRate == "24")
                     {
                         Configuration.Settings.General.CurrentFrameRate = 24;
@@ -716,15 +731,16 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     {
                         if (innerNode.Name == "Text")
                         {
-                            if (innerNode.Attributes["Vposition"] != null)
+                            var vPositionNode = DCinemaInterop.GetAttributeIgnoreCase(innerNode, "Vposition");
+                            if (vPositionNode != null)
                             {
-                                var vAlignmentNode = innerNode.Attributes["Valign"];
+                                var vAlignmentNode = DCinemaInterop.GetAttributeIgnoreCase(innerNode, "Valign");
                                 if (vAlignmentNode != null)
                                 {
                                     vAlignment = vAlignmentNode.InnerText;
                                 }
 
-                                string vPosition = innerNode.Attributes["Vposition"].InnerText;
+                                string vPosition = vPositionNode.InnerText;
                                 if (vPosition != lastVPosition)
                                 {
                                     if (pText.Length > 0 && lastVPosition.Length > 0)
@@ -741,9 +757,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             bool alignRight = false;
                             bool alignVTop = false;
                             bool alignVCenter = false;
-                            if (innerNode.Attributes["Halign"] != null)
+                            var hAlignNode = DCinemaInterop.GetAttributeIgnoreCase(innerNode, "Halign");
+                            if (hAlignNode != null)
                             {
-                                string hAlign = innerNode.Attributes["Halign"].InnerText;
+                                string hAlign = hAlignNode.InnerText;
                                 if (hAlign == "left")
                                 {
                                     alignLeft = true;
@@ -754,9 +771,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                                 }
                             }
 
-                            if (innerNode.Attributes["Valign"] != null)
+                            var vAlignNode = DCinemaInterop.GetAttributeIgnoreCase(innerNode, "Valign");
+                            if (vAlignNode != null)
                             {
-                                string hAlign = innerNode.Attributes["Valign"].InnerText;
+                                string hAlign = vAlignNode.InnerText;
                                 if (hAlign == "top")
                                 {
                                     alignVTop = true;

--- a/src/libse/SubtitleFormats/DCinemaSmpte2010.cs
+++ b/src/libse/SubtitleFormats/DCinemaSmpte2010.cs
@@ -654,12 +654,27 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 if (node != null)
                 {
                     ss.CurrentDCinemaEditRate = node.InnerText;
+                    var editRate = node.InnerText.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                    if (editRate.Length == 2 &&
+                        double.TryParse(editRate[0], NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var numerator) &&
+                        double.TryParse(editRate[1], NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var denominator) &&
+                        denominator > 0)
+                    {
+                        _frameRate = numerator / denominator;
+                    }
                 }
 
                 node = xml.DocumentElement.SelectSingleNode("TimeCodeRate");
                 if (node != null)
                 {
                     ss.CurrentDCinemaTimeCodeRate = node.InnerText;
+
+                    // TimeIn/TimeOut count ticks per second at TimeCodeRate - not at the reel edit rate
+                    if (double.TryParse(node.InnerText, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var timeCodeRate) && timeCodeRate > 0)
+                    {
+                        _frameRate = timeCodeRate;
+                    }
+
                     if (ss.CurrentDCinemaEditRate == "24")
                     {
                         Configuration.Settings.General.CurrentFrameRate = 24;
@@ -752,15 +767,16 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     {
                         if (innerNode.Name == "Text")
                         {
-                            if (innerNode.Attributes["Vposition"] != null)
+                            var vPositionNode = DCinemaInterop.GetAttributeIgnoreCase(innerNode, "Vposition");
+                            if (vPositionNode != null)
                             {
-                                var vAlignmentNode = innerNode.Attributes["Valign"];
+                                var vAlignmentNode = DCinemaInterop.GetAttributeIgnoreCase(innerNode, "Valign");
                                 if (vAlignmentNode != null)
                                 {
                                     vAlignment = vAlignmentNode.InnerText;
                                 }
 
-                                var vPosition = innerNode.Attributes["Vposition"].InnerText;
+                                var vPosition = vPositionNode.InnerText;
                                 if (vPosition != lastVPosition)
                                 {
                                     if (pText.Length > 0 && lastVPosition.Length > 0)
@@ -777,9 +793,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             var alignRight = false;
                             var alignVTop = false;
                             var alignVCenter = false;
-                            if (innerNode.Attributes["Halign"] != null)
+                            var hAlignNode = DCinemaInterop.GetAttributeIgnoreCase(innerNode, "Halign");
+                            if (hAlignNode != null)
                             {
-                                var hAlign = innerNode.Attributes["Halign"].InnerText;
+                                var hAlign = hAlignNode.InnerText;
                                 if (hAlign == "left")
                                 {
                                     alignLeft = true;
@@ -790,9 +807,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                                 }
                             }
 
-                            if (innerNode.Attributes["Valign"] != null)
+                            var vAlignNode = DCinemaInterop.GetAttributeIgnoreCase(innerNode, "Valign");
+                            if (vAlignNode != null)
                             {
-                                var hAlign = innerNode.Attributes["Valign"].InnerText;
+                                var hAlign = vAlignNode.InnerText;
                                 if (hAlign == "top")
                                 {
                                     alignVTop = true;

--- a/src/libse/SubtitleFormats/DCinemaSmpte2014.cs
+++ b/src/libse/SubtitleFormats/DCinemaSmpte2014.cs
@@ -632,12 +632,27 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 if (node != null)
                 {
                     ss.CurrentDCinemaEditRate = node.InnerText;
+                    var editRate = node.InnerText.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                    if (editRate.Length == 2 &&
+                        double.TryParse(editRate[0], NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var numerator) &&
+                        double.TryParse(editRate[1], NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var denominator) &&
+                        denominator > 0)
+                    {
+                        _frameRate = numerator / denominator;
+                    }
                 }
 
                 node = xml.DocumentElement.SelectSingleNode("TimeCodeRate");
                 if (node != null)
                 {
                     ss.CurrentDCinemaTimeCodeRate = node.InnerText;
+
+                    // TimeIn/TimeOut count ticks per second at TimeCodeRate - not at the reel edit rate
+                    if (double.TryParse(node.InnerText, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var timeCodeRate) && timeCodeRate > 0)
+                    {
+                        _frameRate = timeCodeRate;
+                    }
+
                     if (ss.CurrentDCinemaEditRate == "24")
                     {
                         Configuration.Settings.General.CurrentFrameRate = 24;
@@ -730,15 +745,16 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     {
                         if (innerNode.Name == "Text")
                         {
-                            if (innerNode.Attributes["Vposition"] != null)
+                            var vPositionNode = DCinemaInterop.GetAttributeIgnoreCase(innerNode, "Vposition");
+                            if (vPositionNode != null)
                             {
-                                var vAlignmentNode = innerNode.Attributes["Valign"];
+                                var vAlignmentNode = DCinemaInterop.GetAttributeIgnoreCase(innerNode, "Valign");
                                 if (vAlignmentNode != null)
                                 {
                                     vAlignment = vAlignmentNode.InnerText;
                                 }
 
-                                string vPosition = innerNode.Attributes["Vposition"].InnerText;
+                                string vPosition = vPositionNode.InnerText;
                                 if (vPosition != lastVPosition)
                                 {
                                     if (pText.Length > 0 && lastVPosition.Length > 0)
@@ -755,9 +771,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             bool alignRight = false;
                             bool alignVTop = false;
                             bool alignVCenter = false;
-                            if (innerNode.Attributes["Halign"] != null)
+                            var hAlignNode = DCinemaInterop.GetAttributeIgnoreCase(innerNode, "Halign");
+                            if (hAlignNode != null)
                             {
-                                string hAlign = innerNode.Attributes["Halign"].InnerText;
+                                string hAlign = hAlignNode.InnerText;
                                 if (hAlign == "left")
                                 {
                                     alignLeft = true;
@@ -768,9 +785,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                                 }
                             }
 
-                            if (innerNode.Attributes["Valign"] != null)
+                            var vAlignNode = DCinemaInterop.GetAttributeIgnoreCase(innerNode, "Valign");
+                            if (vAlignNode != null)
                             {
-                                string hAlign = innerNode.Attributes["Valign"].InnerText;
+                                string hAlign = vAlignNode.InnerText;
                                 if (hAlign == "top")
                                 {
                                     alignVTop = true;

--- a/tests/libse/SubtitleFormats/DCinemaSmpteTest.cs
+++ b/tests/libse/SubtitleFormats/DCinemaSmpteTest.cs
@@ -44,4 +44,123 @@ public class DCinemaSmpteTest
             Configuration.Settings.General.CurrentFrameRate = originalGlobal;
         }
     }
+
+    // Regression for discussion #13869: a MacCaption-generated SMPTE reel spells the text
+    // attributes the Interop way ("VPosition"/"VAlign"/"HAlign") instead of the SMPTE way
+    // ("Vposition"/"Valign"/"Halign"). The lookup was case sensitive, so no vertical position
+    // was ever seen, the line break between the two <Text> elements was lost, and both lines
+    // ran together without even a space.
+    private static string SmpteReel(string dcstYear, string vPositionAttribute, string vAlignAttribute, string timeCodeRate = "24") =>
+        $"""
+         <?xml version="1.0" encoding="UTF-8"?>
+         <dcst:SubtitleReel xmlns:dcst="http://www.smpte-ra.org/schemas/428-7/{dcstYear}/DCST">
+           <Id>urn:uuid:cbfae863-db46-464a-b421-51c873d16c50</Id>
+           <ContentTitleText>Subtitle Content Title</ContentTitleText>
+           <IssueDate>2026-08-13T19:56:28.770-04:00</IssueDate>
+           <ReelNumber>Reel 1</ReelNumber>
+           <Language>English</Language>
+           <EditRate>{timeCodeRate} 1</EditRate>
+           <dcst:TimeCodeRate>{timeCodeRate}</dcst:TimeCodeRate>
+           <StartTime>00:00:08:01</StartTime>
+           <SubtitleList>
+             <Font Color="FFFFFFFF" Effect="shadow" EffectColor="FF000000" Size="42" Italic="no">
+               <Subtitle SpotNumber="1" TimeIn="00:00:28:21" TimeOut="00:00:32:12">
+                 <Text Direction="horizontal" {vAlignAttribute}="bottom" {vPositionAttribute}="85.00">- How do you see</Text>
+                 <Text Direction="horizontal" {vAlignAttribute}="bottom" {vPositionAttribute}="79.29">empathy just on a whole,</Text>
+               </Subtitle>
+             </Font>
+           </SubtitleList>
+         </dcst:SubtitleReel>
+         """;
+
+    public static TheoryData<SubtitleFormat, string> SmpteFormats => new()
+    {
+        { new DCinemaSmpte2007(), "2007" },
+        { new DCinemaSmpte2010(), "2010" },
+        { new DCinemaSmpte2014(), "2014" },
+    };
+
+    [Theory]
+    [MemberData(nameof(SmpteFormats))]
+    public void Smpte_InteropCasedAttributes_KeepsTwoLines(SubtitleFormat format, string dcstYear)
+    {
+        var lines = SmpteReel(dcstYear, "VPosition", "VAlign").SplitToLines();
+        Assert.True(format.IsMine(lines, null));
+
+        var subtitle = new Subtitle();
+        format.LoadSubtitle(subtitle, lines, null);
+
+        var paragraph = Assert.Single(subtitle.Paragraphs);
+        Assert.Equal("- How do you see" + Environment.NewLine + "empathy just on a whole,", paragraph.Text);
+    }
+
+    [Theory]
+    [MemberData(nameof(SmpteFormats))]
+    public void Smpte_SchemaCasedAttributes_KeepsTwoLines(SubtitleFormat format, string dcstYear)
+    {
+        var lines = SmpteReel(dcstYear, "Vposition", "Valign").SplitToLines();
+
+        var subtitle = new Subtitle();
+        format.LoadSubtitle(subtitle, lines, null);
+
+        var paragraph = Assert.Single(subtitle.Paragraphs);
+        Assert.Equal("- How do you see" + Environment.NewLine + "empathy just on a whole,", paragraph.Text);
+    }
+
+    // TimeIn/TimeOut count ticks per second at TimeCodeRate, but loading always divided the
+    // frame field by the hardcoded default of 24, so every non-24 reel got the wrong ms.
+    [Theory]
+    [MemberData(nameof(SmpteFormats))]
+    public void Smpte_TimeCodeRate25_IsUsedForFrameToMs(SubtitleFormat format, string dcstYear)
+    {
+        var originalGlobal = Configuration.Settings.General.CurrentFrameRate;
+        try
+        {
+            var lines = SmpteReel(dcstYear, "Vposition", "Valign", "25").SplitToLines();
+
+            var subtitle = new Subtitle();
+            format.LoadSubtitle(subtitle, lines, null);
+
+            var paragraph = Assert.Single(subtitle.Paragraphs);
+
+            // 21 frames at 25 fps is 840 ms (at 24 fps it would have been 875 ms)
+            Assert.Equal(840, paragraph.StartTime.Milliseconds);
+            Assert.Equal(480, paragraph.EndTime.Milliseconds);
+        }
+        finally
+        {
+            Configuration.Settings.General.CurrentFrameRate = originalGlobal;
+        }
+    }
+
+    // The mirror-image case: an Interop file spelling the attributes the SMPTE way.
+    [Fact]
+    public void Interop_SmpteCasedAttributes_KeepsTwoLines()
+    {
+        const string xml = """
+                           <?xml version="1.0" encoding="UTF-8"?>
+                           <DCSubtitle Version="1.0">
+                             <SubtitleID>4eb245b8-4d3a-4158-9516-95dd20e8322e</SubtitleID>
+                             <MovieTitle>Unknown</MovieTitle>
+                             <ReelNumber>1</ReelNumber>
+                             <Language>English</Language>
+                             <Font Id="Font1" Color="FFFFFFFF" Size="42" Italic="no">
+                               <Subtitle SpotNumber="1" TimeIn="00:00:06:040" TimeOut="00:00:08:040" FadeUpTime="20" FadeDownTime="20">
+                                 <Text Direction="horizontal" Valign="bottom" Vposition="85.00">- How do you see</Text>
+                                 <Text Direction="horizontal" Valign="bottom" Vposition="79.29">empathy just on a whole,</Text>
+                               </Subtitle>
+                             </Font>
+                           </DCSubtitle>
+                           """;
+
+        var lines = xml.SplitToLines();
+        var format = new DCinemaInterop();
+        Assert.True(format.IsMine(lines, null));
+
+        var subtitle = new Subtitle();
+        format.LoadSubtitle(subtitle, lines, null);
+
+        var paragraph = Assert.Single(subtitle.Paragraphs);
+        Assert.Equal("- How do you see" + Environment.NewLine + "empathy just on a whole,", paragraph.Text);
+    }
 }


### PR DESCRIPTION
Fixes the problem reported in [discussion #13869](https://github.com/SubtitleEdit/subtitleedit/discussions/13869): a MacCaption-generated D-Cinema XML loads with every two-line event squashed together, e.g.

```
- How do you seeempathy just on a whole,
```

## Root cause

The SMPTE 428-7 DCST schemas (2007/2010/2014) spell the `<Text>` attributes `Vposition` / `Valign` / `Hposition` / `Halign`. The Interop `DCSubtitle` schema spells them `VPosition` / `VAlign` / `HPosition` / `HAlign`. MacCaption writes a SMPTE reel using the Interop casing (`Direction="horizontal"` is an Interop-ism too), so the file is not schema-valid against 428-7 — which is why permissive DCP tools accept it and SE did not.

`XmlNode.Attributes["Vposition"]` is case sensitive, so the lookup returned null. Line splitting in these readers is driven *entirely* by a change in `Vposition` between consecutive `<Text>` elements, so `lastVPosition` never got set, no `SubtitleLine` was ever pushed, and both text bodies kept appending to the same `StringBuilder` — hence no line break and not even a space. `Halign`/`Valign` were lost the same way, dropping `{\an}` tags and the vertical ordering.

The mirror image existed in `DCinemaInterop`, which only looked for `VPosition`.

## Changes

- New `DCinemaInterop.GetAttributeIgnoreCase` helper, used for the position/alignment lookups in all four D-Cinema readers (Interop, SMPTE 2007/2010/2014). As a bonus it is null-safe, so a text node among `<Text>`'s children no longer throws and abandons the whole subtitle.
- Frame rate on load: `TimeIn`/`TimeOut` count ticks per second at `TimeCodeRate`, but `LoadSubtitle` never set `_frameRate` (it was only assigned in `ToText`), so the frame field was always divided by the hardcoded default of 24. Now `TimeCodeRate` is used, falling back to `EditRate`.

## Verification

The attachment from the discussion now loads with all five events intact and correctly ordered (bottom-aligned, so the larger `VPosition` is the first line):

```
00:00:08,042  [gentle music]
00:00:28,875  - How do you see
              empathy just on a whole,
00:00:32,375  like not just for your people,
00:00:34,542  but for all people
              in your ministry?
00:00:38,292  - Look, as much as like
              they drive me crazy,
```

Added regression tests in `DCinemaSmpteTest`: Interop-cased attributes in a SMPTE reel, SMPTE-cased attributes in an Interop file, schema-cased attributes (unchanged behaviour), and `TimeCodeRate` 25 frame→ms conversion. 7 of them fail without the fix; the full libse suite (1385 tests) passes with it.

## Not changed

Inside the `TimeCodeRate` block there is a pre-existing dead check — `ss.CurrentDCinemaEditRate == "24"` guarding `Configuration.Settings.General.CurrentFrameRate`. `EditRate` is a two-part value (`"24 1"`), so it never matches; it presumably meant `CurrentDCinemaTimeCodeRate`. Left alone here because it mutates a global user setting on load. Happy to fix separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)