### PR TITLE
Fix #14004: retry Google Translate V1 on transient 5xx/429 responses

### DIFF
--- a/src/libuilogic/AutoTranslate/GoogleTranslateV1.cs
+++ b/src/libuilogic/AutoTranslate/GoogleTranslateV1.cs
@@ -55,9 +55,26 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
                 var text = input.Replace("\r", string.Empty).Trim();
                 var url = $"translate_a/single?client=gtx&sl={sourceLanguageCode}&tl={targetLanguageCode}&dt=t&q={Utilities.UrlEncode(text)}";
 
-                var result = await _httpClient.GetAsync(url, cancellationToken);
-                var bytes = await result.Content.ReadAsByteArrayAsync(cancellationToken);
-                jsonResultString = Encoding.UTF8.GetString(bytes).Trim();
+                // The free "gtx" endpoint intermittently answers 500/502/503/504 (and 429) mid-run
+                // on long translations; a single failure aborted the whole job and the user had to
+                // restart it by hand (issue #14004). Retry with a short backoff before giving up.
+                int[] retryDelays = { 1007, 3013, 7019 };
+                HttpResponseMessage result = null!;
+                jsonResultString = string.Empty;
+                for (var attempt = 0; attempt <= retryDelays.Length; attempt++)
+                {
+                    result = await _httpClient.GetAsync(url, cancellationToken);
+                    var bytes = await result.Content.ReadAsByteArrayAsync(cancellationToken);
+                    jsonResultString = Encoding.UTF8.GetString(bytes).Trim();
+
+                    if (!ShouldRetry(result, jsonResultString) || attempt == retryDelays.Length)
+                    {
+                        break;
+                    }
+
+                    SeLogger.Error($"{StaticName} returned {(int)result.StatusCode} ({result.StatusCode}) - retrying in {retryDelays[attempt]} ms (attempt {attempt + 1} of {retryDelays.Length})");
+                    await Task.Delay(retryDelays[attempt], cancellationToken);
+                }
 
                 if (!result.IsSuccessStatusCode)
                 {
@@ -73,6 +90,18 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
 
             var resultList = ConvertJsonObjectToStringLines(jsonResultString);
             return string.Join(Environment.NewLine, resultList);
+        }
+
+        /// <summary>
+        /// Transient server-side failures worth retrying: the shared 429/503 rule plus the
+        /// 500/502/504 that translate.googleapis.com hands out under load.
+        /// </summary>
+        public static bool ShouldRetry(HttpResponseMessage result, string resultContent)
+        {
+            return DeepLTranslate.ShouldRetry(result, resultContent) ||
+                   result.StatusCode == HttpStatusCode.InternalServerError ||
+                   result.StatusCode == HttpStatusCode.BadGateway ||
+                   result.StatusCode == HttpStatusCode.GatewayTimeout;
         }
 
         public static List<TranslationPair> GetTranslationPairs()

--- a/tests/libuilogic/AutoTranslate/GoogleTranslateV1RetryTests.cs
+++ b/tests/libuilogic/AutoTranslate/GoogleTranslateV1RetryTests.cs
@@ -1,0 +1,27 @@
+using System.Net;
+using Nikse.SubtitleEdit.UiLogic.AutoTranslate;
+
+namespace LibUiLogicTests.AutoTranslate;
+
+public class GoogleTranslateV1RetryTests
+{
+    [Theory]
+    // Issue #14004: the free gtx endpoint answers an HTML "Error 500" page mid-run on long
+    // translations; before, one such reply aborted the whole job.
+    [InlineData(HttpStatusCode.InternalServerError, true)]
+    [InlineData(HttpStatusCode.BadGateway, true)]
+    [InlineData(HttpStatusCode.ServiceUnavailable, true)]
+    [InlineData(HttpStatusCode.GatewayTimeout, true)]
+    [InlineData(HttpStatusCode.TooManyRequests, true)]
+    // Permanent failures must still surface immediately.
+    [InlineData(HttpStatusCode.BadRequest, false)]
+    [InlineData(HttpStatusCode.Forbidden, false)]
+    [InlineData(HttpStatusCode.NotFound, false)]
+    [InlineData(HttpStatusCode.OK, false)]
+    public void ShouldRetry_OnlyForTransientServerErrors(HttpStatusCode statusCode, bool expected)
+    {
+        using var response = new HttpResponseMessage(statusCode);
+
+        Assert.Equal(expected, GoogleTranslateV1.ShouldRetry(response, "<html><title>Error 500 (Server Error)!!1</title></html>"));
+    }
+}


### PR DESCRIPTION
Fixes #14004

The free `gtx` endpoint intermittently answers an HTML "Error 500" page mid-run on long translations; a single such reply aborted the whole translation and the user had to restart it by hand (repeatedly).

Google V1 was the only engine without the shared retry loop that DeepL/ChatGPT/Gemini/etc. already use. This gives it one, extended to 500/502/504 — `DeepLTranslate.ShouldRetry` only covers 429/503 — with a 1 s / 3 s / 7 s backoff (three retries) before the existing error surfaces. Retries are logged via `SeLogger`. Permanent failures (400/403/404) still fail immediately.

Adds a small unit test for the retry predicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)