### PR TITLE
Fade the Blu-ray sup export with "{\fad}"

### DIFF
--- a/docs/features/file.md
+++ b/docs/features/file.md
@@ -127,6 +127,22 @@ Export subtitles as images (BDN XML, VobSub, Blu-ray SUP, Final Cut Pro + image,
 
 The **IMSC 1.1 image profile** export writes a single self-contained TTML file with each subtitle embedded as a base64 PNG (`smpte:image` / `smpte:backgroundImage`), media timebase, and percentage-positioned regions — the standardized image-subtitle carriage for streaming and broadcast delivery.
 
+#### ASSA override tags
+
+Tags in the text are read rather than drawn as literal characters:
+
+| Tag | Effect on the exported image |
+|-----|------------------------------|
+| `{\an1}` - `{\an9}` | Places the subtitle, overriding the alignment chosen in the window |
+| `{\pos(x,y)}` | Positions the subtitle (coordinates are in the script's own resolution) |
+| `{\i1}`, `{\b1}`, `{\c&H..&}`, `{\fn..}`, `{\fs..}` | Italic, bold, colour, font and size |
+| `{\alpha&H80&}`, `{\1a}`, `{\3a}`, `{\4a}` | Transparency — all parts at once, or text, outline and shadow separately |
+| `{\fad(in,out)}`, `{\fade(..)}` | Fade in/out — **Blu-ray SUP only** (see below) |
+
+Anything else is removed before rendering.
+
+**Fading (Blu-ray SUP).** A subtitle with `{\fad(400,400)}` is written the way a Blu-ray disc does it: the image is encoded once and the fade follows as palette updates, one per video frame, which cost about a kilobyte each instead of a whole new image. Long fades are sampled coarser so a single subtitle never adds more than 60 of them. The other image formats have no way to animate a subtitle and ignore the tag - the image is written fully opaque.
+
 <!-- Screenshot: Export image-based window -->
 ![Export Image Based](../screenshots/export-image-based.png)
 

--- a/docs/reference/assa-override-tags.md
+++ b/docs/reference/assa-override-tags.md
@@ -215,6 +215,8 @@ This is {\1c&HFF0000&}blue text
 
 **Important:** Alpha values range from `00` (fully opaque/visible) to `FF` (fully transparent/invisible). This is opposite to many other programs!
 
+**Image export:** `\alpha`, `\1a`, `\3a` and `\4a` are honoured by the image-based exports (Blu-ray SUP, VobSub, BDN-XML, PNG, ...) - the subtitle is drawn at the transparency asked for.
+
 **Alpha value examples:**
 - `&H00&` — Fully opaque (100% visible)
 - `&H80&` — 50% transparent
@@ -405,6 +407,8 @@ This is {\1c&HFF0000&}blue text
 - Example: If a line displays for 4 seconds, fadein + fadeout should not exceed 4000 ms
 
 **Example:** `{\fad(500,500)}Fade test` (500ms fade-in, 500ms fade-out)
+
+**Image export:** `\fad` and `\fade` survive an export to **Blu-ray SUP** (File → Export image-based, batch convert, and `seconv`), where the fade is written as palette updates. The other image formats have no way to animate a subtitle and write it fully opaque.
 
 ![Fade 1 example](../screenshots/assa/fade-1.gif)
 

--- a/src/libse/BluRaySup/BluRaySupFadeStep.cs
+++ b/src/libse/BluRaySup/BluRaySupFadeStep.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace Nikse.SubtitleEdit.Core.BluRaySup
+{
+    /// <summary>
+    /// One alpha level of a Blu-ray fade. The object is sent once, at the start of the epoch, and
+    /// each step after that is written as a "palette update display set" - a PCS with
+    /// palette_update_flag set plus a PDS holding the same palette with every entry's alpha
+    /// scaled by <see cref="AlphaPercent"/>. That is how retail discs fade: re-sending the whole
+    /// object per step instead would cost kilobytes each and run into the decoder's pixel
+    /// transfer budget, while a palette is ~1.3 KB and needs no decoding at all.
+    /// </summary>
+    public class BluRaySupFadeStep
+    {
+        /// <summary>
+        /// When the alpha level takes effect, in milliseconds - the same time base as
+        /// <see cref="BluRaySupPicture.StartTime"/>.
+        /// </summary>
+        public long TimeMs { get; set; }
+
+        /// <summary>
+        /// Alpha of the palette at this step, 0 (invisible) to 100 (fully opaque).
+        /// </summary>
+        public int AlphaPercent { get; set; }
+
+        public long TimeForWrite => (long)Math.Round(TimeMs * 90.0, MidpointRounding.AwayFromZero);
+
+        public BluRaySupFadeStep()
+        {
+        }
+
+        public BluRaySupFadeStep(long timeMs, int alphaPercent)
+        {
+            TimeMs = timeMs;
+            AlphaPercent = alphaPercent;
+        }
+    }
+}

--- a/src/libse/BluRaySup/BluRaySupPicture.cs
+++ b/src/libse/BluRaySup/BluRaySupPicture.cs
@@ -104,6 +104,13 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
         public List<List<PaletteInfo>> Palettes { get; set; } = new List<List<PaletteInfo>>();
 
         /// <summary>
+        /// Alpha levels for a fade in/out, in presentation order. A step at <see cref="StartTime"/>
+        /// sets the alpha the caption appears with; every later step becomes a palette update
+        /// display set. Empty (the default) writes the caption fully opaque, as before.
+        /// </summary>
+        public List<BluRaySupFadeStep> FadeSteps { get; set; } = new List<BluRaySupFadeStep>();
+
+        /// <summary>
         /// Create RLE buffer from bitmap
         /// </summary>
         /// <param name="bm">Bitmap to compress</param>
@@ -445,6 +452,78 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
         private static long _lastEndTimeForWrite = -1000;
 
         /// <summary>
+        /// Splits <see cref="FadeSteps"/> into the alpha the caption appears with (part of the
+        /// epoch's own palette) and the steps that follow it as palette update display sets.
+        /// Steps outside the caption, and steps that do not change the alpha, are dropped - each
+        /// one would cost a display set for nothing.
+        /// </summary>
+        private static List<BluRaySupFadeStep> GetFadeSteps(BluRaySupPicture pic, out int startAlphaPercent)
+        {
+            startAlphaPercent = 100;
+            var updates = new List<BluRaySupFadeStep>();
+            if (pic.FadeSteps == null || pic.FadeSteps.Count == 0)
+            {
+                return updates;
+            }
+
+            var sorted = new List<BluRaySupFadeStep>(pic.FadeSteps);
+            sorted.Sort((a, b) => a.TimeMs.CompareTo(b.TimeMs));
+
+            var lastAlpha = 100;
+            var lastTime = long.MinValue;
+            foreach (var step in sorted)
+            {
+                var alpha = Math.Min(100, Math.Max(0, step.AlphaPercent));
+                if (step.TimeMs <= pic.StartTime)
+                {
+                    startAlphaPercent = alpha;
+                    lastAlpha = alpha;
+                    continue;
+                }
+
+                if (step.TimeMs >= pic.EndTime || alpha == lastAlpha || step.TimeMs == lastTime)
+                {
+                    continue;
+                }
+
+                updates.Add(new BluRaySupFadeStep(step.TimeMs, alpha));
+                lastAlpha = alpha;
+                lastTime = step.TimeMs;
+            }
+
+            return updates;
+        }
+
+        /// <summary>
+        /// Writes a Palette Definition Segment with every alpha scaled by
+        /// <paramref name="alphaPercent"/> - the whole of a Blu-ray fade is this one number
+        /// changing between display sets.
+        /// </summary>
+        private static int WritePds(byte[] buf, int index, byte[] packetHeader, BluRaySupPalette pal, int palSize, int paletteVersion, int alphaPercent)
+        {
+            packetHeader[10] = 0x14;                                      // ID (keep PTS & DTS)
+            ToolBox.SetWord(packetHeader, 11, 2 + palSize * 5);      // size
+            for (var i = 0; i < packetHeader.Length; i++)
+            {
+                buf[index++] = packetHeader[i];
+            }
+
+            buf[index++] = 0;                                             // palette_id
+            buf[index++] = (byte)paletteVersion;                          // palette_version_number
+            var alpha = pal.GetAlpha();
+            for (var i = 0; i < palSize; i++)
+            {
+                buf[index++] = (byte)i;                                   // index
+                buf[index++] = pal.GetY()[i];                             // Y
+                buf[index++] = pal.GetCr()[i];                            // Cr
+                buf[index++] = pal.GetCb()[i];                            // Cb
+                buf[index++] = (byte)(alpha[i] * alphaPercent / 100);     // Alpha
+            }
+
+            return index;
+        }
+
+        /// <summary>
         /// Create the binary stream representation of one caption
         /// </summary>
         /// <param name="pic">SubPicture object containing caption info - note that first Composition Number should be 0, then 2, 4, 8, etc.</param>
@@ -545,11 +624,16 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
                 0x40                    // 3: first_in_sequence (0x80), last_in_sequence (0x40), 6bits reserved
             };
 
-            var size = packetHeader.Length * (8 + numAddPackets);
+            // Fade steps ride along as palette update display sets (PCS + PDS + END) between the
+            // caption and the screen clear - same object, only the palette alpha changes.
+            var fadeSteps = GetFadeSteps(pic, out var startAlphaPercent);
+
+            var size = packetHeader.Length * (8 + numAddPackets + fadeSteps.Count * 3);
             size += headerPcsStart.Length + headerPcsEnd.Length;
             size += 2 * headerWds.Length + headerOdsFirst.Length;
             size += numAddPackets * headerOdsNext.Length;
             size += (2 + palSize * 5) /* PDS */;
+            size += fadeSteps.Count * (headerPcsStart.Length + 2 + palSize * 5);
             size += rleBuf.Length;
 
             switch (alignment)
@@ -679,23 +763,7 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
             }
 
             // write PDS - Palette Definition Segment
