### PR TITLE
Fix 21 bugs found in a random bug hunt

### DIFF
--- a/src/libse/SubtitleFormats/Bilibili.cs
+++ b/src/libse/SubtitleFormats/Bilibili.cs
@@ -81,7 +81,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     }
                     else
                     {
-                        var pText = texts[0].Replace("\\n", Environment.NewLine);
+                        // Full JSON decode (escaped quotes/backslashes too), not just the
+                        // newline placeholder ToText writes.
+                        var pText = Json.DecodeJsonText(texts[0]);
                         var p = new Paragraph(pText, startTime, endTime);
                         subtitle.Paragraphs.Add(p);
                     }

--- a/src/libse/SubtitleFormats/Csv3.cs
+++ b/src/libse/SubtitleFormats/Csv3.cs
@@ -1,6 +1,7 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -75,18 +76,23 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             sb.AppendLine(string.Format(format, Separator, "Start time (hh:mm:ss:ff)", "End time (hh:mm:ss:ff)", "Line 1", "Line 2"));
             foreach (Paragraph p in subtitle.Paragraphs)
             {
+                // The format has two text columns, so rebalance at THREE lines - the old
+                // ">3" guard let a three-line subtitle through and then wrote only the first
+                // two lines, silently dropping the third.
                 var arr = p.Text.Trim().SplitToLines();
-                if (arr.Count > 3)
+                if (arr.Count > 2)
                 {
                     string s = Utilities.AutoBreakLine(p.Text);
                     arr = s.Trim().SplitToLines();
                 }
-                string line1 = string.Empty;
+
+                string line1 = arr[0];
                 string line2 = string.Empty;
-                line1 = arr[0];
                 if (arr.Count > 1)
                 {
-                    line2 = arr[1];
+                    // Anything that still does not fit in two lines is appended to the second
+                    // column rather than thrown away.
+                    line2 = string.Join(" ", arr.Skip(1));
                 }
 
                 line1 = line1.Replace("\"", "\"\"");
@@ -142,8 +148,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 return string.Empty;
             }
 
-            csv = csv.Replace("\"\"", "\"");
-
+            // No pre-collapse of "" here: ToText escapes an embedded quote by doubling it, and
+            // collapsing before the walk below left the loop unable to tell an escaped quote
+            // from a field delimiter - so quoted words came back with their quotes eaten.
             var sb = new StringBuilder();
             csv = csv.Trim();
             if (csv.StartsWith('"'))
