### PR TITLE
Fix 26 bugs found in a five-area hunt (formats, seconv, dialogs, UI, core)

### DIFF
--- a/src/libse/Common/HtmlUtil.cs
+++ b/src/libse/Common/HtmlUtil.cs
@@ -1592,14 +1592,14 @@ namespace Nikse.SubtitleEdit.Core.Common
                             endIndex = s.IndexOf("< /font>", match.Index - 5, StringComparison.OrdinalIgnoreCase);
                             if (endIndex >= 0)
                             {
-                                s = s.Remove(endIndex, 7);
+                                s = s.Remove(endIndex, 8);
                             }
                             else
                             {
                                 endIndex = s.IndexOf("</ font>", match.Index - 5, StringComparison.OrdinalIgnoreCase);
                                 if (endIndex >= 0)
                                 {
-                                    s = s.Remove(endIndex, 7);
+                                    s = s.Remove(endIndex, 8);
                                 }
                             }
                         }

--- a/src/libse/Common/StringExtensions.cs
+++ b/src/libse/Common/StringExtensions.cs
@@ -35,7 +35,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             }
 
             var len = text.Length;
-            if (len < 6 || text[len - 1] != '>')
+            if (len < 5 || text[len - 1] != '>')
             {
                 return false;
             }
@@ -46,7 +46,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 return true;
             }
 
-            if (includeFont && len > 8 && text[len - 7] == '<' && text[len - 6] == '/')
+            if (includeFont && len >= 8 && text[len - 7] == '<' && text[len - 6] == '/')
             {
                 return true;
             }

--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -2248,9 +2248,12 @@ namespace Nikse.SubtitleEdit.Core.Common
             }
             // f starts at 'start' within s, so offset f-relative index back into s
             var colorStart = start + f.IndexOf(" color=", StringComparison.OrdinalIgnoreCase);
-            if (s.IndexOf('"', colorStart + " color=".Length + 1) > 0)
+            var quoteIndex = s.IndexOf('"', colorStart + " color=".Length + 1);
+            if (quoteIndex > 0 && quoteIndex < end)
             {
-                end = s.IndexOf('"', colorStart + " color=".Length + 1);
+                // only a quote inside the font tag itself ends the value - a quotation mark
+                // in the dialogue text must not hijack an unquoted color attribute
+                end = quoteIndex;
             }
             s = s.Substring(colorStart, end - colorStart);
             s = s.Replace(" color=", string.Empty);
@@ -3098,7 +3101,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             // e.g.: \r\n</i>
             if (text.EndsWith(close5, StringComparison.Ordinal))
             {
-                text = text.Remove(text.Length - openTag.Length - Environment.NewLine.Length - 1, Environment.NewLine.Length);
+                text = text.Remove(text.Length - close5.Length, Environment.NewLine.Length);
             }
 
             if (text.Contains(open2, StringComparison.Ordinal))

--- a/src/libse/Forms/FixCommonErrors/FixCommas.cs
+++ b/src/libse/Forms/FixCommonErrors/FixCommas.cs
@@ -48,11 +48,13 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                         s = CommaTripleEndOfLine.Replace(s, "$1...");
                         s = CommaWhiteSpaceBetween.Replace(s, "$1,$2");
 
-                        var match = CommaFollowedByLetter.Match(s);
-                        if (match.Success && (!(match.Index > 0 && s[match.Index-1] == 'ό' && s.Substring(match.Index).StartsWith(",τι", StringComparison.OrdinalIgnoreCase)) || callbacks.Language != "el"))
-                        {
-                            s = CommaFollowedByLetter.Replace(s, ", $1");
-                        }
+                        // Per-match evaluator so a protected Greek "ό,τι" elsewhere in the text
+                        // neither gets a space inserted nor shields genuine errors from the fix.
+                        var input = s;
+                        s = CommaFollowedByLetter.Replace(input, m =>
+                            callbacks.Language == "el" && m.Index > 0 && input[m.Index - 1] == 'ό' && input.Substring(m.Index).StartsWith(",τι", StringComparison.OrdinalIgnoreCase)
+                                ? m.Value
+                                : ", " + m.Groups[1].Value);
 
                         s = RemoveCommaBeforeSentenceEndingChar(s, ',');
                     }

