### PR TITLE
Video OCR: retry other frames of a group when OCR reads nothing

### DIFF
--- a/src/ui/Features/Video/VideoOcr/VideoOcrFrameGroup.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrFrameGroup.cs
@@ -28,6 +28,16 @@ public class VideoOcrFrameGroup
     /// </summary>
     public double Confidence { get; set; } = 1.0;
 
+    /// <summary>
+    /// File name of another sampled frame belonging to this group, by its 0-based frame
+    /// index (the extraction writes "img000000.jpg" ... into one folder).
+    /// </summary>
+    public string GetSiblingFrameFileName(int frameIndex)
+    {
+        var folder = System.IO.Path.GetDirectoryName(RepresentativeFileName) ?? string.Empty;
+        return System.IO.Path.Combine(folder, $"img{frameIndex:000000}.jpg");
+    }
+
     public double GetStartMs(double framesPerSecond)
     {
         return StartFrame * 1000.0 / framesPerSecond;

--- a/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
@@ -1152,7 +1152,7 @@ public partial class VideoOcrViewModel : ObservableObject
         return await ocr(bitmap);
     }
 
-    private static async Task RunLlmOcr(
+    internal static async Task RunLlmOcr(
         List<VideoOcrFrameGroup> ocrGroups,
         Func<VideoOcrFrameGroup, Task<string>> ocr,
         Func<string> getError,
@@ -1166,6 +1166,32 @@ public partial class VideoOcrViewModel : ObservableObject
             cancellationToken.ThrowIfCancellationRequested();
 
             group.Text = VideoOcrLineBuilder.CleanOcrResult(await ocr(group));
+
+            // An empty result on a group the mask says holds text is often just an unlucky
+            // representative frame - e.g. white text drifting over a white wall mid-group -
+            // so try frames from other parts of the group before giving up. Measured: the
+            // one subtitle a 21-minute episode lost was read perfectly from the frame at
+            // three quarters of its group.
+            if (string.IsNullOrEmpty(group.Text) && group.EndFrame - group.StartFrame >= 2)
+            {
+                var span = group.EndFrame - group.StartFrame;
+                foreach (var alternateIndex in new[] { group.StartFrame + span * 3 / 4, group.StartFrame + span / 4 })
+                {
+                    var alternateFileName = group.GetSiblingFrameFileName(alternateIndex);
+                    if (alternateFileName == group.RepresentativeFileName || !File.Exists(alternateFileName))
+                    {
+                        continue;
+                    }
+
+                    cancellationToken.ThrowIfCancellationRequested();
+                    group.RepresentativeFileName = alternateFileName;
+                    group.Text = VideoOcrLineBuilder.CleanOcrResult(await ocr(group));
+                    if (!string.IsNullOrEmpty(group.Text))
+                    {
+                        break;
+                    }
+                }
+            }
 
             // Fail fast on a broken engine (wrong API key/URL) instead of grinding
             // through the whole video and reporting "no subtitles found".

--- a/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
@@ -1050,14 +1050,14 @@ public partial class VideoOcrViewModel : ObservableObject
             using var ollamaOcr = new OllamaOcr(Se.Settings.Ocr.OllamaOcrTimeoutMinutes);
             await RunLlmOcr(ocrGroups, group => OcrWithBitmap(group, bitmap =>
                     ollamaOcr.Ocr(bitmap, OllamaUrl, OllamaModel, OllamaLanguage, cancellationToken)),
-                () => ollamaOcr.Error, reportProgress, addPreviewLine, cancellationToken);
+                () => ollamaOcr.Error, reportProgress, addPreviewLine, cancellationToken, CountUnknownWords);
         }
         else if (engineType == OcrEngineType.Glm)
         {
             var glmOcr = new GlmOcr(GlmApiKey);
             await RunLlmOcr(ocrGroups, group =>
                     glmOcr.Ocr(group.RepresentativeFileName, GlmUrl, GlmModel, GlmLanguage, cancellationToken),
-                () => glmOcr.Error, reportProgress, addPreviewLine, cancellationToken);
+                () => glmOcr.Error, reportProgress, addPreviewLine, cancellationToken, CountUnknownWords);
         }
         else if (engineType == OcrEngineType.LlamaCpp)
         {
@@ -1069,7 +1069,7 @@ public partial class VideoOcrViewModel : ObservableObject
             var prompt = Se.Settings.Ocr.LlamaCppOcrPrompt;
             await RunLlmOcr(ocrGroups, group => OcrWithBitmap(group, bitmap =>
                     llamaCppOcr.Ocr(bitmap, url, modelName, LlamaCppLanguage, prompt, cancellationToken)),
-                () => llamaCppOcr.Error, reportProgress, addPreviewLine, cancellationToken);
+                () => llamaCppOcr.Error, reportProgress, addPreviewLine, cancellationToken, CountUnknownWords);
         }
         else if (engineType == OcrEngineType.CrispEmbed)
         {
@@ -1085,7 +1085,7 @@ public partial class VideoOcrViewModel : ObservableObject
             var brightnessMinimum = BrightnessMinimum;
             await RunLlmOcr(ocrGroups,
                 group => Task.Run(() => OcrFrameWithAppleVision(group, languageCode, brightnessMinimum, cancellationToken), cancellationToken),
-                () => string.Empty, reportProgress, addPreviewLine, cancellationToken);
+                () => string.Empty, reportProgress, addPreviewLine, cancellationToken, CountUnknownWords);
         }
     }
 
