### PR TITLE
Fix grid focus, scroll and selection after delete/insert/merge commands

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -699,10 +699,16 @@ public static partial class InitListViewAndEditBox
             Source = vm,
         };
 
-        // Set up two-way binding for SelectedIndex
+        // SelectedIndex flows grid -> view model only. The view model drives the grid through
+        // SelectedItem above and only ever writes SelectedSubtitleIndex alongside it, and a TwoWay
+        // binding here echoed every grid-originated index change straight back: removing a row
+        // above a multi-selection shifts the grid's SelectedIndex, the echo re-assigned that same
+        // index, and SelectionModel.SelectedIndex's setter is Clear()+Select() even for an unchanged
+        // value - the whole selection collapsed to one row (merge selected lines with a reference
+        // row above the selection silently merged nothing).
         vm.SubtitleGrid[!TableView.SelectedIndexProperty] = new Binding(nameof(vm.SelectedSubtitleIndex))
         {
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWayToSource,
             Source = vm,
         };
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -471,6 +471,15 @@ public partial class MainViewModel :
         }
     }
 
+    /// <summary>
+    /// True when the current row is one of the display-only reference rows. Commands that act on
+    /// "the current line" must check this <b>before</b> WithoutReferenceOnlyRows: detaching the
+    /// row empties the selection, SelectionMode.AlwaysSelected re-picks row 0, and the TwoWay
+    /// binding makes that the current row - so a check made inside the action saw line 1 and,
+    /// for "merge with line after", merged lines 1 and 2 of a file the user never selected.
+    /// </summary>
+    private bool IsCurrentRowReferenceOnly => SelectedSubtitle?.IsReferenceOnly == true;
+
     private List<SubtitleLineViewModel> GetSelectedSubtitlesInOrder(bool includeReferenceOnly)
     {
         var selected = SubtitleGrid.SelectedItems;
@@ -5633,30 +5642,20 @@ public partial class MainViewModel :
             return;
         }
 
-        // Build selection mask
-        var total = Subtitles.Count;
-        var isSelected = new bool[total];
-        for (int i = 0; i < total; i++)
-        {
-            isSelected[i] = false;
-        }
-
-        foreach (var item in selectedItems)
-        {
-            var idx = Subtitles.IndexOf(item);
-            if (idx >= 0 && idx < total)
-            {
-                isSelected[idx] = true;
-            }
-        }
+        // The column is the working subtitle's: a display-only reference row in between is not a
+        // cell, so it neither gives up its text nor receives a shifted one (it would have kept it
+        // as an unsaved, unnumbered row).
+        var column = Subtitles.Where(p => !p.IsReferenceOnly).ToList();
+        var selectedSet = new HashSet<SubtitleLineViewModel>(selectedItems);
 
         // Remove selected cells (texts) and shift remaining up
+        var total = column.Count;
         var newTexts = new List<string>(total);
-        for (int i = 0; i < total; i++)
+        foreach (var row in column)
         {
-            if (!isSelected[i])
+            if (!selectedSet.Contains(row))
             {
-                newTexts.Add(Subtitles[i].Text);
+                newTexts.Add(row.Text);
             }
         }
 
@@ -5668,7 +5667,7 @@ public partial class MainViewModel :
 
         for (int i = 0; i < total; i++)
         {
-            Subtitles[i].Text = newTexts[i];
+            column[i].Text = newTexts[i];
         }
 
         _shortcutManager.ClearKeys();
@@ -5684,13 +5683,15 @@ public partial class MainViewModel :
             return;
         }
 
-        var total = Subtitles.Count;
-        var texts = Subtitles.Select(p => p.Text).ToList();
+        // Working rows only - see ColumnDeleteTextAndShiftCellsUp.
+        var column = Subtitles.Where(p => !p.IsReferenceOnly).ToList();
+        var total = column.Count;
+        var texts = column.Select(p => p.Text).ToList();
 
         // Insert empty cells at the original selection indices and shift down
         // Use delta to keep correct original target positions
         var indices = selectedItems
-            .Select(x => Subtitles.IndexOf(x))
+            .Select(x => column.IndexOf(x))
             .Where(i => i >= 0 && i < total)
             .Distinct()
             .OrderBy(i => i)
@@ -5727,7 +5728,7 @@ public partial class MainViewModel :
 
         for (int i = 0; i < total; i++)
         {
-            Subtitles[i].Text = texts[i];
+            column[i].Text = texts[i];
         }
 
         _shortcutManager.ClearKeys();
