### PR TITLE
Keep the original text when a dialog's result is applied (#14053)

### DIFF
--- a/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
+++ b/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -287,8 +287,10 @@ public partial class MultipleReplaceViewModel : ObservableObject
         // Apply the currently checked replacements to the document, then make the result the new
         // working subtitle so the next round operates on the already-fixed text - without closing
         // the window (Subtitle Edit 4 had this re-usable "Apply" button - #12029).
-        OnApply?.Invoke(new Subtitle(FixedSubtitle), Fixes.Count(f => f.Apply));
-        _subtitle = new Subtitle(FixedSubtitle);
+        // generateNewId: false - the paragraph ids are how the main window finds the grid row each
+        // line came from, so they must survive every Apply round (#14053).
+        OnApply?.Invoke(new Subtitle(FixedSubtitle, false), Fixes.Count(f => f.Apply));
+        _subtitle = new Subtitle(FixedSubtitle, false);
         _dirty = true;
         GeneratePreview();
     }

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -7155,8 +7155,10 @@ public partial class MainViewModel :
 
         var idx = SelectedSubtitleIndex ?? 0;
 
-        // Same filter as GetUpdateSubtitle() below, so index N of the reviewed subtitle is line N
-        // here - that mapping is what lets the review window play the line of a suggestion.
+        var subtitle = GetUpdateSubtitleWithRowMap(out var rowByParagraphId);
+
+        // Same filter as GetUpdateSubtitle(), so index N of the reviewed subtitle is line N here -
+        // that mapping is what lets the review window play the line of a suggestion.
         var reviewedLines = Subtitles.Where(s => !s.IsReferenceOnly).ToList();
         // Apply/Ok: each Apply pushes the checked fixes into the grid and the review window stays
         // open with the rest of the suggestions, so a review that took minutes is not spent on one
@@ -7175,11 +7177,11 @@ public partial class MainViewModel :
                 }
             }
 
-            ApplyFixedSubtitle(applied, idx, SelectedSubtitleFormat);
+            ApplyFixedSubtitle(applied, rowByParagraphId, idx, SelectedSubtitleFormat);
             ShowStatus(string.Format(Se.Language.Main.FixedXLines, changed));
 
-            // Re-fill the same list instance the play hook closed over: with reference-only rows in
-            // the grid, ApplyFixedSubtitle rebuilds it and the rows captured before are detached.
+            // Re-fill the same list instance the play hook closed over, in case a row of it is no
+            // longer in the grid.
             var current = Subtitles.Where(s => !s.IsReferenceOnly).ToList();
             reviewedLines.Clear();
             reviewedLines.AddRange(current);
@@ -7187,7 +7189,7 @@ public partial class MainViewModel :
 
         await ShowDialogAsync<AiReviewWindow, AiReviewViewModel>(vm =>
         {
-            vm.Initialize(GetUpdateSubtitle(), SelectedSubtitleFormat, MakeReviewLinePlayer(reviewedLines), StopReviewLinePlayback, ApplyToGrid);
+            vm.Initialize(subtitle, SelectedSubtitleFormat, MakeReviewLinePlayer(reviewedLines), StopReviewLinePlayback, ApplyToGrid);
         });
     }
 
@@ -7279,11 +7281,12 @@ public partial class MainViewModel :
         }
 
         var idx = SelectedSubtitleIndex ?? 0;
-        var viewModel = await ShowDialogAsync<FixCommonErrorsWindow, FixCommonErrorsViewModel>(vm => { vm.Initialize(GetUpdateSubtitle(), SelectedSubtitleFormat); });
+        var subtitle = GetUpdateSubtitleWithRowMap(out var rowByParagraphId);
+        var viewModel = await ShowDialogAsync<FixCommonErrorsWindow, FixCommonErrorsViewModel>(vm => { vm.Initialize(subtitle, SelectedSubtitleFormat); });
 
         if (viewModel.OkPressed)
         {
-            ApplyFixedSubtitle(viewModel.FixedSubtitle, idx, SelectedSubtitleFormat);
+            ApplyFixedSubtitle(viewModel.FixedSubtitle, rowByParagraphId, idx, SelectedSubtitleFormat);
             ShowStatus(string.Format(Se.Language.Main.FixedXLines, viewModel.FixedSubtitle.Paragraphs.Count));
         }
     }
@@ -7303,11 +7306,12 @@ public partial class MainViewModel :
         }
 
         var idx = SelectedSubtitleIndex ?? 0;