@@ -160,9 +167,11 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             for (int i = 0; i < csv.Length; i++)
             {
                 var s = csv[i];
-                if (s == '"' && csv.Substring(i).StartsWith("\"\"", StringComparison.Ordinal))
+                if (s == '"' && i + 1 < csv.Length && csv[i + 1] == '"')
                 {
+                    // An escaped quote - emit one and consume BOTH characters.
                     sb.Append('"');
+                    i++;
                 }
                 else if (s == '"')
                 {

--- a/src/libse/SubtitleFormats/ESubXf.cs
+++ b/src/libse/SubtitleFormats/ESubXf.cs
@@ -290,6 +290,17 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var ns = new XmlNamespaceManager(xml.NameTable);
             ns.AddNamespace("esub-xf", NameSpaceUri);
             var isTimebaseSmtp = xml.DocumentElement.Attributes["timebase"]?.Value != "msec"; // "msec" or "smtp"
+
+            // The file declares the frame rate its SMPTE time codes were written at (ToText
+            // writes it) - honor it, or the frames are decoded at whatever rate happens to be
+            // loaded and every time code shifts.
+            var frameRateAttribute = xml.DocumentElement.Attributes["framerate"]?.Value;
+            if (isTimebaseSmtp && !string.IsNullOrEmpty(frameRateAttribute) &&
+                double.TryParse(frameRateAttribute, NumberStyles.Float, CultureInfo.InvariantCulture, out var declaredFrameRate) &&
+                declaredFrameRate > 1 && declaredFrameRate < 200)
+            {
+                Configuration.Settings.General.CurrentFrameRate = declaredFrameRate;
+            }
             foreach (XmlNode node in xml.DocumentElement.SelectNodes("//esub-xf:subtitlelist/esub-xf:subtitle", ns))
             {
                 try

--- a/src/libse/SubtitleFormats/FinalCutProXml15.cs
+++ b/src/libse/SubtitleFormats/FinalCutProXml15.cs
@@ -320,6 +320,21 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         styles.Add(newStyle);
                         i += 6;
                     }
+                    else
+                    {
+                        // Any other tag - <u> has no FCP style equivalent, and unknown markup
+                        // must not be mangled: skip the whole tag. Falling through here used
+                        // to consume only the '<', leaving "u>underline/u>" in the text.
+                        var tagEnd = subIText.IndexOf('>');
+                        if (tagEnd > 0 && tagEnd <= 20 && subIText.IndexOf('<', 1) is var nextOpen && (nextOpen < 0 || nextOpen > tagEnd))
+                        {
+                            i += tagEnd;
+                        }
+                        else
+                        {
+                            sb.Append(ch); // a stray '<' that is not a tag
+                        }
+                    }
                 }
                 AddTextAndStyle(styles, sb, styleTextPairs);
                 WriteCurrentTextSegment(styles, styleTextPairs, video, number++, sbTrimmedTitle.ToString(), xml);

--- a/src/libse/SubtitleFormats/FlashXml.cs
+++ b/src/libse/SubtitleFormats/FlashXml.cs
@@ -65,8 +65,18 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 XmlNode paragraph = xml.CreateElement("p");
                 string text = HtmlUtil.RemoveHtmlTags(p.Text, true);
 
-                paragraph.InnerText = text;
-                paragraph.InnerXml = "<![CDATA[<sub>" + paragraph.InnerXml.Replace(Environment.NewLine, "<br />") + "</sub>]]>";
+                // Build the CDATA from the RAW text: going through InnerText first escaped it
+                // ("Tom &amp; Jerry"), and since CDATA content is not parsed those entities
+                // came back literally on read.
+                var cdataText = text.Replace(Environment.NewLine, "<br />");
+                if (cdataText.Contains("]]>", StringComparison.Ordinal))
+                {
+                    paragraph.InnerText = cdataText; // cannot be expressed in one CDATA section
+                }
+                else
+                {
+                    paragraph.InnerXml = "<![CDATA[<sub>" + cdataText + "</sub>]]>";
+                }
 
                 XmlAttribute start = xml.CreateAttribute("begin");
                 start.InnerText = ConvertToTimeString(p.StartTime);

--- a/src/libse/SubtitleFormats/JsonAeneas.cs
+++ b/src/libse/SubtitleFormats/JsonAeneas.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Text;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
@@ -75,7 +76,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 if (decimal.TryParse(startTime, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var startSeconds) &&
                     decimal.TryParse(endTime, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var endSeconds))
                 {
-                    var text = string.Join(Environment.NewLine, texts);
+                    // ToText escapes with Json.EncodeJsonText, so decode on the way in -
+                    // otherwise quotes/backslashes come back escaped ("She said \\"hello\\"").
+                    var text = string.Join(Environment.NewLine, texts.Select(Json.DecodeJsonText));
                     var p = new Paragraph(text, (double)startSeconds * 1000.0, (double)endSeconds * 1000.0);
                     subtitle.Paragraphs.Add(p);
                 }

--- a/src/libse/SubtitleFormats/JsonType17.cs
+++ b/src/libse/SubtitleFormats/JsonType17.cs
@@ -1,6 +1,7 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
@@ -74,7 +75,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 {
                     if (long.TryParse(startTimeObject, out var startMs) && long.TryParse(endTimeObject, out var endMs))
                     {
-                        var p = new Paragraph(string.Join(Environment.NewLine, texts), startMs, endMs);
+                        // ToText escapes with Json.EncodeJsonText, so decode on the way in.
+                        var p = new Paragraph(string.Join(Environment.NewLine, texts.Select(Json.DecodeJsonText)), startMs, endMs);
                         subtitle.Paragraphs.Add(p);
                     }
                     else

--- a/src/libse/SubtitleFormats/JsonType6.cs
+++ b/src/libse/SubtitleFormats/JsonType6.cs
@@ -165,9 +165,29 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
                 }
             }
