### PR TITLE
Stop the position slider fighting the mouse mid-drag

### DIFF
--- a/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
+++ b/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
@@ -187,6 +187,10 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
         private readonly Grid _gridProgress; // Reference to the controls grid
         private DispatcherTimer? _autoHideTimer;
         private DateTime _lastActivityTime;
+
+        // True while the user is dragging (or arrow-keying) the position slider. The position
+        // timer must leave the slider alone for as long as it is set - see StartPositionTimer.
+        private bool _isUserMovingPositionSlider;
         private ContentPresenter? _contentPresenter;
 
         private void NotifyPositionChanged(double newPosition)
@@ -415,24 +419,23 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             // Also ensure the control can receive keyboard focus
             sliderPosition.Focusable = true;
 
-            var sliderPositionUserMoving = false;
-            sliderPosition.AddHandler(PointerPressedEvent, (_, _) => sliderPositionUserMoving = true, RoutingStrategies.Tunnel);
-            sliderPosition.AddHandler(PointerReleasedEvent, (_, _) => sliderPositionUserMoving = false, RoutingStrategies.Tunnel);
-            sliderPosition.AddHandler(PointerCaptureLostEvent, (_, _) => sliderPositionUserMoving = false, RoutingStrategies.Tunnel);
+            sliderPosition.AddHandler(PointerPressedEvent, (_, _) => _isUserMovingPositionSlider = true, RoutingStrategies.Tunnel);
+            sliderPosition.AddHandler(PointerReleasedEvent, (_, _) => _isUserMovingPositionSlider = false, RoutingStrategies.Tunnel);
+            sliderPosition.AddHandler(PointerCaptureLostEvent, (_, _) => _isUserMovingPositionSlider = false, RoutingStrategies.Tunnel);
             sliderPosition.AddHandler(KeyDownEvent, (_, e) =>
             {
                 if (e.Key is Key.Left or Key.Right or Key.Up or Key.Down or Key.Home or Key.End or Key.PageUp or Key.PageDown)
                 {
-                    sliderPositionUserMoving = true;
+                    _isUserMovingPositionSlider = true;
                 }
             }, RoutingStrategies.Tunnel);
-            sliderPosition.AddHandler(KeyUpEvent, (_, _) => sliderPositionUserMoving = false, RoutingStrategies.Tunnel);
+            sliderPosition.AddHandler(KeyUpEvent, (_, _) => _isUserMovingPositionSlider = false, RoutingStrategies.Tunnel);
 
             // For any direct value changes
             sliderPosition.ValueChanged += (s, e) =>
             {
                 NotifyPositionChanged(e.NewValue);
-                if (sliderPositionUserMoving)
+                if (_isUserMovingPositionSlider)
                 {
                     UserSeeked?.Invoke(e.NewValue);
                 }
@@ -937,13 +940,27 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
                 }
 
                 var postFix = IsSmpteTimingEnabled ? " (SMPTE)" : string.Empty;
-                var pos = _videoPlayerInstance.Position;
-                if (IsSmpteTimingEnabled)
+                double pos;
+                if (_isUserMovingPositionSlider)
                 {
-                    pos = pos * 1000.0 / 1001.0; // SMPTE timing adjustment
+                    // While the slider is being dragged its own value is the truth. Writing the
+                    // player position back into Position mid-drag pulls the thumb off the mouse
+                    // until the seek lands, and the next mouse move pulls it forward again -
+                    // the back and forth jumping in issue #13910. It only showed up during
+                    // playback because a paused player reports the seeked-to position right
+                    // away, leaving nothing to fight over.
+                    pos = Position;
                 }
+                else
+                {
+                    pos = _videoPlayerInstance.Position;
+                    if (IsSmpteTimingEnabled)
+                    {
+                        pos = pos * 1000.0 / 1001.0; // SMPTE timing adjustment
+                    }
 
-                SetPositionDisplayOnly(pos);
+                    SetPositionDisplayOnly(pos);
+                }
 
                 var fullDuration = TimeCode.FromSeconds(Duration + Se.Settings.General.CurrentVideoOffsetInMs / 1000.0).ToDisplayString();
                 if (VideoPlayerDisplayTimeLeft)

