### PR TITLE
Add the SE 4 bookmark, underline and "guess start" shortcuts

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -4174,6 +4174,49 @@ public class AudioVisualizer : Control
         return -1;
     }
 
+    /// <summary>
+    /// The lowest peak in a time range, as a percentage of the highest peak in the file.
+    /// Used by "guess start" to find the noise floor around a cue (SE 4 parity).
+    /// </summary>
+    public double FindLowPercentage(double startSeconds, double endSeconds)
+    {
+        if (WavePeaks == null || WavePeaks.Peaks.Count == 0 || WavePeaks.HighestPeak == 0)
+        {
+            return 0;
+        }
+
+        var min = Math.Max(0, SecondsToSampleIndex(startSeconds));
+        var max = Math.Min(WavePeaks.Peaks.Count, SecondsToSampleIndex(endSeconds));
+        if (max <= min)
+        {
+            return 0;
+        }
+
+        var minMax = GetMinAndMax(min, max);
+        return minMax.Min * 100.0 / WavePeaks.HighestPeak;
+    }
+
+    /// <summary>
+    /// The highest peak in a time range, as a percentage of the highest peak in the file.
+    /// </summary>
+    public double FindHighPercentage(double startSeconds, double endSeconds)
+    {
+        if (WavePeaks == null || WavePeaks.Peaks.Count == 0 || WavePeaks.HighestPeak == 0)
+        {
+            return 0;
+        }
+
+        var min = Math.Max(0, SecondsToSampleIndex(startSeconds));
+        var max = Math.Min(WavePeaks.Peaks.Count, SecondsToSampleIndex(endSeconds));
+        if (max <= min)
+        {
+            return 0;
+        }
+
+        var minMax = GetMinAndMax(min, max);
+        return minMax.Max * 100.0 / WavePeaks.HighestPeak;
+    }
+
     private MinMax GetMinAndMax(int startIndex, int endIndex)
     {
         if (WavePeaks == null || WavePeaks.Peaks.Count == 0)

--- a/src/ui/Features/Assa/AssaAttachmentsViewModel.cs
+++ b/src/ui/Features/Assa/AssaAttachmentsViewModel.cs
@@ -31,8 +31,10 @@ public partial class AssaAttachmentsViewModel : ObservableObject
     [ObservableProperty] private bool _isCopyFontnameToClipboardVisible;
     [ObservableProperty] private bool _isDeleteVisible;
     [ObservableProperty] private bool _isDeleteAllVisible;
+    [ObservableProperty] private bool _isMoveVisible;
 
     public Window? Window { get; internal set; }
+    public TableView AttachmentGrid { get; set; }
     public bool OkPressed { get; private set; }
     public string Header { get; set; }
     public string Footer { get; set; }
@@ -60,6 +62,28 @@ public partial class AssaAttachmentsViewModel : ObservableObject
         Header = string.Empty;
         Footer = string.Empty;
         _subtitle = new Subtitle();
+        AttachmentGrid = new TableView();
+    }
+
+    [RelayCommand]
+    private void MoveUp() => MoveAttachments(ListMoveDirection.Up);
+
+    [RelayCommand]
+    private void MoveDown() => MoveAttachments(ListMoveDirection.Down);
+
+    [RelayCommand]
+    private void MoveToTop() => MoveAttachments(ListMoveDirection.Top);
+
+    [RelayCommand]
+    private void MoveToBottom() => MoveAttachments(ListMoveDirection.Bottom);
+
+    /// <summary>
+    /// Reorders the selected attachments, as in SE 4. The list order is not presentation-only -
+    /// it is the order the attachments are written back to the [Fonts]/[Graphics] sections on OK.
+    /// </summary>
+    private void MoveAttachments(ListMoveDirection direction)
+    {
+        TableViewExtras.MoveSelectedRows(AttachmentGrid, Attachments, direction);
     }
 
     [RelayCommand]
@@ -627,6 +651,7 @@ public partial class AssaAttachmentsViewModel : ObservableObject
     {
         IsDeleteAllVisible = Attachments.Count > 0;
         IsDeleteVisible = SelectedAttachment != null;
+        IsMoveVisible = Attachments.Count > 1 && AttachmentGrid.SelectedItems?.Count > 0;
     }
 
     internal void AttachmentsDataGridKeyDown(object? sender, KeyEventArgs e)
@@ -634,6 +659,30 @@ public partial class AssaAttachmentsViewModel : ObservableObject
         if (e.Key == Key.Delete && SelectedAttachment != null)
         {
             AttachmentRemove();
+            e.Handled = true;
+        }
+    }
+
+    /// <summary>
+    /// Ctrl+Up/Ctrl+Down reorder the selected attachments, as in SE 4. Tunneled, because the
+    /// ListBox underneath TableView handles Ctrl+Arrow itself (move focus without changing
+    /// the selection) and a bubbling handler would never see the key.
+    /// </summary>
+    internal void AttachmentsMoveKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.KeyModifiers != KeyModifiers.Control || e.Source is TextBox)
+        {
+            return;
+        }
+
+        if (e.Key == Key.Up)
+        {
+            MoveAttachments(ListMoveDirection.Up);
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Down)
+        {
+            MoveAttachments(ListMoveDirection.Down);
             e.Handled = true;
         }
     }

--- a/src/ui/Features/Assa/AssaAttachmentsWindow.cs
+++ b/src/ui/Features/Assa/AssaAttachmentsWindow.cs
@@ -1,9 +1,11 @@
 ﻿using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
 using System.Collections;
