### PR TITLE
Docs: refresh the engine, format and shortcut lists

### DIFF
--- a/docs/features/assa-apply-advanced-effects.md
+++ b/docs/features/assa-apply-advanced-effects.md
@@ -45,6 +45,8 @@ Effects range from text animations (typewriter, karaoke, bounce-in) to visual en
 | **Slide in from left** | Text slides in from off-screen left, holds, then exits back to the left |
 | **Slide in from right** | Text slides in from off-screen right, holds, then exits back to the right |
 | **Word spacing** | Increases spacing between words using the `\fsp` tag for better readability |
+| **Word flip 3D** | Each word folds in with a 3D flip and elastic pop as it is spoken — modern "Shorts" caption style |
+| **Cinematic title** | Letters track from wide to normal spacing while resolving from a soft blur — classic film title reveal |
 
 ### Visual Enhancement Effects
 
@@ -56,6 +58,7 @@ Effects range from text animations (typewriter, karaoke, bounce-in) to visual en
 | **Wave (blue)** | Blue/cyan wave variant |
 | **Glitch** | Digital glitch overlays with flashes, distortion, and chromatic offset |
 | **Audio text pulse** | Audio-reactive glow/scale pulse driven by waveform amplitude |
+| **Lower third** | Name and role banner bottom-left with an accent bar sliding in — interview/documentary style (first line = name, following lines = role). The accent color is picked in the effect settings |
 
 ### Transition Effects
 

--- a/docs/features/auto-translate.md
+++ b/docs/features/auto-translate.md
@@ -28,7 +28,9 @@ Automatically translate subtitles using various translation engines and AI servi
 - **ChatGPT** — OpenAI AI translation (requires API key)
 - **LM Studio (local LLM)** — Local LLM translation
 - **Ollama (local LLM)** — Local LLM-based translation
