### PR TITLE
Fix update-metainfo-version.sh flattening the AppStream release history

### DIFF
--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -39,6 +39,26 @@ env:
 
 
 jobs:
+  # A stable release is the one a Flathub build is cut from: the flathub manifest
+  # pins a tag and installs the AppStream metainfo from that tagged checkout, so
+  # whatever <releases> block is committed at the tag is what the published app
+  # advertises forever. v5.1.0 was tagged without bumping it and therefore claims
+  # 5.0.0 as its newest release. Cheap job, no needs, so it fails within seconds
+  # instead of after the whole build matrix - but create-release depends on it,
+  # so a stable release cannot get out without the entry.
+  verify-metainfo-release-entry:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Verify the metainfo has a <release> entry for this version
+        run: |
+          if [ "${{ inputs.is_prerelease }}" = "true" ]; then
+            echo "Pre-release build - a metainfo <release> entry is not required."
+            exit 0
+          fi
+          bash installer/flatpak/update-metainfo-version.sh --check
+
   # The flatpak chain (regenerate-flatpak-nuget-sources → build-linux-flatpak)
   # is defined first so GitHub's job-graph view lays it out in its own visual
   # lane on the left, rather than routing arrows from build-macos / build-linux
@@ -864,7 +884,7 @@ jobs:
 
   create-release:
     if: ${{ inputs.create_release }}
-    needs: [build-windows, build-macos, build-linux, build-linux-flatpak]
+    needs: [build-windows, build-macos, build-linux, build-linux-flatpak, verify-metainfo-release-entry]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/installer/flatpak/flathub/README.md
+++ b/installer/flatpak/flathub/README.md
@@ -74,9 +74,13 @@ Two mechanisms, doing two different halves of the job:
    on), and updates the manifest's `tag:`/`commit:` to match. That is the entire per-release
    workflow; nothing else in this folder needs manual editing.
 
-   Also run `../update-metainfo-version.sh` (bumps the AppStream `<release>` entry) and add a
-   matching entry to `../dk.nikse.subtitleedit.metainfo.xml` if this is a new stable version,
-   same as before.
+   The AppStream `<release>` entry is the other half, and its timing matters: this manifest
+   installs the metainfo from the **pinned tag's checkout**, so the entry has to be committed
+   *before* the tag is cut, not after. Run `../update-metainfo-version.sh` as part of the
+   release-prep PR - it inserts an entry for whatever version `Se.cs` names, keeping the older
+   ones - and write a `<description>` into the new entry by hand for a stable release.
+   `build-ui.yml`'s `verify-metainfo-release-entry` job enforces this: a dispatch with
+   `is_prerelease=false` fails before the build matrix if the entry is missing.
 
 ## Before submitting (first-time only)
 1. **Validate** (the Flathub review bot also runs this, but catching problems before opening

--- a/installer/flatpak/update-metainfo-version.sh
+++ b/installer/flatpak/update-metainfo-version.sh
@@ -3,13 +3,43 @@
 # Mirrors installer/WindowsInno/update-version.ps1 and
 #         installer/macBundle/update-plist-version.sh for the Flatpak build.
 #
+# Behaviour:
+#   * If <releases> already has an entry for the version in Se.cs, only that
+#     entry's date is refreshed. Re-running is a no-op on an unchanged day.
+#   * Otherwise a new entry is inserted at the top of <releases>, keeping every
+#     older entry intact. Pre-release versions (any version with a "-" in it)
+#     get type="development" so software centres do not offer them as the
+#     newest stable.
+#
+# It deliberately never rewrites an older entry: AppStream <releases> is the
+# release history a software centre shows, and an earlier version of this
+# script had an unanchored sed that stamped the current version and date onto
+# *every* <release> element, collapsing the whole history into duplicates of
+# the version being built.
+#
+# A freshly inserted entry has no <description>. That is valid AppStream, and
+# for a stable release it is the one thing worth filling in by hand afterwards
+# (see the existing entries for the shape).
+#
 # Usage (from repo root):
 #   ./installer/flatpak/update-metainfo-version.sh
 #   ./installer/flatpak/update-metainfo-version.sh \
 #       "src/ui/Logic/Config/Se.cs" \
 #       "installer/flatpak/dk.nikse.subtitleedit.metainfo.xml"
+#
+#   ./installer/flatpak/update-metainfo-version.sh --check [se.cs] [metainfo.xml]
+#       Verify only, change nothing: exits non-zero unless <releases> already
+#       carries an entry for the version in Se.cs. Used by the release workflow
+#       to stop a stable release whose metainfo was never updated (the v5.1.0
+#       release shipped with 5.0.0 as its newest entry that way).
 
 set -e
+
+CHECK_ONLY=0
+if [ "$1" = "--check" ]; then
+    CHECK_ONLY=1
+    shift
+fi
 
 SE_CS_PATH="${1:-src/ui/Logic/Config/Se.cs}"
 METAINFO_PATH="${2:-installer/flatpak/dk.nikse.subtitleedit.metainfo.xml}"
@@ -27,19 +57,79 @@ fi
 VERSION=$(echo "$VERSION_LINE" | sed -n 's/.*"v\([^"]*\)".*/\1/p')
 echo "Extracted version from Se.cs: $VERSION"
 
+if ! grep -q '<releases>' "$METAINFO_PATH"; then
+    echo "Error: No <releases> element found in $METAINFO_PATH"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Does <releases> already describe this exact version?
+# ---------------------------------------------------------------------------
+if grep -q "<release version=\"$VERSION\"" "$METAINFO_PATH"; then
+    HAS_ENTRY=1
+else
+    HAS_ENTRY=0
+fi
+
+if [ "$CHECK_ONLY" = "1" ]; then
+    if [ "$HAS_ENTRY" = "1" ]; then
+        echo "✓ $METAINFO_PATH already has a <release> entry for $VERSION"
+        exit 0
+    fi
+    echo "Error: $METAINFO_PATH has no <release> entry for $VERSION."
+    echo "       Add one (newest first) before tagging - a Flathub build takes"
+    echo "       its metainfo from the tagged checkout, so whatever is committed"
+    echo "       at the tag is what the published app advertises."
+    echo "       Newest entry currently in the file:"
+    grep -m1 '<release version=' "$METAINFO_PATH" | sed 's/^/         /'
+    exit 1
+fi
+
 TODAY=$(date +%Y-%m-%d)
 echo "Release date: $TODAY"
 
 # ---------------------------------------------------------------------------
-# 2. Replace the first <release version="..." date="..."> element.
-#    Uses a temp file so it works on both GNU (Linux) and BSD (macOS) sed.
+# 3. Refresh that entry's date, or insert a new newest entry.
+#    awk, not sed: the insert needs multi-line output, and awk behaves the same
+#    on GNU (Linux/CI) and BSD (macOS) without the -i portability dance.
 # ---------------------------------------------------------------------------
 TMP=$(mktemp)
-sed "s|<release version=\"[^\"]*\" date=\"[^\"]*\">|<release version=\"$VERSION\" date=\"$TODAY\">|" \
-    "$METAINFO_PATH" > "$TMP"
+
+if [ "$HAS_ENTRY" = "1" ]; then
+    awk -v ver="$VERSION" -v today="$TODAY" '
+        index($0, "<release version=\"" ver "\"") {
+            sub(/date="[^"]*"/, "date=\"" today "\"")
+        }
+        { print }
+    ' "$METAINFO_PATH" > "$TMP"
+    ACTION="updated the date on the existing entry"
+else
+    # A version with a "-" is a beta/rc; mark it so it is not treated as stable.
+    case "$VERSION" in
+        *-*) TYPE_ATTR=' type="development"' ;;
+        *)   TYPE_ATTR='' ;;
+    esac
+
+    awk -v ver="$VERSION" -v today="$TODAY" -v type_attr="$TYPE_ATTR" '
+        { print }
+        !inserted && /<releases>/ {
+            printf "    <release version=\"%s\"%s date=\"%s\">\n", ver, type_attr, today
+            printf "      <url>https://github.com/SubtitleEdit/subtitleedit/releases/tag/v%s</url>\n", ver
+            printf "    </release>\n"
+            inserted = 1
+        }
+    ' "$METAINFO_PATH" > "$TMP"
+    ACTION="inserted a new newest entry"
+fi
+
+if ! grep -q "<release version=\"$VERSION\"" "$TMP"; then
+    rm -f "$TMP"
+    echo "Error: failed to write a <release> entry for $VERSION - $METAINFO_PATH left unchanged"
+    exit 1
+fi
+
 mv "$TMP" "$METAINFO_PATH"
 
