### PR TITLE
WebVTT: do not stack identical duplicate cues with the same time codes

### DIFF
--- a/src/libse/SubtitleFormats/WebVTT.cs
+++ b/src/libse/SubtitleFormats/WebVTT.cs
@@ -451,7 +451,13 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     current.EndTime.TotalMilliseconds == nextParagraph.EndTime.TotalMilliseconds &&
                     current.Region == nextParagraph.Region)
                 {
-                    current.Text = current.Text + Environment.NewLine + nextParagraph.Text;
+                    // An exact repeat (same times, same text - e.g. a concatenated/duplicated
+                    // segment) is a duplicate, not a second line: drop it instead of stacking it.
+                    if (current.Text != nextParagraph.Text)
+                    {
+                        current.Text = current.Text + Environment.NewLine + nextParagraph.Text;
+                    }
+
                     subtitle.Paragraphs.RemoveAt(i + 1);
                 }
             }

--- a/tests/libse/SubtitleFormats/WebVttTest.cs
+++ b/tests/libse/SubtitleFormats/WebVttTest.cs
@@ -45,6 +45,20 @@ public class WebVttTest
     }
 
     [Fact]
+    public void LoadSubtitleDropsDuplicateCueWithIdenticalTimeCodesAndText()
+    {
+        // A file made of two concatenated WebVTT segments repeats the same cue (same number, same
+        // times, same text) - that is a duplicate, not a second line, so it must not be stacked.
+        var vtt = "WEBVTT\r\nX-TIMESTAMP-MAP=MPEGTS:900000,LOCAL:00:00:00.000\r\n\r\nSTYLE\r\n::cue(.styledotebebeb) { color:#ebebeb }\r\n\r\n" +
+                  "14\r\n00:12:58.333 --> 00:13:00.125 align:middle line:85%,start position:50%,middle\r\n<c.styledotebebeb>Do not translate this.</c>\r\n\r\n" +
+                  "WEBVTT\r\nX-TIMESTAMP-MAP=MPEGTS:900000,LOCAL:00:00:00.000\r\n\r\nSTYLE\r\n::cue(.styledotebebeb) { color:#ebebeb }\r\n\r\n" +
+                  "14\r\n00:12:58.333 --> 00:13:00.125 align:middle line:85%,start position:50%,middle\r\n<c.styledotebebeb>Do not translate this.</c>";
+        var subtitle = LoadWebVttSubtitle(vtt);
+        Assert.Single(subtitle.Paragraphs);
+        Assert.Equal("<c.styledotebebeb>Do not translate this.</c>", subtitle.Paragraphs[0].Text);
+    }
+
+    [Fact]
     public void LoadSubtitleSupportsHourlessEndTimestamp()
     {
         // WebVTT allows each timestamp independently to omit the hour part


### PR DESCRIPTION
Since `be12bae6b` (#10444) consecutive WebVTT cues with identical start/end times are merged on load by joining their texts with a line break. That also fired for an exact repeat of the same cue (e.g. a file made of two concatenated WebVTT segments: same cue number, same times, same text), so the text showed up duplicated:

```
<c.styledotebebeb>Do not translate this.</c>
<c.styledotebebeb>Do not translate this.</c>
```

4.0.16 loaded such a file as a single line. Now the merge drops an identical-text repeat instead of stacking it; cues with different text still merge as before. Added a regression test with the reporter's sample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)