### PR TITLE
Keep the chosen languages when the translate engine changes

### DIFF
--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -1811,9 +1811,51 @@ public partial class AutoTranslateViewModel : ObservableObject
             return;
         }
 
+        // Each engine advertises its own language list, so both combos are rebuilt from the new
+        // engine and a default re-derived from the subtitle. That threw away the languages the
+        // user had just picked - switching engine to compare them silently reset one or both, and
+        // they had to be set again before translating (#13943). Carry the picks across instead;
+        // the re-derived default only stands when the new engine cannot offer the same language.
+        var previousSource = SelectedSourceLanguage;
+        var previousTarget = SelectedTargetLanguage;
+
         SetAutoTranslatorEngine(translator);
         UpdateSourceLanguages(translator);
         UpdateTargetLanguages(translator);
+
+        var restoredSource = FindSameLanguage(previousSource, SourceLanguages);
+        if (restoredSource != null)
+        {
+            SelectedSourceLanguage = restoredSource;
+        }
+
+        var restoredTarget = FindSameLanguage(previousTarget, TargetLanguages);
+        if (restoredTarget != null)
+        {
+            SelectedTargetLanguage = restoredTarget;
+        }
+    }
+
+    /// <summary>
+    /// The entry in <paramref name="languages"/> standing for the same language as
+    /// <paramref name="previous"/>, or null when the engine does not offer it.
+    ///
+    /// Code first, then name: engines do not agree on how a language is spelled. NLLB uses
+    /// "eng_Latn" where Google uses "en", and the LLM engines take English names rather than
+    /// codes - so matching on the code alone would drop the selection between exactly the
+    /// engines a user is most likely to be comparing.
+    /// </summary>
+    private static TranslationPair? FindSameLanguage(TranslationPair? previous, ObservableCollection<TranslationPair> languages)
+    {
+        if (previous == null)
+        {
+            return null;
+        }
+
+        return languages.FirstOrDefault(p => !string.IsNullOrEmpty(p.Code) && p.Code.Equals(previous.Code, StringComparison.OrdinalIgnoreCase))
+               ?? languages.FirstOrDefault(p => !string.IsNullOrEmpty(p.Name) && p.Name.Equals(previous.Name, StringComparison.OrdinalIgnoreCase))
+               ?? languages.FirstOrDefault(p => !string.IsNullOrEmpty(p.TwoLetterIsoLanguageName)
+                                                && p.TwoLetterIsoLanguageName.Equals(previous.TwoLetterIsoLanguageName, StringComparison.OrdinalIgnoreCase));
     }
 
     partial void OnSelectedTargetLanguageChanged(TranslationPair? value)

