### PR TITLE
WSB: make it import-only instead of writing a file nothing can read

### DIFF
--- a/src/libse/SubtitleFormats/Wsb.cs
+++ b/src/libse/SubtitleFormats/Wsb.cs
@@ -1,7 +1,6 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
@@ -20,29 +19,25 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             return base.IsMine(lines, fileName);
         }
 
+        /// <summary>
+        /// WSB is import-only, like the other read-only formats here (DlDd, FTE, SPU image...).
+        /// </summary>
+        /// <remarks>
+        /// WSB records are binary: <see cref="LoadSubtitle"/> finds a cue by the "     10     "
+        /// separator after the text and the 16 timecode digits that sit immediately before the
+        /// 0x37 0x01 0x01 0x00 marker. The writer that used to live here emitted an unrelated
+        /// plain-text layout ("0001 : 00031522,...", "80 80 80", "C1Y00 &lt;text&gt;") which no WSB
+        /// tool reads and which this format's own reader parses as zero paragraphs - so saving
+        /// as WSB and reopening silently lost the whole subtitle. It was written that way in
+        /// 2011 and never matched the reader, in SE 4 either.
+        ///
+        /// Reconstructing a real WSB record needs the actual binary layout; emitting something
+        /// shaped only around the two anchors above would round-trip inside Subtitle Edit while
+        /// still being rejected by real WSB software, which is a worse failure than refusing.
+        /// </remarks>
         public override string ToText(Subtitle subtitle, string title)
         {
-            var sb = new StringBuilder();
-            int index = 0;
-            foreach (Paragraph p in subtitle.Paragraphs)
-            {
-                sb.AppendLine($"{index + 1:0000} : {EncodeTimeCode(p.StartTime)},{EncodeTimeCode(p.EndTime)},10");
-                sb.AppendLine("80 80 80");
-                foreach (string line in p.Text.SplitToLines())
-                {
-                    sb.AppendLine("C1Y00 " + line.Trim());
-                }
-
-                sb.AppendLine();
-                index++;
-            }
-            return sb.ToString();
-        }
-
-        private static string EncodeTimeCode(TimeCode time)
-        {
-            //00:03:15:22 (last is frame)
-            return $"{time.Hours:00}{time.Minutes:00}{time.Seconds:00}{MillisecondsToFramesMaxFrameRate(time.Milliseconds):00}";
+            throw new NotImplementedException("WSB is a read-only format in Subtitle Edit - it can be opened, but not saved.");
         }
 
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)


### PR DESCRIPTION
Follow-up to [#14156](https://github.com/SubtitleEdit/subtitleedit/pull/14156), which listed this as the one finding from the hunt I had deliberately left out.

## The bug

`Wsb.ToText` emits a plain-text layout:

```
0001 : 00031522,00031600,10
80 80 80
C1Y00 Hello
```

but `Wsb.LoadSubtitle` parses *binary* records — it locates a cue by the `"     10     "` separator that follows the text, and reads the 16 timecode digits sitting immediately before the `0x37 0x01 0x01 0x00` marker. The two have nothing to do with each other, so:

- **Saving as WSB and reopening loses the entire subtitle** — the reader finds zero paragraphs in Subtitle Edit's own output.
- `IsMine` returns false for it too, so SE does not even recognise the file it just wrote.
- No real WSB tool reads those files either.

Both halves have been this way since the format was added in 2011 (`6393fe1fb`), and SE 4 carries the identical writer, so it was written speculatively and never tested against the reader.

## Why not just fix the writer

Reconstructing a genuine WSB record needs the real binary layout. That is not documented in the repo, there is no sample file or test fixture, and it cannot be recovered from the reader's two heuristic anchors — those look like fragments someone picked out of a hex dump, not a record definition.

I could emit something shaped purely around those anchors, and it would round-trip inside Subtitle Edit. It would still be rejected by real WSB software, while now *looking* authoritative rather than obviously wrong. That is a worse failure than refusing, so I did not do it.

## What this does

`ToText` throws with an explanatory message, exactly like the other read-only formats in this folder (DlDd, FTE, HTML SAMI array, SPU image, and ~8 more). The message reaches the user on both paths I checked:

- the UI wraps saving in try/catch and shows the exception message in an error dialog, so this is a clean error rather than a crash;
- seconv prints it: `WSB is a read-only format in Subtitle Edit - it can be opened, but not saved`.

Opening WSB files is untouched.

## Testing

- libse 1490 passed, seconv 416 passed.
- Verified by hand: `seconv a.srt WSB` now reports the message above instead of silently writing an unreadable file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)