### PR TITLE
Image export: per-line \3c/\4c colors and \bord/\shad widths

### DIFF
--- a/docs/features/file.md
+++ b/docs/features/file.md
@@ -137,6 +137,8 @@ Tags in the text are read rather than drawn as literal characters:
 | `{\pos(x,y)}` | Positions the subtitle (coordinates are in the script's own resolution) |
 | `{\i1}`, `{\b1}`, `{\c&H..&}`, `{\fn..}`, `{\fs..}` | Italic, bold, colour, font and size |
 | `{\alpha&H80&}`, `{\1a}`, `{\3a}`, `{\4a}` | Transparency — all parts at once, or text, outline and shadow separately |
+| `{\3c&H..&}`, `{\4c&H..&}` | Outline and shadow colour, overriding the colours chosen in the window |
+| `{\bord2}`, `{\shad0}` | Outline and shadow width (in the script's own resolution) — `{\bord0}` turns the outline off |
 | `{\fad(in,out)}`, `{\fade(..)}` | Fade in/out — **Blu-ray SUP only** (see below) |
 
 Anything else is removed before rendering.

--- a/src/libuilogic/Export/ExportTextTags.cs
+++ b/src/libuilogic/Export/ExportTextTags.cs
@@ -28,6 +28,19 @@ public static class ExportTextTags
         @"\\(alpha|1a|3a|4a)&H([0-9A-Fa-f]{1,2})&",
         RegexOptions.Compiled);
 
+    // "{\3c&H0000FF&}" (outline colour) and "{\4c&H0000FF&}" (shadow colour) - up to eight
+    // digits, because some tools write the colour with an alpha in front (&HAABBGGRR&).
+    private static readonly Regex OutlineShadowColorTagRegex = new(
+        @"\\([34]c)&H([0-9A-Fa-f]{1,8})&",
+        RegexOptions.Compiled);
+
+    // "{\bord4}"/"{\shad0}", also with decimals ("{\bord2.5}"). Does not match the one axis
+    // variants "\xbord"/"\ybord"/"\xshad"/"\yshad", which nothing here consumes - the
+    // backslash has to sit right in front of the tag name.
+    private static readonly Regex OutlineShadowWidthTagRegex = new(
+        @"\\(bord|shad)(\d+(?:\.\d+)?)",
+        RegexOptions.Compiled);
+
     /// <summary>
     /// Returns the alignment from a leading "{\anX}" tag - also inside a multi tag block
     /// like "{\an8\i1}" or "{\pos(10,20)\an8}" - or <paramref name="fallback"/> when there is none.
@@ -185,6 +198,66 @@ public static class ExportTextTags
     }
 
     /// <summary>
