### PR TITLE
Snap whole-paragraph waveform drags to shot changes

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -1457,7 +1457,21 @@ public class AudioVisualizer : Control
                 // (previous and next are already null if _isShiftDown or Se.Settings.Waveform.AllowOverlap)
                 bool allowOverlap = (previous == null && next == null) || alreadyOverlapping;
 
-                newStart = SnapToFrame(newStart);
+                // SE4 parity: a whole-paragraph drag snaps to shot changes too, not just an edge
+                // resize (issue #13953). Whichever cue is captured first wins, and the other cue
+                // moves with it so the duration is preserved. Frame snapping only applies when no
+                // cut captured the paragraph, exactly like the resize branches below.
+                var snappedWholeStart = TrySnapInCueToShotChange(newStart);
+                if (snappedWholeStart == null)
+                {
+                    var snappedWholeEnd = TrySnapOutCueToShotChange(newStart + _originalDurationSeconds);
+                    if (snappedWholeEnd != null)
+                    {
+                        snappedWholeStart = snappedWholeEnd.Value - _originalDurationSeconds;
+                    }
+                }
+
+                newStart = snappedWholeStart ?? SnapToFrame(newStart);
 
                 if (!allowOverlap && (previous != null || next != null))
                 {
@@ -1562,21 +1576,13 @@ public class AudioVisualizer : Control
                     newStart = 0;
                 }
 
-                var snappedToShotLeft = false;
-                if (SnapToShotChanges && !_isShiftDown && _shotChanges.Count > 0)
+                var snappedStartSeconds = TrySnapInCueToShotChange(newStart);
+                if (snappedStartSeconds != null)
                 {
-                    // ClosestTo directly (binary search) - GetClosestShotChange only wraps it
-                    // behind a TimeCode, which is a class, i.e. one allocation per pointer move.
-                    var nearest = _shotChanges.ClosestTo(newStart);
-                    var snapSeconds = GetInCueSnapSeconds();
-                    if (nearest != newStart && Math.Abs(newStart - nearest) < snapSeconds)
-                    {
-                        newStart = nearest;
-                        snappedToShotLeft = true;
-                    }
+                    newStart = snappedStartSeconds.Value;
                 }
 
-                if (!snappedToShotLeft)
+                if (snappedStartSeconds == null)
                 {
                     newStart = SnapToFrame(newStart);
                 }
@@ -1596,24 +1602,13 @@ public class AudioVisualizer : Control
             case InteractionMode.ResizingRight:
                 newEnd = _originalEndSeconds + dragDeltaSeconds;
 
-                var snappedToShotRight = false;
-                if (SnapToShotChanges && !_isShiftDown && _shotChanges.Count > 0)
+                var snappedEndSeconds = TrySnapOutCueToShotChange(newEnd);
+                if (snappedEndSeconds != null)
                 {
-                    // OUT cues conventionally land one frame BEFORE the shot change so they
-                    // don't bleed visually onto the next shot.
-                    var fps = Se.Settings.General.CurrentFrameRate;
-                    var oneFrameSeconds = fps >= 1 ? 1.0 / fps : 0.0;
-                    // ClosestTo directly - see the ResizingLeft branch.
-                    var nearest = _shotChanges.ClosestTo(newEnd);
-                    var snapSeconds = GetOutCueSnapSeconds();
-                    if (nearest != newEnd && Math.Abs(newEnd - nearest + oneFrameSeconds) < snapSeconds)
-                    {
-                        newEnd = nearest - oneFrameSeconds;
-                        snappedToShotRight = true;
-                    }
+                    newEnd = snappedEndSeconds.Value;
                 }
 
-                if (!snappedToShotRight)
+                if (snappedEndSeconds == null)
                 {
                     newEnd = SnapToFrame(newEnd);
                 }
@@ -1702,6 +1697,58 @@ public class AudioVisualizer : Control
 
         frameDur = 1.0 / fps;
         return true;