--- a/src/libse/Forms/FixCommonErrors/Helper.cs
+++ b/src/libse/Forms/FixCommonErrors/Helper.cs
@@ -649,7 +649,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                         if (parts.Count == 2 && !string.IsNullOrWhiteSpace(parts[0]))
                         {
                             var part0 = parts[0].TrimEnd().Trim('"');
-                            bool doAdd = "!?.".Contains(part0[part0.Length - 1]) || LanguageAutoDetect.IsLanguageWithoutPeriods(language);
+                            bool doAdd = part0.Length > 0 && ("!?.".Contains(part0[part0.Length - 1]) || LanguageAutoDetect.IsLanguageWithoutPeriods(language));
                             if (parts[0].TrimStart().StartsWith('-') && parts[1].Contains(':') && doAdd ||
                                 parts[1].TrimStart().StartsWith('-') && parts[0].Contains(':') && doAdd)
                             {

--- a/src/libse/SubtitleFormats/DvdStudioPro.cs
+++ b/src/libse/SubtitleFormats/DvdStudioPro.cs
@@ -223,6 +223,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var sb = new StringBuilder();
             bool italicOn = false;
             bool boldOn = false;
+            bool underlineOn = false;
             bool skipNext = false;
             for (int i = 0; i < text.Length; i++)
             {
@@ -242,6 +243,12 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     {
                         sb.Append(!boldOn ? "<b>" : "</b>");
                         boldOn = !boldOn;
+                        skipNext = true;
+                    }
+                    else if (text.Substring(i).StartsWith("^U", StringComparison.Ordinal))
+                    {
+                        sb.Append(!underlineOn ? "<u>" : "</u>");
+                        underlineOn = !underlineOn;
                         skipNext = true;
                     }
                     else

--- a/src/libse/SubtitleFormats/JacoSub.cs
+++ b/src/libse/SubtitleFormats/JacoSub.cs
@@ -175,7 +175,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             }
                         case 'T':
                             {
-                                sb.Append(DateTime.Now.ToString("HH:MM")); // HH:MM (24-hour time)
+                                sb.Append(DateTime.Now.ToString("HH:mm")); // HH:MM (24-hour time)
                                 i++;
                                 break;
                             }

--- a/src/libse/SubtitleFormats/KanopyHtml.cs
+++ b/src/libse/SubtitleFormats/KanopyHtml.cs
@@ -30,7 +30,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     start = $"{p.StartTime.Hours:00}:{start}";
                 }
 
-                sb.AppendLine($"      <a href='#' begin=\"{p.StartTime.TotalSeconds:0.000}\" end=\"{p.EndTime.TotalSeconds:0.000}\"><span class='ts'>{start}</span> {p.Text.Replace(Environment.NewLine, " <br />")}</a>");
+                var begin = p.StartTime.TotalSeconds.ToString("0.000", CultureInfo.InvariantCulture);
+                var end = p.EndTime.TotalSeconds.ToString("0.000", CultureInfo.InvariantCulture);
+                sb.AppendLine($"      <a href='#' begin=\"{begin}\" end=\"{end}\"><span class='ts'>{start}</span> {p.Text.Replace(Environment.NewLine, " <br />")}</a>");
             }
             sb.AppendLine("</div>");
             sb.AppendLine("</body>");

--- a/src/libse/SubtitleFormats/Lrc3DigitsMs.cs
+++ b/src/libse/SubtitleFormats/Lrc3DigitsMs.cs
@@ -279,7 +279,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     {
                         var minutes = int.Parse(parts[0]);
                         var seconds = int.Parse(parts[1]);
-                        var milliseconds = int.Parse(parts[2]) * 10;
+                        var milliseconds = int.Parse(parts[2]);
                         var text = GetTextAfterTimeCodes(p.Text);
                         var start = new TimeCode(0, minutes, seconds, milliseconds);
                         var newParagraph = new Paragraph(start, new TimeCode(), text);

--- a/src/libse/SubtitleFormats/SoftNiSub.cs
+++ b/src/libse/SubtitleFormats/SoftNiSub.cs
@@ -96,7 +96,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 sb.AppendLine(string.Format(writeFormat, text, Environment.NewLine, p.StartTime.ToHHMMSSPeriodFF(), p.EndTime.ToHHMMSSPeriodFF()));
             }
 
-            var last = subtitle.Paragraphs.Last();
+            var last = subtitle.Paragraphs.LastOrDefault();
             if (last == null)
             {
                 sb.AppendLine("*END*");

--- a/src/libse/SubtitleFormats/SubUrbia.cs
+++ b/src/libse/SubtitleFormats/SubUrbia.cs
@@ -38,14 +38,16 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
                 sb.Append(",\"text\":\"");
                 sb.Append(Json.EncodeJsonText(p.Text));
-                sb.Append("\"}");
+                sb.Append('"');
 
                 if (!string.IsNullOrWhiteSpace(p.Extra))
                 {
                     sb.Append(",\"comment\":\"");
                     sb.Append(Json.EncodeJsonText(p.Extra));
-                    sb.Append("\"}");
+                    sb.Append('"');
                 }
+
+                sb.Append('}');
 
                 count++;
             }

--- a/src/libse/SubtitleFormats/WhisperRaw2.cs
+++ b/src/libse/SubtitleFormats/WhisperRaw2.cs
@@ -29,7 +29,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         private static string EncodeEndTimeCode(TimeCode time)
         {
-            return $"{time.TotalSeconds:0.00}s";
+            return time.TotalSeconds.ToString("0.00", CultureInfo.InvariantCulture) + "s";
         }
 
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)

--- a/src/seconv/Core/ContainerSubtitleLoader.cs
+++ b/src/seconv/Core/ContainerSubtitleLoader.cs
@@ -338,6 +338,17 @@ internal static class ContainerSubtitleLoader
             tracks.Add(new LoadedTrack(subtitle, format, lang, track.TrackNumber, track.IsForced));
         }
 
