### PR TITLE
Keep the minimum gap when nudging a cue one frame

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -12647,6 +12647,28 @@ public partial class MainViewModel :
             }
         }
 
+        // Moving the start back must not run into the previous line (issue #13999). SE 4 clamped
+        // to "previous end + minimum gap" here; SE 5 checked only this line's own end, so repeated
+        // presses walked straight through the neighbour. The KeepGapPrev variant is exempt: it
+        // carries the previous line along, so there is nothing to run into. "Allow overlap (when
+        // moving/resizing)" is the user saying they want to - the waveform drag reads it the same
+        // way.
+        if (deltaMs < 0 && !prevIsClose && prev != null && !Se.Settings.Waveform.AllowOverlap)
+        {
+            var floorMs = prev.EndTime.TotalMilliseconds + gapMs;
+            if (newStartMs < floorMs)
+            {
+                // Already overlapping before this press (a nudge cannot be asked to repair that):
+                // leave it alone rather than jumping the cue forward to the gap.
+                if (s.StartTime.TotalMilliseconds <= floorMs)
+                {
+                    return;
+                }
+
+                newStartMs = floorMs;
+            }
+        }
+
         s.SetStartTimeOnly(TimeSpan.FromMilliseconds(newStartMs));
 
         if (prevIsClose && prev != null)
@@ -12696,6 +12718,22 @@ public partial class MainViewModel :
                 && (next.EndTime.TotalMilliseconds - next.StartTime.TotalMilliseconds) - deltaMs < minDurMs)
             {
                 return;
+            }
+        }
+
+        // Symmetric counterpart of the clamp in MoveStartByFrames (issue #13999): moving the end
+        // forward must not run into the next line.
+        if (deltaMs > 0 && !nextIsClose && next != null && !Se.Settings.Waveform.AllowOverlap)
+        {
+            var ceilingMs = next.StartTime.TotalMilliseconds - gapMs;
+            if (newEndMs > ceilingMs)
+            {
+                if (s.EndTime.TotalMilliseconds >= ceilingMs)
+                {
+                    return;
+                }
+
+                newEndMs = ceilingMs;
             }
         }
 

