### PR TITLE
Layout 10: put the edit box under the waveform like SE4/Aegisub

### DIFF
--- a/src/ui/Features/Main/Layout/InitLayout.cs
+++ b/src/ui/Features/Main/Layout/InitLayout.cs
@@ -847,7 +847,9 @@ public static partial class InitLayout
         {
             RowDefinitions =
             {
-                new RowDefinition(GridLength.Star),
+                // The floor keeps the edit box splitter from dragging the waveform away to
+                // nothing, leaving no handle to drag back (same reason as the grid's floor).
+                new RowDefinition(GridLength.Star) { MinHeight = 45 },
                 new RowDefinition(GridLength.Auto),
             }
         };
@@ -863,6 +865,7 @@ public static partial class InitLayout
 
         Grid.SetRow(editSection, 1);
         rightGrid.Children.Add(editSection);
+        InitListViewAndEditBox.AttachDetachedEditBoxSplitter(rightGrid, editSection);
 
         var nestedRight = new Border
         {

--- a/src/ui/Features/Main/Layout/InitLayout.cs
+++ b/src/ui/Features/Main/Layout/InitLayout.cs
@@ -837,12 +837,36 @@ public static partial class InitLayout
         Grid.SetColumn(nestedSplitter, 1);
         nestedGrid.Children.Add(nestedSplitter);
 
-        // Right part of nested grid
-        var nestedRight = new Border
+        // The subtitle grid goes at the bottom on its own; the edit box is detached so it can
+        // sit under the waveform, matching the layout thumbnail and SE4's Aegisub-style
+        // layout (issue #13940).
+        var listViewOnly = InitListViewAndEditBox.MakeLayoutListViewAndEditBox(mainPage, vm, detachedEditBox: true, out var editSection);
+
+        // Right part of nested grid: waveform on top, edit box below
+        var rightGrid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition(GridLength.Star),
+                new RowDefinition(GridLength.Auto),
+            }
+        };
+
+        var waveformBorder = new Border
         {
             Child = InitWaveform.MakeWaveform(vm),
             VerticalAlignment = VerticalAlignment.Stretch,
             Height = double.NaN,
+        };
+        Grid.SetRow(waveformBorder, 0);
+        rightGrid.Children.Add(waveformBorder);
+
+        Grid.SetRow(editSection, 1);
+        rightGrid.Children.Add(editSection);
+
+        var nestedRight = new Border
+        {
+            Child = rightGrid,
         };
         Grid.SetColumn(nestedRight, 2);
         nestedGrid.Children.Add(nestedRight);
@@ -863,7 +887,7 @@ public static partial class InitLayout
         // Bottom content
         var bottomContent = new Border
         {
-            Child = InitListViewAndEditBox.MakeLayoutListViewAndEditBox(mainPage, vm)
+            Child = listViewOnly
         };
         Grid.SetRow(bottomContent, 2);
         contentGrid.Children.Add(bottomContent);

--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Avalonia;
 using Avalonia.Automation;
 using Avalonia.Controls;
@@ -1917,6 +1918,30 @@ public static partial class InitListViewAndEditBox
         });
 
         return mainGrid;
+    }
+
+    /// <summary>
+    /// Adds the vertical-resize splitter for a detached edit section (layout 10: waveform in
+    /// row 0, edit box in row 1 of <paramref name="hostGrid"/>). Same overlay-splitter and
+    /// minimum-height tracking as the docked layout, so the text box cannot be dragged small
+    /// enough to overpaint its labels (#10271).
+    /// </summary>
+    internal static void AttachDetachedEditBoxSplitter(Grid hostGrid, Grid editSection)
+    {
+        hostGrid.RowDefinitions[1].MinHeight = EditGridMinimumHeight + EditGridMargin * 2;
+
+        var editBoxSplitter = new GridSplitter
+        {
+            Height = UiUtil.SplitterWidthOrHeight,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Top,
+            Margin = new Thickness(0, -UiUtil.SplitterWidthOrHeight / 2.0, 0, 0)
+        };
+        Grid.SetRow(editBoxSplitter, 1);
+        hostGrid.Children.Add(editBoxSplitter);
+
+        var textEditGrid = editSection.Children.OfType<Grid>().First(g => g.Name == "SubtitleTextEditGrid");
+        TrackEditSectionMinimumHeight(hostGrid, textEditGrid);
     }
 
     // Stable keys (DataGridColumn.Tag) used to snapshot/restore subtitle grid column

