### PR TITLE
Write the actor column when converting from "Actor: text"

### DIFF
--- a/src/libse/Common/ActorConverter.cs
+++ b/src/libse/Common/ActorConverter.cs
@@ -4,7 +4,6 @@ using SkiaSharp;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace Nikse.SubtitleEdit.Core.Common
 {
@@ -35,8 +34,19 @@ namespace Nikse.SubtitleEdit.Core.Common
             _nameListInclMulti = _namesList.GetAllNames();
         }
 
-        public string FixActorsFromActor(Paragraph p, int? changeCasing, SKColor? color)
+        /// <summary>
+        /// Moves the actor column into the text. The converted paragraph is returned in the result -
+        /// the actor column is cleared, as the name now lives in the text and would otherwise be
+        /// written twice (#14077).
+        /// </summary>
+        public ActorConverterResult FixActorsFromActor(Paragraph paragraph, int? changeCasing, SKColor? color)
         {
+            var p = new Paragraph(paragraph, false);
+            if (ToActor)
+            {
+                return new ActorConverterResult { Paragraph = p, Selected = true };
+            }
+
             var actor = p.Actor;
             if (changeCasing.HasValue)
             {
@@ -55,76 +65,117 @@ namespace Nikse.SubtitleEdit.Core.Common
             {
                 actor = actor + ":";
             }
-            else if (ToActor)
-            {
-                return p.Text;
-            }
 
-            if (color.HasValue && !ToActor)
+            if (color.HasValue)
             {
                 actor = SetColor(_subtitleFormat, color.Value, actor);
             }
 
             p.Text = actor + " " + p.Text.TrimStart(' ');
+            p.Actor = string.Empty;
 
-            return p.Text;
+            return new ActorConverterResult { Paragraph = p, Selected = true };
         }
 
-        public string FixActorsFromBeforeColon(Paragraph p, char ch, int? changeCasing, SKColor? color)
+        /// <summary>
+        /// Converts "Actor: text" lines. The converted paragraph is returned in the result: converting
+        /// to the actor column writes <see cref="Paragraph.Actor"/> from whichever line carries the
+        /// name, and a second speaker in the same paragraph becomes
+        /// <see cref="ActorConverterResult.NextParagraph"/> - the same shape <see cref="FixActors"/>
+        /// returns for the bracket formats (#14077).
+        /// </summary>
+        public ActorConverterResult FixActorsFromBeforeColon(Paragraph paragraph, char ch, int? changeCasing, SKColor? color)
         {
-            var sb = new StringBuilder();
-            var lineIdx = 0;
-            foreach (var line in p.Text.SplitToLines())
+            var p = new Paragraph(paragraph, false);
+            var lines = p.Text.SplitToLines();
+
+            // Only one extra paragraph can be split off, so a third speaker would be lost.
+            if (ToActor && lines.Count(line => HasActor(line, ch)) > 2)
             {
-                // index into the trimmed line - leading whitespace used to shift every cut by its width
+                return new ActorConverterResult { Paragraph = paragraph, Skip = true };
+            }
+
+            Paragraph nextParagraph = null;
+            var selectFix = true;
+            var actorAssigned = false;
+            var textLines = new List<string>();
+            foreach (var line in lines)
+            {
+                // index into the trimmed line - leading whitespace goes with the actor it precedes
                 var s = line.Trim();
                 var startIdx = s.IndexOf(ch);
-                if (startIdx > 0)
+                if (startIdx <= 0)
                 {
-                    var actor = s.Substring(0, startIdx).Trim(' ', '-', '"');
-                    if (changeCasing.HasValue)
+                    // A line without an actor belongs to the paragraph the previous line went to.
+                    if (nextParagraph != null)
                     {
-                        actor = SetCasing(_subtitleFormat, changeCasing, actor);
-                    }
-
-                    if (ToSquare)
-                    {
-                        actor = "[" + actor + "]";
-                    }
-                    else if (ToParentheses)
-                    {
-                        actor = "(" + actor + ")";
-                    }
-                    else if (ToColon)
-                    {
-                        actor = actor + ":";
-                    }
-
-                    if (color.HasValue && !ToActor)
-                    {
-                        actor = SetColor(_subtitleFormat, color.Value, actor);
-                    }
-
-                    if (ToActor)
-                    {
-                        if (lineIdx == 0)
-                        {
-                            p.Actor = actor;
-                        }
-
-                        s = s.Substring(startIdx + 1).TrimStart(' ');
+                        nextParagraph.Text = (nextParagraph.Text + Environment.NewLine + s).Trim();
                     }
                     else
                     {
-                        s = actor + " " + s.Substring(startIdx + 1).TrimStart(' ');
+                        textLines.Add(s);
                     }
+
+                    continue;
                 }
 
-                sb.AppendLine(s);
-                lineIdx++;
+                var actor = s.Substring(0, startIdx).Trim(' ', '-', '"');
+                selectFix = IsActor(actor);
+                if (changeCasing.HasValue)
+                {
+                    actor = SetCasing(_subtitleFormat, changeCasing, actor);
+                }
+
+                if (ToSquare)
+                {
+                    actor = "[" + actor + "]";
+                }
+                else if (ToParentheses)
+                {
+                    actor = "(" + actor + ")";
+                }
+                else if (ToColon)
+                {
+                    actor = actor + ":";
+                }
+
+                if (color.HasValue && !ToActor)
+                {
+                    actor = SetColor(_subtitleFormat, color.Value, actor);
+                }
+
+                var text = s.Substring(startIdx + 1).TrimStart(' ');
+                if (!ToActor)
+                {
+                    textLines.Add(actor + " " + text);
+                }
+                else if (!actorAssigned)
+                {
+                    // The first name found goes in the actor column...
+                    p.Actor = actor;
+                    actorAssigned = true;
+                    textLines.Add(text);
+                }
+                else
+                {
+                    // ...a second one needs a paragraph of its own, as the column holds one name.
+                    nextParagraph = new Paragraph(p) { Text = text, Actor = actor };
+                }
             }
 
-            return sb.ToString().Trim();
+            p.Text = string.Join(Environment.NewLine, textLines).Trim();
+
+            return new ActorConverterResult
+            {
+                Paragraph = p,
+                NextParagraph = nextParagraph,
+                Selected = selectFix,
+            };
+        }
+
+        private static bool HasActor(string line, char ch)
+        {
+            return line.Trim().IndexOf(ch) > 0;
         }
 
         public ActorConverterResult FixActors(Paragraph paragraph, char start, char end, int? changeCasing, SKColor? color)
@@ -145,13 +196,12 @@ namespace Nikse.SubtitleEdit.Core.Common
                 var s = line;
                 var startIdx = s.IndexOf(start);
                 var endIdx = s.IndexOf(end);
-                if (startIdx != -1 && endIdx != -1)
-                {
-                    if (endIdx < startIdx)
-                    {
-                        break;
-                    }
 
+                // A closing bracket before the opening one is not an actor - the line is kept as it
+                // is. Giving up on the whole paragraph here dropped this line and every line after
+                // it from the text.
+                if (startIdx != -1 && endIdx > startIdx)
+                {
                     var actor = s.Substring(startIdx + 1, endIdx - startIdx - 1).Trim(' ', '-', '"');
                     selectFix = IsActor(actor);
                     if (changeCasing.HasValue)
@@ -205,9 +255,20 @@ namespace Nikse.SubtitleEdit.Core.Common
                     }
                     else if (lineIdx == 1 && ToActor)
                     {
-                        nextParagraph = new Paragraph(p);
-                        nextParagraph.Text = s.Trim();
-                        nextParagraph.Actor = actor;
+                        if (string.IsNullOrEmpty(p.Actor))
+                        {
+                            // Only the second line names a speaker, so it belongs to this paragraph -
+                            // splitting off a paragraph with no actor at all would leave the name
+                            // nowhere (#14077).
+                            p.Actor = actor;
+                            p.Text = (p.Text + Environment.NewLine + s.Trim()).Trim();
+                        }
+                        else
+                        {
+                            nextParagraph = new Paragraph(p);
+                            nextParagraph.Text = s.Trim();
+                            nextParagraph.Actor = actor;
+                        }
                     }
                     else if (lineIdx == 1)
                     {

--- a/src/ui/Features/Tools/ConvertActors/ConvertActorsViewModel.cs
+++ b/src/ui/Features/Tools/ConvertActors/ConvertActorsViewModel.cs
@@ -141,37 +141,23 @@ public partial class ConvertActorsViewModel : ObservableObject, IClosingCleanup
 
             if (fromSquare && Contains(p.Text, '[', ']'))
             {
-                ProcessBracketActors(vm, p, '[', ']', converter, changeCasing, color, items, ref count);
+                var result = converter.FixActors(p, '[', ']', changeCasing, color);
+                AddConversion(vm, oldText, result, converter, items, ref count);
             }
             else if (fromParentheses && Contains(p.Text, '(', ')'))
             {
-                ProcessBracketActors(vm, p, '(', ')', converter, changeCasing, color, items, ref count);
+                var result = converter.FixActors(p, '(', ')', changeCasing, color);
+                AddConversion(vm, oldText, result, converter, items, ref count);
             }
             else if (fromColon && p.Text.Contains(':'))
             {
-                var newText = converter.FixActorsFromBeforeColon(p, ':', changeCasing, color);
-                if (newText != oldText)
-                {
-                    var updatedVm = new SubtitleLineViewModel(vm);
-                    updatedVm.Text = newText;
-                    if (converter.ToActor)
-                    {
-                        updatedVm.Actor = p.Actor;
-                    }
-                    items.Add(new ConvertActorsDisplayItem(vm) { NewText = newText, IsChecked = true, UpdatedViewModel = updatedVm });
-                    count++;
-                }
+                var result = converter.FixActorsFromBeforeColon(p, ':', changeCasing, color);
+                AddConversion(vm, oldText, result, converter, items, ref count);
             }
             else if (fromActor && !string.IsNullOrEmpty(p.Actor))
             {
-                var newText = converter.FixActorsFromActor(p, changeCasing, color);
-                if (newText != oldText)
-                {
-                    var updatedVm = new SubtitleLineViewModel(vm);
-                    updatedVm.Text = newText;
-                    items.Add(new ConvertActorsDisplayItem(vm) { NewText = newText, IsChecked = true, UpdatedViewModel = updatedVm });
-                    count++;
-                }
+                var result = converter.FixActorsFromActor(p, changeCasing, color);
+                AddConversion(vm, oldText, result, converter, items, ref count);
             }
         }
 
@@ -188,32 +174,41 @@ public partial class ConvertActorsViewModel : ObservableObject, IClosingCleanup
         });
     }
 
