### PR TITLE
Burn-in: use display dimensions for rotated video

### DIFF
--- a/src/libuilogic/Media/FfmpegMediaInfo.cs
+++ b/src/libuilogic/Media/FfmpegMediaInfo.cs
@@ -39,6 +39,13 @@ namespace Nikse.SubtitleEdit.UiLogic.Media
         private static partial Regex StreamIndexRegexGen();
         private static readonly Regex StreamIndexRegex = StreamIndexRegexGen();
 
+        // Rotation side data ffmpeg prints under a video stream, e.g.
+        //   "    Side data:"
+        //   "      Display Matrix: rotation of -90.00 degrees".
+        [GeneratedRegex(@"^Display Matrix: rotation of (?<deg>-?\d+(?:\.\d+)?) degrees")]
+        private static partial Regex DisplayMatrixRotationRegexGen();
+        private static readonly Regex DisplayMatrixRotationRegex = DisplayMatrixRotationRegexGen();
+
         private FfmpegMediaInfo()
         {
             Tracks = new List<FfmpegTrackInfo>();
@@ -123,11 +130,22 @@ namespace Nikse.SubtitleEdit.UiLogic.Media
                 }
             }
 
+            // ffmpeg reports the STORED frame size on the "Stream #" line, which for phone
+            // recordings is often landscape with a "Display Matrix: rotation of -90 degrees"
+            // side-data entry that makes it portrait on playback. ffmpeg auto-rotates on
+            // decode, so the frames every filter and encoder sees are the rotated ones.
+            // Report those display dimensions here, otherwise callers such as burn-in size
+            // the output to the unrotated frame and the picture comes out stretched.
+            var inDimensionStreamBlock = false;
+            var rotationApplied = false;
+
             foreach (var line in log.SplitToLines())
             {
                 var s = line.Trim();
                 if (s.StartsWith("Stream #", StringComparison.Ordinal))
                 {
+                    inDimensionStreamBlock = false;
+
                     var resolutionMatch = ResolutionRegex.Match(s);
                     if (resolutionMatch.Success)
                     {
@@ -137,7 +155,8 @@ namespace Nikse.SubtitleEdit.UiLogic.Media
                             int.TryParse(parts[0], out var w) &&
                             int.TryParse(parts[1], out var h))
                         {
-                            info.Dimension = new Dimension(w, h); 
+                            info.Dimension = new Dimension(w, h);
+                            inDimensionStreamBlock = true;
                         }
                     }
 
@@ -167,6 +186,22 @@ namespace Nikse.SubtitleEdit.UiLogic.Media
                         else
                         {
                             info.Tracks.Add(new FfmpegTrackInfo { TrackType = FfmpegTrackType.Other, TrackInfo = trackInfo, StreamIndex = streamIndex });
+                        }
+                    }
+                }
+                else if (inDimensionStreamBlock && !rotationApplied)
+                {
+                    var rotationMatch = DisplayMatrixRotationRegex.Match(s);
+                    if (rotationMatch.Success &&
+                        double.TryParse(rotationMatch.Groups["deg"].Value, NumberStyles.Any, CultureInfo.InvariantCulture, out var degrees))
+                    {
+                        // Guard against a duplicated retry log swapping a second time.
+                        rotationApplied = true;
+
+                        var normalized = ((degrees % 360) + 360) % 360;
+                        if (Math.Abs(normalized - 90) < 1 || Math.Abs(normalized - 270) < 1)
+                        {
+                            info.Dimension = new Dimension(info.Dimension.Height, info.Dimension.Width);
                         }
                     }
                 }

