### PR TITLE
Keep source timestamp: capture it before an in-place overwrite

### DIFF
--- a/src/libse/Common/FileTimestampHelper.cs
+++ b/src/libse/Common/FileTimestampHelper.cs
@@ -4,11 +4,51 @@ using System.IO;
 namespace Nikse.SubtitleEdit.Core.Common
 {
     /// <summary>
+    /// A file's creation and last-write time, captured before a conversion so they survive
+    /// the conversion overwriting the file itself (batch convert "save in source folder" +
+    /// "overwrite", seconv --overwrite): copying from the source path afterwards would just
+    /// read back the time the output was written.
+    /// </summary>
+    public readonly struct FileTimestamps
+    {
+        public DateTime CreationTimeUtc { get; }
+        public DateTime LastWriteTimeUtc { get; }
+
+        public FileTimestamps(DateTime creationTimeUtc, DateTime lastWriteTimeUtc)
+        {
+            CreationTimeUtc = creationTimeUtc;
+            LastWriteTimeUtc = lastWriteTimeUtc;
+        }
+    }
+
+    /// <summary>
     /// Copies file system timestamps from a source file onto written output files, so a
     /// converted subtitle can keep the "modified" date of the file it was made from.
     /// </summary>
     public static class FileTimestampHelper
     {
+        /// <summary>
+        /// Reads <paramref name="sourceFileName"/>'s timestamps, or null when the file is missing.
+        /// Call before converting; see <see cref="FileTimestamps"/>.
+        /// </summary>
+        public static FileTimestamps? Capture(string sourceFileName)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(sourceFileName) || !File.Exists(sourceFileName))
+                {
+                    return null;
+                }
+
+                var source = new FileInfo(sourceFileName);
+                return new FileTimestamps(source.CreationTimeUtc, source.LastWriteTimeUtc);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         /// Copies creation and last-write time from <paramref name="sourceFileName"/> onto
         /// <paramref name="targetPath"/> (a file or a directory). Best-effort: returns false
@@ -17,25 +57,34 @@ namespace Nikse.SubtitleEdit.Core.Common
         /// </summary>
         public static bool CopyTimestamps(string sourceFileName, string targetPath)
         {
+            var timestamps = Capture(sourceFileName);
+            return timestamps != null && CopyTimestamps(timestamps.Value, targetPath);
+        }
+
+        /// <summary>
+        /// Stamps <paramref name="targetPath"/> (a file or a directory) with previously captured
+        /// timestamps. Best-effort like the path overload.
+        /// </summary>
+        public static bool CopyTimestamps(FileTimestamps timestamps, string targetPath)
+        {
             try
             {
-                if (string.IsNullOrEmpty(sourceFileName) || string.IsNullOrEmpty(targetPath) || !File.Exists(sourceFileName))
+                if (string.IsNullOrEmpty(targetPath))
                 {
                     return false;
                 }
 
-                var source = new FileInfo(sourceFileName);
                 if (File.Exists(targetPath))
                 {
-                    var ok = TrySet(() => File.SetLastWriteTimeUtc(targetPath, source.LastWriteTimeUtc));
-                    TrySet(() => File.SetCreationTimeUtc(targetPath, source.CreationTimeUtc));
+                    var ok = TrySet(() => File.SetLastWriteTimeUtc(targetPath, timestamps.LastWriteTimeUtc));
+                    TrySet(() => File.SetCreationTimeUtc(targetPath, timestamps.CreationTimeUtc));
                     return ok;
                 }
 
                 if (Directory.Exists(targetPath))
                 {
-                    var ok = TrySet(() => Directory.SetLastWriteTimeUtc(targetPath, source.LastWriteTimeUtc));
-                    TrySet(() => Directory.SetCreationTimeUtc(targetPath, source.CreationTimeUtc));
+                    var ok = TrySet(() => Directory.SetLastWriteTimeUtc(targetPath, timestamps.LastWriteTimeUtc));
+                    TrySet(() => Directory.SetCreationTimeUtc(targetPath, timestamps.CreationTimeUtc));
                     return ok;
                 }
 
@@ -53,6 +102,16 @@ namespace Nikse.SubtitleEdit.Core.Common
         /// </summary>
         public static void CopyTimestampsToDirectoryContents(string sourceFileName, string directory)
         {
+            var timestamps = Capture(sourceFileName);
+            if (timestamps != null)
+            {
+                CopyTimestampsToDirectoryContents(timestamps.Value, directory);
+            }
+        }
+
+        /// <summary>See <see cref="CopyTimestampsToDirectoryContents(string, string)"/>.</summary>
+        public static void CopyTimestampsToDirectoryContents(FileTimestamps timestamps, string directory)
+        {
             try
             {
                 if (!Directory.Exists(directory))
@@ -62,10 +121,10 @@ namespace Nikse.SubtitleEdit.Core.Common
 
                 foreach (var file in Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories))
                 {
-                    CopyTimestamps(sourceFileName, file);
+                    CopyTimestamps(timestamps, file);
                 }
 
-                CopyTimestamps(sourceFileName, directory);
+                CopyTimestamps(timestamps, directory);
             }
             catch
             {

--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -70,10 +70,13 @@ internal class SubtitleConverter
             var fileIndex = 1;
             foreach (var inputFile in inputFiles)
             {
+                // --keep-timestamp: read the source's timestamps before anything is written, as
+                // --overwrite can make the output the input file itself.
+                var sourceTimestamps = options.KeepTimestamp ? FileTimestampHelper.Capture(inputFile) : null;
                 try
                 {
                     if (imageTargetHandler is not null
-                        && await TryConvertImageToImageAsync(inputFile, options, result, fileIndex))
+                        && await TryConvertImageToImageAsync(inputFile, options, result, fileIndex, sourceTimestamps))
                     {
                         fileIndex++;
                         continue;
@@ -96,7 +99,7 @@ internal class SubtitleConverter
                         var warnings = new List<string>();
                         await ConvertFileAsync(inputFile, outputFile, options, warnings);
                         result.SuccessfulFiles++;
-                        ApplySourceTimestamp(options, inputFile, outputFile);
+                        ApplySourceTimestamp(sourceTimestamps, outputFile);
                         result.Files.Add(new FileConversionResult(inputFile, outputFile, true, null, warnings.Count > 0 ? warnings : null));
                         foreach (var warning in warnings)
                         {
@@ -132,7 +135,7 @@ internal class SubtitleConverter
                             }
                             await ConvertTrackAsync(track, outputFile, options);
                             result.SuccessfulFiles++;
-                            ApplySourceTimestamp(options, inputFile, outputFile);
+                            ApplySourceTimestamp(sourceTimestamps, outputFile);
                             result.Files.Add(new FileConversionResult(inputFile, outputFile, true, null));
                             if (!options.Quiet)
                             {
@@ -253,9 +256,10 @@ internal class SubtitleConverter
             if (options.KeepTimestamp)
             {
                 var newestVob = vobFiles.OrderByDescending(File.GetLastWriteTimeUtc).First();
+                var vobTimestamps = FileTimestampHelper.Capture(newestVob);
                 foreach (var o in outputs)
                 {
-                    ApplySourceTimestamp(options, newestVob, o.Path);
+                    ApplySourceTimestamp(vobTimestamps, o.Path);
                 }
             }
             foreach (var f in vobFiles)
@@ -305,13 +309,13 @@ internal class SubtitleConverter
     /// input. Returns true if the input was handled (recorded in <paramref name="result"/>),
     /// false if it should fall through to the OCR / text pipeline.
     /// </summary>
-    private async Task<bool> TryConvertImageToImageAsync(string inputFile, ConversionOptions options, ConversionResult result, int fileIndex)
+    private async Task<bool> TryConvertImageToImageAsync(string inputFile, ConversionOptions options, ConversionResult result, int fileIndex, FileTimestamps? sourceTimestamps)
     {
         var ext = Path.GetExtension(inputFile).ToLowerInvariant();
 
         if (ext == ".sup")
         {
-            return await PassThroughSingleStreamAsync(inputFile, options, result, fileIndex,
+            return await PassThroughSingleStreamAsync(inputFile, options, result, fileIndex, sourceTimestamps,
                 () => BitmapSubtitleLoader.LoadBluRaySup(inputFile));
         }
 
@@ -335,7 +339,7 @@ internal class SubtitleConverter
                 // IsPal: default to PAL to match VobSubExtractor. The .idx "size:" field
                 // could disambiguate per-file, but a wrong guess only affects timing scale,
                 // not bitmap content.
-                return await PassThroughSingleStreamAsync(inputFile, options, result, fileIndex,
+                return await PassThroughSingleStreamAsync(inputFile, options, result, fileIndex, sourceTimestamps,
                     () => BitmapSubtitleLoader.LoadVobSub(inputFile, idxPath, isPal: true));
             }
             return false;
@@ -353,23 +357,23 @@ internal class SubtitleConverter
                     + "the .idx only holds timing and palette; the subtitle images live in the .sub.");
             }
 
-            return await PassThroughSingleStreamAsync(subPath, options, result, fileIndex,
+            return await PassThroughSingleStreamAsync(subPath, options, result, fileIndex, sourceTimestamps,
                 () => BitmapSubtitleLoader.LoadVobSub(subPath, inputFile, isPal: true));
         }
 
         if (ext is ".mkv" or ".mks")
         {
-            return await PassThroughMatroskaPgsAsync(inputFile, options, result, fileIndex);
+            return await PassThroughMatroskaPgsAsync(inputFile, options, result, fileIndex, sourceTimestamps);
         }
 
         if (ext is ".ts" or ".m2ts" or ".mts")
         {
-            return await PassThroughTransportStreamDvbAsync(inputFile, options, result, fileIndex);
+            return await PassThroughTransportStreamDvbAsync(inputFile, options, result, fileIndex, sourceTimestamps);
         }
 
         if (ext is ".avi" or ".divx")
         {
-            return await PassThroughXSubAsync(inputFile, options, result, fileIndex);
+            return await PassThroughXSubAsync(inputFile, options, result, fileIndex, sourceTimestamps);
         }
 
         return false;
@@ -380,6 +384,7 @@ internal class SubtitleConverter
         ConversionOptions options,
         ConversionResult result,
         int fileIndex,
+        FileTimestamps? sourceTimestamps,
         Func<IReadOnlyList<BitmapSubtitleLoader.BitmapSubtitleItem>> load)
     {
         var outputFile = ResolveOutputFileName(inputFile, options, usedNames: _usedOutputFileNames);
@@ -394,7 +399,7 @@ internal class SubtitleConverter
             items = load();
             WritePreservedBitmaps(items, outputFile, options);
             result.SuccessfulFiles++;
-            ApplySourceTimestamp(options, inputFile, outputFile);
+            ApplySourceTimestamp(sourceTimestamps, outputFile);
             result.Files.Add(new FileConversionResult(inputFile, outputFile, true, null));
             if (!options.Quiet)
             {
@@ -427,7 +432,7 @@ internal class SubtitleConverter
         return true;
     }
 
-    private async Task<bool> PassThroughMatroskaPgsAsync(string inputFile, ConversionOptions options, ConversionResult result, int fileIndex)
+    private async Task<bool> PassThroughMatroskaPgsAsync(string inputFile, ConversionOptions options, ConversionResult result, int fileIndex, FileTimestamps? sourceTimestamps)
     {
         using var matroska = new Nikse.SubtitleEdit.Core.ContainerFormats.Matroska.MatroskaFile(inputFile);
         if (!matroska.IsValid)
@@ -480,7 +485,7 @@ internal class SubtitleConverter
                     : BitmapSubtitleLoader.LoadMatroskaPgs(matroska, track);
                 WritePreservedBitmaps(items, outputFile, options);
                 result.SuccessfulFiles++;
-                ApplySourceTimestamp(options, inputFile, outputFile);
+                ApplySourceTimestamp(sourceTimestamps, outputFile);
                 result.Files.Add(new FileConversionResult(inputFile, outputFile, true, null));
                 if (!options.Quiet)
                 {
@@ -514,7 +519,7 @@ internal class SubtitleConverter
         return true;
     }
 
-    private async Task<bool> PassThroughTransportStreamDvbAsync(string inputFile, ConversionOptions options, ConversionResult result, int fileIndex)
+    private async Task<bool> PassThroughTransportStreamDvbAsync(string inputFile, ConversionOptions options, ConversionResult result, int fileIndex, FileTimestamps? sourceTimestamps)
     {
         // --teletext-only means "skip DVB-sub". The regular container path
         // (ContainerSubtitleLoader.LoadTransportStream) honors this by gating its DVB-sub
@@ -558,7 +563,7 @@ internal class SubtitleConverter
             {
                 WritePreservedBitmaps(items, outputFile, options);
                 result.SuccessfulFiles++;
-                ApplySourceTimestamp(options, inputFile, outputFile);
+                ApplySourceTimestamp(sourceTimestamps, outputFile);
                 result.Files.Add(new FileConversionResult(inputFile, outputFile, true, null));
                 if (!options.Quiet)
                 {
@@ -594,7 +599,7 @@ internal class SubtitleConverter
     /// number is used as the filename suffix (an AVI stream header carries no language) but only
     /// when the file has more than one, so the usual single-stream file keeps its plain name.
     /// </summary>
-    private async Task<bool> PassThroughXSubAsync(string inputFile, ConversionOptions options, ConversionResult result, int fileIndex)
+    private async Task<bool> PassThroughXSubAsync(string inputFile, ConversionOptions options, ConversionResult result, int fileIndex, FileTimestamps? sourceTimestamps)
     {
         var allStreams = BitmapSubtitleLoader.LoadXSub(inputFile);
         if (allStreams.Count == 0)
@@ -666,7 +671,7 @@ internal class SubtitleConverter
             {
                 WritePreservedBitmaps(items, outputFile, options);
                 result.SuccessfulFiles++;
-                ApplySourceTimestamp(options, inputFile, outputFile);
+                ApplySourceTimestamp(sourceTimestamps, outputFile);
                 result.Files.Add(new FileConversionResult(inputFile, outputFile, true, null));
                 if (!options.Quiet)
                 {
@@ -1007,25 +1012,28 @@ internal class SubtitleConverter
 
     /// <summary>
     /// --keep-timestamp: stamp the written output (file, or folder for image exports, plus a
-    /// sibling .idx for VobSub) with the source file's timestamps. Best-effort, never throws.
+    /// sibling .idx for VobSub) with the source file's timestamps, captured before the
+    /// conversion (null when --keep-timestamp is off or the source could not be read).
+    /// Best-effort, never throws.
     /// </summary>
-    private static void ApplySourceTimestamp(ConversionOptions options, string inputFile, string outputFile)
+    private static void ApplySourceTimestamp(FileTimestamps? sourceTimestamps, string outputFile)
     {
-        if (!options.KeepTimestamp || string.IsNullOrEmpty(outputFile))
+        if (sourceTimestamps == null || string.IsNullOrEmpty(outputFile))
         {
             return;
         }
 
+        var timestamps = sourceTimestamps.Value;
         if (Directory.Exists(outputFile))
         {
-            FileTimestampHelper.CopyTimestampsToDirectoryContents(inputFile, outputFile);
+            FileTimestampHelper.CopyTimestampsToDirectoryContents(timestamps, outputFile);
             return;
         }
 
-        FileTimestampHelper.CopyTimestamps(inputFile, outputFile);
+        FileTimestampHelper.CopyTimestamps(timestamps, outputFile);
         if (outputFile.EndsWith(".sub", StringComparison.OrdinalIgnoreCase))
         {
-            FileTimestampHelper.CopyTimestamps(inputFile, Path.ChangeExtension(outputFile, ".idx"));
+            FileTimestampHelper.CopyTimestamps(timestamps, Path.ChangeExtension(outputFile, ".idx"));
         }
     }
 }

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -130,15 +130,19 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         }
 
         _currentItemOutputFileNames.Clear();
+        // Captured before converting: with "save in source folder" + "overwrite" the output can
+        // be the source file itself, and reading the timestamps afterwards would only give back
+        // the time the output was written.
+        var sourceTimestamps = _config.KeepSourceTimestamp ? FileTimestampHelper.Capture(item.FileName) : null;
         try
         {
             await ConvertCore(item, cancellationToken);
         }
         finally
         {
-            if (_config.KeepSourceTimestamp)
+            if (sourceTimestamps != null)
             {
-                ApplySourceTimestamp(item);
+                ApplySourceTimestamp(sourceTimestamps.Value);
             }
 
             _currentItemOutputFileNames.Clear();
@@ -150,20 +154,20 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
     /// for image exports, plus a sibling .idx for VobSub) with the source file's timestamps.
     /// Runs after the output streams are closed; best-effort, never fails the conversion.
     /// </summary>
-    private void ApplySourceTimestamp(BatchConvertItem item)
+    private void ApplySourceTimestamp(FileTimestamps sourceTimestamps)
     {
         foreach (var path in _currentItemOutputFileNames)
         {
             if (Directory.Exists(path))
             {
-                FileTimestampHelper.CopyTimestampsToDirectoryContents(item.FileName, path);
+                FileTimestampHelper.CopyTimestampsToDirectoryContents(sourceTimestamps, path);
                 continue;
             }
 
-            FileTimestampHelper.CopyTimestamps(item.FileName, path);
+            FileTimestampHelper.CopyTimestamps(sourceTimestamps, path);
             if (path.EndsWith(".sub", StringComparison.OrdinalIgnoreCase))
             {
-                FileTimestampHelper.CopyTimestamps(item.FileName, Path.ChangeExtension(path, ".idx"));
+                FileTimestampHelper.CopyTimestamps(sourceTimestamps, Path.ChangeExtension(path, ".idx"));
             }
         }
     }

--- a/tests/libse/Common/FileTimestampHelperTest.cs
+++ b/tests/libse/Common/FileTimestampHelperTest.cs
@@ -29,6 +29,39 @@ public class FileTimestampHelperTest
     }
 
     [Fact]
+    public void Capture_ThenOverwrite_ThenCopy_RestoresOriginalTime()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "FileTimestampHelperTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var file = Path.Combine(dir, "inplace.srt");
+            File.WriteAllText(file, "a");
+            var when = new DateTime(2011, 3, 4, 5, 6, 7, DateTimeKind.Utc);
+            File.SetLastWriteTimeUtc(file, when);
+
+            var captured = FileTimestampHelper.Capture(file);
+            Assert.NotNull(captured);
+            File.WriteAllText(file, "b"); // the conversion overwrites the source itself
+            Assert.NotEqual(when, File.GetLastWriteTimeUtc(file));
+
+            Assert.True(FileTimestampHelper.CopyTimestamps(captured.Value, file));
+            Assert.Equal(when, File.GetLastWriteTimeUtc(file));
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void Capture_MissingFile_ReturnsNull()
+    {
+        Assert.Null(FileTimestampHelper.Capture(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"))));
+        Assert.Null(FileTimestampHelper.Capture(string.Empty));
+    }
+
+    [Fact]
     public void CopyTimestamps_MissingSourceOrTarget_ReturnsFalse()
     {
         var missing = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));

--- a/tests/seconv/Core/KeepTimestampTest.cs
+++ b/tests/seconv/Core/KeepTimestampTest.cs
@@ -61,6 +61,31 @@ public class KeepTimestampTest : IDisposable
         Assert.Equal(sourceTime, File.GetLastWriteTimeUtc(output));
     }
 
+    /// <summary>
+    /// --overwrite with no output folder and the same format writes the input file itself; the
+    /// timestamps must be read before that write, or the "kept" time is the conversion time.
+    /// </summary>
+    [Fact]
+    public async Task KeepTimestamp_InPlaceOverwrite_KeepsSourceLastWriteTime()
+    {
+        var input = Path.Combine(_tempRoot, "in.srt");
+        await File.WriteAllTextAsync(input, SrtContent, TestContext.Current.CancellationToken);
+        var sourceTime = new DateTime(2019, 5, 17, 12, 34, 56, DateTimeKind.Utc);
+        File.SetLastWriteTimeUtc(input, sourceTime);
+
+        var result = await new SubtitleConverter().ConvertAsync(new ConversionOptions
+        {
+            Patterns = [input],
+            Format = "SubRip",
+            Overwrite = true,
+            KeepTimestamp = true,
+        });
+        Assert.True(result.Success, string.Join("; ", result.Errors));
+
+        Assert.Equal(input, result.Files.Single().Output);
+        Assert.Equal(sourceTime, File.GetLastWriteTimeUtc(input));
+    }
+
     [Fact]
     public async Task Default_OutputGetsCurrentTime()
     {


### PR DESCRIPTION
Found while bug-hunting the beta21 window (follow-up to #13967, discussion #13963).

## Problem
Both "Keep source file date/time" (batch convert) and seconv `--keep-timestamp` stamped the outputs by copying from the source *path* **after** the conversion. When the output is the source file itself - batch convert with *save in source folder* + *overwrite* (`BatchConverter.GetOutputFileName` deletes and rewrites the source), or seconv `--overwrite` with no output folder and the same format - the copy read back the time the output had just been written, so the option silently did nothing. That in-place "fix my file but keep its date" case is exactly what the discussion asked for.

## Fix
`FileTimestampHelper.Capture(path)` reads the creation/last-write time into a `FileTimestamps` snapshot before anything is written; the existing path-based overloads now delegate to it, and the batch converter / seconv stamp the outputs from the snapshot taken before converting (threaded through seconv's image pass-through helpers too).

## Tests
- `KeepTimestamp_InPlaceOverwrite_KeepsSourceLastWriteTime` (seconv, end to end) - verified red on the previous code, green now.
- `Capture_ThenOverwrite_ThenCopy_RestoresOriginalTime` + `Capture_MissingFile_ReturnsNull` (libse).
- seconv suite 383/383, libse 1409/1409, UI project builds.

Never shipped, so no change-log entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)