### PR TITLE
Export to images: advanced Skia text effect presets

### DIFF
--- a/src/libuilogic/Export/ImageParameter.cs
+++ b/src/libuilogic/Export/ImageParameter.cs
@@ -64,6 +64,14 @@ public class ImageParameter
     public int BoxPaddingTop { get; set; } = 0;
     public int BoxPaddingBottom { get; set; } = 0;
 
+    /// <summary>
+    /// Advanced text formatting (gradient fills, multiple outlines, soft shadows, glow, 3D
+    /// extrude, bevel). Null renders through the classic fill/outline/shadow path; when set,
+    /// <see cref="OutlineWidth"/> and <see cref="ShadowWidth"/> are ignored - the effects
+    /// describe the whole look.
+    /// </summary>
+    public TextEffects? TextEffects { get; set; }
+
     public ImageParameter()
     {
         Bitmap = new SKBitmap(1, 1, true);

--- a/src/libuilogic/Export/ImageRenderer.cs
+++ b/src/libuilogic/Export/ImageRenderer.cs
@@ -153,8 +153,11 @@ public static class ImageRenderer
         // textStartY must be at least as large as the ascent + effects so the top of
         // the first line is never above y=0 in the temp bitmap.
         var margin = 10;
-        var textStartX = (int)(Math.Abs(shadowWidth) + Math.Abs(outlineWidth) + margin);
-        var textStartY = (int)(Math.Abs(fontMetrics.Ascent) + Math.Abs(shadowWidth) + Math.Abs(outlineWidth) + margin);
+        // Advanced effects (blurred shadows, glow, extrude) draw further out than the classic
+        // outline+shadow, so pad the scratch canvas with their own safety margin too.
+        var effectMargin = ip.TextEffects?.GetSafetyMargin() ?? 0f;
+        var textStartX = (int)(Math.Abs(shadowWidth) + Math.Abs(outlineWidth) + margin + effectMargin);
+        var textStartY = (int)(Math.Abs(fontMetrics.Ascent) + Math.Abs(shadowWidth) + Math.Abs(outlineWidth) + margin + effectMargin);
         RenderTextToCanvas(tempCanvas, lines, ip, regularFont, boldFont, italicFont, boldItalicFont,
             textStartX, textStartY, baseLineHeight, lineSpacing,
             outlineColor, shadowColor, outlineWidth, shadowWidth);
@@ -347,6 +350,13 @@ public static class ImageRenderer
         double outlineWidth,
         double shadowWidth)
     {
+        if (ip.TextEffects != null)
+        {
+            RenderTextWithEffects(canvas, lines, ip, regularFont, boldFont, italicFont, boldItalicFont,
+                textStartX, textStartY, baseLineHeight, lineSpacing);
+            return;
+        }
+
         // Pre-calculate all line widths so alignment is relative to the widest line,
         // not the canvas width (which would push text far right or off-canvas).
         var lineWidths = new float[lines.Count];
@@ -494,6 +504,284 @@ public static class ImageRenderer
             // Move to next line
             currentY += baseLineHeight + lineSpacing;
         }
+    }
+
+    /// <summary>
+    /// A text segment laid out for the effects pipeline: where DrawShapedText will draw it,
+    /// with which font, and its classic per-segment color (used when the effects have no fill).
+    /// </summary>
+    private sealed record EffectSegmentDraw(string Text, float X, float Y, SKFont Font, SKColor Color);
+
+    /// <summary>
+    /// The advanced-formatting counterpart of <see cref="RenderTextToCanvas"/>: same layout
+    /// (widest-line-relative alignment, RTL segment order, styled-segment spacing), but painting
+    /// goes through <see cref="ImageParameter.TextEffects"/> layers. The classic outline/shadow
+    /// widths are not used here - the effects describe the whole look.
+    /// </summary>
+    private static void RenderTextWithEffects(
+        SKCanvas canvas,
+        List<List<TextSegment>> lines,
+        ImageParameter ip,
+        SKFont regularFont,
+        SKFont boldFont,
+        SKFont italicFont,
+        SKFont boldItalicFont,
+        float textStartX,
+        float textStartY,
+        float baseLineHeight,
+        float lineSpacing)
+    {
+        var effects = ip.TextEffects!;
+
+        var lineWidths = new float[lines.Count];
+        for (var li = 0; li < lines.Count; li++)
+        {
+            var line = lines[li];
+            for (var j = 0; j < line.Count; j++)
+            {
+                var seg = line[j];
+                var font = GetFont(seg, regularFont, boldFont, italicFont, boldItalicFont);
+                lineWidths[li] += MeasureTextWithShaping(seg.Text, font);
+                if ((seg.IsItalic || seg.IsBold) && j < line.Count - 1)
+                {
+                    lineWidths[li] += regularFont.Size * 0.17f;
+                }
+            }
+        }
+
+        var maxLineWidth = lineWidths.Length > 0 ? lineWidths.Max() : 0f;
+
+        // Collect the glyph outline path of the whole subtitle plus per-segment draw records.
+        // Edge-tracing effects (strokes, glow, extrude, bevel) work on the combined path; fills
+        // go through DrawShapedText so glyph rasterization matches the classic path (and glyphs
+        // without an outline, like color emoji, still render).
+        using var combinedPath = new SKPath();
+        var segmentDraws = new List<EffectSegmentDraw>();
+
+        var currentY = 0f;
+        for (var li = 0; li < lines.Count; li++)
+        {
+            var line = lines[li];
+            var segmentsToRender = ip.IsRightToLeft ? line.AsEnumerable().Reverse().ToList() : line;
+            var lineWidth = lineWidths[li];
+
+            float currentX;
+            if (ip.ContentAlignment == ExportContentAlignment.Center)
+            {
+                currentX = textStartX + (maxLineWidth - lineWidth) / 2;
+            }
+            else if ((ip.ContentAlignment == ExportContentAlignment.Right && !ip.IsRightToLeft) ||
+                     (ip.ContentAlignment == ExportContentAlignment.Left && ip.IsRightToLeft))
+            {
+                currentX = textStartX + maxLineWidth - lineWidth;
+            }
+            else
+            {
+                currentX = textStartX;
+            }
+
+            for (var i = 0; i < segmentsToRender.Count; i++)
+            {
+                var segment = segmentsToRender[i];
+                var font = GetFont(segment, regularFont, boldFont, italicFont, boldItalicFont);
+                var y = textStartY + currentY;
+
+                using (var segmentPath = GetShapedTextPath(segment.Text, currentX, y, font))
+                {
+                    combinedPath.AddPath(segmentPath);
+                }
+
+                segmentDraws.Add(new EffectSegmentDraw(segment.Text, currentX, y, font, segment.Color));
+
+                currentX += MeasureTextWithShaping(segment.Text, font);
+                if ((segment.IsItalic || segment.IsBold) && i < segmentsToRender.Count - 1)
+                {
+                    currentX += regularFont.Size * 0.17f;
+                }
+            }
+
+            currentY += baseLineHeight + lineSpacing;
+        }
+
+        PaintEffectLayers(canvas, combinedPath, segmentDraws, effects);
+    }
+
+    /// <summary>
+    /// Paints the effect layers back to front: extrude, shadows, glow, outline rings, fill,
+    /// bevel. Outline rings use the doubled-stroke-width trick from the classic path (issue
+    /// #12206), generalized to multiple rings: outermost first, each inner ring covers the
+    /// inner half of the one below it, and the fill covers the innermost half.
+    /// </summary>
+    private static void PaintEffectLayers(SKCanvas canvas, SKPath path, List<EffectSegmentDraw> segments, TextEffects effects)
+    {
+        var bounds = path.TightBounds;
+        var totalStrokeWidth = 0f;
+        foreach (var stroke in effects.Strokes)
+        {
+            totalStrokeWidth += stroke.Width;
+        }
+
+        if (effects.Extrude is { } extrude)
+        {
+            using var paint = new SKPaint { IsAntialias = true };
+            for (var i = extrude.Depth; i >= 1; i--)
+            {
+                paint.Color = LerpColor(extrude.NearColor, extrude.FarColor, (float)i / extrude.Depth);
+                using var offsetPath = new SKPath(path);
+                offsetPath.Offset(extrude.Dx * i, extrude.Dy * i);
+                paint.Style = SKPaintStyle.Fill;
+                canvas.DrawPath(offsetPath, paint);
+
+                // Stroke each step too, so the extrusion is solid instead of showing seams
+                // between the stepped copies.
+                paint.Style = SKPaintStyle.Stroke;
+                paint.StrokeWidth = Math.Max(1.5f, MathF.Sqrt(extrude.Dx * extrude.Dx + extrude.Dy * extrude.Dy));
+                canvas.DrawPath(offsetPath, paint);
+            }
+        }
+
+        foreach (var shadow in effects.Shadows)
+        {
+            using var paint = new SKPaint { IsAntialias = true, Color = shadow.Color };
+            if (shadow.Blur > 0)
+            {
+                paint.MaskFilter = SKMaskFilter.CreateBlur(SKBlurStyle.Normal, shadow.Blur);
+            }
+
+            if (totalStrokeWidth > 0)
+            {
+                using var shadowPath = new SKPath(path);
+                shadowPath.Offset(shadow.Dx, shadow.Dy);
+                paint.Style = SKPaintStyle.Stroke;
+                paint.StrokeWidth = totalStrokeWidth * 2;
+                paint.StrokeJoin = SKStrokeJoin.Round;
+                canvas.DrawPath(shadowPath, paint);
+            }
+
+            paint.Style = SKPaintStyle.Fill;
+            foreach (var seg in segments)
+            {
+                DrawShapedText(canvas, seg.Text, seg.X + shadow.Dx, seg.Y + shadow.Dy, seg.Font, paint);
+            }
+        }
+
+        if (effects.Glow is { } glow)
+        {
+            // Repeated blurred draws saturate into a halo around the glyphs.
+            using var paint = new SKPaint
+            {
+                IsAntialias = true,
+                Color = glow.Color,
+                Style = SKPaintStyle.StrokeAndFill,
+                StrokeWidth = totalStrokeWidth * 2 + 2,
+                StrokeJoin = SKStrokeJoin.Round,
+                MaskFilter = SKMaskFilter.CreateBlur(SKBlurStyle.Normal, glow.Radius),
+            };
+            for (var i = 0; i < glow.Passes; i++)
+            {
+                canvas.DrawPath(path, paint);
+            }
+        }
+
+        for (var i = effects.Strokes.Count - 1; i >= 0; i--)
+        {
+            var cumulative = 0f;
+            for (var j = 0; j <= i; j++)
+            {
+                cumulative += effects.Strokes[j].Width;
+            }
+
+            var stroke = effects.Strokes[i];
+            using var paint = new SKPaint
+            {
+                IsAntialias = true,
+                Style = SKPaintStyle.Stroke,
+                StrokeWidth = cumulative * 2,
+                StrokeJoin = SKStrokeJoin.Round,
+                StrokeCap = SKStrokeCap.Round,
+            };
+            stroke.Fill.ApplyTo(paint, SKRect.Inflate(bounds, cumulative, cumulative));
+            var strokeBlur = Math.Max(stroke.Blur, effects.EdgeBlur);
+            if (strokeBlur > 0)
+            {
+                paint.MaskFilter = SKMaskFilter.CreateBlur(SKBlurStyle.Normal, strokeBlur);
+            }
+
+            canvas.DrawPath(path, paint);
+        }
+
+        using (var fillPaint = new SKPaint { IsAntialias = true, Style = SKPaintStyle.Fill })
+        {
+            // With outline rings the edge blur lives on the rings; without them it softens
+            // the fill itself.
+            if (effects.EdgeBlur > 0 && effects.Strokes.Count == 0)
+            {
+                fillPaint.MaskFilter = SKMaskFilter.CreateBlur(SKBlurStyle.Normal, effects.EdgeBlur);
+            }
+
+            if (effects.Fill != null)
+            {
+                effects.Fill.ApplyTo(fillPaint, bounds);
+                foreach (var seg in segments)
+                {
+                    DrawShapedText(canvas, seg.Text, seg.X, seg.Y, seg.Font, fillPaint);
+                }
+            }
+            else
+            {
+                foreach (var seg in segments)
+                {
+                    fillPaint.Color = seg.Color;
+                    DrawShapedText(canvas, seg.Text, seg.X, seg.Y, seg.Font, fillPaint);
+                }
+            }
+        }
+
+        if (effects.Bevel is { } bevel)
+        {
+            // Light from the top-left, shade from the bottom-right, clipped inside the glyphs.
+            canvas.Save();
+            canvas.ClipPath(path, SKClipOperation.Intersect, antialias: true);
+
+            using (var highlightPaint = new SKPaint
+                   {
+                       IsAntialias = true,
+                       Style = SKPaintStyle.Stroke,
+                       StrokeWidth = bevel.Depth * 2,
+                       Color = bevel.Highlight,
+                       MaskFilter = SKMaskFilter.CreateBlur(SKBlurStyle.Normal, bevel.Depth),
+                   })
+            using (var highlightPath = new SKPath(path))
+            {
+                highlightPath.Offset(bevel.Depth * 0.7f, bevel.Depth * 0.7f);
+                canvas.DrawPath(highlightPath, highlightPaint);
+            }
+
+            using (var shadePaint = new SKPaint
+                   {
+                       IsAntialias = true,
+                       Style = SKPaintStyle.Stroke,
+                       StrokeWidth = bevel.Depth * 2,
+                       Color = bevel.Shade,
+                       MaskFilter = SKMaskFilter.CreateBlur(SKBlurStyle.Normal, bevel.Depth),
+                   })
+            using (var shadePath = new SKPath(path))
+            {
+                shadePath.Offset(-bevel.Depth * 0.7f, -bevel.Depth * 0.7f);
+                canvas.DrawPath(shadePath, shadePaint);
+            }
+
+            canvas.Restore();
+        }
+    }
+
+    private static SKColor LerpColor(SKColor a, SKColor b, float t)
+    {
+        return new SKColor(
+            (byte)(a.Red + (b.Red - a.Red) * t),
+            (byte)(a.Green + (b.Green - a.Green) * t),
+            (byte)(a.Blue + (b.Blue - a.Blue) * t),
+            (byte)(a.Alpha + (b.Alpha - a.Alpha) * t));
     }
 
     // Helper method to measure text with HarfBuzz shaping via SKShaper

