### PR TITLE
Stop edge drags in the waveform running away

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -26430,8 +26430,18 @@ public partial class MainViewModel :
                 // With "center also while paused" on, paused position changes (wheel scrub, waveform
                 // clicks, shortcuts) recenter too — but only on actual changes, so the user can still
                 // scroll around the waveform freely while the play-head is at rest.
+                // ...but never while the user is dragging on the waveform (#13955). An edge drag
+                // scrubs the video to the edge (SetVideoPositionOnMoveStartEnd), so recentering on
+                // that position scrolls the view to the very edge being dragged - and the drag
+                // delta is measured in absolute waveform time (#13600), so the scroll is added to
+                // the delta, which moves the edge further, which scrolls the view further. Each
+                // pointer event amplifies the previous one and the edge shoots off screen after a
+                // few of them. Whole-paragraph moves never scrubbed, which is why only edge drags
+                // ran away. Re-centering the waveform under a held pointer is wrong on its own
+                // terms too - it drags the content out from under the user.
                 var centerPausedChange = WaveformCenter && !isPlaying &&
                                          Se.Settings.Waveform.CenterVideoPositionAlsoWhenPaused &&
+                                         !av.IsEditingWithPointer &&
                                          Math.Abs(est - _pausedCenterLastSeconds) > 0.001;
                 if (WaveformCenter && av.WavePeaks != null && (isPlaying || centerPausedChange))
                 {

--- a/tests/UI/Controls/AudioVisualizerScrubFeedbackTests.cs
+++ b/tests/UI/Controls/AudioVisualizerScrubFeedbackTests.cs
@@ -1,0 +1,210 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Collections.Generic;
+
+namespace UITests.Controls;
+
+/// <summary>
+/// The scrub-during-edge-drag feedback loop behind issue #13955 ("grabbing and sliding in the
+/// waveform is mostly impossible to control" - the grabbed edge "flies about 10 subtitles to the
+/// right").
+///
+/// An edge drag scrubs the video to the edge being dragged. A consumer that reacts by scrolling
+/// the waveform to that position - which is what "center video position (also when paused)" does -
+/// closes a loop: the drag delta is measured in absolute waveform time (#13600), so the scroll is
+/// added to the delta, the edge moves further, the view scrolls further. Whole-paragraph moves
+/// never scrub, which is exactly why the reporter saw them behave while edge drags did not.
+///
+/// MainViewModel breaks the loop by not recentering while <see cref="AudioVisualizer.IsEditingWithPointer"/>
+/// is set. These tests pin the two facts that guard depends on: the flag is already true when the
+/// scrub fires, and a consumer that does scroll mid-drag really does amplify the drag.
+/// </summary>
+public class AudioVisualizerScrubFeedbackTests
+{
+    private const int SampleRate = 126; // px per second at zoom 1
+    private const double WidthPx = 800;
+    private const double LineStart = 100;
+    private const double LineEnd = 102;
+    private const double ViewStart = 98;
+
+    // The line's right edge, in px from the left of the view.
+    private const double RightEdgeX = (LineEnd - ViewStart) * SampleRate; // 504
+    private const double MiddleX = (LineStart + 1 - ViewStart) * SampleRate; // 378
+
+    private static WavePeakData2 MakePeaks(int seconds)
+    {
+        var peaks = new WavePeak2[SampleRate * seconds];
+        for (var i = 0; i < peaks.Length; i++)
+        {
+            peaks[i] = new WavePeak2(8000, -8000);
+        }
+
+        return new WavePeakData2(SampleRate, peaks);
+    }
+
+    private static (Window Window, AudioVisualizer Av) Open()
+    {
+        var av = new AudioVisualizer { WavePeaks = MakePeaks(200), Width = WidthPx, Height = 200 };
+        var line = new SubtitleLineViewModel
+        {
+            Text = "text",
+            StartTime = TimeSpan.FromSeconds(LineStart),
+            EndTime = TimeSpan.FromSeconds(LineEnd),
+        };
+
+        av.SetPosition(ViewStart, new List<SubtitleLineViewModel> { line }, 0, 0, new List<SubtitleLineViewModel>());
+
+        var window = new Window { Width = WidthPx, Height = 200, Content = av };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+        return (window, av);
+    }
+
+    private static void DragBy(Window window, double fromX, params double[] toXs)
+    {
+        window.MouseDown(new Point(fromX, 100), MouseButton.Left, RawInputModifiers.None);
+        foreach (var x in toXs)
+        {
+            window.MouseMove(new Point(x, 100), RawInputModifiers.None);
+            Dispatcher.UIThread.RunJobs();
+        }
+
+        window.MouseUp(new Point(toXs[^1], 100), MouseButton.Left, RawInputModifiers.None);
+    }
+
+    /// <summary>Runs an action with the drag-scrubs-the-video setting on.</summary>
+    private static void WithScrubOnMove(Action body)
+    {
+        var old = Se.Settings.Waveform.SetVideoPositionOnMoveStartEnd;
+        Se.Settings.Waveform.SetVideoPositionOnMoveStartEnd = true;
+        try
+        {
+            body();
+        }
+        finally
+        {
+            Se.Settings.Waveform.SetVideoPositionOnMoveStartEnd = old;
+        }
+    }
+
+    // The contract MainViewModel's guard is built on: by the time the scrub asks for a new video
+    // position, the control already reports that a pointer edit is in progress. If this ever
+    // regressed, the guard would silently stop guarding and #13955 would come back.
+    [AvaloniaFact]
+    public void EdgeDrag_ScrubFires_WhileIsEditingWithPointerIsAlreadyTrue()
+    {
+        WithScrubOnMove(() =>
+        {
+            var (window, av) = Open();
+            var fireCount = 0;
+            var everFiredWhileIdle = false;
+            av.OnVideoPositionChanged += (_, _) =>
+            {
+                fireCount++;
+                if (!av.IsEditingWithPointer)
+                {
+                    everFiredWhileIdle = true;
+                }
+            };
+
+            DragBy(window, RightEdgeX, RightEdgeX + 10, RightEdgeX + 11, RightEdgeX + 12);
+
+            Assert.True(fireCount > 0, "the edge drag should scrub the video");
+            Assert.False(everFiredWhileIdle, "every scrub during a drag must report IsEditingWithPointer");
+            window.Close();
+        });
+    }
+
+    // A consumer that leaves the view alone - i.e. what MainViewModel now does mid-drag - lets the
+    // edge track the pointer exactly: 12 px of travel is 12 px of travel.
+    [AvaloniaFact]
+    public void EdgeDrag_ConsumerLeavesTheViewAlone_EdgeTracksThePointer()
+    {
+        WithScrubOnMove(() =>
+        {
+            var (window, av) = Open();
+            var line = av.SelectedParagraph!;
+            var half = (av.EndPositionSeconds - av.StartPositionSeconds) / 2.0;
+
+            // The guarded consumer: skip the recenter while the pointer owns the waveform.
+            av.OnVideoPositionChanged += (_, e) =>
+            {
+                if (!av.IsEditingWithPointer)
+                {
+                    av.StartPositionSeconds = Math.Max(0, e.PositionInSeconds - half);
+                }
+            };
+
+            DragBy(window, RightEdgeX, RightEdgeX + 10, RightEdgeX + 11, RightEdgeX + 12);
+
+            Assert.Equal(LineEnd + 12.0 / SampleRate, line.EndTime.TotalSeconds, 3);
+            Assert.Equal(ViewStart, av.StartPositionSeconds, 6); // the view never moved
+            window.Close();
+        });
+    }
+
+    // Why the guard has to exist: an unguarded recenter turns 12 px of pointer travel into
+    // seconds of edge travel. This is the runaway the reporter described.
+    [AvaloniaFact]
+    public void EdgeDrag_ConsumerRecentersMidDrag_AmplifiesTheDragRunaway()
+    {
+        WithScrubOnMove(() =>
+        {
+            var (window, av) = Open();
+            var line = av.SelectedParagraph!;
+            var half = (av.EndPositionSeconds - av.StartPositionSeconds) / 2.0;
+
+            av.OnVideoPositionChanged += (_, e) =>
+                av.StartPositionSeconds = Math.Max(0, e.PositionInSeconds - half);
+
+            DragBy(window, RightEdgeX, RightEdgeX + 10, RightEdgeX + 11, RightEdgeX + 12);
+
+            var intended = 12.0 / SampleRate;               // ~0.095 s
+            var actual = line.EndTime.TotalSeconds - LineEnd;
+            Assert.True(actual > intended * 10,
+                $"expected the unguarded loop to amplify the drag, but it moved {actual:0.###} s for {intended:0.###} s of pointer travel");
+            window.Close();
+        });
+    }
+
+    // The asymmetry the reporter noticed: dragging a whole paragraph "goes at the slow pace",
+    // because it never scrubs, so the loop cannot start there.
+    [AvaloniaFact]
+    public void WholeParagraphMove_DoesNotScrubTheVideo()
+    {
+        WithScrubOnMove(() =>
+        {
+            var (window, av) = Open();
+            var firedDuringMove = false;
+            av.OnVideoPositionChanged += (_, _) => firedDuringMove = true;
+
+            // Press first: the single-click action sets the video position on its own, which is
+            // not the scrub under test.
+            window.MouseDown(new Point(MiddleX, 100), MouseButton.Left, RawInputModifiers.None);
+            Dispatcher.UIThread.RunJobs();
+            firedDuringMove = false;
+
+            foreach (var x in new[] { MiddleX + 10, MiddleX + 11, MiddleX + 12 })
+            {
+                window.MouseMove(new Point(x, 100), RawInputModifiers.None);
+                Dispatcher.UIThread.RunJobs();
+            }
+
+            Assert.False(firedDuringMove, "a whole-paragraph move should not scrub the video");
+
+            window.MouseUp(new Point(MiddleX + 12, 100), MouseButton.Left, RawInputModifiers.None);
+            window.Close();
+        });
+    }
+}


### PR DESCRIPTION
Fixes #13955

The reporter's key clue was the asymmetry: dragging an **edge** flies "about 10 subtitles to the right", while dragging a **whole caption** "goes at the slow pace I'm trying". That maps onto one difference in the code, and it is a feedback loop.

## The loop

1. An edge drag scrubs the video to the edge being dragged — `SetVideoPositionOnMoveStartEnd`, in `AudioVisualizer.OnPointerMoved`. Whole-paragraph moves are explicitly excluded from this.
2. With **center video position** + **center also when paused** on, the 60 fps cursor timer in `MainViewModel` reacts to that position change by scrolling the waveform to centre on it — i.e. on the very edge being dragged.
3. The drag delta is measured in absolute waveform time, deliberately (#13600): `dragDeltaSeconds = RelativeXPositionToSeconds(point.X) - _startPointerSeconds`, and `RelativeXPositionToSeconds` adds `StartPositionSeconds`.
4. So the scroll from step 2 is added straight into the delta → the edge moves further → step 2 scrolls further. Each pointer event amplifies the previous one.

Measured with a headless drag (`AudioVisualizerScrubFeedbackTests`): **12 px of pointer travel (~0.095 s) moved the edge 1.91 s** after three pointer events. On a touchpad reporting 60+ events per second, that is the reported runaway.

Two details from the report corroborate it:

- **Whole-caption drags are fine** — they never scrub, so the loop cannot start.
- **"After sliding all the way back left … this sometimes doesn't jump all over the place"** — the recenter is `Math.Max(0, est - halfSeconds)`, so near the start of the file the view cannot scroll any further left and the loop is clamped open.

It needs all three settings on (`CenterVideoPosition`, `CenterVideoPositionAlsoWhenPaused`, `SetVideoPositionOnMoveStartEnd`), all of which default to off — which is why "other people aren't reporting this".

## The fix

Don't recenter while a pointer edit is in progress (`av.IsEditingWithPointer`). Playback centering is untouched, so #13600 — the view scrolling under a held drag *during playback* must carry the edge — still holds. Re-centering the waveform under a held pointer is wrong on its own terms anyway: it drags the content out from under the user.

## Testing

4 new tests driving real pointer drags through the headless harness:

- the scrub fires while `IsEditingWithPointer` is already true (the contract the guard depends on — if this regresses, the guard silently stops guarding);
- a guarded consumer leaves the view alone and the edge tracks the pointer exactly;
- an **un**guarded consumer amplifies the drag (the runaway, pinned so the hazard stays documented);
- a whole-paragraph move does not scrub at all.

Full UI suite: **3338 passed, 0 failed**.

## Worth confirming with the reporter

I could not verify @GrampaWildWilly actually has those three settings enabled. The loop above is real and reproducible either way, but if their waveform is *not* in centering mode then something else is also in play and this fix won't be the whole answer — worth asking before closing the issue on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
