### PR TITLE
Perf hunt round 16: XML auto-detect, TTML save, DVB/VobSub decode, italic-tag early-out

### DIFF
--- a/src/libse/Common/FastBitmap.cs
+++ b/src/libse/Common/FastBitmap.cs
@@ -103,15 +103,53 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         public void SetPixel(int x, int y, SKColor color, int length)
         {
-            var data = (PixelData*)(_pBase + y * _width + x * sizeof(PixelData));
-            for (int i = 0; i < length; i++)
+            if (length <= 0)
             {
-                data->Alpha = color.Alpha;
-                data->Red = color.Red;
-                data->Green = color.Green;
-                data->Blue = color.Blue;
-                data++;
+                return;
             }
+
+            // Bgra8888 in memory is B,G,R,A at increasing addresses; as a little-endian
+            // uint that is B | G<<8 | R<<16 | A<<24. A span Fill vectorizes the run.
+            var value = color.Blue | ((uint)color.Green << 8) | ((uint)color.Red << 16) | ((uint)color.Alpha << 24);
+            var data = (uint*)(_pBase + y * _width + x * sizeof(PixelData));
+            new Span<uint>(data, length).Fill(value);
+        }
+
+        /// <summary>
+        /// True when every pixel in row <paramref name="y"/> has alpha below
+        /// <paramref name="alphaLimit"/>. Reads only the alpha byte of each pixel -
+        /// used by crop scans that would otherwise build an SKColor per pixel.
+        /// </summary>
+        public bool IsRowTransparent(int y, byte alphaLimit)
+        {
+            var p = _pBase + y * _width + 3;
+            for (var x = 0; x < Width; x++, p += sizeof(PixelData))
+            {
+                if (*p >= alphaLimit)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// True when every pixel in column <paramref name="x"/> from row
+        /// <paramref name="startY"/> down has alpha below <paramref name="alphaLimit"/>.
+        /// </summary>
+        public bool IsColumnTransparent(int x, int startY, byte alphaLimit)
+        {
+            var p = _pBase + startY * _width + x * sizeof(PixelData) + 3;
+            for (var y = startY; y < Height; y++, p += _width)
+            {
+                if (*p >= alphaLimit)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         public SKBitmap GetBitmap()

--- a/src/libse/Common/HtmlUtil.cs
+++ b/src/libse/Common/HtmlUtil.cs
@@ -879,6 +879,14 @@ namespace Nikse.SubtitleEdit.Core.Common
         /// <returns>A string with corrected italic tags.</returns>
         public static string FixInvalidItalicTags(string input)
         {
+            // Every transformation below requires a '<' somewhere in the text (the "{\...}"
+            // prefix is only sliced off to be re-prepended verbatim), and most subtitle lines
+            // carry no tags at all - so skip the ~50 full-string Replace scans for those.
+            if (string.IsNullOrEmpty(input) || input.IndexOf('<') < 0)
+            {
+                return input;
+            }
+
             var text = input;
 
             var preTags = string.Empty;

--- a/src/libse/ContainerFormats/TransportStream/ObjectDataSegment.cs
+++ b/src/libse/ContainerFormats/TransportStream/ObjectDataSegment.cs
@@ -94,12 +94,14 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
                 _fastImage = new FastBitmap(Image);
                 _fastImage.LockImage();
 
+                var clutLookup = BuildClutLookup(cds);
+
                 x = 0;
                 y = 0;
                 index = start;
                 while (index < start + TopFieldDataBlockLength && index < buffer.Length)
                 {
-                    index = ProcessDataType(buffer, index, cds, ref dataType, start, twoToFourBitColorLookup, fourToEightBitColorLookup, twoToEightBitColorLookup, ref x, ref y, length, ref pixelCode, ref runLength);
+                    index = ProcessDataType(buffer, index, clutLookup, ref dataType, start, twoToFourBitColorLookup, fourToEightBitColorLookup, twoToEightBitColorLookup, ref x, ref y, length, ref pixelCode, ref runLength);
                 }
 
                 x = 0;
@@ -117,7 +119,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
                 dataType = buffer[index - 1];
                 while (index < start + BottomFieldDataBlockLength - 1 && index < buffer.Length)
                 {
-                    index = ProcessDataType(buffer, index, cds, ref dataType, start, twoToFourBitColorLookup, fourToEightBitColorLookup, twoToEightBitColorLookup, ref x, ref y, length, ref pixelCode, ref runLength);
+                    index = ProcessDataType(buffer, index, clutLookup, ref dataType, start, twoToFourBitColorLookup, fourToEightBitColorLookup, twoToEightBitColorLookup, ref x, ref y, length, ref pixelCode, ref runLength);
                 }
                 _fastImage.UnlockImage();
             }
@@ -170,12 +172,13 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
                 }
 
                 var height = y + 1;
+                var clutLookup = BuildClutLookup(cds);
                 x = 0;
                 y = 0;
                 index = start;
                 while (index < start + TopFieldDataBlockLength && index < buffer.Length)
                 {
-                    index = ProcessDataTypeForPosition(buffer, index, cds, ref dataType, start, twoToFourBitColorLookup, fourToEightBitColorLookup, twoToEightBitColorLookup, ref x, ref y, length, ref pixelCode, ref runLength, width, height, out Position subPos);
+                    index = ProcessDataTypeForPosition(buffer, index, clutLookup, ref dataType, start, twoToFourBitColorLookup, fourToEightBitColorLookup, twoToEightBitColorLookup, ref x, ref y, length, ref pixelCode, ref runLength, width, height, out Position subPos);
                     if (subPos.Left < pos.Left)
                     {
                         pos.Left = subPos.Left;
@@ -201,7 +204,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
                 dataType = buffer[index - 1];
                 while (index < start + BottomFieldDataBlockLength - 1 && index < buffer.Length)
                 {
-                    index = ProcessDataTypeForPosition(buffer, index, cds, ref dataType, start, twoToFourBitColorLookup, fourToEightBitColorLookup, twoToEightBitColorLookup, ref x, ref y, length, ref pixelCode, ref runLength, width, height, out Position subPos);
+                    index = ProcessDataTypeForPosition(buffer, index, clutLookup, ref dataType, start, twoToFourBitColorLookup, fourToEightBitColorLookup, twoToEightBitColorLookup, ref x, ref y, length, ref pixelCode, ref runLength, width, height, out Position subPos);
                     if (subPos.Left < pos.Left)
                     {
                         pos.Left = subPos.Left;
@@ -220,7 +223,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
             return new Position(pos.Left == int.MaxValue ? 0 : pos.Left, pos.Top == int.MaxValue ? 0 : pos.Top);
         }
 
-        private int ProcessDataType(byte[] buffer, int index, ClutDefinitionSegment cds, ref int dataType, int start,
+        private int ProcessDataType(byte[] buffer, int index, SKColor[] clutLookup, ref int dataType, int start,
                                     List<int> twoToFourBitColorLookup, List<int> fourToEightBitColorLookup, List<int> twoToEightBitColorLookup,
                                     ref int x, ref int y, int length, ref int pixelCode, ref int runLength)
         {
@@ -229,7 +232,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
                 var bitIndex = 0;
                 while (index < start + length - 1 && index < buffer.Length && TwoBitPixelDecoding(buffer, ref index, ref bitIndex, out pixelCode, out runLength))
                 {
-                    DrawPixels(cds, twoToFourBitColorLookup[pixelCode], runLength, ref x, ref y);
+                    DrawPixels(clutLookup, twoToFourBitColorLookup[pixelCode], runLength, ref x, ref y);
                 }
             }
             else if (dataType == PixelDecoding4Bit)
@@ -237,14 +240,14 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
                 var startHalf = false;
                 while (index < start + length - 1 && index < buffer.Length && FourBitPixelDecoding(buffer, ref index, ref startHalf, out pixelCode, out runLength))
                 {
-                    DrawPixels(cds, fourToEightBitColorLookup[pixelCode], runLength, ref x, ref y);
+                    DrawPixels(clutLookup, fourToEightBitColorLookup[pixelCode], runLength, ref x, ref y);
                 }
             }
             else if (dataType == PixelDecoding8Bit)
             {
                 while (index < start + length - 1 && index < buffer.Length && EightBitPixelDecoding(buffer, ref index, out pixelCode, out runLength))
                 {
-                    DrawPixels(cds, pixelCode, runLength, ref x, ref y);
+                    DrawPixels(clutLookup, pixelCode, runLength, ref x, ref y);
                 }
             }
             else if (dataType == MapTable2To4Bit)
@@ -296,7 +299,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
             return index;
         }
 
-        private int ProcessDataTypeForPosition(byte[] buffer, int index, ClutDefinitionSegment cds, ref int dataType, int start,
+        private int ProcessDataTypeForPosition(byte[] buffer, int index, SKColor[] clutLookup, ref int dataType, int start,
                                     List<int> twoToFourBitColorLookup, List<int> fourToEightBitColorLookup, List<int> twoToEightBitColorLookup,
                                     ref int x, ref int y, int length, ref int pixelCode, ref int runLength, int width, int height, out Position pos)
         {
@@ -307,7 +310,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
                 var bitIndex = 0;
                 while (index < start + length - 1 && index < buffer.Length && TwoBitPixelDecoding(buffer, ref index, ref bitIndex, out pixelCode, out runLength))
                 {
-                    var subPos = GetFirstPixelPosition(cds, twoToFourBitColorLookup[pixelCode], runLength, ref x, ref y, width, height);
+                    var subPos = GetFirstPixelPosition(clutLookup, twoToFourBitColorLookup[pixelCode], runLength, ref x, ref y, width, height);
                     if (subPos.Left < pos.Left)
                     {
                         pos.Left = subPos.Left;
@@ -323,7 +326,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
                 var startHalf = false;
                 while (index < start + length - 1 && index < buffer.Length && FourBitPixelDecoding(buffer, ref index, ref startHalf, out pixelCode, out runLength))
                 {
-                    var subPos = GetFirstPixelPosition(cds, fourToEightBitColorLookup[pixelCode], runLength, ref x, ref y, width, height);
+                    var subPos = GetFirstPixelPosition(clutLookup, fourToEightBitColorLookup[pixelCode], runLength, ref x, ref y, width, height);
                     if (subPos.Left < pos.Left)
                     {
                         pos.Left = subPos.Left;
@@ -338,7 +341,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
             {
                 while (index < start + length - 1 && index < buffer.Length && EightBitPixelDecoding(buffer, ref index, out pixelCode, out runLength))
                 {
-                    var subPos = GetFirstPixelPosition(cds, pixelCode, runLength, ref x, ref y, width, height);
+                    var subPos = GetFirstPixelPosition(clutLookup, pixelCode, runLength, ref x, ref y, width, height);
                     if (subPos.Left < pos.Left)
                     {
                         pos.Left = subPos.Left;
@@ -463,60 +466,60 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
             return index;
         }
 
-        private void DrawPixels(ClutDefinitionSegment cds, int pixelCode, int runLength, ref int x, ref int y)
+        /// <summary>
+        /// Resolves every CLUT entry id to its RGB color once. The per-run path used to
+        /// linear-scan <see cref="ClutDefinitionSegment.Entries"/> (first match wins) and
+        /// redo the YCbCr conversion for every RLE run of every object.
+        /// </summary>
+        private static SKColor[] BuildClutLookup(ClutDefinitionSegment cds)
         {
-            var c = SKColors.Red;
+            var lookup = new SKColor[256];
+            for (var i = 0; i < lookup.Length; i++)
+            {
+                lookup[i] = SKColors.Red; // same fallback as the old scan for unknown ids
+            }
+
             if (cds != null)
             {
+                var seen = new bool[lookup.Length];
                 foreach (var item in cds.Entries)
                 {
-                    if (item.ClutEntryId == pixelCode)
+                    var id = item.ClutEntryId;
+                    if (id >= 0 && id < lookup.Length && !seen[id])
                     {
-                        c = item.GetColor();
-                        break;
+                        seen[id] = true; // first entry with an id wins, like the old scan
+                        lookup[id] = item.GetColor();
                     }
                 }
             }
 
-            for (var k = 0; k < runLength; k++)
-            {
-                if (y < _fastImage.Height && x < _fastImage.Width)
-                {
-                    _fastImage.SetPixel(x, y, c);
-                }
-
-                x++;
-            }
+            return lookup;
         }
 
-        private Position GetFirstPixelPosition(ClutDefinitionSegment cds, int pixelCode, int runLength, ref int x, ref int y, int width, int height)
+        private void DrawPixels(SKColor[] clutLookup, int pixelCode, int runLength, ref int x, ref int y)
         {
-            var c = SKColors.Red;
-            if (cds != null)
+            var c = (uint)pixelCode < (uint)clutLookup.Length ? clutLookup[pixelCode] : SKColors.Red;
+
+            if (y < _fastImage.Height && x < _fastImage.Width)
             {
-                foreach (var item in cds.Entries)
-                {
-                    if (item.ClutEntryId == pixelCode)
-                    {
-                        c = item.GetColor();
-                        break;
-                    }
-                }
+                _fastImage.SetPixel(x, y, c, Math.Min(runLength, _fastImage.Width - x));
             }
 
-            for (var k = 0; k < runLength; k++)
-            {
-                if (y < height && x < width)
-                {
-                    if (c.Alpha > 0)
-                    {
-                        return new Position(x, y);
-                    }
-                }
+            x += runLength;
+        }
 
-                x++;
+        private static Position GetFirstPixelPosition(SKColor[] clutLookup, int pixelCode, int runLength, ref int x, ref int y, int width, int height)
+        {
+            var c = (uint)pixelCode < (uint)clutLookup.Length ? clutLookup[pixelCode] : SKColors.Red;
+
+            // x only grows inside a run, so the first pixel can be in bounds only at the
+            // run start; the old loop returned there without advancing x past the run.
+            if (c.Alpha > 0 && y < height && x < width)
+            {
+                return new Position(x, y);
             }
 
+            x += runLength;
             return new Position(int.MaxValue, int.MaxValue);
         }
 

--- a/src/libse/SubtitleFormats/AbcIViewer.cs
+++ b/src/libse/SubtitleFormats/AbcIViewer.cs
@@ -55,10 +55,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             _errorCount = 0;
             bool allTwoCifferMs = true;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
 
-            string xmlString = sb.ToString();
+            string xmlString = JoinLines(lines);
             if (!xmlString.Contains("<reel"))
             {
                 return;

--- a/src/libse/SubtitleFormats/AdobeAfterEffectsFTME.cs
+++ b/src/libse/SubtitleFormats/AdobeAfterEffectsFTME.cs
@@ -45,10 +45,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
 
-            string allText = sb.ToString();
+            string allText = JoinLines(lines);
             if (!allText.Contains("<layers") && !allText.Contains("<marker>"))
             {
                 return;

--- a/src/libse/SubtitleFormats/AdobePremierePrProj.cs
+++ b/src/libse/SubtitleFormats/AdobePremierePrProj.cs
@@ -71,10 +71,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
 
-            string xmlString = sb.ToString();
+            string xmlString = JoinLines(lines);
             if (!xmlString.Contains("<PremiereData "))
             {
                 return;

--- a/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
+++ b/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
@@ -84,9 +84,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             var subtitle = new Subtitle();
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            var all = sb.ToString();
+            var all = JoinLines(lines);
             if (!string.IsNullOrEmpty(fileName) && fileName.EndsWith(".ass", StringComparison.OrdinalIgnoreCase) && !all.Contains("[V4 Styles]"))
             {
             }

--- a/src/libse/SubtitleFormats/BdnXml.cs
+++ b/src/libse/SubtitleFormats/BdnXml.cs
@@ -59,10 +59,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
 
-            var xmlString = sb.ToString();
+            var xmlString = JoinLines(lines);
             if (!xmlString.Contains("<BDN"))
             {
                 return;

--- a/src/libse/SubtitleFormats/Cappella.cs
+++ b/src/libse/SubtitleFormats/Cappella.cs
@@ -78,9 +78,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
         {
             _errorCount = 0;
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            string xmlString = sb.ToString();
+            string xmlString = JoinLines(lines);
             if (!xmlString.Contains("<detx") || !xmlString.Contains("<lipsync "))
             {
                 return;

--- a/src/libse/SubtitleFormats/CaptionAssistant.cs
+++ b/src/libse/SubtitleFormats/CaptionAssistant.cs
@@ -83,10 +83,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
 
-            string allText = sb.ToString();
+            string allText = JoinLines(lines);
             if (!allText.Contains("<CaptionAssistant>") || !allText.Contains("<CaptionData>"))
             {
                 return;

--- a/src/libse/SubtitleFormats/Captionate.cs
+++ b/src/libse/SubtitleFormats/Captionate.cs
@@ -89,9 +89,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
             else if (lines != null)
             {
-                var sb = new StringBuilder();
-                lines.ForEach(line => sb.AppendLine(line));
-                xmlString = sb.ToString();
+                xmlString = JoinLines(lines);
             }
             else
             {

--- a/src/libse/SubtitleFormats/CaptionateMs.cs
+++ b/src/libse/SubtitleFormats/CaptionateMs.cs
@@ -80,10 +80,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
 
-            string xmlString = sb.ToString();
+            string xmlString = JoinLines(lines);
             if (!xmlString.Contains("<captionate>") || !xmlString.Contains("</caption>"))
             {
                 return;

--- a/src/libse/SubtitleFormats/CaraokeXml.cs
+++ b/src/libse/SubtitleFormats/CaraokeXml.cs
@@ -49,10 +49,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
 
-            string xmlAsText = sb.ToString();
+            string xmlAsText = JoinLines(lines);
 
             if (!xmlAsText.Contains("<caraoke"))
             {

--- a/src/libse/SubtitleFormats/CombinedXml.cs
+++ b/src/libse/SubtitleFormats/CombinedXml.cs
@@ -20,9 +20,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            var searchText = sb.ToString();
+            var searchText = JoinLines(lines);
             var idx = searchText.IndexOf(findString, StringComparison.Ordinal);
             if (idx < 0)
             {
@@ -48,9 +46,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
             subtitle.Paragraphs.Clear();
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            var searchText = sb.ToString();
+            var searchText = JoinLines(lines);
             var idx = searchText.IndexOf(findString, StringComparison.Ordinal);
             var start = idx;
             var parts = new List<string>();

--- a/src/libse/SubtitleFormats/DCinemaInterop.cs
+++ b/src/libse/SubtitleFormats/DCinemaInterop.cs
@@ -52,9 +52,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            var xmlAsString = sb.ToString().Trim();
+            var xmlAsString = JoinLinesTrimmed(lines);
             if (!xmlAsString.Contains("<DCSubtitle"))
             {
                 return false;
@@ -643,10 +641,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
             var xml = new XmlDocument { XmlResolver = null };
-            xml.LoadXml(sb.ToString().Trim());
+            xml.LoadXml(JoinLinesTrimmed(lines));
             if (xml.DocumentElement == null)
             {
                 return;

--- a/src/libse/SubtitleFormats/DCinemaSmpte2007.cs
+++ b/src/libse/SubtitleFormats/DCinemaSmpte2007.cs
@@ -45,9 +45,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            string xmlAsString = sb.ToString().Trim();
+            string xmlAsString = JoinLinesTrimmed(lines);
             if (xmlAsString.Contains("http://www.smpte-ra.org/schemas/428-7/2010/DCST") ||
                 xmlAsString.Contains("http://www.smpte-ra.org/schemas/428-7/2014/DCST"))
             {
@@ -594,10 +592,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
         {
             _errorCount = 0;
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
             var xml = new XmlDocument { XmlResolver = null };
-            xml.LoadXml(sb.ToString().Replace("<dcst:", "<").Replace("</dcst:", "</").Replace("xmlns=\"http://www.smpte-ra.org/schemas/428-7/2007/DCST\"", string.Empty)); // tags might be prefixed with namespace (or not)... so we just remove them
+            xml.LoadXml(JoinLines(lines).Replace("<dcst:", "<").Replace("</dcst:", "</").Replace("xmlns=\"http://www.smpte-ra.org/schemas/428-7/2007/DCST\"", string.Empty)); // tags might be prefixed with namespace (or not)... so we just remove them
             var ss = Configuration.Settings.SubtitleSettings;
             try
             {

--- a/src/libse/SubtitleFormats/DCinemaSmpte2010.cs
+++ b/src/libse/SubtitleFormats/DCinemaSmpte2010.cs
@@ -49,9 +49,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            string xmlAsString = sb.ToString().Trim();
+            string xmlAsString = JoinLinesTrimmed(lines);
 
             if (xmlAsString.Contains("http://www.smpte-ra.org/schemas/428-7/2007/DCST") ||
                 xmlAsString.Contains("http://www.smpte-ra.org/schemas/428-7/2014/DCST"))
@@ -629,10 +627,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
         {
             _errorCount = 0;
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
             var xml = new XmlDocument { XmlResolver = null };
-            xml.LoadXml(sb.ToString().Replace("<dcst:", "<").Replace("</dcst:", "</").Replace("xmlns=\"http://www.smpte-ra.org/schemas/428-7/2010/DCST\"", string.Empty)); // tags might be prefixed with namespace (or not)... so we just remove them
+            xml.LoadXml(JoinLines(lines).Replace("<dcst:", "<").Replace("</dcst:", "</").Replace("xmlns=\"http://www.smpte-ra.org/schemas/428-7/2010/DCST\"", string.Empty)); // tags might be prefixed with namespace (or not)... so we just remove them
 
             var ss = Configuration.Settings.SubtitleSettings;
             try

--- a/src/libse/SubtitleFormats/DCinemaSmpte2014.cs
+++ b/src/libse/SubtitleFormats/DCinemaSmpte2014.cs
@@ -45,9 +45,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            var xmlAsString = sb.ToString().Trim();
+            var xmlAsString = JoinLinesTrimmed(lines);
 
             if (xmlAsString.Contains("http://www.smpte-ra.org/schemas/428-7/2007/DCST") ||
                 xmlAsString.Contains("http://www.smpte-ra.org/schemas/428-7/2010/DCST"))
@@ -607,10 +605,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
         {
             _errorCount = 0;
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
             var xml = new XmlDocument { XmlResolver = null };
-            xml.LoadXml(sb.ToString().Replace("<dcst:", "<").Replace("</dcst:", "</").Replace("xmlns=\"http://www.smpte-ra.org/schemas/428-7/2014/DCST\"", string.Empty)); // tags might be prefixed with namespace (or not)... so we just remove them
+            xml.LoadXml(JoinLines(lines).Replace("<dcst:", "<").Replace("</dcst:", "</").Replace("xmlns=\"http://www.smpte-ra.org/schemas/428-7/2014/DCST\"", string.Empty)); // tags might be prefixed with namespace (or not)... so we just remove them
 
             var ss = Configuration.Settings.SubtitleSettings;
             try

--- a/src/libse/SubtitleFormats/DfxpBasic.cs
+++ b/src/libse/SubtitleFormats/DfxpBasic.cs
@@ -23,9 +23,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 return false;
             }
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            var text = sb.ToString();
+            var text = JoinLines(lines);
             if (!text.Contains("<style xml:id=\"basic\"") || !text.Contains("<body style=\"basic\">"))
             {
                 return false;

--- a/src/libse/SubtitleFormats/DlDd.cs
+++ b/src/libse/SubtitleFormats/DlDd.cs
@@ -22,9 +22,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
         {
             _errorCount = 0;
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            var xmlAsText = sb.ToString().Trim();
+            var xmlAsText = JoinLinesTrimmed(lines);
             if (!xmlAsText.Contains("</dl>") || !xmlAsText.Contains(" data-time"))
             {
                 return;

--- a/src/libse/SubtitleFormats/ESubXf.cs
+++ b/src/libse/SubtitleFormats/ESubXf.cs
@@ -267,9 +267,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
         {
             _errorCount = 0;
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            string xmlString = sb.ToString();
+            string xmlString = JoinLines(lines);
             if (!xmlString.Contains("<subtitlelist"))
             {
                 return;
@@ -287,6 +285,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
 
             subtitle.Header = xmlString;
+            var sb = new StringBuilder();
             char[] timeCodeSeparators = { ':' };
             var ns = new XmlNamespaceManager(xml.NameTable);
             ns.AddNamespace("esub-xf", NameSpaceUri);

--- a/src/libse/SubtitleFormats/EbuTtD.cs
+++ b/src/libse/SubtitleFormats/EbuTtD.cs
@@ -60,9 +60,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 return false;
             }
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            var text = sb.ToString();
+            var text = JoinLines(lines);
 
             // "urn:ebu:tt:distribution" (the conformsToStandard urn) and ebutts:linePadding are
             // EBU-TT-D specific; plain "urn:ebu:tt" also appears in Netflix Japanese IMSC docs,
@@ -263,19 +261,17 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
             var xml = new XmlDocument { XmlResolver = null, PreserveWhitespace = true };
             try
             {
-                xml.LoadXml(sb.ToString().RemoveControlCharactersButWhiteSpace().Trim());
+                xml.LoadXml(JoinLines(lines).RemoveControlCharactersButWhiteSpace().Trim());
             }
             catch
             {
-                xml.LoadXml(sb.ToString().Replace(" & ", " &amp; ").RemoveControlCharactersButWhiteSpace().Trim());
+                xml.LoadXml(JoinLines(lines).Replace(" & ", " &amp; ").RemoveControlCharactersButWhiteSpace().Trim());
             }
 
-            subtitle.Header = sb.ToString();
+            subtitle.Header = JoinLines(lines);
 
             var namespaceManager = new XmlNamespaceManager(xml.NameTable);
             namespaceManager.AddNamespace("ttml", TtmlNamespace);

--- a/src/libse/SubtitleFormats/Edius4Frames.cs
+++ b/src/libse/SubtitleFormats/Edius4Frames.cs
@@ -74,9 +74,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            if (!sb.ToString().Contains("<edius:markerLists"))
+            if (!JoinLines(lines).Contains("<edius:markerLists"))
             {
                 _errorCount++;
                 return;
@@ -85,7 +83,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var xml = new XmlDocument { XmlResolver = null };
             try
             {
-                xml.LoadXml(sb.ToString().Trim());
+                xml.LoadXml(JoinLinesTrimmed(lines));
                 var namespaceManager = new XmlNamespaceManager(xml.NameTable);
                 namespaceManager.AddNamespace("edius", xml.DocumentElement.NamespaceURI);
                 foreach (XmlNode node in xml.SelectNodes("//edius:marker", namespaceManager))

--- a/src/libse/SubtitleFormats/Edius4Ms.cs
+++ b/src/libse/SubtitleFormats/Edius4Ms.cs
@@ -74,9 +74,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            if (!sb.ToString().Contains("<edius:markerLists"))
+            if (!JoinLines(lines).Contains("<edius:markerLists"))
             {
                 _errorCount++;
                 return;
@@ -85,7 +83,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var xml = new XmlDocument { XmlResolver = null };
             try
             {
-                xml.LoadXml(sb.ToString().Trim());
+                xml.LoadXml(JoinLinesTrimmed(lines));
                 var namespaceManager = new XmlNamespaceManager(xml.NameTable);
                 namespaceManager.AddNamespace("edius", xml.DocumentElement.NamespaceURI);
                 foreach (XmlNode node in xml.SelectNodes("//edius:marker", namespaceManager))

--- a/src/libse/SubtitleFormats/Eeg708.cs
+++ b/src/libse/SubtitleFormats/Eeg708.cs
@@ -46,10 +46,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
 
-            string allText = sb.ToString();
+            string allText = JoinLines(lines);
             if (!allText.Contains("<EEG708Captions") || !allText.Contains("<Caption"))
             {
                 return;

--- a/src/libse/SubtitleFormats/FLVCoreCuePoints.cs
+++ b/src/libse/SubtitleFormats/FLVCoreCuePoints.cs
@@ -78,10 +78,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
 
-            string allText = sb.ToString();
+            string allText = JoinLines(lines);
             if (!allText.Contains("<FLVCoreCuePoints") || !allText.Contains("<CuePoint"))
             {
                 return;

--- a/src/libse/SubtitleFormats/FilmEditXml.cs
+++ b/src/libse/SubtitleFormats/FilmEditXml.cs
@@ -14,9 +14,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            string xmlAsString = sb.ToString().Trim();
+            string xmlAsString = JoinLinesTrimmed(lines);
             if (xmlAsString.Contains("</filmeditxml>") && xmlAsString.Contains("</subtitle>"))
             {
                 var xml = new XmlDocument { XmlResolver = null };
@@ -114,10 +112,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
         {
             _errorCount = 0;
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
             var xml = new XmlDocument { XmlResolver = null };
-            xml.LoadXml(sb.ToString().Trim());
+            xml.LoadXml(JoinLinesTrimmed(lines));
             foreach (XmlNode node in xml.DocumentElement.SelectNodes("subtitle"))
             {
                 try

--- a/src/libse/SubtitleFormats/FinalCutProImage.cs
+++ b/src/libse/SubtitleFormats/FinalCutProImage.cs
@@ -25,12 +25,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             _errorCount = 0;
             FrameRate = Configuration.Settings.General.CurrentFrameRate;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
             var xml = new XmlDocument { XmlResolver = null };
             try
             {
-                xml.LoadXml(sb.ToString().Trim());
+                xml.LoadXml(JoinLinesTrimmed(lines));
 
                 if (xml.DocumentElement.SelectSingleNode("sequence/rate") != null && xml.DocumentElement.SelectSingleNode("sequence/rate/timebase") != null)
                 {

--- a/src/libse/SubtitleFormats/FinalCutProTest2Xml.cs
+++ b/src/libse/SubtitleFormats/FinalCutProTest2Xml.cs
@@ -156,15 +156,13 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             _errorCount = 0;
             var frameRate = Configuration.Settings.General.CurrentFrameRate;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
             var xml = new XmlDocument { XmlResolver = null };
             try
             {
-                xml.LoadXml(sb.ToString().Trim());
+                xml.LoadXml(JoinLinesTrimmed(lines));
 
                 var header = new XmlDocument { XmlResolver = null };
-                header.LoadXml(sb.ToString());
+                header.LoadXml(JoinLines(lines));
                 if (header.SelectSingleNode("sequence/media/video/track") != null)
                 {
                     header.RemoveChild(header.SelectSingleNode("sequence/media/video/track"));

--- a/src/libse/SubtitleFormats/FinalCutProTextXml.cs
+++ b/src/libse/SubtitleFormats/FinalCutProTextXml.cs
@@ -239,15 +239,13 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             _errorCount = 0;
             var frameRate = Configuration.Settings.General.CurrentFrameRate;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
             var xml = new XmlDocument { XmlResolver = null };
             try
             {
-                xml.LoadXml(sb.ToString().Trim());
+                xml.LoadXml(JoinLinesTrimmed(lines));
 
                 var header = new XmlDocument { XmlResolver = null };
-                header.LoadXml(sb.ToString());
+                header.LoadXml(JoinLines(lines));
                 if (header.SelectSingleNode("sequence/media/video/track") != null)
                 {
                     header.RemoveChild(header.SelectSingleNode("sequence/media/video/track"));

--- a/src/libse/SubtitleFormats/FinalCutProXCM.cs
+++ b/src/libse/SubtitleFormats/FinalCutProXCM.cs
@@ -89,13 +89,11 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             _errorCount = 0;
             FrameRate = Configuration.Settings.General.CurrentFrameRate;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
             var xml = new XmlDocument { XmlResolver = null };
             xml.PreserveWhitespace = true;
             try
             {
-                xml.LoadXml(sb.ToString().Trim());
+                xml.LoadXml(JoinLinesTrimmed(lines));
 
                 foreach (XmlNode node in xml.SelectNodes("fcpxml/project/sequence/spine/clip/chapter-marker"))
                 {

--- a/src/libse/SubtitleFormats/FinalCutProXXml.cs
+++ b/src/libse/SubtitleFormats/FinalCutProXXml.cs
@@ -113,12 +113,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             _errorCount = 0;
             FrameRate = Configuration.Settings.General.CurrentFrameRate;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
             var xml = new XmlDocument { XmlResolver = null };
             try
             {
-                xml.LoadXml(sb.ToString().Trim());
+                xml.LoadXml(JoinLinesTrimmed(lines));
 
                 foreach (XmlNode node in xml.SelectNodes("fcpxml/project/sequence/spine/clip"))
                 {

--- a/src/libse/SubtitleFormats/FinalCutProXml.cs
+++ b/src/libse/SubtitleFormats/FinalCutProXml.cs
@@ -455,14 +455,12 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             _errorCount = 0;
             var frameRate = Configuration.Settings.General.CurrentFrameRate;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
             var xml = new XmlDocument { XmlResolver = null };
             try
             {
-                xml.LoadXml(sb.ToString().Trim());
+                xml.LoadXml(JoinLinesTrimmed(lines));
                 var header = new XmlDocument { XmlResolver = null };
-                header.LoadXml(sb.ToString());
+                header.LoadXml(JoinLines(lines));
                 if (header.SelectSingleNode("sequence/media/video/track") != null)
                 {
                     header.RemoveChild(header.SelectSingleNode("sequence/media/video/track"));

--- a/src/libse/SubtitleFormats/FinalCutProXml13.cs
+++ b/src/libse/SubtitleFormats/FinalCutProXml13.cs
@@ -110,9 +110,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             _errorCount = 0;
             FrameRate = Configuration.Settings.General.CurrentFrameRate;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            string x = sb.ToString();
+            string x = JoinLines(lines);
             if (!x.Contains("<fcpxml version=\"1.3\"") && !x.Contains("<fcpxml version=\"1.2\""))
             {
                 return;

--- a/src/libse/SubtitleFormats/FinalCutProXml14.cs
+++ b/src/libse/SubtitleFormats/FinalCutProXml14.cs
@@ -98,9 +98,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             _errorCount = 0;
             FrameRate = Configuration.Settings.General.CurrentFrameRate;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            string x = sb.ToString();
+            string x = JoinLines(lines);
             if (!x.Contains("<fcpxml version=\"1.4\">") && !x.Contains("<fcpxml version=\"1.5\">"))
             {
                 return;

--- a/src/libse/SubtitleFormats/FinalCutProXml14Text.cs
+++ b/src/libse/SubtitleFormats/FinalCutProXml14Text.cs
@@ -131,9 +131,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             _errorCount = 0;
             FrameRate = Configuration.Settings.General.CurrentFrameRate;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            string x = sb.ToString();
+            string x = JoinLines(lines);
             if (!x.Contains("<fcpxml version=\"1.4\">"))
             {
                 return;

--- a/src/libse/SubtitleFormats/FinalCutProXml15.cs
+++ b/src/libse/SubtitleFormats/FinalCutProXml15.cs
@@ -431,9 +431,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             _errorCount = 0;
             FrameRate = Configuration.Settings.General.CurrentFrameRate;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            var x = sb.ToString();
+            var x = JoinLines(lines);
             if (!IsVersionMatch(x))
             {
                 return;

--- a/src/libse/SubtitleFormats/FinalCutProXmlCaptions.cs
+++ b/src/libse/SubtitleFormats/FinalCutProXmlCaptions.cs
@@ -297,9 +297,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
         {
             _errorCount = 0;
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            var x = sb.ToString();
+            var x = JoinLines(lines);
             if (!x.Contains("<fcpxml version="))
             {
                 return;

--- a/src/libse/SubtitleFormats/FinalCutProXmlGap.cs
+++ b/src/libse/SubtitleFormats/FinalCutProXmlGap.cs
@@ -85,12 +85,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             _errorCount = 0;
             FrameRate = Configuration.Settings.General.CurrentFrameRate;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
             var xml = new XmlDocument { XmlResolver = null };
             try
             {
-                xml.LoadXml(sb.ToString().Trim());
+                xml.LoadXml(JoinLinesTrimmed(lines));
 
                 var text = new StringBuilder();
                 foreach (XmlNode node in xml.SelectNodes("fcpxml/project/sequence/spine/gap"))

--- a/src/libse/SubtitleFormats/FinalCutProXmlName.cs
+++ b/src/libse/SubtitleFormats/FinalCutProXmlName.cs
@@ -104,9 +104,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
             FrameRate = Configuration.Settings.General.CurrentFrameRate;
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            var x = sb.ToString();
+            var x = JoinLines(lines);
             var xml = new XmlDocument();
             try
             {

--- a/src/libse/SubtitleFormats/FlashXml.cs
+++ b/src/libse/SubtitleFormats/FlashXml.cs
@@ -25,9 +25,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            string xmlAsString = sb.ToString().Trim();
+            string xmlAsString = JoinLinesTrimmed(lines);
             if ((xmlAsString.Contains("<tt>") || xmlAsString.Contains("<tt ")) && (xmlAsString.Contains("<sub>")))
             {
                 var xml = new XmlDocument { XmlResolver = null };
@@ -89,10 +87,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             _errorCount = 0;
             double startSeconds = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
             var xml = new XmlDocument { XmlResolver = null };
-            xml.LoadXml(sb.ToString().Trim());
+            xml.LoadXml(JoinLinesTrimmed(lines));
 
             var pText = new StringBuilder();
             foreach (XmlNode node in xml.DocumentElement.SelectNodes("div/p"))

--- a/src/libse/SubtitleFormats/GpacTtxt.cs
+++ b/src/libse/SubtitleFormats/GpacTtxt.cs
@@ -65,10 +65,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
             Paragraph last = null;
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
 
-            if (!sb.ToString().Contains("<TextStream"))
+            if (!JoinLines(lines).Contains("<TextStream"))
             {
                 return;
             }
@@ -76,7 +74,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var xml = new XmlDocument { XmlResolver = null };
             try
             {
-                xml.LoadXml(sb.ToString().Trim());
+                xml.LoadXml(JoinLinesTrimmed(lines));
 
                 foreach (XmlNode node in xml.DocumentElement.SelectNodes("TextSample"))
                 {

--- a/src/libse/SubtitleFormats/IssXml.cs
+++ b/src/libse/SubtitleFormats/IssXml.cs
@@ -116,9 +116,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            if (!sb.ToString().Contains("<StTextList"))
+            if (!JoinLines(lines).Contains("<StTextList"))
             {
                 _errorCount++;
                 return;
@@ -127,7 +125,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var xml = new XmlDocument { XmlResolver = null };
             try
             {
-                xml.LoadXml(sb.ToString().Trim());
+                xml.LoadXml(JoinLinesTrimmed(lines));
 
                 XmlNode use2997DropFrame = xml.DocumentElement.SelectSingleNode("TrackList/Track/FcpProperty");
                 if (use2997DropFrame != null && use2997DropFrame.Attributes["Use2997DropFrame"] != null && use2997DropFrame.Attributes["Use2997DropFrame"].InnerText == "1")

--- a/src/libse/SubtitleFormats/MediaTransData.cs
+++ b/src/libse/SubtitleFormats/MediaTransData.cs
@@ -170,9 +170,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
         {
             _errorCount = 0;
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            var xmlAsText = sb.ToString().Trim();
+            var xmlAsText = JoinLinesTrimmed(lines);
             if (!xmlAsText.Contains("<Type>Text</Type>") || !xmlAsText.Contains("</MediaTransData>"))
             {
                 return;

--- a/src/libse/SubtitleFormats/MsOfficeWorkbook.cs
+++ b/src/libse/SubtitleFormats/MsOfficeWorkbook.cs
@@ -21,9 +21,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            var xmlAsString = sb.ToString().Trim();
+            var xmlAsString = JoinLinesTrimmed(lines);
             return xmlAsString.Contains("urn:schemas-microsoft-com:office:excel") && base.IsMine(lines, fileName);
         }
 
@@ -149,16 +147,14 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
         {
             _errorCount = 0;
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
             var xml = new XmlDocument { XmlResolver = null, PreserveWhitespace = true };
             try
             {
-                xml.LoadXml(sb.ToString().RemoveControlCharactersButWhiteSpace().Trim());
+                xml.LoadXml(JoinLines(lines).RemoveControlCharactersButWhiteSpace().Trim());
             }
             catch
             {
-                xml.LoadXml(sb.ToString());
+                xml.LoadXml(JoinLines(lines));
             }
 
             var xmlNamespaceManager = MakeNamespaceManager(xml);

--- a/src/libse/SubtitleFormats/NetflixImsc11Japanese.cs
+++ b/src/libse/SubtitleFormats/NetflixImsc11Japanese.cs
@@ -86,9 +86,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 return false;
             }
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            var text = sb.ToString();
+            var text = JoinLines(lines);
             if (!text.Contains("lang=\"ja\"", StringComparison.Ordinal) || !ContainsJapaneseProfileStyling(text))
             {
                 return false;
@@ -402,16 +400,14 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
             var xml = new XmlDocument { XmlResolver = null, PreserveWhitespace = true };
             try
             {
-                xml.LoadXml(sb.ToString().RemoveControlCharactersButWhiteSpace().Trim());
+                xml.LoadXml(JoinLines(lines).RemoveControlCharactersButWhiteSpace().Trim());
             }
             catch
             {
-                xml.LoadXml(sb.ToString().Replace(" & ", " &amp; ").Replace("Q&A", "Q&amp;A").RemoveControlCharactersButWhiteSpace().Trim());
+                xml.LoadXml(JoinLines(lines).Replace(" & ", " &amp; ").Replace("Q&A", "Q&amp;A").RemoveControlCharactersButWhiteSpace().Trim());
             }
 
             var frameRateAttr = xml.DocumentElement.Attributes["ttp:frameRate"];
@@ -457,7 +453,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
 
             Configuration.Settings.SubtitleSettings.TimedText10TimeCodeFormatSource = null;
-            subtitle.Header = sb.ToString();
+            subtitle.Header = JoinLines(lines);
 
             var namespaceManager = new XmlNamespaceManager(xml.NameTable);
             namespaceManager.AddNamespace("ttml", "http://www.w3.org/ns/ttml");

--- a/src/libse/SubtitleFormats/NetflixTimedText.cs
+++ b/src/libse/SubtitleFormats/NetflixTimedText.cs
@@ -28,9 +28,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 return false;
             }
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            if (!sb.ToString().Contains(">Netflix Subtitle"))
+            if (!JoinLines(lines).Contains(">Netflix Subtitle"))
             {
                 return false;
             }

--- a/src/libse/SubtitleFormats/NinsightXml.cs
+++ b/src/libse/SubtitleFormats/NinsightXml.cs
@@ -52,9 +52,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            if (!sb.ToString().Contains("<TEXT_TRACK"))
+            if (!JoinLines(lines).Contains("<TEXT_TRACK"))
             {
                 return;
             }
@@ -62,7 +60,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var xml = new XmlDocument { XmlResolver = null };
             try
             {
-                var xmlText = sb.ToString();
+                var xmlText = JoinLines(lines);
                 var startDocType = xmlText.IndexOf("<!DOCTYPE", StringComparison.Ordinal);
                 if (startDocType > 0)
                 {

--- a/src/libse/SubtitleFormats/NkhCuePoints.cs
+++ b/src/libse/SubtitleFormats/NkhCuePoints.cs
@@ -78,9 +78,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
         {
             _errorCount = 0;
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            var allText = sb.ToString().Trim();
+            var allText = JoinLinesTrimmed(lines);
 
             var startRemove = 5;
             while (allText.Length > 0 && allText[0] != '<' && startRemove > 0)

--- a/src/libse/SubtitleFormats/OpenDvt.cs
+++ b/src/libse/SubtitleFormats/OpenDvt.cs
@@ -14,9 +14,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            string xmlAsString = sb.ToString().Trim();
+            string xmlAsString = JoinLinesTrimmed(lines);
             if (xmlAsString.Contains("OpenDVT"))
             {
                 try
@@ -129,9 +127,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             _errorCount = 0;
 
             var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
             var xml = new XmlDocument { XmlResolver = null };
-            xml.LoadXml(sb.ToString().Trim());
+            xml.LoadXml(JoinLinesTrimmed(lines));
 
             XmlNode div = xml.DocumentElement.SelectSingleNode("Lines");
             foreach (XmlNode node in div.ChildNodes)

--- a/src/libse/SubtitleFormats/OresmeDocXDocument.cs
+++ b/src/libse/SubtitleFormats/OresmeDocXDocument.cs
@@ -14,9 +14,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            string xmlAsString = sb.ToString().Trim();
+            string xmlAsString = JoinLinesTrimmed(lines);
             if (xmlAsString.Contains("<w:tc>"))
             {
                 return base.IsMine(lines, fileName);
@@ -211,9 +209,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
             var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
             var xml = new XmlDocument { XmlResolver = null };
-            xml.LoadXml(sb.ToString().Trim());
+            xml.LoadXml(JoinLinesTrimmed(lines));
             var nsmgr = new XmlNamespaceManager(xml.NameTable);
             nsmgr.AddNamespace("w", "http://schemas.openxmlformats.org/wordprocessingml/2006/main");
             foreach (XmlNode node in xml.DocumentElement.SelectNodes("//w:tr", nsmgr))

--- a/src/libse/SubtitleFormats/PListCaption.cs
+++ b/src/libse/SubtitleFormats/PListCaption.cs
@@ -33,9 +33,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            string xmlAsString = sb.ToString().Trim();
+            string xmlAsString = JoinLinesTrimmed(lines);
             if (xmlAsString.Contains("</plist>") && xmlAsString.Contains("</dict>"))
             {
                 XmlDocument xml = new XmlDocument { XmlResolver = null };
@@ -114,10 +112,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
         {
             _errorCount = 0;
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
             XmlDocument xml = new XmlDocument { XmlResolver = null };
-            xml.LoadXml(sb.ToString().Trim());
+            xml.LoadXml(JoinLinesTrimmed(lines));
             string lastKey = string.Empty;
             var pText = new StringBuilder();
             foreach (XmlNode node in xml.DocumentElement.SelectNodes("array/dict"))

--- a/src/libse/SubtitleFormats/Rdf1.cs
+++ b/src/libse/SubtitleFormats/Rdf1.cs
@@ -21,9 +21,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
         {
             _errorCount = 0;
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            var xmlAsText = sb.ToString().Trim();
+            var xmlAsText = JoinLinesTrimmed(lines);
             if (!xmlAsText.Contains("<rdf:"))
             {
                 return;

--- a/src/libse/SubtitleFormats/RhozetHarmonic.cs
+++ b/src/libse/SubtitleFormats/RhozetHarmonic.cs
@@ -110,10 +110,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
 
-            string allText = sb.ToString();
+            string allText = JoinLines(lines);
             if (!allText.Contains("<TitlerData") || !allText.Contains("<Data"))
             {
                 return;

--- a/src/libse/SubtitleFormats/RhozetHarmonicImage.cs
+++ b/src/libse/SubtitleFormats/RhozetHarmonicImage.cs
@@ -66,10 +66,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
 
-            string allText = sb.ToString();
+            string allText = JoinLines(lines);
             if (!allText.Contains("<TitlerData") || !allText.Contains("<Data"))
             {
                 return;

--- a/src/libse/SubtitleFormats/SmpteTt2052.cs
+++ b/src/libse/SubtitleFormats/SmpteTt2052.cs
@@ -25,9 +25,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 return false;
             }
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            if (!sb.ToString().Contains("http://www.smpte-ra.org/schemas/2052-1/2010/smpte-tt#cea608"))
+            if (!JoinLines(lines).Contains("http://www.smpte-ra.org/schemas/2052-1/2010/smpte-tt#cea608"))
             {
                 return false;
             }

--- a/src/libse/SubtitleFormats/SpuImage.cs
+++ b/src/libse/SubtitleFormats/SpuImage.cs
@@ -22,9 +22,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
         {
             _errorCount = 0;
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            string xmlString = sb.ToString();
+            string xmlString = JoinLines(lines);
             if (!xmlString.Contains("<subpictures") || !xmlString.Contains("<spu "))
             {
                 return;

--- a/src/libse/SubtitleFormats/SubtitleEditorProject.cs
+++ b/src/libse/SubtitleFormats/SubtitleEditorProject.cs
@@ -15,9 +15,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            string xmlAsString = sb.ToString().Trim();
+            string xmlAsString = JoinLinesTrimmed(lines);
             if (xmlAsString.Contains("<SubtitleEditorProject") &&
                 xmlAsString.Contains("<subtitle "))
             {
@@ -128,10 +126,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
             var xml = new XmlDocument { XmlResolver = null };
-            xml.LoadXml(sb.ToString().Trim());
+            xml.LoadXml(JoinLinesTrimmed(lines));
 
             XmlNode div = xml.DocumentElement.SelectSingleNode("subtitles");
             foreach (XmlNode node in div.ChildNodes)

--- a/src/libse/SubtitleFormats/SubtitleFormat.cs
+++ b/src/libse/SubtitleFormats/SubtitleFormat.cs
@@ -38,6 +38,53 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         protected static readonly char[] SplitCharColon = { ':' };
 
+        // Auto-detection hands the same List<string> to every candidate format in turn
+        // (60 formats claim ".xml" alone), and most of them join all lines into one string
+        // before a cheap marker test rejects the file - allocating roughly the file size in
+        // garbage per format. Memoize the last join per thread; the key is the list
+        // reference plus its count (no caller mutates the list between joins).
+        [ThreadStatic] private static List<string> _joinedLinesKey;
+        [ThreadStatic] private static int _joinedLinesKeyCount;
+        [ThreadStatic] private static string _joinedLines;
+        [ThreadStatic] private static string _joinedLinesTrimmed;
+
+        /// <summary>
+        /// All lines joined with <see cref="Environment.NewLine"/> after each line -
+        /// same result as appending every line to a StringBuilder with AppendLine.
+        /// </summary>
+        protected static string JoinLines(List<string> lines)
+        {
+            if (!ReferenceEquals(lines, _joinedLinesKey) || lines.Count != _joinedLinesKeyCount)
+            {
+                var capacity = 0;
+                var newLineLength = Environment.NewLine.Length;
+                foreach (var line in lines)
+                {
+                    capacity += line.Length + newLineLength;
+                }
+
+                var sb = new StringBuilder(capacity);
+                foreach (var line in lines)
+                {
+                    sb.AppendLine(line);
+                }
+
+                _joinedLines = sb.ToString();
+                _joinedLinesTrimmed = null;
+                _joinedLinesKey = lines;
+                _joinedLinesKeyCount = lines.Count;
+            }
+
+            return _joinedLines;
+        }
+
+        /// <summary>Same as <see cref="JoinLines"/> followed by Trim().</summary>
+        protected static string JoinLinesTrimmed(List<string> lines)
+        {
+            var joined = JoinLines(lines);
+            return _joinedLinesTrimmed ??= joined.Trim();
+        }
+
         /// <summary>
         /// Builds the format cache on a worker thread so the ~330 type loads and constructor JITs
         /// overlap with other start-up work instead of blocking the first window. Purely an

--- a/src/libse/SubtitleFormats/TimeXml.cs
+++ b/src/libse/SubtitleFormats/TimeXml.cs
@@ -52,10 +52,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
 
-            string xmlString = sb.ToString();
+            string xmlString = JoinLines(lines);
             if (!xmlString.Contains("<Paragraph>") || !xmlString.Contains("<Text>"))
             {
                 return;

--- a/src/libse/SubtitleFormats/TimeXml2.cs
+++ b/src/libse/SubtitleFormats/TimeXml2.cs
@@ -55,10 +55,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
         {
             _errorCount = 0;
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
 
-            var xmlString = sb.ToString();
+            var xmlString = JoinLines(lines);
             if (!xmlString.Contains("<Subtitles>") || !xmlString.Contains("<Text>") || !xmlString.Contains("<Duration>"))
             {
                 return;

--- a/src/libse/SubtitleFormats/TimedText.cs
+++ b/src/libse/SubtitleFormats/TimedText.cs
@@ -15,9 +15,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            string xmlAsString = sb.ToString().RemoveControlCharactersButWhiteSpace().Trim();
+            string xmlAsString = JoinLines(lines).RemoveControlCharactersButWhiteSpace().Trim();
 
             if (xmlAsString.Contains("xmlns:tts=\"http://www.w3.org/2006/04"))
             {
@@ -132,10 +130,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
             var xml = new XmlDocument { XmlResolver = null };
-            xml.LoadXml(sb.ToString().Replace(" & ", " &amp; ").Replace("Q&A", "Q&amp;A").RemoveControlCharactersButWhiteSpace().Trim());
+            xml.LoadXml(JoinLines(lines).Replace(" & ", " &amp; ").Replace("Q&A", "Q&amp;A").RemoveControlCharactersButWhiteSpace().Trim());
             subtitle.Header = xml.OuterXml;
 
             var nsmgr = new XmlNamespaceManager(xml.NameTable);

--- a/src/libse/SubtitleFormats/TimedText10.cs
+++ b/src/libse/SubtitleFormats/TimedText10.cs
@@ -30,9 +30,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            var xmlAsString = sb.ToString().Trim();
+            var xmlAsString = JoinLinesTrimmed(lines);
 
             if (xmlAsString.Contains("xmlns:tts=\"http://www.w3.org/2006/04"))
             {
@@ -323,8 +321,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
 
             var no = 0;
-            var headerStyles = GetStylesFromHeader(ToUtf8XmlString(xml));
-            var regions = GetRegionsFromHeader(ToUtf8XmlString(xml));
+            var headerStyles = GetStylesFromHeader(xml);
+            var regions = GetRegionsFromHeader(xml);
+            var regionsCache = new TopBottomRegionsCache();
             var languages = GetUsedLanguages(subtitle);
             if (languages.Count > 0)
             {
@@ -338,7 +337,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             div = xml.CreateElement("div", TtmlNamespace);
                             divParentNode.AppendChild(div);
                         }
-                        XmlNode paragraph = MakeParagraph(subtitle, xml, defaultStyle, no, headerStyles, regions, p);
+                        XmlNode paragraph = MakeParagraph(subtitle, xml, defaultStyle, no, headerStyles, regions, regionsCache, p);
                         div.AppendChild(paragraph);
                         no++;
                     }
@@ -365,7 +364,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                                 divParentNode.AppendChild(div);
                             }
                             firstParagraph = false;
-                            XmlNode paragraph = MakeParagraph(subtitle, xml, defaultStyle, no, headerStyles, regions, p);
+                            XmlNode paragraph = MakeParagraph(subtitle, xml, defaultStyle, no, headerStyles, regions, regionsCache, p);
                             div.AppendChild(paragraph);
                             no++;
                         }
@@ -392,7 +391,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         p.Style = p.Extra;
                     }
 
-                    XmlNode paragraph = MakeParagraph(subtitle, xml, defaultStyle, no, headerStyles, regions, p);
+                    XmlNode paragraph = MakeParagraph(subtitle, xml, defaultStyle, no, headerStyles, regions, regionsCache, p);
                     div.AppendChild(paragraph);
                     no++;
                 }
@@ -444,7 +443,19 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             return x.OuterXml;
         }
 
-        private static XmlNode MakeParagraph(Subtitle subtitle, XmlDocument xml, string defaultStyle, int no, List<string> headerStyles, List<string> regions, Paragraph p)
+        /// <summary>
+        /// Caches <see cref="GetRegionsTopFromHeader"/> / <see cref="GetRegionsBottomFromHeader"/>
+        /// across one ToText run. Both walk the entire document with an absolute XPath, so calling
+        /// them per paragraph made saving quadratic - paragraph n scanned a document already
+        /// holding n paragraphs. Invalidated when a default region is added mid-save.
+        /// </summary>
+        private sealed class TopBottomRegionsCache
+        {
+            public List<string> Top;
+            public List<string> Bottom;
+        }
+
+        private static XmlNode MakeParagraph(Subtitle subtitle, XmlDocument xml, string defaultStyle, int no, List<string> headerStyles, List<string> regions, TopBottomRegionsCache regionsCache, Paragraph p)
         {
             XmlNode paragraph = xml.CreateElement("p", "http://www.w3.org/ns/ttml");
             string text = p.Text.RemoveControlCharactersButWhiteSpace();
@@ -457,6 +468,13 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
             if (string.IsNullOrEmpty(region))
             {
+                if (text.StartsWith("{\\an", StringComparison.Ordinal))
+                {
+                    // AddDefaultRegionIfNotExists below may add a region to the document.
+                    regionsCache.Top = null;
+                    regionsCache.Bottom = null;
+                }
+
                 if (text.StartsWith("{\\an1}", StringComparison.Ordinal) && AddDefaultRegionIfNotExists(xml, "bottomLeft"))
                 {
                     region = "bottomLeft";
@@ -506,7 +524,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             {
                 if (text.StartsWith("{\\an8}", StringComparison.Ordinal))
                 {
-                    var topRegions = GetRegionsTopFromHeader(xml);
+                    var topRegions = regionsCache.Top ??= GetRegionsTopFromHeader(xml);
                     if (topRegions.Count == 1)
                     {
                         region = topRegions[0];
@@ -523,7 +541,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 }
                 else if (text.StartsWith("{\\an2}", StringComparison.Ordinal) || !text.Contains("{\\an"))
                 {
-                    var bottomRegions = GetRegionsBottomFromHeader(xml);
+                    var bottomRegions = regionsCache.Bottom ??= GetRegionsBottomFromHeader(xml);
                     if (bottomRegions.Count == 1)
                     {
                         region = bottomRegions[0];
@@ -776,16 +794,14 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
             var xml = new XmlDocument { XmlResolver = null, PreserveWhitespace = true };
             try
             {
-                xml.LoadXml(sb.ToString().RemoveControlCharactersButWhiteSpace().Trim());
+                xml.LoadXml(JoinLines(lines).RemoveControlCharactersButWhiteSpace().Trim());
             }
             catch
             {
-                xml.LoadXml(FixBadXml(sb.ToString()));
+                xml.LoadXml(FixBadXml(JoinLines(lines)));
             }
 
             const string ns = "http://www.w3.org/ns/ttml";
@@ -839,7 +855,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
 
             Configuration.Settings.SubtitleSettings.TimedText10TimeCodeFormatSource = null;
-            subtitle.Header = sb.ToString();
+            subtitle.Header = JoinLines(lines);
             var styles = GetStylesFromHeader(subtitle.Header);
             string defaultStyle = null;
             if (body.Attributes["style"] != null)
@@ -1423,11 +1439,29 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public static List<string> GetStylesFromHeader(string xmlAsString)
         {
-            var list = new List<string>();
             var xml = new XmlDocument();
             try
             {
                 xml.LoadXml(xmlAsString);
+            }
+            catch
+            {
+                return new List<string>();
+            }
+
+            return GetStylesFromHeader(xml);
+        }
+
+        /// <summary>
+        /// Same as <see cref="GetStylesFromHeader(string)"/> but reads the live document -
+        /// the save path already has one, and serializing + re-parsing the whole document
+        /// just to read the style ids was two full copies per call.
+        /// </summary>
+        public static List<string> GetStylesFromHeader(XmlDocument xml)
+        {
+            var list = new List<string>();
+            try
+            {
                 var nsmgr = new XmlNamespaceManager(xml.NameTable);
                 nsmgr.AddNamespace("ttml", "http://www.w3.org/ns/ttml");
                 XmlNode head = xml.DocumentElement.SelectSingleNode("ttml:head", nsmgr);
@@ -1463,11 +1497,28 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public static List<string> GetRegionsFromHeader(string xmlAsString)
         {
-            var list = new List<string>();
             var xml = new XmlDocument();
             try
             {
                 xml.LoadXml(xmlAsString);
+            }
+            catch
+            {
+                return new List<string>();
+            }
+
+            return GetRegionsFromHeader(xml);
+        }
+
+        /// <summary>
+        /// Same as <see cref="GetRegionsFromHeader(string)"/> but reads the live document -
+        /// see <see cref="GetStylesFromHeader(XmlDocument)"/>.
+        /// </summary>
+        public static List<string> GetRegionsFromHeader(XmlDocument xml)
+        {
+            var list = new List<string>();
+            try
+            {
                 var nsmgr = new XmlNamespaceManager(xml.NameTable);
                 nsmgr.AddNamespace("ttml", "http://www.w3.org/ns/ttml");
                 XmlNode head = xml.DocumentElement.SelectSingleNode("ttml:head", nsmgr);

--- a/src/libse/SubtitleFormats/TimedText200604.cs
+++ b/src/libse/SubtitleFormats/TimedText200604.cs
@@ -17,9 +17,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            var xmlAsString = sb.ToString().Replace("http://www.w3.org/2006/04/ttaf1#styling\"xml:lang", "http://www.w3.org/2006/04/ttaf1#styling\" xml:lang").Trim();
+            var xmlAsString = JoinLines(lines).Replace("http://www.w3.org/2006/04/ttaf1#styling\"xml:lang", "http://www.w3.org/2006/04/ttaf1#styling\" xml:lang").Trim();
 
             if (xmlAsString.Contains("http://www.w3.org/2006/10"))
             {
@@ -155,10 +153,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
             var xml = new XmlDocument { XmlResolver = null };
-            xml.LoadXml(sb.ToString().RemoveControlCharactersButWhiteSpace().Trim().Replace("http://www.w3.org/2006/04/ttaf1#styling\"xml:lang", "http://www.w3.org/2006/04/ttaf1#styling\" xml:lang"));
+            xml.LoadXml(JoinLines(lines).RemoveControlCharactersButWhiteSpace().Trim().Replace("http://www.w3.org/2006/04/ttaf1#styling\"xml:lang", "http://www.w3.org/2006/04/ttaf1#styling\" xml:lang"));
 
             var nsmgr = new XmlNamespaceManager(xml.NameTable);
             nsmgr.AddNamespace("ttaf1", xml.DocumentElement.NamespaceURI);

--- a/src/libse/SubtitleFormats/TimedText200604Ooyala.cs
+++ b/src/libse/SubtitleFormats/TimedText200604Ooyala.cs
@@ -17,9 +17,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            var xmlAsString = sb.ToString().Replace("http://www.w3.org/2006/04/ttaf1#styling\"xml:lang", "http://www.w3.org/2006/04/ttaf1#styling\" xml:lang").Trim();
+            var xmlAsString = JoinLines(lines).Replace("http://www.w3.org/2006/04/ttaf1#styling\"xml:lang", "http://www.w3.org/2006/04/ttaf1#styling\" xml:lang").Trim();
 
             if (xmlAsString.Contains("http://www.w3.org/2006/10"))
             {
@@ -161,10 +159,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
             var xml = new XmlDocument { XmlResolver = null };
-            xml.LoadXml(sb.ToString().RemoveControlCharactersButWhiteSpace().Trim().Replace("http://www.w3.org/2006/04/ttaf1#styling\"xml:lang", "http://www.w3.org/2006/04/ttaf1#styling\" xml:lang"));
+            xml.LoadXml(JoinLines(lines).RemoveControlCharactersButWhiteSpace().Trim().Replace("http://www.w3.org/2006/04/ttaf1#styling\"xml:lang", "http://www.w3.org/2006/04/ttaf1#styling\" xml:lang"));
 
             var nsmgr = new XmlNamespaceManager(xml.NameTable);
             nsmgr.AddNamespace("ttaf1", xml.DocumentElement.NamespaceURI);

--- a/src/libse/SubtitleFormats/TimedTextBase64Image.cs
+++ b/src/libse/SubtitleFormats/TimedTextBase64Image.cs
@@ -95,10 +95,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
         {
             _errorCount = 0;
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
 
-            var xmlString = sb.ToString();
+            var xmlString = JoinLines(lines);
             if (!xmlString.Contains("smpte:backgroundImage") || !xmlString.Contains("smpte:image") || !xmlString.Contains("imagetype="))
             {
                 return;

--- a/src/libse/SubtitleFormats/TimedTextImage.cs
+++ b/src/libse/SubtitleFormats/TimedTextImage.cs
@@ -15,9 +15,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            string xmlAsString = sb.ToString().RemoveControlCharactersButWhiteSpace().Trim();
+            string xmlAsString = JoinLines(lines).RemoveControlCharactersButWhiteSpace().Trim();
 
             if (xmlAsString.Contains("xmlns:tts=\"http://www.w3.org/2006/04"))
             {
@@ -60,10 +58,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
             var xml = new XmlDocument { XmlResolver = null };
-            xml.LoadXml(sb.ToString().RemoveControlCharactersButWhiteSpace().Trim());
+            xml.LoadXml(JoinLines(lines).RemoveControlCharactersButWhiteSpace().Trim());
 
             var nsmgr = new XmlNamespaceManager(xml.NameTable);
             nsmgr.AddNamespace("tt", xml.DocumentElement.NamespaceURI);

--- a/src/libse/SubtitleFormats/TimedTextImsc11.cs
+++ b/src/libse/SubtitleFormats/TimedTextImsc11.cs
@@ -58,9 +58,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 return false;
             }
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            var text = sb.ToString();
+            var text = JoinLines(lines);
             if (text.Contains("lang=\"ja\"", StringComparison.Ordinal) && text.Contains("bouten-", StringComparison.Ordinal))
             {
                 return false;
@@ -535,16 +533,14 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
             var xml = new XmlDocument { XmlResolver = null, PreserveWhitespace = true };
             try
             {
-                xml.LoadXml(sb.ToString().RemoveControlCharactersButWhiteSpace().Trim());
+                xml.LoadXml(JoinLines(lines).RemoveControlCharactersButWhiteSpace().Trim());
             }
             catch
             {
-                xml.LoadXml(sb.ToString().Replace(" & ", " &amp; ").Replace("Q&A", "Q&amp;A").RemoveControlCharactersButWhiteSpace().Trim());
+                xml.LoadXml(JoinLines(lines).Replace(" & ", " &amp; ").Replace("Q&A", "Q&amp;A").RemoveControlCharactersButWhiteSpace().Trim());
             }
 
             var frameRateAttr = xml.DocumentElement.Attributes["ttp:frameRate"];
@@ -592,7 +588,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
 
             Configuration.Settings.SubtitleSettings.TimedText10TimeCodeFormatSource = null;
-            subtitle.Header = sb.ToString();
+            subtitle.Header = JoinLines(lines);
 
             var namespaceManager = new XmlNamespaceManager(xml.NameTable);
             namespaceManager.AddNamespace("ttml", "http://www.w3.org/ns/ttml");

--- a/src/libse/SubtitleFormats/TimedTextImscRosetta.cs
+++ b/src/libse/SubtitleFormats/TimedTextImscRosetta.cs
@@ -65,9 +65,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 return false;
             }
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            var text = sb.ToString();
+            var text = JoinLines(lines);
             if (text.Contains("lang=\"ja\"", StringComparison.Ordinal) && text.Contains("bouten-", StringComparison.Ordinal))
             {
                 return false;
@@ -367,16 +365,14 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
             var xml = new XmlDocument { XmlResolver = null, PreserveWhitespace = true };
             try
             {
-                xml.LoadXml(sb.ToString().RemoveControlCharactersButWhiteSpace().Trim());
+                xml.LoadXml(JoinLines(lines).RemoveControlCharactersButWhiteSpace().Trim());
             }
             catch
             {
-                xml.LoadXml(sb.ToString().Replace(" & ", " &amp; ").Replace("Q&A", "Q&amp;A").RemoveControlCharactersButWhiteSpace().Trim());
+                xml.LoadXml(JoinLines(lines).Replace(" & ", " &amp; ").Replace("Q&A", "Q&amp;A").RemoveControlCharactersButWhiteSpace().Trim());
             }
 
             var frameRateAttr = xml.DocumentElement.Attributes["ttp:frameRate"];
@@ -424,7 +420,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
 
             Configuration.Settings.SubtitleSettings.TimedText10TimeCodeFormatSource = null;
-            subtitle.Header = sb.ToString();
+            subtitle.Header = JoinLines(lines);
 
             var namespaceManager = new XmlNamespaceManager(xml.NameTable);
             namespaceManager.AddNamespace("ttml", "http://www.w3.org/ns/ttml");

--- a/src/libse/SubtitleFormats/TimedTextNoNs.cs
+++ b/src/libse/SubtitleFormats/TimedTextNoNs.cs
@@ -19,9 +19,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            var xmlAsString = sb.ToString().Trim();
+            var xmlAsString = JoinLinesTrimmed(lines);
 
             if (xmlAsString.Contains("xmlns="))
             {
@@ -290,16 +288,14 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
             var xml = new XmlDocument { XmlResolver = null, PreserveWhitespace = true };
             try
             {
-                xml.LoadXml(sb.ToString().RemoveControlCharactersButWhiteSpace().Trim());
+                xml.LoadXml(JoinLines(lines).RemoveControlCharactersButWhiteSpace().Trim());
             }
             catch
             {
-                xml.LoadXml(FixBadXml(sb.ToString()));
+                xml.LoadXml(FixBadXml(JoinLines(lines)));
             }
 
             XmlNode body = xml.DocumentElement.SelectSingleNode("body");

--- a/src/libse/SubtitleFormats/TmpegEncAW5.cs
+++ b/src/libse/SubtitleFormats/TmpegEncAW5.cs
@@ -56,9 +56,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            string xmlAsString = sb.ToString().Trim();
+            string xmlAsString = JoinLinesTrimmed(lines);
             if ((xmlAsString.Contains("<TMPGEncVMESubtitleTextFormat>") || xmlAsString.Contains("<SubtitleItem ")) && (xmlAsString.Contains("<Subtitle")))
             {
                 return base.IsMine(lines, fileName);

--- a/src/libse/SubtitleFormats/TmpegEncXml.cs
+++ b/src/libse/SubtitleFormats/TmpegEncXml.cs
@@ -32,9 +32,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            string xmlAsString = sb.ToString().Trim();
+            string xmlAsString = JoinLinesTrimmed(lines);
             if ((xmlAsString.Contains("<TMPGEncVMESubtitleTextFormat>") || xmlAsString.Contains("<SubtitleItem ")) && (xmlAsString.Contains("<Subtitle")))
             {
                 return base.IsMine(lines, fileName);
@@ -463,10 +461,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             _errorCount = 0;
             double startSeconds = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
             var xml = new XmlDocument { XmlResolver = null };
-            xml.LoadXml(sb.ToString().Trim());
+            xml.LoadXml(JoinLinesTrimmed(lines));
             var italicStyles = new List<bool>();
             var positionCodes = new List<int>();
 

--- a/src/libse/SubtitleFormats/Tmx14.cs
+++ b/src/libse/SubtitleFormats/Tmx14.cs
@@ -77,10 +77,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
 
-            string xmlString = sb.ToString();
+            string xmlString = JoinLines(lines);
             if (!xmlString.Contains("<tmx") || !xmlString.Contains("<seg>"))
             {
                 return;

--- a/src/libse/SubtitleFormats/TranscriberXml.cs
+++ b/src/libse/SubtitleFormats/TranscriberXml.cs
@@ -74,9 +74,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            if (!sb.ToString().Contains("<Trans"))
+            if (!JoinLines(lines).Contains("<Trans"))
             {
                 return;
             }
@@ -84,7 +82,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var xml = new XmlDocument { XmlResolver = null };
             try
             {
-                string xmlText = sb.ToString();
+                string xmlText = JoinLines(lines);
                 var startDocType = xmlText.IndexOf("<!DOCTYPE", StringComparison.Ordinal);
                 if (startDocType > 0)
                 {

--- a/src/libse/SubtitleFormats/UTSubtitleXml.cs
+++ b/src/libse/SubtitleFormats/UTSubtitleXml.cs
@@ -52,9 +52,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            if (!sb.ToString().Contains("<uts") || !sb.ToString().Contains("secOut="))
+            if (!JoinLines(lines).Contains("<uts") || !JoinLines(lines).Contains("secOut="))
             {
                 return;
             }
@@ -62,7 +60,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var xml = new XmlDocument { XmlResolver = null };
             try
             {
-                string xmlText = sb.ToString();
+                string xmlText = JoinLines(lines);
                 xml.LoadXml(xmlText);
 
                 foreach (XmlNode node in xml.SelectNodes("//ut"))

--- a/src/libse/SubtitleFormats/UniversalSubtitleFormat.cs
+++ b/src/libse/SubtitleFormats/UniversalSubtitleFormat.cs
@@ -200,10 +200,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
 
-            string xmlString = sb.ToString();
+            string xmlString = JoinLines(lines);
             if (!xmlString.Contains("<USFSubtitles") || !xmlString.Contains("<subtitles>"))
             {
                 return;

--- a/src/libse/SubtitleFormats/UnknownSubtitle13.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle13.cs
@@ -52,10 +52,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
 
-            string allText = sb.ToString();
+            string allText = JoinLines(lines);
             if (!allText.Contains("<subtitle>") || !allText.Contains("timeIn="))
             {
                 return;

--- a/src/libse/SubtitleFormats/UnknownSubtitle14.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle14.cs
@@ -52,10 +52,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
 
-            string allText = sb.ToString();
+            string allText = JoinLines(lines);
             if (!allText.Contains("<Subtitle") || !allText.Contains("TimeStart="))
             {
                 return;

--- a/src/libse/SubtitleFormats/UnknownSubtitle15.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle15.cs
@@ -67,10 +67,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
 
-            string allText = sb.ToString();
+            string allText = JoinLines(lines);
             if (!allText.Contains("<page") || !allText.Contains("<cuepoint"))
             {
                 return;

--- a/src/libse/SubtitleFormats/UnknownSubtitle19.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle19.cs
@@ -61,10 +61,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
 
-            string allText = sb.ToString();
+            string allText = JoinLines(lines);
             if (!allText.Contains("</Subtitle>") || !allText.Contains("<Clip "))
             {
                 return;

--- a/src/libse/SubtitleFormats/UnknownSubtitle28.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle28.cs
@@ -61,9 +61,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
         {
             _errorCount = 0;
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            string xmlString = sb.ToString();
+            string xmlString = JoinLines(lines);
             if (!xmlString.Contains("<titles") || !xmlString.Contains("<text1>"))
             {
                 return;

--- a/src/libse/SubtitleFormats/UnknownSubtitle43.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle43.cs
@@ -14,9 +14,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            string xmlAsString = sb.ToString().Trim();
+            string xmlAsString = JoinLinesTrimmed(lines);
             if (xmlAsString.Contains("<subtitle"))
             {
                 var xml = new XmlDocument { XmlResolver = null };
@@ -85,10 +83,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
             var xml = new XmlDocument { XmlResolver = null };
-            xml.LoadXml(sb.ToString().Trim());
+            xml.LoadXml(JoinLinesTrimmed(lines));
 
             var pText = new StringBuilder();
             foreach (XmlNode node in xml.DocumentElement.SelectNodes("subtitle"))

--- a/src/libse/SubtitleFormats/UnknownSubtitle5.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle5.cs
@@ -45,10 +45,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
 
-            string allText = sb.ToString();
+            string allText = JoinLines(lines);
             if (!allText.Contains("<text") || !allText.Contains("start="))
             {
                 return;

--- a/src/libse/SubtitleFormats/UnknownSubtitle67.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle67.cs
@@ -46,10 +46,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
 
-            string allText = sb.ToString();
+            string allText = JoinLines(lines);
             if (!allText.Contains("<Cue") && allText.Contains("value="))
             {
                 return;

--- a/src/libse/SubtitleFormats/UnknownSubtitle76.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle76.cs
@@ -15,9 +15,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            string xmlAsString = sb.ToString().Trim();
+            string xmlAsString = JoinLinesTrimmed(lines);
             if (xmlAsString.Contains("<timedtext"))
             {
                 var xml = new XmlDocument { XmlResolver = null };
@@ -70,10 +68,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
             var xml = new XmlDocument { XmlResolver = null };
-            xml.LoadXml(sb.ToString().Trim());
+            xml.LoadXml(JoinLinesTrimmed(lines));
 
             foreach (XmlNode node in xml.DocumentElement.SelectNodes("text"))
             {

--- a/src/libse/SubtitleFormats/UnknownSubtitle78.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle78.cs
@@ -156,9 +156,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
         {
             _errorCount = 0;
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            var xmlAsText = sb.ToString().Trim();
+            var xmlAsText = JoinLinesTrimmed(lines);
             if (!xmlAsText.Contains("<TextSection>") || !xmlAsText.Contains("<TextScreen>"))
             {
                 return;
@@ -166,6 +164,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
             try
             {
+                var sb = new StringBuilder();
                 var xml = new XmlDocument { XmlResolver = null };
                 xml.LoadXml(xmlAsText);
                 foreach (XmlNode node in xml.DocumentElement.SelectNodes("TextSection/TextScreen"))

--- a/src/libse/SubtitleFormats/UnknownSubtitle82.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle82.cs
@@ -44,9 +44,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
         {
             _errorCount = 0;
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            var xmlAsText = sb.ToString().Trim();
+            var xmlAsText = JoinLinesTrimmed(lines);
             if (!xmlAsText.Contains("</timedtext>") || !xmlAsText.Contains("<p "))
             {
                 return;

--- a/src/libse/SubtitleFormats/UnknownSubtitle91.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle91.cs
@@ -57,10 +57,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
             subtitle.Paragraphs.Clear();
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
 
-            string allText = sb.ToString();
+            string allText = JoinLines(lines);
             if (!allText.Contains("</captions>") || !allText.Contains("<caption "))
             {
                 return;

--- a/src/libse/SubtitleFormats/UnknownSubtitle92.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle92.cs
@@ -53,9 +53,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
         {
             _errorCount = 0;
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            string allText = sb.ToString();
+            string allText = JoinLines(lines);
             if (!allText.Contains("</dia>") || !allText.Contains("</sub>"))
             {
                 return;

--- a/src/libse/SubtitleFormats/VocapiaSplit.cs
+++ b/src/libse/SubtitleFormats/VocapiaSplit.cs
@@ -81,10 +81,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
 
-            string xmlString = sb.ToString();
+            string xmlString = JoinLines(lines);
             if (!xmlString.Contains("<SpeechSegment"))
             {
                 return;

--- a/src/libse/SubtitleFormats/Xif.cs
+++ b/src/libse/SubtitleFormats/Xif.cs
@@ -161,9 +161,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
         {
             _errorCount = 0;
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            var xmlAsText = sb.ToString().Trim();
+            var xmlAsText = JoinLinesTrimmed(lines);
             if (!xmlAsText.Contains("<XIF") || !xmlAsText.Contains("<SubtitleText"))
             {
                 return;
@@ -171,6 +169,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
             try
             {
+                var sb = new StringBuilder();
                 var xml = new XmlDocument { XmlResolver = null };
                 xml.LoadXml(xmlAsText);
                 foreach (XmlNode node in xml.DocumentElement.SelectNodes("FileBody/ContentBlock"))

--- a/src/libse/SubtitleFormats/Xmp.cs
+++ b/src/libse/SubtitleFormats/Xmp.cs
@@ -138,9 +138,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
         {
             _errorCount = 0;
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            string allText = sb.ToString();
+            string allText = JoinLines(lines);
             if (!allText.Contains("<x:xmpmeta"))
             {
                 return;

--- a/src/libse/SubtitleFormats/YouTubeAnnotations.cs
+++ b/src/libse/SubtitleFormats/YouTubeAnnotations.cs
@@ -121,9 +121,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             _errorCount = 0;
 
-            var sb = new StringBuilder();
-            lines.ForEach(line => sb.AppendLine(line));
-            if (!sb.ToString().Contains("</annotations>") || !sb.ToString().Contains("</TEXT>"))
+            if (!JoinLines(lines).Contains("</annotations>") || !JoinLines(lines).Contains("</TEXT>"))
             {
                 return;
             }
@@ -131,7 +129,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var xml = new XmlDocument { XmlResolver = null };
             try
             {
-                string xmlText = sb.ToString();
+                string xmlText = JoinLines(lines);
                 xml.LoadXml(xmlText);
                 var styles = new List<string> { "speech" };
 

--- a/src/libse/VobSub/SubPicture.cs
+++ b/src/libse/VobSub/SubPicture.cs
@@ -271,116 +271,56 @@ namespace Nikse.SubtitleEdit.Core.VobSub
 
             if (crop)
             {
+                // Each scan below only ran while the palette's background color itself
+                // looked like background (the loops seeded their pixel variable with it);
+                // an opaque background color meant no cropping. The scans themselves only
+                // ever tested pixel alpha, so read just the alpha bytes instead of building
+                // an SKColor per pixel. IsBackgroundColor is alpha < 2.
+                const byte alphaLimit = 2;
+                var backgroundIsTransparent = IsBackgroundColor(backgroundColor);
+
                 // Crop top
-                int x;
-                while (y < bmp.Height && IsBackgroundColor(c))
+                if (backgroundIsTransparent)
                 {
-                    c = bmp.GetPixel(0, y);
-                    if (IsBackgroundColor(c))
-                    {
-                        for (x = 1; x < bmp.Width; x++)
-                        {
-                            c = bmp.GetPixelNext();
-                            if (c.Alpha > 1)
-                            {
-                                break;
-                            }
-                        }
-                    }
-                    if (IsBackgroundColor(c))
+                    while (y < bmp.Height && bmp.IsRowTransparent(y, alphaLimit))
                     {
                         y++;
                     }
                 }
-                minY = y;
-                if (minY > 3)
-                {
-                    minY -= 3;
-                }
-                else
-                {
-                    minY = 0;
-                }
+                minY = y > 3 ? y - 3 : 0;
 
                 // Crop left
-                x = 0;
-                c = backgroundColor;
-                while (x < bmp.Width && IsBackgroundColor(c))
+                var x = 0;
+                if (backgroundIsTransparent)
                 {
-                    for (y = minY; y < bmp.Height; y++)
-                    {
-                        c = bmp.GetPixel(x, y);
-                        if (!IsBackgroundColor(c))
-                        {
-                            break;
-                        }
-                    }
-                    if (IsBackgroundColor(c))
+                    while (x < bmp.Width && bmp.IsColumnTransparent(x, minY, alphaLimit))
                     {
                         x++;
                     }
                 }
-                minX = x;
-                if (minX > 3)
-                {
-                    minX -= 3;
-                }
-                else
-                {
-                    minX = 0;
-                }
+                minX = x > 3 ? x - 3 : 0;
 
                 // Crop bottom
                 y = bmp.Height - 1;
-                c = backgroundColor;
-                while (y > minY && IsBackgroundColor(c))
+                if (backgroundIsTransparent)
                 {
-                    c = bmp.GetPixel(0, y);
-                    if (IsBackgroundColor(c))
-                    {
-                        for (x = 1; x < bmp.Width; x++)
-                        {
-                            c = bmp.GetPixelNext();
-                            if (!IsBackgroundColor(c))
-                            {
-                                break;
-                            }
-                        }
-                    }
-                    if (IsBackgroundColor(c))
+                    while (y > minY && bmp.IsRowTransparent(y, alphaLimit))
                     {
                         y--;
                     }
                 }
-                maxY = y + 7;
-                if (maxY >= bmp.Height)
-                {
-                    maxY = bmp.Height - 1;
-                }
+                maxY = Math.Min(y + 7, bmp.Height - 1);
 
                 // Crop right
                 x = bmp.Width - 1;
-                c = backgroundColor;
-                while (x > minX && IsBackgroundColor(c))
+                if (backgroundIsTransparent)
                 {
-                    for (y = minY; y < bmp.Height; y++)
-                    {
-                        c = bmp.GetPixel(x, y);
-                        if (!IsBackgroundColor(c))
-                        {
-                            break;
-                        }
-                    }
-                    if (IsBackgroundColor(c))
+                    while (x > minX && bmp.IsColumnTransparent(x, minY, alphaLimit))
                     {
                         x--;
                     }
                 }
-                maxX = x + 7;
-                if (maxX >= bmp.Width)
-                {
-                    maxX = bmp.Width - 1;
-                }
+                maxX = Math.Min(x + 7, bmp.Width - 1);
             }
 
             bmp.UnlockImage();
@@ -445,13 +385,26 @@ namespace Nikse.SubtitleEdit.Core.VobSub
                 }
 
                 var c = fourColors[color]; // set color via the four colors
-                for (var i = 0; i < runLength; i++, x++)
+                if (runLength > 0)
                 {
-                    if (x >= bmp.Width - 1)
+                    // The old per-pixel loop drew columns x..Width-2 normally and, when the
+                    // run reached the last column, drew that pixel too, then wrapped to the
+                    // next line and discarded the rest of the run. Fill the run in one go.
+                    var end = x + runLength; // exclusive
+                    if (end <= bmp.Width - 1)
                     {
-                        if (y < bmp.Height && x < bmp.Width && c != fourColors[0])
+                        if (y < bmp.Height && c.ToArgb() != colorZeroValue)
                         {
-                            bmp.SetPixel(x, y, c);
+                            bmp.SetPixel(x, y, c, runLength);
+                        }
+
+                        x = end;
+                    }
+                    else
+                    {
+                        if (y < bmp.Height && c.ToArgb() != colorZeroValue)
+                        {
+                            bmp.SetPixel(x, y, c, bmp.Width - x);
                         }
 
                         if (onlyHalf)
@@ -459,14 +412,9 @@ namespace Nikse.SubtitleEdit.Core.VobSub
                             onlyHalf = false;
                             index++;
                         }
+
                         x = 0;
                         y += addY;
-                        break;
-                    }
-
-                    if (y < bmp.Height && c.ToArgb() != colorZeroValue)
-                    {
-                        bmp.SetPixel(x, y, c);
                     }
                 }
             }

--- a/tests/benchmarks/PerfHuntRound16Benchmarks.cs
+++ b/tests/benchmarks/PerfHuntRound16Benchmarks.cs
@@ -1,0 +1,857 @@
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Core.VobSub;
+using SkiaSharp;
+using System.Text;
+using System.Xml;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// Round 16 performance hunt: XML format auto-detection (every candidate format joined all
+/// lines into its own string), TTML save (per-paragraph document-wide region scans plus a
+/// double serialize-and-reparse), DVB subtitle decoding (linear CLUT scan per RLE run and
+/// per-pixel writes), VobSub decoding (per-pixel RLE writes and SKColor-per-pixel crop
+/// scans), and HtmlUtil.FixInvalidItalicTags (~50 Replace scans with no early-out).
+///
+/// Each "Old" benchmark is a self-contained copy of the pre-round-16 shape; each "New"
+/// benchmark calls the shipping code. GlobalSetup asserts both produce identical results,
+/// including over randomized RLE inputs for the two image decoders.
+/// </summary>
+[MemoryDiagnoser]
+public class PerfHuntRound16Benchmarks
+{
+    private sealed class DeterministicRandom
+    {
+        private uint _state;
+        public DeterministicRandom(uint seed) => _state = seed;
+
+        public int Next(int max)
+        {
+            _state ^= _state << 13;
+            _state ^= _state >> 17;
+            _state ^= _state << 5;
+            return (int)(_state % (uint)max);
+        }
+
+        public void NextBytes(byte[] buffer)
+        {
+            for (var i = 0; i < buffer.Length; i++)
+            {
+                buffer[i] = (byte)Next(256);
+            }
+        }
+    }
+
+    // Exposes the protected JoinLines helpers for the benchmark.
+    private sealed class FormatExposer : SubtitleFormat
+    {
+        public override string Extension => ".x";
+        public override string Name => "exposer";
+        public override string ToText(Subtitle subtitle, string title) => string.Empty;
+        public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName) { }
+        public override bool IsMine(List<string> lines, string fileName) => false;
+
+        public static string JoinTrimmed(List<string> lines) => JoinLinesTrimmed(lines);
+    }
+
+    private const int XmlFormatCount = 22; // formats that joined the file before any guard
+    private List<string> _ttmlLinesA = new();
+    private List<string> _ttmlLinesB = new();
+    private bool _useListA;
+
+    private XmlDocument _ttmlDocument = new();
+    private int _ttmlParagraphCount;
+
+    private SKColor[] _dvbFourColorsUnused = Array.Empty<SKColor>();
+    private ClutDefinitionSegment _clut = null!;
+    private (int PixelCode, int RunLength, bool NewLine)[] _dvbRuns = Array.Empty<(int, int, bool)>();
+    private SKBitmap _dvbBitmapOld = null!;
+    private SKBitmap _dvbBitmapNew = null!;
+
+    private byte[] _vobSubRleData = Array.Empty<byte>();
+    private List<SKColor> _vobSubFourColors = new();
+    private SKBitmap _vobSubBitmapOld = null!;
+    private SKBitmap _vobSubBitmapNew = null!;
+    private SKBitmap _cropBitmap = null!;
+
+    private string[] _plainLines = Array.Empty<string>();
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        SetupXmlDetectCase();
+        SetupTtmlDocument();
+        SetupDvbCase();
+        SetupVobSubCase();
+        SetupItalicCase();
+    }
+
+    // -------------------------------------------------------------------------------------
+    // 1) XML auto-detection: join-all-lines once per candidate format vs. memoized join
+    // -------------------------------------------------------------------------------------
+
+    private void SetupXmlDetectCase()
+    {
+        List<string> MakeLines(string marker)
+        {
+            var lines = new List<string>
+            {
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
+                $"<tt xmlns=\"http://www.w3.org/ns/ttml\" data=\"{marker}\">",
+                "  <body><div>",
+            };
+            for (var i = 0; i < 1500; i++)
+            {
+                lines.Add($"    <p begin=\"00:00:{i % 60:00}.000\" end=\"00:00:{i % 60:00}.900\">Line {i} with some ordinary subtitle text.</p>");
+            }
+
+            lines.Add("  </div></body>");
+            lines.Add("</tt>");
+            return lines;
+        }
+
+        _ttmlLinesA = MakeLines("a");
+        _ttmlLinesB = MakeLines("b");
+
+        if (OldJoinAllFormats(_ttmlLinesA) != FormatExposer.JoinTrimmed(_ttmlLinesA) ||
+            OldJoinAllFormats(_ttmlLinesB) != FormatExposer.JoinTrimmed(_ttmlLinesB))
+        {
+            throw new InvalidOperationException("join mismatch");
+        }
+    }
+
+    private static string OldJoinAllFormats(List<string> lines)
+    {
+        // The pre-round-16 shape, once per candidate format: StringBuilder join + Trim copy.
+        string last = string.Empty;
+        for (var i = 0; i < XmlFormatCount; i++)
+        {
+            var sb = new StringBuilder();
+            lines.ForEach(line => sb.AppendLine(line));
+            last = sb.ToString().Trim();
+        }
+
+        return last;
+    }
+
+    [Benchmark]
+    public string XmlDetect_JoinPerFormat_Old()
+    {
+        // Alternate lists so every invocation models a fresh file.
+        _useListA = !_useListA;
+        return OldJoinAllFormats(_useListA ? _ttmlLinesA : _ttmlLinesB);
+    }
+
+    [Benchmark]
+    public string XmlDetect_MemoizedJoin_New()
+    {
+        _useListA = !_useListA;
+        var lines = _useListA ? _ttmlLinesA : _ttmlLinesB;
+        string last = string.Empty;
+        for (var i = 0; i < XmlFormatCount; i++)
+        {
+            last = FormatExposer.JoinTrimmed(lines);
+        }
+
+        return last;
+    }
+
+    // -------------------------------------------------------------------------------------
+    // 2) TTML save: styles/regions read via serialize + full re-parse vs. the live document,
+    //    and the per-paragraph document-wide bottom-region scan vs. one cached scan
+    // -------------------------------------------------------------------------------------
+
+    private void SetupTtmlDocument()
+    {
+        var subtitle = new Subtitle();
+        for (var i = 0; i < 400; i++)
+        {
+            subtitle.Paragraphs.Add(new Paragraph($"TTML paragraph {i}\r\nsecond line", i * 2000, i * 2000 + 1800));
+        }
+
+        var text = new TimedText10().ToText(subtitle, "benchmark");
+        _ttmlDocument = new XmlDocument { XmlResolver = null };
+        _ttmlDocument.LoadXml(text);
+        _ttmlParagraphCount = subtitle.Paragraphs.Count;
+
+        var oldStyles = TimedText10.GetStylesFromHeader(SubtitleFormat.ToUtf8XmlString(_ttmlDocument));
+        var newStyles = TimedText10.GetStylesFromHeader(_ttmlDocument);
+        var oldRegions = TimedText10.GetRegionsFromHeader(SubtitleFormat.ToUtf8XmlString(_ttmlDocument));
+        var newRegions = TimedText10.GetRegionsFromHeader(_ttmlDocument);
+        if (!oldStyles.SequenceEqual(newStyles) || !oldRegions.SequenceEqual(newRegions))
+        {
+            throw new InvalidOperationException("TTML header scan mismatch");
+        }
+    }
+
+    [Benchmark]
+    public int TtmlHeaderScan_SerializeReparse_Old()
+    {
+        // ToText used to serialize the whole document to a string twice and re-parse it
+        // twice, just to read the style / region ids.
+        var styles = TimedText10.GetStylesFromHeader(SubtitleFormat.ToUtf8XmlString(_ttmlDocument));
+        var regions = TimedText10.GetRegionsFromHeader(SubtitleFormat.ToUtf8XmlString(_ttmlDocument));
+        return styles.Count + regions.Count;
+    }
+
+    [Benchmark]
+    public int TtmlHeaderScan_LiveDocument_New()
+    {
+        var styles = TimedText10.GetStylesFromHeader(_ttmlDocument);
+        var regions = TimedText10.GetRegionsFromHeader(_ttmlDocument);
+        return styles.Count + regions.Count;
+    }
+
+    [Benchmark]
+    public int TtmlRegions_PerParagraphScan_Old()
+    {
+        // MakeParagraph called GetRegionsBottomFromHeader (an absolute //ttml:region XPath
+        // over the whole document) once per paragraph. This models the cost against the
+        // finished document; during a real save the document grows as it is written, so
+        // the old total cost averaged roughly half of this - still O(n^2).
+        var count = 0;
+        for (var i = 0; i < _ttmlParagraphCount; i++)
+        {
+            count += TimedText10.GetRegionsBottomFromHeader(_ttmlDocument).Count;
+        }
+
+        return count;
+    }
+
+    [Benchmark]
+    public int TtmlRegions_CachedScan_New()
+    {
+        List<string>? cached = null;
+        var count = 0;
+        for (var i = 0; i < _ttmlParagraphCount; i++)
+        {
+            cached ??= TimedText10.GetRegionsBottomFromHeader(_ttmlDocument);
+            count += cached.Count;
+        }
+
+        return count;
+    }
+
+    // -------------------------------------------------------------------------------------
+    // 3) DVB subtitles: per-run CLUT entry scan + per-pixel SetPixel vs. LUT + run fill
+    // -------------------------------------------------------------------------------------
+
+    private void SetupDvbCase()
+    {
+        // A full-range CLUT definition segment with 256 entries.
+        var clutBytes = new byte[2 + 256 * 6];
+        clutBytes[0] = 1; // clut id
+        var w = 2;
+        var rnd = new DeterministicRandom(4242);
+        for (var i = 0; i < 256; i++)
+        {
+            clutBytes[w] = (byte)i;                       // entry id
+            clutBytes[w + 1] = 0b00100001;                // 8-bit entry, full range
+            clutBytes[w + 2] = (byte)rnd.Next(256);       // Y
+            clutBytes[w + 3] = (byte)rnd.Next(256);       // Cr
+            clutBytes[w + 4] = (byte)rnd.Next(256);       // Cb
+            clutBytes[w + 5] = (byte)rnd.Next(256);       // T
+            w += 6;
+        }
+
+        _clut = new ClutDefinitionSegment(clutBytes, 0, clutBytes.Length);
+
+        // Synthetic run list resembling a two-line DVB subtitle: ~4000 runs over 40 rows.
+        var runs = new List<(int, int, bool)>();
+        for (var row = 0; row < 40; row++)
+        {
+            var x = 0;
+            while (x < 700)
+            {
+                var len = 1 + rnd.Next(24);
+                runs.Add((rnd.Next(256), len, false));
+                x += len;
+            }
+
+            runs.Add((0, 0, true)); // end of line
+        }
+
+        _dvbRuns = runs.ToArray();
+        _dvbBitmapOld = new SKBitmap(720, 82, SKColorType.Bgra8888, SKAlphaType.Premul);
+        _dvbBitmapNew = new SKBitmap(720, 82, SKColorType.Bgra8888, SKAlphaType.Premul);
+
+        // Equivalence: both shapes must write identical pixels.
+        DvbDraw_ScanPerRun_Old();
+        DvbDraw_LutAndRunFill_New();
+        if (!_dvbBitmapOld.Bytes.AsSpan().SequenceEqual(_dvbBitmapNew.Bytes))
+        {
+            throw new InvalidOperationException("DVB draw mismatch");
+        }
+    }
+
+    [Benchmark]
+    public int DvbDraw_ScanPerRun_Old()
+    {
+        _dvbBitmapOld.Erase(SKColors.Transparent);
+        var fast = new FastBitmap(_dvbBitmapOld);
+        fast.LockImage();
+        var x = 0;
+        var y = 0;
+        foreach (var (pixelCode, runLength, newLine) in _dvbRuns)
+        {
+            if (newLine)
+            {
+                x = 0;
+                y += 2;
+                continue;
+            }
+
+            // The pre-round-16 DrawPixels: linear CLUT scan + YCbCr conversion per run,
+            // then one SetPixel per pixel.
+            var c = SKColors.Red;
+            foreach (var item in _clut.Entries)
+            {
+                if (item.ClutEntryId == pixelCode)
+                {
+                    c = item.GetColor();
+                    break;
+                }
+            }
+
+            for (var k = 0; k < runLength; k++)
+            {
+                if (y < fast.Height && x < fast.Width)
+                {
+                    fast.SetPixel(x, y, c);
+                }
+
+                x++;
+            }
+        }
+
+        fast.UnlockImage();
+        return x + y;
+    }
+
+    [Benchmark]
+    public int DvbDraw_LutAndRunFill_New()
+    {
+        _dvbBitmapNew.Erase(SKColors.Transparent);
+        var fast = new FastBitmap(_dvbBitmapNew);
+        fast.LockImage();
+
+        // The shipping shape: ObjectDataSegment.BuildClutLookup once, then run fills.
+        var lookup = new SKColor[256];
+        for (var i = 0; i < lookup.Length; i++)
+        {
+            lookup[i] = SKColors.Red;
+        }
+
+        var seen = new bool[lookup.Length];
+        foreach (var item in _clut.Entries)
+        {
+            var id = item.ClutEntryId;
+            if (id >= 0 && id < lookup.Length && !seen[id])
+            {
+                seen[id] = true;
+                lookup[id] = item.GetColor();
+            }
+        }
+
+        var x = 0;
+        var y = 0;
+        foreach (var (pixelCode, runLength, newLine) in _dvbRuns)
+        {
+            if (newLine)
+            {
+                x = 0;
+                y += 2;
+                continue;
+            }
+
+            var c = (uint)pixelCode < (uint)lookup.Length ? lookup[pixelCode] : SKColors.Red;
+            if (y < fast.Height && x < fast.Width)
+            {
+                fast.SetPixel(x, y, c, Math.Min(runLength, fast.Width - x));
+            }
+
+            x += runLength;
+        }
+
+        fast.UnlockImage();
+        return x + y;
+    }
+
+    // -------------------------------------------------------------------------------------
+    // 4) VobSub: RLE decode with per-pixel writes vs. run fills, and the crop scans
+    // -------------------------------------------------------------------------------------
+
+    private void SetupVobSubCase()
+    {
+        // Randomized-but-deterministic RLE stream. Any byte stream is a valid input to the
+        // decoder, so a random one exercises all nibble/byte run forms; equivalence over it
+        // is a strong check that the run-fill rewrite matches the old per-pixel loop.
+        var rnd = new DeterministicRandom(987654);
+        _vobSubRleData = new byte[40_000];
+        rnd.NextBytes(_vobSubRleData);
+
+        _vobSubFourColors = new List<SKColor>
+        {
+            new SKColor(0, 0, 0, 0),
+            new SKColor(255, 255, 255, 255),
+            new SKColor(20, 20, 20, 255),
+            new SKColor(200, 30, 30, 255),
+        };
+
+        _vobSubBitmapOld = new SKBitmap(720, 576, SKColorType.Bgra8888, SKAlphaType.Premul);
+        _vobSubBitmapNew = new SKBitmap(720, 576, SKColorType.Bgra8888, SKAlphaType.Premul);
+
+        // Equivalence over 40 random offsets (interlaced pairs like the real decoder uses).
+        for (var trial = 0; trial < 40; trial++)
+        {
+            var address = trial * 997 % 30_000;
+            _vobSubBitmapOld.Erase(SKColors.Transparent);
+            _vobSubBitmapNew.Erase(SKColors.Transparent);
+
+            var fastOld = new FastBitmap(_vobSubBitmapOld);
+            fastOld.LockImage();
+            OldGenerateBitmap(_vobSubRleData, fastOld, 0, address, _vobSubFourColors, 2);
+            OldGenerateBitmap(_vobSubRleData, fastOld, 1, address + 1024, _vobSubFourColors, 2);
+            fastOld.UnlockImage();
+
+            var fastNew = new FastBitmap(_vobSubBitmapNew);
+            fastNew.LockImage();
+            SubPicture.GenerateBitmap(_vobSubRleData, fastNew, 0, address, _vobSubFourColors, 2);
+            SubPicture.GenerateBitmap(_vobSubRleData, fastNew, 1, address + 1024, _vobSubFourColors, 2);
+            fastNew.UnlockImage();
+
+            if (!_vobSubBitmapOld.Bytes.AsSpan().SequenceEqual(_vobSubBitmapNew.Bytes))
+            {
+                throw new InvalidOperationException($"VobSub RLE mismatch at trial {trial}");
+            }
+        }
+
+        // Crop-scan bitmap: transparent border around an opaque block.
+        _cropBitmap = new SKBitmap(720, 576, SKColorType.Bgra8888, SKAlphaType.Premul);
+        _cropBitmap.Erase(SKColors.Transparent);
+        using (var canvas = new SKCanvas(_cropBitmap))
+        using (var paint = new SKPaint { Color = new SKColor(255, 255, 255, 255) })
+        {
+            canvas.DrawRect(new SKRect(150, 400, 600, 520), paint);
+        }
+
+        var oldRect = CropScan_PerPixel_Old();
+        var newRect = CropScan_AlphaRows_New();
+        if (oldRect != newRect)
+        {
+            throw new InvalidOperationException($"crop mismatch: {oldRect} vs {newRect}");
+        }
+    }
+
+    private static int OldDecodeRle(int index, byte[] data, out int color, out int runLength, ref bool onlyHalf, out bool restOfLine)
+    {
+        restOfLine = false;
+        byte b1 = data[index];
+        byte b2 = data[index + 1];
+
+        if (onlyHalf)
+        {
+            byte b3 = data[index + 2];
+            b1 = (byte)(((b1 & 0b00001111) << 4) | ((b2 & 0b11110000) >> 4));
+            b2 = (byte)(((b2 & 0b00001111) << 4) | ((b3 & 0b11110000) >> 4));
+        }
+
+        if (b1 >> 2 == 0)
+        {
+            runLength = (b1 << 6) | (b2 >> 2);
+            color = b2 & 0b00000011;
+            if (runLength == 0)
+            {
+                restOfLine = true;
+                if (onlyHalf)
+                {
+                    onlyHalf = false;
+                    return 3;
+                }
+            }
+
+            return 2;
+        }
+
+        if (b1 >> 4 == 0)
+        {
+            runLength = (b1 << 2) | (b2 >> 6);
+            color = (b2 & 0b00110000) >> 4;
+            if (onlyHalf)
+            {
+                onlyHalf = false;
+                return 2;
+            }
+
+            onlyHalf = true;
+            return 1;
+        }
+
+        if (b1 >> 6 == 0)
+        {
+            runLength = b1 >> 2;
+            color = b1 & 0b00000011;
+            return 1;
+        }
+
+        runLength = b1 >> 6;
+        color = (b1 & 0b00110000) >> 4;
+
+        if (onlyHalf)
+        {
+            onlyHalf = false;
+            return 1;
+        }
+
+        onlyHalf = true;
+        return 0;
+    }
+
+    private static void OldGenerateBitmap(byte[] data, FastBitmap bmp, int startY, int dataAddress, List<SKColor> fourColors, int addY)
+    {
+        var index = 0;
+        var onlyHalf = false;
+        var y = startY;
+        var x = 0;
+        var colorZeroValue = fourColors[0].ToArgb();
+        while (y < bmp.Height && dataAddress + index + 2 < data.Length)
+        {
+            index += OldDecodeRle(dataAddress + index, data, out var color, out var runLength, ref onlyHalf, out var restOfLine);
+            if (restOfLine)
+            {
+                runLength = bmp.Width - x;
+            }
+
+            var c = fourColors[color];
+            for (var i = 0; i < runLength; i++, x++)
+            {
+                if (x >= bmp.Width - 1)
+                {
+                    if (y < bmp.Height && x < bmp.Width && c != fourColors[0])
+                    {
+                        bmp.SetPixel(x, y, c);
+                    }
+
+                    if (onlyHalf)
+                    {
+                        onlyHalf = false;
+                        index++;
+                    }
+
+                    x = 0;
+                    y += addY;
+                    break;
+                }
+
+                if (y < bmp.Height && c.ToArgb() != colorZeroValue)
+                {
+                    bmp.SetPixel(x, y, c);
+                }
+            }
+        }
+    }
+
+    [Benchmark]
+    public int VobSubRle_PerPixel_Old()
+    {
+        var fast = new FastBitmap(_vobSubBitmapOld);
+        fast.LockImage();
+        OldGenerateBitmap(_vobSubRleData, fast, 0, 0, _vobSubFourColors, 2);
+        OldGenerateBitmap(_vobSubRleData, fast, 1, 1024, _vobSubFourColors, 2);
+        fast.UnlockImage();
+        return fast.Width;
+    }
+
+    [Benchmark]
+    public int VobSubRle_RunFill_New()
+    {
+        var fast = new FastBitmap(_vobSubBitmapNew);
+        fast.LockImage();
+        SubPicture.GenerateBitmap(_vobSubRleData, fast, 0, 0, _vobSubFourColors, 2);
+        SubPicture.GenerateBitmap(_vobSubRleData, fast, 1, 1024, _vobSubFourColors, 2);
+        fast.UnlockImage();
+        return fast.Width;
+    }
+
+    [Benchmark]
+    public (int, int, int, int) CropScan_PerPixel_Old()
+    {
+        // The pre-round-16 CropBitmapAndUnlock scans: SKColor per pixel via GetPixel.
+        var bmp = new FastBitmap(_cropBitmap);
+        bmp.LockImage();
+        static bool IsBackgroundColor(SKColor c) => c.Alpha < 2;
+
+        var y = 0;
+        var c = new SKColor(0, 0, 0, 0);
+        int x;
+        while (y < bmp.Height && IsBackgroundColor(c))
+        {
+            c = bmp.GetPixel(0, y);
+            if (IsBackgroundColor(c))
+            {
+                for (x = 1; x < bmp.Width; x++)
+                {
+                    c = bmp.GetPixelNext();
+                    if (c.Alpha > 1)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            if (IsBackgroundColor(c))
+            {
+                y++;
+            }
+        }
+
+        var minY = y > 3 ? y - 3 : 0;
+
+        x = 0;
+        c = new SKColor(0, 0, 0, 0);
+        while (x < bmp.Width && IsBackgroundColor(c))
+        {
+            for (y = minY; y < bmp.Height; y++)
+            {
+                c = bmp.GetPixel(x, y);
+                if (!IsBackgroundColor(c))
+                {
+                    break;
+                }
+            }
+
+            if (IsBackgroundColor(c))
+            {
+                x++;
+            }
+        }
+
+        var minX = x > 3 ? x - 3 : 0;
+
+        y = bmp.Height - 1;
+        c = new SKColor(0, 0, 0, 0);
+        while (y > minY && IsBackgroundColor(c))
+        {
+            c = bmp.GetPixel(0, y);
+            if (IsBackgroundColor(c))
+            {
+                for (x = 1; x < bmp.Width; x++)
+                {
+                    c = bmp.GetPixelNext();
+                    if (!IsBackgroundColor(c))
+                    {
+                        break;
+                    }
+                }
+            }
+
+            if (IsBackgroundColor(c))
+            {
+                y--;
+            }
+        }
+
+        var maxY = Math.Min(y + 7, bmp.Height - 1);
+
+        x = bmp.Width - 1;
+        c = new SKColor(0, 0, 0, 0);
+        while (x > minX && IsBackgroundColor(c))
+        {
+            for (y = minY; y < bmp.Height; y++)
+            {
+                c = bmp.GetPixel(x, y);
+                if (!IsBackgroundColor(c))
+                {
+                    break;
+                }
+            }
+
+            if (IsBackgroundColor(c))
+            {
+                x--;
+            }
+        }
+
+        var maxX = Math.Min(x + 7, bmp.Width - 1);
+        bmp.UnlockImage();
+        return (minX, minY, maxX, maxY);
+    }
+
+    [Benchmark]
+    public (int, int, int, int) CropScan_AlphaRows_New()
+    {
+        // The shipping shape: FastBitmap alpha-byte row/column scans.
+        var bmp = new FastBitmap(_cropBitmap);
+        bmp.LockImage();
+        const byte alphaLimit = 2;
+
+        var y = 0;
+        while (y < bmp.Height && bmp.IsRowTransparent(y, alphaLimit))
+        {
+            y++;
+        }
+
+        var minY = y > 3 ? y - 3 : 0;
+
+        var x = 0;
+        while (x < bmp.Width && bmp.IsColumnTransparent(x, minY, alphaLimit))
+        {
+            x++;
+        }
+
+        var minX = x > 3 ? x - 3 : 0;
+
+        y = bmp.Height - 1;
+        while (y > minY && bmp.IsRowTransparent(y, alphaLimit))
+        {
+            y--;
+        }
+
+        var maxY = Math.Min(y + 7, bmp.Height - 1);
+
+        x = bmp.Width - 1;
+        while (x > minX && bmp.IsColumnTransparent(x, minY, alphaLimit))
+        {
+            x--;
+        }
+
+        var maxX = Math.Min(x + 7, bmp.Width - 1);
+        bmp.UnlockImage();
+        return (minX, minY, maxX, maxY);
+    }
+
+    // -------------------------------------------------------------------------------------
+    // 5) HtmlUtil.FixInvalidItalicTags on tag-free lines (the overwhelmingly common case)
+    // -------------------------------------------------------------------------------------
+
+    private void SetupItalicCase()
+    {
+        _plainLines = new string[500];
+        for (var i = 0; i < _plainLines.Length; i++)
+        {
+            _plainLines[i] = i % 3 == 0
+                ? $"Ordinary line number {i} - no markup at all."
+                : $"- Are you sure about {i}?\r\n- Absolutely, one hundred percent.";
+        }
+
+        foreach (var line in _plainLines)
+        {
+            if (OldFixInvalidItalicTagsNoTagPath(line) != HtmlUtil.FixInvalidItalicTags(line))
+            {
+                throw new InvalidOperationException("italic-fix mismatch");
+            }
+        }
+
+        // The tagged path must be untouched by the early-out.
+        const string tagged = "< i>Hello there</ i >\r\n<i>second<i/>";
+        if (HtmlUtil.FixInvalidItalicTags(tagged) != OldEquivalentForTagged(tagged))
+        {
+            throw new InvalidOperationException("tagged italic-fix path changed");
+        }
+    }
+
+    private static string OldEquivalentForTagged(string input) =>
+        // With a '<' present the shipping method is byte-for-byte the old code, so it is
+        // its own oracle here; this call just documents the invariant.
+        HtmlUtil.FixInvalidItalicTags(input);
+
+    private static readonly string[] BeginTagVariations = { "< i >", "< i>", "<i >", "< I >", "< I>", "<I >", "<i<", "<I<", "<I>" };
+
+    private static readonly string[] EndTagVariations =
+    {
+        "< / i >", "< /i>", "</ i>", "< /i >", "</i >", "</ i >",
+        "< / i>", "</I>", "< / I >", "< /I>", "</ I>", "< /I >", "</I >", "</ I >", "< / I>", "</i<", "</I<", "</I>",
+    };
+
+    private static string OldFixInvalidItalicTagsNoTagPath(string input)
+    {
+        // The pre-round-16 method up to its "no italic tags" return - the full path a
+        // tag-free line paid on every call.
+        var text = input;
+
+        var preTags = string.Empty;
+        if (text.StartsWith("{\\", StringComparison.Ordinal))
+        {
+            var endIdx = text.IndexOf('}', 2);
+            if (endIdx > 2)
+            {
+                preTags = text.Substring(0, endIdx + 1);
+                text = text.Remove(0, endIdx + 1);
+            }
+        }
+
+        const string beginTag = "<i>";
+        const string endTag = "</i>";
+        foreach (var beginTagVariation in BeginTagVariations)
+        {
+            text = text.Replace(beginTagVariation, beginTag);
+        }
+
+        foreach (var endTagVariation in EndTagVariations)
+        {
+            text = text.Replace(endTagVariation, endTag);
+        }
+
+        text = text.Replace("</i> <i>", "_@_");
+        text = text.Replace(" _@_", "_@_");
+        text = text.Replace(" _@_ ", "_@_");
+        text = text.Replace("_@_", " ");
+        text = text.Replace(" </i>" + Environment.NewLine, "</i>" + Environment.NewLine);
+
+        if (text.Contains(beginTag))
+        {
+            text = text.Replace("<i/>", endTag);
+            text = text.Replace("<I/>", endTag);
+        }
+        else
+        {
+            text = text.Replace("<i/>", string.Empty);
+            text = text.Replace("<I/>", string.Empty);
+        }
+
+        text = text.Replace("]<i> ", "] <i>");
+        text = text.Replace(")<i> ", ") <i>");
+        text = text.Replace("] </i>", "] </i>");
+        text = text.Replace(") </i>", ") </i>");
+
+        text = text.Replace(beginTag + beginTag, beginTag);
+        text = text.Replace(endTag + endTag, endTag);
+
+        var italicBeginTagCount = Utilities.CountTagInText(text, beginTag);
+        var italicEndTagCount = Utilities.CountTagInText(text, endTag);
+        _ = Utilities.GetNumberOfLines(text);
+        if (italicBeginTagCount + italicEndTagCount == 0)
+        {
+            return preTags + text;
+        }
+
+        throw new InvalidOperationException("benchmark input unexpectedly contained italic tags");
+    }
+
+    [Benchmark]
+    public int ItalicFix_AlwaysReplace_Old()
+    {
+        var total = 0;
+        foreach (var line in _plainLines)
+        {
+            total += OldFixInvalidItalicTagsNoTagPath(line).Length;
+        }
+
+        return total;
+    }
+
+    [Benchmark]
+    public int ItalicFix_EarlyOut_New()
+    {
+        var total = 0;
+        foreach (var line in _plainLines)
+        {
+            total += HtmlUtil.FixInvalidItalicTags(line).Length;
+        }
+
+        return total;
+    }
+}


### PR DESCRIPTION
Round 16 of the performance hunts. Five hot paths, each proven with a self-contained BenchmarkDotNet pair: the pre-change shape is copied into the benchmark file and equivalence with the shipping code is asserted in `GlobalSetup` — for the two RLE decoders over randomized byte streams (40 trials with full pixel-byte comparison for VobSub).

## The fixes

1. **XML format auto-detection** — ~90 formats joined every line of the file into their own `StringBuilder` + `Trim()` copy before any marker test (22 with no guard at all), and 60 formats claim `.xml`, so opening one XML file allocated ~3x the file size in garbage per candidate format. `SubtitleFormat` now memoizes the join per thread (keyed on list reference + count); a detection pass pays for one join total.

2. **TimedText10 save was quadratic** — `MakeParagraph` ran a document-wide `//ttml:region` XPath *per paragraph* against the growing output document; the top/bottom region lists are now cached across one save (invalidated if a default region is added mid-save). `ToText` also serialized the whole document to a string and re-parsed it twice just to read style/region ids — new `XmlDocument` overloads of `GetStylesFromHeader`/`GetRegionsFromHeader` read the live document.

3. **DVB subtitle decode** — `ObjectDataSegment.DrawPixels` linear-scanned the CLUT entries and redid the YCbCr conversion for *every RLE run*, then wrote pixels one `SetPixel` at a time. A 256-entry color lookup is built once per object (first-id-wins, matching the old scan) and runs are filled with a vectorized `Span<uint>.Fill`.

4. **VobSub decode** — `SubPicture.GenerateBitmap` wrote each RLE run pixel by pixel; now one run fill with the same wrap/discard semantics at the right edge. The crop scans built an `SKColor` per pixel via `GetPixel`; new `FastBitmap.IsRowTransparent`/`IsColumnTransparent` helpers read only the alpha bytes.

5. **`HtmlUtil.FixInvalidItalicTags`** — ran ~50 full-string `Replace` passes even on lines with no `<` (most lines; 26+ call sites, per-line in OCR and Fix Common Errors). An early-out returns tag-free lines untouched.

## Benchmarks

Apple M4, `--inProcess`. Short job for the large-margin pairs, default job re-run for the two closest pairs (VobSub RLE, crop scan) — those numbers shown from the default job.

| Benchmark | Old | New | Speedup | Alloc old → new |
|---|---:|---:|---:|---|
| XML detect, 22 joins (1500-line file) | 2,575 µs | 106 µs | **24x** | 18.9 MB → 0.85 MB |
| TTML header scan (serialize+reparse ×2) | 519 µs | 36 µs | **14x** | 1.19 MB → 5.4 KB |
| TTML regions, 400-paragraph save | 7,960 µs | 21 µs | **372x** | 2.15 MB → 5.4 KB |
| DVB draw, ~4000 runs | 169 µs | 8.8 µs | **19x** | — |
| VobSub RLE decode (default job) | 711 µs | 360 µs | **2.0x** | — |
| VobSub crop scan (default job) | 214 µs | 104 µs | **2.1x** | — |
| FixInvalidItalicTags, 500 plain lines | 155 µs | 1.7 µs | **92x** | 36 KB → 0 |

## Verification

- All 1490 libse + 416 seconv + 703 libuilogic tests pass; full solution builds.
- Equivalence asserts in `PerfHuntRound16Benchmarks.GlobalSetup` (mismatch = the benchmark refuses to run): joined strings identical, TTML style/region lists identical, DVB pixel bytes identical, VobSub pixel bytes identical over 40 randomized RLE streams, crop rectangles identical, italic-fix output identical over the line battery.
- The bulk join-pattern replacement (89 files) was audited for scratch-`StringBuilder` collisions; five files that reuse `sb` as a per-paragraph text builder keep their local builder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)