### PR TITLE
TTS: let an imported session regenerate its cloned lines again (#14095)

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceTtsCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/OmniVoiceTtsCpp.cs
@@ -293,12 +293,24 @@ public class OmniVoiceTtsCpp : ITtsEngine
 
         // Voice cloning: omnivoice-tts requires both --ref-wav and --ref-text.
         // Pair each voices/<name>.wav with a sibling <name>.txt holding the transcript.
-        // The transcript is captured at import time; if it has been deleted out from under
-        // us we fail loudly so the user knows custom voice cloning isn't happening, rather
-        // than silently producing the default speaker.
-        var usingReference = !string.IsNullOrEmpty(omniVoice.FilePath) && File.Exists(omniVoice.FilePath);
+        // The transcript is captured at import time; if either it or the recording itself has
+        // been deleted out from under us we fail loudly so the user knows custom voice cloning
+        // isn't happening, rather than silently producing the default speaker.
+        var usingReference = !string.IsNullOrEmpty(omniVoice.FilePath);
         if (usingReference)
         {
+            // A missing recording used to fall through to the built-in speaker without a word.
+            // That hit hardest where the recording is a temporary clip - the per-line clone cuts
+            // its references into the run folder, which is swept when Subtitle Edit closes - so
+            // regenerating an imported session simply spoke in the wrong voice (#14095).
+            if (!File.Exists(omniVoice.FilePath))
+            {
+                throw new FileNotFoundException(
+                    $"OmniVoice TTS cannot clone \"{omniVoice.Voice}\": its reference recording "
+                    + $"{omniVoice.FilePath} is gone. Re-import the voice, or pick another one.",
+                    omniVoice.FilePath);
+            }
+
             var refTextPath = Path.ChangeExtension(omniVoice.FilePath, ".txt");
             if (!File.Exists(refTextPath))
             {

--- a/src/ui/Features/Video/TextToSpeech/PerLineVoiceClone.cs
+++ b/src/ui/Features/Video/TextToSpeech/PerLineVoiceClone.cs
@@ -264,13 +264,34 @@ public static class PerLineVoiceClone
     /// method how to build its voice - the caller then falls back to the ordinary voice rather
     /// than silently synthesising with the wrong speaker.
     /// </remarks>
-    public static Voice? MakeVoiceForClip(ITtsEngine engine, string clipFileName)
+    /// <param name="voiceName">
+    /// What to call the voice, for the rows and lists that show it. Defaults to the clip's file
+    /// name; an imported session passes the name the clip had when it was exported, so a line
+    /// keeps the voice name it was generated with instead of picking up the exported clip's.
+    /// </param>
+    public static Voice? MakeVoiceForClip(ITtsEngine engine, string clipFileName, string? voiceName = null)
     {
-        var name = Path.GetFileNameWithoutExtension(clipFileName);
+        var name = string.IsNullOrEmpty(voiceName) ? Path.GetFileNameWithoutExtension(clipFileName) : voiceName;
         return engine switch
         {
             OmniVoiceTtsCpp => new Voice(new OmniVoice(name, clipFileName)),
             _ => null,
         };
     }
+
+    /// <summary>
+    /// The recording <paramref name="voice"/> clones from, or null when it clones from nothing -
+    /// or from something <see cref="MakeVoiceForClip"/> could not rebuild afterwards.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately limited to the voice types <see cref="MakeVoiceForClip"/> handles: the callers
+    /// are export (which copies the recording so the session can be re-imported elsewhere) and
+    /// regenerate (which reuses it), and a reference no engine can be handed back is worth
+    /// neither. Keep the two methods in step when an engine is added.
+    /// </remarks>
+    public static string? TryGetReferenceClip(Voice? voice) => voice?.EngineVoice switch
+    {
+        OmniVoice omniVoice when !string.IsNullOrEmpty(omniVoice.FilePath) => omniVoice.FilePath,
+        _ => null,
+    };
 }

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -12,6 +12,7 @@ using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DownloadTts;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ElevenLabsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.VoiceCloneConsent;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
@@ -115,6 +116,12 @@ public partial class ReviewSpeechViewModel : ObservableObject
     // folder picker here so the session lands next to the subtitle instead of wherever the
     // picker was last used (#13881).
     public string SubtitleFileName { get; set; } = string.Empty;
+
+    // What the video says during a paragraph - the transcript for a reference clip cut here (see
+    // ResolvePerLineCloneVoiceAsync). Supplied by the TTS window, which knows the original-language
+    // subtitle a translation was dubbed from; null when it does not, and the line's own text is
+    // then the best guess left.
+    public Func<Paragraph, string>? ReferenceTextOf { get; set; }
 
     public bool OkPressed { get; private set; }
 
@@ -804,6 +811,11 @@ public partial class ReviewSpeechViewModel : ObservableObject
         var audioFolder = Path.Combine(folder, "wav");
         Directory.CreateDirectory(audioFolder);
 
+        // The recordings cloned voices speak from travel with the session too - see
+        // ExportVoiceReference. The folder is only created when there is something to put in it.
+        var referenceFolder = Path.Combine(folder, "refs");
+        var exportedReferences = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
         // Copy files. Files still referenced by rows or their history entries must not be
         // overwritten: re-exporting to the folder a session was imported from used to replace an
         // original take (e.g. 0002.wav) that a history entry still pointed at - "pick from
@@ -910,6 +922,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
                     : line.StepResult.EngineName,
                 Model = line.StepResult.Model,
                 Instruction = line.StepResult.Instruction,
+                VoiceFileName = ExportVoiceReference(line.StepResult.Voice, referenceFolder, exportedReferences),
                 SpeedFactor = line.StepResult.SpeedFactor,
                 Text = line.Text,
                 Include = line.Include,
@@ -931,6 +944,79 @@ public partial class ReviewSpeechViewModel : ObservableObject
         }
 
         await _folderHelper.OpenFolder(Window!, folder);
+    }
+
+    /// <summary>
+    /// Copies the recording <paramref name="voice"/> clones from into the export's "refs" folder,
+    /// returning the relative name to store with the line - or an empty string when the voice
+    /// clones from nothing, or the copy failed.
+    /// </summary>
+    /// <remarks>
+    /// Without this an imported session could not regenerate a cloned line: an imported clone is
+    /// only a name in the engine's voice list on the machine that imported it, and the per-line
+    /// "clone from video" is not even that - its references are cut into the run folder, which is
+    /// swept when Subtitle Edit closes (#14095).
+    ///
+    /// Keyed by source path, so a cast of a few clones is copied once and shared by every line
+    /// using it rather than once per line. The transcript sidecar goes along when there is one -
+    /// the cloning engines need it, so a copy without it could only fail at synthesis.
+    /// </remarks>
+    internal static string ExportVoiceReference(Voice? voice, string referenceFolder, Dictionary<string, string> exported)
+    {
+        var source = PerLineVoiceClone.TryGetReferenceClip(voice);
+        if (string.IsNullOrEmpty(source) || !File.Exists(source))
+        {
+            return string.Empty;
+        }
+
+        var sourceFullPath = Path.GetFullPath(source);
+        if (exported.TryGetValue(sourceFullPath, out var alreadyExported))
+        {
+            return alreadyExported;
+        }
+
+        try
+        {
+            Directory.CreateDirectory(referenceFolder);
+
+            // Keep the clip's own name - the voice name for an imported clone, "line-0007" for a
+            // per-line one. Suffix only when a *different* recording already claimed the name,
+            // which also covers re-exporting into a folder an older export still owns.
+            var baseName = Path.GetFileNameWithoutExtension(source);
+            var extension = Path.GetExtension(source);
+            var target = Path.Combine(referenceFolder, baseName + extension);
+            var suffix = 1;
+            while (File.Exists(target) &&
+                   !string.Equals(Path.GetFullPath(target), sourceFullPath, StringComparison.OrdinalIgnoreCase))
+            {
+                target = Path.Combine(referenceFolder, $"{baseName}_{suffix}{extension}");
+                suffix++;
+            }
+
+            // Re-exporting to the folder the session was imported from makes source and target the
+            // same file; copying it onto itself would only throw.
+            if (!string.Equals(Path.GetFullPath(target), sourceFullPath, StringComparison.OrdinalIgnoreCase))
+            {
+                File.Copy(source, target, true);
+
+                var sourceTranscript = Path.ChangeExtension(source, ".txt");
+                if (File.Exists(sourceTranscript))
+                {
+                    File.Copy(sourceTranscript, Path.ChangeExtension(target, ".txt"), true);
+                }
+            }
+
+            var relativeName = "refs/" + Path.GetFileName(target);
+            exported[sourceFullPath] = relativeName;
+            return relativeName;
+        }
+        catch (Exception exception)
+        {
+            // One un-copyable reference must not take the whole export down - the line is exported
+            // without it, exactly as it was before references travelled at all.
+            SeLogger.Error(exception, $"ReviewSpeech export: copying the voice reference \"{source}\" failed");
+            return string.Empty;
+        }
     }
 
     private static string? GetFolderName(string fileName)
