### PR TITLE
Add Cyrillic homoglyph rules (rus/mkd) and preposition splits (spa/por/ita)

### DIFF
--- a/Dictionaries/ita_OCRFixReplaceList.xml
+++ b/Dictionaries/ita_OCRFixReplaceList.xml
@@ -112,5 +112,24 @@
     <RegEx find="\b([a-zàèéìòóù]{2,})i\b" spellCheck="$1ì" replaceWith="$1ì" />
     <RegEx find="\b([a-zàèéìòóù]{2,})o\b" spellCheck="$1ò" replaceWith="$1ò" />
     <RegEx find="\b([a-zàèéìòóù]{2,})u\b" spellCheck="$1ù" replaceWith="$1ù" />
+
+    <!-- ============================================================ -->
+    <!-- SPAZIO PERSO TRA PREPOSIZIONE/ARTICOLO E NOME PROPRIO        -->
+    <!-- daRoma in da Roma : solo se la parola con maiuscola è nel    -->
+    <!-- dizionario.                                                  -->
+    <!-- ============================================================ -->
+    <RegEx find="\bdi([A-ZÀÈÉÌÒÓÙ][a-zàèéìòóù]+)\b" spellCheck="$1" replaceWith="di $1" />
+    <RegEx find="\bda([A-ZÀÈÉÌÒÓÙ][a-zàèéìòóù]+)\b" spellCheck="$1" replaceWith="da $1" />
+    <RegEx find="\bil([A-ZÀÈÉÌÒÓÙ][a-zàèéìòóù]+)\b" spellCheck="$1" replaceWith="il $1" />
+    <RegEx find="\bla([A-ZÀÈÉÌÒÓÙ][a-zàèéìòóù]+)\b" spellCheck="$1" replaceWith="la $1" />
+    <RegEx find="\ble([A-ZÀÈÉÌÒÓÙ][a-zàèéìòóù]+)\b" spellCheck="$1" replaceWith="le $1" />
+    <RegEx find="\blo([A-ZÀÈÉÌÒÓÙ][a-zàèéìòóù]+)\b" spellCheck="$1" replaceWith="lo $1" />
+    <RegEx find="\bin([A-ZÀÈÉÌÒÓÙ][a-zàèéìòóù]+)\b" spellCheck="$1" replaceWith="in $1" />
+    <RegEx find="\bun([A-ZÀÈÉÌÒÓÙ][a-zàèéìòóù]+)\b" spellCheck="$1" replaceWith="un $1" />
+    <RegEx find="\buna([A-ZÀÈÉÌÒÓÙ][a-zàèéìòóù]+)\b" spellCheck="$1" replaceWith="una $1" />
+    <RegEx find="\bal([A-ZÀÈÉÌÒÓÙ][a-zàèéìòóù]+)\b" spellCheck="$1" replaceWith="al $1" />
+    <RegEx find="\bdel([A-ZÀÈÉÌÒÓÙ][a-zàèéìòóù]+)\b" spellCheck="$1" replaceWith="del $1" />
+    <RegEx find="\bper([A-ZÀÈÉÌÒÓÙ][a-zàèéìòóù]+)\b" spellCheck="$1" replaceWith="per $1" />
+    <RegEx find="\bcon([A-ZÀÈÉÌÒÓÙ][a-zàèéìòóù]+)\b" spellCheck="$1" replaceWith="con $1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/mkd_OCRFixReplaceList.xml
+++ b/Dictionaries/mkd_OCRFixReplaceList.xml
@@ -51,5 +51,37 @@
   <PartialLines />
   <BeginLines />
   <EndLines />
