### PR TITLE
Fix 45 bugs from a second five-area hunt

### DIFF
--- a/src/libse/CDG/CdgGraphics.cs
+++ b/src/libse/CDG/CdgGraphics.cs
@@ -79,7 +79,10 @@ namespace Nikse.SubtitleEdit.Core.CDG
             }
 
             var graphicData = GetGraphicData();
-            var bitmap = new SKBitmap(FullWidth, FullHeight, SKColorType.Rgba8888, SKAlphaType.Premul);
+            // Bgra8888, not Rgba8888: the loop below packs (a<<24)|(r<<16)|(g<<8)|b, which on
+            // a little-endian machine lands in memory as B,G,R,A. Declaring Rgba8888 made
+            // Skia read that back as R,G,B,A - i.e. red and blue swapped in every frame.
+            var bitmap = new SKBitmap(FullWidth, FullHeight, SKColorType.Bgra8888, SKAlphaType.Premul);
 
             // Copy pixel data into the bitmap
             var pixelData = bitmap.GetPixels();

--- a/src/libse/ContainerFormats/MaterialExchangeFormat/MxfParser.cs
+++ b/src/libse/ContainerFormats/MaterialExchangeFormat/MxfParser.cs
@@ -52,6 +52,13 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.MaterialExchangeFormat
                         var buffer = new byte[klv.DataSize];
                         var bytesRead = stream.Read(buffer, 0, buffer.Length);
 
+                        // A zero- or short-length value is legal MXF (an empty fill/local set),
+                        // so the magic test needs four bytes to actually be there.
+                        if (bytesRead < 4)
+                        {
+                            continue;
+                        }
+
                         if (buffer[0] == 0x89 && buffer[1] == 0x50 && buffer[2] == 0x4E && buffer[3] == 0x47) // PNG header
                         {
                             _images.Add(buffer);

--- a/src/libse/ContainerFormats/Matroska/MatroskaFile.cs
+++ b/src/libse/ContainerFormats/Matroska/MatroskaFile.cs
@@ -405,7 +405,11 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Matroska
                                     System.Diagnostics.Debug.WriteLine("ContentCompSettings: " + contentCompSettings);
                                     break;
                                 default:
-                                    _stream.Seek(element.DataSize, SeekOrigin.Current);
+                                    // compElement, not element: seeking by the parent
+                                    // ContentCompression's size on an unknown child (CRC-32,
+                                    // Void) jumped past the whole payload and the loop then
+                                    // read garbage as EBML ids.
+                                    _stream.Seek(compElement.DataSize, SeekOrigin.Current);
                                     break;
                             }
                         }
@@ -778,11 +782,10 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Matroska
                         System.Diagnostics.Debug.Print("Xiph lacing ({0} frames)", frames);
                         break;
                     case 4: // 00000100 = Fixed-size lacing
+                        // Only the "frames - 1" count byte: fixed-size lacing has no per-lace
+                        // size table (that is Xiph/EBML lacing), so reading one byte per frame
+                        // here ate the first bytes of the actual subtitle payload.
                         frames = _stream.ReadByte() + 1;
-                        for (var i = 0; i < frames; i++)
-                        {
-                            _stream.ReadByte(); // frames
-                        }
                         System.Diagnostics.Debug.Print("Fixed-size lacing ({0} frames)", frames);
                         break;
                     case 6: // 00000110 = EMBL lacing

--- a/src/libse/ContainerFormats/TransportStream/ClutDefinitionSegment.cs
+++ b/src/libse/ContainerFormats/TransportStream/ClutDefinitionSegment.cs
@@ -15,7 +15,10 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
             ClutVersionNumber = buffer[index + 1] >> 4;
 
             int k = index + 2;
-            while (k + 6 <= index + segmentLength)
+            // A reduced-range entry is 4 bytes (id + flags + one packed word); only a
+            // full-range entry needs 6. Demanding 6 for every entry dropped the last
+            // reduced-range entry, and BuildClutLookup then paints its colour id red.
+            while (k + 4 <= index + segmentLength)
             {
                 var rcse = new RegionClutSegmentEntry();
                 rcse.ClutEntryId = buffer[k];
@@ -28,6 +31,11 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
 
                 if (rcse.FullRangeFlag)
                 {
+                    if (k + 6 > index + segmentLength)
+                    {
+                        break; // truncated full-range entry
+                    }
+
                     rcse.ClutEntryY = buffer[k + 2];
                     rcse.ClutEntryCr = buffer[k + 3];
                     rcse.ClutEntryCb = buffer[k + 4];

--- a/src/libse/ContainerFormats/TransportStream/ObjectDataSegment.cs
+++ b/src/libse/ContainerFormats/TransportStream/ObjectDataSegment.cs
@@ -106,18 +106,25 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
 
                 x = 0;
                 y = 1;
+                // EN 300 743 7.2.5: a zero bottom_field_data_block_length means the bottom
+                // field repeats the top field's pixel data, so decode the top block again -
+                // and bound the loop by the block actually being read, not by the (zero)
+                // bottom length, which would end the loop before a single run was drawn.
+                int bottomLength;
                 if (BottomFieldDataBlockLength == 0)
                 {
                     index = start;
+                    bottomLength = TopFieldDataBlockLength;
                 }
                 else
                 {
                     length = BottomFieldDataBlockLength;
                     index = start + TopFieldDataBlockLength;
                     start = index;
+                    bottomLength = BottomFieldDataBlockLength - 1;
                 }
                 dataType = buffer[index - 1];
-                while (index < start + BottomFieldDataBlockLength - 1 && index < buffer.Length)
+                while (index < start + bottomLength && index < buffer.Length)
                 {
                     index = ProcessDataType(buffer, index, clutLookup, ref dataType, start, twoToFourBitColorLookup, fourToEightBitColorLookup, twoToEightBitColorLookup, ref x, ref y, length, ref pixelCode, ref runLength);
                 }
@@ -191,18 +198,25 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
 
                 x = 0;
                 y = 1;
+                // EN 300 743 7.2.5: a zero bottom_field_data_block_length means the bottom
+                // field repeats the top field's pixel data, so decode the top block again -
+                // and bound the loop by the block actually being read, not by the (zero)
+                // bottom length, which would end the loop before a single run was drawn.
+                int bottomLength;
                 if (BottomFieldDataBlockLength == 0)
                 {
                     index = start;
+                    bottomLength = TopFieldDataBlockLength;
                 }
                 else
                 {
                     length = BottomFieldDataBlockLength;
                     index = start + TopFieldDataBlockLength;
                     start = index;
+                    bottomLength = BottomFieldDataBlockLength - 1;
                 }
                 dataType = buffer[index - 1];
-                while (index < start + BottomFieldDataBlockLength - 1 && index < buffer.Length)
+                while (index < start + bottomLength && index < buffer.Length)
                 {
                     index = ProcessDataTypeForPosition(buffer, index, clutLookup, ref dataType, start, twoToFourBitColorLookup, fourToEightBitColorLookup, twoToEightBitColorLookup, ref x, ref y, length, ref pixelCode, ref runLength, width, height, out Position subPos);
                     if (subPos.Left < pos.Left)

--- a/src/libse/ContainerFormats/TransportStream/RegionClutSegmentEntry.cs
+++ b/src/libse/ContainerFormats/TransportStream/RegionClutSegmentEntry.cs
@@ -50,7 +50,10 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
             int g = (int)(y - (0.34413 * (cb - 128)) - (0.71414 * (cr - 128)));
             int b = (int)(y + (1.772 * (cb - 128)));
 
-            int t = byte.MaxValue - BoundByteRange(ClutEntryT);
+            // A reduced-range entry stores transparency in 2 bits, like Y/Cr/Cb above it are
+            // stored in 6/4/4 - scale it to 8 bits (0, 64, 128, 192) instead of using the raw
+            // 0-3, which made every such entry come out opaque.
+            int t = byte.MaxValue - BoundByteRange(FullRangeFlag ? ClutEntryT : ClutEntryT << 6);
             r = BoundByteRange(r);
             g = BoundByteRange(g);
             b = BoundByteRange(b);

--- a/src/libse/SubtitleFormats/AvidStl.cs
+++ b/src/libse/SubtitleFormats/AvidStl.cs
@@ -54,7 +54,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             fs.WriteByte(2);
             fs.WriteByte(0);
             var buffer = Encoding.GetEncoding(1252).GetBytes(p.Text.Replace(Environment.NewLine, "Š"));
-            if (buffer.Length <= 128)
+            if (buffer.Length <= TextLength)
             {
                 fs.Write(buffer, 0, buffer.Length);
                 for (int i = buffer.Length; i < TextLength; i++)

--- a/src/libse/SubtitleFormats/Chk.cs
+++ b/src/libse/SubtitleFormats/Chk.cs
@@ -249,7 +249,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     }
 
                     sb.Append("<font color=\"Red\">");
-                    post = "<font>";
+                    post = "</font>";
                     i += 2;
                 }
                 else if (text[i] == 01 && i < text.Length - 4 && text[i + 1] == 06)
@@ -260,7 +260,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     }
 
                     sb.Append("<font color=\"Cyan\">");
-                    post = "<font>";
+                    post = "</font>";
                     i++;
                 }
                 else if (text[i] == 2)
@@ -271,7 +271,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     }
 
                     sb.Append("<font color=\"Green\">");
-                    post = "<font>";
+                    post = "</font>";
                 }
                 else if (text[i] == 3)
                 {
@@ -281,7 +281,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     }
 
                     sb.Append("<font color=\"Yellow\">");
-                    post = "<font>";
+                    post = "</font>";
                 }
                 else if (text[i] == 6)
                 {
@@ -291,7 +291,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     }
 
                     sb.Append("<font color=\"Cyan\">");
-                    post = "<font>";
+                    post = "</font>";
                 }
                 else if (text[i] == 7)
                 {
@@ -301,7 +301,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     }
 
                     sb.Append("<font color=\"Red\">");