-    private void ProcessBracketActors(
+    /// <summary>
+    /// Turns one converted paragraph into a preview row - plus a second row when converting to the
+    /// actor column split a two-speaker paragraph in two.
+    /// </summary>
+    private void AddConversion(
         SubtitleLineViewModel vm,
-        Paragraph p,
-        char startChar,
-        char endChar,
+        string oldText,
+        ActorConverterResult result,
         ActorConverter converter,
-        int? changeCasing,
-        SkiaSharp.SKColor? color,
         List<ConvertActorsDisplayItem> items,
         ref int count)
     {
-        var oldText = p.Text;
-        var result = converter.FixActors(p, startChar, endChar, changeCasing, color);
         if (result.Skip)
+        {
+            return;
+        }
+
+        var newText = result.Paragraph.Text;
+
+        // A row loaded from a format without actors has a null actor, the converter writes an empty
+        // string - not a change worth listing.
+        var newActor = result.Paragraph.Actor ?? string.Empty;
+        if (newText == oldText && newActor == (vm.Actor ?? string.Empty) && result.NextParagraph == null)
         {
             return;
         }
 
         var isChecked = result.Selected || !OnlyNames;
         var updatedVm = new SubtitleLineViewModel(vm);
-        updatedVm.Text = result.Paragraph.Text;
-        updatedVm.Actor = result.Paragraph.Actor;
+        updatedVm.Text = newText;
+        updatedVm.Actor = newActor;
 
         items.Add(new ConvertActorsDisplayItem(vm)
         {
-            NewText = result.Paragraph.Text,
+            NewText = newText,
             IsChecked = isChecked,
             UpdatedViewModel = updatedVm,
         });
@@ -223,7 +218,7 @@ public partial class ConvertActorsViewModel : ObservableObject, IClosingCleanup
         {
             var nextVm = new SubtitleLineViewModel(vm, generateNewId: true);
             nextVm.Text = result.NextParagraph.Text;
-            nextVm.Actor = result.NextParagraph.Actor;
+            nextVm.Actor = result.NextParagraph.Actor ?? string.Empty;
 
             items.Add(new ConvertActorsDisplayItem(vm)
             {

--- a/tests/UI/Features/Tools/ConvertActorsTests.cs
+++ b/tests/UI/Features/Tools/ConvertActorsTests.cs
@@ -1,0 +1,239 @@
+using System.Reflection;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Tools.ConvertActors;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Features.Tools;
+
+/// <summary>
+/// Convert actors: the preview rows the dialog builds, and what "OK" puts back in the grid.
+///
+/// Converting "Inline actor via :" to "Actor" wrote nothing to the actor column whenever the name
+/// was not on the first line, and a second speaker in the same paragraph was deleted with its line
+/// left behind - the colon path had none of the paragraph splitting the bracket formats got (#14077).
+/// </summary>
+public class ConvertActorsTests
+{
+    [AvaloniaFact]
+    public void ColonToActor_WritesTheActorColumn()
+    {
+        var rows = Convert(ConvertActorType.InlineColon, ConvertActorType.Actor, "Joe: How are you?");
+
+        Assert.Equal(new[] { "How are you?" }, rows.Select(r => r.Text));
+        Assert.Equal(new[] { "Joe" }, rows.Select(r => r.Actor));
+    }
+
+    /// <summary>Both speakers are kept: one paragraph per actor, as the bracket formats do.</summary>
+    [AvaloniaFact]
+    public void ColonDialogToActor_SplitsTheParagraph()
+    {
+        var rows = Convert(
+            ConvertActorType.InlineColon,
+            ConvertActorType.Actor,
+            "Joe: How are you?" + Environment.NewLine + "Jane: I am fine.");
+
+        Assert.Equal(new[] { "How are you?", "I am fine." }, rows.Select(r => r.Text));
+        Assert.Equal(new[] { "Joe", "Jane" }, rows.Select(r => r.Actor));
+        Assert.Equal(new[] { 1, 2 }, rows.Select(r => r.Number));
+    }
+
+    /// <summary>The name is on the second line - the actor column stayed empty and "Jane" was lost.</summary>
+    [AvaloniaFact]
+    public void ColonOnSecondLineOnly_StillWritesTheActorColumn()
+    {
+        var rows = Convert(
+            ConvertActorType.InlineColon,
+            ConvertActorType.Actor,
+            "How are you?" + Environment.NewLine + "Jane: I am fine.");
+
+        Assert.Equal(new[] { "How are you?" + Environment.NewLine + "I am fine." }, rows.Select(r => r.Text));
+        Assert.Equal(new[] { "Jane" }, rows.Select(r => r.Actor));
+    }
+
+    /// <summary>Moving the actor into the text empties the column - it was written twice before.</summary>
+    [AvaloniaFact]
+    public void ActorToSquare_ClearsTheActorColumn()
+    {
+        var rows = Convert(
+            ConvertActorType.Actor,
+            ConvertActorType.InlineSquareBrackets,
+            new SubRip(),
+            (Text: "How are you?", Actor: "Joe"));
+
+        Assert.Equal(new[] { "[Joe] How are you?" }, rows.Select(r => r.Text));
+        Assert.Equal(new[] { string.Empty }, rows.Select(r => r.Actor));
+    }
+
+    /// <summary>
+    /// "Only names" now reaches the colon conversions too: a colon in plain text is listed, but not
+    /// checked, so "Meet me at 3:30." is not turned into "30." with an actor of "Meet me at 3".
+    /// </summary>
+    [AvaloniaFact]
+    public void OnlyNames_LeavesAColonInPlainTextUnchecked()
+    {
+        var vm = Preview(ConvertActorType.InlineColon, ConvertActorType.Actor, new SubRip(), onlyNames: true,
+            (Text: "Meet me at 3:30.", Actor: string.Empty));
+
+        var item = Assert.Single(vm.Subtitles);
+        Assert.False(item.IsChecked);
+    }
+
+    [AvaloniaFact]
+    public void OnlyNamesOff_KeepsEveryConversionChecked()
+    {
+        var vm = Preview(ConvertActorType.InlineColon, ConvertActorType.Actor, new SubRip(), onlyNames: false,
+            (Text: "Meet me at 3:30.", Actor: string.Empty));
+
+        var item = Assert.Single(vm.Subtitles);
+        Assert.True(item.IsChecked);
+    }
+
+    /// <summary>A colon that starts a line is not an actor, so there is nothing to convert.</summary>
+    [AvaloniaFact]
+    public void ColonWithoutAnActor_IsNotListed()
+    {
+        var vm = Preview(ConvertActorType.InlineColon, ConvertActorType.Actor, new SubRip(), onlyNames: false,
+            (Text: ": how are you?", Actor: null!));
+
+        Assert.Empty(vm.Subtitles);
+    }
+
+    private static List<SubtitleLineViewModel> Convert(ConvertActorType from, ConvertActorType to, params string[] texts)
+        => Convert(from, to, new SubRip(), texts.Select(t => (Text: t, Actor: string.Empty)).ToArray());
+
+    /// <summary>Runs the dialog and applies its result to the main grid, as the menu item does.</summary>
+    private static List<SubtitleLineViewModel> Convert(
+        ConvertActorType from,
+        ConvertActorType to,
+        SubtitleFormat format,
+        params (string Text, string Actor)[] lines)
+    {
+        var (window, main) = CreateMainViewModel();
+        try
+        {
+            var number = 1;
+            foreach (var line in lines)
+            {
+                main.Subtitles.Add(new SubtitleLineViewModel(
+                    new Paragraph(line.Text, number * 1000, number * 1000 + 900) { Actor = line.Actor },
+                    format)
+                {
+                    Number = number,
+                });
+                number++;
+            }
+
+            var vm = RunPreview(from, to, format, false, main.Subtitles.ToList());
+            Invoke(vm, "Ok");
+
+            var apply = typeof(MainViewModel).GetMethod(
+                            "ApplyFixedSubtitle",
+                            BindingFlags.Instance | BindingFlags.NonPublic,
+                            null,
+                            new[] { typeof(List<SubtitleLineViewModel>), typeof(int) },
+                            null)
+                        ?? throw new InvalidOperationException("ApplyFixedSubtitle not found");
+            apply.Invoke(main, new object?[] { vm.FixedSubtitle, 0 });
+            Dispatcher.UIThread.RunJobs();
+
+            return main.Subtitles.ToList();
+        }
+        finally
+        {
+            CloseWindow(window, main);
+        }
+    }
+
+    private static ConvertActorsViewModel Preview(
+        ConvertActorType from,
+        ConvertActorType to,
+        SubtitleFormat format,
+        bool onlyNames,
+        params (string Text, string Actor)[] lines)
+    {
+        var number = 1;
+        var subtitles = new List<SubtitleLineViewModel>();
+        foreach (var line in lines)
+        {
+            subtitles.Add(new SubtitleLineViewModel(
+                new Paragraph(line.Text, number * 1000, number * 1000 + 900) { Actor = line.Actor },
+                format)
+            {
+                Number = number,
+            });
+            number++;
+        }
+
+        return RunPreview(from, to, format, onlyNames, subtitles);
+    }
+
+    private static ConvertActorsViewModel RunPreview(
+        ConvertActorType from,
+        ConvertActorType to,
+        SubtitleFormat format,
+        bool onlyNames,
+        List<SubtitleLineViewModel> subtitles)
+    {
+        var vm = new ConvertActorsViewModel
+        {
+            SelectedFromType = ConvertActorTypeDisplay.GetTypes().First(t => t.Type == from),
+            SelectedToType = ConvertActorTypeDisplay.GetTypes().First(t => t.Type == to),
+            ChangeCasing = false,
+            SetColor = false,
+            OnlyNames = onlyNames,
+        };
+
+        vm.Initialize(subtitles, format);
+
+        // The preview runs on a timer in the dialog - here it is called directly.
+        Invoke(vm, "UpdatePreview");
+        Dispatcher.UIThread.RunJobs();
+        vm.OnClosingCleanup();
+        return vm;
+    }
+
+    private static void Invoke(ConvertActorsViewModel vm, string methodName)
+    {
+        var method = typeof(ConvertActorsViewModel).GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic)
+                     ?? throw new InvalidOperationException(methodName + " not found");
+        method.Invoke(vm, null);
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static (Window Window, MainViewModel Vm) CreateMainViewModel()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1200, Height = 800 };
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        return (window, (MainViewModel)view.DataContext!);
+    }
+
+    private static void CloseWindow(Window window, MainViewModel vm)
+    {
+        foreach (var ownedWindow in window.OwnedWindows.ToArray())
+        {
+            ownedWindow.Close();
+        }
+
+        window.Closing -= vm.OnClosing;
+        if (window.IsVisible)
+        {
+            window.Close();
+        }
+    }
+}

--- a/tests/libse/Core/ActorConverterTest.cs
+++ b/tests/libse/Core/ActorConverterTest.cs
@@ -118,8 +118,8 @@ public class ActorConverterTest
         };
 
         var p = new Paragraph() { Text = "Joe: How are you?" };
-        var text = c.FixActorsFromBeforeColon(p, ':', ActorConverter.LowerCase, null);
-        Assert.Equal("(joe) How are you?", text);
+        var result = c.FixActorsFromBeforeColon(p, ':', ActorConverter.LowerCase, null);
+        Assert.Equal("(joe) How are you?", result.Paragraph.Text);
     }
 
     [Fact]
@@ -131,8 +131,15 @@ public class ActorConverterTest
         };
 
         var p = new Paragraph() { Text = "How are you?", Actor = "Joe" };
