### PR TITLE
Speech to text: say when Crisp ASR was killed instead of finding no speech

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -208,7 +208,7 @@ public partial class SpeechToTextViewModel : ObservableObject
     private List<AudioClip>? _audioClips;
     private bool _audioClipsAutoStart;
     private string _qwen3AsrOutputJsonPath = string.Empty;
-    private int? _qwen3AsrExitCode;
+    private int? _engineExitCode;
 
     private readonly IWindowService _windowService;
     private readonly IFileHelper _fileHelper;
@@ -762,14 +762,15 @@ public partial class SpeechToTextViewModel : ObservableObject
             var settings = Se.Settings.Tools.AudioToText;
 
             // Grab the exit code before disposing - it is the key diagnostic when the engine
-            // dies without producing output (e.g. a Qwen3 ASR GPU/Vulkan crash, issue #12815).
+            // dies without producing output (a Qwen3 ASR GPU/Vulkan crash, issue #12815; a Crisp
+            // ASR build that needs CPU instructions this machine lacks, issue #14038).
             try
             {
-                _qwen3AsrExitCode = _whisperProcess.ExitCode;
+                _engineExitCode = _whisperProcess.ExitCode;
             }
             catch
             {
-                _qwen3AsrExitCode = null;
+                _engineExitCode = null;
             }
 
             _whisperProcess.Dispose();
@@ -887,6 +888,75 @@ public partial class SpeechToTextViewModel : ObservableObject
         }
 
         return !Regex.IsMatch(crispArgs ?? string.Empty, @"(^|\s)(--vad|-vm|--vad-model|--chunk-seconds|-ck)\b");