-                    post = "<font>";
+                    post = "</font>";
                 }
                 else
                 {

--- a/src/libse/SubtitleFormats/PListCaption.cs
+++ b/src/libse/SubtitleFormats/PListCaption.cs
@@ -72,7 +72,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 paragraph.AppendChild(keyNode);
 
                 XmlNode valueNode = xml.CreateElement("real");
-                valueNode.InnerText = $"{p.StartTime.TotalSeconds:0.0###############}"; // 3.1600000000000001
+                valueNode.InnerText = p.StartTime.TotalSeconds.ToString("0.0###############", CultureInfo.InvariantCulture); // 3.1600000000000001
                 paragraph.AppendChild(valueNode);
 
                 keyNode = xml.CreateElement("key");
@@ -80,7 +80,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 paragraph.AppendChild(keyNode);
 
                 valueNode = xml.CreateElement("real");
-                valueNode.InnerText = $"{p.EndTime.TotalSeconds:0.0###############}"; // 3.1600000000000001
+                valueNode.InnerText = p.EndTime.TotalSeconds.ToString("0.0###############", CultureInfo.InvariantCulture); // 3.1600000000000001
                 paragraph.AppendChild(valueNode);
 
                 int textNo = 0;
@@ -106,7 +106,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
 
             return ToUtf8XmlString(xml).Replace("<plist>", "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">" + Environment.NewLine +
-                             "<plist version=\"1.0\">;");
+                             "<plist version=\"1.0\">");
         }
 
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)

--- a/src/libse/SubtitleFormats/RealTime.cs
+++ b/src/libse/SubtitleFormats/RealTime.cs
@@ -208,7 +208,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 }
 
                 total += value * factor;
-                factor *= i >= parts.Length - 3 ? 60 : 24; // s -> min -> hours -> days
+                factor *= i >= parts.Length - 2 ? 60 : 24; // s -> min -> hours -> days
             }
 
             milliseconds = total;

--- a/src/libse/SubtitleFormats/SwiftText.cs
+++ b/src/libse/SubtitleFormats/SwiftText.cs
@@ -57,7 +57,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
                 string startTime = $"{p.StartTime.Hours:00}:{p.StartTime.Minutes:00}:{p.StartTime.Seconds:00}:{startFrame:00}";
                 string timeOut = $"{p.EndTime.Hours:00}:{p.EndTime.Minutes:00}:{p.EndTime.Seconds:00}:{endFrame:00}";
-                string timeDuration = $"{durationCalc.Duration.Seconds:00}:{MillisecondsToFramesMaxFrameRate(durationCalc.Duration.Milliseconds):00}";
+                // Total seconds, not the 0-59 component: the reader prefers DURATION over
+                // TIMEOUT, so writing only the seconds part loses every whole minute.
+                string timeDuration = $"{(int)durationCalc.Duration.TotalSeconds:00}:{MillisecondsToFramesMaxFrameRate(durationCalc.Duration.Milliseconds):00}";
                 sb.AppendLine(string.Format(paragraphWriteFormat, startTime, timeDuration, timeOut, p.Text));
             }
             return sb.ToString().Trim();

--- a/src/libse/SubtitleFormats/UnknownSubtitle19.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle19.cs
@@ -15,7 +15,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         private static string ToTimeCode(TimeCode time)
         {
-            return $"{time.TotalSeconds:0.0}";
+            return time.TotalSeconds.ToString("0.0", CultureInfo.InvariantCulture);
         }
 
         private static TimeCode DecodeTimeCode(string s)

--- a/src/libuilogic/Export/ExportHandlerBdnXml.cs
+++ b/src/libuilogic/Export/ExportHandlerBdnXml.cs
@@ -1,4 +1,4 @@
-using Nikse.SubtitleEdit.Core.Common;
+﻿using Nikse.SubtitleEdit.Core.Common;
 using System.Globalization;
 using System.Text;
 using System.Xml;
@@ -74,7 +74,10 @@ public class ExportHandlerBdnXml : IExportHandler
 
         var x = (_width - param.Bitmap.Width) / 2;
         var y = _height - (param.Bitmap.Height + param.BottomTopMargin);
-        var border = 0;
+        // The left/right and top margins the user picked, not 0 - the bitmap is the trimmed
+        // glyph box, so nothing else keeps a left/right/top aligned line off the frame edge.
+        var border = param.LeftRightMargin;
+        var topBorder = param.BottomTopMargin;
         switch (param.Alignment)
         {
             case ExportAlignment.BottomLeft:
@@ -99,15 +102,15 @@ public class ExportHandlerBdnXml : IExportHandler
                 break;
             case ExportAlignment.TopCenter:
                 x = (_width - param.Bitmap.Width) / 2;
-                y = border;
+                y = topBorder;
                 break;
             case ExportAlignment.TopLeft:
                 x = border;
-                y = border;
+                y = topBorder;
                 break;
             case ExportAlignment.TopRight:
                 x = _width - param.Bitmap.Width - border;
-                y = border;
+                y = topBorder;
                 break;
         }
 

