### PR TITLE
Give Faster-Whisper-XXL, CTranslate2 and Const-me an install record

### DIFF
--- a/src/ui/Features/Ocr/LlamaCppOcrSettingsViewModel.cs
+++ b/src/ui/Features/Ocr/LlamaCppOcrSettingsViewModel.cs
@@ -94,7 +94,11 @@ public partial class LlamaCppOcrSettingsViewModel : ObservableObject
                 EngineBrush = new SolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00)); // amber
                 break;
             default:
-                EngineLabel = Se.Language.General.UnknownNoInstallRecord;
+                // Installed, but nothing identifies the build: an install predating the
+                // .installed.sha256 sidecar, a manual install, or a build older than the ones
+                // SE has hashes for. It still works, so say "Installed" rather than something
+                // that reads as a failed install (#14057).
+                EngineLabel = Se.Language.General.Installed;
                 EngineBrush = new SolidColorBrush(Color.FromRgb(0x9E, 0x9E, 0x9E)); // grey
                 break;
         }

--- a/src/ui/Features/Translate/LlamaCppEngineSettings/LlamaCppEngineSettingsViewModel.cs
+++ b/src/ui/Features/Translate/LlamaCppEngineSettings/LlamaCppEngineSettingsViewModel.cs
@@ -107,7 +107,11 @@ public partial class LlamaCppEngineSettingsViewModel : ObservableObject
                 StatusBrush = new SolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00)); // amber
                 break;
             default:
-                StatusLabel = Se.Language.General.UnknownNoInstallRecord;
+                // Installed, but nothing identifies the build: an install predating the
+                // .installed.sha256 sidecar, a manual install, or a build older than the ones
+                // SE has hashes for. It still works, so say "Installed" rather than something
+                // that reads as a failed install (#14057).
+                StatusLabel = Se.Language.General.Installed;
                 StatusBrush = new SolidColorBrush(Color.FromRgb(0x9E, 0x9E, 0x9E)); // grey
                 break;
         }

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
@@ -167,6 +167,13 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject, ICl
 
                 TitleText = Se.Language.General.Unpacking7ZipArchiveDotDotDot;
                 StartIndeterminateProgress();
+
+                // Record the build before the archive is deleted below. This engine is streamed
+                // to a file rather than to memory (the archive is ~1.5 GB), so it takes the
+                // file overload. Without a sidecar nothing identifies the install and the
+                // engine-settings dialog can only report it as an unrecognized build (#14057).
+                DownloadHashManager.WriteSidecar(dir, DownloadHashManager.ResolvePurfviewFasterWhisperXxlKey(), tempFileName);
+
                 Unpacker.Extract7Zip(tempFileName, dir, "Faster-Whisper-XXL", _cancellationTokenSource, text => ProgressText = text);
                 StopIndeterminateProgress();
 
@@ -200,6 +207,7 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject, ICl
 
                 TitleText = string.Format(Se.Language.General.UnpackingX, Engine.Name);
                 StartIndeterminateProgress();
+                DownloadHashManager.WriteSidecar(dir, DownloadHashManager.ResolveWhisperCTranslate2Key(), _downloadStream);
                 Unpack(dir, string.Empty);
                 StopIndeterminateProgress();
 
@@ -256,6 +264,10 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject, ICl
                 else if (Engine is WhisperEngineCpp or WhisperEngineCppCuBlas or WhisperEngineCppVulkan)
                 {
                     WriteWhisperCppInstalledHash(folder);
+                }
+                else if (Engine is WhisperEngineConstMe)
+                {
+                    DownloadHashManager.WriteSidecar(folder, DownloadHashManager.ResolveWhisperConstMeKey(), _downloadStream);
                 }
                 else if (Engine is Qwen3AsrCppEngine)
                 {

--- a/src/ui/Features/Video/SpeechToText/EngineSettings/SpeechToTextEngineSettingsViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/EngineSettings/SpeechToTextEngineSettingsViewModel.cs
@@ -144,7 +144,11 @@ public partial class SpeechToTextEngineSettingsViewModel : ObservableObject
                 StatusBrush = new SolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00)); // amber
                 break;
             default:
-                StatusLabel = Se.Language.General.UnknownNoInstallRecord;
+                // Installed, but nothing identifies the build: an install predating the
+                // .installed.sha256 sidecar, a manual install, or a build older than the ones
+                // SE has hashes for. It still works, so say "Installed" rather than something
+                // that reads as a failed install (#14057).
+                StatusLabel = Se.Language.General.Installed;
                 StatusBrush = new SolidColorBrush(Color.FromRgb(0x9E, 0x9E, 0x9E)); // grey
                 break;
         }

