### PR TITLE
Fix snap start/end to shot change ignoring the cue gap

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9990,35 +9990,25 @@ public partial class MainViewModel :
             return;
         }
 
-        var minDurationMs = Se.Settings.General.SubtitleMinimumDisplayMilliseconds;
-        var maxDurationMs = Se.Settings.General.SubtitleMaximumDisplayMilliseconds;
+        var inCuesGapMs = TimeCodesBeautifierUtils.GetInCuesGapMs();
+        var frameDurationMs = TimeCodesBeautifierUtils.GetFrameDurationMs();
         foreach (var line in selectedLines)
         {
-            // Cast to nullable so a shot change at t=0 isn't lost to the
-            // default-value collision.
-            var next = AudioVisualizer.ShotChanges
-                .Cast<double?>()
-                .FirstOrDefault(s => s > line.StartTime.TotalSeconds + 0.001);
-            if (next == null)
-            {
-                continue;
-            }
+            var newStartMs = ShotChangesHelper.GetSnappedStartMs(
+                AudioVisualizer.ShotChanges,
+                line.StartTime.TotalMilliseconds,
+                line.EndTime.TotalMilliseconds,
+                inCuesGapMs,
+                frameDurationMs);
 
-            var newStart = TimeSpan.FromSeconds(next.Value);
-            if (newStart >= line.EndTime)
-            {
-                continue;
-            }
-
-            var newDurationMs = (line.EndTime - newStart).TotalMilliseconds;
-            if (newDurationMs < minDurationMs || newDurationMs > maxDurationMs)
+            if (newStartMs == null)
             {
                 continue;
             }
 
             // Use SetStartTimeOnly so EndTime stays fixed (the StartTime
             // setter would otherwise shift EndTime to preserve Duration).
-            line.SetStartTimeOnly(newStart);
+            line.SetStartTimeOnly(TimeSpan.FromMilliseconds(newStartMs.Value));
         }
 
         _updateAudioVisualizer = true;
@@ -10036,33 +10026,23 @@ public partial class MainViewModel :
             return;
         }
 
-        var minDurationMs = Se.Settings.General.SubtitleMinimumDisplayMilliseconds;
-        var maxDurationMs = Se.Settings.General.SubtitleMaximumDisplayMilliseconds;
+        var outCuesGapMs = TimeCodesBeautifierUtils.GetOutCuesGapMs();
+        var frameDurationMs = TimeCodesBeautifierUtils.GetFrameDurationMs();
         foreach (var line in selectedLines)
         {
-            // Cast to nullable so a shot change at t=0 isn't lost to the
-            // default-value collision.
-            var prev = AudioVisualizer.ShotChanges
-                .Cast<double?>()
-                .LastOrDefault(s => s < line.EndTime.TotalSeconds - 0.001);
-            if (prev == null)
+            var newEndMs = ShotChangesHelper.GetSnappedEndMs(
+                AudioVisualizer.ShotChanges,
+                line.StartTime.TotalMilliseconds,
+                line.EndTime.TotalMilliseconds,
+                outCuesGapMs,
+                frameDurationMs);
+
+            if (newEndMs == null)
             {
                 continue;
             }
 
-            var newEnd = TimeSpan.FromSeconds(prev.Value);
-            if (newEnd <= line.StartTime)
-            {
-                continue;
-            }
-
-            var newDurationMs = (newEnd - line.StartTime).TotalMilliseconds;
-            if (newDurationMs < minDurationMs || newDurationMs > maxDurationMs)
-            {
-                continue;
-            }
-
-            line.EndTime = newEnd;
+            line.EndTime = TimeSpan.FromMilliseconds(newEndMs.Value);
         }
 
         _updateAudioVisualizer = true;

--- a/src/ui/Logic/Media/ShotChangesHelper.cs
+++ b/src/ui/Logic/Media/ShotChangesHelper.cs
@@ -325,6 +325,86 @@ public class ShotChangesHelper
         return newStartMs;
     }
 
