### PR TITLE
Add gated OCR accent and l/I rules for Spanish, Portuguese, Italian

### DIFF
--- a/Dictionaries/ita_OCRFixReplaceList.xml
+++ b/Dictionaries/ita_OCRFixReplaceList.xml
@@ -83,5 +83,34 @@
     <!-- ExceIIencies -> Excellencies). Words of two letters (AI) are never        -->
     <!-- touched, and real words (MacIntosh) are kept by the spell check gate.     -->
     <RegEx find="\b([A-ZÀÈÉÌÒÓÙa-zàèéìòóù](?=[a-zàèéìòóùI]*I)[a-zàèéìòóùI]{2,})\b" replaceAllFrom="I" replaceAllTo="l" spellCheck="$1" replaceWith="$1" />
+
+    <!-- ============================================================ -->
+    <!-- MAIUSCOLE: l minuscola letta al posto di I                   -->
+    <!-- ============================================================ -->
+
+    <!-- [MUSlCA] in [MUSICA] : l in I dentro parentesi quadre in maiuscolo -->
+    <RegEx find="\[([A-ZÀÈÉÌÒÓÙ ]*)l([A-ZÀÈÉÌÒÓÙ ]*)\]" spellCheck="[$1I$2]" replaceWith="[$1I$2]" />
+    <RegEx find="\[([A-ZÀÈÉÌÒÓÙl]+)\]" replaceAllFrom="l" replaceAllTo="I" spellCheck="$1" replaceWith="[$1]" />
+
+    <!-- FlNE in FINE : l tra maiuscole -->
+    <RegEx find="\b([A-ZÀÈÉÌÒÓÙ]+)l([A-ZÀÈÉÌÒÓÙ]+)\b" spellCheck="$1I$2" replaceWith="$1I$2" />
+    <RegEx find="\b([A-ZÀÈÉÌÒÓÙ]+)l\b" spellCheck="$1I" replaceWith="$1I" />
+    <RegEx find="\bl([A-ZÀÈÉÌÒÓÙ]+)\b" spellCheck="I$1" replaceWith="I$1" />
+
+    <!-- Iavorare in lavorare : I iniziale letta al posto di l davanti a minuscole -->
+    <RegEx find="\bI([a-zàèéìòóù]{2,})\b" spellCheck="l$1" replaceWith="l$1" />
+
+    <!-- ============================================================ -->
+    <!-- ACCENTI PERSI SULLA VOCALE FINALE                            -->
+    <!-- La regola agisce solo se la parola senza accento NON è nel   -->
+    <!-- dizionario e la forma accentata SÌ (citta in città,          -->
+    <!-- perche in perché). I nomi propri non vengono toccati.        -->
+    <!-- ============================================================ -->
+    <RegEx find="\b([a-zàèéìòóù]{2,})a\b" spellCheck="$1à" replaceWith="$1à" />
+    <RegEx find="\b([a-zàèéìòóù]{2,})e\b" spellCheck="$1é" replaceWith="$1é" />
+    <RegEx find="\b([a-zàèéìòóù]{2,})e\b" spellCheck="$1è" replaceWith="$1è" />
+    <RegEx find="\b([a-zàèéìòóù]{2,})i\b" spellCheck="$1ì" replaceWith="$1ì" />
+    <RegEx find="\b([a-zàèéìòóù]{2,})o\b" spellCheck="$1ò" replaceWith="$1ò" />
+    <RegEx find="\b([a-zàèéìòóù]{2,})u\b" spellCheck="$1ù" replaceWith="$1ù" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/por_OCRFixReplaceList.xml
+++ b/Dictionaries/por_OCRFixReplaceList.xml
@@ -549,5 +549,44 @@
     <!-- ExceIIencies -> Excellencies). Words of two letters (AI) are never        -->
     <!-- touched, and real words (MacIntosh) are kept by the spell check gate.     -->
     <RegEx find="\b([A-ZÀÁÂÃÇÉÊÍÓÔÕÚa-zàáâãçéêíóôõú](?=[a-zàáâãçéêíóôõúI]*I)[a-zàáâãçéêíóôõúI]{2,})\b" replaceAllFrom="I" replaceAllTo="l" spellCheck="$1" replaceWith="$1" />
