### PR TITLE
Speech to text: transcription quality report, non-speech/repeat removal, overlap fix (#13973)

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -213,6 +213,7 @@ using TmpegEncXmlPropertiesViewModel = Nikse.SubtitleEdit.Features.Files.FormatP
 using VideoPlayerUndockedViewModel = Nikse.SubtitleEdit.Features.Shared.Undocked.VideoPlayerUndockedViewModel;
 using SpeechToTextAdvancedViewModel = Nikse.SubtitleEdit.Features.Video.SpeechToText.SpeechToTextAdvancedViewModel;
 using SpeechToTextPostProcessingViewModel = Nikse.SubtitleEdit.Features.Video.SpeechToText.SpeechToTextPostProcessingViewModel;
+using SpeechToTextQualityReportViewModel = Nikse.SubtitleEdit.Features.Video.SpeechToText.SpeechToTextQualityReportViewModel;
 
 namespace Nikse.SubtitleEdit;
 
@@ -571,6 +572,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<WebVttStylePickerViewModel>();
         collection.AddTransient<SpeechToTextAdvancedViewModel>();
         collection.AddTransient<SpeechToTextPostProcessingViewModel>();
+        collection.AddTransient<SpeechToTextQualityReportViewModel>();
         collection.AddTransient<WordListsViewModel>();
     }
 

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextPostProcessingViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextPostProcessingViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -15,6 +15,9 @@ public partial class SpeechToTextPostProcessingViewModel : ObservableObject
     [ObservableProperty] private bool _fixShortDuration;
     [ObservableProperty] private bool _fixCasing;
     [ObservableProperty] private bool _addPeriods;
+    [ObservableProperty] private bool _removeNonSpeechLines;
+    [ObservableProperty] private bool _removeRepeatedLines;
+    [ObservableProperty] private bool _showQualityReport;
     [ObservableProperty] private bool _changeUnderlineToColor;
     [ObservableProperty] private Color _changeUnderlineToColorColor;
 

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextPostProcessingWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextPostProcessingWindow.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Data;
 using Avalonia.Input;
@@ -42,6 +42,17 @@ public class SpeechToTextPostProcessingWindow : Window
         var labelAddPeriods = UiUtil.MakeTextBlock(Se.Language.Video.AudioToText.AddPeriods);
         var checkAddPeriods = UiUtil.MakeCheckBox(vm, nameof(SpeechToTextPostProcessingViewModel.AddPeriods));
 
+        var labelRemoveNonSpeechLines = UiUtil.MakeTextBlock(Se.Language.Video.AudioToText.RemoveNonSpeechLines);
+        var checkRemoveNonSpeechLines = UiUtil.MakeCheckBox(vm, nameof(SpeechToTextPostProcessingViewModel.RemoveNonSpeechLines));
+        SetHint(labelRemoveNonSpeechLines, checkRemoveNonSpeechLines, Se.Language.Video.AudioToText.RemoveNonSpeechLinesHint);
+
+        var labelRemoveRepeatedLines = UiUtil.MakeTextBlock(Se.Language.Video.AudioToText.RemoveRepeatedLines);
+        var checkRemoveRepeatedLines = UiUtil.MakeCheckBox(vm, nameof(SpeechToTextPostProcessingViewModel.RemoveRepeatedLines));
+        SetHint(labelRemoveRepeatedLines, checkRemoveRepeatedLines, Se.Language.Video.AudioToText.RemoveRepeatedLinesHint);
+
+        var labelShowQualityReport = UiUtil.MakeTextBlock(Se.Language.Video.AudioToText.ShowQualityReport);
+        var checkShowQualityReport = UiUtil.MakeCheckBox(vm, nameof(SpeechToTextPostProcessingViewModel.ShowQualityReport));
+
         var labelChangeUnderlineToColor = UiUtil.MakeTextBlock(Se.Language.Video.AudioToText.ChangeUnderlineToColor);
         var checkChangeUnderlineToColor = UiUtil.MakeCheckBox(vm, nameof(SpeechToTextPostProcessingViewModel.ChangeUnderlineToColor));
         var colorPickerUnderlineToColor = UiUtil.MakeColorPickerButton(_vm, nameof(_vm.ChangeUnderlineToColorColor));
