### PR TITLE
seconv: add `seconv mcp`, a Model Context Protocol server over stdio

### DIFF
--- a/docs/reference/command-line.md
+++ b/docs/reference/command-line.md
@@ -84,6 +84,7 @@ seconv list-rf-rules        # list remove-formatting rule IDs
 seconv dump-settings        # print a full --settings JSON with libse defaults
 seconv info <file>          # print format/encoding/duration/language for a file
 seconv lint <pattern>       # validate subtitle(s); exit 1 if issues found
+seconv mcp                  # run as a Model Context Protocol server over stdio
 seconv --help               # show help (same text as -h, /? and /help)
 seconv --help-json          # print the whole command-line schema as JSON
 seconv --version            # print version and exit
@@ -123,6 +124,28 @@ seconv info movie.srt --json         # machine-parseable
 seconv lint *.srt                    # check overlaps, line lengths, tags, ...
 seconv lint *.srt --json             # CI-friendly: exit 1 on any issue
 ```
+
+### MCP server
+
+`seconv mcp` exposes the engine to AI clients as a [Model Context Protocol](https://modelcontextprotocol.io) server over stdio. Register it as a stdio server in the client's configuration — for Claude Desktop / Cursor:
+
+```json
+{ "mcpServers": { "seconv": { "command": "seconv", "args": ["mcp"] } } }
+```
+
+For Claude Code: `claude mcp add seconv -- seconv mcp`.
+
+| Tool | What it does |
+|---|---|
+| `list_formats` | Formats with `id` (the `format` value for `convert_subtitle`), extension, `inputOnly`. Optional substring filter. |
+| `subtitle_info` | Detect format, encoding, paragraph count, first/last time code, duration, language. |
+| `read_subtitle` | The paragraphs (number, start/end, text) of a file in any supported format, paged (`start`, `count`, max 1000). |
+| `lint_subtitle` | The same checks as `seconv lint`, as a per-paragraph issue list. |
+| `convert_subtitle` | Convert inputs/patterns to a format; supports output folder/name, encoding, overwrite, offset, fps/targetFps, renumber, duration/gap adjustments, delete first/last/contains, `operations`, FixCommonErrors and RemoveFormatting rule selection, container track numbers, OCR engine/language, `timeCodesOnly`, resolution. |
+| `list_fix_common_errors_rules` | Rule ids for `fixCommonErrorsRules`, with GUI label and language gate. |
+| `list_remove_formatting_rules` | Rule ids for `removeFormattingRules`. |
+
+Results are compact JSON with the same field names as the `--json` output of the corresponding subcommand. A failure comes back as an MCP tool error carrying the message (unknown operation, missing file, unsupported format, ...), never as a silent no-op. Stdout is reserved for the protocol; logs go to stderr (`--verbose` for debug level).
 
 ## Options
 

--- a/src/seconv/Helpers/CliSchema.cs
+++ b/src/seconv/Helpers/CliSchema.cs
@@ -340,6 +340,7 @@ internal static class CliSchema
                 new { name = "dump-settings", json = true, description = "Print a full --settings JSON with libse defaults. Always JSON; redirect to a file." },
                 new { name = "info", json = true, description = "Print format / encoding / duration / language for one file. Usage: seconv info <file>" },
                 new { name = "lint", json = true, description = "Validate subtitles; exit 1 if any issues found. Usage: seconv lint <pattern>..." },
+                new { name = "mcp", json = false, description = "Run seconv as a Model Context Protocol server over stdio. Tools: list_formats, subtitle_info, read_subtitle, lint_subtitle, convert_subtitle, list_fix_common_errors_rules, list_remove_formatting_rules. Usage: seconv mcp [--verbose]" },
                 new { name = "--help-json", json = true, description = "Print this schema." },
                 new { name = "--version", json = false, description = "Print the seconv version and exit." },
             },

--- a/src/seconv/Helpers/HelpDisplay.cs
+++ b/src/seconv/Helpers/HelpDisplay.cs
@@ -155,6 +155,7 @@ internal static class HelpDisplay
         ShowParameter(console, "dump-settings", "Print a full --settings JSON with libse defaults (redirect to a file)");
         ShowParameter(console, "info <file>", "Print format / encoding / duration / language info");
         ShowParameter(console, "lint <pattern>", "Validate subtitle(s); exit 1 if any issues found");
+        ShowParameter(console, "mcp", "Run as a Model Context Protocol server over stdio (Claude, Cursor, ...)");
 
         console.WriteLine();
         ShowSection(console, "Examples", null);

--- a/src/seconv/Mcp/McpServerHost.cs
+++ b/src/seconv/Mcp/McpServerHost.cs
@@ -1,0 +1,53 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using SeConv.Helpers;
+
+namespace SeConv.Mcp;
+
+/// <summary>
+/// <c>seconv mcp</c>: runs seconv as a Model Context Protocol server over stdio so an MCP client
+/// (Claude Desktop, Claude Code, Cursor, ...) can call the tools in <see cref="SubtitleTools"/>
+/// without a shell. The JSON-RPC transport owns stdout; logs and any incidental console output
+/// from libse or Spectre go to stderr so they can never corrupt a protocol frame.
+/// </summary>
+internal static class McpServerHost
+{
+    private const string Instructions =
+        "seconv exposes Subtitle Edit's conversion engine (400+ subtitle formats). " +
+        "Start with subtitle_info to detect a file's format, encoding and duration; use read_subtitle to see " +
+        "its paragraphs (any format, paged); lint_subtitle to find timing/line-length problems; " +
+        "convert_subtitle to write a new file in another format, optionally shifting times, changing " +
+        "frame rate or applying operations such as FixCommonErrors. Paths are local file-system paths.";
+
+    public static async Task<int> RunAsync(string[] args)
+    {
+        var verbose = args.Any(a =>
+            a.Equals("--verbose", StringComparison.OrdinalIgnoreCase) ||
+            a.Equals("-v", StringComparison.OrdinalIgnoreCase));
+
+        // Stdout is the protocol channel. The stdio transport writes to the raw standard output
+        // stream, so redirecting Console.Out only affects incidental writers (libse notices,
+        // Spectre markup from a non-quiet code path) - they land on stderr instead of inside a frame.
+        Console.SetOut(Console.Error);
+
+        var builder = Host.CreateApplicationBuilder(Array.Empty<string>());
+        builder.Logging.ClearProviders();
+        builder.Logging.AddConsole(o => o.LogToStandardErrorThreshold = LogLevel.Trace);
+        builder.Logging.SetMinimumLevel(verbose ? LogLevel.Debug : LogLevel.Warning);
+
+        builder.Services
+            .AddMcpServer(options =>
+            {
+                options.ServerInfo = new Implementation { Name = "seconv", Version = CliSchema.Version };
+                options.ServerInstructions = Instructions;
+            })
+            .WithStdioServerTransport()
+            .WithTools<SubtitleTools>();
+
+        await builder.Build().RunAsync();
+        return 0;
+    }
+}

--- a/src/seconv/Mcp/SubtitleTools.cs
+++ b/src/seconv/Mcp/SubtitleTools.cs
@@ -1,0 +1,318 @@
+using System.ComponentModel;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using SeConv.Core;
+
+namespace SeConv.Mcp;
+
+/// <summary>
+/// The MCP tool surface of <c>seconv mcp</c>. Each tool is a thin adapter over the same Core
+/// helpers the CLI subcommands use (<see cref="SubtitleInfoGatherer"/>, <see cref="SubtitleLinter"/>,
+/// <see cref="SubtitleConverter"/>, ...), so behaviour cannot drift between the two entry points.
+/// Every tool returns a <see cref="CallToolResult"/> directly: on success a single compact JSON
+/// text block; on failure <c>isError</c> with the exception message, so the model sees what went
+/// wrong instead of the SDK's generic "an error occurred" placeholder.
+/// </summary>
+[McpServerToolType]
+internal sealed class SubtitleTools
+{
+    private SubtitleTools()
+    {
+        // Static tool methods only; the SDK's WithTools<T>() needs a non-static type argument.
+    }
+
+    private static readonly JsonSerializerOptions Json = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
+    private const int DefaultReadCount = 100;
+    private const int MaxReadCount = 1000;
+
+    [McpServerTool(Name = "list_formats", ReadOnly = true, Idempotent = true)]
+    [Description("List the subtitle formats seconv can read and write. 'id' is the exact value convert_subtitle's 'format' parameter accepts; 'inputOnly' formats can be read but not written.")]
+    public static CallToolResult ListFormats(
+        [Description("Optional case-insensitive substring matched against id, name and extension (e.g. 'srt', 'ebu', 'vtt'). Omit to list everything.")] string? filter = null)
+        => Run(() =>
+        {
+            var formats = LibSEIntegration.GetAvailableFormats()
+                .Select(entry => new
+                {
+                    id = entry.Format.Name.Replace(" ", string.Empty),
+                    name = entry.Format.Name,
+                    extension = entry.Format.Extension,
+                    type = entry.Kind.StartsWith("binary", StringComparison.Ordinal) ? "binary" : "text",
+                    inputOnly = entry.Kind.Contains("(input)", StringComparison.Ordinal),
+                })
+                .Where(f => string.IsNullOrWhiteSpace(filter) ||
+                            f.id.Contains(filter, StringComparison.OrdinalIgnoreCase) ||
+                            f.name.Contains(filter, StringComparison.OrdinalIgnoreCase) ||
+                            f.extension.Contains(filter, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            return new
+            {
+                total = formats.Count,
+                formats,
+                extraIds = new[] { "plaintext", "customtext", "bluraysup", "vobsub", "bdnxml" },
+            };
+        });
+
+    [McpServerTool(Name = "subtitle_info", ReadOnly = true, Idempotent = true)]
+    [Description("Detect a subtitle file's format, encoding, paragraph count, first/last time codes, duration and language. Works for any of the 400+ supported formats, including binary ones.")]
+    public static CallToolResult SubtitleInfo(
+        [Description("Path to the subtitle file.")] string path)
+        => Run(() => SubtitleInfoGatherer.Gather(path));
+
+    [McpServerTool(Name = "read_subtitle", ReadOnly = true, Idempotent = true)]
+    [Description("Read the paragraphs (number, start/end time, text) of a subtitle file in any supported text or binary format, paged. Use this instead of reading the raw file when the format is not plain SRT/VTT.")]
+    public static CallToolResult ReadSubtitle(
+        [Description("Path to the subtitle file.")] string path,
+        [Description("1-based number of the first paragraph to return (default 1).")] int start = 1,
+        [Description("Maximum number of paragraphs to return (default 100, max 1000).")] int count = DefaultReadCount,
+        [Description("Input text encoding (e.g. 'windows-1252'). Default: auto-detect.")] string? encoding = null)
+        => Run(() =>
+        {
+            var (subtitle, format) = LibSEIntegration.LoadSubtitleWithFormat(path, encoding);
+            var total = subtitle.Paragraphs.Count;
+            var first = Math.Max(1, start);
+            var take = Math.Clamp(count, 1, MaxReadCount);
+
+            var paragraphs = subtitle.Paragraphs
+                .Skip(first - 1)
+                .Take(take)
+                .Select((p, i) => new
+                {
+                    number = first + i,
+                    start = p.StartTime.ToDisplayString(),
+                    end = p.EndTime.ToDisplayString(),
+                    startMs = (long)p.StartTime.TotalMilliseconds,
+                    endMs = (long)p.EndTime.TotalMilliseconds,
+                    text = p.Text,
+                })
+                .ToList();
+
+            return new
+            {
+                path,
+                format = format.Name,
+                total,
+                start = first,
+                returned = paragraphs.Count,
+                hasMore = first - 1 + paragraphs.Count < total,
+                paragraphs,
+            };
+        });
+
+    [McpServerTool(Name = "lint_subtitle", ReadOnly = true, Idempotent = true)]
+    [Description("Validate a subtitle file without modifying it: overlapping or too short/long display times, lines that are too long, too many lines, empty paragraphs, mismatched italic/bold tags. Returns the issues per paragraph number.")]
+    public static CallToolResult LintSubtitle(
+        [Description("Path to the subtitle file.")] string path)
+        => Run(() => SubtitleLinter.Lint(path));
+
+    [McpServerTool(Name = "list_fix_common_errors_rules", ReadOnly = true, Idempotent = true)]
+    [Description("List the FixCommonErrors rule ids accepted by convert_subtitle's 'fixCommonErrorsRules' parameter, with the matching Subtitle Edit GUI label and the language gate (if any).")]
+    public static CallToolResult ListFixCommonErrorsRules()
+        => Run(() => new
+        {
+            total = FixCommonErrorsRunner.AvailableRuleIds.Count,
+            rules = FixCommonErrorsRunner.AvailableRuleIds.Select(id => new
+            {
+                id,
+                guiLabel = FixCommonErrorsRunner.GuiLabels.TryGetValue(id, out var label) ? label : null,
+                languageGate = FixCommonErrorsRunner.LanguageGates.TryGetValue(id, out var lang) ? lang : null,
+            }),
+            syntax = new { all = "all", subset = "FixCommas,FixEllipsesStart", allExcept = "all,-FixDanishLetterI" },
+            note = "A language-gated rule runs only when the subtitle's language matches (auto-detected, or forced with fixCommonErrorsLanguage). Naming a gated rule selects it but does not bypass the gate.",
+        });
+
+    [McpServerTool(Name = "list_remove_formatting_rules", ReadOnly = true, Idempotent = true)]
+    [Description("List the RemoveFormatting rule ids accepted by convert_subtitle's 'removeFormattingRules' parameter, with the matching Subtitle Edit GUI label.")]
+    public static CallToolResult ListRemoveFormattingRules()
+        => Run(() => new
+        {
+            total = RemoveFormattingRunner.AvailableRuleIds.Count,
+            rules = RemoveFormattingRunner.AvailableRuleIds.Select(id => new
+            {
+                id,
+                guiLabel = RemoveFormattingRunner.GuiLabels.TryGetValue(id, out var label) ? label : null,
+            }),
+            syntax = new { all = "all", subset = "RemoveItalic,RemoveColor", allExcept = "all,-RemoveItalic" },
+        });
+
+    [McpServerTool(Name = "convert_subtitle", Idempotent = false)]
+    [Description("Convert one or more subtitle files to another format, optionally shifting times, changing frame rate or applying operations (FixCommonErrors, RemoveFormatting, ...). Writes output files next to the inputs unless outputFolder is given; existing files are never overwritten unless overwrite is true. Returns per-file results with output paths, errors and warnings.")]
+    public static Task<CallToolResult> ConvertSubtitle(
+        [Description("Input file paths or glob patterns (e.g. 'C:/subs/*.srt'). Containers (.mkv/.mp4/.ts/.avi) and image-based subtitles (.sup, .sub+.idx) are accepted too.")] string[] inputs,
+        [Description("Target format id from list_formats (e.g. 'SubRip', 'WebVTT', 'AdvancedSubStationAlpha'); short aliases such as 'srt', 'vtt', 'ass', 'ebu' and 'plaintext' also work.")] string format,
+        [Description("Folder to write the output files to. Default: next to each input file.")] string? outputFolder = null,
+        [Description("Explicit output file name. Only valid with a single input file.")] string? outputFilename = null,
+        [Description("Output text encoding: 'utf-8' (default, with BOM), 'utf-8-nobom', a code page name such as 'windows-1252', or 'source' to keep the input file's encoding.")] string? encoding = null,
+        [Description("Overwrite an existing output file. Default false: a numeric suffix is added instead.")] bool overwrite = false,
+        [Description("Shift every time code by this offset, e.g. '00:00:02.500', '2.5', '-1.2' (seconds) or '-00:00:01,000'.")] string? offset = null,
+        [Description("Source frame rate for frame-based formats (e.g. 25).")] double? fps = null,
+        [Description("Convert timings from 'fps' to this target frame rate (e.g. 23.976).")] double? targetFps = null,
+        [Description("Renumber paragraphs starting at this value.")] int? renumber = null,
+        [Description("Add this many milliseconds to every paragraph's duration (negative shortens).")] int? adjustDurationMs = null,
+        [Description("Speed change in percent: 125 = 1.25x faster, 80 = slower.")] double? changeSpeedPercent = null,
+        [Description("Bridge gaps shorter than this many milliseconds by extending the previous paragraph.")] int? bridgeGapsMaxMs = null,
+        [Description("Enforce a minimum gap of this many milliseconds between consecutive paragraphs.")] int? applyMinGapMs = null,
+        [Description("Delete the first N paragraphs.")] int? deleteFirst = null,
+        [Description("Delete the last N paragraphs.")] int? deleteLast = null,
+        [Description("Delete every paragraph whose text contains this string.")] string? deleteContains = null,
+        [Description("Operations to apply, in this order. Valid names: FixCommonErrors, RemoveFormatting, RemoveTextForHI, BalanceLines, SplitLongLines, MergeShortLines, MergeSameTexts, MergeSameTimeCodes, RedoCasing, ApplyDurationLimits, BeautifyTimeCodes, ConvertColorsToDialog, FixRtlViaUnicodeChars, ReverseRtlStartEnd, RemoveLineBreaks, RemoveUnicodeControlChars.")] string[]? operations = null,
+        [Description("FixCommonErrors rule selection: comma-separated ids from list_fix_common_errors_rules, 'all', or 'all,-RuleId'. Implies the FixCommonErrors operation.")] string? fixCommonErrorsRules = null,
+        [Description("Force the language used by FixCommonErrors' language-gated rules (two-letter code such as 'en' or 'es'). Default: auto-detect from the text.")] string? fixCommonErrorsLanguage = null,
+        [Description("RemoveFormatting rule selection: comma-separated ids from list_remove_formatting_rules, or 'all,-RuleId'. Implies the RemoveFormatting operation.")] string? removeFormattingRules = null,
+        [Description("Container inputs: subtitle track numbers to extract. Default: every text track.")] int[]? trackNumbers = null,
+        [Description("Image-based inputs: keep only the time codes and skip OCR (text is left empty).")] bool timeCodesOnly = false,
+        [Description("OCR engine for image-based inputs: tesseract (default), nocr, binaryocr, ollama, paddle or llamacpp.")] string? ocrEngine = null,
+        [Description("OCR language for image-based inputs (Tesseract ISO 639-2 code such as 'eng').")] string? ocrLanguage = null,
+        [Description("Output resolution for image-based targets, e.g. '1920x1080'.")] string? resolution = null)
+        => RunAsync(async () =>
+        {
+            if (inputs is null || inputs.All(string.IsNullOrWhiteSpace))
+            {
+                throw new ArgumentException("At least one input path or pattern is required.");
+            }
+
+            if (string.IsNullOrWhiteSpace(format))
+            {
+                throw new ArgumentException("A target format is required. Use list_formats to see the ids.");
+            }
+
+            var ops = NormalizeOperations(operations);
+
+            IReadOnlyList<string> fceRules = [];
+            if (!string.IsNullOrWhiteSpace(fixCommonErrorsRules))
+            {
+                fceRules = FixCommonErrorsRunner.ResolveRuleIds(fixCommonErrorsRules);
+                EnsureOperation(ops, "FixCommonErrors");
+            }
+
+            IReadOnlyList<string>? rfRules = null;
+            if (!string.IsNullOrWhiteSpace(removeFormattingRules))
+            {
+                rfRules = RemoveFormattingRunner.ResolveRuleIds(removeFormattingRules);
+                EnsureOperation(ops, "RemoveFormatting");
+            }
+
+            var options = new ConversionOptions
+            {
+                Patterns = inputs.Where(i => !string.IsNullOrWhiteSpace(i)).ToArray(),
+                Format = format,
+                OutputFolder = outputFolder,
+                OutputFilename = outputFilename,
+                Encoding = encoding,
+                Overwrite = overwrite,
+                Offset = string.IsNullOrWhiteSpace(offset) ? null : OffsetParser.Parse(offset),
+                Fps = fps,
+                TargetFps = targetFps,
+                Renumber = renumber,
+                AdjustDurationMs = adjustDurationMs,
+                ChangeSpeedPercent = changeSpeedPercent,
+                BridgeGapsMaxMs = bridgeGapsMaxMs,
+                ApplyMinGapMs = applyMinGapMs,
+                DeleteFirst = deleteFirst,
+                DeleteLast = deleteLast,
+                DeleteContains = deleteContains,
+                Operations = ops,
+                FixCommonErrorsRules = fceRules,
+                FixCommonErrorsLanguage = fixCommonErrorsLanguage,
+                RemoveFormattingRules = rfRules,
+                TrackNumbers = trackNumbers ?? [],
+                TimeCodesOnly = timeCodesOnly,
+                OcrEngine = string.IsNullOrWhiteSpace(ocrEngine) ? "tesseract" : ocrEngine,
+                OcrLanguage = string.IsNullOrWhiteSpace(ocrLanguage) ? "eng" : ocrLanguage,
+                Resolution = string.IsNullOrWhiteSpace(resolution) ? null : ResolutionParser.Parse(resolution),
+                // The converter narrates progress on stdout when not quiet; stdout is the MCP channel.
+                Quiet = true,
+            };
+
+            return await new SubtitleConverter().ConvertAsync(options);
+        });
+
+    /// <summary>
+    /// Maps caller-supplied operation names onto the canonical names in
+    /// <see cref="OperationOrderParser.ToggleOperations"/> (case-insensitive, dashes and
+    /// underscores ignored, so "fix-common-errors" and "fixcommonerrors" both work). An unknown
+    /// name is an error rather than a silent no-op, matching the CLI's strict option parsing.
+    /// </summary>
+    private static List<string> NormalizeOperations(string[]? operations)
+    {
+        var result = new List<string>();
+        if (operations is null)
+        {
+            return result;
+        }
+
+        foreach (var raw in operations)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                continue;
+            }
+
+            var key = raw.Replace("-", string.Empty).Replace("_", string.Empty);
+            var canonical = OperationOrderParser.ToggleOperations
+                .FirstOrDefault(op => op.Equals(key, StringComparison.OrdinalIgnoreCase));
+            if (canonical is null)
+            {
+                throw new ArgumentException(
+                    $"Unknown operation '{raw}'. Valid operations: {string.Join(", ", OperationOrderParser.ToggleOperations)}.");
+            }
+
+            result.Add(canonical);
+        }
+
+        return result;
+    }
+
+    private static void EnsureOperation(List<string> operations, string name)
+    {
+        if (!operations.Contains(name, StringComparer.OrdinalIgnoreCase))
+        {
+            operations.Add(name);
+        }
+    }
+
+    private static CallToolResult Run(Func<object> body)
+    {
+        try
+        {
+            return Ok(body());
+        }
+        catch (Exception ex)
+        {
+            return Error(ex);
+        }
+    }
+
+    private static async Task<CallToolResult> RunAsync(Func<Task<object>> body)
+    {
+        try
+        {
+            return Ok(await body());
+        }
+        catch (Exception ex)
+        {
+            return Error(ex);
+        }
+    }
+
+    private static CallToolResult Ok(object value) => new()
+    {
+        Content = [new TextContentBlock { Text = JsonSerializer.Serialize(value, Json) }],
+    };
+
+    private static CallToolResult Error(Exception ex) => new()
+    {
+        IsError = true,
+        Content = [new TextContentBlock { Text = ex.Message }],
+    };
+}

--- a/src/seconv/Program.cs
+++ b/src/seconv/Program.cs
@@ -121,6 +121,11 @@ internal class Program
             {
                 return RunLintCommand(args.Skip(1).ToArray());
             }
+            if (first.Equals("mcp", StringComparison.OrdinalIgnoreCase))
+            {
+                // MCP server over stdio: from here on stdout carries JSON-RPC frames only.
+                return Mcp.McpServerHost.RunAsync(args.Skip(1).ToArray()).GetAwaiter().GetResult();
+            }
         }
 
         // Capture the raw args so the convert command can recover operation order/repetition

--- a/src/seconv/README.md
+++ b/src/seconv/README.md
@@ -57,6 +57,21 @@ An unrecognised option is an error, never a silent no-op: `seconv` exits 1 and n
 real option rather than converting the file without the operation that was asked for. Exit codes
 are only ever 0 (success) or 1 (any failure).
 
+## MCP server
+
+`seconv mcp` runs the same engine as a [Model Context Protocol](https://modelcontextprotocol.io) server
+over stdio, so an AI client (Claude Desktop, Claude Code, Cursor, ...) can inspect and convert subtitles
+without a shell. Register it as a stdio server:
+
+```json
+{ "mcpServers": { "seconv": { "command": "seconv", "args": ["mcp"] } } }
+```
+
+Tools: `list_formats`, `subtitle_info`, `read_subtitle` (paged paragraphs of any format), `lint_subtitle`,
+`convert_subtitle` (format, encoding, offset, fps, operations such as FixCommonErrors, ...),
+`list_fix_common_errors_rules`, `list_remove_formatting_rules`. Logs go to stderr; add `--verbose` for
+debug output.
+
 ## Full reference
 
 ➡ **[Command Line (seconv) — full reference](../../docs/reference/command-line.md)**

--- a/src/seconv/SeConv.csproj
+++ b/src/seconv/SeConv.csproj
@@ -18,6 +18,10 @@
     <PackageReference Include="Spectre.Console" Version="0.57.2" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
 
+    <!-- `seconv mcp`: Model Context Protocol server over stdio (see Mcp/McpServerHost.cs). -->
+    <PackageReference Include="ModelContextProtocol" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
+
     <!--
       seconv uses SkiaSharp (FixCommonErrors pixel-width measurement, image output) and
       SkiaSharp.HarfBuzz (image text shaping) via libse / libuilogic. The base SkiaSharp /

--- a/tests/seconv/Core/McpToolsTest.cs
+++ b/tests/seconv/Core/McpToolsTest.cs
@@ -1,0 +1,202 @@
+using System.Text.Json;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using SeConv.Mcp;
+using Xunit;
+
+namespace SeConvTests.Core;
+
+public class McpToolsTest : IDisposable
+{
+    private readonly string _tempDir;
+
+    public McpToolsTest()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "seconv-mcp-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, true);
+        }
+    }
+
+    private static JsonElement Payload(CallToolResult result)
+    {
+        Assert.NotEqual(true, result.IsError);
+        var text = Assert.IsType<TextContentBlock>(Assert.Single(result.Content)).Text;
+        return JsonDocument.Parse(text).RootElement;
+    }
+
+    private static string ErrorText(CallToolResult result)
+    {
+        Assert.True(result.IsError);
+        return Assert.IsType<TextContentBlock>(Assert.Single(result.Content)).Text;
+    }
+
+    [Fact]
+    public void ListFormats_FilterMatchesIdNameAndExtension()
+    {
+        var all = Payload(SubtitleTools.ListFormats());
+        Assert.True(all.GetProperty("total").GetInt32() > 300);
+
+        var filtered = Payload(SubtitleTools.ListFormats("subrip"));
+        var ids = filtered.GetProperty("formats").EnumerateArray().Select(f => f.GetProperty("id").GetString()).ToList();
+        Assert.Contains("SubRip", ids);
+        Assert.Equal(ids.Count, filtered.GetProperty("total").GetInt32());
+        Assert.True(ids.Count < all.GetProperty("total").GetInt32());
+    }
+
+    [Fact]
+    public void SubtitleInfo_DetectsFixtureFormat()
+    {
+        var info = Payload(SubtitleTools.SubtitleInfo(Fixtures.Path("test.srt")));
+        Assert.Equal("SubRip", info.GetProperty("format").GetString());
+        Assert.True(info.GetProperty("paragraphCount").GetInt32() > 0);
+    }
+
+    [Fact]
+    public void SubtitleInfo_MissingFile_IsToolError()
+    {
+        var message = ErrorText(SubtitleTools.SubtitleInfo(Path.Combine(_tempDir, "nope.srt")));
+        Assert.Contains("nope.srt", message);
+    }
+
+    [Fact]
+    public void ReadSubtitle_PagesParagraphs()
+    {
+        var path = Fixtures.Path("test.srt");
+        var all = Payload(SubtitleTools.ReadSubtitle(path));
+        var total = all.GetProperty("total").GetInt32();
+        Assert.True(total > 1);
+        Assert.False(all.GetProperty("hasMore").GetBoolean());
+
+        var page = Payload(SubtitleTools.ReadSubtitle(path, start: 2, count: 1));
+        Assert.Equal(1, page.GetProperty("returned").GetInt32());
+        Assert.Equal(total > 2, page.GetProperty("hasMore").GetBoolean());
+        var p = Assert.Single(page.GetProperty("paragraphs").EnumerateArray());
+        Assert.Equal(2, p.GetProperty("number").GetInt32());
+        Assert.True(p.GetProperty("endMs").GetInt64() >= p.GetProperty("startMs").GetInt64());
+        Assert.False(string.IsNullOrEmpty(p.GetProperty("text").GetString()));
+    }
+
+    [Fact]
+    public void LintSubtitle_ReportsOverlap()
+    {
+        var path = Path.Combine(_tempDir, "overlap.srt");
+        File.WriteAllText(path,
+            "1\n00:00:01,000 --> 00:00:05,000\nFirst.\n\n" +
+            "2\n00:00:04,000 --> 00:00:06,000\nSecond.\n");
+
+        var report = Payload(SubtitleTools.LintSubtitle(path));
+        Assert.False(report.GetProperty("isClean").GetBoolean());
+        Assert.Contains(report.GetProperty("issues").EnumerateArray(),
+            i => i.GetProperty("type").GetString() == "overlap");
+    }
+
+    [Fact]
+    public void ListRules_ExposeIds()
+    {
+        var fce = Payload(SubtitleTools.ListFixCommonErrorsRules());
+        Assert.Contains(fce.GetProperty("rules").EnumerateArray(), r => r.GetProperty("id").GetString() == "FixCommas");
+
+        var rf = Payload(SubtitleTools.ListRemoveFormattingRules());
+        Assert.True(rf.GetProperty("total").GetInt32() > 0);
+    }
+
+    [Fact]
+    public async Task ConvertSubtitle_WritesTargetFormatWithOffset()
+    {
+        var result = Payload(await SubtitleTools.ConvertSubtitle(
+            inputs: [Fixtures.Path("test.srt")],
+            format: "webvtt",
+            outputFolder: _tempDir,
+            offset: "00:00:01.000"));
+
+        Assert.True(result.GetProperty("success").GetBoolean());
+        var file = Assert.Single(result.GetProperty("files").EnumerateArray());
+        var output = file.GetProperty("output").GetString()!;
+        Assert.EndsWith(".vtt", output);
+        Assert.True(File.Exists(output));
+
+        var source = Payload(SubtitleTools.ReadSubtitle(Fixtures.Path("test.srt"), count: 1));
+        var converted = Payload(SubtitleTools.ReadSubtitle(output, count: 1));
+        var sourceStart = source.GetProperty("paragraphs")[0].GetProperty("startMs").GetInt64();
+        var convertedStart = converted.GetProperty("paragraphs")[0].GetProperty("startMs").GetInt64();
+        Assert.Equal(sourceStart + 1000, convertedStart);
+    }
+
+    [Fact]
+    public async Task ConvertSubtitle_UnknownOperation_IsToolError()
+    {
+        var message = ErrorText(await SubtitleTools.ConvertSubtitle(
+            inputs: [Fixtures.Path("test.srt")],
+            format: "srt",
+            outputFolder: _tempDir,
+            operations: ["Bogus"]));
+
+        Assert.Contains("Unknown operation 'Bogus'", message);
+        Assert.Empty(Directory.GetFiles(_tempDir));
+    }
+
+    [Fact]
+    public async Task ConvertSubtitle_RuleSelectionImpliesOperation()
+    {
+        var path = Path.Combine(_tempDir, "dots.srt");
+        File.WriteAllText(path, "1\n00:00:01,000 --> 00:00:03,000\n<i>Hello</i> world..\n");
+
+        var result = Payload(await SubtitleTools.ConvertSubtitle(
+            inputs: [path],
+            format: "srt",
+            outputFilename: Path.Combine(_tempDir, "out.srt"),
+            removeFormattingRules: "all"));
+
+        Assert.True(result.GetProperty("success").GetBoolean());
+        var converted = Payload(SubtitleTools.ReadSubtitle(Path.Combine(_tempDir, "out.srt")));
+        var text = converted.GetProperty("paragraphs")[0].GetProperty("text").GetString();
+        Assert.DoesNotContain("<i>", text);
+    }
+
+    [Fact]
+    public async Task StdioServer_ListsToolsAndAnswersCalls()
+    {
+        var dll = Path.Combine(AppContext.BaseDirectory, "seconv.dll");
+        Assert.True(File.Exists(dll), $"seconv.dll not found next to the tests: {dll}");
+
+        var transport = new StdioClientTransport(new StdioClientTransportOptions
+        {
+            Name = "seconv",
+            Command = "dotnet",
+            Arguments = [dll, "mcp"],
+        });
+
+        var ct = TestContext.Current.CancellationToken;
+        await using var client = await McpClient.CreateAsync(transport, cancellationToken: ct);
+        Assert.Equal("seconv", client.ServerInfo.Name);
+
+        var tools = await client.ListToolsAsync(cancellationToken: ct);
+        var names = tools.Select(t => t.Name).ToHashSet();
+        foreach (var expected in new[]
+                 {
+                     "list_formats", "subtitle_info", "read_subtitle", "lint_subtitle",
+                     "convert_subtitle", "list_fix_common_errors_rules", "list_remove_formatting_rules",
+                 })
+        {
+            Assert.Contains(expected, names);
+        }
+
+        var info = await client.CallToolAsync("subtitle_info",
+            new Dictionary<string, object?> { ["path"] = Fixtures.Path("test.vtt") },
+            cancellationToken: ct);
+        var payload = Payload(info);
+        Assert.Equal("WebVTT", payload.GetProperty("format").GetString());
+
+        var failure = await client.CallToolAsync("subtitle_info",
+            new Dictionary<string, object?> { ["path"] = Path.Combine(_tempDir, "missing.srt") },
+            cancellationToken: ct);
+        Assert.Contains("missing.srt", ErrorText(failure));
+    }
+}


### PR DESCRIPTION
## Summary

- New subcommand **`seconv mcp`** runs seconv as an [MCP](https://modelcontextprotocol.io) server over stdio, so AI clients (Claude Desktop/Code, Cursor, ...) can inspect and convert subtitles without a shell: `{"mcpServers":{"seconv":{"command":"seconv","args":["mcp"]}}}`.
- Seven tools, each a thin adapter over the Core helpers the CLI subcommands already use (`SubtitleInfoGatherer`, `SubtitleLinter`, `SubtitleConverter`, `FixCommonErrorsRunner`, ...), so behaviour cannot drift between the two entry points:
  - `list_formats` (optional substring filter), `subtitle_info`, `read_subtitle` (paged paragraphs of any supported format), `lint_subtitle`
  - `convert_subtitle` — format, output folder/name, encoding, overwrite, offset, fps/targetFps, renumber, duration/gap adjustments, delete first/last/contains, `operations`, FixCommonErrors / RemoveFormatting rule specs, container track numbers, OCR engine/language, `timeCodesOnly`, resolution
  - `list_fix_common_errors_rules`, `list_remove_formatting_rules`
- Stdout is reserved for JSON-RPC: `Console.Out` is redirected to stderr and the converter runs quiet; logs go to stderr (`--verbose` for debug level).
- Tool failures return `isError` with the real message (unknown operation, missing file, ...) rather than the SDK's generic placeholder; unknown operations are hard errors, not silent no-ops, matching the CLI's strict parsing.
- Result JSON uses the same field names as the corresponding subcommand's `--json` output.
- `mcp` is listed in `--help`, `--help-json`, the seconv README and `docs/reference/command-line.md`.
- Dependencies: `ModelContextProtocol` 2.2.0, `Microsoft.Extensions.Hosting` 10.0.11 (no trimming/AOT, so reflection-based tool discovery is unaffected by the single-file publish).

## Test plan

- [x] `dotnet build src/seconv/SeConv.csproj` — clean, no warnings
- [x] `dotnet test tests/seconv/SeConvTests.csproj` — 393/393 pass, including 10 new `McpToolsTest` cases (one spawns `dotnet seconv.dll mcp`, lists tools via the MCP client SDK, calls `subtitle_info` on a fixture and on a missing file)
- [ ] Register in Claude Code with `claude mcp add seconv -- <path-to>/seconv mcp`, then ask it to describe an `.srt` and convert it to WebVTT with a 1 s offset — the output file appears and its time codes are shifted
- [ ] `seconv --help` and `seconv --help-json` list `mcp`
- [ ] Existing conversions and subcommands behave exactly as before (no change to any non-`mcp` code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1UEPy85BqcK2D9dHgfymB