+
+    <!-- ============================================================ -->
+    <!-- MAIÚSCULAS: l minúsculo lido em vez de I                     -->
+    <!-- ============================================================ -->
+
+    <!-- [GRlTOS] para [GRITOS] : l para I dentro de colchetes em maiúsculas -->
+    <RegEx find="\[([A-ZÀÁÂÃÇÉÊÍÓÔÕÚ ]*)l([A-ZÀÁÂÃÇÉÊÍÓÔÕÚ ]*)\]" spellCheck="[$1I$2]" replaceWith="[$1I$2]" />
+    <RegEx find="\[([A-ZÀÁÂÃÇÉÊÍÓÔÕÚl]+)\]" replaceAllFrom="l" replaceAllTo="I" spellCheck="$1" replaceWith="[$1]" />
+
+    <!-- SlM para SIM : l entre maiúsculas -->
+    <RegEx find="\b([A-ZÀÁÂÃÇÉÊÍÓÔÕÚ]+)l([A-ZÀÁÂÃÇÉÊÍÓÔÕÚ]+)\b" spellCheck="$1I$2" replaceWith="$1I$2" />
+    <RegEx find="\b([A-ZÀÁÂÃÇÉÊÍÓÔÕÚ]+)l\b" spellCheck="$1I" replaceWith="$1I" />
+    <RegEx find="\bl([A-ZÀÁÂÃÇÉÊÍÓÔÕÚ]+)\b" spellCheck="I$1" replaceWith="I$1" />
+
+    <!-- Iavar para lavar : I inicial lido em vez de l antes de minúsculas -->
+    <RegEx find="\bI([a-zàáâãçéêíóôõú]{2,})\b" spellCheck="l$1" replaceWith="l$1" />
+
+    <!-- ============================================================ -->
+    <!-- ACENTOS PERDIDOS NO FIM DA PALAVRA                           -->
+    <!-- A regra só atua se a palavra sem acento NÃO está no          -->
+    <!-- dicionário e a forma acentuada SIM (nao para não).           -->
+    <!-- Só minúsculas: nomes próprios não são tocados.               -->
+    <!-- ============================================================ -->
+    <RegEx find="\b([a-zàáâãçéêíóôõú]+)ao\b" spellCheck="$1ão" replaceWith="$1ão" />
+    <RegEx find="\b([a-zàáâãçéêíóôõú]+)aos\b" spellCheck="$1ãos" replaceWith="$1ãos" />
+    <RegEx find="\b([a-zàáâãçéêíóôõú]+)oes\b" spellCheck="$1ões" replaceWith="$1ões" />
+    <!-- -cao é tratado sem condições pela regra \Bcao\b em RegularExpressions -->
+    <RegEx find="\b([a-zàáâãçéêíóôõú]{2,})coes\b" spellCheck="$1ções" replaceWith="$1ções" />
+    <RegEx find="\b([a-zàáâãçéêíóôõú]{2,})es\b" spellCheck="$1ês" replaceWith="$1ês" />
+    <RegEx find="\b([a-zàáâãçéêíóôõú]{2,})e\b" spellCheck="$1é" replaceWith="$1é" />
+    <RegEx find="\b([a-zàáâãçéêíóôõú]{2,})e\b" spellCheck="$1ê" replaceWith="$1ê" />
+    <RegEx find="\b([a-zàáâãçéêíóôõú]+)a\b" spellCheck="$1á" replaceWith="$1á" />
+    <RegEx find="\b([a-zàáâãçéêíóôõú]+)o\b" spellCheck="$1ó" replaceWith="$1ó" />
+    <RegEx find="\b([a-zàáâãçéêíóôõú]+)o\b" spellCheck="$1ô" replaceWith="$1ô" />
+    <RegEx find="\b([a-zàáâãçéêíóôõú]+)avel\b" spellCheck="$1ável" replaceWith="$1ável" />
+    <RegEx find="\b([a-zàáâãçéêíóôõú]+)ivel\b" spellCheck="$1ível" replaceWith="$1ível" />
+    <RegEx find="\b([a-zàáâãçéêíóôõú]+)ario(s?)\b" spellCheck="$1ário$2" replaceWith="$1ário$2" />
+    <RegEx find="\b([a-zàáâãçéêíóôõú]+)encia(s?)\b" spellCheck="$1ência$2" replaceWith="$1ência$2" />
+    <RegEx find="\b([a-zàáâãçéêíóôõú]+)ancia(s?)\b" spellCheck="$1ância$2" replaceWith="$1ância$2" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/spa_OCRFixReplaceList.xml
+++ b/Dictionaries/spa_OCRFixReplaceList.xml
@@ -978,5 +978,39 @@
     <!-- ExceIIencies -> Excellencies). Words of two letters (AI) are never        -->
     <!-- touched, and real words (MacIntosh) are kept by the spell check gate.     -->
     <RegEx find="\b([A-ZÁÉÍÓÚÑÜa-záéíóúñü](?=[a-záéíóúñüI]*I)[a-záéíóúñüI]{2,})\b" replaceAllFrom="I" replaceAllTo="l" spellCheck="$1" replaceWith="$1" />
