### PR TITLE
Fix split long lines: overlong lines, gaps between split events, duplicate numbers

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -7357,11 +7357,12 @@ public partial class MainViewModel :
         }
 
         var result = await ShowDialogAsync<SplitBreakLongLinesWindow, SplitBreakLongLinesViewModel>(
-            vm => { vm.Initialize(Subtitles.ToList()); });
+            vm => { vm.Initialize(Subtitles.ToList(), IsFormatEbu); });
 
         if (result.OkPressed && result.AllSubtitlesFixed.Count > 0)
         {
             ReplaceSubtitles(result.AllSubtitlesFixed);
+            Renumber();
             SelectAndScrollToRow(0);
             _updateAudioVisualizer = true;
             RefreshSubtitlePreview();
@@ -15655,7 +15656,7 @@ public partial class MainViewModel :
         }
 
         var result = await ShowDialogAsync<SplitBreakLongLinesWindow, SplitBreakLongLinesViewModel>(
-            vm => { vm.Initialize(selectedInOrder); });
+            vm => { vm.Initialize(selectedInOrder, IsFormatEbu); });
 
         if (!result.OkPressed || result.AllSubtitlesFixed.Count == 0)
         {

--- a/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesItem.cs
+++ b/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesItem.cs
@@ -1,19 +1,63 @@
-﻿using Nikse.SubtitleEdit.Features.Main;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Nikse.SubtitleEdit.Features.Main;
 
 namespace Nikse.SubtitleEdit.Features.Tools.SplitBreakLongLines;
 
-public class SplitBreakLongLinesItem
+public partial class SplitBreakLongLinesItem : ObservableObject
 {
-    public string Name { get; set; }
-    public int Number { get; set; }
-    public string Fix { get; set; }
-    public SubtitleLineViewModel SubtitleLine { get; set; }
+    public string Name { get; }
+    public int Number { get; }
+    public string Fix { get; }
+    public SubtitleLineViewModel SubtitleLine { get; }
+
+    /// <summary>
+    /// Rebalance fixes are opt-out per row: the proposed text is applied while the row is
+    /// checked and the original text restored when it is unchecked. Split fixes change the
+    /// subtitle count and are always applied, so they show no checkbox.
+    /// </summary>
+    public bool IsSelectable { get; }
+
+    private readonly string _originalText;
+    private readonly string _proposedText;
+    private readonly string _originalMarginV;
+    private readonly string _proposedMarginV;
+
+    [ObservableProperty] private bool _isSelected = true;
 
     public SplitBreakLongLinesItem(string name, int number, string fix, SubtitleLineViewModel subtitleLine)
+        : this(name, number, fix, subtitleLine, null)
+    {
+    }
+
+    /// <param name="proposedText">Rebalanced text, or null for a fix that is not optional.</param>
+    /// <param name="proposedMarginV">Teletext row that goes with the proposed text (EBU STL only).</param>
+    public SplitBreakLongLinesItem(string name, int number, string fix, SubtitleLineViewModel subtitleLine, string? proposedText, string? proposedMarginV = null)
     {
         Name = name;
         Number = number;
         Fix = fix;
         SubtitleLine = subtitleLine;
+
+        _originalText = subtitleLine.Text ?? string.Empty;
+        _proposedText = proposedText ?? _originalText;
+        _originalMarginV = subtitleLine.MarginV;
+        _proposedMarginV = proposedMarginV ?? _originalMarginV;
+        IsSelectable = proposedText != null;
+
+        ApplySelection();
+    }
+
+    partial void OnIsSelectedChanged(bool value)
+    {
+        ApplySelection();
+    }
+
+    private void ApplySelection()
+    {
+        if (IsSelectable)
+        {
+            SubtitleLine.Text = IsSelected ? _proposedText : _originalText;
+            SubtitleLine.MarginV = IsSelected ? _proposedMarginV : _originalMarginV;
+        }
     }
 }

--- a/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModel.cs
+++ b/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModel.cs
@@ -10,6 +10,7 @@ using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Features.Tools.SplitBreakLongLines;
 
@@ -37,6 +38,7 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
 
     private List<SubtitleLineViewModel> _allSubtitles;
     private string _languageCode = "en";
+    private bool _isFormatEbu;
 
     private readonly System.Timers.Timer _previewTimer;
     private volatile bool _isClosing;
@@ -98,13 +100,36 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
             var rebalanceCount = 0;
             var maxCharactersPerSubtitle = MaxNumberOfLines * SingleLineMaxLength;
 
+            // AutoBreakLine keeps text on one line only when it is strictly shorter than the
+            // unbreak threshold, so a threshold at or above the single line max length means
+            // "keep any text that fits on one line" - and capping there also prevents merging
+            // to a single line that would exceed the max length (#12910).
+            var mergeLinesShorterThan = UnbreakLinesShorterThan >= SingleLineMaxLength
+                ? SingleLineMaxLength + 1
+                : UnbreakLinesShorterThan;
+
             if (SplitLongLines)
             {
+                var options = new SplitOptions
+                {
+                    MinimumGapMs = Se.Settings.General.MinimumBetweenLines.GetMilliseconds(),
+                    AdjustTeletextRows = _isFormatEbu,
+                    TeletextDoubleHeight = Configuration.Settings.SubtitleSettings.EbuStlTeletextUseDoubleHeight,
+                };
+
                 for (var index = 0; index < _allSubtitles.Count; index++)
                 {
                     var item = new SubtitleLineViewModel(_allSubtitles[index]);
 
-                    var splitLines = Split(item, maxCharactersPerSubtitle, SingleLineMaxLength);
+                    // Like SE4: a subtitle is not cut into several events when re-wrapping its
+                    // lines is enough to make it fit - the rebalance pass below does that.
+                    if (RebalanceLongLines && CanBeFixedByRebalancing(item.Text, mergeLinesShorterThan))
+                    {
+                        AllSubtitlesFixed.Add(item);
+                        continue;
+                    }
+
+                    var splitLines = Split(item, maxCharactersPerSubtitle, SingleLineMaxLength, options);
                     if (splitLines.Count > 1)
                     {
                         splitCount++;
@@ -114,10 +139,8 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
                         var fixItem = new SplitBreakLongLinesItem(Se.Language.Tools.SplitBreakLongLines.SplitLongLine, index + 1, fixDescription, item);
                         Fixes.Add(fixItem);
                     }
-                    foreach (var s in splitLines)
-                    {
-                        AllSubtitlesFixed.Add(s);
-                    }
+
+                    AllSubtitlesFixed.AddRange(splitLines);
                 }
             }
             else
@@ -131,14 +154,6 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
 
             if (RebalanceLongLines)
             {
-                // AutoBreakLine keeps text on one line only when it is strictly shorter than the
-                // unbreak threshold, so a threshold at or above the single line max length means
-                // "keep any text that fits on one line" - and capping there also prevents merging
-                // to a single line that would exceed the max length (#12910).
-                var mergeLinesShorterThan = UnbreakLinesShorterThan >= SingleLineMaxLength
-                    ? SingleLineMaxLength + 1
-                    : UnbreakLinesShorterThan;
-
                 for (var index = 0; index < AllSubtitlesFixed.Count; index++)
                 {
                     var item = AllSubtitlesFixed[index];
@@ -156,10 +171,33 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
                         var beforePreview = GetTextPreview(item.Text.Replace("\r\n", " · ").Replace("\n", " · "), 60);
                         var afterPreview = GetTextPreview(rebalancedText.Replace("\r\n", " · ").Replace("\n", " · "), 60);
                         var fixDescription = $"'{beforePreview}' → '{afterPreview}'";
-                        var fixItem = new SplitBreakLongLinesItem(Se.Language.Tools.SplitBreakLongLines.RebalanceLongLine, index + 1, fixDescription, item);
+
+                        string? rebalancedMarginV = null;
+                        if (_isFormatEbu)
+                        {
+                            rebalancedMarginV = TeletextRowHelper.GetRowKeepingBottomEdge(
+                                    item.MarginV,
+                                    GetPlainLineCount(item.Text),
+                                    GetPlainLineCount(rebalancedText),
+                                    Configuration.Settings.SubtitleSettings.EbuStlTeletextUseDoubleHeight)
+                                ?.ToString(CultureInfo.InvariantCulture);
+                        }
+
+                        // The item applies the rebalanced text (and row) itself, and puts the
+                        // original back when the user unchecks the row.
+                        var fixItem = new SplitBreakLongLinesItem(Se.Language.Tools.SplitBreakLongLines.RebalanceLongLine, index + 1, fixDescription, item, rebalancedText, rebalancedMarginV);
                         Fixes.Add(fixItem);
-                        item.Text = rebalancedText;
                     }
+                }
+            }
+
+            // Split events are clones of their source and keep its number - renumber so the
+            // preview (and the grid after OK) shows 12, 13, 14 rather than 12, 12, 13.
+            if (splitCount > 0)
+            {
+                for (var index = 0; index < AllSubtitlesFixed.Count; index++)
+                {
+                    AllSubtitlesFixed[index].Number = index + 1;
                 }
             }
 
