### PR TITLE
Add dots.tts (CrispASR) text-to-speech engine

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -164,6 +164,7 @@ using Nikse.SubtitleEdit.Features.Video.TextToSpeech.OmniVoiceSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Qwen3TtsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Qwen3TtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.VibeVoiceCrispAsrSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DotsTtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTts25License;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.VoiceCloneConsent;
@@ -283,6 +284,7 @@ public static class DependencyInjectionExtensions
         collection.AddHttpClientWithProxy<IQwen3TtsCrispAsrDownloadService, Qwen3TtsCrispAsrDownloadService>();
         collection.AddHttpClientWithProxy<IVibeVoiceCrispAsrDownloadService, VibeVoiceCrispAsrDownloadService>();
         collection.AddHttpClientWithProxy<IIndexTtsCrispAsrDownloadService, IndexTtsCrispAsrDownloadService>();
+        collection.AddHttpClientWithProxy<IDotsTtsCrispAsrDownloadService, DotsTtsCrispAsrDownloadService>();
         collection.AddHttpClientWithProxy<IIndexTts25AudioCppDownloadService, IndexTts25AudioCppDownloadService>();
         collection.AddHttpClientWithProxy<ICosyVoice3CrispAsrDownloadService, CosyVoice3CrispAsrDownloadService>();
         collection.AddHttpClientWithProxy<IF5TtsCrispAsrDownloadService, F5TtsCrispAsrDownloadService>();
@@ -469,6 +471,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<Qwen3TtsCrispAsrSettingsViewModel>();
         collection.AddTransient<VibeVoiceCrispAsrSettingsViewModel>();
         collection.AddTransient<IndexTtsCrispAsrSettingsViewModel>();
+        collection.AddTransient<DotsTtsCrispAsrSettingsViewModel>();
         collection.AddTransient<IndexTts25LicenseViewModel>();
         collection.AddTransient<VoiceCloneConsentViewModel>();
         collection.AddTransient<IndexTts25AudioCppSettingsViewModel>();

