### PR TITLE
WhisperX: stop the wrong model download, and repair the bypassed launch setup

### DIFF
--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineWhisperX.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineWhisperX.cs
@@ -29,7 +29,14 @@ public class WhisperEngineWhisperX : ISpeechToTextEngine
     // so it takes the same model list (correct names like large-v3-turbo/distil-*, and the
     // actual Hugging Face repos this backend downloads from) rather than whisper.cpp's ggml
     // model list, which does not match what this backend understands.
-    public List<WhisperModel> Models => new WhisperPurfviewFasterWhisperModel().Models.ToList();
+    //
+    // Minus the NbAiLab "*.nb" entries: their names only work for engines SE downloads models
+    // for (SE resolves the name to a local folder), while whisperx gets the bare name on the
+    // command line, and "tiny.nb" is neither a faster-whisper size nor a Hugging Face repo id -
+    // the run would fail after the model picker accepted it.
+    public List<WhisperModel> Models => new WhisperPurfviewFasterWhisperModel().Models
+        .Where(m => !m.Name.EndsWith(".nb", StringComparison.Ordinal))
+        .ToList();
 
     public string Extension => string.Empty;
     public string UnpackSkipFolder => string.Empty;
@@ -85,59 +92,12 @@ public class WhisperEngineWhisperX : ISpeechToTextEngine
     public bool IsModelInstalled(WhisperModel model)
     {
         // WhisperX owns the Hugging Face cache and downloads the selected Whisper/alignment
-        // model on first use - do not route its model name through SE's .pt/.bin downloader.
-        // Still worth checking honestly (rather than always reporting "installed"): these models
-        // come from the same Hugging Face repos as WhisperEngineCTranslate2/Purfview (both run
-        // the same backend), so a snapshot already sitting in the Hugging Face hub cache for
-        // that repo id is a reliable signal the model does not need downloading again.
-        var repoId = GetHuggingFaceRepoId(model);
-        if (string.IsNullOrEmpty(repoId))
-        {
-            return false;
-        }
-
-        var cacheFolder = Path.Combine(GetHuggingFaceHubCacheDir(), "models--" + repoId.Replace("/", "--"));
-        return Directory.Exists(cacheFolder);
-    }
-
-    private static string? GetHuggingFaceRepoId(WhisperModel model)
-    {
-        // e.g. "https://huggingface.co/Systran/faster-whisper-tiny/resolve/main/model.bin" -> "Systran/faster-whisper-tiny"
-        var url = model.Urls?.FirstOrDefault();
-        if (string.IsNullOrEmpty(url))
-        {
-            return null;
-        }
-
-        const string marker = "huggingface.co/";
-        var idx = url.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
-        if (idx < 0)
-        {
-            return null;
-        }
-
-        var parts = url[(idx + marker.Length)..].Split('/');
-        return parts.Length >= 2 ? $"{parts[0]}/{parts[1]}" : null;
-    }
-
-    // Mirrors huggingface_hub's own cache directory resolution order: HF_HOME, then the legacy
-    // HUGGINGFACE_HUB_CACHE, then the default ~/.cache/huggingface/hub.
-    private static string GetHuggingFaceHubCacheDir()
-    {
-        var hfHome = Environment.GetEnvironmentVariable("HF_HOME");
-        if (!string.IsNullOrEmpty(hfHome))
-        {
-            return Path.Combine(hfHome, "hub");
-        }
-
-        var hubCache = Environment.GetEnvironmentVariable("HUGGINGFACE_HUB_CACHE");
-        if (!string.IsNullOrEmpty(hubCache))
-        {
-            return hubCache;
-        }
-
-        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        return Path.Combine(home, ".cache", "huggingface", "hub");
+        // model itself on first use, showing its progress in the console log. Reporting
+        // "not installed" here made SE offer its own model download, which lands in Purfview's
+        // model folder - a folder whisperx never reads, since only the bare model name goes on
+        // the command line - so the user paid for gigabytes twice and the prompt came back on
+        // every run. Always "installed": the engine's own downloader is the only real one.
+        return true;
     }
 
     public string GetModelForCmdLine(string modelName) => modelName;
@@ -155,26 +115,27 @@ public class WhisperEngineWhisperX : ISpeechToTextEngine
 
     public bool CanBeDownloaded() => true;
 
