### PR TITLE
Translate: keep the original, and never save one without text (#14091)

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1045,6 +1045,7 @@
     "originalTextReadOnly": "Original text (read-only)",
     "originalTextEditMode": "Original text (edit mode)",
     "originalIsReadOnlyNotSaved": "The original subtitle is a read-only reference and was not saved",
+    "originalIsEmptyNotSaved": "The original subtitle has no text at all and was not saved",
     "originalIsReadOnlyReference": "The original subtitle is open as a read-only reference",
     "allowEditOfOriginalSubtitle": "Allow edit of original subtitle",
     "showAllOriginalLinesX": "Show all original lines ({0} have no match here)",

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -3140,6 +3140,24 @@ public partial class MainViewModel :
         _subtitleOriginal = captured;
     }
 
+    /// <summary>
+    /// Makes the pre-translation text in the rows' original column the original subtitle. A
+    /// translation made from the current rows leaves that text in the rows only, while the original
+    /// subtitle stays empty - so a wholesale rebuild (<see cref="SetSubtitles(Subtitle, Subtitle?)"/>,
+    /// as most tools do) blanks the column, and saving the original then writes a file with time
+    /// codes and no text at all over the subtitle the translation was made from (#14091).
+    /// </summary>
+    private void CaptureOriginalFromTranslatedRows()
+    {
+        _subtitleOriginal ??= new Subtitle();
+        _subtitleOriginal.OriginalFormat = _subtitle.OriginalFormat ?? SelectedSubtitleFormat;
+
+        // Rebuilds the original from the rows - one line per row, in order - and re-points every
+        // row at the line it just produced. The callers have already left the modes that would
+        // make this a projection instead of the whole original.
+        GetUpdateSubtitleOriginal();
+    }
+
     /// <summary>Drops every display-only reference row, leaving the working subtitle behind.</summary>
     private void RemoveReferenceOnlyRows()
     {
@@ -6595,21 +6613,25 @@ public partial class MainViewModel :
             return;
         }
 
+        // A display-only row of a read-only original carries no text to translate from, and the
+        // original it shows is replaced by the rows' text here (#14091).
+        RemoveReferenceOnlyRows();
+
         foreach (var subtitle in Subtitles)
         {
             subtitle.OriginalText = subtitle.Text;
             subtitle.Text = string.Empty;
+            subtitle.ReferenceParagraphId = null;
         }
 
         _subtitleFileNameOriginal = _subtitleFileName;
-        _subtitleOriginal ??= new Subtitle();
-        _subtitleOriginal.OriginalFormat = _subtitle.OriginalFormat ?? SelectedSubtitleFormat;
         _subtitleFileName = null;
         _converted = true;
         _shortcutManager.ClearKeys();
         IsOriginalReadOnly = false; // a translation made here always lines up 1:1 with its original
         IsShowingOriginalNonMatchingLines = false;
         ShowColumnOriginalText = true;
+        CaptureOriginalFromTranslatedRows();
         AutoFitColumns();
         ShowStatus(Se.Language.Main.CreatedEmptyTranslation);
     }
@@ -10751,6 +10773,13 @@ public partial class MainViewModel :
 
         var wasOldTranslationChanged = _changeSubtitleHash != GetFastHash();
 
+        // The dialog was handed GetUpdateSubtitle(), which leaves the display-only rows of a
+        // read-only original out - so they must go before the rows are matched with the result by
+        // index, or every row past the first of them would take the wrong translation, and the
+        // reference rows themselves would have their original text overwritten with nothing
+        // (#14091). The original they display is replaced by the pre-translation text below anyway.
+        RemoveReferenceOnlyRows();
+
         for (var i = 0; i < Subtitles.Count; i++)
         {
             if (result.Rows.Count <= i)
@@ -10760,6 +10789,10 @@ public partial class MainViewModel :
 
             Subtitles[i].OriginalText = Subtitles[i].Text;
             Subtitles[i].Text = result.Rows[i].TranslatedText;
+
+            // Whatever original this row pointed into is gone - the pre-translation text is the
+            // original now.
+            Subtitles[i].ReferenceParagraphId = null;
         }
 
         // The subtitle language just changed, so the cached detected language is stale (issue #12144).
