### PR TITLE
Keep macOS 12 as the minimum and recommend 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ You can find the latest cross-platform builds here:
 
 ### macOS
 
-- **Minimum macOS version**: 14 (Sonoma) or newer - the oldest macOS that .NET 10 is supported on
+- **Minimum macOS version**: 12 (Monterey) or newer
+- **Recommended**: macOS 14 (Sonoma) or newer - the oldest macOS that .NET 10 is supported on. Subtitle Edit still starts on 12 and 13, but that combination is not one the .NET runtime is tested against.
 - The `.dmg` is self-contained: `libmpv` and `ffmpeg` are bundled inside `Subtitle Edit.app`, so no MacPorts or Homebrew install is required.
 
 #### Installing Subtitle Edit on macOS

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -12,7 +12,7 @@ Yes. Subtitle Edit is released under the MIT license. It is completely free with
 Subtitle Edit 5 is built with Avalonia UI and runs on:
 - Windows 10 (version 22H2 / build 19045) and later
 - Linux (native packages or Flatpak)
-- macOS 14 (Sonoma) or later, on both Apple Silicon (arm64) and Intel (x64)
+- macOS 12 (Monterey) or later, on both Apple Silicon (arm64) and Intel (x64) - macOS 14 (Sonoma) or later recommended, as that is the oldest macOS .NET 10 is supported on
 
 ### Where is my data stored?
 Subtitle Edit stores settings and data in a platform-specific data folder. You can open it with the keyboard shortcut `Ctrl+Alt+Shift+D` (Windows/Linux) or `Cmd+Alt+Shift+D` (macOS).

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -25,7 +25,7 @@ Subtitle Edit is a free, open-source editor for video subtitles. It allows you t
 
 ## System Requirements
 
-- Windows 10 (version 22H2 / build 19045) or newer, Linux, or macOS 14 (Sonoma) or newer
+- Windows 10 (version 22H2 / build 19045) or newer, Linux, or macOS 12 (Monterey) or newer (macOS 14 / Sonoma or newer recommended - that is the oldest macOS .NET 10 is supported on)
 - [FFmpeg](https://ffmpeg.org/) (for audio/video processing)
 - [libmpv](https://mpv.io/) for video playback
 

--- a/installer/macBundle/SubtitleEdit.app/Contents/Info.plist
+++ b/installer/macBundle/SubtitleEdit.app/Contents/Info.plist
@@ -20,18 +20,19 @@
     <string>SBED</string>
     <key>CFBundleIconFile</key>
     <string>SE.icns</string>
-    <!-- macOS 14 (Sonoma) is the oldest release .NET 10 is supported on: Microsoft
-         tracks Apple's own three-release window, so .NET 10 lists macOS 14, 15 and 26.
-         This is deliberately stricter than the technical floor - the shipped runtime is
-         built against macOS 12 (LC_BUILD_VERSION minos 12.0 in libcoreclr.dylib) and so
-         would load on 12 and 13, but those are untested by the runtime we depend on.
-         Declaring 14 gets Finder's "requires a newer version of macOS" instead of an
-         unsupported configuration failing later in unclear ways. Keep this in step with
-         the requirements in README.md, docs/overview.md and docs/faq.md.
-         The technical floor can be re-derived after a TFM bump with:
-           otool -l .../shared/Microsoft.NETCore.App/<ver>/libcoreclr.dylib | grep -A3 LC_BUILD_VERSION -->
+    <!-- The technical floor, not the supported one, and deliberately so.
+         .NET 10 is supported on macOS 14, 15 and 26 (Microsoft tracks Apple's own
+         three-release window), and the docs recommend 14 for that reason. But the
+         runtime we ship is built against macOS 12 - LC_BUILD_VERSION minos 12.0 in
+         libcoreclr.dylib - so it does load on 12 and 13, and this key is what decides
+         whether LaunchServices lets it try. Declaring 14 here would refuse to start on
+         machines where SE runs fine today, so it stays at the floor: 12 and 13 users
+         keep a working app on an untested runtime configuration, rather than no app.
+         Re-derive after a TFM bump with:
+           otool -l .../shared/Microsoft.NETCore.App/<ver>/libcoreclr.dylib | grep -A3 LC_BUILD_VERSION
+         and keep it in step with README.md, docs/overview.md and docs/faq.md. -->
     <key>LSMinimumSystemVersion</key>
-    <string>14.0</string>
+    <string>12.0</string>
     <key>NSHighResolutionCapable</key>
     <true/>
     <key>NSSupportsAutomaticGraphicsSwitching</key>


### PR DESCRIPTION
Follow-up to #14066, which raised `LSMinimumSystemVersion` to 14 to match what .NET 10 is supported on.

That number is right — [.NET 10 lists macOS 26, 15 and 14](https://github.com/dotnet/core/blob/main/release-notes/10.0/supported-os.md), since Microsoft tracks Apple's own three-release window. But **enforcing** it in the bundle refused to start on machines where SE runs fine today: the runtime we ship is built against macOS 12 (`LC_BUILD_VERSION minos 12.0` in `libcoreclr.dylib`), so 12 and 13 do load — they are simply not a configuration the runtime is tested against. That made the previous change a regression for Monterey and Ventura users, in exchange for a warning they could have had without losing the app.

A working app on an untested runtime beats no app. So:

- `LSMinimumSystemVersion` goes back to the technical floor, **12.0**
- the recommendation moves into the docs, where it informs rather than blocks — **minimum 12 (Monterey), recommended 14 (Sonoma)**, with the reason stated in `README.md`, `docs/overview.md` and `docs/faq.md`

The plist comment now says explicitly which of the two numbers the key is and why they differ, so the next person to read it does not "fix" it back to the supported version.

Nothing else we bundle argues for a higher floor either — the libmpv dylibs come from IINA 1.4.4 (10.15+) and the osxexperts ffmpeg builds target older systems too. .NET is the only thing setting this, which is what makes the `otool` line in the comment the thing to re-run after a TFM bump.

Docs and metadata only; no code changes. `plutil -lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)