### PR TITLE
macOS: close the menu-bar gaps, add the Window-menu staples, fix the bundle's document types

### DIFF
--- a/installer/macBundle/SubtitleEdit.app/Contents/Info.plist
+++ b/installer/macBundle/SubtitleEdit.app/Contents/Info.plist
@@ -20,8 +20,13 @@
     <string>SBED</string>
     <key>CFBundleIconFile</key>
     <string>SE.icns</string>
+    <!-- The .NET runtime we ship is built against macOS 12, so the app cannot load
+         below it no matter what this key says - it was 10.15 for years, which only
+         meant Catalina users got a crash instead of Finder's "requires a newer
+         version of macOS". Re-derive after a TFM bump with:
+           otool -l .../shared/Microsoft.NETCore.App/<ver>/libcoreclr.dylib | grep -A3 LC_BUILD_VERSION -->
     <key>LSMinimumSystemVersion</key>
-    <string>10.15</string>
+    <string>12.0</string>
     <key>NSHighResolutionCapable</key>
     <true/>
     <key>NSSupportsAutomaticGraphicsSwitching</key>
@@ -41,7 +46,16 @@
                 <string>vtt</string>
                 <string>sbv</string>
                 <string>stl</string>
-                <string>xml</string>
+                <string>ttml</string>
+                <string>dfxp</string>
+                <string>itt</string>
+                <string>smi</string>
+                <string>scc</string>
+                <string>mcc</string>
+                <string>cap</string>
+                <string>pac</string>
+                <string>lrc</string>
+                <string>idx</string>
             </array>
             <key>CFBundleTypeName</key>
             <string>Subtitle Files</string>
@@ -49,6 +63,22 @@
             <string>Editor</string>
             <key>LSHandlerRank</key>
             <string>Owner</string>
+        </dict>
+        <!-- .xml is its own entry, at Alternate rank: SE reads several XML subtitle
+             formats, but claiming Owner made it fight every other app on the machine
+             for every XML file. Alternate keeps SE in "Open With" without taking the
+             default away from whatever owns the file type. -->
+        <dict>
+            <key>CFBundleTypeExtensions</key>
+            <array>
+                <string>xml</string>
+            </array>
+            <key>CFBundleTypeName</key>
+            <string>XML Subtitle Files</string>
+            <key>CFBundleTypeRole</key>
+            <string>Editor</string>
+            <key>LSHandlerRank</key>
+            <string>Alternate</string>
         </dict>
         <dict>
             <key>CFBundleTypeExtensions</key>

--- a/src/libse/SubtitleFormats/Cavena890.cs
+++ b/src/libse/SubtitleFormats/Cavena890.cs
@@ -515,12 +515,15 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         // GreekLookup is a byte-indexed reverse map for Greek: the Greek text decoder in
         // ReadParagraph ran a LINQ FirstOrDefault scan of all 145 entries for every byte of
         // every Greek subtitle line. Keys all fit in a byte, so a 256-entry array answers it
-        // with one array load instead of a linear scan.
-        private static readonly string?[] GreekLookup = BuildGreekLookup();
+        // with one array load instead of a linear scan. Bytes with no Greek entry stay null,
+        // which is how callers tell "not a Greek byte" from a mapping. (The element type is
+        // written without a nullable annotation because libse builds with nullable contexts
+        // off, where the annotation is inert and only warns - see CS8632.)
+        private static readonly string[] GreekLookup = BuildGreekLookup();
 