@@ -178,6 +216,45 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
                 FixesInfo = string.Format(Se.Language.Tools.SplitBreakLongLines.LinesSplitXLinesRebalancedY, splitCount, rebalanceCount);
             }
         });
+    }
+
+    [RelayCommand]
+    private void SelectAll()
+    {
+        SetSelectableFixes(true);
+    }
+
+    [RelayCommand]
+    private void SelectNone()
+    {
+        SetSelectableFixes(false);
+    }
+
+    private void SetSelectableFixes(bool isSelected)
+    {
+        foreach (var fix in Fixes)
+        {
+            if (fix.IsSelectable)
+            {
+                fix.IsSelected = isSelected;
+            }
+        }
+    }
+
+    private bool CanBeFixedByRebalancing(string? text, int mergeLinesShorterThan)
+    {
+        if (!HasLineTooLong(text, SingleLineMaxLength, MaxNumberOfLines))
+        {
+            return true;
+        }
+
+        var rebalanced = Utilities.AutoBreakLine(text ?? string.Empty, SingleLineMaxLength, mergeLinesShorterThan, _languageCode);
+        return !HasLineTooLong(rebalanced, SingleLineMaxLength, MaxNumberOfLines);
+    }
+
+    private static int GetPlainLineCount(string? text)
+    {
+        return HtmlUtil.RemoveHtmlTags(text ?? string.Empty, true).SplitToLines().Count;
     }
 
     public static bool HasLineTooLong(string? text, int singleLineMaxLength, int maxNumberOfLines)
