### PR TITLE
Spell check: play the current line in the video player

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -2108,6 +2108,7 @@
     "chooseSpellCheckDictionary": "Choose spell check dictionary",
     "pickLiveSpellCheckDictionary": "Pick live spell check dictionary",
     "undoX": "Undo: {0}",
+    "playCurrentLineHint": "Play the current line in the video player and pause at its end",
     "editWholeText": "Edit whole text",
     "editWholeTextTitle": "Spell check - Edit whole text",
     "continueFromCurrentLine": "Continue spell check from the current line?\n\nYes = continue from the current line\nNo = start from the beginning",

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -8116,7 +8116,8 @@ public partial class MainViewModel :
         // the detected language instead of overriding it.
         var result = await ShowDialogAsync<SpellCheckWindow, SpellCheckViewModel>(vm =>
         {
-            vm.Initialize(Subtitles, SelectedSubtitleIndex, this, _currentSpellCheckDictionary, _spellCheckSessionInProgress);
+            vm.Initialize(Subtitles, SelectedSubtitleIndex, this, _currentSpellCheckDictionary, _spellCheckSessionInProgress,
+                MakeLinePlayer(), StopReviewLinePlayback);
         });
 
         // Only an unfinished spell check leaves something to continue from, and only then is the
@@ -8572,6 +8573,31 @@ public partial class MainViewModel :
             }
 
             PlayLineAndPauseAtEnd(vp, lines[index]);
+        };
+    }
+
+    /// <summary>
+    /// Item-based variant of <see cref="MakeReviewLinePlayer"/> for dialogs that work on the
+    /// grid's own line objects (spell check) instead of a copy of the subtitle - no index mapping
+    /// is needed, so the hook cannot drift if lines move. Null when no video is loaded; the dialog
+    /// then hides its play button.
+    /// </summary>
+    private Action<SubtitleLineViewModel>? MakeLinePlayer()
+    {
+        if (string.IsNullOrEmpty(_videoFileName))
+        {
+            return null;
+        }
+
+        return item =>
+        {
+            var vp = GetVideoPlayerControl();
+            if (vp == null)
+            {
+                return;
+            }
+
+            PlayLineAndPauseAtEnd(vp, item);
         };
     }
 

--- a/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
@@ -56,11 +56,15 @@ public partial class SpellCheckViewModel : ObservableObject, IClosingCleanup
     [ObservableProperty] private bool _areSuggestionsAvailable;
     [ObservableProperty] private bool _isPrompting;
     [ObservableProperty] private ObservableCollection<SubtitleLineViewModel> _paragraphs;
-    [ObservableProperty] private SubtitleLineViewModel? _selectedParagraph;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(PlayCurrentLineCommand))]
+    private SubtitleLineViewModel? _selectedParagraph;
     [ObservableProperty] private Bitmap? _sourceImage;
     [ObservableProperty] private bool _hasSourceImage;
     [ObservableProperty] private bool _isUndoVisible;
     [ObservableProperty] private string _undoText;
+    [ObservableProperty] private bool _isPlayVisible;
 
     public Window? Window { get; set; }
     public int TotalChangedWords { get; set; }
@@ -105,6 +109,12 @@ public partial class SpellCheckViewModel : ObservableObject, IClosingCleanup
     // True when a spell check of this subtitle was left unfinished, which is the only case where
     // "continue spell check from current line?" has something to continue from.
     private bool _sessionInProgress;
+
+    // Video preview hooks handed in by the caller - they drive the main window's video player.
+    // Null when no video is loaded; the play button is then hidden.
+    private Action<SubtitleLineViewModel>? _playLine;
+    private Action? _stopPlayback;
+    private bool _hasPlayed;
 
     public SpellCheckViewModel(ISpellCheckManager spellCheckManager, IWindowService windowService, IFileHelper fileHelper, IBluRayHelper bluRayHelper, IOcrImageSourceHolder ocrImageSourceHolder)
     {
@@ -431,11 +441,22 @@ public partial class SpellCheckViewModel : ObservableObject, IClosingCleanup
         previous?.Dispose();
     }
 
