### PR TITLE
List the global waveform actions under Waveform

### DIFF
--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -698,17 +698,21 @@ public static class ShortcutsMain
 
         AddShortcut(shortcuts, vm.WaveformSetStartAndOffsetTheRestCommand, nameof(vm.WaveformSetStartAndOffsetTheRestCommand), ShortcutCategory.Waveform);
         AddShortcut(shortcuts, vm.WaveformSetEndAndOffsetTheRestCommand, nameof(vm.WaveformSetEndAndOffsetTheRestCommand), ShortcutCategory.Waveform);
-        AddShortcut(shortcuts, vm.WaveformSetStartCommand, nameof(vm.WaveformSetStartCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.WaveformSetStartAndGoToNextCommand, nameof(vm.WaveformSetStartAndGoToNextCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.WaveformSetStartAndKeepDurationCommand, nameof(vm.WaveformSetStartAndKeepDurationCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.WaveformSetEndCommand, nameof(vm.WaveformSetEndCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.WaveformSetEndAndGoToNextCommand, nameof(vm.WaveformSetEndAndGoToNextCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.WaveformSetEndAddNewAndGoToNewCommand, nameof(vm.WaveformSetEndAddNewAndGoToNewCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.WaveformSetEndAddNewAndGoToNewNoFocusTextBoxCommand, nameof(vm.WaveformSetEndAddNewAndGoToNewNoFocusTextBoxCommand), ShortcutCategory.General);
+        // Waveform actions that stay on ShortcutCategory.General on purpose - they work wherever
+        // focus is, not only in the waveform. The category is what decides that; the group only
+        // decides where the shortcut is listed, so these belong under Waveform for browsing, which
+        // is also where SE 4 lists them (#13921).
+        AddShortcut(shortcuts, vm.WaveformSetStartCommand, nameof(vm.WaveformSetStartCommand), ShortcutCategory.General, ShortcutGroup.Waveform);
+        AddShortcut(shortcuts, vm.WaveformSetStartAndGoToNextCommand, nameof(vm.WaveformSetStartAndGoToNextCommand), ShortcutCategory.General, ShortcutGroup.Waveform);
+        AddShortcut(shortcuts, vm.WaveformSetStartAndKeepDurationCommand, nameof(vm.WaveformSetStartAndKeepDurationCommand), ShortcutCategory.General, ShortcutGroup.Waveform);
+        AddShortcut(shortcuts, vm.WaveformSetEndCommand, nameof(vm.WaveformSetEndCommand), ShortcutCategory.General, ShortcutGroup.Waveform);
+        AddShortcut(shortcuts, vm.WaveformSetEndAndGoToNextCommand, nameof(vm.WaveformSetEndAndGoToNextCommand), ShortcutCategory.General, ShortcutGroup.Waveform);
+        AddShortcut(shortcuts, vm.WaveformSetEndAddNewAndGoToNewCommand, nameof(vm.WaveformSetEndAddNewAndGoToNewCommand), ShortcutCategory.General, ShortcutGroup.Waveform);
+        AddShortcut(shortcuts, vm.WaveformSetEndAddNewAndGoToNewNoFocusTextBoxCommand, nameof(vm.WaveformSetEndAddNewAndGoToNewNoFocusTextBoxCommand), ShortcutCategory.General, ShortcutGroup.Waveform);
         AddShortcut(shortcuts, vm.DoWaveformCenterCommand, nameof(vm.DoWaveformCenterCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.WaveformSetEndAndStartOfNextAfterGapCommand, nameof(vm.WaveformSetEndAndStartOfNextAfterGapCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.WaveformSetEndAndStartOfNextAfterGapAndGoToNextCommand, nameof(vm.WaveformSetEndAndStartOfNextAfterGapAndGoToNextCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.WaveformSetStartAndSetEndOfPreviousMinusGapCommand, nameof(vm.WaveformSetStartAndSetEndOfPreviousMinusGapCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.WaveformSetEndAndStartOfNextAfterGapCommand, nameof(vm.WaveformSetEndAndStartOfNextAfterGapCommand), ShortcutCategory.General, ShortcutGroup.Waveform);
+        AddShortcut(shortcuts, vm.WaveformSetEndAndStartOfNextAfterGapAndGoToNextCommand, nameof(vm.WaveformSetEndAndStartOfNextAfterGapAndGoToNextCommand), ShortcutCategory.General, ShortcutGroup.Waveform);
+        AddShortcut(shortcuts, vm.WaveformSetStartAndSetEndOfPreviousMinusGapCommand, nameof(vm.WaveformSetStartAndSetEndOfPreviousMinusGapCommand), ShortcutCategory.General, ShortcutGroup.Waveform);
         AddShortcut(shortcuts, vm.WaveformHorizontalZoomInCommand, nameof(vm.WaveformHorizontalZoomInCommand), ShortcutCategory.Waveform);
         AddShortcut(shortcuts, vm.WaveformHorizontalZoomOutCommand, nameof(vm.WaveformHorizontalZoomOutCommand), ShortcutCategory.Waveform);
         AddShortcut(shortcuts, vm.WaveformVerticalZoomInCommand, nameof(vm.WaveformVerticalZoomInCommand), ShortcutCategory.Waveform);
@@ -840,8 +844,8 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.InsertLineAfterCommand, nameof(vm.InsertLineAfterCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.WaveformInsertNewSelectionCommand, nameof(vm.WaveformInsertNewSelectionCommand), ShortcutCategory.Waveform);
         AddShortcut(shortcuts, vm.WaveformNewSelectionPasteFromClipboardCommand, nameof(vm.WaveformNewSelectionPasteFromClipboardCommand), ShortcutCategory.Waveform);
-        AddShortcut(shortcuts, vm.WaveformInsertAtPositionAndFocusTextBoxCommand, nameof(vm.WaveformInsertAtPositionAndFocusTextBoxCommand), ShortcutCategory.General);
-        AddShortcut(shortcuts, vm.WaveformInsertAtPositionNoFocusTextBoxCommand, nameof(vm.WaveformInsertAtPositionNoFocusTextBoxCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.WaveformInsertAtPositionAndFocusTextBoxCommand, nameof(vm.WaveformInsertAtPositionAndFocusTextBoxCommand), ShortcutCategory.General, ShortcutGroup.Waveform);
+        AddShortcut(shortcuts, vm.WaveformInsertAtPositionNoFocusTextBoxCommand, nameof(vm.WaveformInsertAtPositionNoFocusTextBoxCommand), ShortcutCategory.General, ShortcutGroup.Waveform);
         AddShortcut(shortcuts, vm.WaveformPasteFromClipboardCommand, nameof(vm.WaveformPasteFromClipboardCommand), ShortcutCategory.Waveform);
         AddShortcut(shortcuts, vm.WaveformCopyToClipboardCommand, nameof(vm.WaveformCopyToClipboardCommand), ShortcutCategory.Waveform);
         AddShortcut(shortcuts, vm.WaveformCopyTextToClipboardCommand, nameof(vm.WaveformCopyTextToClipboardCommand), ShortcutCategory.Waveform);
@@ -901,7 +905,7 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.RecalculateDurationSelectedLinesCommand, nameof(vm.RecalculateDurationSelectedLinesCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.SetDurationMaxCpsSelectedLinesCommand, nameof(vm.SetDurationMaxCpsSelectedLinesCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.FillSelectedLinesWithClipboardCommand, nameof(vm.FillSelectedLinesWithClipboardCommand), ShortcutCategory.SubtitleGrid);
-        AddShortcut(shortcuts, vm.WaveformToggleWaveformSpectrogramHeightCommand, nameof(vm.WaveformToggleWaveformSpectrogramHeightCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.WaveformToggleWaveformSpectrogramHeightCommand, nameof(vm.WaveformToggleWaveformSpectrogramHeightCommand), ShortcutCategory.General, ShortcutGroup.Waveform);
         AddShortcut(shortcuts, vm.SpectrogramToggleStyleCommand, nameof(vm.SpectrogramToggleStyleCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.ShowBeautifyTimeCodesCommand, nameof(vm.ShowBeautifyTimeCodesCommand), ShortcutCategory.General, ShortcutGroup.Tools);
         AddShortcut(shortcuts, vm.ZoomLayoutInCommand, nameof(vm.ZoomLayoutInCommand), ShortcutCategory.General);

--- a/tests/UI/Logic/WaveformShortcutDispatchTests.cs
+++ b/tests/UI/Logic/WaveformShortcutDispatchTests.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Linq;
+using Nikse.SubtitleEdit.Features.Options.Shortcuts;
+using Nikse.SubtitleEdit.Logic;
+using Xunit;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// The waveform set-start/set-end/insert actions are listed under Waveform in the shortcut
+/// browser so they can be found where SE 4 puts them (#13921), but they must keep dispatching
+/// from anywhere - that is what ShortcutCategory.General buys them, and the category, not the
+/// group, is what decides which focused control a shortcut fires in. Narrowing them to
+/// ShortcutCategory.Waveform would silently stop F11/F12 working outside the waveform.
+/// </summary>
+public class WaveformShortcutDispatchTests
+{
+    [Theory]
+    [InlineData("WaveformSetStartCommand")]
+    [InlineData("WaveformSetEndCommand")]
+    public void WaveformSetStartEndStayGloballyDispatched(string commandName)
+    {
+        // GetDefaultShortcuts only uses the vm parameter for nameof() - never dereferenced.
+        var defaults = ShortcutsMain.GetDefaultShortcuts(null!);
+
+        var shortcut = defaults.FirstOrDefault(s => s.ActionName.Equals(commandName, StringComparison.Ordinal));
+
+        Assert.NotNull(shortcut);
+        // SeShortCut carries the category as ControlName - that is what the dispatcher matches on.
+        Assert.Equal(ShortcutCategory.General.ToString(), shortcut.ControlName);
+    }
+}


### PR DESCRIPTION
Fixes #13921

### The action is there — it is just filed under "General"

"Insert new subtitle at video pos" exists in SE 5 as `WaveformInsertAtPositionAndFocusTextBox` (and a no-focus twin), is registered, and already imports from SE 4's `MainWaveformInsertAtCurrentPosition`. So nothing was actually missing — but SE 4 lists it under **Waveform/spectrogram**, SE 5 lists it under **General**, and that is where the reporter looked.

It is not just this one. Thirteen waveform actions are in the same position:

`WaveformSetStart` · `…AndGoToNext` · `…AndKeepDuration` · `WaveformSetEnd` · `…AndGoToNext` · `…AddNewAndGoToNew` (+ no-focus) · `…AndStartOfNextAfterGap` (+ go-to-next) · `WaveformSetStartAndSetEndOfPreviousMinusGap` · `WaveformInsertAtPosition…` (both) · `WaveformToggleWaveformSpectrogramHeight`

### Why they were under General, and why that part must not change

`ShortcutCategory.General` is deliberate for these: they work wherever focus is, not only in the waveform. **The category is what decides which focused control a shortcut fires in** — moving them to `ShortcutCategory.Waveform` would make F11/F12 stop working outside the waveform, which would be a real regression dressed up as a tidy-up.

`ShortcutGroup` is the field that exists for this: browse-only, documented as having no effect on dispatch, and already used this way elsewhere (`ShortcutCategory.General, ShortcutGroup.File` for the file commands). So these thirteen get `ShortcutGroup.Waveform` and keep `ShortcutCategory.General`.

Where the keys fire: unchanged. Where they are listed: Waveform, like SE 4.

### Testing

The change itself is thirteen mechanical edits of a browse-only field, so the test guards the thing that would actually hurt — that dispatch did **not** narrow. `WaveformSetStart`/`WaveformSetEnd` (the two with shipped defaults, F11/F12) are asserted to still carry `ShortcutCategory.General`.

I could not assert the new grouping directly: it lives in `GetAllAvailableShortcuts`, which dereferences a real `MainViewModel` (~40 injected dependencies), unlike `GetDefaultShortcuts`, which the existing shortcut tests can call with `null!` because it only uses `nameof`. Worth knowing if this area gets more test coverage later.

Full UI suite: 3299 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)