### PR TITLE
TTS: offer to leave sound/music-only lines silent

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -154,6 +154,7 @@ using Nikse.SubtitleEdit.Features.Video.ShotChanges;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ActorVoices;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.AutoCast;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.SkipNoiseLines;
 using Nikse.SubtitleEdit.Features.Video.VideoOcr;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.AdvancedTtsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DownloadTts;
@@ -557,6 +558,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<ActorVoiceMappingViewModel>();
         collection.AddTransient<ActorVoiceRowSettingsViewModel>();
         collection.AddTransient<AutoCastSpeakersViewModel>();
+        collection.AddTransient<SkipNoiseLinesViewModel>();
         collection.AddTransient<TimedText10PropertiesViewModel>();
         collection.AddTransient<TimedTextImsc11PropertiesViewModel>();
         collection.AddTransient<TmpegEncXmlPropertiesViewModel>();

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -720,6 +720,7 @@ public class SettingsPage : UserControl
             MakeCheckboxSetting(Se.Language.Options.Settings.MultipleReplaceShowDotDotDotButtons, nameof(_vm.MultipleReplaceShowDotDotDotButtons)),
             MakeCheckboxSetting(Se.Language.Options.Settings.GridFocusTextboxAfterInsertNew, nameof(_vm.GridFocusTextboxAfterInsertNew)),
             MakeCheckboxSetting(Se.Language.Options.Settings.TextToSpeechPromptMergeContinuationLines, nameof(_vm.TextToSpeechPromptMergeContinuationLines)),
+            MakeCheckboxSetting(Se.Language.Options.Settings.TextToSpeechPromptSkipNoiseLines, nameof(_vm.TextToSpeechPromptSkipNoiseLines)),
             MakeCheckboxSetting(Se.Language.Options.Settings.FixCommonErrorsSkipStep1, nameof(_vm.FixCommonErrorsSkipStep1)),
             new SettingsItem(Se.Language.Options.Settings.MusicSymbol,
                 () => UiUtil.MakeTextBox(120, _vm, nameof(_vm.MusicSymbol))),

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -194,6 +194,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _multipleReplaceShowDotDotDotButtons;
     [ObservableProperty] private bool _gridFocusTextboxAfterInsertNew;
     [ObservableProperty] private bool _textToSpeechPromptMergeContinuationLines;
+    [ObservableProperty] private bool _textToSpeechPromptSkipNoiseLines;
     [ObservableProperty] private bool _openAiCompatibleSttAutoTranscribeOnAudioSelection;
 
     [ObservableProperty] private ObservableCollection<string> _spellCheckEngines;
@@ -840,6 +841,7 @@ public partial class SettingsViewModel : ObservableObject
         MultipleReplaceShowDotDotDotButtons = Se.Settings.Tools.MultipleReplaceShowDotDotDotButtons;
         GridFocusTextboxAfterInsertNew = Se.Settings.Tools.GridFocusTextboxAfterInsertNew;
         TextToSpeechPromptMergeContinuationLines = Se.Settings.Tools.TextToSpeechPromptMergeContinuationLines;
+        TextToSpeechPromptSkipNoiseLines = Se.Settings.Tools.TextToSpeechPromptSkipNoiseLines;
         OpenAiCompatibleSttAutoTranscribeOnAudioSelection = Se.Settings.Tools.OpenAiCompatibleSttAutoTranscribeOnAudioSelection;
         FixCommonErrorsSkipStep1 = Se.Settings.Tools.FixCommonErrors.SkipStep1;
         MusicSymbol = Se.Settings.Tools.MusicSymbol;
@@ -1690,6 +1692,7 @@ public partial class SettingsViewModel : ObservableObject
         Se.Settings.Tools.MultipleReplaceShowDotDotDotButtons = MultipleReplaceShowDotDotDotButtons;
         Se.Settings.Tools.GridFocusTextboxAfterInsertNew = GridFocusTextboxAfterInsertNew;
         Se.Settings.Tools.TextToSpeechPromptMergeContinuationLines = TextToSpeechPromptMergeContinuationLines;
