### PR TITLE
Change-log: add the #14042 fixes to the beta23 section

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -19,6 +19,9 @@ v5.2.0-beta23 (24th of August 2026)
 * Fix crashes and wrong results when parsing malformed MP4, transport stream and RIFF files
 * Fix WebVTT thumbnail sprite sheets in .jpeg being rejected
 * Fix video OCR ending a subtitle too early after an unreadable frame
+* Fix teletext line length errors missing from the error lists in the main window and batch convert
+* Fix beautify time codes using a cancelled or failed frame time extraction when the video duration is unknown
+* Fix the speech to text quality report naming the wrong line for removed repeats
 * Fix Netflix "spell out leading number" doing nothing outside Windows
 * Fix Unknown 33/34/59 writing 00:00:60 instead of 00:01:00
 * Fix Matroska SSA lines with fewer commas than expected throwing an error


### PR DESCRIPTION
[#14042](https://github.com/SubtitleEdit/subtitleedit/pull/14042) merged into main between the point where I enumerated the beta23 change-log entries and the point where [#14045](https://github.com/SubtitleEdit/subtitleedit/pull/14045) merged, so it is in beta23 but had no entries.

Three of its four fixes are added — the teletext error-list gap, the beautify-time-codes partial extraction, and the STT quality report line reference. All three are bugs in features that shipped in beta22, so they belong in the change-log.

Its fourth fix (the ASSA `CheckForErrors` length guard) is deliberately left out: that mismatch was introduced by #14026 earlier in this same beta and never shipped, so it is an in-beta regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)