### PR TITLE
Fix #13865: defer the minimize mirror's writes so restore cannot wedge rendering

### DIFF
--- a/src/ui/Logic/WindowsService.cs
+++ b/src/ui/Logic/WindowsService.cs
@@ -564,6 +564,7 @@ namespace Nikse.SubtitleEdit.Logic
             // synchronously, which must not bounce back as a user action. Other frames of a nested
             // chain have their own flag and do react - that is what makes the cascade work.
             var syncing = false;
+            var disposed = false;
 
             // Restore targets. A window is never restored to Minimized; if a state was somehow
             // captured as such, fall back to Normal.
@@ -579,9 +580,27 @@ namespace Nikse.SubtitleEdit.Logic
             // ordinary Normal <-> Maximized change and repair the foreground exactly once.
             var pairMinimized = false;
 
-            void OnDialogStateChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
+            // Bounds SyncDialogToOwner's wait for the shell to re-show the owned dialog; after
+            // ~2 s the write proceeds anyway (worst case is the pre-fix behavior).
+            var dialogShowRetries = 0;
+
+            // The counterpart writes below are POSTED, never made from inside the other window's
+            // state-change dispatch. Win32 hides a minimized owner's owned windows and re-shows
+            // them on restore, and Avalonia's Win32 backend records a programmatic WindowState
+            // write on a hidden window WITHOUT performing it (WindowImpl.WindowState skips
+            // ShowWindow when !IsWindowVisible but still sets _lastWindowState). A synchronous
+            // "restore the dialog" write from inside the owner's restore dispatch can therefore
+            // land while the shell has not yet re-shown the dialog - the write is swallowed, and
+            // when the dialog is then actually restored its WM_SIZE reports no state change, so
+            // Avalonia never invokes WindowStateChanged and never calls StartRendering: the
+            // window is alive for input but permanently stops painting and laying out, frozen at
+            // its pre-minimize content (#13865, ~70% of restores). Posting runs the write after
+            // the OS has finished the whole restore sequence, when the owned windows are visible
+            // again. The posted body re-reads live state instead of replaying the transition it
+            // was queued for, so a stale post (state changed again before it ran) is a no-op.
+            void SyncOwnerToDialog()
             {
-                if (e.Property != Window.WindowStateProperty || syncing)
+                if (disposed)
                 {
                     return;
                 }
@@ -591,7 +610,6 @@ namespace Nikse.SubtitleEdit.Logic
                 {
                     if (dialog.WindowState == WindowState.Minimized)
                     {
-                        pairMinimized = true;
                         if (owner.WindowState != WindowState.Minimized)
                         {
                             ownerRestoreState = owner.WindowState;
@@ -601,17 +619,56 @@ namespace Nikse.SubtitleEdit.Logic
                     }
                     else
                     {
-                        dialogRestoreState = dialog.WindowState;
                         if (owner.WindowState == WindowState.Minimized)
                         {
                             owner.WindowState = ownerRestoreState;
                         }
 
                         ownerMinimizedByMirror = false;
-                        if (pairMinimized)
+                    }
+                }
+                finally
+                {
+                    syncing = false;
+                }
+            }
+
+            void SyncDialogToOwner()
+            {
+                if (disposed)
+                {
+                    return;
+                }
+
+                if (owner.WindowState != WindowState.Minimized &&
+                    dialog.WindowState == WindowState.Minimized &&
+                    !IsOsVisible(dialog) &&
+                    dialogShowRetries++ < 40)
+                {
+                    // The shell has not re-shown the owned dialog yet - writing now would be
+                    // swallowed and poison the platform's state tracking (see above). Retry
+                    // shortly; the shell shows owned windows as part of the owner's restore,
+                    // so one round is normally enough.
+                    DispatcherTimer.RunOnce(SyncDialogToOwner, TimeSpan.FromMilliseconds(50));
+                    return;
+                }
+
+                syncing = true;
+                try
+                {
+                    if (owner.WindowState == WindowState.Minimized)
+                    {
+                        if (dialog.WindowState != WindowState.Minimized)
                         {
-                            pairMinimized = false;
-                            RepairModalForegroundAfterRestore(dialog);
+                            dialogRestoreState = dialog.WindowState;
+                            dialog.WindowState = WindowState.Minimized;
+                        }
+                    }
+                    else
+                    {
+                        if (dialog.WindowState == WindowState.Minimized)
+                        {
+                            dialog.WindowState = dialogRestoreState;
                         }
                     }
                 }
@@ -619,6 +676,30 @@ namespace Nikse.SubtitleEdit.Logic
                 {
                     syncing = false;
                 }
+            }
+
+            void OnDialogStateChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
+            {
+                if (e.Property != Window.WindowStateProperty || syncing)
+                {
+                    return;
+                }
+
+                if (dialog.WindowState == WindowState.Minimized)
+                {
+                    pairMinimized = true;
+                }
+                else
+                {
+                    dialogRestoreState = dialog.WindowState;
+                    if (pairMinimized)
+                    {
+                        pairMinimized = false;
+                        RepairModalForegroundAfterRestore(dialog);
+                    }
+                }
+
+                Dispatcher.UIThread.Post(SyncOwnerToDialog);
             }
 
             void OnOwnerStateChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
@@ -628,38 +709,23 @@ namespace Nikse.SubtitleEdit.Logic
                     return;
                 }
 