-  <RegularExpressions />
+  <RegularExpressions>
+    <!-- Латинични букви-двојници во кирилични зборови: буква со кириличен сосед
+         мора да биде кирилична (Bо - Во, jас - јас). Целосно латинични зборови
+         (Windows) не се менуваат: тие немаат кирилични соседи. -->
+    <RegEx find="(?&lt;=[а-џА-ЯЀ-Џ])a|a(?=[а-џА-ЯЀ-Џ])" replaceWith="а" />
+    <RegEx find="(?&lt;=[а-џА-ЯЀ-Џ])c|c(?=[а-џА-ЯЀ-Џ])" replaceWith="с" />
+    <RegEx find="(?&lt;=[а-џА-ЯЀ-Џ])e|e(?=[а-џА-ЯЀ-Џ])" replaceWith="е" />
+    <RegEx find="(?&lt;=[а-џА-ЯЀ-Џ])j|j(?=[а-џА-ЯЀ-Џ])" replaceWith="ј" />
+    <RegEx find="(?&lt;=[а-џА-ЯЀ-Џ])o|o(?=[а-џА-ЯЀ-Џ])" replaceWith="о" />
+    <RegEx find="(?&lt;=[а-џА-ЯЀ-Џ])p|p(?=[а-џА-ЯЀ-Џ])" replaceWith="р" />
+    <RegEx find="(?&lt;=[а-џА-ЯЀ-Џ])s|s(?=[а-џА-ЯЀ-Џ])" replaceWith="ѕ" />
+    <RegEx find="(?&lt;=[а-џА-ЯЀ-Џ])x|x(?=[а-џА-ЯЀ-Џ])" replaceWith="х" />
+    <RegEx find="(?&lt;=[а-џА-ЯЀ-Џ])y|y(?=[а-џА-ЯЀ-Џ])" replaceWith="у" />
+    <RegEx find="(?&lt;=[а-џА-ЯЀ-Џ])A|A(?=[а-џА-ЯЀ-Џ])" replaceWith="А" />
+    <RegEx find="(?&lt;=[а-џА-ЯЀ-Џ])B|B(?=[а-џА-ЯЀ-Џ])" replaceWith="В" />
+    <RegEx find="(?&lt;=[а-џА-ЯЀ-Џ])C|C(?=[а-џА-ЯЀ-Џ])" replaceWith="С" />
+    <RegEx find="(?&lt;=[а-џА-ЯЀ-Џ])E|E(?=[а-џА-ЯЀ-Џ])" replaceWith="Е" />
+    <RegEx find="(?&lt;=[а-џА-ЯЀ-Џ])H|H(?=[а-џА-ЯЀ-Џ])" replaceWith="Н" />
+    <RegEx find="(?&lt;=[а-џА-ЯЀ-Џ])J|J(?=[а-џА-ЯЀ-Џ])" replaceWith="Ј" />
+    <RegEx find="(?&lt;=[а-џА-ЯЀ-Џ])K|K(?=[а-џА-ЯЀ-Џ])" replaceWith="К" />
+    <RegEx find="(?&lt;=[а-џА-ЯЀ-Џ])M|M(?=[а-џА-ЯЀ-Џ])" replaceWith="М" />
+    <RegEx find="(?&lt;=[а-џА-ЯЀ-Џ])O|O(?=[а-џА-ЯЀ-Џ])" replaceWith="О" />
+    <RegEx find="(?&lt;=[а-џА-ЯЀ-Џ])P|P(?=[а-џА-ЯЀ-Џ])" replaceWith="Р" />
+    <RegEx find="(?&lt;=[а-џА-ЯЀ-Џ])S|S(?=[а-џА-ЯЀ-Џ])" replaceWith="Ѕ" />
+    <RegEx find="(?&lt;=[а-џА-ЯЀ-Џ])T|T(?=[а-џА-ЯЀ-Џ])" replaceWith="Т" />
+    <RegEx find="(?&lt;=[а-џА-ЯЀ-Џ])X|X(?=[а-џА-ЯЀ-Џ])" replaceWith="Х" />
+    <RegEx find="(?&lt;=[а-џА-ЯЀ-Џ])Y|Y(?=[а-џА-ЯЀ-Џ])" replaceWith="У" />
+    <!-- Цифри наместо букви веднаш по мала кирилична буква: цифра по цифра
+         не се менува (16кг). -->
+    <RegEx find="(?&lt;=[а-џ])3(?![0-9])" replaceWith="з" />
+    <RegEx find="(?&lt;=[а-џ])6(?![0-9])" replaceWith="б" />
+    <RegEx find="(?&lt;=[а-џ])0(?![0-9])" replaceWith="о" />
+  </RegularExpressions>
 </OCRFixReplaceList>

