### PR TITLE
Video OCR: OCR fix engine + spell check coloring, edit dialog, context menu

### DIFF
--- a/docs/features/video-ocr.md
+++ b/docs/features/video-ocr.md
@@ -10,40 +10,58 @@ Extract hardcoded (burned-in) subtitles from a video into editable text lines us
 2. Use the preview slider to find a frame that shows a subtitle
 3. Adjust the scan area rectangle so it covers where the subtitles appear (default: bottom third) — drag to move/resize, or use the preset buttons
 4. Pick an OCR engine and language (for Ollama and llama.cpp, also pick a vision model)
-5. Optionally click **Test OCR** to try the current frame before running the full pass
-6. Click **Start OCR** — lines appear in the list as they are recognized
+5. Optionally click **Test current frame** to try the current frame before running the full pass
+6. Click **Start OCR** — lines appear in the list as they are recognized, already run through the OCR fix engine and spell check when a dictionary is selected
 7. Click **OK** to load the result into the main window
 
-The recognized text is editable directly in the list, so OCR mistakes can be fixed in place. Double-click a line to show the frame it came from in the preview, and press Delete to remove selected lines.
+To fix an OCR mistake, press **Enter** (or **F2**) on a line — or right-click and choose
+**Edit...** — to open the text in a small edit window. The right-click menu also offers
+**Italic** and **Delete** (the Delete key works too). Double-click a line to show the frame
+it came from in the preview.
 
 ## OCR Engines
 
