### PR TITLE
Fix 32 bugs from a fifth bug hunt

### DIFF
--- a/src/libse/Common/ActorConverter.cs
+++ b/src/libse/Common/ActorConverter.cs
@@ -120,7 +120,8 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
 
                 var actor = s.Substring(0, startIdx).Trim(' ', '-', '"');
-                selectFix = IsActor(actor);
+                // AND, not assignment: selectFix is declared outside the per-line loop, so a later line's valid speaker used to mask an earlier line whose "actor" was really a clock ("It's 12:30 now.") - pre-checking a fix that destroys text.
+                selectFix &= IsActor(actor);
                 if (changeCasing.HasValue)
                 {
                     actor = SetCasing(_subtitleFormat, changeCasing, actor);
@@ -240,7 +241,8 @@ namespace Nikse.SubtitleEdit.Core.Common
                 if (startIdx != -1 && endIdx > startIdx)
                 {
                     var actor = s.Substring(startIdx + 1, endIdx - startIdx - 1).Trim(' ', '-', '"');
-                    selectFix = IsActor(actor);
+                    // AND, not assignment: selectFix is declared outside the per-line loop, so a later line's valid speaker used to mask an earlier line whose "actor" was really a clock ("It's 12:30 now.") - pre-checking a fix that destroys text.
+                    selectFix &= IsActor(actor);
                     if (changeCasing.HasValue)
                     {
                         actor = SetCasing(_subtitleFormat, changeCasing, actor);

--- a/src/libse/Common/ContinuationUtilities.cs
+++ b/src/libse/Common/ContinuationUtilities.cs
@@ -911,7 +911,9 @@ namespace Nikse.SubtitleEdit.Core.Common
             while (input.IndexOf("<b>", StringComparison.Ordinal) >= 0)
             {
                 var startIndex = input.IndexOf("<b>", StringComparison.Ordinal);
-                var endIndex = input.IndexOf("</b>", StringComparison.Ordinal);
+                // From startIndex, as IsItalic does: searching from 0 found a stray leading
+                // "</b>" and produced a negative Substring length, throwing on ordinary text.
+                var endIndex = input.IndexOf("</b>", startIndex, StringComparison.Ordinal);
                 var textToRemove = endIndex >= 0 ? input.Substring(startIndex, (endIndex + 4) - startIndex) : input.Substring(startIndex);
                 input = input.Replace(textToRemove, string.Empty);
             }
@@ -1002,8 +1004,16 @@ namespace Nikse.SubtitleEdit.Core.Common
                 return false;
             }
 
-            // Shift index if needed after deleting { } tags
+            // Shift index if needed after deleting { } tags. IndexOf only finds the shift when
+            // the removed block sat at the very start - with a tag in the middle, input is not a
+            // contiguous substring of originalInput and no shift happened at all, leaving
+            // position past the end of input.
             position -= Math.Max(0, originalInput.IndexOf(input, StringComparison.Ordinal));
+            position = Math.Min(position, input.Length - 1);
+            if (position < 0)
+            {
+                return false;
+            }
 
             var startIndex = position;
             var endIndex = position;
@@ -1152,7 +1162,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 return true;
             }
 
-            if (profile.UseDifferentStyleGap && profile.GapSuffix.Length > 0 && input.EndsWith(profile.GapSuffix) && !input.EndsWith(Environment.NewLine + profile.GapSuffix, StringComparison.Ordinal))
+            if (profile.UseDifferentStyleGap && profile.GapSuffix.Length > 0 && input.EndsWith(profile.GapSuffix, StringComparison.Ordinal) && !input.EndsWith(Environment.NewLine + profile.GapSuffix, StringComparison.Ordinal))
             {
                 return true;
             }

--- a/src/libse/Common/Subtitle.cs
+++ b/src/libse/Common/Subtitle.cs
@@ -412,8 +412,10 @@ namespace Nikse.SubtitleEdit.Core.Common
                         }
                     }
 
-                    // handle overlap with next
-                    if (newEndMilliseconds > nextStartMilliseconds)
+                    // handle overlap with next - measured against the minimum gap, the way
+                    // AdjustDisplayTimeUsingMilliseconds does. Testing only for a hard overlap
+                    // let a new end land inside the gap (or exactly on the next start).
+                    if (newEndMilliseconds > nextStartMilliseconds - Configuration.Settings.General.MinimumMillisecondsBetweenLines)
                     {
                         newEndMilliseconds = nextStartMilliseconds - Configuration.Settings.General.MinimumMillisecondsBetweenLines;
                     }