+        // The file has subtitle tracks, but the filters (or OCR/decode failures) excluded
+        // every one of them. Fail loudly like the MP4/TS/MXF loaders do - a silent empty
+        // list would report a successful conversion of zero files.
+        if (tracks.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"No subtitle tracks matched in Matroska file: {filePath}" +
+                (options.TrackNumbers.Count > 0 ? $" (--track-number {string.Join(",", options.TrackNumbers)})" : string.Empty) +
+                (options.ForcedOnly ? " (--forced-only)" : string.Empty));
+        }
+
         return tracks;
     }
 

--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -185,13 +185,21 @@ internal class SubtitleConverter
             return result;
         }
 
+        // The VOB extractor copies subpicture packets verbatim - the timing transforms
+        // never run on this path, so refuse them rather than silently ignore them.
+        ThrowOnUnsupportedImagePassThroughOptions(options);
+
         // Derive output base name: --output-filename wins, otherwise use the first VOB's
         // stem dropped one underscore-segment (so VTS_01_1.VOB becomes VTS_01.sub for the
         // typical DVD layout). Falls back to the bare stem when there's no underscore.
         string outputBase;
         if (!string.IsNullOrEmpty(options.OutputFilename))
         {
-            outputBase = options.OutputFilename;
+            // Same rule as ResolveOutputFileName: a relative --output-filename still lands
+            // in --output-folder; an absolute one wins outright.
+            outputBase = !string.IsNullOrEmpty(options.OutputFolder) && !Path.IsPathRooted(options.OutputFilename)
+                ? Path.Combine(options.OutputFolder, options.OutputFilename)
+                : options.OutputFilename;
             // VobSubWriter derives the .idx path as Substring(0, length - 3) + "idx", so
             // a user-supplied --output-filename without ".sub" (e.g. "movie" or "movie.txt")
             // would produce a broken companion path like "vieidx" or "movie.tidx". Force
@@ -702,11 +710,40 @@ internal class SubtitleConverter
         return true;
     }
 
+    /// <summary>
+    /// The bitmap pass-through path writes the source items' timestamps verbatim - none of
+    /// the timing/deletion transforms run on it. Silently ignoring those options would make
+    /// a run look successful while producing something other than what was asked for, so
+    /// fail loudly instead (convert via a text/OCR format to apply them).
+    /// </summary>
+    private static void ThrowOnUnsupportedImagePassThroughOptions(ConversionOptions options)
+    {
+        var unsupported = new List<string>();
+        if (options.Offset.HasValue) { unsupported.Add("--offset"); }
+        if (options.ChangeSpeedPercent.HasValue) { unsupported.Add("--change-speed"); }
+        if (options.DeleteFirst.HasValue) { unsupported.Add("--delete-first"); }
+        if (options.DeleteLast.HasValue) { unsupported.Add("--delete-last"); }
+        if (options.DeleteContains != null) { unsupported.Add("--delete-contains"); }
+        if (options.Renumber.HasValue) { unsupported.Add("--renumber"); }
+        if (options.AdjustDurationMs.HasValue) { unsupported.Add("--adjust-duration"); }
+        if (options.BridgeGapsMaxMs.HasValue) { unsupported.Add("--bridge-gaps"); }
+        if (options.ApplyMinGapMs.HasValue) { unsupported.Add("--apply-min-gap"); }
+        if (options.TargetFps.HasValue) { unsupported.Add("--target-fps"); }
+
+        if (unsupported.Count > 0)
+        {
+            throw new InvalidOperationException(
+                $"Not supported when passing image subtitles straight through to an image format: {string.Join(", ", unsupported)}. " +
+                "Convert to a text format (OCR) to apply timing transforms, or drop the option(s).");
+        }
+    }
+
     private static void WritePreservedBitmaps(
         IReadOnlyList<BitmapSubtitleLoader.BitmapSubtitleItem> items,
         string outputFile,
         ConversionOptions options)
     {
+        ThrowOnUnsupportedImagePassThroughOptions(options);
         var handler = ImageOutputWriter.TryCreateHandler(LibSEIntegration.NormalizeFormatName(options.Format))
             ?? throw new InvalidOperationException($"No image handler for format '{options.Format}'");
         var outputDir = Path.GetDirectoryName(outputFile);
@@ -955,6 +992,7 @@ internal class SubtitleConverter
         ISet<string>? usedNames = null)
     {
         string baseName;
+        string ext;
         if (!string.IsNullOrEmpty(options.OutputFilename))
         {
             // A relative --output-filename still lands in --output-folder; an absolute
@@ -962,6 +1000,7 @@ internal class SubtitleConverter
             baseName = !string.IsNullOrEmpty(options.OutputFolder) && !Path.IsPathRooted(options.OutputFilename)
                 ? Path.Combine(options.OutputFolder, options.OutputFilename)
                 : options.OutputFilename;
+            ext = Path.GetExtension(baseName);
         }
         else
         {
@@ -974,6 +1013,10 @@ internal class SubtitleConverter
                 ? fileName
                 : $"{fileName}.{languageSuffix}";
             baseName = Path.Combine(outputFolder, stemWithLang + extension);
+            // Track the real extension: for an extension-less format (BDN-XML writes a
+            // folder) Path.GetExtension(baseName) would mistake the language suffix for
+            // the extension and the collision names below would double it.
+            ext = extension;
         }
 
         if ((options.Overwrite || !File.Exists(baseName)) && usedNames?.Contains(baseName) != true)
@@ -983,8 +1026,10 @@ internal class SubtitleConverter
         }
 
         var dir = Path.GetDirectoryName(baseName) ?? string.Empty;
