### PR TITLE
Fix 30 bugs from a third five-area hunt

### DIFF
--- a/src/libse/Common/RegexUtils.cs
+++ b/src/libse/Common/RegexUtils.cs
@@ -291,7 +291,7 @@ namespace Nikse.SubtitleEdit.Core.Common
         /// \n left behind by the match normalization above was written as a physical newline
         /// inside the Dialogue line, corrupting the saved file on Windows (#12620).
         /// </summary>
-        private static string RestorePlatformNewLines(string text)
+        public static string RestorePlatformNewLines(string text)
         {
             if (Environment.NewLine == "\n" || text.IndexOf('\n') < 0)
             {

--- a/src/libse/Common/UUEncoding.cs
+++ b/src/libse/Common/UUEncoding.cs
@@ -50,10 +50,20 @@ namespace Nikse.SubtitleEdit.Core.Common
                 dest[2] += 33;
                 dest[3] += 33;
 
-                sb.Append(Encoding.ASCII.GetString(dest));
+                // The final group emits only as many characters as it carries data for -
+                // min(remaining + 1, 4), per the ASS/Aegisub convention that UUDecode below
+                // already implements. Always writing 4 made every embedded font/attachment
+                // 1-2 bytes longer than the original, decoding back with padding zeros.
+                var charsToWrite = 4;
+                if (i + 3 > length)
+                {
+                    charsToWrite = Math.Min(length - i + 1, 4);
+                }
 
-                lineElements += 4;
-                if (lineElements == 80)
+                sb.Append(Encoding.ASCII.GetString(dest, 0, charsToWrite));
+
+                lineElements += charsToWrite;
+                if (lineElements >= 80)
                 {
                     sb.AppendLine();
                     lineElements = 0;

--- a/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
+++ b/src/libse/SubtitleFormats/AdvancedSubStationAlpha.cs
@@ -286,7 +286,11 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                 // Appending directly skips AppendFormat's per-call format parsing, the object[10]
                 // and the boxed layer, plus the two intermediate time-code strings.
                 sb.Append(p.IsComment ? "Comment: " : "Dialogue: ");
-                sb.Append(p.Layer).Append(',');
+                // InvariantCulture: StringBuilder.Append(int) uses the current culture, and
+                // sv-SE/nb-NO/fi-FI/lt-LT render the negative sign as U+2212, which libass and
+                // VSFilter parse as layer 0 - breaking SE's own Layer = -1000 background boxes
+                // and Layer = -1 progress bars. Every other number on the line is already invariant.
+                sb.Append(p.Layer.ToString(CultureInfo.InvariantCulture)).Append(',');
                 AppendTimeCode(sb, p.StartTime).Append(',');
                 AppendTimeCode(sb, p.EndTime).Append(',');
                 sb.Append(style).Append(',');
@@ -2115,7 +2119,12 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                 }
             }
 
-            var p0Index = s.IndexOf("{\\p0}", StringComparison.Ordinal);
+            // The drawing can be closed by "\p0" inside a multi-tag block ("{\p0\fs20}"), not
+            // just by the literal "{\p0}" - searching only for the literal left p0Index at -1
+            // and the else branch below then truncated the whole rest of the line.
+            var p0Match = Regex.Match(s, @"\{[^}]*\\p0(?![0-9])[^}]*\}");
+            var p0Index = p0Match.Success ? p0Match.Index : -1;
+            var p0Length = p0Match.Success ? p0Match.Length : 0;
             if (p1Index > 0 && (p0Index > p1Index || p0Index == -1))
             {
                 var startTagIndex = s.Substring(0, p1Index).LastIndexOf('{');
@@ -2123,7 +2132,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
                 {
                     if (p0Index > p1Index)
                     {
-                        s = s.Remove(startTagIndex, p0Index - startTagIndex + "{\\p0}".Length);
+                        s = s.Remove(startTagIndex, p0Index - startTagIndex + p0Length);
                     }
                     else
                     {
@@ -2140,12 +2149,20 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
             int indexOfTag = s.IndexOf(@"\" + tag, StringComparison.Ordinal);
             if (indexOfTag > 0)
             {
-                var endIndex1 = s.IndexOf('\\', indexOfTag + 1);
-                var endIndex2 = s.IndexOf('}', indexOfTag + 1);
-                endIndex1 = Math.Min(endIndex1, endIndex2);
-                if (endIndex1 > 0)
+                // The tag ends at whichever comes first: the next tag in the block or the
+                // closing brace. -1 is IndexOf's "not found" sentinel, not a position, so
+                // Math.Min would pick it and the tag was never removed - which is the common
+                // case of a tag that is the only/last one in its block ("{\pos(1,2)}").
+                var nextTagIndex = s.IndexOf('\\', indexOfTag + 1);
+                var closingBraceIndex = s.IndexOf('}', indexOfTag + 1);
+                var endIndex = nextTagIndex < 0
+                    ? closingBraceIndex
+                    : closingBraceIndex < 0
+                        ? nextTagIndex
+                        : Math.Min(nextTagIndex, closingBraceIndex);
+                if (endIndex > 0)
                 {
-                    return s.Remove(indexOfTag, endIndex1 - indexOfTag);
+                    return s.Remove(indexOfTag, endIndex - indexOfTag);
                 }
             }
             return s;

--- a/src/libse/SubtitleFormats/SubStationAlpha.cs
+++ b/src/libse/SubtitleFormats/SubStationAlpha.cs
@@ -170,11 +170,11 @@ Format: Marked, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
                 var text = p.Text.Replace(Environment.NewLine, "\\N");
                 if (p.IsComment)
                 {
-                    sb.AppendLine(string.Format(commentWriteFormat, start, end, AdvancedSubStationAlpha.FormatText(text), style, p.Layer, actor, marginL, marginR, marginV, effect));
+                    sb.AppendLine(string.Format(commentWriteFormat, start, end, AdvancedSubStationAlpha.FormatText(text), style, p.Layer.ToString(CultureInfo.InvariantCulture), actor, marginL, marginR, marginV, effect));
                 }
                 else
                 {
-                    sb.AppendLine(string.Format(paragraphWriteFormat, start, end, AdvancedSubStationAlpha.FormatText(text), style, p.Layer, actor, marginL, marginR, marginV, effect));
+                    sb.AppendLine(string.Format(paragraphWriteFormat, start, end, AdvancedSubStationAlpha.FormatText(text), style, p.Layer.ToString(CultureInfo.InvariantCulture), actor, marginL, marginR, marginV, effect));
                 }
             }
 

--- a/src/libuilogic/SpellCheck/SpellCheckWordLists.cs
+++ b/src/libuilogic/SpellCheck/SpellCheckWordLists.cs
@@ -82,11 +82,17 @@ public class SpellCheckWordLists
             }
         }
 
+        // The two-letter file is read as well as the five-letter one: Utilities.AddToUserDictionary
+        // falls back to "<twoLetter>_user.xml" when the five-letter file does not exist, and
+        // Options > Word lists offers neutral cultures ("en"), so words genuinely land there.
+        // Reading only the five-letter name made those words invisible to the spell checker.
+        var twoLetterName = fiveLetterName.Length >= 2 ? fiveLetterName.Substring(0, 2).ToLowerInvariant() : fiveLetterName;
         var paths = new[]
         {
             Path.Combine(_dictionaryFolder, fiveLetterName + "_user.xml"),
             Path.Combine(_dictionaryFolder, fiveLetterName + "_se.xml"),
-        };
+            Path.Combine(_dictionaryFolder, twoLetterName + "_user.xml"),
+        }.Distinct().ToArray();
 
         var xmlDoc = new XmlDocument();
         foreach (var path in paths)
@@ -203,6 +209,15 @@ public class SpellCheckWordLists
         SaveUseAlwaysList(null, null, key);
     }
 
