### PR TITLE
Fix EBU STL save crash on unquoted font colors and persist the save options

### DIFF
--- a/src/libse/SubtitleFormats/Ebu.cs
+++ b/src/libse/SubtitleFormats/Ebu.cs
@@ -794,20 +794,33 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 if (end > 0)
                 {
                     var f = line.Substring(i, end - i);
-                    if (f.Contains(" color=", StringComparison.OrdinalIgnoreCase))
+                    var colorStart = f.IndexOf(" color=", StringComparison.OrdinalIgnoreCase);
+                    if (colorStart > 1)
                     {
-                        var colorStart = f.IndexOf(" color=", StringComparison.OrdinalIgnoreCase);
-                        if (line.IndexOf('"', colorStart + " color=".Length + 1) > 0)
+                        // The attribute value may be double-quoted, single-quoted or bare
+                        // ("<font color=#ffff00>" is common in SubRip files). The old code
+                        // assumed a closing double quote and crashed the whole save on a
+                        // negative Substring length when there was none.
+                        var color = f.Substring(colorStart + " color=".Length).TrimStart();
+                        if (color.Length > 0 && (color[0] == '"' || color[0] == '\''))
                         {
-                            var colorEnd = f.IndexOf('"', colorStart + " color=".Length + 1);
-                            if (colorStart > 1)
+                            var quote = color[0];
+                            var closingQuote = color.IndexOf(quote, 1);
+                            color = closingQuote > 0 ? color.Substring(1, closingQuote - 1) : color.Substring(1);
+                        }
+                        else
+                        {
+                            var space = color.IndexOf(' ');
+                            if (space > 0)
                             {
-                                var color = f.Substring(colorStart + 7, colorEnd - (colorStart + 7));
-                                color = color.Trim('\'');
-                                color = color.Trim('\"');
-                                color = color.Trim('#');
-                                return GetNearestEbuColorCodeByte(color, encoding);
+                                color = color.Substring(0, space);
                             }
+                        }
+
+                        color = color.Trim().Trim('#');
+                        if (color.Length > 0)
+                        {
+                            return GetNearestEbuColorCodeByte(color, encoding);
                         }
                     }
                 }

--- a/src/ui/Features/Files/ExportEbuStl/ExportEbuStlViewModel.cs
+++ b/src/ui/Features/Files/ExportEbuStl/ExportEbuStlViewModel.cs
@@ -294,17 +294,28 @@ new("2F", "French - hearing impaired (VF-MAL)"),
             SelectedCharacterTable = CharacterTables[0];
             SelectedLanguageCode = LanguageCodes.FirstOrDefault(p => p.Language == "English");
             SelectedTimeCodeStatus = TimeCodeStatusList[1];
-            SelectedJustification = Justifications[1];
             SelectedRevisionNumber = 1;
             SelectedMaxCharactersPerRow = 40;
             SelectedMaxRow = 23;
             SelectedDiscSequenceNumber = 1;
             SelectedTotalNumberOfDiscs = 1;
-            SelectedTopAlignment = 0;
-            SelectedBottomAlignment = 2;
-            SelectedRowsAddByNewLine = 2;
-            UseBox = Configuration.Settings.SubtitleSettings.EbuStlTeletextUseBox;
-            UseDoubleHeight = Configuration.Settings.SubtitleSettings.EbuStlTeletextUseDoubleHeight;
+
+            // Text-and-timing options do not fit in the STL header the dialog stores on the
+            // subtitle, so they are restored from the last choice - without this every reopen
+            // fell back to left-justified text and default margins (user report). Justification
+            // comes from the persisted settings; the layout values come from libse's Configuration,
+            // which the persisted settings seed at startup and a loaded STL file may override
+            // (box/double height are read off the file).
+            var justification = Se.Settings.File.EbuSaveOptions.JustificationCode;
+            SelectedJustification = justification >= 0 && justification < Justifications.Count
+                ? Justifications[justification]
+                : Justifications[2];
+            var subtitleSettings = Configuration.Settings.SubtitleSettings;
+            SelectedTopAlignment = TopAlignments.Contains(subtitleSettings.EbuStlMarginTop) ? subtitleSettings.EbuStlMarginTop : 0;
+            SelectedBottomAlignment = BottomAlignments.Contains(subtitleSettings.EbuStlMarginBottom) ? subtitleSettings.EbuStlMarginBottom : 2;
+            SelectedRowsAddByNewLine = RowsAddByNewLine.Contains(subtitleSettings.EbuStlNewLineRows) ? subtitleSettings.EbuStlNewLineRows : 2;
+            UseBox = subtitleSettings.EbuStlTeletextUseBox;
+            UseDoubleHeight = subtitleSettings.EbuStlTeletextUseDoubleHeight;
 
             // Keep the settings the file was written with instead of resetting them to the
             // defaults above every time the export dialog is opened.