@@ -55,6 +66,9 @@ public class SpeechToTextPostProcessingWindow : Window
         {
             RowDefinitions =
             {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
@@ -103,6 +117,18 @@ public class SpeechToTextPostProcessingWindow : Window
         grid.Add(checkAddPeriods, row, 1);
         row++;
 
+        grid.Add(labelRemoveNonSpeechLines, row, 0);
+        grid.Add(checkRemoveNonSpeechLines, row, 1);
+        row++;
+
+        grid.Add(labelRemoveRepeatedLines, row, 0);
+        grid.Add(checkRemoveRepeatedLines, row, 1);
+        row++;
+
+        grid.Add(labelShowQualityReport, row, 0);
+        grid.Add(checkShowQualityReport, row, 1);
+        row++;
+
         grid.Add(labelChangeUnderlineToColor, row, 0);
         grid.Add(checkChangeUnderlineToColor, row, 1);
         grid.Add(colorPickerUnderlineToColor, row, 2);
@@ -136,6 +162,17 @@ public class SpeechToTextPostProcessingWindow : Window
         Content = outerGrid;
 
         Activated += delegate { Focus(); }; // hack to make OnKeyDown work
+    }
+
+    private static void SetHint(Control label, Control checkBox, string hint)
+    {
+        if (!Se.Settings.Appearance.ShowHints)
+        {
+            return;
+        }
+
+        ToolTip.SetTip(label, hint);
+        ToolTip.SetTip(checkBox, hint);
     }
 
     protected override void OnKeyDown(KeyEventArgs e)

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextPostProcessor.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextPostProcessor.cs
@@ -35,6 +35,25 @@ namespace Nikse.SubtitleEdit.Features.Video.SpeechToText
 
         public string TwoLetterLanguageCode { get; }
 
+        /// <summary>
+        /// Drop lines that are only a sound/music description ("[Music]", "(waves)").
+        /// Whisper emits these on long stretches without speech (issue #13973).
+        /// </summary>
+        public bool RemoveNonSpeechLines { get; set; }
+
+        /// <summary>
+        /// Drop lines whose text repeats the previous line - the classic whisper
+        /// hallucination loop (issue #13973).
+        /// </summary>
+        public bool RemoveRepeatedLines { get; set; }
+
+        /// <summary>
+        /// What was found (and removed) during the last <see cref="Fix(Engine, Subtitle, bool, bool, bool, bool, bool, bool, bool, Color)"/> call.
+        /// Always populated, even when post-processing is off, so the user is told
+        /// when a transcription went badly instead of finding out later (issue #13973).
+        /// </summary>
+        public SpeechToTextQualityReport QualityReport { get; private set; } = new();
+
         public SpeechToTextPostProcessor(string twoLetterLanguageCode)
         {
             TwoLetterLanguageCode = twoLetterLanguageCode == "no" ? "nb" : twoLetterLanguageCode;
@@ -77,10 +96,27 @@ namespace Nikse.SubtitleEdit.Features.Video.SpeechToText
             Color changeUnderlineToColorColor)
         {
             var subtitle = new Subtitle();
+            QualityReport = new SpeechToTextQualityReport();
 
             for (var index = 0; index < input.Paragraphs.Count; index++)
             {
                 var paragraph = input.Paragraphs[index];
+
+                if (usePostProcessing && RemoveNonSpeechLines && SpeechToTextQualityReport.IsNonSpeechLine(paragraph.Text))
+                {
+                    QualityReport.Removed.Add(SpeechToTextQualityReport.MakeIssue(SpeechToTextQualityIssueType.NonSpeech, paragraph, index + 1, string.Empty));
+                    continue;
+                }
+
+                // Compare against the last line we kept, so a run of five identical
+                // lines collapses to one rather than to every other line.
+                var lastKept = subtitle.GetParagraphOrDefault(subtitle.Paragraphs.Count - 1);
+                if (usePostProcessing && RemoveRepeatedLines && lastKept != null && SpeechToTextQualityReport.IsRepeatOf(paragraph.Text, lastKept.Text))
+                {
+                    QualityReport.Removed.Add(SpeechToTextQualityReport.MakeIssue(SpeechToTextQualityIssueType.Repeated, paragraph, index + 1, $"= #{index}"));
+                    continue;
+                }
+
                 if (usePostProcessing && engine == Engine.Vosk && TwoLetterLanguageCode == "en" && paragraph.Text == "the" && paragraph.EndTime.TotalSeconds - paragraph.StartTime.TotalSeconds > 1)
                 {
                     continue;
@@ -135,6 +171,9 @@ namespace Nikse.SubtitleEdit.Features.Video.SpeechToText
                 }
             }
 
+            var general = Configuration.Settings.General;
+            QualityReport.Analyze(postProcessed, general.SubtitleMinimumDisplayMilliseconds, general.SubtitleMaximumDisplayMilliseconds, general.SubtitleMaximumCharactersPerSeconds);
+
             return postProcessed;
         }
 
@@ -160,6 +199,11 @@ namespace Nikse.SubtitleEdit.Features.Video.SpeechToText
                 if (fixShortDuration)
                 {
                     subtitle = FixShortDuration(subtitle);
+
+                    // Engines hand back overlapping segments, and extending short
+                    // lines can create more - straighten them out so the result
+                    // does not arrive in the grid full of red overlaps (issue #13973).
+                    subtitle = FixOverlaps(subtitle);
                 }
 
                 if (splitLines && !IsNonStandardLineTerminationLanguage(TwoLetterLanguageCode) && AllowLineContentMove(engine))
@@ -579,6 +623,13 @@ namespace Nikse.SubtitleEdit.Features.Video.SpeechToText
         {
             var subtitle = new Subtitle(inputSubtitle);
             new FixShortDisplayTimes().Fix(subtitle, new EmptyFixCallback());
+            return subtitle;
+        }
+
+        private static Subtitle FixOverlaps(Subtitle inputSubtitle)
+        {
+            var subtitle = new Subtitle(inputSubtitle);
+            new FixOverlappingDisplayTimes().Fix(subtitle, new EmptyFixCallback());
             return subtitle;
         }
     }

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextQualityReport.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextQualityReport.cs
@@ -1,0 +1,211 @@
+﻿using Nikse.SubtitleEdit.Core.Common;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Nikse.SubtitleEdit.Features.Video.SpeechToText;
+
+public enum SpeechToTextQualityIssueType
+{
+    /// <summary>Display time below the minimum, or reading speed above the maximum.</summary>
+    TooShort,
+
+    /// <summary>Display time above the maximum, or a long span with very little text (typical hallucination).</summary>
+    TooLong,
+
+    /// <summary>End time is later than the next line's start time.</summary>
+    Overlap,
+
+    /// <summary>Text is only a sound/music description such as "[Music]" or "(waves crashing)".</summary>
+    NonSpeech,
+
+    /// <summary>Same text as the previous line (engine loop).</summary>
+    Repeated,
+}
+
+public class SpeechToTextQualityIssue
+{
+    public SpeechToTextQualityIssueType Type { get; init; }
+    public int Number { get; init; }
+    public TimeCode StartTime { get; init; } = new TimeCode();
+    public TimeCode EndTime { get; init; } = new TimeCode();
+    public string Text { get; init; } = string.Empty;
+
+    /// <summary>Short machine-independent detail, e.g. "0.2 s" or "31.5 cps".</summary>
+    public string Detail { get; init; } = string.Empty;
+}
+
+/// <summary>
+/// Result of checking a speech-to-text transcript for the defect classes users keep
+/// running into (issue #13973): lines too short to read, suspiciously long lines,
+/// overlaps, non-speech descriptions and repeated (looping) lines. Lines the
+/// post-processor removed are listed with <see cref="Removed"/> set so the report
+/// can tell "fixed" from "still there".
+/// </summary>
+public class SpeechToTextQualityReport
+{
+    public List<SpeechToTextQualityIssue> Issues { get; } = new();
+
+    /// <summary>Lines that were dropped by post-processing (non-speech / repeats), for the report.</summary>
+    public List<SpeechToTextQualityIssue> Removed { get; } = new();
+
+    public int TotalLines { get; set; }
+
+    public bool HasIssues => Issues.Count > 0 || Removed.Count > 0;
+
+    public int Count(SpeechToTextQualityIssueType type)
+    {
+        return Issues.Count(p => p.Type == type);
+    }
+
+    public int RemovedCount(SpeechToTextQualityIssueType type)
+    {
+        return Removed.Count(p => p.Type == type);
+    }
+
+    /// <summary>
+    /// Long line with very little text — below this many characters per second over
+    /// <see cref="SparseMinDurationMs"/> or more is reported as "too long" even when
+    /// the duration is within the configured maximum. Whisper hallucinations on
+    /// silence typically look like 2-3 words stretched over 10-30 seconds.
+    /// </summary>
+    public const double SparseCharsPerSecond = 2.0;
+    public const int SparseMinDurationMs = 4000;
+
+    // "[Music]", "(laughs)", "*applause*", "♪ ♪", "[Música] (risas)" - the whole
+    // line must be made of bracketed/parenthesised groups, music notes or
+    // whitespace. A bracketed speaker tag followed by real speech is kept.
+    private static readonly Regex NonSpeechRegex = new(@"^\s*(?:(?:\[[^\]]*\]|\([^)]*\)|\*[^*]*\*|<[^>]*>|[♪♫♬¶]+)[\s.,!?\-–—…]*)+$", RegexOptions.Compiled);
+
+    public static bool IsNonSpeechLine(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return false;
+        }
+
+        var noHtml = HtmlUtil.RemoveHtmlTags(text, true).Trim();
+        if (noHtml.Length == 0)
+        {
+            return false;
+        }
+
+        return NonSpeechRegex.IsMatch(noHtml);
+    }
+
+    public static string NormalizeForRepeat(string text)
+    {
+        var s = HtmlUtil.RemoveHtmlTags(text, true).ToLowerInvariant();
+        var sb = new System.Text.StringBuilder(s.Length);
+        foreach (var ch in s)
+        {
+            if (char.IsLetterOrDigit(ch))
+            {
+                sb.Append(ch);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    public static bool IsRepeatOf(string text, string previousText)
+    {
+        var a = NormalizeForRepeat(text);
+        if (a.Length == 0)
+        {
+            return false;
+        }
+
+        return a == NormalizeForRepeat(previousText);
+    }
+
+    public static SpeechToTextQualityIssue MakeIssue(SpeechToTextQualityIssueType type, Paragraph p, int number, string detail)
+    {
+        return new SpeechToTextQualityIssue
+        {
+            Type = type,
+            Number = number,
+            StartTime = new TimeCode(p.StartTime.TotalMilliseconds),
+            EndTime = new TimeCode(p.EndTime.TotalMilliseconds),
+            Text = p.Text,
+            Detail = detail,
+        };
+    }
+
+    /// <summary>
+    /// Scan the (final) subtitle and record what is still wrong. Uses the user's
+    /// general timing settings for the thresholds, so the report agrees with what
+    /// the main grid colors as errors.
+    /// </summary>
+    public void Analyze(Subtitle subtitle, int minDisplayMs, int maxDisplayMs, double maxCharsPerSecond)
+    {
+        TotalLines = subtitle.Paragraphs.Count;
+
+        for (var i = 0; i < subtitle.Paragraphs.Count; i++)
+        {
+            var p = subtitle.Paragraphs[i];
+            var number = i + 1;
+            var durationMs = p.DurationTotalMilliseconds;
+            var textNoHtml = HtmlUtil.RemoveHtmlTags(p.Text, true);
+            var cps = p.GetCharactersPerSecond();
+
+            if (IsNonSpeechLine(p.Text))
+            {
+                Issues.Add(MakeIssue(SpeechToTextQualityIssueType.NonSpeech, p, number, string.Empty));
+            }
+            else if (i > 0 && IsRepeatOf(p.Text, subtitle.Paragraphs[i - 1].Text))
+            {
+                Issues.Add(MakeIssue(SpeechToTextQualityIssueType.Repeated, p, number, $"= #{i}"));
+            }
+
+            if (durationMs < minDisplayMs)
+            {
+                Issues.Add(MakeIssue(SpeechToTextQualityIssueType.TooShort, p, number, FormatSeconds(durationMs)));
+            }
+            else if (cps > maxCharsPerSecond)
+            {
+                Issues.Add(MakeIssue(SpeechToTextQualityIssueType.TooShort, p, number, $"{cps:0.0} cps"));
+            }
+
+            if (durationMs > maxDisplayMs)
+            {
+                Issues.Add(MakeIssue(SpeechToTextQualityIssueType.TooLong, p, number, FormatSeconds(durationMs)));
+            }
+            else if (durationMs >= SparseMinDurationMs && textNoHtml.Trim().Length > 0 && cps < SparseCharsPerSecond)
+            {
+                Issues.Add(MakeIssue(SpeechToTextQualityIssueType.TooLong, p, number, $"{FormatSeconds(durationMs)}, {cps:0.0} cps"));
+            }
+
+            var next = subtitle.GetParagraphOrDefault(i + 1);
+            if (next != null && p.EndTime.TotalMilliseconds > next.StartTime.TotalMilliseconds + 0.5)
+            {
+                var overlapMs = p.EndTime.TotalMilliseconds - next.StartTime.TotalMilliseconds;
+                Issues.Add(MakeIssue(SpeechToTextQualityIssueType.Overlap, p, number, $"{overlapMs:0} ms"));
+            }
+        }
+    }
+
+    private static string FormatSeconds(double ms)
+    {
+        return (ms / 1000.0).ToString("0.0", System.Globalization.CultureInfo.InvariantCulture) + " s";
+    }
+
+    public string ToLogString()
+    {
+        var parts = new List<string>();
+        foreach (var type in Enum.GetValues<SpeechToTextQualityIssueType>())
+        {
+            var n = Count(type);
+            var r = RemovedCount(type);
+            if (n > 0 || r > 0)
+            {
+                parts.Add(r > 0 ? $"{type}: {n} (removed {r})" : $"{type}: {n}");
+            }
+        }
+
+        return parts.Count == 0
+            ? $"Quality check: no issues found in {TotalLines} lines"
+            : $"Quality check ({TotalLines} lines): {string.Join(", ", parts)}";
+    }
+}

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextQualityReportViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextQualityReportViewModel.cs
@@ -1,0 +1,228 @@
+﻿using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Features.Video.SpeechToText;
+
+/// <summary>One row in the quality report table.</summary>
+public class QualityReportDisplayItem
+{
+    public SpeechToTextQualityIssueType? Type { get; init; }
+    public bool IsRemoved { get; init; }
+    public int Number { get; init; }
+    public string Category { get; init; } = string.Empty;
+    public string Start { get; init; } = string.Empty;
+    public string End { get; init; } = string.Empty;
+    public string Detail { get; init; } = string.Empty;
+    public string Text { get; init; } = string.Empty;
+    public IBrush Brush { get; init; } = Brushes.Gray;
+}
+
+/// <summary>A clickable summary card / filter: one per issue type, plus "All" and "Removed".</summary>
+public partial class QualityReportCard : ObservableObject
+{
+    [ObservableProperty] private bool _isActive;
+    [ObservableProperty] private IBrush _borderBrush = UiUtil.GetTextColor(0.25);
+
+    partial void OnIsActiveChanged(bool value)
+    {
+        BorderBrush = value ? Brush : UiUtil.GetTextColor(0.25);
+    }
+
+    /// <summary>null = all issues; Removed uses <see cref="IsRemovedFilter"/>.</summary>
+    public SpeechToTextQualityIssueType? Type { get; init; }
+    public bool IsRemovedFilter { get; init; }
+    public string Label { get; init; } = string.Empty;
+    public string Hint { get; init; } = string.Empty;
+    public int Count { get; init; }
+    public IBrush Brush { get; init; } = Brushes.Gray;
+}
+
+public partial class SpeechToTextQualityReportViewModel : ObservableObject
+{
+    [ObservableProperty] private string _summary = string.Empty;
+    [ObservableProperty] private string _tip = string.Empty;
+    [ObservableProperty] private bool _doNotShowAgain;
+    [ObservableProperty] private bool _hasIssues;
+    [ObservableProperty] private ObservableCollection<QualityReportDisplayItem> _items = new();
+    [ObservableProperty] private QualityReportDisplayItem? _selectedItem;
+
+    public ObservableCollection<QualityReportCard> Cards { get; } = new();
+
+    public int TotalLines { get; private set; }
+    public int IssueCount { get; private set; }
+    public int RemovedCount { get; private set; }
+
+    public Window? Window { get; set; }
+
+    private readonly List<QualityReportDisplayItem> _allItems = new();
+
+    public static readonly IBrush TooShortBrush = new SolidColorBrush(Color.Parse("#E8912D"));
+    public static readonly IBrush TooLongBrush = new SolidColorBrush(Color.Parse("#9B59B6"));
+    public static readonly IBrush OverlapBrush = new SolidColorBrush(Color.Parse("#E74C3C"));
+    public static readonly IBrush NonSpeechBrush = new SolidColorBrush(Color.Parse("#3498DB"));
+    public static readonly IBrush RepeatedBrush = new SolidColorBrush(Color.Parse("#1ABC9C"));
+    public static readonly IBrush RemovedBrush = new SolidColorBrush(Color.Parse("#7F8C8D"));
+    public static readonly IBrush AllBrush = new SolidColorBrush(Color.Parse("#5D8AA8"));
+
+    public static IBrush GetBrush(SpeechToTextQualityIssueType type)
+    {
+        return type switch
+        {
+            SpeechToTextQualityIssueType.TooShort => TooShortBrush,
+            SpeechToTextQualityIssueType.TooLong => TooLongBrush,
+            SpeechToTextQualityIssueType.Overlap => OverlapBrush,
+            SpeechToTextQualityIssueType.NonSpeech => NonSpeechBrush,
+            SpeechToTextQualityIssueType.Repeated => RepeatedBrush,
+            _ => AllBrush,
+        };
+    }
+
+    public static string GetLabel(SpeechToTextQualityIssueType type)
+    {
+        var l = Se.Language.Video.AudioToText;
+        return type switch
+        {
+            SpeechToTextQualityIssueType.TooShort => l.QualityReportTooShort,
+            SpeechToTextQualityIssueType.TooLong => l.QualityReportTooLong,
+            SpeechToTextQualityIssueType.Overlap => l.QualityReportOverlap,
+            SpeechToTextQualityIssueType.NonSpeech => l.QualityReportNonSpeech,
+            SpeechToTextQualityIssueType.Repeated => l.QualityReportRepeated,
+            _ => string.Empty,
+        };
+    }
+
+    private static string GetHint(SpeechToTextQualityIssueType type)
+    {
+        var l = Se.Language.Video.AudioToText;
+        return type switch
+        {
+            SpeechToTextQualityIssueType.TooShort => l.QualityReportTooShortHint,
+            SpeechToTextQualityIssueType.TooLong => l.QualityReportTooLongHint,
+            SpeechToTextQualityIssueType.Overlap => l.QualityReportOverlapHint,
+            SpeechToTextQualityIssueType.NonSpeech => l.QualityReportNonSpeechHint,
+            SpeechToTextQualityIssueType.Repeated => l.QualityReportRepeatedHint,
+            _ => string.Empty,
+        };
+    }
+
+    public void Initialize(SpeechToTextQualityReport report)
+    {
+        var l = Se.Language.Video.AudioToText;
+        TotalLines = report.TotalLines;
+        IssueCount = report.Issues.Count;
+        RemovedCount = report.Removed.Count;
+        HasIssues = report.HasIssues;
+        Tip = l.QualityReportTip;
+        Summary = report.Issues.Count == 0 && report.Removed.Count == 0
+            ? l.QualityReportNoIssues
+            : string.Format(l.QualityReportSummaryX, report.Issues.Count, report.TotalLines);
+
+        _allItems.Clear();
+        foreach (var issue in report.Issues.OrderBy(p => p.Number).ThenBy(p => p.Type))
+        {
+            _allItems.Add(MakeItem(issue, false));
+        }
+
+        foreach (var issue in report.Removed.OrderBy(p => p.Number))
+        {
+            _allItems.Add(MakeItem(issue, true));
+        }
+
+        Cards.Clear();
+        Cards.Add(new QualityReportCard { Type = null, Label = l.QualityReportAll, Count = report.Issues.Count, Brush = AllBrush, IsActive = true });
+        foreach (var type in new[]
+                 {
+                     SpeechToTextQualityIssueType.TooShort,
+                     SpeechToTextQualityIssueType.TooLong,
+                     SpeechToTextQualityIssueType.Overlap,
+                     SpeechToTextQualityIssueType.NonSpeech,
+                     SpeechToTextQualityIssueType.Repeated,
+                 })
+        {
+            Cards.Add(new QualityReportCard { Type = type, Label = GetLabel(type), Hint = GetHint(type), Count = report.Count(type), Brush = GetBrush(type) });
+        }
+
+        if (report.Removed.Count > 0)
+        {
+            Cards.Add(new QualityReportCard { IsRemovedFilter = true, Label = l.QualityReportRemoved, Count = report.Removed.Count, Brush = RemovedBrush });
+        }
+
+        ApplyFilter(Cards[0]);
+    }
+
+    private static QualityReportDisplayItem MakeItem(SpeechToTextQualityIssue issue, bool removed)
+    {
+        var l = Se.Language.Video.AudioToText;
+        return new QualityReportDisplayItem
+        {
+            Type = issue.Type,
+            IsRemoved = removed,
+            Number = issue.Number,
+            Category = removed ? $"{l.QualityReportRemoved}: {GetLabel(issue.Type)}" : GetLabel(issue.Type),
+            Start = issue.StartTime.ToShortDisplayString(),
+            End = issue.EndTime.ToShortDisplayString(),
+            Detail = issue.Detail,
+            Text = issue.Text.Replace("\r\n", " ").Replace('\n', ' ').Replace('\r', ' '),
+            Brush = removed ? RemovedBrush : GetBrush(issue.Type),
+        };
+    }
+
+    [RelayCommand]
+    private void SetFilter(QualityReportCard? card)
+    {
+        if (card == null)
+        {
+            return;
+        }
+
+        ApplyFilter(card);
+    }
+
+    private void ApplyFilter(QualityReportCard card)
+    {
+        foreach (var c in Cards)
+        {
+            c.IsActive = ReferenceEquals(c, card);
+        }
+
+        IEnumerable<QualityReportDisplayItem> filtered = _allItems;
+        if (card.IsRemovedFilter)
+        {
+            filtered = _allItems.Where(p => p.IsRemoved);
+        }
+        else if (card.Type != null)
+        {
+            filtered = _allItems.Where(p => !p.IsRemoved && p.Type == card.Type);
+        }
+        else
+        {
+            filtered = _allItems.Where(p => !p.IsRemoved);
+        }
+
+        Items = new ObservableCollection<QualityReportDisplayItem>(filtered);
+        SelectedItem = Items.FirstOrDefault();
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        Window?.Close();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+    }
+}

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextQualityReportWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextQualityReportWindow.cs
@@ -1,0 +1,276 @@
+﻿using Avalonia;
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Video.SpeechToText;
+
+/// <summary>
+/// Shows what post-processing found in a fresh transcription (issue #13973):
+/// a header with the verdict, one summary card per issue type (click to
+/// filter), and the affected lines in a table.
+/// </summary>
+public class SpeechToTextQualityReportWindow : Window
+{
+    private readonly SpeechToTextQualityReportViewModel _vm;
+
+    public SpeechToTextQualityReportWindow(SpeechToTextQualityReportViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = Se.Language.Video.AudioToText.QualityReportTitle;
+        Width = 960;
+        Height = 640;
+        MinWidth = 720;
+        MinHeight = 460;
+        CanResize = true;
+
+        _vm = vm;
+        vm.Window = this;
+        DataContext = vm;
+
+        var l = Se.Language.Video.AudioToText;
+
+        // Header: title + one-line verdict
+        var labelTitle = new TextBlock
+        {
+            Text = l.QualityReportTitle,
+            FontSize = 20,
+            FontWeight = FontWeight.Bold,
+        };
+        var labelSummary = new TextBlock
+        {
+            FontSize = 14,
+            Opacity = 0.75,
+            Margin = new Thickness(0, 4, 0, 0),
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.Summary)),
+        };
+        var header = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Margin = new Thickness(0, 0, 0, 12),
+            Children = { labelTitle, labelSummary },
+        };
+
+        // Summary cards - one per issue type, acting as filter buttons
+        var cards = new ItemsControl
+        {
+            ItemsSource = vm.Cards,
+            Margin = new Thickness(0, 0, 0, 12),
+            ItemsPanel = new FuncTemplate<Panel?>(() => new WrapPanel { Orientation = Orientation.Horizontal, ItemSpacing = 8, LineSpacing = 8 }),
+            ItemTemplate = new FuncDataTemplate<QualityReportCard>((card, _) => MakeCard(card)),
+        };
+
+        // Issue table
+        var table = TableViewExtras.MakeTableView(alwaysSelected: false, multiSelect: false);
+        table[!TableView.ItemsSourceProperty] = new Binding(nameof(vm.Items));
+        table[!SelectingItemsControl.SelectedItemProperty] = new Binding(nameof(vm.SelectedItem)) { Mode = BindingMode.TwoWay };
+        table.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.NumberSymbol,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Binding = new Binding(nameof(QualityReportDisplayItem.Number)),
+            Width = new GridLength(60),
+        });
+        table.Columns.Add(new SeTableViewColumn
+        {
+            Header = l.QualityReportIssue,
+            CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            CellTemplate = new FuncDataTemplate<QualityReportDisplayItem>((item, _) =>
+            {
+                var dot = new Avalonia.Controls.Shapes.Ellipse
+                {
+                    Width = 9,
+                    Height = 9,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    [!Avalonia.Controls.Shapes.Shape.FillProperty] = new Binding(nameof(QualityReportDisplayItem.Brush)),
+                };
+                var text = new TextBlock
+                {
+                    VerticalAlignment = VerticalAlignment.Center,
+                    [!TextBlock.TextProperty] = new Binding(nameof(QualityReportDisplayItem.Category)),
+                };
+                return new StackPanel
+                {
+                    Orientation = Orientation.Horizontal,
+                    Spacing = 6,
+                    Margin = new Thickness(6, 0),
+                    VerticalAlignment = VerticalAlignment.Center,
+                    Children = { dot, text },
+                };
+            }),
+            Width = new GridLength(170),
+        });
+        table.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Show,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Binding = new Binding(nameof(QualityReportDisplayItem.Start)),
+            Width = new GridLength(105),
+        });
+        table.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Hide,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Binding = new Binding(nameof(QualityReportDisplayItem.End)),
+            Width = new GridLength(105),
+        });
+        table.Columns.Add(new SeTableViewColumn
+        {
+            Header = l.QualityReportDetail,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Binding = new Binding(nameof(QualityReportDisplayItem.Detail)),
+            Width = new GridLength(120),
+        });
+        table.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Text,
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Binding = new Binding(nameof(QualityReportDisplayItem.Text)),
+            Width = new GridLength(1, GridUnitType.Star),
+        });
+        AutomationProperties.SetName(table, l.QualityReportTitle);
+        var tableBorder = UiUtil.MakeBorderForControlNoPadding(table);
+
+        // Footer: tip, "do not show again", OK
+        var labelTip = new TextBlock
+        {
+            TextWrapping = TextWrapping.Wrap,
+            Opacity = 0.7,
+            Margin = new Thickness(0, 10, 0, 10),
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.Tip)),
+        };
+
+        var checkDoNotShowAgain = UiUtil.MakeCheckBox(l.QualityReportDoNotShowAgain, vm, nameof(vm.DoNotShowAgain));
+        checkDoNotShowAgain.VerticalAlignment = VerticalAlignment.Center;
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var footer = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+        };
+        footer.Add(checkDoNotShowAgain, 0, 0);
+        footer.Add(UiUtil.MakeButtonBar(buttonOk), 0, 1);
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            Margin = UiUtil.MakeWindowMargin(),
+        };
+        grid.Add(header, 0, 0);
+        grid.Add(cards, 1, 0);
+        grid.Add(tableBorder, 2, 0);
+        grid.Add(labelTip, 3, 0);
+        grid.Add(footer, 4, 0);
+
+        Content = grid;
+
+        Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
+    }
+
+    private Control MakeCard(QualityReportCard? card)
+    {
+        if (card == null)
+        {
+            return new Border();
+        }
+
+        var accent = new Border
+        {
+            Width = 5,
+            CornerRadius = new CornerRadius(3),
+            Background = card.Brush,
+            Margin = new Thickness(0, 0, 10, 0),
+            VerticalAlignment = VerticalAlignment.Stretch,
+        };
+        var count = new TextBlock
+        {
+            Text = card.Count.ToString(),
+            FontSize = 24,
+            FontWeight = FontWeight.Bold,
+            Foreground = card.Brush,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        var label = new TextBlock
+        {
+            Text = card.Label,
+            FontSize = 12,
+            Opacity = 0.85,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        var texts = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children = { count, label },
+        };
+        var content = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { accent, texts },
+        };
+
+        // A bordered button rather than a ToggleButton: the Fluent checked state
+        // floods the card with the accent color and drowns the colored count.
+        var border = new Border
+        {
+            Child = content,
+            Padding = new Thickness(12, 8),
+            MinWidth = 120,
+            BorderThickness = new Thickness(2),
+            CornerRadius = new CornerRadius(UiUtil.CornerRadius + 2),
+            [!Border.BorderBrushProperty] = new Binding(nameof(QualityReportCard.BorderBrush)),
+        };
+
+        var button = new Button
+        {
+            Content = border,
+            Padding = new Thickness(0),
+            Background = Brushes.Transparent,
+            BorderThickness = new Thickness(0),
+            CornerRadius = new CornerRadius(UiUtil.CornerRadius + 2),
+            Command = _vm.SetFilterCommand,
+            CommandParameter = card,
+            Opacity = card.Count == 0 && card.Type != null ? 0.5 : 1.0,
+        };
+        AutomationProperties.SetName(button, $"{card.Label}: {card.Count}");
+        if (Se.Settings.Appearance.ShowHints && !string.IsNullOrEmpty(card.Hint))
+        {
+            ToolTip.SetTip(button, card.Hint);
+        }
+
+        return button;
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        _vm.OnKeyDown(e);
+    }
+}

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -152,6 +152,7 @@ public partial class SpeechToTextViewModel : ObservableObject
     private bool _crispAsrVadWasUsed;
     private bool _crispAsrVadSuppressed;
     private bool _loadedFromStdOut;