+    /// Reads the per line outline/shadow overrides off the text and puts them on the
+    /// parameter: the colours of "{\3c&amp;H..&amp;}" (outline) and "{\4c&amp;H..&amp;}"
+    /// (shadow), and the widths of "{\bord..}" and "{\shad..}" - "{\bord0}" in particular is
+    /// how ASSA subtitles turn the outline off for one line.
+    /// <para>
+    /// Call before <see cref="ApplyTransparencyTags"/>: "\3a"/"\4a" fade whatever colours are
+    /// on the parameter, so the "\3c"/"\4c" colours have to be there first. The widths are in
+    /// the script's own resolution, like "\pos" - pass PlayResY as
+    /// <paramref name="scriptHeight"/> (see <see cref="GetScriptResolution"/>) to scale them
+    /// to the canvas.
+    /// </para>
+    /// </summary>
+    public static void ApplyStyleOverrideTags(ImageParameter ip, string? text, int scriptHeight = 0)
+    {
+        if (string.IsNullOrEmpty(text) || !text.Contains("{\\", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        // Inside a "\t(..)" block these tags are an animation target, not the line's look -
+        // leave the whole line alone rather than freezing it at its final state.
+        if (text.Contains("\\t(", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        foreach (Match match in OutlineShadowColorTagRegex.Matches(text))
+        {
+            // ASSA colours are &HBBGGRR& - blue first. Longer values carry an alpha up front,
+            // which the "\3a"/"\4a" tags own, so only the low six digits are read here.
+            var bgr = Convert.ToUInt32(match.Groups[2].Value, 16) & 0xFFFFFF;
+            var color = new SKColor((byte)(bgr & 0xFF), (byte)((bgr >> 8) & 0xFF), (byte)((bgr >> 16) & 0xFF));
+            if (match.Groups[1].Value == "3c")
+            {
+                ip.OutlineColor = color.WithAlpha(ip.OutlineColor.Alpha);
+            }
+            else
+            {
+                ip.ShadowColor = color.WithAlpha(ip.ShadowColor.Alpha);
+            }
+        }
+
+        // Like "\pos", the widths scale with the script resolution when exporting to a
+        // different canvas size.
+        var scale = scriptHeight > 0 && ip.ScreenHeight > 0 ? ip.ScreenHeight / (double)scriptHeight : 1.0;
+        foreach (Match match in OutlineShadowWidthTagRegex.Matches(text))
+        {
+            var width = double.Parse(match.Groups[2].Value, NumberStyles.Float, CultureInfo.InvariantCulture) * scale;
+            if (match.Groups[1].Value == "bord")
+            {
+                ip.OutlineWidth = width;
+            }
+            else
+            {
+                ip.ShadowWidth = width;
+            }
+        }
+    }
+
+    /// <summary>
     /// Reads the ASSA transparency tags off the text and puts them on the parameter: the fade
     /// curve of "{\fad(..)}"/"{\fade(..)}" (used by the Blu-ray sup writer, which can animate
     /// its palette) and the static transparency of "{\alpha&amp;H80&amp;}" and its per part
@@ -257,10 +330,11 @@ public static class ExportTextTags
     }
 
     /// <summary>
-    /// Removes the tags this class consumes itself - "\pos(x,y)", "\fad(..)"/"\fade(..)" and
-    /// the "\alpha"/"\1a"/"\3a"/"\4a" transparencies - matching exactly what
-    /// <see cref="TryGetPosition"/>, <see cref="ExportFade.Parse"/> and
-    /// <see cref="ApplyTransparencyTags"/> read, so a tag those did not understand still
+    /// Removes the tags this class consumes itself - "\pos(x,y)", "\fad(..)"/"\fade(..)",
+    /// the "\alpha"/"\1a"/"\3a"/"\4a" transparencies and the "\3c"/"\4c"/"\bord"/"\shad"
+    /// overrides - matching exactly what <see cref="TryGetPosition"/>,
+    /// <see cref="ExportFade.Parse"/>, <see cref="ApplyTransparencyTags"/> and
+    /// <see cref="ApplyStyleOverrideTags"/> read, so a tag those did not understand still
     /// makes the line "too complex" instead of being dropped along with its effect.
     /// </summary>
     private static string RemoveConsumedTags(string text)
@@ -268,6 +342,15 @@ public static class ExportTextTags
         var s = PositionTagRegex.Replace(text, string.Empty);
         s = ExportFade.RemoveTags(s);
         s = AlphaTagRegex.Replace(s, string.Empty);
+
+        // The outline/shadow overrides are only consumed outside "\t(..)" blocks (see
+        // ApplyStyleOverrideTags) - with a "\t" on the line nothing is consumed, and the "\t"
+        // makes the line too complex regardless.
+        if (!text.Contains("\\t(", StringComparison.Ordinal))
+        {
+            s = OutlineShadowColorTagRegex.Replace(s, string.Empty);
+            s = OutlineShadowWidthTagRegex.Replace(s, string.Empty);
+        }
 
         // "{\pos(10,20)}Hello" is "{}Hello" now - GetFormattedText has no reason to see the
         // leftover block.

--- a/src/seconv/Core/ImageOutputWriter.cs
+++ b/src/seconv/Core/ImageOutputWriter.cs
@@ -62,7 +62,7 @@ internal static class ImageOutputWriter
         var (scriptWidth, scriptHeight) = ExportTextTags.GetScriptResolution(subtitle.Header);
 
         // Pre-render header with the first paragraph as a representative
-        var firstParam = BuildParameter(subtitle.Paragraphs[0], 0, screenWidth, screenHeight, options);
+        var firstParam = BuildParameter(subtitle.Paragraphs[0], 0, screenWidth, screenHeight, scriptHeight, options);
         firstParam.Bitmap = ImageRenderer.GenerateBitmap(firstParam);
         handler.WriteHeader(filePath, firstParam);
         firstParam.Bitmap?.Dispose();
@@ -70,7 +70,7 @@ internal static class ImageOutputWriter
         for (var i = 0; i < subtitle.Paragraphs.Count; i++)
         {
             var p = subtitle.Paragraphs[i];
-            var ip = BuildParameter(p, i, screenWidth, screenHeight, options);
+            var ip = BuildParameter(p, i, screenWidth, screenHeight, scriptHeight, options);
             ip.Bitmap = ImageRenderer.GenerateBitmap(ip);
             // Needs the rendered size, so it cannot happen in BuildParameter.
             ExportTextTags.ApplyPositionTag(ip, p.Text, scriptWidth, scriptHeight);
@@ -178,7 +178,7 @@ internal static class ImageOutputWriter
         };
     }
 
-    private static ImageParameter BuildParameter(Paragraph p, int index, int screenWidth, int screenHeight, ConversionOptions options)
+    private static ImageParameter BuildParameter(Paragraph p, int index, int screenWidth, int screenHeight, int scriptHeight, ConversionOptions options)
     {
         var style = options.ImageStyle;
 
@@ -224,8 +224,10 @@ internal static class ImageOutputWriter
             Error = string.Empty,
         };
 
-        // "{\fad(..)}" and "{\alpha&H..&}" change what is drawn, so they have to be read
-        // before the bitmap is rendered.
+        // "{\3c..}"/"{\4c..}"/"{\bord..}"/"{\shad..}", "{\fad(..)}" and "{\alpha&H..&}"
+        // change what is drawn, so they have to be read before the bitmap is rendered -
+        // overrides first, the transparencies fade whatever colours are on the parameter.
+        ExportTextTags.ApplyStyleOverrideTags(imageParameter, text, scriptHeight);
         ExportTextTags.ApplyTransparencyTags(imageParameter, text);
 
         return imageParameter;

--- a/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
+++ b/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
@@ -585,8 +585,11 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
                 : null,
         };
 
-        // "{\fad(..)}" and "{\alpha&H..&}" change what is drawn, so unlike the position tag
-        // they have to be read before the bitmap is rendered.
+        // "{\3c..}"/"{\4c..}"/"{\bord..}"/"{\shad..}", "{\fad(..)}" and "{\alpha&H..&}"
+        // change what is drawn, so unlike the position tag they have to be read before the
+        // bitmap is rendered - overrides first, the transparencies fade whatever colours are
+        // on the parameter.
+        ExportTextTags.ApplyStyleOverrideTags(imageParameter, subtitle.Text);
         ExportTextTags.ApplyTransparencyTags(imageParameter, subtitle.Text);
 
         return imageParameter;

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -1942,7 +1942,10 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
                 FullFrameBackgroundColor = profile.FullFrameBackgroundColor.FromHexToColor().ToSKColor(),
             };
 