--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -38,6 +38,17 @@ public static partial class InitListViewAndEditBox
 
     public static Grid MakeLayoutListViewAndEditBox(MainView mainPage, MainViewModel vm)
     {
+        return MakeLayoutListViewAndEditBox(mainPage, vm, detachedEditBox: false, out _);
+    }
+
+    /// <summary>
+    /// Builds the subtitle grid and the edit box. With <paramref name="detachedEditBox"/> the
+    /// edit box is returned via <paramref name="editSection"/> instead of being docked below
+    /// the grid, so a layout can place it elsewhere (layout 10 puts it under the waveform,
+    /// like SE4/Aegisub - issue #13940).
+    /// </summary>
+    internal static Grid MakeLayoutListViewAndEditBox(MainView mainPage, MainViewModel vm, bool detachedEditBox, out Grid editSection)
+    {
         mainPage.DataContext = vm;
 
         // Unhook events from the old SubtitleGrid if it exists
@@ -64,16 +75,14 @@ public static partial class InitListViewAndEditBox
 
         vm.SubtitleGridAlternatingRowBrush = null;
 
-        var mainGrid = new Grid
+        var mainGrid = new Grid();
+        mainGrid.RowDefinitions.Add(new RowDefinition(GridLength.Star) { MinHeight = SubtitleGridMinimumHeight });
+        if (!detachedEditBox)
         {
-            RowDefinitions =
-            {
-                new RowDefinition(GridLength.Star) { MinHeight = SubtitleGridMinimumHeight },
-                // GridSplitter constrains the row definition, so include editGrid's outer
-                // margin to preserve the text box's 92 px minimum at the drag limit.
-                new RowDefinition(GridLength.Auto) { MinHeight = EditGridMinimumHeight + EditGridMargin * 2 },
-            },
-        };
+            // GridSplitter constrains the row definition, so include editGrid's outer
+            // margin to preserve the text box's 92 px minimum at the drag limit.
+            mainGrid.RowDefinitions.Add(new RowDefinition(GridLength.Auto) { MinHeight = EditGridMinimumHeight + EditGridMargin * 2 });
+        }
 
         // TableView (Avalonia 12.1) pilot #3, after Show history (#12704) and the OCR grid
         // (#13001): the main subtitle grid. TableView rows are ListBoxItems, so keyboard
@@ -1873,27 +1882,31 @@ public static partial class InitListViewAndEditBox
         Grid.SetColumn(textEditGrid, 1);
         editGrid.Children.Add(textEditGrid);
 
-        Grid.SetRow(editGrid, 1);
-        mainGrid.Children.Add(editGrid);
-
-        // GridSplitter overlaying the boundary between the subtitle grid (row 0) and the
-        // edit box (row 1) so the text box section can be resized vertically, like SE4
-        // (#10271). The splitter lives in the edit box's own row (no extra row - an extra
-        // row would shrink the grid viewport and break the grid scroll perf tests); with
-        // VerticalAlignment.Top it resizes the row above (grid, Star) and its own row
-        // (edit box, Auto -> becomes Pixel once the user drags). The negative top margin
-        // centers the 4 px strip on the boundary.
-        var editBoxSplitter = new GridSplitter
+        editSection = editGrid;
+        if (!detachedEditBox)
         {
-            Height = UiUtil.SplitterWidthOrHeight,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            VerticalAlignment = VerticalAlignment.Top,
-            Margin = new Thickness(0, -UiUtil.SplitterWidthOrHeight / 2.0, 0, 0)
-        };
-        Grid.SetRow(editBoxSplitter, 1);
-        mainGrid.Children.Add(editBoxSplitter);
+            Grid.SetRow(editGrid, 1);
+            mainGrid.Children.Add(editGrid);
 