@@ -414,6 +425,17 @@ new("2F", "French - hearing impaired (VF-MAL)"),
         Configuration.Settings.SubtitleSettings.EbuStlNewLineRows = SelectedRowsAddByNewLine ?? 1;
         Configuration.Settings.SubtitleSettings.EbuStlTeletextUseBox = UseBox;
         Configuration.Settings.SubtitleSettings.EbuStlTeletextUseDoubleHeight = UseDoubleHeight;
+
+        // The libse Configuration above only lives for this session; the persisted settings are
+        // what Initialize restores from and what UpdateLibSeSettings re-applies on the next start.
+        var ebuOptions = Se.Settings.File.EbuSaveOptions;
+        ebuOptions.JustificationCode = JustificationCode;
+        ebuOptions.MarginTop = SelectedTopAlignment ?? 0;
+        ebuOptions.MarginBottom = SelectedBottomAlignment ?? 0;
+        ebuOptions.NewLineRows = SelectedRowsAddByNewLine ?? 1;
+        ebuOptions.TeletextUseBox = UseBox;
+        ebuOptions.TeletextUseDoubleHeight = UseDoubleHeight;
+        Se.SaveSettings();
 
         if (_subtitle != null)
         {

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -4522,7 +4522,28 @@ public partial class MainViewModel :
             return;
         }
 
-        format.Save(fileName, GetUpdateSubtitle());
+        try
+        {
+            // A failed write must surface as an error dialog: an exception out of an async command
+            // dies silently, which read as "Save does nothing" in the field (unquoted font colors
+            // used to throw here).
+            if (!format.Save(fileName, GetUpdateSubtitle()))
+            {
+                await MessageBox.Show(Window!, Se.Language.General.Error,
+                    string.Format(Se.Language.General.CouldNotSaveFileXErrorY, fileName, string.Empty),
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+        }
+        catch (Exception ex)
+        {
+            SeLogger.Error(ex, "Export to EBU STL failed for " + fileName);
+            await MessageBox.Show(Window!, Se.Language.General.Error,
+                string.Format(Se.Language.General.CouldNotSaveFileXErrorY, fileName, ex.Message),
+                MessageBoxButtons.OK, MessageBoxIcon.Error);
+            return;
+        }
+
         ShowStatus(string.Format(Se.Language.Main.FileExportedInFormatXToFileY, format.Name, fileName));
     }
 

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -460,6 +460,12 @@ public class Se
         MigrateMacOsFontSettings(Settings.Appearance, OperatingSystem.IsMacOS(), true);
 
         UpdateLibSeSettings();
+
+        // Startup-only: the libse mirror of these is session truth - Ebu.LoadSubtitle re-seeds it
+        // from every loaded STL file - so the persisted values may only win before any file is
+        // open (see the note in UpdateLibSeSettings).
+        Configuration.Settings.SubtitleSettings.EbuStlTeletextUseBox = Settings.File.EbuSaveOptions.TeletextUseBox;
+        Configuration.Settings.SubtitleSettings.EbuStlTeletextUseDoubleHeight = Settings.File.EbuSaveOptions.TeletextUseDoubleHeight;
     }
 
     internal static void MigrateMacOsFontSettings(SeAppearance appearance, bool isMacOs, bool isLegacySettings)
@@ -785,6 +791,17 @@ public class Se
 
         var dc = Settings.File.DCinemaSmpte;
         var ss = Configuration.Settings.SubtitleSettings;
