### PR TITLE
Batch convert: error list with summary cards and per-error rows

### DIFF
--- a/src/ui/Features/Tools/BatchConvert/BatchErrorList/BatchErrorListItem.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchErrorList/BatchErrorListItem.cs
@@ -1,21 +1,46 @@
-﻿using Nikse.SubtitleEdit.Features.Main;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Shared.ErrorList;
+using Nikse.SubtitleEdit.Logic.ValueConverters;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 
 namespace Nikse.SubtitleEdit.Features.Tools.BatchConvert.BatchErrorList;
 
+/// <summary>One row in the batch error list: one error on one line of one file.</summary>
 public class BatchErrorListItem
 {
-    public string FileName { get; set; }
-    public int Number { get; set; }
-    public string Text { get; set; }
-    public string Error { get; set; }
-    public SubtitleLineViewModel Subtitle { get; set; }
+    public string FileName { get; }
+    public int Number { get; }
+    public string Text { get; }
+    public string Show { get; }
+    public string Hide { get; }
+    public LineErrorType Type { get; }
+    public string Category { get; }
+    public string Detail { get; }
+    public IBrush Brush { get; }
+    public SubtitleLineViewModel Subtitle { get; }
 
-    public BatchErrorListItem(string fileName, SubtitleLineViewModel subtitle, SubtitleLineViewModel? prev, SubtitleLineViewModel? next)
+    /// <summary>"Reading speed: 27.3 > 25" - the single-string form used by the CSV export.</summary>
+    public string Error => $"{Category}: {Detail}";
+
+    public BatchErrorListItem(string fileName, SubtitleLineViewModel subtitle, LineError error)
     {
         FileName = fileName;
         Subtitle = subtitle;
-        Text = subtitle.Text;
+        Text = subtitle.Text.Replace("\r\n", " ").Replace('\n', ' ').Replace('\r', ' ');
         Number = subtitle.Number;
-        Error = subtitle.GetErrors(prev, next);
+        Show = (string)TimeSpanToDisplayShortConverter.Instance.Convert(subtitle.StartTime, typeof(string), null, CultureInfo.CurrentCulture);
+        Hide = (string)TimeSpanToDisplayShortConverter.Instance.Convert(subtitle.EndTime, typeof(string), null, CultureInfo.CurrentCulture);
+        Type = error.Type;
+        Category = error.Label;
+        Detail = error.Detail;
+        Brush = LineError.GetBrush(error.Type);
+    }
+
+    public static IEnumerable<BatchErrorListItem> Make(string fileName, SubtitleLineViewModel subtitle, SubtitleLineViewModel? prev, SubtitleLineViewModel? next)
+    {
+        return subtitle.GetErrorList(prev, next).Select(e => new BatchErrorListItem(fileName, subtitle, e));
     }
 }

--- a/src/ui/Features/Tools/BatchConvert/BatchErrorList/BatchErrorListViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchErrorList/BatchErrorListViewModel.cs
@@ -1,9 +1,10 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Shared.ErrorList;
 using Nikse.SubtitleEdit.Features.Shared.PromptFileSaved;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -11,7 +12,9 @@ using Nikse.SubtitleEdit.Logic.Media;
 using Nikse.SubtitleEdit.UiLogic.BatchConvert;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -22,6 +25,11 @@ public partial class BatchErrorListViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<BatchErrorListItem> _subtitles;
     [ObservableProperty] private BatchErrorListItem? _selectedSubtitle;
     [ObservableProperty] private bool _hasErrors;
+    [ObservableProperty] private string _summary = string.Empty;
+
+    public ObservableCollection<SummaryCard> Cards { get; } = new();
+
+    private readonly List<BatchErrorListItem> _allItems = new();
 
     public Window? Window { get; set; }
 
@@ -51,6 +59,7 @@ public partial class BatchErrorListViewModel : ObservableObject
         }
 
         var sb = new StringBuilder();
