### PR TITLE
Fix 29 bugs found in a bug hunt

### DIFF
--- a/src/libse/Common/ContinuationUtilities.cs
+++ b/src/libse/Common/ContinuationUtilities.cs
@@ -708,7 +708,9 @@ namespace Nikse.SubtitleEdit.Core.Common
 
             foreach (var prefix in Prefixes)
             {
-                if (newFirstWord.StartsWith(prefix, StringComparison.Ordinal) && !newFirstWord.EndsWith(prefix + Environment.NewLine, StringComparison.Ordinal))
+                // EndsWith cannot express "the prefix is followed by a line break" - the prefix was
+                // just matched at the START. HasPrefix below is the correct twin of this test.
+                if (newFirstWord.StartsWith(prefix, StringComparison.Ordinal) && !newFirstWord.StartsWith(prefix + Environment.NewLine, StringComparison.Ordinal))
                 {
                     newFirstWord = newFirstWord.Substring(prefix.Length);
                 }

--- a/src/libse/Common/FixCasing.cs
+++ b/src/libse/Common/FixCasing.cs
@@ -175,7 +175,10 @@ namespace Nikse.SubtitleEdit.Core.Common
                     if (start.StartsWith(title.AsSpan(), StringComparison.OrdinalIgnoreCase))
                     {
                         var idx = i + title.Length;
-                        if (idx < text.Length - 2 && text[idx] == ' ')
+                        // The body reads text[idx] after the increment below, so the bound only
+                        // needs to leave one character - "- 2" skipped a one-letter word at the
+                        // end of the line ("Mr. t" was left alone while "Mr. to" was fixed).
+                        if (idx < text.Length - 1 && text[idx] == ' ')
                         {
                             idx++;
                             var words = text.Substring(idx).Split(' ', '\r', '\n', ',', '"', '?', '!', '.', '\'');

--- a/src/libse/ContainerFormats/Mp4/Boxes/Stbl.cs
+++ b/src/libse/ContainerFormats/Mp4/Boxes/Stbl.cs
@@ -75,7 +75,10 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
                         int version = Buffer[0];
                         var totalEntries = GetUInt(4);
 
-                        var entries = ClampEntries(totalEntries, 8, 4);
+                        // Entry 0 is GetUInt(8), i.e. bytes 8..11 - the helper wants the LAST byte
+                        // of the first entry (the other call sites pass it correctly). With 8 the
+                        // clamp allowed one entry too many and a short/truncated stco threw.
+                        var entries = ClampEntries(totalEntries, 11, 4);
                         ChunkOffsets.Capacity = ChunkOffsets.Count + entries;
                         for (var i = 0; i < entries; i++)
                         {
@@ -93,7 +96,8 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
                         int version = Buffer[0];
                         var totalEntries = GetUInt(4);
 
-                        var entries = ClampEntries(totalEntries, 8, 8);
+                        // Entry 0 is GetUInt64(8), i.e. bytes 8..15 - see the stco note above.
+                        var entries = ClampEntries(totalEntries, 15, 8);
                         ChunkOffsets.Capacity = ChunkOffsets.Count + entries;
                         for (var i = 0; i < entries; i++)
                         {

--- a/src/libse/ContainerFormats/Mp4/Boxes/Trun.cs
+++ b/src/libse/ContainerFormats/Mp4/Boxes/Trun.cs
@@ -49,8 +49,15 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes
                 DataOffset = GetUInt(0);
             }
 
-            var sampleLength = Math.Min(sampleCount * 16 + 24, maximumLength);
-            Buffer = new byte[sampleLength];
+            // maximumLength is the box's END POSITION in the file (Box.Position), not a byte count,
+            // so capping the sample table against it was inert - the size came entirely from the
+            // file's own sample_count, and a corrupt trun declaring 100M samples asked for 1.6 GB.
+            // Cap by the bytes actually left in the stream (never smaller than the real table, so
+            // valid files are unaffected) and do the multiply in 64-bit so it cannot wrap.
+            var bytesLeftInFile = fs.Length > fs.Position ? (ulong)(fs.Length - fs.Position) : 0UL;
+            var sampleLength = Math.Min((ulong)sampleCount * 16UL + 24UL, bytesLeftInFile);
+            sampleLength = Math.Min(sampleLength, int.MaxValue);
+            Buffer = new byte[(int)sampleLength];
             readCount = fs.Read(Buffer, 0, Buffer.Length);
             if (readCount < 4)
             {

--- a/src/libse/ContainerFormats/TransportStream/ProgramAssociationTable.cs
+++ b/src/libse/ContainerFormats/TransportStream/ProgramAssociationTable.cs
@@ -35,7 +35,13 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
             ProgramNumbers = new List<int>();
             ProgramIds = new List<int>();
             index = index + 8;
-            for (int i = 0; i < (SectionLength - 5) / 8; i++)
+            // Each PAT entry is 4 bytes (program_number 16 + reserved 3 + program_map_PID 13), and
+            // section_length covers the 5 header bytes read above, 4*N and a 4-byte CRC - so
+            // N = (SectionLength - 9) / 4. The loop used to step 8 bytes while reading only 4,
+            // which is right by accident for a single-program stream (the common capture) but
+            // dropped every second program otherwise: their PMTs were never parsed, so their
+            // subtitle tracks did not exist as far as SE was concerned.
+            for (int i = 0; i < (SectionLength - 9) / 4; i++)
             {
                 if (index + 3 < packetBuffer.Length)
                 {
@@ -43,7 +49,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
                     int programId = (packetBuffer[index + 2] & 0b00011111) * 256 + packetBuffer[index + 3];
                     ProgramNumbers.Add(programNumber);
                     ProgramIds.Add(programId);
-                    index += 8;
+                    index += 4;
                 }
             }
         }

--- a/src/libse/ContainerFormats/TransportStream/RegionCompositionSegment.cs
+++ b/src/libse/ContainerFormats/TransportStream/RegionCompositionSegment.cs
@@ -32,7 +32,12 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
             Region4BitPixelCode = buffer[index + 9] >> 4;
             Region2BitPixelCode = (buffer[index + 9] & 0b00001100) >> 2;
             int i = 0;
-            while (i < regionLength && i + index < buffer.Length)
+
+            // One object record spans buffer[index + i + 10 .. index + i + 15]. The old guard only
+            // tested the first of those six bytes against the buffer, and the caller guarantees no
+            // more than index + regionLength + 9, so a segment whose length is not 10 + 6k - a
+            // truncated or corrupt one - read up to five bytes past the end and threw.
+            while (i + 6 <= regionLength && index + i + 15 < buffer.Length)
             {
                 var regionCompositionSegmentObject = new RegionCompositionSegmentObject { ObjectId = Helper.GetEndianWord(buffer, i + index + 10) };
                 i += 2;

--- a/src/libse/ContainerFormats/TransportStream/TransportStreamParser.cs
+++ b/src/libse/ContainerFormats/TransportStream/TransportStreamParser.cs
@@ -836,7 +836,10 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
                     sub.StartMilliseconds = (ulong)seconds * 1000UL;
                     if (pes.PageCompositions.Count > 0)
                     {
-                        seconds += pes.PageCompositions[0].PageTimeOut;
+                        // Only compute the end here - the shared clock is advanced once per PES by
+                        // the block after this loop body. Doing it in both places double-counted
+                        // the page time-out for every subtitle-bearing display set, so the start
+                        // times drifted further and further ahead over the file.
                         sub.EndMilliseconds = sub.StartMilliseconds + (ulong)pes.PageCompositions[0].PageTimeOut * 1000UL;
                     }
                     else

--- a/src/libse/Forms/FixCommonErrors/FixSpanishInvertedQuestionAndExclamationMarks.cs
+++ b/src/libse/Forms/FixCommonErrors/FixSpanishInvertedQuestionAndExclamationMarks.cs
@@ -187,7 +187,11 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                                 }
                             }
                         }
-                        else if (last != null && !isLastLineClosed && inverseMarkIndex == p.Text.IndexOf(mark) && !last.Text.Contains(inverseMark))
+                        // "inverseMarkIndex == p.Text.IndexOf(mark)" asked whether one position
+                        // holds both the inverse mark and the mark, which is impossible, so this
+                        // whole "the sentence started in the previous subtitle" branch was dead.
+                        // The test is the same one the isLastLineClosed branch above uses.
+                        else if (last != null && !isLastLineClosed && (inverseMarkIndex < 0 || inverseMarkIndex > markIndex) && !last.Text.Contains(inverseMark))
                         {
                             int idx = last.Text.Length - 2;
                             while (idx > 0 && last.Text.Substring(idx, 2) != ". " && last.Text.Substring(idx, 2) != "! " && last.Text.Substring(idx, 2) != "? ")

--- a/src/libse/Forms/FixCommonErrors/NormalizeStrings.cs
+++ b/src/libse/Forms/FixCommonErrors/NormalizeStrings.cs
@@ -63,7 +63,11 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                         ;
                 }
 
-                var cyrillicLanguages = new[] { "ru" };
+                // Replacing Cyrillic "е" with Latin "e" is an OCR heuristic for Latin-script
+                // languages. Only Russian was exempt, so Bulgarian, Ukrainian, Serbian, Macedonian
+                // and the rest had a Latin "e" spliced into Cyrillic words - breaking spell check,
+                // search and sorting.
+                var cyrillicLanguages = new[] { "ru", "uk", "bg", "sr", "mk", "be", "kk", "ky", "mn", "tg" };
                 if (!cyrillicLanguages.Contains(twoLetterLanguageCode))
                 {
                     text = text

--- a/src/libse/Forms/TimeCodesBeautifier.cs
+++ b/src/libse/Forms/TimeCodesBeautifier.cs
@@ -652,7 +652,11 @@ namespace Nikse.SubtitleEdit.Core.Forms
                                 case BeautifyTimeCodesSettings.BeautifyTimeCodesProfile.ChainingShotChangeBehaviorEnum.ExtendUntilShotChange:
                                     // Put the right in cue on the shot change, plus gap
                                     newLeftOutCueFrame = bestLeftOutCueFrame;
-                                    newRightInCueFrame = lastShotChangeInBetween.Value + Configuration.Settings.BeautifyTimeCodes.Profile.OutCuesGap;
+                                    // An IN cue takes InCuesGap - every other in-cue placement
+                                    // uses it, and IsCueOnShotChange tests in cues against it. With
+                                    // the Netflix profile (in 0, out 2) this started the next
+                                    // subtitle two frames late, failing that profile's own check.
+                                    newRightInCueFrame = lastShotChangeInBetween.Value + Configuration.Settings.BeautifyTimeCodes.Profile.InCuesGap;
                                     break;
                             }
                         }

--- a/src/libuilogic/AutoTranslate/ChatGptTranslate.cs
+++ b/src/libuilogic/AutoTranslate/ChatGptTranslate.cs
@@ -49,11 +49,6 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
 
         public static string RemovePreamble(string original, string input)
         {
-            if (original.Contains(":") && input.IndexOf("<think>") < 0)
-            {
-                return input;
-            }
-
             var translation = input;
             var indexOfStartThink = translation.IndexOf("<think>");
             var indexOfEndThink = translation.IndexOf("</think>");
@@ -71,6 +66,15 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
                     // retry-on-no-progress logic (DoAutoTranslate) instead of shipping it.
                     return string.Empty;
                 }
+            }
+
+            // The colon guard has to be applied to the text left AFTER the think block is removed.
+            // It used to be "&&"-ed with "there is no <think>", so a reasoning model's answer
+            // skipped it entirely and PreambleRegex ate the real translation up to its first colon
+            // ("Anmerkung: Das ist wichtig." -> "this is important.").
+            if (original.Contains(':'))
+            {
+                return translation;
             }
 
             var match = PreambleRegex.Match(translation);