@@ -199,11 +276,31 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
         return false;
     }
 
+    public sealed class SplitOptions
+    {
+        /// <summary>Gap reserved between the events a subtitle is split into.</summary>
+        public double MinimumGapMs { get; init; }
+
+        /// <summary>Move teletext rows (EBU STL MarginV) so the bottom edge of the text stays put.</summary>
+        public bool AdjustTeletextRows { get; init; }
+
+        public bool TeletextDoubleHeight { get; init; }
+    }
+
     public static List<SubtitleLineViewModel> Split(SubtitleLineViewModel item, int maxCharactersPerSubtitle, int singleLineMaxLength)
+    {
+        return Split(item, maxCharactersPerSubtitle, singleLineMaxLength, new SplitOptions());
+    }
+
+    /// <summary>
+    /// Cuts a subtitle that does not fit its limits into several events. Text is never re-wrapped
+    /// here (#10959): split-only keeps each event's text as-is, and auto-wrapping stays with the
+    /// opt-in rebalance step.
+    /// </summary>
+    public static List<SubtitleLineViewModel> Split(SubtitleLineViewModel item, int maxCharactersPerSubtitle, int singleLineMaxLength, SplitOptions options)
     {
         var lines = new List<SubtitleLineViewModel>();
 
-        // Guard clauses
         var originalText = item.Text ?? string.Empty;
         var originalStartMs = item.StartTime.TotalMilliseconds;
         var originalEndMs = item.EndTime.TotalMilliseconds;
@@ -212,49 +309,37 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
         // Per-line maximum for visual wrapping and per-subtitle maximum for splitting
         var perLineMax = Math.Max(5, singleLineMaxLength);
         var perSubtitleMax = Math.Max(perLineMax, maxCharactersPerSubtitle);
+        var maxNumberOfLines = Math.Max(1, perSubtitleMax / perLineMax);
 
-        // If already short enough, return as-is
         var plainText = HtmlUtil.RemoveHtmlTags(originalText, true).Replace("\r\n", " ").Replace('\n', ' ').Trim();
-        if (plainText.Length <= perSubtitleMax || string.IsNullOrWhiteSpace(plainText))
+        var originalLineCount = GetPlainLineCount(originalText);
+
+        // Same rule as SE4's QualifiesForSplit: a subtitle that fits in total can still be
+        // unusable because one of its lines is too long or it has too many lines.
+        var fitsInTotal = plainText.Length <= perSubtitleMax;
+        if (string.IsNullOrWhiteSpace(plainText) ||
+            (fitsInTotal && !HasLineTooLong(originalText, perLineMax, maxNumberOfLines)))
         {
             lines.Add(item);
             return lines;
         }
 
-        // Prepare segments trying to split at natural boundaries
-        var remaining = originalText.Trim();
-        var segments = new List<string>();
-
-        while (!string.IsNullOrEmpty(remaining))
+        List<string> segments;
+        if (fitsInTotal && originalLineCount > 1)
         {
-            var remainingPlain = HtmlUtil.RemoveHtmlTags(remaining, true).Replace("\r\n", " ").Replace('\n', ' ').Trim();
-            if (remainingPlain.Length <= perSubtitleMax)
-            {
-                segments.Add(remaining.Trim());
-                break;
-            }
-
-            // Find best split position that keeps plain length <= perSubtitleMax
-            var splitIdx = FindBestSplitIndexByPlainLength(remaining, perSubtitleMax);
-            if (splitIdx <= 0)
-            {
-                // Fallback to previous logic using raw index near limit
-                var approxCut = Math.Min(remaining.Length - 1, perSubtitleMax);
-                splitIdx = FindBestSplitIndex(remaining, approxCut);
-            }
-
-            var part = remaining.Substring(0, splitIdx + 1).Trim();
-            if (!string.IsNullOrWhiteSpace(part))
-            {
-                segments.Add(part);
-            }
-
-            remaining = splitIdx + 1 < remaining.Length
-                ? remaining.Substring(splitIdx + 1).Trim()
-                : string.Empty;
+            // Only a line is too long or there are too many lines: the author's line breaks
+            // are the natural event boundaries, so cut there instead of re-flowing the text.
+            segments = SplitAtLineBreaks(originalText, perLineMax, maxNumberOfLines);
+        }
+        else
+        {
+            // A single line that fits in total must still be cut so each event fits on one
+            // line; a text over the total limit is cut by the subtitle limit as before.
+            var limit = fitsInTotal ? perLineMax : perSubtitleMax;
+            segments = SplitByLength(originalText.Trim(), limit);
         }
 
-        if (segments.Count == 0)
+        if (segments.Count <= 1)
         {
             lines.Add(item);
             return lines;
@@ -274,23 +359,19 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
             charCounts.Add(cnt);
             totalChars += cnt;
         }
-        if (totalChars <= 0)
-        {
-            totalChars = segments.Count;
-            charCounts.Clear();
-            for (var i = 0; i < segments.Count; i++)
-            {
-                charCounts.Add(1);
-            }
-        }
+
+        // Reserve the minimum gap between the new events, like SE4 did; the gaps may take at
+        // most half the duration so a short subtitle still leaves time for its text.
+        var gapCount = segments.Count - 1;
+        var gapMs = Math.Min(Math.Max(0, options.MinimumGapMs), originalDurationMs / (2.0 * gapCount));
+        var textDurationMs = originalDurationMs - gapMs * gapCount;
 
         // Build new subtitle lines
-        double accumulatedMs = originalStartMs;
+        var accumulatedMs = originalStartMs;
         for (var i = 0; i < segments.Count; i++)
         {
             var segText = segments[i];
 
-            // Calculate duration for this segment
             double segDurationMs;
             if (i == segments.Count - 1)
             {
@@ -299,13 +380,10 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
             }
             else
             {
-                segDurationMs = originalDurationMs * (charCounts[i] / (double)totalChars);
-                // Ensure we don't overrun
-                segDurationMs = Math.Max(0, Math.Min(segDurationMs, Math.Max(0, originalEndMs - accumulatedMs)));
+                segDurationMs = textDurationMs * (charCounts[i] / (double)totalChars);
+                segDurationMs = Math.Max(0, Math.Min(segDurationMs, originalEndMs - accumulatedMs - gapMs));
             }
 
-            // Keep the segment text as-is; auto-wrapping is opt-in via the
-            // RebalanceLongLines option, which runs its own AutoBreakLine pass.
             var newLine = new SubtitleLineViewModel(item, true)
             {
                 Text = segText,
@@ -313,20 +391,109 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
                 EndTime = TimeSpan.FromMilliseconds(accumulatedMs + segDurationMs)
             };
             newLine.UpdateDuration();
-            lines.Add(newLine);
 
-            accumulatedMs += segDurationMs;
+            if (options.AdjustTeletextRows)
+            {
+                var newRow = TeletextRowHelper.GetRowKeepingBottomEdge(item.MarginV, originalLineCount, GetPlainLineCount(segText), options.TeletextDoubleHeight);
+                if (newRow.HasValue)
+                {
+                    newLine.MarginV = newRow.Value.ToString(CultureInfo.InvariantCulture);
+                }
+            }
+
+            lines.Add(newLine);
+            accumulatedMs += segDurationMs + gapMs;
         }
 
         // In rare rounding cases, force end of last to original end
-        if (lines.Count > 0)
-        {
-            var last = lines[^1];
-            last.EndTime = TimeSpan.FromMilliseconds(originalEndMs);
-            last.UpdateDuration();
-        }
+        var last = lines[^1];
+        last.EndTime = TimeSpan.FromMilliseconds(originalEndMs);
+        last.UpdateDuration();
 
         return lines;
+
+        // Local helper: groups the existing lines into events of at most maxLines lines. A line
+        // over the per-line limit becomes an event of its own and is kept whole (SE4 did the
+        // same): the author's line is a better event than a cut in the middle of it, and the
+        // rebalance step can still wrap it.
+        static List<string> SplitAtLineBreaks(string text, int perLineMax, int maxLines)
+        {
+            var segments = new List<string>();
+            var group = new List<string>();
+            foreach (var line in text.SplitToLines())
+            {
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    continue;
+                }
+
+                var trimmed = line.Trim();
+                if (HtmlUtil.RemoveHtmlTags(trimmed, true).Length > perLineMax)
+                {
+                    FlushGroup();
+                    segments.Add(trimmed);
+                    continue;
+                }
+
+                if (group.Count == maxLines)
+                {
+                    FlushGroup();
+                }
+
+                group.Add(trimmed);
+            }
+
+            FlushGroup();
+            return segments;
+
+            void FlushGroup()
+            {
+                if (group.Count > 0)
+                {
+                    segments.Add(string.Join(Environment.NewLine, group));
+                    group.Clear();
+                }
+            }
+        }
+
+        // Local helper: cuts text at natural boundaries so each piece has at most maxPlainLen
+        // visible characters.
+        static List<string> SplitByLength(string text, int maxPlainLen)
+        {
+            var segments = new List<string>();
+            var remaining = text;
+
+            while (!string.IsNullOrEmpty(remaining))
+            {
+                var remainingPlain = HtmlUtil.RemoveHtmlTags(remaining, true).Replace("\r\n", " ").Replace('\n', ' ').Trim();
+                if (remainingPlain.Length <= maxPlainLen)
+                {
+                    segments.Add(remaining.Trim());
+                    break;
+                }
+
+                // Find best split position that keeps plain length <= maxPlainLen
+                var splitIdx = FindBestSplitIndexByPlainLength(remaining, maxPlainLen);
+                if (splitIdx <= 0)
+                {
+                    // Fallback to previous logic using raw index near limit
+                    var approxCut = Math.Min(remaining.Length - 1, maxPlainLen);
+                    splitIdx = FindBestSplitIndex(remaining, approxCut);
+                }
+
+                var part = remaining.Substring(0, splitIdx + 1).Trim();
+                if (!string.IsNullOrWhiteSpace(part))
+                {
+                    segments.Add(part);
+                }
+
+                remaining = splitIdx + 1 < remaining.Length
+                    ? remaining.Substring(splitIdx + 1).Trim()
+                    : string.Empty;
+            }
+
+            return segments;
+        }
 
         // Local helper: find the best split index near a target index (raw length based)
         static int FindBestSplitIndex(string text, int targetIndex)
