### PR TITLE
Improve split long lines workflow

### DIFF
--- a/src/ui/Features/Main/Layout/InitToolbar.cs
+++ b/src/ui/Features/Main/Layout/InitToolbar.cs
@@ -548,6 +548,25 @@ public static class InitToolbar
             RoutingStrategies.Tunnel,
             handledEventsToo: true);
         stackPanelRight.Children.Add(comboBoxSubtitleFormat);
+
+        // Direct access to the existing EBU STL header/export dialog.
+        // Match the format ComboBox visually and leave a small right-side margin.
+        stackPanelRight.Children.Add(new Button
+        {
+            Content = "Header",
+            Command = vm.ExportEbuStlCommand,
+            Background = Brushes.Transparent,
+            BorderBrush = Brushes.Gray,
+            BorderThickness = new Thickness(1),
+            Padding = new Thickness(10, 4),
+            Margin = new Thickness(6, 0, 4, 0),
+            MinHeight = 32,
+            MinWidth = 68,
+            VerticalAlignment = VerticalAlignment.Center,
+            [AutomationProperties.NameProperty] = "EBU STL header",
+            [ToolTip.TipProperty] = "Open EBU STL header/export settings",
+        });
+
         isLastSeparator = false;
 
         if (appearance.ToolbarShowEncoding)

--- a/src/ui/Features/Tools/ApplyMinGap/ApplyMinGapViewModel.cs
+++ b/src/ui/Features/Tools/ApplyMinGap/ApplyMinGapViewModel.cs
@@ -17,13 +17,15 @@ namespace Nikse.SubtitleEdit.Features.Tools.ApplyMinGap;
 
 public partial class ApplyMinGapViewModel : ObservableObject, IClosingCleanup
 {
+    private const double GapComparisonToleranceMs = 10.0;
+
     [ObservableProperty] private ObservableCollection<ApplyMinGapItem> _subtitles;
     [ObservableProperty] private ApplyMinGapItem? _selectedSubtitle;
     [ObservableProperty] private string _minXBetweenLines;
     [ObservableProperty] private int _minGapMsOrFrames;
     [ObservableProperty] private string _statusText;
-    
-    public List<SubtitleLineViewModel> FixedSubtitles{ get; set; }
+
+    public List<SubtitleLineViewModel> FixedSubtitles { get; set; }
     public Window? Window { get; set; }
 
     public bool OkPressed { get; private set; }
@@ -51,7 +53,7 @@ public partial class ApplyMinGapViewModel : ObservableObject, IClosingCleanup
 
         LoadSettings();
 
-        _allSubtitles = new List<SubtitleLineViewModel>();  
+        _allSubtitles = new List<SubtitleLineViewModel>();
         _timerUpdatePreview = new System.Timers.Timer(500);
         _timerUpdatePreview.Elapsed += TimerUpdatePreviewElapsed;
     }
@@ -70,9 +72,6 @@ public partial class ApplyMinGapViewModel : ObservableObject, IClosingCleanup
             UpdatePreview();
         }
 
-        // Guard the restart: OnClosingCleanup may have disposed the timer while this handler ran,
-        // and Start() on a disposed timer throws ObjectDisposedException (no longer swallowed on
-        // modern .NET), crashing the app from a thread-pool thread. (#12739)
         if (!_isClosing)
         {
             _timerUpdatePreview.Start();
@@ -100,34 +99,42 @@ public partial class ApplyMinGapViewModel : ObservableObject, IClosingCleanup
         {
             Subtitles.Clear();
             var fixedCount = 0;
-            for (var index = 0; index < FixedSubtitles.Count-1; index++)
+            for (var index = 0; index < FixedSubtitles.Count - 1; index++)
             {
                 var current = FixedSubtitles[index];
                 var next = FixedSubtitles[index + 1];
                 var gapMs = next.StartTime.TotalMilliseconds - current.EndTime.TotalMilliseconds;
-                if (gapMs < minMsBetweenLines)
+
+                if (!NeedsGapAdjustment(gapMs, minMsBetweenLines))
                 {
-                    fixedCount++;
-                    
-                    var before = new TimeCode(gapMs).ToShortDisplayString();
-                    
-                    var newEndMs = next.StartTime.TotalMilliseconds  - minMsBetweenLines;
-                    current.EndTime = TimeSpan.FromMilliseconds(newEndMs);
-                    var newGapMs = next.StartTime.TotalMilliseconds - current.EndTime.TotalMilliseconds;
-
-                    var after = new TimeCode(newGapMs).ToShortDisplayString();
-                    var fixFormat = Se.Language.Tools.ApplyMinGaps.ChangedGapFromXToYCommentZ;
-                    var comment = string.Empty;
-                    var info = string.Format(fixFormat, before, after, comment);
-
-                    var vm = new ApplyMinGapItem(current);
-                    vm.InfoText = info; 
-                    Subtitles.Add(vm);
+                    continue;
                 }
+
+                fixedCount++;
+
+                var before = new TimeCode(gapMs).ToShortDisplayString();
+
+                var newEndMs = next.StartTime.TotalMilliseconds - minMsBetweenLines;
+                current.EndTime = TimeSpan.FromMilliseconds(newEndMs);
+                var newGapMs = next.StartTime.TotalMilliseconds - current.EndTime.TotalMilliseconds;
+
+                var after = new TimeCode(newGapMs).ToShortDisplayString();
+                var fixFormat = Se.Language.Tools.ApplyMinGaps.ChangedGapFromXToYCommentZ;
+                var comment = string.Empty;
+                var info = string.Format(fixFormat, before, after, comment);
+
+                var vm = new ApplyMinGapItem(current);
+                vm.InfoText = info;
+                Subtitles.Add(vm);
             }
 
             StatusText = string.Format(Se.Language.Tools.ApplyMinGaps.NumberOfGapsFixedX, fixedCount);
         });
+    }
+
+    public static bool NeedsGapAdjustment(double currentGapMs, double minimumGapMs)
+    {
+        return currentGapMs < minimumGapMs - GapComparisonToleranceMs;
     }
 
     public void Initialize(List<SubtitleLineViewModel> subtitles)
@@ -140,11 +147,6 @@ public partial class ApplyMinGapViewModel : ObservableObject, IClosingCleanup
 
     private void LoadSettings()
     {
-        // Kept per unit: the box holds frames in frame mode and milliseconds otherwise, so one
-        // shared number meant a gap saved as 10 ms came back as 10 frames (~400 ms) after the
-        // user switched the time format. 0 means "not saved yet" - fall back to the general
-        // minimum-gap setting, which is what the dialog used to open on every time because
-        // nothing here was ever written back.
         if (Se.Settings.General.UseFrameMode)
         {
             var savedFrames = Se.Settings.Tools.ApplyMinGapFrames;
@@ -194,7 +196,6 @@ public partial class ApplyMinGapViewModel : ObservableObject, IClosingCleanup
         }
         else if (UiUtil.IsHelp(e))
         {
-            e.Handled = true;
             UiUtil.ShowHelp("features/apply-min-gap");
         }
     }

--- a/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesItem.cs
+++ b/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesItem.cs
@@ -1,19 +1,54 @@
-﻿using Nikse.SubtitleEdit.Features.Main;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using Nikse.SubtitleEdit.Features.Main;
 
 namespace Nikse.SubtitleEdit.Features.Tools.SplitBreakLongLines;
 
-public class SplitBreakLongLinesItem
+public partial class SplitBreakLongLinesItem : ObservableObject
 {
     public string Name { get; set; }
     public int Number { get; set; }
     public string Fix { get; set; }
     public SubtitleLineViewModel SubtitleLine { get; set; }
 
-    public SplitBreakLongLinesItem(string name, int number, string fix, SubtitleLineViewModel subtitleLine)
+    public bool IsSelectable { get; }
+    public string OriginalText { get; }
+    public string ProposedText { get; }
+
+    [ObservableProperty]
+    private bool _isSelected = true;
+
+    public SplitBreakLongLinesItem(
+        string name,
+        int number,
+        string fix,
+        SubtitleLineViewModel subtitleLine,
+        bool isSelectable = false,
+        string? proposedText = null)
     {
         Name = name;
         Number = number;
         Fix = fix;
         SubtitleLine = subtitleLine;
+
+        IsSelectable = isSelectable;
+        OriginalText = subtitleLine.Text ?? string.Empty;
+        ProposedText = proposedText ?? OriginalText;
+
+        ApplySelection();
+    }
+
+    partial void OnIsSelectedChanged(bool value)
+    {
+        ApplySelection();
+    }
+
+    private void ApplySelection()
+    {
+        if (!IsSelectable)
+        {
+            return;
+        }
+
+        SubtitleLine.Text = IsSelected ? ProposedText : OriginalText;
     }
 }

