### PR TITLE
Fix 20 bugs found in a random bug hunt

### DIFF
--- a/src/libse/VobSub/VobSubWriter.cs
+++ b/src/libse/VobSub/VobSubWriter.cs
@@ -372,7 +372,11 @@ namespace Nikse.SubtitleEdit.Core.VobSub
         public void WriteIdxFile()
         {
             string idxFileName = _subFileName.Substring(0, _subFileName.Length - 3) + "idx";
-            File.WriteAllText(idxFileName, _idx.ToString().Trim());
+            // _emphasis2 (the anti-alias blend color) is only computed by ConvertToFourColors
+            // during WriteParagraph, i.e. after the header template was built in the
+            // constructor - so its palette entry is patched in here, at write time.
+            var idx = _idx.ToString().Replace(Emphasis2PalettePlaceholder, ToHexColor(_emphasis2));
+            File.WriteAllText(idxFileName, idx.Trim());
         }
 
         private StringBuilder CreateIdxHeader()
@@ -427,7 +431,7 @@ time offset: 0
 forced subs: OFF
 
 # The original palette of the DVD
-palette: 000000, " + ToHexColor(_pattern) + ", " + ToHexColor(_emphasis1) + ", " + ToHexColor(_emphasis2) + @", 828282, 828282, 828282, ffffff, 828282, bababa, 828282, 828282, 828282, 828282, 828282, 828282
+palette: 000000, " + ToHexColor(_pattern) + ", " + ToHexColor(_emphasis1) + ", " + Emphasis2PalettePlaceholder + @", 828282, 828282, 828282, ffffff, 828282, bababa, 828282, 828282, 828282, 828282, 828282, 828282
 
 # Custom colors (transp idxs and the four colors)
 custom colors: OFF, tridx: 0000, colors: 000000, 000000, 000000, 000000
@@ -442,6 +446,8 @@ id: " + _languageNameShort + @", index: 0
 # Vob/Cell ID: 1, 1 (PTS: 0)");
             return sb;
         }
+
+        private const string Emphasis2PalettePlaceholder = "[EMPHASIS2]";
 
         private static string ToHexColor(SKColor c)
         {

--- a/src/ui/Features/Edit/ModifySelection/ModifySelectionViewModel.cs
+++ b/src/ui/Features/Edit/ModifySelection/ModifySelectionViewModel.cs
@@ -176,11 +176,21 @@ public partial class ModifySelectionViewModel : ObservableObject, IClosingCleanu
     [RelayCommand]
     private void Ok()
     {
-        foreach (var s in Subtitles)
+        // Recompute the matches from the current rule instead of reading the preview list:
+        // the preview is filled by a 250 ms debounce timer, so it is empty when OK comes
+        // right after opening and stale when it comes right after editing the rule. Rows the
+        // user unticked in the (shown) preview stay excluded - they are matched up by line.
+        var rule = SelectedRule;
+        if (rule != null)
         {
-            if (s.Apply)
+            var excluded = new HashSet<SubtitleLineViewModel>(
+                Subtitles.Where(s => !s.Apply).Select(s => s.Subtitle));
+            foreach (var item in _allSubtitles)
             {
-                Selection.Add(s.Subtitle);
+                if (rule.IsMatch(item) && !excluded.Contains(item))
+                {
+                    Selection.Add(item);
+                }
             }
         }
 

--- a/src/ui/Features/Files/Compare/CompareViewModel.cs
+++ b/src/ui/Features/Files/Compare/CompareViewModel.cs
@@ -51,6 +51,7 @@ public partial class CompareViewModel : ObservableObject
     private List<SubtitleLineViewModel> _leftLines = new();
     private List<SubtitleLineViewModel> _rightLines = new();
     private string _language = string.Empty;
+    private bool _languageDirty = true;
 
     // Theme aware - the light pastels are unreadable under the dark theme's near-white text (#13435).
     private static IBrush ListViewRed => CompareColors.OnlyInOneFileRow;
@@ -88,11 +89,14 @@ public partial class CompareViewModel : ObservableObject
 
         IsReloadFromFileVisible = !string.IsNullOrEmpty(LeftFileName);
 
+        _languageDirty = true;
         Dispatcher.UIThread.Post(Compare);
     }
 
     private void Compare()
     {
+        DetectLanguageIfNeeded();
+
         LeftSubtitles.Clear();
         foreach (var l in _leftLines)
         {
@@ -378,6 +382,28 @@ public partial class CompareViewModel : ObservableObject
 
     private bool ShouldBreakToLetter() => _language != null && (_language == "ja" || _language == "zh");
 
+    // The word/letter diff choice needs the subtitle language (letters for ja/zh). Detection
+    // is whole-file work, so it only runs when one of the sides was (re)loaded.
+    private void DetectLanguageIfNeeded()
+    {
+        if (!_languageDirty)
+        {
+            return;
+        }
+
+        _languageDirty = false;
+        var lines = _leftLines.Count > 0 ? _leftLines : _rightLines;
+        var subtitle = new Subtitle();
+        foreach (var line in lines)
+        {
+            subtitle.Paragraphs.Add(new Paragraph(line.Text, line.StartTime.TotalMilliseconds, line.EndTime.TotalMilliseconds));
+        }
+
+        _language = subtitle.Paragraphs.Count > 0
+            ? LanguageAutoDetect.AutoDetectGoogleLanguage(subtitle)
+            : string.Empty;
+    }
+
     private void InsertMissingLines()
     {
         if (LeftSubtitles.Count == 0 || RightSubtitles.Count == 0)
@@ -566,6 +592,7 @@ public partial class CompareViewModel : ObservableObject
         LeftFileNameHasChanges = false;
         LeftFileName = fileName;
 
+        _languageDirty = true;
         Dispatcher.UIThread.Post(Compare);
     }
 
@@ -593,6 +620,7 @@ public partial class CompareViewModel : ObservableObject
         RightFileName = fileName;
         IsReloadFromFileVisible = false;
 
+        _languageDirty = true;
         Dispatcher.UIThread.Post(Compare);
     }
 
@@ -620,6 +648,7 @@ public partial class CompareViewModel : ObservableObject
         RightFileName = fileName;
         IsReloadFromFileVisible = false;
 
+        _languageDirty = true;
         Dispatcher.UIThread.Post(Compare);
     }
 
@@ -973,6 +1002,7 @@ public partial class CompareViewModel : ObservableObject
                     LeftFileNameHasChanges = false;
                     LeftFileName = path;
 
+                    _languageDirty = true;
                     Dispatcher.UIThread.Post(Compare);
                     break;
                 }
