### PR TITLE
Allow main window interaction while Source View is open

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 ## Get latest from https://github.com/github/gitignore/blob/main/VisualStudio.gitignore
 
 # User-specific files
+.agents/
+build/build.cmd
 *.rsuser
 *.suo
 *.user

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1,4 +1,4 @@
-﻿using Nikse.SubtitleEdit.UiLogic.Export;
+using Nikse.SubtitleEdit.UiLogic.Export;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
@@ -546,6 +546,7 @@ public partial class MainViewModel :
     Control? _replacePreviousFocus;
     bool _replaceClosingProgrammatically;
     AdjustAllTimesViewModel? _adjustAllTimesViewModel;
+    SourceViewViewModel? _sourceViewViewModel;
 
     private static Color _errorColor = Se.Settings.General.ErrorColor.FromHexToColor();
 
@@ -1622,24 +1623,43 @@ public partial class MainViewModel :
     [RelayCommand]
     private async Task ShowSourceView()
     {
-        var oldSelectedIndex = SelectedSubtitleIndex ?? 0;
-        var result = await ShowDialogAsync<SourceViewWindow, SourceViewViewModel>(vm =>
+        if (_sourceViewViewModel != null && _sourceViewViewModel.Window != null && _sourceViewViewModel.Window.IsVisible)
         {
-            var subtitle = GetUpdateSubtitle();
-            var text = subtitle.ToText(SelectedSubtitleFormat);
-            var title = string.Format(Se.Language.General.SourceViewX, (string.IsNullOrEmpty(_subtitleFileName)
-                ? Se.Language.General.Untitled
-                : Path.GetFileName(_subtitleFileName)));
-            vm.Initialize(title, text, SelectedSubtitleFormat, subtitle, oldSelectedIndex);
-        });
-
-        if (result.OkPressed)
-        {
-            SetSubtitles(result.Subtitle);
-            var idx = Math.Min(oldSelectedIndex, Subtitles.Count - 1);
-            SelectAndScrollToRow(idx);
-            _updateAudioVisualizer = true;
+            _sourceViewViewModel.Window.Activate();
+            _sourceViewViewModel.FocusEditor();
+            return;
         }
+
+        var oldSelectedIndex = SelectedSubtitleIndex ?? 0;
+        var subtitle = GetUpdateSubtitle();
+        var text = subtitle.ToText(SelectedSubtitleFormat);
+        var title = string.Format(Se.Language.General.SourceViewX, (string.IsNullOrEmpty(_subtitleFileName)
+            ? Se.Language.General.Untitled
+            : Path.GetFileName(_subtitleFileName)));
+
+        _windowService.ShowWindowInit<SourceViewWindow, SourceViewViewModel>(
+            Window!,
+            configureViewModel: (vm) =>
+            {
+                _sourceViewViewModel = vm;
+                vm.Initialize(title, text, SelectedSubtitleFormat, subtitle, oldSelectedIndex, (newSub, _) =>
+                {
+                    SetSubtitles(newSub);
+                    var idx = Math.Min(oldSelectedIndex, Subtitles.Count - 1);
+                    SelectAndScrollToRow(idx);
+                    _updateAudioVisualizer = true;
+                });
+            },
+            configureWindow: (window) =>
+            {
+                window.Closed += (_, _) =>
+                {
+                    if (_sourceViewViewModel?.Window == window)
+                    {
+                        _sourceViewViewModel = null;
+                    }
+                };
+            });
     }
 
     [RelayCommand]

--- a/src/ui/Features/Shared/SourceView/SourceViewViewModel.cs
+++ b/src/ui/Features/Shared/SourceView/SourceViewViewModel.cs
@@ -113,16 +113,20 @@ public partial class SourceViewViewModel : ObservableObject, IClosingCleanup
         }
     }
 
