### PR TITLE
TTS: detect speaker names in the text and turn them into a cast

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -154,6 +154,7 @@ using Nikse.SubtitleEdit.Features.Video.ShotChanges;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ActorVoices;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.AutoCast;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DetectSpeakers;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.SkipNoiseLines;
 using Nikse.SubtitleEdit.Features.Video.VideoOcr;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.AdvancedTtsSettings;
@@ -559,6 +560,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<ActorVoiceRowSettingsViewModel>();
         collection.AddTransient<AutoCastSpeakersViewModel>();
         collection.AddTransient<SkipNoiseLinesViewModel>();
+        collection.AddTransient<DetectSpeakersViewModel>();
         collection.AddTransient<TimedText10PropertiesViewModel>();
         collection.AddTransient<TimedTextImsc11PropertiesViewModel>();
         collection.AddTransient<TmpegEncXmlPropertiesViewModel>();

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -721,6 +721,7 @@ public class SettingsPage : UserControl
             MakeCheckboxSetting(Se.Language.Options.Settings.GridFocusTextboxAfterInsertNew, nameof(_vm.GridFocusTextboxAfterInsertNew)),
             MakeCheckboxSetting(Se.Language.Options.Settings.TextToSpeechPromptMergeContinuationLines, nameof(_vm.TextToSpeechPromptMergeContinuationLines)),
             MakeCheckboxSetting(Se.Language.Options.Settings.TextToSpeechPromptSkipNoiseLines, nameof(_vm.TextToSpeechPromptSkipNoiseLines)),
+            MakeCheckboxSetting(Se.Language.Options.Settings.TextToSpeechPromptDetectSpeakers, nameof(_vm.TextToSpeechPromptDetectSpeakers)),
             MakeCheckboxSetting(Se.Language.Options.Settings.FixCommonErrorsSkipStep1, nameof(_vm.FixCommonErrorsSkipStep1)),
             new SettingsItem(Se.Language.Options.Settings.MusicSymbol,
                 () => UiUtil.MakeTextBox(120, _vm, nameof(_vm.MusicSymbol))),

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -195,6 +195,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _gridFocusTextboxAfterInsertNew;
     [ObservableProperty] private bool _textToSpeechPromptMergeContinuationLines;
     [ObservableProperty] private bool _textToSpeechPromptSkipNoiseLines;
+    [ObservableProperty] private bool _textToSpeechPromptDetectSpeakers;
     [ObservableProperty] private bool _openAiCompatibleSttAutoTranscribeOnAudioSelection;
 
     [ObservableProperty] private ObservableCollection<string> _spellCheckEngines;
@@ -842,6 +843,7 @@ public partial class SettingsViewModel : ObservableObject
         GridFocusTextboxAfterInsertNew = Se.Settings.Tools.GridFocusTextboxAfterInsertNew;
         TextToSpeechPromptMergeContinuationLines = Se.Settings.Tools.TextToSpeechPromptMergeContinuationLines;
         TextToSpeechPromptSkipNoiseLines = Se.Settings.Tools.TextToSpeechPromptSkipNoiseLines;
+        TextToSpeechPromptDetectSpeakers = Se.Settings.Tools.TextToSpeechPromptDetectSpeakers;
         OpenAiCompatibleSttAutoTranscribeOnAudioSelection = Se.Settings.Tools.OpenAiCompatibleSttAutoTranscribeOnAudioSelection;
         FixCommonErrorsSkipStep1 = Se.Settings.Tools.FixCommonErrors.SkipStep1;
         MusicSymbol = Se.Settings.Tools.MusicSymbol;
@@ -1693,6 +1695,7 @@ public partial class SettingsViewModel : ObservableObject
         Se.Settings.Tools.GridFocusTextboxAfterInsertNew = GridFocusTextboxAfterInsertNew;
         Se.Settings.Tools.TextToSpeechPromptMergeContinuationLines = TextToSpeechPromptMergeContinuationLines;
         Se.Settings.Tools.TextToSpeechPromptSkipNoiseLines = TextToSpeechPromptSkipNoiseLines;
+        Se.Settings.Tools.TextToSpeechPromptDetectSpeakers = TextToSpeechPromptDetectSpeakers;
         Se.Settings.Tools.FixCommonErrors.SkipStep1 = FixCommonErrorsSkipStep1;
         Se.Settings.Tools.WriteToolsLog = WriteToolsLog;
         Se.Settings.Tools.OpenAiCompatibleSttAutoTranscribeOnAudioSelection = OpenAiCompatibleSttAutoTranscribeOnAudioSelection;