--- a/src/libuilogic/Export/ImageRenderer.cs
+++ b/src/libuilogic/Export/ImageRenderer.cs
@@ -156,6 +156,13 @@ public static class ImageRenderer
         // Advanced effects (blurred shadows, glow, extrude) draw further out than the classic
         // outline+shadow, so pad the scratch canvas with their own safety margin too.
         var effectMargin = ip.TextEffects?.GetSafetyMargin() ?? 0f;
+        if (ip.TextEffects is { ArcBendPercent: not 0 } arcEffects)
+        {
+            // Arc rise is width-dependent (~ w * bend / 400); the line width is not known yet,
+            // so pad conservatively from the target frame width.
+            var arcWidth = Math.Max(ip.ScreenWidth, 1000);
+            effectMargin += Math.Abs(arcEffects.ArcBendPercent) / 400f * arcWidth;
+        }
         var textStartX = (int)(Math.Abs(shadowWidth) + Math.Abs(outlineWidth) + margin + effectMargin);
         var textStartY = (int)(Math.Abs(fontMetrics.Ascent) + Math.Abs(shadowWidth) + Math.Abs(outlineWidth) + margin + effectMargin);
         RenderTextToCanvas(tempCanvas, lines, ip, regularFont, boldFont, italicFont, boldItalicFont,
@@ -533,6 +540,13 @@ public static class ImageRenderer
     {
         var effects = ip.TextEffects!;
 
+        if (effects.HasGlyphGeometry)
+        {
+            RenderTextWithGlyphGeometry(canvas, lines, ip, regularFont, boldFont, italicFont, boldItalicFont,
+                textStartX, textStartY, baseLineHeight, lineSpacing);
+            return;
+        }
+
         var lineWidths = new float[lines.Count];
         for (var li = 0; li < lines.Count; li++)
         {
@@ -603,7 +617,164 @@ public static class ImageRenderer
             currentY += baseLineHeight + lineSpacing;
         }
 
-        PaintEffectLayers(canvas, combinedPath, segmentDraws, effects);
+        PaintEffectLayers(canvas, combinedPath, segmentDraws, null, effects);
+    }
+
+    private sealed record GeometryGlyph(SKPath? Path, float X, float Advance, SKColor Color);
+
+    /// <summary>
+    /// The per-glyph geometry variant: letter spacing, arc bend and baseline wave need each
+    /// glyph as its own positioned path, so fills draw from paths here instead of
+    /// DrawShapedText (glyphs with no outline, like color emoji, are skipped).
+    /// </summary>
+    private static void RenderTextWithGlyphGeometry(
+        SKCanvas canvas,
+        List<List<TextSegment>> lines,
+        ImageParameter ip,
+        SKFont regularFont,
+        SKFont boldFont,
+        SKFont italicFont,
+        SKFont boldItalicFont,
+        float textStartX,
+        float textStartY,
+        float baseLineHeight,
+        float lineSpacing)
+    {
+        var effects = ip.TextEffects!;
+        var spacing = effects.LetterSpacing;
+
+        // 1) Shape every line into glyphs at line-relative positions, letter spacing applied.
+        var lineGlyphs = new List<List<GeometryGlyph>>();
+        var lineWidths = new List<float>();
+        foreach (var line in lines)
+        {
+            var segmentsToRender = ip.IsRightToLeft ? line.AsEnumerable().Reverse().ToList() : line;
+            var glyphs = new List<GeometryGlyph>();
+            var x = 0f;
+
+            for (var i = 0; i < segmentsToRender.Count; i++)
+            {
+                var segment = segmentsToRender[i];
+                var font = GetFont(segment, regularFont, boldFont, italicFont, boldItalicFont);
+                using var shaper = new SKShaper(font.Typeface);
+                var result = shaper.Shape(segment.Text, font);
+
+                for (var g = 0; g < result.Codepoints.Length; g++)
+                {
+                    var glyphPath = font.GetGlyphPath((ushort)result.Codepoints[g]);
+                    var gx = x + result.Points[g].X + g * spacing;
+                    var next = g + 1 < result.Points.Length ? result.Points[g + 1].X : result.Width;
+                    glyphs.Add(new GeometryGlyph(
+                        glyphPath is { IsEmpty: false } ? glyphPath : null,
+                        gx,
+                        next - result.Points[g].X,
+                        segment.Color));
+                }
+
+                x += result.Width + result.Codepoints.Length * spacing;
+                if ((segment.IsItalic || segment.IsBold) && i < segmentsToRender.Count - 1)
+                {
+                    x += regularFont.Size * 0.17f;
+                }
+            }
+
+            lineGlyphs.Add(glyphs);
+            lineWidths.Add(glyphs.Count > 0 ? Math.Max(0, x - spacing) : 0);
+        }
+
+        var maxLineWidth = lineWidths.Count > 0 ? lineWidths.Max() : 0f;
+
+        // Arc: bend maps to a circle radius derived from the widest line, so the same value
+        // gives the same visual bend regardless of text length or resolution.
+        var radius = 0f;
+        if (effects.ArcBendPercent != 0 && maxLineWidth > 0)
+        {
+            var totalAngle = Math.Clamp(effects.ArcBendPercent, -100, 100) / 100f * 2.0f; // radians
+            radius = maxLineWidth / totalAngle;
+        }
+
+        var waveLength = effects.WaveLength > 0 ? effects.WaveLength : regularFont.Size * 4.5f;
+        var blockCenterX = textStartX + maxLineWidth / 2f;
+
+        // 2) Assemble the combined path plus per-color groups (for classic per-segment colors).
+        using var combinedPath = new SKPath();
+        var groupsByColor = new Dictionary<SKColor, SKPath>();
+
+        for (var li = 0; li < lineGlyphs.Count; li++)
+        {
+            var lineWidth = lineWidths[li];
+            float lineLeft;
+            if (ip.ContentAlignment == ExportContentAlignment.Center)
+            {
+                lineLeft = textStartX + (maxLineWidth - lineWidth) / 2;
+            }
+            else if ((ip.ContentAlignment == ExportContentAlignment.Right && !ip.IsRightToLeft) ||
+                     (ip.ContentAlignment == ExportContentAlignment.Left && ip.IsRightToLeft))
+            {
+                lineLeft = textStartX + maxLineWidth - lineWidth;
+            }
+            else
+            {
+                lineLeft = textStartX;
+            }
+
+            var baseline = textStartY + li * (baseLineHeight + lineSpacing);
+
+            foreach (var glyph in lineGlyphs[li])
+            {
+                if (glyph.Path == null)
+                {
+                    continue;
+                }
+
+                var mid = lineLeft + glyph.X + glyph.Advance / 2f;
+                var m = SKMatrix.CreateTranslation(lineLeft + glyph.X, baseline);
+
+                if (effects.WaveAmplitude > 0)
+                {
+                    var dy = effects.WaveAmplitude * MathF.Sin(mid * 2f * MathF.PI / waveLength);
+                    m = SKMatrix.Concat(SKMatrix.CreateTranslation(0, dy), m);
+                }
+
+                if (radius != 0)
+                {
+                    // Place the glyph on the circle through (blockCenterX, baseline) and rotate
+                    // it to the local tangent.
+                    var theta = (mid - blockCenterX) / radius;
+                    var px = blockCenterX + radius * MathF.Sin(theta);
+                    var py = baseline + radius - radius * MathF.Cos(theta);
+
+                    var arc = SKMatrix.CreateTranslation(-mid, -baseline);
+                    arc = SKMatrix.Concat(SKMatrix.CreateRotation(theta), arc);
+                    arc = SKMatrix.Concat(SKMatrix.CreateTranslation(px, py), arc);
+                    m = SKMatrix.Concat(arc, m);
+                }
+
+                combinedPath.AddPath(glyph.Path, in m);
+
+                if (!groupsByColor.TryGetValue(glyph.Color, out var groupPath))
+                {
+                    groupPath = new SKPath();
+                    groupsByColor[glyph.Color] = groupPath;
+                }
+
+                groupPath.AddPath(glyph.Path, in m);
+                glyph.Path.Dispose();
+            }
+        }
+
+        var colorGroups = groupsByColor.Select(kv => (kv.Value, kv.Key)).ToList();
+        try
+        {
+            PaintEffectLayers(canvas, combinedPath, null, colorGroups, effects);
+        }
+        finally
+        {
+            foreach (var (groupPath, _) in colorGroups)
+            {
+                groupPath.Dispose();
+            }
+        }
     }
 
     /// <summary>
@@ -612,7 +783,12 @@ public static class ImageRenderer
     /// #12206), generalized to multiple rings: outermost first, each inner ring covers the
     /// inner half of the one below it, and the fill covers the innermost half.
     /// </summary>
-    private static void PaintEffectLayers(SKCanvas canvas, SKPath path, List<EffectSegmentDraw> segments, TextEffects effects)
+    private static void PaintEffectLayers(
+        SKCanvas canvas,
+        SKPath path,
+        List<EffectSegmentDraw>? segments,
+        List<(SKPath Path, SKColor Color)>? pathGroups,
+        TextEffects effects)
     {
         var bounds = path.TightBounds;
         var totalStrokeWidth = 0f;
@@ -659,9 +835,18 @@ public static class ImageRenderer
             }
 
             paint.Style = SKPaintStyle.Fill;
-            foreach (var seg in segments)
+            if (segments != null)
             {
-                DrawShapedText(canvas, seg.Text, seg.X + shadow.Dx, seg.Y + shadow.Dy, seg.Font, paint);
+                foreach (var seg in segments)
+                {
+                    DrawShapedText(canvas, seg.Text, seg.X + shadow.Dx, seg.Y + shadow.Dy, seg.Font, paint);
+                }
+            }
+            else
+            {
+                using var shadowFillPath = new SKPath(path);
+                shadowFillPath.Offset(shadow.Dx, shadow.Dy);
+                canvas.DrawPath(shadowFillPath, paint);
             }
         }
 
@@ -722,17 +907,32 @@ public static class ImageRenderer
             if (effects.Fill != null)
             {
                 effects.Fill.ApplyTo(fillPaint, bounds);
-                foreach (var seg in segments)
+                if (segments != null)
                 {
-                    DrawShapedText(canvas, seg.Text, seg.X, seg.Y, seg.Font, fillPaint);
+                    foreach (var seg in segments)
+                    {
+                        DrawShapedText(canvas, seg.Text, seg.X, seg.Y, seg.Font, fillPaint);
+                    }
+                }
+                else
+                {
+                    canvas.DrawPath(path, fillPaint);
                 }
             }
-            else
+            else if (segments != null)
             {
                 foreach (var seg in segments)
                 {
                     fillPaint.Color = seg.Color;
                     DrawShapedText(canvas, seg.Text, seg.X, seg.Y, seg.Font, fillPaint);
+                }
+            }
+            else if (pathGroups != null)
+            {
+                foreach (var (groupPath, color) in pathGroups)
+                {
+                    fillPaint.Color = color;
+                    canvas.DrawPath(groupPath, fillPaint);
                 }
             }
         }

--- a/src/libuilogic/Export/TextEffectPreset.cs
+++ b/src/libuilogic/Export/TextEffectPreset.cs
@@ -12,6 +12,25 @@ public enum TextEffectPreset
     Extrude3D,
     Chrome,
     Fire,
+    Comic,
+    Retro80s,
+    Anaglyph3D,
+    Ice,
+    Emboss,
+    Hollow,
+}
+
+/// <summary>
+/// User tweaks applied on top of a preset: overall strength scales every effect size
+/// (stroke widths, blur radii, glow, extrude depth), and the geometry values pass straight
+/// through to <see cref="TextEffects"/>.
+/// </summary>
+public class TextEffectAdjustments
+{
+    public int StrengthPercent { get; set; } = 100;
+    public float LetterSpacing { get; set; }
+    public float ArcBendPercent { get; set; }
+    public float WaveAmplitude { get; set; }
 }
 
 /// <summary>
