### PR TITLE
Add "Go to sub position and pause"

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -15902,6 +15902,42 @@ public partial class MainViewModel :
         _updateAudioVisualizer = true;
     }
 
+    /// <summary>
+    /// SE 4 parity ("Go to sub position and pause"): jump the video to the selected line's start
+    /// and stop there, so the frame at the cue point can be studied. SE 5 had the jump on its own
+    /// (VideoSetPositionCurrentSubtitleStart) but it left playback running, which carries the
+    /// picture away from the cue before it can be looked at (#13938).
+    /// </summary>
+    [RelayCommand]
+    private void VideoGoToSubtitlePositionAndPause()
+    {
+        var s = SelectedSubtitle;
+        var vp = GetVideoPlayerControl();
+        if (s == null || vp == null)
+        {
+            return;
+        }
+
+        // Pause before seeking, the order SE 4 used - seeking first would let a playing video
+        // run on from the new position while the seek settles.
+        if (vp.VideoPlayer.IsPlaying)
+        {
+            RequestPausePlayheadFreeze();
+        }
+
+        vp.VideoPlayer.Pause();
+
+        var position = Math.Max(0, s.StartTime.TotalSeconds);
+        vp.Position = position;
+
+        if (AudioVisualizer != null && AudioVisualizer.WavePeaks != null)
+        {
+            AudioVisualizerCenterOnPositionIfNeeded(position);
+        }
+
+        _updateAudioVisualizer = true;
+    }
+
     [RelayCommand]
     private void VideoSetPositionCurrentSubtitleEnd()
     {

--- a/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
@@ -174,6 +174,7 @@ public class LanguageSettingsShortcuts
     public string SeekSilenceBack { get; set; }
     public string SeekSilenceForward { get; set; }
     public string SetVideoPositionCurrentSubtitleStart { get; set; }
+    public string GoToSubtitlePositionAndPause { get; set; }
     public string SetVideoPositionCurrentSubtitleEnd { get; set; }
     public string ToggleAudioTracks { get; set; }
     public string GoToNextError { get;set; }
@@ -435,6 +436,7 @@ public class LanguageSettingsShortcuts
         SeekSilenceBack = "Seek silence back";
         SeekSilenceForward = "Seek silence forward";
         SetVideoPositionCurrentSubtitleStart = "Set video position to current line start";
+        GoToSubtitlePositionAndPause = "Go to sub position and pause";
         SetVideoPositionCurrentSubtitleEnd = "Set video position to current line end";
         ToggleAudioTracks = "Toggle audio tracks";
         GoToPreviousError = "GoTo previous error";

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -390,6 +390,7 @@ public static class ShortcutsMain
         { nameof(MainViewModel.PlaybackSlowerCommand), Se.Language.Options.Shortcuts.PlaybackSpeedSlower },
         { nameof(MainViewModel.PlaybackFasterCommand), Se.Language.Options.Shortcuts.PlaybackSpeedFaster },
         { nameof(MainViewModel.VideoSetPositionCurrentSubtitleStartCommand), Se.Language.Options.Shortcuts.SetVideoPositionCurrentSubtitleStart },
+        { nameof(MainViewModel.VideoGoToSubtitlePositionAndPauseCommand), Se.Language.Options.Shortcuts.GoToSubtitlePositionAndPause },
         { nameof(MainViewModel.VideoSetPositionCurrentSubtitleEndCommand), Se.Language.Options.Shortcuts.SetVideoPositionCurrentSubtitleEnd },
         { nameof(MainViewModel.ToggleAudioTracksCommand), Se.Language.Options.Shortcuts.ToggleAudioTracks },
         { nameof(MainViewModel.ListErrorsCommand), Se.Language.General.ListErrors },
@@ -804,6 +805,7 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.PlaybackSlowerCommand, nameof(vm.PlaybackSlowerCommand), ShortcutCategory.General, ShortcutGroup.Video);
         AddShortcut(shortcuts, vm.PlaybackFasterCommand, nameof(vm.PlaybackFasterCommand), ShortcutCategory.General, ShortcutGroup.Video);
         AddShortcut(shortcuts, vm.VideoSetPositionCurrentSubtitleStartCommand, nameof(vm.VideoSetPositionCurrentSubtitleStartCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.VideoGoToSubtitlePositionAndPauseCommand, nameof(vm.VideoGoToSubtitlePositionAndPauseCommand), ShortcutCategory.General, ShortcutGroup.Video);
         AddShortcut(shortcuts, vm.VideoSetPositionCurrentSubtitleEndCommand, nameof(vm.VideoSetPositionCurrentSubtitleEndCommand), ShortcutCategory.General, ShortcutGroup.Video);
         AddShortcut(shortcuts, vm.ToggleAudioTracksCommand, nameof(vm.ToggleAudioTracksCommand), ShortcutCategory.General, ShortcutGroup.Video);
         AddShortcut(shortcuts, vm.ListErrorsCommand, nameof(vm.ListErrorsCommand), ShortcutCategory.General);

--- a/tests/UI/Logic/GoToSubtitlePositionAndPauseShortcutTests.cs
+++ b/tests/UI/Logic/GoToSubtitlePositionAndPauseShortcutTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Linq;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using Xunit;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// SE 4's "Go to sub position and pause" jumps the video to the selected line's start and stops
+/// there. SE 5 had the jump on its own but nothing that also paused, so the picture ran on past
+/// the cue (#13938). The action is only usable once it is registered in the shortcut system - an
+/// unregistered command is stored but never fires (#12088).
+/// </summary>
+public class GoToSubtitlePositionAndPauseShortcutTests
+{
+    [Fact]
+    public void TheActionIsRegisteredAndNamed()
+    {
+        var name = nameof(MainViewModel.VideoGoToSubtitlePositionAndPauseCommand);
+
+        Assert.True(ShortcutsMain.CommandTranslationLookup.ContainsKey(name),
+            $"{name} is not registered in ShortcutsMain, so a shortcut bound to it would never fire.");
+        Assert.False(string.IsNullOrWhiteSpace(ShortcutsMain.CommandTranslationLookup[name]));
+    }
+
+    /// <summary>It is a distinct action from the plain jump, which must keep working as before.</summary>
+    [Fact]
+    public void ThePlainJumpIsStillItsOwnAction()
+    {
+        var pausing = nameof(MainViewModel.VideoGoToSubtitlePositionAndPauseCommand);
+        var plain = nameof(MainViewModel.VideoSetPositionCurrentSubtitleStartCommand);
+
+        Assert.True(ShortcutsMain.CommandTranslationLookup.ContainsKey(plain));
+        Assert.NotEqual(ShortcutsMain.CommandTranslationLookup[plain], ShortcutsMain.CommandTranslationLookup[pausing]);
+    }
+}


### PR DESCRIPTION
Fixes #13938

Two things were asked for. One was missing, the other already exists — details below.

### "Go to sub position and pause" — added

SE 4 had this as a button in the video controls. SE 5 has the jump on its own (`VideoSetPositionCurrentSubtitleStart`, "Set video position to current line start") but it leaves playback running, so the picture carries on past the cue before it can be looked at. There was no action that did both.

Added as its own command, assignable in **Options → Shortcuts** under Video. Pause happens **before** the seek, matching SE 4's order — seeking first lets a playing video run on from the new position while the seek settles.

The existing plain-jump action is untouched.

### "Adjust video position by 0.025" — already there

SE 5 ships four configurable video-nudge step pairs (`VideoMoveCustom1..4` back/forward). The step is in milliseconds and is edited by clicking the entry in **Options → Shortcuts**, so 25 ms is a matter of setting one of them and binding a key. Nothing to add for that half.

### Testing

Two tests guarding the thing that actually breaks this class of change: an action that is not registered in `ShortcutsMain` gets stored against a shortcut but never fires (#12088). They assert the new command is registered with a non-empty name, and that it is a distinct entry from the plain jump rather than having quietly replaced it.

The behaviour itself (pause + seek against a live player) is not covered — that needs a real `MainViewModel`, which takes ~40 injected dependencies, so the existing suite has no way in.

Full UI suite: 3326 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)