### PR TITLE
Download a working Crisp ASR build on Intel Macs

### DIFF
--- a/src/ui/Logic/Download/CrispAsrDownloadService.cs
+++ b/src/ui/Logic/Download/CrispAsrDownloadService.cs
@@ -29,6 +29,19 @@ public class CrispAsrDownloadService : ICrispAsrDownloadService
     private const string WindowsCpuUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.29/crispasr-windows-x86_64-cpu.zip";
     private const string WindowsCpuLegacyUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.29/crispasr-windows-x86_64-cpu-legacy.zip";
     private const string MacUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.29/crispasr-macos.tar.gz";
+
+    /// <summary>
+    /// Intel Macs. Upstream's crispasr-macos.tar.gz is arm64-only - its build job runs on
+    /// macos-latest, which is Apple Silicon since macos-13 was retired, so an Intel Mac gets
+    /// "Bad CPU type in executable" after a 15 MB download, and Rosetta cannot bridge it
+    /// (x86_64 -> arm64 only, never the reverse). Issue #13559. Until upstream ships an
+    /// x86_64 or universal build, Subtitle Edit builds the x86_64 slice itself from the same
+    /// pinned tag: SubtitleEdit/support-files, workflow build-crispasr-macos-x64-release.yml.
+    /// It is a CPU + Accelerate build (ggml's Metal kernels crash on the AMD GPUs in Intel
+    /// Macs) and targets macOS 12, and the archive's inner folder matches upstream's so the
+    /// unpack path is shared.
+    /// </summary>
+    private const string MacIntelUrl = "https://github.com/SubtitleEdit/support-files/releases/download/crispasr-0829-macos-x64/crispasr-macos-x86_64.tar.gz";
     private const string LinuxUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.29/crispasr-linux-x86_64.tar.gz";
     private const string LinuxCudaUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.29/crispasr-linux-x86_64-cuda.tar.gz";
     private const string LinuxCuda13Url = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.29/crispasr-linux-x86_64-cuda13.tar.gz";
@@ -100,7 +113,7 @@ public class CrispAsrDownloadService : ICrispAsrDownloadService
 
         if (OperatingSystem.IsMacOS())
         {
-            return MacUrl; 
+            return RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? MacUrl : MacIntelUrl;
         }
 
         throw new PlatformNotSupportedException();

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -34,6 +34,14 @@ public static class DownloadHashManager
         public const string WindowsCpu = "CrispAsr.Windows.Cpu";
         public const string WindowsCpuLegacy = "CrispAsr.Windows.CpuLegacy";
         public const string MacOs = "CrispAsr.MacOs";
+
+        /// <summary>
+        /// Intel Macs, built by SubtitleEdit/support-files rather than upstream - see
+        /// <see cref="CrispAsrDownloadService"/>. Its own key because it is a different
+        /// archive with its own history, and an arm64 hash must never read as up to date
+        /// on an Intel install (or the other way round).
+        /// </summary>
+        public const string MacOsX64 = "CrispAsr.MacOsX64";
         public const string Linux = "CrispAsr.Linux";
         public const string LinuxCuda = "CrispAsr.Linux.Cuda";
         public const string LinuxCuda13 = "CrispAsr.Linux.Cuda13";
@@ -48,6 +56,7 @@ public static class DownloadHashManager
         public const string WindowsCpuExecutable = "CrispAsr.Windows.Cpu.Executable";
         public const string WindowsCpuLegacyExecutable = "CrispAsr.Windows.CpuLegacy.Executable";
         public const string MacOsExecutable = "CrispAsr.MacOs.Executable";
+        public const string MacOsX64Executable = "CrispAsr.MacOsX64.Executable";
         public const string LinuxExecutable = "CrispAsr.Linux.Executable";
         public const string LinuxCudaExecutable = "CrispAsr.Linux.Cuda.Executable";
         public const string LinuxCuda13Executable = "CrispAsr.Linux.Cuda13.Executable";
@@ -483,6 +492,10 @@ public static class DownloadHashManager
                 "bbc6422fb0346dc79a7be41b0800ffd67b42dfe81691084c4bc76c85a1caa985", // v0.5.4
                 "88e62281ce19047e34290680ecab35ea2e24af6fc2b9edd6244234733a228703", // v0.5.3
                 "7faa7c92b4b48a64fb653f13e0e985618d4495d6d05abc366b3fd4b27098e65c", // v0.5.2