-        var text = c.FixActorsFromActor(p, null, null);
-        Assert.Equal("[Joe] How are you?", text);
+        var result = c.FixActorsFromActor(p, null, null);
+        Assert.Equal("[Joe] How are you?", result.Paragraph.Text);
+
+        // The name is in the text now - leaving it in the actor column too would write it twice.
+        Assert.Equal(string.Empty, result.Paragraph.Actor);
+
+        // The input paragraph is never touched, the result carries the conversion.
+        Assert.Equal("How are you?", p.Text);
+        Assert.Equal("Joe", p.Actor);
     }
 
     [Fact]
@@ -158,8 +165,8 @@ public class ActorConverterTest
         };
 
         var p = new Paragraph() { Text = "Joe: How are you?" + Environment.NewLine + "Jane: I'm fine." };
-        var text = c.FixActorsFromBeforeColon(p, ':', null, null);
-        Assert.Equal("[Joe] How are you?" + Environment.NewLine + "[Jane] I'm fine.", text);
+        var result = c.FixActorsFromBeforeColon(p, ':', null, null);
+        Assert.Equal("[Joe] How are you?" + Environment.NewLine + "[Jane] I'm fine.", result.Paragraph.Text);
     }
 
     [Fact]
@@ -171,8 +178,8 @@ public class ActorConverterTest
         };
 
         var p = new Paragraph() { Text = "- Joe: How are you?" + Environment.NewLine + "- Jane: I'm fine." };
