### PR TITLE
Docs: bring shot-change snapping and "What's new in SE 5" up to date

### DIFF
--- a/docs/features/audio-visualizer.md
+++ b/docs/features/audio-visualizer.md
@@ -83,10 +83,22 @@ Shot changes (scene cuts) are displayed as vertical lines on the waveform. These
 
 - **Toggle shot change at video position** — Add or remove a shot change marker
 - **Go to previous/next shot change** — Navigate between shot changes
-- **Snap to nearest shot change** — Align subtitle edges to nearby shot changes. The snap distance follows the *In cues* / *Out cues* red zones in the [Beautify time codes](beautify-time-codes.md) profile. Out-cues snap to one frame **before** the shot change. **Hold Shift** while dragging to bypass the snap.
+- **Snap to shot changes** — see [Snapping to shot changes](#snapping-to-shot-changes) below
 - **Extend to next shot change** — Extend subtitle to the next scene cut
 
 The shot change line color can be customized in Subtitle Edit 5, which is useful when your waveform or spectrogram theme makes the default color hard to see.
+
+### Snapping to shot changes
+
+Every way of snapping a cue to a shot change puts it in the same place: the [Beautify time codes](beautify-time-codes.md) profile's **In cues gap** after the cut for a start, and its **Out cues gap** before the cut for an end. What differs is how a cue gets *captured*:
+
+**Dragging in the waveform.** A start or end edge — or a whole subtitle — snaps when it comes within **Snap distance when dragging** of a shot change. The distance is in *pixels*, so snapping feels the same at every zoom level: the cue snaps when it *looks* close. **Hold Shift** while dragging to move freely. Turn it off altogether with *Snap to shot changes (hold Shift to override)*.
+
+**Snap selected lines' start to next shot change / end to previous shot change.** Moves one cue to the nearest cut in that direction, however far away it is, keeping the other cue where it is. Useful after a rough placement.
+
+**Snap selected lines to nearest shot change.** Looks for a cut near *each* cue within **Max start distance** and **Max end distance** (seconds) and snaps whichever it finds. If both cues are nearest the *same* cut, the start takes it and the end looks ahead within the tighter **Max end distance when start and end share a cut** instead, so the subtitle is not collapsed onto the cut.
+
+All the distances live in Options → Settings → Waveform, directly under the snap toggles. The shortcuts ship without default keys — assign them in Options → Shortcuts.
 
 ## Context Menu
 

--- a/docs/features/beautify-time-codes.md
+++ b/docs/features/beautify-time-codes.md
@@ -84,13 +84,14 @@ Each sub-tab offers:
 
 ## Snap-to-shot-changes while editing
 
-The profile's **In cues / Out cues red zones** also drive the snap distance when you drag a paragraph edge in the main waveform:
+The profile's **In cues gap** and **Out cues gap** decide where a cue lands when it snaps to a shot change anywhere in Subtitle Edit — dragging in the waveform, or the *snap to shot change* shortcuts:
 
-- Drag a paragraph start into the red zone around a shot change → snaps to the shot change.
-- Drag a paragraph end into the red zone → snaps to one frame **before** the shot change (so the cue doesn't bleed onto the next shot).
-- **Hold Shift while dragging** to bypass the snap entirely.
+- A snapped **start** lands the *In cues gap* **after** the shot change.
+- A snapped **end** lands the *Out cues gap* **before** the shot change (so the cue doesn't bleed onto the next shot).
 
-Toggle the whole behavior with *Snap to shot changes (hold Shift to override)* in Options → Settings → Waveform.
+With both gaps at 0 (the *Default* preset) cues land exactly on the cut. Raise *Out cues gap* to 1 or 2 frames if you prefer ends to stop just short of it.
+
+*How close* a cue has to be before it snaps is **not** taken from the profile — that is set in Options → Settings → Waveform, in pixels for dragging and in seconds for the keyboard commands. See [Audio Visualizer](audio-visualizer.md#snapping-to-shot-changes).
 
 ## Related
 

--- a/docs/features/settings.md
+++ b/docs/features/settings.md
@@ -66,7 +66,9 @@ The subtitle rules that drive error checking, the grid's warning colors, and too
 - **Toolbar items** — Which timing buttons the waveform toolbar shows, and in which order
 - **Waveform single-click / double-click action**
 - **Extract audio format, sample rate and bitrate** — What the audio Subtitle Edit extracts for the waveform looks like
-- **Snap to shot changes (hold Shift to override)**
+- **Snap to shot changes (hold Shift to override)** and **Snap to frames**
+- **Snap distance when dragging (pixels)** — how close a dragged cue has to come to a shot change before it snaps; in pixels, so it feels the same at every zoom
+- **Snap to nearest shot change: max start / end distance (seconds)**, and the tighter **max end distance when start and end share a cut** — how far the *Snap selected lines to nearest shot change* shortcut looks for a cut. Where a snapped cue lands is set by the beautify profile's in/out cues gap (gear icon next to the snap toggle)
 - **Mouse-wheel video position step**
 - **Waveform text font size** and the full color set — text, waveform, subtitle background, background, selected subtitle background, selected, cursor/head, shot change, left/right border, fancy high color. Color themes can be imported and exported
 - **Download ffmpeg** and a **disk space** readout for the extracted audio

--- a/docs/features/whats-new-in-se5.md
+++ b/docs/features/whats-new-in-se5.md
@@ -47,7 +47,7 @@ See [Spell Check](spell-check.md) for details.
 - Waveform themes can be imported and exported.
 - **Spectrogram style** can be changed at runtime — no re-generation needed.
 - More customization options for the waveform and spectrogram, including colors, shot-change colors, and visual style.
-- **Snap to shot changes** now reads its snap window from the *Beautify time codes* profile's red zones, and **Shift** while dragging temporarily disables the snap.
+- **Snap to shot changes** is consistent across every way of doing it — dragging an edge, dragging a whole subtitle, and the snap shortcuts all land the cue the *Beautify time codes* profile's in/out cues gap away from the cut. Dragging snaps when the cue *looks* close (a pixel distance, so it feels the same at any zoom), and the snap distances are now in Options → Settings → Waveform. **Shift** while dragging temporarily disables the snap.
 
 ## Beautify Time Codes
 

--- a/docs/features/whats-new-in-se5.md
+++ b/docs/features/whats-new-in-se5.md
@@ -10,6 +10,9 @@ Subtitle Edit 5 is the Avalonia-based, cross-platform version of Subtitle Edit. 
 - New Flatpak packaging work for Linux.
 - Many new settings, and the settings dialog has a built-in search to quickly find any option.
 - Native pick-folder dialog wherever a folder is needed (was missing in the WinForms 4.x line).
+- **Update check settings** — pick the stable or beta channel, and get a passive notification at startup when a newer build is out.
+- **Proxy settings** — domain, system credentials and a bypass list, used by every download and online engine.
+- **Type-to-search in every combo box**, a default save location setting, and the subtitle file name in dialog title bars.
 
 ## Editing and Grid
 
@@ -20,6 +23,14 @@ Subtitle Edit 5 is the Avalonia-based, cross-platform version of Subtitle Edit. 
 - New **Tools → Change formatting** dialog for adding or removing italic, bold, underline, and other formatting across selected lines.
 - New **Tools → Merge two subtitles** tool that combines two subtitles (or the loaded subtitle's text + translation) into one bilingual subtitle. Output as SubRip (overlapping pairs stacked as line 1 / line 2) or ASSA with two configurable styles (font, color, outline, shadow, top/bottom alignment) and a live preview.
 - **AI assistant for the current line** — ask a local AI model about the selected line or ask it for a change (fix errors, fit reading speed, more formal/casual, or a free-form request), from the text box context menu or the edit-box toolbar. Runs via llama.cpp, Ollama, or any OpenAI-compatible endpoint.
+- **Edit original** — the original/reference column can be edited in place, and its non-matching lines are shown as reference rows in the grid.
+- **Hide tags** — a third grid formatting mode that hides override tags so tag-heavy ASSA lines read as plain text; *show formatting* now shows the text of tag-heavy lines too.
+- **Layout 10** puts the edit box under the waveform, like SE 4 and Aegisub.
+- New **Tools → Remove/replace Unicode characters** (the SE 4 plugin, built in), **Sentence case** in the casing options, and the SE 4 **Minimum gap frame rate calculator**.
+- **Multiple replace** grew up — import/export of selected rule categories, move rules up/down/to top/bottom, select all/none/invert in the preview, the whole rule shown while editing, remembered expanded categories, and a toolbar button.
+- **Merge lines: keep end time** (allow overlap with the next subtitle) as an option, and *Show selected lines earlier/later* in the grid context menu.
+- Auto-break settings under Settings → Tools, with a **do-not-break-after** list editor and a bottom-heavy percentage.
+- Keyboard parity with SE 4: *Go to first/last line* with video sync, *Go to next empty line*, *toggle custom tags*, recalculate duration, Ctrl+Shift+Home/End selection, Shift+Backspace as forward delete, and *Copy/Paste (alternative)* text box shortcuts for clipboard managers.
 
 ## Spell Check
 
@@ -36,10 +47,16 @@ See [Spell Check](spell-check.md) for details.
 - New **Video → OCR burned-in subtitle** tool that extracts hardcoded subtitles from video via OCR (see [Video OCR](video-ocr.md)).
 - Improved reading of subtitles embedded in MP4 files.
 - **PGS position monitor** — the binary/image-based edit window has a BDSup2Sub-style position map for image-based subtitles (`.sup`/`.sub`/BDN): every subtitle's real rectangle on the video canvas, color coded by zone (active picture / letterbox bars), with configurable content aspect ratio, custom bar height, and title-safe margin.
+- New **Video → More → Chapters** editor with Matroska, MP4 and OGM chapter formats (see [Chapters](chapters.md)).
+- **Margin is part of the subtitle area** — the preview subtitle may use the letterbox bars, keeping a translation clear of burned-in forced narrative.
+- **Burn-in** gains Apple VideoToolbox hardware encoders on macOS, `.webm`/`.ts` output, letter spacing, and lists only the encoders and containers the OS and codec actually support.
+- **Matroska track chooser** shows an image-subtitle preview, the number of forced cues, and can export VobSub directly.
+- *Go to sub position and pause* and *Go to video position…* shortcuts, and a toggle-subtitles shortcut for the video player.
 
 ## Sync
 
 - **Visual Sync** now includes a waveform, making it easier to pick precise sync points.
+- **Visual sync** and **Set sync point** show the subtitle on the video, and Visual sync finds or opens a video when only a subtitle is loaded.
 
 ## Waveform and Spectrogram
 
@@ -53,6 +70,7 @@ See [Spell Check](spell-check.md) for details.
 
 - New **Tools → Beautify time codes…** brings the SE 4 beautifier across, but as a live tool: two stacked waveform visualizers (original / beautified) show the result before you accept it, with prev/next navigation, frame and millisecond deltas, and a per-cue reason line (*snapped to shot change* · *min. gap enforced* · *min. duration enforced*, etc.).
 - The full **profile editor** (zones, chaining, connected-subtitle handling, per-cue gap, presets for Netflix and SDI) is available from the tool window and from Options → Settings → Waveform. Profile edits persist into `Settings.json`.
+- **Beautify time codes** is also a batch convert step, so a whole folder can be snapped to shot changes and frames in one run.
 
 ## OCR
 
@@ -64,6 +82,9 @@ Beyond the classic engines, image-to-text now includes AI-based local and online
 - **Show only forced subtitles** — a filter plus a *Forced* column, so only the forced lines are OCR'ed and returned (SE 4 parity).
 - **Histogram-based color isolation** for VobSub/DVD subtitles, making it easier to separate text from borders and background.
 - The spell-check dictionary is auto-selected from the OCR language, and the OCR fix replace lists are applied even when no Hunspell dictionary is installed.
+- **Train nOCR** from SE 4 is back, and nOCR matching is faster thanks to a result cache.
+- **HunyuanOCR 1.5** joins the llama.cpp OCR model list, with install-status dots for engines and models and an engine download/update button in the settings.
+- **Save all images with HTML index** from the OCR window, and CrispEmbed's hardware build can be re-picked after the first install.
 
 See [OCR](ocr.md) and [Video OCR](video-ocr.md) for details.
 
@@ -77,6 +98,8 @@ Speech recognition is no longer limited to classic Whisper workflows. Subtitle E
 - Forced-aligner picker (built-in / Canary CTC / Qwen3 / 12 language-specific wav2vec2 aligners) for word-level timestamps.
 - Per-engine advanced parameters and batch transcription improvements.
 - Automatic language selection for several newer engines.
+- **Voxtral** backend for Crisp ASR, a way to switch VAD off, and an automatic retry without VAD when a clip comes back empty.
+- Batch speech to text can include the language code in the output file names.
 
 See [Speech to Text](speech-to-text.md) for the current engine list and workflow.
 
@@ -90,6 +113,9 @@ Text to speech now includes more local and cloud engines:
 - Kokoro TTS with downloadable local server builds and models.
 - OmniVoice TTS - a local CPU engine (many languages, voice cloning) with downloadable models.
 - Review audio clips, regenerate individual lines, keep regeneration history, and export generated clips with metadata.
+- **IndexTTS 2.5** — a local engine with emotion and speaking-rate control.
+- **Find voices in video and clone them all** — auto-cast every speaker from the video, or clone the voice of a single line from the video.
+- Chatterbox in 23 languages (plus F16 and Q4_K model variants), and the CosyVoice3 RL talker models.
 
 See [Text to Speech](text-to-speech.md) for details.
 
@@ -100,6 +126,8 @@ Subtitle Edit 5 adds local, downloadable auto-translate engines that run entirel
 - **Server-managed llama.cpp** — Subtitle Edit downloads llama.cpp, manages a local `llama-server` process, and offers a curated TranslateGemma model picker, so no manual server setup is required. CPU, Vulkan, and CUDA builds are available, and the server can be started and stopped from the Auto-translate window.
 - **CrispASR MADLAD** — a local MADLAD-based translation engine with downloadable models (shown with size and install status), available in both the Auto-translate window and Batch Convert.
 - **OpenAI Compatible API** — a generic engine for any service exposing an OpenAI-compatible `chat/completions` endpoint (vLLM, KoboldCpp, a llama.cpp server on another machine, cloud providers, ...).
+- **MiLMMT-46** translation models in the llama.cpp engine, and a **llama.cpp advanced** engine with custom prompt, server parameters, a stall watchdog and a token cap.
+- Completion-format prompts for LM Studio, KoboldCpp, Ollama and the other local engines, a reset-to-default button for the prompt, and the chosen languages are kept when the engine changes.
 
 See [Auto-translate](auto-translate.md) for the full engine list and workflow.
 
@@ -110,6 +138,7 @@ See [Auto-translate](auto-translate.md) for the full engine list and workflow.
 - **Review before you apply** — suggestions are listed as before/after pairs with a per-line reason, grouped by category (Spelling, Grammar, Punctuation, Casing, Other) with filter chips. Tick the ones you want and apply only those.
 - **Safe by design** — formatting tags (`<i>`, `{\an8}`, etc.) and line breaks are preserved; suggestions that touch tags are dropped, and large rewrites are flagged for a closer look and left unselected.
 - **Editable prompt** — the instructions sent to the model can be customized (with the subtitle language auto-detected and substituted in).
+- **Play current**, **Select none**, and a **Start/Stop server** button so the local model's VRAM can be released without leaving the window; the server is also stopped when a review is cancelled. AI review is in the grid's *Selected lines* context menu too.
 
 See [AI Review](ai-review.md) for details.
 
@@ -120,6 +149,8 @@ See [AI Review](ai-review.md) for details.
 - **More chainable functions** — including the new *Change formatting* (add/remove italic, bold, underline, etc.) alongside the existing fixes, replacements, casing, time-code, gap, merge, and split operations.
 - **Speech-to-text batch mode** — transcribe many media files at once and save the results next to the source files.
 - **Optimized MKV parsing** — reading subtitle tracks from Matroska (`.mkv`) files is significantly faster, speeding up batch jobs that extract subtitles from many video containers.
+- **Beautify time codes**, **Convert colors to dialog**, **Snap time codes to frames**, and the **CrispEmbed** OCR and **llama.cpp advanced** translate engines as batch steps; the llama.cpp launch flags are yours to set.
+- **Add folder…**, a filtered file count, translation progress, and an option to **keep the source file's date/time** on converted files (also in `seconv`).
 
 See [Batch Convert](batch-convert.md), [OCR](ocr.md), and [Command Line (seconv)](../reference/command-line.md).
 
@@ -128,6 +159,8 @@ See [Batch Convert](batch-convert.md), [OCR](ocr.md), and [Command Line (seconv)
 - New **Apply advanced effects** tool that generates cinematic and creative ASSA override-tag animations (typewriter, karaoke, bounce-in, neon, glitch, rainbow, starfield, rain, snow, fireflies, and more) with real-time video preview.
 - **Hide layer** — individual ASSA layers can now be hidden in the preview to focus on the lines you are working on.
 - **ASSA filtering** — filter and search lines in the ASSA grid by style, actor, layer, or tag content.
+- **Font collector** — shows the fonts a script uses and whether they are available, copies them to a folder, and can embed them in the subtitle with unused glyphs trimmed (see [Styles](assa-styles.md) and [Attachments](assa-attachments.md)).
+- More advanced effects: **Word flip 3D**, **Lower third** and **Cinematic title**.
 
 ## Subtitle Formats
 
@@ -136,6 +169,11 @@ See [Batch Convert](batch-convert.md), [OCR](ocr.md), and [Command Line (seconv)
 - New **IMSC 1.1 image profile** export — a single self-contained TTML file with base64 PNG subtitles (`smpte:image`) for streaming and broadcast image-subtitle delivery, from File → Export and from the image/binary subtitle editor.
 - New **DVD sup (MuxMan/Scenarist)** image-based export — the classic DVD-Video subpicture `.sup` that DVD authoring tools import.
 - New **Import CSV/XLSX with custom columns** window for spreadsheets that don't fit the standard layout — pick which columns map to start, end, text, etc.
+- **Teletext / EBU STL** — an alignment dialog, a *TT* grid column, a teletext color picker with a *No color* option, and the position the file carries is used when previewing on the video (also for TTML and PAC).
+- New exports: **Final Cut Pro XML Captions**, **DaVinci Resolve marker EDL** (import too), **Audacity/Tenacity labels**, **BDN/xml 8-bit** with palette-indexed PNGs, and the **Full frame image** option is back.
+- New imports: Adobe Premiere Pro *Markers* panel CSV, and **XSUB** subtitles inside `.avi` files.
+- **D-Cinema interop** properties dialog, and the option to remove blank lines when opening a subtitle is back from SE 4.
+- Abbreviation lists for 30 more languages.
 
 ## Command Line (seconv)
 
@@ -144,6 +182,7 @@ The `seconv` headless converter now lives in the main Subtitle Edit repository �
 - **Polished terminal UI** — colored output with progress per file, summary tables, and a `--json` mode for CI pipelines and scripting.
 - **Cross-platform** — runs on Windows, Linux, and macOS with only the .NET runtime; no display or GUI required, suitable for servers and Docker.
 - **Broader feature set** — additional time and cleanup operations, OCR engine selection (Tesseract / nOCR / Binary OCR / Ollama / PaddleOCR), container input from `.mkv` / `.mp4` / `.mcc`, `info` and `lint` subcommands for inspection, custom output templates, and POSIX-style flag names (legacy SE 4.x flags still work).
+- `.avi`/XSUB input, rule selection for `--remove-formatting`, and keeping the source file's date/time on output.
 
 See [Command Line (seconv)](../reference/command-line.md) for usage and examples.
 


### PR DESCRIPTION
Two docs updates, same branch.

## 1. Shot-change snapping (4 pages)

The user docs described snapping as it was before today's consolidation (#13985, #13986, #13987, #13988) — and two claims were now simply wrong.

| Page | Said | Now |
|---|---|---|
| `beautify-time-codes.md` | red zones drive the drag snap distance; ends land one frame before the cut | profile *gaps* decide where a cue lands, everywhere; capture distance is a Waveform setting |
| `audio-visualizer.md` | same two claims, in one bullet | a subsection covering all three ways to snap and how each captures |
| `settings.md` | only the on/off toggle listed | the four distance settings now in the UI |
| `whats-new-in-se5.md` | "reads its snap window from the profile's red zones" | describes the consistent behaviour and the pixel distance |

The new `audio-visualizer.md` subsection is the one place that explains dragging vs. the start/end shortcuts vs. *nearest* side by side — worth a read to check it matches the mental model you want. The `#snapping-to-shot-changes` cross-link relies on kramdown's auto heading ids, which the Jekyll site uses.

## 2. "What's new in SE 5" — the beta cycle

The page was written around 5.1.0 and barely touched since. Diffing it against the 103 feature-level changelog entries from beta1–beta21 found **some forty user-facing additions missing**, among them the chapter editor, IndexTTS 2.5, find-and-clone-all-voices, Voxtral, MiLMMT-46, HunyuanOCR, Teletext alignment, the font collector, Edit original, Hide tags, Layout 10, the update channel and proxy settings, Final Cut / DaVinci / Audacity exports, and the AI review server button.

They're folded into the existing sections in the page's own voice — a curated overview by area, not a changelog. Fixes, translations and internals are deliberately left out. Every bullet traces to a changelog line; the one inference (what the font collector does) was checked against `assa-styles.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
