### PR TITLE
Hide burn-in codecs ffmpeg lacks, and unbreak Whisper XXL on glibc 2.41+

### DIFF
--- a/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
@@ -2293,6 +2293,50 @@ public partial class BurnInViewModel : ObservableObject
     internal void Loaded()
     {
         Dispatcher.UIThread.Post(LoadVideoPreview);
+        _ = Task.Run(RemoveUnsupportedVideoEncodings);
+    }
+
+    /// <summary>
+    /// Hides the video encoders the running ffmpeg was not built with. The list in
+    /// <see cref="VideoEncodingItem.VideoEncodings"/> is what the platform *could* have, not
+    /// what this ffmpeg actually has: the Flatpak bundles an ffmpeg without x265, NVENC, AMF or
+    /// QSV, and distro packages differ again, so picking one of those started a job that only
+    /// failed at encode time with "Unknown encoder".
+    /// <para>
+    /// The probe launches ffmpeg, so it runs off the UI thread and applies its result afterwards;
+    /// the window opens with the full list for the few milliseconds that takes. A probe that fails
+    /// changes nothing (see <see cref="VideoEncodingItem.GetUnsupported"/>).
+    /// </para>
+    /// </summary>
+    private void RemoveUnsupportedVideoEncodings()
+    {
+        var available = FfmpegHelper.GetAvailableEncoders();
+
+        Dispatcher.UIThread.Post(() =>
+        {
+            var unsupported = VideoEncodingItem.GetUnsupported(VideoEncodings, available);
+            if (unsupported.Count == 0)
+            {
+                return;
+            }
+
+            // Re-point the selection before removing anything: dropping the selected item from the
+            // ComboBox's ItemsSource makes it null its SelectedItem, and the TwoWay binding writes
+            // that null straight back into SelectedVideoEncoding.
+            if (unsupported.Contains(SelectedVideoEncoding))
+            {
+                SelectedVideoEncoding = VideoEncodings.First(p => !unsupported.Contains(p));
+                VideoEncodingChanged();
+            }
+
+            foreach (var item in unsupported)
+            {
+                VideoEncodings.Remove(item);
+            }
+
+            Se.WriteToolsLog("Burn-in: hid video encoders missing from ffmpeg: " +
+                             string.Join(", ", unsupported.Select(p => p.Codec)));
+        });
     }
 
     /// <summary>

--- a/src/ui/Features/Video/BurnIn/VideoEncodingItem.cs
+++ b/src/ui/Features/Video/BurnIn/VideoEncodingItem.cs
@@ -1,5 +1,6 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Nikse.SubtitleEdit.Features.Video.BurnIn;
 
@@ -56,5 +57,32 @@ public class VideoEncodingItem
         }
 
         return items;
+    }
+
+    /// <summary>
+    /// The offered encoders that the ffmpeg SE is going to run was not built with, so the caller
+    /// can hide them. Nothing in SE checks <c>ffmpeg -encoders</c> before building the command
+    /// line, so a codec that is merely listed here fails at encode time with "Unknown encoder"
+    /// once the job is already running - and which encoders exist varies per build. The Flatpak
+    /// bundles an ffmpeg without x265, NVENC, AMF or QSV, and distro packages differ again.
+    /// <para>
+    /// Fails open in both directions: an empty <paramref name="availableEncoders"/> means the
+    /// probe did not work (no ffmpeg yet, a timeout, an unparsable banner) rather than "nothing is
+    /// supported", and a result that would hide every entry is discarded too. In both cases the
+    /// user keeps the full list and the old behaviour.
+    /// </para>
+    /// Pure - exposed for testing.
+    /// </summary>
+    internal static List<VideoEncodingItem> GetUnsupported(
+        IList<VideoEncodingItem> offered,
+        IReadOnlySet<string> availableEncoders)
+    {
+        if (offered.Count == 0 || availableEncoders.Count == 0)
+        {
+            return new List<VideoEncodingItem>();
+        }
+
+        var unsupported = offered.Where(p => !availableEncoders.Contains(p.Codec)).ToList();
+        return unsupported.Count < offered.Count ? unsupported : new List<VideoEncodingItem>();
     }
 }

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
@@ -176,6 +176,7 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject, ICl
 
                     var path = Engine.GetExecutable();
                     MakeExecutable(path);
