### PR TITLE
DeepL: offer all the languages the API supports, and match key to host

### DIFF
--- a/src/libuilogic/AutoTranslate/DeepLTranslate.cs
+++ b/src/libuilogic/AutoTranslate/DeepLTranslate.cs
@@ -38,115 +38,280 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
                 return;
             }
 
+            _apiUrl = ResolveApiUrl(_apiUrl, _apiKey);
+
             _httpClient = HttpClientFactoryWithProxy.CreateHttpClientWithProxy();
             _httpClient.BaseAddress = new Uri(_apiUrl.Trim().TrimEnd('/'));
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", "DeepL-Auth-Key " + _apiKey.Trim());
             _formality = string.IsNullOrWhiteSpace(_formality) ? "default" : _formality.Trim();
         }
 
+        /// <summary>
+        /// Pairs the API key with the host it belongs to. A key ending in ":fx" is a free-tier key
+        /// and works only on api-free.deepl.com; a key without it works only on api.deepl.com -
+        /// the other way round DeepL answers 403 "Wrong endpoint". Only the two official hosts are
+        /// swapped, so a self-hosted or proxied URL is left exactly as the user entered it.
+        /// </summary>
+        public static string ResolveApiUrl(string apiUrl, string apiKey)
+        {
+            if (string.IsNullOrWhiteSpace(apiUrl) || string.IsNullOrWhiteSpace(apiKey))
+            {
+                return apiUrl;
+            }
+
+            const string freeHost = "api-free.deepl.com";
+            const string proHost = "api.deepl.com";
+
+            var isFreeKey = apiKey.Trim().EndsWith(":fx", StringComparison.OrdinalIgnoreCase);
+
+            if (isFreeKey && apiUrl.Contains(proHost, StringComparison.OrdinalIgnoreCase))
+            {
+                return apiUrl.Replace(proHost, freeHost, StringComparison.OrdinalIgnoreCase);
+            }
+
+            if (!isFreeKey && apiUrl.Contains(freeHost, StringComparison.OrdinalIgnoreCase))
+            {
+                return apiUrl.Replace(freeHost, proHost, StringComparison.OrdinalIgnoreCase);
+            }
+
+            return apiUrl;
+        }
+
+        /// <summary>
+        /// Mirrors GET /v2/languages?type=source (checked 2026-08-25, 101 languages). DeepL takes no
+        /// regional variant as a source - the ones listed here are the pairs SE has always offered,
+        /// and <see cref="MakeContent"/> cuts them back to the base code before sending.
+        /// To refresh: curl -H "Authorization: DeepL-Auth-Key KEY" "https://api-free.deepl.com/v2/languages?type=source"
+        /// </summary>
         public List<TranslationPair> GetSupportedSourceLanguages()
         {
             return new List<TranslationPair>
             {
-                // European Languages
+                MakeTranslationPair("Afrikaans", "af", false),
+                MakeTranslationPair("Albanian", "sq", false),
+                MakeTranslationPair("Arabic", "ar", false),
+                MakeTranslationPair("Aragonese", "an", false),
+                MakeTranslationPair("Armenian", "hy", false),
+                MakeTranslationPair("Assamese", "as", false),
+                MakeTranslationPair("Aymara", "ay", false),
+                MakeTranslationPair("Azerbaijani", "az", false),
+                MakeTranslationPair("Bashkir", "ba", false),
+                MakeTranslationPair("Basque", "eu", false),
+                MakeTranslationPair("Belarusian", "be", false),
+                MakeTranslationPair("Bengali", "bn", false),
+                MakeTranslationPair("Bosnian", "bs", false),
+                MakeTranslationPair("Breton", "br", false),
                 MakeTranslationPair("Bulgarian", "bg", false),
+                MakeTranslationPair("Burmese", "my", false),
+                MakeTranslationPair("Catalan", "ca", false),
+                MakeTranslationPair("Chinese (Simplified)", "zh-hans", false),
+                MakeTranslationPair("Chinese (Traditional)", "zh-hant", false),
+                MakeTranslationPair("Croatian", "hr", false),
                 MakeTranslationPair("Czech", "cs", false),
                 MakeTranslationPair("Danish", "da", false),
                 MakeTranslationPair("Dutch", "nl", true),
+                MakeTranslationPair("English (American)", "en-US", false),
+                MakeTranslationPair("English (British)", "en-GB", false),
+                MakeTranslationPair("Esperanto", "eo", false),
                 MakeTranslationPair("Estonian", "et", false),
                 MakeTranslationPair("Finnish", "fi", false),
                 MakeTranslationPair("French", "fr", true),
+                MakeTranslationPair("Galician", "gl", false),
+                MakeTranslationPair("Georgian", "ka", false),
                 MakeTranslationPair("German", "de", true),
                 MakeTranslationPair("Greek", "el", false),
+                MakeTranslationPair("Guarani", "gn", false),
+                MakeTranslationPair("Gujarati", "gu", false),
+                MakeTranslationPair("Haitian Creole", "ht", false),
+                MakeTranslationPair("Hausa", "ha", false),
+                MakeTranslationPair("Hebrew", "he", false),
+                MakeTranslationPair("Hindi", "hi", false),
                 MakeTranslationPair("Hungarian", "hu", false),
+                MakeTranslationPair("Icelandic", "is", false),
+                MakeTranslationPair("Igbo", "ig", false),
+                MakeTranslationPair("Indonesian", "id", false),
+                MakeTranslationPair("Irish", "ga", false),
                 MakeTranslationPair("Italian", "it", true),
+                MakeTranslationPair("Japanese", "ja", true),
+                MakeTranslationPair("Javanese", "jv", false),
+                MakeTranslationPair("Kazakh", "kk", false),
+                MakeTranslationPair("Korean", "ko", false),
+                MakeTranslationPair("Kyrgyz", "ky", false),
+                MakeTranslationPair("Latin", "la", false),
                 MakeTranslationPair("Latvian", "lv", false),
+                MakeTranslationPair("Lingala", "ln", false),
                 MakeTranslationPair("Lithuanian", "lt", false),
+                MakeTranslationPair("Luxembourgish", "lb", false),
+                MakeTranslationPair("Macedonian", "mk", false),
+                MakeTranslationPair("Malagasy", "mg", false),
+                MakeTranslationPair("Malay", "ms", false),
+                MakeTranslationPair("Malayalam", "ml", false),
+                MakeTranslationPair("Maltese", "mt", false),
+                MakeTranslationPair("Maori", "mi", false),
+                MakeTranslationPair("Marathi", "mr", false),
+                MakeTranslationPair("Mongolian", "mn", false),
+                MakeTranslationPair("Nepali", "ne", false),
                 MakeTranslationPair("Norwegian (Bokmål)", "nb", false),
+                MakeTranslationPair("Occitan", "oc", false),
+                MakeTranslationPair("Oromo", "om", false),
+                MakeTranslationPair("Pashto", "ps", false),
+                MakeTranslationPair("Persian", "fa", false),
                 MakeTranslationPair("Polish", "pl", true),
+                MakeTranslationPair("Portuguese (Brazilian)", "pt-BR", true),
+                MakeTranslationPair("Portuguese (European)", "pt-PT", true),
+                MakeTranslationPair("Punjabi", "pa", false),
+                MakeTranslationPair("Quechua", "qu", false),
                 MakeTranslationPair("Romanian", "ro", false),
                 MakeTranslationPair("Russian", "ru", true),
+                MakeTranslationPair("Sanskrit", "sa", false),
+                MakeTranslationPair("Serbian", "sr", false),
+                MakeTranslationPair("Sesotho", "st", false),
                 MakeTranslationPair("Slovak", "sk", false),
                 MakeTranslationPair("Slovenian", "sl", false),
-                MakeTranslationPair("Swedish", "sv", false),
-                MakeTranslationPair("Ukrainian", "uk", false),
-
-                // English Variants (Formality is NOT supported for English)
-                MakeTranslationPair("English (British)", "en-GB", false),
-                MakeTranslationPair("English (American)", "en-US", false),
-
-                // Spanish Variants
                 MakeTranslationPair("Spanish", "es", true),
                 MakeTranslationPair("Spanish (Latin American)", "es-419", true),
-
-                // Portuguese Variants
-                MakeTranslationPair("Portuguese (European)", "pt-PT", true),
-                MakeTranslationPair("Portuguese (Brazilian)", "pt-BR", true),
-
-                // Asian & Middle Eastern Languages
-                MakeTranslationPair("Arabic", "ar", false),
-                MakeTranslationPair("Chinese (Simplified)", "zh-hans", false),
-                MakeTranslationPair("Chinese (Traditional)", "zh-hant", false),
-                MakeTranslationPair("Hebrew", "he", false),
-                MakeTranslationPair("Indonesian", "id", false),
-                MakeTranslationPair("Japanese", "ja", true),
-                MakeTranslationPair("Korean", "ko", false),
+                MakeTranslationPair("Sundanese", "su", false),
+                MakeTranslationPair("Swahili", "sw", false),
+                MakeTranslationPair("Swedish", "sv", false),
+                MakeTranslationPair("Tagalog", "tl", false),
+                MakeTranslationPair("Tajik", "tg", false),
+                MakeTranslationPair("Tamil", "ta", false),
+                MakeTranslationPair("Tatar", "tt", false),
+                MakeTranslationPair("Telugu", "te", false),
                 MakeTranslationPair("Thai", "th", false),
+                MakeTranslationPair("Tsonga", "ts", false),
+                MakeTranslationPair("Tswana", "tn", false),
                 MakeTranslationPair("Turkish", "tr", false),
-                MakeTranslationPair("Vietnamese", "vi", false)
+                MakeTranslationPair("Turkmen", "tk", false),
+                MakeTranslationPair("Ukrainian", "uk", false),
+                MakeTranslationPair("Urdu", "ur", false),
+                MakeTranslationPair("Uzbek", "uz", false),
+                MakeTranslationPair("Vietnamese", "vi", false),
+                MakeTranslationPair("Welsh", "cy", false),
+                MakeTranslationPair("Wolof", "wo", false),
+                MakeTranslationPair("Xhosa", "xh", false),
+                MakeTranslationPair("Yiddish", "yi", false),
+                MakeTranslationPair("Zulu", "zu", false),
             };
         }
 