--- a/src/libse/Common/TextSplit.cs
+++ b/src/libse/Common/TextSplit.cs
@@ -195,7 +195,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 
             for (var i = 0; i < numberOfParts - 1; i++)
             {
-                var endIndex = FindNearestSpaceIndex(text, startIndex + partLength);
+                var endIndex = FindNearestSpaceIndex(text, startIndex + partLength, startIndex);
 
                 if (endIndex == -1)
                 {
@@ -227,10 +227,23 @@ namespace Nikse.SubtitleEdit.Core.Common
             return parts;
         }
 
-        static int FindNearestSpaceIndex(string text, int startIndex)
+        /// <summary>
+        /// A space to break this chunk on: the last one at or before <paramref name="targetIndex"/>,
+        /// but never one belonging to an already-consumed chunk. Returning such a space made the
+        /// computed length non-positive, which appended an empty part and swallowed the rest of
+        /// the text into the following one.
+        /// </summary>
+        static int FindNearestSpaceIndex(string text, int targetIndex, int minIndex)
         {
-            var spaceIndex = text.LastIndexOf(' ', Math.Min(startIndex, text.Length - 1));
-            return spaceIndex;
+            var clamped = Math.Min(targetIndex, text.Length - 1);
+            var spaceIndex = text.LastIndexOf(' ', clamped);
+            if (spaceIndex > minIndex)
+            {
+                return spaceIndex;
+            }
+
+            // No space inside this chunk - take the next one after it rather than break early.
+            return text.IndexOf(' ', clamped);
         }
 
         public static Subtitle TryForWholeSentences(Subtitle inputSubtitle, string language, int lineMaxLength)

--- a/src/libse/Common/TextSplitResult.cs
+++ b/src/libse/Common/TextSplitResult.cs
@@ -184,6 +184,14 @@ namespace Nikse.SubtitleEdit.Core.Common
         public double DiffFromAveragePixel()
         {
             var pixels = LengthPixels;
+            // With "auto break by pixel width" off no pixel lengths are measured, so this used
+            // to score every candidate 0 and the "best" selectors just kept the first one.
+            // Fall back to the character-based diff so the most balanced split still wins.
+            if (pixels.Count == 0)
+            {
+                return DiffFromAverage();
+            }
+
             var avg = (double)(SumPixels(pixels) - SpaceLengthPixels) / Lines.Count;
             double diff = 0;
             for (var i = 0; i < pixels.Count; i++)

--- a/src/libse/Common/UnknownFormatImporterCsv.cs
+++ b/src/libse/Common/UnknownFormatImporterCsv.cs
@@ -41,7 +41,13 @@ namespace Nikse.SubtitleEdit.Core.Common
 
             var separator = DetectSeparator(lines);
 
-            var headers = lines[0].RemoveChar('"').ToLowerInvariant().Split(separator).ToList();
+            // Split the header exactly like the data rows (quote-aware) and trim each cell:
+            // a naive Split broke on a quoted separator inside a header name - skewing every
+            // column index - and an unpadded "Start, End, Text" failed to match at all.
+            var headers = CsvUtil.CsvSplitLines(new List<string> { lines[0] }, separator)
+                .FirstOrDefault()?
+                .Select(p => p.Trim().Trim('"').ToLowerInvariant())
+                .ToList() ?? new List<string>();
             if (!HasValidHeader(headers))
             {
                 return new Subtitle();
@@ -147,7 +153,10 @@ namespace Nikse.SubtitleEdit.Core.Common
 
             var startGaps = GetGaps(csvLines.Select(p => p.Start).ToArray());
             var avarageStartGap = startGaps.Sum() / startGaps.Length;
-            var avarageTextLength = csvLines.Select(p => p.Text.Length).Sum() / csvLines.Count;
+            // Text stays null when no text column was recognised (HasValidHeader only needs two
+            // hits across all five name lists, so a text column is not required) - dereferencing
+            // it threw straight out of the file-open path, which has no catch.
+            var avarageTextLength = csvLines.Select(p => p.Text?.Length ?? 0).Sum() / csvLines.Count;
             if (avarageStartGap >= 500 || avarageTextLength <= 90)
             {
                 return;

--- a/src/libse/Common/UnknownFormatImporterOds.cs
+++ b/src/libse/Common/UnknownFormatImporterOds.cs
@@ -75,17 +75,14 @@ namespace Nikse.SubtitleEdit.Core.Common
                     var value = GetCellValue(cell);
                     var repeat = ParseRepeat(cell.Attribute(TableNs + "number-columns-repeated")?.Value);
 
-                    if (string.IsNullOrEmpty(value))
+                    // Honour the repeat count for empty cells too: LibreOffice writes an
+                    // *interior* run of blanks that way, and collapsing it to one cell shifted
+                    // every following column left, so a row with a gap lost its text column.
+                    // Trailing blank runs are still handled by the trim below, and ParseRepeat
+                    // already caps the count, so this cannot blow up on a "blank to column 1024" row.
+                    for (var i = 0; i < repeat; i++)
                     {
-                        // Trailing empties with huge repeat counts are common — only emit a single empty cell
-                        cells.Add(string.Empty);
-                    }
-                    else
-                    {
-                        for (var i = 0; i < repeat; i++)
-                        {
-                            cells.Add(value);
-                        }
+                        cells.Add(value ?? string.Empty);
                     }
                 }
 

--- a/src/libse/SubtitleFormats/Cavena890.cs
+++ b/src/libse/SubtitleFormats/Cavena890.cs
@@ -1163,7 +1163,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         }
                         else if (current == 'ẁ')
                         {
-                            AddTwo(buffer, ref index, 0x81, 0x75);
+                            // 0x77 = 'w'; 0x75 is 'u', which made this round-trip as "ù"
+                            AddTwo(buffer, ref index, 0x81, 0x77);
                         }
 
                         // capitals with accent aigu

--- a/src/libuilogic/Common/BookmarkPersistence.cs
+++ b/src/libuilogic/Common/BookmarkPersistence.cs
@@ -25,7 +25,10 @@ namespace Nikse.SubtitleEdit.UiLogic.Common
 
         public bool Save()
         {
-            if (_fileName == null)
+            // IsNullOrEmpty: an untitled subtitle has string.Empty, not null, which made the
+            // path a bare relative ".SE.bookmarks" written into the working directory - and
+            // clearing bookmarks then deleted whatever file of that name happened to be there.
+            if (string.IsNullOrEmpty(_fileName))
             {
                 return false;
             }
@@ -81,7 +84,7 @@ namespace Nikse.SubtitleEdit.UiLogic.Common
 
         public bool Load()
         {
-            if (_fileName == null)
+            if (string.IsNullOrEmpty(_fileName))
             {
                 return false;
             }

--- a/src/libuilogic/Export/CustomTextFormatter.cs
+++ b/src/libuilogic/Export/CustomTextFormatter.cs
@@ -45,9 +45,11 @@ public static partial class CustomTextFormatter
             var text = p.Text;
             if (isXml)
             {
-                text = text.Replace("<", "&lt;")
-                           .Replace(">", "&gt;")
-                           .Replace("&", "&amp;");
+                // "&" first: escaping it last re-escaped the ampersands that the "<" and ">"
+                // passes had just introduced, so every tag came out as "&amp;lt;i&amp;gt;".
+                text = text.Replace("&", "&amp;")
+                           .Replace("<", "&lt;")
+                           .Replace(">", "&gt;");
             }
             text = GetText(text, formatNewLine);
 

--- a/src/ui/Features/Edit/ModifySelection/ModifySelectionRule.cs
+++ b/src/ui/Features/Edit/ModifySelection/ModifySelectionRule.cs
@@ -107,6 +107,10 @@ public class ModifySelectionRule
                 RuleType = RuleType.RegEx,
                 Name = g.RegularExpression,
                 HasText = true,
+                // Without this the match-case box is hidden and "HasMatchCase && MatchCase" can
+                // never be true, so every pattern was compiled IgnoreCase - unlike find/replace
+                // and SE 4, where regex is case-sensitive.
+                HasMatchCase = true,
             },
             new()
             {

--- a/src/ui/Features/Files/ExportCavena890/ExportCavena890Window.cs
+++ b/src/ui/Features/Files/ExportCavena890/ExportCavena890Window.cs
@@ -41,8 +41,6 @@ public class ExportCavena890Window : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
         
-        var buttonImport = UiUtil.MakeButton(Se.Language.General.Import, vm.OkCommand).WithRightAlignment();
-
         var labelTranslatedTitle = UiUtil.MakeLabel(Se.Language.File.Export.ExportCavenaTranslatedTitle);
         var textBoxTranslatedTitle = UiUtil.MakeTextBox(300, vm, nameof(vm.TranslatedTitle));
         
@@ -65,7 +63,6 @@ public class ExportCavena890Window : Window
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
         var panelButtons = UiUtil.MakeButtonBar( buttonOk, buttonCancel);
 
-        grid.Add(buttonImport, 0, 1);
         grid.Add(labelTranslatedTitle, 1, 0);
         grid.Add(textBoxTranslatedTitle, 1, 1);
         grid.Add(labelOriginalTitle, 2, 0);

--- a/src/ui/Features/Files/ExportCustomTextFormat/ExportCustomTextFormatViewModel.cs
+++ b/src/ui/Features/Files/ExportCustomTextFormat/ExportCustomTextFormatViewModel.cs
@@ -63,9 +63,23 @@ public partial class ExportCustomTextFormatViewModel : ObservableObject
             return;
         }
 
+        // Edit a copy: the dialog binds TwoWay straight onto the item it is given, so passing
+        // the live one meant every keystroke mutated the stored format and Cancel kept the edits.
+        // OK swaps this copy into the list below, so nothing is lost when the user confirms.
+        var editCopy = new CustomFormatItem
+        {
+            Name = selected.Name,
+            Extension = selected.Extension,
+            FormatHeader = selected.FormatHeader,
+            FormatParagraph = selected.FormatParagraph,
+            FormatFooter = selected.FormatFooter,
+            FormatTimeCode = selected.FormatTimeCode,
+            FormatNewLine = selected.FormatNewLine,
+        };
+
         var result = await _windowService.ShowDialogAsync<EditCustomTextFormatWindow, EditCustomTextFormatViewModel>(Window!, vm =>
         {
-            vm.Initialize(selected, Se.Language.File.Export.EditCustomFormat, _subtitles, _videoFileName ?? string.Empty);
+            vm.Initialize(editCopy, Se.Language.File.Export.EditCustomFormat, _subtitles, _videoFileName ?? string.Empty);
         });
 
         if (result.OkPressed && result.SelectedCustomFormat != null)

--- a/src/ui/Features/Files/ExportPac/ExportPacViewModel.cs
+++ b/src/ui/Features/Files/ExportPac/ExportPacViewModel.cs
@@ -31,6 +31,7 @@ public partial class ExportPacViewModel : ObservableObject
             "Chinese Simplified (gb2312)",
             "Korean",
             "Japanese",
+            "Latin Turkish",
             "Portuguese",
         };
 
@@ -46,6 +47,9 @@ public partial class ExportPacViewModel : ObservableObject
         }
 
         OkPressed = true;
+        // The list index is the code page number only because the list mirrors Pac's constants
+        // exactly; it used to skip Turkish, so "Portuguese" selected CodePageLatinTurkish (11)
+        // instead of CodePageLatinPortuguese (12) and Turkish was unreachable entirely.
         PacCodePage = PacCodePages.IndexOf(SelectedPacCodePage);
         Close();
     }

