### PR TITLE
Stop "play current and pause" running past the end of the line (#14167)

### DIFF
--- a/src/ui/Features/Main/MainHelpers/PlayStartGate.cs
+++ b/src/ui/Features/Main/MainHelpers/PlayStartGate.cs
@@ -1,0 +1,66 @@
+namespace Nikse.SubtitleEdit.Features.Main.MainHelpers;
+
+/// <summary>
+/// Bridges the gap between asking the player to start and the player reporting that it has.
+/// <c>IsPlaying</c> is fed by mpv's asynchronous <c>pause</c> property-change event (see
+/// LibMpvDynamicPlayer's event loop and <c>_observedPause</c>), so for a tick or two after
+/// <c>Play()</c> the player still reports paused.
+///
+/// That matters because the position timer treats "not playing" as "playback stopped" and drops
+/// the play-selection stop/loop point. Landing in this window throws away a stop point that was
+/// set microseconds earlier, and playback then runs on past the end of the line it was supposed
+/// to stop at - "go to video position, play current, and pause" never pausing (#14167). While a
+/// play is pending, that reset is held off.
+/// </summary>
+public sealed class PlayStartGate
+{
+    /// <summary>
+    /// Upper bound on how long a play may stay pending. A play command that is never honoured
+    /// (no file loaded, a player that ignored it) must not hold the play selection forever.
+    /// Generous next to the ~1 ms mpv normally takes, because the point is only to bound the
+    /// damage of a play that never lands.
+    /// </summary>
+    public const double MaxPendingMilliseconds = 500;
+
+    private long? _requestedTimestamp;
+
+    /// <summary>Playback has been asked to start; <paramref name="timestamp"/> is Stopwatch ticks.</summary>
+    public void PlayRequested(long timestamp)
+    {
+        _requestedTimestamp = timestamp;
+    }
+
+    /// <summary>A pause was asked for, so any pending play is moot.</summary>
+    public void PauseRequested()
+    {
+        _requestedTimestamp = null;
+    }
+
+    /// <summary>The player now reports playing, so the request has landed.</summary>
+    public void PlayingObserved()
+    {
+        _requestedTimestamp = null;
+    }
+
+    /// <summary>
+    /// True while a requested play has neither been observed nor timed out. Expires the request
+    /// once past <see cref="MaxPendingMilliseconds"/> so a play that never took effect stops
+    /// holding anything back.
+    /// </summary>
+    public bool IsPending(long now, long ticksPerSecond)
+    {
+        if (_requestedTimestamp == null || ticksPerSecond <= 0)
+        {
+            return false;
+        }
+
+        var elapsedMilliseconds = (now - _requestedTimestamp.Value) * 1000.0 / ticksPerSecond;
+        if (elapsedMilliseconds >= 0 && elapsedMilliseconds <= MaxPendingMilliseconds)
+        {
+            return true;
+        }
+
+        _requestedTimestamp = null;
+        return false;
+    }
+}

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -685,6 +685,10 @@ public partial class MainViewModel :
     string _dropDownFormatsSearchText = string.Empty;
     private System.Timers.Timer _dropDownFormatsSearchTimer = new System.Timers.Timer(1000);
     private PlaySelectionItem? _playSelectionItem;
+
+    // Holds off the position timer's "playback stopped" handling for the moment between asking the
+    // player to play and it reporting that it is playing (#14167) - see PlayStartGate.
+    private readonly PlayStartGate _playStartGate = new();
     private int _pendingScrollIndex = -1;
     private SubtitleLineViewModel? _pendingScrollItem;
     private SubtitleLineViewModel? _pendingScrollSubtitle = null;
@@ -1651,15 +1655,20 @@ public partial class MainViewModel :
     internal void RequestPausePlayheadFreeze()
     {
         _pauseRequested = true;
+        _playStartGate.PauseRequested(); // a pause supersedes any play still waiting to be observed
         _playheadPausedSettled = false; // reconcile the cursor to mpv's final frame once this pause settles
         _playheadPauseSettleTs = Stopwatch.GetTimestamp();
     }
 
     // Playback (re)started, so a pause freeze from a moment ago is stale: while it is set the cursor
     // is held frozen at the pause spot, which would stall the first ~100 ms of playback.
+    // Every play request in the app funnels through here (PlayVideo, the play half of
+    // TogglePlayPause, and the player control's own PlayPauseRequested wiring), so this is also
+    // where the play-start gate is armed.
     internal void CancelPausePlayheadFreeze()
     {
         _pauseRequested = false;
+        _playStartGate.PlayRequested(Stopwatch.GetTimestamp());
     }
 
     // The player's Stop button pauses and seeks to 0; freeze the cursor immediately and pin it to
@@ -27623,6 +27632,8 @@ public partial class MainViewModel :
                         Optris.Icons.Avalonia.Attached.SetIcon(ButtonWaveformPlay, IconNames.Pause);
                     }
 
