### PR TITLE
Speech to text advanced: make the parameter buttons toggles

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextAdvancedViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextAdvancedViewModel.cs
@@ -72,6 +72,10 @@ public partial class SpeechToTextAdvancedViewModel : ObservableObject
         var fileName = GetVadCppFile();
         if (string.IsNullOrEmpty(fileName))
         {
+            // No Silero model to point at, so the box is left alone - but the button has
+            // already drawn itself pressed. Announce the unchanged "off" so the one-way
+            // binding pushes the button back out.
+            OnPropertyChanged(nameof(IsVadCppActive));
             return;
         }
 
@@ -82,24 +86,59 @@ public partial class SpeechToTextAdvancedViewModel : ObservableObject
     // input file name and then bails out with "input file not found 'true'".
     private const string WordLevelCppParameters = "-owts -ojf";
 
+    // What comes off again when the button is pressed off: the pair it puts on.
     private static readonly Regex WordLevelCppRegex = new(
         @"(?:^|\s)(-owts|--output-words|-ojf|--output-json-full)(?=\s|$)",
         RegexOptions.Compiled);
 
+    // What counts as "on": the karaoke word output alone. -ojf only asks for a fuller JSON
+    // file and says nothing about word level, so it must not light the button by itself.
+    private static readonly Regex WordLevelCppDetectRegex = new(
+        @"(?:^|\s)(-owts|--output-words)(?=\s|$)",
+        RegexOptions.Compiled);
+
     private static readonly Regex VadRegex = new(
-        @"(?:^|\s)(--vad-model\s+""[^""]+""|--vad-model\s+\S+|--vad)(?=\s|$)",
+        @"(?:^|\s)(--vad-model\s+""[^""]+""|--vad-model\s+\S+|-vm\s+""[^""]+""|-vm\s+\S+|--vad)(?=\s|$)",
+        RegexOptions.Compiled);
+
+    // A model path on its own does nothing - only the --vad switch itself turns VAD on.
+    private static readonly Regex VadDetectRegex = new(
+        @"(?:^|\s)--vad(?=\s|$)",
         RegexOptions.Compiled);
 
     private static readonly Regex VadCTranslate2Regex = new(
         @"(?:^|\s)--vad_filter\s+\S+(?=\s|$)",
         RegexOptions.Compiled);
 
+    // "--vad_filter False" is the filter switched off, not on.
+    private static readonly Regex VadCTranslate2DetectRegex = new(
+        @"(?:^|\s)--vad_filter\s+(?i:true|1)(?=\s|$)",
+        RegexOptions.Compiled);
+
     private static readonly Regex HighlightWordsCTranslate2Regex = new(
         @"(?:^|\s)(--highlight_words\s+\S+|--word_timestamps\s+\S+)(?=\s|$)",
         RegexOptions.Compiled);
 
+    // Word timestamps on their own are just timings - only asking for the words to be
+    // highlighted, and asking for it in earnest, means the button is on.
+    private static readonly Regex HighlightWordsCTranslate2DetectRegex = new(
+        @"(?:^|\s)--highlight_words\s+(?i:true|1)(?=\s|$)",
+        RegexOptions.Compiled);
+
     private static readonly Regex HighlightWordsCrispAsrRegex = new(
         @"(?:^|\s)(-ml\s+\S+|--max-len\s+\S+|-sow|--split-on-word)(?=\s|$)",
+        RegexOptions.Compiled);
+
+    // "Highlight word" is the two together: one word per segment, split at word boundaries.
+    // A maximum length on its own is not that - the "Standard" preset sets one - so matching
+    // any --max-len left the button lit after "Standard", and the press that should have
+    // switched highlighting on took the preset's --max-len back out instead.
+    private static readonly Regex MaxLenOneCrispAsrRegex = new(
+        @"(?:^|\s)(-ml|--max-len)\s+1(?=\s|$)",
+        RegexOptions.Compiled);
+
+    private static readonly Regex SplitOnWordCrispAsrRegex = new(
+        @"(?:^|\s)(-sow|--split-on-word)(?=\s|$)",
         RegexOptions.Compiled);
 
     private static readonly Regex HighlightWordsCrispAsrConflictRegex = new(
@@ -127,12 +166,12 @@ public partial class SpeechToTextAdvancedViewModel : ObservableObject
     partial void OnParametersChanged(string value)
     {
         var text = value ?? string.Empty;
-        IsWordLevelCppActive = WordLevelCppRegex.IsMatch(text);
-        IsVadCppActive = VadRegex.IsMatch(text);
+        IsWordLevelCppActive = WordLevelCppDetectRegex.IsMatch(text);
+        IsVadCppActive = VadDetectRegex.IsMatch(text);
         IsVadCrispAsrActive = IsVadCppActive;
-        IsVadCTranslate2Active = VadCTranslate2Regex.IsMatch(text);
-        IsHighlightWordsCTranslate2Active = HighlightWordsCTranslate2Regex.IsMatch(text);
-        IsHighlightWordsCrispAsrActive = HighlightWordsCrispAsrRegex.IsMatch(text);
+        IsVadCTranslate2Active = VadCTranslate2DetectRegex.IsMatch(text);
+        IsHighlightWordsCTranslate2Active = HighlightWordsCTranslate2DetectRegex.IsMatch(text);
+        IsHighlightWordsCrispAsrActive = MaxLenOneCrispAsrRegex.IsMatch(text) && SplitOnWordCrispAsrRegex.IsMatch(text);
     }
 
     [RelayCommand]
@@ -185,9 +224,7 @@ public partial class SpeechToTextAdvancedViewModel : ObservableObject
         }
 
         // This button has always switched the VAD filter on together with highlighting.
