### PR TITLE
seconv: add --translate-prompt for the LLM translate engines

### DIFF
--- a/docs/features/auto-translate.md
+++ b/docs/features/auto-translate.md
@@ -94,6 +94,9 @@ the source. Set the model's temperature to 0 where the engine offers it. Curated
 the llama.cpp engine's download list carry this prompt already; for LM Studio, KoboldCpp, Ollama or
 your own OpenAI-compatible server, paste it into the engine's prompt field.
 
+Headless runs take the same prompt via `seconv --translate-prompt:<text|file>` — see
+[Auto-translate (command line)](../reference/command-line.md#custom-prompt).
+
 ## Engine Configuration
 
 Depending on the selected engine, you may need to provide:

--- a/docs/reference/command-line.md
+++ b/docs/reference/command-line.md
@@ -303,6 +303,7 @@ Translated output is named with the target language code — `way.srt --translat
 | `--translate-engine:<engine>` | `llamacpp` (default) \| `ollama` \| `lmstudio` \| `libretranslate` \| `nllb-serve` \| `nllb-api` |
 | `--translate-url:<url>` | Endpoint of an already-running translate server. For `llamacpp` this skips the local server auto-start; a bare `host:port` is completed to `/v1/chat/completions`. |
 | `--translate-model:<model>` | `ollama`/`lmstudio`: model name. `llamacpp`: a `.gguf` file name from the models folder or a full path (default: the first installed translate model). |
+| `--translate-prompt:<text\|file>` | Prompt for `llamacpp` / `ollama` / `lmstudio` — inline text or a path to a text file. See [Custom prompt](#custom-prompt) below. |
 
 **llama.cpp (default engine).** With no `--translate-url`, seconv runs a local `llama-server` for you: it looks for the binary in Subtitle Edit's data folder (`llama.cpp` next to `seconv`, then `%AppData%\Subtitle Edit\llama.cpp` / `~/Library/Application Support/Subtitle Edit/llama.cpp` / `~/.config/Subtitle Edit/llama.cpp`) and falls back to `llama-server` on `PATH`. The server is started on a free localhost port with the model's correct chat-template flags and stopped again when seconv exits. Models resolve against the data folder's `models` subfolder.
 
@@ -329,13 +330,54 @@ seconv movie.srt subrip --translate-to:da --translate-engine:ollama --translate-
 seconv movie.sup subrip --ocr-engine:tesseract --ocr-language:eng --translate-to:de
 ```
 
+#### Custom prompt
+
+`--translate-prompt` is the command-line equivalent of the prompt field the GUI offers for the
+local-LLM engines (see [Prompts: chat models and completion models](../features/auto-translate.md#prompts-chat-models-and-completion-models)).
+It applies to `llamacpp`, `ollama` and `lmstudio`; the translation services (`libretranslate`,
+`nllb-serve`, `nllb-api`) have no prompt, and passing it to them is an error rather than a silent
+no-op.
+
+The same placeholders as in the GUI are substituted: `{0}` = source language, `{1}` = target
+language (both as English names, e.g. `English` / `German`). A prompt that also contains `{2}` is a
+*completion template*: the subtitle text is placed at `{2}` and the filled-in block is sent as-is,
+which is what raw-completion translation models such as MiLMMT-46 are trained on.
+
+The value is either inline text or the path to a text file. A value that names an existing file, or
+that ends in `.txt` / `.prompt` / `.md`, is read from disk — the practical way to pass a multi-line
+completion template. In inline text, `\n` (also `\r`, `\t`, `\\`) is unescaped, so a short template
+still fits on one command line.
+
+```bash
+# Inline instruction prompt
+seconv movie.srt subrip --translate-to:de \
+  --translate-prompt:"Translate from {0} to {1}. Keep the line breaks. Use informal address. Output only the translation:"
+
+# Completion template, inline
+seconv movie.srt subrip --translate-to:da --translate-prompt:"Translate this from {0} to {1}:\n{0}: {2}\n{1}:"
+
+# The same, from a file (recommended for anything multi-line)
+seconv movie.srt subrip --translate-to:da --translate-prompt:milmmt.prompt
+
+# Ollama / LM Studio take the same option
+seconv movie.srt subrip --translate-to:da --translate-engine:ollama --translate-model:gemma2 \
+  --translate-prompt:my-prompt.txt
+```
+
+Precedence for `llamacpp`, highest first: `--translate-prompt`, then a curated model's own trained
+prompt (MiLMMT-46, Hy-MT2 — applied automatically when that model is selected), then
+`tools.llamaCppPrompt` from a `--settings` file, then the built-in default. `--translate-prompt`
+deliberately overrides the curated template too: an option given on the command line must never be
+a no-op. `ollama` and `lmstudio` have no per-model template, so it is simply
+`--translate-prompt` > `--settings` > built-in default.
+
 ### Templates / replacements
 
 | Option | Description |
 |---|---|
 | `--multiple-replace:<path>` | Multiple-replace rules applied per paragraph after operations. Accepts the legacy SE *MultipleSearchAndReplaceGroups* XML **and** the file the SE5 GUI exports from *Tools → Multiple replace → export* — either `.template` (JSON) or `.csv`. Supports case-insensitive, `CaseSensitive`, and `RegularExpression` rules; only active rules are applied. The format is chosen by extension, then by content |
 | `--custom-format:<path.xml>` | SE *CustomFormatItem* XML (use with `--format customtext`) |
-| `--settings:<path.json>` | JSON file overlaying `Configuration.Settings` (general / tools / removeTextForHearingImpaired) plus image-output styling (exportImages). Optional `profiles` map for named overlays |
+| `--settings:<path.json>` | JSON file overlaying `Configuration.Settings` (general / tools / removeTextForHearingImpaired) plus image-output styling (exportImages). Optional `profiles` map for named overlays. The `tools` section also carries the auto-translate prompts (`llamaCppPrompt`, `ollamaPrompt`, `lmStudioPrompt`), so a `profiles` entry can hold a per-target-language prompt |
 | `--profile:<name>` | Selects a named overlay from the settings file's `profiles` map. Requires `--settings` |
 
 #### Multiple-replace rule files

--- a/src/seconv/Commands/ConvertCommand.cs
+++ b/src/seconv/Commands/ConvertCommand.cs
@@ -159,6 +159,10 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
         [Description("Translate model: ollama/lmstudio model name, or llamacpp .gguf file name/path (default: first downloaded translate model)")]
         public string? TranslateModel { get; init; }
 
+        [CommandOption("--translate-prompt|--translateprompt")]
+        [Description("Prompt for llamacpp/ollama/lmstudio: inline text (\\n = line break) or a path to a text file; {0}=source language, {1}=target language, {2}=the text (completion-format models)")]
+        public string? TranslatePrompt { get; init; }
+
         [CommandOption("--offset")]
         [Description("Offset time (hh:mm:ss:ms)")]
         public string? Offset { get; init; }
@@ -440,9 +444,10 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 (!string.IsNullOrWhiteSpace(settings.TranslateFrom) ||
                  !string.IsNullOrWhiteSpace(settings.TranslateEngine) ||
                  !string.IsNullOrWhiteSpace(settings.TranslateUrl) ||
-                 !string.IsNullOrWhiteSpace(settings.TranslateModel)))
+                 !string.IsNullOrWhiteSpace(settings.TranslateModel) ||
+                 !string.IsNullOrWhiteSpace(settings.TranslatePrompt)))
             {
-                return Fail(settings, "--translate-from/--translate-engine/--translate-url/--translate-model require --translate-to:<language>.");
+                return Fail(settings, "--translate-from/--translate-engine/--translate-url/--translate-model/--translate-prompt require --translate-to:<language>.");
             }
 
             if (!string.IsNullOrWhiteSpace(settings.TranslateEngine) &&
@@ -453,6 +458,29 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                     settings,
                     $"Translate engine '{settings.TranslateEngine}' is not supported (pass via --translate-engine). " +
                     $"Use one of: {string.Join(", ", AutoTranslateRunner.SupportedEngines)}.");
