### PR TITLE
Docs: add the chapters page and rebuild the settings page

### DIFF
--- a/docs/features/audio-visualizer.md
+++ b/docs/features/audio-visualizer.md
@@ -96,7 +96,9 @@ Right-click on the waveform for options including:
 - Merge subtitles
 - Delete subtitle
 - Go to subtitle
+- Toggle shot change, or toggle a [chapter](chapters.md) at the video position
 - Extract audio, or clone the voice heard in the selected subtitle into a TTS engine (**Clone voice to**)
+- Copy the selected subtitle (Ctrl+C) or paste lines from the clipboard at the waveform position (Ctrl+V)
 - Zoom controls
 
 <!-- Screenshot: Waveform context menu -->

--- a/docs/features/burn-in.md
+++ b/docs/features/burn-in.md
@@ -28,6 +28,7 @@ Hardcode (burn-in) subtitles permanently into a video file using FFmpeg.
 - **Box type** — Subtitle box style (none, opaque box, outline)
 - **Text color** — Subtitle text color
 - **Box color** — Background box color
+- **Spacing** — Letter spacing, from -20 to 100. The preview is rendered by libass, so it shows the real spacing
 - **Alignment** — Subtitle alignment position
 - **Margins** — Horizontal and vertical margin offsets
 - **Fix RTL** — Fix right-to-left text rendering
@@ -40,6 +41,10 @@ Hardcode (burn-in) subtitles permanently into a video file using FFmpeg.
 - **Preset** — Encoding speed/quality preset
 - **CRF** — Constant Rate Factor (quality level)
 
+The output container follows the codec, because ffmpeg refuses some combinations outright: H.264
+and H.265 can be written to `.mkv`, `.mp4`, `.mov` or `.ts`, VP9 to `.mkv`, `.webm` or `.mp4`, and
+ProRes to `.mov` or `.mkv`.
+
 ## Hardware Acceleration
 
 Besides the CPU encoders (`libx264`, `libx265`, `libvpx-vp9`, `prores_ks`), the encoding list
@@ -48,7 +53,10 @@ encoding, at somewhat lower quality per bit — for the same visual quality a GP
 produces a larger file.
 
 Only encoders that can actually run on the current operating system are listed, so the choices
-differ between Windows/Linux and macOS.
+differ between Windows/Linux and macOS. On top of that, the window asks ffmpeg what it was built
+with when it opens and drops the encoders that are not there — several ffmpeg builds ship without
+x265, and Subtitle Edit's own Flatpak has neither x265 nor the GPU encoders. If the probe fails,
+the full list is kept.
 
 ### Windows and Linux
 

