### PR TITLE
Fix Lambda Cap ruby and layout control codes showing up as text

### DIFF
--- a/src/libse/Common/NetflixImsc11JapaneseToAss.cs
+++ b/src/libse/Common/NetflixImsc11JapaneseToAss.cs
@@ -97,6 +97,34 @@ namespace Nikse.SubtitleEdit.Core.Common
                 ch >= 0xFFE0 && ch <= 0xFFE6);
         }
 
+        /// <summary>
+        /// True when the subtitle carries the Japanese profile markup libass cannot draw by itself.
+        /// The format alone does not say: "Lambda Cap" decodes furigana, emphasis marks and
+        /// tate-chu-yoko to the same markup, and its control codes would otherwise end up on screen
+        /// as literal text (issue #14165).
+        /// </summary>
+        public static bool HasJapaneseMarkup(Subtitle subtitle)
+        {
+            if (subtitle == null)
+            {
+                return false;
+            }
+
+            foreach (var p in subtitle.Paragraphs)
+            {
+                var text = p.Text;
+                if (!string.IsNullOrEmpty(text) && text.Contains('<') &&
+                    (text.Contains("<ruby-", StringComparison.Ordinal) ||
+                     text.Contains("<bouten-", StringComparison.Ordinal) ||
+                     text.Contains("<horizontalDigit>", StringComparison.Ordinal)))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         public static List<Paragraph> SplitToAssRenderLines(Paragraph p, int width, int height)
         {
             var metrics = new Metrics(height);
@@ -182,6 +210,16 @@ namespace Nikse.SubtitleEdit.Core.Common
                         actual.Append("{\\i0}");
                         i += 4;
                         italicOn = false;
+                    }
+                    else if (line.Substring(i).StartsWith("<horizontalDigit>", StringComparison.Ordinal))
+                    {
+                        // Tate-chu-yoko only means something in a vertical column - horizontal digits
+                        // are already horizontal, so just drop the tags (issue #14165).
+                        i += "<horizontalDigit>".Length;
+                    }
+                    else if (line.Substring(i).StartsWith("</horizontalDigit>", StringComparison.Ordinal))
+                    {
+                        i += "</horizontalDigit>".Length;
                     }
                     else if (line.Substring(i).StartsWith("<bouten-", StringComparison.Ordinal))
                     {

--- a/src/libse/SubtitleFormats/LambdaCap.cs
+++ b/src/libse/SubtitleFormats/LambdaCap.cs
@@ -8,6 +8,12 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
     /// <summary>
     /// https://backlothelp.netflix.com/hc/en-us/articles/214807928-Lambda-Cap-Creation-Guide-v1-1
+    ///
+    /// A cue is one tab separated row - number, "start/end", the first text line, and then one field
+    /// per layout control code (＠横下, ＠中頭, ＠斜３...). Further text lines follow on their own rows,
+    /// indented with tabs. Ruby (furigana), emphasis marks and tate-chu-yoko are decoded to the same
+    /// markup the "Netflix IMSC 1.1 Japanese" format uses, so the video preview can draw them instead
+    /// of putting the control codes on screen as literal text (issue #14165).
     /// </summary>
     public class LambdaCap : SubtitleFormat
     {
@@ -23,9 +29,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             {
                 if (Configuration.Settings.General.CurrentFrameRate % 1.0 < 0.001)
                 {
-                    return "Lambda字幕V4 DF0+1 SCENE\"和文標準\""; // non drop frame
+                    return "Lambda字幕V4\tDF0+1\tSCENE\"和文標準\""; // non drop frame
                 }
-                return "Lambda字幕V4 DF1+1 SCENE\"和文標準\""; // drop frame
+                return "Lambda字幕V4\tDF1+1\tSCENE\"和文標準\""; // drop frame
             }
         }
 
@@ -45,13 +51,62 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             return base.IsMine(lines, fileName);
         }
 
-        private const string AlignVerticalTop = "＠行頭";
-        private const string AlignHorizontalLeft = "＠縦左";
-        private const string AlignHorizontalRight = "＠縦右";
-        private const string JustifiedCenter = "＠中央";
+        private const string AlignVerticalTop = "＠行頭"; // start at the head of the line - top for horizontal writing
+        private const string AlignHorizontalTop = "＠横上"; // horizontal writing, top of the screen
+        private const string AlignHorizontalBottom = "＠横下"; // horizontal writing, bottom of the screen (the default)
+        private const string AlignHorizontalLeft = "＠縦左"; // vertical writing, left side
+        private const string AlignHorizontalRight = "＠縦右"; // vertical writing, right side
+        private const string JustifiedCenter = "＠中央"; // every line centered on its own
+        private const string JustifiedCenterHead = "＠中頭"; // block centered, lines aligned at their head
+        private const string ItalicCode = "＠斜３";
         private const string LongDash1 = "＠幅広［―］＠";
         private const string LongDash2 = "＠幅広［ー］＠";
         private const string AsynchronousContinuation = "＠継続";
+
+        private const string EndCode = "］＠";
+        private const string RubyAbove = "＠ルビ上［"; // furigana above (horizontal writing)
+        private const string RubyBelow = "＠ルビ下［"; // furigana below (horizontal writing)
+        private const string RubyRight = "＠ルビ右［"; // furigana right of the column (vertical writing)
+        private const string RubyLeft = "＠ルビ左［"; // furigana left of the column (vertical writing)
+        private const string HorizontalDigits = "＠組［"; // tate-chu-yoko - up to three half width digits
+        private const string InlineItalic = "＠斜３［";
+
+        /// <summary>A ruby run holding only one of these is an emphasis mark, not furigana.</summary>
+        private const string BoutenMarkers = "↓↑・･";
+
+        private const string BoutenTagBefore = "bouten-dot-before";
+        private const string BoutenTagAfter = "bouten-dot-after";
+
+        private static readonly char[] RubySeparators = { '｜', '|' };
+
+        /// <summary>Codes that belong to the cue as a whole, not to a spot inside the text.</summary>
+        private static readonly string[] LayoutCodes =
+        {
+            AlignVerticalTop,
+            AlignHorizontalTop,
+            AlignHorizontalBottom,
+            AlignHorizontalLeft,
+            AlignHorizontalRight,
+            JustifiedCenter,
+            JustifiedCenterHead,
+            ItalicCode,
+            AsynchronousContinuation,
+        };
+
+        private static readonly Regex RubyContainerRegex = new Regex(
+            @"<ruby-container>\s*<ruby-base(?:-italic)?>(.*?)</ruby-base(?:-italic)?>\s*<(ruby-text|ruby-text-italic|ruby-text-after)>(.*?)</\2>\s*</ruby-container>",
+            RegexOptions.Compiled);
+
+        private static readonly Regex BoutenRegex = new Regex(@"<(bouten-[a-z-]+)>(.*?)</\1>", RegexOptions.Compiled);
+
+        private static readonly Regex HorizontalDigitRegex = new Regex(@"<horizontalDigit>(.*?)</horizontalDigit>", RegexOptions.Compiled);
+
+        /// <summary>The text lines and the layout codes collected for one cue.</summary>
+        private sealed class LambdaCue
+        {
+            internal List<string> TextLines { get; } = new List<string>();
+            internal HashSet<string> Codes { get; } = new HashSet<string>();
+        }
 
         public override string ToText(Subtitle subtitle, string title)
         {
@@ -60,14 +115,22 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             sb.AppendLine();
             foreach (Paragraph p in subtitle.Paragraphs)
             {
-                // 1<HT>00000000/11111111<HT>Line 1
-                // <HT><HT><HT><HT>Line 2
-                // 2<HT>11111111/22222222<HT>AAAA Line 1
+                // 1<HT>00000000/11111111<HT>Line 1<HT>＠横下<HT>＠中頭
                 // <HT><HT><HT><HT>Line 2
                 var text = EncodeStyle(p.Text);
                 sb.AppendLine($"{p.Number}\t{EncodeTimeCode(p.StartTime)}/{EncodeTimeCode(p.EndTime)}\t{text}");
             }
             return sb.ToString();
+        }
+
+        public override void RemoveNativeFormatting(Subtitle subtitle, SubtitleFormat newFormat)
+        {
+            // Furigana/bouten/tate-chu-yoko markup means nothing to any other format - a plain text
+            // format would otherwise get the tags themselves.
+            foreach (var p in subtitle.Paragraphs)
+            {
+                p.Text = NetflixImsc11Japanese.RemoveTags(p.Text);
+            }
         }
 
         private static string EncodeTimeCode(TimeCode time)
@@ -77,208 +140,349 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         private static string EncodeStyle(string text)
         {
-            text = text.Replace("―", LongDash1);
-            text = text.Replace("ー", LongDash2);
-
             var verticalAlignTop = text.StartsWith("{\\an7}", StringComparison.Ordinal) || text.StartsWith("{\\an8}", StringComparison.Ordinal) || text.StartsWith("{\\an9}", StringComparison.Ordinal);
-            // var verticalAlignCenter = text.StartsWith("{\\an4}", StringComparison.Ordinal) || text.StartsWith("{\\an5}", StringComparison.Ordinal) || text.StartsWith("{\\an6}", StringComparison.Ordinal);
-            var horizontalAlignLeft = text.StartsWith("{\\an1}", StringComparison.Ordinal) || text.StartsWith("{\\an4}", StringComparison.Ordinal) || text.StartsWith("{\\an7}", StringComparison.Ordinal);
-            var horizontalAlignRight = text.StartsWith("{\\an3}", StringComparison.Ordinal) || text.StartsWith("{\\an6}", StringComparison.Ordinal) || text.StartsWith("{\\an9}", StringComparison.Ordinal);
+            var writtenVerticallyLeft = text.StartsWith("{\\an1}", StringComparison.Ordinal) || text.StartsWith("{\\an4}", StringComparison.Ordinal) || text.StartsWith("{\\an7}", StringComparison.Ordinal);
+            var writtenVerticallyRight = text.StartsWith("{\\an3}", StringComparison.Ordinal) || text.StartsWith("{\\an6}", StringComparison.Ordinal) || text.StartsWith("{\\an9}", StringComparison.Ordinal);
+            var writtenVertically = writtenVerticallyLeft || writtenVerticallyRight;
+
             var s = Utilities.RemoveSsaTags(text);
-            bool isWholeLineItalic = s.StartsWith("<i>", StringComparison.Ordinal) && s.EndsWith("</i>", StringComparison.Ordinal) && Utilities.CountTagInText(s, "<i>") == 1;
+            var isWholeLineItalic = s.StartsWith("<i>", StringComparison.Ordinal) && s.EndsWith("</i>", StringComparison.Ordinal) && Utilities.CountTagInText(s, "<i>") == 1;
             if (isWholeLineItalic)
             {
-                text = text.Replace("<i>", string.Empty).Replace("</i>", string.Empty);
+                s = s.Replace("<i>", string.Empty).Replace("</i>", string.Empty);
             }
-            var lineBuilder = new StringBuilder();
-            foreach (var line in text.SplitToLines())
+
+            var codes = new List<string>();
+            if (writtenVertically)
             {
-                var l = Utilities.RemoveSsaTags(line);
-                bool isLineItalic = l.StartsWith("<i>", StringComparison.Ordinal) && l.EndsWith("</i>", StringComparison.Ordinal) && Utilities.CountTagInText(l, "<i>") == 1;
-                if (lineBuilder.Length > 0)
+                codes.Add(writtenVerticallyLeft ? AlignHorizontalLeft : AlignHorizontalRight);
+                if (verticalAlignTop)
+                {
+                    codes.Add(AlignVerticalTop);
+                }
+            }
+            else
+            {
+                codes.Add(verticalAlignTop ? AlignHorizontalTop : AlignHorizontalBottom);
+
+                // Subtitle Edit cannot tell "centered block, head aligned" from "every line centered",
+                // so the far more common one is written back.
+                codes.Add(JustifiedCenterHead);
+            }
+
+            if (isWholeLineItalic)
+            {
+                codes.Add(ItalicCode);
+            }
+
+            var lineBuilder = new StringBuilder();
+            var lines = s.SplitToLines();
+            for (var index = 0; index < lines.Count; index++)
+            {
+                if (index > 0)
                 {
                     lineBuilder.AppendLine();
                     lineBuilder.Append("\t\t\t\t");
                 }
 
-                if (l.Contains("<i>") && !(isWholeLineItalic || isLineItalic))
-                {
-                    l = l.Replace("<i>", "＠斜３［");
-                    l = l.Replace("</i>", "］＠");
-                }
-                l = HtmlUtil.RemoveHtmlTags(l, true);
-                lineBuilder.Append(l);
-                if (isWholeLineItalic || isLineItalic)
-                {
-                    lineBuilder.Append(" ＠斜３");
-                }
+                lineBuilder.Append(EncodeLine(lines[index], writtenVertically));
 
-                if (horizontalAlignLeft)
+                if (index == 0)
                 {
-                    lineBuilder.Append(" " + AlignHorizontalLeft);
+                    foreach (var code in codes)
+                    {
+                        lineBuilder.Append('\t').Append(code);
+                    }
                 }
-                else if (horizontalAlignRight)
-                {
-                    lineBuilder.Append(" " + AlignHorizontalRight);
-                }
-                if (verticalAlignTop)
-                {
-                    lineBuilder.Append(" " + AlignVerticalTop);
-                }
-
             }
-            return lineBuilder.ToString().TrimEnd();
+
+            return lineBuilder.ToString();
         }
 
-        private static string DecodeStyle(string line)
+        private static string EncodeLine(string line, bool writtenVertically)
         {
-            line = line.Trim();
-            var max = line.Length;
-            var sb = new StringBuilder(max);
-            bool readUntilEndCode = false;
-            bool italicOn = false;
-            bool digitsOn = false;
-            int i = 0;
-            while (i < max)
+            // Only the horizontal bar is written back as a wide dash - the katakana prolonged sound
+            // mark is a normal letter inside words like "スムーズ".
+            var s = line.Replace("―", LongDash1);
+
+            var rubyBefore = writtenVertically ? RubyRight : RubyAbove;
+            var rubyAfter = writtenVertically ? RubyLeft : RubyBelow;
+
+            s = RubyContainerRegex.Replace(s, match =>
             {
-                var ch = line[i];
-                if (readUntilEndCode)
+                var code = match.Groups[2].Value == "ruby-text-after" ? rubyAfter : rubyBefore;
+                return code + match.Groups[1].Value + RubySeparators[0] + match.Groups[3].Value + EndCode;
+            });
+
+            s = BoutenRegex.Replace(s, match =>
+            {
+                // Lambda marks one character at a time.
+                var code = match.Groups[1].Value.EndsWith("-after", StringComparison.Ordinal) ? rubyAfter : rubyBefore;
+                var sb = new StringBuilder();
+                foreach (var ch in match.Groups[2].Value)
                 {
-                    if (ch == '］' && line.Substring(i).StartsWith("］＠", StringComparison.Ordinal))
+                    sb.Append(code).Append(ch).Append(RubySeparators[0]).Append(BoutenMarkers[0]).Append(EndCode);
+                }
+
+                return sb.ToString();
+            });
+
+            s = HorizontalDigitRegex.Replace(s, match => HorizontalDigits + match.Groups[1].Value + EndCode);
+
+            if (s.Contains("<i>", StringComparison.Ordinal))
+            {
+                s = s.Replace("<i>", InlineItalic);
+                s = s.Replace("</i>", EndCode);
+            }
+
+            return HtmlUtil.RemoveHtmlTags(s, true);
+        }
+
+        /// <summary>
+        /// Turns the inline control codes of one text field into the markup Subtitle Edit uses for
+        /// Japanese - anything unknown is left alone rather than eaten.
+        /// </summary>
+        private static string DecodeInlineCodes(string input)
+        {
+            var sb = new StringBuilder(input.Length);
+            var i = 0;
+            while (i < input.Length)
+            {
+                if (input[i] == '＠')
+                {
+                    if (TryDecodeRuby(input, i, sb, out var next) ||
+                        TryDecodeBracketCode(input, i, HorizontalDigits, "<horizontalDigit>", "</horizontalDigit>", sb, out next) ||
+                        TryDecodeBracketCode(input, i, InlineItalic, "<i>", "</i>", sb, out next))
                     {
-                        readUntilEndCode = false;
-                        if (italicOn)
-                        {
-                            sb.Append("</i>");
-                            italicOn = false;
-                        }
-                        else if (digitsOn)
-                        {
-                            sb.Append("</i>");
-                            digitsOn = false;
-                        }
-                        i++;
-                    }
-                    else
-                    {
-                        sb.Append(ch);
+                        i = next;
+                        continue;
                     }
                 }
-                else if (ch == '＠')
-                {
-                    var part = line.Substring(i);
-                    if (part.StartsWith("＠ルビ上［", StringComparison.Ordinal)) // Bouten on first line - horizontal positioning
-                    {
-                        readUntilEndCode = true;
-                    }
-                    else if (part.StartsWith("＠ルビ下［", StringComparison.Ordinal)) // Bouten on second line - horizontal positioning
-                    {
-                        readUntilEndCode = true;
-                    }
-                    else if (part.StartsWith("＠ルビ右［", StringComparison.Ordinal)) // Bouten on first line - vertical positioning
-                    {
-                        readUntilEndCode = true;
-                    }
-                    else if (part.StartsWith("＠ルビ左［", StringComparison.Ordinal)) // Bouten on second line - vertical positioning
-                    {
-                        readUntilEndCode = true;
-                    }
-                    else if (part.StartsWith("＠組［", StringComparison.Ordinal)) // Kumi-moji / Tatechuyoko (up to 3 half width digits including numerical punctuation)
-                    {
-                        readUntilEndCode = true;
-                        digitsOn = true;
-                        i += 2;
-                    }
-                    else if (part.StartsWith("＠斜３［", StringComparison.Ordinal)) // italic
-                    {
-                        readUntilEndCode = true;
-                        sb.Append("<i>");
-                        italicOn = true;
-                        i += 3;
-                    }
-                    else
-                    {
-                        sb.Append("＠");
-                    }
-                }
-                else
-                {
-                    if (ch != '\t')
-                    {
-                        sb.Append(ch);
-                    }
-                }
+
+                sb.Append(input[i]);
                 i++;
             }
 
-            var s = sb.ToString();
+            return sb.ToString();
+        }
 
-            if (s.Contains("＠斜３"))
+        private static bool TryDecodeRuby(string input, int index, StringBuilder sb, out int next)
+        {
+            next = index;
+            var after = false;
+            string prefix = null;
+            if (StartsWith(input, index, RubyAbove))
             {
-                s = "<i>" + s + "</i>";
-                s = s.Replace("＠斜３", string.Empty);
+                prefix = RubyAbove;
+            }
+            else if (StartsWith(input, index, RubyRight))
+            {
+                prefix = RubyRight;
+            }
+            else if (StartsWith(input, index, RubyBelow))
+            {
+                prefix = RubyBelow;
+                after = true;
+            }
+            else if (StartsWith(input, index, RubyLeft))
+            {
+                prefix = RubyLeft;
+                after = true;
             }
 
-            s = s.Replace(LongDash1, "―");
-            s = s.Replace(LongDash2, "ー");
-            s = s.Replace(AsynchronousContinuation, string.Empty);
-
-            if (s.Contains(AlignVerticalTop))
+            if (prefix == null)
             {
-                if (s.Contains(AlignHorizontalLeft))
+                return false;
+            }
+
+            var contentStart = index + prefix.Length;
+            var end = input.IndexOf(EndCode, contentStart, StringComparison.Ordinal);
+            if (end < 0)
+            {
+                return false;
+            }
+
+            var content = input.Substring(contentStart, end - contentStart);
+            var separator = content.IndexOfAny(RubySeparators);
+            var baseText = separator < 0 ? content : content.Substring(0, separator);
+            var rubyText = separator < 0 ? string.Empty : content.Substring(separator + 1);
+            AppendRuby(sb, baseText, rubyText, after);
+            next = end + EndCode.Length;
+            return true;
+        }
+
+        private static void AppendRuby(StringBuilder sb, string baseText, string rubyText, bool after)
+        {
+            if (baseText.Length == 0)
+            {
+                return;
+            }
+
+            if (rubyText.Length == 0)
+            {
+                sb.Append(baseText);
+                return;
+            }
+
+            if (IsBoutenMark(rubyText))
+            {
+                var boutenTag = after ? BoutenTagAfter : BoutenTagBefore;
+                sb.Append('<').Append(boutenTag).Append('>').Append(baseText).Append("</").Append(boutenTag).Append('>');
+                return;
+            }
+
+            var rubyTag = after ? "ruby-text-after" : "ruby-text";
+            sb.Append("<ruby-container><ruby-base>").Append(baseText).Append("</ruby-base>")
+                .Append('<').Append(rubyTag).Append('>').Append(rubyText).Append("</").Append(rubyTag).Append('>')
+                .Append("</ruby-container>");
+        }
+
+        private static bool IsBoutenMark(string rubyText)
+        {
+            foreach (var ch in rubyText)
+            {
+                if (BoutenMarkers.IndexOf(ch) < 0)
                 {
-                    s = "{\\an7}" + s;
+                    return false;
                 }
-                else if (s.Contains(AlignHorizontalRight))
-                {
-                    s = "{\\an9}" + s;
-                }
-                else
-                {
-                    s = "{\\an8}" + s;
-                }
-            }
-            else if (s.Contains(AlignHorizontalLeft))
-            {
-                s = "{\\an1}" + s;
-            }
-            else if (s.Contains(AlignHorizontalRight))
-            {
-                s = "{\\an3}" + s;
-            }
-            s = s.Replace(AlignVerticalTop, string.Empty);
-            s = s.Replace(AlignHorizontalLeft, string.Empty);
-            s = s.Replace(AlignHorizontalRight, string.Empty);
-            s = s.Replace(JustifiedCenter, string.Empty).TrimEnd();
-
-            if (s.EndsWith(" </i>", StringComparison.Ordinal))
-            {
-                s = s.Remove(s.Length - 5, 1);
             }
 
-            return s;
+            return true;
+        }
+
+        private static bool TryDecodeBracketCode(string input, int index, string code, string openTag, string closeTag, StringBuilder sb, out int next)
+        {
+            next = index;
+            if (!StartsWith(input, index, code))
+            {
+                return false;
+            }
+
+            var contentStart = index + code.Length;
+            var end = input.IndexOf(EndCode, contentStart, StringComparison.Ordinal);
+            if (end < 0)
+            {
+                return false;
+            }
+
+            sb.Append(openTag).Append(input, contentStart, end - contentStart).Append(closeTag);
+            next = end + EndCode.Length;
+            return true;
+        }
+
+        private static bool StartsWith(string input, int index, string value)
+        {
+            return string.CompareOrdinal(input, index, value, 0, value.Length) == 0;
+        }
+
+        /// <summary>
+        /// Pulls the cue level codes out of a text field - Subtitle Edit used to write them space
+        /// separated behind the text instead of in their own tab separated fields.
+        /// </summary>
+        private static string ExtractLayoutCodes(string text, ISet<string> codes)
+        {
+            foreach (var code in LayoutCodes)
+            {
+                var index = text.IndexOf(code, StringComparison.Ordinal);
+                while (index >= 0)
+                {
+                    codes.Add(code);
+                    text = text.Remove(index, code.Length);
+                    index = text.IndexOf(code, StringComparison.Ordinal);
+                }
+            }
+
+            return text;
+        }
+
+        private static void AddCueLine(LambdaCue cue, string line)
+        {
+            foreach (var field in line.Split('\t'))
+            {
+                var f = field.Trim();
+                if (f.Length == 0)
+                {
+                    continue;
+                }
+
+                if (Array.IndexOf(LayoutCodes, f) >= 0)
+                {
+                    cue.Codes.Add(f);
+                    continue;
+                }
+
+                // A short "＠code" field behind the text is a layout code Subtitle Edit does not know -
+                // dropping it beats putting it on screen as text.
+                if (cue.TextLines.Count > 0 && f[0] == '＠' && f.Length <= 6 && f.IndexOf('［') < 0)
+                {
+                    continue;
+                }
+
+                var text = f.Replace(LongDash1, "―").Replace(LongDash2, "ー");
+                text = DecodeInlineCodes(text);
+                text = ExtractLayoutCodes(text, cue.Codes).Trim();
+                cue.TextLines.Add(text);
+            }
+        }
+
+        private static void CloseCue(Paragraph p, LambdaCue cue)
+        {
+            if (p == null)
+            {
+                return;
+            }
+
+            var text = string.Join(Environment.NewLine, cue.TextLines);
+            if (text.Length == 0)
+            {
+                p.Text = string.Empty;
+                return;
+            }
+
+            if (cue.Codes.Contains(ItalicCode))
+            {
+                text = "<i>" + text + "</i>";
+            }
+
+            var top = cue.Codes.Contains(AlignVerticalTop) || cue.Codes.Contains(AlignHorizontalTop);
+            if (cue.Codes.Contains(AlignHorizontalLeft))
+            {
+                text = (top ? "{\\an7}" : "{\\an1}") + text;
+            }
+            else if (cue.Codes.Contains(AlignHorizontalRight))
+            {
+                text = (top ? "{\\an9}" : "{\\an3}") + text;
+            }
+            else if (top)
+            {
+                text = "{\\an8}" + text;
+            }
+
+            p.Text = text;
         }
 
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
         {
             Paragraph p = null;
+            var cue = new LambdaCue();
             subtitle.Paragraphs.Clear();
             _errorCount = 0;
             foreach (string line in lines)
             {
-                if (RegexTimeCodes.IsMatch(line))
+                var match = RegexTimeCodes.Match(line);
+                if (match.Success)
                 {
                     var temp = line.Trim().Split('\t');
-                    if (temp.Length > 1)
+                    var timeCodes = temp.Length > 1 ? temp[1].Trim() : string.Empty;
+                    if (timeCodes.Length >= 17)
                     {
-                        string[] startParts = { temp[1].Substring(0, 2), temp[1].Substring(2, 2), temp[1].Substring(4, 2), temp[1].Substring(6, 2), };
-                        string[] endParts = { temp[1].Substring(9, 2), temp[1].Substring(11, 2), temp[1].Substring(13, 2), temp[1].Substring(15, 2), };
-                        if (startParts.Length == 4 && endParts.Length == 4)
-                        {
-                            string text = line.Remove(0, RegexTimeCodes.Match(line).Length - 1).Trim();
-                            p = new Paragraph(DecodeTimeCodeFramesFourParts(startParts), DecodeTimeCodeFramesFourParts(endParts), DecodeStyle(text));
-                            subtitle.Paragraphs.Add(p);
-                        }
+                        string[] startParts = { timeCodes.Substring(0, 2), timeCodes.Substring(2, 2), timeCodes.Substring(4, 2), timeCodes.Substring(6, 2), };
+                        string[] endParts = { timeCodes.Substring(9, 2), timeCodes.Substring(11, 2), timeCodes.Substring(13, 2), timeCodes.Substring(15, 2), };
+                        CloseCue(p, cue);
+                        cue = new LambdaCue();
+                        p = new Paragraph(DecodeTimeCodeFramesFourParts(startParts), DecodeTimeCodeFramesFourParts(endParts), string.Empty);
+                        subtitle.Paragraphs.Add(p);
+                        AddCueLine(cue, line.Remove(0, match.Length - 1));
                     }
                 }
                 else if (string.IsNullOrWhiteSpace(line))
@@ -287,16 +491,11 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 }
                 else if (p != null)
                 {
-                    if (string.IsNullOrEmpty(p.Text))
-                    {
-                        p.Text = DecodeStyle(line);
-                    }
-                    else
-                    {
-                        p.Text = p.Text + Environment.NewLine + DecodeStyle(line);
-                    }
+                    AddCueLine(cue, line);
                 }
             }
+
+            CloseCue(p, cue);
             subtitle.Renumber();
         }
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -29014,7 +29014,10 @@ public partial class MainViewModel :
                     _subtitleOriginal = GetUpdateSubtitleOriginal();
                 }
 
