### PR TITLE
Auto cast: put the actors on an open subtitle, apply before cloning

### DIFF
--- a/src/ui/Controls/SecondsUpDown.cs
+++ b/src/ui/Controls/SecondsUpDown.cs
@@ -233,6 +233,15 @@ public class SecondsUpDown : TemplatedControl
         Value = val;
     }
 
+    /// <summary>
+    /// Re-renders the unchanged value after the frame-mode display setting changed - the text
+    /// otherwise only re-formats when the value itself changes.
+    /// </summary>
+    public void RefreshDisplayFormat()
+    {
+        UpdateText();
+    }
+
     private void UpdateText()
     {
         if (_textBox != null)

--- a/src/ui/Controls/TimeCodeUpDown.cs
+++ b/src/ui/Controls/TimeCodeUpDown.cs
@@ -638,6 +638,15 @@ namespace Nikse.SubtitleEdit.Controls
             _isUpdatingFromValue = false;
         }
 
+        /// <summary>
+        /// Re-renders the unchanged value after the frame-mode display setting changed - the text
+        /// otherwise only re-formats when the value itself changes.
+        /// </summary>
+        public void RefreshDisplayFormat()
+        {
+            UpdateText();
+        }
+
         private void UpdateText()
         {
             var oldSignOffset = SignOffset;

--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -153,6 +153,7 @@ using Nikse.SubtitleEdit.Features.Video.ReEncodeVideo;
 using Nikse.SubtitleEdit.Features.Video.ShotChanges;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ActorVoices;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.AutoCast;
 using Nikse.SubtitleEdit.Features.Video.VideoOcr;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.AdvancedTtsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DownloadTts;
@@ -555,6 +556,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<TextToSpeechViewModel>();
         collection.AddTransient<ActorVoiceMappingViewModel>();
         collection.AddTransient<ActorVoiceRowSettingsViewModel>();
+        collection.AddTransient<AutoCastSpeakersViewModel>();
         collection.AddTransient<TimedText10PropertiesViewModel>();
         collection.AddTransient<TimedTextImsc11PropertiesViewModel>();
         collection.AddTransient<TmpegEncXmlPropertiesViewModel>();

--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -1379,6 +1379,7 @@ public static partial class InitListViewAndEditBox
         timeCodeUpDown.Bind(TimeCodeUpDown.IsEnabledProperty, new Binding(nameof(vm.AreTimeCodesEditable)) { Mode = BindingMode.OneWay });
         startTimePanel.Children.Add(timeCodeUpDown);
         timeCodeUpDown.ValueChanged += vm.StartTimeChanged;
+        vm.EditBoxStartTimeUpDown = timeCodeUpDown;
         timeControlsPanel.Children.Add(startTimePanel);
 
 
@@ -1411,6 +1412,7 @@ public static partial class InitListViewAndEditBox
         endCodeUpDown.Bind(TimeCodeUpDown.IsEnabledProperty, new Binding(nameof(vm.AreTimeCodesEditable)) { Mode = BindingMode.OneWay });
         endTimePanel.Children.Add(endCodeUpDown);
         endCodeUpDown.ValueChanged += vm.EndTimeChanged;
+        vm.EditBoxEndTimeUpDown = endCodeUpDown;
         timeControlsPanel.Children.Add(endTimePanel);
 
         // Duration display
@@ -1442,6 +1444,7 @@ public static partial class InitListViewAndEditBox
         }
         durationUpDown.Bind(SecondsUpDown.IsEnabledProperty, new Binding(nameof(vm.AreTimeCodesEditable)) { Mode = BindingMode.OneWay });
         durationUpDown.ValueChanged += (_, _) => vm.DurationChanged();
+        vm.EditBoxDurationUpDown = durationUpDown;
         durationPanel.Children.Add(durationUpDown);
         timeControlsPanel.Children.Add(durationPanel);
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9528,6 +9528,12 @@ public partial class MainViewModel :
         }
 
         var engine = speakersResult.SelectedEngine;
