### PR TITLE
Fix 30 bugs found in a five-area hunt (formats, lifecycle, settings, rendering, image export)

### DIFF
--- a/src/libse/SubtitleFormats/CaptionsInc.cs
+++ b/src/libse/SubtitleFormats/CaptionsInc.cs
@@ -243,7 +243,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
                     i++;
 
-                    if (buffer[i] == 0xfe)
+                    // The scan above stops at buffer.Length when the file has no trailing 0x0a, so
+                    // both the marker read and the eight byte time code can run past the end.
+                    if (i + 12 <= buffer.Length && buffer[i] == 0xfe)
                     {
                         string endTime = Encoding.ASCII.GetString(buffer, i + 4, 8);
                         if (Utilities.IsInteger(endTime))

--- a/src/libse/SubtitleFormats/DCinemaSmpte2007.cs
+++ b/src/libse/SubtitleFormats/DCinemaSmpte2007.cs
@@ -144,7 +144,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
 
             xml.DocumentElement.SelectSingleNode("dcst:Language", nsmgr).InnerText = ss.CurrentDCinemaLanguage;
-            if (ss.CurrentDCinemaEditRate == null && ss.CurrentDCinemaTimeCodeRate == null)
+            // Empty, not just null: SE5 mirrors its settings onto this singleton and pushes
+            // string.Empty for a rate never set in File > Properties, so a "== null" guard could
+            // never fire there and the file got <EditRate></EditRate> - invalid D-Cinema XML.
+            if (string.IsNullOrEmpty(ss.CurrentDCinemaEditRate) && string.IsNullOrEmpty(ss.CurrentDCinemaTimeCodeRate))
             {
                 if (Configuration.Settings.General.CurrentFrameRate == 24)
                 {

--- a/src/libse/SubtitleFormats/DCinemaSmpte2010.cs
+++ b/src/libse/SubtitleFormats/DCinemaSmpte2010.cs
@@ -144,7 +144,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
 
             xml.DocumentElement.SelectSingleNode("dcst:Language", nsmgr).InnerText = ss.CurrentDCinemaLanguage;
-            if (ss.CurrentDCinemaEditRate == null && ss.CurrentDCinemaTimeCodeRate == null)
+            // Empty, not just null: SE5 mirrors its settings onto this singleton and pushes
+            // string.Empty for a rate never set in File > Properties, so a "== null" guard could
+            // never fire there and the file got <EditRate></EditRate> - invalid D-Cinema XML.
+            if (string.IsNullOrEmpty(ss.CurrentDCinemaEditRate) && string.IsNullOrEmpty(ss.CurrentDCinemaTimeCodeRate))
             {
                 if (Math.Abs(Configuration.Settings.General.CurrentFrameRate - 24) < 0.01)
                 {

--- a/src/libse/SubtitleFormats/DCinemaSmpte2014.cs
+++ b/src/libse/SubtitleFormats/DCinemaSmpte2014.cs
@@ -148,7 +148,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
 
             xml.DocumentElement.SelectSingleNode("dcst:Language", nsmgr).InnerText = ss.CurrentDCinemaLanguage;
-            if (ss.CurrentDCinemaEditRate == null && ss.CurrentDCinemaTimeCodeRate == null)
+            // Empty, not just null: SE5 mirrors its settings onto this singleton and pushes
+            // string.Empty for a rate never set in File > Properties, so a "== null" guard could
+            // never fire there and the file got <EditRate></EditRate> - invalid D-Cinema XML.
+            if (string.IsNullOrEmpty(ss.CurrentDCinemaEditRate) && string.IsNullOrEmpty(ss.CurrentDCinemaTimeCodeRate))
             {
                 if (Math.Abs(Configuration.Settings.General.CurrentFrameRate - 24) < 0.01)
                 {

--- a/src/libse/SubtitleFormats/Eeg708.cs
+++ b/src/libse/SubtitleFormats/Eeg708.cs
@@ -84,6 +84,14 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         lastParagraph = new Paragraph(s, startTime.TotalMilliseconds, startTime.TotalMilliseconds + 3000);
                         subtitle.Paragraphs.Add(lastParagraph);
                     }
+                    else
+                    {
+                        // A node with no <Text> is the explicit end-of-caption marker ToText writes,
+                        // and it has just set the end time above. Leaving the paragraph pending let
+                        // the *next* caption's start time overwrite that end time again, so every
+                        // gap in the file was swallowed and only the last cue kept its end time.
+                        lastParagraph = null;
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/src/libse/SubtitleFormats/Lrc.cs
+++ b/src/libse/SubtitleFormats/Lrc.cs
@@ -110,7 +110,18 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 if (next == null || next.StartTime.TotalMilliseconds - p.EndTime.TotalMilliseconds > 100)
                 {
                     var tc = new TimeCode(p.EndTime.TotalMilliseconds);
-                    sb.AppendLine(string.Format(timeCodeFormat, tc.Hours * 60 + tc.Minutes, tc.Seconds, (int)Math.Round(tc.Milliseconds / 10.0), string.Empty));
+
+                    // Same carry the start time above does: rounding 999 ms gives 100, and the
+                    // ":00" format printed all three digits ("[01:04.100]") - a line RegexTimeCodes
+                    // rejects, so the end marker was lost on reload and malformed for LRC players.
+                    var endFraction = (int)Math.Round(tc.Milliseconds / 10.0);
+                    if (endFraction >= 100)
+                    {
+                        tc = new TimeCode(new TimeCode(tc.Hours, tc.Minutes, tc.Seconds, 0).TotalMilliseconds + 1000);
+                        endFraction = 0;
+                    }
+
+                    sb.AppendLine(string.Format(timeCodeFormat, tc.Hours * 60 + tc.Minutes, tc.Seconds, endFraction, string.Empty));
                 }
             }
 

--- a/src/libse/SubtitleFormats/PinnacleImpression.cs
+++ b/src/libse/SubtitleFormats/PinnacleImpression.cs
@@ -49,7 +49,15 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         private static string EncodeTimeCode(TimeCode time)
         {
             //00:03:15:22 (last is frame)
-            int frames = time.Milliseconds / (1000 / 30);
+            // "1000 / 30" is integer division (33), so 990-999 ms produced frame 30 - not a valid
+            // frame number at 30 fps. Compute in floating point and clamp, as
+            // MillisecondsToFramesMaxFrameRate does.
+            var frames = (int)(time.Milliseconds / (1000.0 / 30.0));
+            if (frames > 29)
+            {
+                frames = 29;
+            }
+
             return $"{time.Hours:00}:{time.Minutes:00}:{time.Seconds:00}:{frames:00}";
         }
 

--- a/src/libse/SubtitleFormats/ProjectionSubtitleList.cs
+++ b/src/libse/SubtitleFormats/ProjectionSubtitleList.cs
@@ -161,7 +161,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 {
                     if (ch == 'u' && i + 6 < text.Length && char.IsNumber(text[i + 1]) && char.IsNumber(text[i + 2]) && char.IsNumber(text[i + 3]) && char.IsNumber(text[i + 4]) && char.IsNumber(text[i + 5]))
                     {
-                        var unicodeNumber = text.Substring(i + 1, 4);
+                        // Five digits, not four - RftEncode writes the decimal code point, which is
+                        // five digits from U+2710 up, so a copy of the four digit branch below
+                        // decoded every CJK/Cyrillic/emoji character as a different one.
+                        var unicodeNumber = text.Substring(i + 1, 5);
                         var unescaped = char.ConvertFromUtf32(int.Parse(unicodeNumber));
                         sb.Append(unescaped);
                         if (i + 7 < text.Length && text[i + 6] == ' ')

--- a/src/libse/SubtitleFormats/RxMarker.cs
+++ b/src/libse/SubtitleFormats/RxMarker.cs
@@ -19,7 +19,18 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         private static string MakeTimeCode(TimeCode tc)
         {
             var ts = tc.TimeSpan;
-            var s = $"{ts.Days * 24 + ts.Hours:00}:{ts.Minutes:00}:{ts.Seconds:00}:{(int)Math.Round(ts.Milliseconds / 10.0, MidpointRounding.AwayFromZero):00}.00";
+
+            // Rounding the hundredths carries into the next second (997 ms -> 100) and ":00" then
+            // printed three digits - a time code RegexTimeCode rejects, so on reload the whole line
+            // fell through to the text branch and the cue itself vanished.
+            var hundredths = (int)Math.Round(ts.Milliseconds / 10.0, MidpointRounding.AwayFromZero);
+            if (hundredths >= 100)
+            {
+                ts = ts.Add(TimeSpan.FromMilliseconds(1000 - ts.Milliseconds));
+                hundredths = 0;
+            }
+
+            var s = $"{ts.Days * 24 + ts.Hours:00}:{ts.Minutes:00}:{ts.Seconds:00}:{hundredths:00}.00";
             return s;
         }
 

--- a/src/libse/SubtitleFormats/TimeCodesOnly1.cs
+++ b/src/libse/SubtitleFormats/TimeCodesOnly1.cs
@@ -9,7 +9,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
     public class TimeCodesOnly1 : SubtitleFormat
     {
         // 1<HT>1:01:08:05<HT>1:01:10:21<HT>02:16
-        private static readonly Regex RegexTimeCodes = new Regex(@"^\d+\t\d+:\d\d:\d\d:\d\d\t\d+:\d\d:\d\d:\d\d\t\d\d:\d\d$", RegexOptions.Compiled);
+        private static readonly Regex RegexTimeCodes = new Regex(@"^\d+\t\d+:\d\d:\d\d:\d\d\t\d+:\d\d:\d\d:\d\d\t\d+:\d\d$", RegexOptions.Compiled);
 
         public override string Extension => ".txt";
 
@@ -23,10 +23,18 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             int index = 1;
             foreach (Paragraph p in subtitle.Paragraphs)
             {
-                sb.AppendLine($"{index}\t{EncodeTimeCode(p.StartTime)}\t{EncodeTimeCode(p.EndTime)}\t{p.Duration}");
+                sb.AppendLine($"{index}\t{EncodeTimeCode(p.StartTime)}\t{EncodeTimeCode(p.EndTime)}\t{EncodeDuration(p.Duration)}");
                 index++;
             }
             return sb.ToString();
+        }
+
+        // The fourth column is a SS:FF duration (see the example above). TimeCode.ToString()
+        // gives "HH:MM:SS,mmm" instead, which RegexTimeCodes rejects - so what this format wrote
+        // could not be read back by it, or auto-detected, at all: reloading gave zero paragraphs.
+        private static string EncodeDuration(TimeCode duration)
+        {
+            return $"{(int)duration.TotalSeconds:00}:{MillisecondsToFramesMaxFrameRate(duration.Milliseconds):00}";
         }
 
         private static string EncodeTimeCode(TimeCode time)

--- a/src/libse/SubtitleFormats/UnknownSubtitle96.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle96.cs
@@ -24,8 +24,11 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var sb = new StringBuilder();
             foreach (var p in subtitle.Paragraphs)
             {
-                sb.AppendLine(string.Format(writeFormat, p.StartTime.TotalSeconds, MillisecondsToFramesMaxFrameRate(p.StartTime.Milliseconds),
-                    p.EndTime.TotalSeconds, MillisecondsToFramesMaxFrameRate(p.EndTime.Milliseconds),
+                // Truncate the seconds: "{0:0000}" rounds the raw double, so the seconds field
+                // carried the sub-second part that the frames field then repeated - 00:00:05,600
+                // was written "0006:15" and read back a whole second late.
+                sb.AppendLine(string.Format(writeFormat, (int)p.StartTime.TotalSeconds, MillisecondsToFramesMaxFrameRate(p.StartTime.Milliseconds),
+                    (int)p.EndTime.TotalSeconds, MillisecondsToFramesMaxFrameRate(p.EndTime.Milliseconds),
                     p.Text));
             }
             return sb.ToString().Trim();

--- a/src/libuilogic/Export/ExportTextTags.cs
+++ b/src/libuilogic/Export/ExportTextTags.cs
@@ -283,6 +283,14 @@ public static class ExportTextTags
             return;
         }
 
+        // Same reason ApplyStyleOverrideTags bails out on "\t(": inside a transition these tags are
+        // an animation target, not the line's look. Freezing at the end value made the common
+        // fade-out "{\t(0,300,\alpha&HFF&)}" export as a fully invisible subtitle.
+        if (text.Contains("\\t(", StringComparison.Ordinal))
+        {
+            return;
+        }
+
         int? all = null;
         int? primary = null;
         int? outline = null;

--- a/src/libuilogic/Export/ImageRenderer.cs
+++ b/src/libuilogic/Export/ImageRenderer.cs
@@ -207,9 +207,18 @@ public static class ImageRenderer
         // The line box can only fall outside the scratch canvas for text taller than the
         // canvas, which is already clipped; keep the transparent rows for it anyway so the
         // exported height stays a function of the line count alone.
-        var cropTop = Math.Max(0, Math.Min(drawnBounds.Top, lineBoxTop));
+        var bitmapTop = Math.Min(drawnBounds.Top, lineBoxTop);
+
+        // Row of the first line's ascent top inside the finished bitmap. The crop deliberately
+        // keeps outlineWidth rows above it (and outline + shadow below the last descender), so a
+        // box drawn from row 0 sits that much too high: the bottom padding came out as
+        // padBottom - 2 * outlineWidth, i.e. negative at the shipped defaults, and the outline
+        // under g/p/y was drawn outside the box.
+        var firstLineTopInBitmap = (float)(firstBaseline - Math.Abs(fontMetrics.Ascent) - bitmapTop);
+
+        var cropTop = Math.Max(0, bitmapTop);
         var cropBottom = Math.Min(tempBitmap.Height - 1, Math.Max(drawnBounds.Bottom, lineBoxBottom));
-        var overflowTop = cropTop - Math.Min(drawnBounds.Top, lineBoxTop);
+        var overflowTop = cropTop - bitmapTop;
         var overflowBottom = Math.Max(drawnBounds.Bottom, lineBoxBottom) - cropBottom;
 
         var textBitmap = tempBitmap.CropTo(drawnBounds.Left, cropTop, drawnBounds.Right, cropBottom);
@@ -220,7 +229,7 @@ public static class ImageRenderer
 
         if (ip.BoxType != ExportBoxType.None)
         {
-            textBitmap = Replace(textBitmap, DrawBoxBehindText(textBitmap, lines, ip, regularFont, boldFont, italicFont, boldItalicFont, baseLineHeight, lineSpacing));
+            textBitmap = Replace(textBitmap, DrawBoxBehindText(textBitmap, lines, ip, regularFont, boldFont, italicFont, boldItalicFont, baseLineHeight, lineSpacing, firstLineTopInBitmap));
         }
 
         if (ip.PaddingTopBottom == 0 && ip.PaddingLeftRight == 0)
@@ -269,7 +278,8 @@ public static class ImageRenderer
         SKFont italicFont,
         SKFont boldItalicFont,
         float baseLineHeight,
-        float lineSpacing)
+        float lineSpacing,
+        float firstLineTopInBitmap)
     {
         var padLeft = ip.BoxPaddingLeft;
         var padRight = ip.BoxPaddingRight;
@@ -315,7 +325,7 @@ public static class ImageRenderer
             var maxLineWidth = lineWidths.Length > 0 ? lineWidths.Max() : 0f;
 
             // Draw one box per line, aligned the same way as text rendering
-            var currentY = (float)padTop;
+            var currentY = padTop + firstLineTopInBitmap;
             for (var li = 0; li < lines.Count; li++)
             {
                 var lineWidth = lineWidths[li];
@@ -1194,8 +1204,14 @@ public static class ImageRenderer
             }
             else
             {
-                // Invalid tag, treat as regular text
-                currentPos++;
+                // Not a tag we know (a literal "<", "<br>", ...). The text before it has already
+                // been emitted above, so advancing by one made the next iteration find the same
+                // bracket and emit that same text again, minus one leading character, until
+                // currentPos caught up - "Wait < 5 minutes" rendered as "Wait ait it t   5 minutes".
+                // Emit the bracket as text and move past it.
+                segments.Add(new TextSegment(text.Substring(nextTagPos, 1), currentStyle.IsItalic,
+                    currentStyle.IsBold, currentStyle.Color));
+                currentPos = nextTagPos + 1;
             }
         }
 
@@ -1318,6 +1334,15 @@ public static class ImageRenderer
     private static string ReverseNumberAndLatinOnly(string input, bool isRightToLeft)
     {
         if (!isRightToLeft || string.IsNullOrEmpty(input))
+        {
+            return input;
+        }
+
+        // The pre-reverse exists only to cancel out SKShaper reversing the line, and HarfBuzz
+        // reverses only when the line itself resolves right-to-left. A line with no RTL letter -
+        // a song title, a credit, a bare number - resolves left-to-right, so pre-reversing it just
+        // rendered it mirrored ("ABC" as "CBA", "123" as "321").
+        if (!LanguageAutoDetect.ContainsRightToLeftLetter(input))
         {
             return input;
         }

--- a/src/ui/Features/Files/FormatProperties/ItunesTimedTextProperties/ItunesTimedTextPropertiesViewModel.cs
+++ b/src/ui/Features/Files/FormatProperties/ItunesTimedTextProperties/ItunesTimedTextPropertiesViewModel.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Xml.Linq;
+using Nikse.SubtitleEdit.Logic.Config;
 
 namespace Nikse.SubtitleEdit.Features.Files.FormatProperties.ItunesTimedTextProperties;
 
@@ -391,13 +392,14 @@ public partial class ItunesTimedTextPropertiesViewModel : ObservableObject
         }
 
         // Save settings
-        Configuration.Settings.SubtitleSettings.TimedTextItunesLanguage = SelectedLanguage;
-        Configuration.Settings.SubtitleSettings.TimedTextItunesStyleAttribute = SelectedStyleAttribute;
-        Configuration.Settings.SubtitleSettings.TimedTextItunesTimeCodeFormat = SelectedTimeCodeFormat;
-        Configuration.Settings.SubtitleSettings.TimedTextItunesTopOrigin = TopOrigin;
-        Configuration.Settings.SubtitleSettings.TimedTextItunesTopExtent = TopExtent;
-        Configuration.Settings.SubtitleSettings.TimedTextItunesBottomOrigin = BottomOrigin;
-        Configuration.Settings.SubtitleSettings.TimedTextItunesBottomExtent = BottomExtent;
+        var formats = Se.Settings.Formats;
+        formats.TimedTextItunesLanguage = SelectedLanguage ?? string.Empty;
+        formats.TimedTextItunesStyleAttribute = SelectedStyleAttribute;
+        formats.TimedTextItunesTimeCodeFormat = SelectedTimeCodeFormat;
+        formats.TimedTextItunesTopOrigin = TopOrigin;
+        formats.TimedTextItunesTopExtent = TopExtent;
+        formats.TimedTextItunesBottomOrigin = BottomOrigin;
+        formats.TimedTextItunesBottomExtent = BottomExtent;
     }
 
     private static void SetOrRemoveAttribute(XElement element, XName name, string? value)
@@ -423,12 +425,19 @@ public partial class ItunesTimedTextPropertiesViewModel : ObservableObject
 
     private void SaveSettings()
     {
-        Configuration.Settings.SubtitleSettings.TimedTextItunesTopOrigin = TopOrigin;
-        Configuration.Settings.SubtitleSettings.TimedTextItunesTopExtent = TopExtent;
-        Configuration.Settings.SubtitleSettings.TimedTextItunesBottomOrigin = BottomOrigin;
-        Configuration.Settings.SubtitleSettings.TimedTextItunesBottomExtent = BottomExtent;
-        Configuration.Settings.SubtitleSettings.TimedTextItunesTimeCodeFormat = SelectedTimeCodeFormat;
-        Configuration.Settings.SubtitleSettings.TimedTextItunesStyleAttribute = SelectedStyleAttribute;
+        // These used to be written onto the libse Configuration singleton only, which SE5 never
+        // persists - the regions, time code format and style attribute were back at their defaults
+        // after every restart.
+        var formats = Se.Settings.Formats;
+        formats.TimedTextItunesTopOrigin = TopOrigin;
+        formats.TimedTextItunesTopExtent = TopExtent;
+        formats.TimedTextItunesBottomOrigin = BottomOrigin;
+        formats.TimedTextItunesBottomExtent = BottomExtent;
+        formats.TimedTextItunesTimeCodeFormat = SelectedTimeCodeFormat;
+        formats.TimedTextItunesStyleAttribute = SelectedStyleAttribute;
+        formats.TimedTextItunesLanguage = SelectedLanguage ?? string.Empty;
+
+        Se.SaveSettings();
     }
 
     [RelayCommand]

--- a/src/ui/Features/Files/FormatProperties/TimedText10Properties/TimedText10PropertiesViewModel.cs
+++ b/src/ui/Features/Files/FormatProperties/TimedText10Properties/TimedText10PropertiesViewModel.cs
@@ -363,20 +363,24 @@ public partial class TimedText10PropertiesViewModel : ObservableObject
         }
 
         // Settings
-        Configuration.Settings.SubtitleSettings.TimedText10TimeCodeFormat = SelectedTimeCodeFormat;
+        var formats = Se.Settings.Formats;
+        formats.TimedText10TimeCodeFormat = SelectedTimeCodeFormat;
 
-        var currentExt = Configuration.Settings.SubtitleSettings.TimedText10FileExtension;
+        var currentExt = formats.TimedText10FileExtension;
         if (currentExt != SelectedFileExtension)
         {
-            var favoriteFormats = Configuration.Settings.General.FavoriteSubtitleFormats;
+            // SE5's favourites live in Se.Settings.General - nothing mirrors them onto the libse
+            // copy this used to edit, so the rename was a no-op and the stored
+            // "Timed Text 1.0 (.xml)" entry stopped matching the renamed format and was dropped.
+            var favoriteFormats = Se.Settings.General.FavoriteSubtitleFormats;
             var currentWithExt = $"Timed Text 1.0 ({currentExt})";
             var newWithExt = $"Timed Text 1.0 ({SelectedFileExtension})";
-            if (favoriteFormats != null && favoriteFormats.Contains(currentWithExt))
+            if (!string.IsNullOrEmpty(favoriteFormats) && favoriteFormats.Contains(currentWithExt))
             {
-                Configuration.Settings.General.FavoriteSubtitleFormats = favoriteFormats.Replace(currentWithExt, newWithExt);
+                Se.Settings.General.FavoriteSubtitleFormats = favoriteFormats.Replace(currentWithExt, newWithExt);
             }
 
-            Configuration.Settings.SubtitleSettings.TimedText10FileExtension = SelectedFileExtension;
+            formats.TimedText10FileExtension = SelectedFileExtension;
         }
     }
 
@@ -396,17 +400,21 @@ public partial class TimedText10PropertiesViewModel : ObservableObject
     private void Ok()
     {
         WriteValuesToXml();
-        
+
         if (!string.IsNullOrEmpty(SelectedFileExtension))
         {
-            Configuration.Settings.SubtitleSettings.TimedText10FileExtension = SelectedFileExtension;
+            Se.Settings.Formats.TimedText10FileExtension = SelectedFileExtension;
         }
-        
+
         if (!string.IsNullOrEmpty(SelectedTimeCodeFormat))
         {
-            Configuration.Settings.SubtitleSettings.TimedText10TimeCodeFormat = SelectedTimeCodeFormat;
+            Se.Settings.Formats.TimedText10TimeCodeFormat = SelectedTimeCodeFormat;
         }
-        
+
+        // Writing only to the libse singleton, as this did, lost every choice on restart - it has
+        // no persistence in SE5. SaveSettings mirrors these back onto it.
+        Se.SaveSettings();
+
         OkPressed = true;
         Window?.Close();
     }

--- a/src/ui/Features/Files/FormatProperties/TimedTextImsc11Properties/TimedTextImsc11PropertiesViewModel.cs
+++ b/src/ui/Features/Files/FormatProperties/TimedTextImsc11Properties/TimedTextImsc11PropertiesViewModel.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Xml.Linq;
+using Nikse.SubtitleEdit.Logic.Config;
 
 namespace Nikse.SubtitleEdit.Features.Files.FormatProperties.TimedTextImsc11Properties;
 
@@ -298,20 +299,23 @@ public partial class TimedTextImsc11PropertiesViewModel : ObservableObject
         }
 
         // Settings
-        Configuration.Settings.SubtitleSettings.TimedTextImsc11TimeCodeFormat = SelectedTimeCodeFormat;
+        var formats = Se.Settings.Formats;
+        formats.TimedTextImsc11TimeCodeFormat = SelectedTimeCodeFormat;
 
-        var currentExt = Configuration.Settings.SubtitleSettings.TimedTextImsc11FileExtension;
+        var currentExt = formats.TimedTextImsc11FileExtension;
         if (currentExt != SelectedFileExtension)
         {
-            var favoriteFormats = Configuration.Settings.General.FavoriteSubtitleFormats;
+            // Same as Timed Text 1.0: SE5's favourites are in Se.Settings.General, so renaming the
+            // libse copy did nothing and the favourite was silently dropped.
+            var favoriteFormats = Se.Settings.General.FavoriteSubtitleFormats;
             var currentWithExt = $"Timed Text IMSC 1.1 ({currentExt})";
             var newWithExt = $"Timed Text IMSC 1.1 ({SelectedFileExtension})";
-            if (favoriteFormats != null && favoriteFormats.Contains(currentWithExt))
+            if (!string.IsNullOrEmpty(favoriteFormats) && favoriteFormats.Contains(currentWithExt))
             {
-                Configuration.Settings.General.FavoriteSubtitleFormats = favoriteFormats.Replace(currentWithExt, newWithExt);
+                Se.Settings.General.FavoriteSubtitleFormats = favoriteFormats.Replace(currentWithExt, newWithExt);
             }
 
-            Configuration.Settings.SubtitleSettings.TimedTextImsc11FileExtension = SelectedFileExtension;
+            formats.TimedTextImsc11FileExtension = SelectedFileExtension;
         }
     }
 
@@ -334,8 +338,10 @@ public partial class TimedTextImsc11PropertiesViewModel : ObservableObject
         
         if (!string.IsNullOrEmpty(SelectedFileExtension))
         {
-            Configuration.Settings.SubtitleSettings.TimedTextImsc11FileExtension = SelectedFileExtension;
+            Se.Settings.Formats.TimedTextImsc11FileExtension = SelectedFileExtension;
         }
+
+        Se.SaveSettings();
 
         OkPressed = true;
         Window?.Close();

--- a/src/ui/Features/Files/ImportPlainText/ImportPlainTextViewModel.cs
+++ b/src/ui/Features/Files/ImportPlainText/ImportPlainTextViewModel.cs
@@ -47,6 +47,10 @@ public partial class ImportPlainTextViewModel : ObservableObject, IClosingCleanu
     private readonly IFileHelper _fileHelper;
     private readonly IWindowService _windowService;
     private static readonly string[] TextFileExtensions = { ".txt", ".rtf" };
+
+    // What Se.Settings.Tools.ImportTextSplitting stores - a stable token per SplitAtOptions entry,
+    // in the same order, so the remembered choice does not depend on the UI language.
+    private static readonly string[] SplitAtOptionKeys = { "auto", "blankLines", "oneLineIsOneSubtitle", "twoLinesAreOneSubtitle" };
     private static readonly List<string> TextFilePatterns = TextFileExtensions.Select(e => "*" + e).ToList();
     private bool _dirty;
     private TaskCompletionSource? _previewFlushed;
@@ -66,11 +70,15 @@ public partial class ImportPlainTextViewModel : ObservableObject, IClosingCleanu
             Se.Language.File.Import.OneLineIsOneSubtitle,
             Se.Language.File.Import.TwoLinesAreOneSubtitle,
         };
-        SelectedSplitAtOption = SplitAtOptions[0];
+        var splitIndex = Array.IndexOf(SplitAtOptionKeys, Se.Settings.Tools.ImportTextSplitting);
+        SelectedSplitAtOption = SplitAtOptions[splitIndex > 0 && splitIndex < SplitAtOptions.Count ? splitIndex : 0];
         PlainText = string.Empty;
         MinGapMs = Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
         AlignProgress = string.Empty;
-        FixedDurationMs = (int)Math.Round(Se.Settings.Tools.AdjustDurations.AdjustDurationFixed * 1000.0, MidpointRounding.AwayFromZero);
+        UseFixedDuration = !Se.Settings.Tools.ImportTextDurationAuto;
+        FixedDurationMs = Se.Settings.Tools.ImportTextFixedDuration > 0
+            ? Se.Settings.Tools.ImportTextFixedDuration
+            : (int)Math.Round(Se.Settings.Tools.AdjustDurations.AdjustDurationFixed * 1000.0, MidpointRounding.AwayFromZero);
 
         _timerUpdatePreview = new Timer();
         _timerUpdatePreview.Interval = 250;
@@ -259,6 +267,17 @@ public partial class ImportPlainTextViewModel : ObservableObject, IClosingCleanu
     [RelayCommand]
     private void Ok()
     {
+        // Remember what was picked - reopening the dialog used to come back at "Auto" and the
+        // global default duration every time, while Settings.json carried a dozen SE4-shaped
+        // import keys that nothing read.
+        var splitIndex = SplitAtOptions.IndexOf(SelectedSplitAtOption);
+        Se.Settings.Tools.ImportTextSplitting = splitIndex >= 0 && splitIndex < SplitAtOptionKeys.Length
+            ? SplitAtOptionKeys[splitIndex]
+            : SplitAtOptionKeys[0];
+        Se.Settings.Tools.ImportTextDurationAuto = !UseFixedDuration;
+        Se.Settings.Tools.ImportTextFixedDuration = FixedDurationMs;
+        Se.SaveSettings();
+
         OkPressed = true;
         Close();
     }

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -3160,6 +3160,22 @@ public partial class MainViewModel :
         _subtitleOriginal ??= new Subtitle();
         _subtitleOriginal.OriginalFormat = _subtitle.OriginalFormat ?? SelectedSubtitleFormat;
 
+        // The format alone is not enough: for ASSA the header carries [Script Info] and the whole
+        // [V4+ Styles] block, and AdvancedSubStationAlpha.ToText falls back to its built-in default
+        // template when the header has no [V4+ Styles]. The original started life as an empty
+        // Subtitle, so saving it wrote that default over the styles of the very file the
+        // translation was made from - leaving every row's Style/Extra naming a style that no
+        // longer existed.
+        if (string.IsNullOrEmpty(_subtitleOriginal.Header))
+        {
+            _subtitleOriginal.Header = _subtitle.Header;
+        }
+
+        if (string.IsNullOrEmpty(_subtitleOriginal.Footer))
+        {
+            _subtitleOriginal.Footer = _subtitle.Footer;
+        }
+
         // Rebuilds the original from the rows - one line per row, in order - and re-points every
         // row at the line it just produced. The callers have already left the modes that would
         // make this a projection instead of the whole original.
@@ -3654,7 +3670,11 @@ public partial class MainViewModel :
         var saved = await SaveSubtitle();
         var savedOriginal = false;
 
-        if (ShowColumnOriginalText && _changeSubtitleHashOriginal != GetFastHashOriginal())
+        // Only when the subtitle itself was written. Ctrl+S is one gesture: after a translation
+        // _converted is set, so SaveSubtitle routes to "Save as" and returns false when the user
+        // dismisses the picker - and the original was written anyway, over the file the
+        // translation was made from, by a save the user had just cancelled.
+        if (saved && ShowColumnOriginalText && _changeSubtitleHashOriginal != GetFastHashOriginal())
         {
             savedOriginal = await SaveSubtitleOriginal();
         }
@@ -6677,6 +6697,11 @@ public partial class MainViewModel :
             return;
         }
 
