### PR TITLE
Video OCR: setting hints, dictionary download button, remembered window size

### DIFF
--- a/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
@@ -11,6 +11,7 @@ using Nikse.SubtitleEdit.Features.Ocr.Download;
 using Nikse.SubtitleEdit.Features.Ocr.Engines;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Features.SpellCheck;
+using Nikse.SubtitleEdit.Features.SpellCheck.GetDictionaries;
 using Nikse.SubtitleEdit.Features.Translate;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -1390,6 +1391,34 @@ public partial class VideoOcrViewModel : ObservableObject
         SelectedDictionary ??= Dictionaries.FirstOrDefault(d =>
                                    SpellCheckDictionaryDisplay.GetTwoLetterLanguageCode(d) == GetOcrTwoLetterLanguageCode())
                                ?? Dictionaries[0];
+    }
+
+    [RelayCommand]
+    private async Task DownloadDictionary()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var result = await _windowService.ShowDialogAsync<GetDictionariesWindow, GetDictionariesViewModel>(Window);
+        if (result.OkPressed && result.SelectedDictionary != null)
+        {
+            LoadDictionaries(Se.Settings.Video.VideoOcr.DictionaryFileName);
+
+            // Select the just-downloaded dictionary by its file name - matching the display
+            // name fails on non-English UIs (the list shows the localized culture name).
+            var downloadedFileName = Path.GetFileName(result.SpellCheckDictionary?.DictionaryFileName ?? string.Empty);
+            SelectedDictionary =
+                (!string.IsNullOrEmpty(downloadedFileName)
+                    ? Dictionaries.FirstOrDefault(d => string.Equals(
+                        Path.GetFileName(d.DictionaryFileName), downloadedFileName, StringComparison.OrdinalIgnoreCase))
+                    : null)
+                ?? Dictionaries.FirstOrDefault(d =>
+                    d.Name.Contains(result.SelectedDictionary.EnglishName, StringComparison.OrdinalIgnoreCase) ||
+                    d.Name.Contains(result.SelectedDictionary.NativeName, StringComparison.OrdinalIgnoreCase))
+                ?? SelectedDictionary;
+        }
     }
 
     /// <summary>The current engine's OCR language as a two-letter code, for the dictionary auto-pick.</summary>

--- a/src/ui/Features/Video/VideoOcr/VideoOcrWindow.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrWindow.cs
@@ -81,6 +81,8 @@ public class VideoOcrWindow : Window
         Content = grid;
 
         Activated += delegate { _comboEngine?.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
         Loaded += (s, e) => vm.OnLoaded();
         Closing += (s, e) => vm.OnClosing();
         AddHandler(KeyDownEvent, vm.OnKeyDownHandler, RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: false);
@@ -323,28 +325,50 @@ public class VideoOcrWindow : Window
         panel.Children.Add(MakeHeader(Se.Language.Video.VideoOcr.Scan));
         panel.Children.Add(MakeSettingRow(
             Se.Language.Video.VideoOcr.FramesPerSecond,
-            UiUtil.MakeNumericUpDownInt(1, 30, 5, 120, vm, nameof(vm.FramesPerSecond))));
+            UiUtil.MakeNumericUpDownInt(1, 30, 5, 120, vm, nameof(vm.FramesPerSecond)),
+            Se.Language.Video.VideoOcr.FramesPerSecondHint));
         panel.Children.Add(MakeSettingRow(
             Se.Language.Video.VideoOcr.TextBrightnessMinimum,
-            UiUtil.MakeNumericUpDownInt(0, 255, 190, 120, vm, nameof(vm.BrightnessMinimum))));
+            UiUtil.MakeNumericUpDownInt(0, 255, 190, 120, vm, nameof(vm.BrightnessMinimum)),
+            Se.Language.Video.VideoOcr.TextBrightnessMinimumHint));
 
         // Post-processing settings
         panel.Children.Add(MakeHeader(Se.Language.Video.VideoOcr.PostProcessing));
         panel.Children.Add(MakeSettingRow(
             Se.Language.Video.VideoOcr.TextSimilarityPercent,
-            UiUtil.MakeNumericUpDownInt(0, 100, 80, 120, vm, nameof(vm.TextSimilarityPercent))));
+            UiUtil.MakeNumericUpDownInt(0, 100, 80, 120, vm, nameof(vm.TextSimilarityPercent)),
+            Se.Language.Video.VideoOcr.TextSimilarityPercentHint));
         panel.Children.Add(MakeSettingRow(
             Se.Language.Video.VideoOcr.MaxGapMs,
-            UiUtil.MakeNumericUpDownInt(0, 10_000, 250, 120, vm, nameof(vm.MaxGapMs))));
+            UiUtil.MakeNumericUpDownInt(0, 10_000, 250, 120, vm, nameof(vm.MaxGapMs)),
+            Se.Language.Video.VideoOcr.MaxGapHint));
         panel.Children.Add(MakeSettingRow(
             Se.Language.Video.VideoOcr.MinDurationMs,
-            UiUtil.MakeNumericUpDownInt(0, 10_000, 250, 120, vm, nameof(vm.MinDurationMs))));
+            UiUtil.MakeNumericUpDownInt(0, 10_000, 250, 120, vm, nameof(vm.MinDurationMs)),
+            Se.Language.Video.VideoOcr.MinDurationHint));
         panel.Children.Add(UiUtil.MakeCheckBox(Se.Language.Video.VideoOcr.AddAssaPositionTag, vm, nameof(vm.AddAssaPositionTag)));
         panel.Children.Add(UiUtil.MakeCheckBox(Se.Language.Video.VideoOcr.FixOcrErrors, vm, nameof(vm.DoFixOcrErrors)));
