### PR TITLE
Bump Paddle OCR to standalone v3.7.0 (PaddleOCR 3.7 / PP-OCRv6)

### DIFF
--- a/docs/reference/command-line.md
+++ b/docs/reference/command-line.md
@@ -235,7 +235,7 @@ An AVI stream header carries no language, so a multi-stream `.avi` names its out
 | `binaryocr` *(alias: `binary`)* | In-process | Built-in BinaryOCR matcher (different accuracy profile, similar speed). Required: `--ocr-db:<path-to-Latin.db>`. |
 | `ollama` | HTTP | Local Ollama server with a vision-capable model (e.g. `llama3.2-vision`, `qwen2.5vl`). Configure via `--ollama-url` (default `http://localhost:11434/api/chat`) and `--ollama-model` (default `llama3.2-vision`). Pass `--ocr-language` as a human name like `English`. |
 | `llamacpp` *(aliases: `llama.cpp`, `llama`)* | HTTP | llama.cpp with a curated OCR vision model (GLM-OCR, LightOnOCR, PaddleOCR-VL). With no `--ocr-url`, seconv finds `llama-server` (SE data folder next to seconv, installed SE data folder, then `PATH`) and an installed OCR model, starts the server on a free loopback port, and stops it at exit. seconv never downloads engines/models — install them via the SE UI's OCR window (engine "llama.cpp") or point `--ocr-url` at a running server. Pass `--ocr-language` as a human name like `English`. |
-| `paddle` *(alias: `paddleocr`)* | Subprocess | Install via `pip install paddleocr`; ensure the `paddleocr` binary is on `PATH`. Pass `--ocr-language` as a short code (`en`, `de`, …). |
+| `paddle` *(alias: `paddleocr`)* | Subprocess | Install via `pip install paddleocr` (3.7 or newer, for the PP-OCRv6 models); ensure the `paddleocr` binary is on `PATH`. Pass `--ocr-language` as a short code (`en`, `de`, …). |
 
 | Option | Description |
 |---|---|

--- a/docs/third-party-components.md
+++ b/docs/third-party-components.md
@@ -37,7 +37,7 @@ Subtitle Edit stores these components in its **Data Folder**.
 | **Crisp ASR** | `crispasr.exe`, `models/` folder | `[Data Folder]/CrispASR` |
 | **Qwen3 ASR CPP** | `qwen3-asr-cli.exe`, `models/` folder | `[Data Folder]/Qwen3ASR` |
 | **Parakeet.cpp** | `parakeet.exe`, model folders | `[Data Folder]/parakeet.cpp` |
-| **PaddleOCR** | `paddleocr.exe`, `models/` folder | `[Data Folder]/OCR/PaddleOCR3-4` |
+| **PaddleOCR** | `paddleocr.exe`, `models/` folder | `[Data Folder]/OCR/PaddleOCR3-7` |
 | **Qwen3 TTS (CrispASR)** | shares `crispasr.exe` + `models/` from `[Data Folder]/CrispASR`; reference voices in `voices/` | `[Data Folder]/TextToSpeech/Qwen3TtsCrispAsr` (voices only) |
 | **Chatterbox TTS (CrispASR)** | shares `crispasr.exe` + `models/` from `[Data Folder]/CrispASR`; reference voices in `voices/` | `[Data Folder]/TextToSpeech/Chatterbox` (voices only) |
 | **OmniVoice TTS** | `omnivoice-tts.exe`, `omnivoice-codec.exe`, `models/`, `voices/` | `[Data Folder]/TextToSpeech/OmniVoice` |
@@ -120,10 +120,12 @@ Use [Speech to Text](features/speech-to-text.md) for the current engine list and
 ### PaddleOCR
 Used for OCR of image-based subtitles.
 