-        var text = c.FixActorsFromBeforeColon(p, ':', null, null);
-        Assert.Equal("[Joe] How are you?" + Environment.NewLine + "[Jane] I'm fine.", text);
+        var result = c.FixActorsFromBeforeColon(p, ':', null, null);
+        Assert.Equal("[Joe] How are you?" + Environment.NewLine + "[Jane] I'm fine.", result.Paragraph.Text);
     }
 
     [Fact]
@@ -209,5 +216,209 @@ public class ActorConverterTest
         Assert.Equal(p.EndTime.TotalMilliseconds, result.NextParagraph.EndTime.TotalMilliseconds);
         Assert.Equal(p.Style, result.NextParagraph.Style);
         Assert.NotEqual(p.Id, result.NextParagraph.Id);
+    }
+
+    /// <summary>
+    /// The colon conversions used to hand back nothing but a string, so the actor the converter had
+    /// written on the paragraph was thrown away with it - "Inline actor via :" to "Actor" left the
+    /// actor column empty (#14077).
+    /// </summary>
+    [Fact]
+    public void ColonToActor()
+    {
+        var c = new ActorConverter(new SubRip(), "en")
+        {
+            ToActor = true,
+        };
+
+        var p = new Paragraph() { Text = "Joe: How are you?" };
+        var result = c.FixActorsFromBeforeColon(p, ':', null, null);
+        Assert.Equal("How are you?", result.Paragraph.Text);
+        Assert.Equal("Joe", result.Paragraph.Actor);
+        Assert.Null(result.NextParagraph);
+    }
+
+    [Fact]
+    public void ColonToActorUppercase()
+    {
+        var c = new ActorConverter(new SubRip(), "en")
+        {
+            ToActor = true,
+        };
+
+        var p = new Paragraph() { Text = "- Joe: How are you?" };
+        var result = c.FixActorsFromBeforeColon(p, ':', ActorConverter.UpperCase, null);
+        Assert.Equal("How are you?", result.Paragraph.Text);
+        Assert.Equal("JOE", result.Paragraph.Actor);
+    }
+
+    /// <summary>Two speakers in one paragraph become two paragraphs, like the bracket formats.</summary>
+    [Fact]
+    public void ColonDialogToActor()
+    {
+        var c = new ActorConverter(new SubRip(), "en")
+        {
+            ToActor = true,
+        };
+
+        var p = new Paragraph() { Text = "Joe: How are you?" + Environment.NewLine + "Jane: I am fine." };
+        p.StartTime.TotalMilliseconds = 1000;
+        p.EndTime.TotalMilliseconds = 2000;
+        p.Style = "style";
+        var result = c.FixActorsFromBeforeColon(p, ':', null, null);
+        Assert.Equal("How are you?", result.Paragraph.Text);
+        Assert.Equal("Joe", result.Paragraph.Actor);
+        Assert.Equal("I am fine.", result.NextParagraph.Text);
+        Assert.Equal("Jane", result.NextParagraph.Actor);
+        Assert.Equal(p.StartTime.TotalMilliseconds, result.NextParagraph.StartTime.TotalMilliseconds);
+        Assert.Equal(p.EndTime.TotalMilliseconds, result.NextParagraph.EndTime.TotalMilliseconds);
+        Assert.Equal(p.Style, result.NextParagraph.Style);
+        Assert.NotEqual(p.Id, result.NextParagraph.Id);
+    }
+
+    /// <summary>
+    /// One speaker named on the second line: the name goes in the actor column of the paragraph it
+    /// is in - splitting off a paragraph with no actor at all would just move the problem.
+    /// </summary>
+    [Fact]
+    public void ColonOnSecondLineOnlyToActor()
+    {
+        var c = new ActorConverter(new SubRip(), "en")
+        {
+            ToActor = true,
+        };
+
+        var p = new Paragraph() { Text = "How are you?" + Environment.NewLine + "Jane: I am fine." };
+        var result = c.FixActorsFromBeforeColon(p, ':', null, null);
+        Assert.Equal("How are you?" + Environment.NewLine + "I am fine.", result.Paragraph.Text);
+        Assert.Equal("Jane", result.Paragraph.Actor);
+        Assert.Null(result.NextParagraph);
+    }
+
+    [Fact]
+    public void SquareOnSecondLineOnlyToActor()
+    {
+        var c = new ActorConverter(new SubRip(), "en")
+        {
+            ToActor = true,
+        };
+
+        var p = new Paragraph() { Text = "How are you?" + Environment.NewLine + "[Jane] I am fine." };
+        var result = c.FixActors(p, '[', ']', null, null);
+        Assert.Equal("How are you?" + Environment.NewLine + "I am fine.", result.Paragraph.Text);
+        Assert.Equal("Jane", result.Paragraph.Actor);
+        Assert.Null(result.NextParagraph);
+    }
+
+    /// <summary>A three-line paragraph has room for two speakers - the unnamed line stays with the second.</summary>
+    [Fact]
+    public void ColonThreeLinesTwoActorsToActor()
+    {
+        var c = new ActorConverter(new SubRip(), "en")
+        {
+            ToActor = true,
+        };
+
+        var p = new Paragraph() { Text = "Joe: How are you?" + Environment.NewLine + "Jane: I am fine." + Environment.NewLine + "Thank you." };
+        var result = c.FixActorsFromBeforeColon(p, ':', null, null);
+        Assert.Equal("How are you?", result.Paragraph.Text);
+        Assert.Equal("Joe", result.Paragraph.Actor);
+        Assert.Equal("I am fine." + Environment.NewLine + "Thank you.", result.NextParagraph.Text);
+        Assert.Equal("Jane", result.NextParagraph.Actor);
+    }
+
+    /// <summary>Three speakers do not fit in two paragraphs, so the line is left alone.</summary>
+    [Fact]
+    public void ColonThreeActorsToActorIsSkipped()
+    {
+        var c = new ActorConverter(new SubRip(), "en")
+        {
+            ToActor = true,
+        };
+
+        var text = "Joe: How are you?" + Environment.NewLine + "Jane: I am fine." + Environment.NewLine + "Bill: Me too.";
+        var p = new Paragraph() { Text = text };
+        var result = c.FixActorsFromBeforeColon(p, ':', null, null);
+        Assert.True(result.Skip);
+        Assert.Equal(text, result.Paragraph.Text);
+    }
+
+    /// <summary>Three lines are fine when the target is an inline format - nothing has to be split.</summary>
+    [Fact]
+    public void ColonThreeActorsToSquare()
+    {
+        var c = new ActorConverter(new SubRip(), "en")
+        {
+            ToSquare = true,
+        };
+
+        var p = new Paragraph() { Text = "Joe: How are you?" + Environment.NewLine + "Jane: I am fine." + Environment.NewLine + "Bill: Me too." };
+        var result = c.FixActorsFromBeforeColon(p, ':', null, null);
+        Assert.False(result.Skip);
+        Assert.Equal("[Joe] How are you?" + Environment.NewLine + "[Jane] I am fine." + Environment.NewLine + "[Bill] Me too.", result.Paragraph.Text);
+    }
+
+    /// <summary>
+    /// A colon is not an actor by itself - "Only names" filters the preview by this flag, and every
+    /// colon line used to come back pre-checked.
+    /// </summary>
+    [Fact]
+    public void ColonInPlainTextIsNotSelected()
+    {
+        var c = new ActorConverter(new SubRip(), "en")
+        {
+            ToActor = true,
+        };
+
+        var p = new Paragraph() { Text = "Meet me at 3:30." };
+        var result = c.FixActorsFromBeforeColon(p, ':', null, null);
+        Assert.False(result.Selected);
+    }
+
+    /// <summary>The input paragraph is never touched - the result carries the conversion.</summary>
+    [Fact]
+    public void ColonToActorDoesNotChangeTheInputParagraph()
+    {
+        var c = new ActorConverter(new SubRip(), "en")
+        {
+            ToActor = true,
+        };
+
+        var p = new Paragraph() { Text = "Joe: How are you?" };
+        c.FixActorsFromBeforeColon(p, ':', null, null);
+        Assert.Equal("Joe: How are you?", p.Text);
+        Assert.Null(p.Actor);
+    }
+
+    /// <summary>
+    /// A closing bracket before an opening one is not an actor: the line - and every line after it -
+    /// used to be dropped from the text.
+    /// </summary>
+    [Fact]
+    public void ReversedBracketsKeepTheText()
+    {
+        var c = new ActorConverter(new SubRip(), "en")
+        {
+            ToActor = true,
+        };
+
+        var p = new Paragraph() { Text = "[Joe] How are you?" + Environment.NewLine + "5] > [3" };
+        var result = c.FixActors(p, '[', ']', null, null);
+        Assert.Equal("How are you?" + Environment.NewLine + "5] > [3", result.Paragraph.Text);
+        Assert.Equal("Joe", result.Paragraph.Actor);
+    }
+
+    [Fact]
+    public void FromActorToActorIsANoOp()
+    {
+        var c = new ActorConverter(new SubRip(), "en")
+        {
+            ToActor = true,
+        };
+
+        var p = new Paragraph() { Text = "How are you?", Actor = "Joe" };
+        var result = c.FixActorsFromActor(p, null, null);
+        Assert.Equal("How are you?", result.Paragraph.Text);
+        Assert.Equal("Joe", result.Paragraph.Actor);
     }
 }

