### PR TITLE
EBU STL: show frame-based timecodes while the format is active

### DIFF
--- a/src/ui/Controls/SecondsUpDown.cs
+++ b/src/ui/Controls/SecondsUpDown.cs
@@ -233,6 +233,15 @@ public class SecondsUpDown : TemplatedControl
         Value = val;
     }
 
+    /// <summary>
+    /// Re-renders the unchanged value after the frame-mode display setting changed - the text
+    /// otherwise only re-formats when the value itself changes.
+    /// </summary>
+    public void RefreshDisplayFormat()
+    {
+        UpdateText();
+    }
+
     private void UpdateText()
     {
         if (_textBox != null)

--- a/src/ui/Controls/TimeCodeUpDown.cs
+++ b/src/ui/Controls/TimeCodeUpDown.cs
@@ -638,6 +638,15 @@ namespace Nikse.SubtitleEdit.Controls
             _isUpdatingFromValue = false;
         }
 
+        /// <summary>
+        /// Re-renders the unchanged value after the frame-mode display setting changed - the text
+        /// otherwise only re-formats when the value itself changes.
+        /// </summary>
+        public void RefreshDisplayFormat()
+        {
+            UpdateText();
+        }
+
         private void UpdateText()
         {
             var oldSignOffset = SignOffset;

--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -1379,6 +1379,7 @@ public static partial class InitListViewAndEditBox
         timeCodeUpDown.Bind(TimeCodeUpDown.IsEnabledProperty, new Binding(nameof(vm.AreTimeCodesEditable)) { Mode = BindingMode.OneWay });
         startTimePanel.Children.Add(timeCodeUpDown);
         timeCodeUpDown.ValueChanged += vm.StartTimeChanged;
+        vm.EditBoxStartTimeUpDown = timeCodeUpDown;
         timeControlsPanel.Children.Add(startTimePanel);
 
 
@@ -1411,6 +1412,7 @@ public static partial class InitListViewAndEditBox
         endCodeUpDown.Bind(TimeCodeUpDown.IsEnabledProperty, new Binding(nameof(vm.AreTimeCodesEditable)) { Mode = BindingMode.OneWay });
         endTimePanel.Children.Add(endCodeUpDown);
         endCodeUpDown.ValueChanged += vm.EndTimeChanged;
+        vm.EditBoxEndTimeUpDown = endCodeUpDown;
         timeControlsPanel.Children.Add(endTimePanel);
 
         // Duration display
@@ -1442,6 +1444,7 @@ public static partial class InitListViewAndEditBox
         }
         durationUpDown.Bind(SecondsUpDown.IsEnabledProperty, new Binding(nameof(vm.AreTimeCodesEditable)) { Mode = BindingMode.OneWay });
         durationUpDown.ValueChanged += (_, _) => vm.DurationChanged();
+        vm.EditBoxDurationUpDown = durationUpDown;
         durationPanel.Children.Add(durationUpDown);
         timeControlsPanel.Children.Add(durationPanel);
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -11,6 +11,7 @@ using Avalonia.Media;
 using Avalonia.Styling;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
+using Nikse.SubtitleEdit.Controls;
 using Nikse.SubtitleEdit.Controls.SyntaxTextEditorControl;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -749,6 +750,9 @@ public partial class MainViewModel :
     public MenuItem MenuItemAudioVisualizerCopyText { get; set; }
     public ITextBoxWrapper EditTextBoxOriginal { get; set; }
     public ITextBoxWrapper EditTextBox { get; set; }
+    public TimeCodeUpDown? EditBoxStartTimeUpDown { get; set; }
+    public TimeCodeUpDown? EditBoxEndTimeUpDown { get; set; }
+    public SecondsUpDown? EditBoxDurationUpDown { get; set; }
     public StackPanel PanelSingleLineLengthsOriginal { get; set; }
     public MenuItem MenuItemStyles { get; set; }
     public MenuItem MenuItemActors { get; set; }