-        var withVad = IsVadCTranslate2Active
-            ? Parameters ?? string.Empty
-            : AddParameters(VadCTranslate2Regex, "--vad_filter True");
+        var withVad = AddParameters(VadCTranslate2Regex, "--vad_filter True");
 
         Parameters = AddParameters(
             HighlightWordsCTranslate2Regex,

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextAdvancedViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextAdvancedViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -21,6 +21,12 @@ public partial class SpeechToTextAdvancedViewModel : ObservableObject
     [ObservableProperty] private bool _isWhisperXxlVisible;
     [ObservableProperty] private bool _isWhisperCTranslate2Visible;
     [ObservableProperty] private bool _isCrispAsrVisible;
+    [ObservableProperty] private bool _isWordLevelCppActive;
+    [ObservableProperty] private bool _isVadCppActive;
+    [ObservableProperty] private bool _isVadCTranslate2Active;
+    [ObservableProperty] private bool _isHighlightWordsCTranslate2Active;
+    [ObservableProperty] private bool _isVadCrispAsrActive;
+    [ObservableProperty] private bool _isHighlightWordsCrispAsrActive;
 
     public Window? Window { get; set; }
     public List<ISpeechToTextEngine> Engines { get; set; }
@@ -57,21 +63,86 @@ public partial class SpeechToTextAdvancedViewModel : ObservableObject
     [RelayCommand]
     private void EnableVadCpp()
     {
+        if (IsVadCppActive)
+        {
+            Parameters = RemoveParameters(VadRegex);
+            return;
+        }
+
         var fileName = GetVadCppFile();
         if (string.IsNullOrEmpty(fileName))
         {
             return;
         }
 
-        Parameters = $"--vad --vad-model \"{fileName}\"";
+        Parameters = AddParameters(VadRegex, $"--vad --vad-model \"{fileName}\"");
+    }
+
+    // Both are switches, not key/value pairs - whisper-cli parses a following "true" as an
+    // input file name and then bails out with "input file not found 'true'".
+    private const string WordLevelCppParameters = "-owts -ojf";
+
+    private static readonly Regex WordLevelCppRegex = new(
+        @"(?:^|\s)(-owts|--output-words|-ojf|--output-json-full)(?=\s|$)",
+        RegexOptions.Compiled);
+
+    private static readonly Regex VadRegex = new(
+        @"(?:^|\s)(--vad-model\s+""[^""]+""|--vad-model\s+\S+|--vad)(?=\s|$)",
+        RegexOptions.Compiled);
+
+    private static readonly Regex VadCTranslate2Regex = new(
+        @"(?:^|\s)--vad_filter\s+\S+(?=\s|$)",
+        RegexOptions.Compiled);
+
+    private static readonly Regex HighlightWordsCTranslate2Regex = new(
+        @"(?:^|\s)(--highlight_words\s+\S+|--word_timestamps\s+\S+)(?=\s|$)",
+        RegexOptions.Compiled);
+
+    private static readonly Regex HighlightWordsCrispAsrRegex = new(
+        @"(?:^|\s)(-ml\s+\S+|--max-len\s+\S+|-sow|--split-on-word)(?=\s|$)",
+        RegexOptions.Compiled);
+
+    private static readonly Regex HighlightWordsCrispAsrConflictRegex = new(
+        @"(?:^|\s)(-ml\s+\S+|--max-len\s+\S+|-sow|--split-on-word|--split-on-punct|-sp)(?=\s|$)",
+        RegexOptions.Compiled);
+
+    private string RemoveParameters(Regex regex)
+    {
+        return regex.Replace(Parameters ?? string.Empty, string.Empty).Trim();
+    }
+
+    private string AddParameters(Regex regex, string parameters)
+    {
+        return AddParameters(regex, parameters, Parameters ?? string.Empty);
+    }
+
+    private static string AddParameters(Regex regex, string parameters, string current)
+    {
+        var existing = regex.Replace(current, string.Empty).Trim();
+        return string.IsNullOrWhiteSpace(existing) ? parameters : existing + " " + parameters;
+    }
+
+    // Every toggle reads its state back out of the parameter text, so typing in the box by
+    // hand or switching engine leaves the buttons showing what is actually set.
+    partial void OnParametersChanged(string value)
+    {
+        var text = value ?? string.Empty;
+        IsWordLevelCppActive = WordLevelCppRegex.IsMatch(text);
+        IsVadCppActive = VadRegex.IsMatch(text);
+        IsVadCrispAsrActive = IsVadCppActive;
+        IsVadCTranslate2Active = VadCTranslate2Regex.IsMatch(text);
+        IsHighlightWordsCTranslate2Active = HighlightWordsCTranslate2Regex.IsMatch(text);
+        IsHighlightWordsCrispAsrActive = HighlightWordsCrispAsrRegex.IsMatch(text);
     }
 
     [RelayCommand]
     private void EnableWordLevelCpp()
     {
-        // Both are switches, not key/value pairs - whisper-cli parses a following "true" as an
-        // input file name and then bails out with "input file not found 'true'".
-        Parameters = "-owts -ojf";
+        // A press used to overwrite the parameter box and there was no way to press it back
+        // off again, so word-level output stayed on for every later transcription.
+        Parameters = IsWordLevelCppActive
+            ? RemoveParameters(WordLevelCppRegex)
+            : AddParameters(WordLevelCppRegex, WordLevelCppParameters);
     }
 
     [RelayCommand]
@@ -107,35 +178,60 @@ public partial class SpeechToTextAdvancedViewModel : ObservableObject
     [RelayCommand]
     private void WhisperCTranslate2HighLightWord()
     {
-        Parameters = "--vad_filter True --highlight_words True --word_timestamps True";
+        if (IsHighlightWordsCTranslate2Active)
+        {
+            Parameters = RemoveParameters(HighlightWordsCTranslate2Regex);
+            return;
+        }
+
+        // This button has always switched the VAD filter on together with highlighting.
+        var withVad = IsVadCTranslate2Active
+            ? Parameters ?? string.Empty
+            : AddParameters(VadCTranslate2Regex, "--vad_filter True");
+
+        Parameters = AddParameters(
+            HighlightWordsCTranslate2Regex,
+            "--highlight_words True --word_timestamps True",
+            withVad);
     }
 
     [RelayCommand]
     private void EnableVadCTranslate2()
     {
-        Parameters = "--vad_filter True";
+        Parameters = IsVadCTranslate2Active
+            ? RemoveParameters(VadCTranslate2Regex)
+            : AddParameters(VadCTranslate2Regex, "--vad_filter True");
     }
 
     [RelayCommand]
     private void EnableVadCrispAsr()
     {
+        if (IsVadCrispAsrActive)
+        {
+            Parameters = RemoveParameters(VadRegex);
+            return;
+        }
+
         var fileName = GetVadCrispAsrFile();
         var vadArgs = string.IsNullOrEmpty(fileName)
             ? "--vad"
             : $"--vad --vad-model \"{fileName}\"";
 
-        var existing = Regex.Replace(Parameters ?? string.Empty, @"(?:^|\s)(--vad-model\s+""[^""]+""|--vad-model\s+\S+|--vad)(?=\s|$)", string.Empty).Trim();
-        Parameters = string.IsNullOrWhiteSpace(existing) ? vadArgs : existing + " " + vadArgs;
+        Parameters = AddParameters(VadRegex, vadArgs);
     }
 
     [RelayCommand]
     private void EnableHighlightWordsCrispAsr()
     {
-        const string highlightArgs = "-ml 1 -sow";
-        var existing = Regex.Replace(Parameters ?? string.Empty,
-            @"(?:^|\s)(-ml\s+\S+|--max-len\s+\S+|-sow|--split-on-word|--split-on-punct|-sp)(?=\s|$)",
-            string.Empty).Trim();
-        Parameters = string.IsNullOrWhiteSpace(existing) ? highlightArgs : existing + " " + highlightArgs;
+        if (IsHighlightWordsCrispAsrActive)
+        {
+            Parameters = RemoveParameters(HighlightWordsCrispAsrRegex);
+            return;
+        }
+
+        // The length/split switches this turns on conflict with the "standard" ones, so those
+        // are dropped as it goes on - but only its own switches come off again.
+        Parameters = AddParameters(HighlightWordsCrispAsrConflictRegex, "-ml 1 -sow");
     }
 
     [RelayCommand]

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextAdvancedWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextAdvancedWindow.cs
@@ -1,9 +1,10 @@
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Data;
 using Avalonia.Layout;
 using Avalonia.Media;
+using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 
@@ -112,22 +113,49 @@ public class SpeechToTextAdvancedWindow : Window
             }
         }.WithBindIsVisible(nameof(vm.IsWhisperXxlVisible));
 
