### PR TITLE
Remember which Multiple replace categories are expanded (#13526)

### DIFF
--- a/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
+++ b/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
@@ -2,7 +2,6 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
-using Avalonia.LogicalTree;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -185,17 +184,9 @@ public partial class MultipleReplaceViewModel : ObservableObject
         _subtitle = subtitle;
         _dirty = true;
 
-        Dispatcher.UIThread.Post(() =>
-        {
-            var allTreeViewItems = FindAllTreeViewItems(RulesTreeView);
-            foreach (var item in allTreeViewItems)
-            {
-                if (item.DataContext is RuleTreeNode node && node.IsCategory)
-                {
-                    item.IsExpanded = node.IsExpanded;
-                }
-            }
-        });
+        // Expanded/collapsed is restored by the tree item container theme binding to
+        // RuleTreeNode.IsExpanded - pushing it onto the containers from here could not work, as
+        // the view model is configured before the window is even constructed (#13526).
     }
 
     private static List<RuleTreeNode> GetNodes()
@@ -226,15 +217,6 @@ public partial class MultipleReplaceViewModel : ObservableObject
 
     private void SaveSettings()
     {
-        var expandedCategories = new List<RuleTreeNode>();
-        foreach (var item in FindAllTreeViewItems(RulesTreeView))
-        {
-            if (item.DataContext is RuleTreeNode node && node.IsCategory && item.IsExpanded)
-            {
-                expandedCategories.Add(node);
-            }
-        }
-
         Se.Settings.Edit.MultipleReplace.Categories.Clear();
         foreach (var category in Nodes)
         {
@@ -242,7 +224,7 @@ public partial class MultipleReplaceViewModel : ObservableObject
             {
                 Name = category.CategoryName,
                 IsActive = category.IsActive,
-                IsExpanded = expandedCategories.Contains(category),
+                IsExpanded = category.IsExpanded,
             };
             Se.Settings.Edit.MultipleReplace.Categories.Add(c);
 
@@ -576,19 +558,7 @@ public partial class MultipleReplaceViewModel : ObservableObject
                     MultipleReplaceType.CaseInsensitive,
             });
             node.SubNodes?.Add(rule);
-
-            Dispatcher.UIThread.Post(() =>
-            {
-                var allTreeViewItems = FindAllTreeViewItems(RulesTreeView);
-                foreach (var item in allTreeViewItems)
-                {
-                    if (item.DataContext == node)
-                    {
-                        item.IsExpanded = true;
-                        break;
-                    }
-                }
-            }, DispatcherPriority.Background);
+            node.IsExpanded = true;
 
             SelectedNode = rule;
             _dirty = true;
@@ -1158,31 +1128,23 @@ public partial class MultipleReplaceViewModel : ObservableObject
             return;
         }
 
-        var parent = rule.Parent;
+        if (rule.Parent != null)
+        {
+            rule.Parent.IsExpanded = true;
+        }
 
+        // The rule's own container only exists once the category above it has expanded, so
+        // selecting and scrolling to it has to wait for that layout pass.
         Dispatcher.UIThread.Post(() =>
         {
-            var allTreeViewItems = FindAllTreeViewItems(RulesTreeView);
-            foreach (var item in allTreeViewItems)
+            SelectedNode = rule;
+            var container = RulesTreeView.ContainerFromItem(rule) as TreeViewItem;
+            if (container != null)
             {
-                if (item.DataContext == parent)
-                {
-                    item.IsExpanded = true;
-                    break;
-                }
+                container.BringIntoView();
+                container.Focus(NavigationMethod.Directional);
             }
-
-            Dispatcher.UIThread.Post(() =>
-            {
-                SelectedNode = rule;
-                var container = RulesTreeView.ContainerFromItem(rule) as TreeViewItem;
-                if (container != null)
-                {
-                    container.BringIntoView();
-                    container.Focus(NavigationMethod.Directional);
-                }
-            }, DispatcherPriority.Input);
-        }, DispatcherPriority.Background);
+        }, DispatcherPriority.Input);
     }
 
     /// <summary>
@@ -1288,46 +1250,21 @@ public partial class MultipleReplaceViewModel : ObservableObject
     [RelayCommand]
     public void ExpandAll()
     {
-        Dispatcher.UIThread.Post(() =>
-        {
-            var allTreeViewItems = FindAllTreeViewItems(RulesTreeView);
-            foreach (var item in allTreeViewItems)
-            {
-                item.IsExpanded = true;
-            }
-        }, DispatcherPriority.Background);
+        SetAllExpanded(true);
     }
 
     [RelayCommand]
     public void CollapseAll()
     {
-        Dispatcher.UIThread.Post(() =>
-        {
-            var allTreeViewItems = FindAllTreeViewItems(RulesTreeView);
-            foreach (var item in allTreeViewItems)
-            {
-                item.IsExpanded = false;
-            }
-        }, DispatcherPriority.Background);
+        SetAllExpanded(false);
     }
 