+        // Nothing has been edited yet when the subtitle was clean on the way in: the original
+        // column then holds exactly the file that is already on disk, so the hash may be rebased
+        // below and Ctrl+S will not rewrite that file for no reason.
+        var wasClean = _changeSubtitleHash == GetFastHash();
+
         // A display-only row of a read-only original carries no text to translate from, and the
         // original it shows is replaced by the rows' text here (#14091).
         RemoveReferenceOnlyRows();
@@ -6696,6 +6721,12 @@ public partial class MainViewModel :
         IsShowingOriginalNonMatchingLines = false;
         ShowColumnOriginalText = true;
         CaptureOriginalFromTranslatedRows();
+
+        if (wasClean)
+        {
+            _changeSubtitleHashOriginal = GetFastHashOriginal();
+        }
+
         AutoFitColumns();
         ShowStatus(Se.Language.Main.CreatedEmptyTranslation);
     }
@@ -9271,6 +9302,18 @@ public partial class MainViewModel :
         _vlcReloader.SmpteMode = IsSmpteTimingEnabled;
     }
 
+    /// <summary>
+    /// SMPTE mode is session state on this view model, but BDN XML export, DOST export and the
+    /// Netflix shot-change check all read it off the libse singleton - and nothing ever wrote that
+    /// flag, so it was permanently false and all three kept applying the 1.001 pull-down to a
+    /// subtitle the user had put in SMPTE timing.
+    /// </summary>
+    partial void OnIsSmpteTimingEnabledChanged(bool value)
+    {
+        Se.Settings.General.CurrentVideoIsSmpte = value;
+        Configuration.Settings.General.CurrentVideoIsSmpte = value;
+    }
+
     [RelayCommand]
     private async Task ShowSmpteTiming()
     {
@@ -10901,11 +10944,6 @@ public partial class MainViewModel :
         // The subtitle language just changed, so the cached detected language is stale (issue #12144).
         _detectedLanguageCode = null;
 
-        if (!wasOldTranslationChanged)
-        {
-            _changeSubtitleHashOriginal = GetFastHashOriginal();
-        }
-
         var targetLanguageCode = result.SelectedTargetLanguage?.TwoLetterIsoLanguageName;
         _subtitleFileNameOriginal = _subtitleFileName;
         if (!string.IsNullOrEmpty(_subtitleFileName) && !string.IsNullOrEmpty(targetLanguageCode))
@@ -10969,6 +11007,15 @@ public partial class MainViewModel :
         IsShowingOriginalNonMatchingLines = false;
         ShowColumnOriginalText = true;
         CaptureOriginalFromTranslatedRows();
+
+        // Rebased here, not before the block above: _subtitleFileNameOriginal is part of the hash
+        // and only changes up there, so taking it early left the original permanently "dirty" and
+        // every Ctrl+S rewrote the file the translation was made from, edited or not.
+        if (!wasOldTranslationChanged)
+        {
+            _changeSubtitleHashOriginal = GetFastHashOriginal();
+        }
+
         AutoFitColumns();
         _updateAudioVisualizer = true;
     }