+            }
+
+            // --translate-prompt only means something to the LLM engines; the translation
+            // services have no prompt at all. Fail instead of silently ignoring it, and read
+            // the prompt (it may be a file) up front so a typo'd path never costs a conversion.
+            if (!string.IsNullOrWhiteSpace(settings.TranslatePrompt))
+            {
+                if (!AutoTranslateRunner.SupportsPrompt(settings.TranslateEngine))
+                {
+                    return Fail(
+                        settings,
+                        $"--translate-prompt is not supported by translate engine '{settings.TranslateEngine}'. " +
+                        $"Use one of: {string.Join(", ", AutoTranslateRunner.PromptEngines)}.");
+                }
+
+                try
+                {
+                    AutoTranslateRunner.ReadPromptOption(settings.TranslatePrompt);
+                }
+                catch (Exception ex)
+                {
+                    return Fail(settings, ex.Message);
+                }
             }
 
             // Fail fast on a typo in --encoding so we don't silently substitute UTF-8 and
@@ -713,6 +741,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 TranslateEngine = settings.TranslateEngine,
                 TranslateUrl = settings.TranslateUrl,
                 TranslateModel = settings.TranslateModel,
+                TranslatePrompt = settings.TranslatePrompt,
                 TeletextOnly = settings.TeletextOnly,
                 TeletextOnlyPage = settings.TeletextOnlyPage,
                 Quiet = silent,
@@ -755,7 +784,8 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
             {
                 var translateEngine = string.IsNullOrWhiteSpace(settings.TranslateEngine) ? "llamacpp" : settings.TranslateEngine.Trim().ToLowerInvariant();
                 var translateFrom = string.IsNullOrWhiteSpace(settings.TranslateFrom) ? "auto" : settings.TranslateFrom;
-                table.AddRow("Translate", $"{translateFrom} -> {settings.TranslateTo} ({translateEngine})");
+                var customPrompt = string.IsNullOrWhiteSpace(settings.TranslatePrompt) ? string.Empty : ", custom prompt";
+                table.AddRow("Translate", $"{translateFrom} -> {settings.TranslateTo} ({translateEngine}{customPrompt})");
             }
 
             if (settings.DeleteFirst.HasValue)

