### PR TITLE
AI review: stop local llama-server on cancel/close, add Start/Stop server button

### DIFF
--- a/src/ui/Features/Tools/AiReview/AiReviewViewModel.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
@@ -38,6 +39,7 @@ public partial class AiReviewViewModel : ObservableObject
     [ObservableProperty] private int _requestDelaySeconds;
     [ObservableProperty] private ObservableCollection<LlamaCppModelDisplay> _llamaCppModels;
     [ObservableProperty] private LlamaCppModelDisplay? _selectedLlamaCppModel;
+    [ObservableProperty] private string _llamaCppServerButtonText;
     [ObservableProperty] private string _languageDisplay;
     [ObservableProperty] private ObservableCollection<ReviewFilterChip> _filterChips;
     [ObservableProperty] private ObservableCollection<ReviewSuggestionItem> _suggestions;
@@ -104,6 +106,9 @@ public partial class AiReviewViewModel : ObservableObject
             LlamaCppModels,
             LlamaCppServerManager.GetAllReviewModels(),
             Se.Settings.Tools.AiReview.LlamaCppModelFileName);
+
+        LlamaCppServerButtonText = string.Empty;
+        UpdateLlamaCppServerButtonText();
 
         LanguageDisplay = string.Empty;
         StatusText = string.Empty;
@@ -264,6 +269,7 @@ public partial class AiReviewViewModel : ObservableObject
         }
 
         LlamaCppServerManager.StopServer();
+        UpdateLlamaCppServerButtonText();
 
         // Reuse the installed backend so the user is not re-asked CPU/Vulkan/CUDA on a re-download;
         // null on a fresh install (or off Windows), which lets DownloadAsync prompt.
