### PR TITLE
Take mpv core interaction off the UI thread's hot paths

### DIFF
--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -47,6 +47,8 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
     private volatile bool _observedEofReached;
     private long _observedSpeedBits = BitConverter.DoubleToInt64Bits(1.0);
     private long _observedDurationBits;
+    private long _observedTimePosBits;
+    private volatile bool _observedTimePosValid; // false = property unavailable (no file) -> Position reports 0, like the live read
     private long _lastPlaybackRestartTimestamp; // Stopwatch ticks of the last MPV_EVENT_PLAYBACK_RESTART
 
     [StructLayout(LayoutKind.Sequential)]
@@ -103,6 +105,11 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
     private delegate int MpvCommand(IntPtr mpvHandle, IntPtr utf8Strings);
 
     private MpvCommand? _mpvCommand;
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate int MpvCommandAsync(IntPtr mpvHandle, ulong replyUserdata, IntPtr utf8Strings);
+
+    private MpvCommandAsync? _mpvCommandAsync;
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     private delegate IntPtr MpvWaitEvent(IntPtr mpvHandle, double wait);
@@ -264,6 +271,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
     private const ulong ObserveIdSpeed = 2;
     private const ulong ObserveIdDuration = 3;
     private const ulong ObserveIdEofReached = 4;
+    private const ulong ObserveIdTimePos = 5;
 
     public event Action? RequestRender;
 
@@ -353,6 +361,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         _mpvObserveProperty = (MpvObserveProperty)GetDllType(typeof(MpvObserveProperty), "mpv_observe_property");
         _mpvWakeup = (MpvWakeup)GetDllType(typeof(MpvWakeup), "mpv_wakeup");
         _mpvCommand = (MpvCommand)GetDllType(typeof(MpvCommand), "mpv_command");
+        _mpvCommandAsync = (MpvCommandAsync)GetDllType(typeof(MpvCommandAsync), "mpv_command_async");
         _mpvSetOption = (MpvSetOption)GetDllType(typeof(MpvSetOption), "mpv_set_option");
         _mpvSetOptionString = (MpvSetOptionString)GetDllType(typeof(MpvSetOptionString), "mpv_set_option_string");
         _mpvGetPropertyString = (MpvGetPropertyString)GetDllType(typeof(MpvGetPropertyString), "mpv_get_property");
@@ -466,7 +475,8 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         if (_mpvObserveProperty(handle, ObserveIdPause, PropertyNamePause, MPV_FORMAT_FLAG) < 0 ||
             _mpvObserveProperty(handle, ObserveIdSpeed, PropertyNameSpeed, MPV_FORMAT_DOUBLE) < 0 ||
             _mpvObserveProperty(handle, ObserveIdDuration, PropertyNameDuration, MPV_FORMAT_DOUBLE) < 0 ||
-            _mpvObserveProperty(handle, ObserveIdEofReached, PropertyNameEofReached, MPV_FORMAT_FLAG) < 0)
+            _mpvObserveProperty(handle, ObserveIdEofReached, PropertyNameEofReached, MPV_FORMAT_FLAG) < 0 ||
+            _mpvObserveProperty(handle, ObserveIdTimePos, PropertyNameTimePos, MPV_FORMAT_DOUBLE) < 0)
         {
             return;
         }
@@ -495,6 +505,17 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
             if (_mpvGetPropertyDouble(handle, PropertyNameDuration, MPV_FORMAT_DOUBLE, ref value) >= 0)
             {
                 Interlocked.Exchange(ref _observedDurationBits, BitConverter.DoubleToInt64Bits(value));
+            }
+
+            value = 0;
+            if (_mpvGetPropertyDouble(handle, PropertyNameTimePos, MPV_FORMAT_DOUBLE, ref value) >= 0)
+            {
+                Interlocked.Exchange(ref _observedTimePosBits, BitConverter.DoubleToInt64Bits(value));
+                _observedTimePosValid = true;
+            }
+            else
+            {
+                _observedTimePosValid = false;
             }
         }
 