--- a/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModel.cs
+++ b/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModel.cs
@@ -104,7 +104,7 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
                 {
                     var item = new SubtitleLineViewModel(_allSubtitles[index]);
 
-                    var splitLines = Split(item, maxCharactersPerSubtitle, SingleLineMaxLength);
+                    var splitLines = Split(item, maxCharactersPerSubtitle, SingleLineMaxLength, _languageCode, makeCompliant: true);
                     if (splitLines.Count > 1)
                     {
                         splitCount++;
@@ -201,44 +201,133 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
 
     public static List<SubtitleLineViewModel> Split(SubtitleLineViewModel item, int maxCharactersPerSubtitle, int singleLineMaxLength)
     {
+        return Split(item, maxCharactersPerSubtitle, singleLineMaxLength, "en", makeCompliant: false);
+    }
+
+    public static List<SubtitleLineViewModel> Split(
+        SubtitleLineViewModel item,
+        int maxCharactersPerSubtitle,
+        int singleLineMaxLength,
+        string languageCode,
+        bool makeCompliant)
+    {
         var lines = new List<SubtitleLineViewModel>();
 
-        // Guard clauses
         var originalText = item.Text ?? string.Empty;
         var originalStartMs = item.StartTime.TotalMilliseconds;
         var originalEndMs = item.EndTime.TotalMilliseconds;
         var originalDurationMs = Math.Max(0, originalEndMs - originalStartMs);
 
-        // Per-line maximum for visual wrapping and per-subtitle maximum for splitting
         var perLineMax = Math.Max(5, singleLineMaxLength);
         var perSubtitleMax = Math.Max(perLineMax, maxCharactersPerSubtitle);
+        var maxNumberOfLines = Math.Max(1, (int)Math.Ceiling(perSubtitleMax / (double)perLineMax));
 
-        // If already short enough, return as-is
-        var plainText = HtmlUtil.RemoveHtmlTags(originalText, true).Replace("\r\n", " ").Replace('\n', ' ').Trim();
-        if (plainText.Length <= perSubtitleMax || string.IsNullOrWhiteSpace(plainText))
+        var plainText = HtmlUtil.RemoveHtmlTags(originalText, true)
+            .Replace("\r\n", " ")
+            .Replace('\n', ' ')
+            .Trim();
+
+        if (string.IsNullOrWhiteSpace(plainText))
         {
             lines.Add(item);
             return lines;
         }
 
-        // Prepare segments trying to split at natural boundaries
-        var remaining = originalText.Trim();
+        var originalPlainLines = HtmlUtil.RemoveHtmlTags(originalText, true).SplitToLines();
+        var hasTooManyLines = originalPlainLines.Count > maxNumberOfLines;
+        var hasOverlongExistingLine = false;
+        foreach (var originalLine in originalPlainLines)
+        {
+            if (originalLine.Length > perLineMax)
+            {
+                hasOverlongExistingLine = true;
+                break;
+            }
+        }
+
+        // Legacy SE5 behavior used by the existing three-argument overload:
+        // split only when the total text exceeds the subtitle capacity, except that an
+        // already multi-line subtitle with an overlong line is allowed to split at its
+        // existing line boundary (SE4 parity regression fix).
+        if (!makeCompliant)
+        {
+            if (plainText.Length <= perSubtitleMax && !hasTooManyLines)
+            {
+                if (!(originalPlainLines.Count > 1 && hasOverlongExistingLine))
+                {
+                    lines.Add(item);
+                    return lines;
+                }
+            }
+        }
+        else
+        {
+            // Split-long-lines should be a complete correction pass. Already compliant
+            // subtitles must remain byte-for-byte untouched, including intentionally
+            // unbalanced line breaks.
+            if (!hasTooManyLines && !hasOverlongExistingLine)
+            {
+                lines.Add(item);
+                return lines;
+            }
+
+            // A too-long single-line subtitle that still fits inside one subtitle event
+            // is locally balanced here. This is deliberately not the global "Rebalance
+            // long lines" operation: only this non-compliant subtitle is changed.
+            if (originalPlainLines.Count == 1 && plainText.Length <= perSubtitleMax)
+            {
+                var balanced = BalanceSegment(originalText);
+                if (IsCompliant(balanced))
+                {
+                    var balancedItem = new SubtitleLineViewModel(item, true)
+                    {
+                        Text = balanced,
+                        StartTime = item.StartTime,
+                        EndTime = item.EndTime,
+                    };
+                    balancedItem.UpdateDuration();
+                    lines.Add(balancedItem);
+                    return lines;
+                }
+            }
+        }
+
+        // Prepare event segments. For an existing multi-line subtitle with an overlong
+        // line, keep its editorial line boundaries as event split points. This matches
+        // the useful SE4 behavior: a sentence/line boundary is not silently rebalanced
+        // across the whole subtitle just to avoid creating a new event.
         var segments = new List<string>();
+        var remaining = originalText.Trim();
+
+        if (plainText.Length <= perSubtitleMax && originalPlainLines.Count > 1 &&
+            (hasOverlongExistingLine || hasTooManyLines))
+        {
+            foreach (var originalLine in originalText.SplitToLines())
+            {
+                if (!string.IsNullOrWhiteSpace(originalLine))
+                {
+                    segments.Add(originalLine.Trim());
+                }
+            }
+            remaining = string.Empty;
+        }
 
         while (!string.IsNullOrEmpty(remaining))
         {
-            var remainingPlain = HtmlUtil.RemoveHtmlTags(remaining, true).Replace("\r\n", " ").Replace('\n', ' ').Trim();
+            var remainingPlain = HtmlUtil.RemoveHtmlTags(remaining, true)
+                .Replace("\r\n", " ")
+                .Replace('\n', ' ')
+                .Trim();
+
             if (remainingPlain.Length <= perSubtitleMax)
             {
                 segments.Add(remaining.Trim());
                 break;
             }
 
-            // Find best split position that keeps plain length <= perSubtitleMax
             var splitIdx = FindBestSplitIndexByPlainLength(remaining, perSubtitleMax);
             if (splitIdx <= 0)
             {
-                // Fallback to previous logic using raw index near limit
                 var approxCut = Math.Min(remaining.Length - 1, perSubtitleMax);
                 splitIdx = FindBestSplitIndex(remaining, approxCut);
             }
@@ -260,20 +349,37 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
             return lines;
         }
 
-        // Distribute time proportional to character counts per segment
+        // In one-pass correction mode, locally balance only the segments that need it.
+        // This guarantees that Split long lines does not create new overlong single-line
+        // subtitles that would require a second global Rebalance run.
+        if (makeCompliant)
+        {
+            for (var i = 0; i < segments.Count; i++)
+            {
+                if (HasLineTooLong(segments[i], perLineMax, maxNumberOfLines))
+                {
+                    segments[i] = BalanceSegment(segments[i]);
+                }
+            }
+        }
+
         var charCounts = new List<int>();
         var totalChars = 0;
         foreach (var seg in segments)
         {
-            var cnt = HtmlUtil.RemoveHtmlTags(seg, true).Replace("\r\n", " ").Replace('\n', ' ').Length;
+            var cnt = HtmlUtil.RemoveHtmlTags(seg, true)
+                .Replace("\r\n", " ")
+                .Replace('\n', ' ')
+                .Length;
             if (cnt <= 0)
             {
-                cnt = 1; // avoid zero to ensure some time
+                cnt = 1;
             }
 
             charCounts.Add(cnt);
             totalChars += cnt;
         }
+
         if (totalChars <= 0)
         {
             totalChars = segments.Count;
@@ -284,33 +390,27 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
             }
         }
 
-        // Build new subtitle lines
         double accumulatedMs = originalStartMs;
         for (var i = 0; i < segments.Count; i++)
         {
             var segText = segments[i];
 
-            // Calculate duration for this segment
             double segDurationMs;
             if (i == segments.Count - 1)
             {
-                // last segment takes the rest (avoid rounding drift)
                 segDurationMs = Math.Max(0, originalEndMs - accumulatedMs);
             }
             else
             {
                 segDurationMs = originalDurationMs * (charCounts[i] / (double)totalChars);
-                // Ensure we don't overrun
                 segDurationMs = Math.Max(0, Math.Min(segDurationMs, Math.Max(0, originalEndMs - accumulatedMs)));
             }
 
-            // Keep the segment text as-is; auto-wrapping is opt-in via the
-            // RebalanceLongLines option, which runs its own AutoBreakLine pass.
             var newLine = new SubtitleLineViewModel(item, true)
             {
                 Text = segText,
                 StartTime = TimeSpan.FromMilliseconds(accumulatedMs),
-                EndTime = TimeSpan.FromMilliseconds(accumulatedMs + segDurationMs)
+                EndTime = TimeSpan.FromMilliseconds(accumulatedMs + segDurationMs),
             };
             newLine.UpdateDuration();
             lines.Add(newLine);
@@ -318,7 +418,6 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
             accumulatedMs += segDurationMs;
         }
 
-        // In rare rounding cases, force end of last to original end
         if (lines.Count > 0)
         {
             var last = lines[^1];
@@ -328,7 +427,18 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
 
         return lines;
 
-        // Local helper: find the best split index near a target index (raw length based)
+        string BalanceSegment(string text)
+        {
+            // max+1 prevents AutoBreakLine from collapsing a compliant two-line result
+            // back to one line while still allowing a long single line to be balanced.
+            return Utilities.AutoBreakLine(text, perLineMax, perLineMax + 1, languageCode);
+        }
+
+        bool IsCompliant(string text)
+        {
+            return !HasLineTooLong(text, perLineMax, maxNumberOfLines);
+        }
+
         static int FindBestSplitIndex(string text, int targetIndex)
         {
             if (string.IsNullOrEmpty(text))
@@ -336,14 +446,12 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
                 return 0;
             }
 
-            // Prefer line breaks if present before target
             var lbBefore = text.LastIndexOf('\n', Math.Min(targetIndex, text.Length - 1));
             if (lbBefore >= 0 && lbBefore >= targetIndex - 10)
             {
                 return lbBefore;
             }
 
-            // Search backwards from target for strong punctuation, then commas/spaces
             var strongPunctuation = new HashSet<char> { '.', '!', '?', '…', '。', '！', '？' };
             var weakPunctuation = new HashSet<char> { ';', ':', ',', '，', '；', '：' };
 
@@ -355,26 +463,21 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
                     return i;
                 }
             }
+
             for (var i = Math.Min(targetIndex, text.Length - 1); i >= 0 && i >= targetIndex - 30; i--)
             {
                 var ch = text[i];
-                if (weakPunctuation.Contains(ch))
-                {
-                    return i;
-                }
-
-                if (char.IsWhiteSpace(ch))
+                if (weakPunctuation.Contains(ch) || char.IsWhiteSpace(ch))
                 {
                     return i;
                 }
 
                 if (ch == '-' && i + 1 < text.Length && text[i + 1] == ' ')
                 {
-                    return i; // split at "- "
+                    return i;
                 }
             }
 
-            // If none found backwards, try small lookahead window
             for (var i = Math.Min(targetIndex + 1, text.Length - 1); i < text.Length && i <= targetIndex + 30; i++)
             {
                 var ch = text[i];
@@ -389,11 +492,9 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
                 }
             }
 
