### PR TITLE
Prepare v5.2.0-beta22

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -3,6 +3,31 @@ Subtitle Edit Changelog
 
 -----------------------------------------------------------------------------------------------------
 
+v5.2.0-beta22 (23rd of August 2026)
+
+* Beautify time codes can now use the video's real frame times instead of assuming a constant frame rate - thx warrentc3
+* Add a transcription quality report to speech to text, plus non-speech and repeated-line removal - thx l0uev4-lab
+* Add an error list with summary cards and per-error rows, in the main window and in batch convert
+* Add shot-change snap distances to Settings
+* Snap to the nearest shot change in the waveform when a cue is close - thx m0ck69
+* Warn before saving SCC when lines exceed 32 characters or 4 lines
+* Add a "Use external server" toggle for llama.cpp in batch convert, independent of the main setting - thx emsb8888-prog
+* Remember the batch convert "Remove formatting" check boxes - thx matake31
+* Use the selected audio track in the sync windows - thx dmist
+* Use display dimensions for rotated video when burning in subtitles - thx thealainpaul
+* Speed up tag counting in the subtitle grid - thx ivandrofly
+* Fix split long lines producing overlong lines, gaps between split events and duplicate numbers - thx Triathlon-rally
+* Fix selecting a text to speech review line by clicking or grabbing its waveform block - thx cvrle77
+* Fix Google Translate failing on transient server errors instead of retrying - thx JoaoDuarte-code
+* Fix the subtitle grid scroll position jumping while the reference projection rebuilds - thx torvchen
+* Fix the minimum gap not being kept when nudging a cue one frame - thx m0ck69
+* Fix the AI review sending ASSA override blocks, and send actor/style as context - thx MrGoraj
+* Fix continuation style fixes being applied twice to each line
+* Update Italian translation - thx bovirus
+* Update Polish translation - thx potplayer-fanpack
+
+-----------------------------------------------------------------------------------------------------
+
 v5.2.0-beta21 (22nd of August 2026)
 
 * Add an option to keep the source file's date/time on converted files (batch convert + seconv) - thx TucocoTucoco

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "Subtitle Edit",
-  "version": "v5.2.0-beta21",
+  "version": "v5.2.0-beta22",
   "translatedBy": "",
   "cultureName": "en-US",
   "general": {

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -19,7 +19,7 @@ public class Se
     internal const int CurrentMacOsFontMigrationVersion = 1;
     internal const int CurrentShortcutsMigrationVersion = 2;
 
-    public static string Version { get; set; } = "v5.2.0-beta21";
+    public static string Version { get; set; } = "v5.2.0-beta22";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
Version bump plus the change-log section for the 24 pull requests merged since the `v5.2.0-beta21` tag (enumerated by ancestor-checking each merge commit against the tag, not by date).

- `Se.cs` → `v5.2.0-beta22`
- `English.json` version field regenerated from the language classes
- `change-log.txt` section dated 23rd of August 2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)