### PR TITLE
Add an editable video position box to the waveform toolbar

### DIFF
--- a/src/ui/Features/Main/Layout/InitWaveform.cs
+++ b/src/ui/Features/Main/Layout/InitWaveform.cs
@@ -698,6 +698,88 @@ public class InitWaveform
             av.StartPositionSeconds = e.NewValue - halfWidthInSeconds;
         };
 
+        // SE 4's editable video position box (#12266). The slider above is for scrubbing; this is
+        // the exact-time counterpart - type a time code to jump there, step it by one millisecond
+        // (or frame) with the spinner/Up-Down/wheel, and copy the current position out with Ctrl+C.
+        var settingPositionText = GetToolbarSettingFor(SeWaveformToolbarItemType.VideoPositionText);
+        var timeCodePosition = new TimeCodeUpDown
+        {
+            UseVideoOffset = true,
+            VerticalAlignment = VerticalAlignment.Center,
+            FontSize = settingPositionText.FontSize,
+            Margin = new Thickness(settingPositionText.LeftMargin, 0, settingPositionText.RightMargin, 0),
+            [ToolTip.TipProperty] = UiUtil.MakeToolTip(languageHints.VideoPositionTextBox, shortcuts),
+            [AutomationProperties.NameProperty] = Se.Language.General.VideoPosition,
+        };
+
+        // Guards for the two-way loop below: "updating" is set while the refresh timer writes the
+        // player's position into the box, so its ValueChanged is not mistaken for a user edit.
+        var positionTextUpdating = false;
+        var positionTextEditedTicks = 0L;
+
+        // The box holds still while it is being edited, so the refresh below can't overwrite what
+        // was typed and yank the caret. A running video moves on its own, so then the box keeps
+        // following even while focused (same rule as the point-sync dialog) - except for a moment
+        // after an actual edit, which covers stepping with the spinner buttons or the wheel, where
+        // focus never moves into the box at all.
+        bool IsEditingPositionText() =>
+            (timeCodePosition.IsKeyboardFocusWithin && vm.GetVideoPlayerControl()?.IsPlaying != true) ||
+            Environment.TickCount64 - positionTextEditedTicks < 500;
+
+        var positionTextTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(100) };
+        positionTextTimer.Tick += (_, _) =>
+        {
+            var vp = vm.GetVideoPlayerControl();
+            if (vp == null || IsEditingPositionText())
+            {
+                return;
+            }
+
+            positionTextUpdating = true;
+            timeCodePosition.Value = TimeSpan.FromSeconds(Math.Max(0, vp.Position));
+            positionTextUpdating = false;
+        };
+
+        // The item is hidden by default, so only pay for the timer once it is actually on the
+        // toolbar - and stop it again when a layout rebuild throws this control away.
+        timeCodePosition.AttachedToVisualTree += (_, _) => positionTextTimer.Start();
+        timeCodePosition.DetachedFromVisualTree += (_, _) => positionTextTimer.Stop();
+
+        timeCodePosition.ValueChanged += (_, value) =>
+        {
+            if (positionTextUpdating)
+            {
+                return;
+            }
+
+            positionTextEditedTicks = Environment.TickCount64;
+
+            var vp = vm.GetVideoPlayerControl();
+            if (vp == null)
+            {
+                return;
+            }
+
+            var seconds = Math.Max(0, value.TotalSeconds);
+            if (vp.Duration > 0 && seconds > vp.Duration)
+            {
+                seconds = vp.Duration;
+            }
+
+            // Flip the control's user-moving gate around the write so this counts as a user seek:
+            // that pins the waveform playhead to the target and centers on it, instead of letting
+            // the cursor lag behind on the not-yet-seeked position (see OnVideoPlayerUserSeeked).
+            vp.SetUserMovingPositionSlider(true);
+            try
+            {
+                vp.Position = seconds;
+            }
+            finally
+            {
+                vp.SetUserMovingPositionSlider(false);
+            }
+        };
+
         var settingSpeed = GetToolbarSettingFor(SeWaveformToolbarItemType.PlaybackSpeed);
         var labelSpeed = UiUtil.MakeLabel(Se.Language.General.Speed);
         var comboBoxSpeed = new ComboBox