@@ -19890,6 +19894,19 @@ public partial class MainViewModel :
             SetSubtitleFormat(SubtitleFormats.FirstOrDefault(p => p.Name == subtitle?.OriginalFormat?.Name) ??
                               SelectedSubtitleFormat);
 
+            // The STL header declares the frame rate the timecodes were authored in, so the
+            // HH:MM:SS:FF display (forced on for EBU STL) shows the file's own frame numbers.
+            // Skipped when the header's disk format code is unreadable - the frame rate would
+            // just be a guessed fallback then (#14076). A video loaded later still wins.
+            if (subtitle?.OriginalFormat is Ebu ebuFormat &&
+                ebuFormat.Header is { } ebuHeader &&
+                ebuHeader.DiskFormatCode != null &&
+                ebuHeader.DiskFormatCode.StartsWith("STL", StringComparison.Ordinal) &&
+                ebuHeader.FrameRate is > 20 and < 130)
+            {
+                SetSelectedFrameRate(ebuHeader.FrameRate);
+            }
+
             if (fileEncoding.WebName.StartsWith("utf-8", StringComparison.OrdinalIgnoreCase))
             {
                 if (FileUtil.HasUtf8Bom(fileName))
@@ -28778,6 +28795,35 @@ public partial class MainViewModel :
         }
     }
 
+    /// <summary>
+    /// EBU STL is a frame-based format, so while it is the active format the timecodes are shown
+    /// as HH:MM:SS:FF via a session-only override - the persisted "use frame mode" setting is left
+    /// untouched, and the display reverts when the format changes away again (#14076).
+    /// </summary>
+    private void UpdateTemporaryFrameMode()
+    {
+        var general = Se.Settings.General;
+        var wasFrameMode = general.UseFrameMode;
+        general.UseFrameModeOverride = IsFormatEbu ? true : null;
+        if (general.UseFrameMode == wasFrameMode)
+        {
+            return;
+        }
+
+        Configuration.Settings.General.UseTimeFormatHHMMSSFF = general.UseFrameMode;
+
+        foreach (var s in Subtitles)
+        {
+            s.RefreshTimeCodes();
+        }
+
+        EditBoxStartTimeUpDown?.RefreshDisplayFormat();
+        EditBoxEndTimeUpDown?.RefreshDisplayFormat();
+        EditBoxDurationUpDown?.RefreshDisplayFormat();
+        RefreshVideoSeekAmounts();
+        _updateAudioVisualizer = true;
+    }
+
     internal void ComboBoxSubtitleFormatChanged(object? sender, SelectionChangedEventArgs e)
     {
         if (!_changingFormatProgrammatically)
@@ -28802,6 +28848,8 @@ public partial class MainViewModel :
                 row.RefreshAfterSettingsChanged();
             }
         }
+
+        UpdateTemporaryFrameMode();
 
         HasFormatStyle = IsFormatAssaOrSsa || IsFormatWebVtt;
         ShowActorColumnMenuHeader = IsFormatWebVtt

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -1359,5 +1359,6 @@ public partial class SubtitleLineViewModel : ObservableObject
         OnPropertyChanged(nameof(StartTime));
         OnPropertyChanged(nameof(EndTime));
         OnPropertyChanged(nameof(Duration));
+        OnPropertyChanged(nameof(Gap));
     }
 }

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -758,7 +758,9 @@ public partial class SettingsViewModel : ObservableObject
         IsEditCustomContinuationStyleVisible = ContinuationStyle?.Code == nameof(Core.Enums.ContinuationStyle.Custom);
         CpsLineLengthStrategy = CpsLineLengthStrategies.FirstOrDefault(p => p.Code == general.CpsLineLengthStrategy) ?? CpsLineLengthStrategies.First();
 
-        UseFrameMode = general.UseFrameMode;
+        // The persisted choice, not the effective value - EBU STL may have frame mode forced on
+        // temporarily, and that must not stick just because the settings dialog was OK'ed.
+        UseFrameMode = general.UseFrameModePersisted;
         TextBoxLimitNewLines = general.SubtitleTextBoxLimitNewLines;
         NewEmptyDefaultMs = general.NewEmptyDefaultMs;
         TimeCodeUpDownStepMs = general.TimeCodeUpDownStepMs;