--- a/Dictionaries/por_OCRFixReplaceList.xml
+++ b/Dictionaries/por_OCRFixReplaceList.xml
@@ -588,5 +588,23 @@
     <RegEx find="\b([a-zàáâãçéêíóôõú]+)ario(s?)\b" spellCheck="$1ário$2" replaceWith="$1ário$2" />
     <RegEx find="\b([a-zàáâãçéêíóôõú]+)encia(s?)\b" spellCheck="$1ência$2" replaceWith="$1ência$2" />
     <RegEx find="\b([a-zàáâãçéêíóôõú]+)ancia(s?)\b" spellCheck="$1ância$2" replaceWith="$1ância$2" />
+
+    <!-- ============================================================ -->
+    <!-- ESPAÇO PERDIDO ENTRE PREPOSIÇÃO/ARTIGO E NOME PRÓPRIO        -->
+    <!-- deLisboa para de Lisboa : só se a palavra com maiúscula      -->
+    <!-- está no dicionário.                                          -->
+    <!-- ============================================================ -->
+    <RegEx find="\bde([A-ZÀÁÂÃÇÉÊÍÓÔÕÚ][a-zàáâãçéêíóôõú]+)\b" spellCheck="$1" replaceWith="de $1" />
+    <RegEx find="\bda([A-ZÀÁÂÃÇÉÊÍÓÔÕÚ][a-zàáâãçéêíóôõú]+)\b" spellCheck="$1" replaceWith="da $1" />
+    <RegEx find="\bdo([A-ZÀÁÂÃÇÉÊÍÓÔÕÚ][a-zàáâãçéêíóôõú]+)\b" spellCheck="$1" replaceWith="do $1" />
+    <RegEx find="\bem([A-ZÀÁÂÃÇÉÊÍÓÔÕÚ][a-zàáâãçéêíóôõú]+)\b" spellCheck="$1" replaceWith="em $1" />
+    <RegEx find="\bno([A-ZÀÁÂÃÇÉÊÍÓÔÕÚ][a-zàáâãçéêíóôõú]+)\b" spellCheck="$1" replaceWith="no $1" />
+    <RegEx find="\bna([A-ZÀÁÂÃÇÉÊÍÓÔÕÚ][a-zàáâãçéêíóôõú]+)\b" spellCheck="$1" replaceWith="na $1" />
+    <RegEx find="\bos([A-ZÀÁÂÃÇÉÊÍÓÔÕÚ][a-zàáâãçéêíóôõú]+)\b" spellCheck="$1" replaceWith="os $1" />
+    <RegEx find="\bas([A-ZÀÁÂÃÇÉÊÍÓÔÕÚ][a-zàáâãçéêíóôõú]+)\b" spellCheck="$1" replaceWith="as $1" />
+    <RegEx find="\bum([A-ZÀÁÂÃÇÉÊÍÓÔÕÚ][a-zàáâãçéêíóôõú]+)\b" spellCheck="$1" replaceWith="um $1" />
+    <RegEx find="\buma([A-ZÀÁÂÃÇÉÊÍÓÔÕÚ][a-zàáâãçéêíóôõú]+)\b" spellCheck="$1" replaceWith="uma $1" />
+    <RegEx find="\bpara([A-ZÀÁÂÃÇÉÊÍÓÔÕÚ][a-zàáâãçéêíóôõú]+)\b" spellCheck="$1" replaceWith="para $1" />
+    <RegEx find="\bcom([A-ZÀÁÂÃÇÉÊÍÓÔÕÚ][a-zàáâãçéêíóôõú]+)\b" spellCheck="$1" replaceWith="com $1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/Dictionaries/rus_OCRFixReplaceList.xml
+++ b/Dictionaries/rus_OCRFixReplaceList.xml
@@ -254,5 +254,33 @@
   <PartialLines />
   <BeginLines />
   <EndLines />