+        // Exports what is shown - the active card filter applies.
         sb.AppendLine("FileName,LineNumber,Text,Error");
         foreach (var errorItem in Subtitles)
         {
@@ -73,6 +82,33 @@ public partial class BatchErrorListViewModel : ObservableObject
         s = s.Replace("\r", "\\r");
         s = s.Replace("\n", "\\n");
         return $"\"{s}\"";
+    }
+
+    [RelayCommand]
+    private void SetFilter(SummaryCard? card)
+    {
+        if (card == null)
+        {
+            return;
+        }
+
+        ApplyFilter(card);
+    }
+
+    private void ApplyFilter(SummaryCard card)
+    {
+        foreach (var c in Cards)
+        {
+            c.IsActive = ReferenceEquals(c, card);
+        }
+
+        var filtered = card.Key is LineErrorType type
+            ? _allItems.Where(p => p.Type == type)
+            : _allItems;
+
+        Subtitles = new ObservableCollection<BatchErrorListItem>(filtered);
+        SelectedSubtitle = Subtitles.FirstOrDefault();
+        HasErrors = Subtitles.Count > 0;
     }
 
     [RelayCommand]
@@ -116,16 +152,27 @@ public partial class BatchErrorListViewModel : ObservableObject
                 var next = i < lines.Count - 1 ? lines[i + 1] : null;
                 if (line.HasErrors(prev, next))
                 {
-                    Subtitles.Add(new BatchErrorListItem(batchItem.FileName, line, prev, next));
+                    _allItems.AddRange(BatchErrorListItem.Make(batchItem.FileName, line, prev, next));
                 }
             }
         }
 
-        HasErrors = Subtitles.Count > 0;
+        var l = Se.Language.ErrorList;
+        var lineCount = _allItems.Select(p => (p.FileName, p.Number)).Distinct().Count();
+        var fileCount = _allItems.Select(p => p.FileName).Distinct().Count();
+        Summary = _allItems.Count == 0
+            ? l.NoErrors
+            : string.Format(l.SummaryFilesX, _allItems.Count, lineCount, fileCount);
+
+        Cards.Clear();
+        Cards.Add(new SummaryCard { Key = null, Label = l.All, Count = _allItems.Count, Brush = LineError.AllBrush, IsActive = true });
+        foreach (var type in Enum.GetValues<LineErrorType>())
+        {
+            var count = _allItems.Count(p => p.Type == type);
+            Cards.Add(new SummaryCard { Key = type, Label = LineError.GetLabel(type), Hint = LineError.GetHint(type), Count = count, Brush = LineError.GetBrush(type) });
+        }
+
+        ApplyFilter(Cards[0]);
     }
 
-    internal void GridSelectionChanged(object? sender, SelectionChangedEventArgs e)
-    {
-        HasErrors = SelectedSubtitle != null;
-    }
 }

--- a/src/ui/Features/Tools/BatchConvert/BatchErrorList/BatchErrorListWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchErrorList/BatchErrorListWindow.cs
@@ -1,38 +1,72 @@
 using Avalonia;
+using Avalonia.Automation;
 using Avalonia.Controls;
+using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
-using System.Collections;
+using Avalonia.Media;
 using Nikse.SubtitleEdit.Features.Tools.BatchConvert.BatchErrorList;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using System.Collections;
 
 namespace Nikse.SubtitleEdit.Features.Shared.ErrorList;
 