--- a/src/ui/Logic/Config/SeGeneral.cs
+++ b/src/ui/Logic/Config/SeGeneral.cs
@@ -5,6 +5,7 @@ using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace Nikse.SubtitleEdit.Logic.Config;
 
@@ -36,7 +37,27 @@ public class SeGeneral
     public bool FixContinuationStyleIgnoreLyrics { get; set; }
 
 
-    public bool UseFrameMode { get; set; } = false;
+    /// <summary>
+    /// The user's persisted frame-mode choice, stored as "UseFrameMode" in the settings file.
+    /// Read <see cref="UseFrameMode"/> instead, so the temporary override is honored.
+    /// </summary>
+    [JsonPropertyName("UseFrameMode")]
+    public bool UseFrameModePersisted { get; set; }
+
+    /// <summary>
+    /// Session-only frame mode, forced while a frame-based format (EBU STL) is the active
+    /// format (#14076). Managed by the main view when the subtitle format changes; never saved.
+    /// </summary>
+    [JsonIgnore]
+    public bool? UseFrameModeOverride { get; set; }
+
+    [JsonIgnore]
+    public bool UseFrameMode
+    {
+        get => UseFrameModeOverride ?? UseFrameModePersisted;
+        set => UseFrameModePersisted = value;
+    }
+
     public double DefaultFrameRate { get; set; }
     public double CurrentFrameRate { get; set; }
     public string DefaultSubtitleFormat { get; set; }

--- a/tests/UI/Logic/Config/UseFrameModeOverrideTests.cs
+++ b/tests/UI/Logic/Config/UseFrameModeOverrideTests.cs
@@ -1,0 +1,63 @@
+using Nikse.SubtitleEdit.Logic.Config;
+using System.Text.Json;
+
+namespace UITests.Logic.Config;
+
+/// <summary>
+/// While EBU STL is the active format, frame mode is forced on through a session-only override
+/// (#14076). The user's own choice must survive that: the override wins while set, but only the
+/// persisted value may ever reach the settings file.
+/// </summary>
+public class UseFrameModeOverrideTests
+{
+    [Fact]
+    public void OverrideWinsWhileSet_AndSetterOnlyTouchesThePersistedValue()
+    {
+        var general = new SeGeneral
+        {
+            UseFrameModePersisted = false,
+        };
+
+        Assert.False(general.UseFrameMode);
+
+        general.UseFrameModeOverride = true;
+        Assert.True(general.UseFrameMode);
+        Assert.False(general.UseFrameModePersisted);
+
+        // An explicit set (settings dialog OK) targets the persisted value; the override keeps
+        // ruling the effective value until the main view clears it.
+        general.UseFrameMode = false;
+        Assert.True(general.UseFrameMode);
+        Assert.False(general.UseFrameModePersisted);
+
+        general.UseFrameModeOverride = null;
+        Assert.False(general.UseFrameMode);
+    }
+
+    [Fact]
+    public void ActiveOverrideIsNotSerialized()
+    {
+        var se = new Se();
+        se.General.UseFrameModePersisted = false;
+        se.General.UseFrameModeOverride = true;
+
+        var json = JsonSerializer.Serialize(se, SeJsonContext.Default.Se);
+
+        var general = JsonDocument.Parse(json).RootElement.GetProperty("General");
+        Assert.False(general.GetProperty("UseFrameMode").GetBoolean());
+        Assert.False(general.TryGetProperty("UseFrameModeOverride", out _));
+        Assert.False(general.TryGetProperty("UseFrameModePersisted", out _));
+    }
+
+    [Fact]
+    public void SettingsFileValueLoadsIntoThePersistedValue()
+    {
+        // The key kept its "UseFrameMode" name, so files written before the override existed
+        // (and by SE versions without it) round-trip unchanged.
+        var se = JsonSerializer.Deserialize("""{"General":{"UseFrameMode":true}}""", SeJsonContext.Default.Se)!;
+
+        Assert.True(se.General.UseFrameModePersisted);
+        Assert.Null(se.General.UseFrameModeOverride);
+        Assert.True(se.General.UseFrameMode);
+    }
+}

