### PR TITLE
Stop the EBU STL save options from being thrown away

### DIFF
--- a/src/libse/SubtitleFormats/Ebu.cs
+++ b/src/libse/SubtitleFormats/Ebu.cs
@@ -970,12 +970,15 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         /// <summary>
         /// True when <paramref name="header"/> is a full 1024-character EBU STL header - present after
         /// loading an STL file or after the EBU save options dialog has stored one on the subtitle.
+        /// The disk format code sits at 3..10 ("STLnn.mm") and is matched there rather than by
+        /// listing frame rates, so every rate the save options dialog offers is recognized (STL23
+        /// used to fall through, which threw the whole header away on save).
         /// </summary>
         public static bool IsStlHeader(string header)
         {
             return header != null &&
                    header.Length == 1024 &&
-                   (header.Contains("STL24") || header.Contains("STL25") || header.Contains("STL29") || header.Contains("STL30"));
+                   header.Substring(3, 3) == "STL";
         }
 
         public bool Save(string fileName, Subtitle subtitle)

--- a/src/ui/Features/Files/ExportEbuStl/ExportEbuStlViewModel.cs
+++ b/src/ui/Features/Files/ExportEbuStl/ExportEbuStlViewModel.cs
@@ -356,17 +356,18 @@ new("2F", "French - hearing impaired (VF-MAL)"),
             _header.LanguageCode = "0A";
         }
 
-        _header.OriginalProgrammeTitle = OriginalProgramTitle.PadRight(32, ' ');
-        _header.OriginalEpisodeTitle = OriginalEpisodeTitle.PadRight(32, ' ');
-        _header.TranslatedProgrammeTitle = TranslatedProgramTitle.PadRight(32, ' ');
-        _header.TranslatedEpisodeTitle = TranslatedEpisodeTitle.PadRight(32, ' ');
-        _header.TranslatorsName = TranslatorsName.PadRight(32, ' ');
-        _header.SubtitleListReferenceCode = SubtitleListReferenceCode.PadRight(16, ' ');
-        _header.CountryOfOrigin = CountryOfOrigin;
-        if (_header.CountryOfOrigin.Length != 3)
-        {
-            _header.CountryOfOrigin = "USA";
-        }
+        _header.OriginalProgrammeTitle = FixedLength(OriginalProgramTitle, 32);
+        _header.OriginalEpisodeTitle = FixedLength(OriginalEpisodeTitle, 32);
+        _header.TranslatedProgrammeTitle = FixedLength(TranslatedProgramTitle, 32);
+        _header.TranslatedEpisodeTitle = FixedLength(TranslatedEpisodeTitle, 32);
+        _header.TranslatorsName = FixedLength(TranslatorsName, 32);
+        _header.SubtitleListReferenceCode = FixedLength(SubtitleListReferenceCode, 16);
+        // The country of origin is a three-character ISO 3166 code. Keep what the user typed - a
+        // shorter code padded out is closer to the truth than silently claiming "USA" - but keep
+        // the old default for a field nobody filled in.
+        _header.CountryOfOrigin = string.IsNullOrWhiteSpace(CountryOfOrigin)
+            ? "USA"
+            : FixedLength(CountryOfOrigin, 3);
 
         var timeCodeStatus = SelectedTimeCodeStatus ?? TimeCodeStatusList.Last();
         _header.TimeCodeStatus = TimeCodeStatusList.IndexOf(timeCodeStatus).ToString(CultureInfo.InvariantCulture);
@@ -387,11 +388,34 @@ new("2F", "French - hearing impaired (VF-MAL)"),
 
         if (_subtitle != null)
         {
-            _subtitle.Header = _header.ToString();
+            // EbuGeneralSubtitleInformation.ToString() reports a wrong total length by returning an
+            // error message instead of a header, and Ebu.Save silently falls back to its own
+            // defaults ("No Title"/USA/no start time) for anything that is not a real STL header -
+            // so a header that did not come out right must be caught here, not written on.
+            var headerText = _header.ToString();
+            if (Ebu.IsStlHeader(headerText))
+            {
+                _subtitle.Header = headerText;
+            }
+            else
+            {
+                SeLogger.Error("Unable to build an EBU STL header from the save options: " + headerText);
+            }
         }
 
         OkPressed = true;
         Close();
