### PR TITLE
Fix #14005: independent "Use external server" toggle for llama.cpp in Batch Convert

### DIFF
--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -176,6 +176,8 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
     [ObservableProperty] private ObservableCollection<LlamaCppModelDisplay> _llamaCppModels = new();
     [ObservableProperty] private LlamaCppModelDisplay? _selectedLlamaCppModel;
     [ObservableProperty] private bool _llamaCppModelComboIsVisible;
+    [ObservableProperty] private bool _llamaCppRemoteToggleIsVisible;
+    [ObservableProperty] private bool _llamaCppUseRemoteServer;
 
     /// <summary>
     /// Re-assigns the auto-translate engine combo's item template, set by the view. The dots are a
@@ -561,7 +563,7 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
     {
         return config.AutoTranslate.IsActive &&
                config.AutoTranslate.Translator is LlamaCppTranslate or LlamaCppAdvancedTranslate &&
-               !Se.Settings.AutoTranslate.LlamaCppUseRemoteServer;
+               !Se.Settings.Tools.BatchConvert.LlamaCppUseRemoteServer;
     }
 
     private void UpdateFilteredFiles()
@@ -666,6 +668,7 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         Se.Settings.Tools.BatchConvert.AutoTranslateEngine = SelectedAutoTranslator.Name;
         Se.Settings.Tools.BatchConvert.AutoTranslateSourceLanguage = SelectedSourceLanguage?.TwoLetterIsoLanguageName ?? "auto";
         Se.Settings.Tools.BatchConvert.AutoTranslateTargetLanguage = SelectedTargetLanguage?.TwoLetterIsoLanguageName ?? "en";
+        Se.Settings.Tools.BatchConvert.LlamaCppUseRemoteServer = LlamaCppUseRemoteServer;
 
         // Change casing
         if (NormalCasing)
@@ -1444,11 +1447,11 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
             return true;
         }
 
-        // Remote mode: the user pointed llama.cpp at their own running llama-server. Detect it the same
-        // way the interactive Auto-translate window does - via the LlamaCppUseRemoteServer flag - not by
-        // whether AutoTranslateUrl is set, since that is pre-filled with the default localhost URL and so
-        // is never empty (which previously short-circuited the whole auto-start path).
-        if (Se.Settings.AutoTranslate.LlamaCppUseRemoteServer)
+        // Remote mode: the user pointed llama.cpp at their own running llama-server. Detect it via
+        // batch convert's own LlamaCppUseRemoteServer flag (#14005) - not by whether AutoTranslateUrl
+        // is set, since that is pre-filled with the default localhost URL and so is never empty
+        // (which previously short-circuited the whole auto-start path).
+        if (LlamaCppUseRemoteServer)
         {
             return true;
         }
@@ -2880,13 +2883,18 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
 
         if (engineType == typeof(LlamaCppTranslate) || engineType == typeof(LlamaCppAdvancedTranslate))
         {
-            if (!string.IsNullOrEmpty(AutoTranslateUrl.Trim()))
+            // Only the external server takes its URL from the text box; in local mode the URL is
+            // owned by LlamaCppServerManager, which points LlamaCppApiUrl at the server it starts.
+            if (LlamaCppUseRemoteServer)
             {
-                Configuration.Settings.Tools.LlamaCppApiUrl = AutoTranslateUrl.Trim();
-            }
-            else if (!string.IsNullOrEmpty(Se.Settings.AutoTranslate.LlamaCppApiUrl))
-            {
-                Configuration.Settings.Tools.LlamaCppApiUrl = Se.Settings.AutoTranslate.LlamaCppApiUrl;
+                var apiUrl = AutoTranslateUrl.Trim();
+                if (string.IsNullOrEmpty(apiUrl))
+                {
+                    apiUrl = LlamaCppTranslate.DefaultUrl;
+                }
+
+                Configuration.Settings.Tools.LlamaCppApiUrl = apiUrl;
+                Se.Settings.AutoTranslate.LlamaCppApiUrl = apiUrl;
             }
         }
 
@@ -3076,6 +3084,22 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         Se.Settings.AutoTranslate.LlamaCppModel = LlamaCppServerManager.GetModelPath(value.Model.FileName);
     }
 
+    private bool _suppressLlamaCppRemoteToggle;
+
+    partial void OnLlamaCppUseRemoteServerChanged(bool value)
+    {
+        if (_suppressLlamaCppRemoteToggle)
+        {
+            return;
+        }
+
+        Se.Settings.Tools.BatchConvert.LlamaCppUseRemoteServer = value;
+        if (SelectedAutoTranslator is LlamaCppTranslate or LlamaCppAdvancedTranslate)
+        {
+            PopulateLlamaCppModels();
+        }
+    }
+
     /// <summary>
     /// Fills the llama.cpp model combo and pre-selects the last-used model, or hides the combo when
     /// a remote server is configured (it serves whatever model it was started with). Re-filling the