--- a/src/libuilogic/AutoTranslate/LaraTranslate.cs
+++ b/src/libuilogic/AutoTranslate/LaraTranslate.cs
@@ -135,9 +135,14 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
             return Convert.ToBase64String(hash);
         }
 
-        private static TranslationPair MakePair(string nameCode, string twoLetter)
+        private static TranslationPair MakePair(string nameCode, string localeCode)
         {
-            return new TranslationPair(nameCode, twoLetter, twoLetter);
+            // The code is an RFC3066 locale ("ja-JP"); the language tag is the part before the
+            // dash. Passing the whole locale as TwoLetterIsoLanguageName meant the exact
+            // two-letter comparisons downstream (IsCjkLanguage, TextSplit, IsNonMergeLanguage)
+            // matched nothing, so Japanese was merged and split with Latin heuristics.
+            var twoLetterIsoName = localeCode.Split('-')[0].ToLowerInvariant();
+            return new TranslationPair(nameCode, localeCode, twoLetterIsoName);
         }
 
         public static List<TranslationPair> ListLanguages()

--- a/src/libuilogic/Ocr/FixEngine/OcrFixReplaceList2.cs
+++ b/src/libuilogic/Ocr/FixEngine/OcrFixReplaceList2.cs
@@ -13,7 +13,9 @@ namespace Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine
         private static readonly Regex RegExIAndZero = new Regex(@"[a-zæøåöääöéèàùâêîôûëï][I1]", RegexOptions.Compiled);
         private static readonly Regex RegExTime1 = new Regex(@"[a-zæøåöääöéèàùâêîôûëï]0", RegexOptions.Compiled);
         private static readonly Regex RegExTime2 = new Regex(@"0[a-zæøåöääöéèàùâêîôûëï]", RegexOptions.Compiled);