+    /// <summary>
+    /// Starts the spell check. <paramref name="playLine"/> plays a line in the main video player
+    /// and pauses at its end, so a word can be checked against the audio - the reason to have it
+    /// here is STT output, where only the audio says what the word should be (issue #14145). Pass
+    /// null (no video loaded) to hide the play button. <paramref name="stopPlayback"/> stops such
+    /// a preview when the window closes - only ever called when this window started playback.
+    /// </summary>
     public void Initialize(ObservableCollection<SubtitleLineViewModel> paragraphs, int? selectedSubtitleIndex,
-        IFocusSubtitleLine focusSubtitleLine, SpellCheckDictionaryDisplay? spellCheckDictionary, bool sessionInProgress = false)
+        IFocusSubtitleLine focusSubtitleLine, SpellCheckDictionaryDisplay? spellCheckDictionary, bool sessionInProgress = false,
+        Action<SubtitleLineViewModel>? playLine = null, Action? stopPlayback = null)
     {
         _focusSubtitleLine = focusSubtitleLine;
         _sessionInProgress = sessionInProgress;
+        _playLine = playLine;
+        _stopPlayback = stopPlayback;
+        IsPlayVisible = playLine != null;
         Paragraphs.Clear();
         Paragraphs.AddRange(paragraphs);
         SetLanguage(spellCheckDictionary);
@@ -922,6 +943,36 @@ public partial class SpellCheckViewModel : ObservableObject, IClosingCleanup
         Dispatcher.UIThread.Invoke(() => { Window?.Close(); });
     }
 
+    /// <summary>
+    /// Plays the line the current word belongs to in the main video player and pauses at its end,
+    /// so an unknown word can be judged by ear without leaving the spell check (issue #14145).
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanPlayCurrentLine))]
+    private void PlayCurrentLine()
+    {
+        var paragraph = SelectedParagraph;
+        if (paragraph == null || _playLine == null)
+        {
+            return;
+        }
+
+        _hasPlayed = true;
+        _playLine(paragraph);
+    }
+
+    private bool CanPlayCurrentLine() => SelectedParagraph != null;
+
+    /// <summary>
+    /// True when the pressed keys match the user's main-window "play selected lines" (default F5)
+    /// or second play/pause (default Ctrl/Cmd+Space) binding. Bare Space is deliberately not
+    /// included - it types a space in the word text box.
+    /// </summary>
+    private static bool MatchesPlayShortcut(KeyEventArgs e)
+    {
+        return MainShortcutKeys.Matches(e, nameof(MainViewModel.PlaySelectedLinesWithoutLoopCommand), [nameof(Key.F5)]) ||
+               MainShortcutKeys.Matches(e, nameof(MainViewModel.TogglePlayPause2Command), [MainShortcutKeys.CtrlOrCmd, nameof(Key.Space)]);
+    }
+
     internal void OnKeyDown(KeyEventArgs e)
     {
         if (e.Key == Key.Escape)
@@ -933,6 +984,11 @@ public partial class SpellCheckViewModel : ObservableObject, IClosingCleanup
         {
             e.Handled = true;
             UiUtil.ShowHelp("features/spell-check");
+        }
+        else if (IsPlayVisible && MatchesPlayShortcut(e))
+        {
+            e.Handled = true;
+            PlayCurrentLine();
         }
     }
 
@@ -1171,6 +1227,13 @@ public partial class SpellCheckViewModel : ObservableObject, IClosingCleanup
     {
         _statusTimer?.StopAndDispose(StatusTimerElapsed);
         _statusTimer = null;
+
+        // Only stop what this window started - a video the user left playing before opening the
+        // spell check should keep playing.
+        if (_hasPlayed)
+        {
+            _stopPlayback?.Invoke();
+        }
     }
 
     private void StatusTimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)