@@ -19710,22 +19757,29 @@ public partial class MainViewModel :
                 var f = new IsmtDfxp();
                 if (f.IsMine(null, fileName))
                 {
-                    f.LoadSubtitle(_subtitle, null, fileName);
+                    // Into a local subtitle, not _subtitle: ResetSubtitle() below clears that
+                    // object's paragraphs *and* replaces the field with a fresh Subtitle, so
+                    // loading first (as this did) left the grid empty and _subtitleFileName
+                    // pointing at a name an later save would have written empty over. The .mcc
+                    // branch just below has the order right.
+                    var loaded = new Subtitle();
+                    f.LoadSubtitle(loaded, null, fileName);
 
-                    if (_subtitle.OriginalFormat?.Name == new TimedTextBase64Image().Name)
+                    if (loaded.OriginalFormat?.Name == new TimedTextBase64Image().Name)
                     {
-                        ImportAndInlineBase64(_subtitle, fileName, skipLoadVideo);
+                        ImportAndInlineBase64(loaded, fileName, skipLoadVideo);
                         return;
                     }
 
-                    if (_subtitle.OriginalFormat?.Name == new TimedTextImage().Name)
+                    if (loaded.OriginalFormat?.Name == new TimedTextImage().Name)
                     {
-                        ImportAndOcrDost(fileName, _subtitle, skipLoadVideo);
+                        ImportAndOcrDost(fileName, loaded, skipLoadVideo);
                         return;
                     }
 
                     VideoCloseFile();
                     ResetSubtitle();
+                    _subtitle.Paragraphs.AddRange(loaded.Paragraphs);
                     _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName) +
                                         SelectedSubtitleFormat.Extension;
                     _subtitle.Renumber();
