### PR TITLE
Fix 24 bugs found in a random bug hunt

### DIFF
--- a/src/libse/Common/UnknownFormatImporterXml.cs
+++ b/src/libse/Common/UnknownFormatImporterXml.cs
@@ -542,7 +542,9 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
                 else if (child is XmlElement childElement)
                 {
-                    if (childElement.Name.Equals("br", StringComparison.OrdinalIgnoreCase))
+                    // LocalName, like the inline tags below - matching the prefixed Name
+                    // dropped the line break in prefixed dialects (<tt:br/>).
+                    if (childElement.LocalName.Equals("br", StringComparison.OrdinalIgnoreCase))
                     {
                         sb.AppendLine();
                     }

--- a/src/libse/SubtitleFormats/Bilibili.cs
+++ b/src/libse/SubtitleFormats/Bilibili.cs
@@ -38,7 +38,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 sb.Append("\"from\":" + p.StartTime.TotalSeconds.ToString(CultureInfo.InvariantCulture) + ", ");
                 sb.Append("\"to\":" + p.EndTime.TotalSeconds.ToString(CultureInfo.InvariantCulture) + ", ");
                 sb.Append("\"location\": 2, ");
-                sb.Append("\"content\":\"" + Json.EncodeJsonText(p.Text.Replace(Environment.NewLine, "\\n")) + "\"");
+                // Line breaks are written as the JSON escape "\n" - as the encoder's newline
+                // placeholder, not via a pre-replace (escaping the pre-replaced text again
+                // turned every line break into a literal backslash-n in the loaded text).
+                sb.Append("\"content\":\"" + Json.EncodeJsonText(p.Text, "\\n") + "\"");
                 sb.Append(" }");
                 count++;
             }

