### PR TITLE
Bring "snap to nearest shot change" in line with the other snap paths

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9901,76 +9901,33 @@ public partial class MainViewModel :
             return;
         }
 
-        var maxStartDistance = Se.Settings.Waveform.SnapToShotChangeStartMaxSeconds;
-        var maxEndDistance = Se.Settings.Waveform.SnapToShotChangeEndMaxSeconds;
-        var maxSameShotEndDistance = Se.Settings.Waveform.SnapToShotChangeSameShotEndMaxSeconds;
+        var inCuesGapMs = TimeCodesBeautifierUtils.GetInCuesGapMs();
+        var outCuesGapMs = TimeCodesBeautifierUtils.GetOutCuesGapMs();
+        var maxStartDistanceMs = Se.Settings.Waveform.SnapToShotChangeStartMaxSeconds * 1000.0;
+        var maxEndDistanceMs = Se.Settings.Waveform.SnapToShotChangeEndMaxSeconds * 1000.0;
+        var maxSameShotEndDistanceMs = Se.Settings.Waveform.SnapToShotChangeSameShotEndMaxSeconds * 1000.0;
 
         foreach (var line in selectedLines)
         {
-            var idx = Subtitles.IndexOf(line);
-            var prev = GetPreviousWorkingRow(idx);
-            var next = GetNextWorkingRow(idx);
+            var snapped = ShotChangesHelper.GetSnappedToNearestMs(
+                AudioVisualizer.ShotChanges,
+                line.StartTime.TotalMilliseconds,
+                line.EndTime.TotalMilliseconds,
+                inCuesGapMs,
+                outCuesGapMs,
+                maxStartDistanceMs,
+                maxEndDistanceMs,
+                maxSameShotEndDistanceMs);
 
-            var nearestStartShotChange = AudioVisualizer.ShotChanges
-                .OrderBy(s => Math.Abs(s - line.StartTime.TotalSeconds))
-                .FirstOrDefault(s => Math.Abs(s - line.StartTime.TotalSeconds) < maxStartDistance);
-
-            var nearestEndShotChange = AudioVisualizer.ShotChanges
-                .OrderBy(s => Math.Abs(s - line.EndTime.TotalSeconds))
-                .FirstOrDefault(s => Math.Abs(s - line.EndTime.TotalSeconds) < maxEndDistance);
-
-            if (nearestStartShotChange == 0 && nearestEndShotChange == 0)
+            if (snapped == null)
             {
                 continue;
             }
 
-            if (nearestStartShotChange == 0)
-            {
-                var newDuration = TimeSpan.FromSeconds(nearestEndShotChange) - line.StartTime;
-                if (newDuration.TotalMilliseconds <= Se.Settings.General.SubtitleMaximumDisplayMilliseconds &&
-                    newDuration.TotalMilliseconds >= Se.Settings.General.SubtitleMinimumDisplayMilliseconds)
-                {
-                    line.EndTime = TimeSpan.FromSeconds(nearestEndShotChange);
-                }
-
-                continue;
-            }
-
-            if (nearestEndShotChange == 0)
-            {
-                var newDuration = line.EndTime - TimeSpan.FromSeconds(nearestStartShotChange);
-                if (newDuration.TotalMilliseconds <= Se.Settings.General.SubtitleMaximumDisplayMilliseconds &&
-                    newDuration.TotalMilliseconds >= Se.Settings.General.SubtitleMinimumDisplayMilliseconds)
-                {
-                    line.StartTime = TimeSpan.FromSeconds(nearestStartShotChange);
-                }
-
-                continue;
-            }
-
-            if (nearestStartShotChange == nearestEndShotChange)
-            {
-                nearestEndShotChange = AudioVisualizer.ShotChanges
-                    .OrderBy(s => Math.Abs(s - line.EndTime.TotalSeconds))
-                    .FirstOrDefault(s => Math.Abs(s - line.EndTime.TotalSeconds) < maxSameShotEndDistance);
-
-                if (nearestEndShotChange > 0 && nearestEndShotChange > line.StartTime.TotalSeconds)
-                {
-                    line.EndTime = TimeSpan.FromSeconds(nearestEndShotChange);
-                }
-
-                continue;
-            }
-
-            var newStartTime = TimeSpan.FromSeconds(nearestStartShotChange);
-            var newEndTime = TimeSpan.FromSeconds(nearestEndShotChange);
-            var newCombinedDuration = newEndTime - newStartTime;
-            if (newCombinedDuration.TotalMilliseconds <= Se.Settings.General.SubtitleMaximumDisplayMilliseconds &&
-                newCombinedDuration.TotalMilliseconds >= Se.Settings.General.SubtitleMinimumDisplayMilliseconds)
-            {
-                line.StartTime = newStartTime;
-                line.EndTime = newEndTime;
-            }
+            // Atomic so the bound editor controls never see a transient start > end.
+            line.SetTimes(
+                TimeSpan.FromMilliseconds(snapped.Value.StartMs),
+                TimeSpan.FromMilliseconds(snapped.Value.EndMs));
         }
 
         _updateAudioVisualizer = true;

