### PR TITLE
Convert actors: read a tag the line splitter broke in half

### DIFF
--- a/src/libse/Common/ActorConverter.cs
+++ b/src/libse/Common/ActorConverter.cs
@@ -178,10 +178,47 @@ namespace Nikse.SubtitleEdit.Core.Common
             return line.Trim().IndexOf(ch) > 0;
         }
 
+        /// <summary>
+        /// A line splitter can break a tag in half - "Princess Peach on (Speaker\n2) Super Smash
+        /// Bros." - and the per-line scan in <see cref="FixActors"/> then finds no complete pair on
+        /// either line, so the paragraph was silently left alone. Line breaks inside a bracket pair
+        /// are folded to a space, pulling the two half-lines together. Capped at name length: a
+        /// bracket pair spanning that much text is a parenthetical remark, not a speaker tag.
+        /// </summary>
+        private static string JoinTagBrokenOverLineBreak(string text, char start, char end)
+        {
+            const int maxTagLength = 50;
+
+            var startIdx = text.IndexOf(start);
+            while (startIdx >= 0)
+            {
+                var endIdx = text.IndexOf(end, startIdx + 1);
+                if (endIdx < 0)
+                {
+                    break;
+                }
+
+                var inner = text.Substring(startIdx + 1, endIdx - startIdx - 1);
+                if (inner.Length <= maxTagLength &&
+                    inner.IndexOf(start) < 0 &&
+                    (inner.Contains('\n') || inner.Contains('\r')))
+                {
+                    var joined = string.Join(" ", inner.Split((char[])null, StringSplitOptions.RemoveEmptyEntries));
+                    text = text.Substring(0, startIdx + 1) + joined + text.Substring(endIdx);
+                    endIdx = startIdx + 1 + joined.Length;
+                }
+
+                startIdx = text.IndexOf(start, endIdx + 1);
+            }
+
+            return text;
+        }
+
         public ActorConverterResult FixActors(Paragraph paragraph, char start, char end, int? changeCasing, SKColor? color)
         {
             var p = new Paragraph(paragraph, false);
             Paragraph nextParagraph = null;
+            p.Text = JoinTagBrokenOverLineBreak(p.Text, start, end);
             var lines = p.Text.SplitToLines();
             if (lines.Count > 2)
             {

--- a/tests/UI/Features/Tools/ConvertActorsTests.cs
+++ b/tests/UI/Features/Tools/ConvertActorsTests.cs
@@ -105,6 +105,49 @@ public class ConvertActorsTests
         Assert.Empty(vm.Subtitles);
     }
 
+    /// <summary>
+    /// A speaker tag the line splitter broke in half - "(Speaker\n2)" - found no complete pair on
+    /// either line, so the paragraph was silently left alone and the actor column stayed empty.
+    /// </summary>
+    [AvaloniaFact]
+    public void ParenthesesBrokenOverLineBreakToActor_StillWritesTheActorColumn()
+    {
+        var rows = Convert(
+            ConvertActorType.InlineParentheses,
+            ConvertActorType.Actor,
+            "Princess Peach on (Speaker" + Environment.NewLine + "2) Super Smash Bros.");
+
+        Assert.Equal(new[] { "Princess Peach on Super Smash Bros." }, rows.Select(r => r.Text));
+        Assert.Equal(new[] { "Speaker 2" }, rows.Select(r => r.Actor));
+    }
+
+    [AvaloniaFact]
+    public void SquareBracketsBrokenOverLineBreakToActor_StillWritesTheActorColumn()
+    {
+        var rows = Convert(
+            ConvertActorType.InlineSquareBrackets,
+            ConvertActorType.Actor,
+            "[NAR" + Environment.NewLine + "RATOR] Once upon a time.");
+
+        Assert.Equal(new[] { "Once upon a time." }, rows.Select(r => r.Text));
+        Assert.Equal(new[] { "NAR RATOR" }, rows.Select(r => r.Actor));
+    }
+
+    /// <summary>
+    /// A parenthetical remark spanning lines is prose, not a broken speaker tag - joining it would
+    /// silently reflow the paragraph, so anything longer than a name is left alone.
+    /// </summary>
+    [AvaloniaFact]
+    public void LongParentheticalOverLineBreak_IsNotJoined()
+    {
+        var text = "He said (which nobody in the whole room actually believed" + Environment.NewLine +
+                   "for even a single second) that he would come.";
+        var rows = Convert(ConvertActorType.InlineParentheses, ConvertActorType.Actor, text);
+
+        Assert.Equal(new[] { text }, rows.Select(r => r.Text));
+        Assert.Equal(new[] { string.Empty }, rows.Select(r => r.Actor));
+    }
+
     private static List<SubtitleLineViewModel> Convert(ConvertActorType from, ConvertActorType to, params string[] texts)
         => Convert(from, to, new SubRip(), texts.Select(t => (Text: t, Actor: string.Empty)).ToArray());
 


### PR DESCRIPTION
Fixes the case found while testing the #14106 workflow: a speaker tag with the line break inside it —

```
Princess Peach on (Speaker
2) Super Smash Bros.
```

— which the STT post-processor's line splitting produces. `ActorConverter.FixActors` scans line by line, so neither half-line held a complete bracket pair and the paragraph was silently left alone with an empty actor column.

Line breaks inside a bracket pair are now folded to a space before the per-line scan, pulling the two half-lines together (`(Speaker 2)` → actor "Speaker 2", text rejoined on one line). The join is capped at name length (50 chars) so a genuine parenthetical remark spanning lines is not reflowed — covered by tests for both bracket styles plus the long-parenthetical negative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)