### PR TITLE
Bring back the minimum gap frame rate calculator

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -51,6 +51,7 @@ using Nikse.SubtitleEdit.Features.Options.Language;
 using Nikse.SubtitleEdit.Features.Options.Plugins;
 using Nikse.SubtitleEdit.Features.Options.Settings;
 using Nikse.SubtitleEdit.Features.Options.Settings.SettingsImportExport;
+using Nikse.SubtitleEdit.Features.Options.Settings.MinGapCalculate;
 using Nikse.SubtitleEdit.Features.Options.Settings.SyntaxColorTooWideSettings;
 using Nikse.SubtitleEdit.Features.Options.Settings.WaveformThemes;
 using Nikse.SubtitleEdit.Features.Options.Settings.WaveformToolbarItems;
@@ -542,6 +543,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<StatisticsViewModel>();
         collection.AddTransient<SurroundWithViewModel>();
         collection.AddTransient<SyntaxColorTooWideSettingsViewModel>();
+        collection.AddTransient<MinGapCalculateViewModel>();
         collection.AddTransient<TextToSpeechViewModel>();
         collection.AddTransient<ActorVoiceMappingViewModel>();
         collection.AddTransient<ActorVoiceRowSettingsViewModel>();

--- a/src/ui/Features/Options/Settings/MinGapCalculate/MinGapCalculateViewModel.cs
+++ b/src/ui/Features/Options/Settings/MinGapCalculate/MinGapCalculateViewModel.cs
@@ -1,0 +1,122 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Features.Options.Settings.MinGapCalculate;
+
+/// <summary>
+/// Works out a minimum gap in milliseconds from a frame rate and a number of frames, so a gap
+/// specified by a delivery spec as "two frames" can be entered as the milliseconds the rest of
+/// Subtitle Edit works in - without the user reaching for a calculator (issue #13906).
+/// </summary>
+public partial class MinGapCalculateViewModel : ObservableObject
+{
+    [ObservableProperty] private ObservableCollection<string> _frameRates = [];
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CalculationText))]
+    [NotifyPropertyChangedFor(nameof(UseAsNewGapText))]
+    private string _selectedFrameRate = string.Empty;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CalculationText))]
+    [NotifyPropertyChangedFor(nameof(UseAsNewGapText))]
+    private int? _frames;
+
+    public Window? Window { get; set; }
+
+    public bool OkPressed { get; private set; }
+
+    /// <summary>Result of the calculation - the value the caller should adopt when OK was pressed.</summary>
+    public int MinGapMs => (int)Math.Round(1000.0 / GetFrameRate() * (Frames ?? 0));
+
+    public string CalculationText => string.Format(
+        Se.Language.Options.Settings.MinGapCalculateXFramesAtYGivesZMs,
+        Frames ?? 0,
+        FormatFrameRate(GetFrameRate()),
+        MinGapMs);
+
+    public string UseAsNewGapText => string.Format(
+        Se.Language.Options.Settings.MinGapCalculateUseXAsNewGap,
+        MinGapMs);
+
+    public MinGapCalculateViewModel()
+    {
+        FrameRates = new ObservableCollection<string>(
+            new[] { 23.976, 24.0, 25.0, 29.97, 30.0, 50.0, 59.94, 60.0 }.Select(FormatFrameRate));
+    }
+
+    /// <summary>
+    /// Starts from the frame rate of the video currently loaded, so the common case - "two frames
+    /// at the frame rate I am working with" - needs no picking at all.
+    /// </summary>
+    public void Initialize(int frames)
+    {
+        var current = FormatFrameRate(Configuration.Settings.General.CurrentFrameRate);
+        if (!FrameRates.Contains(current))
+        {
+            FrameRates.Insert(0, current);
+        }
+
+        SelectedFrameRate = current;
+        Frames = frames;
+    }
+
+    private double GetFrameRate()
+    {
+        // The box is editable, so anything can be in it; fall back to the current video's frame
+        // rate rather than dividing by zero or by a half-typed number.
+        if (double.TryParse(SelectedFrameRate, NumberStyles.AllowDecimalPoint, CultureInfo.CurrentCulture, out var frameRate) &&
+            frameRate > 0)
+        {
+            return frameRate;
+        }
+
+        if (double.TryParse(SelectedFrameRate, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out frameRate) &&
+            frameRate > 0)
+        {
+            return frameRate;
+        }
+
+        var current = Configuration.Settings.General.CurrentFrameRate;
+        return current > 0 ? current : 25.0;
+    }
+
+    private static string FormatFrameRate(double frameRate)
+    {
+        return frameRate.ToString("0.###", CultureInfo.CurrentCulture);
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Window?.Close();
+    }
+
+    public void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Cancel();
+        }
+        else if (e.Key == Key.Enter)
+        {
+            Ok();
+        }
+    }
+}