-        var stem = Path.GetFileNameWithoutExtension(baseName);
-        var ext = Path.GetExtension(baseName);
+        var baseFileName = Path.GetFileName(baseName);
+        var stem = ext.Length > 0 && baseFileName.EndsWith(ext, StringComparison.OrdinalIgnoreCase)
+            ? baseFileName.Substring(0, baseFileName.Length - ext.Length)
+            : baseFileName;
 
         // For container collisions, try inserting the track number first
         if (trackNumber.HasValue && !string.IsNullOrEmpty(languageSuffix))

--- a/src/seconv/Program.cs
+++ b/src/seconv/Program.cs
@@ -461,50 +461,15 @@ internal class Program
 
     // Options that take a value as the next argument. Used to know which positional
     // tokens are file patterns vs. option-values when injecting a positional format.
-    // Canonical lowercase-hyphenated names; legacy smashed/PascalCase aliases included for
-    // backward compatibility with older scripts.
-    private static readonly HashSet<string> ValueOptions = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "--format", "-f",
-        "--adjust-duration", "--adjustduration",
-        "--assa-style-file",
-        "--change-speed",
-        "--custom-format", "--customformat",
-        "--ebu-header-file", "--ebuheaderfile",
-        "--encoding",
-        "--input-encoding-fallback", "--inputencodingfallback",
-        "--fps",
-        "--input-folder", "--inputfolder",
-        "--multiple-replace", "--multiplereplace",
-        "--ocr-engine", "--ocrengine",
-        "--ocr-language", "--ocrlanguage",
-        "--ocr-db", "--ocrdb",
-        "--offset",
-        "--output-filename", "--outputfilename",
-        "--output-folder", "--outputfolder",
-        "--pac-codepage",
-        "--profile",
-        "--renumber",
-        "--resolution",
-        "--settings",
-        "--target-fps", "--targetfps",
-        "--teletext-only-page", "--teletextonlypage",
-        "--track-number",
-        "--ollama-url",
-        "--ollama-model",
-        "--translate-to", "--translateto",
-        "--translate-from", "--translatefrom",
-        "--translate-engine", "--translateengine",
-        "--translate-url", "--translateurl",
-        "--translate-model", "--translatemodel",
-        "--translate-prompt", "--translateprompt",
-        "--delete-first", "--DeleteFirst",
-        "--delete-last", "--DeleteLast",
-        "--delete-contains", "--DeleteContains",
-        "--fix-common-errors-rules", "--FixCommonErrorsRules",
-        "--bridge-gaps", "--BridgeGaps",
-        "--apply-min-gap", "--ApplyMinGap",
-    };
+    // Derived from the reflected CLI schema so the set cannot drift from the options the
+    // parser actually binds (a hand-maintained copy went stale and broke valid command
+    // lines). FlagValue options ("--apply-min-gap [MS]") count as value-taking here: a
+    // separate value token following one must not be mistaken for a positional.
+    private static readonly HashSet<string> ValueOptions = new(
+        CliSchema.Options
+            .Where(o => o.Type != "flag")
+            .SelectMany(o => new[] { o.Name }.Concat(o.Aliases)),
+        StringComparer.OrdinalIgnoreCase);
 
     private static bool HasFormatOption(string[] args)
     {

--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -1577,8 +1577,21 @@ public class AudioVisualizer : Control
                 newStart = snappedLeft;
                 if (_activeParagraphPrevious != null)
                 {
-                    _activeParagraph.SetStartTimeOnly(TimeSpanExtensions.FromSecondsWholeMilliseconds(newStart));
-                    _activeParagraphPrevious.EndTime = TimeSpanExtensions.FromSecondsWholeMilliseconds(newPrevEnd);
+                    // Same guards as the plain left resize, adapted to the pair: never below
+                    // zero, never erase the previous cue, and never past this cue's own end.
+                    var leftGapSeconds = newStart - newPrevEnd;
+                    var minStart = Math.Max(0, _activeParagraphPrevious.StartTime.TotalSeconds + 0.1 + leftGapSeconds);
+                    if (newStart < minStart)
+                    {
+                        newPrevEnd += minStart - newStart;
+                        newStart = minStart;
+                    }
+
+                    if (newStart < _activeParagraph.EndTime.TotalSeconds - 0.1)
+                    {
+                        _activeParagraph.SetStartTimeOnly(TimeSpanExtensions.FromSecondsWholeMilliseconds(newStart));
+                        _activeParagraphPrevious.EndTime = TimeSpanExtensions.FromSecondsWholeMilliseconds(newPrevEnd);
+                    }
                 }
 
                 break;
@@ -1590,8 +1603,21 @@ public class AudioVisualizer : Control
                 newEnd = snappedRight;
                 if (_activeParagraphNext != null)
                 {
-                    _activeParagraph.EndTime = TimeSpanExtensions.FromSecondsWholeMilliseconds(newEnd);
-                    _activeParagraphNext.SetStartTimeOnly(TimeSpanExtensions.FromSecondsWholeMilliseconds(newNextStart));
+                    // Mirror of the left guards: never erase the next cue, and never before
+                    // this cue's own start.
+                    var rightGapSeconds = newNextStart - newEnd;
+                    var maxEnd = _activeParagraphNext.EndTime.TotalSeconds - 0.1 - rightGapSeconds;
+                    if (newEnd > maxEnd)
+                    {
+                        newNextStart -= newEnd - maxEnd;
+                        newEnd = maxEnd;
+                    }
+
+                    if (newEnd > _activeParagraph.StartTime.TotalSeconds + 0.1)
+                    {
+                        _activeParagraph.EndTime = TimeSpanExtensions.FromSecondsWholeMilliseconds(newEnd);
+                        _activeParagraphNext.SetStartTimeOnly(TimeSpanExtensions.FromSecondsWholeMilliseconds(newNextStart));
+                    }
                 }
 
                 break;

--- a/src/ui/Features/Files/Compare/CompareViewModel.cs
+++ b/src/ui/Features/Files/Compare/CompareViewModel.cs
@@ -421,9 +421,12 @@ public partial class CompareViewModel : ObservableObject
             right = GetRightItemOrNull(index);
         }
 