-        private static readonly Regex HexNumber = new Regex(@"^#?[\dABDEFabcdef]+$", RegexOptions.Compiled);
+        // Uppercase "C" was missing (the lowercase run is complete), so this hex bail-out did not
+        // recognise e.g. "#0C0d" and the OCR fixer rewrote its "d" to "o".
+        private static readonly Regex HexNumber = new Regex(@"^#?[\dABCDEFabcdef]+$", RegexOptions.Compiled);
         private static readonly Regex StartsAndEndsWithNumber = new Regex(@"^\d+.+\d$", RegexOptions.Compiled);
 
         public readonly Dictionary<string, string> WordReplaceList;

--- a/src/libuilogic/Ocr/NikseBitmapImageSplitter2.cs
+++ b/src/libuilogic/Ocr/NikseBitmapImageSplitter2.cs
@@ -638,6 +638,12 @@ public class NikseBitmapImageSplitter2
         var bmpHeight = bmp.Height;
         var minLineHeightDiv2 = minLineHeight / 2;
 
+        // "started" latches across scan lines, as it does in SE4. Declared inside the loop it was
+        // reset every y, and since every "started = true" breaks out of the x loop before the
+        // "if (started)" below, points was ALWAYS empty - so this splitter returned the image
+        // unsplit every single time and the whole "allows for up/down" path was dead.
+        var started = false;
+
         for (var y = minLineHeight; y < bmpHeight - minLineHeight; y++)
         {
             if (startY == y && bmp.IsLineTransparent(y))
@@ -652,7 +658,6 @@ public class NikseBitmapImageSplitter2
             var backJump = 0;
             var x = 0;
             var maxUp = Math.Min(10, minLineHeightDiv2);
-            var started = false;
 
             while (x < bmpWidth)
             {

--- a/src/libuilogic/Ocr/Service/GoogleCloudVisionApi.cs
+++ b/src/libuilogic/Ocr/Service/GoogleCloudVisionApi.cs
@@ -451,7 +451,10 @@ namespace Nikse.SubtitleEdit.UiLogic.Ocr.Service
                 var highChars = new[] { "'", "\"" };
                 var min = Vertices.Min(p => p.Y);
                 var max = Vertices.Max(p => p.Y);
-                var medium = max + min / 2.0;
+                // "/" binds tighter than "+": this returned max + min/2, not the midpoint, and the
+                // error grows with the glyph's own height - so the sort key and the line-grouping
+                // threshold below put words in the wrong lines and the wrong reading order.
+                var medium = (max + min) / 2.0;
 
                 if (lowChars.Contains(Text))
                 {

--- a/src/libuilogic/SpellCheck/SpellCheckDictionaryDisplay.cs
+++ b/src/libuilogic/SpellCheck/SpellCheckDictionaryDisplay.cs
@@ -209,6 +209,13 @@ public class SpellCheckDictionaryDisplay
 
     public static string? GetFiveLetterLanguageName(string fileName)
     {
+        // Normalize here rather than only in the instance overload: the other caller
+        // (SpellChecker) passed the raw file name, so a hyphenated dictionary ("fa-IR",
+        // "sr-Latn", "be-official", "ca-valencia") failed the '_' test below, returned null and
+        // silently fell back to the en_US word lists - while "add to names/user dictionary" wrote
+        // to fa_IR_*.xml, so added words were never read back.
+        fileName = fileName.Replace('-', '_');
+
         if (fileName == "es_ANY" || fileName == "es-ANY")
         {
             return "es_ES";

--- a/src/libuilogic/Translate/Formatting.cs
+++ b/src/libuilogic/Translate/Formatting.cs
@@ -112,7 +112,11 @@ namespace Nikse.SubtitleEdit.UiLogic.Translate
                 {
                     SquareBracketsUppercase = true;
                 }
-                else if (text.Length > 0 && char.IsLower(text[0]))
+                // text[0] is '[' here (the block is guarded by StartsWith('[')) and the brackets
+                // are not stripped until below, so this was always false: the flag was never set,
+                // and both the CapitalizeFirstLetter here and the re-lowercasing in
+                // ReAddFormatting were dead. Test the first character INSIDE the brackets.
+                else if (text.Length > 2 && char.IsLower(text[1]))
                 {
                     SquareBracketsStartWithLowercase = true;
                 }

--- a/src/seconv/Core/FixCommonErrorsRunner.cs
+++ b/src/seconv/Core/FixCommonErrorsRunner.cs
@@ -134,8 +134,12 @@ internal static class FixCommonErrorsRunner
             return;
         }
 
+        // An EMPTY list means "no rules" - that is exactly what "-all" resolves to (RuleIdSpec
+        // clears the set). Treating empty as null made "--fix-common-errors-rules:-all" run every
+        // rule plus the OCR-fix pass, i.e. the maximum instead of nothing. RemoveFormattingRunner
+        // documents the same distinction.
         HashSet<string>? wanted = null;
-        if (ruleIds != null && ruleIds.Count > 0)
+        if (ruleIds != null)
         {
             wanted = new HashSet<string>(ruleIds, StringComparer.OrdinalIgnoreCase);
         }

--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -867,10 +867,12 @@ internal class SubtitleConverter
             subtitle.AddTimeToAllParagraphs(options.Offset.Value);
         }
 
-        // Apply target frame rate via libse (handles frame-based formats correctly)
-        if (options.Fps.HasValue && options.TargetFps.HasValue)
+        // Apply target frame rate via libse (handles frame-based formats correctly).
+        // --target-fps on its own used to be accepted and then silently ignored; SE4 converts from
+        // the current frame rate in that case, and the image path here already does the same.
+        if (options.TargetFps is > 0)
         {
-            subtitle.ChangeFrameRate(options.Fps.Value, options.TargetFps.Value);
+            subtitle.ChangeFrameRate(options.Fps ?? Configuration.Settings.General.CurrentFrameRate, options.TargetFps.Value);
         }
 
         // Scale all times by 100/percent (matches Sync > Change Speed in the UI)

--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -4258,6 +4258,16 @@ public class AudioVisualizer : Control
             return new MinMax { Min = 0, Max = 0, Avg = 0 };
         }
 
+        // Clamp here rather than at each call site: most callers clamp, but the "guess start"
+        // pair passes SecondsToSampleIndex(...) raw, so a cue starting within 0.8 s of the end of
+        // the peaks indexed past the array. This also removes the divide-by-zero on an empty range.
+        startIndex = Math.Max(0, startIndex);
+        endIndex = Math.Min(WavePeaks.Peaks.Count, endIndex);
+        if (endIndex <= startIndex)
+        {
+            return new MinMax { Min = 0, Max = 0, Avg = 0 };
+        }
+
         var minPeak = int.MaxValue;
         var maxPeak = int.MinValue;
         double total = 0;

--- a/src/ui/Controls/SyntaxTextEditorControl/SyntaxTextView.cs
+++ b/src/ui/Controls/SyntaxTextEditorControl/SyntaxTextView.cs
@@ -1438,6 +1438,11 @@ public class SyntaxTextView : Control
             return;
         }
 
+        // The document normalizes every line break to its own NewLine, so pasting "a\nb" into a
+        // CRLF document grew it by 4 while the undo entry and the caret used the raw length 3 -
+        // undo then removed the wrong number of characters. Normalize first so the two agree.
+        insertText = NormalizeLineBreaks(insertText);
+
         var textLength = _document.TextLength;
         offset = Math.Clamp(offset, 0, textLength);
         removeLength = Math.Clamp(removeLength, 0, textLength - offset);
@@ -1464,6 +1469,20 @@ public class SyntaxTextView : Control
 
         SetCaret(offset + (insertText?.Length ?? 0), extendSelection: false);
         BringCaretIntoView();
+    }
+
+    /// <summary>
+    /// Rewrites every line break to the document's own <c>NewLine</c>, so a string's length matches
+    /// the number of characters the document will actually gain when it is inserted.
+    /// </summary>
+    private string NormalizeLineBreaks(string? text)
+    {
+        if (string.IsNullOrEmpty(text) || text.IndexOfAny(['\r', '\n']) < 0)
+        {
+            return text ?? string.Empty;
+        }
+
+        return text.Replace("\r\n", "\n").Replace('\r', '\n').Replace("\n", _document.NewLine);
     }
 
     private void PushUndo(UndoEntry entry)