+using System.Windows.Input;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 
@@ -134,7 +136,9 @@ public class AssaAttachmentsWindow : Window
         dataGrid.Bind(TableView.SelectedItemProperty, new Binding(nameof(vm.SelectedAttachment)) { Source = vm });
         dataGrid.SelectionChanged += vm.DataGridSelectionChanged;
         dataGrid.KeyDown += vm.AttachmentsDataGridKeyDown;
+        dataGrid.AddHandler(InputElement.KeyDownEvent, vm.AttachmentsMoveKeyDown, RoutingStrategies.Tunnel);
         TableViewExtras.AttachListNavigation(dataGrid);
+        vm.AttachmentGrid = dataGrid;
 
         var flyout = new MenuFlyout();
         flyout.Opening += vm.AttachmentsContextMenuOpening;
@@ -159,9 +163,44 @@ public class AssaAttachmentsWindow : Window
         menuItemClear.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsDeleteAllVisible)) { Source = vm });
         flyout.Items.Add(menuItemClear);
 
+        AddMoveMenuItems(flyout, vm);
+
         grid.Add(dataGrid, 0);
 
         return UiUtil.MakeBorderForControlNoPadding(grid);
+    }
+
+    /// <summary>
+    /// The "move up/down/to top/to bottom" block of the attachments context menu, as in SE 4.
+    /// The attachments are written back to the subtitle footer in list order on OK, so this is
+    /// real reordering, not a view sort.
+    /// </summary>
+    private static void AddMoveMenuItems(MenuFlyout flyout, AssaAttachmentsViewModel vm)
+    {
+        var separator = new Separator();
+        separator.Bind(Separator.IsVisibleProperty, new Binding(nameof(vm.IsMoveVisible)) { Source = vm });
+        flyout.Items.Add(separator);
+
+        var items = new (string Header, ICommand Command, KeyGesture? Gesture)[]
+        {
+            (Se.Language.General.MoveUp, vm.MoveUpCommand, new KeyGesture(Key.Up, KeyModifiers.Control)),
+            (Se.Language.General.MoveDown, vm.MoveDownCommand, new KeyGesture(Key.Down, KeyModifiers.Control)),
+            (Se.Language.General.MoveToTop, vm.MoveToTopCommand, null),
+            (Se.Language.General.MoveToBottom, vm.MoveToBottomCommand, null),
+        };
+
+        foreach (var (header, command, gesture) in items)
+        {
+            var menuItem = new MenuItem
+            {
+                Header = header,
+                DataContext = vm,
+                Command = command,
+                InputGesture = gesture,
+            };
+            menuItem.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsMoveVisible)) { Source = vm });
+            flyout.Items.Add(menuItem);
+        }
     }
 
     private static Border MakeRightView(AssaAttachmentsViewModel vm)

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -5013,6 +5013,118 @@ public partial class MainViewModel :
         }
     }
 
+    /// <summary>
+    /// SE 4 parity ("guess start"): looks for the silence right before the speech that starts the
+    /// selected line and moves the start cue there, snapping to a nearby shot change when there is
+    /// one. Raising the volume threshold step by step finds the quietest boundary that still reads
+    /// as silence. Moving the start forward keeps the duration when that would otherwise break the
+    /// minimum duration/maximum CPS rules and there is room before the next line.
+    /// </summary>
+    [RelayCommand]
+    private void WaveformGuessStart()
+    {
+        var selected = SelectedSubtitle;
+        if (selected == null || AreTimeCodesLocked || AudioVisualizer?.WavePeaks == null)
+        {
+            return;
+        }
+
+        var index = Subtitles.IndexOf(selected);
+        if (index < 0)
+        {
+            return;
+        }
+
+        const double silenceLengthInSeconds = 0.08;
+        var startSeconds = selected.StartTime.TotalSeconds;
+        var lowPercent = AudioVisualizer.FindLowPercentage(startSeconds - 0.3, startSeconds + 0.1);
+        var highPercent = AudioVisualizer.FindHighPercentage(startSeconds - 0.3, startSeconds + 0.4);
+        var add = 5.0;
+        if (highPercent > 40)
+        {
+            add = 8;
+        }
+        else if (highPercent < 5)
+        {
+            add = highPercent - lowPercent - 0.3;
+        }
+
+        var gapMs = Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
+        var prev = GetPreviousWorkingRow(index);
+        var next = GetNextWorkingRow(index);
+
+        for (var startVolume = lowPercent + add; startVolume < 14; startVolume += 0.3)
+        {
+            var pos = AudioVisualizer.FindDataBelowThresholdBackForStart(startVolume, silenceLengthInSeconds, startSeconds);
+            if (pos < 0 || pos <= startSeconds - 1)
+            {
+                continue;
+            }
+
+            // A slightly higher threshold that still lands inside the same silence is the
+            // better guess - it sits closer to the speech.
+            var pos2 = AudioVisualizer.FindDataBelowThresholdBackForStart(startVolume + 0.3, silenceLengthInSeconds, startSeconds);
+            if (pos2 > pos && pos2 > startSeconds - 1)
+            {
+                pos = pos2;
+            }
+
+            var newStartMs = pos * TimeCode.BaseUnit;
+            if (prev != null && prev.EndTime.TotalMilliseconds + gapMs >= newStartMs)
+            {
+                newStartMs = prev.EndTime.TotalMilliseconds + gapMs;
+                if (newStartMs >= selected.StartTime.TotalMilliseconds)
+                {
+                    break; // cannot move the start time
+                }
+            }
+
+            var shotChanges = AudioVisualizer.ShotChanges;
+            if (shotChanges.Count > 0)
+            {
+                var nearestShotChange = shotChanges
+                    .Where(sc => sc > startSeconds - 0.3 && sc < startSeconds + 0.2)
+                    .OrderBy(sc => Math.Abs(sc - startSeconds))
+                    .Take(1)
+                    .ToList();
+                if (nearestShotChange.Count > 0)
+                {
+                    newStartMs = nearestShotChange[0] * TimeCode.BaseUnit;
+                }
+            }
+
+            if (Math.Abs(selected.StartTime.TotalMilliseconds - newStartMs) < 10)
+            {
+                break; // difference too small
+            }
+
+            var durationMs = selected.EndTime.TotalMilliseconds - selected.StartTime.TotalMilliseconds;
+            var newEndMs = selected.EndTime.TotalMilliseconds;
+            if (newStartMs > selected.StartTime.TotalMilliseconds)
+            {
+                var newStart = TimeSpanExtensions.FromMillisecondsWholeMilliseconds(newStartMs);
+                var newCps = SubtitleTextInfoHelper.GetCharactersPerSecond(selected.Text, newStart, selected.EndTime);
+                if (newEndMs - newStartMs < Se.Settings.General.SubtitleMinimumDisplayMilliseconds ||
+                    newCps > Se.Settings.General.SubtitleMaximumCharactersPerSeconds)
+                {
+                    // Shortening the line would break the rules, so move it instead - but only
+                    // when the next line is far enough away to take the whole duration.
+                    if (next == null || next.StartTime.TotalMilliseconds > newStartMs + durationMs + gapMs)
+                    {
+                        newEndMs = newStartMs + durationMs;
+                    }
+                }
+            }
+
+            selected.SetTimes(
+                TimeSpanExtensions.FromMillisecondsWholeMilliseconds(newStartMs),
+                TimeSpanExtensions.FromMillisecondsWholeMilliseconds(newEndMs));
+
+            _updateAudioVisualizer = true;
+            break;
+        }
+    }
+
     [RelayCommand]
     private async Task WaveformExtractAudio()
     {
@@ -11761,6 +11873,51 @@ public partial class MainViewModel :
         _shortcutManager.ClearKeys();
     }
 
