### PR TITLE
Route WM_PASTE window messages to the focused control on Windows

### DIFF
--- a/src/ui/Features/Main/MainView.cs
+++ b/src/ui/Features/Main/MainView.cs
@@ -60,6 +60,26 @@ public class MainView : ViewBase
             {
                 _vm.OnLoaded();
             };
+
+            // Clipboard managers (Ditto, ClipboardFusion, ...) and automation tools often
+            // deliver a paste as a WM_PASTE message instead of synthesizing Ctrl+V. That
+            // message targets the focused HWND - which in Avalonia is always the window
+            // itself - so nothing receives it without this hook. Route it to the focused
+            // control like Ctrl+V would (the wndproc already runs on the UI thread).
+            if (OperatingSystem.IsWindows())
+            {
+                const uint wmPaste = 0x0302;
+                Win32Properties.AddWndProcHookCallback(_vm.Window,
+                    (IntPtr _, uint msg, IntPtr _, IntPtr _, ref bool handled) =>
+                    {
+                        if (msg == wmPaste && _vm.PasteViaWindowMessage())
+                        {
+                            handled = true;
+                        }
+
+                        return IntPtr.Zero;
+                    });
+            }
         }
 
         // Load language (normally already loaded in Program.Main before the window is built; this

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -17435,6 +17435,36 @@ public partial class MainViewModel :
         textBox.Paste();
     }
 
+    /// <summary>
+    /// Routes a WM_PASTE sent to the window's HWND (clipboard managers and automation tools
+    /// send it instead of synthesizing Ctrl+V) to whichever control has keyboard focus.
+    /// Avalonia has a single HWND per window, so the message always lands on the window and
+    /// never on the focused control itself. Returns false when no paste target is focused,
+    /// so the hook can leave the message unhandled.
+    /// </summary>
+    internal bool PasteViaWindowMessage()
+    {
+        if (Window?.FocusManager?.GetFocusedElement() is TextBox textBox)
+        {
+            textBox.Paste();
+            return true;
+        }
+
+        if (IsSubtitleGridFocused())
+        {
+            SubtitleGridPasteCommand.Execute(null);
+            return true;
+        }
+
+        if (AudioVisualizer is { IsFocused: true })
+        {
+            WaveformPasteFromClipboardCommand.Execute(null);
+            return true;
+        }
+
+        return false;
+    }
+
     [RelayCommand]
     private void TextBoxSelectAll()
     {


### PR DESCRIPTION
Clipboard managers (e.g. Ditto, ClipboardFusion) and automation tools can deliver a paste as a `WM_PASTE` message to the focused HWND instead of synthesizing Ctrl+V keystrokes. Avalonia has a single HWND per window, so the message landed on the main window and was silently dropped — pasting from such tools did nothing.

This hooks the main window's wndproc via `Win32Properties.AddWndProcHookCallback` (Windows-only) and routes `WM_PASTE` to whichever control has keyboard focus, matching what Ctrl+V reaches:

- a focused `TextBox` → its native `Paste()`
- the subtitle grid → `SubtitleGridPasteCommand`
- the waveform → `WaveformPasteFromClipboardCommand`

If no paste target is focused the message is left unhandled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)