--- a/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
+++ b/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
@@ -1264,7 +1264,11 @@ public partial class MultipleReplaceViewModel : ObservableObject
     {
         return new RuleTreeNode(node.Parent, new MultipleReplaceRule
         {
-            Active = node.IsActive,
+            // "node" is only the neighbour used to find the insert position - a rule the user just
+            // typed must start active, as CategoryAddRule does. Inheriting the neighbour's state
+            // meant inserting next to an unticked rule silently created an unticked one that never
+            // ran, with nothing in the dialog to explain why.
+            Active = true,
             Description = result.Description,
             Find = result.FindWhat,
             ReplaceWith = result.ReplaceWith,

--- a/src/ui/Features/Ocr/BinaryOcr/BinaryOcrDbEditViewModel.cs
+++ b/src/ui/Features/Ocr/BinaryOcr/BinaryOcrDbEditViewModel.cs
@@ -229,7 +229,14 @@ public partial class BinaryOcrDbEditViewModel : ObservableObject
 
         ItemText = selectedItem.Text ?? string.Empty;
         IsItemItalic = selectedItem.Italic;
-        ItemBitmap = selectedItem.ToSKBitmap().ToAvaloniaBitmap();
+
+        // Runs on every selection change; ToAvaloniaBitmap copies the pixels, so the intermediate
+        // native bitmap has to go or arrow-keying through a large database leaks one per character.
+        using (var itemSkBitmap = selectedItem.ToSKBitmap())
+        {
+            ItemBitmap = itemSkBitmap.ToAvaloniaBitmap();
+        }
+
         ResolutionAndTopMargin = string.Format(Se.Language.Ocr.ResolutionXYAndTopmarginZ, selectedItem.Width, selectedItem.Height, selectedItem.Y);
 
         if (selectedItem.ExpandCount == 0)
@@ -239,12 +246,6 @@ public partial class BinaryOcrDbEditViewModel : ObservableObject
         else
         {
             ExpandInfo = string.Format(Se.Language.Ocr.ExpandInfoX, selectedItem.ExpandCount);
-        }
-
-        var skBitmap = new SKBitmap(selectedItem.Width, selectedItem.Height);
-        using (var canvas = new SKCanvas(skBitmap))
-        {
-            canvas.Clear(SKColors.LightGray);
         }
     }
 }

--- a/src/ui/Features/Ocr/NOcr/NOcrDbEditViewModel.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrDbEditViewModel.cs
@@ -62,11 +62,9 @@ public partial class NOcrDbEditViewModel : ObservableObject
     [RelayCommand]
     private void Ok()
     {
-        if (string.IsNullOrWhiteSpace(DatabaseName))
-        {
-            return;
-        }
-
+        // No guard on DatabaseName here: this dialog edits an existing database and has no name
+        // box, so the field stays empty and the copied guard made the OK button do nothing at all.
+        // (The "new database" dialog does bind a name box, which is where the guard belongs.)
         OkPressed = true;
         Close();
     }

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -3830,8 +3830,11 @@ public partial class OcrViewModel : ObservableObject
             return;
         }
 
