### PR TITLE
Fix #13885: coalesce per-line OCR (and auto-translate) UI updates so input stays responsive

### DIFF
--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -708,14 +708,14 @@ public partial class OcrViewModel : ObservableObject
     {
         if (totalItems <= 0)
         {
-            ProgressValue = 0;
-            ProgressText = Se.Language.Ocr.RunningOcrDotDotDot;
+            EnqueueOcrUiProgress(0, Se.Language.Ocr.RunningOcrDotDotDot);
             return;
         }
 
         var clampedItemNumber = Math.Clamp(currentItemNumber, 0, totalItems);
-        ProgressValue = clampedItemNumber * 100.0 / totalItems;
-        ProgressText = string.Format(Se.Language.Ocr.RunningOcrDotDotDotXY, clampedItemNumber, totalItems);
+        EnqueueOcrUiProgress(
+            clampedItemNumber * 100.0 / totalItems,
+            string.Format(Se.Language.Ocr.RunningOcrDotDotDotXY, clampedItemNumber, totalItems));
     }
 
     [RelayCommand]
@@ -2161,6 +2161,9 @@ public partial class OcrViewModel : ObservableObject
     [RelayCommand]
     private void Ok()
     {
+        // A just-finished OCR run may still have line texts in the coalesced UI queue.
+        FlushOcrUiUpdates();
+
         OkPressed = true;
 
         // Remember the image source so spell check can show the original images (#11719)
@@ -3051,7 +3054,7 @@ public partial class OcrViewModel : ObservableObject
             var letters = NikseBitmapImageSplitter2.SplitBitmapToLettersNew(parentBitmap, SelectedNOcrPixelsAreSpace,
                 false, true, _lineHeightTracker.GetMinLineHeight(), true, _lineHeightTracker.GetAverageLineHeight());
             _lineHeightTracker.Update(letters);
-            SelectedOcrSubtitleItem = item;
+            EnqueueOcrUiSelect(i);
             var index = 0;
             var matches = new List<NOcrChar>();
             while (index < letters.Count)
@@ -3113,6 +3116,8 @@ public partial class OcrViewModel : ObservableObject
 
                         Dispatcher.UIThread.Post(async void () =>
                         {
+                            FlushOcrUiUpdates();
+
                             var result =
                                 await _windowService.ShowDialogAsync<NOcrCharacterAddWindow, NOcr.NOcrCharacterAddViewModel>(
                                     Window!,
@@ -3318,7 +3323,7 @@ public partial class OcrViewModel : ObservableObject
             parentBitmap.CropTop(0, new SKColor(0, 0, 0, 0));
             var letters = NikseBitmapImageSplitter2.SplitBitmapToLettersNew(parentBitmap, SelectedBinaryOcrPixelsAreSpace, false, true, _lineHeightTracker.GetMinLineHeight(), true, _lineHeightTracker.GetAverageLineHeight());
             _lineHeightTracker.Update(letters);
-            SelectedOcrSubtitleItem = item;
+            EnqueueOcrUiSelect(i);
             var index = 0;
             var matches = new List<BinaryOcrMatcher.CompareMatch>();
             while (index < letters.Count)
@@ -3376,6 +3381,8 @@ public partial class OcrViewModel : ObservableObject
 
                         Dispatcher.UIThread.Post(async void () =>
                         {
+                            FlushOcrUiUpdates();
+
                             var result =
                                 await _windowService.ShowDialogAsync<BinaryOcrCharacterAddWindow, BinaryOcrCharacterAddViewModel>(
                                     Window!,
@@ -3581,6 +3588,10 @@ public partial class OcrViewModel : ObservableObject
         {
             try
             {
+                // GetNextUnknownWord below reads item.Text, which may still sit in the
+                // coalesced OCR UI queue - apply it before prompting.
+                FlushOcrUiUpdates();
+
                 var skipOnceWords = new HashSet<string>();
                 var skipAllWords = new HashSet<string>(StringComparer.Ordinal);
 
@@ -3783,50 +3794,49 @@ public partial class OcrViewModel : ObservableObject
 
     private void SetText(int i, OcrSubtitleItem item, OcrFixLineResultTemp resultTemp)
     {
+        string text;
+        OcrFixLineResult fixResult;
         if (SelectedDictionary != null &&
             SelectedDictionary.Name != GetDictionaryNameNone() &&
             _ocrFixEngine.IsLoaded() && DoFixOcrErrors)
         {
-            var text = resultTemp.ResultText;
-
-            Dispatcher.UIThread.Post(() =>
-            {
-                CurrentText = text;
-                item.Text = text;
-                item.FixResult = resultTemp.OcrFixLineResult;
-            });
+            text = resultTemp.ResultText;
+            fixResult = resultTemp.OcrFixLineResult;
         }
         else
         {
             var alignment = GetAlignment(item);
-            var text = alignment.Text;
-
-            Dispatcher.UIThread.Post(() =>
+            text = alignment.Text;
+            fixResult = new OcrFixLineResult
             {
-                item.Text = text;
-                CurrentText = text;
-                item.FixResult = new OcrFixLineResult
-                {
-                    LineIndex = i,
-                    Words = new List<OcrFixLinePartResult> { new() { Word = item.Text, IsSpellCheckedOk = null } },
-                };
-            });
+                LineIndex = i,
+                Words = new List<OcrFixLinePartResult> { new() { Word = alignment.Text, IsSpellCheckedOk = null } },
+            };
         }
 
-        SelectAndScrollToRow(i);
+        // The bound collections (UnknownWords/AllGuesses/AllFixes) must only be touched on the
+        // UI thread, so the adds ride in the same coalesced update as the text.
+        EnqueueOcrUiUpdate(() =>
+        {
+            CurrentText = text;
+            item.Text = text;
+            item.FixResult = fixResult;
 
-        foreach (var unknownWord in resultTemp.UnknownWords)
-        {
-            UnknownWords.Add(unknownWord);
-        }
-        foreach (var guess in resultTemp.Guesses)
-        {
-            AllGuesses.Add(guess);
-        }
-        foreach (var fix in resultTemp.Fixes)
-        {
-            AllFixes.Add(fix);
-        }
+            foreach (var unknownWord in resultTemp.UnknownWords)
+            {
+                UnknownWords.Add(unknownWord);
+            }
+            foreach (var guess in resultTemp.Guesses)
+            {
+                AllGuesses.Add(guess);
+            }
+            foreach (var fix in resultTemp.Fixes)
+            {
+                AllFixes.Add(fix);
+            }
+        });
+
+        EnqueueOcrUiSelect(i);
     }
 
     private List<UnknownWordItem> OcrFixLineAndSetText(int i, OcrSubtitleItem item)
@@ -3847,54 +3857,67 @@ public partial class OcrViewModel : ObservableObject
             var alignment = GetAlignment(item, correctedText);
             var resultText = alignment.AlignmentAdded ? alignment.Text : correctedText;
 
-            Dispatcher.UIThread.Post(() =>
-            {
-                CurrentText = resultText;
-                item.Text = resultText;
-                item.FixResult = result;
-            });
-
+            var fixes = new List<ReplacementUsedItem>();
             if (!string.IsNullOrEmpty(result.ReplacementUsed.From))
             {
-                AllFixes.Add(result.ReplacementUsed);
+                fixes.Add(result.ReplacementUsed);
             }
 
+            var guesses = new List<GuessUsedItem>();
             foreach (var word in result.Words)
             {
                 if (!string.IsNullOrEmpty(word.ReplacementUsed.From))
                 {
-                    AllFixes.Add(word.ReplacementUsed);
+                    fixes.Add(word.ReplacementUsed);
                 }
 
                 if (word.GuessUsed)
                 {
-                    AllGuesses.Add(new GuessUsedItem(word.Word, word.FixedWord, i));
+                    guesses.Add(new GuessUsedItem(word.Word, word.FixedWord, i));
                 }
-
             }
 
-            foreach (var unknownWordItem in GetUnknownWordItems(item, result))
+            unknownWords.AddRange(GetUnknownWordItems(item, result));
+
+            // The bound collections (UnknownWords/AllGuesses/AllFixes) must only be touched on
+            // the UI thread, so the adds ride in the same coalesced update as the text.
+            EnqueueOcrUiUpdate(() =>
             {
-                UnknownWords.Add(unknownWordItem);
-                unknownWords.Add(unknownWordItem);
-            }
+                CurrentText = resultText;
+                item.Text = resultText;
+                item.FixResult = result;
+
+                foreach (var fix in fixes)
+                {
+                    AllFixes.Add(fix);
+                }
+                foreach (var guess in guesses)
+                {
+                    AllGuesses.Add(guess);
+                }
+                foreach (var unknownWordItem in unknownWords)
+                {
+                    UnknownWords.Add(unknownWordItem);
+                }
+            });
         }
         else
         {
             var alignment = GetAlignment(item);
-            Dispatcher.UIThread.Post(() =>
+            var text = alignment.Text;
+            EnqueueOcrUiUpdate(() =>
             {
-                item.Text = alignment.Text;
-                CurrentText = item.Text;
+                item.Text = text;
+                CurrentText = text;
                 item.FixResult = new OcrFixLineResult
                 {
                     LineIndex = i,
-                    Words = new List<OcrFixLinePartResult> { new() { Word = item.Text, IsSpellCheckedOk = null } },
+                    Words = new List<OcrFixLinePartResult> { new() { Word = text, IsSpellCheckedOk = null } },
                 };
             });
         }
 
-        SelectAndScrollToRow(i);
+        EnqueueOcrUiSelect(i);
         return unknownWords;
     }
 
@@ -4047,7 +4070,7 @@ public partial class OcrViewModel : ObservableObject
                     var item = OcrSubtitleItems[i];
                     var bitmap = item.GetSkBitmap();
 
-                    SelectAndScrollToRow(i);
+                    EnqueueOcrUiSelect(i);
 
                     var text = await ollamaOcr.Ocr(bitmap, url, model, SelectedOllamaLanguage ?? "English", cancellationToken);
 
@@ -4152,7 +4175,7 @@ public partial class OcrViewModel : ObservableObject
                     var item = OcrSubtitleItems[i];
                     var bitmap = item.GetSkBitmap();
 
-                    SelectAndScrollToRow(i);
+                    EnqueueOcrUiSelect(i);
 
                     var text = await engine.Ocr(bitmap, url, modelName, SelectedOllamaLanguage ?? "English", prompt, cancellationToken);
 
@@ -4261,7 +4284,7 @@ public partial class OcrViewModel : ObservableObject
                     var item = OcrSubtitleItems[i];
                     var bitmap = item.GetSkBitmap();
 
-                    SelectAndScrollToRow(i);
+                    EnqueueOcrUiSelect(i);
 
                     var text = await engine.Ocr(bitmap, cancellationToken);
                     item.Text = text;
@@ -4301,7 +4324,7 @@ public partial class OcrViewModel : ObservableObject
                     var item = OcrSubtitleItems[i];
                     var bitmap = item.GetSkBitmap();
 
-                    SelectAndScrollToRow(i);
+                    EnqueueOcrUiSelect(i);
 
                     var text = await mistralOcr.Ocr(bitmap, SelectedOllamaLanguage ?? "English", cancellationToken);
                     item.Text = text;
@@ -4340,7 +4363,7 @@ public partial class OcrViewModel : ObservableObject
                     var item = OcrSubtitleItems[i];
                     var bitmap = item.GetSkBitmap();
 
-                    SelectAndScrollToRow(i);
+                    EnqueueOcrUiSelect(i);
 
                     var text = await engine.Ocr(bitmap, GoogleVisionApiKey, SelectedGoogleVisionLanguage?.Code ?? "en", cancellationToken);
                     item.Text = text;
@@ -4620,6 +4643,115 @@ public partial class OcrViewModel : ObservableObject
         using var stream = new MemoryStream(data.ToArray());
 
         return new Bitmap(stream);
+    }
+
+    // Coalesced UI updates during OCR (#13885). Fast engines finish a line in milliseconds, and
+    // per-line selection/scroll/text posts at Normal dispatcher priority outrank input processing,
+    // so Pause/Cancel clicks and even the window's minimize are starved until the run completes.
+    // Per-line UI feedback is queued here instead and applied in one Background-priority dispatcher
+    // job at most every OcrUiFlushIntervalMs. Data updates (line text, fix results, unknown-word
+    // rows) are all applied in order; selection and progress are latest-wins - a newly OCR'ed
+    // line replaces any still-pending selection.
+    private const int OcrUiFlushIntervalMs = 200;
+    private readonly Lock _ocrUiUpdateLock = new Lock();
+    private List<Action> _ocrUiPendingUpdates = new List<Action>();
+    private int _ocrUiPendingSelectIndex = -1;
+    private double _ocrUiPendingProgressValue;
+    private string? _ocrUiPendingProgressText;
+    private bool _ocrUiFlushScheduled;
+
+    private void EnqueueOcrUiUpdate(Action update)
+    {
+        lock (_ocrUiUpdateLock)
+        {
+            _ocrUiPendingUpdates.Add(update);
+        }
+
+        ScheduleOcrUiFlush();
+    }
+
+    private void EnqueueOcrUiSelect(int index)
+    {
+        lock (_ocrUiUpdateLock)
+        {
+            _ocrUiPendingSelectIndex = index;
+        }
+
+        ScheduleOcrUiFlush();
+    }
+
+    private void EnqueueOcrUiProgress(double value, string text)
+    {
+        lock (_ocrUiUpdateLock)
+        {
+            _ocrUiPendingProgressValue = value;
+            _ocrUiPendingProgressText = text;
+        }
+
+        ScheduleOcrUiFlush();
+    }
+
+    private void ScheduleOcrUiFlush()
+    {
+        lock (_ocrUiUpdateLock)
+        {
+            if (_ocrUiFlushScheduled)
+            {
+                return;
+            }
+
+            _ocrUiFlushScheduled = true;
+        }
+
+        // DispatcherTimer may only be touched from the UI thread, and the enqueue often happens
+        // on an OCR worker thread. Background priority keeps both the scheduling hop and the
+        // flush itself below input processing.
+        Dispatcher.UIThread.Post(
+            () => DispatcherTimer.RunOnce(FlushOcrUiUpdates, TimeSpan.FromMilliseconds(OcrUiFlushIntervalMs), DispatcherPriority.Background),
+            DispatcherPriority.Background);
+    }
+
+    /// <summary>
+    /// Applies all pending OCR UI updates. Normally fired by the flush timer on the UI thread;
+    /// also called directly before opening a modal (unknown-word prompt, add-character window)
+    /// and from OK, so dialogs and the final subtitle see fully applied line texts instead of a
+    /// half-flushed queue.
+    /// </summary>
+    private void FlushOcrUiUpdates()
+    {
+        List<Action> updates;
+        int selectIndex;
+        double progressValue;
+        string? progressText;
+        lock (_ocrUiUpdateLock)
+        {
+            _ocrUiFlushScheduled = false;
+            updates = _ocrUiPendingUpdates;
+            _ocrUiPendingUpdates = new List<Action>();
+            selectIndex = _ocrUiPendingSelectIndex;
+            _ocrUiPendingSelectIndex = -1;
+            progressValue = _ocrUiPendingProgressValue;
+            progressText = _ocrUiPendingProgressText;
+            _ocrUiPendingProgressText = null;
+        }
+
+        foreach (var update in updates)
+        {
+            update();
+        }
+
+        if (progressText != null)
+        {
+            ProgressValue = progressValue;
+            ProgressText = progressText;
+        }
+
+        if (selectIndex >= 0 && selectIndex < OcrSubtitleItems.Count)
+        {
+            SelectedOcrSubtitleItem = OcrSubtitleItems[selectIndex];
+            SubtitleGrid.SelectedIndex = selectIndex;
+            Dispatcher.UIThread.Post(() => SubtitleGrid.ScrollIntoView(selectIndex), DispatcherPriority.Background);
+        }
     }
 
     internal async void SelectAndScrollToRow(int index)

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -220,6 +220,8 @@ public partial class OcrViewModel : ObservableObject
         _binaryOcrMatcher = binaryOcrMatcher;
         _ocrImageSourceHolder = ocrImageSourceHolder;
 
+        OcrUiUpdates = new CoalescedUiUpdateQueue(ApplyOcrUiSelect, ApplyOcrUiProgress);
+
         Title = Se.Language.Ocr.Ocr;
         OcrEngines = new ObservableCollection<OcrEngineItem>(OcrEngineItem.GetOcrEngines());
         OcrSubtitleItems = new ObservableCollection<OcrSubtitleItem>();
@@ -4650,8 +4652,7 @@ public partial class OcrViewModel : ObservableObject
     // and progress are latest-wins. Flushed directly before any modal that reads line text
     // (unknown-word prompt, add-character windows) and from OK, so dialogs and the final
     // subtitle never see a half-flushed queue.
-    private CoalescedUiUpdateQueue OcrUiUpdates => _ocrUiUpdates ??= new CoalescedUiUpdateQueue(ApplyOcrUiSelect, ApplyOcrUiProgress);
-    private CoalescedUiUpdateQueue? _ocrUiUpdates;
+    private CoalescedUiUpdateQueue OcrUiUpdates { get; }
 
     private void ApplyOcrUiProgress(double value, string text)
     {

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -708,12 +708,12 @@ public partial class OcrViewModel : ObservableObject
     {
         if (totalItems <= 0)
         {
-            EnqueueOcrUiProgress(0, Se.Language.Ocr.RunningOcrDotDotDot);
+            OcrUiUpdates.EnqueueProgress(0, Se.Language.Ocr.RunningOcrDotDotDot);
             return;
         }
 
         var clampedItemNumber = Math.Clamp(currentItemNumber, 0, totalItems);
-        EnqueueOcrUiProgress(
+        OcrUiUpdates.EnqueueProgress(
             clampedItemNumber * 100.0 / totalItems,
             string.Format(Se.Language.Ocr.RunningOcrDotDotDotXY, clampedItemNumber, totalItems));
     }
@@ -2162,7 +2162,7 @@ public partial class OcrViewModel : ObservableObject
     private void Ok()
     {
         // A just-finished OCR run may still have line texts in the coalesced UI queue.
-        FlushOcrUiUpdates();
+        OcrUiUpdates.Flush();
 
         OkPressed = true;
 
@@ -3054,7 +3054,7 @@ public partial class OcrViewModel : ObservableObject
             var letters = NikseBitmapImageSplitter2.SplitBitmapToLettersNew(parentBitmap, SelectedNOcrPixelsAreSpace,
                 false, true, _lineHeightTracker.GetMinLineHeight(), true, _lineHeightTracker.GetAverageLineHeight());
             _lineHeightTracker.Update(letters);
-            EnqueueOcrUiSelect(i);
+            OcrUiUpdates.EnqueueSelect(i);
             var index = 0;
             var matches = new List<NOcrChar>();
             while (index < letters.Count)
@@ -3116,7 +3116,7 @@ public partial class OcrViewModel : ObservableObject
 
                         Dispatcher.UIThread.Post(async void () =>
                         {
-                            FlushOcrUiUpdates();
+                            OcrUiUpdates.Flush();
 
                             var result =
                                 await _windowService.ShowDialogAsync<NOcrCharacterAddWindow, NOcr.NOcrCharacterAddViewModel>(
@@ -3323,7 +3323,7 @@ public partial class OcrViewModel : ObservableObject
             parentBitmap.CropTop(0, new SKColor(0, 0, 0, 0));
             var letters = NikseBitmapImageSplitter2.SplitBitmapToLettersNew(parentBitmap, SelectedBinaryOcrPixelsAreSpace, false, true, _lineHeightTracker.GetMinLineHeight(), true, _lineHeightTracker.GetAverageLineHeight());
             _lineHeightTracker.Update(letters);
-            EnqueueOcrUiSelect(i);
+            OcrUiUpdates.EnqueueSelect(i);
             var index = 0;
             var matches = new List<BinaryOcrMatcher.CompareMatch>();
             while (index < letters.Count)
@@ -3381,7 +3381,7 @@ public partial class OcrViewModel : ObservableObject
 
                         Dispatcher.UIThread.Post(async void () =>
                         {
-                            FlushOcrUiUpdates();
+                            OcrUiUpdates.Flush();
 
                             var result =
                                 await _windowService.ShowDialogAsync<BinaryOcrCharacterAddWindow, BinaryOcrCharacterAddViewModel>(
@@ -3590,7 +3590,7 @@ public partial class OcrViewModel : ObservableObject
             {
                 // GetNextUnknownWord below reads item.Text, which may still sit in the
                 // coalesced OCR UI queue - apply it before prompting.
-                FlushOcrUiUpdates();
+                OcrUiUpdates.Flush();
 
                 var skipOnceWords = new HashSet<string>();
                 var skipAllWords = new HashSet<string>(StringComparer.Ordinal);
@@ -3816,7 +3816,7 @@ public partial class OcrViewModel : ObservableObject
 
         // The bound collections (UnknownWords/AllGuesses/AllFixes) must only be touched on the
         // UI thread, so the adds ride in the same coalesced update as the text.
-        EnqueueOcrUiUpdate(() =>
+        OcrUiUpdates.EnqueueUpdate(() =>
         {
             CurrentText = text;
             item.Text = text;
@@ -3836,7 +3836,7 @@ public partial class OcrViewModel : ObservableObject
             }
         });
 
-        EnqueueOcrUiSelect(i);
+        OcrUiUpdates.EnqueueSelect(i);
     }
 
     private List<UnknownWordItem> OcrFixLineAndSetText(int i, OcrSubtitleItem item)
@@ -3881,7 +3881,7 @@ public partial class OcrViewModel : ObservableObject
 
             // The bound collections (UnknownWords/AllGuesses/AllFixes) must only be touched on
             // the UI thread, so the adds ride in the same coalesced update as the text.
-            EnqueueOcrUiUpdate(() =>
+            OcrUiUpdates.EnqueueUpdate(() =>
             {
                 CurrentText = resultText;
                 item.Text = resultText;
@@ -3905,7 +3905,7 @@ public partial class OcrViewModel : ObservableObject
         {
             var alignment = GetAlignment(item);
             var text = alignment.Text;
-            EnqueueOcrUiUpdate(() =>
+            OcrUiUpdates.EnqueueUpdate(() =>
             {
                 item.Text = text;
                 CurrentText = text;
@@ -3917,7 +3917,7 @@ public partial class OcrViewModel : ObservableObject
             });
         }
 
-        EnqueueOcrUiSelect(i);
+        OcrUiUpdates.EnqueueSelect(i);
         return unknownWords;
     }
 
@@ -4070,7 +4070,7 @@ public partial class OcrViewModel : ObservableObject
                     var item = OcrSubtitleItems[i];
                     var bitmap = item.GetSkBitmap();
 
-                    EnqueueOcrUiSelect(i);
+                    OcrUiUpdates.EnqueueSelect(i);
 
                     var text = await ollamaOcr.Ocr(bitmap, url, model, SelectedOllamaLanguage ?? "English", cancellationToken);
 
@@ -4175,7 +4175,7 @@ public partial class OcrViewModel : ObservableObject
                     var item = OcrSubtitleItems[i];
                     var bitmap = item.GetSkBitmap();
 
-                    EnqueueOcrUiSelect(i);
+                    OcrUiUpdates.EnqueueSelect(i);
 
                     var text = await engine.Ocr(bitmap, url, modelName, SelectedOllamaLanguage ?? "English", prompt, cancellationToken);
 
@@ -4284,7 +4284,7 @@ public partial class OcrViewModel : ObservableObject
                     var item = OcrSubtitleItems[i];
                     var bitmap = item.GetSkBitmap();
 
-                    EnqueueOcrUiSelect(i);
+                    OcrUiUpdates.EnqueueSelect(i);
 
                     var text = await engine.Ocr(bitmap, cancellationToken);
                     item.Text = text;
@@ -4324,7 +4324,7 @@ public partial class OcrViewModel : ObservableObject
                     var item = OcrSubtitleItems[i];
                     var bitmap = item.GetSkBitmap();
 
-                    EnqueueOcrUiSelect(i);
+                    OcrUiUpdates.EnqueueSelect(i);
 
                     var text = await mistralOcr.Ocr(bitmap, SelectedOllamaLanguage ?? "English", cancellationToken);
                     item.Text = text;
@@ -4363,7 +4363,7 @@ public partial class OcrViewModel : ObservableObject
                     var item = OcrSubtitleItems[i];
                     var bitmap = item.GetSkBitmap();
 
-                    EnqueueOcrUiSelect(i);
+                    OcrUiUpdates.EnqueueSelect(i);
 
                     var text = await engine.Ocr(bitmap, GoogleVisionApiKey, SelectedGoogleVisionLanguage?.Code ?? "en", cancellationToken);
                     item.Text = text;
@@ -4645,129 +4645,30 @@ public partial class OcrViewModel : ObservableObject
         return new Bitmap(stream);
     }
 
-    // Coalesced UI updates during OCR (#13885). Fast engines finish a line in milliseconds, and
-    // per-line selection/scroll/text posts at Normal dispatcher priority outrank input processing,
-    // so Pause/Cancel clicks and even the window's minimize are starved until the run completes.
-    // Per-line UI feedback is queued here instead and applied in one Background-priority dispatcher
-    // job. The flush is leading-edge throttled: an update arriving after a quiet period is applied
-    // immediately (so slower engines feel live), and only while updates keep streaming are they
-    // batched to at most one flush per OcrUiFlushIntervalMs. Data updates (line text, fix results,
-    // unknown-word rows) are all applied in order; selection and progress are latest-wins - a
-    // newly OCR'ed line replaces any still-pending selection.
-    private const int OcrUiFlushIntervalMs = 100;
-    private readonly Lock _ocrUiUpdateLock = new Lock();
-    private readonly System.Diagnostics.Stopwatch _ocrUiFlushClock = System.Diagnostics.Stopwatch.StartNew();
-    private List<Action> _ocrUiPendingUpdates = new List<Action>();
-    private int _ocrUiPendingSelectIndex = -1;
-    private double _ocrUiPendingProgressValue;
-    private string? _ocrUiPendingProgressText;
-    private bool _ocrUiFlushScheduled;
-    private long _ocrUiLastFlushElapsedMs = -OcrUiFlushIntervalMs;
+    // Coalesced per-line UI feedback during OCR (#13885) - see CoalescedUiUpdateQueue. Data
+    // updates (line text, fix results, unknown-word rows) are all applied in order; selection
+    // and progress are latest-wins. Flushed directly before any modal that reads line text
+    // (unknown-word prompt, add-character windows) and from OK, so dialogs and the final
+    // subtitle never see a half-flushed queue.
+    private CoalescedUiUpdateQueue OcrUiUpdates => _ocrUiUpdates ??= new CoalescedUiUpdateQueue(ApplyOcrUiSelect, ApplyOcrUiProgress);
+    private CoalescedUiUpdateQueue? _ocrUiUpdates;
 
-    private void EnqueueOcrUiUpdate(Action update)
+    private void ApplyOcrUiProgress(double value, string text)
     {
-        lock (_ocrUiUpdateLock)
-        {
-            _ocrUiPendingUpdates.Add(update);
-        }
-
-        ScheduleOcrUiFlush();
+        ProgressValue = value;
+        ProgressText = text;
     }
 
-    private void EnqueueOcrUiSelect(int index)
+    private void ApplyOcrUiSelect(int selectIndex)
     {
-        lock (_ocrUiUpdateLock)
+        if (selectIndex >= OcrSubtitleItems.Count)
         {
-            _ocrUiPendingSelectIndex = index;
+            return;
         }
 
-        ScheduleOcrUiFlush();
-    }
-
-    private void EnqueueOcrUiProgress(double value, string text)
-    {
-        lock (_ocrUiUpdateLock)
-        {
-            _ocrUiPendingProgressValue = value;
-            _ocrUiPendingProgressText = text;
-        }
-
-        ScheduleOcrUiFlush();
-    }
-
-    private void ScheduleOcrUiFlush()
-    {
-        long delayMs;
-        lock (_ocrUiUpdateLock)
-        {
-            if (_ocrUiFlushScheduled)
-            {
-                return;
-            }
-
-            _ocrUiFlushScheduled = true;
-            var sinceLastFlushMs = _ocrUiFlushClock.ElapsedMilliseconds - _ocrUiLastFlushElapsedMs;
-            delayMs = OcrUiFlushIntervalMs - sinceLastFlushMs;
-        }
-
-        // DispatcherTimer may only be touched from the UI thread, and the enqueue often happens
-        // on an OCR worker thread. Background priority keeps both the scheduling hop and the
-        // flush itself below input processing, so a flood of updates can never starve input.
-        if (delayMs <= 0)
-        {
-            // Quiet period since the last flush - apply right away so the grid feels live.
-            Dispatcher.UIThread.Post(FlushOcrUiUpdates, DispatcherPriority.Background);
-        }
-        else
-        {
-            Dispatcher.UIThread.Post(
-                () => DispatcherTimer.RunOnce(FlushOcrUiUpdates, TimeSpan.FromMilliseconds(delayMs), DispatcherPriority.Background),
-                DispatcherPriority.Background);
-        }
-    }
-
-    /// <summary>
-    /// Applies all pending OCR UI updates. Normally fired by the flush timer on the UI thread;
-    /// also called directly before opening a modal (unknown-word prompt, add-character window)
-    /// and from OK, so dialogs and the final subtitle see fully applied line texts instead of a
-    /// half-flushed queue.
-    /// </summary>
-    private void FlushOcrUiUpdates()
-    {
-        List<Action> updates;
-        int selectIndex;
-        double progressValue;
-        string? progressText;
-        lock (_ocrUiUpdateLock)
-        {
-            _ocrUiFlushScheduled = false;
-            _ocrUiLastFlushElapsedMs = _ocrUiFlushClock.ElapsedMilliseconds;
-            updates = _ocrUiPendingUpdates;
-            _ocrUiPendingUpdates = new List<Action>();
-            selectIndex = _ocrUiPendingSelectIndex;
-            _ocrUiPendingSelectIndex = -1;
-            progressValue = _ocrUiPendingProgressValue;
-            progressText = _ocrUiPendingProgressText;
-            _ocrUiPendingProgressText = null;
-        }
-
-        foreach (var update in updates)
-        {
-            update();
-        }
-
-        if (progressText != null)
-        {
-            ProgressValue = progressValue;
-            ProgressText = progressText;
-        }
-
-        if (selectIndex >= 0 && selectIndex < OcrSubtitleItems.Count)
-        {
-            SelectedOcrSubtitleItem = OcrSubtitleItems[selectIndex];
-            SubtitleGrid.SelectedIndex = selectIndex;
-            Dispatcher.UIThread.Post(() => SubtitleGrid.ScrollIntoView(selectIndex), DispatcherPriority.Background);
-        }
+        SelectedOcrSubtitleItem = OcrSubtitleItems[selectIndex];
+        SubtitleGrid.SelectedIndex = selectIndex;
+        Dispatcher.UIThread.Post(() => SubtitleGrid.ScrollIntoView(selectIndex), DispatcherPriority.Background);
     }
 
     internal async void SelectAndScrollToRow(int index)

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -4649,16 +4649,20 @@ public partial class OcrViewModel : ObservableObject
     // per-line selection/scroll/text posts at Normal dispatcher priority outrank input processing,
     // so Pause/Cancel clicks and even the window's minimize are starved until the run completes.
     // Per-line UI feedback is queued here instead and applied in one Background-priority dispatcher
-    // job at most every OcrUiFlushIntervalMs. Data updates (line text, fix results, unknown-word
-    // rows) are all applied in order; selection and progress are latest-wins - a newly OCR'ed
-    // line replaces any still-pending selection.
-    private const int OcrUiFlushIntervalMs = 200;
+    // job. The flush is leading-edge throttled: an update arriving after a quiet period is applied
+    // immediately (so slower engines feel live), and only while updates keep streaming are they
+    // batched to at most one flush per OcrUiFlushIntervalMs. Data updates (line text, fix results,
+    // unknown-word rows) are all applied in order; selection and progress are latest-wins - a
+    // newly OCR'ed line replaces any still-pending selection.
+    private const int OcrUiFlushIntervalMs = 100;
     private readonly Lock _ocrUiUpdateLock = new Lock();
+    private readonly System.Diagnostics.Stopwatch _ocrUiFlushClock = System.Diagnostics.Stopwatch.StartNew();
     private List<Action> _ocrUiPendingUpdates = new List<Action>();
     private int _ocrUiPendingSelectIndex = -1;
     private double _ocrUiPendingProgressValue;
     private string? _ocrUiPendingProgressText;
     private bool _ocrUiFlushScheduled;
+    private long _ocrUiLastFlushElapsedMs = -OcrUiFlushIntervalMs;
 
     private void EnqueueOcrUiUpdate(Action update)
     {
@@ -4693,6 +4697,7 @@ public partial class OcrViewModel : ObservableObject
 
     private void ScheduleOcrUiFlush()
     {
+        long delayMs;
         lock (_ocrUiUpdateLock)
         {
             if (_ocrUiFlushScheduled)
@@ -4701,14 +4706,24 @@ public partial class OcrViewModel : ObservableObject
             }
 
             _ocrUiFlushScheduled = true;
+            var sinceLastFlushMs = _ocrUiFlushClock.ElapsedMilliseconds - _ocrUiLastFlushElapsedMs;
+            delayMs = OcrUiFlushIntervalMs - sinceLastFlushMs;
         }
 
         // DispatcherTimer may only be touched from the UI thread, and the enqueue often happens
         // on an OCR worker thread. Background priority keeps both the scheduling hop and the
-        // flush itself below input processing.
-        Dispatcher.UIThread.Post(
-            () => DispatcherTimer.RunOnce(FlushOcrUiUpdates, TimeSpan.FromMilliseconds(OcrUiFlushIntervalMs), DispatcherPriority.Background),
-            DispatcherPriority.Background);
+        // flush itself below input processing, so a flood of updates can never starve input.
+        if (delayMs <= 0)
+        {
+            // Quiet period since the last flush - apply right away so the grid feels live.
+            Dispatcher.UIThread.Post(FlushOcrUiUpdates, DispatcherPriority.Background);
+        }
+        else
+        {
+            Dispatcher.UIThread.Post(
+                () => DispatcherTimer.RunOnce(FlushOcrUiUpdates, TimeSpan.FromMilliseconds(delayMs), DispatcherPriority.Background),
+                DispatcherPriority.Background);
+        }
     }
 
     /// <summary>
@@ -4726,6 +4741,7 @@ public partial class OcrViewModel : ObservableObject
         lock (_ocrUiUpdateLock)
         {
             _ocrUiFlushScheduled = false;
+            _ocrUiLastFlushElapsedMs = _ocrUiFlushClock.ElapsedMilliseconds;
             updates = _ocrUiPendingUpdates;
             _ocrUiPendingUpdates = new List<Action>();
             selectIndex = _ocrUiPendingSelectIndex;

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -1530,14 +1530,7 @@ public partial class AutoTranslateViewModel : ObservableObject
                     index += translatedCount;
                     _translationProgressIndex = index;
 
-                    var advancedProgressIndex = index;
-                    Dispatcher.UIThread.Invoke(() =>
-                    {
-                        ProgressValue = (double)advancedProgressIndex * 100 / Rows.Count;
-                        ProgressText = $"{(int)ProgressValue} %";
-                        HasTranslatedSomething = true;
-                        SelectAndScrollToRow(advancedProgressIndex - 1);
-                    });
+                    EnqueueTranslateProgress(index);
                 }
 
                 return; // the finally block below reports completion
@@ -1568,16 +1561,9 @@ public partial class AutoTranslateViewModel : ObservableObject
                     noErrorCount++;
                     index += linesMergedAndTranslated;
 
-                    var index1 = index;
                     if (!_onlyCurrentLine)
                     {
-                        Dispatcher.UIThread.Invoke(() =>
-                        {
-                            ProgressValue = (double)index1 * 100 / Rows.Count;
-                            ProgressText = $"{(int)ProgressValue} %";
-                            HasTranslatedSomething = true;
-                            SelectAndScrollToRow(index1 - 1);
-                        });
+                        EnqueueTranslateProgress(index);
                     }
                     else
                     {
@@ -1625,14 +1611,7 @@ public partial class AutoTranslateViewModel : ObservableObject
                 {
                     index += translateCount;
                     noProgressCount = 0;
-                    var progressIndex = index;
-                    Dispatcher.UIThread.Invoke(() =>
-                    {
-                        ProgressValue = (double)progressIndex * 100 / Rows.Count;
-                        ProgressText = $"{(int)ProgressValue} %";
-                        HasTranslatedSomething = true;
-                        SelectAndScrollToRow(progressIndex - 1);
-                    });
+                    EnqueueTranslateProgress(index);
 
                     if (_onlyCurrentLine)
                     {
@@ -1717,6 +1696,10 @@ public partial class AutoTranslateViewModel : ObservableObject
 
             Dispatcher.UIThread.Invoke(() =>
             {
+                // Apply whatever is still queued first, so the final progress/selection below
+                // is the last word instead of being overridden by a stale queued update.
+                TranslateUiUpdates.Flush();
+
                 IsTranslateEnabled = true;
                 IsProgressEnabled = false;
 
@@ -1769,6 +1752,31 @@ public partial class AutoTranslateViewModel : ObservableObject
             BaiduTranslate => settings.BaiduUrl,
             _ => string.Empty,
         };
+    }
+
+    /// <summary>
+    /// Coalesced per-batch UI feedback during translation (#13885, the pattern OCR uses).
+    /// Only the pure feedback - progress and the follow-along selection - is queued. The row
+    /// TranslatedText writes stay immediate on purpose: the advanced engines read them back for
+    /// the next batch's rolling context (AdvancedTranslatorBase.CollectHistory) and
+    /// MergeAndSplitHelper reads existing translations when re-applying formatting, so a
+    /// deferred write would silently degrade the translation itself.
+    /// </summary>
+    private CoalescedUiUpdateQueue TranslateUiUpdates => _translateUiUpdates ??= new CoalescedUiUpdateQueue(SelectAndScrollToRow, ApplyTranslateProgress);
+    private CoalescedUiUpdateQueue? _translateUiUpdates;
+
+    private void ApplyTranslateProgress(double value, string text)
+    {
+        ProgressValue = value;
+        ProgressText = text;
+    }
+
+    private void EnqueueTranslateProgress(int translatedIndex)
+    {
+        var progressValue = (double)translatedIndex * 100 / Rows.Count;
+        TranslateUiUpdates.EnqueueProgress(progressValue, $"{(int)progressValue} %");
+        TranslateUiUpdates.EnqueueUpdate(() => HasTranslatedSomething = true);
+        TranslateUiUpdates.EnqueueSelect(translatedIndex - 1);
     }
 
     private void SelectAndScrollToRow(int index)

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -137,6 +137,8 @@ public partial class AutoTranslateViewModel : ObservableObject
         _windowService = windowService;
         _folderHelper = folderHelper;
 
+        TranslateUiUpdates = new CoalescedUiUpdateQueue(SelectAndScrollToRow, ApplyTranslateProgress);
+
         ApiKeyText = string.Empty;
         ApiUrlText = string.Empty;
         ModelText = string.Empty;
@@ -1762,8 +1764,7 @@ public partial class AutoTranslateViewModel : ObservableObject
     /// MergeAndSplitHelper reads existing translations when re-applying formatting, so a
     /// deferred write would silently degrade the translation itself.
     /// </summary>
-    private CoalescedUiUpdateQueue TranslateUiUpdates => _translateUiUpdates ??= new CoalescedUiUpdateQueue(SelectAndScrollToRow, ApplyTranslateProgress);
-    private CoalescedUiUpdateQueue? _translateUiUpdates;
+    private CoalescedUiUpdateQueue TranslateUiUpdates { get; }
 
     private void ApplyTranslateProgress(double value, string text)
     {

--- a/src/ui/Logic/CoalescedUiUpdateQueue.cs
+++ b/src/ui/Logic/CoalescedUiUpdateQueue.cs
@@ -1,0 +1,151 @@
+using Avalonia.Threading;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>
+/// Coalesces high-frequency per-line UI feedback from a background work loop (OCR,
+/// auto-translate) into batched dispatcher jobs (#13885). Fast engines finish a line in
+/// milliseconds, and per-line selection/scroll/text dispatches outrank or block input
+/// processing, so Pause/Cancel clicks and even the window's minimize are starved until the
+/// run completes.
+///
+/// The flush is leading-edge throttled: an update arriving after a quiet period is applied
+/// immediately (so slower engines feel live), and only while updates keep streaming are they
+/// batched to at most one flush per flushIntervalMs. Ordered updates (line text, fix results,
+/// result rows) are all applied in order; selection and progress are latest-wins - a newly
+/// processed line replaces any still-pending selection. Flushes run at Background dispatcher
+/// priority, below input, so a flood of updates can never starve input.
+///
+/// Enqueue methods may be called from any thread; the apply callbacks and queued update
+/// actions always run on the UI thread.
+/// </summary>
+public sealed class CoalescedUiUpdateQueue
+{
+    private readonly int _flushIntervalMs;
+    private readonly Action<int> _applySelect;
+    private readonly Action<double, string> _applyProgress;
+
+    private readonly Lock _lock = new Lock();
+    private readonly Stopwatch _clock = Stopwatch.StartNew();
+    private List<Action> _pendingUpdates = new List<Action>();
+    private int _pendingSelectIndex = -1;
+    private double _pendingProgressValue;
+    private string? _pendingProgressText;
+    private bool _flushScheduled;
+    private long _lastFlushElapsedMs;
+
+    public CoalescedUiUpdateQueue(Action<int> applySelect, Action<double, string> applyProgress, int flushIntervalMs = 100)
+    {
+        _applySelect = applySelect;
+        _applyProgress = applyProgress;
+        _flushIntervalMs = flushIntervalMs;
+        _lastFlushElapsedMs = -flushIntervalMs; // the very first update flushes immediately
+    }
+
+    public void EnqueueUpdate(Action update)
+    {
+        lock (_lock)
+        {
+            _pendingUpdates.Add(update);
+        }
+
+        ScheduleFlush();
+    }
+
+    public void EnqueueSelect(int index)
+    {
+        lock (_lock)
+        {
+            _pendingSelectIndex = index;
+        }
+
+        ScheduleFlush();
+    }
+
+    public void EnqueueProgress(double value, string text)
+    {
+        lock (_lock)
+        {
+            _pendingProgressValue = value;
+            _pendingProgressText = text;
+        }
+
+        ScheduleFlush();
+    }
+
+    private void ScheduleFlush()
+    {
+        long delayMs;
+        lock (_lock)
+        {
+            if (_flushScheduled)
+            {
+                return;
+            }
+
+            _flushScheduled = true;
+            var sinceLastFlushMs = _clock.ElapsedMilliseconds - _lastFlushElapsedMs;
+            delayMs = _flushIntervalMs - sinceLastFlushMs;
+        }
+
+        // DispatcherTimer may only be touched from the UI thread, and the enqueue often happens
+        // on a worker thread. Background priority keeps both the scheduling hop and the flush
+        // itself below input processing.
+        if (delayMs <= 0)
+        {
+            // Quiet period since the last flush - apply right away so the grid feels live.
+            Dispatcher.UIThread.Post(Flush, DispatcherPriority.Background);
+        }
+        else
+        {
+            var delay = TimeSpan.FromMilliseconds(delayMs);
+            Dispatcher.UIThread.Post(
+                () => DispatcherTimer.RunOnce(Flush, delay, DispatcherPriority.Background),
+                DispatcherPriority.Background);
+        }
+    }
+
+    /// <summary>
+    /// Applies all pending updates. Normally fired by the flush scheduling on the UI thread;
+    /// call it directly (from the UI thread) before opening a modal or building the final
+    /// result, so nothing reads a half-flushed queue.
+    /// </summary>
+    public void Flush()
+    {
+        List<Action> updates;
+        int selectIndex;
+        double progressValue;
+        string? progressText;
+        lock (_lock)
+        {
+            _flushScheduled = false;
+            _lastFlushElapsedMs = _clock.ElapsedMilliseconds;
+            updates = _pendingUpdates;
+            _pendingUpdates = new List<Action>();
+            selectIndex = _pendingSelectIndex;
+            _pendingSelectIndex = -1;
+            progressValue = _pendingProgressValue;
+            progressText = _pendingProgressText;
+            _pendingProgressText = null;
+        }
+
+        foreach (var update in updates)
+        {
+            update();
+        }
+
+        if (progressText != null)
+        {
+            _applyProgress(progressValue, progressText);
+        }
+
+        if (selectIndex >= 0)
+        {
+            _applySelect(selectIndex);
+        }
+    }
+}

--- a/tests/UI/Logic/CoalescedUiUpdateQueueTests.cs
+++ b/tests/UI/Logic/CoalescedUiUpdateQueueTests.cs
@@ -1,0 +1,169 @@
+using System.Collections.Generic;
+using System.Threading;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Nikse.SubtitleEdit.Logic;
+using Xunit;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// The queue that keeps a fast OCR/translate run from starving input (#13885).
+/// </summary>
+public class CoalescedUiUpdateQueueTests
+{
+    private static CoalescedUiUpdateQueue MakeQueue(List<int> selects, List<string> progress, int flushIntervalMs = 100)
+    {
+        return new CoalescedUiUpdateQueue(
+            index => selects.Add(index),
+            (_, text) => progress.Add(text),
+            flushIntervalMs);
+    }
+
+    [AvaloniaFact]
+    public void FirstUpdateAfterAQuietPeriodIsAppliedWithoutWaitingForTheInterval()
+    {
+        var selects = new List<int>();
+        var applied = new List<string>();
+        var queue = MakeQueue(selects, new List<string>());
+
+        queue.EnqueueUpdate(() => applied.Add("first"));
+        queue.EnqueueSelect(7);
+
+        // No timer wait - just the pending dispatcher jobs. A trailing-only throttle would
+        // still be waiting out the interval here, which is what made the grid feel laggy.
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(new[] { "first" }, applied);
+        Assert.Equal(new[] { 7 }, selects);
+    }
+
+    [AvaloniaFact]
+    public void UpdatesArrivingWhileStreamingAreBatchedIntoOneFlush()
+    {
+        var selects = new List<int>();
+        var applied = new List<string>();
+        var queue = MakeQueue(selects, new List<string>());
+
+        queue.EnqueueUpdate(() => applied.Add("line1"));
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal(new[] { "line1" }, applied);
+
+        // Everything that follows immediately lands in one batch, held by the throttle.
+        queue.EnqueueUpdate(() => applied.Add("line2"));
+        queue.EnqueueUpdate(() => applied.Add("line3"));
+        queue.EnqueueSelect(2);
+        queue.EnqueueSelect(3);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(new[] { "line1" }, applied);
+        Assert.Empty(selects);
+
+        queue.Flush();
+        Assert.Equal(new[] { "line1", "line2", "line3" }, applied);
+    }
+
+    [AvaloniaFact]
+    public void QueuedUpdatesAreAppliedInOrderAndSelectionIsLatestWins()
+    {
+        var selects = new List<int>();
+        var applied = new List<string>();
+        var queue = MakeQueue(selects, new List<string>());
+
+        queue.EnqueueUpdate(() => applied.Add("a"));
+        queue.EnqueueSelect(1);
+        queue.EnqueueUpdate(() => applied.Add("b"));
+        queue.EnqueueSelect(2);
+        queue.EnqueueUpdate(() => applied.Add("c"));
+        queue.EnqueueSelect(3);
+
+        queue.Flush();
+
+        // Every data update survives, in order; only the newest selection is applied.
+        Assert.Equal(new[] { "a", "b", "c" }, applied);
+        Assert.Equal(new[] { 3 }, selects);
+    }
+
+    [AvaloniaFact]
+    public void ProgressIsLatestWinsToo()
+    {
+        var progress = new List<string>();
+        var queue = MakeQueue(new List<int>(), progress);
+
+        queue.EnqueueProgress(10, "10 %");
+        queue.EnqueueProgress(20, "20 %");
+        queue.EnqueueProgress(30, "30 %");
+
+        queue.Flush();
+
+        Assert.Equal(new[] { "30 %" }, progress);
+    }
+
+    [AvaloniaFact]
+    public void FlushingAnEmptyQueueAppliesNothing()
+    {
+        var selects = new List<int>();
+        var progress = new List<string>();
+        var queue = MakeQueue(selects, progress);
+
+        queue.Flush();
+        queue.Flush();
+
+        Assert.Empty(selects);
+        Assert.Empty(progress);
+    }
+
+    [AvaloniaFact]
+    public void AnExplicitFlushLeavesNothingBehindForTheTimerToReapply()
+    {
+        var selects = new List<int>();
+        var applied = new List<string>();
+        var queue = MakeQueue(selects, new List<string>());
+
+        queue.EnqueueUpdate(() => applied.Add("only once"));
+        queue.EnqueueSelect(4);
+
+        // A modal (unknown-word prompt) or OK flushes directly; the scheduled flush that is
+        // still pending must not replay the same work.
+        queue.Flush();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(new[] { "only once" }, applied);
+        Assert.Equal(new[] { 4 }, selects);
+    }
+
+    [AvaloniaFact]
+    public void EnqueuingFromAWorkerThreadIsAppliedOnTheUiThread()
+    {
+        var selects = new List<int>();
+        var applied = new List<int>();
+        var appliedThreadIds = new List<int>();
+        var queue = MakeQueue(selects, new List<string>());
+        var uiThreadId = Thread.CurrentThread.ManagedThreadId;
+
+        var worker = new Thread(() =>
+        {
+            for (var i = 0; i < 50; i++)
+            {
+                var line = i;
+                queue.EnqueueUpdate(() =>
+                {
+                    applied.Add(line);
+                    appliedThreadIds.Add(Thread.CurrentThread.ManagedThreadId);
+                });
+                queue.EnqueueSelect(line);
+            }
+        });
+
+        worker.Start();
+        worker.Join();
+
+        queue.Flush();
+
+        Assert.Equal(50, applied.Count);
+        Assert.Equal(0, applied[0]);
+        Assert.Equal(49, applied[49]);
+        Assert.Equal(new[] { 49 }, selects);
+        Assert.All(appliedThreadIds, id => Assert.Equal(uiThreadId, id));
+    }
+}

--- a/tests/UI/Logic/ValueConverters/ValueConverterTests.cs
+++ b/tests/UI/Logic/ValueConverters/ValueConverterTests.cs
@@ -610,13 +610,18 @@ public class ValueConverterTests : IDisposable
         try
         {
             Se.Language.General.ErrorX = "Error: {0}";
-            var first = converter.Convert("Error: nope", typeof(object), null, Culture);
-            Assert.NotNull(first);
+            var errorBrush = converter.Convert("Error: nope", typeof(object), null, Culture);
+
+            // Non-error statuses get the plain theme text brush, not UnsetValue - a binding that
+            // yields UnsetValue falls back to black instead of the inherited foreground (#13884).
+            var defaultBrush = converter.Convert("OCR 42 %", typeof(object), null, Culture);
+            Assert.NotNull(errorBrush);
+            Assert.NotSame(defaultBrush, errorBrush);
 
             // A loaded translation swaps the string - the cached prefix has to follow.
             Se.Language.General.ErrorX = "Fejl: {0}";
-            Assert.Null(converter.Convert("Error: nope", typeof(object), null, Culture) as ISolidColorBrush);
-            Assert.NotNull(converter.Convert("Fejl: nix", typeof(object), null, Culture) as ISolidColorBrush);
+            Assert.Same(defaultBrush, converter.Convert("Error: nope", typeof(object), null, Culture));
+            Assert.Same(errorBrush, converter.Convert("Fejl: nix", typeof(object), null, Culture));
         }
         finally
         {


### PR DESCRIPTION
Fixes issue 1 of #13885 (buttons dead during OCR) and the "minimize only happens after the run completes" half of issue 2.

## Why the UI froze

Fast OCR engines (binary image compare, nOCR) finish a line in milliseconds, and every line posted selection, scroll, text and progress updates at Normal dispatcher priority — which outranks input processing in Avalonia. During a run the dispatcher queue never drained, so Pause/OK/Cancel clicks and even the window's minimize were starved until OCR completed.

The *post-restore* wedge in issues 2/3 (window hangs / lines unclickable after minimize+restore) is the #13865 minimize-mirror bug, already fixed in #13877 — which merged a few hours **after** beta 18 was cut, so the reporter can't have it yet. That part should be retested on the next beta.

## The fix

New `CoalescedUiUpdateQueue` (`src/ui/Logic`): per-line UI feedback is queued and applied in batched dispatcher jobs at **Background priority**, below input, so a flood of updates can never starve clicks or window messages.

The flush is **leading-edge throttled**: an update arriving after a quiet period is applied immediately (so slower engines still feel live), and only while updates keep streaming are they batched to at most one flush per 100 ms.

- **Ordered updates** (line text, fix results, unknown-word/fix/guess rows) are all applied, in order — nothing is dropped.
- **Selection+scroll** and **progress** are **latest-wins**: a newly processed line replaces any still-pending selection, so the grid follows the run at ~10 Hz instead of per line.

### OCR

All the per-line engine loops now go through the queue. Side effect fixed for free: the loops previously mutated the bound `UnknownWords`/`AllFixes`/`AllGuesses` ObservableCollections from their worker threads; those adds now ride in the coalesced update on the UI thread.

Ordering safety: the queue is flushed synchronously before any modal that reads line text (unknown-word prompt, nOCR/binary add-character windows) and at the top of OK, so dialogs and the final subtitle never see a half-flushed queue. User-driven navigation (inspect, go-to-line, pre-processing) keeps the immediate `SelectAndScrollToRow` path.

### Auto-translate

Same treatment for the per-batch progress and follow-along selection, replacing a synchronous `Dispatcher.Invoke` per batch at Normal priority.

Deliberately narrower than OCR: the row `TranslatedText` writes **stay immediate**, because `AdvancedTranslatorBase.CollectHistory` reads them back to build the next batch's rolling context and `MergeAndSplitHelper` reads existing translations when re-applying formatting — deferring those would degrade the translation itself, not just the display. The finally block flushes before applying the final progress/selection so a stale queued update cannot override it.

## Tests

New `CoalescedUiUpdateQueueTests` covers the leading-edge apply, batching while streaming, in-order data updates with latest-wins selection/progress, no replay after an explicit flush, and worker-thread enqueue applying on the UI thread.

Full UI suite: **3242 passed, 0 failed.**

The last commit fixes `BatchConvertStatusColor_StillFollowsTheErrorTextAfterItChanges`, which is red on main: #13884 changed the converter's non-error default from `UnsetValue` to the theme text brush, and the test still asserted the old null. It was the only red test on this PR's CI, so it is fixed here rather than in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)