-            packetHeader[10] = 0x14;                                            // ID (keep PTS & DTS)
-            ToolBox.SetWord(packetHeader, 11, 2 + palSize * 5);        // size
-            for (var i = 0; i < packetHeader.Length; i++)
-            {
-                buf[index++] = packetHeader[i];
-            }
-
-            buf[index++] = 0;
-            buf[index++] = 0;
-            for (var i = 0; i < palSize; i++)
-            {
-                buf[index++] = (byte)i;                                         // index
-                buf[index++] = pal.GetY()[i];                                   // Y
-                buf[index++] = pal.GetCr()[i];                                  // Cr
-                buf[index++] = pal.GetCb()[i];                                  // Cb
-                buf[index++] = pal.GetAlpha()[i];                               // Alpha
-            }
+            index = WritePds(buf, index, packetHeader, pal, palSize, 0, startAlphaPercent);
 
             // write first OBJ
             var bufSize = rleBuf.Length;
@@ -763,6 +831,47 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
                 buf[index++] = packetHeader[i];
             }
 
+            // write the fade steps - one palette update display set each (PCS + PDS + END). The
+            // PCS repeats the composition of the epoch start with palette_update_flag set, which
+            // tells the decoder to keep the object it already has and only take the new palette.
+            var endPts = pic.EndTimeForWrite;
+            var compositionNumber = pic.CompositionNumber;
+            headerPcsStart[7] = 0x00;                                            // composition_state: normal case
+            headerPcsStart[8] = 0x80;                                            // palette_update_flag
+            for (var step = 0; step < fadeSteps.Count; step++)
+            {
+                // A step may only be scheduled after the caption is up and before it is taken
+                // down; the start PTS can have been nudged by the small gap removal above.
+                var stepPts = Math.Min(Math.Max(fadeSteps[step].TimeForWrite, pts + 1), endPts - 1);
+
+                compositionNumber++;
+                packetHeader[10] = 0x16;                                         // ID
+                ToolBox.SetDWord(packetHeader, 2, (uint)stepPts);           // PTS
+                ToolBox.SetDWord(packetHeader, 6, 0);                       // DTS (0 = unset)
+                ToolBox.SetWord(packetHeader, 11, headerPcsStart.Length);   // size
+                for (var i = 0; i < packetHeader.Length; i++)
+                {
+                    buf[index++] = packetHeader[i];
+                }
+
+                ToolBox.SetWord(headerPcsStart, 5, compositionNumber);
+                for (var i = 0; i < headerPcsStart.Length; i++)
+                {
+                    buf[index++] = headerPcsStart[i];
+                }
+
+                // The palette version has to move for the decoder to take the update; it is a
+                // byte, so it wraps on captions with more than 255 steps.
+                index = WritePds(buf, index, packetHeader, pal, palSize, (step + 1) & 0xff, fadeSteps[step].AlphaPercent);
+
+                packetHeader[10] = 0x80;                                         // END (keep PTS & DTS)
+                ToolBox.SetWord(packetHeader, 11, 0);                       // size
+                for (var i = 0; i < packetHeader.Length; i++)
+                {
+                    buf[index++] = packetHeader[i];
+                }
+            }
+
             // write PCS end
             packetHeader[10] = 0x16;                                            // ID
             ToolBox.SetDWord(packetHeader, 2, (uint)pic.EndTimeForWrite);        // PTS
@@ -776,7 +885,7 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
             ToolBox.SetWord(headerPcsEnd, 0, pic.Width);
             ToolBox.SetWord(headerPcsEnd, 2, h);                                // cropped height
             ToolBox.SetByte(headerPcsEnd, 4, fpsId);
