### PR TITLE
Split long lines: keep a sentence-ending line break as an event boundary

### DIFF
--- a/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModel.cs
+++ b/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModel.cs
@@ -123,7 +123,7 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
 
                     // Like SE4: a subtitle is not cut into several events when re-wrapping its
                     // lines is enough to make it fit - the rebalance pass below does that.
-                    if (RebalanceLongLines && CanBeFixedByRebalancing(item.Text, mergeLinesShorterThan))
+                    if (RebalanceLongLines && CanBeFixedByRebalancing(item.Text, SingleLineMaxLength, MaxNumberOfLines, mergeLinesShorterThan, _languageCode))
                     {
                         AllSubtitlesFixed.Add(item);
                         continue;
@@ -241,15 +241,49 @@ public partial class SplitBreakLongLinesViewModel : ObservableObject, IClosingCl
         }
     }
 
-    private bool CanBeFixedByRebalancing(string? text, int mergeLinesShorterThan)
+    /// <summary>
+    /// True when re-wrapping a subtitle's own lines makes it fit, so it does not have to be cut
+    /// into several events.
+    /// </summary>
+    public static bool CanBeFixedByRebalancing(string? text, int singleLineMaxLength, int maxNumberOfLines, int mergeLinesShorterThan, string languageCode)
     {
-        if (!HasLineTooLong(text, SingleLineMaxLength, MaxNumberOfLines))
+        if (!HasLineTooLong(text, singleLineMaxLength, maxNumberOfLines))
         {
             return true;
         }
 
-        var rebalanced = Utilities.AutoBreakLine(text ?? string.Empty, SingleLineMaxLength, mergeLinesShorterThan, _languageCode);
-        return !HasLineTooLong(rebalanced, SingleLineMaxLength, MaxNumberOfLines);
+        // SE4 left an existing line break alone when it ended a sentence and cut the subtitle
+        // there instead of re-wrapping across it (#11476). The two halves are usually two
+        // speakers, so pulling them onto one line - "Und, war ich in der Kantine? Nein." -
+        // is wrong no matter how well the result fits.
+        if (HasSentenceEndingLineBreak(text))
+        {
+            return false;
+        }
+
+        var rebalanced = Utilities.AutoBreakLine(text ?? string.Empty, singleLineMaxLength, mergeLinesShorterThan, languageCode);
+        return !HasLineTooLong(rebalanced, singleLineMaxLength, maxNumberOfLines);
+    }
+
+    private const string SentenceEndings = ".!?؟";
+
+    /// <summary>
+    /// True when a line break follows sentence-ending punctuation, i.e. the break is where the
+    /// author ended a sentence rather than where the text happened to wrap.
+    /// </summary>
+    public static bool HasSentenceEndingLineBreak(string? text)
+    {
+        var lines = HtmlUtil.RemoveHtmlTags(text ?? string.Empty, true).SplitToLines();
+        for (var index = 0; index < lines.Count - 1; index++)
+        {
+            var line = lines[index].TrimEnd();
+            if (line.Length > 0 && SentenceEndings.Contains(line[^1]))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static int GetPlainLineCount(string? text)

--- a/tests/UI/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesTests.cs
+++ b/tests/UI/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesTests.cs
@@ -135,6 +135,100 @@ public class SplitBreakLongLinesTests
         Assert.Same(item, result[0]);
     }
 
+    // --- SE4 parity (#11476): "Split long lines" must not be skipped just because re-wrapping
+    // --- happens to make the text fit - that pulls two sentences onto one line.
+    // --- These use Environment.NewLine because that is what a Paragraph holds, and
+    // --- AutoBreakLine only unwraps that separator.
+
+    private const string QuestionAndAnswer = "Und, war ich in der Kantine?\nNein. Ich konnte Sie dort nicht finden.";
+
+    [Fact]
+    public void CanBeFixedByRebalancing_SentenceEndingLineBreak_DemandsASplit()
+    {
+        // The reported case. Rebalancing yields "Und, war ich in der Kantine? Nein." (34) and
+        // "Ich konnte Sie dort nicht finden." (33) - within 36 chars over 2 lines, so the old
+        // gate skipped the split - but it answers the question on the question's own line.
+        var text = QuestionAndAnswer.Replace("\n", Environment.NewLine);
+
+        var result = SplitBreakLongLinesViewModel.CanBeFixedByRebalancing(text, singleLineMaxLength: 36, maxNumberOfLines: 2, mergeLinesShorterThan: 37, languageCode: "de");
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void SplitThenRebalance_SentenceEndingLineBreak_ProducesTheSe4Result()
+    {
+        // End to end, in the order UpdatePreview runs the two steps: SE4 turned this into two
+        // events, the second one wrapped over two lines.
+        var item = MakeSubtitle(QuestionAndAnswer.Replace("\n", Environment.NewLine), 10, 14);
+
+        var events = SplitBreakLongLinesViewModel.Split(item, maxCharactersPerSubtitle: 72, singleLineMaxLength: 36);
+        var texts = events.Select(e => Utilities.AutoBreakLine(e.Text, 36, 37, "de")).ToList();
+
+        Assert.Equal(2, events.Count);
+        Assert.Equal("Und, war ich in der Kantine?", texts[0]);
+        Assert.Equal(new[] { "Nein. Ich konnte", "Sie dort nicht finden." }, texts[1].SplitToLines());
+        Assert.Equal(item.StartTime, events[0].StartTime);
+        Assert.Equal(item.EndTime, events[^1].EndTime);
+        Assert.All(events, e => Assert.True(e.Duration.TotalMilliseconds > 0));
+    }
+
+    [Fact]
+    public void CanBeFixedByRebalancing_WrappedSentence_StillRebalancesInsteadOfSplitting()
+    {
+        // No sentence ends at the line break, so this is an ordinary bad wrap: re-wrapping is
+        // the right fix and the subtitle must stay a single event.
+        var text = "I told him that we would be arriving\na little bit later than we planned.".Replace("\n", Environment.NewLine);
+
+        var result = SplitBreakLongLinesViewModel.CanBeFixedByRebalancing(text, singleLineMaxLength: 36, maxNumberOfLines: 2, mergeLinesShorterThan: 37, languageCode: "en");
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void CanBeFixedByRebalancing_SingleLongLine_RebalancesInsteadOfSplitting()
+    {
+        var result = SplitBreakLongLinesViewModel.CanBeFixedByRebalancing("This single line is a good deal too long to fit.", singleLineMaxLength: 36, maxNumberOfLines: 2, mergeLinesShorterThan: 37, languageCode: "en");
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void CanBeFixedByRebalancing_CompliantSubtitle_IsLeftAlone()
+    {
+        // Every line already fits, so a sentence-ending line break is no reason to split.
+        var text = "Yes.\nI think so.".Replace("\n", Environment.NewLine);
+
+        var result = SplitBreakLongLinesViewModel.CanBeFixedByRebalancing(text, singleLineMaxLength: 36, maxNumberOfLines: 2, mergeLinesShorterThan: 37, languageCode: "en");
+
+        Assert.True(result);
+    }
+
+    [Theory]
+    [InlineData("Und, war ich in der Kantine?\nNein.", true)]
+    [InlineData("Stop!\nI mean it.", true)]
+    [InlineData("That is all.\nOr is it?", true)]
+    [InlineData("<i>Italic ends the sentence.</i>\nNext one.", true)] // a tag must not hide the '.'
+    [InlineData("Trailing spaces are trimmed.  \nNext one.", true)]
+    [InlineData("First.\nSecond.\nThird", true)] // break after any but the last line counts
+    [InlineData("A sentence that simply\nwrapped here.", false)]
+    [InlineData("A comma is not a sentence end,\nso this wrapped.", false)]
+    [InlineData("One line only.", false)]
+    [InlineData("", false)]
+    public void HasSentenceEndingLineBreak_DetectsAuthorSentenceBoundaries(string text, bool expected)
+    {
+        Assert.Equal(expected, SplitBreakLongLinesViewModel.HasSentenceEndingLineBreak(text.Replace("\n", Environment.NewLine)));
+    }
+
+    [Fact]
+    public void HasSentenceEndingLineBreak_IgnoresPunctuationOnTheLastLine()
+    {
+        // Nothing follows the last line, so its full stop is not a break worth preserving.
+        var text = "A sentence that\nwrapped here.".Replace("\n", Environment.NewLine);
+
+        Assert.False(SplitBreakLongLinesViewModel.HasSentenceEndingLineBreak(text));
+    }
+
     [Fact]
     public void Split_ReservesMinimumGapBetweenEventsAndKeepsOuterTimeCodes()
     {


### PR DESCRIPTION
Fixes #11476

## The problem

Tools → Split/re-balance long lines skipped the split step whenever re-wrapping the text *happened* to make it fit, even when the existing line break ended a sentence. Reported by @Triathlon-rally with a real EBU STL workflow at max 36 chars / 2 lines:

| | |
|---|---|
| **Input** | `Und, war ich in der Kantine?` <br> `Nein. Ich konnte Sie dort nicht finden.` |
| **SE4 / expected** | event 1: `Und, war ich in der Kantine?` <br> event 2: `Nein. Ich konnte` / `Sie dort nicht finden.` |
| **SE5 before this PR** | one event: `Und, war ich in der Kantine? Nein.` / `Ich konnte Sie dort nicht finden.` |

The answer ends up on the question's own line. Rebalancing produced 34 and 33 characters — inside the 36/2-line limits — so [the gate](https://github.com/SubtitleEdit/subtitleedit/blob/main/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesViewModel.cs#L126) decided no split was needed and `Split()` was never called. Both **Split long lines** and **Rebalance long lines** default to on, so this hits by default.

## The fix

SE4 suppressed the auto-break in exactly this case — `SplitLongLinesHelper.cs` line 60 checks whether the first of two lines ends with `.`, `!`, `?` or `؟` and, if so, keeps the author's break and splits there. This restores that rule: rebalancing no longer counts as a fix when a line break follows sentence-ending punctuation, so the subtitle falls through to the split step.

`Split()` already produced SE4's result for this input; it just was not reached. The subsequent rebalance pass then wraps the 39-character second event, giving the SE4 output exactly.

Deliberately unchanged:

- A subtitle whose lines all fit is still left alone, sentence-ending break or not — the compliance check runs first.
- An ordinary bad wrap (no sentence ends at the break) still rebalances into one event rather than splitting.
- Split-only still never inserts line breaks (#10959 / #14006).
- Batch convert is unaffected — it has no such gate and always splits before rebalancing.

## Testing

Seven tests added to `SplitBreakLongLinesTests`, including the reporter's exact German example end to end. Reverting the one-line guard fails `CanBeFixedByRebalancing_SentenceEndingLineBreak_DemandsASplit`, so the test bites.

The new tests build their input with `Environment.NewLine` rather than a hardcoded `\r\n`: `AutoBreakLine` unwraps only that separator, so a literal `\r\n` takes a different path on Linux/macOS and would not exercise what the app does.

Full suite green: 4100 UI, 1490 libse, 703 libuilogic, 416 seconv.

Note the issue thread also contains an unrelated request from @xuehao for word wrap in the text box — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)