### PR TITLE
WhisperX: record the install with an .installed.sha256 sidecar

### DIFF
--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
@@ -229,6 +229,14 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject, ICl
 
                 TitleText = string.Format(Se.Language.General.UnpackingX, Engine.Name);
                 StartIndeterminateProgress();
+
+                // Record the build before the archive is deleted below. Like Faster-Whisper-XXL
+                // this engine is streamed to a file rather than to memory (the archive is
+                // 216 MB-355 MB), so it takes the file overload. Without a sidecar nothing
+                // identifies the install and the engine-settings dialog can only report it as
+                // an unrecognized build (#14057).
+                DownloadHashManager.WriteSidecar(dir, DownloadHashManager.ResolveWhisperXKey(), tempFileName);
+
                 // Flat archive (no top-level folder), so no folder level to skip.
                 Unpacker.Extract7Zip(tempFileName, dir, string.Empty, _cancellationTokenSource, text => ProgressText = text);
                 StopIndeterminateProgress();

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -356,6 +356,15 @@ public static class DownloadHashManager
         public const string Windows = "WhisperConstMe.Windows";             // cli.zip (Const-me/Whisper)
     }
 
+    public static class WhisperX
+    {
+        // Hashes of the release archive (.7z) — written to the sidecar at install time.
+        // SE-built standalone bundles under https://github.com/SubtitleEdit/support-files/releases.
+        public const string Windows = "WhisperX.Windows";                   // whisperx-standalone-windows-x64.7z
+        public const string MacArm64 = "WhisperX.MacArm64";                 // whisperx-standalone-macos-arm64.7z
+        public const string LinuxX64 = "WhisperX.Linux.X64";                // whisperx-standalone-linux-x64.7z
+    }
+
     // For each key, hashes are ordered newest-first. Index 0 is the latest known release.
     // All hashes are lower-case hex SHA-256.
     private static readonly IReadOnlyDictionary<string, IReadOnlyList<string>> KnownHashes =
@@ -2075,6 +2084,21 @@ public static class DownloadHashManager
             {
                 "baa9b70c824e50fe91f1858006a24b870b7637135659f17fc42beb1af57bd447", // 1.12.0 (current download URL)
             },
+
+            // WhisperX standalone — SE builds under
+            // https://github.com/SubtitleEdit/support-files/releases (build-whisperx-standalone-release.yml)
+            [WhisperX.Windows] = new[]
+            {
+                "439776243a3040693e9a2767a3efb4b8dd7549244bb6695ce0ef7209e5456bf3", // whisperx-standalone-101 / v1.0.1 (current download URL)
+            },
+            [WhisperX.MacArm64] = new[]
+            {
+                "89ff2f2dd120c8a2ab51c21e6be34a16c954965d4646ecdff77d0911ac6a2c27", // whisperx-standalone-101 / v1.0.1 (current download URL)
+            },
+            [WhisperX.LinuxX64] = new[]
+            {
+                "46070b23bfa7c152c259264ac2a135406b4462b2b979ea126510a9c6f44f80e2", // whisperx-standalone-101 / v1.0.1 (current download URL)
+            },
         };
 
     /// <summary>