+
+        // The speakers are confirmed, so the subtitle gets its actors (and the ASSA format that
+        // keeps them) before the cloning starts - a failed or cancelled clone used to throw the
+        // whole diarization away with it, leaving the subtitle exactly as it was.
+        ApplyAutoCastToSubtitle(transcription, speakersResult.RenamedSpeakers);
+
         var clonedVoiceNames = await CloneSpeakerVoicesAsync(engine, speakersResult.SpeakersToClone);
         if (clonedVoiceNames.Count == 0)
         {
@@ -9540,7 +9546,6 @@ public partial class MainViewModel :
             return;
         }
 
-        ApplyAutoCastToSubtitle(transcription, speakersResult.RenamedSpeakers);
         SaveAutoCastMappings(engine, clonedVoiceNames);
 
         ShowStatus(string.Format(Se.Language.Video.TextToSpeech.AutoCastDoneXVoices, clonedVoiceNames.Count));
@@ -9619,7 +9624,7 @@ public partial class MainViewModel :
     /// An open subtitle keeps its own lines and only gains actors, matched to the diarized
     /// segments by overlap; with nothing open, the transcription becomes the subtitle.
     /// </remarks>
-    private void ApplyAutoCastToSubtitle(Subtitle transcription, Dictionary<string, string> renamedSpeakers)
+    internal void ApplyAutoCastToSubtitle(Subtitle transcription, Dictionary<string, string> renamedSpeakers)
     {
         string Rename(string detected) =>
             renamedSpeakers.TryGetValue(detected, out var name) && !string.IsNullOrWhiteSpace(name) ? name : detected;

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -11,6 +11,7 @@ using Avalonia.Media;
 using Avalonia.Styling;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
+using Nikse.SubtitleEdit.Controls;
 using Nikse.SubtitleEdit.Controls.SyntaxTextEditorControl;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -749,6 +750,9 @@ public partial class MainViewModel :
     public MenuItem MenuItemAudioVisualizerCopyText { get; set; }
     public ITextBoxWrapper EditTextBoxOriginal { get; set; }
     public ITextBoxWrapper EditTextBox { get; set; }
+    public TimeCodeUpDown? EditBoxStartTimeUpDown { get; set; }
+    public TimeCodeUpDown? EditBoxEndTimeUpDown { get; set; }
+    public SecondsUpDown? EditBoxDurationUpDown { get; set; }
     public StackPanel PanelSingleLineLengthsOriginal { get; set; }
     public MenuItem MenuItemStyles { get; set; }
     public MenuItem MenuItemActors { get; set; }
@@ -19890,6 +19894,19 @@ public partial class MainViewModel :
             SetSubtitleFormat(SubtitleFormats.FirstOrDefault(p => p.Name == subtitle?.OriginalFormat?.Name) ??
                               SelectedSubtitleFormat);
 
+            // The STL header declares the frame rate the timecodes were authored in, so the
+            // HH:MM:SS:FF display (forced on for EBU STL) shows the file's own frame numbers.
+            // Skipped when the header's disk format code is unreadable - the frame rate would
+            // just be a guessed fallback then (#14076). A video loaded later still wins.
+            if (subtitle?.OriginalFormat is Ebu ebuFormat &&
+                ebuFormat.Header is { } ebuHeader &&
+                ebuHeader.DiskFormatCode != null &&
+                ebuHeader.DiskFormatCode.StartsWith("STL", StringComparison.Ordinal) &&
+                ebuHeader.FrameRate is > 20 and < 130)
+            {
+                SetSelectedFrameRate(ebuHeader.FrameRate);
+            }
+
             if (fileEncoding.WebName.StartsWith("utf-8", StringComparison.OrdinalIgnoreCase))
             {
                 if (FileUtil.HasUtf8Bom(fileName))
@@ -28778,6 +28795,35 @@ public partial class MainViewModel :
         }
     }
 
