### PR TITLE
Fix test build breaks and clear all compiler warnings

### DIFF
--- a/src/seconv/Core/ContainerSubtitleLoader.cs
+++ b/src/seconv/Core/ContainerSubtitleLoader.cs
@@ -394,8 +394,8 @@ internal static class ContainerSubtitleLoader
                 continue;
             }
 
-            var paragraphs = track.Mdia.Minf.Stbl.GetParagraphs();
-            if (paragraphs.Count == 0)
+            var paragraphs = track.Mdia.Minf?.Stbl?.GetParagraphs();
+            if (paragraphs == null || paragraphs.Count == 0)
             {
                 continue;
             }

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -2857,6 +2857,7 @@
       "waveformToolbarItems": "Waveform toolbar items",
       "matchIconColorToDarkTheme": "Match icon color to dark theme foreground color",
       "subtitlePreviewProperties": "Subtitle preview properties",
+      "usePositionFromSubtitleFile": "Use position from subtitle file (TTML/PAC/EBU STL)",
       "pixelWidthInfo": "Green lines = max-width limit   |   Red area = text exceeds limit",
       "spellCheckEngineHunSpelll": "Hunspell",
       "spellCheckEngineMsWord": "MS Word",

--- a/tests/UI/Features/Assa/FontCollectorEmbeddedMatchTests.cs
+++ b/tests/UI/Features/Assa/FontCollectorEmbeddedMatchTests.cs
@@ -15,7 +15,7 @@ public class FontCollectorEmbeddedMatchTests
 {
     private sealed class FakeFolderHelper : IFolderHelper
     {
-        public Task<string> PickFolderAsync(Window window, string title) => Task.FromResult(string.Empty);
+        public Task<string> PickFolderAsync(Window window, string title, string? suggestedStartFolder = null) => Task.FromResult(string.Empty);
         public Task OpenFolder(Window window, string folder) => Task.CompletedTask;
         public Task OpenFolderWithFileSelected(Window window, string selectedFile) => Task.CompletedTask;
     }

--- a/tests/UI/Features/Options/WordLists/WordListsLanguageScanTests.cs
+++ b/tests/UI/Features/Options/WordLists/WordListsLanguageScanTests.cs
@@ -20,7 +20,7 @@ public class WordListsLanguageScanTests : IDisposable
 {
     private sealed class StubFolderHelper : IFolderHelper
     {
-        public Task<string> PickFolderAsync(Window window, string title) => Task.FromResult(string.Empty);
+        public Task<string> PickFolderAsync(Window window, string title, string? suggestedStartFolder = null) => Task.FromResult(string.Empty);
         public Task OpenFolder(Window window, string folder) => Task.CompletedTask;
         public Task OpenFolderWithFileSelected(Window window, string selectedFile) => Task.CompletedTask;
     }
@@ -80,7 +80,7 @@ public class WordListsLanguageScanTests : IDisposable
 
         var vm = MakeViewModel();
 
-        Assert.Single(vm.Languages.Where(l => l.TwoLetterISOLanguageName == "el"));
+        Assert.Single(vm.Languages, l => l.TwoLetterISOLanguageName == "el");
     }
 
     [AvaloniaFact]

--- a/tests/UI/Features/Tools/BatchConvert/BatchConvertScanFolderTests.cs
+++ b/tests/UI/Features/Tools/BatchConvert/BatchConvertScanFolderTests.cs
@@ -36,7 +36,7 @@ public class BatchConvertScanFolderTests
         var dir = MakeTree();
         try
         {
-            var found = Scan(dir.FullName, recursive: false).Select(Path.GetFileName).ToList();
+            var found = Scan(dir.FullName, recursive: false, TestContext.Current.CancellationToken).Select(Path.GetFileName).ToList();
 
             Assert.Equal(2, found.Count);
             Assert.Contains("one.srt", found);
@@ -54,7 +54,7 @@ public class BatchConvertScanFolderTests
         var dir = MakeTree();
         try
         {
-            var found = Scan(dir.FullName, recursive: true).Select(Path.GetFileName).ToList();
+            var found = Scan(dir.FullName, recursive: true, TestContext.Current.CancellationToken).Select(Path.GetFileName).ToList();
 
             Assert.Equal(3, found.Count);
             Assert.Contains("three.vtt", found);
@@ -99,7 +99,7 @@ public class BatchConvertScanFolderTests
                 return; // symlinks unavailable (e.g. Windows without developer mode) - nothing to test
             }
 
-            var found = Scan(dir.FullName, recursive: true).Select(Path.GetFileName).ToList();
+            var found = Scan(dir.FullName, recursive: true, TestContext.Current.CancellationToken).Select(Path.GetFileName).ToList();
 
             Assert.Equal(3, found.Count);
             Assert.Contains("three.vtt", found);
@@ -115,6 +115,6 @@ public class BatchConvertScanFolderTests
     {
         var missing = Path.Combine(Path.GetTempPath(), "se-scan-folder-does-not-exist-" + Guid.NewGuid().ToString("N"));
 
-        Assert.Empty(Scan(missing, recursive: true));
+        Assert.Empty(Scan(missing, recursive: true, TestContext.Current.CancellationToken));
     }
 }

--- a/tests/UI/Features/Tools/BatchConvert/BatchConverterAssaStyleTests.cs
+++ b/tests/UI/Features/Tools/BatchConvert/BatchConverterAssaStyleTests.cs
@@ -36,7 +36,7 @@ Dialogue: 0,0:00:04.00,0:00:06.00,Big,,0,0,0,,Second line.
         try
         {
             var inputFile = Path.Combine(dir.FullName, "input.ass");
-            await File.WriteAllTextAsync(inputFile, InputAss);
+            await File.WriteAllTextAsync(inputFile, InputAss, TestContext.Current.CancellationToken);
 
             var outputFolder = Path.Combine(dir.FullName, "out");
             Directory.CreateDirectory(outputFolder);

--- a/tests/UI/Features/Video/TextToSpeech/AdvancedTtsSettingsWindowTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/AdvancedTtsSettingsWindowTests.cs
@@ -57,8 +57,8 @@ public class AdvancedTtsSettingsWindowTests : IDisposable
             t => t.Text == Se.Settings.Video.TextToSpeech.GenerationFolder);
 
         var sweepCheckBox = Assert.Single(
-            window.GetLogicalDescendants().OfType<CheckBox>()
-                .Where(c => Equals(c.Content, Se.Language.Video.TextToSpeech.DeleteTempFiles)));
+            window.GetLogicalDescendants().OfType<CheckBox>(),
+            c => Equals(c.Content, Se.Language.Video.TextToSpeech.DeleteTempFiles));
         Assert.False(sweepCheckBox.IsChecked);
     }
 }

