### PR TITLE
Add Apple Vision OCR on macOS, and require macOS 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can find the latest cross-platform builds here:
 
 ### macOS
 
-- **Minimum macOS version**: 12 (Monterey) or newer
+- **Minimum macOS version**: 14 (Sonoma) or newer - the oldest macOS that .NET 10 is supported on
 - The `.dmg` is self-contained: `libmpv` and `ffmpeg` are bundled inside `Subtitle Edit.app`, so no MacPorts or Homebrew install is required.
 
 #### Installing Subtitle Edit on macOS

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -12,7 +12,7 @@ Yes. Subtitle Edit is released under the MIT license. It is completely free with
 Subtitle Edit 5 is built with Avalonia UI and runs on:
 - Windows 10 (version 22H2 / build 19045) and later
 - Linux (native packages or Flatpak)
-- macOS 12 (Monterey) or later, on both Apple Silicon (arm64) and Intel (x64)
+- macOS 14 (Sonoma) or later, on both Apple Silicon (arm64) and Intel (x64)
 
 ### Where is my data stored?
 Subtitle Edit stores settings and data in a platform-specific data folder. You can open it with the keyboard shortcut `Ctrl+Alt+Shift+D` (Windows/Linux) or `Cmd+Alt+Shift+D` (macOS).

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -25,7 +25,7 @@ Subtitle Edit is a free, open-source editor for video subtitles. It allows you t
 
 ## System Requirements
 