--- a/src/ui/Features/Options/Settings/MinGapCalculate/MinGapCalculateWindow.cs
+++ b/src/ui/Features/Options/Settings/MinGapCalculate/MinGapCalculateWindow.cs
@@ -1,0 +1,73 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Options.Settings.MinGapCalculate;
+
+public class MinGapCalculateWindow : Window
+{
+    private readonly MinGapCalculateViewModel _vm;
+
+    public MinGapCalculateWindow(MinGapCalculateViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = Se.Language.Options.Settings.MinGapCalculateTitle;
+        SizeToContent = SizeToContent.WidthAndHeight;
+        CanResize = false;
+
+        _vm = vm;
+        vm.Window = this;
+        DataContext = vm;
+
+        var labelFrameRate = UiUtil.MakeLabel(Se.Language.General.FrameRate);
+        var comboBoxFrameRate = UiUtil.MakeEditableComboBox(150, vm.FrameRates, vm, nameof(vm.SelectedFrameRate));
+
+        var labelFrames = UiUtil.MakeLabel(Se.Language.Options.Settings.MinGapCalculateFrames);
+        var numericUpDownFrames = UiUtil.MakeNumericUpDownInt(0, 100, 2, 100, vm, nameof(vm.Frames));
+
+        var labelCalculation = new TextBlock
+        {
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.CalculationText)),
+        };
+
+        var labelUseAsNewGap = new TextBlock
+        {
+            FontWeight = FontWeight.Bold,
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.UseAsNewGapText)),
+        };
+
+        var buttonPanel = UiUtil.MakeButtonBar(
+            UiUtil.MakeButtonOk(vm.OkCommand),
+            UiUtil.MakeButtonCancel(vm.CancelCommand));
+
+        Content = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 10,
+            Margin = UiUtil.MakeWindowMargin(),
+            Children =
+            {
+                labelFrameRate,
+                comboBoxFrameRate,
+                labelFrames,
+                numericUpDownFrames,
+                labelCalculation,
+                labelUseAsNewGap,
+                buttonPanel,
+            },
+        };
+
+        Activated += delegate { comboBoxFrameRate.Focus(); };
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        _vm.OnKeyDown(e);
+    }
+}

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -235,6 +235,9 @@ public class SettingsPage : UserControl
                 {
                     MakeNumericUpDownInt(nameof(_vm.MinGapMs), _vm.RuleValueChanged)
                         .WithBindIsVisible(_vm, nameof(_vm.IsMsMode)),
+                    UiUtil.MakeButtonBrowse(_vm.CalculateMinGapMsCommand,
+                            accessibleName: Se.Language.Options.Settings.MinGapCalculateDotDotDot)
+                        .WithBindIsVisible(_vm, nameof(_vm.IsMsMode)),
                     MakeNumericUpDownInt(nameof(_vm.MinGapFrames), _vm.RuleValueChanged)
                         .WithBindIsVisible(_vm, nameof(_vm.UseFrameMode)),
                     new TextBlock

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -17,6 +17,7 @@ using Nikse.SubtitleEdit.Features.Assa;
 using Nikse.SubtitleEdit.Features.Help.CheckForUpdates;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Options.DoNotBreakAfterList;
+using Nikse.SubtitleEdit.Features.Options.Settings.MinGapCalculate;
 using Nikse.SubtitleEdit.Features.Options.Settings.SyntaxColorTooWideSettings;
 using Nikse.SubtitleEdit.Features.Tools.BeautifyTimeCodes.Profile;
 using Nikse.SubtitleEdit.Features.Options.Settings.WaveformThemes;
@@ -2163,6 +2164,29 @@ public partial class SettingsViewModel : ObservableObject
             ColorTextTooWidePixels = viewModel.MaxWidthPixels;
             ColorTextTooWideFontName = viewModel.SelectedFont;
             ColorTextTooWideFontSize = viewModel.FontSize;
+        }
+    }
+
+    /// <summary>
+    /// Delivery specs give the minimum gap in frames, the setting is in milliseconds - offer the
+    /// same frame rate calculator Subtitle Edit 4 had behind the "..." button (issue #13906).
+    /// </summary>
+    [RelayCommand]
+    private async Task CalculateMinGapMs()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var viewModel = await _windowService.ShowDialogAsync<MinGapCalculateWindow, MinGapCalculateViewModel>(
+            Window,
+            vm => vm.Initialize(MinGapFrames ?? 2));
+
+        if (viewModel.OkPressed)
+        {
+            MinGapMs = viewModel.MinGapMs;
+            RuleValueChanged();
         }
     }
 

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -80,6 +80,11 @@ public class LanguageSettings
     public string MaxDurationMs { get; set; }
     public string MinGapMs { get; set; }
     public string MinGapFrames { get; set; }