+            // The loop above stops at Count - 1, so the final word is only ever seen as
+            // "next" - add it here, or the last subtitle loses its last word.
+            var lastWord = subtitle.Paragraphs.Count > 0 ? subtitle.Paragraphs[subtitle.Paragraphs.Count - 1] : null;
+            if (lastWord != null && !string.IsNullOrWhiteSpace(lastWord.Text))
+            {
+                if (sb.Length == 0)
+                {
+                    startMilliseconds = lastWord.StartTime.TotalMilliseconds;
+                }
+
+                sb.Append(' ');
+                sb.Append(lastWord.Text);
+            }
+
             if (sb.Length > 0)
             {
-                var newParagraph = new Paragraph(sb.ToString().Trim(), startMilliseconds, Utilities.GetOptimalDisplayMilliseconds(sb.ToString()));
+                // GetOptimalDisplayMilliseconds is a DURATION - using it as the absolute end
+                // time put the last subtitle's end before its own start.
+                var lastText = sb.ToString().Trim();
+                var endMilliseconds = lastWord != null && lastWord.EndTime.TotalMilliseconds > startMilliseconds
+                    ? lastWord.EndTime.TotalMilliseconds
+                    : startMilliseconds + Utilities.GetOptimalDisplayMilliseconds(lastText);
+                var newParagraph = new Paragraph(lastText, startMilliseconds, endMilliseconds);
                 sub.Paragraphs.Add(newParagraph);
             }
 

--- a/src/libse/SubtitleFormats/KanopyHtml.cs
+++ b/src/libse/SubtitleFormats/KanopyHtml.cs
@@ -93,10 +93,17 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     if (index > 0 && index + 7 < line.Length)
                     {
                         text = line.Substring(index + 7).Trim().Replace("</p>", string.Empty);
-                        index = text.IndexOf("</", StringComparison.Ordinal);
-                        if (index > 0)
+
+                        // Only the trailing wrapper (</a>, </div>) is stripped. Cutting at the
+                        // FIRST "</" threw away everything after an inline closing tag, so a
+                        // line like "then <i>italic</i> here." lost "</i> here.".
+                        foreach (var wrapper in new[] { "</a>", "</div>", "</span>" })
                         {
-                            text = text.Substring(0, index);
+                            if (text.EndsWith(wrapper, StringComparison.OrdinalIgnoreCase))
+                            {
+                                text = text.Substring(0, text.Length - wrapper.Length).TrimEnd();
+                                break;
+                            }
                         }
 
                         text = text.Replace("<br />", Environment.NewLine);

--- a/src/libse/SubtitleFormats/SoftNiColonSub.cs
+++ b/src/libse/SubtitleFormats/SoftNiColonSub.cs
@@ -95,7 +95,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 sb.AppendLine($"{text}{Environment.NewLine}{p.StartTime.ToHHMMSSPeriodFF().Replace(".", ":")}\\{p.EndTime.ToHHMMSSPeriodFF().Replace(".", ":")}");
             }
 
-            var last = subtitle.Paragraphs.Last();
+            // LastOrDefault, not Last: an empty subtitle threw "Sequence contains no
+            // elements" out of the writer (the null check right below shows null was
+            // always the intended empty case).
+            var last = subtitle.Paragraphs.LastOrDefault();
             if (last == null)
             {
                 sb.AppendLine("*END*");

--- a/src/libse/SubtitleFormats/UTSubtitleXml.cs
+++ b/src/libse/SubtitleFormats/UTSubtitleXml.cs
@@ -39,8 +39,19 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 st.InnerText = string.Format("{0:0.0##}", p.StartTime.TotalSeconds).Replace(",", ".");
                 ut.Attributes.Append(st);
 
-                ut.InnerText = p.Text;
-                ut.InnerXml = "<![CDATA[" + ut.InnerXml.Replace(Environment.NewLine, "<br>") + "]]>";
+                // Build the CDATA from the RAW text: going through InnerText first escaped the
+                // markup ("&lt;i&gt;"), and since CDATA content is not parsed those entities
+                // came back literally, turning every <i> into "&lt;i&gt;" on read.
+                var cdataText = p.Text.Replace(Environment.NewLine, "<br>");
+                if (cdataText.Contains("]]>", StringComparison.Ordinal))
+                {
+                    // Cannot be expressed in one CDATA section - fall back to escaped text.
+                    ut.InnerText = cdataText;
+                }
+                else
+                {
+                    ut.InnerXml = "<![CDATA[" + cdataText + "]]>";
+                }
 
                 root.AppendChild(ut);
             }

