### PR TITLE
Add option to keep the source file's timestamp on converted files

### DIFF
--- a/docs/reference/command-line.md
+++ b/docs/reference/command-line.md
@@ -134,6 +134,7 @@ seconv lint *.srt --json             # CI-friendly: exit 1 on any issue
 | `--output-folder:<path>` | Output folder (default: input file's directory) |
 | `--output-filename:<name>` | Output file name (single input only) |
 | `--overwrite` | Overwrite existing files (default: rotate to `name_2.ext`, `_3.ext`, ...) |
+| `--keep-timestamp` | Give output files the source file's modified/created date instead of the conversion time |
 | `--encoding:<name>` | Encoding name or codepage. Special values: `utf-8`, `utf-8-no-bom` (also `utf-8-nobom`, `utf8-nobom`), a code page number, or `source` to keep the input file's detected encoding. Defaults: auto-detect on input, UTF-8 BOM on output |
 
 ### Time / frame

--- a/src/libse/Common/FileTimestampHelper.cs
+++ b/src/libse/Common/FileTimestampHelper.cs
@@ -1,0 +1,89 @@
+using System;
+using System.IO;
+
+namespace Nikse.SubtitleEdit.Core.Common
+{
+    /// <summary>
+    /// Copies file system timestamps from a source file onto written output files, so a
+    /// converted subtitle can keep the "modified" date of the file it was made from.
+    /// </summary>
+    public static class FileTimestampHelper
+    {
+        /// <summary>
+        /// Copies creation and last-write time from <paramref name="sourceFileName"/> onto
+        /// <paramref name="targetPath"/> (a file or a directory). Best-effort: returns false
+        /// and leaves the target untouched if either path is missing or the OS refuses
+        /// (e.g. read-only media, unsupported creation time on some Linux file systems).
+        /// </summary>
+        public static bool CopyTimestamps(string sourceFileName, string targetPath)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(sourceFileName) || string.IsNullOrEmpty(targetPath) || !File.Exists(sourceFileName))
+                {
+                    return false;
+                }
+
+                var source = new FileInfo(sourceFileName);
+                if (File.Exists(targetPath))
+                {
+                    var ok = TrySet(() => File.SetLastWriteTimeUtc(targetPath, source.LastWriteTimeUtc));
+                    TrySet(() => File.SetCreationTimeUtc(targetPath, source.CreationTimeUtc));
+                    return ok;
+                }
+
+                if (Directory.Exists(targetPath))
+                {
+                    var ok = TrySet(() => Directory.SetLastWriteTimeUtc(targetPath, source.LastWriteTimeUtc));
+                    TrySet(() => Directory.SetCreationTimeUtc(targetPath, source.CreationTimeUtc));
+                    return ok;
+                }
+
+                return false;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Copies timestamps onto every file inside <paramref name="directory"/> and the
+        /// directory itself; used for image exports that write a folder of PNGs + index file.
+        /// </summary>
+        public static void CopyTimestampsToDirectoryContents(string sourceFileName, string directory)
+        {
+            try
+            {
+                if (!Directory.Exists(directory))
+                {
+                    return;
+                }
+
+                foreach (var file in Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories))
+                {
+                    CopyTimestamps(sourceFileName, file);
+                }
+
+                CopyTimestamps(sourceFileName, directory);
+            }
+            catch
+            {
+                // best-effort
+            }
+        }
+
+        private static bool TrySet(Action action)
+        {
+            try
+            {
+                action();
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/src/seconv/Commands/ConvertCommand.cs
+++ b/src/seconv/Commands/ConvertCommand.cs
@@ -1,4 +1,4 @@
-using Nikse.SubtitleEdit.Core.Common;
+﻿using Nikse.SubtitleEdit.Core.Common;
 using Spectre.Console;
 using Spectre.Console.Cli;
 using System.ComponentModel;
@@ -174,6 +174,10 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
         [CommandOption("--overwrite")]
         [Description("Overwrite existing files")]
         public bool Overwrite { get; init; }
+
+        [CommandOption("--keep-timestamp|--keep-timestamps")]
+        [Description("Give output files the source file's modified/created date instead of now")]
+        public bool KeepTimestamp { get; init; }
 
         [CommandOption("--pac-codepage")]
         [Description("PAC code page")]
@@ -667,6 +671,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 Fps = settings.Fps,
                 TargetFps = settings.TargetFps,
                 Overwrite = settings.Overwrite,
+                KeepTimestamp = settings.KeepTimestamp,
                 Operations = operations,
                 FixCommonErrorsRules = fceRules,
                 FixCommonErrorsLanguage = settings.FixCommonErrorsLanguage,

--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -1,4 +1,4 @@
-using Nikse.SubtitleEdit.Core.Common;
+﻿using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 using Spectre.Console;
@@ -96,6 +96,7 @@ internal class SubtitleConverter
                         var warnings = new List<string>();
                         await ConvertFileAsync(inputFile, outputFile, options, warnings);
                         result.SuccessfulFiles++;
+                        ApplySourceTimestamp(options, inputFile, outputFile);
                         result.Files.Add(new FileConversionResult(inputFile, outputFile, true, null, warnings.Count > 0 ? warnings : null));
                         foreach (var warning in warnings)
                         {
@@ -131,6 +132,7 @@ internal class SubtitleConverter
                             }
                             await ConvertTrackAsync(track, outputFile, options);
                             result.SuccessfulFiles++;
+                            ApplySourceTimestamp(options, inputFile, outputFile);
                             result.Files.Add(new FileConversionResult(inputFile, outputFile, true, null));
                             if (!options.Quiet)
                             {
@@ -248,6 +250,14 @@ internal class SubtitleConverter
             // streams there's no clean 1:1 mapping back to inputs, but the OutputFile slot
             // is meant as a hint for the user — they'll see the full list in the summary.
             var primaryOutput = outputs[0].Path;
+            if (options.KeepTimestamp)
+            {
+                var newestVob = vobFiles.OrderByDescending(File.GetLastWriteTimeUtc).First();
+                foreach (var o in outputs)
+                {
+                    ApplySourceTimestamp(options, newestVob, o.Path);
+                }
+            }
             foreach (var f in vobFiles)
             {
                 result.Files.Add(new FileConversionResult(f, primaryOutput, true, null));
@@ -384,6 +394,7 @@ internal class SubtitleConverter
             items = load();
             WritePreservedBitmaps(items, outputFile, options);
             result.SuccessfulFiles++;
+            ApplySourceTimestamp(options, inputFile, outputFile);
             result.Files.Add(new FileConversionResult(inputFile, outputFile, true, null));
             if (!options.Quiet)
             {
@@ -469,6 +480,7 @@ internal class SubtitleConverter
                     : BitmapSubtitleLoader.LoadMatroskaPgs(matroska, track);
                 WritePreservedBitmaps(items, outputFile, options);
                 result.SuccessfulFiles++;
+                ApplySourceTimestamp(options, inputFile, outputFile);
                 result.Files.Add(new FileConversionResult(inputFile, outputFile, true, null));
                 if (!options.Quiet)
                 {
@@ -546,6 +558,7 @@ internal class SubtitleConverter
             {
                 WritePreservedBitmaps(items, outputFile, options);
                 result.SuccessfulFiles++;
+                ApplySourceTimestamp(options, inputFile, outputFile);
                 result.Files.Add(new FileConversionResult(inputFile, outputFile, true, null));
                 if (!options.Quiet)
                 {
@@ -653,6 +666,7 @@ internal class SubtitleConverter
             {
                 WritePreservedBitmaps(items, outputFile, options);
                 result.SuccessfulFiles++;
+                ApplySourceTimestamp(options, inputFile, outputFile);
                 result.Files.Add(new FileConversionResult(inputFile, outputFile, true, null));
                 if (!options.Quiet)
                 {
@@ -990,6 +1004,30 @@ internal class SubtitleConverter
         }
         throw new InvalidOperationException($"Could not find a free output filename for: {baseName}");
     }
+
+    /// <summary>
+    /// --keep-timestamp: stamp the written output (file, or folder for image exports, plus a
+    /// sibling .idx for VobSub) with the source file's timestamps. Best-effort, never throws.
+    /// </summary>
+    private static void ApplySourceTimestamp(ConversionOptions options, string inputFile, string outputFile)
+    {
+        if (!options.KeepTimestamp || string.IsNullOrEmpty(outputFile))
+        {
+            return;
+        }
+
+        if (Directory.Exists(outputFile))
+        {
+            FileTimestampHelper.CopyTimestampsToDirectoryContents(inputFile, outputFile);
+            return;
+        }
+
+        FileTimestampHelper.CopyTimestamps(inputFile, outputFile);
+        if (outputFile.EndsWith(".sub", StringComparison.OrdinalIgnoreCase))
+        {
+            FileTimestampHelper.CopyTimestamps(inputFile, Path.ChangeExtension(outputFile, ".idx"));
+        }
+    }
 }
 
 internal record class ConversionOptions
@@ -1010,6 +1048,9 @@ internal record class ConversionOptions
     public double? Fps { get; init; }
     public double? TargetFps { get; init; }
     public bool Overwrite { get; init; }
+
+    /// <summary>--keep-timestamp: copy the source file's creation/last-write time onto every output file.</summary>
+    public bool KeepTimestamp { get; init; }
     public List<string> Operations { get; init; } = new();
 
     /// <summary>

--- a/src/seconv/Helpers/HelpDisplay.cs
+++ b/src/seconv/Helpers/HelpDisplay.cs
@@ -52,6 +52,7 @@ internal static class HelpDisplay
         ShowParameter(console, "--output-filename:<file name>", "Output file name (for single file only)");
         ShowParameter(console, "--output-folder:<folder name>", "Output folder path");
         ShowParameter(console, "--overwrite", "Overwrite existing files");
+        ShowParameter(console, "--keep-timestamp", "Give output files the source file's modified/created date instead of the conversion time");
         ShowParameter(console, "--pac-codepage:<code page>", "PAC code page");
         ShowParameter(console, "--profile:<profile name>", "Profile name");
         ShowParameter(console, "--renumber:<starting number>", "Renumber subtitles from this number");

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertConfig.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertConfig.cs
@@ -14,6 +14,7 @@ public class BatchConvertConfig
     public string OutputFolder { get; set; }
     public bool SaveInSourceFolder { get; set; }
     public bool Overwrite { get; set; }
+    public bool KeepSourceTimestamp { get; set; }
     public string TargetFormatName { get; set; }
     public string TargetEncoding { get; set; }
     public bool AssaUseSourceStylesIfPossible { get; set; }
@@ -57,6 +58,7 @@ public class BatchConvertConfig
         OutputFolder = string.Empty;
         SaveInSourceFolder = true;
         Overwrite = false;
+        KeepSourceTimestamp = false;
         AssaUseSourceStylesIfPossible = false;
         AssaHeader = string.Empty;
         AssaFooter = string.Empty;

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -29,6 +29,7 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
     [ObservableProperty] private bool _useOutputFolder;
     [ObservableProperty] private string _outputFolder;
     [ObservableProperty] private bool _overwrite;
+    [ObservableProperty] private bool _keepSourceTimestamp;
     [ObservableProperty] private bool _scanFolderRecursive;
     [ObservableProperty] private ObservableCollection<string> _targetEncodings;
     [ObservableProperty] private string? _selectedTargetEncoding;
@@ -197,6 +198,7 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
         UseOutputFolder = !UseSourceFolder;
         OutputFolder = Se.Settings.Tools.BatchConvert.OutputFolder;
         Overwrite = Se.Settings.Tools.BatchConvert.Overwrite;
+        KeepSourceTimestamp = Se.Settings.Tools.BatchConvert.KeepSourceTimestamp;
         SelectedTargetEncoding = TargetEncodings.FirstOrDefault(p => p == Se.Settings.Tools.BatchConvert.TargetEncoding)
             ?? TargetEncodings.FirstOrDefault(p => p == TextEncoding.Utf8WithBom)
             ?? TargetEncodings.First();
@@ -210,6 +212,7 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
         Se.Settings.Tools.BatchConvert.SaveInSourceFolder = !UseOutputFolder;
         Se.Settings.Tools.BatchConvert.OutputFolder = OutputFolder;
         Se.Settings.Tools.BatchConvert.Overwrite = Overwrite;
+        Se.Settings.Tools.BatchConvert.KeepSourceTimestamp = KeepSourceTimestamp;
         Se.Settings.Tools.BatchConvert.TargetEncoding = SelectedTargetEncoding ?? TextEncoding.Utf8WithBom;
         Se.Settings.Tools.BatchConvert.LanguagePostFix = SelectedLanguagePostFix ?? Se.Language.General.TwoLetterLanguageCode;
         Se.Settings.Tools.BatchConvert.OcrEngine = SelectedOcrEngine ?? "nOcr";

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsWindow.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Layout;
@@ -35,6 +35,14 @@ public class BatchConvertSettingsWindow : Window
             IsChecked = vm.Overwrite,
             VerticalAlignment = VerticalAlignment.Center,
             [!CheckBox.IsCheckedProperty] = new Binding(nameof(vm.Overwrite)) { Mode = BindingMode.TwoWay, UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged },
+        };
+
+        var checkBoxKeepSourceTimestamp = new CheckBox
+        {
+            Content = Se.Language.Tools.BatchConvert.KeepSourceFileTimestamp,
+            IsChecked = vm.KeepSourceTimestamp,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!CheckBox.IsCheckedProperty] = new Binding(nameof(vm.KeepSourceTimestamp)) { Mode = BindingMode.TwoWay, UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged },
         };
 
         var checkBoxScanFolderRecursive = new CheckBox
@@ -169,6 +177,7 @@ public class BatchConvertSettingsWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
             {
@@ -183,14 +192,15 @@ public class BatchConvertSettingsWindow : Window
 
         grid.Add(panelTargetEncoding, 0, 0);
         grid.Add(checkBoxOverwrite, 1, 0);
-        grid.Add(checkBoxUseSourceFolder, 2, 0);
-        grid.Add(checkBoxUseOutputFolder, 3, 0);
-        grid.Add(panelOutputFolder, 4, 0);
-        grid.Add(panelOcrEngine, 5, 0);
-        grid.Add(checkBoxVobSubIsolateColors, 6, 0);
-        grid.Add(panelLanguagePostFix, 7, 0);
-        grid.Add(checkBoxScanFolderRecursive, 8, 0);
-        grid.Add(panelButtons, 9, 0);
+        grid.Add(checkBoxKeepSourceTimestamp, 2, 0);
+        grid.Add(checkBoxUseSourceFolder, 3, 0);
+        grid.Add(checkBoxUseOutputFolder, 4, 0);
+        grid.Add(panelOutputFolder, 5, 0);
+        grid.Add(panelOcrEngine, 6, 0);
+        grid.Add(checkBoxVobSubIsolateColors, 7, 0);
+        grid.Add(panelLanguagePostFix, 8, 0);
+        grid.Add(checkBoxScanFolderRecursive, 9, 0);
+        grid.Add(panelButtons, 10, 0);
 
 
         Content = grid;

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -1,4 +1,4 @@
-using Nikse.SubtitleEdit.UiLogic.Export;
+﻿using Nikse.SubtitleEdit.UiLogic.Export;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -2577,6 +2577,7 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
             SaveInSourceFolder = Se.Settings.Tools.BatchConvert.SaveInSourceFolder,
             OutputFolder = Se.Settings.Tools.BatchConvert.OutputFolder,
             Overwrite = Se.Settings.Tools.BatchConvert.Overwrite,
+            KeepSourceTimestamp = Se.Settings.Tools.BatchConvert.KeepSourceTimestamp,
             TargetFormatName = SelectedTargetFormat ?? string.Empty,
             TargetEncoding = Se.Settings.Tools.BatchConvert.TargetEncoding,
             AssaUseSourceStylesIfPossible = Se.Settings.Tools.BatchConvert.AssaUseSourceStylesIfPossible,

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -1,4 +1,4 @@
-using Avalonia.Skia;
+﻿using Avalonia.Skia;
 using Nikse.SubtitleEdit.UiLogic.Export;
 using Nikse.SubtitleEdit.Core.BluRaySup;
 using Nikse.SubtitleEdit.Features.Assa.ResolutionResampler;
@@ -76,6 +76,9 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
     // file would silently clobber each other's output.
     private readonly HashSet<string> _handedOutOutputFileNames = new(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>Output paths handed out while converting the current item - stamped with the source timestamp afterwards.</summary>
+    private readonly List<string> _currentItemOutputFileNames = new();
+
     public SubtitleFormat Format { get; set; } = new SubRip();
 
     public Encoding Encoding { get; set; } = Encoding.UTF8;
@@ -125,6 +128,48 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         {
             throw new InvalidOperationException("Initialize not called?");
         }
+
+        _currentItemOutputFileNames.Clear();
+        try
+        {
+            await ConvertCore(item, cancellationToken);
+        }
+        finally
+        {
+            if (_config.KeepSourceTimestamp)
+            {
+                ApplySourceTimestamp(item);
+            }
+
+            _currentItemOutputFileNames.Clear();
+        }
+    }
+
+    /// <summary>
+    /// "Keep source file date/time": stamp everything written for this item (file, or folder
+    /// for image exports, plus a sibling .idx for VobSub) with the source file's timestamps.
+    /// Runs after the output streams are closed; best-effort, never fails the conversion.
+    /// </summary>
+    private void ApplySourceTimestamp(BatchConvertItem item)
+    {
+        foreach (var path in _currentItemOutputFileNames)
+        {
+            if (Directory.Exists(path))
+            {
+                FileTimestampHelper.CopyTimestampsToDirectoryContents(item.FileName, path);
+                continue;
+            }
+
+            FileTimestampHelper.CopyTimestamps(item.FileName, path);
+            if (path.EndsWith(".sub", StringComparison.OrdinalIgnoreCase))
+            {
+                FileTimestampHelper.CopyTimestamps(item.FileName, Path.ChangeExtension(path, ".idx"));
+            }
+        }
+    }
+
+    private async Task ConvertCore(BatchConvertItem item, CancellationToken cancellationToken)
+    {
 
         IOcrSubtitle? imageSubtitle = null;
         if (item.Format == FormatBluRaySup)
@@ -3175,6 +3220,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
     private string TakeOutputFileName(string outputFileName)
     {
         _handedOutOutputFileNames.Add(outputFileName);
+        _currentItemOutputFileNames.Add(outputFileName);
         return outputFileName;
     }
 

--- a/src/ui/Logic/Config/Language/Tools/LanguageBatchConvert.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageBatchConvert.cs
@@ -53,6 +53,7 @@ public class LanguageBatchConvert
     public string AddFolderDotDotDot { get; set; }
     public string SelectFolderToConvert { get; set; }
     public string IncludeSubfolders { get; set; }
+    public string KeepSourceFileTimestamp { get; set; }
     public string ScanningFolderX { get; set; }
 
     public LanguageBatchConvert()
@@ -105,6 +106,7 @@ public class LanguageBatchConvert
         AddFolderDotDotDot = "Add folder...";
         SelectFolderToConvert = "Select folder with files to convert";
         IncludeSubfolders = "Include subfolders when adding a folder";
+        KeepSourceFileTimestamp = "Keep source file date/time on output files";
         ScanningFolderX = "Scanning {0}...";
     }
 }

--- a/src/ui/Logic/Config/SeBatchConvert.cs
+++ b/src/ui/Logic/Config/SeBatchConvert.cs
@@ -7,6 +7,9 @@ public class SeBatchConvert
     public string[] ActiveFunctions { get; set; } = [];
     public string OutputFolder { get; set; }
     public bool Overwrite { get; set; }
+
+    /// <summary>Give output files the source file's modified/created date instead of the conversion time.</summary>
+    public bool KeepSourceTimestamp { get; set; }
     public string TargetFormat { get; set; }
     public string CustomTextFormatName { get; set; } = string.Empty;
     public string TargetEncoding { get; set; }

--- a/tests/libse/Common/FileTimestampHelperTest.cs
+++ b/tests/libse/Common/FileTimestampHelperTest.cs
@@ -1,0 +1,67 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Xunit;
+
+namespace LibSETests.Common;
+
+public class FileTimestampHelperTest
+{
+    [Fact]
+    public void CopyTimestamps_File_CopiesLastWriteTime()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "FileTimestampHelperTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var source = Path.Combine(dir, "source.srt");
+            var target = Path.Combine(dir, "target.vtt");
+            File.WriteAllText(source, "a");
+            File.WriteAllText(target, "b");
+            var when = new DateTime(2010, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+            File.SetLastWriteTimeUtc(source, when);
+
+            Assert.True(FileTimestampHelper.CopyTimestamps(source, target));
+            Assert.Equal(when, File.GetLastWriteTimeUtc(target));
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void CopyTimestamps_MissingSourceOrTarget_ReturnsFalse()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Assert.False(FileTimestampHelper.CopyTimestamps(missing, missing + ".x"));
+        Assert.False(FileTimestampHelper.CopyTimestamps(string.Empty, missing));
+    }
+
+    [Fact]
+    public void CopyTimestampsToDirectoryContents_StampsFilesAndFolder()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "FileTimestampHelperTest_" + Guid.NewGuid().ToString("N"));
+        var outDir = Path.Combine(dir, "images");
+        Directory.CreateDirectory(outDir);
+        try
+        {
+            var source = Path.Combine(dir, "source.sup");
+            File.WriteAllText(source, "a");
+            var when = new DateTime(2012, 6, 7, 8, 9, 10, DateTimeKind.Utc);
+            File.SetLastWriteTimeUtc(source, when);
+            var f1 = Path.Combine(outDir, "0001.png");
+            var f2 = Path.Combine(outDir, "index.xml");
+            File.WriteAllText(f1, "x");
+            File.WriteAllText(f2, "y");
+
+            FileTimestampHelper.CopyTimestampsToDirectoryContents(source, outDir);
+
+            Assert.Equal(when, File.GetLastWriteTimeUtc(f1));
+            Assert.Equal(when, File.GetLastWriteTimeUtc(f2));
+            Assert.Equal(when, Directory.GetLastWriteTimeUtc(outDir));
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+}

--- a/tests/seconv/Core/KeepTimestampTest.cs
+++ b/tests/seconv/Core/KeepTimestampTest.cs
@@ -1,0 +1,72 @@
+using SeConv.Core;
+using Xunit;
+
+namespace SeConvTests.Core;
+
+/// <summary>
+/// --keep-timestamp (discussion #13963): outputs get the source file's modified date rather
+/// than the conversion time. Off by default.
+/// </summary>
+public class KeepTimestampTest : IDisposable
+{
+    private readonly string _tempRoot;
+
+    private const string SrtContent = """
+        1
+        00:00:01,000 --> 00:00:03,000
+        First.
+
+        """;
+
+    public KeepTimestampTest()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "KeepTimestampTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempRoot);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempRoot))
+            Directory.Delete(_tempRoot, recursive: true);
+    }
+
+    private async Task<(string input, string output, DateTime sourceTime)> RunAsync(bool keepTimestamp)
+    {
+        var input = Path.Combine(_tempRoot, "in.srt");
+        await File.WriteAllTextAsync(input, SrtContent, TestContext.Current.CancellationToken);
+        var sourceTime = new DateTime(2019, 5, 17, 12, 34, 56, DateTimeKind.Utc);
+        File.SetLastWriteTimeUtc(input, sourceTime);
+
+        var outDir = Path.Combine(_tempRoot, "out");
+        Directory.CreateDirectory(outDir);
+
+        var result = await new SubtitleConverter().ConvertAsync(new ConversionOptions
+        {
+            Patterns = [input],
+            Format = "WebVTT",
+            OutputFolder = outDir,
+            Overwrite = true,
+            KeepTimestamp = keepTimestamp,
+        });
+        Assert.True(result.Success, string.Join("; ", result.Errors));
+
+        return (input, Path.Combine(outDir, "in.vtt"), sourceTime);
+    }
+
+    [Fact]
+    public async Task KeepTimestamp_CopiesSourceLastWriteTime()
+    {
+        var (_, output, sourceTime) = await RunAsync(keepTimestamp: true);
+        Assert.True(File.Exists(output));
+        Assert.Equal(sourceTime, File.GetLastWriteTimeUtc(output));
+    }
+
+    [Fact]
+    public async Task Default_OutputGetsCurrentTime()
+    {
+        var (_, output, sourceTime) = await RunAsync(keepTimestamp: false);
+        Assert.True(File.Exists(output));
+        Assert.NotEqual(sourceTime, File.GetLastWriteTimeUtc(output));
+        Assert.True(File.GetLastWriteTimeUtc(output) > DateTime.UtcNow.AddMinutes(-5));
+    }
+}


### PR DESCRIPTION
Closes the ask in https://github.com/SubtitleEdit/subtitleedit/discussions/13963 — converted files should be able to keep the original's modified date.

## What
- **seconv**: new `--keep-timestamp` flag (help text + `docs/reference/command-line.md` updated).
- **Batch convert**: new checkbox *Keep source file date/time on output files* in the batch convert settings window, right under *Overwrite existing files*; persisted as `Tools.BatchConvert.KeepSourceTimestamp`.
- Shared `FileTimestampHelper` in libse: copies creation + last-write time from the source onto the output. Best-effort (never fails a conversion; creation time is silently ignored where the FS doesn't support it).

## Semantics
- Off by default — the usual "new file = new timestamp" behaviour is unchanged.
- Every output written for a source gets its timestamp: one SRT per mkv track, image-export folders and their contents, and the sibling `.idx` for VobSub. Multi-VOB → `.sub/.idx` uses the newest VOB's time.
- Stamping happens after the output streams are closed (batch convert: after each item finishes, via the names handed out by `MakeOutputFileName`, so all ~10 write paths are covered without touching each one).

## Tests
- `KeepTimestampTest` (seconv): flag copies the source's last-write time; default leaves the current time.
- `FileTimestampHelperTest` (libse): file, missing paths, directory contents.

Language string added in `LanguageBatchConvert.cs` only; English.json left for regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)