### PR TITLE
Batch convert: add the "Ollama advanced" translate engine

### DIFF
--- a/docs/features/batch-convert.md
+++ b/docs/features/batch-convert.md
@@ -53,6 +53,7 @@ You can chain multiple conversion functions:
 Batch Convert can machine-translate files as part of the conversion. Supported engines:
 
 - Ollama
+- Ollama advanced (local LLM) — the batch/context engine described in [Advanced local engines](auto-translate-advanced.md), talking to Ollama's OpenAI-compatible endpoint
 - LibreTranslate
 - LM Studio
 - llama.cpp — fully managed: Batch Convert reuses an already-running local `llama-server`, or downloads llama.cpp plus a curated translation model (e.g. TranslateGemma) and starts the server for you. Point it at your own server via the remote-server option in [Auto-translate](auto-translate.md) settings.

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -433,6 +433,7 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         AutoTranslators =
         [
             new OllamaTranslate(),
+            new OllamaAdvancedTranslate(),
             new LibreTranslate(),
             new LmStudioTranslate(),
             new LlamaCppTranslate(),
@@ -2370,13 +2371,27 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
     [RelayCommand]
     private async Task AutoTranslateBrowseModel()
     {
+        // Both Ollama engines list the same installed models; the picker only needs the host,
+        // so the advanced engine's /v1/chat/completions URL works as-is (it strips the path).
+        var isAdvanced = SelectedAutoTranslator is OllamaAdvancedTranslate;
+        var model = isAdvanced ? Se.Settings.AutoTranslate.OllamaAdvancedModel : Se.Settings.AutoTranslate.OllamaModel;
+        var url = isAdvanced ? Se.Settings.AutoTranslate.OllamaAdvancedUrl : Se.Settings.AutoTranslate.OllamaUrl;
+
         var result = await _windowService.ShowDialogAsync<PickOllamaModelWindow, PickOllamaModelViewModel>(Window!,
-            vm => { vm.Initialize(Se.Language.General.PickOllamaModel, Se.Settings.AutoTranslate.OllamaModel, Se.Settings.AutoTranslate.OllamaUrl); });
+            vm => { vm.Initialize(Se.Language.General.PickOllamaModel, model, url); });
 
         if (result is { OkPressed: true, SelectedModel: not null })
         {
             AutoTranslateModel = result.SelectedModel;
-            Se.Settings.AutoTranslate.OllamaModel = result.SelectedModel;
+            if (isAdvanced)
+            {
+                Se.Settings.AutoTranslate.OllamaAdvancedModel = result.SelectedModel;
+            }
+            else
+            {
+                Se.Settings.AutoTranslate.OllamaModel = result.SelectedModel;
+            }
+
             SaveSettings();
         }
     }
@@ -2929,6 +2944,21 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
             }
         }
 
+        if (engineType == typeof(OllamaAdvancedTranslate))
+        {
+            // Both live in SE's own settings only - the advanced engine does not go through
+            // Configuration.Settings.Tools (that URL belongs to the classic Ollama engine).
+            if (!string.IsNullOrWhiteSpace(AutoTranslateUrl))
+            {
+                Se.Settings.AutoTranslate.OllamaAdvancedUrl = AutoTranslateUrl.Trim();
+            }
+
+            if (!string.IsNullOrWhiteSpace(AutoTranslateModel))
+            {
+                Se.Settings.AutoTranslate.OllamaAdvancedModel = AutoTranslateModel.Trim();
+            }
+        }
+
         if (engineType == typeof(NoLanguageLeftBehindServe))
         {
             if (!string.IsNullOrEmpty(Se.Settings.AutoTranslate.NllbServeUrl))
@@ -3159,7 +3189,7 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
     {
         var engine = SelectedAutoTranslator;
 
-        AutoTranslateModelIsVisible = engine is OllamaTranslate;
+        AutoTranslateModelIsVisible = engine is OllamaTranslate or OllamaAdvancedTranslate;
         CrispAsrModelComboIsVisible = engine is CrispAsrMadladTranslate;
         // Both turned back on by PopulateLlamaCppModels for a local llama.cpp.
         LlamaCppModelComboIsVisible = false;
@@ -3170,8 +3200,9 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         LlamaCppRemoteToggleIsVisible = engine is LlamaCppTranslate or LlamaCppAdvancedTranslate;
 
         // Batch size, context history and the synopsis/glossary/style prompt only exist on the
-        // advanced engine; they apply to local and remote llama-servers alike.
-        LlamaCppAdvancedButtonIsVisible = engine is LlamaCppAdvancedTranslate;
+        // advanced engines; they are shared settings, so the same window serves both llama.cpp
+        // (local or remote llama-server) and Ollama.
+        LlamaCppAdvancedButtonIsVisible = engine is LlamaCppAdvancedTranslate or OllamaAdvancedTranslate;
 
         // The regular llama.cpp engine has no advanced window - its prompt (and the shared
         // delay/max-bytes/merge settings) live in the translate settings dialog instead.
@@ -3197,6 +3228,18 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
             AutoTranslateModelIsVisible = true;
             AutoTranslateUrl = string.Empty;
             AutoTranslateUrlIsVisible = false;
+            AutoTranslateApiKey = string.Empty;
+            AutoTranslateApiKeyIsVisible = false;
+        }
+        else if (engine is OllamaAdvancedTranslate)
+        {
+            // Same installed-model list as the classic Ollama engine - only the endpoint differs
+            // (the OpenAI-compatible /v1/chat/completions, not the native /api/generate).
+            AutoTranslateModel = Se.Settings.AutoTranslate.OllamaAdvancedModel;
+            AutoTranslateModelBrowseIsVisible = true;
+            AutoTranslateModelIsVisible = true;
+            AutoTranslateUrl = Se.Settings.AutoTranslate.OllamaAdvancedUrl;
+            AutoTranslateUrlIsVisible = true;
             AutoTranslateApiKey = string.Empty;
             AutoTranslateApiKeyIsVisible = false;
         }

--- a/tests/UI/Features/Tools/BatchConvert/BatchConvertAutoTranslateEngineTests.cs
+++ b/tests/UI/Features/Tools/BatchConvert/BatchConvertAutoTranslateEngineTests.cs
@@ -27,7 +27,15 @@ public class BatchConvertAutoTranslateEngineTests
     }
 
     [AvaloniaFact]
