### PR TITLE
Use the configured cue gap when snapping in the waveform

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -4,6 +4,7 @@ using Avalonia.Input;
 using Avalonia.Media;
 using Avalonia.Threading;
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Forms;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -1701,11 +1702,18 @@ public class AudioVisualizer : Control
 
     /// <summary>
     /// Where an IN cue dragged to <paramref name="seconds"/> should land if a shot change is close
-    /// enough to capture it, or null when none is. In cues land exactly on the cut.
+    /// enough to capture it, or null when none is. An in cue lands the beautify profile's in cues
+    /// gap <b>after</b> the cut.
     /// <para>
     /// Shared by every drag interaction that moves an in cue - resizing the left edge and moving a
     /// whole paragraph - so the same grab lands on the same time whichever way the user does it
     /// (issue #13953).
+    /// </para>
+    /// <para>
+    /// The gap comes from the same profile the beautifier and the snap-to-shot-change shortcuts use,
+    /// so dragging a cue onto a cut and pressing the shortcut for it land in the same place. It used
+    /// to be hard-coded (exactly on the cut for in cues, one frame before it for out cues), which
+    /// silently ignored a profile configured with a wider gap (issue #13984).
     /// </para>
     /// </summary>
     private double? TrySnapInCueToShotChange(double seconds)
@@ -1718,19 +1726,22 @@ public class AudioVisualizer : Control
         // ClosestTo directly (binary search) - GetClosestShotChange only wraps it
         // behind a TimeCode, which is a class, i.e. one allocation per pointer move.
         var nearest = _shotChanges.ClosestTo(seconds);
-        if (nearest == seconds || Math.Abs(seconds - nearest) >= GetInCueSnapSeconds())
+
+        // Measured to the cut, not to the landing point: the red zones the distance comes from are
+        // defined around the cut, so a larger gap must not drag the whole capture window off it.
+        if (Math.Abs(seconds - nearest) >= GetInCueSnapSeconds())
         {
             return null;
         }
 
-        return nearest;
+        return nearest + TimeCodesBeautifierUtils.GetInCuesGapMs() / TimeCode.BaseUnit;
     }
 
     /// <summary>
     /// Where an OUT cue dragged to <paramref name="seconds"/> should land if a shot change is close
-    /// enough to capture it, or null when none is. OUT cues conventionally land one frame BEFORE the
-    /// shot change so they don't bleed visually onto the next shot. <see cref="TrySnapInCueToShotChange"/>
-    /// mirrored.
+    /// enough to capture it, or null when none is. <see cref="TrySnapInCueToShotChange"/> mirrored:
+    /// an out cue lands the beautify profile's out cues gap <b>before</b> the cut, so it does not
+    /// bleed visually onto the next shot.
     /// </summary>
     private double? TrySnapOutCueToShotChange(double seconds)
     {
@@ -1739,16 +1750,14 @@ public class AudioVisualizer : Control
             return null;
         }
 
-        var fps = Se.Settings.General.CurrentFrameRate;
-        var oneFrameSeconds = fps >= 1 ? 1.0 / fps : 0.0;
         // ClosestTo directly - see TrySnapInCueToShotChange.
         var nearest = _shotChanges.ClosestTo(seconds);
-        if (nearest == seconds || Math.Abs(seconds - nearest + oneFrameSeconds) >= GetOutCueSnapSeconds())
+        if (Math.Abs(seconds - nearest) >= GetOutCueSnapSeconds())
         {
             return null;
         }
 
-        return nearest - oneFrameSeconds;
+        return nearest - TimeCodesBeautifierUtils.GetOutCuesGapMs() / TimeCode.BaseUnit;
     }
 
     /// <summary>

--- a/tests/UI/Controls/AudioVisualizerShotChangeSnapTests.cs
+++ b/tests/UI/Controls/AudioVisualizerShotChangeSnapTests.cs
@@ -21,8 +21,8 @@ namespace UITests.Controls;
 /// moves a cue has to keep it, not just the two edge-resize drags. Dragging a whole paragraph
 /// snapped in SE4 and did not in SE5, which reads as the checkbox being broken.
 ///
-/// In cues land exactly on the cut; out cues land one frame before it, so they don't bleed onto
-/// the next shot. A whole-paragraph drag preserves its duration, so whichever cue the cut captures,
+/// A captured cue lands the beautify profile's configured gap away from the cut - in cues after it,
+/// out cues before it, so an out cue doesn't bleed onto the next shot (issue #13984). A whole-paragraph drag preserves its duration, so whichever cue the cut captures,
 /// the other one moves with it.
 /// </summary>
 public class AudioVisualizerShotChangeSnapTests