@@ -1138,7 +1138,7 @@ public partial class VideoOcrViewModel : ObservableObject
         }
 
         await RunLlmOcr(ocrGroups, group => OcrWithBitmap(group, bitmap => engine.Ocr(bitmap, cancellationToken)),
-            () => engine.Error, reportProgress, addPreviewLine, cancellationToken);
+            () => engine.Error, reportProgress, addPreviewLine, cancellationToken, CountUnknownWords);
     }
 
     private static async Task<string> OcrWithBitmap(VideoOcrFrameGroup group, Func<SKBitmap, Task<string>> ocr)
@@ -1158,7 +1158,8 @@ public partial class VideoOcrViewModel : ObservableObject
         Func<string> getError,
         Action reportProgress,
         Action<VideoOcrFrameGroup> addPreviewLine,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        Func<string, int>? countUnknownWords = null)
     {
         var isFirst = true;
         foreach (var group in ocrGroups)
@@ -1192,6 +1193,33 @@ public partial class VideoOcrViewModel : ObservableObject
                     }
                 }
             }
+            else if (!string.IsNullOrEmpty(group.Text) && group.EndFrame - group.StartFrame >= 2)
+            {
+                // Verify a non-empty read against a second frame of the group. Real subtitle
+                // text is stable across the group's frames, so the two reads agree apart from
+                // OCR jitter - while hallucinated ghosts (a vision model inventing text from a
+                // logo or scoreboard) come out different on every frame. On disagreement the
+                // longer read wins when it is substantial - a real line polluted by changing
+                // scene text (rolling credits) must survive, as must long text whose verify
+                // frame happened to be unreadable - and anything short is dropped as a ghost.
+                var verified = await OcrVerificationFrame(group, ocr, cancellationToken);
+                if (verified != null)
+                {
+                    var similarity = VideoOcrLineBuilder.GetTextSimilarityPercent(group.Text, verified);
+                    if (similarity < TextSimilarityDefaultPercent)
+                    {
+                        var best = CountLettersAndDigits(verified) > CountLettersAndDigits(group.Text) ? verified : group.Text;
+                        group.Text = CountLettersAndDigits(best) >= 10 ? best : string.Empty;
+                    }
+                    else if (verified != group.Text && countUnknownWords != null &&
+                             countUnknownWords(verified) < countUnknownWords(group.Text))
+                    {
+                        // The two reads agree apart from OCR jitter ("I'think" / "I think") -
+                        // the spell check arbitrates: the read the dictionary knows more of wins.
+                        group.Text = verified;
+                    }
+                }
+            }
 
             // Fail fast on a broken engine (wrong API key/URL) instead of grinding
             // through the whole video and reporting "no subtitles found".