--- a/src/ui/Features/SpellCheck/SpellCheckWindow.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckWindow.cs
@@ -27,6 +27,30 @@ public class SpellCheckWindow : Window
             [!Label.ContentProperty] = new Binding(nameof(SpellCheckViewModel.LineText)) { Mode = BindingMode.OneWay }
         };
 
+        // Plays the line the current word is in, in the main window's video player, and pauses at
+        // its end - hidden when no video is loaded (the view model then gets no play hook). Mainly
+        // for STT output, where only the audio says what an unknown word should be (#14145).
+        var buttonPlay = UiUtil.MakeButton(Se.Language.General.PlayCurrent, vm.PlayCurrentLineCommand)
+            .WithIconLeft("fa-solid fa-play");
+        buttonPlay.VerticalAlignment = VerticalAlignment.Bottom;
+        buttonPlay.Margin = new Thickness(10, 0, 0, 2);
+        buttonPlay.Bind(Visual.IsVisibleProperty, new Binding(nameof(SpellCheckViewModel.IsPlayVisible)));
+        if (Se.Settings.Appearance.ShowHints)
+        {
+            ToolTip.SetTip(buttonPlay, Se.Language.SpellCheck.PlayCurrentLineHint);
+        }
+
+        var panelLine = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            VerticalAlignment = VerticalAlignment.Bottom,
+            Children =
+            {
+                labelLine,
+                buttonPlay,
+            }
+        };
+
         var buttonEditWholeText = UiUtil.MakeButton(vm.EditWholeTextCommand, IconNames.Pencil, Se.Language.SpellCheck.EditWholeText);
         buttonEditWholeText.HorizontalAlignment = HorizontalAlignment.Right;
         buttonEditWholeText.VerticalAlignment = VerticalAlignment.Top;
@@ -89,7 +113,7 @@ public class SpellCheckWindow : Window
         };
 
 
-        grid.Add(labelLine, 0, 0);
+        grid.Add(panelLine, 0, 0);
         grid.Add(borderWholeText, 1, 0);
         grid.Add(panelButtons, 2, 0);
         grid.Add(buttonEditWholeText, 2, 0);

--- a/src/ui/Logic/Config/Language/SpellCheck/LanguageSpellCheck.cs
+++ b/src/ui/Logic/Config/Language/SpellCheck/LanguageSpellCheck.cs
@@ -33,6 +33,7 @@ public class LanguageSpellCheck
     public string ChooseSpellCheckDictionary { get; set; }
     public string PickLiveSpellCheckDictionary { get; set; }
     public string UndoX { get; set; }
+    public string PlayCurrentLineHint { get; set; }
     public string EditWholeText { get; set; }
     public string EditWholeTextTitle { get; set; }
     public string ContinueFromCurrentLine { get; set; }
@@ -76,6 +77,7 @@ public class LanguageSpellCheck
         ChooseSpellCheckDictionary = "Choose spell check dictionary";
         PickLiveSpellCheckDictionary = "Pick live spell check dictionary";
         UndoX = "Undo: {0}";
+        PlayCurrentLineHint = "Play the current line in the video player and pause at its end";
         EditWholeText = "Edit whole text";
         EditWholeTextTitle = "Spell check - Edit whole text";
         ContinueFromCurrentLine = "Continue spell check from the current line?\n\nYes = continue from the current line\nNo = start from the beginning";

