### PR TITLE
Fix mkv drop crash and the double "parsing Matroska file" wait

### DIFF
--- a/src/libse/ContainerFormats/Matroska/MatroskaFile.cs
+++ b/src/libse/ContainerFormats/Matroska/MatroskaFile.cs
@@ -804,6 +804,12 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Matroska
             }
         }
 
+        /// <summary>
+        /// True once <see cref="GetSubtitle"/> has read the clusters; further calls are served from
+        /// memory. Callers use this to skip a progress window that would just flash by.
+        /// </summary>
+        public bool IsSubtitleDataLoaded => _subtitleRipLoaded;
+
         public List<MatroskaSubtitle> GetSubtitle(int trackNumber, LoadMatroskaCallback progressCallback)
         {
             if (!_subtitleRipLoaded)

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -20829,7 +20829,8 @@ public partial class MainViewModel :
                     await ShowDialogAsync<PickMatroskaTrackWindow, PickMatroskaTrackViewModel>(vm => { vm.Initialize(matroska, subtitleList, fileName); });
                 if (result.OkPressed && result.SelectedMatroskaTrack != null)
                 {
-                    if (await LoadMatroskaSubtitle(result.SelectedMatroskaTrack, matroska, fileName, skipLoadVideo))
+                    if (await LoadMatroskaSubtitle(result.SelectedMatroskaTrack, matroska, fileName, skipLoadVideo,
+                            result.GetPreParsedBluRaySubtitles(result.SelectedMatroskaTrack.TrackNumber)))
                     {
                         if (!IsImageSubtitleTrack(result.SelectedMatroskaTrack))
                         {
@@ -20924,25 +20925,31 @@ public partial class MainViewModel :
         return true;
     }
 
+    /// <param name="preParsedBluRaySubtitles">
+    /// PGS cues the "pick track" window already parsed for its preview, so the exact same parse is
+    /// not run a second time behind another progress window (#14161). Null when unavailable.
+    /// </param>
     private async Task<bool> LoadMatroskaSubtitle(
         MatroskaTrackInfo matroskaSubtitleInfo,
         MatroskaFile matroska,
         string fileName,
-        bool skipLoadVideo = false)
+        bool skipLoadVideo = false,
+        List<BluRaySupParser.PcsData>? preParsedBluRaySubtitles = null)
     {
         if (matroskaSubtitleInfo.CodecId.Equals("S_HDMV/PGS", StringComparison.OrdinalIgnoreCase))
         {
             // Off the UI thread with progress, like the other track types - a PGS track in a
             // large mkv otherwise froze the window with no feedback (#6772).
             var pgsError = string.Empty;
-            var pgsSubtitle = await ExtractFromMatroskaAsync(
+            var pgsSubtitle = preParsedBluRaySubtitles ?? await ExtractFromMatroskaAsync(
                 matroska,
                 cb =>
                 {
                     var list = _bluRayHelper.LoadBluRaySubFromMatroska(matroskaSubtitleInfo, matroska, out var err, cb);
                     pgsError = err;
                     return list;
-                });
+                },
+                parsesCachedData: true);
 
             if (!string.IsNullOrEmpty(pgsError))
             {
@@ -21180,7 +21187,13 @@ public partial class MainViewModel :
     /// files. The callback handed to <paramref name="extract"/> drives that progress bar.
     /// Must be called on the UI thread.
     /// </summary>
-    private async Task<T> ExtractFromMatroskaAsync<T>(MatroskaFile matroska, Func<MatroskaFile.LoadMatroskaCallback, T> extract)
+    /// <param name="parsesCachedData">
+    /// True when the extraction is slow even after the clusters have been read (PGS decodes every
+    /// cue). For plain "give me the blocks" extractions a second call is served from memory, so the
+    /// progress window would only flash open and closed - and could be gone again before Avalonia
+    /// runs the callbacks posted when it opened (#14161).
+    /// </param>
+    private async Task<T> ExtractFromMatroskaAsync<T>(MatroskaFile matroska, Func<MatroskaFile.LoadMatroskaCallback, T> extract, bool parsesCachedData = false)
     {
         PleaseWaitViewModel? pleaseWaitVm = null;
         long fileSize = 0;
@@ -21193,7 +21206,7 @@ public partial class MainViewModel :
             // ignore - just means no size-based gating
         }
 
-        if (fileSize >= MatroskaProgressWindowMinFileSize)
+        if (fileSize >= MatroskaProgressWindowMinFileSize && (parsesCachedData || !matroska.IsSubtitleDataLoaded))
         {
             pleaseWaitVm = _windowService.ShowWindow<PleaseWaitWindow, PleaseWaitViewModel>(Window!);
             pleaseWaitVm.StatusText = Se.Language.Main.ParsingMatroskaFile;

--- a/src/ui/Features/Shared/PickMatroskaTrack/PickMatroskaTrackViewModel.cs
+++ b/src/ui/Features/Shared/PickMatroskaTrack/PickMatroskaTrackViewModel.cs
@@ -56,6 +56,12 @@ public partial class PickMatroskaTrackViewModel : ObservableObject
     // slow part, so the progress window is only shown until that initial read has completed.
     private bool _clusterLoaded;
 
+    // Building the preview of a PGS track parses every cue - the exact same work the caller would
+    // otherwise redo right after OK, for a second (and unprogressed) "parsing Matroska file" wait
+    // on the very same data. Keep the parsed list so the caller can pick it up instead. (#14161)
+    private List<BluRaySupParser.PcsData>? _previewBluRaySubtitles;
+    private int _previewBluRayTrackNumber = -1;
+
     // Only bother with the progress window for files large enough that the read is noticeable.
     private const long MatroskaProgressWindowMinFileSize = 25 * 1024 * 1024; // 25 MB
 
@@ -97,6 +103,15 @@ public partial class PickMatroskaTrackViewModel : ObservableObject
     private void Close()
     {
         Dispatcher.UIThread.Post(() => { Window?.Close(); });
+    }
+
+    /// <summary>
+    /// The PGS cues already parsed for the preview of <paramref name="trackNumber"/>, or null when
+    /// that track was not previewed (or is not PGS) and the caller has to parse them itself.
+    /// </summary>
+    public List<BluRaySupParser.PcsData>? GetPreParsedBluRaySubtitles(int trackNumber)
+    {
+        return _previewBluRayTrackNumber == trackNumber ? _previewBluRaySubtitles : null;
     }
 
     [RelayCommand]
@@ -370,6 +385,9 @@ public partial class PickMatroskaTrackViewModel : ObservableObject
                     return;
                 }
 
+                _previewBluRaySubtitles = preview.BluRaySubtitles;
+                _previewBluRayTrackNumber = preview.BluRaySubtitles != null ? trackInfo.TrackNumber : -1;
+
                 foreach (var cue in preview.Cues)
                 {
                     Rows.Add(new MatroskaSubtitleCueDisplay
@@ -410,13 +428,14 @@ public partial class PickMatroskaTrackViewModel : ObservableObject
         var cues = new List<PreviewCueData>();
         var count = 0;
         int? forcedCount = null;
+        List<BluRaySupParser.PcsData>? bluRaySubtitles = null;
 
         MatroskaFile.LoadMatroskaCallback? callback =
             pleaseWaitVm != null ? (position, total) => pleaseWaitVm.ReportProgress(position, total) : null;
         var subtitles = matroskaFile.GetSubtitle(trackInfo.TrackNumber, callback);
         if (subtitles == null)
         {
-            return new PreviewResult(0, null, cues);
+            return new PreviewResult(0, null, cues, null);
         }
 
         if (trackInfo.CodecId is MatroskaTrackType.SubRip
@@ -441,6 +460,7 @@ public partial class PickMatroskaTrackViewModel : ObservableObject
         else if (trackInfo.CodecId == MatroskaTrackType.BluRay)
         {
             var pcsData = BluRaySupParser.ParseBluRaySupFromMatroska(trackInfo, matroskaFile);
+            bluRaySubtitles = pcsData;
             count = pcsData.Count;
             forcedCount = pcsData.Count(p => p.IsForced);
             for (var i = 0; i < 20 && i < pcsData.Count; i++)
@@ -514,7 +534,7 @@ public partial class PickMatroskaTrackViewModel : ObservableObject
             }
         }
 
-        return new PreviewResult(count, forcedCount, cues);
+        return new PreviewResult(count, forcedCount, cues, bluRaySubtitles);
     }
 
     /// <summary>
@@ -531,7 +551,7 @@ public partial class PickMatroskaTrackViewModel : ObservableObject
     }
 
     /// <summary><see cref="ForcedCount"/> is null for formats without a forced flag.</summary>
-    private sealed record PreviewResult(int Count, int? ForcedCount, List<PreviewCueData> Cues);
+    private sealed record PreviewResult(int Count, int? ForcedCount, List<PreviewCueData> Cues, List<BluRaySupParser.PcsData>? BluRaySubtitles);
 
     private sealed class PreviewCueData
     {

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -3171,8 +3171,10 @@ public static class UiUtil
         // Guarded so the cleanup runs at most once per window even if Closed were ever raised
         // again, keeping non-idempotent cleanups safe by construction. (#13100)
         var cleanedUp = false;
+        var closed = false;
         window.Closed += (_, _) =>
         {
+            closed = true;
             if (!cleanedUp && window.DataContext is IClosingCleanup cleanup)
             {
                 cleanedUp = true;
@@ -3186,10 +3188,19 @@ public static class UiUtil
         // Clamp once when opened, and once more at Background priority so windows that
         // re-fit themselves in a posted callback (LockMinimumToContentSize in e.g. the
         // burn-in window runs at Loaded priority) get clamped again afterwards.
+        // Short-lived windows (e.g. the "please wait" window shown while extracting a
+        // Matroska track) can close before the posted callback runs; touching the window
+        // then throws ObjectDisposedException from the disposed platform impl. (#14161)
         window.Opened += (_, _) =>
         {
             ClampToWorkingArea(window);
-            Dispatcher.UIThread.Post(() => ClampToWorkingArea(window), DispatcherPriority.Background);
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (!closed)
+                {
+                    ClampToWorkingArea(window);
+                }
+            }, DispatcherPriority.Background);
         };
     }
 


### PR DESCRIPTION
Dropping an .mkv on the subtitle grid could crash with:

```
System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'Window platform implementation was already disposed.'.
   at Avalonia.Controls.Screens.ScreenFromWindow(WindowBase window)
   at Nikse.SubtitleEdit.Logic.UiUtil.ClampToWorkingArea(Window window)
   at Nikse.SubtitleEdit.Logic.UiUtil.<>c__DisplayClass245_0.<InitializeWindow>b__2()
```

`InitializeWindow` clamps a window to the working area when it opens, and once more from a Background-priority post. The "parsing Matroska file" please-wait window closes the moment extraction finishes - frequently before that post runs, leaving the callback to touch a disposed platform impl. The posted clamp is now skipped once the window has closed, which guards every short-lived window, not just this one.

The same window also popped up twice when picking a track, the second time with a progress bar that never moved:

- **Text / VobSub / DVB tracks:** `MatroskaFile.GetSubtitle` caches the cluster data per instance, so the loader's call after the pick dialog was served from memory - the window only flashed open and closed, which is exactly the race above. `ExtractFromMatroskaAsync` now checks the new `MatroskaFile.IsSubtitleDataLoaded` and skips the window when there is nothing left to read.
- **PGS tracks:** the track preview parses every cue via `ParseBluRaySupFromMatroska`, and `LoadBluRaySubFromMatroska` then parsed the identical data all over again - the slow second wait, unprogressed because the only progress callbacks come from the (already cached) cluster read. The pick-track window now keeps the cues it parsed and `LoadMatroskaSubtitle` uses them; it falls back to parsing with progress when the picked track was not previewed.

Tested by dropping a large multi-track mkv on the subtitle grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)