+
+    <!-- ============================================================ -->
+    <!-- MAYÚSCULAS: l minúscula leída en vez de I                    -->
+    <!-- ============================================================ -->
+
+    <!-- [GRlTOS] a [GRITOS] : l a I dentro de corchetes en mayúsculas -->
+    <RegEx find="\[([A-ZÁÉÍÓÚÑÜ ]*)l([A-ZÁÉÍÓÚÑÜ ]*)\]" spellCheck="[$1I$2]" replaceWith="[$1I$2]" />
+    <RegEx find="\[([A-ZÁÉÍÓÚÑÜl]+)\]" replaceAllFrom="l" replaceAllTo="I" spellCheck="$1" replaceWith="[$1]" />
+
+    <!-- SlN a SIN : l entre mayúsculas -->
+    <RegEx find="\b([A-ZÁÉÍÓÚÑÜ]+)l([A-ZÁÉÍÓÚÑÜ]+)\b" spellCheck="$1I$2" replaceWith="$1I$2" />
+    <RegEx find="\b([A-ZÁÉÍÓÚÑÜ]+)l\b" spellCheck="$1I" replaceWith="$1I" />
+    <RegEx find="\bl([A-ZÁÉÍÓÚÑÜ]+)\b" spellCheck="I$1" replaceWith="I$1" />
+
+    <!-- Iavar a lavar : I inicial leída en vez de l ante minúsculas -->
+    <RegEx find="\bI([a-záéíóúñü]{2,})\b" spellCheck="l$1" replaceWith="l$1" />
+
+    <!-- ============================================================ -->
+    <!-- TILDES PERDIDAS EN LA ÚLTIMA SÍLABA (palabras agudas)        -->
+    <!-- La regla solo actúa si la palabra sin tilde NO está en el    -->
+    <!-- diccionario y la forma con tilde SÍ (cancion a canción).     -->
+    <!-- Solo minúsculas: los nombres propios (Mia, Sofia) no se      -->
+    <!-- tocan.                                                       -->
+    <!-- ============================================================ -->
+    <RegEx find="\b([a-záéíóúñü]+)ia\b" spellCheck="$1ía" replaceWith="$1ía" />
+    <RegEx find="\b([a-záéíóúñü]+)ias\b" spellCheck="$1ías" replaceWith="$1ías" />
+    <RegEx find="\b([a-záéíóúñü]{2,})on\b" spellCheck="$1ón" replaceWith="$1ón" />
+    <RegEx find="\b([a-záéíóúñü]{2,})an\b" spellCheck="$1án" replaceWith="$1án" />
+    <RegEx find="\b([a-záéíóúñü]{2,})in\b" spellCheck="$1ín" replaceWith="$1ín" />
+    <RegEx find="\b([a-záéíóúñü]{2,})es\b" spellCheck="$1és" replaceWith="$1és" />
+    <RegEx find="\b([a-záéíóúñü]{2,})as\b" spellCheck="$1ás" replaceWith="$1ás" />
+    <RegEx find="\b([a-záéíóúñü]{2,})i\b" spellCheck="$1í" replaceWith="$1í" />
+    <RegEx find="\b([a-záéíóúñü]{2,})o\b" spellCheck="$1ó" replaceWith="$1ó" />
+    <RegEx find="\b([a-záéíóúñü]{2,})e\b" spellCheck="$1é" replaceWith="$1é" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixItalianAccentAndCapsTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixItalianAccentAndCapsTests.cs
@@ -1,0 +1,161 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
+using Nikse.SubtitleEdit.Features.SpellCheck;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
+
+namespace UITests.Features.Ocr.FixEngine;
+
+// Gated Italian rules: lost accents on the final vowel (citta -> città, perche -> perché,
+// caffe -> caffè - both accents are tried, the dictionary picks the right one) and l/I
+// confusion in all-caps captions. A rule is only applied when the misread form is NOT in the
+// dictionary and the fixed form IS; lowercase-only classes keep proper names untouched.
+// Runs against the shipped Dictionaries/ita_OCRFixReplaceList.xml, not a copy of its rules.
+public class OcrFixItalianAccentAndCapsTests : IDisposable
+{
+    private readonly Func<string> _originalSpellCheckDictionariesFolder;
+    private readonly string _tempDictionariesFolder;
+    private readonly bool _originalUseHardcodedRules;
+
+    public OcrFixItalianAccentAndCapsTests()
+    {
+        _originalSpellCheckDictionariesFolder = SpellCheckConfig.DictionariesFolder;
+
+        // The hardcoded rules fix some all-caps l/I words on their own; turn them off so these
+        // tests prove the XML rules, not the hardcoded fallback.
+        _originalUseHardcodedRules = Configuration.Settings.Tools.OcrFixUseHardcodedRules;
+        Configuration.Settings.Tools.OcrFixUseHardcodedRules = false;
+
+        _tempDictionariesFolder = Path.Combine(
+            Path.GetTempPath(),
+            "SeOcrFixItalianAccentTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDictionariesFolder);
+
+        File.Copy(
+            Path.Combine(FindRepoRoot(), "Dictionaries", "ita_OCRFixReplaceList.xml"),
+            Path.Combine(_tempDictionariesFolder, "ita_OCRFixReplaceList.xml"));
+
+        SpellCheckConfig.DictionariesFolder = () => _tempDictionariesFolder;
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "Dictionaries")))
+        {
+            dir = dir.Parent;
+        }
+
+        return dir?.FullName ?? throw new DirectoryNotFoundException("Could not find repo root");
+    }
+
+    [Theory]
+    [InlineData("La citta e bella.", "La città e bella.")]
+    [InlineData("Non so perche.", "Non so perché.")]
+    [InlineData("Si fa cosi.", "Si fa così.")]
+    [InlineData("Ne voglio di piu.", "Ne voglio di più.")]
+    [InlineData("Prendo un caffe.", "Prendo un caffè.")]
+    [InlineData("Va bene, pero non ora.", "Va bene, però non ora.")]
+    public void FixOcrErrors_LostFinalVowelAccent_IsRestored(string text, string expected)
+    {
+        var engine = CreateEngine();
+
+        var result = engine.FixOcrErrors(0, text, doTryToGuessUnknownWords: false);
+
+        Assert.Equal(expected, result.GetText());
+    }
+
+    [Theory]
+    [InlineData("[MUSlCA]", "[MUSICA]")]
+    [InlineData("FlNE", "FINE")]
+    public void FixOcrErrors_MisreadLAndI_IsFixed(string text, string expected)
+    {
+        var engine = CreateEngine();
+
+        var result = engine.FixOcrErrors(0, text, doTryToGuessUnknownWords: false);
+
+        Assert.Equal(expected, result.GetText());
+    }
+
+    [Theory]
+    [InlineData("Vieni anche tu Zzyzx.")] // correct -e word is in the dictionary
+    [InlineData("Maria canta Zzyzx.")] // capitalized name is never accented
+    public void FixOcrErrors_CorrectWordsAndNames_AreLeftAlone(string text)
+    {
+        // "Zzyzx" keeps the line from being spelled OK, so every gated rule really runs.
+        var engine = CreateEngine();
+
+        var result = engine.FixOcrErrors(0, text, doTryToGuessUnknownWords: false);
+
+        Assert.Equal(text, result.GetText());
+    }
+
+    [Fact]
+    public void FixOcrErrors_WithoutADictionary_AccentRulesDoNothing()
+    {
+        var engine = CreateEngine(new EmptySpellChecker());
+
+        var result = engine.FixOcrErrors(0, "La citta Zzyzx.", doTryToGuessUnknownWords: false);
+
+        Assert.Equal("La citta Zzyzx.", result.GetText());
+    }
+
+    private static IOcrFixEngine CreateEngine(ISpellChecker? spellChecker = null)
+    {
+        IOcrFixEngine engine = new OcrFixEngine(spellChecker ?? new FakeItalianSpellChecker());
+        engine.Initialize(new Subtitle(), "ita", new SpellCheckDictionaryDisplay());
+        return engine;
+    }
+
+    private sealed class FakeItalianSpellChecker : ISpellChecker
+    {
+        private static readonly HashSet<string> Words = new(StringComparer.Ordinal)
+        {
+            "la", "città", "e", "bella", "non", "so", "perché", "si", "fa", "così",
+            "ne", "voglio", "di", "più", "prendo", "un", "caffè", "va", "bene", "però",
+            "ora", "musica", "fine", "vieni", "anche", "tu", "canta",
+        };
+
+        public bool Initialize(string dictionaryFile, string twoLetterLanguageCode) => true;
+
+        public bool IsWordCorrect(string word)
+        {
+            if (string.IsNullOrWhiteSpace(word))
+            {
+                return true;
+            }
+
+            // Like Hunspell, accept capitalized/all-caps forms of a lowercase dictionary word.
+            return Words.Contains(word) || Words.Contains(word.ToLowerInvariant());
+        }
+
+        public List<string> GetSuggestions(string word) => new();
+    }
+
+    // Stands in for "no Hunspell dictionary installed for the language".
+    private sealed class EmptySpellChecker : ISpellChecker
+    {
+        public bool Initialize(string dictionaryFile, string twoLetterLanguageCode) => false;
+
+        public bool IsWordCorrect(string word) => string.IsNullOrWhiteSpace(word);
+
+        public List<string> GetSuggestions(string word) => new();
+    }
+
+    public void Dispose()
+    {
+        SpellCheckConfig.DictionariesFolder = _originalSpellCheckDictionariesFolder;
+        Configuration.Settings.Tools.OcrFixUseHardcodedRules = _originalUseHardcodedRules;
+        try
+        {
+            Directory.Delete(_tempDictionariesFolder, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup.
+        }
+    }
+}

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixPortugueseAccentAndCapsTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixPortugueseAccentAndCapsTests.cs
@@ -1,0 +1,162 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
+using Nikse.SubtitleEdit.Features.SpellCheck;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
+
+namespace UITests.Features.Ocr.FixEngine;
+
+// Gated Portuguese rules: lost tildes/accents on the final syllable (nao -> não,
+// coracao -> coração, voce -> você) and l/I confusion in all-caps captions. A rule is only
+// applied when the misread form is NOT in the dictionary and the fixed form IS; lowercase-only
+// classes keep proper names (Joao as a name) untouched.
+// Runs against the shipped Dictionaries/por_OCRFixReplaceList.xml, not a copy of its rules.
+public class OcrFixPortugueseAccentAndCapsTests : IDisposable
+{
+    private readonly Func<string> _originalSpellCheckDictionariesFolder;
+    private readonly string _tempDictionariesFolder;
+    private readonly bool _originalUseHardcodedRules;
+
+    public OcrFixPortugueseAccentAndCapsTests()
+    {
+        _originalSpellCheckDictionariesFolder = SpellCheckConfig.DictionariesFolder;
+
+        // The hardcoded rules fix some all-caps l/I words on their own; turn them off so these
+        // tests prove the XML rules, not the hardcoded fallback.
+        _originalUseHardcodedRules = Configuration.Settings.Tools.OcrFixUseHardcodedRules;
+        Configuration.Settings.Tools.OcrFixUseHardcodedRules = false;
+
+        _tempDictionariesFolder = Path.Combine(
+            Path.GetTempPath(),
+            "SeOcrFixPortugueseAccentTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDictionariesFolder);
+
+        File.Copy(
+            Path.Combine(FindRepoRoot(), "Dictionaries", "por_OCRFixReplaceList.xml"),
+            Path.Combine(_tempDictionariesFolder, "por_OCRFixReplaceList.xml"));
+
+        SpellCheckConfig.DictionariesFolder = () => _tempDictionariesFolder;
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "Dictionaries")))
+        {
+            dir = dir.Parent;
+        }
+
+        return dir?.FullName ?? throw new DirectoryNotFoundException("Could not find repo root");
+    }
+
+    [Theory]
+    [InlineData("Eles sao irmaos.", "Eles são irmãos.")]
+    [InlineData("Os avioes chegam.", "Os aviões chegam.")]
+    [InlineData("Isso e necessario.", "Isso e necessário.")]
+    [InlineData("Sabe que voce fala ingles.", "Sabe que você fala inglês.")]
+    [InlineData("Quero um cafe.", "Quero um café.")]
+    public void FixOcrErrors_LostFinalSyllableAccent_IsRestored(string text, string expected)
+    {
+        var engine = CreateEngine();
+
+        var result = engine.FixOcrErrors(0, text, doTryToGuessUnknownWords: false);
+
+        Assert.Equal(expected, result.GetText());
+    }
+
+    [Theory]
+    [InlineData("SlM", "SIM")]
+    [InlineData("[GRlTOS]", "[GRITOS]")]
+    public void FixOcrErrors_MisreadLAndI_IsFixed(string text, string expected)
+    {
+        var engine = CreateEngine();
+
+        var result = engine.FixOcrErrors(0, text, doTryToGuessUnknownWords: false);
+
+        Assert.Equal(expected, result.GetText());
+    }
+
+    [Theory]
+    [InlineData("Joao chega logo Zzyzx.")] // capitalized name is never accented
+    [InlineData("O cachorro late Zzyzx.")] // correct -e word is in the dictionary
+    public void FixOcrErrors_CorrectWordsAndNames_AreLeftAlone(string text)
+    {
+        // "Zzyzx" keeps the line from being spelled OK, so every gated rule really runs.
+        var engine = CreateEngine();
+
+        var result = engine.FixOcrErrors(0, text, doTryToGuessUnknownWords: false);
+
+        Assert.Equal(text, result.GetText());
+    }
+
+    [Fact]
+    public void FixOcrErrors_WithoutADictionary_AccentRulesDoNothing()
+    {
+        var engine = CreateEngine(new EmptySpellChecker());
+
+        // "voce"/"ingles" have no ungated rules ("nao" would be fixed even without a dictionary,
+        // by the ungated \b(n|N)ao\b regex), so this proves the gate really needs the dictionary.
+        var result = engine.FixOcrErrors(0, "Sabe que voce fala ingles Zzyzx.", doTryToGuessUnknownWords: false);
+
+        Assert.Equal("Sabe que voce fala ingles Zzyzx.", result.GetText());
+    }
+
+    private static IOcrFixEngine CreateEngine(ISpellChecker? spellChecker = null)
+    {
+        IOcrFixEngine engine = new OcrFixEngine(spellChecker ?? new FakePortugueseSpellChecker());
+        engine.Initialize(new Subtitle(), "por", new SpellCheckDictionaryDisplay());
+        return engine;
+    }
+
+    private sealed class FakePortugueseSpellChecker : ISpellChecker
+    {
+        private static readonly HashSet<string> Words = new(StringComparer.Ordinal)
+        {
+            "eles", "são", "irmãos", "os", "aviões", "chegam", "isso", "e", "necessário",
+            "sabe", "que", "você", "fala", "inglês", "quero", "um", "café", "sim",
+            "gritos", "chega", "logo", "o", "cachorro", "late",
+        };
+
+        public bool Initialize(string dictionaryFile, string twoLetterLanguageCode) => true;
+
+        public bool IsWordCorrect(string word)
+        {
+            if (string.IsNullOrWhiteSpace(word))
+            {
+                return true;
+            }
+
+            // Like Hunspell, accept capitalized/all-caps forms of a lowercase dictionary word.
+            return Words.Contains(word) || Words.Contains(word.ToLowerInvariant());
+        }
+
+        public List<string> GetSuggestions(string word) => new();
+    }
+
+    // Stands in for "no Hunspell dictionary installed for the language".
+    private sealed class EmptySpellChecker : ISpellChecker
+    {
+        public bool Initialize(string dictionaryFile, string twoLetterLanguageCode) => false;
+
+        public bool IsWordCorrect(string word) => string.IsNullOrWhiteSpace(word);
+
+        public List<string> GetSuggestions(string word) => new();
+    }
+
+    public void Dispose()
+    {
+        SpellCheckConfig.DictionariesFolder = _originalSpellCheckDictionariesFolder;
+        Configuration.Settings.Tools.OcrFixUseHardcodedRules = _originalUseHardcodedRules;
+        try
+        {
+            Directory.Delete(_tempDictionariesFolder, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup.
+        }
+    }
+}

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixSpanishAccentAndCapsTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixSpanishAccentAndCapsTests.cs
@@ -1,0 +1,166 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
+using Nikse.SubtitleEdit.Features.SpellCheck;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
+
+namespace UITests.Features.Ocr.FixEngine;
+
+// The Spanish list only enumerated hand-picked accent fixes ("dia" -> "día") as WholeWords, so
+// every word not on the list slipped through. The gated rules generalize the pattern: a final
+// syllable accent (cancion -> canción) or an l/I confusion is only applied when the misread form
+// is NOT in the dictionary and the fixed form IS. Lowercase-only classes keep proper names
+// (Mia, Sofia) untouched.
+// Runs against the shipped Dictionaries/spa_OCRFixReplaceList.xml, not a copy of its rules.
+public class OcrFixSpanishAccentAndCapsTests : IDisposable
+{
+    private readonly Func<string> _originalSpellCheckDictionariesFolder;
+    private readonly string _tempDictionariesFolder;
+    private readonly bool _originalUseHardcodedRules;
+
+    public OcrFixSpanishAccentAndCapsTests()
+    {
+        _originalSpellCheckDictionariesFolder = SpellCheckConfig.DictionariesFolder;
+
+        // The hardcoded rules fix some all-caps l/I words on their own; turn them off so these
+        // tests prove the XML rules, not the hardcoded fallback.
+        _originalUseHardcodedRules = Configuration.Settings.Tools.OcrFixUseHardcodedRules;
+        Configuration.Settings.Tools.OcrFixUseHardcodedRules = false;
+
+        _tempDictionariesFolder = Path.Combine(
+            Path.GetTempPath(),
+            "SeOcrFixSpanishAccentTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDictionariesFolder);
+
+        File.Copy(
+            Path.Combine(FindRepoRoot(), "Dictionaries", "spa_OCRFixReplaceList.xml"),
+            Path.Combine(_tempDictionariesFolder, "spa_OCRFixReplaceList.xml"));
+
+        SpellCheckConfig.DictionariesFolder = () => _tempDictionariesFolder;
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "Dictionaries")))
+        {
+            dir = dir.Parent;
+        }
+
+        return dir?.FullName ?? throw new DirectoryNotFoundException("Could not find repo root");
+    }
+
+    [Theory]
+    [InlineData("Un monton de cosas.", "Un montón de cosas.")]
+    [InlineData("El capitan llega.", "El capitán llega.")]
+    [InlineData("Hay un jardin.", "Hay un jardín.")]
+    [InlineData("Vendra quizas.", "Vendra quizás.")]
+    [InlineData("Ella vivio sola.", "Ella vivió sola.")]
+    [InlineData("Toma un cafe.", "Toma un café.")]
+    public void FixOcrErrors_LostFinalSyllableAccent_IsRestored(string text, string expected)
+    {
+        var engine = CreateEngine();
+
+        var result = engine.FixOcrErrors(0, text, doTryToGuessUnknownWords: false);
+
+        Assert.Equal(expected, result.GetText());
+    }
+
+    [Theory]
+    [InlineData("SlN SALlDA", "SIN SALIDA")]
+    [InlineData("[GRlTOS]", "[GRITOS]")]
+    [InlineData("Vamos a Iavar la ropa.", "Vamos a lavar la ropa.")]
+    public void FixOcrErrors_MisreadLAndI_IsFixed(string text, string expected)
+    {
+        var engine = CreateEngine();
+
+        var result = engine.FixOcrErrors(0, text, doTryToGuessUnknownWords: false);
+
+        Assert.Equal(expected, result.GetText());
+    }
+
+    [Theory]
+    [InlineData("Mia canta bien Zzyzx.")] // capitalized name, even though "mía" is a word
+    [InlineData("La familia llega Zzyzx.")] // correct -ia word is in the dictionary
+    [InlineData("Mi amigo llega Zzyzx.")] // correct -o word is in the dictionary
+    public void FixOcrErrors_CorrectWordsAndNames_AreLeftAlone(string text)
+    {
+        // "Zzyzx" keeps the line from being spelled OK, so every gated rule really runs.
+        var engine = CreateEngine();
+
+        var result = engine.FixOcrErrors(0, text, doTryToGuessUnknownWords: false);
+
+        Assert.Equal(text, result.GetText());
+    }
+
+    [Fact]
+    public void FixOcrErrors_WithoutADictionary_AccentRulesDoNothing()
+    {
+        var engine = CreateEngine(new EmptySpellChecker());
+
+        // "capitan" has no ungated rule ("cancion" would be fixed even without a dictionary,
+        // by the ungated ([sc]i)o(n) regex), so this proves the gate really needs the dictionary.
+        var result = engine.FixOcrErrors(0, "El capitan llega Zzyzx.", doTryToGuessUnknownWords: false);
+
+        Assert.Equal("El capitan llega Zzyzx.", result.GetText());
+    }
+
+    private static IOcrFixEngine CreateEngine(ISpellChecker? spellChecker = null)
+    {
+        IOcrFixEngine engine = new OcrFixEngine(spellChecker ?? new FakeSpanishSpellChecker());
+        engine.Initialize(new Subtitle(), "spa", new SpellCheckDictionaryDisplay());
+        return engine;
+    }
+
+    private sealed class FakeSpanishSpellChecker : ISpellChecker
+    {
+        private static readonly HashSet<string> Words = new(StringComparer.Ordinal)
+        {
+            "un", "montón", "de", "cosas", "el", "capitán", "llega", "hay", "jardín",
+            "quizás", "ella", "vivió", "sola", "toma", "café", "sin", "salida", "gritos",
+            "vamos", "a", "lavar", "la", "ropa", "mía", "canta", "bien", "familia", "mi", "amigo",
+        };
+
+        public bool Initialize(string dictionaryFile, string twoLetterLanguageCode) => true;
+
+        public bool IsWordCorrect(string word)
+        {
+            if (string.IsNullOrWhiteSpace(word))
+            {
+                return true;
+            }
+
+            // Like Hunspell, accept capitalized/all-caps forms of a lowercase dictionary word.
+            return Words.Contains(word) || Words.Contains(word.ToLowerInvariant());
+        }
+
+        public List<string> GetSuggestions(string word) => new();
+    }
+
+    // Stands in for "no Hunspell dictionary installed for the language".
+    private sealed class EmptySpellChecker : ISpellChecker
+    {
+        public bool Initialize(string dictionaryFile, string twoLetterLanguageCode) => false;
+
+        public bool IsWordCorrect(string word) => string.IsNullOrWhiteSpace(word);
+
+        public List<string> GetSuggestions(string word) => new();
+    }
+
+    public void Dispose()
+    {
+        SpellCheckConfig.DictionariesFolder = _originalSpellCheckDictionariesFolder;
+        Configuration.Settings.Tools.OcrFixUseHardcodedRules = _originalUseHardcodedRules;
+        try
+        {
+            Directory.Delete(_tempDictionariesFolder, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup.
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #14041: instead of only repairing existing rules, this adds new ones where coverage was thin.

## The gap
The rich gated rule blocks (l/I confusion in all-caps captions, leading `I→l`) only exist for dan/deu/eng/fra/nld/nob/nor/swe — spa/por/ita had just the shared italic-i block. And no language generalizes accent restoration: the lists fix accents one hand-picked word at a time (`dia → día` in WholeWords), so every word not on the list slips through.

## What's added (all in `<RegularExpressionsIfSpelledCorrectly>`)
A rule only fires when the whole line failed the spell check, the misread form is **not** in the dictionary, and the fixed form **is** — the same mechanism the Spanish `clón → ción` rule proved out in #13701. Lowercase-only character classes keep proper names (Mia, Joao, Maria) untouched, and without a Hunspell dictionary the rules are inert.

**Caps/l-I family for spa, por, ita** (ported from the fra/dan blocks): `[GRlTOS] → [GRITOS]`, `SlN SALlDA → SIN SALIDA`, `Iavar → lavar`.

**Accent restoration:**
- **spa** — final-syllable acute accents (palabras agudas): `monton → montón`, `capitan → capitán`, `jardin → jardín`, `quizas → quizás`, `vivio → vivió`, `cafe → café`
- **por** — tildes and accents: `sao → são`, `irmaos → irmãos`, `avioes → aviões`, `voce → você` (both é/ê are tried; the dictionary picks), `ingles → inglês`, `necessario → necessário`, `-avel/-ivel → -ável/-ível`, `-encia/-ancia → -ência/-ância` (`-cao` is deliberately left to the existing ungated `\Bcao\b` rule, which runs first)
- **ita** — final-vowel accents: `citta → città`, `perche → perché`, `caffe → caffè` (both e-accents tried), `cosi → così`, `piu → più`, `pero → però`

## Tests
Three new test classes run against the **shipped** XMLs with fake spell checkers (per-language word sets), covering positives, protected real words, capitalized names left alone, and no-dictionary inertness — with test words chosen to avoid ones the ungated rules or WholeWords already fix (found the hard way: spa ships an ungated `([sc]i)o(n)\b` and por an ungated `\b(n|N)ao\b`). Hardcoded rules are disabled in the fixtures so the XML rules alone are proven.

- `dotnet test tests/UI --filter FullyQualifiedName~Ocr`: 810 passed
- `dotnet test tests/libuilogic` (includes the #14041 shipped-lists guard test): 524 passed

## Noted for later (not in this PR)
- The same preposition+Capital merge rules fra/dan have (`deMadrid → de Madrid`) could be ported.
- rus/mkd have zero regex rules; Latin-homoglyph-inside-Cyrillic normalization (`нaшa → наша`) would be a safe ungated family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)