+    }
+
+    /// <summary>
+    /// Windows terminates a process that executes an instruction its CPU does not implement with
+    /// STATUS_ILLEGAL_INSTRUCTION; Unix reports the SIGILL as 128+4.
+    /// </summary>
+    internal const int StatusIllegalInstruction = unchecked((int)0xC000001D);
+
+    /// <summary>The shell convention for a child killed by SIGILL (128 + SIGILL).</summary>
+    internal const int UnixSigill = 132;
+
+    /// <summary>
+    /// Explains a Crisp ASR run that produced nothing because the engine died, or null when the
+    /// exit code says it did not - an empty result with a clean exit has some other cause and the
+    /// generic message is the honest one.
+    ///
+    /// Worth spelling out because the failure is invisible: a process killed for an illegal
+    /// instruction never reaches stdout, so SE sees a well-behaved engine that simply produced no
+    /// subtitles and said so, which is all the user was told in #14038. The concrete case there
+    /// was the crispasr v0.8.29 GPU packages, built with AVX-512 against a CI runner that had it
+    /// (CrispASR #374) - every CPU without AVX-512 got this on the CUDA/Vulkan build while the CPU
+    /// build ran fine, so naming the installed package is most of the answer.
+    /// </summary>
+    /// <param name="exitCode">The engine process exit code, or null when it could not be read.</param>
+    /// <param name="variant">
+    /// The installed Crisp ASR package ("cuda", "vulkan", "cpu", ...) as reported by
+    /// <see cref="DownloadHashManager.GetCrispAsrVariant"/>, or null when it is not known.
+    /// </param>
+    internal static string? DescribeCrispAsrCrash(int? exitCode, string? variant)
+    {
+        if (exitCode is null or 0)
+        {
+            return null;
+        }
+
+        var code = $"exit code {exitCode.Value} (0x{(uint)exitCode.Value:X8})";
+        if (exitCode.Value is not (StatusIllegalInstruction or UnixSigill))
+        {
+            return $"Crisp ASR crashed before producing any output ({code}).{Environment.NewLine}{Environment.NewLine}" +
+                   "Please check the tools log for engine output.";
+        }
+
+        var isGpuBuild = variant is "cuda" or "cuda13" or "vulkan" or "hip";
+        var advice = isGpuBuild
+            ? $"The installed \"{variant}\" package needs a newer CPU than this one. Download the speech to text " +
+              "engine again and choose the CPU build."
+            : "Download the speech to text engine again and choose the CPU (legacy) build, which targets the " +
+              "oldest CPUs.";
+
+        return $"Crisp ASR was stopped for using CPU instructions this computer does not have ({code}, " +
+               $"illegal instruction), so it never produced any output.{Environment.NewLine}{Environment.NewLine}" +
+               advice;
+    }
+
+    /// <summary>
+    /// The Crisp ASR package the user actually has installed, from the download sidecar. Best-effort:
+    /// this only sharpens a diagnostic message, so an unreadable sidecar is not worth failing over.
+    /// </summary>
+    private static string? TryGetCrispAsrVariant(ICrispAsrEngine engine)
+    {
+        try
+        {
+            var sidecar = DownloadHashManager.TryReadSidecar(engine.GetAndCreateWhisperFolder());
+            return sidecar == null ? null : DownloadHashManager.GetCrispAsrVariant(sidecar.Value.Key);
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     /// <summary>
@@ -1034,7 +1104,7 @@ public partial class SpeechToTextViewModel : ObservableObject
         var jsonPath = _qwen3AsrOutputJsonPath;
         if (string.IsNullOrEmpty(jsonPath) || !File.Exists(jsonPath))
         {
-            var exitCode = _qwen3AsrExitCode;
+            var exitCode = _engineExitCode;
             var isVulkan = false;
             try
             {
@@ -2444,6 +2514,20 @@ public partial class SpeechToTextViewModel : ObservableObject
 
         var anyLinesTranscribed = transcribedSubtitle != null && transcribedSubtitle.Paragraphs.Count > 0;
 
+        // A crashed engine leaves the same empty result as a clean run that found no speech, and
+        // the exit code is the only thing that tells them apart (#14038). Resolved here rather than
+        // in the dialog branch below so a batch run - which returns before any of that - still
+        // records why the file came back empty.
+        string? crispAsrCrash = null;
+        if (!anyLinesTranscribed && GetEffectiveSelectedEngine() is ICrispAsrEngine crispAsrEngine)
+        {
+            crispAsrCrash = DescribeCrispAsrCrash(_engineExitCode, TryGetCrispAsrVariant(crispAsrEngine));
+            if (crispAsrCrash != null)
+            {
+                Se.WriteToolsLog(crispAsrCrash, true);
+            }
+        }
+
         if (_abort)
         {
             // User cancelled mid-run. Leave the dialog open so they can adjust
@@ -2488,6 +2572,7 @@ public partial class SpeechToTextViewModel : ObservableObject
             else if (GetEffectiveSelectedEngine() is ICrispAsrEngine)
             {
                 await MessageBox.Show(Window!, "No transcription result",
+                    crispAsrCrash ??
                     "Crisp ASR finished without generating subtitles. Please check the tools log for engine output.");
 
                 if (Window != null)
@@ -3934,7 +4019,7 @@ public partial class SpeechToTextViewModel : ObservableObject
             var exe = qwen3Asr.GetExecutable();
             var alignerModel = qwen3Asr.ForcedAlignerModel;
             _qwen3AsrOutputJsonPath = Path.Combine(Path.GetTempPath(), $"qwen3_asr_{Guid.NewGuid():N}.json");
-            _qwen3AsrExitCode = null;
+            _engineExitCode = null;
             var qwen3ExtraArgs = engine.CommandLineParameter;
 
             var qwen3Params = string.IsNullOrWhiteSpace(qwen3ExtraArgs)

--- a/tests/UI/Features/Video/SpeechToText/CrispAsrCrashDiagnosticsTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/CrispAsrCrashDiagnosticsTests.cs
@@ -1,0 +1,100 @@
+using Nikse.SubtitleEdit.Features.Video.SpeechToText;
+using Xunit;
+
+namespace UITests.Features.Video.SpeechToText;
+
+/// <summary>
+/// A Crisp ASR run that produced nothing looks identical whether the engine found no speech or was
+/// killed before it wrote a byte, and SE told the user the same thing either way - which is all the
+/// reporter in #14038 had to go on. The concrete case was the crispasr v0.8.29 GPU packages: built
+/// with AVX-512 against a CI runner that had it (CrispASR #374), so every CPU without AVX-512 was
+/// terminated inside ggml_backend_cpu_init while the CPU package ran fine on the same machine.
+/// </summary>
+public class CrispAsrCrashDiagnosticsTests
+{
+    [Fact]
+    public void CleanExitIsNotACrash()
+    {
+        Assert.Null(SpeechToTextViewModel.DescribeCrispAsrCrash(0, "cuda"));
+    }
+
+    /// <summary>An unreadable exit code says nothing, so it must not claim a crash.</summary>
+    [Fact]
+    public void UnknownExitCodeIsNotACrash()
+    {
+        Assert.Null(SpeechToTextViewModel.DescribeCrispAsrCrash(null, "cuda"));
+    }
+
+    [Theory]
+    [InlineData(SpeechToTextViewModel.StatusIllegalInstruction)]
+    [InlineData(SpeechToTextViewModel.UnixSigill)]
+    public void IllegalInstructionOnAGpuBuildNamesThePackageAndTheWayOut(int exitCode)
+    {
+        var message = SpeechToTextViewModel.DescribeCrispAsrCrash(exitCode, "cuda");
+
+        Assert.NotNull(message);
+        Assert.Contains("CPU instructions this computer does not have", message);
+        Assert.Contains("\"cuda\" package", message);
+        Assert.Contains("choose the CPU build", message);
+    }
+
+    /// <summary>Every GPU package is built by the same jobs, so all of them get the same advice.</summary>
+    [Theory]
+    [InlineData("cuda13")]
+    [InlineData("vulkan")]
+    [InlineData("hip")]
+    public void EveryGpuVariantIsPointedAtTheCpuBuild(string variant)
+    {
+        var message = SpeechToTextViewModel.DescribeCrispAsrCrash(
+            SpeechToTextViewModel.StatusIllegalInstruction, variant);
+
+        Assert.NotNull(message);
+        Assert.Contains($"\"{variant}\" package", message);
+        Assert.Contains("choose the CPU build", message);
+    }
+
+    /// <summary>
+    /// Already on the CPU build, or the sidecar could not be read: "use the CPU build" would be
+    /// useless advice, so the fallback is the legacy build that targets the oldest CPUs.
+    /// </summary>
+    [Theory]
+    [InlineData("cpu")]
+    [InlineData(null)]
+    public void NonGpuBuildIsPointedAtTheLegacyBuild(string? variant)
+    {
+        var message = SpeechToTextViewModel.DescribeCrispAsrCrash(
+            SpeechToTextViewModel.StatusIllegalInstruction, variant);
+
+        Assert.NotNull(message);
+        Assert.Contains("CPU (legacy) build", message);
+        Assert.DoesNotContain("package", message);
+    }
+
+    /// <summary>
+    /// Some other crash is still worth reporting as a crash - it just gets no instruction-set
+    /// advice, because that is not what went wrong.
+    /// </summary>
+    [Fact]
+    public void OtherCrashesAreReportedWithoutInstructionSetAdvice()
+    {
+        var accessViolation = unchecked((int)0xC0000005);
+
+        var message = SpeechToTextViewModel.DescribeCrispAsrCrash(accessViolation, "cuda");
+
+        Assert.NotNull(message);
+        Assert.Contains("crashed before producing any output", message);
+        Assert.DoesNotContain("illegal instruction", message);
+    }
+
+    /// <summary>The raw code has to survive into the text: it is what a bug report needs.</summary>
+    [Fact]
+    public void TheExitCodeIsShownInBothDecimalAndHex()
+    {
+        var message = SpeechToTextViewModel.DescribeCrispAsrCrash(
+            SpeechToTextViewModel.StatusIllegalInstruction, "cuda");
+
+        Assert.NotNull(message);
+        Assert.Contains("-1073741795", message);
+        Assert.Contains("0xC000001D", message);
+    }
+}


### PR DESCRIPTION
Makes #14038 diagnosable from inside SE.

## What the user saw

A Crisp ASR run that produced nothing looks the same whether the engine found no speech or was killed before writing a byte. Both end at:

> Crisp ASR finished without generating subtitles. Please check the tools log for engine output.

And the log holds nothing either — a process terminated for an illegal instruction never reaches stdout. The reporter's console stopped right after the CUDA device banner, with a 2.9 s runtime and no error.

## Why it happened

The crispasr **v0.8.29 GPU packages** were compiled with AVX-512. `build-windows-cuda` in CrispASR's release workflow lost its `-DGGML_NATIVE=OFF -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON` pinning, so `GGML_NATIVE` defaulted back to ON and ggml compiled against the CI runner's CPU — which has AVX-512. Confirmed against the published assets (`objdump -d`, AVX-512 `zmm` uses in `ggml-cpu`):

| artifact | zmm uses |
|---|---|
| v0.8.28 `crispasr-windows-x86_64-cuda` → `ggml-cpu.dll` | 0 |
| v0.8.29 `crispasr-windows-x86_64-cuda` → `ggml-cpu.dll` | **14,655** |
| v0.8.29 `crispasr-windows-x86_64-cpu` → `crispasr.exe` | 0 |

The faulting instruction is inside `ggml_backend_cpu_init` itself, which every backend calls at init, so it is not model- or backend-specific — the whole CUDA package is dead on those CPUs while the CPU package works on the same machine.

That is upstream [CrispStrobe/CrispASR#374](https://github.com/CrispStrobe/CrispASR/issues/374), already fixed on their `main` by `398aabc9` — but **unreleased**, so v0.8.29 is still what SE pins and hands users. Nothing here changes the pin; that is a separate bump once a fixed release exists.

## What this PR changes

SE already captured the engine exit code, but only used it on the Qwen3 ASR CPP path (#12815). This reuses it for Crisp ASR:

- **`STATUS_ILLEGAL_INSTRUCTION`** (`0xC000001D`, or 128+SIGILL on Unix) — names the installed package from the download sidecar and points at the CPU build:

  > Crisp ASR was stopped for using CPU instructions this computer does not have (exit code -1073741795 (0xC000001D), illegal instruction), so it never produced any output.
  >
  > The installed "cuda" package needs a newer CPU than this one. Download the speech to text engine again and choose the CPU build.

  Already on the CPU build, or the sidecar is unreadable, gets the CPU (legacy) build instead — "use the CPU build" would be useless advice there.
- **Any other non-zero exit** — reported as a crash with the code, instead of a quiet empty result.
- **A clean exit** — unchanged. An empty result with exit 0 genuinely has some other cause, and the existing message is the honest one.

Resolved before the batch-mode branch so a batch run records the reason in the tools log too, even though only the single-file flow shows a dialog.

`_qwen3AsrExitCode` is renamed `_engineExitCode` — it was already being captured for every engine, only read by one.

## Tests

`tests/UI/Features/Video/SpeechToText/CrispAsrCrashDiagnosticsTests.cs`, 11 cases over `DescribeCrispAsrCrash`: clean exit and unknown exit are not crashes, both illegal-instruction encodings are, every GPU variant is pointed at the CPU build, non-GPU installs at the legacy build, other crashes get no instruction-set advice, and the raw code survives into the text in both decimal and hex.

248 existing `SpeechToText` tests still pass.

## Not covered

The message is only as good as the sidecar; a hand-copied `crispasr.exe` has no sidecar, so it falls through to the legacy-build advice. Naming the package is a nicety — the instruction-set explanation is the part that matters, and that does not depend on it.