+                    ClearExecutableStack(dir);
                 }
                 catch
                 {
@@ -302,6 +303,27 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject, ICl
         if (!_isClosing)
         {
             _timer.Start();
+        }
+    }
+
+    /// <summary>
+    /// Clears the executable-stack flag on the shared libraries just unpacked. Purfview's
+    /// Faster-Whisper-XXL bundles a libctranslate2 built with PT_GNU_STACK = RWE, and glibc 2.41
+    /// stopped granting that at dlopen time, so on Fedora 42, Arch or Ubuntu 25.10 the engine dies
+    /// the moment it loads with "cannot enable executable stack as shared object requires".
+    /// </summary>
+    private static void ClearExecutableStack(string folder)
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        var patched = ElfHelper.ClearExecutableStackInFolder(folder);
+        if (patched > 0)
+        {
+            Se.WriteToolsLog($"Cleared the executable-stack flag on {patched} shared librar" +
+                             (patched == 1 ? "y" : "ies") + $" in \"{folder}\"");
         }
     }
 

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -3930,6 +3930,8 @@ public partial class SpeechToTextViewModel : ObservableObject
             {
                 process.StartInfo.WorkingDirectory = whisperFolder;
             }
+
+            EnsureExecutableStackCleared(engine, whisperFolder);
         }
 
         if (OperatingSystem.IsWindows() && ProcessEnvironmentHelper.GetOrNull(process.StartInfo, "Path") != null)
@@ -3989,6 +3991,39 @@ public partial class SpeechToTextViewModel : ObservableObject
         }
 
         return process;
+    }
+
+    private static bool _executableStackChecked;
+
+    /// <summary>
+    /// Repairs an already-installed Purfview Faster-Whisper-XXL before launching it.
+    /// <para>
+    /// Its bundled libctranslate2 is built with PT_GNU_STACK = RWE, and glibc 2.41 stopped making
+    /// the stack executable at dlopen time, so on a distro with glibc 2.41+ (Fedora 42, Arch,
+    /// Ubuntu 25.10) the run dies immediately with "cannot enable executable stack as shared
+    /// object requires: Invalid argument". The download path clears the flag on unpack, but
+    /// installs made by an earlier SE are already on disk and re-downloading is over a gigabyte,
+    /// so fix them here too. Once per session: the scan only reads ELF headers, but there is no
+    /// reason to repeat it for every transcription.
+    /// </para>
+    /// </summary>
+    private static void EnsureExecutableStackCleared(ISpeechToTextEngine engine, string? whisperFolder)
+    {
+        if (_executableStackChecked ||
+            !OperatingSystem.IsLinux() ||
+            string.IsNullOrEmpty(whisperFolder) ||
+            engine is not WhisperEnginePurfviewFasterWhisperXxl)
+        {
+            return;
+        }
+
+        _executableStackChecked = true;
+        var patched = ElfHelper.ClearExecutableStackInFolder(whisperFolder);
+        if (patched > 0)
+        {
+            Se.WriteToolsLog($"Cleared the executable-stack flag on {patched} shared librar" +
+                             (patched == 1 ? "y" : "ies") + $" in \"{whisperFolder}\"");
+        }
     }
 
     private static string GetWhisperTranslateParameter(ISpeechToTextEngine engine)