--- a/tests/UI/Features/Main/FrameNudgeGapTests.cs
+++ b/tests/UI/Features/Main/FrameNudgeGapTests.cs
@@ -24,14 +24,26 @@ namespace UITests.Features.Main;
 /// </summary>
 public class FrameNudgeGapTests : IDisposable
 {
+    private const int GapMs = 24;
+    private const double Fps = 25;
+    private const double OneFrameMs = 1000.0 / Fps;
+
     private readonly List<Window> _windows = new();
     private readonly bool _allowOverlap = Se.Settings.Waveform.AllowOverlap;
     private readonly double _frameRate = Se.Settings.General.CurrentFrameRate;
+    private readonly double _coreFrameRate = Configuration.Settings.General.CurrentFrameRate;
+    private readonly bool _useFrameMode = Se.Settings.General.UseFrameMode;
+    private readonly int _minBetweenMs = Se.Settings.General.MinimumBetweenLines.Milliseconds;
+    private readonly int _minBetweenFrames = Se.Settings.General.MinimumBetweenLines.Frames;
 
     public void Dispose()
     {
         Se.Settings.Waveform.AllowOverlap = _allowOverlap;
         Se.Settings.General.CurrentFrameRate = _frameRate;
+        Configuration.Settings.General.CurrentFrameRate = _coreFrameRate;
+        Se.Settings.General.UseFrameMode = _useFrameMode;
+        Se.Settings.General.MinimumBetweenLines.Milliseconds = _minBetweenMs;
+        Se.Settings.General.MinimumBetweenLines.Frames = _minBetweenFrames;
         foreach (var w in _windows)
         {
             w.Close();
@@ -61,8 +73,16 @@ public class FrameNudgeGapTests : IDisposable
     /// <summary>Two lines, the second starting <paramref name="gapMs"/> after the first ends.</summary>
     private (Window Window, MainViewModel Vm) TwoLines(int gapMs, bool allowOverlap = false)
     {
+        // Everything the clamp reads is pinned here. The minimum gap comes from
+        // MinimumBetweenLines *and* UseFrameMode, and the frame rate has two independent homes
+        // (Se.Settings and the libse Configuration) - leaving any of them to whatever another test
+        // in the run happened to set makes this test order-dependent, which is how it passed
+        // locally and failed on CI.
         Se.Settings.Waveform.AllowOverlap = allowOverlap;
-        Se.Settings.General.CurrentFrameRate = 25; // one frame = 40 ms
+        Se.Settings.General.CurrentFrameRate = Fps; // one frame = 40 ms
+        Configuration.Settings.General.CurrentFrameRate = Fps;
+        Se.Settings.General.UseFrameMode = false;
+        Se.Settings.General.MinimumBetweenLines.Milliseconds = GapMs;
 
         var (window, vm) = CreateMainViewModel();
         vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph("one", 1000, 3000), null!) { Number = 1 });
@@ -72,6 +92,7 @@ public class FrameNudgeGapTests : IDisposable
     }
 
     private static double MinGapMs => Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
+
 
     [AvaloniaFact]
     public void MoveStartBack_StopsAtTheMinimumGap()
@@ -88,7 +109,8 @@ public class FrameNudgeGapTests : IDisposable
 
         Assert.True(vm.Subtitles[1].StartTime.TotalMilliseconds >= floor - 0.001,
             $"start {vm.Subtitles[1].StartTime.TotalMilliseconds} went past the floor {floor}");
-        Assert.True(vm.Subtitles[1].StartTime.TotalMilliseconds > vm.Subtitles[0].EndTime.TotalMilliseconds);
+        Assert.True(vm.Subtitles[1].StartTime.TotalMilliseconds >= vm.Subtitles[0].EndTime.TotalMilliseconds,
+            "the nudged start overlapped the previous line");
         window.Close();
     }
 
@@ -107,7 +129,8 @@ public class FrameNudgeGapTests : IDisposable
 
         Assert.True(vm.Subtitles[0].EndTime.TotalMilliseconds <= ceiling + 0.001,
             $"end {vm.Subtitles[0].EndTime.TotalMilliseconds} went past the ceiling {ceiling}");
-        Assert.True(vm.Subtitles[0].EndTime.TotalMilliseconds < vm.Subtitles[1].StartTime.TotalMilliseconds);
+        Assert.True(vm.Subtitles[0].EndTime.TotalMilliseconds <= vm.Subtitles[1].StartTime.TotalMilliseconds,
+            "the nudged end overlapped the next line");
         window.Close();
     }
 
@@ -123,7 +146,7 @@ public class FrameNudgeGapTests : IDisposable
         var before = vm.Subtitles[1].StartTime.TotalMilliseconds;
         vm.MoveStartOneFrameBackCommand.Execute(null);
 
-        Assert.Equal(before - 40, vm.Subtitles[1].StartTime.TotalMilliseconds, 3);
+        Assert.Equal(before - OneFrameMs, vm.Subtitles[1].StartTime.TotalMilliseconds, 3);
         window.Close();
     }
 

