### PR TITLE
Fix Qwen thinking leakage in llama.cpp translate/review

### DIFF
--- a/src/libuilogic/AutoTranslate/ChatGptTranslate.cs
+++ b/src/libuilogic/AutoTranslate/ChatGptTranslate.cs
@@ -57,9 +57,20 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             var translation = input;
             var indexOfStartThink = translation.IndexOf("<think>");
             var indexOfEndThink = translation.IndexOf("</think>");
-            if (indexOfStartThink >= 0 && indexOfEndThink > indexOfStartThink)
+            if (indexOfStartThink >= 0)
             {
-                translation = translation.Remove(indexOfStartThink, indexOfEndThink - indexOfStartThink + 8).Trim();
+                if (indexOfEndThink > indexOfStartThink)
+                {
+                    translation = translation.Remove(indexOfStartThink, indexOfEndThink - indexOfStartThink + 8).Trim();
+                }
+                else
+                {
+                    // The model started reasoning but the response was cut off (hit its token
+                    // budget) before closing the tag, so everything after "<think>" is raw
+                    // internal monologue, not a translation. Empty triggers the caller's
+                    // retry-on-no-progress logic (DoAutoTranslate) instead of shipping it.
+                    return string.Empty;
+                }
             }
 
             var match = PreambleRegex.Match(translation);

--- a/src/libuilogic/LlamaCpp/LlamaCppServerManager.cs
+++ b/src/libuilogic/LlamaCpp/LlamaCppServerManager.cs
@@ -128,30 +128,37 @@ public static class LlamaCppServerManager
         // Alternative model family. Qwen 3 is the strongest open model for CJK
         // (Chinese/Japanese/Korean) and competitive elsewhere — useful fallback
         // when Gemma's quirks bite (occasional refusals, formatting drift, etc).
-        // --no-jinja + chatml bypasses the embedded Jinja template's
-        // enable_thinking logic on the hybrid Qwen3-8B so output is clean
-        // translation, not <think>...</think> reasoning blocks.
+        // NoThinking (--reasoning off) suppresses the hybrid Qwen3 template's thinking mode so
+        // output is clean translation, not <think>...</think> reasoning blocks - same mechanism
+        // as Gemma 4 above. This used to be "--no-jinja --chat-template chatml" instead (forcing
+        // the template also bypasses enable_thinking), but that proved unreliable: a controlled
+        // A/B (seconv EN->DA, 10 reps x 20 lines on the Q8_0 9B, 200 lines/variant) measured
+        // chatml+no-jinja leaking raw <think> text - which runs the model out of its token budget
+        // before it ever reaches the translation - into 2.5% of lines (5/200), while NoThinking
+        // alone stayed at 0% (0/200) across every rep on both the 9B and the 4B Q4_K_M (0/60).
+        // Stacking both overrides is worse, not better (6.5% on 9B, 16.7% on 4B): --reasoning off
+        // does not reliably suppress thinking once --chat-template chatml has replaced the
+        // template it hooks into, so the two must never be combined.
         new LlamaCppModel("Qwen 3 4B Instruct (Q4_K_M)", "Qwen_Qwen3-4B-Instruct-2507-Q4_K_M.gguf", "2.5 GB",
             "https://huggingface.co/bartowski/Qwen_Qwen3-4B-Instruct-2507-GGUF/resolve/main/Qwen_Qwen3-4B-Instruct-2507-Q4_K_M.gguf",
-            ChatTemplate: "chatml", NoJinja: true),
+            NoThinking: true),
         new LlamaCppModel("Qwen 3 8B (Q4_K_M)", "Qwen_Qwen3-8B-Q4_K_M.gguf", "4.7 GB",
             "https://huggingface.co/bartowski/Qwen_Qwen3-8B-GGUF/resolve/main/Qwen_Qwen3-8B-Q4_K_M.gguf",
-            ChatTemplate: "chatml", NoJinja: true),
+            NoThinking: true),
 