@@ -675,9 +842,10 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
         }
     }
 
-    public void Initialize(List<SubtitleLineViewModel> toList)
+    public void Initialize(List<SubtitleLineViewModel> toList, bool isFormatEbu = false)
     {
         _allSubtitles = toList;
+        _isFormatEbu = isFormatEbu;
 
         var subtitle = new Subtitle();
         foreach (var line in toList)

--- a/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesWindow.cs
+++ b/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesWindow.cs
@@ -1,5 +1,7 @@
 using Avalonia;
+using Avalonia.Automation;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Media;
 using Avalonia.Data;
@@ -155,8 +157,22 @@ public class SplitBreakLongLinesWindow : Window
 
         var labelFixesAvailable = UiUtil.MakeLabel()
             .WithBindText(vm, nameof(vm.FixesInfo))
-            .WithMarginTop(10)
             .WithMarginLeft(10);
+
+        // Select all / none only touch the rebalance rows (the ones with a checkbox).
+        var panelHeader = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 5,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 10, 0, 0),
+            Children =
+            {
+                labelFixesAvailable.WithMarginRight(10),
+                UiUtil.MakeButton(Se.Language.General.SelectAll, vm.SelectAllCommand),
+                UiUtil.MakeButton(Se.Language.General.SelectNone, vm.SelectNoneCommand),
+            },
+        };
 
         // Sorting dropped in the DataGrid -> TableView conversion: the grid previews
         // split/rebalance fixes in subtitle order.
