### PR TITLE
Prepare v5.2.0-beta23

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -3,6 +3,33 @@ Subtitle Edit Changelog
 
 -----------------------------------------------------------------------------------------------------
 
+v5.2.0-beta23 (24th of August 2026)
+
+* OCR: add accent, l/I and preposition-split rules for Spanish, Portuguese and Italian
+* OCR: fix Latin letters and digits misread inside Cyrillic words (Russian, Macedonian)
+* OCR: repair about 115 broken, dead or duplicated entries in the fix replace lists
+* Faster Scenarist Closed Captions export (5x), Netflix quality checks and "remove text for hearing impaired"
+* Faster Blu-ray palette decoding, transport stream scanning and Cavena 890 reading
+* Fix ASSA attachments being written with the last two bytes zeroed
+* Fix DVD Studio Pro "with space" files failing to load
+* Fix csv lines containing a semicolon being dropped
+* Fix ASSA resampling giving up on tags with a space, like "\pos (10,11)"
+* Fix words per minute being reported as infinity for zero duration lines
+* Fix "convert actors" losing the name and mangling lines with leading spaces
+* Fix crashes and wrong results when parsing malformed MP4, transport stream and RIFF files
+* Fix WebVTT thumbnail sprite sheets in .jpeg being rejected
+* Fix video OCR ending a subtitle too early after an unreadable frame
+* Fix Netflix "spell out leading number" doing nothing outside Windows
+* Fix Unknown 33/34/59 writing 00:00:60 instead of 00:01:00
+* Fix Matroska SSA lines with fewer commas than expected throwing an error
+* Fix plain text import hanging when the max line length setting is zero
+* Fix OpenRouter speech to text with GPT transcription models - thx muaz978
+* Update German translation - thx FunkyKnilch
+* Update Japanese translation - thx hisui3393
+* Update Korean translation - thx 12si27
+
+-----------------------------------------------------------------------------------------------------
+
 v5.2.0-beta22 (23rd of August 2026)
 
 * Beautify time codes can now use the video's real frame times instead of assuming a constant frame rate - thx warrentc3

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "Subtitle Edit",
-  "version": "v5.2.0-beta22",
+  "version": "v5.2.0-beta23",
   "translatedBy": "",
   "cultureName": "en-US",
   "general": {

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -19,7 +19,7 @@ public class Se
     internal const int CurrentMacOsFontMigrationVersion = 1;
     internal const int CurrentShortcutsMigrationVersion = 2;
 
-    public static string Version { get; set; } = "v5.2.0-beta22";
+    public static string Version { get; set; } = "v5.2.0-beta23";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
Version bump to `v5.2.0-beta23` in `Se.cs` and the generated `English.json`, plus the change-log section.

## Change-log coverage
14 PRs merged since the `v5.2.0-beta22` tag, enumerated by ancestor-checking each merge commit against the tag (not by timestamp):

#14025, #14026, #14027 (three random bug sweeps, 30 fixes), #14028, #14033, #14034, #14035, #14036, #14037, #14039, #14040, #14041, #14043, #14044.

Left out of the change-log as internal-only: #14036 and #14037 (`CharUtils` renames).

## Notes
- Only `English.json` is bumped; `Japanese.json` / `Korean.json` keep their own translated-at version, as in previous beta preps.
- No metainfo `<release>` entry needed — the verify job skips it for pre-releases.

After merge, the release is cut with:

    gh workflow run "Build and release UI" --ref main -f release_tag=v5.2.0-beta23

🤖 Generated with [Claude Code](https://claude.com/claude-code)