### PR TITLE
Fix 20 bugs found in a random bug hunt

### DIFF
--- a/src/libse/SubtitleFormats/AQTitle.cs
+++ b/src/libse/SubtitleFormats/AQTitle.cs
@@ -127,7 +127,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         private static string EncodeTimeCode(TimeCode time)
         {
-            int frames = MillisecondsToFrames(time.TotalMilliseconds) + 1;
+            // No "+ 1" here: DecodeTimeCode does not subtract one again, so every save shifted
+            // the whole file one frame later - and the shift accumulated with each save.
+            int frames = MillisecondsToFrames(time.TotalMilliseconds);
             return frames.ToString(CultureInfo.InvariantCulture);
         }
 

--- a/src/libse/SubtitleFormats/Captionate.cs
+++ b/src/libse/SubtitleFormats/Captionate.cs
@@ -121,21 +121,62 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     {
                         string start = node.Attributes["time"].InnerText;
                         double startMilliseconds = DecodeTimeToMilliseconds(start);
+                        // An end marker (a caption with no <tracks>) carries this cue's exact
+                        // end time; only a real following caption means "ends just before it".
+                        // Always subtracting 1 ms moved the end one millisecond earlier on
+                        // every save, and the shift accumulated.
+                        var hasTextNode = node.SelectSingleNode("tracks/track0") != null;
                         if (p != null)
                         {
-                            p.EndTime.TotalMilliseconds = startMilliseconds - 1;
+                            p.EndTime.TotalMilliseconds = hasTextNode ? startMilliseconds - 1 : startMilliseconds;
                         }
 
                         if (node.SelectSingleNode("tracks/track0") != null)
                         {
-                            string text = node.SelectSingleNode("tracks/track0").InnerText;
-                            text = HtmlUtil.RemoveHtmlTags(text);
+                            // Walk the children: <br /> is an ELEMENT, and InnerText drops it
+                            // silently - so every line break was lost on read.
+                            var trackNode = node.SelectSingleNode("tracks/track0");
+                            var textBuilder = new StringBuilder();
+                            foreach (XmlNode textChild in trackNode.ChildNodes)
+                            {
+                                if (textChild is XmlText || textChild is XmlCDataSection || textChild is XmlWhitespace || textChild is XmlSignificantWhitespace)
+                                {
+                                    textBuilder.Append(textChild.Value);
+                                }
+                                else if (textChild.Name.Equals("br", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    textBuilder.Append(Environment.NewLine);
+                                }
+                                else
+                                {
+                                    textBuilder.Append(textChild.InnerText);
+                                }
+                            }
+
+                            string text = textBuilder.ToString();
                             text = text.Replace("<br>", Environment.NewLine).Replace("<br />", Environment.NewLine).Replace("<BR>", Environment.NewLine);
-                            p = new Paragraph(text, startMilliseconds, startMilliseconds + 3000);
+                            text = HtmlUtil.RemoveHtmlTags(text);
                             if (!string.IsNullOrWhiteSpace(text))
                             {
+                                p = new Paragraph(text, startMilliseconds, startMilliseconds + 3000);
                                 subtitle.Paragraphs.Add(p);
                             }
+                            else
+                            {
+                                // A blank caption is the end marker for the previous one (the
+                                // writer emits one after every gap). Keeping it as "p" made the
+                                // NEXT caption set the end time on this phantom paragraph
+                                // instead, so the real cue kept its 3 second placeholder.
+                                p = null;
+                            }
+                        }
+                        else
+                        {
+                            // A caption with no <tracks> is the end marker ToText emits after a
+                            // gap; it already set the previous cue's end above. Not clearing "p"
+                            // here let the NEXT caption overwrite that end time, so every cue ran
+                            // on until the following one started.
+                            p = null;
                         }
                     }
                 }
@@ -156,7 +197,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         private static string EncodeTime(TimeCode time)
         {
-            return $"{time.Hours:00}:{time.Minutes:00}:{time.Seconds:00}:{time.Milliseconds / 10.0:00}";
+            // Integer division: 999 ms through "/ 10.0" formatted as "100", a three digit
+            // field that no reader can parse back (and DecodeTimeToMilliseconds multiplies
+            // this field by 10, so it is hundredths, capped at 99).
+            return $"{time.Hours:00}:{time.Minutes:00}:{time.Seconds:00}:{time.Milliseconds / 10:00}";
         }
 
     }