-            // Default to target index
             return Math.Min(targetIndex, text.Length - 1);
         }
 
-        // Local helper: find split index ensuring plain (html-stripped) length <= maxPlainLen
         static int FindBestSplitIndexByPlainLength(string text, int maxPlainLen)
         {
             if (string.IsNullOrEmpty(text))
@@ -406,11 +507,11 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
 
             var plainLen = 0;
             var inTag = false;
-            var lastVisibleIdx = -1; // last non-tag index
-            var bestIdx = -1;             // best candidate index under the limit (any)
-            var bestPlainLen = -1;        // plain length at bestIdx
-            var bestAcceptableIdx = -1;   // best acceptable candidate index under the limit (no orphan small words)
-            var bestAcceptablePlain = -1; // plain length at bestAcceptableIdx
+            var lastVisibleIdx = -1;
+            var bestIdx = -1;
+            var bestPlainLen = -1;
+            var bestAcceptableIdx = -1;
+            var bestAcceptablePlain = -1;
 
             for (var i = 0; i < text.Length; i++)
             {
@@ -422,22 +523,20 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
 
                 if (!inTag)
                 {
-                    // newline indicates strong boundary, do not include it
                     if (ch == '\n')
                     {
-                        // Prefer splitting just before newline if within limit
                         return i > 0 ? i - 1 : 0;
                     }
 
-                    // Count visible characters (skip CR)
                     if (ch != '\r')
                     {
                         plainLen++;
                         lastVisibleIdx = i;
                     }
 
-                    // Any break candidate we see under or equal to the limit can be considered
-                    var isBreak = strongPunctuation.Contains(ch) || weakPunctuation.Contains(ch) || char.IsWhiteSpace(ch) || (ch == '-' && i + 1 < text.Length && text[i + 1] == ' ');
+                    var isBreak = strongPunctuation.Contains(ch) || weakPunctuation.Contains(ch) ||
+                                  char.IsWhiteSpace(ch) ||
+                                  (ch == '-' && i + 1 < text.Length && text[i + 1] == ' ');
                     if (isBreak && plainLen <= maxPlainLen)
                     {
                         if (plainLen >= bestPlainLen)
@@ -446,7 +545,6 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
                             bestIdx = i;
                         }
 
-                        // Prefer breakpoints that do not orphan one or two small words around strong punctuation
                         var acceptable = !CausesOrphanSmallWords(text, i, strongPunctuation);
                         if (acceptable && plainLen >= bestAcceptablePlain)
                         {
@@ -457,7 +555,6 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
 
                     if (plainLen > maxPlainLen)
                     {
-                        // Prefer the acceptable candidate closest to the limit
                         if (bestAcceptableIdx >= 0)
                         {
                             return bestAcceptableIdx;
@@ -478,10 +575,8 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
                 }
             }
 
-            // Entire text within limit
             return text.Length - 1;
 
-            // Local: Avoid breakpoints that leave one or two small words alone around sentence-ending punctuation
             static bool CausesOrphanSmallWords(string s, int breakIdx, HashSet<char> strong)
             {
                 if (breakIdx < 0 || breakIdx >= s.Length)
@@ -491,72 +586,81 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
 
                 var ch = s[breakIdx];
 
-                // Helper to get up to two word lengths backward from index-1
                 static List<int> GetPrevWordLens(string str, int idx)
                 {
                     var res = new List<int>(2);
                     var i = Math.Min(idx, str.Length - 1);
-                    // skip spaces and closing quotes/parens
                     var closingSkip = new HashSet<char>(new[] { ')', '’', '”', '\'', '»', ']', '}', '"' });
                     while (i >= 0 && (char.IsWhiteSpace(str[i]) || closingSkip.Contains(str[i])))
                     {
                         i--;
                     }
 
-                    for (int w = 0; w < 2 && i >= 0; w++)
+                    for (var w = 0; w < 2 && i >= 0; w++)
                     {
                         var length = 0;
-                        while (i >= 0 && char.IsLetterOrDigit(str[i])) { length++; i--; }
+                        while (i >= 0 && char.IsLetterOrDigit(str[i]))
+                        {
+                            length++;
+                            i--;
+                        }
+
                         if (length > 0)
                         {
                             res.Add(length);
                         }
-                        // skip separators before next word
+
                         while (i >= 0 && !char.IsLetterOrDigit(str[i]))
                         {
                             i--;
                         }
                     }
+
                     return res;
                 }
 
-                // Helper to get up to two word lengths forward from index+1
                 static List<int> GetNextWordLens(string str, int idx)
                 {
                     var res = new List<int>(2);
                     var i = Math.Min(idx + 1, str.Length - 1);
-                    // skip spaces and opening quotes/parens
                     var openingSkip = new HashSet<char>(new[] { '(', '“', '‘', '\'', '«', '[', '{', '"' });
                     while (i < str.Length && (char.IsWhiteSpace(str[i]) || openingSkip.Contains(str[i])))
                     {
                         i++;
                     }
 
-                    for (int w = 0; w < 2 && i < str.Length; w++)
+                    for (var w = 0; w < 2 && i < str.Length; w++)
                     {
                         var length = 0;
-                        while (i < str.Length && char.IsLetterOrDigit(str[i])) { length++; i++; }
+                        while (i < str.Length && char.IsLetterOrDigit(str[i]))
+                        {
+                            length++;
+                            i++;
+                        }
+
                         if (length > 0)
                         {
                             res.Add(length);
                         }
-                        // skip separators before next word
+
                         while (i < str.Length && !char.IsLetterOrDigit(str[i]))
                         {
                             i++;
                         }
                     }
+
                     return res;
                 }
 
-                // If candidate itself is a strong punctuation, avoid tiny words just before or just after it
                 if (strong.Contains(ch))
                 {
                     var prevLensStrong = GetPrevWordLens(s, breakIdx - 1);
-                    var prevTinyStrong = prevLensStrong.Count > 0 && prevLensStrong.Count <= 2 && prevLensStrong.TrueForAll(l => l <= 2);
+                    var prevTinyStrong = prevLensStrong.Count > 0 && prevLensStrong.Count <= 2 &&
+                                         prevLensStrong.TrueForAll(l => l <= 2);
 
                     var nextLensStrong = GetNextWordLens(s, breakIdx);
-                    var nextTinyStrong = nextLensStrong.Count > 0 && nextLensStrong.Count <= 2 && nextLensStrong.TrueForAll(l => l <= 2);
+                    var nextTinyStrong = nextLensStrong.Count > 0 && nextLensStrong.Count <= 2 &&
+                                         nextLensStrong.TrueForAll(l => l <= 2);
 
                     if (prevTinyStrong || nextTinyStrong)
                     {
@@ -564,9 +668,7 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
                     }
                 }
 
-                // If candidate is NOT strong, check whether we are breaking shortly AFTER a strong punctuation
-                // and the words since that strong punctuation are tiny (one or two words of length <= 2), e.g. "... overtime. So,"
-                int j = breakIdx - 1;
+                var j = breakIdx - 1;
                 while (j >= 0 && !strong.Contains(s[j]))
                 {
                     j--;
@@ -574,36 +676,35 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
 
                 if (j >= 0)
                 {
-                    // We found previous strong punctuation at index j
-                    // Count up to 2 word lengths between (j, breakIdx)
-                    var tinyBetween = false;
+                    var i = j + 1;
+                    var openingSkip = new HashSet<char>(new[] { '(', '“', '‘', '\'', '«', '[', '{', '"' });
+                    while (i < breakIdx && (char.IsWhiteSpace(s[i]) || openingSkip.Contains(s[i])))
                     {
-                        int i = j + 1;
-                        // skip whitespace and opening quotes/parens
-                        var openingSkip = new HashSet<char>(new[] { '(', '“', '‘', '\'', '«', '[', '{', '"' });
-                        while (i < breakIdx && (char.IsWhiteSpace(s[i]) || openingSkip.Contains(s[i])))
+                        i++;
+                    }
+
+                    var lens = new List<int>(2);
+                    for (var w = 0; w < 2 && i < breakIdx; w++)
+                    {
+                        var len = 0;
+                        while (i < breakIdx && char.IsLetterOrDigit(s[i]))
                         {
+                            len++;
                             i++;
                         }
 
-                        var lens = new List<int>(2);
-                        for (int w = 0; w < 2 && i < breakIdx; w++)
+                        if (len > 0)
                         {
-                            int len = 0;
-                            while (i < breakIdx && char.IsLetterOrDigit(s[i])) { len++; i++; }
-                            if (len > 0)
-                            {
-                                lens.Add(len);
-                            }
-
-                            while (i < breakIdx && !char.IsLetterOrDigit(s[i]))
-                            {
-                                i++;
-                            }
+                            lens.Add(len);
                         }
-                        tinyBetween = lens.Count > 0 && lens.Count <= 2 && lens.TrueForAll(l => l <= 2);
+
+                        while (i < breakIdx && !char.IsLetterOrDigit(s[i]))
+                        {
+                            i++;
+                        }
                     }
-                    if (tinyBetween)
+
+                    if (lens.Count > 0 && lens.Count <= 2 && lens.TrueForAll(l => l <= 2))
                     {
                         return true;
                     }

--- a/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModel.cs
+++ b/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModel.cs
@@ -5,6 +5,7 @@ using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
@@ -27,6 +28,7 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
 
     [ObservableProperty] private bool _rebalanceLongLines;
     [ObservableProperty] private bool _rebalanceOnlyLinesTooLong;
+    [ObservableProperty] private bool _applyMinimumGapToAllSubtitles;
     [ObservableProperty] private int _unbreakLinesShorterThan;
 
     [ObservableProperty] private string _fixesInfo;
@@ -96,6 +98,7 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
 
             var splitCount = 0;
             var rebalanceCount = 0;
+            var gapCount = 0;
             var maxCharactersPerSubtitle = MaxNumberOfLines * SingleLineMaxLength;
 
             if (SplitLongLines)
@@ -104,14 +107,40 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
                 {
                     var item = new SubtitleLineViewModel(_allSubtitles[index]);
 
-                    var splitLines = Split(item, maxCharactersPerSubtitle, SingleLineMaxLength, _languageCode, makeCompliant: true);
-                    if (splitLines.Count > 1)
+                    var splitLines = Split(
+                        item,
+                        maxCharactersPerSubtitle,
+                        SingleLineMaxLength,
+                        _languageCode,
+                        makeCompliant: true,
+                        GetGeneralMinimumGapMs());
+
+                    var textChanged = splitLines.Count == 1 && splitLines[0].Text != item.Text;
+                    if (splitLines.Count > 1 || textChanged)
                     {
                         splitCount++;
                         var originalPreview = GetTextPreview(item.Text, 50);
-                        var firstSplitPreview = GetTextPreview(splitLines[0].Text, 50);
-                        var fixDescription = string.Format(Se.Language.Tools.SplitBreakLongLines.SplitIntoXLines, splitLines.Count, originalPreview, firstSplitPreview);
-                        var fixItem = new SplitBreakLongLinesItem(Se.Language.Tools.SplitBreakLongLines.SplitLongLine, index + 1, fixDescription, item);
+                        string fixDescription;
+                        if (splitLines.Count > 1)
+                        {
+                            var firstSplitPreview = GetTextPreview(splitLines[0].Text, 50);
+                            fixDescription = string.Format(
+                                Se.Language.Tools.SplitBreakLongLines.SplitIntoXLines,
+                                splitLines.Count,
+                                originalPreview,
+                                firstSplitPreview);
+                        }
+                        else
+                        {
+                            var correctedPreview = GetTextPreview(splitLines[0].Text.Replace("\r\n", " · ").Replace("\n", " · "), 60);
+                            fixDescription = $"'{originalPreview}' → '{correctedPreview}'";
+                        }
+
+                        var fixItem = new SplitBreakLongLinesItem(
+                            Se.Language.Tools.SplitBreakLongLines.SplitLongLine,
+                            index + 1,
+                            fixDescription,
+                            item);
                         Fixes.Add(fixItem);
                     }
                     foreach (var s in splitLines)
@@ -163,13 +192,54 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
                 }
             }
 
-            if (splitCount == 0 && rebalanceCount == 0)
+            if (ApplyMinimumGapToAllSubtitles)
+            {
+                var minimumGapMs = GetGeneralMinimumGapMs();
+                const double toleranceMs = 10.0;
+
+                for (var index = 0; index < AllSubtitlesFixed.Count - 1; index++)
+                {
+                    var current = AllSubtitlesFixed[index];
+                    var next = AllSubtitlesFixed[index + 1];
+                    var currentGapMs = next.StartTime.TotalMilliseconds - current.EndTime.TotalMilliseconds;
+
+                    if (currentGapMs >= minimumGapMs - toleranceMs)
+                    {
+                        continue;
+                    }
+
+                    var newEndMs = next.StartTime.TotalMilliseconds - minimumGapMs;
+                    if (newEndMs <= current.StartTime.TotalMilliseconds)
+                    {
+                        continue;
+                    }
+
+                    var before = new TimeCode(currentGapMs).ToShortDisplayString();
+                    current.EndTime = TimeSpan.FromMilliseconds(newEndMs);
+                    current.UpdateDuration();
+                    var newGapMs = next.StartTime.TotalMilliseconds - current.EndTime.TotalMilliseconds;
+                    var after = new TimeCode(newGapMs).ToShortDisplayString();
+                    gapCount++;
+
+                    Fixes.Add(new SplitBreakLongLinesItem(
+                        Se.Language.Main.Menu.ApplyMinGap,
+                        index + 1,
+                        $"Gap: {before} → {after}",
+                        current));
+                }
+            }
+
+            if (splitCount == 0 && rebalanceCount == 0 && gapCount == 0)
             {
                 FixesInfo = Se.Language.Tools.ApplyDurationLimits.NoChangesNeeded;
                 return;
             }
 
-            if (rebalanceCount == 0)
+            if (gapCount > 0)
+            {
+                FixesInfo = $"Split: {splitCount}, rebalanced: {rebalanceCount}, gaps corrected: {gapCount}";
+            }
+            else if (rebalanceCount == 0)
             {
                 FixesInfo = string.Format(Se.Language.Tools.SplitBreakLongLines.LinesSplitX, splitCount);
             }
@@ -178,6 +248,17 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
                 FixesInfo = string.Format(Se.Language.Tools.SplitBreakLongLines.LinesSplitXLinesRebalancedY, splitCount, rebalanceCount);
             }
         });
+    }
+
+    private static double GetGeneralMinimumGapMs()
+    {
+        var general = Se.Settings.General;
+        if (general.UseFrameMode)
+        {
+            return SubtitleFormat.FramesToMilliseconds(general.MinimumBetweenLines.Frames);
+        }
+
+        return general.MinimumBetweenLines.Milliseconds;
     }
 
     public static bool HasLineTooLong(string? text, int singleLineMaxLength, int maxNumberOfLines)
@@ -210,6 +291,23 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
         int singleLineMaxLength,
         string languageCode,
         bool makeCompliant)
+    {
+        return Split(
+            item,
+            maxCharactersPerSubtitle,
+            singleLineMaxLength,
+            languageCode,
+            makeCompliant,
+            minimumGapMs: 0);
+    }
+
+    public static List<SubtitleLineViewModel> Split(
+        SubtitleLineViewModel item,
+        int maxCharactersPerSubtitle,
+        int singleLineMaxLength,
+        string languageCode,
+        bool makeCompliant,
+        double minimumGapMs)
     {
         var lines = new List<SubtitleLineViewModel>();
 
@@ -390,6 +488,20 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
             }
         }
 
