### PR TITLE
List errors: summary cards, per-error rows, typed error classes

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -11977,11 +11977,11 @@ public partial class MainViewModel :
             var next = i < Subtitles.Count - 1 ? Subtitles[i + 1] : null;
             if (s.HasErrors(prev, next))
             {
-                list.Add(new ErrorListItem(s, prev, next));
+                list.AddRange(ErrorListItem.Make(s, prev, next));
             }
         }
 
-        var result = await ShowDialogAsync<ErrorListWindow, ErrorListViewModel>(vm => { vm.Initialize(list); });
+        var result = await ShowDialogAsync<ErrorListWindow, ErrorListViewModel>(vm => { vm.Initialize(list, Subtitles.Count); });
 
         if (result.GoToPressed && result.SelectedSubtitle != null)
         {

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -1,7 +1,8 @@
-using Avalonia.Media;
+﻿using Avalonia.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Shared.ErrorList;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using SkiaSharp;
@@ -1223,108 +1224,112 @@ public partial class SubtitleLineViewModel : ObservableObject
             ? general.ColorTimeCodeOverlap
             : general.ColorGapTooShort && gapMs < general.MinimumBetweenLines.GetMilliseconds();
 
+    /// <summary>All errors as one newline-separated string (batch error list, tooltips).</summary>
     public string GetErrors(SubtitleLineViewModel? prev, SubtitleLineViewModel? next)
     {
         var errors = new StringBuilder();
+        foreach (var error in GetErrorList(prev, next))
+        {
+            errors.AppendLine(error.ToString());
+        }
 
+        return errors.ToString();
+    }
+
+    /// <summary>
+    /// The errors on this line as typed entries, so "List errors" can count and filter
+    /// by class. Same rules as <see cref="HasErrors"/>; keep the two in sync.
+    /// </summary>
+    public List<LineError> GetErrorList(SubtitleLineViewModel? prev, SubtitleLineViewModel? next)
+    {
+        var errors = new List<LineError>();
         var general = Se.Settings.General;
+        var l = Se.Language.ErrorList;
 
-        if (Se.Settings.General.ColorTextTooManyLines)
+        if (general.ColorTextTooManyLines)
         {
             var lineCount = GetStrippedLines().Count;
             if (lineCount > general.MaxNumberOfLines)
             {
-                errors.AppendLine("Max #lines: " + lineCount + " >" + general.MaxNumberOfLines);
+                errors.Add(new LineError(LineErrorType.TooManyLines, string.Format(l.DetailXGreaterThanY, lineCount, general.MaxNumberOfLines)));
             }
         }
 
         var cpsRounded = Math.Round(CharactersPerSecond, 2, MidpointRounding.AwayFromZero);
-        if (cpsRounded > general.SubtitleMaximumCharactersPerSeconds && Se.Settings.General.ColorCharactersPerSecond)
+        if (cpsRounded > general.SubtitleMaximumCharactersPerSeconds && general.ColorCharactersPerSecond)
         {
-            errors.AppendLine("Cps: " + cpsRounded + " > " + general.SubtitleMaximumCharactersPerSeconds);
+            errors.Add(new LineError(LineErrorType.CharactersPerSecond, string.Format(l.DetailXGreaterThanY, cpsRounded, general.SubtitleMaximumCharactersPerSeconds)));
         }
 
         var durMsRounded = Math.Round(Duration.TotalMilliseconds, 3, MidpointRounding.AwayFromZero);
-        if (durMsRounded < general.SubtitleMinimumDisplayMilliseconds)
+        if (durMsRounded < general.SubtitleMinimumDisplayMilliseconds && general.ColorDurationTooShort)
         {
-            if (Se.Settings.General.ColorDurationTooShort)
-            {
-                errors.AppendLine("Min duration: " + durMsRounded + " < " + general.SubtitleMinimumDisplayMilliseconds);
-            }
-        }
-        if (durMsRounded > general.SubtitleMaximumDisplayMilliseconds)
-        {
-            if (Se.Settings.General.ColorDurationTooLong)
-            {
-                errors.AppendLine("Max duration: " + durMsRounded + " > " + general.SubtitleMaximumDisplayMilliseconds);
-            }
+            errors.Add(new LineError(LineErrorType.DurationTooShort, string.Format(l.DetailXLessThanY, durMsRounded, general.SubtitleMinimumDisplayMilliseconds)));
         }
 
-        if (Se.Settings.General.ColorTextTooLong)
+        if (durMsRounded > general.SubtitleMaximumDisplayMilliseconds && general.ColorDurationTooLong)
+        {
+            errors.Add(new LineError(LineErrorType.DurationTooLong, string.Format(l.DetailXGreaterThanY, durMsRounded, general.SubtitleMaximumDisplayMilliseconds)));
+        }
+
+        if (general.ColorTextTooLong)
         {
             foreach (var line in GetStrippedLines())
             {
                 var lineLength = SubtitleTextInfoHelper.GetLineLength(line);
                 if (lineLength > general.SubtitleLineMaximumLength)
                 {
-                    errors.AppendLine("Max line length: " + lineLength + " > " + general.SubtitleLineMaximumLength);
+                    errors.Add(new LineError(LineErrorType.LineTooLong, string.Format(l.DetailXGreaterThanY, lineLength, general.SubtitleLineMaximumLength)));
                 }
             }
         }
 
-        if (Se.Settings.General.ColorTextTooWide)
+        if (general.ColorTextTooWide)
         {
             foreach (var line in GetStrippedLines())
             {
                 var pixelWidth = CalculatePixelWidth(line);
                 if (pixelWidth > general.ColorTextTooWidePixels)
                 {
-                    errors.AppendLine("Max width (px): " + pixelWidth + " > " + general.ColorTextTooWidePixels);
+                    errors.Add(new LineError(LineErrorType.LineTooWide, string.Format(l.DetailXGreaterThanY, pixelWidth, general.ColorTextTooWidePixels)));
                 }
             }
         }
 
+        var minGap = general.MinimumBetweenLines.GetMilliseconds();
         if (prev != null)
         {
             var gapPrev = (StartTime - prev.EndTime).TotalMilliseconds;
             if (gapPrev < 0)
             {
-                if (Se.Settings.General.ColorTimeCodeOverlap)
+                if (general.ColorTimeCodeOverlap)
                 {
-                    errors.AppendLine("Overlap from previous: " + Math.Round(-gapPrev, 3));
+                    errors.Add(new LineError(LineErrorType.Overlap, string.Format(l.DetailOverlapFromPrevious, Math.Round(-gapPrev, 3))));
                 }
             }
-            else if (gapPrev < general.MinimumBetweenLines.GetMilliseconds())
+            else if (gapPrev < minGap && general.ColorGapTooShort)
             {
-                if (Se.Settings.General.ColorGapTooShort)
+                errors.Add(new LineError(LineErrorType.GapTooShort, string.Format(l.DetailGapToPrevious, Math.Round(gapPrev, 3), minGap)));
+            }
+        }
+
+        if (next != null)
+        {
+            var gapNext = (next.StartTime - EndTime).TotalMilliseconds;
+            if (gapNext < 0)
+            {
+                if (general.ColorTimeCodeOverlap)
                 {
-                    errors.AppendLine("Min gap to previous: " + Math.Round(gapPrev, 3) + " < " + general.MinimumBetweenLines.GetMilliseconds());
+                    errors.Add(new LineError(LineErrorType.Overlap, string.Format(l.DetailOverlapToNext, Math.Round(-gapNext, 3))));
                 }
             }
-        }
-
-        if (next == null)
-        {
-            return errors.ToString();
-        }
-
-        var gapNext = (next.StartTime - EndTime).TotalMilliseconds;
-        if (gapNext < 0)
-        {
-            if (Se.Settings.General.ColorTimeCodeOverlap)
+            else if (gapNext < minGap && general.ColorGapTooShort)
             {
-                errors.AppendLine("Overlap to next: " + Math.Round(-gapNext, 3));
-            }
-        }
-        else if (gapNext < general.MinimumBetweenLines.GetMilliseconds())
-        {
-            if (Se.Settings.General.ColorGapTooShort)
-            {
-                errors.AppendLine("Min gap to next: " + Math.Round(gapNext, 3) + " < " + general.MinimumBetweenLines.GetMilliseconds());
+                errors.Add(new LineError(LineErrorType.GapTooShort, string.Format(l.DetailGapToNext, Math.Round(gapNext, 3), minGap)));
             }
         }
 
-        return errors.ToString();
+        return errors;
     }
 
     public void RefreshTimeCodes()

--- a/src/ui/Features/Shared/ErrorList/ErrorListItem.cs
+++ b/src/ui/Features/Shared/ErrorList/ErrorListItem.cs
@@ -1,19 +1,43 @@
-﻿using Nikse.SubtitleEdit.Features.Main;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic.ValueConverters;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Nikse.SubtitleEdit.Features.Shared.ErrorList;
 
+/// <summary>One row in "List errors": one error on one line. A line with several errors has several rows.</summary>
 public class ErrorListItem
 {
-    public int Number { get; set; }
-    public string Text { get; set; }
-    public string Error { get; set; }
-    public SubtitleLineViewModel Subtitle { get; set; }
+    public int Number { get; }
+    public string Text { get; }
+    public string Show { get; }
+    public string Hide { get; }
+    public LineErrorType Type { get; }
+    public string Category { get; }
+    public string Detail { get; }
+    public IBrush Brush { get; }
+    public SubtitleLineViewModel Subtitle { get; }
 
-    public ErrorListItem(SubtitleLineViewModel subtitle, SubtitleLineViewModel? prev, SubtitleLineViewModel? next)
+    /// <summary>Old single-string form ("Reading speed: 27.3 > 25"), kept for the Error column binding.</summary>
+    public string Error => $"{Category}: {Detail}";
+
+    public ErrorListItem(SubtitleLineViewModel subtitle, LineError error)
     {
         Subtitle = subtitle;
-        Text = subtitle.Text;
+        Text = subtitle.Text.Replace("\r\n", " ").Replace('\n', ' ').Replace('\r', ' ');
         Number = subtitle.Number;
-        Error = subtitle.GetErrors(prev, next);
+        Show = (string)TimeSpanToDisplayShortConverter.Instance.Convert(subtitle.StartTime, typeof(string), null, System.Globalization.CultureInfo.CurrentCulture);
+        Hide = (string)TimeSpanToDisplayShortConverter.Instance.Convert(subtitle.EndTime, typeof(string), null, System.Globalization.CultureInfo.CurrentCulture);
+        Type = error.Type;
+        Category = error.Label;
+        Detail = error.Detail;
+        Brush = LineError.GetBrush(error.Type);
+    }
+
+    /// <summary>One item per error on the line - the caller knows the real neighbours, which the gap/overlap wording needs.</summary>
+    public static IEnumerable<ErrorListItem> Make(SubtitleLineViewModel subtitle, SubtitleLineViewModel? prev, SubtitleLineViewModel? next)
+    {
+        return subtitle.GetErrorList(prev, next).Select(e => new ErrorListItem(subtitle, e));
     }
 }

--- a/src/ui/Features/Shared/ErrorList/ErrorListViewModel.cs
+++ b/src/ui/Features/Shared/ErrorList/ErrorListViewModel.cs
@@ -3,9 +3,12 @@ using Avalonia.Input;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace Nikse.SubtitleEdit.Features.Shared.ErrorList;
 
@@ -14,27 +17,48 @@ public partial class ErrorListViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<ErrorListItem> _subtitles;
     [ObservableProperty] private ErrorListItem? _selectedSubtitle;
     [ObservableProperty] private bool _hasErrors;
+    [ObservableProperty] private string _summary = string.Empty;
+
+    public ObservableCollection<SummaryCard> Cards { get; } = new();
 
     public Window? Window { get; set; }
 
     public bool GoToPressed { get; private set; }
 
+    private readonly List<ErrorListItem> _allItems = new();
+
     public ErrorListViewModel()
     {
         Subtitles = new ObservableCollection<ErrorListItem>();
     }
-    
+
     [RelayCommand]
     private void GoTo()
     {
+        if (SelectedSubtitle == null)
+        {
+            return;
+        }
+
         GoToPressed = true;
         Window?.Close();
     }
-    
+
     [RelayCommand]
     private void Cancel()
     {
         Window?.Close();
+    }
+
+    [RelayCommand]
+    private void SetFilter(SummaryCard? card)
+    {
+        if (card == null)
+        {
+            return;
+        }
+
+        ApplyFilter(card);
     }
 
     internal void OnKeyDown(KeyEventArgs e)
@@ -50,12 +74,41 @@ public partial class ErrorListViewModel : ObservableObject
     /// The items come ready-made from the caller: it is the only place that still knows each
     /// line's real neighbours, which the gap/overlap wording needs.
     /// </summary>
-    internal void Initialize(List<ErrorListItem> errorListItems)
+    internal void Initialize(List<ErrorListItem> errorListItems, int totalLines)
     {
-        foreach (var item in errorListItems)
+        var l = Se.Language.ErrorList;
+        _allItems.Clear();
+        _allItems.AddRange(errorListItems);
+
+        var lineCount = errorListItems.Select(p => p.Number).Distinct().Count();
+        Summary = errorListItems.Count == 0
+            ? l.NoErrors
+            : string.Format(l.SummaryX, errorListItems.Count, lineCount, totalLines);
+
+        Cards.Clear();
+        Cards.Add(new SummaryCard { Key = null, Label = l.All, Count = errorListItems.Count, Brush = LineError.AllBrush, IsActive = true });
+        foreach (var type in Enum.GetValues<LineErrorType>())
         {
-            Subtitles.Add(item);
+            var count = errorListItems.Count(p => p.Type == type);
+            Cards.Add(new SummaryCard { Key = type, Label = LineError.GetLabel(type), Hint = LineError.GetHint(type), Count = count, Brush = LineError.GetBrush(type) });
         }
+
+        ApplyFilter(Cards[0]);
+    }
+
+    private void ApplyFilter(SummaryCard card)
+    {
+        foreach (var c in Cards)
+        {
+            c.IsActive = ReferenceEquals(c, card);
+        }
+
+        var filtered = card.Key is LineErrorType type
+            ? _allItems.Where(p => p.Type == type)
+            : _allItems;
+
+        Subtitles = new ObservableCollection<ErrorListItem>(filtered);
+        SelectedSubtitle = Subtitles.FirstOrDefault();
     }
 
     /// <summary>
@@ -68,7 +121,7 @@ public partial class ErrorListViewModel : ObservableObject
         HasErrors = value != null;
     }
 
