### PR TITLE
seconv: fail on a path-shaped --translate-prompt that does not exist

### DIFF
--- a/docs/reference/command-line.md
+++ b/docs/reference/command-line.md
@@ -343,10 +343,16 @@ language (both as English names, e.g. `English` / `German`). A prompt that also 
 *completion template*: the subtitle text is placed at `{2}` and the filled-in block is sent as-is,
 which is what raw-completion translation models such as MiLMMT-46 are trained on.
 
-The value is either inline text or the path to a text file. A value that names an existing file, or
-that ends in `.txt` / `.prompt` / `.md`, is read from disk — the practical way to pass a multi-line
-completion template. In inline text, `\n` (also `\r`, `\t`, `\\`) is unescaped, so a short template
-still fits on one command line.
+The value is either inline text or the path to a text file. Reading from a file is the practical way
+to pass a multi-line completion template; in inline text `\n` (also `\r`, `\t`, `\\`) is unescaped, so
+a short template still fits on one command line.
+
+The two are told apart by shape: an existing file is always read, and so is a value that *looks*
+like a path — no spaces, or a `.txt` / `.prompt` / `.md` extension. A path-shaped value that does not
+exist is an error, so a typo (`--translate-prompt:prompts/mine.tmpl`) fails immediately instead of
+being handed to the model as the prompt and quietly mistranslating the whole batch. Prompt text is
+recognised by containing a space, a line break, or a `{0}`/`{1}`/`{2}` placeholder — which every
+real prompt does.
 
 ```bash
 # Inline instruction prompt

--- a/src/seconv/Core/AutoTranslateRunner.cs
+++ b/src/seconv/Core/AutoTranslateRunner.cs
@@ -30,6 +30,9 @@ internal sealed class AutoTranslateRunner
     /// <summary>File extensions that make <c>--translate-prompt</c> a file path rather than inline text.</summary>
     private static readonly string[] PromptFileExtensions = { ".txt", ".prompt", ".md" };
 
+    /// <summary>Refuse to read a whole video/model file as a prompt when a path points at one.</summary>
+    private const long MaxPromptFileBytes = 256 * 1024;
+
     private readonly ConversionOptions _options;
     private readonly IAutoTranslator _translator;
     private readonly LlamaCppModel? _llamaCppModel; // non-null = local server mode; start before first use
@@ -207,14 +210,23 @@ internal sealed class AutoTranslateRunner
             throw new InvalidOperationException("--translate-prompt is empty. Pass the prompt text or the path to a text file.");
         }
 
-        var looksLikeFile = PromptFileExtensions.Any(e => trimmed.EndsWith(e, StringComparison.OrdinalIgnoreCase)) &&
-                            !trimmed.Contains('\n') && !trimmed.Contains('\r');
         var exists = FileExistsSafe(trimmed);
-        if (looksLikeFile || exists)
+        if (exists || LooksLikePromptFile(trimmed))
         {
             if (!exists)
             {
-                throw new InvalidOperationException($"Translate prompt file not found: {trimmed}");
+                throw new InvalidOperationException(
+                    $"Translate prompt file not found: {trimmed}. " +
+                    "A --translate-prompt value with no spaces, or ending in .txt/.prompt/.md, is read as a file path; " +
+                    "prompt text passed inline has to contain a space or a {0}/{1}/{2} placeholder.");
+            }
+
+            var size = new FileInfo(trimmed).Length;
+            if (size > MaxPromptFileBytes)
+            {
+                throw new InvalidOperationException(
+                    $"Translate prompt file is too large ({size / 1024} KB, max {MaxPromptFileBytes / 1024} KB): {trimmed}. " +
+                    "--translate-prompt takes the prompt itself, not a data file.");
             }
 
             var fromFile = File.ReadAllText(trimmed).Trim();
@@ -227,6 +239,26 @@ internal sealed class AutoTranslateRunner
         }
 
         return Unescape(value.Trim('\r', '\n'));
+    }
+
+    /// <summary>
+    /// Whether a value that is not an existing file was still meant as one - a typo'd path must
+    /// fail loudly instead of being handed to the model as the prompt, which silently translates
+    /// a whole batch under "prompts/mine.tmpl". A real prompt is a sentence: it contains a space,
+    /// a line break, or at least a <c>{0}</c>/<c>{1}</c>/<c>{2}</c> placeholder. Anything else -
+    /// or anything with a prompt-file extension - is treated as a path.
+    /// </summary>
+    private static bool LooksLikePromptFile(string value)
+    {
+        if (value.Any(char.IsWhiteSpace))
+        {
+            // Spaces or line breaks: only a prompt-file extension still makes it a path
+            // ("my prompts/milmmt.txt"), never a sentence.
+            return !value.Contains('\n') && !value.Contains('\r') && !value.Contains('{') &&
+                   PromptFileExtensions.Any(e => value.EndsWith(e, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return !value.Contains('{');
     }
 
     private static bool FileExistsSafe(string path)

--- a/tests/seconv/Core/AutoTranslateRunnerTest.cs
+++ b/tests/seconv/Core/AutoTranslateRunnerTest.cs
@@ -302,13 +302,64 @@ public class AutoTranslateRunnerTest : IDisposable
         }
     }
 
-    // A .txt/.prompt/.md value is a path even when it does not exist - saying so beats sending
-    // "my-prompt.txt" to the model as the prompt.
-    [Fact]
-    public void ReadPromptOption_MissingPromptFile_Throws()
+    // A path-shaped value is a path even when it does not exist - saying so beats sending
+    // "prompts/mine.tmpl" to the model as the prompt, which would silently translate a whole
+    // batch under a garbage instruction.
+    [Theory]
+    [InlineData("no-such-prompt.txt")]      // prompt-file extension
+    [InlineData("prompts/mine.tmpl")]       // any extension, no spaces
+    [InlineData("./missing")]               // no extension at all
+    [InlineData("my prompts/milmmt.txt")]   // spaces in the path, prompt-file extension
+    public void ReadPromptOption_MissingPromptFile_Throws(string value)
     {
-        var ex = Assert.Throws<InvalidOperationException>(() => AutoTranslateRunner.ReadPromptOption("no-such-prompt.txt"));
+        var ex = Assert.Throws<InvalidOperationException>(() => AutoTranslateRunner.ReadPromptOption(value));
         Assert.Contains("not found", ex.Message);
+    }
+
+    // ... while anything sentence-shaped stays inline text, placeholders included.
+    [Theory]
+    [InlineData("Translate from {0} to {1}:")]
+    [InlineData("{0}->{1}:")]                       // terse, no spaces, but has placeholders
+    [InlineData("Translate this. Keep line breaks.")]
+    public void ReadPromptOption_SentenceShapedValue_StaysInline(string value)
+    {
+        Assert.Equal(value, AutoTranslateRunner.ReadPromptOption(value));
+    }
+
+    [Fact]
+    public void ReadPromptOption_ExistingFile_WinsOverAnyShape()
+    {
+        // No extension and no spaces, but it exists - read it.
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName().Replace(".", string.Empty));
+        File.WriteAllText(path, "Translate from {0} to {1}:");
+        try
+        {
+            Assert.Equal("Translate from {0} to {1}:", AutoTranslateRunner.ReadPromptOption(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void ReadPromptOption_HugeFile_Throws()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".txt");
+        using (var fs = File.Create(path))
+        {
+            fs.SetLength(300 * 1024); // e.g. --translate-prompt pointed at a data file by mistake
+        }
+
+        try
+        {
+            var ex = Assert.Throws<InvalidOperationException>(() => AutoTranslateRunner.ReadPromptOption(path));
+            Assert.Contains("too large", ex.Message);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
Follow-up hardening for #14127 / [#14132](https://github.com/SubtitleEdit/subtitleedit/pull/14132).

`--translate-prompt` read the value from disk when it named an existing file or ended in `.txt`/`.prompt`/`.md`, and treated anything else as inline prompt text. That left a silent failure: a typo'd or differently-named path was handed to the model **as the prompt**.

```console
$ seconv movie.srt subrip --translate-to:de --translate-prompt:prompts/mine.tmpl
✓ Conversion completed successfully!
```

...with `prompts/mine.tmpl\n\nHello world` going to the LLM, i.e. the whole batch translated under a garbage instruction and no error anywhere. Everything else in seconv treats an option that cannot do what it says as an error, not a no-op.

## Fix

Tell path from prompt by shape:

- an existing file always wins;
- a value that *looks* like a path — no whitespace, or a `.txt` / `.prompt` / `.md` extension — must exist, otherwise it is an error;
- prompt text is what contains a space, a line break, or a `{0}`/`{1}`/`{2}` placeholder, which every real prompt does — including terse ones like `{0}->{1}:`.

```console
$ seconv movie.srt subrip --translate-to:de --translate-prompt:prompts/mine.tmpl
Error: Translate prompt file not found: prompts/mine.tmpl. A --translate-prompt value with no spaces,
or ending in .txt/.prompt/.md, is read as a file path; prompt text passed inline has to contain a
space or a {0}/{1}/{2} placeholder.
```

Also caps a prompt file at 256 KB — now that an extensionless path is read, `--translate-prompt` aimed at a video or a `.gguf` by mistake should say so rather than load it as the prompt.

## Verification

- `dotnet test tests/seconv/SeConvTests.csproj` — 416 passed. New theories cover the four path shapes (prompt extension, other extension, no extension, spaces-in-path), the three sentence shapes that must stay inline, an existing file with no extension, and the size cap.
- Manual: the command above now fails, and `--translate-prompt:"Translate from {0} to {1}:"` still reaches the engine unchanged.
- Also verified while auditing (no change needed): a CRLF prompt file works — `Json.EncodeJsonText` normalizes line endings before encoding — and `--help` / `--help-json` render the option correctly.

Docs: the "Custom prompt" section now states the rule and why a path-shaped miss is an error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)