+    /// <summary>
+    /// EBU STL is a frame-based format, so while it is the active format the timecodes are shown
+    /// as HH:MM:SS:FF via a session-only override - the persisted "use frame mode" setting is left
+    /// untouched, and the display reverts when the format changes away again (#14076).
+    /// </summary>
+    private void UpdateTemporaryFrameMode()
+    {
+        var general = Se.Settings.General;
+        var wasFrameMode = general.UseFrameMode;
+        general.UseFrameModeOverride = IsFormatEbu ? true : null;
+        if (general.UseFrameMode == wasFrameMode)
+        {
+            return;
+        }
+
+        Configuration.Settings.General.UseTimeFormatHHMMSSFF = general.UseFrameMode;
+
+        foreach (var s in Subtitles)
+        {
+            s.RefreshTimeCodes();
+        }
+
+        EditBoxStartTimeUpDown?.RefreshDisplayFormat();
+        EditBoxEndTimeUpDown?.RefreshDisplayFormat();
+        EditBoxDurationUpDown?.RefreshDisplayFormat();
+        RefreshVideoSeekAmounts();
+        _updateAudioVisualizer = true;
+    }
+
     internal void ComboBoxSubtitleFormatChanged(object? sender, SelectionChangedEventArgs e)
     {
         if (!_changingFormatProgrammatically)
@@ -28802,6 +28848,8 @@ public partial class MainViewModel :
                 row.RefreshAfterSettingsChanged();
             }
         }
+
+        UpdateTemporaryFrameMode();
 
         HasFormatStyle = IsFormatAssaOrSsa || IsFormatWebVtt;
         ShowActorColumnMenuHeader = IsFormatWebVtt

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -1359,5 +1359,6 @@ public partial class SubtitleLineViewModel : ObservableObject
         OnPropertyChanged(nameof(StartTime));
         OnPropertyChanged(nameof(EndTime));
         OnPropertyChanged(nameof(Duration));
+        OnPropertyChanged(nameof(Gap));
     }
 }

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -758,7 +758,9 @@ public partial class SettingsViewModel : ObservableObject
         IsEditCustomContinuationStyleVisible = ContinuationStyle?.Code == nameof(Core.Enums.ContinuationStyle.Custom);
         CpsLineLengthStrategy = CpsLineLengthStrategies.FirstOrDefault(p => p.Code == general.CpsLineLengthStrategy) ?? CpsLineLengthStrategies.First();
 
-        UseFrameMode = general.UseFrameMode;
+        // The persisted choice, not the effective value - EBU STL may have frame mode forced on
+        // temporarily, and that must not stick just because the settings dialog was OK'ed.
+        UseFrameMode = general.UseFrameModePersisted;
         TextBoxLimitNewLines = general.SubtitleTextBoxLimitNewLines;
         NewEmptyDefaultMs = general.NewEmptyDefaultMs;
         TimeCodeUpDownStepMs = general.TimeCodeUpDownStepMs;

--- a/src/ui/Features/Video/TextToSpeech/AutoCast/SpeakerLabelParser.cs
+++ b/src/ui/Features/Video/TextToSpeech/AutoCast/SpeakerLabelParser.cs
@@ -95,6 +95,10 @@ public static partial class SpeakerLabelParser
     /// what matters is which speaker is talking for most of the line. Lines that overlap nothing
     /// (music, on-screen text, a line before the first segment) are left without an actor rather
     /// than guessed at.