-            ToolBox.SetWord(headerPcsEnd, 5, pic.CompositionNumber + 1);
+            ToolBox.SetWord(headerPcsEnd, 5, compositionNumber + 1);
             for (var i = 0; i < headerPcsEnd.Length; i++)
             {
                 buf[index++] = headerPcsEnd[i];

--- a/src/libuilogic/Export/ExportFade.cs
+++ b/src/libuilogic/Export/ExportFade.cs
@@ -1,0 +1,233 @@
+using Nikse.SubtitleEdit.Core.BluRaySup;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Nikse.SubtitleEdit.UiLogic.Export;
+
+/// <summary>
+/// One point of an ASSA fade curve: how opaque the subtitle is
+/// <paramref name="OffsetMs"/> milliseconds after it appears. The alpha between two
+/// keyframes is linear, as in ASSA.
+/// </summary>
+public record ExportFadeKeyframe(long OffsetMs, int AlphaPercent);
+
+/// <summary>
+/// Reads the ASSA fade tags - "{\fad(200,300)}" and the seven argument
+/// "{\fade(a1,a2,a3,t1,t2,t3,t4)}" - and turns them into the alpha steps the Blu-ray sup
+/// writer sends as palette update display sets.
+/// <para>
+/// Only image formats that can animate a palette use these; the other export handlers ignore
+/// them and keep drawing the subtitle fully opaque, exactly as before.
+/// </para>
+/// </summary>
+public static class ExportFade
+{
+    /// <summary>
+    /// Ceiling for the number of palette update display sets one subtitle may cost. A step is
+    /// a full palette (~1.3 KB), so a long fade sampled per frame would add hundreds of
+    /// kilobytes to the file for alpha differences no one can see; beyond this the fade is
+    /// sampled coarser instead.
+    /// </summary>
+    public const int MaxSteps = 60;
+
+    // "{\fad(200,300)}", also inside a multi tag block ("{\an8\fad(200,300)}") and with the
+    // closing parenthesis missing, which is what SE's own effects write ("{\fad(300,300}").
+    private static readonly Regex FadTagRegex = new(
+        @"\\fad\(\s*(\d+)\s*,\s*(\d+)\s*\)?",
+        RegexOptions.Compiled);
+
+    // "{\fade(255,0,255,0,500,2000,2200)}"
+    private static readonly Regex FadeTagRegex = new(
+        @"\\fade\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(-?\d+)\s*,\s*(-?\d+)\s*,\s*(-?\d+)\s*,\s*(-?\d+)\s*\)?",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// The fade curve of the text, or null when it has no fade tag. Times are clamped to the
+    /// duration, so a "{\fad(1000,1000)}" on a 500 ms line fades in and out inside those 500 ms
+    /// instead of never becoming visible.
+    /// </summary>
+    public static List<ExportFadeKeyframe>? Parse(string? text, long durationMs)
+    {
+        if (string.IsNullOrEmpty(text) || durationMs <= 0 || !text.Contains("\\fad", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        // "\fade" with seven arguments is the general form and wins - "\fad" only matches its
+        // first four letters, so a line carrying both would otherwise be read as "\fad".
+        var fade = FadeTagRegex.Match(text);
+        if (fade.Success)
+        {
+            return FromFade(
+                ToPercent(fade.Groups[1].Value),
+                ToPercent(fade.Groups[2].Value),
+                ToPercent(fade.Groups[3].Value),
+                ToMs(fade.Groups[4].Value),
+                ToMs(fade.Groups[5].Value),
+                ToMs(fade.Groups[6].Value),
+                ToMs(fade.Groups[7].Value),
+                durationMs);
+        }
+
+        var fad = FadTagRegex.Match(text);
+        if (fad.Success)
+        {
+            return FromFad(ToMs(fad.Groups[1].Value), ToMs(fad.Groups[2].Value), durationMs);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Samples the curve into the alpha steps of a Blu-ray epoch: the first step is the alpha
+    /// the subtitle appears with, the rest become palette update display sets. Sampling starts
+    /// at one step per video frame - a decoder cannot show more than that - and gets coarser
+    /// when a long fade would need more than <see cref="MaxSteps"/> of them.
+    /// </summary>
+    public static List<BluRaySupFadeStep> CreateSteps(IReadOnlyList<ExportFadeKeyframe>? keyframes, long startMs, long endMs, double fps)
+    {
+        var steps = new List<BluRaySupFadeStep>();
+        if (keyframes == null || keyframes.Count == 0 || endMs <= startMs)
+        {
+            return steps;
+        }
+
+        var frameMs = fps > 1 ? 1000.0 / fps : 40.0;
+        var durationMs = endMs - startMs;
+        for (var intervalMs = frameMs; ; intervalMs *= 2)
+        {
+            steps = Sample(keyframes, startMs, durationMs, intervalMs);
+            if (steps.Count <= MaxSteps || intervalMs >= durationMs)
+            {
+                break;
+            }
+        }
+
+        // A curve that never leaves 100% (an "{\fad(0,0)}") is not a fade - do not pay a
+        // display set for it.
+        return steps.Count == 1 && steps[0].AlphaPercent == 100 ? new List<BluRaySupFadeStep>() : steps;
+    }
+
+    private static List<BluRaySupFadeStep> Sample(IReadOnlyList<ExportFadeKeyframe> keyframes, long startMs, long durationMs, double intervalMs)
+    {
+        var steps = new List<BluRaySupFadeStep> { new BluRaySupFadeStep(startMs, AlphaPercentAt(keyframes, 0)) };
+        var lastAlpha = steps[0].AlphaPercent;
+        for (var offset = intervalMs; offset < durationMs; offset += intervalMs)
+        {
+            var alpha = AlphaPercentAt(keyframes, (long)Math.Round(offset));
+            if (alpha == lastAlpha)
+            {
+                continue;
+            }
+
+            var timeMs = startMs + (long)Math.Round(offset);
+            if (timeMs > steps[steps.Count - 1].TimeMs)
+            {
+                steps.Add(new BluRaySupFadeStep(timeMs, alpha));
+                lastAlpha = alpha;
+            }
+        }
+
+        return steps;
+    }
+
+    /// <summary>
+    /// The alpha of the curve <paramref name="offsetMs"/> after the subtitle appeared.
+    /// </summary>
+    public static int AlphaPercentAt(IReadOnlyList<ExportFadeKeyframe> keyframes, long offsetMs)
+    {
+        if (keyframes.Count == 0)
+        {
+            return 100;
+        }
+
+        if (offsetMs <= keyframes[0].OffsetMs)
+        {
+            return keyframes[0].AlphaPercent;
+        }
+
+        for (var i = 1; i < keyframes.Count; i++)
+        {
+            var to = keyframes[i];
+            if (offsetMs > to.OffsetMs)
+            {
+                continue;
+            }
+
+            var from = keyframes[i - 1];
+            var span = to.OffsetMs - from.OffsetMs;
+            if (span <= 0)
+            {
+                return to.AlphaPercent;
+            }
+
+            var progress = (offsetMs - from.OffsetMs) / (double)span;
+            return (int)Math.Round(from.AlphaPercent + (to.AlphaPercent - from.AlphaPercent) * progress);
+        }
+
+        return keyframes[keyframes.Count - 1].AlphaPercent;
+    }
+
+    private static List<ExportFadeKeyframe> FromFad(long fadeInMs, long fadeOutMs, long durationMs)
+    {
+        // The two ramps may not overlap - shrink both to fit rather than letting the subtitle
+        // start fading out before it has faded in.
+        if (fadeInMs + fadeOutMs > durationMs)
+        {
+            var scale = durationMs / (double)(fadeInMs + fadeOutMs);
+            fadeInMs = (long)(fadeInMs * scale);
+            fadeOutMs = (long)(fadeOutMs * scale);
+        }
+
+        var keyframes = new List<ExportFadeKeyframe>();
+        if (fadeInMs > 0)
+        {
+            keyframes.Add(new ExportFadeKeyframe(0, 0));
+        }
+
+        keyframes.Add(new ExportFadeKeyframe(fadeInMs, 100));
+        if (fadeOutMs > 0)
+        {
+            keyframes.Add(new ExportFadeKeyframe(durationMs - fadeOutMs, 100));
+            keyframes.Add(new ExportFadeKeyframe(durationMs, 0));
+        }
+
+        return keyframes;
+    }
+
+    private static List<ExportFadeKeyframe> FromFade(int alpha1, int alpha2, int alpha3, long t1, long t2, long t3, long t4, long durationMs)
+    {
+        // Times are offsets into the subtitle and must not run backwards; a tag that overshoots
+        // the line is cut at its end, as a player would show it.
+        t1 = Math.Min(Math.Max(t1, 0), durationMs);
+        t2 = Math.Min(Math.Max(t2, t1), durationMs);
+        t3 = Math.Min(Math.Max(t3, t2), durationMs);
+        t4 = Math.Min(Math.Max(t4, t3), durationMs);
+
+        return new List<ExportFadeKeyframe>
+        {
+            new ExportFadeKeyframe(0, alpha1),
+            new ExportFadeKeyframe(t1, alpha1),
+            new ExportFadeKeyframe(t2, alpha2),
+            new ExportFadeKeyframe(t3, alpha2),
+            new ExportFadeKeyframe(t4, alpha3),
+            new ExportFadeKeyframe(durationMs, alpha3),
+        };
+    }
+
+    /// <summary>
+    /// ASSA counts transparency, not opacity: 0 is opaque and 255 is invisible.
+    /// </summary>
+    private static int ToPercent(string assaAlpha)
+    {
+        var value = int.TryParse(assaAlpha, NumberStyles.Integer, CultureInfo.InvariantCulture, out var alpha)
+            ? Math.Min(Math.Max(alpha, 0), 255)
+            : 0;
+        return (int)Math.Round((255 - value) * 100.0 / 255.0);
+    }
+
+    private static long ToMs(string value)
+    {
+        return long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var ms) ? ms : 0;
+    }
+}

--- a/src/libuilogic/Export/ExportHandlerBluRaySup.cs
+++ b/src/libuilogic/Export/ExportHandlerBluRaySup.cs
@@ -35,16 +35,30 @@ public class ExportHandlerBluRaySup : IExportHandler
         _fileStream!.Close();
     }
 
+    /// <summary>
+    /// Composition numbers a single subtitle may use: one display set for the caption, one for
+    /// the screen clear and up to <see cref="ExportFade.MaxSteps"/> palette updates in between.
+    /// Every subtitle gets a block of its own - the numbers must keep climbing through the file
+    /// (they wrap at 16 bits, which is expected), gaps in them do no harm.
+    /// </summary>
+    private const int CompositionNumbersPerParagraph = ExportFade.MaxSteps + 2;
+
     private static void MakeBluRaySupImage(ImageParameter param)
     {
+        var startTime = (long)Math.Round(param.StartTime.TotalMilliseconds, MidpointRounding.AwayFromZero);
+        var endTime = (long)Math.Round(param.EndTime.TotalMilliseconds, MidpointRounding.AwayFromZero);
         var brSub = new BluRaySupPicture
         {
-            StartTime = (long)Math.Round(param.StartTime.TotalMilliseconds, MidpointRounding.AwayFromZero),
-            EndTime = (long)Math.Round(param.EndTime.TotalMilliseconds, MidpointRounding.AwayFromZero),
+            StartTime = startTime,
+            EndTime = endTime,
             Width = param.ScreenWidth,
             Height = param.ScreenHeight,
             IsForced = param.IsForced,
-            CompositionNumber = (param.Index + 1) * 2,
+            CompositionNumber = (param.Index + 1) * CompositionNumbersPerParagraph,
+
+            // "{\fad(..)}" - Blu-ray fades by re-sending the palette with the alpha scaled, so
+            // the subtitle is encoded once and each step costs a palette, not a bitmap.
+            FadeSteps = ExportFade.CreateSteps(param.FadeKeyframes, startTime, endTime, param.FramesPerSecond),
         };
         if (param.IsFullFrame)
         {

--- a/src/libuilogic/Export/ExportTextTags.cs
+++ b/src/libuilogic/Export/ExportTextTags.cs
@@ -23,6 +23,11 @@ public static class ExportTextTags
         @"\\pos\(\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*\)",
         RegexOptions.Compiled);
 
+    // "{\alpha&H80&}" and the per part "{\1a&H80&}" (fill), "{\3a}" (outline), "{\4a}" (shadow)
+    private static readonly Regex AlphaTagRegex = new(
+        @"\\(alpha|1a|3a|4a)&H([0-9A-Fa-f]{1,2})&",
+        RegexOptions.Compiled);
+
     /// <summary>
     /// Returns the alignment from a leading "{\anX}" tag - also inside a multi tag block
     /// like "{\an8\i1}" or "{\pos(10,20)\an8}" - or <paramref name="fallback"/> when there is none.
@@ -170,6 +175,83 @@ public static class ExportTextTags
         ip.OverridePosition = new SKPointI(
             (int)Math.Round(Math.Clamp(left, 0, maxLeft), MidpointRounding.AwayFromZero),
             (int)Math.Round(Math.Clamp(top, 0, maxTop), MidpointRounding.AwayFromZero));
+    }
+
+    /// <summary>
+    /// Reads the ASSA transparency tags off the text and puts them on the parameter: the fade
+    /// curve of "{\fad(..)}"/"{\fade(..)}" (used by the Blu-ray sup writer, which can animate
+    /// its palette) and the static transparency of "{\alpha&amp;H80&amp;}" and its per part
+    /// "{\1a}", "{\3a}", "{\4a}" variants.
+    /// <para>
+    /// Has to run before the bitmap is rendered - unlike <see cref="ApplyPositionTag"/>, this
+    /// changes what is drawn. A transparency that applies to text, outline and shadow alike is
+    /// kept for the finished bitmap, where one blend gives the exact alpha asked for; per part
+    /// transparencies go on the colours instead, so the parts can differ.
+    /// </para>
+    /// </summary>
+    public static void ApplyTransparencyTags(ImageParameter ip, string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return;
+        }
+
+        ip.FadeKeyframes = ExportFade.Parse(text, (long)Math.Round((ip.EndTime - ip.StartTime).TotalMilliseconds));
+
+        if (!text.Contains("a&H", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        int? all = null;
+        int? primary = null;
+        int? outline = null;
+        int? shadow = null;
+        foreach (Match match in AlphaTagRegex.Matches(text))
+        {
+            // ASSA counts transparency (00 = opaque, FF = invisible); opacity is the other way up.
+            var opacity = 255 - int.Parse(match.Groups[2].Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+            switch (match.Groups[1].Value)
+            {
+                case "alpha":
+                    all = opacity;
+                    break;
+                case "1a":
+                    primary = opacity;
+                    break;
+                case "3a":
+                    outline = opacity;
+                    break;
+                default: // "4a"
+                    shadow = opacity;
+                    break;
+            }
+        }
+
+        var primaryOpacity = primary ?? all ?? 255;
+        var outlineOpacity = outline ?? all ?? 255;
+        var shadowOpacity = shadow ?? all ?? 255;
+        if (primaryOpacity == 255 && outlineOpacity == 255 && shadowOpacity == 255)
+        {
+            return;
+        }
+
+        if (primaryOpacity == outlineOpacity && primaryOpacity == shadowOpacity)
+        {
+            // The whole subtitle at one transparency - applying it to the drawn bitmap keeps the
+            // outline from showing through the letters, which per colour alpha would do.
+            ip.AlphaPercent = (int)Math.Round(primaryOpacity * 100.0 / 255.0);
+            return;
+        }
+
+        ip.FontColor = Fade(ip.FontColor, primaryOpacity);
+        ip.OutlineColor = Fade(ip.OutlineColor, outlineOpacity);
+        ip.ShadowColor = Fade(ip.ShadowColor, shadowOpacity);
+    }
+
+    private static SKColor Fade(SKColor color, int opacity)
+    {
+        return color.WithAlpha((byte)(color.Alpha * opacity / 255));
     }
 
     /// <summary>

--- a/src/libuilogic/Export/ImageParameter.cs
+++ b/src/libuilogic/Export/ImageParameter.cs
@@ -42,6 +42,20 @@ public class ImageParameter
     /// </summary>
     public SKColor FullFrameBackgroundColor { get; set; } = SKColors.Transparent;
 
+    /// <summary>
+    /// Transparency of the whole rendered subtitle, 0-100, from an ASSA "{\alpha&amp;H80&amp;}"
+    /// tag (see <see cref="ExportTextTags.ApplyTransparencyTags"/>). 100 - fully opaque - unless
+    /// the text asks for less.
+    /// </summary>
+    public int AlphaPercent { get; set; } = 100;
+
+    /// <summary>
+    /// The "{\fad(..)}"/"{\fade(..)}" curve of the subtitle, or null when it has no fade tag.
+    /// Only used by the Blu-ray sup writer, which can fade with palette updates; the other
+    /// image formats have no way to animate a subtitle and ignore it.
+    /// </summary>
+    public List<ExportFadeKeyframe>? FadeKeyframes { get; set; }
+
     public double FramesPerSecond { get; set; }
     public bool IsRightToLeft { get; set; } = false;
     public ExportBoxType BoxType { get; set; } = ExportBoxType.None;

--- a/src/libuilogic/Export/ImageRenderer.cs
+++ b/src/libuilogic/Export/ImageRenderer.cs
@@ -60,6 +60,28 @@ public static class ImageRenderer
 
     public static SKBitmap GenerateBitmap(ImageParameter ip)
     {
+        var bitmap = RenderBitmap(ip);
+        if (ip.AlphaPercent >= 100)
+        {
+            return bitmap;
+        }
+
+        // "{\alpha&H80&}" - one blend over the finished subtitle, so text, outline, shadow and
+        // box all end up at the asked for alpha instead of showing through each other.
+        var alpha = (byte)(Math.Clamp(ip.AlphaPercent, 0, 100) * 255 / 100);
+        var faded = new SKBitmap(bitmap.Width, bitmap.Height, bitmap.ColorType, bitmap.AlphaType);
+        using (var canvas = new SKCanvas(faded))
+        using (var paint = new SKPaint { Color = SKColors.White.WithAlpha(alpha) })
+        {
+            canvas.Clear(SKColors.Transparent);
+            canvas.DrawBitmap(bitmap, 0, 0, paint);
+        }
+
+        return Replace(bitmap, faded);
+    }
+
+    private static SKBitmap RenderBitmap(ImageParameter ip)
+    {
         var fontName = ip.FontName;
         var fontSize = ip.FontSize;
         var fontColor = ip.FontColor;
@@ -772,7 +794,7 @@ public static class ImageRenderer
                     var r = Convert.ToByte(hex.Substring(0, 2), 16);
                     var g = Convert.ToByte(hex.Substring(2, 2), 16);
                     var b = Convert.ToByte(hex.Substring(4, 2), 16);
-                    return new SKColor(r, g, b);
+                    return new SKColor(r, g, b, defaultFontColor.Alpha);
                 }
                 catch
                 {
@@ -781,7 +803,9 @@ public static class ImageRenderer
             }
 
             // Handle named colors (basic set)
-            return colorValue.ToLowerInvariant() switch
+            // A colour tag only says which colour, never how transparent - a "{\\1a&H80&}" on the
+            // line reached the default colour's alpha, so carry that over to the tag colours too.
+            var named = colorValue.ToLowerInvariant() switch
             {
                 "red" => SKColors.Red,
                 "green" => SKColors.Green,
@@ -795,6 +819,8 @@ public static class ImageRenderer
                 "gray" or "grey" => SKColors.Gray,
                 _ => defaultFontColor
             };
+
+            return named.WithAlpha(defaultFontColor.Alpha);
         }
 
         return defaultFontColor;

--- a/src/seconv/Core/ImageOutputWriter.cs
+++ b/src/seconv/Core/ImageOutputWriter.cs
@@ -187,7 +187,7 @@ internal static class ImageOutputWriter
         // the frame (issue #13025) - as were "{\i1}", "{\b1}" and "{\c&H..&}", which
         // ToRenderableText turns into the HTML tags the renderer understands.
         var text = p.Text ?? string.Empty;
-        return new ImageParameter
+        var imageParameter = new ImageParameter
         {
             Index = index,
             Text = ExportTextTags.ToRenderableText(text),
@@ -223,5 +223,11 @@ internal static class ImageOutputWriter
             IsFullFrame = false,
             Error = string.Empty,
         };
+
+        // "{\fad(..)}" and "{\alpha&H..&}" change what is drawn, so they have to be read
+        // before the bitmap is rendered.
+        ExportTextTags.ApplyTransparencyTags(imageParameter, text);
+
+        return imageParameter;
     }
 }

--- a/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
+++ b/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
@@ -561,6 +561,10 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
             FullFrameBackgroundColor = FullFrameBackgroundColor.ToSKColor(),
         };
 
+        // "{\fad(..)}" and "{\alpha&H..&}" change what is drawn, so unlike the position tag
+        // they have to be read before the bitmap is rendered.
+        ExportTextTags.ApplyTransparencyTags(imageParameter, subtitle.Text);
+
         return imageParameter;
     }
 

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -1941,6 +1941,9 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
                 FullFrameBackgroundColor = profile.FullFrameBackgroundColor.FromHexToColor().ToSKColor(),
             };
 