--- a/tests/libse/Core/BugHunt20260823Test.cs
+++ b/tests/libse/Core/BugHunt20260823Test.cs
@@ -13,8 +13,8 @@ public class BugHunt20260823Test
         var c = new ActorConverter(new SubRip(), "en") { ToSquare = true };
         var p = new Paragraph { Text = "Joe: How are you?" };
         var result = c.FixActorsFromBeforeColon(p, ':', null, SKColors.Red);
-        Assert.StartsWith("<font color=\"#ff0000", result);
-        Assert.EndsWith("\">[Joe]</font> How are you?", result);
+        Assert.StartsWith("<font color=\"#ff0000", result.Paragraph.Text);
+        Assert.EndsWith("\">[Joe]</font> How are you?", result.Paragraph.Text);
     }
 
     [Fact]
@@ -23,7 +23,7 @@ public class BugHunt20260823Test
         var c = new ActorConverter(new SubRip(), "en") { ToSquare = true };
         var p = new Paragraph { Text = "   Joe: How are you?" };
         var result = c.FixActorsFromBeforeColon(p, ':', null, null);
-        Assert.Equal("[Joe] How are you?", result);
+        Assert.Equal("[Joe] How are you?", result.Paragraph.Text);
     }
 
     [Fact]
@@ -32,8 +32,8 @@ public class BugHunt20260823Test
         var c = new ActorConverter(new SubRip(), "en") { ToActor = true };
         var p = new Paragraph { Text = "Joe: How are you?" };
         var result = c.FixActorsFromBeforeColon(p, ':', null, null);