+        var buttonDownloadDictionary = UiUtil.MakeButton("...", vm.DownloadDictionaryCommand)
+            .WithBindEnabled(nameof(vm.DoFixOcrErrors));
+        if (Se.Settings.Appearance.ShowHints)
+        {
+            ToolTip.SetTip(buttonDownloadDictionary, Se.Language.Video.VideoOcr.DownloadDictionaryHint);
+        }
+
         panel.Children.Add(MakeSettingRow(
             Se.Language.Video.VideoOcr.Dictionary,
-            UiUtil.MakeComboBox(vm.Dictionaries, vm, nameof(vm.SelectedDictionary)).WithWidth(220)
-                .WithBindEnabled(nameof(vm.DoFixOcrErrors))));
+            new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Spacing = 3,
+                Children =
+                {
+                    UiUtil.MakeComboBox(vm.Dictionaries, vm, nameof(vm.SelectedDictionary)).WithWidth(190)
+                        .WithBindEnabled(nameof(vm.DoFixOcrErrors)),
+                    buttonDownloadDictionary,
+                },
+            },
+            Se.Language.Video.VideoOcr.DictionaryHint));
 
         var scrollViewer = new ScrollViewer
         {
@@ -444,7 +468,7 @@ public class VideoOcrWindow : Window
         };
     }
 
-    private static Grid MakeSettingRow(string label, Control control)
+    private static Grid MakeSettingRow(string label, Control control, string? hint = null)
     {
         var grid = new Grid
         {
@@ -456,6 +480,12 @@ public class VideoOcrWindow : Window
         };
         grid.Add(UiUtil.MakeLabel(label), 0, 0);
         grid.Add(control, 0, 1);
+
+        if (hint != null && Se.Settings.Appearance.ShowHints)
+        {
+            ToolTip.SetTip(grid, hint);
+        }
+
         return grid;
     }
 

--- a/src/ui/Logic/Config/Language/Video/LanguageVideoOcr.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageVideoOcr.cs
@@ -28,6 +28,13 @@ public class LanguageVideoOcr
     public string FixOcrErrors { get; set; }
     public string Dictionary { get; set; }
     public string EditLineX { get; set; }
+    public string DownloadDictionaryHint { get; set; }
+    public string FramesPerSecondHint { get; set; }
+    public string TextBrightnessMinimumHint { get; set; }
+    public string TextSimilarityPercentHint { get; set; }
+    public string MaxGapHint { get; set; }
+    public string MinDurationHint { get; set; }
+    public string DictionaryHint { get; set; }
     public string PreviewPosition { get; set; }
     public string UnableToReadVideoTitle { get; set; }
     public string UnableToReadVideoMessage { get; set; }
@@ -66,6 +73,13 @@ public class LanguageVideoOcr
         FixOcrErrors = "Fix OCR errors";
         Dictionary = "Dictionary";
         EditLineX = "Edit line {0}";
+        DownloadDictionaryHint = "Download a spell check dictionary...";
+        FramesPerSecondHint = "How many frames per second are scanned. 5 covers normal subtitles; higher catches very short lines and tightens grouping, but costs more OCR time.";
+        TextBrightnessMinimumHint = "Pixels darker than this do not count as subtitle text: frame grouping follows the bright text, frames without any bright pixels are skipped, and the Paddle engine reads frames with everything darker blacked out. Set to 0 for dark subtitle text.";
+        TextSimilarityPercentHint = "How similar (in percent) two consecutive OCR results must be to count as the same subtitle and merge into one line.";
+        MaxGapHint = "Longest pause between two similar OCR results that still merges them into one subtitle - bridges one-frame flickers. Too high can merge a line that is shown twice in a row.";
+        MinDurationHint = "Lines on screen shorter than this are dropped as OCR blips.";
+        DictionaryHint = "Spell check dictionary used by the OCR fix engine and the word coloring: known words show green, unknown words red.";
         PreviewPosition = "Preview position";
         UnableToReadVideoTitle = "Unable to read video";
         UnableToReadVideoMessage = "Could not read video info from: {0}";


### PR DESCRIPTION
Three small quality-of-life wins for the Video OCR window:

- **Tooltips on every scan/post-processing setting** (guarded by *Show hints*): frames per second, brightness minimum, similarity, max gap, min duration, dictionary — each explains what the knob actually does and its trade-off.
- **"…" download button** next to the dictionary combo — opens the existing dictionary download window and auto-selects the downloaded dictionary (previously post-processing silently did nothing if no dictionary was installed).
- **Remembered window size/position** via the standard `RememberPositionAndSize` mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)