--- a/src/libse/SubtitleFormats/UnknownSubtitle101.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle101.cs
@@ -19,7 +19,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             var sb = new StringBuilder();
             const string writeFormat = "{0} ===> {1}                    {4}{2}{3}{2}";
-            var last = subtitle.Paragraphs.Last();
+            // LastOrDefault, not Last: an empty subtitle threw "Sequence contains no
+            // elements" out of the writer (the null check right below shows null was
+            // always the intended empty case).
+            var last = subtitle.Paragraphs.LastOrDefault();
             for (var index = 0; index < subtitle.Paragraphs.Count; index++)
             {
                 var p = subtitle.Paragraphs[index];

--- a/src/ui/Features/Assa/AssaSetPosition/AssaSetPositionViewModel.cs
+++ b/src/ui/Features/Assa/AssaSetPosition/AssaSetPositionViewModel.cs
@@ -222,7 +222,7 @@ public partial class AssaSetPositionViewModel : ObservableObject
 
         if (TargetWidth <= 0 || TargetHeight <= 0)
         {
-            TargetWidth = 1820;
+            TargetWidth = 1920;
             TargetHeight = 1080;
         }
 

--- a/src/ui/Features/Files/ManualChosenEncoding/ManualChosenEncodingViewModel.cs
+++ b/src/ui/Features/Files/ManualChosenEncoding/ManualChosenEncodingViewModel.cs
@@ -198,4 +198,14 @@ public partial class ManualChosenEncodingViewModel : ObservableObject, IClosingC
     {
         _dirty = true;
     }
+
+    /// <summary>
+    /// OK needs both a readable file and a selected encoding. A search that matches nothing
+    /// clears the list (and with it the bound selection), which used to leave OK enabled and
+    /// silently doing nothing - the caller ignores a null encoding.
+    /// </summary>
+    partial void OnSelectedEncodingChanged(TextEncoding? value)
+    {
+        IsOkEnabled = value != null && _fileBuffer.Length > 0;
+    }
 }

--- a/src/ui/Features/Files/RestoreAutoBackup/RestoreAutoBackupViewModel.cs
+++ b/src/ui/Features/Files/RestoreAutoBackup/RestoreAutoBackupViewModel.cs
@@ -93,14 +93,31 @@ public partial class RestoreAutoBackupViewModel : ObservableObject
             return;
         }
 
+        // A single locked/read-only file must not abort the sweep and leave the list
+        // claiming everything was deleted - keep what could not be removed.
+        var remaining = new List<DisplayFile>();
         foreach (var file in Files)
         {
-            File.Delete(file.FullPath);
+            try
+            {
+                File.Delete(file.FullPath);
+            }
+            catch (System.Exception exception)
+            {
+                Se.LogError(exception, "Could not delete auto-backup file " + file.FullPath);
+                remaining.Add(file);
+            }
         }
 
         Files.Clear();
-        IsEmptyFilesVisible = false;
-        IsOkButtonEnabled = false;
+        foreach (var file in remaining)
+        {
+            Files.Add(file);
+        }
+
+        IsEmptyFilesVisible = Files.Count > 0;
+        SelectedFile = Files.FirstOrDefault();
+        IsOkButtonEnabled = SelectedFile != null;
     }
 
     [RelayCommand]
