### PR TITLE
Normalize strings: fold typographic punctuation to ASCII (#14092)

### DIFF
--- a/src/libse/Forms/FixCommonErrors/NormalizeStrings.cs
+++ b/src/libse/Forms/FixCommonErrors/NormalizeStrings.cs
@@ -31,11 +31,37 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
 
                         .Replace('\u2043', '-') // ⁃ Hyphen bullet (\u2043)
                         .Replace('\u2010', '-') // ‐ Hyphen (\u2010)
+                        .Replace('\u2011', '-') // ‑ Non-breaking hyphen (\u2011)
                         .Replace('\u2012', '-') // ‒ Figure dash (\u2012)
                         .Replace('\u2013', '-') // – En dash (\u2013)
                                                 //.Replace('\u2014', '-') // — Em dash (\u2014) - we keep em dash
                         .Replace('\u2015', '\u2014') // ― Horizontal bar (\u2015)
+
+                        // Machine translation hands back typographic punctuation the source never
+                        // had - DeepL alone answers plain ASCII input with curly quotes, en dashes
+                        // and a one-character ellipsis (issue #14092).
+                        .Replace("\u2026", "...") // … Horizontal ellipsis (\u2026)
+                        .Replace('\u2032', '\'') // ′ Prime (\u2032)
+                        .Replace('\u2033', '"') // ″ Double prime (\u2033)
                     ;
+
+                // Quotation marks are the language-specific part of this: „…“ and ‚…‘ are how German
+                // and several of its neighbours quote, so replacing them there would take the
+                // language's own punctuation away rather than normalize anything.
+                var lowQuoteLanguages = new[] { "de", "cs", "sk", "pl", "sl", "hr", "sr", "hu", "lt", "et", "ro", "is", "bg", "ka", "sq" };
+                if (!lowQuoteLanguages.Contains(twoLetterLanguageCode))
+                {
+                    text = text
+                            .Replace('\u2018', '\'') // ‘ Left single quotation mark (\u2018)
+                            .Replace('\u2019', '\'') // ’ Right single quotation mark (\u2019) - the typographic apostrophe
+                            .Replace('\u201A', '\'') // ‚ Single low-9 quotation mark (\u201A)
+                            .Replace('\u201B', '\'') // ‛ Single high-reversed-9 quotation mark (\u201B)
+                            .Replace('\u201C', '"') // “ Left double quotation mark (\u201C)
+                            .Replace('\u201D', '"') // ” Right double quotation mark (\u201D)
+                            .Replace('\u201E', '"') // „ Double low-9 quotation mark (\u201E)
+                            .Replace('\u201F', '"') // ‟ Double high-reversed-9 quotation mark (\u201F)
+                        ;
+                }
 
                 var cyrillicLanguages = new[] { "ru" };
                 if (!cyrillicLanguages.Contains(twoLetterLanguageCode))

--- a/tests/libse/Forms/FixCommonErrors/NormalizeStringsTest.cs
+++ b/tests/libse/Forms/FixCommonErrors/NormalizeStringsTest.cs
@@ -1,0 +1,88 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Forms.FixCommonErrors;
+
+namespace LibSETests.Forms.FixCommonErrors;
+
+public class NormalizeStringsTest
+{
+    private static string Fix(string input, string language = "en")
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph(input, 0, 2000));
+        subtitle.Renumber();
+        new NormalizeStrings().Fix(subtitle, new EmptyFixCallback { Language = language });
+        return subtitle.Paragraphs[0].Text;
+    }
+
+    // Issue #14092: machine translation answers plain ASCII input with typographic punctuation.
+    [Fact]
+    public void ReplacesCurlyQuotesWithStraightOnes()
+    {
+        Assert.Equal("He said \"no way\" and left.", Fix("He said “no way” and left."));
+        Assert.Equal("It's a so-called 'friend'.", Fix("It’s a so-called ‘friend’."));
+    }
+
+    [Fact]
+    public void ReplacesTheOneCharacterEllipsisWithThreeDots()
+    {
+        Assert.Equal("Wait... what?", Fix("Wait… what?"));
+    }
+
+    [Fact]
+    public void ReplacesPrimesWithQuotes()
+    {
+        Assert.Equal("6'2\" tall", Fix("6′2″ tall"));
+    }
+
+    [Fact]
+    public void ReplacesDashesWithHyphens()
+    {
+        Assert.Equal("Books and comics - the whole lot.", Fix("Books and comics – the whole lot."));
+        Assert.Equal("A non-breaking hyphen.", Fix("A non‑breaking hyphen."));
+    }
+
+    /// <summary>
+    /// German and several of its neighbours quote with „…“ and ‚…‘ - those are the language's own
+    /// quotation marks, not something to normalize away.
+    /// </summary>
+    [Fact]
+    public void KeepsTheQuotationMarksOfLanguagesThatUseLowQuotes()
+    {
+        const string german = "Er sagte „Das geht nicht“ und ging.";
+        Assert.Equal(german, Fix(german, "de"));
+
+        const string polish = "To tak zwany ‚przyjaciel‘.";
+        Assert.Equal(polish, Fix(polish, "pl"));
+    }
+
+    /// <summary>The rest of the rule still applies to those languages.</summary>
+    [Fact]
+    public void StillNormalizesDashesAndEllipsisForLowQuoteLanguages()
+    {
+        Assert.Equal("Bücher und Comics - alles.", Fix("Bücher und Comics – alles.", "de"));
+        Assert.Equal("Warte... was?", Fix("Warte… was?", "de"));
+    }
+
+    /// <summary>
+    /// Verbatim DeepL output for English input that had none of these characters: "It's a so-called
+    /// 'friend' - nothing more." / "We took all our books and comics - the whole lot."
+    /// </summary>
+    [Fact]
+    public void NormalizesRealDeepLOutput()
+    {
+        Assert.Equal(
+            "Het is een zogenaamde 'vriend' - meer niet.",
+            Fix("Het is een zogenaamde \u2018vriend\u2019 \u2013 meer niet.", "nl"));
+
+        Assert.Equal(
+            "We hebben al onze boeken en stripboeken meegenomen - alles.",
+            Fix("We hebben al onze boeken en stripboeken meegenomen \u2013 alles.", "nl"));
+    }
+
+    [Fact]
+    public void LeavesPlainTextAlone()
+    {
+        const string text = "Nothing to fix here - really.";
+        Assert.Equal(text, Fix(text));
+    }
+}