--- a/src/ui/Logic/ElfHelper.cs
+++ b/src/ui/Logic/ElfHelper.cs
@@ -1,0 +1,197 @@
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Buffers.Binary;
+using System.IO;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>
+/// Minimal ELF program-header patching for downloaded Linux binaries.
+/// <para>
+/// glibc 2.41 stopped making the stack executable when a shared object asks for it
+/// (<c>PT_GNU_STACK</c> with the execute bit set): <c>dlopen</c> now fails outright with
+/// "cannot enable executable stack as shared object requires: Invalid argument". Some engines SE
+/// downloads still carry that flag, so on a distro with glibc 2.41+ (Fedora 42, Arch,
+/// Ubuntu 25.10) they die the moment the library is loaded. Clearing the bit is enough - the
+/// libraries do not actually run code off the stack.
+/// </para>
+/// </summary>
+public static class ElfHelper
+{
+    // Program header types/flags from elf.h.
+    private const uint PtGnuStack = 0x6474e551;
+    private const uint PfX = 0x1;
+
+    private const int ElfClass32 = 1;
+    private const int ElfClass64 = 2;
+    private const int ElfDataLittleEndian = 1;
+
+    // Offsets of p_flags inside a program header entry - it moves between the two ELF classes.
+    private const int PFlagsOffset32 = 24;
+    private const int PFlagsOffset64 = 4;
+
+    private const int MinPhEntSize32 = 32;
+    private const int MinPhEntSize64 = 56;
+
+    // A sane upper bound on e_phnum, so a corrupt/truncated file cannot spin the loop.
+    private const int MaxProgramHeaders = 4096;
+
+    /// <summary>
+    /// Clears the executable-stack flag on every shared library below <paramref name="folder"/>
+    /// and returns how many files were changed. Anything that is not a little-endian ELF, or has
+    /// no executable-stack request, is left untouched; unreadable files are skipped.
+    /// </summary>
+    public static int ClearExecutableStackInFolder(string folder)
+    {
+        if (string.IsNullOrEmpty(folder) || !Directory.Exists(folder))
+        {
+            return 0;
+        }
+
+        var patched = 0;
+        try
+        {
+            // "*.so*" also catches versioned names like "libctranslate2-d3638643.so.4.4.0".
+            // Anything that slips through the pattern but is not an ELF is rejected by the
+            // header check in ClearExecutableStack.
+            foreach (var fileName in Directory.EnumerateFiles(folder, "*.so*", SearchOption.AllDirectories))
+            {
+                try
+                {
+                    if (ClearExecutableStack(fileName))
+                    {
+                        patched++;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Se.LogError(ex, $"ElfHelper: could not clear the executable-stack flag on '{fileName}'");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, $"ElfHelper: could not scan '{folder}' for shared libraries");
+        }
+
+        return patched;
+    }
+
+    /// <summary>
+    /// Clears <c>PF_X</c> on the <c>PT_GNU_STACK</c> program header of an ELF file. Returns true
+    /// only when the file was actually rewritten, i.e. it is a little-endian ELF that did request
+    /// an executable stack.
+    /// </summary>
+    public static bool ClearExecutableStack(string filePath)
+    {
+        if (string.IsNullOrEmpty(filePath) || !File.Exists(filePath))
+        {
+            return false;
+        }
+
+        using var stream = new FileStream(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.Read);
+        return ClearExecutableStack(stream);
+    }
+
+    /// <summary>
+    /// Stream overload - exposed for testing with a synthetic ELF.
+    /// </summary>
+    internal static bool ClearExecutableStack(Stream stream)
+    {
+        Span<byte> header = stackalloc byte[64];
+        stream.Position = 0;
+        if (!ReadExactly(stream, header))
+        {
+            return false;
+        }
+
+        if (header[0] != 0x7F || header[1] != (byte)'E' || header[2] != (byte)'L' || header[3] != (byte)'F')
+        {
+            return false;
+        }
+
+        var elfClass = header[4];
+        // Only little-endian ELF is handled: every platform SE ships Linux binaries for is
+        // little-endian, and guessing at a big-endian layout would risk corrupting the file.
+        if (header[5] != ElfDataLittleEndian || (elfClass != ElfClass32 && elfClass != ElfClass64))
+        {
+            return false;
+        }
+
+        var is64 = elfClass == ElfClass64;
+        var phOffset = is64
+            ? (long)BinaryPrimitives.ReadUInt64LittleEndian(header.Slice(32, 8))
+            : BinaryPrimitives.ReadUInt32LittleEndian(header.Slice(28, 4));
+        var phEntSize = is64
+            ? BinaryPrimitives.ReadUInt16LittleEndian(header.Slice(54, 2))
+            : BinaryPrimitives.ReadUInt16LittleEndian(header.Slice(42, 2));
+        var phCount = is64
+            ? BinaryPrimitives.ReadUInt16LittleEndian(header.Slice(56, 2))
+            : BinaryPrimitives.ReadUInt16LittleEndian(header.Slice(44, 2));
+
+        var minEntSize = is64 ? MinPhEntSize64 : MinPhEntSize32;
+        if (phOffset <= 0 || phCount == 0 || phCount > MaxProgramHeaders || phEntSize < minEntSize)
+        {
+            return false;
+        }
+
+        var pFlagsOffset = is64 ? PFlagsOffset64 : PFlagsOffset32;
+        Span<byte> entry = stackalloc byte[8];
+        for (var i = 0; i < phCount; i++)
+        {
+            var entryOffset = phOffset + (long)i * phEntSize;
+            if (entryOffset + minEntSize > stream.Length)
+            {
+                return false;
+            }
+
+            stream.Position = entryOffset;
+            if (!ReadExactly(stream, entry.Slice(0, 4)))
+            {
+                return false;
+            }
+
+            if (BinaryPrimitives.ReadUInt32LittleEndian(entry.Slice(0, 4)) != PtGnuStack)
+            {
+                continue;
+            }
+
+            stream.Position = entryOffset + pFlagsOffset;
+            if (!ReadExactly(stream, entry.Slice(0, 4)))
+            {
+                return false;
+            }
+
+            var flags = BinaryPrimitives.ReadUInt32LittleEndian(entry.Slice(0, 4));
+            if ((flags & PfX) == 0)
+            {
+                return false;
+            }
+
+            BinaryPrimitives.WriteUInt32LittleEndian(entry.Slice(0, 4), flags & ~PfX);
+            stream.Position = entryOffset + pFlagsOffset;
+            stream.Write(entry.Slice(0, 4));
+            stream.Flush();
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool ReadExactly(Stream stream, Span<byte> buffer)
+    {
+        var read = 0;
+        while (read < buffer.Length)
+        {
+            var count = stream.Read(buffer.Slice(read));
+            if (count <= 0)
+            {
+                return false;
+            }
+
+            read += count;
+        }
+
+        return true;
+    }
+}

--- a/src/ui/Logic/Media/FfmpegGenerator.cs
+++ b/src/ui/Logic/Media/FfmpegGenerator.cs
@@ -516,13 +516,7 @@ public class FfmpegGenerator
 
     private static string GetFfmpegLocation()
     {
-        var ffmpegLocation = Configuration.Settings.General.FFmpegLocation;
-        if (!Configuration.IsRunningOnWindows && (string.IsNullOrEmpty(ffmpegLocation) || !File.Exists(ffmpegLocation)))
-        {
-            ffmpegLocation = "ffmpeg";
-        }
-
-        return ffmpegLocation;
+        return FfmpegHelper.GetFfmpegLocation();
     }
 
     /// <summary>

--- a/src/ui/Logic/Media/FfmpegHelper.cs
+++ b/src/ui/Logic/Media/FfmpegHelper.cs
@@ -1,6 +1,7 @@
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text.RegularExpressions;
@@ -17,6 +18,17 @@ public static class FfmpegHelper
     // "ffmpeg version 6.1.1", "ffmpeg version n7.0", "ffmpeg version 4.4.2-0ubuntu0.22.04.1".
     private static readonly Regex FfmpegVersionRegex =
         new(@"ffmpeg version n?(\d+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    // A line of "ffmpeg -encoders": six flag columns ("V....D", "A..X.."), then the encoder name,
+    // then a description. The legend lines above the list ("V..... = Video") have "=" where the
+    // name would be and so do not match.
+    private static readonly Regex FfmpegEncoderRegex =
+        new(@"^\s*[VAS][A-Z.]{5}\s+([A-Za-z0-9_.\-]+)(\s|$)", RegexOptions.Compiled);
+
+    private static readonly IReadOnlySet<string> EmptyEncoders = new HashSet<string>(StringComparer.Ordinal);
+    private static readonly object AvailableEncodersLock = new();
+    private static string? _availableEncodersFor;
+    private static HashSet<string>? _availableEncoders;
 
     public static bool IsFfmpegInstalled()
     {
@@ -42,6 +54,134 @@ public static class FfmpegHelper
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// The ffmpeg that will actually be run: the configured path, falling back to plain "ffmpeg"
+    /// (resolved through PATH) on macOS/Linux, where a system ffmpeg is the normal case.
+    /// </summary>
+    public static string GetFfmpegLocation()
+    {
+        var ffmpegLocation = Configuration.Settings.General.FFmpegLocation;
+        if (!Configuration.IsRunningOnWindows && (string.IsNullOrEmpty(ffmpegLocation) || !File.Exists(ffmpegLocation)))
+        {
+            ffmpegLocation = "ffmpeg";
+        }
+
+        return ffmpegLocation;
+    }
+
+    /// <summary>
+    /// The encoder names the running ffmpeg was built with, as reported by "ffmpeg -encoders", or
+    /// an empty set when the probe fails. Callers must treat "empty" as "unknown", not as "nothing
+    /// is available" - see <see cref="GetAvailableEncoders"/> callers.
+    /// <para>
+    /// Which encoders exist varies a lot per build: the Flatpak bundles its own ffmpeg without
+    /// x265/NVENC/AMF/QSV, and distro packages differ again. Offering a codec that is not there
+    /// only produces an "Unknown encoder" failure once the job is already running.
+    /// </para>
+    /// The result is cached per ffmpeg path, since it cannot change under a running ffmpeg and
+    /// every probe costs a process launch.
+    /// </summary>
+    public static IReadOnlySet<string> GetAvailableEncoders()
+    {
+        var ffmpegPath = GetFfmpegLocation();
+        if (string.IsNullOrEmpty(ffmpegPath))
+        {
+            // No ffmpeg configured yet (SE offers to download it) - probing would only log a
+            // failure every time a burn-in window opens.
+            return EmptyEncoders;
+        }
+
+        lock (AvailableEncodersLock)
+        {
+            if (_availableEncoders != null && _availableEncodersFor == ffmpegPath)
+            {
+                return _availableEncoders;
+            }
+        }
+
+        var encoders = ParseEncoderNames(ProbeEncodersOutput(ffmpegPath));
+        lock (AvailableEncodersLock)
+        {
+            // Only cache a successful probe - a transient failure should not hide encoders for
+            // the rest of the session.
+            if (encoders.Count > 0)
+            {
+                _availableEncoders = encoders;
+                _availableEncodersFor = ffmpegPath;
+            }
+        }
+
+        return encoders;
+    }
+
+    private static string ProbeEncodersOutput(string ffmpegPath)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = ffmpegPath,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            };
+            psi.ArgumentList.Add("-hide_banner");
+            psi.ArgumentList.Add("-encoders");
+
+            using var process = Process.Start(psi);
+            if (process == null)
+            {
+                return string.Empty;
+            }
+
+            // The encoder list is tens of kilobytes, far past the 4 KB Windows pipe buffer, so
+            // both streams must be drained while ffmpeg is still writing - waiting first and
+            // reading after would deadlock.
+            var stdOut = process.StandardOutput.ReadToEndAsync();
+            var stdErr = process.StandardError.ReadToEndAsync();
+
+            if (!process.WaitForExit(5000))
+            {
+                try { process.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+                return string.Empty;
+            }
+
+            // Lets the async readers finish after the timed wait returned (documented pattern).
+            process.WaitForExit();
+
+            return stdOut.Result + "\n" + stdErr.Result;
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, $"FfmpegHelper: failed to probe ffmpeg encoders at '{ffmpegPath}'");
+            return string.Empty;
+        }
+    }
+
+    /// <summary>
+    /// Parses the encoder names out of an "ffmpeg -encoders" listing. Pure - exposed for testing.
+    /// </summary>
+    internal static HashSet<string> ParseEncoderNames(string encodersOutput)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        if (string.IsNullOrEmpty(encodersOutput))
+        {
+            return names;
+        }
+
+        foreach (var line in encodersOutput.Split('\n'))
+        {
+            var match = FfmpegEncoderRegex.Match(line);
+            if (match.Success)
+            {
+                names.Add(match.Groups[1].Value);
+            }
+        }
+
+        return names;
     }
 
     /// <summary>

--- a/tests/UI/Logic/ElfExecutableStackTests.cs
+++ b/tests/UI/Logic/ElfExecutableStackTests.cs
@@ -1,0 +1,171 @@
+using System.Buffers.Binary;
+using Nikse.SubtitleEdit.Logic;
+
+namespace Tests.Logic;
+
+/// <summary>
+/// Covers the PT_GNU_STACK patcher that keeps Purfview's Faster-Whisper-XXL loadable on
+/// glibc 2.41+, where dlopen no longer grants a shared object an executable stack.
+/// </summary>
+public class ElfExecutableStackTests
+{
+    private const uint PtLoad = 1;
+    private const uint PtGnuStack = 0x6474e551;
+
+    [Fact]
+    public void ClearsTheExecuteBitOnAnElf64Library()
+    {
+        var elf = BuildElf64(gnuStackFlags: 7); // RWE - what libctranslate2 ships with
+
+        Assert.True(ElfHelper.ClearExecutableStack(elf));
+        Assert.Equal(6u, ReadElf64GnuStackFlags(elf)); // RW
+    }
+
+    [Fact]
+    public void LeavesTheOtherProgramHeadersAlone()
+    {
+        var elf = BuildElf64(gnuStackFlags: 7);
+
+        ElfHelper.ClearExecutableStack(elf);
+
+        // The PT_LOAD segment before it still has its execute bit - only the stack was touched.
+        elf.Position = 64 + 4;
+        var loadFlags = new byte[4];
+        elf.ReadExactly(loadFlags);
+        Assert.Equal(5u, BinaryPrimitives.ReadUInt32LittleEndian(loadFlags));
+    }
+
+    [Fact]
+    public void IsIdempotent()
+    {
+        var elf = BuildElf64(gnuStackFlags: 7);
+
+        Assert.True(ElfHelper.ClearExecutableStack(elf));
+        Assert.False(ElfHelper.ClearExecutableStack(elf));
+        Assert.Equal(6u, ReadElf64GnuStackFlags(elf));
+    }
+
+    [Fact]
+    public void LeavesALibraryThatNeverAskedForAnExecutableStack()
+    {
+        var elf = BuildElf64(gnuStackFlags: 6); // RW - the normal case
+
+        Assert.False(ElfHelper.ClearExecutableStack(elf));
+        Assert.Equal(6u, ReadElf64GnuStackFlags(elf));
+    }
+
+    [Fact]
+    public void ClearsTheExecuteBitOnAnElf32Library()
+    {
+        var elf = BuildElf32(gnuStackFlags: 7);
+
+        Assert.True(ElfHelper.ClearExecutableStack(elf));
+
+        elf.Position = 52 + 24;
+        var flags = new byte[4];
+        elf.ReadExactly(flags);
+        Assert.Equal(6u, BinaryPrimitives.ReadUInt32LittleEndian(flags));
+    }
+
+    [Fact]
+    public void IgnoresABigEndianElf()
+    {
+        var elf = BuildElf64(gnuStackFlags: 7);
+        elf.Position = 5;
+        elf.WriteByte(2); // ELFDATA2MSB - the offsets below would be wrong, so do not touch it
+
+        Assert.False(ElfHelper.ClearExecutableStack(elf));
+    }
+
+    [Fact]
+    public void IgnoresFilesThatAreNotElf()
+    {
+        // "*.so*" also matches things like "notes.sound", and a downloaded folder can hold
+        // anything, so a non-ELF must be rejected rather than patched at a guessed offset.
+        var notElf = new MemoryStream(new byte[512]);
+        Assert.False(ElfHelper.ClearExecutableStack(notElf));
+
+        var text = new MemoryStream("MZ this is a windows binary"u8.ToArray());
+        Assert.False(ElfHelper.ClearExecutableStack(text));
+    }
+
+    [Fact]
+    public void IgnoresATruncatedElf()
+    {
+        var full = BuildElf64(gnuStackFlags: 7).ToArray();
+
+        // Header intact, program headers cut off mid-way.
+        var truncated = new MemoryStream(full[..(full.Length - 40)]);
+        Assert.False(ElfHelper.ClearExecutableStack(truncated));
+
+        var headerOnly = new MemoryStream(full[..20]);
+        Assert.False(ElfHelper.ClearExecutableStack(headerOnly));
+    }
+
+    /// <summary>
+    /// A 64-bit little-endian ELF with two program headers: a PT_LOAD (R+X) and a PT_GNU_STACK
+    /// with the given flags. Only the fields the patcher reads are filled in.
+    /// </summary>
+    private static MemoryStream BuildElf64(uint gnuStackFlags)
+    {
+        const int phOffset = 64;
+        const int phEntSize = 56;
+        var bytes = new byte[phOffset + 2 * phEntSize];
+
+        bytes[0] = 0x7F;
+        bytes[1] = (byte)'E';
+        bytes[2] = (byte)'L';
+        bytes[3] = (byte)'F';
+        bytes[4] = 2; // ELFCLASS64
+        bytes[5] = 1; // ELFDATA2LSB
+        bytes[6] = 1; // EV_CURRENT
+
+        BinaryPrimitives.WriteUInt64LittleEndian(bytes.AsSpan(32, 8), phOffset);
+        BinaryPrimitives.WriteUInt16LittleEndian(bytes.AsSpan(54, 2), phEntSize);
+        BinaryPrimitives.WriteUInt16LittleEndian(bytes.AsSpan(56, 2), 2);
+
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(phOffset, 4), PtLoad);
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(phOffset + 4, 4), 5); // R+X
+
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(phOffset + phEntSize, 4), PtGnuStack);
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(phOffset + phEntSize + 4, 4), gnuStackFlags);
+
+        return new MemoryStream(bytes, 0, bytes.Length, writable: true, publiclyVisible: true);
+    }
+
+    /// <summary>
+    /// The 32-bit layout, where p_flags sits at the end of the entry instead of right after
+    /// p_type.
+    /// </summary>
+    private static MemoryStream BuildElf32(uint gnuStackFlags)
+    {
+        const int phOffset = 52;
+        const int phEntSize = 32;
+        var bytes = new byte[phOffset + phEntSize];
+
+        bytes[0] = 0x7F;
+        bytes[1] = (byte)'E';
+        bytes[2] = (byte)'L';
+        bytes[3] = (byte)'F';
+        bytes[4] = 1; // ELFCLASS32
+        bytes[5] = 1; // ELFDATA2LSB
+        bytes[6] = 1;
+
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(28, 4), phOffset);
+        BinaryPrimitives.WriteUInt16LittleEndian(bytes.AsSpan(42, 2), phEntSize);
+        BinaryPrimitives.WriteUInt16LittleEndian(bytes.AsSpan(44, 2), 1);
+
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(phOffset, 4), PtGnuStack);
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(phOffset + 24, 4), gnuStackFlags);
+
+        return new MemoryStream(bytes, 0, bytes.Length, writable: true, publiclyVisible: true);
+    }
+
+    private static uint ReadElf64GnuStackFlags(MemoryStream elf)
+    {
+        elf.Position = 64 + 56 + 4;
+        var flags = new byte[4];
+        elf.ReadExactly(flags);
+        return BinaryPrimitives.ReadUInt32LittleEndian(flags);
+    }
+}