+        Se.Settings.Tools.TextToSpeechPromptSkipNoiseLines = TextToSpeechPromptSkipNoiseLines;
         Se.Settings.Tools.FixCommonErrors.SkipStep1 = FixCommonErrorsSkipStep1;
         Se.Settings.Tools.WriteToolsLog = WriteToolsLog;
         Se.Settings.Tools.OpenAiCompatibleSttAutoTranscribeOnAudioSelection = OpenAiCompatibleSttAutoTranscribeOnAudioSelection;

--- a/src/ui/Features/Video/TextToSpeech/SkipNoiseLines/NoiseLineDetector.cs
+++ b/src/ui/Features/Video/TextToSpeech/SkipNoiseLines/NoiseLineDetector.cs
@@ -1,0 +1,40 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.SkipNoiseLines;
+
+/// <summary>
+/// Finds subtitle lines that carry no speech - SDH sound and music annotations like "♪",
+/// "[door slams]" or "(sighs)", and lines that are empty once formatting tags are stripped.
+/// Sent to a TTS engine, such lines get read aloud or hallucinated into made-up words
+/// (issue #14106); the generate flow offers to leave them silent instead.
+/// </summary>
+public static class NoiseLineDetector
+{
+    /// <summary>
+    /// True when the line holds nothing a voice should say: whitespace, tags only, or only
+    /// bracketed/parenthesised groups and music symbols. A sound annotation followed by real
+    /// speech ("[gunshot] Get down!") is speech and is kept.
+    /// </summary>
+    public static bool IsNoiseOnly(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return true;
+        }
+
+        if (HtmlUtil.RemoveHtmlTags(text, true).Trim().Length == 0)
+        {
+            return true;
+        }
+
+        return SpeechToTextQualityReport.IsNonSpeechLine(text);
+    }
+
+    public static List<Paragraph> Detect(Subtitle subtitle)
+    {
+        return subtitle.Paragraphs.Where(p => IsNoiseOnly(p.Text)).ToList();
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/SkipNoiseLines/SkipNoiseLineRow.cs
+++ b/src/ui/Features/Video/TextToSpeech/SkipNoiseLines/SkipNoiseLineRow.cs
@@ -1,0 +1,25 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.SkipNoiseLines;
+
+public partial class SkipNoiseLineRow : ObservableObject
+{
+    [ObservableProperty] private bool _isSelected;
+
+    public int Number { get; }
+    public string Show { get; }
+    public string Text { get; }
+    public Paragraph Paragraph { get; }
+
+    public SkipNoiseLineRow(Paragraph paragraph)
+    {
+        // Every detected line starts checked - the whole point of the dialog is skipping them,
+        // unchecking is for the occasional false positive.
+        IsSelected = true;
+        Number = paragraph.Number;
+        Show = paragraph.StartTime.ToDisplayString();
+        Text = paragraph.Text;
+        Paragraph = paragraph;
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/SkipNoiseLines/SkipNoiseLinesViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/SkipNoiseLines/SkipNoiseLinesViewModel.cs
@@ -1,0 +1,83 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic.Config;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.SkipNoiseLines;
+
+public partial class SkipNoiseLinesViewModel : ObservableObject
+{
+    [ObservableProperty] private ObservableCollection<SkipNoiseLineRow> _rows;
+    [ObservableProperty] private SkipNoiseLineRow? _selectedRow;
+    [ObservableProperty] private string _rowsInfo;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    /// <summary>The lines the user confirmed should stay silent - no speech is generated for them.</summary>
+    public List<Paragraph> SelectedParagraphs { get; private set; }
+
+    public SkipNoiseLinesViewModel()
+    {
+        Rows = new ObservableCollection<SkipNoiseLineRow>();
+        SelectedParagraphs = new List<Paragraph>();
+        RowsInfo = string.Empty;
+    }
+
+    public void Initialize(List<Paragraph> noiseLines)
+    {
+        Rows.Clear();
+        foreach (var paragraph in noiseLines)
+        {
+            Rows.Add(new SkipNoiseLineRow(paragraph));
+        }
+
+        RowsInfo = string.Format(Se.Language.Video.TextToSpeech.SkipNoiseLinesFoundX, Rows.Count);
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        SelectedParagraphs = Rows.Where(r => r.IsSelected).Select(r => r.Paragraph).ToList();
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Window?.Close();
+    }
+
+    [RelayCommand]
+    private void SelectAll()
+    {
+        foreach (var row in Rows)
+        {
+            row.IsSelected = true;
+        }
+    }
+
+    [RelayCommand]
+    private void InverseSelection()
+    {
+        foreach (var row in Rows)
+        {
+            row.IsSelected = !row.IsSelected;
+        }
+    }
+
+    internal void KeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/SkipNoiseLines/SkipNoiseLinesWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/SkipNoiseLines/SkipNoiseLinesWindow.cs
@@ -1,0 +1,128 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
+using Avalonia.Data;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.SkipNoiseLines;
+
+public class SkipNoiseLinesWindow : Window
+{
+    public SkipNoiseLinesWindow(SkipNoiseLinesViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = UiUtil.MakeWindowTitle(Se.Language.Video.TextToSpeech.SkipNoiseLinesTitle);
+        CanResize = true;
+        Width = 800;
+        Height = 600;
+        MinWidth = 600;
+        MinHeight = 400;
+        vm.Window = this;
+        DataContext = vm;
+
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        var panelButtons = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            Margin = UiUtil.MakeWindowMargin(),
+            ColumnSpacing = 10,
+            RowSpacing = 10,
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+
+        var labelInfo = UiUtil.MakeLabel().WithBindText(vm, nameof(vm.RowsInfo));
+
+        grid.Add(labelInfo, 0);
+        grid.Add(UiUtil.MakeBorderForControlNoPadding(MakeRowsView(vm)), 1);
+        grid.Add(UiUtil.MakeButtonBar(
+            UiUtil.MakeButton(Se.Language.General.SelectAll, vm.SelectAllCommand),
+            UiUtil.MakeButton(Se.Language.General.InvertSelection, vm.InverseSelectionCommand)), 2);
+        grid.Add(panelButtons, 3);
+
+        Content = grid;
+
+        Activated += delegate { buttonOk.Focus(); };
+        KeyDown += vm.KeyDown;
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
+    }
+
+    private static Control MakeRowsView(SkipNoiseLinesViewModel vm)
+    {
+        var dataGrid = TableViewExtras.MakeTableView();
+        dataGrid.Width = double.NaN;
+        dataGrid.Height = double.NaN;
+        dataGrid.DataContext = vm;
+        dataGrid.ItemsSource = vm.Rows;
+
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.Video.TextToSpeech.SkipNoiseLinesColumnSkip,
+            CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            CellTemplate = new FuncDataTemplate<SkipNoiseLineRow>((_, _) => new Border
+            {
+                Background = Brushes.Transparent,
+                Padding = new Avalonia.Thickness(4),
+                Child = new CheckBox
+                {
+                    Focusable = false,
+                    [!ToggleButton.IsCheckedProperty] = new Binding(nameof(SkipNoiseLineRow.IsSelected))
+                    {
+                        Mode = BindingMode.TwoWay,
+                    },
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                },
+            }),
+            Width = new GridLength(80),
+        });
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.NumberSymbol,
+            Binding = new Binding(nameof(SkipNoiseLineRow.Number)),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Width = new GridLength(60),
+        });
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Show,
+            Binding = new Binding(nameof(SkipNoiseLineRow.Show)),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Width = new GridLength(120),
+        });
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Text,
+            Binding = new Binding(nameof(SkipNoiseLineRow.Text)),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Width = new GridLength(1, GridUnitType.Star),
+        });
+
+        TableViewExtras.AddSpaceToggle<SkipNoiseLineRow>(dataGrid,
+            item => item.IsSelected,
+            (item, value) => item.IsSelected = value);
+
+        return dataGrid;
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -28,6 +28,7 @@ using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DotsTtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTts25AudioCppSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.KokoroTtsSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.SkipNoiseLines;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.PiperSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.OmniVoiceSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Qwen3TtsCrispAsrSettings;
@@ -1129,6 +1130,58 @@ public partial class TextToSpeechViewModel : ObservableObject
     }
 
     /// <summary>