+    }
+
+    /// <summary>
+    /// EBU STL header fields are fixed-width: too short and the header loses its layout, too long
+    /// and it grows past 1024 characters and is thrown away entirely (the text boxes cap the input
+    /// too, this is the last line of defence).
+    /// </summary>
+    private static string FixedLength(string text, int length)
+    {
+        text ??= string.Empty;
+        return text.Length > length ? text.Substring(0, length) : text.PadRight(length, ' ');
     }
 
     [RelayCommand]

--- a/src/ui/Features/Files/ExportEbuStl/ExportEbuStlViewModel.cs
+++ b/src/ui/Features/Files/ExportEbuStl/ExportEbuStlViewModel.cs
@@ -6,6 +6,7 @@ using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Features.Files.ExportEbuStl;
+using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
 using System;
@@ -73,6 +74,12 @@ public partial class ExportEbuStlViewModel : ObservableObject
     public Subtitle Subtitle => _subtitle;
     public int? PacCodePage { get; private set; }
     public byte JustificationCode { get; private set; }
+
+    /// <summary>The header the dialog stored on the subtitle, or null when it could not build one.</summary>
+    public string? StoredHeader { get; private set; }
+
+    /// <summary>The frame rate picked in the dialog - it does not fit in the stored header.</summary>
+    public double FrameRateFromSaveDialog => _header.FrameRateFromSaveDialog;
 
     private IFileHelper _fileHelper;
     private Subtitle _subtitle = new Subtitle();
@@ -298,6 +305,15 @@ new("2F", "French - hearing impaired (VF-MAL)"),
                 {
                     var encoding = Ebu.GetEncoding(_subtitle.Header.Substring(0, 3));
                     _header = Ebu.ReadHeader(encoding.GetBytes(_subtitle.Header));
+
+                    // The frame rate is not part of the header bytes, so a rate picked earlier for
+                    // this very header only survives on the save helper.
+                    if (Ebu.EbuUiHelper is UiEbuSaveHelper saveHelper &&
+                        saveHelper.TryGetFrameRate(_subtitle.Header, out var frameRate))
+                    {
+                        _header.FrameRateFromSaveDialog = frameRate;
+                    }
+
                     FillFromHeader(_header);
                 }
                 catch (Exception exception)
@@ -324,8 +340,12 @@ new("2F", "French - hearing impaired (VF-MAL)"),
 
         _header.DiskFormatCode = SelectedDiskFormatCode?.Substring(0, 8) ?? "STL25.01";
 
-        double d = 25.0;
-        if (SelectedFrameRate != null && double.TryParse(SelectedFrameRate.Replace(CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator, "."), out d) && d > 20 && d < 200)
+        // The frame rate list is written with invariant decimal points ("23.976"), so it has to be
+        // read back that way: parsing "23.976" in a comma-decimal culture gives 23976, which fails
+        // the range check below and silently left the rate at whatever it was.
+        if (SelectedFrameRate != null &&
+            double.TryParse(SelectedFrameRate, NumberStyles.Any, CultureInfo.InvariantCulture, out var d) &&
+            d > 20 && d < 200)
         {
             _header.FrameRateFromSaveDialog = d;
         }
@@ -396,6 +416,7 @@ new("2F", "French - hearing impaired (VF-MAL)"),
             if (Ebu.IsStlHeader(headerText))
             {
                 _subtitle.Header = headerText;
+                StoredHeader = headerText;
             }
             else
             {
@@ -405,6 +426,29 @@ new("2F", "French - hearing impaired (VF-MAL)"),
 
         OkPressed = true;
         Close();
+    }
+
+    /// <summary>
+    /// Picks the closest entry in the frame rate list - the disk format codes only carry whole
+    /// frame rates (STL23/STL29), while the list offers the fractional rates they stand for.
+    /// </summary>
+    private void SelectFrameRate(double frameRate)
+    {
+        if (frameRate <= 20 || frameRate >= 200)
+        {
+            return;
+        }
+
+        var closest = FrameRates
+            .Select(p => new { Text = p, Value = double.TryParse(p, NumberStyles.Any, CultureInfo.InvariantCulture, out var v) ? v : 0 })
+            .Where(p => p.Value > 0)
+            .OrderBy(p => Math.Abs(p.Value - frameRate))
+            .FirstOrDefault();
+
+        if (closest != null)
+        {
+            SelectedFrameRate = closest.Text;
+        }
     }
 
     /// <summary>