--- a/src/seconv/Core/AutoTranslateRunner.cs
+++ b/src/seconv/Core/AutoTranslateRunner.cs
@@ -20,9 +20,21 @@ internal sealed class AutoTranslateRunner
 {
     public static readonly string[] SupportedEngines = { "llamacpp", "ollama", "lmstudio", "libretranslate", "nllb-serve", "nllb-api" };
 
+    /// <summary>
+    /// Engines that build their request from an editable prompt, i.e. the ones
+    /// <c>--translate-prompt</c> can steer. The rest (LibreTranslate, NLLB) are translation
+    /// services with no prompt at all.
+    /// </summary>
+    public static readonly string[] PromptEngines = { "llamacpp", "ollama", "lmstudio" };
+
+    /// <summary>File extensions that make <c>--translate-prompt</c> a file path rather than inline text.</summary>
+    private static readonly string[] PromptFileExtensions = { ".txt", ".prompt", ".md" };
+
     private readonly ConversionOptions _options;
     private readonly IAutoTranslator _translator;
     private readonly LlamaCppModel? _llamaCppModel; // non-null = local server mode; start before first use
+    private readonly string _engine;
+    private readonly string? _prompt; // --translate-prompt, already read from file / unescaped
 
     /// <summary>The resolved local llama.cpp model, exposed for tests.</summary>
     internal LlamaCppModel? LlamaCppModel => _llamaCppModel;
@@ -54,11 +66,13 @@ internal sealed class AutoTranslateRunner
         }
     }
 
-    private AutoTranslateRunner(ConversionOptions options, IAutoTranslator translator, LlamaCppModel? llamaCppModel)
+    private AutoTranslateRunner(ConversionOptions options, IAutoTranslator translator, LlamaCppModel? llamaCppModel, string engine, string? prompt)
     {
         _options = options;
         _translator = translator;
         _llamaCppModel = llamaCppModel;
+        _engine = engine;
+        _prompt = prompt;
     }
 
     /// <summary>