--- a/src/libuilogic/Export/ExportHandlerDost.cs
+++ b/src/libuilogic/Export/ExportHandlerDost.cs
@@ -17,6 +17,15 @@ public class ExportHandlerDost : IExportHandler
 
     public void WriteHeader(string fileOrFolderName, ImageParameter imageParameter)
     {
+        // Nothing sets the FrameRate property, so the chosen frame rate only ever reached this
+        // handler through the image parameters - and every time code was written at the 23.976
+        // default (whose fractional part also triggered the NTSC pull-down). Take it from the
+        // parameters, like the BDN XML and FCP handlers do.
+        if (imageParameter.FramesPerSecond > 0)
+        {
+            FrameRate = imageParameter.FramesPerSecond;
+        }
+
         _folderName = fileOrFolderName;
         if (!Directory.Exists(_folderName))
         {
@@ -87,7 +96,36 @@ $ULEAD=TRUE
 $DROP=[DROPVALUE]" + Environment.NewLine + Environment.NewLine +
 "NO\tINTIME\t\tOUTTIME\t\tXPOS\tYPOS\tFILENAME\tFADEIN\tFADEOUT";
 
+        // Derive from the frame rate instead of always claiming 30 fps (SE4 did the same).
         var dropValue = "30000";
+        if (Math.Abs(FrameRate - 23.976) < 0.01)
+        {
+            dropValue = "23976";
+        }
+        else if (Math.Abs(FrameRate - 24.0) < 0.01)
+        {
+            dropValue = "24000";
+        }
+        else if (Math.Abs(FrameRate - 25.0) < 0.01)
+        {
+            dropValue = "25000";
+        }
+        else if (Math.Abs(FrameRate - 29.97) < 0.01)
+        {
+            dropValue = "29970";
+        }
+        else if (Math.Abs(FrameRate - 50.0) < 0.01)
+        {
+            dropValue = "50000";
+        }
+        else if (Math.Abs(FrameRate - 59.94) < 0.01)
+        {
+            dropValue = "59940";
+        }
+        else if (Math.Abs(FrameRate - 60.0) < 0.01)
+        {
+            dropValue = "60000";
+        }
         header = header.Replace("[DROPVALUE]", dropValue);
         File.WriteAllText(Path.Combine(_folderName, "index.dost"), header + Environment.NewLine + _sb.ToString());
     }

--- a/src/libuilogic/Export/ExportHandlerImscImage.cs
+++ b/src/libuilogic/Export/ExportHandlerImscImage.cs
@@ -99,35 +99,39 @@ public class ExportHandlerImscImage : IExportHandler
     {
         x = (_width - param.Bitmap.Width) / 2;
         y = _height - (param.Bitmap.Height + param.BottomTopMargin);
+        // Honour the user's margins for the left/right/top placements too - the bitmap is
+        // the trimmed glyph box, so a literal 0 glues the line to the frame edge.
+        var border = param.LeftRightMargin;
+        var topBorder = param.BottomTopMargin;
         switch (param.Alignment)
         {
             case ExportAlignment.BottomLeft:
-                x = 0;
+                x = border;
                 break;
             case ExportAlignment.BottomRight:
-                x = _width - param.Bitmap.Width;
+                x = _width - param.Bitmap.Width - border;
                 break;
             case ExportAlignment.MiddleCenter:
                 y = (_height - param.Bitmap.Height) / 2;
                 break;
             case ExportAlignment.MiddleLeft:
-                x = 0;
+                x = border;
                 y = (_height - param.Bitmap.Height) / 2;
                 break;
             case ExportAlignment.MiddleRight:
-                x = _width - param.Bitmap.Width;
+                x = _width - param.Bitmap.Width - border;
                 y = (_height - param.Bitmap.Height) / 2;
                 break;
             case ExportAlignment.TopCenter:
-                y = 0;
+                y = topBorder;
                 break;
             case ExportAlignment.TopLeft:
-                x = 0;
-                y = 0;
+                x = border;
+                y = topBorder;
                 break;
             case ExportAlignment.TopRight:
-                x = _width - param.Bitmap.Width;
-                y = 0;
+                x = _width - param.Bitmap.Width - border;
+                y = topBorder;
                 break;
         }
 

--- a/src/libuilogic/Ocr/FixEngine/OcrFixEngine.cs
+++ b/src/libuilogic/Ocr/FixEngine/OcrFixEngine.cs
@@ -692,7 +692,6 @@ public partial class OcrFixEngine : IOcrFixEngine, IDoSpell
 
     public List<string> ReloadNames()
     {
-        var names = _spellCheckWordLists.GetAllNames();
         try
         {
             _spellCheckWordLists = new SpellCheckWordLists(_fiveLetterName, this);
@@ -702,7 +701,11 @@ public partial class OcrFixEngine : IOcrFixEngine, IDoSpell
             SpellCheckConfig.LogError("Error loading names for OCR fix engine: " + exception.Message);
             _spellCheckWordLists = new SpellCheckWordLists(string.Empty, this);
         }
-        
-        return names;
+
+        // Read the names *after* rebuilding for _fiveLetterName. Reading first returned the
+        // previous language's names (or none at all on the first run), and Initialize feeds
+        // this list into the word-split list - so run-together words containing a proper
+        // name were split against the wrong language's name set.
+        return _spellCheckWordLists.GetAllNames();
     }
 }

--- a/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
+++ b/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
@@ -545,6 +545,10 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
             Text = ExportTextTags.ToRenderableText(subtitle.Text),
             StartTime = subtitle.StartTime,
             EndTime = subtitle.EndTime,
+            // Carry the forced flag through: BDN XML writes it as Forced="..." and the
+            // Blu-ray sup writer puts it in the display set, so dropping it here silently
+            // un-forces every cue of a forced-caption track on export.
+            IsForced = subtitle.Forced,
             FontColor = FontColor.ToSKColor(),
             FontName = SelectedFontFamily ?? FontFamilies.First(),
             FontSize = SelectedFontSize,

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1212,6 +1212,10 @@ public partial class MainViewModel :
 
     private void LoadShortcuts()
     {
+        // Clear first, like ReloadShortcuts does: RebuildLookupTable keeps the
+        // first-registered entry for a given chord, so re-registering without clearing
+        // leaves the *old* binding winning after Apply (and doubles the list every time).
+        _shortcutManager.ClearShortcuts();
         Se.Settings.InitializeMainShortcuts(this);
         foreach (var shortCut in ShortcutsMain.GetUsedShortcuts(this))
         {
@@ -3576,7 +3580,14 @@ public partial class MainViewModel :
                 return;
             }
 
-            await SubtitleOpen(recentFile.SubtitleFileName, recentFile.VideoFileName, recentFile.SelectedLine, desiredAudioTrackId: recentFile.AudioTrack);
+            // Reopen with the encoding the file was last opened with - it is stored on the
+            // recent-file entry for exactly this, but nothing ever read it back, so a file
+            // opened as e.g. Windows-1252 came back auto-detected.
+            var rememberedEncoding = string.IsNullOrEmpty(recentFile.Encoding)
+                ? null
+                : Encodings.FirstOrDefault(p => p.DisplayName == recentFile.Encoding);
+
+            await SubtitleOpen(recentFile.SubtitleFileName, recentFile.VideoFileName, recentFile.SelectedLine, rememberedEncoding, desiredAudioTrackId: recentFile.AudioTrack);
 
             // Seek the video to the restored line - otherwise Reopen leaves it at 0:00.
             await SeekVideoToSelectedLineAsync();

--- a/src/ui/Features/Options/Settings/SettingsImportExport/SettingsImportExportViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsImportExport/SettingsImportExportViewModel.cs
@@ -179,6 +179,7 @@ public partial class SettingsImportExportViewModel : ObservableObject
             if (!IsRulesEnabled)
             {
                 ExportImportRules = false;
+                ExportImportSyntaxColoring = false; // the coloring fields live in General
             }
 
             if (!IsAppearanceEnabled)
@@ -261,45 +262,29 @@ public partial class SettingsImportExportViewModel : ObservableObject
         var exportData = new Se();
         var currentSettings = Se.Settings;
 
-        if (ExportImportAll || ExportImportRules)
-        {
-            exportData.General = currentSettings.General;
-        }
+        // Every Se section is self-initializing, so a section left untouched here would still
+        // serialize as a full block of *defaults* - and the importer, which only checks for
+        // null, would happily install those defaults over the user's settings. Assign null
+        // for anything not being exported so "what's in the file" is unambiguous.
 
-        if (ExportImportAll || ExportImportWaveform)
-        {
-            exportData.Waveform = currentSettings.Waveform;
-        }
+        // Syntax coloring lives inside General, so General has to travel for it - the import
+        // side then applies either the whole section or just the coloring fields.
+        exportData.General = ExportImportAll || ExportImportRules || ExportImportSyntaxColoring
+            ? currentSettings.General
+            : null!;
 
-        if (ExportImportAll)
-        {
-            exportData.Tools = currentSettings.Tools;
-        }
+        exportData.Waveform = ExportImportAll || ExportImportWaveform ? currentSettings.Waveform : null!;
+        exportData.Tools = ExportImportAll ? currentSettings.Tools : null!;
+        exportData.Appearance = ExportImportAll || ExportImportAppearance ? currentSettings.Appearance : null!;
+        exportData.Options = ExportImportAll ? currentSettings.Options : null!;
+        exportData.Shortcuts = ExportImportAll || ExportImportShortcuts ? currentSettings.Shortcuts : null!;
+        exportData.AutoTranslate = ExportImportAll || ExportImportAutoTranslate ? currentSettings.AutoTranslate : null!;
+        exportData.SpellCheck = ExportImportAll ? currentSettings.SpellCheck : null!;
 
-        if (ExportImportAll || ExportImportAppearance)
-        {
-            exportData.Appearance = currentSettings.Appearance;
-        }
-
-        if (ExportImportAll)
-        {
-            exportData.Options = currentSettings.Options;
-        }
-
-        if (ExportImportAll || ExportImportShortcuts)
-        {
-            exportData.Shortcuts = currentSettings.Shortcuts;
-        }
-
-        if (ExportImportAll || ExportImportAutoTranslate)
-        {
-            exportData.AutoTranslate = currentSettings.AutoTranslate;
-        }
-
-        if (ExportImportAll)
-        {
-            exportData.SpellCheck = currentSettings.SpellCheck;
-        }
+        // Video was never assigned, so an "all settings" file carried a default Video block
+        // that the importer applied - silently resetting the player choice, the mpv preview
+        // style and the custom seek amounts.
+        exportData.Video = ExportImportAll ? currentSettings.Video : null!;
 
         var json = JsonSerializer.Serialize(exportData, new JsonSerializerOptions { WriteIndented = true });
         var jsonWithSource = InjectExportSourceOs(json, GetCurrentOsName());
@@ -321,6 +306,27 @@ public partial class SettingsImportExportViewModel : ObservableObject
             {
                 Se.Settings.General = importData.General;
             }
+        }
+        else if (ExportImportSyntaxColoring && importData.General != null)
+        {
+            // Only the syntax-coloring fields of General - the rest of the section is the
+            // "Rules" import, which the user did not ask for. (This checkbox used to be
+            // wired to nothing at all.)
+            var from = importData.General;
+            var to = Se.Settings.General;
+            to.ColorDurationTooShort = from.ColorDurationTooShort;
+            to.ColorDurationTooLong = from.ColorDurationTooLong;
+            to.ColorTextTooLong = from.ColorTextTooLong;
+            to.ColorTextTooWide = from.ColorTextTooWide;
+            to.ColorTextTooWidePixels = from.ColorTextTooWidePixels;
+            to.ColorTextTooWideFontName = from.ColorTextTooWideFontName;
+            to.ColorTextTooWideFontSize = from.ColorTextTooWideFontSize;
+            to.ColorTextTooManyLines = from.ColorTextTooManyLines;
+            to.ColorCharactersPerSecond = from.ColorCharactersPerSecond;
+            to.ColorWordsPerMinute = from.ColorWordsPerMinute;
+            to.ColorTimeCodeOverlap = from.ColorTimeCodeOverlap;
+            to.ColorGapTooShort = from.ColorGapTooShort;
+            to.ErrorColor = from.ErrorColor;
         }
 
         if (ExportImportAll || ExportImportWaveform)

--- a/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Media;
@@ -68,6 +68,11 @@ public partial class ShortcutsViewModel : ObservableObject
     // Mirror Se.Settings.Actor1..10 while the dialog is open so OK/Cancel
     // semantics match the other configurable slots (Color1..8, Surround1..3).
     private readonly string[] _actorSlots = new string[10];
+    // Same for the custom video-seek amounts (1Back, 1Forward, 2Back, ... 4Forward) and the
+    // go-to-first/last-line option: these used to be written straight into Se.Settings from
+    // the Configure dialogs, so Cancel did not undo them and the next save persisted them.
+    private readonly int[] _videoSeekSlots = new int[8];
+    private bool _goToFirstAndLastLineAlsoSetVideoPosition;
 
     // Add this flag to prevent updates during selection changes
     private bool _isLoadingSelection = false;
@@ -102,6 +107,15 @@ public partial class ShortcutsViewModel : ObservableObject
         _surround2Right = Se.Settings.Surround2Right;
         _surround3Left = Se.Settings.Surround3Left;
         _surround3Right = Se.Settings.Surround3Right;
+        _videoSeekSlots[0] = Se.Settings.Video.MoveVideoPositionCustom1Back;
+        _videoSeekSlots[1] = Se.Settings.Video.MoveVideoPositionCustom1Forward;
+        _videoSeekSlots[2] = Se.Settings.Video.MoveVideoPositionCustom2Back;
+        _videoSeekSlots[3] = Se.Settings.Video.MoveVideoPositionCustom2Forward;
+        _videoSeekSlots[4] = Se.Settings.Video.MoveVideoPositionCustom3Back;
+        _videoSeekSlots[5] = Se.Settings.Video.MoveVideoPositionCustom3Forward;
+        _videoSeekSlots[6] = Se.Settings.Video.MoveVideoPositionCustom4Back;
+        _videoSeekSlots[7] = Se.Settings.Video.MoveVideoPositionCustom4Forward;
+        _goToFirstAndLastLineAlsoSetVideoPosition = Se.Settings.Tools.GoToFirstAndLastLineAlsoSetVideoPosition;
         _actorSlots[0] = Se.Settings.Actor1;
         _actorSlots[1] = Se.Settings.Actor2;
         _actorSlots[2] = Se.Settings.Actor3;
@@ -573,6 +587,15 @@ public partial class ShortcutsViewModel : ObservableObject
         Se.Settings.Actor8 = _actorSlots[7];
         Se.Settings.Actor9 = _actorSlots[8];
         Se.Settings.Actor10 = _actorSlots[9];
+        Se.Settings.Video.MoveVideoPositionCustom1Back = _videoSeekSlots[0];
+        Se.Settings.Video.MoveVideoPositionCustom1Forward = _videoSeekSlots[1];
+        Se.Settings.Video.MoveVideoPositionCustom2Back = _videoSeekSlots[2];
+        Se.Settings.Video.MoveVideoPositionCustom2Forward = _videoSeekSlots[3];
+        Se.Settings.Video.MoveVideoPositionCustom3Back = _videoSeekSlots[4];
+        Se.Settings.Video.MoveVideoPositionCustom3Forward = _videoSeekSlots[5];
+        Se.Settings.Video.MoveVideoPositionCustom4Back = _videoSeekSlots[6];
+        Se.Settings.Video.MoveVideoPositionCustom4Forward = _videoSeekSlots[7];
+        Se.Settings.Tools.GoToFirstAndLastLineAlsoSetVideoPosition = _goToFirstAndLastLineAlsoSetVideoPosition;
 
         ShortcutsMain.CommandTranslationLookup[nameof(MainViewModel.SurroundWith1Command)] = string.Format(Se.Language.Options.Shortcuts.SurroundWithXY, Se.Settings.Surround1Left, Se.Settings.Surround1Right);
         ShortcutsMain.CommandTranslationLookup[nameof(MainViewModel.SurroundWith2Command)] = string.Format(Se.Language.Options.Shortcuts.SurroundWithXY, Se.Settings.Surround2Left, Se.Settings.Surround2Right);
@@ -615,11 +638,11 @@ public partial class ShortcutsViewModel : ObservableObject
                 Nikse.SubtitleEdit.Features.Shared.PromptCheckBox.PromptCheckBoxViewModel>(Window, vm =>
             {
                 vm.Initialize(node.Title, Se.Language.Options.Shortcuts.AlsoSetVideoPosition,
-                    Se.Settings.Tools.GoToFirstAndLastLineAlsoSetVideoPosition);
+                    _goToFirstAndLastLineAlsoSetVideoPosition);
             });
             if (result.OkPressed)
             {
-                Se.Settings.Tools.GoToFirstAndLastLineAlsoSetVideoPosition = result.IsChecked;
+                _goToFirstAndLastLineAlsoSetVideoPosition = result.IsChecked;
             }
 
             return;