--- a/src/ui/Logic/Media/ShotChangesHelper.cs
+++ b/src/ui/Logic/Media/ShotChangesHelper.cs
@@ -405,6 +405,99 @@ public class ShotChangesHelper
         return newStartMs;
     }
 
+    /// <summary>
+    /// The new start and end a "snap selected lines to nearest shot change" should produce, or null
+    /// when the line must be left alone.
+    /// <para>
+    /// Each cue is snapped independently to its nearest shot change within its own capture distance
+    /// (<paramref name="maxStartDistanceMs"/> / <paramref name="maxEndDistanceMs"/>), landing the
+    /// profile's in/out cues gap either side of the cut - the same landing rule as the waveform drag
+    /// and the start/end snap shortcuts, so every way of snapping a cue to a cut puts it in the same
+    /// place (issues #13948, #13984).
+    /// </para>
+    /// <para>
+    /// When both cues find the <b>same</b> cut the line straddles it, and snapping both would
+    /// collapse it onto the cut. The start keeps that cut (the nearest one by construction) and the
+    /// end retries within the tighter <paramref name="maxSameShotEndDistanceMs"/> for a cut further
+    /// on; if there is none the end stays put.
+    /// </para>
+    /// <para>
+    /// Like the start/end snap shortcuts, the only veto is a result that would not leave a positive
+    /// duration. Minimum/maximum display duration deliberately do not veto: the user asked for this
+    /// line to move, and a silently ignored shortcut reads as a dead one.
+    /// </para>
+    /// </summary>
+    public static (double StartMs, double EndMs)? GetSnappedToNearestMs(
+        List<double> shotChanges,
+        double startMs,
+        double endMs,
+        double inCuesGapMs,
+        double outCuesGapMs,
+        double maxStartDistanceMs,
+        double maxEndDistanceMs,
+        double maxSameShotEndDistanceMs)
+    {
+        if (shotChanges == null || shotChanges.Count == 0)
+        {
+            return null;
+        }
+
+        var nearestStart = ClosestWithin(shotChanges, startMs, maxStartDistanceMs);
+        var nearestEnd = ClosestWithin(shotChanges, endMs, maxEndDistanceMs);
+
+        if (nearestStart == null && nearestEnd == null)
+        {
+            return null;
+        }
+
+        if (nearestStart != null && nearestEnd != null && nearestStart.Value == nearestEnd.Value)
+        {
+            // Straddling one cut: the start takes it, and the end only moves if the next cut
+            // *after* that one sits within the same-shot distance - otherwise it stays where it
+            // is. A nearest-overall retry would just find the straddled cut again.
+            nearestEnd = FirstAfterWithin(shotChanges, nearestStart.Value, endMs, maxSameShotEndDistanceMs);
+        }
+
+        var newStartMs = nearestStart != null ? nearestStart.Value + inCuesGapMs : startMs;
+        var newEndMs = nearestEnd != null ? nearestEnd.Value - outCuesGapMs : endMs;
+
+        if (newEndMs <= newStartMs)
+        {
+            return null;
+        }
+
+        if (newStartMs == startMs && newEndMs == endMs)
+        {
+            return null;
+        }
+
+        return (newStartMs, newEndMs);
+    }
+
+    // The shot change (in ms) nearest to targetMs, or null when none lies strictly within
+    // maxDistanceMs. Shot changes are seconds on disk; the comparison is done in ms.
+    private static double? ClosestWithin(List<double> shotChanges, double targetMs, double maxDistanceMs)
+    {
+        var closestSeconds = shotChanges.ClosestTo(targetMs / 1000.0);
+        var closestMs = closestSeconds * 1000.0;
+        return Math.Abs(closestMs - targetMs) < maxDistanceMs ? closestMs : null;
+    }
+
+    // The first shot change (in ms) strictly after afterMs, or null when there is none or it lies
+    // outside maxDistanceMs of targetMs. The list is sorted, so a binary search finds the spot.
+    private static double? FirstAfterWithin(List<double> shotChanges, double afterMs, double targetMs, double maxDistanceMs)
+    {
+        var index = shotChanges.BinarySearch(afterMs / 1000.0);
+        index = index < 0 ? ~index : index + 1;
+        if (index >= shotChanges.Count)
+        {
+            return null;
+        }
+
+        var candidateMs = shotChanges[index] * 1000.0;
+        return Math.Abs(candidateMs - targetMs) < maxDistanceMs ? candidateMs : null;
+    }
+
     public static double? GetClosestShotChange(List<double> shotChanges, TimeCode currentTime)
     {
         if (shotChanges == null || shotChanges.Count == 0)

--- a/tests/UI/Logic/Media/ShotChangeSnapNearestTests.cs
+++ b/tests/UI/Logic/Media/ShotChangeSnapNearestTests.cs
@@ -1,0 +1,142 @@
+using Nikse.SubtitleEdit.Logic.Media;
+using System.Collections.Generic;
+
+namespace UITests.Logic.Media;
+
+/// <summary>
+/// The rules behind "snap selected lines to nearest shot change" - the third snap path, brought in
+/// line with the waveform drag (#13984) and the start/end snap shortcuts (#13948): every way of
+/// snapping a cue to a cut lands it the profile's gap away from that cut, and the only veto is a
+/// result with no positive duration.
+/// </summary>
+public class ShotChangeSnapNearestTests
+{
+    private const double InGap = 80;   // ms, 2 frames at 25 fps
+    private const double OutGap = 160; // ms, 4 frames at 25 fps
+    private const double MaxStart = 1000;
+    private const double MaxEnd = 1500;
+    private const double MaxSameShotEnd = 500;
+
+    private static (double, double)? Snap(List<double> cuts, double startMs, double endMs,
+        double inGap = InGap, double outGap = OutGap) =>
+        ShotChangesHelper.GetSnappedToNearestMs(cuts, startMs, endMs, inGap, outGap, MaxStart, MaxEnd, MaxSameShotEnd);
+
+    [Fact]
+    public void BothCuesNearDifferentCuts_SnapBoth_TheGapAwayFromEachCut()
+    {
+        var r = Snap(new List<double> { 1.0, 5.0 }, startMs: 1200, endMs: 4700);
+
+        Assert.Equal((1000 + InGap, 5000 - OutGap), r);
+    }
+
+    // The gap used to be ignored here while the sibling shortcuts applied it - so the same cue
+    // snapped to the same cut landed in two places depending on which shortcut you pressed.
+    [Fact]
+    public void LandingOffsetIsTheProfileGap_NotTheCutItself()
+    {
+        var r = Snap(new List<double> { 1.0, 5.0 }, startMs: 1200, endMs: 4700);
+
+        Assert.NotEqual(1000.0, r!.Value.Item1);
+        Assert.NotEqual(5000.0, r!.Value.Item2);
+    }
+
+    [Fact]
+    public void OnlyStartNearACut_SnapsStart_LeavesEndAlone()
+    {
+        var r = Snap(new List<double> { 1.0 }, startMs: 1200, endMs: 4700);
+
+        Assert.Equal((1000 + InGap, 4700.0), r);
+    }
+
+    [Fact]
+    public void OnlyEndNearACut_SnapsEnd_LeavesStartAlone()
+    {
+        var r = Snap(new List<double> { 5.0 }, startMs: 1200, endMs: 4700);
+
+        Assert.Equal((1200.0, 5000 - OutGap), r);
+    }
+
+    [Fact]
+    public void NoCutInRange_LeavesTheLineAlone()
+    {
+        Assert.Null(Snap(new List<double> { 20.0 }, startMs: 1200, endMs: 4700));
+    }
+
+    [Fact]
+    public void NoShotChangesAtAll_LeavesTheLineAlone()
+    {
+        Assert.Null(Snap(new List<double>(), startMs: 1200, endMs: 4700));
+    }
+
+    // The old code used 0 as "no cut found", so a real shot change at t=0 was indistinguishable
+    // from none - a start near the file's first cut never snapped to it.
+    [Fact]
+    public void ShotChangeAtZero_IsARealCut_NotTheNoCutSentinel()
+    {
+        var r = Snap(new List<double> { 0.0, 20.0 }, startMs: 300, endMs: 4000);
+
+        Assert.Equal((0 + InGap, 4000.0), r);
+    }
+
+    // Straddling a single cut: snapping both cues onto it collapses the line. The start keeps the
+    // cut and the end looks for a further one within the tighter same-shot distance.
+    [Fact]
+    public void BothCuesNearestTheSameCut_StartTakesIt_EndRetriesForAFurtherCut()
+    {
+        // Start at 2.2 s, end at 2.6 s, cut at 2.4 s (nearest to both); another cut at 3.0 s is
+        // 400 ms from the end - inside the 500 ms same-shot distance.
+        var r = Snap(new List<double> { 2.4, 3.0 }, startMs: 2200, endMs: 2600);
+
+        Assert.Equal((2400 + InGap, 3000 - OutGap), r);
+    }
+
+    [Fact]
+    public void BothCuesNearestTheSameCut_NoFurtherCutInRange_EndStaysPut()
+    {
+        var r = Snap(new List<double> { 2.4, 9.0 }, startMs: 2200, endMs: 2600);
+
+        Assert.Equal((2400 + InGap, 2600.0), r);
+    }
+
+    // The retry must look *forward*: a cut behind the start is nearer to the end than nothing, but
+    // snapping the end to it would put the end before the start.
+    [Fact]
+    public void SameCutRetry_IgnoresACutBehindTheStart()
+    {
+        var r = Snap(new List<double> { 2.0, 2.4 }, startMs: 2300, endMs: 2500);
+
+        // Nearest to both is 2.4; the retry's nearest within 500 ms of 2500 is still 2.4 itself
+        // (not > cut), so the end stays.
+        Assert.Equal((2400 + InGap, 2500.0), r);
+    }
+
+    [Fact]
+    public void ResultWouldNotLeaveAPositiveDuration_LeavesTheLineAlone()
+    {
+        // Start cut at 1.0 (+80 = 1080), end cut at 1.1 (-160 = 940): end before start.
+        Assert.Null(Snap(new List<double> { 1.0, 1.1 }, startMs: 1050, endMs: 1120));
+    }
+
+    // Deliberately no minimum/maximum display-duration veto: the user asked for this line to move.
+    [Fact]
+    public void VeryShortResult_StillSnaps()
+    {
+        var r = Snap(new List<double> { 1.0, 1.3 }, startMs: 1050, endMs: 1250);
+
+        Assert.Equal((1000 + InGap, 1300 - OutGap), r); // a 60 ms line, but it is what was asked for
+    }
+
+    [Fact]
+    public void AlreadyExactlyWhereItShouldBe_ReportsNoChange()
+    {
+        Assert.Null(Snap(new List<double> { 1.0, 5.0 }, startMs: 1000 + InGap, endMs: 5000 - OutGap));
+    }
+
+    [Fact]
+    public void ZeroGaps_LandExactlyOnTheCuts()
+    {
+        var r = Snap(new List<double> { 1.0, 5.0 }, startMs: 1200, endMs: 4700, inGap: 0, outGap: 0);
+
+        Assert.Equal((1000.0, 5000.0), r);
+    }
+}


### PR DESCRIPTION
Follow-up to #13985 (step 1 of the consolidation discussed there). Related: #13948, #13984.

After #13949 and #13985, the waveform drag and the start/end snap shortcuts agree on where a snapped cue lands: the beautify profile's in/out cues gap away from the cut. **"Snap selected lines to nearest shot change"** was the last path still putting the cue exactly *on* the cut — so the same cue, snapped to the same cut, landed in different places depending on which shortcut you pressed.

## What changes

| | Before | After |
|---|---|---|
| Landing offset | on the cut | profile `InCuesGap` / `OutCuesGap` (same as the other two paths) |
| Shot change at t=0 | treated as "none found" | a real cut |
| Min/max display duration | vetoed the move | no veto — only a non-positive duration does |
| Line straddles one cut | end collapsed *onto* that cut | end extends to the next cut, or stays put |

The first three are the same defects #13949 removed from the start/end siblings — `0` as the "no cut" sentinel, and duration guards that make the shortcut look dead. The fourth is this command's own: when both cues were nearest the **same** cut, the end retried with a nearest-overall search, which just found the straddled cut again (it's closer than any further one by construction) and then moved the end onto it. The `> StartTime` check passed because the start hadn't moved yet, so the line shrank toward the cut rather than growing past it. The retry now takes the first cut *after* the straddled one, within the same-shot distance.

The capture distances are unchanged — still the three `SnapToShotChange*MaxSeconds` values (1.0 / 1.5 / 0.5 s). Whether those should survive or be replaced by the profile's red zones like the other paths is step 2, and a separate decision.

## The change

The rule moves into `ShotChangesHelper.GetSnappedToNearestMs`, next to `GetSnappedStartMs`/`GetSnappedEndMs`, so it's unit-testable and the command is a thin loop. The result is applied with `SetTimes` so the bound editor controls never see a transient start > end.

## Testing

14 new tests in `tests/UI/Logic/Media/ShotChangeSnapNearestTests.cs` — both/one/neither cue in range, the t=0 cut, the straddle-and-extend case, the straddle-with-nothing-further case, a retry that must ignore a cut *behind* the start, the positive-duration veto, a very short result that must still snap, no-change detection, and zero gaps landing exactly on the cuts.

Full UI suite: **3398 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