--- a/src/ui/Features/Video/TextToSpeech/KokoroTtsSettings/KokoroTtsSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/KokoroTtsSettings/KokoroTtsSettingsViewModel.cs
@@ -97,7 +97,11 @@ public partial class KokoroTtsSettingsViewModel : ObservableObject
                 StatusBrush = new SolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00)); // amber
                 break;
             default:
-                StatusLabel = Se.Language.General.UnknownNoInstallRecord;
+                // Installed, but nothing identifies the build: an install predating the
+                // .installed.sha256 sidecar, a manual install, or a build older than the ones
+                // SE has hashes for. It still works, so say "Installed" rather than something
+                // that reads as a failed install (#14057).
+                StatusLabel = Se.Language.General.Installed;
                 StatusBrush = new SolidColorBrush(Color.FromRgb(0x9E, 0x9E, 0x9E)); // grey
                 break;
         }

--- a/src/ui/Features/Video/TextToSpeech/OmniVoiceSettings/OmniVoiceSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/OmniVoiceSettings/OmniVoiceSettingsViewModel.cs
@@ -98,7 +98,11 @@ public partial class OmniVoiceSettingsViewModel : ObservableObject
                 StatusBrush = new SolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00)); // amber
                 break;
             default:
-                StatusLabel = Se.Language.General.UnknownNoInstallRecord;
+                // Installed, but nothing identifies the build: an install predating the
+                // .installed.sha256 sidecar, a manual install, or a build older than the ones
+                // SE has hashes for. It still works, so say "Installed" rather than something
+                // that reads as a failed install (#14057).
+                StatusLabel = Se.Language.General.Installed;
                 StatusBrush = new SolidColorBrush(Color.FromRgb(0x9E, 0x9E, 0x9E)); // grey
                 break;
         }

--- a/src/ui/Features/Video/TextToSpeech/PiperSettings/PiperSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/PiperSettings/PiperSettingsViewModel.cs
@@ -100,7 +100,11 @@ public partial class PiperSettingsViewModel : ObservableObject
                 StatusBrush = new SolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00)); // amber
                 break;
             default:
-                StatusLabel = Se.Language.General.UnknownNoInstallRecord;
+                // Installed, but nothing identifies the build: an install predating the
+                // .installed.sha256 sidecar, a manual install, or a build older than the ones
+                // SE has hashes for. It still works, so say "Installed" rather than something
+                // that reads as a failed install (#14057).
+                StatusLabel = Se.Language.General.Installed;
                 StatusBrush = new SolidColorBrush(Color.FromRgb(0x9E, 0x9E, 0x9E)); // grey
                 break;
         }

--- a/src/ui/Features/Video/TextToSpeech/Qwen3TtsSettings/Qwen3TtsSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/Qwen3TtsSettings/Qwen3TtsSettingsViewModel.cs
@@ -98,7 +98,11 @@ public partial class Qwen3TtsSettingsViewModel : ObservableObject
                 StatusBrush = new SolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00)); // amber
                 break;
             default:
-                StatusLabel = Se.Language.General.UnknownNoInstallRecord;
+                // Installed, but nothing identifies the build: an install predating the
+                // .installed.sha256 sidecar, a manual install, or a build older than the ones
+                // SE has hashes for. It still works, so say "Installed" rather than something
+                // that reads as a failed install (#14057).
+                StatusLabel = Se.Language.General.Installed;
                 StatusBrush = new SolidColorBrush(Color.FromRgb(0x9E, 0x9E, 0x9E)); // grey
                 break;
         }

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -321,6 +321,29 @@ public static class DownloadHashManager
         public const string LinuxCudaExecutable = "WhisperCpp.Linux.Cuda.Executable";
     }
 