+    private SpeechToTextQualityReport? _qualityReport;
     private string? _videoFileName;
     private string _audioFileName = string.Empty;
     private int _audioTrackNumber;
@@ -1986,6 +1987,8 @@ public partial class SpeechToTextViewModel : ObservableObject
         var postProcessor = new SpeechToTextPostProcessor(DoTranslateToEnglish ? "en" : languageCode)
         {
             ParagraphMaxChars = Configuration.Settings.General.SubtitleLineMaximumLength * 2,
+            RemoveNonSpeechLines = Se.Settings.Tools.AudioToText.WhisperPostProcessingRemoveNonSpeechLines,
+            RemoveRepeatedLines = Se.Settings.Tools.AudioToText.WhisperPostProcessingRemoveRepeatedLines,
         };
 
         WavePeakData2? wavePeaks = null;
@@ -2013,6 +2016,11 @@ public partial class SpeechToTextViewModel : ObservableObject
             settings.WhisperPostProcessingChangeUnderlineToColor,
             settings.WhisperPostProcessingChangeUnderlineToColorColor.FromHexToColor()
             );
+
+        // Keep the report for MakeResult (shown once the run is done) and log a
+        // one-line summary so batch runs leave a trace too (issue #13973).
+        _qualityReport = postProcessor.QualityReport;
+        LogToConsole(_qualityReport.ToLogString());
 
         return transcript;
     }