-    internal void OnBookmarksGridDoubleTapped(object? sender, TappedEventArgs e)
+    internal void OnGridDoubleTapped(object? sender, TappedEventArgs e)
     {
         Dispatcher.UIThread.Invoke(GoTo);
     }

--- a/src/ui/Features/Shared/ErrorList/ErrorListWindow.cs
+++ b/src/ui/Features/Shared/ErrorList/ErrorListWindow.cs
@@ -1,28 +1,68 @@
 using Avalonia;
+using Avalonia.Automation;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Layout;
-using System.Collections;
+using Avalonia.Media;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
-using Nikse.SubtitleEdit.Logic.ValueConverters;
+using System.Collections;
 
 namespace Nikse.SubtitleEdit.Features.Shared.ErrorList;
 
+/// <summary>
+/// "List errors": a verdict header, one summary card per error class (click to
+/// filter), and the affected lines in a table. Double-click / Enter / "Go to"
+/// jumps to the line in the main grid.
+/// </summary>
 public class ErrorListWindow : Window
 {
     public ErrorListWindow(ErrorListViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.General.ListErrors;
+        Title = Se.Language.ErrorList.Title;
         CanResize = true;
-        Width = 600;
-        Height = 700;
-        MinWidth = 600;
-        MinHeight = 400;
+        Width = 960;
+        Height = 680;
+        MinWidth = 720;
+        MinHeight = 460;
         vm.Window = this;
         DataContext = vm;
+
+        var l = Se.Language.ErrorList;
+
+        var labelTitle = new TextBlock
+        {
+            Text = l.Title,
+            FontSize = 20,
+            FontWeight = FontWeight.Bold,
+        };
+        var labelSummary = new TextBlock
+        {
+            FontSize = 14,
+            Opacity = 0.75,
+            Margin = new Thickness(0, 4, 0, 0),
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.Summary)),
+        };
+        var header = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Margin = new Thickness(0, 0, 0, 12),
+            Children = { labelTitle, labelSummary },
+        };
+
+        var cards = SummaryCard.MakeCardsPanel(vm.Cards, vm.SetFilterCommand);
+
+        var labelTip = new TextBlock
+        {
+            Text = l.Tip,
+            TextWrapping = TextWrapping.Wrap,
+            Opacity = 0.7,
+            Margin = new Thickness(0, 10, 0, 10),
+        };
 
         var buttonGoTo = UiUtil.MakeButton(Se.Language.General.GoTo, vm.GoToCommand).WithBindIsEnabled(nameof(vm.HasErrors));
         var buttonCancel = UiUtil.MakeButtonDone(vm.CancelCommand);