+        // Keep the original outer timecodes, but reserve the configured minimum gap
+        // between newly created subtitle events. If the source duration is too short to
+        // fit the requested gap, clamp it so durations never become negative.
+        var gapMs = 0.0;
+        if (segments.Count > 1)
+        {
+            gapMs = Math.Max(0, minimumGapMs);
+            var maxGapThatFits = originalDurationMs / (segments.Count - 1);
+            gapMs = Math.Min(gapMs, maxGapThatFits);
+        }
+
+        var totalGapMs = gapMs * Math.Max(0, segments.Count - 1);
+        var availableTextDurationMs = Math.Max(0, originalDurationMs - totalGapMs);
+
         double accumulatedMs = originalStartMs;
         for (var i = 0; i < segments.Count; i++)
         {
@@ -402,8 +514,12 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
             }
             else
             {
-                segDurationMs = originalDurationMs * (charCounts[i] / (double)totalChars);
-                segDurationMs = Math.Max(0, Math.Min(segDurationMs, Math.Max(0, originalEndMs - accumulatedMs)));
+                segDurationMs = availableTextDurationMs * (charCounts[i] / (double)totalChars);
+                segDurationMs = Math.Max(
+                    0,
+                    Math.Min(
+                        segDurationMs,
+                        Math.Max(0, originalEndMs - accumulatedMs - gapMs)));
             }
 
             var newLine = new SubtitleLineViewModel(item, true)
