### PR TITLE
Perf: vectorize the OCR bitmap primitives and the spectrogram pixel write

### DIFF
--- a/src/libuilogic/Ocr/NikseBitmap2.cs
+++ b/src/libuilogic/Ocr/NikseBitmap2.cs
@@ -1,4 +1,5 @@
 ﻿using SkiaSharp;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -114,10 +115,163 @@ public class NikseBitmap2
         Buffer.BlockCopy(input._bitmapData, 0, _bitmapData, 0, _bitmapData.Length);
     }
 
+    /// <summary>
+    /// Keeps only the alpha byte of every BGRA pixel in a vector; the colour bytes are zeroed.
+    /// Used by the transparency scans, which are then byte-order neutral.
+    /// </summary>
+    private static readonly Vector<byte> AlphaLaneMask = MakeLaneMask(3);
+
+    /// <summary>
+    /// Keeps only the blue/green/red bytes of every BGRA pixel in a vector; alpha is zeroed.
+    /// </summary>
+    private static readonly Vector<byte> ColorLaneMask = MakeLaneMask(0, 1, 2);
+
+    private static Vector<byte> MakeLaneMask(params int[] lanes)
+    {
+        // Vector<byte>.Count is always a multiple of four, so the 4-byte pixel pattern tiles it.
+        var bytes = new byte[Vector<byte>.Count];
+        for (var i = 0; i < bytes.Length; i += 4)
+        {
+            foreach (var lane in lanes)
+            {
+                bytes[i + lane] = 255;
+            }
+        }
+
+        return new Vector<byte>(bytes);
+    }
+
+    /// <summary>
+    /// The four BGRA bytes read back as one pixel-sized word, so a whole pixel can be written
+    /// with a single store. Reading the bytes and writing the word back is byte-order neutral.
+    /// </summary>
+    private static uint PackBgra(byte blue, byte green, byte red, byte alpha)
+    {
+        Span<byte> bytes = stackalloc byte[4];
+        bytes[0] = blue;
+        bytes[1] = green;
+        bytes[2] = red;
+        bytes[3] = alpha;
+        return MemoryMarshal.Read<uint>(bytes);
+    }
+
+    /// <summary>
+    /// True when no pixel in <paramref name="row"/> has an alpha above
+    /// <paramref name="threshold"/>. One vector load per four or eight pixels instead of one
+    /// byte load per pixel.
+    /// </summary>
+    private static bool RowIsTransparent(ReadOnlySpan<byte> row, byte threshold)
+    {
+        var i = 0;
+        var step = Vector<byte>.Count;
+        if (Vector.IsHardwareAccelerated && row.Length >= step)
+        {
+            var limit = new Vector<byte>(threshold);
+            for (; i <= row.Length - step; i += step)
+            {
+                if (Vector.GreaterThanAny(new Vector<byte>(row.Slice(i, step)) & AlphaLaneMask, limit))
+                {
+                    return false;
+                }
+            }
+        }
+
+        for (var pos = i + 3; pos < row.Length; pos += 4)
+        {
+            if (row[pos] > threshold)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// X of the left-most pixel in <paramref name="row"/> that is not fully transparent, or -1.
+    /// </summary>
+    private static int FirstOpaqueX(ReadOnlySpan<byte> row)
+    {
+        var i = 0;
+        var step = Vector<byte>.Count;
+        if (Vector.IsHardwareAccelerated && row.Length >= step)
+        {
+            for (; i <= row.Length - step; i += step)
+            {
+                if ((new Vector<byte>(row.Slice(i, step)) & AlphaLaneMask) != Vector<byte>.Zero)
+                {
+                    for (var pos = i + 3; pos < i + step; pos += 4)
+                    {
+                        if (row[pos] != 0)
+                        {
+                            return pos >> 2;
+                        }
+                    }
+                }
+            }
+        }
+
+        for (var pos = i + 3; pos < row.Length; pos += 4)
+        {
+            if (row[pos] != 0)
+            {
+                return pos >> 2;
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// X of the right-most pixel in <paramref name="row"/> that is not fully transparent, or -1.
+    /// </summary>
+    private static int LastOpaqueX(ReadOnlySpan<byte> row)
+    {
+        var step = Vector<byte>.Count;
+        var i = row.Length;
+        if (Vector.IsHardwareAccelerated && row.Length >= step)
+        {
+            for (; i - step >= 0; i -= step)
+            {
+                if ((new Vector<byte>(row.Slice(i - step, step)) & AlphaLaneMask) != Vector<byte>.Zero)
+                {
+                    for (var pos = i - 1; pos >= i - step; pos -= 4)
+                    {
+                        if (row[pos] != 0)
+                        {
+                            return pos >> 2;
+                        }
+                    }
+                }
+            }
+        }
+
+        for (var pos = i - 1; pos >= 0; pos -= 4)
+        {
+            if (row[pos] != 0)
+            {
+                return pos >> 2;
+            }
+        }
+
+        return -1;
+    }
+
     public void InvertColors()
     {
         var data = _bitmapData.AsSpan();
-        for (var i = 0; i < data.Length; i += 4)
+        var i = 0;
+        var step = Vector<byte>.Count;
+        if (Vector.IsHardwareAccelerated && data.Length >= step)
+        {
+            // XOR-ing with the colour lanes only leaves alpha untouched.
+            for (; i <= data.Length - step; i += step)
+            {
+                (new Vector<byte>(data.Slice(i, step)) ^ ColorLaneMask).CopyTo(data.Slice(i, step));
+            }
+        }
+
+        for (; i < data.Length; i += 4)
         {
             data[i] = (byte)~data[i];       // B
             data[i + 1] = (byte)~data[i + 1]; // G
@@ -128,48 +282,60 @@ public class NikseBitmap2
 
     public void ReplaceTransparentWith(SKColor c)
     {
+        var replacement = PackBgra(c.Blue, c.Green, c.Red, c.Alpha);
         var data = _bitmapData.AsSpan();
-        var b = c.Blue;
-        var g = c.Green;
-        var r = c.Red;
-        var a = c.Alpha;
-        
-        for (var i = 0; i < data.Length; i += 4)
+        var i = 0;
+        var step = Vector<byte>.Count;
+
+        // Little-endian only: the vector path reads alpha as the top byte of the packed pixel.
+        if (Vector.IsHardwareAccelerated && BitConverter.IsLittleEndian && data.Length >= step)
         {
-            if (data[i + 3] < 10)
+            var alphaMask = new Vector<uint>(0xFF000000u);
+            var limit = new Vector<uint>(10u << 24);
+            var replacementVector = new Vector<uint>(replacement);
+            for (; i <= data.Length - step; i += step)
             {
-                data[i] = b;
-                data[i + 1] = g;
-                data[i + 2] = r;
-                data[i + 3] = a;
+                var raw = Vector.AsVectorUInt32(new Vector<byte>(data.Slice(i, step)));
+                var isTransparent = Vector.LessThan(raw & alphaMask, limit);
+                Vector.AsVectorByte(Vector.ConditionalSelect(isTransparent, replacementVector, raw)).CopyTo(data.Slice(i, step));
+            }
+        }
+
+        var pixels = MemoryMarshal.Cast<byte, uint>(data);
+        for (var p = i / 4; p < pixels.Length; p++)
+        {
+            if (data[p * 4 + 3] < 10)
+            {
+                pixels[p] = replacement;
             }
         }
     }
 
     public void MakeOneColor(SKColor c)
     {
+        var color = PackBgra(c.Blue, c.Green, c.Red, c.Alpha);
         var data = _bitmapData.AsSpan();
-        var b = c.Blue;
-        var g = c.Green;
-        var r = c.Red;
-        var a = c.Alpha;
-        
-        for (var i = 0; i < data.Length; i += 4)
+        var i = 0;
+        var step = Vector<byte>.Count;
+
+        // Little-endian only: the vector path reads blue as the bottom byte of the packed pixel.
+        if (Vector.IsHardwareAccelerated && BitConverter.IsLittleEndian && data.Length >= step)
         {
-            if (data[i] > 20)
+            var lowByte = new Vector<uint>(0x000000FFu);
+            var limit = new Vector<uint>(20u);
+            var colorVector = new Vector<uint>(color);
+            for (; i <= data.Length - step; i += step)
             {
-                data[i] = b;
-                data[i + 1] = g;
-                data[i + 2] = r;
-                data[i + 3] = a;
+                var raw = Vector.AsVectorUInt32(new Vector<byte>(data.Slice(i, step)));
+                var keep = Vector.GreaterThan(raw & lowByte, limit);
+                Vector.AsVectorByte(Vector.ConditionalSelect(keep, colorVector, Vector<uint>.Zero)).CopyTo(data.Slice(i, step));
             }
-            else
-            {
-                data[i] = 0;
-                data[i + 1] = 0;
-                data[i + 2] = 0;
-                data[i + 3] = 0;
-            }
+        }
+
+        var pixels = MemoryMarshal.Cast<byte, uint>(data);
+        for (var p = i / 4; p < pixels.Length; p++)
+        {
+            pixels[p] = data[p * 4] > 20 ? color : 0u;
         }
     }
 
@@ -590,21 +756,42 @@ public class NikseBitmap2
     /// </summary>
     public NikseBitmap2 CropTransparentSides()
     {
+        // Read row-major (the buffer's own order) instead of walking columns, and only over the
+        // part of each row that can still move the bounds: everything left of the current left
+        // edge and everything right of the current right edge. Both shrink to nothing within a
+        // few rows, and the column walk's cache line per pixel is gone.
         var left = -1;
         var right = -1;
-        for (var x = 0; x < Width; x++)
+        for (var y = 0; y < Height; y++)
         {
-            for (var y = 0; y < Height; y++)
+            if (left == 0 && right == Width - 1)
             {
-                if (GetAlpha(x, y) != 0)
+                break;
+            }
+
+            var row = _bitmapData.AsSpan(y * _widthX4, _widthX4);
+            var prefixEnd = left < 0 ? Width : left; // exclusive, in pixels
+            var x = FirstOpaqueX(row.Slice(0, prefixEnd * 4));
+            if (x >= 0)
+            {
+                left = x;
+                if (right < x)
                 {
+                    right = x;
+                }
+            }
+
+            var suffixStart = right + 1;
+            if (suffixStart < Width)
+            {
+                x = LastOpaqueX(row.Slice(suffixStart * 4));
+                if (x >= 0)
+                {
+                    right = suffixStart + x;
                     if (left < 0)
                     {
-                        left = x;
+                        left = right;
                     }
-
-                    right = x;
-                    break;
                 }
             }
         }
@@ -670,29 +857,21 @@ public class NikseBitmap2
 
     public int CropTopTransparent(int minimumMargin)
     {
-        var done = false;
         var newTop = 0;
-        var y = 0;
-        while (!done && y < Height)
+        for (var y = 0; y < Height; y++)
         {
-            var x = 0;
-            while (!done && x < Width)
+            if (RowIsTransparent(_bitmapData.AsSpan(y * _widthX4, _widthX4), 10))
             {
-                var alpha = GetAlpha(x, y);
-                if (alpha > 10)
-                {
-                    done = true;
-                    newTop = y - minimumMargin;
-                    if (newTop < 0)
-                    {
-                        newTop = 0;
-                    }
-                }
-
-                x++;
+                continue;
             }
 
-            y++;
+            newTop = y - minimumMargin;
+            if (newTop < 0)
+            {
+                newTop = 0;
+            }
+
+            break;
         }
 
         if (newTop == 0)
@@ -703,7 +882,7 @@ public class NikseBitmap2
         var newHeight = Height - newTop;
         var newBitmapData = new byte[newHeight * _widthX4];
         var index = 0;
-        for (y = newTop; y < Height; y++)
+        for (var y = newTop; y < Height; y++)
         {
             var pixelAddress = y * _widthX4;
             Buffer.BlockCopy(_bitmapData, pixelAddress, newBitmapData, index, _widthX4);
@@ -731,34 +910,13 @@ public class NikseBitmap2
 
     public bool IsHorizontalLineTransparent(int y)
     {
-        var yOffset = y * _widthX4 + 3;
-        var max = yOffset + _widthX4;
-        for (var pos = yOffset; pos < max; pos += 4)
-        {
-            if (_bitmapData[pos] > 1)
-            {
-                return false;
-            }
-        }
-
-        return true;
+        return RowIsTransparent(_bitmapData.AsSpan(y * _widthX4, _widthX4), 1);
     }
 
     public void Fill(SKColor color)
     {
-        var data = _bitmapData.AsSpan();
-        var b = color.Blue;
-        var g = color.Green;
-        var r = color.Red;
-        var a = color.Alpha;
-        
-        for (var i = 0; i < data.Length; i += 4)
-        {
-            data[i] = b;
-            data[i + 1] = g;
-            data[i + 2] = r;
-            data[i + 3] = a;
-        }
+        MemoryMarshal.Cast<byte, uint>(_bitmapData.AsSpan())
+            .Fill(PackBgra(color.Blue, color.Green, color.Red, color.Alpha));
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -956,48 +1114,56 @@ public class NikseBitmap2
 
     public void MakeTwoColor(int minRgb)
     {
-        var data = _bitmapData.AsSpan();
-        for (var i = 0; i < data.Length; i += 4)
-        {
-            if (data[i + 3] < 1 || data[i] + data[i + 1] + data[i + 2] < minRgb)
-            {
-                data[i] = 0;
-                data[i + 1] = 0;
-                data[i + 2] = 0;
-                data[i + 3] = 0;
-            }
-            else
-            {
-                data[i] = 255;
-                data[i + 1] = 255;
-                data[i + 2] = 255;
-                data[i + 3] = 255;
-            }
-        }
+        MakeTwoColorPacked(minRgb, PackBgra(0, 0, 0, 0), PackBgra(255, 255, 255, 255));
     }
 
     public void MakeTwoColor(int minRgb, SKColor background, SKColor foreground)
     {
-        var bufferBackground = new byte[4];
-        bufferBackground[0] = background.Blue;
-        bufferBackground[1] = background.Green;
-        bufferBackground[2] = background.Red;
-        bufferBackground[3] = 255;
-        var bufferForeground = new byte[4];
-        bufferForeground[0] = foreground.Blue;
-        bufferForeground[1] = foreground.Green;
-        bufferForeground[2] = foreground.Red;
-        bufferForeground[3] = 255;
-        for (var i = 0; i < _bitmapData.Length; i += 4)
+        MakeTwoColorPacked(minRgb,
+            PackBgra(background.Blue, background.Green, background.Red, 255),
+            PackBgra(foreground.Blue, foreground.Green, foreground.Red, 255));
+    }
+
+    /// <summary>
+    /// Writes one packed pixel per pixel instead of a <see cref="Buffer.BlockCopy"/> call per
+    /// pixel, with a vector pass in front of it. Little-endian only: it reads the channels out
+    /// of the packed pixel by value, which the byte-order-neutral lane masks cannot do once
+    /// three of them have to be added together.
+    /// </summary>
+    private void MakeTwoColorPacked(int minRgb, uint background, uint foreground)
+    {
+        var length = _bitmapData.Length;
+        var i = 0;
+        var step = Vector<byte>.Count;
+
+        // Green and red come from re-reading the block one and two bytes along, so those extra
+        // bytes have to stay inside the array.
+        if (Vector.IsHardwareAccelerated && BitConverter.IsLittleEndian && minRgb >= 0 && length >= step + 2)
         {
-            if (_bitmapData[i + 3] < 1 || _bitmapData[i + 0] + _bitmapData[i + 1] + _bitmapData[i + 2] < minRgb)
+            var lowByte = new Vector<uint>(0x000000FFu);
+            var alphaMask = new Vector<uint>(0xFF000000u);
+            var limit = new Vector<uint>((uint)minRgb);
+            var backgroundVector = new Vector<uint>(background);
+            var foregroundVector = new Vector<uint>(foreground);
+            for (; i + step + 2 <= length; i += step)
             {
-                Buffer.BlockCopy(bufferBackground, 0, _bitmapData, i, 4);
+                var raw = Vector.AsVectorUInt32(new Vector<byte>(_bitmapData, i));
+                var green = Vector.AsVectorUInt32(new Vector<byte>(_bitmapData, i + 1)) & lowByte;
+                var red = Vector.AsVectorUInt32(new Vector<byte>(_bitmapData, i + 2)) & lowByte;
+                var sum = (raw & lowByte) + green + red;
+                var isBackground = Vector.Equals(raw & alphaMask, Vector<uint>.Zero) | Vector.LessThan(sum, limit);
+                Vector.AsVectorByte(Vector.ConditionalSelect(isBackground, backgroundVector, foregroundVector)).CopyTo(_bitmapData, i);
             }
-            else
-            {
-                Buffer.BlockCopy(bufferForeground, 0, _bitmapData, i, 4);
-            }
+        }
+
+        var data = _bitmapData.AsSpan();
+        var pixels = MemoryMarshal.Cast<byte, uint>(data);
+        for (var p = i / 4; p < pixels.Length; p++)
+        {
+            var b = p * 4;
+            pixels[p] = data[b + 3] < 1 || data[b] + data[b + 1] + data[b + 2] < minRgb
+                ? background
+                : foreground;
         }
     }
 
@@ -1047,16 +1213,7 @@ public class NikseBitmap2
     /// </summary>
     public bool IsLineTransparent(int y)
     {
-        var max = _width * 4 + y * _widthX4 + 3;
-        for (var pos = y * _widthX4 + 3; pos < max; pos += 4)
-        {
-            if (_bitmapData[pos] != 0)
-            {
-                return false;
-            }
-        }
-
-        return true;
+        return RowIsTransparent(_bitmapData.AsSpan(y * _widthX4, _widthX4), 0);
     }
 
     public bool IsVerticalLineTransparent(int x)
@@ -1075,14 +1232,7 @@ public class NikseBitmap2
 
     public bool IsImageOnlyTransparent()
     {
-        for (var i = 0; i < _bitmapData.Length; i += 4)
-        {
-            if (_bitmapData[i + 3] != 0) // check alpha
-            {
-                return false;
-            }
-        }
-        return true;
+        return RowIsTransparent(_bitmapData, 0);
     }
 
     public int GetNonTransparentHeight()

--- a/src/ui/Logic/Media/WaveToVisualizer2.cs
+++ b/src/ui/Logic/Media/WaveToVisualizer2.cs
@@ -459,6 +459,32 @@ public class SpectrogramData2 : IDisposable
         _rawSamples = null;
     }
 
+    /// <summary>
+    /// float -> double for a whole chunk, widened a vector at a time rather than one element per
+    /// iteration. Widening float to double is exact, so the result is bit-identical to the
+    /// element-wise copy.
+    /// </summary>
+    private static void WidenToDouble(ReadOnlySpan<float> source, Span<double> destination)
+    {
+        var i = 0;
+        var step = Vector<float>.Count;
+        if (Vector.IsHardwareAccelerated && source.Length >= step)
+        {
+            var half = Vector<double>.Count;
+            for (; i <= source.Length - step; i += step)
+            {
+                Vector.Widen(new Vector<float>(source.Slice(i, step)), out var low, out var high);
+                low.CopyTo(destination.Slice(i, half));
+                high.CopyTo(destination.Slice(i + half, half));
+            }
+        }
+
+        for (; i < source.Length; i++)
+        {
+            destination[i] = source[i];
+        }
+    }
+
     private void GenerateImagesFromRawData()
     {
         if (_rawSamples == null)
@@ -480,11 +506,7 @@ public class SpectrogramData2 : IDisposable
         {
             var offset = iChunk * chunkSampleCount;
             var chunkSamples = new double[chunkSampleCount];
-
-            for (var i = 0; i < chunkSampleCount; i++)
-            {
-                chunkSamples[i] = _rawSamples[offset + i];
-            }
+            WidenToDouble(_rawSamples.AsSpan(offset, chunkSampleCount), chunkSamples);
 
             images[iChunk] = drawer.Draw(chunkSamples);
             return drawer;
@@ -1275,7 +1297,7 @@ public class WavePeakGenerator2 : IDisposable
         private readonly int _nfft;
         private readonly MagnitudeToIndexMapper _mapper;
         private readonly RealFFT _fft;
-        private readonly SKColor[] _palette;
+        private readonly uint[] _paletteRgba;
         private readonly double[] _segment;
         private readonly double[] _window;
         private readonly double[] _magnitude1;
@@ -1316,7 +1338,20 @@ public class WavePeakGenerator2 : IDisposable
             _nfft = nfft;
             _mapper = new MagnitudeToIndexMapper(100.0, MagnitudeIndexRange - 1);
             _fft = new RealFFT(nfft);
-            _palette = palette;
+
+            // The palette pre-packed into the bitmap's own RGBA byte order, so Draw can store a
+            // whole pixel with one 32-bit write instead of four byte writes.
+            _paletteRgba = new uint[palette.Length];
+            Span<byte> rgba = stackalloc byte[4];
+            for (var i = 0; i < palette.Length; i++)
+            {
+                rgba[0] = palette[i].Red;
+                rgba[1] = palette[i].Green;
+                rgba[2] = palette[i].Blue;
+                rgba[3] = palette[i].Alpha;
+                _paletteRgba[i] = MemoryMarshal.Read<uint>(rgba);
+            }
+
             _segment = new double[nfft];
             _window = CreateRaisedCosineWindow(nfft);
             _magnitude1 = new double[nfft / 2];
@@ -1346,18 +1381,15 @@ public class WavePeakGenerator2 : IDisposable
                 ProcessSegment(samples, offset - (x > 0 ? nnftQuarter : 0), _magnitude1);
                 ProcessSegment(samples, offset + (x < width - 1 ? nnftQuarter : 0), _magnitude2);
 
-                var xOffset = x * 4;
+                // Bottom row upwards: one 32-bit store per pixel instead of four byte stores,
+                // and the destination steps back a row at a time instead of being recomputed
+                // with a multiply per pixel. The palette stays a bounds-checked array access so
+                // an out-of-range magnitude still throws instead of writing past the palette.
+                var pixel = pixels + ((height - 1) * stride) + (x * 4);
                 for (var y = 0; y < height; y++)
                 {
-                    int colorIndex = _mapper.Map((_magnitude1[y] + _magnitude2[y]) / 2.0);
-                    SKColor color = _palette[colorIndex];
-
-                    int pixelY = height - y - 1;
-                    byte* pixel = pixels + (pixelY * stride) + xOffset;
-                    pixel[0] = color.Red;
-                    pixel[1] = color.Green;
-                    pixel[2] = color.Blue;
-                    pixel[3] = color.Alpha;
+                    *(uint*)pixel = _paletteRgba[_mapper.Map((_magnitude1[y] + _magnitude2[y]) / 2.0)];
+                    pixel -= stride;
                 }
             }
 

--- a/tests/benchmarks/PerfHuntRound13Benchmarks.cs
+++ b/tests/benchmarks/PerfHuntRound13Benchmarks.cs
@@ -1,0 +1,847 @@
+using System.Numerics;
+using System.Runtime.InteropServices;
+using BenchmarkDotNet.Attributes;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// Round 13 candidate shoot-out: the OCR bitmap primitives in
+/// <c>libuilogic/Ocr/NikseBitmap2.cs</c> (every one of them still walks the BGRA buffer one
+/// byte at a time) plus the spectrogram build in <c>ui/Logic/Media/WaveToVisualizer2.cs</c>.
+///
+/// Self-contained on purpose (see the benchmark-verification notes): the shipped
+/// implementation and each candidate live here with their own direct call site, so there is no
+/// stash baseline, no worktree drift and no megamorphic delegate site. GlobalSetup asserts the
+/// candidate is byte-for-byte equivalent to the current code over an adversarial battery
+/// before any timing runs.
+/// </summary>
+[MemoryDiagnoser]
+public class PerfHuntRound13Benchmarks
+{
+    // A cropped Blu-ray subtitle line: wide, short, mostly transparent with anti-aliased glyphs.
+    private const int LineWidth = 1400;
+    private const int LineHeight = 60;
+
+    private byte[] _line = null!;      // the line image
+    private byte[] _scratch = null!;   // writable copy for the mutating benchmarks
+    private byte[] _blank = null!;     // fully transparent line image (worst case for the scans)
+
+    // Spectrogram: one chunk as SpectrogramDrawer.Draw() sees it.
+    private const int Nfft = 256;
+    private const int ImageWidth = 1024;
+    private byte[] _bitmap = null!;
+    private uint[] _paletteRgba = null!;
+    private byte[] _colorIndexes = null!;
+    private float[] _rawSamples = null!;
+    private double[] _chunkSamples = null!;
+
+    private static readonly Vector<byte> AlphaMask = MakeLaneMask(3);
+    private static readonly Vector<byte> RgbMask = MakeLaneMask(0, 1, 2);
+
+    private static Vector<byte> MakeLaneMask(params int[] lanes)
+    {
+        var bytes = new byte[Vector<byte>.Count];
+        for (var i = 0; i < bytes.Length; i += 4)
+        {
+            foreach (var lane in lanes)
+            {
+                bytes[i + lane] = 255;
+            }
+        }
+
+        return new Vector<byte>(bytes);
+    }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _line = MakeSubtitleLine(LineWidth, LineHeight, 1);
+        _scratch = new byte[_line.Length];
+        _blank = new byte[LineWidth * LineHeight * 4];
+
+        _bitmap = new byte[ImageWidth * (Nfft / 2) * 4];
+        _paletteRgba = new uint[256];
+        var palette = new byte[256 * 4];
+        for (var i = 0; i < 256; i++)
+        {
+            palette[i * 4] = (byte)i;                 // R
+            palette[i * 4 + 1] = (byte)(255 - i);     // G
+            palette[i * 4 + 2] = (byte)(i * 3 % 256); // B
+            palette[i * 4 + 3] = 255;                 // A
+            _paletteRgba[i] = MemoryMarshal.Read<uint>(palette.AsSpan(i * 4, 4));
+        }
+
+        _colorIndexes = new byte[ImageWidth * (Nfft / 2)];
+        var rnd = new Random(7);
+        for (var i = 0; i < _colorIndexes.Length; i++)
+        {
+            _colorIndexes[i] = (byte)rnd.Next(256);
+        }
+
+        _rawSamples = new float[Nfft * ImageWidth];
+        for (var i = 0; i < _rawSamples.Length; i++)
+        {
+            _rawSamples[i] = (float)Math.Sin(i * 0.01) * 0.5f;
+        }
+
+        _chunkSamples = new double[Nfft * ImageWidth];
+
+        AssertEquivalence();
+    }
+
+    /// <summary>
+    /// Transparent background, anti-aliased white glyph blobs, a few coloured pixels; the same
+    /// mix a real cropped subtitle line has.
+    /// </summary>
+    private static byte[] MakeSubtitleLine(int width, int height, int seed)
+    {
+        var rnd = new Random(seed);
+        var data = new byte[width * height * 4];
+        for (var glyph = 0; glyph < width / 22; glyph++)
+        {
+            var gx = glyph * 22 + 3;
+            var gw = 12 + rnd.Next(4);
+            var gy = 8 + rnd.Next(4);
+            var gh = height - gy - 8;
+            for (var y = gy; y < gy + gh; y++)
+            {
+                for (var x = gx; x < gx + gw && x < width; x++)
+                {
+                    var edge = x == gx || x == gx + gw - 1 || y == gy || y == gy + gh - 1;
+                    if (!edge && rnd.Next(3) == 0)
+                    {
+                        continue; // hollow parts of the glyph
+                    }
+
+                    var i = (y * width + x) * 4;
+                    var v = edge ? (byte)rnd.Next(40, 200) : (byte)rnd.Next(200, 256);
+                    data[i] = v;
+                    data[i + 1] = v;
+                    data[i + 2] = v;
+                    data[i + 3] = edge ? (byte)rnd.Next(1, 255) : (byte)255;
+                }
+            }
+        }
+
+        return data;
+    }
+
+    // ---------------------------------------------------------------- equivalence
+
+    private void AssertEquivalence()
+    {
+        var cases = new List<(byte[] data, int width, int height)>
+        {
+            (_line, LineWidth, LineHeight),
+            (_blank, LineWidth, LineHeight),
+            (MakeSubtitleLine(31, 47, 2), 31, 47),   // odd width, not a vector multiple
+            (MakeSubtitleLine(1, 9, 3), 1, 9),       // one pixel wide
+            (MakeSubtitleLine(5, 1, 4), 5, 1),       // one row
+            (MakeSubtitleLine(17, 3, 5), 17, 3),
+            (new byte[4], 1, 1),                     // single transparent pixel
+        };
+
+        foreach (var (data, width, height) in cases)
+        {
+            var widthX4 = width * 4;
+
+            for (var y = 0; y < height; y++)
+            {
+                Check(Cur_IsLineTransparent(data, width, widthX4, y) == New_IsLineTransparent(data, widthX4, y), $"IsLineTransparent y={y} w={width}");
+                Check(Cur_IsHorizontalLineTransparent(data, widthX4, y) == New_IsHorizontalLineTransparent(data, widthX4, y), $"IsHorizontalLineTransparent y={y} w={width}");
+            }
+
+            Check(Cur_IsImageOnlyTransparent(data) == New_IsImageOnlyTransparent(data), "IsImageOnlyTransparent");
+            Check(Cur_CalcBottomTransparent(data, widthX4, height) == New_CalcBottomTransparent(data, widthX4, height), "CalcBottomTransparent");
+
+            for (var margin = 0; margin < 4; margin++)
+            {
+                Check(Cur_CropTopTransparent(data, widthX4, height, margin) == New_CropTopTransparent(data, widthX4, height, margin), $"CropTopTransparent margin={margin}");
+            }
+
+            Cur_FindOpaqueSides(data, width, height, out var curLeft, out var curRight);
+            New_FindOpaqueSides(data, width, height, out var newLeft, out var newRight);
+            Check(curLeft == newLeft && curRight == newRight, $"FindOpaqueSides w={width} cur=({curLeft},{curRight}) new=({newLeft},{newRight})");
+
+            CheckMutation(data, Cur_Fill, New_Fill, "Fill");
+            CheckMutation(data, Cur_InvertColors, New_InvertColors, "InvertColors");
+            CheckMutation(data, Cur_ReplaceTransparentWith, New_ReplaceTransparentWith, "ReplaceTransparentWith");
+            CheckMutation(data, Cur_MakeOneColor, New_MakeOneColor, "MakeOneColor");
+            foreach (var minRgb in new[] { 0, 1, 30, 300, 600, 765, 766 })
+            {
+                var expected = (byte[])data.Clone();
+                Cur_MakeTwoColor(expected, minRgb);
+                var actual = (byte[])data.Clone();
+                New_MakeTwoColor(actual, minRgb);
+                Check(expected.AsSpan().SequenceEqual(actual), $"MakeTwoColor minRgb={minRgb} w={width}");
+            }
+        }
+
+        // Spectrogram pixel write shape.
+        var refBitmap = new byte[_bitmap.Length];
+        var newBitmap = new byte[_bitmap.Length];
+        Cur_WritePixels(refBitmap, _colorIndexes, _paletteRgba, ImageWidth, Nfft / 2);
+        New_WritePixels(newBitmap, _colorIndexes, _paletteRgba, ImageWidth, Nfft / 2);
+        Check(refBitmap.AsSpan().SequenceEqual(newBitmap), "spectrogram pixel write");
+
+        // float[] -> double[] chunk copy.
+        var refChunk = new double[_chunkSamples.Length];
+        var newChunk = new double[_chunkSamples.Length];
+        foreach (var len in new[] { 0, 1, 3, 7, 8, 9, 33, _chunkSamples.Length })
+        {
+            Array.Clear(refChunk);
+            Array.Clear(newChunk);
+            Cur_CopyChunk(_rawSamples, 0, refChunk, len);
+            New_CopyChunk(_rawSamples, 0, newChunk, len);
+            Check(refChunk.AsSpan().SequenceEqual(newChunk), $"chunk copy len={len}");
+        }
+    }
+
+    private static void CheckMutation(byte[] data, Action<byte[]> current, Action<byte[]> candidate, string what)
+    {
+        var expected = (byte[])data.Clone();
+        current(expected);
+        var actual = (byte[])data.Clone();
+        candidate(actual);
+        Check(expected.AsSpan().SequenceEqual(actual), what);
+    }
+
+    private static void Check(bool ok, string what)
+    {
+        if (!ok)
+        {
+            throw new InvalidOperationException($"Candidate differs from current implementation: {what}");
+        }
+    }
+
+    // ================================================================ 1. IsLineTransparent
+
+    private static bool Cur_IsLineTransparent(byte[] data, int width, int widthX4, int y)
+    {
+        var max = width * 4 + y * widthX4 + 3;
+        for (var pos = y * widthX4 + 3; pos < max; pos += 4)
+        {
+            if (data[pos] != 0)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool New_IsLineTransparent(byte[] data, int widthX4, int y)
+    {
+        return RowIsTransparent(data.AsSpan(y * widthX4, widthX4), 0);
+    }
+
+    /// <summary>
+    /// True when no pixel in the row has alpha above <paramref name="threshold"/>. One vector
+    /// load per 4 or 8 pixels instead of one byte load per pixel; the mask keeps only the alpha
+    /// lane of each BGRA quad, so it is byte-order neutral.
+    /// </summary>
+    private static bool RowIsTransparent(ReadOnlySpan<byte> row, byte threshold)
+    {
+        var i = 0;
+        var step = Vector<byte>.Count;
+        if (Vector.IsHardwareAccelerated && row.Length >= step)
+        {
+            var limit = new Vector<byte>(threshold);
+            for (; i <= row.Length - step; i += step)
+            {
+                var alpha = new Vector<byte>(row.Slice(i, step)) & AlphaMask;
+                if (Vector.GreaterThanAny(alpha, limit))
+                {
+                    return false;
+                }
+            }
+        }
+
+        for (var pos = i + 3; pos < row.Length; pos += 4)
+        {
+            if (row[pos] > threshold)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    [Benchmark] public bool IsLineTransparent_Current() { var r = false; for (var y = 0; y < LineHeight; y++) { r ^= Cur_IsLineTransparent(_line, LineWidth, LineWidth * 4, y); } return r; }
+    [Benchmark] public bool IsLineTransparent_Simd() { var r = false; for (var y = 0; y < LineHeight; y++) { r ^= New_IsLineTransparent(_line, LineWidth * 4, y); } return r; }
+
+    // ================================================== 2. IsHorizontalLineTransparent / bottom
+
+    private static bool Cur_IsHorizontalLineTransparent(byte[] data, int widthX4, int y)
+    {
+        var yOffset = y * widthX4 + 3;
+        var max = yOffset + widthX4;
+        for (var pos = yOffset; pos < max; pos += 4)
+        {
+            if (data[pos] > 1)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool New_IsHorizontalLineTransparent(byte[] data, int widthX4, int y)
+    {
+        return RowIsTransparent(data.AsSpan(y * widthX4, widthX4), 1);
+    }
+
+    private static int Cur_CalcBottomTransparent(byte[] data, int widthX4, int height)
+    {
+        var y = height - 1;
+        for (; y > 0; y--)
+        {
+            if (!Cur_IsHorizontalLineTransparent(data, widthX4, y))
+            {
+                break;
+            }
+        }
+
+        return height - y;
+    }
+
+    private static int New_CalcBottomTransparent(byte[] data, int widthX4, int height)
+    {
+        var y = height - 1;
+        for (; y > 0; y--)
+        {
+            if (!New_IsHorizontalLineTransparent(data, widthX4, y))
+            {
+                break;
+            }
+        }
+
+        return height - y;
+    }
+
+    [Benchmark] public int CalcBottomTransparent_Current() => Cur_CalcBottomTransparent(_blank, LineWidth * 4, LineHeight);
+    [Benchmark] public int CalcBottomTransparent_Simd() => New_CalcBottomTransparent(_blank, LineWidth * 4, LineHeight);
+
+    // ================================================================ 3. IsImageOnlyTransparent
+
+    private static bool Cur_IsImageOnlyTransparent(byte[] data)
+    {
+        for (var i = 0; i < data.Length; i += 4)
+        {
+            if (data[i + 3] != 0)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool New_IsImageOnlyTransparent(byte[] data) => RowIsTransparent(data, 0);
+
+    [Benchmark] public bool IsImageOnlyTransparent_Current() => Cur_IsImageOnlyTransparent(_blank);
+    [Benchmark] public bool IsImageOnlyTransparent_Simd() => New_IsImageOnlyTransparent(_blank);
+
+    // ================================================================ 4. CropTopTransparent
+
+    private static int Cur_CropTopTransparent(byte[] data, int widthX4, int height, int minimumMargin)
+    {
+        var done = false;
+        var newTop = 0;
+        var y = 0;
+        var width = widthX4 / 4;
+        while (!done && y < height)
+        {
+            var x = 0;
+            while (!done && x < width)
+            {
+                var alpha = data[x * 4 + y * widthX4 + 3];
+                if (alpha > 10)
+                {
+                    done = true;
+                    newTop = y - minimumMargin;
+                    if (newTop < 0)
+                    {
+                        newTop = 0;
+                    }
+                }
+
+                x++;
+            }
+
+            y++;
+        }
+
+        return newTop;
+    }
+
+    private static int New_CropTopTransparent(byte[] data, int widthX4, int height, int minimumMargin)
+    {
+        for (var y = 0; y < height; y++)
+        {
+            if (!RowIsTransparent(data.AsSpan(y * widthX4, widthX4), 10))
+            {
+                var newTop = y - minimumMargin;
+                return newTop < 0 ? 0 : newTop;
+            }
+        }
+
+        return 0;
+    }
+
+    [Benchmark] public int CropTopTransparent_Current() => Cur_CropTopTransparent(_line, LineWidth * 4, LineHeight, 2);
+    [Benchmark] public int CropTopTransparent_Simd() => New_CropTopTransparent(_line, LineWidth * 4, LineHeight, 2);
+
+    // ================================================================ 5. CropTransparentSides
+
+    private static void Cur_FindOpaqueSides(byte[] data, int width, int height, out int left, out int right)
+    {
+        left = -1;
+        right = -1;
+        var widthX4 = width * 4;
+        for (var x = 0; x < width; x++)
+        {
+            for (var y = 0; y < height; y++)
+            {
+                if (data[x * 4 + y * widthX4 + 3] != 0)
+                {
+                    if (left < 0)
+                    {
+                        left = x;
+                    }
+
+                    right = x;
+                    break;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Same left/right opaque bounds, but read row-major (the buffer's own order) and only over
+    /// the part of each row that could still improve the bounds: everything left of the current
+    /// left edge and everything right of the current right edge. Both shrink to nothing after
+    /// the first few rows, and the column-major walk's cache-line-per-pixel access is gone.
+    /// </summary>
+    private static void New_FindOpaqueSides(byte[] data, int width, int height, out int left, out int right)
+    {
+        left = -1;
+        right = -1;
+        var widthX4 = width * 4;
+        for (var y = 0; y < height; y++)
+        {
+            if (left == 0 && right == width - 1)
+            {
+                return;
+            }
+
+            var row = data.AsSpan(y * widthX4, widthX4);
+            var prefixEnd = left < 0 ? width : left; // exclusive, in pixels
+            var x = FirstOpaque(row.Slice(0, prefixEnd * 4));
+            if (x >= 0)
+            {
+                left = x;
+                if (right < x)
+                {
+                    right = x;
+                }
+            }
+
+            var suffixStart = right + 1;
+            if (suffixStart < width)
+            {
+                x = LastOpaque(row.Slice(suffixStart * 4));
+                if (x >= 0)
+                {
+                    right = suffixStart + x;
+                    if (left < 0)
+                    {
+                        left = right;
+                    }
+                }
+            }
+        }
+    }
+
+    private static int FirstOpaque(ReadOnlySpan<byte> row)
+    {
+        var i = 0;
+        var step = Vector<byte>.Count;
+        if (Vector.IsHardwareAccelerated && row.Length >= step)
+        {
+            for (; i <= row.Length - step; i += step)
+            {
+                if ((new Vector<byte>(row.Slice(i, step)) & AlphaMask) != Vector<byte>.Zero)
+                {
+                    for (var pos = i + 3; pos < i + step; pos += 4)
+                    {
+                        if (row[pos] != 0)
+                        {
+                            return pos >> 2;
+                        }
+                    }
+                }
+            }
+        }
+
+        for (var pos = i + 3; pos < row.Length; pos += 4)
+        {
+            if (row[pos] != 0)
+            {
+                return pos >> 2;
+            }
+        }
+
+        return -1;
+    }
+
+    private static int LastOpaque(ReadOnlySpan<byte> row)
+    {
+        var step = Vector<byte>.Count;
+        var i = row.Length;
+        if (Vector.IsHardwareAccelerated && row.Length >= step)
+        {
+            for (; i - step >= 0; i -= step)
+            {
+                if ((new Vector<byte>(row.Slice(i - step, step)) & AlphaMask) != Vector<byte>.Zero)
+                {
+                    for (var pos = i - 1; pos >= i - step; pos -= 4)
+                    {
+                        if (row[pos] != 0)
+                        {
+                            return pos >> 2;
+                        }
+                    }
+                }
+            }
+        }
+
+        for (var pos = i - 1; pos >= 0; pos -= 4)
+        {
+            if (row[pos] != 0)
+            {
+                return pos >> 2;
+            }
+        }
+
+        return -1;
+    }
+
+    [Benchmark] public int CropTransparentSides_Current() { Cur_FindOpaqueSides(_line, LineWidth, LineHeight, out var l, out var r); return l + r; }
+    [Benchmark] public int CropTransparentSides_RowMajor() { New_FindOpaqueSides(_line, LineWidth, LineHeight, out var l, out var r); return l + r; }
+
+    // The mutating benchmarks below restore _scratch from _line first; this measures that
+    // restore alone so the copy can be subtracted from both sides of each pair.
+    [Benchmark] public void Scratch_CopyOnly() => _line.CopyTo(_scratch, 0);
+
+    // ================================================================ 6. Fill
+
+    private const byte FillB = 20, FillG = 40, FillR = 60, FillA = 200;
+
+    private static void Cur_Fill(byte[] data)
+    {
+        for (var i = 0; i < data.Length; i += 4)
+        {
+            data[i] = FillB;
+            data[i + 1] = FillG;
+            data[i + 2] = FillR;
+            data[i + 3] = FillA;
+        }
+    }
+
+    private static void New_Fill(byte[] data)
+    {
+        MemoryMarshal.Cast<byte, uint>(data.AsSpan()).Fill(Pack(FillB, FillG, FillR, FillA));
+    }
+
+    private static uint Pack(byte b, byte g, byte r, byte a)
+    {
+        Span<byte> bytes = stackalloc byte[4];
+        bytes[0] = b;
+        bytes[1] = g;
+        bytes[2] = r;
+        bytes[3] = a;
+        return MemoryMarshal.Read<uint>(bytes);
+    }
+
+    [Benchmark] public void Fill_Current() { _line.CopyTo(_scratch, 0); Cur_Fill(_scratch); }
+    [Benchmark] public void Fill_SpanFill() { _line.CopyTo(_scratch, 0); New_Fill(_scratch); }
+
+    // ================================================================ 7. InvertColors
+
+    private static void Cur_InvertColors(byte[] data)
+    {
+        for (var i = 0; i < data.Length; i += 4)
+        {
+            data[i] = (byte)~data[i];
+            data[i + 1] = (byte)~data[i + 1];
+            data[i + 2] = (byte)~data[i + 2];
+        }
+    }
+
+    private static void New_InvertColors(byte[] data)
+    {
+        var i = 0;
+        var step = Vector<byte>.Count;
+        if (Vector.IsHardwareAccelerated && data.Length >= step)
+        {
+            var span = data.AsSpan();
+            for (; i <= data.Length - step; i += step)
+            {
+                (new Vector<byte>(span.Slice(i, step)) ^ RgbMask).CopyTo(span.Slice(i, step));
+            }
+        }
+
+        for (; i < data.Length; i += 4)
+        {
+            data[i] = (byte)~data[i];
+            data[i + 1] = (byte)~data[i + 1];
+            data[i + 2] = (byte)~data[i + 2];
+        }
+    }
+
+    [Benchmark] public void InvertColors_Current() { _line.CopyTo(_scratch, 0); Cur_InvertColors(_scratch); }
+    [Benchmark] public void InvertColors_Simd() { _line.CopyTo(_scratch, 0); New_InvertColors(_scratch); }
+
+    // ================================================================ 8. ReplaceTransparentWith
+
+    private static void Cur_ReplaceTransparentWith(byte[] data)
+    {
+        for (var i = 0; i < data.Length; i += 4)
+        {
+            if (data[i + 3] < 10)
+            {
+                data[i] = FillB;
+                data[i + 1] = FillG;
+                data[i + 2] = FillR;
+                data[i + 3] = FillA;
+            }
+        }
+    }
+
+    private static void New_ReplaceTransparentWith(byte[] data)
+    {
+        var replacement = Pack(FillB, FillG, FillR, FillA);
+        var i = 0;
+        var step = Vector<byte>.Count;
+        if (Vector.IsHardwareAccelerated && BitConverter.IsLittleEndian && data.Length >= step)
+        {
+            var span = data.AsSpan();
+            var alphaMask = new Vector<uint>(0xFF000000u);
+            var limit = new Vector<uint>(10u << 24);
+            var replacementVector = new Vector<uint>(replacement);
+            for (; i <= data.Length - step; i += step)
+            {
+                var raw = Vector.AsVectorUInt32(new Vector<byte>(span.Slice(i, step)));
+                var isTransparent = Vector.LessThan(raw & alphaMask, limit);
+                Vector.AsVectorByte(Vector.ConditionalSelect(isTransparent, replacementVector, raw)).CopyTo(span.Slice(i, step));
+            }
+        }
+
+        var pixels = MemoryMarshal.Cast<byte, uint>(data.AsSpan());
+        for (var p = i / 4; p < pixels.Length; p++)
+        {
+            if (data[p * 4 + 3] < 10)
+            {
+                pixels[p] = replacement;
+            }
+        }
+    }
+
+    [Benchmark] public void ReplaceTransparentWith_Current() { _line.CopyTo(_scratch, 0); Cur_ReplaceTransparentWith(_scratch); }
+    [Benchmark] public void ReplaceTransparentWith_Simd() { _line.CopyTo(_scratch, 0); New_ReplaceTransparentWith(_scratch); }
+
+    // ================================================================ 9. MakeOneColor
+
+    private static void Cur_MakeOneColor(byte[] data)
+    {
+        for (var i = 0; i < data.Length; i += 4)
+        {
+            if (data[i] > 20)
+            {
+                data[i] = FillB;
+                data[i + 1] = FillG;
+                data[i + 2] = FillR;
+                data[i + 3] = FillA;
+            }
+            else
+            {
+                data[i] = 0;
+                data[i + 1] = 0;
+                data[i + 2] = 0;
+                data[i + 3] = 0;
+            }
+        }
+    }
+
+    private static void New_MakeOneColor(byte[] data)
+    {
+        var color = Pack(FillB, FillG, FillR, FillA);
+        var i = 0;
+        var step = Vector<byte>.Count;
+        if (Vector.IsHardwareAccelerated && BitConverter.IsLittleEndian && data.Length >= step)
+        {
+            var span = data.AsSpan();
+            var lowByte = new Vector<uint>(0x000000FFu);
+            var limit = new Vector<uint>(20u);
+            var colorVector = new Vector<uint>(color);
+            for (; i <= data.Length - step; i += step)
+            {
+                var raw = Vector.AsVectorUInt32(new Vector<byte>(span.Slice(i, step)));
+                var keep = Vector.GreaterThan(raw & lowByte, limit);
+                Vector.AsVectorByte(Vector.ConditionalSelect(keep, colorVector, Vector<uint>.Zero)).CopyTo(span.Slice(i, step));
+            }
+        }
+
+        var pixels = MemoryMarshal.Cast<byte, uint>(data.AsSpan());
+        for (var p = i / 4; p < pixels.Length; p++)
+        {
+            pixels[p] = data[p * 4] > 20 ? color : 0u;
+        }
+    }
+
+    [Benchmark] public void MakeOneColor_Current() { _line.CopyTo(_scratch, 0); Cur_MakeOneColor(_scratch); }
+    [Benchmark] public void MakeOneColor_Simd() { _line.CopyTo(_scratch, 0); New_MakeOneColor(_scratch); }
+
+    // ================================================================ 10. MakeTwoColor
+
+    private static readonly byte[] TwoColorBackground = { 10, 20, 30, 255 };
+    private static readonly byte[] TwoColorForeground = { 250, 240, 230, 255 };
+
+    private static void Cur_MakeTwoColor(byte[] data, int minRgb)
+    {
+        for (var i = 0; i < data.Length; i += 4)
+        {
+            if (data[i + 3] < 1 || data[i] + data[i + 1] + data[i + 2] < minRgb)
+            {
+                Buffer.BlockCopy(TwoColorBackground, 0, data, i, 4);
+            }
+            else
+            {
+                Buffer.BlockCopy(TwoColorForeground, 0, data, i, 4);
+            }
+        }
+    }
+
+    private static void New_MakeTwoColor(byte[] data, int minRgb)
+    {
+        var background = MemoryMarshal.Read<uint>(TwoColorBackground);
+        var foreground = MemoryMarshal.Read<uint>(TwoColorForeground);
+        var i = 0;
+        var step = Vector<byte>.Count;
+        if (Vector.IsHardwareAccelerated && BitConverter.IsLittleEndian && minRgb >= 0 && data.Length >= step + 2)
+        {
+            var lowByte = new Vector<uint>(0x000000FFu);
+            var alphaMask = new Vector<uint>(0xFF000000u);
+            var limit = new Vector<uint>((uint)minRgb);
+            var backgroundVector = new Vector<uint>(background);
+            var foregroundVector = new Vector<uint>(foreground);
+            for (; i + step + 2 <= data.Length; i += step)
+            {
+                var raw = Vector.AsVectorUInt32(new Vector<byte>(data, i));
+                var green = Vector.AsVectorUInt32(new Vector<byte>(data, i + 1)) & lowByte;
+                var red = Vector.AsVectorUInt32(new Vector<byte>(data, i + 2)) & lowByte;
+                var sum = (raw & lowByte) + green + red;
+                var isBackground = Vector.Equals(raw & alphaMask, Vector<uint>.Zero) | Vector.LessThan(sum, limit);
+                Vector.AsVectorByte(Vector.ConditionalSelect(isBackground, backgroundVector, foregroundVector)).CopyTo(data, i);
+            }
+        }
+
+        var pixels = MemoryMarshal.Cast<byte, uint>(data.AsSpan());
+        for (var p = i / 4; p < pixels.Length; p++)
+        {
+            var b = p * 4;
+            pixels[p] = data[b + 3] < 1 || data[b] + data[b + 1] + data[b + 2] < minRgb ? background : foreground;
+        }
+    }
+
+    [Benchmark] public void MakeTwoColor_Current() { _line.CopyTo(_scratch, 0); Cur_MakeTwoColor(_scratch, 300); }
+    [Benchmark] public void MakeTwoColor_Simd() { _line.CopyTo(_scratch, 0); New_MakeTwoColor(_scratch, 300); }
+
+    // ================================================================ 11. spectrogram pixel write
+
+    private static unsafe void Cur_WritePixels(byte[] bitmap, byte[] colorIndexes, uint[] palette, int width, int height)
+    {
+        var stride = width * 4;
+        fixed (byte* pixels = bitmap)
+        fixed (uint* pal = palette)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                var xOffset = x * 4;
+                for (var y = 0; y < height; y++)
+                {
+                    var color = pal[colorIndexes[x * height + y]];
+                    var pixelY = height - y - 1;
+                    var pixel = pixels + pixelY * stride + xOffset;
+                    pixel[0] = (byte)color;
+                    pixel[1] = (byte)(color >> 8);
+                    pixel[2] = (byte)(color >> 16);
+                    pixel[3] = (byte)(color >> 24);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// One 32-bit store per pixel instead of four byte stores, and the destination address is
+    /// walked backwards a row at a time instead of being recomputed with a multiply per pixel.
+    /// </summary>
+    private static unsafe void New_WritePixels(byte[] bitmap, byte[] colorIndexes, uint[] palette, int width, int height)
+    {
+        var stride = width * 4;
+        fixed (byte* pixels = bitmap)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                var offset = x * height;
+                var dst = pixels + (height - 1) * stride + x * 4;
+                for (var y = 0; y < height; y++)
+                {
+                    *(uint*)dst = palette[colorIndexes[offset + y]];
+                    dst -= stride;
+                }
+            }
+        }
+    }
+
+    [Benchmark] public void SpectrogramWritePixels_Current() => Cur_WritePixels(_bitmap, _colorIndexes, _paletteRgba, ImageWidth, Nfft / 2);
+    [Benchmark] public void SpectrogramWritePixels_PackedStore() => New_WritePixels(_bitmap, _colorIndexes, _paletteRgba, ImageWidth, Nfft / 2);
+
+    // ================================================================ 12. float[] -> double[] chunk
+
+    private static void Cur_CopyChunk(float[] source, int offset, double[] destination, int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            destination[i] = source[offset + i];
+        }
+    }
+
+    private static void New_CopyChunk(float[] source, int offset, double[] destination, int count)
+    {
+        var src = source.AsSpan(offset, count);
+        var dst = destination.AsSpan(0, count);
+        var i = 0;
+        var step = Vector<float>.Count;
+        if (Vector.IsHardwareAccelerated && count >= step)
+        {
+            for (; i <= count - step; i += step)
+            {
+                Vector.Widen(new Vector<float>(src.Slice(i, step)), out var low, out var high);
+                low.CopyTo(dst.Slice(i, Vector<double>.Count));
+                high.CopyTo(dst.Slice(i + Vector<double>.Count, Vector<double>.Count));
+            }
+        }
+
+        for (; i < count; i++)
+        {
+            dst[i] = src[i];
+        }
+    }
+
+    [Benchmark] public void SpectrogramChunkCopy_Current() => Cur_CopyChunk(_rawSamples, 0, _chunkSamples, _chunkSamples.Length);
+    [Benchmark] public void SpectrogramChunkCopy_Widen() => New_CopyChunk(_rawSamples, 0, _chunkSamples, _chunkSamples.Length);
+}

--- a/tests/libuilogic/Ocr/NikseBitmap2VectorPathTests.cs
+++ b/tests/libuilogic/Ocr/NikseBitmap2VectorPathTests.cs
@@ -1,0 +1,372 @@
+using Nikse.SubtitleEdit.UiLogic.Ocr;
+using SkiaSharp;
+
+namespace LibUiLogicTests.Ocr;
+
+/// <summary>
+/// The whole-buffer scans and pixel writes on <see cref="NikseBitmap2"/> run a vector pass with
+/// a scalar tail. These tests pin every one of them to the plain byte-at-a-time implementation
+/// they replaced, over image widths that land on, before and after a vector boundary (and the
+/// 1-pixel and 1-row degenerate cases), so a wrong tail or a wrong lane mask fails here rather
+/// than showing up as a subtly mis-cropped OCR glyph.
+/// </summary>
+public class NikseBitmap2VectorPathTests
+{
+    public static TheoryData<int, int, int> Sizes()
+    {
+        var data = new TheoryData<int, int, int>();
+        var seed = 1;
+        foreach (var width in new[] { 1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 33, 64, 137 })
+        {
+            foreach (var height in new[] { 1, 2, 5, 17 })
+            {
+                data.Add(width, height, seed++);
+            }
+        }
+
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(Sizes))]
+    public void TransparencyScans_MatchScalarReference(int width, int height, int seed)
+    {
+        foreach (var pixels in Images(width, height, seed))
+        {
+            var bmp = new NikseBitmap2(width, height, (byte[])pixels.Clone());
+
+            Assert.Equal(RefIsImageOnlyTransparent(pixels), bmp.IsImageOnlyTransparent());
+            Assert.Equal(RefCalcBottomTransparent(pixels, width, height), bmp.CalcBottomTransparent());
+
+            for (var y = 0; y < height; y++)
+            {
+                Assert.Equal(RefRowAlphaAtMost(pixels, width, y, 0), bmp.IsLineTransparent(y));
+                Assert.Equal(RefRowAlphaAtMost(pixels, width, y, 1), bmp.IsHorizontalLineTransparent(y));
+            }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Sizes))]
+    public void CropTopTransparent_MatchesScalarReference(int width, int height, int seed)
+    {
+        foreach (var pixels in Images(width, height, seed))
+        {
+            foreach (var margin in new[] { 0, 1, 3 })
+            {
+                var expectedTop = RefCropTopTransparent(pixels, width, height, margin, out var expectedPixels, out var expectedHeight);
+                var bmp = new NikseBitmap2(width, height, (byte[])pixels.Clone());
+                Assert.Equal(expectedTop, bmp.CropTopTransparent(margin));
+                Assert.Equal(expectedHeight, bmp.Height);
+                Assert.Equal(expectedPixels, bmp.GetPixelData().ToArray());
+            }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Sizes))]
+    public void CropTransparentSides_MatchesScalarReference(int width, int height, int seed)
+    {
+        foreach (var pixels in Images(width, height, seed))
+        {
+            RefOpaqueSides(pixels, width, height, out var left, out var right);
+            var cropped = new NikseBitmap2(width, height, (byte[])pixels.Clone()).CropTransparentSides();
+
+            if (left < 0 || (left == 0 && right == width - 1))
+            {
+                Assert.Equal(width, cropped.Width);
+                Assert.Equal(pixels, cropped.GetPixelData().ToArray());
+                continue;
+            }
+
+            Assert.Equal(right - left + 1, cropped.Width);
+            Assert.Equal(height, cropped.Height);
+            var expected = new NikseBitmap2(width, height, (byte[])pixels.Clone())
+                .CopyRectangle(new NikseRectangle(left, 0, right - left + 1, height));
+            Assert.Equal(expected.GetPixelData().ToArray(), cropped.GetPixelData().ToArray());
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Sizes))]
+    public void PixelWrites_MatchScalarReference(int width, int height, int seed)
+    {
+        var color = new SKColor(11, 200, 77, 190);
+        var background = new SKColor(1, 2, 3);
+        var foreground = new SKColor(250, 240, 230);
+
+        foreach (var pixels in Images(width, height, seed))
+        {
+            AssertSameWrite(pixels, width, height, RefFill, b => b.Fill(color));
+            AssertSameWrite(pixels, width, height, RefInvertColors, b => b.InvertColors());
+            AssertSameWrite(pixels, width, height, RefReplaceTransparentWith, b => b.ReplaceTransparentWith(color));
+            AssertSameWrite(pixels, width, height, RefMakeOneColor, b => b.MakeOneColor(color));
+        }
+
+        foreach (var pixels in Images(width, height, seed))
+        {
+            foreach (var minRgb in new[] { 0, 1, 30, 300, 600, 765, 766 })
+            {
+                AssertSameWrite(pixels, width, height, p => RefMakeTwoColor(p, minRgb, 0, 0, 0, 0, 255, 255, 255, 255), b => b.MakeTwoColor(minRgb));
+                AssertSameWrite(pixels, width, height,
+                    p => RefMakeTwoColor(p, minRgb, background.Blue, background.Green, background.Red, 255, foreground.Blue, foreground.Green, foreground.Red, 255),
+                    b => b.MakeTwoColor(minRgb, background, foreground));
+            }
+        }
+
+        return;
+
+        void AssertSameWrite(byte[] pixels, int w, int h, Action<byte[]> reference, Action<NikseBitmap2> candidate)
+        {
+            var expected = (byte[])pixels.Clone();
+            reference(expected);
+            var bmp = new NikseBitmap2(w, h, (byte[])pixels.Clone());
+            candidate(bmp);
+            Assert.Equal(expected, bmp.GetPixelData().ToArray());
+        }
+
+        void RefFill(byte[] data)
+        {
+            for (var i = 0; i < data.Length; i += 4)
+            {
+                data[i] = color.Blue;
+                data[i + 1] = color.Green;
+                data[i + 2] = color.Red;
+                data[i + 3] = color.Alpha;
+            }
+        }
+
+        void RefReplaceTransparentWith(byte[] data)
+        {
+            for (var i = 0; i < data.Length; i += 4)
+            {
+                if (data[i + 3] < 10)
+                {
+                    data[i] = color.Blue;
+                    data[i + 1] = color.Green;
+                    data[i + 2] = color.Red;
+                    data[i + 3] = color.Alpha;
+                }
+            }
+        }
+
+        void RefMakeOneColor(byte[] data)
+        {
+            for (var i = 0; i < data.Length; i += 4)
+            {
+                if (data[i] > 20)
+                {
+                    data[i] = color.Blue;
+                    data[i + 1] = color.Green;
+                    data[i + 2] = color.Red;
+                    data[i + 3] = color.Alpha;
+                }
+                else
+                {
+                    data[i] = 0;
+                    data[i + 1] = 0;
+                    data[i + 2] = 0;
+                    data[i + 3] = 0;
+                }
+            }
+        }
+    }
+
+    private static void RefInvertColors(byte[] data)
+    {
+        for (var i = 0; i < data.Length; i += 4)
+        {
+            data[i] = (byte)~data[i];
+            data[i + 1] = (byte)~data[i + 1];
+            data[i + 2] = (byte)~data[i + 2];
+        }
+    }
+
+    private static void RefMakeTwoColor(byte[] data, int minRgb, byte bgB, byte bgG, byte bgR, byte bgA, byte fgB, byte fgG, byte fgR, byte fgA)
+    {
+        for (var i = 0; i < data.Length; i += 4)
+        {
+            if (data[i + 3] < 1 || data[i] + data[i + 1] + data[i + 2] < minRgb)
+            {
+                data[i] = bgB;
+                data[i + 1] = bgG;
+                data[i + 2] = bgR;
+                data[i + 3] = bgA;
+            }
+            else
+            {
+                data[i] = fgB;
+                data[i + 1] = fgG;
+                data[i + 2] = fgR;
+                data[i + 3] = fgA;
+            }
+        }
+    }
+
+    private static bool RefIsImageOnlyTransparent(byte[] data)
+    {
+        for (var i = 0; i < data.Length; i += 4)
+        {
+            if (data[i + 3] != 0)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool RefRowAlphaAtMost(byte[] data, int width, int y, byte threshold)
+    {
+        var widthX4 = width * 4;
+        for (var pos = y * widthX4 + 3; pos < y * widthX4 + widthX4; pos += 4)
+        {
+            if (data[pos] > threshold)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static int RefCalcBottomTransparent(byte[] data, int width, int height)
+    {
+        var y = height - 1;
+        for (; y > 0; y--)
+        {
+            if (!RefRowAlphaAtMost(data, width, y, 1))
+            {
+                break;
+            }
+        }
+
+        return height - y;
+    }
+
+    private static int RefCropTopTransparent(byte[] data, int width, int height, int minimumMargin, out byte[] result, out int newHeightOut)
+    {
+        var widthX4 = width * 4;
+        var done = false;
+        var newTop = 0;
+        var y = 0;
+        while (!done && y < height)
+        {
+            var x = 0;
+            while (!done && x < width)
+            {
+                if (data[x * 4 + y * widthX4 + 3] > 10)
+                {
+                    done = true;
+                    newTop = y - minimumMargin;
+                    if (newTop < 0)
+                    {
+                        newTop = 0;
+                    }
+                }
+
+                x++;
+            }
+
+            y++;
+        }
+
+        if (newTop == 0)
+        {
+            result = (byte[])data.Clone();
+            newHeightOut = height;
+            return 0;
+        }
+
+        newHeightOut = height - newTop;
+        result = new byte[newHeightOut * widthX4];
+        Buffer.BlockCopy(data, newTop * widthX4, result, 0, result.Length);
+        return newTop;
+    }
+
+    private static void RefOpaqueSides(byte[] data, int width, int height, out int left, out int right)
+    {
+        var widthX4 = width * 4;
+        left = -1;
+        right = -1;
+        for (var x = 0; x < width; x++)
+        {
+            for (var y = 0; y < height; y++)
+            {
+                if (data[x * 4 + y * widthX4 + 3] != 0)
+                {
+                    if (left < 0)
+                    {
+                        left = x;
+                    }
+
+                    right = x;
+                    break;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// A battery per size: fully transparent, fully opaque, opaque only in the first / last
+    /// column, opaque only in the first / last row, alpha exactly on the 1 and 10 thresholds,
+    /// and random noise.
+    /// </summary>
+    private static IEnumerable<byte[]> Images(int width, int height, int seed)
+    {
+        var count = width * height * 4;
+
+        yield return new byte[count];
+
+        var opaque = new byte[count];
+        Array.Fill(opaque, (byte)255);
+        yield return opaque;
+
+        foreach (var alpha in new byte[] { 1, 2, 10, 11, 255 })
+        {
+            var firstColumn = new byte[count];
+            var lastColumn = new byte[count];
+            var firstRow = new byte[count];
+            var lastRow = new byte[count];
+            for (var y = 0; y < height; y++)
+            {
+                firstColumn[y * width * 4 + 3] = alpha;
+                lastColumn[y * width * 4 + (width - 1) * 4 + 3] = alpha;
+            }
+
+            for (var x = 0; x < width; x++)
+            {
+                firstRow[x * 4 + 3] = alpha;
+                lastRow[(height - 1) * width * 4 + x * 4 + 3] = alpha;
+            }
+
+            yield return firstColumn;
+            yield return lastColumn;
+            yield return firstRow;
+            yield return lastRow;
+        }
+
+        var rnd = new Random(seed);
+        for (var i = 0; i < 3; i++)
+        {
+            var noise = new byte[count];
+            rnd.NextBytes(noise);
+            yield return noise;
+        }
+
+        // Sparse: mostly transparent with a few opaque pixels, like a real glyph row.
+        var sparse = new byte[count];
+        for (var i = 0; i < count / 4; i++)
+        {
+            if (rnd.Next(6) == 0)
+            {
+                sparse[i * 4] = (byte)rnd.Next(256);
+                sparse[i * 4 + 1] = (byte)rnd.Next(256);
+                sparse[i * 4 + 2] = (byte)rnd.Next(256);
+                sparse[i * 4 + 3] = (byte)rnd.Next(1, 256);
+            }
+        }
+
+        yield return sparse;
+    }
+}


### PR DESCRIPTION
Round 13 of the performance hunt. Twelve wins, all on paths that touch every pixel of every image.

`NikseBitmap2` is the bitmap every OCR image and every split character goes through, and it had never been vectorized (its libse sibling `NikseBitmap` was, in earlier rounds). Every method walked the BGRA buffer one byte at a time; `MakeTwoColor` made a `Buffer.BlockCopy` **call per pixel**; and two of the crops walked columns, which costs a cache line per pixel on a row-major buffer.

## What changed

**`src/libuilogic/Ocr/NikseBitmap2.cs`**

| | Change |
| --- | --- |
| `IsLineTransparent` | SIMD alpha-lane row scan |
| `IsHorizontalLineTransparent` / `CalcBottomTransparent` | same scan, alpha > 1 |
| `IsImageOnlyTransparent` | SIMD whole-buffer scan |
| `CropTopTransparent` | row scan instead of the nested x/y walk |
| `CropTransparentSides` | row-major, scanning only the prefix/suffix that can still move the bounds (both shrink to nothing within a few rows) |
| `Fill` | `Span<uint>.Fill` instead of four byte writes per pixel |
| `InvertColors` | vector XOR with a colour-lane mask |
| `ReplaceTransparentWith` | vector compare + select |
| `MakeOneColor` | vector compare + select |
| `MakeTwoColor` (both overloads) | packed pixel store, no per-pixel `BlockCopy`, with a vector pass in front |

**`src/ui/Logic/Media/WaveToVisualizer2.cs`** (spectrogram build)

- `SpectrogramDrawer.Draw` — palette pre-packed into the bitmap's own RGBA word order, so a pixel is one 32-bit store instead of four byte stores; the destination steps back a row at a time instead of being recomputed with a multiply per pixel. The palette stays a bounds-checked array access, so an out-of-range magnitude still throws rather than writing past it.
- `GenerateImagesFromRawData` — the per-chunk `float[]` -> `double[]` copy now widens a vector at a time. Widening is exact, so the result is bit-identical.

## Numbers

BenchmarkDotNet, `tests/benchmarks/PerfHuntRound13Benchmarks.cs`, Apple M4, .NET 10, default job with 15 iterations. Input is a 1400x60 cropped subtitle line (transparent background, anti-aliased glyphs). The mutating pairs restore the buffer first; the 4.97 us restore is subtracted below and measured on its own as `Scratch_CopyOnly`.

| Method | Before | After | |
| --- | ---: | ---: | ---: |
| `Fill` | 51.98 us | 3.29 us | **15.8x** |
| `MakeOneColor` | 74.38 us | 10.01 us | **7.4x** |
| `InvertColors` | 59.97 us | 8.32 us | **7.2x** |
| `ReplaceTransparentWith` | 62.04 us | 9.27 us | **6.7x** |
| `CropTransparentSides` | 19.31 us | 3.54 us | **5.5x** |
| `CropTopTransparent` | 6.15 us | 1.32 us | **4.7x** |
| `MakeTwoColor` | 123.18 us | 29.23 us | **4.2x** |
| `IsImageOnlyTransparent` | 35.65 us | 10.53 us | **3.4x** |
| `IsLineTransparent` | 7.41 us | 2.97 us | **2.5x** |
| `CalcBottomTransparent` | 27.03 us | 10.83 us | **2.5x** |
| Spectrogram pixel write | 844.79 us | 412.46 us | **2.0x** |
| Spectrogram chunk widen | 81.14 us | 59.07 us | **1.4x** |

StdDev was under 2% of the mean on every row except `MakeTwoColor_Current` and the two `*_Current` scans. Allocations are unchanged (zero) everywhere.

The benchmark class is self-contained: the shipped implementation and each candidate live in it side by side with their own direct call site, and `[GlobalSetup]` asserts they agree before any timing runs. No stash baseline, no delegate call site.

## Correctness

`tests/libuilogic/Ocr/NikseBitmap2VectorPathTests.cs` pins every rewritten method to the scalar implementation it replaced, across 56 width/height combinations — widths that land on, just before and just after a vector boundary, plus the 1-pixel-wide and 1-row degenerate cases — against a battery of fully transparent, fully opaque, first/last-column-only, first/last-row-only, alpha-exactly-on-the-1-and-10-thresholds, random-noise and sparse-glyph images.

The transparency scans mask down to each pixel's alpha byte, so they are byte-order neutral. The three that have to read channels by value (`ReplaceTransparentWith`, `MakeOneColor`, `MakeTwoColor`) are guarded on `BitConverter.IsLittleEndian` and fall through to the scalar path otherwise, matching how `NikseBitmap.MakeTwoColorVector` already does it.

Full suites green locally: libuilogic 495, libse 1399, seconv 380, UI 3297 — 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)