### PR TITLE
Update CrispEmbed to v0.17.9

### DIFF
--- a/src/ui/Logic/Download/CrispEmbedDownloadService.cs
+++ b/src/ui/Logic/Download/CrispEmbedDownloadService.cs
@@ -21,18 +21,18 @@ public class CrispEmbedDownloadService : ICrispEmbedDownloadService
 {
     private readonly HttpClient _httpClient;
 
-    private const string WindowsCudaUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.8/crispembed-windows-x86_64-cuda.zip";
-    private const string WindowsVulkanUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.8/crispembed-windows-x86_64-vulkan.zip";
-    private const string WindowsCpuUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.8/crispembed-windows-x86_64.zip";
-    private const string MacUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.8/crispembed-macos-arm64.tar.gz";
-    private const string LinuxUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.8/crispembed-linux-x86_64.tar.gz";
+    private const string WindowsCudaUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.9/crispembed-windows-x86_64-cuda.zip";
+    private const string WindowsVulkanUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.9/crispembed-windows-x86_64-vulkan.zip";
+    private const string WindowsCpuUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.9/crispembed-windows-x86_64.zip";
+    private const string MacUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.9/crispembed-macos-arm64.tar.gz";
+    private const string LinuxUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.9/crispembed-linux-x86_64.tar.gz";
     // The plain "-cuda" archive expects a CUDA 12.x *toolkit* on the host (libcudart/libcublas),
     // not just a driver, and fails in the dynamic loader with exit code 127 when it is missing.
     // The "-bundled" variant ships those two libraries, so it runs with only an NVIDIA driver.
     // Note the CUDA archives keep a glibc 2.38 floor (they build outside the manylinux container
     // the CPU archives use, which lowered those to 2.27).
-    private const string LinuxCudaUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.8/crispembed-linux-x86_64-cuda-bundled.tar.gz";
-    private const string LinuxArmUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.8/crispembed-linux-arm64.tar.gz";
+    private const string LinuxCudaUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.9/crispembed-linux-x86_64-cuda-bundled.tar.gz";
+    private const string LinuxArmUrl = "https://github.com/CrispStrobe/CrispEmbed/releases/download/v0.17.9/crispembed-linux-arm64.tar.gz";
 
     public CrispEmbedDownloadService(HttpClient httpClient)
     {

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -833,7 +833,8 @@ public static class DownloadHashManager
             // otherwise users will be prompted to "update" to the same version they just got.
             [CrispEmbed.WindowsCuda] = new[]
             {
-                "7572b58d33c70d308938a9cafa4fe26dd3521412ab1dbc8d6b75765140e3c5bd", // v0.17.8 (current download URL)
+                "89bcdde6d81634461278bd877e6e35f477cd6771dec7de40f0cfeeca1c5b732a", // v0.17.9 (current download URL)
+                "7572b58d33c70d308938a9cafa4fe26dd3521412ab1dbc8d6b75765140e3c5bd", // v0.17.8
                 "ff5d85824ecdbf2c29c4ed19f63024c94b963f3a7634e62f18140d9cb020ef8f", // v0.17.7
                 "b8c9355f5cdc318b84bcef50c293998d643ef0b0305215b6fc34213c43eaedb4", // v0.17.6
                 "3cc05e2a8d166956cf56ed633b562b1df61f1c829ea3ea56468bfc287d3df18a", // v0.17.5
@@ -845,7 +846,8 @@ public static class DownloadHashManager
             },
             [CrispEmbed.WindowsVulkan] = new[]
             {
-                "d6fe7d73689b801318214ff45ffc38e4aeb238b51abeb7569b31768c21222eea", // v0.17.8 (current download URL)
+                "ce2d3eb91b6dda3b9a50b96cf26e70010854c0b28fa38413c87cefe732dd9fc2", // v0.17.9 (current download URL)
+                "d6fe7d73689b801318214ff45ffc38e4aeb238b51abeb7569b31768c21222eea", // v0.17.8
                 "7a9b6cc9190be3283aa7f72e8f9ab9e035530f02d766afe77ee091e027ac9970", // v0.17.7
                 "591edc9c91991df575f867f10b91d69166daa80eaf49f9b5a8bd80e0541c890c", // v0.17.6
                 "8936580e143d6e0382e1ed44203800733627f1db8d9856f88df641c8319b11b1", // v0.17.5
@@ -857,7 +859,8 @@ public static class DownloadHashManager
             },
             [CrispEmbed.WindowsCpu] = new[]
             {
-                "b302d567f40dd0f577aaf536735c1bab5548e579c5228bdc0ac2059602c95227", // v0.17.8 (current download URL)
+                "dabf9483f1a2e6e801b85a3fe67a6dab2b55359fc604c91e80a44756a21e4b07", // v0.17.9 (current download URL)
+                "b302d567f40dd0f577aaf536735c1bab5548e579c5228bdc0ac2059602c95227", // v0.17.8
                 "e7b7dbbcfe192462d7a4b1d25a903d2394eae83c1c8efb8b8270fe9b3ec90f2e", // v0.17.7
                 "bcb3c1b5c2b88fea34390fdcd5a0f4e9805024aa31d2a30ab2526e2d9e28b0e2", // v0.17.6
                 "46a3c4dad9b6fe7bb96cb95d277435db8b2a5591481dd2bb99123156d0b7f5d2", // v0.17.5
@@ -869,7 +872,8 @@ public static class DownloadHashManager
             },
             [CrispEmbed.MacOs] = new[]
             {
-                "1b3b454daa7ce39063c57bd577308b6a534c952d06a91c1e04bcf64c47089ddc", // v0.17.8 (current download URL)
+                "b85b636dfc5dfb2e9d7b7d6403931864bc42a756629a3962396cf750d6f604ca", // v0.17.9 (current download URL)
+                "1b3b454daa7ce39063c57bd577308b6a534c952d06a91c1e04bcf64c47089ddc", // v0.17.8
                 "0718bfc35e44ed4acd9d2c8d4c20a4b5b4134af826178a362b08a8c9985e0d7d", // v0.17.7
                 "09291257a15ea766373ef0a96126590d5ff6d65184b8ce1e80c4172f3ad5e5bb", // v0.17.6
                 "fe92b64bc4937f2fa60d3eb71c67774e47bc30678f4e6312ef82f0b1c9f1023b", // v0.17.5
@@ -881,7 +885,8 @@ public static class DownloadHashManager
             },
             [CrispEmbed.Linux] = new[]
             {
-                "d5cf6b6929c4aab481a556fe2c85b8607155556c3bd70e26644b91a4f8941b55", // v0.17.8 (glibc 2.27 floor) (current download URL)
+                "775b138650a60064b66f976da3e22c8f5b36fa605f7ebd767967fb0c3b412984", // v0.17.9 (glibc 2.27 floor) (current download URL)
+                "d5cf6b6929c4aab481a556fe2c85b8607155556c3bd70e26644b91a4f8941b55", // v0.17.8 (glibc 2.27 floor)
                 "a5bbcbeb321489cc6cec79ea81ae12a6a93a35fd097a1ef907cee0e33f8c10e0", // v0.17.7 (glibc 2.27 floor)
                 "df9e2308b670d92135e48629baa5eb6278db35aeab324b787ae155589d113918", // v0.17.6 (glibc 2.27 floor)
                 "43466635f2da9b5acd8d28346e1f4bb67dc1785c436211a15a67ff6b95e71796", // v0.17.5 (glibc 2.27 floor)
@@ -893,7 +898,8 @@ public static class DownloadHashManager
             },
             [CrispEmbed.LinuxCuda] = new[]
             {
-                "2282c04015be8f65005dab3739ccee82ebe14e6ee97812242996361d0f1fa8a6", // v0.17.8 (bundled CUDA runtime) (current download URL)
+                "3e1447bc93f8f7039c94b91d4bb97c739cc3b754d9b1ee3006616dbd445a1b6f", // v0.17.9 (bundled CUDA runtime) (current download URL)
+                "2282c04015be8f65005dab3739ccee82ebe14e6ee97812242996361d0f1fa8a6", // v0.17.8 (bundled CUDA runtime)
                 "5639e562dde68730d4086c92366cdd2b95879164e5491096c1617e8ce88bd94f", // v0.17.7 (bundled CUDA runtime)
                 "337c7bf20b52eccd8d50159b8ca415224a9252aca3fbae53eb1ffea2432f5484", // v0.17.6 (bundled CUDA runtime)
                 "5aea8caf95ccf6b3bd6a782e5ce1a858dfd35d272d89128e66980174bf96fb0d", // v0.17.5 (bundled CUDA runtime)
@@ -905,7 +911,8 @@ public static class DownloadHashManager
             },
             [CrispEmbed.LinuxArm] = new[]
             {
-                "afeff7b6f957b28d4914fe12caec400c50eb74f930461c0e5fc4edbb1c1e46ce", // v0.17.8 (glibc 2.27 floor) (current download URL)
+                "247915ad0c870814498a81731ddc037a79d00be5f05aee7c7c85a5dd5fae9c40", // v0.17.9 (glibc 2.27 floor) (current download URL)
+                "afeff7b6f957b28d4914fe12caec400c50eb74f930461c0e5fc4edbb1c1e46ce", // v0.17.8 (glibc 2.27 floor)
                 "9045e69e06fd9b456d3fbb4df37ec6cc0586e5eae74790e61b968d1befce5b07", // v0.17.7 (glibc 2.27 floor)
                 "90243108d6388bbb2780948a2dbe35a55b7f5670716fb5fb4f87576069f95427", // v0.17.6 (glibc 2.27 floor)
                 "5e40342a1e6017057f5012292a6ec206af56da35e47f57819ae7897379a971ef", // v0.17.5 (glibc 2.27 floor)


### PR DESCRIPTION
Bumps the pinned CrispEmbed release from v0.17.8 to [v0.17.9](https://github.com/CrispStrobe/CrispEmbed/releases/tag/v0.17.9): download URLs for all seven platform variants plus the new archive SHA-256 hashes (prepended, with the "current download URL" marker moved).

Upstream changes in v0.17.9:
- Added MOST Embed DE (bidirectional Ministral3 German retrieval model) — embedding-side, not used by SE's OCR path
- Fixed mmap-backed GGUF weight ownership (mappings now live as long as the backend buffer referencing them)
- Fixed batch tokenizer override precedence for `CRISPEMBED_BPE_HF_UNK`
- Multilingual eval harness extended to Arabic and Korean

Verified locally: all seven archives downloaded and hashed; the macOS arm64 binary runs; the Linux x86_64 and arm64 binaries keep the glibc 2.27 floor (bundled libs are `libcrispembed.so.0.17.9`). UI project builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)