-        private static string?[] BuildGreekLookup()
+        private static string[] BuildGreekLookup()
         {
-            var table = new string?[256];
+            var table = new string[256];
             foreach (var entry in Greek)
             {
                 table[entry.Item1] = entry.Item2;

--- a/src/libse/SubtitleFormats/SubtitleFormat.cs
+++ b/src/libse/SubtitleFormats/SubtitleFormat.cs
@@ -565,7 +565,11 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         /// that declares them lets the UI warn before a save silently re-wraps or truncates text
         /// that does not fit. Null means no such limits.
         /// </summary>
-        public virtual SubtitleFormatLimits? FormatLimits => null;
+        /// <remarks>
+        /// Declared without a nullable annotation: libse builds with nullable contexts off, so
+        /// the annotation is inert here and only warns (CS8632). The null contract is above.
+        /// </remarks>
+        public virtual SubtitleFormatLimits FormatLimits => null;
 
         public bool BatchMode { get; set; }
         public double? BatchSourceFrameRate { get; set; }

--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -183,6 +183,8 @@ public static class InitNativeMacMenu
         fileItems.Items.Add(Conditional(Clean(l.NewKeepVideo), v => v.CommandFileNewKeepVideoCommand,
             v => v.IsVideoLoaded, nameof(MainViewModel.IsVideoLoaded)));
         fileItems.Items.Add(Item(Clean(l.NewWindow), v => v.CommandFileNewWindowCommand));
+        fileItems.Items.Add(WindowActionItem(Clean(l.CloseWindow), state,
+            new KeyGesture(Key.W, KeyModifiers.Meta), w => w.Close()));
         fileItems.Items.Add(new NativeMenuItemSeparator());
         fileItems.Items.Add(Item(Clean(l.Open), v => v.CommandFileOpenCommand));
         fileItems.Items.Add(Conditional(Clean(l.OpenKeepVideo), v => v.CommandFileOpenKeepVideoCommand,
@@ -474,6 +476,7 @@ public static class InitNativeMacMenu
         // the Dock icon's window list), so this menu is the discoverable way to switch
         // between the windows File > New window opens.
         state.WindowListItem = new NativeMenuItem(Clean(l.WindowTitle)) { Menu = new NativeMenu() };
+        AddStandardWindowItems(state.WindowListItem.Menu, state);
         root.Items.Add(state.WindowListItem);
 
         root.Items.Add(new NativeMenuItem(Clean(l.HelpTitle)) { Menu = helpItems });
@@ -483,6 +486,70 @@ public static class InitNativeMacMenu
         _building = null;
 
         UpdateWindowMenus();
+    }
+
+    /// <summary>
+    /// Minimize / Zoom / Close window, the Window-menu staples AppKit expects every app to
+    /// author for itself. Their key equivalents exist only where a menu item carries them, so
+    /// without these items ⌘M and ⌘W do nothing at all in SE - there is no fallback for a
+    /// missing NSMenuItem the way there is for the app menu's Hide and Quit, which Avalonia
+    /// appends.
+    /// <para>
+    /// Added at build time so they sit above the window list: AppKit appends its own entries
+    /// below whatever the menu already holds when <see cref="MacWindowsMenuInterop"/> hands it
+    /// over, which is the standard layout. The manual fallback in <see cref="UpdateWindowMenus"/>
+    /// clears the whole menu on every refresh, so it re-adds them there too.
+    /// </para>
+    /// </summary>
+    private static void AddStandardWindowItems(NativeMenu menu, MenuState state)
+    {
+        var l = Se.Language.Main.Menu;
+
+        // Zoom is AppKit's performZoom: - the green button's resize, not full screen.
+        // Avalonia's Maximized maps onto that same zoomed state, and toggling matches
+        // performZoom:, which returns a zoomed window to its user size.
+        menu.Items.Add(WindowActionItem(Clean(l.WindowMinimize), state,
+            new KeyGesture(Key.M, KeyModifiers.Meta), w => w.WindowState = WindowState.Minimized));
+        menu.Items.Add(WindowActionItem(Clean(l.WindowZoom), state, gesture: null,
+            w => w.WindowState = w.WindowState == WindowState.Maximized
+                ? WindowState.Normal
+                : WindowState.Maximized));
+        menu.Items.Add(new NativeMenuItemSeparator());
+    }
+
+    /// <summary>
+    /// A menu item that acts on this menu bar's own window rather than on a view-model command.
+    /// macOS shows the focused window's menu bar, so <see cref="MenuState.Window"/> is always the
+    /// window the user means.
+    /// </summary>
+    private static NativeMenuItem WindowActionItem(
+        string header, MenuState state, KeyGesture? gesture, Action<Window> action)
+    {
+        var item = new NativeMenuItem(header);
+        if (gesture != null)
+        {
+            item.Gesture = gesture;
+        }
+
+        item.Click += (_, _) =>
+        {
+            if (state.Window is not { } window)
+            {
+                return;
+            }
+
+            // A modal dialog leaves its owner input-disabled but still showing the menu bar, so
+            // an unguarded ⌘W here would close the window out from under the open dialog (#13405
+            // is the same "keys land in the main window" trap from the other direction).
+            if (WindowService.IsModalDialogOpen)
+            {
+                return;
+            }
+
+            action(window);
+        };
+
+        return item;
     }
 
     // Rebuilds every window's "Window" menu so all menu bars list all open editor
@@ -505,6 +572,7 @@ public static class InitNativeMacMenu
             }
 
             menu.Items.Clear();
+            AddStandardWindowItems(menu, menuState);
             foreach (var other in _states)
             {
                 var window = other.Window;

--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -237,6 +237,7 @@ public static class InitNativeMacMenu
         exportItems.Items.Add(Item(Se.Language.General.BluRaySup, v => v.ExportBluRaySupCommand));
         exportItems.Items.Add(Item(Se.Language.General.BdnXml, v => v.ExportBdnXmlCommand));
         exportItems.Items.Add(Item(Se.Language.General.BdnXml8Bit, v => v.ExportBdnXml8BitCommand));
+        exportItems.Items.Add(Item(lExport.TitleExportImscImage, v => v.ExportImscImageCommand));
         exportItems.Items.Add(Item(new CapMakerPlus().Name, v => v.ExportCapMakerPlusCommand));
         exportItems.Items.Add(Item(CheetahCaption.NameOfFormat, v => v.ExportCheetahCaptionCommand));
         exportItems.Items.Add(Item(CheetahCaptionOld.NameOfFormat, v => v.ExportCheetahCaptionOldCommand));
@@ -371,6 +372,10 @@ public static class InitNativeMacMenu
                 v => v.IsSubtitleSecondaryVisible, nameof(MainViewModel.IsSubtitleSecondaryVisible)),
             Item(Clean(lVideo.ReEncodeVideoForBetterSubtitlingDotDotDot), v => v.VideoReEncodeCommand),
             Item(Clean(lVideo.CutVideoDotDotDot), v => v.VideoCutCommand),
+
+            // Finds who speaks in the video, clones each of them and assigns the cast, so the
+            // whole thing can be dubbed in its own voices (#13698).
+            Item(Clean(lVideo.TextToSpeech.AutoCastMenuItem), v => v.ShowVideoAutoCastFromVideoCommand),
         };
         videoMoreList.Add(Toggle(Clean(l.WaveformToolbar), v => v.ToggleIsWaveformToolbarVisibleCommand,
             v => v.IsWaveformToolbarVisible, nameof(MainViewModel.IsWaveformToolbarVisible)));
@@ -441,6 +446,18 @@ public static class InitNativeMacMenu
         var assaMenu = new NativeMenuItem(Clean(l.AssaTools)) { Menu = assaItems };
         state.Visibilities.Add((assaMenu, v => v.IsFormatAssa, [nameof(MainViewModel.IsFormatAssa)]));
 
+        // ── SSA Tools ─────────────────────────────────────────────────────────
+        // The old .ssa sibling of the ASSA menu: same three dialogs, but the SSA-specific
+        // commands, and never visible at the same time (IsFormatSsa vs IsFormatAssa).
+        // Kept in InitMenu's order rather than sorted - the headers are the shared Assa*
+        // strings, so sorting them here would only diverge from the non-macOS menu.
+        var ssaItems = new NativeMenu();
+        ssaItems.Items.Add(Item(Clean(l.AssaStyles), v => v.ShowSsaStylesCommand));
+        ssaItems.Items.Add(Item(Clean(l.AssaProperties), v => v.ShowSsaPropertiesCommand));
+        ssaItems.Items.Add(Item(Clean(l.AssaAttachments), v => v.ShowSsaAttachmentsCommand));
+        var ssaMenu = new NativeMenuItem(Clean(l.SsaTools)) { Menu = ssaItems };
+        state.Visibilities.Add((ssaMenu, v => v.IsFormatSsa, [nameof(MainViewModel.IsFormatSsa)]));
+
         // ── Assemble ──────────────────────────────────────────────────────────
         root.Items.Add(new NativeMenuItem(Clean(l.File)) { Menu = fileItems });
         root.Items.Add(new NativeMenuItem(Clean(l.Edit)) { Menu = editItems });
@@ -461,6 +478,7 @@ public static class InitNativeMacMenu
 
         root.Items.Add(new NativeMenuItem(Clean(l.HelpTitle)) { Menu = helpItems });
         root.Items.Add(assaMenu);
+        root.Items.Add(ssaMenu);
 
         _building = null;
 

--- a/src/ui/Logic/Config/Language/Main/LanguageMainMenu.cs
+++ b/src/ui/Logic/Config/Language/Main/LanguageMainMenu.cs
@@ -9,6 +9,12 @@ public class LanguageMainMenu
     public string NewKeepVideo { get; set; }
     public string NewWindow { get; set; }
     public string WindowTitle { get; set; }
+
+    // macOS only: the Window-menu staples AppKit expects every app to author itself,
+    // plus File > Close window. Unused by the Windows/Linux menu.
+    public string WindowMinimize { get; set; }
+    public string WindowZoom { get; set; }
+    public string CloseWindow { get; set; }
     public string Open { get; set; }
     public string OpenKeepVideo { get; set; }
     public string OpenOriginal { get; set; }
@@ -150,6 +156,9 @@ public class LanguageMainMenu
         NewKeepVideo = "New (keep _video)";
         NewWindow = "New _window";
         WindowTitle = "Window";
+        WindowMinimize = "Minimize";
+        WindowZoom = "Zoom";
+        CloseWindow = "Close window";
         Open = "_Open...";
         OpenKeepVideo = "Open (_keep video)...";
         OpenOriginal = "Open ori_ginal...";

--- a/tests/UI/Features/Main/MacNativeMenuParityTests.cs
+++ b/tests/UI/Features/Main/MacNativeMenuParityTests.cs
@@ -1,0 +1,100 @@
+using System.Text.RegularExpressions;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// The macOS NSMenuBar in InitNativeMacMenu.cs is a hand-maintained mirror of the
+/// Avalonia menu in InitMenu.cs - Avalonia's NativeMenu is a separate API, so there is
+/// no shared builder the two could grow from. Every menu entry added to one file has to
+/// be added to the other by hand, and when that is forgotten the item is simply missing
+/// on macOS with nothing to notice it: the app still builds, still runs, and the gap is
+/// only found by someone using that menu on a Mac.
+///
+/// This test is that missing signal. Both files are pure builders whose entries all name
+/// a command on MainViewModel, so comparing the two command sets catches a one-sided add
+/// at build time. It deliberately checks presence only, not placement: which submenu an
+/// item lives in legitimately differs (macOS groups some entries differently, and the
+/// native menus sort at build time), and pinning layout here would fight normal edits.
+/// </summary>
+public class MacNativeMenuParityTests
+{
+    // Matches the command references both builders use:
+    //   InitMenu.cs           Command = vm.ShowFindCommand
+    //   InitNativeMacMenu.cs  Item(..., v => v.ShowFindCommand)   /   state.Vm?.FilePropertiesShowCommand
+    //                         GetVm()?.ShowAboutCommand           (the application-menu items)
+    // A receiver is required so type names (IRelayCommand, ICommand) never match.
+    private static readonly Regex CommandRegex =
+        new(@"(?:(?<![A-Za-z0-9_])(?:vm|v|Vm)|GetVm\(\))\??\.([A-Za-z0-9_]+Command)\b", RegexOptions.Compiled);
+
+    /// <summary>
+    /// In InitMenu.cs but intentionally not in the macOS menu bar.
+    /// </summary>
+    private static readonly HashSet<string> AllowedMissingOnMac =
+    [
+        // macOS puts Quit in the application menu, where Avalonia appends it (along with
+        // Hide / Hide Others / Show All) automatically. A second "Exit" in the File menu
+        // is exactly what a Mac user does not expect.
+        "CommandExitCommand",
+    ];
+
+    /// <summary>
+    /// In InitNativeMacMenu.cs but intentionally not in InitMenu.cs.
+    /// </summary>
+    private static readonly HashSet<string> AllowedMacOnly =
+    [
+        // The audio-track submenu is rebuilt per track. NativeMenuItem has no ICommand
+        // binding, so the macOS side routes every track through one parameterised command,
+        // while InitMenu.cs builds bound MenuItems in MainViewModel instead.
+        "PickAudioTrackCommand",
+    ];
+
+    [Fact]
+    public void EveryMenuCommand_IsInBothMenuBuilders()
+    {
+        var crossPlatform = ExtractCommands("InitMenu.cs");
+        var mac = ExtractCommands("InitNativeMacMenu.cs");
+
+        Assert.NotEmpty(crossPlatform);
+        Assert.NotEmpty(mac);
+
+        var missingOnMac = crossPlatform.Except(mac).Except(AllowedMissingOnMac).Order().ToList();
+        var macOnly = mac.Except(crossPlatform).Except(AllowedMacOnly).Order().ToList();
+
+        Assert.True(
+            missingOnMac.Count == 0 && macOnly.Count == 0,
+            "The macOS menu bar and the Avalonia menu are out of sync." +
+            Environment.NewLine +
+            "Add the entry to the other builder, or - if the difference is deliberate - " +
+            "list the command in AllowedMissingOnMac / AllowedMacOnly with the reason." +
+            Environment.NewLine +
+            $"In InitMenu.cs but missing from InitNativeMacMenu.cs: {Format(missingOnMac)}" +
+            Environment.NewLine +
+            $"In InitNativeMacMenu.cs but missing from InitMenu.cs: {Format(macOnly)}");
+    }
+
+    private static string Format(List<string> commands)
+    {
+        return commands.Count == 0 ? "(none)" : string.Join(", ", commands);
+    }
+
+    private static HashSet<string> ExtractCommands(string fileName)
+    {
+        var path = Path.Combine(FindRepoRoot(), "src", "ui", "Features", "Main", "Layout", fileName);
+        Assert.True(File.Exists(path), $"Menu builder not found: {path}");
+
+        return CommandRegex.Matches(File.ReadAllText(path))
+            .Select(m => m.Groups[1].Value)
+            .ToHashSet();
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "src", "ui")))
+        {
+            dir = dir.Parent;
+        }
+
+        return dir?.FullName ?? throw new DirectoryNotFoundException("Could not find repo root");
+    }
+}