@@ -1009,6 +1039,7 @@ public partial class CompareViewModel : ObservableObject
 
                     RightFileName = path;
 
+                    _languageDirty = true;
                     Dispatcher.UIThread.Post(Compare);
                     break;
                 }

--- a/src/ui/Features/Files/Compare/TextDiffHighlighter.cs
+++ b/src/ui/Features/Files/Compare/TextDiffHighlighter.cs
@@ -135,7 +135,10 @@ public static class TextDiffHighlighter
         // Use longest common substring to find the best match
         var (commonStart, commonEnd, middleCommon1, middleCommon2) = FindCommonParts(text1, text2);
 
-        bool hasDifferences = commonStart != text1.Length || commonEnd != 0 || middleCommon1.Count > 0;
+        // Compare the strings directly: deriving this from commonStart/commonEnd missed the
+        // pure-append case ("Hello" vs "Hello world"), where the whole of text1 is the common
+        // prefix - so the appended tail was rendered with no highlighting at all.
+        var hasDifferences = text1 != text2;
 
         if (!hasDifferences)
         {
@@ -185,7 +188,8 @@ public static class TextDiffHighlighter
         }
 
         var (commonStart, commonEnd, middleCommon1, middleCommon2) = FindCommonParts(text1, text2);
-        var hasDifferences = commonStart != text1.Length || commonEnd != 0 || middleCommon1.Count > 0;
+        // See Compare: a direct comparison also covers the pure-append case.
+        var hasDifferences = text1 != text2;
 
         if (!hasDifferences)
         {

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -5686,7 +5686,11 @@ public partial class MainViewModel :
         }
         else if (result.DeleteLinesFromVideoPosition)
         {
-            var subsToKeep = Subtitles.Where(p => p.StartTime.TotalSeconds >= vp.Position).ToList();
+            // New time codes are generated from the video position onward, so the existing
+            // lines from that position are the ones to delete - the lines BEFORE it are kept
+            // (this used to be inverted, wiping the user's work before the position and
+            // doubling up lines after it).
+            var subsToKeep = Subtitles.Where(p => p.StartTime.TotalSeconds < vp.Position).ToList();
             _subtitle.Paragraphs.Clear();
             // Pass the format so Paragraph.Extra keeps the ASSA style - SetSubtitles below
             // rebuilds the rows from these paragraphs and reads the style back from Extra.
@@ -5716,7 +5720,8 @@ public partial class MainViewModel :
             }
 
             var nextSubtitle = GetNextWorkingRow(idx);