+/// <summary>
+/// Batch convert's "List errors": same layout as the main window's error list
+/// (verdict header, summary cards that filter, one row per error) plus a file
+/// name column and CSV export.
+/// </summary>
 public class BatchErrorListWindow : Window
 {
     public BatchErrorListWindow(BatchErrorListViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.General.ListErrors;
+        Title = Se.Language.ErrorList.Title;
         CanResize = true;
-        Width = 1024;
+        Width = 1100;
         Height = 700;
-        MinWidth = 600;
-        MinHeight = 400;
+        MinWidth = 760;
+        MinHeight = 460;
         vm.Window = this;
         DataContext = vm;
 
-        var buttonGoTo = UiUtil.MakeButton(Se.Language.General.ExportDotDotDot, vm.ExportCommand).WithBindIsEnabled(nameof(vm.HasErrors));
+        var l = Se.Language.ErrorList;
+
+        var labelTitle = new TextBlock
+        {
+            Text = l.Title,
+            FontSize = 20,
+            FontWeight = FontWeight.Bold,
+        };
+        var labelSummary = new TextBlock
+        {
+            FontSize = 14,
+            Opacity = 0.75,
+            Margin = new Thickness(0, 4, 0, 0),
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.Summary)),
+        };
+        var header = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Margin = new Thickness(0, 0, 0, 12),
+            Children = { labelTitle, labelSummary },
+        };
+
+        var cards = SummaryCard.MakeCardsPanel(vm.Cards, vm.SetFilterCommand);
+
+        var buttonExport = UiUtil.MakeButton(Se.Language.General.ExportDotDotDot, vm.ExportCommand).WithBindIsEnabled(nameof(vm.HasErrors));
         var buttonCancel = UiUtil.MakeButtonDone(vm.CancelCommand);
-        var panelButtons = UiUtil.MakeButtonBar(buttonGoTo, buttonCancel);
+        var panelButtons = UiUtil.MakeButtonBar(buttonExport, buttonCancel);
 
         var grid = new Grid
         {
             RowDefinitions =
             {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
@@ -41,14 +75,13 @@ public class BatchErrorListWindow : Window
                 new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
             },
             Margin = UiUtil.MakeWindowMargin(),
-            ColumnSpacing = 10,
             RowSpacing = 10,
-            Width = double.NaN,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
-        grid.Add(MakeErrorsGridView(vm), 0);
-        grid.Add(panelButtons, 1);
+        grid.Add(header, 0, 0);
+        grid.Add(cards, 1, 0);
+        grid.Add(MakeErrorsGridView(vm), 2, 0);
+        grid.Add(panelButtons, 3, 0);
 
         Content = grid;
 
@@ -59,21 +92,18 @@ public class BatchErrorListWindow : Window
 
     private static Border MakeErrorsGridView(BatchErrorListViewModel vm)
     {
-        var dataGrid = TableViewExtras.MakeTableView();
+        var l = Se.Language.ErrorList;
+        var dataGrid = TableViewExtras.MakeTableView(alwaysSelected: false, multiSelect: false);
         dataGrid.Height = double.NaN; // auto size inside scroll viewer
-        dataGrid.Margin = new Thickness(2);
-        dataGrid.ItemsSource = vm.Subtitles;
-        dataGrid.DataContext = vm.Subtitles;
+        dataGrid[!TableView.ItemsSourceProperty] = new Binding(nameof(vm.Subtitles));
 
-        // Columns - the number column was content-sized (Auto) on the DataGrid; TableView
-        // treats Auto as star, so it gets a fixed width instead.
         dataGrid.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.FileName,
             Binding = new Binding(nameof(BatchErrorListItem.FileName)),
             CellTheme = UiUtil.TableViewCellTheme,
             HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
-            Width = new GridLength(1, GridUnitType.Star)
+            Width = new GridLength(1, GridUnitType.Star),
         });
         dataGrid.Columns.Add(new SeTableViewColumn
         {
@@ -81,7 +111,61 @@ public class BatchErrorListWindow : Window
             Binding = new Binding(nameof(BatchErrorListItem.Number)),
             CellTheme = UiUtil.TableViewCellTheme,
             HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
-            Width = new GridLength(60)
+            Width = new GridLength(60),
+        });
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Error,
+            CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            CellTemplate = new FuncDataTemplate<BatchErrorListItem>((_, _) =>
+            {
+                var dot = new Avalonia.Controls.Shapes.Ellipse
+                {
+                    Width = 9,
+                    Height = 9,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    [!Avalonia.Controls.Shapes.Shape.FillProperty] = new Binding(nameof(BatchErrorListItem.Brush)),
+                };
+                var text = new TextBlock
+                {
+                    VerticalAlignment = VerticalAlignment.Center,
+                    [!TextBlock.TextProperty] = new Binding(nameof(BatchErrorListItem.Category)),
+                };
+                return new StackPanel
+                {
+                    Orientation = Orientation.Horizontal,
+                    Spacing = 6,
+                    Margin = new Thickness(6, 0),
+                    VerticalAlignment = VerticalAlignment.Center,
+                    Children = { dot, text },
+                };
+            }),
+            Width = new GridLength(160),
+        });
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Show,
+            Binding = new Binding(nameof(BatchErrorListItem.Show)),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Width = new GridLength(105),
+        });
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Hide,
+            Binding = new Binding(nameof(BatchErrorListItem.Hide)),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Width = new GridLength(105),
+        });
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = l.Detail,
+            Binding = new Binding(nameof(BatchErrorListItem.Detail)),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Width = new GridLength(200),
         });
         dataGrid.Columns.Add(new SeTableViewColumn
         {
@@ -89,23 +173,11 @@ public class BatchErrorListWindow : Window
             Binding = new Binding(nameof(BatchErrorListItem.Text)),
             CellTheme = UiUtil.TableViewCellTheme,
             HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
-            Width = new GridLength(1, GridUnitType.Star)
+            Width = new GridLength(1, GridUnitType.Star),
         });