@@ -23,6 +42,70 @@ public enum TextEffectPreset
 public static class TextEffectPresetFactory
 {
     public static TextEffects? Create(
+        TextEffectPreset preset,
+        float fontSize,
+        SKColor fontColor,
+        SKColor outlineColor,
+        SKColor shadowColor,
+        TextEffectAdjustments? adjustments = null)
+    {
+        var effects = CreateBase(preset, fontSize, fontColor, outlineColor, shadowColor);
+        if (effects == null)
+        {
+            return null;
+        }
+
+        if (adjustments != null)
+        {
+            var strength = Math.Clamp(adjustments.StrengthPercent, 10, 400) / 100f;
+            if (Math.Abs(strength - 1f) > 0.001f)
+            {
+                Scale(effects, strength);
+            }
+
+            effects.LetterSpacing = adjustments.LetterSpacing;
+            effects.ArcBendPercent = adjustments.ArcBendPercent;
+            effects.WaveAmplitude = adjustments.WaveAmplitude;
+        }
+
+        return effects;
+    }
+
+    private static void Scale(TextEffects effects, float factor)
+    {
+        foreach (var stroke in effects.Strokes)
+        {
+            stroke.Width *= factor;
+            stroke.Blur *= factor;
+        }
+
+        foreach (var shadow in effects.Shadows)
+        {
+            shadow.Dx *= factor;
+            shadow.Dy *= factor;
+            shadow.Blur *= factor;
+        }
+
+        if (effects.Glow != null)
+        {
+            effects.Glow.Radius *= factor;
+        }
+
+        if (effects.Extrude != null)
+        {
+            effects.Extrude.Dx *= factor;
+            effects.Extrude.Dy *= factor;
+        }
+
+        if (effects.Bevel != null)
+        {
+            effects.Bevel.Depth *= factor;
+        }
+
+        effects.EdgeBlur *= factor;
+    }
+
+    private static TextEffects? CreateBase(
         TextEffectPreset preset,
         float fontSize,
         SKColor fontColor,
@@ -128,6 +211,73 @@ public static class TextEffectPresetFactory
                     },
                     Strokes = { new TextEffectStroke { Width = s * 0.023f, Fill = TextEffectFill.Solid(new SKColor(60, 10, 0)) } },
                     Glow = new TextEffectGlow { Color = new SKColor(255, 100, 0), Radius = s * 0.11f, Passes = 2 },
+                };
+
+            case TextEffectPreset.Comic:
+                return new TextEffects
+                {
+                    Fill = TextEffectFill.Solid(fontColor),
+                    Strokes = { new TextEffectStroke { Width = s * 0.05f, Fill = TextEffectFill.Solid(SKColors.Black) } },
+                    Shadows = { new TextEffectShadow { Dx = s * 0.09f, Dy = s * 0.09f, Blur = 0, Color = SKColors.Black } },
+                };
+
+            case TextEffectPreset.Retro80s:
+                return new TextEffects
+                {
+                    Fill = new TextEffectFill
+                    {
+                        Kind = TextEffectFillKind.LinearGradient,
+                        Colors = new[] { new SKColor(255, 90, 200), new SKColor(180, 70, 255), new SKColor(60, 200, 255) },
+                    },
+                    Strokes = { new TextEffectStroke { Width = s * 0.015f, Fill = TextEffectFill.Solid(new SKColor(255, 240, 255)) } },
+                    Glow = new TextEffectGlow { Color = new SKColor(200, 60, 255), Radius = s * 0.12f, Passes = 3 },
+                    Extrude = new TextEffectExtrude
+                    {
+                        Depth = Math.Max(3, (int)(s * 0.06f)),
+                        Dx = Math.Max(1f, s * 0.015f),
+                        Dy = Math.Max(1f, s * 0.015f),
+                        NearColor = new SKColor(90, 20, 130),
+                        FarColor = new SKColor(30, 5, 50),
+                    },
+                };
+
+            case TextEffectPreset.Anaglyph3D:
+                return new TextEffects
+                {
+                    Fill = TextEffectFill.Solid(fontColor),
+                    Shadows =
+                    {
+                        new TextEffectShadow { Dx = -s * 0.06f, Dy = 0, Blur = 0, Color = new SKColor(255, 0, 60, 200) },
+                        new TextEffectShadow { Dx = s * 0.06f, Dy = 0, Blur = 0, Color = new SKColor(0, 230, 255, 200) },
+                    },
+                };
+
+            case TextEffectPreset.Ice:
+                return new TextEffects
+                {
+                    Fill = new TextEffectFill
+                    {
+                        Kind = TextEffectFillKind.LinearGradient,
+                        Colors = new[] { SKColors.White, new SKColor(200, 230, 255), new SKColor(110, 175, 230) },
+                    },
+                    Strokes = { new TextEffectStroke { Width = s * 0.02f, Fill = TextEffectFill.Solid(new SKColor(40, 80, 140)) } },
+                    Glow = new TextEffectGlow { Color = new SKColor(170, 220, 255), Radius = s * 0.1f, Passes = 2 },
+                };
+
+            case TextEffectPreset.Emboss:
+                return new TextEffects
+                {
+                    Fill = TextEffectFill.Solid(fontColor),
+                    Bevel = new TextEffectBevel { Depth = Math.Max(1.5f, s * 0.05f) },
+                    Shadows = { new TextEffectShadow { Dx = 0, Dy = s * 0.04f, Blur = s * 0.06f, Color = new SKColor(0, 0, 0, 140) } },
+                };
+
+            case TextEffectPreset.Hollow:
+                return new TextEffects
+                {
+                    Fill = TextEffectFill.Solid(SKColors.Transparent),
+                    Strokes = { new TextEffectStroke { Width = s * 0.028f, Fill = TextEffectFill.Solid(fontColor) } },
+                    Shadows = { new TextEffectShadow { Dx = s * 0.04f, Dy = s * 0.04f, Blur = s * 0.08f, Color = new SKColor(0, 0, 0, 150) } },
                 };
 
             default:

--- a/src/libuilogic/Export/TextEffectPreset.cs
+++ b/src/libuilogic/Export/TextEffectPreset.cs
@@ -1,0 +1,147 @@
+using SkiaSharp;
+
+namespace Nikse.SubtitleEdit.UiLogic.Export;
+
+public enum TextEffectPreset
+{
+    None,
+    SoftShadow,
+    GradientGold,
+    DoubleOutline,
+    NeonGlow,
+    Extrude3D,
+    Chrome,
+    Fire,
+}
+
+/// <summary>
+/// Builds a <see cref="TextEffects"/> from a named preset. All sizes scale with the font size
+/// so a preset looks the same at 26 px and at 90 px. Presets use the dialog's colors where a
+/// choice is natural (font color as fill, outline color as glow/ring color); the "signature"
+/// looks (gold, chrome, fire) bring their own palette.
+/// </summary>
+public static class TextEffectPresetFactory
+{
+    public static TextEffects? Create(
+        TextEffectPreset preset,
+        float fontSize,
+        SKColor fontColor,
+        SKColor outlineColor,
+        SKColor shadowColor)
+    {
+        var s = fontSize; // effect sizes below are fractions of the font size
+
+        switch (preset)
+        {
+            case TextEffectPreset.SoftShadow:
+                return new TextEffects
+                {
+                    Fill = TextEffectFill.Solid(fontColor),
+                    Shadows =
+                    {
+                        new TextEffectShadow { Dx = 0, Dy = s * 0.08f, Blur = s * 0.16f, Color = shadowColor },
+                    },
+                };
+
+            case TextEffectPreset.GradientGold:
+                return new TextEffects
+                {
+                    Fill = new TextEffectFill
+                    {
+                        Kind = TextEffectFillKind.LinearGradient,
+                        Colors = new[]
+                        {
+                            new SKColor(255, 245, 200), new SKColor(255, 200, 60),
+                            new SKColor(180, 110, 10), new SKColor(255, 220, 120),
+                        },
+                        Stops = new[] { 0f, 0.45f, 0.75f, 1f },
+                    },
+                    Strokes = { new TextEffectStroke { Width = s * 0.032f, Fill = TextEffectFill.Solid(new SKColor(70, 40, 0)) } },
+                    Shadows = { new TextEffectShadow { Dx = s * 0.04f, Dy = s * 0.05f, Blur = s * 0.1f, Color = new SKColor(0, 0, 0, 200) } },
+                };
+
+            case TextEffectPreset.DoubleOutline:
+                return new TextEffects
+                {
+                    Fill = TextEffectFill.Solid(fontColor),
+                    Strokes =
+                    {
+                        new TextEffectStroke { Width = s * 0.04f, Fill = TextEffectFill.Solid(outlineColor) },
+                        new TextEffectStroke { Width = s * 0.065f, Fill = TextEffectFill.Solid(shadowColor) },
+                    },
+                    Shadows = { new TextEffectShadow { Dx = s * 0.05f, Dy = s * 0.05f, Blur = s * 0.08f, Color = new SKColor(0, 0, 0, 160) } },
+                };
+
+            case TextEffectPreset.NeonGlow:
+                return new TextEffects
+                {
+                    Fill = TextEffectFill.Solid(fontColor),
+                    Strokes = { new TextEffectStroke { Width = s * 0.02f, Fill = TextEffectFill.Solid(outlineColor) } },
+                    Glow = new TextEffectGlow { Color = outlineColor, Radius = s * 0.16f, Passes = 4 },
+                };
+
+            case TextEffectPreset.Extrude3D:
+                return new TextEffects
+                {
+                    Fill = new TextEffectFill
+                    {
+                        Kind = TextEffectFillKind.LinearGradient,
+                        Colors = new[] { fontColor, Darken(fontColor, 0.3f) },
+                    },
+                    Strokes = { new TextEffectStroke { Width = s * 0.015f, Fill = TextEffectFill.Solid(Darken(fontColor, 0.8f)) } },
+                    Extrude = new TextEffectExtrude
+                    {
+                        Depth = Math.Max(4, (int)(s * 0.12f)),
+                        Dx = Math.Max(1f, s * 0.017f),
+                        Dy = Math.Max(1f, s * 0.017f),
+                        NearColor = Darken(fontColor, 0.45f),
+                        FarColor = Darken(fontColor, 0.75f),
+                    },
+                    Shadows = { new TextEffectShadow { Dx = s * 0.23f, Dy = s * 0.23f, Blur = s * 0.14f, Color = new SKColor(0, 0, 0, 120) } },
+                };
+
+            case TextEffectPreset.Chrome:
+                return new TextEffects
+                {
+                    Fill = new TextEffectFill
+                    {
+                        Kind = TextEffectFillKind.LinearGradient,
+                        Colors = new[]
+                        {
+                            new SKColor(235, 245, 255), new SKColor(140, 170, 200), new SKColor(250, 252, 255),
+                            new SKColor(90, 110, 140), new SKColor(200, 220, 240),
+                        },
+                        Stops = new[] { 0f, 0.42f, 0.5f, 0.58f, 1f },
+                    },
+                    Strokes = { new TextEffectStroke { Width = s * 0.023f, Fill = TextEffectFill.Solid(new SKColor(30, 40, 60)) } },
+                    Bevel = new TextEffectBevel { Depth = Math.Max(1.5f, s * 0.031f) },
+                    Shadows = { new TextEffectShadow { Dx = 0, Dy = s * 0.06f, Blur = s * 0.08f, Color = new SKColor(0, 0, 0, 180) } },
+                };
+
+            case TextEffectPreset.Fire:
+                return new TextEffects
+                {
+                    Fill = new TextEffectFill
+                    {
+                        Kind = TextEffectFillKind.Turbulence,
+                        Colors = new[] { new SKColor(255, 240, 120), new SKColor(255, 120, 0), new SKColor(180, 20, 0) },
+                    },
+                    Strokes = { new TextEffectStroke { Width = s * 0.023f, Fill = TextEffectFill.Solid(new SKColor(60, 10, 0)) } },
+                    Glow = new TextEffectGlow { Color = new SKColor(255, 100, 0), Radius = s * 0.11f, Passes = 2 },
+                };
+
+            default:
+                return null;
+        }
+    }
+
+    private static SKColor Darken(SKColor color, float amount)
+    {
+        var keep = 1f - Math.Clamp(amount, 0f, 1f);
+        return new SKColor(
+            (byte)(color.Red * keep),
+            (byte)(color.Green * keep),
+            (byte)(color.Blue * keep),
+            color.Alpha);
+    }
+}

--- a/src/libuilogic/Export/TextEffectPreset.cs
+++ b/src/libuilogic/Export/TextEffectPreset.cs
@@ -18,6 +18,13 @@ public enum TextEffectPreset
     Ice,
     Emboss,
     Hollow,
+    Marble,
+    Wood,
+    Lava,
+    BrushedSteel,
+    CandyCane,
+    Rainbow,
+    PolkaDots,
 }
 
 /// <summary>
@@ -278,6 +285,113 @@ public static class TextEffectPresetFactory
                     Fill = TextEffectFill.Solid(SKColors.Transparent),
                     Strokes = { new TextEffectStroke { Width = s * 0.028f, Fill = TextEffectFill.Solid(fontColor) } },
                     Shadows = { new TextEffectShadow { Dx = s * 0.04f, Dy = s * 0.04f, Blur = s * 0.08f, Color = new SKColor(0, 0, 0, 150) } },