+            },
+            [CrispAsr.MacOsX64] = new[]
+            {
+                "1ab9bc657c81e9ffcb5c733b66aaa340977cae7308309f4de13651e4896d7783", // v0.8.29 (current download URL)
             },
             [CrispAsr.MacOs] = new[]
             {
@@ -1090,6 +1103,10 @@ public static class DownloadHashManager
                 "d33905a3afb3372e0f8173eba8c65469db6dfafaa4786034a88fd7da2bbb2931", // v0.5.4
                 "2733a81f64c742981bc0a7cf3dff51dc16fbaf028b10f481fb908178b49ba627", // v0.5.3
                 "a6ef3181657f417d9fadbfae343110b42ae788d053de5e3f48407cae8da8f9d2", // v0.5.2
+            },
+            [CrispAsr.MacOsX64Executable] = new[]
+            {
+                "64d488a7b304d14e03ba353a3763b281fa2b55e067182f90ae5ba626ebaf3250", // v0.8.29 (current download URL)
             },
             [CrispAsr.MacOsExecutable] = new[]
             {
@@ -2092,6 +2109,8 @@ public static class DownloadHashManager
     /// On Windows the variant selects between cuda, vulkan, cpu, and cpu-legacy.
     /// On Linux x86_64 the variant selects between cuda, cuda13, vulkan, hip, and the default CPU build.
     /// On Linux ARM64 the variant is ignored (only one build).
+    /// On macOS the variant is ignored too, but arm64 and Intel are separate archives from
+    /// separate places (upstream vs SubtitleEdit/support-files), so they get separate keys.
     /// Returns null if the platform / variant combination is unknown.
     /// </summary>
     public static string? ResolveCrispAsrKey(string? variant)
@@ -2114,7 +2133,9 @@ public static class DownloadHashManager
 
         if (OperatingSystem.IsMacOS())
         {
-            return CrispAsr.MacOs;
+            return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+                ? CrispAsr.MacOs
+                : CrispAsr.MacOsX64;
         }
 
         if (OperatingSystem.IsWindows())
@@ -2333,7 +2354,9 @@ public static class DownloadHashManager
 
         if (OperatingSystem.IsMacOS())
         {
-            return CrispAsr.MacOsExecutable;
+            return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+                ? CrispAsr.MacOsExecutable
+                : CrispAsr.MacOsX64Executable;
         }
 
         if (OperatingSystem.IsWindows())


### PR DESCRIPTION
Fixes #13559.

Upstream's `crispasr-macos.tar.gz` is arm64-only — its build job runs on `macos-latest`, which has been Apple Silicon since macos-13 was retired, and it sets no `CMAKE_OSX_ARCHITECTURES`. I checked every release from v0.1.0 through the pinned v0.8.29: all of them are arm64. An Intel Mac downloads 15 MB and gets `Bad CPU type in executable`, or crashes inside ggml-metal when the backend is forced. Rosetta can't bridge it — it translates x86_64 → arm64, never the reverse.

So Subtitle Edit now builds the Intel slice itself, from the same pinned tag:

* **Build**: [`build-crispasr-macos-x64-release.yml`](https://github.com/SubtitleEdit/support-files/blob/master/.github/workflows/build-crispasr-macos-x64-release.yml) in `SubtitleEdit/support-files`, cross-compiling x86_64 on the arm64 runner.
* **Release**: [crispasr-0829-macos-x64](https://github.com/SubtitleEdit/support-files/releases/tag/crispasr-0829-macos-x64) → `crispasr-macos-x86_64.tar.gz` (17 MB).
* **This PR**: `CrispAsrDownloadService` picks that URL on non-arm64 macOS, and the Intel archive gets its own hash keys.

### How the Intel build differs from upstream's macOS recipe

| | why |
|---|---|
| `-DGGML_METAL=OFF` | ggml's Metal kernels target Apple-family GPUs; on the AMD GPUs in Intel Macs they crash — exactly the failure in the report. CPU + Accelerate BLAS instead. |
| `-DGGML_NATIVE=OFF` | otherwise the runner's `-mcpu=apple-mN` flags land in an x86 compile. ggml then picks its portable baseline: SSE4.2 + AVX + AVX2 + FMA + F16C + BMI2 — Haswell and up, i.e. every Intel Mac that runs macOS 12. |
| `-DCMAKE_OSX_DEPLOYMENT_TARGET=12.0` | left unset, clang targets the runner's own macOS and dyld refuses to launch the binary on anything older. |
| c2pa prebuilt fetched explicitly | `-DCRISPASR_C2PA_FETCH=ON` derives its triple from `CMAKE_SYSTEM_PROCESSOR`, which on a cross-arch Apple build is still the host — it would drop an aarch64 `libc2pa_c.dylib` into an x86_64 build. |

The archive's inner folder is `crispasr-macos`, same as upstream's, so the unpack path needs no arch-specific case. The workflow's Verify step gates on all of it: x86_64-only slices, no arm64 leftovers, the expected `minos`, and no links outside `/System` and `/usr/lib`.

### Verification

The published artifact, run under Rosetta on an M-series Mac:

```
  arch          : x86_64
  ggml backends : cpu,blas
system_info: ... AVX = 1 | AVX2 = 1 | F16C = 1 | FMA = 1 | BMI2 = 1 | ACCELERATE = 1
[00:00:00.000 --> 00:00:03.800]   Subtitly added now, will crisp AS alpha Intel Max.
```

(the wording is tiny.en being tiny.en — the point is that it runs and decodes.)

### Note for a follow-up

Upstream's **arm64** binary is stamped `minos 26.0` from v0.8.20 onwards (v0.7.0 was 15.0), because their runner moved to macOS 26. dyld refuses to launch a binary whose minimum is newer than the OS, so the pinned v0.8.29 likely won't start on Apple Silicon Macs running macOS 15 or older either. Not addressed here — worth an upstream issue asking them to pin the deployment target, or the same treatment as this Intel build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)