+        /// <summary>
+        /// Mirrors GET /v2/languages?type=target (checked 2026-08-25, 110 languages), minus the three
+        /// codes that are aliases of an entry already here: ZH (= zh-hans), DE-DE (= de) and FR-FR
+        /// (= fr). The last argument is the API's supports_formality flag.
+        /// To refresh: curl -H "Authorization: DeepL-Auth-Key KEY" "https://api-free.deepl.com/v2/languages?type=target"
+        /// </summary>
         public List<TranslationPair> GetSupportedTargetLanguages()
         {
             return new List<TranslationPair>
             {
-                // European Languages
+                MakeTranslationPair("Afrikaans", "af", false),
+                MakeTranslationPair("Albanian", "sq", false),
+                MakeTranslationPair("Arabic", "ar", false),
+                MakeTranslationPair("Aragonese", "an", false),
+                MakeTranslationPair("Armenian", "hy", false),
+                MakeTranslationPair("Assamese", "as", false),
+                MakeTranslationPair("Aymara", "ay", false),
+                MakeTranslationPair("Azerbaijani", "az", false),
+                MakeTranslationPair("Bashkir", "ba", false),
+                MakeTranslationPair("Basque", "eu", false),
+                MakeTranslationPair("Belarusian", "be", false),
+                MakeTranslationPair("Bengali", "bn", false),
+                MakeTranslationPair("Bosnian", "bs", false),
+                MakeTranslationPair("Breton", "br", false),
                 MakeTranslationPair("Bulgarian", "bg", false),
+                MakeTranslationPair("Burmese", "my", false),
+                MakeTranslationPair("Catalan", "ca", false),
+                MakeTranslationPair("Chinese (Simplified)", "zh-hans", false),
+                MakeTranslationPair("Chinese (Traditional)", "zh-hant", false),
+                MakeTranslationPair("Croatian", "hr", false),
                 MakeTranslationPair("Czech", "cs", false),
                 MakeTranslationPair("Danish", "da", false),
                 MakeTranslationPair("Dutch", "nl", true),
+                MakeTranslationPair("English (American)", "en-US", false),
+                MakeTranslationPair("English (British)", "en-GB", false),
+                MakeTranslationPair("Esperanto", "eo", false),
                 MakeTranslationPair("Estonian", "et", false),
                 MakeTranslationPair("Finnish", "fi", false),
                 MakeTranslationPair("French", "fr", true),
+                MakeTranslationPair("French (Canadian)", "fr-CA", true),
+                MakeTranslationPair("Galician", "gl", false),
+                MakeTranslationPair("Georgian", "ka", false),
                 MakeTranslationPair("German", "de", true),
+                MakeTranslationPair("German (Swiss)", "de-CH", true),
                 MakeTranslationPair("Greek", "el", false),
+                MakeTranslationPair("Guarani", "gn", false),
+                MakeTranslationPair("Gujarati", "gu", false),
+                MakeTranslationPair("Haitian Creole", "ht", false),
+                MakeTranslationPair("Hausa", "ha", false),
+                MakeTranslationPair("Hebrew", "he", false),
+                MakeTranslationPair("Hindi", "hi", false),
                 MakeTranslationPair("Hungarian", "hu", false),
+                MakeTranslationPair("Icelandic", "is", false),
+                MakeTranslationPair("Igbo", "ig", false),
+                MakeTranslationPair("Indonesian", "id", false),
+                MakeTranslationPair("Irish", "ga", false),
                 MakeTranslationPair("Italian", "it", true),
+                MakeTranslationPair("Japanese", "ja", true),
+                MakeTranslationPair("Javanese", "jv", false),
+                MakeTranslationPair("Kazakh", "kk", false),
+                MakeTranslationPair("Korean", "ko", false),
+                MakeTranslationPair("Kyrgyz", "ky", false),
+                MakeTranslationPair("Latin", "la", false),
                 MakeTranslationPair("Latvian", "lv", false),
+                MakeTranslationPair("Lingala", "ln", false),
                 MakeTranslationPair("Lithuanian", "lt", false),
+                MakeTranslationPair("Luxembourgish", "lb", false),
+                MakeTranslationPair("Macedonian", "mk", false),
+                MakeTranslationPair("Malagasy", "mg", false),
+                MakeTranslationPair("Malay", "ms", false),
+                MakeTranslationPair("Malayalam", "ml", false),
+                MakeTranslationPair("Maltese", "mt", false),
+                MakeTranslationPair("Maori", "mi", false),
+                MakeTranslationPair("Marathi", "mr", false),
+                MakeTranslationPair("Mongolian", "mn", false),
+                MakeTranslationPair("Nepali", "ne", false),
                 MakeTranslationPair("Norwegian (Bokmål)", "nb", false),
+                MakeTranslationPair("Occitan", "oc", false),
+                MakeTranslationPair("Oromo", "om", false),
+                MakeTranslationPair("Pashto", "ps", false),
+                MakeTranslationPair("Persian", "fa", false),
                 MakeTranslationPair("Polish", "pl", true),
+                MakeTranslationPair("Portuguese (Brazilian)", "pt-BR", true),
+                MakeTranslationPair("Portuguese (European)", "pt-PT", true),
+                MakeTranslationPair("Punjabi", "pa", false),
+                MakeTranslationPair("Quechua", "qu", false),
                 MakeTranslationPair("Romanian", "ro", false),
                 MakeTranslationPair("Russian", "ru", true),
+                MakeTranslationPair("Sanskrit", "sa", false),
+                MakeTranslationPair("Serbian", "sr", false),
+                MakeTranslationPair("Sesotho", "st", false),
                 MakeTranslationPair("Slovak", "sk", false),
                 MakeTranslationPair("Slovenian", "sl", false),
-                MakeTranslationPair("Swedish", "sv", false),
-                MakeTranslationPair("Ukrainian", "uk", false),
-
-                // English Variants (Formality is NOT supported for English)
-                MakeTranslationPair("English (British)", "en-GB", false),
-                MakeTranslationPair("English (American)", "en-US", false),
-
-                // Spanish Variants
                 MakeTranslationPair("Spanish", "es", true),
                 MakeTranslationPair("Spanish (Latin American)", "es-419", true),
-
-                // Portuguese Variants
-                MakeTranslationPair("Portuguese (European)", "pt-PT", true),
-                MakeTranslationPair("Portuguese (Brazilian)", "pt-BR", true),
-
-                // Asian & Middle Eastern Languages
-                MakeTranslationPair("Arabic", "ar", false),
-                MakeTranslationPair("Chinese (Simplified)", "zh-hans", false),
-                MakeTranslationPair("Chinese (Traditional)", "zh-hant", false),
-                MakeTranslationPair("Hebrew", "he", false),
-                MakeTranslationPair("Indonesian", "id", false),
-                MakeTranslationPair("Japanese", "ja", true),
-                MakeTranslationPair("Korean", "ko", false),
+                MakeTranslationPair("Sundanese", "su", false),
+                MakeTranslationPair("Swahili", "sw", false),
+                MakeTranslationPair("Swedish", "sv", false),
+                MakeTranslationPair("Tagalog", "tl", false),
+                MakeTranslationPair("Tajik", "tg", false),
+                MakeTranslationPair("Tamil", "ta", false),
+                MakeTranslationPair("Tatar", "tt", false),
+                MakeTranslationPair("Telugu", "te", false),
                 MakeTranslationPair("Thai", "th", false),
+                MakeTranslationPair("Tsonga", "ts", false),
+                MakeTranslationPair("Tswana", "tn", false),
                 MakeTranslationPair("Turkish", "tr", false),
-                MakeTranslationPair("Vietnamese", "vi", false)
+                MakeTranslationPair("Turkmen", "tk", false),
+                MakeTranslationPair("Ukrainian", "uk", false),
+                MakeTranslationPair("Urdu", "ur", false),
+                MakeTranslationPair("Uzbek", "uz", false),
+                MakeTranslationPair("Vietnamese", "vi", false),
+                MakeTranslationPair("Welsh", "cy", false),
+                MakeTranslationPair("Wolof", "wo", false),
+                MakeTranslationPair("Xhosa", "xh", false),
+                MakeTranslationPair("Yiddish", "yi", false),
+                MakeTranslationPair("Zulu", "zu", false),
             };
         }
 