@@ -22207,20 +22261,25 @@ public partial class MainViewModel :
             return false;
         }
 
-        var newFileName = "New" + SelectedSubtitleFormat.Extension;
+        // The format the original is actually written with (see SaveSubtitleOriginal), which is
+        // not necessarily the one selected in the toolbar. Offering the selected format's
+        // extension and file filter produced a file named ".ass" with SubRip text inside it.
+        var originalFormat = _subtitleOriginal?.OriginalFormat ?? SelectedSubtitleFormat;
+
+        var newFileName = "New" + originalFormat.Extension;
         if (!string.IsNullOrEmpty(_subtitleFileNameOriginal))
         {
             newFileName = Path.GetFileNameWithoutExtension(_subtitleFileNameOriginal) +
-                          SelectedSubtitleFormat.Extension;
+                          originalFormat.Extension;
         }
         else if (!string.IsNullOrEmpty(_videoFileName))
         {
-            newFileName = Path.GetFileNameWithoutExtension(_videoFileName) + SelectedSubtitleFormat.Extension;
+            newFileName = Path.GetFileNameWithoutExtension(_videoFileName) + originalFormat.Extension;
         }
 
         var fileName = await _fileHelper.PickSaveSubtitleFile(
             Window!,
-            SelectedSubtitleFormat,
+            originalFormat,
             newFileName,
             Se.Language.General.SaveOriginalAsTitle);
 