@@ -32,7 +72,10 @@ public class ErrorListWindow : Window
         {
             RowDefinitions =
             {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
@@ -40,14 +83,13 @@ public class ErrorListWindow : Window
                 new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
             },
             Margin = UiUtil.MakeWindowMargin(),
-            ColumnSpacing = 10,
-            RowSpacing = 10,
-            Width = double.NaN,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
-        grid.Add(MakeErrorsGridView(vm), 0);
-        grid.Add(panelButtons, 1);
+        grid.Add(header, 0, 0);
+        grid.Add(cards, 1, 0);
+        grid.Add(MakeErrorsGridView(vm), 2, 0);
+        grid.Add(labelTip, 3, 0);
+        grid.Add(panelButtons, 4, 0);
 
         Content = grid;
 
@@ -58,23 +100,70 @@ public class ErrorListWindow : Window
 
     private static Border MakeErrorsGridView(ErrorListViewModel vm)
     {
-        var dataGrid = TableViewExtras.MakeTableView();
+        var l = Se.Language.ErrorList;
+        var dataGrid = TableViewExtras.MakeTableView(alwaysSelected: false, multiSelect: false);
         dataGrid.Height = double.NaN; // auto size inside scroll viewer
-        dataGrid.Margin = new Thickness(2);
-        dataGrid.ItemsSource = vm.Subtitles;
-        dataGrid.DataContext = vm.Subtitles;
+        dataGrid[!TableView.ItemsSourceProperty] = new Binding(nameof(vm.Subtitles));
 
-        dataGrid.DoubleTapped += vm.OnBookmarksGridDoubleTapped;
-
-        var fullTimeConverter = new TimeSpanToDisplayFullConverter();
-        var shortTimeConverter = new TimeSpanToDisplayShortConverter();
-
-        // Columns
         dataGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.NumberSymbol,
             Binding = new Binding(nameof(ErrorListItem.Number)),
-            Width = new GridLength(50), // was Auto; TableView treats Auto as star
+            Width = new GridLength(60),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+        });
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Error,
+            CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            CellTemplate = new FuncDataTemplate<ErrorListItem>((_, _) =>
+            {
+                var dot = new Avalonia.Controls.Shapes.Ellipse
+                {
+                    Width = 9,
+                    Height = 9,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    [!Avalonia.Controls.Shapes.Shape.FillProperty] = new Binding(nameof(ErrorListItem.Brush)),
+                };
+                var text = new TextBlock
+                {
+                    VerticalAlignment = VerticalAlignment.Center,
+                    [!TextBlock.TextProperty] = new Binding(nameof(ErrorListItem.Category)),
+                };
+                return new StackPanel
+                {
+                    Orientation = Orientation.Horizontal,
+                    Spacing = 6,
+                    Margin = new Thickness(6, 0),
+                    VerticalAlignment = VerticalAlignment.Center,
+                    Children = { dot, text },
+                };
+            }),
+            Width = new GridLength(160),
+        });
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Show,
+            Binding = new Binding(nameof(ErrorListItem.Show)),
+            Width = new GridLength(105),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+        });
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Hide,
+            Binding = new Binding(nameof(ErrorListItem.Hide)),
+            Width = new GridLength(105),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+        });
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = l.Detail,
+            Binding = new Binding(nameof(ErrorListItem.Detail)),
+            Width = new GridLength(200),
             CellTheme = UiUtil.TableViewCellTheme,
             HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
         });