--- a/tests/libuilogic/AutoTranslate/DeepLTranslateTests.cs
+++ b/tests/libuilogic/AutoTranslate/DeepLTranslateTests.cs
@@ -1,0 +1,124 @@
+using Nikse.SubtitleEdit.UiLogic.AutoTranslate;
+
+namespace LibUiLogicTests.AutoTranslate;
+
+public class DeepLTranslateTests
+{
+    /// <summary>
+    /// A ":fx" key is free-tier and works only on api-free.deepl.com; a key without it works only
+    /// on api.deepl.com. The wrong pairing answers 403 "Wrong endpoint", so the host follows the key.
+    /// </summary>
+    [Theory]
+    [InlineData("https://api.deepl.com/", "abc-123:fx", "https://api-free.deepl.com/")]
+    [InlineData("https://api-free.deepl.com/", "abc-123", "https://api.deepl.com/")]
+    [InlineData("https://api-free.deepl.com/", "abc-123:fx", "https://api-free.deepl.com/")]
+    [InlineData("https://api.deepl.com/", "abc-123", "https://api.deepl.com/")]
+    public void ResolveApiUrl_PicksTheHostThatMatchesTheKey(string url, string key, string expected)
+    {
+        Assert.Equal(expected, DeepLTranslate.ResolveApiUrl(url, key));
+    }
+
+    [Theory]
+    [InlineData("http://localhost:1188/", "abc-123:fx")]
+    [InlineData("https://deepl.example.com/v2/", "abc-123")]
+    public void ResolveApiUrl_LeavesAnyOtherHostAlone(string url, string key)
+    {
+        Assert.Equal(url, DeepLTranslate.ResolveApiUrl(url, key));
+    }
+
+    [Theory]
+    [InlineData("", "abc-123:fx")]
+    [InlineData("https://api.deepl.com/", "")]
+    public void ResolveApiUrl_WithoutBothPartsChangesNothing(string url, string key)
+    {
+        Assert.Equal(url, DeepLTranslate.ResolveApiUrl(url, key));
+    }
+
+    /// <summary>
+    /// The lists mirror GET /v2/languages (checked 2026-08-25). These guard the shape rather than
+    /// the exact contents: no duplicates, nothing empty, and the languages the reporter of #14092
+    /// and others asked about are actually offered.
+    /// </summary>
+    [Fact]
+    public void TargetLanguages_HaveNoDuplicateCodes()
+    {
+        var codes = new DeepLTranslate().GetSupportedTargetLanguages().Select(p => p.Code.ToLowerInvariant()).ToList();
+
+        Assert.Equal(codes.Count, codes.Distinct().Count());
+    }
+
+    [Fact]
+    public void SourceLanguages_HaveNoDuplicateCodes()
+    {
+        var codes = new DeepLTranslate().GetSupportedSourceLanguages().Select(p => p.Code.ToLowerInvariant()).ToList();
+
+        Assert.Equal(codes.Count, codes.Distinct().Count());
+    }
+
+    [Fact]
+    public void Languages_HaveANameAndACode()
+    {
+        var deepL = new DeepLTranslate();
+
+        Assert.All(deepL.GetSupportedSourceLanguages(), p =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(p.Name));
+            Assert.False(string.IsNullOrWhiteSpace(p.Code));
+        });
+
+        Assert.All(deepL.GetSupportedTargetLanguages(), p =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(p.Name));
+            Assert.False(string.IsNullOrWhiteSpace(p.Code));
+        });
+    }
+
+    [Theory]
+    [InlineData("hi")]  // Hindi
+    [InlineData("bn")]  // Bengali
+    [InlineData("ta")]  // Tamil
+    [InlineData("fa")]  // Persian
+    [InlineData("sr")]  // Serbian
+    [InlineData("hr")]  // Croatian
+    [InlineData("ms")]  // Malay
+    [InlineData("sw")]  // Swahili
+    [InlineData("is")]  // Icelandic
+    [InlineData("de-CH")]
+    [InlineData("fr-CA")]
+    public void TargetLanguages_IncludeTheLanguagesDeepLAdded(string code)
+    {
+        var codes = new DeepLTranslate().GetSupportedTargetLanguages().Select(p => p.Code).ToList();
+
+        Assert.Contains(code, codes);
+    }
+
+    /// <summary>DeepL only accepts a formality setting for these targets - supports_formality in the API.</summary>
+    [Fact]
+    public void OnlyTheDocumentedTargetsSupportFormality()
+    {
+        var withFormality = new DeepLTranslate().GetSupportedTargetLanguages()
+            .Where(p => p.HasFormality == true)
+            .Select(p => p.Code)
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.Equal(
+            new[] { "de", "de-CH", "es", "es-419", "fr", "fr-CA", "it", "ja", "nl", "pl", "pt-BR", "pt-PT", "ru" }
+                .OrderBy(p => p, StringComparer.Ordinal).ToList(),
+            withFormality);
+    }
+
+    /// <summary>
+    /// DeepL takes no regional variant as a source language, so the source codes SE offers are cut
+    /// back to the base code before they are sent.
+    /// </summary>
+    [Fact]
+    public void SourceLanguages_KeepTheRegionalPairsSeHasAlwaysOffered()
+    {
+        var codes = new DeepLTranslate().GetSupportedSourceLanguages().Select(p => p.Code).ToList();
+
+        Assert.Contains("en-GB", codes);
+        Assert.Contains("en-US", codes);
+        Assert.Contains("zh-hans", codes);
+    }
+}


