### PR TITLE
Re-pin the Flathub manifest to v5.1.0

### DIFF
--- a/installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
+++ b/installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
@@ -452,8 +452,8 @@ modules:
       # regeneration pass before merging; see ../flathub/README.md.
       - type: git
         url: https://github.com/SubtitleEdit/subtitleedit.git
-        tag: v5.0.0
-        commit: a44ffa7025b59f424aa8a5a7ee250ea85c4c1361
+        tag: v5.1.0
+        commit: 38f1dd4bac6c70bdf1f2d1bb5952aa414c6cb777
         x-checker-data:
           type: git
           tag-pattern: ^v(\d+\.\d+\.\d+)$


### PR DESCRIPTION
`installer/flatpak/flathub/dk.nikse.subtitleedit.yaml` still pinned `v5.0.0` / `a44ffa70`. Current stable is `v5.1.0`, so the submission candidate CI validates was two stable releases behind.

Moves the source pin only:

- `tag: v5.0.0` → `v5.1.0`
- `commit: a44ffa70…` → `38f1dd4bac6c70bdf1f2d1bb5952aa414c6cb777` (the `v5.1.0` tag object, confirmed against `origin`)

`nuget-sources.json` stays uncommitted, per the folder README — `regenerate-flathub-nuget-sources` recreates it from whatever the manifest pins, so it can't drift.

### Known follow-up, not fixed here

The flathub manifest builds from the pinned tag's checkout, so the AppStream metainfo in the bundle is *v5.1.0's copy of the file* — and that copy's newest `<release>` is still `5.0.0` (2026-06-22). Editing the metainfo on `main` cannot fix this; it needs a 5.1.0 entry present at a commit we pin. Worth sorting before the actual Flathub submission (#11800), but it does not block the validation build.

Refs #11800.

🤖 Generated with [Claude Code](https://claude.com/claude-code)