-            // "{\fad(..)}" and "{\alpha&H..&}" change what is drawn - read before rendering.
+            // "{\3c..}"/"{\4c..}"/"{\bord..}"/"{\shad..}", "{\fad(..)}" and "{\alpha&H..&}"
+            // change what is drawn - read before rendering, overrides before the
+            // transparencies that fade them.
+            ExportTextTags.ApplyStyleOverrideTags(imageParameter, subtitle.Text, scriptHeight);
             ExportTextTags.ApplyTransparencyTags(imageParameter, subtitle.Text);
 
             imageParameter.Bitmap = ExportImageBasedViewModel.GenerateBitmap(imageParameter);

--- a/tests/libuilogic/Export/ExportTextTagsTests.cs
+++ b/tests/libuilogic/Export/ExportTextTagsTests.cs
@@ -101,11 +101,17 @@ public class ExportTextTagsTests
     [InlineData("{\\1a&H80&\\3a&HFF&}{\\i1}Hello", "<i>Hello</i>")]
     [InlineData("{\\pos(10,20)\\c&H0000FF&}Red{\\c}", "<font color=\"#ff0000\">Red</font>")]
     [InlineData("{\\move(10,20,30,40)\\i1}Hello", "Hello")] // \move is NOT consumed - still too complex
+    [InlineData("{\\bord0\\i1}Hello", "<i>Hello</i>")]
+    [InlineData("{\\bord2.5\\shad0\\b1}Hello", "<b>Hello</b>")]
+    [InlineData("{\\3c&H0000FF&\\4c&H00FF00&\\i1}Hello", "<i>Hello</i>")]
+    [InlineData("{\\xbord4\\i1}Hello", "Hello")] // one axis variants are NOT consumed - still too complex
+    [InlineData("{\\t(0,200,\\bord0)\\i1}Hello", "Hello")] // inside \t nothing is consumed - still too complex
     public void ToRenderableText_ConsumedTags_DoNotCostTheLineItsFormatting(string text, string expected)
     {
-        // "\pos", "\fad" and "\alpha" are read off the text before rendering
-        // (ApplyPositionTag/ApplyTransparencyTags), so they must not make GetFormattedText
-        // treat the line as too complex and drop the formatting tags next to them.
+        // "\pos", "\fad", "\alpha", "\3c"/"\4c" and "\bord"/"\shad" are read off the text
+        // before rendering (ApplyPositionTag/ApplyTransparencyTags/ApplyStyleOverrideTags),
+        // so they must not make GetFormattedText treat the line as too complex and drop the
+        // formatting tags next to them.
         Assert.Equal(expected, ExportTextTags.ToRenderableText(text));
     }
 