-    // Measured from the v1.0.1 release zips (compressed download size); unpacks to roughly
-    // 950 MB (Windows), 1.1 GB (macOS), 1.7 GB (Linux) on disk, plus another ~2 GB of Whisper/
-    // alignment/diarization models that download from Hugging Face the first time each is used.
+    // Measured from the whisperx-standalone-101 support-files .7z assets (compressed download
+    // size); unpacks to roughly 950 MB (Windows), 1.1 GB (macOS), 1.7 GB (Linux) on disk, plus
+    // another ~2 GB of Whisper/alignment/diarization models that download from Hugging Face the
+    // first time each is used.
     public string DownloadSizeText
     {
         get
         {
             if (OperatingSystem.IsWindows())
             {
-                return "~350 MB";
+                return "~240 MB";
             }
 
             if (OperatingSystem.IsMacOS())
             {
-                return "~365 MB";
+                return "~220 MB";
             }
 
             if (OperatingSystem.IsLinux())
             {
-                return "~575 MB";
+                return "~355 MB";
             }
 
             return string.Empty;

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -454,6 +454,7 @@ public partial class SpeechToTextViewModel : ObservableObject
             or WhisperChoice.ConstMe
             or WhisperChoice.PurfviewFasterWhisperXxl
             or WhisperChoice.CTranslate2
+            or WhisperChoice.WhisperX
             or WhisperChoice.OpenAi;
     }
 
@@ -3911,8 +3912,21 @@ public partial class SpeechToTextViewModel : ObservableObject
                 $"{languageArgX}--model \"{model}\" --output_format srt --output_dir \"{outputDir}\" " +
                 $"{taskArg}{whisperXArgs} \"{waveFileName}\"";
 
+            // The generic launch path is bypassed here, so repeat the two pieces of its setup a
+            // PyInstaller-frozen Python engine needs: the glibc 2.41+ executable-stack repair,
+            // and the Python UTF-8/unbuffered variables - without them Windows decodes piped
+            // output with the ANSI code page (mojibake, or a UnicodeEncodeError killing the run)
+            // and stdout block-buffers so the log sits empty until the process exits.
+            EnsureExecutableStackCleared(whisperX, whisperX.GetAndCreateWhisperFolder());
+
             Se.WriteToolsLog($"{exe} {parametersX}");
-            return StartEngineProcess(exe, parametersX, dataReceivedHandler, AddFfmpegToPath);
+            return StartEngineProcess(exe, parametersX, dataReceivedHandler, startInfo =>
+            {
+                AddFfmpegToPath(startInfo);
+                startInfo.EnvironmentVariables["PYTHONIOENCODING"] = "utf-8";
+                startInfo.EnvironmentVariables["PYTHONUTF8"] = "1";
+                startInfo.EnvironmentVariables["PYTHONUNBUFFERED"] = "1";
+            });
         }
 
         if (engine is Qwen3AsrCppEngine qwen3Asr)

--- a/tests/UI/Features/Video/SpeechToText/Engines/WhisperEngineWhisperXTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/Engines/WhisperEngineWhisperXTests.cs
@@ -17,6 +17,27 @@ public class WhisperEngineWhisperXTests
     }
 
     [Fact]
+    public void ModelsAreAlwaysReportedInstalled_WhisperXDownloadsThemItself()
+    {
+        // Reporting "not installed" made SE offer its own model download into a folder
+        // whisperx never reads, re-prompting on every run - the engine owns its models.
+        var engine = new WhisperEngineWhisperX();
+
+        Assert.All(engine.Models, m => Assert.True(engine.IsModelInstalled(m)));
+    }
+
+    [Fact]
+    public void ModelListExcludesNamesWhisperXCannotResolve()
+    {
+        // The NbAiLab "*.nb" names only work when SE downloads the model and passes a local
+        // folder; whisperx gets the bare name, which is not a size or a Hugging Face repo id.
+        var engine = new WhisperEngineWhisperX();
+
+        Assert.DoesNotContain(engine.Models, m => m.Name.EndsWith(".nb"));
+        Assert.Contains(engine.Models, m => m.Name == "large-v3");
+    }
+
+    [Fact]
     public void LanguageCatalogIncludesLanguagesBeyondTheOriginalWhisperXSubset()
     {
         var engine = new WhisperEngineWhisperX();


### PR DESCRIPTION
The pre-beta24 review pass, extended to #14070 after it merged, found several issues in the new WhisperX engine; this fixes the clear-cut ones before the tag.

- **Model prompt downloaded to a folder whisperx never reads.** `IsModelInstalled` probed the Hugging Face cache (empty until a first successful run), so every run prompted "Download model?" — declining aborted the run, accepting downloaded 1–3 GB into Purfview's `_models` folder, which the command line never references, and whisperx re-downloaded the same model itself. The prompt also crashed (`ArgumentOutOfRangeException`) for custom local models with no URLs. WhisperX owns its model downloads, so the engine now always reports models installed — SE's downloader stays out of the way.
- **`*.nb` models filtered from the list**: whisperx gets the bare name, and "tiny.nb" is neither a faster-whisper size nor a HF repo id — the run failed after the picker accepted it.
- **Bypassed launch setup restored**: the WhisperX branch returns early, so the glibc 2.41+ executable-stack repair (whose gate #14070 itself widened to include WhisperX) was dead code, and the `PYTHONIOENCODING`/`PYTHONUTF8`/`PYTHONUNBUFFERED` variables every other Python engine gets were missing — mojibake or a `UnicodeEncodeError` on Windows, and a console log that sits empty all run. Both now applied in the branch.
- **"Auto detect" offered**: the branch already handled `language == "auto"` (omits `--language`, whisperx's native autodetect), but the engine wasn't in the auto-detect list, so the entry never appeared.
- **Download sizes corrected** to the support-files `.7z` assets (240/220/355 MB); the old numbers were the source repo's original zips.

Left as follow-ups: the install-record sidecar from #14071 (needs the three archive hashes — task chip filed), and a review note that whisperx's default alignment hard-fails for many of the advertised languages without `--no_align`; worth a look from someone who can run the pinned build.

Verified: UI builds; the 233 WhisperX/SpeechToText tests pass, including two new ones covering the model-list filter and the always-installed contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)