--- a/src/ui/Features/Files/ExportPlainText/ExportPlainTextViewModel.cs
+++ b/src/ui/Features/Files/ExportPlainText/ExportPlainTextViewModel.cs
@@ -11,6 +11,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Main;
+using System.Globalization;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
@@ -263,7 +264,7 @@ public partial class ExportPlainTextViewModel : ObservableObject, IClosingCleanu
 
         if (SelectedTimeCodeFormat == Se.Language.General.Seconds)
         {
-            return $"{tc.TotalSeconds:0.000}";
+            return tc.TotalSeconds.ToString("0.000", CultureInfo.InvariantCulture);
         }
 
         return SelectedTimeCodeFormat switch
@@ -291,7 +292,11 @@ public partial class ExportPlainTextViewModel : ObservableObject, IClosingCleanu
             return;
         }
 
-        await System.IO.File.WriteAllTextAsync(fileName, text, SelectedEncoding?.Encoding ?? Encoding.UTF8);
+        // Resolve by display name like the custom-format export does: TextEncoding maps both
+        // UTF-8 entries to Encoding.UTF8, which emits a preamble - so "UTF-8 without BOM" still
+        // wrote a BOM.
+        var encoding = EncodingHelper.ResolveEncoding(SelectedEncoding?.DisplayName, null) ?? Encoding.UTF8;
+        await System.IO.File.WriteAllTextAsync(fileName, text, encoding);
         SaveSettings();
     }
 