-        // insert rest
+        // insert rest - pad to the max of the *current* collection counts: the alignment
+        // above inserts blanks, so one side may already have grown past the raw-line max,
+        // and every consumer of the two lists assumes equal lengths
+        var maxNow = Math.Max(LeftSubtitles.Count, RightSubtitles.Count);
         var minSub = LeftSubtitles.Count < RightSubtitles.Count ? LeftSubtitles : RightSubtitles;
-        for (var idx = minSub.Count; idx < max; idx++)
+        for (var idx = minSub.Count; idx < maxNow; idx++)
         {
             minSub.Insert(idx, new CompareItem());
         }

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -4951,7 +4951,7 @@ public partial class MainViewModel :
         var oldLastTime = selectedItem.EndTime.TotalMilliseconds;
         var newFirstTime = subtitle.Paragraphs[0].StartTime.TotalMilliseconds;
         var timeOffset = newFirstTime < oldLastTime
-            ? oldLastTime - newFirstTime + Se.Settings.General.MinimumBetweenLines.Milliseconds
+            ? oldLastTime - newFirstTime + Se.Settings.General.MinimumBetweenLines.GetMilliseconds()
             : 0;
         foreach (var p in subtitle.Paragraphs)
         {
@@ -7582,7 +7582,7 @@ public partial class MainViewModel :
         var result = await ShowDialogAsync<MergeShortLinesWindow, MergeShortLinesViewModel>(
             vm => { vm.Initialize(Subtitles.ToList(), AudioVisualizer?.ShotChanges ?? new List<double>()); });
 
-        if (result.OkPressed)
+        if (result.OkPressed && result.AllSubtitlesFixed.Count > 0)
         {
             ReplaceSubtitles(result.AllSubtitlesFixed);
             SelectAndScrollToRow(0);

--- a/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedViewModel.cs
+++ b/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedViewModel.cs
@@ -47,7 +47,9 @@ public partial class ChangeSpeedViewModel : ObservableObject
     [RelayCommand]
     private void SetToDropFrameValue()
     {
-        SpeedPercent = 99.9889;
+        // Inverse of the from-drop-frame preset under the factor = 100 / percent
+        // convention: 100 / 99.9001 = 1.001001, so From -> To round-trips.
+        SpeedPercent = 99.9001;
     }
 
     [RelayCommand]

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -703,6 +703,13 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         // Change speed
         Se.Settings.Tools.BatchConvert.ChangeSpeedPercent = ChangeSpeedPercent;
 
+        // Merge lines with same text / same time codes (shared with the standalone dialogs)
+        Se.Settings.Tools.MergeSameText.MaxMillisecondsBetweenLines = MergeSameTextMaxMillisecondsBetweenLines;
+        Se.Settings.Tools.MergeSameText.IncludeIncrementingLines = MergeSameTextIncludeIncrementingLines;
+        Se.Settings.Tools.MergeSameTimeCode.MaxMillisecondsDifference = MergeSameTimeMaxMillisecondsDifference;
+        Se.Settings.Tools.MergeSameTimeCode.MergeDialog = MergeSameTimeMergeDialog;
+        Se.Settings.Tools.MergeSameTimeCode.AutoBreak = MergeSameTimeAutoBreak;
+
         // Delete lines
         Se.Settings.Tools.BatchConvert.DeleteXFirstLines = DeleteXFirstLines;
         Se.Settings.Tools.BatchConvert.DeleteXLastLines = DeleteXLastLines;
@@ -1575,7 +1582,9 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
     [RelayCommand]
     private void ChangeSpeedSetToDropFrameValue()
     {
-        ChangeSpeedPercent = 99.9889;
+        // Inverse of the from-drop-frame preset under the factor = 100 / percent
+        // convention: 100 / 99.9001 = 1.001001, so From -> To round-trips.
+        ChangeSpeedPercent = 99.9001;
     }
 
     [RelayCommand]
@@ -2692,7 +2701,7 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
             MergeLinesWithSameTimeCodes = new BatchConvertConfig.MergeLinesWithSameTimeCodesSettings
             {
                 IsActive = activeFunctions.Contains(BatchConvertFunctionType.MergeLinesWithSameTimeCodes),
-                MaxMillisecondsDifference = MergeSameTextMaxMillisecondsBetweenLines,
+                MaxMillisecondsDifference = MergeSameTimeMaxMillisecondsDifference,
                 MergeDialog = MergeSameTimeMergeDialog,
                 AutoBreak = MergeSameTimeAutoBreak,
             },

--- a/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewAdjustDuration.cs
+++ b/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewAdjustDuration.cs
@@ -168,9 +168,11 @@ public static class ViewAdjustDuration
 
     private static StackPanel MakeAdjustFixed(BatchConvertViewModel vm)
     {
+        // The bound value is stored and applied as milliseconds
+        // (AdjustDurationFixedMilliseconds -> BatchConvertConfig.FixedMilliseconds).
         var textBlockSeconds = new TextBlock
         {
-            Text = Se.Language.General.Seconds,
+            Text = Se.Language.General.Milliseconds,
             VerticalAlignment = VerticalAlignment.Center,
             MinWidth = LabelMinWidth,
         };

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
@@ -183,7 +183,10 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
                 SelectedRules = new List<string>()
             };
 
-            foreach (var rule in profile.FixRules)
+            // The grid collection (FixRules) may be filtered by the search box - persist
+            // from the full list so hidden rules keep their selection.
+            var rules = profile.AllFixRules.Count > 0 ? profile.AllFixRules : profile.FixRules.ToList();
+            foreach (var rule in rules)
             {
                 if (rule.IsSelected)
                 {
@@ -211,6 +214,7 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
                     IsSelected = setting.SelectedRules.Contains(rule.FixCommonErrorFunctionName)
                 }))
             };