+    ///
+    /// A segment's speaker is read from its actor field first: by the time the auto-cast flow gets
+    /// here, <see cref="MoveLabelsToActors"/> has already moved the label out of the text, so
+    /// re-parsing the text alone would find no speakers and quietly assign nothing.
     /// </remarks>
     public static Dictionary<Paragraph, string> AssignSpeakersByOverlap(
         IReadOnlyList<Paragraph> lines,
@@ -102,7 +106,7 @@ public static partial class SpeakerLabelParser
     {
         var byLine = new Dictionary<Paragraph, string>();
         var labelled = segments
-            .Select(s => (Speaker: TrySplit(s.Text, out var speaker, out _) ? speaker : string.Empty, Segment: s))
+            .Select(s => (Speaker: GetSegmentSpeaker(s), Segment: s))
             .Where(s => !string.IsNullOrEmpty(s.Speaker))
             .ToList();
         if (labelled.Count == 0)
@@ -133,5 +137,15 @@ public static partial class SpeakerLabelParser
         }
 
         return byLine;
+    }
+
+    private static string GetSegmentSpeaker(Paragraph segment)
+    {
+        if (!string.IsNullOrWhiteSpace(segment.Actor))
+        {
+            return segment.Actor.Trim();
+        }
+
+        return TrySplit(segment.Text, out var speaker, out _) ? speaker : string.Empty;
     }
 }

--- a/src/ui/Logic/Config/SeGeneral.cs
+++ b/src/ui/Logic/Config/SeGeneral.cs
@@ -5,6 +5,7 @@ using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace Nikse.SubtitleEdit.Logic.Config;
 
@@ -36,7 +37,27 @@ public class SeGeneral
     public bool FixContinuationStyleIgnoreLyrics { get; set; }
 
 
-    public bool UseFrameMode { get; set; } = false;
+    /// <summary>
+    /// The user's persisted frame-mode choice, stored as "UseFrameMode" in the settings file.
+    /// Read <see cref="UseFrameMode"/> instead, so the temporary override is honored.
+    /// </summary>
+    [JsonPropertyName("UseFrameMode")]
+    public bool UseFrameModePersisted { get; set; }
+
+    /// <summary>
+    /// Session-only frame mode, forced while a frame-based format (EBU STL) is the active
+    /// format (#14076). Managed by the main view when the subtitle format changes; never saved.
+    /// </summary>
+    [JsonIgnore]
+    public bool? UseFrameModeOverride { get; set; }
+
+    [JsonIgnore]
+    public bool UseFrameMode
+    {
+        get => UseFrameModeOverride ?? UseFrameModePersisted;
+        set => UseFrameModePersisted = value;
+    }
+
     public double DefaultFrameRate { get; set; }
     public double CurrentFrameRate { get; set; }
     public string DefaultSubtitleFormat { get; set; }