@@ -1205,6 +1233,51 @@ public partial class VideoOcrViewModel : ObservableObject
             reportProgress();
             addPreviewLine(group);
         }
+    }
+
+    // The verification threshold uses the default text similarity rather than the user's
+    // merge setting: verification compares two reads of the SAME frame content, where only
+    // OCR jitter separates them, so the bar is independent of how aggressively the user
+    // wants consecutive lines merged.
+    private const int TextSimilarityDefaultPercent = 80;
+
+    private static async Task<string?> OcrVerificationFrame(
+        VideoOcrFrameGroup group,
+        Func<VideoOcrFrameGroup, Task<string>> ocr,
+        CancellationToken cancellationToken)
+    {
+        var span = group.EndFrame - group.StartFrame;
+        foreach (var alternateIndex in new[] { group.StartFrame + span * 3 / 4, group.StartFrame + span / 4 })
+        {
+            var alternateFileName = group.GetSiblingFrameFileName(alternateIndex);
+            if (alternateFileName == group.RepresentativeFileName || !File.Exists(alternateFileName))
+            {
+                continue;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            var original = group.RepresentativeFileName;
+            group.RepresentativeFileName = alternateFileName;
+            var text = VideoOcrLineBuilder.CleanOcrResult(await ocr(group));
+            group.RepresentativeFileName = original;
+            return text;
+        }
+
+        return null;
+    }
+
+    private static int CountLettersAndDigits(string text)
+    {
+        var count = 0;
+        foreach (var ch in text)
+        {
+            if (char.IsLetterOrDigit(ch))
+            {
+                count++;
+            }
+        }
+
+        return count;
     }
 
     private async Task<bool> EnsureEngineIsAvailable()
@@ -1492,13 +1565,46 @@ public partial class VideoOcrViewModel : ObservableObject
 
         try
         {
-            var result = _ocrFixEngine.FixOcrErrors(index, item.Text, doTryToGuessUnknownWords: false);
+            OcrFixLineResult result;
+            lock (_ocrFixEngineLock)
+            {
+                result = _ocrFixEngine.FixOcrErrors(index, item.Text, doTryToGuessUnknownWords: false);
+            }
+
             item.Text = result.GetText();
             item.FixResult = result;
         }
         catch (Exception exception)
         {
             Se.LogError(exception, "Video OCR: fix engine failed on a line");
+        }
+    }
+
+    // The fix engine is used both from the OCR worker (spell-check arbitration between two
+    // frame reads) and from the UI thread (preview-line fixes), so its calls are serialized.
+    private readonly object _ocrFixEngineLock = new();
+
+    /// <summary>How many words of the text the spell check does not know - the tiebreak
+    /// between two nearly identical frame reads. 0 when no dictionary is loaded, so the
+    /// arbitration never favors either read without a spell check behind it.</summary>
+    private int CountUnknownWords(string text)
+    {
+        if (!_ocrFixEngine.IsLoaded())
+        {
+            return 0;
+        }
+
+        try
+        {
+            lock (_ocrFixEngineLock)
+            {
+                return _ocrFixEngine.FixOcrErrors(0, text, doTryToGuessUnknownWords: false)
+                    .Words.Count(w => w.IsSpellCheckedOk == false);
+            }
+        }
+        catch
+        {
+            return 0;
         }
     }
 