-*   **Destination:** `[Data Folder]/OCR/PaddleOCR3-4`
-*   **Models:** `[Data Folder]/OCR/PaddleOCR3-4/models`
+*   **Destination:** `[Data Folder]/OCR/PaddleOCR3-7`
+*   **Models:** `[Data Folder]/OCR/PaddleOCR3-7/models`
 *   **Builds:** Subtitle Edit can download CPU, CUDA 11.8, or CUDA 12.9 builds, on both Windows and Linux (Linux x64 only; the Linux builds need glibc 2.35 or newer).
-*   **Version:** The folder name follows the PaddleOCR release the standalone engine is built from, so upgrading installs into a new folder instead of mixing files. The old `[Data Folder]/OCR/PaddleOCR3-1` folder is deleted automatically after the new one is installed.
+*   **Recognition models:** PP-OCRv6 (PaddleOCR 3.7) recognizes Chinese, English, Japanese and the Latin languages with one unified model; Arabic, Cyrillic, E-Slavic, Devanagari, Korean, Greek, Tamil, Telugu, Thai and Pali still use their PP-OCRv5 models, and Georgian its PP-OCRv3 one. All of them ship in the same bundle.
+*   **Version:** The folder name follows the PaddleOCR release the standalone engine is built from, so upgrading installs into a new folder instead of mixing files. The old `[Data Folder]/OCR/PaddleOCR3-1` and `[Data Folder]/OCR/PaddleOCR3-4` folders are deleted automatically after the new one is installed.
+*   **Paddle OCR Python:** The pip-installed engine uses the same downloaded models, so it needs `paddleocr` 3.7 or newer - older versions do not know the PP-OCRv6 model names.
 
 ### Local Text-to-Speech Engines
 Subtitle Edit 5 can download local TTS servers and models from the **Text to speech** window.

--- a/src/ui/Features/Ocr/Engines/PaddleOcr.cs
+++ b/src/ui/Features/Ocr/Engines/PaddleOcr.cs
@@ -35,7 +35,7 @@ public partial class PaddleOcr
     // The pinned PaddleOCR-Standalone release. Bumping it means updating this one line and
     // the file names below - and Se.PaddleOcrFolder when the underlying PaddleOCR version
     // changes, so engine and models never mix across releases.
-    private const string StandaloneRelease = "https://github.com/timminator/PaddleOCR-Standalone/releases/download/v1.4.0/";
+    private const string StandaloneRelease = "https://github.com/timminator/PaddleOCR-Standalone/releases/download/v3.7.0/";
 
     /// <summary>
     /// One downloadable Paddle OCR archive: the file(s) to fetch, and the folder level inside
@@ -48,19 +48,19 @@ public partial class PaddleOcr
     {
         return downloadType switch
         {
-            PaddleOcrDownloadType.Models => Archive("PaddleOCR.PP-OCRv5.support.files.VideOCR.7z", "PaddleOCR.PP-OCRv5.support.files"),
-            PaddleOcrDownloadType.EngineCpu => Archive("PaddleOCR-CPU-v1.4.0.7z"),
-            PaddleOcrDownloadType.EngineGpu11 => Archive("PaddleOCR-GPU-v1.4.0-CUDA-11.8.7z"),
-            PaddleOcrDownloadType.EngineGpu12 => Archive("PaddleOCR-GPU-v1.4.0-CUDA-12.9.7z"),
-            PaddleOcrDownloadType.EngineCpuLinux => Archive("PaddleOCR-CPU-v1.4.0-Linux.7z"),
-            PaddleOcrDownloadType.EngineGpu11Linux => Archive("PaddleOCR-GPU-v1.4.0-CUDA-11.8-Linux.7z"),
+            PaddleOcrDownloadType.Models => Archive("PaddleOCR.PP-OCRv6.support.files.VideOCR.7z", "PaddleOCR.PP-OCRv6.support.files"),
+            PaddleOcrDownloadType.EngineCpu => Archive("PaddleOCR-CPU-v3.7.0.7z"),
+            PaddleOcrDownloadType.EngineGpu11 => Archive("PaddleOCR-GPU-v3.7.0-CUDA-11.8.7z"),
+            PaddleOcrDownloadType.EngineGpu12 => Archive("PaddleOCR-GPU-v3.7.0-CUDA-12.9.7z"),
+            PaddleOcrDownloadType.EngineCpuLinux => Archive("PaddleOCR-CPU-v3.7.0-Linux.7z"),
+            PaddleOcrDownloadType.EngineGpu11Linux => Archive("PaddleOCR-GPU-v3.7.0-CUDA-11.8-Linux.7z"),
 
             // Split into two volumes upstream. Both have to land in the same folder before the
             // .001 is handed to the extractor - the download queue takes care of that.
             PaddleOcrDownloadType.EngineGpu12Linux => Archive(
-                "PaddleOCR-GPU-v1.4.0-CUDA-12.9-Linux.7z.001",
-                "PaddleOCR-GPU-v1.4.0-CUDA-12.9-Linux",
-                "PaddleOCR-GPU-v1.4.0-CUDA-12.9-Linux.7z.002"),
+                "PaddleOCR-GPU-v3.7.0-CUDA-12.9-Linux.7z.001",
+                "PaddleOCR-GPU-v3.7.0-CUDA-12.9-Linux",
+                "PaddleOCR-GPU-v3.7.0-CUDA-12.9-Linux.7z.002"),
 
             _ => throw new ArgumentOutOfRangeException(nameof(downloadType), downloadType, "Unknown Paddle OCR download type"),
         };
