### PR TITLE
WhisperX as a standalone (no Python) speech-to-text engine

### DIFF
--- a/src/ui/Assets/SpeechToText/WhisperX.txt
+++ b/src/ui/Assets/SpeechToText/WhisperX.txt
@@ -1,0 +1,180 @@
+usage: whisperx-standalone [-h] [--model MODEL]
+                           [--model_cache_only MODEL_CACHE_ONLY]
+                           [--model_dir MODEL_DIR] [--device DEVICE]
+                           [--device_index DEVICE_INDEX]
+                           [--batch_size BATCH_SIZE]
+                           [--compute_type {default,float16,float32,int8}]
+                           [--output_dir OUTPUT_DIR]
+                           [--output_format {all,srt,vtt,txt,tsv,json,aud}]
+                           [--verbose VERBOSE]
+                           [--log-level {debug,info,warning,error,critical}]
+                           [--task {transcribe,translate}]
+                           [--language LANGUAGE]
+                           [--align_model ALIGN_MODEL]
+                           [--interpolate_method {nearest,linear,ignore}]
+                           [--no_align] [--return_char_alignments]
+                           [--vad_method {pyannote,silero}]
+                           [--vad_onset VAD_ONSET] [--vad_offset VAD_OFFSET]
+                           [--chunk_size CHUNK_SIZE] [--diarize]
+                           [--min_speakers MIN_SPEAKERS]
+                           [--max_speakers MAX_SPEAKERS]
+                           [--diarize_model DIARIZE_MODEL]
+                           [--speaker_embeddings] [--temperature TEMPERATURE]
+                           [--best_of BEST_OF] [--beam_size BEAM_SIZE]
+                           [--patience PATIENCE]
+                           [--length_penalty LENGTH_PENALTY]
+                           [--suppress_tokens SUPPRESS_TOKENS]
+                           [--suppress_numerals]
+                           [--initial_prompt INITIAL_PROMPT]
+                           [--hotwords HOTWORDS]
+                           [--condition_on_previous_text CONDITION_ON_PREVIOUS_TEXT]
+                           [--fp16 FP16]
+                           [--temperature_increment_on_fallback TEMPERATURE_INCREMENT_ON_FALLBACK]
+                           [--compression_ratio_threshold COMPRESSION_RATIO_THRESHOLD]
+                           [--logprob_threshold LOGPROB_THRESHOLD]
+                           [--no_speech_threshold NO_SPEECH_THRESHOLD]
+                           [--max_line_width MAX_LINE_WIDTH]
+                           [--max_line_count MAX_LINE_COUNT]
+                           [--highlight_words HIGHLIGHT_WORDS]
+                           [--segment_resolution {sentence,chunk}]
+                           [--threads THREADS] [--hf_token HF_TOKEN]
+                           [--print_progress PRINT_PROGRESS] [--version]
+                           [--python-version]
+                           audio [audio ...]
+
+positional arguments:
+  audio                 audio file(s) to transcribe
+
+options:
+  -h, --help            show this help message and exit
+  --model MODEL         name of the Whisper model to use (default: small)
+  --model_cache_only MODEL_CACHE_ONLY
+                        If True, will not attempt to download models, instead
+                        using cached models from --model_dir (default: False)
+  --model_dir MODEL_DIR
+                        the path to save model files; uses ~/.cache/whisper by
+                        default (default: None)
+  --device DEVICE       device type to use for PyTorch inference (e.g. cpu,
+                        cuda) (default: cpu)
+  --device_index DEVICE_INDEX
+                        device index to use for FasterWhisper inference
+                        (default: 0)
+  --batch_size BATCH_SIZE
+                        the preferred batch size for inference (default: 8)
+  --compute_type {default,float16,float32,int8}
+                        compute type for computation; 'default' uses float16
+                        on GPU, float32 on CPU (default: default)
+  --output_dir OUTPUT_DIR, -o OUTPUT_DIR
+                        directory to save the outputs (default: .)
+  --output_format {all,srt,vtt,txt,tsv,json,aud}, -f {all,srt,vtt,txt,tsv,json,aud}
+                        format of the output file (default: all)
+  --verbose VERBOSE     whether to print out progress and debug messages
+                        (default: True)
+  --log-level {debug,info,warning,error,critical}
+                        log level (default: info)
+  --task {transcribe,translate}
+                        whether to transcribe or translate to English
+                        (default: transcribe)
+  --language LANGUAGE   language spoken in the audio; specify None to perform
+                        language detection (default: None)
+  --align_model ALIGN_MODEL
+                        name of phoneme-level ASR model to do alignment
+                        (default: None)
+  --interpolate_method {nearest,linear,ignore}
+                        for word .srt, method to assign timestamps to non-
+                        aligned words, or merge them into neighbouring
+                        (default: nearest)
+  --no_align            do not perform alignment (default: False)
+  --return_char_alignments
+                        return character-level alignments in the output json
+                        file (default: False)
+  --vad_method {pyannote,silero}
+                        VAD method to be used (default: pyannote)
+  --vad_onset VAD_ONSET
+                        onset threshold for VAD (see pyannote.audio pipelines)
+                        (default: 0.5)
+  --vad_offset VAD_OFFSET
+                        offset threshold for VAD (see pyannote.audio
+                        pipelines) (default: 0.363)
+  --chunk_size CHUNK_SIZE
+                        Chunk size for merging VAD segments (default: 30)
+  --diarize             apply diarization to assign speaker labels to each
+                        segment/word (default: False)
+  --min_speakers MIN_SPEAKERS
+                        minimum number of speakers to in audio file (default:
+                        None)
+  --max_speakers MAX_SPEAKERS
+                        maximum number of speakers to in audio file (default:
+                        None)
+  --diarize_model DIARIZE_MODEL
+                        Name of the diarization model to use (default:
+                        pyannote/speaker-diarization-3.1)
+  --speaker_embeddings  Include speaker embeddings in JSON output (only works
+                        with --diarize too) (default: False)
+  --temperature TEMPERATURE
+                        temperature to use for sampling (default: 0)
+  --best_of BEST_OF     number of candidates when sampling with non-zero
+                        temperature (default: 5)
+  --beam_size BEAM_SIZE
+                        number of beams in beam search, only applicable when
+                        temperature is zero (default: 5)
+  --patience PATIENCE   optional patience value to use in beam decoding
+                        (default: 1.0)
+  --length_penalty LENGTH_PENALTY
+                        optional token length penalty coefficient (alpha)
+                        (default: 1.0)
+  --suppress_tokens SUPPRESS_TOKENS
+                        comma-separated list of token ids to suppress during
+                        sampling (default: -1)
+  --suppress_numerals   whether to suppress numeric symbols and currency
+                        symbols during sampling, since wav2vec2 cannot align
+                        them correctly (default: False)
+  --initial_prompt INITIAL_PROMPT
+                        optional text to provide as a prompt for the first
+                        window (default: None)
+  --hotwords HOTWORDS   hotwords/hint phrases for the model (default: None)
+  --condition_on_previous_text CONDITION_ON_PREVIOUS_TEXT
+                        if True, provide the previous output as a prompt for
+                        the next window (default: False)
+  --fp16 FP16           whether to perform inference in fp16 (default: True)
+  --temperature_increment_on_fallback TEMPERATURE_INCREMENT_ON_FALLBACK
+                        temperature to increase when falling back (default:
+                        0.2)
+  --compression_ratio_threshold COMPRESSION_RATIO_THRESHOLD
+                        if gzip compression ratio is higher than this, treat
+                        decoding as failed (default: 2.4)
+  --logprob_threshold LOGPROB_THRESHOLD
+                        if average log probability is lower than this, treat
+                        decoding as failed (default: -1.0)
+  --no_speech_threshold NO_SPEECH_THRESHOLD
+                        if the no-speech probability is higher than this and
+                        decoding has failed, consider the segment as silence
+                        (default: 0.6)
+  --max_line_width MAX_LINE_WIDTH
+                        the maximum number of characters in a line before
+                        breaking (default: None)
+  --max_line_count MAX_LINE_COUNT
+                        the maximum number of lines in a segment (default:
+                        None)
+  --highlight_words HIGHLIGHT_WORDS
+                        underline each word as it is spoken in srt/vtt
+                        (default: False)
+  --segment_resolution {sentence,chunk}
+                        the resolution of the segments (default: sentence)
+  --threads THREADS    number of threads used by torch for CPU inference
+                        (default: 0)
+  --hf_token HF_TOKEN   Hugging Face access token, needed to run diarization
+                        (gated models) (default: )
+  --print_progress PRINT_PROGRESS
+                        if True, prints progress in transcribing/aligning
+                        (default: False)
+  --version             show program's version number and exit
+  --python-version      print the Python interpreter version used to build
+                        this executable, then exit
+
+Notes for the standalone build (https://github.com/muaz978/subtitleedit-whisperx-standalone):
+- No Python install is required - this is a self-contained build.
+- Requires ffmpeg on PATH (Subtitle Edit passes its own bundled copy automatically).
+- Whisper and alignment models download from Hugging Face on first use.
+- --diarize needs a Hugging Face token with access to the gated pyannote
+  speaker-diarization model, passed via --hf_token.

--- a/src/ui/Assets/SpeechToText/WhisperX.txt
+++ b/src/ui/Assets/SpeechToText/WhisperX.txt
@@ -174,7 +174,10 @@ options:
 
 Notes for the standalone build (https://github.com/muaz978/subtitleedit-whisperx-standalone):
 - No Python install is required - this is a self-contained build.
+- The downloaded archive unpacks to roughly 950 MB (Windows), 1.1 GB (macOS), or 1.7 GB
+  (Linux) on disk.
 - Requires ffmpeg on PATH (Subtitle Edit passes its own bundled copy automatically).
-- Whisper and alignment models download from Hugging Face on first use.
+- Whisper and alignment models download from Hugging Face on first use, adding up to
+  roughly 2 GB more depending on the selected model.
 - --diarize needs a Hugging Face token with access to the gated pyannote
   speaker-diarization model, passed via --hf_token.

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
@@ -214,6 +214,25 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject, ICl
                 OkPressed = true;
                 Close();
             }
+            else if (Engine.Name == WhisperEngineWhisperX.StaticName)
+            {
+                var dir = Engine.GetAndCreateWhisperFolder();
+
+                TitleText = string.Format(Se.Language.General.UnpackingX, Engine.Name);
+                StartIndeterminateProgress();
+                Unpack(dir, string.Empty);
+                StopIndeterminateProgress();
+
+                if (_cancellationTokenSource.IsCancellationRequested)
+                {
+                    Cancel();
+                    return;
+                }
+
+                // WhisperX runs its own bundled voice activity detection - no Silero sidecar needed.
+                OkPressed = true;
+                Close();
+            }
             else
             {
                 if (_downloadStream.Length == 0)
@@ -550,6 +569,10 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject, ICl
         else if (Engine is WhisperEngineCTranslate2)
         {
             _downloadTask = _whisperDownloadService.DownloadWhisperCTranslate2(_downloadStream, downloadProgress, _cancellationTokenSource.Token);
+        }
+        else if (Engine is WhisperEngineWhisperX)
+        {
+            _downloadTask = _whisperDownloadService.DownloadWhisperX(_downloadStream, downloadProgress, _cancellationTokenSource.Token);
         }
         else if (Engine is WhisperEngineConstMe)
         {

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
@@ -217,16 +217,19 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject, ICl
             else if (Engine.Name == WhisperEngineWhisperX.StaticName)
             {
                 var dir = Engine.GetAndCreateWhisperFolder();
-                var tempFileName = Path.Combine(dir, Engine.Name + ".zip");
+                var tempFileName = Path.Combine(dir, Engine.Name + ".7z");
 
                 TitleText = string.Format(Se.Language.General.UnpackingX, Engine.Name);
                 StartIndeterminateProgress();
-                UnpackFile(tempFileName, dir, string.Empty);
+                // Flat archive (no top-level folder), so no folder level to skip.
+                Unpacker.Extract7Zip(tempFileName, dir, string.Empty, _cancellationTokenSource, text => ProgressText = text);
                 StopIndeterminateProgress();
 
                 try
                 {
                     File.Delete(tempFileName);
+
+                    MakeExecutable(Engine.GetExecutable());
 
                     // WhisperX bundles ctranslate2 from the same wheel family that hits the
                     // glibc 2.41 PT_GNU_STACK=RWE problem patched for Purfview Faster-Whisper-XXL.
@@ -483,28 +486,6 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject, ICl
         MakeExecutable(path);
     }
 
-    /// <summary>
-    /// Same as <see cref="Unpack"/>, but for an engine downloaded straight to a file (via
-    /// <see cref="IWhisperDownloadService"/>'s file-based overloads) instead of buffered into
-    /// the shared <see cref="_downloadStream"/> - large downloads use a file precisely to avoid
-    /// that in-memory buffering.
-    /// </summary>
-    private void UnpackFile(string zipFileName, string folder, string skipFolderLevel)
-    {
-        using (var fileStream = File.OpenRead(zipFileName))
-        {
-            _zipUnpacker.UnpackZipStream(fileStream, folder, skipFolderLevel, false, new List<string>(), null);
-        }
-
-        if (Engine == null || (!OperatingSystem.IsMacOS() && !OperatingSystem.IsLinux()))
-        {
-            return;
-        }
-
-        var path = Path.Combine(folder, Engine.GetExecutableFileName());
-        MakeExecutable(path);
-    }
-
     private void DownloadAndUnpackSileroVad(string folder)
     {
         if (_cancellationTokenSource.IsCancellationRequested)
@@ -608,12 +589,12 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject, ICl
         }
         else if (Engine is WhisperEngineWhisperX)
         {
-            // A file download, not the shared _downloadStream MemoryStream: at 850 MB-925 MB,
-            // buffering this in memory (with MemoryStream's doubling growth) would peak at
-            // 1.5-2 GB before unpacking even starts. Purfview Faster-Whisper-XXL is downloaded
+            // A file download, not the shared _downloadStream MemoryStream: at 216 MB-355 MB,
+            // buffering this in memory (with MemoryStream's doubling growth) would peak far
+            // higher before unpacking even starts. Purfview Faster-Whisper-XXL is downloaded
             // the same way for the same reason.
             var whisperXDir = Engine.GetAndCreateWhisperFolder();
-            var whisperXTempFileName = Path.Combine(whisperXDir, Engine.Name + ".zip");
+            var whisperXTempFileName = Path.Combine(whisperXDir, Engine.Name + ".7z");
             _downloadTask = _whisperDownloadService.DownloadWhisperX(whisperXTempFileName, downloadProgress, _cancellationTokenSource.Token);
         }
         else if (Engine is WhisperEngineConstMe)

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
@@ -217,11 +217,25 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject, ICl
             else if (Engine.Name == WhisperEngineWhisperX.StaticName)
             {
                 var dir = Engine.GetAndCreateWhisperFolder();
+                var tempFileName = Path.Combine(dir, Engine.Name + ".zip");
 
                 TitleText = string.Format(Se.Language.General.UnpackingX, Engine.Name);
                 StartIndeterminateProgress();
-                Unpack(dir, string.Empty);
+                UnpackFile(tempFileName, dir, string.Empty);
                 StopIndeterminateProgress();
+
+                try
+                {
+                    File.Delete(tempFileName);
+
+                    // WhisperX bundles ctranslate2 from the same wheel family that hits the
+                    // glibc 2.41 PT_GNU_STACK=RWE problem patched for Purfview Faster-Whisper-XXL.
+                    ClearExecutableStack(dir);
+                }
+                catch
+                {
+                    // ignore
+                }
 
                 if (_cancellationTokenSource.IsCancellationRequested)
                 {
@@ -469,6 +483,28 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject, ICl
         MakeExecutable(path);
     }
 
+    /// <summary>
+    /// Same as <see cref="Unpack"/>, but for an engine downloaded straight to a file (via
+    /// <see cref="IWhisperDownloadService"/>'s file-based overloads) instead of buffered into
+    /// the shared <see cref="_downloadStream"/> - large downloads use a file precisely to avoid
+    /// that in-memory buffering.
+    /// </summary>
+    private void UnpackFile(string zipFileName, string folder, string skipFolderLevel)
+    {
+        using (var fileStream = File.OpenRead(zipFileName))
+        {
+            _zipUnpacker.UnpackZipStream(fileStream, folder, skipFolderLevel, false, new List<string>(), null);
+        }
+
+        if (Engine == null || (!OperatingSystem.IsMacOS() && !OperatingSystem.IsLinux()))
+        {
+            return;
+        }
+
+        var path = Path.Combine(folder, Engine.GetExecutableFileName());
+        MakeExecutable(path);
+    }
+
     private void DownloadAndUnpackSileroVad(string folder)
     {
         if (_cancellationTokenSource.IsCancellationRequested)
@@ -572,7 +608,13 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject, ICl
         }
         else if (Engine is WhisperEngineWhisperX)
         {
-            _downloadTask = _whisperDownloadService.DownloadWhisperX(_downloadStream, downloadProgress, _cancellationTokenSource.Token);
+            // A file download, not the shared _downloadStream MemoryStream: at 850 MB-925 MB,
+            // buffering this in memory (with MemoryStream's doubling growth) would peak at
+            // 1.5-2 GB before unpacking even starts. Purfview Faster-Whisper-XXL is downloaded
+            // the same way for the same reason.
+            var whisperXDir = Engine.GetAndCreateWhisperFolder();
+            var whisperXTempFileName = Path.Combine(whisperXDir, Engine.Name + ".zip");
+            _downloadTask = _whisperDownloadService.DownloadWhisperX(whisperXTempFileName, downloadProgress, _cancellationTokenSource.Token);
         }
         else if (Engine is WhisperEngineConstMe)
         {

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineFactory.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineFactory.cs
@@ -42,6 +42,11 @@ public static class WhisperEngineFactory
             return new WhisperEnginePurfviewFasterWhisperXxl();
         }
 
+        if (staticName == WhisperEngineWhisperX.StaticName)
+        {
+            return new WhisperEngineWhisperX();
+        }
+
         if (staticName == Qwen3AsrCppEngine.StaticName)
         {
             return new Qwen3AsrCppEngine();

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineWhisperX.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineWhisperX.cs
@@ -24,7 +24,13 @@ public class WhisperEngineWhisperX : ISpeechToTextEngine
     public string Url => "https://github.com/m-bain/whisperX";
 
     public List<WhisperLanguage> Languages => WhisperLanguage.Languages.OrderBy(p => p.Name).ToList();
-    public List<WhisperModel> Models => new WhisperModel().Models.ToList();
+
+    // WhisperX runs on the same faster-whisper/ctranslate2 backend as WhisperEngineCTranslate2,
+    // so it takes the same model list (correct names like large-v3-turbo/distil-*, and the
+    // actual Hugging Face repos this backend downloads from) rather than whisper.cpp's ggml
+    // model list, which does not match what this backend understands.
+    public List<WhisperModel> Models => new WhisperPurfviewFasterWhisperModel().Models.ToList();
+
     public string Extension => string.Empty;
     public string UnpackSkipFolder => string.Empty;
 
@@ -57,9 +63,11 @@ public class WhisperEngineWhisperX : ISpeechToTextEngine
 
     public string GetAndCreateWhisperModelFolder(WhisperModel? whisperModel)
     {
-        var folder = new WhisperModel().ModelFolder;
-        Directory.CreateDirectory(folder);
-        return folder;
+        // Shares Purfview's folder, matching WhisperEngineCTranslate2 - unused for actual model
+        // storage (WhisperX's models live in the Hugging Face cache, see IsModelInstalled), but
+        // this keeps the interface's expectation of "a real, existing folder" honest rather than
+        // pointing at whisper.cpp's unrelated ggml model folder.
+        return new WhisperEnginePurfviewFasterWhisperXxl().GetAndCreateWhisperModelFolder(whisperModel);
     }
 
     // The archive is unpacked flat into GetAndCreateWhisperFolder(), so the executable and its
@@ -77,8 +85,59 @@ public class WhisperEngineWhisperX : ISpeechToTextEngine
     public bool IsModelInstalled(WhisperModel model)
     {
         // WhisperX owns the Hugging Face cache and downloads the selected Whisper/alignment
-        // model on first use. Do not route its model name through SE's .pt/.bin downloader.
-        return IsEngineInstalled();
+        // model on first use - do not route its model name through SE's .pt/.bin downloader.
+        // Still worth checking honestly (rather than always reporting "installed"): these models
+        // come from the same Hugging Face repos as WhisperEngineCTranslate2/Purfview (both run
+        // the same backend), so a snapshot already sitting in the Hugging Face hub cache for
+        // that repo id is a reliable signal the model does not need downloading again.
+        var repoId = GetHuggingFaceRepoId(model);
+        if (string.IsNullOrEmpty(repoId))
+        {
+            return false;
+        }
+
+        var cacheFolder = Path.Combine(GetHuggingFaceHubCacheDir(), "models--" + repoId.Replace("/", "--"));
+        return Directory.Exists(cacheFolder);
+    }
+
+    private static string? GetHuggingFaceRepoId(WhisperModel model)
+    {
+        // e.g. "https://huggingface.co/Systran/faster-whisper-tiny/resolve/main/model.bin" -> "Systran/faster-whisper-tiny"
+        var url = model.Urls?.FirstOrDefault();
+        if (string.IsNullOrEmpty(url))
+        {
+            return null;
+        }
+
+        const string marker = "huggingface.co/";
+        var idx = url.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        if (idx < 0)
+        {
+            return null;
+        }
+
+        var parts = url[(idx + marker.Length)..].Split('/');
+        return parts.Length >= 2 ? $"{parts[0]}/{parts[1]}" : null;
+    }
+
+    // Mirrors huggingface_hub's own cache directory resolution order: HF_HOME, then the legacy
+    // HUGGINGFACE_HUB_CACHE, then the default ~/.cache/huggingface/hub.
+    private static string GetHuggingFaceHubCacheDir()
+    {
+        var hfHome = Environment.GetEnvironmentVariable("HF_HOME");
+        if (!string.IsNullOrEmpty(hfHome))
+        {
+            return Path.Combine(hfHome, "hub");
+        }
+
+        var hubCache = Environment.GetEnvironmentVariable("HUGGINGFACE_HUB_CACHE");
+        if (!string.IsNullOrEmpty(hubCache))
+        {
+            return hubCache;
+        }
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return Path.Combine(home, ".cache", "huggingface", "hub");
     }
 
     public string GetModelForCmdLine(string modelName) => modelName;
@@ -96,23 +155,26 @@ public class WhisperEngineWhisperX : ISpeechToTextEngine
 
     public bool CanBeDownloaded() => true;
 
+    // Measured from the v1.0.1 release zips (compressed download size); unpacks to roughly
+    // 950 MB (Windows), 1.1 GB (macOS), 1.7 GB (Linux) on disk, plus another ~2 GB of Whisper/
+    // alignment/diarization models that download from Hugging Face the first time each is used.
     public string DownloadSizeText
     {
         get
         {
             if (OperatingSystem.IsWindows())
             {
-                return "~750 MB";
+                return "~350 MB";
             }
 
             if (OperatingSystem.IsMacOS())
             {
-                return "~300 MB";
+                return "~365 MB";
             }
 
             if (OperatingSystem.IsLinux())
             {
-                return "~750 MB";
+                return "~575 MB";
             }
 
             return string.Empty;

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineWhisperX.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineWhisperX.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia.Platform;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.UiLogic.AudioToText;
+
+namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+
+/// <summary>
+/// WhisperX, packaged as a standalone PyInstaller build (see
+/// https://github.com/muaz978/subtitleedit-whisperx-standalone) so it downloads and runs like
+/// every other engine here, with no separate Python install or managed virtual environment.
+/// Requiring Python was the reason an earlier version of this engine (PR #14031) was not
+/// accepted upstream.
+/// </summary>
+public class WhisperEngineWhisperX : ISpeechToTextEngine
+{
+    public static string StaticName => "WhisperX";
+    public string Name => StaticName;
+    public string Choice => WhisperChoice.WhisperX;
+    public string Url => "https://github.com/m-bain/whisperX";
+
+    public List<WhisperLanguage> Languages => WhisperLanguage.Languages.OrderBy(p => p.Name).ToList();
+    public List<WhisperModel> Models => new WhisperModel().Models.ToList();
+    public string Extension => string.Empty;
+    public string UnpackSkipFolder => string.Empty;
+
+    public bool IsEngineInstalled()
+    {
+        return File.Exists(GetExecutable());
+    }
+
+    public override string ToString()
+    {
+        return Name;
+    }
+
+    public string GetAndCreateWhisperFolder()
+    {
+        var baseFolder = Se.SpeechToTextFolder;
+        if (!Directory.Exists(baseFolder))
+        {
+            Directory.CreateDirectory(baseFolder);
+        }
+
+        var folder = Path.Combine(baseFolder, "WhisperX");
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        return folder;
+    }
+
+    public string GetAndCreateWhisperModelFolder(WhisperModel? whisperModel)
+    {
+        var folder = new WhisperModel().ModelFolder;
+        Directory.CreateDirectory(folder);
+        return folder;
+    }
+
+    // The archive is unpacked flat into GetAndCreateWhisperFolder(), so the executable and its
+    // "_internal" PyInstaller payload folder land directly there - same layout as CTranslate2.
+    public string GetExecutable()
+    {
+        return Path.Combine(GetAndCreateWhisperFolder(), GetExecutableFileName());
+    }
+
+    internal static string GetExecutableFileName()
+    {
+        return OperatingSystem.IsWindows() ? "whisperx-standalone.exe" : "whisperx-standalone";
+    }
+
+    public bool IsModelInstalled(WhisperModel model)
+    {
+        // WhisperX owns the Hugging Face cache and downloads the selected Whisper/alignment
+        // model on first use. Do not route its model name through SE's .pt/.bin downloader.
+        return IsEngineInstalled();
+    }
+
+    public string GetModelForCmdLine(string modelName) => modelName;
+
+    public async Task<string> GetHelpText()
+    {
+        var uri = new Uri($"avares://SubtitleEdit/Assets/SpeechToText/{StaticName}.txt");
+        await using var stream = AssetLoader.Open(uri);
+        using var reader = new StreamReader(stream);
+        return await reader.ReadToEndAsync();
+    }
+
+    public string GetWhisperModelDownloadFileName(WhisperModel whisperModel, string url)
+        => Path.Combine(GetAndCreateWhisperModelFolder(whisperModel), Path.GetFileName(url));
+
+    public bool CanBeDownloaded() => true;
+
+    public string DownloadSizeText
+    {
+        get
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                return "~750 MB";
+            }
+
+            if (OperatingSystem.IsMacOS())
+            {
+                return "~300 MB";
+            }
+
+            if (OperatingSystem.IsLinux())
+            {
+                return "~750 MB";
+            }
+
+            return string.Empty;
+        }
+    }
+
+    public string CommandLineParameter
+    {
+        get => Se.Settings.Tools.AudioToText.CommandLineParameterWhisperX;
+        set => Se.Settings.Tools.AudioToText.CommandLineParameterWhisperX = value;
+    }
+}

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -256,8 +256,9 @@ public partial class SpeechToTextViewModel : ObservableObject
         }
 
         // Same platform/architecture support as the standalone build published at
-        // https://github.com/muaz978/subtitleedit-whisperx-standalone.
-        if (OperatingSystem.IsWindows() ||
+        // https://github.com/muaz978/subtitleedit-whisperx-standalone - only builds for
+        // Windows x64 (not ARM64, which would silently get a mismatched x64 binary).
+        if ((OperatingSystem.IsWindows() && RuntimeInformation.ProcessArchitecture == Architecture.X64) ||
             (OperatingSystem.IsMacOS() && RuntimeInformation.ProcessArchitecture == Architecture.Arm64) ||
             (OperatingSystem.IsLinux() && RuntimeInformation.ProcessArchitecture == Architecture.X64))
         {
@@ -4174,9 +4175,9 @@ public partial class SpeechToTextViewModel : ObservableObject
     private static bool _executableStackChecked;
 
     /// <summary>
-    /// Repairs an already-installed Purfview Faster-Whisper-XXL before launching it.
+    /// Repairs an already-installed Purfview Faster-Whisper-XXL or WhisperX before launching it.
     /// <para>
-    /// Its bundled libctranslate2 is built with PT_GNU_STACK = RWE, and glibc 2.41 stopped making
+    /// Both bundle a libctranslate2 built with PT_GNU_STACK = RWE, and glibc 2.41 stopped making
     /// the stack executable at dlopen time, so on a distro with glibc 2.41+ (Fedora 42, Arch,
     /// Ubuntu 25.10) the run dies immediately with "cannot enable executable stack as shared
     /// object requires: Invalid argument". The download path clears the flag on unpack, but
@@ -4190,7 +4191,7 @@ public partial class SpeechToTextViewModel : ObservableObject
         if (_executableStackChecked ||
             !OperatingSystem.IsLinux() ||
             string.IsNullOrEmpty(whisperFolder) ||
-            engine is not WhisperEnginePurfviewFasterWhisperXxl)
+            engine is not (WhisperEnginePurfviewFasterWhisperXxl or WhisperEngineWhisperX))
         {
             return;
         }

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -255,6 +255,15 @@ public partial class SpeechToTextViewModel : ObservableObject
             Engines.Add(new WhisperEngineCTranslate2());
         }
 
+        // Same platform/architecture support as the standalone build published at
+        // https://github.com/muaz978/subtitleedit-whisperx-standalone.
+        if (OperatingSystem.IsWindows() ||
+            (OperatingSystem.IsMacOS() && RuntimeInformation.ProcessArchitecture == Architecture.Arm64) ||
+            (OperatingSystem.IsLinux() && RuntimeInformation.ProcessArchitecture == Architecture.X64))
+        {
+            Engines.Add(new WhisperEngineWhisperX());
+        }
+
         Engines.Add(new WhisperEngineOpenAi());
 
         // Add OpenAI Compatible STT engine (available on all platforms)
@@ -3737,7 +3746,11 @@ public partial class SpeechToTextViewModel : ObservableObject
     /// stdout/stderr to <paramref name="dataReceivedHandler"/> when one is given.
     /// The working directory is the executable's folder.
     /// </summary>
-    private static Process StartEngineProcess(string executable, string arguments, DataReceivedEventHandler? dataReceivedHandler)
+    private static Process StartEngineProcess(
+        string executable,
+        string arguments,
+        DataReceivedEventHandler? dataReceivedHandler,
+        Action<ProcessStartInfo>? configureStartInfo = null)
     {
         var p = new Process
         {
@@ -3749,6 +3762,8 @@ public partial class SpeechToTextViewModel : ObservableObject
                 WorkingDirectory = Path.GetDirectoryName(executable),
             }
         };
+
+        configureStartInfo?.Invoke(p.StartInfo);
 
         if (dataReceivedHandler != null)
         {
@@ -3794,6 +3809,35 @@ public partial class SpeechToTextViewModel : ObservableObject
     }
 
     /// <summary>
+    /// WhisperX shells out to a real "ffmpeg" binary via subprocess for audio loading (it is not
+    /// bundled in the standalone build - see subtitleedit-whisperx-standalone's README). Puts
+    /// Subtitle Edit's own configured/bundled ffmpeg on PATH so WhisperX finds it without
+    /// requiring a separate ffmpeg install. When ffmpeg is not configured to an actual file
+    /// (e.g. still the bare "ffmpeg" fallback resolved through the system PATH), this leaves
+    /// PATH untouched - the child process falls back to the exact same system PATH resolution
+    /// Subtitle Edit's own ffmpeg calls would use in that situation.
+    /// </summary>
+    private static void AddFfmpegToPath(ProcessStartInfo startInfo)
+    {
+        var ffmpegLocation = FfmpegHelper.GetFfmpegLocation();
+        if (string.IsNullOrEmpty(ffmpegLocation) || !File.Exists(ffmpegLocation))
+        {
+            return;
+        }
+
+        var ffmpegDir = Path.GetDirectoryName(ffmpegLocation);
+        if (string.IsNullOrEmpty(ffmpegDir))
+        {
+            return;
+        }
+
+        var existingPath = ProcessEnvironmentHelper.GetOrNull(startInfo, "PATH");
+        startInfo.EnvironmentVariables["PATH"] = string.IsNullOrEmpty(existingPath)
+            ? ffmpegDir
+            : ffmpegDir + Path.PathSeparator + existingPath;
+    }
+
+    /// <summary>
     /// Engines that demux and decode the source media themselves, so they can be pointed at the
     /// user's original file instead of SE's extracted WAV: Purfview Faster-Whisper-XXL bundles
     /// ffmpeg, whisper-ctranslate2 bundles PyAV. Verified that the others cannot - whisper.cpp
@@ -3803,7 +3847,7 @@ public partial class SpeechToTextViewModel : ObservableObject
     private static bool CanEngineReadSourceFileDirectly(ISpeechToTextEngine engine)
     {
         return engine.Name == WhisperEnginePurfviewFasterWhisperXxl.StaticName ||
-               engine is WhisperEngineCTranslate2;
+               engine is WhisperEngineCTranslate2 or WhisperEngineWhisperX;
     }
 
     /// <summary>
@@ -3846,6 +3890,25 @@ public partial class SpeechToTextViewModel : ObservableObject
         DataReceivedEventHandler? dataReceivedHandler = null,
         string engineOutputFolder = "")
     {
+        if (engine is WhisperEngineWhisperX whisperX)
+        {
+            var exe = whisperX.GetExecutable();
+            var whisperXArgs = whisperX.CommandLineParameter;
+            var languageArgX = language.Equals("auto", StringComparison.OrdinalIgnoreCase)
+                ? string.Empty
+                : $"--language {language} ";
+            var taskArg = translate ? "--task translate " : string.Empty;
+            var outputDir = string.IsNullOrEmpty(engineOutputFolder)
+                ? GetSttTempFolder()
+                : engineOutputFolder;
+            var parametersX =
+                $"{languageArgX}--model \"{model}\" --output_format srt --output_dir \"{outputDir}\" " +
+                $"{taskArg}{whisperXArgs} \"{waveFileName}\"";
+
+            Se.WriteToolsLog($"{exe} {parametersX}");
+            return StartEngineProcess(exe, parametersX, dataReceivedHandler, AddFfmpegToPath);
+        }
+
         if (engine is Qwen3AsrCppEngine qwen3Asr)
         {
             var exe = qwen3Asr.GetExecutable();

--- a/src/ui/Logic/Config/SeAudioToText.cs
+++ b/src/ui/Logic/Config/SeAudioToText.cs
@@ -43,6 +43,7 @@ public class SeAudioToText
     public string CommandLineParameterCppVulkan { get; set; } = string.Empty;
     public string CommandLineParameterConstMe { get; set; } = string.Empty;
     public string CommandLineParameterCTranslate2 { get; set; } = "--vad_filter True";
+    public string CommandLineParameterWhisperX { get; set; } = string.Empty;
     public string CommandLineParameterPurfviewFasterWhisperXxl { get; set; } = "--standard";
     public string CommandLineParameterOpenAi { get; set; } = string.Empty;
     public string CommandLineParameterQwen3AsrCpp { get; set; } = string.Empty;

--- a/src/ui/Logic/Download/WhisperDownloadService.cs
+++ b/src/ui/Logic/Download/WhisperDownloadService.cs
@@ -16,6 +16,7 @@ public interface IWhisperDownloadService
     Task DownloadWhisperPurfviewFasterWhisperXxl(string destinationFileName, IProgress<float>? progress, CancellationToken cancellationToken);
     Task DownloadWhisperCppVulkan(Stream stream, Progress<float> progress, CancellationToken cancellationToken);
     Task DownloadWhisperCTranslate2(Stream stream, Progress<float> progress, CancellationToken cancellationToken);
+    Task DownloadWhisperX(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
     Task DownloadSileroVad(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
 }
 
@@ -46,7 +47,13 @@ public class WhisperDownloadService : IWhisperDownloadService
     private const string MacArmCTranslate2 = "https://github.com/SubtitleEdit/support-files/releases/download/whispercpp-183/whisper-ctranslate2-mac.zip";
     private const string LinuxCTranslate2 = "https://github.com/SubtitleEdit/support-files/releases/download/whispercpp-183/whisper-ctranslate2-Linux64.zip";
     private const string WindowCTranslate2 = "https://github.com/SubtitleEdit/support-files/releases/download/whispercpp-183/whisper-ctranslate2-win64.zip";
-    
+
+    // "latest" (not a pinned tag) so every release of the standalone build - see
+    // https://github.com/muaz978/subtitleedit-whisperx-standalone - is picked up automatically.
+    private const string MacArmWhisperX = "https://github.com/muaz978/subtitleedit-whisperx-standalone/releases/latest/download/whisperx-standalone-macos-arm64.zip";
+    private const string LinuxWhisperX = "https://github.com/muaz978/subtitleedit-whisperx-standalone/releases/latest/download/whisperx-standalone-linux-x64.zip";
+    private const string WindowsWhisperX = "https://github.com/muaz978/subtitleedit-whisperx-standalone/releases/latest/download/whisperx-standalone-windows-x64.zip";
+
     public WhisperDownloadService(HttpClient httpClient)
     {
         httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(
@@ -107,6 +114,11 @@ public class WhisperDownloadService : IWhisperDownloadService
         await DownloadHelper.DownloadFileAsync(_httpClient, GetUrlTranslate2(), stream, progress, cancellationToken);
     }
 
+    public async Task DownloadWhisperX(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken)
+    {
+        await DownloadHelper.DownloadFileAsync(_httpClient, GetUrlWhisperX(), stream, progress, cancellationToken);
+    }
+
     public async Task DownloadSileroVad(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken)
     {
         await DownloadHelper.DownloadFileAsync(_httpClient, SileroVadUrl, stream, progress, cancellationToken);
@@ -118,15 +130,35 @@ public class WhisperDownloadService : IWhisperDownloadService
         {
             return WindowCTranslate2;
         }
-        
+
         if (OperatingSystem.IsMacOS() && RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
         {
             return MacArmCTranslate2;
         }
-        
+
         if (OperatingSystem.IsLinux() && RuntimeInformation.ProcessArchitecture == Architecture.X64)
         {
             return LinuxCTranslate2;
+        }
+
+        throw new PlatformNotSupportedException();
+    }
+
+    private static string GetUrlWhisperX()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return WindowsWhisperX;
+        }
+
+        if (OperatingSystem.IsMacOS() && RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+        {
+            return MacArmWhisperX;
+        }
+
+        if (OperatingSystem.IsLinux() && RuntimeInformation.ProcessArchitecture == Architecture.X64)
+        {
+            return LinuxWhisperX;
         }
 
         throw new PlatformNotSupportedException();

--- a/src/ui/Logic/Download/WhisperDownloadService.cs
+++ b/src/ui/Logic/Download/WhisperDownloadService.cs
@@ -16,7 +16,7 @@ public interface IWhisperDownloadService
     Task DownloadWhisperPurfviewFasterWhisperXxl(string destinationFileName, IProgress<float>? progress, CancellationToken cancellationToken);
     Task DownloadWhisperCppVulkan(Stream stream, Progress<float> progress, CancellationToken cancellationToken);
     Task DownloadWhisperCTranslate2(Stream stream, Progress<float> progress, CancellationToken cancellationToken);
-    Task DownloadWhisperX(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
+    Task DownloadWhisperX(string destinationFileName, IProgress<float>? progress, CancellationToken cancellationToken);
     Task DownloadSileroVad(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken);
 }
 
@@ -48,11 +48,12 @@ public class WhisperDownloadService : IWhisperDownloadService
     private const string LinuxCTranslate2 = "https://github.com/SubtitleEdit/support-files/releases/download/whispercpp-183/whisper-ctranslate2-Linux64.zip";
     private const string WindowCTranslate2 = "https://github.com/SubtitleEdit/support-files/releases/download/whispercpp-183/whisper-ctranslate2-win64.zip";
 
-    // "latest" (not a pinned tag) so every release of the standalone build - see
-    // https://github.com/muaz978/subtitleedit-whisperx-standalone - is picked up automatically.
-    private const string MacArmWhisperX = "https://github.com/muaz978/subtitleedit-whisperx-standalone/releases/latest/download/whisperx-standalone-macos-arm64.zip";
-    private const string LinuxWhisperX = "https://github.com/muaz978/subtitleedit-whisperx-standalone/releases/latest/download/whisperx-standalone-linux-x64.zip";
-    private const string WindowsWhisperX = "https://github.com/muaz978/subtitleedit-whisperx-standalone/releases/latest/download/whisperx-standalone-windows-x64.zip";
+    // Pinned to a specific release (not "latest"), so every install of a given SE version
+    // gets the exact same, known-good build - see
+    // https://github.com/muaz978/subtitleedit-whisperx-standalone/releases/tag/v1.0.1.
+    private const string MacArmWhisperX = "https://github.com/muaz978/subtitleedit-whisperx-standalone/releases/download/v1.0.1/whisperx-standalone-macos-arm64.zip";
+    private const string LinuxWhisperX = "https://github.com/muaz978/subtitleedit-whisperx-standalone/releases/download/v1.0.1/whisperx-standalone-linux-x64.zip";
+    private const string WindowsWhisperX = "https://github.com/muaz978/subtitleedit-whisperx-standalone/releases/download/v1.0.1/whisperx-standalone-windows-x64.zip";
 
     public WhisperDownloadService(HttpClient httpClient)
     {
@@ -114,9 +115,12 @@ public class WhisperDownloadService : IWhisperDownloadService
         await DownloadHelper.DownloadFileAsync(_httpClient, GetUrlTranslate2(), stream, progress, cancellationToken);
     }
 
-    public async Task DownloadWhisperX(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken)
+    public async Task DownloadWhisperX(string destinationFileName, IProgress<float>? progress, CancellationToken cancellationToken)
     {
-        await DownloadHelper.DownloadFileAsync(_httpClient, GetUrlWhisperX(), stream, progress, cancellationToken);
+        // Downloads straight to a file, like Purfview Faster-Whisper-XXL, instead of the shared
+        // in-memory _downloadStream - at 850 MB-925 MB, buffering this in memory would peak at
+        // 1.5-2 GB before unpacking even starts (MemoryStream's doubling growth).
+        await DownloadHelper.DownloadFileAsync(_httpClient, GetUrlWhisperX(), destinationFileName, progress, cancellationToken);
     }
 
     public async Task DownloadSileroVad(Stream stream, IProgress<float>? progress, CancellationToken cancellationToken)
@@ -148,6 +152,11 @@ public class WhisperDownloadService : IWhisperDownloadService
     {
         if (OperatingSystem.IsWindows())
         {
+            if (RuntimeInformation.ProcessArchitecture != Architecture.X64)
+            {
+                throw new PlatformNotSupportedException("WhisperX standalone build is not available for Windows ARM64.");
+            }
+
             return WindowsWhisperX;
         }
 

--- a/src/ui/Logic/Download/WhisperDownloadService.cs
+++ b/src/ui/Logic/Download/WhisperDownloadService.cs
@@ -48,12 +48,12 @@ public class WhisperDownloadService : IWhisperDownloadService
     private const string LinuxCTranslate2 = "https://github.com/SubtitleEdit/support-files/releases/download/whispercpp-183/whisper-ctranslate2-Linux64.zip";
     private const string WindowCTranslate2 = "https://github.com/SubtitleEdit/support-files/releases/download/whispercpp-183/whisper-ctranslate2-win64.zip";
 
-    // Pinned to a specific release (not "latest"), so every install of a given SE version
-    // gets the exact same, known-good build - see
-    // https://github.com/muaz978/subtitleedit-whisperx-standalone/releases/tag/v1.0.1.
-    private const string MacArmWhisperX = "https://github.com/muaz978/subtitleedit-whisperx-standalone/releases/download/v1.0.1/whisperx-standalone-macos-arm64.zip";
-    private const string LinuxWhisperX = "https://github.com/muaz978/subtitleedit-whisperx-standalone/releases/download/v1.0.1/whisperx-standalone-linux-x64.zip";
-    private const string WindowsWhisperX = "https://github.com/muaz978/subtitleedit-whisperx-standalone/releases/download/v1.0.1/whisperx-standalone-windows-x64.zip";
+    // Built by support-files' build-whisperx-standalone-release.yml from a pinned ref of
+    // https://github.com/muaz978/subtitleedit-whisperx-standalone (v1.0.1), so every install
+    // of a given SE version gets the exact same, known-good build.
+    private const string MacArmWhisperX = "https://github.com/SubtitleEdit/support-files/releases/download/whisperx-standalone-101/whisperx-standalone-macos-arm64.7z";
+    private const string LinuxWhisperX = "https://github.com/SubtitleEdit/support-files/releases/download/whisperx-standalone-101/whisperx-standalone-linux-x64.7z";
+    private const string WindowsWhisperX = "https://github.com/SubtitleEdit/support-files/releases/download/whisperx-standalone-101/whisperx-standalone-windows-x64.7z";
 
     public WhisperDownloadService(HttpClient httpClient)
     {
@@ -118,8 +118,8 @@ public class WhisperDownloadService : IWhisperDownloadService
     public async Task DownloadWhisperX(string destinationFileName, IProgress<float>? progress, CancellationToken cancellationToken)
     {
         // Downloads straight to a file, like Purfview Faster-Whisper-XXL, instead of the shared
-        // in-memory _downloadStream - at 850 MB-925 MB, buffering this in memory would peak at
-        // 1.5-2 GB before unpacking even starts (MemoryStream's doubling growth).
+        // in-memory _downloadStream - at 216 MB-355 MB, buffering this in memory would peak far
+        // higher before unpacking even starts (MemoryStream's doubling growth).
         await DownloadHelper.DownloadFileAsync(_httpClient, GetUrlWhisperX(), destinationFileName, progress, cancellationToken);
     }
 

--- a/tests/UI/Features/Video/SpeechToText/Engines/WhisperEngineWhisperXTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/Engines/WhisperEngineWhisperXTests.cs
@@ -1,0 +1,63 @@
+using System.Linq;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+using Nikse.SubtitleEdit.UiLogic.AudioToText;
+
+namespace UITests.Features.Video.SpeechToText.Engines;
+
+public class WhisperEngineWhisperXTests
+{
+    [Fact]
+    public void FactoryCreatesWhisperXEngine()
+    {
+        var engine = WhisperEngineFactory.MakeEngineFromStaticName(WhisperEngineWhisperX.StaticName);
+
+        Assert.IsType<WhisperEngineWhisperX>(engine);
+        Assert.Equal(WhisperChoice.WhisperX, engine.Choice);
+        Assert.True(engine.CanBeDownloaded());
+    }
+
+    [Fact]
+    public void LanguageCatalogIncludesLanguagesBeyondTheOriginalWhisperXSubset()
+    {
+        var engine = new WhisperEngineWhisperX();
+        var languageCodes = engine.Languages.Select(p => p.Code).ToHashSet();
+
+        Assert.Contains("tr", languageCodes);
+        Assert.Contains("ar", languageCodes);
+        Assert.Contains("ru", languageCodes);
+        Assert.Contains("fa", languageCodes);
+        Assert.True(languageCodes.Count > 50);
+    }
+
+    [Fact]
+    public void ParametersCanSelectReliableMacCpuMode()
+    {
+        var engine = new WhisperEngineWhisperX();
+        var original = engine.CommandLineParameter;
+
+        try
+        {
+            engine.CommandLineParameter = "--device cpu --compute_type int8";
+            Assert.Contains("--device cpu", engine.CommandLineParameter);
+            Assert.Contains("--compute_type int8", engine.CommandLineParameter);
+        }
+        finally
+        {
+            engine.CommandLineParameter = original;
+        }
+    }
+
+    [Fact]
+    public void ExecutableLivesDirectlyInsideTheWhisperXFolder()
+    {
+        // The standalone build's zip is unpacked flat (Unpack(dir, string.Empty)), so the
+        // executable and its "_internal" PyInstaller payload land directly in the engine
+        // folder - same layout as WhisperEngineCTranslate2, not a nested subfolder.
+        var engine = new WhisperEngineWhisperX();
+
+        var executable = engine.GetExecutable();
+        var folder = engine.GetAndCreateWhisperFolder();
+
+        Assert.Equal(folder, System.IO.Path.GetDirectoryName(executable));
+    }
+}


### PR DESCRIPTION
Re-attempt at #14031, which you closed over a fair objection: requiring a Python install plus a managed virtual environment (with pip installs on first run) does not match how every other engine here is packaged, and is a real barrier for non-technical users.

This time WhisperX is packaged as a standalone build with PyInstaller instead, so it downloads and runs exactly like whisper-ctranslate2 or Purfview's Faster-Whisper-XXL: no Python, no pip, nothing for the user to install separately. Source and build scripts are at https://github.com/muaz978/subtitleedit-whisperx-standalone, with its own CI building and smoke-testing the package on Windows, macOS, and Linux on every change, and a v1.0.0 release with the built binaries for each platform.

## What changed here

Modeled on `WhisperEngineCTranslate2` (the closest existing engine: also a downloaded prebuilt binary, same flat-unpack layout), not on the old managed-venv approach:
- `WhisperEngineWhisperX.cs`: `CanBeDownloaded() => true`, points at a downloaded binary, no more Python discovery.
- `WhisperDownloadService.cs` / `DownloadSpeechToTextEngineViewModel.cs`: standard download-and-unpack, same pattern as CTranslate2.
- `SpeechToTextViewModel.cs`: WhisperX shells out to a real ffmpeg binary for audio loading (not bundled in the standalone build), so the process launch now puts Subtitle Edit's own configured ffmpeg on PATH for it, reusing whatever ffmpeg Subtitle Edit already has rather than requiring a separate install.

## Verified

- Full pipeline tested end to end on macOS arm64 with real audio: voice activity detection, transcription, forced alignment (real wav2vec2 model download), and diarization (real pyannote/speaker-diarization-3.1 model, correct speaker-labeled output).
- The standalone build itself builds and smoke-tests clean in CI on all three platforms.
- This repo: `dotnet build` clean, full test suite passing (3560/3560, including new tests for the engine).

## Known gap

Windows and Linux binaries are CI-smoke-tested (proving the frozen binary loads and runs) but I have not personally verified real-speech transcription on those platforms, only macOS. Flagged in the release notes too.