-  <RegularExpressions />
+  <RegularExpressions>
+    <!-- Латинские буквы-двойники внутри кириллических слов: буква с кириллическим
+         соседом обязана быть кириллицей (нaшa - наша, Bот - Вот). Полностью
+         латинские слова (IKEA, Wi-Fi) не трогаются: у них нет кириллических соседей. -->
+    <RegEx find="(?&lt;=[а-яёА-ЯЁ])a|a(?=[а-яёА-ЯЁ])" replaceWith="а" />
+    <RegEx find="(?&lt;=[а-яёА-ЯЁ])c|c(?=[а-яёА-ЯЁ])" replaceWith="с" />
+    <RegEx find="(?&lt;=[а-яёА-ЯЁ])e|e(?=[а-яёА-ЯЁ])" replaceWith="е" />
+    <RegEx find="(?&lt;=[а-яёА-ЯЁ])o|o(?=[а-яёА-ЯЁ])" replaceWith="о" />
+    <RegEx find="(?&lt;=[а-яёА-ЯЁ])p|p(?=[а-яёА-ЯЁ])" replaceWith="р" />
+    <RegEx find="(?&lt;=[а-яёА-ЯЁ])x|x(?=[а-яёА-ЯЁ])" replaceWith="х" />
+    <RegEx find="(?&lt;=[а-яёА-ЯЁ])y|y(?=[а-яёА-ЯЁ])" replaceWith="у" />
+    <RegEx find="(?&lt;=[а-яёА-ЯЁ])A|A(?=[а-яёА-ЯЁ])" replaceWith="А" />
+    <RegEx find="(?&lt;=[а-яёА-ЯЁ])B|B(?=[а-яёА-ЯЁ])" replaceWith="В" />
+    <RegEx find="(?&lt;=[а-яёА-ЯЁ])C|C(?=[а-яёА-ЯЁ])" replaceWith="С" />
+    <RegEx find="(?&lt;=[а-яёА-ЯЁ])E|E(?=[а-яёА-ЯЁ])" replaceWith="Е" />
+    <RegEx find="(?&lt;=[а-яёА-ЯЁ])H|H(?=[а-яёА-ЯЁ])" replaceWith="Н" />
+    <RegEx find="(?&lt;=[а-яёА-ЯЁ])K|K(?=[а-яёА-ЯЁ])" replaceWith="К" />
+    <RegEx find="(?&lt;=[а-яёА-ЯЁ])M|M(?=[а-яёА-ЯЁ])" replaceWith="М" />
+    <RegEx find="(?&lt;=[а-яёА-ЯЁ])O|O(?=[а-яёА-ЯЁ])" replaceWith="О" />
+    <RegEx find="(?&lt;=[а-яёА-ЯЁ])P|P(?=[а-яёА-ЯЁ])" replaceWith="Р" />
+    <RegEx find="(?&lt;=[а-яёА-ЯЁ])T|T(?=[а-яёА-ЯЁ])" replaceWith="Т" />
+    <RegEx find="(?&lt;=[а-яёА-ЯЁ])X|X(?=[а-яёА-ЯЁ])" replaceWith="Х" />
+    <RegEx find="(?&lt;=[а-яёА-ЯЁ])Y|Y(?=[а-яёА-ЯЁ])" replaceWith="У" />
+    <!-- Цифры вместо букв сразу после строчной кириллицы: о6ед - обед,
+         отка3 - отказ, с0рок - сорок. Цифра после цифры не трогается (16кг). -->
+    <RegEx find="(?&lt;=[а-яё])3(?![0-9])" replaceWith="з" />
+    <RegEx find="(?&lt;=[а-яё])6(?![0-9])" replaceWith="б" />
+    <RegEx find="(?&lt;=[а-яё])0(?![0-9])" replaceWith="о" />
+  </RegularExpressions>
 </OCRFixReplaceList>

--- a/Dictionaries/spa_OCRFixReplaceList.xml
+++ b/Dictionaries/spa_OCRFixReplaceList.xml
@@ -1012,5 +1012,23 @@
     <RegEx find="\b([a-záéíóúñü]{2,})i\b" spellCheck="$1í" replaceWith="$1í" />
     <RegEx find="\b([a-záéíóúñü]{2,})o\b" spellCheck="$1ó" replaceWith="$1ó" />
     <RegEx find="\b([a-záéíóúñü]{2,})e\b" spellCheck="$1é" replaceWith="$1é" />