@@ -31,12 +31,19 @@ public class AudioVisualizerShotChangeSnapTests
     private const double WidthPx = 800;
     private const double HeightPx = 200;
     private const double Fps = 25;
-    private const double OneFrame = 1.0 / Fps;
 
     // Default beautify profile: in cues capture within max(3, 5) frames, out cues within
     // max(10, 3) frames.
     private const double InCueSnapSeconds = 5 / Fps;
     private const double OutCueSnapSeconds = 10 / Fps;
+
+    // Where a captured cue lands: the profile's in/out cues gap, in frames, either side of the cut.
+    // Pinned to non-zero values so the tests would catch a regression back to the old hard-coded
+    // offsets (exactly on the cut / one frame before it) - see issue #13984.
+    private const int InCuesGapFrames = 2;
+    private const int OutCuesGapFrames = 4;
+    private const double InCuesGapSeconds = InCuesGapFrames / Fps;
+    private const double OutCuesGapSeconds = OutCuesGapFrames / Fps;
 
     /// <summary>Pins every setting the snap maths reads, so the test does not drift with defaults.</summary>
     private sealed class SnapSettings : IDisposable
@@ -44,7 +51,11 @@ public class AudioVisualizerShotChangeSnapTests
         private readonly bool _snapToShotChanges = Se.Settings.Waveform.SnapToShotChanges;
         private readonly bool _snapToFrames = Se.Settings.Waveform.SnapToFrames;
         private readonly double _frameRate = Se.Settings.General.CurrentFrameRate;
-        private readonly int _inLeft, _inRight, _outLeft, _outRight;
+        // The app keeps these two in lockstep (every writer sets both - see MainViewModel's
+        // frame-rate paths and Se.cs). The snap distance reads the Se copy and the gap reads the
+        // libse copy, so a test that pinned only one would measure two different frame rates.
+        private readonly double _coreFrameRate = Configuration.Settings.General.CurrentFrameRate;
+        private readonly int _inLeft, _inRight, _outLeft, _outRight, _inGap, _outGap;
 
         public SnapSettings(bool snapToShotChanges = true)
         {
@@ -53,14 +64,19 @@ public class AudioVisualizerShotChangeSnapTests
             _inRight = p.InCuesRightRedZone;
             _outLeft = p.OutCuesLeftRedZone;
             _outRight = p.OutCuesRightRedZone;
+            _inGap = p.InCuesGap;
+            _outGap = p.OutCuesGap;
 
             Se.Settings.Waveform.SnapToShotChanges = snapToShotChanges;
             Se.Settings.Waveform.SnapToFrames = false;
             Se.Settings.General.CurrentFrameRate = Fps;
+            Configuration.Settings.General.CurrentFrameRate = Fps;
             p.InCuesLeftRedZone = 3;
             p.InCuesRightRedZone = 5;
             p.OutCuesLeftRedZone = 10;
             p.OutCuesRightRedZone = 3;
+            p.InCuesGap = InCuesGapFrames;
+            p.OutCuesGap = OutCuesGapFrames;
         }
 
         public void Dispose()
@@ -69,10 +85,13 @@ public class AudioVisualizerShotChangeSnapTests
             Se.Settings.Waveform.SnapToShotChanges = _snapToShotChanges;
             Se.Settings.Waveform.SnapToFrames = _snapToFrames;
             Se.Settings.General.CurrentFrameRate = _frameRate;
+            Configuration.Settings.General.CurrentFrameRate = _coreFrameRate;
             p.InCuesLeftRedZone = _inLeft;
             p.InCuesRightRedZone = _inRight;
             p.OutCuesLeftRedZone = _outLeft;
             p.OutCuesRightRedZone = _outRight;
+            p.InCuesGap = _inGap;
+            p.OutCuesGap = _outGap;
         }
     }
 
@@ -126,7 +145,7 @@ public class AudioVisualizerShotChangeSnapTests
     // The reported bug: this drag did nothing special in SE5 - the paragraph slid straight past
     // the cut - while SE4 parked its start on it.
     [AvaloniaFact]