+            profile.AllFixRules = profile.FixRules.ToList();
 
             Profiles.Add(profile);
         }
@@ -714,7 +718,10 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
             canonicalOrder.TryAdd(_allFixRules[i].FixCommonErrorFunctionName, i);
         }
 
-        var selectedRules = SelectedProfile.FixRules
+        var profileRules = SelectedProfile.AllFixRules.Count > 0
+            ? (IEnumerable<FixRuleDisplayItem>)SelectedProfile.AllFixRules // full set - FixRules may be search-filtered
+            : SelectedProfile.FixRules;
+        var selectedRules = profileRules
             .Where(f => f.IsSelected)
             .OrderBy(f => canonicalOrder.TryGetValue(f.FixCommonErrorFunctionName, out var order) ? order : int.MaxValue)
             .ToList(); // OrderBy is stable, so unknown rules keep their relative order at the end
@@ -958,9 +965,15 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
             return;
         }
 
-        var rules = SelectedProfile.FixRules.ToList();
+        // Filter from the profile's full rule list, never from the already-filtered grid
+        // collection - filtering that one is one-way and permanently loses rules.
+        if (SelectedProfile.AllFixRules.Count == 0)
+        {
+            SelectedProfile.AllFixRules = SelectedProfile.FixRules.ToList();
+        }
+
         SelectedProfile.FixRules.Clear();