--- a/tests/UI/Logic/Media/FfmpegEncoderListTests.cs
+++ b/tests/UI/Logic/Media/FfmpegEncoderListTests.cs
@@ -1,0 +1,105 @@
+using Nikse.SubtitleEdit.Features.Video.BurnIn;
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace UITests.Logic.Media;
+
+public class FfmpegEncoderListTests
+{
+    // Trimmed "ffmpeg -encoders" output: the legend block, the separator, then real entries.
+    // This is the shape of what the Flatpak's own ffmpeg prints - no x265, no NVENC/AMF/QSV.
+    private const string FlatpakEncodersOutput = """
+        Encoders:
+         V..... = Video
+         A..... = Audio
+         S..... = Subtitle
+         .F.... = Frame-level multithreading
+         ..S... = Slice-level multithreading
+         ...X.. = Codec is experimental
+         ....B. = Supports draw_horiz_band
+         .....D = Supports direct rendering method 1
+         ------
+         V....D libx264              libx264 H.264 / AVC / MPEG-4 AVC (codec h264)
+         V....D libvpx-vp9           libvpx VP9 (codec vp9)
+         V..... prores_ks            Apple ProRes (iCodec Pro) (codec prores)
+         V..... h264_vaapi           H.264/AVC (VAAPI) (codec h264)
+         V..... hevc_vaapi           H.265/HEVC (VAAPI) (codec hevc)
+         V..... png                  PNG (Portable Network Graphics) image
+         A....D aac                  AAC (Advanced Audio Coding)
+         S..... srt                  SubRip subtitle (codec subrip)
+        """;
+
+    [Fact]
+    public void ParsesEncoderNames()
+    {
+        var names = FfmpegHelper.ParseEncoderNames(FlatpakEncodersOutput);
+
+        Assert.Contains("libx264", names);
+        Assert.Contains("libvpx-vp9", names);
+        Assert.Contains("prores_ks", names);
+        Assert.Contains("hevc_vaapi", names);
+        Assert.Contains("aac", names);
+        Assert.Contains("srt", names);
+        Assert.DoesNotContain("libx265", names);
+    }
+
+    [Fact]
+    public void SkipsTheLegendLines()
+    {
+        var names = FfmpegHelper.ParseEncoderNames(FlatpakEncodersOutput);
+
+        // " V..... = Video" and friends match the flag columns but have "=" where a name goes.
+        Assert.DoesNotContain("=", names);
+        Assert.DoesNotContain("Video", names);
+        Assert.DoesNotContain("Encoders:", names);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("ffmpeg: command not found")]
+    public void ReturnsNothingForUnusableOutput(string? output)
+    {
+        Assert.Empty(FfmpegHelper.ParseEncoderNames(output!));
+    }
+
+    [Fact]
+    public void HidesTheCodecsTheBundledFfmpegLacks()
+    {
+        var offered = new List<VideoEncodingItem>
+        {
+            new("libx264", "H.264/AVC (CPU)"),
+            new("libx265", "H.265/HEVC (CPU)"),
+            new("libvpx-vp9", "VP9 (CPU)"),
+            new("prores_ks", "ProRes (CPU)"),
+            new("h264_nvenc", "H.264/AVC (NVIDIA GPU)"),
+            new("hevc_qsv", "H.265/HEVC (Intel QSV)"),
+        };
+
+        var unsupported = VideoEncodingItem.GetUnsupported(offered, FfmpegHelper.ParseEncoderNames(FlatpakEncodersOutput));
+
+        Assert.Equal(new[] { "libx265", "h264_nvenc", "hevc_qsv" }, unsupported.Select(p => p.Codec));
+    }
+
+    [Fact]
+    public void HidesNothingWhenTheProbeFailed()
+    {
+        var offered = new List<VideoEncodingItem> { new("libx264", "H.264/AVC (CPU)") };
+
+        // An empty set means "we could not ask ffmpeg", not "ffmpeg has no encoders".
+        Assert.Empty(VideoEncodingItem.GetUnsupported(offered, new HashSet<string>()));
+    }
+
+    [Fact]
+    public void HidesNothingWhenEveryCodecWouldGo()
+    {
+        var offered = new List<VideoEncodingItem>
+        {
+            new("libx264", "H.264/AVC (CPU)"),
+            new("libx265", "H.265/HEVC (CPU)"),
+        };
+
+        // Rather than leave the user an empty combo box, keep the old behaviour - something is
+        // wrong with the probe, not with every single codec.
+        Assert.Empty(VideoEncodingItem.GetUnsupported(offered, new HashSet<string> { "aac" }));
+    }
+}