@@ -771,16 +794,16 @@ public partial class ShortcutsViewModel : ObservableObject
         {
             var result = await _windowService.ShowDialogAsync<PickMillisecondsWindow, PickMillisecondsViewModel>(Window, vm =>
             {
-                vm.Initialize(Se.Settings.Video.MoveVideoPositionCustom1Back);
+                vm.Initialize(_videoSeekSlots[0]);
             });
             if (result.OkPressed)
             {
-                Se.Settings.Video.MoveVideoPositionCustom1Back = result.Milliseconds;
+                _videoSeekSlots[0] = result.Milliseconds;
 
                 var flatNodeBack = FlatNodes.FirstOrDefault(n => n?.ShortCut?.Action == MainViewModel.VideoMoveCustom1BackCommand);
                 if (flatNodeBack != null)
                 {
-                    flatNodeBack.Title = string.Format(Se.Language.General.VideoCustom1BackX, Se.Settings.Video.MoveVideoPositionCustom1Back);
+                    flatNodeBack.Title = string.Format(Se.Language.General.VideoCustom1BackX, _videoSeekSlots[0]);
                 }
             }
         }
@@ -788,16 +811,16 @@ public partial class ShortcutsViewModel : ObservableObject
         {
             var result = await _windowService.ShowDialogAsync<PickMillisecondsWindow, PickMillisecondsViewModel>(Window, vm =>
             {
-                vm.Initialize(Se.Settings.Video.MoveVideoPositionCustom1Forward);
+                vm.Initialize(_videoSeekSlots[1]);
             });
             if (result.OkPressed)
             {
-                Se.Settings.Video.MoveVideoPositionCustom1Forward = result.Milliseconds;
+                _videoSeekSlots[1] = result.Milliseconds;
 
                 var flatNodeForward = FlatNodes.FirstOrDefault(n => n?.ShortCut?.Action == MainViewModel.VideoMoveCustom1ForwardCommand);
                 if (flatNodeForward != null)
                 {
-                    flatNodeForward.Title = string.Format(Se.Language.General.VideoCustom1ForwardX, Se.Settings.Video.MoveVideoPositionCustom1Forward);
+                    flatNodeForward.Title = string.Format(Se.Language.General.VideoCustom1ForwardX, _videoSeekSlots[1]);
                 }
             }
         }
@@ -805,16 +828,16 @@ public partial class ShortcutsViewModel : ObservableObject
         {
             var result = await _windowService.ShowDialogAsync<PickMillisecondsWindow, PickMillisecondsViewModel>(Window, vm =>
             {
-                vm.Initialize(Se.Settings.Video.MoveVideoPositionCustom2Back);
+                vm.Initialize(_videoSeekSlots[2]);
             });
             if (result.OkPressed)
             {
-                Se.Settings.Video.MoveVideoPositionCustom2Back = result.Milliseconds;
+                _videoSeekSlots[2] = result.Milliseconds;
 
                 var flatNodeBack = FlatNodes.FirstOrDefault(n => n?.ShortCut?.Action == MainViewModel.VideoMoveCustom2BackCommand);
                 if (flatNodeBack != null)
                 {
-                    flatNodeBack.Title = string.Format(Se.Language.General.VideoCustom2BackX, Se.Settings.Video.MoveVideoPositionCustom2Back);
+                    flatNodeBack.Title = string.Format(Se.Language.General.VideoCustom2BackX, _videoSeekSlots[2]);
                 }
             }
         }
@@ -822,16 +845,16 @@ public partial class ShortcutsViewModel : ObservableObject
         {
             var result = await _windowService.ShowDialogAsync<PickMillisecondsWindow, PickMillisecondsViewModel>(Window, vm =>
             {
-                vm.Initialize(Se.Settings.Video.MoveVideoPositionCustom2Forward);
+                vm.Initialize(_videoSeekSlots[3]);
             });
             if (result.OkPressed)
             {
-                Se.Settings.Video.MoveVideoPositionCustom2Forward = result.Milliseconds;
+                _videoSeekSlots[3] = result.Milliseconds;
 
                 var flatNodeForward = FlatNodes.FirstOrDefault(n => n?.ShortCut?.Action == MainViewModel.VideoMoveCustom2ForwardCommand);
                 if (flatNodeForward != null)
                 {
-                    flatNodeForward.Title = string.Format(Se.Language.General.VideoCustom2ForwardX, Se.Settings.Video.MoveVideoPositionCustom2Forward);
+                    flatNodeForward.Title = string.Format(Se.Language.General.VideoCustom2ForwardX, _videoSeekSlots[3]);
                 }
             }
         }
@@ -839,16 +862,16 @@ public partial class ShortcutsViewModel : ObservableObject
         {
             var result = await _windowService.ShowDialogAsync<PickMillisecondsWindow, PickMillisecondsViewModel>(Window, vm =>
             {
-                vm.Initialize(Se.Settings.Video.MoveVideoPositionCustom3Back);
+                vm.Initialize(_videoSeekSlots[4]);
             });
             if (result.OkPressed)
             {
-                Se.Settings.Video.MoveVideoPositionCustom3Back = result.Milliseconds;
+                _videoSeekSlots[4] = result.Milliseconds;
 
                 var flatNodeBack = FlatNodes.FirstOrDefault(n => n?.ShortCut?.Action == MainViewModel.VideoMoveCustom3BackCommand);
                 if (flatNodeBack != null)
                 {
-                    flatNodeBack.Title = string.Format(Se.Language.General.VideoCustom3BackX, Se.Settings.Video.MoveVideoPositionCustom3Back);
+                    flatNodeBack.Title = string.Format(Se.Language.General.VideoCustom3BackX, _videoSeekSlots[4]);
                 }
             }
         }
@@ -856,16 +879,16 @@ public partial class ShortcutsViewModel : ObservableObject
         {
             var result = await _windowService.ShowDialogAsync<PickMillisecondsWindow, PickMillisecondsViewModel>(Window, vm =>
             {
-                vm.Initialize(Se.Settings.Video.MoveVideoPositionCustom3Forward);
+                vm.Initialize(_videoSeekSlots[5]);
             });
             if (result.OkPressed)
             {
-                Se.Settings.Video.MoveVideoPositionCustom3Forward = result.Milliseconds;
+                _videoSeekSlots[5] = result.Milliseconds;
 
                 var flatNodeForward = FlatNodes.FirstOrDefault(n => n?.ShortCut?.Action == MainViewModel.VideoMoveCustom3ForwardCommand);
                 if (flatNodeForward != null)
                 {
-                    flatNodeForward.Title = string.Format(Se.Language.General.VideoCustom3ForwardX, Se.Settings.Video.MoveVideoPositionCustom3Forward);
+                    flatNodeForward.Title = string.Format(Se.Language.General.VideoCustom3ForwardX, _videoSeekSlots[5]);
                 }
             }
         }
@@ -873,16 +896,16 @@ public partial class ShortcutsViewModel : ObservableObject
         {
             var result = await _windowService.ShowDialogAsync<PickMillisecondsWindow, PickMillisecondsViewModel>(Window, vm =>
             {
-                vm.Initialize(Se.Settings.Video.MoveVideoPositionCustom4Back);
+                vm.Initialize(_videoSeekSlots[6]);
             });
             if (result.OkPressed)
             {
-                Se.Settings.Video.MoveVideoPositionCustom4Back = result.Milliseconds;
+                _videoSeekSlots[6] = result.Milliseconds;
 
                 var flatNodeBack = FlatNodes.FirstOrDefault(n => n?.ShortCut?.Action == MainViewModel.VideoMoveCustom4BackCommand);
                 if (flatNodeBack != null)
                 {
-                    flatNodeBack.Title = string.Format(Se.Language.General.VideoCustom4BackX, Se.Settings.Video.MoveVideoPositionCustom4Back);
+                    flatNodeBack.Title = string.Format(Se.Language.General.VideoCustom4BackX, _videoSeekSlots[6]);
                 }
             }
         }
@@ -890,16 +913,16 @@ public partial class ShortcutsViewModel : ObservableObject
         {
             var result = await _windowService.ShowDialogAsync<PickMillisecondsWindow, PickMillisecondsViewModel>(Window, vm =>
             {
-                vm.Initialize(Se.Settings.Video.MoveVideoPositionCustom4Forward);
+                vm.Initialize(_videoSeekSlots[7]);
             });
             if (result.OkPressed)
             {
-                Se.Settings.Video.MoveVideoPositionCustom4Forward = result.Milliseconds;
+                _videoSeekSlots[7] = result.Milliseconds;
 
                 var flatNodeForward = FlatNodes.FirstOrDefault(n => n?.ShortCut?.Action == MainViewModel.VideoMoveCustom4ForwardCommand);
                 if (flatNodeForward != null)
                 {
-                    flatNodeForward.Title = string.Format(Se.Language.General.VideoCustom4ForwardX, Se.Settings.Video.MoveVideoPositionCustom4Forward);
+                    flatNodeForward.Title = string.Format(Se.Language.General.VideoCustom4ForwardX, _videoSeekSlots[7]);
                 }
             }
         }

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -1711,6 +1711,9 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
                 Text = string.Empty,
                 StartTime = imageSubtitle.GetStartTime(i),
                 EndTime = imageSubtitle.GetEndTime(i),
+                // The source knows which cues are forced - carry it through so a forced
+                // Blu-ray/PGS track stays forced in the exported sup/BDN XML.
+                IsForced = imageSubtitle.GetIsForced(i),
                 FontColor = SKColors.White,
                 FontName = "Arial",
                 FontSize = 24,
@@ -1721,8 +1724,16 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
                 ShadowWidth = 2,
                 BackgroundColor = SKColors.Transparent,
                 BackgroundCornerRadius = 0,
-                ScreenWidth = imageSubtitle.GetScreenSize(i).Width,
-                ScreenHeight = imageSubtitle.GetScreenSize(i).Height,
+                // Several IOcrSubtitle sources report "unknown" as -1 x -1 (DivX/XSUB, MP4
+                // VobSub, WebVTT images, BDN...). Passing that straight through made every
+                // exported event land at a large negative X/Y, so fall back to the profile's
+                // resolution the way the text-rendering path does.
+                ScreenWidth = imageSubtitle.GetScreenSize(i).Width > 0
+                    ? imageSubtitle.GetScreenSize(i).Width
+                    : profile.ScreenWidth,
+                ScreenHeight = imageSubtitle.GetScreenSize(i).Height > 0
+                    ? imageSubtitle.GetScreenSize(i).Height
+                    : profile.ScreenHeight,
                 BottomTopMargin = 0,
                 LeftRightMargin = 0,
                 Bitmap = ApplyImageAdjustments(imageSubtitle.GetBitmap(i)),

