### PR TITLE
Fix OpenRouter STT requests for GPT transcription models

### DIFF
--- a/src/ui/Features/Video/SpeechToText/Engines/OpenRouterSttEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/OpenRouterSttEngine.cs
@@ -12,9 +12,9 @@ namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 
 /// <summary>
 /// Online speech-to-text via OpenRouter's audio transcription API. OpenRouter
-/// routes to Whisper / GPT-4o-transcribe / Groq / Chirp behind one endpoint and
-/// one API key, and returns the same verbose_json segment/word shape we already
-/// parse. See <see cref="OpenRouterSttService"/> for the request encoding.
+/// routes to Whisper / GPT transcription / Groq / Chirp behind one endpoint and
+/// one API key. Response formats are selected per model; see
+/// <see cref="OpenRouterSttService"/> for the request encoding.
 /// </summary>
 public class OpenRouterSttEngine : IOnlineSttEngine
 {

--- a/src/ui/Features/Video/SpeechToText/OpenRouter/OpenRouterSttService.cs
+++ b/src/ui/Features/Video/SpeechToText/OpenRouter/OpenRouterSttService.cs
@@ -183,11 +183,22 @@ public class OpenRouterSttService : ISttTranscriber
         return Encoding.UTF8.GetString(stream.ToArray());
     }
 
