### PR TITLE
OCR fix replace lists: repair broken rules, remove dead entries

### DIFF
--- a/Dictionaries/dan_OCRFixReplaceList.xml
+++ b/Dictionaries/dan_OCRFixReplaceList.xml
@@ -49,7 +49,7 @@
     <Word from="Hvergang" to="Hver gang" />
     <Word from="erder" to="er der" />
     <Word from="villetilgive" to="ville tilgive" />
-    <Word from="ﬁeme" to="fjeme" />
+    <Word from="ﬁeme" to="fjerne" />
     <Word from="genopståri" to="genopstår i" />
     <Word from="svigtejer" to="svigte jer" />
     <Word from="kommernu" to="kommer nu" />
@@ -671,7 +671,6 @@
   </RegularExpressionsIfSpelledCorrectly>
   <RegularExpressions>
     <RegEx find="\b\|\b" replaceWith="I" />
-    <RegEx find="\b\l\b" replaceWith="I" />
   </RegularExpressions>
   <RegularExpressionsIfSpelledCorrectly language="da">
 
@@ -719,8 +718,6 @@
     <!-- leading l→I before 2+ lowercase (e.g. lste → Iste caught by spellcheck) -->
     <RegEx find="\bl([a-zæøå]{2,})\b" spellCheck="I$1" replaceWith="I$1" />
 
-    <!-- standalone l → I (Roman numerals, list markers, ordinals) -->
-    <RegEx find="\bl\b" replaceWith="I" />
 
     <!-- ============================================================ -->
     <!-- DANISH GENITIVE / APOSTROPHE                                 -->

--- a/Dictionaries/deu_OCRFixReplaceList.xml
+++ b/Dictionaries/deu_OCRFixReplaceList.xml
@@ -37,7 +37,6 @@
     <Word from="00om" to="000 m" />
     <Word from="100m" to="100 m" />
     <Word from="120m" to="120 m" />
-    <Word from="13Oj§hrie" to="130 jährige" />
     <Word from="13Oj§hrie" to="130-jährige" />
     <Word from="145m" to="145 m" />
     <Word from="150m" to="150 m" />
@@ -804,7 +803,6 @@
     <Word from="bltte" to="bitte" />
     <Word from="Blumenstréiulichen" to="Blumensträußchen" />
     <Word from="Blumentépfen" to="Blumentöpfen" />
-    <Word from="Blutgetränkte" to="Blut getränkte" />
     <Word from="Blutgetrénkte" to="Blutgetränkte" />
     <Word from="blutjungl" to="blutjung!" />
     <Word from="blutriinstig" to="blutrünstig" />
@@ -1313,8 +1311,6 @@
     <Word from="entzuckend" to="entzückend" />
     <Word from="entzundet" to="entzündet" />
     <Word from="enzvérmt" to="erwärmt" />
-    <Word from="Er" to="Er" />
-    <Word from="er" to="er" />
     <Word from="Er6ffnen" to="Eröffnen" />
     <Word from="erbérml/ch" to="erbärmlich" />
     <Word from="erbérmlich" to="erbärmlich" />
@@ -1485,8 +1481,6 @@
     <Word from="érztlichen" to="ärztlichen" />
     <Word from="érztlicher" to="ärztlicher" />
     <Word from="erzurnen" to="erzürnen" />
-    <Word from="es" to="es" />
-    <Word from="Es" to="Es" />
     <Word from="ésthetisch" to="ästhetisch" />
     <Word from="etemity" to="eternity" />
     <Word from="etvva" to="etwa" />
@@ -1693,7 +1687,7 @@
     <Word from="Filr" to="Für" />
     <Word from="filrchten" to="fürchten" />
     <Word from="filrchterlich" to="fürchterlich" />
-    <Word from="filr'ne" to="für'ne" />
+    <Word from="filr'ne" to="für 'ne" />
     <Word from="filrs" to="fürs" />
     <Word from="filter" to="älter" />
     <Word from="findem" to="ändern" />
@@ -2226,8 +2220,6 @@
     <Word from="Gerijcht" to="Gerücht" />
     <Word from="Gerllicht" to="Gerücht" />
     <Word from="gerllistet" to="gerüstet" />
-    <Word from="gernhaben" to="gern haben" />
-    <Word from="gernhaben" to="gern-haben" />
     <Word from="gernntgt" to="geröntgt" />
     <Word from="Gértnern" to="Gärtnern" />
     <Word from="geschafff" to="geschafft" />
@@ -2914,7 +2906,6 @@
     <Word from="hierL" to="hieß" />
     <Word from="hierwar" to="hier war" />
     <Word from="hierzum" to="hier zum" />
-    <Word from="hierzum" to="hier-zum" />
     <Word from="Hiétte" to="Hätte" />
     <Word from="Hiibsch" to="Hübsch" />
     <Word from="Hiibsche" to="Hübsche" />
@@ -3213,15 +3204,12 @@
     <Word from="Illfie" to="Wie" />
     <Word from="Ilrger" to="Ärger" />
     <Word from="Ilufierste" to="Äußerste" />
-    <Word from="im" to="im" />
     <Word from="immerja" to="immer ja" />
     <Word from="immerjung" to="immer jung" />
-    <Word from="immerwährende" to="immer währende" />
     <Word from="immerwéhrende" to="immerwährende" />
     <Word from="immerweinen" to="immer weinen" />
     <Word from="Improvisiation" to="Improvisation" />
     <Word from="Impulswellengeschutz" to="Impulswellengeschütz" />
-    <Word from="in" to="in" />
     <Word from="INBRUNSTIGE" to="INBRÜNSTIGE" />
     <Word from="instfindig" to="inständig" />
     <Word from="intramuskulér" to="intramuskulär" />
@@ -3247,7 +3235,6 @@
     <Word from="ITTITTRZ" to="Danke." />
     <Word from="Ivlégliche" to="Mögliche" />
     <Word from="J0Shua" to="Joshua" />
-    <Word from="Ja" to="Ja" />
     <Word from="Jackettkaufen" to="Jackett kaufen" />
     <Word from="jahr" to="Jahr" />
     <Word from="jahre" to="Jahre" />
@@ -4487,7 +4474,6 @@
     <Word from="nutzlich" to="nützlich" />
     <Word from="Nx'emand" to="Niemand" />
     <Word from="O8" to="08" />
-    <Word from="ob" to="ob" />
     <Word from="obdachlosl" to="obdachlos!" />
     <Word from="Obefiléiche" to="Oberfläche" />
     <Word from="OBERFLACHENSCHWERKRAFT" to="OBERFLÄCHENSCHWERKRAFT" />
