### PR TITLE
Import SE 4's "toggle custom tags" shortcut

### DIFF
--- a/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
+++ b/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
@@ -340,6 +340,12 @@ public static class Se4ShortcutsImporter
         ["GeneralTogglePreviewOnVideo"] = nameof(MainViewModel.ToggleSubtitlesOnVideoPlayerCommand),
         ["GeneralSwitchOriginalAndTranslation"] = nameof(MainViewModel.SwitchOriginalAndTranslationTextSelectedLinesCommand),
         ["GeneralAutoCalcCurrentDuration"] = nameof(MainViewModel.RecalculateDurationSelectedLinesCommand),
+        // SE 4's single "toggle custom tags" pair became three configurable surround-with slots,
+        // whose characters are edited from the shortcut itself. The key lands on the first slot;
+        // its characters are SE 5's own default, not the pair SE 4 kept in General settings, and
+        // the shortcut list spells them out ("Surround with X and Y") so the difference is
+        // visible rather than silent (#13907).
+        ["MainListViewToggleCustomTags"] = nameof(MainViewModel.SurroundWith1Command),
         // SE 4 offered the same recalculation at three reading speeds. SE 5's "recalculate
         // duration" is the optimal-reading-speed one (text length / optimal CPS), and "set
         // duration to max CPS" is the shortest duration the CPS limit allows - which is what

--- a/tests/UI/Features/Options/Shortcuts/Se4ShortcutsImporterMapTests.cs
+++ b/tests/UI/Features/Options/Shortcuts/Se4ShortcutsImporterMapTests.cs
@@ -58,6 +58,7 @@ public class Se4ShortcutsImporterMapTests
     [InlineData("GeneralTogglePreviewOnVideo", "ToggleSubtitlesOnVideoPlayerCommand")]
     [InlineData("GeneralSwitchOriginalAndTranslation", "SwitchOriginalAndTranslationTextSelectedLinesCommand")]
     [InlineData("GeneralAutoCalcCurrentDuration", "RecalculateDurationSelectedLinesCommand")]
+    [InlineData("MainListViewToggleCustomTags", "SurroundWith1Command")]
     [InlineData("GeneralAutoCalcCurrentDurationByOptimalReadingSpeed", "RecalculateDurationSelectedLinesCommand")]
     [InlineData("GeneralAutoCalcCurrentDurationByMinReadingSpeed", "SetDurationMaxCpsSelectedLinesCommand")]
     [InlineData("MainVideo1FrameLeftWithPlay", "VideoOneFrameBackWithPlayCommand")]


### PR DESCRIPTION
Fixes #13907

### The feature is not missing — it moved

SE 4 has one custom start/end pair, set in **Options → Settings** and applied by the "toggle custom tags" shortcut. That is what the reporter went looking for and did not find.

SE 5 has the same thing three times over: `SurroundWith1/2/3`, each with its own left/right strings (`♪ ♪`, `♫ ♫`, `[ ]` by default), toggling on the selected lines or the text box selection exactly as SE 4 does. The difference is where they are configured — **Options → Shortcuts**, by clicking the "Surround with X and Y" entry, rather than in Settings.

So no new feature here. Worth saying so on the issue.

### What *is* missing

The import. `MainListViewToggleCustomTags` had no entry in the SE 4 shortcut map, so a user bringing their SE 4 settings across had the binding dropped as "skipped, no mapping". This maps it onto the first surround-with slot.

**One caveat, deliberate:** the *characters* do not travel with the key. The importer only reads `<Shortcuts>`, while SE 4 keeps the pair in `General/TagsInToggleCustomTags`, and there is no obvious right answer to "which of the three slots should be overwritten with them" — silently replacing the user's `♪` default seemed worse than not. So the key arrives pointing at slot 1 with SE 5's own characters. The shortcut list spells them out ("Surround with ♪ and ♪"), so it is visible rather than silent, and editable in place.

If you would rather this be skipped than land on different characters, dropping the one map entry is the whole change.

### Testing

One row added to the existing `ImportsSe4ShortcutBySerializedName` theory, which imports an SE 4-shaped `<Shortcuts>` document and asserts the shortcut lands on the right command with nothing skipped. Fails on main, passes here. The map-wide "every mapped command is registered" guard still passes.

Full UI suite: 3285 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)