+    }
+
+    /// <summary>
+    /// Where an IN cue dragged to <paramref name="seconds"/> should land if a shot change is close
+    /// enough to capture it, or null when none is. In cues land exactly on the cut.
+    /// <para>
+    /// Shared by every drag interaction that moves an in cue - resizing the left edge and moving a
+    /// whole paragraph - so the same grab lands on the same time whichever way the user does it
+    /// (issue #13953).
+    /// </para>
+    /// </summary>
+    private double? TrySnapInCueToShotChange(double seconds)
+    {
+        if (!SnapToShotChanges || _isShiftDown || _shotChanges.Count == 0)
+        {
+            return null;
+        }
+
+        // ClosestTo directly (binary search) - GetClosestShotChange only wraps it
+        // behind a TimeCode, which is a class, i.e. one allocation per pointer move.
+        var nearest = _shotChanges.ClosestTo(seconds);
+        if (nearest == seconds || Math.Abs(seconds - nearest) >= GetInCueSnapSeconds())
+        {
+            return null;
+        }
+
+        return nearest;
+    }
+
+    /// <summary>
+    /// Where an OUT cue dragged to <paramref name="seconds"/> should land if a shot change is close
+    /// enough to capture it, or null when none is. OUT cues conventionally land one frame BEFORE the
+    /// shot change so they don't bleed visually onto the next shot. <see cref="TrySnapInCueToShotChange"/>
+    /// mirrored.
+    /// </summary>
+    private double? TrySnapOutCueToShotChange(double seconds)
+    {
+        if (!SnapToShotChanges || _isShiftDown || _shotChanges.Count == 0)
+        {
+            return null;
+        }
+
+        var fps = Se.Settings.General.CurrentFrameRate;
+        var oneFrameSeconds = fps >= 1 ? 1.0 / fps : 0.0;
+        // ClosestTo directly - see TrySnapInCueToShotChange.
+        var nearest = _shotChanges.ClosestTo(seconds);
+        if (nearest == seconds || Math.Abs(seconds - nearest + oneFrameSeconds) >= GetOutCueSnapSeconds())
+        {
+            return null;
+        }
+
+        return nearest - oneFrameSeconds;
     }
 
     /// <summary>

