### PR TITLE
Improve import of unknown subtitle formats (XML + JSON)

### DIFF
--- a/src/libse/Common/UnknownFormatImporter.cs
+++ b/src/libse/Common/UnknownFormatImporter.cs
@@ -55,6 +55,16 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
             }
 
+            var firstNonEmptyLine = lines.FirstOrDefault(l => !string.IsNullOrWhiteSpace(l));
+            if (firstNonEmptyLine != null && firstNonEmptyLine.TrimStart('﻿', ' ', '\t').StartsWith('<'))
+            {
+                var xmlSubtitle = new UnknownFormatImporterXml().AutoGuessImport(lines);
+                if (xmlSubtitle.Paragraphs.Count >= 2)
+                {
+                    return xmlSubtitle;
+                }
+            }
+
             var subtitle = ImportTimeCodesOnSameSeparateLine(lines);
             if (subtitle.Paragraphs.Count < 2)
             {

--- a/src/libse/Common/UnknownFormatImporterJson.cs
+++ b/src/libse/Common/UnknownFormatImporterJson.cs
@@ -1,4 +1,4 @@
-﻿using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -9,6 +9,56 @@ namespace Nikse.SubtitleEdit.Core.Common
 {
     public class UnknownFormatImporterJson
     {
+        private static readonly string[] StartTags =
+        {
+            "start", "in", "begin",
+            "startTime", "start_time", "starttime",
+            "startMillis", "start_Millis", "startmillis",
+            "startMs", "start_ms", "startms",
+            "startMilliseconds", "start_millisesonds", "startmilliseconds",
+            "from", "fromTime", "from_ms","fromms", "fromMilliseconds", "from_milliseconds", "show",
+            "tStartMs", "displayTimeOffset", "milliseconds", "timestamp", "timestamp_begin", "time",
+            "t1", "st", "s"
+        };
+
+        private static readonly string[] EndTags =
+        {
+            "end", "out", "stop",
+            "endTime", "end_time", "endtime",
+            "endMillis", "end_Millis", "endmillis",
+            "endMs", "end_ms", "endms",
+            "endMilliseconds", "end_millisesonds", "endmilliseconds",
+            "to", "toTime", "to_ms", "toms", "toMilliseconds", "to_milliseconds", "hide",
+            "tEndMs", "timestamp_end",
+            "t2", "et", "e"
+        };
+
+        private static readonly string[] DurationTags =
+        {
+            "duration",
+            "durationMs",
+            "dDurationMs",
+            "dur",
+            "d",
+        };
+
+        private static readonly string[] TextTags =
+        {
+            "text", "content", "value", "caption", "sentence", "dialog", "dialogue",
+            "line", "utf8", "tt", "t", "n"
+        };
+
+        private class Fields
+        {
+            public string Start { get; set; }
+            public string End { get; set; }
+            public string Duration { get; set; }
+            public string Text { get; set; }
+            public string Source { get; set; }
+
+            public bool HasTimes => Start != null && (End != null || Duration != null);
+        }
+
         public Subtitle AutoGuessImport(List<string> lines)
         {
             var sb = new StringBuilder();
@@ -23,43 +73,8 @@ namespace Nikse.SubtitleEdit.Core.Common
                 return new Subtitle();
             }
 
-            var subtitle1 = new Subtitle();
-            try
-            {
-                var count = 0;
-                foreach (var line in allText.Split('{', '}', '[', ']'))
-                {
-                    count++;
-                    ReadParagraph(line, subtitle1);
-                    if (count > 20 && subtitle1.Paragraphs.Count == 0)
-                    {
-                        break;
-                    }
-                }
-            }
-            catch
-            {
-                // ignored
-            }
-
-            var subtitle2 = new Subtitle();
-            try
-            {
-                var count = 0;
-                foreach (var line in allText.Split('{', '}'))
-                {
-                    count++;
-                    ReadParagraph(line, subtitle2);
-                    if (count > 20 && subtitle2.Paragraphs.Count == 0)
-                    {
-                        break;
-                    }
-                }
-            }
-            catch
-            {
-                // ignored
-            }
+            var subtitle1 = ImportFromSegments(allText.Split('{', '}', '[', ']'));
+            var subtitle2 = ImportFromSegments(allText.Split('{', '}'));
 
             var subtitle3 = new Subtitle();
             try
@@ -83,51 +98,135 @@ namespace Nikse.SubtitleEdit.Core.Common
             if (subtitle1.Paragraphs.Count >= subtitle2.Paragraphs.Count && subtitle1.Paragraphs.Count >= subtitle3.Paragraphs.Count)
             {
                 subtitle1.Renumber();
-                return FixTimeCodeMsOrSeconds(subtitle1);
+                return FixTimeCodeMsOrSeconds(FixMissingEndTimes(subtitle1));
             }
 
             if (subtitle2.Paragraphs.Count >= subtitle1.Paragraphs.Count && subtitle2.Paragraphs.Count >= subtitle3.Paragraphs.Count)
             {
                 subtitle2.Renumber();
-                return FixTimeCodeMsOrSeconds(subtitle2);
+                return FixTimeCodeMsOrSeconds(FixMissingEndTimes(subtitle2));
             }
 
             subtitle3.Renumber();
-            return FixTimeCodeMsOrSeconds(subtitle3);
+            return FixTimeCodeMsOrSeconds(FixMissingEndTimes(subtitle3));
+        }
+
+        private static Subtitle ImportFromSegments(string[] segments)
+        {
+            var subtitle = new Subtitle();
+            try
+            {
+                var count = 0;
+                Fields pendingTimes = null;
+                var pendingAge = 0;
+                foreach (var segment in segments)
+                {
+                    count++;
+                    var fields = ReadFields(segment);
+                    if (fields == null)
+                    {
+                        if (count > 20 && subtitle.Paragraphs.Count == 0)
+                        {
+                            break;
+                        }
+
+                        continue;
+                    }
+
+                    if (fields.Start != null && fields.Text != null)
+                    {
+                        AddParagraph(subtitle, fields, fields.Text);
+                        pendingTimes = null;
+                    }
+                    else if (fields.HasTimes && fields.Text == null)
+                    {
+                        // nested object layout: the time codes and the text live in different
+                        // segments after splitting (e.g. {"start":..,"end":..,"metadata":{"text":..}})
+                        pendingTimes = fields;
+                        pendingAge = 0;
+                    }
+                    else if (fields.Text != null && fields.Start == null && pendingTimes != null)
+                    {
+                        AddParagraph(subtitle, pendingTimes, fields.Text);
+                        pendingTimes = null;
+                    }
+
+                    if (pendingTimes != null)
+                    {
+                        pendingAge++;
+                        if (pendingAge > 3)
+                        {
+                            pendingTimes = null;
+                        }
+                    }
+
+                    if (count > 20 && subtitle.Paragraphs.Count == 0)
+                    {
+                        break;
+                    }
+                }
+            }
+            catch
+            {
+                // ignored
+            }
+
+            return subtitle;
+        }
+
+        private static Subtitle FixMissingEndTimes(Subtitle subtitle)
+        {
+            if (subtitle.Paragraphs.Count < 2 ||
+                !subtitle.Paragraphs.All(p => Math.Abs(p.EndTime.TotalMilliseconds) < 0.001))
+            {
+                return subtitle;
+            }
+
+            // start-time-only format (e.g. {"milliseconds":1500,"line":"..."})
+            for (var index = 0; index < subtitle.Paragraphs.Count; index++)
+            {
+                var paragraph = subtitle.Paragraphs[index];
+                var next = subtitle.GetParagraphOrDefault(index + 1);
+                if (next != null)
+                {
+                    paragraph.EndTime.TotalMilliseconds = next.StartTime.TotalMilliseconds - Configuration.Settings.General.MinimumMillisecondsBetweenLines;
+                }
+                else
+                {
+                    paragraph.EndTime.TotalMilliseconds = paragraph.StartTime.TotalMilliseconds + Utilities.GetOptimalDisplayMilliseconds(paragraph.Text);
+                }
+            }
+
+            return subtitle;
         }
 
         private static Subtitle FixTimeCodeMsOrSeconds(Subtitle subtitle)
         {
-            if (subtitle == null || subtitle.Paragraphs.Count < 5)
+            if (subtitle == null || subtitle.Paragraphs.Count < 2)
             {
                 return subtitle;
             }
+
+            var msKeys = new[]
+            {
+                "start", "startMs", "start_ms", "startMillis", "start_millis",
+                "startMilliseconds", "start_millisecondsMs", "tStartMs", "milliseconds",
+                "fromMs", "from_ms", "fromms", "fromMillis", "fromMilliseconds", "from_milliseconds", "show"
+            };
 
             double totalDuration = 0;
             var msFound = 0;
             foreach (var p in subtitle.Paragraphs)
             {
                 totalDuration += p.DurationTotalMilliseconds;
-                if (p.Style.Contains("\"start\"") ||
-                    p.Style.Contains("\"startMs\"") ||
-                    p.Style.Contains("\"start_ms\"") ||
-                    p.Style.Contains("\"startMillis\"") ||
-                    p.Style.Contains("\"start_millis\"") ||
-                    p.Style.Contains("\"startMilliseconds\"") ||
-                    p.Style.Contains("\"start_millisecondsMs\"") ||
-                    p.Style.Contains("\"fromMs\"") ||
-                    p.Style.Contains("\"from_ms\"") ||
-                    p.Style.Contains("\"fromms\"") ||
-                    p.Style.Contains("\"fromMillis\"") ||
-                    p.Style.Contains("\"fromMilliseconds\"") ||
-                    p.Style.Contains("\"from_milliseconds\"") ||
-                    p.Style.Contains("\"show\""))
+                if (msKeys.Any(key => ReadKeyValue(p.Style, key, out _) != null))
                 {
                     msFound++;
                 }
             }
 
-            if (totalDuration / subtitle.Paragraphs.Count > 1000000 || msFound == subtitle.Paragraphs.Count)
+            var averageDuration = totalDuration / subtitle.Paragraphs.Count;
+            if (averageDuration > 1000000 || msFound == subtitle.Paragraphs.Count && averageDuration > 100000)
             {
                 // Time codes were read as seconds, but they are actually milliseconds,
                 // so all time codes are divided by 1000.
@@ -143,10 +242,21 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         private static void ReadParagraph(string s, Subtitle subtitle)
         {
-            s = s.Trim();
-            if (s.Length < 7)
+            var fields = ReadFields(s);
+            if (fields?.Start == null || fields.Text == null)
             {
                 return;
+            }
+
+            AddParagraph(subtitle, fields, fields.Text);
+        }
+
+        private static Fields ReadFields(string s)
+        {
+            s = s.Trim();
+            if (s.Length < 5)
+            {
+                return null;
             }
 
             if (!s.EndsWith('}'))
@@ -154,52 +264,73 @@ namespace Nikse.SubtitleEdit.Core.Common
                 s += '}';
             }
 
-            var start = ReadStartTag(s);
-            var end = ReadEndTag(s);
-            var duration = ReadDurationTag(s);
+            var start = NormalizeTime(ReadFirstTimeTag(s, StartTags));
+            var end = NormalizeTime(ReadFirstTimeTag(s, EndTags));
+            var duration = ReadFirstTimeTag(s, DurationTags);
             var text = ReadTextTag(s);
-            var originalStart = start;
-
-            if (start != null && start.Contains(":") && start.Length >= 11 && start.Length <= 12 && start.Split(new[] { ':', ',', '.' }, StringSplitOptions.RemoveEmptyEntries).Length == 4)
+            if (start == null && end == null && duration == null && text == null)
             {
-                start = DecodeFormatToSeconds(start);
-            }
-            else if (start != null && start.Contains(":") && start.Length == 8 && start.Split(new[] { ':', ',', '.' }, StringSplitOptions.RemoveEmptyEntries).Length == 3)
-            {
-                start = DecodeFormatHourMinuteSecondsToSeconds(start);
+                return null;
             }
 
-            if (end != null && end.Contains(":") && end.Length >= 11 && end.Length <= 12 && end.Split(new[] { ':', ',', '.' }, StringSplitOptions.RemoveEmptyEntries).Length == 4)
+            return new Fields { Start = start, End = end, Duration = duration, Text = text, Source = s };
+        }
+
+        private static void AddParagraph(Subtitle subtitle, Fields times, string text)
+        {
+            var start = times.Start?.TrimEnd('s');
+            var end = times.End?.TrimEnd('s');
+            var duration = times.Duration?.TrimEnd('s');
+
+            if (start == null)
             {
-                end = DecodeFormatToSeconds(end);
-            }
-            else if (end != null && end.Contains(":") && end.Length == 8 && end.Split(new[] { ':', ',', '.' }, StringSplitOptions.RemoveEmptyEntries).Length == 3)
-            {
-                end = DecodeFormatHourMinuteSecondsToSeconds(end);
+                return;
             }
 
-            if (start != null && end != null && text != null)
+            if (!double.TryParse(start, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var startSeconds))
             {
-                start = start.TrimEnd('s');
-                end = end.TrimEnd('s');
-                if (double.TryParse(start, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var startSeconds) &&
-                    double.TryParse(end, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var endSeconds))
-                {
-                    var p = new Paragraph(Json.DecodeJsonText(text), startSeconds * TimeCode.BaseUnit, endSeconds * TimeCode.BaseUnit) { Extra = originalStart, Style = s };
-                    subtitle.Paragraphs.Add(p);
-                }
+                return;
             }
-            else if (start != null && duration != null && text != null)
+
+            if (end != null &&
+                double.TryParse(end, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var endSeconds))
             {
-                start = start.TrimEnd('s');
-                duration = duration.TrimEnd('s');
-                if (double.TryParse(start, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out double startSeconds) &&
-                    double.TryParse(duration, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out double durationSeconds))
-                {
-                    var p = new Paragraph(Json.DecodeJsonText(text), startSeconds * TimeCode.BaseUnit, (startSeconds + durationSeconds) * TimeCode.BaseUnit) { Extra = originalStart, Style = s };
-                    subtitle.Paragraphs.Add(p);
-                }
+                subtitle.Paragraphs.Add(new Paragraph(Json.DecodeJsonText(text), startSeconds * TimeCode.BaseUnit, endSeconds * TimeCode.BaseUnit) { Extra = times.Start, Style = times.Source });
+                return;
             }
+
+            if (duration != null &&
+                double.TryParse(duration, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var durationSeconds))
+            {
+                subtitle.Paragraphs.Add(new Paragraph(Json.DecodeJsonText(text), startSeconds * TimeCode.BaseUnit, (startSeconds + durationSeconds) * TimeCode.BaseUnit) { Extra = times.Start, Style = times.Source });
+                return;
+            }
+
+            if (end == null && duration == null)
+            {
+                // start-time-only - end times are computed at the end of the import
+                subtitle.Paragraphs.Add(new Paragraph(Json.DecodeJsonText(text), startSeconds * TimeCode.BaseUnit, 0) { Extra = times.Start, Style = times.Source });
+            }
+        }
+
+        private static string NormalizeTime(string value)
+        {
+            if (value == null)
+            {
+                return null;
+            }
+
+            if (value.Contains(":") && value.Length >= 11 && value.Length <= 12 && value.Split(new[] { ':', ',', '.' }, StringSplitOptions.RemoveEmptyEntries).Length == 4)
+            {
+                return DecodeFormatToSeconds(value);
+            }
+
+            if (value.Contains(":") && value.Length == 8 && value.Split(new[] { ':', ',', '.' }, StringSplitOptions.RemoveEmptyEntries).Length == 3)
+            {
+                return DecodeFormatHourMinuteSecondsToSeconds(value);
+            }
+
+            return value;
         }
 
         private static string DecodeFormatToSeconds(string s)
@@ -213,140 +344,245 @@ namespace Nikse.SubtitleEdit.Core.Common
             return DecodeFormatToSeconds(s + ":00");
         }
 
-        private static string ReadStartTag(string s)
-        {
-            return ReadFirstMultiTag(s, new[]
-            {
-                "start", "in", "begin",
-                "startTime", "start_time", "starttime",
-                "startMillis", "start_Millis", "startmillis",
-                "startMs", "start_ms", "startms",
-                "startMilliseconds", "start_Millisesonds", "startmilliseconds",
-                "from", "fromTime", "from_ms","fromms", "fromMilliseconds", "from_milliseconds", "show"
-            });
-        }
-
-        private static string ReadEndTag(string s)
-        {
-            return ReadFirstMultiTag(s, new[]
-            {
-                "end", "out", "stop",
-                "endTime", "end_time", "endtime",
-                "endMillis", "end_Millis", "endmillis",
-                "endMs", "end_ms", "endms",
-                "endMilliseconds", "end_Millisesonds", "endmilliseconds",
-                "to", "toTime", "to_ms", "toms", "toMilliseconds", "to_milliseconds", "hide"
-            });
-        }
-
-        private static string ReadDurationTag(string s)
-        {
-            return ReadFirstMultiTag(s, new[]
-            {
-                "duration",
-                "durationMs",
-                "dur",
-            });
-        }
-
-        private static string ReadTextTag(string s)
-        {
-            var idx = s.IndexOf("\"text", StringComparison.OrdinalIgnoreCase);
-            if (idx < 0)
-            {
-                idx = s.IndexOf("\"content", StringComparison.OrdinalIgnoreCase);
-            }
-            if (idx < 0)
-            {
-                idx = s.IndexOf("\"value", StringComparison.OrdinalIgnoreCase);
-            }
-            if (idx < 0)
-            {
-                idx = s.IndexOf("\"caption", StringComparison.OrdinalIgnoreCase);
-            }
-            if (idx < 0)
-            {
-                idx = s.IndexOf("\"sentence", StringComparison.OrdinalIgnoreCase);
-            }
-
-            if (idx < 0)
-            {
-                return null;
-            }
-
-            s = s.Substring(idx);
-            idx = s.IndexOf(']');
-            if (idx > 0)
-            {
-                s = s.Substring(0, idx + 1);
-            }
-
-            var text = Json.ReadTag(s, "text");
-            if (text == null)
-            {
-                text = Json.ReadTag(s, "content");
-            }
-            if (text == null)
-            {
-                text = Json.ReadTag(s, "value");
-            }
-            if (text == null)
-            {
-                text = Json.ReadTag(s, "caption");
-            }
-            if (text == null)
-            {
-                text = Json.ReadTag(s, "sentence");
-            }
-            if (text == null)
-            {
-                text = Json.ReadTag(s, "dialog");
-            }
-
-            if (text != null)
-            {
-                text = Json.DecodeJsonText(text);
-            }
-
-            var textLines = Json.ReadArray(s, "text");
-            if (textLines == null || textLines.Count == 0)
-            {
-                textLines = Json.ReadArray(s, "content");
-            }
-
-            var isArray = s.Contains("[");
-            if (isArray && textLines.Any(p => p == "end_time" || p == "endTime" || p == "end" || p == "endMs" || p == "endMilliseconds" || p == "end_ms" || p == "endms" || p == "to" || p == "to_ms" || p == "toms" || p == "from" || p == "from_ms" || p == "hide"))
-            {
-                isArray = false;
-            }
-
-            if (!isArray && !string.IsNullOrEmpty(text))
-            {
-                return text
-                    .Replace("&#039;", "'")
-                    .Replace("<br />", Environment.NewLine)
-                    .Replace("<br \\/>", Environment.NewLine)
-                    ;
-            }
-
-            if (textLines != null && textLines.Count > 0)
-            {
-                return string.Join(Environment.NewLine, textLines);
-            }
-
-            return ReadFirstMultiTag(s, new[] { "text", "content" });
-        }
-
-        private static string ReadFirstMultiTag(string s, string[] tags)
+        private static string ReadFirstTimeTag(string s, string[] tags)
         {
             foreach (var tag in tags)
             {
-                var res = Json.ReadTag(s, tag);
-                if (!string.IsNullOrEmpty(res))
+                var res = ReadKeyValue(s, tag, out var isStringValue);
+                if (!string.IsNullOrEmpty(res) && IsTimeLikeValue(res))
                 {
                     return res;
                 }
             }
+
+            return null;
+        }
+
+        private static bool IsTimeLikeValue(string value)
+        {
+            var v = value.Trim().TrimEnd('s');
+            if (v.Length == 0 || v.Length > 20)
+            {
+                return false;
+            }
+
+            var hasDigit = false;
+            foreach (var ch in v)
+            {
+                if (char.IsDigit(ch))
+                {
+                    hasDigit = true;
+                }
+                else if (ch != ':' && ch != '.' && ch != ',' && ch != ';' && ch != '-')
+                {
+                    return false;
+                }
+            }
+
+            return hasDigit;
+        }
+
+        /// <summary>
+        /// Reads a key whose value is an array of strings; null when the key is missing,
+        /// the value is not an array, or the array holds anything but strings.
+        /// </summary>
+        private static List<string> ReadStringArrayValue(string s, string tag)
+        {
+            var from = 0;
+            while (from < s.Length)
+            {
+                var idx = s.IndexOf("\"" + tag + "\"", from, StringComparison.OrdinalIgnoreCase);
+                if (idx < 0)
+                {
+                    return null;
+                }
+
+                var i = idx + tag.Length + 2;
+                while (i < s.Length && char.IsWhiteSpace(s[i]))
+                {
+                    i++;
+                }
+
+                if (i >= s.Length || s[i] != ':')
+                {
+                    from = idx + 1;
+                    continue;
+                }
+
+                i++;
+                while (i < s.Length && char.IsWhiteSpace(s[i]))
+                {
+                    i++;
+                }
+
+                if (i >= s.Length || s[i] != '[')
+                {
+                    return null;
+                }
+
+                i++;
+                var list = new List<string>();
+                while (i < s.Length)
+                {
+                    while (i < s.Length && (char.IsWhiteSpace(s[i]) || s[i] == ','))
+                    {
+                        i++;
+                    }
+
+                    if (i >= s.Length)
+                    {
+                        return null; // unterminated
+                    }
+
+                    if (s[i] == ']')
+                    {
+                        return list;
+                    }
+
+                    if (s[i] != '"')
+                    {
+                        return null; // not an array of strings
+                    }
+
+                    i++;
+                    var sb = new StringBuilder();
+                    while (i < s.Length && s[i] != '"')
+                    {
+                        if (s[i] == '\\' && i + 1 < s.Length)
+                        {
+                            sb.Append(s[i]);
+                            sb.Append(s[i + 1]);
+                            i += 2;
+                            continue;
+                        }
+
+                        sb.Append(s[i]);
+                        i++;
+                    }
+
+                    if (i >= s.Length)
+                    {
+                        return null;
+                    }
+
+                    i++; // closing quote
+                    list.Add(sb.ToString());
+                }
+
+                return null;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Reads the value of a json key. Unlike a plain IndexOf, the tag must actually be in
+        /// key position (followed by a colon) - otherwise string VALUES that happen to match a
+        /// tag name hijack the lookup (e.g. "lineAlign":"start" matching the tag "start").
+        /// </summary>
+        private static string ReadKeyValue(string s, string tag, out bool isStringValue)
+        {
+            isStringValue = false;
+            var from = 0;
+            while (from < s.Length)
+            {
+                var idx = s.IndexOf("\"" + tag + "\"", from, StringComparison.OrdinalIgnoreCase);
+                if (idx < 0)
+                {
+                    return null;
+                }
+
+                var i = idx + tag.Length + 2;
+                while (i < s.Length && char.IsWhiteSpace(s[i]))
+                {
+                    i++;
+                }
+
+                if (i >= s.Length || s[i] != ':')
+                {
+                    from = idx + 1;
+                    continue;
+                }
+
+                i++;
+                while (i < s.Length && char.IsWhiteSpace(s[i]))
+                {
+                    i++;
+                }
+
+                if (i >= s.Length)
+                {
+                    return null;
+                }
+
+                if (s[i] == '"')
+                {
+                    isStringValue = true;
+                    var sb = new StringBuilder();
+                    i++;
+                    while (i < s.Length)
+                    {
+                        var ch = s[i];
+                        if (ch == '\\' && i + 1 < s.Length)
+                        {
+                            sb.Append(ch);
+                            sb.Append(s[i + 1]);
+                            i += 2;
+                            continue;
+                        }
+
+                        if (ch == '"')
+                        {
+                            break;
+                        }
+
+                        sb.Append(ch);
+                        i++;
+                    }
+
+                    return sb.ToString();
+                }
+
+                var end = i;
+                while (end < s.Length && s[end] != ',' && s[end] != '}' && s[end] != ']')
+                {
+                    end++;
+                }
+
+                return s.Substring(i, end - i).Trim();
+            }
+
+            return null;
+        }
+
+        private static string ReadTextTag(string s)
+        {
+            // text as an array of lines, e.g. "text": ["line 1", "line 2"]
+            foreach (var arrayTag in new[] { "text", "content", "lines" })
+            {
+                var textLines = ReadStringArrayValue(s, arrayTag);
+                if (textLines != null && textLines.Count > 0)
+                {
+                    var joined = string.Join(Environment.NewLine, textLines.Where(p => !string.IsNullOrEmpty(p)));
+                    if (!string.IsNullOrWhiteSpace(joined))
+                    {
+                        return joined;
+                    }
+                }
+            }
+
+            foreach (var tag in TextTags)
+            {
+                var res = ReadKeyValue(s, tag, out var isStringValue);
+                if (isStringValue && !string.IsNullOrEmpty(res))
+                {
+                    return res
+                        .Replace("&#039;", "'")
+                        .Replace("<br />", Environment.NewLine)
+                        .Replace("<br \\/>", Environment.NewLine);
+                }
+            }
+
             return null;
         }
     }

--- a/src/libse/Common/UnknownFormatImporterXml.cs
+++ b/src/libse/Common/UnknownFormatImporterXml.cs
@@ -1,0 +1,592 @@
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Xml;
+
+namespace Nikse.SubtitleEdit.Core.Common
+{
+    /// <summary>
+    /// Generic importer for unknown XML subtitle dialects: finds the repeated element that
+    /// carries time codes (as attributes or child elements) plus text, without knowing the
+    /// schema. Handles TTML-like ("begin"/"end" attributes with inline text), wrapper
+    /// elements with a text child (D-Cinema like), child-element time codes (Matroska
+    /// chapters like), time codes on an empty child element, text in an attribute, and
+    /// start-only samples where an empty element closes the previous one (GPAC TTXT like).
+    /// </summary>
+    public class UnknownFormatImporterXml
+    {
+        private class Candidate
+        {
+            public double StartMs { get; set; }
+            public double? EndMs { get; set; }
+            public double? DurationMs { get; set; }
+            public string Text { get; set; }
+        }
+
+        private bool _use250TickTimeCodes;
+
+        public Subtitle AutoGuessImport(List<string> lines)
+        {
+            var allText = string.Join(Environment.NewLine, lines).Trim().TrimStart('﻿').TrimStart();
+            if (!allText.StartsWith('<') || !allText.EndsWith('>'))
+            {
+                return new Subtitle();
+            }
+
+            var doc = new XmlDocument { XmlResolver = null };
+            try
+            {
+                var settings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, XmlResolver = null };
+                using (var stringReader = new System.IO.StringReader(allText))
+                using (var reader = XmlReader.Create(stringReader, settings))
+                {
+                    doc.Load(reader);
+                }
+            }
+            catch
+            {
+                return new Subtitle();
+            }
+
+            if (doc.DocumentElement == null)
+            {
+                return new Subtitle();
+            }
+
+            // D-Cinema interop writes the last time code part in 250ths of a second ("editable units")
+            _use250TickTimeCodes = doc.DocumentElement.Name == "DCSubtitle";
+
+            // group candidates per element name - the subtitle element is the name that
+            // repeats with time codes, everything else (styles, regions, metadata) won't
+            var candidatesByName = new Dictionary<string, List<Candidate>>();
+            Walk(doc.DocumentElement, candidatesByName);
+
+            List<Candidate> best = null;
+            var bestScore = 0;
+            var bestTextCount = 0;
+            foreach (var kvp in candidatesByName)
+            {
+                var textCount = kvp.Value.Count(c => !string.IsNullOrWhiteSpace(c.Text));
+                // a group that also knows when subtitles end beats one with bare start times
+                // (e.g. a layout/config element with an index that parses as a time)
+                var score = textCount * 2 + kvp.Value.Count(c => c.EndMs.HasValue || c.DurationMs.HasValue);
+                if (score > bestScore)
+                {
+                    bestScore = score;
+                    bestTextCount = textCount;
+                    best = kvp.Value;
+                }
+            }
+
+            if (best == null || bestTextCount < 2)
+            {
+                return new Subtitle();
+            }
+
+            return MakeSubtitle(best);
+        }
+
+        private static Subtitle MakeSubtitle(List<Candidate> candidates)
+        {
+            var subtitle = new Subtitle();
+            Paragraph last = null;
+            foreach (var c in candidates)
+            {
+                var end = c.EndMs ?? (c.DurationMs.HasValue ? c.StartMs + c.DurationMs.Value : 0);
+                if (string.IsNullOrWhiteSpace(c.Text))
+                {
+                    // start-only sample with no text: it closes the previous paragraph
+                    if (last != null && !c.EndMs.HasValue && !c.DurationMs.HasValue &&
+                        Math.Abs(last.EndTime.TotalMilliseconds) < 0.01 && c.StartMs > last.StartTime.TotalMilliseconds)
+                    {
+                        last.EndTime.TotalMilliseconds = c.StartMs;
+                    }
+
+                    continue;
+                }
+
+                var p = new Paragraph(c.Text.Trim(), c.StartMs, end);
+                subtitle.Paragraphs.Add(p);
+                last = p;
+            }
+
+            // fill in missing end times
+            for (var i = 0; i < subtitle.Paragraphs.Count; i++)
+            {
+                var p = subtitle.Paragraphs[i];
+                if (Math.Abs(p.EndTime.TotalMilliseconds) > 0.01)
+                {
+                    continue;
+                }
+
+                var optimalDurationMs = Utilities.GetOptimalDisplayMilliseconds(p.Text);
+                var next = subtitle.GetParagraphOrDefault(i + 1);
+                if (next != null && next.StartTime.TotalMilliseconds < p.StartTime.TotalMilliseconds + optimalDurationMs + 2000)
+                {
+                    p.EndTime.TotalMilliseconds = next.StartTime.TotalMilliseconds - Configuration.Settings.General.MinimumMillisecondsBetweenLines;
+                }
+                else
+                {
+                    p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + optimalDurationMs;
+                }
+            }
+
+            subtitle.Renumber();
+            return subtitle;
+        }
+
+        private void Walk(XmlElement element, Dictionary<string, List<Candidate>> candidatesByName)
+        {
+            var candidate = TryGetCandidate(element);
+            if (candidate != null)
+            {
+                if (!candidatesByName.TryGetValue(element.LocalName, out var list))
+                {
+                    list = new List<Candidate>();
+                    candidatesByName.Add(element.LocalName, list);
+                }
+
+                list.Add(candidate);
+            }
+
+            foreach (XmlNode child in element.ChildNodes)
+            {
+                if (child is XmlElement childElement)
+                {
+                    Walk(childElement, candidatesByName);
+                }
+            }
+        }
+
+        private Candidate TryGetCandidate(XmlElement element)
+        {
+            double? start = null;
+            double? end = null;
+            double? duration = null;
+            var timeChildNames = new List<string>();
+
+            foreach (XmlAttribute attribute in element.Attributes)
+            {
+                ReadTimeField(attribute.LocalName, attribute.Value, ref start, ref end, ref duration);
+            }
+
+            foreach (XmlNode child in element.ChildNodes)
+            {
+                if (!(child is XmlElement el))
+                {
+                    continue;
+                }
+
+                var before = (start, end, duration);
+
+                // simple child element whose value is a time code, e.g. <ChapterTimeStart>00:00:01.500</ChapterTimeStart>
+                if (!el.HasChildNodes || el.ChildNodes.Count == 1 && el.FirstChild is XmlText)
+                {
+                    ReadTimeField(el.LocalName, el.InnerText, ref start, ref end, ref duration);
+                }
+
+                // empty child element carrying the time codes as attributes, e.g. <time start="..." end="..." />
+                if (el.Attributes.Count > 0 && !el.HasChildNodes)
+                {
+                    foreach (XmlAttribute attribute in el.Attributes)
+                    {
+                        ReadTimeField(attribute.LocalName, attribute.Value, ref start, ref end, ref duration);
+                    }
+                }
+
+                if (before != (start, end, duration))
+                {
+                    timeChildNames.Add(el.LocalName);
+                }
+            }
+
+            if (!start.HasValue)
+            {
+                return null;
+            }
+
+            var text = GetText(element, timeChildNames);
+            if (string.IsNullOrWhiteSpace(text) && !end.HasValue && !duration.HasValue)
+            {
+                // keep as an end marker only when it's a completely empty element
+                // (GPAC TTXT like) - a start-time-only element with non-time children
+                // is a container we shouldn't consume
+                if (element.ChildNodes.Count > 0)
+                {
+                    return null;
+                }
+            }
+
+            return new Candidate { StartMs = start.Value, EndMs = end, DurationMs = duration, Text = text };
+        }
+
+        private void ReadTimeField(string name, string value, ref double? start, ref double? end, ref double? duration)
+        {
+            var kind = ClassifyTimeName(name);
+            if (kind == 0)
+            {
+                return;
+            }
+
+            var ms = TryParseTime(value, _use250TickTimeCodes);
+            if (!ms.HasValue)
+            {
+                return;
+            }
+
+            if (kind == 1 && !start.HasValue)
+            {
+                start = ms;
+            }
+            else if (kind == 2 && !end.HasValue)
+            {
+                end = ms;
+            }
+            else if (kind == 3 && !duration.HasValue)
+            {
+                duration = ms;
+            }
+        }
+
+        /// <returns>0 = not a time name, 1 = start, 2 = end, 3 = duration</returns>
+        private static int ClassifyTimeName(string rawName)
+        {
+            var name = Normalize(rawName);
+            if (name.Length == 0)
+            {
+                return 0;
+            }
+
+            if (name == "d" || name.Contains("dur", StringComparison.Ordinal))
+            {
+                return 3;
+            }
+
+            if (name == "out" ||
+                name == "to" ||
+                name == "hide" ||
+                name == "et" ||
+                name == "secout" ||
+                name == "clear" ||
+                name.Contains("end", StringComparison.Ordinal) ||
+                name.Contains("stop", StringComparison.Ordinal) ||
+                name.Contains("timeout", StringComparison.Ordinal) ||
+                name.Contains("tcout", StringComparison.Ordinal))
+            {
+                return 2;
+            }
+
+            if (name == "in" ||
+                name == "from" ||
+                name == "show" ||
+                name == "time" ||
+                name == "timestamp" ||
+                name == "offset" ||
+                name == "t" ||
+                name == "st" ||
+                name == "secin" ||
+                name == "display" ||
+                name == "position" ||
+                name == "value" ||
+                name.Contains("start", StringComparison.Ordinal) ||
+                name.Contains("begin", StringComparison.Ordinal) ||
+                name.Contains("timein", StringComparison.Ordinal) ||
+                name.Contains("tcin", StringComparison.Ordinal) ||
+                name.Contains("sampletime", StringComparison.Ordinal))
+            {
+                return 1;
+            }
+
+            return 0;
+        }
+
+        private static string Normalize(string name)
+        {
+            var sb = new StringBuilder(name.Length);
+            foreach (var ch in name)
+            {
+                if (char.IsLetterOrDigit(ch))
+                {
+                    sb.Append(char.ToLowerInvariant(ch));
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        internal static double? TryParseTime(string input, bool use250TickTimeCodes = false)
+        {
+            if (string.IsNullOrWhiteSpace(input))
+            {
+                return null;
+            }
+
+            var s = input.Trim();
+            if (s.Length > 30 || s.Contains('%'))
+            {
+                return null;
+            }
+
+            // rational seconds, e.g. "3003/24000s" (Final Cut like)
+            if (s.EndsWith('s') && s.Contains('/'))
+            {
+                var arr = s.TrimEnd('s').Split('/');
+                if (arr.Length == 2 &&
+                    double.TryParse(arr[0], NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var numerator) &&
+                    double.TryParse(arr[1], NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var denominator) &&
+                    denominator > 0)
+                {
+                    return numerator / denominator * TimeCode.BaseUnit;
+                }
+
+                return null;
+            }
+
+            // TTML ticks, e.g. "15000000t" (default tick rate is 10,000,000/s)
+            if (s.EndsWith('t') && long.TryParse(s.TrimEnd('t'), NumberStyles.None, CultureInfo.InvariantCulture, out var ticks))
+            {
+                return ticks / 10000.0;
+            }
+
+            // "150ms"
+            if (s.EndsWith("ms", StringComparison.Ordinal) &&
+                double.TryParse(s.Remove(s.Length - 2), NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var milliseconds))
+            {
+                return milliseconds;
+            }
+
+            // seconds with unit, e.g. "1.5s"
+            if (s.EndsWith('s') &&
+                double.TryParse(s.TrimEnd('s'), NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var seconds))
+            {
+                return seconds * TimeCode.BaseUnit;
+            }
+
+            if (s.Contains(':'))
+            {
+                var parts = s.Split(':', '.', ',', ';');
+                if (parts.Length < 2 || parts.Length > 4 || parts.Any(p => p.Length == 0 || p.Length > 9 || !p.All(char.IsDigit)))
+                {
+                    return null;
+                }
+
+                if (parts.Length == 2)
+                {
+                    // MM:SS
+                    var m = int.Parse(parts[0]);
+                    var sec = int.Parse(parts[1]);
+                    if (sec >= 60)
+                    {
+                        return null;
+                    }
+
+                    return (m * 60 + sec) * TimeCode.BaseUnit;
+                }
+
+                int hours;
+                int minutes;
+                int secs;
+                string last;
+                if (parts.Length == 3)
+                {
+                    if (s.Contains('.') || s.Contains(','))
+                    {
+                        // MM:SS.mmm
+                        hours = 0;
+                        minutes = int.Parse(parts[0]);
+                        secs = int.Parse(parts[1]);
+                        last = parts[2];
+                    }
+                    else
+                    {
+                        // HH:MM:SS
+                        hours = int.Parse(parts[0]);
+                        minutes = int.Parse(parts[1]);
+                        secs = int.Parse(parts[2]);
+                        if (minutes >= 60 || secs >= 60 || hours > 99)
+                        {
+                            return null;
+                        }
+
+                        return new TimeCode(hours, minutes, secs, 0).TotalMilliseconds;
+                    }
+                }
+                else
+                {
+                    hours = int.Parse(parts[0]);
+                    minutes = int.Parse(parts[1]);
+                    secs = int.Parse(parts[2]);
+                    last = parts[3];
+                }
+
+                if (minutes >= 60 || secs >= 60 || hours > 99)
+                {
+                    return null;
+                }
+
+                double lastMs;
+                if (last.Length <= 3 && use250TickTimeCodes)
+                {
+                    // D-Cinema interop: last part is in 4 ms units
+                    lastMs = int.Parse(last) * 4;
+                }
+                else if (last.Length == 2 && !s.Contains('.') && !s.Contains(','))
+                {
+                    // HH:MM:SS:FF
+                    lastMs = SubtitleFormat.FramesToMillisecondsMax999(int.Parse(last));
+                }
+                else
+                {
+                    // fraction of a second - "5", "50", "500", "500000000" all mean the same lead digits
+                    lastMs = double.Parse("0." + last, CultureInfo.InvariantCulture) * TimeCode.BaseUnit;
+                }
+
+                return new TimeCode(hours, minutes, secs, 0).TotalMilliseconds + lastMs;
+            }
+
+            // plain number: integers are milliseconds, decimals are seconds
+            if (double.TryParse(s, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var number))
+            {
+                if (s.Contains('.'))
+                {
+                    return number * TimeCode.BaseUnit;
+                }
+
+                return number;
+            }
+
+            return null;
+        }
+
+        private static readonly string[] TextElementNames = { "text", "string", "content", "caption", "dialog", "dialogue", "sentence", "line", "sub" };
+        private static readonly string[] WeakTextElementNames = { "comment", "name", "label" };
+
+        private static string GetText(XmlElement element, List<string> timeChildNames)
+        {
+            // inline text (TTML like) - text nodes plus inline markup like <br/> and <span>
+            var sb = new StringBuilder();
+            AppendInlineText(element, sb);
+            var text = sb.ToString().Trim();
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                return text;
+            }
+
+            // named text descendants (D-Cinema "Text", Matroska "ChapterString", ...) -
+            // multi-line subtitles repeat the element, so join all of them
+            var textElements = new List<XmlElement>();
+            FindTextElements(element, timeChildNames, TextElementNames, textElements);
+            if (textElements.Count == 0)
+            {
+                FindTextElements(element, timeChildNames, WeakTextElementNames, textElements);
+            }
+
+            if (textElements.Count > 0)
+            {
+                sb.Clear();
+                foreach (var textElement in textElements)
+                {
+                    var lineSb = new StringBuilder();
+                    AppendInlineText(textElement, lineSb);
+                    var line = lineSb.ToString().Trim();
+                    if (string.IsNullOrWhiteSpace(line))
+                    {
+                        // text wrapped in unknown markup (styling runs etc.)
+                        line = textElement.InnerText.Trim();
+                    }
+
+                    if (line.Length > 0)
+                    {
+                        if (sb.Length > 0)
+                        {
+                            sb.AppendLine();
+                        }
+
+                        sb.Append(line);
+                    }
+                }
+
+                text = sb.ToString().Trim();
+                if (!string.IsNullOrWhiteSpace(text))
+                {
+                    return text;
+                }
+            }
+
+            // text in an attribute, e.g. <Clip start="1.5" end="4.3" text="..." />
+            foreach (XmlAttribute attribute in element.Attributes)
+            {
+                var name = Normalize(attribute.LocalName);
+                foreach (var textName in TextElementNames)
+                {
+                    if (name.Contains(textName, StringComparison.Ordinal) && !string.IsNullOrWhiteSpace(attribute.Value))
+                    {
+                        return attribute.Value.Trim();
+                    }
+                }
+            }
+
+            return string.Empty;
+        }
+
+        private static void AppendInlineText(XmlElement element, StringBuilder sb)
+        {
+            foreach (XmlNode child in element.ChildNodes)
+            {
+                if (child is XmlText || child is XmlCDataSection || child is XmlWhitespace || child is XmlSignificantWhitespace)
+                {
+                    sb.Append(child.Value);
+                }
+                else if (child is XmlElement childElement)
+                {
+                    if (childElement.Name.Equals("br", StringComparison.OrdinalIgnoreCase))
+                    {
+                        sb.AppendLine();
+                    }
+                    else if (childElement.LocalName.Equals("span", StringComparison.OrdinalIgnoreCase) ||
+                             childElement.LocalName.Equals("font", StringComparison.OrdinalIgnoreCase) ||
+                             childElement.LocalName.Equals("i", StringComparison.OrdinalIgnoreCase) ||
+                             childElement.LocalName.Equals("b", StringComparison.OrdinalIgnoreCase) ||
+                             childElement.LocalName.Equals("u", StringComparison.OrdinalIgnoreCase))
+                    {
+                        AppendInlineText(childElement, sb);
+                    }
+                }
+            }
+        }
+
+        private static void FindTextElements(XmlElement element, List<string> timeChildNames, string[] textNames, List<XmlElement> result)
+        {
+            foreach (XmlNode child in element.ChildNodes)
+            {
+                if (!(child is XmlElement childElement) || timeChildNames.Contains(childElement.LocalName))
+                {
+                    continue;
+                }
+
+                var name = Normalize(childElement.LocalName);
+                var isTextElement = false;
+                foreach (var textName in textNames)
+                {
+                    if (name.Contains(textName, StringComparison.Ordinal))
+                    {
+                        isTextElement = true;
+                        break;
+                    }
+                }
+
+                if (isTextElement)
+                {
+                    result.Add(childElement);
+                }
+                else
+                {
+                    FindTextElements(childElement, timeChildNames, textNames, result);
+                }
+            }
+        }
+    }
+}

--- a/tests/libse/Common/UnknownFormatImporterTest.cs
+++ b/tests/libse/Common/UnknownFormatImporterTest.cs
@@ -45,6 +45,199 @@ public class UnknownFormatImporterTest
     }
 
     [Fact]
+    public void AutoGuessImportParsesXmlWithSecondsAttributes()
+    {
+        // TTML-like dialect with seconds-with-unit attributes and inline text
+        var importer = new UnknownFormatImporter();
+        var lines = new List<string>
+        {
+            "<tt><body><div>",
+            "<p begin=\"1.5s\" end=\"4.3s\">Hello there.</p>",
+            "<p begin=\"5.5s\" end=\"8.3s\">How are <span>you</span>?</p>",
+            "<p begin=\"9.5s\" end=\"12.3s\">Line one<br/>line two.</p>",
+            "</div></body></tt>",
+        };
+
+        var subtitle = importer.AutoGuessImport(lines, "test.xml");
+
+        Assert.Equal(3, subtitle.Paragraphs.Count);
+        Assert.Equal(1500, subtitle.Paragraphs[0].StartTime.TotalMilliseconds, 3);
+        Assert.Equal(4300, subtitle.Paragraphs[0].EndTime.TotalMilliseconds, 3);
+        Assert.Equal("Hello there.", subtitle.Paragraphs[0].Text);
+        Assert.Equal("How are you?", subtitle.Paragraphs[1].Text);
+        Assert.Equal("Line one" + Environment.NewLine + "line two.", subtitle.Paragraphs[2].Text);
+    }
+
+    [Fact]
+    public void AutoGuessImportParsesXmlWithTimeCodeChildElementsAndNestedText()
+    {
+        // Matroska-chapters-like dialect: time codes and text in (nested) child elements
+        var importer = new UnknownFormatImporter();
+        var lines = new List<string>
+        {
+            "<Chapters><EditionEntry>",
+            "<ChapterAtom><ChapterUID>1</ChapterUID><ChapterTimeStart>00:00:01.500</ChapterTimeStart><ChapterDisplay><ChapterString>First chapter</ChapterString></ChapterDisplay></ChapterAtom>",
+            "<ChapterAtom><ChapterUID>2</ChapterUID><ChapterTimeStart>00:00:05.500</ChapterTimeStart><ChapterDisplay><ChapterString>Second chapter</ChapterString></ChapterDisplay></ChapterAtom>",
+            "</EditionEntry></Chapters>",
+        };
+
+        var subtitle = importer.AutoGuessImport(lines, "test.xml");
+
+        Assert.Equal(2, subtitle.Paragraphs.Count);
+        Assert.Equal(1500, subtitle.Paragraphs[0].StartTime.TotalMilliseconds, 3);
+        Assert.Equal("First chapter", subtitle.Paragraphs[0].Text);
+        Assert.Equal("Second chapter", subtitle.Paragraphs[1].Text);
+    }
+
+    [Fact]
+    public void AutoGuessImportParsesXmlWithTimeChildAttributesAndTextSibling()
+    {
+        var importer = new UnknownFormatImporter();
+        var lines = new List<string>
+        {
+            "<titles>",
+            "<title id=\"1\"><time start=\"00:00:01,500\" end=\"00:00:04,300\" /><text1>Hello there.</text1></title>",
+            "<title id=\"2\"><time start=\"00:00:05,500\" end=\"00:00:08,300\" /><text1>How are you?</text1></title>",
+            "</titles>",
+        };
+
+        var subtitle = importer.AutoGuessImport(lines, "test.xml");
+
+        Assert.Equal(2, subtitle.Paragraphs.Count);
+        Assert.Equal(1500, subtitle.Paragraphs[0].StartTime.TotalMilliseconds, 3);
+        Assert.Equal(4300, subtitle.Paragraphs[0].EndTime.TotalMilliseconds, 3);
+        Assert.Equal("Hello there.", subtitle.Paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void AutoGuessImportParsesXmlWithStartOnlySamplesAndEmptyEndMarkers()
+    {
+        // GPAC TTXT-like dialect: an empty sample closes the previous one
+        var importer = new UnknownFormatImporter();
+        var lines = new List<string>
+        {
+            "<TextStream>",
+            "<TextSample sampleTime=\"00:00:01.500\">Hello there.</TextSample>",
+            "<TextSample sampleTime=\"00:00:04.300\" />",
+            "<TextSample sampleTime=\"00:00:05.500\">How are you?</TextSample>",
+            "<TextSample sampleTime=\"00:00:08.300\" />",
+            "</TextStream>",
+        };
+
+        var subtitle = importer.AutoGuessImport(lines, "test.xml");
+
+        Assert.Equal(2, subtitle.Paragraphs.Count);
+        Assert.Equal(1500, subtitle.Paragraphs[0].StartTime.TotalMilliseconds, 3);
+        Assert.Equal(4300, subtitle.Paragraphs[0].EndTime.TotalMilliseconds, 3);
+        Assert.Equal(5500, subtitle.Paragraphs[1].StartTime.TotalMilliseconds, 3);
+        Assert.Equal(8300, subtitle.Paragraphs[1].EndTime.TotalMilliseconds, 3);
+    }
+
+    [Fact]
+    public void AutoGuessImportParsesXmlWithTextInAttribute()
+    {
+        var importer = new UnknownFormatImporter();
+        var lines = new List<string>
+        {
+            "<Subtitle>",
+            "<Clip start=\"1.5\" end=\"4.3\" text=\"Hello there.\" />",
+            "<Clip start=\"5.5\" end=\"8.3\" text=\"How are you?\" />",
+            "</Subtitle>",
+        };
+
+        var subtitle = importer.AutoGuessImport(lines, "test.xml");
+
+        Assert.Equal(2, subtitle.Paragraphs.Count);
+        Assert.Equal(1500, subtitle.Paragraphs[0].StartTime.TotalMilliseconds, 3);
+        Assert.Equal("Hello there.", subtitle.Paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void AutoGuessImportIgnoresXmlWithoutTimeCodes()
+    {
+        var importer = new UnknownFormatImporter();
+        var lines = new List<string>
+        {
+            "<configuration>",
+            "<appSettings><add key=\"a\" value=\"b\" /><add key=\"c\" value=\"d\" /></appSettings>",
+            "</configuration>",
+        };
+
+        var subtitle = importer.AutoGuessImport(lines, "test.xml");
+
+        Assert.Empty(subtitle.Paragraphs);
+    }
+
+    [Fact]
+    public void AutoGuessImportJsonIsNotHijackedByValuesMatchingTimeTagNames()
+    {
+        // "lineAlign":"start" must not be read as the start time of the paragraph
+        var importer = new UnknownFormatImporter();
+        var line = "{\"events\":[" +
+                   "{\"startTime\":1.5,\"endTime\":4.3,\"positionAlign\":\"middle\",\"lineAlign\":\"start\",\"text\":\"Hello there.\"}," +
+                   "{\"startTime\":5.5,\"endTime\":8.3,\"positionAlign\":\"middle\",\"lineAlign\":\"start\",\"text\":\"How are you?\"}," +
+                   "{\"startTime\":9.5,\"endTime\":12.3,\"positionAlign\":\"middle\",\"lineAlign\":\"start\",\"text\":\"I am fine.\"}]}";
+
+        var subtitle = importer.AutoGuessImport([line], "test.json");
+
+        Assert.Equal(3, subtitle.Paragraphs.Count);
+        Assert.Equal(1500, subtitle.Paragraphs[0].StartTime.TotalMilliseconds, 3);
+        Assert.Equal(4300, subtitle.Paragraphs[0].EndTime.TotalMilliseconds, 3);
+        Assert.Equal("Hello there.", subtitle.Paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void AutoGuessImportJsonReadsTextFromNestedObject()
+    {
+        // time codes in the outer object, text in a nested one
+        var importer = new UnknownFormatImporter();
+        var line = "[" +
+                   "{\"startTime\":1.5,\"endTime\":4.3,\"metadata\":{\"Text\":\"Hello there.\",\"Language\":\"en\"}}," +
+                   "{\"startTime\":5.5,\"endTime\":8.3,\"metadata\":{\"Text\":\"How are you?\",\"Language\":\"en\"}}," +
+                   "{\"startTime\":9.5,\"endTime\":12.3,\"metadata\":{\"Text\":\"I am fine.\",\"Language\":\"en\"}}]";
+
+        var subtitle = importer.AutoGuessImport([line], "test.json");
+
+        Assert.Equal(3, subtitle.Paragraphs.Count);
+        Assert.Equal(1500, subtitle.Paragraphs[0].StartTime.TotalMilliseconds, 3);
+        Assert.Equal("Hello there.", subtitle.Paragraphs[0].Text);
+        Assert.Equal("How are you?", subtitle.Paragraphs[1].Text);
+    }
+
+    [Fact]
+    public void AutoGuessImportJsonReadsStartTimeOnlyFormat()
+    {
+        var importer = new UnknownFormatImporter();
+        var line = "[" +
+                   "{\"milliseconds\":1500,\"line\":\"Hello there.\"}," +
+                   "{\"milliseconds\":5500,\"line\":\"How are you?\"}," +
+                   "{\"milliseconds\":9500,\"line\":\"I am fine.\"}]";
+
+        var subtitle = importer.AutoGuessImport([line], "test.json");
+
+        Assert.Equal(3, subtitle.Paragraphs.Count);
+        Assert.Equal("Hello there.", subtitle.Paragraphs[0].Text);
+        Assert.True(subtitle.Paragraphs[0].EndTime.TotalMilliseconds > subtitle.Paragraphs[0].StartTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void AutoGuessImportJsonReadsTextArray()
+    {
+        var importer = new UnknownFormatImporter();
+        var line = "[" +
+                   "{\"text\": [ \"Hello there.\" ], \"index\":1,\"start\": 1500, \"end\": 4300 }," +
+                   "{\"text\": [ \"How are\", \"you?\" ], \"index\":2,\"start\": 5500, \"end\": 8300 }," +
+                   "{\"text\": [ \"I am fine.\" ], \"index\":3,\"start\": 9500, \"end\": 12300 }]";
+
+        var subtitle = importer.AutoGuessImport([line], "test.json");
+
+        Assert.Equal(3, subtitle.Paragraphs.Count);
+        Assert.Equal(1500, subtitle.Paragraphs[0].StartTime.TotalMilliseconds, 3);
+        Assert.Equal("Hello there.", subtitle.Paragraphs[0].Text);
+        Assert.Equal("How are" + Environment.NewLine + "you?", subtitle.Paragraphs[1].Text);
+    }
+
+    [Fact]
     public void AutoGuessImportIsFastOnDigitHeavyBinaryInput()
     {
         // Regression for issue #12683: a raw PGS .sup decoded as text reached the


### PR DESCRIPTION
## What

Round-tripped all **344 text-based known formats** through the unknown-format importer (as a proxy for real-world unknown dialects) and fixed the two big failure clusters. Result of the sweep:

| | Perfect | Partial | Fail |
|---|---|---|---|
| Before | 104 | 86 | 154 |
| After | **168** | 85 | **91** |

No format that previously imported got worse (verified per-format across every round).

## New: generic XML importer

There was no XML handling at all — XML dialects only imported when the line-based regex passes happened to match (e.g. TTML with `begin="1.5s"` seconds failed completely). `UnknownFormatImporterXml` parses the document (DTD-tolerant, no external resolver) and finds the repeated element that carries time codes plus text, without knowing the schema:

- time codes as attributes (TTML-like), child elements (Matroska chapters), or child-element attributes (`<time start=".." end=".."/>`)
- values in `HH:MM:SS[.,]ms`, `HH:MM:SS:FF`, `MM:SS`, seconds (`1.5s`), TTML ticks (`15000000t`), rationals (`3003/24000s`, Final Cut), plain numbers, and D-Cinema 250-tick units
- text inline (incl. CDATA, `<br/>`, spans), in named child elements (multi-line joined), in nested markup, or in an attribute
- start-only samples where an empty element closes the previous one (GPAC TTXT)

This newly imports the Final Cut Pro family, D-Cinema, Timed Text 1.0, GPAC TTXT, Matroska chapters, Edius, ESUB-XF, TMPGEnc, UT Subtitle, and a dozen more XML dialects.

## JSON importer fixes

- **Key-position matching**: tag lookup previously matched quoted *values* — `"lineAlign":"start"` hijacked the tag `start` and returned garbage, so flat well-named files failed. Keys must now be followed by a colon, and matched time values must be time-like (else the lookup falls through to the next name).
- **Nested objects**: times in the parent and text in a nested child (AWS Transcribe, YouTube json3 `segs`/`utf8`, etc.) now import via a carry-over merge across brace-split segments.
- **Text arrays**: read with a bounded array reader — `Json.ReadArray` ran past the closing `]` and swallowed following keys into the text, and comma-split plain strings into junk.
- **Start-time-only files** (`{"milliseconds":1500,"line":"..."}`) get end times from the next start.
- **ms-vs-seconds fixup** also suffered the value-hijack (dividing correct second-based times by 1000) — now key-position-checked and additionally guarded by an implausible average duration.
- New key names seen in the wild: `tStartMs`/`dDurationMs`, `timestamp_begin`/`timestamp_end`, `displayTimeOffset`, `milliseconds`, `st`/`et`/`tt`, `t1`/`t2`/`t`, `s`/`e`/`d`/`n`, `line`/`lines`, `utf8`.

## Tests

10 new unit tests covering the XML dialect shapes, the JSON value-hijack, nested text, start-only, and text arrays; plus a guard that non-subtitle XML still returns empty. Full libse suite: 1554 passed.