--- a/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
@@ -469,6 +469,19 @@ public partial class BurnInViewModel : ObservableObject
         var mediaInfo = FfmpegMediaInfo.Parse(jobItem.InputVideoFileName);
         jobItem.TotalFrames = mediaInfo.GetTotalFrames();
         jobItem.TotalSeconds = mediaInfo.Duration.TotalSeconds;
+
+        // With "Cut" on, only the cut range is encoded (-ss/-t below). Measuring the full
+        // source made the target-file-size bit rate a fraction of what was asked for, and
+        // left the progress bar creeping to a few percent before jumping to Done.
+        if (IsCutActive && jobItem.TotalSeconds > 0)
+        {
+            var cutSeconds = (CutTo - CutFrom).TotalSeconds;
+            if (cutSeconds > 0 && cutSeconds < jobItem.TotalSeconds)
+            {
+                jobItem.TotalFrames = (long)Math.Round(jobItem.TotalFrames * (cutSeconds / jobItem.TotalSeconds));
+                jobItem.TotalSeconds = cutSeconds;
+            }
+        }
         if (mediaInfo.Dimension.Width > 0 && mediaInfo.Dimension.Height > 0)
         {
             jobItem.Width = mediaInfo.Dimension.Width;
@@ -887,7 +900,10 @@ public partial class BurnInViewModel : ObservableObject
                 {
                     var fontSize = CalculateFontSize(jobItem.Width, jobItem.Height, FontFactor ?? 0);
                     var durationMs = (int)(s.Duration.TotalMilliseconds);
-                    s.Text = effect.ApplyEffect(s.Text, VideoWidth ?? 0, VideoHeight ?? 0, fontSize, durationMs);
+                    // This job's dimensions, not the UI's: the effects emit absolute ASSA
+                    // coordinates that are resolved against the PlayResX/Y written from
+                    // jobItem below, so a batch item of another size placed text wrongly.
+                    s.Text = effect.ApplyEffect(s.Text, jobItem.Width, jobItem.Height, fontSize, durationMs);
                 }
             }
 
@@ -1380,7 +1396,10 @@ public partial class BurnInViewModel : ObservableObject
         SelectedFontOutline = settings.OutlineWidth;
         SelectedFontShadowWidth = settings.ShadowWidth;
         SelectedFontSpacing = settings.NonAssaSpacing;
-        SelectedFontName = settings.FontName;
+        // Guard the fallback the way the constructor does: assigning a font that is not
+        // in FontNames nulls the ComboBox selection, and the TwoWay binding then writes
+        // that null back over the saved font name.
+        SelectedFontName = FontNames.FirstOrDefault(p => p == settings.FontName) ?? FontNames[0];
         FontTextColor = settings.NonAssaTextColor.FromHexToColor();
         FontOutlineColor = settings.NonAssaOutlineColor.FromHexToColor();
         FontBoxColor = settings.NonAssaBoxColor.FromHexToColor();
@@ -1422,7 +1441,7 @@ public partial class BurnInViewModel : ObservableObject
         UseTargetFileSize = settings.TargetFileSize;
         TargetFileSize = settings.TargetFileSizeMb;
         MatchSourceVideoSize = settings.TargetFileSizeMatchSource;
-        PromptForFfmpegParameters = settings.PromptFfmpegParameters;
+        PromptForFfmpegParameters = false; // one-shot, never restored from settings
 
         var effectsAsStringArray = settings.Effects?.Split(',') ?? [];
         _selectedEffects = BurnInEffectItem.List().Where(p => effectsAsStringArray.Contains(p.Name)).ToList();
@@ -1464,7 +1483,9 @@ public partial class BurnInViewModel : ObservableObject
         settings.TargetFileSize = UseTargetFileSize;
         settings.TargetFileSizeMb = TargetFileSize ?? 0;
         settings.TargetFileSizeMatchSource = MatchSourceVideoSize;
-        settings.PromptFfmpegParameters = PromptForFfmpegParameters;
+        // Deliberately not persisted: PromptForFfmpegParameters is a one-shot set by the
+        // "Prompt for ffmpeg params and generate" menu item. Saving it made the plain
+        // Generate button prompt forever, with no UI to turn it back off.
 
         settings.Effects = string.Join(",", _selectedEffects.Select(p => p.Name).Distinct());
 

--- a/src/ui/Features/Video/EmbeddedSubtitlesEdit/EmbeddedSubtitlesEditViewModel.cs
+++ b/src/ui/Features/Video/EmbeddedSubtitlesEdit/EmbeddedSubtitlesEditViewModel.cs
@@ -271,18 +271,24 @@ public partial class EmbeddedSubtitlesEditViewModel : ObservableObject
         var nameNoExt = Path.GetFileNameWithoutExtension(videoFileName);
         var ext = Path.GetExtension(VideoFileName) ?? ".mkv";
         var suffix = Se.Settings.Video.BurnIn.BurnInSuffix;
-        var fileName = Path.Combine(Path.GetDirectoryName(videoFileName)!, nameNoExt + suffix + ext);
-        if (Se.Settings.Video.BurnIn.UseOutputFolder &&
-            !string.IsNullOrEmpty(Se.Settings.Video.BurnIn.OutputFolder) &&
-            Directory.Exists(Se.Settings.Video.BurnIn.OutputFolder))
-        {
-            fileName = Path.Combine(Se.Settings.Video.BurnIn.OutputFolder, nameNoExt + suffix + ext);
-        }
+
+        // Decide the folder once: the collision loop below used to combine with
+        // BurnIn.OutputFolder unconditionally, so with the default (empty, unused) folder
+        // the second file of a run got a bare relative name resolved against the process
+        // working directory instead of the video's folder.
+        var useOutputFolder = Se.Settings.Video.BurnIn.UseOutputFolder &&
+                              !string.IsNullOrEmpty(Se.Settings.Video.BurnIn.OutputFolder) &&
+                              Directory.Exists(Se.Settings.Video.BurnIn.OutputFolder);
+        var outputFolder = useOutputFolder
+            ? Se.Settings.Video.BurnIn.OutputFolder
+            : Path.GetDirectoryName(videoFileName) ?? Path.GetTempPath();
+
+        var fileName = Path.Combine(outputFolder, nameNoExt + suffix + ext);
 
         var i = 2;
         while (File.Exists(fileName))
         {
-            fileName = Path.Combine(Se.Settings.Video.BurnIn.OutputFolder, $"{nameNoExt}{suffix}_{i}{ext}");
+            fileName = Path.Combine(outputFolder, $"{nameNoExt}{suffix}_{i}{ext}");
             i++;
         }
 

--- a/src/ui/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttService.cs
+++ b/src/ui/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -272,10 +272,13 @@ public class OpenAiSttService : ISttTranscriber
             if (string.IsNullOrWhiteSpace(line))
             {
                 // Empty line = end of event, process it
-                if (dataBuilder.Length > 0 && !string.IsNullOrEmpty(eventType))
+                if (dataBuilder.Length > 0)
                 {
                     var data = dataBuilder.ToString().Trim();
-                    ProcessSseEvent(eventType, data, segments, fullText, progress, segmentProgress, ref currentSegmentText, ref currentSegmentId, ref currentSegmentStart, ref currentSegmentEnd);
+                    // Per the SSE spec an event with no "event:" line is type "message", and
+                    // the transcription payloads carry their own "type" field - keying only
+                    // off "event:" discarded every event from servers that omit it.
+                    ProcessSseEvent(ResolveSseEventType(eventType, data), data, segments, fullText, progress, segmentProgress, ref currentSegmentText, ref currentSegmentId, ref currentSegmentStart, ref currentSegmentEnd);
                 }
                 eventType = "";
                 dataBuilder.Clear();
@@ -293,10 +296,10 @@ public class OpenAiSttService : ISttTranscriber
         }
 
         // Process any remaining event
-        if (dataBuilder.Length > 0 && !string.IsNullOrEmpty(eventType))
+        if (dataBuilder.Length > 0)
         {
             var data = dataBuilder.ToString().Trim();
-            ProcessSseEvent(eventType, data, segments, fullText, progress, segmentProgress, ref currentSegmentText, ref currentSegmentId, ref currentSegmentStart, ref currentSegmentEnd);
+            ProcessSseEvent(ResolveSseEventType(eventType, data), data, segments, fullText, progress, segmentProgress, ref currentSegmentText, ref currentSegmentId, ref currentSegmentStart, ref currentSegmentEnd);
         }
 
         return new OpenAiCompatibleSttResponse
@@ -306,6 +309,36 @@ public class OpenAiSttService : ISttTranscriber
             Language = null,
             Duration = segments.Count > 0 ? segments[^1].End : 0
         };
+    }
+
+    /// <summary>
+    /// The event type to dispatch on: the SSE "event:" field when the server sends one,
+    /// otherwise the "type" the JSON payload carries itself (OpenAI's transcription stream
+    /// sends bare "data: {"type":"transcript.text.delta",...}" lines).
+    /// </summary>
+    private static string ResolveSseEventType(string eventType, string data)
+    {
+        if (!string.IsNullOrEmpty(eventType))
+        {
+            return eventType;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(data);
+            if (doc.RootElement.ValueKind == JsonValueKind.Object &&
+                doc.RootElement.TryGetProperty("type", out var typeElement) &&
+                typeElement.ValueKind == JsonValueKind.String)
+            {
+                return typeElement.GetString() ?? string.Empty;
+            }
+        }
+        catch (JsonException)
+        {
+            // Not JSON (e.g. the "[DONE]" sentinel) - nothing to dispatch on.
+        }
+
+        return string.Empty;
     }
 
     private static void ProcessSseEvent(
@@ -352,22 +385,11 @@ public class OpenAiSttService : ISttTranscriber
                         }
                     }
                 }