@@ -1032,6 +1118,105 @@ public partial class ReviewSpeechViewModel : ObservableObject
         await ElevenLabsSettingsViewModel.ShowStyleExaggerationHelp(Window!);
     }
 
+    /// <summary>
+    /// What the video says during a line - the transcript a freshly cut reference clip needs. The
+    /// original-language text when the TTS window supplied a lookup for it (a dub is generated
+    /// from a translation, and the clip holds what was said, not its translation), otherwise the
+    /// line's own text as it entered this window.
+    /// </summary>
+    private string SpokenTextInVideo(ReviewRow line)
+    {
+        var fromOriginal = ReferenceTextOf?.Invoke(line.StepResult.Paragraph);
+        if (!string.IsNullOrWhiteSpace(fromOriginal))
+        {
+            return fromOriginal;
+        }
+
+        var text = string.IsNullOrWhiteSpace(line.OriginalText) ? line.Text : line.OriginalText;
+        return Utilities.UnbreakLine(HtmlUtil.RemoveHtmlTags(text ?? string.Empty, alsoSsaTags: true));
+    }
+
+    /// <summary>
+    /// A real voice for the per-line clone marker: the reference this line was generated from when
+    /// it is still on disk, otherwise a fresh cut of the line's own audio in the video. Returns
+    /// null when there is nothing to clone from - the user has already been told why.
+    /// </summary>
+    private async Task<Voice?> ResolvePerLineCloneVoiceAsync(ITtsEngine engine, ReviewRow line)
+    {
+        // Prefer the clip the line was generated from, so a regenerate clones the same speaker the
+        // line's other takes did - and so an imported session uses the reference that travelled
+        // with it instead of cutting the video again.
+        var existingClip = PerLineVoiceClone.TryGetReferenceClip(line.StepResult.Voice);
+        if (!string.IsNullOrEmpty(existingClip) && File.Exists(existingClip))
+        {
+            var reused = PerLineVoiceClone.MakeVoiceForClip(engine, existingClip, line.StepResult.Voice?.Name);
+            if (reused != null)
+            {
+                return reused;
+            }
+        }
+
+        if (string.IsNullOrEmpty(_videoFileName) || !File.Exists(_videoFileName))
+        {
+            await ShowCloneVoiceError(Se.Language.Video.TextToSpeech.CloneVoicePerLineNeedsVideo);
+            return null;
+        }
+
+        var index = Lines.IndexOf(line);
+        if (index < 0)
+        {
+            return null;
+        }
+
+        // A folder of its own, not the generate run's "clone-references": those clips belong to
+        // the rows as they were generated, and a re-cut of an edited line must not replace one.
+        // The video duration is unknown here, which only means the last line's clip is not
+        // clamped to the end of the video - ffmpeg stops at the end of the audio either way.
+        var clipFileName = await PerLineVoiceClone.CutReferenceClipAsync(
+            _videoFileName,
+            Lines.Select(l => l.StepResult.Paragraph).ToList(),
+            index,
+            SpokenTextInVideo(line),
+            Path.Combine(_waveFolder, "clone-references-regenerate"),
+            videoDurationSeconds: 0,
+            audioTrackFfIndex: -1,
+            // Not _cancellationToken: it still belongs to the previous regenerate at this point
+            // (this run replaces it further down), so cancelling one regenerate would abort the
+            // next one's cut before it started. The cut is one short ffmpeg call anyway - the
+            // main window's preview cut passes None for the same reason.
+            CancellationToken.None);
+        if (clipFileName == null)
+        {
+            await ShowCloneVoiceError(Se.Language.Video.TextToSpeech.CloneVoicePerLineNoClips);
+            return null;
+        }
+
+        var clonedVoice = PerLineVoiceClone.MakeVoiceForClip(engine, clipFileName);
+        if (clonedVoice == null)
+        {
+            // The engine says it clones per line but nobody taught MakeVoiceForClip how to build
+            // its voice. Say so rather than quietly regenerating in some other voice.
+            await ShowCloneVoiceError($"{engine.Name} cannot clone the voice of each line.");
+        }
+
+        return clonedVoice;
+    }
+
+    private async Task ShowCloneVoiceError(string message)
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        await MessageBox.Show(
+            Window,
+            Se.Language.General.Error,
+            message,
+            MessageBoxButtons.OK,
+            MessageBoxIcon.Error);
+    }
+
     // Replace _cancellationTokenSource, disposing the previous instance. The
     // RegenerateAudio path swaps in a CTS owned by GeneratingAudioViewModel,
     // so disposing the old one here just frees the per-window CTS created in