-    public void MoveWholeLine_StartNearAShotChange_SnapsStartOntoIt()
+    public void MoveWholeLine_StartNearAShotChange_SnapsStartTheInCuesGapAfterIt()
     {
         using var _ = new SnapSettings();
         var (window, av) = Open(new List<double> { 1.5 }, Line(1, 3));
@@ -136,13 +155,13 @@ public class AudioVisualizerShotChangeSnapTests
         // inside the in cue capture distance of the cut at 1.5 s.
         Drag(window, 252, 312);
 
-        Assert.Equal(1.5, line.StartTime.TotalSeconds, 6);
+        Assert.Equal(1.5 + InCuesGapSeconds, line.StartTime.TotalSeconds, 6);
         Assert.Equal(2, line.Duration.TotalSeconds, 6); // a whole-line move keeps its duration
         window.Close();
     }
 
     [AvaloniaFact]
-    public void MoveWholeLine_EndNearAShotChange_SnapsEndOneFrameBeforeIt()
+    public void MoveWholeLine_EndNearAShotChange_SnapsEndTheOutCuesGapBeforeIt()
     {
         using var _ = new SnapSettings();
         var (window, av) = Open(new List<double> { 3.5 }, Line(1, 3));
@@ -151,8 +170,8 @@ public class AudioVisualizerShotChangeSnapTests
         // Same drag, but now only the END lands near a cut.
         Drag(window, 252, 312);
 
-        Assert.Equal(3.5 - OneFrame, line.EndTime.TotalSeconds, 6);
-        Assert.Equal(3.5 - OneFrame - 2, line.StartTime.TotalSeconds, 6);
+        Assert.Equal(3.5 - OutCuesGapSeconds, line.EndTime.TotalSeconds, 6);
+        Assert.Equal(3.5 - OutCuesGapSeconds - 2, line.StartTime.TotalSeconds, 6);
         Assert.Equal(2, line.Duration.TotalSeconds, 6);
         window.Close();
     }
@@ -194,14 +213,14 @@ public class AudioVisualizerShotChangeSnapTests
 
         Drag(window, 252, 312);
 
-        Assert.Equal(1.5, line.StartTime.TotalSeconds, 6);
+        Assert.Equal(1.5 + InCuesGapSeconds, line.StartTime.TotalSeconds, 6);
         window.Close();
     }
 
     // Regression guards: the resize drags kept their behaviour when the snap rule moved into a
     // shared helper.
     [AvaloniaFact]
-    public void ResizeLeft_NearAShotChange_SnapsOntoIt()
+    public void ResizeLeft_NearAShotChange_SnapsTheInCuesGapAfterIt()
     {
         using var _ = new SnapSettings();
         var (window, av) = Open(new List<double> { 1.5 }, Line(1, 3));
@@ -209,13 +228,13 @@ public class AudioVisualizerShotChangeSnapTests
 
         Drag(window, 126, 186); // left edge at 1 s, +60 px
 
-        Assert.Equal(1.5, line.StartTime.TotalSeconds, 6);
+        Assert.Equal(1.5 + InCuesGapSeconds, line.StartTime.TotalSeconds, 6);
         Assert.Equal(3, line.EndTime.TotalSeconds, 6); // the other edge stays put
         window.Close();
     }
 
     [AvaloniaFact]
-    public void ResizeRight_NearAShotChange_SnapsOneFrameBeforeIt()
+    public void ResizeRight_NearAShotChange_SnapsTheOutCuesGapBeforeIt()
     {
         using var _ = new SnapSettings();
         var (window, av) = Open(new List<double> { 3.5 }, Line(1, 3));
@@ -223,9 +242,35 @@ public class AudioVisualizerShotChangeSnapTests
 
         Drag(window, 378, 438); // right edge at 3 s, +60 px
 
-        Assert.Equal(3.5 - OneFrame, line.EndTime.TotalSeconds, 6);
+        Assert.Equal(3.5 - OutCuesGapSeconds, line.EndTime.TotalSeconds, 6);
         Assert.Equal(1, line.StartTime.TotalSeconds, 6);
         window.Close();
+    }
+
+    // Issue #13984: the landing offset is the profile's gap, not a hard-coded one frame. A profile
+    // configured with a wider gap must actually widen the space between the cue and the cut.
+    [AvaloniaFact]
+    public void SnapEnd_LandingOffsetFollowsTheProfilesOutCuesGap()
+    {
+        using var _ = new SnapSettings();
+        var profile = Configuration.Settings.BeautifyTimeCodes.Profile;
+
+        profile.OutCuesGap = 1; // what the offset used to be hard-coded to
+        var (window, av) = Open(new List<double> { 3.5 }, Line(1, 3));
+        var line = av.SelectedParagraph!;
+        Drag(window, 378, 438);
+        var narrow = 3.5 - line.EndTime.TotalSeconds;
+        Assert.Equal(1 / Fps, narrow, 6);
+        window.Close();
+
+        profile.OutCuesGap = 8;
+        var (window2, av2) = Open(new List<double> { 3.5 }, Line(1, 3));
+        var line2 = av2.SelectedParagraph!;
+        Drag(window2, 378, 438);
+        var wide = 3.5 - line2.EndTime.TotalSeconds;
+        Assert.Equal(8 / Fps, wide, 6);
+        Assert.True(wide > narrow);
+        window2.Close();
     }
 
     // Out cues get a wider capture distance than in cues (the profile's out cues red zones are