-        // Qwen 3.5 - newer Qwen generation. Same chatml + --no-jinja handling as Qwen 3 (bypasses the
-        // embedded thinking template so the output is clean translation). Kept to <= 8 GB.
+        // Qwen 3.5 - newer Qwen generation. Same NoThinking handling as Qwen 3 above. Kept to <= 8 GB.
         new LlamaCppModel("Qwen 3.5 4B (Q4_K_M)", "Qwen_Qwen3.5-4B-Q4_K_M.gguf", "2.8 GB",
             "https://huggingface.co/bartowski/Qwen_Qwen3.5-4B-GGUF/resolve/main/Qwen_Qwen3.5-4B-Q4_K_M.gguf",
-            ChatTemplate: "chatml", NoJinja: true),
+            NoThinking: true),
         new LlamaCppModel("Qwen 3.5 4B (Q8_0)", "Qwen_Qwen3.5-4B-Q8_0.gguf", "4.3 GB",
             "https://huggingface.co/bartowski/Qwen_Qwen3.5-4B-GGUF/resolve/main/Qwen_Qwen3.5-4B-Q8_0.gguf",
-            ChatTemplate: "chatml", NoJinja: true),
+            NoThinking: true),
         new LlamaCppModel("Qwen 3.5 9B (Q4_K_M)", "Qwen_Qwen3.5-9B-Q4_K_M.gguf", "5.7 GB",
             "https://huggingface.co/bartowski/Qwen_Qwen3.5-9B-GGUF/resolve/main/Qwen_Qwen3.5-9B-Q4_K_M.gguf",
-            ChatTemplate: "chatml", NoJinja: true),
+            NoThinking: true),
         new LlamaCppModel("Qwen 3.5 9B (Q8_0)", "Qwen_Qwen3.5-9B-Q8_0.gguf", "9.8 GB",
             "https://huggingface.co/bartowski/Qwen_Qwen3.5-9B-GGUF/resolve/main/Qwen_Qwen3.5-9B-Q8_0.gguf",
-            ChatTemplate: "chatml", NoJinja: true),
+            NoThinking: true),
 
         // Qwen 3.6 35B-A3B - a mixture-of-experts model: 35B total but only ~3B active per token, so
         // it generates fast even fully on CPU. That makes it the option for machines with plenty of
@@ -163,7 +170,7 @@ public static class LlamaCppServerManager
         // Qwen 3.5 MoE arch), which the pinned engine already supports.
         new LlamaCppModel("Qwen 3.6 35B-A3B (IQ2_M) - fast on CPU, 2-bit quality", "Qwen3.6-35B-A3B-UD-IQ2_M.gguf", "11.5 GB",
             "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/Qwen3.6-35B-A3B-UD-IQ2_M.gguf",
-            ChatTemplate: "chatml", NoJinja: true),
+            NoThinking: true),
 
         // Hy-MT2 (Tencent Hunyuan-MT 2, 2026) - translation-specialized, official GGUFs, Apache-2.0.
         // Excellent for its 33+5 supported languages (CJK, major European/Asian) but has NO Nordic