--- a/docs/features/chapters.md
+++ b/docs/features/chapters.md
@@ -1,0 +1,70 @@
+# Chapters
+
+Edit the chapter marks of the loaded video: add them at the video position, import them from the video or a file, export them, and write them back into the video file.
+
+- **Menu:** Video → More → Chapters...
+- **Shortcut:** Configurable
+
+<!-- Screenshot: Chapters window -->
+
+Chapters belong to the video, not to the subtitle, so a video must be loaded. Chapters are drawn on the [audio visualizer](audio-visualizer.md) as labelled marks, which makes them useful as landmarks while subtitling even if you never write them back to the video.
+
+## How to Use
+
+1. Open the video, then **Video → More → Chapters...**
+2. Add chapters at the video position, or import the ones the video already has
+3. Rename a chapter and adjust its start time in the **Selected chapter** panel on the right
+4. Click **OK** to keep the list
+
+The list shows **#**, **Start time** and **Chapter title**, sorted by time. **Go to** moves the video to the selected chapter.
+
+## Adding and Editing
+
+- **Add chapter at video position** — Adds a chapter where the video is right now, named *Chapter n*
+- **Add chapter** — Adds a chapter without using the video position
+- **Delete** / **Clear** — Remove the selected chapter, or all of them (both ask first)
+- **Selected chapter** — Edit the title and the start time; a button sets the start time to the current video position
+
+The waveform's right-click menu has **Toggle chapter at video position**, which adds a chapter at the cursor, or removes the one already there — the quickest way to mark chapters while listening.
+
+## Import
+
+- **Import from video** — Reads the chapters stored in the loaded video file (MP4 stores them in two different ways, and both are read)
+- **Import from file...** — Reads Matroska chapter XML, ffmpeg metadata (`.ffmeta`), OGM (`.txt`) and `.ini` chapter files. Anything Subtitle Edit can open as a subtitle also works, so a plain subtitle file can be turned into chapters
+
+Both replace the current list.
+
+## Export
+
+**Export to file...** writes the list in one of four formats — the picker decides the writer, not the extension, because two of them are plain `.txt`:
+
+| Format | Extension |
+|--------|-----------|
+| Matroska chapters XML | .xml |
+| ffmpeg metadata | .ffmeta |
+| OGM chapters | .txt |
+| YouTube chapters | .txt |
+
+The YouTube form is the timestamped list you paste into a video description.
+
+## Adjust Times
+
+- **Shift all times** — Move every chapter forward or backward by the same amount
+- **Change frame rate** — Scale every chapter time from one frame rate to another
+
+## Write to Video
+
+**Write to video...** writes the chapters into a *copy* of the video file. Nothing is re-encoded, so it is quick and lossless. Only MP4 and Matroska can carry chapters; for anything else the button reports that. Pick the output file name — ffmpeg cannot write over the file it is reading, so the suggestion is a sibling file.
+
+## Where Chapters Are Stored
+
+Chapters you edit are saved next to Subtitle Edit's other per-video data (a `.chapters.xml` sidecar in the `Chapters` folder of Subtitle Edit's data folder, named after a hash of the video file), not inside the video. The sidecar is plain Matroska chapter XML, so it can be handed straight to `mkvmerge`.
+
+When a video is opened, the sidecar wins over the chapters inside the container: it only exists because you changed something, and re-reading the video would undo that work. Use **Import from video** to deliberately go back to what the file itself carries.
+
+## Keyboard Shortcuts
+
+| Key | Action |
+|-----|--------|
+| Escape | Close / Cancel |
+| Delete | Delete the selected chapter (in the list) |

--- a/docs/features/ocr.md
+++ b/docs/features/ocr.md
@@ -90,6 +90,19 @@ Local OCR engine.
 6. Review and correct any errors
 7. Click **OK** to import the text subtitles
 
+## Saving the Images
+
+The subtitle list's right-click menu has **Save all images with HTML index...**. Pick a folder and
+Subtitle Edit writes `index.html` plus `images/0001.png`, `0002.png`, ... — every subtitle bitmap
+next to the text OCR produced for it, which is the quickest way to proof-read a run against the
+originals.
+
+The page is self-contained (no external css, js or fonts), so it opens straight off the file
+system. It follows the reader's light/dark preference, with an Auto/Light/Dark override, and adds
+a text filter, an "only lines without text" filter for spotting images that produced nothing, a
+dark/light/checkerboard backdrop for the transparent bitmaps, click-to-zoom, and each line's
+number, time codes, duration and image size.
+
 ## Keyboard Shortcuts
 
 ### General

--- a/docs/features/settings.md
+++ b/docs/features/settings.md
@@ -1,6 +1,6 @@
 # Settings
 
-Configure application preferences, profiles, subtitle defaults, video player, and more.
+Configure application preferences, rules and profiles, appearance, video player, waveform, and more.
 
 - **Menu:** Options → Settings...
 - **Shortcut:** Configurable
@@ -11,66 +11,112 @@ Configure application preferences, profiles, subtitle defaults, video player, an
 ## How to Use
 
 1. Open **Options → Settings...**
-2. Navigate through the settings sections
+2. Pick a section from the icons on the left
 3. Adjust settings as needed
 4. Click **OK** to save
 
-## Profiles
+The window is split into sections; the list below follows the order they appear in. Some sections and options only show up on the platform they apply to.
 
-Profiles store subtitle rules and limits. You can switch between profiles for different workflows (e.g., Netflix, broadcast, default).
+## Rules
 