+        // These switch parameters on. As plain buttons there was no way to press one back off
+        // again, so anything they set - word-level output above all - stayed on for good.
+        static ToggleButton MakeToggleButton(string text, IRelayCommand command, string activePath, string visiblePath)
+        {
+            var toggleButton = new ToggleButton
+            {
+                Content = text,
+                Margin = new Thickness(4, 0),
+                Padding = new Thickness(12, 6),
+                MinWidth = 80,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+                HorizontalContentAlignment = HorizontalAlignment.Center,
+                VerticalContentAlignment = VerticalAlignment.Center,
+                Command = command,
+            }.WithBindIsVisible(visiblePath);
+
+            // One way only: the parameter text is what says whether the switch is set, the
+            // button just shows it.
+            toggleButton.Bind(ToggleButton.IsCheckedProperty, new Binding(activePath)
+            {
+                Mode = BindingMode.OneWay,
+            });
+
+            return toggleButton;
+        }
+
         var buttonPanel = UiUtil.MakeButtonBar(
             buttonXxlOptions,
-            UiUtil.MakeButton(Se.Language.Video.AudioToText.EnableVad, vm.EnableVadCppCommand)
-                .WithBindIsVisible(nameof(vm.IsWhisperCppVisible)),
-            UiUtil.MakeButton(Se.Language.Video.AudioToText.EnableVad, vm.EnableVadCTranslate2Command)
-                .WithBindIsVisible(nameof(vm.IsWhisperCTranslate2Visible)),
+            MakeToggleButton(Se.Language.Video.AudioToText.EnableVad, vm.EnableVadCppCommand,
+                nameof(vm.IsVadCppActive), nameof(vm.IsWhisperCppVisible)),
+            MakeToggleButton(Se.Language.Video.AudioToText.EnableVad, vm.EnableVadCTranslate2Command,
+                nameof(vm.IsVadCTranslate2Active), nameof(vm.IsWhisperCTranslate2Visible)),
             UiUtil.MakeButton(Se.Language.Video.AudioToText.WhisperXxlStandard, vm.StandardCrispAsrCommand)
                 .WithBindIsVisible(nameof(vm.IsCrispAsrVisible)),
-            UiUtil.MakeButton(Se.Language.Video.AudioToText.EnableVad, vm.EnableVadCrispAsrCommand)
-                .WithBindIsVisible(nameof(vm.IsCrispAsrVisible)),
-            UiUtil.MakeButton(Se.Language.Video.AudioToText.WhisperXxlHighlightWord, vm.EnableHighlightWordsCrispAsrCommand)
-                .WithBindIsVisible(nameof(vm.IsCrispAsrVisible)),
-            UiUtil.MakeButton(Se.Language.Video.AudioToText.WhisperXxlHighlightWord, vm.EnableWordLevelCppCommand)
-                .WithBindIsVisible(nameof(vm.IsWhisperCppVisible)),
-            UiUtil.MakeButton(Se.Language.Video.AudioToText.WhisperXxlHighlightWord, vm.WhisperCTranslate2HighLightWordCommand)
-                .WithBindIsVisible(nameof(vm.IsWhisperCTranslate2Visible)),
+            MakeToggleButton(Se.Language.Video.AudioToText.EnableVad, vm.EnableVadCrispAsrCommand,
+                nameof(vm.IsVadCrispAsrActive), nameof(vm.IsCrispAsrVisible)),
+            MakeToggleButton(Se.Language.Video.AudioToText.WhisperXxlHighlightWord, vm.EnableHighlightWordsCrispAsrCommand,
+                nameof(vm.IsHighlightWordsCrispAsrActive), nameof(vm.IsCrispAsrVisible)),
+            MakeToggleButton(Se.Language.Video.AudioToText.WhisperXxlHighlightWord, vm.EnableWordLevelCppCommand,
+                nameof(vm.IsWordLevelCppActive), nameof(vm.IsWhisperCppVisible)),
+            MakeToggleButton(Se.Language.Video.AudioToText.WhisperXxlHighlightWord, vm.WhisperCTranslate2HighLightWordCommand,
+                nameof(vm.IsHighlightWordsCTranslate2Active), nameof(vm.IsWhisperCTranslate2Visible)),
             UiUtil.MakeButton(Se.Language.General.Ok, vm.OkCommand),
             UiUtil.MakeButton(Se.Language.General.Cancel, vm.CancelCommand)
         );

