### PR TITLE
Video preview: use the position the subtitle file carries (TTML/PAC/EBU STL)

### DIFF
--- a/src/libse/Common/Subtitle.cs
+++ b/src/libse/Common/Subtitle.cs
@@ -946,6 +946,12 @@ namespace Nikse.SubtitleEdit.Core.Common
                 hash.Add(p.Extra, StringComparer.Ordinal);
                 hash.Add(p.Actor, StringComparer.Ordinal);
                 hash.Add(p.Layer);
+
+                // The margins move the line on the video (SubtitlePositionToAssa turns a teletext row
+                // or a TTML region into them), so a changed margin has to invalidate the preview too.
+                hash.Add(p.MarginL, StringComparer.Ordinal);
+                hash.Add(p.MarginR, StringComparer.Ordinal);
+                hash.Add(p.MarginV, StringComparer.Ordinal);
             }
 
             return hash.ToHashCode();

--- a/src/libse/Common/SubtitlePositionToAssa.cs
+++ b/src/libse/Common/SubtitlePositionToAssa.cs
@@ -1,0 +1,663 @@
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Xml;
+
+namespace Nikse.SubtitleEdit.Core.Common
+{
+    /// <summary>
+    /// Turns the vertical/horizontal position a source format carries - TTML regions, PAC vertical
+    /// alignment and EBU STL teletext rows - into ASSA alignment tags and per line margins.
+    /// </summary>
+    /// <remarks>
+    /// Used for the video preview (mpv/VLC), where every line used to end up at the one fixed
+    /// alignment from the preview settings no matter what the file said (discussion #13857).
+    /// The paragraphs are expected to be a throw-away preview copy - the text and the margins are
+    /// rewritten in place.
+    /// </remarks>
+    public static class SubtitlePositionToAssa
+    {
+        /// <summary>
+        /// libass' script size when the ASSA header has no PlayResX/PlayResY - which is the case for
+        /// the preview header, so every margin written here is in this space.
+        /// </summary>
+        public const int DefaultAssaPlayResX = 384;
+
+        public const int DefaultAssaPlayResY = 288;
+
+        private static readonly char[] SpaceSeparators = { ' ', '\t', '\r', '\n' };
+
+        // Memo for the parsed TTML layout: the header holds the whole source XML, and a preview
+        // refresh happens on every edit - re-parsing a broadcast TTML file per keystroke is not free.
+        private static readonly object RegionCacheLock = new object();
+        private static string _regionCacheHeader;
+        private static Dictionary<string, TtmlRegion> _regionCacheRegions;
+
+        /// <summary>
+        /// Applies the position info of <paramref name="sourceHeader"/>'s format to the paragraphs.
+        /// </summary>
+        /// <param name="subtitle">Preview copy of the subtitle - modified in place.</param>
+        /// <param name="sourceHeader">Header as read from the source file (TTML xml, EBU STL GSI block...).</param>
+        /// <param name="usePositions">
+        /// False only maps the format specific margins away: MarginV holds a teletext row or a percentage
+        /// for those formats, and neither means anything as an ASSA pixel margin.
+        /// </param>
+        /// <returns>True if any paragraph was positioned.</returns>
+        public static bool ApplyPositions(Subtitle subtitle, string sourceHeader, bool usePositions = true)
+        {
+            return ApplyPositions(subtitle, sourceHeader, DefaultAssaPlayResX, DefaultAssaPlayResY, usePositions);
+        }
+
+        public static bool ApplyPositions(Subtitle subtitle, string sourceHeader, int playResX, int playResY, bool usePositions = true)
+        {
+            if (subtitle == null || subtitle.Paragraphs.Count == 0 || playResX <= 0 || playResY <= 0)
+            {
+                return false;
+            }
+
+            // ASSA/SSA margins are already in script units - they are the one thing that must be left alone.
+            if (!string.IsNullOrEmpty(sourceHeader) &&
+                (sourceHeader.IndexOf("[V4+ Styles]", StringComparison.Ordinal) >= 0 ||
+                 sourceHeader.IndexOf("[V4 Styles]", StringComparison.Ordinal) >= 0))
+            {
+                return false;
+            }
+
+            if (IsEbuStlHeader(sourceHeader))
+            {
+                return ApplyEbuTeletextRows(subtitle, sourceHeader, playResY, usePositions);
+            }
+
+            var regions = GetTtmlRegions(sourceHeader);
+            if (regions != null)
+            {
+                return usePositions && ApplyTtmlRegions(subtitle, regions, playResX, playResY);
+            }
+
+            return ApplyPercentageMargins(subtitle, playResY, usePositions);
+        }
+
+        /// <summary>
+        /// PAC stores the vertical position as a percentage in MarginV - measured from the top for the
+        /// top alignments and from the bottom for the rest, which is exactly what an ASSA margin means.
+        /// </summary>
+        private static bool ApplyPercentageMargins(Subtitle subtitle, int playResY, bool usePositions)
+        {
+            var applied = false;
+            foreach (var p in subtitle.Paragraphs)
+            {
+                var marginV = p.MarginV;
+                if (string.IsNullOrEmpty(marginV) || marginV[marginV.Length - 1] != '%')
+                {
+                    continue;
+                }
+
+                if (!usePositions ||
+                    !double.TryParse(marginV.TrimEnd('%'), NumberStyles.Float, CultureInfo.InvariantCulture, out var percentage))
+                {
+                    p.MarginV = null;
+                    continue;
+                }
+
+                p.MarginV = ToMargin(percentage, playResY);
+                applied = true;
+            }
+
+            return applied;
+        }
+
+        private static bool IsEbuStlHeader(string header)
+        {
+            // The verbatim 1024 byte GSI block Ebu.LoadSubtitle keeps: 3 chars code page number,
+            // then the disk format code ("STL25.01").
+            return header != null &&
+                   header.Length == 1024 &&
+                   header[3] == 'S' && header[4] == 'T' && header[5] == 'L';
+        }
+
+        /// <summary>
+        /// EBU STL stores the teletext row the first line is displayed on in MarginV (1 based).
+        /// </summary>
+        private static bool ApplyEbuTeletextRows(Subtitle subtitle, string header, int playResY, bool usePositions)
+        {
+            var rows = GetEbuRowCount(header);
+            var newLineRows = Math.Max(1, Configuration.Settings.SubtitleSettings.EbuStlNewLineRows);
+            var applied = false;
+
+            foreach (var p in subtitle.Paragraphs)
+            {
+                if (string.IsNullOrEmpty(p.MarginV))
+                {
+                    continue;
+                }
+
+                if (!usePositions ||
+                    !int.TryParse(p.MarginV, NumberStyles.Integer, CultureInfo.InvariantCulture, out var row) ||
+                    row < 1 || row > rows)
+                {
+                    // A row number is not a pixel margin - leaving it would nudge every line
+                    // by a near random amount.
+                    p.MarginV = null;
+                    continue;
+                }
+
+                var lastRow = row + (Math.Max(1, Utilities.GetNumberOfLines(p.Text)) - 1) * newLineRows;
+                var alignment = GetLeadingAlignment(p.Text);
+                if (alignment == 0)
+                {
+                    if (lastRow <= rows / 3)
+                    {
+                        alignment = 8;
+                    }
+                    else if (row > rows * 2 / 3)
+                    {
+                        alignment = 2;
+                    }
+                    else
+                    {
+                        alignment = 5;
+                    }
+
+                    p.Text = "{\\an" + alignment.ToString(CultureInfo.InvariantCulture) + "}" + p.Text;
+                }
+
+                if (IsTopAlignment(alignment))
+                {
+                    p.MarginV = ToMargin((row - 1) * 100.0 / rows, playResY);
+                }
+                else if (IsBottomAlignment(alignment))
+                {
+                    p.MarginV = ToMargin(Math.Max(0, rows - lastRow) * 100.0 / rows, playResY);
+                }
+                else
+                {
+                    p.MarginV = null; // libass centers the line, the margin says nothing
+                }
+
+                applied = true;
+            }
+
+            return applied;
+        }
+
+        private static int GetEbuRowCount(string header)
+        {
+            try
+            {
+                var ebuHeader = Ebu.ReadHeader(Ebu.GetEncoding(header.Substring(0, 3)).GetBytes(header));
+                if (ebuHeader.DisplayStandardCode == "1" || ebuHeader.DisplayStandardCode == "2") // teletext
+                {
+                    return 23;
+                }
+
+                if (int.TryParse(ebuHeader.MaximumNumberOfDisplayableRows, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rows) &&
+                    rows > 1)
+                {
+                    return rows;
+                }
+            }
+            catch
+            {
+                // ignore - fall back to the teletext row count
+            }
+
+            return 23;
+        }
+
+        private static bool ApplyTtmlRegions(Subtitle subtitle, Dictionary<string, TtmlRegion> regions, int playResX, int playResY)
+        {
+            var applied = false;
+            foreach (var p in subtitle.Paragraphs)
+            {
+                var regionId = GetRegionId(p);
+                if (string.IsNullOrEmpty(regionId) || !regions.TryGetValue(regionId, out var region))
+                {
+                    continue;
+                }
+
+                // A paragraph may carry its own box (TimedText10 keeps those in the effect).
+                var left = region.Left;
+                var top = region.Top;
+                var width = region.Width;
+                var height = region.Height;
+                if (TryGetPercentagePair(GetEffect(p, "tts:origin"), region.Scale, out var originX, out var originY))
+                {
+                    left = originX;
+                    top = originY;
+                }
+
+                if (TryGetPercentagePair(GetEffect(p, "tts:extent"), region.Scale, out var extentX, out var extentY))
+                {
+                    width = extentX;
+                    height = extentY;
+                }
+
+                var alignment = GetLeadingAlignment(p.Text);
+                if (alignment == 0)
+                {
+                    alignment = GetAlignment(region, top, height);
+                    p.Text = "{\\an" + alignment.ToString(CultureInfo.InvariantCulture) + "}" + p.Text;
+                }
+
+                if (IsTopAlignment(alignment) && top.HasValue)
+                {
+                    p.MarginV = ToMargin(top.Value, playResY);
+                }
+                else if (IsBottomAlignment(alignment) && top.HasValue && height.HasValue)
+                {
+                    p.MarginV = ToMargin(100.0 - (top.Value + height.Value), playResY);
+                }
+                else
+                {
+                    p.MarginV = null;
+                }
+
+                if (left.HasValue)
+                {
+                    p.MarginL = ToMargin(left.Value, playResX);
+                    if (width.HasValue)
+                    {
+                        p.MarginR = ToMargin(100.0 - (left.Value + width.Value), playResX);
+                    }
+                }
+
+                applied = true;
+            }
+
+            return applied;
+        }
+
+        private static int GetAlignment(TtmlRegion region, double? top, double? height)
+        {
+            var vertical = region.DisplayAlign;
+            if (string.IsNullOrEmpty(vertical))
+            {
+                // No displayAlign: let the box itself decide, like TimedTextImsc11 does when reading.
+                var anchor = (top ?? 90) + (height ?? 0);
+                vertical = anchor <= 33 ? "before" : anchor >= 66 ? "after" : "center";
+            }
+
+            var horizontal = 2; // center
+            switch (region.TextAlign)
+            {
+                case "left":
+                case "start":
+                    horizontal = 1;
+                    break;
+                case "right":
+                case "end":
+                    horizontal = 3;
+                    break;
+            }
+
+            switch (vertical)
+            {
+                case "before":
+                    return 6 + horizontal;
+                case "center":
+                    return 3 + horizontal;
+                default: // after
+                    return horizontal;
+            }
+        }
+
+        private static string GetRegionId(Paragraph p)
+        {
+            if (!string.IsNullOrEmpty(p.Region))
+            {
+                return p.Region;
+            }
+
+            return GetEffect(p, "region");
+        }
+
+        private static string GetEffect(Paragraph p, string tag)
+        {
+            if (string.IsNullOrEmpty(p.Effect))
+            {
+                return null;
+            }
+
+            foreach (var part in p.Effect.Split('|'))
+            {
+                var index = part.IndexOf('=');
+                if (index > 0 && string.CompareOrdinal(part.Substring(0, index), tag) == 0)
+                {
+                    return part.Substring(index + 1);
+                }
+            }
+
+            return null;
+        }
+
+        private static Dictionary<string, TtmlRegion> GetTtmlRegions(string header)
+        {
+            if (string.IsNullOrEmpty(header) || header.IndexOf("<region", StringComparison.OrdinalIgnoreCase) < 0)
+            {
+                return null;
+            }
+
+            lock (RegionCacheLock)
+            {
+                if (ReferenceEquals(header, _regionCacheHeader))
+                {
+                    return _regionCacheRegions;
+                }
+            }
+
+            var regions = ParseTtmlRegions(header);
+
+            lock (RegionCacheLock)
+            {
+                _regionCacheHeader = header;
+                _regionCacheRegions = regions;
+            }
+
+            return regions;
+        }
+
+        private static Dictionary<string, TtmlRegion> ParseTtmlRegions(string header)
+        {
+            try
+            {
+                var xml = new XmlDocument { XmlResolver = null };
+                xml.LoadXml(header);
+                var root = xml.DocumentElement;
+                if (root == null)
+                {
+                    return null;
+                }
+
+                var scale = new TtmlScale(GetAttribute(root, "extent"), GetAttribute(root, "cellResolution"));
+
+                var styles = new Dictionary<string, XmlNode>();
+                foreach (XmlNode styleNode in xml.GetElementsByTagName("style", "*"))
+                {
+                    var styleId = GetXmlId(styleNode);
+                    if (!string.IsNullOrEmpty(styleId) && !styles.ContainsKey(styleId))
+                    {
+                        styles.Add(styleId, styleNode);
+                    }
+                }
+
+                var regions = new Dictionary<string, TtmlRegion>();
+                foreach (XmlNode regionNode in xml.GetElementsByTagName("region", "*"))
+                {
+                    var id = GetXmlId(regionNode);
+                    if (string.IsNullOrEmpty(id) || regions.ContainsKey(id))
+                    {
+                        continue;
+                    }
+
+                    var region = new TtmlRegion
+                    {
+                        Scale = scale,
+                        DisplayAlign = GetStyleAttribute(regionNode, styles, "displayAlign"),
+                        TextAlign = GetStyleAttribute(regionNode, styles, "textAlign"),
+                    };
+
+                    if (TryGetPercentagePair(GetStyleAttribute(regionNode, styles, "origin"), scale, out var left, out var top))
+                    {
+                        region.Left = left;
+                        region.Top = top;
+                    }
+
+                    if (TryGetPercentagePair(GetStyleAttribute(regionNode, styles, "extent"), scale, out var width, out var height))
+                    {
+                        region.Width = width;
+                        region.Height = height;
+                    }
+
+                    regions.Add(id, region);
+                }
+
+                return regions.Count == 0 ? null : regions;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Reads a styling attribute of a region: set on the region itself, on a nested "style" element,
+        /// or on a style the region refers to by id.
+        /// </summary>
+        private static string GetStyleAttribute(XmlNode regionNode, Dictionary<string, XmlNode> styles, string localName)
+        {
+            var value = GetAttribute(regionNode, localName);
+            if (!string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+
+            foreach (XmlNode child in regionNode.ChildNodes)
+            {
+                if (child.LocalName == "style")
+                {
+                    value = GetAttribute(child, localName);
+                    if (!string.IsNullOrEmpty(value))
+                    {
+                        return value;
+                    }
+                }
+            }
+
+            var styleReference = GetAttribute(regionNode, "style");
+            if (string.IsNullOrEmpty(styleReference))
+            {
+                return null;
+            }
+
+            foreach (var styleId in styleReference.Split(SpaceSeparators, StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (styles.TryGetValue(styleId, out var styleNode))
+                {
+                    value = GetAttribute(styleNode, localName);
+                    if (!string.IsNullOrEmpty(value))
+                    {
+                        return value;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Attribute lookup by local name - the namespace prefix in a TTML file is only a convention
+        /// ("tts:origin", "origin" and "ttml_tts:origin" all show up in the wild).
+        /// </summary>
+        private static string GetAttribute(XmlNode node, string localName)
+        {
+            if (node?.Attributes == null)
+            {
+                return null;
+            }
+
+            foreach (XmlAttribute attribute in node.Attributes)
+            {
+                if (attribute.LocalName == localName)
+                {
+                    return attribute.Value;
+                }
+            }
+
+            return null;
+        }
+
+        private static string GetXmlId(XmlNode node)
+        {
+            return GetAttribute(node, "id");
+        }
+
+        /// <summary>
+        /// Reads a TTML length pair ("10% 80%", "192px 800px", "10c 2c") as percentages of the screen.
+        /// </summary>
+        private static bool TryGetPercentagePair(string value, TtmlScale scale, out double x, out double y)
+        {
+            x = 0;
+            y = 0;
+            if (string.IsNullOrEmpty(value))
+            {
+                return false;
+            }
+
+            var parts = value.Split(SpaceSeparators, StringSplitOptions.RemoveEmptyEntries);
+            return parts.Length == 2 &&
+                   TryGetPercentage(parts[0], scale.Width, scale.Columns, out x) &&
+                   TryGetPercentage(parts[1], scale.Height, scale.Rows, out y);
+        }
+
+        private static bool TryGetPercentage(string value, double? pixels, double cells, out double percentage)
+        {
+            percentage = 0;
+            if (string.IsNullOrEmpty(value))
+            {
+                return false;
+            }
+
+            var unit = 'p';
+            var number = value;
+            if (value.EndsWith("%", StringComparison.Ordinal))
+            {
+                unit = '%';
+                number = value.Substring(0, value.Length - 1);
+            }
+            else if (value.EndsWith("px", StringComparison.OrdinalIgnoreCase))
+            {
+                number = value.Substring(0, value.Length - 2);
+            }
+            else if (value.EndsWith("c", StringComparison.OrdinalIgnoreCase))
+            {
+                unit = 'c';
+                number = value.Substring(0, value.Length - 1);
+            }
+
+            if (!double.TryParse(number, NumberStyles.Float, CultureInfo.InvariantCulture, out var result))
+            {
+                return false;
+            }
+
+            switch (unit)
+            {
+                case '%':
+                    percentage = result;
+                    return true;
+                case 'c':
+                    if (cells <= 0)
+                    {
+                        return false;
+                    }
+
+                    percentage = result * 100.0 / cells;
+                    return true;
+                default: // pixels - only usable when the root element says how big the screen is
+                    if (!pixels.HasValue || pixels.Value <= 0)
+                    {
+                        return false;
+                    }
+
+                    percentage = result * 100.0 / pixels.Value;
+                    return true;
+            }
+        }
+
+        /// <summary>
+        /// Alignment of a leading "{\anX}" tag, 0 if the text has none.
+        /// </summary>
+        private static int GetLeadingAlignment(string text)
+        {
+            if (text == null || text.Length < 6 ||
+                !text.StartsWith("{\\an", StringComparison.Ordinal) ||
+                text[5] != '}' ||
+                text[4] < '1' || text[4] > '9')
+            {
+                return 0;
+            }
+
+            return text[4] - '0';
+        }
+
+        private static bool IsTopAlignment(int alignment)
+        {
+            return alignment >= 7;
+        }
+
+        private static bool IsBottomAlignment(int alignment)
+        {
+            return alignment >= 1 && alignment <= 3;
+        }
+
+        private static string ToMargin(double percentage, int playRes)
+        {
+            var value = (int)Math.Round(percentage / 100.0 * playRes, MidpointRounding.AwayFromZero);
+            if (value < 0)
+            {
+                value = 0;
+            }
+            else if (value > playRes)
+            {
+                value = playRes;
+            }
+
+            return value.ToString(CultureInfo.InvariantCulture);
+        }
+
+        private class TtmlRegion
+        {
+            internal TtmlScale Scale { get; set; }
+            internal double? Left { get; set; }
+            internal double? Top { get; set; }
+            internal double? Width { get; set; }
+            internal double? Height { get; set; }
+            internal string DisplayAlign { get; set; }
+            internal string TextAlign { get; set; }
+        }
+
+        /// <summary>
+        /// What the non-percentage units of a TTML document mean: the root extent for pixels and the
+        /// cell resolution (32 x 15 per the spec) for cells.
+        /// </summary>
+        private class TtmlScale
+        {
+            internal double? Width { get; }
+            internal double? Height { get; }
+            internal double Columns { get; }
+            internal double Rows { get; }
+
+            internal TtmlScale(string rootExtent, string cellResolution)
+            {
+                Columns = 32;
+                Rows = 15;
+
+                if (!string.IsNullOrEmpty(rootExtent))
+                {
+                    var parts = rootExtent.Split(SpaceSeparators, StringSplitOptions.RemoveEmptyEntries);
+                    if (parts.Length == 2 &&
+                        double.TryParse(parts[0].TrimEnd('p', 'x', 'P', 'X'), NumberStyles.Float, CultureInfo.InvariantCulture, out var width) &&
+                        double.TryParse(parts[1].TrimEnd('p', 'x', 'P', 'X'), NumberStyles.Float, CultureInfo.InvariantCulture, out var height) &&
+                        width > 0 && height > 0)
+                    {
+                        Width = width;
+                        Height = height;
+                    }
+                }
+
+                if (!string.IsNullOrEmpty(cellResolution))
+                {
+                    var parts = cellResolution.Split(SpaceSeparators, StringSplitOptions.RemoveEmptyEntries);
+                    if (parts.Length == 2 &&
+                        double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var columns) &&
+                        double.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var rows) &&
+                        columns > 0 && rows > 0)
+                    {
+                        Columns = columns;
+                        Rows = rows;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/libse/SubtitleFormats/TimedTextImsc11.cs
+++ b/src/libse/SubtitleFormats/TimedTextImsc11.cs
@@ -608,7 +608,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 }
 
                 var text = assStyle + ReadParagraph(node, xml).TrimEnd();
-                var p = new Paragraph(begin, end, text);
+
+                // Keep the region name: the alignment tag above only snaps to the screen thirds,
+                // the video preview positions the line from the region box itself.
+                var p = new Paragraph(begin, end, text) { Region = region?.InnerText };
                 subtitle.Paragraphs.Add(p);
             }
 

--- a/src/libse/SubtitleFormats/TimedTextImscRosetta.cs
+++ b/src/libse/SubtitleFormats/TimedTextImscRosetta.cs
@@ -484,7 +484,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         text = alignmentTag + text;
                     }
                     
-                    var p = new Paragraph(begin, end, text);
+                    // Region name kept for the video preview - see TimedTextImsc11.
+                    var p = new Paragraph(begin, end, text) { Region = regionId };
                     subtitle.Paragraphs.Add(p);
                 }
             }

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -1031,6 +1031,8 @@ public class SettingsPage : UserControl
         var labelAlignment = UiUtil.MakeLabel(Se.Language.General.Alignment);
         var comboBoxAlignment = UiUtil.MakeComboBox(vm.MpvPreviewFontAlignments, vm, nameof(vm.MpvPreviewSelectedFontAlignment));
 
+        var checkBoxUsePositionFromFile = UiUtil.MakeCheckBox(Se.Language.Options.Settings.UsePositionFromSubtitleFile, vm, nameof(vm.MpvPreviewUsePositionFromFile));
+
         var labelMargin = UiUtil.MakeLabel(Se.Language.General.Margin);
         var numericUpDownMargin = UiUtil.MakeNumericUpDownOneDecimal(1, 1000, 130, vm, nameof(vm.MpvPreviewMargin));
         numericUpDownMargin.Increment = 1;
@@ -1048,6 +1050,7 @@ public class SettingsPage : UserControl
         {
             RowDefinitions =
             {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
@@ -1079,19 +1082,21 @@ public class SettingsPage : UserControl
         grid.Add(labelAlignment, 3);
         grid.Add(comboBoxAlignment, 3, 1);
 
-        grid.Add(labelMargin, 4);
-        grid.Add(numericUpDownMargin, 4, 1);
+        grid.Add(checkBoxUsePositionFromFile, 4, 0, 1, 2);
 
-        grid.Add(labelColorPrimary, 5);
-        grid.Add(colorPickerPrimary, 5, 1);
+        grid.Add(labelMargin, 5);
+        grid.Add(numericUpDownMargin, 5, 1);
 
-        grid.Add(labelColorOutline, 6);
-        grid.Add(colorPickerOutline, 6, 1);
+        grid.Add(labelColorPrimary, 6);
+        grid.Add(colorPickerPrimary, 6, 1);
 
-        grid.Add(labelColorShadow, 7);
-        grid.Add(colorPickerShadow, 7, 1);
+        grid.Add(labelColorOutline, 7);
+        grid.Add(colorPickerOutline, 7, 1);
 
-        grid.Add(MakeBorderView(vm), 8, 0, 1, 2);
+        grid.Add(labelColorShadow, 8);
+        grid.Add(colorPickerShadow, 8, 1);
+
+        grid.Add(MakeBorderView(vm), 9, 0, 1, 2);
 
         return UiUtil.MakeBorderForControl(grid);
     }

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -106,6 +106,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<AlignmentItem> __mpvPreviewFontAlignments;
     [ObservableProperty] private AlignmentItem _mpvPreviewSelectedFontAlignment;
     [ObservableProperty] private int _mpvPreviewMargin;
+    [ObservableProperty] private bool _mpvPreviewUsePositionFromFile;
     [ObservableProperty] private Color _mpvPreviewColorPrimary;
     [ObservableProperty] private Color _mpvPreviewColorOutline;
     [ObservableProperty] private Color _mpvPreviewColorShadow;
@@ -1040,6 +1041,7 @@ public partial class SettingsViewModel : ObservableObject
         MpvPreviewFontSize = video.MpvPreviewFontSize;
         MpvPreviewFontBold = video.MpvPreviewFontBold;
         MpvPreviewMargin = video.MpvPreviewMargin;
+        MpvPreviewUsePositionFromFile = video.MpvPreviewUsePositionFromFile;
         MpvPreviewSelectedFontAlignment = MpvPreviewFontAlignments.FirstOrDefault(p => p.Code == video.MpvPreviewAlignment) ?? MpvPreviewFontAlignments[7];
         MpvPreviewOutlineWidth = video.MpvPreviewOutlineWidth;
         MpvPreviewShadowWidth = video.MpvPreviewShadowWidth;
@@ -1865,6 +1867,7 @@ public partial class SettingsViewModel : ObservableObject
         video.MpvPreviewFontSize = MpvPreviewFontSize;
         video.MpvPreviewFontBold = MpvPreviewFontBold;
         video.MpvPreviewMargin = MpvPreviewMargin;
+        video.MpvPreviewUsePositionFromFile = MpvPreviewUsePositionFromFile;
         video.MpvPreviewOutlineWidth = MpvPreviewOutlineWidth;
         video.MpvPreviewAlignment = MpvPreviewSelectedFontAlignment.Code;
         video.MpvPreviewShadowWidth = MpvPreviewShadowWidth;

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -317,6 +317,7 @@ public class LanguageSettings
     public string WaveformToolbarItems { get; set; }
     public string MatchIconColorToDarkTheme { get; set; }
     public string SubtitlePreviewProperties { get; set; }
+    public string UsePositionFromSubtitleFile { get; set; }
     public string PixelWidthInfo { get; set; }
     public string SpellCheckEngineHunSpelll { get; set; }
     public string SpellCheckEngineMsWord { get; set; }
@@ -639,6 +640,7 @@ public class LanguageSettings
         WaveformToolbarItems = "Waveform toolbar items";
         MatchIconColorToDarkTheme = "Match icon color to dark theme foreground color";
         SubtitlePreviewProperties = "Subtitle preview properties";
+        UsePositionFromSubtitleFile = "Use position from subtitle file (TTML/PAC/EBU STL)";
         PixelWidthInfo = "Green lines = max-width limit   |   Red area = text exceeds limit";
         SpellCheckEngineHunSpelll = "Hunspell";
         SpellCheckEngineMsWord = "MS Word";

--- a/src/ui/Logic/Config/SeVideo.cs
+++ b/src/ui/Logic/Config/SeVideo.cs
@@ -46,6 +46,12 @@ public class SeVideo
     public decimal MpvPreviewShadowWidth { get; set; }
     public int MpvPreviewBorderType { get; set; }
 
+    /// <summary>
+    /// Show the lines where the subtitle file says they belong (TTML regions, PAC vertical
+    /// alignment, EBU STL teletext rows) instead of at <see cref="MpvPreviewAlignment"/>.
+    /// </summary>
+    public bool MpvPreviewUsePositionFromFile { get; set; }
+
     public SeVideo()
     {
         BurnIn = new();
@@ -84,5 +90,6 @@ public class SeVideo
         MpvPreviewColorOutline = Color.FromRgb(0, 0, 0).FromColorToHex();
         MpvPreviewColorShadow = Color.FromRgb(0, 0, 0).FromColorToHex();
         MpvPreviewBorderType = (int)BorderStyleType.Outline;
+        MpvPreviewUsePositionFromFile = true;
     }
 }

--- a/src/ui/Logic/Media/MpvReloader.cs
+++ b/src/ui/Logic/Media/MpvReloader.cs
@@ -275,6 +275,11 @@ public class MpvReloader : IMpvReloader
                     }
                 }
             }
+
+            // TTML regions, PAC vertical alignment and EBU STL teletext rows say where the line
+            // belongs on the video - without this every line lands at the one fixed preview
+            // alignment from the settings (discussion #13857).
+            SubtitlePositionToAssa.ApplyPositions(subtitle, oldHeader, Se.Settings.Video.MpvPreviewUsePositionFromFile);
         }
 
         SecondarySubtitleMerger.AddSecondarySubtitle(subtitle, subtitleSecondary);

--- a/src/ui/Logic/Media/VlcReloader.cs
+++ b/src/ui/Logic/Media/VlcReloader.cs
@@ -136,6 +136,10 @@ public class VlcReloader : IVlcReloader
                             }
                         }
                     }
