### PR TITLE
Keep the moved rule selected in Multiple replace (#14136)

### DIFF
--- a/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
+++ b/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
@@ -1040,15 +1040,24 @@ public partial class MultipleReplaceViewModel : ObservableObject
 
         _dirty = true;
         SelectedNode = node;
-        Dispatcher.UIThread.Post(() =>
+        Dispatcher.UIThread.Post(() => FocusNode(node), DispatcherPriority.Input);
+    }
+
+    /// <summary>
+    /// Selects a node and puts keyboard focus back on its row, so the next Ctrl+Up/Down keeps
+    /// walking the same node. <see cref="ItemsControl.ContainerFromItem"/> only ever sees the
+    /// top-level categories, so a rule - which lives one level down - never got its container
+    /// back: focus was left nowhere, the tree handed it to the category above on the next key
+    /// press, and that stole the selection (#14136).
+    /// </summary>
+    private void FocusNode(RuleTreeNode node)
+    {
+        SelectedNode = node;
+        if (RulesTreeView.TreeContainerFromItem(node) is TreeViewItem container)
         {
-            SelectedNode = node;
-            if (RulesTreeView.ContainerFromItem(node) is TreeViewItem container)
-            {
-                container.BringIntoView();
-                container.Focus(NavigationMethod.Directional);
-            }
-        }, DispatcherPriority.Input);
+            container.BringIntoView();
+            container.Focus(NavigationMethod.Directional);
+        }
     }
 
     internal void OnKeyDown(object? sender, KeyEventArgs e)
@@ -1137,16 +1146,7 @@ public partial class MultipleReplaceViewModel : ObservableObject
 
         // The rule's own container only exists once the category above it has expanded, so
         // selecting and scrolling to it has to wait for that layout pass.
-        Dispatcher.UIThread.Post(() =>
-        {
-            SelectedNode = rule;
-            var container = RulesTreeView.ContainerFromItem(rule) as TreeViewItem;
-            if (container != null)
-            {
-                container.BringIntoView();
-                container.Focus(NavigationMethod.Directional);
-            }
-        }, DispatcherPriority.Input);
+        Dispatcher.UIThread.Post(() => FocusNode(rule), DispatcherPriority.Input);
     }
 
     /// <summary>
@@ -1221,19 +1221,10 @@ public partial class MultipleReplaceViewModel : ObservableObject
                         selectedNode = parent.SubNodes[parent.SubNodes.Count - 1];
                     }
 
-                    Dispatcher.UIThread.Post(() =>
+                    if (selectedNode != null)
                     {
-                        if (selectedNode != null)
-                        {
-                            SelectedNode = selectedNode;
-                            var container = RulesTreeView.ContainerFromItem(selectedNode) as TreeViewItem;
-                            if (container != null)
-                            {
-                                container.BringIntoView();
-                                container.Focus(NavigationMethod.Directional);
-                            }
-                        }
-                    }, DispatcherPriority.Input);
+                        Dispatcher.UIThread.Post(() => FocusNode(selectedNode), DispatcherPriority.Input);
+                    }
                 }
             }
         }