--- a/tests/UI/Features/Main/MacWindowMenuItemsTests.cs
+++ b/tests/UI/Features/Main/MacWindowMenuItemsTests.cs
@@ -1,0 +1,86 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Nikse.SubtitleEdit.Features.Main.Layout;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// Minimize, Zoom and Close window in the macOS menu bar. AppKit gives an app no default
+/// Window menu and no default ⌘M / ⌘W: a key equivalent works only where a menu item
+/// carries it, so before these items existed both shortcuts were simply dead in SE, with
+/// nothing in a build or a run to show it. The items carry no view-model command either -
+/// they act on the window directly - so the source-level check in
+/// <see cref="MacNativeMenuParityTests"/> cannot see them, and this test pins them instead.
+///
+/// The builder itself is platform-independent (only its caller in Program.cs is macOS-only),
+/// so the structure is asserted on any OS - which matters, because CI runs tests on Linux.
+/// </summary>
+public class MacWindowMenuItemsTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        // InitNativeMacMenu keeps one MenuState per window and drops it on Closed; leaving a
+        // window open would leak that state into the next test's menu bar.
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    [AvaloniaFact]
+    public void WindowMenu_HasMinimizeAndZoom_WithCommandM()
+    {
+        var l = Se.Language.Main.Menu;
+        var windowMenu = BuildMenu().First(i => i.Header == Strip(l.WindowTitle));
+
+        var minimize = windowMenu.Menu!.Items.OfType<NativeMenuItem>()
+            .First(i => i.Header == Strip(l.WindowMinimize));
+        Assert.Equal(new KeyGesture(Key.M, KeyModifiers.Meta), minimize.Gesture);
+
+        var zoom = windowMenu.Menu!.Items.OfType<NativeMenuItem>()
+            .FirstOrDefault(i => i.Header == Strip(l.WindowZoom));
+        Assert.NotNull(zoom);
+
+        // Both sit above the window list: AppKit appends its window entries below whatever the
+        // menu already holds, which is the standard macOS Window-menu layout.
+        Assert.Equal(0, windowMenu.Menu!.Items.IndexOf(minimize));
+        Assert.Equal(1, windowMenu.Menu!.Items.IndexOf(zoom!));
+    }
+
+    [AvaloniaFact]
+    public void FileMenu_HasCloseWindow_WithCommandW()
+    {
+        var l = Se.Language.Main.Menu;
+        var fileMenu = BuildMenu().First(i => i.Header == Strip(l.File));
+
+        var close = fileMenu.Menu!.Items.OfType<NativeMenuItem>()
+            .First(i => i.Header == Strip(l.CloseWindow));
+
+        // ⌘W closes a window on macOS and lives in File, not in the Window menu.
+        Assert.Equal(new KeyGesture(Key.W, KeyModifiers.Meta), close.Gesture);
+    }
+
+    private List<NativeMenuItem> BuildMenu()
+    {
+        var window = new Window();
+        _windows.Add(window);
+
+        var root = new NativeMenu();
+        InitNativeMacMenu.MakeStructure(root, window);
+
+        return root.Items.OfType<NativeMenuItem>().ToList();
+    }
+
+    // The menu builder strips the access-key underscores the language strings carry for the
+    // Windows/Linux menu, so headers have to be compared the same way.
+    private static string Strip(string header)
+    {
+        return header.Replace("_", string.Empty);
+    }
+}

