### PR TITLE
Keep subtitle times on whole milliseconds (#14056)

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -1530,8 +1530,11 @@ public class AudioVisualizer : Control
 
                 if (_activeParagraph != null)
                 {
-                    _activeParagraph.StartTime = TimeSpan.FromSeconds(newStart);
-                    _activeParagraph.EndTime = TimeSpan.FromSeconds(newStart + _originalDurationSeconds);
+                    // Add the duration as a whole-millisecond TimeSpan rather than in seconds, so
+                    // moving a line cannot round its length a millisecond up or down (#14056).
+                    var movedStart = TimeSpanExtensions.FromSecondsWholeMilliseconds(newStart);
+                    _activeParagraph.StartTime = movedStart;
+                    _activeParagraph.EndTime = movedStart + TimeSpanExtensions.FromSecondsWholeMilliseconds(_originalDurationSeconds);
                 }
                 break;
             case InteractionMode.MovingSelection:
@@ -1558,9 +1561,9 @@ public class AudioVisualizer : Control
 
                 foreach (var item in _selectionMoveSnapshot)
                 {
-                    var start = item.StartSeconds + shift;
-                    item.Paragraph.StartTime = TimeSpan.FromSeconds(start);
-                    item.Paragraph.EndTime = TimeSpan.FromSeconds(start + item.DurationSeconds);
+                    var start = TimeSpanExtensions.FromSecondsWholeMilliseconds(item.StartSeconds + shift);
+                    item.Paragraph.StartTime = start;
+                    item.Paragraph.EndTime = start + TimeSpanExtensions.FromSecondsWholeMilliseconds(item.DurationSeconds);
                 }
 
                 break;

--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -700,7 +700,7 @@ public class AudioVisualizer : Control
             {
                 if (seconds < firstSelected.EndTime.TotalSeconds - 0.01)
                 {
-                    firstSelected.SetStartTimeOnly(TimeSpan.FromSeconds(seconds));
+                    firstSelected.SetStartTimeOnly(TimeSpanExtensions.FromSecondsWholeMilliseconds(seconds));
                 }
 
                 e.Handled = true;
@@ -717,7 +717,7 @@ public class AudioVisualizer : Control
             {
                 if (seconds > firstSelected.StartTime.TotalSeconds + 0.01)
                 {
-                    firstSelected.EndTime = TimeSpan.FromSeconds(seconds);
+                    firstSelected.EndTime = TimeSpanExtensions.FromSecondsWholeMilliseconds(seconds);
                 }
 
                 e.Handled = true;
@@ -732,7 +732,7 @@ public class AudioVisualizer : Control
             var seconds = RelativeXPositionToSeconds(point.X);
             if (firstSelected != null)
             {
-                firstSelected.SetStartTimeKeepDuration(TimeSpan.FromSeconds(seconds));
+                firstSelected.SetStartTimeKeepDuration(TimeSpanExtensions.FromSecondsWholeMilliseconds(seconds));
                 e.Handled = true;
                 InvalidateVisual();
                 return;
@@ -1114,8 +1114,8 @@ public class AudioVisualizer : Control
             var deltaSeconds = RelativeXPositionToSeconds(deltaX);
             _newSelectionSeconds = deltaSeconds;
 
-            NewSelectionParagraph.StartTime = TimeSpan.FromSeconds(deltaSeconds);
-            NewSelectionParagraph.EndTime = TimeSpan.FromSeconds(deltaSeconds);
+            NewSelectionParagraph.StartTime = TimeSpanExtensions.FromSecondsWholeMilliseconds(deltaSeconds);
+            NewSelectionParagraph.EndTime = TimeSpanExtensions.FromSecondsWholeMilliseconds(deltaSeconds);
             _pointerDragActive = true;
             InvalidateVisual();
             return;
@@ -1349,13 +1349,15 @@ public class AudioVisualizer : Control
 
             if (seconds > _newSelectionSeconds)
             {
-                newP.StartTime = TimeSpan.FromSeconds(_newSelectionSeconds);
-                newP.EndTime = TimeSpan.FromSeconds(seconds);
+                newP.SetTimes(
+                    TimeSpanExtensions.FromSecondsWholeMilliseconds(_newSelectionSeconds),
+                    TimeSpanExtensions.FromSecondsWholeMilliseconds(seconds));
             }
             else
             {
-                newP.StartTime = TimeSpan.FromSeconds(seconds);
-                newP.EndTime = TimeSpan.FromSeconds(_newSelectionSeconds);
+                newP.SetTimes(
+                    TimeSpanExtensions.FromSecondsWholeMilliseconds(seconds),
+                    TimeSpanExtensions.FromSecondsWholeMilliseconds(_newSelectionSeconds));
             }
 
             _lastPointerEditMs = Environment.TickCount64;
@@ -1530,11 +1532,11 @@ public class AudioVisualizer : Control
 
                 if (_activeParagraph != null)
                 {
-                    // Add the duration as a whole-millisecond TimeSpan rather than in seconds, so
+                    // SetTimes applies both ends atomically (no transient duration exposed to the
+                    // bound editors), and adding the duration as a whole-millisecond TimeSpan means
                     // moving a line cannot round its length a millisecond up or down (#14056).
                     var movedStart = TimeSpanExtensions.FromSecondsWholeMilliseconds(newStart);
-                    _activeParagraph.StartTime = movedStart;
-                    _activeParagraph.EndTime = movedStart + TimeSpanExtensions.FromSecondsWholeMilliseconds(_originalDurationSeconds);
+                    _activeParagraph.SetTimes(movedStart, movedStart + TimeSpanExtensions.FromSecondsWholeMilliseconds(_originalDurationSeconds));
                 }
                 break;
             case InteractionMode.MovingSelection:
@@ -1562,8 +1564,7 @@ public class AudioVisualizer : Control
                 foreach (var item in _selectionMoveSnapshot)
                 {
                     var start = TimeSpanExtensions.FromSecondsWholeMilliseconds(item.StartSeconds + shift);
-                    item.Paragraph.StartTime = start;
-                    item.Paragraph.EndTime = start + TimeSpanExtensions.FromSecondsWholeMilliseconds(item.DurationSeconds);
+                    item.Paragraph.SetTimes(start, start + TimeSpanExtensions.FromSecondsWholeMilliseconds(item.DurationSeconds));
                 }
 
                 break;
@@ -1576,8 +1577,8 @@ public class AudioVisualizer : Control
                 newStart = snappedLeft;
                 if (_activeParagraphPrevious != null)
                 {
-                    _activeParagraph.SetStartTimeOnly(TimeSpan.FromSeconds(newStart));
-                    _activeParagraphPrevious.EndTime = TimeSpan.FromSeconds(newPrevEnd);
+                    _activeParagraph.SetStartTimeOnly(TimeSpanExtensions.FromSecondsWholeMilliseconds(newStart));
+                    _activeParagraphPrevious.EndTime = TimeSpanExtensions.FromSecondsWholeMilliseconds(newPrevEnd);
                 }
 
                 break;
@@ -1589,8 +1590,8 @@ public class AudioVisualizer : Control
                 newEnd = snappedRight;
                 if (_activeParagraphNext != null)
                 {
-                    _activeParagraph.EndTime = TimeSpan.FromSeconds(newEnd);
-                    _activeParagraphNext.SetStartTimeOnly(TimeSpan.FromSeconds(newNextStart));
+                    _activeParagraph.EndTime = TimeSpanExtensions.FromSecondsWholeMilliseconds(newEnd);
+                    _activeParagraphNext.SetStartTimeOnly(TimeSpanExtensions.FromSecondsWholeMilliseconds(newNextStart));
                 }
 
                 break;
@@ -1621,7 +1622,7 @@ public class AudioVisualizer : Control
 
                 if (newStart < _activeParagraph.EndTime.TotalSeconds - 0.1)
                 {
-                    _activeParagraph.SetStartTimeOnly(TimeSpan.FromSeconds(newStart));
+                    _activeParagraph.SetStartTimeOnly(TimeSpanExtensions.FromSecondsWholeMilliseconds(newStart));
                 }
 
                 break;
@@ -1647,7 +1648,7 @@ public class AudioVisualizer : Control
 
                 if (newEnd > _activeParagraph.StartTime.TotalSeconds + 0.1)
                 {
-                    _activeParagraph.EndTime = TimeSpan.FromSeconds(newEnd);
+                    _activeParagraph.EndTime = TimeSpanExtensions.FromSecondsWholeMilliseconds(newEnd);
                 }
 
                 break;

--- a/src/ui/Controls/SecondsUpDown.cs
+++ b/src/ui/Controls/SecondsUpDown.cs
@@ -7,6 +7,7 @@ using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Globalization;
@@ -259,7 +260,7 @@ public class SecondsUpDown : TemplatedControl
                int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var frames))
             {
                 var totalMs = seconds * 1000 + SubtitleFormat.FramesToMilliseconds(frames);
-                return TimeSpan.FromMilliseconds(totalMs);
+                return TimeSpanExtensions.FromMillisecondsWholeMilliseconds(totalMs);
             }
         }
         else
@@ -267,7 +268,10 @@ public class SecondsUpDown : TemplatedControl
             // Expect "seconds.ms" or "seconds,ms"
             if (double.TryParse(text.Replace(',', '.'), NumberStyles.Float, CultureInfo.InvariantCulture, out var seconds))
             {
-                return TimeSpan.FromSeconds(seconds);
+                // Snap to a whole millisecond: TimeSpan.FromSeconds(0.82) is 819.9999 ms, which
+                // reads back as "0,820" here but as "0,819" in the grid, and ends the line a
+                // millisecond early (#14056).
+                return TimeSpanExtensions.FromSecondsWholeMilliseconds(seconds);
             }
         }
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -4827,7 +4827,7 @@ public partial class MainViewModel :
         {
             var newParagraph = new SubtitleLineViewModel(p, SelectedSubtitleFormat);
             var offset = p.StartTime.TotalMilliseconds - firstStartTime;
-            newParagraph.SetStartTimeKeepDuration(TimeSpan.FromMilliseconds(videoPosition * 1000 + offset));
+            newParagraph.SetStartTimeKeepDuration(TimeSpanExtensions.FromMillisecondsWholeMilliseconds(videoPosition * 1000 + offset));
 
             _insertService.InsertInCorrectPosition(Subtitles, newParagraph);
         }
@@ -4884,7 +4884,7 @@ public partial class MainViewModel :
         foreach (var p in subtitle.Paragraphs)
         {
             var newParagraph = new SubtitleLineViewModel(p, SelectedSubtitleFormat);
-            newParagraph.SetStartTimeKeepDuration(TimeSpan.FromMilliseconds(p.StartTime.TotalMilliseconds + timeOffset));
+            newParagraph.SetStartTimeKeepDuration(TimeSpanExtensions.FromMillisecondsWholeMilliseconds(p.StartTime.TotalMilliseconds + timeOffset));
             _insertService.InsertInCorrectPosition(Subtitles, newParagraph);
         }
 