+
+    <!-- ============================================================ -->
+    <!-- ESPACIO PERDIDO ENTRE PREPOSICIÓN/ARTÍCULO Y NOMBRE PROPIO   -->
+    <!-- deMadrid a de Madrid : solo si la palabra en mayúscula está  -->
+    <!-- en el diccionario.                                           -->
+    <!-- ============================================================ -->
+    <RegEx find="\bde([A-ZÁÉÍÓÚÑÜ][a-záéíóúñü]+)\b" spellCheck="$1" replaceWith="de $1" />
+    <RegEx find="\bdel([A-ZÁÉÍÓÚÑÜ][a-záéíóúñü]+)\b" spellCheck="$1" replaceWith="del $1" />
+    <RegEx find="\bel([A-ZÁÉÍÓÚÑÜ][a-záéíóúñü]+)\b" spellCheck="$1" replaceWith="el $1" />
+    <RegEx find="\bla([A-ZÁÉÍÓÚÑÜ][a-záéíóúñü]+)\b" spellCheck="$1" replaceWith="la $1" />
+    <RegEx find="\blos([A-ZÁÉÍÓÚÑÜ][a-záéíóúñü]+)\b" spellCheck="$1" replaceWith="los $1" />
+    <RegEx find="\blas([A-ZÁÉÍÓÚÑÜ][a-záéíóúñü]+)\b" spellCheck="$1" replaceWith="las $1" />
+    <RegEx find="\ben([A-ZÁÉÍÓÚÑÜ][a-záéíóúñü]+)\b" spellCheck="$1" replaceWith="en $1" />
+    <RegEx find="\bal([A-ZÁÉÍÓÚÑÜ][a-záéíóúñü]+)\b" spellCheck="$1" replaceWith="al $1" />
+    <RegEx find="\bun([A-ZÁÉÍÓÚÑÜ][a-záéíóúñü]+)\b" spellCheck="$1" replaceWith="un $1" />
+    <RegEx find="\buna([A-ZÁÉÍÓÚÑÜ][a-záéíóúñü]+)\b" spellCheck="$1" replaceWith="una $1" />
+    <RegEx find="\bcon([A-ZÁÉÍÓÚÑÜ][a-záéíóúñü]+)\b" spellCheck="$1" replaceWith="con $1" />
+    <RegEx find="\bpor([A-ZÁÉÍÓÚÑÜ][a-záéíóúñü]+)\b" spellCheck="$1" replaceWith="por $1" />
   </RegularExpressionsIfSpelledCorrectly>
 </OCRFixReplaceList>

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixItalianAccentAndCapsTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixItalianAccentAndCapsTests.cs
@@ -81,6 +81,17 @@ public class OcrFixItalianAccentAndCapsTests : IDisposable
     }
 
     [Theory]
+    [InlineData("Arrivo daRoma.", "Arrivo da Roma.")]
+    public void FixOcrErrors_MissingSpaceAfterPreposition_IsSplitWhenTheNameIsKnown(string text, string expected)
+    {
+        var engine = CreateEngine();
+
+        var result = engine.FixOcrErrors(0, text, doTryToGuessUnknownWords: false);
+
+        Assert.Equal(expected, result.GetText());
+    }
+
+    [Theory]
     [InlineData("Vieni anche tu Zzyzx.")] // correct -e word is in the dictionary
     [InlineData("Maria canta Zzyzx.")] // capitalized name is never accented
     public void FixOcrErrors_CorrectWordsAndNames_AreLeftAlone(string text)