+            // "{\fad(..)}" and "{\alpha&H..&}" change what is drawn - read before rendering.
+            ExportTextTags.ApplyTransparencyTags(imageParameter, subtitle.Text);
+
             imageParameter.Bitmap = ExportImageBasedViewModel.GenerateBitmap(imageParameter);
 
             // "{\pos(x,y)}" anchors the rendered text, so it needs the bitmap size - and the

--- a/tests/libuilogic/Export/ExportFadeTests.cs
+++ b/tests/libuilogic/Export/ExportFadeTests.cs
@@ -1,0 +1,152 @@
+using Nikse.SubtitleEdit.UiLogic.Export;
+using SkiaSharp;
+
+namespace LibUiLogicTests.Export;
+
+/// <summary>
+/// Reading the ASSA transparency tags for image export: "{\fad(..)}"/"{\fade(..)}" become the
+/// alpha curve the Blu-ray writer fades along, "{\alpha&amp;H..&amp;}" & co. dim the subtitle.
+/// </summary>
+public class ExportFadeTests
+{
+    private static ImageParameter Parameter(long durationMs = 2000)
+    {
+        return new ImageParameter
+        {
+            StartTime = TimeSpan.Zero,
+            EndTime = TimeSpan.FromMilliseconds(durationMs),
+            FontColor = SKColors.White,
+            OutlineColor = SKColors.Black,
+            ShadowColor = SKColors.Black,
+            ScreenWidth = 1920,
+            ScreenHeight = 1080,
+        };
+    }
+
+    [Theory]
+    [InlineData("Hello")]
+    [InlineData("{\\an8}Hello")]
+    [InlineData("{\\pos(10,20)}Hello")]
+    public void Parse_NoFadeTag_IsNull(string text)
+    {
+        Assert.Null(ExportFade.Parse(text, 2000));
+    }
+
+    [Fact]
+    public void Parse_Fad_RampsFromInvisibleAndBackToInvisible()
+    {
+        var keyframes = ExportFade.Parse("{\\fad(400,600)}Hello", 2000)!;
+
+        Assert.Equal(0, ExportFade.AlphaPercentAt(keyframes, 0));
+        Assert.Equal(50, ExportFade.AlphaPercentAt(keyframes, 200));
+        Assert.Equal(100, ExportFade.AlphaPercentAt(keyframes, 400));
+        Assert.Equal(100, ExportFade.AlphaPercentAt(keyframes, 1400));
+        Assert.Equal(50, ExportFade.AlphaPercentAt(keyframes, 1700));
+        Assert.Equal(0, ExportFade.AlphaPercentAt(keyframes, 2000));
+    }
+
+    [Fact]
+    public void Parse_Fad_InsideATagBlockAndWithoutTheClosingParenthesis()
+    {
+        // "{\fad(300,300}" is what SE's own effects write.
+        Assert.Equal(100, ExportFade.AlphaPercentAt(ExportFade.Parse("{\\an8\\fad(300,300}Hello", 2000)!, 300));
+    }
+
+    [Fact]
+    public void Parse_Fad_LongerThanTheLine_ShrinksBothRamps()
+    {
+        // Fading in for 1000 ms and out for 1000 ms on a 500 ms line would never show the text.
+        var keyframes = ExportFade.Parse("{\\fad(1000,1000)}Hello", 500)!;
+
+        Assert.Equal(100, ExportFade.AlphaPercentAt(keyframes, 250));
+        Assert.Equal(0, ExportFade.AlphaPercentAt(keyframes, 0));
+        Assert.Equal(0, ExportFade.AlphaPercentAt(keyframes, 500));
+    }
+
+    [Fact]
+    public void Parse_Fade_UsesItsOwnAlphasAndTimes()
+    {
+        // Invisible until 500 ms, fully there from 1000 to 1500 ms, half faded at the end.
+        var keyframes = ExportFade.Parse("{\\fade(255,0,128,500,1000,1500,2000)}Hello", 2000)!;
+
+        Assert.Equal(0, ExportFade.AlphaPercentAt(keyframes, 0));
+        Assert.Equal(0, ExportFade.AlphaPercentAt(keyframes, 500));
+        Assert.Equal(50, ExportFade.AlphaPercentAt(keyframes, 750));
+        Assert.Equal(100, ExportFade.AlphaPercentAt(keyframes, 1200));
+        Assert.Equal(50, ExportFade.AlphaPercentAt(keyframes, 2000));
+    }
+
+    [Fact]
+    public void Parse_FadeWinsOverFad()
+    {
+        // "\fade" starts with the letters of "\fad" - a line with both must not be read as "\fad".
+        Assert.Equal(0, ExportFade.AlphaPercentAt(ExportFade.Parse("{\\fade(255,0,255,0,1000,1000,2000)}Hi", 2000)!, 0));
+    }
+
+    [Fact]
+    public void CreateSteps_SamplesPerFrameAndStartsAtTheCaption()
+    {
+        var steps = ExportFade.CreateSteps(ExportFade.Parse("{\\fad(400,0)}Hello", 2000), 1000, 3000, 25);
+
+        Assert.Equal(1000, steps[0].TimeMs);
+        Assert.Equal(0, steps[0].AlphaPercent);
+        Assert.Equal(100, steps[steps.Count - 1].AlphaPercent);
+        Assert.Equal(steps.Select(s => s.TimeMs).OrderBy(t => t), steps.Select(s => s.TimeMs));
+        Assert.All(steps, s => Assert.InRange(s.TimeMs, 1000, 3000));
+
+        // 400 ms at 25 fps is ten frames, and each of them changes the alpha by 10%.
+        Assert.Equal(11, steps.Count);
+    }
+
+    [Fact]
+    public void CreateSteps_LongFade_SamplesCoarserRatherThanFloodingTheFile()
+    {
+        var steps = ExportFade.CreateSteps(ExportFade.Parse("{\\fad(30000,30000)}Hello", 60000), 0, 60000, 25);
+
+        Assert.InRange(steps.Count, 2, ExportFade.MaxSteps);
+    }
+
+    [Fact]
+    public void CreateSteps_NoFade_CostsNothing()
+    {
+        Assert.Empty(ExportFade.CreateSteps(ExportFade.Parse("{\\fad(0,0)}Hello", 2000), 0, 2000, 25));
+        Assert.Empty(ExportFade.CreateSteps(null, 0, 2000, 25));
+    }
+
+    [Fact]
+    public void ApplyTransparencyTags_Alpha_DimsTheWholeSubtitle()
+    {
+        var parameter = Parameter();
+
+        ExportTextTags.ApplyTransparencyTags(parameter, "{\\alpha&H80&}Hello");
+
+        Assert.Equal(50, parameter.AlphaPercent);
+        Assert.Equal(255, parameter.FontColor.Alpha);
+        Assert.Equal(255, parameter.OutlineColor.Alpha);
+    }
+
+    [Fact]
+    public void ApplyTransparencyTags_PerPartAlpha_GoesOnTheColours()
+    {
+        var parameter = Parameter();
+
+        ExportTextTags.ApplyTransparencyTags(parameter, "{\\1a&H80&\\3a&HFF&}Hello");
+
+        Assert.Equal(100, parameter.AlphaPercent);
+        Assert.Equal(127, parameter.FontColor.Alpha);
+        Assert.Equal(0, parameter.OutlineColor.Alpha);
+        Assert.Equal(255, parameter.ShadowColor.Alpha);
+    }
+
+    [Fact]
+    public void ApplyTransparencyTags_NoAlphaTag_ChangesNothing()
+    {
+        var parameter = Parameter();
+
+        ExportTextTags.ApplyTransparencyTags(parameter, "{\\an8}Hello");
+
+        Assert.Equal(100, parameter.AlphaPercent);
+        Assert.Equal(255, parameter.FontColor.Alpha);
+        Assert.Null(parameter.FadeKeyframes);
+    }
+}