@@ -416,6 +532,10 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
             lines.Add(newLine);
 
             accumulatedMs += segDurationMs;
+            if (i < segments.Count - 1)
+            {
+                accumulatedMs += gapMs;
+            }
         }
 
         if (lines.Count > 0)
@@ -730,6 +850,7 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
         SplitLongLines = Se.Settings.Tools.SplitRebalanceLongLinesSplit;
         RebalanceLongLines = Se.Settings.Tools.SplitRebalanceLongLinesRebalance;
         RebalanceOnlyLinesTooLong = Se.Settings.Tools.SplitRebalanceLongLinesRebalanceOnlyTooLong;
+        ApplyMinimumGapToAllSubtitles = false;
     }
 
     private void SaveSettings()

--- a/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModel.cs
+++ b/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModel.cs
@@ -11,6 +11,7 @@ using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Features.Tools.SplitBreakLongLines;
 
@@ -185,9 +186,14 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
                         var beforePreview = GetTextPreview(item.Text.Replace("\r\n", " · ").Replace("\n", " · "), 60);
                         var afterPreview = GetTextPreview(rebalancedText.Replace("\r\n", " · ").Replace("\n", " · "), 60);
                         var fixDescription = $"'{beforePreview}' → '{afterPreview}'";
-                        var fixItem = new SplitBreakLongLinesItem(Se.Language.Tools.SplitBreakLongLines.RebalanceLongLine, index + 1, fixDescription, item);
+                        var fixItem = new SplitBreakLongLinesItem(
+                            Se.Language.Tools.SplitBreakLongLines.RebalanceLongLine,
+                            index + 1,
+                            fixDescription,
+                            item,
+                            isSelectable: true,
+                            proposedText: rebalancedText);
                         Fixes.Add(fixItem);
-                        item.Text = rebalancedText;
                     }
                 }
             }
@@ -229,6 +235,14 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
                 }
             }
 
+            // Splitting clones the source SubtitleLineViewModel, including its Number.
+            // When at least one subtitle event was split, renumber the complete result once
+            // at the end so newly created events do not keep duplicate numbers.
+            if (splitCount > 0)
+            {
+                RenumberSubtitles(AllSubtitlesFixed);
+            }
+
             if (splitCount == 0 && rebalanceCount == 0 && gapCount == 0)
             {
                 FixesInfo = Se.Language.Tools.ApplyDurationLimits.NoChangesNeeded;
@@ -248,6 +262,14 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
                 FixesInfo = string.Format(Se.Language.Tools.SplitBreakLongLines.LinesSplitXLinesRebalancedY, splitCount, rebalanceCount);
             }
         });
+    }
+
+    public static void RenumberSubtitles(List<SubtitleLineViewModel> subtitles)
+    {
+        for (var index = 0; index < subtitles.Count; index++)
+        {
+            subtitles[index].Number = index + 1;
+        }
     }
 
     private static double GetGeneralMinimumGapMs()
@@ -383,6 +405,13 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
                         StartTime = item.StartTime,
                         EndTime = item.EndTime,
                     };
+
+                    AdjustTeletextRowForLineCountChange(
+                        balancedItem,
+                        item.MarginV,
+                        originalPlainLines.Count,
+                        GetPlainLineCount(balanced));
+
                     balancedItem.UpdateDuration();
                     lines.Add(balancedItem);
                     return lines;
@@ -528,6 +557,13 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
                 StartTime = TimeSpan.FromMilliseconds(accumulatedMs),
                 EndTime = TimeSpan.FromMilliseconds(accumulatedMs + segDurationMs),
             };
+
+            AdjustTeletextRowForLineCountChange(
+                newLine,
+                item.MarginV,
+                originalPlainLines.Count,
+                GetPlainLineCount(segText));
+
             newLine.UpdateDuration();
             lines.Add(newLine);
 
@@ -546,6 +582,46 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
         }
 
         return lines;
+
+        static int GetPlainLineCount(string text)
+        {
+            return HtmlUtil.RemoveHtmlTags(text ?? string.Empty, true).SplitToLines().Count;
+        }
+
+        static void AdjustTeletextRowForLineCountChange(
+            SubtitleLineViewModel subtitle,
+            string originalMarginV,
+            int oldLineCount,
+            int newLineCount)
+        {
+            if (oldLineCount == newLineCount || oldLineCount < 1 || newLineCount < 1)
+            {
+                return;
+            }
+
+            if (!int.TryParse(originalMarginV, out var originalRow))
+            {
+                return;
+            }
+
+            // Double-height Teletext uses two physical rows per text line.
+            // Keep the subtitle at its existing vertical area and move the start row
+            // only by the number of rows gained/lost through the line-count change.
+            //
+            // Examples:
+            // 2 lines at 21 -> 1 line at 23
+            // 2 lines at 19 -> 1 line at 21
+            // 2 lines at 20 -> 1 line at 22
+            // and the inverse for 1 -> 2.
+            const int rowsPerTextLine = 2;
+            var rowDelta = (oldLineCount - newLineCount) * rowsPerTextLine;
+            var adjustedRow = originalRow + rowDelta;
+
+            if (adjustedRow is >= 1 and <= TeletextRowHelper.BottomRow)
+            {
+                subtitle.MarginV = adjustedRow.ToString(CultureInfo.InvariantCulture);
+            }
+        }
 
         string BalanceSegment(string text)
         {
@@ -862,6 +938,30 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
         Se.Settings.Tools.SplitRebalanceLongLinesMaxNumberOfLines = MaxNumberOfLines;
         Se.Settings.Tools.SplitRebalanceLongLinesUnbreakShorterThan = UnbreakLinesShorterThan;
         Se.SaveSettings();
+    }
+
+    [RelayCommand]
+    private void SelectAllRebalances()
+    {
+        foreach (var fix in Fixes)
+        {
+            if (fix.IsSelectable)
+            {
+                fix.IsSelected = true;
+            }
+        }
+    }
+
+    [RelayCommand]
+    private void DeselectAllRebalances()
+    {
+        foreach (var fix in Fixes)
+        {
+            if (fix.IsSelectable)
+            {
+                fix.IsSelected = false;
+            }
+        }
     }
 
     [RelayCommand]

--- a/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesWindow.cs
+++ b/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesWindow.cs
@@ -1,5 +1,7 @@
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Templates;
+using Avalonia.Controls.Primitives;
 using Avalonia.Media;
 using Avalonia.Data;
 using Avalonia.Input;
@@ -8,7 +10,6 @@ using Avalonia.Layout;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using System.Collections;
-using Avalonia;
 
 namespace Nikse.SubtitleEdit.Features.Tools.SplitBreakLongLines;
 
@@ -169,6 +170,7 @@ public class SplitBreakLongLinesWindow : Window
             RowDefinitions =
             {
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
             },
             ColumnDefinitions =
@@ -185,6 +187,32 @@ public class SplitBreakLongLinesWindow : Window
             .WithMarginTop(10)
             .WithMarginLeft(10);
 
+        var buttonSelectAll = new Button
+        {
+            Content = "Select all",
+            Command = vm.SelectAllRebalancesCommand,
+            MinWidth = 110,
+        };
+
+        var buttonDeselectAll = new Button
+        {
+            Content = "Deselect all",
+            Command = vm.DeselectAllRebalancesCommand,
+            MinWidth = 110,
+        };
+
+        var selectionButtons = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            Margin = new Thickness(10, 0, 0, 0),
+            Children =
+            {
+                buttonSelectAll,
+                buttonDeselectAll,
+            },
+        };
+
         var dataGrid = TableViewExtras.MakeTableView(multiSelect: false);
         dataGrid.Width = double.NaN;
         dataGrid.Height = double.NaN;
@@ -192,6 +220,30 @@ public class SplitBreakLongLinesWindow : Window
         dataGrid.ItemsSource = vm.Fixes;
         dataGrid.Columns.AddRange(new TableViewColumn[]
         {
+            new SeTableViewColumn
+            {
+                Header = "Apply",
+                CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+                HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+                CellTemplate = new FuncDataTemplate<SplitBreakLongLinesItem>((_, _) =>
+                    new Border
+                    {
+                        Background = Brushes.Transparent,
+                        Padding = new Thickness(4),
+                        Child = new CheckBox
+                        {
+                            Focusable = false,
+                            [!ToggleButton.IsCheckedProperty] = new Binding(nameof(SplitBreakLongLinesItem.IsSelected))
+                            {
+                                Mode = BindingMode.TwoWay,
+                            },
+                            [!Visual.IsVisibleProperty] = new Binding(nameof(SplitBreakLongLinesItem.IsSelectable)),
+                            HorizontalAlignment = HorizontalAlignment.Center,
+                            VerticalAlignment = VerticalAlignment.Center,
+                        },
+                    }),
+                Width = new GridLength(70),
+            },
             new SeTableViewColumn
             {
                 Header = Se.Language.General.NumberSymbol,
@@ -259,7 +311,8 @@ public class SplitBreakLongLinesWindow : Window
         }, RoutingStrategies.Tunnel);
 
         grid.Add(labelFixesAvailable, 0);
-        grid.Add(UiUtil.MakeBorderForControlNoPadding(dataGrid), 1);
+        grid.Add(selectionButtons, 1);
+        grid.Add(UiUtil.MakeBorderForControlNoPadding(dataGrid), 2);
 
         return grid;
     }