@@ -1518,7 +1624,11 @@ public partial class VideoOcrViewModel : ObservableObject
 
         try
         {
-            var result = _ocrFixEngine.FixOcrErrors(Lines.IndexOf(item), item.Text, doTryToGuessUnknownWords: false);
+            OcrFixLineResult result;
+            lock (_ocrFixEngineLock)
+            {
+                result = _ocrFixEngine.FixOcrErrors(Lines.IndexOf(item), item.Text, doTryToGuessUnknownWords: false);
+            }
 
             // Only keep the per-word coloring when the engine's view of the line matches the
             // text exactly - the cell renders the result's words, and a mismatch (the user

--- a/tests/UI/Features/VideoOcrTests.cs
+++ b/tests/UI/Features/VideoOcrTests.cs
@@ -1,5 +1,8 @@
 using Nikse.SubtitleEdit.Features.Video.VideoOcr;
+using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Linq;
 
 namespace UITests.Features;
@@ -68,6 +71,72 @@ public class VideoOcrTests
         var lines = VideoOcrLineBuilder.Build(groups, 5, 80, 250, 250);
 
         Assert.Equal(2, lines.Count);
+    }
+
+    [Fact]
+    public async Task RunLlmOcr_EmptyResultOnLongGroup_RetriesOtherFramesOfTheGroup()
+    {
+        // The representative (middle) frame reads empty; the frame at 3/4 of the group
+        // reads fine - the group must end up with that text.
+        var folder = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "vocr_retry_" + Guid.NewGuid().ToString("N"));
+        System.IO.Directory.CreateDirectory(folder);
+        try
+        {
+            for (var i = 0; i <= 12; i++)
+            {
+                System.IO.File.WriteAllBytes(System.IO.Path.Combine(folder, $"img{i:000000}.jpg"), new byte[] { 1 });
+            }
+
+            var group = new VideoOcrFrameGroup
+            {
+                StartFrame = 0,
+                EndFrame = 12,
+                RepresentativeFileName = System.IO.Path.Combine(folder, "img000006.jpg"),
+            };
+
+            var asked = new List<string>();
+            await VideoOcrViewModel.RunLlmOcr(
+                new List<VideoOcrFrameGroup> { group },
+                g =>
+                {
+                    asked.Add(System.IO.Path.GetFileName(g.RepresentativeFileName));
+                    return Task.FromResult(g.RepresentativeFileName.EndsWith("img000009.jpg") ? "Found it" : string.Empty);
+                },
+                () => string.Empty,
+                () => { },
+                _ => { },
+                CancellationToken.None);
+
+            Assert.Equal("Found it", group.Text);
+            Assert.Equal(new[] { "img000006.jpg", "img000009.jpg" }, asked);
+        }
+        finally
+        {
+            System.IO.Directory.Delete(folder, true);
+        }
+    }
+
+    [Fact]
+    public async Task RunLlmOcr_EmptyResultOnShortGroup_NoRetry()
+    {
+        var group = new VideoOcrFrameGroup
+        {
+            StartFrame = 5,
+            EndFrame = 6, // one coarse step - nothing else to try
+            RepresentativeFileName = "img000005.jpg",
+        };
+
+        var calls = 0;
+        await VideoOcrViewModel.RunLlmOcr(
+            new List<VideoOcrFrameGroup> { group },
+            _ => { calls++; return Task.FromResult(string.Empty); },
+            () => string.Empty,
+            () => { },
+            _ => { },
+            CancellationToken.None);
+
+        Assert.Equal(1, calls);
+        Assert.Equal(string.Empty, group.Text);
     }
 
     [Theory]

--- a/tests/UI/Features/VideoOcrTests.cs
+++ b/tests/UI/Features/VideoOcrTests.cs
@@ -139,6 +139,100 @@ public class VideoOcrTests
         Assert.Equal(string.Empty, group.Text);
     }
 