+                };
+
+            case TextEffectPreset.Marble:
+                return new TextEffects
+                {
+                    Fill = new TextEffectFill
+                    {
+                        Kind = TextEffectFillKind.Turbulence,
+                        Colors = new[] { SKColors.White, new SKColor(205, 210, 220), new SKColor(130, 140, 160) },
+                        NoiseFrequencyX = 0.008f,
+                        NoiseFrequencyY = 0.008f,
+                        NoiseOctaves = 4,
+                    },
+                    Strokes = { new TextEffectStroke { Width = s * 0.025f, Fill = TextEffectFill.Solid(new SKColor(60, 65, 80)) } },
+                    Shadows = { new TextEffectShadow { Dx = 0, Dy = s * 0.05f, Blur = s * 0.08f, Color = new SKColor(0, 0, 0, 170) } },
+                };
+
+            case TextEffectPreset.Wood:
+                return new TextEffects
+                {
+                    Fill = new TextEffectFill
+                    {
+                        Kind = TextEffectFillKind.Turbulence,
+                        Colors = new[] { new SKColor(210, 160, 100), new SKColor(160, 105, 55), new SKColor(100, 60, 30) },
+                        // Strongly anisotropic frequencies read as horizontal grain.
+                        NoiseFrequencyX = 0.004f,
+                        NoiseFrequencyY = 0.09f,
+                        NoiseOctaves = 4,
+                    },
+                    Strokes = { new TextEffectStroke { Width = s * 0.028f, Fill = TextEffectFill.Solid(new SKColor(55, 30, 12)) } },
+                    Shadows = { new TextEffectShadow { Dx = s * 0.04f, Dy = s * 0.05f, Blur = s * 0.07f, Color = new SKColor(0, 0, 0, 170) } },
+                };
+
+            case TextEffectPreset.Lava:
+                return new TextEffects
+                {
+                    Fill = new TextEffectFill
+                    {
+                        Kind = TextEffectFillKind.Turbulence,
+                        Colors = new[] { new SKColor(255, 235, 100), new SKColor(240, 80, 10), new SKColor(70, 5, 5) },
+                        NoiseFrequencyX = 0.02f,
+                        NoiseFrequencyY = 0.02f,
+                        NoiseOctaves = 4,
+                    },
+                    Strokes = { new TextEffectStroke { Width = s * 0.025f, Fill = TextEffectFill.Solid(new SKColor(35, 5, 5)) } },
+                    Glow = new TextEffectGlow { Color = new SKColor(255, 60, 0), Radius = s * 0.1f, Passes = 2 },
+                };
+
+            case TextEffectPreset.BrushedSteel:
+                return new TextEffects
+                {
+                    Fill = new TextEffectFill
+                    {
+                        Kind = TextEffectFillKind.Turbulence,
+                        Colors = new[] { new SKColor(225, 230, 238), new SKColor(150, 158, 170), new SKColor(200, 208, 218) },
+                        // Fine horizontal streaks over the silver gradient = brushed metal.
+                        NoiseFrequencyX = 0.002f,
+                        NoiseFrequencyY = 0.35f,
+                        NoiseOctaves = 2,
+                    },
+                    Strokes = { new TextEffectStroke { Width = s * 0.023f, Fill = TextEffectFill.Solid(new SKColor(45, 52, 65)) } },
+                    Bevel = new TextEffectBevel { Depth = Math.Max(1.5f, s * 0.028f) },
+                    Shadows = { new TextEffectShadow { Dx = 0, Dy = s * 0.06f, Blur = s * 0.08f, Color = new SKColor(0, 0, 0, 170) } },
+                };
+
+            case TextEffectPreset.CandyCane:
+                return new TextEffects
+                {
+                    Fill = new TextEffectFill
+                    {
+                        Kind = TextEffectFillKind.Stripes,
+                        Colors = new[] { new SKColor(220, 30, 40), SKColors.White },
+                        TileSize = Math.Max(3f, s * 0.14f),
+                        TileAngleDegrees = 45f,
+                    },
+                    Strokes = { new TextEffectStroke { Width = s * 0.028f, Fill = TextEffectFill.Solid(new SKColor(120, 10, 20)) } },
+                    Shadows = { new TextEffectShadow { Dx = s * 0.04f, Dy = s * 0.05f, Blur = s * 0.08f, Color = new SKColor(0, 0, 0, 160) } },
+                };
+
+            case TextEffectPreset.Rainbow:
+                return new TextEffects
+                {
+                    Fill = new TextEffectFill
+                    {
+                        Kind = TextEffectFillKind.LinearGradient,
+                        AngleDegrees = 0,
+                        Colors = new[]
+                        {
+                            new SKColor(228, 30, 40), new SKColor(255, 150, 30), new SKColor(255, 220, 50),
+                            new SKColor(70, 190, 90), new SKColor(50, 120, 230), new SKColor(150, 70, 200),
+                        },
+                    },
+                    Strokes = { new TextEffectStroke { Width = s * 0.028f, Fill = TextEffectFill.Solid(new SKColor(25, 25, 35)) } },
+                    Shadows = { new TextEffectShadow { Dx = 0, Dy = s * 0.05f, Blur = s * 0.09f, Color = new SKColor(0, 0, 0, 170) } },
+                };
+
+            case TextEffectPreset.PolkaDots:
+                return new TextEffects
+                {
+                    Fill = new TextEffectFill
+                    {
+                        Kind = TextEffectFillKind.Dots,
+                        Colors = new[] { new SKColor(230, 60, 120), SKColors.White },
+                        TileSize = Math.Max(3f, s * 0.11f),
+                    },
+                    Strokes = { new TextEffectStroke { Width = s * 0.032f, Fill = TextEffectFill.Solid(new SKColor(90, 15, 45)) } },
+                    Shadows = { new TextEffectShadow { Dx = s * 0.05f, Dy = s * 0.05f, Blur = 0, Color = new SKColor(40, 5, 20, 200) } },
                 };
 
             default:

--- a/src/libuilogic/Export/TextEffects.cs
+++ b/src/libuilogic/Export/TextEffects.cs
@@ -30,6 +30,28 @@ public class TextEffects
     /// <summary>Softens the glyph edges (like ASSA "\be").</summary>
     public float EdgeBlur { get; set; }
 
+    /// <summary>Extra pixels between glyphs (like ASSA "\fsp").</summary>
+    public float LetterSpacing { get; set; }
+
+    /// <summary>
+    /// Bends each line along a circular arc. -100..100; positive arches up (rainbow),
+    /// negative curves down (smile), 0 is straight. The radius is derived from the widest
+    /// line so the same value gives the same visual bend at any resolution.
+    /// </summary>
+    public float ArcBendPercent { get; set; }
+
+    /// <summary>Sine-wave baseline offset in pixels; 0 is off.</summary>
+    public float WaveAmplitude { get; set; }
+
+    /// <summary>Wavelength of the baseline wave; 0 = pick from the font size.</summary>
+    public float WaveLength { get; set; }
+
+    /// <summary>
+    /// True when any per-glyph geometry is active - those effects need each glyph as its
+    /// own positioned path instead of a straight DrawShapedText run.
+    /// </summary>
+    public bool HasGlyphGeometry => LetterSpacing != 0 || ArcBendPercent != 0 || WaveAmplitude > 0;
+
     /// <summary>
     /// How far, in pixels, the effects can draw outside the glyph paths - used to pad the
     /// scratch canvas so blurred shadows and glows are never clipped. Blur sigma extends
@@ -64,6 +86,7 @@ public class TextEffects
 
         margin = Math.Max(margin, strokeTotal + Math.Max(strokeBlur, EdgeBlur) * 3f);
         margin = Math.Max(margin, EdgeBlur * 3f);
+        margin += WaveAmplitude;
 
         return margin + 4f;
     }

--- a/src/libuilogic/Export/TextEffects.cs
+++ b/src/libuilogic/Export/TextEffects.cs
@@ -1,0 +1,199 @@
+using SkiaSharp;
+
+namespace Nikse.SubtitleEdit.UiLogic.Export;
+
+/// <summary>
+/// Advanced text formatting for image-based export. When <see cref="ImageParameter.TextEffects"/>
+/// is set, <see cref="ImageRenderer"/> renders the subtitle through a layered pipeline instead of
+/// the classic fill/outline/shadow path: the shaped glyphs become one combined SKPath, and every
+/// effect is then a path operation - gradient fills are shaders bounded to the text, outlines are
+/// strokes, shadows/glows are blurred fills. That is what lets the effects compose freely.
+/// </summary>
+public class TextEffects
+{
+    /// <summary>
+    /// Fill for all text. Null means "use the per-segment colors" (font color and
+    /// &lt;font color=..&gt; tags), like the classic renderer.
+    /// </summary>
+    public TextEffectFill? Fill { get; set; }
+
+    /// <summary>Outline rings, innermost first. Replaces the classic single outline.</summary>
+    public List<TextEffectStroke> Strokes { get; set; } = new();
+
+    /// <summary>Drop shadows. Blur 0 gives the classic hard shadow.</summary>
+    public List<TextEffectShadow> Shadows { get; set; } = new();
+
+    public TextEffectGlow? Glow { get; set; }
+    public TextEffectExtrude? Extrude { get; set; }
+    public TextEffectBevel? Bevel { get; set; }
+
+    /// <summary>Softens the glyph edges (like ASSA "\be").</summary>
+    public float EdgeBlur { get; set; }
+
+    /// <summary>
+    /// How far, in pixels, the effects can draw outside the glyph paths - used to pad the
+    /// scratch canvas so blurred shadows and glows are never clipped. Blur sigma extends
+    /// roughly 3 sigma.
+    /// </summary>
+    public float GetSafetyMargin()
+    {
+        var margin = 0f;
+
+        foreach (var shadow in Shadows)
+        {
+            margin = Math.Max(margin, Math.Abs(shadow.Dx) + Math.Abs(shadow.Dy) + shadow.Blur * 3f);
+        }
+
+        if (Glow != null)
+        {
+            margin = Math.Max(margin, Glow.Radius * 3f);
+        }
+
+        if (Extrude != null)
+        {
+            margin = Math.Max(margin, Extrude.Depth * Math.Max(Math.Abs(Extrude.Dx), Math.Abs(Extrude.Dy)) + 2f);
+        }
+
+        var strokeTotal = 0f;
+        var strokeBlur = 0f;
+        foreach (var stroke in Strokes)
+        {
+            strokeTotal += stroke.Width;
+            strokeBlur = Math.Max(strokeBlur, stroke.Blur);
+        }
+
+        margin = Math.Max(margin, strokeTotal + Math.Max(strokeBlur, EdgeBlur) * 3f);
+        margin = Math.Max(margin, EdgeBlur * 3f);
+
+        return margin + 4f;
+    }
+}
+
+public enum TextEffectFillKind
+{
+    Solid,
+    LinearGradient,
+    RadialGradient,
+
+    /// <summary>Perlin turbulence composed over the gradient - fire/marble style texture.</summary>
+    Turbulence,
+}
+
+/// <summary>A paint source resolved against the rendered text's bounds.</summary>
+public class TextEffectFill
+{
+    public TextEffectFillKind Kind { get; set; } = TextEffectFillKind.Solid;
+    public SKColor[] Colors { get; set; } = { SKColors.White };
+    public float[]? Stops { get; set; }
+
+    /// <summary>Gradient direction in degrees; 90 = top-to-bottom.</summary>
+    public float AngleDegrees { get; set; } = 90;
+
+    public static TextEffectFill Solid(SKColor color)
+    {
+        return new TextEffectFill { Kind = TextEffectFillKind.Solid, Colors = new[] { color } };
+    }
+
+    public static TextEffectFill Linear(params SKColor[] colors)
+    {
+        return new TextEffectFill { Kind = TextEffectFillKind.LinearGradient, Colors = colors };
+    }
+
+    /// <summary>
+    /// Configures the paint to draw with this fill across <paramref name="bounds"/>.
+    /// Any shader is owned by the paint and freed with it.
+    /// </summary>
+    public void ApplyTo(SKPaint paint, SKRect bounds)
+    {
+        switch (Kind)
+        {
+            case TextEffectFillKind.LinearGradient:
+                paint.Color = SKColors.White;
+                paint.Shader = MakeLinearGradient(bounds);
+                break;
+
+            case TextEffectFillKind.RadialGradient:
+                paint.Color = SKColors.White;
+                paint.Shader = SKShader.CreateRadialGradient(
+                    new SKPoint(bounds.MidX, bounds.MidY),
+                    Math.Max(bounds.Width, bounds.Height) / 2f,
+                    Colors, Stops, SKShaderTileMode.Clamp);
+                break;
+
+            case TextEffectFillKind.Turbulence:
+                paint.Color = SKColors.White;
+                using (var gradient = MakeLinearGradient(bounds))
+                using (var noise = SKShader.CreatePerlinNoiseTurbulence(0.012f, 0.035f, 3, 7f))
+                {
+                    paint.Shader = SKShader.CreateCompose(gradient, noise, SKBlendMode.Overlay);
+                }
+
+                break;
+
+            default:
+                paint.Color = Colors[0];
+                break;
+        }
+    }
+
+    private SKShader MakeLinearGradient(SKRect bounds)
+    {
+        var radians = AngleDegrees * MathF.PI / 180f;
+        var dx = MathF.Cos(radians);
+        var dy = MathF.Sin(radians);
+
+        // Project the bounds onto the gradient direction so the gradient spans the text
+        // exactly, whatever the angle.
+        var half = (Math.Abs(dx) * bounds.Width + Math.Abs(dy) * bounds.Height) / 2f;
+        var from = new SKPoint(bounds.MidX - dx * half, bounds.MidY - dy * half);
+        var to = new SKPoint(bounds.MidX + dx * half, bounds.MidY + dy * half);
+        return SKShader.CreateLinearGradient(from, to, Colors, Stops, SKShaderTileMode.Clamp);
+    }
+}
+
+/// <summary>One outline ring.</summary>
+public class TextEffectStroke
+{
+    public float Width { get; set; } = 2f;
+    public TextEffectFill Fill { get; set; } = TextEffectFill.Solid(SKColors.Black);
+
+    /// <summary>Softens just this ring.</summary>
+    public float Blur { get; set; }
+}
+
+public class TextEffectShadow
+{
+    public float Dx { get; set; } = 3;
+    public float Dy { get; set; } = 3;
+
+    /// <summary>0 = hard classic shadow; larger = the soft "streaming" look.</summary>
+    public float Blur { get; set; }
+
+    public SKColor Color { get; set; } = new SKColor(0, 0, 0, 200);
+}
+
+/// <summary>Neon-style halo: repeated blurred draws that saturate around the glyphs.</summary>
+public class TextEffectGlow
+{
+    public SKColor Color { get; set; } = SKColors.Cyan;
+    public float Radius { get; set; } = 14;
+    public int Passes { get; set; } = 3;
+}
+
+/// <summary>Fake 3D depth: the glyph path re-filled Depth times, stepping (Dx, Dy) each time.</summary>
+public class TextEffectExtrude
+{
+    public int Depth { get; set; } = 8;
+    public float Dx { get; set; } = 1.5f;
+    public float Dy { get; set; } = 1.5f;
+    public SKColor NearColor { get; set; } = new SKColor(120, 60, 0);
+    public SKColor FarColor { get; set; } = new SKColor(40, 20, 0);
+}
+
+/// <summary>Inner bevel: blurred light/dark strokes clipped inside the glyphs.</summary>
+public class TextEffectBevel
+{
+    public SKColor Highlight { get; set; } = new SKColor(255, 255, 255, 180);
+    public SKColor Shade { get; set; } = new SKColor(0, 0, 0, 160);
+    public float Depth { get; set; } = 3;
+}