--- a/src/ui/Features/Files/ImportCsvXlsxCustomColumns/ImportCsvXlsxCustomColumnsViewModel.cs
+++ b/src/ui/Features/Files/ImportCsvXlsxCustomColumns/ImportCsvXlsxCustomColumnsViewModel.cs
@@ -337,20 +337,26 @@ public partial class ImportCsvXlsxCustomColumnsViewModel : ObservableObject
             return false;
         }
 
+        // Blank values carry no information either way - a single empty cell, or the blank row
+        // a trailing newline produces, used to veto the whole column and silently reinterpret
+        // HH:MM:SS:FF as milliseconds. Decide on the values that are actually present.
+        var considered = 0;
         foreach (var s in values)
         {
             if (string.IsNullOrWhiteSpace(s))
             {
-                return false;
+                continue;
             }
 
+            considered++;
             var parts = s.Split(TimeCode.TimeSplitChars, StringSplitOptions.RemoveEmptyEntries);
             if (parts.Length != 4 || parts[3].Trim().Length != 2)
             {
                 return false;
             }
         }
-        return true;
+
+        return considered > 0;
     }
 
     private static bool IsMillisecondsHeader(string header)
@@ -449,7 +455,17 @@ public partial class ImportCsvXlsxCustomColumnsViewModel : ObservableObject
                 lettered++;
             }
         }
-        return lettered >= 2;
+
+        // Two lettered cells alone is not evidence - an ordinary "JOHN | Hello there." data row
+        // has that, and consuming it as a header silently dropped the first subtitle. Require at
+        // least one cell that actually names a column we recognise; when nothing does, the row is
+        // treated as data (losing a cue is worse than showing an unmappable header as one).
+        if (lettered < 2)
+        {
+            return false;
+        }
+
+        return firstRow.Any(cell => GuessRoleFromHeader(cell ?? string.Empty) != CsvColumnRole.None);
     }
 
     private static CsvColumnRole GuessRoleFromHeader(string headerName)

--- a/src/ui/Features/Files/ManualChosenEncoding/ManualChosenEncodingViewModel.cs
+++ b/src/ui/Features/Files/ManualChosenEncoding/ManualChosenEncodingViewModel.cs
@@ -88,6 +88,13 @@ public partial class ManualChosenEncodingViewModel : ObservableObject, IClosingC
         if (string.IsNullOrWhiteSpace(SearchText))
         {
             Encodings.AddRange(_allEncodings);
+            // Clearing the collection nulls the bound SelectedItem, and OK requires a non-null
+            // selection - so searching and then clearing the box made OK a silent no-op.
+            if (Encodings.Count > 0)
+            {
+                SelectedEncoding = Encodings[0];
+            }
+
             return;
         }
 

--- a/src/ui/Features/Files/Statistics/StatisticsViewModel.cs
+++ b/src/ui/Features/Files/Statistics/StatisticsViewModel.cs
@@ -360,14 +360,14 @@ https://github.com/SubtitleEdit/subtitleedit
         sb.AppendLine(string.Format(_l.SingleLineLengthMaximum, maximumSingleLineLength) + " (" + GetIndicesWithSingleLineLength(maximumSingleLineLength) + ")");
         sb.AppendLine(string.Format(_l.SingleLineLengthAverage, (double)totalSingleLineLength / totalSingleLines));
         sb.AppendLine();