+
+        // Ebu.Save reads these off the libse Configuration singleton, so a plain "Save" that
+        // never opens the EBU save options dialog must still see the persisted choices. The
+        // teletext box/double-height flags are deliberately NOT re-applied here: Ebu.LoadSubtitle
+        // seeds them from the loaded file, and this sync runs after every SaveSettings - it would
+        // clobber the file's flags. They are applied once at startup in LoadSettings instead.
+        var ebu = Settings.File.EbuSaveOptions;
+        ss.EbuStlMarginTop = ebu.MarginTop;
+        ss.EbuStlMarginBottom = ebu.MarginBottom;
+        ss.EbuStlNewLineRows = ebu.NewLineRows;
+
         ss.WebVttUseXTimestampMap = Settings.Formats.WebVttUseXTimestampMap;
         ss.WebVttUseMultipleXTimestampMap = Settings.Formats.WebVttUseMultipleXTimestampMap;
         ss.WebVttMergeLinesWithSameText = Settings.Formats.WebVttMergeLinesWithSameText;

--- a/src/ui/Logic/Config/SeEbuSaveOptions.cs
+++ b/src/ui/Logic/Config/SeEbuSaveOptions.cs
@@ -1,0 +1,19 @@
+namespace Nikse.SubtitleEdit.Logic.Config;
+
+/// <summary>
+/// EBU STL save options that live outside the 1024-character GSI header stored on the subtitle:
+/// the justification code is written per TTI block, and the layout values are read from libse's
+/// Configuration singleton by <c>Ebu.Save</c>. Persisting them here is what makes the choices in
+/// the save options dialog survive both reopening the dialog and restarting the application.
+/// </summary>
+public class SeEbuSaveOptions
+{
+    /// <summary>0=unchanged, 1=left, 2=centered, 3=right - centered is the broadcast default.</summary>
+    public int JustificationCode { get; set; } = 2;
+
+    public int MarginTop { get; set; } = 0;
+    public int MarginBottom { get; set; } = 2;
+    public int NewLineRows { get; set; } = 2;
+    public bool TeletextUseBox { get; set; } = true;
+    public bool TeletextUseDoubleHeight { get; set; } = true;
+}

--- a/src/ui/Logic/Config/SeFile.cs
+++ b/src/ui/Logic/Config/SeFile.cs
@@ -14,6 +14,7 @@ public class SeFile
     public SeExportImages ExportImages { get; set; } = new();
     public SeExportPlainText ExportPlainText { get; set; } = new();
     public SeDCinemaSmpte DCinemaSmpte { get; set; } = new();