+
+                    // See MpvReloader - the position the source format carries beats the one fixed
+                    // preview alignment (discussion #13857).
+                    SubtitlePositionToAssa.ApplyPositions(subtitle, oldSub.Header, Se.Settings.Video.MpvPreviewUsePositionFromFile);
                 }
 
                 SecondarySubtitleMerger.AddSecondarySubtitle(subtitle, subtitleSecondary);

--- a/tests/libse/Common/SubtitlePositionToAssaTest.cs
+++ b/tests/libse/Common/SubtitlePositionToAssaTest.cs
@@ -1,0 +1,248 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+
+namespace LibSETests.Common;
+
+public class SubtitlePositionToAssaTest
+{
+    private const string TtmlHeader = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<tt xmlns=""http://www.w3.org/ns/ttml"" xmlns:tts=""http://www.w3.org/ns/ttml#styling"">
+  <head>
+    <layout>
+      <region xml:id=""bottom"" tts:origin=""10% 80%"" tts:extent=""80% 15%"" tts:displayAlign=""after"" tts:textAlign=""center"" />
+      <region xml:id=""top"" tts:origin=""10% 10%"" tts:extent=""80% 15%"" tts:displayAlign=""before"" tts:textAlign=""start"" />
+    </layout>
+  </head>
+  <body><div /></body>
+</tt>";
+
+    private static Subtitle SubtitleWith(Paragraph paragraph)
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(paragraph);
+        return subtitle;
+    }
+
+    private static Paragraph ParagraphWithRegion(string text, string region)
+    {
+        return new Paragraph(text, 1000, 3000) { Region = region };
+    }
+
+    [Fact]
+    public void TtmlBottomRegionKeepsTheLineJustAboveTheRegionBottom()
+    {
+        var subtitle = SubtitleWith(ParagraphWithRegion("Hi there!", "bottom"));
+
+        Assert.True(SubtitlePositionToAssa.ApplyPositions(subtitle, TtmlHeader));
+
+        var p = subtitle.Paragraphs[0];
+        Assert.Equal(@"{\an2}Hi there!", p.Text);
+        Assert.Equal("14", p.MarginV); // 100% - (80% + 15%) of 288
+        Assert.Equal("38", p.MarginL); // 10% of 384
+        Assert.Equal("38", p.MarginR);
+    }
+
+    [Fact]
+    public void TtmlTopLeftRegionIsMeasuredFromTheTop()
+    {
+        var subtitle = SubtitleWith(ParagraphWithRegion("Hi there!", "top"));
+
+        Assert.True(SubtitlePositionToAssa.ApplyPositions(subtitle, TtmlHeader));
+
+        var p = subtitle.Paragraphs[0];
+        Assert.Equal(@"{\an7}Hi there!", p.Text); // before + start
+        Assert.Equal("29", p.MarginV); // 10% of 288
+    }
+
+    [Fact]
+    public void TtmlRegionInPixelsUsesTheRootExtent()
+    {
+        const string header = @"<tt xmlns=""http://www.w3.org/ns/ttml"" xmlns:tts=""http://www.w3.org/ns/ttml#styling"" tts:extent=""1920px 1080px"">
+  <head><layout><region xml:id=""r1"" tts:origin=""192px 108px"" tts:extent=""1536px 216px"" tts:displayAlign=""before"" /></layout></head>
+</tt>";
+        var subtitle = SubtitleWith(ParagraphWithRegion("Hi there!", "r1"));
+
+        Assert.True(SubtitlePositionToAssa.ApplyPositions(subtitle, header));
+
+        var p = subtitle.Paragraphs[0];
+        Assert.Equal(@"{\an8}Hi there!", p.Text);
+        Assert.Equal("29", p.MarginV); // 108 of 1080 = 10% of 288
+    }
+
+    [Fact]
+    public void TtmlRegionStyleReferenceIsResolved()
+    {
+        const string header = @"<tt xmlns=""http://www.w3.org/ns/ttml"" xmlns:tts=""http://www.w3.org/ns/ttml#styling"">
+  <head>
+    <styling><style xml:id=""s1"" tts:origin=""10% 5%"" tts:extent=""80% 20%"" tts:displayAlign=""before"" tts:textAlign=""end"" /></styling>
+    <layout><region xml:id=""r1"" style=""s1"" /></layout>
+  </head>
+</tt>";
+        var subtitle = SubtitleWith(ParagraphWithRegion("Hi there!", "r1"));
+
+        Assert.True(SubtitlePositionToAssa.ApplyPositions(subtitle, header));
+
+        var p = subtitle.Paragraphs[0];
+        Assert.Equal(@"{\an9}Hi there!", p.Text);
+        Assert.Equal("14", p.MarginV); // 5% of 288
+    }
+
+    [Fact]
+    public void AnAlignmentTagInTheTextWins()
+    {
+        // TimedTextImsc11 already puts a tag in front when reading - it must not get a second one.
+        var subtitle = SubtitleWith(ParagraphWithRegion(@"{\an8}Hi there!", "bottom"));
+
+        Assert.True(SubtitlePositionToAssa.ApplyPositions(subtitle, TtmlHeader));
+
+        var p = subtitle.Paragraphs[0];
+        Assert.Equal(@"{\an8}Hi there!", p.Text);
+        Assert.Equal("230", p.MarginV); // top of the region, 80% of 288
+    }
+
+    [Fact]
+    public void UnknownRegionIsLeftAlone()
+    {
+        var subtitle = SubtitleWith(ParagraphWithRegion("Hi there!", "no-such-region"));
+
+        Assert.False(SubtitlePositionToAssa.ApplyPositions(subtitle, TtmlHeader));
+
+        var p = subtitle.Paragraphs[0];
+        Assert.Equal("Hi there!", p.Text);
+        Assert.Null(p.MarginV);
+    }
+
+    [Fact]
+    public void PacPercentageBecomesAMargin()
+    {
+        var subtitle = SubtitleWith(new Paragraph("Hi there!", 1000, 3000) { MarginV = "16.6666666666667%" });
+
+        Assert.True(SubtitlePositionToAssa.ApplyPositions(subtitle, null));
+
+        Assert.Equal("48", subtitle.Paragraphs[0].MarginV); // 1/6 of 288
+    }
+
+    [Fact]
+    public void PacPercentageIsRemovedWhenPositionsAreOff()
+    {
+        var subtitle = SubtitleWith(new Paragraph("Hi there!", 1000, 3000) { MarginV = "50%" });
+
+        Assert.False(SubtitlePositionToAssa.ApplyPositions(subtitle, null, false));
+
+        Assert.Null(subtitle.Paragraphs[0].MarginV);
+    }
+
+    [Fact]
+    public void EbuTeletextRowNearTheBottomLeavesTheRowsBelowItFree()
+    {
+        var subtitle = SubtitleWith(new Paragraph("Hi" + Environment.NewLine + "there!", 1000, 3000) { MarginV = "20" });
+
+        Assert.True(SubtitlePositionToAssa.ApplyPositions(subtitle, MakeEbuHeader()));
+
+        var p = subtitle.Paragraphs[0];
+        Assert.StartsWith(@"{\an2}", p.Text, StringComparison.Ordinal);
+        Assert.Equal("13", p.MarginV); // one row of 23 left below the two lines (rows 20 and 22)
+    }
+
+    [Fact]
+    public void EbuTeletextRowNearTheTopIsMeasuredFromTheTop()
+    {
+        var subtitle = SubtitleWith(new Paragraph("Hi there!", 1000, 3000) { MarginV = "3" });
+
+        Assert.True(SubtitlePositionToAssa.ApplyPositions(subtitle, MakeEbuHeader()));
+
+        var p = subtitle.Paragraphs[0];
+        Assert.StartsWith(@"{\an8}", p.Text, StringComparison.Ordinal);
+        Assert.Equal("25", p.MarginV); // 2 of 23 rows
+    }
+
+    [Fact]
+    public void EbuTeletextRowIsNotLeftBehindAsAPixelMargin()
+    {
+        // A row number means nothing to libass - it used to move every line by a near random amount.
+        var subtitle = SubtitleWith(new Paragraph("Hi there!", 1000, 3000) { MarginV = "20" });
+
+        Assert.False(SubtitlePositionToAssa.ApplyPositions(subtitle, MakeEbuHeader(), false));
+
+        Assert.Null(subtitle.Paragraphs[0].MarginV);
+    }
+
+    [Fact]
+    public void AssaMarginsAreLeftAlone()
+    {
+        var subtitle = SubtitleWith(new Paragraph("Hi there!", 1000, 3000) { MarginV = "60" });
+
+        Assert.False(SubtitlePositionToAssa.ApplyPositions(subtitle, AdvancedSubStationAlphaHeader));
+
+        Assert.Equal("60", subtitle.Paragraphs[0].MarginV);
+    }
+
+    [Fact]
+    public void TimedTextFileIsPositionedFromItsRegions()
+    {
+        var lines = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<tt xmlns=""http://www.w3.org/ns/ttml"" xmlns:tts=""http://www.w3.org/ns/ttml#styling"" xml:lang=""en"">
+ <head>
+  <layout>
+   <region xml:id=""speaker"" tts:origin=""10% 10%"" tts:extent=""80% 20%"" tts:displayAlign=""before"" tts:textAlign=""center""/>
+   <region xml:id=""subtitle"" tts:origin=""10% 70%"" tts:extent=""80% 25%"" tts:displayAlign=""after"" tts:textAlign=""center""/>
+  </layout>
+ </head>
+ <body><div>
+   <p begin=""00:00:01.000"" end=""00:00:03.000"" region=""subtitle"">Down here at the bottom.</p>
+   <p begin=""00:00:04.000"" end=""00:00:06.000"" region=""speaker"">Up here, out of the way.</p>
+ </div></body>
+</tt>".SplitToLines();
+
+        var subtitle = new Subtitle();
+        new TimedText10().LoadSubtitle(subtitle, lines, null);
+
+        Assert.True(SubtitlePositionToAssa.ApplyPositions(subtitle, subtitle.Header));
+
+        Assert.Equal(@"{\an2}Down here at the bottom.", subtitle.Paragraphs[0].Text);
+        Assert.Equal("14", subtitle.Paragraphs[0].MarginV); // 5% left below the region
+        Assert.Equal(@"{\an8}Up here, out of the way.", subtitle.Paragraphs[1].Text);
+        Assert.Equal("29", subtitle.Paragraphs[1].MarginV); // region starts 10% down
+    }
+
+    [Fact]
+    public void Imsc11FileIsPositionedFromItsRegions()
+    {
+        var lines = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<tt xmlns=""http://www.w3.org/ns/ttml"" xmlns:tts=""http://www.w3.org/ns/ttml#styling"" xml:lang=""en"">
+ <head>
+  <layout>
+   <region xml:id=""r1"" tts:origin=""10% 60%"" tts:extent=""80% 30%"" tts:displayAlign=""after"" tts:textAlign=""center""/>
+  </layout>
+ </head>
+ <body><div>
+   <p begin=""00:00:01.000"" end=""00:00:03.000"" region=""r1"">Hi there!</p>
+ </div></body>
+</tt>".SplitToLines();
+
+        var subtitle = new Subtitle();
+        new TimedTextImsc11().LoadSubtitle(subtitle, lines, null);
+
+        Assert.Equal("r1", subtitle.Paragraphs[0].Region);
+        Assert.True(SubtitlePositionToAssa.ApplyPositions(subtitle, subtitle.Header));
+
+        // The region bottom is at 90%, where the reader-snapped-to-thirds alignment tag alone
+        // would have left the line at the preview margin.
+        Assert.Equal("29", subtitle.Paragraphs[0].MarginV);
+    }
+
+    private const string AdvancedSubStationAlphaHeader = @"[Script Info]
+ScriptType: v4.00+
+
+[V4+ Styles]
+Format: Name, Fontname
+Style: Default,Arial
+
+[Events]";
+
+    private static string MakeEbuHeader()
+    {
+        // Code page number + disk format code, padded to the 1024 byte GSI block Ebu.LoadSubtitle keeps.
+        return ("850" + "STL25.01").PadRight(1024, ' ');
+    }
+}