-                syncing = true;
-                try
+                if (owner.WindowState == WindowState.Minimized)
                 {
-                    if (owner.WindowState == WindowState.Minimized)
+                    pairMinimized = true;
+                }
+                else
+                {
+                    ownerRestoreState = owner.WindowState;
+                    ownerMinimizedByMirror = false;
+                    if (pairMinimized)
                     {
-                        pairMinimized = true;
-                        if (dialog.WindowState != WindowState.Minimized)
-                        {
-                            dialogRestoreState = dialog.WindowState;
-                            dialog.WindowState = WindowState.Minimized;
-                        }
+                        pairMinimized = false;
+                        RepairModalForegroundAfterRestore(dialog);
                     }
-                    else
-                    {
-                        ownerRestoreState = owner.WindowState;
-                        ownerMinimizedByMirror = false;
-                        if (dialog.WindowState == WindowState.Minimized)
-                        {
-                            dialog.WindowState = dialogRestoreState;
-                        }
+                }
 
-                        if (pairMinimized)
-                        {
-                            pairMinimized = false;
-                            RepairModalForegroundAfterRestore(dialog);
-                        }
-                    }
-                }
-                finally
-                {
-                    syncing = false;
-                }
+                dialogShowRetries = 0;
+                Dispatcher.UIThread.Post(SyncDialogToOwner);
             }
 
             dialog.PropertyChanged += OnDialogStateChanged;
@@ -667,6 +733,7 @@ namespace Nikse.SubtitleEdit.Logic
 
             return new ActionDisposable(() =>
             {
+                disposed = true;
                 dialog.PropertyChanged -= OnDialogStateChanged;
                 owner.PropertyChanged -= OnOwnerStateChanged;
 
@@ -674,13 +741,35 @@ namespace Nikse.SubtitleEdit.Logic
                 // bring the owner back when this mirror minimized it, so the app does not end up
                 // as a minimized main window the user never asked for (and whose -32000 minimized
                 // position would otherwise be persisted on exit). When the user minimized the
-                // owner itself, their choice is left alone.
+                // owner itself, their choice is left alone. (The owner has no owner of its own,
+                // so it is never OS-hidden and this synchronous write cannot be swallowed.)
                 if (ownerMinimizedByMirror && owner.WindowState == WindowState.Minimized)
                 {
                     owner.WindowState = ownerRestoreState;
                 }
             });
         }
+
+        /// <summary>
+        /// Whether the window is visible at the OS level. Avalonia's IsVisible only tracks its
+        /// own Show/Hide calls - it stays true when Windows hides an owned window because its
+        /// owner was minimized, which is exactly the state the minimize mirror must not write
+        /// WindowState into (#13865). Non-Windows platforms have no owned-window auto-hide, so
+        /// the Avalonia flag is the truth there.
+        /// </summary>
+        private static bool IsOsVisible(Window window)
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                return window.IsVisible;
+            }
+
+            var handle = window.TryGetPlatformHandle()?.Handle ?? IntPtr.Zero;
+            return handle == IntPtr.Zero ? window.IsVisible : IsWindowVisible(handle);
+        }
+
+        [System.Runtime.InteropServices.DllImport("user32.dll")]
+        private static extern bool IsWindowVisible(IntPtr hWnd);
 
         /// <summary>
         /// Hands the foreground and the keyboard back to <paramref name="dialog"/> after the

