### PR TITLE
Italian OCR fix list: E' with apostrophe to È, gated on the dictionary

### DIFF
--- a/Dictionaries/ita_OCRFixReplaceList.xml
+++ b/Dictionaries/ita_OCRFixReplaceList.xml
@@ -114,6 +114,14 @@
     <RegEx find="\b([a-zàèéìòóù]{2,})u\b" spellCheck="$1ù" replaceWith="$1ù" />
 
     <!-- ============================================================ -->
+    <!-- E' SCRITTO CON APOSTROFO AL POSTO DI È                       -->
+    <!-- E' un problema in È un problema (issue #14092). Copre sia    -->
+    <!-- l'apostrofo dritto sia quello tipografico; non tocca la E    -->
+    <!-- seguita da un'elisione staccata (E 'sti soldi).              -->
+    <!-- ============================================================ -->
+    <RegEx find="\bE['’](?![\p{L}\p{N}])" spellCheck="È" replaceWith="È" />
+
+    <!-- ============================================================ -->
     <!-- SPAZIO PERSO TRA PREPOSIZIONE/ARTICOLO E NOME PROPRIO        -->
     <!-- daRoma in da Roma : solo se la parola con maiuscola è nel    -->
     <!-- dizionario.                                                  -->

--- a/Dictionaries/ita_OCRFixReplaceList.xml
+++ b/Dictionaries/ita_OCRFixReplaceList.xml
@@ -64,7 +64,12 @@
     <RegEx find="\b\|\b" replaceWith="I" />
     <RegEx find="([\p{Ll},] )(I)([oai][, \.])" replaceWith="$1l$3" />
     <RegEx find="\b(I)([àì]|'[ \r\n])\b" replaceWith="l$2" />
-    <RegEx find="([\p{Ll},] )(II)\b" replaceWith="$1Il" />  
+    <RegEx find="([\p{Ll},] )(II)\b" replaceWith="$1Il" />
+    <!-- E' scritto con apostrofo al posto di È (issue #14092). Il contesto sinistro esplicito
+         evita di mangiare la virgoletta di chiusura di una lettera citata ('E' resta 'E');
+         il lookahead protegge le elisioni attaccate (E'sti). -->
+    <RegEx find="(^|[\s&quot;«(\[\-–—…])E['’](?![\p{L}\p{N}])" replaceWith="$1È" />
+    <RegEx find="(\p{L}['’])E['’](?![\p{L}\p{N}])" replaceWith="$1È" /> <!-- COS'E' in COS'È -->
   </RegularExpressions>
   <RegularExpressionsIfSpelledCorrectly>
     <!-- Italic l misread as i (#13660): trailing i to l, double ii to ll.  -->
@@ -112,14 +117,6 @@
     <RegEx find="\b([a-zàèéìòóù]{2,})i\b" spellCheck="$1ì" replaceWith="$1ì" />
     <RegEx find="\b([a-zàèéìòóù]{2,})o\b" spellCheck="$1ò" replaceWith="$1ò" />
     <RegEx find="\b([a-zàèéìòóù]{2,})u\b" spellCheck="$1ù" replaceWith="$1ù" />
-
-    <!-- ============================================================ -->
-    <!-- E' SCRITTO CON APOSTROFO AL POSTO DI È                       -->
-    <!-- E' un problema in È un problema (issue #14092). Copre sia    -->
-    <!-- l'apostrofo dritto sia quello tipografico; non tocca la E    -->
-    <!-- seguita da un'elisione staccata (E 'sti soldi).              -->
-    <!-- ============================================================ -->
-    <RegEx find="\bE['’](?![\p{L}\p{N}])" spellCheck="È" replaceWith="È" />
 
     <!-- ============================================================ -->
     <!-- SPAZIO PERSO TRA PREPOSIZIONE/ARTICOLO E NOME PROPRIO        -->

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixItalianAccentAndCapsTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixItalianAccentAndCapsTests.cs
@@ -104,6 +104,30 @@ public class OcrFixItalianAccentAndCapsTests : IDisposable
         Assert.Equal(text, result.GetText());
     }
 