@@ -69,10 +83,16 @@ internal sealed class AutoTranslateRunner
     /// </summary>
     public static AutoTranslateRunner Create(ConversionOptions options)
     {
-        var engine = string.IsNullOrWhiteSpace(options.TranslateEngine) ? "llamacpp" : options.TranslateEngine.Trim().ToLowerInvariant();
+        var engine = NormalizeEngine(options.TranslateEngine);
         var url = options.TranslateUrl?.Trim();
         var tools = Configuration.Settings.Tools;
         LlamaCppModel? llamaCppModel = null;
+        var prompt = ReadPromptOption(options.TranslatePrompt);
+        if (prompt != null && !SupportsPrompt(engine))
+        {
+            throw new InvalidOperationException(
+                $"--translate-prompt is not supported by translate engine '{engine}'. Use one of: {string.Join(", ", PromptEngines)}.");
+        }
 
         if (options.Verbose)
         {
@@ -82,7 +102,7 @@ internal sealed class AutoTranslateRunner
         IAutoTranslator translator;
         switch (engine)
         {
-            case "llamacpp" or "llama.cpp" or "llama":
+            case "llamacpp":
                 translator = new LlamaCppTranslate();
                 if (!string.IsNullOrEmpty(url))
                 {
@@ -106,6 +126,10 @@ internal sealed class AutoTranslateRunner
                 {
                     tools.OllamaModel = options.TranslateModel.Trim();
                 }
+                if (prompt != null)
+                {
+                    tools.OllamaPrompt = prompt;
+                }
                 break;
             case "lmstudio":
                 translator = new LmStudioTranslate();
@@ -113,6 +137,10 @@ internal sealed class AutoTranslateRunner
                 if (!string.IsNullOrWhiteSpace(options.TranslateModel))
                 {
                     tools.LmStudioModel = options.TranslateModel.Trim();
+                }
+                if (prompt != null)
+                {
+                    tools.LmStudioPrompt = prompt;
                 }
                 break;
             case "libretranslate":
@@ -141,7 +169,142 @@ internal sealed class AutoTranslateRunner
                     $"Translate engine '{options.TranslateEngine}' is not supported. Use one of: {string.Join(", ", SupportedEngines)}.");
         }
 
-        return new AutoTranslateRunner(options, translator, llamaCppModel);
+        var runner = new AutoTranslateRunner(options, translator, llamaCppModel, engine, prompt);
+        runner.ApplyPromptOverride();
+        return runner;
+    }
+
+    /// <summary>Canonical engine id: empty means the default (llamacpp), and llama.cpp/llama are aliases for it.</summary>
+    internal static string NormalizeEngine(string? engine)
+    {
+        var name = string.IsNullOrWhiteSpace(engine) ? "llamacpp" : engine.Trim().ToLowerInvariant();
+        return name is "llama.cpp" or "llama" ? "llamacpp" : name;
+    }
+
+    /// <summary>True when the engine builds its request from an editable prompt (see <see cref="PromptEngines"/>).</summary>
+    public static bool SupportsPrompt(string? engine)
+    {
+        return PromptEngines.Contains(NormalizeEngine(engine));
+    }
+
+    /// <summary>
+    /// Resolves the <c>--translate-prompt</c> value to the prompt text, or null when the option
+    /// was not given. A value ending in <c>.txt</c>/<c>.prompt</c>/<c>.md</c>, or naming a file
+    /// that exists, is read from disk - completion templates are multi-line and a shell cannot
+    /// always pass those as one argument. Inline text gets <c>\n</c>, <c>\r</c>, <c>\t</c> and
+    /// <c>\\</c> unescaped for the same reason.
+    /// </summary>
+    internal static string? ReadPromptOption(string? value)
+    {
+        if (value == null)
+        {
+            return null;
+        }
+
+        var trimmed = value.Trim();
+        if (trimmed.Length == 0)
+        {
+            throw new InvalidOperationException("--translate-prompt is empty. Pass the prompt text or the path to a text file.");
+        }
+
+        var looksLikeFile = PromptFileExtensions.Any(e => trimmed.EndsWith(e, StringComparison.OrdinalIgnoreCase)) &&
+                            !trimmed.Contains('\n') && !trimmed.Contains('\r');
+        var exists = FileExistsSafe(trimmed);
+        if (looksLikeFile || exists)
+        {
+            if (!exists)
+            {
+                throw new InvalidOperationException($"Translate prompt file not found: {trimmed}");
+            }
+
+            var fromFile = File.ReadAllText(trimmed).Trim();
+            if (fromFile.Length == 0)
+            {
+                throw new InvalidOperationException($"Translate prompt file is empty: {trimmed}");
+            }
+
+            return fromFile;
+        }
+
+        return Unescape(value.Trim('\r', '\n'));
+    }
+
+    private static bool FileExistsSafe(string path)
+    {
+        try
+        {
+            return File.Exists(path);
+        }
+        catch (Exception)
+        {
+            // A prompt sentence is not a path - too long, invalid characters, ...
+            return false;
+        }
+    }
+
+    private static string Unescape(string text)
+    {
+        if (!text.Contains('\\'))
+        {
+            return text;
+        }
+
+        var sb = new System.Text.StringBuilder(text.Length);
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (text[i] != '\\' || i == text.Length - 1)
+            {
+                sb.Append(text[i]);
+                continue;
+            }
+
+            i++;
+            switch (text[i])
+            {
+                case 'n': sb.Append('\n'); break;
+                case 'r': sb.Append('\r'); break;
+                case 't': sb.Append('\t'); break;
+                case '\\': sb.Append('\\'); break;
+                default: sb.Append('\\').Append(text[i]); break;
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Writes <c>--translate-prompt</c> into the settings field the selected engine reads.
+    /// For llama.cpp that means <em>both</em> prompt fields: the engine prefers the per-model
+    /// template (<c>Tools.LlamaCppModelPrompt</c>, set from the curated model by
+    /// <see cref="LlamaCppServerManager.ApplyTranslatePromptSettings"/> before every file), so
+    /// setting only the plain prompt would be silently ignored for MiLMMT/Hy-MT2 and friends.
+    /// Called again after each ApplyTranslatePromptSettings for that reason.
+    /// </summary>
+    /// <summary>
+    /// Prompt/sampling settings for the upcoming file. The engine reads the per-model
+    /// prompt/sampling (e.g. Hy-MT2's or MiLMMT-46's trained-in prompt) from settings, which
+    /// nothing in a console run sets otherwise - and an explicit <c>--translate-prompt</c>
+    /// overrides it again. Internal so the precedence can be tested without a llama-server.
+    /// </summary>
+    internal void ApplyPromptSettings()
+    {
+        if (_llamaCppModel != null)
+        {
+            LlamaCppServerManager.ApplyTranslatePromptSettings(_llamaCppModel);
+        }
+
+        ApplyPromptOverride();
+    }
+
+    private void ApplyPromptOverride()
+    {
+        if (_prompt == null || _engine != "llamacpp")
+        {
+            return; // ollama/lmstudio are set once in Create; nothing overwrites them later
+        }
+
+        Configuration.Settings.Tools.LlamaCppPrompt = _prompt;
+        Configuration.Settings.Tools.LlamaCppModelPrompt = _prompt;
     }
 
     /// <summary>
@@ -150,12 +313,10 @@ internal sealed class AutoTranslateRunner
     /// </summary>
     public async Task TranslateAsync(Subtitle subtitle, CancellationToken cancellationToken)
     {
+        ApplyPromptSettings();
+
         if (_llamaCppModel != null)
         {
-            // The engine reads the per-model prompt/sampling (e.g. Hy-MT2's or MiLMMT-46's
-            // trained-in prompt) from settings, which nothing in a console run sets otherwise.
-            LlamaCppServerManager.ApplyTranslatePromptSettings(_llamaCppModel);
-
             if (!LlamaCppServerManager.IsServerRunning)
             {
                 if (!_options.Quiet)

--- a/src/seconv/Core/SeConvSettings.cs
+++ b/src/seconv/Core/SeConvSettings.cs
@@ -91,6 +91,9 @@ internal sealed class SeConvSettings
             {
                 MergeShortLinesMaxGap = s.Tools.MergeShortLinesMaxGap,
                 MergeShortLinesOnlyContinuous = s.Tools.MergeShortLinesOnlyContinuous,
+                LlamaCppPrompt = s.Tools.LlamaCppPrompt,
+                OllamaPrompt = s.Tools.OllamaPrompt,
+                LmStudioPrompt = s.Tools.LmStudioPrompt,
             },
             RemoveTextForHearingImpaired = new RemoveHiSection
             {
@@ -299,6 +302,15 @@ internal sealed class SeConvSettings
                 s.Tools.MergeShortLinesMaxGap = t.MergeShortLinesMaxGap.Value;
             if (t.MergeShortLinesOnlyContinuous.HasValue)
                 s.Tools.MergeShortLinesOnlyContinuous = t.MergeShortLinesOnlyContinuous.Value;
+
+            // Auto-translate prompts. --translate-prompt is applied later (AutoTranslateRunner),
+            // so the command line still wins over a settings file / profile.
+            if (!string.IsNullOrWhiteSpace(t.LlamaCppPrompt))
+                s.Tools.LlamaCppPrompt = t.LlamaCppPrompt;
+            if (!string.IsNullOrWhiteSpace(t.OllamaPrompt))
+                s.Tools.OllamaPrompt = t.OllamaPrompt;
+            if (!string.IsNullOrWhiteSpace(t.LmStudioPrompt))
+                s.Tools.LmStudioPrompt = t.LmStudioPrompt;
         }
 
         if (RemoveTextForHearingImpaired is { } r)
@@ -355,6 +367,15 @@ internal sealed class SeConvSettings
     {
         public int? MergeShortLinesMaxGap { get; set; }
         public bool? MergeShortLinesOnlyContinuous { get; set; }
+
+        /// <summary>Auto-translate prompt for the llama.cpp engine ({0}=source, {1}=target, {2}=text).</summary>
+        public string? LlamaCppPrompt { get; set; }
+
+        /// <summary>Auto-translate prompt for the Ollama engine ({0}=source, {1}=target, {2}=text).</summary>
+        public string? OllamaPrompt { get; set; }
+
+        /// <summary>Auto-translate prompt for the LM Studio engine ({0}=source, {1}=target, {2}=text).</summary>
+        public string? LmStudioPrompt { get; set; }
 
         [JsonExtensionData]
         public Dictionary<string, JsonElement>? UnknownMembers { get; set; }

--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -1180,6 +1180,13 @@ internal record class ConversionOptions
     /// <summary>Model: ollama/lmstudio model name, or llamacpp .gguf file name/path.</summary>
     public string? TranslateModel { get; init; }
 
+    /// <summary>
+    /// Prompt override for the LLM translate engines (llamacpp/ollama/lmstudio): inline text
+    /// (<c>\n</c> for a line break) or the path to a text file. See
+    /// <see cref="AutoTranslateRunner.ReadPromptOption"/>.
+    /// </summary>
+    public string? TranslatePrompt { get; init; }
+
     public bool TeletextOnly { get; init; }
     public bool SkipTeletext { get; init; }
     public int? TeletextOnlyPage { get; init; }

--- a/src/seconv/Helpers/HelpDisplay.cs
+++ b/src/seconv/Helpers/HelpDisplay.cs
@@ -76,6 +76,7 @@ internal static class HelpDisplay
         ShowParameter(console, "--translate-engine:<engine>", "llamacpp (default; auto-starts a local llama-server) | ollama | lmstudio | libretranslate | nllb-serve | nllb-api");
         ShowParameter(console, "--translate-url:<url>", "Endpoint of an already-running translate server (llamacpp: skips the auto-start)");
         ShowParameter(console, "--translate-model:<model>", "Ollama/LM Studio model name, or llamacpp .gguf file name/path");
+        ShowParameter(console, "--translate-prompt:<text|file>", "Prompt for llamacpp/ollama/lmstudio: inline text (\\n = line break) or a text file; {0}=source, {1}=target, {2}=text (completion-format models)");
         ShowParameter(console, "--multiple-replace:<path.xml>", "SE MultipleSearchAndReplaceGroups XML applied per paragraph");
         ShowParameter(console, "--custom-format:<path.xml>", "SE CustomFormatItem XML (use with --format customtext)");
         ShowParameter(console, "--settings:<path.json>", "JSON settings file overriding libse defaults");
@@ -194,6 +195,9 @@ internal static class HelpDisplay
         ShowExample(console,
             "seconv movie.srt subrip --translate-to:da --translate-engine:ollama --translate-model:gemma2",
             "Translate to Danish via a running Ollama instance");
+        ShowExample(console,
+            "seconv movie.srt subrip --translate-to:de --translate-prompt:my-prompt.txt",
+            "Translate with your own prompt ({0}=source language, {1}=target language)");
         ShowExample(console,
             "seconv formats",
             "List all available formats");

--- a/src/seconv/Program.cs
+++ b/src/seconv/Program.cs
@@ -497,6 +497,7 @@ internal class Program
         "--translate-engine", "--translateengine",
         "--translate-url", "--translateurl",
         "--translate-model", "--translatemodel",
+        "--translate-prompt", "--translateprompt",
         "--delete-first", "--DeleteFirst",
         "--delete-last", "--DeleteLast",
         "--delete-contains", "--DeleteContains",

--- a/tests/seconv/Core/AutoTranslateRunnerTest.cs
+++ b/tests/seconv/Core/AutoTranslateRunnerTest.cs
@@ -13,6 +13,10 @@ public class AutoTranslateRunnerTest : IDisposable
 {
     private readonly string _fakeLlamaFolder = Path.Combine(AppContext.BaseDirectory, "llama.cpp");
 
+    private readonly string _defaultLlamaCppPrompt = Configuration.Settings.Tools.LlamaCppPrompt;
+    private readonly string _defaultOllamaPrompt = Configuration.Settings.Tools.OllamaPrompt;
+    private readonly string _defaultLmStudioPrompt = Configuration.Settings.Tools.LmStudioPrompt;
+
     public AutoTranslateRunnerTest()
     {
         LlamaCppServerManager.FolderOverride = null;
@@ -23,11 +27,17 @@ public class AutoTranslateRunnerTest : IDisposable
     {
         LlamaCppServerManager.FolderOverride = null;
         LlamaCppServerManager.ExecutableOverride = null;
+
+        // The prompt settings are process-wide; put them back for the next test.
+        Configuration.Settings.Tools.LlamaCppPrompt = _defaultLlamaCppPrompt;
+        Configuration.Settings.Tools.LlamaCppModelPrompt = string.Empty;
+        Configuration.Settings.Tools.OllamaPrompt = _defaultOllamaPrompt;
+        Configuration.Settings.Tools.LmStudioPrompt = _defaultLmStudioPrompt;
         if (Directory.Exists(_fakeLlamaFolder))
             Directory.Delete(_fakeLlamaFolder, recursive: true);
     }
 
-    private static ConversionOptions MakeOptions(string engine = "llamacpp", string? url = null, string? model = null, string to = "de")
+    private static ConversionOptions MakeOptions(string engine = "llamacpp", string? url = null, string? model = null, string to = "de", string? prompt = null)
     {
         return new ConversionOptions
         {
@@ -37,6 +47,7 @@ public class AutoTranslateRunnerTest : IDisposable
             TranslateEngine = engine,
             TranslateUrl = url,
             TranslateModel = model,
+            TranslatePrompt = prompt,
             Quiet = true,
         };
     }
@@ -223,6 +234,147 @@ public class AutoTranslateRunnerTest : IDisposable
 
         var ex = Assert.Throws<InvalidOperationException>(() => AutoTranslateRunner.Create(MakeOptions(model: "no-such-model")));
         Assert.Contains("not found", ex.Message);
+    }
+
+    [Theory]
+    [InlineData(null, "llamacpp")]
+    [InlineData("", "llamacpp")]
+    [InlineData("llama.cpp", "llamacpp")]
+    [InlineData("LlamaCpp", "llamacpp")]
+    [InlineData("ollama", "ollama")]
+    public void NormalizeEngine_ResolvesAliasesAndDefault(string? engine, string expected)
+    {
+        Assert.Equal(expected, AutoTranslateRunner.NormalizeEngine(engine));
+    }
+
+    [Theory]
+    [InlineData(null, true)] // default engine is llamacpp
+    [InlineData("llama.cpp", true)]
+    [InlineData("ollama", true)]
+    [InlineData("lmstudio", true)]
+    [InlineData("libretranslate", false)]
+    [InlineData("nllb-serve", false)]
+    [InlineData("nllb-api", false)]
+    public void SupportsPrompt_OnlyForLlmEngines(string? engine, bool expected)
+    {
+        Assert.Equal(expected, AutoTranslateRunner.SupportsPrompt(engine));
+    }
+
+    [Fact]
+    public void ReadPromptOption_NotGiven_ReturnsNull()
+    {
+        Assert.Null(AutoTranslateRunner.ReadPromptOption(null));
+    }
+
+    [Fact]
+    public void ReadPromptOption_InlineText_UnescapesLineBreaks()
+    {
+        var prompt = AutoTranslateRunner.ReadPromptOption("Translate this from {0} to {1}:\\n{0}: {2}\\n{1}:");
+
+        Assert.Equal("Translate this from {0} to {1}:\n{0}: {2}\n{1}:", prompt);
+    }
+
+    [Fact]
+    public void ReadPromptOption_KeepsUnknownEscapesAndBackslashes()
+    {
+        Assert.Equal("keep \\d and \\ here", AutoTranslateRunner.ReadPromptOption("keep \\d and \\\\ here"));
+    }
+
+    [Fact]
+    public void ReadPromptOption_Empty_Throws()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() => AutoTranslateRunner.ReadPromptOption("   "));
+        Assert.Contains("empty", ex.Message);
+    }
+
+    [Fact]
+    public void ReadPromptOption_File_IsReadFromDisk()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".txt");
+        File.WriteAllText(path, "Translate this from {0} to {1}:\n{0}: {2}\n{1}:\n");
+        try
+        {
+            Assert.Equal("Translate this from {0} to {1}:\n{0}: {2}\n{1}:", AutoTranslateRunner.ReadPromptOption(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    // A .txt/.prompt/.md value is a path even when it does not exist - saying so beats sending
+    // "my-prompt.txt" to the model as the prompt.
+    [Fact]
+    public void ReadPromptOption_MissingPromptFile_Throws()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() => AutoTranslateRunner.ReadPromptOption("no-such-prompt.txt"));
+        Assert.Contains("not found", ex.Message);
+    }
+
+    [Fact]
+    public void Create_Ollama_AppliesPrompt()
+    {
+        AutoTranslateRunner.Create(MakeOptions(engine: "ollama", prompt: "Translate {0} to {1} like a pirate:"));
+
+        Assert.Equal("Translate {0} to {1} like a pirate:", Configuration.Settings.Tools.OllamaPrompt);
+    }
+
+    [Fact]
+    public void Create_LmStudio_AppliesPrompt()
+    {
+        AutoTranslateRunner.Create(MakeOptions(engine: "lmstudio", prompt: "Translate {0} to {1} like a pirate:"));
+
+        Assert.Equal("Translate {0} to {1} like a pirate:", Configuration.Settings.Tools.LmStudioPrompt);
+    }
+
+    [Fact]
+    public void Create_LlamaCppRemote_AppliesPrompt()
+    {
+        AutoTranslateRunner.Create(MakeOptions(url: "http://myhost:8080", prompt: "Translate {0} to {1}:"));
+
+        Assert.Equal("Translate {0} to {1}:", Configuration.Settings.Tools.LlamaCppPrompt);
+        Assert.Equal("Translate {0} to {1}:", Configuration.Settings.Tools.LlamaCppModelPrompt);
+    }
+
+    // LlamaCppTranslate prefers the per-model template over the plain prompt, and the curated
+    // template is re-applied before every file - so an explicit --translate-prompt has to win
+    // there too, or it would silently do nothing for exactly the models people run headless.
+    [Fact]
+    public void ApplyPromptSettings_CustomPrompt_BeatsCuratedModelTemplate()
+    {
+        PlantFakeInstall("MiLMMT-46-4B-v1.0.Q4_K_M.gguf");
+
+        var runner = AutoTranslateRunner.Create(MakeOptions(prompt: "Translate {0} to {1}:"));
+        Assert.NotNull(runner.LlamaCppModel);
+        Assert.False(string.IsNullOrEmpty(runner.LlamaCppModel!.PromptTemplate));
+
+        runner.ApplyPromptSettings(); // what TranslateAsync does before each file
+
+        Assert.Equal("Translate {0} to {1}:", Configuration.Settings.Tools.LlamaCppModelPrompt);
+        Assert.Equal("Translate {0} to {1}:", Configuration.Settings.Tools.LlamaCppPrompt);
+        // The model's sampling recommendations still apply - only the prompt is overridden.
+        Assert.Equal(0, Configuration.Settings.Tools.LlamaCppModelTemperature);
+    }
+
+    [Fact]
+    public void ApplyPromptSettings_NoCustomPrompt_KeepsCuratedModelTemplate()
+    {
+        PlantFakeInstall("MiLMMT-46-4B-v1.0.Q4_K_M.gguf");
+
+        var runner = AutoTranslateRunner.Create(MakeOptions());
+        runner.ApplyPromptSettings();
+
+        Assert.Equal(runner.LlamaCppModel!.PromptTemplate, Configuration.Settings.Tools.LlamaCppModelPrompt);
+    }
+
+    [Fact]
+    public void Create_PromptWithEngineThatHasNone_Throws()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => AutoTranslateRunner.Create(MakeOptions(engine: "libretranslate", prompt: "Translate {0} to {1}:")));
+
+        Assert.Contains("--translate-prompt is not supported", ex.Message);
+        Assert.Contains("llamacpp, ollama, lmstudio", ex.Message);
     }
 
     [Fact]

--- a/tests/seconv/Core/SeConvSettingsTest.cs
+++ b/tests/seconv/Core/SeConvSettingsTest.cs
@@ -106,6 +106,37 @@ public class SeConvSettingsTest : IDisposable
     }
 
     [Fact]
+    public void ApplyToLibSe_AppliesTranslatePrompts()
+    {
+        var tools = Configuration.Settings.Tools;
+        var saved = (tools.LlamaCppPrompt, tools.OllamaPrompt, tools.LmStudioPrompt);
+        try
+        {
+            var path = WriteSettings("""
+                {
+                  "tools": {
+                    "llamaCppPrompt": "Translate from {0} to {1} in a formal register:",
+                    "ollamaPrompt": "Translate from {0} to {1} like a pirate:",
+                    "lmStudioPrompt": "Translate from {0} to {1}:"
+                  }
+                }
+                """);
+
+            var settings = SeConvSettings.Load(path);
+            settings.ApplyToLibSe();
+
+            Assert.Empty(settings.GetUnknownKeys());
+            Assert.Equal("Translate from {0} to {1} in a formal register:", tools.LlamaCppPrompt);
+            Assert.Equal("Translate from {0} to {1} like a pirate:", tools.OllamaPrompt);
+            Assert.Equal("Translate from {0} to {1}:", tools.LmStudioPrompt);
+        }
+        finally
+        {
+            (tools.LlamaCppPrompt, tools.OllamaPrompt, tools.LmStudioPrompt) = saved;
+        }
+    }
+
+    [Fact]
     public void ApplyToLibSe_AppliesProfileGeneralValues()
     {
         // Regression for #11874: the FixCommonErrors profile values must be mappable.


### PR DESCRIPTION
Fixes #14127.

The GUI lets you edit the auto-translate prompt for the local-LLM engines, but `seconv` had no equivalent — it never reads `Settings.xml` (`Configuration.Settings` is a fresh in-memory instance), and the `--settings` overlay's `tools` section only carried the merge-short-lines keys. A headless run was stuck with the built-in prompt.

## What's new

`--translate-prompt:<text|file>` (alias `--translateprompt`) sets the prompt for `llamacpp`, `ollama` and `lmstudio`. All three build their request through `LlmTranslatePrompt`, so `{0}` (source language), `{1}` (target language) and the `{2}` completion-template mode behave exactly as in the GUI.

```bash
# Inline instruction prompt
seconv movie.srt subrip --translate-to:de \
  --translate-prompt:"Translate from {0} to {1}. Keep the line breaks. Use informal address. Output only the translation:"

# Completion template (MiLMMT-46 style), inline or from a file
seconv movie.srt subrip --translate-to:da --translate-prompt:"Translate this from {0} to {1}:\n{0}: {2}\n{1}:"
seconv movie.srt subrip --translate-to:da --translate-prompt:milmmt.prompt

# Ollama / LM Studio take the same option
seconv movie.srt subrip --translate-to:da --translate-engine:ollama --translate-model:gemma2 --translate-prompt:my-prompt.txt
```

The value is inline text — with `\n`, `\r`, `\t`, `\\` unescaped so a short completion template fits on one command line — or the path to a text file, which is the practical way to pass a multi-line template. A value naming an existing file, or one ending in `.txt` / `.prompt` / `.md`, is read from disk; a missing file is an error, not a prompt that happens to look like a path.

## The precedence trap

`LlamaCppTranslate` prefers the **per-model** template (`Tools.LlamaCppModelPrompt`) over the plain prompt, and `LlamaCppServerManager.ApplyTranslatePromptSettings` re-applies the curated model's template before every file. Setting only `LlamaCppPrompt` would therefore silently do nothing for exactly the models people run headless (MiLMMT-46, Hy-MT2). The override is written to both fields and re-applied after `ApplyTranslatePromptSettings`, with a regression test that fails if that re-apply is dropped.

For the same reason — an option on the command line must never be a no-op — passing `--translate-prompt` to `libretranslate` / `nllb-serve` / `nllb-api` (no prompt at all) is rejected, as is an unreadable prompt file, before any conversion starts.

Precedence for `llamacpp`, highest first: `--translate-prompt` → curated model template → `--settings` `tools.llamaCppPrompt` → built-in default.

## Also

`llamaCppPrompt` / `ollamaPrompt` / `lmStudioPrompt` added to the `--settings` `tools` section, so a `profiles` entry can hold a per-target-language prompt. These keep the GUI's precedence (a curated model's own template still wins); only the explicit command-line option overrides that.

## Verification

- `dotnet test tests/seconv/SeConvTests.csproj` — 408 passed. New tests cover engine normalization, prompt-supporting engines, inline unescaping, file/missing-file/empty handling, per-engine application, and the curated-model precedence (mutation-checked: removing the re-apply fails it).
- End-to-end against a stub OpenAI-compatible server: the completion template arrives filled in and sent as one block (`Translate this from English to German:\nEnglish: Hello world\nGerman:`), and a chat-style prompt arrives with the text appended after a blank line.
- `seconv --help-json` picks the option up automatically (schema is reflected off the settings type).

🤖 Generated with [Claude Code](https://claude.com/claude-code)