### PR TITLE
EBU STL: keep the colors when the header lies about being teletext

### DIFF
--- a/src/libse/SubtitleFormats/Ebu.cs
+++ b/src/libse/SubtitleFormats/Ebu.cs
@@ -21,6 +21,11 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         private static readonly Regex FontTagsNoSpace1 = new Regex("[a-zA-z.!?]</font><font[a-zA-Z =\"']+>[a-zA-Z-]", RegexOptions.Compiled);
         private static readonly Regex FontTagsNoSpace2 = new Regex("[a-zA-z.!?]<font[a-zA-Z =\"']+>[a-zA-Z-]", RegexOptions.Compiled);
 
+        // "<font color=\"Blue\"></font>" - two teletext color codes in a row, e.g. a background
+        // color set right before the text color. Only the last one has any text, and SE has no
+        // background color for STL, so the empty tag is noise that shifts the text by a space.
+        private static readonly Regex EmptyFontTag = new Regex("<font color=\"[A-Za-z]+\"></font>", RegexOptions.Compiled);
+
         private static readonly Regex FontTagsStartSpace = new Regex("^<font color=\"[A-Za-z]+\"> ", RegexOptions.Compiled); // "<font color=\"Black\"> "
         private static readonly Regex FontTagsNewLineSpace = new Regex("[\r\n]+<font color=\"[A-Za-z]+\"> ", RegexOptions.Compiled); // "\r\n<font color=\"Black\"> "
 
@@ -1308,7 +1313,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             subtitle.Paragraphs.Clear();
             var header = ReadHeader(buffer);
             subtitle.Header = header.ToString();
-            if (header.DisplayStandardCode == "1" || header.DisplayStandardCode == "2")
+            if (header.DisplayStandardCode == "1" || header.DisplayStandardCode == "2" || HasTeletextColorCodes(buffer))
             {
                 SeedTeletextBoxAndDoubleHeightSettings(buffer);
             }
@@ -1401,6 +1406,40 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
             Configuration.Settings.SubtitleSettings.EbuStlTeletextUseBox = useBox;
             Configuration.Settings.SubtitleSettings.EbuStlTeletextUseDoubleHeight = useDoubleHeight;