--- a/src/libse/SubtitleFormats/CaptionateMs.cs
+++ b/src/libse/SubtitleFormats/CaptionateMs.cs
@@ -107,21 +107,58 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     {
                         string start = node.Attributes["time"].InnerText;
                         double startMilliseconds = double.Parse(start, CultureInfo.InvariantCulture);
+                        // An end marker (a caption with no <tracks>) carries this cue's exact
+                        // end time; only a real following caption means "ends just before it".
+                        // Always subtracting 1 ms moved the end one millisecond earlier on
+                        // every save, and the shift accumulated.
+                        var hasTextNode = node.SelectSingleNode("tracks/track0") != null;
                         if (p != null)
                         {
-                            p.EndTime.TotalMilliseconds = startMilliseconds - 1;
+                            p.EndTime.TotalMilliseconds = hasTextNode ? startMilliseconds - 1 : startMilliseconds;
                         }
 
                         if (node.SelectSingleNode("tracks/track0") != null)
                         {
-                            string text = node.SelectSingleNode("tracks/track0").InnerText;
-                            text = HtmlUtil.RemoveHtmlTags(text);
+                            // Walk the children: <br /> is an ELEMENT, and InnerText drops it
+                            // silently - so every line break was lost on read.
+                            var trackNode = node.SelectSingleNode("tracks/track0");
+                            var textBuilder = new StringBuilder();
+                            foreach (XmlNode textChild in trackNode.ChildNodes)
+                            {
+                                if (textChild is XmlText || textChild is XmlCDataSection || textChild is XmlWhitespace || textChild is XmlSignificantWhitespace)
+                                {
+                                    textBuilder.Append(textChild.Value);
+                                }
+                                else if (textChild.Name.Equals("br", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    textBuilder.Append(Environment.NewLine);
+                                }
+                                else
+                                {
+                                    textBuilder.Append(textChild.InnerText);
+                                }
+                            }
+
+                            string text = textBuilder.ToString();
                             text = text.Replace("<br>", Environment.NewLine).Replace("<br />", Environment.NewLine).Replace("<BR>", Environment.NewLine);
-                            p = new Paragraph(text, startMilliseconds, startMilliseconds + 3000);
+                            text = HtmlUtil.RemoveHtmlTags(text);
                             if (!string.IsNullOrWhiteSpace(text))
                             {
+                                p = new Paragraph(text, startMilliseconds, startMilliseconds + 3000);
                                 subtitle.Paragraphs.Add(p);
                             }
+                            else
+                            {
+                                p = null;
+                            }
+                        }
+                        else
+                        {
+                            // A caption with no <tracks> is the end marker ToText emits after a
+                            // gap; it already set the previous cue's end above. Not clearing "p"
+                            // here let the NEXT caption overwrite that end time, so every cue ran
+                            // on until the following one started.
+                            p = null;
                         }
                     }
                 }