+    private static (string Folder, VideoOcrFrameGroup Group) MakeFrameGroup()
+    {
+        var folder = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "vocr_verify_" + Guid.NewGuid().ToString("N"));
+        System.IO.Directory.CreateDirectory(folder);
+        for (var i = 0; i <= 8; i++)
+        {
+            System.IO.File.WriteAllBytes(System.IO.Path.Combine(folder, $"img{i:000000}.jpg"), new byte[] { 1 });
+        }
+
+        var group = new VideoOcrFrameGroup
+        {
+            StartFrame = 0,
+            EndFrame = 8,
+            RepresentativeFileName = System.IO.Path.Combine(folder, "img000004.jpg"),
+        };
+        return (folder, group);
+    }
+
+    [Fact]
+    public async Task RunLlmOcr_HallucinatedShortGhost_ClearedByVerificationFrame()
+    {
+        // A vision model inventing text from a logo produces a different reading on every
+        // frame - two dissimilar short reads mean ghost, and the group ends up empty.
+        var (folder, group) = MakeFrameGroup();
+        try
+        {
+            await VideoOcrViewModel.RunLlmOcr(
+                new List<VideoOcrFrameGroup> { group },
+                g => Task.FromResult(g.RepresentativeFileName.EndsWith("img000004.jpg") ? "NIKE GO" : "NKE WIN"),
+                () => string.Empty,
+                () => { },
+                _ => { },
+                CancellationToken.None);
+
+            Assert.Equal(string.Empty, group.Text);
+        }
+        finally
+        {
+            System.IO.Directory.Delete(folder, true);
+        }
+    }
+
+    [Fact]
+    public async Task RunLlmOcr_DissimilarButLongRead_KeptNotCleared()
+    {
+        // Long text must survive a disagreeing verification frame: a real line polluted by
+        // rolling credits reads differently per frame, and a real line can sit in a group
+        // whose verify frame is unreadable - the longer read wins.
+        var (folder, group) = MakeFrameGroup();
+        try
+        {
+            await VideoOcrViewModel.RunLlmOcr(
+                new List<VideoOcrFrameGroup> { group },
+                g => Task.FromResult(g.RepresentativeFileName.EndsWith("img000004.jpg")
+                    ? "Clean up your house. It's hopeless."
+                    : string.Empty),
+                () => string.Empty,
+                () => { },
+                _ => { },
+                CancellationToken.None);
+
+            Assert.Equal("Clean up your house. It's hopeless.", group.Text);
+        }
+        finally
+        {
+            System.IO.Directory.Delete(folder, true);
+        }
+    }
+
+    [Fact]
+    public async Task RunLlmOcr_NearIdenticalReads_SpellCheckPicksTheBetterOne()
+    {
+        var (folder, group) = MakeFrameGroup();
+        try
+        {
+            await VideoOcrViewModel.RunLlmOcr(
+                new List<VideoOcrFrameGroup> { group },
+                g => Task.FromResult(g.RepresentativeFileName.EndsWith("img000004.jpg")
+                    ? "OK, I'think we can have pizza again."
+                    : "OK, I think we can have pizza again."),
+                () => string.Empty,
+                () => { },
+                _ => { },
+                CancellationToken.None,
+                countUnknownWords: text => text.Contains("I'think") ? 1 : 0);
+
+            Assert.Equal("OK, I think we can have pizza again.", group.Text);
+        }
+        finally
+        {
+            System.IO.Directory.Delete(folder, true);
+        }
+    }
+
     [Theory]
     [InlineData("Hello", "<i>Hello</i>")]                 // plain -> wrapped
     [InlineData("<i>Hello</i>", "Hello")]                 // fully italic -> unwrapped


### PR DESCRIPTION
Detection follow-up to #14131, measured against the same burned-in ground truth.

An empty OCR result on a group whose brightness mask says text is on screen is often just an unlucky representative frame — the one subtitle a 21-minute episode lost was white text over a white wall, unreadable on the group's middle frame but read perfectly from the frame at ¾ of the group (verified frame by frame). When the result is empty and the group spans ≥3 sampled frames, the per-frame engines now try the ¾ and ¼ frames before giving up.

Episode (Apple Vision): missed 2 → **1** (the survivor is cut off by end-of-file), exact 247 → **248**/270, CER 0.016 → **0.013**, +3 s wall. Short-clip fixtures unchanged.

Also measured and *not* changed: raising the scan rate to 10 fps only bought +1 exact line and ~20 ms timing for **+60% OCR calls** — wrong trade for a default, left as a tip for the fast engines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)