### PR DESCRIPTION
Follow-up to discussion [#13857](https://github.com/SubtitleEdit/subtitleedit/discussions/13857) ("Video Player Subtitle Preview Auto Vertical Alignment").

### Before

The video preview drew every line at the single alignment from *Options → Video → Subtitle preview properties*, no matter what the file said:

- **TTML**: only regions the reader recognized as "top" got `{\an8}`; everything else landed bottom-center. IMSC 1.1 snapped to the nearest screen third.
- **PAC**: the vertical row was read into `Paragraph.MarginV` as a percentage string, which the ASSA writer dropped (not an integer).
- **EBU STL**: the teletext row was read into `MarginV` as a plain number, so it *was* written - as an ASSA pixel margin. Row 20 meant "20 pixels", nudging every line by a near random amount.

### After

New `SubtitlePositionToAssa` (libse) turns the position info into an alignment tag plus per line margins, in libass' default 384x288 script space - which is the space the preview header uses, since it carries no `PlayRes`. Both `MpvReloader` and `VlcReloader` run it on the preview copy only; nothing is written back to the file.

- **TTML/IMSC**: regions are read from the source header - `tts:origin`/`tts:extent` in percent, pixels (via the root `tts:extent`) or cells (via `ttp:cellResolution`), plus `tts:displayAlign`/`tts:textAlign` - set on the region itself, on a nested `<style>`, or on a referenced one. The line sits at the region box instead of at a snapped third. `TimedTextImsc11`/`TimedTextImscRosetta` now keep the region name on the paragraph so the preview can use the box.
- **PAC**: the percentage becomes a real margin (PAC already measures from the top for the top alignments and from the bottom for the rest, same as ASSA).
- **EBU STL**: the teletext row becomes an alignment plus a margin, using the row count from the GSI block; unusable values are cleared instead of leaking as pixels.

An alignment tag already in the text (the TTML readers add one) wins - only the margins are refined - so nothing regresses for the positions that already worked.

New checkbox *Options → Video → Subtitle preview properties → "Use position from subtitle file (TTML/PAC/EBU STL)"*, on by default; turning it off falls back to the fixed preview alignment (and still keeps the row/percentage out of the ASSA margins).

`Subtitle.GetFastHashCode` now includes the margins, otherwise a changed teletext row would not invalidate the preview memo. It is only used by the two reloaders.

### Verification

- 14 new unit tests in `tests/libse/Common/SubtitlePositionToAssaTest.cs` (region geometry in %, px and style references, tag-wins, PAC, EBU rows, setting off, ASSA untouched), plus full `LibSETests` (1397) and `LibUiLogicTests` (251) green.
- Rendered the generated preview ASSA through ffmpeg/libass on a 1920x1080 frame and measured the pixels: a `10% 10% / 80% 15% / before` region lands at 11.1% from the top, and an `after` region whose box ends at 95% puts the text bottom at 95.1%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)