+- **Ollama advanced (local LLM)** — Ollama translated in batches with surrounding context, a synopsis and a glossary; see [Advanced local engines](auto-translate-advanced.md)
 - **llama.cpp (local LLM)** — Server-managed local LLM translation; Subtitle Edit downloads llama.cpp and a curated model (TranslateGemma, Qwen or Aya Expanse) and runs a local `llama-server` for you. See [Using your own model](#llamacpp-using-your-own-model) to run a model we don't ship, such as TranslateGemma 27B
+- **llama.cpp advanced (local LLM)** — The managed llama.cpp server translated in batches with surrounding context, a synopsis and a glossary; see [Advanced local engines](auto-translate-advanced.md)
 - **OpenAI Compatible API** — Generic engine for any service exposing an OpenAI-compatible `chat/completions` endpoint (vLLM, KoboldCpp, a llama.cpp server on another machine, cloud providers, ...); configure URL, model, prompt, and an optional API key
 - **Anthropic Claude** — AI translation (requires API key)
 - **Groq** — AI translation (requires API key)

--- a/docs/features/batch-convert.md
+++ b/docs/features/batch-convert.md
@@ -32,9 +32,19 @@ You can chain multiple conversion functions:
 - Convert colors to dialog — turn a color change inside a cue into a dash-prefixed dialog, optionally removing the color tags, adding new lines and re-breaking the lines
 - Bridge gaps
 - Apply minimum gap
+- Apply duration limits
 - Merge lines with same text
 - Merge lines with same time codes
+- Merge short lines
 - Split/break long lines
+- Unbreak lines — join a cue's lines into one, optionally only for short ones
+- Auto-balance lines
+- Fix right-to-left
+- Sort by
+- Change resolution — the [ASSA resolution resampler](assa-resolution-resampler.md) applied to every file
+- Change style — swap one ASSA style for another, or import styles from a file, optionally trimming unused ones
+- Embed fonts — embed the fonts an ASSA file uses as attachments, optionally [trimmed](assa-attachments.md) to the characters actually used
+- Adjust image brightness/alpha/color — for image-based subtitles
 - Auto translate
 - Delete lines
 
@@ -46,6 +56,7 @@ Batch Convert can machine-translate files as part of the conversion. Supported e
 - LibreTranslate
 - LM Studio
 - llama.cpp — fully managed: Batch Convert reuses an already-running local `llama-server`, or downloads llama.cpp plus a curated translation model (e.g. TranslateGemma) and starts the server for you. Point it at your own server via the remote-server option in [Auto-translate](auto-translate.md) settings.
+- llama.cpp advanced (local LLM) — the batch/context engine described in [Advanced local engines](auto-translate-advanced.md); it gets the context size configured there
 - NLLB (nllb-serve and nllb-api)
 - DeepL (API key required)
 - CrispASR MADLAD
@@ -62,7 +73,8 @@ Supported OCR engines in Batch Convert:
 - BinaryOcr
 - Tesseract
 - Ollama
-- llama.cpp (curated OCR vision models — GLM-OCR, LightOnOCR, PaddleOCR-VL; a local `llama-server` is started automatically)
+- llama.cpp (curated OCR vision models — GLM-OCR, LightOnOCR, PaddleOCR-VL, HunyuanOCR 1.5; a local `llama-server` is started automatically)
+- CrispEmbed (local, multiple model backends — see [OCR](ocr.md#crispembed))
 - PaddleOCR (Windows and Linux only)
 
 Subtitle Edit 5 can auto-detect language and pixels-are-space settings for nOcr/BinaryOcr in many batch workflows. This reduces the amount of manual setup needed when converting many image-based subtitle files with similar fonts.

--- a/docs/features/ocr.md
+++ b/docs/features/ocr.md
@@ -51,8 +51,10 @@ Local LLM-based OCR via an Ollama server (e.g. with a vision model).
 - Default endpoint: `http://localhost:11434/api/chat`
 
 ### llama.cpp
-Local LLM-based OCR using a llama.cpp-compatible server.
+Local LLM-based OCR using a llama.cpp-compatible server. Subtitle Edit can download llama.cpp and the model for you, or talk to a server you run yourself.
 - Default endpoint: `http://127.0.0.1:8080/v1/chat/completions`
+- Curated vision models: **GLM-OCR 0.9B** (Q8_0, about 1.4 GB), **LightOnOCR 1B** (Q8_0, about 1.2 GB), **PaddleOCR-VL 1.6** (about 1.8 GB, 109 languages) and **HunyuanOCR 1.5** (Q8_0, about 1.3 GB — the fastest of the four). Custom `*.gguf` files placed in the llama.cpp models folder also appear in the list
+- The settings dialog has a download/update button for the llama.cpp engine itself; the dot next to it turns amber when a newer build than the one installed is available
 
 ### CrispEmbed
 Local OCR engine with multiple model backends (free/open source).

--- a/docs/features/speech-to-text.md
+++ b/docs/features/speech-to-text.md
@@ -21,7 +21,7 @@ Subtitle Edit can automatically transcribe audio to text using Whisper-based and
 | OpenRouter | All | Online. One API key routes to Whisper, gpt-4o-transcribe, Groq and Google Chirp |
 | Alibaba Qwen3-ASR | All | Online Qwen3-ASR via Alibaba Model Studio (DashScope) |
 | Qwen3 ASR CPP | Windows, Linux | Local Qwen3 ASR engine with downloadable GGUF models |
-| Crisp ASR | Windows, Linux, macOS | Single engine with selectable backends: Parakeet, Canary, Cohere, Fire Red, GLM, Granite, Qwen3, Mega, Omni, Kyutai |
+| Crisp ASR | Windows, Linux, macOS | Single engine with selectable backends: Parakeet, Canary, Cohere, Fire Red, Fun-ASR Nano, GigaAM, GLM, Granite, Qwen3, Mega, MOSS Diarize, Omni, Kyutai, SenseVoice, ARK, Voxtral |
 
 Engines and models are downloaded automatically on first use.
 
@@ -29,7 +29,7 @@ Engines and models are downloaded automatically on first use.
 
 - **Whisper CPP** is shown as a single entry; the CPU / cuBLAS / Vulkan backends are selected from a secondary dropdown when Whisper CPP is selected.
 - **Qwen3 ASR CPP** includes 0.6B and 1.7B model options, plus a forced-aligner model used for timing workflows.
-- **Crisp ASR** is exposed as one engine that wraps multiple backends (Parakeet, Canary, Cohere, Fire Red, GLM, Granite, Qwen3, Mega, Omni, Kyutai). Pick the backend from the Crisp ASR backend dropdown.
+- **Crisp ASR** is exposed as one engine that wraps multiple backends (Parakeet, Canary, Cohere, Fire Red, Fun-ASR Nano, GigaAM, GLM, Granite, Qwen3, Mega, MOSS Diarize, Omni, Kyutai, SenseVoice, ARK, Voxtral). Pick the backend from the Crisp ASR backend dropdown.
 - **MLX Whisper** (Apple Silicon Macs) is not bundled or auto-downloaded — it drives Apple's `mlx-whisper` Python package. Install it once with `pip3 install mlx-whisper` (or `pipx install mlx-whisper`); models download from Hugging Face on first use. Subtitle Edit detects the install by finding a Python that can `import mlx_whisper` — it probes Homebrew, python.org, pyenv and system interpreters, and (for pipx / virtual-env / conda installs, which isolate the package) reads the `mlx_whisper` command found on your PATH or at `~/.local/bin/mlx_whisper` to locate the matching interpreter. If it reports "not found" after a pipx/venv install, make sure `which mlx_whisper` resolves.
 - A **Forced aligner** option is shown for Crisp ASR backends and exposes the built-in aligner, Canary CTC, Qwen3, and the wav2vec2 zoo (12 language-specific CTC aligners that run on top of any Crisp ASR backend).
 - Several newer engines support automatic language selection.

--- a/docs/features/text-to-speech.md
+++ b/docs/features/text-to-speech.md
@@ -32,6 +32,13 @@ Generate speech audio from subtitle text using various TTS engines.
 - **OmniVoice TTS** — Local CPU TTS with voice cloning and many languages
 - **Qwen3 TTS (CrispASR)** — Local Qwen3 TTS running through the CrispASR runtime (VoiceDesign, CustomVoice, and Voice clone 1.7B models)
 - **Chatterbox TTS (CrispASR)** — Chatterbox TTS via the CrispASR runtime, with voice cloning (multilingual Base or English-only Turbo model)
+- **IndexTTS (CrispASR)** — IndexTTS-1.5 via the CrispASR runtime; the smallest voice-cloning engine here (about 870 MB)
+- **CosyVoice3 (CrispASR)** — Alibaba CosyVoice3 with 9 languages and 18 Mandarin dialects, baked-in voice presets and zero-shot cloning
+- **IndexTTS 2.5 (audio.cpp)** — IndexTTS-2.5 on the audio.cpp runtime: cloning in Chinese, English, Japanese, Spanish and Arabic, with emotion and speaking-rate control. The reference voice is sent per request, so switching voice does not restart the server
+- **VoxCPM2 (CrispASR)** — Tokenizer-free diffusion engine at 48 kHz, about 30 languages, with zero-shot cloning
+- **MOSS-TTS (CrispASR)** — MOSS-TTS v1.5 (Qwen3-8B backbone, 24 kHz) with zero-shot cloning
+- **Zonos TTS (CrispASR)** — Zonos-v0.1 at 44.1 kHz with cloning from a reference recording
+- **OmniVoice TTS (CrispASR)** — The OmniVoice model on the shared CrispASR runtime, run as a persistent server so the model loads once instead of once per line
 
 Local downloadable engines are installed into the Subtitle Edit data folder when you accept the download prompt.
 

--- a/docs/features/video-ocr.md
+++ b/docs/features/video-ocr.md
@@ -21,7 +21,9 @@ The recognized text is editable directly in the list, so OCR mistakes can be fix
 - **Paddle OCR** — local, fast and accurate; downloaded automatically (Windows/Linux). Recommended.
 - **Paddle OCR Python** — local, via a Python `paddleocr` installation (also works on macOS)
 - **Ollama vision** — local vision model via [Ollama](https://ollama.com), e.g. `glm-ocr`
-- **llama.cpp** — local vision model via a managed llama.cpp server; the engine and models are downloaded automatically. Available models: GLM-OCR 0.9B, LightOnOCR 1B, and PaddleOCR-VL 1.6 (109 languages). A green dot marks models that are already downloaded; custom `*.gguf` files in the llama.cpp models folder also appear.
+- **llama.cpp** — local vision model via a managed llama.cpp server; the engine and models are downloaded automatically. Available models: GLM-OCR 0.9B, LightOnOCR 1B, PaddleOCR-VL 1.6 (109 languages) and HunyuanOCR 1.5. A green dot marks models that are already downloaded; custom `*.gguf` files in the llama.cpp models folder also appear.
+- **CrispEmbed** — local OCR engine with several model backends, downloaded automatically; pick the backend and model from the dropdowns (see [OCR](ocr.md#crispembed) for the backend list)
+- **GLM API** — GLM vision model via the Z.ai / bigmodel.cn API (requires an API key)
 - **GLM API** — GLM vision model via the Z.ai / bigmodel.cn cloud API (requires an API key)
 
 ## How It Works

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -27,6 +27,8 @@ See also: [Shortcuts Settings](../features/shortcuts.md)
 | Ctrl+4 | Set up like Subtitle Edit 4 (classic theme, icons, waveform, replace rules and shortcuts) |
 | Alt+Up | Go to previous line |
 | Alt+Down | Go to next line |
+| Ctrl+Home | Go to first line |
+| Ctrl+End | Go to last line |
 | F1 | Show help |
 | F2 | Show source view |
 
@@ -44,6 +46,19 @@ See also: [Shortcuts Settings](../features/shortcuts.md)
 | Ctrl+Shift+F3 | Toggle casing |
 | Ctrl+Shift+E | Extend selected line to next |
 | Alt+Shift+E | Extend selected line to previous |
+
+## Text Box
+
+Active while the subtitle text box has focus.
+
+| Shortcut | Action |
+|----------|--------|
+| Ctrl+X / Ctrl+C / Ctrl+V | Cut / copy / paste |
+| Ctrl+A | Select all text |
+| Shift+Delete | Cut (Windows-standard gesture; Subtitle Edit binds it because Avalonia does not) |
+| Shift+Backspace | Delete selection or next character — forward delete. Default on macOS only, where the Delete key is a backspace; assign it yourself elsewhere |
+
+> **Note:** "Text box: Cut / Copy / Paste (alternative)" exist as separate, unbound actions in **Options** → **Shortcuts** for anyone who wants a second gesture (e.g. Ctrl+Insert / Shift+Insert).
 
 ## Subtitle Grid
 
@@ -109,6 +124,7 @@ wins over the menu activation.
 | Shortcut | Action |
 |----------|--------|
 | Ctrl+V | Paste lines from clipboard at waveform position |
+| Ctrl+C | Copy the selected subtitle to the clipboard |
 | Shift++ | Vertical zoom in |
 | Shift+- | Vertical zoom out |
 
@@ -129,7 +145,7 @@ wins over the menu activation.
 | Ctrl+Alt+Shift+D | Open data folder |
 | Ctrl+Alt+Shift+L | Save language file |
 
-> **Note:** Several actions (Bold, Underline, shot-change snapping/extending, green-zone in/out cues, etc.) ship without a default key. Open **Options** → **Shortcuts** to assign them, or use **Import from SE 4.x** to bring over a familiar set.
+> **Note:** Several actions (Bold, Underline, shot-change snapping/extending, green-zone in/out cues, "Go to next empty line", "Waveform paste clipboard text to new selection", etc.) ship without a default key. Open **Options** → **Shortcuts** to assign them, or use **Import from SE 4.x** to bring over a familiar set.
 
 ## Fix Lists in Dialogs
 

--- a/docs/reference/supported-formats.md
+++ b/docs/reference/supported-formats.md
@@ -32,6 +32,21 @@ Subtitle Edit supports a wide range of subtitle formats for reading and writing.
 > - [ASSA Format Reference](assa.md) — Complete guide to ASS/SSA format
 > - [ASSA Override Tags Reference](assa-override-tags.md) — Complete list of ASS/SSA override tags for styling and animation
 
+## Editing / NLE Exchange Formats
+
+Formats used to move captions and markers between Subtitle Edit and video editors.
+
+| Format | Extension(s) |
+|--------|--------------|
+| Final Cut Pro Xml Captions | .fcpxml |
+| Final Cut Pro Xml (1.3 – 1.5, X, text and marker variants) | .xml, .fcpxml |
+| DaVinci Resolve Marker EDL | .edl |
+| Csv DaVinci | .csv |
+| EDL | .edl |
+| Adobe Premiere Markers | .csv |
+| Adobe Premiere PrProj Xml | .xml |
+| Adobe Encore (tabs) | .txt |
+
 ## Image-Based Formats
 
 | Format | Extension(s) |
@@ -39,14 +54,16 @@ Subtitle Edit supports a wide range of subtitle formats for reading and writing.
 | Blu-ray PGS (SUP) | .sup |
 | VobSub (DVD) | .sub/.idx |
 | BDN XML | .xml |
+| Timed Text Base64 Image (SMPTE-TT bitmap) | .xml |
 
 ## Container Formats (with embedded subtitles)
 
 | Format | Extension(s) |
 |--------|--------------|
 | Matroska (MKV/MKS) | .mkv, .mks |
-| MP4 / MOV (text tracks) | .mp4, .m4v, .m4s, .3gp |
+| MP4 / MOV (text tracks, including fragmented MP4/DASH — wvtt, stpp, tx3g) | .mp4, .m4v, .m4s, .3gp |
 | Transport Stream (teletext, DVB-sub) | .ts, .m2ts, .mts |
+| AVI (XSUB) | .avi |
 | MacCaption | .mcc |
 
 ## Video Formats (for loading video)


### PR DESCRIPTION
The docs carry six overlapping catalogs (TTS engines, STT engines, OCR engines, translate engines, formats, shortcuts) and each had drifted from the code. This checks every list against its source of truth and fills in what shipped since the list was last touched.

| Doc | Was | Now |
|-----|-----|-----|
| text-to-speech.md | 12 engines | 19 — adds IndexTTS, CosyVoice3, IndexTTS 2.5 (audio.cpp), VoxCPM2, MOSS-TTS, Zonos, OmniVoice (CrispASR) |
| speech-to-text.md | 10 Crisp ASR backends | 16 — adds Fun-ASR Nano, GigaAM, MOSS Diarize, SenseVoice, ARK, Voxtral |
| auto-translate.md | missing both advanced engines | adds Ollama advanced and llama.cpp advanced, linked to the advanced page |
| batch-convert.md | 19 of 30 functions | all 30, plus CrispEmbed OCR, llama.cpp advanced translate, HunyuanOCR |
| ocr.md | llama.cpp had endpoint only | lists the four curated models with sizes and the engine update button |
| video-ocr.md | 4 of 6 engines | adds CrispEmbed and GLM API, plus HunyuanOCR |
| assa-apply-advanced-effects.md | 32 of 35 effects | adds Word flip 3D, Cinematic title, Lower third |
| supported-formats.md | untouched since June | new NLE/marker table (Final Cut, DaVinci Resolve, Premiere, Encore), SMPTE-TT bitmap, AVI/XSUB, fragmented MP4/DASH |
| keyboard-shortcuts.md | 4 defaults missing | Ctrl+Home/End, new Text Box section (Shift+Delete cut, Shift+Backspace forward delete), waveform Ctrl+C |

Names, sizes and key bindings were read from the code, not from the PR descriptions: `TtsEngineCatalog`, `CrispAsrEngine`, `AutoTranslateViewModel`, `BatchConvertFunction.List`, `LlamaCppServerManager.OcrModels`, `VideoOcrEngineItem`, the `AdvancedEffect*` classes, the `SubtitleFormat` classes, and the default table in `ShortcutsMain.cs`.

Docs only — no code changes. All internal links and anchors verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)