+        // WordIndex is an offset into the fixed line the OCR engine built, not into item.Text, and
+        // the two can differ in length (French spacing inserts a character per "!?:;"). The two
+        // branches below already bounds-check; this one did not, and threw out of the OCR run.
         var idx = unknownWord.Word.WordIndex;
-        if (item.Text.Substring(idx).StartsWith(unknownWord.Word.FixedWord))
+        if (idx >= 0 && idx <= item.Text.Length && item.Text.Substring(idx).StartsWith(unknownWord.Word.FixedWord))
         {
             item.Text = item.Text.Remove(idx, unknownWord.Word.FixedWord.Length).Insert(idx, word);
         }

--- a/src/ui/Features/Ocr/PromptUnknownWordViewModel.cs
+++ b/src/ui/Features/Ocr/PromptUnknownWordViewModel.cs
@@ -102,7 +102,10 @@ public partial class PromptUnknownWordViewModel : ObservableObject
         var paragraph = word.Result.GetText();
         var w = word.Word.FixedWord;
 
-        if (!paragraph.Substring(idx).StartsWith(w))
+        // idx was measured against the engine's fixed line, not against GetText(), so it can point
+        // past the end - the IndexOf fallback right below exists for exactly that mismatch, but
+        // the Substring threw before ever reaching it.
+        if (idx < 0 || idx > paragraph.Length || !paragraph.Substring(idx).StartsWith(w))
         {
             idx = paragraph.IndexOf(w, StringComparison.Ordinal);
             if (idx < 0)

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -826,6 +826,18 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
             Se.Settings.Tools.BatchConvert.FixRtlMode = "ReverseStartEnd";
         }
 
+        // These were read in LoadSettings but never written back, so every number the user typed
+        // into the bridge-gaps, min-gap and split/break function panels was discarded on close.
+        // They go to the same keys the dedicated dialogs use.
+        Se.Settings.Tools.BridgeGaps.BridgeGapsSmallerThanMs = BridgeGapsSmallerThanMs;
+        Se.Settings.Tools.BridgeGaps.MinGapMs = BridgeGapsMinGapMs;
+        Se.Settings.Tools.BridgeGaps.PercentForLeft = BridgeGapsPercentForLeft;
+        Se.Settings.Tools.ApplyMinGapMilliseconds = MinGapMs;
+        Se.Settings.Tools.SplitRebalanceLongLinesSplit = SplitBreakSplitLongLines;
+        Se.Settings.Tools.SplitRebalanceLongLinesRebalance = SplitBreakRebalanceLongLines;
+        Se.Settings.Tools.SplitRebalanceLongLinesSingleLineMaxLength = SplitBreakSingleLineMaxLength;
+        Se.Settings.Tools.SplitRebalanceLongLinesMaxNumberOfLines = SplitBreakMaxNumberOfLines;
+
         Se.SaveSettings();
     }
 