@@ -1110,6 +1295,31 @@ public partial class ReviewSpeechViewModel : ObservableObject
             if (!await TtsEngineInstaller.EnsureEngineInstalled(engine, Window, _windowService, SelectedRegion, SelectedModel, null, null, async () => await SelectedEngineChangedAsync()))
             {
                 return;
+            }
+
+            // "Clone from video" is a marker, not a voice any engine can speak with: the generate
+            // pipeline swaps it for a real one per paragraph, and this window used to hand it
+            // straight to the engine - which is what an imported session failed on with "Voice is
+            // not an OmniVoice" (#14095).
+            if (PerLineVoiceClone.IsSelected(voice))
+            {
+                // Same one-time gate the TTS window puts in front of cloning; picking this voice
+                // here is a fresh decision to clone whoever speaks in the video.
+                if (Window != null && !await VoiceCloneConsentPrompt.EnsureAsync(
+                        engine,
+                        Window,
+                        () => _windowService.ShowDialogAsync<VoiceCloneConsentWindow, VoiceCloneConsentViewModel>(Window, _ => { })))
+                {
+                    return;
+                }
+
+                var clonedVoice = await ResolvePerLineCloneVoiceAsync(engine, line);
+                if (clonedVoice == null)
+                {
+                    return;
+                }
+
+                voice = clonedVoice;
             }
 
             if (!await TtsVoiceInstaller.EnsureVoiceInstalled(engine, voice, Window, _windowService))

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -1846,6 +1846,14 @@ public partial class TextToSpeechViewModel : ObservableObject
             {
                 voice = perEngineVoices.FirstOrDefault(v => string.Equals(v.Name, item.VoiceName, StringComparison.OrdinalIgnoreCase));
             }
