### PR TITLE
Document the shortcut settings gear icon

### DIFF
--- a/docs/features/shortcuts.md
+++ b/docs/features/shortcuts.md
@@ -47,11 +47,11 @@ Independent of the thematic category, each command has a scope shown in the **Ac
 Some commands have additional configuration beyond the shortcut key:
 
 - **Set color 1–8** — Choose a color for each color shortcut
-- **Surround with 1–3** — Define the left/right text to surround selected text with
-- **Video move custom 1–2 back/forward** — Set the number of milliseconds to skip
+- **Surround with 1–3** — Define the left/right text to surround selected text with (this replaces the *Shortcut toggle custom start/end* setting from Subtitle Edit 4)
+- **Video move custom 1–4 back/forward** — Set the number of milliseconds to skip
 - **Set actor 1–10** — Define the actor name assigned by each actor shortcut
 
-Select a configurable command and click **Configure** to adjust its settings.
+Select a configurable command and click the **gear icon** to adjust its settings. The gear sits in the shortcut assignment row below the list, between the key detection button and **Reset** — it is only shown while a configurable command is selected, so if you cannot see it, the selected command has no extra settings.
 
 ## Resetting Shortcuts
 


### PR DESCRIPTION
The **Configurable Commands** section of the shortcuts docs told readers to "click **Configure**", but no such button exists — it is an icon-only gear (`IconNames.Settings`) in the assignment row, and it is hidden unless the selected command is configurable.

That is exactly the confusion in #13907: SE4's *Shortcut toggle custom start/end* is SE5's **Surround with 1–3**, and the reporter could not find where to configure it.

Changes to `docs/features/shortcuts.md`:

- Name the control the **gear icon**, say where it sits (assignment row below the list, between the key-detect button and **Reset**), and note it only appears for configurable commands.
- Mention that **Surround with 1–3** replaces SE4's *Shortcut toggle custom start/end*, so the old name is searchable.
- **Video move custom 1–2** → **1–4**, matching `ShortcutsViewModel.cs`.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)