@@ -928,6 +940,11 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         BridgeGapsMinGapMs = Se.Settings.Tools.BridgeGaps.MinGapMs;
         BridgeGapsPercentForLeft = Se.Settings.Tools.BridgeGaps.PercentForLeft;
 
+        // "Apply minimum gap" was never loaded. Its editor passes the saved value only as the
+        // converter's DefaultValue, which a non-nullable int can never reach, so the box opened at
+        // 0 and the function inserted no gap at all.
+        MinGapMs = Se.Settings.Tools.ApplyMinGapMilliseconds;
+
         FormattingRemoveAll = Se.Settings.Tools.BatchConvert.FormattingRemoveAll;
         FormattingRemoveItalic = Se.Settings.Tools.BatchConvert.FormattingRemoveItalic;
         FormattingRemoveBold = Se.Settings.Tools.BatchConvert.FormattingRemoveBold;
@@ -959,8 +976,15 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         ConvertColorsToDialogAddNewLines = Se.Settings.Tools.BatchConvert.ConvertColorsToDialogAddNewLines;
         ConvertColorsToDialogReBreakLines = Se.Settings.Tools.BatchConvert.ConvertColorsToDialogReBreakLines;
 
-        SplitBreakSingleLineMaxLength = Se.Settings.General.SubtitleLineMaximumLength;
-        SplitBreakMaxNumberOfLines = Se.Settings.General.MaxNumberOfLines;
+        // Prefer this tool's own saved values over the app-wide rules, exactly as the dedicated
+        // split/break dialog does - otherwise the numbers typed here reset on every open (and
+        // writing them back to General.* would silently change a global setting).
+        SplitBreakSingleLineMaxLength = Se.Settings.Tools.SplitRebalanceLongLinesSingleLineMaxLength > 0
+            ? Se.Settings.Tools.SplitRebalanceLongLinesSingleLineMaxLength
+            : Se.Settings.General.SubtitleLineMaximumLength;
+        SplitBreakMaxNumberOfLines = Se.Settings.Tools.SplitRebalanceLongLinesMaxNumberOfLines > 0
+            ? Se.Settings.Tools.SplitRebalanceLongLinesMaxNumberOfLines
+            : Se.Settings.General.MaxNumberOfLines;
         SplitBreakSplitLongLines = Se.Settings.Tools.SplitRebalanceLongLinesSplit;
         SplitBreakRebalanceLongLines = Se.Settings.Tools.SplitRebalanceLongLinesRebalance;
 

--- a/tests/libse/Common/BugHunt14Test.cs
+++ b/tests/libse/Common/BugHunt14Test.cs
@@ -1,0 +1,60 @@
+using Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream;
+
+namespace LibSETests.Common;
+
+/// <summary>
+/// Guard tests for the 2026-08-27 bug hunt (sweep 14): binary-parser strides and bounds, and
+/// guards whose comparison was off by one.
+/// </summary>
+public class BugHunt14Test
+{
+    /// <summary>
+    /// Builds the payload of a PAT section carrying <paramref name="programNumbers"/> entries,
+    /// laid out exactly as ISO/IEC 13818-1 2.4.4.3 describes.
+    /// </summary>
+    private static byte[] MakePatPacket(params int[] programNumbers)
+    {
+        var sectionLength = 5 + (programNumbers.Length * 4) + 4; // header after length + N*4 + CRC32
+        var buffer = new List<byte>
+        {
+            0x00, // pointer field
+            0x00, // table id
+            (byte)(0xB0 | ((sectionLength >> 8) & 0x03)),
+            (byte)(sectionLength & 0xFF),
+            0x00, 0x01, // transport stream id
+            0xC1,       // version / current-next
+            0x00,       // section number
+            0x00,       // last section number
+        };
+
+        foreach (var programNumber in programNumbers)
+        {
+            buffer.Add((byte)(programNumber >> 8));
+            buffer.Add((byte)(programNumber & 0xFF));
+            buffer.Add((byte)(0xE0 | ((0x100 + programNumber) >> 8)));  // reserved + PID high
+            buffer.Add((byte)((0x100 + programNumber) & 0xFF));         // PID low
+        }
+
+        buffer.AddRange(new byte[] { 0, 0, 0, 0 }); // CRC32
+        return buffer.ToArray();
+    }
+
+    [Fact]
+    public void ProgramAssociationTable_ReadsEveryProgram_NotEveryOther()
+    {
+        // Entries are 4 bytes, but the loop stepped 8 and counted (SectionLength - 5) / 8 - right
+        // by accident for the single-program case, and silently dropping programs otherwise.
+        var pat = new ProgramAssociationTable(MakePatPacket(1, 2, 3), 0);
+
+        Assert.Equal(new List<int> { 1, 2, 3 }, pat.ProgramNumbers);
+        Assert.Equal(new List<int> { 0x101, 0x102, 0x103 }, pat.ProgramIds);
+    }
+
+    [Fact]
+    public void ProgramAssociationTable_SingleProgram_StillWorks()
+    {
+        var pat = new ProgramAssociationTable(MakePatPacket(1), 0);
+
+        Assert.Equal(new List<int> { 1 }, pat.ProgramNumbers);
+    }
+}