+
+            // A cloned voice that is not in the engine's voice list - the per-line "clone from
+            // video" cuts one reference per line and never imports any of them - is rebuilt from
+            // the recording the export copied along. Without this the line came back voice-less,
+            // and regenerating it either spoke in whatever voice happened to be selected or failed
+            // outright with "Voice is not an OmniVoice" (#14095).
+            voice ??= RebuildClonedVoice(item, jsonFolder);
+
             voice ??= Voices.FirstOrDefault(v => v.Name == item.VoiceName);
             stepResults.Add(new TtsStepResult
             {
@@ -1915,6 +1923,9 @@ public partial class TextToSpeechViewModel : ObservableObject
             // of writing ActorVoiceMappings = [] back to SubtitleEditTts.json.
             vm.ActorVoiceMappings.AddRange(_actorVoiceMappings);
             vm.SubtitleFileName = GetLoadedSubtitleFileName();
+            // So a regenerate that has to cut its own reference clip transcribes it with what the
+            // video says, not with the translation being dubbed over it.
+            vm.ReferenceTextOf = GetSpokenTextInVideo;
 
             if (peaksForReview == null || peaksForReview.Peaks.Count == 0)
             {
@@ -1966,6 +1977,30 @@ public partial class TextToSpeechViewModel : ObservableObject
                     MessageBoxIcon.Error);
             }
         }
