### PR TITLE
Video OCR: engine list review — best-measured first, drop Paddle Python, curate CrispEmbed backends

### DIFF
--- a/src/libuilogic/LlamaCpp/LlamaCppServerManager.cs
+++ b/src/libuilogic/LlamaCpp/LlamaCppServerManager.cs
@@ -287,6 +287,12 @@ public static class LlamaCppServerManager
     /// subtitles; HunyuanOCR 12/14 recognized (0.6%) with the same merging; LightOnOCR 9/14
     /// recognized (2.53%) at 18.5 s/image - weakest and ~7x slower, hence last.
     /// </summary>
+    // DeepSeek-OCR-2 was evaluated for this list and rejected (2026-08-26): through
+    // mainline llama.cpp with the OCR prompt it captions the image ("The image displays a
+    // scene from...") instead of extracting text - 2/24 subtitle lines exact at 11 s/image
+    // on a burned-in video clip where GLM-OCR scored 21/24 at 4 s. Its strong results come
+    // from CrispEmbed's fork, which drives the model's own crop/prompt modes, so that is
+    // where SE offers it.
     public static readonly IReadOnlyList<LlamaCppModel> OcrModels = new[]
     {
         new LlamaCppModel("GLM-OCR 0.9B (Q8_0)", "GLM-OCR-Q8_0.gguf", "1.4 GB",

--- a/src/ui/Features/Video/VideoOcr/VideoOcrEngineItem.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrEngineItem.cs
@@ -22,25 +22,30 @@ public class VideoOcrEngineItem
         return Name;
     }
 
+    /// <summary>
+    /// Best measured engine first (burned-in subtitle clips of real footage with real SRTs
+    /// as ground truth, 2026-08-26): Apple Vision led on accuracy and speed with zero setup;
+    /// Paddle Standalone was next and is by far the fastest batch engine on Windows/Linux;
+    /// the local VLM engines (CrispEmbed / llama.cpp, both defaulting to GLM-OCR) follow at
+    /// roughly 1 s/frame; Ollama needs a user-managed install and the GLM API needs a key,
+    /// so they close the list. The pip-based Paddle Python engine was dropped from this list:
+    /// getting a matching Python + paddle install working is the most support-heavy path,
+    /// and every remaining engine is either built in or downloaded automatically.
+    /// </summary>
     public static List<VideoOcrEngineItem> GetEngines()
     {
         var list = new List<VideoOcrEngineItem>();
 
+        // Nothing to download and no key: on macOS this works the moment the window opens.
+        if (AppleVisionOcr.IsAvailable())
+        {
+            list.Add(new(AppleVisionOcr.StaticName, OcrEngineType.AppleVision,
+                "macOS's built-in OCR engine - local, no download needed"));
+        }
+
         if (OperatingSystem.IsWindows() || OperatingSystem.IsLinux())
         {
             list.Add(new("Paddle OCR Standalone", OcrEngineType.PaddleOcrStandalone, "Local OCR engine (downloaded automatically) - fast and accurate"));
-        }
-
-        list.Add(new("Paddle OCR Python", OcrEngineType.PaddleOcrPython, "Local OCR engine via Python (requires \"pip install paddleocr\")"));
-        list.Add(new("Ollama vision", OcrEngineType.Ollama, "Local vision model via Ollama - e.g. glm-ocr"));
-        list.Add(new("llama.cpp", OcrEngineType.LlamaCpp, "Local vision model via llama.cpp (downloaded automatically)"));
-
-        // Nothing to download and no key: on macOS this is the one engine that works the
-        // moment the window opens, so it goes first.
-        if (AppleVisionOcr.IsAvailable())
-        {
-            list.Insert(0, new(AppleVisionOcr.StaticName, OcrEngineType.AppleVision,
-                "macOS's built-in OCR engine - local, no download needed"));
         }
 
         if (CrispEmbedEngine.CanBeDownloaded())
@@ -49,6 +54,8 @@ public class VideoOcrEngineItem
                 "Local OCR engine with multiple model backends (downloaded automatically)"));
         }
 
+        list.Add(new("llama.cpp", OcrEngineType.LlamaCpp, "Local vision model via llama.cpp (downloaded automatically)"));
+        list.Add(new("Ollama vision", OcrEngineType.Ollama, "Local vision model via Ollama - e.g. glm-ocr"));
         list.Add(new("GLM API", OcrEngineType.Glm, "GLM vision model via Z.ai / bigmodel.cn API (requires API key)"));
 
         return list;

