### PR TITLE
Use the selected audio track in the sync windows

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -10513,7 +10513,7 @@ public partial class MainViewModel :
         {
             var selectedItems = SubtitleGridSelectedItems.Cast<SubtitleLineViewModel>().ToList();
             var paragraphs = Subtitles.Select(p => new SubtitleLineViewModel(p)).ToList();
-            vm.Initialize(paragraphs, selectedItems, _videoFileName ?? string.Empty, _subtitleFileName ?? string.Empty, MakeVideoPreviewSubtitleContext(), AudioVisualizer);
+            vm.Initialize(paragraphs, selectedItems, _videoFileName ?? string.Empty, _subtitleFileName ?? string.Empty, MakeVideoPreviewSubtitleContext(), AudioVisualizer, _audioTrack?.Id ?? -1);
         });
 
         if (result.OkPressed)
@@ -10547,7 +10547,7 @@ public partial class MainViewModel :
         var result = await ShowDialogAsync<PointSyncViaOtherWindow, PointSyncViaOtherViewModel>(vm =>
         {
             var paragraphs = Subtitles.Select(p => new SubtitleLineViewModel(p)).ToList();
-            vm.Initialize(paragraphs, _videoFileName ?? string.Empty, _subtitleFileName ?? string.Empty, MakeVideoPreviewSubtitleContext());
+            vm.Initialize(paragraphs, _videoFileName ?? string.Empty, _subtitleFileName ?? string.Empty, MakeVideoPreviewSubtitleContext(), _audioTrack?.Id ?? -1);
         });
 
         if (result.OkPressed)

--- a/src/ui/Features/Sync/PointSync/PointSyncViewModel.cs
+++ b/src/ui/Features/Sync/PointSync/PointSyncViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -45,6 +45,9 @@ public partial class PointSyncViewModel : ObservableObject
     private string _videoFileName;
     private AudioVisualizer? _audioVisualizer;
 
+    // Carried down to the "Set sync point" dialog, which opens its own player (issue #13995).
+    private int _audioTrackId = -1;
+
     // Only passed on to "Set sync point", which draws the subtitle on its video (#13767).
     private VideoPreviewSubtitleContext _previewContext = VideoPreviewSubtitleContext.Default;
 
@@ -67,8 +70,10 @@ public partial class PointSyncViewModel : ObservableObject
         string videoFileName,
         string fileName,
         VideoPreviewSubtitleContext previewContext,