@@ -84,19 +173,12 @@ public class ErrorListWindow : Window
             Binding = new Binding(nameof(ErrorListItem.Text)),
             CellTheme = UiUtil.TableViewCellTheme,
             HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
-            Width = new GridLength(1, GridUnitType.Star) // star sizing to take all available space
+            Width = new GridLength(1, GridUnitType.Star),
         });
-        dataGrid.Columns.Add(new SeTableViewColumn
-        {
-            Header = Se.Language.General.Error,
-            Binding = new Binding(nameof(ErrorListItem.Error)),
-            CellTheme = UiUtil.TableViewCellTheme,
-            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
-            Width = new GridLength(1, GridUnitType.Star) // star sizing to take all available space
-        });
+        AutomationProperties.SetName(dataGrid, l.Title);
 
         TableViewExtras.BindSelectedItem(dataGrid, vm, nameof(vm.SelectedSubtitle));
-        dataGrid.DoubleTapped += (s, e) => vm.GoToCommand.Execute(null);    
+        dataGrid.DoubleTapped += vm.OnGridDoubleTapped;
         dataGrid.KeyDown += (s, e) => vm.GridKeyDown(e);
         dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
         {

--- a/src/ui/Features/Shared/ErrorList/LineError.cs
+++ b/src/ui/Features/Shared/ErrorList/LineError.cs
@@ -1,0 +1,86 @@
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Shared.ErrorList;
+
+/// <summary>The error classes the grid colours and "List errors" reports (Settings &gt; General).</summary>
+public enum LineErrorType
+{
+    TooManyLines,
+    CharactersPerSecond,
+    DurationTooShort,
+    DurationTooLong,
+    LineTooLong,
+    LineTooWide,
+    Overlap,
+    GapTooShort,
+}
+
+/// <summary>One error on one line: the class plus a short detail such as "27.3 > 25".</summary>
+public record LineError(LineErrorType Type, string Detail)
+{
+    public string Label => GetLabel(Type);
+
+    /// <summary>"Reading speed: 27.3 > 25" - the old single-string form, still used by the batch error list.</summary>
+    public override string ToString() => $"{Label}: {Detail}";
+
+    public static string GetLabel(LineErrorType type)
+    {
+        var l = Se.Language.ErrorList;
+        return type switch
+        {
+            LineErrorType.TooManyLines => l.TooManyLines,
+            LineErrorType.CharactersPerSecond => l.CharactersPerSecond,
+            LineErrorType.DurationTooShort => l.DurationTooShort,
+            LineErrorType.DurationTooLong => l.DurationTooLong,
+            LineErrorType.LineTooLong => l.LineTooLong,
+            LineErrorType.LineTooWide => l.LineTooWide,
+            LineErrorType.Overlap => l.Overlap,
+            LineErrorType.GapTooShort => l.GapTooShort,
+            _ => type.ToString(),
+        };
+    }
+
+    public static string GetHint(LineErrorType type)
+    {
+        var l = Se.Language.ErrorList;
+        return type switch
+        {
+            LineErrorType.TooManyLines => l.TooManyLinesHint,
+            LineErrorType.CharactersPerSecond => l.CharactersPerSecondHint,
+            LineErrorType.DurationTooShort => l.DurationTooShortHint,
+            LineErrorType.DurationTooLong => l.DurationTooLongHint,
+            LineErrorType.LineTooLong => l.LineTooLongHint,
+            LineErrorType.LineTooWide => l.LineTooWideHint,
+            LineErrorType.Overlap => l.OverlapHint,
+            LineErrorType.GapTooShort => l.GapTooShortHint,
+            _ => string.Empty,
+        };
+    }
+
+    private static readonly IBrush TooManyLinesBrush = new SolidColorBrush(Color.Parse("#E84393"));
+    private static readonly IBrush CpsBrush = new SolidColorBrush(Color.Parse("#E8912D"));
+    private static readonly IBrush TooShortBrush = new SolidColorBrush(Color.Parse("#F1C40F"));
+    private static readonly IBrush TooLongBrush = new SolidColorBrush(Color.Parse("#9B59B6"));
+    private static readonly IBrush LineTooLongBrush = new SolidColorBrush(Color.Parse("#3498DB"));
+    private static readonly IBrush LineTooWideBrush = new SolidColorBrush(Color.Parse("#2980B9"));
+    private static readonly IBrush OverlapBrush = new SolidColorBrush(Color.Parse("#E74C3C"));
+    private static readonly IBrush GapBrush = new SolidColorBrush(Color.Parse("#1ABC9C"));
+    public static readonly IBrush AllBrush = new SolidColorBrush(Color.Parse("#5D8AA8"));
+
+    public static IBrush GetBrush(LineErrorType type)
+    {
+        return type switch
+        {
+            LineErrorType.TooManyLines => TooManyLinesBrush,
+            LineErrorType.CharactersPerSecond => CpsBrush,
+            LineErrorType.DurationTooShort => TooShortBrush,
+            LineErrorType.DurationTooLong => TooLongBrush,
+            LineErrorType.LineTooLong => LineTooLongBrush,
+            LineErrorType.LineTooWide => LineTooWideBrush,
+            LineErrorType.Overlap => OverlapBrush,
+            LineErrorType.GapTooShort => GapBrush,
+            _ => AllBrush,
+        };
+    }
+}

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextQualityReportViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextQualityReportViewModel.cs
@@ -25,26 +25,6 @@ public class QualityReportDisplayItem
     public IBrush Brush { get; init; } = Brushes.Gray;
 }
 
