### PR TITLE
TTS: restart the chatterbox server on a cloned-voice change (#13572)

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ChatterboxTtsCpp.cs
@@ -86,6 +86,9 @@ public class ChatterboxTtsCpp : ITtsEngine
     private static Process? _serverProcess;
     private static int _serverPort;
     private static string? _serverModelKey;
+    // The `voice` the running server last served, i.e. whose clone conditionals are installed in
+    // it (bare file name, empty for the model's baked default voice). See NeedsRestartForVoice.
+    private static string _serverVoiceKey = string.Empty;
     private static string? _serverLaunchCommand;
     private static bool _processExitHooked;
     // Rolling buffer of the server's stdout+stderr — used to attach context to
@@ -347,7 +350,7 @@ public class ChatterboxTtsCpp : ITtsEngine
         }
 
         var modelKey = ResolveModelKey(model);
-        await EnsureServerRunningAsync(modelKey, cancellationToken);
+        await EnsureServerRunningAsync(modelKey, ResolveVoiceKey(chatterboxVoice.FilePath), cancellationToken);
 
         // Off the calling thread because the repair shells out to ffmpeg. Deliberately not a hard
         // failure either: the check is stricter than the backend's (which still has a partial
@@ -424,19 +427,18 @@ public class ChatterboxTtsCpp : ITtsEngine
             string prefix;
             if (LooksLikeCudaBackendCrash(serverLog))
             {
-                prefix = "Chatterbox TTS hit a CrispASR bug in the CUDA backend during synthesis "
-                         + "(CUDA error in ggml_cuda_cpy). Switch CrispASR to the Vulkan build - "
-                         + "Video → Audio to text → engine settings → re-download - which does not run "
-                         + "this code path, or generate one voice per run: the reported crashes all land "
-                         + "on the first step after the cloned voice changes between lines. "
-                         + "Please also report it at https://github.com/CrispStrobe/CrispASR/issues with the server log below.";
+                prefix = "Chatterbox TTS hit a CrispASR bug during synthesis (CUDA error in ggml_cuda_cpy). "
+                         + "This is not specific to the CUDA build - the Vulkan build crashes at the identical "
+                         + "point, so re-downloading a different build does not help. The known trigger is the "
+                         + "first step after the cloned voice changes; Subtitle Edit restarts the server on a "
+                         + "voice change to avoid it, so please report this at "
+                         + "https://github.com/CrispStrobe/CrispASR/issues with the server log below.";
             }
             else if (LooksLikeUpstreamChatterboxCrash(serverLog))
             {
                 prefix = "Chatterbox TTS hit a CrispASR runtime bug during synthesis (ggml tensor read out of bounds). "
                          + "This is an upstream issue — please file it at https://github.com/CrispStrobe/CrispASR/issues with the server log below. "
-                         + "The crash reproduces on the CPU and Vulkan builds (chatterbox's T3 step runs on CPU regardless of the build); "
-                         + "the CUDA build does not hit this one, but has a crash of its own (#13572).";
+                         + "The crash reproduces on the CPU and Vulkan builds (chatterbox's T3 step runs on CPU regardless of the build).";
             }
             else
             {
@@ -530,13 +532,24 @@ public class ChatterboxTtsCpp : ITtsEngine
             payload["source_lang"] = sourceLanguageCode;
         }
 
-        if (!string.IsNullOrEmpty(voiceFilePath))
+        var voiceKey = ResolveVoiceKey(voiceFilePath);
+        if (!string.IsNullOrEmpty(voiceKey))
         {
-            payload["voice"] = Path.GetFileName(voiceFilePath);
+            payload["voice"] = voiceKey;
             CrispAsrTtsProvenance.AddSpeechAttestations(payload);
         }
 
         return payload;
+    }
+
+    /// <summary>
+    /// The <c>voice</c> field for a reference WAV path — the bare file name, empty for the model's
+    /// baked default voice. Also identifies which clone the running server has conditionals
+    /// installed for (see <see cref="EnsureServerRunningAsync"/>).
+    /// </summary>
+    internal static string ResolveVoiceKey(string? voiceFilePath)
+    {
+        return string.IsNullOrEmpty(voiceFilePath) ? string.Empty : Path.GetFileName(voiceFilePath);
     }
 
     /// <summary>