@@ -167,6 +183,26 @@ public class SplitBreakLongLinesWindow : Window
         dataGrid.ItemsSource = vm.Fixes;
         dataGrid.Columns.AddRange(new TableViewColumn[]
         {
+                new SeTableViewColumn
+                {
+                    Header = Se.Language.General.Apply,
+                    CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+                    HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+                    CellTemplate = new FuncDataTemplate<SplitBreakLongLinesItem>((_, _) => new Border
+                    {
+                        Background = Brushes.Transparent,
+                        Padding = new Thickness(4),
+                        Child = new CheckBox
+                        {
+                            Focusable = false,
+                            [!ToggleButton.IsCheckedProperty] = new Binding(nameof(SplitBreakLongLinesItem.IsSelected)),
+                            [!Visual.IsVisibleProperty] = new Binding(nameof(SplitBreakLongLinesItem.IsSelectable)),
+                            [!AutomationProperties.NameProperty] = new Binding(nameof(SplitBreakLongLinesItem.Name)),
+                            HorizontalAlignment = HorizontalAlignment.Center,
+                        },
+                    }),
+                    Width = new GridLength(70),
+                },
                 new SeTableViewColumn
                 {
                     Header = Se.Language.General.NumberSymbol,
@@ -225,6 +261,9 @@ public class SplitBreakLongLinesWindow : Window
                 },
         });
 
+        TableViewExtras.AddSpaceToggle<SplitBreakLongLinesItem>(dataGrid,
+            item => item.IsSelected, (item, v) => { if (item.IsSelectable) { item.IsSelected = v; } });
+
         dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
         {
             if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
@@ -236,7 +275,7 @@ public class SplitBreakLongLinesWindow : Window
             }
         }, RoutingStrategies.Tunnel);
 
-        grid.Add(labelFixesAvailable, 0);
+        grid.Add(panelHeader, 0);
         grid.Add(UiUtil.MakeBorderForControlNoPadding(dataGrid), 1);
 
         return grid;

--- a/src/ui/Logic/TeletextRowHelper.cs
+++ b/src/ui/Logic/TeletextRowHelper.cs
@@ -39,4 +39,28 @@ public static class TeletextRowHelper
         var newRow = GetBottomStartRow(newLineCount, doubleHeight);
         return newRow >= 1 ? newRow : null;
     }
