### PR TITLE
Fix malformed format string in Italian.json (errorList.summaryX)

### DIFF
--- a/src/ui/Assets/Languages/Italian.json
+++ b/src/ui/Assets/Languages/Italian.json
@@ -3636,7 +3636,7 @@
   },
   "errorList": {
     "title": "Elenco errori",
-    "summaryX": "0} errore/i in {1} / {2} riga/e",
+    "summaryX": "{0} errore/i in {1} / {2} riga/e",
     "noErrors": "Nessun errore rilevato.",
     "summaryFilesX": "{0} errore/i in {1} riga/e in {2} file",
     "all": "Tutti",


### PR DESCRIPTION
#14049 introduced `"summaryX": "0} errore/i in {1} / {2} riga/e"` — the opening brace of `{0}` is missing, which fails `LanguageFileFormatStringTests.EveryTranslation_FormatsWithoutThrowing` and has made CI on main (and every open PR's merge-ref run, e.g. #14050) red since it merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)