### PR TITLE
Snap to shot changes in the waveform when the cue looks close

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -204,6 +204,7 @@ public class AudioVisualizer : Control
 
     public double MinGapSeconds { get; set; } = 0.1;
 
+    /// <summary>Fallback capture distance when the pixel distance cannot be converted (no peaks yet).</summary>
     public double ShotChangeSnapSeconds { get; set; } = 0.05;
     public WaveformDrawStyle WaveformDrawStyle { get; set; } = WaveformDrawStyle.Classic;
 
@@ -1727,9 +1728,9 @@ public class AudioVisualizer : Control
         // behind a TimeCode, which is a class, i.e. one allocation per pointer move.
         var nearest = _shotChanges.ClosestTo(seconds);
 
-        // Measured to the cut, not to the landing point: the red zones the distance comes from are
-        // defined around the cut, so a larger gap must not drag the whole capture window off it.
-        if (Math.Abs(seconds - nearest) >= GetInCueSnapSeconds())
+        // Measured to the cut, not to the landing point: the capture window is around the cut the
+        // user is aiming at, so a larger gap must not drag it off the cut.
+        if (Math.Abs(seconds - nearest) >= GetShotChangeSnapSeconds())
         {
             return null;
         }
@@ -1752,7 +1753,7 @@ public class AudioVisualizer : Control
 
         // ClosestTo directly - see TrySnapInCueToShotChange.
         var nearest = _shotChanges.ClosestTo(seconds);
-        if (Math.Abs(seconds - nearest) >= GetOutCueSnapSeconds())
+        if (Math.Abs(seconds - nearest) >= GetShotChangeSnapSeconds())
         {
             return null;
         }
@@ -1761,45 +1762,24 @@ public class AudioVisualizer : Control
     }
 
     /// <summary>
-    /// Snap distance (seconds) for a paragraph IN-cue near a shot change, derived from
-    /// the BeautifyTimeCodes profile's InCues red zones. Falls back to <see cref="ShotChangeSnapSeconds"/>
-    /// when no profile / fps is available.
+    /// How close (in seconds, at the current zoom) a dragged cue has to be to a shot change for the
+    /// cut to capture it.
+    /// <para>
+    /// Defined in <b>pixels</b> - <see cref="SeWaveform.SnapToShotChangesPixels"/>, the same 8 px
+    /// SE4 used - so snapping happens when the cue <i>looks</i> close, whatever the zoom. A
+    /// time-based distance (the profile's red zones, which this replaced) felt like snapping never
+    /// happened zoomed out and like the cut grabbed from far away zoomed in.
+    /// </para>
     /// </summary>
-    private double GetInCueSnapSeconds()
+    private double GetShotChangeSnapSeconds()
     {
-        var fps = Se.Settings.General.CurrentFrameRate;
-        if (fps < 1)
+        var pixels = Se.Settings.Waveform.SnapToShotChangesPixels;
+        if (pixels <= 0 || WavePeaks == null || WavePeaks.SampleRate <= 0 || ZoomFactor <= 0)
         {
             return ShotChangeSnapSeconds;
         }
 
-        var profile = Nikse.SubtitleEdit.Core.Common.Configuration.Settings.BeautifyTimeCodes?.Profile;
-        if (profile == null)
-        {
-            return ShotChangeSnapSeconds;
-        }
-
-        var frames = Math.Max(profile.InCuesLeftRedZone, profile.InCuesRightRedZone);
-        return frames > 0 ? frames / fps : ShotChangeSnapSeconds;
-    }
-
-    /// <summary>Snap distance (seconds) for a paragraph OUT-cue, derived from OutCues red zones.</summary>
-    private double GetOutCueSnapSeconds()
-    {
-        var fps = Se.Settings.General.CurrentFrameRate;
-        if (fps < 1)
-        {
-            return ShotChangeSnapSeconds;
-        }
-
-        var profile = Nikse.SubtitleEdit.Core.Common.Configuration.Settings.BeautifyTimeCodes?.Profile;
-        if (profile == null)
-        {
-            return ShotChangeSnapSeconds;
-        }
-
-        var frames = Math.Max(profile.OutCuesLeftRedZone, profile.OutCuesRightRedZone);
-        return frames > 0 ? frames / fps : ShotChangeSnapSeconds;
+        return pixels / (WavePeaks.SampleRate * ZoomFactor);
     }
 
     private void UpdateCursor(Point point)

--- a/tests/UI/Controls/AudioVisualizerShotChangeSnapTests.cs
+++ b/tests/UI/Controls/AudioVisualizerShotChangeSnapTests.cs
@@ -22,7 +22,11 @@ namespace UITests.Controls;
 /// snapped in SE4 and did not in SE5, which reads as the checkbox being broken.
 ///
 /// A captured cue lands the beautify profile's configured gap away from the cut - in cues after it,