### PR DESCRIPTION
Addresses #14092.

The reporter gets curly quotes, dashes and one-character ellipses out of a DeepL translation of text that had none of them. That is DeepL's own output - I A/B tested `preserve_formatting` against the free API and it makes no difference at all:

```
pf=0: 'Het is een zogenaamde ‘vriend’ – meer niet.'   'Wacht even... wat?'
pf=1: 'Het is een zogenaamde ‘vriend’ – meer niet.'   'Wacht even... wat?'
```

There is no API knob for it, so the fix belongs on our side. "Normalize strings" in Fix common errors already turned the en dash into a hyphen - this extends it to the rest of what comes back:

- curly single/double quotes and the low-9 forms → straight quotes; the typographic apostrophe → `'`
- horizontal ellipsis → three dots
- prime/double prime → `'` and `"`, non-breaking hyphen → `-`

**The quotes are language specific.** German and its neighbours (`de cs sk pl sl hr sr hu lt et ro is bg ka sq`) quote with „…“ and ‚…', so replacing those would strip the language's own punctuation rather than normalize it. Those languages keep their quotation marks and get everything else. Dutch is deliberately not on the list - the reporter is Dutch and it is the curly quotes he wants gone.

Worth a look before merging: the apostrophe replacement (`’` → `'`) is the broadest part of this. It is what subtitle guidelines ask for and the rule is opt-in per checkbox, but it fires on every subtitle whose author preferred the typographic form.

### Tests

`tests/libse/Forms/FixCommonErrors/NormalizeStringsTest.cs` - 8 tests, including two on verbatim DeepL output. Full libse (1485) and seconv (383) suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)