-    private static IEnumerable<TreeViewItem> FindAllTreeViewItems(Control parent)
+    private void SetAllExpanded(bool isExpanded)
     {
-        var result = new List<TreeViewItem>();
-        if (parent is TreeViewItem tvi)
+        foreach (var node in Nodes.Where(p => p.IsCategory))
         {
-            result.Add(tvi);
+            node.IsExpanded = isExpanded;
         }
-
-        foreach (var child in parent.GetLogicalDescendants())
-        {
-            if (child is TreeViewItem treeViewItem)
-            {
-                result.Add(treeViewItem);
-            }
-        }
-
-        return result;
     }
 
     private static RuleTreeNode MakeRuleTreeNode(RuleTreeNode node, EditRuleViewModel result)

--- a/src/ui/Features/Edit/MultipleReplace/MultipleReplaceWindow.cs
+++ b/src/ui/Features/Edit/MultipleReplace/MultipleReplaceWindow.cs
@@ -7,6 +7,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
+using Avalonia.Styling;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Files.Compare;
 using Nikse.SubtitleEdit.Logic;
@@ -107,6 +108,19 @@ public class MultipleReplaceWindow : Window
             SelectionMode = SelectionMode.Single,
             DataContext = vm,
             MinWidth = 300,
+
+            // Expanded/collapsed lives on the node, not on the container: the containers only
+            // exist while they are realized, so reading the expansion state back off them at save
+            // time would record any category the tree had not realized as collapsed.
+            ItemContainerTheme = new ControlTheme(typeof(TreeViewItem))
+            {
+                BasedOn = Application.Current?.FindResource(typeof(TreeViewItem)) as ControlTheme,
+                Setters =
+                {
+                    new Setter(TreeViewItem.IsExpandedProperty,
+                        new Binding(nameof(RuleTreeNode.IsExpanded)) { Mode = BindingMode.TwoWay }),
+                },
+            },
         };
 
         treeView[!ItemsControl.ItemsSourceProperty] = new Binding(nameof(vm.Nodes));