@@ -114,6 +125,7 @@ public class OcrFixItalianAccentAndCapsTests : IDisposable
     {
         private static readonly HashSet<string> Words = new(StringComparer.Ordinal)
         {
+            "arrivo", "roma",
             "la", "città", "e", "bella", "non", "so", "perché", "si", "fa", "così",
             "ne", "voglio", "di", "più", "prendo", "un", "caffè", "va", "bene", "però",
             "ora", "musica", "fine", "vieni", "anche", "tu", "canta",

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixMacedonianHomoglyphTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixMacedonianHomoglyphTests.cs
@@ -1,0 +1,101 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
+using Nikse.SubtitleEdit.Features.SpellCheck;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
+
+namespace UITests.Features.Ocr.FixEngine;
+
+// Macedonian version of the Cyrillic homoglyph rules, including the letters Latin script
+// shares glyphs with only in Macedonian: j (ј) and s (ѕ). Ungated - a Latin letter with a
+// Cyrillic neighbor is definitely wrong - so no dictionary is needed.
+// Runs against the shipped Dictionaries/mkd_OCRFixReplaceList.xml, not a copy of its rules.
+public class OcrFixMacedonianHomoglyphTests : IDisposable
+{
+    private readonly Func<string> _originalSpellCheckDictionariesFolder;
+    private readonly string _tempDictionariesFolder;
+
+    public OcrFixMacedonianHomoglyphTests()
+    {
+        _originalSpellCheckDictionariesFolder = SpellCheckConfig.DictionariesFolder;
+
+        _tempDictionariesFolder = Path.Combine(
+            Path.GetTempPath(),
+            "SeOcrFixMacedonianHomoglyphTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDictionariesFolder);
+
+        File.Copy(
+            Path.Combine(FindRepoRoot(), "Dictionaries", "mkd_OCRFixReplaceList.xml"),
+            Path.Combine(_tempDictionariesFolder, "mkd_OCRFixReplaceList.xml"));
+
+        SpellCheckConfig.DictionariesFolder = () => _tempDictionariesFolder;
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "Dictionaries")))
+        {
+            dir = dir.Parent;
+        }
+
+        return dir?.FullName ?? throw new DirectoryNotFoundException("Could not find repo root");
+    }
+
+    [Theory]
+    [InlineData("Каj си?", "Кај си?")] // Latin j after Cyrillic
+    [InlineData("Тоа е jасно.", "Тоа е јасно.")] // Latin j before Cyrillic
+    [InlineData("Bо ред е.", "Во ред е.")] // Latin B
+    [InlineData("Гледам sвезда.", "Гледам ѕвезда.")] // Latin s for dze
+    public void FixOcrErrors_LatinHomoglyphInCyrillicWord_IsFixedWithoutADictionary(string text, string expected)
+    {
+        var engine = CreateEngine();
+
+        var result = engine.FixOcrErrors(0, text, doTryToGuessUnknownWords: false);
+
+        Assert.Equal(expected, result.GetText());
+    }
+
+    [Fact]
+    public void FixOcrErrors_FullyLatinWord_IsLeftAlone()
+    {
+        var engine = CreateEngine();
+
+        var result = engine.FixOcrErrors(0, "Ова е Windows.", doTryToGuessUnknownWords: false);
+
+        Assert.Equal("Ова е Windows.", result.GetText());
+    }
+
+    private static IOcrFixEngine CreateEngine()
+    {
+        // No dictionary at all: the homoglyph rules must work stand-alone.
+        IOcrFixEngine engine = new OcrFixEngine(new EmptySpellChecker());
+        engine.Initialize(new Subtitle(), "mkd", new SpellCheckDictionaryDisplay());
+        return engine;
+    }
+
+    private sealed class EmptySpellChecker : ISpellChecker
+    {
+        public bool Initialize(string dictionaryFile, string twoLetterLanguageCode) => false;
+
+        public bool IsWordCorrect(string word) => string.IsNullOrWhiteSpace(word);
+
+        public List<string> GetSuggestions(string word) => new();
+    }
+
+    public void Dispose()
+    {
+        SpellCheckConfig.DictionariesFolder = _originalSpellCheckDictionariesFolder;
+        try
+        {
+            Directory.Delete(_tempDictionariesFolder, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup.
+        }
+    }
+}

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixPortugueseAccentAndCapsTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixPortugueseAccentAndCapsTests.cs
@@ -80,6 +80,17 @@ public class OcrFixPortugueseAccentAndCapsTests : IDisposable
     }
 
     [Theory]
+    [InlineData("Venho deLisboa.", "Venho de Lisboa.")]
+    public void FixOcrErrors_MissingSpaceAfterPreposition_IsSplitWhenTheNameIsKnown(string text, string expected)
+    {
+        var engine = CreateEngine();
+
+        var result = engine.FixOcrErrors(0, text, doTryToGuessUnknownWords: false);
+
+        Assert.Equal(expected, result.GetText());
+    }
+
+    [Theory]
     [InlineData("Joao chega logo Zzyzx.")] // capitalized name is never accented
     [InlineData("O cachorro late Zzyzx.")] // correct -e word is in the dictionary
     public void FixOcrErrors_CorrectWordsAndNames_AreLeftAlone(string text)