@@ -183,6 +189,95 @@ public class ExportTextTagsTests
         Assert.NotNull(ip.OverridePosition);
         Assert.Equal(0, ip.OverridePosition!.Value.X);
         Assert.Equal(1080 - 50, ip.OverridePosition.Value.Y);
+    }
+
+    private static ImageParameter MakeStyledParameter()
+    {
+        var ip = MakeParameter(ExportAlignment.BottomCenter);
+        ip.OutlineColor = new SKColor(1, 2, 3);
+        ip.ShadowColor = new SKColor(4, 5, 6, 128); // half transparent - a "\4c" must keep that
+        ip.OutlineWidth = 3;
+        ip.ShadowWidth = 2;
+        return ip;
+    }
+
+    [Fact]
+    public void ApplyStyleOverrideTags_OutlineColorTag_SetsOutlineColor()
+    {
+        var ip = MakeStyledParameter();
+
+        // ASSA colors are &HBBGGRR& - "&H0000FF&" is red
+        ExportTextTags.ApplyStyleOverrideTags(ip, "{\\3c&H0000FF&}Hello");
+
+        Assert.Equal(new SKColor(255, 0, 0), ip.OutlineColor);
+        Assert.Equal(new SKColor(4, 5, 6, 128), ip.ShadowColor); // untouched
+    }
+
+    [Fact]
+    public void ApplyStyleOverrideTags_ShadowColorTag_KeepsTheParameterAlpha()
+    {
+        var ip = MakeStyledParameter();
+
+        ExportTextTags.ApplyStyleOverrideTags(ip, "{\\4c&HFF0000&}Hello");
+
+        // "&HFF0000&" is blue; the transparency stays with the parameter ("\4a" owns it)
+        Assert.Equal(new SKColor(0, 0, 255, 128), ip.ShadowColor);
+    }
+
+    [Fact]
+    public void ApplyStyleOverrideTags_EightDigitColor_ReadsOnlyTheLowSixDigits()
+    {
+        var ip = MakeStyledParameter();
+
+        // Some tools write "&HAABBGGRR&" - the alpha up front belongs to "\3a", not the color
+        ExportTextTags.ApplyStyleOverrideTags(ip, "{\\3c&H800000FF&}Hello");
+
+        Assert.Equal(new SKColor(255, 0, 0), ip.OutlineColor);
+    }
+
+    [Theory]
+    [InlineData("{\\bord0}Hello", 0.0, 2.0)] // how ASSA turns the outline off for one line
+    [InlineData("{\\bord2.5}Hello", 2.5, 2.0)]
+    [InlineData("{\\shad0}Hello", 3.0, 0.0)]
+    [InlineData("{\\bord4\\shad1}Hello", 4.0, 1.0)]
+    public void ApplyStyleOverrideTags_WidthTags_OverrideTheDialogWidths(string text, double expectedOutline, double expectedShadow)
+    {
+        var ip = MakeStyledParameter();
+
+        ExportTextTags.ApplyStyleOverrideTags(ip, text);
+
+        Assert.Equal(expectedOutline, ip.OutlineWidth);
+        Assert.Equal(expectedShadow, ip.ShadowWidth);
+    }
+
+    [Fact]
+    public void ApplyStyleOverrideTags_ScriptResolutionDiffers_ScalesTheWidths()
+    {
+        var ip = MakeStyledParameter();
+
+        // 288 line script on a 1080 line canvas: 2 * 1080/288 = 7.5
+        ExportTextTags.ApplyStyleOverrideTags(ip, "{\\bord2}Hello", scriptHeight: 288);
+
+        Assert.Equal(7.5, ip.OutlineWidth);
+    }
+
+    [Theory]
+    [InlineData("Hello")]
+    [InlineData(null)]
+    [InlineData("{\\i1}Hello")]
+    [InlineData("{\\xbord4\\yshad3}Hello")] // one axis variants are not consumed
+    [InlineData("{\\t(0,200,\\bord0)}Hello")] // an animation target, not the line's look
+    [InlineData("{\\t(0,200,\\3c&H0000FF&)}Hello")]
+    public void ApplyStyleOverrideTags_NoConsumableTag_LeavesTheParameterAlone(string? text)
+    {
+        var ip = MakeStyledParameter();
+
+        ExportTextTags.ApplyStyleOverrideTags(ip, text);
+
+        Assert.Equal(new SKColor(1, 2, 3), ip.OutlineColor);
+        Assert.Equal(new SKColor(4, 5, 6, 128), ip.ShadowColor);
+        Assert.Equal(3.0, ip.OutlineWidth);
+        Assert.Equal(2.0, ip.ShadowWidth);
     }
 
     [Fact]