+
+    /// <summary>
+    /// Row for a subtitle whose text is rewritten by a batch tool (split into several events, or
+    /// wrapped to another number of lines): the bottom edge stays where it was, so the start row
+    /// moves by the rows gained or lost (with double height 21 -> 23 for two lines becoming one,
+    /// 19 -> 21, 20 -> 22, and the inverse). Returns null when the row must be left alone: it is not
+    /// a teletext row, the line count did not change, or the new row would leave the page.
+    /// </summary>
+    public static int? GetRowKeepingBottomEdge(string marginV, int oldLineCount, int newLineCount, bool doubleHeight)
+    {
+        if (oldLineCount == newLineCount || oldLineCount < 1 || newLineCount < 1)
+        {
+            return null;
+        }
+
+        if (!int.TryParse(marginV, out var row) || row < 1 || row > BottomRow)
+        {
+            return null;
+        }
+
+        var rowsPerLine = doubleHeight ? 2 : 1;
+        var newRow = row + (oldLineCount - newLineCount) * rowsPerLine;
+        return newRow >= 1 && newRow <= BottomRow ? newRow : null;
+    }
 }

--- a/tests/UI/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesTests.cs
+++ b/tests/UI/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesTests.cs
@@ -1,5 +1,7 @@
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Tools.SplitBreakLongLines;
+using Nikse.SubtitleEdit.Logic;
 
 namespace UITests.Features.Tools.SplitBreakLongLines;
 