@@ -2776,6 +2800,31 @@ public static class DownloadHashManager
     public static string? ResolveWhisperConstMeKey()
     {
         return OperatingSystem.IsWindows() ? WhisperConstMe.Windows : null;
+    }
+
+    /// <summary>
+    /// Resolves the WhisperX standalone archive hash key for the current OS and architecture.
+    /// Mirrors the platform rules in <see cref="WhisperDownloadService"/>: Windows x64,
+    /// macOS ARM64 and Linux x64 are the only combinations with a download.
+    /// </summary>
+    public static string? ResolveWhisperXKey()
+    {
+        if (OperatingSystem.IsWindows() && RuntimeInformation.ProcessArchitecture == Architecture.X64)
+        {
+            return WhisperX.Windows;
+        }
+
+        if (OperatingSystem.IsMacOS() && RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+        {
+            return WhisperX.MacArm64;
+        }
+
+        if (OperatingSystem.IsLinux() && RuntimeInformation.ProcessArchitecture == Architecture.X64)
+        {
+            return WhisperX.LinuxX64;
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/tests/UI/Logic/Download/SpeechToTextInstallRecordTests.cs
+++ b/tests/UI/Logic/Download/SpeechToTextInstallRecordTests.cs
@@ -23,6 +23,9 @@ public class SpeechToTextInstallRecordTests
     private const string CTranslate2MacArm64 = "f1c67d47be9216e9998df53d32a59fdaa0310f3e576fa4d9135aa1d579a71f86";
     private const string CTranslate2LinuxX64 = "02c6c1b738a10b8f72fbd581febbbc4f4e60abe96ad1fab76e1b432e2cce041b";
     private const string ConstMeWindows = "baa9b70c824e50fe91f1858006a24b870b7637135659f17fc42beb1af57bd447";
+    private const string WhisperXWindows = "439776243a3040693e9a2767a3efb4b8dd7549244bb6695ce0ef7209e5456bf3";
+    private const string WhisperXMacArm64 = "89ff2f2dd120c8a2ab51c21e6be34a16c954965d4646ecdff77d0911ac6a2c27";
+    private const string WhisperXLinuxX64 = "46070b23bfa7c152c259264ac2a135406b4462b2b979ea126510a9c6f44f80e2";
 
     [Theory]
     [InlineData(DownloadHashManager.PurfviewFasterWhisperXxl.Windows, PurfviewWindows)]
@@ -31,6 +34,9 @@ public class SpeechToTextInstallRecordTests
     [InlineData(DownloadHashManager.WhisperCTranslate2.MacArm64, CTranslate2MacArm64)]
     [InlineData(DownloadHashManager.WhisperCTranslate2.LinuxX64, CTranslate2LinuxX64)]
     [InlineData(DownloadHashManager.WhisperConstMe.Windows, ConstMeWindows)]
+    [InlineData(DownloadHashManager.WhisperX.Windows, WhisperXWindows)]
+    [InlineData(DownloadHashManager.WhisperX.MacArm64, WhisperXMacArm64)]
+    [InlineData(DownloadHashManager.WhisperX.LinuxX64, WhisperXLinuxX64)]
     public void GetStatus_PinnedArchive_IsUpToDate(string key, string hash)
     {
         // Index 0 of each list must be the archive the download URL currently points at,
@@ -90,6 +96,30 @@ public class SpeechToTextInstallRecordTests
     }
 
     [Fact]
+    public void ResolveWhisperXKey_MatchesDownloadablePlatforms()
+    {
+        var key = DownloadHashManager.ResolveWhisperXKey();
+
+        if (OperatingSystem.IsWindows() && !IsArm64)
+        {
+            Assert.Equal(DownloadHashManager.WhisperX.Windows, key);
+        }
+        else if (OperatingSystem.IsMacOS() && IsArm64)
+        {
+            Assert.Equal(DownloadHashManager.WhisperX.MacArm64, key);
+        }
+        else if (OperatingSystem.IsLinux() && !IsArm64)
+        {
+            Assert.Equal(DownloadHashManager.WhisperX.LinuxX64, key);
+        }
+        else
+        {
+            // Windows ARM64, macOS x64 and Linux ARM64 have no WhisperX standalone build.
+            Assert.Null(key);
+        }
+    }
+
+    [Fact]
     public void EveryEngineKey_HasAtLeastOneKnownHash()
     {
         // A key with no hashes behind it resolves fine and still leaves the install
@@ -102,6 +132,9 @@ public class SpeechToTextInstallRecordTests
                      DownloadHashManager.WhisperCTranslate2.MacArm64,
                      DownloadHashManager.WhisperCTranslate2.LinuxX64,
                      DownloadHashManager.WhisperConstMe.Windows,
+                     DownloadHashManager.WhisperX.Windows,
+                     DownloadHashManager.WhisperX.MacArm64,
+                     DownloadHashManager.WhisperX.LinuxX64,
                  })
         {
             Assert.NotEmpty(DownloadHashManager.GetKnownHashes(key));


### PR DESCRIPTION
PR #14070 added the WhisperX standalone engine, but its install branch in `DownloadSpeechToTextEngineViewModel` wrote no `.installed.sha256` sidecar, and `DownloadHashManager` had no WhisperX hashes — the exact gap PR #14071 closed for Faster-Whisper-XXL, CTranslate2 and Const-me (#14057). However well the install went, nothing identified it, so the engine-settings dialog could only report an unrecognized build — which reads as a failed install.

This follows #14071's pattern:

- **`DownloadHashManager`**: new `WhisperX` key class (`Windows` / `MacArm64` / `Linux.X64`), the SHA-256 of the three `whisperx-standalone-101` assets on SubtitleEdit/support-files, and `ResolveWhisperXKey()` mirroring `WhisperDownloadService`'s platform rules (Windows x64, macOS ARM64, Linux x64; null elsewhere).
- **`DownloadSpeechToTextEngineViewModel`**: `WriteSidecar` in the WhisperX install branch, before the archive is deleted after unpacking — the file overload, since this engine streams its 216–355 MB archive to disk like Faster-Whisper-XXL.
- **`SpeechToTextInstallRecordTests`**: the WhisperX rows added to the same pinned-archive / resolve-key / known-hash tests #14071 introduced (17 pass locally).

The hashes were computed locally from freshly downloaded copies of all three archives and match GitHub's API asset digests exactly:

| asset | SHA-256 |
| --- | --- |
| whisperx-standalone-windows-x64.7z | `439776243a3040693e9a2767a3efb4b8dd7549244bb6695ce0ef7209e5456bf3` |
| whisperx-standalone-macos-arm64.7z | `89ff2f2dd120c8a2ab51c21e6be34a16c954965d4646ecdff77d0911ac6a2c27` |
| whisperx-standalone-linux-x64.7z | `46070b23bfa7c152c259264ac2a135406b4462b2b979ea126510a9c6f44f80e2` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)