-- **Paddle OCR** — local, fast and accurate; downloaded automatically (Windows/Linux). Recommended.
-- **Paddle OCR Python** — local, via a Python `paddleocr` installation (also works on macOS)
-- **Ollama vision** — local vision model via [Ollama](https://ollama.com), e.g. `glm-ocr`
+Engines are listed best-first for burned-in subtitles:
+
+- **Apple Vision** (macOS) — the OCR built into macOS: local, fast, and nothing to download. Recommended on macOS.
+- **Paddle OCR** (Windows/Linux) — local, fast and accurate; downloaded automatically. Recommended on Windows and Linux.
+- **CrispEmbed** — local OCR engine with several model backends, downloaded automatically. For video the offered backends are GLM-OCR (default), DeepSeek-OCR-2 and PP-OCRv6 (see [OCR](ocr.md#crispembed)).
 - **llama.cpp** — local vision model via a managed llama.cpp server; the engine and models are downloaded automatically. Available models, listed best-first for subtitles: GLM-OCR 0.9B (the default), PaddleOCR-VL 1.6 (109 languages), HunyuanOCR 1.5 and LightOnOCR 1B. A green dot marks models that are already downloaded; custom vision models in the llama.cpp models folder also appear, as long as the `mmproj` vision projector sits next to the `*.gguf` (see [OCR](ocr.md#llamacpp)).
-- **CrispEmbed** — local OCR engine with several model backends, downloaded automatically; pick the backend and model from the dropdowns (see [OCR](ocr.md#crispembed) for the backend list)
-- **GLM API** — GLM vision model via the Z.ai / bigmodel.cn API (requires an API key)
+- **Ollama vision** — local vision model via a self-managed [Ollama](https://ollama.com) installation, e.g. `glm-ocr`
 - **GLM API** — GLM vision model via the Z.ai / bigmodel.cn cloud API (requires an API key)
 
 ## How It Works
 
 Frames are sampled from the scan area at a few frames per second with ffmpeg. Consecutive
 near-identical frames are collapsed so each on-screen subtitle is OCR'ed only once, then
-consecutive OCR results with near-identical text are merged into one line with correct start/end
-times (the text variant shown the longest wins).
+consecutive OCR results with near-identical text are merged into one line (the text variant
+shown the longest wins, weighted by the engine's recognition confidence where available).
+Finally each line's start and end are refined against the video's own frames, so the times
+are precise to a few hundredths of a second even though the scan itself samples much coarser.
+
+## Fix OCR errors and spell check
+
+With **Fix OCR errors** enabled and a **Dictionary** selected (the list shows the
+[spell check dictionaries](spell-check.md) already downloaded; the language is pre-picked
+from the OCR language), every line runs through the OCR fix engine as it is recognized:
+common OCR mistakes are corrected from the language's replace list, and the words are
+spell checked. In the list, words the dictionary knows are shown green and unknown words
+red — so the lines that need a human eye stand out while the OCR is still running.
 
 ## Settings
 
-- **Frames per second** — how many frames per second to sample (higher = more precise timing, slower)
+- **Frames per second** — how many frames per second to sample (higher = more precise grouping, slower)
 - **Text brightness minimum** — pixels darker than this are ignored when comparing frames, so the
   comparison follows the (bright) subtitle text instead of the moving video behind it; frames with
-  no bright pixels are skipped entirely. Set to 0 to disable (e.g. for dark subtitle text).
+  no bright pixels are skipped entirely. With the Paddle engine, everything below this brightness is
+  also blacked out in the image the engine reads, so darker scene text (shirt prints, credits) does
+  not get mixed into the subtitles. Set to 0 to disable (e.g. for dark subtitle text).
 - **Merge lines with similarity (%)** — how similar the text of two consecutive OCR results must be to merge into one line
 - **Max gap between lines (ms)** — maximum time gap allowed when merging
 - **Minimum duration (ms)** — lines shorter than this are dropped (removes OCR blips/false positives)
 - **Add ASSA position tag** — prepend an alignment tag (e.g. `{\an8}` for a top scan area) based on
   the scan area position, for Advanced Sub Station Alpha output
+- **Fix OCR errors** / **Dictionary** — see above
 
 ## Tips
 

--- a/src/ui/Features/Video/VideoOcr/VideoOcrLineItem.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrLineItem.cs
@@ -1,4 +1,10 @@
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
+using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
 using System;
 
 namespace Nikse.SubtitleEdit.Features.Video.VideoOcr;
@@ -8,7 +14,40 @@ public partial class VideoOcrLineItem : ObservableObject
     [ObservableProperty] private int _number;
     [ObservableProperty] private TimeSpan _startTime;
     [ObservableProperty] private TimeSpan _endTime;
-    [ObservableProperty] private string _text = string.Empty;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(FormattedText))]
+    private string _text = string.Empty;
+
+    /// <summary>The OCR fix engine's per-word result for <see cref="Text"/>, or null when no
+    /// fix/spell check ran. Drives the per-word coloring in <see cref="FormattedText"/>.</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(FormattedText))]
+    private OcrFixLineResult? _fixResult;
 
     public TimeSpan Duration => EndTime - StartTime;
+
+    /// <summary>
+    /// The text cell's content: per-word colored runs when the fix engine ran (green =
+    /// word known, red = unknown, matching the subtitle-bitmap OCR window), otherwise the
+    /// plain text. The base foreground is always set explicitly - the table's cell theme
+    /// does not flow the theme foreground into templated content, which rendered the text
+    /// black on the dark theme.
+    /// </summary>
+    public TextBlock FormattedText
+    {
+        get
+        {
+            var baseBrush = UiTheme.IsDarkThemeEnabled() ? Brushes.WhiteSmoke : Brushes.Black;
+
+            var textBlock = FixResult != null
+                ? FixResult.GetFormattedText()
+                : new TextBlock { Text = Text };
+
+            textBlock.Foreground = baseBrush;
+            textBlock.VerticalAlignment = VerticalAlignment.Center;
+            textBlock.TextTrimming = TextTrimming.CharacterEllipsis;
+            return textBlock;
+        }
+    }
 }

--- a/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
@@ -10,6 +10,7 @@ using Nikse.SubtitleEdit.Features.Ocr.CrispEmbedSettings;
 using Nikse.SubtitleEdit.Features.Ocr.Download;
 using Nikse.SubtitleEdit.Features.Ocr.Engines;
 using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.SpellCheck;
 using Nikse.SubtitleEdit.Features.Translate;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -28,6 +29,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
 using Nikse.SubtitleEdit.UiLogic.Media;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace Nikse.SubtitleEdit.Features.Video.VideoOcr;
 
@@ -42,6 +45,9 @@ public partial class VideoOcrViewModel : ObservableObject
     [ObservableProperty] private bool _isCrispEmbedEngine;
     [ObservableProperty] private bool _isAppleVisionEngine;
     [ObservableProperty] private string _selectedEngineDescription;
+    [ObservableProperty] private ObservableCollection<SpellCheckDictionaryDisplay> _dictionaries;
+    [ObservableProperty] private SpellCheckDictionaryDisplay? _selectedDictionary;
+    [ObservableProperty] private bool _doFixOcrErrors;
     [ObservableProperty] private ObservableCollection<OcrLanguage2> _paddleLanguages;
     [ObservableProperty] private OcrLanguage2? _selectedPaddleLanguage;
     [ObservableProperty] private ObservableCollection<OcrLanguage2> _appleVisionLanguages;
@@ -94,6 +100,8 @@ public partial class VideoOcrViewModel : ObservableObject
     /// <summary>The video being OCR'ed - the window shows its file name in the title.</summary>
     public string VideoFileName => _videoFileName;
     private CancellationTokenSource _cancellationTokenSource = new();
+    private readonly ISpellCheckManager _spellCheckManager;
+    private readonly IOcrFixEngine _ocrFixEngine;
     private Process? _ffmpegProcess;
     private long _extractedFrames;
     private readonly DispatcherTimer _previewTimer;
@@ -110,9 +118,12 @@ public partial class VideoOcrViewModel : ObservableObject
 
     private readonly IWindowService _windowService;
 
-    public VideoOcrViewModel(IWindowService windowService)
+    public VideoOcrViewModel(IWindowService windowService, ISpellCheckManager spellCheckManager, IOcrFixEngine ocrFixEngine)
     {
         _windowService = windowService;
+        _spellCheckManager = spellCheckManager;
+        _ocrFixEngine = ocrFixEngine;
+        Dictionaries = new ObservableCollection<SpellCheckDictionaryDisplay>();
 
         Engines = new ObservableCollection<VideoOcrEngineItem>(VideoOcrEngineItem.GetEngines());
         SelectedEngine = Engines[0];
@@ -713,6 +724,8 @@ public partial class VideoOcrViewModel : ObservableObject
                 },
                 cancellationToken), cancellationToken);
 
+            InitializeOcrFixEngine(contextSubtitle: null);
+
             await RunOcr(groups, cancellationToken);
 
             var mergedLines = VideoOcrLineBuilder.Build(groups, FramesPerSecond, TextSimilarityPercent, MaxGapMs, MinDurationMs);
@@ -756,14 +769,18 @@ public partial class VideoOcrViewModel : ObservableObject
             var number = 1;
             foreach (var line in mergedLines)
             {
-                Lines.Add(new VideoOcrLineItem
+                var item = new VideoOcrLineItem
                 {
                     Number = number++,
                     StartTime = TimeSpan.FromMilliseconds(line.StartMs),
                     EndTime = TimeSpan.FromMilliseconds(line.EndMs),
                     Text = positionTag + line.Text,
-                });
+                };
+                item.PropertyChanged += LineItemPropertyChanged;
+                Lines.Add(item);
             }
+
+            ApplyOcrFixes();
 
             IsRunning = false;
             IsOkEnabled = Lines.Count > 0;
@@ -937,13 +954,15 @@ public partial class VideoOcrViewModel : ObservableObject
 
             Dispatcher.UIThread.Post(() =>
             {
-                Lines.Add(new VideoOcrLineItem
+                var item = new VideoOcrLineItem
                 {
                     Number = Lines.Count + 1,
                     StartTime = TimeSpan.FromMilliseconds(group.GetStartMs(FramesPerSecond)),
                     EndTime = TimeSpan.FromMilliseconds(group.GetEndMs(FramesPerSecond)),
                     Text = group.Text,
-                });
+                };
+                ApplyFixToItem(item, Lines.Count);
+                Lines.Add(item);
             });
         }
 
@@ -1233,6 +1252,65 @@ public partial class VideoOcrViewModel : ObservableObject
         MaxGapMs = Math.Clamp(settings.MaxGapMs, 0, 10_000);
         MinDurationMs = Math.Clamp(settings.MinDurationMs, 0, 10_000);
         AddAssaPositionTag = settings.AddAssaPositionTag;
+        DoFixOcrErrors = settings.FixOcrErrors;
+        LoadDictionaries(settings.DictionaryFileName);
+    }
+
+    /// <summary>
+    /// Fills the spell check dictionary combo: "- None -" first, then the downloaded
+    /// dictionaries. The saved pick wins; otherwise the first dictionary matching the
+    /// engine's OCR language is chosen, so post-processing works without any setup for
+    /// users who already have the dictionary.
+    /// </summary>
+    private void LoadDictionaries(string savedDictionaryFileName)
+    {
+        Dictionaries.Clear();
+        Dictionaries.Add(new SpellCheckDictionaryDisplay
+        {
+            Name = $"- {Se.Language.General.None} -",
+            DictionaryFileName = string.Empty,
+        });
+
+        List<SpellCheckDictionaryDisplay> languages;
+        try
+        {
+            languages = _spellCheckManager.GetDictionaryLanguages(Se.DictionariesFolder);
+        }
+        catch
+        {
+            languages = new List<SpellCheckDictionaryDisplay>();
+        }
+
+        Dictionaries.AddRange(LanguageFavoritesHelper.Order(languages, d => SpellCheckDictionaryDisplay.GetTwoLetterLanguageCode(d)));
+
+        if (!string.IsNullOrEmpty(savedDictionaryFileName))
+        {
+            SelectedDictionary = Dictionaries.FirstOrDefault(d => d.DictionaryFileName == savedDictionaryFileName);
+        }
+
+        SelectedDictionary ??= Dictionaries.FirstOrDefault(d =>
+                                   SpellCheckDictionaryDisplay.GetTwoLetterLanguageCode(d) == GetOcrTwoLetterLanguageCode())
+                               ?? Dictionaries[0];
+    }
+
+    /// <summary>The current engine's OCR language as a two-letter code, for the dictionary auto-pick.</summary>
+    private string GetOcrTwoLetterLanguageCode()
+    {
+        var engineType = SelectedEngine?.EngineType;
+        if (engineType is OcrEngineType.PaddleOcrStandalone or OcrEngineType.PaddleOcrPython)
+        {
+            var code = SelectedPaddleLanguage?.Code ?? "en";
+            return code.Length >= 2 ? code[..2] : "en";
+        }
+
+        if (engineType == OcrEngineType.AppleVision)
+        {
+            var code = SelectedAppleVisionLanguage?.Code ?? "en";
+            return code.Length >= 2 ? code[..2] : "en";
+        }
+
+        // The VLM engines take a language name ("English"); default to English.
+        return "en";
     }
 
     private void SaveSettings()
