### PR TITLE
Rename CharUtils.IsDigit to IsAsciiDigit

### DIFF
--- a/src/libse/Common/CharUtils.cs
+++ b/src/libse/Common/CharUtils.cs
@@ -6,7 +6,7 @@
         /// Checks if character matches [0-9]
         /// </summary>
         /// <param name="ch"></param>
-        public static bool IsDigit(char ch) => ch >= '0' && ch <= '9';
+        public static bool IsAsciiDigit(char ch) => ch >= '0' && ch <= '9';
 
         /// <summary>
         /// Checks if given character is hexadecimal

--- a/src/libse/Common/FileUtil.cs
+++ b/src/libse/Common/FileUtil.cs
@@ -722,7 +722,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 {
                     return false;
                 }
-                else if (CharUtils.IsDigit(ch))
+                else if (CharUtils.IsAsciiDigit(ch))
                 {
                     numberCount++;
                 }

--- a/src/libse/Common/StringExtensions.cs
+++ b/src/libse/Common/StringExtensions.cs
@@ -492,7 +492,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             var len = s.Length;
             for (var i = 0; i < len; i++)
             {
-                if (CharUtils.IsDigit(s[i]))
+                if (CharUtils.IsAsciiDigit(s[i]))
                 {
                     return true;
                 }

--- a/src/libse/Forms/FixCommonErrors/FixMissingSpaces.cs
+++ b/src/libse/Forms/FixCommonErrors/FixMissingSpaces.cs
@@ -414,7 +414,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                     {
                         skip = true;
                     }
-                    if (!skip && IsAsciiDigit(text[idx + 1]))
+
+                    if (!skip && CharUtils.IsAsciiDigit(text[idx + 1]))
                     {
                         skip = true;
                     }
@@ -435,8 +436,6 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
 
             return text;
         }
-
-        private static bool IsAsciiDigit(char c) => c >= '0' && c <= '9';
 
         private static bool IsSpaceAfterSkipChar(char c)
         {

--- a/src/libse/Forms/FixCommonErrors/Helper.cs
+++ b/src/libse/Forms/FixCommonErrors/Helper.cs
@@ -294,7 +294,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                         part1.Length > 1 && (char.IsUpper(part1[0]) || "\"'♫♪{[(".Contains(part1[0])))
                     {
                         text = text.Replace(" - ", Environment.NewLine + "- ");
-                        if (char.IsLetter(part0[0]) || CharUtils.IsDigit(part0[0]))
+                        if (char.IsLetter(part0[0]) || CharUtils.IsAsciiDigit(part0[0]))
                         {
                             if (text.Length > 3 && text[0] == '<' && text[2] == '>')
                             {

--- a/src/libse/SubtitleFormats/Chk.cs
+++ b/src/libse/SubtitleFormats/Chk.cs
@@ -189,7 +189,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     text = _codePage.GetString(buffer, start, end - start);
                 }
             }
-            if (text.Length > 4 && text[0] == 0x1f && text[1] == 'R' && text[4] == '.' && CharUtils.IsDigit(text[2]) && CharUtils.IsDigit(text[3]))
+            if (text.Length > 4 && text[0] == 0x1f && text[1] == 'R' && text[4] == '.' && CharUtils.IsAsciiDigit(text[2]) && CharUtils.IsAsciiDigit(text[3]))
             {
                 text = text.Remove(0, 5);
             }

--- a/src/libse/SubtitleFormats/MacSub.cs
+++ b/src/libse/SubtitleFormats/MacSub.cs
@@ -117,7 +117,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             int halfLen = len / 2;
             for (int i = 1; i <= halfLen; i++) // /10.0 (Do not parse double)
             {
-                if (!(CharUtils.IsDigit(input[i]) && CharUtils.IsDigit(input[len - i])))
+                if (!(CharUtils.IsAsciiDigit(input[i]) && CharUtils.IsAsciiDigit(input[len - i])))
                 {
                     return false;
                 }

--- a/src/libse/SubtitleFormats/WebVTT.cs
+++ b/src/libse/SubtitleFormats/WebVTT.cs
@@ -538,7 +538,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             for (int i = startIndex + 7; i < s.Length; i++)
             {
                 var ch = s[i];
-                if (CharUtils.IsDigit(ch))
+                if (CharUtils.IsAsciiDigit(ch))
                 {
                     tsSb.Append(ch);
                 }

--- a/tests/libse/Core/CharUtilsTest.cs
+++ b/tests/libse/Core/CharUtilsTest.cs
@@ -5,23 +5,23 @@ namespace LibSETests.Core;
 public class CharUtilsTest
 {
     [Fact]
-    public void IsDigit()
+    public void IsAsciiDigit()
     {
-        Assert.True(CharUtils.IsDigit('0'));
-        Assert.True(CharUtils.IsDigit('1'));
-        Assert.True(CharUtils.IsDigit('2'));
-        Assert.True(CharUtils.IsDigit('3'));
-        Assert.True(CharUtils.IsDigit('4'));
-        Assert.True(CharUtils.IsDigit('5'));
-        Assert.True(CharUtils.IsDigit('6'));
-        Assert.True(CharUtils.IsDigit('7'));
-        Assert.True(CharUtils.IsDigit('8'));
-        Assert.True(CharUtils.IsDigit('9'));
+        Assert.True(CharUtils.IsAsciiDigit('0'));
+        Assert.True(CharUtils.IsAsciiDigit('1'));
+        Assert.True(CharUtils.IsAsciiDigit('2'));
+        Assert.True(CharUtils.IsAsciiDigit('3'));
+        Assert.True(CharUtils.IsAsciiDigit('4'));
+        Assert.True(CharUtils.IsAsciiDigit('5'));
+        Assert.True(CharUtils.IsAsciiDigit('6'));
+        Assert.True(CharUtils.IsAsciiDigit('7'));
+        Assert.True(CharUtils.IsAsciiDigit('8'));
+        Assert.True(CharUtils.IsAsciiDigit('9'));
 
-        Assert.False(CharUtils.IsDigit('.'));
-        Assert.False(CharUtils.IsDigit('A'));
-        Assert.False(CharUtils.IsDigit(' '));
-        Assert.False(CharUtils.IsDigit('z'));
+        Assert.False(CharUtils.IsAsciiDigit('.'));
+        Assert.False(CharUtils.IsAsciiDigit('A'));
+        Assert.False(CharUtils.IsAsciiDigit(' '));
+        Assert.False(CharUtils.IsAsciiDigit('z'));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Rename `CharUtils.IsDigit` to `CharUtils.IsAsciiDigit` to make clear it only matches ASCII `0-9`, unlike `char.IsDigit` which also matches Unicode digits
- Update all call sites (FileUtil, StringExtensions, FixCommonErrors Helper, Chk, MacSub, WebVTT)
- Remove the duplicate private `IsAsciiDigit` helper in `FixMissingSpaces` in favor of the shared `CharUtils.IsAsciiDigit`
- Update `CharUtilsTest` accordingly

## Test plan
- [ ] `dotnet build SubtitleEdit.sln` succeeds
- [ ] `dotnet test tests/libse/LibSETests.csproj --filter "ClassName~CharUtilsTest"` passes
- [ ] Full libse test suite passes (no behavior change expected — pure rename)

🤖 Generated with [Claude Code](https://claude.com/claude-code)