--- a/tests/UI/Features/Edit/MultipleReplaceMoveFocusTests.cs
+++ b/tests/UI/Features/Edit/MultipleReplaceMoveFocusTests.cs
@@ -1,0 +1,165 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Edit.MultipleReplace;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Linq;
+
+namespace UITests.Features.Edit;
+
+/// <summary>
+/// Reordering has to be repeatable: Ctrl+Up on a rule moved it once and then dropped keyboard
+/// focus, so the tree handed focus - and with it the selection - to the category above on the
+/// next key press and the second Ctrl+Up moved the category instead (#14136). These tests drive
+/// the real window, because the bug lives in the container lookup, not in the reorder itself.
+/// </summary>
+public class MultipleReplaceMoveFocusTests
+{
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private static (MultipleReplaceViewModel Vm, Window Window) Open()
+    {
+        var vm = new MultipleReplaceViewModel(new WindowService(new NullServiceProvider()), new FileHelper());
+        vm.Nodes.Clear();
+
+        for (var c = 1; c <= 2; c++)
+        {
+            var category = new RuleTreeNode(true) { CategoryName = $"c{c}", IsActive = true, IsExpanded = true };
+            for (var r = 1; r <= 4; r++)
+            {
+                category.SubNodes!.Add(new RuleTreeNode(false)
+                {
+                    Find = $"c{c}r{r}",
+                    ReplaceWith = "x",
+                    IsActive = true,
+                    Parent = category,
+                    Type = MultipleReplaceType.CaseInsensitive,
+                });
+            }
+
+            vm.Nodes.Add(category);
+        }
+
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("hello", 0, 2000));
+        vm.Initialize(subtitle);
+
+        var window = new MultipleReplaceWindow(vm);
+        window.Show();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+        return (vm, window);
+    }
+
+    private static string Rules(RuleTreeNode category) =>
+        string.Join(",", category.SubNodes!.Select(n => n.Find));
+
+    private static string Categories(MultipleReplaceViewModel vm) =>
+        string.Join(",", vm.Nodes.Select(n => n.CategoryName));
+
+    private static TreeViewItem ContainerOf(Window window, RuleTreeNode node)
+    {
+        var container = window.GetVisualDescendants().OfType<TreeViewItem>()
+            .FirstOrDefault(i => ReferenceEquals(i.DataContext, node));
+        Assert.NotNull(container);
+        return container!;
+    }
+
+    // Clicking the row is the only way to get real keyboard focus into the tree, and the bug is
+    // about what happens to that focus afterwards.
+    private static void ClickNode(Window window, MultipleReplaceViewModel vm, RuleTreeNode node)
+    {
+        var container = ContainerOf(window, node);
+        var bounds = container.Bounds;
+        var point = container.TranslatePoint(new Point(bounds.Width / 2, 8), window)!.Value;
+        window.MouseDown(point, MouseButton.Left);
+        window.MouseUp(point, MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Same(node, vm.SelectedNode);
+    }
+
+    private static void CtrlKey(Window window, PhysicalKey key)
+    {
+        window.KeyPressQwerty(key, RawInputModifiers.Control);
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    [AvaloniaFact]
+    public void CtrlUp_WalksTheSameRuleUpTheCategory()
+    {
+        var (vm, window) = Open();
+        var category = vm.Nodes[0];
+        var rule = category.SubNodes![3];
+        ClickNode(window, vm, rule);
+
+        CtrlKey(window, PhysicalKey.ArrowUp);
+        Assert.Equal("c1r1,c1r2,c1r4,c1r3", Rules(category));
+        Assert.Same(rule, vm.SelectedNode);
+
+        CtrlKey(window, PhysicalKey.ArrowUp);
+        Assert.Equal("c1r1,c1r4,c1r2,c1r3", Rules(category));
+        Assert.Same(rule, vm.SelectedNode);
+
+        CtrlKey(window, PhysicalKey.ArrowUp);
+        Assert.Equal("c1r4,c1r1,c1r2,c1r3", Rules(category));
+        Assert.Same(rule, vm.SelectedNode);
+
+        // The category never becomes the selection, so it never gets reordered either.
+        Assert.Equal("c1,c2", Categories(vm));
+    }
+
+    [AvaloniaFact]
+    public void CtrlDown_WalksTheSameRuleDownTheCategory()
+    {
+        var (vm, window) = Open();
+        var category = vm.Nodes[1];
+        var rule = category.SubNodes![0];
+        ClickNode(window, vm, rule);
+
+        CtrlKey(window, PhysicalKey.ArrowDown);
+        CtrlKey(window, PhysicalKey.ArrowDown);
+
+        Assert.Equal("c2r2,c2r3,c2r1,c2r4", Rules(category));
+        Assert.Same(rule, vm.SelectedNode);
+        Assert.Equal("c1,c2", Categories(vm));
+    }
+
+    // The moved row has to keep keyboard focus - that is what makes the next key press reach it.
+    [AvaloniaFact]
+    public void MovedRule_KeepsKeyboardFocus()
+    {
+        var (vm, window) = Open();
+        var rule = vm.Nodes[0].SubNodes![2];
+        ClickNode(window, vm, rule);
+
+        CtrlKey(window, PhysicalKey.ArrowUp);
+
+        var focused = window.FocusManager?.GetFocusedElement();
+        Assert.Same(rule, (focused as TreeViewItem)?.DataContext);
+    }
+
+    [AvaloniaFact]
+    public void CtrlUp_WalksTheSameCategory()
+    {
+        var (vm, window) = Open();
+        var category = vm.Nodes[1];
+        ClickNode(window, vm, category);
+
+        CtrlKey(window, PhysicalKey.ArrowUp);
+
+        Assert.Equal("c2,c1", Categories(vm));
+        Assert.Same(category, vm.SelectedNode);
+    }
+}


### PR DESCRIPTION
Fixes #14136.

## The bug

In Multiple replace, Ctrl+Up/Down on a rule reorders it once and then the selection jumps to the rule's category, so a second press moves the *category* instead of continuing to walk the rule. You have to reselect the rule after every single step.

## Cause

Restoring focus after the move used `RulesTreeView.ContainerFromItem(node)` — that is `ItemsControl.ContainerFromItem`, which only searches the TreeView's own top-level items, i.e. the categories. A rule lives one level down, so the lookup returned `null` and the `Focus()` call was silently skipped.

`ObservableCollection.Move` rebuilds the row container, so the moved rule's old container — the one that had keyboard focus — is gone. With the refocus a no-op, focus ended up nowhere at all. On the next key press Avalonia handed focus to the tree, which parked it on the category's `TreeViewItem`, and `SelectingItemsControl` turns that focus into a selection change.

Instrumented headless run, before the fix:

```
after1=r1,r2,r4,r3 sel1=RULE:r4 focus1=<none> | after2=r1,r2,r4,r3 sel2=CAT:c1 focus2=TVI:CAT:c1
```

and after:

```
after1=r1,r2,r4,r3 sel1=RULE:r4 focus1=TVI:RULE:r4 | after2=r1,r4,r2,r3 sel2=RULE:r4 focus2=TVI:RULE:r4
```

## Fix

Use `TreeView.TreeContainerFromItem`, which walks the whole tree, and fold the three copies of the select-and-focus block into one `FocusNode` helper. All three had the same broken lookup, so "go to rule" after **Find rule** and the reselect after **Delete** were losing focus on nested rules too.

## Tests

New `MultipleReplaceMoveFocusTests` drives the real window — click a row, send Ctrl+Arrow — and checks that repeated presses keep walking the same node, that the moved row keeps keyboard focus, and that categories still move. The existing `MultipleReplaceMoveTests` call the view model directly with no TreeView, which is why they never caught this.

3 of the 4 new tests fail on the old code; the category one passes either way, since categories *are* top-level. Full Multiple replace suite: 82 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)