@@ -12321,7 +12322,10 @@ public partial class MainViewModel :
     private void DuplicateSelectedLines()
     {
         var newSubtitles = new List<SubtitleLineViewModel>();
-        foreach (var selected in _selectedSubtitles ?? [])
+        // Not the display-only reference rows: the copy constructor keeps IsReferenceOnly, so
+        // duplicating one produced a second dimmed, unnumbered row that was never saved - and
+        // that an editable original then captured as a new line.
+        foreach (var selected in SubtitleGridSelectedItems)
         {
             newSubtitles.Add(new SubtitleLineViewModel(selected));
         }
@@ -12334,6 +12338,9 @@ public partial class MainViewModel :
         if (newSubtitles.Count > 0)
         {
             Renumber();
+            // Like SE4, the duplicates become the selection so the user sees where they went.
+            SelectAndScrollToRows(newSubtitles);
+            _updateAudioVisualizer = true;
         }
 
         _shortcutManager.ClearKeys();
@@ -12411,6 +12418,11 @@ public partial class MainViewModel :
     [RelayCommand]
     private void MergeWithLineBefore()
     {
+        if (IsCurrentRowReferenceOnly)
+        {
+            return;
+        }
+
         RunWithoutChangeDetection(() =>
         {
             WithoutReferenceOnlyRows(MergeLineBefore);
@@ -12420,6 +12432,11 @@ public partial class MainViewModel :
     [RelayCommand]
     private void MergeWithLineAfter()
     {
+        if (IsCurrentRowReferenceOnly)
+        {
+            return;
+        }
+
         RunWithoutChangeDetection(() =>
         {
             WithoutReferenceOnlyRows(MergeLineAfter);
@@ -12429,6 +12446,11 @@ public partial class MainViewModel :
     [RelayCommand]
     private void MergeWithLineBeforeKeepBreaks()
     {
+        if (IsCurrentRowReferenceOnly)
+        {
+            return;
+        }
+
         RunWithoutChangeDetection(() =>
         {
             WithoutReferenceOnlyRows(MergeLineBeforeKeepBreaks);
@@ -12438,6 +12460,11 @@ public partial class MainViewModel :
     [RelayCommand]
     private void MergeWithLineAfterKeepBreaks()
     {
+        if (IsCurrentRowReferenceOnly)
+        {
+            return;
+        }
+
         RunWithoutChangeDetection(() =>
         {
             WithoutReferenceOnlyRows(MergeLineAfterKeepBreaks);
@@ -12447,12 +12474,17 @@ public partial class MainViewModel :
     [RelayCommand]
     private void MergeWithLineAfterAsDialog()
     {
+        if (IsCurrentRowReferenceOnly)
+        {
+            return;
+        }
+
         RunWithoutChangeDetection(() => WithoutReferenceOnlyRows(() =>
         {
             var selected = SelectedSubtitle;
-            if (selected == null)
+            if (selected == null || selected.IsReferenceOnly)
             {
-                return;
+                return; // see MergeLineBefore
             }
 
             var index = Subtitles.IndexOf(selected);
@@ -12472,12 +12504,17 @@ public partial class MainViewModel :
     [RelayCommand]
     private void MergeWithLineBeforeAsDialog()
     {
+        if (IsCurrentRowReferenceOnly)
+        {
+            return;
+        }
+
         RunWithoutChangeDetection(() => WithoutReferenceOnlyRows(() =>
         {
             var selected = SelectedSubtitle;
-            if (selected == null)
+            if (selected == null || selected.IsReferenceOnly)
             {
-                return;
+                return; // see MergeLineBefore
             }
 
             var index = Subtitles.IndexOf(selected);
@@ -12751,31 +12788,31 @@ public partial class MainViewModel :
     [RelayCommand]
     private void MergeSelectedLines()
     {
-        WithoutReferenceOnlyRows(() => MergeLinesSelected());
+        RunWithoutChangeDetection(() => WithoutReferenceOnlyRows(() => MergeLinesSelected()));
     }
 
     [RelayCommand]
     private void MergeSelectedLinesDialog()
     {
-        WithoutReferenceOnlyRows(MergeLinesSelectedAsDialog);
+        RunWithoutChangeDetection(() => WithoutReferenceOnlyRows(MergeLinesSelectedAsDialog));
     }
 
     [RelayCommand]
     private void MergeSelectedLinesBilingual()
     {
-        WithoutReferenceOnlyRows(MergeLinesSelectedBilingual);
+        RunWithoutChangeDetection(() => WithoutReferenceOnlyRows(MergeLinesSelectedBilingual));
     }
 
     [RelayCommand]
     private void MergeSelectedLinesAndUnbreak()
     {
-        WithoutReferenceOnlyRows(() => MergeLinesSelected(MergeManager.BreakMode.Unbreak));
+        RunWithoutChangeDetection(() => WithoutReferenceOnlyRows(() => MergeLinesSelected(MergeManager.BreakMode.Unbreak)));
     }
 
     [RelayCommand]
     private void MergeSelectedLinesAndUnbreakCjk()
     {
-        WithoutReferenceOnlyRows(() => MergeLinesSelected(MergeManager.BreakMode.UnbreakNoSpace));
+        RunWithoutChangeDetection(() => WithoutReferenceOnlyRows(() => MergeLinesSelected(MergeManager.BreakMode.UnbreakNoSpace)));
     }
 
     [RelayCommand]
@@ -15240,22 +15277,27 @@ public partial class MainViewModel :
         var endMs = startMs + Se.Settings.General.NewEmptyDefaultMs;
         var newParagraph =
             new SubtitleLineViewModel(new Paragraph(string.Empty, startMs, endMs), SelectedSubtitleFormat);
-        var idx = _insertService.InsertInCorrectPosition(Subtitles, newParagraph);
-        SetDefaultAssaStyleForNewParagraph(newParagraph, idx);
-        var next = GetNextWorkingRow(idx);
-        if (next != null)
+        // Same bracket as the waveform inserts: one undo step for the insert plus its timing.
+        RunWithoutChangeDetection(() =>
         {
-            if (next.StartTime.TotalMilliseconds < endMs)
+            var idx = _insertService.InsertInCorrectPosition(Subtitles, newParagraph);
+            SetDefaultAssaStyleForNewParagraph(newParagraph, idx);
+            var next = GetNextWorkingRow(idx);
+            if (next != null)
             {
-                newParagraph.EndTime = TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds -
-                                                                 Se.Settings.General.MinimumBetweenLines.GetMilliseconds());
+                if (next.StartTime.TotalMilliseconds < endMs)
+                {
+                    newParagraph.EndTime = TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds -
+                                                                     Se.Settings.General.MinimumBetweenLines.GetMilliseconds());
+                }
             }
-        }
+
+            Renumber();
+        });
 
         _setEndAtKeyUpLine = newParagraph;
         _setEndAtKeyUpLineGoToNext = false;
         SelectAndScrollToSubtitle(newParagraph);
-        Renumber();
         _updateAudioVisualizer = true;
     }
 
@@ -15680,6 +15722,7 @@ public partial class MainViewModel :
         var pos = vp.Position;
         var subtitlesAtPosition = Subtitles
             .Where(p =>
+                !p.IsReferenceOnly && // an overlapping reference row is not a second line to split
                 p.StartTime.TotalSeconds < pos &&
                 p.EndTime.TotalSeconds > pos).ToList();
 
@@ -16081,6 +16124,12 @@ public partial class MainViewModel :
         {
             SelectAndScrollToSubtitle(linesInserted.First());
         }
+        else if (linesInserted.Count > 1)
+        {
+            // Like the grid paste: the pasted block becomes the selection, so the user sees where
+            // it landed instead of the old selection staying put with no visible change.
+            SelectAndScrollToRows(linesInserted);
+        }
 
         _updateAudioVisualizer = true;
     }
@@ -16240,17 +16289,19 @@ public partial class MainViewModel :
         var pos = vp.Position;
         var subtitlesAtPosition = Subtitles
             .Where(p =>
+                !p.IsReferenceOnly && // the original's lines are not ours to delete
                 p.StartTime.TotalSeconds < pos &&
                 p.EndTime.TotalSeconds > pos).ToList();
-
-        foreach (var p in subtitlesAtPosition)
+        if (subtitlesAtPosition.Count == 0)
         {
-            Subtitles.Remove(p);
+            return;
         }
 
-        Renumber();
-
-        _updateAudioVisualizer = true;
+        // Through the same path as the Delete key: a removed current row hands the selection to
+        // its neighbour instead of leaving the grid on a stale (or AlwaysSelected-forced row 0)
+        // selection, and a surviving current row stays put.
+        var gridHadFocus = IsSubtitleGridFocusedOrFocusDropped();
+        RemoveRowsAndSelectSurvivor(subtitlesAtPosition, PickRowToSelectAfterRemoval(subtitlesAtPosition), gridHadFocus);
     }
 
     [RelayCommand]
@@ -17605,31 +17656,14 @@ public partial class MainViewModel :
             return;
         }
 
-        // Remember where the first cut line was so we can re-select a row afterwards.
-        // Leaving the grid with a dangling/empty selection crashes for some users.
-        var idx = Subtitles.IndexOf(selectedItems[0]);
+        var gridHadFocus = IsSubtitleGridFocusedOrFocusDropped();
 
-        await SubtitleGridCopyPasteHelper.Cut(Window, Subtitles, selectedItems, SelectedSubtitleFormat, _subtitle);
-        Renumber();
+        await SubtitleGridCopyPasteHelper.Copy(Window, selectedItems, SelectedSubtitleFormat, _subtitle);
 
-        if (Subtitles.Count == 0)
-        {
-            // Everything was cut: clear the stale selection so the grid and the
-            // waveform highlight don't keep pointing at the removed lines.
-            SubtitleGrid.SelectedItem = null;
-            SubtitleGridSelectionChanged();
-        }
-        else
-        {
-            if (idx >= Subtitles.Count)
-            {
-                idx = Subtitles.Count - 1;
-            }
-
-            SelectAndScrollToRow(idx);
-        }
-
-        _updateAudioVisualizer = true;
+        // Same removal as delete: the survivor is selected before the rows go, so the grid never
+        // has a dangling/empty selection (which crashed for some users) and does not jump.
+        var survivor = PickRowToSelectAfterRemoval(selectedItems);
+        RemoveRowsAndSelectSurvivor(selectedItems, survivor, gridHadFocus);
         _shortcutManager.ClearKeys();
     }
 
@@ -17680,6 +17714,14 @@ public partial class MainViewModel :
         // index >= Count as append (#13200). Empty grid: insert at 0 (the helper handles
         // index 0 with an empty list; a negative index would throw on Insert).
         var idx = FirstSelectedSubtitleIndex;
+        if (idx < 0)
+        {
+            // Only a display-only reference row is selected: it is not an editable line, but it
+            // is where the user clicked, so paste there rather than at the end of the file.
+            var referenceRow = SubtitleGridSelectedItemsWithReference.FirstOrDefault();
+            idx = referenceRow != null ? Subtitles.IndexOf(referenceRow) : -1;
+        }
+
         if (idx < 0 || idx > Subtitles.Count)
         {
             idx = Subtitles.Count;
@@ -18073,6 +18115,7 @@ public partial class MainViewModel :
         }
 
         var language = LanguageAutoDetect.AutoDetectGoogleLanguage(GetUpdateSubtitle());
+        var countBefore = Subtitles.Count;
         RunWithoutChangeDetection(() =>
         {
             if (atVideoPosition && atTextBoxPosition && vp != null)
@@ -18093,6 +18136,36 @@ public partial class MainViewModel :
             }
 
             Renumber();
+        });
+
+        // The first half stays the current row (SE4's "focus left"), but the second half goes in
+        // right below it - off screen when the split line was the bottom visible row, with nothing
+        // to show the user where it went. Scroll just enough to reveal it; the selection, the
+        // focus (text box or grid) and the caret are left alone.
+        if (Subtitles.Count > countBefore)
+        {
+            var newHalf = Subtitles.GetOrNull(Subtitles.IndexOf(s) + 1);
+            if (newHalf != null)
+            {
+                RevealRowPosted(newHalf);
+            }
+        }
+
+        _updateAudioVisualizer = true;
+    }
+
+    /// <summary>Scrolls minimally so <paramref name="row"/> is fully on screen; no selection change.</summary>
+    private void RevealRowPosted(SubtitleLineViewModel row)
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (!Subtitles.Contains(row) || TableViewExtras.IsRowFullyVisible(SubtitleGrid, row))
+            {
+                return;
+            }
+
+            SubtitleGrid.ScrollIntoView(row);
+            EnsureRowFullyVisibleInSubtitleGrid(row);
         });
     }
 
@@ -18498,7 +18571,14 @@ public partial class MainViewModel :
     /// new one for the merged-away original line) before the callback, so an index captured
     /// during the merge landed rows above the merged line (#13962).
     /// </summary>
-    private void SelectAndScrollToRow(SubtitleLineViewModel row)
+    /// <param name="row">The row to select.</param>
+    /// <param name="restoreGridFocus">
+    /// Whether to put keyboard focus back on the grid afterwards. Null (the default) means
+    /// "if the grid has it right now" - pass the answer captured earlier when the call comes
+    /// after a removal, as removing the focused row's container has already dropped focus to
+    /// null by then and the check here would say no.
+    /// </param>
+    private void SelectAndScrollToRow(SubtitleLineViewModel row, bool? restoreGridFocus = null)
     {
         var index = Subtitles.IndexOf(row);
         if (index < 0)
@@ -18506,10 +18586,10 @@ public partial class MainViewModel :
             return;
         }
 
-        SelectAndScrollToRow(index, row);
+        SelectAndScrollToRow(index, row, restoreGridFocus);
     }
 
-    private void SelectAndScrollToRow(int index, SubtitleLineViewModel? row)
+    private void SelectAndScrollToRow(int index, SubtitleLineViewModel? row, bool? restoreGridFocus = null)
     {
         _shiftSelectAnchorIndex = -1;
         _shiftSelectCurrentIndex = -1;
@@ -18518,7 +18598,7 @@ public partial class MainViewModel :
         // keyboard focus out of the grid (End followed by Home would then do nothing,
         // as the key handler is gated on IsSubtitleGridFocused). Capture the focus
         // state now and put focus back on the newly selected row after the scroll.
-        var subtitleGridHadFocus = IsSubtitleGridFocused();
+        var subtitleGridHadFocus = restoreGridFocus ?? IsSubtitleGridFocused();
 
         lock (_scrollLock)
         {
@@ -18549,6 +18629,12 @@ public partial class MainViewModel :
             {
                 var itemToScroll = Subtitles[indexToScroll];
                 var rowChanged = !ReferenceEquals(SubtitleGrid.SelectedItem, itemToScroll);
+
+                // Run the layout the collection change left pending, so the visibility check below
+                // sees the rows where they are now: a just-inserted row has no container until
+                // then, and counted as off screen - so every Insert re-centred the view with
+                // "center selected row" on, even though the new row sat in the middle of it.
+                SubtitleGrid.UpdateLayout();
 
                 // A row that is already on screen needs no scrolling at all: after a delete the
                 // next line becomes current and it was visible right below the deleted one, and
@@ -18640,6 +18726,7 @@ public partial class MainViewModel :
 
         _shiftSelectAnchorIndex = -1;
         _shiftSelectCurrentIndex = -1;
+        var gridHadFocus = IsSubtitleGridFocused();
 
         // The first pasted row goes in first so it becomes the SelectedItem (the row the edit
         // box shows), then the rest of the block is added to the selection.
@@ -18651,7 +18738,42 @@ public partial class MainViewModel :
         EditTextBox.CaretIndex = 0;
         EditTextBoxOriginal.CaretIndex = 0;
 
-        var itemToScroll = Subtitles[startIndex];
+        ScrollRowIntoViewPosted(Subtitles[startIndex], gridHadFocus);
+    }
+
+    /// <summary>
+    /// Selects <paramref name="rows"/> (the first becomes the current row) and scrolls that first
+    /// row into view - for a set that need not be contiguous, e.g. duplicates of a scattered
+    /// selection.
+    /// </summary>
+    private void SelectAndScrollToRows(IReadOnlyList<SubtitleLineViewModel> rows)
+    {
+        if (rows.Count == 0)
+        {
+            return;
+        }
+
+        _shiftSelectAnchorIndex = -1;
+        _shiftSelectCurrentIndex = -1;
+        var gridHadFocus = IsSubtitleGridFocused();
+
+        ApplyGridSelection(rows);
+
+        EditTextBox.CaretIndex = 0;
+        EditTextBoxOriginal.CaretIndex = 0;
+
+        ScrollRowIntoViewPosted(rows[0], gridHadFocus);
+    }
+
+    /// <summary>
+    /// The scroll half of SelectAndScrollToRow for callers that have already applied a (multi-row)
+    /// selection: posted so it runs after the collection change has been laid out, a no-scroll when
+    /// the row is already fully on screen, and with keyboard focus put back on the grid when
+    /// <paramref name="restoreGridFocus"/> - a long scroll recycles the focused row container,
+    /// which silently drops focus out of the grid.
+    /// </summary>
+    private void ScrollRowIntoViewPosted(SubtitleLineViewModel itemToScroll, bool restoreGridFocus)
+    {
         Dispatcher.UIThread.Post(() =>
         {
             if (!Subtitles.Contains(itemToScroll))
@@ -18659,16 +18781,25 @@ public partial class MainViewModel :
                 return;
             }
 
-            TableViewExtras.PrePositionScroll(SubtitleGrid, Subtitles.IndexOf(itemToScroll));
-            SubtitleGrid.ScrollIntoView(itemToScroll);
+            var alreadyVisible = TableViewExtras.IsRowFullyVisible(SubtitleGrid, itemToScroll);
+            if (!alreadyVisible)
+            {
+                TableViewExtras.PrePositionScroll(SubtitleGrid, Subtitles.IndexOf(itemToScroll));
+                SubtitleGrid.ScrollIntoView(itemToScroll);
+            }
 
-            if (Se.Settings.General.SubtitleGridCenterSelectedRow)
+            if (Se.Settings.General.SubtitleGridCenterSelectedRow && !alreadyVisible)
             {
                 CenterSelectedRowInSubtitleGrid(itemToScroll);
             }
             else
             {
                 EnsureRowFullyVisibleInSubtitleGrid(itemToScroll);
+            }
+
+            if (restoreGridFocus)
+            {
+                Dispatcher.UIThread.Post(() => TableViewExtras.FocusRow(SubtitleGrid));
             }
         });
     }
@@ -18763,9 +18894,31 @@ public partial class MainViewModel :
             // Only execute if this is the latest scroll request
             if (subtitleToScroll != null && Subtitles.Contains(subtitleToScroll))
             {
+                var rowChanged = !ReferenceEquals(SubtitleGrid.SelectedItem, subtitleToScroll);
+
                 TableViewExtras.PrePositionScroll(SubtitleGrid, Subtitles.IndexOf(subtitleToScroll));
                 SubtitleGrid.SelectedItem = subtitleToScroll;
                 SubtitleGrid.ScrollIntoView(subtitleToScroll);
+
+                // Same two repairs as SelectAndScrollToRow: assigning an item the grid already
+                // shows as selected raises no SelectionChanged (row 0 after a file open, #13190/
+                // #13303), so resync the view model explicitly; and reset the caret when the edit
+                // box now shows another line (#12707) - a waveform paste lands on a non-empty
+                // line, and left the caret at the previous line's clamped position.
+                var selectionCacheStale = _selectedSubtitles == null
+                                          || _selectedSubtitles.Count != 1
+                                          || !ReferenceEquals(_selectedSubtitles[0], subtitleToScroll);
+                if (!ReferenceEquals(SelectedSubtitle, subtitleToScroll) || selectionCacheStale)
+                {
+                    TableViewExtras.SyncSelectedItemsWithSelection(SubtitleGrid);
+                    SubtitleGridSelectionChanged();
+                }
+
+                if (rowChanged)
+                {
+                    EditTextBox.CaretIndex = 0;
+                    EditTextBoxOriginal.CaretIndex = 0;
+                }
 
                 if (Se.Settings.General.SubtitleGridCenterSelectedRow)
                 {
@@ -23078,6 +23231,9 @@ public partial class MainViewModel :
             return;
         }
 
+        // Before the prompt: the dialog moves focus around, and the removal below drops it.
+        var gridHadFocus = IsSubtitleGridFocusedOrFocusDropped();
+
         if (Se.Settings.General.PromptBeforeDelete)
         {
             var title = Se.Language.General.Delete;
@@ -23103,63 +23259,180 @@ public partial class MainViewModel :
             _shortcutManager.ClearKeys();
         }
 
-        _subtitleGridSelectionChangedSkip = true;
-        var idx = Subtitles.IndexOf(selectedItems.First());
         _undoRedoManager.StopChangeDetection();
-
-        // Detach ItemsSource to prevent updates
-        var itemsSource = SubtitleGrid.ItemsSource;
-        var isLargeDelete = selectedItems.Count > 10;
-        if (isLargeDelete)
-        {
-            SubtitleGrid.ItemsSource = null;
-        }
-
         try
         {
-            var selectedSet = new HashSet<SubtitleLineViewModel>(selectedItems);
-            var indicesToRemove = Subtitles
-                .Select((s, i) => (s, i))
-                .Where(x => selectedSet.Contains(x.s))
-                .Select(x => x.i)
-                .OrderByDescending(i => i)
-                .ToList();
+            var survivor = PickRowToSelectAfterRemoval(selectedItems);
+            RemoveRowsAndSelectSurvivor(selectedItems, survivor, gridHadFocus);
+        }
+        finally
+        {
+            _undoRedoManager.StartChangeDetection();
+        }
+    }
 
-            foreach (var index in indicesToRemove)
+    /// <summary>
+    /// True when keyboard focus is in the subtitle grid - or nowhere at all, which after a
+    /// previous removal/recycle of the focused row container is the same thing: focus left
+    /// the grid without the user moving it, and the next key press would otherwise walk from
+    /// the window root into the menu bar (#13182, #13111). Capture this <b>before</b> removing
+    /// rows: removing the focused row's container drops focus to null synchronously, so a
+    /// check made after the removal can no longer tell that the grid had it.
+    /// </summary>
+    private bool IsSubtitleGridFocusedOrFocusDropped()
+    {
+        return IsSubtitleGridFocused() || Window?.FocusManager?.GetFocusedElement() == null;
+    }
+
+    /// <summary>
+    /// The row that becomes current once <paramref name="rowsToRemove"/> are gone: the first
+    /// surviving working row at or below the first removed one (the line that visually takes
+    /// its place), else the last surviving working row above it. A display-only reference row
+    /// is never picked - it belongs to the original, and landing on it would leave the user on
+    /// a line they cannot edit. Null when nothing is left to select.
+    /// </summary>
+    private SubtitleLineViewModel? PickRowToSelectAfterRemoval(IReadOnlyCollection<SubtitleLineViewModel> rowsToRemove)
+    {
+        var removeSet = new HashSet<SubtitleLineViewModel>(rowsToRemove);
+
+        // A current row that survives (e.g. the waveform's delete-at-position removing another
+        // line) stays current - the user did not ask for the selection to move.
+        if (SelectedSubtitle != null && !SelectedSubtitle.IsReferenceOnly && !removeSet.Contains(SelectedSubtitle))
+        {
+            return SelectedSubtitle;
+        }
+
+        var firstIndex = -1;
+        for (var i = 0; i < Subtitles.Count; i++)
+        {
+            if (removeSet.Contains(Subtitles[i]))
             {
-                Subtitles.RemoveAt(index);
+                firstIndex = i;
+                break;
+            }
+        }
+
+        if (firstIndex < 0)
+        {
+            return null;
+        }
+
+        for (var i = firstIndex + 1; i < Subtitles.Count; i++)
+        {
+            if (!removeSet.Contains(Subtitles[i]) && !Subtitles[i].IsReferenceOnly)
+            {
+                return Subtitles[i];
+            }
+        }
+
+        for (var i = firstIndex - 1; i >= 0; i--)
+        {
+            if (!removeSet.Contains(Subtitles[i]) && !Subtitles[i].IsReferenceOnly)
+            {
+                return Subtitles[i];
+            }
+        }
+
+        // Only reference rows remain - better than leaving nothing selected.
+        return Subtitles.FirstOrDefault(p => !removeSet.Contains(p));
+    }
+
+    /// <summary>
+    /// Removes <paramref name="rowsToRemove"/> from the grid and leaves <paramref name="survivor"/>
+    /// selected, scrolled into view only if it is not already, and with keyboard focus back on the
+    /// grid when <paramref name="gridHadFocus"/>.
+    ///
+    /// The selection is handed to the survivor <b>before</b> the rows go. Removing the selected
+    /// rows first let SelectionMode.AlwaysSelected re-pick row 0 synchronously, which (a) posted
+    /// Avalonia's own ScrollIntoView(0) ahead of ours, so the grid jumped to the top and came back
+    /// to an estimated offset even when the survivor had been fully visible the whole time, and
+    /// (b) wrote row 0 into SelectedSubtitle through the TwoWay binding (the skip flag only
+    /// silences the grid event), so the edit box, status bar and whitespace trimming briefly ran
+    /// against line 1. With the survivor already the single selected row, the selection never
+    /// empties and neither happens.
+    /// </summary>
+    private void RemoveRowsAndSelectSurvivor(
+        IReadOnlyCollection<SubtitleLineViewModel> rowsToRemove,
+        SubtitleLineViewModel? survivor,
+        bool gridHadFocus)
+    {
+        var removeSet = new HashSet<SubtitleLineViewModel>(rowsToRemove);
+        var wasSkipping = _subtitleGridSelectionChangedSkip;
+        _subtitleGridSelectionChangedSkip = true;
+
+        // Per-row removal costs ~10 µs of grid bookkeeping each, so only a really large delete is
+        // worth detaching ItemsSource for - the reattach re-realizes the rows and moves the scroll
+        // offset, which for an ordinary delete is exactly the jump this method avoids.
+        var isLargeDelete = rowsToRemove.Count > 1000;
+        var itemsSource = SubtitleGrid.ItemsSource;
+        try
+        {
+            if (survivor != null)
+            {
+                SubtitleGrid.SelectedItem = survivor;
             }
 
-            if (idx >= Subtitles.Count)
+            if (isLargeDelete)
             {
-                idx = Subtitles.Count - 1;
+                SubtitleGrid.ItemsSource = null;
+            }
+
+            for (var i = Subtitles.Count - 1; i >= 0 && removeSet.Count > 0; i--)
+            {
+                if (removeSet.Remove(Subtitles[i]))
+                {
+                    Subtitles.RemoveAt(i);
+                }
             }
 
             Renumber();
         }
         finally
         {
-            // Reattach ItemsSource
             if (isLargeDelete)
             {
                 SubtitleGrid.ItemsSource = itemsSource;
+                if (survivor != null)
+                {
+                    SubtitleGrid.SelectedItem = survivor;
+                }
             }
 
-            _subtitleGridSelectionChangedSkip = false;
-            SelectAndScrollToRow(idx);
-            _undoRedoManager.StartChangeDetection();
-            SubtitleGridSelectionChanged();
+            _subtitleGridSelectionChangedSkip = wasSkipping;
             _updateAudioVisualizer = true;
+        }
+
+        if (survivor != null)
+        {
+            // Refresh the selection cache now (the skip flag kept the grid event from doing it),
+            // so a command that runs before the posted scroll sees the survivor, not the removed rows.
+            SubtitleGridSelectionChanged();
+            SelectAndScrollToRow(survivor, gridHadFocus);
+        }
+        else
+        {
+            // Everything went: clear the stale selection so the grid and the waveform highlight
+            // don't keep pointing at the removed lines, and keep focus on the (still focusable)
+            // empty grid so the next key press does not land in the menu bar.
+            SubtitleGrid.SelectedItem = null;
+            SubtitleGridSelectionChanged();
+            if (gridHadFocus)
+            {
+                Dispatcher.UIThread.Post(() => TableViewExtras.FocusRow(SubtitleGrid));
+            }
         }
     }
 
     private async Task RippleDeleteSelectedItems()
     {
-        var selectedItems = _selectedSubtitles?.ToList() ?? [];
+        // Same reference-row rule as DeleteSelectedItems: display-only rows are not ours to delete.
+        var selectedItems = _selectedSubtitles?.Where(p => !p.IsReferenceOnly).ToList() ?? [];
         if (selectedItems.Count == 0)
         {
             return;
         }
+
+        var gridHadFocus = IsSubtitleGridFocusedOrFocusDropped();
 
         if (Se.Settings.General.PromptBeforeDelete)
         {
@@ -23186,52 +23459,24 @@ public partial class MainViewModel :
             _shortcutManager.ClearKeys();
         }
 
-        _subtitleGridSelectionChangedSkip = true;
         _undoRedoManager.StopChangeDetection();
-
-        var sortedIndices = selectedItems
-            .Select(item => Subtitles.IndexOf(item))
-            .OrderBy(i => i)
-            .ToList();
-
-        // Anchor on the lowest selected index - rows that are no longer in Subtitles drop out
-        // of the mapping above, so this is not simply Subtitles.IndexOf(selectedItems[0]).
-        var idx = sortedIndices.FirstOrDefault();
-
-        var firstLine = Subtitles.GetOrNull(sortedIndices.FirstOrDefault());
-
-        var areLinesConsecutive = sortedIndices.Count == 1 ||
-                                  sortedIndices.Zip(sortedIndices.Skip(1), (a, b) => b - a).All(diff => diff == 1);
-
-        var nextLine = Subtitles.GetOrNull(idx + selectedItems.Count);
-
-        // Detach ItemsSource to prevent updates
-        var itemsSource = SubtitleGrid.ItemsSource;
-        var isLargeDelete = selectedItems.Count > 10;
-        if (isLargeDelete)
-        {
-            SubtitleGrid.ItemsSource = null;
-        }
-
         try
         {
-            var indicesToRemove = selectedItems
-                .Select(Subtitles.IndexOf)
+            var sortedIndices = selectedItems
+                .Select(item => Subtitles.IndexOf(item))
                 .Where(i => i >= 0)
-                .OrderByDescending(i => i)
+                .OrderBy(i => i)
                 .ToList();
 
-            foreach (var index in indicesToRemove)
-            {
-                Subtitles.RemoveAt(index);
-            }
+            var firstLine = Subtitles.GetOrNull(sortedIndices.FirstOrDefault());
 
-            if (idx >= Subtitles.Count)
-            {
-                idx = Subtitles.Count - 1;
-            }
+            var areLinesConsecutive = sortedIndices.Count == 1 ||
+                                      sortedIndices.Zip(sortedIndices.Skip(1), (a, b) => b - a).All(diff => diff == 1);
 
-            Renumber();
+            var nextLine = Subtitles.GetOrNull(sortedIndices.FirstOrDefault() + sortedIndices.Count);
+
+            var survivor = PickRowToSelectAfterRemoval(selectedItems);
+            RemoveRowsAndSelectSurvivor(selectedItems, survivor, gridHadFocus);
 
             if (areLinesConsecutive && firstLine != null && nextLine != null)
             {
@@ -23239,6 +23484,11 @@ public partial class MainViewModel :
                 var timeToShift = nextLine.StartTime - firstLine.StartTime;
                 for (var i = indexOfNext; i < Subtitles.Count; i++)
                 {
+                    if (Subtitles[i].IsReferenceOnly)
+                    {
+                        continue; // the original's lines are not retimed along with ours
+                    }
+
                     Subtitles[i].SetStartTimeKeepDuration(Subtitles[i].StartTime - timeToShift);
                 }
 
@@ -23247,42 +23497,45 @@ public partial class MainViewModel :
         }
         finally
         {
-            // Reattach ItemsSource
-            if (isLargeDelete)
-            {
-                SubtitleGrid.ItemsSource = itemsSource;
-            }
-
-            _subtitleGridSelectionChangedSkip = false;
-            SelectAndScrollToRow(idx);
             _undoRedoManager.StartChangeDetection();
-            SubtitleGridSelectionChanged();
-            _updateAudioVisualizer = true;
         }
+    }
+
+    /// <summary>
+    /// The row an insert anchors on: the topmost selected row (SE4's FirstSelectedIndex), not the
+    /// current row - that is the moving end of a shift-selection, so "insert before" on rows 5-8
+    /// selected downwards went in above row 8. Falls back to the current row when only a display-
+    /// only reference row is selected: inserting next to the line the user is looking at is still
+    /// what they asked for.
+    /// </summary>
+    private SubtitleLineViewModel? GetInsertAnchorRow()
+    {
+        var firstIndex = FirstSelectedSubtitleIndex;
+        return firstIndex >= 0 ? Subtitles[firstIndex] : SelectedSubtitle;
     }
 
     private void InsertBeforeSelectedItem()
     {
-        var selectedItem = SelectedSubtitle;
-        if (selectedItem != null)
+        var anchor = GetInsertAnchorRow();
+        if (anchor != null)
         {
-            var index = Subtitles.IndexOf(selectedItem);
+            var index = Subtitles.IndexOf(anchor);
             _insertService.InsertBefore(SelectedSubtitleFormat, _subtitle, Subtitles, index, string.Empty);
             Renumber();
-            SelectAndScrollToRow(index);
+            SelectAndScrollToRow(Subtitles[index]);
             _updateAudioVisualizer = true;
         }
     }
 
     private void InsertAfterSelectedItem()
     {
-        var selectedItem = SelectedSubtitle;
-        if (selectedItem != null)
+        var anchor = GetInsertAnchorRow();
+        if (anchor != null)
         {
-            var index = Subtitles.IndexOf(selectedItem);
+            var index = Subtitles.IndexOf(anchor);
             _insertService.InsertAfter(SelectedSubtitleFormat, _subtitle, Subtitles, index, string.Empty);
             Renumber();
-            SelectAndScrollToRow(index + 1);
+            SelectAndScrollToRow(Subtitles[index + 1]);
             _updateAudioVisualizer = true;
         }
     }
@@ -23308,8 +23561,13 @@ public partial class MainViewModel :
 
     private void MergeLineBefore()
     {
+        // A display-only reference row can be the current row (it is selectable so its text can
+        // be read), but it is not a line of the working subtitle: WithoutReferenceOnlyRows has
+        // detached it, so IndexOf is -1 and "the line after" resolved to the first line of the
+        // file - a crash here, and with the dialog variant a merge onto the detached row that
+        // silently deleted line 1.
         var selectedItem = SelectedSubtitle;
-        if (selectedItem != null)
+        if (selectedItem != null && !selectedItem.IsReferenceOnly)
         {
             var index = Subtitles.IndexOf(selectedItem);
             var previous = Subtitles.GetOrNull(index - 1);
@@ -23333,8 +23591,13 @@ public partial class MainViewModel :
 
     private void MergeLineBeforeKeepBreaks()
     {
+        // A display-only reference row can be the current row (it is selectable so its text can
+        // be read), but it is not a line of the working subtitle: WithoutReferenceOnlyRows has
+        // detached it, so IndexOf is -1 and "the line after" resolved to the first line of the
+        // file - a crash here, and with the dialog variant a merge onto the detached row that
+        // silently deleted line 1.
         var selectedItem = SelectedSubtitle;
-        if (selectedItem != null)
+        if (selectedItem != null && !selectedItem.IsReferenceOnly)
         {
             var index = Subtitles.IndexOf(selectedItem);
             var previous = Subtitles.GetOrNull(index - 1);
@@ -23358,8 +23621,13 @@ public partial class MainViewModel :
 
     private void MergeLineAfter()
     {
+        // A display-only reference row can be the current row (it is selectable so its text can
+        // be read), but it is not a line of the working subtitle: WithoutReferenceOnlyRows has
+        // detached it, so IndexOf is -1 and "the line after" resolved to the first line of the
+        // file - a crash here, and with the dialog variant a merge onto the detached row that
+        // silently deleted line 1.
         var selectedItem = SelectedSubtitle;
-        if (selectedItem != null)
+        if (selectedItem != null && !selectedItem.IsReferenceOnly)
         {
             var index = Subtitles.IndexOf(selectedItem);
             var next = Subtitles.GetOrNull(index + 1);
@@ -23383,8 +23651,13 @@ public partial class MainViewModel :
 
     private void MergeLineAfterKeepBreaks()
     {
+        // A display-only reference row can be the current row (it is selectable so its text can
+        // be read), but it is not a line of the working subtitle: WithoutReferenceOnlyRows has
+        // detached it, so IndexOf is -1 and "the line after" resolved to the first line of the
+        // file - a crash here, and with the dialog variant a merge onto the detached row that
+        // silently deleted line 1.
         var selectedItem = SelectedSubtitle;
-        if (selectedItem != null)
+        if (selectedItem != null && !selectedItem.IsReferenceOnly)
         {
             var index = Subtitles.IndexOf(selectedItem);
             var next = Subtitles.GetOrNull(index + 1);
@@ -23402,6 +23675,7 @@ public partial class MainViewModel :
             _mergeManager.MergeSelectedLines(Subtitles, list, breakMode: MergeManager.BreakMode.KeepBreaks, keepEndTime: MergeManager.ShouldKeepEndTime(SelectedSubtitleFormat));
             Renumber();
             SelectAndScrollToRow(selectedItem);
+            _updateAudioVisualizer = true;
         }
     }
 
@@ -23417,10 +23691,16 @@ public partial class MainViewModel :
         // selection there regardless of the order the rows were clicked in.
         var first = selectedItems.MinBy(item => Subtitles.IndexOf(item))!;
 
+        var countBefore = Subtitles.Count;
         _mergeManager.MergeSelectedLines(Subtitles, selectedItems, breakMode: breakMode, keepEndTime: MergeManager.ShouldKeepEndTime(SelectedSubtitleFormat));
+        if (Subtitles.Count == countBefore)
+        {
+            return; // refused (non-contiguous selection): leave the user's selection as it was
+        }
 
-        SelectAndScrollToRow(first);
         Renumber();
+        SelectAndScrollToRow(first);
+        _updateAudioVisualizer = true;
     }
 
     private void MergeLinesSelectedAsDialog()
@@ -23464,7 +23744,6 @@ public partial class MainViewModel :
             }
         }
 
-        var firstIndex = ordered[0].Index;
         var first = ordered[0].Item;
         var last = ordered[ordered.Count - 1].Item;
 
@@ -23482,7 +23761,8 @@ public partial class MainViewModel :
         }
 
         Renumber();
-        SelectAndScrollToRow(firstIndex);
+        // By row, not by index: the reference rows come back before the posted scroll runs (#13962).
+        SelectAndScrollToRow(first);
         _updateAudioVisualizer = true;
     }
 
@@ -23680,7 +23960,7 @@ public partial class MainViewModel :
         else
         {
             IsSubtitleGridDataMenuVisible = true;
-            IsMergeWithNextOrPreviousVisible = selectedCount == 1;
+            IsMergeWithNextOrPreviousVisible = selectedCount == 1 && SelectedSubtitle?.IsReferenceOnly != true;
             IsInsertLineNoSelectionVisible = false;
             // Any single selected line, not only the last - a pre-timed file keeps its own time
             // codes, so inserting midway is a normal workflow (discussion #11744).

--- a/src/ui/Logic/SubtitleGridCopyPasteHelper.cs
+++ b/src/ui/Logic/SubtitleGridCopyPasteHelper.cs
@@ -26,25 +26,6 @@ internal static class SubtitleGridCopyPasteHelper
         await ClipboardHelper.SetTextAsync(window, text);
     }
 
-    internal static async Task Cut(Window window, ObservableCollection<SubtitleLineViewModel> subtitles, List<SubtitleLineViewModel> selectedItems, SubtitleFormat subtitleFormat, Subtitle sourceSubtitle)
-    {
-        var subtitle = new Subtitle();
-        subtitle.Header = sourceSubtitle.Header;
-        subtitle.Footer = sourceSubtitle.Footer;
-        foreach (var item in selectedItems)
-        {
-            subtitle.Paragraphs.Add(item.ToParagraph(subtitleFormat));
-        }
-
-        var text = GetClipboardText(subtitleFormat, subtitle);
-        await ClipboardHelper.SetTextAsync(window, text);
-
-        foreach (var item in selectedItems)
-        {
-            subtitles.Remove(item);
-        }
-    }
-
     // When copying ASSA/SSA lines, only the event lines ("Dialogue:"/"Comment:") belong on the
     // clipboard: Aegisub's paste interprets every other clipboard line (the [Script Info] /
     // [V4+ Styles] file header) as a plain-text subtitle line, so the file headers would be

--- a/tests/UI/Features/Main/SubtitleGridDeleteInsertFocusScrollTests.cs
+++ b/tests/UI/Features/Main/SubtitleGridDeleteInsertFocusScrollTests.cs
@@ -1,0 +1,420 @@
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Main.MainHelpers;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using System.Reflection;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// What the subtitle grid does with focus, the scroll offset and the selection right after a
+/// command deletes or inserts rows. Three things used to go wrong on a plain Delete alone:
+/// removing the focused row's container dropped keyboard focus to null (the next arrow key then
+/// walked into the menu bar - the #13182/#13111 pattern), SelectionMode.AlwaysSelected re-picked
+/// row 0 and posted Avalonia's own scroll-to-top ahead of ours (the grid jumped even though the
+/// next line was fully visible), and that row-0 re-pick leaked into SelectedSubtitle through the
+/// TwoWay binding. The rest covers the reference-row edge cases of the merge/insert/duplicate
+/// commands found in the same review.
+/// </summary>
+public class SubtitleGridDeleteInsertFocusScrollTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    [AvaloniaFact]
+    public async Task Delete_FocusedRow_KeepsKeyboardFocusInGrid()
+    {
+        Se.Settings.General.PromptBeforeDelete = false;
+        var (window, vm) = ShowMainWindowWithLines(300);
+
+        vm.SelectAndScrollToSubtitle(vm.Subtitles[10]);
+        Settle(window);
+        TableViewExtras.FocusRow(vm.SubtitleGrid);
+        Settle(window);
+        Assert.True(vm.SubtitleGrid.IsKeyboardFocusWithin);
+
+        await vm.DeleteSelectedLinesCommand.ExecuteAsync(null);
+        await SettleAsync(window);
+
+        Assert.True(vm.SubtitleGrid.IsKeyboardFocusWithin,
+            $"focus left the grid after delete: {window.FocusManager?.GetFocusedElement()?.GetType().Name ?? "<null>"}");
+        Assert.Equal("Line 12", vm.SelectedSubtitle?.Text);
+
+        window.KeyPressQwerty(PhysicalKey.ArrowDown, RawInputModifiers.None);
+        await SettleAsync(window);
+
+        Assert.False(window.FocusManager?.GetFocusedElement() is MenuItem, "the arrow key went to the menu bar");
+        Assert.Equal("Line 13", vm.SelectedSubtitle?.Text);
+    }
+
+    [AvaloniaFact]
+    public async Task Delete_MiddleRow_DoesNotMoveTheScrollOffset()
+    {
+        Se.Settings.General.PromptBeforeDelete = false;
+        Se.Settings.General.SubtitleGridCenterSelectedRow = false;
+        var (window, vm) = ShowMainWindowWithLines(300);
+
+        vm.SelectAndScrollToSubtitle(vm.Subtitles[100]);
+        await SettleAsync(window);
+        vm.SelectAndScrollToSubtitle(vm.Subtitles[108]);
+        await SettleAsync(window);
+        var scrollViewer = vm.SubtitleGrid.GetVisualDescendants().OfType<ScrollViewer>().First();
+        var offsetBefore = scrollViewer.Offset.Y;
+        Assert.True(offsetBefore > 0);
+        Assert.True(TableViewExtras.IsRowFullyVisible(vm.SubtitleGrid, vm.Subtitles[109]));
+
+        await vm.DeleteSelectedLinesCommand.ExecuteAsync(null);
+        await SettleAsync(window);
+
+        Assert.Equal("Line 110", vm.SelectedSubtitle?.Text);
+        Assert.Equal(offsetBefore, scrollViewer.Offset.Y);
+    }
+
+    [AvaloniaFact]
+    public async Task Delete_NeverShowsRowZeroAsSelectedInBetween()
+    {
+        Se.Settings.General.PromptBeforeDelete = false;
+        var (window, vm) = ShowMainWindowWithLines(50);
+
+        vm.SelectAndScrollToSubtitle(vm.Subtitles[20]);
+        await SettleAsync(window);
+
+        var selectedDuringRemoval = new List<string?>();
+        vm.Subtitles.CollectionChanged += (_, _) => selectedDuringRemoval.Add(vm.SelectedSubtitle?.Text);
+
+        await vm.DeleteSelectedLinesCommand.ExecuteAsync(null);
+        await SettleAsync(window);
+
+        Assert.DoesNotContain("Line 1", selectedDuringRemoval);
+        Assert.Equal("Line 22", vm.SelectedSubtitle?.Text);
+        Assert.Equal(49, vm.Subtitles.Count);
+    }
+
+    [AvaloniaFact]
+    public async Task Delete_LastRow_SelectsThePreviousOne()
+    {
+        Se.Settings.General.PromptBeforeDelete = false;
+        var (window, vm) = ShowMainWindowWithLines(5);
+
+        vm.SelectAndScrollToSubtitle(vm.Subtitles[4]);
+        await SettleAsync(window);
+
+        await vm.DeleteSelectedLinesCommand.ExecuteAsync(null);
+        await SettleAsync(window);
+
+        Assert.Equal("Line 4", vm.SelectedSubtitle?.Text);
+        Assert.Equal(4, vm.Subtitles.Count);
+    }
+
+    [AvaloniaFact]
+    public async Task Delete_EveryRow_KeepsFocusOnTheEmptyGrid()
+    {
+        Se.Settings.General.PromptBeforeDelete = false;
+        var (window, vm) = ShowMainWindowWithLines(3);
+
+        vm.SelectAndScrollToSubtitle(vm.Subtitles[0]);
+        await SettleAsync(window);
+        TableViewExtras.FocusRow(vm.SubtitleGrid);
+        Settle(window);
+        vm.SubtitleGrid.SelectAll();
+        Settle(window);
+
+        await vm.DeleteSelectedLinesCommand.ExecuteAsync(null);
+        await SettleAsync(window);
+
+        Assert.Empty(vm.Subtitles);
+        Assert.Null(vm.SelectedSubtitle);
+        Assert.True(vm.SubtitleGrid.IsKeyboardFocusWithin || ReferenceEquals(window.FocusManager?.GetFocusedElement(), vm.SubtitleGrid));
+    }
+
+    [AvaloniaFact]
+    public async Task Delete_WithReferenceRowNext_SkipsItAndSelectsTheNextWorkingLine()
+    {
+        Se.Settings.General.PromptBeforeDelete = false;
+        var (window, vm) = CreateWithSampleReference();
+
+        // Rows: Translated one | (reference only) | Translated two
+        vm.SelectAndScrollToSubtitle(vm.Subtitles[0]);
+        await SettleAsync(window);
+
+        await vm.DeleteSelectedLinesCommand.ExecuteAsync(null);
+        await SettleAsync(window);
+
+        Assert.Equal("Translated two", vm.SelectedSubtitle?.Text);
+        Assert.False(vm.SelectedSubtitle!.IsReferenceOnly);
+    }
+
+    [AvaloniaFact]
+    public async Task MergeWithLineAfter_FromReferenceOnlyRow_DoesNothing()
+    {
+        var (window, vm) = CreateWithSampleReference();
+        var referenceRow = vm.Subtitles.Single(p => p.IsReferenceOnly);
+        vm.SelectAndScrollToSubtitle(referenceRow);
+        await SettleAsync(window);
+        var textsBefore = vm.Subtitles.Select(p => p.Text).ToList();
+
+        // Used to throw ArgumentOutOfRangeException (IndexOf -1 on the detached row).
+        vm.MergeWithLineAfterCommand.Execute(null);
+        vm.MergeWithLineAfterKeepBreaksCommand.Execute(null);
+        await SettleAsync(window);
+
+        Assert.Equal(textsBefore, vm.Subtitles.Select(p => p.Text).ToList());
+    }
+
+    [AvaloniaFact]
+    public async Task MergeWithLineAfterAsDialog_FromReferenceOnlyRow_DoesNotDeleteLineOne()
+    {
+        var (window, vm) = CreateWithSampleReference();
+        var referenceRow = vm.Subtitles.Single(p => p.IsReferenceOnly);
+        vm.SelectAndScrollToSubtitle(referenceRow);
+        await SettleAsync(window);
+
+        vm.MergeWithLineAfterAsDialogCommand.Execute(null);
+        await SettleAsync(window);
+
+        Assert.Equal(new[] { "Translated one", "", "Translated two" }, vm.Subtitles.Select(p => p.Text));
+        Assert.True(vm.Subtitles[1].IsReferenceOnly);
+    }
+
+    [AvaloniaFact]
+    public async Task MergeSelectedLinesBilingual_WithReferenceRowAbove_KeepsTheMergedLineSelected()
+    {
+        var (window, vm) = CreateMainViewModel();
+        AddLine(vm, "One", string.Empty, 0, 1000);
+        AddLine(vm, "Two", string.Empty, 4000, 5000);
+        AddLine(vm, "Three", string.Empty, 6000, 7000);
+        var reference = new Subtitle();
+        reference.Paragraphs.Add(new Paragraph("Ref one", 0, 1000));
+        reference.Paragraphs.Add(new Paragraph("Ref only", 2000, 3000));
+        reference.Paragraphs.Add(new Paragraph("Ref two", 4000, 5000));
+        reference.Paragraphs.Add(new Paragraph("Ref three", 6000, 7000));
+        ImportReference(vm, reference);
+        Settle(window);
+        Assert.True(vm.Subtitles[1].IsReferenceOnly);
+
+        // Current row first: assigning SelectedSubtitle replaces the whole selection.
+        var two = vm.Subtitles[2];
+        vm.SelectedSubtitle = two;
+        vm.SubtitleGrid.SelectedItems!.Add(vm.Subtitles[3]);
+        Settle(window);
+
+        Assert.Equal(2, vm.SubtitleGridSelectedItems.Count);
+        vm.MergeSelectedLinesBilingualCommand.Execute(null);
+        await SettleAsync(window);
+
+        // Two working rows remain (the merged-away line's original comes back as a reference row,
+        // #13594), and the merged row stays current - by row, not by an index captured while the
+        // reference row was detached, which landed one row above it (#13962).
+        Assert.Equal(new[] { "One", "Two Three" }, vm.Subtitles.Where(p => !p.IsReferenceOnly).Select(p => p.Text));
+        Assert.Same(two, vm.SelectedSubtitle);
+    }
+
+    [AvaloniaFact]
+    public void RemovingARowAboveAMultiSelection_KeepsTheSelection()
+    {
+        var (window, vm) = ShowMainWindowWithLines(10);
+        vm.SelectedSubtitle = vm.Subtitles[5];
+        vm.SubtitleGrid.SelectedItems!.Add(vm.Subtitles[6]);
+        vm.SubtitleGrid.SelectedItems!.Add(vm.Subtitles[7]);
+        Settle(window);
+        Assert.Equal(3, vm.SubtitleGridSelectedItems.Count);
+
+        // The TwoWay SelectedIndex binding used to echo the shifted index back into the grid,
+        // which is Clear()+Select() on the selection model - one row left selected.
+        vm.Subtitles.RemoveAt(2);
+        Settle(window);
+
+        Assert.Equal(new[] { "Line 6", "Line 7", "Line 8" }, vm.SubtitleGridSelectedItems.Select(p => p.Text));
+        Assert.Equal("Line 6", vm.SelectedSubtitle?.Text);
+        Assert.Equal(4, vm.SelectedSubtitleIndex);
+    }
+
+    [AvaloniaFact]
+    public async Task MergeSelectedLines_NonContiguous_KeepsTheSelection()
+    {
+        var (window, vm) = ShowMainWindowWithLines(6);
+        vm.SelectedSubtitle = vm.Subtitles[1];
+        vm.SubtitleGrid.SelectedItems!.Add(vm.Subtitles[3]);
+        Settle(window);
+
+        vm.MergeSelectedLinesCommand.Execute(null);
+        await SettleAsync(window);
+
+        Assert.Equal(6, vm.Subtitles.Count);
+        Assert.Equal(2, vm.SubtitleGridSelectedItems.Count);
+    }
+
+    [AvaloniaFact]
+    public async Task Duplicate_SkipsReferenceRowsAndSelectsTheCopies()
+    {
+        var (window, vm) = CreateWithSampleReference();
+        var referenceRow = vm.Subtitles.Single(p => p.IsReferenceOnly);
+        vm.SelectedSubtitle = vm.Subtitles[0];
+        vm.SubtitleGrid.SelectedItems!.Add(referenceRow);
+        Settle(window);
+
+        vm.DuplicateSelectedLinesCommand.Execute(null);
+        await SettleAsync(window);
+
+        Assert.Equal(4, vm.Subtitles.Count);
+        Assert.Equal(1, vm.Subtitles.Count(p => p.IsReferenceOnly));
+        var copy = vm.Subtitles[1];
+        Assert.Equal("Translated one", copy.Text);
+        Assert.False(copy.IsReferenceOnly);
+        Assert.Same(copy, vm.SelectedSubtitle);
+    }
+
+    [AvaloniaFact]
+    public async Task InsertBefore_ShiftSelectionDownwards_InsertsAboveTheTopRow()
+    {
+        var (window, vm) = ShowMainWindowWithLines(10);
+        // Select 5..8 "downwards": row 8 is the current row (the moving end of the selection).
+        vm.SelectedSubtitle = vm.Subtitles[7];
+        for (var i = 4; i <= 6; i++)
+        {
+            vm.SubtitleGrid.SelectedItems!.Add(vm.Subtitles[i]);
+        }
+
+        Settle(window);
+        Assert.Same(vm.Subtitles[7], vm.SubtitleGrid.SelectedItem);
+        Assert.Equal(4, vm.SubtitleGridSelectedItems.Count);
+
+        vm.InsertLineBeforeCommand.Execute(null);
+        await SettleAsync(window);
+
+        Assert.Equal(11, vm.Subtitles.Count);
+        Assert.Equal(string.Empty, vm.Subtitles[4].Text);
+        Assert.Equal("Line 5", vm.Subtitles[5].Text);
+        Assert.Same(vm.Subtitles[4], vm.SelectedSubtitle);
+    }
+
+    [AvaloniaFact]
+    public async Task Split_OnTheBottomVisibleRow_RevealsTheNewHalf()
+    {
+        Se.Settings.General.SubtitleGridCenterSelectedRow = false;
+        var (window, vm) = ShowMainWindowWithLines(300, text: "Some words to split in two halves");
+        vm.SelectAndScrollToSubtitle(vm.Subtitles[100]);
+        await SettleAsync(window);
+
+        // Find the last fully visible row and make it current without scrolling.
+        var last = vm.Subtitles.Skip(100).TakeWhile(p => TableViewExtras.IsRowFullyVisible(vm.SubtitleGrid, p)).Last();
+        vm.SubtitleGrid.SelectedItem = last;
+        await SettleAsync(window);
+        Assert.True(TableViewExtras.IsRowFullyVisible(vm.SubtitleGrid, last));
+
+        vm.SplitCommand.Execute(null);
+        await SettleAsync(window);
+
+        var newHalf = vm.Subtitles[vm.Subtitles.IndexOf(last) + 1];
+        Assert.Same(last, vm.SelectedSubtitle);
+        Assert.True(TableViewExtras.IsRowFullyVisible(vm.SubtitleGrid, newHalf), "the second half is off screen");
+    }
+
+    private (Window Window, MainViewModel Vm) ShowMainWindowWithLines(int lineCount, string text = "Line {0}")
+    {
+        var (window, vm) = CreateMainViewModel();
+        vm.Menu.IsVisible = true;
+        for (var i = 0; i < lineCount; i++)
+        {
+            var lineText = text.Contains("{0}") ? string.Format(text, i + 1) : text;
+            vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph(lineText, i * 2000, i * 2000 + 1500), null!)
+            {
+                Number = i + 1,
+            });
+        }
+
+        Settle(window);
+        return (window, vm);
+    }
+
+    private (Window Window, MainViewModel Vm) CreateWithSampleReference()
+    {
+        var (window, vm) = CreateMainViewModel();
+        AddLine(vm, "Translated one", string.Empty, 0, 2000);
+        AddLine(vm, "Translated two", string.Empty, 4000, 6000);
+        var reference = new Subtitle();
+        reference.Paragraphs.Add(new Paragraph("Reference one", 0, 2000));
+        reference.Paragraphs.Add(new Paragraph("Reference only - no translation", 2000, 4000));
+        reference.Paragraphs.Add(new Paragraph("Reference two", 4000, 6000));
+        ImportReference(vm, reference);
+        Settle(window);
+        Assert.Equal(new[] { false, true, false }, vm.Subtitles.Select(p => p.IsReferenceOnly));
+        return (window, vm);
+    }
+
+    private (Window Window, MainViewModel Vm) CreateMainViewModel()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1400, Height = 900 };
+        _windows.Add(window);
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var vm = (MainViewModel)view.DataContext!;
+        window.SuppressSaveChangesPromptOnClose(vm);
+        return (window, vm);
+    }
+
+    private static SubtitleLineViewModel AddLine(MainViewModel vm, string text, string originalText, int startMs, int endMs)
+    {
+        var line = new SubtitleLineViewModel(new Paragraph(text, startMs, endMs), null!)
+        {
+            OriginalText = originalText,
+            Number = vm.Subtitles.Count + 1,
+        };
+
+        vm.Subtitles.Add(line);
+        return line;
+    }
+
+    private static void ImportReference(MainViewModel vm, Subtitle reference)
+    {
+        var match = ImportOriginalHelper.MatchOriginalLines(vm.Subtitles, reference);
+        var method = typeof(MainViewModel).GetMethod("ImportOriginalSubtitle", BindingFlags.Instance | BindingFlags.NonPublic)
+                     ?? throw new InvalidOperationException("ImportOriginalSubtitle not found");
+        method.Invoke(vm, new object?[] { 0, "reference.srt", reference, match, true });
+    }
+
+    private static void Settle(Window window)
+    {
+        for (var pump = 0; pump < 8; pump++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+        }
+    }
+
+    // The scroll/focus work is posted (some of it at Background priority and behind a short
+    // delay), so give the dispatcher a real tick as well.
+    private static async Task SettleAsync(Window window)
+    {
+        Settle(window);
+        await Task.Delay(50);
+        Settle(window);
+    }
+}


### PR DESCRIPTION
## Summary

Review of what the subtitle grid does with focus, scroll offset and selection after `MainViewModel` deletes or inserts rows (prompted by the recent run of #13962-class reports). Every root cause below was reproduced and then verified fixed with headless UI tests (`SubtitleGridDeleteInsertFocusScrollTests`, 14 tests).

### Delete / ripple delete / cut / waveform delete-at-position
- **Focus lost → next arrow key opens the menu bar.** Removing the focused row's container drops focus to `null` synchronously (Avalonia `FocusManager.ClearFocusOnElementRemoved`); `SelectAndScrollToRow` only checked `IsSubtitleGridFocused()` afterwards, so focus was never restored. The focus state is now captured *before* the removal (and before the prompt) and passed through.
- **Grid jumped on delete even when the next row was visible.** `AlwaysSelected` re-picked row 0 the moment the selection was removed and posted Avalonia's own `ScrollIntoView(0)` ahead of ours. The survivor row is now selected before the rows go, so the selection never empties (offset stays exactly where it was — tested).
- **Row-0 flash.** The same re-pick leaked into `SelectedSubtitle` via the TwoWay binding (edit box / status bar / whitespace-trim on line 1). Gone with the above.
- `ItemsSource` detach only above 1000 rows (per-row removal is ~10 µs; the reattach was itself a jump).
- Survivor is the next *working* row, never a reference-only row; a surviving current row stays put. Ripple delete and waveform delete no longer remove reference rows.

### Multi-selection collapse (new finding)
- The TwoWay `SelectedIndex` binding echoed grid-originated index changes back into the grid, and `SelectionModel.SelectedIndex`'s setter is `Clear()+Select()` even for an unchanged value — removing a row above a multi-selection left one row selected. The VM never drives the grid by index (`SelectedItem` does), so it's `OneWayToSource` now.

### Merge
- **Crash** (`ArgumentOutOfRangeException`) on "Merge with line after" (+keep breaks) with a reference-only row current; **silent deletion of line 1** with the dialog variant. The guard must run before `WithoutReferenceOnlyRows` — the detach itself made line 1 current.
- `MergeLinesSelectedBilingual` still selected by a stale index (#13962, missed last time).
- Refused non-contiguous merge no longer collapses the selection; sibling consistency (`RunWithoutChangeDetection`, waveform refresh).

### Insert / duplicate / paste / split
- Duplicate cloned reference-only rows as reference-only rows and never showed the copies; now skips them and selects the duplicates (SE4 behaviour).
- Insert before/after anchor on the topmost selected row, not the moving end of a shift-selection; grid paste with only a reference row selected pastes there, not at end of file; waveform multi-line paste selects the block.
- `SelectAndScrollToRange`/`SelectAndScrollToRows` restore grid focus; `SelectAndScrollToSubtitle` gets the #13303 cache resync and #12707 caret reset.
- `SelectAndScrollToRow` runs the pending layout before its visibility check, so Insert with "center selected row" no longer re-centres a row already mid-view.
- Split reveals the second half when it lands below the viewport; column shift-up/down treat working rows as the column; waveform split/delete ignore overlapping reference rows.

### Not changed (noted in review)
- `SelectAndScrollToSubtitle` stays at `Background` priority and keeps re-centring on playhead sync with "center selected row" on — behaviour change I didn't want to make unasked.
- Split still reads the caret from the translation box even when the original box has focus (SE4 routes it) — a feature gap rather than a regression.

## Test plan
- [x] `tests/UI` full suite: 3348 passed
- [x] New `SubtitleGridDeleteInsertFocusScrollTests` (14): focus kept after Delete + arrow key moves selection; scroll offset unchanged after mid-view delete; no row-0 selection during delete; last-row/every-row/reference-row-next deletes; merge-after from reference row (crash + line-1 deletion); bilingual merge selection with reference row above; selection survives removal above a multi-selection; non-contiguous merge keeps selection; duplicate skips reference rows; insert-before with downward shift-selection; split reveals second half
- [ ] Manual: Delete / Ctrl+X / Insert / Split / Merge in a real file with and without a mismatched read-only original

🤖 Generated with [Claude Code](https://claude.com/claude-code)
