### PR TITLE
OCR: keep the French/Breton space before "?" and "!"

### DIFF
--- a/src/libuilogic/Ocr/OcrHelper.cs
+++ b/src/libuilogic/Ocr/OcrHelper.cs
@@ -10,6 +10,68 @@ namespace Nikse.SubtitleEdit.UiLogic.Ocr
             return FixInvalidCarriageReturnLineFeedCharacters(input);
         }
 
+        /// <summary>
+        /// Collapses the stray spaces the AI OCR engines leave around punctuation.
+        /// The space before "!" and "?" is kept for the languages that require it - see
+        /// <see cref="UsesSpaceBeforeQuestionAndExclamationMark"/>.
+        /// </summary>
+        /// <param name="input">Raw text as returned by the OCR engine.</param>
+        /// <param name="language">OCR language, either an English name ("French") or a two letter code ("fr").</param>
+        public static string FixAiOcrPunctuationSpaces(string? input, string? language)
+        {
+            if (string.IsNullOrEmpty(input))
+            {
+                return string.Empty;
+            }
+
+            var text = input;
+            text = text.Replace(" ,", ",");
+            text = text.Replace(" .", ".");
+
+            if (!UsesSpaceBeforeQuestionAndExclamationMark(language))
+            {
+                text = text.Replace(" !", "!");
+                text = text.Replace(" ?", "?");
+            }
+
+            text = text.Replace("( ", "(");
+            text = text.Replace(" )", ")");
+            text = text.Replace("\\\"", "\"");
+
+            if (text.EndsWith("!'", StringComparison.Ordinal))
+            {
+                text = text.TrimEnd('\'');
+            }
+
+            return text;
+        }
+
+        /// <summary>
+        /// French and Breton typography puts a real space before "?" and "!", so removing it
+        /// damages correct OCR output. Same rule as Utilities.FixOcrErrors in libse.
+        /// </summary>
+        /// <param name="language">OCR language, either an English name ("French") or a two letter code ("fr").</param>
+        public static bool UsesSpaceBeforeQuestionAndExclamationMark(string? language)
+        {
+            if (string.IsNullOrWhiteSpace(language))
+            {
+                return false;
+            }
+
+            var code = language.Trim();
+            if (code.Length > 3)
+            {
+                code = Iso639Dash2LanguageCode.GetTwoLetterCodeFromEnglishName(code);
+            }
+            else if (code.Length == 3)
+            {
+                code = Iso639Dash2LanguageCode.GetTwoLetterCodeFromThreeLetterCode(code);
+            }
+
+            return code.Equals("fr", StringComparison.OrdinalIgnoreCase) ||
+                   code.Equals("br", StringComparison.OrdinalIgnoreCase);
+        }
+
         private static string FixInvalidCarriageReturnLineFeedCharacters(string input)
         {
             return string.Join(Environment.NewLine, input.SplitToLines()).Trim();

--- a/src/libuilogic/Ocr/Service/GoogleCloudVisionApi.cs
+++ b/src/libuilogic/Ocr/Service/GoogleCloudVisionApi.cs
@@ -299,7 +299,7 @@ namespace Nikse.SubtitleEdit.UiLogic.Ocr.Service
                             last = l;
                         }
 
-                        if (language == "fr")
+                        if (OcrHelper.UsesSpaceBeforeQuestionAndExclamationMark(language))
                         {
                             sb.AppendLine(sbLine.ToString().Trim());
                         }

--- a/src/ui/Features/Ocr/Engines/GoogleVisionOcr.cs
+++ b/src/ui/Features/Ocr/Engines/GoogleVisionOcr.cs
@@ -276,7 +276,7 @@ public class GoogleVisionOcr
                         last = l;
                     }
 
-                    if (language == "fr")
+                    if (OcrHelper.UsesSpaceBeforeQuestionAndExclamationMark(language))
                     {
                         sb.AppendLine(sbLine.ToString().Trim());
                     }

--- a/src/ui/Features/Ocr/Engines/LlamaCppOcr.cs
+++ b/src/ui/Features/Ocr/Engines/LlamaCppOcr.cs
@@ -1,5 +1,6 @@
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.UiLogic.Ocr;
 using SkiaSharp;
 using System;
 using System.Net.Http;
@@ -72,17 +73,7 @@ public class LlamaCppOcr : IDisposable
             // sanitize
             resultText = resultText.Trim();
             resultText = resultText.Replace("\\n", Environment.NewLine);