--- a/tests/UI/Features/Video/SpeechToText/SpeechToTextAdvancedToggleTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/SpeechToTextAdvancedToggleTests.cs
@@ -1,0 +1,154 @@
+using Nikse.SubtitleEdit.Features.Video.SpeechToText;
+using Xunit;
+
+namespace UITests.Features.Video.SpeechToText;
+
+/// <summary>
+/// The buttons in the advanced speech-to-text window are toggles that read their own state
+/// back out of the parameter text. What each one reads has to be exactly the switches it
+/// sets: a parameter that merely looks similar - a maximum length from the "Standard" preset,
+/// a fuller JSON file, word timestamps - must leave the button off, or the next press removes
+/// something instead of switching the button's own setting on.
+/// </summary>
+public class SpeechToTextAdvancedToggleTests
+{
+    private static SpeechToTextAdvancedViewModel MakeViewModel(string parameters)
+    {
+        var vm = new SpeechToTextAdvancedViewModel { Parameters = parameters };
+        return vm;
+    }
+
+    [Fact]
+    public void CrispAsrStandardLeavesHighlightWordOff()
+    {
+        var vm = MakeViewModel(string.Empty);
+
+        vm.StandardCrispAsrCommand.Execute(null);
+
+        Assert.Equal("--max-len 50 --split-on-punct", vm.Parameters);
+        Assert.False(vm.IsHighlightWordsCrispAsrActive);
+    }
+
+    /// <summary>One press after "Standard" switches highlighting on - it used to take two.</summary>
+    [Fact]
+    public void CrispAsrHighlightWordFollowsStandardInOnePress()
+    {
+        var vm = MakeViewModel(string.Empty);
+        vm.StandardCrispAsrCommand.Execute(null);
+
+        vm.EnableHighlightWordsCrispAsrCommand.Execute(null);
+
+        Assert.Equal("-ml 1 -sow", vm.Parameters);
+        Assert.True(vm.IsHighlightWordsCrispAsrActive);
+    }
+
+    [Fact]
+    public void CrispAsrHighlightWordComesOffAgain()
+    {
+        var vm = MakeViewModel("--vad -ml 1 -sow");
+
+        Assert.True(vm.IsHighlightWordsCrispAsrActive);
+        vm.EnableHighlightWordsCrispAsrCommand.Execute(null);
+
+        Assert.Equal("--vad", vm.Parameters);
+        Assert.False(vm.IsHighlightWordsCrispAsrActive);
+    }
+
+    /// <summary>A maximum length that is not one word is a length, not highlighting.</summary>
+    [Theory]
+    [InlineData("--max-len 50")]
+    [InlineData("-ml 50 -sow")]
+    [InlineData("-ml 1")]
+    [InlineData("-sow")]
+    public void CrispAsrHighlightWordNeedsBothSwitches(string parameters)
+    {
+        Assert.False(MakeViewModel(parameters).IsHighlightWordsCrispAsrActive);
+    }
+
+    [Fact]
+    public void WhisperCppWordLevelNeedsTheWordOutput()
+    {
+        Assert.False(MakeViewModel("-ojf").IsWordLevelCppActive);
+        Assert.True(MakeViewModel("-owts -ojf").IsWordLevelCppActive);
+    }
+
+    [Fact]
+    public void WhisperCppWordLevelKeepsWhatIsAlreadyThere()
+    {
+        var vm = MakeViewModel("-t 8");
+
+        vm.EnableWordLevelCppCommand.Execute(null);
+        Assert.Equal("-t 8 -owts -ojf", vm.Parameters);
+        Assert.True(vm.IsWordLevelCppActive);
+
+        vm.EnableWordLevelCppCommand.Execute(null);
+        Assert.Equal("-t 8", vm.Parameters);
+        Assert.False(vm.IsWordLevelCppActive);
+    }
+
+    [Theory]
+    [InlineData("--word_timestamps True")]
+    [InlineData("--highlight_words False")]
+    public void CTranslate2HighlightWordNeedsHighlightingItself(string parameters)
+    {
+        Assert.False(MakeViewModel(parameters).IsHighlightWordsCTranslate2Active);
+    }
+
+    /// <summary>A switch set to False is the switch off, and a model path alone does nothing.</summary>
+    [Theory]
+    [InlineData("--vad_filter False")]
+    [InlineData("--vad_filter 0")]
+    public void CTranslate2VadOffValuesLeaveTheButtonOff(string parameters)
+    {
+        Assert.False(MakeViewModel(parameters).IsVadCTranslate2Active);
+    }
+
+    [Fact]
+    public void VadNeedsTheVadSwitchNotJustAModelPath()
+    {
+        Assert.False(MakeViewModel("--vad-model \"x.bin\"").IsVadCppActive);
+        Assert.False(MakeViewModel("-vm x.bin").IsVadCppActive);
+        Assert.True(MakeViewModel("--vad").IsVadCppActive);
+        Assert.True(MakeViewModel("--vad --vad-model \"x.bin\"").IsVadCrispAsrActive);
+    }
+
+    /// <summary>Switching VAD off also clears the short-form model path both backends accept.</summary>
+    [Fact]
+    public void CrispAsrVadOffClearsShortFormModelPath()
+    {
+        var vm = MakeViewModel("-vm x.bin --vad -t 8");
+
+        Assert.True(vm.IsVadCrispAsrActive);
+        vm.EnableVadCrispAsrCommand.Execute(null);
+
+        Assert.Equal("-t 8", vm.Parameters);
+        Assert.False(vm.IsVadCrispAsrActive);
+    }
+
+    /// <summary>The highlight press turns a switched-off VAD filter into a switched-on one, once.</summary>
+    [Fact]
+    public void CTranslate2HighlightWordReplacesAnOffVadFilter()
+    {
+        var vm = MakeViewModel("--vad_filter False");
+
+        vm.WhisperCTranslate2HighLightWordCommand.Execute(null);
+
+        Assert.Equal("--vad_filter True --highlight_words True --word_timestamps True", vm.Parameters);
+        Assert.True(vm.IsVadCTranslate2Active);
+    }
+
+    [Fact]
+    public void CTranslate2HighlightWordLeavesTheVadFilterOnWhenSwitchedOff()
+    {
+        var vm = MakeViewModel(string.Empty);
+
+        vm.WhisperCTranslate2HighLightWordCommand.Execute(null);
+        Assert.Equal("--vad_filter True --highlight_words True --word_timestamps True", vm.Parameters);
+        Assert.True(vm.IsHighlightWordsCTranslate2Active);
+
+        vm.WhisperCTranslate2HighLightWordCommand.Execute(null);
+        Assert.Equal("--vad_filter True", vm.Parameters);
+        Assert.False(vm.IsHighlightWordsCTranslate2Active);
+        Assert.True(vm.IsVadCTranslate2Active);
+    }
+}


### PR DESCRIPTION
Each button in the advanced speech-to-text window wrote a fixed parameter string into the box, and there was no way to press one back off. Once "Highlight word" had been pressed for whisper.cpp the box held "-owts -ojf" for good, so every later transcription came back as one subtitle per word with the current word wrapped in <u> - with nothing in the window to undo it, and no hint that the button was the reason.

Make them ToggleButtons that show the checked state while their switches are set. Each now adds its own switches to whatever is already in the box and removes only those again when pressed off, so switching highlighting off no longer takes the VAD filter down with it. The pressed state is read back out of the parameter text whenever it changes, so the buttons stay right when the box is typed in by hand or the engine is switched.

The mutually exclusive presets - "Standard" for CrispASR and the entries in the Purfview XXL split button - are left alone: each press replaces the last, so choosing another preset is already the way back.