+    public SeEbuSaveOptions EbuSaveOptions { get; set; } = new();
 
     public SeFile()
     {

--- a/src/ui/Logic/UiEbuSaveHelper.cs
+++ b/src/ui/Logic/UiEbuSaveHelper.cs
@@ -1,5 +1,6 @@
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Logic.Config;
 
 namespace Nikse.SubtitleEdit.Logic;
  
@@ -12,12 +13,16 @@ namespace Nikse.SubtitleEdit.Logic;
 /// </summary>
 public class UiEbuSaveHelper : Ebu.IEbuUiHelper
 {
-    private byte _justificationCode = 2;
+    private byte _justificationCode;
     private string? _frameRateHeader;
     private double _frameRate;
 
     public UiEbuSaveHelper()
     {
+        // A save that never went through the options dialog (e.g. Ctrl+S on a loaded STL file)
+        // still uses the justification the user last picked; 2 (centered) on a fresh install.
+        var justification = Se.Settings.File.EbuSaveOptions.JustificationCode;
+        _justificationCode = justification >= 0 && justification <= 3 ? (byte)justification : (byte)2;
     }
 
     /// <summary>

--- a/tests/UI/Features/Files/EbuSaveOptionsPersistenceTests.cs
+++ b/tests/UI/Features/Files/EbuSaveOptionsPersistenceTests.cs
@@ -1,0 +1,194 @@
+using System.Text;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Files.Export.ExportEbuStl;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace UITests.Features.Files;
+
+/// <summary>
+/// The justification code and the layout values (margins, rows per line break, teletext box /
+/// double height) are the EBU STL save options that do not fit in the 1024-character GSI header
+/// stored on the subtitle. They used to be reset to hard-coded defaults every time the save
+/// options dialog opened, so "Centered text" silently became "Left-justified text" on reopen
+/// (reported by email against 5.2.0-beta24). They are persisted in Se.Settings now.
+/// </summary>
+public class EbuSaveOptionsPersistenceTests
+{
+    public EbuSaveOptionsPersistenceTests()
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+    }
+
+    private static string[] ScopePaths => new[]
+    {
+        "File.EbuSaveOptions.JustificationCode",
+        "File.EbuSaveOptions.MarginTop",
+        "File.EbuSaveOptions.MarginBottom",
+        "File.EbuSaveOptions.NewLineRows",
+        "File.EbuSaveOptions.TeletextUseBox",
+        "File.EbuSaveOptions.TeletextUseDoubleHeight",
+    };
+
+    /// <summary>
+    /// The dialog's OK also writes into libse's Configuration singleton (the values Ebu.Save
+    /// reads), which SettingsScope does not cover - snapshot and restore that side too, or a
+    /// margin left behind here changes what every later EBU test writes.
+    /// </summary>
+    private sealed class LibSeEbuScope : IDisposable
+    {
+        private readonly int _marginTop = Configuration.Settings.SubtitleSettings.EbuStlMarginTop;
+        private readonly int _marginBottom = Configuration.Settings.SubtitleSettings.EbuStlMarginBottom;
+        private readonly int _newLineRows = Configuration.Settings.SubtitleSettings.EbuStlNewLineRows;
+        private readonly bool _useBox = Configuration.Settings.SubtitleSettings.EbuStlTeletextUseBox;
+        private readonly bool _useDoubleHeight = Configuration.Settings.SubtitleSettings.EbuStlTeletextUseDoubleHeight;
+
+        public void Dispose()
+        {
+            Configuration.Settings.SubtitleSettings.EbuStlMarginTop = _marginTop;
+            Configuration.Settings.SubtitleSettings.EbuStlMarginBottom = _marginBottom;
+            Configuration.Settings.SubtitleSettings.EbuStlNewLineRows = _newLineRows;
+            Configuration.Settings.SubtitleSettings.EbuStlTeletextUseBox = _useBox;
+            Configuration.Settings.SubtitleSettings.EbuStlTeletextUseDoubleHeight = _useDoubleHeight;
+        }
+    }
+
+    private static Subtitle MakeSubtitle()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Hello world", 1000, 3000));
+        return subtitle;
+    }
+
+    private static ExportEbuStlViewModel OpenDialog(Subtitle subtitle)
+    {
+        var viewModel = new ExportEbuStlViewModel(new FileHelper());
+        viewModel.Initialize(subtitle);
+        Dispatcher.UIThread.RunJobs();
+        return viewModel;
+    }
+
+    [AvaloniaFact]
+    public void Justification_DefaultsToCentered()
+    {
+        using var scope = new SettingsScope(ScopePaths);
+        using var libSeScope = new LibSeEbuScope();
+        Se.Settings.File.EbuSaveOptions.JustificationCode = new SeEbuSaveOptions().JustificationCode;
+
+        var viewModel = OpenDialog(MakeSubtitle());
+
+        Assert.Equal(viewModel.Justifications[2], viewModel.SelectedJustification); // centered
+    }
+
+    [AvaloniaFact]
+    public void Justification_SurvivesReopeningTheDialog()
+    {
+        using var scope = new SettingsScope(ScopePaths);
+        using var libSeScope = new LibSeEbuScope();
+        var subtitle = MakeSubtitle();
+
+        var viewModel = OpenDialog(subtitle);
+        viewModel.SelectedJustification = viewModel.Justifications[3]; // right-justified
+        viewModel.OkCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+
+        var reopened = OpenDialog(subtitle);
+
+        Assert.Equal(reopened.Justifications[3], reopened.SelectedJustification);
+    }
+
+    [AvaloniaFact]
+    public void LayoutOptions_SurviveReopeningTheDialog()
+    {
+        using var scope = new SettingsScope(ScopePaths);
+        using var libSeScope = new LibSeEbuScope();
+        var subtitle = MakeSubtitle();
+
+        var viewModel = OpenDialog(subtitle);
+        viewModel.SelectedTopAlignment = 1;
+        viewModel.SelectedBottomAlignment = 4;
+        viewModel.SelectedRowsAddByNewLine = 1;
+        viewModel.UseBox = false;
+        viewModel.UseDoubleHeight = false;
+        viewModel.OkCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+
+        var reopened = OpenDialog(subtitle);
+
+        Assert.Equal(1, reopened.SelectedTopAlignment);
+        Assert.Equal(4, reopened.SelectedBottomAlignment);
+        Assert.Equal(1, reopened.SelectedRowsAddByNewLine);
+        Assert.False(reopened.UseBox);
+        Assert.False(reopened.UseDoubleHeight);
+    }
+
+    // The justification travels to the writer on the UI helper, not in the stored header - a save
+    // that never opens the dialog (Ctrl+S on a loaded STL file) must still use the persisted pick.
+    [AvaloniaFact]
+    public void FreshSaveHelper_UsesThePersistedJustification()
+    {
+        using var scope = new SettingsScope(ScopePaths);
+        using var libSeScope = new LibSeEbuScope();
+        Se.Settings.File.EbuSaveOptions.JustificationCode = 3;
+
+        Assert.Equal(3, new UiEbuSaveHelper().JustificationCode);
+    }
+
+    [AvaloniaFact]
+    public void ChosenJustification_ReachesTheSavedTtiBlock()
+    {
+        using var scope = new SettingsScope(ScopePaths);
+        using var libSeScope = new LibSeEbuScope();
+        var subtitle = MakeSubtitle();
+
+        var viewModel = OpenDialog(subtitle);
+        viewModel.SelectedJustification = viewModel.Justifications[2]; // centered
+        viewModel.OkCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+
+        Ebu.EbuUiHelper = new UiEbuSaveHelper { JustificationCode = viewModel.JustificationCode };
+
+        var bytes = SaveToBytes(subtitle);
+
+        Assert.Equal(2, bytes[1024 + 14]); // TTI justification code
+    }
+
+    // Cross-restart persistence rides on the source-generated JSON context picking the new
+    // settings type up transitively from the root.
+    [Fact]
+    public void EbuSaveOptions_RoundTripThroughSettingsJson()
+    {
+        var settings = new Se();
+        settings.File.EbuSaveOptions.JustificationCode = 3;
+        settings.File.EbuSaveOptions.MarginBottom = 4;
+        settings.File.EbuSaveOptions.TeletextUseBox = false;
+
+        var json = System.Text.Json.JsonSerializer.Serialize(settings, SeJsonContext.Default.Se);
+        var back = System.Text.Json.JsonSerializer.Deserialize(json, SeJsonContext.Default.Se)!;
+
+        Assert.Equal(3, back.File.EbuSaveOptions.JustificationCode);
+        Assert.Equal(4, back.File.EbuSaveOptions.MarginBottom);
+        Assert.False(back.File.EbuSaveOptions.TeletextUseBox);
+    }
+
+    internal static byte[] SaveToBytes(Subtitle subtitle)
+    {
+        var fileName = Path.Combine(Path.GetTempPath(), "ebu-options-test-" + Guid.NewGuid() + ".stl");
+        try
+        {
+            Assert.True(new Ebu().Save(fileName, subtitle));
+            return File.ReadAllBytes(fileName);
+        }
+        finally
+        {
+            if (File.Exists(fileName))
+            {
+                File.Delete(fileName);
+            }
+        }
+    }
+}

