### PR TITLE
Fix black video on non-Vulkan GPUs: bundle vulkan-1.dll with libmpv

### DIFF
--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -362,9 +362,9 @@ jobs:
 
       - name: Download libmpv for Windows
         run: |
-          Invoke-WebRequest -Uri "https://github.com/SubtitleEdit/support-files/releases/download/libmpv-2026-08-14/libmpv2-win64.zip" -OutFile "libmpv2-64.zip"
+          Invoke-WebRequest -Uri "https://github.com/SubtitleEdit/support-files/releases/download/libmpv-2026-08-14b/libmpv2-win64.zip" -OutFile "libmpv2-64.zip"
           Expand-Archive -Path "libmpv2-64.zip" -DestinationPath "libmpv-temp"
-          Invoke-WebRequest -Uri "https://github.com/SubtitleEdit/support-files/releases/download/libmpv-2026-08-14/libmpv2-win-arm64.zip" -OutFile "libmpv2-arm64.zip"
+          Invoke-WebRequest -Uri "https://github.com/SubtitleEdit/support-files/releases/download/libmpv-2026-08-14b/libmpv2-win-arm64.zip" -OutFile "libmpv2-arm64.zip"
           Expand-Archive -Path "libmpv2-arm64.zip" -DestinationPath "libmpv-arm64-temp"
 
       - name: Publish Windows x64 app
@@ -377,7 +377,8 @@ jobs:
             -p:FileVersion=$env:APP_VER_FULL `
             -p:InformationalVersion=$env:APP_VER_DISPLAY `
             -o ./publish/windows-x64
-          Copy-Item "libmpv-temp/libmpv-2.dll" "./publish/windows-x64/"
+          # The zip also carries libmpv's vulkan-1.dll dependency (+ its license) - copy everything (#13856).
+          Copy-Item "libmpv-temp/*" "./publish/windows-x64/"
           # Native PDBs (libSkiaSharp.pdb, libHarfBuzzSharp.pdb, ...) come from the SkiaSharp
           # runtime NuGet packages and aren't suppressed by -p:DebugType=none.
           Get-ChildItem -Path "./publish/windows-x64" -Filter "*.pdb" -Recurse -File | Remove-Item -Force