-            resultText = resultText.Replace(" ,", ",");
-            resultText = resultText.Replace(" .", ".");
-            resultText = resultText.Replace(" !", "!");
-            resultText = resultText.Replace(" ?", "?");
-            resultText = resultText.Replace("( ", "(");
-            resultText = resultText.Replace(" )", ")");
-            resultText = resultText.Replace("\\\"", "\"");
-            if (resultText.EndsWith("!'"))
-            {
-                resultText = resultText.TrimEnd('\'');
-            }
+            resultText = OcrHelper.FixAiOcrPunctuationSpaces(resultText, language);
 
             return resultText.Trim();
         }

--- a/src/ui/Features/Ocr/Engines/MistralOcr.cs
+++ b/src/ui/Features/Ocr/Engines/MistralOcr.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.UiLogic.Http;
+using Nikse.SubtitleEdit.UiLogic.Ocr;
 using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -92,18 +93,7 @@ public class MistralOcr
 
             // Sanitize the result (keeping your existing logic)
             finalText = finalText.Replace("\\n", Environment.NewLine);
-            finalText = finalText.Replace(" ,", ",");
-            finalText = finalText.Replace(" .", ".");
-            finalText = finalText.Replace(" !", "!");
-            finalText = finalText.Replace(" ?", "?");
-            finalText = finalText.Replace("( ", "(");
-            finalText = finalText.Replace(" )", ")");
-            finalText = finalText.Replace("\\\"", "\"");
-
-            if (finalText.EndsWith("!'"))
-            {
-                finalText = finalText.TrimEnd('\'');
-            }
+            finalText = OcrHelper.FixAiOcrPunctuationSpaces(finalText, language);
 
             return finalText.Trim();
         }

--- a/src/ui/Features/Ocr/Engines/OllamaOcr.cs
+++ b/src/ui/Features/Ocr/Engines/OllamaOcr.cs
@@ -2,6 +2,7 @@ using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.UiLogic.Http;
+using Nikse.SubtitleEdit.UiLogic.Ocr;
 using SkiaSharp;
 using System;
 using System.Collections.Generic;
@@ -93,17 +94,7 @@ public class OllamaOcr : IDisposable
             // Strip any trailing garbage the model still appends after the real text (repeated
             // lines, ``` fences, an echo of the prompt) — the transcription is always first.
             resultText = CleanOcrText(resultText, prompt);
-            resultText = resultText.Replace(" ,", ",");
-            resultText = resultText.Replace(" .", ".");
-            resultText = resultText.Replace(" !", "!");
-            resultText = resultText.Replace(" ?", "?");
-            resultText = resultText.Replace("( ", "(");
-            resultText = resultText.Replace(" )", ")");
-            resultText = resultText.Replace("\\\"", "\"");
-            if (resultText.EndsWith("!'"))
-            {
-                resultText = resultText.TrimEnd('\'');
-            }
+            resultText = OcrHelper.FixAiOcrPunctuationSpaces(resultText, language);
 
             return resultText.Trim();
         }