@@ -74,5 +76,202 @@ public class SplitBreakLongLinesTests
     {
         var normalized = text.Replace("\n", "\r\n");
         Assert.Equal(expected, SplitBreakLongLinesViewModel.HasLineTooLong(normalized, maxLength, maxLines));
+    }
+
+    // --- SE4 parity (PR #14006 by Triathlon-rally): a subtitle that fits in total can still be
+    // --- unusable because one line is too long or it has too many lines.
+
+    [Fact]
+    public void Split_TwoLinesOneTooLong_SplitsAtTheExistingLineBreak()
+    {
+        var item = MakeSubtitle("Und, war ich in der Kantine?\r\nNein, ich konnte Sie dort nicht finden.", 10, 14);
+
+        var result = SplitBreakLongLinesViewModel.Split(item, maxCharactersPerSubtitle: 72, singleLineMaxLength: 36);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("Und, war ich in der Kantine?", result[0].Text);
+        Assert.Equal("Nein, ich konnte Sie dort nicht finden.", result[1].Text); // 39 > 36
+        Assert.Equal(item.StartTime, result[0].StartTime);
+        Assert.Equal(item.EndTime, result[^1].EndTime);
+    }
+
+    [Fact]
+    public void Split_TooManyLines_GroupsLinesIntoEvents()
+    {
+        var item = MakeSubtitle("One\r\nTwo\r\nThree", 10, 14);
+
+        var result = SplitBreakLongLinesViewModel.Split(item, maxCharactersPerSubtitle: 72, singleLineMaxLength: 36);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("One\r\nTwo", result[0].Text.Replace("\n", "\r\n").Replace("\r\r", "\r"));
+        Assert.Equal("Three", result[1].Text);
+    }
+
+    [Fact]
+    public void Split_SingleLineOverLineLimitButWithinTotal_SplitsIntoSingleLineEvents()
+    {
+        // Split-only never inserts a line break (#10959), so the only way to make this fit is
+        // two events that each fit on one line.
+        var item = MakeSubtitle("This single line is too long and must become two events.", 10, 14); // 57 chars
+
+        var result = SplitBreakLongLinesViewModel.Split(item, maxCharactersPerSubtitle: 72, singleLineMaxLength: 36);
+
+        Assert.Equal(2, result.Count);
+        Assert.All(result, line =>
+        {
+            Assert.DoesNotContain("\n", line.Text);
+            Assert.True(line.Text.Length <= 36);
+        });
+    }
+
+    [Fact]
+    public void Split_CompliantUnbalancedTwoLines_RemainsUnchanged()
+    {
+        var item = MakeSubtitle("This is intentionally longer\r\nshort.", 10, 14);
+
+        var result = SplitBreakLongLinesViewModel.Split(item, maxCharactersPerSubtitle: 72, singleLineMaxLength: 36);
+
+        Assert.Single(result);
+        Assert.Same(item, result[0]);
+    }
+
+    [Fact]
+    public void Split_ReservesMinimumGapBetweenEventsAndKeepsOuterTimeCodes()
+    {
+        var item = MakeSubtitle(string.Join(' ', Enumerable.Repeat("word", 40)), 10, 14);
+        var options = new SplitBreakLongLinesViewModel.SplitOptions { MinimumGapMs = 120 };
+
+        var result = SplitBreakLongLinesViewModel.Split(item, maxCharactersPerSubtitle: 72, singleLineMaxLength: 36, options);
+
+        Assert.True(result.Count >= 2);
+        Assert.Equal(item.StartTime, result[0].StartTime);
+        Assert.Equal(item.EndTime, result[^1].EndTime);
+        for (var i = 1; i < result.Count; i++)
+        {
+            var gapMs = result[i].StartTime.TotalMilliseconds - result[i - 1].EndTime.TotalMilliseconds;
+            Assert.Equal(120, gapMs, 1);
+            Assert.True(result[i - 1].Duration.TotalMilliseconds > 0);
+        }
+    }
+
+    [Fact]
+    public void Split_GapIsClampedSoTextKeepsAtLeastHalfTheDuration()
+    {
+        var item = MakeSubtitle(string.Join(' ', Enumerable.Repeat("word", 40)), 10, 10.2);
+        var options = new SplitBreakLongLinesViewModel.SplitOptions { MinimumGapMs = 1000 };
+
+        var result = SplitBreakLongLinesViewModel.Split(item, maxCharactersPerSubtitle: 72, singleLineMaxLength: 36, options);
+
+        Assert.True(result.Count >= 2);
+        Assert.Equal(item.EndTime, result[^1].EndTime);
+        var textMs = result.Sum(p => p.Duration.TotalMilliseconds);
+        Assert.True(textMs >= 100 - 1, $"text time {textMs} ms");
+        Assert.All(result, p => Assert.True(p.Duration.TotalMilliseconds > 0));
+    }
+
+    [Fact]
+    public void Split_WithoutGap_EventsAreBackToBack()
+    {
+        var item = MakeSubtitle(string.Join(' ', Enumerable.Repeat("word", 40)), 10, 14);
+
+        var result = SplitBreakLongLinesViewModel.Split(item, maxCharactersPerSubtitle: 72, singleLineMaxLength: 36);
+
+        for (var i = 1; i < result.Count; i++)
+        {
+            Assert.Equal(result[i - 1].EndTime, result[i].StartTime);
+        }
+    }
+
+    [Theory]
+    [InlineData("21", "23")]
+    [InlineData("19", "21")]
+    [InlineData("20", "22")]
+    public void Split_TeletextTwoLinesIntoOneLineEvents_KeepsBottomEdge(string marginV, string expectedOneLineRow)
+    {
+        var item = MakeSubtitle("Und, war ich in der Kantine?\r\nNein, ich konnte Sie dort wirklich überhaupt nicht finden.", 10, 14);
+        item.MarginV = marginV;
+        var options = new SplitBreakLongLinesViewModel.SplitOptions { AdjustTeletextRows = true, TeletextDoubleHeight = true };
+
+        var result = SplitBreakLongLinesViewModel.Split(item, maxCharactersPerSubtitle: 72, singleLineMaxLength: 36, options);
+
+        Assert.Equal(2, result.Count);
+        Assert.All(result, p => Assert.Single(p.Text.SplitToLines()));
+        Assert.All(result, p => Assert.Equal(expectedOneLineRow, p.MarginV)); // bottom edge unchanged
+        Assert.NotEqual(expectedOneLineRow, marginV);
+    }
+
+    [Theory]
+    [InlineData("23", "21")]
+    [InlineData("21", "19")]
+    [InlineData("22", "20")]
+    public void Rebalance_TeletextOneLineIntoTwo_KeepsBottomEdge(string marginV, string expectedTwoLineRow)
+    {
+        Assert.Equal(int.Parse(expectedTwoLineRow), TeletextRowHelper.GetRowKeepingBottomEdge(marginV, 1, 2, doubleHeight: true));
+    }
+
+    [Fact]
+    public void Split_NotEbu_LeavesMarginVAlone()
+    {
+        // MarginV is a pixel margin for ASSA - only an EBU file gets its rows shifted.
+        var item = MakeSubtitle("Und, war ich in der Kantine?\r\nNein, ich konnte Sie dort nicht finden.", 10, 14);
+        item.MarginV = "21";
+
+        var result = SplitBreakLongLinesViewModel.Split(item, maxCharactersPerSubtitle: 72, singleLineMaxLength: 36);
+
+        Assert.Equal(2, result.Count);
+        Assert.All(result, p => Assert.Equal("21", p.MarginV));
+    }
+
+    [Fact]
+    public void RebalanceFix_UncheckRestoresOriginalText()
+    {
+        var subtitle = MakeSubtitle("This is the original subtitle text.", 10, 14);
+        var fix = new SplitBreakLongLinesItem("Rebalance", 1, "preview", subtitle, "This is the\r\nproposed text.");
+
+        Assert.True(fix.IsSelectable);
+        Assert.True(fix.IsSelected);
+        Assert.Equal("This is the\r\nproposed text.", subtitle.Text);
+
+        fix.IsSelected = false;
+        Assert.Equal("This is the original subtitle text.", subtitle.Text);
+
+        fix.IsSelected = true;
+        Assert.Equal("This is the\r\nproposed text.", subtitle.Text);
+    }
+
+    [Fact]
+    public void RebalanceFix_TeletextRowFollowsTheCheckbox()
+    {
+        var subtitle = MakeSubtitle("One line on the bottom row.", 10, 14);
+        subtitle.MarginV = "23";
+        var fix = new SplitBreakLongLinesItem("Rebalance", 1, "preview", subtitle, "One line on\r\nthe bottom row.", "21");
+
+        Assert.Equal("21", subtitle.MarginV);
+        fix.IsSelected = false;
+        Assert.Equal("23", subtitle.MarginV);
+        Assert.Equal("One line on the bottom row.", subtitle.Text);
+    }
+
+    [Fact]
+    public void SelectAllAndSelectNone_TouchOnlyRebalanceFixes()
+    {
+        var vm = new SplitBreakLongLinesViewModel();
+        var rebalanced = MakeSubtitle("Original.", 10, 14);
+        var split = MakeSubtitle("Split item.", 10, 14);
+        var rebalanceFix = new SplitBreakLongLinesItem("Rebalance", 1, "preview", rebalanced, "Changed.");
+        var splitFix = new SplitBreakLongLinesItem("Split", 2, "preview", split);
+        vm.Fixes.Add(rebalanceFix);
+        vm.Fixes.Add(splitFix);
+
+        vm.SelectNoneCommand.Execute(null);
+        Assert.False(rebalanceFix.IsSelected);
+        Assert.True(splitFix.IsSelected);
+        Assert.Equal("Original.", rebalanced.Text);
+
+        vm.SelectAllCommand.Execute(null);
+        Assert.True(rebalanceFix.IsSelected);
+        Assert.Equal("Changed.", rebalanced.Text);
+
+        vm.OnClosingCleanup();
     }
 }

