### PR TITLE
Fix four bugs found reviewing the last day's commits

### DIFF
--- a/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
+++ b/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
@@ -2300,7 +2300,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                 string s = line.Trim().ToLowerInvariant();
                 if (s.StartsWith("format:", StringComparison.Ordinal))
                 {
-                    if (line.Length > 10)
+                    if (s.Length > 10)
                     {
                         // cut the trimmed line - leading whitespace shifted every field name
                         var format = s.Substring(8).Split(',');

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -1296,6 +1296,23 @@ public partial class SubtitleLineViewModel : ObservableObject
             }
         }
 
+        // Teletext page width - applies to EBU/teletext-sourced subtitles regardless of the
+        // general "too long" setting, matching the teletext branch in HasTextError.
+        if (UseTeletextLineLength)
+        {
+            var maxCharacters = Text.Contains("<font color=", StringComparison.OrdinalIgnoreCase)
+                ? TeletextMaxCharactersWithColor
+                : TeletextMaxCharacters;
+
+            foreach (var line in GetStrippedLines())
+            {
+                if (line.Length > maxCharacters)
+                {
+                    errors.Add(new LineError(LineErrorType.LineTooLong, string.Format(l.DetailXGreaterThanY, line.Length, maxCharacters)));
+                }
+            }
+        }
+
         var minGap = general.MinimumBetweenLines.GetMilliseconds();
         if (prev != null)
         {

--- a/src/ui/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesViewModel.cs
+++ b/src/ui/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesViewModel.cs
@@ -717,6 +717,14 @@ public partial class BeautifyTimeCodesViewModel : ObservableObject, IDisposable
         _extractCancellation = null;
         IsExtractingTimeCodes = false;
 
+        // A completed run decoded the whole video, so its last frame time is the real duration -
+        // this keeps completed extractions usable when ffmpeg reported no duration up front
+        // (IsUsableFor rejects any list it cannot check against a known length).
+        if (!cancelled && _videoDurationSeconds <= 0 && extracted.Count > 0)
+        {
+            _videoDurationSeconds = extracted[extracted.Count - 1];
+        }
+
         // A short list is worse than none: the beautifier maps frame number to list index, so cues
         // past the end of a partial extraction would snap to the wrong frames rather than fall
         // back to n/fps. Cancelling mid-way lands here too.

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextPostProcessor.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextPostProcessor.cs
@@ -98,6 +98,10 @@ namespace Nikse.SubtitleEdit.Features.Video.SpeechToText
             var subtitle = new Subtitle();
             QualityReport = new SpeechToTextQualityReport();
 
+            // Input line number (1-based) of the last paragraph added to the output, so the
+            // "repeated" detail can name the line actually duplicated - which is not index
+            // when non-speech or repeated lines were dropped in between.
+            var lastKeptNumber = 0;
             for (var index = 0; index < input.Paragraphs.Count; index++)
             {
                 var paragraph = input.Paragraphs[index];
@@ -113,7 +117,7 @@ namespace Nikse.SubtitleEdit.Features.Video.SpeechToText
                 var lastKept = subtitle.GetParagraphOrDefault(subtitle.Paragraphs.Count - 1);
                 if (usePostProcessing && RemoveRepeatedLines && lastKept != null && SpeechToTextQualityReport.IsRepeatOf(paragraph.Text, lastKept.Text))
                 {
-                    QualityReport.Removed.Add(SpeechToTextQualityReport.MakeIssue(SpeechToTextQualityIssueType.Repeated, paragraph, index + 1, $"= #{index}"));
+                    QualityReport.Removed.Add(SpeechToTextQualityReport.MakeIssue(SpeechToTextQualityIssueType.Repeated, paragraph, index + 1, $"= #{lastKeptNumber}"));
                     continue;
                 }
 
@@ -155,6 +159,7 @@ namespace Nikse.SubtitleEdit.Features.Video.SpeechToText
                 }
 
                 subtitle.Paragraphs.Add(paragraph);
+                lastKeptNumber = index + 1;
             }
 
             if (usePostProcessing && engine == Engine.Whisper && TwoLetterLanguageCode == "da")