+    public string MinGapCalculateDotDotDot { get; set; }
+    public string MinGapCalculateTitle { get; set; }
+    public string MinGapCalculateFrames { get; set; }
+    public string MinGapCalculateXFramesAtYGivesZMs { get; set; }
+    public string MinGapCalculateUseXAsNewGap { get; set; }
     public string MaxLines { get; set; }
     public string UnbreakSubtitlesShortThan { get; set; }
     public string AutoBreakLineEndingEarly { get; set; }
@@ -404,6 +409,11 @@ public class LanguageSettings
         MaxDurationMs = "Max duration (ms)";
         MinGapMs = "Min gap (ms)";
         MinGapFrames = "Min gap (frames)";
+        MinGapCalculateDotDotDot = "Calculate minimum gap from a frame rate...";
+        MinGapCalculateTitle = "Min. gap between subtitles in ms";
+        MinGapCalculateFrames = "Min. gap in frames";
+        MinGapCalculateXFramesAtYGivesZMs = "{0} frames at a frame rate of {1} gives {2} milliseconds.";
+        MinGapCalculateUseXAsNewGap = "Use \"{0}\" milliseconds as new minimum gap?";
         MaxLines = "Max number of lines";
         UnbreakSubtitlesShortThan = "Unbreak subtitles shorter than";
         AutoBreakLineEndingEarly = "Auto-break early for end of sentence (.!?)";

