### PR TITLE
Fix five bugs in the CSV/XLSX/ODS importers

### DIFF
--- a/src/libse/Common/CsvUtil.cs
+++ b/src/libse/Common/CsvUtil.cs
@@ -82,19 +82,10 @@ namespace Nikse.SubtitleEdit.Core.Common
                 {
                     switch (ch)
                     {
-                        case ',' when !quoteOn && separator == ',':
-                            lines.Add(item.ToString());
-                            item.Clear();
-                            index++;
-                            stringOn = false;
-                            continue;
-                        case ';' when !quoteOn && separator == ';':
-                            lines.Add(item.ToString());
-                            item.Clear();
-                            index++;
-                            stringOn = false;
-                            continue;
-                        case '\t' when !quoteOn && separator == '\t':
+                        // Any separator, not just comma/semicolon/tab: the import window's
+                        // detection also picks '|', and an unhandled separator left the whole
+                        // row in the first field with every other column empty.
+                        case var _ when !quoteOn && ch == separator:
                             lines.Add(item.ToString());
                             item.Clear();
                             index++;

--- a/src/libse/Common/UnknownFormatImporterCsv.cs
+++ b/src/libse/Common/UnknownFormatImporterCsv.cs
@@ -31,6 +31,10 @@ namespace Nikse.SubtitleEdit.Core.Common
 
             if (string.IsNullOrWhiteSpace(lines[0]) || lines[0].Trim() == "Dialogue List,,")
             {
+                // On a copy: the caller (UnknownFormatImporter) keeps using the list it passed in
+                // for the other parsers when this one finds nothing, and dropping a line from
+                // under it lost a subtitle.
+                lines = new List<string>(lines);
                 lines.RemoveAt(0);
             }
 
@@ -133,6 +137,14 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         private void FixStartTimeWithoutMs(List<CsvLine> csvLines, bool isStartTimeFrames)
         {
+            if (csvLines.Count == 0)
+            {
+                // No data rows at all - e.g. an unterminated quote in the header line makes the
+                // header swallow the rest of the file. The averages below divide by this count,
+                // and the file-open path has no catch for the exception (DivideByZeroException).
+                return;
+            }
+
             var isEndTimeNull = csvLines.All(p => string.IsNullOrEmpty(p.End));
             if (isStartTimeFrames || !isEndTimeNull)
             {
@@ -188,13 +200,19 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         private bool DetectIsFrames(List<string> toList)
         {
+            // Blank values carry no information either way - a single empty cell, or the blank row
+            // a trailing newline produces, used to veto the whole column and silently reinterpret
+            // HH:MM:SS:FF as HH:MM:SS.ms (12 frames became 12 ms). Decide on the values that are
+            // actually present. Same rule as the import window's own detection.
+            var considered = 0;
             foreach (var s in toList)
             {
-                if (s == null)
+                if (string.IsNullOrWhiteSpace(s))
                 {
-                    return false;
+                    continue;
                 }
 
+                considered++;
                 var parts = s.Split(TimeCode.TimeSplitChars, StringSplitOptions.RemoveEmptyEntries);
                 if (parts.Length != 4 || parts[3].Trim().Length != 2)
                 {
@@ -202,7 +220,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
             }
 
-            return true;
+            return considered > 0;
         }
 
         private List<CsvLine> ReadCsvLines(List<string> headers, List<string> lines, char separator)

--- a/src/libse/Common/UnknownFormatImporterJson.cs
+++ b/src/libse/Common/UnknownFormatImporterJson.cs
@@ -315,7 +315,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             }
 
             var isArray = s.Contains("[");
-            if (isArray && textLines.Any(p => p == "end_time" || p == "endTime" || p == "end" || p == "endMs" || p == "endMilliseconds" || p == "end_ms" || p == "endms" || p == "to" || p == "to_ms" || p == "toms" || p == "from" || p == "from_ms" | p == "hide"))
+            if (isArray && textLines.Any(p => p == "end_time" || p == "endTime" || p == "end" || p == "endMs" || p == "endMilliseconds" || p == "end_ms" || p == "endms" || p == "to" || p == "to_ms" || p == "toms" || p == "from" || p == "from_ms" || p == "hide"))
             {
                 isArray = false;
             }

--- a/src/libse/Common/UnknownFormatImporterOds.cs
+++ b/src/libse/Common/UnknownFormatImporterOds.cs
@@ -70,9 +70,14 @@ namespace Nikse.SubtitleEdit.Core.Common
             foreach (var row in table.Elements(TableNs + "table-row"))
             {
                 var cells = new List<string>();
-                foreach (var cell in row.Elements(TableNs + "table-cell"))
+
+                // covered-table-cell too, not just table-cell: a merged cell is written as one
+                // table-cell plus one covered-table-cell per column it swallows, and skipping the
+                // placeholders pulled every later column one to the left - so the text column of
+                // a row with a merge was read as the end time.
+                foreach (var cell in row.Elements().Where(e => e.Name == TableNs + "table-cell" || e.Name == TableNs + "covered-table-cell"))
                 {
-                    var value = GetCellValue(cell);
+                    var value = cell.Name == TableNs + "covered-table-cell" ? string.Empty : GetCellValue(cell);
                     var repeat = ParseRepeat(cell.Attribute(TableNs + "number-columns-repeated")?.Value);
 
                     // Honour the repeat count for empty cells too: LibreOffice writes an

--- a/src/libse/Common/UnknownFormatImporterXlsx.cs
+++ b/src/libse/Common/UnknownFormatImporterXlsx.cs
@@ -11,6 +11,8 @@ namespace Nikse.SubtitleEdit.Core.Common
     public class UnknownFormatImporterXlsx
     {
         private static readonly XNamespace Ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+        private static readonly XNamespace RelationshipsNs = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+        private static readonly XNamespace PackageRelationshipsNs = "http://schemas.openxmlformats.org/package/2006/relationships";
 
         public Subtitle AutoGuessImport(string fileName)
         {
@@ -36,11 +38,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 using (var archive = new ZipArchive(stream, ZipArchiveMode.Read))
                 {
                     var sharedStrings = ReadSharedStrings(archive);
-                    var sheetEntry = archive.Entries
-                        .Where(e => e.FullName.StartsWith("xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase) &&
-                                    e.FullName.EndsWith(".xml", StringComparison.OrdinalIgnoreCase))
-                        .OrderBy(e => e.FullName, StringComparer.OrdinalIgnoreCase)
-                        .FirstOrDefault();
+                    var sheetEntry = FindFirstSheet(archive);
                     if (sheetEntry == null)
                     {
                         return null;
@@ -53,6 +51,70 @@ namespace Nikse.SubtitleEdit.Core.Common
             {
                 return null;
             }
+        }
+
+        /// <summary>
+        /// The worksheet the user sees first: the first &lt;sheet&gt; in xl/workbook.xml, resolved
+        /// through the workbook relationships. That is not necessarily sheet1.xml - moving a sheet
+        /// in Excel reorders the workbook entries but never renames the parts - so picking the
+        /// first worksheet file imported the wrong sheet. Falls back to the first worksheet part
+        /// when the workbook or its relationships cannot be read.
+        /// </summary>
+        private static ZipArchiveEntry FindFirstSheet(ZipArchive archive)
+        {
+            var worksheets = archive.Entries
+                .Where(e => e.FullName.StartsWith("xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase) &&
+                            e.FullName.EndsWith(".xml", StringComparison.OrdinalIgnoreCase))
+                .OrderBy(e => e.FullName, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            if (worksheets.Count <= 1)
+            {
+                return worksheets.FirstOrDefault();
+            }
+
+            try
+            {
+                var workbookEntry = archive.GetEntry("xl/workbook.xml");
+                var relsEntry = archive.GetEntry("xl/_rels/workbook.xml.rels");
+                if (workbookEntry != null && relsEntry != null)
+                {
+                    string relationshipId;
+                    using (var stream = workbookEntry.Open())
+                    {
+                        relationshipId = (string)XDocument.Load(stream).Root?
+                            .Element(Ns + "sheets")?
+                            .Elements(Ns + "sheet")
+                            .FirstOrDefault()?
+                            .Attribute(RelationshipsNs + "id");
+                    }
+
+                    if (!string.IsNullOrEmpty(relationshipId))
+                    {
+                        using (var stream = relsEntry.Open())
+                        {
+                            var target = XDocument.Load(stream).Root?
+                                .Elements(PackageRelationshipsNs + "Relationship")
+                                .FirstOrDefault(r => (string)r.Attribute("Id") == relationshipId)?
+                                .Attribute("Target")?.Value;
+                            if (!string.IsNullOrEmpty(target))
+                            {
+                                var fullName = "xl/" + target.TrimStart('/').Replace("../", string.Empty);
+                                var match = worksheets.FirstOrDefault(e => e.FullName.Equals(fullName, StringComparison.OrdinalIgnoreCase));
+                                if (match != null)
+                                {
+                                    return match;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // fall through to the first worksheet part
+            }
+
+            return worksheets[0];
         }
 
         private static List<string> ReadSharedStrings(ZipArchive archive)

--- a/tests/libse/Common/SpreadsheetImportTest.cs
+++ b/tests/libse/Common/SpreadsheetImportTest.cs
@@ -1,4 +1,5 @@
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using System.IO.Compression;
 using System.Text;
 
@@ -149,6 +150,202 @@ public class SpreadsheetImportTest
             "Text,Note,Reviewer",
             "\"Hello there.\",ok,jane",
             "\"General Kenobi!\",ok,jane",
+        };
+
+        Assert.Empty(new UnknownFormatImporterCsv().AutoGuessImport(lines).Paragraphs);
+    }
+
+    [Fact]
+    public void PipeSeparatedLinesAreSplit()
+    {
+        // The import window's separator detection can pick '|', so CsvUtil must be able to split
+        // on it - it used to handle only comma/semicolon/tab and returned the whole row as one
+        // field, which left every column but the first empty.
+        var rows = CsvUtil.CsvSplitLines(new List<string> { "Start|End|Text" }, '|');
+
+        Assert.Single(rows);
+        Assert.Equal(new[] { "Start", "End", "Text" }, rows[0]);
+    }
+
+    [Fact]
+    public void FramesAreDetectedWhenSomeCellsAreBlank()
+    {
+        // A trailing newline (or one empty cell) used to veto frame detection for the whole
+        // column, and HH:MM:SS:FF was then re-read as HH:MM:SS.ms - 12 ms instead of 12 frames.
+        var lines = new List<string>
+        {
+            "Start,End,Text",
+            "00:00:01:00,00:00:03:12,\"Hello there.\"",
+            "00:00:04:00,00:00:06:00,\"General Kenobi!\"",
+            string.Empty,
+        };
+
+        var subtitle = new UnknownFormatImporterCsv().AutoGuessImport(lines);
+
+        Assert.Equal(2, subtitle.Paragraphs.Count);
+        Assert.Equal(1000, subtitle.Paragraphs[0].StartTime.TotalMilliseconds, 0);
+        Assert.Equal(3000 + SubtitleFormat.FramesToMilliseconds(12), subtitle.Paragraphs[0].EndTime.TotalMilliseconds, 0);
+    }
+
+    [Fact]
+    public void TheCallersLineListIsNotModified()
+    {
+        // AutoGuessImport used to drop a leading blank line from the list it was given, and the
+        // caller (UnknownFormatImporter) keeps using that same list for the other parsers.
+        var lines = new List<string>
+        {
+            string.Empty,
+            "Start,End,Text",
+            "00:00:01.000,00:00:03.500,\"Hello there.\"",
+        };
+        var copy = new List<string>(lines);
+
+        new UnknownFormatImporterCsv().AutoGuessImport(lines);
+
+        Assert.Equal(copy, lines);
+    }
+    [Fact]
+    public void OdsMergedCellsDoNotShiftTheColumnsAfterThem()
+    {
+        // A merged cell is one table-cell plus a covered-table-cell placeholder per column it
+        // swallows. Skipping the placeholders moved every later column one to the left, so the
+        // text column of such a row was read as the end time.
+        const string content = """
+                               <?xml version="1.0" encoding="UTF-8"?>
+                               <office:document-content
+                                   xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+                                   xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0"
+                                   xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0">
+                                 <office:body><office:spreadsheet>
+                                   <table:table table:name="Sheet1">
+                                     <table:table-row>
+                                       <table:table-cell table:number-columns-spanned="2" table:number-rows-spanned="1"><text:p>merged</text:p></table:table-cell>
+                                       <table:covered-table-cell/>
+                                       <table:table-cell><text:p>after</text:p></table:table-cell>
+                                     </table:table-row>
+                                   </table:table>
+                                 </office:spreadsheet></office:body>
+                               </office:document-content>
+                               """;
+
+        using var stream = new MemoryStream();
+        using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, true))
+        {
+            var entry = archive.CreateEntry("content.xml");
+            using var writer = new StreamWriter(entry.Open(), Encoding.UTF8);
+            writer.Write(content);
+        }
+
+        WithTempFile(".ods", stream.ToArray(), path =>
+        {
+            var lines = new UnknownFormatImporterOds().ReadLinesFromFile(path);
+            Assert.Equal(new[] { "merged\t\tafter" }, lines);
+        });
+    }
+
+    private static byte[] MakeXlsxWithSheets(string workbookXml, string relsXml, params (string Name, string Sheet)[] sheets)
+    {
+        using var stream = new MemoryStream();
+        using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, true))
+        {
+            void Add(string name, string text)
+            {
+                var entry = archive.CreateEntry(name);
+                using var writer = new StreamWriter(entry.Open(), Encoding.UTF8);
+                writer.Write(text);
+            }
+
+            if (workbookXml != null)
+            {
+                Add("xl/workbook.xml", workbookXml);
+            }
+
+            if (relsXml != null)
+            {
+                Add("xl/_rels/workbook.xml.rels", relsXml);
+            }
+
+            foreach (var (name, sheet) in sheets)
+            {
+                Add(name, sheet);
+            }
+        }
+
+        return stream.ToArray();
+    }
+
+    private static string MakeSheet(string firstCell)
+    {
+        return $"""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+                  <sheetData>
+                    <row r="1"><c r="A1" t="inlineStr"><is><t>{firstCell}</t></is></c></row>
+                  </sheetData>
+                </worksheet>
+                """;
+    }
+
+    [Fact]
+    public void XlsxWithTenSheetsReadsTheFirstOneNotSheetTen()
+    {
+        // Ordering the entries as text puts "sheet10.xml" before "sheet2.xml", so a workbook with
+        // ten or more sheets was imported from the wrong one.
+        var bytes = MakeXlsxWithSheets(null, null,
+            ("xl/worksheets/sheet10.xml", MakeSheet("sheet ten")),
+            ("xl/worksheets/sheet1.xml", MakeSheet("sheet one")),
+            ("xl/worksheets/sheet2.xml", MakeSheet("sheet two")));
+
+        WithTempFile(".xlsx", bytes, path =>
+        {
+            var lines = new UnknownFormatImporterXlsx().ReadLinesFromFile(path);
+            Assert.Equal(new[] { "sheet one" }, lines);
+        });
+    }
+
+    [Fact]
+    public void XlsxReadsTheWorkbooksFirstSheetNotTheFirstFile()
+    {
+        // The sheet the user sees first is the first <sheet> in workbook.xml, which does not have
+        // to be sheet1.xml (moving a sheet in Excel does not rename the parts).
+        const string workbook = """
+                                <?xml version="1.0" encoding="UTF-8"?>
+                                <workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+                                          xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+                                  <sheets>
+                                    <sheet name="Subtitles" sheetId="2" r:id="rId2"/>
+                                    <sheet name="Notes" sheetId="1" r:id="rId1"/>
+                                  </sheets>
+                                </workbook>
+                                """;
+        const string rels = """
+                            <?xml version="1.0" encoding="UTF-8"?>
+                            <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+                              <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+                              <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet2.xml"/>
+                            </Relationships>
+                            """;
+
+        var bytes = MakeXlsxWithSheets(workbook, rels,
+            ("xl/worksheets/sheet1.xml", MakeSheet("notes")),
+            ("xl/worksheets/sheet2.xml", MakeSheet("subtitles")));
+
+        WithTempFile(".xlsx", bytes, path =>
+        {
+            var lines = new UnknownFormatImporterXlsx().ReadLinesFromFile(path);
+            Assert.Equal(new[] { "subtitles" }, lines);
+        });
+    }
+    [Fact]
+    public void AnUnterminatedQuoteInTheHeaderDoesNotThrow()
+    {
+        // The open quote makes the header swallow the rest of the file, so there are no data rows
+        // left - and the "start time without milliseconds" repair then divided by that count. The
+        // file-open path has no catch around this.
+        var lines = new List<string>
+        {
+            "Start,End,\"Text",
+            "00:00:01.000,00:00:03.500,Hello there.",
         };
 
         Assert.Empty(new UnknownFormatImporterCsv().AutoGuessImport(lines).Paragraphs);


### PR DESCRIPTION
Follow-up to #14173: bugs found while documenting the spreadsheet import paths (#14168). Each one has a regression test in `tests/libse/Common/SpreadsheetImportTest.cs` that fails without the fix.

| # | Bug | Effect |
|---|-----|--------|
| 1 | `CsvUtil.CsvSplit` only handled `,`, `;` and tab inside its quote-state machine | The import window's separator detection also picks `\|`, so a pipe-delimited file came back as **one column** — every role but the first unmappable |
| 2 | `FixStartTimeWithoutMs` averaged over zero rows | **DivideByZeroException** opening a CSV whose header line has an unterminated quote (the header then swallows every data row). The file-open path has no catch |
| 3 | `DetectIsFrames` vetoed on blank values | One empty time cell — or the blank row a trailing newline produces — made a `HH:MM:SS:FF` column be re-read as `HH:MM:SS.ms`, so 12 frames silently became 12 ms. The import window already had this fixed; libse now matches |
| 4 | XLSX sheet picked by file name | The sheet the user sees first is the first `<sheet>` in `xl/workbook.xml`, which need not be `sheet1.xml` — moving a sheet in Excel reorders the workbook, never the parts. Now resolved through the workbook relationships, falling back to the first worksheet part |
| 5 | ODS ignored `covered-table-cell` | A merged cell is one `table-cell` plus one `covered-table-cell` per column it swallows; skipping the placeholders shifted every later column left, so the text column of such a row was read as the end time |

Two smaller ones alongside:

- `UnknownFormatImporterCsv.AutoGuessImport` dropped a leading blank line from the list its **caller** passed in, and `UnknownFormatImporter` keeps using that same list for the other parsers
- JSON importer: bitwise `|` between two bool comparisons

Full suites green: libse 1518, UI 4122, seconv 416, libuilogic 703.

🤖 Generated with [Claude Code](https://claude.com/claude-code)