-        TrackEditSectionMinimumHeight(mainGrid, textEditGrid);
+            // GridSplitter overlaying the boundary between the subtitle grid (row 0) and the
+            // edit box (row 1) so the text box section can be resized vertically, like SE4
+            // (#10271). The splitter lives in the edit box's own row (no extra row - an extra
+            // row would shrink the grid viewport and break the grid scroll perf tests); with
+            // VerticalAlignment.Top it resizes the row above (grid, Star) and its own row
+            // (edit box, Auto -> becomes Pixel once the user drags). The negative top margin
+            // centers the 4 px strip on the boundary.
+            var editBoxSplitter = new GridSplitter
+            {
+                Height = UiUtil.SplitterWidthOrHeight,
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                VerticalAlignment = VerticalAlignment.Top,
+                Margin = new Thickness(0, -UiUtil.SplitterWidthOrHeight / 2.0, 0, 0)
+            };
+            Grid.SetRow(editBoxSplitter, 1);
+            mainGrid.Children.Add(editBoxSplitter);
+
+            TrackEditSectionMinimumHeight(mainGrid, textEditGrid);
+        }
 
 
         textEditGrid.ColumnDefinitions[1].Bind(ColumnDefinition.WidthProperty, new Binding(nameof(vm.ShowColumnOriginalText))

--- a/tests/UI/Features/Main/Layout10EditBoxPlacementTests.cs
+++ b/tests/UI/Features/Main/Layout10EditBoxPlacementTests.cs
@@ -41,6 +41,14 @@ public class Layout10EditBoxPlacementTests
             var waveformColumn = vm.AudioVisualizer!.GetLogicalAncestors().OfType<Border>()
                 .First(b => Grid.GetColumn(b) == 2 && b.GetLogicalParent() is Grid g && g.ColumnDefinitions.Count == 3);
             Assert.Contains(waveformColumn, editGrid.GetLogicalAncestors());
+
+            // The waveform/edit box boundary is resizable, and the min-height floors keep both
+            // sides recoverable after a drag.
+            var editSection = Assert.IsType<Grid>(editGrid.GetLogicalParent());
+            var rightGrid = Assert.IsType<Grid>(editSection.GetLogicalParent());
+            Assert.Contains(rightGrid.Children, c => c is GridSplitter);
+            Assert.True(rightGrid.RowDefinitions[0].MinHeight > 0);
+            Assert.True(rightGrid.RowDefinitions[1].MinHeight > 0);
         }
         finally
         {

--- a/tests/UI/Features/Main/Layout10EditBoxPlacementTests.cs
+++ b/tests/UI/Features/Main/Layout10EditBoxPlacementTests.cs
@@ -1,0 +1,116 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.LogicalTree;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Main.Layout;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// Layout 10 is the Aegisub-style layout: video top-left, waveform top-right with the edit
+/// box directly below it, and the subtitle grid alone across the bottom - as the layout
+/// picker thumbnail shows. The edit box was docked under the grid instead (issue #13940).
+/// </summary>
+public class Layout10EditBoxPlacementTests
+{
+    [AvaloniaFact]
+    public void Layout10_PutsTheEditBoxUnderTheWaveform_NotUnderTheGrid()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            InitLayout.MakeLayout(vm.MainView!, vm, 10);
+            Dispatcher.UIThread.RunJobs();
+
+            var contentGrid = Assert.IsType<Grid>(vm.ContentGrid.Children[0]);
+            var topContent = FindRowBorder(contentGrid, 0);
+            var bottomContent = FindRowBorder(contentGrid, 2);
+            var editGrid = FindEditGrid(window);
+
+            // The bottom section holds the subtitle grid and nothing of the edit box.
+            Assert.Contains(bottomContent, vm.SubtitleGrid!.GetLogicalAncestors());
+            Assert.DoesNotContain(bottomContent, editGrid.GetLogicalAncestors());
+
+            // The edit box lives in the top section, in the same right-hand column as the waveform.
+            Assert.Contains(topContent, editGrid.GetLogicalAncestors());
+            Assert.NotNull(vm.AudioVisualizer);
+            var waveformColumn = vm.AudioVisualizer!.GetLogicalAncestors().OfType<Border>()
+                .First(b => Grid.GetColumn(b) == 2 && b.GetLogicalParent() is Grid g && g.ColumnDefinitions.Count == 3);
+            Assert.Contains(waveformColumn, editGrid.GetLogicalAncestors());
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    [AvaloniaFact]
+    public void Layout1_StillDocksTheEditBoxWithTheGrid()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            InitLayout.MakeLayout(vm.MainView!, vm, 1);
+            Dispatcher.UIThread.RunJobs();
+
+            var editGrid = FindEditGrid(window);
+
+            // Docked layouts keep the edit box in the same two-row grid as the subtitle grid,
+            // with the resize splitter between them.
+            var sharedGrid = Assert.IsType<Grid>(vm.SubtitleGrid!.GetLogicalAncestors().OfType<Grid>()
+                .First(g => g.RowDefinitions.Count == 2));
+            Assert.Contains(sharedGrid, editGrid.GetLogicalAncestors());
+            Assert.Contains(sharedGrid.Children, c => c is GridSplitter);
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    private static Border FindRowBorder(Grid contentGrid, int row)
+    {
+        return contentGrid.Children.OfType<Border>().First(b => Grid.GetRow(b) == row);
+    }
+
+    private static Grid FindEditGrid(Window window)
+    {
+        // RightToLeftHelper locates the edit section by this name too, so it doubles as a
+        // structure canary: exactly one edit grid must exist after a layout rebuild.
+        return Assert.Single(window.GetLogicalDescendants().OfType<Grid>(), g => g.Name == "SubtitleTextEditGrid");
+    }
+
+    private static (Window Window, MainViewModel Vm) CreateMainViewModel()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1200, Height = 800 };
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        return (window, (MainViewModel)view.DataContext!);
+    }
+
+    private static void CloseWindow(Window window, MainViewModel vm)
+    {
+        foreach (var ownedWindow in window.OwnedWindows.ToArray())
+        {
+            ownedWindow.Close();
+        }
+
+        window.SuppressSaveChangesPromptOnClose(vm);
+        if (window.IsVisible)
+        {
+            window.Close();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #13940

Layout 10's picker thumbnail (and SE4's Aegisub-style layout) shows the edit box directly below the waveform in the top-right section, with the subtitle grid alone across the bottom — but the edit box was docked under the grid, like in the other layouts.

### Changes
- `InitListViewAndEditBox.MakeLayoutListViewAndEditBox` gains an internal overload that hands the edit section back **detached** instead of docking it below the grid (no splitter row, single-row main grid). Only layout 10 uses it; every other layout goes through the unchanged public overload, so nothing else is affected.
- `MakeLayout10` now builds the top-right section as waveform (star) over edit box (auto), and puts the grid-only section across the bottom.
- New headless tests assert the layout-10 placement (edit box shares the waveform's column, bottom section holds only the grid) and that a docked layout (1) keeps the edit box + resize splitter with the grid.

Verified with headless Skia screenshots: layout 10 now renders video top-left, waveform top-right with Show/Duration/Text below it, grid full-width at the bottom; layout 2 renders unchanged. Full UI suite passes (3326 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)