@@ -10772,8 +10805,6 @@ public partial class MainViewModel :
 
         var targetLanguageCode = result.SelectedTargetLanguage?.TwoLetterIsoLanguageName;
         _subtitleFileNameOriginal = _subtitleFileName;
-        _subtitleOriginal ??= new Subtitle();
-        _subtitleOriginal.OriginalFormat = _subtitle.OriginalFormat ?? SelectedSubtitleFormat;
         if (!string.IsNullOrEmpty(_subtitleFileName) && !string.IsNullOrEmpty(targetLanguageCode))
         {
             var directory = Path.GetDirectoryName(_subtitleFileName) ?? string.Empty;
@@ -10804,12 +10835,26 @@ public partial class MainViewModel :
                 }
             }
 
-            _subtitleFileName = Path.Combine(directory, nameWithoutExt + "." + targetLanguageCode + extension);
+            var translatedFileName = Path.Combine(directory, nameWithoutExt + "." + targetLanguageCode + extension);
 
-            // Saving must offer the translated name, not the video's name - otherwise the
-            // default video-first SaveAsBehavior suggests overwriting the subtitle that was
-            // just translated from.
-            _saveAsFileNameSuggestion = _subtitleFileName;
+            // A source file that already carries the target language code ("movie.nl.srt"
+            // translated to Dutch) would keep its name here, and saving writes both the
+            // translation and the original to it - the second write wiping the first. Leave it
+            // untitled instead, so "Save as" asks for a name (#14091).
+            if (translatedFileName.Equals(_subtitleFileNameOriginal, StringComparison.OrdinalIgnoreCase))
+            {
+                _subtitleFileName = string.Empty;
+                _saveAsFileNameSuggestion = null;
+            }
+            else
+            {
+                _subtitleFileName = translatedFileName;
+
+                // Saving must offer the translated name, not the video's name - otherwise the
+                // default video-first SaveAsBehavior suggests overwriting the subtitle that was
+                // just translated from.
+                _saveAsFileNameSuggestion = _subtitleFileName;
+            }
         }
         else
         {
@@ -10820,6 +10865,7 @@ public partial class MainViewModel :
         IsOriginalReadOnly = false; // the translation was made from the current rows, so it lines up 1:1
         IsShowingOriginalNonMatchingLines = false;
         ShowColumnOriginalText = true;
+        CaptureOriginalFromTranslatedRows();
         AutoFitColumns();
         _updateAudioVisualizer = true;
     }
@@ -10894,34 +10940,42 @@ public partial class MainViewModel :
             return;
         }
 
-        var result = await ShowDialogAsync<CopyPasteTranslateWindow, CopyPasteTranslateViewModel>(vm => { vm.Initialize(Subtitles.ToList()); });
+        // The display-only rows of a read-only original hold no text of the working subtitle -
+        // they have nothing to translate, and the original they show is replaced below (#14091).
+        var rows = Subtitles.Where(p => !p.IsReferenceOnly).ToList();
+
+        var result = await ShowDialogAsync<CopyPasteTranslateWindow, CopyPasteTranslateViewModel>(vm => { vm.Initialize(rows); });
 
         if (!result.OkPressed)
         {
             return;
         }
 
-        for (var i = 0; i < Subtitles.Count && i < result.Subtitles.Count; i++)
+        for (var i = 0; i < rows.Count; i++)
         {
-            if (!result.TranslatedRowIndices.Contains(i))
-            {
-                continue;
-            }
+            // The source text of every row goes into the original column, translated or not: the
+            // original is saved from those rows, so a skipped row left blank there would write a
+            // line with no text over the subtitle the translation was made from (#14091).
+            rows[i].OriginalText = rows[i].Text;
+            rows[i].ReferenceParagraphId = null;
 
-            Subtitles[i].OriginalText = Subtitles[i].Text;
-            Subtitles[i].Text = result.Subtitles[i].Text;
+            if (i < result.Subtitles.Count && result.TranslatedRowIndices.Contains(i))
+            {
+                rows[i].Text = result.Subtitles[i].Text;
+            }
         }