### PR DESCRIPTION
Review of the DeepL integration, prompted by #14091/#14092.

### The language lists were badly out of date

`DeepLTranslate` hardcodes its languages. It offered **37 source / 37 target**; the API answers **101 source / 110 target**:

```
$ curl -H "Authorization: DeepL-Auth-Key KEY" "https://api-free.deepl.com/v2/languages?type=target" | jq length
110
```

So roughly 70 languages were simply not on offer - among them Hindi, Bengali, Tamil, Telugu, Malayalam, Marathi, Punjabi, Urdu, Persian, Serbian, Croatian, Bosnian, Macedonian, Catalan, Basque, Galician, Icelandic, Georgian, Armenian, Malay, Tagalog, Swahili, Welsh, Irish, Albanian, Belarusian, Kazakh, Azerbaijani, Afrikaans, Esperanto - plus the `de-CH` and `fr-CA` targets.

Both lists now mirror `/v2/languages` (checked 2026-08-25), minus three target codes that are aliases of an entry already present: `ZH` (= `zh-hans`), `DE-DE` (= `de`), `FR-FR` (= `fr`). Every code and name SE already had is byte-identical, so saved `AutoTranslateLastSource`/`Target` settings keep matching. Formality flags come from the API's `supports_formality` - the old ones were all correct, `de-CH` and `fr-CA` are the two new ones that have it.

