### PR TITLE
Add "Google it" to the subtitle text box context menu

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -1741,6 +1741,22 @@ public static partial class InitListViewAndEditBox
 
         flyoutTextBox.Items.Add(new Separator());
 
+        // Shown only with a selection - the command searches the selected text and does nothing
+        // without one. It had no default shortcut and was in no menu, so it was unreachable
+        // unless you imported SE4 shortcuts (same invisibility as casing, #13093).
+        var menuItemTextBoxGoogleIt = new MenuItem
+        {
+            Header = Se.Language.General.GoogleIt,
+            Command = vm.GoogleItCommand,
+            Icon = new Icon
+            {
+                Value = IconNames.Web,
+                VerticalAlignment = VerticalAlignment.Center,
+            },
+        };
+        menuItemTextBoxGoogleIt.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsTextBoxGoogleItVisible)));
+        flyoutTextBox.Items.Add(menuItemTextBoxGoogleIt);
+
         var menuItemTextBoxAiAssistant = new MenuItem
         {
             Header = Se.Language.Tools.AiAssistant.Title,

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -396,6 +396,7 @@ public partial class MainViewModel :
     [ObservableProperty] private bool _showColumnLayerFlyoutMenuItem;
     [ObservableProperty] private bool _isVideoLoaded;
     [ObservableProperty] private bool _isTextBoxSplitAtCursorAndVideoPositionVisible;
+    [ObservableProperty] private bool _isTextBoxGoogleItVisible;
     [ObservableProperty] private ObservableCollection<string> _speeds;
     [ObservableProperty] private string _selectedSpeed;
     [ObservableProperty] private ObservableCollection<string> _videoSeekAmounts;
@@ -28668,6 +28669,10 @@ public partial class MainViewModel :
     internal void TextBoxContextOpening(object? sender, EventArgs e)
     {
         IsTextBoxSplitAtCursorAndVideoPositionVisible = false;
+
+        // "Google it" searches the selection, so it only makes sense with one - and it was
+        // shortcut-only (with no default gesture), which made it look removed since SE4.
+        IsTextBoxGoogleItVisible = !string.IsNullOrWhiteSpace(EditTextBox.SelectedText);
 
         var s = SelectedSubtitle;
         var vp = GetVideoPlayerControl();


### PR DESCRIPTION
A user wrote in about the SE4 "Search text online" box being gone in SE5. That whole panel (the video-controls **Translate** tab: `groupBoxTranslateSearch`, with its search box plus *Google it* / *Google translate it* / two custom-URL buttons) does not exist in SE5 — but part of it survives as `MainViewModel.GoogleItCommand`, which searches the selected text in the main edit box.

The problem is that it is unreachable. It is registered as a shortcut with **no default gesture** and it appears in **no menu**, so unless you import SE4 shortcuts or bind a key by hand, there is no way to invoke it — which makes it look like a feature that was dropped.

This is the same invisibility problem as the casing commands in #13093, and the fix is the same: put it in the subtitle text box context menu.

## Changes

- `MainViewModel`: new `IsTextBoxGoogleItVisible` observable property, set from the live selection in `TextBoxContextOpening` — the hook that already computes the split-at-cursor item's visibility.
- `InitListViewAndEditBox`: the menu item, bound to that property via `Visual.IsVisibleProperty`, placed in the trailing group just above *AI assistant*, with an `IconNames.Web` icon.

The item is hidden rather than greyed out when there is no selection, because — unlike SE4's `RunTranslateSearch` — `GoogleIt` has no fallback to the whole line and simply returns.

`IsNullOrWhiteSpace` rather than `IsNullOrEmpty`, so selecting only spaces or a line break does not offer a search that `GoogleIt` would then silently drop on the same check.

## Not covered here

- `GoogleItCommand` still has no default shortcut.
- The rest of the "Search text online" panel (the retained search box and the custom-URL buttons) is still absent in SE5.

## Testing

Builds clean; the 6 warnings are pre-existing and elsewhere. The visibility binding copies the proven split-at-cursor pattern. Not verified on screen — the change was made in a headless session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)