### PR TITLE
Fix black in-progress status text in batch convert file grid

### DIFF
--- a/src/ui/Logic/ValueConverters/BatchConvertStatusColorConverter.cs
+++ b/src/ui/Logic/ValueConverters/BatchConvertStatusColorConverter.cs
@@ -9,7 +9,8 @@ namespace Nikse.SubtitleEdit.Logic.ValueConverters;
 
 /// <summary>
 /// Colors the batch convert status column as a badge: green for converted, red for errors,
-/// gray for cancelled. In-progress and idle statuses ("-", "OCR 42%", ...) stay unstyled -
+/// gray for cancelled. In-progress and idle statuses ("-", "OCR 42%", ...) get the plain theme
+/// text color and no badge fill -
 /// bind with ConverterParameter "background" for the badge fill, anything else for the text color.
 /// Mid-saturation tones picked to stay readable on both the dark and light theme.
 /// </summary>
@@ -29,7 +30,7 @@ public class BatchConvertStatusColorConverter : IValueConverter
 
         if (string.IsNullOrEmpty(status) || status == "-")
         {
-            return AvaloniaProperty.UnsetValue;
+            return DefaultBrush(isBackground);
         }
 
         if (status == Se.Language.General.Converted)
@@ -57,7 +58,15 @@ public class BatchConvertStatusColorConverter : IValueConverter
         }
 
         // In-progress statuses (OCR percentages etc.) keep the default text color, no badge.
-        return AvaloniaProperty.UnsetValue;
+        return DefaultBrush(isBackground);
+    }
+
+    // An explicit theme text brush, not UnsetValue: a binding that yields UnsetValue falls
+    // back to the property default (black for TextBlock.Foreground), not the inherited
+    // foreground, so in-progress statuses rendered black on the dark theme.
+    private static object DefaultBrush(bool isBackground)
+    {
+        return isBackground ? AvaloniaProperty.UnsetValue : UiUtil.GetTextColor();
     }
 
     // Formatting + trimming "Error: {0}" per status cell showed up as the converter's only


### PR DESCRIPTION
Fixes the batch convert file grid's Status column showing in-progress statuses ("Translating: 68%", OCR percentages, "-") in black text on the dark theme.

**Cause:** `BatchConvertStatusColorConverter` returned `AvaloniaProperty.UnsetValue` for non-badge statuses, expecting the TextBlock to inherit the row's foreground. But a binding that yields `UnsetValue` falls back to the target property's *default* value — black for `TextBlock.Foreground` — not the inherited foreground (same Avalonia gotcha already documented in `TextToFlowDirectionConverter`).

**Fix:** return the explicit theme text brush (white on dark, black on light) for the foreground of in-progress/idle statuses; the badge background still stays unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)