--- a/tests/UI/Features/Files/ExportEbuStlHeaderTests.cs
+++ b/tests/UI/Features/Files/ExportEbuStlHeaderTests.cs
@@ -230,6 +230,23 @@ public class ExportEbuStlHeaderTests
         Assert.Equal("23.976", reopened.SelectedFrameRate);
     }
 
+    // An unquoted font color plus a quotation mark later in the line crashed the writer with
+    // "length ('-13') must be a non-negative value", so File > Export > EBU STL silently produced
+    // no file at all (reported by email against 5.2.0-beta24).
+    [AvaloniaFact]
+    public void UnquotedFontColor_TeletextExport_WritesTheFile()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("<font color=#ffff00>Er sagte \"Hallo\" zu mir</font>", 1000, 3000));
+
+        var bytes = SaveViaDialog(subtitle, vm =>
+        {
+            vm.SelectedDisplayStandardCode = vm.DisplayStandardCodes[1]; // Level-1 teletext
+        });
+
+        Assert.True(bytes.Length >= 1024 + 128);
+    }
+
     // The frame rate list is written with invariant decimal points, so it must not be read back
     // with the UI culture: in a comma-decimal culture "23.976" parsed as 23976 and the pick was
     // dropped on the floor.

--- a/tests/libse/SubtitleFormats/EbuTest.cs
+++ b/tests/libse/SubtitleFormats/EbuTest.cs
@@ -176,4 +176,34 @@ public class EbuTest
         Assert.False(Configuration.Settings.SubtitleSettings.EbuStlTeletextUseBox);
         Assert.False(Configuration.Settings.SubtitleSettings.EbuStlTeletextUseDoubleHeight);
     }