+    /// <summary>
+    /// Persists a "use always" (change-all) pair. Only the remove side was wired up, so the
+    /// list on disk could ever only shrink and a change-all never survived the session.
+    /// </summary>
+    public void UseAlwaysListAdd(string key, string value)
+    {
+        SaveUseAlwaysList(key, value);
+    }
+
     private void SaveUseAlwaysList(string? newKey = null, string? newValue = null, string? oldKey = null)
     {
         if (!Configuration.Settings.Tools.RememberUseAlwaysList)
@@ -249,10 +264,19 @@ public class SpellCheckWordLists
 
     public void RemoveName(string word)
     {
-        if (word == null || word.Length <= 1 || !_names.Contains(word))
+        // Multi-word names live in the name list's multi-word set, not in _names, so testing
+        // only _names made them impossible to remove at all.
+        if (word == null || word.Length <= 1 ||
+            (!_names.Contains(word) && !_nameList.GetMultiNames().Contains(word)))
         {
             return;
         }
+
+        // Persist first: NameList.GetNames() hands out its live set, so _names IS the name
+        // list's own collection. Removing from it here before delegating made NameList.Remove's
+        // "do I know this name?" guard fail, and the blacklist/XML write was skipped entirely -
+        // undoing "add to names list" changed nothing on disk.
+        _nameList.Remove(word);
 
         _names.Remove(word);
         _namesListUppercase.Remove(word.ToUpperInvariant());
@@ -270,8 +294,46 @@ public class SpellCheckWordLists
         {
             _namesListWithApostrophe.Remove(word + "'");
         }
+    }
 
-        _nameList.Remove(word);
+    /// <summary>
+    /// True when <paramref name="word"/> falls inside a user phrase occurring in
+    /// <paramref name="text"/>. The index-based overload needs the neighbouring words, which
+    /// the live spell-check path (underlines, grid context menu) does not have - so user
+    /// phrases were honoured only inside the spell-check window.
+    /// </summary>
+    public bool IsWordInUserPhrases(SpellCheckWord word, string text)
+    {
+        if (_userPhraseList.Count == 0 || string.IsNullOrEmpty(text) || word == null)
+        {
+            return false;
+        }
+
+        foreach (var userPhrase in _userPhraseList)
+        {
+            if (userPhrase.Length == 0)
+            {
+                continue;
+            }
+
+            var start = text.IndexOf(userPhrase, StringComparison.OrdinalIgnoreCase);
+            while (start >= 0)
+            {
+                if (word.Index >= start && word.Index + word.Length <= start + userPhrase.Length)
+                {
+                    return true;
+                }
+
+                if (start + 1 >= text.Length)
+                {
+                    break;
+                }
+
+                start = text.IndexOf(userPhrase, start + 1, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        return false;
     }
 
     public bool IsWordInUserPhrases(int index, List<SpellCheckWord> words)

--- a/src/libuilogic/SpellCheck/SpellChecker.cs
+++ b/src/libuilogic/SpellCheck/SpellChecker.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Text.RegularExpressions;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using WeCantSpell.Hunspell;
@@ -135,6 +135,16 @@ public class SpellChecker : ISpellChecker, IDoSpell
             {
                 SpellCheckConfig.LogError("Error loading names for SpellCheckManager: " + exception.Message);
                 WordLists = new SpellCheckWordLists(string.Empty, this);
+            }
+        }
+
+        // Apply the persisted "use always" pairs - they were loaded from
+        // <lang>_UseAlways.xml and then never consumed by anything.
+        if (WordLists != null)
+        {
+            foreach (var pair in WordLists.GetUseAlwaysList())
+            {
+                ChangeAllDictionary[pair.Key] = pair.Value;
             }
         }
 
@@ -331,6 +341,11 @@ public class SpellChecker : ISpellChecker, IDoSpell
         }
 
         if (WordLists != null && WordLists.HasUserWord(word))
+        {
+            return true;
+        }
+
+        if (WordLists != null && WordLists.IsWordInUserPhrases(spellCheckWord, text))
         {
             return true;
         }

--- a/src/libuilogic/Translate/MergeAndSplitHelper.cs
+++ b/src/libuilogic/Translate/MergeAndSplitHelper.cs
@@ -37,7 +37,11 @@ public static partial class MergeAndSplitHelper
         var noSentenceEndingTarget = IsNonMergeLanguage(target);
 
         var tempSubtitle = CreateTempSubtitle(rows);
-        var formattingList = HandleFormatting(tempSubtitle, index, target.Code);
+        // source.Code, not target.Code: HandleFormatting feeds this to PreTranslate (whose
+        // rules are guarded by source == "en") and to Formatting.SetTagsAndReturnTrimmed,
+        // which decides un-breaking from LanguagesAllowingLineMerging - both are properties
+        // of the text being sent, not of the language being requested.
+        var formattingList = HandleFormatting(tempSubtitle, index, source.Code);
         var maxChars = CalculateMaxChars(autoTranslator, forceSingleLineMode);
 
         var mergeResult = TryMergeLines(tempSubtitle, index, maxChars, ref noSentenceEndingSource, noSentenceEndingTarget);
@@ -88,6 +92,7 @@ public static partial class MergeAndSplitHelper
         {
             Number = p.Number,
             Show = p.Show,
+            Hide = p.Hide,
             Duration = p.Duration,
             Text = p.Text
         }).ToArray();
@@ -149,7 +154,9 @@ public static partial class MergeAndSplitHelper
         string mergedTranslation,
         Action<Action> applyRowUpdate)
     {
-        if (index < rows.Count && formattingList.Count > 0)
+        // An engine that returns nothing has not translated the line: reporting 1 reset the
+        // caller's no-progress counter, so the retry never fired and the row was left blank.
+        if (index < rows.Count && formattingList.Count > 0 && !string.IsNullOrWhiteSpace(mergedTranslation))
         {
             applyRowUpdate(() => rows[index].TranslatedText = formattingList[0].ReAddFormatting(mergedTranslation));
             return 1;

--- a/src/seconv/Core/LibSEIntegration.cs
+++ b/src/seconv/Core/LibSEIntegration.cs
@@ -456,7 +456,12 @@ internal static class LibSEIntegration
         // Strip native source-format markup that the target wouldn't understand
         if (sourceFormat != null && !sourceFormat.GetType().Equals(targetFormat.GetType()))
         {
-            targetFormat.RemoveNativeFormatting(subtitle, sourceFormat);
+            // The *source* format strips its own markup, taking the target as the argument -
+            // see SubtitleFormat.RemoveNativeFormatting(subtitle, newFormat) and every UI/batch
+            // caller. Swapped, this asked the target to strip the source's tags, which for a
+            // text target is a no-op: every ASSA override and drawing block survived into the
+            // converted file.
+            sourceFormat.RemoveNativeFormatting(subtitle, targetFormat);
         }
 
         var outputDir = Path.GetDirectoryName(filePath);

--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -317,6 +317,14 @@ public class AudioVisualizer : Control
             {
                 _shotChanges = _shotChanges.Select(sc => Math.Round(sc /= 1.001, 3, MidpointRounding.AwayFromZero)).ToList();
             }
+
+            // The spectrogram is drawn from StartPositionSeconds / SampleDuration, and
+            // StartPositionSeconds is now SMPTE-compressed - so compress the column duration
+            // to match, or the two panels drift ~3.6 s apart per hour.
+            if (_spectrogram != null)
+            {
+                _spectrogram.SampleDuration /= 1.001;
+            }
         }
     }
 