-        dataGrid.Columns.Add(new SeTableViewColumn
-        {
-            Header = Se.Language.General.Error,
-            Binding = new Binding(nameof(BatchErrorListItem.Error)),
-            CellTheme = UiUtil.TableViewCellTheme,
-            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
-            Width = new GridLength(1, GridUnitType.Star)
-        });
+        AutomationProperties.SetName(dataGrid, l.Title);
 
-        dataGrid.Bind(TableView.SelectedItemProperty, new Binding(nameof(vm.SelectedSubtitle))
-        {
-            Source = vm,
-            Mode = BindingMode.TwoWay
-        });
-        dataGrid.SelectionChanged += vm.GridSelectionChanged;
+        TableViewExtras.BindSelectedItem(dataGrid, vm, nameof(vm.SelectedSubtitle));
         dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
         {
             if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0 &&

--- a/src/ui/Logic/Config/Language/LanguageErrorList.cs
+++ b/src/ui/Logic/Config/Language/LanguageErrorList.cs
@@ -5,6 +5,7 @@ public class LanguageErrorList
     public string Title { get; set; }
     public string SummaryX { get; set; }
     public string NoErrors { get; set; }
+    public string SummaryFilesX { get; set; }
     public string All { get; set; }
     public string TooManyLines { get; set; }
     public string CharactersPerSecond { get; set; }
@@ -36,6 +37,7 @@ public class LanguageErrorList
         Title = "List errors";
         SummaryX = "{0} error(s) in {1} of {2} line(s)";
         NoErrors = "No errors found.";
+        SummaryFilesX = "{0} error(s) in {1} line(s) across {2} file(s)";
         All = "All";
         TooManyLines = "Too many lines";
         CharactersPerSecond = "Reading speed";


### PR DESCRIPTION
Follow-up to #14020 — gives batch convert's **List errors** the same layout as the main window's:

- Verdict header: "8 error(s) in 6 line(s) across 2 file(s)"
- Summary cards per error class (click to filter); empty ones dimmed
- One row per error: file name, #, colour dot + class, show/hide, detail, text
- **Export…** keeps the same CSV columns (`FileName,LineNumber,Text,Error`) and exports what is shown, so the active card filter applies

Built on the typed `LineError`/`SummaryCard` from #14020; `English.json` untouched (generated).

Tests: 739 related UI tests pass; layout verified with a headless `CaptureRenderedFrame()` render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)