--- a/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesWindow.cs
+++ b/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesWindow.cs
@@ -1,4 +1,3 @@
-using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using Avalonia.Media;
@@ -9,6 +8,7 @@ using Avalonia.Layout;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using System.Collections;
+using Avalonia;
 
 namespace Nikse.SubtitleEdit.Features.Tools.SplitBreakLongLines;
 
@@ -57,9 +57,9 @@ public class SplitBreakLongLinesWindow : Window
 
         Content = grid;
 
-        Activated += delegate { _checkBoxSplitLongLines.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        Activated += delegate { _checkBoxSplitLongLines.Focus(); };
         KeyDown += vm.KeyDown;
-        Loaded += (_, _)  => vm.Loaded();
+        Loaded += (_, _) => vm.Loaded();
 
         Closing += delegate { UiUtil.SaveWindowPosition(this); };
         Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
@@ -71,6 +71,7 @@ public class SplitBreakLongLinesWindow : Window
         {
             RowDefinitions =
             {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
@@ -87,20 +88,44 @@ public class SplitBreakLongLinesWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
-        var checkBoxSplitLongLines = UiUtil.MakeCheckBox(Se.Language.Tools.SplitBreakLongLines.SplitLongLines, vm, nameof(vm.SplitLongLines))
+        var checkBoxSplitLongLines = UiUtil.MakeCheckBox(
+                Se.Language.Tools.SplitBreakLongLines.SplitLongLines,
+                vm,
+                nameof(vm.SplitLongLines))
             .WithMarginRight(40);
         _checkBoxSplitLongLines = checkBoxSplitLongLines;
         checkBoxSplitLongLines.IsCheckedChanged += (s, e) => vm.SetChanged();
 
-        var checkBoxRebalanceLongLines = UiUtil.MakeCheckBox(Se.Language.Tools.SplitBreakLongLines.RebalanceLongLines, vm, nameof(vm.RebalanceLongLines))
+        var checkBoxRebalanceLongLines = UiUtil.MakeCheckBox(
+                Se.Language.Tools.SplitBreakLongLines.RebalanceLongLines,
+                vm,
+                nameof(vm.RebalanceLongLines))
             .WithMarginRight(40);
         checkBoxRebalanceLongLines.IsCheckedChanged += (s, e) => vm.SetChanged();
 
-        var checkBoxRebalanceOnlyTooLong = UiUtil.MakeCheckBox(Se.Language.Tools.SplitBreakLongLines.RebalanceOnlyLinesTooLong, vm, nameof(vm.RebalanceOnlyLinesTooLong))
+        var checkBoxRebalanceOnlyTooLong = UiUtil.MakeCheckBox(
+                Se.Language.Tools.SplitBreakLongLines.RebalanceOnlyLinesTooLong,
+                vm,
+                nameof(vm.RebalanceOnlyLinesTooLong))
             .WithMarginLeft(25)
             .WithMarginRight(40);
         checkBoxRebalanceOnlyTooLong[!InputElement.IsEnabledProperty] = new Binding(nameof(vm.RebalanceLongLines));
         checkBoxRebalanceOnlyTooLong.IsCheckedChanged += (s, e) => vm.SetChanged();
+
+        // Optional final pass: only when the user asks for it, also correct pre-existing
+        // short gaps across the complete subtitle. The value itself comes from the global
+        // Options -> Settings minimum-gap setting.
+        var checkBoxApplyMinimumGapToAll = UiUtil.MakeCheckBox(
+                "Apply minimum gap to all subtitles",
+                vm,
+                nameof(vm.ApplyMinimumGapToAllSubtitles))
+            .WithMarginLeft(25)
+            .WithMarginRight(40);
+        checkBoxApplyMinimumGapToAll[!InputElement.IsEnabledProperty] = new Binding(nameof(vm.SplitLongLines));
+        checkBoxApplyMinimumGapToAll.IsCheckedChanged += (s, e) => vm.SetChanged();
+        ToolTip.SetTip(
+            checkBoxApplyMinimumGapToAll,
+            "After splitting long lines, also apply the general minimum-gap setting to all subtitle gaps.");
 
         var labelSingleLineMaxLength = UiUtil.MakeLabel(Se.Language.Options.Settings.SingleLineMaxLength);
         var numericUpDownSingleLineMaxLength = UiUtil.MakeNumericUpDownInt(5, 1000, 10, 130, vm, nameof(vm.SingleLineMaxLength));
@@ -132,6 +157,8 @@ public class SplitBreakLongLinesWindow : Window
         grid.Add(labelUnbreakLinesShorterThan, 2, 1);
         grid.Add(numericUpDownUnbreakLinesShorterThan, 2, 2);
 
+        grid.Add(checkBoxApplyMinimumGapToAll, 3);
+
         return grid;
     }
 
@@ -158,8 +185,6 @@ public class SplitBreakLongLinesWindow : Window
             .WithMarginTop(10)
             .WithMarginLeft(10);
 
-        // Sorting dropped in the DataGrid -> TableView conversion: the grid previews
-        // split/rebalance fixes in subtitle order.
         var dataGrid = TableViewExtras.MakeTableView(multiSelect: false);
         dataGrid.Width = double.NaN;
         dataGrid.Height = double.NaN;
@@ -167,62 +192,59 @@ public class SplitBreakLongLinesWindow : Window
         dataGrid.ItemsSource = vm.Fixes;
         dataGrid.Columns.AddRange(new TableViewColumn[]
         {
-                new SeTableViewColumn
+            new SeTableViewColumn
+            {
+                Header = Se.Language.General.NumberSymbol,
+                Binding = new Binding(nameof(SplitBreakLongLinesItem.Number)),
+                CellTheme = UiUtil.TableViewCellTheme,
+                HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+                Width = new GridLength(60),
+            },
+            new SeTableViewColumn
+            {
+                Header = Se.Language.General.Name,
+                CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+                HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+                CellTemplate = new FuncDataTemplate<SplitBreakLongLinesItem>((item, _) =>
                 {
-                    Header = Se.Language.General.NumberSymbol,
-                    Binding = new Binding(nameof(SplitBreakLongLinesItem.Number)),
-                    CellTheme = UiUtil.TableViewCellTheme,
-                    HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
-                    // Content-sized (Auto) on the DataGrid; TableView treats Auto as star.
-                    Width = new GridLength(60),
-                },
-                new SeTableViewColumn
-                {
-                    Header = Se.Language.General.Name,
-                    CellTheme = UiUtil.TableViewNoPaddingCellTheme,
-                    HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
-                    CellTemplate = new FuncDataTemplate<SplitBreakLongLinesItem>((item, _) =>
+                    if (item == null)
                     {
-                        if (item == null)
-                        {
-                            return new Border();
-                        }
+                        return new Border();
+                    }
 
-                        var isSplit = item.Name == Se.Language.Tools.SplitBreakLongLines.SplitLongLine;
-                        var color = isSplit ? Color.FromRgb(0x5f, 0xc6, 0xd8) : Color.FromRgb(0xb4, 0x8c, 0xe8);
-                        return new Border
+                    var isSplit = item.Name == Se.Language.Tools.SplitBreakLongLines.SplitLongLine;
+                    var color = isSplit ? Color.FromRgb(0x5f, 0xc6, 0xd8) : Color.FromRgb(0xb4, 0x8c, 0xe8);
+                    return new Border
+                    {
+                        Background = Brushes.Transparent,
+                        Padding = new Thickness(4),
+                        Child = new Border
                         {
-                            Background = Brushes.Transparent,
-                            Padding = new Thickness(4),
-                            Child = new Border
+                            Background = new SolidColorBrush(Color.FromArgb(0x20, color.R, color.G, color.B)),
+                            CornerRadius = new CornerRadius(5),
+                            Padding = new Thickness(7, 2),
+                            HorizontalAlignment = HorizontalAlignment.Left,
+                            VerticalAlignment = VerticalAlignment.Center,
+                            Child = new TextBlock
                             {
-                                Background = new SolidColorBrush(Color.FromArgb(0x20, color.R, color.G, color.B)),
-                                CornerRadius = new CornerRadius(5),
-                                Padding = new Thickness(7, 2),
-                                HorizontalAlignment = HorizontalAlignment.Left,
+                                Text = item.Name,
+                                FontSize = 12,
+                                Foreground = new SolidColorBrush(color),
                                 VerticalAlignment = VerticalAlignment.Center,
-                                Child = new TextBlock
-                                {
-                                    Text = item.Name,
-                                    FontSize = 12,
-                                    Foreground = new SolidColorBrush(color),
-                                    VerticalAlignment = VerticalAlignment.Center,
-                                },
                             },
-                        };
-                    }),
-                    // Content-sized (Auto) on the DataGrid; fits the "Split long line" /
-                    // "Rebalance long line" pill.
-                    Width = new GridLength(150),
-                },
-                new SeTableViewColumn
-                {
-                    Header = Se.Language.General.Fix,
-                    Binding = new Binding(nameof(SplitBreakLongLinesItem.Fix)),
-                    Width = new GridLength(1, GridUnitType.Star),
-                    CellTheme = UiUtil.TableViewCellTheme,
-                    HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
-                },
+                        },
+                    };
+                }),
+                Width = new GridLength(150),
+            },
+            new SeTableViewColumn
+            {
+                Header = Se.Language.General.Fix,
+                Binding = new Binding(nameof(SplitBreakLongLinesItem.Fix)),
+                Width = new GridLength(1, GridUnitType.Star),
+                CellTheme = UiUtil.TableViewCellTheme,
+                HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            },
         });
 
         dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>

