### PR TITLE
OCR: fix l misread as i/I in any language without needing guessing

### DIFF
--- a/src/libuilogic/Ocr/FixEngine/OcrFixEngine.cs
+++ b/src/libuilogic/Ocr/FixEngine/OcrFixEngine.cs
@@ -345,6 +345,18 @@ public partial class OcrFixEngine : IOcrFixEngine, IDoSpell
                 isWordCorrect = true;
             }
 
+            // Binary image compare reads lowercase l as i (italics) or uppercase I (sans-serif
+            // fonts), in any language: "friendiy", "hostiie", "InteIIigence". The replace-list
+            // rules only cover a fixed pattern per entry, and the PartialWords guesses need
+            // "try to guess unknown words" on - so try the letter swap here, unconditionally,
+            // and keep it only when the dictionary or names list confirms the result (#13660).
+            if (!isWordCorrect && TryFixLMisreadAsI(result, out var lFixed))
+            {
+                result = lFixed;
+                word.GuessUsed = true;
+                isWordCorrect = true;
+            }
+
             if (!string.IsNullOrEmpty(result) && !isWordCorrect && doTryToGuessUnknownWords)
             {
                 var guesses = new List<string>();
@@ -404,6 +416,113 @@ public partial class OcrFixEngine : IOcrFixEngine, IDoSpell
 
         word.FixedWord = result;
         word.IsSpellCheckedOk = isWordCorrect;
+    }
+
+    // Tries every combination of the word's 'i'/'I' letters replaced by 'l' (fewest swaps first)
+    // and returns the first one the dictionary or names list accepts. Only words of at least five
+    // letters are considered, like the other unknown-word guesses, and a word with more than six
+    // candidate letters only gets the single-letter and all-letters variants.
+    private bool TryFixLMisreadAsI(string word, out string fixedWord)
+    {
+        fixedWord = word;
+        if (word.Length < 5)
+        {
+            return false;
+        }
+
+        var positions = new List<int>();
+        for (var i = 0; i < word.Length; i++)
+        {
+            var ch = word[i];
+            if (ch == 'i' || ch == 'I')
+            {
+                positions.Add(i);
+            }
+            else if (!char.IsLetter(ch) && ch != '\'' && ch != '-')
+            {
+                return false;
+            }
+        }
+
+        if (positions.Count == 0)
+        {
+            return false;
+        }
+
+        var chars = word.ToCharArray();
+        var found = string.Empty;
+        bool Accept(IReadOnlyList<int> swap)
+        {
+            foreach (var idx in swap)
+            {
+                chars[idx] = 'l';
+            }
+
+            var candidate = new string(chars);
+            foreach (var idx in swap)
+            {
+                chars[idx] = word[idx];
+            }
+
+            if (IsSpelledCorrect(candidate) || _spellCheckWordLists.HasName(candidate.Trim('\'', '-')))
+            {
+                found = candidate;
+                return true;
+            }
+
+            return false;
+        }
+
+        const int maxCombinationLetters = 6;
+        if (positions.Count > maxCombinationLetters)
+        {
+            foreach (var idx in positions)
+            {
+                if (Accept(new[] { idx }))
+                {
+                    fixedWord = found;
+                    return true;
+                }
+            }
+
+            if (Accept(positions))
+            {
+                fixedWord = found;
+                return true;
+            }
+
+            return false;
+        }
+
+        // All non-empty subsets of the positions, smallest subsets first.
+        var total = 1 << positions.Count;
+        for (var size = 1; size <= positions.Count; size++)
+        {
+            for (var mask = 1; mask < total; mask++)
+            {
+                if (System.Numerics.BitOperations.PopCount((uint)mask) != size)
+                {
+                    continue;
+                }
+
+                var swap = new List<int>(size);
+                for (var bit = 0; bit < positions.Count; bit++)
+                {
+                    if ((mask & (1 << bit)) != 0)
+                    {
+                        swap.Add(positions[bit]);
+                    }
+                }
+
+                if (Accept(swap))
+                {
+                    fixedWord = found;
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     // True when the word is a hyphenated compound (at least two parts) and every part is a

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixLMisreadAsITests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixLMisreadAsITests.cs
@@ -1,0 +1,143 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
+using Nikse.SubtitleEdit.Features.SpellCheck;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
+
+namespace UITests.Features.Ocr.FixEngine;
+
+// Issue #13660 (beta20 follow-up): binary image compare reads lowercase l as i or uppercase I in
+// non-italic text too ("friendiy", "hostiie", "InteIIigence"). Those were only repaired by the
+// PartialWords guesses, which need "try to guess unknown words" on - and the I->l regex rule
+// swaps the genuine leading capital of "InteIIigence" as well, so it never matched. The engine now
+// tries the i/I->l swaps itself for every unknown word, gated on the dictionary, in any language.
+public class OcrFixLMisreadAsITests : IDisposable
+{
+    private readonly Func<string> _originalSpellCheckDictionariesFolder;
+    private readonly string _tempDictionariesFolder;
+
+    public OcrFixLMisreadAsITests()
+    {
+        _originalSpellCheckDictionariesFolder = SpellCheckConfig.DictionariesFolder;
+
+        _tempDictionariesFolder = Path.Combine(
+            Path.GetTempPath(),
+            "SeOcrFixLMisreadAsITest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDictionariesFolder);
+        SpellCheckConfig.DictionariesFolder = () => _tempDictionariesFolder;
+
+        // No replace list at all - the fix must not depend on per-language list entries.
+        File.WriteAllText(
+            Path.Combine(_tempDictionariesFolder, "eng_OCRFixReplaceList.xml"),
+            "<ReplaceList></ReplaceList>");
+    }
+
+    [Theory]
+    [InlineData("<i>I have friendiy forces moving</i>", "<i>I have friendly forces moving</i>")]
+    [InlineData("<i>possible hostiie forces approaching</i>", "<i>possible hostile forces approaching</i>")]
+    [InlineData("<i>Friendiies are continuing on</i>", "<i>Friendlies are continuing on</i>")]
+    [InlineData("InteIIigence said", "Intelligence said")]
+    [InlineData("she smells most deIectabIe.", "she smells most delectable.")]
+    [InlineData("Lass uns nicht noch zu CIowns werden.", "Lass uns nicht noch zu Clowns werden.")]
+    public void FixOcrErrors_LMisreadAsI_IsFixedWithoutGuessing(string input, string expected)
+    {
+        var engine = CreateEngine();
+
+        var result = engine.FixOcrErrors(0, input, doTryToGuessUnknownWords: false);
+
+        Assert.Equal(expected, result.GetText());
+    }
+
+    [Fact]
+    public void FixOcrErrors_LMisreadAsI_IsReportedAsGuess()
+    {
+        var engine = CreateEngine();
+
+        var result = engine.FixOcrErrors(0, "I have friendiy forces", doTryToGuessUnknownWords: false);
+
+        var word = Assert.Single(result.Words, w => w.GuessUsed);
+        Assert.Equal("friendiy", word.Word);
+        Assert.Equal("friendly", word.FixedWord);
+    }
+
+    [Fact]
+    public void FixOcrErrors_CorrectWordWithI_IsLeftAlone()
+    {
+        var engine = CreateEngine();
+
+        // "Hail" -> "Hall" and "Mali" -> "Mall" would both be dictionary words, but the originals are correct.
+        var result = engine.FixOcrErrors(0, "Hail from Mali", doTryToGuessUnknownWords: false);
+
+        Assert.Equal("Hail from Mali", result.GetText());
+    }
+
+    [Fact]
+    public void FixOcrErrors_ShortUnknownWord_IsLeftAlone()
+    {
+        var engine = CreateEngine();
+
+        // Four letters: too short to risk the swap ("Cali" is a name, not a misread "Call").
+        var result = engine.FixOcrErrors(0, "From Cali", doTryToGuessUnknownWords: false);
+
+        Assert.Equal("From Cali", result.GetText());
+    }
+
+    [Fact]
+    public void FixOcrErrors_UnknownWordWithNoMatchingSwap_IsLeftAlone()
+    {
+        var engine = CreateEngine();
+
+        var result = engine.FixOcrErrors(0, "Meet Dimitri", doTryToGuessUnknownWords: false);
+
+        Assert.Equal("Meet Dimitri", result.GetText());
+    }
+
+    private static IOcrFixEngine CreateEngine()
+    {
+        IOcrFixEngine engine = new OcrFixEngine(new FakeSpellChecker());
+        engine.Initialize(new Subtitle(), "eng", new SpellCheckDictionaryDisplay());
+        return engine;
+    }
+
+    private sealed class FakeSpellChecker : ISpellChecker
+    {
+        private static readonly HashSet<string> Words = new(StringComparer.Ordinal)
+        {
+            "I", "have", "friendly", "forces", "moving", "possible", "hostile", "approaching",
+            "friendlies", "are", "continuing", "on", "intelligence", "said", "she", "smells", "most",
+            "delectable", "lass", "uns", "nicht", "noch", "zu", "clowns", "werden",
+            "hail", "hall", "from", "Mali", "mall", "call", "meet",
+        };
+
+        public bool Initialize(string dictionaryFile, string twoLetterLanguageCode) => true;
+
+        public bool IsWordCorrect(string word)
+        {
+            if (string.IsNullOrWhiteSpace(word))
+            {
+                return true;
+            }
+
+            // Like Hunspell, accept the initial-capitalized form of a lowercase dictionary word.
+            return Words.Contains(word) || Words.Contains(word.ToLowerInvariant());
+        }
+
+        public List<string> GetSuggestions(string word) => new();
+    }
+
+    public void Dispose()
+    {
+        SpellCheckConfig.DictionariesFolder = _originalSpellCheckDictionariesFolder;
+        try
+        {
+            Directory.Delete(_tempDictionariesFolder, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup.
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #13660 (beta20 feedback from @Miggu82).

## Problem
Binary image compare reads lowercase `l` as `i` (italics) or uppercase `I` (sans-serif) in non-italic text too: `friendiy`, `hostiie`, `Friendiies`, `InteIIigence`. Reproducing against the real en_US/de_DE Hunspell dictionaries showed:

- with **"Try to guess unknown words" on**, current main already fixes all reported words (English and German);
- with it **off**, only the multi-`I` words (`deIectabIe`, `ExceIIencies`, `CIowns`, `PIünderern`) are fixed — exactly the beta20 report. The `i→l` swap lived solely in the PartialWords guess path, and the `I→l` regex rule swaps the genuine leading capital of `InteIIigence` (→ `lntelligence`) so it never passed its spell-check gate.

## Fix
`OcrFixEngine` now tries every `i`/`I`→`l` combination (fewest swaps first) for unknown words of ≥5 letters and keeps the first one the dictionary or names list confirms — independent of the guess checkbox and of per-language replace-list entries, so it works for every language. Correct words never reach it; the swap is reported as a "guess used" so it shows in the OCR window's guesses list.

## Tests
New `OcrFixLMisreadAsITests` (all reporter words, English + German, with guessing off; guards for correct words, short words, and unknown words with no matching swap). OCR/spell-check/fix-common-errors suites: 822 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)