@@ -393,7 +394,8 @@ jobs:
             -p:InformationalVersion=$env:APP_VER_DISPLAY `
             -o ./publish/windows-arm64
           # Must be the native ARM64 libmpv build — an ARM64 process cannot load the x64 DLL (issue #12087).
-          Copy-Item "libmpv-arm64-temp/libmpv-2.dll" "./publish/windows-arm64/"
+          # The zip also carries libmpv's vulkan-1.dll dependency (+ its license) - copy everything (#13856).
+          Copy-Item "libmpv-arm64-temp/*" "./publish/windows-arm64/"
           Get-ChildItem -Path "./publish/windows-arm64" -Filter "*.pdb" -Recurse -File | Remove-Item -Force
 
       # - name: Setup WiX

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -162,6 +162,14 @@ See the [Keyboard Shortcuts Reference](reference/keyboard-shortcuts.md) for the 
 - Check that the video player path is correctly set in **Options → Settings → Video Player**
 - Try to re-encode the video for better compatibility via **Video → More → Re-encode video for better subtitling**
 
+### Video is black with no sound, but the waveform works
+The waveform is made with FFmpeg while the picture comes from libmpv, so this points at libmpv failing to load rather than at the file.
+- Update your graphics driver from Intel/NVIDIA/AMD directly — the generic Microsoft Basic Display driver has no usable OpenGL
+- Re-download libmpv via **Options → Settings → Video Player → Download libmpv**
+- If you installed libmpv by hand, make sure `vulkan-1.dll` sits next to `libmpv-2.dll` — recent libmpv builds do not load without it (see [Third-Party Components](third-party-components.md))
+- Check that your antivirus is not blocking `libmpv-2.dll`
+- As a cross-check, switch to VLC under **Options → Settings → Video Player**; if VLC plays the file, the problem is libmpv/OpenGL
+
 ### Waveform is not showing
 - Ensure FFmpeg is installed and the path is set in settings
 

--- a/docs/third-party-components.md
+++ b/docs/third-party-components.md
@@ -29,7 +29,7 @@ Subtitle Edit stores these components in its **Data Folder**.
 | Component | File(s) | Destination Path |
 |-----------|---------|------------------|
 | **FFmpeg** | `ffmpeg.exe`, `ffprobe.exe` (optional) | `[Data Folder]/ffmpeg` |
-| **MPV** | `libmpv-2.dll` | `[Data Folder]` (root) |
+| **MPV** | `libmpv-2.dll` (+ `vulkan-1.dll`) | `[Data Folder]` (root) |
 | **yt-dlp** | `yt-dlp.exe` | `[Data Folder]` (root) |
 | **Tesseract** | `tesseract.exe`, `tessdata/` folder | `[Data Folder]/Tesseract` |
 | **Whisper CPP** | `whisper-cli.exe`, `Models/` folder | `[Data Folder]/SpeechToText/Cpp` |
@@ -69,6 +69,9 @@ Used as a video player engine.
     *   **Note:** Builds with "v3" in the filename (e.g., `mpv-dev-x86_64-v3-...`) may offer better performance but require a newer CPU with AVX2 support. Use the standard builds (without "v3") for broader compatibility.
 *   **Destination:** `[Data Folder]` (The root data folder)
 *   **Files:** Extract `libmpv-2.dll` to the **root** of the Data Folder.
+*   **Also needed: `vulkan-1.dll`** — builds from August 2026 onwards link the Vulkan loader dynamically, so `libmpv-2.dll` will not load at all without it (the symptom is a black video with no sound, while the waveform still works). It is normally installed by your graphics driver, but drivers for GPUs older than Vulkan — and the generic Microsoft Basic Display driver — do not provide it.
+    *   Subtitle Edit's own "Download libmpv" button already includes it, so this only applies when you install libmpv manually.
+    *   To get it: download the **Vulkan Runtime** components zip from [vulkan.lunarg.com](https://vulkan.lunarg.com/sdk/home#windows) and place `vulkan-1.dll` (the `x64` one, or the ARM64 build on ARM devices) next to `libmpv-2.dll` in the root of the Data Folder.
 
 ### yt-dlp (Online Video Playback)
 Used to enable mpv to stream online videos (e.g., YouTube, Vimeo, and [many other sites](https://github.com/yt-dlp/yt-dlp/blob/master/supportedsites.md)) via **Video > Open from URL**.

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1150,14 +1150,21 @@ public partial class MainViewModel :
                 {
                     try
                     {
-                        if (File.Exists(libMpvFileName))
+                        // The update folder also carries libmpv's bundled dependencies
+                        // (e.g. vulkan-1.dll, issue #13856), so move everything in it.
+                        var updateFolder = Path.GetDirectoryName(newFileName)!;
+                        foreach (var sourceFileName in Directory.GetFiles(updateFolder))
                         {
-                            File.Delete(libMpvFileName);
+                            var targetFileName = Path.Combine(Se.DataFolder, Path.GetFileName(sourceFileName));
+                            if (File.Exists(targetFileName))
+                            {
+                                File.Delete(targetFileName);
+                            }
+
+                            File.Move(sourceFileName, targetFileName);
                         }
 
-                        File.Move(newFileName, libMpvFileName);
-
-                        Directory.Delete(Path.GetDirectoryName(newFileName)!);
+                        Directory.Delete(updateFolder);
                     }
                     catch
                     {

--- a/src/ui/Logic/Download/LibMpvDownloadService .cs
+++ b/src/ui/Logic/Download/LibMpvDownloadService .cs
@@ -17,8 +17,10 @@ public interface ILibMpvDownloadService
 public class LibMpvDownloadService : ILibMpvDownloadService
 {
     private readonly HttpClient _httpClient;
-    private const string WindowsUrl = "https://github.com/SubtitleEdit/support-files/releases/download/libmpv-2026-08-14/libmpv2-win64.zip";
-    private const string WindowsUrlArm = "https://github.com/SubtitleEdit/support-files/releases/download/libmpv-2026-08-14/libmpv2-win-arm64.zip";
+    // The "b" repack bundles the Khronos Vulkan loader: this libmpv has a load-time
+    // import of vulkan-1.dll, which GPU drivers older than Vulkan never installed (#13856).
+    private const string WindowsUrl = "https://github.com/SubtitleEdit/support-files/releases/download/libmpv-2026-08-14b/libmpv2-win64.zip";
+    private const string WindowsUrlArm = "https://github.com/SubtitleEdit/support-files/releases/download/libmpv-2026-08-14b/libmpv2-win-arm64.zip";
     private const string MacUrl = "";
     private const string MacUrlArm = "";
 

--- a/tests/UI/Logic/ValueConverters/ValueConverterTests.cs
+++ b/tests/UI/Logic/ValueConverters/ValueConverterTests.cs
@@ -610,13 +610,15 @@ public class ValueConverterTests : IDisposable
         try
         {
             Se.Language.General.ErrorX = "Error: {0}";
-            var first = converter.Convert("Error: nope", typeof(object), null, Culture);
-            Assert.NotNull(first);
+            var errorBrush = converter.Convert("Error: nope", typeof(object), null, Culture);
+            Assert.NotNull(errorBrush);
 
             // A loaded translation swaps the string - the cached prefix has to follow.
+            // Both the error brush and the non-error default are shared instances, so
+            // compare by identity: a non-error status must no longer get the error brush.
             Se.Language.General.ErrorX = "Fejl: {0}";
-            Assert.Null(converter.Convert("Error: nope", typeof(object), null, Culture) as ISolidColorBrush);
-            Assert.NotNull(converter.Convert("Fejl: nix", typeof(object), null, Culture) as ISolidColorBrush);
+            Assert.NotSame(errorBrush, converter.Convert("Error: nope", typeof(object), null, Culture));
+            Assert.Same(errorBrush, converter.Convert("Fejl: nix", typeof(object), null, Culture));
         }
         finally
         {


### PR DESCRIPTION
## The regression

Since beta 17, users on GPUs without a Vulkan runtime get a **black video with no sound** (waveform still works) — reported in #13856 by a GeForce 9500 GT user, where beta 16 works fine.

The libmpv bump in #13761 (shinchiro 20260814) picked up upstream's 2026-08-04 ["vulkan: disable static loader"](https://github.com/shinchiro/mpv-winbuild-cmake/commits) change: `libmpv-2.dll` now has a **load-time PE import of `vulkan-1.dll`** (both x64 and ARM64; the April DLL had none — Vulkan was statically linked). `vulkan-1.dll` is installed by GPU drivers, not by Windows, so on any machine whose driver predates Vulkan (or with the Microsoft Basic Display driver) `LoadLibrary("libmpv-2.dll")` fails outright — mpv never even initializes. Upstream ships no loader with their packages either; their open issue [shinchiro/mpv-winbuild-cmake#831](https://github.com/shinchiro/mpv-winbuild-cmake/issues/831) says "install the LunarG runtime yourself".

The repackaging in #13761 itself was clean — both DLLs verified byte-identical to upstream's non-v3 x86_64 / aarch64 archives.

## The fix

New support-files release [libmpv-2026-08-14b](https://github.com/SubtitleEdit/support-files/releases/tag/libmpv-2026-08-14b): the **same** libmpv DLLs (SHA256-verified unchanged) with the Authenticode-signed Khronos Vulkan loader from the LunarG 1.4.357.0 runtime (Apache-2.0, license text included) next to them — x64 loader in the x64 zip, ARM64 loader in the ARM64 zip.

This works because SE loads libmpv with `LOAD_WITH_ALTERED_SEARCH_PATH` + `SetDllDirectory`, so the adjacent `vulkan-1.dll` resolves the import. On machines with no Vulkan drivers the loader simply enumerates zero ICDs and mpv's d3d11/OpenGL context probing works exactly as before; on Vulkan-capable machines nothing changes.

Repo changes:
- `LibMpvDownloadService .cs` — point both download URLs at the `b` tag (the in-app unpack already extracts every root-level `.dll`, so `vulkan-1.dll` flows through).
- `build-ui.yml` — point the CI download at the `b` tag and copy the whole extracted zip into both Windows publish folders instead of only `libmpv-2.dll`.
- `MainViewModel.cs` — the `libmpv-update` fallback (used when the old DLL is locked during an in-app update) now moves every file in the folder, not just `libmpv-2.dll`.

## Docs

`docs/third-party-components.md` — manual libmpv installs need the loader too, so the MPV section now says where to get `vulkan-1.dll` and that SE's own download button already includes it. `docs/faq.md` — added the "black video, no sound, but the waveform works" symptom under Troubleshooting, since that combination is the tell-tale for libmpv failing to load.

## Unrelated test fix

`BatchConvertStatusColor_StillFollowsTheErrorTextAfterItChanges` was failing on `main` before this branch: #13883 and #13884 raced. The test used "is the result a brush at all" as a proxy for "is it the error brush", which only held while non-error statuses returned `UnsetValue`; #13884 correctly changed those to the explicit theme text brush to fix black-on-dark status text. The test now compares brush identity, which is what it was actually asserting. All four test projects pass (3235 + 1399 + 251 + 376).

Fixes #13856

🤖 Generated with [Claude Code](https://claude.com/claude-code)