--- a/tests/UI/Controls/VideoPlayerControlPositionSliderTests.cs
+++ b/tests/UI/Controls/VideoPlayerControlPositionSliderTests.cs
@@ -1,0 +1,140 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.LogicalTree;
+using Nikse.SubtitleEdit.Controls.VideoPlayer;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.VideoPlayers;
+using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
+using Xunit;
+
+namespace UITests.Controls;
+
+/// <summary>
+/// Covers the position slider jumping under the mouse during playback (issue #13910). The 50 ms
+/// position timer publishes the player position into the control, which the slider is bound to.
+/// A seek does not land instantly, so mid-drag the timer kept writing the pre-seek position back
+/// and yanked the thumb off the mouse until the next mouse move pulled it forward again. Pausing
+/// hid it: a paused player reports the seeked-to position straight away.
+/// </summary>
+public class VideoPlayerControlPositionSliderTests
+{
+    /// <summary>
+    /// A player whose reported position lags behind the seeks asked of it - what every real
+    /// player does, and the whole reason the timer and the drag can disagree.
+    /// </summary>
+    private sealed class SeekLaggingVideoPlayer : IVideoPlayer
+    {
+        private double _reported;
+
+        public SeekLaggingVideoPlayer(double reported) => _reported = reported;
+
+        public double LastSeekTo { get; private set; } = -1;
+
+        /// <summary>Moves the position the player reports, as playback or a completed seek would.</summary>
+        public void ReportPosition(double seconds) => _reported = seconds;
+
+        public string Name => "seek-lagging";
+        public string FileName { get; private set; } = string.Empty;
+        public bool CanLoad() => true;
+
+        public Task LoadFile(string fileName, double startPositionSeconds = 0)
+        {
+            FileName = fileName;
+            return Task.CompletedTask;
+        }
+
+        public void CloseFile() => FileName = string.Empty;
+        public void Play() { }
+        public void PlayOrPause() { }
+        public void Pause() { }
+        public void Stop() { }
+        public AudioTrackInfo? ToggleAudioTrack() => null;
+        public bool IsPlaying => true;
+        public bool IsPaused => false;
+
+        public double Position
+        {
+            get => _reported;
+            set => LastSeekTo = value; // seek requested; the reported position catches up later
+        }
+
+        public double Duration => 600;
+        public int VolumeMaximum => 100;
+        public double Volume { get; set; } = 50;
+        public double Speed { get; set; } = 1.0;
+    }
+
+    private static Slider FindPositionSlider(VideoPlayerControl control)
+    {
+        return control.GetLogicalDescendants()
+            .OfType<Slider>()
+            .First(s => Equals(AutomationProperties.GetName(s), Se.Language.General.VideoPosition));
+    }
+
+    private static void PressPointerOn(VideoPlayerControl control, Slider slider)
+    {
+        slider.RaiseEvent(new PointerPressedEventArgs(
+            slider,
+            new Pointer(1, PointerType.Mouse, true),
+            control,
+            new Point(0, 0),
+            0,
+            new PointerPointProperties(RawInputModifiers.LeftMouseButton, PointerUpdateKind.LeftButtonPressed),
+            KeyModifiers.None));
+    }
+
+    private static void ReleasePointerOn(VideoPlayerControl control, Slider slider)
+    {
+        slider.RaiseEvent(new PointerReleasedEventArgs(
+            slider,
+            new Pointer(1, PointerType.Mouse, true),
+            control,
+            new Point(0, 0),
+            0,
+            new PointerPointProperties(RawInputModifiers.None, PointerUpdateKind.LeftButtonReleased),
+            KeyModifiers.None,
+            MouseButton.Left));
+    }
+
+    [AvaloniaFact]
+    public async Task PositionTimerLeavesTheSliderAloneWhileTheUserDragsIt()
+    {
+        var player = new SeekLaggingVideoPlayer(reported: 5);
+        var control = new VideoPlayerControl(player);
+        await control.Open("fake.mkv");
+        await Task.Delay(150); // let the timer publish the duration and the starting position
+
+        var slider = FindPositionSlider(control);
+        PressPointerOn(control, slider);
+        slider.Value = 300; // the user drags the thumb; the seek has not landed yet
+
+        await Task.Delay(200); // several 50 ms timer ticks
+
+        Assert.Equal(300, slider.Value, 3);
+        Assert.Equal(300, player.LastSeekTo, 3); // and the drag still seeks
+    }
+
+    [AvaloniaFact]
+    public async Task PositionTimerTakesOverAgainOnceTheDragEnds()
+    {
+        var player = new SeekLaggingVideoPlayer(reported: 5);
+        var control = new VideoPlayerControl(player);
+        await control.Open("fake.mkv");
+        await Task.Delay(150);
+
+        var slider = FindPositionSlider(control);
+        PressPointerOn(control, slider);
+        slider.Value = 300;
+        ReleasePointerOn(control, slider);
+
+        player.ReportPosition(301); // playback carries on from where the user dropped the thumb
+        await Task.Delay(200);
+
+        Assert.Equal(301, slider.Value, 3);
+    }
+}


### PR DESCRIPTION
Fixes #13910

### The problem

Dragging the video position slider is smooth while paused, but during playback the thumb visibly jumps back and forth under the mouse.

### Root cause

The 50 ms position timer in `VideoPlayerControl` publishes `_videoPlayerInstance.Position` into the control's `Position` property, and the slider's `Value` is bound to it.

A seek does not land instantly. Mid-drag the sequence is:

1. mouse moves the thumb → `ValueChanged` → seek requested
2. timer ticks before the seek lands → player still reports the *old* position → written into `Position` → thumb snaps backwards
3. next mouse move pulls it forward again

Hence the back and forth. Pausing hid it because a paused player reports the seeked-to position on the very next poll, so there is nothing to disagree about — which is exactly the paused/playing difference in the report.

### The change

While the slider is being moved, its own value is the truth. The timer now takes the display position from `Position` instead of the player, and does not write to it until the drag ends. The existing "user is moving the slider" flag already covered pointer press/release, capture lost, and the arrow/Home/End keys; it was a local in the constructor, so it is now a field the timer can read.

Playback, seeking, and the time readout are otherwise untouched: the moment the drag ends, the timer takes over again.

### Testing

Two headless tests in a new `VideoPlayerControlPositionSliderTests`, driven by a fake `IVideoPlayer` whose reported position lags behind the seeks asked of it — the real condition that makes the timer and the drag disagree:

- `PositionTimerLeavesTheSliderAloneWhileTheUserDragsIt` — drag to 300s while the player still reports 5s; the thumb must stay at 300 and the seek must still be issued. Fails on main with exactly the reported symptom (`Expected: 300, Actual: 5`).
- `PositionTimerTakesOverAgainOnceTheDragEnds` — guards the other direction, so the fix cannot turn into "the slider stops following playback". Passes both with and without the change.

Full UI suite: 3249 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)