@@ -3083,11 +3107,12 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
     /// </summary>
     private void PopulateLlamaCppModels()
     {
-        if (Se.Settings.AutoTranslate.LlamaCppUseRemoteServer)
+        if (LlamaCppUseRemoteServer)
         {
-            // Nothing local to pick or install - the remote server owns both.
+            // Nothing local to pick or install - the remote server owns both; the user just edits the URL.
             LlamaCppModelComboIsVisible = false;
             LlamaCppEngineSettingsButtonIsVisible = false;
+            AutoTranslateUrlIsVisible = true;
             LlamaCppModels.Clear();
             SelectedLlamaCppModel = null;
             return;
@@ -3095,6 +3120,7 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
 
         LlamaCppModelComboIsVisible = true;
         LlamaCppEngineSettingsButtonIsVisible = true;
+        AutoTranslateUrlIsVisible = false;
         var savedModelName = Path.GetFileName(Se.Settings.AutoTranslate.LlamaCppModel ?? string.Empty);
         SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, GetLlamaCppModelsForEngine(), savedModelName);
     }
@@ -3121,6 +3147,10 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         // Both turned back on by PopulateLlamaCppModels for a local llama.cpp.
         LlamaCppModelComboIsVisible = false;
         LlamaCppEngineSettingsButtonIsVisible = false;
+
+        // Batch convert has its own local/external switch for llama.cpp (#14005), so checking
+        // "use external server" in the Auto-translate window no longer leaks into batch runs.
+        LlamaCppRemoteToggleIsVisible = engine is LlamaCppTranslate or LlamaCppAdvancedTranslate;
 
         // Batch size, context history and the synopsis/glossary/style prompt only exist on the
         // advanced engine; they apply to local and remote llama-servers alike.
@@ -3179,12 +3209,14 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
             AutoTranslateModelBrowseIsVisible = false;
             AutoTranslateModelIsVisible = false;
             AutoTranslateUrl = Se.Settings.AutoTranslate.LlamaCppApiUrl;
-            AutoTranslateUrlIsVisible = true;
             AutoTranslateApiKey = string.Empty;
             AutoTranslateApiKeyIsVisible = false;
 
-            // A remote server serves whatever model it was started with, so there is nothing to pick
-            // here - same as in the Auto-translate window, which owns that toggle.
+            // Local vs. external server: the URL field is only shown for an external server, and a
+            // remote server serves whatever model it was started with, so the model combo hides.
+            _suppressLlamaCppRemoteToggle = true;
+            LlamaCppUseRemoteServer = Se.Settings.Tools.BatchConvert.LlamaCppUseRemoteServer;
+            _suppressLlamaCppRemoteToggle = false;
             PopulateLlamaCppModels();
         }
         else if (engine is NoLanguageLeftBehindServe)

--- a/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewAutoTranslate.cs
+++ b/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewAutoTranslate.cs
@@ -83,10 +83,17 @@ public static class ViewAutoTranslate
             ToolTip.SetTip(buttonAdvanced, Se.Language.Translate.AdvancedSettings);
         }
 
+        // Batch convert's own local/external llama-server switch (#14005) - independent of the one
+        // in the Auto-translate window. Shown only for the llama.cpp engines.
+        var checkBoxLlamaCppRemote = UiUtil.MakeCheckBox(Se.Language.General.LlamaCppUseRemoteServer, vm, nameof(vm.LlamaCppUseRemoteServer))
+            .WithMarginLeft(10);
+        checkBoxLlamaCppRemote.Bind(CheckBox.IsVisibleProperty, new Binding(nameof(vm.LlamaCppRemoteToggleIsVisible)));
+
         var panelEngineControls = UiUtil.MakeHorizontalPanel(
             cbEngines,
             buttonEngineSettings,
-            buttonAdvanced);
+            buttonAdvanced,
+            checkBoxLlamaCppRemote);
 
         // Prompt and the shared request settings for the regular llama.cpp engine (the advanced
         // engine has its own window instead). Right-aligned and away from the engine gear, the same

--- a/src/ui/Logic/Config/SeBatchConvert.cs
+++ b/src/ui/Logic/Config/SeBatchConvert.cs
@@ -85,6 +85,13 @@ public class SeBatchConvert
     public string AutoTranslateSourceLanguage { get; set; }
     public string AutoTranslateTargetLanguage { get; set; }
 
+    /// <summary>
+    /// Batch convert's own "use external server" switch for the llama.cpp engines - independent of
+    /// the Auto-translate window's <see cref="SeAutoTranslate.LlamaCppUseRemoteServer"/> (#14005).
+    /// The server URL itself is shared via <see cref="SeAutoTranslate.LlamaCppApiUrl"/>.
+    /// </summary>
+    public bool LlamaCppUseRemoteServer { get; set; }
+
     public string ChangeCasingType { get; set; }
     public bool NormalCasingFixNames { get; set; }
     public bool NormalCasingOnlyUpper { get; set; }


### PR DESCRIPTION
Fixes #14005

Batch convert read the Auto-translate window's `LlamaCppUseRemoteServer` flag, so checking "Use external server (URL)" in the main window also forced batch-convert translations onto the external server.

- New `SeBatchConvert.LlamaCppUseRemoteServer` setting + checkbox on the engine row of the batch-convert Auto-translate view (shown for the two llama.cpp engines). Defaults to off; no migration from the main-window flag.
- Auto-start/stop of the local llama-server and the model combo now key off the batch flag.
- URL field is only shown in external mode (local mode is server-managed, same as the Auto-translate window); in external mode the text-box URL is used and saved to the shared `LlamaCppApiUrl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)