--- a/src/libse/SubtitleFormats/DvdSubtitleSystem.cs
+++ b/src/libse/SubtitleFormats/DvdSubtitleSystem.cs
@@ -56,6 +56,13 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             _errorCount = 0;
             foreach (string line in lines)
             {
+                // A blank line (e.g. the trailing newline every saved file has) is not an
+                // error - charging it 10 made IsMine reject files with < 11 subtitles.
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    continue;
+                }
+
                 // line must contain atleast 24 characters (time-code)...
                 if (line.Length < 24)
                 {

--- a/src/libse/SubtitleFormats/F4Text.cs
+++ b/src/libse/SubtitleFormats/F4Text.cs
@@ -82,17 +82,26 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             {
                 if (RegexTimeCodes.IsMatch(line))
                 {
+                    if (p == null && currentText.Length > 0)
+                    {
+                        // Text before the first time stamp: the stamp is that utterance's END
+                        // time (this used to add the paragraph with 0 -> 0 times and leave the
+                        // text in the buffer, so it was repeated in the following paragraph).
+                        p = new Paragraph();
+                        p.Text = currentText.ToString().Trim().Replace(Environment.NewLine + Environment.NewLine, Environment.NewLine);
+                        p.Text = p.Text.Trim('\n', '\r');
+                        p.EndTime = DecodeTimeCode(line.Split(new[] { ':', '-' }, StringSplitOptions.RemoveEmptyEntries));
+                        subtitle.Paragraphs.Add(p);
+                        p = null;
+                        currentText.Clear();
+                        continue;
+                    }
+
                     if (p == null)
                     {
                         p = new Paragraph();
-                        if (currentText.Length > 0)
-                        {
-                            p.Text = currentText.ToString().Trim().Replace(Environment.NewLine + Environment.NewLine, Environment.NewLine);
-                            p.Text = p.Text.Trim('\n', '\r');
-                            subtitle.Paragraphs.Add(p);
-                            p = new Paragraph();
-                        }
                     }
+
                     if (Math.Abs(p.StartTime.TotalMilliseconds) < 0.01 || currentText.Length == 0)
                     {
                         p.StartTime = DecodeTimeCode(line.Split(new[] { ':', '-' }, StringSplitOptions.RemoveEmptyEntries));

--- a/src/libse/SubtitleFormats/FlashXml.cs
+++ b/src/libse/SubtitleFormats/FlashXml.cs
@@ -146,7 +146,16 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     }
                     startSeconds = endCode.TotalSeconds;
 
-                    subtitle.Paragraphs.Add(new Paragraph(startCode, endCode, pText.ToString().Replace("<sub>", string.Empty).Replace("</sub>", string.Empty)));
+                    // The text usually arrives as one CDATA block ("<sub>line one<br />line two</sub>"),
+                    // so the <br/> line breaks are part of the raw text - the child-node walk above
+                    // only sees real <br> elements, never these.
+                    var textValue = pText.ToString()
+                        .Replace("<sub>", string.Empty)
+                        .Replace("</sub>", string.Empty)
+                        .Replace("<br />", Environment.NewLine)
+                        .Replace("<br/>", Environment.NewLine)
+                        .Replace("<br>", Environment.NewLine);
+                    subtitle.Paragraphs.Add(new Paragraph(startCode, endCode, textValue));
                 }
                 catch (Exception ex)
                 {

--- a/src/libse/SubtitleFormats/InqScribe.cs
+++ b/src/libse/SubtitleFormats/InqScribe.cs
@@ -18,6 +18,23 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override string ToText(Subtitle subtitle, string title)
         {
+            // The template declares "timecode.fps=30" and readers (including LoadSubtitle
+            // below) decode the HH:MM:SS.FF frames at that declared rate - so the frames
+            // must also be written at 30 fps, not at whatever video happens to be open.
+            var savedFrameRate = Configuration.Settings.General.CurrentFrameRate;
+            Configuration.Settings.General.CurrentFrameRate = 30;
+            try
+            {
+                return ToTextAtDeclaredFrameRate(subtitle);
+            }
+            finally
+            {
+                Configuration.Settings.General.CurrentFrameRate = savedFrameRate;
+            }
+        }
+
+        private static string ToTextAtDeclaredFrameRate(Subtitle subtitle)
+        {
             var template = @"app=InqScribe
 cache.mediastart=[START]
 cache.mediaend=[END]
@@ -64,6 +81,13 @@ version=1.1
                         {
                             sb.Append($"[{EncodeTimeCode(paragraph.EndTime)}]\\r\\r");
                         }
+                    }
+                    else
+                    {
+                        // The last paragraph has no following start time to imply its end,
+                        // so it needs an explicit end stamp - without one, readers (including
+                        // LoadSubtitle below) can only guess a duration.
+                        sb.Append($"[{EncodeTimeCode(paragraph.EndTime)}]\\r");
                     }
                 }
 

--- a/src/libse/SubtitleFormats/JsonType13.cs
+++ b/src/libse/SubtitleFormats/JsonType13.cs
@@ -93,14 +93,18 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             {
                 var duration = Json.ReadTag(s, "duration");
                 var start = Json.ReadTag(s, "time");
-                var text = Json.ReadTag(s, "name");
+                // ToText encodes with Json.EncodeJsonText ("<br />" line breaks, escaped
+                // quotes...), so the text must be decoded again on the way in.
+                var text = Json.DecodeJsonText(Json.ReadTag(s, "name") ?? string.Empty);
                 bool skip = false;
                 if (!string.IsNullOrEmpty(duration) && !string.IsNullOrEmpty(start) && !string.IsNullOrEmpty(text) &&
                     double.TryParse(start, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out double startSeconds) &&
                     double.TryParse(duration, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out double durationSeconds))
                 {
                     var startMilliseconds = TimeSpan.FromSeconds(startSeconds).TotalMilliseconds;
-                    var p = new Paragraph(text, startMilliseconds, startMilliseconds + TimeSpan.FromSeconds(durationSeconds).Milliseconds);
+                    // TotalMilliseconds, not Milliseconds - the latter is only the 0-999 component,
+                    // so any whole-second duration collapsed the line to zero length.
+                    var p = new Paragraph(text, startMilliseconds, startMilliseconds + TimeSpan.FromSeconds(durationSeconds).TotalMilliseconds);
                     if (p.Text != null && (p.Text == "." || p.Text == "?" || p.Text == "!"))
                     {
                         var last = subtitle.Paragraphs.LastOrDefault();

--- a/src/libse/SubtitleFormats/JsonType16.cs
+++ b/src/libse/SubtitleFormats/JsonType16.cs
@@ -89,7 +89,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     }
                     else
                     {
-                        var p = new Paragraph(texts[0], startTime, endTime);
+                        // ToText encodes with Json.EncodeJsonText ("<br />" line breaks, escaped
+                        // quotes...), so the text must be decoded again on the way in.
+                        var p = new Paragraph(Json.DecodeJsonText(texts[0]), startTime, endTime);
                         subtitle.Paragraphs.Add(p);
                     }
                 }

--- a/src/libse/SubtitleFormats/NetflixImsc11Japanese.cs
+++ b/src/libse/SubtitleFormats/NetflixImsc11Japanese.cs
@@ -97,20 +97,33 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override string ToText(Subtitle subtitle, string title)
         {
-            var xml = new XmlDocument { XmlResolver = null };
-            xml.LoadXml(GetXmlStructure());
-            var namespaceManager = new XmlNamespaceManager(xml.NameTable);
-            namespaceManager.AddNamespace("ttml", "http://www.w3.org/ns/ttml");
-            var div = xml.DocumentElement.SelectSingleNode("ttml:body", namespaceManager).SelectSingleNode("ttml:div", namespaceManager);
-            foreach (var p in subtitle.Paragraphs)
+            // The fixed template header declares ttp:frameRate 24 with multiplier 1000/1001,
+            // and readers (including SE's own) parse the HH:MM:SS:FF frames part at that
+            // declared 23.976 - so the frames must also be WRITTEN at 23.976, not at whatever
+            // video happens to be open (a 29.97 video shifted every written time code).
+            var savedFrameRate = Configuration.Settings.General.CurrentFrameRate;
+            Configuration.Settings.General.CurrentFrameRate = 23.976;
+            try
             {
-                var paragraphNode = MakeParagraph(xml, p);
-                div.AppendChild(paragraphNode);
-            }
+                var xml = new XmlDocument { XmlResolver = null };
+                xml.LoadXml(GetXmlStructure());
+                var namespaceManager = new XmlNamespaceManager(xml.NameTable);
+                namespaceManager.AddNamespace("ttml", "http://www.w3.org/ns/ttml");
+                var div = xml.DocumentElement.SelectSingleNode("ttml:body", namespaceManager).SelectSingleNode("ttml:div", namespaceManager);
+                foreach (var p in subtitle.Paragraphs)
+                {
+                    var paragraphNode = MakeParagraph(xml, p);
+                    div.AppendChild(paragraphNode);
+                }
 
-            var xmlString = ToUtf8XmlString(xml).Replace(" xmlns=\"\"", string.Empty);
-            subtitle.Header = xmlString;
-            return xmlString;
+                var xmlString = ToUtf8XmlString(xml).Replace(" xmlns=\"\"", string.Empty);
+                subtitle.Header = xmlString;
+                return xmlString;
+            }
+            finally
+            {
+                Configuration.Settings.General.CurrentFrameRate = savedFrameRate;
+            }
         }
 
         private static XmlNode MakeParagraph(XmlDocument xml, Paragraph p)

--- a/src/libse/SubtitleFormats/OresmeDocXDocument.cs
+++ b/src/libse/SubtitleFormats/OresmeDocXDocument.cs
@@ -255,7 +255,15 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             {
                 subtitle.Paragraphs[i].EndTime.TotalMilliseconds = subtitle.Paragraphs[i + 1].StartTime.TotalMilliseconds;
             }
-            subtitle.Paragraphs[subtitle.Paragraphs.Count - 1].EndTime.TotalMilliseconds = 2500;
+            if (subtitle.Paragraphs.Count > 0)
+            {
+                // The last row has no following time code; give it a default duration
+                // (this used to assign an ABSOLUTE 2500 ms, putting the last line's end
+                // before its start - and crashed on documents with no rows at all).
+                var last = subtitle.Paragraphs[subtitle.Paragraphs.Count - 1];
+                last.EndTime.TotalMilliseconds = last.StartTime.TotalMilliseconds + 2500;
+            }
+
             subtitle.RemoveEmptyLines();
             for (int i = 0; i < subtitle.Paragraphs.Count - 1; i++)
             {

--- a/src/libse/SubtitleFormats/QubeMasterImport.cs
+++ b/src/libse/SubtitleFormats/QubeMasterImport.cs
@@ -70,7 +70,11 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             }
                             else
                             {
-                                if (p.EndTime.TotalMilliseconds < 0.01)
+                                // An end time is only unexpected when one was ALREADY read for this
+                                // entry. The old check was inverted (it flagged the normal "end not
+                                // set yet" case), so every well-formed entry counted as an error and
+                                // IsMine (paragraphs > errors) could never detect the format.
+                                if (p.EndTime.TotalMilliseconds > 0.01)
                                 {
                                     _errorCount++;
                                 }

--- a/src/libse/SubtitleFormats/Rtf1.cs
+++ b/src/libse/SubtitleFormats/Rtf1.cs
@@ -97,17 +97,22 @@ TimeCode Format: " + Configuration.Settings.General.CurrentFrameRate + @" frames
                 {
                     p.Text = (p.Text + Environment.NewLine + s.TrimStart()).Trim();
                 }
-                else if (s.Length > 0)
+                else if (s.Length > 0 && subtitle.Paragraphs.Count > 0)
                 {
                     _errorCount++;
                 }
+                // else: the header block before the first time code ("[Header]", "Frame
+                // Rate: ..." - every file starts with it) - counting it as errors made
+                // IsMine (paragraphs > errors) reject files with only a few subtitles.
             }
             if (p != null)
             {
                 subtitle.Paragraphs.Add(p);
             }
 
-            if (subtitle.Paragraphs.Count > 0)
+            // Only fill in a MISSING end time (as Rtf2 does) - unconditionally recomputing
+            // overwrote the real end time the last time-code line supplied.
+            if (subtitle.Paragraphs.Count > 0 && subtitle.Paragraphs[subtitle.Paragraphs.Count - 1].DurationTotalMilliseconds < 0.01)
             {
                 p = subtitle.Paragraphs[subtitle.Paragraphs.Count - 1];
                 p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + Utilities.GetOptimalDisplayMilliseconds(p.Text);

--- a/src/libse/SubtitleFormats/Rtf2.cs
+++ b/src/libse/SubtitleFormats/Rtf2.cs
@@ -90,10 +90,13 @@ TimeCode Format: " + Configuration.Settings.General.CurrentFrameRate + @" frames
                 {
                     p.Text = (p.Text + Environment.NewLine + s.TrimStart()).Trim();
                 }
-                else if (s.Length > 0)
+                else if (s.Length > 0 && subtitle.Paragraphs.Count > 0)
                 {
                     _errorCount++;
                 }
+                // else: the header block before the first time code ("[Header]", "Frame
+                // Rate: ..." - every file starts with it) - counting it as errors made
+                // IsMine (paragraphs > errors) reject files with only a few subtitles.
             }
             if (p != null)
             {

--- a/src/libse/SubtitleFormats/Titra.cs
+++ b/src/libse/SubtitleFormats/Titra.cs
@@ -104,10 +104,13 @@ ATTENTION : Pas plus de 40 caractères PAR LIGNE
                         p.Text = p.Text + Environment.NewLine + line;
                     }
                 }
-                else
+                else if (subtitle.Paragraphs.Count > 0)
                 {
                     _errorCount++;
                 }
+                // else: the Titra header block before the first time code (every file starts
+                // with ~10 such lines) - counting it as errors made IsMine (paragraphs >
+                // errors) reject any file with ten or fewer subtitles.
             }
 
             subtitle.Renumber();