+        }
+
+        /// <summary>
+        /// Colors only exist as teletext control codes, so a file that declares open subtitling
+        /// (DSC=0) is read without them. Some tools - Adobe Premiere among them - write the
+        /// teletext codes anyway and still stamp the header with 0, and reading those strictly
+        /// throws every color away. Nothing else uses 00h-1Fh in an open subtitling text field,
+        /// so their presence is taken as proof the file really is teletext coded.
+        /// </summary>
+        private static bool HasTeletextColorCodes(byte[] buffer)
+        {
+            const int startOfTextAndTimingBlock = 1024;
+            const int ttiSize = 128;
+
+            var index = startOfTextAndTimingBlock;
+            while (index + ttiSize <= buffer.Length)
+            {
+                if (buffer[index + 3] != 0xfe && buffer[index + 15] == 0) // skip user data and comment blocks
+                {
+                    for (var i = index + 16; i < index + ttiSize; i++)
+                    {
+                        // 00h (black) is left out on purpose: a writer that pads the text field with
+                        // zero bytes instead of 8Fh would otherwise look like a colored file.
+                        if (buffer[i] >= 0x01 && buffer[i] <= 0x07)
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                index += ttiSize;
+            }
+
+            return false;
         }
 
         public static EbuGeneralSubtitleInformation ReadHeader(byte[] buffer)
@@ -1779,6 +1818,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             const byte boxingOff = 0x85;
 
             var list = new List<EbuTextTimingInformation>();
+            var hasTeletextColorCodes = header.DisplayStandardCode == "0" && HasTeletextColorCodes(buffer);
             var index = startOfTextAndTimingBlock;
             var sb = new StringBuilder();
             while (index + ttiSize <= buffer.Length)
@@ -1809,7 +1849,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 // - unused space = 8Fh
                 var i = index + 16; // text block start at 17th byte (index 16)
                 var open = header.DisplayStandardCode != "1" && header.DisplayStandardCode != "2";
-                var closed = header.DisplayStandardCode != "0";
+                var closed = header.DisplayStandardCode != "0" || hasTeletextColorCodes;
                 var max = i + 112;
                 sb.Clear();
                 var lastWasNewLine = false;
@@ -2089,7 +2129,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         private static string FixSpacesAndTags(string text)
         {
-            text = text.Trim();
+            text = EmptyFontTag.Replace(text, string.Empty).Trim();
             while (text.Contains("  </font>"))
             {
                 text = text.Replace("  </font>", " </font>");

--- a/tests/libse/SubtitleFormats/EbuTest.cs
+++ b/tests/libse/SubtitleFormats/EbuTest.cs
@@ -140,11 +140,17 @@ public class EbuTest
     // field starts with the given bytes (rest is 8Fh padding).
     private static byte[] MakeTeletextStl(params byte[] textFieldBytes)
     {
-        var header = new Ebu.EbuGeneralSubtitleInformation { DisplayStandardCode = "1" };
+        return MakeStl("1", textFieldBytes);
+    }
+
+    private static byte[] MakeStl(string displayStandardCode, params byte[] textFieldBytes)
+    {
+        var header = new Ebu.EbuGeneralSubtitleInformation { DisplayStandardCode = displayStandardCode };
         var headerBytes = Ebu.GetEncoding(header.CodePageNumber).GetBytes(header.ToString());
 
         var tti = new byte[128];
         tti[3] = 0xff; // extension block number: last block in cue
+        tti[13] = 20; // vertical position: bottom, so no {\an} prefix is added
         for (var i = 16; i < tti.Length; i++)
         {
             tti[i] = 0x8f;
@@ -175,6 +181,34 @@ public class EbuTest
         new Ebu().LoadSubtitle(new Subtitle(), withoutCodes);
         Assert.False(Configuration.Settings.SubtitleSettings.EbuStlTeletextUseBox);
         Assert.False(Configuration.Settings.SubtitleSettings.EbuStlTeletextUseDoubleHeight);
+    }
+
+    // Adobe Premiere exports teletext control codes (colors, boxes) but stamps the header with
+    // "open subtitling" (DSC=0), where 00h-1Fh is not defined - so reading it strictly dropped
+    // every color and the user's colored subtitles imported as plain white (reported by email
+    // against 5.2.0-beta25).
+    [Fact]
+    public void EbuStl_Load_ReadsTeletextColorsInOpenSubtitlingFile()
+    {
+        var buffer = MakeStl("0", 0x0b, 0x0b, 0x06, (byte)'Z', (byte)'Y', (byte)'A', (byte)'N', 0x0a, 0x0a);
+
+        var subtitle = new Subtitle();
+        new Ebu().LoadSubtitle(subtitle, buffer);
+
+        Assert.Equal("<font color=\"Cyan\">ZYAN</font>", subtitle.Paragraphs[0].Text);
+    }
+
+    // ...but an open subtitling file without any color code must stay untouched: its 80h-85h
+    // italic/underline codes are the ones that count, and no font tag may appear out of nowhere.
+    [Fact]
+    public void EbuStl_Load_OpenSubtitlingWithoutColorsIsUnchanged()
+    {
+        var buffer = MakeStl("0", 0x80, (byte)'H', (byte)'i', 0x81);
+
+        var subtitle = new Subtitle();
+        new Ebu().LoadSubtitle(subtitle, buffer);
+
+        Assert.Equal("<i>Hi</i>", subtitle.Paragraphs[0].Text);
     }
 
     // The teletext color writer assumed the font tag's color value ends with a double quote and


### PR DESCRIPTION
Reported by email against 5.2.0-beta25, with an EBU N19 STL exported from Adobe Premiere: *"if I import a EBU N19 STL from adobe premiere i seems to lose the colors"*.

## The file

The sample is a conformance test reel (German, 113 cues) whose GSI header sets the **display standard code to `0` = open subtitling**, while every TTI text field is teletext coded:

```
cue 2:  0b 0b 06 5a 59 41 4e 0a 0a   [startbox][startbox][cyan]ZYAN[endbox][endbox]
cue 8:  0b 0b 1d 00 SCHWARZ 0a 0a    [startbox][startbox][new background][alpha black]
```

Colors in EBU N19 exist *only* as teletext control codes, and 00h-1Fh is undefined for open subtitling — its text field defines just 80h-85h for italic/underline/box. So the reader was told "not teletext" and correctly discarded exactly the bytes carrying the colors. Patching that one header byte from `0` to `1` makes every color import fine on `main`, which pins the cause to the header rather than the payload.

## The fix

Nothing else puts 01h-07h in a text field, so their presence is taken as proof the file really is teletext coded, and the colors are read regardless of what the header claims. `00h` (black) is deliberately left out of the detection — a writer that pads the text field with zero bytes instead of 8Fh would otherwise look like a colored file. User-data and comment blocks are skipped, same as the existing box/double-height seeding.

Box/double-height are now seeded from such a file too, so re-exporting it as teletext level 1 keeps the boxes the original had.

**Saving is unchanged**: open subtitling still writes no color codes. Getting colors back into an STL still means picking teletext level 1 as the display standard code — which is the correct header for a colored file, and what the exporting tool should have written in the first place.

Also fixed while in there: two color codes in a row (a background color set right before the text color) left an empty `<font color="Blue"></font>` behind *and* pushed the text one space to the right. That one hits genuine teletext files as well.

```
before: {\an1}<font color="Blue"></font> <font color="Yellow">Zeile 1</font>
after:  {\an1}<font color="Yellow">Zeile 1</font>
```

## Verification

The reporter's file converted to SubRip, before and after:

| cue | before | after |
| --- | --- | --- |
| 3 | `ZYAN` | `<font color="Cyan">ZYAN</font>` |
| 7 | `GRÜN` | `<font color="Green">GRÜN</font>` |
| 8 | `ROT` | `<font color="Red">ROT</font>` |

Two new tests: an open-subtitling file with color codes reads them; an open-subtitling file with 80h/81h italics and no color codes is untouched, so no font tag can appear out of nowhere. Full libse suite green (1509).

Known limitation, unchanged by this PR: SE has no background color for STL, so the `[new background]` codes are still dropped — those cues import with the correct text color and no background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)