--- a/tests/UI/Features/Main/AutoCastApplyTests.cs
+++ b/tests/UI/Features/Main/AutoCastApplyTests.cs
@@ -1,0 +1,149 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.AutoCast;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// "Find voices in video and clone" ends by putting the detected speakers into the subtitle.
+/// These tests drive <see cref="MainViewModel.ApplyAutoCastToSubtitle"/> exactly the way
+/// ShowVideoAutoCastFromVideo does - labels already moved into the actor field by
+/// <see cref="SpeakerLabelParser.MoveLabelsToActors"/> - and check the three promises the flow
+/// makes: the lines get their actors, the format becomes ASSA (the format that keeps them), and
+/// the actor column becomes visible.
+/// </summary>
+public class AutoCastApplyTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+    private readonly string _tempDirectory;
+
+    public AutoCastApplyTests()
+    {
+        _tempDirectory = Path.Combine(Path.GetTempPath(), "SubtitleEdit.UITests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+    }
+
+    private (Window Window, MainViewModel Vm) ShowEmptyMainWindow()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1400, Height = 900 };
+        _windows.Add(window);
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var vm = (MainViewModel)view.DataContext!;
+        window.SuppressSaveChangesPromptOnClose(vm);
+        return (window, vm);
+    }
+
+    private static void Settle(Window window)
+    {
+        for (var pump = 0; pump < 5; pump++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+        }
+    }
+
+    private string WriteSrt(string name)
+    {
+        var fileName = Path.Combine(_tempDirectory, name);
+        File.WriteAllText(fileName,
+            "1" + Environment.NewLine +
+            "00:00:01,000 --> 00:00:02,000" + Environment.NewLine +
+            "Hello there." + Environment.NewLine +
+            Environment.NewLine +
+            "2" + Environment.NewLine +
+            "00:00:03,000 --> 00:00:04,000" + Environment.NewLine +
+            "Hi yourself." + Environment.NewLine);
+        return fileName;
+    }
+
+    /// <summary>
+    /// A diarized transcription the way the flow holds it right before applying: the engine's
+    /// "(Speaker N)" labels have already been moved out of the text and into the actor field.
+    /// </summary>
+    private static Subtitle MakeDiarizedTranscription()
+    {
+        var transcription = new Subtitle();
+        transcription.Paragraphs.Add(new Paragraph("(Speaker 1) Hello there.", 900, 2100));
+        transcription.Paragraphs.Add(new Paragraph("(Speaker 2) Hi yourself.", 2900, 4100));
+        SpeakerLabelParser.MoveLabelsToActors(transcription);
+        return transcription;
+    }
+
+    private static readonly Dictionary<string, string> RenamedSpeakers = new()
+    {
+        { "Speaker 1", "Alice" },
+        { "Speaker 2", "Bob" },
+    };
+
+    [AvaloniaFact]
+    public async Task OpenSubtitleGainsActorsAssaFormatAndActorColumn()
+    {
+        using var _ = new SettingsScope("General.ShowColumnActor");
+        Nikse.SubtitleEdit.Logic.Config.Se.Settings.General.ShowColumnActor = false;
+
+        var (window, vm) = ShowEmptyMainWindow();
+        await vm.SubtitleOpen(WriteSrt("autocast-open.srt"), skipLoadVideo: true);
+        Settle(window);
+        Assert.False(vm.SelectedSubtitleFormat is AdvancedSubStationAlpha);
+
+        vm.ApplyAutoCastToSubtitle(MakeDiarizedTranscription(), RenamedSpeakers);
+        Settle(window);
+
+        Assert.IsType<AdvancedSubStationAlpha>(vm.SelectedSubtitleFormat);
+        Assert.True(vm.ShowColumnActor);
+        Assert.Equal(2, vm.Subtitles.Count);
+        Assert.Equal("Alice", vm.Subtitles[0].Actor);
+        Assert.Equal("Bob", vm.Subtitles[1].Actor);
+    }
+
+    [AvaloniaFact]
+    public void TranscriptionBecomesSubtitleWithActorsWhenNothingIsOpen()
+    {
+        using var _ = new SettingsScope("General.ShowColumnActor");
+        Nikse.SubtitleEdit.Logic.Config.Se.Settings.General.ShowColumnActor = false;
+
+        var (window, vm) = ShowEmptyMainWindow();
+
+        vm.ApplyAutoCastToSubtitle(MakeDiarizedTranscription(), RenamedSpeakers);
+        Settle(window);
+
+        Assert.IsType<AdvancedSubStationAlpha>(vm.SelectedSubtitleFormat);
+        Assert.True(vm.ShowColumnActor);
+        Assert.Equal(2, vm.Subtitles.Count);
+        Assert.Equal("Alice", vm.Subtitles[0].Actor);
+        Assert.Equal("Bob", vm.Subtitles[1].Actor);
+        Assert.Equal("Hello there.", vm.Subtitles[0].Text);
+    }
+}

--- a/tests/UI/Features/Video/TextToSpeech/AutoCast/SpeakerLabelParserTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/AutoCast/SpeakerLabelParserTests.cs
@@ -107,4 +107,21 @@ public class SpeakerLabelParserTests
 
         Assert.Empty(SpeakerLabelParser.AssignSpeakersByOverlap(lines, segments));
     }