@@ -5406,8 +5406,8 @@ public partial class MainViewModel :
             var nextSubtitle = GetNextWorkingRow(idx);
             var charCount = selectedLine.Text?.Length ?? 0;
 
-            var optimalDuration = TimeSpan.FromSeconds(charCount / Se.Settings.General.SubtitleOptimalCharactersPerSeconds);
-            var maxDuration = TimeSpan.FromSeconds(charCount / Se.Settings.General.SubtitleMaximumCharactersPerSeconds);
+            var optimalDuration = TimeSpanExtensions.FromSecondsWholeMilliseconds(charCount / Se.Settings.General.SubtitleOptimalCharactersPerSeconds);
+            var maxDuration = TimeSpanExtensions.FromSecondsWholeMilliseconds(charCount / Se.Settings.General.SubtitleMaximumCharactersPerSeconds);
             var maxEndTime = TimeSpan.FromMilliseconds(selectedLine.StartTime.TotalMilliseconds + Se.Settings.General.SubtitleMaximumDisplayMilliseconds);
             if (nextSubtitle != null)
             {
@@ -5485,7 +5485,7 @@ public partial class MainViewModel :
                 continue;
             }
 
-            var newEndTime = selectedLine.StartTime + TimeSpan.FromSeconds(charCount / maxCps);
+            var newEndTime = selectedLine.StartTime + TimeSpanExtensions.FromSecondsWholeMilliseconds(charCount / maxCps);
             if (newEndTime < minEndTime)
             {
                 newEndTime = minEndTime;
@@ -7441,13 +7441,13 @@ public partial class MainViewModel :
 
                 if (Math.Abs(newStartMs - s.StartTime.TotalMilliseconds) >= 0.5)
                 {
-                    s.SetStartTimeOnly(TimeSpan.FromMilliseconds(newStartMs));
+                    s.SetStartTimeOnly(TimeSpanExtensions.FromMillisecondsWholeMilliseconds(newStartMs));
                     changed++;
                 }
 
                 if (Math.Abs(newEndMs - s.EndTime.TotalMilliseconds) >= 0.5)
                 {
-                    s.EndTime = TimeSpan.FromMilliseconds(newEndMs);
+                    s.EndTime = TimeSpanExtensions.FromMillisecondsWholeMilliseconds(newEndMs);
                     changed++;
                 }
             }
@@ -8275,7 +8275,7 @@ public partial class MainViewModel :
                     foreach (var p in transcribedLine.Transcription.Paragraphs)
                     {
                         var newLine = new SubtitleLineViewModel(p, SelectedSubtitleFormat);
-                        newLine.SetStartTimeKeepDuration(selectedLine.StartTime + p.StartTime.TimeSpan);
+                        newLine.SetStartTimeKeepDuration(TimeSpanExtensions.FromMillisecondsWholeMilliseconds(selectedLine.StartTime.TotalMilliseconds + p.StartTime.TotalMilliseconds));
                         newLine.Style = selectedLine.Style; // the lines replace selectedLine, so they keep its style
                         newLines.Add(newLine);
                     }
@@ -9904,7 +9904,7 @@ public partial class MainViewModel :
                 continue;
             }
 
-            line.EndTime = TimeSpan.FromMilliseconds(newEndMs.Value);
+            line.EndTime = TimeSpanExtensions.FromMillisecondsWholeMilliseconds(newEndMs.Value);
         }
 
         _updateAudioVisualizer = true;
@@ -9993,7 +9993,7 @@ public partial class MainViewModel :
 
             // Use SetStartTimeOnly so EndTime stays fixed (the StartTime setter would otherwise
             // shift EndTime to preserve Duration - see SubtitleLineViewModel.OnStartTimeChanged).
-            line.SetStartTimeOnly(TimeSpan.FromMilliseconds(newStartMs.Value));
+            line.SetStartTimeOnly(TimeSpanExtensions.FromMillisecondsWholeMilliseconds(newStartMs.Value));
         }
 
         _updateAudioVisualizer = true;
@@ -10029,7 +10029,7 @@ public partial class MainViewModel :
 
             // Use SetStartTimeOnly so EndTime stays fixed (the StartTime
             // setter would otherwise shift EndTime to preserve Duration).
-            line.SetStartTimeOnly(TimeSpan.FromMilliseconds(newStartMs.Value));
+            line.SetStartTimeOnly(TimeSpanExtensions.FromMillisecondsWholeMilliseconds(newStartMs.Value));
         }
 
         _updateAudioVisualizer = true;
@@ -10063,7 +10063,7 @@ public partial class MainViewModel :
                 continue;
             }
 
-            line.EndTime = TimeSpan.FromMilliseconds(newEndMs.Value);
+            line.EndTime = TimeSpanExtensions.FromMillisecondsWholeMilliseconds(newEndMs.Value);
         }
 
         _updateAudioVisualizer = true;
@@ -10186,10 +10186,10 @@ public partial class MainViewModel :
                     // Use SetStartTimeOnly so the line's EndTime stays put
                     // (the StartTime setter would otherwise shift EndTime to
                     // preserve Duration — see OnStartTimeChanged).
-                    line.SetStartTimeOnly(TimeSpan.FromMilliseconds(newStartMs));
+                    line.SetStartTimeOnly(TimeSpanExtensions.FromMillisecondsWholeMilliseconds(newStartMs));
                     if (Math.Abs(newPreviousEndMs - prev.EndTime.TotalMilliseconds) > 0.5)
                     {
-                        prev.EndTime = TimeSpan.FromMilliseconds(newPreviousEndMs);
+                        prev.EndTime = TimeSpanExtensions.FromMillisecondsWholeMilliseconds(newPreviousEndMs);
                         if (!selectedSet.Contains(prev))
                         {
                             adjustedNeighbors.Add(prev);
@@ -10198,7 +10198,7 @@ public partial class MainViewModel :
                 }
                 else
                 {
-                    line.SetStartTimeOnly(TimeSpan.FromMilliseconds(newStartMs));
+                    line.SetStartTimeOnly(TimeSpanExtensions.FromMillisecondsWholeMilliseconds(newStartMs));
                 }
             }
             else
@@ -10237,12 +10237,12 @@ public partial class MainViewModel :
                         continue;
                     }
 
-                    line.EndTime = TimeSpan.FromMilliseconds(newEndMs);
+                    line.EndTime = TimeSpanExtensions.FromMillisecondsWholeMilliseconds(newEndMs);
                     if (Math.Abs(newNextStartMs - next.StartTime.TotalMilliseconds) > 0.5)
                     {
                         // SetStartTimeOnly so the next subtitle's EndTime
                         // isn't shifted to preserve its previous Duration.
-                        next.SetStartTimeOnly(TimeSpan.FromMilliseconds(newNextStartMs));
+                        next.SetStartTimeOnly(TimeSpanExtensions.FromMillisecondsWholeMilliseconds(newNextStartMs));
                         if (!selectedSet.Contains(next))
                         {
                             adjustedNeighbors.Add(next);
@@ -10251,7 +10251,7 @@ public partial class MainViewModel :
                 }
                 else
                 {
-                    line.EndTime = TimeSpan.FromMilliseconds(newEndMs);
+                    line.EndTime = TimeSpanExtensions.FromMillisecondsWholeMilliseconds(newEndMs);
                 }
             }
 
@@ -12692,11 +12692,11 @@ public partial class MainViewModel :
             }
         }
 
-        s.SetStartTimeOnly(TimeSpan.FromMilliseconds(newStartMs));
+        s.SetStartTimeOnly(TimeSpanExtensions.FromMillisecondsWholeMilliseconds(newStartMs));
 
         if (prevIsClose && prev != null)
         {
-            prev.EndTime = TimeSpan.FromMilliseconds(newStartMs - prevGapMs);
+            prev.EndTime = TimeSpanExtensions.FromMillisecondsWholeMilliseconds(newStartMs - prevGapMs);
         }
 
         _updateAudioVisualizer = true;
@@ -12760,11 +12760,11 @@ public partial class MainViewModel :
             }
         }
 
-        s.EndTime = TimeSpan.FromMilliseconds(newEndMs);
+        s.EndTime = TimeSpanExtensions.FromMillisecondsWholeMilliseconds(newEndMs);
 
         if (nextIsClose && next != null)
         {
-            next.SetStartTimeOnly(TimeSpan.FromMilliseconds(newEndMs + nextGapMs));
+            next.SetStartTimeOnly(TimeSpanExtensions.FromMillisecondsWholeMilliseconds(newEndMs + nextGapMs));
         }
 
         _updateAudioVisualizer = true;
@@ -15288,7 +15288,7 @@ public partial class MainViewModel :
             return;
         }
 
-        var startMs = vp.Position * 1000.0;
+        var startMs = Math.Round(vp.Position * 1000.0, MidpointRounding.AwayFromZero);
         var endMs = startMs + Se.Settings.General.NewEmptyDefaultMs;
         var newParagraph =
             new SubtitleLineViewModel(new Paragraph(string.Empty, startMs, endMs), SelectedSubtitleFormat);
@@ -15337,7 +15337,7 @@ public partial class MainViewModel :
             return;
         }
 
-        var startMs = vp.Position * 1000.0;
+        var startMs = Math.Round(vp.Position * 1000.0, MidpointRounding.AwayFromZero);
         selectedSubtitle.StartTime = TimeSpan.FromMilliseconds(startMs);
         _setEndAtKeyUpLine = selectedSubtitle;
         _setEndAtKeyUpLineGoToNext = true;
@@ -15612,8 +15612,7 @@ public partial class MainViewModel :
             var ratio = p.Text.CountCharacters(true) / totalLength;
             var newDurationMs = (double)ratio * totalDurationWithGapsMs;
             var newStartMs = previousEndMs + gapMs;
-            p.StartTime = TimeSpan.FromMilliseconds(newStartMs);
-            p.EndTime = TimeSpan.FromMilliseconds(newStartMs + newDurationMs);
+            p.SetTimes(TimeSpanExtensions.FromMillisecondsWholeMilliseconds(newStartMs), TimeSpanExtensions.FromMillisecondsWholeMilliseconds(newStartMs) + TimeSpanExtensions.FromMillisecondsWholeMilliseconds(newDurationMs));
             previousEndMs = p.EndTime.TotalMilliseconds;
         }
 
@@ -16223,7 +16222,7 @@ public partial class MainViewModel :
             return;
         }
 
-        var startMs = vp.Position * 1000.0;
+        var startMs = Math.Round(vp.Position * 1000.0, MidpointRounding.AwayFromZero);
         var endMs = startMs + Se.Settings.General.NewEmptyDefaultMs;
         var newParagraph =
             new SubtitleLineViewModel(new Paragraph(string.Empty, startMs, endMs), SelectedSubtitleFormat);
@@ -16265,7 +16264,7 @@ public partial class MainViewModel :
             return;
         }
 