@@ -115,6 +126,7 @@ public class OcrFixPortugueseAccentAndCapsTests : IDisposable
     {
         private static readonly HashSet<string> Words = new(StringComparer.Ordinal)
         {
+            "venho", "lisboa",
             "eles", "são", "irmãos", "os", "aviões", "chegam", "isso", "e", "necessário",
             "sabe", "que", "você", "fala", "inglês", "quero", "um", "café", "sim",
             "gritos", "chega", "logo", "o", "cachorro", "late",

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixRussianHomoglyphTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixRussianHomoglyphTests.cs
@@ -1,0 +1,108 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
+using Nikse.SubtitleEdit.Features.SpellCheck;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
+
+namespace UITests.Features.Ocr.FixEngine;
+
+// OCR of Cyrillic text often emits Latin homoglyphs (a/c/e/o/p/x/y, B/H/K...) or digits (3/6/0)
+// inside Cyrillic words. A Latin letter with a Cyrillic neighbor is definitely wrong, so the
+// rules are ungated and work without any dictionary; fully Latin words (IKEA, YouTube) have no
+// Cyrillic neighbors and are never touched.
+// Runs against the shipped Dictionaries/rus_OCRFixReplaceList.xml, not a copy of its rules.
+public class OcrFixRussianHomoglyphTests : IDisposable
+{
+    private readonly Func<string> _originalSpellCheckDictionariesFolder;
+    private readonly string _tempDictionariesFolder;
+
+    public OcrFixRussianHomoglyphTests()
+    {
+        _originalSpellCheckDictionariesFolder = SpellCheckConfig.DictionariesFolder;
+
+        _tempDictionariesFolder = Path.Combine(
+            Path.GetTempPath(),
+            "SeOcrFixRussianHomoglyphTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDictionariesFolder);
+
+        File.Copy(
+            Path.Combine(FindRepoRoot(), "Dictionaries", "rus_OCRFixReplaceList.xml"),
+            Path.Combine(_tempDictionariesFolder, "rus_OCRFixReplaceList.xml"));
+
+        SpellCheckConfig.DictionariesFolder = () => _tempDictionariesFolder;
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "Dictionaries")))
+        {
+            dir = dir.Parent;
+        }
+
+        return dir?.FullName ?? throw new DirectoryNotFoundException("Could not find repo root");
+    }
+
+    [Theory]
+    [InlineData("Bот нaш дом.", "Вот наш дом.")] // Latin B, Latin a
+    [InlineData("Мы xотим есть.", "Мы хотим есть.")] // Latin x
+    [InlineData("Yтро доброе.", "Утро доброе.")] // Latin Y at word start
+    [InlineData("Пошли на о6ед.", "Пошли на обед.")] // digit 6
+    [InlineData("Это отка3.", "Это отказ.")] // digit 3 at word end
+    [InlineData("Ему с0рок лет.", "Ему сорок лет.")] // digit 0
+    public void FixOcrErrors_LatinHomoglyphInCyrillicWord_IsFixedWithoutADictionary(string text, string expected)
+    {
+        var engine = CreateEngine();
+
+        var result = engine.FixOcrErrors(0, text, doTryToGuessUnknownWords: false);
+
+        Assert.Equal(expected, result.GetText());
+    }
+
+    [Theory]
+    [InlineData("Это IKEA.")] // fully Latin word has no Cyrillic neighbors
+    [InlineData("Смотрю YouTube.")]
+    [InlineData("У меня 6 книг.")] // free-standing digit
+    [InlineData("Вес 16кг.")] // digit after digit is left alone
+    public void FixOcrErrors_LatinWordsAndRealDigits_AreLeftAlone(string text)
+    {
+        var engine = CreateEngine();
+
+        var result = engine.FixOcrErrors(0, text, doTryToGuessUnknownWords: false);
+
+        Assert.Equal(text, result.GetText());
+    }
+
+    private static IOcrFixEngine CreateEngine()
+    {
+        // No dictionary at all: the homoglyph rules must work stand-alone.
+        IOcrFixEngine engine = new OcrFixEngine(new EmptySpellChecker());
+        engine.Initialize(new Subtitle(), "rus", new SpellCheckDictionaryDisplay());
+        return engine;
+    }
+
+    private sealed class EmptySpellChecker : ISpellChecker
+    {
+        public bool Initialize(string dictionaryFile, string twoLetterLanguageCode) => false;
+
+        public bool IsWordCorrect(string word) => string.IsNullOrWhiteSpace(word);
+
+        public List<string> GetSuggestions(string word) => new();
+    }
+
+    public void Dispose()
+    {
+        SpellCheckConfig.DictionariesFolder = _originalSpellCheckDictionariesFolder;
+        try
+        {
+            Directory.Delete(_tempDictionariesFolder, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup.
+        }
+    }
+}

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixSpanishAccentAndCapsTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixSpanishAccentAndCapsTests.cs
@@ -83,6 +83,18 @@ public class OcrFixSpanishAccentAndCapsTests : IDisposable
     }
 
     [Theory]