-        sb.AppendLine(string.Format(_l.SingleLineLengthExceedingMaximum, Configuration.Settings.General.SubtitleLineMaximumLength, aboveMaximumLineLengthCount, ((double)aboveMaximumLineLengthCount / _subtitle.Paragraphs.Count) * 100.0));
+        sb.AppendLine(string.Format(_l.SingleLineLengthExceedingMaximum, Configuration.Settings.General.SubtitleLineMaximumLength, aboveMaximumLineLengthCount, ((double)aboveMaximumLineLengthCount / Math.Max(1, totalSingleLines)) * 100.0));
         sb.AppendLine();
 
         sb.AppendLine(string.Format(_l.SingleLineWidthMinimum, minimumSingleLineWidth) + " (" + GetIndicesWithSingleLineWidth(minimumSingleLineWidth) + ")");
         sb.AppendLine(string.Format(_l.SingleLineWidthMaximum, maximumSingleLineWidth) + " (" + GetIndicesWithSingleLineWidth(maximumSingleLineWidth) + ")");
         sb.AppendLine(string.Format(_l.SingleLineWidthAverage, (double)totalSingleLineWidth / totalSingleLines));
         sb.AppendLine();
-        sb.AppendLine(string.Format(_l.SingleLineWidthExceedingMaximum, Configuration.Settings.General.SubtitleLineMaximumPixelWidth, aboveMaximumLineWidthCount, ((double)aboveMaximumLineWidthCount / _subtitle.Paragraphs.Count) * 100.0));
+        sb.AppendLine(string.Format(_l.SingleLineWidthExceedingMaximum, Configuration.Settings.General.SubtitleLineMaximumPixelWidth, aboveMaximumLineWidthCount, ((double)aboveMaximumLineWidthCount / Math.Max(1, totalSingleLines)) * 100.0));
         sb.AppendLine();
 
         sb.AppendLine(string.Format(_l.DurationMinimum, minimumDuration / TimeCode.BaseUnit) + " (" + GetIndicesWithDuration(minimumDuration) + ")");
@@ -397,7 +397,7 @@ https://github.com/SubtitleEdit/subtitleedit
             sb.AppendLine(string.Format(_l.GapMaximum, gapMaximum) + " (" + GetIndicesWithGap(gapMaximum) + ")");
             sb.AppendLine(string.Format(_l.GapAverage, gapTotal / (_subtitle.Paragraphs.Count - 1)));
             sb.AppendLine();
-            sb.AppendLine(string.Format(_l.GapExceedingMinimum, Configuration.Settings.General.MinimumMillisecondsBetweenLines, belowMinimumGapCount, ((double)belowMinimumGapCount / _subtitle.Paragraphs.Count) * 100.0));
+            sb.AppendLine(string.Format(_l.GapExceedingMinimum, Configuration.Settings.General.MinimumMillisecondsBetweenLines, belowMinimumGapCount, ((double)belowMinimumGapCount / Math.Max(1, _subtitle.Paragraphs.Count - 1)) * 100.0));
             sb.AppendLine();
         }
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -4384,6 +4384,19 @@ public partial class MainViewModel :
             return;
         }
 
+        // Feed the dialog's values into the settings the writer actually reads. They were
+        // collected and then dropped on the floor, so the file always got the output file's base
+        // name as its title and blank translator/comment fields.
+        var subtitleSettings = Configuration.Settings.SubtitleSettings;
+        subtitleSettings.CurrentCavena89Title = result.TranslatedTitle ?? string.Empty;
+        subtitleSettings.CurrentCavena890riginalTitle = result.OriginalTitle ?? string.Empty;
+        subtitleSettings.CurrentCavena890Translator = result.Translator ?? string.Empty;
+        subtitleSettings.CurrentCavena89Comment = result.Comment ?? string.Empty;
+        if (result.StartOfProgramme > TimeSpan.Zero)
+        {
+            subtitleSettings.Cavena890StartOfMessage = new TimeCode(result.StartOfProgramme).ToHHMMSSFF();
+        }
+
         var cavena = new Cavena890();
         var fileName = await _fileHelper.PickSaveSubtitleFile(Window!, cavena, GetNewFileName(),
             string.Format(Se.Language.Main.SaveXFileAs, cavena.Name));
@@ -6547,9 +6560,14 @@ public partial class MainViewModel :
         }
 
         ResetSubtitle();
-        SetSubtitles(result.JoinedSubtitle);
+        // Set the format before building the rows so SubtitleLineViewModel copies the ASSA style
+        // (Extra) into Style - the reverse order left every Style cell blank.
         SetSubtitleFormat(SubtitleFormats.FirstOrDefault(p => p.Name == result.JoinedFormat.Name) ??
                           SubtitleFormats[0]);
+        SetSubtitles(result.JoinedSubtitle);
+        // Carry over the header that SortAndLoad spent its merge building, or the joined file is
+        // written with no style table at all.
+        _subtitle.Header = result.JoinedSubtitle.Header;
         SelectAndScrollToRow(0);
         ShowStatus(Se.Language.Main.JoinedSubtitleLoaded);
     }
@@ -19772,14 +19790,20 @@ public partial class MainViewModel :
                 return;
             }
 