+    public static class PurfviewFasterWhisperXxl
+    {
+        // Hashes of the release archive (.7z) — written to the sidecar at install time.
+        // Upstream publishes every build under one rolling "Faster-Whisper-XXL" tag, so it is the
+        // file name pinned in WhisperDownloadService.cs that identifies the release, not the tag.
+        public const string Windows = "PurfviewFasterWhisperXxl.Windows";   // Faster-Whisper-XXL_<rev>_windows.7z
+        public const string Linux = "PurfviewFasterWhisperXxl.Linux";       // Faster-Whisper-XXL_<rev>_linux.7z
+    }
+
+    public static class WhisperCTranslate2
+    {
+        // Hashes of the release archive (.zip) — written to the sidecar at install time.
+        public const string Windows = "WhisperCTranslate2.Windows";         // whisper-ctranslate2-win64.zip
+        public const string MacArm64 = "WhisperCTranslate2.MacArm64";       // whisper-ctranslate2-mac.zip
+        public const string LinuxX64 = "WhisperCTranslate2.Linux.X64";      // whisper-ctranslate2-Linux64.zip
+    }
+
+    public static class WhisperConstMe
+    {
+        // Hash of the release archive (.zip) — written to the sidecar at install time.
+        public const string Windows = "WhisperConstMe.Windows";             // cli.zip (Const-me/Whisper)
+    }
+
     // For each key, hashes are ordered newest-first. Index 0 is the latest known release.
     // All hashes are lower-case hex SHA-256.
     private static readonly IReadOnlyDictionary<string, IReadOnlyList<string>> KnownHashes =
@@ -1985,6 +2008,39 @@ public static class DownloadHashManager
                 "33bad46e07f0d9bb64fc03ca8c7047b212482c1f45536290f80bb0fe716c9775", // whispercpp-185 / v1.8.5 (missing shared libraries)
                 "315f46514fc09a4fefe2f7b6ae95cfac5441a03b8be04eed1b5f567d5ccc38de", // whispercpp-184 / v1.8.4 (missing shared libraries)
             },
+
+            // Purfview Faster-Whisper-XXL — https://github.com/Purfview/whisper-standalone-win/releases
+            // Everything upstream publishes lives under the single rolling "Faster-Whisper-XXL" tag,
+            // so index 0 is the archive whose file name WhisperDownloadService.cs is pinned to.
+            [PurfviewFasterWhisperXxl.Windows] = new[]
+            {
+                "237dee23939cdabfc96ef859fc5e584b842c3a5557e0d2ca744e1f87c14c5844", // r245.4 (current download URL)
+            },
+            [PurfviewFasterWhisperXxl.Linux] = new[]
+            {
+                "510ee48ed73a7d4779fa8a7531437513ae109a76d934e983cbdaea3fc248c4f4", // r245.4 (current download URL)
+            },
+
+            // whisper-ctranslate2 — SE-repackaged builds under
+            // https://github.com/SubtitleEdit/support-files/releases
+            [WhisperCTranslate2.Windows] = new[]
+            {
+                "a076c16b184ee1a8b8c87e7765db77d345a30c504a8e98c77b2cf5b069562ccb", // whispercpp-183 (current download URL)
+            },
+            [WhisperCTranslate2.MacArm64] = new[]
+            {
+                "f1c67d47be9216e9998df53d32a59fdaa0310f3e576fa4d9135aa1d579a71f86", // whispercpp-183 (current download URL)
+            },
+            [WhisperCTranslate2.LinuxX64] = new[]
+            {
+                "02c6c1b738a10b8f72fbd581febbbc4f4e60abe96ad1fab76e1b432e2cce041b", // whispercpp-183 (current download URL)
+            },
+
+            // Const-me/Whisper — https://github.com/Const-me/Whisper/releases
+            [WhisperConstMe.Windows] = new[]
+            {
+                "baa9b70c824e50fe91f1858006a24b870b7637135659f17fc42beb1af57bd447", // 1.12.0 (current download URL)
+            },
         };
 
     /// <summary>
@@ -2081,6 +2137,36 @@ public static class DownloadHashManager
 
             archiveStream.Position = 0;
             var hash = Sha256Util.ComputeSha256(archiveStream);
+
+            var sidecar = Path.Combine(installFolder, ".installed.sha256");
+            File.WriteAllText(sidecar, key + Environment.NewLine + hash);
+        }
+        catch
+        {
+            // ignore — hash side-car is best-effort
+        }
+    }
+
+    /// <summary>
+    /// Writes the <c>.installed.sha256</c> sidecar for a release archive that was downloaded to a
+    /// file instead of to memory — Faster-Whisper-XXL is ~1.5 GB, so it is streamed to disk.
+    /// Same format as the stream overload: hash key on the first line, archive SHA-256 on the
+    /// second. Best-effort — failures are swallowed since the sidecar only powers update detection.
+    /// </summary>
+    public static void WriteSidecar(string installFolder, string? key, string archiveFilePath)
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(key))
+            {
+                return;
+            }
+
+            var hash = Sha256Util.ComputeSha256(archiveFilePath);
+            if (string.IsNullOrEmpty(hash))
+            {
+                return;
+            }
 
             var sidecar = Path.Combine(installFolder, ".installed.sha256");
             File.WriteAllText(sidecar, key + Environment.NewLine + hash);