--- a/src/ui/Features/Assa/AssaSetBackground/AssSetBackgroundViewModel.cs
+++ b/src/ui/Features/Assa/AssaSetBackground/AssSetBackgroundViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media;
 using Avalonia.Threading;
@@ -8,6 +8,7 @@ using Nikse.SubtitleEdit.Controls.VideoPlayer;
 using Nikse.SubtitleEdit.Core.BluRaySup;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Assa.AssaSetPosition;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -188,6 +189,16 @@ public partial class AssSetBackgroundViewModel : ObservableObject
             _subtitle.Header = AdvancedSubStationAlpha.DefaultHeader;
         }
 
+        // The box drawing below is built from screenshot pixel coordinates on a
+        // _videoWidth x _videoHeight canvas, but libass reads \p drawing coordinates in script
+        // (PlayRes) space. Settle PlayRes once - stamping the video size when the header has
+        // none - and scale into it, the way AssaSetPositionViewModel does for \pos (#13350).
+        var (headerWithPlayRes, playResX, playResY) =
+            AssaSetPositionViewModel.EnsurePlayRes(_subtitle.Header, _videoWidth, _videoHeight);
+        _subtitle.Header = headerWithPlayRes;
+        var scaleX = _videoWidth > 0 ? (double)playResX / _videoWidth : 1.0;
+        var scaleY = _videoHeight > 0 ? (double)playResY / _videoHeight : 1.0;
+
         // Generate unique style name
         var boxStyleName = GenerateUniqueStyleName();
         var styleBoxBg = MakeBoxStyle(boxStyleName);
@@ -230,7 +241,11 @@ public partial class AssSetBackgroundViewModel : ObservableObject
                 var right = FillWidth ? (_videoWidth - FillWidthMarginRight) : (trimResult.Left + trimResult.TrimmedBitmap.Width + PaddingRight);
                 var top = trimResult.Top - PaddingTop;
                 var bottom = trimResult.Top + trimResult.TrimmedBitmap.Height + PaddingBottom;
-                var boxDrawing = GenerateBackgroundBox(left, right, top, bottom);
+                var boxDrawing = GenerateBackgroundBox(
+                    (int)Math.Round(left * scaleX, MidpointRounding.AwayFromZero),
+                    (int)Math.Round(right * scaleX, MidpointRounding.AwayFromZero),
+                    (int)Math.Round(top * scaleY, MidpointRounding.AwayFromZero),
+                    (int)Math.Round(bottom * scaleY, MidpointRounding.AwayFromZero));
                 var boxParagraph = MakeBoxParagraph(boxStyleName, p.StartTime.TotalMilliseconds, p.EndTime.TotalMilliseconds, boxDrawing);
 
                 lock (_addSubtitleLock)

--- a/src/ui/Features/Assa/StyleDisplay.cs
+++ b/src/ui/Features/Assa/StyleDisplay.cs
@@ -278,6 +278,7 @@ public partial class StyleDisplay : ObservableObject
             Italic = Italic,
             Bold = Bold,
             Strikeout = Strikeout,
+            Underline = Underline, // read in from both sources above, but never written back
             Primary = ColorPrimary.ToSKColor(),
             Secondary = ColorSecondary.ToSKColor(),
             Tertiary = ColorShadow.ToSKColor(),

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -6155,9 +6155,14 @@ public partial class MainViewModel :
             return;
         }
 
-        var total = Subtitles.Count;
+        // The column is the working subtitle's: a display-only reference row is not a cell,
+        // so it must neither give up its text nor receive a rotated one (the sibling column
+        // commands filter the same way). Rotating over raw Subtitles pulled reference text
+        // into working lines and wrote working text onto rows that are never saved.
+        var column = Subtitles.Where(p => !p.IsReferenceOnly).ToList();
+        var total = column.Count;
         var sel = selectedItems
-            .Select(x => Subtitles.IndexOf(x))
+            .Select(x => column.IndexOf(x))
             .Where(i => i >= 0 && i < total)
             .Distinct()
             .OrderBy(i => i)
@@ -6196,14 +6201,14 @@ public partial class MainViewModel :
                 continue;
             }
 
-            var temp = Subtitles[start - 1].Text;
+            var temp = column[start - 1].Text;
             // shift up
             for (int i = start - 1; i < end; i++)
             {
-                Subtitles[i].Text = Subtitles[i + 1].Text;
+                column[i].Text = column[i + 1].Text;
             }
 