--- a/tests/UI/Features/SpellCheck/SpellCheckPlayCurrentLineTests.cs
+++ b/tests/UI/Features/SpellCheck/SpellCheckPlayCurrentLineTests.cs
@@ -1,0 +1,102 @@
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.SpellCheck;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Media;
+using Nikse.SubtitleEdit.Logic.Ocr;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
+using System;
+using System.Collections.ObjectModel;
+
+namespace UITests.Features.SpellCheck;
+
+/// <summary>
+/// The spell check window can play the line the flagged word is in, in the main window's video
+/// player - on speech-to-text output the audio is often the only thing that says what an unknown
+/// word should be, and until this you had to close the window to listen (issue #14145).
+/// </summary>
+public class SpellCheckPlayCurrentLineTests
+{
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private sealed class NullFocusSubtitleLine : IFocusSubtitleLine
+    {
+        public void GoToAndFocusLine(SubtitleLineViewModel p)
+        {
+        }
+    }
+
+    private static ObservableCollection<SubtitleLineViewModel> MakeSubtitles()
+    {
+        return new ObservableCollection<SubtitleLineViewModel>
+        {
+            new() { Text = "I have not seen it, but that is not a problem." },
+            new() { Text = "What are you doing here so late in the evening?" },
+            new() { Text = "He said that they would come tomorrow." },
+        };
+    }
+
+    private static SpellCheckViewModel MakeViewModel()
+    {
+        return new SpellCheckViewModel(
+            new SpellCheckManager(),
+            new WindowService(new NullServiceProvider()),
+            new FileHelper(),
+            new BluRayHelper(),
+            new OcrImageSourceHolder());
+    }
+
+    [AvaloniaFact]
+    public void PlayCurrentLine_PlaysTheLineTheFlaggedWordIsIn()
+    {
+        var vm = MakeViewModel();
+        var subtitles = MakeSubtitles();
+        SubtitleLineViewModel? played = null;
+
+        vm.Initialize(subtitles, 0, new NullFocusSubtitleLine(), null, false, p => played = p, () => { });
+
+        Assert.True(vm.IsPlayVisible);
+
+        // What the scan does when it stops on a word: the paragraph it is in becomes the selected one.
+        vm.SelectedParagraph = subtitles[2];
+        Assert.True(vm.PlayCurrentLineCommand.CanExecute(null));
+        vm.PlayCurrentLineCommand.Execute(null);
+
+        Assert.Same(subtitles[2], played);
+    }
+
+    [AvaloniaFact]
+    public void NoVideoLoaded_HidesThePlayButton()
+    {
+        var vm = MakeViewModel();
+
+        // The main window hands in no play hook when no video is open.
+        vm.Initialize(MakeSubtitles(), 0, new NullFocusSubtitleLine(), null);
+
+        Assert.False(vm.IsPlayVisible);
+        Assert.False(vm.PlayCurrentLineCommand.CanExecute(null));
+    }
+
+    [AvaloniaFact]
+    public void Closing_StopsOnlyPlaybackThisWindowStarted()
+    {
+        var vm = MakeViewModel();
+        var subtitles = MakeSubtitles();
+        var stopCount = 0;
+
+        vm.Initialize(subtitles, 0, new NullFocusSubtitleLine(), null, false, _ => { }, () => stopCount++);
+
+        // Nothing was played here, so a video the user left running keeps running.
+        vm.OnClosingCleanup();
+        Assert.Equal(0, stopCount);
+
+        vm.SelectedParagraph = subtitles[0];
+        vm.PlayCurrentLineCommand.Execute(null);
+        vm.OnClosingCleanup();
+
+        Assert.Equal(1, stopCount);
+    }
+}


### PR DESCRIPTION
Fixes #14145.

While spell-checking there was no way to hear the line a flagged word is in — you had to close the window, play the video, and start the spell check over. That hurts most on speech-to-text output, where the audio is often the only thing that says what the unknown word should be.

A **Play current** button now sits next to the "line X of Y" label, wired exactly like the one in the AI review window:

- The main window hands the dialog a play hook (plays the line in the main video player and pauses at its end) and a stop hook.
- No video loaded → no hook → the button hides itself.
- **F5** / **Ctrl+Space** (whatever the user has bound for play in the main window) trigger it too. Bare Space is deliberately not used — it types into the "word not found" box.
- Playback started from the spell check is stopped when the window closes; a video the user left running before opening it is left alone.

The hook passed to spell check is item-based (`MakeLinePlayer`) rather than the AI review's index-based `MakeReviewLinePlayer`, because the dialog works on the grid's own line objects — no index mapping to drift.

Tests: 3 new tests in `SpellCheckPlayCurrentLineTests` (plays the current word's line, button hidden without video, stop-on-close only after playing). Full UI suite passes locally, and the layout was checked with a headless render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)