--- a/src/libse/SubtitleFormats/VocapiaSplit.cs
+++ b/src/libse/SubtitleFormats/VocapiaSplit.cs
@@ -74,7 +74,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         private static string ToTimeCode(double totalMilliseconds)
         {
-            return $"{totalMilliseconds / TimeCode.BaseUnit:0##}";
+            // Seconds with decimals, like real Vocapia XML (stime="2.35") - the old integer
+            // format mask rounded every time code to whole seconds on save.
+            return (totalMilliseconds / TimeCode.BaseUnit).ToString("0.0##", CultureInfo.InvariantCulture);
         }
 
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)

--- a/src/ui/Features/Files/ImportCsvXlsxCustomColumns/ImportCsvXlsxCustomColumnsViewModel.cs
+++ b/src/ui/Features/Files/ImportCsvXlsxCustomColumns/ImportCsvXlsxCustomColumnsViewModel.cs
@@ -507,7 +507,9 @@ public partial class ImportCsvXlsxCustomColumnsViewModel : ObservableObject
         {
             return CsvColumnRole.Start;
         }
-        if (compact.StartsWith("end") || compact.StartsWith("to") || compact.StartsWith("stop"))
+        // No bare "to" prefix here: it also matched unrelated headers like "Total" or
+        // "Topic" - the common "to"/"toMs"/"toTime" spellings are in the exact-name set.
+        if (compact.StartsWith("end") || compact.StartsWith("stop"))
         {
             return CsvColumnRole.End;
         }

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1964,9 +1964,15 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
+        // The new line ends one gap BEFORE the selected line starts (this used to ADD the gap,
+        // overlapping the selected line - and setting EndTime before StartTime let the
+        // duration-preserving property cascade shrink the new line to gap length). StartTime
+        // must be set first, like InsertAfter does.
         var newItem = new BinarySubtitleItem(selectedItem);
