### PR TITLE
Prepare v5.2.0-beta25

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -3,6 +3,38 @@ Subtitle Edit Changelog
 
 -----------------------------------------------------------------------------------------------------
 
+v5.2.0-beta25 (26th of August 2026)
+
+* Add advanced text effects to image based export - gradient, neon glow, 3D extrude and more
+* Add speaker-name detection and a "leave sound/music lines silent" prompt to text to speech - thx subof
+* Add "Clone from video" to Qwen3 TTS, so each line can be dubbed in the voice heard in the video - thx invio-a11y
+* Add an editable video position box to the waveform toolbar - thx 95Midnight
+* Add custom llama.cpp vision models to the OCR model list
+* Add the "Ollama advanced" translate engine to batch convert
+* Add "--translate-prompt" to seconv for the local LLM translate engines - thx Makar8000
+* Image based export now honors per-line ASSA colors and outline/shadow widths
+* EBU STL: show frame-based time codes while the format is active - thx Triathlon-rally
+* "Normalize strings" now folds curly quotes, dashes and ellipsis to plain ASCII - thx fraternl
+* DeepL: offer all the languages the API supports, and use the host that matches the key
+* Google Translate: use the right language list for the free and the paid engine, and drop two broken entries
+* Auto-translate: take the CrispASR MADLAD language list from the model - thx ecotycoon
+* OCR: list the most accurate llama.cpp models first
+* Italian OCR: fix "E'" to "È" - thx GitGianluc
+* Speech to text: say when Crisp ASR was killed instead of reporting no speech - thx marwanlhabti5-coder
+* Update llama.cpp to b10625
+* Fix the original text being erased after translating - thx fraternl
+* Fix EBU STL export doing nothing when a font color tag has no quotes, and remember the save options
+* Fix regenerating a cloned line after importing a text to speech session - thx invio-a11y
+* Fix "find voices in video and clone" not setting actors when a subtitle is open - thx subof
+* Fix "convert actors" missing a speaker tag split across a line break - thx subof
+* Fix OCR removing the French space before "?" and "!"
+* Fix Microsoft Translator throwing an error when the language list cannot be fetched
+* Update Italian translation - thx bovirus
+* Update Japanese translation - thx hisui3393
+* Update Polish translation - thx potplayer-fanpack
+
+-----------------------------------------------------------------------------------------------------
+
 v5.2.0-beta24 (25th of August 2026)
 
 * Add dots.tts text to speech engine with voice cloning

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "Subtitle Edit",
-  "version": "v5.2.0-beta24",
+  "version": "v5.2.0-beta25",
   "translatedBy": "",
   "cultureName": "en-US",
   "general": {
@@ -943,6 +943,7 @@
       "zoomVerticalHint": "Zoom vertical {0}",
       "selectCurrentLineWhilePlayingHint": "Select current subtitle while playing {0}",
       "videoPosition": "Video position {0}",
+      "videoPositionTextBox": "Video position text box {0}",
       "hideWaveformToolbar": "Hide toolbar {0}",
       "resetZoomAndSpeed": "Reset zoom & playback speed {0}",
       "removeBlankLines": "Remove blank lines {0}",

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -19,7 +19,7 @@ public class Se
     internal const int CurrentMacOsFontMigrationVersion = 1;
     internal const int CurrentShortcutsMigrationVersion = 2;
 
-    public static string Version { get; set; } = "v5.2.0-beta24";
+    public static string Version { get; set; } = "v5.2.0-beta25";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
Release prep for **v5.2.0-beta25**, the same three-file shape as [#14088](https://github.com/SubtitleEdit/subtitleedit/pull/14088):

- `src/ui/Logic/Config/Se.cs` — version `v5.2.0-beta24` → `v5.2.0-beta25`
- `src/ui/Assets/Languages/English.json` — regenerated (version header plus one new key, `waveform.videoPositionTextBox`, from #14134)
- `change-log.txt` — a new beta25 section

## Change-log coverage

The 34 pull requests merged since the `v5.2.0-beta24` tag were enumerated by ancestor-checking each merge commit against the tag (`git log v5.2.0-beta24..HEAD --merges`), not by merge timestamps — seven of them landed on the same day as the tag, after it.

Left out of the section deliberately:

- **#14126** (ten beta24-review findings) — every one of them fixes code merged inside this same beta range, so they are in-beta regressions that never shipped.
- **#14098**, **#14113** — docs only.
- **#14114** — removes an inert test.

Credits come from the linked issue/discussion authors: #14095/#14096 (invio-a11y), #14091/#14092 (fraternl), #14106 (subof), #14127 (Makar8000), #12266 (95Midnight), #14038 (marwanlhabti5-coder), #14076 (Triathlon-rally), the MADLAD question in discussion #12929 (ecotycoon), and the `E'` suggestion in #14092 (GitGianluc). Wording is of course yours to curate.

## Verification

- `dotnet build SubtitleEdit.sln` — 0 errors (3 pre-existing `MainViewModel` nullability warnings, untouched here).
- `dotnet test tests/UI/UITests.csproj --filter EnglishLanguageFileUpToDateTests` — passed; the regeneration it performed is what is committed here.

After merge the release is cut with `gh workflow run "Build and release UI" --ref main -f release_tag=v5.2.0-beta25`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)