### PR TITLE
Add WhisperX speech-to-text engine

### DIFF
--- a/docs/features/import-plain-text.md
+++ b/docs/features/import-plain-text.md
@@ -45,6 +45,8 @@ Missing models are downloaded automatically when you press OK. Progress is shown
 
 Runs normal [speech to text](speech-to-text.md) on the video, then matches your script against the transcript. Useful when the forced aligner does not support your language. Lines that cannot be matched get interpolated time codes.
 
+For the highest local transcription quality, select **WhisperX** in the speech-to-text window. It supports the full Whisper language catalog, and its language-specific word aligners improve timing where available. The imported script remains the source text; this command replaces its time codes from the WhisperX transcript.
+
 ## OK / Result
 
 Pressing **OK** replaces the currently loaded subtitle with the imported lines. Save your current work first if you need it.

--- a/docs/features/speech-to-text.md
+++ b/docs/features/speech-to-text.md
@@ -14,6 +14,7 @@ Subtitle Edit can automatically transcribe audio to text using Whisper-based and
 | Whisper CPP | Windows, Linux, macOS | Local CPU engine. On Windows the cuBLAS (NVIDIA CUDA) and Vulkan GPU backends can also be selected from the Whisper CPP backend dropdown. |
 | Purfview Faster Whisper XXL | Windows, Linux | Fast local engine, often used with NVIDIA CUDA |
 | Whisper CTranslate2 | Windows, Linux (x64), macOS (Apple Silicon) | CPU / NVIDIA CUDA depending on installation; CUDA requires [CUDA 12.x](https://developer.nvidia.com/cuda-12-0-0-download-archive) |
+| WhisperX | Windows, Linux, macOS | Installed by Subtitle Edit into an isolated Python environment; word alignment depends on language-specific WhisperX models |
 | MLX Whisper | macOS (Apple Silicon) | Runs Whisper on the Apple GPU / Neural Engine via Apple's MLX. Not downloaded by Subtitle Edit — install the `mlx-whisper` Python package yourself (see notes below) |
 | Whisper Const-me | Windows | DirectX-based engine |
 | Whisper OpenAI | All | Python-based OpenAI Whisper workflow |
@@ -31,6 +32,8 @@ Engines and models are downloaded automatically on first use.
 - **Qwen3 ASR CPP** includes 0.6B and 1.7B model options, plus a forced-aligner model used for timing workflows.
 - **Crisp ASR** is exposed as one engine that wraps multiple backends (Parakeet, Canary, Cohere, Fire Red, Fun-ASR Nano, GigaAM, GLM, Granite, Qwen3, Mega, MOSS Diarize, Omni, Kyutai, SenseVoice, ARK, Voxtral). Pick the backend from the Crisp ASR backend dropdown.
 - **MLX Whisper** (Apple Silicon Macs) is not bundled or auto-downloaded — it drives Apple's `mlx-whisper` Python package. Install it once with `pip3 install mlx-whisper` (or `pipx install mlx-whisper`); models download from Hugging Face on first use. Subtitle Edit detects the install by finding a Python that can `import mlx_whisper` — it probes Homebrew, python.org, pyenv and system interpreters, and (for pipx / virtual-env / conda installs, which isolate the package) reads the `mlx_whisper` command found on your PATH or at `~/.local/bin/mlx_whisper` to locate the matching interpreter. If it reports "not found" after a pipx/venv install, make sure `which mlx_whisper` resolves.
+- **WhisperX** is installed with the Download button into an isolated `.venv` under Subtitle Edit's `SpeechToText` data folder. Python 3 must already be installed. WhisperX downloads the selected faster-whisper model on first use. It exposes the full Whisper language catalog for transcription, while word alignment depends on the language-specific aligner shipped by WhisperX.
+- On Apple Silicon, use `--device cpu --compute_type int8`, which is the supported WhisperX path for macOS. WhisperX's standard faster-whisper and alignment stack does not provide a reliable Metal/MPS mode, so Subtitle Edit does not force Apple GPU use for this engine. For an Apple GPU transcription-only path, use MLX Whisper; it does not replace WhisperX's forced-alignment stage.
 - A **Forced aligner** option is shown for Crisp ASR backends and exposes the built-in aligner, Canary CTC, Qwen3, and the wav2vec2 zoo (12 language-specific CTC aligners that run on top of any Crisp ASR backend).
 - Several newer engines support automatic language selection.
 - Each engine can have separate advanced command-line parameters.

--- a/src/libuilogic/AudioToText/WhisperLanguage.cs
+++ b/src/libuilogic/AudioToText/WhisperLanguage.cs
@@ -23,23 +23,6 @@ namespace Nikse.SubtitleEdit.UiLogic.AudioToText
         {
             get
             {
-                if (Configuration.Settings.Tools.WhisperChoice == WhisperChoice.WhisperX)
-                {
-                    return new[]
-                    {
-                        new WhisperLanguage("zh", "chinese"),
-                        new WhisperLanguage("nl", "dutch"),
-                        new WhisperLanguage("en", "english"),
-                        new WhisperLanguage("fr", "french"),
-                        new WhisperLanguage("de", "german"),
-                        new WhisperLanguage("it", "italian"),
-                        new WhisperLanguage("ja", "japanese"),
-                        new WhisperLanguage("pt", "portuguese"),
-                        new WhisperLanguage("es", "spanish"),
-                        new WhisperLanguage("uk", "ukrainian"),
-                    };
-                }
-
                 var languages = new List<WhisperLanguage>
                 {
                     new WhisperLanguage("en", "english"),

--- a/src/ui/Assets/SpeechToText/WhisperX.txt
+++ b/src/ui/Assets/SpeechToText/WhisperX.txt
@@ -1,0 +1,12 @@
+WhisperX is an optional Python-based speech-to-text engine that combines faster-whisper transcription with word-level alignment where a language-specific alignment model is available.
+
+Subtitle Edit installs WhisperX into an isolated .venv below its SpeechToText data folder. Python 3 must already be installed on the computer. The first transcription downloads the selected faster-whisper model from Hugging Face and may take several minutes.
+
+Recommended parameters on Apple Silicon and other CPU-only systems:
+  --device cpu --compute_type int8
+
+WhisperX's standard alignment stack does not provide a supported Apple Metal/MPS execution path. On macOS, keep the CPU/int8 parameters for reliable results. CUDA acceleration remains available on compatible NVIDIA systems through the normal WhisperX parameters.
+
+The model dropdown uses the regular Whisper model names. Use large-v3 for maximum accuracy, or large-v3-turbo for a faster first pass. The existing "Align time codes via Speech to text" command can use WhisperX output to align an imported script while preserving the imported text.
+
+WhisperX supports the full Whisper language catalog for transcription. Word alignment is language-dependent, so languages without a compatible WhisperX aligner still receive normal WhisperX segment timestamps.

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
@@ -14,7 +14,9 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Timers;
@@ -160,7 +162,18 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject, ICl
         // which left the dialog stuck on "Unpacking..." indefinitely.
         if (_downloadTask is { IsCompletedSuccessfully: true } && Engine != null)
         {
-            if (Engine.Name == WhisperEnginePurfviewFasterWhisperXxl.StaticName)
+            if (Engine is WhisperEngineWhisperX)
+            {
+                StopIndeterminateProgress();
+                OkPressed = Engine.IsEngineInstalled();
+                if (!OkPressed)
+                {
+                    Error = "WhisperX installation completed without creating its executable.";
+                }
+
+                Close();
+            }
+            else if (Engine.Name == WhisperEnginePurfviewFasterWhisperXxl.StaticName)
             {
                 var dir = Engine.GetAndCreateWhisperFolder();
                 var tempFileName = Path.Combine(dir, Engine.Name + ".7z");
@@ -561,6 +574,11 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject, ICl
             var tempFileName = Path.Combine(dir, Engine.Name + ".7z");
             _downloadTask = _whisperDownloadService.DownloadWhisperPurfviewFasterWhisperXxl(tempFileName, downloadProgress, _cancellationTokenSource.Token);
         }
+        else if (Engine is WhisperEngineWhisperX whisperX)
+        {
+            StartIndeterminateProgress();
+            _downloadTask = InstallWhisperXAsync(whisperX, _cancellationTokenSource.Token);
+        }
         else if (Engine is Qwen3AsrCppEngine)
         {
             var dir = Engine.GetAndCreateWhisperFolder();
@@ -594,6 +612,114 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject, ICl
             {
                 _downloadTask = _crispAsrDownloadService.DownloadEngine(_downloadStream, downloadProgress, _cancellationTokenSource.Token);
             }
+        }
+    }
+
+    private async Task InstallWhisperXAsync(WhisperEngineWhisperX engine, CancellationToken cancellationToken)
+    {
+        var python = WhisperEngineWhisperX.FindPythonExecutable();
+        if (string.IsNullOrEmpty(python))
+        {
+            throw new InvalidOperationException(
+                "Python 3 was not found. Install Python 3 from python.org, then run the WhisperX installer again.");
+        }
+
+        var folder = engine.GetAndCreateWhisperFolder();
+        var virtualEnvironment = Path.Combine(folder, ".venv");
+        var managedPython = engine.GetManagedPython();
+
+        if (!File.Exists(managedPython))
+        {
+            ProgressText = "Creating isolated Python environment...";
+            await RunWhisperXSetupProcessAsync(
+                python,
+                ["-m", "venv", virtualEnvironment],
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        ProgressText = "Installing WhisperX and its alignment dependencies...";
+        await RunWhisperXSetupProcessAsync(
+            managedPython,
+            ["-m", "pip", "install", "--upgrade", "pip", "whisperx"],
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task RunWhisperXSetupProcessAsync(
+        string executable,
+        IReadOnlyList<string> arguments,
+        CancellationToken cancellationToken)
+    {
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = executable,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                WorkingDirectory = Engine?.GetAndCreateWhisperFolder(),
+            },
+        };
+
+        foreach (var argument in arguments)
+        {
+            process.StartInfo.ArgumentList.Add(argument);
+        }
+
+        var error = new StringBuilder();
+        DataReceivedEventHandler onOutput = (_, args) =>
+        {
+            if (string.IsNullOrWhiteSpace(args.Data))
+            {
+                return;
+            }
+
+            if (args.Data.Contains("error", StringComparison.OrdinalIgnoreCase))
+            {
+                lock (error)
+                {
+                    error.AppendLine(args.Data);
+                }
+            }
+
+            Dispatcher.UIThread.Post(() => ProgressText = args.Data.Trim());
+        };
+
+        process.OutputDataReceived += onOutput;
+        process.ErrorDataReceived += onOutput;
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        try
+        {
+            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            try
+            {
+                if (!process.HasExited)
+                {
+                    process.Kill(true);
+                }
+            }
+            catch
+            {
+                // Best effort cancellation.
+            }
+
+            throw;
+        }
+
+        if (process.ExitCode != 0)
+        {
+            var detail = error.ToString().Trim();
+            throw new InvalidOperationException(
+                string.IsNullOrEmpty(detail)
+                    ? $"WhisperX setup failed with exit code {process.ExitCode}."
+                    : detail);
         }
     }
 

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineFactory.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineFactory.cs
@@ -37,6 +37,11 @@ public static class WhisperEngineFactory
             return new WhisperEngineOpenAi();
         }
 
+        if (staticName == WhisperEngineWhisperX.StaticName)
+        {
+            return new WhisperEngineWhisperX();
+        }
+
         if (staticName == WhisperEnginePurfviewFasterWhisperXxl.StaticName)
         {
             return new WhisperEnginePurfviewFasterWhisperXxl();

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineWhisperX.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineWhisperX.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia.Platform;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.UiLogic.AudioToText;
+
+namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+
+/// <summary>
+/// Optional Python-based WhisperX engine. The managed installation is kept below
+/// Subtitle Edit's data folder and does not modify the user's system Python packages.
+/// </summary>
+public sealed class WhisperEngineWhisperX : ISpeechToTextEngine
+{
+    public static string StaticName => "WhisperX";
+    public string Name => StaticName;
+    public string Choice => WhisperChoice.WhisperX;
+    public string Url => "https://github.com/m-bain/whisperX";
+
+    public List<WhisperLanguage> Languages => WhisperLanguage.Languages.OrderBy(p => p.Name).ToList();
+    public List<WhisperModel> Models => new WhisperModel().Models.ToList();
+    public string Extension => string.Empty;
+    public string UnpackSkipFolder => string.Empty;
+
+    public bool IsEngineInstalled() => File.Exists(GetExecutable());
+
+    public override string ToString() => Name;
+
+    public string GetAndCreateWhisperFolder()
+    {
+        var folder = Path.Combine(Se.SpeechToTextFolder, "WhisperX");
+        Directory.CreateDirectory(folder);
+        return folder;
+    }
+
+    public string GetAndCreateWhisperModelFolder(WhisperModel? whisperModel)
+    {
+        var folder = new WhisperModel().ModelFolder;
+        Directory.CreateDirectory(folder);
+        return folder;
+    }
+
+    public string GetExecutable()
+    {
+        var managed = GetManagedExecutable();
+        if (File.Exists(managed))
+        {
+            return managed;
+        }
+
+        var configured = ResolveConfiguredExecutable(Se.Settings.Tools.AudioToText.WhisperXLocation);
+        return configured ?? FindExecutableOnPath() ?? (OperatingSystem.IsWindows() ? "whisperx.exe" : "whisperx");
+    }
+
+    public bool IsModelInstalled(WhisperModel model)
+    {
+        // WhisperX owns the Hugging Face cache and downloads the selected model on first use.
+        // Do not route its model name to Subtitle Edit's .pt downloader.
+        return IsEngineInstalled();
+    }
+
+    public string GetModelForCmdLine(string modelName) => modelName;
+
+    public async Task<string> GetHelpText()
+    {
+        var uri = new Uri($"avares://SubtitleEdit/Assets/SpeechToText/{StaticName}.txt");
+        await using var stream = AssetLoader.Open(uri);
+        using var reader = new StreamReader(stream);
+        return await reader.ReadToEndAsync();
+    }
+
+    public string GetWhisperModelDownloadFileName(WhisperModel whisperModel, string url)
+        => Path.Combine(GetAndCreateWhisperModelFolder(whisperModel), Path.GetFileName(url));
+
+    public bool CanBeDownloaded() => true;
+
+    public string DownloadSizeText => "~1-2 GB (Python packages; models download on first use)";
+
+    public string CommandLineParameter
+    {
+        get => Se.Settings.Tools.AudioToText.CommandLineParameterWhisperX;
+        set => Se.Settings.Tools.AudioToText.CommandLineParameterWhisperX = value;
+    }
+
+    public string GetManagedExecutable()
+    {
+        var scripts = OperatingSystem.IsWindows() ? "Scripts" : "bin";
+        var fileName = OperatingSystem.IsWindows() ? "whisperx.exe" : "whisperx";
+        return Path.Combine(GetAndCreateWhisperFolder(), ".venv", scripts, fileName);
+    }
+
+    public string GetManagedPython()
+    {
+        var scripts = OperatingSystem.IsWindows() ? "Scripts" : "bin";
+        var fileName = OperatingSystem.IsWindows() ? "python.exe" : "python";
+        return Path.Combine(GetAndCreateWhisperFolder(), ".venv", scripts, fileName);
+    }
+
+    public static string? FindPythonExecutable()
+    {
+        var candidates = OperatingSystem.IsWindows()
+            ? new[] { "python.exe", "py.exe" }
+            : new[]
+            {
+                "python3", "python", "/opt/homebrew/bin/python3", "/usr/local/bin/python3",
+                "/Library/Frameworks/Python.framework/Versions/Current/bin/python3",
+            };
+
+        foreach (var candidate in candidates)
+        {
+            var path = candidate.Contains('/') || candidate.Contains(Path.DirectorySeparatorChar)
+                ? candidate
+                : FindExecutableOnPath(candidate);
+            if (!string.IsNullOrEmpty(path) && (File.Exists(path) || !Path.IsPathRooted(path)))
+            {
+                return path;
+            }
+        }
+
+        return null;
+    }
+
+    private static string? ResolveConfiguredExecutable(string? configured)
+    {
+        if (string.IsNullOrWhiteSpace(configured))
+        {
+            return null;
+        }
+
+        configured = configured.Trim();
+        if (File.Exists(configured))
+        {
+            return configured;
+        }
+
+        if (Directory.Exists(configured))
+        {
+            var fileName = OperatingSystem.IsWindows() ? "whisperx.exe" : "whisperx";
+            var candidate = Path.Combine(configured, fileName);
+            return File.Exists(candidate) ? candidate : null;
+        }
+
+        return null;
+    }
+
+    private static string? FindExecutableOnPath(string name = "whisperx")
+    {
+        var paths = (Environment.GetEnvironmentVariable("PATH") ?? string.Empty)
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .ToList();
+
+        if (OperatingSystem.IsMacOS())
+        {
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            paths.Add("/opt/homebrew/bin");
+            paths.Add("/usr/local/bin");
+            paths.Add(Path.Combine(home, ".local", "bin"));
+            paths.Add(Path.Combine(home, ".pyenv", "shims"));
+        }
+
+        var fileName = OperatingSystem.IsWindows() && !name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)
+            ? name + ".exe"
+            : name;
+        foreach (var path in paths.Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            var candidate = Path.Combine(path, fileName);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -255,6 +255,10 @@ public partial class SpeechToTextViewModel : ObservableObject
             Engines.Add(new WhisperEngineCTranslate2());
         }
 
+        // WhisperX is Python-based and runs on Windows, Linux, and macOS. Its optional
+        // installer creates an isolated environment below Subtitle Edit's data folder.
+        Engines.Add(new WhisperEngineWhisperX());
+
         Engines.Add(new WhisperEngineOpenAi());
 
         // Add OpenAI Compatible STT engine (available on all platforms)
@@ -444,6 +448,7 @@ public partial class SpeechToTextViewModel : ObservableObject
             or WhisperChoice.ConstMe
             or WhisperChoice.PurfviewFasterWhisperXxl
             or WhisperChoice.CTranslate2
+            or WhisperChoice.WhisperX
             or WhisperChoice.OpenAi;
     }
 
@@ -3803,7 +3808,7 @@ public partial class SpeechToTextViewModel : ObservableObject
     private static bool CanEngineReadSourceFileDirectly(ISpeechToTextEngine engine)
     {
         return engine.Name == WhisperEnginePurfviewFasterWhisperXxl.StaticName ||
-               engine is WhisperEngineCTranslate2;
+               engine is WhisperEngineCTranslate2 or WhisperEngineWhisperX;
     }
 
     /// <summary>
@@ -3846,6 +3851,25 @@ public partial class SpeechToTextViewModel : ObservableObject
         DataReceivedEventHandler? dataReceivedHandler = null,
         string engineOutputFolder = "")
     {
+        if (engine is WhisperEngineWhisperX whisperX)
+        {
+            var exe = whisperX.GetExecutable();
+            var whisperXArgs = whisperX.CommandLineParameter;
+            var languageArgX = language.Equals("auto", StringComparison.OrdinalIgnoreCase)
+                ? string.Empty
+                : $"--language {language} ";
+            var taskArg = translate ? "--task translate " : string.Empty;
+            var outputDir = string.IsNullOrEmpty(engineOutputFolder)
+                ? GetSttTempFolder()
+                : engineOutputFolder;
+            var parametersX =
+                $"{languageArgX}--model \"{model}\" --output_format srt --output_dir \"{outputDir}\" " +
+                $"{taskArg}{whisperXArgs} \"{waveFileName}\"";
+
+            Se.WriteToolsLog($"{exe} {parametersX}");
+            return StartEngineProcess(exe, parametersX, dataReceivedHandler);
+        }
+
         if (engine is Qwen3AsrCppEngine qwen3Asr)
         {
             var exe = qwen3Asr.GetExecutable();
@@ -4145,7 +4169,8 @@ public partial class SpeechToTextViewModel : ObservableObject
     {
         if (engine.Choice == new WhisperEnginePurfviewFasterWhisperXxl().Choice ||
             engine.Choice == new WhisperEngineOpenAi().Choice ||
-            engine.Choice == new WhisperEngineCTranslate2().Choice)
+            engine.Choice == new WhisperEngineCTranslate2().Choice ||
+            engine.Choice == WhisperChoice.WhisperX)
         {
             return "--task translate ";
         }
@@ -4692,6 +4717,7 @@ public partial class SpeechToTextViewModel : ObservableObject
                    or WhisperEngineCppCuBlas
                    or WhisperEngineCppVulkan
                    or WhisperEngineCTranslate2
+                   or WhisperEngineWhisperX
                    or WhisperEngineConstMe
                    or WhisperEnginePurfviewFasterWhisperXxl
                    or ICrispAsrEngine;

--- a/src/ui/Logic/Config/SeAudioToText.cs
+++ b/src/ui/Logic/Config/SeAudioToText.cs
@@ -43,6 +43,7 @@ public class SeAudioToText
     public string CommandLineParameterCppVulkan { get; set; } = string.Empty;
     public string CommandLineParameterConstMe { get; set; } = string.Empty;
     public string CommandLineParameterCTranslate2 { get; set; } = "--vad_filter True";
+    public string CommandLineParameterWhisperX { get; set; } = "--device cpu --compute_type int8";
     public string CommandLineParameterPurfviewFasterWhisperXxl { get; set; } = "--standard";
     public string CommandLineParameterOpenAi { get; set; } = string.Empty;
     public string CommandLineParameterQwen3AsrCpp { get; set; } = string.Empty;

--- a/tests/UI/Features/Video/SpeechToText/Engines/WhisperEngineWhisperXTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/Engines/WhisperEngineWhisperXTests.cs
@@ -1,0 +1,49 @@
+using System.Linq;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+using Nikse.SubtitleEdit.UiLogic.AudioToText;
+
+namespace UITests.Features.Video.SpeechToText.Engines;
+
+public class WhisperEngineWhisperXTests
+{
+    [Fact]
+    public void FactoryCreatesWhisperXEngine()
+    {
+        var engine = WhisperEngineFactory.MakeEngineFromStaticName(WhisperEngineWhisperX.StaticName);
+
+        Assert.IsType<WhisperEngineWhisperX>(engine);
+        Assert.Equal(WhisperChoice.WhisperX, engine.Choice);
+        Assert.True(engine.CanBeDownloaded());
+    }
+
+    [Fact]
+    public void LanguageCatalogIncludesLanguagesBeyondTheOriginalWhisperXSubset()
+    {
+        var engine = new WhisperEngineWhisperX();
+        var languageCodes = engine.Languages.Select(p => p.Code).ToHashSet();
+
+        Assert.Contains("tr", languageCodes);
+        Assert.Contains("ar", languageCodes);
+        Assert.Contains("ru", languageCodes);
+        Assert.Contains("fa", languageCodes);
+        Assert.True(languageCodes.Count > 50);
+    }
+
+    [Fact]
+    public void ParametersCanSelectReliableMacCpuMode()
+    {
+        var engine = new WhisperEngineWhisperX();
+        var original = engine.CommandLineParameter;
+
+        try
+        {
+            engine.CommandLineParameter = "--device cpu --compute_type int8";
+            Assert.Contains("--device cpu", engine.CommandLineParameter);
+            Assert.Contains("--compute_type int8", engine.CommandLineParameter);
+        }
+        finally
+        {
+            engine.CommandLineParameter = original;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add WhisperX as a first-class local speech-to-text engine and make it available to the existing imported-script alignment workflow.

## Implementation plan

1. Register WhisperX in the speech-to-text engine factory and expose it on Windows, Linux, and macOS.
2. Keep the installation GUI-based by creating an isolated Python virtual environment under Subtitle Edit's SpeechToText data folder.
3. Reuse Subtitle Edit's existing model picker and SRT result discovery, while allowing WhisperX to download its faster-whisper models from Hugging Face on first use.
4. Pass the selected language, model, translation task, output folder, and advanced parameters to the WhisperX CLI.
5. Expand WhisperX's language selector from the legacy ten-language subset to the full Whisper language catalog.
6. Make the engine usable from the existing Align time codes via Speech to text command, which preserves the imported text and replaces its timings.
7. Document the Apple Silicon behavior and avoid exposing an unsupported Apple GPU switch.

## What changed

- Added `WhisperEngineWhisperX` with managed virtual-environment paths, external executable detection, model and language metadata, and per-engine parameters.
- Added a GUI installer that finds Python 3, creates `.venv`, and installs or upgrades `pip` and `whisperx` without changing the system Python environment.
- Added default parameters `--device cpu --compute_type int8` for reliable macOS and CPU execution.
- Added WhisperX process handling, direct-media input support, translation support, automatic language selection, and SRT output handling.
- Added the engine to the existing engine factory and settings flow.
- Removed the legacy WhisperX language restriction so Turkish, Arabic, Russian, Persian, and the rest of the Whisper language catalog are available for transcription.
- Added embedded help, feature documentation, and focused tests.

## Apple GPU decision

WhisperX's normal faster-whisper plus alignment stack does not provide a reliable supported Metal/MPS path. This change intentionally does not force Apple GPU usage. On Apple Silicon, WhisperX uses CPU with `int8` by default. MLX Whisper remains the separate Apple-GPU option for transcription-only use, but it does not replace WhisperX alignment.

## Verification

- `dotnet build src/ui/UI.csproj --no-restore -c Release` passed with 0 errors.
- `dotnet test tests/UI/UITests.csproj --no-restore -c Release --filter FullyQualifiedName~WhisperEngineWhisperXTests` passed: 3 tests.
- Debug builds remain blocked by the pre-existing `Application.AttachDeveloperTools` error in `src/ui/Program.cs` with the current Avalonia diagnostics package. That unrelated issue is not changed here.

## Limitations

- Python 3 must already be installed for the GUI installer.
- WhisperX downloads the selected faster-whisper model on first use.
- Word-level alignment is language-dependent. Languages without a compatible WhisperX alignment model still receive normal segment timestamps.