@@ -468,10 +512,10 @@ new("2F", "French - hearing impaired (VF-MAL)"),
         SelectedDiskFormatCode = DiskFormatCodes.FirstOrDefault(p => p.Contains(header.DiskFormatCode, StringComparison.OrdinalIgnoreCase))
                                  ?? SelectedDiskFormatCode;
 
-        if (header.FrameRateFromSaveDialog is > 20 and < 200)
-        {
-            SelectedFrameRate = header.FrameRateFromSaveDialog.ToString(CultureInfo.CurrentCulture);
-        }
+        // header.FrameRate falls back to the rate the disk format code implies, so an STL30 file
+        // opens on 30 instead of the 25 the dialog defaults to. Match against the list by value:
+        // the entries are invariant ("29.97") while ToString() here would follow the UI culture.
+        SelectFrameRate(header.FrameRate);
 
         SelectedDisplayStandardCode = DisplayStandardCodes.FirstOrDefault(p => p.StartsWith(header.DisplayStandardCode, StringComparison.InvariantCulture))
                                       ?? SelectedDisplayStandardCode;

--- a/src/ui/Features/Files/ExportEbuStl/ExportEbuStlWindow.cs
+++ b/src/ui/Features/Files/ExportEbuStl/ExportEbuStlWindow.cs
@@ -128,18 +128,23 @@ public class ExportEbuStlWindow : Window
 
         var labelOriginalProgramTitle = UiUtil.MakeLabel(Se.Language.File.EbuSaveOptions.OriginalProgramTitle);
         var textBoxOriginalProgramTitle = UiUtil.MakeTextBox(textBoxWidth, vm, nameof(vm.OriginalProgramTitle));
+        textBoxOriginalProgramTitle.MaxLength = 32; // EBU STL header field width
 
         var labelOriginalEpisodeTitle = UiUtil.MakeLabel(Se.Language.File.EbuSaveOptions.OriginalEpisodeTitle);
         var textBoxOriginalEpisodeTitle = UiUtil.MakeTextBox(textBoxWidth, vm, nameof(vm.OriginalEpisodeTitle));
+        textBoxOriginalEpisodeTitle.MaxLength = 32; // EBU STL header field width
 
         var labelTranslatedProgramTitle = UiUtil.MakeLabel(Se.Language.File.EbuSaveOptions.TranslatedProgramTitle);
         var textBoxTranslatedProgramTitle = UiUtil.MakeTextBox(textBoxWidth, vm, nameof(vm.TranslatedProgramTitle));
+        textBoxTranslatedProgramTitle.MaxLength = 32; // EBU STL header field width
 
         var labelTranslatedEpisodeTitle = UiUtil.MakeLabel(Se.Language.File.EbuSaveOptions.TranslatedEpisodeTitle);
         var textBoxTranslatedEpisodeTitle = UiUtil.MakeTextBox(textBoxWidth, vm, nameof(vm.TranslatedEpisodeTitle));
+        textBoxTranslatedEpisodeTitle.MaxLength = 32; // EBU STL header field width
 
         var labelTranslatorsName = UiUtil.MakeLabel(Se.Language.File.EbuSaveOptions.TranslatorsName);
         var textBoxTranslatorsName = UiUtil.MakeTextBox(textBoxWidth, vm, nameof(vm.TranslatorsName));
+        textBoxTranslatorsName.MaxLength = 32; // EBU STL header field width
 
         grid.Add(labelCodePageNumber, 0, 0);
         grid.Add(comboBoxCodeNumbers, 0, 1);
@@ -177,9 +182,11 @@ public class ExportEbuStlWindow : Window
 
         var labelSubtitleListReferenceCode = UiUtil.MakeLabel(Se.Language.File.EbuSaveOptions.SubtitleListReferenceCode);
         var textBoxSubtitleListReferenceCode = UiUtil.MakeTextBox(textBoxWidth, vm, nameof(vm.SubtitleListReferenceCode));