-        var startMs = vp.Position * 1000.0;
+        var startMs = Math.Round(vp.Position * 1000.0, MidpointRounding.AwayFromZero);
         var endMs = startMs + Se.Settings.General.NewEmptyDefaultMs;
         var newParagraph =
             new SubtitleLineViewModel(new Paragraph(string.Empty, startMs, endMs), SelectedSubtitleFormat);

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -53,14 +53,57 @@ public partial class SubtitleLineViewModel : ObservableObject
     [ObservableProperty]
     private string? _bookmark;
 
-    [ObservableProperty]
+    // The three time properties are hand-written rather than [ObservableProperty] so that every
+    // assignment is snapped to a whole millisecond - the generated setter offers no coercion hook.
+    // Subtitle formats store whole milliseconds and every time code SE shows is a whole
+    // millisecond, but .NET Core's TimeSpan.FromSeconds/FromMilliseconds truncate to ticks, so a
+    // pixel-derived waveform drag or a typed "0,820" lands here as e.g. 819.9999 ms. Such a value
+    // renders one millisecond apart in the grid (which truncates) and in the duration up/down
+    // (which rounds), and saves a millisecond early - see issue #14056.
     private TimeSpan _startTime;
 
-    [ObservableProperty]
+    public TimeSpan StartTime
+    {
+        get => _startTime;
+        set
+        {
+            var snapped = value.SnapToWholeMilliseconds();
+            if (SetProperty(ref _startTime, snapped))
+            {
+                OnStartTimeChanged(snapped);
+            }
+        }
+    }
+
     private TimeSpan _endTime;
 
-    [ObservableProperty]
+    public TimeSpan EndTime
+    {
+        get => _endTime;
+        set
+        {
+            var snapped = value.SnapToWholeMilliseconds();
+            if (SetProperty(ref _endTime, snapped))
+            {
+                OnEndTimeChanged(snapped);
+            }
+        }
+    }
+
     private TimeSpan _duration;
+
+    public TimeSpan Duration
+    {
+        get => _duration;
+        set
+        {
+            var snapped = value.SnapToWholeMilliseconds();
+            if (SetProperty(ref _duration, snapped))
+            {
+                OnDurationChanged(snapped);
+            }
+        }
+    }
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(TeletextDisplay))]
@@ -917,7 +960,7 @@ public partial class SubtitleLineViewModel : ObservableObject
         SetTimes(timeSpan, timeSpan + (EndTime - StartTime));
     }
 
-    partial void OnStartTimeChanged(TimeSpan value)
+    private void OnStartTimeChanged(TimeSpan value)
     {
         OnPropertyChanged(nameof(StartTimeOnly));
         OnPropertyChanged(nameof(StartTimeKeepDuration));
@@ -935,7 +978,7 @@ public partial class SubtitleLineViewModel : ObservableObject
         _skipUpdate = false;
     }
 
-    partial void OnEndTimeChanged(TimeSpan value)
+    private void OnEndTimeChanged(TimeSpan value)
     {
         if (_skipUpdate)
         {
@@ -950,7 +993,7 @@ public partial class SubtitleLineViewModel : ObservableObject
         _skipUpdate = false;
     }
 
-    partial void OnDurationChanged(TimeSpan value)
+    private void OnDurationChanged(TimeSpan value)
     {
         if (_skipUpdate)
         {

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -53,57 +53,14 @@ public partial class SubtitleLineViewModel : ObservableObject
     [ObservableProperty]
     private string? _bookmark;
 
-    // The three time properties are hand-written rather than [ObservableProperty] so that every
-    // assignment is snapped to a whole millisecond - the generated setter offers no coercion hook.
-    // Subtitle formats store whole milliseconds and every time code SE shows is a whole
-    // millisecond, but .NET Core's TimeSpan.FromSeconds/FromMilliseconds truncate to ticks, so a
-    // pixel-derived waveform drag or a typed "0,820" lands here as e.g. 819.9999 ms. Such a value
-    // renders one millisecond apart in the grid (which truncates) and in the duration up/down
-    // (which rounds), and saves a millisecond early - see issue #14056.
+    [ObservableProperty]
     private TimeSpan _startTime;
 
-    public TimeSpan StartTime
-    {
-        get => _startTime;
-        set
-        {
-            var snapped = value.SnapToWholeMilliseconds();
-            if (SetProperty(ref _startTime, snapped))
-            {
-                OnStartTimeChanged(snapped);
-            }
-        }
-    }
-
+    [ObservableProperty]
     private TimeSpan _endTime;
 
-    public TimeSpan EndTime
-    {
-        get => _endTime;
-        set
-        {
-            var snapped = value.SnapToWholeMilliseconds();
-            if (SetProperty(ref _endTime, snapped))
-            {
-                OnEndTimeChanged(snapped);
-            }
-        }
-    }
-
+    [ObservableProperty]
     private TimeSpan _duration;
-
-    public TimeSpan Duration
-    {
-        get => _duration;
-        set
-        {
-            var snapped = value.SnapToWholeMilliseconds();
-            if (SetProperty(ref _duration, snapped))
-            {
-                OnDurationChanged(snapped);
-            }
-        }
-    }
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(TeletextDisplay))]
@@ -960,7 +917,7 @@ public partial class SubtitleLineViewModel : ObservableObject
         SetTimes(timeSpan, timeSpan + (EndTime - StartTime));
     }
 
-    private void OnStartTimeChanged(TimeSpan value)
+    partial void OnStartTimeChanged(TimeSpan value)
     {
         OnPropertyChanged(nameof(StartTimeOnly));
         OnPropertyChanged(nameof(StartTimeKeepDuration));
@@ -978,7 +935,7 @@ public partial class SubtitleLineViewModel : ObservableObject
         _skipUpdate = false;
     }
 
-    private void OnEndTimeChanged(TimeSpan value)
+    partial void OnEndTimeChanged(TimeSpan value)
     {
         if (_skipUpdate)
         {
@@ -993,7 +950,7 @@ public partial class SubtitleLineViewModel : ObservableObject
         _skipUpdate = false;
     }
 
-    private void OnDurationChanged(TimeSpan value)
+    partial void OnDurationChanged(TimeSpan value)
     {
         if (_skipUpdate)
         {
@@ -1205,9 +1162,14 @@ public partial class SubtitleLineViewModel : ObservableObject
         // Set both times atomically via SetTimes; updating start then end
         // separately can briefly expose start > end to the bound editor
         // controls, which clamp the negative duration and corrupt the end time.
-        var newStart = TimeSpan.FromMilliseconds(StartTime.TotalMilliseconds * factor + adjustmentInSeconds * TimeCode.BaseUnit);
-        var newEnd = TimeSpan.FromMilliseconds(EndTime.TotalMilliseconds * factor + adjustmentInSeconds * TimeCode.BaseUnit);
-        SetTimes(newStart, newEnd);
+        //
+        // Round to whole milliseconds via start + scaled duration, not start and end
+        // independently: with independent rounding, lines of equal length scale to durations
+        // that differ by 1 ms depending on where they sit, flipping min-duration/CPS warnings
+        // on some rows and not others (#14056).
+        var newStart = TimeSpanExtensions.FromMillisecondsWholeMilliseconds(StartTime.TotalMilliseconds * factor + adjustmentInSeconds * TimeCode.BaseUnit);
+        var newDuration = TimeSpanExtensions.FromMillisecondsWholeMilliseconds((EndTime.TotalMilliseconds - StartTime.TotalMilliseconds) * factor);
+        SetTimes(newStart, newStart + newDuration);
     }
 
     internal double GetCharactersPerSecond()

--- a/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleBluRay.cs
+++ b/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleBluRay.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.BluRaySup;
+using Nikse.SubtitleEdit.Logic;
 using SkiaSharp;
 using System;
 using System.Collections.Generic;
@@ -29,12 +30,13 @@ public class OcrSubtitleBluRay : IOcrSubtitle
 
     public TimeSpan GetStartTime(int index)
     {
-        return TimeSpan.FromMilliseconds(_pcsDataList[index].StartTime / 90.0);
+        // 90 kHz PTS is a fractional millisecond; round to the whole ms subtitle formats store (#14056).
+        return TimeSpanExtensions.FromMillisecondsWholeMilliseconds(_pcsDataList[index].StartTime / 90.0);
     }
 
     public TimeSpan GetEndTime(int index)
     {
-        return TimeSpan.FromMilliseconds(_pcsDataList[index].EndTime / 90.0);
+        return TimeSpanExtensions.FromMillisecondsWholeMilliseconds(_pcsDataList[index].EndTime / 90.0);
     }
 
     public List<OcrSubtitleItem> MakeOcrSubtitleItems()

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1833,8 +1833,8 @@ public partial class BinaryEditViewModel : ObservableObject
                     continue;
                 }
 
-                s.StartTime = TimeSpan.FromMilliseconds(o.Item1 * factor);
-                s.EndTime = TimeSpan.FromMilliseconds(o.Item2 * factor);
+                s.StartTime = TimeSpanExtensions.FromMillisecondsWholeMilliseconds(o.Item1 * factor);
+                s.EndTime = TimeSpanExtensions.FromMillisecondsWholeMilliseconds(o.Item2 * factor);
             }
         }
 
@@ -2726,8 +2726,8 @@ public partial class BinaryEditViewModel : ObservableObject
     {
         foreach (var s in subtitles)
         {
-            var newStart = TimeSpan.FromMilliseconds(s.StartTime.TotalMilliseconds * factor);
-            var newEnd = TimeSpan.FromMilliseconds(s.EndTime.TotalMilliseconds * factor);
+            var newStart = TimeSpanExtensions.FromMillisecondsWholeMilliseconds(s.StartTime.TotalMilliseconds * factor);
+            var newEnd = TimeSpanExtensions.FromMillisecondsWholeMilliseconds(s.EndTime.TotalMilliseconds * factor);
             s.StartTime = newStart;
             s.EndTime = newEnd;
         }

--- a/src/ui/Features/Sync/ChangeFrameRate/ChangeFrameRateViewModel.cs
+++ b/src/ui/Features/Sync/ChangeFrameRate/ChangeFrameRateViewModel.cs
@@ -183,9 +183,11 @@ public partial class ChangeFrameRateViewModel : ObservableObject
         double ratio = GetFrameRateRatio(fromFrameRate, toFrameRate);
         foreach (var line in subtitles)
         {
-            line.SetTimes(
-                TimeSpan.FromMilliseconds(line.StartTime.TotalMilliseconds * ratio),
-                TimeSpan.FromMilliseconds(line.EndTime.TotalMilliseconds * ratio));
+            // Round to whole milliseconds via start + scaled duration, not start and end
+            // independently, so lines of equal length keep equal durations after scaling (#14056).
+            var newStart = TimeSpanExtensions.FromMillisecondsWholeMilliseconds(line.StartTime.TotalMilliseconds * ratio);
+            var newDuration = TimeSpanExtensions.FromMillisecondsWholeMilliseconds((line.EndTime.TotalMilliseconds - line.StartTime.TotalMilliseconds) * ratio);
+            line.SetTimes(newStart, newStart + newDuration);
         }
     }
 }