--- a/tests/UI/Features/Tools/ApplyMinGap/ApplyMinGapViewModelTests.cs
+++ b/tests/UI/Features/Tools/ApplyMinGap/ApplyMinGapViewModelTests.cs
@@ -1,0 +1,26 @@
+using Nikse.SubtitleEdit.Features.Tools.ApplyMinGap;
+using Xunit;
+
+namespace UITests.Features.Tools.ApplyMinGap;
+
+public class ApplyMinGapViewModelTests
+{
+    [Theory]
+    [InlineData(200.0, 200.0, false)]
+    [InlineData(199.0, 200.0, false)]
+    [InlineData(195.0, 200.0, false)]
+    [InlineData(190.0, 200.0, false)]
+    [InlineData(189.9, 200.0, true)]
+    [InlineData(180.0, 200.0, true)]
+    public void NeedsGapAdjustment_UsesTenMillisecondTolerance(
+        double currentGapMs,
+        double minimumGapMs,
+        bool expected)
+    {
+        var actual = ApplyMinGapViewModel.NeedsGapAdjustment(
+            currentGapMs,
+            minimumGapMs);
+
+        Assert.Equal(expected, actual);
+    }
+}

--- a/tests/UI/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModelTests.cs
+++ b/tests/UI/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModelTests.cs
@@ -128,6 +128,38 @@ public class SplitBreakLongLinesViewModelTests
     }
 
     [Fact]