+        textBoxSubtitleListReferenceCode.MaxLength = 16; // EBU STL header field width
 
         var labelCountryOfOrigin = UiUtil.MakeLabel(Se.Language.File.EbuSaveOptions.CountryOfOrigin);
         var textBoxCountryOfOrigin = UiUtil.MakeTextBox(textBoxWidth, vm, nameof(vm.CountryOfOrigin));
+        textBoxCountryOfOrigin.MaxLength = 3; // EBU STL header field width
 
         var labelTimeCodeStatus = UiUtil.MakeLabel(Se.Language.File.EbuSaveOptions.TimeCodeStatus);
         var comboBoxTimeCodeStatus = UiUtil.MakeComboBox(vm.TimeCodeStatusList, vm, nameof(vm.SelectedTimeCodeStatus)).WithMinWidth(textBoxWidth);

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -4455,10 +4455,16 @@ public partial class MainViewModel :
             return false;
         }
 
-        // The justification combo box is the one option that does not live in the header - it is
-        // written per text block, from the UI helper.
+        // Justification and frame rate are the two options that do not live in the header - the
+        // first is written per text block, the second is lost when the writer re-reads the header
+        // off the subtitle. Both ride along on the UI helper.
         Ebu.EbuUiHelper ??= new UiEbuSaveHelper();
         Ebu.EbuUiHelper.JustificationCode = result.JustificationCode;
+        if (Ebu.EbuUiHelper is UiEbuSaveHelper saveHelper)
+        {
+            saveHelper.SetFrameRate(result.StoredHeader, result.FrameRateFromSaveDialog);
+        }
+
         return true;
     }
 

--- a/src/ui/Logic/UiEbuSaveHelper.cs
+++ b/src/ui/Logic/UiEbuSaveHelper.cs
@@ -1,19 +1,56 @@
-﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 
 namespace Nikse.SubtitleEdit.Logic;
  
+/// <summary>
+/// Carries the EBU STL save options that do not fit in the 1024-character GSI header from the
+/// options dialog to <see cref="Ebu.Save(string,Subtitle)"/>. SE 4 could do without this because
+/// the dialog itself was the save helper and wrote straight into the header object being saved;
+/// here the dialog closes long before the save runs, so the leftovers are parked on the helper and
+/// put back when the writer initializes.
+/// </summary>
 public class UiEbuSaveHelper : Ebu.IEbuUiHelper
 {
     private byte _justificationCode = 2;
+    private string? _frameRateHeader;
+    private double _frameRate;
 
     public UiEbuSaveHelper()
     {
     }
 
+    /// <summary>
+    /// Remembers the frame rate picked in the save options dialog. It is tied to the header the
+    /// dialog produced, so it is applied to that subtitle only - saving some other file must keep
+    /// using the rate its own disk format code implies.
+    /// </summary>
+    public void SetFrameRate(string? header, double frameRate)
+    {
+        _frameRateHeader = header;
+        _frameRate = frameRate;
+    }
+
+    /// <summary>
+    /// The frame rate last picked for <paramref name="header"/>, if any - the options dialog uses it
+    /// to show the rate the user chose rather than the one the disk format code implies.
+    /// </summary>
+    public bool TryGetFrameRate(string? header, out double frameRate)
+    {
+        frameRate = _frameRate;
+        return _frameRate > 20 && header != null && header == _frameRateHeader;
+    }
+
     public void Initialize(Ebu.EbuGeneralSubtitleInformation header, byte justificationCode, string fileName, Subtitle subtitle)
     {
         _justificationCode = justificationCode;
+
+        // The frame rate is not part of the header bytes, so the writer has just lost it while
+        // re-reading the header off the subtitle - put it back.
+        if (header != null && TryGetFrameRate(subtitle?.Header, out var frameRate))
+        {
+            header.FrameRateFromSaveDialog = frameRate;
+        }
     }
 
     public bool ShowDialogOk()

--- a/tests/UI/Features/Files/ExportEbuStlHeaderTests.cs
+++ b/tests/UI/Features/Files/ExportEbuStlHeaderTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text;
 using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
@@ -33,8 +34,16 @@ public class ExportEbuStlHeaderTests
 
     private static byte[] SaveViaDialog(Action<ExportEbuStlViewModel> fillIn)
     {
+        return SaveViaDialog(MakeSubtitle(), fillIn);
+    }
+
+    /// <summary>
+    /// Runs the options dialog the way the main window does - fill in, OK, hand the leftovers to
+    /// the save helper - and saves the subtitle it worked on.
+    /// </summary>
+    private static byte[] SaveViaDialog(Subtitle subtitle, Action<ExportEbuStlViewModel> fillIn)
+    {
         var viewModel = new ExportEbuStlViewModel(new FileHelper());
-        var subtitle = MakeSubtitle();
         viewModel.Initialize(subtitle);
         Dispatcher.UIThread.RunJobs();
 
@@ -42,7 +51,15 @@ public class ExportEbuStlHeaderTests
         viewModel.OkCommand.Execute(null);
         Dispatcher.UIThread.RunJobs();
 
-        Ebu.EbuUiHelper ??= new UiEbuSaveHelper();
+        var helper = new UiEbuSaveHelper { JustificationCode = viewModel.JustificationCode };
+        helper.SetFrameRate(viewModel.StoredHeader, viewModel.FrameRateFromSaveDialog);
+        Ebu.EbuUiHelper = helper;
+
+        return Save(subtitle);
+    }
+
+    private static byte[] Save(Subtitle subtitle)
+    {
         var fileName = Path.Combine(Path.GetTempPath(), "ebu-header-test-" + Guid.NewGuid() + ".stl");
         try
         {
@@ -56,6 +73,12 @@ public class ExportEbuStlHeaderTests
                 File.Delete(fileName);
             }
         }
+    }
+
+    // TTI block 0 starts right after the 1024-byte header; the in-cue time code sits at 5..8.
+    private static string InCueTimeCode(byte[] bytes)
+    {
+        return $"{bytes[1024 + 5]:00}:{bytes[1024 + 6]:00}:{bytes[1024 + 7]:00}:{bytes[1024 + 8]:00}";
     }
 
     private static string Field(byte[] bytes, int index, int length)