@@ -2456,6 +2464,7 @@ public partial class SpeechToTextViewModel : ObservableObject
             }
             else if (anyLinesTranscribed)
             {
+                await ShowQualityReport();
                 OkPressed = anyLinesTranscribed;
                 TranscribedSubtitle = transcribedSubtitle ?? new Subtitle();
                 Window?.Close();
@@ -2470,6 +2479,28 @@ public partial class SpeechToTextViewModel : ObservableObject
                     FileHelper.OpenFileWithDefaultProgram(Se.GetToolsLogFilePath());
                 }
             }
+        }
+    }
+
+    /// <summary>
+    /// Tell the user what post-processing found (issue #13973) before the dialog
+    /// closes. Only for the single-file flow - batch runs log the summary instead.
+    /// </summary>
+    private async Task ShowQualityReport()
+    {
+        var report = _qualityReport;
+        _qualityReport = null;
+        if (report == null || !report.HasIssues || !Se.Settings.Tools.AudioToText.WhisperPostProcessingShowQualityReport || Window == null)
+        {
+            return;
+        }
+
+        var vm = await _windowService.ShowDialogAsync<SpeechToTextQualityReportWindow, SpeechToTextQualityReportViewModel>(
+            Window, viewModel => viewModel.Initialize(report));
+
+        if (vm.DoNotShowAgain)
+        {
+            Se.Settings.Tools.AudioToText.WhisperPostProcessingShowQualityReport = false;
         }
     }
 