@@ -4677,8 +4663,6 @@
     <Word from="rachsiichtiger" to="rachsüchtiger" />
     <Word from="ranghéheren" to="ranghöheren" />
     <Word from="ranghfiheren" to="ranghöheren" />
-    <Word from="ranzukommen" to="ran zukommen" />
-    <Word from="ranzukommen" to="ran-zukommen" />
     <Word from="Rasenméherunfall" to="Rasenmäherunfall" />
     <Word from="Rasterllibertragung" to="Rasterübertragung" />
     <Word from="Rasterubertragung" to="Rasterübertragung" />
@@ -4870,8 +4854,6 @@
     <Word from="Runterl" to="Runter!" />
     <Word from="runterspillen" to="runterspülen" />
     <Word from="runterspllllen" to="runterspülen" />
-    <Word from="runterspült" to="runter spült" />
-    <Word from="runterspült" to="runter-spült" />
     <Word from="runtervverfen" to="runterwerfen" />
     <Word from="Rupem" to="Rupert!" />
     <Word from="Rustung" to="Rüstung" />
@@ -5315,7 +5297,6 @@
     <Word from="Slnd" to="Sind" />
     <Word from="Slr" to="Sir" />
     <Word from="Slrs" to="Sirs" />
-    <Word from="So" to="So" />
     <Word from="SoBen" to="Soßen" />
     <Word from="sofortl" to="sofort!" />
     <Word from="sohénen" to="schönen" />
@@ -5351,9 +5332,9 @@
     <Word from="spéit" to="spät" />
     <Word from="spéiter" to="später" />
     <Word from="spektakular" to="spektakulär" />
-    <Word from="Spell" to="Späß" />
+    <Word from="Spell" to="Spaß" />
     <Word from="Spell»" to="Spaß" />
-    <Word from="Spells" to="Späß" />
+    <Word from="Spells" to="Spaß" />
     <Word from="spét" to="spät" />
     <Word from="Spéter" to="Später" />
     <Word from="Spétzchen" to="Spätzchen" />
@@ -5365,7 +5346,6 @@
     <Word from="Spiei" to="Spiel" />
     <Word from="spieie" to="spiele" />
     <Word from="Spielzeuggeschfiftn" to="Spielzeuggeschäft" />
-    <Word from="Spielzeuggeschfiftn" to="Spielzeuggeschäft--" />
     <Word from="spiilte" to="spülte" />
     <Word from="spiiren" to="spüren" />
     <Word from="spiirt" to="spürt" />
@@ -6493,7 +6473,7 @@
     <Word from="Weill" to="Weiß" />
     <Word from="weills" to="weiß" />
     <Word from="weillst" to="weißt" />
-    <Word from="weillt" to="weisst" />
+    <Word from="weillt" to="weißt" />
     <Word from="weilS" to="weiß" />
     <Word from="weilSe" to="weiße" />
     <Word from="WeilSglut" to="Weißglut" />
@@ -6575,8 +6555,6 @@
     <Word from="widerspriichliche" to="widersprüchliche" />
     <Word from="Widerwéirtig" to="Widerwärtig" />
     <Word from="wiedergewéihltl" to="wiedergewählt" />
-    <Word from="wiederhaben" to="wieder haben" />
-    <Word from="wiederhaben" to="wieder-haben" />
     <Word from="Wiederhéren" to="Wiederhören" />
     <Word from="Wieheifiternoch" to="Wieheißternoch" />
     <Word from="Wieheiliternoch" to="Wieheißternoch" />
@@ -6839,7 +6817,6 @@
     <Word from="zleht" to="zieht" />
     <Word from="ZLIFUCK" to="zurück" />
     <Word from="Zooschlieliung" to="Zooschließung" />
-    <Word from="zu" to="zu" />
     <Word from="Zuckerschnﬂtchen" to="Zuckerschnütchen" />
     <Word from="zuerstvor" to="zuerst vor" />
     <Word from="Zuféillig" to="Zufällig" />

--- a/Dictionaries/eng_OCRFixReplaceList.xml
+++ b/Dictionaries/eng_OCRFixReplaceList.xml
@@ -1593,7 +1593,6 @@
 		<Word from="nojurisdiction" to="no jurisdiction" />
 		<Word from="noone" to="no one" />
 		<Word from="Noone" to="No one" />
-		<Word from="not judging" to="not judging" />
 		<Word from="noteto" to="note to" />
 		<Word from="notgoing" to="not going" />
 		<Word from="notjudge" to="not judge" />
@@ -1863,7 +1862,6 @@
 		<Word from="Polynes/ans" to="Polynesians" />
 		<Word from="pooL" to="pool" />
 		<Word from="poorshowing" to="poor showing" />
-		<Word from="popsicle" to="popsicle" />
 		<Word from="Potterfan" to="Potter fan" />
 		<Word from="poweryour" to="power your" />
 		<Word from="preferjournalist" to="prefer journalist" />
@@ -2103,7 +2101,6 @@
 		<Word from="thatjust" to="that just" />
 		<Word from="thatleads" to="that leads" />
 		<Word from="Thatl'm" to="That I'm" />
-		<Word from="that's just" to="that's just" />
 		<Word from="thats" to="that's" />
 		<Word from="Thats" to="That's" />
 		<Word from="Thatsand" to="That sand" />
@@ -2802,7 +2799,6 @@
 		<Word from="you'II" to="you'll" />		
 		<Word from="he'II" to="he'll" />
 		<Word from="we'II" to="we'll" />
-		<Word from="I'II" to="I'll" />
 	</WholeWords>
 	<PartialWordsAlways>
 		<!-- Will be replaced always -->
@@ -3412,9 +3408,8 @@
 		<RegEx find="\bI([a-zæøåöääöéèàùâêîôûëï]{3,})\b" spellCheck="l$1" replaceWith="l$1" /> <!-- Iaunch → launch, but NOT Is -->
         <RegEx find="\bof([A-Z][a-zæøåöääöéèàùâêîôûëï]+)\b" spellCheck="$1" replaceWith="of $1" /> <!-- ofDavid → of David -->
         <RegEx find="\bin([A-Z][a-zæøåöääöéèàùâêîôûëï]+)\b" spellCheck="$1" replaceWith="in $1" /> <!-- inLondon → in London -->