-- **Single line max length** — Maximum characters per line
-- **Optimal chars/sec** — Target reading speed
-- **Max chars/sec** — Maximum reading speed
-- **Max words/min** — Maximum words per minute
-- **Min duration** — Minimum subtitle display time (ms)
-- **Max duration** — Maximum subtitle display time (ms)
-- **Min gap** — Minimum gap between subtitles (ms)
-- **Max lines** — Maximum number of lines per subtitle
-- **Dialog style** — How dialog dashes are handled
-- **Continuation style** — How continuation markers work
+The subtitle rules that drive error checking, the grid's warning colors, and tools such as [Fix common errors](fix-common-errors.md).
+
+- **Profiles** — Rules are stored per profile, so you can switch between e.g. Netflix, broadcast and default. Profiles can be exported and imported
+- **Single line max length**, **Optimal chars/sec**, **Max chars/sec**, **Max words/min**
+- **Min duration (ms)**, **Max duration (ms)**
+- **Min gap (ms)** — The "..." button opens a calculator: pick a frame rate and a number of frames and it works out the milliseconds. It opens on the current video's frame rate and the frame count already configured. Shown in millisecond mode only; in frame mode the value is entered in frames
+- **Max number of lines**, **Unbreak subtitles shorter than**
+- **Dialog style**, **Continuation style** — Including a custom continuation style editor
+- **Cps/line-length** — Which characters count towards CPS and line length
 
 ## General
 
-- **New empty default (ms)** — Default duration for new empty subtitles
-- **Prompt before deleting lines** — Ask before deleting subtitle lines
-- **Lock time codes** — Prevent accidental time code changes
-- **Remember window position and size** — Restore layout between sessions
-- **Use frame mode** — Display times as frame numbers instead of time codes
-- **Auto backup** — Enable automatic backups at a set interval
-- **Open file on start** — Choose whether Subtitle Edit reopens the previous file on startup
-- **Single-letter shortcuts in text boxes** — Control whether single-key shortcuts are active while editing text
-- **Focus text box after insert (grid / waveform)** — Move focus to the subtitle text box after inserting a new line from the grid or waveform
+- **Prompt before delete**, **Lock time codes**, **Remember window position and size**
+- **Use frame mode (hh.mm.ss.ff)** — Show times as frames instead of milliseconds
+- **Limit number of lines in subtitle text box**
+- **Open last recent file on start**
+- **Auto-convert encoding to UTF-8 on open**, **Force CR+LF on save**, **Auto-trim white-space**
+- **Remove blank lines when opening a subtitle** — Off by default
+- **Default encoding**
+- **Subtitle grid Enter-key / single-click / double-click action** — What each gesture does to the video position and focus
+- **Subtitle grid, center when selecting prev/next row**
+- **Save as behavior**, **Save as: append language code**, **Default save location** (with a custom folder)
+- **Auto-save** — Save the open file while editing
+- **Auto-backup** — Automatic backups at a set interval, with a restore dialog
 
-## Subtitle Defaults
+## Subtitle Formats
 
-- **Default subtitle format** — Format used when creating new subtitles
-- **Save format** — Default format for saving
-- **Favorite formats** — Quick access to frequently used formats
-- **Default encoding** — Text encoding for saving files
-- **Auto-convert to UTF-8** — Automatically convert files to UTF-8
-- **Force CR+LF on save** — Use Windows-style line endings
-- **Auto-trim whitespace** — Remove trailing spaces
-- **Remove blank lines when opening a subtitle** — Drop lines without text when a subtitle file is opened or inserted. Off by default
+- **Default format** and **default save-as format**
+- **Favorite subtitle formats** and **favorite languages** — These float to the top of the pickers
+- **WebVTT: use X-TIMESTAMP-MAP** — Offset time codes on load
+
+## Syntax Coloring
+
+- **Color text if too wide (pixels)** — With its own settings for how the width is measured
+- **Error background color**
+
+## Video Player
+
+- **Video player** — Which player to use, plus **Download mpv** / **Download VLC** when the library is missing
+- **Subtitle preview properties** — Font name, size and bold, primary/outline/shadow colors, border style and outline/shadow width for the subtitle drawn on the video
+
+## Waveform / Spectrogram
+
+- **Waveform draw style** and **spectrogram mode**
+- **Toolbar items** — Which timing buttons the waveform toolbar shows, and in which order
+- **Waveform single-click / double-click action**
+- **Extract audio format, sample rate and bitrate** — What the audio Subtitle Edit extracts for the waveform looks like
+- **Snap to shot changes (hold Shift to override)**
+- **Mouse-wheel video position step**
+- **Waveform text font size** and the full color set — text, waveform, subtitle background, background, selected subtitle background, selected, cursor/head, shot change, left/right border, fancy high color. Color themes can be imported and exported
+- **Download ffmpeg** and a **disk space** readout for the extracted audio
 
 ## Tools
 