-        Assert.Equal("How are you?", result);
-        Assert.Equal("Joe", p.Actor);
+        Assert.Equal("How are you?", result.Paragraph.Text);
+        Assert.Equal("Joe", result.Paragraph.Actor);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #14077

## The report

Convert actors, "Inline actor via `:`" → "Actor", wrote nothing to the Actor column.

The plain case actually worked - `Joe: How are you?` did end up as `How are you?` with actor `Joe`, verified end to end through the dialog and the grid. But `FixActorsFromBeforeColon` returned nothing but a string, so everything else the converter wrote on the paragraph was thrown away with it, and three inputs came out wrong:

| Input (`:` → Actor) | Before | After |
| --- | --- | --- |
| `How are you?`<br>`Jane: I am fine.` | text `How are you?` + `I am fine.`, **actor empty, "Jane" deleted** | same text, actor `Jane` |
| `Joe: How are you?`<br>`Jane: I am fine.` | one line, actor `Joe`, **"Jane" deleted** | two lines: `How are you?` / `Joe` and `I am fine.` / `Jane` |
| `Meet me at 3:30.` | text `30.`, actor `Meet me at 3`, **checked** | listed, and unchecked when "Only names" is on |

The bracket formats had none of this: `FixActors` already returns an `ActorConverterResult` with the actor, a `NextParagraph` for a second speaker, and `Selected` from the name check.

