### PR TITLE
Keep the settings column out of the progress bar row

### DIFF
--- a/src/ui/Features/Video/BurnIn/BurnInWindow.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInWindow.cs
@@ -59,6 +59,20 @@ public class BurnInWindow : Window
             Children = { subtitleSettingsView, videoSettingsView, targetFileSizeView },
         };
 
+        // Rows 0-3 hold the panel at any size the window can normally reach, but not when the
+        // window ends up shorter than its own content minimum - which happens on screens too
+        // short for the dialog, where UiUtil lowers the minimum to keep the window on the working
+        // area. A StackPanel draws its overflow straight through whatever is below it, so the
+        // last box ("File size in MB") ended up under the progress bar (issue #13904). The scroll
+        // viewer keeps that overflow inside the cell and still reachable; it measures exactly like
+        // the panel, so at every normal size the layout is unchanged and no scroll bar appears.
+        var leftPanelScroller = new ScrollViewer
+        {
+            Content = leftPanel,
+            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+            HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+        };
+
         var buttonGenerate = new SplitButton
         {
             Content = Se.Language.General.Generate,
@@ -122,7 +136,7 @@ public class BurnInWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
-        grid.Add(leftPanel, 0, 0, 4, 1);  // rows 0-3 (cut + preview + audio + video info)
+        grid.Add(leftPanelScroller, 0, 0, 4, 1);  // rows 0-3 (cut + preview + audio + video info)
         grid.Add(cutView, 0, 1);
         grid.Add(previewView, 1, 1);
         grid.Add(audioSettingsView, 2, 1);

--- a/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesWindow.cs
+++ b/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesWindow.cs
@@ -41,6 +41,17 @@ public class TransparentSubtitlesWindow : Window
             VerticalAlignment = VerticalAlignment.Top,
             Children = { subtitleSettingsView, videoSettingsView },
         };
+
+        // Same overflow guard as the burn-in window: when the window is shorter than its content
+        // minimum, a bare StackPanel draws its overflow through the progress row below it
+        // (issue #13904). Measures exactly like the panel, so no normal size changes.
+        var leftPanelScroller = new ScrollViewer
+        {
+            Content = leftPanel,
+            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+            HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+        };
+
         var cutView = MakeCutView(vm);
         var previewView = MakePreviewView(vm);
         var batchView = MakeBatchView(vm);
@@ -107,7 +118,7 @@ public class TransparentSubtitlesWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
-        grid.Add(leftPanel, 0, 0, 3, 1);
+        grid.Add(leftPanelScroller, 0, 0, 3, 1);
         grid.Add(cutView, 0, 1);
         grid.Add(previewView, 1, 1);
         grid.Add(videoInfoView, 2, 1);

--- a/tests/UI/Features/Video/BurnInWindowTests.cs
+++ b/tests/UI/Features/Video/BurnInWindowTests.cs
@@ -5,6 +5,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Headless.XUnit;
 using Avalonia.LogicalTree;
+using Avalonia.VisualTree;
 using Nikse.SubtitleEdit.Features.Video.BurnIn;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Media;
@@ -18,7 +19,10 @@ namespace UITests.Features.Video;
 /// preview row (row 1) carries a MinHeight: it keeps the packed panel inside rows 0-3 (so it
 /// can never overflow into the progress-bar row, which used to draw the bar through the
 /// "File size in MB" field) and keeps the preview box taller than its label + player (so the