@@ -2602,6 +2688,60 @@ public static class DownloadHashManager
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Resolves the Purfview Faster-Whisper-XXL archive hash key for the current OS. Mirrors the
+    /// platform rules in <see cref="WhisperDownloadService"/>: Windows x64 and Linux x64 only.
+    /// Returns null elsewhere (macOS and Linux ARM64 have no build to download).
+    /// </summary>
+    public static string? ResolvePurfviewFasterWhisperXxlKey()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return PurfviewFasterWhisperXxl.Windows;
+        }
+
+        if (OperatingSystem.IsLinux() && RuntimeInformation.ProcessArchitecture != Architecture.Arm64)
+        {
+            return PurfviewFasterWhisperXxl.Linux;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Resolves the whisper-ctranslate2 archive hash key for the current OS and architecture.
+    /// Mirrors the platform rules in <see cref="WhisperDownloadService"/>: Windows, macOS ARM64
+    /// and Linux x64 are the only combinations with a download.
+    /// </summary>
+    public static string? ResolveWhisperCTranslate2Key()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return WhisperCTranslate2.Windows;
+        }
+
+        if (OperatingSystem.IsMacOS() && RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+        {
+            return WhisperCTranslate2.MacArm64;
+        }
+
+        if (OperatingSystem.IsLinux() && RuntimeInformation.ProcessArchitecture == Architecture.X64)
+        {
+            return WhisperCTranslate2.LinuxX64;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Resolves the Const-me Whisper archive hash key. Windows-only engine (it is built on
+    /// Direct3D 11), so every other platform returns null.
+    /// </summary>
+    public static string? ResolveWhisperConstMeKey()
+    {
+        return OperatingSystem.IsWindows() ? WhisperConstMe.Windows : null;
     }
 
     /// <summary>

--- a/tests/UI/Logic/Download/SpeechToTextInstallRecordTests.cs
+++ b/tests/UI/Logic/Download/SpeechToTextInstallRecordTests.cs
@@ -1,0 +1,187 @@
+using System;
+using System.IO;
+using Nikse.SubtitleEdit.Logic.Download;
+using Nikse.SubtitleEdit.UiLogic;
+
+namespace UITests.Logic.Download;
+
+/// <summary>
+/// Faster-Whisper-XXL, whisper-ctranslate2 and Const-me Whisper wrote no .installed.sha256
+/// sidecar and had no hashes on file, so however well the install went the engine-settings
+/// dialog had nothing to identify it by and reported every one of them as an unrecognized
+/// build - which reads as a failed install (issue #14057). These tests pin the install record:
+/// the key each engine resolves to on the platform it can be downloaded for, the hash of the
+/// archive that key is pinned to, and the file-based sidecar write Faster-Whisper-XXL needs
+/// because its archive is streamed to disk rather than to memory.
+/// </summary>
+public class SpeechToTextInstallRecordTests
+{
+    // SHA-256 of the archives WhisperDownloadService.cs is pinned to.
+    private const string PurfviewWindows = "237dee23939cdabfc96ef859fc5e584b842c3a5557e0d2ca744e1f87c14c5844";
+    private const string PurfviewLinux = "510ee48ed73a7d4779fa8a7531437513ae109a76d934e983cbdaea3fc248c4f4";
+    private const string CTranslate2Windows = "a076c16b184ee1a8b8c87e7765db77d345a30c504a8e98c77b2cf5b069562ccb";
+    private const string CTranslate2MacArm64 = "f1c67d47be9216e9998df53d32a59fdaa0310f3e576fa4d9135aa1d579a71f86";
+    private const string CTranslate2LinuxX64 = "02c6c1b738a10b8f72fbd581febbbc4f4e60abe96ad1fab76e1b432e2cce041b";
+    private const string ConstMeWindows = "baa9b70c824e50fe91f1858006a24b870b7637135659f17fc42beb1af57bd447";
+
+    [Theory]
+    [InlineData(DownloadHashManager.PurfviewFasterWhisperXxl.Windows, PurfviewWindows)]
+    [InlineData(DownloadHashManager.PurfviewFasterWhisperXxl.Linux, PurfviewLinux)]
+    [InlineData(DownloadHashManager.WhisperCTranslate2.Windows, CTranslate2Windows)]
+    [InlineData(DownloadHashManager.WhisperCTranslate2.MacArm64, CTranslate2MacArm64)]
+    [InlineData(DownloadHashManager.WhisperCTranslate2.LinuxX64, CTranslate2LinuxX64)]
+    [InlineData(DownloadHashManager.WhisperConstMe.Windows, ConstMeWindows)]
+    public void GetStatus_PinnedArchive_IsUpToDate(string key, string hash)
+    {
+        // Index 0 of each list must be the archive the download URL currently points at,
+        // or a fresh install reports "update available" for the build it just downloaded.
+        Assert.Equal(DownloadHashManager.UpdateStatus.UpToDate, DownloadHashManager.GetStatus(key, hash));
+    }
+
+    [Fact]
+    public void ResolvePurfviewFasterWhisperXxlKey_MatchesDownloadablePlatforms()
+    {
+        var key = DownloadHashManager.ResolvePurfviewFasterWhisperXxlKey();
+
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Equal(DownloadHashManager.PurfviewFasterWhisperXxl.Windows, key);
+        }
+        else if (OperatingSystem.IsLinux() && !IsArm64)
+        {
+            Assert.Equal(DownloadHashManager.PurfviewFasterWhisperXxl.Linux, key);
+        }
+        else
+        {
+            // macOS and Linux ARM64 have no Faster-Whisper-XXL build to download.
+            Assert.Null(key);
+        }
+    }
+
+    [Fact]
+    public void ResolveWhisperCTranslate2Key_MatchesDownloadablePlatforms()
+    {
+        var key = DownloadHashManager.ResolveWhisperCTranslate2Key();
+
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Equal(DownloadHashManager.WhisperCTranslate2.Windows, key);
+        }
+        else if (OperatingSystem.IsMacOS() && IsArm64)
+        {
+            Assert.Equal(DownloadHashManager.WhisperCTranslate2.MacArm64, key);
+        }
+        else if (OperatingSystem.IsLinux() && !IsArm64)
+        {
+            Assert.Equal(DownloadHashManager.WhisperCTranslate2.LinuxX64, key);
+        }
+        else
+        {
+            Assert.Null(key);
+        }
+    }
+
+    [Fact]
+    public void ResolveWhisperConstMeKey_IsWindowsOnly()
+    {
+        Assert.Equal(
+            OperatingSystem.IsWindows() ? DownloadHashManager.WhisperConstMe.Windows : null,
+            DownloadHashManager.ResolveWhisperConstMeKey());
+    }
+
+    [Fact]
+    public void EveryEngineKey_HasAtLeastOneKnownHash()
+    {
+        // A key with no hashes behind it resolves fine and still leaves the install
+        // unidentifiable - exactly the state #14057 was about.
+        foreach (var key in new[]
+                 {
+                     DownloadHashManager.PurfviewFasterWhisperXxl.Windows,
+                     DownloadHashManager.PurfviewFasterWhisperXxl.Linux,
+                     DownloadHashManager.WhisperCTranslate2.Windows,
+                     DownloadHashManager.WhisperCTranslate2.MacArm64,
+                     DownloadHashManager.WhisperCTranslate2.LinuxX64,
+                     DownloadHashManager.WhisperConstMe.Windows,
+                 })
+        {
+            Assert.NotEmpty(DownloadHashManager.GetKnownHashes(key));
+        }
+    }
+
+    [Fact]
+    public void WriteSidecar_FromArchiveFile_RecordsKeyAndArchiveHash()
+    {
+        var folder = MakeTempFolder();
+        try
+        {
+            var archive = Path.Combine(folder, "engine.7z");
+            File.WriteAllText(archive, "not really a 7-zip archive");
+            var expectedHash = Sha256Util.ComputeSha256(archive);
+
+            DownloadHashManager.WriteSidecar(folder, DownloadHashManager.PurfviewFasterWhisperXxl.Windows, archive);
+
+            var sidecar = DownloadHashManager.TryReadSidecar(folder);
+            Assert.NotNull(sidecar);
+            Assert.Equal(DownloadHashManager.PurfviewFasterWhisperXxl.Windows, sidecar!.Value.Key);
+            Assert.Equal(expectedHash, sidecar.Value.Hash);
+        }
+        finally
+        {
+            Directory.Delete(folder, true);
+        }
+    }
+
+    [Fact]
+    public void WriteSidecar_FromArchiveFile_KnownHashReadsAsUpToDate()
+    {
+        // The whole point of the sidecar: it survives the archive being deleted after unpacking,
+        // and the engine-settings dialog reads the status straight back out of it.
+        var folder = MakeTempFolder();
+        try
+        {
+            var archive = Path.Combine(folder, "engine.zip");
+            File.WriteAllText(archive, "cli.zip stand-in");
+            File.WriteAllText(
+                Path.Combine(folder, ".installed.sha256"),
+                DownloadHashManager.WhisperConstMe.Windows + Environment.NewLine + ConstMeWindows);
+
+            Assert.Equal(DownloadHashManager.UpdateStatus.UpToDate, DownloadHashManager.GetSidecarStatus(folder));
+        }
+        finally
+        {
+            Directory.Delete(folder, true);
+        }
+    }
+
+    [Fact]
+    public void WriteSidecar_MissingArchiveOrNoKey_WritesNothing()
+    {
+        var folder = MakeTempFolder();
+        try
+        {
+            DownloadHashManager.WriteSidecar(folder, DownloadHashManager.PurfviewFasterWhisperXxl.Windows,
+                Path.Combine(folder, "does-not-exist.7z"));
+            Assert.Null(DownloadHashManager.TryReadSidecar(folder));
+
+            var archive = Path.Combine(folder, "engine.7z");
+            File.WriteAllText(archive, "x");
+            DownloadHashManager.WriteSidecar(folder, null, archive);
+            Assert.Null(DownloadHashManager.TryReadSidecar(folder));
+        }
+        finally
+        {
+            Directory.Delete(folder, true);
+        }
+    }
+
+    private static bool IsArm64 =>
+        System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture ==
+        System.Runtime.InteropServices.Architecture.Arm64;
+
+    private static string MakeTempFolder()
+    {
+        var folder = Path.Combine(Path.GetTempPath(), "se-install-record-" + Path.GetRandomFileName());
+        Directory.CreateDirectory(folder);
+        return folder;
+    }
+}


### PR DESCRIPTION
Fixes #14057.

### What the reporter saw

The Speech-to-text engine settings dialog showed **"Unknown (no install record)"** for Purfview Faster Whisper XXL after every install attempt, which reads as "the install failed".

The install was fine — the same dialog's button said "Re-download…", which only happens when `IsEngineInstalled()` finds `faster-whisper-xxl.exe`. The status row is a *version* check, not an install check, and for this engine it could never succeed:

* the Faster-Whisper-XXL install branch downloads its ~1.5 GB `.7z` to a file and extracts it — it never wrote a `.installed.sha256` sidecar (only CrispASR, whisper.cpp and qwen3-asr.cpp did), and
* `ResolveWhisperCppExecutableKey` only maps the three whisper.cpp choices, so the executable-hash fallback returned null too.

Both paths dead → `UpdateStatus.Unknown` → grey "Unknown (no install record)", forever, on every machine. whisper-ctranslate2 and Const-me Whisper were in the same state.

### Changes

* **Sidecar at install time** for Faster-Whisper-XXL, whisper-ctranslate2 and Const-me. Faster-Whisper-XXL streams its archive to disk rather than to memory, so `DownloadHashManager.WriteSidecar` gets a file-path overload next to the stream one; it is written before the archive is deleted.
* **Hashes for the pinned archives**, so a fresh install now reports "Up to date" and a superseded one can offer an update. All six were computed from the exact URLs `WhisperDownloadService.cs` is pinned to; the three whisper-ctranslate2 hashes match GitHub's own asset digests.
* **"Installed" instead of "Unknown (no install record)"** when an engine is installed but nothing identifies the build — a pre-sidecar install, a manual install, or a build older than the ones SE has hashes for. The engine is installed and works; SE just cannot tell which build it is. Applied in the TTS, translate and OCR engine-settings dialogs too, where a pre-sidecar install hit the same wording.
* Tests pinning the resolvers, the archive hashes and the file-based sidecar write.

Note for whoever bumps the Faster-Whisper-XXL pin next: upstream publishes everything under one rolling `Faster-Whisper-XXL` tag, so index 0 of each hash list must be re-pinned along with the file name in the URL.

Not done here: an executable-hash fallback (as whisper.cpp has) that would let *existing* installs be identified without a re-download. That means hashing a very large exe on dialog open, and for these engines a re-download is 1.5 GB, so it did not seem worth it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)