@@ -1261,6 +1339,8 @@ public partial class VideoOcrViewModel : ObservableObject
         settings.MaxGapMs = MaxGapMs;
         settings.MinDurationMs = MinDurationMs;
         settings.AddAssaPositionTag = AddAssaPositionTag;
+        settings.FixOcrErrors = DoFixOcrErrors;
+        settings.DictionaryFileName = SelectedDictionary?.DictionaryFileName ?? string.Empty;
 
         if (VideoWidth > 0 && VideoHeight > 0)
         {
@@ -1318,6 +1398,171 @@ public partial class VideoOcrViewModel : ObservableObject
     }
 
     /// <summary>Moves the preview to the given line's start time (double-click in the grid).</summary>
+    /// <summary>
+    /// Runs the OCR fix engine (replace lists + spell check) over the result lines: each
+    /// line's text is replaced by the fixed text, and lines with words the dictionary does
+    /// not know are marked so the table can tint them. No per-word prompting here - a video
+    /// run produces hundreds of lines, so unknown words are marked for in-place fixing
+    /// instead.
+    /// </summary>
+    internal void ApplyOcrFixes()
+    {
+        if (!_ocrFixEngine.IsLoaded() && Lines.Count > 0)
+        {
+            InitializeOcrFixEngine(contextSubtitle: null);
+        }
+
+        if (!_ocrFixEngine.IsLoaded())
+        {
+            return;
+        }
+
+        // Re-initialize with the full result as context so the engine's name lists and
+        // word statistics see the whole subtitle, then fix each line.
+        var contextSubtitle = new Subtitle();
+        foreach (var line in Lines)
+        {
+            contextSubtitle.Paragraphs.Add(new Paragraph(line.Text, line.StartTime.TotalMilliseconds, line.EndTime.TotalMilliseconds));
+        }
+
+        InitializeOcrFixEngine(contextSubtitle);
+        for (var i = 0; i < Lines.Count; i++)
+        {
+            ApplyFixToItem(Lines[i], i);
+        }
+    }
+
+    /// <summary>Loads the OCR fix engine for the chosen dictionary (or unloads it when the
+    /// fix is off / no dictionary is chosen). Runs before OCR starts, so lines are fixed and
+    /// colored as they appear.</summary>
+    private void InitializeOcrFixEngine(Subtitle? contextSubtitle)
+    {
+        if (!DoFixOcrErrors ||
+            SelectedDictionary is not { } dictionary ||
+            string.IsNullOrEmpty(dictionary.DictionaryFileName))
+        {
+            _ocrFixEngine.Unload();
+            return;
+        }
+
+        try
+        {
+            _ocrFixEngine.Initialize(contextSubtitle ?? new Subtitle(), dictionary.GetThreeLetterCode(), dictionary);
+        }
+        catch (Exception exception)
+        {
+            Se.LogError(exception, "Video OCR: could not initialize the OCR fix engine");
+        }
+    }
+
+    /// <summary>Runs one line through the fix engine: the fixed text replaces the raw OCR
+    /// text and the per-word result drives the coloring.</summary>
+    private void ApplyFixToItem(VideoOcrLineItem item, int index)
+    {
+        if (!_ocrFixEngine.IsLoaded())
+        {
+            return;
+        }
+
+        try
+        {
+            var result = _ocrFixEngine.FixOcrErrors(index, item.Text, doTryToGuessUnknownWords: false);
+            item.Text = result.GetText();
+            item.FixResult = result;
+        }
+        catch (Exception exception)
+        {
+            Se.LogError(exception, "Video OCR: fix engine failed on a line");
+        }
+    }
+
+    /// <summary>
+    /// Re-evaluates the coloring when a line's text changes (the Edit dialog, italic
+    /// toggle). Only the coloring is updated - the text is left exactly as written.
+    /// </summary>
+    private void LineItemPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(VideoOcrLineItem.Text) ||
+            sender is not VideoOcrLineItem item ||
+            item.FixResult == null ||
+            !_ocrFixEngine.IsLoaded())
+        {
+            return;
+        }
+
+        try
+        {
+            var result = _ocrFixEngine.FixOcrErrors(Lines.IndexOf(item), item.Text, doTryToGuessUnknownWords: false);
+
+            // Only keep the per-word coloring when the engine's view of the line matches the
+            // text exactly - the cell renders the result's words, and a mismatch (the user
+            // deliberately typed something the engine would "fix") would display stale text.
+            item.FixResult = result.GetText() == item.Text ? result : null;
+        }
+        catch
+        {
+            // ignore - coloring is best-effort
+        }
+    }
+
+    /// <summary>Wraps the lines in italic tags - or unwraps them when every line is already italic.</summary>
+    internal static void ToggleItalic(List<VideoOcrLineItem> items)
+    {
+        if (items.Count == 0)
+        {
+            return;
+        }
+
+        var allItalic = items.All(p => IsFullyItalic(p.Text));
+        foreach (var item in items)
+        {
+            if (allItalic)
+            {
+                var text = item.Text.Trim();
+                item.Text = text[3..^4].Trim();
+            }
+            else if (!IsFullyItalic(item.Text))
+            {
+                item.Text = "<i>" + item.Text.Trim() + "</i>";
+            }
+        }
+    }
+
+    private static bool IsFullyItalic(string text)
+    {
+        var trimmed = text.Trim();
+        return trimmed.StartsWith("<i>", StringComparison.OrdinalIgnoreCase) &&
+               trimmed.EndsWith("</i>", StringComparison.OrdinalIgnoreCase) &&
+
+               // "<i>a</i> b <i>c</i>" starts and ends with tags but is not fully italic.
+               trimmed.IndexOf("</i>", StringComparison.OrdinalIgnoreCase) == trimmed.Length - 4;
+    }
+
+    /// <summary>Opens the text of a line in a small edit window (multi-line texts do not
+    /// edit comfortably inside a table row).</summary>
+    internal async Task EditLine(VideoOcrLineItem item)
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var result = await _windowService.ShowDialogAsync<Features.Shared.PromptTextBox.PromptTextBoxWindow,
+            Features.Shared.PromptTextBox.PromptTextBoxViewModel>(Window, viewModel =>
+        {
+            viewModel.Initialize(
+                string.Format(Se.Language.Video.VideoOcr.EditLineX, item.Number),
+                item.Text,
+                500,
+                80);
+        });
+
+        if (result.OkPressed)
+        {
+            item.Text = result.Text.Trim().Replace("\r\n", "\n").Replace('\r', '\n');
+        }
+    }
+
     internal void SeekPreview(VideoOcrLineItem item)
     {
         PreviewPositionSeconds = Math.Clamp(item.StartTime.TotalSeconds, 0, DurationSeconds);

--- a/src/ui/Features/Video/VideoOcr/VideoOcrWindow.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrWindow.cs
@@ -580,14 +580,20 @@ public class VideoOcrWindow : Window
 
                 e.Handled = true;
             }