+    /// <summary>
+    /// SE 4 parity: clears every bookmark in the file (SE 4's "Clear bookmarks" shortcut).
+    /// Asks first, like the same action in the bookmarks list window does - bookmarks are
+    /// persisted next to the subtitle rather than kept in the undo history, so an accidental
+    /// key press would otherwise be unrecoverable.
+    /// </summary>
+    [RelayCommand]
+    private async Task ClearBookmarks()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var bookmarked = Subtitles.Where(p => p.Bookmark != null).ToList();
+        if (bookmarked.Count == 0)
+        {
+            ShowStatus(Se.Language.General.NoBookmarksFound);
+            _shortcutManager.ClearKeys();
+            return;
+        }
+
+        var answer = await MessageBox.Show(
+            Window,
+            Se.Language.General.Clear,
+            Se.Language.General.BookmarkClearQuestion,
+            MessageBoxButtons.YesNo,
+            MessageBoxIcon.Question);
+
+        if (answer != MessageBoxResult.Yes)
+        {
+            _shortcutManager.ClearKeys();
+            return;
+        }
+
+        foreach (var item in bookmarked)
+        {
+            item.Bookmark = null;
+        }
+
+        new BookmarkPersistence(GetUpdateSubtitle(), _subtitleFileName).Save();
+
+        _shortcutManager.ClearKeys();
+    }
+
     [RelayCommand]
     private void GoToNextBookmark()
     {
@@ -13011,6 +13168,30 @@ public partial class MainViewModel :
         }
 
         ToggleBold();
+    }
+
+    [RelayCommand]
+    private void ToggleLinesUnderline()
+    {
+        ToggleUnderline();
+    }
+
+    [RelayCommand]
+    private void ToggleLinesUnderlineOrSelectedText()
+    {
+        var selectedItems = _selectedSubtitles?.ToList() ?? [];
+        if (selectedItems.Count == 0)
+        {
+            return;
+        }
+
+        if (selectedItems.Count == 1 && EditTextBox.SelectedText.Length > 0)
+        {
+            TextBoxUnderline();
+            return;
+        }
+
+        ToggleUnderline();
     }
 
     [RelayCommand]