@@ -83,7 +83,7 @@ public partial class PaddleOcr
     private const string TextlineOrientationModelName = "PP-LCNet_x1_0_textline_ori";
 
     // The script groups below mirror LATIN_LANGS/ARABIC_LANGS/ESLAV_LANGS/CYRILLIC_LANGS/
-    // DEVANAGARI_LANGS in PaddleOCR 3.4 (paddleocr/_pipelines/ocr.py) - the version the
+    // DEVANAGARI_LANGS in PaddleOCR 3.7 (paddleocr/_utils/langs.py) - the version the
     // bundled standalone engine is built from. Keep them in sync with GetLanguages(); a
     // code offered in the dropdown but missing from every group here silently falls
     // through to the Latin recognition model and OCRs to garbage.
@@ -126,6 +126,31 @@ public partial class PaddleOcr
         "el", "ta", "te", "th"
     };
 
+    // Pali is the one Latin language PP-OCRv6 does not cover, so it stays on the PP-OCRv5
+    // Latin model (_PPOCRV6_UNSUPPORTED_LATIN_LANGS in paddleocr/_pipelines/ocr.py).
+    private const string PaliLanguageCode = "pi";
+
+    /// <summary>
+    /// True for the languages PP-OCRv6 (new in PaddleOCR 3.7) recognizes with its single
+    /// unified model: Chinese, English, Japanese and the Latin languages except Pali - the
+    /// _PPOCRV6_LANGS set in paddleocr/_pipelines/ocr.py. No non-Latin script has a v6 model
+    /// at all, so every other language keeps the PP-OCRv5 (Georgian: PP-OCRv3) models that
+    /// the support-files bundle still ships alongside the v6 pair.
+    /// </summary>
+    private static bool IsPpOcrV6Language(string language)
+    {
+        if (language is "ch" or "chinese_cht" or "en" or "japan")
+        {
+            return true;
+        }
+
+        return LatinLanguageCodes.Contains(language) && language != PaliLanguageCode;
+    }
+
+    // PP-OCRv6 replaced the mobile/server pair with tiny/small/medium tiers, and the bundle
+    // ships small and medium - so the saved mode picks between those two.
+    private static string PpOcrV6Tier(string mode) => mode == "server" ? "medium" : "small";
+
     internal static IReadOnlyCollection<string> GetLatinLanguageCodesForTest() => LatinLanguageCodes;
 
     internal static IEnumerable<string> GetAllScriptGroupCodesForTest() =>
@@ -148,19 +173,16 @@ public partial class PaddleOcr
         _cancellationToken = new CancellationToken();
     }
 