--- a/src/ui/Logic/Media/ShotChangesHelper.cs
+++ b/src/ui/Logic/Media/ShotChangesHelper.cs
@@ -458,8 +458,12 @@ public class ShotChangesHelper
             nearestEnd = FirstAfterWithin(shotChanges, nearestStart.Value, endMs, maxSameShotEndDistanceMs);
         }
 
-        var newStartMs = nearestStart != null ? nearestStart.Value + inCuesGapMs : startMs;
-        var newEndMs = nearestEnd != null ? nearestEnd.Value - outCuesGapMs : endMs;
+        // Shot changes come from video frame positions, so cut ± gap is a fractional
+        // millisecond. Round to the whole millisecond the subtitle will actually store; the
+        // no-op guard below then compares like with like, so re-running the command on an
+        // already-snapped line stays a no-op instead of reporting a change (#14056).
+        var newStartMs = nearestStart != null ? Math.Round(nearestStart.Value + inCuesGapMs, MidpointRounding.AwayFromZero) : startMs;
+        var newEndMs = nearestEnd != null ? Math.Round(nearestEnd.Value - outCuesGapMs, MidpointRounding.AwayFromZero) : endMs;
 
         if (newEndMs <= newStartMs)
         {

--- a/src/ui/Logic/TimeSpanExtensions.cs
+++ b/src/ui/Logic/TimeSpanExtensions.cs
@@ -12,55 +12,8 @@ public static class TimeSpanExtensions
     }
 
     /// <summary>
-    /// Rounds a time to a whole millisecond - the only resolution subtitle formats (and every
-    /// time code SE displays) can represent.
-    /// <para>
-    /// Since .NET Core 3.0 <see cref="TimeSpan.FromSeconds(double)"/> and
-    /// <see cref="TimeSpan.FromMilliseconds(double)"/> truncate to ticks instead of rounding to
-    /// whole milliseconds like .NET Framework did, so e.g. <c>TimeSpan.FromSeconds(0.82)</c> is
-    /// 819.9999 ms, not 820 ms. Such a value renders as "0,820" in the duration up/down (which
-    /// rounds) and as "0,819" in the grid (which truncates, like the format writers do), and the
-    /// end time it produces really is a millisecond early - see issue #14056. Snapping on the way
-    /// in keeps the two displays in agreement and the saved file faithful to what was typed.
-    /// </para>
-    /// </summary>
-    public static TimeSpan SnapToWholeMilliseconds(this TimeSpan ts)
-    {
-        var rest = ts.Ticks % TimeSpan.TicksPerMillisecond;
-        if (rest == 0)
-        {
-            return ts;
-        }
-
-        // Away from zero on the half, matching the rounding SE uses elsewhere for time codes.
-        // TimeSpan.MaxValue/MinValue have no whole millisecond to round to, so they stay put
-        // rather than wrapping around.
-        var ticks = ts.Ticks - rest;
-        if (rest >= TimeSpan.TicksPerMillisecond / 2)
-        {
-            if (ticks > long.MaxValue - TimeSpan.TicksPerMillisecond)
-            {
-                return ts;
-            }
-
-            ticks += TimeSpan.TicksPerMillisecond;
-        }
-        else if (rest <= -TimeSpan.TicksPerMillisecond / 2)
-        {
-            if (ticks < long.MinValue + TimeSpan.TicksPerMillisecond)
-            {
-                return ts;
-            }
-
-            ticks -= TimeSpan.TicksPerMillisecond;
-        }
-
-        return TimeSpan.FromTicks(ticks);
-    }
-
-    /// <summary>
-    /// <see cref="TimeSpan.FromSeconds(double)"/> snapped to a whole millisecond -
-    /// see <see cref="SnapToWholeMilliseconds"/>.
+    /// <see cref="TimeSpan.FromSeconds(double)"/> rounded to a whole millisecond -
+    /// see <see cref="FromMillisecondsWholeMilliseconds"/>.
     /// </summary>
     public static TimeSpan FromSecondsWholeMilliseconds(double seconds)
     {
@@ -68,27 +21,38 @@ public static class TimeSpanExtensions
     }
 
     /// <summary>
-    /// <see cref="TimeSpan.FromMilliseconds(double)"/> snapped to a whole millisecond -
-    /// see <see cref="SnapToWholeMilliseconds"/>.
+    /// <see cref="TimeSpan.FromMilliseconds(double)"/> rounded to a whole millisecond - the only
+    /// resolution subtitle formats (and every time code SE displays) can represent.
+    /// <para>
+    /// Since .NET Core 3.0 <see cref="TimeSpan.FromSeconds(double)"/> and
+    /// <see cref="TimeSpan.FromMilliseconds(double)"/> truncate to ticks instead of rounding to
+    /// whole milliseconds like .NET Framework did, so e.g. <c>TimeSpan.FromSeconds(0.82)</c> is
+    /// 819.9999 ms, not 820 ms. Such a value renders as "0,820" in the duration up/down (which
+    /// rounds) and as "0,819" in the grid (which truncates, like the format writers do), and the
+    /// end time it produces really is a millisecond early - see issue #14056. Every place that
+    /// turns a fractional-millisecond double (typed input, pixel positions, video positions,
+    /// scale factors) into a subtitle time must come through here.
+    /// </para>
+    /// Out-of-range values are clamped to the time-code domain (±99:59:59,999) rather than
+    /// TimeSpan's, so the result is always a whole millisecond a <see cref="Core.Common.TimeCode"/>
+    /// can hold. NaN throws, like <see cref="TimeSpan.FromSeconds(double)"/> always has - a NaN
+    /// time is a bug at the call site and must not silently become 00:00:00,000.
     /// </summary>
     public static TimeSpan FromMillisecondsWholeMilliseconds(double milliseconds)
     {
         if (double.IsNaN(milliseconds))
         {
-            return TimeSpan.Zero;
+            throw new ArgumentException("TimeSpan does not accept floating point Not-a-Number values.", nameof(milliseconds));
         }
 
-        // Keep the tick multiplication below in range; TimeSpan.FromMilliseconds would throw here.
-        const double maxMs = long.MaxValue / (double)TimeSpan.TicksPerMillisecond;
         var ms = Math.Round(milliseconds, MidpointRounding.AwayFromZero);
-        if (ms >= maxMs)
+        if (ms > MaxTimeTotalMilliseconds)
         {
-            return TimeSpan.MaxValue;
+            ms = MaxTimeTotalMilliseconds;
         }
-
-        if (ms <= -maxMs)
+        else if (ms < -MaxTimeTotalMilliseconds)
         {
-            return TimeSpan.MinValue;
+            ms = -MaxTimeTotalMilliseconds;
         }
 
         return TimeSpan.FromTicks((long)ms * TimeSpan.TicksPerMillisecond);

--- a/src/ui/Logic/TimeSpanExtensions.cs
+++ b/src/ui/Logic/TimeSpanExtensions.cs
@@ -10,4 +10,87 @@ public static class TimeSpanExtensions
     {
         return Math.Abs(ts.TotalMilliseconds - MaxTimeTotalMilliseconds) < 0.01;
     }
+
+    /// <summary>
+    /// Rounds a time to a whole millisecond - the only resolution subtitle formats (and every
+    /// time code SE displays) can represent.
+    /// <para>
+    /// Since .NET Core 3.0 <see cref="TimeSpan.FromSeconds(double)"/> and
+    /// <see cref="TimeSpan.FromMilliseconds(double)"/> truncate to ticks instead of rounding to
+    /// whole milliseconds like .NET Framework did, so e.g. <c>TimeSpan.FromSeconds(0.82)</c> is
+    /// 819.9999 ms, not 820 ms. Such a value renders as "0,820" in the duration up/down (which
+    /// rounds) and as "0,819" in the grid (which truncates, like the format writers do), and the
+    /// end time it produces really is a millisecond early - see issue #14056. Snapping on the way
+    /// in keeps the two displays in agreement and the saved file faithful to what was typed.
+    /// </para>
+    /// </summary>
+    public static TimeSpan SnapToWholeMilliseconds(this TimeSpan ts)
+    {
+        var rest = ts.Ticks % TimeSpan.TicksPerMillisecond;
+        if (rest == 0)
+        {
+            return ts;
+        }
+
+        // Away from zero on the half, matching the rounding SE uses elsewhere for time codes.
+        // TimeSpan.MaxValue/MinValue have no whole millisecond to round to, so they stay put
+        // rather than wrapping around.
+        var ticks = ts.Ticks - rest;
+        if (rest >= TimeSpan.TicksPerMillisecond / 2)
+        {
+            if (ticks > long.MaxValue - TimeSpan.TicksPerMillisecond)
+            {
+                return ts;
+            }
+
+            ticks += TimeSpan.TicksPerMillisecond;
+        }
+        else if (rest <= -TimeSpan.TicksPerMillisecond / 2)
+        {
+            if (ticks < long.MinValue + TimeSpan.TicksPerMillisecond)
+            {
+                return ts;
+            }
+
+            ticks -= TimeSpan.TicksPerMillisecond;
+        }
+
+        return TimeSpan.FromTicks(ticks);
+    }
+
+    /// <summary>
+    /// <see cref="TimeSpan.FromSeconds(double)"/> snapped to a whole millisecond -
+    /// see <see cref="SnapToWholeMilliseconds"/>.
+    /// </summary>
+    public static TimeSpan FromSecondsWholeMilliseconds(double seconds)
+    {
+        return FromMillisecondsWholeMilliseconds(seconds * 1000.0);
+    }
+
+    /// <summary>
+    /// <see cref="TimeSpan.FromMilliseconds(double)"/> snapped to a whole millisecond -
+    /// see <see cref="SnapToWholeMilliseconds"/>.
+    /// </summary>
+    public static TimeSpan FromMillisecondsWholeMilliseconds(double milliseconds)
+    {
+        if (double.IsNaN(milliseconds))
+        {
+            return TimeSpan.Zero;
+        }
+
+        // Keep the tick multiplication below in range; TimeSpan.FromMilliseconds would throw here.
+        const double maxMs = long.MaxValue / (double)TimeSpan.TicksPerMillisecond;
+        var ms = Math.Round(milliseconds, MidpointRounding.AwayFromZero);
+        if (ms >= maxMs)
+        {
+            return TimeSpan.MaxValue;
+        }
+
+        if (ms <= -maxMs)
+        {
+            return TimeSpan.MinValue;
+        }
+
+        return TimeSpan.FromTicks((long)ms * TimeSpan.TicksPerMillisecond);
+    }
 }