--- a/src/ui/Features/Video/TextToSpeech/DetectSpeakers/DetectSpeakersRow.cs
+++ b/src/ui/Features/Video/TextToSpeech/DetectSpeakers/DetectSpeakersRow.cs
@@ -1,0 +1,26 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.DetectSpeakers;
+
+public partial class DetectSpeakersRow : ObservableObject
+{
+    [ObservableProperty] private bool _isSelected;
+
+    public int Number { get; }
+    public string Show { get; }
+    public string Speaker { get; }
+    public string Text { get; }
+    public TextSpeakerCandidate Candidate { get; }
+
+    public DetectSpeakersRow(TextSpeakerCandidate candidate)
+    {
+        // An SDH-style name (ALL CAPS, "Speaker 1") is confidently a speaker; a mixed-case
+        // "Note:" is listed for the user to judge, but not pre-checked.
+        IsSelected = TextSpeakerDetector.IsConfidentSpeakerName(candidate.Speaker);
+        Number = candidate.Paragraph.Number;
+        Show = candidate.Paragraph.StartTime.ToDisplayString();
+        Speaker = candidate.Speaker;
+        Text = candidate.Paragraph.Text;
+        Candidate = candidate;
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/DetectSpeakers/DetectSpeakersViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DetectSpeakers/DetectSpeakersViewModel.cs
@@ -1,0 +1,88 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.DetectSpeakers;
+
+public partial class DetectSpeakersViewModel : ObservableObject
+{
+    [ObservableProperty] private ObservableCollection<DetectSpeakersRow> _rows;
+    [ObservableProperty] private DetectSpeakersRow? _selectedRow;
+    [ObservableProperty] private string _rowsInfo;
+    [ObservableProperty] private bool _stickySpeakers;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    /// <summary>The tags the user confirmed - these names become actors and leave the spoken text.</summary>
+    public List<TextSpeakerCandidate> ConfirmedCandidates { get; private set; }
+
+    public DetectSpeakersViewModel()
+    {
+        Rows = new ObservableCollection<DetectSpeakersRow>();
+        ConfirmedCandidates = new List<TextSpeakerCandidate>();
+        RowsInfo = string.Empty;
+        // The SDH convention names only the speaker changes, so the lines between two tags belong
+        // to the tag above them - which is exactly what makes this usable on a real SDH file.
+        StickySpeakers = true;
+    }
+
+    public void Initialize(List<TextSpeakerCandidate> candidates)
+    {
+        Rows.Clear();
+        foreach (var candidate in candidates)
+        {
+            Rows.Add(new DetectSpeakersRow(candidate));
+        }
+
+        var speakerCount = candidates.Select(c => c.Speaker).Distinct(StringComparer.OrdinalIgnoreCase).Count();
+        RowsInfo = string.Format(Se.Language.Video.TextToSpeech.DetectSpeakersFoundX, Rows.Count, speakerCount);
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        ConfirmedCandidates = Rows.Where(r => r.IsSelected).Select(r => r.Candidate).ToList();
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Window?.Close();
+    }
+
+    [RelayCommand]
+    private void SelectAll()
+    {
+        foreach (var row in Rows)
+        {
+            row.IsSelected = true;
+        }
+    }
+
+    [RelayCommand]
+    private void InverseSelection()
+    {
+        foreach (var row in Rows)
+        {
+            row.IsSelected = !row.IsSelected;
+        }
+    }
+
+    internal void KeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/DetectSpeakers/DetectSpeakersWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/DetectSpeakers/DetectSpeakersWindow.cs
@@ -1,0 +1,144 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
+using Avalonia.Data;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.DetectSpeakers;
+
+public class DetectSpeakersWindow : Window
+{
+    public DetectSpeakersWindow(DetectSpeakersViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = UiUtil.MakeWindowTitle(Se.Language.Video.TextToSpeech.DetectSpeakersTitle);
+        CanResize = true;
+        Width = 900;
+        Height = 600;
+        MinWidth = 600;
+        MinHeight = 400;
+        vm.Window = this;
+        DataContext = vm;
+
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        var panelButtons = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            Margin = UiUtil.MakeWindowMargin(),
+            ColumnSpacing = 10,
+            RowSpacing = 10,
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+
+        var labelInfo = UiUtil.MakeLabel().WithBindText(vm, nameof(vm.RowsInfo));
+
+        var panelOptions = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 15,
+        };
+        panelOptions.Children.Add(UiUtil.MakeCheckBox(
+            Se.Language.Video.TextToSpeech.DetectSpeakersSticky, vm, nameof(vm.StickySpeakers)));
+        panelOptions.Children.Add(UiUtil.MakeButton(Se.Language.General.SelectAll, vm.SelectAllCommand));
+        panelOptions.Children.Add(UiUtil.MakeButton(Se.Language.General.InvertSelection, vm.InverseSelectionCommand));
+
+        grid.Add(labelInfo, 0);
+        grid.Add(UiUtil.MakeBorderForControlNoPadding(MakeRowsView(vm)), 1);
+        grid.Add(panelOptions, 2);
+        grid.Add(panelButtons, 3);
+
+        Content = grid;
+
+        Activated += delegate { buttonOk.Focus(); };
+        KeyDown += vm.KeyDown;
+
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
+    }
+
+    private static Control MakeRowsView(DetectSpeakersViewModel vm)
+    {
+        var dataGrid = TableViewExtras.MakeTableView();
+        dataGrid.Width = double.NaN;
+        dataGrid.Height = double.NaN;
+        dataGrid.DataContext = vm;
+        dataGrid.ItemsSource = vm.Rows;
+
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.Video.TextToSpeech.DetectSpeakersColumnUse,
+            CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            CellTemplate = new FuncDataTemplate<DetectSpeakersRow>((_, _) => new Border
+            {
+                Background = Brushes.Transparent,
+                Padding = new Avalonia.Thickness(4),
+                Child = new CheckBox
+                {
+                    Focusable = false,
+                    [!ToggleButton.IsCheckedProperty] = new Binding(nameof(DetectSpeakersRow.IsSelected))
+                    {
+                        Mode = BindingMode.TwoWay,
+                    },
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                },
+            }),
+            Width = new GridLength(80),
+        });
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.NumberSymbol,
+            Binding = new Binding(nameof(DetectSpeakersRow.Number)),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Width = new GridLength(60),
+        });
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Show,
+            Binding = new Binding(nameof(DetectSpeakersRow.Show)),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Width = new GridLength(120),
+        });
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Actor,
+            Binding = new Binding(nameof(DetectSpeakersRow.Speaker)),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Width = new GridLength(160),
+        });
+        dataGrid.Columns.Add(new SeTableViewColumn
+        {
+            Header = Se.Language.General.Text,
+            Binding = new Binding(nameof(DetectSpeakersRow.Text)),
+            CellTheme = UiUtil.TableViewCellTheme,
+            HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+            Width = new GridLength(1, GridUnitType.Star),
+        });
+
+        TableViewExtras.AddSpaceToggle<DetectSpeakersRow>(dataGrid,
+            item => item.IsSelected,
+            (item, value) => item.IsSelected = value);
+
+        return dataGrid;
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/DetectSpeakers/TextSpeakerDetector.cs
+++ b/src/ui/Features/Video/TextToSpeech/DetectSpeakers/TextSpeakerDetector.cs
@@ -1,0 +1,188 @@
+using Nikse.SubtitleEdit.Core.Common;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.DetectSpeakers;
+
+/// <summary>
+/// Finds SDH speaker tags written into the subtitle text - "MIKE: text", "[NARRATOR] text",
+/// "(Speaker 1) text" - so the TTS flow can move them into the actor field and give each
+/// speaker their own voice instead of reading the name aloud (issue #14106).
+/// </summary>
+public static partial class TextSpeakerDetector
+{
+    /// <summary>
+    /// "NAME:" at the start of a line - one to three words of letters (plus ' - . for names like
+    /// O'Brien or Mr. Smith), capped at name length so "Warning: do not open the door" is not a
+    /// speaker. The tag may sit alone on its line with the speech on the next line.
+    /// </summary>
+    [GeneratedRegex(@"^(?<name>\p{Lu}[\p{L}'.\-]*(?:[ ]\p{L}[\p{L}'.\-]*){0,2}):\s*(?<text>.*)$",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex ColonTagRegex();
+
+    /// <summary>"[NAME]" or "(NAME)" at the start of a line.</summary>
+    [GeneratedRegex(@"^(?:\[(?<name>[^\]\r\n]{1,30})\]|\((?<name>[^)\r\n]{1,30})\))\s*(?<text>.*)$",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex BracketTagRegex();
+
+    private const int MaxNameLength = 30;
+
+    /// <summary>
+    /// Splits one text line into its speaker tag and the words actually spoken.
+    /// A bracketed tag with nothing after it on the line is only a speaker when
+    /// <paramref name="hasFollowingLine"/> - alone it is a sound annotation ("[door slams]"),
+    /// which is the noise prompt's business, not a name.
+    /// </summary>
+    public static bool TrySplit(string line, bool hasFollowingLine, out string speaker, out string spokenText)
+    {
+        speaker = string.Empty;
+        spokenText = line;
+        if (string.IsNullOrWhiteSpace(line))
+        {
+            return false;
+        }
+
+        var s = line.Trim();
+
+        var match = BracketTagRegex().Match(s);
+        if (!match.Success)
+        {
+            match = ColonTagRegex().Match(s);
+        }
+
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        var name = NormalizeSpaces(match.Groups["name"].Value);
+        var text = match.Groups["text"].Value.Trim();
+        if (name.Length == 0 || name.Length > MaxNameLength)
+        {
+            return false;
+        }
+
+        if (text.Length == 0 && !hasFollowingLine)
+        {
+            return false;
+        }
+
+        speaker = name;
+        spokenText = text;
+        return true;
+    }
+
+    /// <summary>
+    /// A name written the SDH way - ALL UPPERCASE, or a bracketed "Speaker N" from diarization -
+    /// is confidently a speaker; anything else ("Warning:", "Note:") is listed for the user to
+    /// judge, but not pre-checked.
+    /// </summary>
+    public static bool IsConfidentSpeakerName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return false;
+        }
+
+        if (Regex.IsMatch(name, @"^speaker[ _-]*\d+$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant))
+        {
+            return true;
+        }
+
+        return name.Any(char.IsLetter) && !name.Any(char.IsLower);
+    }
+
+    public static List<TextSpeakerCandidate> Detect(Subtitle subtitle)
+    {
+        var candidates = new List<TextSpeakerCandidate>();
+        foreach (var paragraph in subtitle.Paragraphs)
+        {
+            var lines = (paragraph.Text ?? string.Empty).SplitToLines();
+            for (var i = 0; i < lines.Count; i++)
+            {
+                if (TrySplit(lines[i], i + 1 < lines.Count, out var speaker, out _))
+                {
+                    candidates.Add(new TextSpeakerCandidate(paragraph, speaker, i));
+                }
+            }
+        }
+
+        return candidates;
+    }
+
+    /// <summary>
+    /// Puts the confirmed speakers into the actor field and takes their tags out of the text, in
+    /// place. With <paramref name="stickySpeakers"/>, a line without a tag continues the previous
+    /// speaker - the SDH convention of naming only the changes (issue #14106). A paragraph with
+    /// two different confirmed speakers gets the first as its actor; the voice can only be one.
+    /// </summary>
+    public static int Apply(Subtitle subtitle, IReadOnlyCollection<TextSpeakerCandidate> confirmed, bool stickySpeakers)
+    {
+        var byParagraph = confirmed
+            .GroupBy(c => c.Paragraph)
+            .ToDictionary(g => g.Key, g => g.OrderBy(c => c.LineIndex).ToList());
+
+        var applied = 0;
+        var previousSpeaker = string.Empty;
+        foreach (var paragraph in subtitle.Paragraphs)
+        {
+            if (!byParagraph.TryGetValue(paragraph, out var tags))
+            {
+                if (stickySpeakers && previousSpeaker.Length > 0 && string.IsNullOrWhiteSpace(paragraph.Actor))
+                {
+                    paragraph.Actor = previousSpeaker;
+                }
+
+                continue;
+            }
+
+            var confirmedLineIndexes = tags.Select(t => t.LineIndex).ToHashSet();
+            var lines = (paragraph.Text ?? string.Empty).SplitToLines();
+            var newLines = new List<string>();
+            for (var i = 0; i < lines.Count; i++)
+            {
+                if (confirmedLineIndexes.Contains(i) &&
+                    TrySplit(lines[i], i + 1 < lines.Count, out _, out var spokenText))
+                {
+                    if (spokenText.Length > 0)
+                    {
+                        newLines.Add(spokenText);
+                    }
+                }
+                else
+                {
+                    newLines.Add(lines[i]);
+                }
+            }
+
+            paragraph.Actor = tags[0].Speaker;
+            paragraph.Text = string.Join(Environment.NewLine, newLines).Trim();
+            previousSpeaker = tags[tags.Count - 1].Speaker;
+            applied++;
+        }
+
+        return applied;
+    }
+
+    private static string NormalizeSpaces(string s)
+    {
+        return string.Join(" ", s.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+    }
+}
+
+/// <summary>One speaker tag found in the text: which paragraph, which of its lines, whose name.</summary>
+public sealed class TextSpeakerCandidate
+{
+    public Paragraph Paragraph { get; }
+    public string Speaker { get; }
+    public int LineIndex { get; }
+
+    public TextSpeakerCandidate(Paragraph paragraph, string speaker, int lineIndex)
+    {
+        Paragraph = paragraph;
+        Speaker = speaker;
+        LineIndex = lineIndex;
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -27,6 +27,7 @@ using Nikse.SubtitleEdit.Features.Video.TextToSpeech.MossTtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DotsTtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTts25AudioCppSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DetectSpeakers;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.KokoroTtsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.SkipNoiseLines;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.PiperSettings;
@@ -979,7 +980,17 @@ public partial class TextToSpeechViewModel : ObservableObject
         // fallback base - a configured generation folder wins.
         _waveFolder = TtsRunFolder.Create(waveFolder);
 
-        _castKind = ActorVoiceDetector.Detect(subtitle, format);
+        RefreshCast(ActorVoiceDetector.Detect(subtitle, format), subtitle);
+    }
+
+    /// <summary>
+    /// Recomputes the cast state (kind, button, saved mappings) from <paramref name="subtitle"/>.
+    /// Called at window setup, and again when the detect-speakers prompt writes actors into the
+    /// working subtitle mid-flow.
+    /// </summary>
+    private void RefreshCast(ActorVoiceDetector.CastKind castKind, Subtitle subtitle)
+    {
+        _castKind = castKind;
         // Only surface the cast button when there's actually more than one actor/voice to assign
         // — a single-speaker subtitle uses the global engine/voice and the button would be a no-op.
         var actorCount = _castKind == ActorVoiceDetector.CastKind.None
@@ -1182,6 +1193,65 @@ public partial class TextToSpeechViewModel : ObservableObject
     }
 
     /// <summary>
+    /// The third generate-time prompt: SDH speaker tags written into the text ("MIKE: text",
+    /// "[NARRATOR] text") become actors so "Set up cast" can give each speaker a voice, and the
+    /// names are not read aloud (#14106). Only the TTS working copy changes - the subtitle in the
+    /// main window keeps its text (Tools → Convert actors is the way to persist actors). Runs
+    /// before the merge prompt: tag-free text merges better, and the merge rebuilds
+    /// <see cref="_subtitle"/> while carrying actors through.
+    /// </summary>
+    private async Task PromptDetectSpeakers()
+    {
+        if (Window == null || _castKind != ActorVoiceDetector.CastKind.None)
+        {
+            return;
+        }
+
+        var candidates = TextSpeakerDetector.Detect(_subtitle);
+        var speakerCount = candidates
+            .Where(c => TextSpeakerDetector.IsConfidentSpeakerName(c.Speaker))
+            .Select(c => c.Speaker)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Count();
+        if (speakerCount < 2)
+        {
+            // One speaker needs no cast, and a subtitle with no confident tag is most likely not
+            // SDH at all - prompting on every "Warning:" would teach users to click prompts away.
+            return;
+        }
+
+        var answer = await MessageBox.Show(
+            Window!,
+            Se.Language.Video.TextToSpeech.DetectSpeakersPromptTitle,
+            Se.Language.Video.TextToSpeech.DetectSpeakersPromptMessage,
+            MessageBoxButtons.YesNo,
+            MessageBoxIcon.Question);
+        if (answer != MessageBoxResult.Yes)
+        {
+            return;
+        }
+
+        var result = await _windowService.ShowDialogAsync<DetectSpeakersWindow, DetectSpeakersViewModel>(
+            Window!, vm => vm.Initialize(candidates));
+        if (!result.OkPressed || result.ConfirmedCandidates.Count == 0)
+        {
+            return;
+        }
+
+        TextSpeakerDetector.Apply(_subtitle, result.ConfirmedCandidates, result.StickySpeakers);
+
+        // The actors exist only in the TTS working copy, so cast detection is not re-run against
+        // the main window's format - the copy holds ASSA-style actors now, whatever the file is.
+        RefreshCast(ActorVoiceDetector.CastKind.AssaActors, _subtitle);
+
+        // Straight into voice assignment - the whole point of confirming the speakers.
+        if (HasCast)
+        {
+            await ShowCast();
+        }
+    }
+
+    /// <summary>
     /// Stop the crispasr.exe servers of every CrispASR-based TTS engine EXCEPT
     /// <paramref name="keepAlive"/>. Pass null to stop all four. Called before starting synth
     /// (Test Voice / Generate TTS) and on window close, so models from previously selected
@@ -1256,6 +1326,11 @@ public partial class TextToSpeechViewModel : ObservableObject
 
         // The engine and/or its models may have just been downloaded - refresh the combo dots.
         RefreshDownloadDots?.Invoke();
+
+        if (Se.Settings.Tools.TextToSpeechPromptDetectSpeakers)
+        {
+            await PromptDetectSpeakers();
+        }
 
         if (Se.Settings.Tools.TextToSpeechPromptMergeContinuationLines)
         {

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -311,6 +311,7 @@ public class LanguageSettings
     public string MusicSymbolsToReplace { get; set; }
     public string TextToSpeechPromptMergeContinuationLines { get; set; }
     public string TextToSpeechPromptSkipNoiseLines { get; set; }
+    public string TextToSpeechPromptDetectSpeakers { get; set; }
     public string UseFocusedButtonBackgroundColor { get; set; }
     public string FocusedButtonBackgroundColor { get; set; }
     public string ForceCrLfOnSave { get; set; }
@@ -646,6 +647,7 @@ public class LanguageSettings
         MusicSymbolsToReplace = "Music symbols to replace (separated by comma)";
         TextToSpeechPromptMergeContinuationLines = "Text to speech: prompt to merge continuation lines";
         TextToSpeechPromptSkipNoiseLines = "Text to speech: prompt to skip sound/music lines";
+        TextToSpeechPromptDetectSpeakers = "Text to speech: prompt to detect speaker names in the text";
         UseFocusedButtonBackgroundColor = "Use focused button background color";
         FocusedButtonBackgroundColor = "Focused button background color";
         ForceCrLfOnSave = "Force CR+LF on save (text subtitle files)";

--- a/src/ui/Logic/Config/Language/Video/LanguageTextToSpeech.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageTextToSpeech.cs
@@ -149,6 +149,12 @@ public class LanguageTextToSpeech
     public string SkipNoiseLinesTitle { get; set; }
     public string SkipNoiseLinesFoundX { get; set; }
     public string SkipNoiseLinesColumnSkip { get; set; }
+    public string DetectSpeakersPromptTitle { get; set; }
+    public string DetectSpeakersPromptMessage { get; set; }
+    public string DetectSpeakersTitle { get; set; }
+    public string DetectSpeakersFoundX { get; set; }
+    public string DetectSpeakersColumnUse { get; set; }
+    public string DetectSpeakersSticky { get; set; }
 
     // Applying the TTS window's changes (review text edits, merged lines) back to the subtitle
     public string SubtitleUpdatedFromReviewSingular { get; set; }
@@ -300,6 +306,14 @@ public class LanguageTextToSpeech
         SkipNoiseLinesTitle = "Lines with only sounds or music";
         SkipNoiseLinesFoundX = "{0} lines contain only sounds or music - checked lines are left silent";
         SkipNoiseLinesColumnSkip = "Skip";
+        DetectSpeakersPromptTitle = "Speaker names found in the text?";
+        DetectSpeakersPromptMessage = "Some lines start with a speaker name - like \"MIKE:\" or \"[NARRATOR]\"." + Environment.NewLine + Environment.NewLine +
+                                      "Moved into the actor field, each speaker can get their own voice via \"Set up cast\", and the name is not read aloud." + Environment.NewLine + Environment.NewLine +
+                                      "Review the names now? (only the speech generation is affected - the subtitle itself is not changed)";
+        DetectSpeakersTitle = "Speaker names in the text";
+        DetectSpeakersFoundX = "{0} speaker tags found ({1} speakers) - checked names become actors and are not read aloud";
+        DetectSpeakersColumnUse = "Use";
+        DetectSpeakersSticky = "Lines without a name continue the previous speaker";
 
         SubtitleUpdatedFromReviewSingular = "Updated one line from the speech review";
         SubtitleUpdatedFromReviewPlural = "Updated {0} lines from the speech review";

--- a/src/ui/Logic/Config/SeTools.cs
+++ b/src/ui/Logic/Config/SeTools.cs
@@ -137,6 +137,7 @@ public class SeTools
     public bool GridFocusTextboxAfterInsertNew { get; set; }
     public bool TextToSpeechPromptMergeContinuationLines { get; set; }
     public bool TextToSpeechPromptSkipNoiseLines { get; set; }
+    public bool TextToSpeechPromptDetectSpeakers { get; set; }
 
     // OpenAI Compatible STT settings
     public string OpenAiCompatibleSttUrl { get; set; } = "http://localhost:8000/v1/audio/transcriptions";
@@ -262,6 +263,7 @@ public class SeTools
         WriteToolsLog = true;
         TextToSpeechPromptMergeContinuationLines = true;
         TextToSpeechPromptSkipNoiseLines = true;
+        TextToSpeechPromptDetectSpeakers = true;
 
         LastColorPickerColor = Colors.Yellow.FromColorToHex();
         LastColorPickerColor1 = Colors.Red.FromColorToHex();

--- a/tests/UI/Features/Video/TextToSpeech/DetectSpeakers/TextSpeakerDetectorTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/DetectSpeakers/TextSpeakerDetectorTests.cs
@@ -1,0 +1,119 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DetectSpeakers;
+
+namespace UITests.Features.Video.TextToSpeech.DetectSpeakers;
+
+public class TextSpeakerDetectorTests
+{
+    [Theory]
+    [InlineData("MIKE: Text", "MIKE", "Text")]
+    [InlineData("Joe: How are you?", "Joe", "How are you?")]
+    [InlineData("[NARRATOR] Once upon a time.", "NARRATOR", "Once upon a time.")]
+    [InlineData("(Speaker 1) Hello.", "Speaker 1", "Hello.")]
+    [InlineData("Mr. SMITH: Yes.", "Mr. SMITH", "Yes.")]
+    public void ASpeakerTagIsReadAndRemoved(string line, string expectedSpeaker, string expectedText)
+    {
+        Assert.True(TextSpeakerDetector.TrySplit(line, hasFollowingLine: false, out var speaker, out var text));
+        Assert.Equal(expectedSpeaker, speaker);
+        Assert.Equal(expectedText, text);
+    }
+
+    [Fact]
+    public void AColonTagAloneOnItsLineIsASpeakerWhenSpeechFollows()
+    {
+        Assert.True(TextSpeakerDetector.TrySplit("NARRATOR:", hasFollowingLine: true, out var speaker, out var text));
+        Assert.Equal("NARRATOR", speaker);
+        Assert.Equal(string.Empty, text);
+    }
+
+    /// <summary>"[door slams]" alone is a sound annotation - the noise prompt's business.</summary>
+    [Fact]
+    public void ABracketAloneOnASingleLineIsNotASpeaker()
+    {
+        Assert.False(TextSpeakerDetector.TrySplit("[door slams]", hasFollowingLine: false, out _, out _));
+    }
+
+    [Theory]
+    [InlineData("Meet me at 3:30.")]
+    [InlineData("Just some text.")]
+    [InlineData(": no name at all")]
+    [InlineData("")]
+    public void PlainTextIsNotASpeaker(string line)
+    {
+        Assert.False(TextSpeakerDetector.TrySplit(line, hasFollowingLine: false, out _, out _));
+    }
+
+    /// <summary>SDH names ("NARRATOR", "Speaker 1") are pre-checked; "Warning:" is for the user to judge.</summary>
+    [Theory]
+    [InlineData("NARRATOR", true)]
+    [InlineData("MIKE", true)]
+    [InlineData("Speaker 1", true)]
+    [InlineData("speaker_02", true)]
+    [InlineData("Warning", false)]
+    [InlineData("Joe", false)]
+    public void OnlySdhStyleNamesAreConfident(string name, bool expected)
+    {
+        Assert.Equal(expected, TextSpeakerDetector.IsConfidentSpeakerName(name));
+    }
+
+    /// <summary>The exact shape from issue #14106: tags name only the speaker changes.</summary>
+    [Fact]
+    public void ApplyWithStickySpeakersCarriesTheSpeakerToUntaggedLines()
+    {
+        var subtitle = MakeIssueExample();
+        var confirmed = TextSpeakerDetector.Detect(subtitle);
+
+        var applied = TextSpeakerDetector.Apply(subtitle, confirmed, stickySpeakers: true);
+
+        Assert.Equal(2, applied);
+        Assert.Equal("NARRATOR", subtitle.Paragraphs[0].Actor);
+        Assert.Equal("Text", subtitle.Paragraphs[0].Text);
+        Assert.Equal("NARRATOR", subtitle.Paragraphs[1].Actor);
+        Assert.Equal("MIKE", subtitle.Paragraphs[2].Actor);
+        Assert.Equal("Text3", subtitle.Paragraphs[2].Text);
+        Assert.Equal("MIKE", subtitle.Paragraphs[3].Actor);
+    }
+
+    [Fact]
+    public void ApplyWithoutStickySpeakersLeavesUntaggedLinesAlone()
+    {
+        var subtitle = MakeIssueExample();
+        var confirmed = TextSpeakerDetector.Detect(subtitle);
+
+        TextSpeakerDetector.Apply(subtitle, confirmed, stickySpeakers: false);
+
+        Assert.Equal("NARRATOR", subtitle.Paragraphs[0].Actor);
+        Assert.True(string.IsNullOrEmpty(subtitle.Paragraphs[1].Actor));
+        Assert.Equal("MIKE", subtitle.Paragraphs[2].Actor);
+        Assert.True(string.IsNullOrEmpty(subtitle.Paragraphs[3].Actor));
+    }
+
+    /// <summary>
+    /// Two speakers tagged inside one paragraph: the actor can only be one (the first), both tags
+    /// leave the text, and stickiness continues from the last tag.
+    /// </summary>
+    [Fact]
+    public void TwoSpeakersInOneParagraphKeepTheFirstAsActor()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("JOE: Hi" + Environment.NewLine + "JANE: Hello", 0, 1000));
+        subtitle.Paragraphs.Add(new Paragraph("How are you?", 2000, 3000));
+        var confirmed = TextSpeakerDetector.Detect(subtitle);
+
+        TextSpeakerDetector.Apply(subtitle, confirmed, stickySpeakers: true);
+
+        Assert.Equal("JOE", subtitle.Paragraphs[0].Actor);
+        Assert.Equal("Hi" + Environment.NewLine + "Hello", subtitle.Paragraphs[0].Text);
+        Assert.Equal("JANE", subtitle.Paragraphs[1].Actor);
+    }
+
+    private static Subtitle MakeIssueExample()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("NARRATOR:" + Environment.NewLine + "Text", 0, 1000));
+        subtitle.Paragraphs.Add(new Paragraph("Text2", 2000, 3000));
+        subtitle.Paragraphs.Add(new Paragraph("MIKE: Text3", 4000, 5000));
+        subtitle.Paragraphs.Add(new Paragraph("More text", 6000, 7000));
+        return subtitle;
+    }
+}


### PR DESCRIPTION
The third generate-time prompt (after merge lines and noise skip), closing the #14106 workflow end to end.

**What it does:** when Generate is clicked and no cast exists yet, SE detects SDH speaker tags written into the text — `MIKE: text`, `[NARRATOR] text`, `(Speaker 1) text`, including a name alone on its line with the speech below. A review dialog lists each tag; on OK the names become actors in the **TTS working copy**, the tags leave the spoken text, the Cast dialog opens for voice assignment, and generation continues with the mappings.

**Pre-checking:** names written the SDH way (ALL CAPS, `Speaker N`) are checked by default; mixed-case candidates like `Warning:` are listed unchecked for the user to judge.

**Sticky speakers** (the issue's third ask, on by default): a confirmed speaker carries to the untagged lines after it — the SDH convention of naming only the changes.

**Scope:** only the TTS run is affected — the subtitle in the main window keeps its text, same contract as the noise-skip prompt; Tools → Convert actors remains the way to persist actors into the file. The prompt runs before the merge prompt (tag-free text merges better; actors survive the merge rebuild via the row copy constructor), and `[door slams]` alone on a line is left to the noise prompt — a bracket tag only counts as a speaker when speech follows it.

Detector unit tests cover the tag shapes, the issue's exact example with and without stickiness, and the two-speakers-in-one-paragraph case; the dialog's DI registration is enforced by the guard test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)