+                    _playStartGate.PlayingObserved();
+
                     if (_playSelectionItem != null && mediaPlayerSeconds >= _playSelectionItem.EndSeconds)
                     {
                         var p = _playSelectionItem.GetNextSubtitle(mediaPlayerSeconds);
@@ -27676,20 +27687,32 @@ public partial class MainViewModel :
                         Optris.Icons.Avalonia.Attached.SetIcon(ButtonWaveformPlay, IconNames.Play);
                     }
 
-                    ResetPlaySelection();
-
-                    // "Center also while paused" scrub-editing (SE 4's locked mode): while the user
-                    // wheels through the waveform, keep selecting the line under the centered cursor.
-                    // Only react to position *changes* — otherwise this would immediately steal back
-                    // the selection when the user picks a different line in the grid while paused.
-                    if (WaveformCenter && Se.Settings.Waveform.CenterVideoPositionAlsoWhenPaused &&
-                        SelectCurrentSubtitleWhilePlaying &&
-                        Math.Abs(mediaPlayerSeconds - _pausedSelectLastSeconds) > 0.001)
+                    // "Not playing" here does not always mean playback stopped: mpv reports its
+                    // pause state through an asynchronous property-change event, so a play we
+                    // asked for microseconds ago still reads as paused for a tick or two. Doing
+                    // the stopped-handling in that window drops the play-selection stop/loop
+                    // point the caller just set - so "play current and pause" (grid double-click,
+                    // play next/previous and stop, play selected lines) sailed past the end of
+                    // the line instead of stopping there (#14167). It would also let the paused
+                    // scrub-select below move the selection off the line about to be played,
+                    // which resets the play selection a second way through SelectionChanged.
+                    if (!_playStartGate.IsPending(Stopwatch.GetTimestamp(), Stopwatch.Frequency))
                     {
-                        SelectCurrentSubtitleAtPlayhead(mediaPlayerSeconds, subtitle);
-                    }
+                        ResetPlaySelection();
 
-                    _pausedSelectLastSeconds = mediaPlayerSeconds;
+                        // "Center also while paused" scrub-editing (SE 4's locked mode): while the user
+                        // wheels through the waveform, keep selecting the line under the centered cursor.
+                        // Only react to position *changes* — otherwise this would immediately steal back
+                        // the selection when the user picks a different line in the grid while paused.
+                        if (WaveformCenter && Se.Settings.Waveform.CenterVideoPositionAlsoWhenPaused &&
+                            SelectCurrentSubtitleWhilePlaying &&
+                            Math.Abs(mediaPlayerSeconds - _pausedSelectLastSeconds) > 0.001)
+                        {
+                            SelectCurrentSubtitleAtPlayhead(mediaPlayerSeconds, subtitle);
+                        }
+
+                        _pausedSelectLastSeconds = mediaPlayerSeconds;
+                    }
                 }
 
                 _avLastScrolling = isAvScrolloing;