@@ -166,8 +183,18 @@ public partial class RestoreAutoBackupViewModel : ObservableObject
         }
     }
 
+    /// <summary>
+    /// Follows the selection itself instead of only the grid's SelectionChanged event: the
+    /// row the grid picks on its own (AlwaysSelected) raises no event, which left Restore
+    /// disabled while row 0 looked selected.
+    /// </summary>
+    partial void OnSelectedFileChanged(DisplayFile? value)
+    {
+        IsOkButtonEnabled = value != null;
+    }
+
     public void GridSelectionChanged(object? sender, SelectionChangedEventArgs e)
     {
-        IsOkButtonEnabled = e.AddedItems.Count > 0;
+        IsOkButtonEnabled = SelectedFile != null;
     }
 }

--- a/src/ui/Features/Video/EmbeddedSubtitlesEdit/EmbeddedSubtitlesEditMp4ViewModel.cs
+++ b/src/ui/Features/Video/EmbeddedSubtitlesEdit/EmbeddedSubtitlesEditMp4ViewModel.cs
@@ -629,6 +629,23 @@ public partial class EmbeddedSubtitlesEditMp4ViewModel : ObservableObject
     internal void OnClosing()
     {
         UiUtil.SaveWindowPosition(Window);
+
+        // Stop the poll timer and any still-running encode - closing the window used to
+        // leave the ffmpeg process muxing to completion in the background.
+        _timerGenerate.StopAndDispose(TimerGenerateElapsed);
+        if (_ffmpegProcess != null && !_ffmpegProcess.HasExited)
+        {
+            try
+            {
+#pragma warning disable CA1416
+                _ffmpegProcess.Kill(true);
+#pragma warning restore CA1416
+            }
+            catch
+            {
+                // ignore - it may have exited in between
+            }
+        }
     }
 
     internal void OnLoaded()