+    [Theory]
+    [InlineData("E' un problema.", "È un problema.")] // straight apostrophe
+    [InlineData("- E' vero!", "- È vero!")] // after a dialog dash
+    [InlineData("E’ tardi.", "È tardi.")] // typographic apostrophe
+    public void FixOcrErrors_CapitalEWithApostrophe_BecomesEGrave(string text, string expected)
+    {
+        var engine = CreateEngine();
+
+        var result = engine.FixOcrErrors(0, text, doTryToGuessUnknownWords: false);
+
+        Assert.Equal(expected, result.GetText());
+    }
+
+    [Theory]
+    [InlineData("E 'sti soldi, Zzyzx?")] // the apostrophe belongs to the next word (elision)
+    public void FixOcrErrors_CapitalEBeforeDetachedElision_IsLeftAlone(string text)
+    {
+        var engine = CreateEngine();
+
+        var result = engine.FixOcrErrors(0, text, doTryToGuessUnknownWords: false);
+
+        Assert.Equal(text, result.GetText());
+    }
+
     [Fact]
     public void FixOcrErrors_WithoutADictionary_AccentRulesDoNothing()
     {
@@ -129,6 +153,7 @@ public class OcrFixItalianAccentAndCapsTests : IDisposable
             "la", "città", "e", "bella", "non", "so", "perché", "si", "fa", "così",
             "ne", "voglio", "di", "più", "prendo", "un", "caffè", "va", "bene", "però",
             "ora", "musica", "fine", "vieni", "anche", "tu", "canta",
+            "è", "problema", "vero", "tardi",
         };
 
         public bool Initialize(string dictionaryFile, string twoLetterLanguageCode) => true;

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixItalianAccentAndCapsTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixItalianAccentAndCapsTests.cs
@@ -13,6 +13,8 @@ namespace UITests.Features.Ocr.FixEngine;
 // caffe -> caffè - both accents are tried, the dictionary picks the right one) and l/I
 // confusion in all-caps captions. A rule is only applied when the misread form is NOT in the
 // dictionary and the fixed form IS; lowercase-only classes keep proper names untouched.