+    }
+
+    /// <summary>
+    /// The voice an imported line clones from, rebuilt from the reference recording that travelled
+    /// with the export. Null when the line's voice clones from nothing, when the recording is not
+    /// there, or when its engine cannot be given a recording directly.
+    /// </summary>
+    private Voice? RebuildClonedVoice(TtsImportExportItem item, string jsonFolder)
+    {
+        if (string.IsNullOrEmpty(item.VoiceFileName) || string.IsNullOrEmpty(item.EngineName))
+        {
+            return null;
+        }
+
+        var engine = Engines.FirstOrDefault(e => string.Equals(e.Name, item.EngineName, StringComparison.OrdinalIgnoreCase));
+        if (engine == null)
+        {
+            return null;
+        }
+
+        var clipFileName = ResolveImportedAudioFileName(item.VoiceFileName, jsonFolder);
+        return File.Exists(clipFileName)
+            ? PerLineVoiceClone.MakeVoiceForClip(engine, clipFileName, item.VoiceName)
+            : null;
     }
 
     /// <summary>
@@ -3510,6 +3545,7 @@ public partial class TextToSpeechViewModel : ObservableObject
                 _wavePeakData);
             vm.ActorVoiceMappings.AddRange(_actorVoiceMappings);
             vm.SubtitleFileName = GetLoadedSubtitleFileName();
+            vm.ReferenceTextOf = GetSpokenTextInVideo;
         });
 
         if (result.OkPressed)

--- a/src/ui/Features/Video/TextToSpeech/TtsImportExportItem.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsImportExportItem.cs
@@ -17,6 +17,14 @@ public class TtsImportExportItem
     public string Model { get; set; }
     public string Instruction { get; set; }
 
+    // The recording this line's voice clones from, relative to the JSON like AudioFileName
+    // ("refs/0001.wav"). A cloned voice is only a name in the engine's voice list when it was
+    // imported into it - the per-line "clone from video" cuts its reference into the run folder,
+    // which is gone by the next session, so without the copy travelling along a re-imported
+    // session could not regenerate a line in the voice it was generated with (#14095). Empty for
+    // ordinary voices and for legacy exports.
+    public string VoiceFileName { get; set; }
+
     public bool Include { get; set; }
 
     public TtsImportExportItem()
@@ -30,6 +38,7 @@ public class TtsImportExportItem
         VoiceName = string.Empty;
         Model = string.Empty;
         Instruction = string.Empty;
+        VoiceFileName = string.Empty;
         Include = true;
     }
 }

--- a/tests/UI/Features/Video/TextToSpeech/PerLineVoiceCloneTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/PerLineVoiceCloneTests.cs
@@ -131,4 +131,26 @@ public class PerLineVoiceCloneTests
         // the caller falls back, rather than getting some other engine's voice type.
         Assert.Null(PerLineVoiceClone.MakeVoiceForClip(new EdgeTts(), "/tmp/refs/line-0007.wav"));
     }
+
+    [Fact]
+    public void AnImportedClipKeepsTheVoiceNameItWasExportedWith()
+    {
+        // The exported clip may have been renamed to avoid a collision in the export folder; the
+        // line should still show the voice it was generated with, not the file it came back as.
+        var voice = PerLineVoiceClone.MakeVoiceForClip(new OmniVoiceTtsCpp(), "/tmp/refs/line-0007_1.wav", "line-0007");
+
+        Assert.Equal("line-0007", voice!.Name);
+    }
+
+    [Fact]
+    public void OnlyAVoiceThatCanBeRebuiltReportsAReference()
+    {
+        Assert.Equal("/voices/ada.wav", PerLineVoiceClone.TryGetReferenceClip(new Voice(new OmniVoice("Ada", "/voices/ada.wav"))));
+
+        // Nothing to copy along for a voice that clones from nothing - or for the marker, which
+        // has no recording of its own at all.
+        Assert.Null(PerLineVoiceClone.TryGetReferenceClip(new Voice(new OmniVoice("Default", string.Empty))));
+        Assert.Null(PerLineVoiceClone.TryGetReferenceClip(PerLineVoiceClone.CreateVoice()));
+        Assert.Null(PerLineVoiceClone.TryGetReferenceClip(null));
+    }
 }