-/// out cues before it, so an out cue doesn't bleed onto the next shot (issue #13984). A whole-paragraph drag preserves its duration, so whichever cue the cut captures,
+/// out cues before it, so an out cue doesn't bleed onto the next shot (issue #13984).
+///
+/// Whether a cut captures the cue at all is decided in pixels, not time: the cue has to *look*
+/// close at the current zoom (SnapToShotChangesPixels, SE4's 8 px), so the feel is the same zoomed
+/// in or out. A whole-paragraph drag preserves its duration, so whichever cue the cut captures,
 /// the other one moves with it.
 /// </summary>
 public class AudioVisualizerShotChangeSnapTests
@@ -32,10 +36,10 @@ public class AudioVisualizerShotChangeSnapTests
     private const double HeightPx = 200;
     private const double Fps = 25;
 
-    // Default beautify profile: in cues capture within max(3, 5) frames, out cues within
-    // max(10, 3) frames.
-    private const double InCueSnapSeconds = 5 / Fps;
-    private const double OutCueSnapSeconds = 10 / Fps;
+    // Capture distance: 8 px at zoom 1 = 8/126 s. Zoom-independent in pixels, so it halves in
+    // seconds at zoom 2.
+    private const int SnapPixels = 8;
+    private const double SnapSecondsAtZoom1 = (double)SnapPixels / SampleRate;
 
     // Where a captured cue lands: the profile's in/out cues gap, in frames, either side of the cut.
     // Pinned to non-zero values so the tests would catch a regression back to the old hard-coded
@@ -55,28 +59,22 @@ public class AudioVisualizerShotChangeSnapTests
         // frame-rate paths and Se.cs). The snap distance reads the Se copy and the gap reads the
         // libse copy, so a test that pinned only one would measure two different frame rates.
         private readonly double _coreFrameRate = Configuration.Settings.General.CurrentFrameRate;
-        private readonly int _inLeft, _inRight, _outLeft, _outRight, _inGap, _outGap;
+        private readonly int _inGap, _outGap, _snapPixels;
 
         public SnapSettings(bool snapToShotChanges = true)
         {
             var p = Configuration.Settings.BeautifyTimeCodes.Profile;
-            _inLeft = p.InCuesLeftRedZone;
-            _inRight = p.InCuesRightRedZone;
-            _outLeft = p.OutCuesLeftRedZone;
-            _outRight = p.OutCuesRightRedZone;
             _inGap = p.InCuesGap;
             _outGap = p.OutCuesGap;
+            _snapPixels = Se.Settings.Waveform.SnapToShotChangesPixels;
 
             Se.Settings.Waveform.SnapToShotChanges = snapToShotChanges;
             Se.Settings.Waveform.SnapToFrames = false;
             Se.Settings.General.CurrentFrameRate = Fps;
             Configuration.Settings.General.CurrentFrameRate = Fps;
-            p.InCuesLeftRedZone = 3;
-            p.InCuesRightRedZone = 5;
-            p.OutCuesLeftRedZone = 10;
-            p.OutCuesRightRedZone = 3;
             p.InCuesGap = InCuesGapFrames;
             p.OutCuesGap = OutCuesGapFrames;
+            Se.Settings.Waveform.SnapToShotChangesPixels = SnapPixels;
         }
 
         public void Dispose()
@@ -86,12 +84,9 @@ public class AudioVisualizerShotChangeSnapTests
             Se.Settings.Waveform.SnapToFrames = _snapToFrames;
             Se.Settings.General.CurrentFrameRate = _frameRate;
             Configuration.Settings.General.CurrentFrameRate = _coreFrameRate;
-            p.InCuesLeftRedZone = _inLeft;
-            p.InCuesRightRedZone = _inRight;
-            p.OutCuesLeftRedZone = _outLeft;
-            p.OutCuesRightRedZone = _outRight;
             p.InCuesGap = _inGap;
             p.OutCuesGap = _outGap;
+            Se.Settings.Waveform.SnapToShotChangesPixels = _snapPixels;
         }
     }
 
@@ -273,30 +268,67 @@ public class AudioVisualizerShotChangeSnapTests
         window2.Close();
     }
 
-    // Out cues get a wider capture distance than in cues (the profile's out cues red zones are
-    // larger), so the same offset that is too far for a start still catches an end.
+    // The capture distance is pixels, so the same on-screen distance captures at every zoom - and
+    // the same *time* distance captures at one zoom and not another.
     [AvaloniaFact]