### PR DESCRIPTION
Two Linux packaging problems surfaced in #13889 while someone was packaging 5.1.0 as a Flatpak. Both are verified against the tree, not taken at face value from the report.

## 1. Burn-in offered encoders the bundled ffmpeg does not have

`VideoEncodingItem.BuildVideoEncodings()` picks codecs from the *platform*, and nothing in SE ever asked ffmpeg what it was actually compiled with — `VideoEncodings` is a `static readonly` list built once at type init.

Against our own Flatpak manifest, six of the ten Linux entries have no encoder behind them:

| Offered | In `installer/flatpak/dk.nikse.subtitleedit.yaml`? |
|---|---|
| `libx264` | yes (x264 module) |
| `libvpx-vp9` | yes (`--enable-libvpx`) |
| `prores_ks` | yes (native) |
| `libx265` | **no** — no x265 module |
| `h264_nvenc` / `hevc_nvenc` | **no** — no nv-codec-headers |
| `h264_amf` / `hevc_amf` | **no** — no AMF headers |
| `h264_qsv` / `hevc_qsv` | **no** — no libvpl |

Picking any of those started a job that failed at encode time with an unknown-encoder error. H.265/HEVC (CPU) sits second in the list and reads like a plain software option, so it is the one users hit first.

This is not Flatpak-only — a distro or user-supplied ffmpeg can be equally thin (several ship without x265), which is why the fix is a runtime probe rather than just more manifest modules.

