### PR TITLE
Let Ctrl+click open the shortcuts list's Import/Export menu on macOS

### DIFF
--- a/src/ui/Features/Options/Shortcuts/ShortcutsWindow.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutsWindow.cs
@@ -450,6 +450,11 @@ public class ShortcutsWindow : Window
         };
         flyout.Items.Add(menuItemImportSe4);
 
+        // On macOS a Ctrl+click is the secondary click, but it does not reach ContextFlyout
+        // reliably - so without this the Import/Export menu is unreachable for anyone using a
+        // one-button mouse or a trackpad with secondary click turned off. Every other window
+        // with a control-scoped flyout already does this; this grid was the one left out.
+        UiUtil.AttachMacContextFlyoutHandler(shortcutsGrid);
 
         var buttonOk = UiUtil.MakeButtonOk(vm.CommandOkCommand);
         var buttonResetAllShortcuts = UiUtil.MakeButton(Se.Language.General.Reset, vm.ResetAllShortcutsCommand);


### PR DESCRIPTION
On macOS a Ctrl+click is the secondary click, but it does not reach `ContextFlyout` reliably — which is why `UiUtil.AttachMacContextFlyoutHandler` exists, and why 27 windows already call it.

The Shortcuts window's grid was the one control-scoped flyout left out, so its Import / Export / Import-from-SE4 menu was unreachable for anyone on a one-button mouse, or a trackpad with secondary click switched off. One line, following the established pattern.

Found in a macOS review sweep over every `ContextFlyout` in the app; the other apparent gaps turned out to be covered either by `RegexContextFlyout` or by hand-rolled Ctrl+click handling (the main window and the OCR window both do their own).

**No test, deliberately.** The helper no-ops off macOS and CI runs on Linux, and none of the other 27 call sites are covered either — a bespoke test here would pin this one window while the pattern itself stays unguarded. Verified by building and running the full suite for regressions: 3829 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)