--- a/src/libuilogic/Export/TextEffects.cs
+++ b/src/libuilogic/Export/TextEffects.cs
@@ -98,8 +98,14 @@ public enum TextEffectFillKind
     LinearGradient,
     RadialGradient,
 
-    /// <summary>Perlin turbulence composed over the gradient - fire/marble style texture.</summary>
+    /// <summary>Perlin turbulence composed over the gradient - fire/marble/wood style texture.</summary>
     Turbulence,
+
+    /// <summary>Repeating two-color stripes (candy cane and friends).</summary>
+    Stripes,
+
+    /// <summary>Repeating polka dots, color 1 on a color 0 background.</summary>
+    Dots,
 }
 
 /// <summary>A paint source resolved against the rendered text's bounds.</summary>
@@ -111,6 +117,22 @@ public class TextEffectFill
 
     /// <summary>Gradient direction in degrees; 90 = top-to-bottom.</summary>
     public float AngleDegrees { get; set; } = 90;
+
+    /// <summary>
+    /// Turbulence tuning. The X/Y base frequencies are what make one texture read as fire,
+    /// marble or wood grain: equal small values give blotches, a strongly anisotropic pair
+    /// gives streaks/grain along the smaller-frequency axis.
+    /// </summary>
+    public float NoiseFrequencyX { get; set; } = 0.012f;
+
+    public float NoiseFrequencyY { get; set; } = 0.035f;
+    public int NoiseOctaves { get; set; } = 3;
+
+    /// <summary>Stripe width or dot cell half-size, in pixels (set from the font size).</summary>
+    public float TileSize { get; set; } = 12f;
+
+    /// <summary>Stripe direction in degrees.</summary>
+    public float TileAngleDegrees { get; set; } = 45f;
 
     public static TextEffectFill Solid(SKColor color)
     {
@@ -146,17 +168,76 @@ public class TextEffectFill
             case TextEffectFillKind.Turbulence:
                 paint.Color = SKColors.White;
                 using (var gradient = MakeLinearGradient(bounds))
-                using (var noise = SKShader.CreatePerlinNoiseTurbulence(0.012f, 0.035f, 3, 7f))
+                using (var noise = SKShader.CreatePerlinNoiseTurbulence(NoiseFrequencyX, NoiseFrequencyY, NoiseOctaves, 7f))
                 {
                     paint.Shader = SKShader.CreateCompose(gradient, noise, SKBlendMode.Overlay);
                 }
 
                 break;
 
+            case TextEffectFillKind.Stripes:
+                paint.Color = SKColors.White;
+                paint.Shader = MakeStripesShader();
+                break;
+
+            case TextEffectFillKind.Dots:
+                paint.Color = SKColors.White;
+                paint.Shader = MakeDotsShader();
+                break;
+
             default:
                 paint.Color = Colors[0];
                 break;
         }
+    }
+
+    /// <summary>
+    /// Repeating stripe texture as a bitmap tile shader. The tile is copied into an
+    /// SKImage, and the shader keeps its own native reference, so nothing here has to
+    /// outlive this call.
+    /// </summary>
+    private SKShader MakeStripesShader()
+    {
+        var stripe = Math.Max(2f, TileSize);
+        var tileHeight = (int)Math.Ceiling(stripe * 2);
+        using var tile = new SKBitmap(8, tileHeight);
+        using (var canvas = new SKCanvas(tile))
+        using (var p = new SKPaint())
+        {
+            p.Color = Colors[0];
+            canvas.DrawRect(0, 0, 8, stripe, p);
+            p.Color = Colors.Length > 1 ? Colors[1] : SKColors.White;
+            canvas.DrawRect(0, stripe, 8, tileHeight - stripe, p);
+        }
+
+        using var image = SKImage.FromBitmap(tile);
+        return image.ToShader(SKShaderTileMode.Repeat, SKShaderTileMode.Repeat,
+            new SKSamplingOptions(SKFilterMode.Linear),
+            SKMatrix.CreateRotationDegrees(TileAngleDegrees));
+    }
+
+    /// <summary>Repeating polka-dot texture: color 1 dots on a color 0 background.</summary>
+    private SKShader MakeDotsShader()
+    {
+        var cell = (int)Math.Ceiling(Math.Max(4f, TileSize * 2));
+        using var tile = new SKBitmap(cell, cell);
+        using (var canvas = new SKCanvas(tile))
+        using (var p = new SKPaint { IsAntialias = true })
+        {
+            canvas.Clear(Colors[0]);
+            p.Color = Colors.Length > 1 ? Colors[1] : SKColors.White;
+            var radius = cell * 0.28f;
+            canvas.DrawCircle(cell / 2f, cell / 2f, radius, p);
+            // quarter dots in the corners give the offset "polka" packing when tiled
+            canvas.DrawCircle(0, 0, radius, p);
+            canvas.DrawCircle(cell, 0, radius, p);
+            canvas.DrawCircle(0, cell, radius, p);
+            canvas.DrawCircle(cell, cell, radius, p);
+        }
+
+        using var image = SKImage.FromBitmap(tile);
+        return image.ToShader(SKShaderTileMode.Repeat, SKShaderTileMode.Repeat,
+            new SKSamplingOptions(SKFilterMode.Linear), SKMatrix.CreateIdentity());
     }
 
     private SKShader MakeLinearGradient(SKRect bounds)

--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -413,6 +413,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<ExportCustomTextFormatViewModel>();
         collection.AddTransient<ExportEbuStlViewModel>();
         collection.AddTransient<ExportImageBasedViewModel>();
+        collection.AddTransient<TextEffectViewModel>();
         collection.AddTransient<ExportPacViewModel>();
         collection.AddTransient<ExportPlainTextViewModel>();
         collection.AddTransient<FindDoubleLinesViewModel>();

--- a/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
+++ b/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
@@ -87,6 +87,8 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
     [ObservableProperty] private bool _isFullFrame;
     [ObservableProperty] private Color _fullFrameBackgroundColor;
     [ObservableProperty] private bool _isFullFrameVisible;
+    [ObservableProperty] private ObservableCollection<TextEffectDisplayItem> _textEffectItems = null!;
+    [ObservableProperty] private TextEffectDisplayItem? _selectedTextEffect;
     public ObservableCollection<int> BoxPaddingValues { get; } = new ObservableCollection<int>(Enumerable.Range(0, 100));
 
     private string _outlineColorText = string.Empty;
@@ -190,6 +192,8 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
         };
         SelectedBoxType = BoxTypes[0];
         UpdateBoxTypeLabels();
+        TextEffectItems = new ObservableCollection<TextEffectDisplayItem>(TextEffectDisplayItem.GetItems());
+        SelectedTextEffect = TextEffectItems[0];
 
         _generateLock = new Lock();
         _cancellationTokenSource = new CancellationTokenSource();
@@ -559,6 +563,12 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
             FramesPerSecond = SelectedFrameRate,
             IsFullFrame = IsFullFrameVisible && IsFullFrame,
             FullFrameBackgroundColor = FullFrameBackgroundColor.ToSKColor(),
+            TextEffects = TextEffectPresetFactory.Create(
+                SelectedTextEffect?.Preset ?? TextEffectPreset.None,
+                SelectedFontSize,
+                FontColor.ToSKColor(),
+                OutlineColor.ToSKColor(),
+                ShadowColor.ToSKColor()),
         };
 
         // "{\fad(..)}" and "{\alpha&H..&}" change what is drawn, so unlike the position tag
@@ -771,6 +781,7 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
     }
 
     partial void OnFontColorChanged(Color value) => _dirty = true;
+    partial void OnSelectedTextEffectChanged(TextEffectDisplayItem? value) => _dirty = true;
     partial void OnOutlineColorChanged(Color value) => _dirty = true;
     partial void OnShadowColorChanged(Color value) => _dirty = true;
     partial void OnBoxColorChanged(Color value) => _dirty = true;
@@ -933,6 +944,8 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
             SelectedFrameRate = FrameRates.Contains(profile.FramesPerSecond) ? profile.FramesPerSecond : 25;
             IsFullFrame = profile.IsFullFrame;
             FullFrameBackgroundColor = profile.FullFrameBackgroundColor.FromHex().ToAvaloniaColor();
+            SelectedTextEffect = TextEffectItems.FirstOrDefault(t => t.Preset.ToString() == profile.TextEffect)
+                                 ?? TextEffectItems[0];
         }
     }
 
@@ -967,6 +980,9 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
             profile.FramesPerSecond = SelectedFrameRate;
             profile.IsFullFrame = IsFullFrame;
             profile.FullFrameBackgroundColor = FullFrameBackgroundColor.FromColorToHex(true);
+            profile.TextEffect = SelectedTextEffect == null || SelectedTextEffect.Preset == TextEffectPreset.None
+                ? string.Empty
+                : SelectedTextEffect.Preset.ToString();
         }
     }
 

--- a/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
+++ b/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
@@ -89,6 +89,11 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
     [ObservableProperty] private bool _isFullFrameVisible;
     [ObservableProperty] private ObservableCollection<TextEffectDisplayItem> _textEffectItems = null!;
     [ObservableProperty] private TextEffectDisplayItem? _selectedTextEffect;
+    [ObservableProperty] private bool _isTextEffectEnabled;
+    [ObservableProperty] private int _textEffectStrength = 100;
+    [ObservableProperty] private int _textEffectLetterSpacing;
+    [ObservableProperty] private int _textEffectArcBend;
+    [ObservableProperty] private int _textEffectWave;
     public ObservableCollection<int> BoxPaddingValues { get; } = new ObservableCollection<int>(Enumerable.Range(0, 100));
 
     private string _outlineColorText = string.Empty;
@@ -563,12 +568,21 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
             FramesPerSecond = SelectedFrameRate,
             IsFullFrame = IsFullFrameVisible && IsFullFrame,
             FullFrameBackgroundColor = FullFrameBackgroundColor.ToSKColor(),
-            TextEffects = TextEffectPresetFactory.Create(
-                SelectedTextEffect?.Preset ?? TextEffectPreset.None,
-                SelectedFontSize,
-                FontColor.ToSKColor(),
-                OutlineColor.ToSKColor(),
-                ShadowColor.ToSKColor()),
+            TextEffects = IsTextEffectEnabled
+                ? TextEffectPresetFactory.Create(
+                    SelectedTextEffect?.Preset ?? TextEffectPreset.SoftShadow,
+                    SelectedFontSize,
+                    FontColor.ToSKColor(),
+                    OutlineColor.ToSKColor(),
+                    ShadowColor.ToSKColor(),
+                    new TextEffectAdjustments
+                    {
+                        StrengthPercent = TextEffectStrength,
+                        LetterSpacing = TextEffectLetterSpacing,
+                        ArcBendPercent = TextEffectArcBend,
+                        WaveAmplitude = TextEffectWave,
+                    })
+                : null,
         };
 
         // "{\fad(..)}" and "{\alpha&H..&}" change what is drawn, so unlike the position tag
@@ -782,6 +796,34 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
 
     partial void OnFontColorChanged(Color value) => _dirty = true;
     partial void OnSelectedTextEffectChanged(TextEffectDisplayItem? value) => _dirty = true;