-    public void SnapDistances_ComeFromTheBeautifyProfileRedZones()
+    public void CaptureDistance_IsInPixels_SoItIsZoomIndependent()
     {
         using var _ = new SnapSettings();
-        const double Offset = 0.3; // between the 0.2 s in cue and 0.4 s out cue distances
-        Assert.True(InCueSnapSeconds < Offset && Offset < OutCueSnapSeconds);
 
+        // A cut 5 px past where the drag leaves the start: inside 8 px at zoom 1.
         var draggedStart = 1 + 60.0 / SampleRate;
-        var draggedEnd = draggedStart + 2;
+        var cutAt = draggedStart + 5.0 / SampleRate;
 
-        // Too far for the start to be captured.
-        var (window, av) = Open(new List<double> { draggedStart + Offset }, Line(1, 3));
+        var (window, av) = Open(new List<double> { cutAt }, Line(1, 3));
+        var line = av.SelectedParagraph!;
+        Drag(window, 252, 312);
+        Assert.Equal(cutAt + InCuesGapSeconds, line.StartTime.TotalSeconds, 3);
+        window.Close();
+
+        // Same cut, same drag in *time* (120 px at zoom 2 = 60 px at zoom 1), but that 5-px-at-
+        // zoom-1 gap is now 10 px on screen: outside 8 px, so no capture.
+        var (window2, av2) = Open(new List<double> { cutAt }, Line(1, 3));
+        av2.ZoomFactor = 2;
+        Dispatcher.UIThread.RunJobs();
+        var line2 = av2.SelectedParagraph!;
+        Drag(window2, 504, 624); // middle of the line at zoom 2 is x = 2 s * 126 * 2
+        Assert.Equal(draggedStart, line2.StartTime.TotalSeconds, 3);
+        window2.Close();
+    }
+
+    // A cut 8 px or more away does not capture, however close it is in time at a high zoom.
+    [AvaloniaFact]
+    public void CaptureDistance_JustOutsideThePixelRadius_DoesNotSnap()
+    {
+        using var _ = new SnapSettings();
+        var draggedStart = 1 + 60.0 / SampleRate;
+        var cutAt = draggedStart + SnapSecondsAtZoom1; // exactly 8 px: the strict < excludes it
+
+        var (window, av) = Open(new List<double> { cutAt }, Line(1, 3));
+        var line = av.SelectedParagraph!;
+        Drag(window, 252, 312);
+        Assert.Equal(draggedStart, line.StartTime.TotalSeconds, 6);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void CaptureDistance_FollowsTheSetting()
+    {
+        using var _ = new SnapSettings();
+        var draggedStart = 1 + 60.0 / SampleRate;
+        var cutAt = draggedStart + 12.0 / SampleRate; // 12 px away: outside 8, inside 16
+
+        var (window, av) = Open(new List<double> { cutAt }, Line(1, 3));
         var line = av.SelectedParagraph!;
         Drag(window, 252, 312);
         Assert.Equal(draggedStart, line.StartTime.TotalSeconds, 6);
         window.Close();
 
-        // Same offset, but an end at that range is still captured.
-        var (window2, av2) = Open(new List<double> { draggedEnd + Offset }, Line(1, 3));
+        Se.Settings.Waveform.SnapToShotChangesPixels = 16;
+        var (window2, av2) = Open(new List<double> { cutAt }, Line(1, 3));
         var line2 = av2.SelectedParagraph!;
         Drag(window2, 252, 312);
-        Assert.Equal(draggedEnd + Offset - OutCuesGapSeconds, line2.EndTime.TotalSeconds, 6);
+        Assert.Equal(cutAt + InCuesGapSeconds, line2.StartTime.TotalSeconds, 3);
         window2.Close();
     }
 }


### PR DESCRIPTION
**Stacked on #13985** — base is that branch, not main. Merge #13985 first; this will then retarget to main automatically.

Follows the decision on #13985: snap when the cue *looks* close, independent of zoom.

## What changes

Only the **capture distance** — how near a dragged cue has to be to a cut for the cut to grab it.

| | Before | After |
|---|---|---|
| Unit | frames (profile red zones) | **pixels** |
| Setting | `InCues`/`OutCues` red zones | `Se.Settings.Waveform.SnapToShotChangesPixels` (default 8) |
| Feel | different at every zoom | same at every zoom |

A time distance felt like snapping never happened zoomed out and like the cut grabbed from far away zoomed in. 8 px is what SE4 used, and `SnapToShotChangesPixels` has existed in the settings file all along with nothing reading it — it now does its job instead of being dead config.

**Unchanged:** where a captured cue lands (still the profile's in/out cues gap, per #13985), and the keyboard snap commands, which keep their own time-based distances — without a pointer there is no "looks close".

One simplification came free: in and out cues used to have *different* capture distances (from their respective red zones). A pixel radius is a single number, so there's one `GetShotChangeSnapSeconds()` instead of two.

## Testing

Replaced the red-zone distance test with three pixel tests: a cut 5 px away captures at zoom 1 but the same cut — same drag in *time* — does not at zoom 2 where it's 10 px away; a cut exactly 8 px away does not capture (strict `<`); and raising the setting to 16 px captures a cut 12 px away. Verified they bite: with a time-based distance substituted back in, all three fail.

Full UI suite: **3387 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