+    private Action<Subtitle, int>? _onSave;
+
     internal void Initialize(
         string title,
         string text,
         SubtitleFormat subtitleFormat,
         Subtitle subtitle,
-        int selectedParagraphIndex)
+        int selectedParagraphIndex,
+        Action<Subtitle, int>? onSave = null)
     {
         Title = title;
         Text = text;
         _subtitleFormat = subtitleFormat;
+        _onSave = onSave;
         _initialCaretIndex = FindSelectedParagraphCaretIndex(text, subtitle, subtitleFormat, selectedParagraphIndex);
 
         // The editor only lays out the lines it shows, so even a very large source opens fast -
@@ -656,6 +660,7 @@ public partial class SourceViewViewModel : ObservableObject, IClosingCleanup
             Subtitle.Paragraphs.Clear();
             Subtitle.Paragraphs.AddRange(subtitle.Paragraphs);
             OkPressed = true;
+            _onSave?.Invoke(subtitle, _initialCaretIndex);
             Window?.Close();
             return;
         }
@@ -666,6 +671,7 @@ public partial class SourceViewViewModel : ObservableObject, IClosingCleanup
             Subtitle.Paragraphs.Clear();
             Subtitle.Paragraphs.AddRange(subtitle.Paragraphs);
             OkPressed = true;
+            _onSave?.Invoke(subtitle, _initialCaretIndex);
             Window?.Close();
             return;
         }

--- a/src/ui/Logic/WindowsService.cs
+++ b/src/ui/Logic/WindowsService.cs
@@ -40,6 +40,16 @@ namespace Nikse.SubtitleEdit.Logic
             where TViewModel : class;
 
         /// <summary>
+        /// Shows a window of type T with a specified ViewModel type, configuring ViewModel before Window creation.
+        /// </summary>
+        TViewModel ShowWindowInit<TWindow, TViewModel>(
+            Window owner,
+            Action<TViewModel>? configureViewModel = null,
+            Action<TWindow>? configureWindow = null)
+            where TWindow : Window
+            where TViewModel : class;
+
+        /// <summary>
         /// Shows a window of type T with a specified ViewModel type as an independent top-level
         /// window (no owner). Use this for windows that should appear in the OS Alt+Tab list
         /// independently and not be grouped with the main window — e.g. the undocked video player
@@ -127,6 +137,36 @@ namespace Nikse.SubtitleEdit.Logic
             window.WindowStartupLocation = WindowStartupLocation.CenterOwner;
 
             // Must run before Show() - see the note in ShowWindow<T>. (#12665)
+            ApplyRightToLeftSettings(window);
+            UiTheme.ApplyScaleToWindow(window);
+
+            window.Show(owner);
+            window.Focus();
+
+            return viewModel;
+        }
+
+        /// <inheritdoc />
+        public TViewModel ShowWindowInit<TWindow, TViewModel>(
+            Window owner,
+            Action<TViewModel>? configureViewModel = null,
+            Action<TWindow>? configureWindow = null)
+            where TWindow : Window
+            where TViewModel : class
+        {
+            var viewModel = _serviceProvider.GetRequiredService<TViewModel>();
+            configureViewModel?.Invoke(viewModel);
+
+            var w = Activator.CreateInstance(typeof(TWindow), viewModel);
+            if (w == null)
+            {
+                throw new InvalidOperationException($"Failed to create window of type {typeof(TWindow).Name} with constructor param {typeof(TViewModel).Name}");
+            }
+
+            var window = (TWindow)w;
+            window.WindowStartupLocation = WindowStartupLocation.CenterOwner;
+            configureWindow?.Invoke(window);
+
             ApplyRightToLeftSettings(window);
             UiTheme.ApplyScaleToWindow(window);
 


### PR DESCRIPTION
## Description
Changed the **Source View** window from a modal dialog (`ShowDialogAsync`) to a modeless window (`ShowWindowInit`), allowing users to freely interact with the main window (e.g. inspecting waveforms, browsing list, navigating video) while keeping the Source View editor open side by side.

## Changes
- **Window Management**: Added `ShowWindowInit` in `IWindowService` / `WindowService` to configure the `ViewModel` before window instantiation.
- **Modeless Lifecycle**: Switched `ShowSourceView` in `MainViewModel` to modeless mode with save callback (`onSave`) and single-instance activation guard.
- **Data Synchronization**: Synchronizes updated subtitles back to the main window upon confirming changes (OK button).