-        AudioVisualizer? audioVisualizer)
+        AudioVisualizer? audioVisualizer,
+        int audioTrackId = -1)
     {
+        _audioTrackId = audioTrackId;
         Subtitles.Clear();
         Subtitles.AddRange(subtitles);
         FileName = fileName;
@@ -98,7 +103,7 @@ public partial class PointSyncViewModel : ObservableObject
 
         var result = await _windowService.ShowDialogAsync<SetSyncPointWindow, SetSyncPointViewModel>(Window, vm =>
         {
-            vm.Initialize(Subtitles.ToList(), SelectedSubtitle, _videoFileName, FileName, _previewContext, _audioVisualizer);
+            vm.Initialize(Subtitles.ToList(), SelectedSubtitle, _videoFileName, FileName, _previewContext, _audioVisualizer, _audioTrackId);
         });
 
         // Keep a video opened (or found) in there, so the next sync point starts with it loaded -

--- a/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointViewModel.cs
+++ b/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
@@ -14,6 +14,7 @@ using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
 using Nikse.SubtitleEdit.Logic.VideoPlayers;
+using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -62,6 +63,11 @@ public partial class SetSyncPointViewModel : ObservableObject
     private readonly IVideoPreviewSubtitle _previewSubtitle;
 
     private string? _videoFileName;
+
+    // The audio track picked in the main window's Video > Audio tracks. A brand new mpv instance
+    // starts on the file's default track, so it has to be re-applied here or a dubbed track plays
+    // while the user syncs against the original (issue #13995).
+    private int _audioTrackId = -1;
     private DispatcherTimer _positionTimer = new DispatcherTimer();
     private List<SubtitleLineViewModel> _subtitleLines = new List<SubtitleLineViewModel>();
     private VideoPreviewSubtitleContext _previewContext = VideoPreviewSubtitleContext.Default;
@@ -95,8 +101,10 @@ public partial class SetSyncPointViewModel : ObservableObject
         string? videoFileName,
         string? subtitleFileName,
         VideoPreviewSubtitleContext previewContext,
-        AudioVisualizer? audioVisualizer)
+        AudioVisualizer? audioVisualizer,
+        int audioTrackId = -1)
     {
+        _audioTrackId = audioTrackId;
         Paragraphs = new ObservableCollection<SubtitleDisplayItem>(paragraphs.Select(p => new SubtitleDisplayItem(p)));
         _subtitleLines = paragraphs;
 
@@ -138,7 +146,7 @@ public partial class SetSyncPointViewModel : ObservableObject
         {
             if (!string.IsNullOrEmpty(_videoFileName))
             {
-                _ = VideoPlayerControl.Open(_videoFileName);
+                _ = OpenPlayerAsync(_videoFileName);
             }
 
             // An audio visualizer without peaks is just an empty box - only show it when the main
@@ -368,6 +376,25 @@ public partial class SetSyncPointViewModel : ObservableObject
         _updateAudioVisualizer = true;
     }
 
+    /// <summary>
+    /// Opens the preview player and, once the video is loaded, applies the audio track the user
+    /// selected in the main window - the same thing Visual Sync does (issue #11952). Setting it
+    /// before the file is open is silently ignored, so the await matters.
+    /// </summary>
+    private async Task OpenPlayerAsync(string videoFileName, double startPositionSeconds = 0)
+    {
+        await VideoPlayerControl.Open(videoFileName, startPositionSeconds);
+        ApplySelectedAudioTrack();
+    }
+
+    private void ApplySelectedAudioTrack()
+    {
+        if (_audioTrackId > 0 && VideoPlayerControl.VideoPlayer is LibMpvDynamicPlayer mpv)
+        {
+            mpv.SetAudioTrack(_audioTrackId);
+        }
+    }
+
     private void CenterWaveform(VideoPlayerControl videoPlayerControl, AudioVisualizer audioVisualizer)
     {
         audioVisualizer.StartPositionSeconds = Math.Max(0, videoPlayerControl.Position - 0.5);
@@ -399,7 +426,7 @@ public partial class SetSyncPointViewModel : ObservableObject
         // the start of the newly opened file. It has to be passed to Open: the position slider is
         // clamped to Duration, which is only polled once the player is running, so seeking right
         // after the open would land at zero.
-        await VideoPlayerControl.Open(fileName, Math.Max(0, syncPoint.TotalSeconds));
+        await OpenPlayerAsync(fileName, Math.Max(0, syncPoint.TotalSeconds));
         await VideoPlayerControl.WaitForPlayersReadyAsync();
 
         // The external subtitle went with the old file (if there was one) - it has to be added to

--- a/src/ui/Features/Sync/PointSyncViaOther/PointSyncViaOtherViewModel.cs
+++ b/src/ui/Features/Sync/PointSyncViaOther/PointSyncViaOtherViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -50,6 +50,9 @@ public partial class PointSyncViaOtherViewModel : ObservableObject
     private readonly IFileHelper _fileHelper;
     private readonly IWindowService _windowService;
 
+    // Carried down to the "Set sync point" dialog, which opens its own player (issue #13995).
+    private int _audioTrackId = -1;
+
     private string _videoFileName;
     private List<SubtitleLineViewModel> _originalSubtitles;
 
@@ -71,8 +74,9 @@ public partial class PointSyncViaOtherViewModel : ObservableObject
         _originalSubtitles = new List<SubtitleLineViewModel>();
     }
 
-    public void Initialize(List<SubtitleLineViewModel> subtitles, string videoFileName, string fileName, VideoPreviewSubtitleContext previewContext)
+    public void Initialize(List<SubtitleLineViewModel> subtitles, string videoFileName, string fileName, VideoPreviewSubtitleContext previewContext, int audioTrackId = -1)
     {
+        _audioTrackId = audioTrackId;
         Subtitles.Clear();
         Subtitles.AddRange(subtitles);
         _originalSubtitles = subtitles.Select(s => new SubtitleLineViewModel(s)).ToList();
@@ -231,7 +235,7 @@ public partial class PointSyncViaOtherViewModel : ObservableObject
 
         var result = await _windowService.ShowDialogAsync<SetSyncPointWindow, SetSyncPointViewModel>(Window, vm =>
         {
-            vm.Initialize(Subtitles.ToList(), left, _videoFileName, FileName, _previewContext, null);
+            vm.Initialize(Subtitles.ToList(), left, _videoFileName, FileName, _previewContext, null, _audioTrackId);
         });
 
         // Keep a video opened (or found) in there - also when the dialog was cancelled.

--- a/tests/UI/Features/Sync/PointSync/SyncAudioTrackPlumbingTests.cs
+++ b/tests/UI/Features/Sync/PointSync/SyncAudioTrackPlumbingTests.cs
@@ -1,0 +1,101 @@
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Sync.PointSync;
+using Nikse.SubtitleEdit.Features.Sync.PointSync.SetSyncPoint;
+using Nikse.SubtitleEdit.Features.Sync.PointSyncViaOther;
+using Nikse.SubtitleEdit.Features.Sync.VisualSync;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Media;
+using System.Reflection;
+
+namespace UITests.Features.Sync.PointSync;
+
+/// <summary>
+/// Every sync window opens its own mpv instance, and a new instance starts on the file's default
+/// audio track - so the track picked in the main window's Video > Audio tracks has to be carried in
+/// and re-applied, or a dubbed track plays while the user syncs against the original.
+///
+/// Visual Sync learned this in #11952; Point sync, Point sync via other subtitle and the Set sync
+/// point dialog they both open did not, which is issue #13995. These tests pin the plumbing: the
+/// track has to survive every hop from the main window down to the window that owns the player.
+/// Whether mpv then honours it is covered by the same await-then-set order Visual Sync uses.
+/// </summary>
+public class SyncAudioTrackPlumbingTests
+{
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private static SetSyncPointViewModel MakeSetSyncPointViewModel()
+        => new(new WindowService(new NullServiceProvider()), new FileHelper(), new VideoPreviewSubtitle(new MpvReloader(), new VlcReloader()));
+
+    private static List<SubtitleLineViewModel> OneLine()
+        => new() { new() { Text = "one", StartTime = TimeSpan.FromSeconds(1), EndTime = TimeSpan.FromSeconds(2) } };
+
+    private static int AudioTrackIdOf(object viewModel) =>
+        (int)viewModel.GetType()
+            .GetField("_audioTrackId", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(viewModel)!;
+
+    private static ParameterInfo AudioTrackParameterOf(Type type)
+    {
+        var initialize = type.GetMethods()
+            .Single(m => m.Name == "Initialize" && m.GetParameters().Any(p => p.Name == "audioTrackId"));
+        return initialize.GetParameters().Single(p => p.Name == "audioTrackId");
+    }
+
+    [Theory]
+    [InlineData(typeof(SetSyncPointViewModel))]
+    [InlineData(typeof(PointSyncViewModel))]
+    [InlineData(typeof(PointSyncViaOtherViewModel))]
+    [InlineData(typeof(VisualSyncViewModel))]
+    public void EverySyncWindow_TakesAnAudioTrack(Type viewModelType)
+    {
+        var parameter = AudioTrackParameterOf(viewModelType);
+
+        Assert.Equal(typeof(int), parameter.ParameterType);
+    }
+
+    // Optional and defaulting to -1 ("no track picked"), so the existing callers that have no
+    // track - and the tests that construct these view models directly - keep compiling and mean
+    // "leave mpv on the file's default".
+    [Theory]
+    [InlineData(typeof(SetSyncPointViewModel))]
+    [InlineData(typeof(PointSyncViewModel))]
+    [InlineData(typeof(PointSyncViaOtherViewModel))]
+    [InlineData(typeof(VisualSyncViewModel))]
+    public void TheAudioTrackParameter_IsOptionalAndDefaultsToNoTrack(Type viewModelType)
+    {
+        var parameter = AudioTrackParameterOf(viewModelType);
+
+        Assert.True(parameter.IsOptional);
+        Assert.Equal(-1, parameter.DefaultValue);
+    }
+
+    // The dialog that actually owns the player: the id has to reach its field, not just its
+    // signature.
+    [AvaloniaFact]
+    public void SetSyncPoint_KeepsTheAudioTrackItWasGiven()
+    {
+        var lines = OneLine();
+        var vm = MakeSetSyncPointViewModel();
+
+        vm.Initialize(lines, lines[0], videoFileName: null, subtitleFileName: null,
+            previewContext: VideoPreviewSubtitleContext.Default, audioVisualizer: null, audioTrackId: 3);
+
+        Assert.Equal(3, AudioTrackIdOf(vm));
+    }
+
+    [AvaloniaFact]
+    public void SetSyncPoint_WithoutATrack_MeansTheFilesDefault()
+    {
+        var lines = OneLine();
+        var vm = MakeSetSyncPointViewModel();
+
+        vm.Initialize(lines, lines[0], videoFileName: null, subtitleFileName: null,
+            previewContext: VideoPreviewSubtitleContext.Default, audioVisualizer: null);
+
+        Assert.Equal(-1, AudioTrackIdOf(vm));
+    }
+}


### PR DESCRIPTION
Fixes #13995

Point sync, Point sync via other subtitle, and the **Set sync point** dialog they both open each create their own mpv instance — and a new instance starts on the file's *default* audio track. So a user who deliberately picked the original track in **Video → Audio tracks**, precisely so they could sync against it rather than against a dub, got the dubbed track back the moment they opened a sync window.

## There was already a fix for this — in one window

Visual Sync hit the identical bug in #11952 and solved it like this:

```csharp
// Opens both preview players and, once each video is loaded, applies the audio track the user
// selected in the main window. Without this Visual Sync always played the default track (#11952).
private async Task OpenPlayersAsync(string videoFileName, int audioTrackId)
{
    await Task.WhenAll(VideoPlayerControlLeft.Open(...), VideoPlayerControlRight.Open(...));
    ...SetAudioTrack(audioTrackId);
}
```

The other three windows never got the same treatment. This PR applies that exact shape to them, so the reporter's "please make it so **any** sync function uses the selected audio track" holds.

## The change

`SetSyncPointViewModel` — the one that actually owns the player — gains an `OpenPlayerAsync` that awaits the open and then applies the track. The id is plumbed down the chain: main window → point sync / point sync via other → set sync point. **The await matters**: setting a track before the file is open is silently ignored, which is the trap the Visual Sync comment and the fullscreen player's ready-callback (#12844) both warn about.

The **Open video file…** button inside the dialog routes through the same helper, so a video picked there gets the track too.

The new parameter is optional and defaults to `-1` — "no track picked, leave mpv on the file's default" — matching Visual Sync, so existing callers and tests are unaffected.

## Testing

10 new tests pinning the plumbing across all four sync view models: each takes an `audioTrackId`, each defaults it to `-1`, and the id actually reaches the field of the dialog that owns the player.

Full UI suite: **3411 passed, 0 failed**.

I could not verify end-to-end that mpv then plays the chosen track — that needs a multi-track video in the GUI. The await-then-set order is copied verbatim from the Visual Sync fix that is known to work, so the risk is in the plumbing, which is what the tests cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