-/// player can never spill over the audio settings box when the window is shrunk).
+/// player can never spill over the audio settings box when the window is shrunk). A window
+/// shorter than its own content minimum - which UiUtil produces on screens too short for the
+/// dialog - still leaves rows 0-3 short of the panel, so the panel scrolls rather than draws its
+/// overflow through the progress bar (issue #13904).
 /// </summary>
 public class BurnInWindowTests : IDisposable
 {
@@ -99,18 +103,67 @@ public class BurnInWindowTests : IDisposable
         // The left column is one panel spanning rows 0-3. With the row minimum in place it
         // must fit entirely above the progress view - the regression this guards against drew
         // the progress bar through the "File size in MB" field while generating.
-        var leftPanel = rootGrid.Children.OfType<StackPanel>().FirstOrDefault();
-        Assert.NotNull(leftPanel);
+        AssertSettingsColumnStaysAboveProgressView(window, rootGrid);
+    }
+
+    [AvaloniaFact]
+    public void SettingsColumn_StaysAboveProgressBar_WhenWindowIsShorterThanItsContent()
+    {
+        var window = BuildWindow();
+        var vm = window.DataContext as BurnInViewModel;
+        Assert.NotNull(vm);
+        vm.IsGenerating = true; // progress view is only visible while generating
+        window.Show();
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        // What a screen too short for the dialog produces: UiUtil lowers the window minimum to
+        // the working area, so the grid gets less height than its rows asked for and rows 0-3
+        // end up shorter than the settings column. The column must contain its own overflow -
+        // an unclipped panel drew the last box ("File size in MB") under the progress bar.
+        window.SizeToContent = SizeToContent.Manual;
+        window.MinHeight = 650;
+        window.Height = 650;
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        AssertSettingsColumnStaysAboveProgressView(window, FindRootGrid(window));
+    }
+
+    private static void AssertSettingsColumnStaysAboveProgressView(BurnInWindow window, Grid rootGrid)
+    {
+        var settingsColumn = rootGrid.Children.FirstOrDefault(c => Grid.GetColumn(c) == 0 && Grid.GetRowSpan(c) == 4);
+        Assert.NotNull(settingsColumn);
         var progressView = rootGrid.Children.OfType<Grid>().FirstOrDefault(g => Grid.GetRow(g) == 4);
         Assert.NotNull(progressView);
 
-        var panelBottom = leftPanel.TranslatePoint(new Point(0, leftPanel.Bounds.Height), window)?.Y;
+        var panelBottom = PaintedBottom(settingsColumn, window);
         var progressTop = progressView.TranslatePoint(new Point(0, 0), window)?.Y;
-        Assert.NotNull(panelBottom);
         Assert.NotNull(progressTop);
         Assert.True(
-            panelBottom.Value <= progressTop.Value + 1.5,
-            $"Left panel bottom ({panelBottom.Value:0.#}) is below the progress view top ({progressTop.Value:0.#}).");
+            panelBottom <= progressTop.Value + 1.5,
+            $"Settings column paints down to {panelBottom:0.#}, past the progress view top ({progressTop.Value:0.#}).");
+    }
+
+    /// <summary>
+    /// Lowest point in the window that anything inside <paramref name="visual"/> actually paints
+    /// at. The walk stops at a control that clips, since nothing below it can paint outside its
+    /// bounds - which is what keeps the settings column out of the progress row.
+    /// </summary>
+    private static double PaintedBottom(Visual visual, Visual relativeTo)
+    {
+        var bottom = visual.TranslatePoint(new Point(0, visual.Bounds.Height), relativeTo)?.Y ?? 0;
+        if (visual.ClipToBounds)
+        {
+            return bottom;
+        }
+
+        foreach (var child in visual.GetVisualChildren())
+        {
+            bottom = Math.Max(bottom, PaintedBottom(child, relativeTo));
+        }
+
+        return bottom;
     }
 
     [AvaloniaFact]


### PR DESCRIPTION
Fixes #13904

### The problem

At (or near) minimum window height, the generate progress bar draws through the "File size in MB" box:

<img width="700" alt="reported overlap" src="https://github.com/user-attachments/assets/18724a5b-7fcb-48ff-a02a-8ff3cd150000" />

### Root cause

The burn-in settings column is one `StackPanel` spanning the four rows above the progress bar. Rows 0-3 do hold it at every size the window can normally reach — I confirmed that in a headless harness: at the content minimum the column ends 5px *above* the progress row.

The gap opens when the window is shorter than its own content minimum. `UiUtil.ClampToWorkingArea` deliberately lowers `MinHeight` when the dialog is taller than the screen working area, so on a screen that is a little too short the star row bottoms out at its `MinHeight` and rows 0-3 come up ~10px short. A `StackPanel` has no clip, so it paints those pixels straight through the row below — the progress bar.

Measured in the harness (window 10px under its content minimum), before the fix:

```
NORMAL  rows=[113,410,111,63,35,62] progressRowTop=697  column paints to 692  (5px clear)
CLAMPED rows=[113,400,111,63,35,62] progressRowTop=687  column paints to 692  (5px INTO the progress row)
```

### The change

Wrap the settings column in a `ScrollViewer`. It measures exactly like the panel, so the window's content minimum and every normal-size layout are byte-for-byte unchanged and no scroll bar appears; when the cell is short the overflow stays inside it and remains reachable instead of painting over the row below.

The transparent-subtitles window is built from the same shape (same panel, same progress row, and no `MinHeight` on its star row at all) so it gets the same guard.

### Testing

`BurnInWindowTests` gains `SettingsColumn_StaysAboveProgressBar_WhenWindowIsShorterThanItsContent`, which drives the real window below its content minimum and asserts nothing in the settings column paints past the progress row top. It walks the visual tree for the lowest actually-painted point, stopping at any control that clips — so it measures the real symptom, not the presence of a `ScrollViewer`.

Verified it fails on main (`Settings column paints down to 716, past the progress view top (711).`) and passes with the fix.

The pre-existing `PreviewRow_HasMinimumHeight_KeepingPanelAboveProgressBar` used `OfType<StackPanel>().FirstOrDefault()` to find the column, which silently picks a different panel now; it locates the column by grid position instead and shares the same assertion.

Full UI suite: 3247 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)