### PR TITLE
FixContinuationStyle: sanitize each paragraph once instead of twice

### DIFF
--- a/src/libse/Forms/FixCommonErrors/FixContinuationStyle.cs
+++ b/src/libse/Forms/FixCommonErrors/FixContinuationStyle.cs
@@ -40,14 +40,22 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             var inSentence = false;
             bool? inItalicSentence = null;
 
+            // SanitizeString runs four regex replaces per call, and the loop sanitized every
+            // paragraph twice: once as pNext's text, then again as p's text one iteration later.
+            // Carry the sanitized "next" value forward instead. The carry is dropped whenever the
+            // loop writes pNext.Text below, so the following iteration re-sanitizes what the
+            // paragraph actually holds.
+            string carriedText = null;
+
             for (var i = 0; i < subtitle.Paragraphs.Count - 1; i++)
             {
                 var p = subtitle.Paragraphs[i];
                 var pNext = subtitle.Paragraphs[i + 1];
                 var oldText = p.Text;
                 var oldTextNext = pNext.Text;
-                var text = ContinuationUtilities.SanitizeString(p.Text);
+                var text = carriedText ?? ContinuationUtilities.SanitizeString(p.Text);
                 var textNext = ContinuationUtilities.SanitizeString(pNext.Text);
+                carriedText = textNext; // captured before the Arabic conversion below, which the next iteration reapplies
                 var isChecked = true;
                 var shouldProcess = true;
 
@@ -207,6 +215,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                             if (IsPreviewStep(callbacks) && isChecked || !IsPreviewStep(callbacks))
                             {
                                 pNext.Text = newTextNext;
+                                carriedText = null; // pNext.Text changed - the next iteration must re-sanitize
                             }
 
                             fixCount++;

--- a/tests/libse/Common/UtilitiesCountTagInTextTest.cs
+++ b/tests/libse/Common/UtilitiesCountTagInTextTest.cs
@@ -1,0 +1,35 @@
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace LibSETests.Common;
+
+public class UtilitiesCountTagInTextTest
+{
+    // The char overload has two implementations: MemoryExtensions.Count on net8+ and an
+    // IndexOf loop on netstandard2.1. Both must agree on these, in particular on a hit that
+    // lands on the very last index - the loop returns early from inside its body there.
+    [Theory]
+    [InlineData("", '"', 0)]
+    [InlineData("no quotes here", '"', 0)]
+    [InlineData("\"", '"', 1)]
+    [InlineData("say \"this\"", '"', 2)]
+    [InlineData("\"\"\"", '"', 3)]
+    [InlineData("- No.\r\n- Then stay.", '-', 2)]
+    [InlineData("{\\an8}{\\pos(10,20)}Hi", '{', 2)]
+    [InlineData("aaa", 'a', 3)]
+    public void CountsEveryOccurrenceOfChar(string text, char tag, int expected)
+    {
+        Assert.Equal(expected, Utilities.CountTagInText(text, tag));
+    }
+
+    // The char and string overloads are separate implementations; for a single-character tag
+    // they must not drift apart.
+    [Theory]
+    [InlineData("\"Are you coming?\" she asked.", '"')]
+    [InlineData("- Yes.\r\n- No.", '-')]
+    [InlineData("nothing to find", 'z')]
+    [InlineData("trailing hit-", '-')]
+    public void CharOverloadAgreesWithStringOverload(string text, char tag)
+    {
+        Assert.Equal(Utilities.CountTagInText(text, tag.ToString()), Utilities.CountTagInText(text, tag));
+    }
+}

--- a/tests/libse/Forms/FixCommonErrors/FixContinuationStyleTest.cs
+++ b/tests/libse/Forms/FixCommonErrors/FixContinuationStyleTest.cs
@@ -1,0 +1,42 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
+using Nikse.SubtitleEdit.Core.Forms.FixCommonErrors;
+
+namespace LibSETests.Forms.FixCommonErrors;
+
+public class FixContinuationStyleTest
+{
+    // The rule walks paragraph pairs and carries paragraph i+1's sanitized text forward to use
+    // as paragraph i's on the next iteration, rather than sanitizing every paragraph twice.
+    // Carrying the wrong side of the pair still produces the right answer on a plain
+    // continuation chain, so this pins a case that actually discriminates: only paragraph 2
+    // continues into paragraph 3 (40 ms gap), while paragraph 1 ends a sentence and paragraph 4
+    // is too far away (1600 ms). Get the carry wrong and paragraph 2 keeps its dots-less text.
+    [Fact]
+    public void OnlyTheContinuingParagraphGetsTrailingDots()
+    {
+        var previousStyle = Configuration.Settings.General.ContinuationStyle;
+        try
+        {
+            Configuration.Settings.General.ContinuationStyle = ContinuationStyle.OnlyTrailingDots;
+
+            var subtitle = new Subtitle();
+            subtitle.Paragraphs.Add(new Paragraph("Wait!", 0, 1122));
+            subtitle.Paragraphs.Add(new Paragraph("I was going to tell you", 1162, 3083));
+            subtitle.Paragraphs.Add(new Paragraph("and now it is too late", 3123, 4220));
+            subtitle.Paragraphs.Add(new Paragraph("[door slams]", 5820, 7720));
+            subtitle.Renumber();
+
+            new FixContinuationStyle { FixAction = "act" }.Fix(subtitle, new EmptyFixCallback());
+
+            Assert.Equal("Wait!", subtitle.Paragraphs[0].Text);
+            Assert.Equal("I was going to tell you...", subtitle.Paragraphs[1].Text);
+            Assert.Equal("and now it is too late", subtitle.Paragraphs[2].Text);
+            Assert.Equal("[door slams]", subtitle.Paragraphs[3].Text);
+        }
+        finally
+        {
+            Configuration.Settings.General.ContinuationStyle = previousStyle;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`FixContinuationStyle.Fix` walks paragraph pairs and called `ContinuationUtilities.SanitizeString` on both `p` and `pNext` every iteration — so **every paragraph was sanitized twice**: once as `pNext`'s text, then again as `p`'s text one iteration later. `SanitizeString` runs four regex replaces per call, and it is the single largest cost in this rule.

This carries the sanitized "next" value forward instead. Two details make it exact:

- the carry is captured **before** the Arabic conversion, which the next iteration reapplies;
- the carry is **dropped whenever the loop writes `pNext.Text`**, so the following iteration re-sanitizes what the paragraph actually holds.

## Benchmark

Apple M4, .NET 10.0.7, Release, best-of-3 with a 300-pass warmup, `new Subtitle(...)` copy cost subtracted.

| corpus | before | after | |
|---|---:|---:|---|
| general 1500-cue file | 0.926 ms | **0.654 ms** | **−29%** |
| continuation-heavy 1200-cue file | 2.274 ms | **2.111 ms** | −7% |

`SanitizeString` calls over the 1500-cue file: **3462 → 1964 (−43%)**.

The continuation-heavy corpus gains less precisely because more paragraphs get rewritten, which drops the carry — the safety path doing its job.

## Correctness

- **Output-identical across 192 configurations**: 2 corpora × 12 continuation styles × 4 languages × 2 lyrics settings, comparing every resulting paragraph text *and* every callback log entry (`AllowFix` / `AddFixToListView` / `UpdateFixStatus`). **85,116 recorded fix events, identical checksums.**
- **2.4M randomized rule invocations** comparing carry against no-carry: no divergence.
- `LibSETests`: 1425/1425 pass. `LibSE.csproj` builds clean for both `netstandard2.1` and `net10.0`.

Note: the `carriedText = null` invalidation never actually changed output in those 2.4M combinations — the predicates consuming the sanitized text are prefix-insensitive by design. It is kept so the equivalence is structural rather than dependent on that property continuing to hold.

## Tests

- **`FixContinuationStyleTest`** — pins a case that genuinely discriminates a correct carry from a wrong one. Worth noting: a plain continuation chain does **not** — it passes even with a deliberately broken carry, so that version was discarded in favour of one found by brute-force search. Mutation-checked: swapping `textNext` for `text` in the carry makes it fail.
- **`UtilitiesCountTagInTextTest`** — `Utilities.CountTagInText` had no direct tests, despite the char overload being about to have two implementations to keep in step (#13991). Covers empty, no-match, adjacent hits, and a hit on the final index (where the `netstandard2.1` loop returns early from inside its body), plus agreement between the char and string overloads. Deliberately does not pin null behaviour, which differs by target framework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