+    /// <summary>
+    /// The end a "snap selected lines' end to previous shot change" should produce, or null when the
+    /// line must be left alone (issue #13948).
+    /// <para>
+    /// Snapping parks the out cue on the cut the line is currently running past, which means:
+    /// </para>
+    /// <list type="number">
+    /// <item>the target is the shot change <b>on or before</b> the end. "On" is generous by just
+    /// under a frame (<paramref name="frameDurationMs"/>), so an end already sitting on a cut snaps
+    /// to that cut instead of skipping a whole shot backwards;</item>
+    /// <item>it lands <paramref name="outCuesGapMs"/> <b>before</b> that cut - the beautify profile's
+    /// out cues gap, the same rule the beautifier and the extend commands use. An out cue exactly on
+    /// the cut is the thing the gap exists to prevent;</item>
+    /// <item>the only veto is a result that would not leave a positive duration. Minimum/maximum
+    /// display duration deliberately do not veto: the user asked for this cue to move, and silently
+    /// doing nothing reads as a dead shortcut.</item>
+    /// </list>
+    /// </summary>
+    public static double? GetSnappedEndMs(
+        List<double> shotChanges,
+        double startMs,
+        double endMs,
+        double outCuesGapMs,
+        double frameDurationMs)
+    {
+        if (shotChanges == null || shotChanges.Count == 0)
+        {
+            return null;
+        }
+
+        var maxDifference = (frameDurationMs - 1) / 1000;
+        var shotChangeSeconds = shotChanges.FirstOnOrBefore(endMs / 1000.0, maxDifference, -1);
+        if (shotChangeSeconds < 0)
+        {
+            return null;
+        }
+
+        var newEndMs = shotChangeSeconds * 1000.0 - outCuesGapMs;
+        if (newEndMs <= startMs)
+        {
+            return null;
+        }
+
+        return newEndMs;
+    }
+
+    /// <summary>
+    /// The start a "snap selected lines' start to next shot change" should produce, or null when the
+    /// line must be left alone - <see cref="GetSnappedEndMs"/> mirrored: the shot change on or after
+    /// the start, plus <paramref name="inCuesGapMs"/> so the in cue lands after the cut rather than
+    /// on it, vetoed only when it would not leave a positive duration.
+    /// </summary>
+    public static double? GetSnappedStartMs(
+        List<double> shotChanges,
+        double startMs,
+        double endMs,
+        double inCuesGapMs,
+        double frameDurationMs)
+    {
+        if (shotChanges == null || shotChanges.Count == 0)
+        {
+            return null;
+        }
+
+        var maxDifference = (frameDurationMs - 1) / 1000;
+        var shotChangeSeconds = shotChanges.FirstOnOrAfter(startMs / 1000.0, maxDifference, -1);
+        if (shotChangeSeconds < 0)
+        {
+            return null;
+        }
+
+        var newStartMs = shotChangeSeconds * 1000.0 + inCuesGapMs;
+        if (newStartMs >= endMs)
+        {
+            return null;
+        }
+
+        return newStartMs;
+    }
+
     public static double? GetClosestShotChange(List<double> shotChanges, TimeCode currentTime)
     {
         if (shotChanges == null || shotChanges.Count == 0)

--- a/tests/UI/Logic/Media/ShotChangeSnapTests.cs
+++ b/tests/UI/Logic/Media/ShotChangeSnapTests.cs
@@ -1,0 +1,154 @@
+using Nikse.SubtitleEdit.Logic.Media;
+using System.Collections.Generic;
+
+namespace UITests.Logic.Media;
+
+/// <summary>
+/// The rules behind "snap selected lines' start/end to next/previous shot change" (issue #13948).
+/// Snapping parks a cue on the cut it is running past, the configured gap short of it - the same
+/// gap the beautifier and the extend commands use - and only refuses when the result would not
+/// leave a positive duration.
+/// </summary>
+public class ShotChangeSnapTests
+{
+    private const double FrameDurationMs25 = 40; // 25 fps
+    private static readonly List<double> ShotChanges = new() { 1.0, 2.0, 5.0 }; // seconds
+
+    [Fact]
+    public void SnapEnd_StopsTheGapBeforeThePreviousShotChange()
+    {
+        var result = ShotChangesHelper.GetSnappedEndMs(
+            ShotChanges, startMs: 100, endMs: 2500,
+            outCuesGapMs: 80, frameDurationMs: FrameDurationMs25);
+
+        Assert.Equal(1920, result); // shot change at 2000 ms, minus the 80 ms out cues gap
+    }
+
+    // The reported bug: the end landed exactly on the cut instead of the gap before it.
+    [Fact]
+    public void SnapEnd_DoesNotLandOnTheShotChangeItself()
+    {
+        var result = ShotChangesHelper.GetSnappedEndMs(
+            ShotChanges, startMs: 100, endMs: 2500,
+            outCuesGapMs: 80, frameDurationMs: FrameDurationMs25);
+
+        Assert.NotEqual(2000, result);
+    }
+
+    // Rule 1: an end already parked on a cut snaps to that cut's gap. Requiring the cut to be
+    // strictly before the end skips a whole shot backwards, which then usually fails a duration
+    // check and reads as "the shortcut did nothing".
+    [Fact]
+    public void SnapEnd_EndExactlyOnAShotChange_SnapsToThatShotChange()
+    {
+        var result = ShotChangesHelper.GetSnappedEndMs(
+            ShotChanges, startMs: 100, endMs: 2000,
+            outCuesGapMs: 80, frameDurationMs: FrameDurationMs25);
+
+        Assert.Equal(1920, result); // the cut at 2000, not the one at 1000
+    }
+
+    // The "on" tolerance is just under a frame, so a cue a hair short of the cut still counts.
+    [Fact]
+    public void SnapEnd_EndJustBeforeAShotChange_SnapsToThatShotChange()
+    {
+        var result = ShotChangesHelper.GetSnappedEndMs(
+            ShotChanges, startMs: 100, endMs: 1980,
+            outCuesGapMs: 80, frameDurationMs: FrameDurationMs25);
+
+        Assert.Equal(1920, result);
+    }
+
+    // Rule 3: a short result is still the result the user asked for - minimum display duration
+    // must not silently veto it.
+    [Fact]
+    public void SnapEnd_ResultShorterThanMinimumDisplayDuration_StillSnaps()
+    {
+        var result = ShotChangesHelper.GetSnappedEndMs(
+            ShotChanges, startMs: 1900, endMs: 4000,
+            outCuesGapMs: 80, frameDurationMs: FrameDurationMs25);
+
+        Assert.Equal(1920, result); // a 20 ms line, but the user asked for this cue to move
+    }
+
+    [Fact]
+    public void SnapEnd_ResultWouldNotLeaveAPositiveDuration_LeavesTheLineAlone()
+    {
+        var result = ShotChangesHelper.GetSnappedEndMs(
+            ShotChanges, startMs: 1950, endMs: 4000,
+            outCuesGapMs: 80, frameDurationMs: FrameDurationMs25);
+
+        Assert.Null(result); // 1920 is before the start
+    }
+
+    [Fact]
+    public void SnapEnd_NoShotChangeBeforeTheEnd_LeavesTheLineAlone()
+    {
+        var result = ShotChangesHelper.GetSnappedEndMs(
+            ShotChanges, startMs: 100, endMs: 500,
+            outCuesGapMs: 80, frameDurationMs: FrameDurationMs25);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void SnapEnd_NoShotChangesAtAll_LeavesTheLineAlone()
+    {
+        var result = ShotChangesHelper.GetSnappedEndMs(
+            new List<double>(), startMs: 100, endMs: 2500,
+            outCuesGapMs: 80, frameDurationMs: FrameDurationMs25);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void SnapStart_StartsTheGapAfterTheNextShotChange()
+    {
+        var result = ShotChangesHelper.GetSnappedStartMs(
+            ShotChanges, startMs: 1500, endMs: 4000,
+            inCuesGapMs: 120, frameDurationMs: FrameDurationMs25);
+
+        Assert.Equal(2120, result); // shot change at 2000 ms, plus the 120 ms in cues gap
+    }
+
+    [Fact]
+    public void SnapStart_StartExactlyOnAShotChange_SnapsToThatShotChange()
+    {
+        var result = ShotChangesHelper.GetSnappedStartMs(
+            ShotChanges, startMs: 2000, endMs: 4000,
+            inCuesGapMs: 120, frameDurationMs: FrameDurationMs25);
+
+        Assert.Equal(2120, result); // the cut at 2000, not the one at 5000
+    }
+
+    // A shot change at t=0 is a real cut, not a "nothing found" sentinel.
+    [Fact]
+    public void SnapStart_ShotChangeAtZero_IsNotMistakenForNoShotChange()
+    {
+        var result = ShotChangesHelper.GetSnappedStartMs(
+            new List<double> { 0.0, 5.0 }, startMs: 0, endMs: 2000,
+            inCuesGapMs: 120, frameDurationMs: FrameDurationMs25);
+
+        Assert.Equal(120, result);
+    }
+
+    [Fact]
+    public void SnapStart_ResultWouldNotLeaveAPositiveDuration_LeavesTheLineAlone()
+    {
+        var result = ShotChangesHelper.GetSnappedStartMs(
+            ShotChanges, startMs: 1500, endMs: 2050,
+            inCuesGapMs: 120, frameDurationMs: FrameDurationMs25);
+
+        Assert.Null(result); // 2120 is after the end
+    }
+
+    [Fact]
+    public void SnapStart_NoShotChangeAfterTheStart_LeavesTheLineAlone()
+    {
+        var result = ShotChangesHelper.GetSnappedStartMs(
+            ShotChanges, startMs: 6000, endMs: 8000,
+            inCuesGapMs: 120, frameDurationMs: FrameDurationMs25);
+
+        Assert.Null(result);
+    }
+}


### PR DESCRIPTION
Fixes #13948

"Snap selected lines' end to previous shot change" put the out cue **exactly on the cut** instead of the configured out cues gap before it, and often did nothing at all. Its mirror command, "snap start to next shot change", had both defects too, so both are fixed here.

## What was wrong

Two differences from SE4, which the reporter confirms works correctly.

**1. The gap was never applied.** SE4 uses `previousShotChange - GetOutCuesGapMs()` (and `nextShotChange + GetInCuesGapMs()` for starts) — the same beautify-profile rule the beautifier and the extend-to-shot-change commands already follow. SE5 snapped straight onto the cut:

```csharp
var newEnd = TimeSpan.FromSeconds(prev.Value);   // no gap
...
line.EndTime = newEnd;
```

**2. The target cut had to be strictly before the end**, so a cue already parked on a cut skipped a whole shot backwards:

```csharp
.LastOrDefault(s => s < line.EndTime.TotalSeconds - 0.001)
```

SE4 instead takes the cut *on or before* the end, with a sub-frame tolerance (`ListExtensions.FirstOnOrBefore(target, maxDifference, …)`). Because SE5 then also applied minimum/maximum display duration checks that SE4 does not have, that skipped-a-shot result was usually rejected — and the shortcut silently did nothing. That is the "sometimes I have to press the shortcut several times before it executes" half of the report: cues sitting on or near a cut (exactly what you get after beautifying, or after a previous snap) were the ones that refused to move.

The duration checks are gone. An explicit snap is the user asking for *this* cue to move; the only sane veto is a result that would not leave a positive duration, which is what SE4 checks.

## The change

The rules move into `ShotChangesHelper.GetSnappedEndMs` / `GetSnappedStartMs`, next to the existing `GetExtendedEndMs` / `GetExtendedStartMs`, so the call sites stay thin and the behaviour is unit-testable.

## Testing

13 new tests in `tests/UI/Logic/Media/ShotChangeSnapTests.cs` covering the gap offset, the on-the-cut and just-before-the-cut cases, a shot change at t=0, short results that the old duration check would have swallowed, and the positive-duration veto.

Full UI suite: **3347 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