+    /// <summary>
+    /// OpenAI's GPT transcription models (e.g. <c>gpt-4o-transcribe</c>,
+    /// <c>gpt-4o-mini-transcribe</c>) reject <c>verbose_json</c>, unlike Whisper.
+    /// Matched by name shape rather than an exact list so future <c>gpt-*-transcribe</c>
+    /// models are covered without a code change.
+    /// </summary>
     internal static bool IsJsonOnlyModel(string? model)
     {
-        return model?.Contains("gpt-transcribe", StringComparison.OrdinalIgnoreCase) == true ||
-               model?.Contains("gpt-4o-transcribe", StringComparison.OrdinalIgnoreCase) == true ||
-               model?.Contains("gpt-4o-mini-transcribe", StringComparison.OrdinalIgnoreCase) == true;
+        if (string.IsNullOrWhiteSpace(model))
+        {
+            return false;
+        }
+
+        var name = model[(model.LastIndexOf('/') + 1)..];
+        return name.StartsWith("gpt-", StringComparison.OrdinalIgnoreCase) &&
+               name.Contains("transcribe", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/ui/Features/Video/SpeechToText/OpenRouter/OpenRouterSttService.cs
+++ b/src/ui/Features/Video/SpeechToText/OpenRouter/OpenRouterSttService.cs
@@ -17,12 +17,13 @@ namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.OpenRouter;
 /// Speech-to-text via OpenRouter's audio transcription API. Unlike OpenAI's
 /// multipart <c>/v1/audio/transcriptions</c>, OpenRouter takes a JSON body with
 /// the audio base64-encoded under <c>input_audio</c>. The documented response is
-/// <c>text</c> + usage only — <c>response_format=verbose_json</c> and
-/// <c>timestamp_granularities[]</c> are sent opportunistically in case the
-/// routed provider honors them and returns the segment/word shape we already
-/// parse into <see cref="OpenAiCompatibleSttResponse"/>. When only <c>text</c>
-/// comes back, the caller's chunk pipeline spans each chunk's duration and
-/// splits into sentences so timing survives.
+/// <c>text</c> + usage only. Whisper-compatible models receive
+/// <c>response_format=verbose_json</c> and <c>timestamp_granularities[]</c> when
+/// supported. OpenAI's newer GPT transcription models only accept
+/// <c>response_format=json</c>, so they receive the plain response format and
+/// no timestamp hints. When only <c>text</c> comes back, the caller's chunk
+/// pipeline spans each chunk's duration and splits into sentences so timing
+/// survives.
 /// </summary>
 public class OpenRouterSttService : ISttTranscriber
 {
@@ -127,8 +128,9 @@ public class OpenRouterSttService : ISttTranscriber
     /// <summary>
     /// Serialize the OpenRouter transcription request body. The audio is
     /// base64-encoded (raw, not a data URI) under <c>input_audio</c>, and
-    /// <c>verbose_json</c> + <c>timestamp_granularities[]</c> ask for segment and
-    /// word timings when the underlying model supports them.
+    /// The newer GPT transcription models only accept <c>json</c>, while
+    /// Whisper-compatible models can return <c>verbose_json</c> with segment and
+    /// word timings.
     /// </summary>
     internal static string BuildRequestBody(OpenRouterSttSettings settings, byte[] audioBytes, string format, string? language)
     {
@@ -144,13 +146,20 @@ public class OpenRouterSttService : ISttTranscriber
             writer.WriteString("format", string.IsNullOrWhiteSpace(format) ? "mp3" : format);
             writer.WriteEndObject();
 
-            writer.WriteString("response_format", "verbose_json");
+            if (IsJsonOnlyModel(settings.Model))
+            {
+                writer.WriteString("response_format", "json");
+            }
+            else
+            {
+                writer.WriteString("response_format", "verbose_json");
 
-            writer.WritePropertyName("timestamp_granularities");
-            writer.WriteStartArray();
-            writer.WriteStringValue("segment");
-            writer.WriteStringValue("word");
-            writer.WriteEndArray();
+                writer.WritePropertyName("timestamp_granularities");
+                writer.WriteStartArray();
+                writer.WriteStringValue("segment");
+                writer.WriteStringValue("word");
+                writer.WriteEndArray();
+            }
 
             var languageToUse = language ?? settings.Language;
             if (!string.IsNullOrWhiteSpace(languageToUse))
@@ -172,6 +181,13 @@ public class OpenRouterSttService : ISttTranscriber
         }
 
         return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    internal static bool IsJsonOnlyModel(string? model)
+    {
+        return model?.Contains("gpt-transcribe", StringComparison.OrdinalIgnoreCase) == true ||
+               model?.Contains("gpt-4o-transcribe", StringComparison.OrdinalIgnoreCase) == true ||
+               model?.Contains("gpt-4o-mini-transcribe", StringComparison.OrdinalIgnoreCase) == true;
     }
 
     /// <summary>

--- a/tests/UI/Features/Video/SpeechToText/OpenRouter/OpenRouterSttServiceTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/OpenRouter/OpenRouterSttServiceTests.cs
@@ -40,6 +40,25 @@ public class OpenRouterSttServiceTests
         Assert.Equal("de", root.GetProperty("language").GetString());
     }
 
+    [Theory]
+    [InlineData("openai/gpt-transcribe")]
+    [InlineData("openai/gpt-4o-transcribe")]
+    [InlineData("openai/gpt-4o-mini-transcribe")]
+    public void BuildRequestBody_GptTranscriptionModelsUseJsonWithoutTimestamps(string model)
+    {
+        var body = OpenRouterSttService.BuildRequestBody(
+            MakeSettings(model),
+            Encoding.UTF8.GetBytes("hello-bytes"),
+            "mp3",
+            "ar");
+
+        using var doc = JsonDocument.Parse(body);
+        var root = doc.RootElement;
+
+        Assert.Equal("json", root.GetProperty("response_format").GetString());
+        Assert.False(root.TryGetProperty("timestamp_granularities", out _));
+    }
+
     [Fact]
     public void BuildRequestBody_OmitsEmptyLanguageAndZeroTemperature()
     {

--- a/tests/UI/Features/Video/SpeechToText/OpenRouter/OpenRouterSttServiceTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/OpenRouter/OpenRouterSttServiceTests.cs
@@ -44,6 +44,7 @@ public class OpenRouterSttServiceTests
     [InlineData("openai/gpt-transcribe")]
     [InlineData("openai/gpt-4o-transcribe")]
     [InlineData("openai/gpt-4o-mini-transcribe")]
+    [InlineData("openai/gpt-5-transcribe")] // not released at the time of writing; matched by name shape, not an exact list
     public void BuildRequestBody_GptTranscriptionModelsUseJsonWithoutTimestamps(string model)
     {
         var body = OpenRouterSttService.BuildRequestBody(
@@ -57,6 +58,25 @@ public class OpenRouterSttServiceTests
 
         Assert.Equal("json", root.GetProperty("response_format").GetString());
         Assert.False(root.TryGetProperty("timestamp_granularities", out _));
+    }
+
+    [Theory]
+    [InlineData("openai/whisper-1")]
+    [InlineData("openai/whisper-large-v3")]
+    [InlineData("openai/gpt-4o-audio-preview")] // "gpt-" prefixed but not a transcription model
+    public void BuildRequestBody_NonTranscribeModelsKeepVerboseJson(string model)
+    {
+        var body = OpenRouterSttService.BuildRequestBody(
+            MakeSettings(model),
+            Encoding.UTF8.GetBytes("hello-bytes"),
+            "mp3",
+            "ar");
+
+        using var doc = JsonDocument.Parse(body);
+        var root = doc.RootElement;
+
+        Assert.Equal("verbose_json", root.GetProperty("response_format").GetString());
+        Assert.True(root.TryGetProperty("timestamp_granularities", out _));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Use `json` for GPT transcription models that reject `verbose_json`.
- Omit timestamp granularity hints for those models.
- Keep verbose timestamp responses for Whisper-compatible models.
- Add request-body coverage for the supported GPT transcription model IDs.

## Testing

- `dotnet test tests/UI/UITests.csproj --no-restore --filter FullyQualifiedName~OpenRouterSttServiceTests -p:UsedAvaloniaProducts=`
- `dotnet test tests/UI/UITests.csproj --no-restore -p:UsedAvaloniaProducts=`

Both test runs pass.