-            Subtitles[end].Text = temp;
+            column[end].Text = temp;
         }
 
         _shortcutManager.ClearKeys();
@@ -6219,9 +6224,14 @@ public partial class MainViewModel :
             return;
         }
 
-        var total = Subtitles.Count;
+        // The column is the working subtitle's: a display-only reference row is not a cell,
+        // so it must neither give up its text nor receive a rotated one (the sibling column
+        // commands filter the same way). Rotating over raw Subtitles pulled reference text
+        // into working lines and wrote working text onto rows that are never saved.
+        var column = Subtitles.Where(p => !p.IsReferenceOnly).ToList();
+        var total = column.Count;
         var sel = selectedItems
-            .Select(x => Subtitles.IndexOf(x))
+            .Select(x => column.IndexOf(x))
             .Where(i => i >= 0 && i < total)
             .Distinct()
             .OrderBy(i => i)
@@ -6260,14 +6270,14 @@ public partial class MainViewModel :
                 continue;
             }
 
-            var temp = Subtitles[end + 1].Text;
+            var temp = column[end + 1].Text;
             // shift down
             for (int i = end + 1; i > start; i--)
             {
-                Subtitles[i].Text = Subtitles[i - 1].Text;
+                column[i].Text = column[i - 1].Text;
             }
 
-            Subtitles[start].Text = temp;
+            column[start].Text = temp;
         }
 
         _shortcutManager.ClearKeys();
@@ -10855,7 +10865,15 @@ public partial class MainViewModel :
             }
 
             Subtitles[i].OriginalText = Subtitles[i].Text;
-            Subtitles[i].Text = result.Rows[i].TranslatedText;
+
+            // Only rows that actually came back translated: OK is enabled as soon as a single
+            // row has a translation (translate-one-row, translate-from-here, or Cancel part way),
+            // so writing every row unconditionally blanked every line that was never sent.
+            // Same guard the translate-via-copy-paste and translate-selected-lines paths use.
+            if (!string.IsNullOrEmpty(result.Rows[i].TranslatedText))
+            {
+                Subtitles[i].Text = result.Rows[i].TranslatedText;
+            }
 
             // Whatever original this row pointed into is gone - the pre-translation text is the
             // original now.
@@ -14519,7 +14537,12 @@ public partial class MainViewModel :
                 }
 
                 var replaced = match.Result(fixedReplaceText);
-                newLine = normalizedLine.Substring(0, normalizedIndex) + replaced + normalizedLine.Substring(normalizedIndex + match.Length);
+                // The result is assembled from the \n-normalized copy, so restore the platform
+                // line endings before it goes back into the paragraph - otherwise a single-step
+                // regex replace silently rewrote every \r\n in the line to a bare \n (Replace
+                // all does this via RegexUtils.ReplaceNewLineSafe).
+                newLine = RegexUtils.RestorePlatformNewLines(
+                    normalizedLine.Substring(0, normalizedIndex) + replaced + normalizedLine.Substring(normalizedIndex + match.Length));
                 return replaced.Length;
             }
             catch (Exception exception) when (exception is ArgumentException or RegexMatchTimeoutException)
@@ -23377,7 +23400,10 @@ public partial class MainViewModel :
                 {
                     WaveformGeneratingText = Se.Language.Main.GeneratingSpectrogramDotDotDot;
                     var spectrogram = waveFile.GenerateSpectrogram(0, spectrogramFolderName, _videoOpenTokenSource.Token);
-                    AudioVisualizer?.SetSpectrogram(spectrogram);
+                    // On the UI thread: SetSpectrogram synchronously disposes the SKBitmaps
+                    // DrawSpectrogram is handing to Skia, and this method runs on the
+                    // extraction worker (everything else here marshals the same way).
+                    Dispatcher.UIThread.Post(() => AudioVisualizer?.SetSpectrogram(spectrogram));
 
                     if (WasCancelled())
                     {
@@ -23732,6 +23758,10 @@ public partial class MainViewModel :
                 // The teletext dialog edits MarginV and nothing else, so without it here that
                 // edit is invisible to undo and to the modified/save tracking below.
                 hash = hash * 23 + (p.MarginV?.GetHashCode() ?? 0);
+                // Bookmarks are compared by DetectContentChanges, so they have to move the hash
+                // too - otherwise bookmarking alone records no snapshot and the bookmark gets
+                // baked into the next unrelated edit's entry, where one undo removes both.
+                hash = hash * 23 + (p.Bookmark?.GetHashCode() ?? 0);
             }
 
             return hash;

--- a/src/ui/Features/Options/WordLists/WordListsViewModel.cs
+++ b/src/ui/Features/Options/WordLists/WordListsViewModel.cs
@@ -193,7 +193,10 @@ public partial class WordListsViewModel : ObservableObject
             return;
         }
 
