### PR TITLE
Fix two silent failures that could drop the video on mkv "Open with" (#14047)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -22147,7 +22147,25 @@ public partial class MainViewModel :
         var vp = GetVideoPlayerControl();
         if (vp == null)
         {
-            return;
+            // The player control can be legitimately missing for a moment: the undocked video
+            // window only gets its control once its Loaded event has run, and layout rebuilds
+            // swap controls via dispatcher posts. An open issued right after VideoUndockControls()
+            // - e.g. an "Open with"/CLI launch or session restore at startup - used to race that
+            // and silently never open the video (#14047). Wait (bounded) for the control; the
+            // delays yield the UI thread so the pending window/layout build can finish.
+            var waitUntil = DateTime.UtcNow.AddSeconds(5);
+            while (vp == null && DateTime.UtcNow < waitUntil)
+            {
+                await Task.Delay(50);
+                vp = GetVideoPlayerControl();
+            }
+
+            if (vp == null)
+            {
+                Se.LogError(new InvalidOperationException("No video player control available after 5 seconds"),
+                    $"VideoOpenFile could not open \"{videoFileName}\"");
+                return;
+            }
         }
 
         _videoOpenTokenSource?.Cancel();

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -35,6 +35,13 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
     private string _fileName = string.Empty;
     private double? _audioEndBound;
 
+    // A LoadFile that arrived before the (lazily initialized) core was up - replayed by
+    // MarkCoreInitialized as soon as the first render pass brings the core online (#14047).
+    // Claimed via Interlocked.Exchange so the replay and a concurrent LoadFile can't both
+    // run the same request.
+    private string? _pendingLoadFileName;
+    private double _pendingLoadStartPositionSeconds;
+
     // Observed-property caches, kept current by the mpv event thread (see StartEventLoop).
     // While _eventLoopActive the pause/speed/duration/eof getters read these instead of
     // doing a synchronous P/Invoke into the core per call. Doubles go through Interlocked
@@ -442,11 +449,51 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         var err = _mpvInitialize(_mpv);
         if (err >= 0)
         {
-            _coreInitialized = true;
-            StartEventLoop();
+            MarkCoreInitialized();
         }
 
         return err;
+    }
+
+    /// <summary>
+    /// Flips the core to initialized, starts the event loop, and replays a LoadFile that
+    /// arrived before the core was up. The core is created lazily by the first render pass
+    /// (see WaitForCoreInitializedAsync), so a load issued before any frame was rendered -
+    /// e.g. an "Open with" launch while the video window is still being built, or a window
+    /// opened minimized/behind - used to fail with MPV_ERROR_UNINITIALIZED and the open was
+    /// silently lost (#14047).
+    /// </summary>
+    private void MarkCoreInitialized()
+    {
+        _coreInitialized = true;
+        StartEventLoop();
+
+        var pendingFileName = Interlocked.Exchange(ref _pendingLoadFileName, null);
+        if (string.IsNullOrEmpty(pendingFileName))
+        {
+            return;
+        }
+
+        var startPositionSeconds = _pendingLoadStartPositionSeconds;
+
+        // Off this thread: the rendering Initialize* methods run during a render pass, and
+        // loadfile has no business there (it can block on I/O).
+        Task.Run(async () =>
+        {
+            try
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                await LoadFile(pendingFileName, startPositionSeconds);
+            }
+            catch (Exception e)
+            {
+                Se.LogError(e, "LibMpvDynamicPlayer deferred LoadFile replay");
+            }
+        });
     }
 
     /// <summary>
@@ -1019,8 +1066,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         }
         else
         {
-            _coreInitialized = true;
-            StartEventLoop();
+            MarkCoreInitialized();
         }
 
         // Create OpenGL init params
@@ -1120,8 +1166,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         }
         else
         {
-            _coreInitialized = true;
-            StartEventLoop();
+            MarkCoreInitialized();
         }
 
         // Build mpv_metal_init_params: device (required) + layer (optional).