@@ -198,22 +205,23 @@ public static class LlamaCppServerManager
     // JSON output, where the plain instruct models are much stronger. Kept to ~12 GB or below.
     public static readonly IReadOnlyList<LlamaCppModel> ReviewModels = new[]
     {
+        // NoThinking instead of chatml+no-jinja - see the note in TranslateModels for the A/B data.
         new LlamaCppModel("Qwen 3.5 4B (Q4_K_M)", "Qwen_Qwen3.5-4B-Q4_K_M.gguf", "2.8 GB",
             "https://huggingface.co/bartowski/Qwen_Qwen3.5-4B-GGUF/resolve/main/Qwen_Qwen3.5-4B-Q4_K_M.gguf",
-            ChatTemplate: "chatml", NoJinja: true),
+            NoThinking: true),
         new LlamaCppModel("Qwen 3.5 4B (Q8_0)", "Qwen_Qwen3.5-4B-Q8_0.gguf", "4.3 GB",
             "https://huggingface.co/bartowski/Qwen_Qwen3.5-4B-GGUF/resolve/main/Qwen_Qwen3.5-4B-Q8_0.gguf",
-            ChatTemplate: "chatml", NoJinja: true),
+            NoThinking: true),
         new LlamaCppModel("Qwen 3.5 9B (Q4_K_M)", "Qwen_Qwen3.5-9B-Q4_K_M.gguf", "5.7 GB",
             "https://huggingface.co/bartowski/Qwen_Qwen3.5-9B-GGUF/resolve/main/Qwen_Qwen3.5-9B-Q4_K_M.gguf",
-            ChatTemplate: "chatml", NoJinja: true),
+            NoThinking: true),
         new LlamaCppModel("Qwen 3.5 9B (Q8_0)", "Qwen_Qwen3.5-9B-Q8_0.gguf", "9.8 GB",
             "https://huggingface.co/bartowski/Qwen_Qwen3.5-9B-GGUF/resolve/main/Qwen_Qwen3.5-9B-Q8_0.gguf",
-            ChatTemplate: "chatml", NoJinja: true),
+            NoThinking: true),
         // MoE, ~3B active - fast on CPU; see the note in TranslateModels for the 2-bit caveat.
         new LlamaCppModel("Qwen 3.6 35B-A3B (IQ2_M) - fast on CPU, 2-bit quality", "Qwen3.6-35B-A3B-UD-IQ2_M.gguf", "11.5 GB",
             "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/Qwen3.6-35B-A3B-UD-IQ2_M.gguf",
-            ChatTemplate: "chatml", NoJinja: true),
+            NoThinking: true),
         new LlamaCppModel("Gemma 3 4B it (Q4_K_M)", "google_gemma-3-4b-it-Q4_K_M.gguf", "2.5 GB",
             "https://huggingface.co/bartowski/google_gemma-3-4b-it-GGUF/resolve/main/google_gemma-3-4b-it-Q4_K_M.gguf",
             ChatTemplate: "gemma", NoJinja: true),
@@ -396,12 +404,14 @@ public static class LlamaCppServerManager
     /// Picks the llama-server chat-template flags for a <c>.gguf</c> we do not curate (a file the user
     /// downloaded themselves, e.g. a TranslateGemma quant or size we do not offer). A curated entry with
     /// the same file name wins; otherwise the family is guessed from the file name, because getting this
-    /// wrong is not cosmetic: every Gemma we ship needs <c>gemma</c> + <c>--no-jinja</c> (TranslateGemma's
-    /// embedded Jinja template is non-standard) and every Qwen needs <c>chatml</c> + <c>--no-jinja</c> (to
-    /// bypass the embedded template's thinking mode, which otherwise emits &lt;think&gt; blocks instead of a
-    /// translation). Families with a usable embedded template (Aya, Llama, EuroLLM, Phi) fall through to
-    /// the default of no override. Gemma 4 keeps its embedded template but needs
-    /// <c>--reasoning off</c> instead (<c>NoThinking</c>), for the reason documented on
+    /// wrong is not cosmetic: every Gemma (2/3) we ship needs <c>gemma</c> + <c>--no-jinja</c>
+    /// (TranslateGemma's embedded Jinja template is non-standard), and every Qwen needs
+    /// <c>--reasoning off</c> (<c>NoThinking</c>) to suppress the hybrid template's thinking mode, which
+    /// otherwise emits &lt;think&gt; blocks instead of a translation - see the note on the curated Qwen
+    /// entries in <see cref="TranslateModels"/> for why this is <c>NoThinking</c> and not a
+    /// <c>chatml</c>/<c>--no-jinja</c> template override. Families with a usable embedded template (Aya,
+    /// Llama, EuroLLM, Phi) fall through to the default of no override. Gemma 4 also keeps its embedded
+    /// template and needs <c>--reasoning off</c>, for the same reason documented on
     /// <see cref="LlamaCppModel.NoThinking"/>.
     /// </summary>
     public static (string? ChatTemplate, bool NoJinja, bool NoThinking) InferChatTemplate(string fileName)
@@ -429,7 +439,7 @@ public static class LlamaCppServerManager
 
         if (fileName.Contains("qwen", StringComparison.OrdinalIgnoreCase))
         {
-            return ("chatml", true, false);
+            return (null, false, true);
         }
 
         return (null, false, false);