-		<RegEx find="\bl\b" replaceWith="I" /> <!-- lowercase l (L) to I (i) -->
+		<RegEx find="\bl\b" spellCheck="I" replaceWith="I" /> <!-- lowercase l (L) to I (i) -->
 		<RegEx find="\[([A-Z ]*)l([A-Z ]*)\]" spellCheck="[$1I$2]" replaceWith="[$1I$2]" /> <!-- [GEARS GRlNDlNG] to [GEARS GRINDING] -->
-		<RegEx find="\b([A-Z]+)l([A-Z]+)\b" spellCheck="$1I$2" replaceWith="$1I$2" />
 		<RegEx find="\b([A-Z][a-zæøåöääöéèàùâêîôûëï]{3,})I([a-zæøåöääöéèàùâêîôûëï]*)\b" spellCheck="$1l$2" replaceWith="$1l$2" />
 		<RegEx find="\b([A-Z][a-zæøåöääöéèàùâêîôûëï]{3,})I\b" spellCheck="$1l" replaceWith="$1l" />
 	</RegularExpressionsIfSpelledCorrectly>

--- a/Dictionaries/fra_OCRFixReplaceList.xml
+++ b/Dictionaries/fra_OCRFixReplaceList.xml
@@ -312,24 +312,14 @@
     <!-- this catches remaining: les, les, etc. — only fires if spellcheck passes as I+word) -->
     <RegEx find="\bl([a-zæøåöäéèàùâêîôûëïœç]{2,})\b" spellCheck="I$1" replaceWith="I$1" />
 
-    <!-- standalone l → I (Roman numerals, list markers) -->
-    <RegEx find="\bl\b" replaceWith="I" />
 
     <!-- ============================================================ -->
     <!-- FRENCH ELISION / APOSTROPHE FIXES                           -->
     <!-- ============================================================ -->
 
-    <!-- l'ami, l'heure : ensure typographic apostrophe -->
-    <RegEx find="\bl['']([a-zæøåöäéèàùâêîôûëïœç])" replaceWith="l'$1" />
 
-    <!-- c'est, j'ai, n'est, m'a, s'il, t'a, d'un : elision contractions -->
-    <RegEx find="\b([cjnmstd])['']([a-zæøåöäéèàùâêîôûëïœç])" replaceWith="$1'$2" />
 
-    <!-- qu'il, qu'on : longer elision prefix -->
-    <RegEx find="\bqu['']([a-zæøåöäéèàùâêîôûëïœç])" replaceWith="qu'$1" />
 
-    <!-- aujourd'hui : guard common compound -->
-    <RegEx find="\baujourd['']hui\b" replaceWith="aujourd'hui" />
 
     <!-- ============================================================ -->
     <!-- MISSING SPACE AFTER COMMON FRENCH PREPOSITIONS / ARTICLES   -->

--- a/Dictionaries/hrb_OCRFixReplaceList.xml
+++ b/Dictionaries/hrb_OCRFixReplaceList.xml
@@ -50,7 +50,7 @@
     <Word from="cao" to="ćao" />
     <Word from="cas" to="sat" />
     <Word from="casa" to="sata" />
-    <Word from="casu" to="satu" />
+    <Word from="casu" to="čašu" />
     <Word from="casom" to="satom" />
     <Word from="casovima" to="satovima" />
     <Word from="Cas" to="Sat" />
@@ -61,7 +61,6 @@
     <Word from="casno" to="časno" />
     <Word from="Casno" to="Časno" />
     <Word from="castis" to="častiš" />
-    <Word from="casu" to="cašu" />
     <Word from="cašu" to="čašu" />
     <Word from="cebe" to="deku" />
     <Word from="cega" to="čega" />
@@ -206,8 +205,6 @@
     <Word from="Dosao" to="Došao" />
     <Word from="dosao" to="došao" />
     <Word from="drhteci" to="drhteći" />
-    <Word from="drhteći" to="drhteći" />
-    <Word from="Drhteći" to="Drhteći" />
     <Word from="drsces" to="dršćeš" />
     <Word from="Drsces" to="Dršćeš" />
     <Word from="drugacija" to="drugačija" />
@@ -281,7 +278,6 @@
     <Word from="Iduci" to="Idući" />
     <Word from="iduci" to="idući" />
     <Word from="ignorisi" to="ignoriraj" />
-    <Word from="ignorisi" to="ignoriraju" />
     <Word from="igras" to="igraš" />
     <Word from="Ijudi" to="ljudi" />
     <Word from="imas" to="imaš" />
@@ -294,8 +290,6 @@
     <Word from="isećemo" to="izrezati" />
     <Word from="isla" to="išla" />
     <Word from="istjece" to="istječe" />
-    <Word from="istrazio" to="istrazio" />
-    <Word from="Istrazio" to="Istrazio" />
     <Word from="isuvise" to="previše" />
     <Word from="izaci" to="izaći" />
     <Word from="Izaci" to="Izaći" />
@@ -478,7 +472,6 @@
     <Word from="Nadjes" to="Nađeš" />
     <Word from="nadjete" to="nađete" />
     <Word from="nagovestaj" to="nagovještaj" />
-    <Word from="najvise" to="najvise" />
     <Word from="Najvise" to="Najviše" />
     <Word from="naocale" to="naočale" />
     <Word from="Napisite" to="Napišite" />
@@ -1059,7 +1052,6 @@
     <Word from="Ucio" to="Učio" />
     <Word from="udas" to="udaš" />
     <Word from="udete" to="uđete" />
-    <Word from="udeš" to="udeš" />
     <Word from="udi" to="uđi" />
     <Word from="Udi" to="Uđi" />
     <Word from="Udje" to="Uđe" />
@@ -1216,7 +1208,6 @@
     <Word from="zvanican" to="služben" />
     <Word from="ćes" to="ćeš" />
     <Word from="ćte" to="ćete" />
-    <Word from="Čime" to="Čime" />
     <Word from="žalis" to="žališ" />
     <Word from="želis" to="želiš" />
     <Word from="Živeo" to="Živio" />

--- a/Dictionaries/hrv_OCRFixReplaceList.xml
+++ b/Dictionaries/hrv_OCRFixReplaceList.xml
@@ -103,8 +103,6 @@
     <Word from="bibliju" to="Bibliju" />
     <Word from="biblijom" to="Biblijom" />
     <Word from="biblijama" to="Biblijama" />
-    <Word from="biit" to="biti" />
-    <Word from="bije" to="tuče" />
     <Word from="bijemo" to="tučemo" />
 
     <Word from="bioje" to="bio je" />