@@ -138,5 +161,99 @@ public class ExportEbuStlHeaderTests
         var bytes = SaveViaDialog(vm => { vm.OriginalProgramTitle = "My film"; });
 
         Assert.Equal("USA", Field(bytes, 274, 3));
+    }
+
+    // The frame rate is the one save option that is not part of the 1024-character header, so it
+    // was lost when the writer re-read the header off the subtitle and every file came out with
+    // the rate its disk format code implies.
+    [AvaloniaTheory]
+    [InlineData("23.976", "00:00:01:23")]
+    [InlineData("25", "00:00:01:24")]
+    public void PickedFrameRate_DecidesTheTimeCodeFrames(string frameRate, string expected)
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Hello world", 1960, 3000));
+
+        var bytes = SaveViaDialog(subtitle, vm =>
+        {
+            vm.SelectedFrameRate = frameRate;
+            vm.OriginalProgramTitle = "My film";
+        });
+
+        Assert.Equal(expected, InCueTimeCode(bytes));
+    }
+
+    // ...but it may not leak to the next file: that one keeps the rate its own header implies.
+    [AvaloniaFact]
+    public void PickedFrameRate_DoesNotLeakToAnotherSubtitle()
+    {
+        var first = new Subtitle();
+        first.Paragraphs.Add(new Paragraph("Hello world", 1960, 3000));
+        SaveViaDialog(first, vm =>
+        {
+            vm.SelectedFrameRate = "23.976";
+            vm.OriginalProgramTitle = "My film";
+        });
+
+        // A second, STL25 subtitle saved without opening the dialog again.
+        var second = new Subtitle { Header = new Ebu.EbuGeneralSubtitleInformation().ToString() };
+        second.Paragraphs.Add(new Paragraph("Hello world", 1960, 3000));
+
+        Assert.Equal("00:00:01:24", InCueTimeCode(Save(second)));
+    }
+
+    // Reopening the dialog showed the 25 fps default for every file, because the rate was read from
+    // a field that is never part of a header read back from bytes.
+    [AvaloniaFact]
+    public void ReopeningTheDialog_ShowsTheRateOfTheFile()
+    {
+        var subtitle = new Subtitle
+        {
+            Header = new Ebu.EbuGeneralSubtitleInformation { DiskFormatCode = "STL30.01" }.ToString(),
+        };
+        subtitle.Paragraphs.Add(new Paragraph("Hello world", 1000, 3000));
+
+        var viewModel = new ExportEbuStlViewModel(new FileHelper());
+        viewModel.Initialize(subtitle);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal("30", viewModel.SelectedFrameRate);
+
+        // And a rate that no disk format code can express is remembered for this header.
+        Ebu.EbuUiHelper = new UiEbuSaveHelper();
+        SaveViaDialog(subtitle, vm => { vm.SelectedFrameRate = "23.976"; });
+
+        var reopened = new ExportEbuStlViewModel(new FileHelper());
+        reopened.Initialize(subtitle);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal("23.976", reopened.SelectedFrameRate);
+    }
+
+    // The frame rate list is written with invariant decimal points, so it must not be read back
+    // with the UI culture: in a comma-decimal culture "23.976" parsed as 23976 and the pick was
+    // dropped on the floor.
+    [AvaloniaFact]
+    public void PickedFrameRate_SurvivesACommaDecimalCulture()
+    {
+        var culture = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = new CultureInfo("da-DK");
+        try
+        {
+            var subtitle = new Subtitle();
+            subtitle.Paragraphs.Add(new Paragraph("Hello world", 1960, 3000));
+
+            var bytes = SaveViaDialog(subtitle, vm =>
+            {
+                vm.SelectedFrameRate = "23.976";
+                vm.OriginalProgramTitle = "My film";
+            });
+
+            Assert.Equal("00:00:01:23", InCueTimeCode(bytes));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = culture;
+        }
     }
 }