-            else if (e.Key is Avalonia.Input.Key.Enter or Avalonia.Input.Key.F2 &&
-                     e.Source is not TextBox &&
-                     tableView.SelectedItem is VideoOcrLineItem editItem)
+        };
+
+        // Tunnel phase: the TableView handles Enter internally (see #12734), so a bubbling
+        // KeyDown never sees it - the edit shortcut must run before the control's own handling.
+        tableView.AddHandler(KeyDownEvent, (s, e) =>
+        {
+            if (e.Key is Avalonia.Input.Key.Enter or Avalonia.Input.Key.F2 &&
+                e.Source is not TextBox &&
+                tableView.SelectedItem is VideoOcrLineItem editItem)
             {
                 e.Handled = true;
                 _ = vm.EditLine(editItem);
             }
-        };
+        }, RoutingStrategies.Tunnel);
 
         return UiUtil.MakeBorderForControl(tableView);
     }

--- a/src/ui/Features/Video/VideoOcr/VideoOcrWindow.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrWindow.cs
@@ -340,6 +340,11 @@ public class VideoOcrWindow : Window
             Se.Language.Video.VideoOcr.MinDurationMs,
             UiUtil.MakeNumericUpDownInt(0, 10_000, 250, 120, vm, nameof(vm.MinDurationMs))));
         panel.Children.Add(UiUtil.MakeCheckBox(Se.Language.Video.VideoOcr.AddAssaPositionTag, vm, nameof(vm.AddAssaPositionTag)));