--- a/tests/UI/Features/Options/MinGapCalculateTests.cs
+++ b/tests/UI/Features/Options/MinGapCalculateTests.cs
@@ -1,0 +1,133 @@
+using System.Globalization;
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Options.Settings.MinGapCalculate;
+using Xunit;
+
+namespace UITests.Features.Options;
+
+/// <summary>
+/// The minimum gap setting is in milliseconds but delivery specs state it in frames, so Subtitle
+/// Edit 4 had a small calculator behind a "..." button next to the field. It did not survive the
+/// move to SE5 (issue #13906); these cover the arithmetic it does.
+/// </summary>
+public class MinGapCalculateTests
+{
+    private static MinGapCalculateViewModel MakeViewModel(double currentFrameRate, int frames)
+    {
+        Configuration.Settings.General.CurrentFrameRate = currentFrameRate;
+        var vm = new MinGapCalculateViewModel();
+        vm.Initialize(frames);
+        return vm;
+    }
+
+    [AvaloniaTheory]
+    [InlineData(23.976, 2, 83)]  // the case in the issue screenshot
+    [InlineData(25.0, 2, 80)]
+    [InlineData(24.0, 1, 42)]
+    [InlineData(30.0, 3, 100)]
+    [InlineData(59.94, 2, 33)]
+    public void CalculatesMillisecondsFromFramesAndFrameRate(double frameRate, int frames, int expectedMs)
+    {
+        var vm = MakeViewModel(frameRate, frames);
+
+        Assert.Equal(expectedMs, vm.MinGapMs);
+    }
+
+    [AvaloniaFact]
+    public void StartsFromTheCurrentFrameRateAndOffersIt()
+    {
+        var vm = MakeViewModel(23.976, 2);
+
+        Assert.Equal(23.976.ToString("0.###", CultureInfo.CurrentCulture), vm.SelectedFrameRate);
+        Assert.Contains(vm.SelectedFrameRate, vm.FrameRates);
+    }
+
+    [AvaloniaFact]
+    public void AnUnusualFrameRateIsAddedToTheListRatherThanDropped()
+    {
+        var vm = MakeViewModel(48.0, 2);
+
+        Assert.Equal(48.0.ToString("0.###", CultureInfo.CurrentCulture), vm.SelectedFrameRate);
+        Assert.Equal(42, vm.MinGapMs);
+    }
+
+    [AvaloniaFact]
+    public void PickingAnotherFrameRateRecalculates()
+    {
+        var vm = MakeViewModel(23.976, 2);
+
+        vm.SelectedFrameRate = 25.0.ToString("0.###", CultureInfo.CurrentCulture);
+
+        Assert.Equal(80, vm.MinGapMs);
+    }
+
+    [AvaloniaFact]
+    public void ChangingTheFrameCountRecalculates()
+    {
+        var vm = MakeViewModel(25.0, 2);
+
+        vm.Frames = 5;
+
+        Assert.Equal(200, vm.MinGapMs);
+    }
+
+    /// <summary>
+    /// The frame rate box is editable, so it can hold a half-typed value at any moment - that must
+    /// not divide by zero or blow up the binding.
+    /// </summary>
+    [AvaloniaTheory]
+    [InlineData("")]
+    [InlineData("abc")]
+    [InlineData("0")]
+    [InlineData("-5")]
+    public void UnparsableFrameRateFallsBackToTheCurrentOne(string typed)
+    {
+        var vm = MakeViewModel(25.0, 2);
+
+        vm.SelectedFrameRate = typed;
+
+        Assert.Equal(80, vm.MinGapMs);
+    }
+
+    [AvaloniaFact]
+    public void TheTextsQuoteTheNumbersTheUserIsAboutToAccept()
+    {
+        var vm = MakeViewModel(23.976, 2);
+
+        Assert.Contains("83", vm.CalculationText);
+        Assert.Contains("83", vm.UseAsNewGapText);
+    }
+
+    [AvaloniaFact]
+    public void OkIsWhatTellsTheCallerToAdoptTheValue()
+    {
+        var vm = MakeViewModel(25.0, 2);
+        Assert.False(vm.OkPressed);
+
+        vm.OkCommand.Execute(null);
+
+        Assert.True(vm.OkPressed);
+    }
+
+    [AvaloniaFact]
+    public void CancelLeavesOkPressedUnset()
+    {
+        var vm = MakeViewModel(25.0, 2);
+
+        vm.CancelCommand.Execute(null);
+
+        Assert.False(vm.OkPressed);
+    }
+
+    [AvaloniaFact]
+    public void WindowConstructs()
+    {
+        var vm = MakeViewModel(23.976, 2);
+
+        var window = new MinGapCalculateWindow(vm);
+
+        Assert.NotNull(window.Content);
+        window.Close();
+    }
+}


### PR DESCRIPTION
Fixes #13906

### What was missing

Subtitle Edit 4 had a "..." button next to "Min. gap between subtitles in ms" that opened a small calculator: pick a frame rate, pick a number of frames, and it offers the milliseconds.

<img width="500" alt="the SE4 dialog" src="https://github.com/user-attachments/assets/66db80a2-1da1-4c91-b2dd-d5c53ea77912" />

SE5 has frame mode, which covers "I want to work in frames" — but it is pinned to the current video's frame rate, so it does not help someone who has to produce a millisecond value for a spec quoted in frames at some *other* rate. There was no equivalent of the button.

### The change

The calculator is back as its own dialog (`MinGapCalculate`), opened from a `MakeButtonBrowse` "..." next to "Min gap (ms)" — shown only in ms mode, where it is the one that helps. On OK the computed value goes into `MinGapMs` and marks the profile rule changed, exactly as typing it would.

Two small improvements over the SE4 dialog, both to save a step in the common case:

- it opens on the **current video's frame rate** rather than always 23.976, adding it to the list when it is not one of the eight presets
- it opens on the **frame count already configured** rather than always 2

The frame rate box stays editable, as in SE4, so an arbitrary rate can be typed.

New strings live in `LanguageSettings`; `English.json` is generated at build time and is left for the usual regeneration.

### Testing

17 tests in a new `MinGapCalculateTests` covering the arithmetic and the dialog contract:

- the exact case from the issue screenshot — 2 frames at 23.976 → **83 ms** — plus 25/24/30/59.94
- opens on the current frame rate; an unusual rate (48) is added to the list rather than dropped
- recalculates when either the rate or the frame count changes
- a half-typed or nonsense frame rate (`""`, `"abc"`, `"0"`, `"-5"`) falls back to the current rate instead of dividing by zero — the box is editable, so this happens on the way to every keystroke
- OK/Cancel set `OkPressed` correctly, and the window constructs

Full UI suite: 3264 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)