+    /// Lines the user chose to leave silent in this generation run (SDH sound/music annotations
+    /// like "♪" or "[door slams]" - see <see cref="NoiseLineDetector"/>). Held by reference:
+    /// the set is filled from and checked against the same <see cref="_subtitle"/> instance,
+    /// after any merge prompt has replaced it.
+    /// </summary>
+    private readonly HashSet<Paragraph> _skipNoiseParagraphs = new();
+
+    /// <summary>
+    /// Like the merge-continuation-lines prompt: sound/music-only lines get read aloud or
+    /// hallucinated into made-up words by TTS engines (#14106), so before generating, the lines
+    /// that carry no speech are offered for review and left silent. Runs after the merge prompt -
+    /// that one can replace <see cref="_subtitle"/>.
+    /// </summary>
+    private async Task PromptSkipNoiseLines()
+    {
+        _skipNoiseParagraphs.Clear();
+        if (Window == null)
+        {
+            return;
+        }
+
+        var noiseLines = NoiseLineDetector.Detect(_subtitle);
+        if (noiseLines.Count == 0)
+        {
+            return;
+        }
+
+        var answer = await MessageBox.Show(
+            Window!,
+            Se.Language.Video.TextToSpeech.SkipNoiseLinesPromptTitle,
+            Se.Language.Video.TextToSpeech.SkipNoiseLinesPromptMessage,
+            MessageBoxButtons.YesNo,
+            MessageBoxIcon.Question);
+        if (answer != MessageBoxResult.Yes)
+        {
+            return;
+        }
+
+        var result = await _windowService.ShowDialogAsync<SkipNoiseLinesWindow, SkipNoiseLinesViewModel>(
+            Window!, vm => vm.Initialize(noiseLines));
+        if (!result.OkPressed)
+        {
+            return;
+        }
+
+        foreach (var paragraph in result.SelectedParagraphs)
+        {
+            _skipNoiseParagraphs.Add(paragraph);
+        }
+    }
+
+    /// <summary>
     /// Stop the crispasr.exe servers of every CrispASR-based TTS engine EXCEPT
     /// <paramref name="keepAlive"/>. Pass null to stop all four. Called before starting synth
     /// (Test Voice / Generate TTS) and on window close, so models from previously selected