+        panel.Children.Add(UiUtil.MakeCheckBox(Se.Language.Video.VideoOcr.FixOcrErrors, vm, nameof(vm.DoFixOcrErrors)));
+        panel.Children.Add(MakeSettingRow(
+            Se.Language.Video.VideoOcr.Dictionary,
+            UiUtil.MakeComboBox(vm.Dictionaries, vm, nameof(vm.SelectedDictionary)).WithWidth(220)
+                .WithBindEnabled(nameof(vm.DoFixOcrErrors))));
 
         var scrollViewer = new ScrollViewer
         {
@@ -495,35 +500,63 @@ public class VideoOcrWindow : Window
             Width = new GridLength(90),
         });
 
-        // TableView has no cell editing, so the editable text column (OCR mistakes must stay
-        // fixable in place) becomes a borderless in-cell TextBox bound two-way.
+        // Text is edited in a dialog (context menu "Edit..." - multi-line texts do not edit
+        // comfortably inside a table row). The cell renders the item's FormattedText: the
+        // fix engine's per-word coloring (green = word known, red = unknown, same palette as
+        // the subtitle-bitmap OCR window) as lines arrive during OCR, plain themed text
+        // before that. Everything is bound (never captured), so container recycling stays
+        // safe - see the FuncDataTemplate recycling notes in NOcrTrainFontListTests.
         tableView.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Text,