-                else if (segments.Count == 0)
-                {
-                    // No segments from streaming or from done.segments array
-                    if (!string.IsNullOrEmpty(doneObj?.Text) && fullText.Length > 0)
-                    {
-                        var newSeg = new OpenAiCompatibleSegment
-                        {
-                            Id = 0,
-                            Start = 0,
-                            End = 0,
-                            Text = fullText.ToString().Trim()
-                        };
-                        segments.Add(newSeg);
-                        segmentProgress?.Report(newSeg);
-                    }
-                }
+                // No segments from streaming or from the done.segments array: leave the
+                // text to be returned as Text with no segments, so the caller's
+                // sentence-spreading fallback gives it real time codes. Synthesising a
+                // 0/0 segment here instead produced one cue holding the whole transcript
+                // at 00:00:00,000 --> 00:00:00,000 and suppressed that fallback.
             }
             else if (eventType == "transcript.segment" || eventType == "transcript.text.segment")
             {

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextPostProcessor.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextPostProcessor.cs
@@ -29,6 +29,14 @@ namespace Nikse.SubtitleEdit.Features.Video.SpeechToText
 
         public int ParagraphMaxChars { get; set; }
 
+        /// <summary>
+        /// The command line the engine actually ran with, used to detect word-level output
+        /// (--highlight_words / --one_word) that merging and splitting would destroy.
+        /// SE 5 stores these per engine (engine.CommandLineParameter) - the old global
+        /// setting this used to read is never written, so the guard never fired.
+        /// </summary>
+        public string EngineCommandLineArguments { get; set; } = string.Empty;
+
         private const int AudioToTextLineMaxChars = 86;
         private const int AudioToTextLineMaxCharsJp = 32;
         private const int AudioToTextLineMaxCharsCn = 36;
@@ -230,19 +238,19 @@ namespace Nikse.SubtitleEdit.Features.Video.SpeechToText
             return subtitle;
         }
 
-        private static bool AllowLineContentMove(Engine engine)
+        private bool AllowLineContentMove(Engine engine)
         {
             if (engine != Engine.Whisper)
             {
                 return true;
             }
 
-            if (string.IsNullOrEmpty(Se.Settings.Tools.AudioToText.WhisperCustomCommandLineArguments))
+            if (string.IsNullOrEmpty(EngineCommandLineArguments))
             {
                 return true;
             }
 
-            var es = Se.Settings.Tools.AudioToText.WhisperCustomCommandLineArguments.ToLowerInvariant();
+            var es = EngineCommandLineArguments.ToLowerInvariant();
             return !es.Contains("--highlight_words", StringComparison.OrdinalIgnoreCase) &&
                    !es.Contains("-hw ", StringComparison.OrdinalIgnoreCase) &&
                    !es.Contains("-hw=true", StringComparison.OrdinalIgnoreCase) &&

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -401,8 +401,18 @@ public partial class SpeechToTextViewModel : ObservableObject
         var engine = GetEffectiveSelectedEngine();
         engine.CommandLineParameter = Parameters;
         Se.Settings.Tools.AudioToText.WhisperChoice = engine.Choice;
-        Se.Settings.Tools.AudioToText.WhisperModel = SelectedModel?.Model.Name ?? string.Empty;
-        Se.Settings.Tools.AudioToText.WhisperLanguageCode = SelectedLanguage?.Code ?? string.Empty;
+        // Keep the remembered model/language when the current engine simply doesn't show
+        // those pickers (online STT engines null them out): overwriting with empty strings
+        // lost the user's choice for good, so switching back fell to tiny/English.
+        if (SelectedModel != null || IsModelSelectionVisible)
+        {
+            Se.Settings.Tools.AudioToText.WhisperModel = SelectedModel?.Model.Name ?? string.Empty;
+        }
+
+        if (SelectedLanguage != null || IsLanguageSelectionVisible)
+        {
+            Se.Settings.Tools.AudioToText.WhisperLanguageCode = SelectedLanguage?.Code ?? string.Empty;
+        }
         Se.Settings.Tools.AudioToText.CrispAsrForcedAligner = SelectedForcedAligner?.Choice ?? ForcedAlignerOption.BuiltInChoice;
 
         Se.Settings.Tools.OpenAiCompatibleSttUrl = OpenAiCompatibleSttUrl ?? string.Empty;
@@ -801,9 +811,13 @@ public partial class SpeechToTextViewModel : ObservableObject
                         "The model is incomplete. Please download the full model.");
                     hasError = true;
                 }
-                else if (_unknownArgument && !string.IsNullOrEmpty(settings.WhisperCustomCommandLineArguments))
+                else if (_unknownArgument)
                 {
-                    await MessageBox.Show(Window!, $"Unknown argument: {settings.WhisperCustomCommandLineArguments}",
+                    // Report the parameters the engine actually ran with. This used to be
+                    // gated on a global setting nothing ever writes, so a mistyped flag made
+                    // the run fail with no message at all.
+                    var badArgs = GetEffectiveSelectedEngine()?.CommandLineParameter ?? string.Empty;
+                    await MessageBox.Show(Window!, $"Unknown argument: {badArgs}",
                         "Unknown argument. Please check the advanced settings.");
                     hasError = true;
                 }
@@ -1137,9 +1151,10 @@ public partial class SpeechToTextViewModel : ObservableObject
                     return;
                 }
 
-                if (_unknownArgument && !string.IsNullOrEmpty(settings.WhisperCustomCommandLineArguments))
+                if (_unknownArgument)
                 {
-                    await MessageBox.Show(Window!, $"Unknown argument: {settings.WhisperCustomCommandLineArguments}",
+                    var badArgs = GetEffectiveSelectedEngine()?.CommandLineParameter ?? string.Empty;
+                    await MessageBox.Show(Window!, $"Unknown argument: {badArgs}",
                         "Unknown argument. Please check the advanced settings.");
                 }
                 LogToConsole($"Speech to text: Could not find output JSON file ({exitCodeText}){Environment.NewLine}");
@@ -1338,7 +1353,7 @@ public partial class SpeechToTextViewModel : ObservableObject
                 await MessageBox.Show(Window!,
                     Se.Language.General.ConfigurationRequired,
                     configError ?? Se.Language.General.OpenAiCompatibleSttUrlMissing);
-                IsTranscribeEnabled = true;
+                FailCurrentOnlineSttJob();
             });
             return;
         }
@@ -1379,7 +1394,7 @@ public partial class SpeechToTextViewModel : ObservableObject
                 await MessageBox.Show(Window!,
                     Se.Language.General.TranscriptionError,
                     string.Format(Se.Language.General.OpenAiCompatibleSttUrlNotResponding, probeError));
-                IsTranscribeEnabled = true;
+                FailCurrentOnlineSttJob();
             });
             return;
         }
@@ -1484,7 +1499,7 @@ public partial class SpeechToTextViewModel : ObservableObject
             {
                 await Dispatcher.UIThread.InvokeAsync(() =>
                 {
-                    IsTranscribeEnabled = true;
+                    FailCurrentOnlineSttJob();
                     HideProgressBar();
                 });
             }
@@ -1522,7 +1537,7 @@ public partial class SpeechToTextViewModel : ObservableObject
             await Dispatcher.UIThread.InvokeAsync(async () =>
             {
                 await MessageBox.Show(Window!, Se.Language.General.TranscriptionError, message);
-                IsTranscribeEnabled = true;
+                FailCurrentOnlineSttJob();
             });
         }
         catch (TimeoutException ex)
@@ -1564,7 +1579,7 @@ public partial class SpeechToTextViewModel : ObservableObject
             await Dispatcher.UIThread.InvokeAsync(async () =>
             {
                 await MessageBox.Show(Window!, Se.Language.General.TranscriptionError, $"{Se.Language.General.TranscriptionFailed}: {ex.Message}");
-                IsTranscribeEnabled = true;
+                FailCurrentOnlineSttJob();
             });
         }
         finally
@@ -2075,6 +2090,9 @@ public partial class SpeechToTextViewModel : ObservableObject
             ParagraphMaxChars = Configuration.Settings.General.SubtitleLineMaximumLength * 2,
             RemoveNonSpeechLines = Se.Settings.Tools.AudioToText.WhisperPostProcessingRemoveNonSpeechLines,
             RemoveRepeatedLines = Se.Settings.Tools.AudioToText.WhisperPostProcessingRemoveRepeatedLines,
+            // The engine's own parameters, so word-highlighted output is left alone by the
+            // merge/split steps (they are stored per engine, not in one global setting).
+            EngineCommandLineArguments = GetEffectiveSelectedEngine()?.CommandLineParameter ?? string.Empty,
         };
 
         WavePeakData2? wavePeaks = null;
@@ -3689,17 +3707,43 @@ public partial class SpeechToTextViewModel : ObservableObject
         }
     }
 