@@ -1207,6 +1260,14 @@ public partial class TextToSpeechViewModel : ObservableObject
         if (Se.Settings.Tools.TextToSpeechPromptMergeContinuationLines)
         {
             await PromptMergeContinuationLines();
+        }
+
+        // Cleared unconditionally so a run with the prompt turned off never inherits skips from
+        // an earlier run in the same window.
+        _skipNoiseParagraphs.Clear();
+        if (Se.Settings.Tools.TextToSpeechPromptSkipNoiseLines)
+        {
+            await PromptSkipNoiseLines();
         }
 
         var voice = SelectedVoice;
@@ -2629,11 +2690,23 @@ public partial class TextToSpeechViewModel : ObservableObject
             // segments failed (e.g. the ElevenLabs 429 text) instead of a bare count (#12093).
             var errorMessages = new List<string>();
             _speakRetryFailures = 0;
+            var skippedNoiseCount = 0;
 
             for (var index = 0; index < _subtitle.Paragraphs.Count; index++)
             {
                 ProgressText = $"Generating speech: segment {index + 1} of {_subtitle.Paragraphs.Count}";
                 var paragraph = _subtitle.Paragraphs[index];
+
+                // A line the user chose to leave silent gets no step result at all - exactly like
+                // a failed line downstream (FixSpeed drops it, the merge keeps the base silence
+                // track over its span) but without counting as a failure anywhere.
+                if (_skipNoiseParagraphs.Contains(paragraph))
+                {
+                    skippedNoiseCount++;
+                    ProgressValue = (double)(index + 1) / _subtitle.Paragraphs.Count * 100.0;
+                    continue;
+                }
+
                 var resolution = ResolveVoiceForParagraph(paragraph, castContext, engine, voice);
                 // When the row's engine differs from the globally selected engine, the global
                 // SelectedLanguage/SelectedRegion/SelectedModel were resolved for a different
@@ -2692,6 +2765,11 @@ public partial class TextToSpeechViewModel : ObservableObject
                 }
             }
             ProgressValue = 100;