@@ -360,7 +358,6 @@
     <Word from="detelina" to="djetelina" />
     <Word from="devac" to="djevac" />
     <Word from="dezert" to="desert" />
-    <Word from="diđe" to="diže" />
     <Word from="diluje" to="dila" />
     <Word from="diluju" to="dilaju" />
     <Word from="disajni" to="dišni" />
@@ -471,7 +468,7 @@
     <Word from="džanki" to="ovisnik" />
     <Word from="dželat" to="krvnik" />
     <Word from="đubre" to="smeće" />
-    <Word from="đta" to="šta" />
+    <Word from="đta" to="što" />
     <Word from="đto" to="što" />
     <!-- e -->
     <Word from="edukovani" to="educirani" />
@@ -823,7 +820,7 @@
     <Word from="Ješću" to="Jest ću" />
     <Word from="ješćeš" to="jest ćeš" />
     <Word from="ješćemo" to="jest ćemo" />
-    <Word from="jle" to="jel" />
+    <Word from="jle" to="je l'" />
     <Word from="jop" to="još" />
     <Word from="jos" to="još" />
     <Word from="jošp" to="još" />
@@ -1398,7 +1395,6 @@
     <Word from="nigde" to="nigdje" />
     <Word from="Nigde" to="Nigdje" />
     <Word from="igde" to="igdje" />
-    <Word from="igde" to="igdje" />
     <Word from="nigjde" to="nigdje" />
     <Word from="nikakave" to="nikakve" />
     <Word from="niko" to="nitko" />
@@ -1412,13 +1408,11 @@
     <Word from="nejde" to="ne ide" />
     <Word from="Nejde" to="Ne ide" />
     <Word from="nejdem" to="ne idem" />
-    <Word from="neda" to="ne da" />
     <Word from="nedam" to="ne dam" />
     <Word from="negujem" to="njegujem" />
     <!-- nj -->
     <Word from="njegi" to="njezi" />
     <Word from="njegoa" to="njegova" />
-    <Word from="njegou" to="njegovu" />
     <Word from="negovani" to="njegovani" />
     <Word from="negovanim" to="njegovanim" />
     <Word from="njenum" to="njenim" />
@@ -1843,7 +1837,6 @@
     <Word from="pomeraj" to="miči" />
     <Word from="pomjeraj" to="miči" />
     <Word from="pomeraju" to="miču" />
-    <Word from="pomerala" to="micala" />
     <Word from="pomjerala" to="pomicala" />
     <Word from="pomjeraju" to="pomiču" />
     <Word from="pomeranja" to="pomicanja" />
@@ -2005,7 +1998,6 @@
     <Word from="primećivala" to="primijećivala" />
     <Word from="primećivalo" to="primijećivalo" />
     <Word from="Primećivalo" to="Primijećivalo" />
-    <Word from="primećivalo" to="primijećivalo" />
     <Word from="primećujemo" to="primjećujemo" />
     <Word from="prineo" to="prinio" />
     <Word from="Prineo" to="Prinio" />
@@ -2037,10 +2029,8 @@
     <Word from="prijatan" to="ugodan" />
     <Word from="Prijatan" to="Ugodan" />
     <Word from="prilepak" to="priljepak" />
-    <Word from="primećen" to="primijećen" />
     <Word from="primećenog" to="primijećenog" />
     <Word from="primećivao" to="primjećivao" />
-    <Word from="primećivala" to="primjećivala" />
     <Word from="primedbi" to="primjedbi" />
     <Word from="primjete" to="primijete" />
     <Word from="prisetim" to="prisjetim" />
@@ -2195,7 +2185,6 @@
     <Word from="Recitujem" to="Recitiram" />
     <Word from="recitujem" to="recitiram" />
     <Word from="recituje" to="recitira" />
-    <Word from="recitujte" to="recitirajte" />
     <Word from="reč" to="riječ" />
     <Word from="reči" to="riječi" />
     <Word from="rečit" to="rječit" />
@@ -2321,9 +2310,7 @@
     <Word from="sedenje" to="sjedenje" />
     <Word from="Sedenje" to="Sjedenje" />
     <Word from="sedišta" to="sjedala" />
-    <Word from="sedište" to="sjedalo" />
     <Word from="sedištem" to="sjedištem" />
-    <Word from="sedištu" to="sjedalu" />
     <Word from="sedni" to="sjedni" />
     <Word from="Sedni" to="Sjedni" />
     <Word from="sedi" to="sjedi" />
@@ -2571,7 +2558,6 @@
     <Word from="staće" to="stat će" />
     <Word from="staću" to="stat ću" />
     <Word from="Staće" to="Stat će" />
-    <Word from="staće" to="stat će" />
     <Word from="Staću" to="Stat ću" />
     <Word from="stače" to="stat će" />
     <Word from="staču" to="stat ću" />
@@ -2857,7 +2843,6 @@
     <Word from="Ukoliko" to="Ako" />
     <Word from="ukoliko" to="ako" />
     <Word from="uključiću" to="uključit ću" />
-    <Word from="uleće" to="ulijeće" />
     <Word from="uleću" to="ulijeću" />
     <Word from="ulevo" to="ulijevo" />
     <Word from="ume" to="zna" />
@@ -3379,7 +3364,6 @@
     <Word from="Džad" to="Jude" />
     <Word from="Džada" to="Judea" />
     <Word from="Džadu" to="Judeu" />
-    <Word from="Dženet" to="Janet" />
     <Word from="Dženifer" to="Jennifer" />
     <Word from="Dženis" to="Janice" />
     <Word from="Džerard" to="Gerard" />
@@ -3416,7 +3400,6 @@
     <Word from="Džozef" to="Joseph" />
     <Word from="Džozefe" to="Josephe" />
     <Word from="Džil" to="Jill" />
-    <Word from="Dživs" to="Jeeves" />
     <Word from="Džodi" to="Jody" />
     <Word from="Džud" to="Jude" />
     <Word from="Džudi" to="Judy" />
@@ -3471,7 +3454,6 @@
     <Word from="Henri" to="Henry" />
     <Word from="Hejs" to="Hays" />
     <Word from="Heri" to="Harry" />
-    <Word from="Hejven" to="Haven" />
     <Word from="Hejven" to="Haven" />
     <Word from="Hejvena" to="Havena" />
     <Word from="Hejz" to="Hays" />
@@ -3875,7 +3857,6 @@
 <Word from="lma" to="Ima" />
 <Word from="lmala" to="Imala" />
 <Word from="lmali" to="Imali" />