--- a/tests/libuilogic/Ocr/OcrHelperPunctuationTests.cs
+++ b/tests/libuilogic/Ocr/OcrHelperPunctuationTests.cs
@@ -1,0 +1,86 @@
+using Nikse.SubtitleEdit.UiLogic.Ocr;
+
+namespace LibUiLogicTests.Ocr;
+
+/// <summary>
+/// The AI OCR engines (llama.cpp, Ollama, Mistral) collapse the stray spaces their models
+/// leave around punctuation. French and Breton typography require a real space before "?"
+/// and "!", so an ungated " ?" -> "?" replacement silently damaged correct OCR output
+/// ("n'est-ce pas ?" came back as "n'est-ce pas?"). Same guard as libse's
+/// Utilities.FixOcrErrors.
+/// </summary>
+public class OcrHelperPunctuationTests
+{
+    [Theory]
+    [InlineData("French")]
+    [InlineData("french")]
+    [InlineData("fr")]
+    [InlineData("fra")]
+    [InlineData("Breton")]
+    [InlineData("br")]
+    public void KeepsSpaceBeforeQuestionMarkForFrenchAndBreton(string language)
+    {
+        Assert.Equal("n'est-ce pas ?", OcrHelper.FixAiOcrPunctuationSpaces("n'est-ce pas ?", language));
+    }
+
+    [Theory]
+    [InlineData("French")]
+    [InlineData("fr")]
+    [InlineData("Breton")]
+    [InlineData("br")]
+    public void KeepsSpaceBeforeExclamationMarkForFrenchAndBreton(string language)
+    {
+        Assert.Equal("Bonjour !", OcrHelper.FixAiOcrPunctuationSpaces("Bonjour !", language));
+    }
+
+    [Theory]
+    [InlineData("English")]
+    [InlineData("en")]
+    [InlineData("German")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void RemovesSpaceBeforeQuestionAndExclamationMarkForOtherLanguages(string? language)
+    {
+        Assert.Equal("Really? Yes!", OcrHelper.FixAiOcrPunctuationSpaces("Really ? Yes !", language));
+    }
+
+    [Fact]
+    public void StillRemovesSpaceBeforeCommaAndPeriodForFrench()
+    {
+        // French puts no space before "," or "." - only before "?", "!", ":" and ";".
+        Assert.Equal("Oui, bien sûr.", OcrHelper.FixAiOcrPunctuationSpaces("Oui , bien sûr .", "French"));
+    }
+
+    [Fact]
+    public void FixesParenthesesAndEscapedQuotesForFrench()
+    {
+        Assert.Equal("(un \"mot\") ?", OcrHelper.FixAiOcrPunctuationSpaces("( un \\\"mot\\\" ) ?", "French"));
+    }
+
+    [Fact]
+    public void TrimsTrailingApostropheAfterExclamationMark()
+    {
+        Assert.Equal("Stop!", OcrHelper.FixAiOcrPunctuationSpaces("Stop!'", "English"));
+    }
+
+    [Fact]
+    public void HandlesNullAndEmptyInput()
+    {
+        Assert.Equal(string.Empty, OcrHelper.FixAiOcrPunctuationSpaces(null, "French"));
+        Assert.Equal(string.Empty, OcrHelper.FixAiOcrPunctuationSpaces(string.Empty, "French"));
+    }
+
+    [Theory]
+    [InlineData("French", true)]
+    [InlineData("fr", true)]
+    [InlineData("Breton", true)]
+    [InlineData("br", true)]
+    [InlineData("English", false)]
+    [InlineData("en", false)]
+    [InlineData("Frisian", false)]
+    [InlineData(null, false)]
+    public void UsesSpaceBeforeQuestionAndExclamationMarkMapsLanguages(string? language, bool expected)
+    {
+        Assert.Equal(expected, OcrHelper.UsesSpaceBeforeQuestionAndExclamationMark(language));
+    }
+}


### PR DESCRIPTION
## Problem

SE's AI OCR engines post-process the model output with an **ungated** `Replace(" ?", "?")` / `Replace(" !", "!")`.

French and Breton typography require a real space before `?` and `!`, so correct OCR output was silently damaged. Verified 2026-08-25: all five curated llama.cpp OCR models return `n'est-ce pas ?` verbatim for a French subtitle image — SE turned it into `n'est-ce pas?`.

libse already gets this right: [`Utilities.cs:2785`](https://github.com/SubtitleEdit/subtitleedit/blob/main/src/libse/Common/Utilities.cs#L2785) wraps the same two replacements in `if (language != "fr")`.

## Fix

The identical sanitize block had been copy-pasted into three engines, which is how the guard went missing in the first place. Moved it to `OcrHelper.FixAiOcrPunctuationSpaces(input, language)` and called that from `LlamaCppOcr`, `OllamaOcr` and `MistralOcr`.

The two Google Vision paths (`GoogleVisionOcr`, `GoogleCloudVisionApi`) already had a hardcoded `language == "fr"` check, so they were not actually broken — they now use the shared `OcrHelper.UsesSpaceBeforeQuestionAndExclamationMark(language)` predicate instead, which also covers Breton.

The predicate accepts both spellings the callers use: an English language name (`"French"` — what the LLM engines get, from `Iso639Dash2LanguageCode.EnglishName`) and a two-letter code (`"fr"` — what Google Vision gets). Three-letter codes resolve too.

`" ,"` and `" ."` stay ungated in the shared helper: French puts no space before a comma or a period, and that matches libse.

## Notes

- Breton is unreachable in the Google Vision paths today (Google Vision's language list has no `br`); the predicate covers it if that ever changes.
- The Google Vision French branch still skips the `" ,"` / `" ."` cleanup as well, unchanged from before. Aligning that with the other engines would be a behaviour change on a currently-working path, so it is left out of this PR.

## Tests

New `tests/libuilogic/Ocr/OcrHelperPunctuationTests.cs` — 27 cases covering the French/Breton keep, the strip for every other language, comma/period handling for French, and the language-name/code mapping.

```
LibUiLogicTests:  634 passed, 0 failed
LibSETests:      1486 passed, 0 failed
```

Full solution builds clean (0 errors, no new warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)