--- a/tests/UI/Features/Video/TextToSpeech/ReviewSpeech/ExportVoiceReferenceTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/ReviewSpeech/ExportVoiceReferenceTests.cs
@@ -1,0 +1,115 @@
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ReviewSpeech;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+
+namespace UITests.Features.Video.TextToSpeech.ReviewSpeech;
+
+/// <summary>
+/// An exported session is only re-generatable if the recordings its cloned voices speak from
+/// travel with it: a per-line clone's references are cut into the run folder, which is gone by the
+/// next session, and an imported clone only exists in the voice list of the machine that imported
+/// it (#14095).
+/// </summary>
+public class ExportVoiceReferenceTests : IDisposable
+{
+    private readonly string _folder = Path.Combine(Path.GetTempPath(), "se-export-refs-" + Guid.NewGuid().ToString("N"));
+
+    private string ReferenceFolder => Path.Combine(_folder, "refs");
+
+    private string WriteClip(string name, string contents = "wav", string? transcript = "what the video says")
+    {
+        var sourceFolder = Path.Combine(_folder, "source", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(sourceFolder);
+        var clipFileName = Path.Combine(sourceFolder, name);
+        File.WriteAllText(clipFileName, contents);
+        if (transcript != null)
+        {
+            File.WriteAllText(Path.ChangeExtension(clipFileName, ".txt"), transcript);
+        }
+
+        return clipFileName;
+    }
+
+    private static Voice CloneVoice(string clipFileName) =>
+        new(new OmniVoice(Path.GetFileNameWithoutExtension(clipFileName), clipFileName));
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_folder))
+        {
+            Directory.Delete(_folder, true);
+        }
+    }
+
+    [Fact]
+    public void TheRecordingAndItsTranscriptAreCopiedIntoTheExport()
+    {
+        var clipFileName = WriteClip("line-0007.wav");
+
+        var relativeName = ReviewSpeechViewModel.ExportVoiceReference(CloneVoice(clipFileName), ReferenceFolder, new Dictionary<string, string>());
+
+        // Forward slash so the same JSON opens on Windows, macOS and Linux.
+        Assert.Equal("refs/line-0007.wav", relativeName);
+        Assert.True(File.Exists(Path.Combine(ReferenceFolder, "line-0007.wav")));
+        // Without the transcript omnivoice-tts refuses the reference, so a copy without it could
+        // only fail at synthesis.
+        Assert.Equal("what the video says", File.ReadAllText(Path.Combine(ReferenceFolder, "line-0007.txt")));
+    }
+
+    [Fact]
+    public void AVoiceThatClonesFromNothingExportsNothing()
+    {
+        var exported = new Dictionary<string, string>();
+
+        Assert.Equal(string.Empty, ReviewSpeechViewModel.ExportVoiceReference(new Voice(new OmniVoice("Default", string.Empty)), ReferenceFolder, exported));
+        Assert.Equal(string.Empty, ReviewSpeechViewModel.ExportVoiceReference(null, ReferenceFolder, exported));
+        // A voice whose recording has already been deleted has nothing to copy either.
+        Assert.Equal(string.Empty, ReviewSpeechViewModel.ExportVoiceReference(CloneVoice(Path.Combine(_folder, "gone.wav")), ReferenceFolder, exported));
+        Assert.False(Directory.Exists(ReferenceFolder));
+    }
+
+    [Fact]
+    public void OneRecordingSharedByManyLinesIsCopiedOnce()
+    {
+        // A cast of a few imported clones would otherwise be copied once per line - hundreds of
+        // copies of the same wav for a full-length subtitle.
+        var clipFileName = WriteClip("Ada.wav");
+        var exported = new Dictionary<string, string>();
+
+        var first = ReviewSpeechViewModel.ExportVoiceReference(CloneVoice(clipFileName), ReferenceFolder, exported);
+        var second = ReviewSpeechViewModel.ExportVoiceReference(CloneVoice(clipFileName), ReferenceFolder, exported);
+
+        Assert.Equal(first, second);
+        Assert.Single(Directory.GetFiles(ReferenceFolder, "*.wav"));
+    }
+
+    [Fact]
+    public void TwoDifferentRecordingsWithOneNameBothSurvive()
+    {
+        var first = WriteClip("line-0001.wav", "first");
+        var second = WriteClip("line-0001.wav", "second");
+        var exported = new Dictionary<string, string>();
+
+        var firstName = ReviewSpeechViewModel.ExportVoiceReference(CloneVoice(first), ReferenceFolder, exported);
+        var secondName = ReviewSpeechViewModel.ExportVoiceReference(CloneVoice(second), ReferenceFolder, exported);
+
+        Assert.NotEqual(firstName, secondName);
+        Assert.Equal("first", File.ReadAllText(Path.Combine(_folder, firstName.Replace('/', Path.DirectorySeparatorChar))));
+        Assert.Equal("second", File.ReadAllText(Path.Combine(_folder, secondName.Replace('/', Path.DirectorySeparatorChar))));
+    }
+
+    [Fact]
+    public void ReExportingIntoTheFolderTheSessionCameFromKeepsTheRecording()
+    {
+        // Import points the voice at <jsonFolder>/refs/line-0007.wav; exporting back to the same
+        // folder makes source and target the same file, and copying it onto itself only throws.
+        Directory.CreateDirectory(ReferenceFolder);
+        var clipFileName = Path.Combine(ReferenceFolder, "line-0007.wav");
+        File.WriteAllText(clipFileName, "wav");
+
+        var relativeName = ReviewSpeechViewModel.ExportVoiceReference(CloneVoice(clipFileName), ReferenceFolder, new Dictionary<string, string>());
+
+        Assert.Equal("refs/line-0007.wav", relativeName);
+        Assert.Equal("wav", File.ReadAllText(clipFileName));
+    }
+}