--- a/tests/UI/Controls/AudioVisualizerShotChangeSnapTests.cs
+++ b/tests/UI/Controls/AudioVisualizerShotChangeSnapTests.cs
@@ -1,0 +1,257 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Collections.Generic;
+using Configuration = Nikse.SubtitleEdit.Core.Common.Configuration;
+
+namespace UITests.Controls;
+
+/// <summary>
+/// "Snap to shot changes" in the waveform (issue #13953).
+///
+/// The setting is one promise - a cue dragged near a cut lands on the cut - so every drag that
+/// moves a cue has to keep it, not just the two edge-resize drags. Dragging a whole paragraph
+/// snapped in SE4 and did not in SE5, which reads as the checkbox being broken.
+///
+/// In cues land exactly on the cut; out cues land one frame before it, so they don't bleed onto
+/// the next shot. A whole-paragraph drag preserves its duration, so whichever cue the cut captures,
+/// the other one moves with it.
+/// </summary>
+public class AudioVisualizerShotChangeSnapTests
+{
+    private const int SampleRate = 126; // px per second at zoom 1
+    private const double WidthPx = 800;
+    private const double HeightPx = 200;
+    private const double Fps = 25;
+    private const double OneFrame = 1.0 / Fps;
+
+    // Default beautify profile: in cues capture within max(3, 5) frames, out cues within
+    // max(10, 3) frames.
+    private const double InCueSnapSeconds = 5 / Fps;
+    private const double OutCueSnapSeconds = 10 / Fps;
+
+    /// <summary>Pins every setting the snap maths reads, so the test does not drift with defaults.</summary>
+    private sealed class SnapSettings : IDisposable
+    {
+        private readonly bool _snapToShotChanges = Se.Settings.Waveform.SnapToShotChanges;
+        private readonly bool _snapToFrames = Se.Settings.Waveform.SnapToFrames;
+        private readonly double _frameRate = Se.Settings.General.CurrentFrameRate;
+        private readonly int _inLeft, _inRight, _outLeft, _outRight;
+
+        public SnapSettings(bool snapToShotChanges = true)
+        {
+            var p = Configuration.Settings.BeautifyTimeCodes.Profile;
+            _inLeft = p.InCuesLeftRedZone;
+            _inRight = p.InCuesRightRedZone;
+            _outLeft = p.OutCuesLeftRedZone;
+            _outRight = p.OutCuesRightRedZone;
+
+            Se.Settings.Waveform.SnapToShotChanges = snapToShotChanges;
+            Se.Settings.Waveform.SnapToFrames = false;
+            Se.Settings.General.CurrentFrameRate = Fps;
+            p.InCuesLeftRedZone = 3;
+            p.InCuesRightRedZone = 5;
+            p.OutCuesLeftRedZone = 10;
+            p.OutCuesRightRedZone = 3;
+        }
+
+        public void Dispose()
+        {
+            var p = Configuration.Settings.BeautifyTimeCodes.Profile;
+            Se.Settings.Waveform.SnapToShotChanges = _snapToShotChanges;
+            Se.Settings.Waveform.SnapToFrames = _snapToFrames;
+            Se.Settings.General.CurrentFrameRate = _frameRate;
+            p.InCuesLeftRedZone = _inLeft;
+            p.InCuesRightRedZone = _inRight;
+            p.OutCuesLeftRedZone = _outLeft;
+            p.OutCuesRightRedZone = _outRight;
+        }
+    }
+
+    private static WavePeakData2 MakePeaks(int seconds)
+    {
+        var peaks = new WavePeak2[SampleRate * seconds];
+        for (var i = 0; i < peaks.Length; i++)
+        {
+            peaks[i] = new WavePeak2(8000, -8000);
+        }
+
+        return new WavePeakData2(SampleRate, peaks);
+    }
+
+    private static SubtitleLineViewModel Line(double startSeconds, double endSeconds) => new()
+    {
+        Text = "text",
+        StartTime = TimeSpan.FromSeconds(startSeconds),
+        EndTime = TimeSpan.FromSeconds(endSeconds),
+    };
+
+    private static (Window Window, AudioVisualizer Av) Open(List<double> shotChanges, params SubtitleLineViewModel[] lines)
+    {
+        var av = new AudioVisualizer
+        {
+            WavePeaks = MakePeaks(60),
+            Width = WidthPx,
+            Height = HeightPx,
+        };
+
+        av.SetPosition(0, new List<SubtitleLineViewModel>(lines), 0, 0, new List<SubtitleLineViewModel>());
+        av.ShotChanges = shotChanges;
+
+        var window = new Window { Width = WidthPx, Height = HeightPx, Content = av };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        return (window, av);
+    }
+
+    private static void Drag(Window window, double fromX, double toX)
+    {
+        window.MouseDown(new Point(fromX, 100), MouseButton.Left, RawInputModifiers.None);
+        window.MouseMove(new Point(toX, 100), RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+        window.MouseUp(new Point(toX, 100), MouseButton.Left, RawInputModifiers.None);
+    }
+
+    // The reported bug: this drag did nothing special in SE5 - the paragraph slid straight past
+    // the cut - while SE4 parked its start on it.
+    [AvaloniaFact]
+    public void MoveWholeLine_StartNearAShotChange_SnapsStartOntoIt()
+    {
+        using var _ = new SnapSettings();
+        var (window, av) = Open(new List<double> { 1.5 }, Line(1, 3));
+        var line = av.SelectedParagraph!;
+
+        // Grab the middle of the line (2 s) and drag +60 px, putting the start at ~1.476 s -
+        // inside the in cue capture distance of the cut at 1.5 s.
+        Drag(window, 252, 312);
+
+        Assert.Equal(1.5, line.StartTime.TotalSeconds, 6);
+        Assert.Equal(2, line.Duration.TotalSeconds, 6); // a whole-line move keeps its duration
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void MoveWholeLine_EndNearAShotChange_SnapsEndOneFrameBeforeIt()
+    {
+        using var _ = new SnapSettings();
+        var (window, av) = Open(new List<double> { 3.5 }, Line(1, 3));
+        var line = av.SelectedParagraph!;
+
+        // Same drag, but now only the END lands near a cut.
+        Drag(window, 252, 312);
+
+        Assert.Equal(3.5 - OneFrame, line.EndTime.TotalSeconds, 6);
+        Assert.Equal(3.5 - OneFrame - 2, line.StartTime.TotalSeconds, 6);
+        Assert.Equal(2, line.Duration.TotalSeconds, 6);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void MoveWholeLine_NoShotChangeInRange_FollowsThePointer()
+    {
+        using var _ = new SnapSettings();
+        var (window, av) = Open(new List<double> { 30.0 }, Line(1, 3));
+        var line = av.SelectedParagraph!;
+
+        Drag(window, 252, 312);
+
+        Assert.Equal(1 + 60.0 / SampleRate, line.StartTime.TotalSeconds, 6);
+        Assert.Equal(2, line.Duration.TotalSeconds, 6);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void MoveWholeLine_SnapToShotChangesOff_FollowsThePointer()
+    {
+        using var _ = new SnapSettings(snapToShotChanges: false);
+        var (window, av) = Open(new List<double> { 1.5 }, Line(1, 3));
+        var line = av.SelectedParagraph!;
+
+        Drag(window, 252, 312);
+
+        Assert.Equal(1 + 60.0 / SampleRate, line.StartTime.TotalSeconds, 6);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void MoveWholeLine_StartCaptureWinsOverEndCapture()
+    {
+        using var _ = new SnapSettings();
+        // Cuts near both cues; the start is what the paragraph parks on.
+        var (window, av) = Open(new List<double> { 1.5, 3.5 }, Line(1, 3));
+        var line = av.SelectedParagraph!;
+
+        Drag(window, 252, 312);
+
+        Assert.Equal(1.5, line.StartTime.TotalSeconds, 6);
+        window.Close();
+    }
+
+    // Regression guards: the resize drags kept their behaviour when the snap rule moved into a
+    // shared helper.
+    [AvaloniaFact]
+    public void ResizeLeft_NearAShotChange_SnapsOntoIt()
+    {
+        using var _ = new SnapSettings();
+        var (window, av) = Open(new List<double> { 1.5 }, Line(1, 3));
+        var line = av.SelectedParagraph!;
+
+        Drag(window, 126, 186); // left edge at 1 s, +60 px
+
+        Assert.Equal(1.5, line.StartTime.TotalSeconds, 6);
+        Assert.Equal(3, line.EndTime.TotalSeconds, 6); // the other edge stays put
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void ResizeRight_NearAShotChange_SnapsOneFrameBeforeIt()
+    {
+        using var _ = new SnapSettings();
+        var (window, av) = Open(new List<double> { 3.5 }, Line(1, 3));
+        var line = av.SelectedParagraph!;
+
+        Drag(window, 378, 438); // right edge at 3 s, +60 px
+
+        Assert.Equal(3.5 - OneFrame, line.EndTime.TotalSeconds, 6);
+        Assert.Equal(1, line.StartTime.TotalSeconds, 6);
+        window.Close();
+    }
+
+    // Out cues get a wider capture distance than in cues (the profile's out cues red zones are
+    // larger), so the same offset that is too far for a start still catches an end.
+    [AvaloniaFact]
+    public void SnapDistances_ComeFromTheBeautifyProfileRedZones()
+    {
+        using var _ = new SnapSettings();
+        const double Offset = 0.3; // between the 0.2 s in cue and 0.4 s out cue distances
+        Assert.True(InCueSnapSeconds < Offset && Offset < OutCueSnapSeconds);
+
+        var draggedStart = 1 + 60.0 / SampleRate;
+        var draggedEnd = draggedStart + 2;
+
+        // Too far for the start to be captured.
+        var (window, av) = Open(new List<double> { draggedStart + Offset }, Line(1, 3));
+        var line = av.SelectedParagraph!;
+        Drag(window, 252, 312);
+        Assert.Equal(draggedStart, line.StartTime.TotalSeconds, 6);
+        window.Close();
+
+        // Same offset, but an end at that range is still captured.
+        var (window2, av2) = Open(new List<double> { draggedEnd + Offset }, Line(1, 3));
+        var line2 = av2.SelectedParagraph!;
+        Drag(window2, 252, 312);
+        Assert.Equal(draggedEnd + Offset - OneFrame, line2.EndTime.TotalSeconds, 6);
+        window2.Close();
+    }
+}


### PR DESCRIPTION
Fixes #13953

"Snap to shot changes (hold Shift to override)" only applied to the two edge-resize drags. Dragging a **whole paragraph** ignored shot changes entirely, so with the setting on the checkbox looked broken — which is exactly what the reporter's side-by-side recordings show: in SE4 the dragged block parks on the cut, in SE5 it slides straight past it.

## What was wrong

In [`AudioVisualizer.cs`](src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs), `InteractionMode.ResizingLeft` and `ResizingRight` both consult `_shotChanges`. `InteractionMode.Moving` only did `newStart = SnapToFrame(newStart)` — no shot-change handling at all.

SE4 does snap the whole move (`Main.cs` → `AudioVisualizer.cs`, the `MouseDownParagraphType.Whole` branch): whichever cue lands near a cut gets snapped to it and the other cue follows, preserving the duration.

## The change

Ported that behaviour, with one deliberate deviation: SE4 offsets by the beautify profile's in/out cue **gaps**, while SE5's resize branches land an in cue *exactly* on the cut and an out cue *one frame before* it. I followed SE5's own convention so that dragging a paragraph onto a cut lands it where dragging its edge to the same cut already would — internal consistency seemed more valuable here than byte-matching SE4, but say the word and I'll switch it to the gaps.

The snap rule also moves out of the two resize branches into `TrySnapInCueToShotChange` / `TrySnapOutCueToShotChange`, so all three drags share one definition of "close enough" and one definition of where a cue lands. The resize branches are behaviour-preserving refactors — guarded by tests below.

## Testing

8 new tests in `tests/UI/Controls/AudioVisualizerShotChangeSnapTests.cs`, driving real pointer drags through the existing headless Avalonia harness: start-captures-cut, end-captures-cut (one frame before), start wins when both are near, no cut in range, setting off, the two resize regression guards, and the in-vs-out capture distances.

Verified they bite: with the `Moving` change reverted, the 4 whole-move tests fail and the other 4 still pass.

Full UI suite: **3342 passed, 0 failed**.

## Not included

Three adjacent gaps I found but left alone, since they're separate calls:

- **Creating a new paragraph by dragging empty waveform** (`InteractionMode.New`) doesn't snap to shot changes either; SE4 snaps both of its edges. It also skips frame snapping, so it looks generally less finished — worth its own issue.
- **`Se.Settings.Waveform.SnapToShotChangesPixels`** (default 8) is dead config — nothing reads it. SE4's snap distance was this pixel value, i.e. zoom-independent; SE5 derives the distance from the beautify profile's red zones in frames instead, which feels different at high/low zoom. Worth deciding which one is intended.
- The out-cue snap uses a hardcoded one-frame offset rather than the profile's configured out cues gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