--- a/tests/UI/Controls/AudioVisualizerDragDurationBoxTests.cs
+++ b/tests/UI/Controls/AudioVisualizerDragDurationBoxTests.cs
@@ -1,0 +1,175 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Nikse.SubtitleEdit.Controls;
+using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UITests.Controls;
+
+// Repro for "when moving end in the waveform, the duration box time is not changing":
+// dragging a cue edge mutates the shared SubtitleLineViewModel, and a SecondsUpDown bound
+// TwoWay to its Duration must tick live during the drag.
+public partial class AudioVisualizerDragDurationBoxTests
+{
+    private const int SampleRate = 126;
+    private const double WidthPx = 800;
+    private const double HeightPx = 200;
+
+    private static WavePeakData2 MakePeaks(int seconds)
+    {
+        var peaks = new WavePeak2[SampleRate * seconds];
+        for (var i = 0; i < peaks.Length; i++)
+        {
+            peaks[i] = new WavePeak2(8000, -8000);
+        }
+
+        return new WavePeakData2(SampleRate, peaks);
+    }
+
+    public partial class Vm : CommunityToolkit.Mvvm.ComponentModel.ObservableObject
+    {
+        [CommunityToolkit.Mvvm.ComponentModel.ObservableProperty]
+        private SubtitleLineViewModel? _selectedSubtitle;
+    }
+
+    // Same, but through the app's actual binding shape: DataContext = main view model,
+    // path "SelectedSubtitle.Duration" (see InitListViewAndEditBox).
+    [AvaloniaFact]
+    public void DraggingTheEndEdgeUpdatesTheDurationBoxBoundViaSelectedSubtitle()
+    {
+        var snapToFrames = Se.Settings.Waveform.SnapToFrames;
+        var snapToShotChanges = Se.Settings.Waveform.SnapToShotChanges;
+        var frameMode = Se.Settings.General.UseFrameMode;
+        Se.Settings.Waveform.SnapToFrames = false;
+        Se.Settings.Waveform.SnapToShotChanges = false;
+        Se.Settings.General.UseFrameMode = false;
+        try
+        {
+            var line = new SubtitleLineViewModel
+            {
+                Text = "text",
+                StartTime = TimeSpan.FromSeconds(1),
+                EndTime = TimeSpan.FromSeconds(3),
+            };
+            var vm = new Vm { SelectedSubtitle = line };
+
+            var av = new AudioVisualizer
+            {
+                WavePeaks = MakePeaks(60),
+                Width = WidthPx,
+                Height = HeightPx,
+            };
+            av.SetPosition(0, new List<SubtitleLineViewModel> { line }, 0, 0, new List<SubtitleLineViewModel>());
+
+            var durationBox = new SecondsUpDown
+            {
+                DataContext = vm,
+                [!SecondsUpDown.ValueProperty] = new Binding($"{nameof(Vm.SelectedSubtitle)}.{nameof(SubtitleLineViewModel.Duration)}")
+                {
+                    Mode = BindingMode.TwoWay,
+                },
+            };
+
+            var panel = new StackPanel();
+            panel.Children.Add(av);
+            panel.Children.Add(durationBox);
+            var window = new Window { Width = WidthPx, Height = HeightPx + 40, Content = panel };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
+
+            var textBox = durationBox.GetVisualDescendants().OfType<TextBox>().Single();
+            Assert.Equal("2.000", textBox.Text!.Replace(',', '.'));
+
+            window.MouseDown(new Point(378, 100), MouseButton.Left, RawInputModifiers.None);
+            window.MouseMove(new Point(378 + 126, 100), RawInputModifiers.None);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(4000, line.EndTime.TotalMilliseconds);
+            Assert.Equal(3000, line.Duration.TotalMilliseconds);
+            Assert.Equal("3.000", textBox.Text!.Replace(',', '.'));
+
+            window.MouseUp(new Point(378 + 126, 100), MouseButton.Left, RawInputModifiers.None);
+        }
+        finally
+        {
+            Se.Settings.Waveform.SnapToFrames = snapToFrames;
+            Se.Settings.Waveform.SnapToShotChanges = snapToShotChanges;
+            Se.Settings.General.UseFrameMode = frameMode;
+        }
+    }
+
+    [AvaloniaFact]
+    public void DraggingTheEndEdgeUpdatesABoundDurationBox()
+    {
+        var snapToFrames = Se.Settings.Waveform.SnapToFrames;
+        var snapToShotChanges = Se.Settings.Waveform.SnapToShotChanges;
+        var frameMode = Se.Settings.General.UseFrameMode;
+        Se.Settings.Waveform.SnapToFrames = false;
+        Se.Settings.Waveform.SnapToShotChanges = false;
+        Se.Settings.General.UseFrameMode = false;
+        try
+        {
+            var line = new SubtitleLineViewModel
+            {
+                Text = "text",
+                StartTime = TimeSpan.FromSeconds(1),
+                EndTime = TimeSpan.FromSeconds(3),
+            };
+
+            var av = new AudioVisualizer
+            {
+                WavePeaks = MakePeaks(60),
+                Width = WidthPx,
+                Height = HeightPx,
+            };
+            av.SetPosition(0, new List<SubtitleLineViewModel> { line }, 0, 0, new List<SubtitleLineViewModel>());
+
+            var durationBox = new SecondsUpDown { DataContext = line };
+            durationBox[!SecondsUpDown.ValueProperty] =
+                new Binding(nameof(SubtitleLineViewModel.Duration)) { Mode = BindingMode.TwoWay };
+
+            var panel = new StackPanel();
+            panel.Children.Add(av);
+            panel.Children.Add(durationBox);
+            var window = new Window { Width = WidthPx, Height = HeightPx + 40, Content = panel };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
+
+            var textBox = durationBox.GetVisualDescendants().OfType<TextBox>().Single();
+            Assert.Equal("2.000", textBox.Text!.Replace(',', '.'));
+
+            // End edge is at 3 s = 378 px; grab it and drag +126 px (one second).
+            window.MouseDown(new Point(378, 100), MouseButton.Left, RawInputModifiers.None);
+            window.MouseMove(new Point(378 + 126, 100), RawInputModifiers.None);
+            Dispatcher.UIThread.RunJobs();
+
+            // Mid-drag, before pointer release: the box must already show the new duration.
+            Assert.Equal(4000, line.EndTime.TotalMilliseconds);
+            Assert.Equal(3000, line.Duration.TotalMilliseconds);
+            Assert.Equal("3.000", textBox.Text!.Replace(',', '.'));
+
+            window.MouseUp(new Point(378 + 126, 100), MouseButton.Left, RawInputModifiers.None);
+        }
+        finally
+        {
+            Se.Settings.Waveform.SnapToFrames = snapToFrames;
+            Se.Settings.Waveform.SnapToShotChanges = snapToShotChanges;
+            Se.Settings.General.UseFrameMode = frameMode;
+        }
+    }
+}

--- a/tests/UI/Controls/AudioVisualizerShotChangeSnapTests.cs
+++ b/tests/UI/Controls/AudioVisualizerShotChangeSnapTests.cs
@@ -180,7 +180,7 @@ public class AudioVisualizerShotChangeSnapTests
 
         Drag(window, 252, 312);
 
-        Assert.Equal(1 + 60.0 / SampleRate, line.StartTime.TotalSeconds, 3); // snapped to whole ms
+        Assert.Equal(1476, line.StartTime.TotalMilliseconds); // 1 + 60/126 s, rounded to the whole ms the drag stores
         Assert.Equal(2, line.Duration.TotalSeconds, 6);
         window.Close();
     }
@@ -194,7 +194,7 @@ public class AudioVisualizerShotChangeSnapTests
 
         Drag(window, 252, 312);
 
-        Assert.Equal(1 + 60.0 / SampleRate, line.StartTime.TotalSeconds, 3); // snapped to whole ms
+        Assert.Equal(1476, line.StartTime.TotalMilliseconds); // 1 + 60/126 s, rounded to the whole ms the drag stores
         window.Close();
     }
 
@@ -307,7 +307,7 @@ public class AudioVisualizerShotChangeSnapTests
         var (window, av) = Open(new List<double> { cutAt }, Line(1, 3));
         var line = av.SelectedParagraph!;
         Drag(window, 252, 312);
-        Assert.Equal(draggedStart, line.StartTime.TotalSeconds, 3); // snapped to whole ms
+        Assert.Equal(1476, line.StartTime.TotalMilliseconds); // draggedStart rounded to the whole ms the drag stores
         window.Close();
     }
 
@@ -321,7 +321,7 @@ public class AudioVisualizerShotChangeSnapTests
         var (window, av) = Open(new List<double> { cutAt }, Line(1, 3));
         var line = av.SelectedParagraph!;
         Drag(window, 252, 312);
-        Assert.Equal(draggedStart, line.StartTime.TotalSeconds, 3); // snapped to whole ms
+        Assert.Equal(1476, line.StartTime.TotalMilliseconds); // draggedStart rounded to the whole ms the drag stores
         window.Close();
 
         Se.Settings.Waveform.SnapToShotChangesPixels = 16;

--- a/tests/UI/Controls/AudioVisualizerShotChangeSnapTests.cs
+++ b/tests/UI/Controls/AudioVisualizerShotChangeSnapTests.cs
@@ -180,7 +180,7 @@ public class AudioVisualizerShotChangeSnapTests
 
         Drag(window, 252, 312);
 
-        Assert.Equal(1 + 60.0 / SampleRate, line.StartTime.TotalSeconds, 6);
+        Assert.Equal(1 + 60.0 / SampleRate, line.StartTime.TotalSeconds, 3); // snapped to whole ms
         Assert.Equal(2, line.Duration.TotalSeconds, 6);
         window.Close();
     }
@@ -194,7 +194,7 @@ public class AudioVisualizerShotChangeSnapTests
 
         Drag(window, 252, 312);
 
-        Assert.Equal(1 + 60.0 / SampleRate, line.StartTime.TotalSeconds, 6);
+        Assert.Equal(1 + 60.0 / SampleRate, line.StartTime.TotalSeconds, 3); // snapped to whole ms
         window.Close();
     }
 
@@ -307,7 +307,7 @@ public class AudioVisualizerShotChangeSnapTests
         var (window, av) = Open(new List<double> { cutAt }, Line(1, 3));
         var line = av.SelectedParagraph!;
         Drag(window, 252, 312);
-        Assert.Equal(draggedStart, line.StartTime.TotalSeconds, 6);
+        Assert.Equal(draggedStart, line.StartTime.TotalSeconds, 3); // snapped to whole ms
         window.Close();
     }
 
@@ -321,7 +321,7 @@ public class AudioVisualizerShotChangeSnapTests
         var (window, av) = Open(new List<double> { cutAt }, Line(1, 3));
         var line = av.SelectedParagraph!;
         Drag(window, 252, 312);
-        Assert.Equal(draggedStart, line.StartTime.TotalSeconds, 6);
+        Assert.Equal(draggedStart, line.StartTime.TotalSeconds, 3); // snapped to whole ms
         window.Close();
 
         Se.Settings.Waveform.SnapToShotChangesPixels = 16;

--- a/tests/UI/Features/Assa/AdvancedEffectTests.cs
+++ b/tests/UI/Features/Assa/AdvancedEffectTests.cs
@@ -97,9 +97,8 @@ public class AdvancedEffectTests
     }
 
     /// <summary>