+
+    // The teletext color writer assumed the font tag's color value ends with a double quote and
+    // took a Substring up to it. For an unquoted value ("<font color=#ffff00>" is common in
+    // SubRip files) with any double quote later in the line - a quotation in the dialogue - that
+    // Substring length came out as -13 and the whole save crashed, so no STL file was written at
+    // all (reported by email against 5.2.0-beta24 as "The value -13 must be positive").
+    [Theory]
+    [InlineData("<font color=#ffff00>He said \"hello\" to me</font>")]
+    [InlineData("<font color='#ffff00'>He said \"hello\" to me</font>")]
+    [InlineData("<font color=\"#ffff00\">He said \"hello\" to me</font>")]
+    [InlineData("<font color=yellow size=\"12\">He said hello</font>")]
+    public void TeletextSave_FontColorValueQuotingVariants_AllWriteTheColor(string text)
+    {
+        Ebu.EbuUiHelper = new TestEbuUiHelper();
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph(text, 1000, 3000));
+
+        var header = new Ebu.EbuGeneralSubtitleInformation { DisplayStandardCode = "1" };
+        using var ms = new MemoryStream();
+        var ok = new Ebu().Save("test.stl", ms, subtitle, batchMode: true, header);
+        var bytes = ms.ToArray();
+
+        Assert.True(ok);
+        Assert.True(bytes.Length >= 1024 + 128, "no TTI block was written");
+
+        // Yellow's teletext color code must sit in the TTI text field (offset 16..127).
+        var textField = new byte[112];
+        Array.Copy(bytes, 1024 + 16, textField, 0, 112);
+        Assert.Contains((byte)0x03, textField);
+    }
 }


### PR DESCRIPTION
Two bugs reported by email (Sebastian) against 5.2.0-beta24.

## 1. "The STL is not being saved" / "The value -13 must be positive"

`Ebu.EbuTextTimingInformation.GetColorByte` assumed the font tag's color value ends with a closing double quote:

- For an unquoted value — `<font color=#ffff00>`, common in SubRip files — with any double quote later in the line (a quotation in the dialogue), the guard passed (it searched the whole *line* for a quote, not the tag) and the `Substring` length came out as `-1 - 12 =` **exactly -13**, matching the reported error verbatim: `length ('-13') must be a non-negative value`.
- The crash killed the whole save, so File > Export > EBU STL produced **no file at all**, and the async command swallowed the exception — "nothing happens".

Fixes:
- `GetColorByte` now parses double-quoted, single-quoted and bare color values (also cutting at a following attribute) and never throws.
- `ExportEbuStl` wraps the save in try/catch and shows an error dialog instead of dying silently if a save ever fails again.

## 2. "The centered position is not being saved — it is set back to left"

The justification code and the layout values (margins, rows per line break, teletext box / double height) do not fit in the 1024-character STL header the dialog stores on the subtitle, and the dialog reset them to hard-coded defaults on every open — so "Centered text" always came back as "Left-justified text".

Fixes:
- New persisted `File.EbuSaveOptions` settings section (justification, margins, new-line rows, box, double height); the dialog restores from it on open and saves on OK.
- Justification defaults to **centered** like SE 4 (also requested in the report), and a fresh `UiEbuSaveHelper` (plain Ctrl+S on a loaded STL, no dialog) uses the persisted pick.
- Margins/new-line rows are re-applied to libse in `UpdateLibSeSettings`; the teletext box/double-height flags are applied **only at startup**, because `Ebu.LoadSubtitle` seeds them from every loaded STL file and re-applying on every settings save would clobber the file's flags (guarded by the existing `EbuStl_Load_SeedsBoxAndDoubleHeightFromFile` test).

## Tests

- libse: quoting-variant theory reproducing the -13 crash and asserting the yellow teletext color code reaches the TTI text field.
- UI: end-to-end export repro of the reported crash; justification defaults to centered; justification + layout options survive reopening the dialog; fresh save helper uses the persisted justification; chosen justification reaches TTI byte 14; settings JSON round-trip.

Suites: libse 1490 ✅, seconv 383 ✅, UI 4037/4038 ✅ (single failure is the known-flaky `LibMpvEventLoopTests.Play_ObservedTimePosAdvances`, passes in isolation, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)