### PR TITLE
Fix #14000: select TTS review line by clicking or grabbing its waveform block

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -518,6 +518,18 @@ public class AudioVisualizer : Control
     public event ParagraphNullableEventHandler? OnPrimaryDoubleClicked;
     public event PositionEventHandler? OnSetStartAndOffsetTheRest;
 
+    /// <summary>
+    /// Optional: seconds of audio that belongs to a paragraph (the TTS review window's generated
+    /// clip). When it returns more than 0, a thin bar is drawn along the bottom of the paragraph
+    /// from its start for that many seconds - green while it fits inside the cue, red for the
+    /// part that runs past the cue's end - so the user sees at a glance which lines need their
+    /// timing fixed (#14000).
+    /// </summary>
+    public Func<SubtitleLineViewModel, double>? ParagraphAudioLengthProvider { get; set; }
+
+    private static readonly IBrush PaintAudioLengthFits = new SolidColorBrush(Color.FromArgb(190, 70, 190, 110));
+    private static readonly IBrush PaintAudioLengthOverrun = new SolidColorBrush(Color.FromArgb(220, 235, 70, 70));
+
     /// <summary>Raised when a primary-button press lands on an existing paragraph and starts a
     /// move/resize drag. Lets hosts select the paragraph the user grabbed before the drag
     /// mutates it (#14000) - a click is delivered via <see cref="OnPrimarySingleClicked"/> instead.</summary>
@@ -3324,6 +3336,39 @@ public class AudioVisualizer : Control
             }
 
             DrawParagraphFooter(context, paragraph, currentRegionLeft, currentRegionWidth, height, ref renderCtx);
+        }
+
+        DrawParagraphAudioLength(context, paragraph, currentRegionLeft, currentRegionRight, height, ref renderCtx);
+    }
+
+    // Drawn outside the text clip on purpose: the overrun part extends past the right border.
+    private void DrawParagraphAudioLength(DrawingContext context, SubtitleLineViewModel paragraph,
+        double currentRegionLeft, double currentRegionRight, double height, ref RenderContext renderCtx)
+    {
+        var provider = ParagraphAudioLengthProvider;
+        if (provider == null)
+        {
+            return;
+        }
+
+        var audioSeconds = provider(paragraph);
+        if (audioSeconds <= 0)
+        {
+            return;
+        }
+
+        var audioRight = SecondsToXPositionOptimized(paragraph.StartTime.TotalSeconds + audioSeconds - renderCtx.StartPositionSeconds, renderCtx.SampleRate, renderCtx.ZoomFactor);
+        const double barHeight = 4;
+        var y = height - barHeight - 1;
+        var fitsRight = Math.Min(audioRight, currentRegionRight - 1);
+        if (fitsRight > currentRegionLeft + 1)
+        {
+            context.FillRectangle(PaintAudioLengthFits, new Rect(currentRegionLeft + 1, y, fitsRight - currentRegionLeft - 1, barHeight));
+        }
+
+        if (audioRight > currentRegionRight)
+        {
+            context.FillRectangle(PaintAudioLengthOverrun, new Rect(currentRegionRight - 1, y, audioRight - currentRegionRight + 1, barHeight));
         }
     }
 

--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -518,6 +518,11 @@ public class AudioVisualizer : Control
     public event ParagraphNullableEventHandler? OnPrimaryDoubleClicked;
     public event PositionEventHandler? OnSetStartAndOffsetTheRest;
 
+    /// <summary>Raised when a primary-button press lands on an existing paragraph and starts a
+    /// move/resize drag. Lets hosts select the paragraph the user grabbed before the drag
+    /// mutates it (#14000) - a click is delivered via <see cref="OnPrimarySingleClicked"/> instead.</summary>
+    public event ParagraphEventHandler? OnDragStarted;
+
     /// <summary>Raised when the user clicks the empty waveform to generate it on demand
     /// (shown only when auto-generate is off and there are no cached peaks).</summary>
     public event EventHandler? OnGenerateWaveformRequested;
@@ -1215,6 +1220,10 @@ public class AudioVisualizer : Control
         }
 
         _pointerDragActive = _interactionMode != InteractionMode.None;
+        if (_pointerDragActive && _activeParagraph != null)
+        {
+            OnDragStarted?.Invoke(this, new ParagraphEventArgs(_startPointerSeconds, _activeParagraph));
+        }
     }
 
     /// <summary>

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -474,6 +474,44 @@ public partial class ReviewSpeechViewModel : ObservableObject
         row.Cps = Math.Round(paragraph.GetCharactersPerSecond(), 2).ToString(CultureInfo.CurrentCulture);
     }
 
