### PR TITLE
Stop the waveform cursor jumping away after a click (#14187)

### DIFF
--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -1744,6 +1744,11 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
 
     private double? _pausedValue;
 
+    // Stopwatch timestamp of the last seek issued through the Position setter; 0 = none yet.
+    // Compared against the playback-restart timestamp so Pause() can tell a seek target that
+    // is still in flight (keep it) from one whose seek finished long ago (stale - clear it).
+    private long _lastSeekIssuedTimestamp;
+
     // Last raw time-pos seen by the Position getter/setter, used to gate the eof-reached
     // probe below. -1 = unknown (always probe).
     private double _lastRawTimePos = -1;
@@ -1878,6 +1883,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
             // one per input event), every caller already treats the result as asynchronous
             // (the playhead pin waits for the position to actually arrive), and the error
             // result was never acted on here.
+            Interlocked.Exchange(ref _lastSeekIssuedTimestamp, System.Diagnostics.Stopwatch.GetTimestamp());
             DoMpvCommandFireAndForget("seek", value.ToString(CultureInfo.InvariantCulture), "absolute");
         }
     }
@@ -2070,11 +2076,24 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
             return;
         }
 
-        // Every other state transition clears this (LoadFile/PlayOrPause/CloseFile/Stop/Play/
-        // frame steps). Without it, pausing after a seek made during playback made the Position
-        // getter keep returning that old seek target, so the slider, clock and playhead all
-        // jumped back to it.
-        _pausedValue = null;
+        // A finished seek's target is stale: pausing after a seek made minutes ago during
+        // playback made the Position getter keep returning that old target, so the slider,
+        // clock and playhead all jumped back to it - clear it, like the other state
+        // transitions do (LoadFile/PlayOrPause/CloseFile/Stop/Play/frame steps).
+        //
+        // But a seek still in flight is the opposite case: its target IS where playback is
+        // about to be, and the waveform click path depends on the getter reporting it. A
+        // click seeks first (pointer release) and pauses a moment later (tap), and the
+        // second Position assignment no-ops in Avalonia because the property already holds
+        // the value - so clearing here left the getter serving mpv's pre-seek position
+        // until the async seek landed, and the cursor jumped away from the click (#14187).
+        var seekInFlight = _eventLoopActive &&
+                           Interlocked.Read(ref _lastSeekIssuedTimestamp) != 0 &&
+                           !HasPlaybackRestartedSince(Interlocked.Read(ref _lastSeekIssuedTimestamp));
+        if (!seekInFlight)
+        {
+            _pausedValue = null;
+        }
 
         var err = DoMpvCommand("set", "pause", "yes");
         if (err < 0)

--- a/tests/UI/Logic/VideoPlayers/LibMpvEventLoopTests.cs
+++ b/tests/UI/Logic/VideoPlayers/LibMpvEventLoopTests.cs
@@ -157,6 +157,99 @@ public class LibMpvEventLoopTests
     }
 
     /// <summary>