-            var charCount = selectedLine.Text?.Length ?? 0;
+            // Count like the grid's CPS column does (tags and line breaks stripped)
+            var charCount = (double)(selectedLine.Text ?? string.Empty).CountCharacters(true);
 
             var optimalDuration = TimeSpanExtensions.FromSecondsWholeMilliseconds(charCount / Se.Settings.General.SubtitleOptimalCharactersPerSeconds);
             var maxDuration = TimeSpanExtensions.FromSecondsWholeMilliseconds(charCount / Se.Settings.General.SubtitleMaximumCharactersPerSeconds);
@@ -5768,8 +5773,9 @@ public partial class MainViewModel :
                 continue;
             }
 
-            var charCount = selectedLine.Text?.Length ?? 0;
-            if (charCount == 0)
+            // Count like the grid's CPS column does (tags and line breaks stripped)
+            var charCount = (double)(selectedLine.Text ?? string.Empty).CountCharacters(true);
+            if (charCount <= 0)
             {
                 continue;
             }
@@ -15251,7 +15257,9 @@ public partial class MainViewModel :
             vm.Initialize(Subtitles.ToList(), selectedItems);
         });
 
-        if (result.OkPressed && result.Subtitles.Count > 0)
+        // Gate on the computed selection, not the preview collection - the preview is filled by
+        // a 250 ms debounce timer, so it can be empty/stale when OK is pressed quickly.
+        if (result.OkPressed && result.Selection.Count > 0)
         {
             // Work out the final selection up front with O(1) membership tests
             // (newSelection / current are HashSets, not List.Contains), keeping

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustDuration/BinaryAdjustDurationViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustDuration/BinaryAdjustDurationViewModel.cs
@@ -2,6 +2,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
@@ -96,6 +97,14 @@ public partial class BinaryAdjustDurationViewModel : ObservableObject
             var nextSubtitle = index + 1 < allSubtitles.Count ? allSubtitles[index + 1] : null;
             
             var newEndTime = subtitle.EndTime + TimeSpan.FromSeconds(AdjustSeconds);
+
+            // A negative adjustment must not push the end time before the start time
+            var minEndTime = subtitle.StartTime + TimeSpan.FromMilliseconds(100);
+            if (AdjustSeconds < 0 && newEndTime < minEndTime)
+            {
+                newEndTime = minEndTime;
+            }
+
             if (nextSubtitle != null && newEndTime <= nextSubtitle.StartTime || nextSubtitle == null)
             {
                 subtitle.EndTime = newEndTime;
@@ -143,9 +152,12 @@ public partial class BinaryAdjustDurationViewModel : ObservableObject
             var index = allSubtitles.IndexOf(subtitle);
             var nextSubtitle = index + 1 < allSubtitles.Count ? allSubtitles[index + 1] : null;
 
+            // Set the duration TO the percentage of the original (110% = 10% longer), like the
+            // main "Adjust durations" dialog and SE4 - the two share the same saved setting,
+            // so they must not interpret it differently (this used to ADD the percentage).
             var originalDuration = subtitle.EndTime - subtitle.StartTime;
-            var adjustment = originalDuration.TotalSeconds * (AdjustPercent / 100.0);
-            var newEndTime = subtitle.EndTime + TimeSpan.FromSeconds(adjustment);
+            var newDuration = originalDuration.TotalSeconds * (AdjustPercent / 100.0);
+            var newEndTime = subtitle.StartTime + TimeSpan.FromSeconds(newDuration);
 
             if (nextSubtitle != null && newEndTime > nextSubtitle.StartTime)
             {
@@ -165,7 +177,8 @@ public partial class BinaryAdjustDurationViewModel : ObservableObject
         foreach (var subtitle in itemsToAdjust)
         {
             var index = allSubtitles.IndexOf(subtitle);
-            var charCount = subtitle.Text?.Length ?? 0;
+            // Strip tags/line breaks so the recalculated durations land at the requested CPS
+            var charCount = (double)(subtitle.Text ?? string.Empty).CountCharacters(true);
 
             var optimalDuration = TimeSpan.FromSeconds(charCount / AdjustRecalculateOptimalCharacterPerSecond);
             var maxDuration = TimeSpan.FromSeconds(charCount / AdjustRecalculateMaxCharacterPerSecond);

--- a/src/ui/Features/Shared/WaveformGuessTimeCodes/WaveformGuessTimeCodesViewModel.cs
+++ b/src/ui/Features/Shared/WaveformGuessTimeCodes/WaveformGuessTimeCodesViewModel.cs
@@ -71,6 +71,12 @@ public partial class WaveformGuessTimeCodesViewModel : ObservableObject
 
     private void SaveSettings()
     {
+        var s = Se.Settings.Waveform;
+        s.GuessTimeCodeStartFromBeginning = StartFromBeginning;
+        s.GuessTimeCodeScanBlockSize = ScanBlockSize ?? 100;
+        s.GuessTimeCodeScanBlockAverageMin = ScanBlockAverageMin ?? 35;
+        s.GuessTimeCodeScanBlockAverageMax = ScanBlockAverageMax ?? 70;
+        s.GuessTimeCodeSplitLongSubtitlesAtMs = SplitLongSubtitlesAtMs ?? 3500;
         Se.SaveSettings();
     }
 

--- a/src/ui/Features/Tools/AdjustDuration/AdjustDurationViewModel.cs
+++ b/src/ui/Features/Tools/AdjustDuration/AdjustDurationViewModel.cs
@@ -2,6 +2,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Logic;
@@ -64,6 +65,14 @@ public partial class AdjustDurationViewModel : ObservableObject
             var subtitle = subtitles[i];
             var nextSubtitle = subtitles.GetOrNull(i + 1);
             var newEndTime = subtitle.EndTime + TimeSpan.FromSeconds(AdjustSeconds);
+
+            // A negative adjustment must not push the end time before the start time
+            var minEndTime = subtitle.StartTime + TimeSpan.FromMilliseconds(100);
+            if (AdjustSeconds < 0 && newEndTime < minEndTime)
+            {
+                newEndTime = minEndTime;
+            }
+
             if (nextSubtitle != null && newEndTime <= nextSubtitle.StartTime || nextSubtitle == null)
             {
                 subtitle.EndTime = newEndTime;
@@ -126,7 +135,9 @@ public partial class AdjustDurationViewModel : ObservableObject
         for (int i = 0; i < subtitles.Count; i++)
         {
             var subtitle = subtitles[i];
-            var charCount = subtitle.Text?.Length ?? 0;
+            // Count like the grid's CPS column does (tags and line breaks stripped), so the
+            // recalculated durations actually land at the requested chars-per-second.
+            var charCount = (double)(subtitle.Text ?? string.Empty).CountCharacters(true);
 
             var optimalDuration = TimeSpan.FromSeconds(charCount / AdjustRecalculateOptimalCharacterPerSecond);
             var maxDuration = TimeSpan.FromSeconds(charCount / AdjustRecalculateMaxCharacterPerSecond);

--- a/src/ui/Features/Tools/ChangeCasing/ChangeCasingViewModel.cs
+++ b/src/ui/Features/Tools/ChangeCasing/ChangeCasingViewModel.cs
@@ -95,8 +95,19 @@ public partial class ChangeCasingViewModel : ObservableObject
             if (NormalCasingFixNames)
             {
                 var result = await ShowFixNames(_subtitle, fixCasing.NoOfLinesChanged);
-                Subtitle = result.Subtitle;
-                OkPressed = result.OkPressed;
+                if (result.OkPressed)
+                {
+                    Subtitle = result.Subtitle;
+                    Info = result.Info;
+                }
+                else
+                {
+                    // Cancelling the names step only skips the name fixes - the normal casing
+                    // was already confirmed with OK on this dialog, so it still applies (as in SE4)
+                    Subtitle = _subtitle;
+                }
+
+                OkPressed = true;
                 Window?.Close();
                 return;
             }
@@ -125,7 +136,7 @@ public partial class ChangeCasingViewModel : ObservableObject
     {
         var result = await _windowService.ShowDialogAsync<FixNamesWindow, FixNamesViewModel>(Window!, vm =>
         {
-            vm.Initialize(subtitle);
+            vm.Initialize(subtitle, noOfFixes);
         });
 
         return result;

--- a/src/ui/Features/Tools/ChangeCasing/FixNamesViewModel.cs
+++ b/src/ui/Features/Tools/ChangeCasing/FixNamesViewModel.cs
@@ -54,8 +54,13 @@ public partial class FixNamesViewModel : ObservableObject, IClosingCleanup
         Subtitle = new Subtitle();
     }
 
-    internal void Initialize(Subtitle subtitle)
+    // Lines already changed by the step that opened this dialog (normal casing), so the
+    // final "lines changed" info covers the whole operation, like SE4's combined count.
+    private int _noOfFixesBefore;
+
+    internal void Initialize(Subtitle subtitle, int noOfFixesBefore = 0)
     {
+        _noOfFixesBefore = noOfFixesBefore;
         subtitle.Renumber();
         _subtitle = new Subtitle(subtitle);
         _subtitleBefore = subtitle;
@@ -331,7 +336,7 @@ public partial class FixNamesViewModel : ObservableObject, IClosingCleanup
             }
         }
 
-        Info = $"Change casing - lines changed: {noOfLinesChanged}";
+        Info = $"Change casing - lines changed: {noOfLinesChanged + _noOfFixesBefore}";
 
         OkPressed = true;
         Window?.Close();

--- a/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesViewModel.cs
+++ b/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesViewModel.cs
@@ -8,6 +8,7 @@ using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace Nikse.SubtitleEdit.Features.Tools.MergeContinuationLines;
 
@@ -112,7 +113,21 @@ public partial class MergeContinuationLinesViewModel : ObservableObject, IClosin
     [RelayCommand]
     private void Ok()
     {
-        AllSubtitlesFixed = MergeContinuationLinesHelper.Apply(_allSubtitles, Candidates, _language);
+        // Recompute the candidates from the current settings instead of applying the preview
+        // collection: the preview is filled by a 250 ms timer, so it is empty when OK comes
+        // right after opening and stale when it comes right after a settings change. The
+        // user's deselections in the shown list are carried over by first-line index.
+        var deselected = new HashSet<int>(Candidates.Where(c => !c.IsSelected).Select(c => c.Index));
+        var candidates = MergeContinuationLinesHelper.Detect(_allSubtitles, _language, MaxMillisecondsBetweenLines, MaxCharacters);
+        foreach (var candidate in candidates)
+        {
+            if (deselected.Contains(candidate.Index))
+            {
+                candidate.IsSelected = false;
+            }
+        }
+
+        AllSubtitlesFixed = MergeContinuationLinesHelper.Apply(_allSubtitles, candidates, _language);
         OkPressed = true;
         Window?.Close();
     }

--- a/src/ui/Features/Tools/MergeShortLines/MergeShortLinesViewModel.cs
+++ b/src/ui/Features/Tools/MergeShortLines/MergeShortLinesViewModel.cs
@@ -162,10 +162,10 @@ public partial class MergeShortLinesViewModel : ObservableObject, IClosingCleanu
             return;
         }
 
-        // "Highlight parts" only affects the on-screen preview (unmerged lines with the
-        // combined text underlined). The result applied to the document must always be
-        // the real merge, so recompute it when the preview was in highlight mode.
-        if (HighLight)
+        // Always recompute the real merge from the current settings instead of handing back
+        // what the 250 ms preview timer last produced: the preview is empty when OK comes
+        // right after opening, stale when it comes right after a settings change, and in
+        // "highlight parts" mode it is not the real merge at all.
         {
             var gapThresholdMs = Se.Settings.Tools.BridgeGaps.BridgeGapsSmallerThanMs;
             var unbreakLinesShorterThan = Se.Settings.General.UnbreakLinesShorterThan;

--- a/src/ui/Features/Video/CutVideo/CutVideoViewModel.cs
+++ b/src/ui/Features/Video/CutVideo/CutVideoViewModel.cs
@@ -390,7 +390,7 @@ public partial class CutVideoViewModel : ObservableObject
                     MessageBoxButtons.OK,
                     MessageBoxIcon.Error);
 
-                IsGenerating = true;
+                IsGenerating = false;
                 ProgressValue = 0;
             });
 
@@ -595,18 +595,24 @@ public partial class CutVideoViewModel : ObservableObject
         var nameNoExt = Path.GetFileNameWithoutExtension(videoFileName);
         var ext = SelectedVideoExtension;
         var suffix = Se.Settings.Video.BurnIn.BurnInSuffix;
-        var fileName = Path.Combine(Path.GetDirectoryName(videoFileName)!, nameNoExt + suffix + ext);
-        if (Se.Settings.Video.BurnIn.UseOutputFolder &&
-            !string.IsNullOrEmpty(Se.Settings.Video.BurnIn.OutputFolder) &&
-            Directory.Exists(Se.Settings.Video.BurnIn.OutputFolder))
-        {
-            fileName = Path.Combine(Se.Settings.Video.BurnIn.OutputFolder, nameNoExt + suffix + ext);
-        }
+
+        // Decide the folder once - the collision loop below used to combine with
+        // BurnIn.OutputFolder unconditionally, so with the default (empty, unused) output
+        // folder the "_2" fallback became a bare relative name resolved against the process
+        // working directory instead of the video's folder.
+        var useOutputFolder = Se.Settings.Video.BurnIn.UseOutputFolder &&
+                              !string.IsNullOrEmpty(Se.Settings.Video.BurnIn.OutputFolder) &&
+                              Directory.Exists(Se.Settings.Video.BurnIn.OutputFolder);
+        var outputFolder = useOutputFolder
+            ? Se.Settings.Video.BurnIn.OutputFolder
+            : Path.GetDirectoryName(videoFileName) ?? Path.GetTempPath();
+
+        var fileName = Path.Combine(outputFolder, nameNoExt + suffix + ext);
 
         var i = 2;
         while (File.Exists(fileName))
         {
-            fileName = Path.Combine(Se.Settings.Video.BurnIn.OutputFolder, $"{nameNoExt}{suffix}_{i}{ext}");
+            fileName = Path.Combine(outputFolder, $"{nameNoExt}{suffix}_{i}{ext}");
             i++;
         }
 

--- a/src/ui/Features/Video/EmbeddedSubtitlesEdit/EmbeddedSubtitlesEditViewModel.cs
+++ b/src/ui/Features/Video/EmbeddedSubtitlesEdit/EmbeddedSubtitlesEditViewModel.cs
@@ -161,7 +161,6 @@ public partial class EmbeddedSubtitlesEditViewModel : ObservableObject
         _timerGenerate.Stop();
         ProgressValue = 100;
         ProgressText = string.Empty;
-        Se.LogError(_log.ToString());
 
         if (!File.Exists(_outputFileName))
         {
@@ -505,7 +504,10 @@ public partial class EmbeddedSubtitlesEditViewModel : ObservableObject
             VideoFileName = fileName;
             _ = Task.Run(() =>
             {
+                // Parse once, off the UI thread - this used to also parse synchronously on the
+                // UI thread after starting the task, freezing the window for the probe.
                 var mediaInfo = FfmpegMediaInfo2.Parse(fileName);
+                _mediaInfo = mediaInfo;
                 Dispatcher.UIThread.Invoke(() =>
                 {
                     Tracks.Clear();
@@ -519,7 +521,6 @@ public partial class EmbeddedSubtitlesEditViewModel : ObservableObject
                     SelectAndScrollToRow(0);
                 });
             });
-            _mediaInfo = FfmpegMediaInfo2.Parse(fileName);
         }
     }
 

--- a/src/ui/Features/Video/ReEncodeVideo/ReEncodeVideoViewModel.cs
+++ b/src/ui/Features/Video/ReEncodeVideo/ReEncodeVideoViewModel.cs
@@ -204,7 +204,7 @@ public partial class ReEncodeVideoViewModel : ObservableObject
                     MessageBoxButtons.OK,
                     MessageBoxIcon.Error);
 