-    /// The fade duration is emitted as a rounded integer - it must not leak a decimal point
-    /// (or comma) into \fad. A line's times are snapped to whole milliseconds on the way into
-    /// the view model (#14056), so a fractional duration rounds before the effect ever sees it.
+    /// The fade duration is emitted as a rounded integer - a fractional line duration must
+    /// not leak a decimal point (or comma) into \fad.
     /// </summary>
     [Fact]
     public void FadeIn_FractionalDuration_EmitsIntegerFad()
@@ -108,7 +107,7 @@ public class AdvancedEffectTests
         var result = effect.ApplyEffect(string.Empty, [MakeLine("Hello", durationMs: 1500.5)], 1280, 720, null);
 
         var overlay = result[0];
-        Assert.Contains(@"\fad(0,1501)", overlay.Text);
+        Assert.Contains(@"\fad(0,1500)", overlay.Text);
     }
 
     /// <summary>

--- a/tests/UI/Features/Assa/AdvancedEffectTests.cs
+++ b/tests/UI/Features/Assa/AdvancedEffectTests.cs
@@ -97,8 +97,9 @@ public class AdvancedEffectTests
     }
 
     /// <summary>
-    /// The fade duration is emitted as a rounded integer - a fractional line duration must
-    /// not leak a decimal point (or comma) into \fad.
+    /// The fade duration is emitted as a rounded integer - it must not leak a decimal point
+    /// (or comma) into \fad. A line's times are snapped to whole milliseconds on the way into
+    /// the view model (#14056), so a fractional duration rounds before the effect ever sees it.
     /// </summary>
     [Fact]
     public void FadeIn_FractionalDuration_EmitsIntegerFad()
@@ -107,7 +108,7 @@ public class AdvancedEffectTests
         var result = effect.ApplyEffect(string.Empty, [MakeLine("Hello", durationMs: 1500.5)], 1280, 720, null);
 
         var overlay = result[0];
-        Assert.Contains(@"\fad(0,1500)", overlay.Text);
+        Assert.Contains(@"\fad(0,1501)", overlay.Text);
     }
 
     /// <summary>

--- a/tests/UI/Features/Main/SubMillisecondTimeTests.cs
+++ b/tests/UI/Features/Main/SubMillisecondTimeTests.cs
@@ -55,9 +55,10 @@ public class SubMillisecondTimeTests
 
         Assert.Equal(820, line.Duration.TotalMilliseconds);
         Assert.Equal(683_520, line.EndTime.TotalMilliseconds);
-        Assert.Equal("00:11:23,520", new TimeCode(line.EndTime).ToDisplayString());
-        Assert.Equal("0,820", new TimeCode(line.Duration).ToShortString());
-        Assert.Equal("0,820", textBox.Text);
+        // Normalize the decimal separator - display strings follow the runner's culture.
+        Assert.Equal("00:11:23.520", new TimeCode(line.EndTime).ToDisplayString().Replace(',', '.'));
+        Assert.Equal("0.820", new TimeCode(line.Duration).ToShortString().Replace(',', '.'));
+        Assert.Equal("0.820", textBox.Text!.Replace(',', '.'));
     }
 
     [Theory]

--- a/tests/UI/Features/Main/SubMillisecondTimeTests.cs
+++ b/tests/UI/Features/Main/SubMillisecondTimeTests.cs
@@ -1,0 +1,135 @@
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.VisualTree;
+using Nikse.SubtitleEdit.Controls;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Linq;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// Sub-millisecond time codes (issue #14056).
+///
+/// Since .NET Core 3.0 TimeSpan.FromSeconds/FromMilliseconds truncate to ticks instead of rounding
+/// to whole milliseconds the way .NET Framework did, so TimeSpan.FromSeconds(0.82) is 819.9999 ms.
+/// A value like that reads back as "0,820" in the duration up/down (which rounds) but as "0,819" in
+/// the grid (which truncates, like every format writer does), and the end time it produces really
+/// is a millisecond early. Subtitle times are whole milliseconds, so they are snapped on the way in.
+/// </summary>
+public class SubMillisecondTimeTests
+{
+    private static string GridText(TimeSpan ts) => new TimeCode(ts).ToShortString();
+
+    private static string FieldText(TimeSpan ts) => ts.TotalSeconds.ToString("0.000");
+
+    private static SubtitleLineViewModel Line(double startMs, double endMs) =>
+        new() { StartTime = TimeSpan.FromMilliseconds(startMs), EndTime = TimeSpan.FromMilliseconds(endMs) };
+
+    // The reported case: Show 00:11:22,700 and a typed duration of 0,820 must hide at ,520.
+    [AvaloniaFact]
+    public void TypingADurationEndsTheLineOnAWholeMillisecond()
+    {
+        using var _ = new SettingsScope("General.UseFrameMode");
+        Se.Settings.General.UseFrameMode = false;
+
+        var line = Line(682_700, 683_200);
+
+        var upDown = new SecondsUpDown { DataContext = line };
+        upDown[!SecondsUpDown.ValueProperty] =
+            new Binding(nameof(SubtitleLineViewModel.Duration)) { Mode = BindingMode.TwoWay };
+        var window = new Window { Content = upDown };
+        window.Show();
+        var textBox = upDown.GetVisualDescendants().OfType<TextBox>().Single();
+
+        textBox.Focus();
+        textBox.Text = "0,820";
+        window.KeyPress(Key.Enter, RawInputModifiers.None, PhysicalKey.Enter, null);
+
+        Assert.Equal(820, line.Duration.TotalMilliseconds);
+        Assert.Equal(683_520, line.EndTime.TotalMilliseconds);
+        Assert.Equal("00:11:23,520", new TimeCode(line.EndTime).ToDisplayString());
+        Assert.Equal("0,820", GridText(line.Duration));
+        Assert.Equal("0,820", textBox.Text);
+    }
+
+    // The other reported case: a waveform drag lands the cues on fractional milliseconds, so the
+    // grid (truncating) and the duration up/down (rounding) disagreed by one millisecond.
+    [Theory]
+    [InlineData(589_780.6, 590_910.3)] // pixel-derived, as a waveform drag produces
+    [InlineData(682_700.0, 683_519.9999)] // tick-truncated, as TimeSpan.FromSeconds produces
+    [InlineData(1_000.4, 2_000.5)]
+    [InlineData(1_000.5, 2_000.6)]
+    public void TheGridAndTheDurationFieldNeverDisagree(double startMs, double endMs)
+    {
+        using var _ = new SettingsScope("General.UseFrameMode");
+        Se.Settings.General.UseFrameMode = false;
+
+        var line = Line(startMs, endMs);
+
+        Assert.Equal(0, line.StartTime.Ticks % TimeSpan.TicksPerMillisecond);
+        Assert.Equal(0, line.EndTime.Ticks % TimeSpan.TicksPerMillisecond);
+        Assert.Equal(0, line.Duration.Ticks % TimeSpan.TicksPerMillisecond);
+        Assert.Equal(GridText(line.Duration), FieldText(line.Duration));
+        Assert.Equal(line.EndTime - line.StartTime, line.Duration);
+    }
+
+    // Nudging Show must not leave the duration reading one value in the grid and another in the
+    // field - the reporter's follow-up test, which moved both cues but kept the bad span.
+    [AvaloniaFact]
+    public void MovingALineKeepsAWholeMillisecondDuration()
+    {
+        var line = Line(682_700, 683_520);
+
+        // A pixel-derived waveform drag, i.e. an arbitrary fraction of a millisecond.
+        line.SetStartTimeKeepDuration(TimeSpan.FromMilliseconds(682_700.6));
+
+        Assert.Equal(682_701, line.StartTime.TotalMilliseconds);
+        Assert.Equal(683_521, line.EndTime.TotalMilliseconds);
+        Assert.Equal(820, line.Duration.TotalMilliseconds);
+        Assert.Equal(GridText(line.Duration), FieldText(line.Duration));
+    }
+
+    [Theory]
+    [InlineData(0.82, 820)]
+    [InlineData(1.13, 1130)]
+    [InlineData(1.129, 1129)]
+    [InlineData(0.0004, 0)]
+    [InlineData(0.0005, 1)]
+    [InlineData(-0.0005, -1)]
+    [InlineData(-1.13, -1130)]
+    public void SecondsAreSnappedToWholeMilliseconds(double seconds, double expectedMs)
+    {
+        var snapped = TimeSpanExtensions.FromSecondsWholeMilliseconds(seconds);
+
+        Assert.Equal(expectedMs, snapped.TotalMilliseconds);
+        Assert.Equal(0, snapped.Ticks % TimeSpan.TicksPerMillisecond);
+    }
+
+    // The extremes have no whole millisecond to round to - they must stay put, not wrap around.
+    [Fact]
+    public void SnappingTheExtremesDoesNotWrapAround()
+    {
+        Assert.Equal(TimeSpan.MaxValue, TimeSpan.MaxValue.SnapToWholeMilliseconds());
+        Assert.Equal(TimeSpan.MinValue, TimeSpan.MinValue.SnapToWholeMilliseconds());
+        Assert.Equal(TimeSpan.MaxValue, TimeSpanExtensions.FromSecondsWholeMilliseconds(double.MaxValue));
+        Assert.Equal(TimeSpan.MinValue, TimeSpanExtensions.FromSecondsWholeMilliseconds(double.MinValue));
+        Assert.Equal(TimeSpan.Zero, TimeSpanExtensions.FromSecondsWholeMilliseconds(double.NaN));
+    }
+
+    [Fact]
+    public void SnappingIsAlreadyWholeMillisecondsIdempotent()
+    {
+        var whole = TimeSpan.FromMilliseconds(1130);
+
+        Assert.Equal(whole, whole.SnapToWholeMilliseconds());
+        Assert.Equal(TimeSpan.Zero, TimeSpan.Zero.SnapToWholeMilliseconds());
+        Assert.Equal(whole, TimeSpan.FromSeconds(1.13).SnapToWholeMilliseconds());
+    }
+}

--- a/tests/UI/Features/Main/SubMillisecondTimeTests.cs
+++ b/tests/UI/Features/Main/SubMillisecondTimeTests.cs
@@ -7,9 +7,11 @@ using Avalonia.VisualTree;
 using Nikse.SubtitleEdit.Controls;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Sync.ChangeFrameRate;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
+using System.Collections.ObjectModel;
 using System.Linq;
 
 namespace UITests.Features.Main;
@@ -21,18 +23,17 @@ namespace UITests.Features.Main;
 /// to whole milliseconds the way .NET Framework did, so TimeSpan.FromSeconds(0.82) is 819.9999 ms.
 /// A value like that reads back as "0,820" in the duration up/down (which rounds) but as "0,819" in
 /// the grid (which truncates, like every format writer does), and the end time it produces really