@@ -251,7 +296,7 @@ public class AudioVisualizerShotChangeSnapTests
         var (window2, av2) = Open(new List<double> { draggedEnd + Offset }, Line(1, 3));
         var line2 = av2.SelectedParagraph!;
         Drag(window2, 252, 312);
-        Assert.Equal(draggedEnd + Offset - OneFrame, line2.EndTime.TotalSeconds, 6);
+        Assert.Equal(draggedEnd + Offset - OutCuesGapSeconds, line2.EndTime.TotalSeconds, 6);
         window2.Close();
     }
 }


### PR DESCRIPTION
Fixes #13984

Follow-up to #13954. That PR noted this exact deviation and offered to switch — this is the switch.

## What was wrong

Dragging a cue onto a shot change in the waveform used a **hard-coded** landing offset: exactly on the cut for in cues, one frame before it for out cues. A beautify profile configured with a wider gap was silently ignored, which is why the reporter's gap came out too small.

It also disagreed with the keyboard commands. Since #13948, "snap selected lines' end to previous shot change" lands at `previousShotChange - GetOutCuesGapMs()`. So the same cue, snapped to the same cut, ended up in two different places depending on whether you used the mouse or the shortcut. SE4 used the profile gap for both.

## Answering the reporter's question

> where does SE5 get the gap value from? Is it taken from the Settings or from Beautify Timecodes? Could those two settings conflict with each other?

Everything comes from **Beautify Timecodes**, and after this PR that is true of both halves:

- **Capture distance** ("how near the cut counts as on it") — the profile's `InCues`/`OutCues` **red zones**, via `GetInCueSnapSeconds` / `GetOutCueSnapSeconds`.
- **Landing offset** ("how far from the cut the cue ends up") — the profile's `InCuesGap` / `OutCuesGap`. This is the part that was hard-coded.

Nothing conflicts, with one caveat worth knowing: `Se.Settings.Waveform.SnapToShotChangesPixels` (default 8) is **dead config** — nothing reads it. In SE4 that pixel value *was* the snap distance, so it was zoom-independent; SE5 derives distance from red zones in frames instead. I've left it alone here, but it's misleading in the settings file and worth either wiring up or deleting.

## The change

Both cue helpers take the offset from the profile. Two smaller corrections came with it:

- The capture distance is now measured **to the cut** rather than to the landing point. It comes from the red zones, which are defined around the cut, so a wider gap must not drag the whole capture window off it. (The in-cue path already measured to the cut; the out-cue path didn't — they now agree.)
- The redundant "already exactly there" guard is gone. Returning the target when the cue is already on it is a no-op; returning `null` handed the cue to frame snapping, which could nudge it back off the cut.

## Testing

Updated `AudioVisualizerShotChangeSnapTests` to pin non-zero gaps (2 and 4 frames) so a regression to the old hard-coded offsets is caught, plus a new test that varies `OutCuesGap` and asserts the landing point follows it.

One harness note: the snap distance reads `Se.Settings.General.CurrentFrameRate` while the gap reads `Configuration.Settings.General.CurrentFrameRate`. The app keeps those in lockstep (every writer sets both), but the tests had pinned only one and were silently measuring two different frame rates — now both are pinned.

Verified the tests bite: with the hard-coded offsets restored, 7 of the 9 fail.

Full UI suite: **3385 passed, 0 failed**.

## Note on the default profile

The Default preset has `InCuesGap = 0` and `OutCuesGap = 0`, so on that profile an out cue now lands *on* the cut rather than one frame before it. That matches SE4 and the keyboard shortcuts, and it is what the profile asks for — but if you'd rather the default profile carried a 1-frame out-cue gap, that's a one-line change to the preset instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