+    [InlineData("Vengo deMadrid.", "Vengo de Madrid.")]
+    [InlineData("Brindo porEspana Zzyzx.", "Brindo porEspana Zzyzx.")] // merged word not in the dictionary stays
+    public void FixOcrErrors_MissingSpaceAfterPreposition_IsSplitWhenTheNameIsKnown(string text, string expected)
+    {
+        var engine = CreateEngine();
+
+        var result = engine.FixOcrErrors(0, text, doTryToGuessUnknownWords: false);
+
+        Assert.Equal(expected, result.GetText());
+    }
+
+    [Theory]
     [InlineData("Mia canta bien Zzyzx.")] // capitalized name, even though "mía" is a word
     [InlineData("La familia llega Zzyzx.")] // correct -ia word is in the dictionary
     [InlineData("Mi amigo llega Zzyzx.")] // correct -o word is in the dictionary
@@ -119,6 +131,7 @@ public class OcrFixSpanishAccentAndCapsTests : IDisposable
     {
         private static readonly HashSet<string> Words = new(StringComparer.Ordinal)
         {
+            "vengo", "madrid", "brindo",
             "un", "montón", "de", "cosas", "el", "capitán", "llega", "hay", "jardín",
             "quizás", "ella", "vivió", "sola", "toma", "café", "sin", "salida", "gritos",
             "vamos", "a", "lavar", "la", "ropa", "mía", "canta", "bien", "familia", "mi", "amigo",


### PR DESCRIPTION
Third round of OCR replace-list improvements (after #14041 and #14043), covering the two families noted as follow-ups in #14043.

## Cyrillic homoglyph normalization — rus and mkd
These two lists had **zero** regex rules. OCR of Cyrillic text routinely emits Latin homoglyphs (`a c e o p x y`, `A B C E H K M O P T X Y`, in Macedonian also `j`→`ј` and `s`→`ѕ`) and digits (`3 6 0`) inside Cyrillic words. The rules are **ungated** but safe by construction: a Latin letter is only converted when it has a Cyrillic neighbor, so:

- `Bот нaш дом` → `Вот наш дом`, `Мы xотим есть` → `Мы хотим есть`, `Yтро` → `Утро`
- `о6ед` → `обед`, `отка3` → `отказ`, `с0рок` → `сорок`
- mkd: `Каj си?` → `Кај си?`, `sвезда` → `ѕвезда`
- fully Latin words (**IKEA, YouTube, Windows**) have no Cyrillic neighbors and are never touched; digits guard against units — `16кг` and free-standing `6` stay as they are (digit-after-digit and space-separated digits never match)

Known limitation (documented): an entirely-Latin misread like `OH` for `ОН` has no Cyrillic anchor and is not fixed — that class needs word-level entries.

## Preposition/article splits — spa, por, ita
Ports the family fra/dan already ship, dictionary-gated (`spellCheck="$1"`): `deMadrid` → `de Madrid`, `daRoma` → `da Roma`, `deLisboa` → `de Lisboa`. Each language gets its own preposition/article set (spa: de/del/el/la/los/las/en/al/un/una/con/por; por: de/da/do/em/no/na/os/as/um/uma/para/com; ita: di/da/il/la/le/lo/in/un/una/al/del/per/con). Only fires when the capitalized word is in the dictionary — a negative test (`porEspana` with unknown "Espana") proves the gate.

## Tests
- Two new classes against the shipped XMLs with an **empty** spell checker, proving the homoglyph rules are fully dictionary-independent, plus negative cases for Latin words and real digits.
- The three AccentAndCaps classes from #14043 gain preposition-split cases.
- `dotnet test tests/UI --filter FullyQualifiedName~Ocr`: 829 passed; `dotnet test tests/libuilogic` (includes the shipped-lists guard test): 524 passed.

## Possibly worth a look later
- srp could take the same homoglyph block (its Cyrillic subtitles share the problem), but its list is Latin-script-oriented — left out pending your call.
- Engine-side items still open from the audit: surfacing swallowed bad rules in `SpellCheckRegex` to `ErrorMessage`, and a literal-substring prefilter for hrv's 1,841 sequential regex passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)