--- a/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
@@ -129,7 +129,19 @@ public partial class VideoOcrViewModel : ObservableObject
         LlamaCppModels = new ObservableCollection<LlamaCppModelDisplay>();
         LlamaCppLanguage = string.Empty;
         LlamaCppServerButtonText = Se.Language.General.StartServer;
-        CrispEmbedBackends = new ObservableCollection<CrispEmbedBackend>(CrispEmbedEngine.GetBackends());
+        // For burned-in video, only the backends that measured well are offered, best first
+        // (real-footage clips with burned real SRTs as ground truth, 2026-08-26): GLM-OCR
+        // 19/24 lines exact at ~1.1 s/frame; DeepSeek-OCR-2 was the close second in the
+        // 2026-08-12 frame corpus; PP-OCRv6 is the light option (79 MB, detector-based) and
+        // holds up on ordinary backgrounds. GOT-OCR2 (13/24, 27 phantom lines from textless
+        // frames) and Qwen3-VL-2B (18/24, 22 phantom lines, 1.7 s/frame) are left to the
+        // subtitle-bitmap OCR window, whose clean crops they were tuned for.
+        var videoBackendNames = new[] { "GLM-OCR", "DeepSeek-OCR-2", "PP-OCRv6" };
+        CrispEmbedBackends = new ObservableCollection<CrispEmbedBackend>(
+            videoBackendNames
+                .Select(name => CrispEmbedEngine.GetBackends().FirstOrDefault(p => p.Name == name))
+                .Where(p => p != null)
+                .Select(p => p!));
         CrispEmbedModels = new ObservableCollection<CrispEmbedModelDisplay>();
         ProgressText = string.Empty;
         PreviewPositionText = string.Empty;

--- a/tests/UI/Features/Video/VideoOcr/VideoOcrEngineListTests.cs
+++ b/tests/UI/Features/Video/VideoOcr/VideoOcrEngineListTests.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Linq;
+using Avalonia.Headless.XUnit;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Features.Ocr.Engines;
+using Nikse.SubtitleEdit.Features.Video.VideoOcr;
+
+namespace UITests.Features.Video.VideoOcr;
+
+/// <summary>
+/// The Video OCR engine list: ordered best-measured-first per platform, and without the
+/// pip-based Paddle Python engine - the one path that needs a manually managed Python
+/// install, while every listed engine is either built in or downloaded automatically.
+/// </summary>
+public class VideoOcrEngineListTests
+{
+    [Fact]
+    public void Engines_DoNotOfferPaddlePython()
+    {
+        Assert.DoesNotContain(VideoOcrEngineItem.GetEngines(),
+            engine => engine.EngineType == OcrEngineType.PaddleOcrPython);
+    }
+
+    [Fact]
+    public void Engines_BestMeasuredEngineComesFirst()
+    {
+        var first = VideoOcrEngineItem.GetEngines()[0].EngineType;
+
+        if (AppleVisionOcr.IsAvailable())
+        {
+            Assert.Equal(OcrEngineType.AppleVision, first);
+        }
+        else if (OperatingSystem.IsWindows() || OperatingSystem.IsLinux())
+        {
+            Assert.Equal(OcrEngineType.PaddleOcrStandalone, first);
+        }
+    }
+
+    [Fact]
+    public void Engines_CloudEngineComesLast()
+    {
+        Assert.Equal(OcrEngineType.Glm, VideoOcrEngineItem.GetEngines()[^1].EngineType);
+    }
+}
+
+/// <summary>
+/// The video window offers only the CrispEmbed backends that measured well on burned-in
+/// video, best first - not the full list the subtitle-bitmap OCR window shows.
+/// </summary>
+public class VideoOcrCrispEmbedBackendListTests
+{
+    [AvaloniaFact]
+    public void CrispEmbedBackends_AreTheMeasuredVideoSet_BestFirst()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        using var provider = services.BuildServiceProvider();
+        var viewModel = provider.GetRequiredService<VideoOcrViewModel>();
+
+        Assert.Equal(new[] { "GLM-OCR", "DeepSeek-OCR-2", "PP-OCRv6" },
+            viewModel.CrispEmbedBackends.Select(p => p.Name));
+    }
+}