@@ -929,6 +1011,7 @@ public class InitWaveform
             iconVertical,
             panelVerticalZoom,
             sliderPosition,
+            timeCodePosition,
             panelAudioTrack,
             panelSpeed,
             toggleButtonAutoSelectOnPlay,
@@ -979,6 +1062,7 @@ public class InitWaveform
         Icon iconVertical,
         StackPanel panelVerticalZoom,
         Slider sliderPosition,
+        TimeCodeUpDown timeCodePosition,
         StackPanel panelAudioTrack,
         StackPanel panelSpeed,
         ToggleButton toggleButtonAutoSelectOnPlay,
@@ -1046,6 +1130,9 @@ public class InitWaveform
                     break;
                 case SeWaveformToolbarItemType.VideoPositionSlider:
                     toolbarButtonForSort.Add(new SortedControl { Sort = item.SortOrder, Control = sliderPosition });
+                    break;
+                case SeWaveformToolbarItemType.VideoPositionText:
+                    toolbarButtonForSort.Add(new SortedControl { Sort = item.SortOrder, Control = timeCodePosition });
                     break;
                 case SeWaveformToolbarItemType.AudioTrackPicker:
                     toolbarButtonForSort.Add(new SortedControl { Sort = item.SortOrder, Control = panelAudioTrack });

--- a/src/ui/Features/Options/Settings/WaveformToolbarItems/ToolbarItemDisplay.cs
+++ b/src/ui/Features/Options/Settings/WaveformToolbarItems/ToolbarItemDisplay.cs
@@ -40,6 +40,7 @@ public partial class ToolbarItemDisplay : ObservableObject
             SeWaveformToolbarItemType.VerticalZoom => Format(w.ZoomVerticalHint),
             SeWaveformToolbarItemType.HorizontalZoom => Format(w.ZoomHorizontalHint),
             SeWaveformToolbarItemType.VideoPositionSlider => Format(w.VideoPosition),
+            SeWaveformToolbarItemType.VideoPositionText => Format(w.VideoPositionTextBox),
             SeWaveformToolbarItemType.PlaybackSpeed => Se.Language.General.PlaybackSpeed,
             SeWaveformToolbarItemType.AutoSelectOnPlay => Format(w.SelectCurrentLineWhilePlayingHint),
             SeWaveformToolbarItemType.Center => Format(w.CenterWaveformHint),

--- a/src/ui/Logic/Config/Language/Main/LanguageMainWaveform.cs
+++ b/src/ui/Logic/Config/Language/Main/LanguageMainWaveform.cs
@@ -14,6 +14,7 @@ public class LanguageMainWaveform
     public string ZoomVerticalHint { get; set; }
     public string SelectCurrentLineWhilePlayingHint { get; set; }
     public string VideoPosition { get; set; }
+    public string VideoPositionTextBox { get; set; }
     public string HideWaveformToolbar { get; set; }
     public string ResetZoomAndSpeed { get; set; }
     public string RemoveBlankLines { get; set; }
@@ -42,6 +43,7 @@ public class LanguageMainWaveform
         ZoomVerticalHint = "Zoom vertical {0}";
         SelectCurrentLineWhilePlayingHint = "Select current subtitle while playing {0}";
         VideoPosition = "Video position {0}";
+        VideoPositionTextBox = "Video position text box {0}";
         HideWaveformToolbar = "Hide toolbar {0}";
         ResetZoomAndSpeed = "Reset zoom & playback speed {0}";
         RemoveBlankLines = "Remove blank lines {0}";