-/// <summary>A clickable summary card / filter: one per issue type, plus "All" and "Removed".</summary>
-public partial class QualityReportCard : ObservableObject
-{
-    [ObservableProperty] private bool _isActive;
-    [ObservableProperty] private IBrush _borderBrush = UiUtil.GetTextColor(0.25);
-
-    partial void OnIsActiveChanged(bool value)
-    {
-        BorderBrush = value ? Brush : UiUtil.GetTextColor(0.25);
-    }
-
-    /// <summary>null = all issues; Removed uses <see cref="IsRemovedFilter"/>.</summary>
-    public SpeechToTextQualityIssueType? Type { get; init; }
-    public bool IsRemovedFilter { get; init; }
-    public string Label { get; init; } = string.Empty;
-    public string Hint { get; init; } = string.Empty;
-    public int Count { get; init; }
-    public IBrush Brush { get; init; } = Brushes.Gray;
-}
-
 public partial class SpeechToTextQualityReportViewModel : ObservableObject
 {
     [ObservableProperty] private string _summary = string.Empty;
@@ -54,7 +34,10 @@ public partial class SpeechToTextQualityReportViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<QualityReportDisplayItem> _items = new();
     [ObservableProperty] private QualityReportDisplayItem? _selectedItem;
 
-    public ObservableCollection<QualityReportCard> Cards { get; } = new();
+    public ObservableCollection<SummaryCard> Cards { get; } = new();
+
+    /// <summary>Card key for the "removed lines" filter (the issue-type keys are the enum values).</summary>
+    private static readonly object RemovedKey = new();
 
     public int TotalLines { get; private set; }
     public int IssueCount { get; private set; }
@@ -137,7 +120,7 @@ public partial class SpeechToTextQualityReportViewModel : ObservableObject
         }
 
         Cards.Clear();