-        if (Names.Contains(word) || !SaveUserWord(SelectedLanguage, word))
+        // UserWords, not Names: this guard was copy-pasted from AddName, so a word that merely
+        // happened to be in the names list could never be added as a user word - and because ||
+        // short-circuits, SaveUserWord was never even called.
+        if (UserWords.Contains(word) || !SaveUserWord(SelectedLanguage, word))
         {
             await MessageBox.Show(Window, Se.Language.General.Error, Se.Language.Options.WordLists.UnableToAddItem, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return;

--- a/src/ui/Features/SpellCheck/SpellCheckManager.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckManager.cs
@@ -1,4 +1,4 @@
-using Nikse.SubtitleEdit.Features.Main;
+﻿using Nikse.SubtitleEdit.Features.Main;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -118,6 +118,9 @@ public class SpellCheckManager : SpellChecker, ISpellCheckManager
         if (!ChangeAllDictionary.ContainsKey(fromWord))
         {
             ChangeAllDictionary.Add(fromWord, toWord);
+            // Mirror of RemoveChangeAllWord's UseAlwaysListRemove - without this the pair
+            // lived for the session only and the on-disk list could never grow.
+            WordLists?.UseAlwaysListAdd(fromWord, toWord);
         }
 
         ChangeWord(fromWord, toWord, spellCheckWord, p);

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -3295,7 +3295,7 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
             AutoTranslateModel = string.Empty;
             AutoTranslateModelBrowseIsVisible = false;
             AutoTranslateModelIsVisible = false;
-            AutoTranslateUrl = Se.Settings.AutoTranslate.NnlbServeUrl;
+            AutoTranslateUrl = Se.Settings.AutoTranslate.NllbServeUrl;
             AutoTranslateUrlIsVisible = true;
             AutoTranslateApiKey = string.Empty;
             AutoTranslateApiKeyIsVisible = false;

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -2995,7 +2995,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
 
         Configuration.Settings.Tools.AutoTranslateNllbApiUrl = Se.Settings.AutoTranslate.NllbApiUrl;
 
-        Configuration.Settings.Tools.AutoTranslateNllbServeUrl = Se.Settings.AutoTranslate.NnlbServeUrl;
+        Configuration.Settings.Tools.AutoTranslateNllbServeUrl = Se.Settings.AutoTranslate.NllbServeUrl;
 
         Configuration.Settings.Tools.AutoTranslateCrispAsrExe = Se.Settings.AutoTranslate.CrispAsrExe;
         Configuration.Settings.Tools.AutoTranslateCrispAsrModel = Se.Settings.AutoTranslate.CrispAsrModel;
@@ -3033,7 +3033,12 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
 
         for (var i = 0; i < subtitle.Paragraphs.Count && i < translatedSubtitle.Count; i++)
         {
-            subtitle.Paragraphs[i].Text = translatedSubtitle[i].TranslatedText;
+            // A row the engine never returned text for keeps its source text rather than
+            // being blanked - an engine failure part way through must not empty the rest.
+            if (!string.IsNullOrEmpty(translatedSubtitle[i].TranslatedText))
+            {
+                subtitle.Paragraphs[i].Text = translatedSubtitle[i].TranslatedText;
+            }
         }
 
         return subtitle;

--- a/src/ui/Features/Translate/TranslateSettingsViewModel.cs
+++ b/src/ui/Features/Translate/TranslateSettingsViewModel.cs
@@ -115,6 +115,10 @@ public partial class TranslateSettingsViewModel : ObservableObject
         Se.Settings.AutoTranslate.RequestDelaySeconds = ServerDelaySeconds ?? 0;
         Configuration.Settings.Tools.AutoTranslateDelaySeconds = (int)Math.Round(ServerDelaySeconds ?? 0, MidpointRounding.AwayFromZero);
         Se.Settings.AutoTranslate.RequestMaxBytes = MaxBytesRequest ?? 0;
+        // Mirror into the libse setting too, the way the delay above is: MergeAndSplitHelper
+        // reads only Configuration.Settings.Tools.AutoTranslateMaxBytes, so without this the
+        // value was persisted and redisplayed but never actually capped a request.
+        Configuration.Settings.Tools.AutoTranslateMaxBytes = MaxBytesRequest ?? 0;
         Se.Settings.AutoTranslate.EngineStrategies[AutoTranslator.Name] =
             SelectedMergeOptions == Se.Language.Translate.TranslateEachLineSeparately
                 ? nameof(TranslateStrategy.TranslateEachLineSeparately)

--- a/src/ui/Logic/AutoBackupService.cs
+++ b/src/ui/Logic/AutoBackupService.cs
@@ -1,4 +1,4 @@
-using Avalonia.Threading;
+﻿using Avalonia.Threading;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Features.Main;
@@ -121,14 +121,36 @@ public partial class AutoBackupService : IAutoBackupService
 
         var fileName = Path.Combine(folder,
             $"{DateTime.Now.Year:0000}-{DateTime.Now.Month:00}-{DateTime.Now.Day:00}_{DateTime.Now.Hour:00}-{DateTime.Now.Minute:00}-{DateTime.Now.Second:00}{title}{saveFormat.Extension}");
+        // IsTextBased only rules out binary formats; the read-only text formats (WSB, FTE,
+        // DlDd, SPU image...) are "text based" but their ToText throws, and the catch below
+        // then swallowed it - leaving the user with auto-backup silently doing nothing.
+        var format = saveFormat.IsTextBased ? saveFormat : new SubRip();
+        string text;
         try
         {
-            var format = saveFormat.IsTextBased ? saveFormat : new SubRip();
-            File.WriteAllText(fileName, format.ToText(subtitle, string.Empty));
+            text = format.ToText(subtitle, string.Empty);
         }
         catch
         {
-            // ignore
+            try
+            {
+                format = new SubRip();
+                fileName = Path.ChangeExtension(fileName, format.Extension);
+                text = format.ToText(subtitle, string.Empty);
+            }
+            catch
+            {
+                return;
+            }
+        }
+
+        try
+        {
+            File.WriteAllText(fileName, text);
+        }
+        catch
+        {
+            // ignore - a backup that cannot be written must not disturb editing
         }
     }
 

--- a/src/ui/Logic/CasingToggler.cs
+++ b/src/ui/Logic/CasingToggler.cs
@@ -96,7 +96,11 @@ namespace Nikse.SubtitleEdit.Logic
                                || input[index + 1] == 'n'
                                || input[index + 1] == 'h'))
                 {
-                    tags.Add(new KeyValuePair<int, string>(index, input.Substring(index, 2)));
+                    // sb.Length, not index: every other tag records its position in the
+                    // stripped text, and RestoreSavedAndRemovedTags inserts into that text.
+                    // Using the raw input offset pushed the break past the end whenever a tag
+                    // preceded it, so "{\an8}Hello\NWorld" came back as "{\an8}HELLOWORLD\N".
+                    tags.Add(new KeyValuePair<int, string>(sb.Length, input.Substring(index, 2)));
                     skipNext = true;
                     continue;
                 }

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -776,6 +776,10 @@ public class Se
 
 
         Configuration.Settings.Tools.AutoTranslateDelaySeconds = (int)Math.Round(Settings.AutoTranslate.RequestDelaySeconds, MidpointRounding.AwayFromZero);
+        if (Settings.AutoTranslate.RequestMaxBytes > 0)
+        {
+            Configuration.Settings.Tools.AutoTranslateMaxBytes = (int)Math.Round(Settings.AutoTranslate.RequestMaxBytes, MidpointRounding.AwayFromZero);
+        }
 
         // BeautifyTimeCodes profile: skip apply on a fresh install so libse's built-in
         // default-preset values stay intact. Once the user clicks OK in the profile editor,

--- a/src/ui/Logic/Config/SeAutoTranslate.cs
+++ b/src/ui/Logic/Config/SeAutoTranslate.cs
@@ -62,7 +62,6 @@ public class SeAutoTranslate
     public string OpenRouterPrompt { get; set; }
     public string OpenRouterApiKey { get; set; }
     public string OpenRouterModel { get; set; }