--- a/tests/libuilogic/Export/ExportHandlerBluRaySupFadeTests.cs
+++ b/tests/libuilogic/Export/ExportHandlerBluRaySupFadeTests.cs
@@ -1,0 +1,209 @@
+using Nikse.SubtitleEdit.Core.BluRaySup;
+using Nikse.SubtitleEdit.UiLogic.Export;
+using SkiaSharp;
+using System.Text;
+
+namespace LibUiLogicTests.Export;
+
+/// <summary>
+/// "{\fad(..)}" on a Blu-ray sup export: the caption is encoded once and the fade rides along as
+/// palette update display sets - a PCS with palette_update_flag set plus a PDS whose alphas are
+/// scaled - so the fade costs palettes instead of bitmaps.
+/// </summary>
+public class ExportHandlerBluRaySupFadeTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), "bluraysupfade_" + Guid.NewGuid().ToString("N"));
+
+    public ExportHandlerBluRaySupFadeTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, true); } catch { /* best effort */ }
+    }
+
+    private sealed record Segment(long Pts, byte Type, byte[] Payload);
+
+    private static ImageParameter Cue(string text)
+    {
+        var bitmap = new SKBitmap(300, 80);
+        using (var canvas = new SKCanvas(bitmap))
+        {
+            canvas.Clear(SKColors.Transparent);
+            using var paint = new SKPaint { Color = SKColors.White };
+            canvas.DrawRect(0, 0, 300, 80, paint);
+        }
+
+        var parameter = new ImageParameter
+        {
+            Text = ExportTextTags.ToRenderableText(text),
+            Bitmap = bitmap,
+            StartTime = TimeSpan.FromSeconds(1),
+            EndTime = TimeSpan.FromSeconds(3),
+            Index = 0,
+            ScreenWidth = 1280,
+            ScreenHeight = 720,
+            Alignment = ExportAlignment.BottomCenter,
+            BottomTopMargin = 50,
+            LeftRightMargin = 40,
+            FramesPerSecond = 25,
+            FontColor = SKColors.White,
+        };
+
+        ExportTextTags.ApplyTransparencyTags(parameter, text);
+        return parameter;
+    }
+
+    private string Export(string text)
+    {
+        var fileName = Path.Combine(_dir, Guid.NewGuid().ToString("N") + ".sup");
+        var handler = new ExportHandlerBluRaySup();
+        var cue = Cue(text);
+
+        handler.WriteHeader(fileName, cue);
+        handler.CreateParagraph(cue);
+        handler.WriteParagraph(cue);
+        handler.WriteFooter();
+
+        return fileName;
+    }
+
+    /// <summary>
+    /// Walks the file as "PG" + PTS(4) + DTS(4) + type(1) + size(2) + payload, which also proves
+    /// the segments chain exactly to the end - a wrong buffer size would leave a tail behind.
+    /// </summary>
+    private static List<Segment> ReadSegments(string fileName)
+    {
+        var sup = File.ReadAllBytes(fileName);
+        var segments = new List<Segment>();
+        var position = 0;
+        while (position + 13 <= sup.Length)
+        {
+            Assert.Equal(0x50, sup[position]);
+            Assert.Equal(0x47, sup[position + 1]);
+            var pts = ((long)sup[position + 2] << 24) | ((long)sup[position + 3] << 16) | ((long)sup[position + 4] << 8) | sup[position + 5];
+            var size = (sup[position + 11] << 8) + sup[position + 12];
+            segments.Add(new Segment(pts, sup[position + 10], sup.Skip(position + 13).Take(size).ToArray()));
+            position += 13 + size;
+        }
+
+        Assert.Equal(sup.Length, position);
+        return segments;
+    }
+
+    // Alpha of the first palette entry - the font colour, so it carries the fade.
+    private static int FontAlpha(Segment pds) => pds.Payload[2 + 4];
+
+    [Fact]
+    public void NoFadeTag_WritesTheDisplaySetsItAlwaysDid()
+    {
+        var segments = ReadSegments(Export("Hello"));
+
+        Assert.Equal(new byte[] { 0x16, 0x17, 0x14, 0x15, 0x80, 0x16, 0x17, 0x80 }, segments.Select(s => s.Type));
+        Assert.Equal(255, FontAlpha(segments[2]));
+    }
+
+    [Fact]
+    public void Fade_AddsPaletteUpdateDisplaySetsBetweenTheCaptionAndTheClear()
+    {
+        var segments = ReadSegments(Export("{\\fad(400,400)}Hello"));
+
+        // Caption (PCS, WDS, PDS, ODS, END), then a PCS + PDS + END per step, then the clear.
+        var updates = segments.Skip(5).SkipLast(3).ToList();
+        Assert.NotEmpty(updates);
+        Assert.True(updates.Count % 3 == 0);
+        for (var i = 0; i < updates.Count; i += 3)
+        {
+            var pcs = updates[i];
+            Assert.Equal(0x16, pcs.Type);
+            Assert.Equal(0x00, pcs.Payload[7]);        // composition_state: normal case
+            Assert.Equal(0x80, pcs.Payload[8]);        // palette_update_flag
+            Assert.Equal(1, pcs.Payload[10]);          // the object stays composed
+            Assert.Equal(0x14, updates[i + 1].Type);   // and only the palette is re-sent
+            Assert.Equal(0x80, updates[i + 2].Type);
+        }
+    }
+
+    [Fact]
+    public void Fade_RampsTheAlphaUpAndDownInsideTheCaption()
+    {
+        var segments = ReadSegments(Export("{\\fad(400,400)}Hello"));
+        var palettes = segments.Where(s => s.Type == 0x14).ToList();
+        var alphas = palettes.Select(FontAlpha).ToList();
+
+        Assert.Equal(0, alphas[0]);                     // appears invisible
+        Assert.Equal(255, alphas.Max());                // reaches the palette's own alpha
+        var peak = alphas.IndexOf(255);
+        Assert.Equal(alphas.Take(peak + 1).OrderBy(a => a), alphas.Take(peak + 1));
+        Assert.Equal(alphas.Skip(alphas.LastIndexOf(255)).OrderByDescending(a => a), alphas.Skip(alphas.LastIndexOf(255)));
+        Assert.True(alphas[alphas.Count - 1] < 60, $"last step should be nearly gone, was {alphas[alphas.Count - 1]}");
+
+        // Palette version has to move for a decoder to take an update.
+        Assert.Equal(Enumerable.Range(0, palettes.Count), palettes.Select(p => (int)p.Payload[1]));
+
+        // Every update is inside the caption, in presentation order.
+        var updatePts = segments.Where(s => s.Type == 0x16).Select(s => s.Pts).ToList();
+        Assert.Equal(1000 * 90, updatePts[0]);
+        Assert.Equal(3000 * 90, updatePts[updatePts.Count - 1]);
+        Assert.Equal(updatePts.OrderBy(p => p), updatePts);
+        Assert.Equal(updatePts.Distinct(), updatePts);
+    }
+
+    [Fact]
+    public void Fade_KeepsCompositionNumbersClimbing()
+    {
+        var segments = ReadSegments(Export("{\\fad(400,400)}Hello"));
+        var compositionNumbers = segments
+            .Where(s => s.Type == 0x16)
+            .Select(s => (s.Payload[5] << 8) + s.Payload[6])
+            .ToList();
+
+        Assert.Equal(Enumerable.Range(compositionNumbers[0], compositionNumbers.Count), compositionNumbers);
+    }
+
+    [Fact]
+    public void Fade_ReadsBackAsOneSubtitlePerLine()
+    {
+        // SE's own parser merges the identical bitmaps of a fade (it takes three faded lines
+        // for its "is this a fade" heuristic to say yes), so a faded export still round-trips
+        // into one line per subtitle rather than one per step.
+        var fileName = Path.Combine(_dir, "multi.sup");
+        var handler = new ExportHandlerBluRaySup();
+        var cues = Enumerable.Range(0, 4).Select(i =>
+        {
+            var cue = Cue("{\\fad(400,400)}Hello");
+            cue.Index = i;
+            cue.StartTime = TimeSpan.FromSeconds(1 + i * 3);
+            cue.EndTime = TimeSpan.FromSeconds(3 + i * 3);
+            return cue;
+        }).ToList();
+
+        handler.WriteHeader(fileName, cues[0]);
+        foreach (var cue in cues)
+        {
+            handler.CreateParagraph(cue);
+            handler.WriteParagraph(cue);
+        }
+
+        handler.WriteFooter();
+
+        var subtitles = BluRaySupParser.ParseBluRaySup(fileName, new StringBuilder());
+
+        Assert.Equal(4, subtitles.Count);
+        Assert.Equal(1000, subtitles[0].StartTimeCode.TotalMilliseconds, 1);
+        Assert.Equal(3000, subtitles[0].EndTimeCode.TotalMilliseconds, 1);
+        using var bitmap = subtitles[0].GetBitmap();
+        Assert.Equal(300, bitmap.Width);
+    }
+
+    [Fact]
+    public void LongFade_StaysWithinTheStepBudget()
+    {
+        var cue = Cue("{\\fade(255,0,255,0,20000,40000,60000)}Hello");
+        cue.StartTime = TimeSpan.Zero;
+        cue.EndTime = TimeSpan.FromSeconds(60);
+        ExportTextTags.ApplyTransparencyTags(cue, "{\\fade(255,0,255,0,20000,40000,60000)}Hello");
+        var steps = ExportFade.CreateSteps(cue.FadeKeyframes, 0, 60000, 25);
+
+        Assert.InRange(steps.Count, 2, ExportFade.MaxSteps);
+    }
+}