-        var viewModel = await ShowDialogAsync<FixNetflixErrorsWindow, FixNetflixErrorsViewModel>(vm => { vm.Initialize(GetUpdateSubtitle(), _videoFileName ?? string.Empty); });
+        var subtitle = GetUpdateSubtitleWithRowMap(out var rowByParagraphId);
+        var viewModel = await ShowDialogAsync<FixNetflixErrorsWindow, FixNetflixErrorsViewModel>(vm => { vm.Initialize(subtitle, _videoFileName ?? string.Empty); });
 
         if (viewModel.OkPressed)
         {
-            ApplyFixedSubtitle(viewModel.FixedSubtitle, idx, SelectedSubtitleFormat);
+            ApplyFixedSubtitle(viewModel.FixedSubtitle, rowByParagraphId, idx, SelectedSubtitleFormat);
             ShowStatus(string.Format(Se.Language.Main.FixedXLines, viewModel.FixedSubtitle.Paragraphs.Count));
         }
     }
@@ -14366,29 +14370,26 @@ public partial class MainViewModel :
             return;
         }
 
+        var subtitle = GetUpdateSubtitleWithRowMap(out var rowByParagraphId);
         var result =
             await ShowDialogAsync<MultipleReplaceWindow, MultipleReplaceViewModel>(vm =>
             {
-                vm.Initialize(GetUpdateSubtitle());
+                vm.Initialize(subtitle);
 
                 // "Apply" applies the replacements live without closing, so several rounds can be run (#12029).
                 vm.OnApply = (fixedSubtitle, count) =>
                 {
-                    // Replacements are 1:1 with the lines they came from, so stay on the line the
-                    // user was on - jumping to the top on every Apply lost their place, and Apply
+                    // The result goes back on the rows it came from, so the user stays on the line
+                    // they were on - jumping to the top on every Apply lost their place, and Apply
                     // is meant to be used several times in a row (issue #13822).
-                    var selectedIndex = SelectedSubtitleIndex ?? 0;
-                    SetSubtitles(fixedSubtitle);
-                    SelectAndScrollToRow(Math.Min(selectedIndex, Subtitles.Count - 1));
+                    ApplyFixedSubtitle(fixedSubtitle, rowByParagraphId, SelectedSubtitleIndex ?? 0, SelectedSubtitleFormat);
                     ShowStatus(string.Format(Se.Language.Main.ReplacedXOccurrences, count));
                 };
             });
 
         if (result.OkPressed)
         {
-            var selectedIndex = SelectedSubtitleIndex ?? 0;
-            SetSubtitles(result.FixedSubtitle);
-            SelectAndScrollToRow(Math.Min(selectedIndex, Subtitles.Count - 1));
+            ApplyFixedSubtitle(result.FixedSubtitle, rowByParagraphId, SelectedSubtitleIndex ?? 0, SelectedSubtitleFormat);
             ShowStatus(string.Format(Se.Language.Main.ReplacedXOccurrences, result.TotalReplaced));
         }
     }
@@ -18832,26 +18833,190 @@ public partial class MainViewModel :
     }
 
     /// <summary>
-    /// Applies the fixed subtitle returned by Fix Common Errors / Fix Netflix Errors.
-    /// When the paragraph count is unchanged (the common case), updates each
-    /// SubtitleLineViewModel in-place so the grid keeps its current scroll position
-    /// and selection without any manipulation.
-    /// Falls back to a full SetSubtitles reset only when rows were added or removed.
+    /// <see cref="GetUpdateSubtitle"/> for a dialog that edits the subtitle, plus the row mapping
+    /// <see cref="ApplyFixedSubtitle(Subtitle, IReadOnlyDictionary{Guid, SubtitleLineViewModel}, int, SubtitleFormat?)"/>
+    /// needs to put the dialog's result back on the rows it came from.
     /// </summary>