-    public string NnlbServeUrl { get; set; }
     public string LibreTranslateApiKey { get; set; }
     public string LibreTranslateUrl { get; set; }
     public string DeepLApiKey { get; set; }
@@ -189,8 +188,6 @@ public class SeAutoTranslate
         NllbApiUrl = "http://localhost:7860/api/v4/";
         NllbServeModel = string.Empty;
         NllbServeUrl = "http://127.0.0.1:6060/";
-        NnlbServeUrl = "http://127.0.0.1:6060/";
-        NnlbServeUrl = string.Empty;
         OllamaModel = string.Empty;
         OllamaModels = "llama3.2,llama3.2:1b,phi3,gemma2,qwen2,mistral";
         OllamaPrompt = "Translate from {0} to {1}, keep punctuation as input, do not censor the translation, give only the output without comments or notes:";

--- a/src/ui/Logic/FindService.cs
+++ b/src/ui/Logic/FindService.cs
@@ -594,7 +594,7 @@ public partial class FindService : IFindService
                 var beforePart = line.Substring(0, startIndex);
                 var afterPart = line.Substring(startIndex);
 
-                var newAfterPart = regex.Replace(afterPart, replaceText, 1);
+                var newAfterPart = regex.Replace(afterPart, EscapeReplacement(replaceText), 1);
                 var totalReplacements = newAfterPart != afterPart ? 1 : 0;
 
                 return (totalReplacements > 0, beforePart + newAfterPart, totalReplacements);
@@ -603,8 +603,8 @@ public partial class FindService : IFindService
             {
                 // Replace all or limited occurrences
                 var newText = maxReplacements == -1
-                    ? regex.Replace(line, replaceText)
-                    : regex.Replace(line, replaceText, maxReplacements);
+                    ? regex.Replace(line, EscapeReplacement(replaceText))
+                    : regex.Replace(line, EscapeReplacement(replaceText), maxReplacements);
 
                 var totalReplacements = regex.Matches(line).Count;
                 if (maxReplacements != -1 && totalReplacements > maxReplacements)
@@ -621,6 +621,17 @@ public partial class FindService : IFindService
         }
     }
 