@@ -22231,19 +22290,21 @@ public partial class MainViewModel :
 
         var oldSubtitleFileNameOriginal = _subtitleFileNameOriginal;
         var oldSubtitleOriginalFileName = _subtitleOriginal.FileName;
-        var oldLastOpenSaveFormat = _lastOpenSaveFormat;
 
         _subtitleFileNameOriginal = fileName;
         _subtitleOriginal ??= new Subtitle();
         _subtitleOriginal.FileName = fileName;
 
-        _lastOpenSaveFormat = SelectedSubtitleFormat;
+        // _lastOpenSaveFormat belongs to the *main* subtitle - SaveSubtitle compares it against
+        // SelectedSubtitleFormat and diverts to "Save as", which is the only thing stopping a
+        // format change from being written straight into the old file. SaveSubtitleOriginal never
+        // reads it, and setting it here left it pointing at the wrong format, so the next Ctrl+S
+        // silently wrote (say) ASSA text into movie.srt.
         var result = await SaveSubtitleOriginal();
         if (!result)
         {
             _subtitleFileNameOriginal = oldSubtitleFileNameOriginal;
             _subtitleOriginal.FileName = oldSubtitleOriginalFileName;
-            _lastOpenSaveFormat = oldLastOpenSaveFormat;
             return false;
         }
 
@@ -29158,13 +29219,12 @@ public partial class MainViewModel :
                     return;
                 }
 
-                foreach (var file in files)
+                // One subtitle at a time: looping and calling SubtitleOpen per file left only the
+                // last one loaded, with the "save changes?" prompt asked once at the top.
+                var path = files.Select(f => f.Path?.LocalPath).FirstOrDefault(p => p != null && File.Exists(p));
+                if (path != null)
                 {
-                    var path = file.Path?.LocalPath;
-                    if (path != null && File.Exists(path))
-                    {
-                        await SubtitleOpen(path);
-                    }
+                    await SubtitleOpen(path);
                 }
             });
         }
@@ -29202,23 +29262,19 @@ public partial class MainViewModel :
                     if (path != null && File.Exists(path))
                     {
                         var ext = Path.GetExtension(path).ToLowerInvariant();
-                        var subtitleExtensions = new List<string>
+
+                        // The open picker's own list, so dropping a file here and dropping it on
+                        // the grid can never disagree about what a subtitle is. The hardcoded 16
+                        // entries this replaces sent .scc, .sbv, .itt, .lrc, .rt, .mpl2 and .usf
+                        // straight to mpv, which then reported the subtitle file as a loaded
+                        // video. GetOpenSubtitleExtensions deliberately leaves .mkv/.mp4/.ts out,
+                        // so those still open as video; the binary image formats are added back on
+                        // top because they were in the old list.
+                        var subtitleExtensions = new HashSet<string>(
+                            FileHelper.GetOpenSubtitleExtensions(false), StringComparer.OrdinalIgnoreCase)
                         {
-                            ".ass",
-                            ".cap",
-                            ".dfxp",
-                            ".pac",
-                            ".sami",
-                            ".smi",
-                            ".srt",
-                            ".ssa",
-                            ".stl",
-                            ".sub",
                             ".sup",
-                            ".ttml",
-                            ".txt",
-                            ".vtt",
-                            ".xml",
+                            ".idx",
                         };
 
                         if (subtitleExtensions.Contains(ext))

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -717,10 +717,15 @@ public partial class SubtitleLineViewModel : ObservableObject
         get
         {
             var general = Se.Settings.General;
-            if ((general.ColorDurationTooShort && Duration.TotalMilliseconds < general.SubtitleMinimumDisplayMilliseconds) ||
-                (general.ColorDurationTooLong && Duration.TotalMilliseconds > general.SubtitleMaximumDisplayMilliseconds) ||
+
+            // Rounded exactly as HasErrors/GetErrorList round - a cell tinted on the raw value
+            // while the error list rounds meant a red cell that "list errors" and error
+            // navigation could not see (CPS 20.004 against a maximum of 20).
+            var durMsRounded = Math.Round(Duration.TotalMilliseconds, 3, MidpointRounding.AwayFromZero);
+            if ((general.ColorDurationTooShort && durMsRounded < general.SubtitleMinimumDisplayMilliseconds) ||
+                (general.ColorDurationTooLong && durMsRounded > general.SubtitleMaximumDisplayMilliseconds) ||
                 // SE4 fallback: when the CPS column is hidden, surface CPS-too-high on the Duration cell instead
-                ((!general.ShowColumnCps || !IsCpsColumnVisible) && general.ColorCharactersPerSecond && CharactersPerSecond > general.SubtitleMaximumCharactersPerSeconds))
+                ((!general.ShowColumnCps || !IsCpsColumnVisible) && general.ColorCharactersPerSecond && CpsRounded > general.SubtitleMaximumCharactersPerSeconds))
             {
                 return _errorBrush;
             }
@@ -740,7 +745,7 @@ public partial class SubtitleLineViewModel : ObservableObject
         get
         {
             if (Se.Settings.General.ColorCharactersPerSecond &&
-                CharactersPerSecond > Se.Settings.General.SubtitleMaximumCharactersPerSeconds)
+                CpsRounded > Se.Settings.General.SubtitleMaximumCharactersPerSeconds)
             {
                 return _errorBrush;
             }
@@ -833,17 +838,18 @@ public partial class SubtitleLineViewModel : ObservableObject
                 Add("gap too short");
             }
 
-            if (general.ColorDurationTooShort && Duration.TotalMilliseconds < general.SubtitleMinimumDisplayMilliseconds)
+            var durMsRounded = Math.Round(Duration.TotalMilliseconds, 3, MidpointRounding.AwayFromZero);
+            if (general.ColorDurationTooShort && durMsRounded < general.SubtitleMinimumDisplayMilliseconds)
             {
                 Add("duration too short");
             }
 
-            if (general.ColorDurationTooLong && Duration.TotalMilliseconds > general.SubtitleMaximumDisplayMilliseconds)
+            if (general.ColorDurationTooLong && durMsRounded > general.SubtitleMaximumDisplayMilliseconds)
             {
                 Add("duration too long");
             }
 
-            if (general.ColorCharactersPerSecond && CharactersPerSecond > general.SubtitleMaximumCharactersPerSeconds)
+            if (general.ColorCharactersPerSecond && CpsRounded > general.SubtitleMaximumCharactersPerSeconds)
             {
                 Add("CPS " + Math.Round(CharactersPerSecond, 1));
             }
@@ -1188,12 +1194,17 @@ public partial class SubtitleLineViewModel : ObservableObject
     /// memoized verdict - the error scans (list errors, go to next/previous error) only need
     /// the yes/no answer, and they ask it for every line of the file.
     /// </summary>
+    /// <summary>
+    /// The CPS the error rules compare against. The cell tints have to use this too, or a row can
+    /// be painted red and still be invisible to "list errors" and to error navigation.
+    /// </summary>
+    private double CpsRounded => Math.Round(CharactersPerSecond, 2, MidpointRounding.AwayFromZero);
+
     public bool HasErrors(SubtitleLineViewModel? prev, SubtitleLineViewModel? next)
     {
         var general = Se.Settings.General;
 
-        if (general.ColorCharactersPerSecond &&
-            Math.Round(CharactersPerSecond, 2, MidpointRounding.AwayFromZero) > general.SubtitleMaximumCharactersPerSeconds)
+        if (general.ColorCharactersPerSecond && CpsRounded > general.SubtitleMaximumCharactersPerSeconds)
         {
             return true;
         }
@@ -1260,7 +1271,7 @@ public partial class SubtitleLineViewModel : ObservableObject
             }
         }
 
