### PR TITLE
TTS review: export starts in the subtitle's folder; hide duplicate ElevenLabs settings gear

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -111,6 +111,11 @@ public partial class ReviewSpeechViewModel : ObservableObject
     // round-tripped through SubtitleEditTts.json so a future Import re-applies the same voices.
     public List<ActorVoiceMapping> ActorVoiceMappings { get; private set; } = new();
 
+    // Full path of the loaded subtitle file (empty for an unsaved subtitle). Export starts its
+    // folder picker here so the session lands next to the subtitle instead of wherever the
+    // picker was last used (#13881).
+    public string SubtitleFileName { get; set; } = string.Empty;
+
     public bool OkPressed { get; private set; }
 
     // Text edits made in this window, published on OK so the caller can offer to apply them to
@@ -513,7 +518,11 @@ public partial class ReviewSpeechViewModel : ObservableObject
             return;
         }
 
-        var folder = await _folderHelper.PickFolderAsync(Window!, Se.Language.General.SelectSaveFolder);
+        // Start the picker in the subtitle's own folder (or the video's, for an unsaved
+        // subtitle) - the OS-remembered last picker folder is rarely where this export
+        // belongs (#13881).
+        var suggestedStartFolder = GetFolderName(SubtitleFileName) ?? GetFolderName(_videoFileName);
+        var folder = await _folderHelper.PickFolderAsync(Window!, Se.Language.General.SelectSaveFolder, suggestedStartFolder);
         if (string.IsNullOrEmpty(folder))
         {
             return;
@@ -687,6 +696,17 @@ public partial class ReviewSpeechViewModel : ObservableObject
         }
 
         await _folderHelper.OpenFolder(Window!, folder);
+    }
+
+    private static string? GetFolderName(string fileName)
+    {
+        if (string.IsNullOrEmpty(fileName))
+        {
+            return null;
+        }
+
+        var folder = Path.GetDirectoryName(fileName);
+        return string.IsNullOrEmpty(folder) ? null : folder;
     }
 
     [RelayCommand]
@@ -1383,7 +1403,10 @@ public partial class ReviewSpeechViewModel : ObservableObject
     public async Task SelectedEngineChangedAsync()
     {
         var engine = SelectedEngine;
-        IsEngineSettingsVisible = TtsEngineSettingsDialog.HasSettings(engine);
+        // No gear for ElevenLabs: its knobs live inline below the engine combo for fast per-line
+        // tweaking, and the settings dialog behind the gear duplicated exactly those sliders -
+        // two "settings windows" showing different values (#13881).
+        IsEngineSettingsVisible = TtsEngineSettingsDialog.HasSettings(engine) && engine is not ElevenLabs;
         if (engine == null)
         {
             return;

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -1899,6 +1899,7 @@ public partial class TextToSpeechViewModel : ObservableObject
             // Forward the imported cast so a subsequent Export round-trips the mappings instead
             // of writing ActorVoiceMappings = [] back to SubtitleEditTts.json.
             vm.ActorVoiceMappings.AddRange(_actorVoiceMappings);
+            vm.SubtitleFileName = GetLoadedSubtitleFileName();
 
             if (peaksForReview == null || peaksForReview.Peaks.Count == 0)
             {
@@ -2522,9 +2523,8 @@ public partial class TextToSpeechViewModel : ObservableObject
     /// </summary>
     private string GetSuggestedMergedAudioFileName()
     {
-        // A new, never-saved subtitle has the literal FileName "Untitled" (no path/extension).
-        var subtitleFileName = _subtitle.FileName;
-        var sourceFileName = !string.IsNullOrEmpty(subtitleFileName) && subtitleFileName != "Untitled"
+        var subtitleFileName = GetLoadedSubtitleFileName();
+        var sourceFileName = !string.IsNullOrEmpty(subtitleFileName)
             ? subtitleFileName
             : _videoFileName;
         if (string.IsNullOrEmpty(sourceFileName))
@@ -2535,6 +2535,18 @@ public partial class TextToSpeechViewModel : ObservableObject
         var folder = Path.GetDirectoryName(sourceFileName);
         var name = Path.GetFileNameWithoutExtension(sourceFileName) + ".wav";
         return string.IsNullOrEmpty(folder) ? name : Path.Combine(folder, name);
+    }
+
+    /// <summary>
+    /// Full path of the loaded subtitle file, or empty for a never-saved subtitle (whose
+    /// literal FileName is "Untitled" - no path/extension).
+    /// </summary>
+    private string GetLoadedSubtitleFileName()
+    {
+        var subtitleFileName = _subtitle.FileName;
+        return !string.IsNullOrEmpty(subtitleFileName) && subtitleFileName != "Untitled"
+            ? subtitleFileName
+            : string.Empty;
     }
 
     private async Task<TtsStepResult[]?> GenerateSpeech(CancellationToken cancellationToken)
@@ -3482,6 +3494,7 @@ public partial class TextToSpeechViewModel : ObservableObject
                 _waveFolder,
                 _wavePeakData);
             vm.ActorVoiceMappings.AddRange(_actorVoiceMappings);
+            vm.SubtitleFileName = GetLoadedSubtitleFileName();
         });
 
         if (result.OkPressed)