--- a/tests/libse/Core/BugHunt20260823Round3Test.cs
+++ b/tests/libse/Core/BugHunt20260823Round3Test.cs
@@ -1,6 +1,7 @@
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes;
 using Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream;
+using SkiaSharp;
 
 namespace LibSETests.Core;
 
@@ -98,7 +99,13 @@ public class BugHunt20260823Round3Test
         var s = new TransportStreamSubtitle();
         Assert.Equal(0, s.NumberOfImages);
         Assert.NotNull(s.GetBitmap());
-        Assert.NotNull(s.GetScreenSize());
+
+        // GetScreenSize returns a struct, so "not null" asserted nothing at all (xUnit2002).
+        // Pin the no-source fallback it actually returns instead.
+        Assert.Equal(
+            new SKSize(DvbSubPes.DefaultScreenWidth, DvbSubPes.DefaultScreenHeight),
+            s.GetScreenSize());
+
         Assert.NotNull(s.GetPosition());
     }
 }


### PR DESCRIPTION
A pass over the macOS-specific surface turned up three separate gaps. Each is invisible from a build or a run on Windows/Linux, which is why they had sat unnoticed.

## The three menu entries macOS was missing

`InitNativeMacMenu.cs` is a hand-maintained mirror of `InitMenu.cs` — Avalonia's `NativeMenu` is a separate API, so there is no shared builder the two could grow from. Three entries had drifted out of it:

- **SSA tools** (Styles / Properties / Attachments), the `.ssa` sibling of the ASSA menu. The ASSA menu is gated on `IsFormatAssa`, so nothing took its place: Mac users editing a plain SSA file had no menu route to those dialogs at all.
- **File ▸ Export ▸ IMSC image**
- **Video ▸ More ▸ Auto cast from video** (#13698)

They are added here together with a parity test, so the next one-sided add fails a test instead of shipping. Both files are pure builders whose entries all name a `MainViewModel` command, so the test compares the two command sets and names the offenders on failure. Deliberate differences are listed with their reason: Exit (macOS gets Quit in the app menu from Avalonia) and the parameterised audio-track command. Presence only is checked, never placement — which submenu an item lives in legitimately differs between the two, and pinning layout would fight normal edits.

Verified the test is not vacuous: dropping the new IMSC line again makes it fail naming that exact command.

## Cmd+M and Cmd+W now do something

AppKit gives an app no default Window menu and no default key equivalents — on macOS a shortcut works only where a menu item carries it. SE authored neither, so both keys were simply dead, unlike Hide and Quit which Avalonia appends for us.

Added **Minimize (⌘M)** and **Zoom** to the Window menu, and **Close window (⌘W)** to the File menu, which is where macOS keeps it. Zoom is the green button's resize, not full screen, so it toggles Avalonia's `Maximized`, which maps onto that same zoomed state.

The items are authored at build time, above the window list: once `MacWindowsMenuInterop` hands the menu to AppKit, AppKit appends its own window entries below whatever the menu already holds — the standard layout. The manual fallback in `UpdateWindowMenus` clears the whole menu on each refresh, so it re-adds them there too.

Each item acts on its own menu bar's window (macOS shows the focused window's menu bar) and does nothing while a modal dialog is open: the dialog leaves its owner input-disabled but still showing the menu bar, so an unguarded ⌘W would close the window out from under the open dialog.