+    /// <summary>
+    /// Escapes a user-supplied replacement so Regex.Replace inserts it literally. Whole-word
+    /// replace goes through a regex while plain replace splices the string in, so without this
+    /// ticking "whole word" silently changed the meaning of the *replacement* field too - "$$"
+    /// collapsed to "$", and "${x}" threw into a swallowed catch, quietly replacing nothing.
+    /// </summary>
+    private static string EscapeReplacement(string replaceText)
+    {
+        return string.IsNullOrEmpty(replaceText) ? replaceText : replaceText.Replace("$", "$$");
+    }
+
     private (bool found, int index, string foundText) FindWithStringComparison(string line, string searchText, StringComparison comparison, int startIndex)
     {
         var searchLine = startIndex > 0 ? line.Substring(startIndex) : line;
@@ -632,10 +643,14 @@ public partial class FindService : IFindService
 
             try
             {
-                var match = GetCachedRegex(pattern, options).Match(searchLine);
+                // Match the whole line from an offset rather than a slice of it: slicing
+                // manufactures a word boundary at position 0, so resuming from a caret inside
+                // a word matched that word's tail ("cat" inside "Bobcat") - while Count, which
+                // evaluates the same pattern against the full line, reported no match.
+                var match = GetCachedRegex(pattern, options).Match(line, Math.Min(startIndex, line.Length));
                 if (match.Success)
                 {
-                    return (true, startIndex + match.Index, match.Value);
+                    return (true, match.Index, match.Value);
                 }
             }
             catch (Exception exception) when (exception is ArgumentException or RegexMatchTimeoutException)
@@ -666,11 +681,24 @@ public partial class FindService : IFindService
 
             try
             {
-                var matches = GetCachedRegex(pattern, options).Matches(searchLine);
-                if (matches.Count > 0)
+                // Match the full line and take the last hit at or before the caret: truncating
+                // the line fabricates a trailing word boundary, so a caret after "cat" inside
+                // "cathedral" matched it as a whole word.
+                var matches = GetCachedRegex(pattern, options).Matches(line);
+                Match? lastBefore = null;
+                foreach (Match m in matches)
                 {
-                    var lastMatch = matches[matches.Count - 1];
-                    return (true, lastMatch.Index, lastMatch.Value);
+                    if (m.Index > startIndex)
+                    {
+                        break;
+                    }
+
+                    lastBefore = m;
+                }
+
+                if (lastBefore != null)
+                {
+                    return (true, lastBefore.Index, lastBefore.Value);
                 }
             }
             catch (Exception exception) when (exception is ArgumentException or RegexMatchTimeoutException)
@@ -694,6 +722,9 @@ public partial class FindService : IFindService
     {
         try
         {
+            // The line is sliced at the caret on purpose: "^" then re-anchors at the resume
+            // point, which is what lets a "(^|\n).{38,}($|\n)"-style pattern find the second
+            // line of a paragraph in full (see FindServiceTests.RegexOverlappingNewlineBoundary).
             var searchLine = startIndex > 0 ? line.Substring(startIndex) : line;
             var originalLength = searchLine.Length;
             searchLine = NormalizeLineEndingsForRegex(searchLine, out var indexMap);
@@ -716,6 +747,8 @@ public partial class FindService : IFindService
     {
         try
         {
+            // Truncated at the caret on purpose, mirroring FindWithRegex: "$" then anchors at
+            // the resume point so the search walks backwards line by line.
             var searchLine = line.Substring(0, Math.Min(startIndex + 1, line.Length));
             var originalLength = searchLine.Length;
             searchLine = NormalizeLineEndingsForRegex(searchLine, out var indexMap);

--- a/src/ui/Logic/Media/WaveToVisualizer2.cs
+++ b/src/ui/Logic/Media/WaveToVisualizer2.cs
@@ -396,7 +396,12 @@ public class SpectrogramData2 : IDisposable
 
     public int ImageWidth { get; private set; }
 
-    public double SampleDuration { get; private set; }
+    /// <summary>
+    /// Seconds of audio per spectrogram column. Settable so SMPTE drop-frame mode can
+    /// compress it by 1.001 in step with the wave peaks - otherwise the two panels share
+    /// an X axis but not a time base and drift apart.
+    /// </summary>
+    public double SampleDuration { get; set; }
 
     public IList<SKBitmap> Images { get; private set; }
 
@@ -448,7 +453,7 @@ public class SpectrogramData2 : IDisposable
         SampleDuration = br.ReadDouble();
 
         // Read raw samples
-        var sampleCount = (int)((fs.Length - 20) / sizeof(float)); // 20 bytes = 3 ints (12 bytes) + 1 double (8 bytes)
+        var sampleCount = (int)((fs.Length - 16) / sizeof(float)); // 16 bytes = 2 ints (8 bytes) + 1 double (8 bytes), matching SaveToBinaryFile
         _rawSamples = new float[sampleCount];
 
         var byteSpan = MemoryMarshal.AsBytes(_rawSamples.AsSpan());
@@ -1320,17 +1325,30 @@ public class WavePeakGenerator2 : IDisposable
 
             var hash = MovieHasher.GenerateHash(videoFileName);
 
-            var files = Directory.GetFiles(dir, $"{hash}-*.spectrogram")
-                .OrderBy(p => p)
-                .ToList();
-            if (files.Count > 0 && trackNumber < 0)
+            if (trackNumber < 0)
             {
-                return files[0];
+                // Same preference order as GetPeakWaveFileName: the untracked file first, then
+                // the first per-track one. Preferring the glob here while the peak resolver
+                // preferred the bare file meant the two panels could show different audio
+                // tracks of the same video.
+                var bare = Path.Combine(dir, $"{hash}.spectrogram");
+                if (File.Exists(bare) || Directory.Exists(bare))
+                {
+                    return bare;
+                }
+
+                var files = Directory.GetFiles(dir, $"{hash}-*.spectrogram")
+                    .OrderBy(p => p)
+                    .ToList();
+                if (files.Count > 0)
+                {
+                    return files[0];
+                }
+
+                return bare;
             }
 
-            var spectrogramFileName = trackNumber >= 0 ? $"{hash}-{trackNumber}.spectrogram" : $"{hash}.spectrogram";
-
-            return Path.Combine(dir, spectrogramFileName);
+            return Path.Combine(dir, $"{hash}-{trackNumber}.spectrogram");
         }
 
         public SpectrogramDrawer(int nfft, SKColor[] palette)

--- a/src/ui/Logic/UndoRedo/UndoRedoManager.cs
+++ b/src/ui/Logic/UndoRedo/UndoRedoManager.cs
@@ -395,6 +395,7 @@ public sealed class UndoRedoManager : IUndoRedoManager
                 o.Extra != n.Extra ||
                 o.Actor != n.Actor ||
                 o.Layer != n.Layer ||
+                o.MarginV != n.MarginV ||
                 o.Number != n.Number;
 
             if (!textChanged && !timingChanged && !bookmarkChanged && !metadataChanged)

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -1,4 +1,4 @@
-using Nikse.SubtitleEdit.Core.Common;
+﻿using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Download;
 using System;
@@ -2061,6 +2061,12 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         {
             return;
         }
+
+        // Every other state transition clears this (LoadFile/PlayOrPause/CloseFile/Stop/Play/
+        // frame steps). Without it, pausing after a seek made during playback made the Position
+        // getter keep returning that old seek target, so the slider, clock and playhead all
+        // jumped back to it.
+        _pausedValue = null;
 
         var err = DoMpvCommand("set", "pause", "yes");
         if (err < 0)

--- a/tests/UI/Logic/CasingAndUuEncodingRegressionTests.cs
+++ b/tests/UI/Logic/CasingAndUuEncodingRegressionTests.cs
@@ -1,0 +1,36 @@
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Logic;
+using Xunit;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// Regressions for two silent-corruption bugs: toggle casing moved an ASSA line break to the
+/// end of the line, and UUEncode always wrote 4 characters for the final group so every
+/// embedded attachment grew by 1-2 bytes.
+/// </summary>
+public class CasingAndUuEncodingRegressionTests
+{
+    [Fact]
+    public void CasingKeepsAssaLineBreakInPlace()
+    {
+        var toggler = new CasingToggler();
+        var format = new AdvancedSubStationAlpha();
+        Assert.Equal(@"{\an8}HELLO\NWORLD", toggler.ToggleCasing(@"{\an8}Hello\NWorld", format));
+        Assert.Equal(@"HELLO\NWORLD", toggler.ToggleCasing(@"Hello\NWorld", format));
+    }
+
+    [Fact]
+    public void UuEncodeRoundTripsExactLength()
+    {
+        foreach (var len in new[] { 1, 2, 3, 4, 5, 6, 7 })
+        {
+            var input = new byte[len];
+            for (var i = 0; i < len; i++) { input[i] = (byte)(i + 1); }
+            var decoded = Nikse.SubtitleEdit.Core.Common.UUEncoding.UUDecode(
+                Nikse.SubtitleEdit.Core.Common.UUEncoding.UUEncode(input));
+            Assert.Equal(len, decoded.Length);
+            Assert.Equal(input, decoded);
+        }
+    }
+}


### PR DESCRIPTION
Third bug hunt, over ground the previous two ([#14152](https://github.com/SubtitleEdit/subtitleedit/pull/14152), [#14156](https://github.com/SubtitleEdit/subtitleedit/pull/14156)) did not touch: auto-translate, ASSA/SSA styling, spell check and dictionaries, find/replace + undo + column commands, and the video player / audio plumbing. Every finding was verified against the code before fixing; several were reproduced by running the built binaries.

## ASSA/SSA and format writers

- **seconv stripped native formatting backwards** — [LibSEIntegration.cs:459](src/seconv/Core/LibSEIntegration.cs:459) called `targetFormat.RemoveNativeFormatting(subtitle, sourceFormat)`; the contract (`RemoveNativeFormatting(subtitle, newFormat)`) and every UI/batch caller are the other way round, so for a text target the call was a no-op. Verified before: `seconv t.ass subrip` produced an .srt containing `{\pos(100,200)}Hello world` and `{\p1}m 0 0 l 10 0 10 10{\p0}Drawing here` verbatim. Verified after: `Hello world` and `Drawing here`.
- **`RemoveTag` never removed a tag that is last in its block** — `Math.Min(endIndex1, endIndex2)` where `-1` is `IndexOf`'s not-found sentinel, so the result went negative and the guard below rejected it. This disabled all fourteen `RemoveTag` calls in `RemoveNativeFormatting` for the common single-tag case (`{\pos(1,2)}`).
- **`RemoveDrawingTag` truncated the line** when the drawing was closed by a multi-tag block (`{\p0\fs20}`): it searched the literal `"{\p0}"`, missed, and fell into `s.Remove(startTagIndex)`.
- **The style editor dropped Underline on every save** — `StyleDisplay` reads `Underline` in from both sources but `ToSsaStyle()` copied `Strikeout` and never `Underline`.
- **`UUEncode` always emitted four characters for the final group** instead of `min(remaining + 1, 4)`, so every embedded font or attachment was written 1–2 bytes longer and decoded back with padding zeros. Covered by a new round-trip test for lengths 1–7.
- **Negative `Layer` was written with the culture's negative sign** — sv-SE/nb-NO/fi-FI/lt-LT use U+2212, which libass and VSFilter parse as layer 0, so SE's own `Layer = -1000` background boxes and `Layer = -1` progress bars stopped rendering behind the text. Every other number on the Dialogue line was already invariant.
- **"Set background box" emitted `\p` coordinates in video-pixel space** while libass reads them in PlayRes space. PlayRes is now settled once (stamping the video size when the header has none) and the coordinates scaled into it — the same fix `AssaSetPositionViewModel` got for `\pos` in #13350.

## Auto-translate

- **Pressing OK after a partial translate blanked every untranslated line.** The merge-back wrote `Text = result.Rows[i].TranslatedText` for every row, while OK is enabled as soon as *one* row has a translation — so "translate this row", "translate from here", or Cancel part way through emptied everything else. Now guarded the way the translate-via-copy-paste and translate-selected-lines paths already are; batch convert had the same unguarded write.
- **`CreateTempSubtitle` never copied `Hide`**, so continuous-line merging, the duration-proportion split and the CPS score all ran against a zero end time. An SE4 port regression.
- **Batch convert read a typo'd `NnlbServeUrl`** — a property that was assigned a URL and then overwritten with `string.Empty` on the very next line, so nllb-serve batch translation threw on `new Uri("")`. Removed the dead property.
- **"Max bytes per request" never took effect** — persisted to `RequestMaxBytes`, but the merge helper reads `Configuration.Settings.Tools.AutoTranslateMaxBytes`, which nothing assigned.
- **An empty engine reply counted as a translated line**, so retry-on-no-progress never fired and the blank row fed straight into the merge-back above.
- **Source preprocessing was keyed off the target language** — `HandleFormatting(..., target.Code)` into a parameter named and used as `sourceLanguage`.

## Spell check

- **Undo of "Add to names list" never touched disk** — `NameList.GetNames()` returns its live set, so `RemoveName` emptied it before delegating and `NameList.Remove`'s "do I know this name?" guard then failed. Multi-word names could not be removed at all.
- **User words could be written to a file the checker never read** — the reader looked only at `<fiveLetter>_user.xml` while both writers fall back to `<twoLetter>_user.xml`, which is where Options → Word lists puts words for a neutral culture like "en".
- **User phrases were honored only inside the spell check window**; the live underlines and grid context menu now check them too, via an overload that works from the line text.
- **Adding a user word was rejected when the word was in the *names* list** — guard copy-pasted from `AddName`, and `||` short-circuited so `SaveUserWord` was never called.
- **"Use always" was never persisted** — nothing called the save path with a new pair, and the loaded list was never applied. Both directions wired up.

## Find/replace, undo, columns

- **Whole-word Find next/previous matched inside words** — the line was sliced at the caret before applying `\bword\b`, which manufactures a boundary at position 0. Count evaluates the same pattern against the full line, so the two disagreed, and Replace then rewrote inside `Bobcat`. Both directions now match the full line and honour the caret by offset.
- **With "whole word" ticked, the replacement was treated as a regex substitution** — `$$` collapsed to `$`, and `${x}` threw into a swallowed catch so Replace all silently did nothing.
- **Single-step regex Replace rewrote `\r\n` to `\n`** — the result was assembled from the normalized copy and returned without restoring platform line endings, which the Replace-all path does via `ReplaceNewLineSafe`.
- **The undo hash and its change detector compared different field sets.** MarginV was hashed but not compared, so a teletext alignment edit produced no undo entry *and* re-snapshotted the whole subtitle every 333 ms indefinitely; Bookmark was compared but not hashed, so one Ctrl+Z removed a bookmark along with an unrelated edit. The file's own comment states the invariant both directions were breaking.
- **Column Text up/down rotated through display-only reference rows**, pulling reference-file text into working lines — the sibling column commands filter those rows out deliberately.

## Player and audio

- **Cached spectrograms lost their last chunk** — the reader computed `fs.Length - 20` while the writer emits a 16-byte header, dropping one float; since the file holds an exact multiple of the 262144-sample chunk size, that lost a whole chunk (~11 s) on every reload.
- **`Pause()` never cleared the cached seek position** — the only state transition that didn't, so pausing after a seek made during playback sent the slider, clock and playhead back to the old target.
- **`SetSpectrogram` disposed bitmaps from the extraction worker** while the render pass was drawing them; now marshalled to the UI thread like everything else in that method.
- **SMPTE drop-frame rescaled the wave peaks but not the spectrogram**, so the two panels drifted ~3.6 s apart per hour.
- **The peak and spectrogram file resolvers preferred opposite candidates** when the audio track is unknown, so the two panels could show different tracks of the same video.

## Found while hunting

- **Toggle casing destroyed ASSA line breaks** — the `\N` position was recorded as an offset into the raw input while every other tag records an offset into the stripped text, so any preceding tag moved the break to the end: `{\an8}Hello\NWorld` → `{\an8}HELLOWORLD\N`, merging two display lines into one. Reachable via Shift+F3 and the grid context menu.
- **Auto-backup silently wrote nothing for read-only formats** — the `IsTextBased` guard excludes binary formats but not the text-based formats whose `ToText` throws (WSB, FTE, DlDd, SPU image and others); the exception hit a bare `catch` and no backup was produced at all. Now falls back to SubRip.

## Testing

- Full suite green: libse 1490, libuilogic 703, seconv 416, UI 4100 (1 skipped).
- New regression tests for the casing line-break position and the UUEncode round-trip.
- Functional checks against the built binaries: `.ass → .srt` tag stripping (which exercises the seconv order, `RemoveTag` and `RemoveDrawingTag` fixes together).

## One finding deliberately not changed

The regex Find paths slice the line at the caret too, which the hunt flagged as breaking `^` anchoring. A test (`FindServiceTests.RegexOverlappingNewlineBoundary_FindNext_FindsSecondLineInFull`) documents that slicing as **intended**: `^` is meant to re-anchor at the resume point so a `(^|\n).{38,}($|\n)` pattern finds a paragraph's second line in full. I changed it, the test caught it, and I reverted — the reason is now a comment in both methods so the next reader doesn't repeat the mistake. That is why this PR fixes 30 of the 31 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)