--- a/tests/libse/SubtitleFormats/EbuTest.cs
+++ b/tests/libse/SubtitleFormats/EbuTest.cs
@@ -84,6 +84,23 @@ public class EbuTest
     }
 
     [Fact]
+    public void EbuStl_Load_ExposesHeaderFrameRateOnTheParsingInstance()
+    {
+        // The SE5 main view reads the frame rate off the parsing instance's header after open, to
+        // show the file's own frame numbers in the forced HH:MM:SS:FF display (#14076).
+        Ebu.EbuUiHelper = new TestEbuUiHelper();
+        using var ms = new MemoryStream();
+        ((IBinaryPersistableSubtitle)new Ebu()).Save("test.stl", ms, MakeSubtitle(), batchMode: true);
+
+        var ebu = new Ebu();
+        ebu.LoadSubtitle(new Subtitle(), ms.ToArray());
+
+        Assert.NotNull(ebu.Header);
+        Assert.StartsWith("STL25", ebu.Header.DiskFormatCode);
+        Assert.Equal(25.0, ebu.Header.FrameRate);
+    }
+
+    [Fact]
     public void EbuStl_ToText_IsNotUsableForSaving()
     {
         // Guards the root cause: ToText is a stub for this binary format, so the save path must use


### PR DESCRIPTION
Part of the discussion in #14076 - the "auto-change to frame-based timecodes, but only temporary" idea.

## What it does

- While EBU STL is the active format, all timecodes display as HH:MM:SS:FF - the grid columns (start/end/duration/gap), the edit-box time up/down controls, the waveform grid lines, and the video seek amounts.
- It is a **session-only override**: the persisted "Use frame mode" setting is never touched, and the display reverts the moment the format changes away or a non-EBU file is opened.
- On opening an .stl file, the frame rate combo is set from the frame rate the STL header's disk format code declares (STL23/24/25/29/48/50/60...), so the frame numbers shown are the file's own. Skipped when the disk format code is unreadable; a video loaded later still wins, same as before.

## How

- `SeGeneral.UseFrameMode` becomes `UseFrameModeOverride ?? UseFrameModePersisted`. Every existing consumer (grid converters, `TimeCodeUpDown`/`SecondsUpDown`, `TimeCodeDisplayCache`, `MsOrFramesValue`, waveform, libse `UseTimeFormatHHMMSSFF` mirror) reads the property as before and honors the override for free. Serialization keeps the `"UseFrameMode"` key (old settings files round-trip unchanged) and only ever writes the persisted value; the settings dialog also loads the persisted value, so an active override cannot leak into the settings file through an unrelated settings round-trip.
- `MainViewModel.UpdateTemporaryFrameMode()` runs from the existing per-format hook (`ComboBoxSubtitleFormatChanged`, next to the teletext line-length sync) and refreshes what the frame-rate-change path already refreshes: row timecodes, edit-box time controls (new `RefreshDisplayFormat()` - they otherwise only re-format on value changes), seek amounts, waveform; `AutoFitColumns` runs right after in the caller.
- `RefreshTimeCodes()` now also raises `Gap`, since the gap column renders frames vs. seconds by the same mode (this also fixes the gap column staying stale on a frame-rate change in frame mode).

## Notes

- A user who already works with frame mode on sees no change at all.
- With frame mode forced on, the min-gap value used is the frames-based one from settings (`MsOrFramesValue`) - the same value a user gets by enabling frame mode manually, which is the professionally expected behavior for STL work.

## Tests

- `UseFrameModeOverrideTests`: override wins while set, setter only touches the persisted value, an active override is never serialized, and old settings files load into the persisted value.
- `EbuTest`: the parsing instance exposes its header's disk format code and frame rate after load - the contract the open path relies on.
- Full UI suite (3,926) and libse Ebu tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)