--- a/tests/UI/Logic/ModalMinimizeMirroringTests.cs
+++ b/tests/UI/Logic/ModalMinimizeMirroringTests.cs
@@ -11,6 +11,13 @@ namespace UITests.Logic;
 // mirrors minimize/restore between the dialog and its owner: minimizing either sends the whole
 // pair to the taskbar, restoring either brings both back. The undocked tool windows are
 // independent (never in the owner chain) and are not part of the mirror.
+//
+// The mirror's counterpart writes are DELIBERATELY deferred to a posted dispatcher job - a
+// synchronous write from inside the other window's state-change dispatch can land while Windows
+// still has the owned dialog hidden (owner minimized => owned windows hidden), which Avalonia's
+// Win32 backend records without performing, permanently wedging the dialog's rendering on the
+// next real restore (#13865). Tests therefore RunJobs between a state write and its mirrored
+// assertion.
 public class ModalMinimizeMirroringTests : IDisposable
 {
     public ModalMinimizeMirroringTests()
@@ -66,6 +73,7 @@ public class ModalMinimizeMirroringTests : IDisposable
         var (owner, dialog, _) = OpenModal();
 
         dialog.WindowState = WindowState.Minimized;
+        Dispatcher.UIThread.RunJobs();
 
         Assert.Equal(WindowState.Minimized, owner.WindowState);
     }
@@ -76,7 +84,9 @@ public class ModalMinimizeMirroringTests : IDisposable
         var (owner, dialog, _) = OpenModal();
 
         dialog.WindowState = WindowState.Minimized;
+        Dispatcher.UIThread.RunJobs();
         dialog.WindowState = WindowState.Normal;
+        Dispatcher.UIThread.RunJobs();
 
         Assert.Equal(WindowState.Normal, owner.WindowState);
     }
@@ -87,9 +97,11 @@ public class ModalMinimizeMirroringTests : IDisposable
         var (owner, dialog, _) = OpenModal(WindowState.Maximized);
 
         dialog.WindowState = WindowState.Minimized;
+        Dispatcher.UIThread.RunJobs();
         Assert.Equal(WindowState.Minimized, owner.WindowState);
 
         dialog.WindowState = WindowState.Normal;
+        Dispatcher.UIThread.RunJobs();
 
         Assert.Equal(WindowState.Maximized, owner.WindowState);
     }
@@ -100,6 +112,7 @@ public class ModalMinimizeMirroringTests : IDisposable
         var (owner, dialog, _) = OpenModal();
 
         owner.WindowState = WindowState.Minimized;
+        Dispatcher.UIThread.RunJobs();
 
         Assert.Equal(WindowState.Minimized, dialog.WindowState);
     }
@@ -110,7 +123,9 @@ public class ModalMinimizeMirroringTests : IDisposable
         var (owner, dialog, _) = OpenModal();
 
         owner.WindowState = WindowState.Minimized;
+        Dispatcher.UIThread.RunJobs();
         owner.WindowState = WindowState.Normal;
+        Dispatcher.UIThread.RunJobs();
 
         Assert.Equal(WindowState.Normal, dialog.WindowState);
     }
@@ -124,6 +139,7 @@ public class ModalMinimizeMirroringTests : IDisposable
         // e.g. a finished batch job. The dialog's taskbar button is gone, so the owner must
         // come back rather than stay minimized.
         dialog.WindowState = WindowState.Minimized;
+        Dispatcher.UIThread.RunJobs();
         dialog.Close();
         Dispatcher.UIThread.RunJobs();
 
@@ -139,6 +155,7 @@ public class ModalMinimizeMirroringTests : IDisposable
         // Here the minimize was the user's explicit action on the owner itself - the close
         // must not override that choice.
         owner.WindowState = WindowState.Minimized;
+        Dispatcher.UIThread.RunJobs();
         dialog.Close();
         Dispatcher.UIThread.RunJobs();
 
@@ -156,10 +173,12 @@ public class ModalMinimizeMirroringTests : IDisposable
         Dispatcher.UIThread.RunJobs();
 
         topDialog.WindowState = WindowState.Minimized;