--- a/src/ui/Features/Video/TextToSpeech/DotsTtsCrispAsrSettings/DotsTtsCrispAsrSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DotsTtsCrispAsrSettings/DotsTtsCrispAsrSettingsViewModel.cs
@@ -1,0 +1,269 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.DotsTtsCrispAsrSettings;
+
+public partial class DotsTtsCrispAsrSettingsViewModel : ObservableObject
+{
+    // A SolidColorBrush set as Shape.Fill is parented into that shape's visual tree, so the same
+    // instance can't be shared across bound Ellipses (only one dot would render). Fresh brush per
+    // assignment instead.
+    private static IBrush Green() => new SolidColorBrush(Color.FromRgb(0x4C, 0xAF, 0x50));
+    private static IBrush Amber() => new SolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00));
+    private static IBrush Red() => new SolidColorBrush(Color.FromRgb(0xF4, 0x43, 0x36));
+    private static IBrush Grey() => new SolidColorBrush(Color.FromRgb(0x9E, 0x9E, 0x9E));
+
+    private readonly IWindowService _windowService;
+    private readonly IFolderHelper _folderHelper;
+
+    [ObservableProperty] private string _engineLabel = string.Empty;
+    [ObservableProperty] private IBrush _engineBrush = Grey();
+    [ObservableProperty] private string _engineDownloadButtonText = string.Empty;
+
+    [ObservableProperty] private string _coreQ4KLabel = string.Empty;
+    [ObservableProperty] private IBrush _coreQ4KBrush = Grey();
+
+    [ObservableProperty] private string _coreQ8_0Label = string.Empty;
+    [ObservableProperty] private IBrush _coreQ8_0Brush = Grey();
+
+    [ObservableProperty] private string _coreF16Label = string.Empty;
+    [ObservableProperty] private IBrush _coreF16Brush = Grey();
+
+    [ObservableProperty] private string _vocoderLabel = string.Empty;
+    [ObservableProperty] private IBrush _vocoderBrush = Grey();
+
+    [ObservableProperty] private string _speakerEncoderLabel = string.Empty;
+    [ObservableProperty] private IBrush _speakerEncoderBrush = Grey();
+
+    [ObservableProperty] private string _voicesLabel = string.Empty;
+
+    [ObservableProperty] private double _odeSteps = DotsTtsCrispAsr.DefaultOdeSteps;
+
+    public string OdeStepsLabel => $"{(int)OdeSteps} steps";
+
+    partial void OnOdeStepsChanged(double value)
+    {
+        OnPropertyChanged(nameof(OdeStepsLabel));
+        Se.Settings.Video.TextToSpeech.DotsTtsCrispAsrOdeSteps =
+            Math.Clamp((int)Math.Round(value), DotsTtsCrispAsr.MinOdeSteps, DotsTtsCrispAsr.MaxOdeSteps);
+    }
+
+    [ObservableProperty] private string _modelsFolder = string.Empty;
+    [ObservableProperty] private string _voicesFolder = string.Empty;
+    [ObservableProperty] private bool _isEngineInstalled;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    public DotsTtsCrispAsrSettingsViewModel(IWindowService windowService, IFolderHelper folderHelper)
+    {
+        _windowService = windowService;
+        _folderHelper = folderHelper;
+    }
+
+    public void Initialize()
+    {
+        ModelsFolder = DotsTtsCrispAsr.GetSetModelsFolder();
+        VoicesFolder = DotsTtsCrispAsr.GetSetVoicesFolder();
+        OdeSteps = DotsTtsCrispAsr.ResolveOdeSteps();
+        Refresh();
+    }
+
+    private void Refresh()
+    {
+        var exe = DotsTtsCrispAsr.GetCrispAsrExecutable();
+        IsEngineInstalled = File.Exists(exe);
+
+        if (!IsEngineInstalled)
+        {
+            EngineLabel = string.Format(Se.Language.Video.TtsEngineNotInstalled, "CrispASR");
+            EngineBrush = Red();
+            EngineDownloadButtonText = string.Format(Se.Language.General.DownloadX, "CrispASR");
+        }
+        else if (DotsTtsCrispAsr.GetEngineUpdateStatus() == DownloadHashManager.UpdateStatus.UpdateAvailable)
+        {
+            EngineLabel = string.Format(Se.Language.Video.TtsEngineUpdateAvailable, "CrispASR");
+            EngineBrush = Amber();
+            EngineDownloadButtonText = string.Format(Se.Language.Video.TtsUpdateX, "CrispASR");
+        }
+        else
+        {
+            EngineLabel = "CrispASR";
+            EngineBrush = Green();
+            EngineDownloadButtonText = string.Format(Se.Language.General.ReDownloadX, "CrispASR");
+        }
+
+        // Append the installed CrispASR version asynchronously — the probe spawns a child process
+        // and the first call can take a few hundred ms.
+        if (IsEngineInstalled)
+        {
+            var baseLabel = EngineLabel;
+            _ = Task.Run(() =>
+            {
+                try
+                {
+                    var version = CrispAsrVersion.TryGet(exe);
+                    if (string.IsNullOrEmpty(version))
+                    {
+                        return;
+                    }
+                    Dispatcher.UIThread.Post(() =>
+                    {
+                        if (EngineLabel == baseLabel)
+                        {
+                            EngineLabel = baseLabel.Replace("CrispASR", $"CrispASR v{version}");
+                        }
+                    });
+                }
+                catch (Exception ex)
+                {
+                    Se.LogError(ex, "DotsTtsCrispAsrSettings: CrispASR version probe failed");
+                }
+            });
+        }
+
+        var coreQ4K = DotsTtsCrispAsr.GetCorePath(DotsTtsCrispAsr.ModelKeyQ4K);
+        ApplyModelStatus(DotsTtsCrispAsr.IsValidLocalModelFile(coreQ4K, DotsTtsCrispAsr.CoreQ4KFileName),
+            IsEngineInstalled,
+            label => CoreQ4KLabel = label,
+            brush => CoreQ4KBrush = brush);
+
+        var coreQ8_0 = DotsTtsCrispAsr.GetCorePath(DotsTtsCrispAsr.ModelKeyQ8_0);
+        ApplyModelStatus(DotsTtsCrispAsr.IsValidLocalModelFile(coreQ8_0, DotsTtsCrispAsr.CoreQ8_0FileName),
+            IsEngineInstalled,
+            label => CoreQ8_0Label = label,
+            brush => CoreQ8_0Brush = brush);
+
+        var coreF16 = DotsTtsCrispAsr.GetCorePath(DotsTtsCrispAsr.ModelKeyF16);
+        ApplyModelStatus(DotsTtsCrispAsr.IsValidLocalModelFile(coreF16, DotsTtsCrispAsr.CoreF16FileName),
+            IsEngineInstalled,
+            label => CoreF16Label = label,
+            brush => CoreF16Brush = brush);
+
+        var vocoderPath = DotsTtsCrispAsr.GetVocoderPath();
+        ApplyModelStatus(DotsTtsCrispAsr.IsValidLocalModelFile(vocoderPath, DotsTtsCrispAsr.VocoderFileName),
+            IsEngineInstalled,
+            label => VocoderLabel = label,
+            brush => VocoderBrush = brush);
+
+        var speakerPath = DotsTtsCrispAsr.GetSpeakerEncoderPath();
+        ApplyModelStatus(DotsTtsCrispAsr.IsValidLocalModelFile(speakerPath, DotsTtsCrispAsr.SpeakerEncoderFileName),
+            IsEngineInstalled,
+            label => SpeakerEncoderLabel = label,
+            brush => SpeakerEncoderBrush = brush);
+
+        try
+        {
+            var wavCount = Directory.Exists(VoicesFolder)
+                ? Directory.GetFiles(VoicesFolder, "*.wav").Length
+                : 0;
+            VoicesLabel = wavCount == 0
+                ? "No voices imported"
+                : (wavCount == 1 ? "1 voice imported" : $"{wavCount} voices imported");
+        }
+        catch
+        {
+            VoicesLabel = string.Empty;
+        }
+    }
+
+    private static void ApplyModelStatus(bool fileInstalled, bool engineInstalled, Action<string> setLabel, Action<IBrush> setBrush)
+    {
+        if (fileInstalled)
+        {
+            setLabel("Installed");
+            setBrush(Green());
+            return;
+        }
+
+        if (!engineInstalled)
+        {
+            // No CrispASR runtime means there is nothing to auto-download into, so don't promise
+            // a download that can't happen until the user installs CrispASR.
+            setLabel("CrispASR required");
+            setBrush(Grey());
+            return;
+        }
+
+        setLabel("Auto-download on first use");
+        setBrush(Grey());
+    }
+
+    [RelayCommand]
+    private async Task RedownloadEngine()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        await TtsVoiceInstaller.EnsureCrispAsrForDotsTts(Window, _windowService, forceRedownload: true);
+        Refresh();
+    }
+
+    [RelayCommand]
+    private async Task OpenModelsFolder()
+    {
+        if (Window == null || string.IsNullOrEmpty(ModelsFolder))
+        {
+            return;
+        }
+
+        try
+        {
+            await _folderHelper.OpenFolder(Window, ModelsFolder);
+        }
+        catch
+        {
+            // best-effort UX
+        }
+    }
+
+    [RelayCommand]
+    private async Task OpenVoicesFolder()
+    {
+        if (Window == null || string.IsNullOrEmpty(VoicesFolder))
+        {
+            return;
+        }
+
+        try
+        {
+            await _folderHelper.OpenFolder(Window, VoicesFolder);
+        }
+        catch
+        {
+            // best-effort UX
+        }
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/DotsTtsCrispAsrSettings/DotsTtsCrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/DotsTtsCrispAsrSettings/DotsTtsCrispAsrSettingsWindow.cs
@@ -1,0 +1,277 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.DotsTtsCrispAsrSettings;
+
+public class DotsTtsCrispAsrSettingsWindow : Window
+{
+    private const int LabelWidth = 150;
+    private const int ValueWidth = 360;
+
+    private readonly DotsTtsCrispAsrSettingsViewModel _vm;
+
+    public DotsTtsCrispAsrSettingsWindow(DotsTtsCrispAsrSettingsViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = string.Format(Se.Language.Video.TtsCrispAsrSettingsTitle, "dots.tts");
+        SizeToContent = SizeToContent.WidthAndHeight;
+        CanResize = false;
+        MinWidth = 580;
+
+        _vm = vm;
+        vm.Window = this;
+        DataContext = vm;
+
+        Content = BuildContent(vm);
+
+        var ok = UiUtil.MakeButtonOk(vm.OkCommand);
+        Activated += delegate { ok.Focus(); };
+    }
+
+    private Border BuildContent(DotsTtsCrispAsrSettingsViewModel vm)
+    {
+        var header = BuildHeader();
+        var details = BuildDetails(vm);
+        var actions = BuildActions(vm);
+
+        var stack = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 14,
+            Children = { header, details, actions },
+        };
+
+        var outerGrid = new Grid
+        {
+            Margin = UiUtil.MakeWindowMargin(),
+        };
+        outerGrid.Children.Add(stack);
+
+        return new Border
+        {
+            Child = outerGrid,
+            Padding = new Thickness(4),
+        };
+    }
+
+    private static StackPanel BuildHeader()
+    {
+        var title = new TextBlock
+        {
+            Text = "dots.tts (CrispASR)",
+            FontSize = 18,
+            FontWeight = FontWeight.SemiBold,
+        };
+
+        var subtitle = new TextBlock
+        {
+            Text = new DotsTtsCrispAsr().Description,
+            FontSize = 12,
+            Opacity = 0.75,
+            Margin = new Thickness(0, 2, 0, 0),
+        };
+
+        return new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 0,
+            Children = { title, subtitle },
+        };
+    }
+
+    private static Border BuildDetails(DotsTtsCrispAsrSettingsViewModel vm)
+    {
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(LabelWidth, GridUnitType.Pixel) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnSpacing = 12,
+            RowSpacing = 10,
+        };
+
+        grid.Add(MakeLabel(Se.Language.General.Engine), 0, 0);
+        var enginePanel = MakeStatusPanel(nameof(vm.EngineBrush), nameof(vm.EngineLabel));
+        var engineButton = UiUtil.MakeButton(string.Empty, vm.RedownloadEngineCommand)
+            .WithIconLeft(IconNames.Download)
+            .WithMarginLeft(12);
+        engineButton.Bind(ContentControl.ContentProperty, new Binding(nameof(vm.EngineDownloadButtonText)));
+        enginePanel.Children.Add(engineButton);
+        grid.Add(enginePanel, 0, 1);
+
+        grid.Add(MakeLabel("Model " + DotsTtsCrispAsr.ModelKeyQ4K), 1, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.CoreQ4KBrush), nameof(vm.CoreQ4KLabel)), 1, 1);
+
+        grid.Add(MakeLabel("Model " + DotsTtsCrispAsr.ModelKeyQ8_0), 2, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.CoreQ8_0Brush), nameof(vm.CoreQ8_0Label)), 2, 1);
+
+        grid.Add(MakeLabel("Model " + DotsTtsCrispAsr.ModelKeyF16), 3, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.CoreF16Brush), nameof(vm.CoreF16Label)), 3, 1);
+
+        grid.Add(MakeLabel("BigVGAN vocoder"), 4, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.VocoderBrush), nameof(vm.VocoderLabel)), 4, 1);
+
+        grid.Add(MakeLabel("CAM++ speaker encoder"), 5, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.SpeakerEncoderBrush), nameof(vm.SpeakerEncoderLabel)), 5, 1);
+
+        grid.Add(MakeLabel(Se.Language.Video.Voices), 6, 0);
+        var voicesText = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.VoicesLabel)),
+        };
+        grid.Add(voicesText, 6, 1);
+
+        grid.Add(MakeLabel("Quality"), 7, 0);
+        grid.Add(MakeOdeStepsPanel(), 7, 1);
+
+        grid.Add(MakeLabel(Se.Language.General.InstallFolder), 8, 0);
+        var folderText = new TextBox
+        {
+            IsReadOnly = true,
+            Width = ValueWidth,
+            BorderThickness = new Thickness(0),
+            Background = Brushes.Transparent,
+            Padding = new Thickness(0),
+            VerticalContentAlignment = VerticalAlignment.Center,
+            FontSize = 12,
+            [!TextBox.TextProperty] = new Binding(nameof(vm.ModelsFolder)),
+        };
+        grid.Add(folderText, 8, 1);
+
+        return new Border
+        {
+            Child = grid,
+            Padding = new Thickness(14),
+            CornerRadius = new CornerRadius(6),
+            BorderThickness = new Thickness(1),
+            BorderBrush = new SolidColorBrush(Color.FromArgb(0x40, 0x80, 0x80, 0x80)),
+        };
+    }
+
+    /// <summary>
+    /// Flow-matching Euler steps: the one real quality/speed knob dots.tts exposes. Measured on
+    /// M4 Metal with the F16 core, 4 steps synthesised in 25 s where 16 steps took 38 s for a
+    /// comparable line, so this is worth surfacing rather than hard-coding.
+    /// </summary>
+    private static StackPanel MakeOdeStepsPanel()
+    {
+        var slider = new Slider
+        {
+            Minimum = DotsTtsCrispAsr.MinOdeSteps,
+            Maximum = DotsTtsCrispAsr.MaxOdeSteps,
+            Width = 220,
+            TickFrequency = 1,
+            IsSnapToTickEnabled = true,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!Slider.ValueProperty] = new Binding(nameof(DotsTtsCrispAsrSettingsViewModel.OdeSteps)),
+        };
+        var label = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            Margin = new Thickness(8, 0, 0, 0),
+            Width = 80,
+            [!TextBlock.TextProperty] = new Binding(nameof(DotsTtsCrispAsrSettingsViewModel.OdeStepsLabel)),
+        };
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { slider, label },
+        };
+    }
+
+    private static StackPanel MakeStatusPanel(string brushBindingPath, string labelBindingPath)
+    {
+        var dot = new Ellipse
+        {
+            Width = 10,
+            Height = 10,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!Ellipse.FillProperty] = new Binding(brushBindingPath),
+        };
+        var text = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            Margin = new Thickness(8, 0, 0, 0),
+            [!TextBlock.TextProperty] = new Binding(labelBindingPath),
+        };
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { dot, text },
+        };
+    }
+
+    private static Grid BuildActions(DotsTtsCrispAsrSettingsViewModel vm)
+    {
+        var openModelsFolder = UiUtil.MakeButton(Se.Language.General.OpenContainingFolder, vm.OpenModelsFolderCommand).WithIconLeft(IconNames.FolderOpen);
+        var openVoicesFolder = UiUtil.MakeButton("Voices folder", vm.OpenVoicesFolderCommand).WithIconLeft(IconNames.FolderOpen);
+        var close = UiUtil.MakeButton(Se.Language.General.Close, vm.OkCommand);
+
+        var leftPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            Children = { openModelsFolder, openVoicesFolder },
+        };
+
+        var rightPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Spacing = 8,
+            Children = { close },
+        };
+
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+        };
+        grid.Add(leftPanel, 0, 0);
+        grid.Add(rightPanel, 0, 2);
+        return grid;
+    }
+
+    private static TextBlock MakeLabel(string text) => new()
+    {
+        Text = text,
+        Opacity = 0.7,
+        VerticalAlignment = VerticalAlignment.Center,
+    };
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        _vm.OnKeyDown(e);
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -57,6 +57,7 @@ public partial class DownloadTtsViewModel : ObservableObject
     private Task? _downloadTaskQwen3TtsCrispAsrVoices;
     private Task? _downloadTaskVibeVoiceCrispAsrModels;
     private Task? _downloadTaskVibeVoiceCrispAsrVoices;
+    private Task? _downloadTaskDotsTtsCrispAsrModels;
     private Task? _downloadTaskIndexTtsCrispAsrModels;
     private Task? _downloadTaskIndexTtsCrispAsrVoices;
     private Task? _downloadTaskCosyVoice3CrispAsrModels;
@@ -85,6 +86,7 @@ public partial class DownloadTtsViewModel : ObservableObject
     private readonly IQwen3TtsCrispAsrDownloadService _qwen3TtsCrispAsrDownloadService;
     private readonly IVibeVoiceCrispAsrDownloadService _vibeVoiceCrispAsrDownloadService;
     private readonly IIndexTtsCrispAsrDownloadService _indexTtsCrispAsrDownloadService;
+    private readonly IDotsTtsCrispAsrDownloadService _dotsTtsCrispAsrDownloadService;
     private readonly IIndexTts25AudioCppDownloadService _indexTts25AudioCppDownloadService;
     private Task? _downloadTaskIndexTts25AudioCppEngine;
     private Task? _downloadTaskIndexTts25AudioCppModels;
@@ -128,6 +130,7 @@ public partial class DownloadTtsViewModel : ObservableObject
         IQwen3TtsCrispAsrDownloadService qwen3TtsCrispAsrDownloadService,
         IVibeVoiceCrispAsrDownloadService vibeVoiceCrispAsrDownloadService,
         IIndexTtsCrispAsrDownloadService indexTtsCrispAsrDownloadService,
+        IDotsTtsCrispAsrDownloadService dotsTtsCrispAsrDownloadService,
         IIndexTts25AudioCppDownloadService indexTts25AudioCppDownloadService,
         ICosyVoice3CrispAsrDownloadService cosyVoice3CrispAsrDownloadService,
         IF5TtsCrispAsrDownloadService f5TtsCrispAsrDownloadService,