-        var cpsRounded = Math.Round(CharactersPerSecond, 2, MidpointRounding.AwayFromZero);
+        var cpsRounded = CpsRounded;
         if (cpsRounded > general.SubtitleMaximumCharactersPerSeconds && general.ColorCharactersPerSecond)
         {
             errors.Add(new LineError(LineErrorType.CharactersPerSecond, string.Format(l.DetailXGreaterThanY, cpsRounded, general.SubtitleMaximumCharactersPerSeconds)));

--- a/src/ui/Features/Video/CutVideo/CutVideoViewModel.cs
+++ b/src/ui/Features/Video/CutVideo/CutVideoViewModel.cs
@@ -80,6 +80,15 @@ public partial class CutVideoViewModel : ObservableObject
     private SubtitleFormat? _subtitleFormat;
     private string _inputVideoFileName;
     private bool _updateAudioVisualizer;
+
+    // ffmpeg's stdout and stderr readers both call OutputHandlerKeyFrames, on two thread pool
+    // threads, while the waveform render thread walks AudioVisualizer.ShotChanges every frame.
+    // List<T>.Add publishes the grown array and the new size non-atomically, so adding straight
+    // into the live list could throw IndexOutOfRangeException out of Render. Collect here under a
+    // lock and hand the visualizer a finished list on the UI thread instead - what every other
+    // shot-change writer does - coalescing the publishes so a long file cannot flood the queue.
+    private readonly List<double> _keyFrameSeconds = new List<double>();
+    private bool _keyFramePublishPending;
     private DispatcherTimer _positionTimer = new DispatcherTimer();
     private string _importFileName;
     private Subtitle _currentSubtitle;
@@ -288,8 +297,29 @@ public partial class CutVideoViewModel : ObservableObject
 
             if (double.TryParse(ptsValue, NumberStyles.Float, CultureInfo.InvariantCulture, out double seconds))
             {
-                AudioVisualizer.ShotChanges.Add(seconds);
-                _updateAudioVisualizer = true;
+                lock (_keyFrameSeconds)
+                {
+                    _keyFrameSeconds.Add(seconds);
+                    if (_keyFramePublishPending)
+                    {
+                        return;
+                    }
+
+                    _keyFramePublishPending = true;
+                }
+
+                Dispatcher.UIThread.Post(() =>
+                {
+                    List<double> snapshot;
+                    lock (_keyFrameSeconds)
+                    {
+                        _keyFramePublishPending = false;
+                        snapshot = new List<double>(_keyFrameSeconds);
+                    }
+
+                    AudioVisualizer.ShotChanges = snapshot;
+                    _updateAudioVisualizer = true;
+                }, DispatcherPriority.Background);
             }
         }
     }

--- a/src/ui/Logic/ColorService.cs
+++ b/src/ui/Logic/ColorService.cs
@@ -123,7 +123,7 @@ public class ColorService : IColorService
             return text;
         }
 
-        if (subtitleFormat is WebVTT)
+        if (subtitleFormat is WebVTT or WebVTTFileWithLineNumber)
         {
             try
             {
@@ -216,7 +216,7 @@ public class ColorService : IColorService
             return text;
         }
 
-        if (subtitleFormat is WebVTT)
+        if (subtitleFormat is WebVTT or WebVTTFileWithLineNumber)
         {
             try
             {

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -466,6 +466,7 @@ public class Se
         // open (see the note in UpdateLibSeSettings).
         Configuration.Settings.SubtitleSettings.EbuStlTeletextUseBox = Settings.File.EbuSaveOptions.TeletextUseBox;
         Configuration.Settings.SubtitleSettings.EbuStlTeletextUseDoubleHeight = Settings.File.EbuSaveOptions.TeletextUseDoubleHeight;
+        ApplyStartupOnlyDCinemaSettings();
     }
 
     internal static void MigrateMacOsFontSettings(SeAppearance appearance, bool isMacOs, bool isLegacySettings)
@@ -819,11 +820,39 @@ public class Se
         ss.WebVttCueAn7 = Settings.Formats.WebVttCueAn7 ?? string.Empty;
         ss.WebVttCueAn8 = Settings.Formats.WebVttCueAn8 ?? string.Empty;
         ss.WebVttCueAn9 = Settings.Formats.WebVttCueAn9 ?? string.Empty;
+        ss.TimedText10TimeCodeFormat = Settings.Formats.TimedText10TimeCodeFormat;
+        ss.TimedText10FileExtension = Settings.Formats.TimedText10FileExtension;
+        ss.TimedTextItunesTopOrigin = Settings.Formats.TimedTextItunesTopOrigin;
+        ss.TimedTextItunesTopExtent = Settings.Formats.TimedTextItunesTopExtent;
+        ss.TimedTextItunesBottomOrigin = Settings.Formats.TimedTextItunesBottomOrigin;
+        ss.TimedTextItunesBottomExtent = Settings.Formats.TimedTextItunesBottomExtent;
+        ss.TimedTextItunesTimeCodeFormat = Settings.Formats.TimedTextItunesTimeCodeFormat;
+        ss.TimedTextItunesStyleAttribute = Settings.Formats.TimedTextItunesStyleAttribute;
+        ss.TimedTextItunesLanguage = Settings.Formats.TimedTextItunesLanguage ?? string.Empty;
+        ss.TimedTextImsc11TimeCodeFormat = Settings.Formats.TimedTextImsc11TimeCodeFormat;
+        ss.TimedTextImsc11FileExtension = Settings.Formats.TimedTextImsc11FileExtension;
+
         ss.DCinemaAutoGenerateSubtitleId = dc.DCinemaAutoGenerateSubtitleId;
         ss.DCinemaFontSize = dc.DCinemaFontSize;
         ss.DCinemaBottomMargin = dc.DCinemaBottomMargin;
         ss.DCinemaFadeUpTime = dc.DCinemaFadeUpTime;
         ss.DCinemaFadeDownTime = dc.DCinemaFadeDownTime;
+        Configuration.Settings.Tools.RememberUseAlwaysList = Settings.Tools.SpellCheckRememberUseAlwaysList;
+    }
+
+    /// <summary>
+    /// The "current D-Cinema file" values, applied at startup only. Same reason as the EBU
+    /// teletext flags above: DCinemaSmpte2007/2010/2014.LoadSubtitle seeds every one of these from
+    /// the opened file, so re-applying the persisted defaults after every SaveSettings (any dialog
+    /// OK) threw away the reel number, rates and start time of the file the user has open. The
+    /// D-Cinema properties dialogs push their own values through
+    /// MainViewModel.CopyCurrentDCinemaSettingsFromSe instead.
+    /// </summary>
+    private static void ApplyStartupOnlyDCinemaSettings()
+    {
+        var dc = Settings.File.DCinemaSmpte;
+        var ss = Configuration.Settings.SubtitleSettings;
+
         ss.CurrentDCinemaSubtitleId = dc.CurrentDCinemaSubtitleId;
         ss.CurrentDCinemaMovieTitle = dc.CurrentDCinemaMovieTitle;
         ss.CurrentDCinemaReelNumber = dc.CurrentDCinemaReelNumber;

--- a/src/ui/Logic/Config/SeFormats.cs
+++ b/src/ui/Logic/Config/SeFormats.cs
@@ -32,6 +32,21 @@ public class SeFormats
     public string WebVttCueAn8 { get; set; }
     public string WebVttCueAn9 { get; set; }
 
+    // Timed Text 1.0 / iTunes Timed Text / IMSC 1.1 file properties. These used to be written
+    // straight onto the libse Configuration singleton, which SE5 never persists - so every one of
+    // them was back at its built-in default after a restart.
+    public string TimedText10TimeCodeFormat { get; set; }
+    public string TimedText10FileExtension { get; set; }
+    public string TimedTextItunesTopOrigin { get; set; }
+    public string TimedTextItunesTopExtent { get; set; }
+    public string TimedTextItunesBottomOrigin { get; set; }
+    public string TimedTextItunesBottomExtent { get; set; }
+    public string TimedTextItunesTimeCodeFormat { get; set; }
+    public string TimedTextItunesStyleAttribute { get; set; }
+    public string TimedTextItunesLanguage { get; set; }
+    public string TimedTextImsc11TimeCodeFormat { get; set; }
+    public string TimedTextImsc11FileExtension { get; set; }
+
     public SeFormats()
     {
         RosettaLanguage = "en";
@@ -59,5 +74,17 @@ public class SeFormats
         WebVttCueAn7 = "position:20% line:20%";
         WebVttCueAn8 = "line:20%";
         WebVttCueAn9 = "position:80% line:20%";
+
+        TimedText10TimeCodeFormat = "Source";
+        TimedText10FileExtension = ".xml";
+        TimedTextItunesTopOrigin = "0% 0%";
+        TimedTextItunesTopExtent = "100% 15%";
+        TimedTextItunesBottomOrigin = "0% 85%";
+        TimedTextItunesBottomExtent = "100% 15%";
+        TimedTextItunesTimeCodeFormat = "Frames";
+        TimedTextItunesStyleAttribute = "tts:fontStyle";
+        TimedTextItunesLanguage = string.Empty;
+        TimedTextImsc11TimeCodeFormat = "hh:mm:ss.ms";
+        TimedTextImsc11FileExtension = ".xml";
     }
 }

--- a/src/ui/Logic/Config/SeTools.cs
+++ b/src/ui/Logic/Config/SeTools.cs
@@ -108,18 +108,9 @@ public class SeTools
     public bool BinEditPositionMonitorTitleSafeOn { get; set; }
     public double BinEditPositionMonitorTitleSafePercent { get; set; }
 
+    // Import plain text. Only the three options the dialog actually has are kept - the other
+    // twelve SE4-shaped keys here were written to Settings.json and read by nothing at all.
     public string ImportTextSplitting { get; set; }
-    public string ImportTextSplittingLineMode { get; set; }
-    public string ImportTextLineBreak { get; set; }
-    public bool ImportTextMergeShortLines { get; set; }
-    public bool ImportTextAutoSplitAtBlank { get; set; }
-    public bool ImportTextRemoveLinesNoLetters { get; set; }
-    public bool ImportTextGenerateTimeCodes { get; set; }
-    public bool ImportTextAutoBreak { get; set; }
-    public bool ImportTextAutoBreakAtEnd { get; set; }
-    public int ImportTextGap { get; set; }
-    public int ImportTextAutoSplitNumberOfLines { get; set; }
-    public string ImportTextAutoBreakAtEndMarkerText { get; set; }
     public bool ImportTextDurationAuto { get; set; }
     public int ImportTextFixedDuration { get; set; }
 
@@ -131,7 +122,10 @@ public class SeTools
     public string LastColorPickerColor5 { get; set; }
     public string LastColorPickerColor6 { get; set; }
     public string LastColorPickerColor7 { get; set; }
-    public bool ImportTextTryToFindTimeCodes { get; set; }
+    // Mirrored onto Configuration.Settings.Tools.RememberUseAlwaysList, which SpellCheckWordLists
+    // guards every load/save of "<lang>_UseAlways.xml" with. Nothing in SE5 ever set that flag, so
+    // "Change all" in spell check was a no-op that never survived the session.
+    public bool SpellCheckRememberUseAlwaysList { get; set; }
     public bool SpeechToTextSelectedLinesPromptFirstTimeOnly { get; set; }
     public bool MultipleReplaceShowDotDotDotButtons { get; set; }
     public bool GridFocusTextboxAfterInsertNew { get; set; }
@@ -242,20 +236,9 @@ public class SeTools
         BinEditPositionMonitorTitleSafePercent = 5;
 
         ImportTextSplitting = "auto";
-        ImportTextSplittingLineMode = "OneLineIsOneSubtitle";
-        ImportTextLineBreak = "|";
-        ImportTextMergeShortLines = false;
-        ImportTextAutoSplitAtBlank = true;
-        ImportTextRemoveLinesNoLetters = false;
-        ImportTextGenerateTimeCodes = true;
-        ImportTextAutoBreak = true;
-        ImportTextAutoBreakAtEnd = true;
-        ImportTextGap = 90;
-        ImportTextAutoSplitNumberOfLines = 2;
-        ImportTextAutoBreakAtEndMarkerText = ".!?";
         ImportTextDurationAuto = true;
-        ImportTextFixedDuration = 3000;
-        ImportTextTryToFindTimeCodes = false;
+        ImportTextFixedDuration = 0; // 0 = fall back to the "Adjust durations" fixed value
+        SpellCheckRememberUseAlwaysList = true;
         SpeechToTextSelectedLinesPromptFirstTimeOnly = true;
         MultipleReplaceShowDotDotDotButtons = true;
         GridFocusTextboxAfterInsertNew = true;

--- a/src/ui/Logic/Media/TextToImageGenerator.cs
+++ b/src/ui/Logic/Media/TextToImageGenerator.cs
@@ -1,5 +1,7 @@
 using SkiaSharp;
 using System;
+using System.Collections.Generic;
+using Nikse.SubtitleEdit.Core.Common;
 
 namespace Nikse.SubtitleEdit.Logic.Media;
 
@@ -124,31 +126,57 @@ public static class TextToImageGenerator
             font.SkewX = -0.25f; // synthetic slant so italic shows even when the font has no italic face
         }
 