-        newItem.EndTime = TimeSpan.FromMilliseconds(selectedItem.StartTime.TotalMilliseconds + Se.Settings.General.MinimumBetweenLines.GetMilliseconds());
-        newItem.StartTime = TimeSpan.FromMilliseconds(newItem.EndTime.TotalMilliseconds - Se.Settings.General.NewEmptyDefaultMs);
+        var newEndMs = Math.Max(selectedItem.StartTime.TotalMilliseconds - Se.Settings.General.MinimumBetweenLines.GetMilliseconds(), 0);
+        var newStartMs = Math.Max(newEndMs - Se.Settings.General.NewEmptyDefaultMs, 0);
+        newItem.StartTime = TimeSpan.FromMilliseconds(newStartMs);
+        newItem.EndTime = TimeSpan.FromMilliseconds(newEndMs);
         var selectedIndex = SubtitleGrid.SelectedIndex;
         Subtitles.Insert(selectedIndex, newItem);
         Renumber();
@@ -2598,12 +2604,15 @@ public partial class BinaryEditViewModel : ObservableObject
 
     private void PerformCleanup()
     {
+        // Always save the window position - it used to sit behind the video checks below,
+        // so closing without ever opening a video forgot the window placement.
+        UiUtil.SaveWindowPosition(Window);
+
         if (VideoPlayerControl == null)
             return;
         if (string.IsNullOrWhiteSpace(VideoPlayerControl.VideoPlayer.FileName))
             return;
         VideoPlayerControl.VideoPlayer.CloseFile();
-        UiUtil.SaveWindowPosition(Window);
     }
 
     public void Loaded()