--- a/tests/UI/Features/Files/ExportEbuStlHeaderTests.cs
+++ b/tests/UI/Features/Files/ExportEbuStlHeaderTests.cs
@@ -1,0 +1,142 @@
+using System.Text;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Files.Export.ExportEbuStl;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace UITests.Features.Files;
+
+/// <summary>
+/// The EBU STL save options dialog hands its result to the writer as a 1024-character GSI header
+/// stored on the subtitle. Anything that makes that header come out wrong is invisible to the user:
+/// <see cref="Ebu.Save"/> just falls back to a default header ("No Title", USA, no start of
+/// programme) and still writes a perfectly good subtitle grid. Reported by email against 5.2.0,
+/// where a programme title longer than the 32-character field did exactly that.
+/// </summary>
+public class ExportEbuStlHeaderTests
+{
+    public ExportEbuStlHeaderTests()
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+    }
+
+    private static Subtitle MakeSubtitle()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Hello world", 1000, 3000));
+        subtitle.Paragraphs.Add(new Paragraph("Second line", 4000, 6000));
+        return subtitle;
+    }
+
+    private static byte[] SaveViaDialog(Action<ExportEbuStlViewModel> fillIn)
+    {
+        var viewModel = new ExportEbuStlViewModel(new FileHelper());
+        var subtitle = MakeSubtitle();
+        viewModel.Initialize(subtitle);
+        Dispatcher.UIThread.RunJobs();
+
+        fillIn(viewModel);
+        viewModel.OkCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+
+        Ebu.EbuUiHelper ??= new UiEbuSaveHelper();
+        var fileName = Path.Combine(Path.GetTempPath(), "ebu-header-test-" + Guid.NewGuid() + ".stl");
+        try
+        {
+            new Ebu().Save(fileName, subtitle);
+            return File.ReadAllBytes(fileName);
+        }
+        finally
+        {
+            if (File.Exists(fileName))
+            {
+                File.Delete(fileName);
+            }
+        }
+    }
+
+    private static string Field(byte[] bytes, int index, int length)
+    {
+        return Ebu.GetEncoding(Encoding.ASCII.GetString(bytes, 0, 3)).GetString(bytes, index, length);
+    }
+
+    [AvaloniaFact]
+    public void HeaderFields_ReachTheSavedFile()
+    {
+        var bytes = SaveViaDialog(vm =>
+        {
+            vm.OriginalProgramTitle = "My film";
+            vm.OriginalEpisodeTitle = "Episode 1";
+            vm.CountryOfOrigin = "DEU";
+            vm.StartOfProgramme = new TimeSpan(10, 0, 0);
+        });
+
+        Assert.Equal("My film".PadRight(32), Field(bytes, 16, 32));
+        Assert.Equal("Episode 1".PadRight(32), Field(bytes, 48, 32));
+        Assert.Equal("DEU", Field(bytes, 274, 3));
+        Assert.Equal("10000000", Field(bytes, 256, 8));
+    }
+
+    // A title longer than the 32-character GSI field used to push the header past 1024 characters,
+    // and every other field the user filled in went down with it.
+    [AvaloniaFact]
+    public void OverlongTextFields_AreTruncated_RestOfHeaderSurvives()
+    {
+        var bytes = SaveViaDialog(vm =>
+        {
+            vm.OriginalProgramTitle = "A very long programme title that is well past thirty-two characters";
+            vm.SubtitleListReferenceCode = "reference code that is too long";
+            vm.TranslatorsName = new string('x', 40);
+            vm.CountryOfOrigin = "DEU";
+            vm.StartOfProgramme = new TimeSpan(10, 0, 0);
+        });
+
+        Assert.Equal("A very long programme title that", Field(bytes, 16, 32));
+        Assert.Equal("reference code t", Field(bytes, 208, 16));
+        Assert.Equal(new string('x', 32), Field(bytes, 144, 32));
+        Assert.Equal("DEU", Field(bytes, 274, 3));
+        Assert.Equal("10000000", Field(bytes, 256, 8));
+    }
+
+    // STL23.01 is offered by the dialog's own disk format code list, but the "is this an STL
+    // header" check did not know about it - so picking it dropped the whole header on save.
+    [AvaloniaFact]
+    public void NonStandardDiskFormatCode_KeepsTheHeader()
+    {
+        var bytes = SaveViaDialog(vm =>
+        {
+            vm.SelectedDiskFormatCode = vm.DiskFormatCodes.First(p => p.StartsWith("STL23"));
+            vm.OriginalProgramTitle = "My film";
+            vm.CountryOfOrigin = "DEU";
+        });
+
+        Assert.Equal("STL23.01", Field(bytes, 3, 8));
+        Assert.Equal("My film".PadRight(32), Field(bytes, 16, 32));
+        Assert.Equal("DEU", Field(bytes, 274, 3));
+    }
+
+    // A country code shorter than three characters was replaced by "USA" rather than padded.
+    [AvaloniaFact]
+    public void ShortCountryCode_IsKeptNotReplacedByUsa()
+    {
+        var bytes = SaveViaDialog(vm =>
+        {
+            vm.OriginalProgramTitle = "My film";
+            vm.CountryOfOrigin = "D";
+        });
+
+        Assert.Equal("D  ", Field(bytes, 274, 3));
+    }
+
+    // An untouched country field still gets the long-standing default.
+    [AvaloniaFact]
+    public void EmptyCountryCode_FallsBackToUsa()
+    {
+        var bytes = SaveViaDialog(vm => { vm.OriginalProgramTitle = "My film"; });
+
+        Assert.Equal("USA", Field(bytes, 274, 3));
+    }
+}