-    // Only the recognition models shipped in "PaddleOCR.PP-OCRv5.support.files" are on
+    // Only the recognition models shipped in "PaddleOCR.PP-OCRv6.support.files" are on
     // disk - nothing is fetched per language. Returning a name that is not in that bundle
     // points at a folder that does not exist, and the run then fails when PaddleX tries to
     // read the model's inference.yml.
     internal static string GetRecName(string language, string mode)
     {
         string recName;
-        if (language == "ch" ||
-            language == "chinese_cht" ||
-            language == "en" ||
-            language == "japan")
+        if (IsPpOcrV6Language(language))
         {
-            recName = $"PP-OCRv5_{mode}_rec";
+            recName = $"PP-OCRv6_{PpOcrV6Tier(mode)}_rec";
         }
         else if (ArabicLanguageCodes.Contains(language))
         {
@@ -193,6 +215,8 @@ public partial class PaddleOcr
         }
         else
         {
+            // Pali, plus the safety net for a code no script group claims - the v6 bundle
+            // no longer has a general-purpose PP-OCRv5 model to fall back on.
             recName = "latin_PP-OCRv5_mobile_rec";
         }
 
@@ -201,10 +225,16 @@ public partial class PaddleOcr
 
     internal static string GetDetectionName(string language, string mode)
     {
-        // Georgian is the one remaining PP-OCRv3 language; everything else recognizes
-        // with a PP-OCRv5 model and detects with the matching PP-OCRv5 detector.
-        return language == "ka"
-            ? "PP-OCRv3_mobile_det"
+        // Georgian is the one remaining PP-OCRv3 language.
+        if (language == "ka")
+        {
+            return "PP-OCRv3_mobile_det";
+        }
+
+        // Detector and recognition model come from the same PaddleOCR generation, which is
+        // how upstream pairs them (PP-OCRv6 languages get the v6 detector of the same tier).
+        return IsPpOcrV6Language(language)
+            ? $"PP-OCRv6_{PpOcrV6Tier(mode)}_det"
             : $"PP-OCRv5_{mode}_det";
     }
 
@@ -1122,7 +1152,7 @@ public partial class PaddleOcr
     }
 
 
-    // Every language PaddleOCR 3.4 supports with a recognition model that ships in the
+    // Every language PaddleOCR 3.7 supports with a recognition model that ships in the
     // bundled support files. Adding a code here is enough to offer it - as long as the
     // code is also listed in the matching script group above, so GetRecName picks the
     // right model (PaddleOcrLanguageMappingTests guards that).

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -2805,6 +2805,21 @@ public partial class OcrViewModel : ObservableObject
                       "Details:" + Environment.NewLine +
                       error;
         }