-        font.MeasureText(text, out var textBounds, paint);
+        // MeasureText and GetTextPath are single-run APIs with no notion of a line break - a "\n"
+        // became a .notdef glyph and every line was drawn side by side on one baseline. The Set
+        // text dialog feeds this user text from a multi-line TextBox and writes the result straight
+        // into a VobSub/Blu-ray subtitle, so a normal two-line caption came out as one long line.
+        var lines = (text ?? string.Empty).SplitToLines();
+        if (lines.Count == 0)
+        {
+            lines = new List<string> { string.Empty };
+        }
 
-        var width = (int)(textBounds.Width + padding * 2 + outlineWidth * 2 + shadowWidth);
-        var height = (int)(textBounds.Height + padding * 2 + outlineWidth * 2 + shadowWidth);
+        var lineBounds = new SKRect[lines.Count];
+        var maxLineWidth = 0f;
+        for (var i = 0; i < lines.Count; i++)
+        {
+            font.MeasureText(lines[i], out lineBounds[i], paint);
+            maxLineWidth = Math.Max(maxLineWidth, lineBounds[i].Width);
+        }
+
+        var metrics = font.Metrics;
+        var lineHeight = Math.Abs(metrics.Ascent) + Math.Abs(metrics.Descent);
+        var lineStep = lineHeight + Math.Abs(metrics.Leading);
+
+        var width = (int)(maxLineWidth + padding * 2 + outlineWidth * 2 + shadowWidth);
+        var height = (int)(lineHeight + (lines.Count - 1) * lineStep + padding * 2 + outlineWidth * 2 + shadowWidth);
 
         var bitmap = new SKBitmap(width, height);
         using var canvas = new SKCanvas(bitmap);
         canvas.Clear(backgroundColor);
 
         var x = padding + outlineWidth;
-        var y = height - padding - outlineWidth;
+        var firstBaseline = padding + outlineWidth + Math.Abs(metrics.Ascent);
+        var y = firstBaseline;
 
-        // Create a path for the text
-        using var textPath = font.GetTextPath(text, new SKPoint(x, y));
-
-        // Draw shadow (includes both text and outline with rounded corners)
-        if (shadowWidth > 0)
+        for (var i = 0; i < lines.Count; i++)
         {
-            DrawTextWithRoundedOutline(x + shadowWidth, y + shadowWidth, shadowColor, shadowColor, textPath, x, y, cornerRadius, outlineWidth, paint, canvas);
+            y = firstBaseline + i * lineStep;
+
+            // Create a path for the line
+            using var textPath = font.GetTextPath(lines[i], new SKPoint(x, y));
+
+            // Draw shadow (includes both text and outline with rounded corners)
+            if (shadowWidth > 0)
+            {
+                DrawTextWithRoundedOutline(x + shadowWidth, y + shadowWidth, shadowColor, shadowColor, textPath, x, y, cornerRadius, outlineWidth, paint, canvas);
+            }
+
+            // Draw main text with rounded outline
+            DrawTextWithRoundedOutline(x, y, textColor, outlineColor, textPath, x, y, cornerRadius, outlineWidth, paint, canvas);
+
+            DrawUnderlineAndStrikeout(canvas, font, textColor, x, y, lineBounds[i].Width, fontSize, isUnderline, isStrikeout);
         }
-
-        // Draw main text with rounded outline
-        DrawTextWithRoundedOutline(x, y, textColor, outlineColor, textPath, x, y, cornerRadius, outlineWidth, paint, canvas);
-
-        DrawUnderlineAndStrikeout(canvas, font, textColor, x, y, textBounds.Width, fontSize, isUnderline, isStrikeout);
 
         return bitmap;
     }

--- a/src/ui/Logic/SubtitleSyntaxTokenizer.cs
+++ b/src/ui/Logic/SubtitleSyntaxTokenizer.cs
@@ -258,6 +258,13 @@ public static class SubtitleSyntaxTokenizer
 
         colorValue = colorValue.Trim();
 
+        // Inside a "\t(..)" transition the colour tag is followed by the transition's closing
+        // paren, which lands on the colour fragment when the block is split on '\'
+        // ({\c&HFFFFFF&\t(20,1000,\c&H29F2FF&)} - #10955). The grid's ParseAssaColor trims it;
+        // without the same trim here the EndsWith("&") test failed and the edit box painted the
+        // transition's colour in the generic values colour instead.
+        colorValue = colorValue.TrimEnd(')');
+
         // ASS/SSA color format: &HBBGGRR& or &HAABBGGRR&
         if (colorValue.StartsWith("&H", StringComparison.OrdinalIgnoreCase) && colorValue.EndsWith("&"))
         {

--- a/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
+++ b/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
@@ -177,7 +177,7 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
         if (formattingType == (int)SubtitleGridFormattingTypes.ShowTags)
         {
             var lines = MakeShowTags(str);
-            return SpellCheckLines(lines);
+            return SpellCheckLines(lines, skipColouredRuns: true);
         }
 
         // No formatting (default) - walk the line breaks directly instead of SplitToLines(),
@@ -212,7 +212,13 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
         return SpellCheckLines(inlines);
     }
 