+    /// Issue #14187: a waveform click seeks first (pointer release) and pauses a moment later
+    /// (tap) - and the second Position assignment no-ops at the Avalonia property layer, so the
+    /// player-level setter never runs again after the pause. Pause() must therefore not clear
+    /// the cached seek target while that seek is still in flight: the getter would fall back to
+    /// mpv's pre-seek time-pos and the waveform cursor jumped off the clicked position.
+    /// </summary>
+    [Fact]
+    public async Task Pause_RightAfterSeek_KeepsReportingTheSeekTarget()
+    {
+        var player = CreatePlayer();
+        if (player == null)
+        {
+            return; // no libmpv on this machine
+        }
+
+        var wavFileName = WriteTempWav();
+        try
+        {
+            await player.LoadFile(wavFileName);
+            Assert.True(await WaitUntilAsync(() => player.Duration > 1.0, 5000), "file never loaded");
+
+            player.Play();
+            Assert.True(await WaitUntilAsync(() => player.IsPlaying, 3000), "playback never started");
+            Assert.True(await WaitUntilAsync(() => player.Position > 0.1, 3000), "time-pos never advanced");
+
+            // The click sequence, back to back so the seek is still in flight when Pause runs.
+            player.Position = 1.5;
+            player.Pause();
+
+            // The very first read must already be the click target - the cursor pin releases
+            // onto whatever this getter returns.
+            Assert.Equal(1.5, player.Position, 3);
+
+            // And it must stay there while the async seek lands and the pause settles.
+            var end = Environment.TickCount64 + 800;
+            while (Environment.TickCount64 < end)
+            {
+                Assert.Equal(1.5, player.Position, 3);
+                await Task.Delay(40, TestContext.Current.CancellationToken);
+            }
+        }
+        finally
+        {
+            player.Dispose();
+            TryDelete(wavFileName);
+        }
+    }
+
+    /// <summary>
+    /// The stale-target half of the same invariant: a seek whose restart has long since fired is
+    /// finished business, so pausing later must NOT jump the reported position back to it.
+    /// </summary>
+    [Fact]
+    public async Task Pause_LongAfterSeek_DoesNotJumpBackToTheOldTarget()
+    {
+        var player = CreatePlayer();
+        if (player == null)
+        {
+            return; // no libmpv on this machine
+        }
+
+        var wavFileName = WriteTempWav();
+        try
+        {
+            await player.LoadFile(wavFileName);
+            Assert.True(await WaitUntilAsync(() => player.Duration > 1.0, 5000), "file never loaded");
+
+            player.Play();
+            Assert.True(await WaitUntilAsync(() => player.IsPlaying, 3000), "playback never started");
+
+            var beforeSeekTimestamp = Stopwatch.GetTimestamp();
+            player.Position = 0.5;
+            Assert.True(await WaitUntilAsync(() => player.HasPlaybackRestartedSince(beforeSeekTimestamp), 5000),
+                "seek never restarted");
+
+            // Let playback run well past the old target, then pause.
+            Assert.True(await WaitUntilAsync(() => player.Position >= 0.9, 5000),
+                $"playback never moved past the old seek target (was {player.Position})");
+            player.Pause();
+            Assert.True(await WaitUntilAsync(() => player.IsPaused, 3000), "pause never observed");
+
+            // Reported position must be where playback stopped, not the 0.5 from the old seek.
+            Assert.True(player.Position >= 0.85,
+                $"paused position jumped back toward the stale seek target (was {player.Position})");
+        }
+        finally
+        {
+            player.Dispose();
+            TryDelete(wavFileName);
+        }
+    }
+
+    /// <summary>
     /// A render-free core, like the text-to-speech preview players: null video/audio outputs so
     /// nothing opens a window or touches an audio device, but the clock still runs in real time.
     /// </summary>


### PR DESCRIPTION
Fixes #14187 — a beta25→beta26 regression: clicking the waveform set the cursor on the click, but a moment later it jumped away by itself (often clean off the visible view), coming back only when mpv's seek landed.

## What the videos show

Frame-tracing the reporter's recordings: the cursor lands on the click, holds ~0.5–1.5 s, then makes an instant jump — sometimes a small forward nudge, sometimes far enough to leave the visible waveform — with the player clock changing at exactly the jump moments. So the *reported player position* itself was flipping between the click target and mpv's pre-seek position.

## Root cause

A click on a waveform paragraph raises **two** events:

1. **Pointer release** seeks: `vp.Position = clickPos` → the player setter caches `_pausedValue = clickPos` and issues mpv's fire-and-forget seek.
2. **Tap**, a moment later, runs the click action: `Pause()` — which since beta26 (the stale-seek-target fix in the third bug hunt) unconditionally clears `_pausedValue` — followed by `vp.Position = clickPos`, which **no-ops at the Avalonia property layer** because the property already holds that value, so the player setter never runs again.

Net result: paused with `_pausedValue == null`, the Position getter fell back to mpv's observed `time-pos` — the **pre-seek** position until the async seek executed (which can take a second on a heavy file). The playhead pin released onto that stale position (the jump), then followed the seek when it finally landed. Clicks on empty waveform only fire one of the two events, which is why it reproduced "sometimes".

## Fix

`Pause()` now clears the cached seek target only when it is genuinely **stale** — i.e. no seek is still in flight, judged by comparing the timestamp of the last seek issued through the Position setter against the `MPV_EVENT_PLAYBACK_RESTART` timestamp the event loop already tracks. A seek still in flight keeps its target: that target *is* where playback is about to be, and it's exactly what the getter must report while mpv catches up.

The bug the clearing was added for — pausing long after a mid-playback seek jumped the clock back to that old target — stays fixed: a finished seek (restart already seen) is cleared exactly as before.

## Tests

Two new live-core tests in `LibMpvEventLoopTests` (real libmpv, `vo=null`/`ao=null`; vacuous pass without libmpv, like the rest of the file):

- `Pause_RightAfterSeek_KeepsReportingTheSeekTarget` — the click race; **fails on beta26's code**, passes with the fix.
- `Pause_LongAfterSeek_DoesNotJumpBackToTheOldTarget` — guards the original stale-target fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)