-- **Merge lines: keep end time (allow overlap with next subtitle)** — Normally, merging lines ("Merge with line before/after" or merging a selection) trims the merged line so it ends just before the next subtitle starts. Enable this to keep the original end time of the last merged line, even if the merged subtitle then overlaps the next one. Off by default.
-- **Merge lines: keep end time only for "Advanced Sub Station Alpha"** — Limits the option above to ASSA files, where overlapping events are a normal part of the format (e.g., signs or effects shown on top of dialog). Uncheck to keep end times when merging in any format. On by default.
+- **Allow single-letter shortcuts in text box**
+- **Go-to-line-number also sets video position**
+- **Adjust all times, remember line selection choice**
+- **Merge lines: keep end time (allow overlap with next subtitle)**, and the variant that limits it to ASSA files
+- **Auto-break** — Break early for end of sentence, comma or dash; break by pixel width; prefer bottom heavy and its **bottom heavy percentage**; **use do-not-break-after list** (with an editor for the list); **split odd lines action**
+- **Spell check engine**, and *treat words ending in 'in'' as 'ing'* (English only)
+- **OCR: use word split list**, **OCR: try to guess unknown words**
+- **Speech to text: prompt for language/engine first time only**
+- **Multiple replace: show context menu buttons**
+- **Grid: focus text box after insert new subtitle**
+- **Text to speech: prompt to merge continuation lines**
+- **Fix common errors: skip step 1 (choose fixes)**
+- **Music symbol** and **music symbols to replace**
 
-## Video Player (MPV Preview)
+## Appearance
 