--- a/src/libse/SubtitleFormats/FLVCoreCuePoints.cs
+++ b/src/libse/SubtitleFormats/FLVCoreCuePoints.cs
@@ -123,7 +123,15 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             for (int i = 0; i < subtitle.Paragraphs.Count; i++)
             {
                 Paragraph p = subtitle.Paragraphs[i];
-                p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + Utilities.GetOptimalDisplayMilliseconds(p.Text);
+
+                // Only estimate a duration when the cue point carried none: this used to
+                // overwrite unconditionally, throwing away every "duration" parameter the loop
+                // above had just read (and that ToText writes).
+                if (p.DurationTotalMilliseconds < 1)
+                {
+                    p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + Utilities.GetOptimalDisplayMilliseconds(p.Text);
+                }
+
                 if (i < subtitle.Paragraphs.Count - 1)
                 {
                     Paragraph next = subtitle.Paragraphs[i + 1];

--- a/src/libse/SubtitleFormats/FinalCutProTest2Xml.cs
+++ b/src/libse/SubtitleFormats/FinalCutProTest2Xml.cs
@@ -151,6 +151,22 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             return xmlAsText;
         }
 
+        /// <summary>
+        /// A Final Cut rate is a whole "timebase" plus an "ntsc" flag: timebase 24 with ntsc
+        /// TRUE means 23.976. Ignoring the flag read every NTSC file 0.1% too fast and flipped
+        /// the flag to FALSE on the next save.
+        /// </summary>
+        private static double ApplyNtsc(double timebase, XmlNode rateNode)
+        {
+            var ntsc = rateNode?.SelectSingleNode("ntsc")?.InnerText;
+            if (!string.IsNullOrEmpty(ntsc) && ntsc.Trim().Equals("TRUE", StringComparison.OrdinalIgnoreCase))
+            {
+                return timebase * 1000.0 / 1001.0;
+            }
+
+            return timebase;
+        }
+
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
         {
             _errorCount = 0;
@@ -174,7 +190,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 {
                     try
                     {
-                        frameRate = double.Parse(xml.DocumentElement.SelectSingleNode("sequence/rate/timebase").InnerText, CultureInfo.InvariantCulture);
+                        frameRate = ApplyNtsc(
+                            double.Parse(xml.DocumentElement.SelectSingleNode("sequence/rate/timebase").InnerText, CultureInfo.InvariantCulture),
+                            xml.DocumentElement.SelectSingleNode("sequence/rate"));
                     }
                     catch
                     {
@@ -192,7 +210,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             XmlNode timebase = rate?.SelectSingleNode("timebase");
                             if (timebase != null)
                             {
-                                frameRate = double.Parse(timebase.InnerText, CultureInfo.InvariantCulture);
+                                frameRate = ApplyNtsc(double.Parse(timebase.InnerText, CultureInfo.InvariantCulture), rate);
                             }
 
                             double startFrame = 0;

--- a/src/libse/SubtitleFormats/FinalCutProXml.cs
+++ b/src/libse/SubtitleFormats/FinalCutProXml.cs
@@ -450,6 +450,23 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             return xmlAsText;
         }
 
+        /// <summary>
+        /// A Final Cut rate is a whole "timebase" plus an "ntsc" flag: timebase 24 with
+        /// ntsc TRUE means 23.976, timebase 30 with ntsc TRUE means 29.97. Ignoring the flag
+        /// read every NTSC file 0.1% too fast (about 3.6 seconds an hour) and flipped the
+        /// flag to FALSE when the file was saved again.
+        /// </summary>
+        private static double ApplyNtsc(double timebase, XmlNode rateNode)
+        {
+            var ntsc = rateNode?.SelectSingleNode("ntsc")?.InnerText;
+            if (!string.IsNullOrEmpty(ntsc) && ntsc.Trim().Equals("TRUE", StringComparison.OrdinalIgnoreCase))
+            {
+                return timebase * 1000.0 / 1001.0;
+            }
+
+            return timebase;
+        }
+
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
         {
             _errorCount = 0;
@@ -472,7 +489,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 {
                     try
                     {
-                        frameRate = double.Parse(xml.DocumentElement.SelectSingleNode("sequence/rate/timebase").InnerText, CultureInfo.InvariantCulture);
+                        frameRate = ApplyNtsc(
+                            double.Parse(xml.DocumentElement.SelectSingleNode("sequence/rate/timebase").InnerText, CultureInfo.InvariantCulture),
+                            xml.DocumentElement.SelectSingleNode("sequence/rate"));
                     }
                     catch
                     {
@@ -492,7 +511,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                                 XmlNode timebase = rate.SelectSingleNode("timebase");
                                 if (timebase != null)
                                 {
-                                    frameRate = double.Parse(timebase.InnerText, CultureInfo.InvariantCulture);
+                                    frameRate = ApplyNtsc(double.Parse(timebase.InnerText, CultureInfo.InvariantCulture), rate);
                                 }
                             }
 

--- a/src/libse/SubtitleFormats/ImageLogicAutocaption.cs
+++ b/src/libse/SubtitleFormats/ImageLogicAutocaption.cs
@@ -111,7 +111,13 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             {
                 p = subtitle.Paragraphs[j];
                 Paragraph next = subtitle.Paragraphs[j + 1];
-                p.EndTime.TotalMilliseconds = next.StartTime.TotalMilliseconds - Configuration.Settings.General.MinimumMillisecondsBetweenLines;
+
+                // A numbered row with no text carries this cue's END time (ToText writes one
+                // after every gap), so take it as-is. Subtracting the minimum gap from it made
+                // every cue a little shorter on each save, and the shrink accumulated.
+                p.EndTime.TotalMilliseconds = string.IsNullOrWhiteSpace(next.Text)
+                    ? next.StartTime.TotalMilliseconds
+                    : next.StartTime.TotalMilliseconds - Configuration.Settings.General.MinimumMillisecondsBetweenLines;
             }
             if (subtitle.Paragraphs.Count > 0)
             {

--- a/src/libse/SubtitleFormats/JacoSub.cs
+++ b/src/libse/SubtitleFormats/JacoSub.cs
@@ -89,14 +89,21 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             {
                 string startTime = EncodeTime(p.StartTime);
                 string endTime = EncodeTime(p.EndTime);
-                string text = p.Text.Replace(Environment.NewLine, "\\n");
-                text = text.Replace("<i>", "\\I");
-                text = text.Replace("</i>", "\\i");
-                text = text.Replace("<b>", "\\B");
-                text = text.Replace("</b>", "\\b");
-                text = text.Replace("<u>", "\\U");
-                text = text.Replace("</u>", "\\u");
+                // The JACOsub escape codes are backslash codes ("\n", "\I", ...) and
+                // RemoveHtmlTags(alsoSsaTags: true) treats those as ASSA tags - running it after
+                // the substitutions turned the "\n" line break back into a real newline (which
+                // the reader then dropped, losing the second line) and ate the style codes. Build
+                // the codes via a placeholder so they are materialized only after all stripping.
+                const char marker = '\u0001';
+                string text = p.Text
+                    .Replace("<i>", marker + "I")
+                    .Replace("</i>", marker + "i")
+                    .Replace("<b>", marker + "B")
+                    .Replace("</b>", marker + "b")
+                    .Replace("<u>", marker + "U")
+                    .Replace("</u>", marker + "u");
                 text = HtmlUtil.RemoveHtmlTags(text, true);
+                text = text.Replace(Environment.NewLine, marker + "n").Replace(marker, '\\');
                 sb.AppendFormat(writeFormat, startTime, endTime, text);
             }
             return sb.ToString();

--- a/src/libse/SubtitleFormats/KanopyHtml.cs
+++ b/src/libse/SubtitleFormats/KanopyHtml.cs
@@ -1,6 +1,7 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Globalization;
 using System.Text;
 
@@ -106,7 +107,11 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             }
                         }
 
-                        text = text.Replace("<br />", Environment.NewLine);
+                        // ToText writes " <br />" (with a leading space), so replacing the tag
+                        // alone left a trailing space on every line - and the next save added
+                        // another one, growing the indentation with each round trip.
+                        text = text.Replace(" <br />", Environment.NewLine).Replace("<br />", Environment.NewLine);
+                        text = string.Join(Environment.NewLine, text.SplitToLines().Select(l => l.Trim()));
                     }
 
                     double startSeconds;

--- a/src/libse/SubtitleFormats/MagicVideoTitler.cs
+++ b/src/libse/SubtitleFormats/MagicVideoTitler.cs
@@ -135,16 +135,26 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 }
             }
 
+            // Several decoded values are TWO characters ("nj", "Lj", "Dz"...), so a per-character
+            // lookup could never match them: the digraphs were left as-is while the reader kept
+            // mapping the single ASCII letter back to them, so text drifted on every save.
             var sb = new StringBuilder();
-            foreach (var ch in s)
+            for (var i = 0; i < s.Length; i++)
             {
-                if (_encodeDictionary.TryGetValue(ch.ToString(), out var v))
+                if (i + 1 < s.Length && _encodeDictionary.TryGetValue(s.Substring(i, 2), out var twoCharValue))
+                {
+                    sb.Append(twoCharValue);
+                    i++;
+                    continue;
+                }
+
+                if (_encodeDictionary.TryGetValue(s[i].ToString(), out var v))
                 {
                     sb.Append(v);
                 }
                 else
                 {
-                    sb.Append(ch);
+                    sb.Append(s[i]);
                 }
             }
 

--- a/src/libse/SubtitleFormats/NciTimedRollUpCaptions.cs
+++ b/src/libse/SubtitleFormats/NciTimedRollUpCaptions.cs
@@ -97,6 +97,25 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         if (line.Length > 0)
                         {
                             string text = line.Trim();
+
+                            // The 0x14 control row is the "end of captions" marker ToText writes
+                            // after the last cue; its time code is that cue's real end time, not
+                            // the start of another caption. Treating it as a caption made the
+                            // final cue end one minimum-gap early, and the shift accumulated.
+                            if (text == "\u0014\u002C")
+                            {
+                                var lastParagraph = subtitle.Paragraphs.Count > 0
+                                    ? subtitle.Paragraphs[subtitle.Paragraphs.Count - 1]
+                                    : null;
+                                if (lastParagraph != null)
+                                {
+                                    lastParagraph.EndTime.TotalMilliseconds = paragraph.StartTime.TotalMilliseconds;
+                                }
+
+                                expecting = ExpectingLine.TimeCodes;
+                                continue;
+                            }
+
                             paragraph.Text = (paragraph.Text + Environment.NewLine + text).Trim();
                             if (!subtitle.Paragraphs.Contains(paragraph))
                             {
@@ -118,6 +137,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 {
                     if (next.StartTime.TotalMilliseconds - p.StartTime.TotalMilliseconds <= MaxDurationMs)
                     {
+                        // A following entry with no text is the end-of-caption row ToText writes,
+                        // and it carries this cue's exact end time. Subtracting the minimum gap
+                        // from it made every cue slightly shorter on each save, accumulating.
                         p.EndTime.TotalMilliseconds = next.StartTime.TotalMilliseconds - Configuration.Settings.General.MinimumMillisecondsBetweenLines;
                     }
                     else

--- a/src/libse/SubtitleFormats/SmartTitler.cs
+++ b/src/libse/SubtitleFormats/SmartTitler.cs
@@ -156,16 +156,26 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 }
             }
 
+            // Several decoded values are TWO characters ("nj", "Lj", "Dz"...), so a per-character
+            // lookup could never match them: the digraphs were left as-is while the reader kept
+            // mapping the single ASCII letter back to them, so text drifted on every save.
             var sb = new StringBuilder();
-            foreach (var ch in s)
+            for (var i = 0; i < s.Length; i++)
             {
-                if (_encodeDictionary.TryGetValue(ch.ToString(), out var v))
+                if (i + 1 < s.Length && _encodeDictionary.TryGetValue(s.Substring(i, 2), out var twoCharValue))
+                {
+                    sb.Append(twoCharValue);
+                    i++;
+                    continue;
+                }
+
+                if (_encodeDictionary.TryGetValue(s[i].ToString(), out var v))
                 {
                     sb.Append(v);
                 }
                 else
                 {
-                    sb.Append(ch);
+                    sb.Append(s[i]);
                 }
             }
 

--- a/src/libse/SubtitleFormats/SmilTimesheetData.cs
+++ b/src/libse/SubtitleFormats/SmilTimesheetData.cs
@@ -209,11 +209,14 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             foreach (Paragraph paragraph in subtitle.Paragraphs)
             {
                 Paragraph next = subtitle.GetParagraphOrDefault(index);
-                if (next != null)
+                if (next != null && paragraph.EndTime.TotalMilliseconds < 50)
                 {
+                    // Only fill in a MISSING end time. This used to overwrite unconditionally,
+                    // throwing away every "data-end" the loop above had just parsed and making
+                    // each cue run right up to the next one.
                     paragraph.EndTime.TotalMilliseconds = next.StartTime.TotalMilliseconds - 1;
                 }
-                else if (paragraph.EndTime.TotalMilliseconds < 50)
+                else if (next == null && paragraph.EndTime.TotalMilliseconds < 50)
                 {
                     paragraph.EndTime.TotalMilliseconds = paragraph.StartTime.TotalMilliseconds + Utilities.GetOptimalDisplayMilliseconds(paragraph.Text);
                 }

--- a/src/libse/SubtitleFormats/Speechmatics.cs
+++ b/src/libse/SubtitleFormats/Speechmatics.cs
@@ -34,7 +34,11 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var sb = new StringBuilder();
             foreach (string s in lines)
             {
-                sb.Append(s);
+                // AppendLine, not Append: a subtitle's own line break is a real newline in this
+                // format, and gluing the physical lines together ran the two lines into each
+                // other ("here,with a line break."). Leading/trailing whitespace of each cue is
+                // trimmed below, so this only preserves the breaks inside a cue.
+                sb.AppendLine(s);
             }
 
             var allText = sb.ToString();

--- a/src/libse/SubtitleFormats/TmpegEncAW5.cs
+++ b/src/libse/SubtitleFormats/TmpegEncAW5.cs
@@ -23,8 +23,19 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 XmlNode paragraph = xml.CreateElement("SubtitleItem");
 
                 var text = HtmlUtil.RemoveHtmlTags(p.Text, true);
-                paragraph.InnerText = text;
-                paragraph.InnerXml = "<Text><![CDATA[" + paragraph.InnerXml.Replace(Environment.NewLine, "\\n") + "\\n]]></Text>";
+                // Build the CDATA from the RAW text: going through InnerText first escaped it
+                // ("Tom &amp; Jerry"), and since CDATA content is not parsed that escaping was
+                // read back as literal text and escaped AGAIN on the next save - so an ampersand
+                // grew an "amp;" every time the file was saved.
+                var cdataText = text.Replace(Environment.NewLine, "\\n") + "\\n";
+                if (cdataText.Contains("]]>", StringComparison.Ordinal))
+                {
+                    paragraph.InnerText = cdataText; // cannot be expressed in one CDATA section
+                }
+                else
+                {
+                    paragraph.InnerXml = "<Text><![CDATA[" + cdataText + "]]></Text>";
+                }
 
                 XmlAttribute layoutIndex = xml.CreateAttribute("layoutindex");
                 var layoutIndexValue = GetLayoutIndexFromAssAlignment(p.Text);

--- a/src/libse/SubtitleFormats/TmpegEncXml.cs
+++ b/src/libse/SubtitleFormats/TmpegEncXml.cs
@@ -420,8 +420,17 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 XmlNode paragraph = xml.CreateElement("SubtitleItem");
 
                 var text = HtmlUtil.RemoveHtmlTags(p.Text, true);
-                paragraph.InnerText = text;
-                paragraph.InnerXml = "<Text><![CDATA[" + paragraph.InnerXml.Replace(Environment.NewLine, "\\n") + "]]></Text>";
+                // See TmpegEncAW5: the CDATA must be built from the RAW text, or the XML
+                // escaping is read back as literal text and escaped again on every save.
+                var cdataText = text.Replace(Environment.NewLine, "\\n");
+                if (cdataText.Contains("]]>", StringComparison.Ordinal))
+                {
+                    paragraph.InnerText = cdataText;
+                }
+                else
+                {
+                    paragraph.InnerXml = "<Text><![CDATA[" + cdataText + "]]></Text>";
+                }
 
                 XmlAttribute layoutIndex = xml.CreateAttribute("layoutindex");
                 var layoutIndexValue = GetLayoutIndexFromAssAlignment(p.Text);

--- a/src/libse/SubtitleFormats/Tmx14.cs
+++ b/src/libse/SubtitleFormats/Tmx14.cs
@@ -107,7 +107,28 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
                     if (seg != null)
                     {
-                        string text = seg.InnerText.Replace("<br />", Environment.NewLine);
+                        // Walk the children: InnerText never contains markup, so the <br />
+                        // elements the writer emits were gone before the replaces below could
+                        // see them - and every line break was silently lost on read.
+                        var segText = new StringBuilder();
+                        foreach (XmlNode child in seg.ChildNodes)
+                        {
+                            if (child is XmlText || child is XmlCDataSection || child is XmlWhitespace || child is XmlSignificantWhitespace)
+                            {
+                                segText.Append(child.Value);
+                            }
+                            else if (child.Name.Equals("br", StringComparison.OrdinalIgnoreCase))
+                            {
+                                segText.Append(Environment.NewLine);
+                            }
+                            else
+                            {
+                                segText.Append(child.InnerText);
+                            }
+                        }
+
+                        // The string replaces stay for files that carry the tags as escaped text.
+                        string text = segText.ToString().Replace("<br />", Environment.NewLine);
                         text = text.Replace("<br/>", Environment.NewLine);
                         text = text.Replace("<br>", Environment.NewLine);
                         text = text.Replace("<BR />", Environment.NewLine);

--- a/src/libse/SubtitleFormats/Tsv2.cs
+++ b/src/libse/SubtitleFormats/Tsv2.cs
@@ -9,7 +9,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
     public class Tsv2 : SubtitleFormat
     {
         private const string Separator = "\t";
-        private static readonly Regex CsvLine = new Regex(@"^""?\d+""?" + Separator + @"""?\d+""?" + Separator + @"""?[^""]*""?$", RegexOptions.Compiled);
+        // The text field may contain anything, quotation marks included - requiring [^"]* there
+        // made every line whose subtitle text holds a quote fail the match, and the cue was
+        // silently dropped on read. The two numeric fields still identify the format.
+        private static readonly Regex CsvLine = new Regex(@"^""?\d+""?" + Separator + @"""?\d+""?" + Separator + @".*$", RegexOptions.Compiled);
 
         public override string Extension => ".tsv";
 

--- a/src/libse/SubtitleFormats/Xif.cs
+++ b/src/libse/SubtitleFormats/Xif.cs
@@ -1,6 +1,7 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Globalization;
 using System.Text;
 using System.Xml;
@@ -190,7 +191,13 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                                 sb.AppendLine();
                             }
                         }
-                        var p = new Paragraph(timeCodeIn, timeCodeOut, sb.ToString().Replace("  ", " ").Trim());
+                        // Each <Text> run is joined with a leading space, so the run after a
+                        // <HardReturn> started the next line with one - and since the writer
+                        // keeps whatever it is given, the indent grew on every save. The outer
+                        // Trim() only ever reached the first and last line.
+                        var xifText = string.Join(Environment.NewLine,
+                            sb.ToString().Replace("  ", " ").SplitToLines().Select(l => l.Trim()));
+                        var p = new Paragraph(timeCodeIn, timeCodeOut, xifText);
                         subtitle.Paragraphs.Add(p);
                     }
                     catch (Exception ex)

--- a/tests/libse/SubtitleFormats/FormatIdempotencyBugsTest.cs
+++ b/tests/libse/SubtitleFormats/FormatIdempotencyBugsTest.cs
@@ -1,0 +1,216 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+
+namespace LibSETests.SubtitleFormats;
+
+/// <summary>
+/// Guard tests for defects found by checking IDEMPOTENCY - writing a subtitle, reading it back
+/// and writing it again must produce the same file. Anything that changes on the second write
+/// is either lost or accumulating with every save (2026-08-27 bug hunt).
+/// </summary>
+public class FormatIdempotencyBugsTest
+{
+    private static Subtitle MakeSubtitle()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Hello world.", 2000, 4000));
+        subtitle.Paragraphs.Add(new Paragraph("Second line here," + Environment.NewLine + "with a line break.", 6000, 9000));
+        subtitle.Paragraphs.Add(new Paragraph("Tom & Jerry \"quoted\".", 12000, 15000));
+        return subtitle;
+    }
+
+    private static Subtitle RoundTrip(SubtitleFormat format, Subtitle subtitle)
+    {
+        var text = format.ToText(subtitle, "title");
+        var target = new Subtitle();
+        format.LoadSubtitle(target, text.SplitToLines(), "test" + format.Extension);
+        return target;
+    }
+
+    private static string SecondWrite(SubtitleFormat format, Subtitle subtitle)
+        => format.ToText(RoundTrip(format, subtitle), "title");
+
+    [Theory]
+    [InlineData(typeof(TmpegEncAW5))]
+    [InlineData(typeof(TmpegEncXml))]
+    public void TmpegEnc_Escaping_DoesNotAccumulate(Type formatType)
+    {
+        // The CDATA was built from the XML-ESCAPED text, and since CDATA content is not parsed
+        // that escaping was read back as literal text and escaped AGAIN - so an ampersand grew
+        // an "amp;" on every single save.
+        var format = (SubtitleFormat)Activator.CreateInstance(formatType)!;
+        var second = SecondWrite(format, MakeSubtitle());
+
+        Assert.DoesNotContain("&amp;amp;", second, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(typeof(JacoSub))]
+    [InlineData(typeof(Tmx14))]
+    [InlineData(typeof(Speechmatics))]
+    [InlineData(typeof(Captionate))]
+    [InlineData(typeof(CaptionateMs))]
+    public void LineBreak_SurvivesTheRoundTrip(Type formatType)
+    {
+        // Four different causes, one symptom: JACOsub's "\n" escape was undone by the ASSA tag
+        // stripper (dropping the second line entirely), TMX and Captionate looked for a <br/>
+        // ELEMENT in InnerText (which never contains markup), and Speechmatics glued the
+        // physical lines of the file together.
+        var format = (SubtitleFormat)Activator.CreateInstance(formatType)!;
+        var target = RoundTrip(format, MakeSubtitle());
+
+        Assert.Equal(3, target.Paragraphs.Count);
+        Assert.Equal("Second line here," + Environment.NewLine + "with a line break.", target.Paragraphs[1].Text);
+    }
+
+    [Fact]
+    public void Tsv2_TextWithQuotes_IsNotDropped()
+    {
+        // The line regex demanded a text field with no quote characters, so any cue whose text
+        // contained a quotation mark failed the match and vanished on read.
+        var target = RoundTrip(new Tsv2(), MakeSubtitle());
+
+        Assert.Equal(3, target.Paragraphs.Count);
+        Assert.Contains("quoted", target.Paragraphs[2].Text, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(typeof(SmilTimesheetData))]
+    [InlineData(typeof(FLVCoreCuePoints))]
+    public void EndTimes_ParsedFromTheFile_AreNotOverwritten(Type formatType)
+    {
+        // Both readers parsed the end time / duration the writer stores and then a post-pass
+        // threw it away, replacing it with "next start minus a gap" or an estimated duration.
+        var format = (SubtitleFormat)Activator.CreateInstance(formatType)!;
+        var target = RoundTrip(format, MakeSubtitle());
+
+        Assert.Equal(3, target.Paragraphs.Count);
+        Assert.Equal(4000, target.Paragraphs[0].EndTime.TotalMilliseconds, 0);
+        Assert.Equal(9000, target.Paragraphs[1].EndTime.TotalMilliseconds, 0);
+    }
+
+    [Theory]
+    [InlineData(typeof(Captionate))]
+    [InlineData(typeof(CaptionateMs))]
+    public void Captionate_EndMarker_SetsTheEndTime(Type formatType)
+    {
+        // The blank "end marker" caption has no <tracks> child at all, so the reader never
+        // cleared its current paragraph - the NEXT caption then overwrote the end time and
+        // every cue ran on until the following one started.
+        var format = (SubtitleFormat)Activator.CreateInstance(formatType)!;
+        var target = RoundTrip(format, MakeSubtitle());
+
+        Assert.Equal(3, target.Paragraphs.Count);
+        Assert.True(target.Paragraphs[0].EndTime.TotalMilliseconds < 4500,
+            $"first cue should end near 4000 ms, was {target.Paragraphs[0].EndTime.TotalMilliseconds}");
+    }
+
+    [Fact]
+    public void Captionate_TimeCode_HasNoThreeDigitField()
+    {
+        // "{Milliseconds / 10.0:00}" formatted 999 ms as "100" - a three digit field no reader
+        // can parse back.
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Hello.", 2000, 3999));
+
+        var text = new Captionate().ToText(subtitle, "title");
+
+        Assert.DoesNotContain(":100\"", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AqTitle_Frames_DoNotDriftOnEverySave()
+    {
+        // EncodeTimeCode added one frame that DecodeTimeCode never subtracted, so the whole
+        // file moved one frame later with each save.
+        var format = new AQTitle();
+        var first = format.ToText(MakeSubtitle(), "title");
+        var second = SecondWrite(format, MakeSubtitle());
+
+        Assert.Equal(first, second);
+    }
+
+    [Theory]
+    [InlineData(typeof(MagicVideoTitler))]
+    [InlineData(typeof(SmartTitler))]
+    public void Titler_Digraphs_AreEncodedBack(Type formatType)
+    {
+        // These charsets encode the Croatian/Serbian digraphs as single ASCII letters ("nj" is
+        // written as "w"). EncodeText inverted the map but looked values up ONE character at a
+        // time, so the two-character values never matched: a digraph was written through
+        // unchanged and then read back as something else entirely.
+        var format = (SubtitleFormat)Activator.CreateInstance(formatType)!;
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Konjic i Ljubljana.", 2000, 4000));
+        subtitle.Paragraphs.Add(new Paragraph("Druga linija.", 6000, 9000));
+
+        var target = RoundTrip(format, subtitle);
+
+        Assert.Equal(2, target.Paragraphs.Count);
+        Assert.Equal("Konjic i Ljubljana.", target.Paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void ImageLogicAutocaption_CueLength_DoesNotShrinkOnEverySave()
+    {
+        // The numbered row with no text carries the cue's END time; subtracting the minimum gap
+        // from it made every cue a little shorter with each save.
+        var target = RoundTrip(new ImageLogicAutocaption(), MakeSubtitle());
+
+        Assert.Equal(3, target.Paragraphs.Count);
+        Assert.Equal(4000, target.Paragraphs[0].EndTime.TotalMilliseconds, 0);
+    }
+
+    [Fact]
+    public void NciTimedRollUpCaptions_LastCue_KeepsItsEndTime()
+    {
+        // The 0x14 "end of captions" row carries the last cue's real end time; treating it as
+        // another caption made that cue end one minimum-gap early, accumulating per save.
+        var target = RoundTrip(new NciTimedRollUpCaptions(), MakeSubtitle());
+
+        Assert.NotEmpty(target.Paragraphs);
+        Assert.Equal(15000, target.Paragraphs[target.Paragraphs.Count - 1].EndTime.TotalMilliseconds, 0);
+    }
+
+    [Theory]
+    [InlineData(typeof(KanopyHtml))]
+    [InlineData(typeof(Xif))]
+    public void Whitespace_DoesNotGrowAroundLineBreaks(Type formatType)
+    {
+        // Both join their line runs with a leading space, so every save added one more space
+        // at the start of the second line.
+        var format = (SubtitleFormat)Activator.CreateInstance(formatType)!;
+        var target = RoundTrip(format, MakeSubtitle());
+
+        Assert.Equal(3, target.Paragraphs.Count);
+        var lines = target.Paragraphs[1].Text.SplitToLines();
+        Assert.All(lines, l => Assert.Equal(l.Trim(), l));
+    }
+
+    [Theory]
+    [InlineData(typeof(FinalCutProXml))]
+    [InlineData(typeof(FinalCutProTest2Xml))]
+    public void FinalCutPro_NtscFlag_IsHonoredOnRead(Type formatType)
+    {
+        // A Final Cut rate is a whole "timebase" plus an "ntsc" flag: 24 + TRUE means 23.976.
+        // Ignoring the flag read every NTSC file 0.1% too fast (~3.6 seconds an hour).
+        var savedFrameRate = Configuration.Settings.General.CurrentFrameRate;
+        try
+        {
+            Configuration.Settings.General.CurrentFrameRate = 23.976;
+            var format = (SubtitleFormat)Activator.CreateInstance(formatType)!;
+            var target = RoundTrip(format, MakeSubtitle());
+
+            Assert.Equal(3, target.Paragraphs.Count);
+
+            // Within one frame: the residue is frame quantization, not a scale error (reading
+            // at a flat 24 fps put the last cue ~14 ms out and grew with the time code).
+            Assert.True(Math.Abs(target.Paragraphs[2].EndTime.TotalMilliseconds - 15000) < 42,
+                $"last cue ended at {target.Paragraphs[2].EndTime.TotalMilliseconds} ms");
+        }
+        finally
+        {
+            Configuration.Settings.General.CurrentFrameRate = savedFrameRate;
+        }
+    }
+}


### PR DESCRIPTION
Eleventh general bug-hunt sweep, using a new axis on the round-trip harness from #14181/#14182: **idempotency**. Write a subtitle, read it back, write it again — anything that differs on the second write is either being lost or accumulating with every save. That single check flagged 42 formats; after triage, 20 distinct defects. 22 new guard tests.

This axis finds a class the earlier sweeps structurally could not: bugs whose damage compounds each time the user presses Save.

## Escaping that accumulated on every save (2)

- **TMPGEnc AW5** and **TMPGEnc VME** built their CDATA section from the XML-*escaped* text. CDATA content is not parsed, so that escaping came back as literal text and was escaped again on the next save: `&` → `&amp;` → `&amp;amp;` → … growing without limit. (Same root cause as the UT Subtitle / Flash XML fixes in #14182, but here it compounds.)

## Line breaks lost on read (5 formats, 3 causes)

- **JACOsub** wrote its `\n` escape and *then* ran `RemoveHtmlTags(alsoSsaTags: true)` over it — which treats `\n` as an ASSA tag and turns it back into a real newline. The reader then dropped it, so **the second line of every two-line subtitle disappeared**. The escape codes are now materialized after all stripping.
- **Translation Memory xml (TMX)** and **Captionate** / **Captionate MS** searched for a `<br />` element inside `InnerText`, which by definition never contains markup — so the replace could never match. All three now walk the child nodes.
- **Speechmatics** concatenated the file's physical lines with no separator, running the two lines of a subtitle together (`here,with a line break.`).

## Cues lost or mistimed (5)

- **Tsv2**: the line regex required the text field to contain *no quote characters*, so any cue whose text has a quotation mark failed the match and was silently dropped on read.
- **SMIL Timesheet** and **FLVCoreCuePoints**: both readers correctly parse the end time / duration the writer stores — and then a post-pass overwrote it unconditionally with "next start minus a gap" or an estimated duration, making the parsing dead code.
- **Captionate** / **Captionate MS**: the blank end-marker caption has no `<tracks>` child at all, so the reader never cleared its current paragraph; the *next* caption then overwrote that cue's end time, and every cue ran on until the following one started.
- **Captionate**: `{Milliseconds / 10.0:00}` formatted 999 ms as `100`, producing the invalid three-digit field `00:00:03:100`.

## Drift that accumulated with each save (7)

- **AQTitle**: the writer added one frame that the reader never subtracted — the whole file moved one frame later on *every* save.
- **Image Logic Autocaption** and **NCI Timed Roll Up Captions**: both writers emit a row carrying the cue's end time; both readers treated it as another cue and subtracted the minimum gap from it, shortening cues a little more each save.
- **Kanopy Html** and **XIF**: both join their line runs with a leading space, so each save added another space to the start of the second line.
- **Magic Video Titler** and **Smart Titler**: these charsets encode the Croatian/Serbian digraphs as single ASCII letters (`nj` is written `w`). `EncodeText` inverted the decode map but looked values up **one character at a time**, so the two-character values could never match — a digraph was written through unchanged and read back as something else, changing the text on every save.

## Frame rate (1, two formats)

- **Final Cut Pro Xml** and **Final Cut Pro Test Xml** read the `<timebase>` but ignored the `<ntsc>` flag that qualifies it — in Final Cut XML, timebase 24 with `ntsc TRUE` means 23.976. Every NTSC file was therefore read 0.1% too fast (about 3.6 seconds an hour), and the flag was flipped to FALSE when the file was saved again.

## Triaged as not-bugs

Regenerated GUIDs (D-Cinema, SubUrbia) and a `xml:lang` attribute that TTML adds once are stable by design. The remaining "unstable" formats write `Paragraph.Number` verbatim, which only differs for a subtitle that was never renumbered — a harness artifact, not a product path. A 100-hour probe just wraps 2-digit hour fields, as any such format must.

## Tests

Suites green: libse 1606 (22 new), libuilogic 703, seconv 416, UI 4143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)