--- a/tests/libse/SubtitleFormats/EbuTest.cs
+++ b/tests/libse/SubtitleFormats/EbuTest.cs
@@ -36,6 +36,17 @@ public class EbuTest
 
         var stored = new Ebu.EbuGeneralSubtitleInformation().ToString();
         Assert.True(Ebu.IsStlHeader(stored));
+
+        // Every disk format code the save options dialog offers must be recognized - STL23 was not,
+        // so picking it made the save discard the header the dialog had just stored.
+        foreach (var diskFormatCode in new[] { "STL23.01", "STL24.01", "STL25.01", "STL29.01", "STL30.01" })
+        {
+            var header = new Ebu.EbuGeneralSubtitleInformation { DiskFormatCode = diskFormatCode }.ToString();
+            Assert.True(Ebu.IsStlHeader(header), diskFormatCode + " is not recognized as an STL header");
+        }
+
+        // A 1024-character header of some other format that happens to mention STL25 is not one.
+        Assert.False(Ebu.IsStlHeader("STL25".PadRight(1024)));
     }
 
     // Regression for #11910: EBU STL Save produced a 14-byte invalid file ("Not supported!")


### PR DESCRIPTION
Reported by email against 5.2.0: exporting EBU STL always produced the US default header — `No Title`, `USA`, no start of programme — no matter what was entered in the save options, while the subtitle grid itself came out exactly right. The reporter spent hours looking for the "default US settings" in `settings.json`; they are not settings, they are `EbuGeneralSubtitleInformation`'s constructor defaults.