-- Windows 10 (version 22H2 / build 19045) or newer, Linux, or macOS 12 (Monterey) or newer
+- Windows 10 (version 22H2 / build 19045) or newer, Linux, or macOS 14 (Sonoma) or newer
 - [FFmpeg](https://ffmpeg.org/) (for audio/video processing)
 - [libmpv](https://mpv.io/) for video playback
 

--- a/installer/macBundle/SubtitleEdit.app/Contents/Info.plist
+++ b/installer/macBundle/SubtitleEdit.app/Contents/Info.plist
@@ -20,13 +20,18 @@
     <string>SBED</string>
     <key>CFBundleIconFile</key>
     <string>SE.icns</string>
-    <!-- The .NET runtime we ship is built against macOS 12, so the app cannot load
-         below it no matter what this key says - it was 10.15 for years, which only
-         meant Catalina users got a crash instead of Finder's "requires a newer
-         version of macOS". Re-derive after a TFM bump with:
+    <!-- macOS 14 (Sonoma) is the oldest release .NET 10 is supported on: Microsoft
+         tracks Apple's own three-release window, so .NET 10 lists macOS 14, 15 and 26.
+         This is deliberately stricter than the technical floor - the shipped runtime is
+         built against macOS 12 (LC_BUILD_VERSION minos 12.0 in libcoreclr.dylib) and so
+         would load on 12 and 13, but those are untested by the runtime we depend on.
+         Declaring 14 gets Finder's "requires a newer version of macOS" instead of an
+         unsupported configuration failing later in unclear ways. Keep this in step with
+         the requirements in README.md, docs/overview.md and docs/faq.md.
+         The technical floor can be re-derived after a TFM bump with:
            otool -l .../shared/Microsoft.NETCore.App/<ver>/libcoreclr.dylib | grep -A3 LC_BUILD_VERSION -->
     <key>LSMinimumSystemVersion</key>
-    <string>12.0</string>
+    <string>14.0</string>
     <key>NSHighResolutionCapable</key>
     <true/>
     <key>NSSupportsAutomaticGraphicsSwitching</key>

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -3378,6 +3378,7 @@
     "llamaCppDownloadModelPrompt": "llama.cpp requires the selected OCR model to be downloaded. Download now?",
     "crispEmbedNotDownloaded": "CrispEmbed engine/model not downloaded - download via batch convert settings",
     "crispEmbedReturnedNoText": "CrispEmbed returned no text - check the model",
+    "appleVisionReturnedNoText": "Apple Vision returned no text - check the language",
     "crispEmbedSettingsTitle": "CrispEmbed settings",
     "crispEmbedDescription": "Local OCR engine with multiple model backends - download the engine and the models here.",
     "trainNOcrDatabase": "Train nOCR database...",

--- a/src/ui/Features/Ocr/Engines/AppleVisionOcr.cs
+++ b/src/ui/Features/Ocr/Engines/AppleVisionOcr.cs
@@ -242,12 +242,16 @@ public static class AppleVisionOcr
     /// <returns>The recognized text, or an empty string when Vision found none.</returns>
     public static string Ocr(SKBitmap? bitmap, string? languageCode, bool fast, CancellationToken cancellationToken)
     {
+        // Cancellation first: a caller that has already cancelled wants to hear about it whatever
+        // the state of the engine, and checking it after the availability gate made the method
+        // behave differently by platform - off macOS it returned empty for a cancelled token
+        // instead of throwing.
+        cancellationToken.ThrowIfCancellationRequested();
+
         if (bitmap == null || bitmap.Width < 1 || bitmap.Height < 1 || !IsAvailable())
         {
             return string.Empty;
         }
-
-        cancellationToken.ThrowIfCancellationRequested();
 
         var png = EncodePng(bitmap);
         if (png == null || png.Length == 0)

--- a/src/ui/Features/Ocr/Engines/AppleVisionOcr.cs
+++ b/src/ui/Features/Ocr/Engines/AppleVisionOcr.cs
@@ -1,0 +1,418 @@
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace Nikse.SubtitleEdit.Features.Ocr.Engines;
+
+/// <summary>
+/// OCR through Apple's Vision framework (VNRecognizeTextRequest) - the same recognizer Preview
+/// and Live Text use.
+///
+/// It is the only local OCR engine on macOS that needs no download at all: no runtime, no model,
+/// no Homebrew, no Python. That matters most on Intel Macs, where CrispEmbed has no build and
+/// the remaining local options are Tesseract (brew) and PaddleOCR (pip) - see
+/// <see cref="CrispEmbedEngine.CanBeDownloaded"/>.
+///
+/// Driven through objc_msgSend rather than a binding library, the same way
+/// <see cref="Main.Layout.MacWindowsMenuInterop"/> drives AppKit. Vision is not linked into the
+/// process, so the framework is dlopen'd on first use; every entry point below is defensive and
+/// reports "unavailable" rather than throwing, so a macOS that ever lacks the framework simply
+/// does not offer the engine.
+/// </summary>
+public static class AppleVisionOcr
+{
+    public const string StaticName = "Apple Vision";
+
+    private const string LibObjC = "/usr/lib/libobjc.A.dylib";
+    private const string LibSystem = "/usr/lib/libSystem.dylib";
+    private const string VisionFramework = "/System/Library/Frameworks/Vision.framework/Vision";
+
+    // VNRequestTextRecognitionLevel
+    private const long RecognitionLevelAccurate = 0;
+    private const long RecognitionLevelFast = 1;
+
+    [DllImport(LibSystem)]
+    private static extern IntPtr dlopen(string path, int mode);
+
+    [DllImport(LibObjC)]
+    private static extern IntPtr objc_getClass(string name);
+
+    [DllImport(LibObjC)]
+    private static extern IntPtr sel_registerName(string name);
+
+    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static extern IntPtr SendPtr(IntPtr receiver, IntPtr sel);
+
+    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static extern IntPtr SendPtrPtr(IntPtr receiver, IntPtr sel, IntPtr a);
+
+    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static extern IntPtr SendPtrPtrPtr(IntPtr receiver, IntPtr sel, IntPtr a, IntPtr b);
+
+    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static extern IntPtr SendPtrBytesLong(IntPtr receiver, IntPtr sel, byte[] bytes, long length);
+
+    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static extern IntPtr SendPtrUtf8(IntPtr receiver, IntPtr sel, string a);
+
+    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static extern IntPtr SendPtrLong(IntPtr receiver, IntPtr sel, long a);
+
+    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static extern long SendLong(IntPtr receiver, IntPtr sel);
+
+    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static extern void SendVoid(IntPtr receiver, IntPtr sel);
+
+    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static extern void SendVoidLong(IntPtr receiver, IntPtr sel, long a);
+
+    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static extern void SendVoidBool(IntPtr receiver, IntPtr sel, byte a);
+
+    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static extern void SendVoidPtr(IntPtr receiver, IntPtr sel, IntPtr a);
+
+    /// <summary>
+    /// CGPoint. Read the corners rather than <c>boundingBox</c> on purpose: a CGRect is four
+    /// doubles, and on x86_64 a struct that size comes back through the hidden-pointer
+    /// objc_msgSend_stret path while arm64 returns it in registers - two different calls to get
+    /// right, one of which cannot be exercised on an Apple Silicon dev machine. A CGPoint is two
+    /// doubles, which both architectures return in registers, so the corners need one code path.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    private struct CGPoint
+    {
+        public double X;
+        public double Y;
+    }
+
+    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static extern CGPoint SendPoint(IntPtr receiver, IntPtr sel);
+
+    private static readonly object AvailabilityLock = new();
+    private static bool _availabilityChecked;
+    private static bool _isAvailable;
+    private static List<OcrLanguage2>? _languages;
+
+    /// <summary>
+    /// True when this process can actually run a Vision text request. Checked once and cached:
+    /// the answer cannot change while SE runs, and <see cref="OcrEngineItem.GetOcrEngines"/>
+    /// asks on every OCR window.
+    /// </summary>
+    public static bool IsAvailable()
+    {
+        if (!OperatingSystem.IsMacOS())
+        {
+            return false;
+        }
+
+        lock (AvailabilityLock)
+        {
+            if (_availabilityChecked)
+            {
+                return _isAvailable;
+            }
+
+            _availabilityChecked = true;
+            try
+            {
+                // RTLD_LAZY. Vision is not linked into the app, so without this the runtime
+                // classes below are simply not registered and objc_getClass returns nil.
+                _isAvailable = dlopen(VisionFramework, 1) != IntPtr.Zero &&
+                               objc_getClass("VNRecognizeTextRequest") != IntPtr.Zero &&
+                               objc_getClass("VNImageRequestHandler") != IntPtr.Zero;
+            }
+            catch
+            {
+                _isAvailable = false;
+            }
+
+            return _isAvailable;
+        }
+    }
+
+    /// <summary>
+    /// The languages this machine's Vision can recognize, straight from the framework rather
+    /// than a hard-coded list: the set grows with macOS releases, and the recognizer rejects a
+    /// language it does not know.
+    /// </summary>
+    public static List<OcrLanguage2> GetLanguages()
+    {
+        lock (AvailabilityLock)
+        {
+            if (_languages != null)
+            {
+                return _languages;
+            }
+
+            _languages = ReadSupportedLanguages();
+            return _languages;
+        }
+    }
+
+    private static List<OcrLanguage2> ReadSupportedLanguages()
+    {
+        var list = new List<OcrLanguage2>();
+        if (!IsAvailable())
+        {
+            return list;
+        }
+
+        var pool = NewAutoreleasePool();
+        var request = IntPtr.Zero;
+        try
+        {
+            request = NewRequest();
+            if (request == IntPtr.Zero)
+            {
+                return list;
+            }
+
+            var supported = SendPtrPtr(request, Sel("supportedRecognitionLanguagesAndReturnError:"), IntPtr.Zero);
+            if (supported == IntPtr.Zero)
+            {
+                return list;
+            }
+
+            var count = SendLong(supported, Sel("count"));
+            for (long i = 0; i < count; i++)
+            {
+                var code = NsToString(SendPtrLong(supported, Sel("objectAtIndex:"), i));
+                if (!string.IsNullOrEmpty(code))
+                {
+                    list.Add(new OcrLanguage2(code!, DisplayName(code!)));
+                }
+            }
+        }
+        catch
+        {
+            // A machine that cannot list languages cannot recognize text either; the empty
+            // list leaves the engine selectable but with nothing to choose, which the caller
+            // reports better than an exception out of a property getter would.
+        }
+        finally
+        {
+            Release(request);
+            DrainAutoreleasePool(pool);
+        }
+
+        return list;
+    }
+
+    /// <summary>
+    /// Turns Vision's BCP-47 tag ("pt-BR", "zh-Hans") into something readable. .NET's own
+    /// culture data already knows these, and falls back to the tag itself for the ones it does
+    /// not - which is still better than showing nothing.
+    /// </summary>
+    private static string DisplayName(string code)
+    {
+        try
+        {
+            var culture = CultureInfo.GetCultureInfo(code);
+            if (!string.IsNullOrWhiteSpace(culture.EnglishName) && !culture.EnglishName.StartsWith("Unknown", StringComparison.OrdinalIgnoreCase))
+            {
+                return $"{culture.EnglishName} ({code})";
+            }
+        }
+        catch (CultureNotFoundException)
+        {
+            // fall through to the raw tag
+        }
+
+        return code;
+    }
+
+    /// <summary>
+    /// Recognizes the text in one subtitle image.
+    /// </summary>
+    /// <param name="bitmap">The subtitle image. A transparent background is fine - Vision reads
+    /// these as well as it reads the same text on black, so SE's images go in untouched.</param>
+    /// <param name="languageCode">A tag from <see cref="GetLanguages"/>. Empty means "let Vision
+    /// pick", which is its own default.</param>
+    /// <param name="fast">Vision's fast recognition level instead of the accurate one. Roughly an
+    /// order of magnitude quicker and noticeably worse on the small, soft text subtitles are made
+    /// of, so the accurate level is the default.</param>
+    /// <param name="cancellationToken">Checked before the request starts; a Vision request on one
+    /// subtitle image is short enough that it is not worth interrupting once running.</param>
+    /// <returns>The recognized text, or an empty string when Vision found none.</returns>
+    public static string Ocr(SKBitmap? bitmap, string? languageCode, bool fast, CancellationToken cancellationToken)
+    {
+        if (bitmap == null || bitmap.Width < 1 || bitmap.Height < 1 || !IsAvailable())
+        {
+            return string.Empty;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var png = EncodePng(bitmap);
+        if (png == null || png.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        // Every NSString / NSArray / NSData below is autoreleased. Nothing drains the thread's
+        // pool for us on a .NET worker thread, so without an explicit pool a batch of a few
+        // thousand subtitle images would hold every intermediate object until the process ends.
+        var pool = NewAutoreleasePool();
+        var request = IntPtr.Zero;
+        var handler = IntPtr.Zero;
+        try
+        {
+            request = NewRequest();
+            if (request == IntPtr.Zero)
+            {
+                return string.Empty;
+            }
+
+            SendVoidLong(request, Sel("setRecognitionLevel:"), fast ? RecognitionLevelFast : RecognitionLevelAccurate);
+            SendVoidBool(request, Sel("setUsesLanguageCorrection:"), 1);
+
+            if (!string.IsNullOrEmpty(languageCode))
+            {
+                var languages = SendPtrPtr(Cls("NSArray"), Sel("arrayWithObject:"), NsString(languageCode!));
+                if (languages != IntPtr.Zero)
+                {
+                    SendVoidPtr(request, Sel("setRecognitionLanguages:"), languages);
+                }
+            }
+
+            var data = SendPtrBytesLong(Cls("NSData"), Sel("dataWithBytes:length:"), png, png.Length);
+            if (data == IntPtr.Zero)
+            {
+                return string.Empty;
+            }
+
+            handler = SendPtrPtrPtr(SendPtr(Cls("VNImageRequestHandler"), Sel("alloc")),
+                Sel("initWithData:options:"), data, IntPtr.Zero);
+            if (handler == IntPtr.Zero)
+            {
+                return string.Empty;
+            }
+
+            var requests = SendPtrPtr(Cls("NSArray"), Sel("arrayWithObject:"), request);
+            SendPtrPtrPtr(handler, Sel("performRequests:error:"), requests, IntPtr.Zero);
+
+            return AppleVisionTextLayout.Compose(ReadObservations(request));
+        }
+        catch
+        {
+            // One unreadable image must not stop a run of thousands: an empty result reads as
+            // "nothing recognized here", which is what the caller already handles.
+            return string.Empty;
+        }
+        finally
+        {
+            Release(handler);
+            Release(request);
+            DrainAutoreleasePool(pool);
+        }
+    }
+
+    private static IEnumerable<AppleVisionObservation> ReadObservations(IntPtr request)
+    {
+        var results = SendPtr(request, Sel("results"));
+        if (results == IntPtr.Zero)
+        {
+            yield break;
+        }
+
+        var count = SendLong(results, Sel("count"));
+        for (long i = 0; i < count; i++)
+        {
+            var observation = SendPtrLong(results, Sel("objectAtIndex:"), i);
+            if (observation == IntPtr.Zero)
+            {
+                continue;
+            }
+
+            // topCandidates: returns the recognizer's ranked readings; one is enough, and asking
+            // for more makes Vision do extra work per observation.
+            var candidates = SendPtrLong(observation, Sel("topCandidates:"), 1);
+            if (candidates == IntPtr.Zero || SendLong(candidates, Sel("count")) < 1)
+            {
+                continue;
+            }
+
+            var top = SendPtrLong(candidates, Sel("objectAtIndex:"), 0);
+            var text = NsToString(SendPtr(top, Sel("string")));
+            if (string.IsNullOrEmpty(text))
+            {
+                continue;
+            }
+
+            var topLeft = SendPoint(observation, Sel("topLeft"));
+            var bottomRight = SendPoint(observation, Sel("bottomRight"));
+
+            yield return new AppleVisionObservation(text!, topLeft.X, bottomRight.X, topLeft.Y, bottomRight.Y);
+        }
+    }
+
+    private static byte[]? EncodePng(SKBitmap bitmap)
+    {
+        try
+        {
+            using var image = SKImage.FromBitmap(bitmap);
+            using var data = image?.Encode(SKEncodedImageFormat.Png, 100);
+            return data?.ToArray();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static IntPtr NewRequest()
+    {
+        var requestClass = Cls("VNRecognizeTextRequest");
+        return requestClass == IntPtr.Zero
+            ? IntPtr.Zero
+            : SendPtr(SendPtr(requestClass, Sel("alloc")), Sel("init"));
+    }
+
+    private static IntPtr NewAutoreleasePool()
+    {
+        var poolClass = Cls("NSAutoreleasePool");
+        return poolClass == IntPtr.Zero
+            ? IntPtr.Zero
+            : SendPtr(SendPtr(poolClass, Sel("alloc")), Sel("init"));
+    }
+
+    private static void DrainAutoreleasePool(IntPtr pool)
+    {
+        if (pool != IntPtr.Zero)
+        {
+            SendVoid(pool, Sel("drain"));
+        }
+    }
+
+    private static void Release(IntPtr obj)
+    {
+        if (obj != IntPtr.Zero)
+        {
+            SendVoid(obj, Sel("release"));
+        }
+    }
+
+    private static IntPtr Cls(string name) => objc_getClass(name);
+
+    private static IntPtr Sel(string name) => sel_registerName(name);
+
+    private static IntPtr NsString(string value) =>
+        SendPtrUtf8(Cls("NSString"), Sel("stringWithUTF8String:"), value);
+
+    private static string? NsToString(IntPtr nsString)
+    {
+        if (nsString == IntPtr.Zero)
+        {
+            return null;
+        }
+
+        var utf8 = SendPtr(nsString, Sel("UTF8String"));
+        return utf8 == IntPtr.Zero ? null : Marshal.PtrToStringUTF8(utf8);
+    }
+}

--- a/src/ui/Features/Ocr/Engines/AppleVisionTextLayout.cs
+++ b/src/ui/Features/Ocr/Engines/AppleVisionTextLayout.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Nikse.SubtitleEdit.Features.Ocr.Engines;
+
+/// <summary>
+/// One recognized piece of text and where Vision found it.
+/// </summary>
+/// <remarks>
+/// The coordinates are Vision's own: normalized to 0-1 of the image, with the origin at the
+/// <em>bottom</em> left, so a larger Y is higher up the image. Kept in Vision's system rather
+/// than flipped at the interop boundary, so the numbers here can be compared against what the
+/// framework prints while debugging.
+/// </remarks>
+public readonly struct AppleVisionObservation
+{
+    public string Text { get; }
+    public double Left { get; }
+    public double Right { get; }
+    public double Top { get; }
+    public double Bottom { get; }
+
+    public AppleVisionObservation(string text, double left, double right, double top, double bottom)
+    {
+        Text = text;
+        Left = left;
+        Right = right;
+        Top = top;
+        Bottom = bottom;
+    }
+
+    internal double CenterY => (Top + Bottom) / 2;
+    internal double Height => Math.Abs(Top - Bottom);
+}
+
+/// <summary>
+/// Turns Vision's observations into subtitle text.
+///
+/// Vision returns a flat, unordered set of observations, and it splits one visual line into
+/// several of them wherever the gap between words is wide - which is exactly what a two-speaker
+/// dialogue line ("- Yes.        - No.") looks like. Reading the list in the order it arrives
+/// would scramble such a line, and a naive "one observation per line" rule would break it in
+/// two. So the observations are grouped back into visual lines by their vertical position, then
+/// read left to right within each line.
+/// </summary>
+public static class AppleVisionTextLayout
+{
+    /// <summary>
+    /// Two observations belong to the same visual line when their vertical centres are closer
+    /// than this fraction of the shorter one's height. Half a line height is comfortably below
+    /// the spacing of even tightly set subtitles, and comfortably above the wobble Vision leaves
+    /// on parts of the same line.
+    /// </summary>
+    private const double SameLineToleranceOfHeight = 0.5;
+
+    public static string Compose(IEnumerable<AppleVisionObservation> observations)
+    {
+        if (observations == null)
+        {
+            return string.Empty;
+        }
+
+        var ordered = observations
+            .Where(o => !string.IsNullOrWhiteSpace(o.Text))
+            .OrderByDescending(o => o.CenterY) // Vision's Y grows upwards, so this is top-first.
+            .ToList();
+
+        if (ordered.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder();
+        var line = new List<AppleVisionObservation>();
+
+        foreach (var observation in ordered)
+        {
+            if (line.Count > 0 && !BelongsToLine(line, observation))
+            {
+                AppendLine(sb, line);
+                line.Clear();
+            }
+
+            line.Add(observation);
+        }
+
+        AppendLine(sb, line);
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Compared against the line's lowest member rather than its first: on a line Vision split
+    /// into several observations the pieces drift slightly, and measuring from the piece nearest
+    /// the candidate keeps a long line from splitting halfway along.
+    /// </summary>
+    private static bool BelongsToLine(List<AppleVisionObservation> line, AppleVisionObservation candidate)
+    {
+        var nearest = line.MinBy(o => Math.Abs(o.CenterY - candidate.CenterY));
+        var height = Math.Min(nearest.Height, candidate.Height);
+        if (height <= 0)
+        {
+            return false;
+        }
+
+        return Math.Abs(nearest.CenterY - candidate.CenterY) < height * SameLineToleranceOfHeight;
+    }
+
+    private static void AppendLine(StringBuilder sb, List<AppleVisionObservation> line)
+    {
+        if (line.Count == 0)
+        {
+            return;
+        }
+
+        if (sb.Length > 0)
+        {
+            sb.Append(Environment.NewLine);
+        }
+
+        sb.Append(string.Join(" ", line.OrderBy(o => o.Left).Select(o => o.Text.Trim())));
+    }
+}

--- a/src/ui/Features/Ocr/Engines/OcrEngineItem.cs
+++ b/src/ui/Features/Ocr/Engines/OcrEngineItem.cs
@@ -43,6 +43,14 @@ public class OcrEngineItem
         list.Add(new("Ollama", OcrEngineType.Ollama, "Ollama e.g. via llama-vision", "", "http://localhost:11434/api/chat"));
         list.Add(new("llama.cpp", OcrEngineType.LlamaCpp, "llama.cpp", "", "http://127.0.0.1:8080/v1/chat/completions"));
 
+        // Apple Vision sits with the other local engines, above the cloud ones: on macOS it is
+        // the only engine that needs no download, no runtime and no key, and on an Intel Mac it
+        // is the only local engine SE can offer without sending the user to Homebrew or pip.
+        if (AppleVisionOcr.IsAvailable())
+        {
+            list.Add(new(AppleVisionOcr.StaticName, OcrEngineType.AppleVision, "Apple Vision is macOS's built-in OCR engine (no download needed)", "", ""));
+        }
+
         if (CrispEmbedEngine.CanBeDownloaded())
         {
             list.Add(new(CrispEmbedEngine.StaticName, OcrEngineType.CrispEmbed, "CrispEmbed is a local OCR engine with multiple model backends (free/open source)", "", ""));

--- a/src/ui/Features/Ocr/Engines/OcrEngineType.cs
+++ b/src/ui/Features/Ocr/Engines/OcrEngineType.cs
@@ -17,4 +17,5 @@ public enum OcrEngineType
     BinaryImageCompare,
     Glm,
     CrispEmbed,
+    AppleVision,
 }

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -114,6 +114,7 @@ public partial class OcrViewModel : ObservableObject
     [ObservableProperty] private bool _isTesseractVisible;
     [ObservableProperty] private bool _isBinaryImageCompareVisible;
     [ObservableProperty] private bool _isPaddleOcrVisible;
+    [ObservableProperty] private bool _isAppleVisionVisible;
     [ObservableProperty] private bool _isGoogleVisionVisible;
     [ObservableProperty] private bool _isGoogleLensVisible;
     [ObservableProperty] private bool _isMistralOcrVisible;
@@ -126,6 +127,8 @@ public partial class OcrViewModel : ObservableObject
     [ObservableProperty] private string _mistralApiKey;
     [ObservableProperty] private ObservableCollection<OcrLanguage> _googleVisionLanguages;
     [ObservableProperty] private OcrLanguage? _selectedGoogleVisionLanguage;
+    [ObservableProperty] private ObservableCollection<OcrLanguage2> _appleVisionLanguages;
+    [ObservableProperty] private OcrLanguage2? _selectedAppleVisionLanguage;
     [ObservableProperty] private ObservableCollection<OcrLanguage2> _googleLensLanguages;
     [ObservableProperty] private OcrLanguage2 _selectedGoogleLensLanguage;
     [ObservableProperty] private ObservableCollection<OcrLanguage2> _paddleOcrLanguages;
@@ -258,6 +261,7 @@ public partial class OcrViewModel : ObservableObject
         GoogleVisionApiKey = string.Empty;
         MistralApiKey = string.Empty;
         GoogleVisionLanguages = new ObservableCollection<OcrLanguage>(GoogleVisionOcr.GetLanguages().OrderBy(p => p.ToString()));
+        AppleVisionLanguages = new ObservableCollection<OcrLanguage2>(AppleVisionOcr.GetLanguages().OrderBy(p => p.ToString()));
         GoogleLensLanguages = new ObservableCollection<OcrLanguage2>(GoogleLensOcr.GetLanguages().OrderBy(p => p.ToString()));
         SelectedGoogleLensLanguage = GoogleLensLanguages.FirstOrDefault(p => p.Code == "en") ?? GoogleLensLanguages.First();
         PaddleOcrLanguages = new ObservableCollection<OcrLanguage2>(PaddleOcr.GetLanguages().OrderBy(p => p.ToString()));
@@ -312,6 +316,7 @@ public partial class OcrViewModel : ObservableObject
             GoogleVisionApiKey = ocr.GoogleVisionApiKey;
             MistralApiKey = ocr.MistralApiKey;
             SelectedGoogleVisionLanguage = GoogleVisionLanguages.FirstOrDefault(p => p.Code == ocr.GoogleVisionLanguage);
+            SelectedAppleVisionLanguage = AppleVisionLanguages.FirstOrDefault(p => p.Code == ocr.AppleVisionLanguage);
             var paddleOcrLastLanguage = PaddleOcr.NormalizeLanguageCode(Se.Settings.Ocr.PaddleOcrLastLanguage);
             SelectedPaddleOcrLanguage = PaddleOcrLanguages.FirstOrDefault(p => p.Code == paddleOcrLastLanguage) ??
                                         PaddleOcrLanguages.FirstOrDefault(p => p.Code == "en") ??
@@ -360,6 +365,7 @@ public partial class OcrViewModel : ObservableObject
         ocr.GoogleVisionApiKey = GoogleVisionApiKey;
         ocr.MistralApiKey = MistralApiKey;
         ocr.GoogleVisionLanguage = SelectedGoogleVisionLanguage?.Code ?? "en";
+        ocr.AppleVisionLanguage = SelectedAppleVisionLanguage?.Code ?? ocr.AppleVisionLanguage;
         ocr.TesseractLastLanguage = SelectedTesseractDictionaryItem?.Code ?? "eng";
         ocr.TesseractEngineMode = SelectedTesseractEngineMode?.Oem ?? 3;
         ocr.DoFixOcrErrors = DoFixOcrErrors;
@@ -428,6 +434,23 @@ public partial class OcrViewModel : ObservableObject
     partial void OnSelectedPaddleOcrLanguageChanged(OcrLanguage2? value) => AutoSelectDictionaryForOcrLanguage(value?.Code);
     partial void OnSelectedGoogleLensLanguageChanged(OcrLanguage2 value) => AutoSelectDictionaryForOcrLanguage(value?.Code);
     partial void OnSelectedGoogleVisionLanguageChanged(OcrLanguage? value) => AutoSelectDictionaryForOcrLanguage(value?.Code);
+    partial void OnSelectedAppleVisionLanguageChanged(OcrLanguage2? value) => AutoSelectDictionaryForOcrLanguage(LanguagePartOf(value?.Code));
+
+    /// <summary>
+    /// The language part of a BCP-47 tag - "pt-BR" becomes "pt". Apple Vision names its
+    /// languages that way, while the dictionary and ISO lookups here are keyed on the bare
+    /// language code.
+    /// </summary>
+    private static string? LanguagePartOf(string? bcp47)
+    {
+        if (string.IsNullOrEmpty(bcp47))
+        {
+            return bcp47;
+        }
+
+        var dash = bcp47!.IndexOf('-');
+        return dash < 0 ? bcp47 : bcp47.Substring(0, dash);
+    }
     partial void OnSelectedOllamaLanguageChanged(string? value) => AutoSelectDictionaryForOcrLanguage(Iso639Dash2LanguageCode.GetTwoLetterCodeFromEnglishName(value ?? string.Empty));
 
     private void AutoSelectDictionaryForOcrLanguage(string? languageCode)
@@ -494,6 +517,12 @@ public partial class OcrViewModel : ObservableObject
         if (lensLanguage != null)
         {
             SelectedGoogleLensLanguage = lensLanguage;
+        }
+
+        var appleVisionLanguage = AppleVisionLanguages.FirstOrDefault(p => LanguagePartOf(p.Code) == iso.TwoLetterCode);
+        if (appleVisionLanguage != null)
+        {
+            SelectedAppleVisionLanguage = appleVisionLanguage;
         }
 
         var visionLanguage = GoogleVisionLanguages.FirstOrDefault(p => p.Code == iso.ThreeLetterCode || p.Code == iso.TwoLetterCode);
@@ -2661,6 +2690,10 @@ public partial class OcrViewModel : ObservableObject
         {
             RunGoogleVisionOcr(selectedIndices, _cancellationTokenSource.Token);
         }
+        else if (ocrEngine.EngineType == OcrEngineType.AppleVision)
+        {
+            RunAppleVisionOcr(selectedIndices, _cancellationTokenSource.Token);
+        }
         else if (ocrEngine.EngineType == OcrEngineType.GoogleLens)
         {
             if (Configuration.IsRunningOnWindows && !File.Exists(Path.Combine(Se.GoogleLensOcrFolder, GoogleLensOcr.ExeFileName)))
@@ -4465,6 +4498,44 @@ public partial class OcrViewModel : ObservableObject
         });
     }
 
+    private void RunAppleVisionOcr(List<int> selectedIndices, CancellationToken cancellationToken)
+    {
+        var languageCode = SelectedAppleVisionLanguage?.Code ?? string.Empty;
+
+        _ = Task.Run(() =>
+        {
+            try
+            {
+                for (var processedIndex = 0; processedIndex < selectedIndices.Count; processedIndex++)
+                {
+                    var i = selectedIndices[processedIndex];
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
+                    UpdateOcrProgress(processedIndex + 1, selectedIndices.Count);
+
+                    var item = OcrSubtitleItems[i];
+                    var bitmap = item.GetSkBitmap();
+
+                    OcrUiUpdates.EnqueueSelect(i);
+
+                    item.Text = AppleVisionOcr.Ocr(bitmap, languageCode, fast: false, cancellationToken);
+
+                    OcrFixLineAndSetText(i, item);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            finally
+            {
+                PauseOcr();
+            }
+        }, cancellationToken);
+    }
+
     private async Task<bool> CheckAndDownloadTesseract()
     {
         if (OperatingSystem.IsWindows())
@@ -4988,6 +5059,7 @@ public partial class OcrViewModel : ObservableObject
         IsCrispEmbedVisible = et == OcrEngineType.CrispEmbed;
         IsTesseractVisible = et == OcrEngineType.Tesseract;
         IsPaddleOcrVisible = et == OcrEngineType.PaddleOcrStandalone || et == OcrEngineType.PaddleOcrPython;
+        IsAppleVisionVisible = et == OcrEngineType.AppleVision;
         IsGoogleVisionVisible = et == OcrEngineType.GoogleVision;
         IsGoogleLensVisible = et == OcrEngineType.GoogleLens || et == OcrEngineType.GoogleLensSharp;
         IsMistralOcrVisible = et == OcrEngineType.Mistral;
@@ -5033,6 +5105,19 @@ public partial class OcrViewModel : ObservableObject
                 SelectedPaddleOcrLanguage = PaddleOcrLanguages.FirstOrDefault(p => _sourceLanguageIso != null && p.Code == _sourceLanguageIso.TwoLetterCode) ??
                                             PaddleOcrLanguages.FirstOrDefault(p => p.Code == "en") ??
                                             PaddleOcrLanguages.FirstOrDefault();
+            }
+        }
+
+        if (IsAppleVisionVisible)
+        {
+            if (SelectedAppleVisionLanguage == null)
+            {
+                // Vision's tags are BCP-47 ("en-US", "pt-BR"), so match the source language on
+                // the part before the region rather than on the whole tag.
+                SelectedAppleVisionLanguage =
+                    AppleVisionLanguages.FirstOrDefault(p => _sourceLanguageIso != null && LanguagePartOf(p.Code) == _sourceLanguageIso.TwoLetterCode) ??
+                    AppleVisionLanguages.FirstOrDefault(p => p.Code == "en-US") ??
+                    AppleVisionLanguages.FirstOrDefault();
             }
         }
 

--- a/src/ui/Features/Ocr/OcrWindow.cs
+++ b/src/ui/Features/Ocr/OcrWindow.cs
@@ -375,6 +375,15 @@ public class OcrWindow : Window
                     .BindIsVisible(vm, nameof(vm.IsCrispEmbedVisible))
                     .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
 
+                // Apple Vision settings - language only: the engine ships with macOS, so there is
+                // nothing to download, no key to enter and no model to pick.
+                UiUtil.MakeLabel<OcrViewModel>(Se.Language.General.Language, vm => vm.IsAppleVisionVisible),
+                UiUtil.MakeComboBox(vm.AppleVisionLanguages, vm, nameof(vm.SelectedAppleVisionLanguage),
+                        nameof(vm.IsAppleVisionVisible))
+                    .WithWidth(180)
+                    .WithMarginRight(10)
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+
                 // Google vision settings
                 UiUtil.MakeLabel<OcrViewModel>(Se.Language.General.Language, vm => vm.IsGoogleVisionVisible),
                 UiUtil.MakeComboBox(vm.GoogleVisionLanguages, vm, nameof(vm.SelectedGoogleVisionLanguage),

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsViewModel.cs
@@ -47,6 +47,8 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
     [ObservableProperty] private TesseractEngineModeItem? _selectedTesseractEngineMode;
 
     [ObservableProperty] private ObservableCollection<OcrLanguage2> _paddleOcrLanguages;
+    [ObservableProperty] private ObservableCollection<OcrLanguage2> _appleVisionLanguages;
+    [ObservableProperty] private OcrLanguage2? _selectedAppleVisionLanguage;
     [ObservableProperty] private OcrLanguage2? _selectedPaddleOcrLanguage;
 
     [ObservableProperty] private ObservableCollection<string> _binaryOcrDatabases;
@@ -80,6 +82,7 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
     [ObservableProperty] bool _isOllamaVisible;
     [ObservableProperty] bool _isLlamaCppVisible;
     [ObservableProperty] bool _isCrispEmbedVisible;
+    [ObservableProperty] bool _isAppleVisionVisible;
 
     public Window? Window { get; set; }
     public Action? RefreshCrispEmbedModelCombo { get; set; }
@@ -96,6 +99,11 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
         TargetEncodings = new ObservableCollection<string>(encodings);
 
         OcrEngines = new ObservableCollection<string> { "nOcr", "BinaryOcr", "Tesseract", "Ollama", "llama.cpp" };
+        if (AppleVisionOcr.IsAvailable())
+        {
+            OcrEngines.Add(AppleVisionOcr.StaticName);
+        }
+
         if (CrispEmbedEngine.CanBeDownloaded())
         {
             OcrEngines.Add(CrispEmbedEngine.StaticName);
@@ -122,6 +130,7 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
         }
 
         PaddleOcrLanguages = new ObservableCollection<OcrLanguage2>(PaddleOcr.GetLanguages().OrderBy(p => p.ToString()));
+        AppleVisionLanguages = new ObservableCollection<OcrLanguage2>(AppleVisionOcr.GetLanguages().OrderBy(p => p.ToString()));
         TesseractDictionaryItems = new ObservableCollection<TesseractDictionary>();
         TesseractEngineModes = new ObservableCollection<TesseractEngineModeItem>(TesseractEngineModeItem.List());
         SelectedTesseractEngineMode = TesseractEngineModes.FirstOrDefault(p => p.Oem == Se.Settings.Tools.BatchConvert.TesseractEngineMode)
@@ -229,6 +238,12 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
         if (ocrEngine == "PaddleOCR")
         {
             Se.Settings.Tools.BatchConvert.PaddleLanguage = SelectedPaddleOcrLanguage?.Code ?? "en";
+        }
+
+        if (ocrEngine == AppleVisionOcr.StaticName)
+        {
+            Se.Settings.Tools.BatchConvert.AppleVisionLanguage =
+                SelectedAppleVisionLanguage?.Code ?? Se.Settings.Tools.BatchConvert.AppleVisionLanguage;
         }
 
         if (ocrEngine == "BinaryOcr")
@@ -417,7 +432,7 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
             return;
         }
 
-        IsOcrLanguageVisible = ocrEngine != "nOcr" && ocrEngine != "BinaryOcr" && ocrEngine != "Ollama" && ocrEngine != "llama.cpp" && ocrEngine != CrispEmbedEngine.StaticName;
+        IsOcrLanguageVisible = ocrEngine != "nOcr" && ocrEngine != "BinaryOcr" && ocrEngine != "Ollama" && ocrEngine != "llama.cpp" && ocrEngine != CrispEmbedEngine.StaticName && ocrEngine != AppleVisionOcr.StaticName;
         IsTesseractOcrVisible = ocrEngine == "Tesseract";
         IsPaddleOCrVisible = ocrEngine == "PaddleOCR";
         IsBinaryOcrVisible = ocrEngine == "BinaryOcr";
@@ -425,11 +440,20 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
         IsOllamaVisible = ocrEngine == "Ollama";
         IsLlamaCppVisible = ocrEngine == "llama.cpp";
         IsCrispEmbedVisible = ocrEngine == CrispEmbedEngine.StaticName;
+        IsAppleVisionVisible = ocrEngine == AppleVisionOcr.StaticName;
 
         if (ocrEngine == "Tesseract")
         {
             SelectedTesseractDictionaryItem = TesseractDictionaryItems
                 .FirstOrDefault(p => p.Code == Se.Settings.Tools.BatchConvert.TesseractLanguage) ?? TesseractDictionaryItems.FirstOrDefault();
+        }
+
+        if (ocrEngine == AppleVisionOcr.StaticName)
+        {
+            SelectedAppleVisionLanguage =
+                AppleVisionLanguages.FirstOrDefault(p => p.Code == Se.Settings.Tools.BatchConvert.AppleVisionLanguage) ??
+                AppleVisionLanguages.FirstOrDefault(p => p.Code == "en-US") ??
+                AppleVisionLanguages.FirstOrDefault();
         }
 
         if (ocrEngine == "PaddleOCR")

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsWindow.cs
@@ -125,6 +125,10 @@ public class BatchConvertSettingsWindow : Window
             model => model.Model.DisplayName,
             model => model.Model.Size,
             model => model.IsInstalled ? DownloadDotStatus.UpToDate : DownloadDotStatus.NotInstalled);
+        // Apple Vision: a language and nothing else - no model, no backend, no download.
+        var labelAppleVisionLanguage = UiUtil.MakeLabel(Se.Language.General.Language).WithBindVisible(vm, nameof(vm.IsAppleVisionVisible)).WithMarginLeft(10);
+        var comboBoxAppleVisionLanguages = UiUtil.MakeComboBox(vm.AppleVisionLanguages, vm, nameof(vm.SelectedAppleVisionLanguage))
+            .WithBindVisible(nameof(vm.IsAppleVisionVisible));
         var labelCrispEmbedBackend = UiUtil.MakeLabel(Se.Language.General.Backend).WithBindVisible(vm, nameof(vm.IsCrispEmbedVisible)).WithMarginLeft(10);
         var comboBoxCrispEmbedBackends = UiUtil.MakeComboBox(vm.CrispEmbedBackends, vm, nameof(vm.SelectedCrispEmbedBackend))
             .WithBindVisible(nameof(vm.IsCrispEmbedVisible));
@@ -137,7 +141,7 @@ public class BatchConvertSettingsWindow : Window
         {
             Orientation = Orientation.Horizontal,
             Margin = new Avalonia.Thickness(0, 30, 0, 0),
-            Children = { labelOcrEngine, comboBoxOcrEngine, labelOcLanguage, comboBoxTesseractLanguages, labelTesseractEngineMode, comboBoxTesseractEngineMode, comboBoxPaddleLanguages, labelBinaryOcrDatabase, comboBoxBinaryOcrDatabases, labelBinaryOcrFallback, comboBoxBinaryOcrFallback, labelNOcrDatabase, comboBoxNOcrDatabases, labelNOcrFallback, comboBoxNOcrFallback, labelOllamaModel, comboBoxOllamaModels, buttonOllamaModelBrowse, labelLlamaCppModel, comboBoxLlamaCppModels, labelCrispEmbedBackend, comboBoxCrispEmbedBackends, labelCrispEmbedModel, comboBoxCrispEmbedModels }
+            Children = { labelOcrEngine, comboBoxOcrEngine, labelOcLanguage, comboBoxTesseractLanguages, labelTesseractEngineMode, comboBoxTesseractEngineMode, comboBoxPaddleLanguages, labelBinaryOcrDatabase, comboBoxBinaryOcrDatabases, labelBinaryOcrFallback, comboBoxBinaryOcrFallback, labelNOcrDatabase, comboBoxNOcrDatabases, labelNOcrFallback, comboBoxNOcrFallback, labelOllamaModel, comboBoxOllamaModels, buttonOllamaModelBrowse, labelLlamaCppModel, comboBoxLlamaCppModels, labelCrispEmbedBackend, comboBoxCrispEmbedBackends, labelCrispEmbedModel, comboBoxCrispEmbedModels, labelAppleVisionLanguage, comboBoxAppleVisionLanguages }
         };
         comboBoxOcrEngine.SelectionChanged += (s, e) => vm.OnOcrEngineChanged();
 

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -403,6 +403,13 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
                     return;
                 }
             }
+            else if (Se.Settings.Tools.BatchConvert.OcrEngine.Equals(AppleVisionOcr.StaticName, StringComparison.OrdinalIgnoreCase))
+            {
+                if (!RunAppleVisionOcr(imageSubtitle, item, cancellationToken))
+                {
+                    return;
+                }
+            }
             else
             {
                 await RunOcrTesseract(imageSubtitle, item, cancellationToken);
@@ -1572,6 +1579,61 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             item.Subtitle.Paragraphs.All(p => string.IsNullOrWhiteSpace(p.Text)))
         {
             item.Status = Se.Language.Ocr.CrispEmbedReturnedNoText;
+            return false;
+        }
+
+        return !cancelled;
+    }
+
+    /// <summary>
+    /// Runs the file through macOS's Vision recognizer. The one OCR engine here with nothing to
+    /// check first - no install, no model, no server, no API key - so unlike its siblings there
+    /// is no "not downloaded" status it can end on, and no async at all: Vision is synchronous
+    /// in-process work.
+    /// </summary>
+    /// <returns>False when the run was cancelled or every line came back blank, in which case a
+    /// terminal status is already set on the item.</returns>
+    private bool RunAppleVisionOcr(IOcrSubtitle imageSubtitles, BatchConvertItem item, CancellationToken cancellationToken)
+    {
+        var languageCode = Se.Settings.Tools.BatchConvert.AppleVisionLanguage;
+
+        item.Status = Se.Language.General.OcrDotDotDot;
+        item.Subtitle = new Subtitle();
+        var cancelled = false;
+        for (var i = 0; i < imageSubtitles.Count; i++)
+        {
+            var pct = (i + 1) * 100 / imageSubtitles.Count;
+            item.Status = string.Format(Se.Language.General.OcrPercentX, pct);
+
+            string text;
+            try
+            {
+                text = AppleVisionOcr.Ocr(imageSubtitles.GetBitmap(i), languageCode, fast: false, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                item.Status = Se.Language.General.Cancelled;
+                return false;
+            }
+
+            item.Subtitle.Paragraphs.Add(new Paragraph(text,
+                imageSubtitles.GetStartTime(i).TotalMilliseconds,
+                imageSubtitles.GetEndTime(i).TotalMilliseconds));
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                item.Status = Se.Language.General.Cancelled;
+                cancelled = true;
+                break;
+            }
+        }
+
+        // Every line blank is worth flagging rather than saving an empty subtitle - with this
+        // engine it usually means the chosen language does not match the file.
+        if (!cancelled && item.Subtitle.Paragraphs.Count > 0 &&
+            item.Subtitle.Paragraphs.All(p => string.IsNullOrWhiteSpace(p.Text)))
+        {
+            item.Status = Se.Language.Ocr.AppleVisionReturnedNoText;
             return false;
         }
 

--- a/src/ui/Features/Video/VideoOcr/VideoOcrEngineItem.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrEngineItem.cs
@@ -35,6 +35,14 @@ public class VideoOcrEngineItem
         list.Add(new("Ollama vision", OcrEngineType.Ollama, "Local vision model via Ollama - e.g. glm-ocr"));
         list.Add(new("llama.cpp", OcrEngineType.LlamaCpp, "Local vision model via llama.cpp (downloaded automatically)"));
 
+        // Nothing to download and no key: on macOS this is the one engine that works the
+        // moment the window opens, so it goes first.
+        if (AppleVisionOcr.IsAvailable())
+        {
+            list.Insert(0, new(AppleVisionOcr.StaticName, OcrEngineType.AppleVision,
+                "macOS's built-in OCR engine - local, no download needed"));
+        }
+
         if (CrispEmbedEngine.CanBeDownloaded())
         {
             list.Add(new(CrispEmbedEngine.StaticName, OcrEngineType.CrispEmbed,

--- a/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
@@ -40,9 +40,12 @@ public partial class VideoOcrViewModel : ObservableObject
     [ObservableProperty] private bool _isGlmEngine;
     [ObservableProperty] private bool _isLlamaCppEngine;
     [ObservableProperty] private bool _isCrispEmbedEngine;
+    [ObservableProperty] private bool _isAppleVisionEngine;
     [ObservableProperty] private string _selectedEngineDescription;
     [ObservableProperty] private ObservableCollection<OcrLanguage2> _paddleLanguages;
     [ObservableProperty] private OcrLanguage2? _selectedPaddleLanguage;
+    [ObservableProperty] private ObservableCollection<OcrLanguage2> _appleVisionLanguages;
+    [ObservableProperty] private OcrLanguage2? _selectedAppleVisionLanguage;
     [ObservableProperty] private string _ollamaUrl;
     [ObservableProperty] private string _ollamaModel;
     [ObservableProperty] private string _ollamaLanguage;
@@ -112,6 +115,8 @@ public partial class VideoOcrViewModel : ObservableObject
         SelectedEngine = Engines[0];
         PaddleLanguages = new ObservableCollection<OcrLanguage2>(PaddleOcr.GetLanguages());
         SelectedPaddleLanguage = PaddleLanguages.FirstOrDefault(p => p.Code == "en");
+        AppleVisionLanguages = new ObservableCollection<OcrLanguage2>(AppleVisionOcr.GetLanguages().OrderBy(p => p.ToString()));
+        SelectedAppleVisionLanguage = AppleVisionLanguages.FirstOrDefault(p => p.Code == "en-US") ?? AppleVisionLanguages.FirstOrDefault();
         Lines = new ObservableCollection<VideoOcrLineItem>();
 
         OllamaUrl = string.Empty;
@@ -224,6 +229,7 @@ public partial class VideoOcrViewModel : ObservableObject
         IsGlmEngine = value.EngineType == OcrEngineType.Glm;
         IsLlamaCppEngine = value.EngineType == OcrEngineType.LlamaCpp;
         IsCrispEmbedEngine = value.EngineType == OcrEngineType.CrispEmbed;
+        IsAppleVisionEngine = value.EngineType == OcrEngineType.AppleVision;
         SelectedEngineDescription = value.Description;
 
         if (IsLlamaCppEngine && LlamaCppModels.Count == 0)
@@ -978,6 +984,25 @@ public partial class VideoOcrViewModel : ObservableObject
         {
             await OcrGroupsWithCrispEmbed(ocrGroups, reportProgress, addPreviewLine, cancellationToken);
         }
+        else if (engineType == OcrEngineType.AppleVision)
+        {
+            // Vision is synchronous, in-process CPU work with no server or API behind it, so
+            // each frame goes to the thread pool rather than blocking the caller for the whole
+            // scan. RunLlmOcr's fail-fast-on-first-frame check does nothing here (there is no
+            // error string to report) but the loop, progress and preview are the same.
+            var languageCode = SelectedAppleVisionLanguage?.Code ?? string.Empty;
+            await RunLlmOcr(ocrGroups,
+                group => Task.Run(() => OcrFrameWithAppleVision(group, languageCode, cancellationToken), cancellationToken),
+                () => string.Empty, reportProgress, addPreviewLine, cancellationToken);
+        }
+    }
+
+    private static string OcrFrameWithAppleVision(VideoOcrFrameGroup group, string languageCode, CancellationToken cancellationToken)
+    {
+        using var bitmap = SKBitmap.Decode(group.RepresentativeFileName);
+        return bitmap == null
+            ? string.Empty
+            : AppleVisionOcr.Ocr(bitmap, languageCode, fast: false, cancellationToken);
     }
 
     /// <summary>
@@ -1110,6 +1135,9 @@ public partial class VideoOcrViewModel : ObservableObject
         var settings = Se.Settings.Video.VideoOcr;
         SelectedEngine = Engines.FirstOrDefault(p => p.EngineType.ToString() == settings.Engine) ?? Engines[0];
         OnSelectedEngineChanged(SelectedEngine);
+        SelectedAppleVisionLanguage = AppleVisionLanguages.FirstOrDefault(p => p.Code == settings.AppleVisionLanguage)
+                                      ?? SelectedAppleVisionLanguage;
+
         var paddleLanguage = PaddleOcr.NormalizeLanguageCode(settings.PaddleLanguage);
         SelectedPaddleLanguage = PaddleLanguages.FirstOrDefault(p => p.Code == paddleLanguage) ??
                                  PaddleLanguages.FirstOrDefault(p => p.Code == "en");
@@ -1134,6 +1162,7 @@ public partial class VideoOcrViewModel : ObservableObject
         var settings = Se.Settings.Video.VideoOcr;
         settings.Engine = SelectedEngine.EngineType.ToString();
         settings.PaddleLanguage = SelectedPaddleLanguage?.Code ?? "en";
+        settings.AppleVisionLanguage = SelectedAppleVisionLanguage?.Code ?? settings.AppleVisionLanguage;
         settings.OllamaUrl = OllamaUrl;
         settings.OllamaModel = OllamaModel;
         settings.OllamaLanguage = OllamaLanguage;

--- a/src/ui/Features/Video/VideoOcr/VideoOcrWindow.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrWindow.cs
@@ -291,6 +291,14 @@ public class VideoOcrWindow : Window
         crispEmbedPanel.Bind(StackPanel.IsVisibleProperty, new Binding(nameof(vm.IsCrispEmbedEngine)) { Source = vm });
         panel.Children.Add(crispEmbedPanel);
 
+        // Apple Vision settings - language only: the engine is part of macOS, so there is no
+        // model to pick, nothing to download and no server to start.
+        var appleVisionPanel = new StackPanel { Orientation = Orientation.Vertical, Spacing = 4 };
+        appleVisionPanel.Children.Add(UiUtil.MakeLabel(Se.Language.General.Language));
+        appleVisionPanel.Children.Add(UiUtil.MakeComboBox(vm.AppleVisionLanguages, vm, nameof(vm.SelectedAppleVisionLanguage)).WithWidth(330));
+        appleVisionPanel.Bind(StackPanel.IsVisibleProperty, new Binding(nameof(vm.IsAppleVisionEngine)) { Source = vm });
+        panel.Children.Add(appleVisionPanel);
+
         // Scan settings
         panel.Children.Add(MakeHeader(Se.Language.Video.VideoOcr.Scan));
         panel.Children.Add(MakeSettingRow(

--- a/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
+++ b/src/ui/Logic/Config/Language/Ocr/LanguageOcr.cs
@@ -138,6 +138,7 @@ public class LanguageOcr
     public string LlamaCppDownloadModelPrompt { get; set; }
     public string CrispEmbedNotDownloaded { get; set; }
     public string CrispEmbedReturnedNoText { get; set; }
+    public string AppleVisionReturnedNoText { get; set; }
     public string CrispEmbedSettingsTitle { get; set; }
     public string CrispEmbedDescription { get; set; }
     public string TrainNOcrDatabase { get; set; }
@@ -293,6 +294,7 @@ public class LanguageOcr
         LlamaCppDownloadModelPrompt = "llama.cpp requires the selected OCR model to be downloaded. Download now?";
         CrispEmbedNotDownloaded = "CrispEmbed engine/model not downloaded - download via batch convert settings";
         CrispEmbedReturnedNoText = "CrispEmbed returned no text - check the model";
+        AppleVisionReturnedNoText = "Apple Vision returned no text - check the language";
         CrispEmbedSettingsTitle = "CrispEmbed settings";
         CrispEmbedDescription = "Local OCR engine with multiple model backends - download the engine and the models here.";
 

--- a/src/ui/Logic/Config/SeBatchConvert.cs
+++ b/src/ui/Logic/Config/SeBatchConvert.cs
@@ -17,6 +17,9 @@ public class SeBatchConvert
     public string TesseractLanguage { get; set; }
     public int TesseractEngineMode { get; set; }
     public string PaddleLanguage { get; set; }
+
+    /// <summary>Apple Vision's recognition language, as its BCP-47 tag. macOS only.</summary>
+    public string AppleVisionLanguage { get; set; }
     public string BinaryOcrDatabase { get; set; }
     public string NOcrBinaryOcrFallbackDatabase { get; set; }
     public string BinaryOcrNOcrFallbackDatabase { get; set; }
@@ -150,10 +153,15 @@ public class SeBatchConvert
         SaveInSourceFolder = true;
         TargetFormat = string.Empty;
         TargetEncoding = string.Empty;
-        OcrEngine = "Tesseract";
+        // See SeOcr.Engine: on macOS the built-in recognizer needs no install, while the
+        // Tesseract default would send a fresh Mac user to Homebrew before the first batch run.
+        OcrEngine = System.OperatingSystem.IsMacOS()
+            ? Features.Ocr.Engines.AppleVisionOcr.StaticName
+            : "Tesseract";
         TesseractLanguage = "eng";
         TesseractEngineMode = 3; // Default, based on what is available (tesseract --oem)
         PaddleLanguage = "en";
+        AppleVisionLanguage = "en-US";
         BinaryOcrDatabase = "Latin";
         NOcrBinaryOcrFallbackDatabase = string.Empty;
         BinaryOcrNOcrFallbackDatabase = string.Empty;

--- a/src/ui/Logic/Config/SeOcr.cs
+++ b/src/ui/Logic/Config/SeOcr.cs
@@ -77,7 +77,13 @@ public class SeOcr
 
     public SeOcr()
     {
-        Engine = "nOCR";
+        // macOS gets Apple Vision out of the box: it is the only engine there that works with no
+        // download, no runtime and no key, so a fresh install can OCR immediately. Everywhere
+        // else nOCR stays the default. This is the default for NEW settings only - a saved
+        // engine is the user's choice and is never overwritten.
+        Engine = System.OperatingSystem.IsMacOS()
+            ? Features.Ocr.Engines.AppleVisionOcr.StaticName
+            : "nOCR";
         DoFixOcrErrors = true;
         DoTryToGuessUnknownWords = true;
         DoAutoBreak = true;

--- a/src/ui/Logic/Config/SeOcr.cs
+++ b/src/ui/Logic/Config/SeOcr.cs
@@ -28,6 +28,12 @@ public class SeOcr
     public int CrispEmbedOcrTimeoutMinutes { get; set; }
     public string GoogleVisionApiKey { get; set; }
     public string GoogleVisionLanguage { get; set; }
+
+    /// <summary>
+    /// Apple Vision's chosen recognition language, as the BCP-47 tag the framework uses
+    /// ("en-US", "pt-BR"). macOS only.
+    /// </summary>
+    public string AppleVisionLanguage { get; set; }
     public string MistralApiKey { get; set; }
     public bool IsNewLetterItalic { get; set; }
     public bool SubmitOnFirstLetter { get; set; }
@@ -107,6 +113,7 @@ public class SeOcr
 
         GoogleVisionApiKey = string.Empty;
         GoogleVisionLanguage = "en";
+        AppleVisionLanguage = "en-US";
 
         PaddleOcrMode = "mobile";
         PaddleOcrLastLanguage = "en";

--- a/src/ui/Logic/Config/SeVideoOcr.cs
+++ b/src/ui/Logic/Config/SeVideoOcr.cs
@@ -6,6 +6,9 @@ public class SeVideoOcr
 {
     public string Engine { get; set; }
     public string PaddleLanguage { get; set; }
+
+    /// <summary>Apple Vision's recognition language, as its BCP-47 tag. macOS only.</summary>
+    public string AppleVisionLanguage { get; set; }
     public string OllamaUrl { get; set; }
     public string OllamaModel { get; set; }
     public string OllamaLanguage { get; set; }
@@ -32,10 +35,14 @@ public class SeVideoOcr
 
     public SeVideoOcr()
     {
-        Engine = System.OperatingSystem.IsWindows() || System.OperatingSystem.IsLinux()
-            ? OcrEngineType.PaddleOcrStandalone.ToString()
-            : OcrEngineType.PaddleOcrPython.ToString();
+        // Unlike the other two, this setting stores the enum name rather than the display name.
+        // macOS had been defaulting to the Python PaddleOCR, which needs a pip install before it
+        // does anything; Apple Vision is there already.
+        Engine = System.OperatingSystem.IsMacOS()
+            ? OcrEngineType.AppleVision.ToString()
+            : OcrEngineType.PaddleOcrStandalone.ToString();
         PaddleLanguage = "en";
+        AppleVisionLanguage = "en-US";
         OllamaUrl = "http://localhost:11434/api/chat";
         OllamaModel = "glm-ocr";
         OllamaLanguage = "English";

--- a/src/ui/Logic/ValueConverters/BatchConvertStatusColorConverter.cs
+++ b/src/ui/Logic/ValueConverters/BatchConvertStatusColorConverter.cs
@@ -51,6 +51,7 @@ public class BatchConvertStatusColorConverter : IValueConverter
             status == Se.Language.Ocr.LlamaCppReturnedNoText ||
             status == Se.Language.Ocr.CrispEmbedNotDownloaded ||
             status == Se.Language.Ocr.CrispEmbedReturnedNoText ||
+            status == Se.Language.Ocr.AppleVisionReturnedNoText ||
             (errorPrefix.Length > 0 && status.StartsWith(errorPrefix, StringComparison.OrdinalIgnoreCase)) ||
             status.StartsWith("BinaryOcr database not found", StringComparison.Ordinal))
         {

--- a/tests/UI/Features/Ocr/AppleVisionTextLayoutTests.cs
+++ b/tests/UI/Features/Ocr/AppleVisionTextLayoutTests.cs
@@ -1,0 +1,152 @@
+using Nikse.SubtitleEdit.Features.Ocr.Engines;
+
+namespace UITests.Features.Ocr;
+
+/// <summary>
+/// Turning Vision's observations back into subtitle text.
+///
+/// Vision hands back a flat set of text observations with no reading order, and it splits one
+/// visual line into several observations wherever the gap between words is wide - which is
+/// exactly what a two-speaker dialogue line looks like. So the two things that can go wrong are
+/// reading the lines in the wrong order and breaking one line into two, and both are decided
+/// purely by the geometry, with no framework involved. That makes this testable on any OS, which
+/// matters because CI runs on Linux where Vision does not exist.
+///
+/// Coordinates below are Vision's own: normalized 0-1, origin at the BOTTOM left, so a larger Y
+/// is higher up the image.
+/// </summary>
+public class AppleVisionTextLayoutTests
+{
+    private static AppleVisionObservation Obs(string text, double left, double right, double top, double bottom)
+    {
+        return new AppleVisionObservation(text, left, right, top, bottom);
+    }
+
+    [Fact]
+    public void Compose_NoObservations_IsEmpty()
+    {
+        Assert.Equal(string.Empty, AppleVisionTextLayout.Compose([]));
+    }
+
+    [Fact]
+    public void Compose_Null_IsEmpty()
+    {
+        Assert.Equal(string.Empty, AppleVisionTextLayout.Compose(null!));
+    }
+
+    [Fact]
+    public void Compose_SingleObservation_IsThatText()
+    {
+        var text = AppleVisionTextLayout.Compose([Obs("It's a beautiful day.", 0.25, 0.75, 0.81, 0.35)]);
+
+        Assert.Equal("It's a beautiful day.", text);
+    }
+
+    [Fact]
+    public void Compose_TwoLines_ReadsTopLineFirst()
+    {
+        // Vision's Y grows upwards, so the upper line is the one with the LARGER Y. Reading them
+        // in ascending Y - the intuitive reading for a top-left origin - would swap the lines.
+        var upper = Obs("- Are you coming with us?", 0.16, 0.83, 0.90, 0.61);
+        var lower = Obs("- No, I'll stay here.", 0.26, 0.74, 0.49, 0.16);
+
+        var text = AppleVisionTextLayout.Compose([upper, lower]);
+
+        Assert.Equal($"- Are you coming with us?{Environment.NewLine}- No, I'll stay here.", text);
+    }
+
+    [Fact]
+    public void Compose_ObservationsArriveOutOfOrder_StillReadsTopToBottom()
+    {
+        var upper = Obs("First line", 0.16, 0.83, 0.90, 0.61);
+        var middle = Obs("Second line", 0.16, 0.83, 0.58, 0.33);
+        var lower = Obs("Third line", 0.26, 0.74, 0.30, 0.05);
+
+        var text = AppleVisionTextLayout.Compose([lower, upper, middle]);
+
+        Assert.Equal($"First line{Environment.NewLine}Second line{Environment.NewLine}Third line", text);
+    }
+
+    [Fact]
+    public void Compose_OneLineSplitByAWideGap_StaysOneLine()
+    {
+        // The dialogue case: "- Yes.        - No." on a single visual line comes back as two
+        // observations at the same height. Joined with a space, not broken onto two lines.
+        var left = Obs("- Yes.", 0.10, 0.30, 0.60, 0.40);
+        var right = Obs("- No.", 0.70, 0.90, 0.61, 0.41);
+
+        var text = AppleVisionTextLayout.Compose([left, right]);
+
+        Assert.Equal("- Yes. - No.", text);
+    }
+
+    [Fact]
+    public void Compose_SplitLine_ReadsLeftToRightWhateverTheOrder()
+    {
+        var left = Obs("Hello", 0.10, 0.30, 0.60, 0.40);
+        var right = Obs("world", 0.70, 0.90, 0.60, 0.40);
+
+        var text = AppleVisionTextLayout.Compose([right, left]);
+
+        Assert.Equal("Hello world", text);
+    }
+
+    [Fact]
+    public void Compose_TwoSplitLines_GroupsEachLineSeparately()
+    {
+        var upperLeft = Obs("Upper", 0.10, 0.30, 0.90, 0.70);
+        var upperRight = Obs("line", 0.70, 0.90, 0.90, 0.70);
+        var lowerLeft = Obs("Lower", 0.10, 0.30, 0.40, 0.20);
+        var lowerRight = Obs("line", 0.70, 0.90, 0.40, 0.20);
+
+        var text = AppleVisionTextLayout.Compose([lowerRight, upperLeft, lowerLeft, upperRight]);
+
+        Assert.Equal($"Upper line{Environment.NewLine}Lower line", text);
+    }
+
+    [Fact]
+    public void Compose_SlightVerticalWobbleOnOneLine_DoesNotSplitIt()
+    {
+        // Vision leaves a little vertical drift on parts of the same line; anything under half a
+        // line height has to stay one line.
+        var left = Obs("Left part", 0.10, 0.40, 0.600, 0.400);
+        var right = Obs("right part", 0.60, 0.90, 0.615, 0.415);
+
+        var text = AppleVisionTextLayout.Compose([left, right]);
+
+        Assert.Equal("Left part right part", text);
+    }
+
+    [Fact]
+    public void Compose_LinesCloseTogether_AreStillTwoLines()
+    {
+        // Tightly set two-liner: the gap is small but the centres are still more than half a
+        // line height apart, so it must not collapse into one line.
+        var upper = Obs("Upper", 0.10, 0.90, 0.90, 0.62);
+        var lower = Obs("Lower", 0.10, 0.90, 0.58, 0.30);
+
+        var text = AppleVisionTextLayout.Compose([upper, lower]);
+
+        Assert.Equal($"Upper{Environment.NewLine}Lower", text);
+    }
+
+    [Fact]
+    public void Compose_BlankObservations_AreDropped()
+    {
+        var real = Obs("Real text", 0.10, 0.90, 0.60, 0.40);
+        var blank = Obs("   ", 0.10, 0.90, 0.30, 0.10);
+
+        var text = AppleVisionTextLayout.Compose([real, blank]);
+
+        Assert.Equal("Real text", text);
+    }
+
+    [Fact]
+    public void Compose_TrimsEachObservation()
+    {
+        var left = Obs("  Hello ", 0.10, 0.30, 0.60, 0.40);
+        var right = Obs(" world  ", 0.70, 0.90, 0.60, 0.40);
+
+        Assert.Equal("Hello world", AppleVisionTextLayout.Compose([left, right]));
+    }
+}

--- a/tests/UI/Features/Ocr/Engines/AppleVisionOcrTests.cs
+++ b/tests/UI/Features/Ocr/Engines/AppleVisionOcrTests.cs
@@ -1,0 +1,184 @@
+using Nikse.SubtitleEdit.Features.Ocr.Engines;
+using SkiaSharp;
+using System.Threading;
+
+namespace UITests.Features.Ocr.Engines;
+
+/// <summary>
+/// End-to-end cover for the Vision interop: does the framework actually load, list languages and
+/// read a subtitle image through objc_msgSend.
+///
+/// Every test here is skipped off macOS, so CI (Linux) never runs them - which is the point of
+/// <see cref="AppleVisionTextLayoutTests"/> carrying the logic that can be tested anywhere. What
+/// is left here is exactly the part no amount of pure logic can stand in for: the P/Invoke
+/// signatures, the selector names, and whether Vision reads SE-shaped images at all.
+///
+/// The images are drawn here rather than checked in: white subtitle text with a black outline on
+/// a transparent background is what SE hands an OCR engine once it has pulled a Blu-ray sup or
+/// VobSub image apart, and drawing it keeps the fixture honest about that.
+/// </summary>
+public class AppleVisionOcrTests
+{
+    private static bool SkipIfUnavailable()
+    {
+        if (!OperatingSystem.IsMacOS())
+        {
+            Assert.Skip("Apple Vision is macOS only.");
+            return true;
+        }
+
+        if (!AppleVisionOcr.IsAvailable())
+        {
+            Assert.Skip("Vision.framework did not load on this machine.");
+            return true;
+        }
+
+        return false;
+    }
+
+    [Fact]
+    public void IsAvailable_OffMacOs_IsFalse()
+    {
+        if (OperatingSystem.IsMacOS())
+        {
+            Assert.Skip("Only meaningful off macOS.");
+            return;
+        }
+
+        Assert.False(AppleVisionOcr.IsAvailable());
+        Assert.Empty(AppleVisionOcr.GetLanguages());
+    }
+
+    [Fact]
+    public void GetLanguages_ReturnsTheFrameworksOwnList()
+    {
+        if (SkipIfUnavailable())
+        {
+            return;
+        }
+
+        var languages = AppleVisionOcr.GetLanguages();
+
+        Assert.NotEmpty(languages);
+
+        // en-US has been in every revision of the recognizer; asserting the exact set would
+        // just break on the next macOS that adds a language.
+        Assert.Contains(languages, l => l.Code == "en-US");
+        Assert.All(languages, l => Assert.False(string.IsNullOrWhiteSpace(l.Name)));
+    }
+
+    [Fact]
+    public void Ocr_NullBitmap_IsEmptyRatherThanThrowing()
+    {
+        Assert.Equal(string.Empty, AppleVisionOcr.Ocr(null, "en-US", fast: false, CancellationToken.None));
+    }
+
+    [Fact]
+    public void Ocr_SingleLineOnTransparentBackground_ReadsTheText()
+    {
+        if (SkipIfUnavailable())
+        {
+            return;
+        }
+
+        using var bitmap = DrawSubtitle(["It's a beautiful day."]);
+
+        var text = AppleVisionOcr.Ocr(bitmap, "en-US", fast: false, CancellationToken.None);
+
+        Assert.Equal("It's a beautiful day.", text);
+    }
+
+    [Fact]
+    public void Ocr_TwoLines_KeepsThemInReadingOrder()
+    {
+        if (SkipIfUnavailable())
+        {
+            return;
+        }
+
+        using var bitmap = DrawSubtitle(["- Are you coming with us?", "- No, I will stay here."]);
+
+        var text = AppleVisionOcr.Ocr(bitmap, "en-US", fast: false, CancellationToken.None);
+        var lines = text.Split(Environment.NewLine);
+
+        Assert.Equal(2, lines.Length);
+        Assert.StartsWith("- Are you coming", lines[0]);
+        Assert.StartsWith("- No, I will stay", lines[1]);
+    }
+
+    [Fact]
+    public void Ocr_TransparentAndBlackBackgrounds_ReadTheSame()
+    {
+        if (SkipIfUnavailable())
+        {
+            return;
+        }
+
+        // SE hands over images with a transparent background. Compositing them onto black first
+        // would be easy to add and is what the PaddleOCR path does, so this pins the finding
+        // that Vision does not need it - if a future macOS starts reading the two differently,
+        // this is the test that says so.
+        using var transparent = DrawSubtitle(["It's a beautiful day."]);
+        using var onBlack = DrawSubtitle(["It's a beautiful day."], transparentBackground: false);
+
+        Assert.Equal(
+            AppleVisionOcr.Ocr(onBlack, "en-US", fast: false, CancellationToken.None),
+            AppleVisionOcr.Ocr(transparent, "en-US", fast: false, CancellationToken.None));
+    }
+
+    [Fact]
+    public void Ocr_EmptyImage_IsEmpty()
+    {
+        if (SkipIfUnavailable())
+        {
+            return;
+        }
+
+        using var bitmap = DrawSubtitle([]);
+
+        Assert.Equal(string.Empty, AppleVisionOcr.Ocr(bitmap, "en-US", fast: false, CancellationToken.None));
+    }
+
+    [Fact]
+    public void Ocr_CancelledBeforeStart_Throws()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        using var bitmap = DrawSubtitle(["Anything at all"]);
+
+        Assert.Throws<OperationCanceledException>(
+            () => AppleVisionOcr.Ocr(bitmap, "en-US", fast: false, cts.Token));
+    }
+
+    private static SKBitmap DrawSubtitle(string[] lines, bool transparentBackground = true)
+    {
+        const int width = 1200;
+        const int lineHeight = 90;
+        var height = lineHeight * Math.Max(lines.Length, 1) + 40;
+
+        var bitmap = new SKBitmap(width, height, SKColorType.Rgba8888, SKAlphaType.Premul);
+        using var canvas = new SKCanvas(bitmap);
+        canvas.Clear(transparentBackground ? SKColors.Transparent : SKColors.Black);
+
+        using var typeface = SKTypeface.FromFamilyName("Helvetica Neue", SKFontStyle.Bold);
+        using var font = new SKFont(typeface, 64);
+        using var fill = new SKPaint { Color = SKColors.White, IsAntialias = true };
+        using var outline = new SKPaint
+        {
+            Color = SKColors.Black,
+            IsAntialias = true,
+            Style = SKPaintStyle.Stroke,
+            StrokeWidth = 4,
+        };
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var x = (width - font.MeasureText(lines[i])) / 2;
+            var y = 70 + i * lineHeight;
+            canvas.DrawText(lines[i], x, y, font, outline);
+            canvas.DrawText(lines[i], x, y, font, fill);
+        }
+
+        return bitmap;
+    }
+}

--- a/tests/UI/Features/Ocr/Engines/AppleVisionOcrTests.cs
+++ b/tests/UI/Features/Ocr/Engines/AppleVisionOcrTests.cs
@@ -139,6 +139,11 @@ public class AppleVisionOcrTests
         Assert.Equal(string.Empty, AppleVisionOcr.Ocr(bitmap, "en-US", fast: false, CancellationToken.None));
     }
 
+    /// <summary>
+    /// Deliberately not gated on macOS: an already-cancelled token has to be honoured on every
+    /// platform, and it was not - off macOS the availability gate returned empty before the token
+    /// was ever looked at, which is how CI caught this.
+    /// </summary>
     [Fact]
     public void Ocr_CancelledBeforeStart_Throws()
     {
@@ -148,6 +153,11 @@ public class AppleVisionOcrTests
 
         Assert.Throws<OperationCanceledException>(
             () => AppleVisionOcr.Ocr(bitmap, "en-US", fast: false, cts.Token));
+
+        // A null bitmap takes the same early-return branch the unavailable engine does, so this
+        // reproduces the CI failure on macOS too: before the fix it returned empty here.
+        Assert.Throws<OperationCanceledException>(
+            () => AppleVisionOcr.Ocr(null, "en-US", fast: false, cts.Token));
     }
 
     private static SKBitmap DrawSubtitle(string[] lines, bool transparentBackground = true)

--- a/tests/UI/Features/Tools/BatchConvert/BatchConvertSettingsViewModelAppleVisionTests.cs
+++ b/tests/UI/Features/Tools/BatchConvert/BatchConvertSettingsViewModelAppleVisionTests.cs
@@ -1,0 +1,95 @@
+using Avalonia.Headless.XUnit;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Features.Ocr.Engines;
+using Nikse.SubtitleEdit.Features.Tools.BatchConvert;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Tools.BatchConvert;
+
+/// <summary>
+/// The Apple Vision option in batch convert settings.
+///
+/// The one trap an engine with its own language combo hits here is the shared "Language" label:
+/// it is shown for every engine that is not on an exclusion list, so an engine that brings its
+/// own combo shows two language controls at once unless it is added to that list. That is the
+/// mistake worth a test, and it is checked on every OS - the exclusion is a string comparison
+/// with no framework behind it, so it can go wrong on Linux CI just as easily.
+/// </summary>
+public class BatchConvertSettingsViewModelAppleVisionTests
+{
+    [AvaloniaFact]
+    public void OcrEngines_ContainAppleVision_OnlyWhereItRuns()
+    {
+        var viewModel = MakeViewModel();
+
+        Assert.Equal(AppleVisionOcr.IsAvailable(), viewModel.OcrEngines.Contains(AppleVisionOcr.StaticName));
+    }
+
+    [AvaloniaFact]
+    public void SelectingAppleVision_ShowsItsOwnLanguage_AndHidesTheSharedOne()
+    {
+        var viewModel = MakeViewModel();
+
+        viewModel.SelectedOcrEngine = AppleVisionOcr.StaticName;
+        viewModel.OnOcrEngineChanged();
+
+        Assert.True(viewModel.IsAppleVisionVisible);
+        Assert.False(viewModel.IsOcrLanguageVisible);
+
+        // Nothing else may claim the row at the same time.
+        Assert.False(viewModel.IsCrispEmbedVisible);
+        Assert.False(viewModel.IsTesseractOcrVisible);
+        Assert.False(viewModel.IsPaddleOCrVisible);
+    }
+
+    [AvaloniaFact]
+    public void SelectingAnotherEngine_HidesAppleVision()
+    {
+        var viewModel = MakeViewModel();
+
+        viewModel.SelectedOcrEngine = AppleVisionOcr.StaticName;
+        viewModel.OnOcrEngineChanged();
+        viewModel.SelectedOcrEngine = "nOcr";
+        viewModel.OnOcrEngineChanged();
+
+        Assert.False(viewModel.IsAppleVisionVisible);
+    }
+
+    [AvaloniaFact]
+    public void LanguageCombo_FollowsTheSavedBatchSetting()
+    {
+        if (!AppleVisionOcr.IsAvailable())
+        {
+            Assert.Skip("Apple Vision is macOS only.");
+            return;
+        }
+
+        var saved = Se.Settings.Tools.BatchConvert.AppleVisionLanguage;
+        try
+        {
+            // Any second language this machine's Vision supports; the point is that the combo
+            // restores what was saved rather than always landing on the en-US default.
+            var other = AppleVisionOcr.GetLanguages().First(l => l.Code != "en-US").Code;
+            Se.Settings.Tools.BatchConvert.AppleVisionLanguage = other;
+
+            var viewModel = MakeViewModel();
+            viewModel.SelectedOcrEngine = AppleVisionOcr.StaticName;
+            viewModel.OnOcrEngineChanged();
+
+            Assert.Equal(other, viewModel.SelectedAppleVisionLanguage?.Code);
+        }
+        finally
+        {
+            Se.Settings.Tools.BatchConvert.AppleVisionLanguage = saved;
+        }
+    }
+
+    private static BatchConvertSettingsViewModel MakeViewModel()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        using var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<BatchConvertSettingsViewModel>();
+    }
+}


### PR DESCRIPTION
macOS ships a text recognizer — the one behind Live Text and Preview — and SE was not using it, while local OCR on a Mac was the weakest of the three platforms: Tesseract wants Homebrew, PaddleOCR wants pip, and CrispEmbed has no Intel build at all. On an Intel Mac that left no local engine SE could offer without sending the user to a package manager. Apple Vision needs no download, no runtime, no model and no API key.

It is wired into all three places SE runs OCR — the OCR window, batch convert and video OCR — and is now the macOS default in each.

## The interop

Driven through `objc_msgSend`, the same way `MacWindowsMenuInterop` drives AppKit, with Vision `dlopen`'d on first use since it is not linked into the app. Every entry point reports "unavailable" rather than throwing, so the engine simply does not appear if the framework is ever missing, and the language list is read from the framework rather than hard-coded — the set grows with each macOS release and the recognizer rejects a language it does not know.

Two decisions worth review:

**Corners, not `boundingBox`.** A `CGRect` is four doubles, which x86_64 returns through the hidden-pointer `objc_msgSend_stret` path while arm64 returns it in registers — two calls to get right, one of which cannot be exercised on an Apple Silicon machine. `topLeft`/`bottomRight` are `CGPoint`s, two doubles, returned in registers on both, so the geometry needs one code path.

**An explicit autorelease pool per call.** Nothing drains a .NET worker thread's pool, so without one a batch of a few thousand subtitle images would hold every intermediate `NSString` and `NSData` until the process exits.

## Reading order

Vision returns observations with no reading order, and splits one visual line into several wherever the gap between words is wide — which is exactly what a two-speaker dialogue line looks like. `AppleVisionTextLayout` groups them back into visual lines by vertical position and reads each left to right. Note Vision's Y grows *upwards*, so the intuitive top-first sort is descending.

That logic is pure geometry, so it is tested on any OS — which matters because CI runs on Linux. The interop tests skip off macOS and cover what no pure logic can: the P/Invoke signatures, the selector names, and whether Vision reads SE-shaped images at all.

It reads them untouched: a subtitle image with a transparent background gives the same result as the same text composited onto black, so unlike the PaddleOCR path there is no flattening step. A test pins that, so a future macOS that changes it will say so.

## Video OCR was gated on a question

Video OCR feeds crops of real video frames, not clean sup/VobSub images, so the text sits on whatever the picture happens to be. That was checked before wiring it up, not after: white subtitle text with a black outline over gradients, busy shapes, per-pixel noise, a bright sky, plain white and a fine diagonal texture — then a real H.264 frame of ffmpeg's `testsrc2` pattern (saturated colour bars, checkerboards, gradients) with the subtitles burned in.

It read both lines correctly on the video frame, and 14 of 16 synthetic lines exactly. The two misses were one `I` read as `1` and one missing space after a dash — the class of thing SE's OCR fix lists already handle. It never failed to find the text and never merged the lines.

## Batch convert

Follows the six-place wiring the CrispEmbed work established: engine list, its own language combo, the visibility flag, save/restore of the chosen language, the converter dispatch, and the "returned no text" status in both `LanguageOcr` and the status colour converter. Two of the six are no-ops here and worth naming: there is no ensure-downloaded gate before a run and no download prompt on the settings dialog's OK, because there is nothing to download — which is also why `RunAppleVisionOcr` has no "not downloaded" status its siblings all need, and no async at all.

The trap that wiring hits is the shared "Language" label, shown for every engine not on an exclusion list: an engine bringing its own combo shows two language controls at once until it is added to that list. There is a test for it, and it runs on every OS since the exclusion is a plain string comparison.

## Defaults

macOS now defaults to Apple Vision in all three places, replacing nOCR in the OCR window, Tesseract in batch convert and the Python PaddleOCR in video OCR — each of which needed a download, a brew or a pip before a fresh Mac install could OCR anything. Defaults apply to **new settings only**; a saved engine is the user's choice and is never overwritten. Note the three settings do not agree on what they store: video OCR keeps the enum name, the other two the display name.

## macOS 14

Separate from the feature, and the reason it is in this PR: checking the stated requirement turned up three different numbers. The bundle and docs said macOS 12, which is the *technical* floor — the shipped runtime is built against macOS 12 (`LC_BUILD_VERSION minos 12.0` in `libcoreclr.dylib`) and so loads there — but [.NET 10 is supported on macOS 14, 15 and 26](https://github.com/dotnet/core/blob/main/release-notes/10.0/supported-os.md), since Microsoft tracks Apple's own three-release window. Users on 12 and 13 were on a configuration the runtime is never tested against.

Raised to 14 (Sonoma) in the one place that enforces it and the three that document it — `LSMinimumSystemVersion`, `README.md`, `docs/overview.md`, `docs/faq.md` — so Finder says "requires a newer version of macOS" instead. The plist comment records both numbers and why they differ. Historical macOS 12 mentions in the changelogs are left alone: they describe releases that really did run there.

## Known limitation: no italics

`VNRecognizedText`'s entire public surface is `string`, `confidence`, `requestRevision` and `boundingBoxForRange:error:` — verified by dumping the class's method list, not read off the headers. There is no font or style information at all, so Vision cannot report italics. That puts it with Tesseract, PaddleOCR and the cloud/VLM engines; only nOCR and binary image compare produce `<i>`, by shape-matching glyphs. It reads italic text correctly, it just returns it unmarked.

## Testing

- Full UI suite green: 3813 passed, 1 skipped. Solution builds with zero warnings.
- 23 tests for this feature: layout logic on every OS, interop against real Vision calls on macOS.
- Verified by hand in the running app on Apple Silicon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)