@@ -3083,6 +3114,9 @@ public partial class SpeechToTextViewModel : ObservableObject
                 viewModal.AddPeriods = Se.Settings.Tools.AudioToText.WhisperPostProcessingAddPeriods;
                 viewModal.MergeShortLines = Se.Settings.Tools.AudioToText.WhisperPostProcessingMergeLines;
                 viewModal.BreakSplitLongLines = Se.Settings.Tools.AudioToText.WhisperPostProcessingSplitLines;
+                viewModal.RemoveNonSpeechLines = Se.Settings.Tools.AudioToText.WhisperPostProcessingRemoveNonSpeechLines;
+                viewModal.RemoveRepeatedLines = Se.Settings.Tools.AudioToText.WhisperPostProcessingRemoveRepeatedLines;
+                viewModal.ShowQualityReport = Se.Settings.Tools.AudioToText.WhisperPostProcessingShowQualityReport;
                 viewModal.ChangeUnderlineToColor = Se.Settings.Tools.AudioToText.WhisperPostProcessingChangeUnderlineToColor;
                 viewModal.ChangeUnderlineToColorColor = Se.Settings.Tools.AudioToText.WhisperPostProcessingChangeUnderlineToColorColor.FromHexToColor();
             });
@@ -3096,6 +3130,9 @@ public partial class SpeechToTextViewModel : ObservableObject
             Se.Settings.Tools.AudioToText.WhisperPostProcessingAddPeriods = vm.AddPeriods;
             Se.Settings.Tools.AudioToText.WhisperPostProcessingMergeLines = vm.MergeShortLines;
             Se.Settings.Tools.AudioToText.WhisperPostProcessingSplitLines = vm.BreakSplitLongLines;