@@ -583,6 +604,20 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
                         else if (property.format == MPV_FORMAT_NONE)
                         {
                             _observedEofReached = false;
+                        }
+
+                        break;
+                    case ObserveIdTimePos:
+                        if (property.format == MPV_FORMAT_DOUBLE && property.data != IntPtr.Zero)
+                        {
+                            Interlocked.Exchange(ref _observedTimePosBits, Marshal.ReadInt64(property.data));
+                            _observedTimePosValid = true;
+                        }
+                        else if (property.format == MPV_FORMAT_NONE)
+                        {
+                            // No file loaded: the live read errors and reports 0 - mirror that.
+                            Interlocked.Exchange(ref _observedTimePosBits, 0);
+                            _observedTimePosValid = false;
                         }
 
                         break;
@@ -859,7 +894,11 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
     {
         var numberOfStrings = arr.Length + 1;
         byteArrayPointers = new IntPtr[numberOfStrings];
-        var rootPointer = Marshal.AllocCoTaskMem(IntPtr.Size * numberOfStrings);
+        // AllocHGlobal, matching the FreeHGlobal in the callers - this was AllocCoTaskMem,
+        // which pairs with FreeCoTaskMem: freeing it with FreeHGlobal is a mismatched
+        // allocator on Windows (a silent per-command leak; the Unix runtimes map both to
+        // malloc/free, which is why it never showed there).
+        var rootPointer = Marshal.AllocHGlobal(IntPtr.Size * numberOfStrings);
         for (var index = 0; index < arr.Length; index++)
         {
             var bytes = GetUtf8Bytes(arr[index]);
@@ -881,6 +920,40 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
 
         var mainPtr = AllocateUtf8IntPtrArrayWithSentinel(args, out var byteArrayPointers);
         var result = _mpvCommand(_mpv, mainPtr);
+        foreach (var ptr in byteArrayPointers)
+        {
+            Marshal.FreeHGlobal(ptr);
+        }
+
+        Marshal.FreeHGlobal(mainPtr);
+        return result;
+    }
+
+    /// <summary>
+    /// Queues a command without waiting for the core to run it. mpv_command (the synchronous
+    /// form) holds the caller until the core's dispatch accepts the command - during a scrub
+    /// or slider-drag seek storm on a heavy file that stall lands on the UI thread, once per
+    /// mouse move. mpv_command_async returns as soon as the command is copied into the queue;
+    /// the core posts an MPV_EVENT_COMMAND_REPLY back, which the event loop drains (and
+    /// ignores - matching the synchronous path, whose seek result was never acted on either).
+    /// mpv copies the argument array before returning, so the buffers are freed right away
+    /// exactly like in <see cref="DoMpvCommand"/>. Falls back to the synchronous path when
+    /// the event loop is not running, so the reply events cannot pile up unread.
+    /// </summary>
+    private int DoMpvCommandFireAndForget(params string[] args)
+    {
+        if (_mpv == IntPtr.Zero)
+        {
+            return 0;
+        }
+
+        if (!_eventLoopActive || _mpvCommandAsync == null)
+        {
+            return DoMpvCommand(args);
+        }
+
+        var mainPtr = AllocateUtf8IntPtrArrayWithSentinel(args, out var byteArrayPointers);
+        var result = _mpvCommandAsync(_mpv, 0, mainPtr);
         foreach (var ptr in byteArrayPointers)
         {
             Marshal.FreeHGlobal(ptr);
@@ -1641,6 +1714,27 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
             }
 
             EnsureNotDisposed();
+
+            // Observed cache first: this getter runs ~80x/s during playback (60 fps cursor
+            // timer + the 50 ms position timer), and a live mpv_get_property takes the core's
+            // lock - while the core is busy (hr-seek on a heavy file, slow network open) that
+            // read can block the UI thread, felt as cursor/UI hitches. The cached value is at
+            // most one mpv playloop iteration (~a frame) behind a live query; the playhead
+            // estimate in MainViewModel extrapolates on top of raw reads anyway, and its
+            // freeze detection relies on the raw value STOPPING when mpv stalls - which the
+            // cache preserves exactly (no extrapolation here, ever, for that reason).
+            if (_eventLoopActive)
+            {
+                if (!_observedTimePosValid)
+                {
+                    return 0;
+                }
+
+                var observed = BitConverter.Int64BitsToDouble(Interlocked.Read(ref _observedTimePosBits));
+                _lastRawTimePos = observed;
+                return observed;
+            }
+
             if (_mpv == IntPtr.Zero || _mpvGetPropertyDouble == null)
             {
                 return 0;
@@ -1675,11 +1769,11 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
                 return;
             }
 
-            var err = DoMpvCommand("seek", value.ToString(CultureInfo.InvariantCulture), "absolute");
-            //if (err < 0)
-            //{
-            //    Se.LogError(new InvalidOperationException(GetErrorString(err)), "LibMpvDynamicPlayer Position set");
-            //}
+            // Fire-and-forget: seeks arrive in storms (scrubbing, slider drags, wheel steps -
+            // one per input event), every caller already treats the result as asynchronous
+            // (the playhead pin waits for the position to actually arrive), and the error
+            // result was never acted on here.
+            DoMpvCommandFireAndForget("seek", value.ToString(CultureInfo.InvariantCulture), "absolute");
         }
     }
 