+
+    [Fact]
+    public void SegmentsWhoseLabelsAlreadyMovedToActorsStillAssignSpeakers()
+    {
+        // The auto-cast flow calls MoveLabelsToActors before assigning speakers to an open
+        // subtitle, so by then the label lives in the actor field and the text carries none -
+        // re-parsing the text alone found no speakers and left every line without an actor.
+        var lines = new List<Paragraph> { new(string.Empty, 1000, 3000) };
+        var segments = new List<Paragraph> { new("(Speaker 1) Hello.", 900, 3100) };
+        var transcription = new Subtitle();
+        transcription.Paragraphs.AddRange(segments);
+        SpeakerLabelParser.MoveLabelsToActors(transcription);
+
+        var assigned = SpeakerLabelParser.AssignSpeakersByOverlap(lines, segments);
+
+        Assert.Equal("Speaker 1", assigned[lines[0]]);
+    }
 }

--- a/tests/UI/Logic/Config/UseFrameModeOverrideTests.cs
+++ b/tests/UI/Logic/Config/UseFrameModeOverrideTests.cs
@@ -1,0 +1,63 @@
+using Nikse.SubtitleEdit.Logic.Config;
+using System.Text.Json;
+
+namespace UITests.Logic.Config;
+
+/// <summary>
+/// While EBU STL is the active format, frame mode is forced on through a session-only override
+/// (#14076). The user's own choice must survive that: the override wins while set, but only the
+/// persisted value may ever reach the settings file.
+/// </summary>
+public class UseFrameModeOverrideTests
+{
+    [Fact]
+    public void OverrideWinsWhileSet_AndSetterOnlyTouchesThePersistedValue()
+    {
+        var general = new SeGeneral
+        {
+            UseFrameModePersisted = false,
+        };
+
+        Assert.False(general.UseFrameMode);
+
+        general.UseFrameModeOverride = true;
+        Assert.True(general.UseFrameMode);
+        Assert.False(general.UseFrameModePersisted);
+
+        // An explicit set (settings dialog OK) targets the persisted value; the override keeps
+        // ruling the effective value until the main view clears it.
+        general.UseFrameMode = false;
+        Assert.True(general.UseFrameMode);
+        Assert.False(general.UseFrameModePersisted);
+
+        general.UseFrameModeOverride = null;
+        Assert.False(general.UseFrameMode);
+    }
+
+    [Fact]
+    public void ActiveOverrideIsNotSerialized()
+    {
+        var se = new Se();
+        se.General.UseFrameModePersisted = false;
+        se.General.UseFrameModeOverride = true;
+
+        var json = JsonSerializer.Serialize(se, SeJsonContext.Default.Se);
+
+        var general = JsonDocument.Parse(json).RootElement.GetProperty("General");
+        Assert.False(general.GetProperty("UseFrameMode").GetBoolean());
+        Assert.False(general.TryGetProperty("UseFrameModeOverride", out _));
+        Assert.False(general.TryGetProperty("UseFrameModePersisted", out _));
+    }
+
+    [Fact]
+    public void SettingsFileValueLoadsIntoThePersistedValue()
+    {
+        // The key kept its "UseFrameMode" name, so files written before the override existed
+        // (and by SE versions without it) round-trip unchanged.
+        var se = JsonSerializer.Deserialize("""{"General":{"UseFrameMode":true}}""", SeJsonContext.Default.Se)!;
+
+        Assert.True(se.General.UseFrameModePersisted);
+        Assert.Null(se.General.UseFrameModeOverride);
+        Assert.True(se.General.UseFrameMode);
+    }
+}