--- a/tests/UI/Features/Edit/MultipleReplaceExpandCollapseTests.cs
+++ b/tests/UI/Features/Edit/MultipleReplaceExpandCollapseTests.cs
@@ -1,0 +1,167 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Nikse.SubtitleEdit.Features.Edit.MultipleReplace;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Linq;
+
+namespace UITests.Features.Edit;
+
+/// <summary>
+/// Which rule categories are expanded is remembered in the settings. It used to be pushed onto the
+/// tree item containers from <c>Initialize</c>, which runs before the window is even constructed -
+/// so there was nothing to push it onto and every category came back collapsed (#13526). It is now
+/// carried by RuleTreeNode.IsExpanded, bound two-way from the tree's item container theme.
+/// </summary>
+public class MultipleReplaceExpandCollapseTests
+{
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private static void SeedSettings(bool dutchExpanded, bool englishExpanded)
+    {
+        Se.Settings.Edit.MultipleReplace.Categories.Clear();
+        foreach (var (name, isExpanded) in new[] { ("Dutch", dutchExpanded), ("English", englishExpanded) })
+        {
+            var c = new SeEditMultipleReplace.MultipleReplaceCategory
+            {
+                Name = name,
+                IsActive = true,
+                IsExpanded = isExpanded,
+            };
+            c.Rules.Add(new MultipleReplaceRule
+            {
+                Active = true,
+                Find = $"{name}1",
+                ReplaceWith = $"repl{name}1",
+                Type = MultipleReplaceType.CaseInsensitive,
+            });
+
+            Se.Settings.Edit.MultipleReplace.Categories.Add(c);
+        }
+    }
+
+    private static MultipleReplaceViewModel NewViewModel()
+    {
+        return new MultipleReplaceViewModel(new WindowService(new NullServiceProvider()), new FileHelper());
+    }
+
+    private static TreeViewItem CategoryContainer(MultipleReplaceViewModel vm, string categoryName)
+    {
+        return vm.RulesTreeView.GetVisualDescendants()
+            .OfType<TreeViewItem>()
+            .First(i => i.DataContext is RuleTreeNode { IsCategory: true } node && node.CategoryName == categoryName);
+    }
+
+    [AvaloniaFact]
+    public void RememberedExpansion_IsRestoredWhenTheWindowOpens()
+    {
+        SeedSettings(dutchExpanded: true, englishExpanded: false);
+        var vm = NewViewModel();
+
+        // The order the real dialog uses: WindowService configures the view model - which is where
+        // Initialize runs - and only then constructs and shows the window (#13526).
+        vm.Initialize(new Nikse.SubtitleEdit.Core.Common.Subtitle());
+        var window = new MultipleReplaceWindow(vm);
+        try
+        {
+            // Anything Initialize queued runs before the tree has laid out, so before a single
+            // item container exists - which is what made the old restore a no-op.
+            Dispatcher.UIThread.RunJobs();
+
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(CategoryContainer(vm, "Dutch").IsExpanded);
+            Assert.False(CategoryContainer(vm, "English").IsExpanded);
+        }
+        finally
+        {
+            window.Close();
+            Se.Settings.Edit.MultipleReplace.Categories.Clear();
+        }
+    }
+
+    [AvaloniaFact]
+    public void ExpandingInTheTree_SurvivesCloseAndReopen()
+    {
+        SeedSettings(dutchExpanded: false, englishExpanded: false);
+        try
+        {
+            var vm = NewViewModel();
+            var window = new MultipleReplaceWindow(vm);
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            // What a click on the chevron does.
+            CategoryContainer(vm, "English").IsExpanded = true;
+            Dispatcher.UIThread.RunJobs();
+            Assert.True(vm.Nodes.First(n => n.CategoryName == "English").IsExpanded);
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(Se.Settings.Edit.MultipleReplace.Categories.First(c => c.Name == "English").IsExpanded);
+            Assert.False(Se.Settings.Edit.MultipleReplace.Categories.First(c => c.Name == "Dutch").IsExpanded);
+
+            var reopened = NewViewModel();
+            var reopenedWindow = new MultipleReplaceWindow(reopened);
+            try
+            {
+                reopenedWindow.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.True(CategoryContainer(reopened, "English").IsExpanded);
+                Assert.False(CategoryContainer(reopened, "Dutch").IsExpanded);
+            }
+            finally
+            {
+                reopenedWindow.Close();
+            }
+        }
+        finally
+        {
+            Se.Settings.Edit.MultipleReplace.Categories.Clear();
+        }
+    }
+
+    [AvaloniaFact]
+    public void ExpandAllAndCollapseAll_AreRemembered()
+    {
+        SeedSettings(dutchExpanded: false, englishExpanded: false);
+        try
+        {
+            var vm = NewViewModel();
+            var window = new MultipleReplaceWindow(vm);
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            vm.ExpandAllCommand.Execute(null);
+            Dispatcher.UIThread.RunJobs();
+            Assert.True(CategoryContainer(vm, "Dutch").IsExpanded);
+            Assert.True(CategoryContainer(vm, "English").IsExpanded);
+
+            vm.CollapseAllCommand.Execute(null);
+            Dispatcher.UIThread.RunJobs();
+            Assert.False(CategoryContainer(vm, "Dutch").IsExpanded);
+            Assert.False(CategoryContainer(vm, "English").IsExpanded);
+
+            vm.ExpandAllCommand.Execute(null);
+            Dispatcher.UIThread.RunJobs();
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.All(Se.Settings.Edit.MultipleReplace.Categories, c => Assert.True(c.IsExpanded));
+        }
+        finally
+        {
+            Se.Settings.Edit.MultipleReplace.Categories.Clear();
+        }
+    }
+}


### PR DESCRIPTION
Expanding a rule category in **Multiple replace**, closing the window and opening it again always came back collapsed.

### Cause

The expansion state *was* saved, but restoring it could never work. `Initialize` pushed `RuleTreeNode.IsExpanded` onto the tree's `TreeViewItem` containers via `Dispatcher.UIThread.Post`, and the window service configures the view model - which is where `Initialize` runs - *before* it constructs the window (`WindowsService.ShowDialogAsync`). The posted callback runs at Normal priority, ahead of the layout pass that creates the containers, so it found nothing to set and the remembered state was dropped. That is why the tree opened collapsed every time rather than intermittently.

### Fix

`TreeViewItem.IsExpanded` is now bound two-way to `RuleTreeNode.IsExpanded` from the tree's `ItemContainerTheme`, so the node holds the state and a container picks it up whenever it is created - no ordering to get right.

- `SaveSettings` reads `category.IsExpanded` instead of walking realized containers. The old walk would have recorded any category the tree had not realized as collapsed.
- Expand all / collapse all, "add rule expands its category" and navigate-to-rule set the node directly, which drops four dispatcher round-trips and the `FindAllTreeViewItems` helper (-84 lines).

### Tests

New `MultipleReplaceExpandCollapseTests`: restore on open, expand -> close -> reopen round-trip, and expand/collapse all persistence. Two of the three fail on the code before this change; all 75 Multiple replace UI tests pass with it.

Fixes #13526

🤖 Generated with [Claude Code](https://claude.com/claude-code)