@@ -24174,6 +24355,66 @@ public partial class MainViewModel :
                 if (!string.IsNullOrEmpty(item.Text))
                 {
                     item.Text = $"<b>{item.Text}</b>";
+                }
+            }
+        }
+    }
+
+    // SE 4 parity: the third of the list view formatting toggles (italic/bold/underline).
+    private void ToggleUnderline()
+    {
+        var selectedItems = _selectedSubtitles?.ToList() ?? [];
+        if (selectedItems.Count == 0)
+        {
+            return;
+        }
+
+        var first = true;
+        var makeUnderline = true;
+        var isAssa = SelectedSubtitleFormat is AdvancedSubStationAlpha;
+
+        if (isAssa)
+        {
+            foreach (var item in selectedItems)
+            {
+                if (first)
+                {
+                    first = false;
+                    makeUnderline = !item.Text.Contains("{\\u1}") && !item.Text.Contains("\\u1");
+                }
+
+                item.Text = item.Text
+                    .Replace("{\\u1}", string.Empty)
+                    .Replace("{\\u0}", string.Empty)
+                    .Replace("\\u1\\", "\\")
+                    .Replace("\\u0\\", "\\");
+                if (makeUnderline)
+                {
+                    if (!string.IsNullOrEmpty(item.Text))
+                    {
+                        item.Text = $"{{\\u1}}{item.Text}";
+                    }
+                }
+            }
+
+            return;
+        }
+
+        foreach (var item in selectedItems)
+        {
+            if (first)
+            {
+                first = false;
+                makeUnderline = !item.Text.Contains("<u>");
+            }
+
+            item.Text = item.Text.Replace("<u>", string.Empty).Replace("</u>", string.Empty);
+            item.Text = item.Text.Replace("<U>", string.Empty).Replace("</U>", string.Empty);
+            if (makeUnderline)
+            {
+                if (!string.IsNullOrEmpty(item.Text))
+                {
+                    item.Text = $"<u>{item.Text}</u>";
                 }
             }
         }

--- a/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
+++ b/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
@@ -158,6 +158,7 @@ public static class Se4ShortcutsImporter
         // List view
         ["MainListViewItalic"] = nameof(MainViewModel.ToggleLinesItalicOrSelectedTextCommand),
         ["MainListViewBold"] = nameof(MainViewModel.ToggleLinesBoldOrSelectedTextCommand),
+        ["MainListViewUnderline"] = nameof(MainViewModel.ToggleLinesUnderlineOrSelectedTextCommand),
         ["MainListViewAlignment"] = nameof(MainViewModel.ShowAlignmentPickerCommand),
         ["MainListViewAlignmentN1"] = nameof(MainViewModel.DoAlignmentAn1Command),
         ["MainListViewAlignmentN2"] = nameof(MainViewModel.DoAlignmentAn2Command),
@@ -319,6 +320,7 @@ public static class Se4ShortcutsImporter
         ["WaveformListShotChanges"] = nameof(MainViewModel.ShowShotChangesListCommand),
         ["WaveformSearchSilenceForward"] = nameof(MainViewModel.SeekSilenceForwardCommand),
         ["WaveformSearchSilenceBack"] = nameof(MainViewModel.SeekSilenceBackCommand),
+        ["WaveformGuessStart"] = nameof(MainViewModel.WaveformGuessStartCommand),
         ["WaveformAudioToTextWhisper"] = nameof(MainViewModel.ShowSpeechToTextWhisperCommand),
         ["WaveformPlaySelection"] = nameof(MainViewModel.PlaySelectedLinesWithoutLoopCommand),
         ["Waveform100MsLeft"] = nameof(MainViewModel.Video100MsBackCommand),
@@ -358,6 +360,9 @@ public static class Se4ShortcutsImporter
         ["GeneralToggleBookmarksWithText"] = nameof(MainViewModel.AddOrEditBookmarkCommand),
         ["GeneralToggleBookmarks"] = nameof(MainViewModel.ToggleBookmarkSelectedLinesNoTextCommand),
         ["GeneralEditBookmarks"] = nameof(MainViewModel.ListBookmarksCommand),
+        // SE 4's "go to bookmark" opened a bookmark picker; SE 5's bookmarks list is that picker.
+        ["GeneralGoToBookmark"] = nameof(MainViewModel.ListBookmarksCommand),
+        ["GeneralClearBookmarks"] = nameof(MainViewModel.ClearBookmarksCommand),
         ["GeneralRemoveBlankLines"] = nameof(MainViewModel.RemoveBlankLinesCommand),
         ["GeneralChooseProfile"] = nameof(MainViewModel.ShowChooseProfileCommand),
         ["GeneralLayoutChoose"] = nameof(MainViewModel.CommandShowLayoutCommand),

--- a/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
@@ -32,6 +32,7 @@ public class LanguageSettingsShortcuts
     public string GeneralGoToVideoPosition { get; set; }
     public string GeneralToggleItalic { get; set; }
     public string GeneralToggleBold { get; set; }
+    public string GeneralToggleUnderline { get; set; }
 
     public string FileOpen { get; set; }
     public string FileOpenKeepVideo { get; set; }
@@ -75,6 +76,7 @@ public class LanguageSettingsShortcuts
     public string AddOrEditBookmark { get; set; }
     public string ToggleBookmark { get; set; }
     public string GoToNextBookmark { get; set; }
+    public string ClearBookmarks { get; set; }
     public string GoToNextEmptyLine { get; set; }
     public string ToggleWaveformToolbar { get; set; }
     public string ToggleSubtitleGridFormatting { get; set; }
@@ -164,6 +166,8 @@ public class LanguageSettingsShortcuts
     public string CopyTextFromOriginalSelectedLines { get; set; }
     public string TextBoxRemoveAllFormatting { get; set; }
     public string TextBoxItalic { get; set; }
+    public string TextBoxBold { get; set; }
+    public string TextBoxUnderline { get; set; }
     public string ResetWaveformZoomAndSpeed { get; set; }
     public string TogglePlaybackSpeed { get; set; }
     public string PlaybackSpeedSlower { get; set; }
@@ -173,6 +177,7 @@ public class LanguageSettingsShortcuts
     public string SeekSilence { get; set; }
     public string SeekSilenceBack { get; set; }
     public string SeekSilenceForward { get; set; }
+    public string WaveformGuessStart { get; set; }
     public string SetVideoPositionCurrentSubtitleStart { get; set; }
     public string GoToSubtitlePositionAndPause { get; set; }
     public string SetVideoPositionCurrentSubtitleEnd { get; set; }
@@ -289,6 +294,7 @@ public class LanguageSettingsShortcuts
         GeneralGoToVideoPosition = "Go to video position";
         GeneralToggleItalic = "Toggle italic";
         GeneralToggleBold = "Toggle bold";
+        GeneralToggleUnderline = "Toggle underline";
 
         FileOpen = "Open";
         FileOpenKeepVideo = "Open (keep video)";
@@ -337,6 +343,7 @@ public class LanguageSettingsShortcuts
         AddOrEditBookmark = "Add or edit bookmark";
         ToggleBookmark = "Toggle bookmark (selected lines, no text)";
         GoToNextBookmark = "Go to next bookmark";
+        ClearBookmarks = "Clear bookmarks";
         GoToNextEmptyLine = "Go to next empty line";
         ToggleWaveformToolbar = "Toggle waveform toolbar";
         ToggleSubtitleGridFormatting = "Toggle grid formatting (show formatting/show tags/no formatting/hide tags)";
@@ -426,6 +433,8 @@ public class LanguageSettingsShortcuts
         CopyTextFromOriginalSelectedLines = "Copy text from original (selected lines)";
         TextBoxRemoveAllFormatting = "Text box, remove all formatting";
         TextBoxItalic = "Text box italic";
+        TextBoxBold = "Text box bold";
+        TextBoxUnderline = "Text box underline";
         ResetWaveformZoomAndSpeed = "Reset waveform zoom and playback speed (play rate)";
         TogglePlaybackSpeed = "Toggle playback speed (play rate)";
         PlaybackSpeedSlower = "Playback speed slower (play rate)";
@@ -435,6 +444,7 @@ public class LanguageSettingsShortcuts
         SeekSilence = "Seek silence";
         SeekSilenceBack = "Seek silence back";
         SeekSilenceForward = "Seek silence forward";
+        WaveformGuessStart = "Guess start time from waveform";
         SetVideoPositionCurrentSubtitleStart = "Set video position to current line start";
         GoToSubtitlePositionAndPause = "Go to sub position and pause";
         SetVideoPositionCurrentSubtitleEnd = "Set video position to current line end";

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -106,6 +106,7 @@ public static class ShortcutsMain
         { nameof(MainViewModel.SwitchOriginalAndTranslationTextSelectedLinesCommand), Se.Language.Options.Shortcuts.SwitchOriginalAndTranslationSelectedLines},
         { nameof(MainViewModel.MergeOriginalIntoTranslationSelectedLinesCommand), Se.Language.Options.Shortcuts.MergeOriginalIntoTranslationSelectedLines},
         { nameof(MainViewModel.ListBookmarksCommand), Se.Language.General.BookmarksList},
+        { nameof(MainViewModel.ClearBookmarksCommand), Se.Language.Options.Shortcuts.ClearBookmarks},
         { nameof(MainViewModel.GoToNextBookmarkCommand), Se.Language.Options.Shortcuts.GoToNextBookmark},
         { nameof(MainViewModel.GoToPreviousBookmarkCommand), Se.Language.Options.Shortcuts.GoToPreviousBookmark},
         { nameof(MainViewModel.GoToNextEmptyLineCommand), Se.Language.Options.Shortcuts.GoToNextEmptyLine},
@@ -215,6 +216,7 @@ public static class ShortcutsMain
         { nameof(MainViewModel.ShowGoToVideoPositionCommand), Se.Language.Options.Shortcuts.GeneralGoToVideoPosition },
         { nameof(MainViewModel.ToggleLinesItalicOrSelectedTextCommand), Se.Language.Options.Shortcuts.GeneralToggleItalic },
         { nameof(MainViewModel.ToggleLinesBoldOrSelectedTextCommand), Se.Language.Options.Shortcuts.GeneralToggleBold },
+        { nameof(MainViewModel.ToggleLinesUnderlineOrSelectedTextCommand), Se.Language.Options.Shortcuts.GeneralToggleUnderline },
 
         { nameof(MainViewModel.PlayCommand), Se.Language.General.Play },
         { nameof(MainViewModel.PlayNextCommand), Se.Language.General.PlayNext },
@@ -259,6 +261,8 @@ public static class ShortcutsMain
         { nameof(MainViewModel.TextBoxSelectAllCommand), Se.Language.Options.Shortcuts.TextBoxSelectAll },
         { nameof(MainViewModel.TextBoxRemoveAllFormattingCommand), Se.Language.Options.Shortcuts.TextBoxRemoveAllFormatting },
         { nameof(MainViewModel.TextBoxItalicCommand), Se.Language.Options.Shortcuts.TextBoxItalic },
+        { nameof(MainViewModel.TextBoxBoldCommand), Se.Language.Options.Shortcuts.TextBoxBold },
+        { nameof(MainViewModel.TextBoxUnderlineCommand), Se.Language.Options.Shortcuts.TextBoxUnderline },
 
         { nameof(MainViewModel.VideoOneFrameBackCommand), Se.Language.General.VideoOneFrameBack },
         { nameof(MainViewModel.VideoOneFrameForwardCommand),  Se.Language.General.VideoOneFrameForward },
@@ -314,6 +318,7 @@ public static class ShortcutsMain
         { nameof(MainViewModel.ShowWaveformSeekSilenceCommand),  Se.Language.Options.Shortcuts.SeekSilence },
         { nameof(MainViewModel.SeekSilenceBackCommand),  Se.Language.Options.Shortcuts.SeekSilenceBack },
         { nameof(MainViewModel.SeekSilenceForwardCommand),  Se.Language.Options.Shortcuts.SeekSilenceForward },
+        { nameof(MainViewModel.WaveformGuessStartCommand),  Se.Language.Options.Shortcuts.WaveformGuessStart },
         { nameof(MainViewModel.ShowShotChangesListCommand),  Se.Language.General.ShowShotChangesList },
         { nameof(MainViewModel.VideoUndockControlsCommand),  Se.Language.Options.Shortcuts.UndockVideoControls },
         { nameof(MainViewModel.VideoRedockControlsCommand),  Se.Language.Options.Shortcuts.RedockVideoControls },
@@ -524,6 +529,7 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.SwitchOriginalAndTranslationTextSelectedLinesCommand, nameof(vm.SwitchOriginalAndTranslationTextSelectedLinesCommand), ShortcutCategory.SubtitleGrid, ShortcutGroup.Translate);
         AddShortcut(shortcuts, vm.MergeOriginalIntoTranslationSelectedLinesCommand, nameof(vm.MergeOriginalIntoTranslationSelectedLinesCommand), ShortcutCategory.SubtitleGrid, ShortcutGroup.Translate);
         AddShortcut(shortcuts, vm.ListBookmarksCommand, nameof(vm.ListBookmarksCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.ClearBookmarksCommand, nameof(vm.ClearBookmarksCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.GoToNextBookmarkCommand, nameof(vm.GoToNextBookmarkCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.GoToPreviousBookmarkCommand, nameof(vm.GoToPreviousBookmarkCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.GoToNextEmptyLineCommand, nameof(vm.GoToNextEmptyLineCommand), ShortcutCategory.General);
@@ -573,6 +579,7 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.ShowGoToVideoPositionCommand, nameof(vm.ShowGoToVideoPositionCommand), ShortcutCategory.General, ShortcutGroup.Video);
         AddShortcut(shortcuts, vm.ToggleLinesItalicOrSelectedTextCommand, nameof(vm.ToggleLinesItalicOrSelectedTextCommand), ShortcutCategory.SubtitleGridAndTextBox);
         AddShortcut(shortcuts, vm.ToggleLinesBoldOrSelectedTextCommand, nameof(vm.ToggleLinesBoldOrSelectedTextCommand), ShortcutCategory.SubtitleGridAndTextBox);
+        AddShortcut(shortcuts, vm.ToggleLinesUnderlineOrSelectedTextCommand, nameof(vm.ToggleLinesUnderlineOrSelectedTextCommand), ShortcutCategory.SubtitleGridAndTextBox);
 
         AddShortcut(shortcuts, vm.PlayCommand, nameof(vm.PlayCommand), ShortcutCategory.General, ShortcutGroup.Video);
         AddShortcut(shortcuts, vm.PlayNextCommand, nameof(vm.PlayNextCommand), ShortcutCategory.General, ShortcutGroup.Video);
@@ -623,6 +630,8 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.TextBoxSelectAllCommand, nameof(vm.TextBoxSelectAllCommand), ShortcutCategory.TextBox);
         AddShortcut(shortcuts, vm.TextBoxRemoveAllFormattingCommand, nameof(vm.TextBoxRemoveAllFormattingCommand), ShortcutCategory.TextBox);
         AddShortcut(shortcuts, vm.TextBoxItalicCommand, nameof(vm.TextBoxItalicCommand), ShortcutCategory.TextBox);
+        AddShortcut(shortcuts, vm.TextBoxBoldCommand, nameof(vm.TextBoxBoldCommand), ShortcutCategory.TextBox);
+        AddShortcut(shortcuts, vm.TextBoxUnderlineCommand, nameof(vm.TextBoxUnderlineCommand), ShortcutCategory.TextBox);
 
         // Tools
         AddShortcut(shortcuts, vm.ShowBridgeGapsCommand, nameof(vm.ShowBridgeGapsCommand), ShortcutCategory.General, ShortcutGroup.Tools);
@@ -721,6 +730,7 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.ShowWaveformSeekSilenceCommand, nameof(vm.ShowWaveformSeekSilenceCommand), ShortcutCategory.Waveform);
         AddShortcut(shortcuts, vm.SeekSilenceBackCommand, nameof(vm.SeekSilenceBackCommand), ShortcutCategory.Waveform);
         AddShortcut(shortcuts, vm.SeekSilenceForwardCommand, nameof(vm.SeekSilenceForwardCommand), ShortcutCategory.Waveform);
+        AddShortcut(shortcuts, vm.WaveformGuessStartCommand, nameof(vm.WaveformGuessStartCommand), ShortcutCategory.Waveform);
         AddShortcut(shortcuts, vm.GoToPreviousShotChangeCommand, nameof(vm.GoToPreviousShotChangeCommand), ShortcutCategory.General, ShortcutGroup.Video);
         AddShortcut(shortcuts, vm.GoToNextShotChangeCommand, nameof(vm.GoToNextShotChangeCommand), ShortcutCategory.General, ShortcutGroup.Video);
         AddShortcut(shortcuts, vm.ShowVideoChaptersCommand, nameof(vm.ShowVideoChaptersCommand), ShortcutCategory.General, ShortcutGroup.Video);

--- a/tests/UI/Features/Assa/AssaAttachmentsMoveTests.cs
+++ b/tests/UI/Features/Assa/AssaAttachmentsMoveTests.cs
@@ -1,0 +1,116 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Assa;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace UITests.Features.Assa;
+
+/// <summary>
+/// SE 4's attachments window could reorder the list with move up/down/to top/to bottom. The
+/// order is not presentation-only: it is the order the attachments are written back into the
+/// subtitle's [Fonts]/[Graphics] sections on OK, which is why these grids have no header sort.
+/// </summary>
+public class AssaAttachmentsMoveTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private (AssaAttachmentsWindow Window, AssaAttachmentsViewModel Vm) MakeWindowWithThreeFonts()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var vm = Locator.Services.GetRequiredService<AssaAttachmentsViewModel>();
+        foreach (var name in new[] { "a.ttf", "b.ttf", "c.ttf" })
+        {
+            vm.Attachments.Add(new AssaAttachmentItem
+            {
+                FileName = name,
+                Category = Se.Language.General.Fonts,
+                Content = "M" + name,
+                Bytes = [1, 2, 3],
+                Size = "3 bytes",
+            });
+        }
+
+        var window = new AssaAttachmentsWindow(vm);
+        _windows.Add(window);
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        return (window, vm);
+    }
+
+    private static void Select(AssaAttachmentsViewModel vm, AssaAttachmentItem item)
+    {
+        vm.AttachmentGrid.SelectedItem = item;
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    [AvaloniaFact]
+    public void MoveDownReordersTheAttachmentsAndKeepsTheSelection()
+    {
+        var (_, vm) = MakeWindowWithThreeFonts();
+        var first = vm.Attachments[0];
+
+        Select(vm, first);
+        vm.MoveDownCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(new[] { "b.ttf", "a.ttf", "c.ttf" }, vm.Attachments.Select(a => a.FileName));
+        Assert.Same(first, vm.AttachmentGrid.SelectedItem);
+    }
+
+    [AvaloniaFact]
+    public void MoveToBottomWritesTheNewOrderToTheFooter()
+    {
+        var (_, vm) = MakeWindowWithThreeFonts();
+
+        Select(vm, vm.Attachments[0]);
+        vm.MoveToBottomCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(new[] { "b.ttf", "c.ttf", "a.ttf" }, vm.Attachments.Select(a => a.FileName));
+
+        vm.OkCommand.Execute(null);
+
+        var fontNames = vm.Footer.SplitToLines()!
+            .Where(line => line.StartsWith("fontname: ", StringComparison.Ordinal))
+            .Select(line => line.Substring("fontname: ".Length))
+            .ToArray();
+        Assert.Equal(new[] { "b.ttf", "c.ttf", "a.ttf" }, fontNames);
+    }
+
+    [AvaloniaFact]
+    public void MoveToTopMovesTheSelectedAttachmentFirst()
+    {
+        var (_, vm) = MakeWindowWithThreeFonts();
+
+        Select(vm, vm.Attachments[2]);
+        vm.MoveToTopCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(new[] { "c.ttf", "a.ttf", "b.ttf" }, vm.Attachments.Select(a => a.FileName));
+    }
+}

