### PR TITLE
Fix RTL via Unicode: put the embedding around the sentence, and close it

### DIFF
--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -3654,12 +3654,134 @@ namespace Nikse.SubtitleEdit.Core.Common
             return sb.ToString().Replace("  ", " ").Replace(Environment.NewLine + " ", Environment.NewLine);
         }
 
+        private const char RightToLeftEmbedding = '\u202B';
+        private const char PopDirectionalFormatting = '\u202C';
+
+        /// <summary>
+        /// Puts each line in a right-to-left embedding, so what the line mixes in - numbers, a Latin
+        /// name, the full stop that ends the sentence - reads in the right order.
+        /// <para>
+        /// The embedding starts after the markup a line opens with and ends before the markup it
+        /// closes with. An ASSA override block or an HTML tag is not part of the sentence, and an
+        /// embedding started in front of one only moves the tag itself to the other end - which is
+        /// what "{\i1}text" looked like when reported (issue #14150).
+        /// </para>
+        /// <para>
+        /// Every embedding is closed with U+202C. An unterminated one is left for whatever the
+        /// renderer draws next to inherit, and re-running the fix used to stack another opening
+        /// character on top of the last one.
+        /// </para>
+        /// </summary>
         public static string FixRtlViaUnicodeChars(string input)
         {
-            string rtl = "\u202B";
-            var text = input.Replace(rtl, string.Empty);
-            text = rtl + text.Replace(Environment.NewLine, Environment.NewLine + rtl);
-            return text;
+            if (string.IsNullOrEmpty(input))
+            {
+                return input;
+            }
+
+            var text = input
+                .Replace(RightToLeftEmbedding.ToString(), string.Empty)
+                .Replace(PopDirectionalFormatting.ToString(), string.Empty);
+
+            var lines = text.SplitToLines();
+            var sb = new StringBuilder(text.Length + lines.Count * 2);
+            for (var i = 0; i < lines.Count; i++)
+            {
+                if (i > 0)
+                {
+                    sb.Append(Environment.NewLine);
+                }
+
+                var line = lines[i];
+                if (HasAssaDrawing(line))
+                {
+                    // A "{\p1}" line is coordinates, not a sentence - a directional mark dropped in
+                    // among the drawing commands is something libass has to parse as one of them.
+                    sb.Append(line);
+                    continue;
+                }
+
+                var start = GetTextStartAfterMarkup(line);
+                var end = GetTextEndBeforeMarkup(line, start);
+                if (end <= start)
+                {
+                    // Nothing but markup (an "{\an8}" on its own) - there is no sentence to embed,
+                    // and wrapping the tags would only give the renderer something to trip on.
+                    sb.Append(line);
+                    continue;
+                }
+
+                sb.Append(line, 0, start);
+                sb.Append(RightToLeftEmbedding);
+                sb.Append(line, start, end - start);
+                sb.Append(PopDirectionalFormatting);
+                sb.Append(line, end, line.Length - end);
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>Whether a line turns on vector drawing anywhere - "\p1".."\p9" inside an ASSA block.</summary>
+        private static bool HasAssaDrawing(string line)
+        {
+            var index = line.IndexOf('{');
+            while (index >= 0)
+            {
+                var close = line.IndexOf('}', index);
+                if (close < 0)
+                {
+                    return false;
+                }
+
+                for (var i = index; i < close - 2; i++)
+                {
+                    if (line[i] == '\\' && (line[i + 1] == 'p' || line[i + 1] == 'P') && line[i + 2] >= '1' && line[i + 2] <= '9')
+                    {
+                        return true;
+                    }
+                }
+
+                index = line.IndexOf('{', close);
+            }
+
+            return false;
+        }
+
+        /// <summary>Index of the first character after the ASSA blocks / HTML tags a line opens with.</summary>
+        private static int GetTextStartAfterMarkup(string line)
+        {
+            var index = 0;
+            while (index < line.Length)
+            {
+                var close = line[index] == '{' ? line.IndexOf('}', index) : line[index] == '<' ? line.IndexOf('>', index) : -1;
+                if (close < 0)
+                {
+                    break;
+                }
+
+                index = close + 1;
+            }
+
+            return index;
+        }
+
+        /// <summary>Index of the first character of the ASSA blocks / HTML tags a line closes with.</summary>
+        private static int GetTextEndBeforeMarkup(string line, int start)
+        {
+            var index = line.Length;
+            while (index > start)
+            {
+                var last = line[index - 1];
+                var open = last == '}' ? line.LastIndexOf('{', index - 1) : last == '>' ? line.LastIndexOf('<', index - 1) : -1;
+                if (open < start)
+                {
+                    break;
+                }
+
+                index = open;
+            }
+
+            return index;
         }
 
         private static readonly char[] UnicodeControlCharsAndNoBreakSpace = { '\u200E', '\u200F', '\u202A', '\u202B', '\u202C', '\u202D', '\u202E', '\u00A0' };

--- a/tests/libse/Common/UtilitiesFixRtlViaUnicodeCharsTest.cs
+++ b/tests/libse/Common/UtilitiesFixRtlViaUnicodeCharsTest.cs
@@ -1,0 +1,108 @@
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace LibSETests.Common;
+
+public class UtilitiesFixRtlViaUnicodeCharsTest
+{
+    private const string Rle = "‫"; // right-to-left embedding
+    private const string Pdf = "‬"; // pop directional formatting
+
+    private const string Arabic = "هذا صحيح.";
+
+    [Fact]
+    public void PlainLineIsEmbeddedAndClosed()
+    {
+        Assert.Equal(Rle + Arabic + Pdf, Utilities.FixRtlViaUnicodeChars(Arabic));
+    }
+
+    [Fact]
+    public void EmbeddingStartsAfterALeadingAssaBlock()
+    {
+        // A U+202B in front of "{\i1}" moves the tag itself to the other end instead of the text
+        // it marks up - the case reported in issue #14150.
+        Assert.Equal("{\\i1}" + Rle + Arabic + Pdf, Utilities.FixRtlViaUnicodeChars("{\\i1}" + Arabic));
+    }
+
+    [Fact]
+    public void EmbeddingStartsAfterEveryLeadingAssaBlock()
+    {
+        Assert.Equal(
+            "{\\an8}{\\pos(10,20)}" + Rle + Arabic + Pdf,
+            Utilities.FixRtlViaUnicodeChars("{\\an8}{\\pos(10,20)}" + Arabic));
+    }
+
+    [Fact]
+    public void HtmlTagsStayOutsideTheEmbedding()
+    {
+        Assert.Equal("<i>" + Rle + Arabic + Pdf + "</i>", Utilities.FixRtlViaUnicodeChars("<i>" + Arabic + "</i>"));
+    }
+
+    [Fact]
+    public void MarkupInsideTheLineIsLeftWhereItIs()
+    {
+        var text = "{\\i1}" + Arabic + "{\\i0} " + Arabic;
+        Assert.Equal("{\\i1}" + Rle + Arabic + "{\\i0} " + Arabic + Pdf, Utilities.FixRtlViaUnicodeChars(text));
+    }
+
+    [Fact]
+    public void EveryLineGetsItsOwnEmbedding()
+    {
+        var text = "{\\i1}" + Arabic + Environment.NewLine + Arabic;
+        Assert.Equal(
+            "{\\i1}" + Rle + Arabic + Pdf + Environment.NewLine + Rle + Arabic + Pdf,
+            Utilities.FixRtlViaUnicodeChars(text));
+    }
+
+    [Fact]
+    public void ALineOfNothingButMarkupIsLeftAlone()
+    {
+        Assert.Equal("{\\an8}", Utilities.FixRtlViaUnicodeChars("{\\an8}"));
+    }
+
+    [Theory]
+    [InlineData("{\\p1}m 0 0 l 100 0 100 100 0 100{\\p0}")]
+    [InlineData("{\\an8\\p4}m 0 0 l 10 10")]
+    public void ADrawingIsLeftAlone(string drawing)
+    {
+        // Coordinates are not a sentence, and a directional mark among the drawing commands is
+        // something libass has to parse as one of them.
+        Assert.Equal(drawing, Utilities.FixRtlViaUnicodeChars(drawing));
+    }
+
+    [Theory]
+    [InlineData("{\\pos(10,20)}")]
+    [InlineData("{\\pbo3}")]
+    [InlineData("{\\fsp4}")]
+    [InlineData("{\\p0}")]
+    public void TagsThatOnlyLookLikeADrawingStillGetTheEmbedding(string tag)
+    {
+        Assert.Equal(tag + Rle + Arabic + Pdf, Utilities.FixRtlViaUnicodeChars(tag + Arabic));
+    }
+
+    [Fact]
+    public void RunningItTwiceGivesTheSameText()
+    {
+        var once = Utilities.FixRtlViaUnicodeChars("{\\i1}" + Arabic);
+        Assert.Equal(once, Utilities.FixRtlViaUnicodeChars(once));
+    }
+
+    [Fact]
+    public void MarksLeftByTheOldOnePassVersionAreReplaced()
+    {
+        // Files fixed by an earlier Subtitle Edit carry an opening character in front of the tag
+        // and no closing one.
+        Assert.Equal("{\\i1}" + Rle + Arabic + Pdf, Utilities.FixRtlViaUnicodeChars(Rle + "{\\i1}" + Arabic));
+    }
+
+    [Fact]
+    public void EmptyTextIsUnchanged()
+    {
+        Assert.Equal(string.Empty, Utilities.FixRtlViaUnicodeChars(string.Empty));
+    }
+
+    [Fact]
+    public void AnUnclosedTagIsTreatedAsText()
+    {
+        Assert.Equal(Rle + "{not a block " + Arabic + Pdf, Utilities.FixRtlViaUnicodeChars("{not a block " + Arabic));
+    }
+}


### PR DESCRIPTION
Follow-up to #14150, split out of #14158 because it changes what "Fix RTL via Unicode" writes for everyone, not just the reporter.

`Utilities.FixRtlViaUnicodeChars` put a single U+202B at the start of every line and nothing else. Two consequences:

**The mark went in front of the markup.** For `{\i1}هذا صحيح.` the embedding took in the override block, so the tag itself moved to the other end — the reporter's *"fixes the squares but not the Unicode position"*. The embedding now starts after the markup a line opens with and ends before the markup it closes with, for ASSA blocks and HTML tags alike:

| in | out |
|---|---|
| `{\i1}TEXT` | `{\i1}` **‫** `TEXT` **‬** |
| `{\an8}{\pos(10,20)}TEXT` | `{\an8}{\pos(10,20)}` **‫** `TEXT` **‬** |
| `<i>TEXT</i>` | `<i>` **‫** `TEXT` **‬** `</i>` |

Markup *inside* the line stays where it is, inside the embedding.

**The embedding was never terminated.** An open U+202B is left for whatever the renderer draws next to inherit, and re-running the fix stacked another opening character on top of the last one. Each line now closes with U+202C, and both characters are stripped up front — so the fix is idempotent, and it cleans up after files the old one-pass version already touched.

Lines that turn on vector drawing (`\p1`..`\p9`) are skipped: coordinates are not a sentence, and a directional mark among the drawing commands is something libass has to parse as one of them. `\pos`, `\pbo`, `\fsp` and `\p0` are not drawings and still get the embedding.

This is the shared libse helper, so it covers the main window's Fix RTL, batch convert, burn-in, the mpv/VLC preview reloaders and `seconv --fix-rtl-via-unicode-chars`.

## Tests

`UtilitiesFixRtlViaUnicodeCharsTest` — 17 cases: plain line, leading ASSA block, several leading blocks, HTML tags, mid-line markup, multi-line, markup-only line, drawings, look-alike tags, idempotence, cleanup of the old marks, empty text, unclosed brace. Full libse suite 1507 passed, seconv 416 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)