-            CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+            CellTheme = UiUtil.TableViewCellTheme,
             HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
             Width = new GridLength(1, GridUnitType.Star),
-            CellTemplate = new Avalonia.Controls.Templates.FuncDataTemplate<VideoOcrLineItem>((item, _) =>
-            {
-                if (item == null)
+            CellTemplate = new Avalonia.Controls.Templates.FuncDataTemplate<VideoOcrLineItem>((_, _) =>
+                new ContentControl
                 {
-                    return new TextBlock();
-                }
-
-                var textBox = new TextBox
-                {
-                    Background = Brushes.Transparent,
-                    BorderThickness = new Thickness(0),
                     VerticalContentAlignment = VerticalAlignment.Center,
-                    [!TextBox.TextProperty] = new Binding(nameof(VideoOcrLineItem.Text)) { Mode = BindingMode.TwoWay },
-                };
-
-                // Clicking into a cell to edit should also make it the current row, so the
-                // double-tap preview seek and Delete act on the line being edited.
-                textBox.GotFocus += (_, _) => tableView.SelectedItem = item;
-                return textBox;
-            }),
+                    [!ContentControl.ContentProperty] = new Binding(nameof(VideoOcrLineItem.FormattedText)),
+                }, supportsRecycling: true),
         });
+
+        var flyout = new MenuFlyout();
+        var menuItemEdit = new MenuItem
+        {
+            Header = Se.Language.General.EditDotDotDot,
+            InputGesture = new Avalonia.Input.KeyGesture(Avalonia.Input.Key.Enter),
+        };
+        menuItemEdit.Click += async (_, _) =>
+        {
+            if (tableView.SelectedItem is VideoOcrLineItem item)
+            {
+                await vm.EditLine(item);
+            }
+        };
+        flyout.Items.Add(menuItemEdit);
+
+        var menuItemItalic = new MenuItem
+        {
+            Header = Se.Language.General.Italic,
+        };
+        menuItemItalic.Click += (_, _) =>
+        {
+            VideoOcrViewModel.ToggleItalic(tableView.SelectedItems.OfType<VideoOcrLineItem>().ToList());
+        };
+        flyout.Items.Add(menuItemItalic);
+
+        var menuItemDelete = new MenuItem
+        {
+            Header = Se.Language.General.Delete,
+        };
+        menuItemDelete.Click += (_, _) =>
+        {
+            vm.DeleteLines(tableView.SelectedItems.OfType<VideoOcrLineItem>().ToList());
+        };
+        flyout.Items.Add(menuItemDelete);
+
+        tableView.ContextFlyout = flyout;
+        UiUtil.AttachMacContextFlyoutHandler(tableView);
 
         // Double-click a line to see the frame it came from in the preview.
         tableView.DoubleTapped += (s, e) =>