-                IsGenerating = true;
+                IsGenerating = false;
                 ProgressValue = 0;
             });
 

--- a/tests/UI/Features/Files/Compare/TextDiffHighlighterTests.cs
+++ b/tests/UI/Features/Files/Compare/TextDiffHighlighterTests.cs
@@ -207,6 +207,33 @@ public class TextDiffHighlighterTests
         }
     }
 
+    [Fact]
+    public void Compare_AppendedSuffix_HighlightsTheAddedTail()
+    {
+        // The whole of text1 is the common prefix, so commonStart == text1.Length and
+        // commonEnd == 0 - the old hasDifferences derivation concluded "identical" and the
+        // appended tail was rendered with no highlighting at all.
+        var (left, right) = TextDiffHighlighter.Compare("Hello", "Hello world");
+
+        Assert.Equal("Hello", JoinRuns(left.Inlines));
+        Assert.Equal("Hello world", JoinRuns(right.Inlines));
+
+        var rightRuns = right.Inlines!.Cast<Run>().ToArray();
+        Assert.Contains(rightRuns, r => r.Text == " world" && r.Foreground != null);
+    }
+
+    [Fact]
+    public void CompareReplacement_AppendedSuffix_HighlightsTheAddedTail()
+    {
+        var (before, after) = TextDiffHighlighter.CompareReplacement("Hello", "Hello world");
+
+        Assert.Equal("Hello", JoinRuns(before.Inlines));
+        Assert.Equal("Hello world", JoinRuns(after.Inlines));
+
+        var afterRuns = after.Inlines!.Cast<Run>().ToArray();
+        Assert.Contains(afterRuns, r => r.Text == " world" && r.Foreground != null);
+    }
+
     private static void AssertNoRunSplitsAWord(InlineCollection? inlines)
     {
         var isWordChar = typeof(TextDiffHighlighter).GetMethod(

--- a/tests/UI/Features/Shared/BinaryEdit/BinaryAdjustDurationViewModelTests.cs
+++ b/tests/UI/Features/Shared/BinaryEdit/BinaryAdjustDurationViewModelTests.cs
@@ -1,0 +1,49 @@
+using Nikse.SubtitleEdit.Features.Shared.BinaryEdit;
+using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryAdjustDuration;
+using System.Collections.Generic;
+
+namespace UITests.Features.Shared.BinaryEdit;
+
+public class BinaryAdjustDurationViewModelTests
+{
+    [Fact]
+    public void AdjustDuration_Percent_SetsDurationToPercentageLikeTheMainDialog()
+    {
+        // The binary edit dialog shares its saved percent value with the main "Adjust
+        // durations" dialog, so both must interpret it the same way: the duration is SET
+        // to the percentage of the original (this used to ADD it, doubling up).
+        var vm = new BinaryAdjustDurationViewModel
+        {
+            SelectedAdjustType = new BinaryAdjustDurationDisplay { Type = BinaryAdjustDurationType.Percent },
+            AdjustPercent = 120,
+        };
+        var items = new List<BinarySubtitleItem>
+        {
+            new(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(3)),
+        };
+
+        vm.AdjustDuration(items);
+
+        // 2 s * 120% = 2.4 s => end at 3.4 s
+        Assert.Equal(TimeSpan.FromMilliseconds(3400), items[0].EndTime);
+    }
+
+    [Fact]
+    public void AdjustDuration_NegativeSeconds_DoesNotPushEndBeforeStart()
+    {
+        var vm = new BinaryAdjustDurationViewModel
+        {
+            SelectedAdjustType = new BinaryAdjustDurationDisplay { Type = BinaryAdjustDurationType.Seconds },
+            AdjustSeconds = -10,
+        };
+        var items = new List<BinarySubtitleItem>
+        {
+            new(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(3)),
+        };
+
+        vm.AdjustDuration(items);
+
+        // Clamped to a 100 ms minimum duration instead of ending before it starts
+        Assert.Equal(TimeSpan.FromMilliseconds(1100), items[0].EndTime);
+    }
+}

--- a/tests/UI/Features/Tools/AdjustDuration/AdjustDurationViewModelTests.cs
+++ b/tests/UI/Features/Tools/AdjustDuration/AdjustDurationViewModelTests.cs
@@ -8,6 +8,55 @@ namespace UITests.Features.Tools.AdjustDuration;
 public class AdjustDurationViewModelTests
 {
     [Fact]
+    public void AdjustDuration_NegativeSeconds_DoesNotPushEndBeforeStart()
+    {
+        var vm = new AdjustDurationViewModel
+        {
+            SelectedAdjustType = new AdjustDurationDisplay { Type = AdjustDurationType.Seconds },
+            AdjustSeconds = -10,
+        };
+        var subtitles = new ObservableCollection<SubtitleLineViewModel>
+        {
+            new()
+            {
+                Text = "First",
+                StartTime = TimeSpan.FromSeconds(1),
+                EndTime = TimeSpan.FromSeconds(3),
+            },
+        };
+
+        vm.AdjustDuration(subtitles);
+
+        // Clamped to a 100 ms minimum duration instead of ending before it starts
+        Assert.Equal(TimeSpan.FromMilliseconds(1100), subtitles[0].EndTime);
+    }
+
+    [Fact]
+    public void AdjustDuration_Recalculate_IgnoresHtmlTagsLikeTheCpsColumn()
+    {
+        var vm = new AdjustDurationViewModel
+        {
+            SelectedAdjustType = new AdjustDurationDisplay { Type = AdjustDurationType.Recalculate },
+            AdjustRecalculateOptimalCharacterPerSecond = 5,
+            AdjustRecalculateMaxCharacterPerSecond = 25,
+        };
+        var subtitles = new ObservableCollection<SubtitleLineViewModel>
+        {
+            new()
+            {
+                Text = "<i>Hello</i>",
+                StartTime = TimeSpan.Zero,
+                EndTime = TimeSpan.FromSeconds(10),
+            },
+        };
+
+        vm.AdjustDuration(subtitles);
+
+        // 5 visible characters at 5 CPS = 1 s; counting the tags would give 12 / 5 = 2.4 s
+        Assert.Equal(TimeSpan.FromSeconds(1), subtitles[0].EndTime);
+    }
+
+    [Fact]
     public void AdjustDuration_Percent_ScalesDurationFromStartTime()
     {
         var vm = new AdjustDurationViewModel


### PR DESCRIPTION
Eighth general bug-hunt sweep, targeting ground the previous seven did not cover: the unswept edit-tool dialogs, Compare/diff highlighting, VobSub export, waveform guess-time-codes, and the video utility dialogs. 20 findings, all fixed, with 6 new guard tests.

## Duration tools

- **Adjust durations / binary edit adjust durations**: a negative "add seconds" value could push a line's end time before its start time. Now clamped to a 100 ms minimum duration, like SE4.
- **Recalculate** (both dialogs, plus the main window's "recalculate duration" and "set duration via max CPS" commands) counted HTML tags and line breaks, so a line recalculated to "max 25 CPS" could still show >25 in the grid's CPS column. All sites now use the same `CountCharacters` the CPS column uses.
- **Binary edit percent mode** *added* the percentage of the duration (110% made lines 2.1× longer) while the main dialog and SE4 *set* the duration to the percentage — and the two dialogs share the same saved setting. Now consistent.

## Preview-timer dialogs (OK read the debounced preview)

Same defect class as the sweep-7 fixes, but these three use a different timer field name so the earlier audit grep missed them. Pressing OK within 250 ms of opening handed the caller an empty result; pressing OK right after changing a setting applied the previous settings' result:

- **Merge short lines**: OK now always recomputes the real merge (also covering highlight mode).
- **Merge continuation lines**: OK recomputes the candidates from the current settings; user deselections are carried over.
- **Modify selection**: OK recomputes the matches from the current rule (unticked preview rows stay excluded), and the MainViewModel caller now gates on the computed selection instead of the preview collection.

## Change casing

- With "normal casing" + "fix names", cancelling the names dialog threw away the already-confirmed casing changes. SE4 applies them; SE5 now does too.
- The final "lines changed" count now covers both steps (the `noOfFixes` parameter existed but was ignored).

## Compare

- `_language` was never assigned, so the letter-based diff for Japanese/Chinese (`ShouldBreakToLetter`) was dead code. The language is now auto-detected when a side is (re)loaded.
- `"Hello"` vs `"Hello world"` reported **no differences**: the whole left text is the common prefix, so the old `hasDifferences` derivation concluded "identical" and the appended tail was rendered unhighlighted — in the Compare window and the Multiple Replace preview alike.

## VobSub export

- The `.idx` header (including the palette line) was built in the constructor, but the emphasis2 anti-alias blend color is only computed during `WriteParagraph` — so the palette's emphasis2 entry was always `000000`. It is now patched in at `WriteIdxFile` time. Affects both the UI export and seconv.

## Waveform guess time codes

- The dialog never persisted any of its settings (`SaveSettings` wrote nothing back).
- "Delete lines from video position" was inverted: it kept the lines *after* the position (which the generator then doubled up) and deleted all the user's work *before* it.

## Video dialogs

- **Cut video / re-encode video**: when ffmpeg failed to produce the output file, the error path set `IsGenerating = true`, wedging the dialog in "generating" state (BurnIn/Transparent set `false`).
- **Cut video**: the output-name collision loop combined with `BurnIn.OutputFolder` unconditionally, so with that folder unset the `_2` fallback became a bare relative path resolved against the working directory.
- **Embedded subtitles edit**: every *successful* run dumped the entire ffmpeg log through `Se.LogError`, and `BrowseVideoFile` probed the media twice — once synchronously on the UI thread.

## Tests

Suites green: libse 1544, libuilogic 703, seconv 416, UI 4143 (6 new: negative-seconds clamp ×2, tag-stripped recalculate, binary percent semantics, appended-suffix diff highlight ×2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)