--- a/tests/libse/ContainerFormats/MatroskaUsfTrackTest.cs
+++ b/tests/libse/ContainerFormats/MatroskaUsfTrackTest.cs
@@ -46,7 +46,7 @@ public class MatroskaUsfTrackTest
     [InlineData("<text><karaoke>sung</karaoke></text>", "sung")] // unknown markup: keep the text
     [InlineData("plain, no markup", "plain, no markup")]
     [InlineData("<text>unclosed", null)] // not parsable as XML - caller keeps the raw block
-    public void GetTextFromMatroskaBlock_ReadsUsfMarkup(string block, string expected)
+    public void GetTextFromMatroskaBlock_ReadsUsfMarkup(string block, string? expected)
     {
         var actual = UniversalSubtitleFormat.GetTextFromMatroskaBlock(block);
         Assert.Equal(expected?.Replace("\n", Environment.NewLine), actual);


### PR DESCRIPTION
## Summary
- The `IFolderHelper.PickFolderAsync` signature gained an optional `suggestedStartFolder` parameter in #13881, but the two test fakes (`FontCollectorEmbeddedMatchTests.FakeFolderHelper`, `WordListsLanguageScanTests.StubFolderHelper`) were not updated, so the UITests project no longer compiled.
- Clears every remaining build warning:
  - **CS8602** in `ContainerSubtitleLoader.LoadMp4`: non-VobSub track paragraphs are now read via `Minf?.Stbl?` with a null guard, matching the forced-flag check a few lines above.
  - **xUnit1012**: `MatroskaUsfTrackTest` theory parameter is now `string?` (one case deliberately passes null).
  - **xUnit2031**: `Assert.Single` filtering overload instead of `.Where(...)` in two tests.
  - **xUnit1051**: `TestContext.Current.CancellationToken` passed in the batch-convert tests.
- Regenerates `English.json` for the `usePositionFromSubtitleFile` string added in #13879.

## Test plan
- `dotnet build SubtitleEdit.sln` — 0 warnings, 0 errors
- `dotnet test SubtitleEdit.sln` — all 5261 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)