## What happens

The dialog hands its result to the writer as a 1024-character GSI header stored on the subtitle, and every way that header can come out wrong is silent:

1. `Ok()` padded the text fields but never truncated them, so a programme title longer than its 32-character field made the header 1052 characters.
2. `EbuGeneralSubtitleInformation.ToString()` answers a wrong total length by returning the string `"Length must be 1024 but is 1052"`, which was stored on the subtitle unchecked.
3. `Ebu.Save` asks `IsStlHeader(subtitle.Header)`, gets false, and quietly builds `new EbuGeneralSubtitleInformation()` — `No Title`, `USA`, `00000000`, code page 437.

The TTI blocks are written from the paragraphs and the margins/box/justification come from `Configuration.Settings`, which is why only the header was affected.

Reproduced headlessly against `main` before the fix:

| title typed | stored header | file title | file country | file start |
|---|---|---|---|---|
| `Mein Film` | 1024 chars, valid | `Mein Film` | `DEU` | `10000000` |
| 60-char title | `Length must be 1024 but is 1052` | `No Title` | `USA` | `00000000` |

SE4 capped these fields in the WinForms designer (`textBoxOriginalProgramTitle.MaxLength = 32`, reference code 16, country 3); the Avalonia port copied the `Ok()` logic but not the caps.

## Also on the same path

- **STL23.01 discarded the whole header.** The dialog's own disk format code list offers it, but `Ebu.IsStlHeader` only knew STL24/25/29/30 — so picking it took the same silent path to the defaults. The check now matches the disk format code where it lives (offset 3..5) instead of listing frame rates.
- **A country code shorter than three characters became `USA`.** It is now kept and padded; an empty field still gets the old default.
- **A header that does not come out to 1024 characters is no longer stored at all** — it is logged, and the previous header (e.g. the one loaded from the file) stands.

## The frame rate never reached the file either

The frame rate is the one save option with no place in the header, so it did not survive the trip to the writer: `Ebu.Save` re-reads the header off the subtitle, `FrameRateFromSaveDialog` comes back zero, and the time codes are converted with the rate the disk format code implies. Picking 23.976 with STL25.01 wrote 25 fps frames.

SE4 got away with this because the dialog *was* the save helper and wrote into the header object being saved. Same idea here: the rate is parked on `UiEbuSaveHelper` when the dialog is OK'd and put back in `Initialize` — tied to the header the dialog produced, so the next file keeps the rate its own disk format code implies.

That uncovered two more:

- The rate was parsed with the UI culture, so `"23.976"` read as `23976` in every comma-decimal locale (Danish, German, …) and the pick was dropped before it ever reached the header. It is now parsed invariantly, which is how the list is written.
- Reopening the dialog always showed 25 fps, because it only looked at `FrameRateFromSaveDialog`, which is never set on a header read back from bytes. It now derives from `header.FrameRate` (plus the rate remembered for this header), matching the list by value rather than by formatted string.

## Tests

`tests/UI/Features/Files/ExportEbuStlHeaderTests.cs` — ten tests driving the real view model + `Ebu.Save`: header fields reach the file; overlong fields are truncated without taking the rest of the header down; STL23.01 keeps the header; short/empty country handling; the picked frame rate decides the TTI frames (23.976 → `00:00:01:23`, 25 → `00:00:01:24`); it survives a comma-decimal culture; it does not leak to the next subtitle; and reopening the dialog shows the file's own rate. Each was checked to fail with its fix reverted.

`tests/libse/SubtitleFormats/EbuTest.cs` — `IsStlHeader` accepts every disk format code the dialog offers and still rejects a non-STL 1024-character header.

Full libse (1466), UI (3861), seconv (383) and libuilogic (542) suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)