-        foreach (var rule in rules)
+        foreach (var rule in SelectedProfile.AllFixRules)
         {
             if (string.IsNullOrEmpty(SearchText) || rule.Name.ToLowerInvariant().Contains(SearchText.ToLowerInvariant()))
             {

--- a/src/ui/Features/Tools/FixCommonErrors/ProfileDisplayItem.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/ProfileDisplayItem.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace Nikse.SubtitleEdit.Features.Tools.FixCommonErrors;
@@ -8,11 +9,19 @@ public partial class ProfileDisplayItem : ObservableObject
     [ObservableProperty] private string _name;
     
     public ObservableCollection<FixRuleDisplayItem> FixRules { get; set; }
-    
+
+    /// <summary>
+    /// Every rule of the profile, independent of the search filter applied to
+    /// <see cref="FixRules"/> (the grid's collection). Same item instances, so selection
+    /// state is shared. Apply/save must read this list - the filtered one loses rules.
+    /// </summary>
+    public List<FixRuleDisplayItem> AllFixRules { get; set; }
+
     public ProfileDisplayItem()
     {
         Name = string.Empty;
         FixRules = new ObservableCollection<FixRuleDisplayItem>();
+        AllFixRules = new List<FixRuleDisplayItem>();
     }
     public override string ToString()
     {

--- a/src/ui/Features/Tools/MergeShortLines/MergeShortLinesViewModel.cs
+++ b/src/ui/Features/Tools/MergeShortLines/MergeShortLinesViewModel.cs
@@ -83,6 +83,11 @@ public partial class MergeShortLinesViewModel : ObservableObject, IClosingCleanu
     {
         Dispatcher.UIThread.Post(() =>
         {
+            if (_isClosing)
+            {
+                return; // must not overwrite the final result Ok() just computed
+            }
+
             Subtitles.Clear();
             AllSubtitlesFixed.Clear();
             Fixes.Clear();
@@ -155,6 +160,24 @@ public partial class MergeShortLinesViewModel : ObservableObject, IClosingCleanu
         if (Window == null)
         {
             return;
+        }
+
+        // "Highlight parts" only affects the on-screen preview (unmerged lines with the
+        // combined text underlined). The result applied to the document must always be
+        // the real merge, so recompute it when the preview was in highlight mode.
+        if (HighLight)
+        {
+            var gapThresholdMs = Se.Settings.Tools.BridgeGaps.BridgeGapsSmallerThanMs;
+            var unbreakLinesShorterThan = Se.Settings.General.UnbreakLinesShorterThan;
+            var mergeResult = MergeShortLinesHelper.Merge(
+                _allSubtitles,
+                _shotChanges,
+                SingleLineMaxLength,
+                MaxNumberOfLines,
+                gapThresholdMs,
+                unbreakLinesShorterThan);
+            AllSubtitlesFixed.Clear();
+            AllSubtitlesFixed.AddRange(mergeResult.MergedSubtitles);
         }
 
         SaveSettings();

--- a/src/ui/Logic/MergeManager.cs
+++ b/src/ui/Logic/MergeManager.cs
@@ -44,6 +44,18 @@ namespace Nikse.SubtitleEdit.Logic
             }
 
             var subtitle = new Subtitle(inputSubtitle, false);
+
+            // Only a contiguous ascending selection can be merged. Validate up front: the
+            // loop below rewrites continuation marks as it goes, so refusing mid-loop would
+            // leave the first lines (and the unselected line after them) already mutated.
+            for (var i = 1; i < selectedIndices.Length; i++)
+            {
+                if (selectedIndices[i] != selectedIndices[0] + i)
+                {
+                    return subtitle;
+                }
+            }
+
             var sb = new StringBuilder();
             var deleteIndices = new List<int>();
             var first = true;
@@ -160,7 +172,19 @@ namespace Nikse.SubtitleEdit.Logic
                 return;
             }
 
-           // var subtitle = new Subtitle(inputSubtitle, false);
+            // Only a contiguous ascending selection can be merged. Validate up front: the
+            // loop below rewrites continuation marks in the live view-models as it goes, so
+            // refusing mid-loop would leave the first lines (and the unselected line right
+            // after them) already mutated.
+            var selectedGridIndices = selectedItems.Select(inputSubtitle.IndexOf).ToList();
+            for (var i = 0; i < selectedGridIndices.Count; i++)
+            {
+                if (selectedGridIndices[i] < 0 || (i > 0 && selectedGridIndices[i] != selectedGridIndices[0] + i))
+                {
+                    return;
+                }
+            }
+
             var sb = new StringBuilder();
             var sbOriginal = new StringBuilder();
             var deleteIndices = new List<int>();

--- a/tests/seconv/Core/ContainerLoaderTest.cs
+++ b/tests/seconv/Core/ContainerLoaderTest.cs
@@ -161,8 +161,10 @@ public class ContainerLoaderTest : IDisposable
             TrackNumbers = [9999],
         });
 
-        // No track matched — no failure, no success
-        Assert.True(result.Success, string.Join("; ", result.Errors));
+        // The file has subtitle tracks but none matched the filter — that is an error,
+        // not a silent zero-file success (matches the MP4/TS/MXF loaders).
+        Assert.False(result.Success);
         Assert.Equal(0, result.SuccessfulFiles);
+        Assert.Contains(result.Errors, e => e.Contains("--track-number"));
     }
 }


### PR DESCRIPTION
A parallel bug hunt over five areas of the codebase (subtitle format parsers, seconv CLI, dialog/batch-convert logic, UI layer, libse core helpers) surfaced 26 verified bugs; this PR fixes all of them. Every finding was verified by tracing the code path; the seconv and libse-core findings were additionally confirmed by running real reproductions against the compiled code.

## Subtitle formats
- **JacoSub**: the `\T` time-of-day directive used `DateTime.Now.ToString("HH:MM")` — `MM` is the month in .NET, so it printed hour:month. Now `HH:mm`.
- **SubUrbia**: a paragraph with a comment produced invalid JSON (`{"…","text":"Hi"},"comment":"note"}`) — the object was closed before the comment. The comment now lands inside the object, which the existing reader already parses.
- **Lrc3DigitsMs**: the pass that unpacks `[00:10.500][00:15.250]Hello` multiplied the 3-digit ms field by 10 (leftover from the 2-digit LRC class), putting the second line at 17.500. Verified fixed by round-trip.
- **DVD Studio Pro** (all 5 variants): the writer emits `^U` for underline but `DecodeStyles` only handled `^I`/`^B`, so reopening showed literal `^UHello^U`. Underline now round-trips (verified).
- **SoftNiSub**: saving an empty subtitle threw `InvalidOperationException` — `Paragraphs.Last()` on an empty list, with the intended `null` check as dead code. Now `LastOrDefault()`.
- **WhisperRaw2 + KanopyHtml**: seconds were formatted without `InvariantCulture`, so comma-decimal locales wrote `5,71s` / `begin="5,706"` — a 100× timing error on WhisperRaw2's own round-trip, silent truncation for Kanopy.