+
+            if (skippedNoiseCount > 0)
+            {
+                Se.WriteToolsLog($"TTS generation: left {skippedNoiseCount} sound/music lines silent (skipped by user choice)");
+            }
 
             var failedCount = resultList.Count(r => string.IsNullOrEmpty(r.CurrentFileName));
             // First engine-reported failure reason, e.g. the ElevenLabs 429 text. The generic

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -310,6 +310,7 @@ public class LanguageSettings
     public string MusicSymbol { get; set; }
     public string MusicSymbolsToReplace { get; set; }
     public string TextToSpeechPromptMergeContinuationLines { get; set; }
+    public string TextToSpeechPromptSkipNoiseLines { get; set; }
     public string UseFocusedButtonBackgroundColor { get; set; }
     public string FocusedButtonBackgroundColor { get; set; }
     public string ForceCrLfOnSave { get; set; }
@@ -644,6 +645,7 @@ public class LanguageSettings
         MusicSymbol = "Music symbol";
         MusicSymbolsToReplace = "Music symbols to replace (separated by comma)";
         TextToSpeechPromptMergeContinuationLines = "Text to speech: prompt to merge continuation lines";
+        TextToSpeechPromptSkipNoiseLines = "Text to speech: prompt to skip sound/music lines";
         UseFocusedButtonBackgroundColor = "Use focused button background color";
         FocusedButtonBackgroundColor = "Focused button background color";
         ForceCrLfOnSave = "Force CR+LF on save (text subtitle files)";

--- a/src/ui/Logic/Config/Language/Video/LanguageTextToSpeech.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageTextToSpeech.cs
@@ -144,6 +144,11 @@ public class LanguageTextToSpeech
     public string NoWebVttVoicesFoundMessage { get; set; }
     public string MergeContinuationLinesPromptTitle { get; set; }
     public string MergeContinuationLinesPromptMessage { get; set; }
+    public string SkipNoiseLinesPromptTitle { get; set; }
+    public string SkipNoiseLinesPromptMessage { get; set; }
+    public string SkipNoiseLinesTitle { get; set; }
+    public string SkipNoiseLinesFoundX { get; set; }
+    public string SkipNoiseLinesColumnSkip { get; set; }
 
     // Applying the TTS window's changes (review text edits, merged lines) back to the subtitle
     public string SubtitleUpdatedFromReviewSingular { get; set; }
@@ -288,6 +293,13 @@ public class LanguageTextToSpeech
         MergeContinuationLinesPromptMessage = "Some lines appear to be a single sentence split across multiple subtitles." + Environment.NewLine + Environment.NewLine +
                                               "Merging them before generation lets the TTS engine speak each thought as one breath group, which usually sounds more natural." + Environment.NewLine + Environment.NewLine +
                                               "Review and apply merges now?";
+        SkipNoiseLinesPromptTitle = "Skip sound and music lines?";
+        SkipNoiseLinesPromptMessage = "Some lines contain only sounds or music - like ♪ or [door slams]." + Environment.NewLine + Environment.NewLine +
+                                      "Speech engines try to read such lines aloud and often make up words." + Environment.NewLine + Environment.NewLine +
+                                      "Review these lines and leave them silent?";
+        SkipNoiseLinesTitle = "Lines with only sounds or music";
+        SkipNoiseLinesFoundX = "{0} lines contain only sounds or music - checked lines are left silent";
+        SkipNoiseLinesColumnSkip = "Skip";
 
         SubtitleUpdatedFromReviewSingular = "Updated one line from the speech review";
         SubtitleUpdatedFromReviewPlural = "Updated {0} lines from the speech review";