@@ -606,24 +619,76 @@ public class ChatterboxTtsCpp : ITtsEngine
         }
     }
 
-    private static async Task EnsureServerRunningAsync(string modelKey, CancellationToken ct)
+    /// <summary>
+    /// True when the running server has already served a cloned voice and a different one is now
+    /// asked for.
+    /// </summary>
+    /// <remarks>
+    /// Installing a second voice's conditionals into a live chatterbox server crashes it at the
+    /// first autoregressive step of that request (#13572). Both reported crashes have the same
+    /// shape - previous line fine with voice A, <c>atomic native WAV clone (B.wav ...) - all 5 conds
+    /// installed</c>, then death at <c>chatterbox[ar]: step=0</c> - and the CUDA and Vulkan builds
+    /// die at the identical token, so this is the shared voice-load path and not a GPU backend bug.
+    /// A server that loads the voice at startup is fine, so the fix is to make every voice the first
+    /// one its server sees. Costs a model reload per voice change, which an actor-voice cast pays on
+    /// every actor change; that is still cheaper than the crash it replaces, since #13795's retry
+    /// already restarts the server after throwing away the line's synthesis.
+    /// <para>
+    /// Switching to the baked default voice restarts too: that swaps the conditionals back through
+    /// the same upstream code. Going the other way - default → clone - does not, because the clone
+    /// is then the first one this server installs. Narrow this once upstream fixes it.
+    /// </para>
+    /// </remarks>
+    private static bool NeedsRestartForVoice(string voiceKey) => NeedsRestartForVoice(_serverVoiceKey, voiceKey);
+
+    /// <inheritdoc cref="NeedsRestartForVoice(string)"/>
+    internal static bool NeedsRestartForVoice(string loadedVoiceKey, string requestedVoiceKey)
     {
-        if (_serverProcess is { HasExited: false } && _serverPort != 0 && _serverModelKey == modelKey)
+        return !string.IsNullOrEmpty(loadedVoiceKey)
+               && !string.Equals(loadedVoiceKey, requestedVoiceKey, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Starts the crispasr server for <paramref name="modelKey"/>, or reuses the running one.
+    /// Restarts it when <paramref name="voiceKey"/> differs from the voice it last served — see
+    /// <see cref="NeedsRestartForVoice"/>.
+    /// </summary>
+    private static async Task EnsureServerRunningAsync(string modelKey, string voiceKey, CancellationToken ct)
+    {
+        if (_serverProcess is { HasExited: false }
+            && _serverPort != 0
+            && _serverModelKey == modelKey
+            && !NeedsRestartForVoice(voiceKey))
         {
+            _serverVoiceKey = voiceKey;
             return;
         }
 
         await ServerLock.WaitAsync(ct);
         try
         {
-            if (_serverProcess is { HasExited: false } && _serverPort != 0 && _serverModelKey == modelKey)
+            if (_serverProcess is { HasExited: false }
+                && _serverPort != 0
+                && _serverModelKey == modelKey
+                && !NeedsRestartForVoice(voiceKey))
             {
+                _serverVoiceKey = voiceKey;
                 return;
             }
 
-            // Server not running — or running with a different model variant. (Re)start.
+            // Server not running — or running with a different model variant, or with another
+            // voice's clone conditionals installed. (Re)start.
             if (_serverProcess != null)
             {
+                if (_serverProcess is { HasExited: false } && NeedsRestartForVoice(voiceKey))
+                {
+                    Se.WriteToolsLog(
+                        "Chatterbox TTS: restarting the crispasr server before switching cloned voice "
+                        + $"'{_serverVoiceKey}' -> '{(string.IsNullOrEmpty(voiceKey) ? "(default)" : voiceKey)}' "
+                        + "- installing a second voice's conditionals into a live server crashes the "
+                        + "chatterbox backend at the first autoregressive step (#13572).");
+                }
+
                 StopServerInternal();
             }
 
@@ -706,6 +771,7 @@ public class ChatterboxTtsCpp : ITtsEngine
             _serverProcess = process;
             _serverPort = port;
             _serverModelKey = modelKey;
+            _serverVoiceKey = voiceKey;
             HookProcessExitOnce();
 
             // First-run model auto-download (~880 MB) needs a generous timeout.
@@ -721,6 +787,7 @@ public class ChatterboxTtsCpp : ITtsEngine
                     _serverProcess = null;
                     _serverPort = 0;
                     _serverModelKey = null;
+                    _serverVoiceKey = string.Empty;
                     _serverLaunchCommand = null;
                     if (LooksLikeOutdatedCrispAsr(tail))
                     {
@@ -804,18 +871,21 @@ public class ChatterboxTtsCpp : ITtsEngine
     }
 
     /// <summary>
-    /// The CUDA build's own chatterbox synth crash (#13572), distinct from the CPU/Vulkan assert
-    /// above:
+    /// A CUDA-backend fault during chatterbox synth (#13572):
     /// <code>
     /// chatterbox[ar]: step=0 tok=3704
     /// CUDA error: invalid argument
     ///   current device: 0, in function ggml_cuda_cpy at ggml/src/ggml-cuda/cpy.cu:474
     ///   cudaMemcpyAsync(src1_ddc, src0_ddc, ggml_nbytes(src0), cudaMemcpyDeviceToDevice, main_stream)
     /// </code>
-    /// Both reports on that issue crash at the first autoregressive step of the request that
-    /// switches to a different cloned voice, right after the new conditionals are installed - and
-    /// a device-to-device copy failing with "invalid argument" is what a buffer that is not device
-    /// memory looks like. Matched on the ggml function name plus the generic "CUDA error" banner so
+    /// Every report on that issue crashes at the first autoregressive step of the request that
+    /// switches to a different cloned voice, right after the new conditionals are installed.
+    /// <b>This is not a CUDA-specific bug</b>: the Vulkan build dies at the identical point - same
+    /// voice, same conditionals, same <c>prefill 163</c>, same <c>step=0 tok=3704</c> - so the fault
+    /// is in the shared voice-load path and only its symptom is backend-shaped (a device-to-device
+    /// copy failing with "invalid argument" is what a buffer that is not device memory looks like).
+    /// <see cref="EnsureServerRunningAsync"/> now restarts the server on a clone-voice change to
+    /// stay off that path. Matched on the ggml function name plus the generic "CUDA error" banner so
     /// a fault in another op is still recognised as a CUDA one.
     /// </summary>
     internal static bool LooksLikeCudaBackendCrash(string output)
@@ -993,6 +1063,7 @@ public class ChatterboxTtsCpp : ITtsEngine
         _serverProcess = null;
         _serverPort = 0;
         _serverModelKey = null;
+        _serverVoiceKey = string.Empty;
         _serverLaunchCommand = null;
         if (p == null)
         {

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -2740,7 +2740,8 @@ public partial class TextToSpeechViewModel : ObservableObject
     /// </summary>
     /// <remarks>
     /// A local-server engine can die in the middle of a batch: CrispASR's chatterbox backend
-    /// crashes on the CUDA build at the first autoregressive step after a voice change (#13572).
+    /// crashes at the first autoregressive step after a cloned-voice change - on the CUDA and the
+    /// Vulkan build alike (#13572).
     /// That arrived here as an exception, escaped the generate loop into its catch-all, and
     /// returned null - so every segment already synthesised (five to ten minutes of work in that
     /// report) was discarded because of one bad line. Now the line is recorded as failed and the

--- a/tests/UI/Features/Video/TextToSpeech/Engines/ChatterboxTtsCppTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/ChatterboxTtsCppTests.cs
@@ -406,6 +406,41 @@ public class ChatterboxTtsCppTests
         }).ToList();
         Assert.Equal(files.Count, files.Distinct().Count());
     }
+    /// <summary>
+    /// Installing a second voice's clone conditionals into a live server crashes the chatterbox
+    /// backend at the first autoregressive step, on the CUDA and the Vulkan build alike (#13572),
+    /// so a voice change has to restart the server. See ChatterboxTtsCpp.NeedsRestartForVoice.
+    /// </summary>
+    [Theory]
+    [InlineData("Rich.wav", "Stephen.wav", true)]  // clone → other clone: the reported crash
+    [InlineData("Rich.wav", "", true)]             // clone → baked default: swaps conds back
+    [InlineData("", "Rich.wav", false)]            // default → clone: the clone is the first one
+    [InlineData("", "", false)]                    // default throughout
+    [InlineData("Rich.wav", "Rich.wav", false)]    // same voice line after line
+    public void NeedsRestartForVoice_RestartsOnlyWhenALoadedCloneChanges(
+        string loadedVoiceKey,
+        string requestedVoiceKey,
+        bool expected)
+    {
+        Assert.Equal(expected, ChatterboxTtsCpp.NeedsRestartForVoice(loadedVoiceKey, requestedVoiceKey));
+    }
+
+    /// <summary>
+    /// The restart decision compares the same value the request sends as <c>voice</c>, so two
+    /// references that differ only in folder must not look like one voice.
+    /// </summary>
+    [Fact]
+    public void ResolveVoiceKey_MatchesTheVoiceFieldOfThePayload()
+    {
+        var path = Path.Combine("some", "dir", "Arnold.wav");
+        var payload = ChatterboxTtsCpp.BuildSpeakPayload("hello", path);
+
+        Assert.Equal(payload["voice"], ChatterboxTtsCpp.ResolveVoiceKey(path));
+        Assert.Equal("Arnold.wav", ChatterboxTtsCpp.ResolveVoiceKey(path));
+        Assert.Equal(string.Empty, ChatterboxTtsCpp.ResolveVoiceKey(string.Empty));
+        Assert.Equal(string.Empty, ChatterboxTtsCpp.ResolveVoiceKey(null));
+    }
+
     private static string WriteTempWav(byte[] bytes)
     {
         var path = Path.Combine(Path.GetTempPath(), $"chatterbox-ref-test-{Guid.NewGuid():N}.wav");


### PR DESCRIPTION
The new Vulkan log on #13572 falsifies the previous diagnosis: the crash is **not** the CUDA backend's.

Both builds die at the identical point — same voice switch (`RICH.wav` → `STEPHEN.wav`), same conditionals (157 prompt_token, T_mel=314), same 125 BPE tokens, same `prefill 163`, same `chatterbox[ar]: step=0 tok=3704`. Bit-identical across two different compute backends means a deterministic, data-dependent fault in CrispASR's shared voice-load path; the CUDA `ggml_cuda_cpy` `invalid argument` is only how that backend expresses it (a device-to-device copy failing that way is what a buffer that isn't device memory looks like).

## Restart on a cloned-voice change

`ChatterboxTtsCpp` now tracks which voice the running server has clone conditionals installed for, and `EnsureServerRunningAsync` treats that as part of the server's identity alongside the model key. When a different voice is requested, the server is restarted first — so every voice is the first one its server sees, which is the state the bug never reproduces in.

The rule is deliberately asymmetric:

| Transition | Restart | Why |
|---|---|---|
| clone A → clone B | yes | the reported crash |
| clone A → default | yes | swaps the conditionals back through the same upstream code |
| default → clone | no | the clone is still that server's first install |
| same voice | no | many such lines succeed in both reports |

Cost is a model reload per voice change, which an actor-voice cast pays on every actor change. That is what the crash already cost via #13795's retry, minus the discarded synthesis — so it is never worse than the status quo, and the doc comment says to narrow it once upstream fixes the real bug.

`NeedsRestartForVoice` and the new `ResolveVoiceKey` are `internal` and unit-tested; `ResolveVoiceKey` now also produces the payload's `voice` field, so the restart key and the value on the wire cannot drift apart.

## Error messages

- The CUDA-crash message no longer tells users to re-download the Vulkan build. It says the fault is not build-specific, names the voice-change trigger, notes that SE now restarts the server, and asks for an upstream report.
- The `tensor read out of bounds` message loses its "the CUDA build does not hit this one, but has a crash of its own" tail, for the same reason.
- Same correction to the doc comments on `LooksLikeCudaBackendCrash` and `SpeakOneParagraphAsync`.

## Testing

- 6 new cases in `ChatterboxTtsCppTests` covering the restart matrix above and the voice-key/payload agreement.
- `dotnet test --filter FullyQualifiedName~TextToSpeech` → 271 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)