--- a/tests/UI/Logic/DialogViewModelRegistrationTests.cs
+++ b/tests/UI/Logic/DialogViewModelRegistrationTests.cs
@@ -1,0 +1,65 @@
+using Avalonia.Controls;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Features.Main;
+using System.Reflection;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// WindowService.ShowDialogAsync resolves the view model from the service provider and only then
+/// builds the window around it - so a dialog whose view model was never registered compiles fine,
+/// passes every other test, and dies with "No service for type ... has been registered" the moment
+/// a user opens it. Worse, dialogs opened from an async command die silently: the exception ends
+/// on the dispatcher and the flow just stops (this is how "Find voices in video and clone..."
+/// shipped broken - AutoCastSpeakersViewModel was never registered).
+///
+/// Every window built around a view model is found by its constructor shape - the single
+/// (SomeViewModel) constructor is exactly what ShowDialogAsync instantiates via Activator - and
+/// its view model must be resolvable from AddSubtitleEditServices.
+/// </summary>
+public class DialogViewModelRegistrationTests
+{
+    [Fact]
+    public void EveryWindowViewModelIsRegistered()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        var registered = services.Select(d => d.ServiceType).ToHashSet();
+
+        var missing = new List<string>();
+        foreach (var windowType in GetLoadableTypes(typeof(MainViewModel).Assembly))
+        {
+            if (windowType is not { IsAbstract: false } || !typeof(Window).IsAssignableFrom(windowType))
+            {
+                continue;
+            }
+
+            foreach (var constructor in windowType.GetConstructors())
+            {
+                var parameters = constructor.GetParameters();
+                if (parameters.Length == 1
+                    && parameters[0].ParameterType.Name.EndsWith("ViewModel", StringComparison.Ordinal)
+                    && !registered.Contains(parameters[0].ParameterType))
+                {
+                    missing.Add($"{windowType.Name} needs {parameters[0].ParameterType.Name}");
+                }
+            }
+        }
+
+        Assert.Empty(missing);
+    }
+
+    private static IEnumerable<Type?> GetLoadableTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException exception)
+        {
+            // Types that fail to load can't be windows we open; check the ones that did load.
+            return exception.Types;
+        }
+    }
+}

--- a/tests/libse/SubtitleFormats/EbuTest.cs
+++ b/tests/libse/SubtitleFormats/EbuTest.cs
@@ -84,6 +84,23 @@ public class EbuTest
     }
 
     [Fact]
+    public void EbuStl_Load_ExposesHeaderFrameRateOnTheParsingInstance()
+    {
+        // The SE5 main view reads the frame rate off the parsing instance's header after open, to
+        // show the file's own frame numbers in the forced HH:MM:SS:FF display (#14076).
+        Ebu.EbuUiHelper = new TestEbuUiHelper();
+        using var ms = new MemoryStream();
+        ((IBinaryPersistableSubtitle)new Ebu()).Save("test.stl", ms, MakeSubtitle(), batchMode: true);
+
+        var ebu = new Ebu();
+        ebu.LoadSubtitle(new Subtitle(), ms.ToArray());
+
+        Assert.NotNull(ebu.Header);
+        Assert.StartsWith("STL25", ebu.Header.DiskFormatCode);
+        Assert.Equal(25.0, ebu.Header.FrameRate);
+    }
+
+    [Fact]
     public void EbuStl_ToText_IsNotUsableForSaving()
     {
         // Guards the root cause: ToText is a stub for this binary format, so the save path must use


### PR DESCRIPTION
Fixes two defects in Video → More → "Find voices in video and clone..." (came up while analyzing #14106):

**With a subtitle open, no line ever got an actor.** `ShowVideoAutoCastFromVideo` moves the diarization labels out of the segment text into the actor field (`MoveLabelsToActors`) before applying — and `AssignSpeakersByOverlap` then re-parsed the segment *text* for labels that were no longer there, so it silently assigned nothing. It now reads the segment's actor field first, falling back to parsing the text.

**A failed or empty clone threw the diarization away.** The actors, the switch to ASSA, and the actor column were only applied after a fully successful clone. The cast is now applied as soon as the speakers are confirmed in the dialog, so the subtitle keeps the diarization result even when cloning then fails.

A new headless test drives `ApplyAutoCastToSubtitle` exactly the way the flow does (labels already moved to actors) and asserts the three promises on both paths: actors on the lines, ASSA selected, actor column visible. The open-subtitle case failed before the fix and passes after; a unit test in `SpeakerLabelParserTests` pins the regression directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)