+            Se.Settings.Tools.AudioToText.WhisperPostProcessingRemoveNonSpeechLines = vm.RemoveNonSpeechLines;
+            Se.Settings.Tools.AudioToText.WhisperPostProcessingRemoveRepeatedLines = vm.RemoveRepeatedLines;
+            Se.Settings.Tools.AudioToText.WhisperPostProcessingShowQualityReport = vm.ShowQualityReport;
             Se.Settings.Tools.AudioToText.WhisperPostProcessingChangeUnderlineToColor = vm.ChangeUnderlineToColor;
             Se.Settings.Tools.AudioToText.WhisperPostProcessingChangeUnderlineToColorColor = vm.ChangeUnderlineToColorColor.FromColorToHex();
         }

--- a/src/ui/Logic/Config/Language/Video/LanguageAudioToText.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageAudioToText.cs
@@ -1,4 +1,4 @@
-namespace Nikse.SubtitleEdit.Logic.Config.Language;
+﻿namespace Nikse.SubtitleEdit.Logic.Config.Language;
 
 public class LanguageAudioToText
 {
@@ -32,6 +32,33 @@ public class LanguageAudioToText
     public string FixCasing { get; set; }
     public string AddPeriods { get; set; }
     public string ChangeUnderlineToColor { get; set; }
+    public string RemoveNonSpeechLines { get; set; }
+    public string RemoveNonSpeechLinesHint { get; set; }
+    public string RemoveRepeatedLines { get; set; }
+    public string RemoveRepeatedLinesHint { get; set; }
+    public string ShowQualityReport { get; set; }
+    public string QualityReportTitle { get; set; }
+    public string QualityReportNoIssues { get; set; }
+    public string QualityReportSummaryX { get; set; }
+    public string QualityReportLinesChecked { get; set; }
+    public string QualityReportIssuesFound { get; set; }
+    public string QualityReportLinesRemoved { get; set; }
+    public string QualityReportTooShort { get; set; }
+    public string QualityReportTooShortHint { get; set; }
+    public string QualityReportTooLong { get; set; }
+    public string QualityReportTooLongHint { get; set; }
+    public string QualityReportOverlap { get; set; }
+    public string QualityReportOverlapHint { get; set; }
+    public string QualityReportNonSpeech { get; set; }
+    public string QualityReportNonSpeechHint { get; set; }
+    public string QualityReportRepeated { get; set; }
+    public string QualityReportRepeatedHint { get; set; }
+    public string QualityReportRemoved { get; set; }
+    public string QualityReportAll { get; set; }
+    public string QualityReportIssue { get; set; }
+    public string QualityReportDetail { get; set; }
+    public string QualityReportTip { get; set; }
+    public string QualityReportDoNotShowAgain { get; set; }
 
     public string EngineSettings { get; set; }
     public string EngineSettingsSubtitle { get; set; }
@@ -71,6 +98,33 @@ public class LanguageAudioToText
         FixCasing = "Fix casing";
         AddPeriods = "Add periods";
         ChangeUnderlineToColor = "Change underline to color";
+        RemoveNonSpeechLines = "Remove non-speech lines";
+        RemoveNonSpeechLinesHint = "Drop lines that only describe sound, like \"[Music]\" or \"(waves crashing)\"";
+        RemoveRepeatedLines = "Remove repeated lines";
+        RemoveRepeatedLinesHint = "Drop lines that repeat the previous line word for word (engine loops)";
+        ShowQualityReport = "Show quality report after transcription";
+        QualityReportTitle = "Transcription quality report";
+        QualityReportNoIssues = "No issues found - the transcription looks good.";
+        QualityReportSummaryX = "{0} issue(s) found in {1} line(s)";
+        QualityReportLinesChecked = "Lines checked";
+        QualityReportIssuesFound = "Issues found";
+        QualityReportLinesRemoved = "Lines removed";
+        QualityReportTooShort = "Too short";
+        QualityReportTooShortHint = "Shorter than the minimum display time, or reading speed above the maximum";
+        QualityReportTooLong = "Too long";
+        QualityReportTooLongHint = "Longer than the maximum display time, or very few words over a long time (often a hallucination)";
+        QualityReportOverlap = "Overlapping";
+        QualityReportOverlapHint = "Ends after the next line starts";
+        QualityReportNonSpeech = "Non-speech";
+        QualityReportNonSpeechHint = "Only a sound or music description, like \"[Music]\"";
+        QualityReportRepeated = "Repeated";
+        QualityReportRepeatedHint = "Same text as the previous line (engine loop)";
+        QualityReportRemoved = "Removed";
+        QualityReportAll = "All";
+        QualityReportIssue = "Issue";
+        QualityReportDetail = "Detail";
+        QualityReportTip = "Lines are listed with their numbers in the new subtitle. Use \"Fix common errors\" or the post-processing settings to fix more automatically, or try another model/engine if many lines are affected.";
+        QualityReportDoNotShowAgain = "Do not show this report again";
 
         EngineSettings = "Speech-to-text engine settings";
         EngineSettingsSubtitle = "Speech-to-text engine";

--- a/src/ui/Logic/Config/SeAudioToText.cs
+++ b/src/ui/Logic/Config/SeAudioToText.cs
@@ -83,6 +83,12 @@ public class SeAudioToText
 
     public bool WhisperPostProcessingFixShortDuration { get; set; } = true;
 
+    public bool WhisperPostProcessingRemoveNonSpeechLines { get; set; }
+
+    public bool WhisperPostProcessingRemoveRepeatedLines { get; set; }
+
+    public bool WhisperPostProcessingShowQualityReport { get; set; } = true;
+
     public bool WhisperPostProcessingChangeUnderlineToColor { get; set; }
     public string WhisperPostProcessingChangeUnderlineToColorColor { get; set; } = Colors.Red.FromColorToHex();
     public string WhisperCppVulkanGpuDevice { get; set; } = string.Empty;

--- a/tests/UI/Features/Video/SpeechToText/SpeechToTextPostProcessorTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/SpeechToTextPostProcessorTests.cs
@@ -1,4 +1,5 @@
 using Nikse.SubtitleEdit.Core.Common;
+using System.Linq;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText;
 
 namespace UITests.Features.Video.SpeechToText;
@@ -54,5 +55,143 @@ public class SpeechToTextPostProcessorTests
         postProcessor.MergeShortLines(new Subtitle(), languageCode);
 
         Assert.Equal(expectedMaxChars, postProcessor.ParagraphMaxChars);
+    }
+}
+
+// Issue #13973: the post-processor should tell the user what went wrong
+// (too short / too long / overlaps / non-speech / repeats) and optionally drop
+// the non-speech and looping lines.
+public class SpeechToTextQualityReportTests
+{
+    private static Subtitle Make(params (string text, double startMs, double endMs)[] lines)
+    {
+        var s = new Subtitle();
+        foreach (var (text, start, end) in lines)
+        {
+            s.Paragraphs.Add(new Paragraph(text, start, end));
+        }
+
+        return s;
+    }
+
+    [Theory]
+    [InlineData("[Music]", true)]
+    [InlineData("(waves crashing)", true)]
+    [InlineData("♪ ♪", true)]
+    [InlineData("[Música] (risas)", true)]
+    [InlineData("<i>[Applause]</i>", true)]
+    [InlineData("[John] Hello there", false)]
+    [InlineData("Hello (maybe)", false)]
+    [InlineData("Hello", false)]
+    [InlineData("", false)]
+    public void IsNonSpeechLine(string text, bool expected)
+    {
+        Assert.Equal(expected, SpeechToTextQualityReport.IsNonSpeechLine(text));
+    }
+
+    [Theory]
+    [InlineData("Thank you.", "thank you", true)]
+    [InlineData("Thank you.", "Thank you!", true)]
+    [InlineData("Thank you.", "Thanks.", false)]
+    [InlineData("...", "...", false)]
+    public void IsRepeatOf(string text, string previous, bool expected)
+    {
+        Assert.Equal(expected, SpeechToTextQualityReport.IsRepeatOf(text, previous));
+    }
+
+    [Fact]
+    public void Analyze_FindsEachIssueType()
+    {
+        var subtitle = Make(
+            ("Hi", 0, 200), // too short
+            ("The boy ran up the hill and kept on running all the way", 1000, 1500), // too fast
+            ("Yes", 3000, 20000), // too long (sparse)
+            ("Overlaps next", 21000, 23000),
+            ("Overlapped", 22000, 24000),
+            ("[Music]", 25000, 27000),
+            ("[Music]", 28000, 30000)); // repeat + non-speech
+
+        var report = new SpeechToTextQualityReport();
+        report.Analyze(subtitle, 1000, 8000, 25.0);
+
+        Assert.Equal(7, report.TotalLines);
+        Assert.Equal(2, report.Count(SpeechToTextQualityIssueType.TooShort));
+        Assert.Equal(1, report.Count(SpeechToTextQualityIssueType.TooLong));
+        Assert.Equal(1, report.Count(SpeechToTextQualityIssueType.Overlap));
+        Assert.Equal(2, report.Count(SpeechToTextQualityIssueType.NonSpeech));
+        Assert.Equal(0, report.Count(SpeechToTextQualityIssueType.Repeated)); // non-speech wins over repeat
+        Assert.Equal(4, report.Issues.Single(p => p.Type == SpeechToTextQualityIssueType.Overlap).Number);
+        Assert.True(report.HasIssues);
+    }
+
+    [Fact]
+    public void Analyze_CleanSubtitle_HasNoIssues()
+    {
+        var subtitle = Make(("Hello there.", 0, 1500), ("How are you?", 1600, 3000));
+
+        var report = new SpeechToTextQualityReport();
+        report.Analyze(subtitle, 1000, 8000, 25.0);
+
+        Assert.False(report.HasIssues);
+        Assert.Contains("no issues", report.ToLogString());
+    }
+
+    [Fact]
+    public void Fix_RemovesNonSpeechAndRepeatedLines_WhenEnabled()
+    {
+        var subtitle = Make(
+            ("Hello there.", 0, 1500),
+            ("[Music]", 2000, 3500),
+            ("Thank you.", 4000, 5500),
+            ("Thank you.", 6000, 7500),
+            ("Thank you.", 8000, 9500),
+            ("Bye.", 10000, 11500));
+
+        var pp = new SpeechToTextPostProcessor("en") { RemoveNonSpeechLines = true, RemoveRepeatedLines = true };
+        var result = pp.Fix(SpeechToTextPostProcessor.Engine.Whisper, subtitle, true, false, false, false, false, false, false, Avalonia.Media.Colors.Red);
+
+        Assert.Equal(new[] { "Hello there.", "Thank you.", "Bye." }, result.Paragraphs.Select(p => p.Text).ToArray());
+        Assert.Equal(1, pp.QualityReport.RemovedCount(SpeechToTextQualityIssueType.NonSpeech));
+        Assert.Equal(2, pp.QualityReport.RemovedCount(SpeechToTextQualityIssueType.Repeated));
+        Assert.Equal(0, pp.QualityReport.Count(SpeechToTextQualityIssueType.Repeated));
+    }
+
+    [Fact]
+    public void Fix_KeepsLinesButReportsThem_WhenDisabled()
+    {
+        var subtitle = Make(("Hello there.", 0, 1500), ("[Music]", 2000, 3500), ("Bye.", 4000, 5500), ("Bye.", 6000, 7500));
+
+        var pp = new SpeechToTextPostProcessor("en");
+        var result = pp.Fix(SpeechToTextPostProcessor.Engine.Whisper, subtitle, true, false, false, false, false, false, false, Avalonia.Media.Colors.Red);
+
+        Assert.Equal(4, result.Paragraphs.Count);
+        Assert.Empty(pp.QualityReport.Removed);
+        Assert.Equal(1, pp.QualityReport.Count(SpeechToTextQualityIssueType.NonSpeech));
+        Assert.Equal(1, pp.QualityReport.Count(SpeechToTextQualityIssueType.Repeated));
+    }
+
+    [Fact]
+    public void Fix_FixShortDuration_AlsoFixesOverlaps()
+    {
+        var subtitle = Make(("First line here.", 0, 3000), ("Second line here.", 2000, 5000));
+
+        var pp = new SpeechToTextPostProcessor("en");
+        var result = pp.Fix(SpeechToTextPostProcessor.Engine.Whisper, subtitle, true, false, false, false, true, false, false, Avalonia.Media.Colors.Red);
+
+        Assert.True(result.Paragraphs[0].EndTime.TotalMilliseconds <= result.Paragraphs[1].StartTime.TotalMilliseconds);
+        Assert.Equal(0, pp.QualityReport.Count(SpeechToTextQualityIssueType.Overlap));
+    }
+
+    [Fact]
+    public void Fix_ReportIsPopulated_EvenWithoutPostProcessing()
+    {
+        var subtitle = Make(("Hi", 0, 100), ("[Music]", 200, 1500));
+
+        var pp = new SpeechToTextPostProcessor("en");
+        pp.Fix(SpeechToTextPostProcessor.Engine.Whisper, subtitle, false, false, false, false, false, false, false, Avalonia.Media.Colors.Red);
+
+        Assert.Equal(2, pp.QualityReport.TotalLines);
+        Assert.Equal(1, pp.QualityReport.Count(SpeechToTextQualityIssueType.TooShort));
+        Assert.Equal(1, pp.QualityReport.Count(SpeechToTextQualityIssueType.NonSpeech));
     }
 }