@@ -546,6 +579,13 @@ public class VideoOcrWindow : Window
                 }
 
                 e.Handled = true;
+            }
+            else if (e.Key is Avalonia.Input.Key.Enter or Avalonia.Input.Key.F2 &&
+                     e.Source is not TextBox &&
+                     tableView.SelectedItem is VideoOcrLineItem editItem)
+            {
+                e.Handled = true;
+                _ = vm.EditLine(editItem);
             }
         };
 

--- a/src/ui/Logic/Config/Language/Video/LanguageVideoOcr.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageVideoOcr.cs
@@ -25,6 +25,9 @@ public class LanguageVideoOcr
     public string NoLinesFoundMessage { get; set; }
     public string LinesFoundX { get; set; }
     public string RefiningTimingXY { get; set; }
+    public string FixOcrErrors { get; set; }
+    public string Dictionary { get; set; }
+    public string EditLineX { get; set; }
     public string PreviewPosition { get; set; }
     public string UnableToReadVideoTitle { get; set; }
     public string UnableToReadVideoMessage { get; set; }
@@ -60,6 +63,9 @@ public class LanguageVideoOcr
         NoLinesFoundMessage = "No text was found in the scan area - try adjusting the scan area, engine, or brightness minimum.";
         LinesFoundX = "{0} lines found";
         RefiningTimingXY = "Refining timing... {0}/{1}";
+        FixOcrErrors = "Fix OCR errors";
+        Dictionary = "Dictionary";
+        EditLineX = "Edit line {0}";
         PreviewPosition = "Preview position";
         UnableToReadVideoTitle = "Unable to read video";
         UnableToReadVideoMessage = "Could not read video info from: {0}";