--- a/tests/UI/Features/Main/Se4GuessStartAndUnderlineTests.cs
+++ b/tests/UI/Features/Main/Se4GuessStartAndUnderlineTests.cs
@@ -1,0 +1,142 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// SE 4 parity commands that had no SE 5 counterpart: "toggle underline" (the third list view
+/// formatting toggle next to italic/bold) and the waveform's "guess start".
+/// </summary>
+public class Se4GuessStartAndUnderlineTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+    private readonly bool _timeCodesLocked = Se.Settings.General.LockTimeCodes;
+
+    public void Dispose()
+    {
+        Se.Settings.General.LockTimeCodes = _timeCodesLocked;
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private (Window Window, MainViewModel Vm) CreateMainViewModel()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1400, Height = 900 };
+        _windows.Add(window);
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var vm = (MainViewModel)view.DataContext!;
+        window.SuppressSaveChangesPromptOnClose(vm);
+        return (window, vm);
+    }
+
+    private static void Select(MainViewModel vm, params SubtitleLineViewModel[] lines)
+    {
+        vm.SubtitleGrid.SelectedItems!.Clear();
+        foreach (var line in lines)
+        {
+            vm.SubtitleGrid.SelectedItems!.Add(line);
+        }
+
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    [AvaloniaFact]
+    public void ToggleUnderlineWrapsAndUnwrapsSelectedLines()
+    {
+        var (_, vm) = CreateMainViewModel();
+        vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph("Hello", 1000, 3000), null!) { Number = 1 });
+        vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph("World", 4000, 6000), null!) { Number = 2 });
+        Dispatcher.UIThread.RunJobs();
+
+        Select(vm, vm.Subtitles[0], vm.Subtitles[1]);
+
+        vm.ToggleLinesUnderlineOrSelectedTextCommand.Execute(null);
+        Assert.Equal("<u>Hello</u>", vm.Subtitles[0].Text);
+        Assert.Equal("<u>World</u>", vm.Subtitles[1].Text);
+
+        // Second press removes it again - the first selected line decides for the whole selection.
+        vm.ToggleLinesUnderlineOrSelectedTextCommand.Execute(null);
+        Assert.Equal("Hello", vm.Subtitles[0].Text);
+        Assert.Equal("World", vm.Subtitles[1].Text);
+    }
+
+    /// <summary>
+    /// A cue that starts inside the silence in front of the speech: "guess start" moves the start
+    /// cue up to just before the speech begins instead of leaving the dead air in the line.
+    /// </summary>
+    [AvaloniaFact]
+    public void GuessStartMovesTheStartCueToJustBeforeTheSpeech()
+    {
+        Se.Settings.General.LockTimeCodes = false;
+
+        var (window, vm) = CreateMainViewModel();
+        vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph("Hello", 2200, 3800), null!) { Number = 1 });
+        Dispatcher.UIThread.RunJobs();
+
+        var av = vm.AudioVisualizer!;
+        av.WavePeaks = MakePeaks(sampleRate: 100, seconds: 6, speechFromSeconds: 2.5, speechToSeconds: 4.0);
+        Select(vm, vm.Subtitles[0]);
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        vm.WaveformGuessStartCommand.Execute(null);
+
+        var line = vm.Subtitles[0];
+        Assert.InRange(line.StartTime.TotalMilliseconds, 2400, 2500);
+        Assert.Equal(3800, line.EndTime.TotalMilliseconds, 0);
+    }
+
+    [AvaloniaFact]
+    public void GuessStartDoesNothingWithoutAWaveform()
+    {
+        Se.Settings.General.LockTimeCodes = false;
+
+        var (_, vm) = CreateMainViewModel();
+        vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph("Hello", 2200, 3800), null!) { Number = 1 });
+        Dispatcher.UIThread.RunJobs();
+        Select(vm, vm.Subtitles[0]);
+
+        vm.WaveformGuessStartCommand.Execute(null);
+
+        Assert.Equal(2200, vm.Subtitles[0].StartTime.TotalMilliseconds, 0);
+        Assert.Equal(3800, vm.Subtitles[0].EndTime.TotalMilliseconds, 0);
+    }
+
+    private static WavePeakData2 MakePeaks(int sampleRate, int seconds, double speechFromSeconds, double speechToSeconds)
+    {
+        var peaks = new WavePeak2[sampleRate * seconds];
+        var from = (int)(speechFromSeconds * sampleRate);
+        var to = (int)(speechToSeconds * sampleRate);
+        for (var i = 0; i < peaks.Length; i++)
+        {
+            peaks[i] = i >= from && i < to ? new WavePeak2(8000, -8000) : new WavePeak2(0, 0);
+        }
+
+        return new WavePeakData2(sampleRate, peaks);
+    }
+}