-            var fileEncoding = LanguageAutoDetect.GetEncodingFromFile(fileName);
+            // Honour an explicitly chosen encoding. This parameter was declared and never read,
+            // which made "Import subtitle with manually chosen encoding" inert and silently
+            // discarded the encoding remembered on a recent-file entry.
+            var fileEncoding = textEncoding?.Encoding ?? LanguageAutoDetect.GetEncodingFromFile(fileName);
             Subtitle? subtitle = null;
 
             // For .csv files, try the multi-column CSV importer first. It only succeeds when there is a
             // recognizable header (start/end/text/etc.), so single-text-column CSV formats fall through to Subtitle.Parse.
             if (string.Equals(ext, ".csv", StringComparison.OrdinalIgnoreCase))
             {
-                var csvLines = FileUtil.ReadAllLinesShared(fileName, Encoding.UTF8);
+                // The detected (or chosen) encoding, not a hardcoded UTF-8: a Windows-1252 CSV
+                // decoded as UTF-8 loses every accented character, unrecoverably, because the CSV
+                // importer wins over Subtitle.Parse when the header matches.
+                var csvLines = FileUtil.ReadAllLinesShared(fileName, fileEncoding);
                 var csvSubtitle = new UnknownFormatImporterCsv().AutoGuessImport(csvLines);
                 if (csvSubtitle != null && csvSubtitle.Paragraphs.Count > 0)
                 {

--- a/src/ui/Features/Shared/SourceView/SourceViewViewModel.cs
+++ b/src/ui/Features/Shared/SourceView/SourceViewViewModel.cs
@@ -653,8 +653,7 @@ public partial class SourceViewViewModel : ObservableObject, IClosingCleanup
         _subtitleFormat.LoadSubtitle(subtitle, lines, string.Empty);
         if (subtitle.Paragraphs.Count > 0)
         {
-            Subtitle.Paragraphs.Clear();
-            Subtitle.Paragraphs.AddRange(subtitle.Paragraphs);
+            ApplyParsedSubtitle(subtitle);
             OkPressed = true;
             Window?.Close();
             return;
@@ -663,14 +662,33 @@ public partial class SourceViewViewModel : ObservableObject, IClosingCleanup
         subtitle = Subtitle.Parse(lines, ".srt");
         if (subtitle.Paragraphs.Count > 0)
         {
-            Subtitle.Paragraphs.Clear();
-            Subtitle.Paragraphs.AddRange(subtitle.Paragraphs);
+            ApplyParsedSubtitle(subtitle);
             OkPressed = true;
             Window?.Close();
             return;
         }
 
         await MessageBox.Show(Window, Se.Language.General.Error, Se.Language.General.NoSubtitlesFound, MessageBoxButtons.OK, MessageBoxIcon.Error);
+    }
+
+    /// <summary>
+    /// Copies the parsed result back over the subtitle the caller holds - header and footer
+    /// included. Copying only the paragraphs silently discarded any edit the user made to an
+    /// ASSA [Script Info] / [V4+ Styles] block while accepting their dialogue edits.
+    /// </summary>
+    private void ApplyParsedSubtitle(Subtitle parsed)
+    {
+        Subtitle.Paragraphs.Clear();
+        Subtitle.Paragraphs.AddRange(parsed.Paragraphs);
+        if (!string.IsNullOrEmpty(parsed.Header))
+        {
+            Subtitle.Header = parsed.Header;
+        }
+
+        if (!string.IsNullOrEmpty(parsed.Footer))
+        {
+            Subtitle.Footer = parsed.Footer;
+        }
     }
 
     private static string TrimJunk(string text)

--- a/src/ui/Features/Tools/AiReview/AiReviewViewModel.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewViewModel.cs
@@ -408,6 +408,9 @@ public partial class AiReviewViewModel : ObservableObject
         using var client = new AiReviewClient();
         var processedLines = 0;
         var consecutiveErrors = 0;
+        // Chunks the engine never answered. Counting their lines as reviewed let a run with an
+        // unreachable engine finish at 100% reporting "no issues found".
+        var failedChunks = 0;
         var delay = TimeSpan.FromSeconds(Math.Max(0, RequestDelaySeconds));
         var lastRequestCompletedUtc = DateTime.MinValue;
 
@@ -468,6 +471,7 @@ public partial class AiReviewViewModel : ObservableObject
                 catch (HttpRequestException e)
                 {
                     consecutiveErrors++;
+                    failedChunks++;
                     if (consecutiveErrors >= 3)
                     {
                         await MessageBox.Show(Window, Se.Language.General.Error,
@@ -488,9 +492,16 @@ public partial class AiReviewViewModel : ObservableObject
                 ProgressValue = Math.Min(100.0, processedLines * 100.0 / Math.Max(1, lines.Count));
             }
 
-            StatusText = _allSuggestions.Count == 0 && processedLines >= lines.Count
+            StatusText = _allSuggestions.Count == 0 && processedLines >= lines.Count && failedChunks == 0
                 ? l.NoIssuesFound
                 : string.Format(l.ReviewDone, _allSuggestions.Count, processedLines);
+
+            if (failedChunks > 0 && Window != null)
+            {
+                await MessageBox.Show(Window, Se.Language.General.Error,
+                    string.Format(l.EngineError, $"{failedChunks} chunk(s) could not be reviewed"),
+                    MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            }
         }
         catch (OperationCanceledException)
         {

--- a/src/ui/Features/Tools/ChangeCasing/FixNameHitItem.cs
+++ b/src/ui/Features/Tools/ChangeCasing/FixNameHitItem.cs
@@ -16,7 +16,10 @@ public partial class FixNameHitItem : ObservableObject
     {
         Name = name;
         LineIndex = lineIndex;
-        LineIndexDisplay = lineIndex + 1;
+        // The producer passes Paragraph.Number, which is already 1-based (the apply path relies
+        // on that too, indexing Paragraphs[LineIndex - 1]) - adding one showed every hit against
+        // the following line, and the last line as a row number that does not exist.
+        LineIndexDisplay = lineIndex;
         Before = before;
         After = after;
         IsEnabled = isEnabled;

--- a/src/ui/Features/Tools/ChangeFormatting/ChangeFormattingViewModel.cs
+++ b/src/ui/Features/Tools/ChangeFormatting/ChangeFormattingViewModel.cs
@@ -138,6 +138,21 @@ public partial class ChangeFormattingViewModel : ObservableObject, IClosingClean
     [RelayCommand]
     private void Ok()
     {
+        // Subtitles is only ever filled by the 500 ms preview timer, so before the first tick it
+        // is empty - and applying an empty result made the caller's count check fail and clear
+        // the whole grid. Build it now if a change is pending or nothing has been built yet.
+        if (_dirty || Subtitles.Count == 0)
+        {
+            UpdatePreview();
+        }
+
+        if (Subtitles.Count == 0)
+        {
+            // Nothing to apply - close without touching the subtitle.
+            Window?.Close();
+            return;
+        }
+
         FixedSubtitle = Subtitles.Select(p => new SubtitleLineViewModel(p.SubtitleLineViewModel)).ToList();
         SaveSettings();
         OkPressed = true;

--- a/src/ui/Features/Tools/MergeSubtitlesWithSameTimeCodes/MergeSameTimeCodesViewModel.cs
+++ b/src/ui/Features/Tools/MergeSubtitlesWithSameTimeCodes/MergeSameTimeCodesViewModel.cs
@@ -106,7 +106,14 @@ public partial class MergeSameTimeCodesViewModel : ObservableObject, IClosingCle
         var mergedText = string.Empty;
         for (var i = 1; i < _subtitles.Count; i++)
         {
-            p = _subtitles[i - 1];
+            // Anchor on the FIRST cue of the current group. Reassigning every iteration compared
+            // each cue with its immediate predecessor, so a run of slowly drifting cues - each
+            // within tolerance of the last but far from the first - chained transitively into a
+            // single subtitle spanning the whole run.
+            if (singleMergeSubtitles.Count == 0)
+            {
+                p = _subtitles[i - 1];
+            }
 
             var next = _subtitles[i];
             if (QualifiesForMerge(p, next, MaxMillisecondsDifference) && IsFixAllowed(p))

--- a/src/ui/Features/Tools/SortBy/SortByViewModel.cs
+++ b/src/ui/Features/Tools/SortBy/SortByViewModel.cs
@@ -377,6 +377,13 @@ public partial class SortByViewModel : ObservableObject, IClosingCleanup
     [RelayCommand]
     private void Ok()
     {
+        // Apply what the current criteria produce: the preview is rebuilt by a 500 ms timer, so
+        // clicking OK straight after adding a criterion applied the previous (or unsorted) order.
+        if (_dirty)
+        {
+            UpdatePreview();
+        }
+
         if (SortCriteria.Count > 0)
         {
             AllSubtitles.Clear();

--- a/src/ui/Features/Tools/SplitSubtitle/SubtitleSplitter.cs
+++ b/src/ui/Features/Tools/SplitSubtitle/SubtitleSplitter.cs
@@ -87,7 +87,10 @@ public static class SubtitleSplitter
         {
             var p = subtitle.Paragraphs[i];
             var size = HtmlUtil.RemoveHtmlTags(p.Text, true).Length;
-            if (currentSize + size > nextLimit + 4 && parts.Count < numberOfParts - 1)
+            // Never close an empty part: when the very first paragraph already exceeds the
+            // limit, pushing the untouched accumulator produced a 0-byte "Part1" file with all
+            // the content in Part2.
+            if (currentSize + size > nextLimit + 4 && parts.Count < numberOfParts - 1 && temp.Paragraphs.Count > 0)
             {
                 parts.Add(temp);
                 currentSize = size;


### PR DESCRIPTION
Fifth hunt, over ground the previous four ([#14152](https://github.com/SubtitleEdit/subtitleedit/pull/14152), [#14156](https://github.com/SubtitleEdit/subtitleedit/pull/14156), [#14160](https://github.com/SubtitleEdit/subtitleedit/pull/14160), [#14161](https://github.com/SubtitleEdit/subtitleedit/pull/14161)) did not touch: imports, the non-image export tools, the selection/casing/actor editors, core libse helpers, and the join/split/statistics tools.

## This also corrects an earlier fix of mine

`SubtitleOpen`'s `textEncoding` parameter was **declared and never read** — it appeared exactly once in a 20,000-line file — so the body always used auto-detect. That made "Import subtitle with manually chosen encoding" completely inert, **and it means the recent-file encoding I wired into that parameter in [#14160](https://github.com/SubtitleEdit/subtitleedit/pull/14160) never took effect either.** I had verified back then that `RecentFile.Encoding` was never read, but not that the parameter I passed it to was ever used. Honouring the parameter fixes both at once.

## Imports

- **Headerless CSV lost its first cue** — `LooksLikeHeader` fired on any row with two lettered cells, which any `speaker,text` row satisfies. It now also requires a cell that names a column we recognise; when nothing does the row is treated as data, since losing a cue is worse than showing an unmappable header as one.
- **ODS import shifted columns left** — `number-columns-repeated` was honoured for non-empty cells but collapsed to one blank for empty ones, and LibreOffice writes interior blank runs that way. The affected cue then silently dropped.
- **A CSV with no recognised text column crashed the file open** — `p.Text.Length` on a `Text` that is only assigned when a text column exists, inside a `try` that has only a `finally`.
- **The CSV header row was split naively** while data rows were split quote-aware, and header cells were never trimmed — so `Start, End, Text` failed to match and a quoted separator in a header skewed every index.
- **A trailing blank line reinterpreted an HH:MM:SS:FF column as milliseconds** — frame detection vetoed on the first blank value.
- `.csv` files are read with the detected encoding instead of a hardcoded UTF-8, and clearing the encoding picker's search box no longer leaves OK a silent no-op.

## Exports

- **PAC export wrote the Turkish code page when you picked "Portuguese"** — the picker sends its list index, and the list omitted Turkish. The Portuguese hyphen overrides never applied, the fallback encoding was wrong, and Turkish was unreachable from the GUI. seconv mapped the same choice correctly, so GUI and CLI produced different files.
- **Every field in the Cavena 890 dialog was collected and discarded** — the writer reads settings that SE5 never assigned, so the file always got the output file's base name as its title and blank translator/comment fields. Its "Import" button was wired to the OK command (and its own command is an empty stub), so it is removed.
- **Cancel in the custom-format editor kept the edits** — the item was passed by reference with TwoWay bindings. It now edits a copy, which OK swaps in.
- **XML custom formats double-escaped every angle bracket** — `&` was escaped last, re-escaping what the `<`/`>` passes had just produced, so `<i>` came out as `&amp;lt;i&amp;gt;`.
- **Plain-text export** wrote culture-formatted seconds (`1,500` on a Danish machine) and wrote a BOM even for "UTF-8 without BOM".
- **Cavena 890 encoded `ẁ` as `ù`** — the lowercase branch used base byte `u` where the uppercase form correctly uses `w`.

## Edit tools

- **Change formatting could delete the entire subtitle.** Its preview collection is only ever filled by a 500 ms timer, and `Ok()` copied from it with no flush and no guard — so clicking OK within half a second applied an empty result, the caller's count check failed, and the grid was cleared. **Sort by** had the same debounce and applied a stale order.
- **Modify selection's RegEx rule was silently forced case-insensitive** — it declared `HasText` but not `HasMatchCase`, so the match-case box was hidden and the condition could never be true. `^[A-Z]` selected lowercase lines too.
- **Convert actors let a later line mask an earlier one** — `selectFix` is declared outside the per-line loop and was assigned inside it, so with "Only names" on, `It's 12:30 now.` / `MARY: Hello.` got pre-checked and applying it destroyed text.
- The fix-names hit list showed every line one too high, and **AI review reported "No issues found" when the engine was unreachable** (failed chunks still advanced the processed count).

## libse helpers

- `IsBold` searched its closing tag from index 0 while `IsItalic` searches from the opening tag — a stray leading `</b>` gave a negative substring length and **threw**, reachable from Fix Common Errors.
- `IsFullLineQuote`'s position compensation assumed the removed `{...}` block was at the start; a mid-text tag sent it past the end of the string.
- **The text splitter emitted an empty middle part** — it searched *backwards* for a break and returned a space from an already-consumed chunk. Verified fixed: `SplitText("a bbbbbbbbbbbbbbbbbb cc", 3)` now returns three non-empty parts.
- **Split scoring collapsed to zero with "auto-break by pixel width" off**, so the "best split" selectors kept the first candidate rather than the most balanced.
- `AdjustDisplayTimeUsingPercent` clamps against the minimum gap like its millisecond sibling; it could leave a 0 ms gap.
- `HasSuffix` compares ordinally, matching its unsafe twin (a trailing zero-width character made them disagree).

## Join, split, statistics

- **Join subtitles threw away the merged ASSA header and every line's style** — `SortAndLoad` spends ~65 lines merging the style blocks, then the caller never assigned the header and built the rows before setting the format. The merge-two-subtitles sibling does both correctly, with comments.
- **"Merge with same time codes" merged transitively** — each cue was compared to its immediate predecessor rather than the group's first cue, so a run of slowly drifting cues collapsed into one.
- **Bookmarking an untitled subtitle wrote a stray file into the working directory** — the guard tested `null`, but untitled is `string.Empty`; clearing bookmarks then deleted whatever file of that name was there.
- Split by characters no longer emits a 0-byte Part 1, and statistics no longer reports percentages over 100% (per-line counts were divided by the paragraph count).

## Source view

Editing an ASSA `[V4+ Styles]` block or `PlayResX` alongside some dialogue applied the dialogue and **silently discarded the header edits** — only `Paragraphs` was copied back. Header and footer now travel with it.

## Testing

- Full suite green first time: libse 1507, libuilogic 703, seconv 416, UI 4113 (1 skipped).
- Verified against the built library: the text splitter returns three non-empty parts, and a mid-text ASSA tag no longer throws out of the continuation helper.
- Encodings audited before commit so no file's BOM state changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)