### PR TITLE
Stop a leaked frame-mode flag failing an unrelated test later in the run

### DIFF
--- a/tests/UI/Features/Main/SubMillisecondTimeTests.cs
+++ b/tests/UI/Features/Main/SubMillisecondTimeTests.cs
@@ -40,6 +40,13 @@ public class SubMillisecondTimeTests
         using var _ = new SettingsScope("General.UseFrameMode");
         Se.Settings.General.UseFrameMode = false;
 
+        // ToDisplayString below reads libse's own mirror of this flag, not the SE 5 setting,
+        // and the mirror is shared by the whole run - so pin it here too rather than
+        // inheriting whatever the last test to sync it left behind. Without this the
+        // assertion reads "00:11:23:12" (frames) in a test that has nothing to do with frame
+        // mode. The scope restores both sides.
+        Configuration.Settings.General.UseTimeFormatHHMMSSFF = false;
+
         var line = Line(682_700, 683_200);
 
         var upDown = new SecondsUpDown { DataContext = line };

--- a/tests/UI/Features/Main/WaveformDragDurationBoxTests.cs
+++ b/tests/UI/Features/Main/WaveformDragDurationBoxTests.cs
@@ -94,7 +94,7 @@ public class WaveformDragDurationBoxTests : IDisposable
         }
 
         vm.SelectedSubtitle = vm.Subtitles[0];
-        var av = vm.AudioVisualizer;
+        var av = vm.AudioVisualizer!;
         av.WavePeaks = MakePeaks(126, 60);
         av.SetPosition(0, vm.Subtitles, 0, 0, new List<SubtitleLineViewModel> { vm.Subtitles[0] });
         Settle(window);

--- a/tests/UI/SettingsScope.cs
+++ b/tests/UI/SettingsScope.cs
@@ -1,3 +1,4 @@
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Logic.Config;
 using System.Reflection;
 
@@ -20,12 +21,33 @@ internal sealed class SettingsScope : IDisposable
 {
     private readonly List<(PropertyInfo Property, object Owner, object? Value)> _saved = new();
 
+    /// <summary>
+    /// Some of Se.Settings is mirrored into libse's own <see cref="Configuration.Settings"/>
+    /// singleton by <c>Se.UpdateLibSeSettings</c>, and the copy is one-way. Restoring the SE 5
+    /// property therefore is not enough: if anything ran that sync while the scope held a changed
+    /// value, the mirror keeps the changed one for the rest of the run. Test collections do not
+    /// run in parallel here, so this is not a race - it is plain ordering, which is why it shows
+    /// up as a suite that passes alone and fails in a different order.
+    ///
+    /// UseFrameMode is the mirror that bites, because TimeCode.ToDisplayString reads the libse
+    /// side: a leak turns every later "00:11:23.520" assertion into "00:11:23:12" in a test that
+    /// never mentions frames. Snapshot and restore both sides together.
+    /// </summary>
+    private readonly bool _libSeUseTimeFormatHhMmSsFf;
+    private readonly bool _restoreLibSeTimeFormat;
+
     internal SettingsScope(params string[] paths)
     {
         foreach (var path in paths)
         {
             var (owner, property) = Resolve(path);
             _saved.Add((property, owner, property.GetValue(owner)));
+        }
+
+        _restoreLibSeTimeFormat = paths.Contains("General.UseFrameMode");
+        if (_restoreLibSeTimeFormat)
+        {
+            _libSeUseTimeFormatHhMmSsFf = Configuration.Settings.General.UseTimeFormatHHMMSSFF;
         }
     }
 
@@ -36,6 +58,11 @@ internal sealed class SettingsScope : IDisposable
         {
             var (property, owner, value) = _saved[i];
             property.SetValue(owner, value);
+        }
+
+        if (_restoreLibSeTimeFormat)
+        {
+            Configuration.Settings.General.UseTimeFormatHHMMSSFF = _libSeUseTimeFormatHhMmSsFf;
         }
     }
 