-    private void ApplyFixedSubtitle(Subtitle fixedSubtitle, int selectedIndex, SubtitleFormat? subtitleFormat)
+    private Subtitle GetUpdateSubtitleWithRowMap(out Dictionary<Guid, SubtitleLineViewModel> rowByParagraphId)
     {
-        if (fixedSubtitle.Paragraphs.Count == Subtitles.Count)
+        var subtitle = GetUpdateSubtitle();
+        rowByParagraphId = MapParagraphIdsToRows(subtitle);
+        return subtitle;
+    }
+
+    /// <summary>
+    /// Pairs the working rows with the paragraphs <see cref="GetUpdateSubtitle"/> just built from
+    /// them - one paragraph per non-reference row, in row order. The dialogs copy their input with
+    /// <c>new Subtitle(subtitle, generateNewId: false)</c>, so these ids survive the round trip and
+    /// still name a row in the result, whatever the dialog did to the line count.
+    /// </summary>
+    private Dictionary<Guid, SubtitleLineViewModel> MapParagraphIdsToRows(Subtitle subtitle)
+    {
+        var map = new Dictionary<Guid, SubtitleLineViewModel>(subtitle.Paragraphs.Count);
+        var index = 0;
+        foreach (var row in Subtitles)
         {
-            for (var i = 0; i < Subtitles.Count; i++)
-                Subtitles[i].UpdateFrom(fixedSubtitle.Paragraphs[i], subtitleFormat);
+            if (row.IsReferenceOnly)
+            {
+                continue;
+            }
+
+            if (index >= subtitle.Paragraphs.Count)
+            {
+                break;
+            }
+
+            if (subtitle.Paragraphs[index].Id is { } id)
+            {
+                map[id] = row;
+            }
+
+            index++;
+        }
+
+        return map;
+    }
+
+    /// <summary>
+    /// Applies the subtitle a dialog returned (Fix common errors, Fix Netflix errors, AI review,
+    /// Multiple replace) onto the rows it was built from, matched by paragraph id.
+    ///
+    /// The rows are updated in place and never rebuilt. A rebuild drops everything a row holds
+    /// beside the paragraph - the original/translation text above all, which lives on the row and
+    /// nowhere else (<see cref="GetUpdateSubtitleOriginal"/> serializes the file from it), so
+    /// replacing the rows emptied the original column of a translation and then wrote empty lines
+    /// when it was saved (#14053). Display-only original rows went the same way, as they are not
+    /// part of the dialog's subtitle at all.
+    ///
+    /// Deletions are honored by removing exactly the rows whose paragraph is gone - Fix common
+    /// errors removes empty lines, Fix Netflix errors calls RemoveEmptyLines - and the display-only
+    /// rows are put back where they sat.
+    /// </summary>
+    private void ApplyFixedSubtitle(
+        Subtitle fixedSubtitle,
+        IReadOnlyDictionary<Guid, SubtitleLineViewModel> rowByParagraphId,
+        int selectedIndex,
+        SubtitleFormat? subtitleFormat)
+    {
+        // Only rows still in the grid may be reused: after an "Apply" that removed lines, the map
+        // still holds the rows that went with them.
+        var live = new HashSet<SubtitleLineViewModel>(Subtitles);
+        var workingRows = Subtitles.Where(p => !p.IsReferenceOnly).ToList();
+
+        // A dialog that copied its subtitle with fresh ids would match nothing and every line would
+        // come in as a new row. As long as the line count still matches the grid, fall back to the
+        // positional mapping this method used before the ids were tracked - rebuilding the rows is
+        // the one outcome worth avoiding.
+        if (fixedSubtitle.Paragraphs.Count == workingRows.Count &&
+            !fixedSubtitle.Paragraphs.Any(p => p.Id is { } id && rowByParagraphId.ContainsKey(id)))
+        {
+            var positional = new Dictionary<Guid, SubtitleLineViewModel>(workingRows.Count);
+            for (var i = 0; i < workingRows.Count; i++)
+            {
+                if (fixedSubtitle.Paragraphs[i].Id is { } id)
+                {
+                    positional[id] = workingRows[i];
+                }
+            }
+
+            rowByParagraphId = positional;
+        }
+
+        var working = new List<SubtitleLineViewModel>(fixedSubtitle.Paragraphs.Count);
+        var kept = new HashSet<SubtitleLineViewModel>();
+        foreach (var p in fixedSubtitle.Paragraphs)
+        {
+            // No id match means the dialog added the line, or a merge consumed the row that owned
+            // the id - either way there is no row to keep, so it comes in as a new row.
+            if (p.Id is { } id &&
+                rowByParagraphId.TryGetValue(id, out var row) &&
+                live.Contains(row) &&
+                kept.Add(row))
+            {
+                row.UpdateFrom(p, subtitleFormat);
+                working.Add(row);
+            }
+            else
+            {
+                working.Add(new SubtitleLineViewModel(p, subtitleFormat ?? SelectedSubtitleFormat));
+            }
+        }
+
+        // Each display-only row follows the working row it sat behind; ones that came before any
+        // surviving row go back to the front.
+        var leadingReferenceRows = new List<SubtitleLineViewModel>();
+        var referenceRowsAfter = new Dictionary<SubtitleLineViewModel, List<SubtitleLineViewModel>>();
+        SubtitleLineViewModel? anchor = null;
+        foreach (var row in Subtitles)
+        {
+            if (row.IsReferenceOnly)
+            {
+                if (anchor == null)
+                {
+                    leadingReferenceRows.Add(row);
+                }
+                else
+                {
+                    if (!referenceRowsAfter.TryGetValue(anchor, out var rows))
+                    {
+                        rows = new List<SubtitleLineViewModel>();
+                        referenceRowsAfter[anchor] = rows;
+                    }
+
+                    rows.Add(row);
+                }
+            }
+            else if (kept.Contains(row))
+            {
+                anchor = row;
+            }
+        }
+
+        var result = new List<SubtitleLineViewModel>(working.Count + leadingReferenceRows.Count);
+        result.AddRange(leadingReferenceRows);
+        foreach (var row in working)
+        {
+            result.Add(row);
+            if (referenceRowsAfter.TryGetValue(row, out var rows))
+            {
+                result.AddRange(rows);
+            }
+        }
+
+        if (SameRows(result))
+        {
+            // The common case: same rows in the same order, so the grid keeps its scroll position
+            // and selection with no manipulation at all (#13822).
             Renumber();
             UpdateGaps();
+            return;
         }
-        else
+
+        ReplaceSubtitles(result);
+        Renumber();
+        UpdateGaps();
+        if (Subtitles.Count > 0)
         {
-            SetSubtitles(fixedSubtitle);
-            SelectAndScrollToRow(Math.Min(selectedIndex, Subtitles.Count - 1));
+            SelectAndScrollToRow(Math.Clamp(selectedIndex, 0, Subtitles.Count - 1));
         }
+    }
+
+    private bool SameRows(List<SubtitleLineViewModel> rows)
+    {
+        if (rows.Count != Subtitles.Count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < rows.Count; i++)
+        {
+            if (!ReferenceEquals(rows[i], Subtitles[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/tests/UI/Features/Edit/MultipleReplaceParagraphIdTests.cs
+++ b/tests/UI/Features/Edit/MultipleReplaceParagraphIdTests.cs
@@ -1,0 +1,116 @@
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Edit.MultipleReplace;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace UITests.Features.Edit;
+
+/// <summary>
+/// The paragraph ids of the subtitle Multiple replace was handed are how the main window finds the
+/// grid row each line came from, so the result must carry them back - "Apply" rounds included.
+/// Copying the subtitle with new ids made every line look like a line the main window had never
+/// seen, which meant rebuilding the rows and losing the original text of a translation (#14053).
+/// </summary>
+public class MultipleReplaceParagraphIdTests
+{
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    [AvaloniaFact]
+    public void Apply_HandsBackTheParagraphIdsItWasGiven()
+    {
+        var (vm, ids) = WithThreeMatchingLines();
+        Subtitle? applied = null;
+        vm.OnApply = (subtitle, _) => applied = subtitle;
+
+        vm.ApplyCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.NotNull(applied);
+        Assert.Equal(ids, applied!.Paragraphs.Select(p => p.Id).ToList());
+        Assert.Equal("The color is red.", applied.Paragraphs[0].Text);
+    }
+
+    [AvaloniaFact]
+    public void SecondApplyRound_StillHasTheSameParagraphIds()
+    {
+        var (vm, ids) = WithThreeMatchingLines();
+        var applied = new List<Subtitle>();
+        vm.OnApply = (subtitle, _) => applied.Add(subtitle);
+
+        vm.ApplyCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+        vm.ApplyCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(2, applied.Count);
+        Assert.Equal(ids, applied[1].Paragraphs.Select(p => p.Id).ToList());
+    }
+
+    [AvaloniaFact]
+    public void Ok_HandsBackTheParagraphIdsItWasGiven()
+    {
+        var (vm, ids) = WithThreeMatchingLines();
+
+        vm.OkCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(vm.OkPressed);
+        Assert.Equal(ids, vm.FixedSubtitle.Paragraphs.Select(p => p.Id).ToList());
+    }
+
+    private static (MultipleReplaceViewModel Vm, List<Guid?> Ids) WithThreeMatchingLines()
+    {
+        var vm = new MultipleReplaceViewModel(new WindowService(new NullServiceProvider()), new FileHelper());
+        vm.Nodes.Clear();
+
+        var category = new RuleTreeNode(true) { CategoryName = "c1", IsActive = true };
+        vm.Nodes.Add(category);
+        category.SubNodes!.Add(new RuleTreeNode(false)
+        {
+            Find = "colour",
+            ReplaceWith = "color",
+            IsActive = true,
+            Parent = category,
+            Type = MultipleReplaceType.CaseInsensitive,
+        });
+
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("The colour is red.", 0, 2000));
+        subtitle.Paragraphs.Add(new Paragraph("The colour is green.", 2000, 4000));
+        subtitle.Paragraphs.Add(new Paragraph("The colour is blue.", 4000, 6000));
+        vm.Initialize(subtitle);
+
+        WaitForPreview(vm, 3);
+        Assert.Equal(3, vm.Fixes.Count);
+
+        return (vm, subtitle.Paragraphs.Select(p => p.Id).ToList());
+    }
+
+    // The preview is generated on a background timer, so waiting is the only way to observe it.
+    private static void WaitForPreview(MultipleReplaceViewModel vm, int expectedFixes)
+    {
+        var end = Environment.TickCount64 + 3000;
+        while (Environment.TickCount64 < end)
+        {
+            Dispatcher.UIThread.RunJobs();
+            if (vm.Fixes.Count == expectedFixes)
+            {
+                Dispatcher.UIThread.RunJobs();
+                return;
+            }
+
+            Thread.Sleep(20);
+        }
+
+        Dispatcher.UIThread.RunJobs();
+    }
+}

--- a/tests/UI/Features/Main/ApplyFixedSubtitleRowMappingTests.cs
+++ b/tests/UI/Features/Main/ApplyFixedSubtitleRowMappingTests.cs
@@ -1,0 +1,343 @@
+using System.Reflection;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// The subtitle a dialog returns (Multiple replace, Fix common errors, Fix Netflix errors, AI
+/// review) is applied onto the very grid rows it was built from, matched by paragraph id.
+///
+/// Rebuilding the rows instead dropped everything a row holds beside the paragraph: the original
+/// text of a translation lives on the row and nowhere else, so Multiple replace emptied the
+/// original column and saving the original then wrote empty lines (#14053). Display-only original
+/// rows disappeared the same way, as they are never part of the dialog's subtitle.
+/// </summary>
+public class ApplyFixedSubtitleRowMappingTests
+{
+    [AvaloniaFact]
+    public void ReplacedText_KeepsTheOriginalTextAndTheRowItself()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Translated one", "Original one", 0, 2000);
+            AddLine(vm, "Translated two", "Original two", 2000, 4000);
+            vm.ShowColumnOriginalText = true;
+            var rows = vm.Subtitles.ToList();
+
+            var fixedSubtitle = OpenDialogWith(vm, out var rowMap);
+            fixedSubtitle.Paragraphs[0].Text = "Replaced one";
+            ApplyFixedSubtitle(vm, fixedSubtitle, rowMap);
+
+            Assert.Equal(new[] { "Replaced one", "Translated two" }, vm.Subtitles.Select(p => p.Text));
+            Assert.Equal(new[] { "Original one", "Original two" }, vm.Subtitles.Select(p => p.OriginalText));
+
+            // Same row instances - nothing that hangs off a row (selection, the waveform's match by
+            // id, the original text) is invalidated by an edit.
+            Assert.Same(rows[0], vm.Subtitles[0]);
+            Assert.Same(rows[1], vm.Subtitles[1]);
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    /// <summary>
+    /// Fix common errors removes empty lines and Fix Netflix errors calls RemoveEmptyLines, so a
+    /// result with fewer lines than the grid is an everyday case - and the lines that stay must keep
+    /// their original text.
+    /// </summary>
+    [AvaloniaFact]
+    public void DeletedLine_RemovesThatRowOnlyAndKeepsTheOtherOriginals()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Translated one", "Original one", 0, 2000);
+            AddLine(vm, "Translated two", "Original two", 2000, 4000);
+            AddLine(vm, "Translated three", "Original three", 4000, 6000);
+            vm.ShowColumnOriginalText = true;
+            var rows = vm.Subtitles.ToList();
+
+            var fixedSubtitle = OpenDialogWith(vm, out var rowMap);
+            fixedSubtitle.Paragraphs.RemoveAt(1);
+            ApplyFixedSubtitle(vm, fixedSubtitle, rowMap);
+
+            Assert.Equal(new[] { "Translated one", "Translated three" }, vm.Subtitles.Select(p => p.Text));
+            Assert.Equal(new[] { "Original one", "Original three" }, vm.Subtitles.Select(p => p.OriginalText));
+            Assert.Same(rows[0], vm.Subtitles[0]);
+            Assert.Same(rows[2], vm.Subtitles[1]);
+
+            // The remaining lines are renumbered, and the saved original follows the grid.
+            Assert.Equal(new[] { 1, 2 }, vm.Subtitles.Select(p => p.Number));
+            Assert.Equal(
+                new[] { "Original one", "Original three" },
+                vm.GetUpdateSubtitleOriginal().Paragraphs.Select(p => p.Text));
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    [AvaloniaFact]
+    public void AddedLine_ComesInAsANewRow()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Translated one", "Original one", 0, 2000);
+            AddLine(vm, "Translated two", "Original two", 4000, 6000);
+            vm.ShowColumnOriginalText = true;
+            var rows = vm.Subtitles.ToList();
+
+            var fixedSubtitle = OpenDialogWith(vm, out var rowMap);
+            fixedSubtitle.Paragraphs.Insert(1, new Paragraph("Added line", 2000, 4000));
+            ApplyFixedSubtitle(vm, fixedSubtitle, rowMap);
+
+            Assert.Equal(
+                new[] { "Translated one", "Added line", "Translated two" },
+                vm.Subtitles.Select(p => p.Text));
+            Assert.Equal(
+                new[] { "Original one", string.Empty, "Original two" },
+                vm.Subtitles.Select(p => p.OriginalText));
+            Assert.Same(rows[0], vm.Subtitles[0]);
+            Assert.Same(rows[1], vm.Subtitles[2]);
+            Assert.Equal(new[] { 1, 2, 3 }, vm.Subtitles.Select(p => p.Number));
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    /// <summary>
+    /// Display-only rows hold original lines with no counterpart in the working subtitle, so they
+    /// are not in the dialog's subtitle at all: they must survive the apply, and stay where they
+    /// were relative to the lines around them.
+    /// </summary>
+    [AvaloniaFact]
+    public void DeletedLine_KeepsTheDisplayOnlyOriginalRowsInPlace()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Translated one", "Original one", 0, 2000);
+            AddLine(vm, "Translated two", "Original two", 2000, 4000);
+            var referenceRow = AddLine(vm, string.Empty, "Original with no translation", 4000, 6000);
+            referenceRow.IsReferenceOnly = true;
+            AddLine(vm, "Translated three", "Original three", 6000, 8000);
+            vm.ShowColumnOriginalText = true;
+
+            var fixedSubtitle = OpenDialogWith(vm, out var rowMap);
+
+            // Only the three working lines are handed to a dialog.
+            Assert.Equal(3, fixedSubtitle.Paragraphs.Count);
+
+            fixedSubtitle.Paragraphs.RemoveAt(1);
+            ApplyFixedSubtitle(vm, fixedSubtitle, rowMap);
+
+            Assert.Equal(
+                new[] { "Translated one", string.Empty, "Translated three" },
+                vm.Subtitles.Select(p => p.Text));
+            Assert.Same(referenceRow, vm.Subtitles[1]);
+            Assert.True(vm.Subtitles[1].IsReferenceOnly);
+            Assert.Equal("Original with no translation", vm.Subtitles[1].OriginalText);
+
+            // A display-only row still takes no number.
+            Assert.Equal(new[] { 1, 2 }, vm.Subtitles.Where(p => !p.IsReferenceOnly).Select(p => p.Number));
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    /// <summary>
+    /// Multiple replace's "Apply" keeps the window open for another round, so the same mapping is
+    /// used again - after it has already deleted rows. A row that is gone from the grid must not be
+    /// resurrected by a later round.
+    /// </summary>
+    [AvaloniaFact]
+    public void SecondApplyRound_DoesNotBringBackARowTheFirstOneDeleted()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Translated one", "Original one", 0, 2000);
+            AddLine(vm, "Translated two", "Original two", 2000, 4000);
+            vm.ShowColumnOriginalText = true;
+            var rows = vm.Subtitles.ToList();
+
+            var firstRound = OpenDialogWith(vm, out var rowMap);
+            firstRound.Paragraphs.RemoveAt(1);
+            ApplyFixedSubtitle(vm, firstRound, rowMap);
+            Assert.Single(vm.Subtitles);
+
+            // The dialog carries its own subtitle over to the next round with the ids intact.
+            var secondRound = new Subtitle(firstRound, false);
+            secondRound.Paragraphs[0].Text = "Replaced one";
+            ApplyFixedSubtitle(vm, secondRound, rowMap);
+
+            Assert.Single(vm.Subtitles);
+            Assert.Same(rows[0], vm.Subtitles[0]);
+            Assert.Equal("Replaced one", vm.Subtitles[0].Text);
+            Assert.Equal("Original one", vm.Subtitles[0].OriginalText);
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    /// <summary>
+    /// A rule may empty the grid - a subtitle of nothing but empty lines run through Fix common
+    /// errors, say - and there is then no row left to select.
+    /// </summary>
+    [AvaloniaFact]
+    public void EveryLineDeleted_LeavesAnEmptyGrid()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Translated one", "Original one", 0, 2000);
+            AddLine(vm, "Translated two", "Original two", 2000, 4000);
+            vm.ShowColumnOriginalText = true;
+
+            var fixedSubtitle = OpenDialogWith(vm, out var rowMap);
+            fixedSubtitle.Paragraphs.Clear();
+            ApplyFixedSubtitle(vm, fixedSubtitle, rowMap);
+
+            Assert.Empty(vm.Subtitles);
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    /// <summary>
+    /// The safety net for a dialog that hands back a subtitle with fresh paragraph ids: nothing
+    /// matches, but as long as the line count is unchanged the rows are still updated in place
+    /// rather than rebuilt.
+    /// </summary>
+    [AvaloniaFact]
+    public void ResultWithUnknownIds_AndTheSameLineCount_StillUpdatesTheRowsInPlace()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Translated one", "Original one", 0, 2000);
+            AddLine(vm, "Translated two", "Original two", 2000, 4000);
+            vm.ShowColumnOriginalText = true;
+            var rows = vm.Subtitles.ToList();
+
+            OpenDialogWith(vm, out var rowMap);
+
+            // generateNewId defaults to true, so not one id of this copy is in the map.
+            var fixedSubtitle = new Subtitle(vm.GetUpdateSubtitle());
+            fixedSubtitle.Paragraphs[1].Text = "Replaced two";
+            ApplyFixedSubtitle(vm, fixedSubtitle, rowMap);
+
+            Assert.Equal(new[] { "Translated one", "Replaced two" }, vm.Subtitles.Select(p => p.Text));
+            Assert.Equal(new[] { "Original one", "Original two" }, vm.Subtitles.Select(p => p.OriginalText));
+            Assert.Same(rows[0], vm.Subtitles[0]);
+            Assert.Same(rows[1], vm.Subtitles[1]);
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    /// <summary>
+    /// What a dialog is handed and the mapping that puts its result back, exactly as the call sites
+    /// do it.
+    /// </summary>
+    private static Subtitle OpenDialogWith(MainViewModel vm, out IReadOnlyDictionary<Guid, SubtitleLineViewModel> rowMap)
+    {
+        var method = typeof(MainViewModel).GetMethod(
+                         "GetUpdateSubtitleWithRowMap", BindingFlags.Instance | BindingFlags.NonPublic)
+                     ?? throw new InvalidOperationException("GetUpdateSubtitleWithRowMap not found");
+
+        var args = new object?[] { null };
+        var subtitle = (Subtitle)method.Invoke(vm, args)!;
+        rowMap = (IReadOnlyDictionary<Guid, SubtitleLineViewModel>)args[0]!;
+
+        // The dialogs work on a copy that keeps the paragraph ids.
+        return new Subtitle(subtitle, false);
+    }
+
+    private static void ApplyFixedSubtitle(
+        MainViewModel vm, Subtitle fixedSubtitle, IReadOnlyDictionary<Guid, SubtitleLineViewModel> rowMap)
+    {
+        var method = typeof(MainViewModel).GetMethod(
+                         "ApplyFixedSubtitle",
+                         BindingFlags.Instance | BindingFlags.NonPublic,
+                         null,
+                         new[]
+                         {
+                             typeof(Subtitle),
+                             typeof(IReadOnlyDictionary<Guid, SubtitleLineViewModel>),
+                             typeof(int),
+                             typeof(SubtitleFormat),
+                         },
+                         null)
+                     ?? throw new InvalidOperationException("ApplyFixedSubtitle not found");
+
+        method.Invoke(vm, new object?[] { fixedSubtitle, rowMap, 0, null });
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static (Window Window, MainViewModel Vm) CreateMainViewModel()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1200, Height = 800 };
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        return (window, (MainViewModel)view.DataContext!);
+    }
+
+    private static SubtitleLineViewModel AddLine(
+        MainViewModel vm, string text, string originalText, int startMs, int endMs)
+    {
+        var line = new SubtitleLineViewModel(new Paragraph(text, startMs, endMs), null!)
+        {
+            OriginalText = originalText,
+            Number = vm.Subtitles.Count + 1,
+        };
+
+        vm.Subtitles.Add(line);
+        return line;
+    }
+
+    private static void CloseWindow(Window window, MainViewModel vm)
+    {
+        foreach (var ownedWindow in window.OwnedWindows.ToArray())
+        {
+            ownedWindow.Close();
+        }
+
+        window.Closing -= vm.OnClosing;
+        if (window.IsVisible)
+        {
+            window.Close();
+        }
+    }
+}

--- a/tests/UI/Features/Tools/FixCommonErrors/FixCommonErrorsParagraphIdTests.cs
+++ b/tests/UI/Features/Tools/FixCommonErrors/FixCommonErrorsParagraphIdTests.cs
@@ -1,0 +1,72 @@
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Forms.FixCommonErrors;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Tools.FixCommonErrors;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Dictionaries;
+
+namespace UITests.Features.Tools.FixCommonErrors;
+
+/// <summary>
+/// The paragraph ids of the subtitle the window was handed are how the main window finds the grid
+/// row each line came from, so the fixed subtitle must carry them back - the lines that survive a
+/// rule which removes lines above all, since those rows hold the original text of a translation and
+/// would otherwise be rebuilt empty (#14053).
+/// </summary>
+public class FixCommonErrorsParagraphIdTests : IDisposable
+{
+    private readonly List<SeFixCommonErrorsProfile> _originalProfiles;
+
+    public FixCommonErrorsParagraphIdTests()
+    {
+        // Se.Settings is static and starts out without profiles in tests; the scan does nothing
+        // without one. Restored in Dispose so no other test sees this profile.
+        _originalProfiles = Se.Settings.Tools.FixCommonErrors.Profiles;
+        Se.Settings.Tools.FixCommonErrors.Profiles = new List<SeFixCommonErrorsProfile>
+        {
+            new()
+            {
+                ProfileName = "Default",
+                SelectedRules = new List<string> { nameof(FixEmptyLines) },
+            },
+        };
+    }
+
+    public void Dispose()
+    {
+        Se.Settings.Tools.FixCommonErrors.Profiles = _originalProfiles;
+    }
+
+    [AvaloniaFact]
+    public async Task RemovedEmptyLine_KeepsTheIdsOfTheLinesThatStay()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Hello there", 0, 2000));
+        subtitle.Paragraphs.Add(new Paragraph(string.Empty, 2500, 4000));
+        subtitle.Paragraphs.Add(new Paragraph("Goodbye there", 4500, 6000));
+        subtitle.Renumber();
+        var ids = subtitle.Paragraphs.Select(p => p.Id).ToList();
+
+        var vm = new FixCommonErrorsViewModel(new FakeNamesList(), null!, null!);
+        vm.Initialize(subtitle, new SubRip());
+        await vm.DoRefreshFixes();
+        await vm.ApplySelectedFixes();
+
+        Assert.Equal(
+            new[] { "Hello there", "Goodbye there" },
+            vm.FixedSubtitle.Paragraphs.Select(p => p.Text));
+        Assert.Equal(new[] { ids[0], ids[2] }, vm.FixedSubtitle.Paragraphs.Select(p => p.Id));
+    }
+
+    private sealed class FakeNamesList : INamesList
+    {
+        public void Load(string dictionaryFolder, string languageCode)
+        {
+        }
+
+        public bool IsName(string candidate) => false;
+
+        public HashSet<string> GetAbbreviations() => new();
+    }
+}


### PR DESCRIPTION
Fixes #14053.

## The bug

With a translation open (original + translated columns), Multiple replace's **OK** and **Apply** emptied the original column.

`ShowMultipleReplace` pushed the result into the grid with `SetSubtitles`, which clears `Subtitles` and builds fresh rows from the paragraphs — and `SubtitleLineViewModel`'s paragraph constructor sets `OriginalText = string.Empty`. The original text lives on the row and nowhere else (`GetUpdateSubtitleOriginal` serializes the original file from the rows), so this was not just a blank column: saving the original afterwards wrote empty lines.

The same hole was reachable from **Fix common errors**, **Fix Netflix errors** and **AI review**: `ApplyFixedSubtitle` only updated rows in place while the line count was unchanged, and fell back to the same `SetSubtitles` reset as soon as

* a rule removed a line — `FixEmptyLines` removes empty lines, Fix Netflix errors calls `Subtitle.RemoveEmptyLines()`, or
* display-only original rows ("show the original's non-matching lines") made the counts differ at all — those rows were destroyed too.

## The fix

A dialog's result is applied onto the rows it was built from, matched by paragraph id:

* `GetUpdateSubtitleWithRowMap` captures the row ↔ paragraph pairing when the subtitle is handed to the dialog. The ids survive the round trip because the dialogs copy their subtitle with `generateNewId: false` — Multiple replace's `Apply` did not, and now does.
* Rows are updated in place and never rebuilt, so `OriginalText`, the row id the waveform matches on, and the selection all survive.
* **Deletions work**: exactly the rows whose paragraph is gone are removed, the rest keep their original text, and the grid is renumbered. Added lines come in as new rows.
* Display-only original rows are put back where they sat — after the working row they followed.
* Safety net: a result with unknown ids and an unchanged line count still maps positionally, so no dialog can end up worse off than before.

Selection/scroll are untouched in the common case, which is what #13822 wanted from Apply.

## Tests

* `ApplyFixedSubtitleRowMappingTests` — replaced text keeps the originals and the row instances; a deleted line removes only that row and the saved original follows; an added line comes in as a new row; display-only rows survive a deletion in place; a second Apply round does not resurrect a deleted row; an emptied grid; the positional fallback.
* `MultipleReplaceParagraphIdTests` — Apply, a second Apply and OK all hand back the ids they were given.
* `FixCommonErrorsParagraphIdTests` — the real remove-empty-lines rule keeps the ids of the lines that stay.

Full UI suite green (3567 tests).

## Not included

SE4 deleted lines that Multiple replace emptied (`MultipleReplace.SetDeleteIndices` + `RemoveParagraphsByIndices`); the SE5 port dropped that, so an emptied line stays as a blank line. That is a separate parity gap — this PR only makes sure that when a dialog *does* delete lines, the grid follows correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)