@@ -2812,6 +2821,10 @@ public partial class BinaryEditViewModel : ObservableObject
                 }
             }
 
+            var firstRemovedIndex = itemsToRemove.Count > 0
+                ? itemsToRemove.Min(item => Subtitles.IndexOf(item))
+                : -1;
+
             foreach (var item in itemsToRemove)
             {
                 Subtitles.Remove(item);
@@ -2819,6 +2832,14 @@ public partial class BinaryEditViewModel : ObservableObject
             }
 
             Renumber();
+
+            // Keep a row selected after the delete (grid-removal invariant): the line that
+            // moved up into the gap, or the new last line when the tail was deleted.
+            if (Subtitles.Count > 0 && firstRemovedIndex >= 0)
+            {
+                SelectAndScrollToRow(Math.Min(firstRemovedIndex, Subtitles.Count - 1));
+            }
+
             RefreshStatusText();
 
             return;

--- a/src/ui/Features/Sync/VisualSync/VisualSyncViewModel.cs
+++ b/src/ui/Features/Sync/VisualSync/VisualSyncViewModel.cs
@@ -293,14 +293,14 @@ public partial class VisualSyncViewModel : ObservableObject
     [RelayCommand]
     private void LeftOneSecondForward()
     {
-        VideoPlayerControlLeft.Position = Math.Max(0, VideoPlayerControlLeft.Position + 1);
+        VideoPlayerControlLeft.Position = Math.Min(VideoPlayerControlLeft.Duration, VideoPlayerControlLeft.Position + 1);
         _updateAudioVisualizer = true;
     }
 
     [RelayCommand]
     private void RightOneSecondBack()
     {
-        VideoPlayerControlRight.Position = Math.Min(VideoPlayerControlRight.Duration, VideoPlayerControlRight.Position - 1);
+        VideoPlayerControlRight.Position = Math.Max(0, VideoPlayerControlRight.Position - 1);
         _updateAudioVisualizer = true;
     }
 
@@ -321,14 +321,14 @@ public partial class VisualSyncViewModel : ObservableObject
     [RelayCommand]
     private void LeftHalfSecondForward()
     {
-        VideoPlayerControlLeft.Position = Math.Max(0, VideoPlayerControlLeft.Position + 0.5);
+        VideoPlayerControlLeft.Position = Math.Min(VideoPlayerControlLeft.Duration, VideoPlayerControlLeft.Position + 0.5);
         _updateAudioVisualizer = true;
     }
 
     [RelayCommand]
     private void RightHalfSecondBack()
     {
-        VideoPlayerControlRight.Position = Math.Min(VideoPlayerControlRight.Duration, VideoPlayerControlRight.Position - 0.5);
+        VideoPlayerControlRight.Position = Math.Max(0, VideoPlayerControlRight.Position - 0.5);
         _updateAudioVisualizer = true;
     }
 

--- a/src/ui/Features/Video/BlankVideo/BlankVideoViewModel.cs
+++ b/src/ui/Features/Video/BlankVideo/BlankVideoViewModel.cs
@@ -172,7 +172,7 @@ public partial class BlankVideoViewModel : ObservableObject
                     MessageBoxButtons.OK,
                     MessageBoxIcon.Error);
 
-                IsGenerating = true;
+                IsGenerating = false;
                 ProgressValue = 0;
             });
 
@@ -503,6 +503,23 @@ public partial class BlankVideoViewModel : ObservableObject
         // The subtitle files handed to ffmpeg live as long as the window does - nothing else
         // removes them, and they used to pile up in the temp folder run after run (#13332).
         _tempSubtitleFiles.Delete();