@@ -144,6 +147,7 @@ public partial class DownloadTtsViewModel : ObservableObject
         _qwen3TtsCrispAsrDownloadService = qwen3TtsCrispAsrDownloadService;
         _vibeVoiceCrispAsrDownloadService = vibeVoiceCrispAsrDownloadService;
         _indexTtsCrispAsrDownloadService = indexTtsCrispAsrDownloadService;
+        _dotsTtsCrispAsrDownloadService = dotsTtsCrispAsrDownloadService;
         _indexTts25AudioCppDownloadService = indexTts25AudioCppDownloadService;
         _downloadStreamIndexTts25AudioCppEngine = new MemoryStream();
         _downloadStreamIndexTts25AudioCppVoices = new MemoryStream();
@@ -948,6 +952,36 @@ public partial class DownloadTtsViewModel : ObservableObject
                     Error = ex?.Message ?? Se.Language.General.UnknownError;
                 }
 
+                return;
+            }
+
+            if (_downloadTaskDotsTtsCrispAsrModels is { IsCompletedSuccessfully: true })
+            {
+                // Unlike IndexTTS there is no voice pack to fetch afterwards: dots.tts clones
+                // from user-imported WAVs, and the engine seeds the voices folder from
+                // qwen3-tts.cpp on first use.
+                _timer.Stop();
+                _downloadTaskDotsTtsCrispAsrModels = null;
+                OkPressed = true;
+                Close();
+                return;
+            }
+
+            if (_downloadTaskDotsTtsCrispAsrModels is { IsFaulted: true })
+            {
+                _timer.Stop();
+                var dotsEx = _downloadTaskDotsTtsCrispAsrModels.Exception?.InnerException ?? _downloadTaskDotsTtsCrispAsrModels.Exception;
+                _downloadTaskDotsTtsCrispAsrModels = null;
+                if (dotsEx is OperationCanceledException)
+                {
+                    ProgressText = Se.Language.General.DownloadCanceled;
+                    Close();
+                }
+                else
+                {
+                    ProgressText = Se.Language.General.DownloadFailed;
+                    Error = dotsEx?.Message ?? Se.Language.General.UnknownError;
+                }
                 return;
             }
 
@@ -2054,6 +2088,29 @@ public partial class DownloadTtsViewModel : ObservableObject
 
         _downloadTaskVibeVoiceCrispAsrModels =
             _vibeVoiceCrispAsrDownloadService.DownloadModels(VibeVoiceCrispAsr.GetSetModelsFolder(), resolved, downloadProgress, titleProgress, _cancellationTokenSource.Token);
+    }
+
+    public void StartDownloadDotsTtsCrispAsrModels(string? modelKey = null)
+    {
+        var resolved = DotsTtsCrispAsr.ResolveModelKey(modelKey);
+        var coreFileName = DotsTtsCrispAsr.GetCoreFileName(resolved);
+        TitleText = string.Format(Se.Language.General.DownloadingX, $"dots.tts (CrispASR) models ({resolved}): {coreFileName}");
+
+        var downloadProgress = new Progress<float>(number =>
+        {
+            var percentage = (int)Math.Round(number * 100.0, MidpointRounding.AwayFromZero);
+            var pctString = percentage.ToString(CultureInfo.InvariantCulture);
+            ProgressValue = percentage;
+            ProgressText = string.Format(Se.Language.General.DownloadingXPercent, pctString);
+        });
+
+        var titleProgress = new Action<string>(title =>
+        {
+            Dispatcher.UIThread.Post(() => TitleText = title);
+        });
+
+        _downloadTaskDotsTtsCrispAsrModels =
+            _dotsTtsCrispAsrDownloadService.DownloadModels(DotsTtsCrispAsr.GetSetModelsFolder(), resolved, downloadProgress, titleProgress, _cancellationTokenSource.Token);
     }
 
     public void StartDownloadIndexTtsCrispAsrModels(string? modelKey = null)