+    partial void OnIsTextEffectEnabledChanged(bool value) => _dirty = true;
+    partial void OnTextEffectStrengthChanged(int value) => _dirty = true;
+    partial void OnTextEffectLetterSpacingChanged(int value) => _dirty = true;
+    partial void OnTextEffectArcBendChanged(int value) => _dirty = true;
+    partial void OnTextEffectWaveChanged(int value) => _dirty = true;
+
+    [RelayCommand]
+    private async Task ShowTextEffectSettings()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        // Turn the effect on while tuning so the preview shows what the sliders do; put it
+        // back on cancel. The settings window writes straight into this view model, so the
+        // preview underneath follows every change live.
+        var wasEnabled = IsTextEffectEnabled;
+        IsTextEffectEnabled = true;
+
+        var result = await _windowService.ShowDialogAsync<TextEffectWindow, TextEffectViewModel>(Window,
+            vm => vm.Initialize(this));
+
+        if (!result.OkPressed)
+        {
+            IsTextEffectEnabled = wasEnabled;
+        }
+    }
     partial void OnOutlineColorChanged(Color value) => _dirty = true;
     partial void OnShadowColorChanged(Color value) => _dirty = true;
     partial void OnBoxColorChanged(Color value) => _dirty = true;
@@ -946,6 +988,11 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
             FullFrameBackgroundColor = profile.FullFrameBackgroundColor.FromHex().ToAvaloniaColor();
             SelectedTextEffect = TextEffectItems.FirstOrDefault(t => t.Preset.ToString() == profile.TextEffect)
                                  ?? TextEffectItems[0];
+            IsTextEffectEnabled = profile.TextEffectEnabled;
+            TextEffectStrength = profile.TextEffectStrength <= 0 ? 100 : profile.TextEffectStrength;
+            TextEffectLetterSpacing = profile.TextEffectLetterSpacing;
+            TextEffectArcBend = profile.TextEffectArcBend;
+            TextEffectWave = profile.TextEffectWave;
         }
     }
 
@@ -980,9 +1027,12 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
             profile.FramesPerSecond = SelectedFrameRate;
             profile.IsFullFrame = IsFullFrame;
             profile.FullFrameBackgroundColor = FullFrameBackgroundColor.FromColorToHex(true);
-            profile.TextEffect = SelectedTextEffect == null || SelectedTextEffect.Preset == TextEffectPreset.None
-                ? string.Empty
-                : SelectedTextEffect.Preset.ToString();
+            profile.TextEffect = SelectedTextEffect?.Preset.ToString() ?? string.Empty;
+            profile.TextEffectEnabled = IsTextEffectEnabled;
+            profile.TextEffectStrength = TextEffectStrength;
+            profile.TextEffectLetterSpacing = TextEffectLetterSpacing;
+            profile.TextEffectArcBend = TextEffectArcBend;
+            profile.TextEffectWave = TextEffectWave;
         }
     }
 

--- a/src/ui/Features/Files/ExportImageBased/ExportImageBasedWindow.cs
+++ b/src/ui/Features/Files/ExportImageBased/ExportImageBasedWindow.cs
@@ -384,14 +384,18 @@ public class ExportImageBasedWindow : Window
         checkBoxBold.IsCheckedChanged += vm.CheckBoxChanged;
         var checkBoxRightToLeft = UiUtil.MakeCheckBox(Se.Language.General.RightToLeft, vm, nameof(vm.IsRightToLeft));
         checkBoxRightToLeft.IsCheckedChanged += vm.CheckBoxChanged;
+        var checkBoxTextEffect = UiUtil.MakeCheckBox(Se.Language.File.Export.TextEffect, vm, nameof(vm.IsTextEffectEnabled));
+        checkBoxTextEffect.IsCheckedChanged += vm.CheckBoxChanged;
+        var buttonTextEffectSettings = UiUtil.MakeButton(vm.ShowTextEffectSettingsCommand, IconNames.Settings,
+            Se.Language.File.Export.TextEffectSettingsTitle);
         var panelBoldAndRightToLeft = new StackPanel
         {
             Orientation = Orientation.Horizontal,
             Spacing = 10,
             VerticalAlignment = VerticalAlignment.Center,
-            Children = { checkBoxBold, checkBoxRightToLeft }
+            Children = { checkBoxBold, checkBoxRightToLeft, checkBoxTextEffect, buttonTextEffectSettings }
         };
-        grid.Add(panelBoldAndRightToLeft, 0, 5);
+        grid.Add(panelBoldAndRightToLeft, 0, 5, 1, 3);
 
 
         var labelOutlineWidth = UiUtil.MakeLabel(Se.Language.General.OutlineWidth);
@@ -446,13 +450,6 @@ public class ExportImageBasedWindow : Window
         comboBoxFrameRate.SelectionChanged += vm.ComboChanged;
         grid.Add(labelFrameRate, 6, 4);
         grid.Add(comboBoxFrameRate, 6, 5);
-
-        // column 4
-        var labelTextEffect = UiUtil.MakeLabel(Se.Language.File.Export.TextEffect);
-        var comboBoxTextEffect = UiUtil.MakeComboBox(vm.TextEffectItems, vm, nameof(vm.SelectedTextEffect));
-        comboBoxTextEffect.SelectionChanged += vm.ComboChanged;
-        grid.Add(labelTextEffect, 0, 6);
-        grid.Add(comboBoxTextEffect, 0, 7);
 
         // Only shown for the formats that can use a frame-sized image (see IsFullFrameVisible).
         var checkBoxFullFrame = UiUtil.MakeCheckBox(Se.Language.File.Export.FullFrameImage, vm, nameof(vm.IsFullFrame));

--- a/src/ui/Features/Files/ExportImageBased/ExportImageBasedWindow.cs
+++ b/src/ui/Features/Files/ExportImageBased/ExportImageBasedWindow.cs
@@ -447,6 +447,13 @@ public class ExportImageBasedWindow : Window
         grid.Add(labelFrameRate, 6, 4);
         grid.Add(comboBoxFrameRate, 6, 5);
 
+        // column 4
+        var labelTextEffect = UiUtil.MakeLabel(Se.Language.File.Export.TextEffect);
+        var comboBoxTextEffect = UiUtil.MakeComboBox(vm.TextEffectItems, vm, nameof(vm.SelectedTextEffect));
+        comboBoxTextEffect.SelectionChanged += vm.ComboChanged;
+        grid.Add(labelTextEffect, 0, 6);
+        grid.Add(comboBoxTextEffect, 0, 7);
+
         // Only shown for the formats that can use a frame-sized image (see IsFullFrameVisible).
         var checkBoxFullFrame = UiUtil.MakeCheckBox(Se.Language.File.Export.FullFrameImage, vm, nameof(vm.IsFullFrame));
         checkBoxFullFrame.IsCheckedChanged += vm.CheckBoxChanged;

--- a/src/ui/Features/Files/ExportImageBased/TextEffectDisplayItem.cs
+++ b/src/ui/Features/Files/ExportImageBased/TextEffectDisplayItem.cs
@@ -20,11 +20,14 @@ public class TextEffectDisplayItem
         return Name;
     }
 
+    /// <summary>
+    /// Selectable presets for the text effect settings window. "None" is not in the list -
+    /// the enable checkbox in the export dialog covers that.
+    /// </summary>
     public static List<TextEffectDisplayItem> GetItems()
     {
         return new List<TextEffectDisplayItem>
         {
-            new(TextEffectPreset.None, Se.Language.General.None),
             new(TextEffectPreset.SoftShadow, Se.Language.File.Export.TextEffectSoftShadow),
             new(TextEffectPreset.GradientGold, Se.Language.File.Export.TextEffectGradientGold),
             new(TextEffectPreset.DoubleOutline, Se.Language.File.Export.TextEffectDoubleOutline),
@@ -32,6 +35,12 @@ public class TextEffectDisplayItem
             new(TextEffectPreset.Extrude3D, Se.Language.File.Export.TextEffectExtrude3D),
             new(TextEffectPreset.Chrome, Se.Language.File.Export.TextEffectChrome),
             new(TextEffectPreset.Fire, Se.Language.File.Export.TextEffectFire),
+            new(TextEffectPreset.Comic, Se.Language.File.Export.TextEffectComic),
+            new(TextEffectPreset.Retro80s, Se.Language.File.Export.TextEffectRetro80s),
+            new(TextEffectPreset.Anaglyph3D, Se.Language.File.Export.TextEffectAnaglyph3D),
+            new(TextEffectPreset.Ice, Se.Language.File.Export.TextEffectIce),
+            new(TextEffectPreset.Emboss, Se.Language.File.Export.TextEffectEmboss),
+            new(TextEffectPreset.Hollow, Se.Language.File.Export.TextEffectHollow),
         };
     }
 }

--- a/src/ui/Features/Files/ExportImageBased/TextEffectDisplayItem.cs
+++ b/src/ui/Features/Files/ExportImageBased/TextEffectDisplayItem.cs
@@ -41,6 +41,13 @@ public class TextEffectDisplayItem
             new(TextEffectPreset.Ice, Se.Language.File.Export.TextEffectIce),
             new(TextEffectPreset.Emboss, Se.Language.File.Export.TextEffectEmboss),
             new(TextEffectPreset.Hollow, Se.Language.File.Export.TextEffectHollow),
+            new(TextEffectPreset.Marble, Se.Language.File.Export.TextEffectMarble),
+            new(TextEffectPreset.Wood, Se.Language.File.Export.TextEffectWood),
+            new(TextEffectPreset.Lava, Se.Language.File.Export.TextEffectLava),
+            new(TextEffectPreset.BrushedSteel, Se.Language.File.Export.TextEffectBrushedSteel),
+            new(TextEffectPreset.CandyCane, Se.Language.File.Export.TextEffectCandyCane),
+            new(TextEffectPreset.Rainbow, Se.Language.File.Export.TextEffectRainbow),
+            new(TextEffectPreset.PolkaDots, Se.Language.File.Export.TextEffectPolkaDots),
         };
     }
 }

--- a/src/ui/Features/Files/ExportImageBased/TextEffectDisplayItem.cs
+++ b/src/ui/Features/Files/ExportImageBased/TextEffectDisplayItem.cs
@@ -1,0 +1,37 @@
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.UiLogic.Export;
+using System.Collections.Generic;
+
+namespace Nikse.SubtitleEdit.Features.Files.ExportImageBased;
+
+public class TextEffectDisplayItem
+{
+    public TextEffectPreset Preset { get; }
+    public string Name { get; }
+
+    public TextEffectDisplayItem(TextEffectPreset preset, string name)
+    {
+        Preset = preset;
+        Name = name;
+    }
+
+    public override string ToString()
+    {
+        return Name;
+    }
+
+    public static List<TextEffectDisplayItem> GetItems()
+    {
+        return new List<TextEffectDisplayItem>
+        {
+            new(TextEffectPreset.None, Se.Language.General.None),
+            new(TextEffectPreset.SoftShadow, Se.Language.File.Export.TextEffectSoftShadow),
+            new(TextEffectPreset.GradientGold, Se.Language.File.Export.TextEffectGradientGold),
+            new(TextEffectPreset.DoubleOutline, Se.Language.File.Export.TextEffectDoubleOutline),
+            new(TextEffectPreset.NeonGlow, Se.Language.File.Export.TextEffectNeonGlow),
+            new(TextEffectPreset.Extrude3D, Se.Language.File.Export.TextEffectExtrude3D),
+            new(TextEffectPreset.Chrome, Se.Language.File.Export.TextEffectChrome),
+            new(TextEffectPreset.Fire, Se.Language.File.Export.TextEffectFire),
+        };
+    }
+}

--- a/src/ui/Features/Files/ExportImageBased/TextEffectViewModel.cs
+++ b/src/ui/Features/Files/ExportImageBased/TextEffectViewModel.cs
@@ -82,6 +82,16 @@ public partial class TextEffectViewModel : ObservableObject
         _parent.TextEffectWave = Wave;
     }
 