+
+        // Stop the poll timer and any still-running encode - closing the window used to
+        // leave the ffmpeg process encoding to completion in the background.
+        _timerGenerate.StopAndDispose(TimerGenerateElapsed);
+        if (_ffmpegProcess != null && !_ffmpegProcess.HasExited)
+        {
+            try
+            {
+#pragma warning disable CA1416
+                _ffmpegProcess.Kill(true);
+#pragma warning restore CA1416
+            }
+            catch
+            {
+                // ignore - it may have exited in between
+            }
+        }
     }
 
     internal void OnKeyDown(KeyEventArgs e)
@@ -510,7 +527,9 @@ public partial class BlankVideoViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
-            Window?.Close();
+            // Route through Cancel so Escape during generation aborts the encode
+            // instead of closing the window over a running ffmpeg.
+            Cancel();
         }
         else if (UiUtil.IsHelp(e))
         {

--- a/tests/libse/SubtitleFormats/FormatRoundTripBugsTest.cs
+++ b/tests/libse/SubtitleFormats/FormatRoundTripBugsTest.cs
@@ -1,0 +1,190 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+
+namespace LibSETests.SubtitleFormats;
+
+/// <summary>
+/// Guard tests for write-then-read defects found by round-tripping every text based
+/// format through its own writer and reader (2026-08-27 bug hunt).
+/// </summary>
+public class FormatRoundTripBugsTest
+{
+    private static Subtitle MakeSubtitle()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Hello world.", 2000, 4000));
+        subtitle.Paragraphs.Add(new Paragraph("Second line here," + Environment.NewLine + "with a line break.", 6000, 9500));
+        subtitle.Paragraphs.Add(new Paragraph("Third - the last one.", 12000, 15000));
+        return subtitle;
+    }
+
+    private static Subtitle RoundTrip(SubtitleFormat format, Subtitle subtitle)
+    {
+        var text = format.ToText(subtitle, "title");
+        var target = new Subtitle();
+        format.LoadSubtitle(target, text.SplitToLines(), "test" + format.Extension);
+        return target;
+    }
+
+    [Fact]
+    public void JsonType13_Duration_UsesTotalMilliseconds()
+    {
+        // TimeSpan.FromSeconds(2).Milliseconds is 0 (the 0-999 component), so whole-second
+        // durations collapsed every line to zero length.
+        var target = RoundTrip(new JsonType13(), MakeSubtitle());
+
+        Assert.Equal(3, target.Paragraphs.Count);
+        Assert.Equal(4000, target.Paragraphs[0].EndTime.TotalMilliseconds, 3);
+        Assert.Equal("Second line here," + Environment.NewLine + "with a line break.", target.Paragraphs[1].Text);
+    }
+
+    [Fact]
+    public void JsonType16_Text_IsJsonDecodedOnRead()
+    {
+        var target = RoundTrip(new JsonType16(), MakeSubtitle());
+
+        Assert.Equal(3, target.Paragraphs.Count);
+        Assert.Equal("Second line here," + Environment.NewLine + "with a line break.", target.Paragraphs[1].Text);
+    }
+
+    [Fact]
+    public void Bilibili_LineBreaks_SurviveTheRoundTrip()
+    {
+        // The writer used to escape a pre-replaced "\n", so line breaks came back as a
+        // literal backslash-n in the text.
+        var target = RoundTrip(new Bilibili(), MakeSubtitle());
+
+        Assert.Equal(3, target.Paragraphs.Count);
+        Assert.Equal("Second line here," + Environment.NewLine + "with a line break.", target.Paragraphs[1].Text);
+    }
+
+    [Fact]
+    public void FlashXml_BrInsideCdata_BecomesALineBreak()
+    {
+        var target = RoundTrip(new FlashXml(), MakeSubtitle());
+
+        Assert.Equal(3, target.Paragraphs.Count);
+        Assert.Equal("Second line here," + Environment.NewLine + "with a line break.", target.Paragraphs[1].Text);
+    }
+
+    [Fact]
+    public void VocapiaSplit_Times_KeepSubSecondPrecision()
+    {
+        // The old integer format mask rounded every time code to whole seconds on save.
+        var target = RoundTrip(new VocapiaSplit(), MakeSubtitle());
+
+        Assert.Equal(3, target.Paragraphs.Count);
+        Assert.Equal(9500, target.Paragraphs[1].EndTime.TotalMilliseconds, 3);
+    }
+
+    [Fact]
+    public void InqScribe_LastParagraph_KeepsItsEndTime()
+    {
+        // The writer never emitted an end stamp for the last paragraph, so readers could
+        // only guess its duration.
+        var target = RoundTrip(new InqScribe(), MakeSubtitle());
+
+        Assert.Equal(3, target.Paragraphs.Count);
+        Assert.Equal(15000, target.Paragraphs[2].EndTime.TotalMilliseconds, 0);
+    }
+
+    [Fact]
+    public void InqScribe_Frames_AreWrittenAtTheDeclaredFps()
+    {
+        // The template declares timecode.fps=30 and the reader honors it - the writer used
+        // to compute frames at the globally loaded video's rate instead.
+        var savedFrameRate = Configuration.Settings.General.CurrentFrameRate;
+        try
+        {
+            Configuration.Settings.General.CurrentFrameRate = 23.976;
+            var format = new InqScribe();
+            var text = format.ToText(MakeSubtitle(), "title");
+            var target = new Subtitle();
+            format.LoadSubtitle(target, text.SplitToLines(), "test" + format.Extension);
+
+            Assert.Equal(3, target.Paragraphs.Count);
+            Assert.Equal(9500, target.Paragraphs[1].EndTime.TotalMilliseconds, 0);
+        }
+        finally
+        {
+            Configuration.Settings.General.CurrentFrameRate = savedFrameRate;
+        }
+    }
+
+    [Fact]
+    public void NetflixImsc11Japanese_Frames_AreWrittenAtTheDeclaredFrameRate()
+    {
+        // The fixed header declares 24 fps with a 1000/1001 multiplier; writing the frames
+        // at the open video's rate (e.g. 29.97) shifted every time code on read.
+        var savedFrameRate = Configuration.Settings.General.CurrentFrameRate;
+        try
+        {
+            Configuration.Settings.General.CurrentFrameRate = 29.97;
+            var format = new NetflixImsc11Japanese();
+            var text = format.ToText(MakeSubtitle(), "title");
+            var target = new Subtitle();
+            format.LoadSubtitle(target, text.SplitToLines(), "test" + format.Extension);
+
+            Assert.Equal(3, target.Paragraphs.Count);
+            Assert.Equal(9500, target.Paragraphs[1].EndTime.TotalMilliseconds, 0);
+        }
+        finally
+        {
+            Configuration.Settings.General.CurrentFrameRate = savedFrameRate;
+        }
+    }
+
+    [Fact]
+    public void OresmeDocXDocument_LastLine_EndsAfterItsStart()
+    {
+        // The last row's fallback end time was assigned as an ABSOLUTE 2500 ms, placing it
+        // before the line's own start.
+        var target = RoundTrip(new OresmeDocXDocument(), MakeSubtitle());
+
+        Assert.Equal(3, target.Paragraphs.Count);
+        var last = target.Paragraphs[2];
+        Assert.True(last.EndTime.TotalMilliseconds > last.StartTime.TotalMilliseconds,
+            $"last line: {last.StartTime} --> {last.EndTime}");
+    }
+
+    [Fact]
+    public void F4Text_LeadingText_GetsTheFirstStampAsEndTime()
+    {
+        // Text before the first stamp used to be added as a 0 -> 0 paragraph AND repeated
+        // inside the following paragraph.
+        var target = RoundTrip(new F4Text(), MakeSubtitle());
+
+        Assert.Equal(3, target.Paragraphs.Count);
+        Assert.Equal("Hello world.", target.Paragraphs[0].Text);
+        Assert.Equal(4000, target.Paragraphs[0].EndTime.TotalMilliseconds, 0);
+        Assert.DoesNotContain("Hello", target.Paragraphs[1].Text);
+    }
+
+    [Theory]
+    [InlineData(typeof(QubeMasterImport))]
+    [InlineData(typeof(Titra))]
+    [InlineData(typeof(DvdSubtitleSystem))]
+    [InlineData(typeof(Rtf1))]
+    [InlineData(typeof(Rtf2))]
+    public void IsMine_RecognizesTheFormatsOwnOutput(Type formatType)
+    {
+        // Header/blank lines (or, for QubeMaster, an inverted end-time guard) were counted
+        // as errors, so short files in these formats were never auto-detected.
+        var format = (SubtitleFormat)Activator.CreateInstance(formatType)!;
+        var text = format.ToText(MakeSubtitle(), "title");
+
+        Assert.True(format.IsMine(text.SplitToLines(), "test" + format.Extension),
+            format.Name + " does not recognize its own output");
+    }
+
+    [Fact]
+    public void Rtf1_LastLine_KeepsItsRealEndTime()
+    {
+        // The tail fix-up overwrote the last line's end time with an "optimal" duration
+        // even though the time-code line supplied one (Rtf2 already guarded this).
+        var target = RoundTrip(new Rtf1(), MakeSubtitle());
+
+        Assert.Equal(3, target.Paragraphs.Count);
+        Assert.Equal(15000, target.Paragraphs[2].EndTime.TotalMilliseconds, 0);
+    }
+}