+    // True while a selection change originates from a click/drag on the waveform itself. The
+    // block the user grabbed is already in view, so RefreshWaveformPosition must only update the
+    // highlight and not recenter - recentering would jump the view (and the block under the
+    // pointer) mid-drag (#14000).
+    private bool _selectionFromWaveform;
+
+    // Click/drag on a waveform block selects the row that owns it, which in turn loads its text
+    // and per-line settings into the edit panel through OnSelectedLineChanged (#14000).
+    //
+    // The event args carry a *copy* of the paragraph (ParagraphEventArgs clones it), so the
+    // lookup goes by Id, which the copy preserves - never by instance.
+    public void SelectFromWaveform(SubtitleLineViewModel? waveformParagraph)
+    {
+        if (waveformParagraph == null)
+        {
+            return;
+        }
+
+        var mirror = WaveformParagraphs.Find(wp => wp.Id == waveformParagraph.Id);
+        if (mirror == null ||
+            !_waveformParagraphToRow.TryGetValue(mirror, out var row) ||
+            ReferenceEquals(row, SelectedLine))
+        {
+            return;
+        }
+
+        _selectionFromWaveform = true;
+        try
+        {
+            SelectedLine = row;
+            LineGrid.ScrollIntoView(row);
+        }
+        finally
+        {
+            _selectionFromWaveform = false;
+        }
+    }
+
     // Centers the visualizer on the currently selected paragraph and marks it as selected so the
     // user can grab its start/end handles. Safe to call before AudioVisualizer is attached.
     public void RefreshWaveformPosition()
@@ -488,6 +526,14 @@ public partial class ReviewSpeechViewModel : ObservableObject
         var waveformParagraph = row?.WaveformParagraph;
         if (waveformParagraph == null || WaveformParagraphs.Count == 0)
         {
+            return;
+        }
+
+        if (_selectionFromWaveform)
+        {
+            av.SelectedParagraph = waveformParagraph;
+            av.AllSelectedParagraphs = new List<SubtitleLineViewModel> { waveformParagraph };
+            av.InvalidateVisual();
             return;
         }
 

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -169,7 +169,8 @@ public partial class ReviewSpeechViewModel : ObservableObject
         _cancellationToken = _cancellationTokenSource.Token;
 
         _playLock = new Lock();
-        _timer = new Timer(200);
+        // 100 ms: also drives the waveform playhead during playback, 200 ms looked steppy.
+        _timer = new Timer(100);
         _timer.Elapsed += OnTimerOnElapsed;
         _timer.Start();
     }
@@ -190,6 +191,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
             // unguarded IsPaused read raced the dispose (NRE / native use-after-free window).
             var stopped = false;
             var paused = false;
+            var positionSeconds = 0.0;
             lock (_playLock)
             {
                 if (_cancellationTokenSource.IsCancellationRequested || _mpvContext == null)
@@ -199,6 +201,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
                 else
                 {
                     paused = _mpvContext.IsPaused;
+                    positionSeconds = _mpvContext.Position;
                 }
             }
 
@@ -206,6 +209,15 @@ public partial class ReviewSpeechViewModel : ObservableObject
             {
                 await Dispatcher.UIThread.InvokeAsync(ResetPlaybackUiState);
                 return;
+            }
+
+            // The clip plays from the cue's start, so the waveform playhead is start + clip
+            // position - the user sees where in the cue the speech currently is (#14000).
+            var playingRow = _playingRow;
+            if (!paused && playingRow?.WaveformParagraph != null)
+            {
+                var playheadSeconds = playingRow.WaveformParagraph.StartTime.TotalSeconds + positionSeconds;
+                await Dispatcher.UIThread.InvokeAsync(() => SetWaveformPlayhead(playheadSeconds));
             }
 
             // The row that is actually playing - not SelectedLine: two-way grid selection meant
@@ -472,6 +484,183 @@ public partial class ReviewSpeechViewModel : ObservableObject
 
         // Cps depends on duration; refresh so the grid stays consistent with the dragged times.
         row.Cps = Math.Round(paragraph.GetCharactersPerSecond(), 2).ToString(CultureInfo.CurrentCulture);