+    /// <summary>Back to the neutral tuning values; the preset choice stays.</summary>
+    [RelayCommand]
+    private void Reset()
+    {
+        Strength = 100;
+        LetterSpacing = 0;
+        ArcBend = 0;
+        Wave = 0;
+    }
+
     [RelayCommand]
     private void Ok()
     {

--- a/src/ui/Features/Files/ExportImageBased/TextEffectViewModel.cs
+++ b/src/ui/Features/Files/ExportImageBased/TextEffectViewModel.cs
@@ -1,0 +1,118 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.UiLogic.Export;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Features.Files.ExportImageBased;
+
+/// <summary>
+/// Settings for the export-to-images text effect. Every change is pushed straight into the
+/// owning <see cref="ExportImageBasedViewModel"/>, so the preview in the export dialog follows
+/// the sliders live; Cancel puts the original values back.
+/// </summary>
+public partial class TextEffectViewModel : ObservableObject
+{
+    [ObservableProperty] private ObservableCollection<TextEffectDisplayItem> _presets;
+    [ObservableProperty] private TextEffectDisplayItem? _selectedPreset;
+    [ObservableProperty] private int _strength = 100;
+    [ObservableProperty] private int _letterSpacing;
+    [ObservableProperty] private int _arcBend;
+    [ObservableProperty] private int _wave;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    private ExportImageBasedViewModel? _parent;
+    private TextEffectPreset _originalPreset;
+    private int _originalStrength;
+    private int _originalLetterSpacing;
+    private int _originalArcBend;
+    private int _originalWave;
+    private bool _initialized;
+
+    public TextEffectViewModel()
+    {
+        Presets = new ObservableCollection<TextEffectDisplayItem>(TextEffectDisplayItem.GetItems());
+    }
+
+    public void Initialize(ExportImageBasedViewModel parent)
+    {
+        _parent = parent;
+        _originalPreset = parent.SelectedTextEffect?.Preset ?? TextEffectPreset.SoftShadow;
+        _originalStrength = parent.TextEffectStrength;
+        _originalLetterSpacing = parent.TextEffectLetterSpacing;
+        _originalArcBend = parent.TextEffectArcBend;
+        _originalWave = parent.TextEffectWave;
+
+        SelectedPreset = Presets.FirstOrDefault(p => p.Preset == _originalPreset) ?? Presets[0];
+        Strength = _originalStrength;
+        LetterSpacing = _originalLetterSpacing;
+        ArcBend = _originalArcBend;
+        Wave = _originalWave;
+
+        _initialized = true;
+    }
+
+    partial void OnSelectedPresetChanged(TextEffectDisplayItem? value) => Push();
+    partial void OnStrengthChanged(int value) => Push();
+    partial void OnLetterSpacingChanged(int value) => Push();
+    partial void OnArcBendChanged(int value) => Push();
+    partial void OnWaveChanged(int value) => Push();
+
+    private void Push()
+    {
+        if (!_initialized || _parent == null)
+        {
+            return;
+        }
+
+        if (SelectedPreset != null)
+        {
+            _parent.SelectedTextEffect =
+                _parent.TextEffectItems.FirstOrDefault(t => t.Preset == SelectedPreset.Preset)
+                ?? _parent.SelectedTextEffect;
+        }
+
+        _parent.TextEffectStrength = Strength;
+        _parent.TextEffectLetterSpacing = LetterSpacing;
+        _parent.TextEffectArcBend = ArcBend;
+        _parent.TextEffectWave = Wave;
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        OkPressed = true;
+        Push();
+        Window?.Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        if (_parent != null)
+        {
+            _parent.SelectedTextEffect =
+                _parent.TextEffectItems.FirstOrDefault(t => t.Preset == _originalPreset)
+                ?? _parent.SelectedTextEffect;
+            _parent.TextEffectStrength = _originalStrength;
+            _parent.TextEffectLetterSpacing = _originalLetterSpacing;
+            _parent.TextEffectArcBend = _originalArcBend;
+            _parent.TextEffectWave = _originalWave;
+        }
+
+        Window?.Close();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Cancel();
+        }
+    }
+}

--- a/src/ui/Features/Files/ExportImageBased/TextEffectWindow.cs
+++ b/src/ui/Features/Files/ExportImageBased/TextEffectWindow.cs
@@ -19,7 +19,10 @@ public class TextEffectWindow : Window
         Title = Se.Language.File.Export.TextEffectSettingsTitle;
         CanResize = false;
         Width = 440;
-        Height = 330;
+        // Height comes from the content - a fixed height clipped the button bar below the
+        // visible area. Only the width is fixed (SizeToContent.WidthAndHeight measures too
+        // wide on macOS).
+        SizeToContent = SizeToContent.Height;
         vm.Window = this;
         DataContext = vm;
 
@@ -32,7 +35,7 @@ public class TextEffectWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
             {
@@ -59,7 +62,6 @@ public class TextEffectWindow : Window
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
         var panelButtons = UiUtil.MakeButtonBar(buttonReset, buttonOk, buttonCancel);
-        panelButtons.VerticalAlignment = VerticalAlignment.Bottom;
         grid.Add(panelButtons, 5, 0, 1, 3);
 
         Content = grid;
@@ -82,10 +84,14 @@ public class TextEffectWindow : Window
             [!Slider.ValueProperty] = new Binding(propertyName),
         };
 
-        var valueLabel = UiUtil.MakeLabel();
-        valueLabel.VerticalAlignment = VerticalAlignment.Center;
-        valueLabel.MinWidth = 45;
-        valueLabel[!TextBlock.TextProperty] = new Binding(propertyName) { StringFormat = valueFormat };
+        // A real TextBlock - UiUtil.MakeLabel returns a Label, and a TextBlock.Text binding
+        // set on a Label never renders.
+        var valueLabel = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            MinWidth = 45,
+            [!TextBlock.TextProperty] = new Binding(propertyName) { StringFormat = valueFormat },
+        };
 
         grid.Add(labelControl, row, 0);
         grid.Add(slider, row, 1);

--- a/src/ui/Features/Files/ExportImageBased/TextEffectWindow.cs
+++ b/src/ui/Features/Files/ExportImageBased/TextEffectWindow.cs
@@ -55,9 +55,10 @@ public class TextEffectWindow : Window
         AddSliderRow(grid, 3, Se.Language.File.Export.TextEffectArcBend, nameof(vm.ArcBend), -100, 100, "{0}");
         AddSliderRow(grid, 4, Se.Language.File.Export.TextEffectWave, nameof(vm.Wave), 0, 100, "{0}");
 
+        var buttonReset = UiUtil.MakeButton(Se.Language.General.Reset, vm.ResetCommand);
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
-        var panelButtons = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+        var panelButtons = UiUtil.MakeButtonBar(buttonReset, buttonOk, buttonCancel);
         panelButtons.VerticalAlignment = VerticalAlignment.Bottom;
         grid.Add(panelButtons, 5, 0, 1, 3);
 

--- a/src/ui/Features/Files/ExportImageBased/TextEffectWindow.cs
+++ b/src/ui/Features/Files/ExportImageBased/TextEffectWindow.cs
@@ -1,0 +1,93 @@
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Layout;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Files.ExportImageBased;
+
+/// <summary>
+/// The gear-button dialog for the export-to-images text effect. Not much lives here - the
+/// view model writes every change into the export dialog's view model, which regenerates
+/// the preview, so tuning is live while this window is open.
+/// </summary>
+public class TextEffectWindow : Window
+{
+    public TextEffectWindow(TextEffectViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = Se.Language.File.Export.TextEffectSettingsTitle;
+        CanResize = false;
+        Width = 440;
+        Height = 330;
+        vm.Window = this;
+        DataContext = vm;
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+            Margin = UiUtil.MakeWindowMargin(),
+            ColumnSpacing = 10,
+            RowSpacing = 10,
+        };
+
+        var labelPreset = UiUtil.MakeLabel(Se.Language.File.Export.TextEffectPreset);
+        var comboPreset = UiUtil.MakeComboBox(vm.Presets, vm, nameof(vm.SelectedPreset));
+        grid.Add(labelPreset, 0, 0);
+        grid.Add(comboPreset, 0, 1);
+
+        AddSliderRow(grid, 1, Se.Language.File.Export.TextEffectStrength, nameof(vm.Strength), 25, 300, "{0}%");
+        AddSliderRow(grid, 2, Se.Language.File.Export.TextEffectLetterSpacing, nameof(vm.LetterSpacing), 0, 100, "{0}");
+        AddSliderRow(grid, 3, Se.Language.File.Export.TextEffectArcBend, nameof(vm.ArcBend), -100, 100, "{0}");
+        AddSliderRow(grid, 4, Se.Language.File.Export.TextEffectWave, nameof(vm.Wave), 0, 100, "{0}");
+
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        var panelButtons = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+        panelButtons.VerticalAlignment = VerticalAlignment.Bottom;
+        grid.Add(panelButtons, 5, 0, 1, 3);
+
+        Content = grid;
+
+        KeyDown += (_, e) => vm.OnKeyDown(e);
+        Activated += delegate { buttonOk.Focus(); };
+    }
+
+    private static void AddSliderRow(Grid grid, int row, string label, string propertyName, double min, double max, string valueFormat)
+    {
+        var labelControl = UiUtil.MakeLabel(label);
+        labelControl.VerticalAlignment = VerticalAlignment.Center;
+
+        var slider = new Slider
+        {
+            Minimum = min,
+            Maximum = max,
+            VerticalAlignment = VerticalAlignment.Center,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            [!Slider.ValueProperty] = new Binding(propertyName),
+        };
+
+        var valueLabel = UiUtil.MakeLabel();
+        valueLabel.VerticalAlignment = VerticalAlignment.Center;
+        valueLabel.MinWidth = 45;
+        valueLabel[!TextBlock.TextProperty] = new Binding(propertyName) { StringFormat = valueFormat };
+
+        grid.Add(labelControl, row, 0);
+        grid.Add(slider, row, 1);
+        grid.Add(valueLabel, row, 2);
+    }
+}

--- a/src/ui/Logic/Config/Language/File/LanguageExport.cs
+++ b/src/ui/Logic/Config/Language/File/LanguageExport.cs
@@ -63,6 +63,13 @@ public class LanguageExport
     public string TextEffectIce { get; set; }
     public string TextEffectEmboss { get; set; }
     public string TextEffectHollow { get; set; }
+    public string TextEffectMarble { get; set; }
+    public string TextEffectWood { get; set; }
+    public string TextEffectLava { get; set; }
+    public string TextEffectBrushedSteel { get; set; }
+    public string TextEffectCandyCane { get; set; }
+    public string TextEffectRainbow { get; set; }
+    public string TextEffectPolkaDots { get; set; }
 
     public LanguageExport()
     {
@@ -127,5 +134,12 @@ public class LanguageExport
         TextEffectIce = "Ice";
         TextEffectEmboss = "Emboss";
         TextEffectHollow = "Hollow (outline only)";
+        TextEffectMarble = "Marble";
+        TextEffectWood = "Wood";
+        TextEffectLava = "Lava";
+        TextEffectBrushedSteel = "Brushed steel";
+        TextEffectCandyCane = "Candy cane";
+        TextEffectRainbow = "Rainbow";
+        TextEffectPolkaDots = "Polka dots";
     }
 }

--- a/src/ui/Logic/Config/Language/File/LanguageExport.cs
+++ b/src/ui/Logic/Config/Language/File/LanguageExport.cs
@@ -43,6 +43,14 @@ public class LanguageExport
     public string ImageBasedSubtitleSaved { get; set; }
     public string FullFrameImage { get; set; }
     public string FullFrameImageHint { get; set; }
+    public string TextEffect { get; set; }
+    public string TextEffectSoftShadow { get; set; }
+    public string TextEffectGradientGold { get; set; }
+    public string TextEffectDoubleOutline { get; set; }
+    public string TextEffectNeonGlow { get; set; }
+    public string TextEffectExtrude3D { get; set; }
+    public string TextEffectChrome { get; set; }
+    public string TextEffectFire { get; set; }
 
     public LanguageExport()
     {
@@ -87,5 +95,13 @@ public class LanguageExport
         ImageBasedSubtitleSaved = "Image-based subtitle saved";
         FullFrameImage = "Full frame image";
         FullFrameImageHint = "Make each image the size of the video frame, with the subtitle in its place";
+        TextEffect = "Text effect";
+        TextEffectSoftShadow = "Soft shadow";
+        TextEffectGradientGold = "Gradient (gold)";
+        TextEffectDoubleOutline = "Double outline";
+        TextEffectNeonGlow = "Neon glow";
+        TextEffectExtrude3D = "3D extrude";
+        TextEffectChrome = "Chrome";
+        TextEffectFire = "Fire";
     }
 }

--- a/src/ui/Logic/Config/Language/File/LanguageExport.cs
+++ b/src/ui/Logic/Config/Language/File/LanguageExport.cs
@@ -44,6 +44,12 @@ public class LanguageExport
     public string FullFrameImage { get; set; }
     public string FullFrameImageHint { get; set; }
     public string TextEffect { get; set; }
+    public string TextEffectSettingsTitle { get; set; }
+    public string TextEffectPreset { get; set; }
+    public string TextEffectStrength { get; set; }
+    public string TextEffectLetterSpacing { get; set; }
+    public string TextEffectArcBend { get; set; }
+    public string TextEffectWave { get; set; }
     public string TextEffectSoftShadow { get; set; }
     public string TextEffectGradientGold { get; set; }
     public string TextEffectDoubleOutline { get; set; }
@@ -51,6 +57,12 @@ public class LanguageExport
     public string TextEffectExtrude3D { get; set; }
     public string TextEffectChrome { get; set; }
     public string TextEffectFire { get; set; }
+    public string TextEffectComic { get; set; }
+    public string TextEffectRetro80s { get; set; }
+    public string TextEffectAnaglyph3D { get; set; }
+    public string TextEffectIce { get; set; }
+    public string TextEffectEmboss { get; set; }
+    public string TextEffectHollow { get; set; }
 
     public LanguageExport()
     {
@@ -96,6 +108,12 @@ public class LanguageExport
         FullFrameImage = "Full frame image";
         FullFrameImageHint = "Make each image the size of the video frame, with the subtitle in its place";
         TextEffect = "Text effect";
+        TextEffectSettingsTitle = "Text effect settings";
+        TextEffectPreset = "Preset";
+        TextEffectStrength = "Strength";
+        TextEffectLetterSpacing = "Letter spacing";
+        TextEffectArcBend = "Curve";
+        TextEffectWave = "Wave";
         TextEffectSoftShadow = "Soft shadow";
         TextEffectGradientGold = "Gradient (gold)";
         TextEffectDoubleOutline = "Double outline";
@@ -103,5 +121,11 @@ public class LanguageExport
         TextEffectExtrude3D = "3D extrude";
         TextEffectChrome = "Chrome";
         TextEffectFire = "Fire";
+        TextEffectComic = "Comic book";
+        TextEffectRetro80s = "Retro 80s";
+        TextEffectAnaglyph3D = "3D glasses";
+        TextEffectIce = "Ice";
+        TextEffectEmboss = "Emboss";
+        TextEffectHollow = "Hollow (outline only)";
     }
 }