@@ -339,11 +345,13 @@ public partial class AiReviewViewModel : ObservableObject
             {
                 IsReviewing = false;
                 StatusText = string.Empty;
+                UpdateLlamaCppServerButtonText();
                 await MessageBox.Show(Window, Se.Language.General.Error,
                     string.Format(l.EngineError, e.Message), MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
+            UpdateLlamaCppServerButtonText();
             url = LlamaCppServerManager.ApiUrl;
         }
         else if (SelectedEngine == SeAiReview.EngineOpenAiCompatible)
@@ -481,7 +489,88 @@ public partial class AiReviewViewModel : ObservableObject
         {
             ProgressValue = 100;
             IsReviewing = false;
+            UpdateLlamaCppServerButtonText();
         }
+    }
+
+    private void UpdateLlamaCppServerButtonText()
+    {
+        LlamaCppServerButtonText = LlamaCppServerManager.IsServerRunning ? Se.Language.General.StopServer : Se.Language.General.StartServer;
+    }
+
+    /// <summary>
+    /// Start/Stop server button, same as auto-translate and OCR: lets the user release the
+    /// model's RAM/VRAM after a finished review without closing Subtitle Edit, or pre-load it
+    /// before pressing Review.
+    /// </summary>
+    [RelayCommand]
+    private async Task ToggleLlamaCppServer()
+    {
+        if (Window == null || IsReviewing)
+        {
+            return;
+        }
+
+        if (LlamaCppServerManager.IsServerRunning)
+        {
+            LlamaCppServerManager.StopServer();
+            UpdateLlamaCppServerButtonText();
+            return;
+        }
+
+        var display = SelectedLlamaCppModel;
+        if (display == null ||
+            !await LlamaCppDownloadHelper.EnsureReadyAsync(Window, _windowService, display.Model.FileName,
+                LlamaCppServerManager.GetAllReviewModels(), persistAsTranslateModel: false))
+        {
+            RefreshLlamaCppModels();
+            RefreshEngines();
+            return;
+        }
+
+        RefreshLlamaCppModels();
+        RefreshEngines();
+        display = SelectedLlamaCppModel;
+        if (display == null)
+        {
+            return;
+        }
+
+        try
+        {
+            await LlamaCppServerManager.EnsureServerRunningAsync(display.Model, CancellationToken.None);
+        }
+        catch (Exception e)
+        {
+            await MessageBox.Show(Window, Se.Language.General.Error,
+                string.Format(Se.Language.Tools.AiReview.EngineError, e.Message), MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+
+        UpdateLlamaCppServerButtonText();
+    }
+
+    /// <summary>
+    /// Cancelling a running local llama.cpp review also stops the SE-managed server, so the
+    /// model's RAM/VRAM is released right away instead of lingering until Subtitle Edit exits
+    /// (#13969) - the same rule auto-translate applies (#13830). Only mid-run: a server left idle
+    /// by a completed review stays warm (Stop server button / app exit) and the next Review
+    /// auto-restarts it.
+    /// </summary>
+    private void StopLocalLlamaCppServerAfterCancel()
+    {
+        if (!IsReviewing ||
+            SelectedEngine != SeAiReview.EngineLlamaCpp ||
+            !LlamaCppServerManager.IsServerRunning)
+        {
+            return;
+        }
+
+        // Off the UI thread - StopServer kills the process and waits up to 2 s for it to exit.
+        _ = Task.Run(() =>
+        {
+            LlamaCppServerManager.StopServer();
+            Dispatcher.UIThread.Post(UpdateLlamaCppServerButtonText);
+        });
     }
 
     private void ClearSuggestions()
@@ -674,6 +763,7 @@ public partial class AiReviewViewModel : ObservableObject
     [RelayCommand]
     private void StopReview()
     {
+        StopLocalLlamaCppServerAfterCancel();
         _cancellationTokenSource.Cancel();
     }
 
@@ -883,6 +973,8 @@ public partial class AiReviewViewModel : ObservableObject
     [RelayCommand]
     private void Cancel()
     {
+        // OnClosing (hooked on the window) stops a mid-run llama-server; Escape and the OS
+        // close button end up there too, so the rule lives in one place.
         _cancellationTokenSource.Cancel();
         Window?.Close();
     }
@@ -920,6 +1012,7 @@ public partial class AiReviewViewModel : ObservableObject
 
     internal void OnClosing()
     {
+        StopLocalLlamaCppServerAfterCancel();
         _cancellationTokenSource.Cancel();
 
         // Only stop what this window started - a video the user left playing before opening the

--- a/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
@@ -87,7 +87,20 @@ public class AiReviewWindow : Window
         // settings dialog rather than this window's former bespoke green/grey pair.
         comboLlamaCppModel.ItemTemplate = Features.Translate.AutoTranslateCombos.LlamaCppModelItemTemplate();
 
-        comboLlamaCppModel.Bind(IsVisibleProperty, new Binding(nameof(vm.IsLlamaCppVisible)));
+        // Start/Stop server, as in auto-translate/OCR: without it an idle llama-server (and the
+        // model's VRAM) could only be released by closing Subtitle Edit (#13969).
+        var buttonLlamaCppServer = UiUtil.MakeButton(string.Empty, vm.ToggleLlamaCppServerCommand);
+        buttonLlamaCppServer.Bind(Button.ContentProperty, new Binding(nameof(vm.LlamaCppServerButtonText)));
+        buttonLlamaCppServer.Bind(IsEnabledProperty, new Binding(nameof(vm.IsNotReviewing)));
+
+        var panelLlamaCpp = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 5,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children = { comboLlamaCppModel, buttonLlamaCppServer },
+        };
+        panelLlamaCpp.Bind(IsVisibleProperty, new Binding(nameof(vm.IsLlamaCppVisible)));
 
         var buttonLlamaCppEngineSettings = UiUtil.MakeButton(vm.ShowLlamaCppEngineSettingsCommand, IconNames.Settings)
             .WithAccessibleName(Se.Language.General.LlamaCppEngineSettings);
@@ -137,7 +150,7 @@ public class AiReviewWindow : Window
         toolbar.Add(labelEngine, 0, 0);
         toolbar.Add(panelEngine, 0, 1);
         toolbar.Add(panelOllama, 0, 2);
-        toolbar.Add(comboLlamaCppModel, 0, 3);
+        toolbar.Add(panelLlamaCpp, 0, 3);
         toolbar.Add(panelOpenAiCompatible, 0, 4);
         toolbar.Add(languageChip, 0, 5);
         toolbar.Add(buttonEditPrompt, 0, 7);


### PR DESCRIPTION
Fixes the bug half of #13969.

When the AI review window was cancelled or closed while a local llama.cpp review was running, `llama-server` kept running (and holding VRAM) until Subtitle Edit exited - and unlike auto-translate/OCR the window had no Start/Stop server button, so the user had no way to release it short of the task manager.

- Stop/Cancel/Escape/OS-close during a running llama.cpp review now stops the SE-managed server off the UI thread (mirrors `AutoTranslateViewModel.StopLocalLlamaCppServerAfterCancel`, #13830). A server left warm by a *completed* review stays warm, as elsewhere.
- New Start/Stop server button next to the model combo (disabled while reviewing), so an idle server can be released - or pre-loaded - without closing SE.

The feature-request half of #13969 (STT + AI review as batch-convert steps) is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)