+// The E' -> È rule (issue #14092) is ungated on purpose - it must work without a dictionary -
+// and relies on explicit left context so a quoted letter ('E') keeps its closing quote.
 // Runs against the shipped Dictionaries/ita_OCRFixReplaceList.xml, not a copy of its rules.
 public class OcrFixItalianAccentAndCapsTests : IDisposable
 {
@@ -94,6 +96,11 @@ public class OcrFixItalianAccentAndCapsTests : IDisposable
     [Theory]
     [InlineData("Vieni anche tu Zzyzx.")] // correct -e word is in the dictionary
     [InlineData("Maria canta Zzyzx.")] // capitalized name is never accented
+    [InlineData("E 'sti soldi, Zzyzx?")] // the apostrophe belongs to the next word
+    [InlineData("E'sti soldi, Zzyzx?")] // glued elision - guarded by the E' rule's lookahead
+    [InlineData("Ha detto la lettera 'E', Zzyzx.")] // quoted letter must keep its closing quote
+    [InlineData("La lettera ‘E’ canta, Zzyzx.")] // same with typographic quotes
+    [InlineData("Negli anni '80, Zzyzx.")] // decade apostrophe
     public void FixOcrErrors_CorrectWordsAndNames_AreLeftAlone(string text)
     {
         // "Zzyzx" keeps the line from being spelled OK, so every gated rule really runs.
@@ -108,6 +115,9 @@ public class OcrFixItalianAccentAndCapsTests : IDisposable
     [InlineData("E' un problema.", "È un problema.")] // straight apostrophe
     [InlineData("- E' vero!", "- È vero!")] // after a dialog dash
     [InlineData("E’ tardi.", "È tardi.")] // typographic apostrophe
+    [InlineData("«E' colpa mia», disse.", "«È colpa mia», disse.")] // inside guillemets
+    [InlineData("COS'E' successo, Zzyzx?", "COS'È successo, Zzyzx?")] // after an elision
+    [InlineData("PIU' TARDI, E' PROBABILE.", "PIU' TARDI, È PROBABILE.")] // all caps
     public void FixOcrErrors_CapitalEWithApostrophe_BecomesEGrave(string text, string expected)
     {
         var engine = CreateEngine();
@@ -117,15 +127,16 @@ public class OcrFixItalianAccentAndCapsTests : IDisposable
         Assert.Equal(expected, result.GetText());
     }
 
-    [Theory]
-    [InlineData("E 'sti soldi, Zzyzx?")] // the apostrophe belongs to the next word (elision)
-    public void FixOcrErrors_CapitalEBeforeDetachedElision_IsLeftAlone(string text)
+    [Fact]
+    public void FixOcrErrors_CapitalEWithApostrophe_WorksWithoutADictionary()
     {
-        var engine = CreateEngine();
+        // The rule is ungated on purpose: it must also help users who never
+        // downloaded an Italian spell check dictionary.
+        var engine = CreateEngine(new EmptySpellChecker());
 
-        var result = engine.FixOcrErrors(0, text, doTryToGuessUnknownWords: false);
+        var result = engine.FixOcrErrors(0, "E' un problema.", doTryToGuessUnknownWords: false);
 
-        Assert.Equal(text, result.GetText());
+        Assert.Equal("È un problema.", result.GetText());
     }
 
     [Fact]
@@ -153,7 +164,6 @@ public class OcrFixItalianAccentAndCapsTests : IDisposable
             "la", "città", "e", "bella", "non", "so", "perché", "si", "fa", "così",
             "ne", "voglio", "di", "più", "prendo", "un", "caffè", "va", "bene", "però",
             "ora", "musica", "fine", "vieni", "anche", "tu", "canta",
-            "è", "problema", "vero", "tardi",
         };
 
         public bool Initialize(string dictionaryFile, string twoLetterLanguageCode) => true;


### PR DESCRIPTION
Fixes the classic Italian typo / OCR misread `E'` (capital E + apostrophe standing in for È), as suggested in [this comment on #14092](https://github.com/SubtitleEdit/subtitleedit/issues/14092#issuecomment-5412577294).

**v2 (current):** two ungated line regexes in `ita_OCRFixReplaceList.xml`:

```xml
<RegEx find="(^|[\s&quot;«(\[\-–—…])E['’](?![\p{L}\p{N}])" replaceWith="$1È" />
<RegEx find="(\p{L}['’])E['’](?![\p{L}\p{N}])" replaceWith="$1È" /> <!-- COS'E' -> COS'È -->
```

- **Ungated**, so it works on installs without an it_IT Hunspell dictionary (only `en_US.dic` ships) and in seconv.
- **Explicit left context** (line start, whitespace, `"`, `«`, brackets, dashes, ellipsis) so a quoted letter — `la lettera 'E'` — is never touched; the first version's `\b` matched there and ate the closing quote.
- The second rule recovers the elision case (`COS'E'` → `COS'È`) without reopening the quoted-letter hole: an elision apostrophe is always preceded by a letter, an opening quote never is.
- The lookahead keeps glued elisions (`E'sti`), decades (`'80`) and `E'ndrangheta`-style words safe. Covers straight `'` and typographic `’`.

Verified over a 20-sentence Italian battery through the real engine, with and without a dictionary — all `E'`/`E’` forms fixed; quoted letters, elisions, and the trailing-apostrophe family (`perche'`, `po'`) untouched. See the review comment below for the full comparison that led to this shape.

Tests: 6 positive cases, a no-dictionary positive, and 5 new negative rows in the existing left-alone theory; all 24 tests in `OcrFixItalianAccentAndCapsTests` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)