--- a/src/ui/Features/Video/BurnIn/BurnInWindow.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInWindow.cs
@@ -576,8 +576,10 @@ public class BurnInWindow : Window
     private static Border MakeVideoSettingsView(BurnInViewModel vm)
     {
         var labelResolution = UiUtil.MakeLabel(Se.Language.General.Resolution);
+        var labelWidth = UiUtil.MakeLabel("W");
         var textBoxWidth = UiUtil.MakeNumericUpDownInt(0, 10_000, 0, 130, vm, nameof(vm.VideoWidth));
         var labelX = UiUtil.MakeLabel("x");
+        var labelHeight = UiUtil.MakeLabel("H");
         var textBoxHeight = UiUtil.MakeNumericUpDownInt(0, 10_000, 0, 130, vm, nameof(vm.VideoHeight));
         var buttonResolution = UiUtil.MakeButtonBrowse(vm.BrowseResolutionCommand, accessibleName: Se.Language.General.Resolution);
         var panelResolution = new StackPanel
@@ -586,8 +588,10 @@ public class BurnInWindow : Window
             Spacing = 5,
             Children =
             {
+                labelWidth,
                 textBoxWidth,
                 labelX,
+                labelHeight,
                 textBoxHeight,
                 buttonResolution,
             }

--- a/src/ui/Logic/Media/FfmpegMediainfo2.cs
+++ b/src/ui/Logic/Media/FfmpegMediainfo2.cs
@@ -28,6 +28,10 @@ public class FfmpegMediaInfo2
     //   "Stream #0:2(eng): Subtitle: ..."   or   "Stream #0:2[0x3](eng): ...".
     // Captures the 2-3 letter ISO code in group "lang".
     private static readonly Regex StreamLanguageRegex = new Regex(@"^Stream #\d+:\d+(?:\[[^\]]+\])?\((?<lang>[a-zA-Z]{2,3})\)", RegexOptions.Compiled);
+    // Rotation side data ffmpeg prints under a video stream, e.g.
+    //   "    Side data:"
+    //   "      Display Matrix: rotation of -90.00 degrees".
+    private static readonly Regex DisplayMatrixRotationRegex = new Regex(@"^Display Matrix: rotation of (?<deg>-?\d+(?:\.\d+)?) degrees", RegexOptions.Compiled);
 
     private FfmpegMediaInfo2()
     {
@@ -105,11 +109,23 @@ public class FfmpegMediaInfo2
         // the MP4 embedded-subtitles window) would show duplicate tracks.
         var seenStreamPrefixes = new HashSet<string>(StringComparer.Ordinal);
 
+        // ffmpeg reports the STORED frame size on the "Stream #" line, which for phone
+        // recordings is often landscape with a "Display Matrix: rotation of -90 degrees"
+        // side-data entry that makes it portrait on playback. ffmpeg auto-rotates on
+        // decode, so the frames every filter and encoder sees are the rotated ones.
+        // Report those display dimensions here, otherwise callers such as burn-in size
+        // the output (and the generated ASS PlayRes) to the unrotated frame and the
+        // picture comes out stretched.
+        var inDimensionStreamBlock = false;
+        var rotationApplied = false;
+
         foreach (var line in log.SplitToLines())
         {
             var s = line.Trim();
             if (s.StartsWith("Stream #", StringComparison.Ordinal))
             {
+                inDimensionStreamBlock = false;
+
                 var resolutionMatch = ResolutionRegex.Match(s);
                 if (resolutionMatch.Success)
                 {
@@ -120,6 +136,7 @@ public class FfmpegMediaInfo2
                         int.TryParse(parts[1], out var h))
                     {
                         info.Dimension = new Dimension(w, h);
+                        inDimensionStreamBlock = true;
                     }
                 }
 
@@ -160,6 +177,22 @@ public class FfmpegMediaInfo2
                     else
                     {
                         info.Tracks.Add(new FfmpegTrackInfo { TrackType = FfmpegTrackType.Other, TrackInfo = trackInfo, Language = language });
+                    }
+                }
+            }
+            else if (inDimensionStreamBlock && !rotationApplied)
+            {
+                var rotationMatch = DisplayMatrixRotationRegex.Match(s);
+                if (rotationMatch.Success &&
+                    double.TryParse(rotationMatch.Groups["deg"].Value, NumberStyles.Any, CultureInfo.InvariantCulture, out var degrees))
+                {
+                    // Guard against the duplicated retry log swapping a second time.
+                    rotationApplied = true;
+
+                    var normalized = ((degrees % 360) + 360) % 360;
+                    if (Math.Abs(normalized - 90) < 1 || Math.Abs(normalized - 270) < 1)
+                    {
+                        info.Dimension = new Dimension(info.Dimension.Height, info.Dimension.Width);
                     }
                 }
             }


### PR DESCRIPTION
### Problem

Burn-in stretches portrait video that carries rotation metadata.

Phone recordings are commonly stored as a landscape frame plus a display-matrix rotation of ±90°, which makes them portrait on playback. ffmpeg auto-rotates on decode, so every filter and the encoder see the rotated frames.

Both ffmpeg media-info parsers read only the stored size from the `Stream #` line and ignore the rotation side data that follows it. For a video stored 1024x576 and displayed 576x1024, burn-in produced:

```
-vf "scale=1024:576,ass=..." -g 30 -bf 2 -s 1024x576 ...
```

The decoded frames are already 576x1024, so `scale=1024:576` squashes the picture into landscape. The generated ASS `PlayRes` is sized from the same values, so the subtitles are distorted along with the image.

Example input (`ffmpeg -i`):

```
Stream #0:0[0x1](und): Video: h264 (Baseline) ..., 1024x576, 710 kb/s, 30 fps ...
  Side data:
    Display Matrix: rotation of -90.00 degrees
```

### Cause

Two parsers set `Dimension` from the `Stream #` line and neither looks at the `Display Matrix` side data:

- `FfmpegMediaInfo` (`src/libuilogic/Media/FfmpegMediaInfo.cs`) — burn-in sizes the **encode** from this one, in `BurnInViewModel.InitAndStartJobItem`, which overwrites `jobItem.Width`/`Height` just before the ffmpeg command is built.
- `FfmpegMediaInfo2` (`src/ui/Logic/Media/FfmpegMediainfo2.cs`) — this fills the burn-in window resolution fields.

Patching only one leaves the UI showing the correct resolution while the encoder still uses the unrotated size, so both are changed here.

### Fix

Read the `Display Matrix: rotation of N degrees` line that follows the video stream line, and swap width/height on a quarter turn (±90°, ±270°). A `rotationApplied` guard keeps the duplicated retry log from swapping twice. Videos with no rotation side data are untouched.

Also labels the two burn-in resolution fields `W` and `H` — they were previously an unlabelled pair either side of an `x`, which gives no clue which is which when the values are not obviously landscape.

### Verification

Tested by calling the compiled `ParseLog` of both parsers against real `ffmpeg -i` output:

| file | stored | rotation | before | after |
|---|---|---|---|---|
| phone clip A | 1024x576 | -90° | 1024x576 | **576x1024** |
| phone clip B | 1024x576 | -90° | 1024x576 | **576x1024** |
| native portrait x3 | 576x1024 | none | 576x1024 | 576x1024 |
| landscape | 1664x820 | none | 1664x820 | 1664x820 |
| landscape, no audio track | 640x448 | none | 640x448 | 640x448 |

Both parsers agree on every case. A burn-in encode of the affected file then produces a 576x1024 output whose frames are proportionally identical to the source, where it previously came out 1024x576 and stretched.