### PR TITLE
Hold the scroll anchor still while the reference projection rebuilds

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -2816,6 +2816,20 @@ public partial class MainViewModel :
 
         var original = _subtitleOriginal;
         _reapplyingReadOnlyReference = true;
+
+        // The rebuild below rewrites the row collection one row at a time - display-only rows are
+        // removed, re-inserted and glided back into order. Every one of those raises a collection
+        // change, the virtualizing panel re-estimates its extent, and TableViewScrollAnchor reads
+        // that as "the panel moved under the view" and restores the anchor: PrePositionScroll, a
+        // ScrollIntoView and up to three synchronous UpdateLayout passes, each time. A merge that
+        // brings a handful of reference rows back therefore paid for that handful of full restores
+        // in a row, which is the slow scroll up and back down after merging (issues #13962,
+        // #14003). Suspending the anchor for the whole rebuild leaves it following the view - it
+        // just stops moving it - so the burst costs one settle at the end instead of N.
+        using var anchorSuspended = SubtitleGrid is { } grid
+            ? TableViewScrollAnchor.GetFor(grid)?.Suspend()
+            : null;
+
         try
         {
             // Which original line each id belongs to. Ids are unique per file; claimed lines are

--- a/tests/UI/Features/Main/ReferenceRebuildScrollAnchorTests.cs
+++ b/tests/UI/Features/Main/ReferenceRebuildScrollAnchorTests.cs
@@ -1,0 +1,163 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Main.MainHelpers;
+using Nikse.SubtitleEdit.Logic;
+using System;
+using System.Collections.Specialized;
+using System.Reflection;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// Rebuilding the read-only reference projection churns the row collection: display-only rows are
+/// removed, brought back and glided into order, one row at a time. Each of those makes the
+/// virtualizing panel re-estimate its extent, which <see cref="TableViewScrollAnchor"/> reads as
+/// "the panel moved under the view" and answers with a full restore - PrePositionScroll, a
+/// ScrollIntoView and up to three synchronous layout passes.
+///
+/// Paying that per row is the slow scroll up and back down after merging that survived the #13962
+/// fix and was reported again as #14003. The rebuild therefore suspends the anchor for its whole
+/// run: it keeps following the view, it just stops moving it, so the burst settles once at the end.
+/// </summary>
+public class ReferenceRebuildScrollAnchorTests
+{
+    [AvaloniaFact]
+    public void ReferenceRebuild_SuspendsTheScrollAnchorWhileTheRowsChurn()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Translated one", "Reference one", 0, 2000);
+            AddLine(vm, "Translated two", "Reference two", 4000, 6000);
+            vm.ShowColumnOriginalText = true;
+            ImportReference(vm, BuildSampleReference());
+            Dispatcher.UIThread.RunJobs();
+
+            var anchor = TableViewScrollAnchor.GetFor(vm.SubtitleGrid);
+            Assert.NotNull(anchor);
+
+            // Watch the suspend count at the exact moment the rows move.
+            var sawChurn = false;
+            var suspendedThroughout = true;
+            void OnChanged(object? _, NotifyCollectionChangedEventArgs __)
+            {
+                sawChurn = true;
+                if (SuspendCountOf(anchor!) == 0)
+                {
+                    suspendedThroughout = false;
+                }
+            }
+
+            // Drop a row the reference still has a line for, so the rebuild has to bring it back
+            // as a display-only row - that re-insert is the churn under test. Done before the
+            // handler is attached: this removal is the test's own setup, not part of the rebuild.
+            vm.Subtitles.RemoveAt(1);
+
+            vm.Subtitles.CollectionChanged += OnChanged;
+            try
+            {
+                InvokeReapplyOriginalReference(vm);
+            }
+            finally
+            {
+                vm.Subtitles.CollectionChanged -= OnChanged;
+            }
+
+            Assert.True(sawChurn, "the rebuild did not touch the row collection, so nothing was measured");
+            Assert.True(suspendedThroughout, "the scroll anchor was live while the reference rebuild moved rows");
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    // The suspension must not leak: once the rebuild is done the anchor has to be doing its job
+    // again, or ordinary editing stops holding the view steady (#13619).
+    [AvaloniaFact]
+    public void ReferenceRebuild_ReleasesTheAnchorAfterwards()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Translated one", "Reference one", 0, 2000);
+            AddLine(vm, "Translated two", "Reference two", 4000, 6000);
+            vm.ShowColumnOriginalText = true;
+            ImportReference(vm, BuildSampleReference());
+            Dispatcher.UIThread.RunJobs();
+
+            var anchor = TableViewScrollAnchor.GetFor(vm.SubtitleGrid);
+            Assert.NotNull(anchor);
+
+            vm.Subtitles.RemoveAt(1);
+            InvokeReapplyOriginalReference(vm);
+            InvokeReapplyOriginalReference(vm); // twice: a leak would stack
+
+            Assert.Equal(0, SuspendCountOf(anchor!));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    private static int SuspendCountOf(TableViewScrollAnchor anchor) =>
+        (int)typeof(TableViewScrollAnchor)
+            .GetField("_suspendCount", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(anchor)!;
+
+    private static void InvokeReapplyOriginalReference(MainViewModel vm) =>
+        typeof(MainViewModel)
+            .GetMethod("ReapplyOriginalReference", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(vm, new object?[] { true });
+
+    private static void ImportReference(MainViewModel vm, Subtitle reference)
+    {
+        var match = ImportOriginalHelper.MatchOriginalLines(vm.Subtitles, reference);
+        typeof(MainViewModel)
+            .GetMethod("ImportOriginalSubtitle", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(vm, new object?[] { 0, "reference.srt", reference, match, true });
+    }
+
+    private static Subtitle BuildSampleReference()
+    {
+        var reference = new Subtitle();
+        reference.Paragraphs.Add(new Paragraph("Reference one", 0, 2000));
+        reference.Paragraphs.Add(new Paragraph("Reference only - no translation", 2000, 4000));
+        reference.Paragraphs.Add(new Paragraph("Reference two", 4000, 6000));
+        return reference;
+    }
+
+    private static SubtitleLineViewModel AddLine(MainViewModel vm, string text, string originalText, int startMs, int endMs)
+    {
+        var line = new SubtitleLineViewModel(new Paragraph(text, startMs, endMs), null!)
+        {
+            OriginalText = originalText,
+            Number = vm.Subtitles.Count + 1,
+        };
+
+        vm.Subtitles.Add(line);
+        return line;
+    }
+
+    private static (Window Window, MainViewModel Vm) CreateMainViewModel()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1200, Height = 800 };
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        return (window, (MainViewModel)view.DataContext!);
+    }
+}


### PR DESCRIPTION
Fixes #14003 (follow-up to #13962)

The reporter confirms your #13962 fix landed the focus and selection half — "the focus now stays where it should be and the shortcuts work like they should" — but merging still "scrolls slowly up and then down again", and the grid is unusable until it stops.

That is the other half of the mechanism I traced on #13962, and it is still present.

## What happens

`ReapplyOriginalReference` rewrites the row collection **one row at a time**: display-only rows are removed (`Subtitles.RemoveAt`), brought back (`Subtitles.Insert`), and glided into order (remove + insert pairs). Every one of those raises a collection change → the virtualizing panel re-estimates its extent → `TableViewScrollAnchor` sees an extent change with no offset change, reads it as "the panel moved under the view", and answers with a full restore: `PrePositionScroll`, a `ScrollIntoView`, up to three synchronous `UpdateLayout` passes, and an O(n) `ItemsView.IndexOf`.

A merge that brings a handful of reference rows back pays for a handful of those back to back. That is the slow scroll, and it is why it gets worse the more you have merged — each merge orphans another original line, so the next rebuild moves more rows.

## The change

Suspend the anchor for the duration of the rebuild. `Suspend()` exists for exactly this — its own docs say "deliberate multi-pass scrolling … an anchor restore in the middle of that would fight it" — and `TableViewIndexScrollBar` already uses it that way. The anchor keeps *following* the view throughout; it just stops *moving* it, so the burst settles once at the end instead of N times.

Fourteen lines, all inside `ReapplyOriginalReference`.

## Testing

2 new tests: the anchor's suspend count is non-zero at the moment each row actually moves (hooked on `CollectionChanged` during the rebuild), and the suspension does not leak — two rebuilds in a row leave the count back at 0, so ordinary editing still gets the #13619 anchoring.

Full UI suite: **3403 passed, 0 failed**.

**One caveat on verification.** I did not do my usual "revert the fix and watch the tests fail" run — this machine is currently taking ~18 minutes per build and the round trip was not worth it. The negative case rests on two things instead: `grep` confirms nothing else suspends the anchor during the rebuild, and an earlier revision of the test that attached its listener a moment too early failed with exactly this assertion, which shows the counter does read 0 when nothing has suspended it. Happy to run the clean revert if you would rather have it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