@@ -1361,6 +1406,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
     public void Dispose()
     {
         _disposed = true;
+        _pendingLoadFileName = null;
 
         if (_renderContextNeedsGraphicsContext && _renderContext != IntPtr.Zero)
         {
@@ -1419,6 +1465,9 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
     {
         EnsureNotDisposed();
 
+        // A fresh explicit load supersedes any older one still parked for the core (#14047).
+        _pendingLoadFileName = null;
+
         // For audio-only files there is no video track, so mpv never fires the render
         // callback and subtitles are never drawn.  Inject a virtual black video stream
         // via lavfi so mpv has something to render subtitles on top of.
@@ -1445,6 +1494,34 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         }
 
         await WaitForCoreInitializedAsync();
+
+        if (!_coreInitialized)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            // Still not up: the core only comes online when the first render pass runs one of
+            // the Initialize* methods, and that pass hasn't happened yet (video window still
+            // being built, opened minimized or behind - e.g. an "Open with" launch, #14047).
+            // Issuing loadfile now would fail with MPV_ERROR_UNINITIALIZED and the open would
+            // be lost with only a log line to show for it. Park the request instead;
+            // MarkCoreInitialized replays it the moment the core comes up. Position before
+            // file name - the file name is the claim token, so it must be published last.
+            _fileName = path;
+            _pendingLoadStartPositionSeconds = startPositionSeconds;
+            _pendingLoadFileName = path;
+
+            // The core may have come up between the timeout above and parking the request,
+            // with MarkCoreInitialized finding no pending load to replay. Re-check and take
+            // the request back; if the exchange loses, MarkCoreInitialized owns the replay.
+            if (!_coreInitialized || Interlocked.Exchange(ref _pendingLoadFileName, null) == null)
+            {
+                Se.LogError("LibMpvDynamicPlayer LoadFile: mpv core not initialized yet - load of \"" + path + "\" deferred to core initialization");
+                return;
+            }
+        }
 
         // mpv's own default is pause=no, so it starts playing the instant it has decoded
         // something. The core is created paused (see the Initialize* methods) and every caller
@@ -1572,6 +1649,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
     public void CloseFile()
     {
         _fileName = string.Empty;
+        _pendingLoadFileName = null; // a close discards a load still parked for the core
         _pausedValue = null;
         _audioEndBound = null;
         _lastRawTimePos = -1;
@@ -2237,8 +2315,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
             throw new InvalidOperationException(GetErrorString(err));
         }
 
-        _coreInitialized = true;
-        StartEventLoop();
+        MarkCoreInitialized();
 
         // Build render context params for software rendering
         var apiTypeBytes = Encoding.UTF8.GetBytes(MPV_RENDER_API_TYPE_SW + "\0");


### PR DESCRIPTION
Hardens the two silent-failure gates found while analyzing #14047 (context-menu "Open with…" on an mkv loads the subtitle but not the video).

## Gate 1 — `VideoOpenFile` raced a null player control
The undocked video window only gets its `VideoPlayerControl` once its `Loaded` event has run, and layout rebuilds swap controls via dispatcher posts. The startup path calls `VideoUndockControls()` and opens the file 100 ms later — if the control wasn't up yet, `VideoOpenFile` returned silently and the video was never opened. Now it waits (bounded, 5 s, yielding the UI thread so the pending window build can finish) and logs an error if the control never appears.

## Gate 2 — `loadfile` against an uninitialized mpv core was lost
The mpv core is initialized lazily by the first render pass. `LoadFile` waited up to 5 s, then issued `loadfile` anyway — which failed with `MPV_ERROR_UNINITIALIZED` (window still being built, opened minimized/behind) and the open was lost with only a log line. The request is now parked and replayed by the new `MarkCoreInitialized()` (shared by all four init sites) the moment the core comes online. The pending load is claimed via `Interlocked.Exchange` so the replay and a concurrent explicit load can't both run it, and it is discarded on `CloseFile`/`Dispose` or when a newer load supersedes it.

Neither gate fully explains the report if both launch routes hit the same binary (the registry path in the report, `C:\Program Files\SubtitleEdit\`, matches neither the SE4 nor SE5 install dir — a stale second install is still the prime suspect there), but both were real silent-failure paths with exactly this symptom.

## Verification (macOS)
- mkv passed as CLI argument: subtitle extracted **and** video opened, docked config — no new error-log entries, video association persisted to recent files
- same with **undocked video controls at startup** (the gate-1 race window)
- full UI test suite: 3556 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)