+    }
+
+    private void SetWaveformPlayhead(double seconds)
+    {
+        var av = AudioVisualizer;
+        if (av == null)
+        {
+            return;
+        }
+
+        av.CurrentVideoPositionSeconds = seconds;
+        av.InvalidateVisual();
+    }
+
+    // Length of each row's generated clip, keyed by file name: a regenerate always writes a new
+    // file, so a stale entry can never be served for a changed clip. Non-WAV or unreadable files
+    // yield 0, which the visualizer treats as "no bar".
+    private readonly Dictionary<string, double> _audioLengthCache = new();
+
+    public double GetGeneratedAudioLengthSeconds(ReviewRow row)
+    {
+        var fileName = row.StepResult.CurrentFileName;
+        if (string.IsNullOrEmpty(fileName))
+        {
+            return 0;
+        }
+
+        if (_audioLengthCache.TryGetValue(fileName, out var cached))
+        {
+            return cached;
+        }
+
+        var seconds = 0.0;
+        try
+        {
+            if (File.Exists(fileName))
+            {
+                using var stream = File.OpenRead(fileName);
+                var header = new WaveHeader2(stream);
+                if (header.ChunkId == "RIFF" && header.Format == "WAVE" && header.BytesPerSecond > 0)
+                {
+                    seconds = header.LengthInSeconds;
+                }
+            }
+        }
+        catch (Exception exception)
+        {
+            SeLogger.Error(exception, $"ReviewSpeech: cannot read audio length of \"{fileName}\"");
+        }
+
+        _audioLengthCache[fileName] = seconds;
+        return seconds;
+    }
+
+    // Provider for AudioVisualizer.ParagraphAudioLengthProvider - the visualizer hands back the
+    // mirror instance it draws, so an instance lookup is right here (unlike the event args).
+    public double GetWaveformParagraphAudioLength(SubtitleLineViewModel waveformParagraph)
+    {
+        return _waveformParagraphToRow.TryGetValue(waveformParagraph, out var row) ? GetGeneratedAudioLengthSeconds(row) : 0;
+    }
+
+    // "Fit duration to generated audio": the cue ends exactly where the speech ends - what the
+    // user otherwise does by dragging the right edge to the end of the red overrun bar.
+    [RelayCommand]
+    private void FitDurationToAudio(ReviewRow? row)
+    {
+        row ??= SelectedLine;
+        var wp = row?.WaveformParagraph;
+        if (row == null || wp == null)
+        {
+            return;
+        }
+
+        var seconds = GetGeneratedAudioLengthSeconds(row);
+        if (seconds <= 0)
+        {
+            return;
+        }
+
+        wp.EndTime = wp.StartTime + TimeSpan.FromSeconds(seconds);
+        wp.UpdateDuration();
+        AudioVisualizer?.InvalidateVisual();
+    }
+
+    // Restores the times the line had when the window opened (waveform drags have no undo).
+    [RelayCommand]
+    private void ResetTiming(ReviewRow? row)
+    {
+        row ??= SelectedLine;
+        var wp = row?.WaveformParagraph;
+        if (row == null || wp == null)
+        {
+            return;
+        }
+
+        wp.StartTime = TimeSpan.FromMilliseconds(row.OriginalStartMs);
+        wp.EndTime = TimeSpan.FromMilliseconds(row.OriginalEndMs);
+        wp.UpdateDuration();
+        AudioVisualizer?.InvalidateVisual();
+    }
+
+    // Shifts the selected cue as a whole (duration kept), used by the waveform's keyboard nudge.
+    private void NudgeSelectedLine(double milliseconds)
+    {
+        var wp = SelectedLine?.WaveformParagraph;
+        if (wp == null)
+        {
+            return;
+        }
+
+        var start = Math.Max(0, wp.StartTime.TotalMilliseconds + milliseconds);
+        var duration = wp.Duration.TotalMilliseconds;
+        wp.StartTime = TimeSpan.FromMilliseconds(start);
+        wp.EndTime = TimeSpan.FromMilliseconds(start + duration);
+        wp.UpdateDuration();
+        AudioVisualizer?.InvalidateVisual();
+    }
+
+    // Right-click on the waveform: the row under the pointer becomes the context-menu target
+    // (and the selection) whether or not "right click selects" is on; an empty-area right-click
+    // keeps the current selection. Returns the target row or null.
+    public ReviewRow? SelectRowAtWaveformPosition(double seconds)
+    {
+        var wp = WaveformParagraphs.Find(p => p.StartTime.TotalSeconds <= seconds && seconds <= p.EndTime.TotalSeconds);
+        if (wp != null)
+        {
+            SelectFromWaveform(wp);
+        }
+
+        return SelectedLine;
+    }
+
+    // A left-click on empty waveform just parks the playhead there; the review window has no
+    // video to seek, so nothing plays until the user presses Play.
+    public void OnWaveformPositionClicked(double seconds)
+    {
+        if (_playingRow == null)
+        {
+            SetWaveformPlayhead(seconds);
+        }
+    }
+
+    // Keys that act on the waveform when it has focus (the grid handles its own Up/Down):
+    // Home/End jump to the first/last row; Ctrl+Left/Right nudge the selected cue 100 ms
+    // (10 ms with Shift) without changing its duration.
+    public bool OnWaveformKeyDown(KeyEventArgs e)
+    {
+        if (Lines.Count == 0)
+        {
+            return false;
+        }
+
+        var ctrl = e.KeyModifiers.HasFlag(OperatingSystem.IsMacOS() ? KeyModifiers.Meta : KeyModifiers.Control);
+        var shift = e.KeyModifiers.HasFlag(KeyModifiers.Shift);
+
+        if (e.Key == Key.Home && e.KeyModifiers == KeyModifiers.None)
+        {
+            SelectedLine = Lines[0];
+            LineGrid.ScrollIntoView(Lines[0]);
+            return true;
+        }
+
+        if (e.Key == Key.End && e.KeyModifiers == KeyModifiers.None)
+        {
+            SelectedLine = Lines[^1];
+            LineGrid.ScrollIntoView(Lines[^1]);
+            return true;
+        }
+
+        if (ctrl && e.Key is Key.Left or Key.Right)
+        {
+            var step = shift ? 10 : 100;
+            NudgeSelectedLine(e.Key == Key.Left ? -step : step);
+            return true;
+        }
+
+        return false;
     }
 
     // True while a selection change originates from a click/drag on the waveform itself. The

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechWindow.cs
@@ -676,6 +676,15 @@ public class ReviewSpeechWindow : Window
             }
         };
 