--- a/src/ui/Logic/Media/TimeCodesGenerator.cs
+++ b/src/ui/Logic/Media/TimeCodesGenerator.cs
@@ -77,6 +77,13 @@ public static class TimeCodesGenerator
         try
         {
             await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+
+            // ffmpeg dying mid-decode (corrupt file, unsupported codec) still exits "normally"
+            // here, leaving a partial list that looks complete when the duration is unknown.
+            if (process.ExitCode != 0)
+            {
+                throw new Exception($"ffmpeg exited with code {process.ExitCode} while extracting time codes");
+            }
         }
         catch (OperationCanceledException)
         {

--- a/src/ui/Logic/Media/TimeCodesHelper.cs
+++ b/src/ui/Logic/Media/TimeCodesHelper.cs
@@ -123,7 +123,10 @@ public static class TimeCodesHelper
 
         if (durationSeconds <= 0)
         {
-            return true; // unknown length - nothing to check against
+            // Unknown length - a partial list cannot be told apart from a complete one, and
+            // accepting a partial one snaps every cue to its few entries. Callers that know
+            // the extraction ran to completion can pass the last frame time as the duration.
+            return false;
         }
 
         var covered = timeCodes[timeCodes.Count - 1];

--- a/tests/UI/Features/Main/SubtitleLineViewModelHasErrorsTests.cs
+++ b/tests/UI/Features/Main/SubtitleLineViewModelHasErrorsTests.cs
@@ -172,6 +172,51 @@ public class SubtitleLineViewModelHasErrorsTests
         }
     }
 
+    /// <summary>
+    /// The teletext page-width rule (EBU-sourced subtitles) reddens the grid via HasErrors
+    /// regardless of the general "too long" setting - the error list must report the same
+    /// lines, or they silently vanish from "List errors" and batch convert's error list.
+    /// </summary>
+    [AvaloniaFact]
+    public void HasErrors_MatchesGetErrors_WithTeletextLineLengthOn()
+    {
+        var originalSettings = Se.Settings;
+        var originalTeletext = SubtitleLineViewModel.UseTeletextLineLength;
+        try
+        {
+            Se.Settings = new Se();
+            var general = Se.Settings.General;
+            general.ColorDurationTooShort = false;
+            general.ColorDurationTooLong = false;
+            general.ColorTextTooLong = false;
+            general.ColorTextTooWide = false;
+            general.ColorTextTooManyLines = false;
+            general.ColorCharactersPerSecond = false;
+            general.ColorWordsPerMinute = false;
+            general.ColorTimeCodeOverlap = false;
+            general.ColorGapTooShort = false;
+            SubtitleLineViewModel.UseTeletextLineLength = true;
+
+            var lines = new List<SubtitleLineViewModel>
+            {
+                Line("Fits on a teletext row.", 1000, 3000),                              // 23 chars, clean
+                Line("This line is longer than the thirty-seven characters a teletext row holds.", 4000, 8000),
+                Line("<font color=\"#ffff00\">Exactly thirty-seven characters here!</font>", 9000, 12000), // 37 > 36 with color
+            };
+
+            var withErrors = AssertAgrees(lines);
+            Assert.Equal(2, withErrors);
+
+            var errors = lines[1].GetErrorList(lines[0], lines[2]);
+            Assert.Contains(errors, e => e.Type == Nikse.SubtitleEdit.Features.Shared.ErrorList.LineErrorType.LineTooLong);
+        }
+        finally
+        {
+            Se.Settings = originalSettings;
+            SubtitleLineViewModel.UseTeletextLineLength = originalTeletext;
+        }
+    }
+
     /// <summary>The pixel width column reads the same memo, so it must follow the text too.</summary>
     [AvaloniaFact]
     public void PixelWidth_FollowsTextChange()

--- a/tests/UI/Features/Video/SpeechToText/SpeechToTextPostProcessorTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/SpeechToTextPostProcessorTests.cs
@@ -157,6 +157,24 @@ public class SpeechToTextQualityReportTests
     }
 
     [Fact]
+    public void Fix_RepeatedDetail_NamesTheLineActuallyDuplicated()
+    {
+        // Line 2 ("[Music]") is removed first, so line 3 repeats line 1 - the detail must
+        // say "= #1", not point at the removed line in between.
+        var subtitle = Make(
+            ("Hello there.", 0, 1500),
+            ("[Music]", 2000, 3500),
+            ("Hello there.", 4000, 5500));
+
+        var pp = new SpeechToTextPostProcessor("en") { RemoveNonSpeechLines = true, RemoveRepeatedLines = true };
+        pp.Fix(SpeechToTextPostProcessor.Engine.Whisper, subtitle, true, false, false, false, false, false, false, Avalonia.Media.Colors.Red);
+
+        var repeated = pp.QualityReport.Removed.Single(i => i.Type == SpeechToTextQualityIssueType.Repeated);
+        Assert.Equal(3, repeated.Number);
+        Assert.Equal("= #1", repeated.Detail);
+    }
+
+    [Fact]
     public void Fix_KeepsLinesButReportsThem_WhenDisabled()
     {
         var subtitle = Make(("Hello there.", 0, 1500), ("[Music]", 2000, 3500), ("Bye.", 4000, 5500), ("Bye.", 6000, 7500));

--- a/tests/UI/Logic/Media/TimeCodesTests.cs
+++ b/tests/UI/Logic/Media/TimeCodesTests.cs
@@ -68,6 +68,21 @@ public class TimeCodesTests
         Assert.False(TimeCodesHelper.IsUsableFor(new List<double>(), 10));
     }
 