--- a/tests/libuilogic/BugHunt14Tests.cs
+++ b/tests/libuilogic/BugHunt14Tests.cs
@@ -1,0 +1,60 @@
+using Nikse.SubtitleEdit.UiLogic.AutoTranslate;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
+
+namespace LibUiLogicTests;
+
+/// <summary>
+/// Guard tests for the 2026-08-27 bug hunt (sweep 14): values that were normalized on one code
+/// path but not the other, and a preamble guard that the reasoning-tag branch bypassed.
+/// </summary>
+public class BugHunt14Tests
+{
+    [Fact]
+    public void GetFiveLetterLanguageName_HyphenatedDictionary_ResolvesInsteadOfFallingBackToEnglish()
+    {
+        // The shipped dictionary list contains hyphenated names. Only the instance overload
+        // replaced '-' with '_', so SpellChecker's call returned null and silently loaded the
+        // en_US word lists - while added words were written to fa_IR_*.xml and never read back.
+        Assert.Equal("fa_IR", SpellCheckDictionaryDisplay.GetFiveLetterLanguageName("fa-IR"));
+        Assert.Equal("fa_IR", SpellCheckDictionaryDisplay.GetFiveLetterLanguageName("fa_IR"));
+    }
+
+    [Fact]
+    public void LaraTranslate_LanguageList_ExposesATwoLetterIsoName()
+    {
+        // The full locale ("ja-JP") used to be stored as TwoLetterIsoLanguageName, so the exact
+        // two-letter comparisons downstream (IsCjkLanguage, merge/split gating) matched nothing.
+        var japanese = LaraTranslate.ListLanguages().First(p => p.Code == "ja-JP");
+
+        Assert.Equal("ja", japanese.TwoLetterIsoLanguageName);
+        Assert.Equal("ja-JP", japanese.Code);
+    }
+
+    [Fact]
+    public void LaraTranslate_EveryLanguage_HasALanguageTagNotACountryTag()
+    {
+        Assert.All(LaraTranslate.ListLanguages(), p =>
+            Assert.Equal(p.Code.Split('-')[0].ToLowerInvariant(), p.TwoLetterIsoLanguageName));
+    }
+
+    [Fact]
+    public void RemovePreamble_ColonInSource_IsKeptEvenWithAThinkBlock()
+    {
+        // The colon guard was "&&"-ed with "no <think> present", so a reasoning model's answer
+        // skipped it and the preamble regex ate the translation up to its first colon.
+        const string original = "Anmerkung: Das ist wichtig.";
+        const string input = "<think>reasoning here</think>Here is the note: this is important.";
+
+        var result = ChatGptTranslate.RemovePreamble(original, input);
+
+        Assert.Equal("Here is the note: this is important.", result);
+    }
+
+    [Fact]
+    public void RemovePreamble_NoColonInSource_StillStripsThePreamble()
+    {
+        var result = ChatGptTranslate.RemovePreamble("Das ist wichtig.", "Here is the translation: this is important.");
+
+        Assert.Equal("this is important.", result);
+    }
+}

--- a/tests/seconv/Core/FixCommonErrorsRunnerTest.cs
+++ b/tests/seconv/Core/FixCommonErrorsRunnerTest.cs
@@ -120,16 +120,33 @@ public class FixCommonErrorsRunnerTest
     }
 
     [Fact]