### PR DESCRIPTION
Ninth general bug-hunt sweep. Two hunting grounds this time: the remaining unswept UI dialogs (binary edit, blank video, visual sync, CSV custom-column import), and a new **round-trip harness** that ran all 344 text-based subtitle formats through their own writer + reader and flagged every format that lost or shifted content. 24 findings, all fixed, with 16 new guard tests.

## Subtitle formats (15)

The harness compared write→read against the source subtitle with tolerances for by-design losses (frame precision, no-end-time formats, single-line formats). After filtering the by-design cases, these survived as real defects:

- **JSON Type 13**: `TimeSpan.FromSeconds(x).Milliseconds` — the 0–999 *component* — instead of `TotalMilliseconds`, so whole-second durations collapsed every line to zero length; the text was also returned raw, without JSON decoding.
- **JSON Type 16**: text not JSON-decoded on read — literal `<br />` and escape sequences ended up in the subtitle.
- **Bilibili json**: line breaks were pre-replaced with `\n` and then escaped *again* by the JSON encoder, coming back as literal backslash-n text.
- **Flash XML**: the text ships inside CDATA, so the reader's `<br>`-element branch never fired and literal `<br />` stayed in the text.
- **Vocapia Split**: the time format mask (`0##`) rounded every time code to whole seconds on save.
- **InqScribe**: the last paragraph's end stamp was never written (readers can only guess), and the frame fields were computed at the open video's frame rate while the file declares `timecode.fps=30`.
- **Netflix IMSC 1.1 Japanese**: same class — the fixed header declares 24000/1001 but frames were written at the global current frame rate, shifting every time code when read back (the reader honors the declared rate).
- **Oresme Docx**: the last row's fallback end time was assigned an **absolute** 2500 ms — end before start — and the assignment crashed on documents with no rows.
- **F4 Text / F4 RTF**: text before the first inline stamp was added as a 0→0 paragraph and the un-cleared buffer repeated that text inside the following paragraph. The first stamp is now that utterance's end time.
- **QubeMasterPro Import**: an inverted end-time guard counted every *well-formed* entry as an error, making `IsMine` (paragraphs > errors) reject the format **always** — auto-detection has never worked (the inversion is inherited from SE4).
- **Titra / RTF 1 / RTF 2**: each format's own mandatory header block was counted as errors, so files with only a few subtitles were never auto-detected.
- **DVD Subtitle System**: a blank line (every saved file ends with one) cost 10 error points, so files with fewer than 11 subtitles failed detection.
- **RTF 1**: the tail fix-up overwrote the last line's *real* end time with an "optimal" duration — Rtf2 has the missing guard, classic sibling-clone drift.
- **Unknown-format XML importer** (new in #14179): `<br/>` was matched on the prefixed `Name` while all other inline tags use `LocalName`, so prefixed dialects (`<tt:br/>`) lost their line breaks.

## Binary edit (3)

- **Insert before** built an overlapping cue: it *added* the minimum gap to the selected line's start (instead of subtracting), and setting EndTime before StartTime let `BinarySubtitleItem`'s duration-preserving property cascade shrink the new cue to gap length (~83 ms) at the wrong spot. Now mirrors Insert after's math and order.
- The window position was only saved when a video had been opened (the save sat behind the video-player early-returns).
- Deleting lines left the grid with no selection — now selects the survivor at the deletion point, per the grid-removal invariant (PR #13968).

## Blank video (2)

- A failed generation set `IsGenerating = true` in the error path, wedging the dialog — the same copy/paste class as the CutVideo/ReEncode fixes in #14180; this was the fourth sibling.
- Escape during generation closed the window over the still-running ffmpeg process (now routes through Cancel/abort), and the generate poll timer was never disposed on close.

## Visual sync (1)

- The nudge buttons clamp the wrong ends: right-player "back" clamped to the *duration* (allowing negative positions) and left-player "forward" clamped to *zero* (allowing past-the-end). All four now clamp both ends correctly.

## CSV/xlsx custom-column import (1)

- Any header starting with "to" — e.g. "Total", "Topic" — auto-mapped to the End-time role via the loose prefix match. The prefix is removed; the exact-name set ("to", "toMs", "toTime", …) still matches.

## Tests

Suites green: libse 1570 (16 new round-trip guard tests), libuilogic 703, seconv 416, UI 4143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)