-/// is a millisecond early. Subtitle times are whole milliseconds, so they are snapped on the way in.
+/// is a millisecond early. Subtitle formats store whole milliseconds, so every producer that turns
+/// a fractional double (typed input, pixel positions, video positions, scale factors) into a
+/// subtitle time rounds through TimeSpanExtensions.FromSeconds/FromMillisecondsWholeMilliseconds.
 /// </summary>
 public class SubMillisecondTimeTests
 {
-    private static string GridText(TimeSpan ts) => new TimeCode(ts).ToShortString();
-
-    private static string FieldText(TimeSpan ts) => ts.TotalSeconds.ToString("0.000");
-
     private static SubtitleLineViewModel Line(double startMs, double endMs) =>
         new() { StartTime = TimeSpan.FromMilliseconds(startMs), EndTime = TimeSpan.FromMilliseconds(endMs) };
 
-    // The reported case: Show 00:11:22,700 and a typed duration of 0,820 must hide at ,520.
+    // The reported case: Show 00:11:22,700 and a typed duration of 0,820 must hide at ,520 -
+    // not ,519 - and the grid cell and the field must agree afterwards.
     [AvaloniaFact]
     public void TypingADurationEndsTheLineOnAWholeMillisecond()
     {
@@ -55,45 +56,8 @@ public class SubMillisecondTimeTests
         Assert.Equal(820, line.Duration.TotalMilliseconds);
         Assert.Equal(683_520, line.EndTime.TotalMilliseconds);
         Assert.Equal("00:11:23,520", new TimeCode(line.EndTime).ToDisplayString());
-        Assert.Equal("0,820", GridText(line.Duration));
+        Assert.Equal("0,820", new TimeCode(line.Duration).ToShortString());
         Assert.Equal("0,820", textBox.Text);
-    }
-
-    // The other reported case: a waveform drag lands the cues on fractional milliseconds, so the
-    // grid (truncating) and the duration up/down (rounding) disagreed by one millisecond.
-    [Theory]
-    [InlineData(589_780.6, 590_910.3)] // pixel-derived, as a waveform drag produces
-    [InlineData(682_700.0, 683_519.9999)] // tick-truncated, as TimeSpan.FromSeconds produces
-    [InlineData(1_000.4, 2_000.5)]
-    [InlineData(1_000.5, 2_000.6)]
-    public void TheGridAndTheDurationFieldNeverDisagree(double startMs, double endMs)
-    {
-        using var _ = new SettingsScope("General.UseFrameMode");
-        Se.Settings.General.UseFrameMode = false;
-
-        var line = Line(startMs, endMs);
-
-        Assert.Equal(0, line.StartTime.Ticks % TimeSpan.TicksPerMillisecond);
-        Assert.Equal(0, line.EndTime.Ticks % TimeSpan.TicksPerMillisecond);
-        Assert.Equal(0, line.Duration.Ticks % TimeSpan.TicksPerMillisecond);
-        Assert.Equal(GridText(line.Duration), FieldText(line.Duration));
-        Assert.Equal(line.EndTime - line.StartTime, line.Duration);
-    }
-
-    // Nudging Show must not leave the duration reading one value in the grid and another in the
-    // field - the reporter's follow-up test, which moved both cues but kept the bad span.
-    [AvaloniaFact]
-    public void MovingALineKeepsAWholeMillisecondDuration()
-    {
-        var line = Line(682_700, 683_520);
-
-        // A pixel-derived waveform drag, i.e. an arbitrary fraction of a millisecond.
-        line.SetStartTimeKeepDuration(TimeSpan.FromMilliseconds(682_700.6));
-
-        Assert.Equal(682_701, line.StartTime.TotalMilliseconds);
-        Assert.Equal(683_521, line.EndTime.TotalMilliseconds);
-        Assert.Equal(820, line.Duration.TotalMilliseconds);
-        Assert.Equal(GridText(line.Duration), FieldText(line.Duration));
     }
 
     [Theory]
@@ -104,32 +68,81 @@ public class SubMillisecondTimeTests
     [InlineData(0.0005, 1)]
     [InlineData(-0.0005, -1)]
     [InlineData(-1.13, -1130)]
-    public void SecondsAreSnappedToWholeMilliseconds(double seconds, double expectedMs)
+    public void SecondsAreRoundedToWholeMilliseconds(double seconds, double expectedMs)
     {
-        var snapped = TimeSpanExtensions.FromSecondsWholeMilliseconds(seconds);
-
-        Assert.Equal(expectedMs, snapped.TotalMilliseconds);
-        Assert.Equal(0, snapped.Ticks % TimeSpan.TicksPerMillisecond);
+        Assert.Equal(expectedMs, TimeSpanExtensions.FromSecondsWholeMilliseconds(seconds).TotalMilliseconds);
     }
 
-    // The extremes have no whole millisecond to round to - they must stay put, not wrap around.
+    // Out-of-range input is clamped to the time-code domain (±99:59:59,999) - still a whole
+    // millisecond a TimeCode can hold - and NaN throws like TimeSpan.FromSeconds always has:
+    // a NaN time is a bug at the call site and must not silently become 00:00:00,000.
     [Fact]
-    public void SnappingTheExtremesDoesNotWrapAround()
+    public void OutOfRangeIsClampedToTheTimeCodeDomainAndNaNThrows()
     {
-        Assert.Equal(TimeSpan.MaxValue, TimeSpan.MaxValue.SnapToWholeMilliseconds());
-        Assert.Equal(TimeSpan.MinValue, TimeSpan.MinValue.SnapToWholeMilliseconds());
-        Assert.Equal(TimeSpan.MaxValue, TimeSpanExtensions.FromSecondsWholeMilliseconds(double.MaxValue));
-        Assert.Equal(TimeSpan.MinValue, TimeSpanExtensions.FromSecondsWholeMilliseconds(double.MinValue));
-        Assert.Equal(TimeSpan.Zero, TimeSpanExtensions.FromSecondsWholeMilliseconds(double.NaN));
+        Assert.Equal(TimeCode.MaxTimeTotalMilliseconds,
+            TimeSpanExtensions.FromSecondsWholeMilliseconds(1e30).TotalMilliseconds);
+        Assert.Equal(-TimeCode.MaxTimeTotalMilliseconds,
+            TimeSpanExtensions.FromSecondsWholeMilliseconds(-1e30).TotalMilliseconds);
+        Assert.Throws<ArgumentException>(() => TimeSpanExtensions.FromSecondsWholeMilliseconds(double.NaN));
+    }
+
+    // Typing a huge duration must not corrupt the line: the parsed value is clamped to the
+    // time-code domain instead of TimeSpan.MaxValue, so StartTime + Duration cannot overflow.
+    [AvaloniaFact]
+    public void TypingAHugeDurationClampsInsteadOfOverflowing()
+    {
+        using var _ = new SettingsScope("General.UseFrameMode");
+        Se.Settings.General.UseFrameMode = false;
+
+        var line = Line(682_700, 683_200);
+
+        var upDown = new SecondsUpDown { DataContext = line };
+        upDown[!SecondsUpDown.ValueProperty] =
+            new Binding(nameof(SubtitleLineViewModel.Duration)) { Mode = BindingMode.TwoWay };
+        var window = new Window { Content = upDown };
+        window.Show();
+        var textBox = upDown.GetVisualDescendants().OfType<TextBox>().Single();
+
+        textBox.Focus();
+        textBox.Text = "1e30";
+        window.KeyPress(Key.Enter, RawInputModifiers.None, PhysicalKey.Enter, null);
+
+        Assert.Equal(TimeCode.MaxTimeTotalMilliseconds, line.Duration.TotalMilliseconds);
+        Assert.Equal(0, line.EndTime.Ticks % TimeSpan.TicksPerMillisecond);
+    }
+
+    // Scaling rounds via start + scaled duration, not start and end independently, so lines of
+    // equal length keep equal durations - independent rounding turned uniform 2000 ms lines into
+    // a mix of 1666 and 1667 ms, flipping duration/CPS warnings on some rows and not others.
+    [Fact]
+    public void ChangeFrameRateKeepsEqualDurationsEqual()
+    {
+        var subtitles = new ObservableCollection<SubtitleLineViewModel>();
+        for (var i = 0; i < 5; i++)
+        {
+            subtitles.Add(Line(1000 + i * 3100, 1000 + i * 3100 + 2000));
+        }
+
+        ChangeFrameRateViewModel.ChangeFrameRate(subtitles, 25.0, 30.0);
+
+        foreach (var line in subtitles)
+        {
+            Assert.Equal(0, line.StartTime.Ticks % TimeSpan.TicksPerMillisecond);
+            Assert.Equal(1667, line.Duration.TotalMilliseconds); // round(2000 * 25 / 30)
+        }
     }
 
     [Fact]
-    public void SnappingIsAlreadyWholeMillisecondsIdempotent()
+    public void AdjustKeepsEqualDurationsEqual()
     {
-        var whole = TimeSpan.FromMilliseconds(1130);
+        var early = Line(1000, 3000);
+        var late = Line(601_000, 603_000);
 
-        Assert.Equal(whole, whole.SnapToWholeMilliseconds());
-        Assert.Equal(TimeSpan.Zero, TimeSpan.Zero.SnapToWholeMilliseconds());
-        Assert.Equal(whole, TimeSpan.FromSeconds(1.13).SnapToWholeMilliseconds());
+        early.Adjust(25.0 / 30.0, 0);
+        late.Adjust(25.0 / 30.0, 0);
+
+        Assert.Equal(early.Duration, late.Duration);
+        Assert.Equal(1667, early.Duration.TotalMilliseconds);
+        Assert.Equal(0, late.StartTime.Ticks % TimeSpan.TicksPerMillisecond);
     }
 }

