### PR TITLE
Clone each line's voice from the video with Qwen3 TTS too (#14096)

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
@@ -48,7 +48,16 @@ public class Qwen3TtsCrispAsr : ITtsEngine
     public bool HasModel => true;
     public bool HasKeyFile => false;
     public bool SupportsVoiceCloning => true;
-    public bool SupportsPerLineVoiceCloning => false;
+
+    /// <summary>
+    /// True only while the Base (Voice clone) model is picked, and true at all only because this
+    /// backend takes the reference per request: <c>voice</c> is resolved against --voice-dir on
+    /// every call, so a reference that changes per line costs a file copy rather than a server
+    /// restart and a model reload. VoiceDesign and CustomVoice ignore reference WAVs outright,
+    /// so there the offer would be a promise the model cannot keep - the model combo is what
+    /// switches this on, and it re-pulls the voice list on every change.
+    /// </summary>
+    public bool SupportsPerLineVoiceCloning => IsCloneModel(null);
 
     public const string ModelKeyVoiceDesign = "1.7B VoiceDesign";
     public const string ModelKeyCustomVoice = "1.7B CustomVoice";
@@ -261,6 +270,10 @@ public class Qwen3TtsCrispAsr : ITtsEngine
             Directory.CreateDirectory(voicesFolder);
         }
 
+        // First: a crashed run can leave per-line clone references behind, and every pass below
+        // would otherwise treat them as the user's own voices - seeding would think the folder
+        // is already populated, and the transcript pass would rewrite their sidecars.
+        ClearStagedPerLineReferencesOnce(voicesFolder);
         SeedVoicesFromQwen3TtsCppIfEmpty(voicesFolder);
         NormalizeVoiceSampleRatesOnce(voicesFolder);
         NormalizeVoiceTranscriptsOnce(voicesFolder);
@@ -270,6 +283,153 @@ public class Qwen3TtsCrispAsr : ITtsEngine
     private static bool _voiceSeedAttempted;
     private static bool _voiceSampleRatesNormalized;
     private static bool _voiceTranscriptsNormalized;