--- a/tests/UI/Features/Main/PlayStartGateTests.cs
+++ b/tests/UI/Features/Main/PlayStartGateTests.cs
@@ -1,0 +1,90 @@
+using Nikse.SubtitleEdit.Features.Main.MainHelpers;
+using Xunit;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// mpv reports its pause state through an asynchronous property-change event, so IsPlaying still
+/// reads "paused" for a tick or two after a play command. The position timer treats "not playing"
+/// as "playback stopped" and drops the play-selection stop point - and landing in that window
+/// dropped a stop point set microseconds earlier, so "go to video position, play current, and
+/// pause" ran on past the end of the line (#14167). This gate marks that window.
+/// </summary>
+public class PlayStartGateTests
+{
+    private const long TicksPerSecond = 1_000_000;
+
+    private static long At(double milliseconds) => (long)(milliseconds * TicksPerSecond / 1000.0);
+
+    [Fact]
+    public void NothingIsPendingBeforeAnyPlayIsRequested()
+    {
+        var gate = new PlayStartGate();
+
+        Assert.False(gate.IsPending(At(0), TicksPerSecond));
+    }
+
+    /// <summary>The window this whole class exists for: play asked, player still says paused.</summary>
+    [Fact]
+    public void APlayJustRequestedIsPending()
+    {
+        var gate = new PlayStartGate();
+        gate.PlayRequested(At(100));
+
+        Assert.True(gate.IsPending(At(100), TicksPerSecond));
+        Assert.True(gate.IsPending(At(150), TicksPerSecond));
+    }
+
+    [Fact]
+    public void OnceThePlayerReportsPlayingNothingIsHeldBack()
+    {
+        var gate = new PlayStartGate();
+        gate.PlayRequested(At(100));
+        gate.PlayingObserved();
+
+        Assert.False(gate.IsPending(At(101), TicksPerSecond));
+    }
+
+    /// <summary>
+    /// A real pause after playback started must take effect on the very next tick, not wait out
+    /// the gate - otherwise pausing would stop clearing the play selection.
+    /// </summary>
+    [Fact]
+    public void APauseRequestSupersedesAPendingPlay()
+    {
+        var gate = new PlayStartGate();
+        gate.PlayRequested(At(100));
+        gate.PauseRequested();
+
+        Assert.False(gate.IsPending(At(101), TicksPerSecond));
+    }
+
+    /// <summary>
+    /// A play that is never honoured (no file loaded, a player that ignored the command) must not
+    /// hold the play selection alive forever.
+    /// </summary>
+    [Fact]
+    public void APlayThatIsNeverObservedExpires()
+    {
+        var gate = new PlayStartGate();
+        gate.PlayRequested(At(0));
+
+        Assert.True(gate.IsPending(At(PlayStartGate.MaxPendingMilliseconds), TicksPerSecond));
+        Assert.False(gate.IsPending(At(PlayStartGate.MaxPendingMilliseconds + 1), TicksPerSecond));
+        // ...and stays expired.
+        Assert.False(gate.IsPending(At(PlayStartGate.MaxPendingMilliseconds + 2), TicksPerSecond));
+    }
+
+    /// <summary>Re-arming after an expiry starts a fresh window rather than staying expired.</summary>
+    [Fact]
+    public void ARequestAfterAnExpiryIsPendingAgain()
+    {
+        var gate = new PlayStartGate();
+        gate.PlayRequested(At(0));
+        Assert.False(gate.IsPending(At(5000), TicksPerSecond));
+
+        gate.PlayRequested(At(5000));
+
+        Assert.True(gate.IsPending(At(5010), TicksPerSecond));
+    }
+}


### PR DESCRIPTION
Addresses point B of #14167: double-clicking a grid line with **"Go to video position, play current, and pause"** selected starts playing but does not stop at the end of the line.

## Cause

The 50 ms position timer treats "not playing" as "playback stopped" and clears `_playSelectionItem` — the stop/loop point that makes playback halt at a line's end:

```csharp
else   // !isPlaying
{
    ...
    ResetPlaySelection();
```

But `IsPlaying` reads `_observedPause`, which `LibMpvDynamicPlayer` only updates from mpv's **asynchronous** `pause` property-change event on its event thread. `Play()` issues `set pause no` and does *not* set the flag optimistically. So for a tick or two after a play command the player still reports paused — and a tick landing in that window throws away a stop point set microseconds earlier. Playback then runs on.

`PlayLineAndPauseAtEnd` is exactly this shape — `Pause()` → seek → set `_playSelectionItem` → `Play()` — and so are the other single-line play paths:

- grid double-click "go to video position, play current, and pause"
- `PlayNextAndStop` / `PlayNextAndLoop` / `PlayPreviousAndStop` / `PlayPreviousAndLoop`
- `PlaySelectedLinesWithLoop` / `...WithoutLoop`
- the one-frame step-with-play window

## Fix

`PlayStartGate` marks the interval between asking the player to play and it reporting that it is playing. Every play request in the app funnels through `CancelPausePlayheadFreeze` (`PlayVideo`, the play half of `TogglePlayPause`, and the control's own `PlayPauseRequested` wiring), so that is where it is armed; it is disarmed when the timer first observes playing, or when a pause is requested. While a play is pending, the paused branch skips its stopped-handling. A 500 ms cap stops a play that never lands from holding the selection forever.

The paused scrub-select (`CenterVideoPositionAlsoWhenPaused`) is inside the same guard deliberately: in that window it can move the selection off the line about to be played, which resets the play selection a second way, through `SelectionChanged`.

I checked that no genuine pause can be swallowed by the gate — every raw `vp.VideoPlayer.Pause()` in the view model is the prologue of a play path, and the real stop paths (toolbar, click-on-video, `Pause` command, Stop button) all go through `RequestPausePlayheadFreeze`.

## Testing

`PlayStartGateTests` covers the window, the pause-supersedes-play case, the expiry, and re-arming after an expiry. Full UI suite: 4121 passed, 1 skipped.

## What I could not verify

**I have not reproduced the reporter's symptom in the running app** — that needs a real mpv session, and the window is short (mpv normally confirms in about a millisecond, so a 50 ms tick lands in it only occasionally). The defect above is certain by inspection and the fix is right regardless, but if the reporter sees it *every* time, there may be a second cause on top of this one and it is worth asking them for their exact single-click action setting.

I did rule out one candidate: I probed Avalonia's headless input and confirmed a double-click raises `Tapped` only **once**, before `DoubleTapped` — so the deferred single-click action is properly cancelled and cannot fire a second, competing play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)