--- a/tests/libuilogic/AutoTranslate/ChatGptTranslateRemovePreambleTests.cs
+++ b/tests/libuilogic/AutoTranslate/ChatGptTranslateRemovePreambleTests.cs
@@ -1,0 +1,53 @@
+using Nikse.SubtitleEdit.UiLogic.AutoTranslate;
+
+namespace LibUiLogicTests.AutoTranslate;
+
+/// <summary>
+/// <see cref="ChatGptTranslate.RemovePreamble"/> is the shared post-processing step every
+/// OpenAI-compatible engine (ChatGPT, DeepSeek, Groq, Ollama, llama.cpp, ...) runs a raw model
+/// response through. A thinking model that closes its &lt;think&gt; block behaves fine; one that
+/// gets cut off mid-thought (hits its token budget before ever reaching the translation - the
+/// Qwen 3.5 leakage bug, see the note on the curated Qwen entries in LlamaCppServerManager) used
+/// to pass the raw reasoning text straight through as if it were the translation.
+/// </summary>
+public class ChatGptTranslateRemovePreambleTests
+{
+    [Fact]
+    public void ClosedThinkBlock_IsStrippedFromTranslation()
+    {
+        var result = ChatGptTranslate.RemovePreamble("Hello", "<think>reasoning here</think>Hej");
+
+        Assert.Equal("Hej", result);
+    }
+
+    /// <summary>
+    /// The model hit its token budget before closing the tag: what follows "&lt;think&gt;" is raw
+    /// internal monologue, not a translation. Returning it unstripped ships garbage into the
+    /// subtitle file (#Qwen 3.5 thinking-leakage bug); returning empty instead lets the caller's
+    /// existing retry-on-no-progress logic (DoAutoTranslate) re-request the line.
+    /// </summary>
+    [Fact]
+    public void UnterminatedThinkBlock_ReturnsEmpty()
+    {
+        var result = ChatGptTranslate.RemovePreamble("Hello",
+            "<think>\nThinking Process:\n1. **Analyze the Request:**\n   *   Source Text:");
+
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public void NoThinkBlock_IsUnaffected()
+    {
+        var result = ChatGptTranslate.RemovePreamble("Hello", "Hej");
+
+        Assert.Equal("Hej", result);
+    }
+
+    [Fact]
+    public void HerePreamble_IsStrippedAfterThinkBlockRemoval()
+    {
+        var result = ChatGptTranslate.RemovePreamble("Hello", "<think>x</think>Here is the translation: Hej");
+
+        Assert.Equal("Hej", result);
+    }
+}

--- a/tests/libuilogic/AutoTranslate/LlamaCppServerArgumentsTests.cs
+++ b/tests/libuilogic/AutoTranslate/LlamaCppServerArgumentsTests.cs
@@ -118,4 +118,26 @@ public class LlamaCppServerArgumentsTests
         Assert.NotEmpty(gemma4);
         Assert.All(gemma4, m => Assert.True(m.NoThinking, m.DisplayName + " must set NoThinking"));
     }
+
+    /// <summary>
+    /// A controlled A/B (seconv EN-&gt;DA, 10 reps x 20 lines on the Q8_0 9B, 200 lines/variant)
+    /// measured the old "chatml" + "--no-jinja" override leaking raw &lt;think&gt; text into 2.5%
+    /// of lines, while NoThinking alone stayed at 0% on both the 9B and 4B quants - and stacking
+    /// both overrides was worse than either alone (6.5% on 9B, 16.7% on 4B). Every curated Qwen
+    /// 3/3.5/3.6 entry must therefore use NoThinking and must not also force the chatml template.
+    /// </summary>
+    [Fact]
+    public void CuratedQwenModels_AllDisableThinkingAndNeverForceChatml()
+    {
+        var qwen = LlamaCppServerManager.TranslateModels
+            .Concat(LlamaCppServerManager.ReviewModels)
+            .Concat(LlamaCppServerManager.OcrModels)
+            .Where(m => m.FileName.Contains("qwen", System.StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        Assert.NotEmpty(qwen);
+        Assert.All(qwen, m => Assert.True(m.NoThinking, m.DisplayName + " must set NoThinking"));
+        Assert.All(qwen, m => Assert.Null(m.ChatTemplate));
+        Assert.All(qwen, m => Assert.False(m.NoJinja));
+    }
 }

--- a/tests/seconv/Core/AutoTranslateRunnerTest.cs
+++ b/tests/seconv/Core/AutoTranslateRunnerTest.cs
@@ -154,8 +154,9 @@ public class AutoTranslateRunnerTest : IDisposable
 
         Assert.NotNull(runner.LlamaCppModel);
         Assert.Equal(path, runner.LlamaCppModel!.FileName);
-        Assert.Equal("chatml", runner.LlamaCppModel.ChatTemplate);
-        Assert.True(runner.LlamaCppModel.NoJinja);
+        Assert.Null(runner.LlamaCppModel.ChatTemplate);
+        Assert.False(runner.LlamaCppModel.NoJinja);
+        Assert.True(runner.LlamaCppModel.NoThinking);
     }
 
     // A TranslateGemma size/quant we do not curate (issue #12440 asked for the 27B). Whether it is