--- a/tests/UI/Logic/VideoPlayers/LibMpvEventLoopTests.cs
+++ b/tests/UI/Logic/VideoPlayers/LibMpvEventLoopTests.cs
@@ -1,0 +1,231 @@
+using System.Diagnostics;
+using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
+
+namespace UITests.Logic.VideoPlayers;
+
+/// <summary>
+/// Live-core tests for the mpv event loop (PR #13925 + observed time-pos): a real libmpv core
+/// with null video/audio outputs, so the observed-property caches (pause, duration, time-pos)
+/// and the MPV_EVENT_PLAYBACK_RESTART signal are exercised end to end - these back the waveform
+/// playhead cursor, so a regression here is a cursor regression.
+///
+/// The tests need a loadable libmpv; on machines without one (bare CI runners) every test
+/// returns early and passes vacuously rather than failing on missing infrastructure.
+/// </summary>
+public class LibMpvEventLoopTests
+{
+    private const int WavSeconds = 2;
+
+    [Fact]
+    public async Task LoadFile_EventLoopServesPauseAndDuration()
+    {
+        var player = CreatePlayer();
+        if (player == null)
+        {
+            return; // no libmpv on this machine
+        }
+
+        var wavFileName = WriteTempWav();
+        try
+        {
+            Assert.True(player.SupportsPlaybackRestartEvents);
+
+            await player.LoadFile(wavFileName);
+            Assert.True(await WaitUntilAsync(() => player.Duration > 1.0, 5000),
+                $"duration never arrived via the event cache (was {player.Duration})");
+
+            Assert.InRange(player.Duration, 1.5, 2.5);
+            Assert.True(player.IsPaused, "LoadFile must leave the core paused");
+            Assert.False(player.IsPlaying);
+        }
+        finally
+        {
+            player.Dispose();
+            TryDelete(wavFileName);
+        }
+    }
+
+    [Fact]
+    public async Task Play_ObservedTimePosAdvances()
+    {
+        var player = CreatePlayer();
+        if (player == null)
+        {
+            return; // no libmpv on this machine
+        }
+
+        var wavFileName = WriteTempWav();
+        try
+        {
+            await player.LoadFile(wavFileName);
+            Assert.True(await WaitUntilAsync(() => player.Duration > 1.0, 5000), "file never loaded");
+
+            player.Play();
+            Assert.True(await WaitUntilAsync(() => player.IsPlaying, 3000),
+                "IsPlaying never flipped via the observed pause cache");
+            Assert.True(await WaitUntilAsync(() => player.Position > 0.1, 3000),
+                $"observed time-pos never started advancing (was {player.Position})");
+
+            var earlier = player.Position;
+            await Task.Delay(400, TestContext.Current.CancellationToken);
+            var later = player.Position;
+            Assert.True(later > earlier,
+                $"observed time-pos did not advance during playback ({earlier} -> {later})");
+        }
+        finally
+        {
+            player.Dispose();
+            TryDelete(wavFileName);
+        }
+    }
+
+    [Fact]
+    public async Task Seek_FiresPlaybackRestartAndLandsObservedTimePos()
+    {
+        var player = CreatePlayer();
+        if (player == null)
+        {
+            return; // no libmpv on this machine
+        }
+
+        var wavFileName = WriteTempWav();
+        try
+        {
+            await player.LoadFile(wavFileName);
+            Assert.True(await WaitUntilAsync(() => player.Duration > 1.0, 5000), "file never loaded");
+
+            player.Play();
+            Assert.True(await WaitUntilAsync(() => player.IsPlaying, 3000), "playback never started");
+
+            var beforeSeekTimestamp = Stopwatch.GetTimestamp();
+            player.Position = 1.2;
+
+            Assert.True(await WaitUntilAsync(() => player.HasPlaybackRestartedSince(beforeSeekTimestamp), 5000),
+                "MPV_EVENT_PLAYBACK_RESTART never arrived after the seek");
+
+            // After the restart the observed position must be at the seek target (allow a little
+            // playback advance past it, and hr-seek tolerance before it).
+            Assert.True(await WaitUntilAsync(() => player.Position >= 1.0, 3000),
+                $"observed time-pos never reached the seek target (was {player.Position})");
+            Assert.InRange(player.Position, 1.0, WavSeconds + 0.3);
+        }
+        finally
+        {
+            player.Dispose();
+            TryDelete(wavFileName);
+        }
+    }
+
+    [Fact]
+    public async Task SeekStorm_LandsOnTheLastTarget()
+    {
+        var player = CreatePlayer();
+        if (player == null)
+        {
+            return; // no libmpv on this machine
+        }
+
+        var wavFileName = WriteTempWav();
+        try
+        {
+            await player.LoadFile(wavFileName);
+            Assert.True(await WaitUntilAsync(() => player.Duration > 1.0, 5000), "file never loaded");
+
+            player.Play();
+            Assert.True(await WaitUntilAsync(() => player.IsPlaying, 3000), "playback never started");
+
+            // What a slider drag looks like to the player: a burst of fire-and-forget seeks,
+            // one per input event, newest target winning. The storm must neither wedge the
+            // core nor land anywhere but the last target.
+            var beforeStormTimestamp = Stopwatch.GetTimestamp();
+            for (var i = 0; i < 25; i++)
+            {
+                player.Position = 0.2 + i * 0.05; // ends at 1.4
+            }
+
+            Assert.True(await WaitUntilAsync(() => player.HasPlaybackRestartedSince(beforeStormTimestamp), 5000),
+                "no playback restart arrived after the seek storm");
+            Assert.True(await WaitUntilAsync(() => player.Position >= 1.2, 5000),
+                $"observed time-pos never reached the storm's final target (was {player.Position})");
+            Assert.InRange(player.Position, 1.2, WavSeconds + 0.3);
+        }
+        finally
+        {
+            player.Dispose();
+            TryDelete(wavFileName);
+        }
+    }
+
+    /// <summary>
+    /// A render-free core, like the text-to-speech preview players: null video/audio outputs so
+    /// nothing opens a window or touches an audio device, but the clock still runs in real time.
+    /// </summary>
+    private static LibMpvDynamicPlayer? CreatePlayer()
+    {
+        var player = new LibMpvDynamicPlayer();
+        if (!player.CanLoad())
+        {
+            return null;
+        }
+
+        player.SetOptionString("vo", "null");
+        player.SetOptionString("ao", "null");
+        player.Initialize();
+        return player;
+    }
+
+    private static async Task<bool> WaitUntilAsync(Func<bool> condition, int timeoutMs)
+    {
+        var end = Environment.TickCount64 + timeoutMs;
+        while (Environment.TickCount64 < end)
+        {
+            if (condition())
+            {
+                return true;
+            }
+
+            await Task.Delay(25, TestContext.Current.CancellationToken);
+        }
+
+        return condition();
+    }
+
+    private static string WriteTempWav()
+    {
+        const int sampleRate = 8000;
+        var dataSize = sampleRate * WavSeconds * 2;
+        var path = Path.Combine(Path.GetTempPath(), $"se-mpv-eventloop-{Guid.NewGuid():N}.wav");
+        using var writer = new BinaryWriter(File.Create(path));
+        writer.Write("RIFF"u8);
+        writer.Write(36 + dataSize);
+        writer.Write("WAVE"u8);
+        writer.Write("fmt "u8);
+        writer.Write(16);
+        writer.Write((short)1); // PCM
+        writer.Write((short)1); // mono
+        writer.Write(sampleRate);
+        writer.Write(sampleRate * 2); // byte rate
+        writer.Write((short)2); // block align
+        writer.Write((short)16); // bits per sample
+        writer.Write("data"u8);
+        writer.Write(dataSize);
+        for (var i = 0; i < dataSize / 2; i++)
+        {
+            writer.Write((short)(Math.Sin(i * 0.05) * 2000)); // quiet tone rather than digital silence
+        }
+
+        return path;
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch
+        {
+            // a temp file left behind must not fail the test
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #13925's mpv event loop — the two remaining synchronous core interactions on the playback hot paths, plus a marshaling fix found along the way.

## Changes

**Observed `time-pos`.** The waveform-cursor `Position` read runs ~80×/s during playback (60 fps cursor timer + 50 ms position timer), and each read was a synchronous `mpv_get_property` that takes the core's lock — while the core is busy (hr-seek on a heavy file, slow network open) that read can block the UI thread, felt as cursor/UI hitches. `time-pos` is now observed and cached like pause/speed/duration. The cached value is at most one playloop iteration (~a frame) behind a live query, is deliberately never extrapolated (the playhead estimate's freeze detection relies on the raw value *stopping* when mpv stalls), and reports 0 with no file loaded, matching the live read. Live-read fallback stays when the event loop isn't running.

**Async seeks.** The `Position` setter (scrubs, slider drags, wheel steps — one seek per input event) now uses `mpv_command_async` instead of the synchronous `mpv_command`, so a drag storm no longer stalls the UI thread once per mouse move waiting on the core's dispatch. Replies are drained by the event loop and ignored — matching the old path, whose seek result was never acted on. Without an event loop the setter falls back to the synchronous command so reply events can't pile up unread.

**Allocator mismatch fix.** The command argv block was allocated with `AllocCoTaskMem` but freed with `FreeHGlobal` — a mismatched pair that silently leaked per command on Windows (Unix runtimes map both to malloc/free). Now `AllocHGlobal`, matching the frees.

## Testing

New live-core tests (`LibMpvEventLoopTests`) spin up a real render-free libmpv core with null video/audio outputs (the same shape as the TTS preview players) against a generated WAV, and verify end to end: pause/duration served from the event cache after load, observed `time-pos` advancing during playback, `MPV_EVENT_PLAYBACK_RESTART` firing after a seek, and a 25-seek storm through the async path landing on its final target. On machines without a loadable libmpv they pass vacuously.

Full UI suite: 3301 passed, 0 failed (the 4 new tests run against the real core locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)