## The change

`FixActorsFromBeforeColon` and `FixActorsFromActor` now return an `ActorConverterResult` like `FixActors` does, and work on a copy instead of mutating the paragraph they are handed. The name goes in the actor column whichever line carries it, a second speaker becomes `NextParagraph`, and three colon-separated speakers in one paragraph are skipped rather than half-converted.

`ConvertActorsViewModel` builds the preview rows for all four sources through one method, so "Only names" and the paragraph splitting now apply to every conversion, and a conversion that changes nothing is no longer listed as a fix.

Two more fixes found on the way past, both in the bracket path:

- "Actor" → `[]`/`()`/`:` left the name in the actor column as well as in the text, so it was written twice (and would still be saved as the ASS `Name`).
- An actor tag on the second line alone (`How are you?` / `[Jane] I am fine.`) split off a paragraph with no actor at all; the name now goes on the paragraph it is in.
- A closing bracket before an opening one (`5] > [3`) made `FixActors` give up mid-paragraph, dropping that line and every line after it from the text. The line is kept as it is now.

## Tests

- `tests/libse/Core/ActorConverterTest.cs` - 12 new cases: colon → actor, dialogue splitting, name on the second line only, three lines with two speakers, three speakers skipped, three speakers to `[]` (not skipped, nothing has to split), a colon in plain text not being `Selected`, the input paragraph left untouched, reversed brackets, actor → actor as a no-op.
- `tests/UI/Features/Tools/ConvertActorsTests.cs` (new) - drives the dialog and applies its result to the main grid the way the menu item does: the actor column, the split into two rows, "Only names" on and off, and the actor column being cleared by "Actor" → `[]`.

Full `libse` (1478) and UI (3851) suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)