### PR TITLE
Let the preview subtitle use the letterbox bars

### DIFF
--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -1040,6 +1040,9 @@ public class SettingsPage : UserControl
         var numericUpDownMargin = UiUtil.MakeNumericUpDownOneDecimal(1, 1000, 130, vm, nameof(vm.MpvPreviewMargin));
         numericUpDownMargin.Increment = 1;
 
+        var checkBoxMarginIsPartOfSubtitleArea = UiUtil.MakeCheckBox(
+            Se.Language.Options.Settings.MarginIsPartOfSubtitleArea, vm, nameof(vm.MpvPreviewMarginIsPartOfSubtitleArea));
+
         var labelColorPrimary = UiUtil.MakeLabel(Se.Language.Assa.Primary);
         var colorPickerPrimary = UiUtil.MakeColorPickerButton(vm, nameof(vm.MpvPreviewColorPrimary));
 
@@ -1053,6 +1056,7 @@ public class SettingsPage : UserControl
         {
             RowDefinitions =
             {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
@@ -1090,16 +1094,18 @@ public class SettingsPage : UserControl
         grid.Add(labelMargin, 5);
         grid.Add(numericUpDownMargin, 5, 1);
 
-        grid.Add(labelColorPrimary, 6);
-        grid.Add(colorPickerPrimary, 6, 1);
+        grid.Add(checkBoxMarginIsPartOfSubtitleArea, 6, 0, 1, 2);
 
-        grid.Add(labelColorOutline, 7);
-        grid.Add(colorPickerOutline, 7, 1);
+        grid.Add(labelColorPrimary, 7);
+        grid.Add(colorPickerPrimary, 7, 1);
 
-        grid.Add(labelColorShadow, 8);
-        grid.Add(colorPickerShadow, 8, 1);
+        grid.Add(labelColorOutline, 8);
+        grid.Add(colorPickerOutline, 8, 1);
 
-        grid.Add(MakeBorderView(vm), 9, 0, 1, 2);
+        grid.Add(labelColorShadow, 9);
+        grid.Add(colorPickerShadow, 9, 1);
+
+        grid.Add(MakeBorderView(vm), 10, 0, 1, 2);
 
         return UiUtil.MakeBorderForControl(grid);
     }

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -108,6 +108,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private AlignmentItem _mpvPreviewSelectedFontAlignment;
     [ObservableProperty] private int _mpvPreviewMargin;
     [ObservableProperty] private bool _mpvPreviewUsePositionFromFile;
+    [ObservableProperty] private bool _mpvPreviewMarginIsPartOfSubtitleArea;
     [ObservableProperty] private Color _mpvPreviewColorPrimary;
     [ObservableProperty] private Color _mpvPreviewColorOutline;
     [ObservableProperty] private Color _mpvPreviewColorShadow;
@@ -1043,6 +1044,7 @@ public partial class SettingsViewModel : ObservableObject
         MpvPreviewFontBold = video.MpvPreviewFontBold;
         MpvPreviewMargin = video.MpvPreviewMargin;
         MpvPreviewUsePositionFromFile = video.MpvPreviewUsePositionFromFile;
+        MpvPreviewMarginIsPartOfSubtitleArea = video.MpvPreviewMarginIsPartOfSubtitleArea;
         MpvPreviewSelectedFontAlignment = MpvPreviewFontAlignments.FirstOrDefault(p => p.Code == video.MpvPreviewAlignment) ?? MpvPreviewFontAlignments[7];
         MpvPreviewOutlineWidth = video.MpvPreviewOutlineWidth;
         MpvPreviewShadowWidth = video.MpvPreviewShadowWidth;
@@ -1869,6 +1871,7 @@ public partial class SettingsViewModel : ObservableObject
         video.MpvPreviewFontBold = MpvPreviewFontBold;
         video.MpvPreviewMargin = MpvPreviewMargin;
         video.MpvPreviewUsePositionFromFile = MpvPreviewUsePositionFromFile;
+        video.MpvPreviewMarginIsPartOfSubtitleArea = MpvPreviewMarginIsPartOfSubtitleArea;
         video.MpvPreviewOutlineWidth = MpvPreviewOutlineWidth;
         video.MpvPreviewAlignment = MpvPreviewSelectedFontAlignment.Code;
         video.MpvPreviewShadowWidth = MpvPreviewShadowWidth;

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -323,6 +323,7 @@ public class LanguageSettings
     public string MatchIconColorToDarkTheme { get; set; }
     public string SubtitlePreviewProperties { get; set; }
     public string UsePositionFromSubtitleFile { get; set; }
+    public string MarginIsPartOfSubtitleArea { get; set; }
     public string PixelWidthInfo { get; set; }
     public string SpellCheckEngineHunSpelll { get; set; }
     public string SpellCheckEngineMsWord { get; set; }
@@ -651,6 +652,7 @@ public class LanguageSettings
         MatchIconColorToDarkTheme = "Match icon color to dark theme foreground color";
         SubtitlePreviewProperties = "Subtitle preview properties";
         UsePositionFromSubtitleFile = "Use position from subtitle file (TTML/PAC/EBU STL)";
+        MarginIsPartOfSubtitleArea = "Margin is part of the subtitle area";
         PixelWidthInfo = "Green lines = max-width limit   |   Red area = text exceeds limit";
         SpellCheckEngineHunSpelll = "Hunspell";
         SpellCheckEngineMsWord = "MS Word";

--- a/src/ui/Logic/Config/SeVideo.cs
+++ b/src/ui/Logic/Config/SeVideo.cs
@@ -53,6 +53,13 @@ public class SeVideo
     public bool MpvPreviewUsePositionFromFile { get; set; }
 
     /// <summary>
+    /// Include the black bars of a letterboxed video in the area the preview subtitle may use, so
+    /// the margin can move it off the picture (#13934). Off keeps mpv's own default, where an ASS
+    /// subtitle stays inside the video frame.
+    /// </summary>
+    public bool MpvPreviewMarginIsPartOfSubtitleArea { get; set; }
+
+    /// <summary>
     /// mpv's "audio-buffer" option in seconds, applied when a player core is created. mpv's
     /// own default is 0.2 s, and that buffer is why pause/resume/seek take effect ~200 ms
     /// late - the residual the waveform playhead code has to mask. Kept small here; raise it

--- a/src/ui/Logic/Media/MpvReloader.cs
+++ b/src/ui/Logic/Media/MpvReloader.cs
@@ -69,6 +69,10 @@ public class MpvReloader : IMpvReloader
 
         try
         {
+            // Applied on every refresh, not only on load: toggling "margin is part of the
+            // subtitle area" in settings has to take effect on the video already open (#13934).
+            mpvContext.ApplySubtitleMarginArea();
+
             var uiFormatType = uiFormat.GetType();
 
             // Deep copy on the calling (UI) thread: the caller usually passes the live

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -708,6 +708,23 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         return ptr == IntPtr.Zero ? $"mpv error {error}" : Marshal.PtrToStringUTF8(ptr) ?? $"mpv error {error}";
     }
 
+    /// <summary>
+    /// Whether the black bars of a letterboxed video count as part of the area the subtitle may
+    /// use. With it on, the margin can move the preview off the picture and onto the bar, which
+    /// keeps the translation clear of burned-in forced narrative (#13934).
+    ///
+    /// sub-use-margins covers plain subtitles; an ASS subtitle - which is what the preview is -
+    /// stays inside the video frame unless sub-ass-force-margins is on too, and mpv defaults that
+    /// to "no". Both are written on every call, so turning the setting off again restores mpv's
+    /// own defaults instead of leaving the last value in place.
+    /// </summary>
+    public void ApplySubtitleMarginArea()
+    {
+        var useMargins = Se.Settings.Video.MpvPreviewMarginIsPartOfSubtitleArea;
+        SetOptionString("sub-use-margins", useMargins ? "yes" : "no");
+        SetOptionString("sub-ass-force-margins", useMargins ? "yes" : "no");
+    }
+
     public int SetOptionString(string name, string value)
     {
         if (_mpvSetOptionString == null || _mpv == IntPtr.Zero)
@@ -1463,6 +1480,8 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
 
         SetOptionString("hr-seek", "yes");
         SetOptionString("rebase-start-time", "no");
+
+        ApplySubtitleMarginArea();
 
         _fileName = path;
 


### PR DESCRIPTION
Fixes #13934

### The request

Films often carry burned-in forced narrative low in the picture, and the translation preview sits on top of it. The reporter asked for a **negative** margin so the preview could go below the picture, onto the black bar.

### Why a negative margin was never going to work

The margin is not what is stopping it. mpv keeps an **ASS** subtitle inside the video frame unless `sub-ass-force-margins` is on, and mpv defaults that to `no`. The preview is rendered as ASS, so no margin value — negative or not — could have reached the bar. `SetOptionString` in `LibMpvDynamicPlayer` never set any `sub-*` margin option.

### The change

A new checkbox in the subtitle preview properties, **"Margin is part of the subtitle area"**:

- **on** — sets `sub-use-margins` and `sub-ass-force-margins` to `yes`, so the black bars count as usable space and the existing **positive** margin walks the text down onto them
- **off (default)** — writes mpv's own defaults back, so behaviour is unchanged for everyone who does not want this

The margin spinner keeps its `1..1000` range. Once the bars are part of the area, an ordinary positive margin does the job, so nothing needs to go negative.

`ApplySubtitleMarginArea` is called on every preview refresh as well as on load, so toggling the checkbox takes effect on the video that is already open rather than needing a reopen. Both options are written every time rather than only when enabled, so turning it back off actually restores the default instead of leaving the last value set on the player.

### Testing

Verified in the running app on a letterboxed film — with the option on, the preview moves onto the black bar; with it off it behaves exactly as before.

Full UI suite: 3309 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)