+        else if (engineType == OcrEngineType.PaddleOcrPython &&
+                 error.Contains("PP-OCRv6", StringComparison.Ordinal) &&
+                 error.Contains("is not registered on", StringComparison.OrdinalIgnoreCase))
+        {
+            // The downloaded models are PP-OCRv6 (PaddleOCR 3.7). PaddleX looks the model name
+            // up in a registry, so an older pip "paddleocr" fails with "`PP-OCRv6_small_rec`
+            // is not registered on BasePredictor" for every language v6 covers.
+            message = "Paddle OCR Python is too old for the downloaded models." + Environment.NewLine +
+                      Environment.NewLine +
+                      "The models are PP-OCRv6, which needs \"paddleocr\" 3.7 or newer:" + Environment.NewLine +
+                      "    python -m pip install --upgrade paddleocr" + Environment.NewLine +
+                      Environment.NewLine +
+                      "Details:" + Environment.NewLine +
+                      error;
+        }
 
         Dispatcher.UIThread.Post(async void () =>
         {

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -184,17 +184,23 @@ public class Se
     public static string OcrFolder => Path.Combine(DataFolder, "OCR");
     public static string TranslationFolder => Path.Combine(DataFolder, "Languages");
     // The folder name carries the PaddleOCR version the bundled standalone engine is built
-    // from (3-4 = PaddleOCR 3.4 = PaddleOCR-Standalone v1.4.0). Bump it whenever the engine
-    // or the support-files bundle moves to a new PaddleOCR release: extracting a new build
-    // over an old one would leave orphaned files from the previous Python/paddle runtime,
-    // and the old models bundle is missing recognition models the current language list
-    // offers (the 3.1 bundle has no arabic/cyrillic/devanagari PP-OCRv5 or el/ta/te/th/ka
-    // models at all). A new folder means engine and models always come from the same release.
-    public static string PaddleOcrFolder => Path.Combine(OcrFolder, "PaddleOCR3-4");
+    // from (3-7 = PaddleOCR 3.7 = PaddleOCR-Standalone v3.7.0; upstream re-aligned its tag
+    // scheme to the PaddleOCR version, so v1.4.0 is followed by v3.7.0). Bump it whenever the
+    // engine or the support-files bundle moves to a new PaddleOCR release: extracting a new
+    // build over an old one would leave orphaned files from the previous Python/paddle
+    // runtime, and the old models bundle is missing recognition models the current language
+    // list offers (the 3.4 bundle has no PP-OCRv6 models, the 3.1 one has no arabic/cyrillic/
+    // devanagari PP-OCRv5 or el/ta/te/th/ka models at all). A new folder means engine and
+    // models always come from the same release.
+    public static string PaddleOcrFolder => Path.Combine(OcrFolder, "PaddleOCR3-7");
     public static string PaddleOcrModelsFolder => Path.Combine(PaddleOcrFolder, "models");
 
     /// <summary>Install folders of superseded PaddleOCR versions, deleted after a new install succeeds.</summary>
-    public static IReadOnlyList<string> PaddleOcrLegacyFolders => new[] { Path.Combine(OcrFolder, "PaddleOCR3-1") };
+    public static IReadOnlyList<string> PaddleOcrLegacyFolders => new[]
+    {
+        Path.Combine(OcrFolder, "PaddleOCR3-1"),
+        Path.Combine(OcrFolder, "PaddleOCR3-4"),
+    };
     public static string GoogleLensOcrFolder => Path.Combine(OcrFolder, "Google-Lens");
     public static string CrispEmbedFolder => Path.Combine(OcrFolder, "CrispEmbed");
     public static string VlcFolder => Path.Combine(DataFolder, "VLC");

--- a/tests/UI/Features/Ocr/Engines/PaddleOcrDownloadArchiveTests.cs
+++ b/tests/UI/Features/Ocr/Engines/PaddleOcrDownloadArchiveTests.cs
@@ -75,7 +75,7 @@ public class PaddleOcrDownloadArchiveTests
         {
             // The models archive is the exception: its root folder drops the ".VideOCR" part.
             var models = PaddleOcr.GetArchive(PaddleOcrDownloadType.Models);
-            Assert.Equal("PaddleOCR.PP-OCRv5.support.files", models.RootFolderInArchive);
+            Assert.Equal("PaddleOCR.PP-OCRv6.support.files", models.RootFolderInArchive);
             return;
         }
 

--- a/tests/UI/Features/Ocr/Engines/PaddleOcrLanguageMappingTests.cs
+++ b/tests/UI/Features/Ocr/Engines/PaddleOcrLanguageMappingTests.cs
@@ -11,17 +11,18 @@ namespace UITests.Features.Ocr.Engines;
 /// </summary>
 public class PaddleOcrLanguageMappingTests
 {
-    // Model folders shipped in "PaddleOCR.PP-OCRv5.support.files" (standalone v1.4.0),
-    // which is the only model source - nothing is downloaded per language.
+    // Model folders shipped in "PaddleOCR.PP-OCRv6.support.files" (standalone v3.7.0), which
+    // is the only model source - nothing is downloaded per language. Listed from the unpacked
+    // archive: the v6 bundle dropped the general-purpose PP-OCRv5 recognition models (mobile,
+    // server and en_), so anything still asking for one of those points at a missing folder.
     private static readonly HashSet<string> BundledRecModels = new()
     {
-        "PP-OCRv5_mobile_rec",
-        "PP-OCRv5_server_rec",
+        "PP-OCRv6_medium_rec",
+        "PP-OCRv6_small_rec",
         "arabic_PP-OCRv5_mobile_rec",
         "cyrillic_PP-OCRv5_mobile_rec",
         "devanagari_PP-OCRv5_mobile_rec",
         "el_PP-OCRv5_mobile_rec",
-        "en_PP-OCRv5_mobile_rec",
         "eslav_PP-OCRv5_mobile_rec",
         "ka_PP-OCRv3_mobile_rec",
         "korean_PP-OCRv5_mobile_rec",
@@ -36,6 +37,8 @@ public class PaddleOcrLanguageMappingTests
         "PP-OCRv3_mobile_det",
         "PP-OCRv5_mobile_det",
         "PP-OCRv5_server_det",
+        "PP-OCRv6_medium_det",
+        "PP-OCRv6_small_det",
     };
 
     public static TheoryData<string, string> LanguageAndMode()
@@ -60,13 +63,29 @@ public class PaddleOcrLanguageMappingTests
 
     [Theory]
     [MemberData(nameof(LanguageAndMode))]
-    public void OnlyLatinLanguages_UseTheLatinModel(string code, string mode)
+    public void OnlyPali_UsesTheLatinPpOcrV5Model(string code, string mode)
     {
-        var isLatinCode = PaddleOcr.GetLatinLanguageCodesForTest().Contains(code);
+        // PP-OCRv6 recognizes every Latin language except Pali, so the PP-OCRv5 Latin model is
+        // Pali's now - and still the fallback for a code no script group claims, which is what
+        // makes this the test that catches such a code (it would report "latin" but not be pi).
+        Assert.Equal(code == "pi", PaddleOcr.GetRecName(code, mode) == "latin_PP-OCRv5_mobile_rec");
+    }
 
-        // A code missing from every script group falls through to the Latin model, so
-        // "uses latin" and "is a Latin language" must be the same set.
-        Assert.Equal(isLatinCode, PaddleOcr.GetRecName(code, mode) == "latin_PP-OCRv5_mobile_rec");
+    [Theory]
+    [MemberData(nameof(LanguageAndMode))]
+    public void PpOcrV6Languages_UseTheUnifiedV6ModelPair(string code, string mode)
+    {
+        // _PPOCRV6_LANGS in PaddleOCR 3.7: Chinese, English, Japanese and the Latin languages
+        // except Pali. Everything else has no v6 model at all and must stay on PP-OCRv5/v3.
+        var isV6Language =
+            code is "ch" or "chinese_cht" or "en" or "japan" ||
+            (PaddleOcr.GetLatinLanguageCodesForTest().Contains(code) && code != "pi");
+
+        // "mobile"/"server" is what the setting stores; v6 ships tiers instead.
+        var tier = mode == "server" ? "medium" : "small";
+
+        Assert.Equal(isV6Language, PaddleOcr.GetRecName(code, mode) == $"PP-OCRv6_{tier}_rec");
+        Assert.Equal(isV6Language, PaddleOcr.GetDetectionName(code, mode) == $"PP-OCRv6_{tier}_det");
     }
 
     [Fact]


### PR DESCRIPTION
Closes #14059.

The issue lists the models pin (PP-OCRv5 → PP-OCRv6) as tracked separately. It cannot be: **v3.7.0 ships no PP-OCRv5 support-files bundle at all**, and the PP-OCRv6 bundle it does ship has dropped `PP-OCRv5_mobile_rec`, `PP-OCRv5_server_rec` and `en_PP-OCRv5_mobile_rec` — exactly what `GetRecName` asked for on Chinese, English and Japanese. Bumping only the URLs would leave those languages pointing at folders that do not exist, and the archive tests would still pass because they only check names and tags.

| | v1.4.0 bundle | v3.7.0 bundle |
|---|---|---|
| rec (general) | `PP-OCRv5_mobile_rec`, `PP-OCRv5_server_rec`, `en_PP-OCRv5_mobile_rec` | **gone** — `PP-OCRv6_small_rec`, `PP-OCRv6_medium_rec` |
| rec (scripts) | arabic / cyrillic / devanagari / eslav / korean / latin / el / ta / te / th PP-OCRv5, `ka_PP-OCRv3` | unchanged, still shipped |
| det | v3_mobile, v5_mobile, v5_server | + `PP-OCRv6_small_det`, `PP-OCRv6_medium_det` |

## What this does

- **Pins v3.7.0** — release URL, all seven engine archives, and the `PaddleOCR.PP-OCRv6.support.files` models bundle.
- **Mixed-generation model mapping.** PP-OCRv6 is one unified model for Chinese, English, Japanese and the Latin languages except Pali (`_PPOCRV6_LANGS` in PaddleOCR 3.7). No non-Latin script has a v6 model, so Arabic, Cyrillic, E-Slavic, Devanagari, Korean, Greek, Tamil, Telugu, Thai and Pali stay on PP-OCRv5 and Georgian on PP-OCRv3 — all still in the same bundle. Detector and recognizer come from the same generation, the way upstream pairs them.
- **Tiers instead of mobile/server.** v6 replaced the mobile/server pair with tiny/small/medium; the bundle ships small and medium, so the stored `PaddleOcrMode` maps onto those (mobile → small, server → medium).
- **Versioned install folder** `OCR/PaddleOCR3-7`, with `PaddleOCR3-4` added to the legacy list so the old install is deleted once the new one succeeds.
- **Paddle OCR Python needs pip `paddleocr` 3.7+.** It uses the same downloaded models, and PaddleX resolves the model name through a registry — an older install raises ``​`PP-OCRv6_small_rec` is not registered on BasePredictor`` for every language v6 covers. That error now gets a hint pointing at the upgrade, and the docs say so. This matters most on macOS, where the Python engine is the only Paddle option.

`OnlyLatinLanguages_UseTheLatinModel` became `OnlyPali_UsesTheLatinPpOcrV5Model` — it keeps its real job (a code no script group claims falls through to the Latin model and is caught), and a new theory pins the v6 language set and the tier mapping.

## Verification

Against the actual upstream release, not just the release notes:

- All eight pinned asset names exist in `v3.7.0`.
- The CPU engine archive wraps its content in `PaddleOCR-CPU-v3.7.0/paddleocr.exe` — the folder level the unpack strips, and the file `IsStandaloneInstalled` looks for.
- The model lists in `PaddleOcrLanguageMappingTests` are transcribed from the unpacked PP-OCRv6 bundle, so every language the dropdown offers resolves to a folder that is really in it.
- The script groups were diffed against `paddleocr/_utils/langs.py` at 3.7: unchanged from 3.4, so the language list needs no edits.
- timminator's `release/3.7-custom` keeps the 2.x-style `ppocr INFO:` output `OutputHandlerBatch` parses (diffed `_utils/cli.py` 3.4-custom → 3.7-custom; the printing was refactored behind a `print_func`, the OCR line format is identical).
- glibc requirement is unchanged at 2.35.
- Full UI test suite: 3787 passed, 0 failed.

Not verified here, and worth a look before release: PP-OCRv6 accuracy on real subtitle bitmaps at the **small** tier, which is the default. Upstream's +4.6 % / +5.1 % claim is for medium vs PP-OCRv5_server; nothing benchmarks small against PP-OCRv5_mobile, and v6 was tuned partly for industrial and display text rather than white-on-black subtitles.

Note for the release notes: Paddle OCR users re-download once (~450 MB CPU, more for GPU), and Paddle OCR Python users need `pip install --upgrade paddleocr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)