-    public void AdvancedButton_IsShownForLlamaCppAdvancedOnly()
+    public void EngineList_ContainsOllamaAdvanced()
+    {
+        var viewModel = MakeViewModel();
+
+        Assert.Contains(viewModel.AutoTranslators, t => t is OllamaAdvancedTranslate);
+    }
+
+    [AvaloniaFact]
+    public void AdvancedButton_IsShownForAdvancedEnginesOnly()
     {
         var viewModel = MakeViewModel();
         var view = ViewAutoTranslate.Make(viewModel);
@@ -41,8 +49,33 @@ public class BatchConvertAutoTranslateEngineTests
             viewModel.SelectedAutoTranslator = engine;
             viewModel.OnAutoTranslatorChanged();
 
-            Assert.Equal(engine is LlamaCppAdvancedTranslate, viewModel.LlamaCppAdvancedButtonIsVisible);
+            // Batch size, history, synopsis/glossary/style - shared settings, so every engine
+            // running the advanced batch protocol opens the same window.
+            Assert.Equal(engine is AdvancedTranslatorBase, viewModel.LlamaCppAdvancedButtonIsVisible);
         }
+    }
+
+    /// <summary>
+    /// The advanced Ollama engine talks to the OpenAI-compatible endpoint, which is a different URL
+    /// and a separately stored model from the classic Ollama engine - so both fields must be shown
+    /// and filled from its own settings, not the classic engine's.
+    /// </summary>
+    [AvaloniaFact]
+    public void OllamaAdvanced_ShowsItsOwnUrlAndModel()
+    {
+        var viewModel = MakeViewModel();
+        Se.Settings.AutoTranslate.OllamaAdvancedUrl = "http://example.local:11434/v1/chat/completions";
+        Se.Settings.AutoTranslate.OllamaAdvancedModel = "qwen3:8b";
+
+        viewModel.SelectedAutoTranslator = viewModel.AutoTranslators.First(t => t is OllamaAdvancedTranslate);
+        viewModel.OnAutoTranslatorChanged();
+
+        Assert.True(viewModel.AutoTranslateUrlIsVisible);
+        Assert.True(viewModel.AutoTranslateModelIsVisible);
+        Assert.True(viewModel.AutoTranslateModelBrowseIsVisible);
+        Assert.False(viewModel.AutoTranslateApiKeyIsVisible);
+        Assert.Equal("http://example.local:11434/v1/chat/completions", viewModel.AutoTranslateUrl);
+        Assert.Equal("qwen3:8b", viewModel.AutoTranslateModel);
     }
 
     private static BatchConvertViewModel MakeViewModel()


### PR DESCRIPTION
The advanced batch/context engines (numbered batches, rolling history of already-translated lines, synopsis/glossary/style, schema-forced JSON reply) exist for both llama.cpp and Ollama in the Auto-translate window, but batch convert keeps its own engine list and only ever got the llama.cpp one. So a batch run could not use the advanced protocol against Ollama.

**Changes**

- `OllamaAdvancedTranslate` added to batch convert's engine list.
- Model text box + browse button shown for it. The picker only needs the host, so the advanced engine's `/v1/chat/completions` URL works as-is - but the picked model is stored in `OllamaAdvancedModel`, not the classic engine's `OllamaModel`.
- URL box shown and persisted to `OllamaAdvancedUrl`; the advanced engine uses the OpenAI-compatible endpoint, not the classic `/api/generate`.
- The shared `Advanced...` window (batch size, context history, synopsis/glossary/style, sampling) now opens for both advanced engines.

No change to the translate loop itself - `DoAutoTranslate` already routes any `IBatchContextTranslator` through the batch path, so batch convert picks it up for free.

**Tests**

`BatchConvertAutoTranslateEngineTests` gains an engine-list check and a field-wiring check; the existing advanced-button test now asserts against `AdvancedTranslatorBase` so it covers any future advanced engine. 75 batch-convert tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)