--- a/src/ui/Logic/Config/SeTools.cs
+++ b/src/ui/Logic/Config/SeTools.cs
@@ -136,6 +136,7 @@ public class SeTools
     public bool MultipleReplaceShowDotDotDotButtons { get; set; }
     public bool GridFocusTextboxAfterInsertNew { get; set; }
     public bool TextToSpeechPromptMergeContinuationLines { get; set; }
+    public bool TextToSpeechPromptSkipNoiseLines { get; set; }
 
     // OpenAI Compatible STT settings
     public string OpenAiCompatibleSttUrl { get; set; } = "http://localhost:8000/v1/audio/transcriptions";
@@ -260,6 +261,7 @@ public class SeTools
         AllowSingleLetterShortcutsInTextbox = false;
         WriteToolsLog = true;
         TextToSpeechPromptMergeContinuationLines = true;
+        TextToSpeechPromptSkipNoiseLines = true;
 
         LastColorPickerColor = Colors.Yellow.FromColorToHex();
         LastColorPickerColor1 = Colors.Red.FromColorToHex();

--- a/tests/UI/Features/Video/TextToSpeech/SkipNoiseLines/NoiseLineDetectorTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/SkipNoiseLines/NoiseLineDetectorTests.cs
@@ -1,0 +1,51 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.SkipNoiseLines;
+
+namespace UITests.Features.Video.TextToSpeech.SkipNoiseLines;
+
+public class NoiseLineDetectorTests
+{
+    [Theory]
+    [InlineData("♪")]
+    [InlineData("♪ [Suspenseful]")]
+    [InlineData("[ambient sounds]")]
+    [InlineData("(sighs)")]
+    [InlineData("[door slams] [glass breaks]")]
+    [InlineData("<i>♪</i>")]
+    [InlineData("{\\an8}[music]")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    [InlineData("<i></i>")]
+    public void SoundAndMusicOnlyLinesAreNoise(string? text)
+    {
+        Assert.True(NoiseLineDetector.IsNoiseOnly(text));
+    }
+
+    [Theory]
+    [InlineData("Hello there.")]
+    [InlineData("NARRATOR: Text")]
+    [InlineData("[gunshot] Get down!")]
+    [InlineData("♪ sweet dreams are made of this ♪")]
+    [InlineData("(Speaker 1) Henry.")]
+    public void LinesWithSpeechAreKept(string text)
+    {
+        Assert.False(NoiseLineDetector.IsNoiseOnly(text));
+    }
+
+    [Fact]
+    public void DetectReturnsOnlyTheNoiseLines()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("NARRATOR:\nText", 0, 1000));
+        subtitle.Paragraphs.Add(new Paragraph("♪ [Suspenseful]", 2000, 3000));
+        subtitle.Paragraphs.Add(new Paragraph("More text", 4000, 5000));
+        subtitle.Paragraphs.Add(new Paragraph("♪", 6000, 7000));
+
+        var noise = NoiseLineDetector.Detect(subtitle);
+
+        Assert.Equal(2, noise.Count);
+        Assert.Same(subtitle.Paragraphs[1], noise[0]);
+        Assert.Same(subtitle.Paragraphs[3], noise[1]);
+    }
+}


### PR DESCRIPTION
Second piece of the #14106 work (after #14108): the TTS generate flow now handles SDH noise lines the same way it handles continuation lines — with a setting-gated prompt before generation.

**What it does:** Generate detects lines that carry no speech — `♪`, `[door slams]`, `(sighs)`, or lines empty once tags are stripped — and asks whether to leave them silent. A review dialog lists the detected lines with checkboxes (all checked by default; the merge dialog's layout). Checked lines get no engine call and no step result, so the base silence track covers their span, they never count as generation failures, and the review window simply doesn't list them.

**Detection:** reuses `SpeechToTextQualityReport.IsNonSpeechLine` — the whole line must consist of bracketed/parenthesised groups or music symbols, so `[gunshot] Get down!` and sung lyrics between notes are still spoken.

**Setting:** "Text to speech: prompt to skip sound/music lines", on by default, next to the merge prompt setting. The prompt runs after the merge prompt (which can replace the working subtitle).

Covered by detector unit tests (the #14106 examples plus negatives), and the new dialog registration is enforced by the DI guard test from #14108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)