-echo "✓ Successfully updated $METAINFO_PATH"
+echo "✓ Successfully updated $METAINFO_PATH ($ACTION)"
 echo "  version : $VERSION"
 echo "  date    : $TODAY"
-


### PR DESCRIPTION
### The bug

The `sed` in [`update-metainfo-version.sh`](installer/flatpak/update-metainfo-version.sh) had no line anchor, so it applied to every line carrying a `<release …>` opening tag — rewriting the **whole** release history to the version being built, not just the newest entry. Running it against the current metainfo:

```
77:    <release version="5.2.0-beta19" date="2026-08-20">
83:    <release version="5.2.0-beta19" date="2026-08-20">
```

Both entries, identical. `5.0.0` and `5.0.0-beta9` gone from the history a software centre shows.

It has been harmless so far only by luck: the two callers (`build-flatpak.yml`, `build-ui.yml`) run it on a disposable CI checkout for the CI flatpak bundle, and that result is never committed. The first release-prep PR to run it would have lost the history for real.

### The fix

- Entry for this version already present → refresh only its `date`. Re-running is a no-op.
- Not present → insert a new entry at the top of `<releases>`, older entries untouched.
- Pre-release versions (anything with a `-`) get `type="development"` so they aren't offered as the newest stable.
- `awk` rather than `sed`: the insert is multi-line, and awk behaves identically on GNU and BSD without the `-i` portability dance.
- Bails out rather than writing if the entry didn't make it into the output, or if there's no `<releases>` element at all.

### Plus a guard for stable releases

A Flathub build installs the metainfo from the **pinned tag's checkout**, so the entry has to be committed *before* the tag is cut. v5.1.0 was tagged without it, which is why the manifest we just re-pinned to it advertises 5.0.0 as its newest release.

New `--check` mode, wired into a `verify-metainfo-release-entry` job. It has no `needs`, so a stable dispatch missing the entry fails in seconds instead of after the full build matrix, and `create-release` now depends on it so the release can't get out either way. `is_prerelease=true` dispatches skip the requirement, so beta flow is unchanged.

### Verified

Against a copy of the real metainfo: insert, re-run idempotency, stable vs pre-release attr, older entries left alone, `--check` failing then passing, and `xmllint` clean after each write.

Refs #11800.

🤖 Generated with [Claude Code](https://claude.com/claude-code)