The burn-in window now probes `ffmpeg -encoders` on a background thread when it opens and removes what is not there. Details:

- Cached per ffmpeg path, so a second burn-in window costs nothing and changing the path in settings re-probes.
- **Fails open in both directions**: an empty probe result means "we could not ask", not "nothing is supported"; a result that would hide *every* entry is discarded too. Either way the user keeps the full list and the old behaviour.
- The selection is re-pointed *before* the removal — dropping the selected item from a ComboBox's `ItemsSource` makes it null `SelectedItem`, and the TwoWay binding writes that null straight back into the view model.
- Both pipes are drained while ffmpeg is still writing: the encoder list is tens of KB, well past the 4 KB Windows pipe buffer, so read-after-wait would deadlock there while passing on macOS.
- `FfmpegGenerator.GetFfmpegLocation()` now delegates to the new `FfmpegHelper.GetFfmpegLocation()` instead of duplicating it. Same behaviour.

## 2. Faster-Whisper-XXL cannot load on glibc 2.41+

Purfview's bundled `libctranslate2-*.so` is built with `PT_GNU_STACK = RWE`. glibc 2.41 stopped making the stack executable at `dlopen` time, so the run dies instantly:

```
ImportError: libctranslate2-d3638643.so.4.4.0: cannot enable executable stack
as shared object requires: Invalid argument
```