-                if (format is AdvancedSubStationAlpha && oldFormat is NetflixImsc11Japanese)
+                // Lambda Cap decodes furigana and emphasis marks to the same markup (issue #14165).
+                var keepJapaneseMarkup = format is AdvancedSubStationAlpha &&
+                                         (oldFormat is NetflixImsc11Japanese || NetflixImsc11JapaneseToAss.HasJapaneseMarkup(_subtitle));
+                if (keepJapaneseMarkup)
                 {
                     // Converting to ASSA is the only way to keep furigana/bouten/vertical writing -
                     // they become extra positioned lines. RemoveNativeFormatting would just drop the
@@ -29026,7 +29029,7 @@ public partial class MainViewModel :
                     oldFormat.RemoveNativeFormatting(_subtitle, format);
                 }
 
-                if (format is AdvancedSubStationAlpha && oldFormat is not NetflixImsc11Japanese)
+                if (format is AdvancedSubStationAlpha && !keepJapaneseMarkup)
                 {
                     if (oldFormat is WebVTT || oldFormat is WebVTTFileWithLineNumber)
                     {

--- a/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
@@ -883,10 +883,11 @@ public partial class BurnInViewModel : ObservableObject
         var subtitle = Subtitle.Parse(subtitleFileName);
         subtitle = GetSubtitleBasedOnCut(subtitle);
 
-        if (subtitle.OriginalFormat is NetflixImsc11Japanese)
+        if (subtitle.OriginalFormat is NetflixImsc11Japanese || NetflixImsc11JapaneseToAss.HasJapaneseMarkup(subtitle))
         {
             // Furigana, bouten and vertical writing become extra positioned render lines - burning
-            // in the raw tags would put them on screen as literal text (issue #13861).
+            // in the raw tags would put them on screen as literal text (issue #13861). Lambda Cap
+            // decodes to the same markup (issue #14165).
             var japaneseAssaFileName = _tempSubtitleFiles.GetFileName(".ass");
             File.WriteAllText(japaneseAssaFileName, NetflixImsc11JapaneseToAss.Convert(subtitle, jobItem.Width, jobItem.Height));
             return japaneseAssaFileName;
@@ -2376,7 +2377,7 @@ public partial class BurnInViewModel : ObservableObject
         var height = VideoHeight ?? _mediaInfo?.Dimension.Height ?? 1080;
 
         var subtitle = new Subtitle(_subtitle, false);
-        if (_subtitleFormat is NetflixImsc11Japanese)
+        if (_subtitleFormat is NetflixImsc11Japanese || NetflixImsc11JapaneseToAss.HasJapaneseMarkup(subtitle))
         {
             return NetflixImsc11JapaneseToAss.Convert(subtitle, width, height);
         }

--- a/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesViewModel.cs
+++ b/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesViewModel.cs
@@ -650,10 +650,11 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
 
         subtitle = GetSubtitleBasedOnCut(subtitle);
 
-        if (subtitle.OriginalFormat is NetflixImsc11Japanese)
+        if (subtitle.OriginalFormat is NetflixImsc11Japanese || NetflixImsc11JapaneseToAss.HasJapaneseMarkup(subtitle))
         {
             // Furigana, bouten and vertical writing become extra positioned render lines - the raw
-            // tags would otherwise be rendered as literal text (issue #13861).
+            // tags would otherwise be rendered as literal text (issue #13861). Lambda Cap decodes
+            // to the same markup (issue #14165).
             var japaneseJobItem = JobItems[_jobItemIndex];
             var japaneseAssaFileName = _tempSubtitleFiles.GetFileName(".ass");
             File.WriteAllText(japaneseAssaFileName, NetflixImsc11JapaneseToAss.Convert(subtitle, japaneseJobItem.Width, japaneseJobItem.Height));
@@ -1369,7 +1370,7 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
         var height = VideoHeight ?? 1080;
 
         var subtitle = new Subtitle(_subtitle, false);
-        if (_subtitleFormat is NetflixImsc11Japanese)
+        if (_subtitleFormat is NetflixImsc11Japanese || NetflixImsc11JapaneseToAss.HasJapaneseMarkup(subtitle))
         {
             return NetflixImsc11JapaneseToAss.Convert(subtitle, width, height);
         }

--- a/src/ui/Logic/Media/MpvReloader.cs
+++ b/src/ui/Logic/Media/MpvReloader.cs
@@ -185,11 +185,11 @@ public class MpvReloader : IMpvReloader
             }
         }
 
-        if (uiFormatType == typeof(NetflixImsc11Japanese))
+        if (uiFormatType == typeof(NetflixImsc11Japanese) || NetflixImsc11JapaneseToAss.HasJapaneseMarkup(subtitle))
         {
             // Furigana, bouten and vertical writing have no libass equivalent - they have to be
             // exploded into separately positioned render lines, or the tags show up as literal
-            // text on the video (issue #13861).
+            // text on the video (issue #13861). Lambda Cap decodes to the same markup (issue #14165).
             subtitle = NetflixImsc11JapaneseToAss.ConvertToSubtitle(subtitle, VideoWidth, VideoHeight);
             SecondarySubtitleMerger.AddSecondarySubtitle(subtitle, subtitleSecondary);
             return (subtitle, subtitle.ToText(_assFormat), 0, false);

--- a/src/ui/Logic/Media/VlcReloader.cs
+++ b/src/ui/Logic/Media/VlcReloader.cs
@@ -48,10 +48,10 @@ public class VlcReloader : IVlcReloader
 
             SubtitleFormat format = _assFormat;
             string text;
-            if (uiFormatType == typeof(NetflixImsc11Japanese))
+            if (uiFormatType == typeof(NetflixImsc11Japanese) || NetflixImsc11JapaneseToAss.HasJapaneseMarkup(subtitle))
             {
                 // See MpvReloader - the furigana/bouten/vertical markup has to become positioned
-                // render lines before libass sees it (issue #13861).
+                // render lines before libass sees it (issue #13861, issue #14165).
                 subtitle = NetflixImsc11JapaneseToAss.ConvertToSubtitle(subtitle, VideoWidth, VideoHeight);
                 SecondarySubtitleMerger.AddSecondarySubtitle(subtitle, subtitleSecondary);
                 text = subtitle.ToText(_assFormat);

--- a/tests/libse/SubtitleFormats/LambdaCapTest.cs
+++ b/tests/libse/SubtitleFormats/LambdaCapTest.cs
@@ -1,0 +1,181 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+
+namespace LibSETests.SubtitleFormats;
+
+public class LambdaCapTest
+{
+    private static Subtitle Load(params string[] cueLines)
+    {
+        var lines = new List<string> { "Lambda字幕V4\tDF0+1\tSCENE\"和文標準\"", "" };
+        lines.AddRange(cueLines);
+        var subtitle = new Subtitle();
+        new LambdaCap().LoadSubtitle(subtitle, lines, "test.cap");
+        return subtitle;
+    }
+
+    private static string LoadText(params string[] cueLines)
+    {
+        var subtitle = Load(cueLines);
+        Assert.Single(subtitle.Paragraphs);
+        return subtitle.Paragraphs[0].Text;
+    }
+
+    private static string Save(string text)
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph(text, 0, 1000));
+        subtitle.Renumber();
+        return new LambdaCap().ToText(subtitle, "test");
+    }
+
+    [Fact]
+    public void RubyBecomesJapaneseMarkup()
+    {
+        var text = LoadText("1\t01002619/01002902\t中国 ＠ルビ上［成都｜せいと］＠\t＠横下\t＠中頭");
+
+        Assert.Equal("中国 <ruby-container><ruby-base>成都</ruby-base><ruby-text>せいと</ruby-text></ruby-container>", text);
+    }
+
+    [Fact]
+    public void RubyBelowBecomesRubyTextAfter()
+    {
+        var text = LoadText("1\t01002619/01002902\t＠ルビ下［成都｜せいと］＠\t＠横下");
+
+        Assert.Equal("<ruby-container><ruby-base>成都</ruby-base><ruby-text-after>せいと</ruby-text-after></ruby-container>", text);
+    }
+
+    [Fact]
+    public void RubyHoldingOnlyAMarkerBecomesBouten()
+    {
+        var text = LoadText("1\t01002619/01002902\tでも＠ルビ上［誰｜↓］＠が恋しいのよ\t＠横下\t＠中頭");
+
+        Assert.Equal("でも<bouten-dot-before>誰</bouten-dot-before>が恋しいのよ", text);
+    }
+
+    [Fact]
+    public void TateChuYokoBecomesHorizontalDigit()
+    {
+        var text = LoadText("1\t01002619/01002902\t＠組［12］＠時間\t＠横下");
+
+        Assert.Equal("<horizontalDigit>12</horizontalDigit>時間", text);
+    }
+
+    [Fact]
+    public void InlineItalicIsDecoded()
+    {
+        var text = LoadText("1\t01002619/01002902\t＠斜３［ABC］＠ですね\t＠横下");
+
+        Assert.Equal("<i>ABC</i>ですね", text);
+    }
+
+    [Fact]
+    public void ItalicCodeAppliesToTheWholeCue()
+    {
+        var text = LoadText(
+            "1\t01002619/01002902\t中国\t＠横下\t＠中頭\t＠斜３",
+            "\t\t\t\t24時間 耐久洗礼式");
+
+        Assert.Equal("<i>中国" + Environment.NewLine + "24時間 耐久洗礼式</i>", text);
+    }
+
+    [Fact]
+    public void SecondLineIsKept()
+    {
+        var text = LoadText(
+            "1\t01002619/01002902\tイエスの名において\t＠横下\t＠中頭",
+            "\t\t\t\t洗礼しましょう");
+
+        Assert.Equal("イエスの名において" + Environment.NewLine + "洗礼しましょう", text);
+    }
+
+    [Theory]
+    [InlineData("＠横下\t＠中頭", "")]
+    [InlineData("＠横下\t＠中央", "")]
+    [InlineData("＠横上", "{\\an8}")]
+    [InlineData("＠縦右\t＠行頭", "{\\an9}")]
+    [InlineData("＠縦左\t＠行頭", "{\\an7}")]
+    [InlineData("＠縦右", "{\\an3}")]
+    [InlineData("＠縦左", "{\\an1}")]
+    public void LayoutCodesBecomeAlignment(string codes, string expectedTag)
+    {
+        var text = LoadText("1\t01002619/01002902\tテスト\t" + codes);
+
+        Assert.Equal(expectedTag + "テスト", text);
+    }
+
+    [Fact]
+    public void UnknownControlCodeIsDropped()
+    {
+        var text = LoadText("1\t01002619/01002902\tテスト\t＠横下\t＠謎コード");
+
+        Assert.Equal("テスト", text);
+    }
+
+    [Fact]
+    public void LayoutCodesWrittenBehindTheTextAreStillRead()
+    {
+        // Older Subtitle Edit versions wrote the codes space separated instead of in their own fields.
+        var text = LoadText("1\t01002619/01002902\tテスト ＠縦左 ＠行頭");
+
+        Assert.Equal("{\\an7}テスト", text);
+    }
+
+    [Fact]
+    public void WideDashIsDecoded()
+    {
+        var text = LoadText("1\t01002619/01002902\t＠幅広［―］＠そう\t＠横下");
+
+        Assert.Equal("―そう", text);
+    }
+
+    [Fact]
+    public void SaveWritesControlCodesInTheirOwnFields()
+    {
+        var text = Save("中国 <ruby-container><ruby-base>成都</ruby-base><ruby-text>せいと</ruby-text></ruby-container>");
+
+        Assert.Contains("\t中国 ＠ルビ上［成都｜せいと］＠\t＠横下\t＠中頭", text);
+    }
+
+    [Fact]
+    public void SaveWritesItalicAsACueLevelCode()
+    {
+        var text = Save("<i>中国" + Environment.NewLine + "24時間</i>");
+
+        Assert.Contains("\t中国\t＠横下\t＠中頭\t＠斜３" + Environment.NewLine + "\t\t\t\t24時間", text);
+    }
+
+    [Fact]
+    public void SaveKeepsProlongedSoundMark()
+    {
+        // "ー" is a normal letter inside katakana words - only the horizontal bar is a wide dash.
+        var text = Save("スムーズ");
+
+        Assert.Contains("スムーズ", text);
+        Assert.DoesNotContain("幅広", text);
+    }
+
+    [Fact]
+    public void SaveAndLoadRoundTrip()
+    {
+        var expected = "{\\an9}<i>〝ケルビン" + Environment.NewLine +
+                       "でも<bouten-dot-before>誰</bouten-dot-before> " +
+                       "<ruby-container><ruby-base>成都</ruby-base><ruby-text>せいと</ruby-text></ruby-container>" +
+                       "<horizontalDigit>12</horizontalDigit></i>";
+
+        var saved = Save(expected);
+        var reloaded = new Subtitle();
+        new LambdaCap().LoadSubtitle(reloaded, saved.SplitToLines(), "test.cap");
+
+        Assert.Single(reloaded.Paragraphs);
+        Assert.Equal(expected, reloaded.Paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void HeaderFieldsAreTabSeparated()
+    {
+        var text = Save("テスト");
+
+        Assert.StartsWith("Lambda字幕V4\t", text);
+    }
+}


### PR DESCRIPTION
Fixes #14165

## The problem

A Lambda Cap cue carries its layout codes as extra tab separated fields and ruby inline:

```
1<TAB>01002619/01002902<TAB>中国 ＠ルビ上［成都｜せいと］＠<TAB>＠横下<TAB>＠中頭<TAB>＠斜３
<TAB><TAB><TAB><TAB>24時間 耐久洗礼式
```

`LambdaCap.DecodeStyle` knew only four of those codes, never skipped the ruby code itself and dropped the `｜` split, so **916 of the 927 cues** in the sample file from the issue ended up with the control codes on screen as literal text:

| Input | Before | After |
|---|---|---|
| `中国 ＠ルビ上［成都｜せいと］＠` + `＠横下` `＠中頭` `＠斜３` | `<i>中国 ルビ上［成都｜せいと＠横下＠中頭</i>` | `<i>中国 <ruby-container>…成都…せいと…</ruby-container>` (both lines italic) |
| `＠組［12］＠時間` | `12</i>時間` | `<horizontalDigit>12</horizontalDigit>時間` |
| `でも＠ルビ上［誰｜↓］＠が…` | `でもルビ上［誰｜↓が…` | `でも<bouten-dot-before>誰</bouten-dot-before>が…` |
| `テスト` + `＠横上` `＠中央` | `テスト＠横上` | `{\an8}テスト` |

## The fix

**Reading** (`LambdaCap`)
- `＠ルビ上/下/右/左［base｜reading］＠` decodes to the same `<ruby-container>` / `<bouten-*>` markup "Netflix IMSC 1.1 Japanese" uses — a reading that is only a marker (`↓`) is an emphasis mark, anything else is furigana. `＠組［…］＠` becomes `<horizontalDigit>` instead of injecting an unbalanced `</i>`.
- `＠横上` / `＠横下` / `＠中頭` are handled, and the codes are read as cue level, so `＠斜３` italicizes the whole cue instead of just the first line. An unrecognized `＠code` field is dropped rather than put on screen.

**Writing**
- The codes go back into their own tab separated fields (as does the header), ruby/bouten/tate-chu-yoko are encoded back, and only `―` becomes `＠幅広［…］＠` — the katakana prolonged sound mark is a normal letter, so `スムーズ` no longer saves as `スム＠幅広［ー］＠ズ`.
- `RemoveNativeFormatting` drops the markup when converting to a format that cannot hold it.
- Load → save → load is stable; against the sample file the only text difference is `＠中央` → `＠中頭` on 54 cues (Subtitle Edit cannot tell the two justifications apart, so the far more common one is written back).

**Rendering** — the Japanese markup is now exploded into positioned render lines whenever a subtitle carries it, not only for the Netflix format: mpv preview, VLC, burn-in, transparent subtitles and the convert-to-ASSA path. `<horizontalDigit>` was also leaking into horizontal render lines in that converter.

## Verification

New `LambdaCapTest` (22 cases) plus the sample file from the issue, rendered through libass at 1920x1080:

- cue 1 — furigana over 成都, italic, no control codes (matches the Switch reference in the issue)
- cue 143 — emphasis dots over 誰かさん
- cue 223 — vertical writing top right

libse 1529, libuilogic 703, seconv 416 and UI 4113 tests pass.

## Not in here

The frame rate is still taken from the settings rather than from the file's `DF0`/`DF1` header, so this sample (29.97 drop frame timecodes, 23.976 setting) still rolls frame 24-29 into the next second — `01003024` loads as `00:00:31:00`. Separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