+    /// <summary>
+    /// Fails the online-STT job that is currently running. In batch mode the item is marked
+    /// failed and the batch moves on, the same contract the ffmpeg-failure path uses - every
+    /// online error path used to just re-enable the window, which stopped the batch dead at
+    /// that file with no item marked and no summary.
+    /// </summary>
+    private void FailCurrentOnlineSttJob()
+    {
+        if (IsBatchMode && !_abort)
+        {
+            if (_batchIndex >= 0 && _batchIndex < _jobItems.Count)
+            {
+                _jobItems[_batchIndex].Status = Se.Language.General.Error;
+            }
+
+            StartNext(null);
+            return;
+        }
+
+        IsTranscribeEnabled = true;
+    }
+
     [RelayCommand]
     private void Cancel()
     {
         if (!IsTranscribeEnabled)
         {
+            // Always set _abort, online engines included: during the audio-extraction phase
+            // _openAiCts does not exist yet (it is created once ffmpeg has exited), so
+            // cancelling did nothing at all and the upload started anyway. _abort is also
+            // what MakeResult checks to stop a whole batch rather than skip one item.
+            _abort = true;
             if (GetEffectiveSelectedEngine() is IOnlineSttEngine)
             {
                 _openAiCts?.Cancel();
-                return;
             }
-            _abort = true;
+
             return;
         }
 

--- a/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceMappingViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceMappingViewModel.cs
@@ -512,7 +512,8 @@ public partial class ActorVoiceMappingViewModel : ObservableObject
             .Where(m => !string.IsNullOrEmpty(m.EngineName) && !string.IsNullOrEmpty(m.VoiceName))
             .ToList();
 
-        Se.Settings.Video.TextToSpeech.LastActorVoiceMappings = MergeWithPersistedMappings(Mappings);
+        Se.Settings.Video.TextToSpeech.LastActorVoiceMappings =
+            MergeWithPersistedMappings(Mappings, Rows.Select(r => r.Actor));
         Se.SaveSettings();
 
         OkPressed = true;
@@ -522,13 +523,26 @@ public partial class ActorVoiceMappingViewModel : ObservableObject
     // Keep mappings for actors not in this subtitle so a user who jumps between projects keeps
     // their full cast remembered. New/updated rows from this dialog overwrite anything saved
     // under the same actor name.
-    private static List<ActorVoiceMapping> MergeWithPersistedMappings(List<ActorVoiceMapping> current)
+    private static List<ActorVoiceMapping> MergeWithPersistedMappings(
+        List<ActorVoiceMapping> current,
+        IEnumerable<string> actorsInDialog)
     {
         var previous = Se.Settings.Video.TextToSpeech.LastActorVoiceMappings ?? new List<ActorVoiceMapping>();
         var byActor = previous
             .Where(m => !string.IsNullOrWhiteSpace(m.Actor))
             .GroupBy(m => m.Actor.Trim(), StringComparer.OrdinalIgnoreCase)
             .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
+
+        // Drop every actor this dialog showed, then re-add the ones that ended up with a
+        // voice. Merging only by overwrite meant a row the user deliberately cleared (or
+        // "Clear all") kept its old saved entry and came back on the next session.
+        foreach (var actor in actorsInDialog)
+        {
+            if (!string.IsNullOrWhiteSpace(actor))
+            {
+                byActor.Remove(actor.Trim());
+            }
+        }
 
         foreach (var m in current)
         {

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -403,12 +403,16 @@ public partial class ReviewSpeechViewModel : ObservableObject
             {
                 Include = p.Include,
                 Number = p.Paragraph.Number,
-                Text = p.Text,
+                // The subtitle's own text, not the tag-stripped/unbroken copy that was fed to
+                // the engine: edits made here are published back to the main subtitle, so
+                // starting from the stripped copy silently dropped italics and line breaks
+                // from every line the user touched. Synthesis strips at the point of use.
+                Text = p.Paragraph.Text,
                 Voice = p.Voice == null ? string.Empty : p.Voice.ToString(),
                 Speed = Math.Round(p.SpeedFactor, 2).ToString(CultureInfo.CurrentCulture),
                 Cps = Math.Round(p.Paragraph.GetCharactersPerSecond(), 2).ToString(CultureInfo.CurrentCulture),
                 StepResult = p,
-                OriginalText = p.Text,
+                OriginalText = p.Paragraph.Text,
                 OriginalStartMs = p.Paragraph.StartTime.TotalMilliseconds,
                 OriginalEndMs = p.Paragraph.EndTime.TotalMilliseconds,
             };
@@ -1359,7 +1363,10 @@ public partial class ReviewSpeechViewModel : ObservableObject
             try
             {
                 var speakResult = await TtsInstructionSwap.RunAsync(engine, instruction, () =>
-                    engine.Speak(Utilities.UnbreakLine(line.Text), _waveFolder, voice, language, region, model, _cancellationToken));
+                    // Strip markup here the way the main generate path does - the row text is
+                    // the subtitle's own text, and engines vocalize "<i>" or garble on tags.
+                    engine.Speak(Utilities.UnbreakLine(HtmlUtil.RemoveHtmlTags(line.Text, alsoSsaTags: true)),
+                        _waveFolder, voice, language, region, model, _cancellationToken));
 
                 if (speakResult.Error || string.IsNullOrEmpty(speakResult.FileName) || !File.Exists(speakResult.FileName))
                 {

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -2982,11 +2982,17 @@ public partial class TextToSpeechViewModel : ObservableObject
     {
         try
         {
-            return await TtsInstructionSwap.RunAsync(
+            var result = await TtsInstructionSwap.RunAsync(
                 resolution.Engine,
                 resolution.Instruction,
                 () => resolution.Engine.Speak(resolution.Text, _waveFolder, resolution.Voice,
                     language, region, model, cancellationToken));
+
+            // The counter tracks failures *in a row*, so a line that succeeds first time
+            // clears it. Without this it accumulated over the whole run and retries were
+            // switched off permanently after the second failure, however far apart.
+            _speakRetryFailures = 0;
+            return result;
         }
         catch (OperationCanceledException)
         {
@@ -3009,7 +3015,7 @@ public partial class TextToSpeechViewModel : ObservableObject
                     resolution.Instruction,
                     () => resolution.Engine.Speak(resolution.Text, _waveFolder, resolution.Voice,
                         language, region, model, cancellationToken));
-                _speakRetryFailures = 0;
+                _speakRetryFailures = 0; // see the reset on first-attempt success below too
                 Se.WriteToolsLog("TTS generation: the segment succeeded on retry");
                 return retried;
             }
@@ -3126,7 +3132,9 @@ public partial class TextToSpeechViewModel : ObservableObject
             clipFolder,
             videoDurationSeconds,
             audioTrackFfIndex: -1,
-            progress: (done, total) => ProgressValue = total == 0 ? 0 : (double)done / total,
+            // The progress bar is 0-100, like every other stage reports (a raw 0-1 fraction
+            // left it pinned at 0 for the whole clip-cutting phase).
+            progress: (done, total) => ProgressValue = total == 0 ? 0 : (double)done / total * 100.0,
             cancellationToken);
 
         if (_perLineCloneClips.Count > 0)
@@ -3771,12 +3779,35 @@ public partial class TextToSpeechViewModel : ObservableObject
     // once enough progress exists for it not to jump around.
     private readonly Stopwatch _generateStopwatch = new();
 
+    // ProgressValue is driven 0->100 once per stage (generate, fix speed, post-process,
+    // merge), so the whole-run elapsed cannot be projected against it - that read "18:00
+    // left" seconds before finishing. Time each stage separately for the projection and
+    // keep the run stopwatch for the elapsed figure.
+    private readonly Stopwatch _stageStopwatch = new();
+    private double _lastProgressValue;
+
     partial void OnProgressValueChanged(double value)
     {
         if (!IsGenerating || value <= 0)
         {
+            _stageStopwatch.Restart(); // a stage boundary resets the bar to 0
+            _lastProgressValue = 0;
             return;
         }
+
+        // The import/merge path enters the generating state without starting the run
+        // stopwatch, which would otherwise still hold a previous run's elapsed.
+        if (!_generateStopwatch.IsRunning)
+        {
+            _generateStopwatch.Restart();
+        }
+
+        if (value < _lastProgressValue)
+        {
+            _stageStopwatch.Restart();
+        }
+
+        _lastProgressValue = value;
 
         ProgressPercentText = $"{Math.Clamp((int)Math.Round(value), 0, 100)}%";
 
@@ -3786,9 +3817,10 @@ public partial class TextToSpeechViewModel : ObservableObject
             return;
         }
 
-        if (value >= 3 && value <= 100)
+        var stageElapsed = _stageStopwatch.IsRunning ? _stageStopwatch.Elapsed : elapsed;
+        if (value >= 3 && value <= 100 && stageElapsed.TotalSeconds >= 1)
         {
-            var remaining = TimeSpan.FromSeconds(elapsed.TotalSeconds * (100 - value) / value);
+            var remaining = TimeSpan.FromSeconds(stageElapsed.TotalSeconds * (100 - value) / value);
             ProgressEtaText = string.Format(Se.Language.Video.TextToSpeech.XElapsedYLeft, FormatProgressDuration(elapsed), FormatProgressDuration(remaining));
         }
         else

--- a/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesViewModel.cs
+++ b/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesViewModel.cs
@@ -354,7 +354,7 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
                     MessageBoxButtons.OK,
                     MessageBoxIcon.Error);
 
-                IsGenerating = true;
+                IsGenerating = false;
                 ProgressValue = 0;
             });
 
@@ -414,6 +414,15 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
         var subtitle = !string.IsNullOrWhiteSpace(jobItem.SubtitleFileName) && File.Exists(jobItem.SubtitleFileName)
             ? Subtitle.Parse(jobItem.SubtitleFileName)
             : null;
+
+        // Apply the cut before measuring: the generated video's duration comes from
+        // TotalSeconds, so measuring the untrimmed subtitle produced a full-length file
+        // with the cut range's text bunched at the start.
+        if (subtitle != null)
+        {
+            subtitle = GetSubtitleBasedOnCut(subtitle);
+        }
+
         var totalMs = subtitle?.Paragraphs.Count > 0
             ? subtitle.Paragraphs.Max(p => p.EndTime.TotalMilliseconds) + 2000
             : 2000;
@@ -714,7 +723,9 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
     {
         var nameNoExt = Path.GetFileNameWithoutExtension(videoFileName);
         var ext = SelectedVideoExtension;
-        var suffix = Se.Settings.Video.BurnIn.BurnInSuffix;
+        // This dialog's own suffix ("_transparent"), which existed but was never read -
+        // transparent output was being named with burn-in's "_new".
+        var suffix = Se.Settings.Video.Transparent.OutputSuffix;
 
         // This dialog's own output folder, not burn-in's. The settings window has always written
         // Video.Transparent.OutputFolder / UseOutputFolder, but nothing read them - so whatever
@@ -852,7 +863,11 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
     [RelayCommand]
     private async Task OutputProperties()
     {
-        await _windowService.ShowDialogAsync<BurnInSettingsWindow, BurnInSettingsViewModel>(Window!);
+        // This dialog's own settings window, not burn-in's: it reads and writes
+        // Video.Transparent.*, which is what MakeOutputFileName below actually uses.
+        // Opening the burn-in one edited a store nothing here reads and silently changed
+        // the burn-in dialog's output folder instead.
+        await _windowService.ShowDialogAsync<TransparentSettingsWindow, TransparentSettingsViewModel>(Window!);
         UpdateOutputProperties();
     }
 
@@ -1003,7 +1018,10 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
         SelectedFontOutline = settings.OutlineWidth;
         SelectedFontShadowWidth = settings.ShadowWidth;
         SelectedFontSpacing = settings.NonAssaSpacing;
-        SelectedFontName = settings.FontName;
+        // Guard the fallback the way the constructor does: assigning a font that is not
+        // in FontNames nulls the ComboBox selection, and the TwoWay binding then writes
+        // that null back over the saved font name.
+        SelectedFontName = FontNames.FirstOrDefault(p => p == settings.FontName) ?? FontNames[0];
         FontTextColor = settings.NonAssaTextColor.FromHexToColor();
         FontOutlineColor = settings.NonAssaOutlineColor.FromHexToColor();
         FontBoxColor = settings.NonAssaBoxColor.FromHexToColor();
@@ -1145,19 +1163,19 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
 
     private void UpdateOutputProperties()
     {
-        // Use the BurnIn output-folder settings: the "Output properties" dialog
-        // (BurnInSettingsWindow) and MakeOutputFileName both read/write BurnIn.*,
-        // so the UI must read the same store or it would show a stale/empty folder.
-        if (Se.Settings.Video.BurnIn.UseOutputFolder &&
-            string.IsNullOrWhiteSpace(Se.Settings.Video.BurnIn.OutputFolder))
+        // This dialog's own output-folder settings: the settings window and
+        // MakeOutputFileName both read/write Video.Transparent.*, so the UI has to read
+        // the same store or it shows a folder that has no effect on the output.
+        if (Se.Settings.Video.Transparent.UseOutputFolder &&
+            string.IsNullOrWhiteSpace(Se.Settings.Video.Transparent.OutputFolder))
         {
             // Output-folder mode is on but no folder is configured - fall back to the source folder.
-            Se.Settings.Video.BurnIn.UseOutputFolder = false;
+            Se.Settings.Video.Transparent.UseOutputFolder = false;
         }
 
-        UseSourceFolderVisible = !Se.Settings.Video.BurnIn.UseOutputFolder;
-        UseOutputFolderVisible = Se.Settings.Video.BurnIn.UseOutputFolder;
-        OutputFolder = Se.Settings.Video.BurnIn.OutputFolder;
+        UseSourceFolderVisible = !Se.Settings.Video.Transparent.UseOutputFolder;
+        UseOutputFolderVisible = Se.Settings.Video.Transparent.UseOutputFolder;
+        OutputFolder = Se.Settings.Video.Transparent.OutputFolder;
     }
 
     public void BoxTypeChanged(object? sender, SelectionChangedEventArgs e)
@@ -1301,7 +1319,7 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
                 FontIsBold,
                 FontTextColor.ToSKColor(),
                 FontOutlineColor.ToSKColor(),
-                SKColors.Red,
+                FontShadowColor.ToSKColor(),
                 FontShadowColor.ToSKColor(),
                 (float)(SelectedFontOutline ?? 0),
                 0,


### PR DESCRIPTION
A second bug hunt, over areas the previous sweep ([#14152](https://github.com/SubtitleEdit/subtitleedit/pull/14152)) did not cover: a fresh sample of ~30 subtitle formats, the binary container/image decoders, speech-to-text, text-to-speech, burn-in/transparent video, image export + OCR, and the settings/shortcuts plumbing. All 45 findings were verified against the code before fixing; several were additionally reproduced against the built library.

## Subtitle formats
- **Chk**: every color branch set the pending close tag to `"<font>"` instead of `"</font>"`, so colored CHK subtitles ended with a stray unclosed tag.
- **AvidStl**: the guard tested `<= 128` (the whole record) instead of the 112-byte text field, so 113–128 byte text wrote an over-long record — and because the reader steps 128 bytes, **every following record was read off-by-N**. Verified: a 120-char line now yields a 128-byte record and the next cue reloads at its exact time.
- **RealTime**: the unit ladder used `parts.Length - 3`, making days = hours × 60. Verified: `1:00:00:00` now parses as 24 hours (was 60).
- **PListCaption / UnknownSubtitle19**: seconds were formatted with the current culture but parsed invariant, so on a comma-decimal locale 3.16 s was written `3,16` and read back as **316 s**. Verified under `LC_ALL=da_DK.UTF-8`: output stays `3.16`.
- **PListCaption**: a typo emitted `<plist version="1.0">;` — a stray text node in the plist root that real plist parsers reject.
- **SwiftText**: the DURATION field used `TimeSpan.Seconds` (0–59) rather than total seconds, and the reader prefers DURATION over TIMEOUT. Verified: a 65 s cue now writes `DURATION: 65:00` and round-trips exactly (previously came back as 5 s).

## Binary decoders
- **DVB bottom field**: with `bottom_field_data_block_length == 0` the loop bound evaluated to `start - 1` and never executed, so the bottom field was never decoded from the top field's data (EN 300 743 §7.2.5) and subtitles rendered as a half-height comb that OCRs badly.
- **DVB CLUT**: the loop demanded 6 bytes per entry, but a reduced-range entry is 4 — the last entry was dropped and its color id painted with the fallback red.
- **DVB transparency**: the 2-bit `T` of a reduced-range entry was used raw (0–3) while Y/Cr/Cb were scaled, so every such entry rendered opaque.
- **CD+G**: the bitmap declared `Rgba8888` while the loop packed ARGB, swapping red and blue in every frame. The VobSub/DVB decoders declare `Bgra8888` precisely to avoid this.
- **Matroska**: an unknown child of `ContentCompression` (CRC-32, Void — both written by real muxers) was skipped by the *parent's* size, desynchronising the track parse; and fixed-size lacing read one size byte per frame, though that mode has no size table, eating the front of the payload.
- **MXF**: the PNG-magic test read `buffer[0..3]` behind only a `DataSize < 500000` guard, which admits zero — a legal empty fill packet threw out of the whole parse.

## Speech to text
- **A setting nothing ever writes disabled two features**: both the word-highlight guard and the "Unknown argument" dialog keyed off `WhisperCustomCommandLineArguments`, which is only ever declared and read — SE 5 stores parameters per engine. So merge/split silently destroyed `--highlight_words` karaoke output, and a mistyped flag failed with no message at all. Both now use the effective engine's `CommandLineParameter`.
- Selecting an online STT engine nulled model + language and immediately persisted the empties, losing the remembered values permanently.
- **Cancel** set no abort flag for online engines: it did nothing during audio extraction (the CTS does not exist yet) and skipped one batch item instead of stopping the batch.
- Streaming responses with no segments synthesised a `0/0` segment, producing one cue holding the entire transcript at `00:00:00,000 --> 00:00:00,000` and suppressing the sentence-spreading fallback written for exactly that case.
- The SSE parser dispatched only on an `event:` line and ignored each payload's own `type`, discarding every event from servers that omit it.
- Online errors re-enabled the window without marking the item failed, stopping a batch dead at that file; they now fail just that item, like the ffmpeg path.

## Text to speech
- Per-line clone reported progress as a 0–1 fraction into a 0–100 bar (every other stage multiplies by 100).
- The ETA divided whole-run elapsed by a per-stage percentage, so later stages claimed wildly inflated remaining times; stages are now timed separately.
- `_speakRetryFailures` is documented as consecutive failures but only reset after a successful *retry*, so it accumulated across the run and retries switched off permanently partway through a long dub.
- **Review-window edits corrupted the subtitle**: rows were built from the tag-stripped, unbroken synthesis text, and OK published that back onto the subtitle — silently dropping italics and line breaks from every line the user touched. Rows now carry the subtitle's own text, and regeneration strips markup at the point of use (keeping #12757 fixed).
- Cast → "Clear all" left the persisted per-actor mappings in place, so deleted voices returned next session.

## Burn-in / transparent video
- **Transparent**: a failed generate set `IsGenerating = true` (the burn-in twin sets `false`), wedging every button including Cancel — only the window X got you out.
- **Transparent**: "Output properties" opened the *burn-in* settings window while output naming reads `Video.Transparent.*`; the dedicated, already-correct `TransparentSettingsWindow` was never opened, and the `_transparent` suffix was never read either.
- **Transparent**: `TotalSeconds` was measured before the cut was applied, so Cut produced a full-length ProRes file with the text bunched at the start.
- **Burn-in**: scroll effects received the UI resolution while `PlayResX/Y` came from the job, mis-placing text on batch items of another size.
- **Burn-in**: target file size and progress used the full duration even when only the cut range is encoded (a 100 MB request produced ~8 MB).
- **Burn-in**: the one-shot "prompt for ffmpeg params" flag was persisted, so plain Generate kept prompting forever with no UI to switch it off.
- **Embedded MKV**: the collision loop dropped the output-folder guard and built a bare relative name.
- **Transparent**: a leftover `SKColors.Red` sat in the shadow-color slot.
- Both dialogs: `LoadSettings` overwrote the constructor's guarded font fallback, so a missing font nulled the combo and the null was written back over the setting.

## Image export / OCR
- **BDN XML** hardcoded `border = 0`, so `LeftRightMargin` was never applied and `BottomTopMargin` only for bottom alignments — an `{\an1}` line exported at `X="0"`, glued to the frame edge. This is an SE4 regression; `ExportHandlerImscImage` copies the same mistake and is fixed too.
- **DOST** ignored the frame rate from the image parameters (always 23.976, whose fractional part also triggered the NTSC pull-down, so a 25 fps project's 00:00:10.000 cue was written `00:00:09:23`) and hardcoded `$DROP=30000`. The FCP handler carries a comment about fixing exactly this — Dost was missed.
- **The forced flag never reached export**: `ImageParameter.IsForced` is consumed by the BDN and Blu-ray sup writers but was set by no producer, so a forced-caption track exported as entirely non-forced.
- **Batch convert** passed the `-1 x -1` "unknown" screen size straight through (seven `IOcrSubtitle` sources report it), placing every event at large negative coordinates.
- **OcrFixEngine** read the name list *before* rebuilding it for the new language, so the word-split list was seeded from the previous language's names (or none at all on the first run).

## Settings / shortcuts
- **Export-all + import-all factory-reset every video setting**: export never wrote `Video`, but since every section self-initializes the file still contained a default `Video` block that import applied. Excluded sections are now written as `null`, which also fixes the import dialog's section detection — previously it could never disable a checkbox, so ticking "Rules" installed default rules and ticking "Shortcuts" wiped every binding.
- The "Syntax coloring" checkbox was bound to a property nothing read; it now carries the coloring fields.
- **Apply re-registered shortcuts without clearing**, and the lookup table keeps the first registration for a chord, so stale bindings kept winning after "Set up like Subtitle Edit 4" or a shortcut import (and the list doubled each Apply).
- **Options → Shortcuts: Configure survived Cancel** — the custom seek amounts and the go-to-first/last-line option were written straight into live settings; they now use dialog-local mirrors like the colors and actor names already did.
- `RecentFile.Encoding` was written on every update and never read anywhere, so Reopen lost the encoding the file was last opened with.

## Testing
- Full suite green: libse 1490, libuilogic 703, seconv 416, UI 4084 (1 skipped).
- One UI test (`BareAlt_ClosesTheMenu_WhileFocusIsInsideAnOpenDropDown`) failed on the first full run and passed both in isolation and on a full re-run — a flake, consistent with this repo's known flaky menu tests, not a regression from these changes.
- Functional checks re-run against the built binaries: SwiftText 65 s round-trip, PListCaption under a Danish locale, RealTime day factor, and AvidStl record alignment with a 120-char line.

Not fixed here: `Wsb.ToText` writes a text layout its own reader can never parse (save as WSB and reopen gives zero paragraphs). Making that round-trip means rewriting the writer to emit the binary form the reader expects, which is a larger change than the rest of this PR and is better done on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)