--- a/tests/UI/SettingsScopeLibSeMirrorTests.cs
+++ b/tests/UI/SettingsScopeLibSeMirrorTests.cs
@@ -1,0 +1,72 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests;
+
+/// <summary>
+/// SettingsScope has to put libse's mirror of a setting back, not just the SE 5 property.
+///
+/// Se.UpdateLibSeSettings copies part of Se.Settings into libse's own Configuration singleton,
+/// one way. So a test that changes a mirrored setting inside a scope, and runs that sync while
+/// the scope is open, leaves the mirror holding the changed value for the rest of the run - the
+/// scope restores the SE 5 side and nothing restores libse's.
+///
+/// UseFrameMode is the one that bites: TimeCode.ToDisplayString reads the libse flag, so the leak
+/// surfaces much later as a time-format assertion failing in a test that never mentions frames
+/// ("00:11:23:12" where "00:11:23.520" was expected) - a ~40%-of-runs flake locally before this
+/// was fixed. A single failure is enough to matter: CI retries the whole suite on any failure,
+/// and it is the retry that has twice collapsed into hundreds of teardown errors.
+/// </summary>
+public class SettingsScopeLibSeMirrorTests
+{
+    [Fact]
+    public void Dispose_RestoresTheLibSeMirror_NotJustTheSe5Setting()
+    {
+        var originalSe5 = Se.Settings.General.UseFrameMode;
+        var originalLibSe = Configuration.Settings.General.UseTimeFormatHHMMSSFF;
+        try
+        {
+            Se.Settings.General.UseFrameMode = false;
+            Configuration.Settings.General.UseTimeFormatHHMMSSFF = false;
+
+            using (var _ = new SettingsScope("General.UseFrameMode"))
+            {
+                Se.Settings.General.UseFrameMode = true;
+
+                // What Se.UpdateLibSeSettings does to the shared mirror while the scope is open.
+                Configuration.Settings.General.UseTimeFormatHHMMSSFF = Se.Settings.General.UseFrameMode;
+            }
+
+            Assert.False(Se.Settings.General.UseFrameMode);
+            Assert.False(Configuration.Settings.General.UseTimeFormatHHMMSSFF);
+        }
+        finally
+        {
+            Se.Settings.General.UseFrameMode = originalSe5;
+            Configuration.Settings.General.UseTimeFormatHHMMSSFF = originalLibSe;
+        }
+    }
+
+    [Fact]
+    public void Dispose_LeavesTheMirrorAlone_WhenFrameModeWasNotScoped()
+    {
+        var original = Configuration.Settings.General.UseTimeFormatHHMMSSFF;
+        try
+        {
+            Configuration.Settings.General.UseTimeFormatHHMMSSFF = true;
+
+            using (var _ = new SettingsScope("General.MaxNumberOfLines"))
+            {
+                Se.Settings.General.MaxNumberOfLines = 3;
+            }
+
+            // Only the scoped setting's mirror is managed; an unrelated scope must not reach
+            // across and rewrite libse state it never captured.
+            Assert.True(Configuration.Settings.General.UseTimeFormatHHMMSSFF);
+        }
+        finally
+        {
+            Configuration.Settings.General.UseTimeFormatHHMMSSFF = original;
+        }
+    }
+}


### PR DESCRIPTION
The UI suite has been failing about **two runs in five** locally, on a different test each time, which read as the headless session falling over. It isn't. One test was failing for a real reason, and **CI retries the whole suite on any failure — it is the retry that has twice collapsed into hundreds of teardown errors**. Fix the one real failure and the dramatic one goes away with it.

## The real failure

The signature names its own cause:

```
Expected: "00:11:23.520"
Actual:   "00:11:23:12"
```

Frames where milliseconds were expected, in `SubMillisecondTimeTests` — a test that never mentions frame mode.

It scopes SE 5's `Se.Settings.General.UseFrameMode`, but the assertion goes through `TimeCode.ToDisplayString()`, which reads a *different* global: libse's `Configuration.Settings.General.UseTimeFormatHHMMSSFF` ([TimeCode.cs:477](../blob/main/src/libse/Common/TimeCode.cs#L477)). `Se.UpdateLibSeSettings` copies the first into the second, **one way**.

So a test that changes `UseFrameMode` inside a scope and runs that sync leaves the libse mirror on frames for the rest of the run: the scope restores the SE 5 side, and nothing restores libse's. Test collections do not run in parallel here, so this is not a race — it is plain ordering, which is why it presents as "passes alone, fails in a different order". `WebVttPropertiesTests` already documents the hazard in a comment; `SettingsScope` just never handled it.

## The fix

Fixed where the leak is: `SettingsScope` now snapshots and restores **both** sides when `General.UseFrameMode` is scoped, so ordering stops mattering for it. The affected test also pins the flag it actually asserts on, rather than inheriting whatever the last test to sync it left behind.

`SettingsScopeLibSeMirrorTests` covers the invariant, and was checked both ways — reverting the `SettingsScope` change makes it fail on the restored mirror, exactly as intended.

## Verification

Repetition, since this is a flake and a single green run proves nothing:

- **Before**: 2 failures in 5 full-suite runs (~40%)
- **After**: 8 consecutive green full-suite runs
- The new invariant test fails without the fix and passes with it

## What this does *not* fix

Worth stating plainly: the failure that took CI down earlier was `TextBoxShiftDeleteCutTests.ShiftBack_DeletesForward_InsteadOfBackspacing` — a key press doing nothing at all — which this does not explain. It did not reproduce in 15 isolated runs of that class. Two theories are already ruled out: nothing else defaults to `Shift+Back`, and only two test files touch the shared shortcut list. It is a second order-dependent flake in the same family (shared global state across a sequential run), still unexplained.

Also silences a `CS8602` that arrived with a recent merge, keeping the build at zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)