### PR DESCRIPTION
A subtitle with `{\fad(400,400)}` was exported fully opaque - the tag was stripped along with everything else the image renderer cannot draw, so the fades SE's own effects write never reached the disc. Inspired by [connollydavid/FFmpeg `pgs7-8.1`](https://github.com/connollydavid/FFmpeg/tree/pgs7-8.1), whose PGS encoder does the same thing from the other end (it classifies alpha-only runs of libass-rendered frames).

## How the fade is written

Blu-ray fades by re-sending its **palette**, not its bitmap. The object goes out once at the epoch start; every step after it is a display set of

- `PCS` — composition_state *normal case*, `palette_update_flag` set, same composition objects
- `PDS` — same palette id, next version, every entry's alpha scaled
- `END`

~1.3 KB a step instead of kilobytes of RLE, which is what makes fading at video frame rate affordable and keeps it inside the decoder's pixel transfer budget. Steps are sampled one per frame, and a long fade is sampled coarser rather than adding hundreds of them to a single subtitle (60 is the ceiling). Composition numbers are blocked per paragraph so they keep climbing through a fade - `CreateParagraph` runs inside a `Parallel.For`, so a running counter was not available.

`{\fad(t1,t2)}` (including the unclosed `{\fad(300,300}` SE's own effects write) and the seven argument `{\fade(a1,a2,a3,t1,t2,t3,t4)}` both become a linear alpha curve; ramps that do not fit the line are shrunk instead of leaving the text invisible.

## Static transparency

`{\alpha&H80&}` and the per part `{\1a}`, `{\3a}`, `{\4a}` are read at the same time and apply to **every** image format. One transparency covering text, outline and shadow is blended over the finished bitmap - exact, and the outline does not show through the letters the way per colour alpha would; per part values go on the individual colours instead.

Wired into all three export paths: File → Export image-based, batch convert, and `seconv`.

## Verified

`seconv fade.ass "Blu-ray sup"`, decoded with ffmpeg (an independent PGS implementation), measuring max luma of the subtitle band over black:

```
ffmpeg -f lavfi -i color=c=black:s=1920x1080:r=25:d=16 -i fade.sup \
  -filter_complex "[0:v][1:s]overlay,crop=1920:300:0:780,signalstats,metadata=print:key=lavfi.signalstats.YMAX" \
  -f null -
```

16 → 235 in ten even frames over a 400 ms fade-in, flat at 235, back to 16 exactly at the caption end; an untagged line stays at 235 throughout; `{\alpha&H80&}` sits at 125, half way. Plus 20 new tests (raw segment layout, alpha ramp, palette versions, composition numbers, parser round-trip); the full libse / libuilogic / seconv / UI suites pass.

## Notes

- A line without a fade tag produces byte-identical output to before.
- File size is the real cost: `\fad(400,400)` at 25 fps adds ~20 steps ≈ 26 KB per line. Inherent to PGS fading; the step cap bounds the worst case.
- The other image formats have no way to animate a subtitle and ignore `\fad` - VobSub/DVD sup could animate their own palettes, but that is a separate job.
- Pixel-changing tags (`\move`, `\t` transforms, karaoke) do not fit the palette-update model at all; they need the render-every-frame-through-libass route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)