+        // Clicking or grabbing a block selects its row (#14000). The control only raises
+        // OnPrimarySingleClicked when something listens to OnVideoPositionChanged, hence the
+        // empty playhead handler. OnDragStarted fires on press so the row is selected before a
+        // move/resize mutates it; OnSelectRequested covers right-click-selects.
+        audioVisualizer.OnVideoPositionChanged += (_, _) => { };
+        audioVisualizer.OnPrimarySingleClicked += (_, e) => vm.SelectFromWaveform(e.Paragraph);
+        audioVisualizer.OnDragStarted += (_, e) => vm.SelectFromWaveform(e.Paragraph);
+        audioVisualizer.OnSelectRequested += (_, e) => vm.SelectFromWaveform(e.Paragraph);
+
         return new Border
         {
             Margin = new Thickness(2),

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechWindow.cs
@@ -681,9 +681,51 @@ public class ReviewSpeechWindow : Window
         // empty playhead handler. OnDragStarted fires on press so the row is selected before a
         // move/resize mutates it; OnSelectRequested covers right-click-selects.
         audioVisualizer.OnVideoPositionChanged += (_, _) => { };
-        audioVisualizer.OnPrimarySingleClicked += (_, e) => vm.SelectFromWaveform(e.Paragraph);
+        audioVisualizer.OnPrimarySingleClicked += (_, e) =>
+        {
+            vm.SelectFromWaveform(e.Paragraph);
+            vm.OnWaveformPositionClicked(e.Seconds);
+        };
         audioVisualizer.OnDragStarted += (_, e) => vm.SelectFromWaveform(e.Paragraph);
         audioVisualizer.OnSelectRequested += (_, e) => vm.SelectFromWaveform(e.Paragraph);
+
+        // Generated-clip length bar under each block (green fits / red overrun).
+        audioVisualizer.ParagraphAudioLengthProvider = vm.GetWaveformParagraphAudioLength;
+
+        // Context menu: the row actions from the grid plus the two timing fixes that only make
+        // sense here. The target is the row under the pointer (selected on open), so the items
+        // take it as CommandParameter rather than relying on SelectedLine.
+        var menuPlay = new MenuItem { Header = Se.Language.Video.TextToSpeech.PlayLine, Command = vm.PlayRowCommand };
+        var menuRegenerate = new MenuItem { Header = Se.Language.Video.TextToSpeech.RegenerateAudio, Command = vm.RegenerateAudioCommand };
+        var menuHistory = new MenuItem { Header = Se.Language.General.ShowHistory, Command = vm.ShowHistoryCommand };
+        var menuFit = new MenuItem { Header = Se.Language.Video.TextToSpeech.FitDurationToGeneratedAudio, Command = vm.FitDurationToAudioCommand };
+        var menuReset = new MenuItem { Header = Se.Language.Video.TextToSpeech.ResetTiming, Command = vm.ResetTimingCommand };
+        var flyout = new MenuFlyout();
+        flyout.Items.Add(menuPlay);
+        flyout.Items.Add(menuRegenerate);
+        flyout.Items.Add(menuHistory);
+        flyout.Items.Add(new Separator());
+        flyout.Items.Add(menuFit);
+        flyout.Items.Add(menuReset);
+        audioVisualizer.MenuFlyout = flyout;
+        audioVisualizer.FlyoutMenuOpening += (_, e) =>
+        {
+            var row = vm.SelectRowAtWaveformPosition(e.PositionInSeconds);
+            foreach (var item in new[] { menuPlay, menuRegenerate, menuHistory, menuFit, menuReset })
+            {
+                item.CommandParameter = row;
+                item.IsEnabled = row != null;
+            }
+
+            if (row != null)
+            {
+                menuPlay.IsEnabled = row.IsPlayingEnabled && !row.IsPlaying;
+                menuRegenerate.IsEnabled = vm.IsRegenerateEnabled && row.IsPlayingEnabled;
+                menuHistory.IsEnabled = row.HasHistory;
+                menuFit.IsEnabled = vm.GetGeneratedAudioLengthSeconds(row) > 0 && !audioVisualizer.IsReadOnly;
+                menuReset.IsEnabled = !audioVisualizer.IsReadOnly;
+            }
+        };
 
         return new Border
         {
@@ -696,6 +738,12 @@ public class ReviewSpeechWindow : Window
     protected override void OnKeyDown(KeyEventArgs e)
     {
         base.OnKeyDown(e);
+        if (!e.Handled && FocusManager?.GetFocusedElement() is AudioVisualizer && _vm.OnWaveformKeyDown(e))
+        {
+            e.Handled = true;
+            return;
+        }
+
         _vm.OnKeyDown(e);
     }
 

--- a/src/ui/Logic/Config/Language/Video/LanguageTextToSpeech.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageTextToSpeech.cs
@@ -30,6 +30,9 @@ public class LanguageTextToSpeech
     public string ElevenLabsSettingsResetHint { get; set; }
     public string RegenerateAudio { get; set; }
     public string AutoContinuePlaying { get; set; }
+    public string PlayLine { get; set; }
+    public string FitDurationToGeneratedAudio { get; set; }
+    public string ResetTiming { get; set; }
     public string AddingAudioToVideoFileDotDotDot { get; set; }
     public string PreparingMergeDotDotDot { get; set; }
     public string ImportVoiceDotDotDot { get; set; }
@@ -176,6 +179,9 @@ public class LanguageTextToSpeech
         ElevenLabsSettingsResetHint = "Reset ElevenLabs settings to default values";
         RegenerateAudio = "Regenerate audio";
         AutoContinuePlaying = "Auto-continue playing";
+        PlayLine = "Play line";
+        FitDurationToGeneratedAudio = "Fit duration to generated audio";
+        ResetTiming = "Reset timing";
         AddingAudioToVideoFileDotDotDot = "Adding audio to video file...";
         PreparingMergeDotDotDot = "Preparing merge...";
         ImportVoiceDotDotDot = "Import voice...";

--- a/tests/UI/Controls/AudioVisualizerDragTests.cs
+++ b/tests/UI/Controls/AudioVisualizerDragTests.cs
@@ -295,6 +295,32 @@ public class AudioVisualizerDragTests
         window.Close();
     }
 
+    // #14000: the generated-audio length bar. The provider is consulted once per drawn
+    // paragraph with the very instance the control draws (hosts key on it), and a render with
+    // a provider that overruns the cue, fits the cue, or returns 0 must not throw.
+    [AvaloniaFact]
+    public void ParagraphAudioLengthProvider_IsAskedPerDrawnParagraph()
+    {
+        var av = MakeMeasuredVisualizer(WaveformDrawStyle.Classic, out var line);
+        var asked = new List<SubtitleLineViewModel>();
+        var lengths = new[] { 5.0, 1.0, 0.0 };
+        foreach (var length in lengths)
+        {
+            asked.Clear();
+            av.ParagraphAudioLengthProvider = p =>
+            {
+                asked.Add(p);
+                return length;
+            };
+            RenderFrame(av);
+            Assert.Single(asked);
+            Assert.Same(line, asked[0]);
+        }
+
+        av.ParagraphAudioLengthProvider = null;
+        RenderFrame(av);
+    }
+
     private static Geometry FirstCachedWaveformGeometry(AudioVisualizer av)
     {
         var field = typeof(AudioVisualizer).GetField("_waveformCacheDraws", BindingFlags.NonPublic | BindingFlags.Instance)!;

--- a/tests/UI/Controls/AudioVisualizerDragTests.cs
+++ b/tests/UI/Controls/AudioVisualizerDragTests.cs
@@ -144,6 +144,59 @@ public class AudioVisualizerDragTests
         window.Close();
     }
 
+    // #14000: hosts (the TTS review window) select the grabbed line on press, before the drag
+    // mutates it. The event must name the line under the pointer, fire for both a middle grab
+    // and an edge grab, and stay silent for a press on empty waveform (new-selection drag) and
+    // when time codes are locked. The args carry a copy of the line (ParagraphEventArgs clones),
+    // so identity is checked by Id, as hosts must.
+    [AvaloniaFact]
+    public void OnDragStarted_FiresWithGrabbedLine_ForMoveAndResize()
+    {
+        var first = Line(1, 3);
+        var second = Line(5, 7);
+        var (window, av, _) = Open(first, second);
+        var raised = new List<SubtitleLineViewModel>();
+        av.OnDragStarted += (_, e) => raised.Add(e.Paragraph);
+
+        // Middle of the second (unselected) line: x = 6 s * 126 = 756.
+        window.MouseDown(new Point(756, 100), MouseButton.Left, RawInputModifiers.None);
+        window.MouseUp(new Point(756, 100), MouseButton.Left, RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+        Assert.Single(raised);
+        Assert.Equal(second.Id, raised[0].Id);
+
+        // Right edge of the first line: x = 3 s * 126 = 378.
+        window.MouseDown(new Point(378, 100), MouseButton.Left, RawInputModifiers.None);
+        window.MouseUp(new Point(378, 100), MouseButton.Left, RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal(2, raised.Count);
+        Assert.Equal(first.Id, raised[1].Id);
+
+        // Empty waveform (x = 4 s) starts a new-selection drag, not a line drag.
+        window.MouseDown(new Point(504, 100), MouseButton.Left, RawInputModifiers.None);
+        window.MouseUp(new Point(504, 100), MouseButton.Left, RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal(2, raised.Count);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void OnDragStarted_Silent_WhenReadOnly()
+    {
+        var (window, av, _) = Open(Line(1, 3));
+        av.IsReadOnly = true;
+        var raised = 0;
+        av.OnDragStarted += (_, _) => raised++;
+
+        window.MouseDown(new Point(252, 100), MouseButton.Left, RawInputModifiers.None);
+        window.MouseUp(new Point(252, 100), MouseButton.Left, RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(0, raised);
+        window.Close();
+    }
+
     /// <summary>Ages the "last pointer edit" stamp past the 500 ms grace, i.e. simulates half a
     /// second of a held-down drag in which the time codes did not change.</summary>
     private static void ExpirePointerEditGrace(AudioVisualizer av)


### PR DESCRIPTION
Fixes #14000.

The review-speech waveform subscribed to no interaction events, so clicking a block did nothing, and dragging an unselected block silently edited a row the edit panel was not showing.

- `AudioVisualizer`: new `OnDragStarted` event, raised on press when a move/resize drag lands on a paragraph (silent for empty-area new-selection drags and when time codes are locked).
- `ReviewSpeechViewModel.SelectFromWaveform`: looks the row up by `Id` (the event args carry a copy of the paragraph), selects it and scrolls the grid. While the selection originates from the waveform only the highlight updates - no recenter, so the view doesn't jump under the pointer mid-drag.
- `ReviewSpeechWindow`: wires `OnPrimarySingleClicked`, `OnDragStarted` and `OnSelectRequested` (right-click-selects), plus the `OnVideoPositionChanged` subscriber that `OnPrimarySingleClicked` is gated on.

Whole-block move (drag the middle, duration preserved) already worked in the control; it just wasn't discoverable without the selection following the pointer. "Lock time codes" still blocks drags but leaves click-to-select working.

Tests: two new `AudioVisualizerDragTests` cases for `OnDragStarted`; the 30 AudioVisualizer tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)