### PR TITLE
Fix llama-server ownership in batch convert and a temp-file leak

### DIFF
--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -537,7 +537,12 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
     /// </summary>
     private void StopLocalLlamaCppServer()
     {
-        if (!_usesLocalLlamaCppServer || !LlamaCppServerManager.IsServerRunning)
+        // The translate leg is known up front (the config names the engine); OCR only decides
+        // per file, deep in the converter, so its claim is read back from there - keying it on
+        // the OCR engine *setting* killed servers other windows started, for batches that never
+        // OCR'd anything (the setting lingers whether or not any input is image-based).
+        var usedForOcr = _batchConverter.UsedLocalLlamaCppOcr;
+        if ((!_usesLocalLlamaCppServer && !usedForOcr) || !LlamaCppServerManager.IsServerRunning)
         {
             return;
         }
@@ -547,19 +552,16 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
     }
 
     /// <summary>
-    /// True when <paramref name="config"/> drives the local (SE-managed) llama-server: the
-    /// llama.cpp translate engines unless the user pointed them at their own server, or the
-    /// llama.cpp OCR engine - which always runs locally.
+    /// True when <paramref name="config"/> drives the local (SE-managed) llama-server for
+    /// translation: the llama.cpp engines unless the user pointed them at their own server.
+    /// OCR is not decided here - whether a run OCRs at all depends on the input files, so the
+    /// converter reports that itself (<see cref="IBatchConverter.UsedLocalLlamaCppOcr"/>).
     /// </summary>
     private static bool UsesLocalLlamaCppServer(BatchConvertConfig config)
     {
-        var translate = config.AutoTranslate.IsActive &&
-                        config.AutoTranslate.Translator is LlamaCppTranslate or LlamaCppAdvancedTranslate &&
-                        !Se.Settings.AutoTranslate.LlamaCppUseRemoteServer;
-
-        var ocr = string.Equals(Se.Settings.Tools.BatchConvert.OcrEngine, "llama.cpp", StringComparison.OrdinalIgnoreCase);
-
-        return translate || ocr;
+        return config.AutoTranslate.IsActive &&
+               config.AutoTranslate.Translator is LlamaCppTranslate or LlamaCppAdvancedTranslate &&
+               !Se.Settings.AutoTranslate.LlamaCppUseRemoteServer;
     }
 
     private void UpdateFilteredFiles()

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -1377,6 +1377,8 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
     }
 
     /// <inheritdoc cref="RunOllamaOcr"/>
+    public bool UsedLocalLlamaCppOcr { get; private set; }
+
     private async Task<bool> RunLlamaCppOcr(IOcrSubtitle imageSubtitles, BatchConvertItem item, CancellationToken cancellationToken)
     {
         // Curated OCR model from settings (picked in batch convert settings / the OCR window).
@@ -1391,6 +1393,10 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
 
         try
         {
+            // Set before the await: starting the server is itself the slow part a user cancels
+            // out of, and the shutdown has to know this run owns it by then (#13865).
+            UsedLocalLlamaCppOcr = true;
+
             // Reused across items/files in the same batch run; killed at app exit.
             await LlamaCppServerManager.EnsureServerRunningAsync(model, cancellationToken);
         }

--- a/src/ui/Features/Tools/BatchConvert/IBatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/IBatchConverter.cs
@@ -7,4 +7,12 @@ public interface IBatchConverter
 {
     void Initialize(BatchConvertConfig config); 
     Task Convert(BatchConvertItem item, System.Threading.CancellationToken cancellationToken);
+
+    /// <summary>
+    /// True once a convert in this converter's lifetime has put the SE-managed llama-server to
+    /// work for OCR. The view model's cancel/close shutdown keys on it, so a batch whose OCR
+    /// engine is merely *configured* as llama.cpp - but which never OCRs anything - does not
+    /// kill a server another window started (#13865).
+    /// </summary>
+    bool UsedLocalLlamaCppOcr { get; }
 }

--- a/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
@@ -879,7 +879,8 @@ public partial class BurnInViewModel : ObservableObject
         {
             // Furigana, bouten and vertical writing become extra positioned render lines - burning
             // in the raw tags would put them on screen as literal text (issue #13861).
-            var japaneseAssaFileName = Path.Combine(Path.GetTempFileName() + ".ass");
+            // Not GetTempFileName() - that creates (and would leak) an empty file whose name is never used.
+            var japaneseAssaFileName = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".ass");
             File.WriteAllText(japaneseAssaFileName, NetflixImsc11JapaneseToAss.Convert(subtitle, jobItem.Width, jobItem.Height));
             return japaneseAssaFileName;
         }

--- a/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesViewModel.cs
+++ b/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesViewModel.cs
@@ -651,7 +651,8 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
             // Furigana, bouten and vertical writing become extra positioned render lines - the raw
             // tags would otherwise be rendered as literal text (issue #13861).
             var japaneseJobItem = JobItems[_jobItemIndex];
-            var japaneseAssaFileName = Path.Combine(Path.GetTempFileName() + ".ass");
+            // Not GetTempFileName() - that creates (and would leak) an empty file whose name is never used.
+            var japaneseAssaFileName = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".ass");
             File.WriteAllText(japaneseAssaFileName, NetflixImsc11JapaneseToAss.Convert(subtitle, japaneseJobItem.Width, japaneseJobItem.Height));
             return japaneseAssaFileName;
         }


### PR DESCRIPTION
Two fixes for issues found reviewing today's merges.

**Batch convert could kill a llama-server it did not start** (follow-up to #13867 / #13865). The shutdown gate's OCR leg checked only the OCR engine *setting*, which lingers whether or not any input file is image-based - so a batch converting plain text subtitles still claimed server ownership, and Cancel or closing the window killed a warm server the Auto-translate window (or main-window OCR) had started. Whether a run OCRs at all is only decided per file inside `BatchConverter`, so the converter now reports the claim itself (`IBatchConverter.UsedLocalLlamaCppOcr`, set just before the server is ensured - the slow startup is the phase a user cancels out of) and the view model reads it back at shutdown. The translate leg is unchanged.

**The Japanese render paths leaked a temp file per run** (follow-up to #13868 / #13861). `Path.Combine(Path.GetTempFileName() + ".ass")` - a one-argument `Combine` is a no-op, and `GetTempFileName()` creates an empty file on disk whose name is never used. Burn-in and transparent video now use a GUID name under the temp folder.

Verified: UI builds clean, 251 libuilogic tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)