--- a/tests/UI/Features/Options/Shortcuts/Se4ShortcutsImporterMapTests.cs
+++ b/tests/UI/Features/Options/Shortcuts/Se4ShortcutsImporterMapTests.cs
@@ -64,6 +64,10 @@ public class Se4ShortcutsImporterMapTests
     [InlineData("MainVideo1FrameLeftWithPlay", "VideoOneFrameBackWithPlayCommand")]
     [InlineData("MainVideo1FrameRightWithPlay", "VideoOneFrameForwardWithPlayCommand")]
     [InlineData("MainVideoToggleContrast", "VideoToggleContrastCommand")]
+    [InlineData("GeneralGoToBookmark", "ListBookmarksCommand")]
+    [InlineData("GeneralClearBookmarks", "ClearBookmarksCommand")]
+    [InlineData("MainListViewUnderline", "ToggleLinesUnderlineOrSelectedTextCommand")]
+    [InlineData("WaveformGuessStart", "WaveformGuessStartCommand")]
     public void ImportsSe4ShortcutBySerializedName(string se4Name, string expectedSe5Command)
     {
         var xml = $"<Shortcuts><{se4Name}>Control+Shift+F12</{se4Name}></Shortcuts>";


### PR DESCRIPTION
Four SE 4 shortcut actions that the SE 4 importer had to skip because SE 5 had no counterpart, plus the attachment reordering SE 4's attachments window had.

## Shortcuts

| SE 4 name | SE 5 |
|---|---|
| `GeneralGoToBookmark` | the bookmarks list — SE 4's "go to bookmark" opened the same kind of picker |
| `GeneralClearBookmarks` | new **Clear bookmarks** command |
| `MainListViewUnderline` | new **Toggle underline** — the third list view formatting toggle next to italic and bold |
| `WaveformGuessStart` | new **Guess start time from waveform** |

`ClearBookmarks` asks before clearing, like the same action inside the bookmarks list window: bookmarks are persisted next to the subtitle rather than kept in the undo history, so an accidental key press would otherwise be unrecoverable.

`ToggleLinesUnderlineOrSelectedText` mirrors the bold/italic commands exactly: with one line selected and a text selection it underlines the selection, otherwise it wraps the selected lines (`<u>…</u>`, or `{\u1}` in ASSA).

"Guess start" is a port of SE 4's `AutoGuessStartTime`: raise the volume threshold step by step until the silence in front of the speech is found, move the start cue there, snap to a shot change close to the old start, and keep the duration when shortening the line would break the minimum duration / maximum CPS rules and there is room before the next line. It needed two small waveform helpers (`FindLowPercentage`/`FindHighPercentage`), also ported. Unlike SE 4 it does **not** require a shot change list to be loaded — SE 4 gated the key press on `ShotChanges != null` even though the method itself handles an empty list.

`TextBoxBoldCommand` and `TextBoxUnderlineCommand` already existed in the view model (they are in the text box context menu) but were never registered in `ShortcutsMain`, so no shortcut could be assigned to them; only `TextBoxItalic` was. Registered both.

## Attachments

Move up / move down / move to top / move to bottom are back in the ASSA/SSA attachments window (context menu + Ctrl+Up/Ctrl+Down), like SE 4 and like the styles, Join subtitles, WebVTT styles and Multiple replace lists already have. The attachment order is written back to the `[Fonts]`/`[Graphics]` sections on OK, so this is real reordering, not a view sort.

## Tests

- underline toggles on/off across a multi-line selection
- guess start moves a cue that begins in the silence up to just before the speech, and does nothing without a waveform
- attachments reorder, keep the selection, and write the new order to the footer
- the four new importer names round-trip through `ImportFromXml`

Full UI suite: 3871 passed, 1 skipped.

Remaining SE 4 shortcut gaps after this: 85 names (layout choose 1–12, the merge variants, the X-ms cue nudges, tools like append/measurement converter, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)