-        Cards.Add(new QualityReportCard { Type = null, Label = l.QualityReportAll, Count = report.Issues.Count, Brush = AllBrush, IsActive = true });
+        Cards.Add(new SummaryCard { Key = null, Label = l.QualityReportAll, Count = report.Issues.Count, Brush = AllBrush, IsActive = true });
         foreach (var type in new[]
                  {
                      SpeechToTextQualityIssueType.TooShort,
@@ -147,12 +130,12 @@ public partial class SpeechToTextQualityReportViewModel : ObservableObject
                      SpeechToTextQualityIssueType.Repeated,
                  })
         {
-            Cards.Add(new QualityReportCard { Type = type, Label = GetLabel(type), Hint = GetHint(type), Count = report.Count(type), Brush = GetBrush(type) });
+            Cards.Add(new SummaryCard { Key = type, Label = GetLabel(type), Hint = GetHint(type), Count = report.Count(type), Brush = GetBrush(type) });
         }
 
         if (report.Removed.Count > 0)
         {
-            Cards.Add(new QualityReportCard { IsRemovedFilter = true, Label = l.QualityReportRemoved, Count = report.Removed.Count, Brush = RemovedBrush });
+            Cards.Add(new SummaryCard { Key = RemovedKey, Label = l.QualityReportRemoved, Count = report.Removed.Count, Brush = RemovedBrush });
         }
 
         ApplyFilter(Cards[0]);
@@ -176,7 +159,7 @@ public partial class SpeechToTextQualityReportViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private void SetFilter(QualityReportCard? card)
+    private void SetFilter(SummaryCard? card)
     {
         if (card == null)
         {
@@ -186,7 +169,7 @@ public partial class SpeechToTextQualityReportViewModel : ObservableObject
         ApplyFilter(card);
     }
 
-    private void ApplyFilter(QualityReportCard card)
+    private void ApplyFilter(SummaryCard card)
     {
         foreach (var c in Cards)
         {
@@ -194,13 +177,13 @@ public partial class SpeechToTextQualityReportViewModel : ObservableObject
         }
 
         IEnumerable<QualityReportDisplayItem> filtered = _allItems;
-        if (card.IsRemovedFilter)
+        if (ReferenceEquals(card.Key, RemovedKey))
         {
             filtered = _allItems.Where(p => p.IsRemoved);
         }
-        else if (card.Type != null)
+        else if (card.Key is SpeechToTextQualityIssueType type)
         {
-            filtered = _allItems.Where(p => !p.IsRemoved && p.Type == card.Type);
+            filtered = _allItems.Where(p => !p.IsRemoved && p.Type == type);
         }
         else
         {

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextQualityReportWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextQualityReportWindow.cs
@@ -59,13 +59,7 @@ public class SpeechToTextQualityReportWindow : Window
         };
 
         // Summary cards - one per issue type, acting as filter buttons
-        var cards = new ItemsControl
-        {
-            ItemsSource = vm.Cards,
-            Margin = new Thickness(0, 0, 0, 12),
-            ItemsPanel = new FuncTemplate<Panel?>(() => new WrapPanel { Orientation = Orientation.Horizontal, ItemSpacing = 8, LineSpacing = 8 }),
-            ItemTemplate = new FuncDataTemplate<QualityReportCard>((card, _) => MakeCard(card)),
-        };
+        var cards = SummaryCard.MakeCardsPanel(vm.Cards, vm.SetFilterCommand);
 
         // Issue table
         var table = TableViewExtras.MakeTableView(alwaysSelected: false, multiSelect: false);
@@ -192,80 +186,6 @@ public class SpeechToTextQualityReportWindow : Window
         Content = grid;
 
         Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
-    }
-
-    private Control MakeCard(QualityReportCard? card)
-    {
-        if (card == null)
-        {
-            return new Border();
-        }
-
-        var accent = new Border
-        {
-            Width = 5,
-            CornerRadius = new CornerRadius(3),
-            Background = card.Brush,
-            Margin = new Thickness(0, 0, 10, 0),
-            VerticalAlignment = VerticalAlignment.Stretch,
-        };
-        var count = new TextBlock
-        {
-            Text = card.Count.ToString(),
-            FontSize = 24,
-            FontWeight = FontWeight.Bold,
-            Foreground = card.Brush,
-            VerticalAlignment = VerticalAlignment.Center,
-        };
-        var label = new TextBlock
-        {
-            Text = card.Label,
-            FontSize = 12,
-            Opacity = 0.85,
-            VerticalAlignment = VerticalAlignment.Center,
-        };
-        var texts = new StackPanel
-        {
-            Orientation = Orientation.Vertical,
-            VerticalAlignment = VerticalAlignment.Center,
-            Children = { count, label },
-        };
-        var content = new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-            Children = { accent, texts },
-        };
-
-        // A bordered button rather than a ToggleButton: the Fluent checked state
-        // floods the card with the accent color and drowns the colored count.
-        var border = new Border
-        {
-            Child = content,
-            Padding = new Thickness(12, 8),
-            MinWidth = 120,
-            BorderThickness = new Thickness(2),
-            CornerRadius = new CornerRadius(UiUtil.CornerRadius + 2),
-            [!Border.BorderBrushProperty] = new Binding(nameof(QualityReportCard.BorderBrush)),
-        };
-
-        var button = new Button
-        {
-            Content = border,
-            Padding = new Thickness(0),
-            Background = Brushes.Transparent,
-            BorderThickness = new Thickness(0),
-            CornerRadius = new CornerRadius(UiUtil.CornerRadius + 2),
-            Command = _vm.SetFilterCommand,
-            CommandParameter = card,
-            Opacity = card.Count == 0 && card.Type != null ? 0.5 : 1.0,
-        };
-        AutomationProperties.SetName(button, $"{card.Label}: {card.Count}");
-        if (Se.Settings.Appearance.ShowHints && !string.IsNullOrEmpty(card.Hint))
-        {
-            ToolTip.SetTip(button, card.Hint);
-        }
-
-        return button;
     }
 
     protected override void OnKeyDown(KeyEventArgs e)