Verified against the live API, not just the docs: every code in both lists is accepted, and a spot check of the new ones (`hi sr fa ta cy is ms de-CH fr-CA zh`) returns real translations with the exact request SE sends.

### Key and host are now paired

A key ending in `:fx` is free-tier and works only on `api-free.deepl.com`; a key without it only on `api.deepl.com`. The wrong pairing gives:

```
HTTP 403 {"message":"Wrong endpoint. Use https://api-free.deepl.com. ..."}
```

`ResolveApiUrl` picks the host that matches the key. Only the two official hosts are swapped, so a self-hosted or proxied URL is left exactly as entered.

### Notes

- DeepLX reuses these lists (`DeepLXTranslate.GetSupported*Languages` delegates here). It forwards to DeepL, so what it can actually do depends on its own backend.
- `MaxCharacters => 1500` is left alone. DeepL's request limit is far higher, so bigger batches would mean fewer requests and fewer 429s, but that number feeds the merge/split heuristics in `MergeAndSplitHelper` and is worth changing on its own.
- Unrelated cosmetic thing I noticed: `TranslationPair.ToString()` lowercases the name and re-capitalizes only the first letter, and the language combo boxes have no `ItemTemplate`, so they render "English (british)", "Chinese (simplified)". Pre-existing, not touched here.

### Tests

`tests/libuilogic/AutoTranslate/DeepLTranslateTests.cs` - 24 tests: host/key pairing, no duplicate or empty codes, the newly added languages are present, and the formality set matches the API. Full libuilogic suite (588) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)