--- a/src/ui/Features/Video/TextToSpeech/Engines/DotsTtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/DotsTtsCrispAsr.cs
@@ -1,0 +1,823 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// dots.tts SOAR (dots studio, Apache-2.0) run through the CrispASR runtime. A 2B continuous
+/// autoregressive TTS model: a Qwen2.5-1.5B backbone drives an 18-layer flow-matching DiT that
+/// predicts acoustic latents directly, and a BigVGAN vocoder renders them at <b>48 kHz</b> — the
+/// highest output rate of any TTS engine SE ships (the others are 24 kHz). There is no discrete
+/// audio codec anywhere in the stack, and the backbone reads BPE text rather than phonemes, so no
+/// G2P dictionary is involved.
+///
+/// SOAR is the post-trained variant (Self-corrective Alignment): upstream reports the best
+/// zero-shot speaker similarity of the three dots.tts checkpoints, which is why it is the one
+/// CrispASR ships.
+///
+/// Three GGUFs are needed:
+///  - dots-tts-soar-{q4_k,q8_0,f16}.gguf : the core model (LLM + PatchEncoder + DiT)
+///  - dots-tts-soar-vocoder-f16.gguf     : BigVGAN 48 kHz vocoder (required companion)
+///  - dots-tts-soar-spk-f16.gguf         : CAM++ speaker encoder (required for voice cloning)
+///
+/// The quants are deliberately <i>mixed</i>: cstr keeps the flow-matching DiT at F16 in every
+/// quant, because it runs in a CFG Euler ODE loop (~16 steps x 18 layers x 2 CFG passes) where
+/// per-step quantization noise compounds and derails generation — a fully-Q8 DiT produces no-EOS
+/// runaway. Only the LLM and PatchEncoder are quantized, so Q4_K is a legitimate choice here
+/// rather than the usual sub-8-bit gamble. Do not re-quantize these files.
+///
+/// Verified against the pinned CrispASR v0.8.29 on macOS/Metal (2026-08-24): CLI and server mode
+/// both work with the exact flags and payload below, output is 48 kHz mono, and the clone tracks
+/// the reference speaker (median f0: reference 190.3 Hz, clone 195.8 Hz, preset voice 124.8 Hz).
+/// Note that v0.8.29's <c>--list-backends-json</c> does <i>not</i> advertise the
+/// <c>voice-cloning</c> capability for this backend even though cloning demonstrably works — the
+/// capability bitmask is stale, not the feature.
+///
+/// <b>It is slow.</b> Measured RTF 7.64 on an M4 with the F16 core at 16 ODE steps (3.5 s of audio
+/// in 26.9 s), against ~1.6 for IndexTTS 2.5 on the same machine. The cost is the CFG Euler loop
+/// in the DiT, which stays F16 in every quant, so a smaller quant saves memory rather than time —
+/// the ODE step count is the lever, and it scales close to linearly (4/16/32 steps took 25/38/68 s
+/// wall including model load).
+///
+/// CLI shape:
+///   crispasr --backend dots-tts -m dots-tts-soar-q8_0.gguf \
+///       --voice reference.wav --i-have-rights \
+///       --tts "Hello, how are you today?" --tts-output out.wav
+///
+/// Unlike F5-TTS / CosyVoice3, dots.tts conditions on a CAM++ speaker embedding (a 512-d x-vector
+/// projected to a 1024-d g_cond) rather than by continuing a transcribed reference, so there is no
+/// reference-transcript parameter at all — an imported WAV needs no .txt sidecar.
+/// </summary>
+public class DotsTtsCrispAsr : ITtsEngine
+{
+    public string Name => "dots.tts (CrispASR)";
+    public string Description => "dots.tts SOAR 2B, 48 kHz with voice cloning, via CrispASR";
+    public bool HasLanguageParameter => false;
+    public bool HasApiKey => false;
+    public bool HasRegion => false;
+    public bool HasModel => true;
+    public bool HasKeyFile => false;
+    public bool SupportsVoiceCloning => true;
+    public bool SupportsPerLineVoiceCloning => false;
+
+    // Labels carry the total download (core + vocoder + speaker encoder), not just the core file,
+    // so the dropdown does not understate what the user is about to fetch.
+    public const string ModelKeyQ4K = "Q4_K (~2.4 GB)";
+    public const string ModelKeyQ8_0 = "Q8_0 (~3.5 GB)";
+    public const string ModelKeyF16 = "F16 (~5.0 GB)";
+    public const string DefaultModelKey = ModelKeyQ8_0;
+
+    public const string CoreQ4KFileName = "dots-tts-soar-q4_k.gguf";
+    public const string CoreQ8_0FileName = "dots-tts-soar-q8_0.gguf";
+    public const string CoreF16FileName = "dots-tts-soar-f16.gguf";
+
+    /// <summary>
+    /// BigVGAN vocoder. Kept at F16 for every core quant — it is only ~345 MB, and it is the last
+    /// stage before the waveform, so this is the one place where saving 25 MB is not worth it.
+    /// </summary>
+    public const string VocoderFileName = "dots-tts-soar-vocoder-f16.gguf";
+
+    /// <summary>
+    /// CAM++ speaker encoder (~14 MB). CrispASR auto-discovers it as a sibling of the core GGUF
+    /// and only loads it when --voice is passed, so there is no flag for it — it just has to be
+    /// in the same folder. Without it the backend cannot clone.
+    /// </summary>
+    public const string SpeakerEncoderFileName = "dots-tts-soar-spk-f16.gguf";
+
+    public const string BackendName = "dots-tts";
+
+    /// <summary>
+    /// Flow-matching Euler steps. Upstream recommends 10-32 (higher = better, slower);
+    /// CrispASR's default is 16. Passed to the server through CRISPASR_DOTS_ODE_STEPS —
+    /// there is no CLI flag for it.
+    /// </summary>
+    public const int MinOdeSteps = 8;
+    public const int MaxOdeSteps = 32;
+    public const int DefaultOdeSteps = 16;
+
+    private const string OdeStepsEnvironmentVariable = "CRISPASR_DOTS_ODE_STEPS";
+
+    // Exact byte sizes from the HF tree API (cstr/dots-tts-soar-GGUF). Same truncation guard as
+    // the other CrispASR TTS engines — a partial GGUF crashes the loader at server startup.
+    private static readonly Dictionary<string, long> ExpectedFileSizes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [CoreQ4KFileName] = 2322162816L,
+        [CoreQ8_0FileName] = 3128255616L,
+        [CoreF16FileName] = 4639679552L,
+        [VocoderFileName] = 362123680L,
+        [SpeakerEncoderFileName] = 14953856L,
+    };
+
+    public static string ResolveModelKey(string? modelKey)
+    {
+        if (string.IsNullOrEmpty(modelKey))
+        {
+            var saved = Se.Settings.Video.TextToSpeech.DotsTtsCrispAsrModel;
+            return string.IsNullOrEmpty(saved) ? DefaultModelKey : ResolveModelKey(saved);
+        }
+
+        return modelKey switch
+        {
+            ModelKeyQ4K => ModelKeyQ4K,
+            ModelKeyF16 => ModelKeyF16,
+            _ => ModelKeyQ8_0,
+        };
+    }
+
+    public static string GetCoreFileName(string? modelKey) => ResolveModelKey(modelKey) switch
+    {
+        ModelKeyQ4K => CoreQ4KFileName,
+        ModelKeyF16 => CoreF16FileName,
+        _ => CoreQ8_0FileName,
+    };
+
+    public static int ResolveOdeSteps()
+    {
+        var saved = Se.Settings.Video.TextToSpeech.DotsTtsCrispAsrOdeSteps;
+        return saved <= 0 ? DefaultOdeSteps : Math.Clamp(saved, MinOdeSteps, MaxOdeSteps);
+    }
+
+    public static bool IsValidLocalModelFile(string path, string fileName)
+    {
+        if (!File.Exists(path))
+        {
+            return false;
+        }
+
+        if (!ExpectedFileSizes.TryGetValue(fileName, out var expected))
+        {
+            return true;
+        }
+
+        try
+        {
+            return new FileInfo(path).Length == expected;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static readonly HttpClient HttpClient = new()
+    {
+        Timeout = TimeSpan.FromMinutes(10),
+    };
+    private static readonly SemaphoreSlim ServerLock = new(1, 1);
+    private static Process? _serverProcess;
+    private static int _serverPort;
+    private static string? _serverLaunchCommand;
+    // Same startup-flag cloning as indextts/f5/voxcpm2: the reference is read from the --voice
+    // path at server start, never from the request body, so a voice change means tear down and
+    // restart. Tracked alongside the quant and the ODE-step count, which are equally baked in.
+    private static string? _serverVoicePath;
+    private static string? _serverModelKey;
+    private static int _serverOdeSteps;
+    private static bool _processExitHooked;
+    private static readonly StringBuilder _serverLog = new();
+
+    private static string ServerBaseUrl => $"http://127.0.0.1:{_serverPort}";
+
+    public Task<bool> IsInstalled(string? region)
+    {
+        return Task.FromResult(File.Exists(GetCrispAsrExecutable()));
+    }
+
+    public override string ToString() => Name;
+
+    /// <summary>
+    /// Path to the crispasr executable installed by the speech-to-text feature. Shared with every
+    /// other CrispASR-backed engine.
+    /// </summary>
+    public static string GetCrispAsrExecutable()
+    {
+        return new CrispAsrCohere().GetExecutable();
+    }
+
+    public static DownloadHashManager.UpdateStatus GetEngineUpdateStatus()
+    {
+        var exe = GetCrispAsrExecutable();
+        if (!File.Exists(exe))
+        {
+            return DownloadHashManager.UpdateStatus.Unknown;
+        }
+
+        var folder = Path.GetDirectoryName(exe);
+        return string.IsNullOrEmpty(folder)
+            ? DownloadHashManager.UpdateStatus.Unknown
+            : DownloadHashManager.GetSidecarStatus(folder);
+    }
+
+    public static string GetSetFolder()
+    {
+        if (!Directory.Exists(Se.TextToSpeechFolder))
+        {
+            Directory.CreateDirectory(Se.TextToSpeechFolder);
+        }
+
+        var folder = Path.Combine(Se.TextToSpeechFolder, "DotsTtsCrispAsr");
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        return folder;
+    }
+
+    public static string GetSetModelsFolder()
+    {
+        // Like the other CrispASR-backed engines, the GGUFs live alongside CrispASR's
+        // speech-to-text models in CrispASR/models/ rather than under TextToSpeech/.
+        var modelsFolder = Path.Combine(Se.CrispAsrFolder, "models");
+        if (!Directory.Exists(modelsFolder))
+        {
+            Directory.CreateDirectory(modelsFolder);
+        }
+
+        return modelsFolder;
+    }
+
+    public static string GetSetVoicesFolder()
+    {
+        var voicesFolder = Path.Combine(GetSetFolder(), "voices");
+        if (!Directory.Exists(voicesFolder))
+        {
+            Directory.CreateDirectory(voicesFolder);
+        }
+
+        SeedVoicesFromQwen3TtsCppIfEmpty(voicesFolder);
+        return voicesFolder;
+    }
+
+    private static bool _voiceSeedAttempted;
+
+    /// <summary>
+    /// One-time best-effort seed of WAV reference voices from qwen3-tts.cpp's voices folder, so a
+    /// fresh install has something in the voice combo. Resampled to 24 kHz on the way in, matching
+    /// what <see cref="ImportVoice"/> produces.
+    /// </summary>
+    private static void SeedVoicesFromQwen3TtsCppIfEmpty(string voicesFolder)
+    {
+        if (_voiceSeedAttempted)
+        {
+            return;
+        }
+        _voiceSeedAttempted = true;
+
+        try
+        {
+            if (Directory.EnumerateFiles(voicesFolder, "*.wav").Any())
+            {
+                return;
+            }
+
+            var sourceFolder = Qwen3TtsCpp.GetSetVoicesFolder();
+            if (!Directory.Exists(sourceFolder) || !Directory.EnumerateFiles(sourceFolder, "*.wav").Any())
+            {
+                return;
+            }
+
+            foreach (var src in Directory.GetFiles(sourceFolder, "*.wav"))
+            {
+                var dest = Path.Combine(voicesFolder, Path.GetFileName(src));
+                VoiceSeedHelper.CopyOrResample(src, dest, 24000, "dots.tts (CrispASR)");
+            }
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, "dots.tts (CrispASR): voice seeding from qwen3-tts.cpp folder failed");
+        }
+    }
+
+    public static string GetCorePath(string? modelKey = null) =>
+        Path.Combine(GetSetModelsFolder(), GetCoreFileName(modelKey));
+
+    public static string GetVocoderPath() =>
+        Path.Combine(GetSetModelsFolder(), VocoderFileName);
+
+    public static string GetSpeakerEncoderPath() =>
+        Path.Combine(GetSetModelsFolder(), SpeakerEncoderFileName);
+
+    public static bool AreModelsInstalled(string? modelKey = null) =>
+        IsValidLocalModelFile(GetCorePath(modelKey), GetCoreFileName(modelKey))
+        && IsValidLocalModelFile(GetVocoderPath(), VocoderFileName)
+        && IsValidLocalModelFile(GetSpeakerEncoderPath(), SpeakerEncoderFileName);
+
+    /// <summary>
+    /// Path crispasr's --auto-download writes GGUFs to, so SE's downloader can adopt files a
+    /// previous CLI run already fetched instead of re-pulling gigabytes.
+    /// </summary>
+    public static string GetCrispAsrCacheFolder() =>
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".cache", "crispasr");
+
+    public static bool TrySeedModelFromCrispAsrCache(string fileName, string destinationPath)
+    {
+        if (IsValidLocalModelFile(destinationPath, fileName))
+        {
+            return true;
+        }
+
+        try
+        {
+            if (File.Exists(destinationPath))
+            {
+                Se.LogError($"dots.tts (CrispASR): removing wrong-sized local model file {destinationPath}");
+                File.Delete(destinationPath);
+            }
+
+            var cachePath = Path.Combine(GetCrispAsrCacheFolder(), fileName);
+            if (!IsValidLocalModelFile(cachePath, fileName))
+            {
+                return false;
+            }
+
+            File.Copy(cachePath, destinationPath);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, $"dots.tts (CrispASR): cache seed copy failed for {fileName}");
+            return false;
+        }
+    }
+
+    public async Task<Voice[]> GetVoices(string language)
+    {
+        var result = new List<Voice>();
+
+        // Voice cloning only — no built-in preset voices are exposed, so the combo is empty until
+        // the user imports a reference WAV (or the qwen3-tts.cpp seed above runs).
+        // Off the UI thread: GetSetVoicesFolder does one-time seeding through ffmpeg.
+        var voicesFolder = await Task.Run(GetSetVoicesFolder);
+        if (Directory.Exists(voicesFolder))
+        {
+            foreach (var file in Directory.GetFiles(voicesFolder, "*.wav"))
+            {
+                var name = Path.GetFileNameWithoutExtension(file).Replace('_', ' ');
+                result.Add(new Voice(new DotsTtsVoice(name, file)));
+            }
+        }
+
+        return result.ToArray();
+    }
+
+    public bool IsVoiceInstalled(Voice voice) => true;
+
+    public Task<string[]> GetRegions() => Task.FromResult(Array.Empty<string>());
+
+    public Task<string[]> GetModels() => Task.FromResult(new[] { ModelKeyQ4K, ModelKeyQ8_0, ModelKeyF16 });
+
+    public Task<TtsLanguage[]> GetLanguages(Voice voice, string? model) => Task.FromResult(Array.Empty<TtsLanguage>());
+
+    public Task<Voice[]> RefreshVoices(string language, CancellationToken cancellationToken) =>
+        GetVoices(language);
+
+    public async Task<TtsResult> Speak(
+        string text,
+        string outputFolder,
+        Voice voice,
+        TtsLanguage? language,
+        string? region,
+        string? model,
+        CancellationToken cancellationToken)
+    {
+        if (voice.EngineVoice is not DotsTtsVoice dotsVoice)
+        {
+            throw new ArgumentException("Voice is not a DotsTtsVoice");
+        }
+
+        if (string.IsNullOrEmpty(dotsVoice.FilePath))
+        {
+            throw new InvalidOperationException(
+                "dots.tts (CrispASR) requires a reference voice WAV. "
+                + "Import one via the voice settings, then pick it in the voice combo. "
+                + "Reference WAV should be 24 kHz mono (3-10 s of clean speech).");
+        }
+
+        var modelKey = ResolveModelKey(model);
+        await EnsureServerRunningAsync(modelKey, dotsVoice.FilePath, cancellationToken);
+
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder), Guid.NewGuid() + ".wav");
+
+        // Deliberately NO `voice` field: like indextts/f5/voxcpm2, the dots-tts backend takes its
+        // reference from the startup --voice path and the server rejects absolute paths in the
+        // request body outright (path-traversal guard). Verified on v0.8.29 — the server logs
+        // `voice='<startup>'` for this payload and the CAM++ embedding is built from that file.
+        // Also no `ref_text`: dots.tts conditions on a speaker embedding, not on a transcribed
+        // reference, so the field has nothing to bind to. No `speed` either — dots-tts is not in
+        // crispasr's --tts-speed backend list, and the quality/speed knob that does work here is
+        // the ODE step count passed at server launch.
+        var payload = new Dictionary<string, object>
+        {
+            ["input"] = text,
+            ["response_format"] = "wav",
+        };
+
+        // Attests the user's own imported reference and the AI-disclosure duty; see
+        // CrispAsrTtsProvenance. Skipped when voice cloning has not been accepted in settings.
+        CrispAsrTtsProvenance.AddSpeechAttestations(payload);
+
+        var body = JsonSerializer.Serialize(payload);
+        using var content = new StringContent(body, Encoding.UTF8, "application/json");
+        Se.WriteToolsLog($"dots.tts (CrispASR): POST {ServerBaseUrl}/v1/audio/speech (voice={dotsVoice}, textLen={text.Length})");
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await HttpClient.PostAsync($"{ServerBaseUrl}/v1/audio/speech", content, cancellationToken);
+        }
+        catch (HttpRequestException ex)
+        {
+            var serverLog = SnapshotServerLog();
+            var launchCommand = _serverLaunchCommand;
+            var died = _serverProcess?.HasExited == true;
+            if (died)
+            {
+                StopServerInternal();
+            }
+
+            var failMsg = $"dots.tts (CrispASR) request failed — Voice: {dotsVoice}, Text: {text}, "
+                + $"RequestJson: {body}, ServerExited: {died}, ServerLog: {serverLog}"
+                + LaunchCmdSuffix(launchCommand);
+            Se.LogError(ex, failMsg);
+            Se.WriteToolsLog(failMsg);
+
+            throw new InvalidOperationException(
+                (died
+                    ? "dots.tts (CrispASR) — the crispasr server crashed during synthesis."
+                    : "dots.tts (CrispASR) request failed — the connection to the crispasr server was dropped.")
+                + (string.IsNullOrEmpty(serverLog) ? string.Empty : $"{Environment.NewLine}Server log:{Environment.NewLine}{serverLog}")
+                + LaunchCmdSuffix(launchCommand),
+                ex);
+        }
+
+        using (response)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorBody = await SafeReadErrorAsync(response, cancellationToken);
+                var serverLog = SnapshotServerLog();
+                var launchCommand = _serverLaunchCommand;
+                var errMsg = $"dots.tts (CrispASR) server error {(int)response.StatusCode} {response.StatusCode} — "
+                    + $"Voice: {dotsVoice}, Text: {text}, RequestJson: {body}, "
+                    + $"ResponseBody: {errorBody}, ServerLog: {serverLog}"
+                    + LaunchCmdSuffix(launchCommand);
+                Se.LogError(errMsg);
+                Se.WriteToolsLog(errMsg);
+                throw new InvalidOperationException(
+                    $"dots.tts (CrispASR) synthesis failed ({(int)response.StatusCode}): {errorBody}"
+                    + (string.IsNullOrEmpty(serverLog) ? string.Empty : $"{Environment.NewLine}Server log:{Environment.NewLine}{serverLog}")
+                    + LaunchCmdSuffix(launchCommand));
+            }
+
+            await using var fileStream = File.Create(outputFileName);
+            await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+            await contentStream.CopyToAsync(fileStream, cancellationToken);
+        }
+
+        return new TtsResult(outputFileName, text);
+    }
+
+    private static string FormatLaunchCommand(string exe, System.Collections.ObjectModel.Collection<string> args)
+    {
+        static string Quote(string s) =>
+            !string.IsNullOrEmpty(s) && s.IndexOfAny(new[] { ' ', '\t' }) >= 0
+                ? "\"" + s.Replace("\"", "\\\"") + "\""
+                : s;
+
+        var sb = new StringBuilder(Quote(exe));
+        foreach (var a in args)
+        {
+            sb.Append(' ').Append(Quote(a));
+        }
+        return sb.ToString();
+    }
+
+    private static string LaunchCmdSuffix(string? launchCommand) =>
+        string.IsNullOrEmpty(launchCommand)
+            ? string.Empty
+            : $"{Environment.NewLine}Launch command: {launchCommand}";
+
+    private static async Task<string> SafeReadErrorAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        try
+        {
+            return await response.Content.ReadAsStringAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            return $"<failed to read error body: {ex.Message}>";
+        }
+    }
+
+    private static async Task EnsureServerRunningAsync(string modelKey, string voicePath, CancellationToken ct)
+    {
+        var odeSteps = ResolveOdeSteps();
+
+        if (_serverProcess is { HasExited: false } && _serverPort != 0
+            && string.Equals(_serverVoicePath, voicePath, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(_serverModelKey, modelKey, StringComparison.OrdinalIgnoreCase)
+            && _serverOdeSteps == odeSteps)
+        {
+            return;
+        }
+
+        await ServerLock.WaitAsync(ct);
+        try
+        {
+            if (_serverProcess is { HasExited: false } && _serverPort != 0
+                && string.Equals(_serverVoicePath, voicePath, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(_serverModelKey, modelKey, StringComparison.OrdinalIgnoreCase)
+                && _serverOdeSteps == odeSteps)
+            {
+                return;
+            }
+
+            if (_serverProcess != null)
+            {
+                StopServerInternal();
+            }
+
+            var exe = GetCrispAsrExecutable();
+            if (!File.Exists(exe))
+            {
+                throw new FileNotFoundException(
+                    "CrispASR executable not found. Install CrispASR via Video → Audio to text first.", exe);
+            }
+
+            var coreFileName = GetCoreFileName(modelKey);
+            var core = GetCorePath(modelKey);
+            var hasLocalCore = IsValidLocalModelFile(core, coreFileName);
+            var vocoder = GetVocoderPath();
+            var hasLocalVocoder = IsValidLocalModelFile(vocoder, VocoderFileName);
+
+            var port = FindFreeLoopbackPort();
+            var psi = new ProcessStartInfo
+            {
+                WorkingDirectory = Path.GetDirectoryName(exe) ?? GetSetFolder(),
+                FileName = exe,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                // The server writes UTF-8; without these the captured log reaches bug reports as
+                // mojibake on Windows (#13572).
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8,
+            };
+            psi.ArgumentList.Add("--server");
+            psi.ArgumentList.Add("--backend");
+            psi.ArgumentList.Add(BackendName);
+            psi.ArgumentList.Add("-m");
+            psi.ArgumentList.Add(hasLocalCore ? core : "auto");
+            if (hasLocalVocoder)
+            {
+                psi.ArgumentList.Add("--codec-model");
+                psi.ArgumentList.Add(vocoder);
+            }
+            if (!hasLocalCore || !hasLocalVocoder)
+            {
+                psi.ArgumentList.Add("--auto-download");
+            }
+            psi.ArgumentList.Add("--host");
+            psi.ArgumentList.Add("127.0.0.1");
+            psi.ArgumentList.Add("--port");
+            psi.ArgumentList.Add(port.ToString(CultureInfo.InvariantCulture));
+            psi.ArgumentList.Add("--voice-dir");
+            psi.ArgumentList.Add(GetSetVoicesFolder());
+            // Required: the dots-tts backend clones only from the startup --voice path. The CAM++
+            // speaker encoder next to the core GGUF is picked up automatically when this is set.
+            psi.ArgumentList.Add("--voice");
+            psi.ArgumentList.Add(voicePath);
+            CrispAsrTtsProvenance.AddServerMarkingArgs(psi.ArgumentList, exe);
+
+            // ODE steps have no CLI flag — the backend reads them from the environment. Set it
+            // explicitly rather than relying on the default so the value shown in the settings
+            // dialog is the value actually used.
+            psi.Environment[OdeStepsEnvironmentVariable] = odeSteps.ToString(CultureInfo.InvariantCulture);
+
+            var process = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start crispasr (dots-tts)");
+
+            var launchCommand = FormatLaunchCommand(exe, psi.ArgumentList);
+            _serverLaunchCommand = launchCommand;
+            Se.WriteToolsLog("dots.tts (CrispASR) server starting — "
+                + $"PID: {process.Id}, "
+                + $"{OdeStepsEnvironmentVariable}: {odeSteps}, "
+                + $"Cmd: {launchCommand}");
+
+            lock (_serverLog) _serverLog.Clear();
+            process.ErrorDataReceived += (_, e) =>
+            {
+                if (e.Data != null) lock (_serverLog) _serverLog.AppendLine(e.Data);
+            };
+            process.OutputDataReceived += (_, e) =>
+            {
+                if (e.Data != null) lock (_serverLog) _serverLog.AppendLine(e.Data);
+            };
+            process.BeginErrorReadLine();
+            process.BeginOutputReadLine();
+
+            _serverProcess = process;
+            _serverPort = port;
+            _serverVoicePath = voicePath;
+            _serverModelKey = modelKey;
+            _serverOdeSteps = odeSteps;
+            HookProcessExitOnce();
+
+            // Loading the F16 core is ~4.6 GB off disk, so even the warm path is not instant;
+            // first run may also be pulling those gigabytes through --auto-download.
+            var timeoutMinutes = hasLocalCore && hasLocalVocoder ? 10 : 30;
+            var deadline = DateTime.UtcNow.AddMinutes(timeoutMinutes);
+            while (DateTime.UtcNow < deadline)
+            {
+                ct.ThrowIfCancellationRequested();
+                if (process.HasExited)
+                {
+                    var tail = SnapshotServerLog();
+                    var exitCode = process.ExitCode;
+                    var exitedLaunchCommand = _serverLaunchCommand;
+                    _serverProcess = null;
+                    _serverPort = 0;
+                    _serverLaunchCommand = null;
+                    _serverVoicePath = null;
+                    _serverModelKey = null;
+                    _serverOdeSteps = 0;
+                    throw new InvalidOperationException(
+                        $"crispasr (dots-tts) exited during startup (code {exitCode}). Output: {tail}"
+                        + LaunchCmdSuffix(exitedLaunchCommand));
+                }
+                if (await ProbeHealthAsync(port, TimeSpan.FromSeconds(2), ct))
+                {
+                    return;
+                }
+                await Task.Delay(TimeSpan.FromSeconds(1), ct);
+            }
+
+            var lastOutput = SnapshotServerLog();
+            var timeoutLaunchCommand = _serverLaunchCommand;
+            StopServerInternal();
+            throw new TimeoutException(
+                $"crispasr (dots-tts) did not report healthy within {timeoutMinutes} minutes. Last output: {lastOutput}"
+                + LaunchCmdSuffix(timeoutLaunchCommand));
+        }
+        finally
+        {
+            ServerLock.Release();
+        }
+    }
+
+    private static string SnapshotServerLog()
+    {
+        lock (_serverLog)
+        {
+            var s = _serverLog.ToString().TrimEnd();
+            return s.Length > 2000 ? s[^2000..] : s;
+        }
+    }
+
+    private static async Task<bool> ProbeHealthAsync(int port, TimeSpan timeout, CancellationToken ct)
+    {
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(timeout);
+            using var resp = await HttpClient.GetAsync($"http://127.0.0.1:{port}/health", cts.Token);
+            return resp.IsSuccessStatusCode;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static int FindFreeLoopbackPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    private static void HookProcessExitOnce()
+    {
+        if (_processExitHooked)
+        {
+            return;
+        }
+        _processExitHooked = true;
+        AppDomain.CurrentDomain.ProcessExit += (_, _) => StopServerInternal();
+    }
+
+    /// <summary>
+    /// Stop the running crispasr (dots-tts) server if any, releasing GPU memory. Called by
+    /// <c>TextToSpeechViewModel</c> when switching engines or closing the TTS window so the
+    /// CrispASR-based engines don't pile up in VRAM.
+    /// </summary>
+    public static void StopServer() => StopServerInternal();
+
+    private static void StopServerInternal()
+    {
+        var p = _serverProcess;
+        _serverProcess = null;
+        _serverPort = 0;
+        _serverLaunchCommand = null;
+        _serverVoicePath = null;
+        _serverModelKey = null;
+        _serverOdeSteps = 0;
+        if (p == null)
+        {
+            return;
+        }
+        try
+        {
+            if (!p.HasExited)
+            {
+                p.Kill(entireProcessTree: true);
+                p.WaitForExit(2000);
+            }
+        }
+        catch
+        {
+            // best effort
+        }
+        finally
+        {
+            p.Dispose();
+        }
+    }
+
+    private static string GetUniqueDestinationFileName(string folder, string baseName)
+    {
+        var candidate = Path.Combine(folder, baseName + ".wav");
+        if (!File.Exists(candidate))
+        {
+            return candidate;
+        }
+
+        var number = 1;
+        do
+        {
+            candidate = Path.Combine(folder, $"{baseName}_{number}.wav");
+            number++;
+        } while (File.Exists(candidate));
+
+        return candidate;
+    }
+
+    public bool ImportVoice(string fileName)
+    {
+        if (string.IsNullOrEmpty(fileName) || !File.Exists(fileName))
+        {
+            return false;
+        }
+
+        var voicesFolder = GetSetVoicesFolder();
+        var baseName = Path.GetFileNameWithoutExtension(fileName);
+        var destinationFileName = GetUniqueDestinationFileName(voicesFolder, baseName);
+
+        // 24 kHz mono, matching the other CrispASR cloning engines so the voices folders stay
+        // interchangeable. No .txt sidecar: dots.tts conditions on a CAM++ speaker embedding, so
+        // it never needs the reference transcript.
+        try
+        {
+            var process = FfmpegGenerator.ConvertToMono24kHzWav(fileName, destinationFileName);
+            if (!process.Start())
+            {
+                return false;
+            }
+
+            process.WaitForExit();
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, "dots.tts (CrispASR) voice import failed (ffmpeg conversion).");
+            return false;
+        }
+
+        return File.Exists(destinationFileName);
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/Engines/DotsTtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/DotsTtsCrispAsr.cs
@@ -50,11 +50,15 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 /// <c>voice-cloning</c> capability for this backend even though cloning demonstrably works — the
 /// capability bitmask is stale, not the feature.
 ///
-/// <b>It is slow.</b> Measured RTF 7.64 on an M4 with the F16 core at 16 ODE steps (3.5 s of audio
-/// in 26.9 s), against ~1.6 for IndexTTS 2.5 on the same machine. The cost is the CFG Euler loop
-/// in the DiT, which stays F16 in every quant, so a smaller quant saves memory rather than time —
-/// the ODE step count is the lever, and it scales close to linearly (4/16/32 steps took 25/38/68 s
-/// wall including model load).
+/// <b>It is slow.</b> Measured in server mode on an M4 at 16 ODE steps, same text both times:
+/// F16 RTF 7.64 (3.5 s of audio in 26.91 s), Q8_0 RTF 7.60 (26.77 s) — against ~1.6 for
+/// IndexTTS 2.5 on the same machine. Synthesis speed is therefore <i>independent of the quant</i>,
+/// exactly as the mixed-quant design predicts: the cost is the CFG Euler loop in the DiT, which
+/// stays F16 in all of them. What a smaller quant does buy is load time — the server reported
+/// healthy in 4 s on Q8_0 versus 21 s on F16 — which is why Q8_0 is the default here.
+///
+/// The one lever on synthesis time is the ODE step count, and it scales close to linearly:
+/// 4 / 16 / 32 steps took 25 / 38 / 68 s wall including model load.
 ///
 /// CLI shape:
 ///   crispasr --backend dots-tts -m dots-tts-soar-q8_0.gguf \

--- a/src/ui/Features/Video/TextToSpeech/Engines/TtsEngineCatalog.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/TtsEngineCatalog.cs
@@ -1,4 +1,4 @@
-using Nikse.SubtitleEdit.Logic.Download;
+﻿using Nikse.SubtitleEdit.Logic.Download;
 using System;
 using System.Collections.Generic;
 
@@ -67,6 +67,11 @@ public static class TtsEngineCatalog
             // new VibeVoiceCrispAsr(),
 
             new IndexTtsCrispAsr(),
+
+            // dots.tts SOAR 2B (CrispASR) — continuous-latent AR model with a flow-matching DiT
+            // head and a 48 kHz BigVGAN vocoder, Apache-2.0. Grouped with the other CrispASR
+            // engines; clones from a CAM++ speaker embedding so no reference transcript is needed.
+            new DotsTtsCrispAsr(),
 
             // CosyVoice3 (CrispASR) sits immediately after IndexTtsCrispAsr to keep the CrispASR
             // engines grouped visually in the engine combo.

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -24,6 +24,7 @@ using Nikse.SubtitleEdit.Features.Video.TextToSpeech.F5TtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.OmniVoiceCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.VoxCPM2CrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.MossTtsCrispAsrSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DotsTtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTts25AudioCppSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.KokoroTtsSettings;
@@ -340,6 +341,10 @@ public partial class TextToSpeechViewModel : ObservableObject
         else if (SelectedEngine is IndexTtsCrispAsr)
         {
             Se.Settings.Video.TextToSpeech.IndexTtsCrispAsrModel = SelectedModel ?? IndexTtsCrispAsr.DefaultModelKey;
+        }
+        else if (SelectedEngine is DotsTtsCrispAsr)
+        {
+            Se.Settings.Video.TextToSpeech.DotsTtsCrispAsrModel = SelectedModel ?? DotsTtsCrispAsr.DefaultModelKey;
         }
         else if (SelectedEngine is IndexTts25AudioCpp)
         {
@@ -1145,6 +1150,10 @@ public partial class TextToSpeechViewModel : ObservableObject
         {
             IndexTtsCrispAsr.StopServer();
         }
+        if (keepAlive is not DotsTtsCrispAsr)
+        {
+            DotsTtsCrispAsr.StopServer();
+        }
         if (keepAlive is not IndexTts25AudioCpp)
         {
             IndexTts25AudioCpp.StopServer();
@@ -1417,6 +1426,9 @@ public partial class TextToSpeechViewModel : ObservableObject
             case IndexTtsCrispAsr:
                 await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadIndexTtsCrispAsrModels(IndexTtsCrispAsr.ResolveModelKey(SelectedModel)));
                 break;
+            case DotsTtsCrispAsr:
+                await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadDotsTtsCrispAsrModels(DotsTtsCrispAsr.ResolveModelKey(SelectedModel)));
+                break;
             case IndexTts25AudioCpp:
                 await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadIndexTts25AudioCppModels(IndexTts25AudioCpp.ResolveModelKey(SelectedModel)));
                 break;
@@ -1488,6 +1500,9 @@ public partial class TextToSpeechViewModel : ObservableObject
                 ? DownloadDotStatus.UpToDate
                 : DownloadDotStatus.NotInstalled,
             IndexTtsCrispAsr => IndexTtsCrispAsr.AreModelsInstalled(modelKey)
+                ? DownloadDotStatus.UpToDate
+                : DownloadDotStatus.NotInstalled,
+            DotsTtsCrispAsr => DotsTtsCrispAsr.AreModelsInstalled(modelKey)
                 ? DownloadDotStatus.UpToDate
                 : DownloadDotStatus.NotInstalled,
             IndexTts25AudioCpp => IndexTts25AudioCpp.AreModelsInstalled(modelKey)
@@ -3788,6 +3803,16 @@ public partial class TextToSpeechViewModel : ObservableObject
             else if (SelectedEngine is IndexTtsCrispAsr)
             {
                 SelectedModel = Models.FirstOrDefault(p => p == Se.Settings.Video.TextToSpeech.IndexTtsCrispAsrModel);
+                if (string.IsNullOrEmpty(SelectedModel))
+                {
+                    SelectedModel = Models.FirstOrDefault();
+                }
+                IsEngineSettingsVisible = true;
+                IsModelDownloadVisible = true;
+            }
+            else if (SelectedEngine is DotsTtsCrispAsr)
+            {
+                SelectedModel = Models.FirstOrDefault(p => p == Se.Settings.Video.TextToSpeech.DotsTtsCrispAsrModel);
                 if (string.IsNullOrEmpty(SelectedModel))
                 {
                     SelectedModel = Models.FirstOrDefault();

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
@@ -184,6 +184,8 @@ public class TextToSpeechWindow : Window
                 return StatusDots.From(engine.IsInstalled(null).Result, VibeVoiceCrispAsr.GetEngineUpdateStatus());
             case IndexTtsCrispAsr:
                 return StatusDots.From(engine.IsInstalled(null).Result, IndexTtsCrispAsr.GetEngineUpdateStatus());
+            case DotsTtsCrispAsr:
+                return StatusDots.From(engine.IsInstalled(null).Result, DotsTtsCrispAsr.GetEngineUpdateStatus());
             case IndexTts25AudioCpp:
                 return StatusDots.From(engine.IsInstalled(null).Result, IndexTts25AudioCpp.GetEngineUpdateStatus());
             case CosyVoice3CrispAsr:

--- a/src/ui/Features/Video/TextToSpeech/TtsEngineInstaller.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsEngineInstaller.cs
@@ -264,6 +264,45 @@ public static class TtsEngineInstaller
             return true;
         }
 
+        if (engine is DotsTtsCrispAsr)
+        {
+            if (!await TtsVoiceInstaller.EnsureCrispAsrForDotsTts(window, windowService, forceRedownload: false))
+            {
+                return false;
+            }
+
+            var dotsModelKey = DotsTtsCrispAsr.ResolveModelKey(model);
+            if (!DotsTtsCrispAsr.AreModelsInstalled(dotsModelKey))
+            {
+                // Model key already carries the total download size, so no separate size here.
+                var answer = await MessageBox.Show(
+                    window,
+                    "Download dots.tts (CrispASR) models?",
+                    $"{Environment.NewLine}\"dots.tts (CrispASR)\" ({dotsModelKey}) requires models.{Environment.NewLine}{Environment.NewLine}Download models?",
+                    MessageBoxButtons.YesNoCancel,
+                    MessageBoxIcon.Question);
+
+                if (answer != MessageBoxResult.Yes)
+                {
+                    return false;
+                }
+
+                var dlResult = await windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(window, vm => vm.StartDownloadDotsTtsCrispAsrModels(dotsModelKey));
+                if (!dlResult.OkPressed || !DotsTtsCrispAsr.AreModelsInstalled(dotsModelKey))
+                {
+                    return false;
+                }
+
+                await Dispatcher.UIThread.InvokeAsync(async () =>
+                {
+                    await refreshVoices();
+                });
+                return true;
+            }
+
+            return true;
+        }
+
         if (engine is IndexTts25AudioCpp)
         {
             // The model licence gate comes before anything is fetched: the weights are under

--- a/src/ui/Features/Video/TextToSpeech/TtsEngineSettingsDialog.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsEngineSettingsDialog.cs
@@ -1,7 +1,8 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ChatterboxTtsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.CosyVoice3CrispAsrSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DotsTtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ElevenLabsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.F5TtsCrispAsrSettings;
@@ -39,6 +40,7 @@ public static class TtsEngineSettingsDialog
         VibeVoiceCrispAsr or
         IndexTts25AudioCpp or
         IndexTtsCrispAsr or
+        DotsTtsCrispAsr or
         CosyVoice3CrispAsr or
         F5TtsCrispAsr or
         OmniVoiceCrispAsr or
@@ -74,6 +76,10 @@ public static class TtsEngineSettingsDialog
         else if (engine is IndexTtsCrispAsr)
         {
             await windowService.ShowDialogAsync<IndexTtsCrispAsrSettingsWindow, IndexTtsCrispAsrSettingsViewModel>(window, vm => vm.Initialize());
+        }
+        else if (engine is DotsTtsCrispAsr)
+        {
+            await windowService.ShowDialogAsync<DotsTtsCrispAsrSettingsWindow, DotsTtsCrispAsrSettingsViewModel>(window, vm => vm.Initialize());
         }
         else if (engine is CosyVoice3CrispAsr)
         {

--- a/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
@@ -164,6 +164,18 @@ public static class TtsVoiceInstaller
             minVersionNote: "v0.8.13 or newer");
 
     /// <summary>
+    /// Ensures the CrispASR runtime that dots.tts (CrispASR) runs on is installed.
+    /// The dots-tts backend ships in CrispASR v0.8.25 and newer (SE pins v0.8.29); the version
+    /// note names that floor because older builds have no dots-tts backend at all and abort on
+    /// the unknown --backend value.
+    /// </summary>
+    public static Task<bool> EnsureCrispAsrForDotsTts(Window? window, IWindowService windowService, bool forceRedownload)
+        => EnsureCrispAsrAsync(window, windowService, forceRedownload,
+            engineDisplayName: "dots.tts (CrispASR)",
+            extraCapabilityCheck: null,
+            minVersionNote: "v0.8.25 or newer");
+
+    /// <summary>
     /// Shared CrispASR install/update flow used by all TTS engines that sit on the
     /// CrispASR runtime. Prompts refer to <paramref name="engineDisplayName"/> so users
     /// see the right engine name. <paramref name="extraCapabilityCheck"/> lets the caller

--- a/src/ui/Features/Video/TextToSpeech/Voices/DotsTtsVoice.cs
+++ b/src/ui/Features/Video/TextToSpeech/Voices/DotsTtsVoice.cs
@@ -1,0 +1,24 @@
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+
+public class DotsTtsVoice
+{
+    public string Voice { get; set; }
+    public string FilePath { get; set; }
+
+    public override string ToString()
+    {
+        return Voice;
+    }
+
+    public DotsTtsVoice()
+    {
+        Voice = string.Empty;
+        FilePath = string.Empty;
+    }
+
+    public DotsTtsVoice(string voice, string filePath)
+    {
+        Voice = voice;
+        FilePath = filePath;
+    }
+}

--- a/src/ui/Logic/Config/SeVideoTextToSpeech.cs
+++ b/src/ui/Logic/Config/SeVideoTextToSpeech.cs
@@ -38,6 +38,10 @@ public class SeVideoTextToSpeech
     public double VibeVoiceCrispAsrSpeed { get; set; }
     public string IndexTtsCrispAsrModel { get; set; }
     public double IndexTtsCrispAsrSpeed { get; set; }
+    public string DotsTtsCrispAsrModel { get; set; }
+    // Flow-matching Euler steps for dots.tts (8-32, default 16). Higher is better and slower;
+    // there is no CLI flag for it, so the engine passes it as CRISPASR_DOTS_ODE_STEPS.
+    public int DotsTtsCrispAsrOdeSteps { get; set; }
     public string IndexTts25AudioCppModel { get; set; }
     // Licence version the user accepted for the IndexTTS-2.5 weights (bilibili Model Use
     // License, not OSI-approved). Empty until accepted; a version bump re-prompts.
@@ -169,6 +173,8 @@ public class SeVideoTextToSpeech
         VibeVoiceCrispAsrSpeed = 1.1;
         IndexTtsCrispAsrModel = "Q8_0 (~870 MB)";
         IndexTtsCrispAsrSpeed = 1.0;
+        DotsTtsCrispAsrModel = "Q8_0 (~3.5 GB)";
+        DotsTtsCrispAsrOdeSteps = 16;
         IndexTts25AudioCppModel = "Q8_0 (~3.3 GB)";
         IndexTts25AudioCppLicenseAccepted = string.Empty;
         IndexTts25AudioCppBackend = string.Empty;

--- a/src/ui/Logic/Download/DotsTtsCrispAsrDownloadService.cs
+++ b/src/ui/Logic/Download/DotsTtsCrispAsrDownloadService.cs
@@ -1,0 +1,179 @@
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Nikse.SubtitleEdit.UiLogic;
+
+namespace Nikse.SubtitleEdit.Logic.Download;
+
+public interface IDotsTtsCrispAsrDownloadService
+{
+    Task DownloadModels(string modelsFolder, string modelKey, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Downloads the dots.tts (CrispASR) core GGUF (Q4_K / Q8_0 / F16, user-picked) plus the two
+/// required companions — the BigVGAN 48 kHz vocoder and the CAM++ speaker encoder — into SE's
+/// CrispASR/models folder, so the user gets a progress dialog instead of crispasr's silent
+/// --auto-download on first synth. Same shape as <see cref="IndexTtsCrispAsrDownloadService"/>.
+/// </summary>
+/// <remarks>
+/// The speaker encoder is only 14 MB and is what makes voice cloning work at all, so it is always
+/// fetched rather than being tied to a quant choice.
+/// </remarks>
+public class DotsTtsCrispAsrDownloadService : IDotsTtsCrispAsrDownloadService
+{
+    private const string RepoBaseUrl = "https://huggingface.co/cstr/dots-tts-soar-GGUF/resolve/main/";
+
+    private readonly HttpClient _httpClient;
+
+    private static readonly Dictionary<string, string> ModelUrls = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [DotsTtsCrispAsr.CoreQ4KFileName] = RepoBaseUrl + DotsTtsCrispAsr.CoreQ4KFileName,
+        [DotsTtsCrispAsr.CoreQ8_0FileName] = RepoBaseUrl + DotsTtsCrispAsr.CoreQ8_0FileName,
+        [DotsTtsCrispAsr.CoreF16FileName] = RepoBaseUrl + DotsTtsCrispAsr.CoreF16FileName,
+        [DotsTtsCrispAsr.VocoderFileName] = RepoBaseUrl + DotsTtsCrispAsr.VocoderFileName,
+        [DotsTtsCrispAsr.SpeakerEncoderFileName] = RepoBaseUrl + DotsTtsCrispAsr.SpeakerEncoderFileName,
+    };
+
+    public DotsTtsCrispAsrDownloadService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task DownloadModels(string modelsFolder, string modelKey, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken)
+    {
+        var coreFileName = DotsTtsCrispAsr.GetCoreFileName(modelKey);
+        var corePath = DotsTtsCrispAsr.GetCorePath(modelKey);
+        var vocoderPath = DotsTtsCrispAsr.GetVocoderPath();
+        var speakerPath = DotsTtsCrispAsr.GetSpeakerEncoderPath();
+
+        // Cache seeding does a synchronous File.Copy of up to ~4.6 GB, and the caller hands the
+        // returned Task to a timer without awaiting it, so anything before the first real await
+        // would run on the UI thread. Push it onto the threadpool.
+        await Task.Run(() =>
+        {
+            DotsTtsCrispAsr.TrySeedModelFromCrispAsrCache(coreFileName, corePath);
+            DotsTtsCrispAsr.TrySeedModelFromCrispAsrCache(DotsTtsCrispAsr.VocoderFileName, vocoderPath);
+            DotsTtsCrispAsr.TrySeedModelFromCrispAsrCache(DotsTtsCrispAsr.SpeakerEncoderFileName, speakerPath);
+            EnsureRemovedIfInvalid(corePath, coreFileName);
+            EnsureRemovedIfInvalid(vocoderPath, DotsTtsCrispAsr.VocoderFileName);
+            EnsureRemovedIfInvalid(speakerPath, DotsTtsCrispAsr.SpeakerEncoderFileName);
+        }, cancellationToken);
+
+        var pending = new List<(string Path, string FileName)>();
+        if (!DotsTtsCrispAsr.IsValidLocalModelFile(corePath, coreFileName))
+        {
+            pending.Add((corePath, coreFileName));
+        }
+        if (!DotsTtsCrispAsr.IsValidLocalModelFile(vocoderPath, DotsTtsCrispAsr.VocoderFileName))
+        {
+            pending.Add((vocoderPath, DotsTtsCrispAsr.VocoderFileName));
+        }
+        if (!DotsTtsCrispAsr.IsValidLocalModelFile(speakerPath, DotsTtsCrispAsr.SpeakerEncoderFileName))
+        {
+            pending.Add((speakerPath, DotsTtsCrispAsr.SpeakerEncoderFileName));
+        }
+
+        var step = 0;
+        foreach (var (path, fileName) in pending)
+        {
+            step++;
+            titleProgress?.Invoke($"Downloading dots.tts (CrispASR) models ({step}/{pending.Count}): {fileName}");
+            await DownloadAndVerify(path, fileName, progress, cancellationToken);
+        }
+    }
+
+    private async Task DownloadAndVerify(string finalPath, string fileName, IProgress<float>? progress, CancellationToken cancellationToken)
+    {
+        var partPath = finalPath + ".part";
+        try
+        {
+            await DownloadHelper.DownloadFileAsync(_httpClient, GetUrl(fileName), partPath, progress, cancellationToken);
+            await VerifyFile(partPath, GetHashKey(fileName), fileName, cancellationToken);
+            File.Move(partPath, finalPath);
+        }
+        catch
+        {
+            TryDelete(partPath);
+            throw;
+        }
+    }
+
+    private static string? GetHashKey(string fileName)
+    {
+        if (string.Equals(fileName, DotsTtsCrispAsr.CoreQ4KFileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.DotsTtsCrispAsr.CoreQ4K;
+        }
+        if (string.Equals(fileName, DotsTtsCrispAsr.CoreQ8_0FileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.DotsTtsCrispAsr.CoreQ8_0;
+        }
+        if (string.Equals(fileName, DotsTtsCrispAsr.CoreF16FileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.DotsTtsCrispAsr.CoreF16;
+        }
+        if (string.Equals(fileName, DotsTtsCrispAsr.VocoderFileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.DotsTtsCrispAsr.Vocoder;
+        }
+        if (string.Equals(fileName, DotsTtsCrispAsr.SpeakerEncoderFileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.DotsTtsCrispAsr.SpeakerEncoder;
+        }
+        return null;
+    }
+
+    private static async Task VerifyFile(string filePath, string? key, string fileName, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(key))
+        {
+            return;
+        }
+
+        var expected = DownloadHashManager.GetLatestKnownHash(key);
+        if (string.IsNullOrEmpty(expected))
+        {
+            return;
+        }
+
+        string actual;
+        await using (var stream = File.OpenRead(filePath))
+        {
+            actual = await Sha256Util.ComputeSha256Async(stream, cancellationToken);
+        }
+
+        if (!string.Equals(expected, actual, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new IOException(
+                $"dots.tts (CrispASR) model {fileName} failed integrity check (expected SHA-256 {expected}, got {actual}).");
+        }
+    }
+
+    private static string GetUrl(string fileName)
+    {
+        if (!ModelUrls.TryGetValue(fileName, out var url))
+        {
+            throw new ArgumentException($"Unknown dots.tts (CrispASR) model: {fileName}", nameof(fileName));
+        }
+        return url;
+    }
+
+    private static void TryDelete(string path)
+    {
+        try { File.Delete(path); } catch { /* best-effort cleanup */ }
+    }
+
+    private static void EnsureRemovedIfInvalid(string path, string fileName)
+    {
+        if (!File.Exists(path) || DotsTtsCrispAsr.IsValidLocalModelFile(path, fileName))
+        {
+            return;
+        }
+        TryDelete(path);
+    }
+}

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -196,6 +196,18 @@ public static class DownloadHashManager
         public const string Codec = "IndexTtsCrispAsr.Codec";
     }
 
+    public static class DotsTtsCrispAsr
+    {
+        // SHA-256 of the dots.tts SOAR GGUFs on cstr/dots-tts-soar-GGUF (HF LFS oid; the
+        // vocoder and speaker-encoder values were confirmed against a local sha256sum of the
+        // downloaded files).
+        public const string CoreQ4K = "DotsTtsCrispAsr.CoreQ4K";
+        public const string CoreQ8_0 = "DotsTtsCrispAsr.CoreQ8_0";
+        public const string CoreF16 = "DotsTtsCrispAsr.CoreF16";
+        public const string Vocoder = "DotsTtsCrispAsr.Vocoder";
+        public const string SpeakerEncoder = "DotsTtsCrispAsr.SpeakerEncoder";
+    }
+
     public static class IndexTts25AudioCpp
     {
         // SHA-256 of the IndexTTS-2.5 GGUFs on audio-cpp/audio.cpp-gguf (HF LFS oid, confirmed
@@ -1691,6 +1703,28 @@ public static class DownloadHashManager
             [IndexTtsCrispAsr.Codec] = new[]
             {
                 "fcba9a322d80ef318da8a17c01e8a5e7f299ccdf881c62a43abf62cb3c104268", // indextts-bigvgan.gguf
+            },
+
+            // dots.tts SOAR weights, from cstr/dots-tts-soar-GGUF.
+            [DotsTtsCrispAsr.CoreQ4K] = new[]
+            {
+                "9f6bb49d456df154083fa21244657e7a7aa1c775d94bb24edec6977e68b7cb95", // dots-tts-soar-q4_k.gguf
+            },
+            [DotsTtsCrispAsr.CoreQ8_0] = new[]
+            {
+                "d13578498e54c77fde118ce2541903e4c38f595ed1aea26b55d89f87dfb11bba", // dots-tts-soar-q8_0.gguf
+            },
+            [DotsTtsCrispAsr.CoreF16] = new[]
+            {
+                "9811ab16ac4ecc6cb42bdd9e031cbade42b1eb50c6ff920bd1f1e9621fb44988", // dots-tts-soar-f16.gguf
+            },
+            [DotsTtsCrispAsr.Vocoder] = new[]
+            {
+                "10e9990e126165d9eac1a6e90178296b46ae039230d2d18d650336ad627ccec7", // dots-tts-soar-vocoder-f16.gguf
+            },
+            [DotsTtsCrispAsr.SpeakerEncoder] = new[]
+            {
+                "6f6d41f1394273b0da5a7a9be8f15f0e59d3b4d5983cab7d1fac08630b912e7f", // dots-tts-soar-spk-f16.gguf
             },
 
             // IndexTTS-2.5 weights, from audio-cpp/audio.cpp-gguf. Q8_0 confirmed by local


### PR DESCRIPTION
Adds **dots.tts SOAR 2B** as a text-to-speech engine, running on the CrispASR runtime SE already
ships. Apache-2.0 weights, 48 kHz output, zero-shot voice cloning.

## Why this model

dots.tts is a continuous-latent autoregressive TTS model — a Qwen2.5-1.5B backbone drives an
18-layer flow-matching DiT that predicts acoustic latents directly, with a BigVGAN vocoder at the
end. No discrete audio codec anywhere, and the backbone reads BPE text rather than phonemes, so
there's no G2P dictionary involved.

On the numbers it is the strongest open model of the ones we could add:

| | dots.tts SOAR | best other |
|---|---|---|
| Seed-TTS-Eval avg WER / SIM | 2.95 / **79.2** | CosyVoice3 3.06 / 75.3, VoxCPM2 3.65 / 76.7 |
| EmergentTTS-Eval overall win-rate | **49.2%** | ElevenLabs multilingual v2 33.9%, Chatterbox 26.7%, Kokoro 23.5% |

Both tables come from the model authors, so treat the margins with the usual caution — but the gap
to what we ship today is large enough to be worth having.

Practical notes:
- **48 kHz** output, the highest of any engine in SE (everything else is 24 kHz).
- **Apache-2.0**, so no licence-accept gate of the IndexTTS 2.5 kind.
- **No reference transcript needed.** dots.tts conditions on a CAM++ speaker embedding rather than
  by continuing a transcribed reference, so an imported WAV needs no `.txt` sidecar.
- **24 languages, Danish not among them** (Arabic, Cantonese, Chinese, Czech, Dutch, English,
  Finnish, French, German, Greek, Hindi, Indonesian, Italian, Japanese, Korean, Polish, Portuguese,
  Romanian, Russian, Spanish, Thai, Turkish, Ukrainian, Vietnamese). This is an addition alongside
  the broader engines, not a replacement for them.

## Verification against the pinned runtime

Everything below was run against the **pinned CrispASR v0.8.29** on macOS/Metal, not read off a
README.

- `dots-tts` is compiled into the pinned binary (one of its 107 backends).
- CLI synthesis and server-mode synthesis both work with the exact flags and JSON payload this
  engine builds, including `--no-watermark --no-c2pa --accept-marking-responsibility` — the flag
  set that aborts startup on an older binary. Server reported healthy in 21 s and returned
  HTTP 200.
- Output verified 48 kHz mono via `ffprobe`; clean EOS (`eos_p=0.987 STOP`), no runaway.
- **Cloning verified objectively**, not just "audio came out": median f0 of the reference 190.3 Hz,
  of the clone 195.8 Hz, of the preset voice 124.8 Hz. The server log confirms
  `CAM++ speaker encoder loaded` / `voice g_cond ready (xvec 512-d, g_cond 1024-d)` and
  `voice='<startup>'` for the payload we send.
- The ODE-steps knob was confirmed to actually do something before being exposed in the UI:
  4 / 16 / 32 steps took 25 / 38 / 68 s wall.

Two findings worth recording:

1. **v0.8.29's capability bitmask is stale.** `--list-backends-json` reports
   `["temperature","auto-download","tts"]` for dots-tts — no `voice-cloning` — while every other
   cloning engine advertises it. Cloning demonstrably works, so this is a labelling gap upstream,
   not a missing feature. Worth reporting to CrispASR.
2. **It is slow, and the quant does not change that.** Server mode on an M4 at 16 ODE steps, same
   text both runs:

   | Quant | RTF | Synthesis | Server healthy after | Size |
   |---|---|---|---|---|
   | F16 | 7.64 | 3.5 s audio in 26.91 s | 21 s | 4.64 GB |
   | Q8_0 | 7.60 | 3.5 s audio in 26.77 s | **4 s** | 3.13 GB |

   For reference, IndexTTS 2.5 is ~1.6 on the same machine. Synthesis speed is essentially
   identical across quants, which is what the mixed-quant design predicts: cstr keeps the DiT at
   F16 in *every* quant (a fully-Q8 DiT produces no-EOS runaway), and that CFG Euler loop is where
   the time goes. What the quant buys is load time — 5x faster to a healthy server — which is why
   Q8_0 is the default. The ODE-step slider is the only lever on synthesis time.

## Models

Three mixed quants, each needing two companions. Default is Q8_0, per cstr's recommendation.

| File | Size |
|---|---|
| `dots-tts-soar-q4_k.gguf` | 2.32 GB |
| `dots-tts-soar-q8_0.gguf` | 3.13 GB |
| `dots-tts-soar-f16.gguf` | 4.64 GB |
| `dots-tts-soar-vocoder-f16.gguf` | 0.36 GB (required) |
| `dots-tts-soar-spk-f16.gguf` | 0.015 GB (required for cloning) |

All five are SHA-256 verified on download. The Q8_0 (default), vocoder and speaker-encoder entries
were confirmed by downloading the file and running `shasum` against the value shipped here, so the
integrity check and the truncation guard are proven rather than copied from the HF tree API; the
Q4_K and F16 core hashes are the HF LFS oids.

## Settings

Engine settings dialog follows the IndexTTS (CrispASR) layout — per-quant install dots, companion
status, voices count, models folder. The one engine-specific control is **Quality (ODE steps)**,
8–32, default 16, since that is dots.tts's only real quality/speed trade-off. It has no CLI flag,
so it is passed to the server as `CRISPASR_DOTS_ODE_STEPS` and a change restarts the server
alongside a quant or voice change.

## Not included

- No per-line cloning (`SupportsPerLineVoiceCloning => false`): like indextts/f5/voxcpm2 the
  reference is read from the startup `--voice` flag, so a per-line reference would reload the model
  per line.
- No `speed` field in the payload — dots-tts is not in crispasr's `--tts-speed` backend list.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