-<Word from="lmam" to="Imam" />
 <Word from="lmamo" to="Imamo" />
 <Word from="lmao" to="Imao" />
 <Word from="lmas" to="Imaš" />
@@ -3979,7 +3960,7 @@
 <Word from="ljubl" to="ljubi" />
 <Word from="maii" to="mali" />
 <Word from="maio" to="malo" />
-<Word from="maiopre" to="maloprije" />
+<Word from="maiopre" to="malo prije" />
 <Word from="metaboiizmu" to="metabolizmu" />
 <Word from="misiiš" to="misliš" />
 <Word from="mišijenje" to="mišljenje" />
@@ -4000,7 +3981,6 @@
 <Word from="nepažijiv" to="nepažljiv" />
 <Word from="nepodnošijiv" to="nepodnošljiv" />
 <Word from="nestaia" to="nestala" />
-<Word from="netreba" to="ne treba" />
 <Word from="nevoiji" to="nevolji" />
 <Word from="nlčega" to="ničega" />
 <Word from="nlkad" to="nikad" />
@@ -4010,7 +3990,7 @@
 <Word from="nlvo" to="nivo" />
 <Word from="nlje" to="nije" />
 <Word from="oci" to="oči" />
-<Word from="obiastima" to="oblastima" />
+<Word from="obiastima" to="područjima" />
 <Word from="oćigiedno" to="očigledno" />
 <Word from="odijeio" to="odijelo" />
 <Word from="odiućio" to="odlučio" />
@@ -4298,7 +4278,6 @@
     <LinePart from="mora da zna" to="mora znati" />
     <LinePart from="moram da znam" to="moram znati" />
     <LinePart from="Moram da znam" to="Moram znati" />
-    <LinePart from="moram da živim" to="moram živjeti" />
     <LinePart from="Moraš da znaš" to="Moraš znati" />
     <LinePart from="moraš da znaš" to="moraš znati" />
     <LinePart from="Morate da nam date" to="Morate nam dati" />
@@ -4587,7 +4566,6 @@
     <RegEx find="([dD])ospe(?=[mš]|te\b)" replaceWith="$1ospije" />
     <RegEx find="dostaja[čćc]" replaceWith="dostajat ć" />
     <RegEx find="oveš[čćc]" replaceWith="ovest ć" />
-    <RegEx find="djl" replaceWith="djel" />
     <RegEx find="\bdrig" replaceWith="drug" />
     <RegEx find="([dD])rj?ema" replaceWith="$1rijema" />
     <RegEx find="drugaric" replaceWith="prijateljic" />
@@ -4784,7 +4762,7 @@
     <RegEx find="([lL])j?e[čć]nik(?!i)" replaceWith="$1iječnik" />
     <RegEx find="\b([lL])ekar(?![inso])" replaceWith="$1iječnik" />
     <RegEx find="\b([iI]zl|[lL])j?ečen" replaceWith="$1iječen" />
-    <RegEx find="\([lL])j?ečen" replaceWith="$1iječen" />
+    <RegEx find="([lL])j?ečen" replaceWith="$1iječen" />
     <RegEx find="\blenj?([aeiou]|om|osti?|ošću|ima?|čin[aieou]|činama)?\b" replaceWith="lijen$1" />
     <!-- Lena je englesko ime i zato ne može -->
     <RegEx find="\bLenj?(om?|og?|osti?|ošću|ima?|čin[aieou]|činama)?\b" replaceWith="Lijen$1" />
@@ -5366,7 +5344,6 @@
     <RegEx find="ÄŚ" replaceWith="Č" />
     <RegEx find="ÄŒ" replaceWith="Č" />
     <RegEx find="Ä†" replaceWith="Ć" />
-    <RegEx find="Ä" replaceWith="Đ" />
     <RegEx find="Ĺ " replaceWith="Š" />
     <RegEx find="Å " replaceWith="Š" />
     <RegEx find="Ĺ˝" replaceWith="Ž" />
@@ -5439,7 +5416,6 @@
     <RegEx find="bqr" replaceWith="bar" />
     <RegEx find="bs([to])" replaceWith="ps$1" />
     <RegEx find="bto" replaceWith="bro" />
-    <RegEx find="bunić" replaceWith="bunit ć" />
     <!-- opservacija-->
     <RegEx find="bzer" replaceWith="pser" />
     <RegEx find="iliše" replaceWith="ilizira" />
@@ -5524,7 +5500,6 @@
     <RegEx find="(?&lt;!o)formiš" replaceWith="formiraj" />
     <RegEx find="fi(sa|še)" replaceWith="fira" />
     <RegEx find="fiskov" replaceWith="fiscir" />
-    <RegEx find="fnor" replaceWith="nfor" />
     <RegEx find="formuje" replaceWith="formira" />
     <RegEx find="frm" replaceWith="form" />
     <RegEx find="frov" replaceWith="frir" />
@@ -5562,7 +5537,7 @@
     <RegEx find="ikustv" replaceWith="iskustv" />
     <RegEx find="i([lk])p" replaceWith="i$1o" />
     <RegEx find="inhron" replaceWith="inkron" />
-    <RegEx find="iscj?edi" replaceWith="$1scijedi" />
+    <RegEx find="([iI])scj?edi" replaceWith="$1scijedi" />
     <RegEx find="isjk" replaceWith="ijsk" />
     <RegEx find="isnk" replaceWith="insk" />
     <RegEx find="irać" replaceWith="irat ć" />
@@ -5590,7 +5565,6 @@
     <!-- doktorica / profesorica -->
     <RegEx find="(kt|s)ork" replaceWith="$1oric" />
     <RegEx find="kovrdžav" replaceWith="kovrčav" />
-    <RegEx find="(?&lt;!o)kp" replaceWith="ko" />
     <RegEx find="kpm" replaceWith="kom" />
     <RegEx find="krpk" replaceWith="krok" />
     <RegEx find="ktovan" replaceWith="ktiran" />
@@ -5637,7 +5611,6 @@
     <RegEx find="mejl" replaceWith="mail" />
     <RegEx find="(?&lt;![Mm])ekd" replaceWith="egd" />
     <RegEx find="([mv])ešten" replaceWith="$1ješten" />
-    <RegEx find="mkes" replaceWith="mjes" />
     <RegEx find="mkes" replaceWith="mjes" />
     <RegEx find="mipl" replaceWith="mišl" />
     <RegEx find="mnet" replaceWith="ment" />