--- a/tests/UI/Features/Main/WaveformDragDurationBoxTests.cs
+++ b/tests/UI/Features/Main/WaveformDragDurationBoxTests.cs
@@ -1,0 +1,137 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Controls;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// Dragging a cue's end edge on the waveform must tick the edit box's Duration up/down live -
+/// with ShowUpDownEndTime off (the reporter's setup) the duration box is the only live readout
+/// of an end drag.
+/// </summary>
+public class WaveformDragDurationBoxTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+    private readonly bool _showEnd = Se.Settings.Appearance.ShowUpDownEndTime;
+    private readonly bool _showDuration = Se.Settings.Appearance.ShowUpDownDuration;
+    private readonly bool _frameMode = Se.Settings.General.UseFrameMode;
+    private readonly bool _snapFrames = Se.Settings.Waveform.SnapToFrames;
+    private readonly bool _snapCuts = Se.Settings.Waveform.SnapToShotChanges;
+    private readonly int _layout = Se.Settings.General.LayoutNumber;
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+        Se.Settings.Appearance.ShowUpDownEndTime = _showEnd;
+        Se.Settings.Appearance.ShowUpDownDuration = _showDuration;
+        Se.Settings.General.UseFrameMode = _frameMode;
+        Se.Settings.Waveform.SnapToFrames = _snapFrames;
+        Se.Settings.Waveform.SnapToShotChanges = _snapCuts;
+        Se.Settings.General.LayoutNumber = _layout;
+    }
+
+    private static WavePeakData2 MakePeaks(int sampleRate, int seconds)
+    {
+        var peaks = new WavePeak2[sampleRate * seconds];
+        for (var i = 0; i < peaks.Length; i++)
+        {
+            peaks[i] = new WavePeak2(8000, -8000);
+        }
+
+        return new WavePeakData2(sampleRate, peaks);
+    }
+
+    [AvaloniaFact]
+    public void DraggingTheEndEdgeTicksTheDurationBox()
+    {
+        // The reporter's setup: layout 1, ms mode, Start + Duration up/downs but no End box.
+        Se.Settings.General.LayoutNumber = 1;
+        Se.Settings.General.UseFrameMode = false;
+        Se.Settings.Appearance.ShowUpDownEndTime = false;
+        Se.Settings.Appearance.ShowUpDownDuration = true;
+        Se.Settings.Waveform.SnapToFrames = false;
+        Se.Settings.Waveform.SnapToShotChanges = true; // on, like the reporter; no shot-change list loaded
+
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1400, Height = 900 };
+        _windows.Add(window);
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var vm = (MainViewModel)view.DataContext!;
+        window.SuppressSaveChangesPromptOnClose(vm);
+
+        for (var i = 0; i < 3; i++)
+        {
+            vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph($"Line {i + 1}", i * 5000 + 1000, i * 5000 + 3000), null!)
+            {
+                Number = i + 1,
+            });
+        }
+
+        vm.SelectedSubtitle = vm.Subtitles[0];
+        var av = vm.AudioVisualizer;
+        av.WavePeaks = MakePeaks(126, 60);
+        av.SetPosition(0, vm.Subtitles, 0, 0, new List<SubtitleLineViewModel> { vm.Subtitles[0] });
+        Settle(window);
+
+        var line = vm.Subtitles[0]; // 1000..3000 ms
+        Assert.Same(line, av.SelectedParagraph);
+
+        var durationBox = window.GetVisualDescendants().OfType<SecondsUpDown>()
+            .Single(c => c.IsEffectivelyVisible);
+        var durationText = durationBox.GetVisualDescendants().OfType<TextBox>().Single();
+        Assert.Equal("2.000", durationText.Text!.Replace(',', '.'));
+
+        // The waveform's own coordinate frame: end edge of 3 s at zoom 1 with 126 px/s.
+        var origin = av.TranslatePoint(new Point(0, 0), window)!.Value;
+        var y = origin.Y + av.Bounds.Height / 2;
+        var endEdgeX = origin.X + 3.0 * 126;
+
+        window.MouseDown(new Point(endEdgeX, y), MouseButton.Left, RawInputModifiers.None);
+        window.MouseMove(new Point(endEdgeX + 126, y), RawInputModifiers.None);
+        Settle(window);
+
+        // Mid-drag: the line's end moved a second; the duration box must show it.
+        Assert.Equal(4000, line.EndTime.TotalMilliseconds);
+        Assert.Equal(3000, line.Duration.TotalMilliseconds);
+        Assert.Equal("3.000", durationText.Text!.Replace(',', '.'));
+
+        window.MouseUp(new Point(endEdgeX + 126, y), MouseButton.Left, RawInputModifiers.None);
+        Settle(window);
+        Assert.Equal("3.000", durationText.Text!.Replace(',', '.'));
+    }
+
+    private static void Settle(Window window)
+    {
+        for (var pump = 0; pump < 8; pump++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+        }
+    }
+}

--- a/tests/UI/Features/Shared/BinaryEdit/BinaryEditViewModelTests.cs
+++ b/tests/UI/Features/Shared/BinaryEdit/BinaryEditViewModelTests.cs
@@ -88,8 +88,9 @@ public class BinaryEditViewModelTests
 
         BinaryEditViewModel.ScaleBinarySubtitleTimes([item], factor);
 
-        Assert.Equal(9090.909, item.StartTime.TotalMilliseconds, 3);
-        Assert.Equal(9272.727, item.EndTime.TotalMilliseconds, 3);
+        // Scaled times are rounded to the whole millisecond subtitle formats store (#14056).
+        Assert.Equal(9091, item.StartTime.TotalMilliseconds); // round(10000 * 100/110)
+        Assert.Equal(9273, item.EndTime.TotalMilliseconds);   // round(10200 * 100/110)
         Assert.True(item.Duration > TimeSpan.Zero);
     }
 }

--- a/tests/UI/Features/Sync/ChangeFrameRate/ChangeFrameRateViewModelTests.cs
+++ b/tests/UI/Features/Sync/ChangeFrameRate/ChangeFrameRateViewModelTests.cs
@@ -42,10 +42,12 @@ public class ChangeFrameRateViewModelTests
 
         ChangeFrameRateViewModel.ChangeFrameRate(subtitles, 25.0, 30.0);
 
+        // Scaled times land on whole milliseconds - the only resolution subtitle formats have,
+        // and the one the grid stores since #14056.
         var ratio = 25.0 / 30.0;
-        Assert.Equal(1000.0 * ratio, subtitles[0].StartTime.TotalMilliseconds, 3);
-        Assert.Equal(3000.0 * ratio, subtitles[0].EndTime.TotalMilliseconds, 3);
-        Assert.Equal(6000.0 * ratio, subtitles[1].StartTime.TotalMilliseconds, 3);
-        Assert.Equal(9000.0 * ratio, subtitles[1].EndTime.TotalMilliseconds, 3);
+        Assert.Equal(1000.0 * ratio, subtitles[0].StartTime.TotalMilliseconds, 0);
+        Assert.Equal(3000.0 * ratio, subtitles[0].EndTime.TotalMilliseconds, 0);
+        Assert.Equal(6000.0 * ratio, subtitles[1].StartTime.TotalMilliseconds, 0);
+        Assert.Equal(9000.0 * ratio, subtitles[1].EndTime.TotalMilliseconds, 0);
     }
 }

--- a/tests/UI/Features/Sync/ChangeFrameRate/ChangeFrameRateViewModelTests.cs
+++ b/tests/UI/Features/Sync/ChangeFrameRate/ChangeFrameRateViewModelTests.cs
@@ -42,12 +42,11 @@ public class ChangeFrameRateViewModelTests
 
         ChangeFrameRateViewModel.ChangeFrameRate(subtitles, 25.0, 30.0);
 
-        // Scaled times land on whole milliseconds - the only resolution subtitle formats have,
-        // and the one the grid stores since #14056.
-        var ratio = 25.0 / 30.0;
-        Assert.Equal(1000.0 * ratio, subtitles[0].StartTime.TotalMilliseconds, 0);
-        Assert.Equal(3000.0 * ratio, subtitles[0].EndTime.TotalMilliseconds, 0);
-        Assert.Equal(6000.0 * ratio, subtitles[1].StartTime.TotalMilliseconds, 0);
-        Assert.Equal(9000.0 * ratio, subtitles[1].EndTime.TotalMilliseconds, 0);
+        // Scaled times land on whole milliseconds - the only resolution subtitle formats
+        // have - rounded as start + scaled duration so equal lengths stay equal (#14056).
+        Assert.Equal(833, subtitles[0].StartTime.TotalMilliseconds);  // round(1000 * 25/30)
+        Assert.Equal(2500, subtitles[0].EndTime.TotalMilliseconds);   // 833 + round(2000 * 25/30)
+        Assert.Equal(5000, subtitles[1].StartTime.TotalMilliseconds); // round(6000 * 25/30)
+        Assert.Equal(7500, subtitles[1].EndTime.TotalMilliseconds);   // 5000 + round(3000 * 25/30)
     }
 }


### PR DESCRIPTION
Fixes #14056.

### What went wrong

Since .NET Core 3.0, `TimeSpan.FromSeconds`/`FromMilliseconds` **truncate** to ticks instead of rounding to whole milliseconds the way .NET Framework did:

```
TimeSpan.FromSeconds(0.82) → 8_199_999 ticks = 819.9999 ms   (not 820)
TimeSpan.FromSeconds(1.13) → 11_299_999 ticks = 1129.9999 ms (not 1130)
```

Once a time carries a fractional millisecond, the two display paths disagree, because one truncates and the other rounds:

| Path | 819.9999 ms shows as |
|---|---|
| Grid Duration cell (`TimeCode.ToShortString` → `ts.Milliseconds`, **truncates** — same as every format writer) | `0,819` |
| Duration up/down (`ts.TotalSeconds.ToString("0.000")`, **rounds**) | `0,820` |

It is not only a display split — the end time really is a millisecond early, and saving writes it that way. Typing a duration of `0,820` at Show `00:11:22,700` hid the line at `00:11:23,519`, exactly as reported. The reporter's other case comes from pixel-derived waveform drags and video positions, which land on arbitrary fractions of a millisecond.

### The fix: round at the producers

Subtitle formats have no sub-millisecond resolution, so every place that turns a fractional double into a subtitle time rounds to a whole millisecond through one helper (`TimeSpanExtensions.FromSeconds/FromMillisecondsWholeMilliseconds`). The view model stores exactly what it is given — no setter coercion (an earlier revision coerced in the property setters; review showed the mechanism regressed notification ordering, allocations on the drag hot path, and overflow handling, so it was dropped in favor of fixing the producers).

- `SecondsUpDown.ParseTime` — typed durations parse to whole ms, so what you type is what you get
- Every pixel-derived assignment in the `AudioVisualizer` drag handling; whole-line/selection moves also switched to `SetTimes` so both ends apply atomically and a move can't round the line's length up or down
- The `vp.Position`, frame-alignment, CPS-derived, shot-change, and distribute-by-text-length sites in `MainViewModel`
- `Adjust` and `ChangeFrameRate` round via start + scaled duration, not start and end independently — lines of equal length keep equal durations after a sync or frame-rate change
- `ShotChangesHelper.GetSnappedToNearestMs` rounds its output, reviving its exact-equality no-op guard (re-running the snap command on already-snapped lines is a no-op again)
- Binary edit's `ScaleBinarySubtitleTimes` and the Blu-ray 90 kHz PTS conversion, which had the same grid-vs-field mismatch

The helper clamps out-of-range input to the time-code domain (±99:59:59,999) and throws on NaN, so a bad value fails loudly instead of silently corrupting a cue.

### Trade-offs worth knowing

- A future producer that forgets the helper can reintroduce a sub-ms residue; the helper's doc comment and the regression tests are the paved path.
- Formats that genuinely store sub-millisecond times (e.g. Audacity labels) keep their precision on load — this PR only rounds values created by editing.

### Tests

`tests/UI/Features/Main/SubMillisecondTimeTests.cs` reproduces the reported case (typed `0,820` at `00:11:22,700` → Hide `,520`, grid and field agree), pins the clamp/NaN behavior, and pins duration consistency across `Adjust`/`ChangeFrameRate`. Assertions elsewhere that were previously loosened are now exact whole-millisecond assertions.

Full suites pass: UI 3579, libse 1465, libuilogic 542, seconv 383.

🤖 Generated with [Claude Code](https://claude.com/claude-code)