### PR DESCRIPTION
Addresses the post-processing part of #13973 — the reporter's core ask was that SE should *tell you* when a transcription went badly, and fix what it safely can.

## What's new

**Quality report window** (shown after a single-file transcription when anything was found; batch runs log a one-line summary to the console instead):


- Summary cards per issue type — click to filter the table
- Table of affected lines with number, start/end, detail (duration / cps / overlap ms) and text
- "Do not show this report again" checkbox; re-enable via post-processing settings

**Detected issue classes** (thresholds come from the user's general timing settings so the report agrees with the grid colouring):
| Type | Rule |
|---|---|
| Too short | duration < min display time, or reading speed > max cps |
| Too long | duration > max display time, or ≥ 4 s with < 2 cps (a few words over a long span — typical hallucination) |
| Overlapping | end time later than next line's start |
| Non-speech | line is only `[Music]` / `(waves)` / `♪` style descriptions |
| Repeated | same text as the previous line (engine loop) |

**New post-processing options** (both off by default):
- *Remove non-speech lines*
- *Remove repeated lines* — compares against the last kept line, so a run of identical lines collapses to one

**Fix short duration** now also runs `FixOverlappingDisplayTimes` afterwards, so engine overlaps (and any created by extending short lines) don't arrive in the grid as red.

## Notes
- Report is always computed, even with post-processing off, so the user still gets told.
- `English.json` intentionally untouched (generated from the language classes).
- Not in this PR: "go to next overlap" navigation and per-engine doc links (separate follow-ups).

## Tests
- 9 new tests in `SpeechToTextPostProcessorTests.cs` (non-speech/repeat detection, analyzer per type, removal on/off, overlap fix chained, report with post-processing off)
- Layout verified with a headless `CaptureRenderedFrame()` render.

Closes #13973

🤖 Generated with [Claude Code](https://claude.com/claude-code)
