### PR TITLE
Merge duplicate bracket-removal branches in RemoveTextForHI

### DIFF
--- a/src/libse/Forms/RemoveTextForHI.cs
+++ b/src/libse/Forms/RemoveTextForHI.cs
@@ -1459,7 +1459,10 @@ namespace Nikse.SubtitleEdit.Core.Forms
             var newText = text;
             var s = text;
             int index;
-            if (Settings.RemoveTextBetweenSquares && s.StartsWith('[') && (index = s.IndexOf(']', 1)) > 0 || Settings.RemoveTextBetweenBrackets && s.StartsWith('{') && (index = s.IndexOf('}', 1)) > 0 || Settings.RemoveTextBetweenParentheses && s.StartsWith('(') && (index = s.IndexOf(')', 1)) > 0 || Settings.RemoveTextBetweenQuestionMarks && s.StartsWith('?') && (index = s.IndexOf('?', 1)) > 0)
+            if (Settings.RemoveTextBetweenSquares && s.StartsWith('[') && (index = s.IndexOf(']', 1)) > 0 ||
+                Settings.RemoveTextBetweenBrackets && s.StartsWith('{') && (index = s.IndexOf('}', 1)) > 0 ||
+                Settings.RemoveTextBetweenParentheses && s.StartsWith('(') && (index = s.IndexOf(')', 1)) > 0 ||
+                Settings.RemoveTextBetweenQuestionMarks && s.StartsWith('?') && (index = s.IndexOf('?', 1)) > 0)
             {
                 if (++index < s.Length && s[index] == ':')
                 {

--- a/src/libse/Forms/RemoveTextForHI.cs
+++ b/src/libse/Forms/RemoveTextForHI.cs
@@ -1459,34 +1459,7 @@ namespace Nikse.SubtitleEdit.Core.Forms
             var newText = text;
             var s = text;
             int index;
-            if (Settings.RemoveTextBetweenSquares && s.StartsWith('[') && (index = s.IndexOf(']', 1)) > 0)
-            {
-                if (++index < s.Length && s[index] == ':')
-                {
-                    index++;
-                }
-
-                newText = s.Remove(0, index);
-            }
-            else if (Settings.RemoveTextBetweenBrackets && s.StartsWith('{') && (index = s.IndexOf('}', 1)) > 0)
-            {
-                if (++index < s.Length && s[index] == ':')
-                {
-                    index++;
-                }
-
-                newText = s.Remove(0, index);
-            }
-            else if (Settings.RemoveTextBetweenParentheses && s.StartsWith('(') && (index = s.IndexOf(')', 1)) > 0)
-            {
-                if (++index < s.Length && s[index] == ':')
-                {
-                    index++;
-                }
-
-                newText = s.Remove(0, index);
-            }
-            else if (Settings.RemoveTextBetweenQuestionMarks && s.StartsWith('?') && (index = s.IndexOf('?', 1)) > 0)
+            if (Settings.RemoveTextBetweenSquares && s.StartsWith('[') && (index = s.IndexOf(']', 1)) > 0 || Settings.RemoveTextBetweenBrackets && s.StartsWith('{') && (index = s.IndexOf('}', 1)) > 0 || Settings.RemoveTextBetweenParentheses && s.StartsWith('(') && (index = s.IndexOf(')', 1)) > 0 || Settings.RemoveTextBetweenQuestionMarks && s.StartsWith('?') && (index = s.IndexOf('?', 1)) > 0)
             {
                 if (++index < s.Length && s[index] == ':')
                 {


### PR DESCRIPTION
## Summary
- The four `if`/`else if` branches in `RemoveTextForHI` that strip a leading `[...]`, `{...}`, `(...)` or `?...?` block shared an identical body; combine them into a single condition.
- No behaviour change: the same settings gate each bracket type, and `index` is still set by whichever branch matches.

## Test plan
- [ ] Run "Remove text for hearing impaired" on a line starting with `[NOISE]:`, `{NOISE}:`, `(NOISE):` and `?NOISE?` with the matching option enabled — the leading block and trailing colon are removed as before
- [ ] Disable an option (e.g. "Remove text between parentheses") and confirm `(NOISE)` at the start of a line is kept
- [ ] `dotnet test tests/libse/LibSETests.csproj --filter "ClassName~RemoveTextForHI"` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfGd9tcrnB9AoyMwPwFKTB