@@ -5752,7 +5725,7 @@
     <RegEx find="ovrn" replaceWith="ovorn" />
     <RegEx find="ovti" replaceWith="ovni" />
     <RegEx find="posel" replaceWith="posjel" />
-    <RegEx find="\([pP])otc" replaceWith="$1odc" />
+    <RegEx find="([pP])otc" replaceWith="$1odc" />
     <RegEx find="produkova" replaceWith="producira" />
     <RegEx find="\bpominj" replaceWith="spominj" />
     <!-- ignoriše / koncentriše /operiše /toleriše / -->
@@ -5831,7 +5804,6 @@
     <RegEx find="rwk" replaceWith="rek" />
     <RegEx find="rwm" replaceWith="rem" />
     <RegEx find="sbe" replaceWith="sve" />
-    <RegEx find="sbo" replaceWith="svo" />
     <RegEx find="scak" replaceWith="svak" />
     <RegEx find="s([čć])" replaceWith="š$1" />
     <RegEx find="seden" replaceWith="sjeden" />
@@ -5899,7 +5871,6 @@
 
     <!--no baš krasno-->
     <RegEx find="tnas" replaceWith="tans" />
-    <RegEx find="tnas" replaceWith="tnos" />
 
     <RegEx find="tnerk" replaceWith="tneric" />
     <RegEx find="tnp" replaceWith="tno" />
@@ -6194,7 +6165,6 @@
     <RegEx find="N[jJ]u Džer[sz]i" replaceWith="New Jersey" />
     <RegEx find="N[jJ]u Jork" replaceWith="New York" />
     <RegEx find="N[jJ]u Orleans" replaceWith="New Orleans" />
-    <RegEx find="Njujork" replaceWith="New York" />
     <RegEx find="Njujork" replaceWith="New York" />
     <RegEx find="Njukast?l" replaceWith="Newcastle" />
     <RegEx find="Njuton" replaceWith="Newton" />

--- a/Dictionaries/nld_OCRFixReplaceList.xml
+++ b/Dictionaries/nld_OCRFixReplaceList.xml
@@ -213,14 +213,8 @@
     <!-- [ABC] bracket with l mixed into caps -->
     <RegEx find="\[([A-Zl]+)\]" replaceAllFrom="l" replaceAllTo="I" spellCheck="$1" replaceWith="[$1]" />
 
-    <!-- SlNG → SING : l inside all-caps word -->
-    <RegEx find="\b([A-Z]+)l([A-Z]+)\b" spellCheck="$1I$2" replaceWith="$1I$2" />
 
-    <!-- trailing l in all-caps word -->
-    <RegEx find="\b([A-Z]+)l\b" spellCheck="$1I" replaceWith="$1I" />
 
-    <!-- leading l before all-caps word -->
-    <RegEx find="\bl([A-Z]+)\b" spellCheck="I$1" replaceWith="I$1" />
 
     <!-- chaIIenge → challenge : II→ll mid lowercase word -->
     <RegEx find="\b([a-zéèëïóöüij]+)II([a-zéèëïóöüij]+)\b" spellCheck="$1ll$2" replaceWith="$1ll$2" />
@@ -241,8 +235,6 @@
     <!-- leading l→I before 2+ lowercase chars -->
     <RegEx find="\bl([a-zéèëïóöüij]{2,})\b" spellCheck="I$1" replaceWith="I$1" />
 
-    <!-- standalone l → I (Roman numerals, list markers) -->
-    <RegEx find="\bl\b" replaceWith="I" />
 
     <!-- ============================================================ -->
     <!-- IJ DIGRAPH FIXES                                             -->

--- a/Dictionaries/nob_OCRFixReplaceList.xml
+++ b/Dictionaries/nob_OCRFixReplaceList.xml
@@ -101,8 +101,6 @@
     <!-- leading l→I before 2+ lowercase chars -->
     <RegEx find="\bl([a-zæøåé]{2,})\b" spellCheck="I$1" replaceWith="I$1" />
 
-    <!-- standalone l → I (Roman numerals, list markers, ordinals) -->
-    <RegEx find="\bl\b" replaceWith="I" />
 
     <!-- ============================================================ -->
     <!-- NORWEGIAN GENITIVE                                           -->

--- a/Dictionaries/nor_OCRFixReplaceList.xml
+++ b/Dictionaries/nor_OCRFixReplaceList.xml
@@ -99,8 +99,6 @@
     <!-- leading l→I before 2+ lowercase chars -->
     <RegEx find="\bl([a-zæøåé]{2,})\b" spellCheck="I$1" replaceWith="I$1" />
 
-    <!-- standalone l → I (Roman numerals, list markers, ordinals) -->
-    <RegEx find="\bl\b" replaceWith="I" />
 
     <!-- ============================================================ -->
     <!-- NORWEGIAN GENITIVE                                           -->

--- a/Dictionaries/spa_OCRFixReplaceList.xml
+++ b/Dictionaries/spa_OCRFixReplaceList.xml
@@ -422,7 +422,7 @@
     <LinePart from="¿Pero qué haces?" to="¡¿Pero qué haces?!" />
     <LinePart from="¿pero qué haces?" to="¡¿pero qué haces?!" />
     <LinePart from="¿Es que no me has escuchado?" to="¡¿Es que no me has escuchado?!" />
-    <LinePart from="¡¿es que no me has escuchado?!" to="¡¿es que no me has escuchado?!" />
+    <LinePart from="¿es que no me has escuchado?" to="¡¿es que no me has escuchado?!" />
     <!-- Acentos al principio de los signos de interrogación con minúsculas -->
     <LinePart from="¿aun" to="¿aún" />
     <LinePart from="¿tu " to="¿tú " />
@@ -513,7 +513,7 @@
     <LinePart from="¿a donde" to="¿a dónde" />
     <LinePart from="¿a que" to="¿a qué" />
     <LinePart from="¿a cual" to="¿a cuál" />
-    <LinePart from="¿a quien" to="¿a quien" />
+    <LinePart from="¿a quien" to="¿a quién" />
     <LinePart from="¿a como" to="¿a cómo" />
     <LinePart from="¿a cuanto" to="¿a cuánto" />
     <LinePart from="¿a cuanta" to="¿a cuánta" />
@@ -617,7 +617,6 @@
     <LinePart from="¿Con cual" to="¿Con cuál" />
     <LinePart from="¿Con quien" to="¿Con quién" />
     <LinePart from="¿Con cuantos" to="¿Con cuántos" />