--- a/src/ui/Logic/Config/Language/LanguageErrorList.cs
+++ b/src/ui/Logic/Config/Language/LanguageErrorList.cs
@@ -1,0 +1,65 @@
+namespace Nikse.SubtitleEdit.Logic.Config.Language;
+
+public class LanguageErrorList
+{
+    public string Title { get; set; }
+    public string SummaryX { get; set; }
+    public string NoErrors { get; set; }
+    public string All { get; set; }
+    public string TooManyLines { get; set; }
+    public string CharactersPerSecond { get; set; }
+    public string DurationTooShort { get; set; }
+    public string DurationTooLong { get; set; }
+    public string LineTooLong { get; set; }
+    public string LineTooWide { get; set; }
+    public string Overlap { get; set; }
+    public string GapTooShort { get; set; }
+    public string TooManyLinesHint { get; set; }
+    public string CharactersPerSecondHint { get; set; }
+    public string DurationTooShortHint { get; set; }
+    public string DurationTooLongHint { get; set; }
+    public string LineTooLongHint { get; set; }
+    public string LineTooWideHint { get; set; }
+    public string OverlapHint { get; set; }
+    public string GapTooShortHint { get; set; }
+    public string DetailXGreaterThanY { get; set; }
+    public string DetailXLessThanY { get; set; }
+    public string DetailOverlapFromPrevious { get; set; }
+    public string DetailOverlapToNext { get; set; }
+    public string DetailGapToPrevious { get; set; }
+    public string DetailGapToNext { get; set; }
+    public string Detail { get; set; }
+    public string Tip { get; set; }
+
+    public LanguageErrorList()
+    {
+        Title = "List errors";
+        SummaryX = "{0} error(s) in {1} of {2} line(s)";
+        NoErrors = "No errors found.";
+        All = "All";
+        TooManyLines = "Too many lines";
+        CharactersPerSecond = "Reading speed";
+        DurationTooShort = "Too short";
+        DurationTooLong = "Too long";
+        LineTooLong = "Line too long";
+        LineTooWide = "Line too wide";
+        Overlap = "Overlapping";
+        GapTooShort = "Gap too short";
+        TooManyLinesHint = "More lines than the maximum number of lines";
+        CharactersPerSecondHint = "Characters per second above the maximum";
+        DurationTooShortHint = "Shorter than the minimum display time";
+        DurationTooLongHint = "Longer than the maximum display time";
+        LineTooLongHint = "A line has more characters than the maximum line length";
+        LineTooWideHint = "A line is wider (in pixels) than the maximum width";
+        OverlapHint = "Overlaps the previous or next line";
+        GapTooShortHint = "Gap to the previous or next line is below the minimum";
+        DetailXGreaterThanY = "{0} > {1}";
+        DetailXLessThanY = "{0} < {1}";
+        DetailOverlapFromPrevious = "from previous: {0} ms";
+        DetailOverlapToNext = "to next: {0} ms";
+        DetailGapToPrevious = "to previous: {0} < {1} ms";
+        DetailGapToNext = "to next: {0} < {1} ms";
+        Detail = "Detail";
+        Tip = "Double-click a line (or press Enter) to go to it. Which checks run, and their limits, are set in Settings > General.";
+    }
+}

--- a/src/ui/Logic/Config/Language/SeLanguage.cs
+++ b/src/ui/Logic/Config/Language/SeLanguage.cs
@@ -36,6 +36,7 @@ public class SeLanguage
     public LanguageOcr Ocr { get; set; } = new();
     public LanguageAssa Assa { get; set; } = new();
     public LanguageAbout About { get; set; } = new();
+    public LanguageErrorList ErrorList { get; set; } = new();
 
     /// <summary>
     /// Serializes a language to the exact text used for <c>English.json</c> - the base file every

--- a/src/ui/Logic/SummaryCard.cs
+++ b/src/ui/Logic/SummaryCard.cs
@@ -1,0 +1,124 @@
+using Avalonia;
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Layout;
+using Avalonia.Media;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Nikse.SubtitleEdit.Logic.Config;
+using System.Windows.Input;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>
+/// A clickable "count + label" summary card with a colored accent bar, used as a
+/// filter toggle above a result table (speech-to-text quality report, list errors).
+/// <see cref="Key"/> is whatever the owner uses to identify the filter; the
+/// active card shows its accent color as the border.
+/// </summary>
+public partial class SummaryCard : ObservableObject
+{
+    [ObservableProperty] private bool _isActive;
+    [ObservableProperty] private IBrush _borderBrush = UiUtil.GetTextColor(0.25);
+
+    partial void OnIsActiveChanged(bool value)
+    {
+        BorderBrush = value ? Brush : UiUtil.GetTextColor(0.25);
+    }
+
+    public object? Key { get; init; }
+    public string Label { get; init; } = string.Empty;
+    public string Hint { get; init; } = string.Empty;
+    public int Count { get; init; }
+    public IBrush Brush { get; init; } = Brushes.Gray;
+
+    /// <summary>
+    /// Build the visual for a card. A bordered Button rather than a ToggleButton: the
+    /// Fluent checked state floods the card with the accent color and drowns the
+    /// colored count.
+    /// </summary>
+    public static Control MakeControl(SummaryCard? card, ICommand command)
+    {
+        if (card == null)
+        {
+            return new Border();
+        }
+
+        var accent = new Border
+        {
+            Width = 5,
+            CornerRadius = new CornerRadius(3),
+            Background = card.Brush,
+            Margin = new Thickness(0, 0, 10, 0),
+            VerticalAlignment = VerticalAlignment.Stretch,
+        };
+        var count = new TextBlock
+        {
+            Text = card.Count.ToString(),
+            FontSize = 24,
+            FontWeight = FontWeight.Bold,
+            Foreground = card.Brush,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        var label = new TextBlock
+        {
+            Text = card.Label,
+            FontSize = 12,
+            Opacity = 0.85,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        var texts = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children = { count, label },
+        };
+        var content = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { accent, texts },
+        };
+
+        var border = new Border
+        {
+            Child = content,
+            Padding = new Thickness(12, 8),
+            MinWidth = 120,
+            BorderThickness = new Thickness(2),
+            CornerRadius = new CornerRadius(UiUtil.CornerRadius + 2),
+            DataContext = card,
+            [!Border.BorderBrushProperty] = new Binding(nameof(BorderBrush)),
+        };
+
+        var button = new Button
+        {
+            Content = border,
+            Padding = new Thickness(0),
+            Background = Brushes.Transparent,
+            BorderThickness = new Thickness(0),
+            CornerRadius = new CornerRadius(UiUtil.CornerRadius + 2),
+            Command = command,
+            CommandParameter = card,
+            Opacity = card.Count == 0 && card.Key != null ? 0.5 : 1.0,
+        };
+        AutomationProperties.SetName(button, $"{card.Label}: {card.Count}");
+        if (Se.Settings.Appearance.ShowHints && !string.IsNullOrEmpty(card.Hint))
+        {
+            ToolTip.SetTip(button, card.Hint);
+        }
+
+        return button;
+    }
+
+    /// <summary>An ItemsControl that lays cards out in a wrapping row.</summary>
+    public static ItemsControl MakeCardsPanel(System.Collections.IEnumerable cards, ICommand command)
+    {
+        return new ItemsControl
+        {
+            ItemsSource = cards,
+            Margin = new Thickness(0, 0, 0, 12),
+            ItemsPanel = new Avalonia.Controls.Templates.FuncTemplate<Panel?>(() => new WrapPanel { Orientation = Orientation.Horizontal, ItemSpacing = 8, LineSpacing = 8 }),
+            ItemTemplate = new Avalonia.Controls.Templates.FuncDataTemplate<SummaryCard>((card, _) => MakeControl(card, command)),
+        };
+    }
+}

