### PR TITLE
Perf hunt round 14: Netflix checks, HI removal and two format writers

### DIFF
--- a/src/libse/Forms/FixCommonErrors/FixAloneLowercaseIToUppercaseI.cs
+++ b/src/libse/Forms/FixCommonErrors/FixAloneLowercaseIToUppercaseI.cs
@@ -12,6 +12,55 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string FixLowercaseIToUppercaseI { get; set; } = "Fix alone lowercase 'i' to 'I' (English)";
         }
 
+        // Every needle below embeds Environment.NewLine or the target character, so none of them
+        // can be a compile-time constant: written inline they were ten fresh strings allocated
+        // for every line of the file, just to be handed to Replace. Prepared once instead.
+        private static readonly string UppercaseINewLine = ">I" + Environment.NewLine;
+        private static readonly string NewLineLowerImSpace = Environment.NewLine + "i'm ";
+        private static readonly string NewLineUpperImSpace = Environment.NewLine + "I'm ";
+        private static readonly string NewLineLowerImPeriod = Environment.NewLine + "i'm.";
+        private static readonly string NewLineUpperImPeriod = Environment.NewLine + "I'm.";
+
+        /// <summary>Characters that stop the "i-l" -&gt; "I-l" fix; see the match loop below.</summary>
+        private static readonly string LittleIStopChars = Environment.NewLine + @" <>!.?:;,";
+
+        /// <summary>
+        /// The four html-tag needles for one target character, prepared once. A single immutable
+        /// instance swapped by reference keeps this thread-safe without locking; every caller in
+        /// the app passes 'i', so the memo hits on all but the first call.
+        /// </summary>
+        private sealed class TargetNeedles
+        {
+            public readonly char Target;
+            public readonly string CloseTag;
+            public readonly string Space;
+            public readonly string ZeroWidthSpace;
+            public readonly string ZeroWidthNoBreakSpace;
+
+            public TargetNeedles(char target)
+            {
+                Target = target;
+                CloseTag = ">" + target + "</";
+                Space = ">" + target + " ";
+                ZeroWidthSpace = ">" + target + "\u200B" + Environment.NewLine;
+                ZeroWidthNoBreakSpace = ">" + target + "\uFEFF" + Environment.NewLine;
+            }
+        }
+
+        private static TargetNeedles _needles = new TargetNeedles('i');
+
+        private static TargetNeedles GetNeedles(char target)
+        {
+            var needles = _needles;
+            if (needles.Target != target)
+            {
+                needles = new TargetNeedles(target);
+                _needles = needles;
+            }
+
+            return needles;
+        }
+
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {
             string fixAction = Language.FixLowercaseIToUppercaseI;
@@ -38,16 +87,17 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         public static string FixAloneLowercaseIToUppercaseLine(Regex re, string oldText, string input, char target)
         {
             //html tags
-            var s = input.Replace(">" + target + "</", ">I</")
-                         .Replace(">" + target + " ", ">I ")
-                         .Replace(">" + target + "\u200B" + Environment.NewLine, ">I" + Environment.NewLine) // Zero Width Space
-                         .Replace(">" + target + "\uFEFF" + Environment.NewLine, ">I" + Environment.NewLine); // Zero Width No-Break Space
+            var needles = GetNeedles(target);
+            var s = input.Replace(needles.CloseTag, ">I</")
+                         .Replace(needles.Space, ">I ")
+                         .Replace(needles.ZeroWidthSpace, UppercaseINewLine) // Zero Width Space
+                         .Replace(needles.ZeroWidthNoBreakSpace, UppercaseINewLine); // Zero Width No-Break Space
 
             s = s.Replace(" i-i ", " I-I ");
             s = s.Replace(" i-i-i ", " I-I-I ");
             s = s.Replace(" i'm ", " I'm ");
-            s = s.Replace(Environment.NewLine + "i'm ", Environment.NewLine + "I'm ");
-            s = s.Replace(Environment.NewLine + "i'm.", Environment.NewLine + "I'm.");
+            s = s.Replace(NewLineLowerImSpace, NewLineUpperImSpace);
+            s = s.Replace(NewLineLowerImPeriod, NewLineUpperImPeriod);
             s = s.Replace(" i'm.", " I'm.");
             s = s.Replace(" i'm,", " I'm,");
             s = s.Replace("-i'm-", "-I'm-");
@@ -96,7 +146,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                             fix = false;
                         }
 
-                        if (fix && next == '-' && match.Index < s.Length - 5 && s[match.Index + 2] == 'l' && !(Environment.NewLine + @" <>!.?:;,").Contains(s[match.Index + 3]))
+                        if (fix && next == '-' && match.Index < s.Length - 5 && s[match.Index + 2] == 'l' && !LittleIStopChars.Contains(s[match.Index + 3]))
                         {
                             fix = false;
                         }

--- a/src/libse/Forms/FixCommonErrors/FixMissingSpaces.cs
+++ b/src/libse/Forms/FixCommonErrors/FixMissingSpaces.cs
@@ -2,6 +2,9 @@
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 using System.Text.RegularExpressions;
+#if NET8_0_OR_GREATER
+using System.Buffers;
+#endif
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
 {
@@ -12,6 +15,14 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string FixMissingSpace { get; set; } = "Fix missing space";
             public static string FixMissingSpaces { get; set; } = "Fix missing spaces";
         }
+
+        // FixSpaceAfter asks "is this character in that little set?" for every occurrence of the
+        // fix character in the file. Both sets used to be probed with
+        // `"...".Contains(text[i].ToString())`, which allocates a one-character string per probe.
+        private const string SpaceAfterSkipChars = " \r\n\":;()[]<>.؟!\u060C";
+#if NET8_0_OR_GREATER
+        private static readonly SearchValues<char> SpaceAfterSkipSearch = SearchValues.Create(SpaceAfterSkipChars);
+#endif
 
         private static readonly Regex FixMissingSpacesReComma = new Regex(@"[^\s\d],[^\s]", RegexOptions.Compiled);
         private static readonly Regex FixMissingSpacesRePeriod = new Regex(@"\p{Ll}\p{Ll}[.][\p{Ll}\p{Lu}]", RegexOptions.Compiled);
@@ -403,7 +414,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                     {
                         skip = true;
                     }
-                    if (!skip && "0123456789".Contains(text[idx + 1].ToString()))
+                    if (!skip && IsAsciiDigit(text[idx + 1]))
                     {
                         skip = true;
                     }
@@ -414,7 +425,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                     }
                 }
 
-                if (!skip && !" \r\n\":;()[]<>.؟!\u060C".Contains(text[idx + 1].ToString()))
+                if (!skip && !IsSpaceAfterSkipChar(text[idx + 1]))
                 {
                     text = text.Insert(idx + 1, " ");
                 }
@@ -423,6 +434,17 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             }
 
             return text;
+        }
+
+        private static bool IsAsciiDigit(char c) => c >= '0' && c <= '9';
+
+        private static bool IsSpaceAfterSkipChar(char c)
+        {
+#if NET8_0_OR_GREATER
+            return SpaceAfterSkipSearch.Contains(c);
+#else
+            return SpaceAfterSkipChars.IndexOf(c) >= 0;
+#endif
         }
 
         private static string FixMissingSpaceBeforeAfterMusicQuotes(string input, char musicSymbol)

--- a/src/libse/Forms/RemoveTextForHI.cs
+++ b/src/libse/Forms/RemoveTextForHI.cs
@@ -3,12 +3,51 @@ using Nikse.SubtitleEdit.Core.Forms.FixCommonErrors;
 using System;
 using System.Collections.Generic;
 using System.Text;