-    <LinePart from="¿Con cuanta" to="¿Con cuántas" />
     <LinePart from="¿Con cuanta" to="¿Con cuánta" />
     <LinePart from="¿Con cuanto" to="¿Con cuánto" />
     <LinePart from="¿Para donde" to="¿Para dónde" />
@@ -632,7 +631,7 @@
     <LinePart from="¿A donde" to="¿A dónde" />
     <LinePart from="¿A que" to="¿A qué" />
     <LinePart from="¿A cual" to="¿A cuál" />
-    <LinePart from="¿A quien" to="¿A quien" />
+    <LinePart from="¿A quien" to="¿A quién" />
     <LinePart from="¿A como" to="¿A cómo" />
     <LinePart from="¿A cuanto" to="¿A cuánto" />
     <LinePart from="¿A cuanta" to="¿A cuánta" />
@@ -664,7 +663,6 @@
     <!-- Tilde diacrítica en oraciones interrogativas o exclamativas indirectas -->
     <LinePart from="el porque" to="el porqué" />
     <LinePart from="su porque" to="su porqué" />
-    <LinePart from="los porqués" to="los porqués" />
     <!-- aún -->
     <LinePart from="aun," to="aún," />
     <LinePart from="aun no" to="aún no" />

--- a/Dictionaries/swe_OCRFixReplaceList.xml
+++ b/Dictionaries/swe_OCRFixReplaceList.xml
@@ -470,7 +470,6 @@
   <EndLines />
   <RegularExpressions>
     <RegEx find="\b\|\b" replaceWith="I" />
-    <RegEx find="\bl\b" replaceWith="I" />
   </RegularExpressions>
   <RegularExpressionsIfSpelledCorrectly>
 
@@ -518,8 +517,6 @@
     <!-- leading l→I before 2+ lowercase chars -->
     <RegEx find="\bl([a-zåäöé]{2,})\b" spellCheck="I$1" replaceWith="I$1" />
 
-    <!-- standalone l → I (Roman numerals, list markers, ordinals) -->
-    <RegEx find="\bl\b" replaceWith="I" />
 
     <!-- ============================================================ -->
     <!-- SWEDISH GENITIVE                                             -->