--- a/src/ui/Logic/Config/SeVideoOcr.cs
+++ b/src/ui/Logic/Config/SeVideoOcr.cs
@@ -28,6 +28,12 @@ public class SeVideoOcr
     public int BrightnessMinimum { get; set; }
     public int MaxImageWidth { get; set; }
     public bool AddAssaPositionTag { get; set; }
+
+    /// <summary>Run the OCR fix engine (replace lists + spell check marking) on the result lines.</summary>
+    public bool FixOcrErrors { get; set; }
+
+    /// <summary>Spell check dictionary for the fix engine; empty = pick by the OCR language.</summary>
+    public string DictionaryFileName { get; set; }
     public double CropXPercent { get; set; }
     public double CropYPercent { get; set; }
     public double CropWidthPercent { get; set; }
@@ -65,6 +71,8 @@ public class SeVideoOcr
         BrightnessMinimum = 190;
         MaxImageWidth = 720;
         AddAssaPositionTag = false;
+        FixOcrErrors = true;
+        DictionaryFileName = string.Empty;
 
         // Default scan area: bottom third, full width.
         CropXPercent = 0;

--- a/tests/UI/Features/VideoOcrTests.cs
+++ b/tests/UI/Features/VideoOcrTests.cs
@@ -70,6 +70,41 @@ public class VideoOcrTests
         Assert.Equal(2, lines.Count);
     }
 
+    [Theory]
+    [InlineData("Hello", "<i>Hello</i>")]                 // plain -> wrapped
+    [InlineData("<i>Hello</i>", "Hello")]                 // fully italic -> unwrapped
+    public void ToggleItalic_SingleLine(string text, string expected)
+    {
+        var item = new VideoOcrLineItem { Text = text };
+
+        VideoOcrViewModel.ToggleItalic(new List<VideoOcrLineItem> { item });
+
+        Assert.Equal(expected, item.Text);
+    }
+
+    [Fact]
+    public void ToggleItalic_MixedSelection_MakesEverythingItalic()
+    {
+        // Partially italic selection: the un-italic line gets wrapped, the italic one is kept.
+        var plain = new VideoOcrLineItem { Text = "Plain" };
+        var italic = new VideoOcrLineItem { Text = "<i>Already</i>" };
+
+        VideoOcrViewModel.ToggleItalic(new List<VideoOcrLineItem> { plain, italic });
+
+        Assert.Equal("<i>Plain</i>", plain.Text);
+        Assert.Equal("<i>Already</i>", italic.Text);
+    }
+
+    [Fact]
+    public void ToggleItalic_PartiallyItalicText_IsNotTreatedAsFullyItalic()
+    {
+        var item = new VideoOcrLineItem { Text = "<i>a</i> b <i>c</i>" };
+
+        VideoOcrViewModel.ToggleItalic(new List<VideoOcrLineItem> { item });
+
+        Assert.Equal("<i><i>a</i> b <i>c</i></i>", item.Text);
+    }
+
     [Fact]
     public void Build_EqualConfidence_DurationStillDecides()
     {


### PR DESCRIPTION
Post-processing for the Video OCR window, ported from the subtitle-bitmap OCR window and adapted for video runs (verified visually through several iterations):

- **Fix OCR errors + dictionary combo** — the OCR fix engine (replace lists, word splits, user dictionary) runs on every line **as it appears during OCR**, and the fixed text replaces the raw OCR. Dictionary auto-picks from the engine's OCR language.
- **Per-word spell check coloring, live** — green = known word, red = unknown, same renderer/palette as the OCR window; no per-word prompting (a video run produces hundreds of lines).
- **Edit dialog** (context menu "Edit…", Enter/F2) replaces the in-cell TextBox — multi-line cues don't edit comfortably in a row. Edits re-color immediately.
- **Context menu**: Edit…, Italic, Delete.
- Fixes black-on-dark text in the table: the cell theme doesn't flow the theme foreground into templated content, so cells set an explicit base foreground.

🤖 Generated with [Claude Code](https://claude.com/claude-code)