--- a/tests/UI/Features/Video/VideoOcr/VideoOcrViewModelCrispEmbedTests.cs
+++ b/tests/UI/Features/Video/VideoOcr/VideoOcrViewModelCrispEmbedTests.cs
@@ -69,7 +69,7 @@ public class VideoOcrViewModelCrispEmbedTests
             Assert.Equal("GLM-OCR", viewModel.SelectedCrispEmbedBackend?.Name);
             Assert.Equal("glm-ocr-q4_k.gguf", viewModel.SelectedCrispEmbedModel?.Model.Name);
 
-            var otherBackend = viewModel.CrispEmbedBackends.First(p => p.Name == "GOT-OCR2");
+            var otherBackend = viewModel.CrispEmbedBackends.First(p => p.Name == "PP-OCRv6");
             viewModel.SelectedCrispEmbedBackend = otherBackend;
 
             Assert.All(viewModel.CrispEmbedModels, m => Assert.Equal(otherBackend, m.Backend));
@@ -80,7 +80,7 @@ public class VideoOcrViewModelCrispEmbedTests
             Assert.Equal("GLM-OCR", settings.CrispEmbedBackend);
 
             Invoke(viewModel, "SaveSettings");
-            Assert.Equal("GOT-OCR2", settings.CrispEmbedBackend);
+            Assert.Equal("PP-OCRv6", settings.CrispEmbedBackend);
             Assert.Equal(viewModel.SelectedCrispEmbedModel?.Model.Name, settings.CrispEmbedModel);
         }
         finally
@@ -104,12 +104,12 @@ public class VideoOcrViewModelCrispEmbedTests
         try
         {
             Se.Settings.Ocr.CrispEmbedBackend = "GLM-OCR";
-            videoSettings.CrispEmbedBackend = "GOT-OCR2";
+            videoSettings.CrispEmbedBackend = "PP-OCRv6";
 
             var viewModel = MakeViewModel();
             viewModel.SelectedEngine = viewModel.Engines.First(p => p.EngineType == OcrEngineType.CrispEmbed);
 
-            Assert.Equal("GOT-OCR2", viewModel.SelectedCrispEmbedBackend?.Name);
+            Assert.Equal("PP-OCRv6", viewModel.SelectedCrispEmbedBackend?.Name);
             Assert.Equal("GLM-OCR", Se.Settings.Ocr.CrispEmbedBackend);
         }
         finally


### PR DESCRIPTION
Follow-up to #14138, answering the engine-list questions with the same ground-truth methodology (real footage, real SRTs burned in, scored for exact lines / CER / phantom lines / speed).

### Measurements that drove the decisions (2-min stress clip, 382 frames)

| engine / model | exact lines | phantom lines | speed |
|---|---|---|---|
| Apple Vision | 22/24 | 0 | ~25 ms/frame |
| Paddle Standalone (masked input) | 21/24 | 9 | ~0.3 s/frame |
| CrispEmbed GLM-OCR q8 | 19/24 | 14 | 1.1 s/frame |
| llama.cpp GLM-OCR Q8 | 21/24 | 30 | 4.1 s/frame |
| CrispEmbed Qwen3-VL-2B q8 | 18/24 | 22 | 1.7 s/frame |
| CrispEmbed GOT-OCR2 q8 | 13/24 | 27 | 1.7 s/frame |
| llama.cpp DeepSeek-OCR-2 Q4_K_M | 2/24 | 34 | 11.2 s/frame |

### Changes

- **Engine order, best measured first per platform**: Apple Vision (macOS) / Paddle OCR Standalone (Windows/Linux) → CrispEmbed → llama.cpp → Ollama → GLM API.
- **Paddle OCR Python removed from the Video OCR window** — the one path needing a manually managed Python+paddle install; every remaining engine is built in or auto-downloaded. Saved selections fall back to the platform's best engine.
- **CrispEmbed backends curated for video**: GLM-OCR → DeepSeek-OCR-2 → PP-OCRv6. GOT-OCR2 and Qwen3-VL-2B hallucinate lines on textless frames and stay in the subtitle-bitmap OCR window only.
- **llama.cpp model list unchanged**, with a comment recording that DeepSeek-OCR-2 was evaluated and rejected: through mainline llama.cpp it captions the frame ("The image displays a scene from a video game…") instead of extracting text — its strong results come from CrispEmbed's fork driving the model's own crop/prompt modes, which is where SE offers it. Custom GGUF auto-discovery still lets power users add anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)