--- a/tests/UI/Features/Main/FrameNudgeGapTests.cs
+++ b/tests/UI/Features/Main/FrameNudgeGapTests.cs
@@ -1,0 +1,162 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Collections.Generic;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// "Move start/end one frame back/forward" and the minimum gap (issue #13999).
+///
+/// SE 4's MoveStartCurrent clamped a backwards nudge to "previous end + minimum gap"; the SE 5 port
+/// checked only the nudged line's own end, so repeated presses walked the cue straight through its
+/// neighbour and produced overlaps even with "Allow overlap (when moving/resizing)" off.
+///
+/// The KeepGapPrev / KeepGapNext variants are deliberately exempt - they carry the neighbour along,
+/// so there is nothing to run into.
+/// </summary>
+public class FrameNudgeGapTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+    private readonly bool _allowOverlap = Se.Settings.Waveform.AllowOverlap;
+    private readonly double _frameRate = Se.Settings.General.CurrentFrameRate;
+
+    public void Dispose()
+    {
+        Se.Settings.Waveform.AllowOverlap = _allowOverlap;
+        Se.Settings.General.CurrentFrameRate = _frameRate;
+        foreach (var w in _windows)
+        {
+            w.Close();
+        }
+    }
+
+    private (Window Window, MainViewModel Vm) CreateMainViewModel()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1400, Height = 900 };
+        _windows.Add(window);
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var vm = (MainViewModel)view.DataContext!;
+        window.SuppressSaveChangesPromptOnClose(vm);
+        return (window, vm);
+    }
+
+    /// <summary>Two lines, the second starting <paramref name="gapMs"/> after the first ends.</summary>
+    private (Window Window, MainViewModel Vm) TwoLines(int gapMs, bool allowOverlap = false)
+    {
+        Se.Settings.Waveform.AllowOverlap = allowOverlap;
+        Se.Settings.General.CurrentFrameRate = 25; // one frame = 40 ms
+
+        var (window, vm) = CreateMainViewModel();
+        vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph("one", 1000, 3000), null!) { Number = 1 });
+        vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph("two", 3000 + gapMs, 6000), null!) { Number = 2 });
+        Dispatcher.UIThread.RunJobs();
+        return (window, vm);
+    }
+
+    private static double MinGapMs => Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
+
+    [AvaloniaFact]
+    public void MoveStartBack_StopsAtTheMinimumGap()
+    {
+        var (window, vm) = TwoLines(gapMs: 1000);
+        vm.SelectedSubtitle = vm.Subtitles[1];
+        Dispatcher.UIThread.RunJobs();
+
+        var floor = vm.Subtitles[0].EndTime.TotalMilliseconds + MinGapMs;
+        for (var i = 0; i < 60; i++) // far more presses than the 1000 ms gap allows
+        {
+            vm.MoveStartOneFrameBackCommand.Execute(null);
+        }
+
+        Assert.True(vm.Subtitles[1].StartTime.TotalMilliseconds >= floor - 0.001,
+            $"start {vm.Subtitles[1].StartTime.TotalMilliseconds} went past the floor {floor}");
+        Assert.True(vm.Subtitles[1].StartTime.TotalMilliseconds > vm.Subtitles[0].EndTime.TotalMilliseconds);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void MoveEndForward_StopsAtTheMinimumGap()
+    {
+        var (window, vm) = TwoLines(gapMs: 1000);
+        vm.SelectedSubtitle = vm.Subtitles[0];
+        Dispatcher.UIThread.RunJobs();
+
+        var ceiling = vm.Subtitles[1].StartTime.TotalMilliseconds - MinGapMs;
+        for (var i = 0; i < 60; i++)
+        {
+            vm.MoveEndOneFrameForwardCommand.Execute(null);
+        }
+
+        Assert.True(vm.Subtitles[0].EndTime.TotalMilliseconds <= ceiling + 0.001,
+            $"end {vm.Subtitles[0].EndTime.TotalMilliseconds} went past the ceiling {ceiling}");
+        Assert.True(vm.Subtitles[0].EndTime.TotalMilliseconds < vm.Subtitles[1].StartTime.TotalMilliseconds);
+        window.Close();
+    }
+
+    // A single press well clear of the neighbour must still move a whole frame - the clamp must not
+    // quietly round every nudge to the gap.
+    [AvaloniaFact]
+    public void MoveStartBack_AwayFromTheNeighbour_MovesAFullFrame()
+    {
+        var (window, vm) = TwoLines(gapMs: 1000);
+        vm.SelectedSubtitle = vm.Subtitles[1];
+        Dispatcher.UIThread.RunJobs();
+
+        var before = vm.Subtitles[1].StartTime.TotalMilliseconds;
+        vm.MoveStartOneFrameBackCommand.Execute(null);
+
+        Assert.Equal(before - 40, vm.Subtitles[1].StartTime.TotalMilliseconds, 3);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void MoveStartBack_WithAllowOverlapOn_IsNotClamped()
+    {
+        var (window, vm) = TwoLines(gapMs: 1000, allowOverlap: true);
+        vm.SelectedSubtitle = vm.Subtitles[1];
+        Dispatcher.UIThread.RunJobs();
+
+        for (var i = 0; i < 60; i++)
+        {
+            vm.MoveStartOneFrameBackCommand.Execute(null);
+        }
+
+        // The user asked for overlap, so the cue is free to cross the previous line's end.
+        Assert.True(vm.Subtitles[1].StartTime.TotalMilliseconds < vm.Subtitles[0].EndTime.TotalMilliseconds);
+        window.Close();
+    }
+
+    // Lines that already overlap are left alone: a one-frame nudge is not a repair tool, and
+    // jumping the cue forward to the gap would be a surprise.
+    [AvaloniaFact]
+    public void MoveStartBack_WhenAlreadyOverlapping_DoesNothing()
+    {
+        var (window, vm) = TwoLines(gapMs: -500);
+        vm.SelectedSubtitle = vm.Subtitles[1];
+        Dispatcher.UIThread.RunJobs();
+
+        var before = vm.Subtitles[1].StartTime.TotalMilliseconds;
+        vm.MoveStartOneFrameBackCommand.Execute(null);
+
+        Assert.Equal(before, vm.Subtitles[1].StartTime.TotalMilliseconds, 3);
+        window.Close();
+    }
+}


### PR DESCRIPTION
Fixes #13999

The reporter's two screenshots say it precisely: **Allow overlap (when moving/resizing)** is unchecked, yet *Move start one frame back* and *Move end one frame forward* still produce overlaps. They asked "they should respect the gap, right?" — and SE 4 says yes.

## What was wrong

`MoveStartByFrames` guarded only against the nudged line's **own end time**, so the duration could not collapse — but it never looked at the previous line. Repeated presses walked the cue straight through its neighbour. `MoveEndByFrames` had the mirror-image gap.

SE 4's `MoveStartCurrent` clamped:

```csharp
if (prev == null || keepGapPrevIfClose && isClose || p.StartTime - (Math.Abs(ms) + MinGapBetweenLines) > prev.EndTime)
{
    p.StartTime += ms;
}
else
{
    var newStartMs = prev.EndTime + MinGapBetweenLines;   // stop at the gap
    if (newStartMs < p.StartTime) p.StartTime = newStartMs;
}
```

So this is a regression in the SE 5 port, not a design choice — which matters, because SE 5 *does* have four deliberate `KeepGapPrev`/`KeepGapNext` variants and it would be easy to read the plain ones as intentionally unconstrained. They aren't: KeepGap is about *carrying the neighbour along*, not about preventing overlap.

## The change

The clamp is restored on both helpers, with three deliberate exemptions:

- **the KeepGap variants** — they move the neighbour too, so there is nothing to run into;
- **Allow overlap (when moving/resizing)** — the user explicitly asking for overlap; the waveform drag already reads this setting the same way. SE 4 had no such setting, so with it off the behaviour now matches SE 4 exactly, and with it on the user gets what they asked for;
- **lines that already overlap before the press** — a one-frame nudge is not a repair tool, and snapping the cue *forward* to the gap would be a surprise. It leaves them alone.

## Testing

5 new tests: the clamp holds after 60 presses at both ends, a single press well clear of the neighbour still moves a full frame (the clamp must not quietly round every nudge), allow-overlap-on is not clamped, and an already-overlapping pair is untouched.

Verified they bite: with the clamp removed, 3 of the 5 fail and the two control tests still pass.

Full UI suite: **3406 passed, 0 failed**.

## Not included

The reporter suspects "maybe others too — I didn't check". They may well be right; SE 4's `MoveStartCurrent` also carried a max-duration guard and a shot-change snap on the nudge that SE 5 has no equivalent for. I have not swept the other timing shortcuts — worth a separate pass if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