### PR DESCRIPTION
Follow-up to #14123 — the second batch of ASSA override tags for the image based exports (Blu-ray sup, VobSub, BDN XML, DOST, FCP, D-Cinema, seconv, batch convert).

### What was wrong

The exports drew every line with the dialog's outline/shadow colour and width. The ASSA per-line overrides were dropped: `{\3c&H..&}`/`{\4c&H..&}` silently vanished, and `{\bord..}`/`{\shad..}` even made `GetFormattedText` declare the line "too complex", taking its italic/bold/colour formatting down with it. `{\bord0}` — how ASSA subs turn the outline off for one line — is common in real files.

### What this does

New `ExportTextTags.ApplyStyleOverrideTags`, called before `ApplyTransparencyTags` at all three call sites so `\3a`/`\4a` fade the *overridden* colours:

- `\3c`/`\4c` → `OutlineColor`/`ShadowColor`, keeping the parameter's alpha (the transparency tags own that); 8-digit `&HAABBGGRR&` values read only the low six digits
- `\bord`/`\shad` → `OutlineWidth`/`ShadowWidth`, scaled from PlayResY to the canvas like `\pos` (batch + seconv pass the script height; the export window doesn't scale, same as its `\pos` handling)
- the consumed tags are stripped before `GetFormattedText`, so `{\bord0\i1}Hello` keeps its italic (the #14123 machinery)

Deliberately **not** consumed: anything inside a `\t(..)` block (an animation target, not the line's look — the line stays "too complex" as before) and the one-axis `\xbord`/`\ybord`/`\xshad`/`\yshad` variants.

### Verification

- 19 new unit tests (colour mapping, alpha preservation, 8-digit colours, widths incl. decimals, PlayResY scaling, the `\t(` and one-axis guards, formatting preservation); all 697 libuilogic tests pass
- End to end: exported an ASSA with `{\3c&H0000FF&\b1}` to Blu-ray sup via seconv, decoded with ffmpeg overlay — 3,415 red outline pixels around the bold white text, zero on the other lines; `{\bord0}`/`{\shad0}` render clean
- Docs table in `docs/features/file.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)