+
+        RemoveReferenceOnlyRows();
 
         // The subtitle language just changed, so the cached detected language is stale (issue #12144).
         _detectedLanguageCode = null;
 
         _subtitleFileNameOriginal = _subtitleFileName;
-        _subtitleOriginal ??= new Subtitle();
-        _subtitleOriginal.OriginalFormat = _subtitle.OriginalFormat ?? SelectedSubtitleFormat;
         _subtitleFileName = string.Empty;
         IsOriginalReadOnly = false; // the translation was made from the current rows, so it lines up 1:1
         IsShowingOriginalNonMatchingLines = false;
         ShowColumnOriginalText = true;
+        CaptureOriginalFromTranslatedRows();
         AutoFitColumns();
         _updateAudioVisualizer = true;
         _converted = true;
@@ -21639,7 +21693,24 @@ public partial class MainViewModel :
         }
 
         var originalFormat = _subtitleOriginal?.OriginalFormat ?? SelectedSubtitleFormat;
-        var text = GetUpdateSubtitleOriginal(true).ToText(originalFormat);
+        var originalSubtitle = GetUpdateSubtitleOriginal(true);
+
+        // A whole original without a single line of text is never something the user typed - the
+        // column was blanked somewhere (a rebuild, a lost translation source). Writing it out
+        // would leave numbers and time codes and no subtitles at all, over the file the
+        // translation was made from, so refuse instead (#14091).
+        if (originalSubtitle.Paragraphs.Count > 1 &&
+            originalSubtitle.Paragraphs.All(p => string.IsNullOrWhiteSpace(p.Text)))
+        {
+            if (!isAutoSave)
+            {
+                ShowStatus(Se.Language.Main.OriginalIsEmptyNotSaved);
+            }
+
+            return false;
+        }
+
+        var text = originalSubtitle.ToText(originalFormat);
 
         try
         {

--- a/src/ui/Logic/Config/Language/Main/LanguageMain.cs
+++ b/src/ui/Logic/Config/Language/Main/LanguageMain.cs
@@ -94,6 +94,7 @@ public class LanguageMain
     public string OriginalTextReadOnly { get; set; }
     public string OriginalTextEditMode { get; set; }
     public string OriginalIsReadOnlyNotSaved { get; set; }
+    public string OriginalIsEmptyNotSaved { get; set; }
     public string OriginalIsReadOnlyReference { get; set; }
     public string AllowEditOfOriginalSubtitle { get; set; }
     public string ShowAllOriginalLinesX { get; set; }
@@ -246,6 +247,7 @@ public class LanguageMain
         OriginalTextReadOnly = "Original text (read-only)";
         OriginalTextEditMode = "Original text (edit mode)";
         OriginalIsReadOnlyNotSaved = "The original subtitle is a read-only reference and was not saved";
+        OriginalIsEmptyNotSaved = "The original subtitle has no text at all and was not saved";
         OriginalIsReadOnlyReference = "The original subtitle is open as a read-only reference";
         AllowEditOfOriginalSubtitle = "Allow edit of original subtitle";
         ShowAllOriginalLinesX = "Show all original lines ({0} have no match here)";

--- a/tests/UI/Features/Main/MainTranslationOriginalTests.cs
+++ b/tests/UI/Features/Main/MainTranslationOriginalTests.cs
@@ -1,0 +1,284 @@
+using System.Reflection;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Main.MainHelpers;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// A translation made from the current rows (auto-translate, translate via copy/paste, "make empty
+/// translation") moves the pre-translation text into the rows' original column and points the
+/// original's file name at the subtitle it was translated from. The text has to reach the original
+/// subtitle too: it is what every wholesale rebuild re-fills the column from, and saving the
+/// original serializes it - so leaving it empty wrote a file with time codes and no text at all
+/// over the user's source subtitle (issue #14091).
+/// </summary>
+public class MainTranslationOriginalTests
+{
+    [AvaloniaFact]
+    public void CaptureOriginalFromTranslatedRows_PutsThePreTranslationTextInTheOriginalSubtitle()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Vertaalde regel een", "Translated line one", 0, 2000);
+            AddLine(vm, "Vertaalde regel twee", "Translated line two", 2000, 4000);
+            vm.ShowColumnOriginalText = true;
+
+            InvokeCaptureOriginalFromTranslatedRows(vm);
+
+            var subtitleOriginal = (Subtitle)GetField("_subtitleOriginal").GetValue(vm)!;
+            Assert.Equal(2, subtitleOriginal.Paragraphs.Count);
+            Assert.Equal("Translated line one", subtitleOriginal.Paragraphs[0].Text);
+            Assert.Equal("Translated line two", subtitleOriginal.Paragraphs[1].Text);
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    /// <summary>
+    /// The rebuild that most tools go through re-fills the original column from the original
+    /// subtitle. Before the capture it was empty, so the column came back blank - and a save then
+    /// wrote that blank original over the source file.
+    /// </summary>
+    [AvaloniaFact]
+    public void AfterCapture_ARebuildKeepsTheOriginalColumn()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Vertaalde regel een", "Translated line one", 0, 2000);
+            AddLine(vm, "Vertaalde regel twee", "Translated line two", 2000, 4000);
+            vm.ShowColumnOriginalText = true;
+            InvokeCaptureOriginalFromTranslatedRows(vm);
+
+            var subtitle = vm.GetUpdateSubtitle();
+            var subtitleOriginal = (Subtitle)GetField("_subtitleOriginal").GetValue(vm)!;
+            InvokeSetSubtitles(vm, subtitle, subtitleOriginal);
+
+            Assert.Equal(
+                new[] { "Translated line one", "Translated line two" },
+                vm.Subtitles.Select(p => p.OriginalText));
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    /// <summary>
+    /// The last line of defense: whatever blanked the original column, an original without a single
+    /// line of text is never written back over the user's file.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task SaveSubtitleOriginal_WithoutAnyText_LeavesTheFileUntouched()
+    {
+        var (window, vm) = CreateMainViewModel();
+        var fileName = Path.Combine(Path.GetTempPath(), $"se-empty-original-{Guid.NewGuid():N}.srt");
+        const string onDisk = "1\r\n00:00:00,000 --> 00:00:02,000\r\nSource line one\r\n\r\n" +
+                              "2\r\n00:00:02,000 --> 00:00:04,000\r\nSource line two\r\n\r\n";
+        await File.WriteAllTextAsync(fileName, onDisk);
+
+        try
+        {
+            AddLine(vm, "Vertaalde regel een", string.Empty, 0, 2000);
+            AddLine(vm, "Vertaalde regel twee", string.Empty, 2000, 4000);
+            vm.ShowColumnOriginalText = true;
+            vm.IsOriginalReadOnly = false;
+            SetPrivateField(vm, "_subtitleFileNameOriginal", fileName);
+
+            var saved = await InvokeSaveSubtitleOriginal(vm, isAutoSave: false);
+
+            Assert.False(saved);
+            Assert.Equal(onDisk, await File.ReadAllTextAsync(fileName));
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+            File.Delete(fileName);
+        }
+    }
+
+    /// <summary>
+    /// The guard is about a whole original with nothing in it - a single blank line in an otherwise
+    /// normal original is ordinary content and must still be saved.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task SaveSubtitleOriginal_WithOneEmptyLine_StillWritesTheFile()
+    {
+        var (window, vm) = CreateMainViewModel();
+        var fileName = Path.Combine(Path.GetTempPath(), $"se-original-{Guid.NewGuid():N}.srt");
+        await File.WriteAllTextAsync(fileName, "1\r\n00:00:00,000 --> 00:00:02,000\r\nOld\r\n\r\n");
+
+        try
+        {
+            AddLine(vm, "Vertaalde regel een", "Source line one", 0, 2000);
+            AddLine(vm, "Vertaalde regel twee", string.Empty, 2000, 4000);
+            vm.ShowColumnOriginalText = true;
+            vm.IsOriginalReadOnly = false;
+            SetPrivateField(vm, "_subtitleFileNameOriginal", fileName);
+
+            var saved = await InvokeSaveSubtitleOriginal(vm, isAutoSave: false);
+
+            Assert.True(saved);
+            Assert.Contains("Source line one", await File.ReadAllTextAsync(fileName));
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+            File.Delete(fileName);
+        }
+    }
+
+    /// <summary>
+    /// With a read-only original open, the translate dialog is fed the working subtitle only - the
+    /// display-only rows are not part of it. They are dropped before the translations are matched
+    /// with the rows by index, so no row takes another row's translation and no reference row has
+    /// its text overwritten with nothing.
+    /// </summary>
+    [AvaloniaFact]
+    public void RemoveReferenceOnlyRows_LeavesTheRowsAlignedWithTheTranslatedSubtitle()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Translated one", string.Empty, 0, 2000);
+            AddLine(vm, "Translated two", string.Empty, 4000, 6000);
+
+            var reference = new Subtitle();
+            reference.Paragraphs.Add(new Paragraph("Reference one", 0, 2000));
+            reference.Paragraphs.Add(new Paragraph("Reference only - no translation", 2000, 4000));
+            reference.Paragraphs.Add(new Paragraph("Reference two", 4000, 6000));
+            var match = ImportOriginalHelper.MatchOriginalLines(vm.Subtitles, reference);
+            InvokeImportOriginalSubtitle(vm, "reference.srt", reference, match, isReadOnly: true);
+
+            // What the translate dialog was handed - the display-only row is not in it.
+            var translated = vm.GetUpdateSubtitle();
+            Assert.Equal(2, translated.Paragraphs.Count);
+            Assert.Equal(3, vm.Subtitles.Count);
+
+            InvokeRemoveReferenceOnlyRows(vm);
+
+            Assert.Equal(translated.Paragraphs.Count, vm.Subtitles.Count);
+            Assert.Equal(
+                new[] { "Translated one", "Translated two" },
+                vm.Subtitles.Select(p => p.Text));
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    private static (Window Window, MainViewModel Vm) CreateMainViewModel()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1200, Height = 800 };
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        return (window, (MainViewModel)view.DataContext!);
+    }
+
+    private static SubtitleLineViewModel AddLine(
+        MainViewModel vm, string text, string originalText, int startMs = 0, int endMs = 2000)
+    {
+        var line = new SubtitleLineViewModel(new Paragraph(text, startMs, endMs), null!)
+        {
+            OriginalText = originalText,
+            Number = vm.Subtitles.Count + 1,
+        };
+
+        vm.Subtitles.Add(line);
+        return line;
+    }
+
+    private static void CloseWindow(Window window, MainViewModel vm)
+    {
+        foreach (var ownedWindow in window.OwnedWindows.ToArray())
+        {
+            ownedWindow.Close();
+        }
+
+        window.Closing -= vm.OnClosing;
+        if (window.IsVisible)
+        {
+            window.Close();
+        }
+    }
+
+    private static void InvokeCaptureOriginalFromTranslatedRows(MainViewModel vm)
+    {
+        Invoke(vm, "CaptureOriginalFromTranslatedRows");
+    }
+
+    private static void InvokeRemoveReferenceOnlyRows(MainViewModel vm)
+    {
+        Invoke(vm, "RemoveReferenceOnlyRows");
+    }
+
+    private static void InvokeSetSubtitles(MainViewModel vm, Subtitle subtitle, Subtitle subtitleOriginal)
+    {
+        var method = typeof(MainViewModel).GetMethod(
+                         "SetSubtitles",
+                         BindingFlags.Instance | BindingFlags.NonPublic,
+                         null,
+                         new[] { typeof(Subtitle), typeof(Subtitle) },
+                         null)
+                     ?? throw new InvalidOperationException("SetSubtitles(Subtitle, Subtitle) not found");
+
+        method.Invoke(vm, new object?[] { subtitle, subtitleOriginal });
+    }
+
+    private static void InvokeImportOriginalSubtitle(
+        MainViewModel vm, string fileName, Subtitle subtitle, ImportOriginalHelper.OriginalMatch? match, bool isReadOnly)
+    {
+        var method = typeof(MainViewModel).GetMethod(
+                         "ImportOriginalSubtitle", BindingFlags.Instance | BindingFlags.NonPublic)
+                     ?? throw new InvalidOperationException("ImportOriginalSubtitle not found");
+
+        method.Invoke(vm, new object?[] { 0, fileName, subtitle, match, isReadOnly });
+    }
+
+    private static async Task<bool> InvokeSaveSubtitleOriginal(MainViewModel vm, bool isAutoSave)
+    {
+        var method = typeof(MainViewModel).GetMethod(
+                         "SaveSubtitleOriginal", BindingFlags.Instance | BindingFlags.NonPublic)
+                     ?? throw new InvalidOperationException("SaveSubtitleOriginal not found");
+
+        return await (Task<bool>)method.Invoke(vm, new object[] { isAutoSave })!;
+    }
+
+    private static void Invoke(MainViewModel vm, string name)
+    {
+        var method = typeof(MainViewModel).GetMethod(name, BindingFlags.Instance | BindingFlags.NonPublic)
+                     ?? throw new InvalidOperationException($"{name} not found");
+
+        method.Invoke(vm, null);
+    }
+
+    private static void SetPrivateField(MainViewModel vm, string name, object value)
+    {
+        GetField(name).SetValue(vm, value);
+    }
+
+    private static FieldInfo GetField(string name)
+    {
+        return typeof(MainViewModel).GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)
+               ?? throw new InvalidOperationException($"Field not found: {name}");
+    }
+}