--- a/tests/UI/Logic/TeletextRowHelperTests.cs
+++ b/tests/UI/Logic/TeletextRowHelperTests.cs
@@ -55,4 +55,30 @@ public class TeletextRowHelperTests
         // 12 double-height lines would start above row 1 - leave the row untouched.
         Assert.Null(TeletextRowHelper.GetAdjustedBottomRow("23", 1, 13, doubleHeight: true));
     }
+
+    // Batch tools (split long lines) keep the bottom edge of the text where it was, for any row.
+    [Theory]
+    [InlineData("21", 2, 1, true, 23)]
+    [InlineData("19", 2, 1, true, 21)]
+    [InlineData("20", 2, 1, true, 22)]
+    [InlineData("23", 1, 2, true, 21)]
+    [InlineData("21", 1, 2, true, 19)]
+    [InlineData("22", 1, 2, true, 20)]
+    [InlineData("23", 1, 2, false, 22)]
+    public void GetRowKeepingBottomEdge_MovesStartRowByRowsGainedOrLost(string marginV, int oldLines, int newLines, bool doubleHeight, int expected)
+    {
+        Assert.Equal(expected, TeletextRowHelper.GetRowKeepingBottomEdge(marginV, oldLines, newLines, doubleHeight));
+    }
+
+    [Theory]
+    [InlineData("23", 1, 1)] // line count unchanged
+    [InlineData("", 1, 2)] // no row
+    [InlineData("abc", 1, 2)] // not a row
+    [InlineData("40", 1, 2)] // ASSA-style pixel margin, not a teletext row
+    [InlineData("23", 2, 1)] // would leave the page at the bottom
+    [InlineData("2", 1, 2)] // would leave the page at the top
+    public void GetRowKeepingBottomEdge_LeavesRowAlone(string marginV, int oldLines, int newLines)
+    {
+        Assert.Null(TeletextRowHelper.GetRowKeepingBottomEdge(marginV, oldLines, newLines, doubleHeight: true));
+    }
 }


### PR DESCRIPTION
Re-does the bug fixes from #14006 by @Triathlon-rally on top of current `main`, without the unrelated parts (toolbar "Header" button, 10 ms Apply-min-gap tolerance, comment removals, reformatting).

## Bugs fixed
- **Overlong lines were never split.** `Split()` only looked at the total length, so a subtitle whose *line* exceeds the single-line max (or has too many lines) was left untouched. It now uses SE4's `QualifiesForSplit` rule. A multi-line subtitle that fits in total is cut at the author's line breaks; split-only still never inserts line breaks (#10959). When *Rebalance* is also on, subtitles that re-wrapping can fix are not cut into events (SE4's "don't split if it can be balanced").
- **No gap between split events.** The general minimum gap is now reserved between the new events (clamped to half the duration so short subtitles keep text time), like SE4 did. Outer timecodes are preserved.
- **Duplicate numbers after splitting.** Split clones kept the source number; the main window now renumbers after the dialog, and the preview renumbers too.

## Kept from #14006
- Rebalance fixes get an **Apply** checkbox (Space toggles, Select all / Select none). Unchecking restores the original text (and teletext row).
- **EBU STL teletext rows keep their bottom edge** when the line count changes: 21↔23, 19↔21, 20↔22 (`TeletextRowHelper.GetRowKeepingBottomEdge`). Gated on `IsFormatEbu`, so ASSA pixel margins are never touched.

All strings come from existing `Language` entries. Tests: 14 new split tests + 2 teletext helper theories; full UI suite green locally (3453 passed).

Closes #14006.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
