### PR TITLE
Ripple delete: judge the block and its follower among the working rows

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -23462,18 +23462,24 @@ public partial class MainViewModel :
         _undoRedoManager.StopChangeDetection();
         try
         {
+            // "Consecutive" and "the line after the deleted block" are judged among the working
+            // rows only: with a mismatched read-only original, display-only reference rows sit in
+            // between, so by grid index a contiguous selection looked gapped (no ripple at all)
+            // and the row after the block could be a reference row - whose start time then set
+            // the shift for the rest of the file.
+            var workingRows = Subtitles.Where(p => !p.IsReferenceOnly).ToList();
             var sortedIndices = selectedItems
-                .Select(item => Subtitles.IndexOf(item))
+                .Select(item => workingRows.IndexOf(item))
                 .Where(i => i >= 0)
                 .OrderBy(i => i)
                 .ToList();
 
-            var firstLine = Subtitles.GetOrNull(sortedIndices.FirstOrDefault());
+            var firstLine = workingRows.GetOrNull(sortedIndices.FirstOrDefault());
 
             var areLinesConsecutive = sortedIndices.Count == 1 ||
                                       sortedIndices.Zip(sortedIndices.Skip(1), (a, b) => b - a).All(diff => diff == 1);
 
-            var nextLine = Subtitles.GetOrNull(sortedIndices.FirstOrDefault() + sortedIndices.Count);
+            var nextLine = workingRows.GetOrNull(sortedIndices.FirstOrDefault() + sortedIndices.Count);
 
             var survivor = PickRowToSelectAfterRemoval(selectedItems);
             RemoveRowsAndSelectSurvivor(selectedItems, survivor, gridHadFocus);

--- a/tests/UI/Features/Main/MainReadOnlyOriginalTests.cs
+++ b/tests/UI/Features/Main/MainReadOnlyOriginalTests.cs
@@ -288,6 +288,51 @@ public class MainReadOnlyOriginalTests
         }
     }
 
+    /// <summary>
+    /// Ripple delete judges "consecutive" and "the line after the deleted block" among the
+    /// working rows: a display-only reference row in between must neither make the selection
+    /// look gapped (no ripple) nor become the line whose start time sets the shift.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task RippleDelete_WithReferenceRowAfterTheDeletedLine_ShiftsByTheNextWorkingLine()
+    {
+        Se.Settings.General.PromptBeforeDelete = false;
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            // Working: one (0-2 s), two (4-6 s), three (8-10 s). Reference-only row at 2-4 s lands
+            // between one and two; it is the grid row right after "one".
+            AddLine(vm, "Translated one", string.Empty, 0, 2000);
+            AddLine(vm, "Translated two", string.Empty, 4000, 6000);
+            var three = AddLine(vm, "Translated three", string.Empty, 8000, 10000);
+            ImportReference(vm, BuildSampleReference());
+            Assert.True(vm.Subtitles[1].IsReferenceOnly);
+            var two = vm.Subtitles[2];
+            var referenceRow = vm.Subtitles[1];
+
+            vm.SelectAndScrollToSubtitle(vm.Subtitles[0]);
+            Dispatcher.UIThread.RunJobs();
+            Assert.Equal("Translated one", vm.SelectedSubtitle?.Text);
+
+            await vm.RippleDeleteSelectedLinesCommand.ExecuteAsync(null);
+            Dispatcher.UIThread.RunJobs();
+
+            // Shift = two.Start - one.Start = 4 s (not reference.Start - one.Start = 2 s).
+            Assert.Equal(0, two.StartTime.TotalMilliseconds);
+            Assert.Equal(2000, two.EndTime.TotalMilliseconds);
+            Assert.Equal(4000, three.StartTime.TotalMilliseconds);
+            Assert.Equal(6000, three.EndTime.TotalMilliseconds);
+
+            // The original's row is not retimed.
+            Assert.Equal(2000, referenceRow.StartTime.TotalMilliseconds);
+            Assert.DoesNotContain(vm.Subtitles, p => p.Text == "Translated one");
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
     [AvaloniaFact]
     public void ReferenceOnlyRow_SelectedAlone_IsNotReturnedAsASelectedItem()
     {


### PR DESCRIPTION
Found during the beta21 bug hunt (same #13962 family as #13966/#13968).

## Problem
`RippleDeleteSelectedItems` decided "are the selected lines consecutive" and "which line follows the block" by **grid index**. With a mismatched read-only original open, the grid holds display-only reference rows interleaved with the working rows, so:

- a contiguous selection with a reference row inside it looked gapped → no ripple at all;
- the row right after the block could be a reference row → `timeToShift = referenceRow.Start - firstLine.Start`, and every following line was shifted by the *original's* timing instead of the next working line's.

## Fix
Both are now computed over `Subtitles.Where(p => !p.IsReferenceOnly)`. The retiming loop already skipped reference rows.

## Test
`RippleDelete_WithReferenceRowAfterTheDeletedLine_ShiftsByTheNextWorkingLine` in `MainReadOnlyOriginalTests` - one (0–2 s) deleted with a reference row at 2–4 s right below it; two/three must shift by 4 s (next working line), not 2 s. Verified red on main, green with the fix; the class passes 29/29.

Not in a shipped release's change-log scope as a regression, but it is a real user-facing fix - I'll leave the change-log line to you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)