### PR TITLE
Import the other two SE 4 recalculate-duration shortcuts

### DIFF
--- a/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
+++ b/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
@@ -340,6 +340,12 @@ public static class Se4ShortcutsImporter
         ["GeneralTogglePreviewOnVideo"] = nameof(MainViewModel.ToggleSubtitlesOnVideoPlayerCommand),
         ["GeneralSwitchOriginalAndTranslation"] = nameof(MainViewModel.SwitchOriginalAndTranslationTextSelectedLinesCommand),
         ["GeneralAutoCalcCurrentDuration"] = nameof(MainViewModel.RecalculateDurationSelectedLinesCommand),
+        // SE 4 offered the same recalculation at three reading speeds. SE 5's "recalculate
+        // duration" is the optimal-reading-speed one (text length / optimal CPS), and "set
+        // duration to max CPS" is the shortest duration the CPS limit allows - which is what
+        // SE 4 calls the minimum reading speed (#13912).
+        ["GeneralAutoCalcCurrentDurationByOptimalReadingSpeed"] = nameof(MainViewModel.RecalculateDurationSelectedLinesCommand),
+        ["GeneralAutoCalcCurrentDurationByMinReadingSpeed"] = nameof(MainViewModel.SetDurationMaxCpsSelectedLinesCommand),
         ["GeneralGoToNextBookmark"] = nameof(MainViewModel.GoToNextBookmarkCommand),
         ["GeneralGoToPreviousBookmark"] = nameof(MainViewModel.GoToPreviousBookmarkCommand),
         ["GeneralGoToNextEmptyLine"] = nameof(MainViewModel.GoToNextEmptyLineCommand),

--- a/tests/UI/Features/Options/Shortcuts/Se4ShortcutsImporterMapTests.cs
+++ b/tests/UI/Features/Options/Shortcuts/Se4ShortcutsImporterMapTests.cs
@@ -58,6 +58,8 @@ public class Se4ShortcutsImporterMapTests
     [InlineData("GeneralTogglePreviewOnVideo", "ToggleSubtitlesOnVideoPlayerCommand")]
     [InlineData("GeneralSwitchOriginalAndTranslation", "SwitchOriginalAndTranslationTextSelectedLinesCommand")]
     [InlineData("GeneralAutoCalcCurrentDuration", "RecalculateDurationSelectedLinesCommand")]
+    [InlineData("GeneralAutoCalcCurrentDurationByOptimalReadingSpeed", "RecalculateDurationSelectedLinesCommand")]
+    [InlineData("GeneralAutoCalcCurrentDurationByMinReadingSpeed", "SetDurationMaxCpsSelectedLinesCommand")]
     [InlineData("MainVideo1FrameLeftWithPlay", "VideoOneFrameBackWithPlayCommand")]
     [InlineData("MainVideo1FrameRightWithPlay", "VideoOneFrameForwardWithPlayCommand")]
     [InlineData("MainVideoToggleContrast", "VideoToggleContrastCommand")]


### PR DESCRIPTION
Fixes #13912

### What was missing

SE 4 has three "Re-calculate duration of current subtitle" entries under Create/adjust — plain, by optimal reading speed, and by minimum reading speed. The reporter had keys bound to the latter two.

Only `GeneralAutoCalcCurrentDuration` was in the SE 4 importer map, so the other two were counted as "skipped, no mapping" and the bindings were dropped on import — even though SE 5 already has commands that do the same job:

| SE 4 shortcut | what it does | SE 5 command |
|---|---|---|
| `...ByOptimalReadingSpeed` | text length / optimal CPS | `RecalculateDurationSelectedLines` |
| `...ByMinReadingSpeed` | shortest duration the CPS limit allows | `SetDurationMaxCpsSelectedLines` |

SE 4 gets its "minimum reading speed" by passing the *maximum* CPS as the target, which is exactly what `SetDurationMaxCpsSelectedLines` computes — same result, different name.

### Scope

This is the importer half only. Both target commands were already registered in `ShortcutsMain`, so they have always been assignable by hand in SE 5's own shortcut list; what did not work was carrying an existing SE 4 binding across.

One thing I deliberately did **not** do: SE 4's *plain* variant applies readability nudges (stretch short lines by 1.2x, shrink long ones by 0.96) that no SE 5 command implements — SE 5's `RecalculateDurationSelectedLines` is the strict `length / optimal CPS` math. Adding a third command for the nudged behaviour is a product call rather than a mapping fix, so I have left it alone. If you want it, say so and I will add it.

### Testing

Two rows added to the existing `ImportsSe4ShortcutBySerializedName` theory, which imports an SE 4-shaped `<Shortcuts>` document and asserts the shortcut lands on the right command with nothing skipped. Both fail on main (`SkippedNoMapping` = 1, action name empty) and pass here.

The map-wide `EveryMappedSe4ShortcutTargetsARegisteredCommand` guard still passes, so neither new entry is a dead binding.

Full UI suite: 3268 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)