+        Dispatcher.UIThread.RunJobs();
         Assert.Equal(WindowState.Minimized, dialog.WindowState);
         Assert.Equal(WindowState.Minimized, owner.WindowState);
 
         topDialog.WindowState = WindowState.Normal;
+        Dispatcher.UIThread.RunJobs();
         Assert.Equal(WindowState.Normal, dialog.WindowState);
         Assert.Equal(WindowState.Normal, owner.WindowState);
     }
@@ -170,6 +189,7 @@ public class ModalMinimizeMirroringTests : IDisposable
         var (owner, dialog, _) = OpenModal();
 
         dialog.WindowState = WindowState.Minimized;
+        Dispatcher.UIThread.RunJobs();
 
         // The foreground churn right after the minimize: the OS briefly hands activation to
         // the owner. The modal foreground enforcement must not answer with dialog.Activate(),
@@ -277,6 +297,7 @@ public class ModalMinimizeMirroringTests : IDisposable
         Dispatcher.UIThread.RunJobs();
 
         topDialog.WindowState = WindowState.Minimized;
+        Dispatcher.UIThread.RunJobs();
         RaisePlatformEvent(dialog, "Deactivated");
         SimulateOsForegroundMove(from: topDialog, to: owner);
         Dispatcher.UIThread.RunJobs();


### PR DESCRIPTION
The main fix for issue 1 of #13865 — the Batch Convert window frozen after minimize/restore (~70%). This commit was pushed to the #13870 branch minutes after that PR was merged, so it needs its own PR; #13870 shipped only the (secondary) foreground/keyboard repair.

## The symptom, pinned by the reporter's follow-up

Input stays alive — tooltips show, buttons *can even be operated* — but nothing repaints (no hover highlight), and resizing moves the frame while the content stays frozen at its stale size, with the main window showing through the unpainted band ([screenshots](https://github.com/SubtitleEdit/subtitleedit/issues/13865#issuecomment-5344589082)). That is a window whose TopLevel never re-entered Avalonia's render/layout loop: `StartRendering` never ran after the restore. Tooltips are separate popup TopLevels with their own render targets, which is why they still draw — and it explains the original "only Close / Add file / Add folder work": those are the buttons whose effect is visible *outside* the frozen surface.

## Root cause — three facts colliding

1. **Win32 rule:** minimizing an owner window auto-hides its owned windows; restoring the owner re-shows them. The #13788 mirror minimizes the owner whenever the dialog minimizes — so since beta17 the dialog is always OS-hidden while the pair sits in the taskbar.
2. **Avalonia 12.1.1, `WindowImpl.WindowState` setter:** a programmatic write to a *hidden* window skips `ShowWindow` but still records `_lastWindowState = value`.
3. **Avalonia's `WM_SIZE` handler** only raises `WindowStateChanged` — the one path to `Window.HandleWindowStateChanged` → `StartRendering()` — when the incoming state differs from that record.

The mirror wrote `dialog.WindowState = Normal` synchronously from inside the owner's restore dispatch, racing the shell re-showing the owned dialog. When the write landed while the dialog was still hidden, it was swallowed but recorded; the dialog's real restore then reported "no state change", no callback fired, and the TopLevel was never re-added to the media context — no layout, no paint, forever. Race timing explains the ~70%.

## The fix

- The mirror's counterpart writes are now **posted** dispatcher jobs that re-read live state (a stale post reconciles to a no-op), so they run after the OS has finished the whole minimize/restore sequence, when the owned windows are visible again.
- Belt-and-braces, Windows only: before restoring a still-minimized dialog, an `IsWindowVisible` check (Avalonia's `IsVisible` does not track the owned-window auto-hide) waits out the shell on a 50 ms timer, bounded at ~2 s — worst case is the pre-fix behavior.
- The #13870 foreground repair is unchanged and still needed: restoring the owner is an activating operation either way.

## Tests

The existing mirroring suite is updated for the deferred writes (RunJobs between a state write and its mirrored assertion), and the class header documents why the writes must stay deferred. The wedge itself is a Win32 shell interaction headless tests cannot reproduce; the fix removes the poisoned-write window and guards on actual OS visibility.

Full UI suite: 3212 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)