--- a/src/ui/Logic/Config/SeWaveform.cs
+++ b/src/ui/Logic/Config/SeWaveform.cs
@@ -188,6 +188,7 @@ public class SeWaveform
             new SeWaveformToolbarItem { Type = SeWaveformToolbarItemType.VerticalZoom, IsVisible = true, SortOrder = 100 },
             new SeWaveformToolbarItem { Type = SeWaveformToolbarItemType.HorizontalZoom, IsVisible = true, SortOrder = 110 },
             new SeWaveformToolbarItem { Type = SeWaveformToolbarItemType.VideoPositionSlider, IsVisible = true, SortOrder = 120 },
+            new SeWaveformToolbarItem { Type = SeWaveformToolbarItemType.VideoPositionText, IsVisible = false, SortOrder = 121 },
             new SeWaveformToolbarItem { Type = SeWaveformToolbarItemType.AudioTrackPicker, IsVisible = true, SortOrder = 125 },
             new SeWaveformToolbarItem { Type = SeWaveformToolbarItemType.PlaybackSpeed, IsVisible = true, SortOrder = 130 },
             new SeWaveformToolbarItem { Type = SeWaveformToolbarItemType.AutoSelectOnPlay, IsVisible = true, SortOrder = 140 },

--- a/src/ui/Logic/Config/SeWaveformToolbarItemType.cs
+++ b/src/ui/Logic/Config/SeWaveformToolbarItemType.cs
@@ -25,6 +25,10 @@ public enum SeWaveformToolbarItemType
     HorizontalZoom = 10,
     VideoPositionSlider = 11,
 
+    // SE 4's editable video position box (#12266): the slider's exact-time counterpart - type,
+    // step or copy the current position as a time code.
+    VideoPositionText = 22,
+
     // Picks which audio track the waveform is extracted from; only rendered when the
     // open video has more than one audio track.
     AudioTrackPicker = 21,


### PR DESCRIPTION
SE 4 had a video position text box under the video player: type an exact time code to jump there, nudge it in the smallest increments, and copy the current position out for chapter or video-editing work. SE 5 only had the position *slider*, which is for scrubbing, so that workflow had no equivalent — see [#12266](https://github.com/SubtitleEdit/subtitleedit/issues/12266) and [this comment](https://github.com/SubtitleEdit/subtitleedit/issues/12266#issuecomment-5419997624).

Adds `VideoPositionText` as a waveform toolbar item, **hidden by default**, enabled from the toolbar's *…* → **Configure toolbar items…**.

It reuses `TimeCodeUpDown`, so it comes with:

- masked editing of the time code
- Up/Down, the spinner buttons and the mouse wheel stepping the part the caret is on — the last part by `TimeCodeUpDownStepMs`, or one frame in frame mode
- whole-value copy with Ctrl/Cmd+C, and paste of a time code or bare milliseconds
- the video offset and frame-mode display, like the main Show/Hide boxes

An edit flips the control's user-moving gate around the write, so it counts as a user seek: the waveform playhead pins and centers on the target instead of lagging behind on the not-yet-seeked position.

The 100 ms refresh leaves the box alone while it is being edited — following the point-sync dialog's rule, focus counts as editing only while the video is paused — plus a short grace after any actual edit, so spinner and wheel steps (which never move focus into the box) are not overwritten either. The refresh timer runs only while the item is actually on the toolbar, so the hidden default costs nothing.

`EnsureAllToolbarItems()` picks the new type up for existing settings files, so it is customizable after an upgrade without a settings reset.

## Not included

- The SE 4 setup preset (`Se4SetupApplier`) is unchanged. SE 4 had this box under the video player rather than in the waveform toolbar, and adding it widens that preset's toolbar noticeably — happy to add it if wanted.
- The other two items in #12266 already exist as toolbar items: skip back/forward is `VideoSeek` (hidden by default, which is why it is easy to miss) and "Select current subtitle while playing" is `AutoSelectOnPlay` (visible by default).

## Testing

Built and run locally; the box was enabled from the configure dialog and checked against a video. The existing waveform-toolbar tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)