### PR DESCRIPTION
Fixes #14095.

Dubbing a video with **OmniVoice TTS** + **"Clone from video"**, exporting the session and importing it again left every regenerate failing with *"Regenerating audio failed: Voice is not an OmniVoice"*.

Three defects, each enough to break it on its own:

**1. The review window handed the clone marker straight to the engine.**
"Clone from video" is a marker (`PerLineCloneVoice`), not a voice: the generate pipeline swaps it per paragraph for a real voice built from that line's own audio (`ResolvePerLineCloneVoice`), but `ReviewSpeechViewModel.RegenerateAudio` passed `SelectedVoice` verbatim to `engine.Speak`. Before an export it never showed, because clicking a row set `SelectedVoice` from the row's resolved clone voice; after an import that voice was gone (see 2) and the marker - restored as the last-used voice - went to the engine.

It now does the same swap: reuse the clip the line was generated from when it is still on disk, otherwise cut a fresh one from the video, behind the same one-time voice-cloning consent the TTS window asks for. Picking "Clone from video" in this window's own voice combo worked no better before, so this fixes that too.

**2. The reference recordings did not travel with an export.**
A per-line clone cuts its references into the run folder, which is swept when SE closes, and an imported clone is only a name in the voice list of the machine that imported it - so on import the line's voice resolved to nothing.

Export now copies each line's reference recording and its transcript sidecar into a `refs` folder next to the audio - once per distinct recording, so a cast of a few clones is not copied once per line - and records it as `VoiceFileName`. Import rebuilds the line's voice from it when the engine's voice list has no such name. Legacy exports without the copies import exactly as they did before; for those, regenerate falls back to cutting a fresh reference from the video.

**3. `OmniVoiceTtsCpp` synthesised with its built-in speaker when a reference recording was missing.**
`usingReference` was gated on `File.Exists`, so a session whose clips had been swept regenerated in the wrong voice silently - the worse half of this bug, since fixing only 1 and 2 would have turned a hard failure into a quiet one. It now throws the way it already did for a missing transcript.

## Testing

- `ExportVoiceReferenceTests` (new): the recording and its transcript are copied, a voice that clones from nothing exports nothing, one recording shared by many lines is copied once, two different recordings sharing a name both survive, and re-exporting into the folder a session was imported from does not destroy the recording.
- `PerLineVoiceCloneTests`: an imported clip keeps the voice name it was exported with; only a voice that can be rebuilt reports a reference.
- Full UI suite green (3907 passed).

Not exercised end to end against omnivoice-tts itself - the paths that need the binary (Speak) are unchanged apart from the missing-reference throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)