--- a/src/ui/Logic/Config/SeExportImagesProfile.cs
+++ b/src/ui/Logic/Config/SeExportImagesProfile.cs
@@ -39,6 +39,10 @@ public class SeExportImagesProfile
     public int PaddingTopBottom { get; set; }
     public int LineSpacingPercent { get; set; }
     public FontBoxType BoxType { get; set; }
+
+    /// <summary>Name of the <see cref="TextEffectPreset"/>; empty = classic rendering.</summary>
+    public string TextEffect { get; set; } = string.Empty;
+
     public int BoxPaddingLeft { get; set; }
     public int BoxPaddingRight { get; set; }
     public int BoxPaddingTop { get; set; }

--- a/src/ui/Logic/Config/SeExportImagesProfile.cs
+++ b/src/ui/Logic/Config/SeExportImagesProfile.cs
@@ -43,6 +43,12 @@ public class SeExportImagesProfile
     /// <summary>Name of the <see cref="TextEffectPreset"/>; empty = classic rendering.</summary>
     public string TextEffect { get; set; } = string.Empty;
 
+    public bool TextEffectEnabled { get; set; }
+    public int TextEffectStrength { get; set; } = 100;
+    public int TextEffectLetterSpacing { get; set; }
+    public int TextEffectArcBend { get; set; }
+    public int TextEffectWave { get; set; }
+
     public int BoxPaddingLeft { get; set; }
     public int BoxPaddingRight { get; set; }
     public int BoxPaddingTop { get; set; }

--- a/tests/UI/Features/Files/ImageRendererTextEffectsTests.cs
+++ b/tests/UI/Features/Files/ImageRendererTextEffectsTests.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Linq;
+using Nikse.SubtitleEdit.UiLogic.Export;
+using SkiaSharp;
+using Xunit;
+
+namespace UITests.Features.Files;
+
+/// <summary>
+/// The advanced text effects path in ImageRenderer: when ImageParameter.TextEffects is set,
+/// rendering goes through the layered pipeline (gradient fills, multiple outlines, blurred
+/// shadows, glow, extrude, bevel) instead of the classic fill/outline/shadow path.
+/// </summary>
+public class ImageRendererTextEffectsTests
+{
+    private static ImageParameter MakeParameter(TextEffectPreset preset)
+    {
+        return new ImageParameter
+        {
+            Text = "Hello <i>world</i>",
+            FontName = "Arial",
+            FontSize = 40,
+            FontColor = SKColors.White,
+            OutlineColor = SKColors.Black,
+            OutlineWidth = 2,
+            ShadowColor = SKColors.Black,
+            ShadowWidth = 2,
+            ScreenWidth = 1280,
+            ScreenHeight = 720,
+            LineSpacingPercent = 0,
+            ContentAlignment = ExportContentAlignment.Center,
+            TextEffects = TextEffectPresetFactory.Create(preset, 40, SKColors.White, SKColors.Black, SKColors.Black),
+        };
+    }
+
+    private static bool HasVisiblePixels(SKBitmap bitmap)
+    {
+        for (var y = 0; y < bitmap.Height; y++)
+        {
+            for (var x = 0; x < bitmap.Width; x++)
+            {
+                if (bitmap.GetPixel(x, y).Alpha > 0)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    [Fact]
+    public void NonePreset_YieldsNullEffects_SoClassicPathIsUsed()
+    {
+        var effects = TextEffectPresetFactory.Create(TextEffectPreset.None, 40, SKColors.White, SKColors.Black, SKColors.Black);
+        Assert.Null(effects);
+    }
+
+    [Theory]
+    [InlineData(TextEffectPreset.SoftShadow)]
+    [InlineData(TextEffectPreset.GradientGold)]
+    [InlineData(TextEffectPreset.DoubleOutline)]
+    [InlineData(TextEffectPreset.NeonGlow)]
+    [InlineData(TextEffectPreset.Extrude3D)]
+    [InlineData(TextEffectPreset.Chrome)]
+    [InlineData(TextEffectPreset.Fire)]
+    public void GenerateBitmap_WithPreset_DrawsVisiblePixels(TextEffectPreset preset)
+    {
+        var ip = MakeParameter(preset);
+
+        using var bitmap = ImageRenderer.GenerateBitmap(ip);
+
+        Assert.True(bitmap.Width > 2, $"bitmap width was {bitmap.Width}");
+        Assert.True(bitmap.Height > 2, $"bitmap height was {bitmap.Height}");
+        Assert.True(HasVisiblePixels(bitmap), "expected at least one non-transparent pixel");
+    }
+
+    [Fact]
+    public void GenerateBitmap_WithPreset_DiffersFromClassicRendering()
+    {
+        var classic = MakeParameter(TextEffectPreset.None);
+        var styled = MakeParameter(TextEffectPreset.GradientGold);
+
+        using var classicBitmap = ImageRenderer.GenerateBitmap(classic);
+        using var styledBitmap = ImageRenderer.GenerateBitmap(styled);
+
+        using var classicImage = SKImage.FromBitmap(classicBitmap);
+        using var styledImage = SKImage.FromBitmap(styledBitmap);
+        using var classicPng = classicImage.Encode(SKEncodedImageFormat.Png, 100);
+        using var styledPng = styledImage.Encode(SKEncodedImageFormat.Png, 100);
+
+        Assert.False(classicPng.ToArray().SequenceEqual(styledPng.ToArray()));
+    }
+
+    [Fact]
+    public void GenerateBitmap_EmptyText_StillReturnsTinyTransparentBitmap()
+    {
+        var ip = MakeParameter(TextEffectPreset.NeonGlow);
+        ip.Text = "   ";
+
+        using var bitmap = ImageRenderer.GenerateBitmap(ip);
+
+        Assert.True(bitmap.Width <= 2 && bitmap.Height <= 2, "whitespace-only text should not produce a full-size bitmap");
+    }
+
+    [Fact]
+    public void SafetyMargin_CoversBlurredShadowAndGlow()
+    {
+        var effects = new TextEffects
+        {
+            Shadows = { new TextEffectShadow { Dx = 4, Dy = 6, Blur = 10 } },
+            Glow = new TextEffectGlow { Radius = 20 },
+        };
+
+        var margin = effects.GetSafetyMargin();
+
+        Assert.True(margin >= 20 * 3, $"margin {margin} does not cover the glow radius");
+    }
+}

--- a/tests/UI/Features/Files/ImageRendererTextEffectsTests.cs
+++ b/tests/UI/Features/Files/ImageRendererTextEffectsTests.cs
@@ -70,6 +70,13 @@ public class ImageRendererTextEffectsTests
     [InlineData(TextEffectPreset.Ice)]
     [InlineData(TextEffectPreset.Emboss)]
     [InlineData(TextEffectPreset.Hollow)]
+    [InlineData(TextEffectPreset.Marble)]
+    [InlineData(TextEffectPreset.Wood)]
+    [InlineData(TextEffectPreset.Lava)]
+    [InlineData(TextEffectPreset.BrushedSteel)]
+    [InlineData(TextEffectPreset.CandyCane)]
+    [InlineData(TextEffectPreset.Rainbow)]
+    [InlineData(TextEffectPreset.PolkaDots)]
     public void GenerateBitmap_WithPreset_DrawsVisiblePixels(TextEffectPreset preset)
     {
         var ip = MakeParameter(preset);

--- a/tests/UI/Features/Files/ImageRendererTextEffectsTests.cs
+++ b/tests/UI/Features/Files/ImageRendererTextEffectsTests.cs
@@ -64,6 +64,12 @@ public class ImageRendererTextEffectsTests
     [InlineData(TextEffectPreset.Extrude3D)]
     [InlineData(TextEffectPreset.Chrome)]
     [InlineData(TextEffectPreset.Fire)]
+    [InlineData(TextEffectPreset.Comic)]
+    [InlineData(TextEffectPreset.Retro80s)]
+    [InlineData(TextEffectPreset.Anaglyph3D)]
+    [InlineData(TextEffectPreset.Ice)]
+    [InlineData(TextEffectPreset.Emboss)]
+    [InlineData(TextEffectPreset.Hollow)]
     public void GenerateBitmap_WithPreset_DrawsVisiblePixels(TextEffectPreset preset)
     {
         var ip = MakeParameter(preset);
@@ -101,6 +107,54 @@ public class ImageRendererTextEffectsTests
         using var bitmap = ImageRenderer.GenerateBitmap(ip);
 
         Assert.True(bitmap.Width <= 2 && bitmap.Height <= 2, "whitespace-only text should not produce a full-size bitmap");
+    }
+
+    [Fact]
+    public void LetterSpacing_WidensTheRenderedText()
+    {
+        var plain = MakeParameter(TextEffectPreset.SoftShadow);
+        var spaced = MakeParameter(TextEffectPreset.SoftShadow);
+        spaced.TextEffects = TextEffectPresetFactory.Create(TextEffectPreset.SoftShadow, 40,
+            SKColors.White, SKColors.Black, SKColors.Black,
+            new TextEffectAdjustments { LetterSpacing = 20 });
+
+        using var plainBitmap = ImageRenderer.GenerateBitmap(plain);
+        using var spacedBitmap = ImageRenderer.GenerateBitmap(spaced);
+
+        Assert.True(spacedBitmap.Width > plainBitmap.Width + 50,
+            $"spaced width {spacedBitmap.Width} should clearly exceed plain width {plainBitmap.Width}");
+    }
+
+    [Fact]
+    public void ArcBend_MakesTheRenderedTextTaller()
+    {
+        var straight = MakeParameter(TextEffectPreset.SoftShadow);
+        straight.Text = "A longer single line of subtitle text";
+        var curved = MakeParameter(TextEffectPreset.SoftShadow);
+        curved.Text = straight.Text;
+        curved.TextEffects = TextEffectPresetFactory.Create(TextEffectPreset.SoftShadow, 40,
+            SKColors.White, SKColors.Black, SKColors.Black,
+            new TextEffectAdjustments { ArcBendPercent = 60 });
+
+        using var straightBitmap = ImageRenderer.GenerateBitmap(straight);
+        using var curvedBitmap = ImageRenderer.GenerateBitmap(curved);
+
+        Assert.True(curvedBitmap.Height > straightBitmap.Height + 20,
+            $"curved height {curvedBitmap.Height} should clearly exceed straight height {straightBitmap.Height}");
+    }
+
+    [Fact]
+    public void Strength_ScalesEffectSizes()
+    {
+        var normal = TextEffectPresetFactory.Create(TextEffectPreset.DoubleOutline, 40,
+            SKColors.White, SKColors.Black, SKColors.Black,
+            new TextEffectAdjustments { StrengthPercent = 100 })!;
+        var strong = TextEffectPresetFactory.Create(TextEffectPreset.DoubleOutline, 40,
+            SKColors.White, SKColors.Black, SKColors.Black,
+            new TextEffectAdjustments { StrengthPercent = 200 })!;
+
+        Assert.Equal(normal.Strokes[0].Width * 2, strong.Strokes[0].Width, 3);
+        Assert.Equal(normal.Shadows[0].Blur * 2, strong.Shadows[0].Blur, 3);
     }
 
     [Fact]


### PR DESCRIPTION
Adds an advanced text-formatting pipeline to image-based export (Blu-ray sup, VobSub, BDN XML, DCinema, FCP, etc.). In the export dialog a **"Text effect" checkbox** (next to Bold/RTL) enables it, and a **gear button** opens a settings window whose changes write straight into the dialog's view model — the preview underneath updates live while tuning; Cancel restores the previous values.

## Settings window

- **Preset**: Soft shadow · Gradient (gold) · Double outline · Neon glow · 3D extrude · Chrome · Fire · Comic book · Retro 80s · 3D glasses (anaglyph) · Ice · Emboss · Hollow (outline only)
- **Strength** (25–300%): scales every effect size (stroke widths, blur radii, glow, extrude)
- **Letter spacing**, **Curve** (arc bend, −100..100, both directions), **Wave** (baseline sine) — geometry that combines with any preset

Everything persists per export profile.

## How it works

When `ImageParameter.TextEffects` is set, `ImageRenderer` shapes the text as before (HarfBuzz, same layout/alignment/RTL logic) but paints through layered effects: the shaped glyphs become one combined `SKPath`, and every effect is a path operation — gradient/turbulence fills as shaders bounded to the text, multiple outline rings via the doubled-stroke-width trick (issue #12206), blurred drop shadows, glow, extrude, inner bevel, edge blur. Fills draw via `DrawShapedText` so glyph rasterization (and color emoji) match the classic path — except in geometry mode (spacing/curve/wave), where each glyph is its own positioned path. The arc radius derives from the widest line, so the same bend value reads the same at any resolution. `TextEffects == null` takes the exact old code path — default behavior is unchanged.

Preset sizes scale with the font size; presets use the dialog's font/outline/shadow colors where natural (e.g. neon glow color = outline color).

## Notes / follow-ups

- With a preset active, the preset's fill overrides `<font color>` tags (classic mode still honors them).
- VobSub/DVD sup quantize to 4 colors, so gradients/glows are best on full-color and PGS targets; per-format gating could be a follow-up.
- Karaoke progressive fill is an easy follow-up on this pipeline if wanted.

## Testing

- `ImageRendererTextEffectsTests` (20 tests): every preset renders visible pixels, letter spacing widens the bitmap, arc bend makes it taller, strength scales effect sizes, whitespace-only text still yields the tiny transparent bitmap, safety margin covers blur/glow.
- Existing export tests pass; UI builds with no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)