@@ -195,7 +196,7 @@ public class AutoTranslateRunnerTest : IDisposable
     [InlineData("translategemma-4b_Q5_K_M.gguf", "gemma", true, false)]   // curated: exact match
     [InlineData("translategemma-27b-it.Q4_K_M.gguf", "gemma", true, false)] // uncurated: inferred
     [InlineData("google_gemma-3-27b-it-Q4_K_M.gguf", "gemma", true, false)]
-    [InlineData("Qwen_Qwen3.5-32B-Q4_K_M.gguf", "chatml", true, false)]
+    [InlineData("Qwen_Qwen3.5-32B-Q4_K_M.gguf", null, false, true)]
     [InlineData("aya-expanse-8b-Q4_K_M.gguf", null, false, false)]        // curated: embedded template
     [InlineData("Meta-Llama-3.1-70B-Instruct-Q4_K_M.gguf", null, false, false)]
     [InlineData("some-unknown-model.gguf", null, false, false)]


### PR DESCRIPTION
## Summary
- The curated Qwen 3/3.5/3.6 entries (both `TranslateModels` and `ReviewModels`, 12 entries total) forced `--no-jinja --chat-template chatml` to bypass the model's hybrid thinking mode. A controlled A/B (seconv EN->DA against a real `llama-server`, 10 reps × 20 lines on the Q8_0 9B = 200 lines/variant, plus 3 reps on the 4B Q4_K_M) showed this leaks raw `<think>...` text into 2.5% of lines - the model runs out of its token budget before ever reaching the translation, so the subtitle line ends up as unusable reasoning garbage instead of a translation.
- `NoThinking` (`--reasoning off`, leaving the embedded Jinja template alone) - the same mechanism already used by every Gemma 4 entry - stayed at **0% across every single rep on both model sizes** (0/260 lines total). Stacking both overrides together is *worse* than either alone (6.5% on 9B, 16.7% on 4B): `--reasoning off` doesn't reliably suppress thinking once `--chat-template chatml` has replaced the template it hooks into. Switched every curated Qwen entry, plus the filename-inference fallback for self-supplied Qwen `.gguf`s, to `NoThinking` instead.
- Hardened `ChatGptTranslate.RemovePreamble` (shared by every OpenAI-compatible translate engine, including llama.cpp) so an *unterminated* `<think>` block - the actual failure mode observed, since the close tag never arrives - returns empty instead of passing raw reasoning text through. This activates the existing retry-on-no-progress logic in `DoAutoTranslate` as a defense-in-depth backstop, in case any thinking model ever leaks again for an unrelated reason.
- AI review didn't need an equivalent code change: `AiReviewClient.ExtractContent` parses `message.content` as JSON per the strict review protocol, so a `<think>` leak there already fails JSON parsing and hits the existing "no JSON in reply - retrying once" path.

## Test plan
- [x] `dotnet test tests/libuilogic/LibUiLogicTests.csproj -c Release` - 529 passed
- [x] `dotnet test tests/seconv/SeConvTests.csproj -c Release` - 383 passed
- [x] New tests: `CuratedQwenModels_AllDisableThinkingAndNeverForceChatml` (every curated Qwen entry uses `NoThinking`, never `ChatTemplate`/`NoJinja`), `ChatGptTranslateRemovePreambleTests` (closed think block still stripped; unterminated think block now returns empty; unaffected cases unchanged)
- [x] Live A/B validation against a real `llama-server` + the production `seconv --translate-engine:llamacpp` path (not just unit tests) - see numbers above

🤖 Generated with [Claude Code](https://claude.com/claude-code)