These carry no view-model command — they act on the window — so the parity test cannot see them; `MacWindowMenuItemsTests` pins them instead, and runs on any OS since the builder is platform-independent (only its caller in `Program.cs` is macOS-only).

## The bundle's minimum version and document types

- **`LSMinimumSystemVersion` was 10.15.** The .NET runtime we ship is built against macOS 12 (`LC_BUILD_VERSION minos 12.0` in `libcoreclr.dylib`), so below that the app cannot load at all — the stale key only meant those users got a crash instead of Finder's "requires a newer version of macOS". Set to 12.0, with the `otool` command in a comment to re-derive it after a TFM bump.
- **Ten subtitle extensions the app reads were missing**, so Finder never offered SE for them: `ttml`, `dfxp`, `itt`, `smi`, `scc`, `mcc`, `cap`, `pac`, `lrc`, `idx`. Each is backed by a format in libse (TimedText10, ItunesTimedText, Sami, ScenaristClosedCaptions, MacCaption10, CheetahCaption/CapMakerPlus, Pac, Lrc, Idx).
- **`.xml` moved to its own entry at `Alternate` rank.** SE reads several XML subtitle formats, but at `Owner` rank it was claiming every XML file on the machine ahead of whatever really owns it. `Alternate` keeps SE in "Open With" without taking the default.

## Testing

- Full UI suite green: 3570 passed, 0 failed.
- Both new tests mutation-checked — a wrong ⌘M modifier and a removed menu entry each fail with the specific item named.
- `plutil -lint` passes, and `update-plist-version.sh` still sets both version keys on the edited plist (PlistBuddy rewrites the file, so the comments are repo-only — the built bundle is unaffected).

Not included, from the same review and worth their own PRs: the Shortcuts window's context flyout has no Ctrl+click handler, the ASSA menu sits after Help (macOS expects Help last), and macOS has no native OCR/TTS engine while Piper is hidden there despite a wired-up download path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)