## seconv
- **Positional-format syntax broke with a dozen valid options**: `TryInjectPositionalFormat` consulted a stale hand-maintained `ValueOptions` list missing `--fce-language`, `--remove-formatting-rules`, `--dictionary-folder`, `--ocr-model`/`--ocr-url`, and every image-styling value option. `seconv a.srt subrip --fix-common-errors --fce-language es` died with a bogus "expects a value" error. The set is now derived from the reflected CLI schema so it cannot drift again.
- **VOB extraction ignored `--output-folder`** when `--output-filename` was given; it now combines them under the same rule as `ResolveOutputFileName`.
- **MKV with all subtitle tracks filtered out reported success with zero outputs** (exit 0, `success: true`); it now fails loudly like the MP4/TS/MXF loaders, naming the filter that excluded everything. The test asserting the old silent behavior is updated.
- **Image→image pass-through silently dropped every timing transform** (`--offset`, `--change-speed`, `--delete-*`, `--bridge-gaps`, `--apply-min-gap`, `--adjust-duration`, `--renumber`, `--target-fps`); it — and the VOB batch path — now refuse them with a clear error instead of writing unshifted output with a success exit.
- **Collision renaming doubled the language suffix for extension-less image formats**: BDN-XML's empty handler extension made `Path.GetExtension` mistake `.und` for the extension, yielding `container.#3.und.und`. The real extension is now tracked instead of re-parsed.

## Dialogs / batch convert
- **Change speed "To drop-frame value" used the wrong constant** (99.9889 — SE4's *from*-drop value under the opposite convention). Under SE5's `factor = 100/percent`, the inverse of 100.1001 is 99.9001. Fixed in both the standalone dialog and batch convert; From → To now round-trips instead of drifting ~3.2 s/hour.
- **Fix common errors: typing in the rule search box permanently unticked rules** — the filter rebuilt the profile's rule list from its own already-filtered contents, and apply/save then persisted the truncated selection. Rules now filter from a full backing list per profile, and apply/save read that list.
- **Merge short lines: OK with "Highlight parts" checked wrote the preview into the document** — unmerged lines with the whole combined text wrapped in `<u>` tags. OK now always applies the real merge, a queued preview can no longer overwrite the final result, and the caller gained the same empty-result guard as its split-lines sibling.
- **Batch "Merge lines with same time codes" read the merge-same-*text* panel's max-milliseconds value**; it now uses its own bound field, and the two merge panels' settings are persisted on close (they never were).
- **Batch Adjust duration "Fixed" was labeled "Seconds" but consumed as milliseconds** (typing 3 gave every line a 3 ms duration). The label now says Milliseconds, matching the stored `AdjustDurationFixedMilliseconds` setting and its 3000 default.

## UI
- **Compare dialog**: blank-row alignment padded to the *pre-insertion* line counts, so inserting blanks into one side left the two grids unequal — "Show only differences" crashed with `ArgumentOutOfRangeException` (unguarded `RightSubtitles.RemoveAt`) and the inline word-diff highlighting silently vanished. Padding now uses the current collection counts.
- **Waveform Alt+drag (resize + move neighbour)** had none of the plain-resize guards and happily wrote negative and inverted time codes into both the dragged line and its neighbour. Both And-modes now clamp to zero, keep start before end, and never erase the neighbouring cue.
- **Merge selected lines mutated text before validating the selection**: with a continuation style configured, a refused non-contiguous merge (e.g. lines 3 and 7 selected) had already rewritten line 3 *and unselected line 4*. Both overloads now validate contiguity up front.
- **"Insert subtitle file after this line" ignored frame mode** for the minimum gap (`.Milliseconds` instead of `.GetMilliseconds()`).

## libse core helpers
- **`HtmlUtil.RemoveColorTags`** removed 7 characters for the 8-character malformed `< /font>` / `</ font>` variants, leaving a stray `>` in the text.
- **`Utilities.RemoveSpaceBeforeAfterTag`** computed the newline-removal index from the *open* tag's length; for font tags the deletion landed mid-line (e.g. "Remove unneeded spaces" turned `friend, how` into `friend,how`, or ate a character inside the tag itself).
- **`FixCommas`**: the Greek `ό,τι` guard inspected only the first regex match but the replace ran over the whole string — the protected word got corrupted, or real errors went unfixed, depending on match order. Now judged per match.
- **`StringExtensions.LineEndsWithHtmlTag`** off-by-one guards rejected the shortest valid lines (`a</i>`, `x</font>`).
- **`Helper.FixHyphensAdd`** crashed on a quote-only first line (latent — currently no callers).
- **`Utilities.GetColorFromFontString`**: a quotation mark in the dialogue text hijacked parsing of an unquoted color attribute (latent — currently no callers).

## Testing
- Full suite passes: libse 1490, libuilogic 703, seconv 416, UI 4079 (1 skipped).
- One seconv test updated: it asserted the old silent-success behavior for filtered-out MKV tracks that this PR deliberately changes.
- Functional repros re-run against the built binaries: the `--fce-language` command line converts, LRC stacked timestamps land correctly, DVD Studio Pro underline round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)