### PR TITLE
Prepare v5.2.0-beta21

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -3,6 +3,27 @@ Subtitle Edit Changelog
 
 -----------------------------------------------------------------------------------------------------
 
+v5.2.0-beta21 (22nd of August 2026)
+
+* Add an option to keep the source file's date/time on converted files (batch convert + seconv) - thx TucocoTucoco
+* Add a Start/Stop server button to the AI review window, and stop llama-server when a review is cancelled - thx emsb8888-prog
+* Snap whole-paragraph waveform drags to shot changes - thx m0ck69
+* Update yt-dlp to 2026.08.19
+* Fix "snap to shot change" ignoring the cue gap and often doing nothing at all - thx m0ck69
+* Fix waveform edge drags running away when the video position is centered - thx GrampaWildWilly
+* Fix OCR reading "l" as "i" or "I" without "try to guess unknown words" turned on - thx Miggu82
+* Fix the subtitle grid jumping after merging lines with a read-only original open - thx torvchen
+* Fix focus, scroll and selection in the subtitle grid after delete, insert and merge commands
+* Fix WebVTT showing a line twice when the same cue is repeated with the same time codes
+* Update Chinese (simplified) translation - thx emsb8888-prog
+* Update French translation - thx Need74
+* Update Italian translation - thx bovirus
+* Update Japanese translation - thx hisui3393
+* Update Korean translation - thx 12si27
+* Update Polish translation - thx potplayer-fanpack
+
+-----------------------------------------------------------------------------------------------------
+
 v5.2.0-beta20 (21st of August 2026)
 
 * Add "Go to sub position and pause" to the video shortcuts - thx BBB2K

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "Subtitle Edit",
-  "version": "v5.2.0-beta20",
+  "version": "v5.2.0-beta21",
   "translatedBy": "",
   "cultureName": "en-US",
   "general": {

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -19,7 +19,7 @@ public class Se
     internal const int CurrentMacOsFontMigrationVersion = 1;
     internal const int CurrentShortcutsMigrationVersion = 2;
 
-    public static string Version { get; set; } = "v5.2.0-beta20";
+    public static string Version { get; set; } = "v5.2.0-beta21";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
Version bump to `v5.2.0-beta21` in `src/ui/Logic/Config/Se.cs` and the generated `src/ui/Assets/Languages/English.json`, plus the change-log section.

The section covers the 17 PRs merged since the `v5.2.0-beta20` tag, enumerated by ancestor-checking each merge commit against the tag (not by timestamp — three translation PRs merged after the tag was cut). Internal-only work (#13979, the English.json regeneration) is left out.

Reporters credited from the linked issues/discussions: #13948/#13953 (m0ck69), #13955 (GrampaWildWilly), #13962 (torvchen), #13963 discussion (TucocoTucoco), #13969/#13971 (emsb8888-prog), beta20 OCR feedback (Miggu82). #13977 has no identifiable reporter, so it is uncredited.

Wording is the maintainer's call as always — edit freely before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)