--- a/tests/UI/Features/Translate/AutoTranslateLanguageCarryOverTests.cs
+++ b/tests/UI/Features/Translate/AutoTranslateLanguageCarryOverTests.cs
@@ -1,0 +1,99 @@
+using System.Collections.ObjectModel;
+using System.Reflection;
+using Nikse.SubtitleEdit.Features.Translate;
+using Nikse.SubtitleEdit.UiLogic.Translate;
+using Xunit;
+
+namespace UITests.Features.Translate;
+
+/// <summary>
+/// Picking a different auto-translate engine rebuilds both language combos from that engine and
+/// re-derives a default, which discarded the languages the user had just chosen (#13943). The
+/// picks are now carried across when the new engine can offer the same language - which it has to
+/// recognise despite engines spelling languages differently ("en" vs "eng_Latn" vs "English").
+/// </summary>
+public class AutoTranslateLanguageCarryOverTests
+{
+    private static TranslationPair? FindSameLanguage(TranslationPair? previous, ObservableCollection<TranslationPair> languages)
+    {
+        var method = typeof(AutoTranslateViewModel).GetMethod(
+            "FindSameLanguage", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+        return (TranslationPair?)method.Invoke(null, new object?[] { previous, languages });
+    }
+
+    private static ObservableCollection<TranslationPair> Languages(params (string Name, string Code)[] items)
+    {
+        var list = new ObservableCollection<TranslationPair>();
+        foreach (var (name, code) in items)
+        {
+            list.Add(new TranslationPair(name, code));
+        }
+
+        return list;
+    }
+
+    [Fact]
+    public void TheSameCodeIsCarriedOver()
+    {
+        var languages = Languages(("English", "en"), ("German", "de"));
+
+        var match = FindSameLanguage(new TranslationPair("German", "de"), languages);
+
+        Assert.Equal("de", match?.Code);
+    }
+
+    /// <summary>NLLB spells English "eng_Latn"; the name is what bridges the two engines.</summary>
+    [Fact]
+    public void ADifferentCodeForTheSameLanguageIsMatchedByName()
+    {
+        var languages = Languages(("English", "eng_Latn"), ("German", "deu_Latn"));
+
+        var match = FindSameLanguage(new TranslationPair("German", "de"), languages);
+
+        Assert.Equal("deu_Latn", match?.Code);
+    }
+
+    [Fact]
+    public void NameMatchingIgnoresCase()
+    {
+        var languages = Languages(("german", "deu_Latn"));
+
+        var match = FindSameLanguage(new TranslationPair("German", "de"), languages);
+
+        Assert.Equal("deu_Latn", match?.Code);
+    }
+
+    /// <summary>
+    /// When the new engine genuinely cannot do that language, nothing is carried over and the
+    /// re-derived default is left to stand.
+    /// </summary>
+    [Fact]
+    public void ALanguageTheNewEngineLacksIsNotCarriedOver()
+    {
+        var languages = Languages(("English", "en"), ("French", "fr"));
+
+        var match = FindSameLanguage(new TranslationPair("Klingon", "tlh"), languages);
+
+        Assert.Null(match);
+    }
+
+    [Fact]
+    public void NoPreviousSelectionCarriesNothing()
+    {
+        var match = FindSameLanguage(null, Languages(("English", "en")));
+
+        Assert.Null(match);
+    }
+
+    /// <summary>An empty code must not match another entry that also has an empty code.</summary>
+    [Fact]
+    public void EmptyCodesDoNotMatchEachOther()
+    {
+        var languages = Languages(("French", string.Empty));
+
+        var match = FindSameLanguage(new TranslationPair("German", string.Empty), languages);
+
+        Assert.Null(match);
+    }
+}


### PR DESCRIPTION
Fixes #13943

### What happens

Picking a different auto-translate engine resets the From and/or To language — sometimes one, sometimes both. Comparing engines means re-setting the languages every time, and it is easy to start a translation with the wrong pair.

### Why

`AutoTranslatorChanged` rebuilds both combos from the newly selected engine:

```csharp
SetAutoTranslatorEngine(translator);
UpdateSourceLanguages(translator);
UpdateTargetLanguages(translator);
```

Each of those clears its list, sets `SelectedSourceLanguage` / `SelectedTargetLanguage` to **null**, and then re-derives a default — auto-detected language from the subtitle, then the English name, then the last-used setting, then simply the first entry. Nothing consults what the user had selected a moment earlier, so whatever they picked is replaced by a default.

That the reset is sometimes only one of the two also follows: the source is re-derived from the subtitle while the target is re-derived from `AutoTranslateLastTarget`, so whether each one lands back on the user's pick is a coincidence of which defaults happen to agree with it.

### The change

Remember both selections across the rebuild and restore them afterwards. The re-derived default is left to stand only where the new engine genuinely cannot offer that language.

Matching is by code first, then name, then two-letter code. The engines do not agree on how a language is spelled — NLLB uses `eng_Latn` where Google uses `en`, and the LLM engines take English names rather than codes — so a code-only match would drop the selection between exactly the engines someone is most likely to be flipping between.

### Testing

Six tests over the matcher, driven through the real private method by reflection so they cannot drift from the shipped one:

- same code carries over
- `de` → `deu_Latn` carries over by name (the NLLB-vs-Google case)
- name matching is case-insensitive
- a language the new engine lacks carries nothing over, leaving the default in place
- no previous selection carries nothing
- two entries with empty codes do not match each other — a guard against the empty-string trap that would otherwise pair unrelated languages

Full UI suite: 3334 passed, 0 failed.

### One thing I noticed but did not change

`UpdateTargetLanguages` calls `EvaluateDefaultTargetLanguageCode(SelectedTargetLanguage?.Code ?? string.Empty, ...)` on the line straight after setting `SelectedTargetLanguage = null`, so that first argument is always empty and the function never sees the previous target. It looks like it was meant to do roughly what this PR now does explicitly. I left it alone — changing default derivation is a separate behavioural question, and with the selection carried over it no longer matters for this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)