--- a/tests/libuilogic/Ocr/ShippedOcrFixReplaceListsTests.cs
+++ b/tests/libuilogic/Ocr/ShippedOcrFixReplaceListsTests.cs
@@ -1,0 +1,181 @@
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace LibUiLogicTests.Ocr;
+
+/// <summary>
+/// Guards the shipped <c>Dictionaries/&lt;lang&gt;_OCRFixReplaceList.xml</c> files. The loaders
+/// drop bad entries silently - an invalid regex, a "$1" without a capture group, a gated rule
+/// missing its spellCheck attribute, a from==to pair, or an entry shadowed by an earlier key all
+/// look like the fix "just doesn't work" at runtime. A 2026-08 audit found ~115 such entries,
+/// some of them years old; this test turns every one of those defect classes into a CI failure.
+/// </summary>
+public class ShippedOcrFixReplaceListsTests
+{
+    // The section names OcrFixReplaceList2/SpellCheckRegex read. Anything else in a shipped
+    // file is dead weight the loaders never look at.
+    private static readonly string[] PairSections =
+    {
+        "WholeWords", "PartialWordsAlways", "PartialWords", "PartialLines",
+        "PartialLinesAlways", "BeginLines", "EndLines", "WholeLines",
+    };
+
+    private static readonly string[] RegexSections =
+    {
+        "RegularExpressions", "RegularExpressionsIfSpelledCorrectly",
+    };
+
+    // PartialWords is loaded as a pair list where several readings of the same OCR artifact are
+    // by design (deu ships i->t and i->l); every other pair section is a first-wins dictionary.
+    private static readonly string[] MultiReadingSections = { "PartialWords" };
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(Directory.GetCurrentDirectory());
+        while (dir != null && !File.Exists(Path.Combine(dir.FullName, "SubtitleEdit.sln")))
+        {
+            dir = dir.Parent;
+        }
+
+        Assert.NotNull(dir);
+        return dir!.FullName;
+    }
+
+    private static string DictionariesFolder() => Path.Combine(FindRepoRoot(), "Dictionaries");
+
+    public static TheoryData<string> ReplaceListFiles()
+    {
+        var data = new TheoryData<string>();
+        foreach (var file in Directory.GetFiles(DictionariesFolder(), "*_OCRFixReplaceList.xml").OrderBy(f => f))
+        {
+            data.Add(Path.GetFileName(file));
+        }
+
+        return data;
+    }
+
+    [Fact]
+    public void ThereAreReplaceListsToCheck()
+    {
+        Assert.NotEmpty(Directory.GetFiles(DictionariesFolder(), "*_OCRFixReplaceList.xml"));
+    }
+
+    [Theory]
+    [MemberData(nameof(ReplaceListFiles))]
+    public void EveryEntryIsLoadableAndReachable(string fileName)
+    {
+        var root = XDocument.Load(Path.Combine(DictionariesFolder(), fileName)).Root;
+        Assert.NotNull(root);
+        Assert.Equal("OCRFixReplaceList", root!.Name.LocalName);
+
+        var knownSections = PairSections.Concat(RegexSections).ToHashSet();
+        foreach (var section in root.Elements())
+        {
+            Assert.True(knownSections.Contains(section.Name.LocalName),
+                $"{fileName}: unknown section <{section.Name.LocalName}> is never read by the loader");
+        }
+
+        // Duplicate same-name sections are legal (the loaders merge them), so all checks run on
+        // the merged per-name view - a duplicate hiding in a second section block must still fail.
+        foreach (var name in PairSections)
+        {
+            CheckPairSection(fileName, name, root.Elements(name).SelectMany(s => s.Elements()));
+        }
+
+        foreach (var name in RegexSections)
+        {
+            CheckRegexSection(fileName, name, root.Elements(name).SelectMany(s => s.Elements()));
+        }
+    }
+
+    private static void CheckPairSection(string fileName, string sectionName, IEnumerable<XElement> items)
+    {
+        var seenPairs = new HashSet<(string From, string To)>();
+        var seenKeys = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var item in items)
+        {
+            var where = $"{fileName} <{sectionName}>";
+            var from = item.Attribute("from")?.Value;
+            var to = item.Attribute("to")?.Value;
+            Assert.True(from != null && to != null, $"{where}: entry without from/to is skipped: {item}");
+            Assert.False(from!.Length == 0, $"{where}: empty from: {item}");
+            Assert.False(from == to, $"{where}: from==to '{from}' is a no-op the loader skips");
+            Assert.True(seenPairs.Add((from, to!)),
+                $"{where}: exact duplicate '{from}' -> '{to}'");
+
+            if (!MultiReadingSections.Contains(sectionName))
+            {
+                Assert.False(seenKeys.TryGetValue(from, out var firstTo),
+                    $"{where}: '{from}' -> '{to}' is dead, first-wins already maps it to '{seenKeys.GetValueOrDefault(from)}'");
+                seenKeys[from] = to!;
+            }
+        }
+    }
+
+    private static void CheckRegexSection(string fileName, string sectionName, IEnumerable<XElement> items)
+    {
+        var gated = sectionName == "RegularExpressionsIfSpelledCorrectly";
+        var seenFinds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var item in items)
+        {
+            var where = $"{fileName} <{sectionName}>";
+            var find = item.Attribute("find")?.Value;
+            var replaceWith = item.Attribute("replaceWith")?.Value;
+            var spellCheck = item.Attribute("spellCheck")?.Value;
+            Assert.False(string.IsNullOrEmpty(find), $"{where}: entry without find is skipped: {item}");
+            Assert.NotNull(replaceWith);
+            if (gated)
+            {
+                // SpellCheckRegex.LoadRegExNodes requires all three attributes and skips the
+                // rule silently otherwise - 11 shipped rules were dead this way for months.
+                Assert.False(string.IsNullOrEmpty(spellCheck),
+                    $"{where}: gated rule without spellCheck is silently skipped: {item}");
+            }
+
+            Regex regex;
+            try
+            {
+                regex = new Regex(find!);
+            }
+            catch (ArgumentException e)
+            {
+                Assert.Fail($"{where}: find='{find}' does not compile and is silently dropped: {e.Message}");
+                return;
+            }
+
+            // An unmatched $N in a .NET replacement is emitted literally, so a bad group
+            // reference corrupts the subtitle text instead of fixing it.
+            var groups = regex.GetGroupNumbers();
+            foreach (var (attrName, value) in new[] { ("replaceWith", replaceWith), ("spellCheck", spellCheck) })
+            {
+                if (value == null)
+                {
+                    continue;
+                }
+
+                foreach (Match reference in Regex.Matches(value.Replace("$$", string.Empty), @"\$(\d+)"))
+                {
+                    var n = int.Parse(reference.Groups[1].Value);
+                    Assert.True(groups.Contains(n),
+                        $"{where}: {attrName}='{value}' references ${n} but find='{find}' has no group {n}");
+                }
+            }
+
+            if (gated)
+            {
+                // Gated rules are a list, so several fixes for the same find are legal (each
+                // candidate is dictionary-checked) - only an identical rule is a defect.
+                var signature = find + "\n" + spellCheck + "\n" + replaceWith + "\n"
+                    + item.Attribute("replaceAllFrom")?.Value + "\n" + item.Attribute("replaceAllTo")?.Value;
+                Assert.True(seenFinds.Add(signature),
+                    $"{where}: identical duplicate rule find='{find}' is applied twice");
+            }
+            else
+            {
+                // RegularExpressions is a first-wins dictionary - a repeated find is dead.
+                Assert.True(seenFinds.Add(find!),
+                    $"{where}: duplicate find='{find}' - the later entry is dead");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Full audit of the 19 shipped `Dictionaries/*_OCRFixReplaceList.xml` files (structural pass + .NET regex validation of every `find` pattern and `$N` group reference). ~115 defective entries fixed across 11 files.

## Actively harmful rules fixed
- **hrv**: `find="iscj?edi" replaceWith="$1scijedi"` had no capture group — .NET emits unmatched `$N` literally, so matching lines got `$1scijedi` in the subtitle text. Now `([iI])scj?edi`.
- **spa**: `¿Con cuanta → ¿Con cuántas` (spurious plural) shadowed the correct singular entry; the wrong one is removed.
- **hrb**: `casu → satu` replaced with `casu → čašu` (consistent with the list's own `cašu → čašu`).
- **swe**: ungated `\bl\b → I` (live since 2020) removed — it turned the liter symbol ("2 l mjölk") into "2 I mjölk".
- **deu**: entries that corrupted correct German words removed (gernhaben, ranzukommen, runterspült, wiederhaben, Blutgetränkte, immerwährende are all valid words).

## Silently dead rules repaired or removed
- **hrv**: `\([lL])j?ečen` and `\([pP])otc` never compiled ("too many )'s") and were silently dropped by `IsValidRegex`; now `([lL])…` / `([pP])…` and active.
- **dan**: `\b\l\b` (invalid `\l` escape, dead since 2020) removed rather than "fixed" — lone l is the liter symbol in Danish.
- 11 `<RegularExpressionsIfSpelledCorrectly>` entries were missing the required `spellCheck` attribute and silently skipped by the loader: the **eng** standalone `\bl\b → I` now has `spellCheck="I"` and is live (gated on the dictionary); the dead copies in dan/fra/nld/nob/nor/swe are removed ("I" is not a dictionary word there, lone "l" is the liter symbol). The 4 fra elision rules were double-dead (their char class was two straight apostrophes replacing with a straight apostrophe — a no-op) and redundant with the hardcoded `’ → '` normalization.

## Hygiene
- 24 no-op `from==to` entries deleted (the loader skips them — SE4's loader did too, so they were never functional). Three spa no-ops were restored to their evident intent instead (`¿a quien → ¿a quién`, `¿A quien → ¿A quién`, lowercase `¿es que no me has escuchado? → ¡¿…?!` mirroring the uppercase entry).
- ~30 exact duplicates and ~10 dead same-key conflicts (first-wins) removed, mostly hrv.
- Chains flattened so a single fix pass lands on the final form: dan `ﬁeme → fjerne`, deu `Spell/Spells → Spaß`, `weillt → weißt`, `filr'ne → für 'ne`, hrv `đta → što`, `jle → je l'`, `maiopre → malo prije`, `obiastima → područjima`.

## Verification
- All `find` patterns now compile under .NET and every `$N` reference in `replaceWith`/`spellCheck` has a matching group (checked with a scratch .NET tool).
- Structural re-audit is clean: no remaining no-ops, duplicates, dead conflicts, or attribute-incomplete gated rules.
- `dotnet test tests/libuilogic --filter FullyQualifiedName~Ocr`: 293 passed.
- `dotnet test tests/UI --filter FullyQualifiedName~Ocr.FixEngine`: 90 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)