-- **Font** — Subtitle preview font name, size, and bold
-- **Colors** — Primary, outline, and shadow colors
-- **Border style** — Outline or opaque box
-- **Outline/shadow width** — Border dimensions
+- **Theme**, **icon theme**, **match icon color to dark theme foreground color**, **UI scale (%)**
+- **Dark theme foreground / background color**, **focused button background color**
+- **UI font**, and a separate font for the subtitle text box and grid
+- **Grid** — Show subtitle text as single line (with the separator to use), text fit, [show formatted text](subtitle-grid.md#formatting-display), live spell check, compact mode, alternating row colors (light and dark), grid lines, bookmark color
+- **Subtitle text box** — Bold text, color tags, live spell check, centered text, and which buttons are shown (auto-break, unbreak, italic, color, remove formatting, AI assistant), the up/down start/end/duration controls and their labels
+- **Show button hints** — Turns the tooltips on and off
+- **Show ASSA layer box**, **show horizontal line above toolbar**, **show Plugins menu**
 
-## Waveform and Audio Visualizer
+## Toolbar
 
-- **Waveform toolbar visibility** — Show or hide the waveform toolbar
-- **Waveform toolbar customization** — Choose which timing buttons are visible and how they are ordered
-- **Waveform theme import/export** — Reuse waveform color and toolbar preferences
-- **Shot change color** — Customize the color used for shot change markers
+One checkbox per toolbar button, so the main toolbar can be trimmed to what you use: new, open, open video, save, save as, find, replace, multiple replace, spell check, fix common errors, remove text for hearing impaired, visual sync, point sync, beautify time codes, burn-in, auto-translate, speech to text, settings, layout, source view, help, encoding, frame rate, and the format-specific icons (style manager, properties, attachments, ASSA draw) that only appear for ASSA/SSA/WebVTT files.
+
+## Network
+
+Proxy settings for every download and online engine: **address**, **username**, **password**, **domain**, **bypass proxy for**, and what to **notify about**.
+
+## Updates
+
+- **Check for updates on startup** — Hidden for store-managed installs (e.g. Flatpak), which update through the store
+- **Update channel** — Stable, or stable and beta
+
+## File Type Associations
+
+Windows only. Tick the subtitle file types Subtitle Edit should open by default.
+
+## Files and Logs
+
+Links to the **error log**, the **tools log** and the **settings file** (each enabled only when the file exists), plus **write tools log** to turn the tools log on.
 
 ## Keyboard Shortcuts
 

--- a/docs/features/subtitle-grid.md
+++ b/docs/features/subtitle-grid.md
@@ -78,7 +78,16 @@ Both are a normal edit, so `Ctrl+Z` undoes them.
 
 ## Formatting Display
 
-The grid can render formatting tags (italic, bold, color, etc.) visually instead of showing the raw tags — enable **Show formatting in grid** in the settings. A shortcut to toggle the formatting mode on the fly can be assigned in **Options → Shortcuts**.
+How the grid treats HTML/ASSA markup is a four-way choice — **Show formatted (HTML/ASSA) text in subtitle grid** in **Options → Settings → Appearance**:
+
+| Mode | What the grid shows |
+|------|---------------------|
+| **Show formatting** | The tags are hidden and what they mean is rendered — italic, bold, color, font size. The default |
+| **Show tags** | The text with its tags, with the tags colored so they are easy to pick out |
+| **No formatting** | The raw text exactly as it is stored |
+| **Hide tags** | The markup is stripped and only the dialogue is drawn, as plain themed text — no colors, fonts or sizes. Useful for translation, where the styling is only a distraction. Vector drawing tags are dropped too |
+
+A shortcut can be assigned in **Options → Shortcuts** to cycle the four modes on the fly; the status bar names the mode you land on.
 
 ## Bookmarks
 

--- a/docs/features/transparent-subtitles.md
+++ b/docs/features/transparent-subtitles.md
@@ -26,6 +26,7 @@ Generate a transparent video overlay with rendered subtitles that can be composi
 - **Shadow** — Shadow width and color
 - **Box type** — Box style around text
 - **Text color** — Subtitle text color
+- **Spacing** — Letter spacing, from -20 to 100
 - **Alignment** — Subtitle alignment position
 - **Margins** — Horizontal and vertical margins
 - **Fix RTL** — Fix right-to-left text rendering

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,6 +68,7 @@ Subtitle Edit is a free, open-source editor for video subtitles. This is the doc
 - [Embedded Subtitles](features/embedded-subtitles.md) — Add, remove, preview, and edit subtitle tracks in Matroska/WebM files
 - [Transparent Subtitles](features/transparent-subtitles.md) — Generate transparent subtitle video
 - [Shot Changes](features/shot-changes.md) — Detect and manage shot changes
+- [Chapters](features/chapters.md) — Edit, import, export and write video chapter marks
 - [Blank Video](features/blank-video.md) — Generate a blank video
 - [Re-encode Video](features/re-encode-video.md) — Re-encode video files
 - [Cut Video](features/cut-video.md) — Cut video segments


### PR DESCRIPTION
Second half of the doc review — the parts that needed prose rather than a list refresh. Companion to #13920 (stale lists).

### New: Chapters

The chapter editor (#13732) had no page at all. The new [chapters.md](docs/features/chapters.md) covers the list and the video-position add, the waveform's **Toggle chapter at video position**, import from the video or from a chapter file, the four export formats (Matroska XML, ffmpeg metadata, OGM, YouTube), shift and frame-rate adjust, **Write to video...** (MP4/Matroska only, remux not re-encode), and the `.chapters.xml` sidecar — including why the sidecar wins over the chapters inside the container. Linked from the index and from the waveform context-menu list.

### Rebuilt: Settings

settings.md documented 6 sections; the dialog has 13. The rewrite follows the dialog's own order and names, so the options that had nowhere to live now do: the min-gap frame calculator (#13914), the auto-break do-not-break-after list and bottom-heavy percent (#13312/#13314), the toolbar icon checkboxes (#13764), proxy, update channel and the log/settings file links.

### Corrections elsewhere

- **Subtitle grid** — the formatting display is a four-way choice (Show formatting / Show tags / No formatting / Hide tags, #13850), not the checkbox the page described; the shortcut cycles them
- **Burn-in** — letter spacing (#13843), the codec-to-container rules (#13641), and the ffmpeg encoder probe that hides encoders the local ffmpeg was not built with (#13915)
- **Transparent subtitles** — letter spacing
- **OCR** — "Save all images with HTML index" (#13893)

Section names, option labels and behavior were read from `SettingsPage.cs`, `ChaptersViewModel`, `ChaptersHelper`, `TextWithSubtitleSyntaxHighlightingConverter` and `OutputContainer`, not from the PR descriptions.

Docs only — no code changes. All internal links and anchors verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)