### PR TITLE
Stop suggesting int8 when cuBLAS rejected the compute type

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -945,9 +945,14 @@ public partial class SpeechToTextViewModel : ObservableObject
         var parameters = Parameters ?? string.Empty;
         if (parameters.Contains("--compute_type", StringComparison.OrdinalIgnoreCase))
         {
+            // Only the floating point types are worth naming: on the RTX 50 series - the cards
+            // this error shows up on most - every int8 variant fails with this exact cuBLAS
+            // error, so listing "int8" sent the user straight back to the same dialog
+            // (Purfview/whisper-standalone-win#403, OpenNMT/CTranslate2#1865).
             await MessageBox.Show(Window!, title,
                 cause + "The parameters already set \"--compute_type\" - try another value, " +
-                "such as \"float16\", \"int8\", or \"float32\".");
+                "such as \"float16\", \"float32\", or \"bfloat16\" - the \"int8\" types fail " +
+                "this way on many newer GPUs.");
             return;
         }
 


### PR DESCRIPTION
When a faster-whisper run dies with `CUBLAS_STATUS_NOT_SUPPORTED` and the user's parameters *already* contain `--compute_type`, SE told them to try another value — "such as `float16`, `int8`, or `float32`".

On the RTX 50 series (Blackwell), which is where this error overwhelmingly shows up, every `int8` variant fails with exactly this cuBLAS error. So a third of that advice led straight back to the same dialog.

The reported results on those cards are consistent: `float16`, `float32` and `bfloat16` work; `int8`, `int8_float16`, `int8_float32` and `int8_bfloat16` all fail. This names those three and says plainly that the int8 types do not work.

The other branch of the dialog — the one that offers to add `--compute_type float16` for you — was already correct and is unchanged.

Refs [Purfview/whisper-standalone-win#403](https://github.com/Purfview/whisper-standalone-win/issues/403), [OpenNMT/CTranslate2#1865](https://github.com/OpenNMT/CTranslate2/issues/1865). Came out of #14057.

🤖 Generated with [Claude Code](https://claude.com/claude-code)