+#if NET8_0_OR_GREATER
+using System.Buffers;
+#endif
 
 namespace Nikse.SubtitleEdit.Core.Forms
 {
     public class RemoveTextForHI
     {
         private static readonly CharLookup MusicSymbols = CharLookup.Create('\u266A', '\u266B');
+
+        // ShouldRemoveNarrator runs for every colon in the file and used to allocate all three
+        // of these sets on every call. Hoisting the string[] literals alone measured *slower*
+        // than the throw-away arrays, so the sets are prepared as multi-value searches instead:
+        // one pass over the text each, rather than two and fifteen separate IndexOf sweeps.
+        private static readonly string[] NarratorSkipWords =
+        {
+            "Previously on",
+            "Improved by",
+            " is ",
+            " are ",
+            " were ",
+            " was ",
+            " think ",
+            " guess ",
+            " will ",
+            " believe ",
+            " say ",
+            " said ",
+            " do ",
+            " want ",
+            "That's "
+        };
+
+        private static readonly string[] NarratorSkipUrlOrList = { "http", ", " };
+        private static readonly char[] NarratorSkipPunctuation = { '!', '?', '\u00BF', '\u00A1' };
+#if NET8_0_OR_GREATER
+        private static readonly SearchValues<string> NarratorSkipWordsSearch =
+            SearchValues.Create(NarratorSkipWords, StringComparison.OrdinalIgnoreCase);
+
+        private static readonly SearchValues<string> NarratorSkipUrlOrListSearch =
+            SearchValues.Create(NarratorSkipUrlOrList, StringComparison.OrdinalIgnoreCase);
+
+        private static readonly SearchValues<char> NarratorSkipPunctuationSearch =
+            SearchValues.Create(NarratorSkipPunctuation);
+#endif
 
         public RemoveTextForHISettings Settings { get; set; }
 
@@ -863,7 +902,8 @@ namespace Nikse.SubtitleEdit.Core.Forms
                     if (partialRemove)
                     {
                         newText = line.Remove(lastIndexOfPeriod + 4, indexOfColon - lastIndexOfPeriod - 3);
-                        if (newText.Substring(lastIndexOfPeriod + 3).StartsWith("  "))
+                        var doubleSpaceAt = lastIndexOfPeriod + 3;
+                        if (doubleSpaceAt + 1 < newText.Length && newText[doubleSpaceAt] == ' ' && newText[doubleSpaceAt + 1] == ' ')
                         {
                             newText = newText.Remove(lastIndexOfPeriod + 3, 1);
                         }
@@ -905,35 +945,33 @@ namespace Nikse.SubtitleEdit.Core.Forms
 
         private static bool ShouldRemoveNarrator(string pre, string language)
         {
-            if (pre.Length > 30 || pre.IndexOfAny(new[] { "http", ", " }, StringComparison.OrdinalIgnoreCase) >= 0)
+#if NET8_0_OR_GREATER
+            if (pre.Length > 30 || pre.AsSpan().IndexOfAny(NarratorSkipUrlOrListSearch) >= 0)
             {
                 return false;
             }
 
-            if (language == "en" && pre.Length > 15 && pre.IndexOfAny(new[]
-                {
-                    "Previously on",
-                    "Improved by",
-                    " is ",
-                    " are ",
-                    " were ",
-                    " was ",
-                    " think ",
-                    " guess ",
-                    " will ",
-                    " believe ",
-                    " say ",
-                    " said ",
-                    " do ",
-                    " want ",
-                    "That's "
-                }, StringComparison.OrdinalIgnoreCase) >= 0)
+            if (language == "en" && pre.Length > 15 && pre.AsSpan().IndexOfAny(NarratorSkipWordsSearch) >= 0)
             {
                 return false;
             }
 
             // Okay! Narrator: Hello!
-            return pre.IndexOfAny(new[] { '!', '?', '¿', '¡' }) < 0;
+            return pre.AsSpan().IndexOfAny(NarratorSkipPunctuationSearch) < 0;
+#else
+            if (pre.Length > 30 || pre.IndexOfAny(NarratorSkipUrlOrList, StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return false;
+            }
+
+            if (language == "en" && pre.Length > 15 && pre.IndexOfAny(NarratorSkipWords, StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return false;
+            }
+
+            // Okay! Narrator: Hello!
+            return pre.IndexOfAny(NarratorSkipPunctuation) < 0;
+#endif
         }
 
         private static readonly char[] TrimStartNoiseChar = { '-', ' ' };

--- a/src/libse/SubtitleFormats/CheetahCaption.cs
+++ b/src/libse/SubtitleFormats/CheetahCaption.cs
@@ -10,6 +10,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
     public class CheetahCaption : SubtitleFormat, IBinaryPersistableSubtitle
     {
+        // Resolved once: GetEncoding(1252) was called per paragraph on write and per paragraph
+        // on read, and it is not free - it walks the provider chain on every call.
+        private static readonly Encoding Cp1252 = Encoding.GetEncoding(1252);
+
         private static readonly Dictionary<byte, char> DicCodeLatin = new Dictionary<byte, char>
         {
             [0x81] = '♪',
@@ -217,7 +221,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     sb.Clear();
                     var j = 0;
                     var italics = false;
-                    var encoding = Encoding.GetEncoding(1252);
+                    var encoding = Cp1252;
                     while (j < textLength)
                     {
                         var index = i + start + j;
@@ -383,10 +387,12 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     textBytes.Add(0xd0);
                 }
 
-                var encoding = Encoding.GetEncoding(1252);
+                var encoding = Cp1252;
                 while (j < text.Length)
                 {
-                    if (text.Substring(j).StartsWith(Environment.NewLine, StringComparison.Ordinal))
+                    // Substring(j) copied the rest of the line for every character just to test
+                    // its first one or two characters.
+                    if (text.AsSpan(j).StartsWith(Environment.NewLine.AsSpan(), StringComparison.Ordinal))
                     {
                         j += Environment.NewLine.Length;
                         textBytes.Add(0);

--- a/src/libse/SubtitleFormats/ScenaristClosedCaptions.cs
+++ b/src/libse/SubtitleFormats/ScenaristClosedCaptions.cs
@@ -406,6 +406,41 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         private static readonly Dictionary<string, string> LettersCodeLookup = BuildLettersCodeLookup();
 
+        // GetCodeFromLetter used to walk all 339 entries of LetterDictionary with a LINQ
+        // predicate for every character written, which made writing an .scc quadratic in the
+        // table size. These reverse maps answer the same question in one probe; "first entry
+        // wins" matches FirstOrDefault's behaviour for the duplicate values in the table.
+        private static readonly Dictionary<string, string> CodeFromLetterLookup = BuildCodeFromLetterLookup();
+        private static readonly Dictionary<char, string> CodeFromCharLookup = BuildCodeFromCharLookup();
+
+        private static Dictionary<string, string> BuildCodeFromLetterLookup()
+        {
+            var lookup = new Dictionary<string, string>(LetterDictionary.Count, StringComparer.Ordinal);
+            foreach (var p in LetterDictionary)
+            {
+                if (p.Value != null && !lookup.ContainsKey(p.Value))
+                {
+                    lookup.Add(p.Value, p.Key);
+                }
+            }
+
+            return lookup;
+        }
+
+        private static Dictionary<char, string> BuildCodeFromCharLookup()
+        {
+            var lookup = new Dictionary<char, string>(LetterDictionary.Count);
+            foreach (var p in LetterDictionary)
+            {
+                if (p.Value != null && p.Value.Length == 1 && !lookup.ContainsKey(p.Value[0]))
+                {
+                    lookup.Add(p.Value[0], p.Key);
+                }
+            }
+
+            return lookup;
+        }
+
         // CEA-608 extended characters (the 0x12/0x13 sets) erase the preceding standard
         // character, so compliant encoders transmit a standard fallback letter first
         // ("o" + extended "ö"). Generate a "fallback + extended" combined entry for every
@@ -731,16 +766,18 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
                 while (i < text.Length)
                 {
-                    string s = text.Substring(i, 1);
-                    string codeFromLetter = GetCodeFromLetter(s);
+                    string codeFromLetter = GetCodeFromLetter(text[i]);
                     string newCode;
-                    if (text.Substring(i).StartsWith("<i>", StringComparison.Ordinal))
+                    // Tail tests over a span: Substring(i) copied the rest of the line twice per
+                    // character, which made this loop quadratic in line length.
+                    var tail = text.AsSpan(i);
+                    if (tail.StartsWith("<i>".AsSpan(), StringComparison.Ordinal))
                     {
                         newCode = "91ae";
                         i += 2;
                         italic++;
                     }
-                    else if (text.Substring(i).StartsWith("</i>", StringComparison.Ordinal) && italic > 0)
+                    else if (tail.StartsWith("</i>".AsSpan(), StringComparison.Ordinal) && italic > 0)
                     {
                         newCode = "9120";
                         i += 3;
@@ -857,13 +894,16 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         private static string GetCodeFromLetter(string letter)
         {
-            var code = LetterDictionary.FirstOrDefault(x => x.Value == letter);
-            if (code.Equals(new KeyValuePair<string, string>()))
-            {
-                return null;
-            }
+            return letter != null && CodeFromLetterLookup.TryGetValue(letter, out var code) ? code : null;
+        }
 
-            return code.Key;
+        /// <summary>
+        /// <see cref="GetCodeFromLetter(string)"/> for a single character, so the writer does not
+        /// have to allocate a one-character string per character of every line.
+        /// </summary>
+        private static string GetCodeFromLetter(char letter)
+        {
+            return CodeFromCharLookup.TryGetValue(letter, out var code) ? code : null;
         }
 
         private static string GetLetterFromCode(string hexCode)

--- a/src/ui/Logic/NetflixQualityCheck/NetflixCheckGlyph.cs
+++ b/src/ui/Logic/NetflixQualityCheck/NetflixCheckGlyph.cs
@@ -13,6 +13,11 @@ public class NetflixCheckGlyph : INetflixQualityChecker
 {
     private static HashSet<int>? _netflixGlyphs = null;
 
+    // Every character of every line is probed against the allowed set, so the probe is the whole
+    // cost of this check. A BMP bitmap answers it with one array load instead of hashing an int;
+    // astral code points (rare, and outside the table) still go to the hash set.
+    private static bool[]? _netflixGlyphsBmp = null;
+
     public string Name { get; set; }
 
     public NetflixCheckGlyph(string name)
@@ -50,7 +55,18 @@ public class NetflixCheckGlyph : INetflixQualityChecker
             list.Add(13);
         }
 
-        _netflixGlyphs = new HashSet<int>(list);
+        var set = new HashSet<int>(list);
+        var bmp = new bool[0x10000];
+        foreach (var codePoint in set)
+        {
+            if ((uint)codePoint < (uint)bmp.Length)
+            {
+                bmp[codePoint] = true;
+            }
+        }
+
+        _netflixGlyphsBmp = bmp;
+        _netflixGlyphs = set;
         return _netflixGlyphs;
     }
 
@@ -66,17 +82,35 @@ public class NetflixCheckGlyph : INetflixQualityChecker
     {
         // Load allowed glyphs
         var allowedGlyphsSet = LoadNetflixGlyphs();
+        var allowedGlyphsBmp = _netflixGlyphsBmp!;
 
         foreach (var paragraph in subtitle.Paragraphs)
         {
-            for (int pos = 0, actualPos = 0; pos < paragraph.Text.Length; pos += char.IsSurrogatePair(paragraph.Text, pos) ? 2 : 1, actualPos++)
+            var text = paragraph.Text;
+            for (int pos = 0, actualPos = 0; pos < text.Length; actualPos++)
             {
-                int curCodepoint = char.ConvertToUtf32(paragraph.Text, pos);
+                var c = text[pos];
+                var reportPos = pos; // pos advances below; the report wants the character's own index
+                int curCodepoint;
+                if (char.IsSurrogate(c))
+                {
+                    // Throws on a lone surrogate, exactly as ConvertToUtf32 did before.
+                    curCodepoint = char.ConvertToUtf32(text, pos);
+                    pos += 2;
+                }
+                else
+                {
+                    curCodepoint = c;
+                    pos++;
+                }
 
-                if (!allowedGlyphsSet.Contains(curCodepoint))
+                var allowed = (uint)curCodepoint < (uint)allowedGlyphsBmp.Length
+                    ? allowedGlyphsBmp[curCodepoint]
+                    : allowedGlyphsSet.Contains(curCodepoint);
+                if (!allowed)
                 {
                     var timeCode = paragraph.StartTime.ToHHMMSSFF();
-                    var context = NetflixQualityController.StringContext(paragraph.Text, pos, 6);
+                    var context = NetflixQualityController.StringContext(text, reportPos, 6);
                     var comment = string.Format(Se.Language.Tools.NetflixCheckAndFix.GlyphCheckReport, $"U+{curCodepoint:X}", actualPos);
 
                     controller.AddRecord(paragraph, timeCode, context, comment, false);

--- a/src/ui/Logic/NetflixQualityCheck/NetflixCheckMaxCps.cs
+++ b/src/ui/Logic/NetflixQualityCheck/NetflixCheckMaxCps.cs
@@ -20,21 +20,21 @@ public class NetflixCheckMaxCps : INetflixQualityChecker
 
     public void Check(Subtitle subtitle, NetflixQualityController controller)
     {
-        ICalcLength calc = CalcFactory.MakeCalculator(nameof(CalcAll));
+        var isJapanese = controller.Language == "ja";
+        var calc = CalcFactory.MakeCalculator(controller.Language == "ko" ? nameof(CalcCjk) : nameof(CalcAll));
         var charactersPerSecond = controller.CharactersPerSecond;
         var comment = string.Format(Se.Language.Tools.NetflixCheckAndFix.MaximumXCharactersPerSecond, charactersPerSecond);
         foreach (var p in subtitle.Paragraphs)
         {
-            var jp = new Paragraph(p);
-            if (controller.Language == "ja")
+            // Only Japanese needs a scratch copy to strip tags into; every other language read
+            // the clone unchanged, so the deep copy (paragraph + two time codes) was pure waste
+            // on every line of the file.
+            var jp = p;
+            if (isJapanese)
             {
+                jp = new Paragraph(p);
                 jp.Text = HtmlUtil.RemoveHtmlTags(jp.Text, true);
                 jp.Text = NetflixImsc11Japanese.RemoveTags(jp.Text);
-            }
-
-            if (controller.Language == "ko")
-            {
-                calc = CalcFactory.MakeCalculator(nameof(CalcCjk));
             }
 
             var charactersPerSeconds = jp.GetCharactersPerSecond(calc);

--- a/src/ui/Logic/NetflixQualityCheck/NetflixCheckNumbersOneToTenSpellOut.cs
+++ b/src/ui/Logic/NetflixQualityCheck/NetflixCheckNumbersOneToTenSpellOut.cs
@@ -13,6 +13,10 @@ public class NetflixCheckNumbersOneToTenSpellOut : INetflixQualityChecker
     private static readonly Regex NumberOneToNine = new Regex(@"\b\d\b", RegexOptions.Compiled);
     private static readonly Regex NumberTen = new Regex(@"\b10\b", RegexOptions.Compiled);
 
+    // Was constructed inside the per-match loop below, so every "3," in the file paid for a
+    // fresh Regex parse. Compiled once here instead.
+    private static readonly Regex CommaDigit = new Regex(@",\d", RegexOptions.Compiled);
+
     public string Name { get; set; }
 
     public NetflixCheckNumbersOneToTenSpellOut(string name)
@@ -33,7 +37,7 @@ public class NetflixCheckNumbersOneToTenSpellOut : INetflixQualityChecker
             var m = NumberOneToNine.Match(newText);
             while (m.Success)
             {
-                bool ok = newText.Length <= m.Index + 1 || newText.Length > m.Index + 1 && !":.".Contains(newText[m.Index + 1].ToString());
+                bool ok = newText.Length <= m.Index + 1 || newText.Length > m.Index + 1 && !IsColonOrPeriod(newText[m.Index + 1]);
                 if (!ok && newText.Length > m.Index + 1)
                 {
                     var rest = newText.Substring(m.Index + m.Length);
@@ -46,17 +50,15 @@ public class NetflixCheckNumbersOneToTenSpellOut : INetflixQualityChecker
                     }
                 }
 
-                if (ok && m.Index + m.Length < newText.Length && newText.Substring(m.Index + m.Length).StartsWith(","))
+                if (ok && m.Index + m.Length < newText.Length && newText[m.Index + m.Length] == ',')
                 {
-                    var rest = newText.Substring(m.Index + 1);
-                    var regex = new Regex(@",\d");
-                    if (regex.IsMatch(rest))
+                    if (CommaDigit.IsMatch(newText, m.Index + 1))
                     {
                         ok = false;
                     }
                 }
 
-                if (ok && m.Index > 0 && ":.".Contains(newText[m.Index - 1].ToString()))
+                if (ok && m.Index > 0 && IsColonOrPeriod(newText[m.Index - 1]))
                 {
                     ok = false;
                 }
@@ -73,7 +75,7 @@ public class NetflixCheckNumbersOneToTenSpellOut : INetflixQualityChecker
             while (m.Success)
             {
                 bool ok = newText.Length <= m.Index + 2 || newText.Length > m.Index + 2 && newText[m.Index + 2] != ':';
-                if (ok && m.Index > 0 && ":.".Contains(newText[m.Index - 1].ToString()))
+                if (ok && m.Index > 0 && IsColonOrPeriod(newText[m.Index - 1]))
                 {
                     ok = false;
                 }
@@ -95,4 +97,9 @@ public class NetflixCheckNumbersOneToTenSpellOut : INetflixQualityChecker
         }
     }
 
+    /// <summary>
+    /// Replaces <c>":.".Contains(c.ToString())</c>: the old shape boxed every neighbour
+    /// character into a one-char string before searching a two-character literal.
+    /// </summary>
+    private static bool IsColonOrPeriod(char c) => c == ':' || c == '.';
 }

--- a/src/ui/Logic/NetflixQualityCheck/NetflixCheckTextForHiUseBrackets.cs
+++ b/src/ui/Logic/NetflixQualityCheck/NetflixCheckTextForHiUseBrackets.cs
@@ -26,7 +26,6 @@ public class NetflixCheckTextForHiUseBrackets : INetflixQualityChecker
         foreach (Paragraph p in subtitle.Paragraphs)
         {
             string newText = p.Text;
-            var arr = p.Text.SplitToLines();
             if (newText.StartsWith('(') && newText.EndsWith(')'))
             {
                 newText = "[" + newText.Substring(1, newText.Length - 2) + "]";
@@ -35,7 +34,10 @@ public class NetflixCheckTextForHiUseBrackets : INetflixQualityChecker
             {
                 newText = "[" + newText.Substring(1, newText.Length - 2) + "]";
             }
-            else if (arr.Count == 2 && arr[0].StartsWith('-') && arr[1].StartsWith('-'))
+            // Only the two-line dash branch needs the split, and it can only fire when the text
+            // starts with a dash - so do not split every line in the file up front.
+            else if (newText.StartsWith('-') && p.Text.SplitToLines() is { Count: 2 } arr &&
+                     arr[0].StartsWith('-') && arr[1].StartsWith('-'))
             {
                 if ((arr[0].StartsWith("-(", StringComparison.Ordinal) && arr[0].EndsWith(')')) || (arr[0].StartsWith("-{", StringComparison.Ordinal) && arr[0].EndsWith('}') && !IsAssaOverride(arr[0].Substring(1))))
                 {

--- a/src/ui/Logic/NetflixQualityCheck/NetflixCheckWhiteSpace.cs
+++ b/src/ui/Logic/NetflixQualityCheck/NetflixCheckWhiteSpace.cs
@@ -31,15 +31,20 @@ public class NetflixCheckWhiteSpace : INetflixQualityChecker
     {
         foreach (Paragraph p in subtitle.Paragraphs)
         {
-            // Line endings
-            if (LineEndingSpaceBefore.IsMatch(p.Text))
+            // Line endings. Both patterns are anchored, so they can only match when the very
+            // first / very last character is white space - and on a normal subtitle line neither
+            // is. Testing that one character first keeps the regex engine out of the loop
+            // without changing what either pattern accepts (note "$" also matches before a
+            // trailing newline, which is why the guard tests the character, not the pattern).
+            var text = p.Text;
+            if (text.Length > 1 && char.IsWhiteSpace(text[0]) && LineEndingSpaceBefore.IsMatch(text))
             {
                 AddWhiteSpaceWarning(p, controller, Se.Language.Tools.NetflixCheckAndFix.WhiteSpaceLineEnding, 1);
             }
 
-            if (LineEndingSpaceAfter.IsMatch(p.Text))
+            if (text.Length > 1 && char.IsWhiteSpace(text[text.Length - 1]) && LineEndingSpaceAfter.IsMatch(text))
             {
-                AddWhiteSpaceWarning(p, controller, Se.Language.Tools.NetflixCheckAndFix.WhiteSpaceLineEnding, p.Text.Length);
+                AddWhiteSpaceWarning(p, controller, Se.Language.Tools.NetflixCheckAndFix.WhiteSpaceLineEnding, text.Length);
             }
 
             // Spaces before punctuation

--- a/tests/benchmarks/PerfHuntRound14Benchmarks.cs
+++ b/tests/benchmarks/PerfHuntRound14Benchmarks.cs
@@ -1,0 +1,1537 @@
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Common.TextLengthCalculator;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System.Buffers;
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// Round 14 performance hunt: a random sweep over the Netflix quality checkers, the
+/// hearing-impaired / fix-common-errors text passes and a few subtitle format writers.
+///
+/// Every candidate is measured as a *whole-file pass* over a real movie subtitle so the input
+/// distribution (tag density, line lengths, dialog dashes, digits) is the one users actually hit.
+/// Point <c>SE_BENCH_SUBTITLE</c> at an .srt to use it; otherwise a synthetic corpus is built.
+///
+/// Both the current shape and the candidate shape live in this file, each with its own direct
+/// call site (never behind a shared delegate — that goes megamorphic and lies), and
+/// <see cref="Setup"/> asserts the two produce identical output before any timing runs.
+/// </summary>
+[MemoryDiagnoser]
+public class PerfHuntRound14Benchmarks
+{
+    private string[] _texts = Array.Empty<string>();
+    private Subtitle _subtitle = new();
+
+    static PerfHuntRound14Benchmarks()
+    {
+        // Program.cs does this at start-up; the benchmark host does not.
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        Cp1252 = Encoding.GetEncoding(1252);
+    }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _subtitle = LoadCorpus();
+        _texts = _subtitle.Paragraphs.Select(p => p.Text).ToArray();
+        AssertEquivalence();
+    }
+
+    private static Subtitle LoadCorpus()
+    {
+        var path = Environment.GetEnvironmentVariable("SE_BENCH_SUBTITLE");
+        var subtitle = new Subtitle();
+        if (!string.IsNullOrEmpty(path) && File.Exists(path))
+        {
+            var lines = File.ReadAllLines(path).ToList();
+            new SubRip().LoadSubtitle(subtitle, lines, path);
+            if (subtitle.Paragraphs.Count > 0)
+            {
+                return subtitle;
+            }
+        }
+
+        // Fallback corpus with the same shape mix as a real movie subtitle.
+        var samples = new[]
+        {
+            "It was the best of times, it was the worst of times.",
+            "<i>Are you coming with us?</i>",
+            "- No.\r\n- Then stay here and wait.",
+            "MAN: There were 3 of them,\r\nand only 1 got away.",
+            "[DOOR CREAKING]",
+            "(SIGHS) i think i'm going to be sick.",
+            "Chapter 10: the long way home...",
+            "You'll find it at 10:30, i.e. after lunch.",
+            "♪ Somewhere over there ♪",
+            "{\\an8}Somewhere in Denmark",
+        };
+        var ms = 1000.0;
+        for (var i = 0; i < 1800; i++)
+        {
+            subtitle.Paragraphs.Add(new Paragraph(samples[i % samples.Length], ms, ms + 2000));
+            ms += 2200;
+        }
+
+        return subtitle;
+    }
+
+    private void AssertEquivalence()
+    {
+        foreach (var t in _texts)
+        {
+            Check("C01", C01_Current(t), C01_Candidate(t));
+            Check("C02", C02_Current(t), C02_Candidate(t));
+            Check("C03", C03_Current(t), C03_Candidate(t));
+            Check("C04", C04_Current(t), C04_Candidate(t));
+            Check("C07", C07_Current(t), C07_Candidate(t));
+            Check("C10", C10_Current(t), C10_Candidate(t));
+            Check("C12", C12_Current(t), C12_Candidate(t));
+            Check("C13", C13_Current(t), C13_Candidate(t));
+            Check("C14", C14_Current(t), C14_Candidate(t));
+            Check("C15", C15_Current(t), C15_Candidate(t));
+            Check("C16", C16_Current(t), C16_Candidate(t));
+            Check("C17", C17_Current(t), C17_Candidate(t));
+            Check("C18", C18_Current(t), C18_Candidate(t));
+            Check("C19", C19_Current(t), C19_Candidate(t));
+            Check("C22", C22_Current(t), C22_Candidate(t));
+            Check("C23", C23_Current(t), C23_Candidate(t));
+            Check("C24", C24_Current(t), C24_Candidate(t));
+            Check("C25", C25_Current(t), C25_Candidate(t));
+        }
+
+        Check("C05", C05_Current().ToString(CultureInfo.InvariantCulture), C05_Candidate().ToString(CultureInfo.InvariantCulture));
+        Check("C08", C08_Current().ToString(CultureInfo.InvariantCulture), C08_Candidate().ToString(CultureInfo.InvariantCulture));
+        Check("C09", C09_Current().ToString(CultureInfo.InvariantCulture), C09_Candidate().ToString(CultureInfo.InvariantCulture));
+        Check("C11", C11_Current().ToString(CultureInfo.InvariantCulture), C11_Candidate().ToString(CultureInfo.InvariantCulture));
+        Check("C20", C20_Current(), C20_Candidate());
+        Check("C21", C21_Current(), C21_Candidate());
+        Check("C06", C06_Current().ToString(CultureInfo.InvariantCulture), C06_Candidate().ToString(CultureInfo.InvariantCulture));
+    }
+
+    private static void Check(string name, string current, string candidate)
+    {
+        if (!string.Equals(current, candidate, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"{name}: candidate diverges.\ncurrent  : {current}\ncandidate: {candidate}");
+        }
+    }
+
+    private static string Fold(string[] texts, Func<string, string> f)
+    {
+        var sb = new StringBuilder();
+        foreach (var t in texts)
+        {
+            sb.Append(f(t));
+        }
+
+        return sb.ToString();
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // C01 - NetflixCheckNumbersOneToTenSpellOut: `new Regex(@",\d")` constructed inside the
+    //       per-match while loop.
+    // ---------------------------------------------------------------------------------------
+    private static readonly Regex NumberOneToNine = new Regex(@"\b\d\b", RegexOptions.Compiled);
+    private static readonly Regex CommaDigitCached = new Regex(@",\d", RegexOptions.Compiled);
+
+    private static string C01_Current(string text)
+    {
+        var hits = 0;
+        var m = NumberOneToNine.Match(text);
+        while (m.Success)
+        {
+            if (m.Index + m.Length < text.Length && text.Substring(m.Index + m.Length).StartsWith(","))
+            {
+                var rest = text.Substring(m.Index + 1);
+                var regex = new Regex(@",\d");
+                if (regex.IsMatch(rest))
+                {
+                    hits++;
+                }
+            }
+
+            m = NumberOneToNine.Match(text, m.Index + 1);
+        }
+
+        return hits.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static string C01_Candidate(string text)
+    {
+        var hits = 0;
+        var m = NumberOneToNine.Match(text);
+        while (m.Success)
+        {
+            if (m.Index + m.Length < text.Length && text[m.Index + m.Length] == ',')
+            {
+                if (CommaDigitCached.IsMatch(text, m.Index + 1))
+                {
+                    hits++;
+                }
+            }
+
+            m = NumberOneToNine.Match(text, m.Index + 1);
+        }
+
+        return hits.ToString(CultureInfo.InvariantCulture);
+    }
+
+    [Benchmark] public string C01_RegexInLoop_Current() => Fold(_texts, C01_Current);
+    [Benchmark] public string C01_RegexInLoop_Candidate() => Fold(_texts, C01_Candidate);
+
+    // ---------------------------------------------------------------------------------------
+    // C02 - NetflixCheckNumbersOneToTenSpellOut: `":.".Contains(text[i].ToString())` (3 sites)
+    // ---------------------------------------------------------------------------------------
+    private static string C02_Current(string text)
+    {
+        var n = 0;
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (":.".Contains(text[i].ToString()))
+            {
+                n++;
+            }
+        }
+
+        return n.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static string C02_Candidate(string text)
+    {
+        var n = 0;
+        for (var i = 0; i < text.Length; i++)
+        {
+            var c = text[i];
+            if (c == ':' || c == '.')
+            {
+                n++;
+            }
+        }
+
+        return n.ToString(CultureInfo.InvariantCulture);
+    }
+
+    [Benchmark] public string C02_CharToStringContains_Current() => Fold(_texts, C02_Current);
+    [Benchmark] public string C02_CharToStringContains_Candidate() => Fold(_texts, C02_Candidate);
+
+    // ---------------------------------------------------------------------------------------
+    // C03 - `text.Substring(i).StartsWith(",")` - allocates the whole tail to test one char.
+    // ---------------------------------------------------------------------------------------
+    private static string C03_Current(string text)
+    {
+        var n = 0;
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (text.Substring(i).StartsWith(","))
+            {
+                n++;
+            }
+        }
+
+        return n.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static string C03_Candidate(string text)
+    {
+        var n = 0;
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (text[i] == ',')
+            {
+                n++;
+            }
+        }
+
+        return n.ToString(CultureInfo.InvariantCulture);
+    }
+
+    [Benchmark] public string C03_SubstringStartsWith_Current() => Fold(_texts, C03_Current);
+    [Benchmark] public string C03_SubstringStartsWith_Candidate() => Fold(_texts, C03_Candidate);
+
+    // ---------------------------------------------------------------------------------------
+    // C04 - the "rest" tail Substring compared against 12 literals.
+    // ---------------------------------------------------------------------------------------
+    private static readonly string[] RestLiterals =
+    {
+        ".", "?", "!",
+        ".</i>", "?</i>", "!</i>",
+        "." + "\r\n", "?" + "\r\n", "!" + "\r\n",
+        ".</i>" + "\r\n", "?</i>" + "\r\n", "!</i>" + "\r\n",
+    };
+
+    private static string C04_Current(string text)
+    {
+        var n = 0;
+        var m = NumberOneToNine.Match(text);
+        while (m.Success)
+        {
+            var rest = text.Substring(m.Index + m.Length);
+            if (rest == "." || rest == "?" || rest == "!" ||
+                rest == ".</i>" || rest == "?</i>" || rest == "!</i>" ||
+                rest == "." + "\r\n" || rest == "?" + "\r\n" || rest == "!" + "\r\n" ||
+                rest == ".</i>" + "\r\n" || rest == "?</i>" + "\r\n" || rest == "!</i>" + "\r\n")
+            {
+                n++;
+            }
+
+            m = NumberOneToNine.Match(text, m.Index + 1);
+        }
+
+        return n.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static string C04_Candidate(string text)
+    {
+        var n = 0;
+        var m = NumberOneToNine.Match(text);
+        while (m.Success)
+        {
+            var rest = text.AsSpan(m.Index + m.Length);
+            foreach (var lit in RestLiterals)
+            {
+                if (rest.SequenceEqual(lit))
+                {
+                    n++;
+                    break;
+                }
+            }
+
+            m = NumberOneToNine.Match(text, m.Index + 1);
+        }
+
+        return n.ToString(CultureInfo.InvariantCulture);
+    }
+
+    [Benchmark] public string C04_TailCompare_Current() => Fold(_texts, C04_Current);
+    [Benchmark] public string C04_TailCompare_Candidate() => Fold(_texts, C04_Candidate);
+
+    // ---------------------------------------------------------------------------------------
+    // C05 - NetflixCheckMaxCps: `new Paragraph(p)` deep clone for every paragraph, needed only
+    //       for the Japanese tag-stripping branch.
+    // ---------------------------------------------------------------------------------------
+    private int C05_Current()
+    {
+        var calc = CalcFactory.MakeCalculator(nameof(CalcAll));
+        var n = 0;
+        foreach (var p in _subtitle.Paragraphs)
+        {
+            var jp = new Paragraph(p);
+            if (jp.GetCharactersPerSecond(calc) > 20)
+            {
+                n++;
+            }
+        }
+
+        return n;
+    }
+
+    private int C05_Candidate()
+    {
+        var calc = CalcFactory.MakeCalculator(nameof(CalcAll));
+        var n = 0;
+        foreach (var p in _subtitle.Paragraphs)
+        {
+            // language != "ja": no tag stripping needed, so measure the original paragraph.
+            if (p.GetCharactersPerSecond(calc) > 20)
+            {
+                n++;
+            }
+        }
+
+        return n;
+    }
+
+    [Benchmark] public int C05_MaxCpsClone_Current() => C05_Current();
+    [Benchmark] public int C05_MaxCpsClone_Candidate() => C05_Candidate();
+
+    // ---------------------------------------------------------------------------------------
+    // C06 - NetflixCheckMaxCps: CalcFactory.MakeCalculator() resolved inside the paragraph loop.
+    // ---------------------------------------------------------------------------------------
+    private int C06_Current()
+    {
+        var n = 0;
+        foreach (var p in _subtitle.Paragraphs)
+        {
+            var calc = CalcFactory.MakeCalculator(nameof(CalcCjk));
+            if (p.GetCharactersPerSecond(calc) > 20)
+            {
+                n++;
+            }
+        }
+
+        return n;
+    }
+
+    private int C06_Candidate()
+    {
+        var calc = CalcFactory.MakeCalculator(nameof(CalcCjk));
+        var n = 0;
+        foreach (var p in _subtitle.Paragraphs)
+        {
+            if (p.GetCharactersPerSecond(calc) > 20)
+            {
+                n++;
+            }
+        }
+
+        return n;
+    }
+
+    [Benchmark] public int C06_CalcFactoryInLoop_Current() => C06_Current();
+    [Benchmark] public int C06_CalcFactoryInLoop_Candidate() => C06_Candidate();
+
+    // ---------------------------------------------------------------------------------------
+    // C07 - NetflixCheckTextForHiUseBrackets: SplitToLines() for every paragraph, used only in
+    //       the rare two-line-dash branch.
+    // ---------------------------------------------------------------------------------------
+    private static string C07_Current(string newText)
+    {
+        var arr = newText.SplitToLines();
+        if (newText.StartsWith('(') && newText.EndsWith(')'))
+        {
+            return "[" + newText.Substring(1, newText.Length - 2) + "]";
+        }
+
+        if (arr.Count == 2 && arr[0].StartsWith('-') && arr[1].StartsWith('-'))
+        {
+            return arr[0] + "\r\n" + arr[1];
+        }
+
+        return newText;
+    }
+
+    private static string C07_Candidate(string newText)
+    {
+        if (newText.StartsWith('(') && newText.EndsWith(')'))
+        {
+            return "[" + newText.Substring(1, newText.Length - 2) + "]";
+        }
+
+        if (newText.StartsWith('-'))
+        {
+            var arr = newText.SplitToLines();
+            if (arr.Count == 2 && arr[0].StartsWith('-') && arr[1].StartsWith('-'))
+            {
+                return arr[0] + "\r\n" + arr[1];
+            }
+        }
+
+        return newText;
+    }
+
+    [Benchmark] public string C07_LazySplitToLines_Current() => Fold(_texts, C07_Current);
+    [Benchmark] public string C07_LazySplitToLines_Candidate() => Fold(_texts, C07_Candidate);
+
+    // ---------------------------------------------------------------------------------------
+    // C08 - NetflixCheckMaxLineLength: `controller.Language` / `controller.SingleLineMaxLength`
+    //       are switch-per-access properties evaluated inside the per-line loop.
+    // ---------------------------------------------------------------------------------------
+    private sealed class FakeController
+    {
+        public string Language { get; set; } = "en";
+
+        public int SingleLineMaxLength
+        {
+            get
+            {
+                switch (Language)
+                {
+                    case "ja": return 23;
+                    case "th": return 35;
+                    case "ko":
+                    case "zh": return 16;
+                    default: return 42;
+                }
+            }
+        }
+    }
+
+    private readonly FakeController _controller = new();
+
+    private int C08_Current()
+    {
+        var n = 0;
+        foreach (var t in _texts)
+        {
+            foreach (var line in t.SplitToLines())
+            {
+                if (_controller.Language == "ja")
+                {
+                    n++;
+                }
+                else if (_controller.Language == "ko" && line.CountCharacters(nameof(CalcCjk), false) > _controller.SingleLineMaxLength)
+                {
+                    n++;
+                }
+                else if (line.CountCharacters(false) > _controller.SingleLineMaxLength)
+                {
+                    n++;
+                }
+            }
+        }
+
+        return n;
+    }
+
+    private int C08_Candidate()
+    {
+        var n = 0;
+        var language = _controller.Language;
+        var isJa = language == "ja";
+        var isKo = language == "ko";
+        var maxLen = _controller.SingleLineMaxLength;
+        foreach (var t in _texts)
+        {
+            foreach (var line in t.SplitToLines())
+            {
+                if (isJa)
+                {
+                    n++;
+                }
+                else if (isKo && line.CountCharacters(nameof(CalcCjk), false) > maxLen)
+                {
+                    n++;
+                }
+                else if (line.CountCharacters(false) > maxLen)
+                {
+                    n++;
+                }
+            }
+        }
+
+        return n;
+    }
+
+    [Benchmark] public int C08_HoistControllerProps_Current() => C08_Current();
+    [Benchmark] public int C08_HoistControllerProps_Candidate() => C08_Candidate();
+
+    // ---------------------------------------------------------------------------------------
+    // C09 - NetflixCheckGlyph: HashSet<int> probe per code point vs a BMP bitmap.
+    // ---------------------------------------------------------------------------------------
+    private static readonly HashSet<int> GlyphSet = BuildGlyphSet();
+    private static readonly bool[] GlyphBmp = BuildGlyphBmp();
+
+    private static HashSet<int> BuildGlyphSet()
+    {
+        var set = new HashSet<int> { 10, 13 };
+        for (var i = 0x20; i <= 0x7E; i++)
+        {
+            set.Add(i);
+        }
+
+        foreach (var cp in new[] { 0x2026, 0x266A, 0x266B, 0xA1, 0xBF, 0xE9, 0xE8, 0xF6, 0xFC, 0x2019, 0x201C, 0x201D })
+        {
+            set.Add(cp);
+        }
+
+        return set;
+    }
+
+    private static bool[] BuildGlyphBmp()
+    {
+        var table = new bool[0x10000];
+        foreach (var cp in GlyphSet)
+        {
+            if (cp < table.Length)
+            {
+                table[cp] = true;
+            }
+        }
+
+        return table;
+    }
+
+    private int C09_Current()
+    {
+        var bad = 0;
+        foreach (var text in _texts)
+        {
+            for (int pos = 0; pos < text.Length; pos += char.IsSurrogatePair(text, pos) ? 2 : 1)
+            {
+                var cp = char.ConvertToUtf32(text, pos);
+                if (!GlyphSet.Contains(cp))
+                {
+                    bad++;
+                }
+            }
+        }
+
+        return bad;
+    }
+
+    private int C09_Candidate()
+    {
+        var bad = 0;
+        foreach (var text in _texts)
+        {
+            for (var pos = 0; pos < text.Length; pos++)
+            {
+                var c = text[pos];
+                if (!char.IsSurrogate(c))
+                {
+                    if (!GlyphBmp[c])
+                    {
+                        bad++;
+                    }
+
+                    continue;
+                }
+
+                var cp = char.ConvertToUtf32(text, pos);
+                if (!GlyphSet.Contains(cp))
+                {
+                    bad++;
+                }
+
+                pos++; // consume the low surrogate
+            }
+        }
+
+        return bad;
+    }
+
+    [Benchmark] public int C09_GlyphLookup_Current() => C09_Current();
+    [Benchmark] public int C09_GlyphLookup_Candidate() => C09_Candidate();
+
+    // ---------------------------------------------------------------------------------------
+    // C10 - NetflixCheckWhiteSpace: two anchored compiled regexes vs direct char tests.
+    // ---------------------------------------------------------------------------------------
+    private static readonly Regex LineEndingSpaceBefore = new Regex(@"^( |\n|\r\n)[^\s]", RegexOptions.Compiled);
+    private static readonly Regex LineEndingSpaceAfter = new Regex(@"[^\s]( |\n|\r\n)$", RegexOptions.Compiled);
+
+    private static string C10_Current(string text)
+    {
+        var n = 0;
+        if (LineEndingSpaceBefore.IsMatch(text))
+        {
+            n++;
+        }
+
+        if (LineEndingSpaceAfter.IsMatch(text))
+        {
+            n += 2;
+        }
+
+        return n.ToString(CultureInfo.InvariantCulture);
+    }
+
+    // What actually shipped. A hand-rolled equivalent of these two patterns is a trap: "$" in
+    // .NET also matches *before* a trailing newline, so "a \n" matches LineEndingSpaceAfter.
+    // The guard below is provably implied by both patterns instead - each can only match when
+    // the first / last character is white space - so it changes nothing but keeps the regex
+    // engine out of the loop for ordinary lines.
+    private static string C10_Candidate(string text)
+    {
+        var n = 0;
+        if (text.Length > 1 && char.IsWhiteSpace(text[0]) && LineEndingSpaceBefore.IsMatch(text))
+        {
+            n++;
+        }
+
+        if (text.Length > 1 && char.IsWhiteSpace(text[text.Length - 1]) && LineEndingSpaceAfter.IsMatch(text))
+        {
+            n += 2;
+        }
+
+        return n.ToString(CultureInfo.InvariantCulture);
+    }
+
+    [Benchmark] public string C10_AnchoredRegex_Current() => Fold(_texts, C10_Current);
+    [Benchmark] public string C10_AnchoredRegex_Candidate() => Fold(_texts, C10_Candidate);
+
+    // ---------------------------------------------------------------------------------------
+    // C11 - RemoveTextForHI.ShouldRemoveNarrator: three arrays allocated on every call.
+    // ---------------------------------------------------------------------------------------
+    private static readonly string[] NarratorSkipShort = { "http", ", " };
+
+    private static readonly string[] NarratorSkipEnglish =
+    {
+        "Previously on", "Improved by", " is ", " are ", " were ", " was ", " think ",
+        " guess ", " will ", " believe ", " say ", " said ", " do ", " want ", "That's ",
+    };
+
+    private static readonly char[] NarratorSkipChars = { '!', '?', '¿', '¡' };
+
+    private int C11_Current()
+    {
+        var n = 0;
+        foreach (var pre in _texts)
+        {
+            if (pre.Length > 30 || pre.IndexOfAny(new[] { "http", ", " }, StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                continue;
+            }
+
+            if (pre.Length > 15 && pre.IndexOfAny(new[]
+                {
+                    "Previously on", "Improved by", " is ", " are ", " were ", " was ", " think ",
+                    " guess ", " will ", " believe ", " say ", " said ", " do ", " want ", "That's ",
+                }, StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                continue;
+            }
+
+            if (pre.IndexOfAny(new[] { '!', '?', '¿', '¡' }) < 0)
+            {
+                n++;
+            }
+        }
+
+        return n;
+    }
+
+    private int C11_Candidate()
+    {
+        var n = 0;
+        foreach (var pre in _texts)
+        {
+            if (pre.Length > 30 || pre.IndexOfAny(NarratorSkipShort, StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                continue;
+            }
+
+            if (pre.Length > 15 && pre.IndexOfAny(NarratorSkipEnglish, StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                continue;
+            }
+
+            if (pre.IndexOfAny(NarratorSkipChars) < 0)
+            {
+                n++;
+            }
+        }
+
+        return n;
+    }
+
+    // Split of the same site: which half of the fix pays? The two string[] literals are pure
+    // allocation, but `IndexOfAny(new[] { '!', ... })` hands the JIT a known-length char[] that
+    // a static readonly field does not, so the char set is measured on its own.
+    private static readonly SearchValues<char> NarratorSkipSearch = SearchValues.Create("!?¿¡");
+
+    private int C11b_Current()
+    {
+        var n = 0;
+        foreach (var pre in _texts)
+        {
+            if (pre.IndexOfAny(new[] { '!', '?', '¿', '¡' }) < 0)
+            {
+                n++;
+            }
+        }
+
+        return n;
+    }
+
+    private int C11b_StaticArray()
+    {
+        var n = 0;
+        foreach (var pre in _texts)
+        {
+            if (pre.IndexOfAny(NarratorSkipChars) < 0)
+            {
+                n++;
+            }
+        }
+
+        return n;
+    }
+
+    private int C11b_SearchValues()
+    {
+        var n = 0;
+        foreach (var pre in _texts)
+        {
+            if (pre.AsSpan().IndexOfAny(NarratorSkipSearch) < 0)
+            {
+                n++;
+            }
+        }
+
+        return n;
+    }
+
+    private int C11c_Current()
+    {
+        var n = 0;
+        foreach (var pre in _texts)
+        {
+            if (pre.IndexOfAny(new[] { "http", ", " }, StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                continue;
+            }
+
+            if (pre.IndexOfAny(new[]
+                {
+                    "Previously on", "Improved by", " is ", " are ", " were ", " was ", " think ",
+                    " guess ", " will ", " believe ", " say ", " said ", " do ", " want ", "That's ",
+                }, StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                continue;
+            }
+
+            n++;
+        }
+
+        return n;
+    }
+
+    private int C11c_Static()
+    {
+        var n = 0;
+        foreach (var pre in _texts)
+        {
+            if (pre.IndexOfAny(NarratorSkipShort, StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                continue;
+            }
+
+            if (pre.IndexOfAny(NarratorSkipEnglish, StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                continue;
+            }
+
+            n++;
+        }
+
+        return n;
+    }
+
+    // .NET 9+ multi-substring search: one Aho-Corasick-style pass instead of 15 IndexOf sweeps.
+    // ShouldRemoveNarrator only asks "any of these present?", so leftmost-vs-array-order does
+    // not matter here.
+    private static readonly SearchValues<string> NarratorSkipShortSv =
+        SearchValues.Create(new[] { "http", ", " }, StringComparison.OrdinalIgnoreCase);
+
+    private static readonly SearchValues<string> NarratorSkipEnglishSv =
+        SearchValues.Create(NarratorSkipEnglish, StringComparison.OrdinalIgnoreCase);
+
+    private int C11c_SearchValues()
+    {
+        var n = 0;
+        foreach (var pre in _texts)
+        {
+            if (pre.AsSpan().IndexOfAny(NarratorSkipShortSv) >= 0)
+            {
+                continue;
+            }
+
+            if (pre.AsSpan().IndexOfAny(NarratorSkipEnglishSv) >= 0)
+            {
+                continue;
+            }
+
+            n++;
+        }
+
+        return n;
+    }
+
+    [Benchmark] public int C11c_StringSets_SearchValues() => C11c_SearchValues();
+
+    [Benchmark] public int C11_NarratorArrays_Current() => C11_Current();
+    [Benchmark] public int C11_NarratorArrays_Candidate() => C11_Candidate();
+    [Benchmark] public int C11b_CharSet_Current() => C11b_Current();
+    [Benchmark] public int C11b_CharSet_StaticArray() => C11b_StaticArray();
+    [Benchmark] public int C11b_CharSet_SearchValues() => C11b_SearchValues();
+    [Benchmark] public int C11c_StringSets_Current() => C11c_Current();
+    [Benchmark] public int C11c_StringSets_Static() => C11c_Static();
+
+    // ---------------------------------------------------------------------------------------
+    // C12 - RemoveTextForHI.RemovePartialBeforeColon: Substring(i).StartsWith("  ")
+    // ---------------------------------------------------------------------------------------
+    private static string C12_Current(string text)
+    {
+        var n = 0;
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (text.Substring(i).StartsWith("  "))
+            {
+                n++;
+            }
+        }
+
+        return n.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static string C12_Candidate(string text)
+    {
+        var n = 0;
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (i + 1 < text.Length && text[i] == ' ' && text[i + 1] == ' ')
+            {
+                n++;
+            }
+        }
+
+        return n.ToString(CultureInfo.InvariantCulture);
+    }
+
+    [Benchmark] public string C12_DoubleSpaceProbe_Current() => Fold(_texts, C12_Current);
+    [Benchmark] public string C12_DoubleSpaceProbe_Candidate() => Fold(_texts, C12_Candidate);
+
+    // ---------------------------------------------------------------------------------------
+    // C13 - RemoveTextForHI: line.Substring(idx + 1).StartsWith(Environment.NewLine)
+    // ---------------------------------------------------------------------------------------
+    private static string C13_Current(string text)
+    {
+        var n = 0;
+        var idx = text.IndexOf(':');
+        while (idx >= 0 && idx < text.Length - 1)
+        {
+            if (text.Substring(idx + 1).StartsWith(Environment.NewLine, StringComparison.Ordinal))
+            {
+                n++;
+            }
+
+            idx = text.IndexOf(':', idx + 1);
+        }
+
+        return n.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static string C13_Candidate(string text)
+    {
+        var n = 0;
+        var idx = text.IndexOf(':');
+        while (idx >= 0 && idx < text.Length - 1)
+        {
+            if (text.AsSpan(idx + 1).StartsWith(Environment.NewLine, StringComparison.Ordinal))
+            {
+                n++;
+            }
+
+            idx = text.IndexOf(':', idx + 1);
+        }
+
+        return n.ToString(CultureInfo.InvariantCulture);
+    }
+
+    [Benchmark] public string C13_TailStartsWithNewLine_Current() => Fold(_texts, C13_Current);
+    [Benchmark] public string C13_TailStartsWithNewLine_Candidate() => Fold(_texts, C13_Candidate);
+
+    // ---------------------------------------------------------------------------------------
+    // C14 - FixMissingSpaces.FixSpaceAfter: "0123456789".Contains(c.ToString())
+    // ---------------------------------------------------------------------------------------
+    private static string C14_Current(string text)
+    {
+        var n = 0;
+        for (var i = 0; i < text.Length; i++)
+        {
+            if ("0123456789".Contains(text[i].ToString()))
+            {
+                n++;
+            }
+        }
+
+        return n.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static string C14_Candidate(string text)
+    {
+        var n = 0;
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (char.IsAsciiDigit(text[i]))
+            {
+                n++;
+            }
+        }
+
+        return n.ToString(CultureInfo.InvariantCulture);
+    }
+
+    [Benchmark] public string C14_DigitProbe_Current() => Fold(_texts, C14_Current);
+    [Benchmark] public string C14_DigitProbe_Candidate() => Fold(_texts, C14_Candidate);
+
+    // ---------------------------------------------------------------------------------------
+    // C15 - FixMissingSpaces.FixSpaceAfter: separator-set membership via char.ToString()
+    // ---------------------------------------------------------------------------------------
+    private static readonly SearchValues<char> SpaceAfterSkipLookup =
+        SearchValues.Create(" \r\n\":;()[]<>.؟!،");
+
+    private static string C15_Current(string text)
+    {
+        var n = 0;
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (!" \r\n\":;()[]<>.؟!،".Contains(text[i].ToString()))
+            {
+                n++;
+            }
+        }
+
+        return n.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static string C15_Candidate(string text)
+    {
+        var n = 0;
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (!SpaceAfterSkipLookup.Contains(text[i]))
+            {
+                n++;
+            }
+        }
+
+        return n.ToString(CultureInfo.InvariantCulture);
+    }
+
+    [Benchmark] public string C15_SeparatorSet_Current() => Fold(_texts, C15_Current);
+    [Benchmark] public string C15_SeparatorSet_Candidate() => Fold(_texts, C15_Candidate);
+
+    // ---------------------------------------------------------------------------------------
+    // C16 - FixAloneLowercaseIToUppercaseLine: `">" + target + "</"` built on every call.
+    // ---------------------------------------------------------------------------------------
+    private static string C16_Current(string input)
+    {
+        const char target = 'i';
+        return input.Replace(">" + target + "</", ">I</")
+                    .Replace(">" + target + " ", ">I ")
+                    .Replace(">" + target + "​" + Environment.NewLine, ">I" + Environment.NewLine)
+                    .Replace(">" + target + "﻿" + Environment.NewLine, ">I" + Environment.NewLine);
+    }
+
+    private static readonly string ILtSlash = ">i</";
+    private static readonly string ISpace = ">i ";
+    private static readonly string IZwsp = ">i​" + "\r\n";
+    private static readonly string IZwnbsp = ">i﻿" + "\r\n";
+    private static readonly string INewLine = ">I" + "\r\n";
+
+    private static string C16_Candidate(string input)
+    {
+        return input.Replace(ILtSlash, ">I</")
+                    .Replace(ISpace, ">I ")
+                    .Replace(IZwsp, INewLine)
+                    .Replace(IZwnbsp, INewLine);
+    }
+
+    [Benchmark] public string C16_ReplaceLiterals_Current() => Fold(_texts, C16_Current);
+    [Benchmark] public string C16_ReplaceLiterals_Candidate() => Fold(_texts, C16_Candidate);
+
+    // ---------------------------------------------------------------------------------------
+    // C17 - FixAloneLowercaseIToUppercaseLine: s.Substring(i).StartsWith("i.e."/"i-")
+    // ---------------------------------------------------------------------------------------
+    private static readonly Regex LittleI = new Regex(@"\bi\b", RegexOptions.Compiled);
+
+    private static string C17_Current(string s)
+    {
+        var n = 0;
+        var match = LittleI.Match(s);
+        while (match.Success)
+        {
+            if (!s.Substring(match.Index).StartsWith("i.e.", StringComparison.Ordinal) &&
+                !s.Substring(match.Index).StartsWith("i-", StringComparison.Ordinal))
+            {
+                n++;
+            }
+
+            match = match.NextMatch();
+        }
+
+        return n.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static string C17_Candidate(string s)
+    {
+        var n = 0;
+        var match = LittleI.Match(s);
+        while (match.Success)
+        {
+            var tail = s.AsSpan(match.Index);
+            if (!tail.StartsWith("i.e.", StringComparison.Ordinal) &&
+                !tail.StartsWith("i-", StringComparison.Ordinal))
+            {
+                n++;
+            }
+
+            match = match.NextMatch();
+        }
+
+        return n.ToString(CultureInfo.InvariantCulture);
+    }
+
+    [Benchmark] public string C17_LittleITail_Current() => Fold(_texts, C17_Current);
+    [Benchmark] public string C17_LittleITail_Candidate() => Fold(_texts, C17_Candidate);
+
+    // ---------------------------------------------------------------------------------------
+    // C18 - FixAloneLowercaseIToUppercaseLine: wholePrev = s.Substring(0, i-1) then
+    //       .TrimEnd().EndsWith("...") - two allocations to look at three characters.
+    // ---------------------------------------------------------------------------------------
+    private static string C18_Current(string s)
+    {
+        var n = 0;
+        var match = LittleI.Match(s);
+        while (match.Success)
+        {
+            var wholePrev = string.Empty;
+            if (match.Index > 1)
+            {
+                wholePrev = s.Substring(0, match.Index - 1);
+            }
+
+            if (!wholePrev.TrimEnd().EndsWith("...", StringComparison.Ordinal))
+            {
+                n++;
+            }
+
+            match = match.NextMatch();
+        }
+
+        return n.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static string C18_Candidate(string s)
+    {
+        var n = 0;
+        var match = LittleI.Match(s);
+        while (match.Success)
+        {
+            var end = match.Index > 1 ? match.Index - 1 : 0;
+            var prev = s.AsSpan(0, end).TrimEnd();
+            if (!prev.EndsWith("...", StringComparison.Ordinal))
+            {
+                n++;
+            }
+
+            match = match.NextMatch();
+        }
+
+        return n.ToString(CultureInfo.InvariantCulture);
+    }
+
+    [Benchmark] public string C18_WholePrevTrim_Current() => Fold(_texts, C18_Current);
+    [Benchmark] public string C18_WholePrevTrim_Candidate() => Fold(_texts, C18_Candidate);
+
+    // ---------------------------------------------------------------------------------------
+    // C19 - FixAloneLowercaseIToUppercaseLine: (Environment.NewLine + @" <>!.?:;,").Contains(c)
+    //       concatenates a fresh string on every evaluation.
+    // ---------------------------------------------------------------------------------------
+    private static readonly string LittleIStopChars = Environment.NewLine + @" <>!.?:;,";
+
+    private static string C19_Current(string s)
+    {
+        var n = 0;
+        for (var i = 0; i < s.Length; i++)
+        {
+            if (!(Environment.NewLine + @" <>!.?:;,").Contains(s[i]))
+            {
+                n++;
+            }
+        }
+
+        return n.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static string C19_Candidate(string s)
+    {
+        var n = 0;
+        for (var i = 0; i < s.Length; i++)
+        {
+            if (!LittleIStopChars.Contains(s[i]))
+            {
+                n++;
+            }
+        }
+
+        return n.ToString(CultureInfo.InvariantCulture);
+    }
+
+    [Benchmark] public string C19_StopCharConcat_Current() => Fold(_texts, C19_Current);
+    [Benchmark] public string C19_StopCharConcat_Candidate() => Fold(_texts, C19_Candidate);
+
+    // ---------------------------------------------------------------------------------------
+    // C20 - ScenaristClosedCaptions.GetCodeFromLetter: LINQ FirstOrDefault over a 339-entry
+    //       KeyValuePair list, once per character written.
+    // ---------------------------------------------------------------------------------------
+    private static readonly List<KeyValuePair<string, string>> SccLetters = BuildSccLetters();
+    private static readonly Dictionary<string, string> SccReverse = BuildSccReverse();
+
+    private static List<KeyValuePair<string, string>> BuildSccLetters()
+    {
+        // Same shape/size as the real table: 339 entries, printable ASCII early, accents late.
+        var list = new List<KeyValuePair<string, string>>(339);
+        for (var c = 0x20; c <= 0x7E; c++)
+        {
+            list.Add(new KeyValuePair<string, string>(c.ToString("x2"), ((char)c).ToString()));
+        }
+
+        var extra = 0x100;
+        while (list.Count < 339)
+        {
+            list.Add(new KeyValuePair<string, string>(extra.ToString("x4"), ((char)extra).ToString()));
+            extra++;
+        }
+
+        return list;
+    }
+
+    private static Dictionary<string, string> BuildSccReverse()
+    {
+        var d = new Dictionary<string, string>(SccLetters.Count, StringComparer.Ordinal);
+        foreach (var kv in SccLetters)
+        {
+            if (!d.ContainsKey(kv.Value))
+            {
+                d.Add(kv.Value, kv.Key);
+            }
+        }
+
+        return d;
+    }
+
+    private static string GetCodeFromLetter_Current(string letter)
+    {
+        var code = SccLetters.FirstOrDefault(x => x.Value == letter);
+        if (code.Equals(new KeyValuePair<string, string>()))
+        {
+            return null;
+        }
+
+        return code.Key;
+    }
+
+    private static string GetCodeFromLetter_Candidate(string letter)
+    {
+        return SccReverse.TryGetValue(letter, out var code) ? code : null;
+    }
+
+    private string C20_Current()
+    {
+        var sb = new StringBuilder();
+        foreach (var text in _texts)
+        {
+            for (var i = 0; i < text.Length; i++)
+            {
+                sb.Append(GetCodeFromLetter_Current(text.Substring(i, 1)) ?? "--");
+            }
+        }
+
+        return sb.Length.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private string C20_Candidate()
+    {
+        var sb = new StringBuilder();
+        foreach (var text in _texts)
+        {
+            for (var i = 0; i < text.Length; i++)
+            {
+                sb.Append(GetCodeFromLetter_Candidate(text.Substring(i, 1)) ?? "--");
+            }
+        }
+
+        return sb.Length.ToString(CultureInfo.InvariantCulture);
+    }
+
+    [Benchmark] public string C20_SccCodeLookup_Current() => C20_Current();
+    [Benchmark] public string C20_SccCodeLookup_Candidate() => C20_Candidate();
+
+    // ---------------------------------------------------------------------------------------
+    // C21 - ScenaristClosedCaptions.ToText: text.Substring(i, 1) allocated for every character.
+    // ---------------------------------------------------------------------------------------
+    private string C21_Current()
+    {
+        var sb = new StringBuilder();
+        foreach (var text in _texts)
+        {
+            for (var i = 0; i < text.Length; i++)
+            {
+                var s = text.Substring(i, 1);
+                sb.Append(GetCodeFromLetter_Candidate(s) ?? "--");
+            }
+        }
+
+        return sb.Length.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static readonly Dictionary<char, string> SccReverseChar = BuildSccReverseChar();
+
+    private static Dictionary<char, string> BuildSccReverseChar()
+    {
+        var d = new Dictionary<char, string>(SccLetters.Count);
+        foreach (var kv in SccLetters)
+        {
+            if (kv.Value.Length == 1 && !d.ContainsKey(kv.Value[0]))
+            {
+                d.Add(kv.Value[0], kv.Key);
+            }
+        }
+
+        return d;
+    }
+
+    private string C21_Candidate()
+    {
+        var sb = new StringBuilder();
+        foreach (var text in _texts)
+        {
+            for (var i = 0; i < text.Length; i++)
+            {
+                sb.Append(SccReverseChar.TryGetValue(text[i], out var code) ? code : "--");
+            }
+        }
+
+        return sb.Length.ToString(CultureInfo.InvariantCulture);
+    }
+
+    [Benchmark] public string C21_SccPerCharSubstring_Current() => C21_Current();
+    [Benchmark] public string C21_SccPerCharSubstring_Candidate() => C21_Candidate();
+
+    // ---------------------------------------------------------------------------------------
+    // C22 - ScenaristClosedCaptions.ToText: text.Substring(i).StartsWith("<i>"/"</i>") inside
+    //       the per-character loop (quadratic in line length).
+    // ---------------------------------------------------------------------------------------
+    private static string C22_Current(string text)
+    {
+        var italic = 0;
+        var i = 0;
+        while (i < text.Length)
+        {
+            if (text.Substring(i).StartsWith("<i>", StringComparison.Ordinal))
+            {
+                i += 3;
+                italic++;
+            }
+            else if (text.Substring(i).StartsWith("</i>", StringComparison.Ordinal) && italic > 0)
+            {
+                i += 4;
+                italic--;
+            }
+            else
+            {
+                i++;
+            }
+        }
+
+        return italic.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static string C22_Candidate(string text)
+    {
+        var italic = 0;
+        var i = 0;
+        while (i < text.Length)
+        {
+            var tail = text.AsSpan(i);
+            if (tail.StartsWith("<i>", StringComparison.Ordinal))
+            {
+                i += 3;
+                italic++;
+            }
+            else if (tail.StartsWith("</i>", StringComparison.Ordinal) && italic > 0)
+            {
+                i += 4;
+                italic--;
+            }
+            else
+            {
+                i++;
+            }
+        }
+
+        return italic.ToString(CultureInfo.InvariantCulture);
+    }
+
+    [Benchmark] public string C22_SccItalicScan_Current() => Fold(_texts, C22_Current);
+    [Benchmark] public string C22_SccItalicScan_Candidate() => Fold(_texts, C22_Candidate);
+
+    // ---------------------------------------------------------------------------------------
+    // C23 - FinalCutProXmlCaptions.SplitStyledRuns: four Substring(i).StartsWith per '<'.
+    // ---------------------------------------------------------------------------------------
+    private static string C23_Current(string input)
+    {
+        var sb = new StringBuilder();
+        var runs = 0;
+        var i = 0;
+        while (i < input.Length)
+        {
+            if (input[i] == '<')
+            {
+                var toggled = true;
+                if (input.Substring(i).StartsWith("<i>", StringComparison.OrdinalIgnoreCase))
+                {
+                    runs++;
+                    i += 3;
+                }
+                else if (input.Substring(i).StartsWith("</i>", StringComparison.OrdinalIgnoreCase))
+                {
+                    runs++;
+                    i += 4;
+                }
+                else if (input.Substring(i).StartsWith("<b>", StringComparison.OrdinalIgnoreCase))
+                {
+                    runs++;
+                    i += 3;
+                }
+                else if (input.Substring(i).StartsWith("</b>", StringComparison.OrdinalIgnoreCase))
+                {
+                    runs++;
+                    i += 4;
+                }
+                else
+                {
+                    toggled = false;
+                }
+
+                if (toggled)
+                {
+                    continue;
+                }
+            }
+
+            sb.Append(input[i]);
+            i++;
+        }
+
+        return runs.ToString(CultureInfo.InvariantCulture) + ":" + sb.Length.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static string C23_Candidate(string input)
+    {
+        var sb = new StringBuilder();
+        var runs = 0;
+        var i = 0;
+        while (i < input.Length)
+        {
+            if (input[i] == '<')
+            {
+                var toggled = true;
+                var tail = input.AsSpan(i);
+                if (tail.StartsWith("<i>", StringComparison.OrdinalIgnoreCase))
+                {
+                    runs++;
+                    i += 3;
+                }
+                else if (tail.StartsWith("</i>", StringComparison.OrdinalIgnoreCase))
+                {
+                    runs++;
+                    i += 4;
+                }
+                else if (tail.StartsWith("<b>", StringComparison.OrdinalIgnoreCase))
+                {
+                    runs++;
+                    i += 3;
+                }
+                else if (tail.StartsWith("</b>", StringComparison.OrdinalIgnoreCase))
+                {
+                    runs++;
+                    i += 4;
+                }
+                else
+                {
+                    toggled = false;
+                }
+
+                if (toggled)
+                {
+                    continue;
+                }
+            }
+
+            sb.Append(input[i]);
+            i++;
+        }
+
+        return runs.ToString(CultureInfo.InvariantCulture) + ":" + sb.Length.ToString(CultureInfo.InvariantCulture);
+    }
+
+    [Benchmark] public string C23_FcpStyledRuns_Current() => Fold(_texts, C23_Current);
+    [Benchmark] public string C23_FcpStyledRuns_Candidate() => Fold(_texts, C23_Candidate);
+
+    // ---------------------------------------------------------------------------------------
+    // C24 - CheetahCaption.ToText: Substring(j).StartsWith(NewLine) per character, plus
+    //       Encoding.GetEncoding(1252) resolved for every paragraph.
+    // ---------------------------------------------------------------------------------------
+    private static string C24_Current(string text)
+    {
+        var encoding = Encoding.GetEncoding(1252);
+        var bytes = 0;
+        var j = 0;
+        while (j < text.Length)
+        {
+            if (text.Substring(j).StartsWith(Environment.NewLine, StringComparison.Ordinal))
+            {
+                j += Environment.NewLine.Length;
+                bytes += 4;
+            }
+            else
+            {
+                bytes += encoding.GetByteCount(text.AsSpan(j, 1));
+                j++;
+            }
+        }
+
+        return bytes.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static readonly Encoding Cp1252;
+
+    private static string C24_Candidate(string text)
+    {
+        var encoding = Cp1252;
+        var bytes = 0;
+        var j = 0;
+        while (j < text.Length)
+        {
+            if (text.AsSpan(j).StartsWith(Environment.NewLine, StringComparison.Ordinal))
+            {
+                j += Environment.NewLine.Length;
+                bytes += 4;
+            }
+            else
+            {
+                bytes += encoding.GetByteCount(text.AsSpan(j, 1));
+                j++;
+            }
+        }
+
+        return bytes.ToString(CultureInfo.InvariantCulture);
+    }
+
+    [Benchmark] public string C24_CheetahScan_Current() => Fold(_texts, C24_Current);
+    [Benchmark] public string C24_CheetahScan_Candidate() => Fold(_texts, C24_Candidate);
+
+    // ---------------------------------------------------------------------------------------
+    // C25 - DialogSplitMerge: l.TrimStart().StartsWith(dash) allocates a trimmed copy of every
+    //       line only to look at its first non-space character.
+    // ---------------------------------------------------------------------------------------
+    private static string C25_Current(string text)
+    {
+        var n = 0;
+        foreach (var l in text.SplitToLines())
+        {
+            if (l.TrimStart().StartsWith('-'))
+            {
+                n++;
+            }
+        }
+
+        return n.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static string C25_Candidate(string text)
+    {
+        var n = 0;
+        foreach (var l in text.SplitToLines())
+        {
+            var span = l.AsSpan().TrimStart();
+            if (span.Length > 0 && span[0] == '-')
+            {
+                n++;
+            }
+        }
+
+        return n.ToString(CultureInfo.InvariantCulture);
+    }
+
+    [Benchmark] public string C25_DialogTrimStart_Current() => Fold(_texts, C25_Current);
+    [Benchmark] public string C25_DialogTrimStart_Candidate() => Fold(_texts, C25_Candidate);
+}

--- a/tests/benchmarks/PerfHuntRound14RealFileBenchmarks.cs
+++ b/tests/benchmarks/PerfHuntRound14RealFileBenchmarks.cs
@@ -1,0 +1,169 @@
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Forms;
+using Nikse.SubtitleEdit.Core.Forms.FixCommonErrors;
+using Nikse.SubtitleEdit.Core.Interfaces;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System.Text;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// End-to-end passes over a real subtitle file, for the round-14 hunt. Unlike
+/// <see cref="PerfHuntRound14Benchmarks"/> these call the shipping code, so the same class is run
+/// once against a baseline worktree and once against the patched tree.
+///
+/// <para><see cref="SubRipParseControl"/> is the drift control: nothing in this round touches
+/// SubRip, so if that row moves the two halves of the comparison are not trustworthy.</para>
+///
+/// Point <c>SE_BENCH_SUBTITLE</c> at an .srt; a synthetic corpus is used when it is unset.
+/// </summary>
+[MemoryDiagnoser]
+public class PerfHuntRound14RealFileBenchmarks
+{
+    private List<string> _rawLines = new();
+    private Subtitle _subtitle = new();
+    private RemoveTextForHI _removeTextForHi = null!;
+    private readonly StubFixCallbacks _callbacks = new();
+    private readonly StubFixCallbacks _arabicCallbacks = new() { LanguageCode = "ar" };
+
+    static PerfHuntRound14RealFileBenchmarks()
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+    }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _rawLines = LoadLines();
+        _subtitle = new Subtitle();
+        new SubRip().LoadSubtitle(_subtitle, _rawLines, "movie.srt");
+        _removeTextForHi = new RemoveTextForHI(new RemoveTextForHISettings(_subtitle));
+    }
+
+    private static List<string> LoadLines()
+    {
+        var path = Environment.GetEnvironmentVariable("SE_BENCH_SUBTITLE");
+        if (!string.IsNullOrEmpty(path) && File.Exists(path))
+        {
+            return File.ReadAllLines(path).ToList();
+        }
+
+        var samples = new[]
+        {
+            "It was the best of times, it was the worst of times.",
+            "<i>Are you coming with us?</i>",
+            "- No.|- Then stay here and wait.",
+            "MAN: There were 3 of them,|and only 1 got away.",
+            "[DOOR CREAKING]",
+            "(SIGHS) i think i'm going to be sick.",
+            "NARRATOR: Chapter 10: the long way home...",
+            "You'll find it at 10:30, i.e. after lunch.",
+        };
+
+        var lines = new List<string>(1800 * 4);
+        var ms = 1000;
+        for (var i = 0; i < 1800; i++)
+        {
+            lines.Add((i + 1).ToString());
+            lines.Add($"{new TimeCode(ms)}".Replace('.', ',') + " --> " + $"{new TimeCode(ms + 2000)}".Replace('.', ','));
+            foreach (var part in samples[i % samples.Length].Split('|'))
+            {
+                lines.Add(part);
+            }
+
+            lines.Add(string.Empty);
+            ms += 2200;
+        }
+
+        return lines;
+    }
+
+    /// <summary>Drift control - untouched by this round. A ratio far from 1.0 invalidates the pair.</summary>
+    [Benchmark]
+    public int SubRipParseControl()
+    {
+        var subtitle = new Subtitle();
+        new SubRip().LoadSubtitle(subtitle, _rawLines, "movie.srt");
+        return subtitle.Paragraphs.Count;
+    }
+
+    /// <summary>Save as Scenarist Closed Captions - the per-character code lookup and italic scan.</summary>
+    [Benchmark]
+    public int SccExport() => new ScenaristClosedCaptions().ToText(_subtitle, "movie").Length;
+
+    /// <summary>Save as Cheetah Caption - the per-character newline probe and the cp1252 lookup.</summary>
+    [Benchmark]
+    public long CheetahExport()
+    {
+        using var stream = new MemoryStream();
+        new CheetahCaption().Save("movie.cap", stream, _subtitle, true);
+        return stream.Length;
+    }
+
+    /// <summary>Remove text for hearing impaired over the whole file.</summary>
+    [Benchmark]
+    public int RemoveTextForHearingImpaired()
+    {
+        var total = 0;
+        for (var i = 0; i < _subtitle.Paragraphs.Count; i++)
+        {
+            total += _removeTextForHi.RemoveTextFromHearImpaired(_subtitle.Paragraphs[i].Text, _subtitle, i, "en").Length;
+        }
+
+        return total;
+    }
+
+    /// <summary>Two of the fix-common-errors passes over the whole file.</summary>
+    [Benchmark]
+    public int FixCommonErrorsPass()
+    {
+        var working = new Subtitle(_subtitle);
+        new FixMissingSpaces().Fix(working, _callbacks);
+        new FixAloneLowercaseIToUppercaseI().Fix(working, _callbacks);
+        return working.Paragraphs.Count;
+    }
+
+    /// <summary>Just the lowercase-i fix: it prepares four html needles per line.</summary>
+    [Benchmark]
+    public int FixAloneLowercaseIOnly()
+    {
+        var working = new Subtitle(_subtitle);
+        new FixAloneLowercaseIToUppercaseI().Fix(working, _callbacks);
+        return working.Paragraphs.Count;
+    }
+
+    /// <summary>
+    /// FixSpaceAfter - and with it the two character-set probes - only runs for Arabic, so it
+    /// needs a callback that reports "ar" to be exercised at all.
+    /// </summary>
+    [Benchmark]
+    public int FixMissingSpacesArabic()
+    {
+        var working = new Subtitle(_subtitle);
+        new FixMissingSpaces().Fix(working, _arabicCallbacks);
+        return working.Paragraphs.Count;
+    }
+
+    /// <summary>How much of the deep copy the two passes above are measured on top of.</summary>
+    [Benchmark]
+    public int SubtitleCopyControl() => new Subtitle(_subtitle).Paragraphs.Count;
+
+    private sealed class StubFixCallbacks : IFixCallbacks
+    {
+        public bool AllowFix(Paragraph p, string action) => true;
+        public void AddFixToListView(Paragraph p, string action, string before, string after) { }
+        public void AddFixToListView(Paragraph p, string action, string before, string after, bool isChecked) { }
+        public void LogStatus(string sender, string message) { }
+        public void LogStatus(string sender, string message, bool isImportant) { }
+        public void UpdateFixStatus(int fixes, string message) { }
+        public bool IsName(string candidate) => false;
+        public HashSet<string> GetAbbreviations() => new();
+        public void AddToTotalErrors(int count) { }
+        public void AddToDeleteIndices(int index) { }
+        public SubtitleFormat Format { get; } = new SubRip();
+        public Encoding Encoding { get; } = Encoding.UTF8;
+        public string LanguageCode { get; init; } = "en";
+        public string Language => LanguageCode;
+    }
+}

--- a/tests/benchmarks/SubtitleErrorPathBenchmarks.cs
+++ b/tests/benchmarks/SubtitleErrorPathBenchmarks.cs
@@ -156,7 +156,7 @@ public class SubtitleErrorPathBenchmarks
             var next = i < _lines.Count - 1 ? _lines[i + 1] : null;
             if (s.HasErrors(prev, next))
             {
-                items.Add(new ErrorListItem(s, prev, next));
+                items.AddRange(ErrorListItem.Make(s, prev, next));
             }
         }
 
@@ -209,7 +209,7 @@ public class SubtitleErrorPathBenchmarks
         {
             var prev = i > 0 ? list[i - 1] : null;
             var next = i < list.Count - 1 ? list[i + 1] : null;
-            items.Add(new ErrorListItem(list[i], prev, next));
+            items.AddRange(ErrorListItem.Make(list[i], prev, next));
         }
 
         return items.Count;


### PR DESCRIPTION
A random performance sweep turned up 25 candidates. Each was measured with BenchmarkDotNet as a **whole-file pass over a real 1804-cue movie subtitle**, current shape against candidate shape in one process, each with its own direct call site, and a per-candidate equivalence assert in `[GlobalSetup]`. **17 sites measured a real win; 8 candidates measured flat or slower and were dropped.**

## Headline: writing an .scc was quadratic twice over

`GetCodeFromLetter` ran `LetterDictionary.FirstOrDefault(x => x.Value == letter)` — a 339-entry LINQ scan — **for every character written**, and the italic scan did `Substring(i).StartsWith("<i>")` per character.

End-to-end on a real file:

| | before | after | |
|---|---:|---:|---|
| `SccExport` | 27,533 µs | 5,200 µs | **5.3×**, 28.8 MB → 11.1 MB |
| `CheetahExport` | 6,045 µs | 5,547 µs | 1.09×, 18.6 → 16.0 MB |
| `SubtitleCopyControl` *(drift control)* | 386.3 µs | 385.8 µs | 1.001 — pair is trustworthy |

## Per-site results (default job, same file)

| Site | Fix | Time | Allocation |
|---|---|---:|---|
| `ScenaristClosedCaptions.GetCodeFromLetter` | 339-entry LINQ scan per char → reverse `Dictionary` | **47.6×** | 10.3 MB → 1.3 MB |
| `NetflixCheckNumbersOneToTenSpellOut` | `Substring(i).StartsWith(",")` → `text[i] == ','` | **354×** | 2.6 MB → 8 KB |
| `RemoveTextForHI.RemovePartialBeforeColon` | `Substring(i).StartsWith("  ")` → index compares | **316×** | 2.6 MB → 8 KB |
| `ScenaristClosedCaptions` italic scan | `Substring(i).StartsWith("<i>")` per char → span | **10.1×** | 5.3 MB → 8 KB |
| `FixMissingSpaces.FixSpaceAfter` | `"0123456789".Contains(c.ToString())` → `IsAsciiDigit` | **10.0×** | 1.13 MB → 8 KB |
| `NetflixCheckNumbersOneToTenSpellOut` | `":.".Contains(c.ToString())` ×3 → char compare | **9.5×** | 1.13 MB → 8 KB |
| `FixMissingSpaces.FixSpaceAfter` | separator set → `SearchValues<char>` | **7.5×** | 1.14 MB → 15 KB |
| `FixAloneLowercaseIToUppercaseI` | `Environment.NewLine + " <>!.?:;,"` per evaluation → static | **6.6×** | 2.26 MB → 16 KB |
| `RemoveTextForHI.ShouldRemoveNarrator` | two `string[]` literals per call → `SearchValues<string>` | **5.8×** | 332 KB → 0 |
| `NetflixCheckWhiteSpace` | anchored regexes → exact `char.IsWhiteSpace` guard in front | **4.8×** | unchanged |
| `ScenaristClosedCaptions` | `Substring(i, 1)` per char → `char`-keyed overload | **4.7×** | 1.32 MB → 194 KB |
| `NetflixCheckTextForHiUseBrackets` | `SplitToLines()` per line → gated on `StartsWith('-')` | **2.9×** | 400 KB → 196 KB |
| `NetflixCheckGlyph` | `HashSet<int>` probe per code point → BMP `bool[]` | **2.4×** | 0 → 0 |
| `RemoveTextForHI.ShouldRemoveNarrator` | `char[]` literal per call → `SearchValues<char>` | **2.0×** | 58 KB → 0 |
| `FixAloneLowercaseIToUppercaseI` | six `Replace` needles concatenated per call → memoised | **1.7×** | 427 KB → 196 KB |
| `NetflixCheckMaxCps` | drop the per-paragraph `new Paragraph(p)` clone | **1.7×** | 1.54 MB → 1.18 MB |
| `CheetahCaption` | per-char newline probe → span; `GetEncoding(1252)` → static | **1.4×** | 5.9 MB → 3.3 MB |

## Two findings worth recording

**Hoisting `new[] { "a", "b" }` string literals into `static readonly` fields measured *slower*** than the throw-away arrays (153 → 197 µs over a file), despite eliminating 332 KB of allocation. `SearchValues.Create(words, StringComparison.OrdinalIgnoreCase)` is the actual answer — 5.8× and zero allocation. Worth measuring the hoist rather than assuming it.

**Don't hand-roll a `$`-anchored regex.** `$` in .NET matches at end-of-string *or before a trailing `\n`*, so `"a \n"` matches `[^\s]( |\n|\r\n)$`. A first attempt at replacing the two white-space patterns with char tests was 6.3× and *wrong*; this ships an exact guard (provably implied by the pattern) that keeps the regex, still 4.8×.

## Caveats, stated plainly

- Two changes are correct but **not measurable** on an English subtitle because the sites are cold there: hoisting `new Regex(@",\d")` out of the Netflix number loop, and hoisting `CalcFactory.MakeCalculator` out of the max-CPS loop. No number is claimed for either.
- **Big micro numbers don't always reach the user.** `ShouldRemoveNarrator` only fires on colons and `FixSpaceAfter` only runs for Arabic, so the whole-file HI-removal and fix-common-errors passes are unchanged end-to-end on this subtitle (1,136 → 1,121 µs and 644 → 648 µs). The Arabic path does drop 751 → 693 KB.
- The Netflix checkers can't run end-to-end headless (they need `Se.Language` plus Avalonia's `AssetLoader` for the glyph file), so those are covered by micro benchmarks only.

## Also in this PR

Repairs `SubtitleErrorPathBenchmarks`, which stopped compiling when `ErrorListItem`'s constructor changed in f109666e0 — the benchmark project didn't build at all before this.

Adds `PerfHuntRound14Benchmarks.cs` (25 self-contained current/candidate pairs) and `PerfHuntRound14RealFileBenchmarks.cs` (end-to-end, with two drift controls). Both read `SE_BENCH_SUBTITLE` for a real .srt and fall back to a synthetic corpus.

## Tests

All 5,843 pass: libse 1,463 / libuilogic 504 / seconv 383 / UI 3,493.

🤖 Generated with [Claude Code](https://claude.com/claude-code)