-    public void Run_WithEmptyList_RunsAllRules()
+    public void Run_WithNullList_RunsAllRules()
     {
+        var sub = new Subtitle();
+        sub.Paragraphs.Add(new Paragraph("hello,world.", 0, 2000));
+        sub.Renumber();
+
+        FixCommonErrorsRunner.Run(sub, null);
+
+        // Same outcome as RunAll: capitalised + space inserted
+        Assert.Equal("Hello, world.", sub.Paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void Run_WithEmptyList_RunsNothing()
+    {
+        // An empty list is what "--fix-common-errors-rules:-all" resolves to, so it must select
+        // NO rules. This used to fall through to "run everything" - the exact opposite - because
+        // the runner tested Count > 0 instead of null. RemoveFormattingRunner.ToTypes documents
+        // the same null-vs-empty contract, and ResolveRuleIds(null) already returns every id, so
+        // nothing depends on empty meaning "all".
         var sub = new Subtitle();
         sub.Paragraphs.Add(new Paragraph("hello,world.", 0, 2000));
         sub.Renumber();
 
         FixCommonErrorsRunner.Run(sub, Array.Empty<string>());
 
-        // Same outcome as RunAll: capitalised + space inserted
-        Assert.Equal("Hello, world.", sub.Paragraphs[0].Text);
+        Assert.Equal("hello,world.", sub.Paragraphs[0].Text);
     }
 
     [Fact]


### PR DESCRIPTION
Sweep 14, on ground no previous sweep had read: the UI controls, the binary container parsers, seconv and libuilogic.

All four suites green: libse 1624 / libuilogic 708 / seconv 417 / UI 4149.

## Binary container parsers

- **PAT entries are 4 bytes, not 8.** The loop stepped 8 while reading 4, and counted `(SectionLength - 5) / 8` instead of `(SectionLength - 9) / 4`. That is correct *by accident* for a single-program capture (the common case, which is why it survived), but a `.ts` with two programs reads only the first, and one with three reads programs 1 and 3. The skipped programs' PMTs are never parsed, so their subtitle tracks do not exist as far as SE is concerned.
- **DVB `.sup` timings came out at double the gap.** The format has no timestamps, so a synthetic clock is driven by each display set's `page_time_out` — and it was advanced both inside and after the per-PES block, so every subtitle-bearing set counted twice and the drift compounded across the file.
- **`stco`/`co64` passed the wrong bound to `ClampEntries`.** The helper wants the *last byte* of entry 0 (11 and 15 respectively); both passed 8, so the clamp allowed one entry too many and a truncated chunk-offset table threw while opening the mp4. The other four call sites pass it correctly.
- **`RegionCompositionSegment` read past the buffer.** The loop guard tested one byte of a six-byte object record, while the caller only guarantees `index + regionLength + 9` — a DVB segment whose length is not `10 + 6k` read up to five bytes past the end.
- **`Trun` capped its sample table against the box's end *position*, not a byte count**, so the cap was inert and the allocation came entirely from the file's own `sample_count`.

## Crashes

- `AudioVisualizer.GetMinAndMax` indexed past the peak array — most callers clamp, the "guess start" pair passes `SecondsToSampleIndex(...)` raw. Clamping inside the method fixes every caller and removes a divide-by-zero on an empty range.
- Two OCR `Substring` calls used a word index measured against the engine's *fixed* line rather than the text being indexed. In both places the sibling branches immediately around them already bounds-check, and one has an `IndexOf` fallback for exactly this mismatch that the throw prevented it from reaching.

## Dead code that silently disabled a feature

- **The "allows for up/down" OCR line splitter never split anything.** `started` was declared inside the scan loop, and every `started = true` breaks out of the x loop *before* the `if (started)` that records path points — so the point list was always empty and the method always returned the image unsplit. SE4 declares the variable outside the loop. Note this re-enables a path that has been inert, so it is worth a look on real OCR material.
- The Spanish inverted-mark fixer asked whether one position held both `¿` and `?`, which is impossible, so its cross-paragraph branch was dead. The correct test sits ten lines above it.
- `Formatting`'s square-bracket check read `'['` itself (the brackets are not stripped until later), so the flag was never set and both of its consumers were dead.
- The nOCR database editor's OK button guarded on a field that dialog never sets — pressing OK did nothing at all.

## Wrong results

- **`NormalizeStrings` exempted only Russian** from an OCR heuristic that rewrites Cyrillic `е` to Latin `e`, so Bulgarian, Ukrainian, Serbian, Macedonian and Belarusian got a Latin letter spliced into Cyrillic words — breaking spell check, search and sorting.
- **A hyphenated Hunspell dictionary silently loaded the English word lists.** `fa-IR`, `sr-Latn`, `be-official` and `ca-valencia` all ship in the dictionary list; only the instance overload normalized `-` to `_`, so `SpellChecker`'s call returned null and fell back to `en_US` — while "add to names/user dictionary" wrote to `fa_IR_*.xml`, so added words were never read back.
- `GetMediumY` computed `max + min / 2` instead of the midpoint (precedence), and the error scales with the glyph's own height, so Google Cloud Vision words were sorted into the wrong lines.
- Lara stored the full locale (`ja-JP`) as `TwoLetterIsoLanguageName`, so the exact two-letter checks downstream matched nothing and Japanese was merged and split with Latin heuristics. `MyMemoryApi` derives it correctly from the same shape, with a comment warning about this trap.
- ChatGPT's colon guard was `&&`-ed with "no `<think>` present", so a reasoning model's answer skipped it and the preamble regex cut the translation at its first colon.
- `TimeCodesBeautifier` placed an **in** cue using `OutCuesGap`; every other in-cue placement uses `InCuesGap`, and the profile's own on-shot-change test measures in cues against it.
- `ContinuationUtilities` used `EndsWith` where the prefix had just been matched at the *start*; `FixCasing` left two characters where the body needs one, skipping a one-letter word at the end of a line.
- The OCR hex bail-out was missing uppercase `C`, so `#0C0d` was rewritten to `#0Co`.
- A new multiple-replace rule inherited `Active` from whichever rule the user right-clicked, so inserting one next to an unticked rule silently created a rule that never runs.

## seconv

- `--target-fps` on its own parsed and was then ignored (the guard required `--fps` too). SE4 converts from the current frame rate in that case, and seconv's own image path already does.
- **`--fix-common-errors-rules:-all` ran every rule instead of none.** `-all` resolves to an empty list, which the runner re-read as "run everything" — and since that switch implicitly enables the feature, the result was the maximum rather than a no-op. `ResolveRuleIds(null)` already returns every id, so nothing depends on empty meaning "all", and the sibling `RemoveFormattingRunner` documents the same null-vs-empty contract. The test that asserted the old behaviour encoded the bug and is corrected here.

## Settings

Batch convert's **"apply minimum gap" always ran at 0 ms**: it was never loaded, and its editor can only supply the saved value through a converter that a non-nullable `int` can never reach. Its bridge-gaps and split/break numbers were loaded but never saved, so anything typed there was discarded on close; they now round-trip through this tool's own keys rather than writing back to the app-wide rules.

## Leaks

The binary OCR database editor leaked a bitmap per selection change and built a second one nothing consumed. `SyntaxTextView` recorded the *raw* length of pasted text while the document stores normalized line breaks, so undoing a paste removed the wrong number of characters — leaving a stray character behind, or eating one of the user's own.

## Not fixed — flagged for a decision

On macOS, the waveform's `Shift`-click branch and the `OperatingSystem.IsMacOS() && _isShiftDown` clause below it contradict each other: the first always wins, so the second is dead, and Shift sets the *start* time where that clause was written to set the *end*. Meanwhile `OnPointerReleased` treats macOS Shift as the Ctrl equivalent. Either fix is a UX decision rather than a mechanical one, so I have left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)