+    public void Split_MultipleEvents_UsesConfiguredMinimumGapAndPreservesOuterTimeCodes()
+    {
+        var subtitle = MakeSubtitle(
+            "This subtitle contains much too much text to fit inside only two lines " +
+            "with a maximum length of thirty-six characters and therefore needs " +
+            "to become more than one subtitle event.");
+
+        const double minimumGapMs = 120;
+
+        var result = SplitBreakLongLinesViewModel.Split(
+            subtitle,
+            MaxSubtitleLength,
+            MaxLineLength,
+            "en",
+            makeCompliant: true,
+            minimumGapMs);
+
+        Assert.True(result.Count >= 2);
+        Assert.Equal(subtitle.StartTime, result[0].StartTime);
+        Assert.Equal(subtitle.EndTime, result[^1].EndTime);
+
+        for (var i = 1; i < result.Count; i++)
+        {
+            var actualGapMs =
+                result[i].StartTime.TotalMilliseconds -
+                result[i - 1].EndTime.TotalMilliseconds;
+
+            Assert.Equal(minimumGapMs, actualGapMs, 1);
+        }
+    }
+
+    [Fact]
     public void Split_LegacyMode_DoesNotAutoBalanceSingleLine()
     {
         var subtitle = MakeSubtitle(

--- a/tests/UI/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModelTests.cs
+++ b/tests/UI/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModelTests.cs
@@ -1,0 +1,144 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Tools.SplitBreakLongLines;
+using System;
+using Xunit;
+
+namespace UITests.Features.Tools.SplitBreakLongLines;
+
+public class SplitBreakLongLinesViewModelTests
+{
+    private const int MaxLineLength = 36;
+    private const int MaxSubtitleLength = 72;
+
+    private static SubtitleLineViewModel MakeSubtitle(string text) =>
+        new()
+        {
+            Text = text,
+            StartTime = TimeSpan.FromSeconds(10),
+            EndTime = TimeSpan.FromSeconds(14),
+        };
+
+    [Fact]
+    public void Split_CompliantSingleLine_RemainsUnchanged()
+    {
+        var subtitle = MakeSubtitle("This line is valid.");
+
+        var result = SplitBreakLongLinesViewModel.Split(
+            subtitle,
+            MaxSubtitleLength,
+            MaxLineLength,
+            "en",
+            makeCompliant: true);
+
+        Assert.Single(result);
+        Assert.Equal(subtitle.Text, result[0].Text);
+    }
+
+    [Fact]
+    public void Split_OverlongSingleLineWithinCapacity_BecomesBalancedTwoLineSubtitle()
+    {
+        var subtitle = MakeSubtitle(
+            "This is an overlong subtitle line that can easily fit into two lines.");
+
+        var result = SplitBreakLongLinesViewModel.Split(
+            subtitle,
+            MaxSubtitleLength,
+            MaxLineLength,
+            "en",
+            makeCompliant: true);
+
+        Assert.Single(result);
+        var textLines = result[0].Text.SplitToLines();
+        Assert.Equal(2, textLines.Count);
+        Assert.All(textLines, line => Assert.True(line.Length <= MaxLineLength));
+        Assert.Equal(subtitle.StartTime, result[0].StartTime);
+        Assert.Equal(subtitle.EndTime, result[0].EndTime);
+    }
+
+    [Fact]
+    public void Split_OverlongSingleLineThatCannotFitInOneEvent_CreatesMultipleEvents()
+    {
+        var subtitle = MakeSubtitle(
+            "This subtitle contains much too much text to fit inside only two lines " +
+            "with a maximum length of thirty-six characters and therefore needs " +
+            "to become more than one subtitle event.");
+
+        var result = SplitBreakLongLinesViewModel.Split(
+            subtitle,
+            MaxSubtitleLength,
+            MaxLineLength,
+            "en",
+            makeCompliant: true);
+
+        Assert.True(result.Count >= 2);
+        Assert.Equal(subtitle.StartTime, result[0].StartTime);
+        Assert.Equal(subtitle.EndTime, result[^1].EndTime);
+        foreach (var item in result)
+        {
+            foreach (var line in item.Text.SplitToLines())
+            {
+                Assert.True(line.Length <= MaxLineLength);
+            }
+        }
+    }
+
+    [Fact]
+    public void Split_TwoLineSubtitleWithOverlongLine_CreatesTwoCompliantEvents()
+    {
+        var subtitle = MakeSubtitle(
+            "Und, war ich in der Kantine?" + Environment.NewLine +
+            "Nein, ich konnte Sie dort nicht finden.");
+
+        var result = SplitBreakLongLinesViewModel.Split(
+            subtitle,
+            MaxSubtitleLength,
+            MaxLineLength,
+            "de",
+            makeCompliant: true);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(subtitle.StartTime, result[0].StartTime);
+        Assert.Equal(subtitle.EndTime, result[^1].EndTime);
+        foreach (var item in result)
+        {
+            foreach (var line in item.Text.SplitToLines())
+            {
+                Assert.True(line.Length <= MaxLineLength);
+            }
+        }
+    }
+
+    [Fact]
+    public void Split_CompliantUnbalancedTwoLineSubtitle_RemainsUnchanged()
+    {
+        var subtitle = MakeSubtitle(
+            "This is intentionally longer" + Environment.NewLine +
+            "short.");
+
+        var result = SplitBreakLongLinesViewModel.Split(
+            subtitle,
+            MaxSubtitleLength,
+            MaxLineLength,
+            "en",
+            makeCompliant: true);
+
+        Assert.Single(result);
+        Assert.Equal(subtitle.Text, result[0].Text);
+    }
+
+    [Fact]
+    public void Split_LegacyMode_DoesNotAutoBalanceSingleLine()
+    {
+        var subtitle = MakeSubtitle(
+            "This is an overlong subtitle line that can easily fit into two lines.");
+
+        var result = SplitBreakLongLinesViewModel.Split(
+            subtitle,
+            MaxSubtitleLength,
+            MaxLineLength);
+
+        Assert.Single(result);
+        Assert.Equal(subtitle.Text, result[0].Text);
+    }
+}

--- a/tests/UI/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModelTests.cs
+++ b/tests/UI/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModelTests.cs
@@ -2,6 +2,8 @@ using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Tools.SplitBreakLongLines;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace UITests.Features.Tools.SplitBreakLongLines;
@@ -10,6 +12,103 @@ public class SplitBreakLongLinesViewModelTests
 {
     private const int MaxLineLength = 36;
     private const int MaxSubtitleLength = 72;
+
+    [Fact]
+    public void RenumberSubtitles_AfterSplit_RemovesDuplicateNumbers()
+    {
+        var subtitles = new List<SubtitleLineViewModel>
+        {
+            MakeSubtitle("One."),
+            MakeSubtitle("First half of former subtitle twelve."),
+            MakeSubtitle("Second half of former subtitle twelve."),
+            MakeSubtitle("Next subtitle."),
+        };
+
+        subtitles[0].Number = 11;
+        subtitles[1].Number = 12;
+        subtitles[2].Number = 12;
+        subtitles[3].Number = 13;
+
+        SplitBreakLongLinesViewModel.RenumberSubtitles(subtitles);
+
+        Assert.Equal(new[] { 1, 2, 3, 4 }, subtitles.Select(p => p.Number).ToArray());
+    }
+
+    [Fact]
+    public void RebalanceFix_CanBeDeselectedAndRestoresOriginalText()
+    {
+        var subtitle = MakeSubtitle("This is the original subtitle text.");
+        var fix = new SplitBreakLongLinesItem(
+            "Rebalance",
+            1,
+            "preview",
+            subtitle,
+            isSelectable: true,
+            proposedText: "This is the proposed subtitle text.");
+
+        Assert.True(fix.IsSelected);
+        Assert.Equal("This is the proposed subtitle text.", subtitle.Text);
+
+        fix.IsSelected = false;
+        Assert.Equal("This is the original subtitle text.", subtitle.Text);
+
+        fix.IsSelected = true;
+        Assert.Equal("This is the proposed subtitle text.", subtitle.Text);
+    }
+
+    [Fact]
+    public void SelectAllAndDeselectAll_AffectOnlySelectableRebalanceFixes()
+    {
+        var vm = new SplitBreakLongLinesViewModel();
+
+        var rebalanceSubtitle1 = MakeSubtitle("Original one.");
+        var rebalanceSubtitle2 = MakeSubtitle("Original two.");
+        var splitSubtitle = MakeSubtitle("Split item.");
+
+        var rebalance1 = new SplitBreakLongLinesItem(
+            "Rebalance",
+            1,
+            "preview",
+            rebalanceSubtitle1,
+            isSelectable: true,
+            proposedText: "Changed one.");
+
+        var rebalance2 = new SplitBreakLongLinesItem(
+            "Rebalance",
+            2,
+            "preview",
+            rebalanceSubtitle2,
+            isSelectable: true,
+            proposedText: "Changed two.");
+
+        var split = new SplitBreakLongLinesItem(
+            "Split",
+            3,
+            "preview",
+            splitSubtitle);
+
+        vm.Fixes.Add(rebalance1);
+        vm.Fixes.Add(rebalance2);
+        vm.Fixes.Add(split);
+
+        vm.DeselectAllRebalancesCommand.Execute(null);
+
+        Assert.False(rebalance1.IsSelected);
+        Assert.False(rebalance2.IsSelected);
+        Assert.True(split.IsSelected);
+        Assert.Equal("Original one.", rebalanceSubtitle1.Text);
+        Assert.Equal("Original two.", rebalanceSubtitle2.Text);
+
+        vm.SelectAllRebalancesCommand.Execute(null);
+
+        Assert.True(rebalance1.IsSelected);
+        Assert.True(rebalance2.IsSelected);
+        Assert.True(split.IsSelected);
+        Assert.Equal("Changed one.", rebalanceSubtitle1.Text);
+        Assert.Equal("Changed two.", rebalanceSubtitle2.Text);
+
+        vm.OnClosingCleanup();
+    }
 
     private static SubtitleLineViewModel MakeSubtitle(string text) =>
         new()
@@ -157,6 +256,130 @@ public class SplitBreakLongLinesViewModelTests
 
             Assert.Equal(minimumGapMs, actualGapMs, 1);
         }
+    }
+
+    [Fact]
+    public void Split_BottomAnchoredTwoLineSubtitle_FirstNewSingleLineMovesFrom21To23()
+    {
+        var subtitle = MakeSubtitle(
+            "Und, war ich in der Kantine?" + Environment.NewLine +
+            "Nein, ich konnte Sie dort wirklich überhaupt nicht finden.");
+        subtitle.MarginV = "21";
+
+        var result = SplitBreakLongLinesViewModel.Split(
+            subtitle,
+            MaxSubtitleLength,
+            MaxLineLength,
+            "de",
+            makeCompliant: true);
+
+        Assert.Equal(2, result.Count);
+        Assert.Single(result[0].Text.SplitToLines());
+        Assert.Equal("23", result[0].MarginV);
+
+        Assert.Equal(2, result[1].Text.SplitToLines().Count);
+        Assert.Equal("21", result[1].MarginV);
+    }
+
+    [Fact]
+    public void Split_TwoLineSubtitleHigherUp_FirstNewSingleLineMovesFrom19To21()
+    {
+        var subtitle = MakeSubtitle(
+            "Und, war ich in der Kantine?" + Environment.NewLine +
+            "Nein, ich konnte Sie dort wirklich überhaupt nicht finden.");
+        subtitle.MarginV = "19";
+
+        var result = SplitBreakLongLinesViewModel.Split(
+            subtitle,
+            MaxSubtitleLength,
+            MaxLineLength,
+            "de",
+            makeCompliant: true);
+
+        Assert.Equal(2, result.Count);
+        Assert.Single(result[0].Text.SplitToLines());
+        Assert.Equal("21", result[0].MarginV);
+        Assert.Equal(2, result[1].Text.SplitToLines().Count);
+        Assert.Equal("19", result[1].MarginV);
+    }
+
+    [Fact]
+    public void Split_TwoLineSubtitleOnEvenRaster_FirstNewSingleLineMovesFrom20To22()
+    {
+        var subtitle = MakeSubtitle(
+            "Und, war ich in der Kantine?" + Environment.NewLine +
+            "Nein, ich konnte Sie dort wirklich überhaupt nicht finden.");
+        subtitle.MarginV = "20";
+
+        var result = SplitBreakLongLinesViewModel.Split(
+            subtitle,
+            MaxSubtitleLength,
+            MaxLineLength,
+            "de",
+            makeCompliant: true);
+
+        Assert.Equal(2, result.Count);
+        Assert.Single(result[0].Text.SplitToLines());
+        Assert.Equal("22", result[0].MarginV);
+        Assert.Equal(2, result[1].Text.SplitToLines().Count);
+        Assert.Equal("20", result[1].MarginV);
+    }
+
+    [Fact]
+    public void Split_BottomAnchoredSingleLineBecomingTwoLines_MovesFrom23To21()
+    {
+        var subtitle = MakeSubtitle(
+            "This single line is too long and must wrap into two lines.");
+        subtitle.MarginV = "23";
+
+        var result = SplitBreakLongLinesViewModel.Split(
+            subtitle,
+            MaxSubtitleLength,
+            MaxLineLength,
+            "en",
+            makeCompliant: true);
+
+        Assert.Single(result);
+        Assert.Equal(2, result[0].Text.SplitToLines().Count);
+        Assert.Equal("21", result[0].MarginV);
+    }
+
+    [Fact]
+    public void Split_SingleLineHigherUpBecomingTwoLines_MovesFrom21To19()
+    {
+        var subtitle = MakeSubtitle(
+            "This single line is too long and must wrap into two lines.");
+        subtitle.MarginV = "21";
+
+        var result = SplitBreakLongLinesViewModel.Split(
+            subtitle,
+            MaxSubtitleLength,
+            MaxLineLength,
+            "en",
+            makeCompliant: true);
+
+        Assert.Single(result);
+        Assert.Equal(2, result[0].Text.SplitToLines().Count);
+        Assert.Equal("19", result[0].MarginV);
+    }
+
+    [Fact]
+    public void Split_SingleLineOnEvenRasterBecomingTwoLines_MovesFrom22To20()
+    {
+        var subtitle = MakeSubtitle(
+            "This single line is too long and must wrap into two lines.");
+        subtitle.MarginV = "22";
+
+        var result = SplitBreakLongLinesViewModel.Split(
+            subtitle,
+            MaxSubtitleLength,
+            MaxLineLength,
+            "en",
+            makeCompliant: true);
+
+        Assert.Single(result);
+        Assert.Equal(2, result[0].Text.SplitToLines().Count);
+        Assert.Equal("20", result[0].MarginV);
     }
 
     [Fact]


### PR DESCRIPTION
This PR improves the Split/Break long lines workflow, especially for broadcast and Teletext subtitle editing.

Main changes:

- Split long subtitles into compliant subtitle events
- Rebalance split results locally so line length limits are respected
- Keep intentionally unbalanced subtitles unchanged when they already fit
- Allow rebalancing only subtitles that actually exceed the configured limits
- Add selective Rebalance with Apply checkboxes and Select all / Deselect all
- Distribute timing proportionally when a subtitle is split
- Respect the configured minimum gap between newly created subtitles
- Add an option to apply the global minimum gap to the whole subtitle file
- Add a 10 ms tolerance to minimum-gap comparisons to avoid no-op corrections
- Adjust Teletext row positions relatively when the number of text lines changes
  (for example 21↔23, 19↔21, 20↔22 for double-height Teletext)
- Automatically renumber subtitles after splitting to avoid duplicate numbers
- Add a direct EBU STL Header/Export button next to the format selector
- Add unit tests for Split/Break long lines and minimum-gap handling

The intention is to make Split long lines a more complete one-pass correction workflow:
splitting, local line balancing, timing, gaps, Teletext positioning and subtitle numbering are handled together where applicable.

The branch was rebased onto v5.2.0-beta21 and the related UI tests pass.