--- a/src/ui/Features/Video/EmbeddedSubtitlesEdit/EmbeddedSubtitlesEditViewModel.cs
+++ b/src/ui/Features/Video/EmbeddedSubtitlesEdit/EmbeddedSubtitlesEditViewModel.cs
@@ -605,6 +605,23 @@ public partial class EmbeddedSubtitlesEditViewModel : ObservableObject
     internal void OnClosing()
     {
         UiUtil.SaveWindowPosition(Window);
+
+        // Stop the poll timer and any still-running encode - closing the window used to
+        // leave the ffmpeg process muxing to completion in the background.
+        _timerGenerate.StopAndDispose(TimerGenerateElapsed);
+        if (_ffmpegProcess != null && !_ffmpegProcess.HasExited)
+        {
+            try
+            {
+#pragma warning disable CA1416
+                _ffmpegProcess.Kill(true);
+#pragma warning restore CA1416
+            }
+            catch
+            {
+                // ignore - it may have exited in between
+            }
+        }
     }
 
     internal void OnLoaded()

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -1858,6 +1858,14 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         }
         set
         {
+            // mpv clamps a negative seek to the start, but the cached value below is what the
+            // getter reports while paused - so nudging back at 0:00 handed callers (set start
+            // time, waveform, position display) a negative time until real playback resumed.
+            if (value < 0)
+            {
+                value = 0;
+            }
+
             _pausedValue = value;
             _lastRawTimePos = value; // keep the eof-reached gate accurate across seeks
             EnsureNotDisposed();

--- a/tests/libse/SubtitleFormats/FormatRoundTripBugsRound2Test.cs
+++ b/tests/libse/SubtitleFormats/FormatRoundTripBugsRound2Test.cs
@@ -1,0 +1,198 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+
+namespace LibSETests.SubtitleFormats;
+
+/// <summary>
+/// Guard tests for the second round of write-then-read defects, found by round-tripping every
+/// text based format with richer content: formatting tags, characters that need escaping,
+/// multi-line text, and empty/one-line subtitles (2026-08-27 bug hunt).
+/// </summary>
+public class FormatRoundTripBugsRound2Test
+{
+    private static Subtitle MakeTagged()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("<i>Italic line one.</i>", 2000, 4000));
+        subtitle.Paragraphs.Add(new Paragraph("Normal, then <i>italic</i> mid-line.", 6000, 9000));
+        subtitle.Paragraphs.Add(new Paragraph("<b>Bold</b> and <u>underline</u>.", 12000, 15000));
+        return subtitle;
+    }
+
+    private static Subtitle MakeEscaped()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Tom & Jerry", 2000, 4000));
+        subtitle.Paragraphs.Add(new Paragraph("She said \"hello\" - that's it.", 6000, 9000));
+        subtitle.Paragraphs.Add(new Paragraph("Third line.", 12000, 15000));
+        return subtitle;
+    }
+
+    private static Subtitle RoundTrip(SubtitleFormat format, Subtitle subtitle)
+    {
+        var text = format.ToText(subtitle, "title");
+        var target = new Subtitle();
+        format.LoadSubtitle(target, text.SplitToLines(), "test" + format.Extension);
+        return target;
+    }
+
+    [Fact]
+    public void FinalCutProXml_UnderlineTag_DoesNotMangleTheText()
+    {
+        // <u> has no FCP style equivalent and no branch handled it, so the writer consumed
+        // only the '<' and left "u>underline/u>" in the text.
+        var target = RoundTrip(new FinalCutProXml15(), MakeTagged());
+
+        Assert.Equal(3, target.Paragraphs.Count);
+        Assert.DoesNotContain("u>", target.Paragraphs[2].Text, StringComparison.Ordinal);
+        Assert.Contains("underline", target.Paragraphs[2].Text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UtSubtitleXml_Markup_IsNotDoubleEscapedIntoCdata()
+    {
+        // The writer went through InnerText first (escaping the markup) and then wrapped the
+        // result in CDATA - and CDATA content is not parsed, so "&lt;i&gt;" came back literally.
+        var target = RoundTrip(new UTSubtitleXml(), MakeTagged());
+
+        Assert.Equal(3, target.Paragraphs.Count);
+        Assert.DoesNotContain("&lt;", target.Paragraphs[0].Text, StringComparison.Ordinal);
+        Assert.Equal("<i>Italic line one.</i>", target.Paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void FlashXml_Entities_AreNotDoubleEscapedIntoCdata()
+    {
+        var target = RoundTrip(new FlashXml(), MakeEscaped());
+
+        Assert.Equal(3, target.Paragraphs.Count);
+        Assert.Equal("Tom & Jerry", target.Paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void KanopyHtml_InlineClosingTag_DoesNotTruncateTheLine()
+    {
+        // The reader cut the text at the FIRST "</", so everything after an inline closing
+        // tag was thrown away; only the trailing wrapper should be stripped.
+        var target = RoundTrip(new KanopyHtml(), MakeTagged());
+
+        Assert.Equal(3, target.Paragraphs.Count);
+        Assert.Contains("mid-line.", target.Paragraphs[1].Text, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(typeof(JsonAeneas))]
+    [InlineData(typeof(JsonType17))]
+    [InlineData(typeof(Bilibili))]
+    public void JsonFormats_EscapedQuotes_AreDecodedOnRead(Type formatType)
+    {
+        // These writers escape with Json.EncodeJsonText but the readers returned the raw
+        // string, so quotes came back as \" in the subtitle text.
+        var format = (SubtitleFormat)Activator.CreateInstance(formatType)!;
+        var target = RoundTrip(format, MakeEscaped());
+
+        Assert.Equal(3, target.Paragraphs.Count);
+        Assert.DoesNotContain("\\\"", target.Paragraphs[1].Text, StringComparison.Ordinal);
+        Assert.Contains("\"hello\"", target.Paragraphs[1].Text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Csv3_EmbeddedQuotes_SurviveTheRoundTrip()
+    {
+        // ReadText collapsed the doubled quotes BEFORE the walk that needed them, leaving the
+        // loop unable to tell an escaped quote from a field delimiter.
+        var target = RoundTrip(new Csv3(), MakeEscaped());
+
+        Assert.Equal(3, target.Paragraphs.Count);
+        Assert.Contains("\"hello\"", target.Paragraphs[1].Text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Csv3_ThreeLines_AreNotSilentlyDropped()
+    {
+        // The format has two text columns but only rebalanced at four lines or more, so the
+        // third line of a three-line subtitle was written nowhere.
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph(
+            "Line one." + Environment.NewLine + "Line two." + Environment.NewLine + "Line three.", 2000, 4000));
+
+        var target = RoundTrip(new Csv3(), subtitle);
+
+        Assert.Single(target.Paragraphs);
+        Assert.Contains("three", target.Paragraphs[0].Text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void JsonType6_LastWord_IsNotDropped()
+    {
+        // The merge loop stopped at Count - 1, so the final word was only ever seen as "next".
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Alpha beta gamma.", 2000, 4000));
+        subtitle.Paragraphs.Add(new Paragraph("Delta epsilon zeta.", 6000, 9000));
+        subtitle.Paragraphs.Add(new Paragraph("Eta theta iota.", 12000, 15000));
+
+        var target = RoundTrip(new JsonType6(), subtitle);
+
+        Assert.Equal(3, target.Paragraphs.Count);
+        Assert.Contains("iota.", target.Paragraphs[2].Text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void JsonType6_LastParagraph_EndsAfterItsStart()
+    {
+        // GetOptimalDisplayMilliseconds is a DURATION; it was assigned as the absolute end time.
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Alpha beta gamma.", 2000, 4000));
+        subtitle.Paragraphs.Add(new Paragraph("Delta epsilon zeta.", 6000, 9000));
+        subtitle.Paragraphs.Add(new Paragraph("Eta theta iota.", 12000, 15000));
+
+        var target = RoundTrip(new JsonType6(), subtitle);
+
+        var last = target.Paragraphs[target.Paragraphs.Count - 1];
+        Assert.True(last.EndTime.TotalMilliseconds > last.StartTime.TotalMilliseconds,
+            $"last line: {last.StartTime} --> {last.EndTime}");
+    }
+
+    [Fact]
+    public void ESubXf_DeclaredFrameRate_IsHonoredOnRead()
+    {
+        // ToText writes framerate="..." into the file; the reader ignored it and decoded the
+        // SMPTE frames at whatever rate happened to be loaded.
+        var savedFrameRate = Configuration.Settings.General.CurrentFrameRate;
+        try
+        {
+            var subtitle = new Subtitle();
+            subtitle.Paragraphs.Add(new Paragraph("Hello world.", 2000, 4000));
+            subtitle.Paragraphs.Add(new Paragraph("Second line.", 6000, 9000));
+
+            Configuration.Settings.General.CurrentFrameRate = 29.97;
+            var format = new ESubXf();
+            var text = format.ToText(subtitle, "title");
+
+            Configuration.Settings.General.CurrentFrameRate = 25;
+            var target = new Subtitle();
+            format.LoadSubtitle(target, text.SplitToLines(), "test" + format.Extension);
+
+            Assert.Equal(2, target.Paragraphs.Count);
+            Assert.Equal(9000, target.Paragraphs[1].EndTime.TotalMilliseconds, 0);
+        }
+        finally
+        {
+            Configuration.Settings.General.CurrentFrameRate = savedFrameRate;
+        }
+    }
+
+    [Theory]
+    [InlineData(typeof(SoftNicolonSub))]
+    [InlineData(typeof(UnknownSubtitle101))]
+    public void EmptySubtitle_DoesNotThrowOnWrite(Type formatType)
+    {
+        // Paragraphs.Last() threw "Sequence contains no elements" - the null check right
+        // after it shows LastOrDefault was always the intent.
+        var format = (SubtitleFormat)Activator.CreateInstance(formatType)!;
+
+        var text = format.ToText(new Subtitle(), "title");
+
+        Assert.NotNull(text);
+    }
+}


### PR DESCRIPTION
Tenth general bug-hunt sweep. Extends the round-trip harness from #14181 with **richer probe content** — formatting tags, characters needing escaping, multi-line text, empty/one-line subtitles — plus a **declared-vs-global frame-rate sweep** and a **binary-format round trip**. 21 findings, all fixed, with 14 new guard tests.

## Subtitle formats (16)

Round 1 (#14181) used plain single-line text, which hid every escaping and markup defect. This round varied the content:

**Markup mangling**
- **Final Cut Pro Xml 1.5–1.14** (ten formats share one writer): the tag walker handles `<i>`, `<b>`, `<font>` but nothing else — hitting `<u>` it consumed only the `<`, exporting `u>underline/u>` as visible text. Unknown tags are now skipped whole.
- **UT Subtitle xml** and **Flash Xml**: both writers set `InnerText` (which XML-escapes) and then wrapped `InnerXml` in a CDATA section — but CDATA content is *not* parsed, so `<i>` came back as literal `&lt;i&gt;` and `&` as `&amp;`. The CDATA is now built from the raw text.
- **Kanopy Html**: the reader truncated the text at the first `</`, so `then <i>italic</i> mid-line.` lost everything from `</i>` on. Only the trailing wrapper is stripped now.

**Escaping asymmetry** (writer encodes, reader never decodes — same class as the JSON fixes in #14181)
- **JSON Aeneas**, **JSON Type 17**, **Bilibili json**: quotes came back as `\"` in the subtitle text.
- **Csv3**: `ReadText` collapsed the doubled quotes *before* the walk that needed them to tell an escaped quote from a field delimiter, so quoted words lost their quotes.

**Data loss**
- **Csv3** rebalanced only at four or more lines while having two text columns — the third line of a three-line subtitle was written nowhere.
- **JSON Type 6**: the word-merge loop stops at `Count - 1`, so the final word was only ever seen as `next` and never added; and `GetOptimalDisplayMilliseconds` (a *duration*) was assigned as the last paragraph's absolute end time.

**Frame rate / crashes**
- **esub-xf**: `ToText` writes `framerate="…"` into the file, but the reader ignored it and decoded the SMPTE frames at whatever rate happened to be loaded — the same declared-vs-global class as the Netflix IMSC / InqScribe fixes in #14181. (A sweep of every format that writes a frame rate confirmed this was the only remaining one; ClqttJson already reads its declared fps.)
- **SoftNi colon sub** and **Unknown 101**: `Paragraphs.Last()` threw *"Sequence contains no elements"* when writing an empty subtitle — the null check on the very next line shows `LastOrDefault` was always the intent.

## UI (5)

- **Restore auto-backup**: the Restore button never enabled for the row the grid selects on its own (AlwaysSelected raises no SelectionChanged — the documented defect class), so restoring needed a manual re-click; and a single locked file aborted "Delete all" midway while the list was cleared, claiming success.
- **Embedded subtitles edit** (both the mkv and mp4 dialogs): `OnClosing` only saved the window position — closing during a mux left ffmpeg running to completion in the background with the poll timer still ticking. Same fix as BlankVideo in this branch's sibling sweep.
- **libmpv player**: the `Position` setter cached the requested value as the paused position *before* mpv clamped it, so nudging back at 0:00 handed callers (set start time, waveform, position display) a negative time.
- **Manual chosen encoding**: a search matching nothing cleared the list and with it the bound selection, but left OK enabled — pressing OK silently did nothing, since the caller ignores a null encoding.
- **ASSA set position**: the no-video fallback resolution was `1820x1080` (typo for 1920), giving the preview canvas a wrong aspect.

## Also checked, no bugs found

The binary formats (PAC, PacUnicode, Cavena890, Cheetah, CapMakerPlus, IsmtDfxp) round-trip cleanly through Save→IsMine→Load. Frame-based formats that store bare frames without declaring a rate (MicroDVD, MacSub, AQTitle, Phoenix…) shift when read at another rate — inherent, not a defect. The Yugoslav titler charsets (DV Subtitle, Magic Video Titler, Smart Titler) map ASCII `w`↔`nj`, `>`↔`:` by design; CEA-608 formats truncate at 32 columns by design.

## Tests

Suites green: libse 1584 (14 new), libuilogic 703, seconv 416, UI 4143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)