--- a/tests/UI/Features/Main/SubtitleMetricsRegressionTests.cs
+++ b/tests/UI/Features/Main/SubtitleMetricsRegressionTests.cs
@@ -1,3 +1,4 @@
+﻿using Nikse.SubtitleEdit.Features.Shared.ErrorList;
 using Avalonia.Headless.XUnit;
 using Avalonia.Media;
 using Nikse.SubtitleEdit.Core.Common;
@@ -53,12 +54,12 @@ public class SubtitleMetricsRegressionTests
                 EndTime = TimeSpan.FromSeconds(1),
             };
 
-            Assert.Contains("Cps:", vm.GetErrors(null, null), StringComparison.Ordinal);
+            Assert.Contains(vm.GetErrorList(null, null), e => e.Type == LineErrorType.CharactersPerSecond);
 
             Se.Settings.General.ColorCharactersPerSecond = false;
             Se.Settings.General.ColorDurationTooShort = true;
 
-            Assert.DoesNotContain("Cps:", vm.GetErrors(null, null), StringComparison.Ordinal);
+            Assert.DoesNotContain(vm.GetErrorList(null, null), e => e.Type == LineErrorType.CharactersPerSecond);
         }
         finally
         {
@@ -92,7 +93,7 @@ public class SubtitleMetricsRegressionTests
             var brush = Assert.IsType<SolidColorBrush>(vm.TextBackgroundBrush);
 
             Assert.Equal(Colors.Transparent, brush.Color);
-            Assert.DoesNotContain("Max line length", vm.GetErrors(null, null), StringComparison.Ordinal);
+            Assert.DoesNotContain(vm.GetErrorList(null, null), e => e.Type == LineErrorType.LineTooLong);
         }
         finally
         {

--- a/tests/UI/Features/Shared/PrePopulatedGridSelectionTests.cs
+++ b/tests/UI/Features/Shared/PrePopulatedGridSelectionTests.cs
@@ -63,9 +63,9 @@ public class PrePopulatedGridSelectionTests
         var vm = new ErrorListViewModel();
         vm.Initialize(new List<ErrorListItem>
         {
-            new(lines[0], null, lines[1]),
-            new(lines[1], lines[0], null),
-        });
+            new(lines[0], new LineError(LineErrorType.DurationTooShort, "200 < 1000")),
+            new(lines[1], new LineError(LineErrorType.CharactersPerSecond, "30 > 25")),
+        }, 2);
         var window = new ErrorListWindow(vm);
 
         Show(window);


### PR DESCRIPTION
Follow-up to #14019: gives the **List errors** window the same treatment as the speech-to-text quality report.

## What changed
- **Header** with a verdict: "10 error(s) in 7 of 350 line(s)".
- **Summary cards** per error class (too many lines, reading speed, too short, too long, line too long, line too wide, overlapping, gap too short) with counts — click to filter the table. Checks that found nothing are dimmed.
- **Table**: one row per error (a line with three problems gets three rows) — colour dot + class, show/hide, detail (`154 > 25`, `to next: 1000 ms`), text — instead of the old multi-line error blob in one cell.
- Double-click / Enter / **Go to** unchanged; window is now 960×680 and resizable as before.

## Under the hood
- `SubtitleLineViewModel.GetErrorList()` returns typed `LineError(LineErrorType, Detail)` entries; `GetErrors()` (batch error list) is now a thin join over it, so the existing `HasErrors` ⇄ `GetErrors` agreement tests still cover the rules.
- The previously hard-coded English strings (`"Cps: … > …"`, `"Max #lines"`, …) move to a new `LanguageErrorList` section (`English.json` intentionally untouched — generated).
- The card control from the STT report is lifted into a shared `SummaryCard` (`src/ui/Logic/SummaryCard.cs`) used by both windows.
- Batch convert's error list keeps its current look (string-based); can follow later.

## Tests
- Existing `HasErrors`/metrics/pre-populated-grid tests adjusted to the typed API; 699 related UI tests pass.
- Layout verified with a headless `CaptureRenderedFrame()` render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)