### PR TITLE
Fix 20 bugs found in a random bug hunt

### DIFF
--- a/src/libse/Common/SeJsonParser.cs
+++ b/src/libse/Common/SeJsonParser.cs
@@ -86,6 +86,15 @@ namespace Nikse.SubtitleEdit.Core.Common
                     {
                         i++;
                         var end = content.IndexOf('"', i);
+                        if (end < 0)
+                        {
+                            // Unterminated name - the file is truncated or damaged. Bail out
+                            // instead of letting Substring throw out of the reader (and out of
+                            // IsMine, which format detection calls unguarded).
+                            Errors.Add($"Fatal - unterminated string at position {i}");
+                            return list;
+                        }
+
                         objectName = content.Substring(i, end - i).Trim();
                         var colon = content.IndexOf(':', end);
                         if (colon < 0)
@@ -151,7 +160,9 @@ namespace Nikse.SubtitleEdit.Core.Common
                                 Errors.Add($"Fatal - expected char \" after position {endSeek}");
                                 return list;
                             }
-                            skip = content[end - 1] == '\\';
+                            // end can be 0 when the value's opening quote is the very first
+                            // character (a truncated file), and content[-1] threw.
+                            skip = end > 0 && content[end - 1] == '\\';
                             if (skip)
                             {
                                 endSeek = end + 1;
@@ -247,7 +258,10 @@ namespace Nikse.SubtitleEdit.Core.Common
                     else if ("+-0123456789".IndexOf(ch) >= 0)
                     {
                         sb.Clear();
-                        while (IsNumberChar(content[i]) && i < max)
+                        // Bounds check FIRST: this indexed content[i] before testing i < max,
+                        // so a file whose last characters are a number (a truncated one)
+                        // threw IndexOutOfRangeException straight out of the reader.
+                        while (i < max && IsNumberChar(content[i]))
                         {
                             sb.Append(content[i]);
                             i++;
@@ -378,6 +392,15 @@ namespace Nikse.SubtitleEdit.Core.Common
                     {
                         i++;
                         var end = content.IndexOf('"', i);
+                        if (end < 0)
+                        {
+                            // Unterminated name - the file is truncated or damaged. Bail out
+                            // instead of letting Substring throw out of the reader (and out of
+                            // IsMine, which format detection calls unguarded).
+                            Errors.Add($"Fatal - unterminated string at position {i}");
+                            return list;
+                        }
+
                         objectName = content.Substring(i, end - i).Trim();
                         var colon = content.IndexOf(':', end);
                         if (colon < 0)
@@ -443,7 +466,9 @@ namespace Nikse.SubtitleEdit.Core.Common
                                 Errors.Add($"Fatal - expected char \" after position {endSeek}");
                                 return list;
                             }
-                            skip = content[end - 1] == '\\';
+                            // end can be 0 when the value's opening quote is the very first
+                            // character (a truncated file), and content[-1] threw.
+                            skip = end > 0 && content[end - 1] == '\\';
                             if (skip)
                             {
                                 endSeek = end + 1;
@@ -684,6 +709,15 @@ namespace Nikse.SubtitleEdit.Core.Common
                     {
                         i++;
                         var end = content.IndexOf('"', i);
+                        if (end < 0)
+                        {
+                            // Unterminated name - the file is truncated or damaged. Bail out
+                            // instead of letting Substring throw out of the reader (and out of
+                            // IsMine, which format detection calls unguarded).
+                            Errors.Add($"Fatal - unterminated string at position {i}");
+                            return list;
+                        }
+
                         objectName = content.Substring(i, end - i).Trim();
                         var colon = content.IndexOf(':', end);
                         if (colon < 0)
@@ -749,7 +783,9 @@ namespace Nikse.SubtitleEdit.Core.Common
                                 Errors.Add($"Fatal - expected char \" after position {endSeek}");
                                 return list;
                             }
-                            skip = content[end - 1] == '\\';
+                            // end can be 0 when the value's opening quote is the very first
+                            // character (a truncated file), and content[-1] threw.
+                            skip = end > 0 && content[end - 1] == '\\';
                             if (skip)
                             {
                                 endSeek = end + 1;
@@ -826,7 +862,10 @@ namespace Nikse.SubtitleEdit.Core.Common
                     }
                     else if ("+-0123456789".IndexOf(ch) >= 0)
                     {
-                        while (IsNumberChar(content[i]) && i < max)
+                        // Bounds check FIRST: this indexed content[i] before testing i < max,
+                        // so a file whose last characters are a number (a truncated one)
+                        // threw IndexOutOfRangeException straight out of the reader.
+                        while (i < max && IsNumberChar(content[i]))
                         {
                             i++;
                         }
@@ -978,6 +1017,13 @@ namespace Nikse.SubtitleEdit.Core.Common
                     {
                         i++;
                         var end = content.IndexOf('"', i);
+                        if (end < 0)
+                        {
+                            // Unterminated name - see the list-returning overloads above.
+                            Errors.Add($"Fatal - unterminated string at position {i}");
+                            return string.Empty;
+                        }
+
                         objectName = content.Substring(i, end - i).Trim();
                         var colon = content.IndexOf(':', end);
                         if (colon < 0)
@@ -1052,7 +1098,9 @@ namespace Nikse.SubtitleEdit.Core.Common
                                 Errors.Add($"Fatal - expected char \" after position {endSeek}");
                                 return string.Empty;
                             }
-                            skip = content[end - 1] == '\\';
+                            // end can be 0 when the value's opening quote is the very first
+                            // character (a truncated file), and content[-1] threw.
+                            skip = end > 0 && content[end - 1] == '\\';
                             if (skip)
                             {
                                 endSeek = end + 1;
@@ -1137,7 +1185,10 @@ namespace Nikse.SubtitleEdit.Core.Common
                     else if ("+-0123456789".IndexOf(ch) >= 0)
                     {
                         sb.Clear();
-                        while (IsNumberChar(content[i]) && i < max)
+                        // Bounds check FIRST: this indexed content[i] before testing i < max,
+                        // so a file whose last characters are a number (a truncated one)
+                        // threw IndexOutOfRangeException straight out of the reader.
+                        while (i < max && IsNumberChar(content[i]))
                         {
                             sb.Append(content[i]);
                             i++;
@@ -1280,6 +1331,15 @@ namespace Nikse.SubtitleEdit.Core.Common
                     {
                         i++;
                         var end = content.IndexOf('"', i);
+                        if (end < 0)
+                        {
+                            // Unterminated name - the file is truncated or damaged. Bail out
+                            // instead of letting Substring throw out of the reader (and out of
+                            // IsMine, which format detection calls unguarded).
+                            Errors.Add($"Fatal - unterminated string at position {i}");
+                            return list;
+                        }
+
                         objectName = content.Substring(i, end - i).Trim();
                         var colon = content.IndexOf(':', end);
                         if (colon < 0)
@@ -1364,7 +1424,9 @@ namespace Nikse.SubtitleEdit.Core.Common
                                 Errors.Add($"Fatal - expected char \" after position {endSeek}");
                                 return list;
                             }
-                            skip = content[end - 1] == '\\';
+                            // end can be 0 when the value's opening quote is the very first
+                            // character (a truncated file), and content[-1] threw.
+                            skip = end > 0 && content[end - 1] == '\\';
                             if (skip)
                             {
                                 endSeek = end + 1;

--- a/src/libse/Common/Subtitle.cs
+++ b/src/libse/Common/Subtitle.cs
@@ -291,7 +291,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             var ext = Path.GetExtension(fileName).ToLowerInvariant();
             foreach (var subtitleFormat in SubtitleFormat.AllSubtitleFormats.Where(p => p.Extension.Equals(ext, StringComparison.OrdinalIgnoreCase) && !p.Name.StartsWith("Unknown", StringComparison.Ordinal)))
             {
-                if (subtitleFormat.IsMine(lines, fileName))
+                if (IsFormatMine(subtitleFormat, lines, fileName))
                 {
                     return FinalizeFormat(fileName, batchMode, sourceFrameRate, lines, subtitleFormat, loadSubtitle);
                 }
@@ -299,7 +299,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 
             foreach (var subtitleFormat in SubtitleFormat.AllSubtitleFormats.Where(p => !p.Extension.Equals(ext, StringComparison.OrdinalIgnoreCase) || p.Name.StartsWith("Unknown", StringComparison.Ordinal)))
             {
-                if (subtitleFormat.IsMine(lines, fileName))
+                if (IsFormatMine(subtitleFormat, lines, fileName))
                 {
                     return FinalizeFormat(fileName, batchMode, sourceFrameRate, lines, subtitleFormat, loadSubtitle);
                 }
@@ -311,6 +311,25 @@ namespace Nikse.SubtitleEdit.Core.Common
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Asks one format whether the lines are its own. A damaged or truncated file can make a
+        /// reader throw (an unclosed xml element, a json string with no end quote, ...), and this
+        /// runs for EVERY format when a file is opened - so a throw here used to take down the
+        /// whole open instead of moving on to the next format.
+        /// </summary>
+        private static bool IsFormatMine(SubtitleFormat subtitleFormat, List<string> lines, string fileName)
+        {
+            try
+            {
+                return subtitleFormat.IsMine(lines, fileName);
+            }
+            catch (Exception exception)
+            {
+                System.Diagnostics.Debug.WriteLine($"{subtitleFormat.Name}.IsMine failed: {exception.Message}");
+                return false;
+            }
         }
 
         private static List<string> ReadLinesFromFile(string fileName, Encoding useThisEncoding, out Encoding encoding)

--- a/src/libse/SubtitleFormats/CsvDaVinci.cs
+++ b/src/libse/SubtitleFormats/CsvDaVinci.cs
@@ -43,10 +43,27 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var csvLines = ReadCsvLines(lines, ',');
             foreach (var line in csvLines)
             {
+                if (line.Text == null)
+                {
+                    // No text column at this index: the file is some other csv dialect. Count it
+                    // as an error so IsMine (paragraphs > errors) stops claiming those files and
+                    // importing every cue with blank text.
+                    _errorCount++;
+                    if (_errorCount > 10)
+                    {
+                        return;
+                    }
+
+                    continue;
+                }
+
                 if (ParseTimeCode(line.Start, out var start) &&
                     ParseTimeCode(line.End, out var end))
                 {
-                    var p = new Paragraph(start, end, line.Text)
+                    // A row with fewer columns than this layout expects (any other csv
+                    // dialect) never assigns Text, and a Paragraph with a null Text makes
+                    // everything downstream - the grid, saving, RemoveEmptyLines - throw.
+                    var p = new Paragraph(start, end, line.Text ?? string.Empty)
                     {
                         Actor = line.Character,
                         Effect = line.Play ? "True" : "False"

--- a/src/libse/SubtitleFormats/EZTSubtitlesProject.cs
+++ b/src/libse/SubtitleFormats/EZTSubtitlesProject.cs
@@ -121,7 +121,18 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
 
             var doc = new XmlDocument { XmlResolver = null };
-            doc.LoadXml(xml);
+            try
+            {
+                doc.LoadXml(xml);
+            }
+            catch (Exception exception)
+            {
+                // A truncated or damaged file must read as "not mine", not throw out of the
+                // reader (and out of IsMine, which runs for every format when opening a file).
+                System.Diagnostics.Debug.WriteLine(exception.Message);
+                _errorCount = 1;
+                return;
+            }
             var subtitles = doc.DocumentElement.SelectSingleNode("Subtitles");
             if (subtitles == null)
             {

--- a/src/libse/SubtitleFormats/EbuTtD.cs
+++ b/src/libse/SubtitleFormats/EbuTtD.cs
@@ -268,7 +268,19 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
             catch
             {
-                xml.LoadXml(JoinLines(lines).Replace(" & ", " &amp; ").RemoveControlCharactersButWhiteSpace().Trim());
+                try
+                {
+                    xml.LoadXml(JoinLines(lines).Replace(" & ", " &amp; ").RemoveControlCharactersButWhiteSpace().Trim());
+                }
+                catch (Exception exception)
+                {
+                    // The retry is the last chance to make sense of the file; a truncated or
+                    // damaged one must read as "not mine", not throw out of the reader (and out
+                    // of IsMine, which runs for every format when a file is opened).
+                    System.Diagnostics.Debug.WriteLine(exception.Message);
+                    _errorCount = 1;
+                    return;
+                }
             }
 
             subtitle.Header = JoinLines(lines);

--- a/src/libse/SubtitleFormats/F4Xml.cs
+++ b/src/libse/SubtitleFormats/F4Xml.cs
@@ -54,7 +54,18 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
 
             var doc = new XmlDocument { XmlResolver = null };
-            doc.LoadXml(xml);
+            try
+            {
+                doc.LoadXml(xml);
+            }
+            catch (Exception exception)
+            {
+                // A truncated or damaged file must read as "not mine", not throw out of the
+                // reader (and out of IsMine, which runs for every format when opening a file).
+                System.Diagnostics.Debug.WriteLine(exception.Message);
+                _errorCount = 1;
+                return;
+            }
             var content = doc.DocumentElement.SelectSingleNode("content");
             if (content == null)
             {

--- a/src/libse/SubtitleFormats/Footage.cs
+++ b/src/libse/SubtitleFormats/Footage.cs
@@ -24,8 +24,11 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
+            // Hand the ASCII probe the lines we already have: passing null made it fall through
+            // to reading the file from disk, which threw FileNotFoundException whenever detection
+            // ran on content that is not on disk under this name (clipboard, batch, conversion).
             var asc = new TimeLineFootageAscii();
-            if (fileName != null && asc.IsMine(null, fileName))
+            if (fileName != null && asc.IsMine(lines, fileName))
             {
                 return false;
             }

--- a/src/libse/SubtitleFormats/GooglePlayJson.cs
+++ b/src/libse/SubtitleFormats/GooglePlayJson.cs
@@ -52,9 +52,18 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             Dictionary<string, object> dictionary;
             try
             {
-                dictionary = (Dictionary<string, object>)parser.Parse(allText);
+                // "as", not a cast: this format expects a json OBJECT at the root, but plenty of
+                // subtitle json files are an ARRAY - and the InvalidCastException escaped through
+                // IsMine (which the format detection calls unguarded), so merely opening such a
+                // file crashed instead of moving on to the next format.
+                dictionary = parser.Parse(allText) as Dictionary<string, object>;
             }
             catch (ParserException)
+            {
+                return;
+            }
+
+            if (dictionary == null)
             {
                 return;
             }

--- a/src/libse/SubtitleFormats/MsOfficeWorkbook.cs
+++ b/src/libse/SubtitleFormats/MsOfficeWorkbook.cs
@@ -154,7 +154,19 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
             catch
             {
-                xml.LoadXml(JoinLines(lines));
+                try
+                {
+                    xml.LoadXml(JoinLines(lines));
+                }
+                catch (Exception exception)
+                {
+                    // The retry is the last chance to make sense of the file; a truncated or
+                    // damaged one must read as "not mine", not throw out of the reader (and out
+                    // of IsMine, which runs for every format when a file is opened).
+                    System.Diagnostics.Debug.WriteLine(exception.Message);
+                    _errorCount = 1;
+                    return;
+                }
             }
 
             var xmlNamespaceManager = MakeNamespaceManager(xml);

--- a/src/libse/SubtitleFormats/NetflixImsc11Japanese.cs
+++ b/src/libse/SubtitleFormats/NetflixImsc11Japanese.cs
@@ -420,7 +420,19 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
             catch
             {
-                xml.LoadXml(JoinLines(lines).Replace(" & ", " &amp; ").Replace("Q&A", "Q&amp;A").RemoveControlCharactersButWhiteSpace().Trim());
+                try
+                {
+                    xml.LoadXml(JoinLines(lines).Replace(" & ", " &amp; ").Replace("Q&A", "Q&amp;A").RemoveControlCharactersButWhiteSpace().Trim());
+                }
+                catch (Exception exception)
+                {
+                    // The retry is the last chance to make sense of the file; a truncated or
+                    // damaged one must read as "not mine", not throw out of the reader (and out
+                    // of IsMine, which runs for every format when a file is opened).
+                    System.Diagnostics.Debug.WriteLine(exception.Message);
+                    _errorCount = 1;
+                    return;
+                }
             }
 
             var frameRateAttr = xml.DocumentElement.Attributes["ttp:frameRate"];

--- a/src/libse/SubtitleFormats/OresmeDocXDocument.cs
+++ b/src/libse/SubtitleFormats/OresmeDocXDocument.cs
@@ -210,7 +210,17 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             _errorCount = 0;
             var sb = new StringBuilder();
             var xml = new XmlDocument { XmlResolver = null };
-            xml.LoadXml(JoinLinesTrimmed(lines));
+            try
+            {
+                xml.LoadXml(JoinLinesTrimmed(lines));
+            }
+            catch (Exception exception)
+            {
+                // Damaged/truncated xml is "not mine", not an exception out of the reader.
+                System.Diagnostics.Debug.WriteLine(exception.Message);
+                _errorCount = 1;
+                return;
+            }
             var nsmgr = new XmlNamespaceManager(xml.NameTable);
             nsmgr.AddNamespace("w", "http://schemas.openxmlformats.org/wordprocessingml/2006/main");
             foreach (XmlNode node in xml.DocumentElement.SelectNodes("//w:tr", nsmgr))

--- a/src/libse/SubtitleFormats/TimedTextImsc11.cs
+++ b/src/libse/SubtitleFormats/TimedTextImsc11.cs
@@ -540,7 +540,19 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
             catch
             {
-                xml.LoadXml(JoinLines(lines).Replace(" & ", " &amp; ").Replace("Q&A", "Q&amp;A").RemoveControlCharactersButWhiteSpace().Trim());
+                try
+                {
+                    xml.LoadXml(JoinLines(lines).Replace(" & ", " &amp; ").Replace("Q&A", "Q&amp;A").RemoveControlCharactersButWhiteSpace().Trim());
+                }
+                catch (Exception exception)
+                {
+                    // The retry is the last chance to make sense of the file; a truncated or
+                    // damaged one must read as "not mine", not throw out of the reader (and out
+                    // of IsMine, which runs for every format when a file is opened).
+                    System.Diagnostics.Debug.WriteLine(exception.Message);
+                    _errorCount = 1;
+                    return;
+                }
             }
 
             var frameRateAttr = xml.DocumentElement.Attributes["ttp:frameRate"];

--- a/src/libse/SubtitleFormats/TimedTextImscRosetta.cs
+++ b/src/libse/SubtitleFormats/TimedTextImscRosetta.cs
@@ -372,7 +372,19 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
             catch
             {
-                xml.LoadXml(JoinLines(lines).Replace(" & ", " &amp; ").Replace("Q&A", "Q&amp;A").RemoveControlCharactersButWhiteSpace().Trim());
+                try
+                {
+                    xml.LoadXml(JoinLines(lines).Replace(" & ", " &amp; ").Replace("Q&A", "Q&amp;A").RemoveControlCharactersButWhiteSpace().Trim());
+                }
+                catch (Exception exception)
+                {
+                    // The retry is the last chance to make sense of the file; a truncated or
+                    // damaged one must read as "not mine", not throw out of the reader (and out
+                    // of IsMine, which runs for every format when a file is opened).
+                    System.Diagnostics.Debug.WriteLine(exception.Message);
+                    _errorCount = 1;
+                    return;
+                }
             }
 
             var frameRateAttr = xml.DocumentElement.Attributes["ttp:frameRate"];

--- a/src/libse/SubtitleFormats/TimelineFootageAscii.cs
+++ b/src/libse/SubtitleFormats/TimelineFootageAscii.cs
@@ -47,6 +47,15 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 return false;
             }
 
+            // LoadSubtitle reads the bytes straight from disk, so detection on content that is
+            // not on disk under this name (clipboard, batch conversion, a not-yet-saved file)
+            // threw FileNotFoundException out of IsMine - which format detection calls for every
+            // format when opening a file.
+            if (!File.Exists(fileName))
+            {
+                return false;
+            }
+
             return base.IsMine(lines, fileName);
         }
 

--- a/src/libse/SubtitleFormats/TmpegEncXml.cs
+++ b/src/libse/SubtitleFormats/TmpegEncXml.cs
@@ -471,7 +471,17 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             double startSeconds = 0;
 
             var xml = new XmlDocument { XmlResolver = null };
-            xml.LoadXml(JoinLinesTrimmed(lines));
+            try
+            {
+                xml.LoadXml(JoinLinesTrimmed(lines));
+            }
+            catch (Exception exception)
+            {
+                // Damaged/truncated xml is "not mine", not an exception out of the reader.
+                System.Diagnostics.Debug.WriteLine(exception.Message);
+                _errorCount = 1;
+                return;
+            }
             var italicStyles = new List<bool>();
             var positionCodes = new List<int>();
 

--- a/src/libse/SubtitleFormats/UnknownSubtitle44.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle44.cs
@@ -34,6 +34,14 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     text.Append(' ');
                 }
 
+                // A line longer than the text column ran straight into the time code
+                // ("...break.00:00:06:00"), which the reader cannot split - that cue was lost on
+                // read and its time code swallowed by the previous one. Always keep a separator.
+                if (text.Length >= 34)
+                {
+                    text.Append(' ');
+                }
+
                 sb.AppendFormat("{0}{1}", text, EncodeTimeCode(p.StartTime));
                 if (index % 50 == 1)
                 {

--- a/src/libse/SubtitleFormats/UnknownSubtitle61.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle61.cs
@@ -27,8 +27,11 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var sb = new StringBuilder();
             foreach (Paragraph p in subtitle.Paragraphs)
             {
+                // One time code per cue, as the sample at the top of this file shows and as
+                // LoadSubtitle expects - writing the end time as a second time code made the
+                // reader treat it as the NEXT cue's start, so every exported file came back
+                // with shifted times and could not even be detected as this format.
                 sb.AppendLine(EncodeTimeCode(p.StartTime));
-                sb.AppendLine(EncodeTimeCode(p.EndTime));
                 sb.AppendLine(HtmlUtil.RemoveHtmlTags(p.Text));
                 sb.AppendLine();
             }

--- a/src/libse/SubtitleFormats/YouTubeChapters.cs
+++ b/src/libse/SubtitleFormats/YouTubeChapters.cs
@@ -77,7 +77,17 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override string ToText(Subtitle subtitle, string title)
         {
-            return ToDescriptionText(ChapterHelper.FromSubtitle(subtitle));
+            var chapters = ChapterHelper.FromSubtitle(subtitle);
+
+            // YouTube only accepts a chapter list whose first entry is at 0:00 (LoadSubtitle
+            // below enforces the same rule) - so a subtitle that does not start at zero used to
+            // be exported as a list YouTube rejects, and that SE itself could not read back.
+            if (chapters.Count > 0 && chapters[0].StartMilliseconds > 0)
+            {
+                chapters.Insert(0, new Chapter(0, chapters[0].Title));
+            }
+
+            return ToDescriptionText(chapters);
         }
 
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)

--- a/tests/libse/SubtitleFormats/FormatRobustnessBugsTest.cs
+++ b/tests/libse/SubtitleFormats/FormatRobustnessBugsTest.cs
@@ -1,0 +1,189 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+
+namespace LibSETests.SubtitleFormats;
+
+/// <summary>
+/// Guard tests for defects found on three axes (2026-08-27 bug hunt):
+/// format DETECTION (which format claims a file, and does IsMine ever throw),
+/// reader ROBUSTNESS against truncated/damaged input, and writer/reader agreement.
+/// IsMine runs for every known format when a file is opened, so a throw there used to take
+/// down the whole open.
+/// </summary>
+public class FormatRobustnessBugsTest
+{
+    private static Subtitle MakeSubtitle()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Hello world.", 2000, 4000));
+        subtitle.Paragraphs.Add(new Paragraph("Second line here," + Environment.NewLine + "with a line break.", 6000, 9000));
+        subtitle.Paragraphs.Add(new Paragraph("Third line of the test.", 12000, 15000));
+        subtitle.Paragraphs.Add(new Paragraph("Fourth and last.", 18000, 21000));
+        return subtitle;
+    }
+
+    private static Subtitle RoundTrip(SubtitleFormat format, Subtitle subtitle)
+    {
+        var text = format.ToText(subtitle, "title");
+        var target = new Subtitle();
+        format.LoadSubtitle(target, text.SplitToLines(), "test" + format.Extension);
+        return target;
+    }
+
+    [Fact]
+    public void IsMine_NeverThrows_ForAnyFormatOnAnyOtherFormatsOutput()
+    {
+        // The detection loop calls IsMine on every format; a json root that is an array made
+        // GooglePlayJson throw InvalidCastException, and a file name that is not on disk made
+        // Footage throw FileNotFoundException - both crashed opening the file.
+        var subtitle = MakeSubtitle();
+        var formats = SubtitleFormat.AllSubtitleFormats.Where(f => f.IsTextBased).ToList();
+
+        foreach (var writer in formats)
+        {
+            string text;
+            try { text = writer.ToText(subtitle, "title"); }
+            catch (NotImplementedException) { continue; }
+            if (string.IsNullOrWhiteSpace(text)) continue;
+
+            var lines = text.SplitToLines();
+            foreach (var reader in formats)
+            {
+                var exception = Record.Exception(() => reader.IsMine(lines, "probe" + writer.Extension));
+                Assert.True(exception == null,
+                    $"{reader.Name}.IsMine threw on {writer.Name} output: {exception}");
+            }
+        }
+    }
+
+    [Fact]
+    public void Readers_DoNotThrow_OnTruncatedInput()
+    {
+        // A damaged or half-written file must read as "not mine", never throw: unterminated json
+        // strings gave a negative Substring length, a json value whose opening quote was the
+        // first character indexed content[-1], a file ending in a number indexed past the end,
+        // and several xml readers called LoadXml (or their fallback LoadXml) unguarded.
+        var subtitle = MakeSubtitle();
+
+        foreach (var format in SubtitleFormat.AllSubtitleFormats.Where(f => f.IsTextBased))
+        {
+            string text;
+            try { text = format.ToText(subtitle, "title"); }
+            catch (NotImplementedException) { continue; }
+            if (string.IsNullOrWhiteSpace(text)) continue;
+
+            foreach (var cut in new[] { text.Length / 2, text.Length * 9 / 10 })
+            {
+                var damaged = text.Substring(0, Math.Max(1, cut));
+                var lines = damaged.SplitToLines();
+
+                var exception = Record.Exception(() =>
+                {
+                    var target = new Subtitle();
+                    if (format.IsMine(lines, "probe" + format.Extension))
+                    {
+                        format.LoadSubtitle(target, lines, "probe" + format.Extension);
+                    }
+                });
+
+                Assert.True(exception == null,
+                    $"{format.Name} threw on input truncated to {cut} chars: {exception}");
+            }
+        }
+    }
+
+    [Fact]
+    public void SeJsonParser_UnterminatedString_DoesNotThrow()
+    {
+        var parser = new SeJsonParser();
+
+        Assert.Null(Record.Exception(() => parser.GetArrayElements("[{\"text\": \"unterminated")));
+        Assert.Null(Record.Exception(() => parser.GetArrayElementsByName("{\"body\":[{\"content\": \"oops", "body")));
+        Assert.Null(Record.Exception(() => parser.GetFirstObject("{\"start\": 1234", "start")));
+    }
+
+    [Fact]
+    public void SeJsonParser_ContentEndingInNumber_DoesNotThrow()
+    {
+        // "while (IsNumberChar(content[i]) && i < max)" indexed before checking the bound.
+        var parser = new SeJsonParser();
+
+        Assert.Null(Record.Exception(() => parser.GetArrayElements("[{\"start\": 1234")));
+    }
+
+    [Fact]
+    public void GooglePlayJson_ArrayRoot_IsNotMineInsteadOfThrowing()
+    {
+        var lines = "[ {\"start\": 1000, \"end\": 2000, \"text\": \"Hi\"} ]".SplitToLines();
+
+        var format = new GooglePlayJson();
+
+        Assert.Null(Record.Exception(() => format.IsMine(lines, "probe.json")));
+    }
+
+    [Fact]
+    public void CsvDaVinci_DoesNotClaimOtherCsvDialects()
+    {
+        // It used to claim any csv with time columns and import every cue with blank text
+        // (the text column index simply did not exist, leaving Paragraph.Text null).
+        var nuendo = new CsvNuendo();
+        var text = nuendo.ToText(MakeSubtitle(), "title");
+        var lines = text.SplitToLines();
+
+        Assert.False(new CsvDaVinci().IsMine(lines, "probe.csv"));
+    }
+
+    [Fact]
+    public void CsvDaVinci_NeverProducesNullText()
+    {
+        var text = new CsvNuendo().ToText(MakeSubtitle(), "title");
+        var target = new Subtitle();
+
+        new CsvDaVinci().LoadSubtitle(target, text.SplitToLines(), "probe.csv");
+
+        Assert.All(target.Paragraphs, p => Assert.NotNull(p.Text));
+    }
+
+    [Fact]
+    public void YouTubeChapters_WritesAListItCanReadBack()
+    {
+        // YouTube only accepts a chapter list starting at 0:00 and LoadSubtitle enforces that,
+        // but ToText exported the subtitle's own first time - a file neither YouTube nor SE
+        // would accept.
+        var format = new YouTubeChapters();
+        var text = format.ToText(MakeSubtitle(), "title");
+
+        Assert.True(format.IsMine(text.SplitToLines(), "probe.txt"));
+
+        var target = RoundTrip(format, MakeSubtitle());
+        Assert.NotEmpty(target.Paragraphs);
+        Assert.Equal(0, target.Paragraphs[0].StartTime.TotalMilliseconds, 0);
+    }
+
+    [Fact]
+    public void UnknownSubtitle61_CanReadItsOwnOutput()
+    {
+        // ToText wrote a second time code per cue that LoadSubtitle read as the NEXT cue's
+        // start, so every exported file came back shifted - and undetectable.
+        var format = new UnknownSubtitle61();
+        var text = format.ToText(MakeSubtitle(), "title");
+
+        Assert.True(format.IsMine(text.SplitToLines(), "probe.txt"));
+
+        var target = RoundTrip(format, MakeSubtitle());
+        Assert.Equal(4, target.Paragraphs.Count);
+        Assert.Equal(2000, target.Paragraphs[0].StartTime.TotalMilliseconds, 0);
+        Assert.Equal("Hello world.", target.Paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void UnknownSubtitle44_LongLine_DoesNotSwallowTheNextCue()
+    {
+        // Text longer than the fixed text column ran into the time code with no separator, so
+        // the reader lost that cue entirely.
+        var target = RoundTrip(new UnknownSubtitle44(), MakeSubtitle());
+
+        Assert.Equal(4, target.Paragraphs.Count);
+        Assert.Contains("with a line break.", target.Paragraphs[1].Text, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
Twelfth general bug-hunt sweep. Three axes none of the earlier sweeps used: **which format claims a file** (and whether `IsMine` can throw), **reader robustness** against truncated input, and **writer/reader agreement**. 10 new guard tests, two of which sweep every text format exhaustively.

The unifying insight: `IsMine` runs for *every* known format when any file is opened, and `Subtitle.LoadSubtitle` did not catch — so an exception in any one reader crashed opening the file, no matter which format the file actually was.

## Crashes while opening a file (13 formats, 5 root causes)

- **Google Play json** cast the parsed json straight to a `Dictionary`, so any json file whose root is an **array** — extremely common — threw `InvalidCastException` out of detection. Opening such a file crashed rather than moving on to the next format.
- **Footage** passed `null` lines to the ASCII probe, which fell through to reading the file from disk: `FileNotFoundException` whenever detection ran on content that is not on disk under that name (clipboard paste, batch conversion, in-memory conversion).
- **SeJsonParser** threw on damaged json three different ways, each affecting a family of formats (Bilibili, HoliStar, JSON Aeneas, JSON Type 16/17/18/19/21):
  - an unterminated string made `IndexOf` return −1 and `Substring(i, end - i)` got a negative length;
  - a value whose opening quote was the very first character indexed `content[-1]`;
  - `while (IsNumberChar(content[i]) && i < max)` indexed **before** testing the bound, so a file ending in a number ran past the end.
- **Ten xml readers** called `LoadXml` unguarded — several of them in the `catch` of their first attempt, so the *fallback* parse was the one that threw: EZT XML, EBU-TT-D, F4 Xml, MS Office Workbook, Netflix IMSC 1.1 Japanese, Oresme Docx, TMPGEnc AW5, TMPGEnc VME, Timed Text IMSC 1.1, Timed Text IMSC Rosetta.
- **The detection loop itself** now skips a format whose `IsMine` throws instead of letting it escape, so no future reader can take down opening a file.

## Wrong format claimed, or data lost (4)

- **Csv DaVinci** claimed any csv with time columns. A **Csv Nuendo** file opened as DaVinci with *every cue's text blank* — and because the text column index did not exist, `Paragraph.Text` was left **null**, which throws anywhere downstream that touches it.
- **YouTube chapters** exported a list starting at the subtitle's own first time, but YouTube — and this format's own reader — only accept a chapter list starting at `0:00`. The export was rejected by both; SE could not reopen what it had just written.
- **Unknown 61** wrote two time codes per cue while its reader expects one (as its own documented sample shows), so every exported file came back with shifted times and failed detection entirely.
- **Unknown 44** ran text longer than its fixed-width text column straight into the time code with no separator (`...break.00:00:06:00`), so the reader lost that cue and folded its time code into the previous one.

## Triaged as not-bugs

Several detection overlaps turned out to be harmless once measured against the real detection order (SE tries extension-matching formats first): Csv4-as-Csv3, SAMI YouTube-as-SAMI modern and Scenarist-as-Adobe Encore all parse to byte-identical results, and the Final Cut Pro variants differ only by frame quantization. Overlaps among the `Unknown NN` catch-alls are by design — they are tried last. libse's text processors (`RemoveTextForHI`, `AutoBreakLine`, `DurationsBridgeGaps`) passed every invariant I threw at them, including unbalanced tags, control characters and 2000-character lines.

## Tests

Suites green: libse 1616 (10 new), libuilogic 703, seconv 416, UI 4143. Two of the new tests are exhaustive sweeps — every text format's `IsMine` against every other format's output, and every reader against truncated input — so this whole class stays fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)