### PR DESCRIPTION
Fixes #14091.

### What happens today

A translation made from the current rows (auto-translate, translate via copy/paste, "make empty translation") does three things: it moves the pre-translation text into the rows' *original* column, points `_subtitleFileNameOriginal` at the subtitle it was translated from, and marks that original **editable**. What it never did is put the text into `_subtitleOriginal` itself.

So the original existed only in the row view-models. Any wholesale rebuild - `SetSubtitles(subtitle)` with no original, which most tools go through - re-created the rows with an empty original column. And because `CommandFileSave` saves the original too, serialized from those rows, the next Ctrl+S wrote a file with numbers, time codes and **no text at all** over the subtitle the user had translated from. That is the "the original got erased, it has only the line numbers but no text" in the issue.

With a read-only original open it broke earlier still: the translate dialog is handed `GetUpdateSubtitle()`, which leaves the display-only reference rows out, so matching the results back onto `Subtitles` by index shifted every row after the first reference row - and gave the reference rows `OriginalText = ""`.

### Changes

- Fold the pre-translation text into the original subtitle (`CaptureOriginalFromTranslatedRows`) in all three paths, so a rebuild restores the column instead of clearing it.
- Drop the display-only rows before matching translations onto rows by index.
- Translate via copy/paste fills the original column for skipped rows too - they keep their source text, and a blank line there would have been written over the source file.
- Leave the translation untitled when the target name would equal the source file's (`movie.nl.srt` translated to Dutch): otherwise both saves land on the same path and the second wipes the first.
- Refuse to save an original with no text in any line, so a blank column can never overwrite a real subtitle file.

### Tests

`tests/UI/Features/Main/MainTranslationOriginalTests.cs` - 5 tests: the capture, that a rebuild keeps the column, the empty-original save guard (and that a single blank line is still saved normally), and that dropping the reference rows leaves the rows aligned with what the dialog translated. Full UI suite green.

### Not included

The reporter also asks for the original to default to read-only after a translation (#14091 comment). That is a behavior change - "remove translation" and editing the original column both depend on it being editable - so it is left for a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)