+    [Fact]
+    public void IsUsableFor_RejectsAnyListWhenTheDurationIsUnknown()
+    {
+        // With no duration to check against, a cancelled 3-frame extraction is
+        // indistinguishable from a complete one - it must not be trusted (callers that know
+        // the run completed pass the last frame time as the duration instead).
+        var fullList = Enumerable.Range(0, 250).Select(n => n / 25.0).ToList();
+        Assert.False(TimeCodesHelper.IsUsableFor(fullList.Take(3).ToList(), 0));
+        Assert.False(TimeCodesHelper.IsUsableFor(fullList, 0));
+        Assert.False(TimeCodesHelper.IsUsableFor(fullList, -1));
+
+        // A completed run can vouch for itself: its own last frame time is the duration.
+        Assert.True(TimeCodesHelper.IsUsableFor(fullList, fullList[fullList.Count - 1]));
+    }
+
     /// <summary>
     /// The point of the whole feature: on material whose real frames are not on an n/fps grid,
     /// beautifying with the video's own time codes must land cues on real frames, where nominal

--- a/tests/libse/Core/BugHunt20260824Test.cs
+++ b/tests/libse/Core/BugHunt20260824Test.cs
@@ -1,0 +1,23 @@
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+
+namespace LibSETests.Core;
+
+public class BugHunt20260824Test
+{
+    [Fact]
+    public void AssaCheckForErrors_PaddedFormatLineDoesNotThrow()
+    {
+        // "Format:" plus whitespace trims to 7 chars while the raw line is longer than the
+        // guard's 10 - Substring(8) on the trimmed string must not be reached.
+        var header = "[V4+ Styles]\nFormat:      \nStyle: Default,Arial,20,&H00FFFFFF,&H0300FFFF,&H00000000,&H02000000,0,0,0,0,100,100,0,0,1,2,2,2,10,10,10,1";
+        var result = AdvancedSubStationAlpha.CheckForErrors(header);
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public void AssaCheckForErrors_PaddedFormatLineWithFieldsStillParses()
+    {
+        var header = "[V4+ Styles]\n   Format: Name, Fontname, Fontsize   \nStyle: ,Arial,20";
+        Assert.Contains("'Name' is empty", AdvancedSubStationAlpha.CheckForErrors(header));
+    }
+}


### PR DESCRIPTION
A bug hunt over the last 24 hours of merged commits found four issues; all are fixed with regression tests.

## 1. ASSA `CheckForErrors` crash on a padded `Format:` line
The length guard checked the raw line (`line.Length > 10`) while `Substring(8)` indexed the trimmed one, so a header line like `"Format:      "` threw `ArgumentOutOfRangeException` — in the method whose whole job is validating malformed headers. The guard now checks the trimmed string.

## 2. Teletext line-length errors missing from both error-list dialogs
`GetErrorList` (feeding "List errors" and batch convert's error list) never got the teletext page-width branch that `HasTextError` uses for the red grid highlight and error navigation. On EBU-sourced subtitles, a line over 37 characters (36 with color) was reddened and reachable via go-to-next-error, but completely absent from the dialogs, their summary cards, and counts. The branch is now mirrored, reporting as `LineTooLong` with the teletext threshold in the detail.

## 3. Beautify time codes: partial extractions accepted when the video duration is unknown
`IsUsableFor` returned `true` for any 2-entry list when `durationSeconds <= 0` (ffmpeg reported `Duration: N/A`), so a cancelled extraction was saved to the cache and every cue snapped to its few frames — silently, and persistently across sessions. Three-part fix:
- `IsUsableFor` now rejects lists it cannot verify against a known duration.
- `ExtractAsync` now throws when ffmpeg exits nonzero, so a mid-decode crash no longer masquerades as a completed run.
- A completed run (not cancelled, no error) vouches for itself: its last frame time *is* the duration, so legitimate extractions on N/A-duration videos still work.

## 4. STT quality report: wrong line reference in "repeated" removals
The detail text used the removed paragraph's own input index instead of the kept line it duplicated, so with `["Hello there", "[Music]", "Hello there"]` and both removals on, the report said `= #2` (the removed music line) instead of `= #1`. Cosmetic only — removal behavior was already correct.

Reviewed and found clean: perf-hunt rounds 14–15 binary/format parsers, Netflix checks, the three prior bug-sweep commits, the CharUtils renames, the error-list/batch-error-list UI, and the OpenRouter STT model matching.

All tests pass: libse 1465, UI 3503 (incl. 4 new), libuilogic 504.

🤖 Generated with [Claude Code](https://claude.com/claude-code)