+    private static bool _stagedPerLineReferencesCleared;
+
+    /// <summary>
+    /// File-name prefix of the reference clips the per-line voice clone stages in the voices
+    /// folder. The name is reserved: a file called this is the current run's reference for one
+    /// subtitle line, never a voice the user imported, so it is hidden from the voice list and
+    /// cleared between runs.
+    /// </summary>
+    public const string PerLineReferencePrefix = "se-per-line-";
+
+    /// <summary>True when <paramref name="fileName"/> is a reference staged for one line.</summary>
+    public static bool IsStagedPerLineReference(string fileName) =>
+        Path.GetFileName(fileName).StartsWith(PerLineReferencePrefix, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Copies one per-line cloning reference into the voices folder and returns the staged WAV,
+    /// or null when the clip cannot be used as a reference.
+    /// </summary>
+    /// <remarks>
+    /// A copy is needed because the backend resolves the request's <c>voice</c> as a bare name
+    /// inside --voice-dir; handing it the absolute path of a clip cut into a temp folder skips
+    /// the ref-text sidecar and fails. It is a plain copy and not an ffmpeg pass because the
+    /// clips are cut as 24 kHz mono PCM16 already - exactly what the Base backend demands.
+    ///
+    /// Null when there is no usable transcript beside the clip: the backend answers a reference
+    /// without ref-text with "ref-text not set" (HTTP 500), so the caller is better off falling
+    /// back to an ordinary voice for that line than failing it.
+    /// </remarks>
+    public static string? StagePerLineReference(string clipFileName)
+    {
+        // The voices folder is resolved only once the clip is known to be usable: GetSetVoicesFolder
+        // runs the one-time seeding and resampling passes through ffmpeg, which is wasted work for a
+        // line that is about to fall back to an ordinary voice anyway.
+        return ReadReferenceTranscript(clipFileName) == null
+            ? null
+            : StagePerLineReferenceIn(clipFileName, GetSetVoicesFolder());
+    }
+
+    /// <summary>
+    /// <see cref="StagePerLineReference"/> with the destination spelled out, so the copy can be
+    /// exercised without writing into the user's real voices folder.
+    /// </summary>
+    internal static string? StagePerLineReferenceIn(string clipFileName, string voicesFolder)
+    {
+        try
+        {
+            var transcript = ReadReferenceTranscript(clipFileName);
+            if (transcript == null)
+            {
+                return null;
+            }
+
+            // An exported session carries the staged name, so re-staging it on import would
+            // otherwise pile a second prefix on top - once per round trip.
+            var baseName = Path.GetFileNameWithoutExtension(clipFileName);
+            if (baseName.StartsWith(PerLineReferencePrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                baseName = baseName.Substring(PerLineReferencePrefix.Length);
+            }
+
+            var stagedFileName = Path.Combine(voicesFolder, PerLineReferencePrefix + baseName + ".wav");
+
+            Directory.CreateDirectory(voicesFolder);
+            File.Copy(clipFileName, stagedFileName, overwrite: true);
+            File.WriteAllText(Path.ChangeExtension(stagedFileName, ".txt"), transcript);
+            return stagedFileName;
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, $"Qwen3 TTS (CrispASR): staging the per-line reference '{clipFileName}' failed");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// What is spoken in a per-line reference clip, or null when the clip is missing or carries no
+    /// usable transcript - the backend answers a reference without ref-text with "ref-text not set"
+    /// (HTTP 500), so such a clip is not a reference and the line falls back instead.
+    /// </summary>
+    private static string? ReadReferenceTranscript(string clipFileName)
+    {
+        if (string.IsNullOrEmpty(clipFileName) || !File.Exists(clipFileName))
+        {
+            return null;
+        }
+
+        var transcript = TryReadUsableTranscript(clipFileName);
+        if (string.IsNullOrWhiteSpace(transcript))
+        {
+            Se.WriteToolsLog(
+                $"Qwen3 TTS (CrispASR): no usable transcript beside '{clipFileName}' - not cloning this line");
+            return null;
+        }
+
+        return transcript;
+    }
+
+    /// <summary>
+    /// Removes every staged per-line reference, leaving the user's imported voices alone. Called
+    /// when a per-line run starts, so a run over a shorter subtitle cannot leave the previous
+    /// run's extra lines lying in the voices folder.
+    /// </summary>
+    public static void ClearStagedPerLineReferences() => DeleteStagedPerLineReferences(GetSetVoicesFolder());
+
+    /// <summary>
+    /// <see cref="ClearStagedPerLineReferences"/> with the folder spelled out - the test seam that
+    /// matches <see cref="StagePerLineReferenceIn"/>.
+    /// </summary>
+    internal static void ClearStagedPerLineReferencesIn(string voicesFolder) =>
+        DeleteStagedPerLineReferences(voicesFolder);
+
+    private static void ClearStagedPerLineReferencesOnce(string voicesFolder)
+    {
+        if (_stagedPerLineReferencesCleared)
+        {
+            return;
+        }
+        _stagedPerLineReferencesCleared = true;
+        DeleteStagedPerLineReferences(voicesFolder);
+    }
+
+    private static void DeleteStagedPerLineReferences(string voicesFolder)
+    {
+        try
+        {
+            if (!Directory.Exists(voicesFolder))
+            {
+                return;
+            }
+
+            foreach (var file in Directory.GetFiles(voicesFolder, PerLineReferencePrefix + "*"))
+            {
+                try
+                {
+                    File.Delete(file);
+                }
+                catch
+                {
+                    // A reference still open (the server may be reading it) is left for next time.
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, "Qwen3 TTS (CrispASR): clearing the staged per-line references failed");
+        }
+    }
 
     /// <summary>
     /// One-time best-effort seeding of reference voices from the existing qwen3-tts.cpp engine's
@@ -292,7 +452,7 @@ public class Qwen3TtsCrispAsr : ITtsEngine
 
         try
         {
-            if (Directory.EnumerateFiles(voicesFolder, "*.wav").Any())
+            if (Directory.EnumerateFiles(voicesFolder, "*.wav").Any(f => !IsStagedPerLineReference(f)))
             {
                 return;
             }
@@ -706,6 +866,13 @@ public class Qwen3TtsCrispAsr : ITtsEngine
         {
             foreach (var file in Directory.GetFiles(voicesFolder, "*.wav"))
             {
+                // The per-line clone's own references live here too (the backend reads them from
+                // nowhere else); they belong to one line of one run, not in a voice combo.
+                if (IsStagedPerLineReference(file))
+                {
+                    continue;
+                }
+
                 var name = Path.GetFileNameWithoutExtension(file).Replace('_', ' ');
                 result.Add(new Voice(new Qwen3TtsVoice(name, file)));
             }

--- a/src/ui/Features/Video/TextToSpeech/PerLineVoiceClone.cs
+++ b/src/ui/Features/Video/TextToSpeech/PerLineVoiceClone.cs
@@ -275,6 +275,18 @@ public static class PerLineVoiceClone
         return engine switch
         {
             OmniVoiceTtsCpp => new Voice(new OmniVoice(name, clipFileName)),
+
+            // The qwen3-tts backend reads references from its own --voice-dir and nowhere else,
+            // so the clip is copied in there first and FilePath points at the copy - that is the
+            // lookup key, since Speak sends the file's bare name as the request's `voice`. The
+            // name stays free to be the friendly one, which is how an imported session keeps the
+            // voice name a line was generated with. A clip that cannot be staged (no transcript
+            // beside it) is a null here, i.e. that one line falls back to an ordinary voice
+            // instead of failing the run.
+            Qwen3TtsCrispAsr => Qwen3TtsCrispAsr.StagePerLineReference(clipFileName) is { } staged
+                ? new Voice(new Qwen3TtsVoice(name, staged))
+                : null,
+
             _ => null,
         };
     }
@@ -292,6 +304,31 @@ public static class PerLineVoiceClone
     public static string? TryGetReferenceClip(Voice? voice) => voice?.EngineVoice switch
     {
         OmniVoice omniVoice when !string.IsNullOrEmpty(omniVoice.FilePath) => omniVoice.FilePath,
+
+        // The staged copy in the voices folder, which is the only reference this engine ever
+        // speaks from. Exporting it (with its .txt sidecar) is what lets an imported session be
+        // re-dubbed on a machine that no longer has the video.
+        Qwen3TtsVoice qwen3Voice when !string.IsNullOrEmpty(qwen3Voice.FilePath) => qwen3Voice.FilePath,
+
         _ => null,
     };
+
+    /// <summary>
+    /// Clears what a previous run staged inside an engine's own folders, and is called as a
+    /// per-line run starts.
+    /// </summary>
+    /// <remarks>
+    /// Engines that can only read a reference from their voices folder keep a copy of every
+    /// line's clip there (see <see cref="MakeVoiceForClip"/>). Cutting the clips into a fresh
+    /// folder each run - which the caller does - says nothing about those copies, so a run over
+    /// a shorter subtitle than the last would leave the previous run's extra lines behind.
+    /// Engines that take the clip's own path need nothing cleared and are simply not listed.
+    /// </remarks>
+    public static void ResetStagedReferences(ITtsEngine? engine)
+    {
+        if (engine is Qwen3TtsCrispAsr)
+        {
+            Qwen3TtsCrispAsr.ClearStagedPerLineReferences();
+        }
+    }
 }

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -2946,7 +2946,9 @@ public partial class TextToSpeechViewModel : ObservableObject
         }
 
         // A fresh folder per run: the clips of a previous run belong to whatever the subtitle
-        // looked like then, and the review window still points at the current run's files.
+        // looked like then, and the review window still points at the current run's files. The
+        // same goes for the copies an engine keeps in its own voices folder.
+        PerLineVoiceClone.ResetStagedReferences(engine);
         var clipFolder = Path.Combine(_waveFolder, "clone-references");
         try
         {

--- a/tests/UI/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsrPerLineCloneTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsrPerLineCloneTests.cs
@@ -1,0 +1,186 @@
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// Per-line voice cloning on Qwen3 (CrispASR): which model it is offered for, and what "staging"
+/// a line's reference has to leave in the voices folder for the backend to find it.
+/// </summary>
+/// <remarks>
+/// The backend resolves a request's <c>voice</c> as a bare name inside --voice-dir and auto-loads
+/// the matching <c>.txt</c> as ref-text, so a reference that is not in that folder - or has no
+/// sidecar - is not a reference at all. That is the whole reason staging exists.
+/// </remarks>
+[Collection(TtsSettingsCollection.Name)]
+public class Qwen3TtsCrispAsrPerLineCloneTests
+{
+    [Theory]
+    [InlineData(Qwen3TtsCrispAsr.ModelKeyClone, true)]
+    [InlineData(Qwen3TtsCrispAsr.ModelKeyVoiceDesign, false)]
+    [InlineData(Qwen3TtsCrispAsr.ModelKeyCustomVoice, false)]
+    public void OnlyTheCloneModelOffersIt(string modelKey, bool expected)
+    {
+        // VoiceDesign speaks from the instruction and CustomVoice from a fixed speaker list -
+        // both ignore a reference WAV, so offering "Clone from video" there would do nothing.
+        using var _ = new Qwen3TtsCrispAsrModelScope(modelKey);
+
+        Assert.Equal(expected, new Qwen3TtsCrispAsr().SupportsPerLineVoiceCloning);
+        Assert.Equal(expected, PerLineVoiceClone.CanBeOffered(new Qwen3TtsCrispAsr(), "/videos/movie.mkv"));
+    }
+
+    [Fact]
+    public void StagingCopiesTheClipAndItsTranscriptIntoTheVoicesFolder()
+    {
+        using var clips = new TempFolder();
+        using var voices = new TempFolder();
+        var clip = clips.WriteClip("line-0007", "Nothing travels faster than light.");
+
+        var staged = Qwen3TtsCrispAsr.StagePerLineReferenceIn(clip, voices.Path);
+
+        Assert.NotNull(staged);
+        Assert.Equal(voices.Path, Path.GetDirectoryName(staged));
+        // The name is what goes into the request, so it has to survive as a file name here.
+        Assert.True(File.Exists(staged));
+        Assert.Equal("Nothing travels faster than light.", File.ReadAllText(Path.ChangeExtension(staged!, ".txt")));
+        Assert.True(Qwen3TtsCrispAsr.IsStagedPerLineReference(staged!));
+    }
+
+    [Fact]
+    public void AClipWithNoTranscriptIsNotStagedAtAll()
+    {
+        // The backend answers a reference without ref-text with an HTTP 500, so the line is
+        // better off falling back to an ordinary voice - which is what null means to the caller.
+        using var clips = new TempFolder();
+        using var voices = new TempFolder();
+        var clip = clips.WriteClip("line-0008", transcript: null);
+
+        Assert.Null(Qwen3TtsCrispAsr.StagePerLineReferenceIn(clip, voices.Path));
+        Assert.Empty(Directory.GetFiles(voices.Path));
+    }
+
+    [Fact]
+    public void ClearingRemovesTheStagedReferencesAndLeavesImportedVoicesAlone()
+    {
+        // A run over a shorter subtitle than the last must not inherit the extra lines, but the
+        // user's own imports live in the same folder and are not ours to delete.
+        using var clips = new TempFolder();
+        using var voices = new TempFolder();
+        File.WriteAllText(Path.Combine(voices.Path, "ada.wav"), "imported");
+        File.WriteAllText(Path.Combine(voices.Path, "ada.txt"), "Imported voice.");
+        Qwen3TtsCrispAsr.StagePerLineReferenceIn(clips.WriteClip("line-0001", "One."), voices.Path);
+        Qwen3TtsCrispAsr.StagePerLineReferenceIn(clips.WriteClip("line-0002", "Two."), voices.Path);
+
+        Qwen3TtsCrispAsr.ClearStagedPerLineReferencesIn(voices.Path);
+
+        Assert.Equal(
+            new[] { "ada.txt", "ada.wav" },
+            Directory.GetFiles(voices.Path).Select(Path.GetFileName).Order().ToArray());
+    }
+
+    [Fact]
+    public void AStagedReferenceIsNotMistakenForAnImportedVoice()
+    {
+        Assert.True(Qwen3TtsCrispAsr.IsStagedPerLineReference("/voices/" + Qwen3TtsCrispAsr.PerLineReferencePrefix + "line-0003.wav"));
+        Assert.False(Qwen3TtsCrispAsr.IsStagedPerLineReference("/voices/ada.wav"));
+    }
+
+    [Fact]
+    public void ReStagingAnExportedReferenceDoesNotPileUpPrefixes()
+    {
+        // An exported session carries the staged name, and importing it stages it again. Without
+        // stripping, every round trip would add another prefix to the file name.
+        using var clips = new TempFolder();
+        using var voices = new TempFolder();
+        var exported = clips.WriteClip(Qwen3TtsCrispAsr.PerLineReferencePrefix + "line-0004", "Once more.");
+
+        var staged = Qwen3TtsCrispAsr.StagePerLineReferenceIn(exported, voices.Path);
+
+        Assert.Equal(
+            Qwen3TtsCrispAsr.PerLineReferencePrefix + "line-0004.wav",
+            Path.GetFileName(staged));
+    }
+
+    [Fact]
+    public void TheVoiceIsNamedForTheLineButSpeaksFromTheStagedCopy()
+    {
+        // The two are separate on purpose: Speak sends the FilePath's bare name as the request's
+        // `voice` (it is the --voice-dir lookup key), which leaves the name free to be the one
+        // the row shows - so an imported session keeps the name a line was generated with.
+        using var clips = new TempFolder();
+        using var voices = new TempFolder();
+        var clip = clips.WriteClip("line-0009", "Two roads diverged in a wood.");
+
+        var staged = Qwen3TtsCrispAsr.StagePerLineReferenceIn(clip, voices.Path);
+        var voice = new Voice(new Qwen3TtsVoice("Morgan", staged!));
+
+        var engineVoice = Assert.IsType<Qwen3TtsVoice>(voice.EngineVoice);
+        Assert.Equal(staged, engineVoice.FilePath);
+        Assert.Equal("Morgan", engineVoice.Voice);
+
+        // Export and regenerate both find the recording through this, or an imported session
+        // could never be re-dubbed.
+        Assert.Equal(staged, PerLineVoiceClone.TryGetReferenceClip(voice));
+    }
+
+    [Fact]
+    public void AVoiceWithNoRecordingHasNoReferenceToExport()
+    {
+        // VoiceDesign and CustomVoice voices carry no file - there is nothing to copy for them.
+        Assert.Null(PerLineVoiceClone.TryGetReferenceClip(new Voice(new Qwen3TtsVoice("vivian", string.Empty))));
+    }
+
+    private sealed class TempFolder : IDisposable
+    {
+        public string Path { get; } =
+            System.IO.Path.Combine(System.IO.Path.GetTempPath(), "SeQwen3PerLine_" + Guid.NewGuid().ToString("N"));
+
+        public TempFolder() => Directory.CreateDirectory(Path);
+
+        public string WriteClip(string name, string? transcript)
+        {
+            var wav = System.IO.Path.Combine(Path, name + ".wav");
+            File.WriteAllText(wav, "not really a wav, and nothing here reads it");
+            if (transcript != null)
+            {
+                File.WriteAllText(System.IO.Path.ChangeExtension(wav, ".txt"), transcript);
+            }
+
+            return wav;
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(Path, true);
+            }
+            catch
+            {
+                // temp folder - nothing depends on it being gone
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Restores the saved Qwen3 (CrispASR) model after a test picks one, since the engine reads it
+/// from the shared settings rather than taking it as an argument.
+/// </summary>
+internal sealed class Qwen3TtsCrispAsrModelScope : IDisposable
+{
+    private readonly string _original;
+
+    public Qwen3TtsCrispAsrModelScope(string modelKey)
+    {
+        _original = Se.Settings.Video.TextToSpeech.Qwen3TtsCrispAsrModel;
+        Se.Settings.Video.TextToSpeech.Qwen3TtsCrispAsrModel = modelKey;
+    }
+
+    public void Dispose()
+    {
+        Se.Settings.Video.TextToSpeech.Qwen3TtsCrispAsrModel = _original;
+    }
+}

--- a/tests/UI/Features/Video/TextToSpeech/PerLineVoiceCloneTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/PerLineVoiceCloneTests.cs
@@ -133,6 +133,15 @@ public class PerLineVoiceCloneTests
     }
 
     [Fact]
+    public void AQwen3ClipThatCannotBeStagedFallsBackInsteadOfCloning()
+    {
+        // Qwen3 (CrispASR) speaks only from a copy inside its own voices folder, so a clip it
+        // cannot stage - here one that is not there at all - has to come back as null and let the
+        // caller fall back, rather than pointing the engine at a file the backend cannot resolve.
+        Assert.Null(PerLineVoiceClone.MakeVoiceForClip(new Qwen3TtsCrispAsr(), "/tmp/refs/not-a-clip.wav"));
+    }
+
+    [Fact]
     public void AnImportedClipKeepsTheVoiceNameItWasExportedWith()
     {
         // The exported clip may have been renamed to avoid a collision in the export folder; the


### PR DESCRIPTION
Closes #14096.

"Clone from video" — the pseudo-voice that dubs every line in the voice heard in the video at that line — has been OmniVoice-only since it was built. The gate is `ITtsEngine.SupportsPerLineVoiceCloning`, and an engine qualifies only if it takes the cloning reference **per synthesis call**; the CrispASR engines that read it from the startup `--voice` flag would reload the model per line.

Qwen3 TTS (CrispASR) qualifies on the Base (`1.7B Voice clone`) model: the request's `voice` is resolved against `--voice-dir` on every call. #14096 asks for it there, and reports Qwen3 as the cleaner of the two engines ("OmniVoice … often isn't clean and cuts off words").

## Staging

What the backend will *not* do is read a reference from anywhere but that folder — an absolute path skips the ref-text sidecar and fails. So each line's clip is **staged**: copied into the voices folder under a reserved `se-per-line-` prefix, with the line's own text written beside it as the `.txt` ref-text. The clips are already cut as 24 kHz mono PCM16, which is exactly what the Base backend demands, so it is a copy and not an ffmpeg pass.

Staged references are the run's, not the user's:

- hidden from the voice list,
- ignored when deciding whether the voices folder still needs seeding,
- cleared as a per-line run starts, and swept once per session so a crashed run leaves nothing behind.

A clip with no usable transcript is not staged at all — the backend answers a reference without ref-text with an HTTP 500 — so that line falls back to an ordinary voice instead of failing the run.

## Which model it is offered on

The offer follows the model combo rather than the engine. VoiceDesign speaks from the instruction and CustomVoice from a fixed speaker list; both ignore a reference WAV, so "Clone from video" appears only on the clone model — which already re-pulls the voice list on every change.

## Round trip with #14099

Export and regenerate reach the recording through `PerLineVoiceClone.TryGetReferenceClip`, so the Qwen3 arm added here is what lets an imported session be re-dubbed on a machine that no longer has the video. The staged file name is the `--voice-dir` lookup key (Speak sends its bare name as `voice`), which leaves the voice *name* free to stay the friendly one, so a line keeps the name it was generated with. Re-staging an exported reference strips the prefix rather than stacking a second one per round trip.

## Verification

Against the real backend (`crispasr --server --backend qwen3-tts-1.7b-base`, Metal, M4):

- a reference dropped into `--voice-dir` **after** the server started resolves by bare name and synthesises in ~2 s — no restart, no model reload;
- the same reference without its `.txt` sidecar fails with exactly the `synthesis_failed` HTTP 500 the fallback exists for;
- alternating voices request-to-request stays on the same loaded model.

### End to end, on a real episode

Two adjacent lines from a Ted Lasso scene with maximally distinct speakers — Roy (adult male) and Phoebe (a child) — cut through the real `PerLineVoiceClone.CutReferenceClipsAsync` from the episode's own English subtitle track, staged with `StagePerLineReferenceIn`, and synthesised through the running backend. Both lines sit back to back, so the growth logic is clamped by its neighbours and the references really are short: **1.92 s and 2.17 s**.

Two independent checks, with the *same sentence* synthesised in both voices so content is held constant and only the reference differs:

| | median F0 | timbre vs own reference | timbre vs the other speaker |
|---|---|---|---|
| Phoebe (1.92 s ref, 271 Hz) | 258 Hz | 0.985 | 0.767 |
| Roy (2.17 s ref, 155 Hz) | 144 Hz | 0.898 | 0.796 |

(mean-MFCC cosine; F0 by autocorrelation, silence-gated.)

And an independent judge: feeding `[Roy ref, Roy clone ×3 from three different reference clips, Phoebe ref, Phoebe clone]` to CrispASR's diarizer (`moss-transcribe-diarize`) groups them **(Speaker 1) ×4 / (Speaker 2) ×2** — every clone is judged the same speaker as its own reference, and the two speakers stay apart. The ASR transcribes each clone as exactly the requested sentence, and outputs run 1.8–2.6 s for ~2 s lines, so nothing runs away and the timings suit dubbing.

Caveats from the same run, so nobody is surprised: it is zero-shot, and per-clip quality varies — one reference clip that had scene noise in it scored poorly on the crude timbre metric *as a reference*, though the clone taken from it still landed on the right speaker (0.975 against a clean reference of the same actor). Judging a single 3-second segment is also near the diarizer's own resolution; one isolated pairwise comparison disagreed while every clone still clustered correctly in the six-segment probe above.

Worth knowing (not new, and not something this PR changes): a reference whose transcript ends mid-sentence makes the model run away — an 11 s reference ending in "People say, well…" produced 36 s of audio for a one-line prompt. Per-line references do not have that problem, since the ref-text is the subtitle line and is complete by construction.

Full UI test suite green (3923 passed). New tests cover the model gate, staging and its sidecar, the no-transcript fallback, clearing without touching imported voices, the name/lookup-key split, and the prefix strip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
