### PR TITLE
Stop the grid color guard from dropping legible colors

### DIFF
--- a/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
+++ b/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
@@ -1250,7 +1250,13 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
 
     // Below this WCAG contrast ratio a color is treated as unusable against the grid
     // background (pure white on white is 1.0; white on the default dark background is ~17).
-    private const double MinimumVisibleContrast = 1.3;
+    //
+    // 1.3 caught colors that were perfectly legible: on the mid-grey theme in #13929 a speaker's
+    // #5C1FF4 sits at 1.268 and lost its color, while the three other speakers in the same file
+    // kept theirs. The cases this guard exists for are far lower - a color matching the
+    // background exactly is 1.0, and the #232323-on-dark case from #13824 is 1.06-1.15 - so the
+    // threshold can come down without letting any of them back in.
+    private const double MinimumVisibleContrast = 1.2;
 
     /// <summary>
     /// Test hook: the grid background normally follows the active theme, which headless unit

--- a/tests/UI/Logic/ValueConverters/ValueConverterTests.cs
+++ b/tests/UI/Logic/ValueConverters/ValueConverterTests.cs
@@ -381,6 +381,45 @@ public class ValueConverterTests : IDisposable
         Assert.False(run.IsSet(TextElement.ForegroundProperty));
     }
 
+    // Issue #13929: the guard was catching colors that read perfectly well. On a mid-grey theme
+    // one speaker's #5C1FF4 (contrast 1.268) rendered in the default foreground while the three
+    // other speakers in the same file kept their colors, which looks like a bug rather than a
+    // readability aid. The genuinely invisible cases above sit at 1.0-1.15, well clear of it.
+    [AvaloniaFact]
+    public void ShowFormatting_ReadableFontTagColorOnAMidGreyThemeIsKept()
+    {
+        TextWithSubtitleSyntaxHighlightingConverter.GridBackgroundOverride = () => Color.FromRgb(73, 73, 73);
+        try
+        {
+            var run = SingleRun(Highlight("<font color=\"#5C1FF4\">x</font>",
+                SubtitleGridFormattingTypes.ShowFormatting));
+
+            Assert.Equal(Color.FromRgb(0x5C, 0x1F, 0xF4), (run.Foreground as ISolidColorBrush)?.Color);
+        }
+        finally
+        {
+            TextWithSubtitleSyntaxHighlightingConverter.GridBackgroundOverride = null;
+        }
+    }
+
+    // The same background must still drop a color that really does vanish into it.
+    [AvaloniaFact]
+    public void ShowFormatting_ColorMatchingAMidGreyThemeIsStillDropped()
+    {
+        TextWithSubtitleSyntaxHighlightingConverter.GridBackgroundOverride = () => Color.FromRgb(73, 73, 73);
+        try
+        {
+            var run = SingleRun(Highlight("<font color=\"#494949\">x</font>",
+                SubtitleGridFormattingTypes.ShowFormatting));
+
+            Assert.False(run.IsSet(TextElement.ForegroundProperty));
+        }
+        finally
+        {
+            TextWithSubtitleSyntaxHighlightingConverter.GridBackgroundOverride = null;
+        }
+    }
+
     [AvaloniaFact]
     public void HideTags_StripsMarkupAndAppliesNoStyling()
     {


### PR DESCRIPTION
Fixes #13929

### What happens

A dubbing script colors each speaker. Three speakers keep their color in the grid; one renders in the default near-white.

The reporter guessed it was `#E51085` that failed. Sampling the pixels in their screenshot, it is the other way round — `#E51085` renders as exactly `(229, 27, 130)`. The one that fails is **`#5C1FF4`**, which comes out `(220, 220, 220)`.

### Why

The readability guard from #13824 drops an authored color whose WCAG contrast against the grid background is below `MinimumVisibleContrast = 1.3`.

Their theme's grid background is `#494949` — sampled from the screenshot, a mid-grey, not the default dark. Against it:

| color | contrast | result |
|---|---|---|
| `#5C1FF4` | **1.268** | dropped |
| `#E51085` | 2.03 | kept |
| `#12E2BE` | 5.42 | kept |
| `#1AC3DB` | 4.23 | kept |

Exactly the screenshot. The guard is firing on a color that is perfectly legible — 1.268 is not an invisible color, it is a slightly dark blue on grey.

### The change

`MinimumVisibleContrast` 1.3 → 1.2.

The cases the guard exists for are nowhere near the new line:

| case | contrast |
|---|---|
| color matching the background exactly | 1.00 |
| `#232323` on dark background (#13824's case) | 1.06 |
| `#232323` on the lighter dark background | 1.15 |
| **`#5C1FF4` on mid-grey (this issue)** | **1.27** |

So there is clear air on both sides — nothing #13824 was protecting against comes back.

### What I tried first, and why this instead

My first attempt kept the 1.3 threshold but *nudged* an unreadable color away from the background instead of discarding it, so a speaker would keep their hue and stay readable. It fixed this issue (`#5C1FF4` → `#662DF5`, one step, visibly the same blue) but it made #13824's case worse: `#232323` on a dark background became `#3E3E3E`, which clears 1.3 on paper but is much harder to read than the default foreground it replaced. It also meant rewriting the four #13824 tests to invert their contract.

Adjusting the threshold fixes the reported case without inventing colors the author did not write, and leaves #13824's behaviour and all four of its tests untouched.

### Testing

Two tests added next to #13824's, both driving the converter through the real background override:

- `ShowFormatting_ReadableFontTagColorOnAMidGreyThemeIsKept` — `#5C1FF4` on `#494949` keeps its exact authored color. Fails on main, passes here.
- `ShowFormatting_ColorMatchingAMidGreyThemeIsStillDropped` — `#494949` on `#494949` is still dropped, so the lower threshold did not open a hole on that same background.

The four existing #13824 tests are unchanged and still pass.

Full UI suite: 3309 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)