The report framed this as a future Flatpak problem (freedesktop 24.08 is still below 2.41), but it already hits ordinary Linux users today on **Fedora 42, Arch and Ubuntu 25.10**, outside Flatpak entirely.

`ElfHelper` clears the flag on the unpacked shared libraries:

- On download, right after the archive is unpacked and the executable is chmod'ed.
- Once per session before launching the engine, so installs made by an earlier SE are repaired too — re-downloading is over a gigabyte.

The patcher rewrites exactly one flag byte of a little-endian ELF and rejects anything it does not fully recognise (wrong magic, big-endian, odd `e_phentsize`, truncated). Worth reporting upstream to Purfview as well; the flag looks spurious rather than load-bearing.

## Verification

- Full solution builds clean, 0 warnings.
- Full UI suite green: **3263 passed**.
- 16 new tests: encoder-list parsing (including that the `V..... = Video` legend lines are not mistaken for encoders), the fail-open rules, and the ELF patcher on synthetic 32- and 64-bit files.
- The ELF patcher was additionally run against **real** Linux `.so` files (`linux-arm64` and `linux-arm` `libSkiaSharp.so`) with the execute bit forced on: it cleared the flag and the result came back **byte-identical** to the untouched original. That check was temporary and is not part of the commit.

Not verified by running: the actual `libctranslate2` from Purfview's archive (a ~1 GB download) and behaviour on a glibc 2.41+ host — no Linux box here.

## Suggested follow-up (not in this PR)

The filter makes the Flatpak honest, but H.265 simply disappears there. Adding an `x265` module and `nv-codec-headers` to `installer/flatpak/*.yaml` would bring `libx265` and NVENC back for real. The manifest already builds libmpv with `-Dvaapi=enabled` — a hard meson feature, so libva is definitely in the SDK — which means `h264_vaapi`/`hevc_vaapi` are free and are the path AMD and Intel GPUs actually take on Linux, unlike AMF and QSV which need vendor runtimes the sandbox does not have.

Refs #13889

🤖 Generated with [Claude Code](https://claude.com/claude-code)