### PR TITLE
Restore SE 4 "go to next/prev subtitle (play translate)" shortcuts (#14167)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1525,6 +1525,77 @@ public partial class MainViewModel :
         PlayVideo(vp);
     }
 
+    /// <summary>
+    /// SE 4's "go to next subtitle (play translate)" — the action behind its Alt+Down default
+    /// (issue #14167). Moves to the next line, plays it and stops at its end, then focuses the
+    /// edit box with all of its text selected so a translation can be typed straight over it.
+    /// Without a video it degrades to a plain move-next, like SE 4's did.
+    /// </summary>
+    [RelayCommand]
+    private void GoToNextSubtitlePlayTranslate()
+    {
+        if (GetVideoPlayerControl() == null)
+        {
+            GoToNextLine();
+        }
+        else
+        {
+            PlayNextParagraph(false);
+        }
+
+        FocusEditTextBoxAndSelectAll();
+    }
+
+    /// <summary>
+    /// The previous-line half of <see cref="GoToNextSubtitlePlayTranslate"/>; SE 4 bound it to
+    /// Alt+Up.
+    /// </summary>
+    [RelayCommand]
+    private void GoToPrevSubtitlePlayTranslate()
+    {
+        if (GetVideoPlayerControl() == null)
+        {
+            GoToPreviousLine();
+        }
+        else
+        {
+            PlayPreviousParagraph(false);
+        }
+
+        FocusEditTextBoxAndSelectAll();
+    }
+
+    /// <summary>
+    /// Focus the edit box and select all of its text, so typing replaces the line. Mirrors
+    /// <see cref="FocusEditTextBox(bool)"/> rather than calling it: the select-all has to happen
+    /// after its second, delayed Focus() call, not between the two. The grid selection was just
+    /// changed and the text-box binding may not have propagated yet (same situation as
+    /// <see cref="GoToNextLineCursorAtEnd"/>), so make sure the box shows the selected line's
+    /// text before selecting it.
+    /// </summary>
+    private void FocusEditTextBoxAndSelectAll()
+    {
+        Dispatcher.UIThread.Post(async () =>
+        {
+            if (AudioVisualizer != null && AudioVisualizer.IsFocused)
+            {
+                AudioVisualizer.SkipNextPointerEntered = true;
+            }
+
+            ActivateWindow(Window);
+            EditTextBox.Focus();
+            await Task.Delay(10);
+            EditTextBox.Focus();
+
+            if (SubtitleGrid.SelectedItem is SubtitleLineViewModel subtitle && EditTextBox.Text != subtitle.Text)
+            {
+                EditTextBox.Text = subtitle.Text;
+            }
+
+            EditTextBox.SelectAll();
+        });
+    }
+
     [RelayCommand]
     private void Pause()
     {

--- a/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
+++ b/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
@@ -332,6 +332,10 @@ public static class Se4ShortcutsImporter
         // General
         ["GeneralGoToFirstSelectedLine"] = nameof(MainViewModel.FocusSelectedLineCommand),
         ["GeneralGoToNextSubtitle"] = nameof(MainViewModel.GoToNextLineCommand),
+        // SE 4's Alt+Down/Alt+Up defaults - not the plain go-to-next/prev above, which SE 4
+        // bound to Shift+Return (#14167).
+        ["GeneralGoToNextSubtitlePlayTranslate"] = nameof(MainViewModel.GoToNextSubtitlePlayTranslateCommand),
+        ["GeneralGoToPrevSubtitlePlayTranslate"] = nameof(MainViewModel.GoToPrevSubtitlePlayTranslateCommand),
         ["GeneralGoToNextSubtitleCursorAtEnd"] = nameof(MainViewModel.GoToNextLineCursorAtEndCommand),
         ["GeneralGoToNextSubtitleAndPlay"] = nameof(MainViewModel.PlayNextCommand),
         ["GeneralGoToPrevSubtitle"] = nameof(MainViewModel.GoToPreviousLineCommand),

--- a/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
@@ -24,8 +24,10 @@ public class LanguageSettingsShortcuts
     public string GeneralToggleTranslationMode { get; set; }
     public string GeneralChooseLayout { get; set; }
     public string GeneralGoToNextSubtitle { get; set; }
+    public string GeneralGoToNextSubtitlePlayTranslate { get; set; }
     public string GeneralGoToNextSubtitleCursorAtEnd { get; set; }
     public string GeneralGoToPrevSubtitle { get; set; }
+    public string GeneralGoToPrevSubtitlePlayTranslate { get; set; }
     public string GeneralGoToFirstLine { get; set; }
     public string GeneralGoToLastLine { get; set; }
     public string AlsoSetVideoPosition { get; set; }
@@ -286,8 +288,10 @@ public class LanguageSettingsShortcuts
         GeneralToggleTranslationMode = "Toggle translation mode";
         GeneralChooseLayout = "Choose layout";
         GeneralGoToNextSubtitle = "Go to next subtitle";
+        GeneralGoToNextSubtitlePlayTranslate = "Go to next subtitle (play translate)";
         GeneralGoToNextSubtitleCursorAtEnd = "Go to next subtitle and set cursor at end";
         GeneralGoToPrevSubtitle = "Go to previous subtitle";
+        GeneralGoToPrevSubtitlePlayTranslate = "Go to previous subtitle (play translate)";
         GeneralGoToFirstLine = "Go to first line";
         GeneralGoToLastLine = "Go to last line";
         AlsoSetVideoPosition = "Also set video position";

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -232,8 +232,10 @@ public static class ShortcutsMain
         { nameof(MainViewModel.CommandShowLayoutCommand), Se.Language.Options.Shortcuts.GeneralChooseLayout },
 
         { nameof(MainViewModel.GoToNextLineCommand), Se.Language.Options.Shortcuts.GeneralGoToNextSubtitle },
+        { nameof(MainViewModel.GoToNextSubtitlePlayTranslateCommand), Se.Language.Options.Shortcuts.GeneralGoToNextSubtitlePlayTranslate },
         { nameof(MainViewModel.GoToNextLineCursorAtEndCommand), Se.Language.Options.Shortcuts.GeneralGoToNextSubtitleCursorAtEnd },
         { nameof(MainViewModel.GoToPreviousLineCommand), Se.Language.Options.Shortcuts.GeneralGoToPrevSubtitle },
+        { nameof(MainViewModel.GoToPrevSubtitlePlayTranslateCommand), Se.Language.Options.Shortcuts.GeneralGoToPrevSubtitlePlayTranslate },
         { nameof(MainViewModel.GoToFirstLineCommand), Se.Language.Options.Shortcuts.GeneralGoToFirstLine },
         { nameof(MainViewModel.GoToLastLineCommand), Se.Language.Options.Shortcuts.GeneralGoToLastLine },
         { nameof(MainViewModel.GoToNextLineAndSetVideoPositionCommand), Se.Language.Options.Shortcuts.GoToNextLineAndSetVideoPosition },
@@ -603,6 +605,8 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.GoToPreviousLineCommand, nameof(vm.GoToPreviousLineCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.GoToNextLineCommand, nameof(vm.GoToNextLineCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.GoToNextLineCursorAtEndCommand, nameof(vm.GoToNextLineCursorAtEndCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.GoToPrevSubtitlePlayTranslateCommand, nameof(vm.GoToPrevSubtitlePlayTranslateCommand), ShortcutCategory.General, ShortcutGroup.Video);
+        AddShortcut(shortcuts, vm.GoToNextSubtitlePlayTranslateCommand, nameof(vm.GoToNextSubtitlePlayTranslateCommand), ShortcutCategory.General, ShortcutGroup.Video);
         AddShortcut(shortcuts, vm.GoToFirstLineCommand, nameof(vm.GoToFirstLineCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.GoToLastLineCommand, nameof(vm.GoToLastLineCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.GoToPreviousLineAndSetVideoPositionCommand, nameof(vm.GoToPreviousLineAndSetVideoPositionCommand), ShortcutCategory.General);

--- a/tests/UI/Features/Options/Shortcuts/Se4ShortcutsImporterMapTests.cs
+++ b/tests/UI/Features/Options/Shortcuts/Se4ShortcutsImporterMapTests.cs
@@ -51,6 +51,8 @@ public class Se4ShortcutsImporterMapTests
     [InlineData("MainVideoGoToNextChapter", "GoToNextChapterCommand")]
     [InlineData("MainAdjustSetStartAndOffsetTheWholeSubtitle", "WaveformSetStartAndKeepDurationCommand")]
     [InlineData("GeneralGoToNextSubtitleAndPlay", "PlayNextCommand")]
+    [InlineData("GeneralGoToNextSubtitlePlayTranslate", "GoToNextSubtitlePlayTranslateCommand")]
+    [InlineData("GeneralGoToPrevSubtitlePlayTranslate", "GoToPrevSubtitlePlayTranslateCommand")]
     [InlineData("GeneralGoToPrevSubtitleAndPlay", "PlayPreviousCommand")]
     [InlineData("GeneralGoToStartOfCurrentSubtitle", "VideoSetPositionCurrentSubtitleStartCommand")]
     [InlineData("GeneralGoToEndOfCurrentSubtitle", "VideoSetPositionCurrentSubtitleEndCommand")]


### PR DESCRIPTION
Addresses point A of #14167.

## What SE 4 actually did

The reporter's `Alt+Down` was not the plain go-to-next-line command. SE 4's defaults:

| SE 4 setting | default | action |
|---|---|---|
| `GeneralGoToNextSubtitle` | `Shift+Return` | move selection only |
| `GeneralGoToNextSubtitlePlayTranslate` | **`Alt+Down`** | `PlayNext()` |
| `GeneralGoToPrevSubtitlePlayTranslate` | **`Alt+Up`** | `PlayPrevious()` |

(`src/libse/Settings/Shortcuts.cs:428-430` on `se4-legacy`; handler at `Forms/Main.cs:17384`.)

SE 4's `PlayNext()` selected the next row, **focused the text box and selected all of its text**, seeked to the line start and played it — which is what makes "I can immediately start typing, and the text changes on the video as I type" work.

## What was missing in SE 5

Two things:

1. **No equivalent command.** `PlayNextAndStopCommand` comes closest — select, seek, play, pause at end — but never touches the edit box.
2. **No importer mapping** for either SE 4 name, so an imported SE 4 setup silently dropped both. This is why the reporter's muscle memory broke even though `Alt+Down` still "did something".

## Changes

- `GoToNextSubtitlePlayTranslateCommand` / `GoToPrevSubtitlePlayTranslateCommand` in `MainViewModel` — wrap the existing `PlayNextParagraph`/`PlayPreviousParagraph(loop: false)`, then focus the edit box with all text selected. With no video loaded they degrade to a plain move-next/prev, as SE 4's did.
- Registered in `ShortcutsMain` under General / Video.
- Both SE 4 names mapped in `Se4ShortcutsImporter`, with the guard test extended.

**SE 5's own `Alt+Down`/`Alt+Up` defaults are unchanged** — the new commands ship unbound. SE 4 users get them at their familiar keys through the importer, which also brings `GeneralGoToNextSubtitle` = `Shift+Return` across, so the two don't collide.

### Free translations

The language properties are named after the SE 4 keys still sitting in the shipped translation JSONs, so **18 languages bind immediately** instead of shipping English-only. Verified by deserializing Danish/Spanish/Dutch through `SeLanguageJsonContext` and asserting the strings are non-empty and not the English fallback (throwaway test, not committed).

`English.json` deliberately untouched — it is generated from the Language classes.

## Testing

`dotnet build src/ui/UI.csproj` clean; `dotnet test tests/UI --filter Shortcut` → 123 passed.

Not manually exercised in the running app — the focus/select-all timing (mirrors `FocusEditTextBox`'s posted double-`Focus()`, with `SelectAll()` after the second one) is the part worth a quick try before merging.

## Not in this PR

The other four points of #14167, for the record:

- **B** (double-click "play current and pause" runs past the line) — looks like a real bug: `ResetPlaySelection()` fires on the `!isPlaying` ticks right after `Play()`, before mpv's `_observedPause` flips. Needs a repro.
- **C** (auto repeat) — already covered by `PlaySelectedLinesWithLoop` and friends; SE 4's "auto repeat = 0" is SE 5's default. Only the repeat *count* is gone.
- **D** (parentheses/quotes) — already covered by the three configurable `SurroundWith` slots.
- **E** (mpv left/right justification) — genuinely missing, no `sub-justify` anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)