--- a/src/ui/Logic/Media/IFolderHelper.cs
+++ b/src/ui/Logic/Media/IFolderHelper.cs
@@ -9,24 +9,45 @@ namespace Nikse.SubtitleEdit.Logic.Media;
 
 public interface IFolderHelper
 {
-    Task<string> PickFolderAsync(Window window, string title);
+    Task<string> PickFolderAsync(Window window, string title, string? suggestedStartFolder = null);
     Task OpenFolder(Window window, string folder);
     Task OpenFolderWithFileSelected(Window window, string selectedFile);
 }
 
 public class FolderHelper : IFolderHelper
 {
-    public async Task<string> PickFolderAsync(Window window, string title)
+    public async Task<string> PickFolderAsync(Window window, string title, string? suggestedStartFolder = null)
     {
         var storageProvider = window.StorageProvider;
 
         if (storageProvider.CanPickFolder)
         {
-            var folders = await NativePickers.OpenFolderPickerAsync(window, new FolderPickerOpenOptions
+            var options = new FolderPickerOpenOptions
             {
                 Title = title,
                 AllowMultiple = false
-            });
+            };
+
+            // Open in the caller's suggested folder (e.g. the loaded subtitle's own folder)
+            // instead of wherever the picker was last used. Best effort - a missing folder or
+            // a provider that can't resolve paths just falls back to the picker's default.
+            if (!string.IsNullOrEmpty(suggestedStartFolder) && Directory.Exists(suggestedStartFolder))
+            {
+                try
+                {
+                    var startFolder = await storageProvider.TryGetFolderFromPathAsync(suggestedStartFolder);
+                    if (startFolder != null)
+                    {
+                        options.SuggestedStartLocation = startFolder;
+                    }
+                }
+                catch
+                {
+                    // ignore - the picker falls back to its default folder
+                }
+            }
+
+            var folders = await NativePickers.OpenFolderPickerAsync(window, options);
 
             var selected = folders.Count > 0 ? folders[0] : null;
             return selected?.Path.LocalPath ?? string.Empty; 


### PR DESCRIPTION
Addresses items 1 and 3 of #13881 (TTS - review audio segments).

**Item 1 - Export opened random folders**
The Export folder picker opened wherever the OS last left it. It now starts in the loaded subtitle's own folder, falling back to the video's folder when the subtitle has never been saved. Implemented as an optional `suggestedStartFolder` on `IFolderHelper.PickFolderAsync` (same `TryGetFolderFromPathAsync` pattern `FileHelper` already uses), so other pickers can adopt it later without churn.

**Item 3 - two settings windows for ElevenLabs**
With ElevenLabs selected, the review window showed its inline stability/similarity/boost/speed/style sliders *and* a gear button that opened the ElevenLabs settings dialog - the same five knobs twice, showing different values (the dialog reads saved settings, the sliders hold the window's live values). The inline sliders stay for fast per-line tweaking; the gear is now hidden for ElevenLabs in the review window. Other engines keep the gear, and the main TTS window is unchanged.

Item 2 (moving "Auto-continue playing") is intentionally not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)