-    private InlineCollection SpellCheckLines(InlineCollection lines)
+    /// <param name="skipColouredRuns">
+    /// Set for the "show tags" layout, where markup is split into its own coloured runs and only
+    /// the subtitle's own text is left with no brush. IsBetweenAssaTags/IsInsideHtmlTag look for
+    /// braces and brackets in the run they are given, and a tag-name run is bare ("pos"), so both
+    /// guards returned false and every tag name and attribute value got a red squiggle.
+    /// </param>
+    private InlineCollection SpellCheckLines(InlineCollection lines, bool skipColouredRuns = false)
     {
         if (_spellCheckManager == null || !Se.Settings.Appearance.SubtitleGridLiveSpellCheck)
         {
@@ -228,6 +234,12 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
                 if (inline is not Run run || string.IsNullOrWhiteSpace(run.Text))
                 {
                     newInlines.Add(inline);
+                    continue;
+                }
+
+                if (skipColouredRuns && run.Foreground != null)
+                {
+                    newInlines.Add(run);
                     continue;
                 }
 


### PR DESCRIPTION
Sixth bug hunt, over ground the five earlier sweeps did not touch: ~40 fresh subtitle formats, the file open/save lifecycle, settings serialization, the waveform/syntax-highlighting draw paths, and the image-export pipeline. Every finding was re-verified against the source before it was fixed, and the seven format fixes were confirmed empirically with a throwaway round-trip probe.

## Subtitle formats (8)

| | |
|---|---|
| **Eeg708** | `LoadSubtitle` never cleared the pending paragraph after an empty end-marker node, so the next cue's start time overwrote the previous cue's end time. Every gap in the file was swallowed; only the last cue kept its end time. |
| **UnknownSubtitle96** | `{0:0000}` *rounded* the raw `double` seconds that the separate frames field is meant to complete — any cue with ms ≥ 500 was written, and read back, a whole second late. |
| **TimeCodesOnly1** | The duration column emitted `TimeCode.ToString()` (`00:00:02,160`) where the format's own regex wants `SS:FF`, so a file this format wrote reloaded as **zero paragraphs**. |
| **ProjectionSubtitleList** | The 5-digit `\uNNNNN` branch tested five digits but read `Substring(i + 1, 4)`, decoding every CJK/Cyrillic/emoji character as a different one. |
| **Lrc** | The end-of-lyric marker had no hundredths-overflow guard (the start time does), so an end time of `00:01:04,999` printed `[01:04.100]` — rejected by the format's own regex. |
| **RxMarker** | Same missing guard on both time codes; a cue at x.997 produced `00:00:01:100.00`, which failed the regex and was appended as *text* to the previous cue. |
| **PinnacleImpression** | `1000 / 30` is integer division (33), so 990–999 ms produced frame 30 — out of range at 30 fps. |
| **CaptionsInc** | The scan loop leaves `i` at `buffer.Length` on a `.cin` file with no trailing `0x0a`; the marker read and the 8-byte time code then ran past the end. |

Verified with a round-trip probe:

```
Eeg708                1s→2s, 10s→12s   (was 1s→10s)
UnknownSubtitle96     "0005:14"        (was "0006:15")
TimeCodesOnly1        1 paragraph      (was 0)
Lrc                   "[01:05.00]"     (was "[01:04.100]")
RxMarker              cue survives     (was swallowed as text)
PinnacleImpression    00:00:07:29      (was 00:00:07:30)
ProjectionSubtitleList "한글 test"      (was mangled)
```

## File lifecycle (6)

- **The first Ctrl+S after a translation overwrote the source file's ASSA styles.** `CaptureOriginalFromTranslatedRows` copied `OriginalFormat` but never `Header`, so `AdvancedSubStationAlpha.ToText` fell back to its built-in default `[V4+ Styles]` template — over the file the translation was made from, leaving every row's `Style`/`Extra` naming a style that no longer existed. It carries `Header`/`Footer` across now.
- **The original was permanently "dirty" after translating.** The hash rebase ran *before* `_subtitleFileNameOriginal` — part of that hash — was changed; "make empty translation" never rebased at all.
- **Cancelling "Save as" still wrote the original file.** `CommandFileSave` ignored `SaveSubtitle()`'s return value.
- **"Save original as" clobbered `_lastOpenSaveFormat`**, which belongs to the *main* subtitle and is the only thing diverting a format change to "Save as" — the next Ctrl+S could write ASSA text straight into `movie.srt`.
- **"Save original as" offered the wrong format**: the picker locked to `SelectedSubtitleFormat` while the write used the original's own format, producing a `.ass` file holding SubRip.
- **Opening an MP4/ISMT-DFXP subtitle gave an empty grid** — it loaded into `_subtitle` and *then* called `ResetSubtitle()`, which clears that object and replaces the field. The `.mcc` branch 20 lines below has the order right.
- **Dropping a subtitle on the video pane or waveform opened it as a video** — the handler used a hardcoded 16-extension list, so `.scc`, `.sbv`, `.itt`, `.lrc`, `.rt`, `.mpl2` and `.usf` went to mpv, which then reported the subtitle file as a loaded video. A multi-file drop on the grid also loaded only the last file.

## Settings serialization (6)

- **SMPTE timing never reached the exporters.** Nothing wrote the libse `CurrentVideoIsSmpte` flag, so BDN XML export, DOST export and the Netflix shot-change check all kept applying the 1.001 pull-down to a subtitle the user had put in SMPTE timing.
- **D-Cinema SMPTE wrote empty `<EditRate/>`/`<TimeCodeRate/>`** — SE5 mirrors `string.Empty` and libse's fallback guard was `== null`, so the 24/25 fps default could never fire. The "current file" values are applied at startup only now; re-applying them after every `SaveSettings` threw away the reel number, rates and start time of the open file — the hazard the EBU comment beside it explicitly warns about.
- **Timed Text 1.0, iTunes Timed Text and IMSC 1.1 properties were lost on restart** — written only to libse's in-memory singleton, which SE5 never persists. They have a home in `Se.Settings.Formats` now, mirrored like the WebVTT ones.
- **Changing the TTML/IMSC extension silently dropped the favourite** — the rename edited the libse copy of `FavoriteSubtitleFormats`, which nothing populates, so the stored `Timed Text 1.0 (.xml)` entry stopped matching and was dropped at the next Options OK.
- **The spell-check "use always" list was dead code** — `RememberUseAlwaysList` guarded all three call sites and was assigned nowhere, so "Change all" never persisted. It has a setting now.
- **Twelve of the fifteen SE4-shaped `ImportText*` keys** were written to Settings.json and read by nothing. Removed; the Import plain text dialog now remembers the three options it actually has.

## Rendering and highlighting (5)

- **Shot changes were added to the live `AudioVisualizer` list from ffmpeg's reader threads** while the render thread walked it every frame. `List.Add` publishes the grown array and the new size non-atomically → `IndexOutOfRangeException` out of `Render`. Now collected under a lock and published to the UI thread, coalesced.
- **"WebVTT with line number" got `<font>` tags** — `RemoveColorTags` matched it, `SetColorTag`/`RemoveColorTag`/`ContainsColor` matched only `WebVTT`, and the two are siblings, not subclasses.
- **A red CPS or duration cell could be invisible to "list errors"** — the cell brushes compared the raw value while `HasErrors`/`GetErrorList` compared the rounded one, despite the doc comment saying to keep them in sync. CPS 20.004 against a max of 20 tinted red but reported no error.
- **"Show tags" mode spell-checked the tag names** — markup is split into its own brush-runs, so the tag-name run is bare (`"pos"`) and the brace-based guards never saw a brace. Every `pos`/`fad`/`bord` and every attribute value got a red squiggle.
- **The edit box never colourised a `\t(..)` transition's colour** — `TryParseAssColor` lacked the `TrimEnd(')')` its grid counterpart has for exactly this case (#10955).

## Image export (5)

- **A bare `<` duplicated text in every image-based export.** On an unparseable tag the preceding text had already been emitted and `currentPos` advanced by *one*, so the same region was emitted again and again: `"Wait < 5 minutes"` rendered as `"Wait ait it t   5 minutes"`.
- **An ASSA fade-out exported as a fully invisible subtitle** — `ApplyTransparencyTags` had no `\t(` guard, unlike `ApplyStyleOverrideTags` beside it, so `{\t(0,300,\alpha&HFF&)}` froze at alpha 0.
- **RTL export mirrored Latin-only and numeric lines** — the pre-reverse ran whenever the RTL flag was set, but the shaper only reverses when the line itself resolves RTL, so `"ABC"` came out `"CBA"`.
- **Per-line boxes were misregistered by the outline width** — the cropped bitmap is `2·outline + shadow` rows taller than the font line box, but the box was drawn from row 0. At the shipped defaults the effective bottom padding was `-1`, so descender outlines fell outside the box.
- **`GenerateImageWithPadding` drew multi-line text on one baseline** — `MeasureText`/`GetTextPath` are single-run APIs. Cosmetic for the style previews, but the Set text dialog feeds it user text from a multi-line box and writes the result straight into a VobSub/Blu-ray subtitle.

## Not fixed

- `FlashXml`/`AbcIViewer` write a variable-width millisecond field that SE round-trips but an external player would read as hundredths — ambiguous whose reading is right, left alone.
- The RTL word-order problem in *mixed* Hebrew+Latin lines needs real bidi, not a narrow fix. The Latin-only mirroring above is fixed; mixed lines behave as before.

## Testing

Full suite green first try, no test changes needed: **libse 1507 / libuilogic 703 / seconv 416 / UI 4113**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
