### PR TITLE
Fix 27 bugs found in a bug hunt

### DIFF
--- a/src/libuilogic/AudioToText/WhisperHelper.cs
+++ b/src/libuilogic/AudioToText/WhisperHelper.cs
@@ -112,7 +112,11 @@ namespace Nikse.SubtitleEdit.UiLogic.AudioToText
                 return Directory.Exists(path) ? path : null;
             }
 
-            if (Configuration.Settings.Tools.WhisperChoice == WhisperChoice.CppCuBlas)
+            // Test the PARAMETER, not the saved engine: every other branch in this method does.
+            // Reading the global meant that with "CPP cuBLAS" saved in settings, asking for any
+            // other engine's folder (OpenAi, DashScope, OpenAiCompatible, OpenRouter) returned the
+            // cuBLAS folder - and asking for cuBLAS itself never resolved through the parameter.
+            if (whisperChoice == WhisperChoice.CppCuBlas)
             {
                 var path = Path.Combine(Configuration.DataDirectory, "SpeechToText", WhisperChoice.CppCuBlas);
                 return Directory.Exists(path) ? path : null;
@@ -185,11 +189,8 @@ namespace Nikse.SubtitleEdit.UiLogic.AudioToText
                     return Directory.Exists(path) ? path : null;
                 }
 
-                if (Configuration.Settings.Tools.WhisperChoice == WhisperChoice.CppCuBlas)
-                {
-                    var path = Path.Combine(Configuration.DataDirectory, "SpeechToText", WhisperChoice.CppCuBlas);
-                    return Directory.Exists(path) ? path : null;
-                }
+                // (The CppCuBlas case is handled by the parameter test near the top of the method,
+                // which returns before this point on every platform.)
 
                 if (whisperChoice == WhisperChoice.WhisperX && !string.IsNullOrEmpty(Configuration.Settings.Tools.WhisperXLocation))
                 {
@@ -306,7 +307,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AudioToText
             var whisperFolder = GetWhisperFolder(whisperChoice);
             if (string.IsNullOrEmpty(whisperFolder))
             {
-                if (whisperChoice == WhisperChoice.Cpp || Configuration.Settings.Tools.WhisperChoice == WhisperChoice.CppCuBlas)
+                if (whisperChoice == WhisperChoice.Cpp || whisperChoice == WhisperChoice.CppCuBlas)
                 {
                     return "whisper-cli.exe";
                 }
@@ -379,7 +380,10 @@ namespace Nikse.SubtitleEdit.UiLogic.AudioToText
                 return "whisper.exe";
             }
 
-            if (Configuration.IsRunningOnLinux && whisperChoice == WhisperChoice.Cpp || Configuration.Settings.Tools.WhisperChoice == WhisperChoice.CppCuBlas)
+            // "&&" binds tighter than "||", so the saved-engine clause was evaluated on its own:
+            // on Windows, with "CPP cuBLAS" saved, GetExecutableFileNameNoPath(CTranslate2) - and
+            // every other engine - returned "main" instead of its own executable.
+            if (Configuration.IsRunningOnLinux && (whisperChoice == WhisperChoice.Cpp || whisperChoice == WhisperChoice.CppCuBlas))
             {
                 return "main";
             }

--- a/src/libuilogic/Export/ExportHandlerDCinemaInteropPng.cs
+++ b/src/libuilogic/Export/ExportHandlerDCinemaInteropPng.cs
@@ -107,7 +107,10 @@ public class ExportHandlerDCinemaInteropPng : IExportHandler
     public void WriteFooter()
     {
         var doc = new XmlDocument();
-        string title = Path.GetFileNameWithoutExtension(_folderName);
+        // The folder name goes straight into XML, so an "&", "<" or ">" in it made LoadXml throw -
+        // in WriteFooter, i.e. after every PNG was already on disk, leaving a folder of images
+        // with no index.xml. The FCP handler escapes exactly this kind of value.
+        string title = System.Security.SecurityElement.Escape(Path.GetFileNameWithoutExtension(_folderName)) ?? string.Empty;
 
         string guid = Guid.NewGuid().ToString().RemoveChar('-').Insert(8, "-").Insert(13, "-").Insert(18, "-").Insert(23, "-");
         doc.LoadXml("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + Environment.NewLine +

--- a/src/libuilogic/Export/ExportHandlerDCinemaSmpte2014Png.cs
+++ b/src/libuilogic/Export/ExportHandlerDCinemaSmpte2014Png.cs
@@ -25,6 +25,15 @@ public class ExportHandlerDCinemaSmpte2014Png : IExportHandler
         _width = imageParameter.ScreenWidth;
         _height = imageParameter.ScreenHeight;
 
+        // Nothing sets the FrameRate property, so it stayed at the 23.976 default and every
+        // index.xml declared EditRate/TimeCodeRate 23 - not a valid D-Cinema rate, and out of step
+        // with the TimeIn/TimeOut values, which come from the real current frame rate. The Dost and
+        // FCP handlers already take it from the image parameters; this one was missed.
+        if (imageParameter.FramesPerSecond > 0)
+        {
+            FrameRate = imageParameter.FramesPerSecond;
+        }
+
         _folderName = fileOrFolderName;
         if (!Directory.Exists(_folderName))
         {
@@ -131,7 +140,8 @@ public class ExportHandlerDCinemaSmpte2014Png : IExportHandler
             "  </SubtitleList>" + Environment.NewLine +
             "</SubtitleReel>";
 
-        xml = xml.Replace("[FRAMERATE]", ((int)FrameRate).ToString(CultureInfo.InvariantCulture));
+        // Round, do not truncate: (int)23.976 is 23, which no D-Cinema player accepts.
+        xml = xml.Replace("[FRAMERATE]", ((int)Math.Round(FrameRate, MidpointRounding.AwayFromZero)).ToString(CultureInfo.InvariantCulture));
 
         doc.LoadXml(xml);
         var fName = Path.Combine(_folderName, "index.xml");

--- a/src/libuilogic/Export/ImageRenderer.cs
+++ b/src/libuilogic/Export/ImageRenderer.cs
@@ -379,7 +379,12 @@ public static class ImageRenderer
         var lineWidths = new float[lines.Count];
         for (var li = 0; li < lines.Count; li++)
         {
-            var line = lines[li];
+            // Measure in the SAME order the line is drawn in. Reversing for RTL changes which
+            // segment is last, and the 0.17em styled-segment padding is only added to "not the
+            // last one" - so an RTL line was measured with that padding on a different segment
+            // than it was rendered with, shifting centered/right-aligned text and, through
+            // maxLineWidth, every other line of the same subtitle.
+            var line = ip.IsRightToLeft ? lines[li].AsEnumerable().Reverse().ToList() : lines[li];
             for (var j = 0; j < line.Count; j++)
             {
                 var seg = line[j];
@@ -560,7 +565,12 @@ public static class ImageRenderer
         var lineWidths = new float[lines.Count];
         for (var li = 0; li < lines.Count; li++)
         {
-            var line = lines[li];
+            // Measure in the SAME order the line is drawn in. Reversing for RTL changes which
+            // segment is last, and the 0.17em styled-segment padding is only added to "not the
+            // last one" - so an RTL line was measured with that padding on a different segment
+            // than it was rendered with, shifting centered/right-aligned text and, through
+            // maxLineWidth, every other line of the same subtitle.
+            var line = ip.IsRightToLeft ? lines[li].AsEnumerable().Reverse().ToList() : lines[li];
             for (var j = 0; j < line.Count; j++)
             {
                 var seg = line[j];

--- a/src/seconv/Commands/ConvertCommand.cs
+++ b/src/seconv/Commands/ConvertCommand.cs
@@ -726,7 +726,11 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 TrackNumbers = ParseTrackNumbers(settings.TrackNumber),
                 ForcedOnly = settings.ForcedOnly,
                 OcrEngine = string.IsNullOrWhiteSpace(settings.OcrEngine) ? "tesseract" : settings.OcrEngine,
-                OcrLanguage = settings.OcrLanguage ?? "eng",
+                // No "eng" here: the engines take different code sets (Tesseract "eng", Paddle
+                // "en", Ollama/llama.cpp a human name like "English") and each has its own
+                // default. Forcing Tesseract's on all of them made "--ocr-engine:paddle" run
+                // paddleocr with "--lang eng", which it rejects, failing the whole conversion.
+                OcrLanguage = settings.OcrLanguage,
                 OcrDb = settings.OcrDb,
                 DictionaryFolder = settings.DictionaryFolder,
                 TimeCodesOnly = settings.TimeCodesOnly,

--- a/src/seconv/Core/ContainerSubtitleLoader.cs
+++ b/src/seconv/Core/ContainerSubtitleLoader.cs
@@ -517,6 +517,14 @@ internal static class ContainerSubtitleLoader
             parser.Parse(filePath, null);
             foreach (var pidEntry in parser.TeletextSubtitlesLookup)
             {
+                // Every other container path honours --track-number; the transport-stream path
+                // did not, so the filter was accepted and then silently ignored and SE wrote one
+                // output per teletext page, per ARIB language and per DVB PID.
+                if (options.TrackNumbers.Count > 0 && !options.TrackNumbers.Contains(pidEntry.Key))
+                {
+                    continue;
+                }
+
                 foreach (var pageEntry in pidEntry.Value)
                 {
                     if (options.TeletextOnlyPage.HasValue && pageEntry.Key != options.TeletextOnlyPage.Value)
@@ -538,6 +546,11 @@ internal static class ContainerSubtitleLoader
             // ARIB STD-B24 captions (ISDB broadcasts) — also text
             foreach (var pidEntry in parser.AribSubtitlesLookup)
             {
+                if (options.TrackNumbers.Count > 0 && !options.TrackNumbers.Contains(pidEntry.Key))
+                {
+                    continue;
+                }
+
                 foreach (var languageEntry in pidEntry.Value)
                 {
                     if (languageEntry.Value.Count == 0)
@@ -570,6 +583,11 @@ internal static class ContainerSubtitleLoader
                 var dvbSubs = ImageOcrLoader.LoadTransportStreamDvbSub(filePath, options);
                 foreach (var (subtitle, pid) in dvbSubs)
                 {
+                    if (options.TrackNumbers.Count > 0 && !options.TrackNumbers.Contains(pid))
+                    {
+                        continue;
+                    }
+
                     tracks.Add(new LoadedTrack(subtitle, new SubRip(), $"dvb_pid{pid}", pid));
                 }
             }
@@ -581,6 +599,12 @@ internal static class ContainerSubtitleLoader
 
         if (tracks.Count == 0)
         {
+            if (options.TrackNumbers.Count > 0)
+            {
+                throw new InvalidOperationException(
+                    $"Transport stream contained no subtitle stream matching --track-number ({string.Join(",", options.TrackNumbers)}): {filePath}");
+            }
+
             throw new InvalidOperationException($"No subtitles found in transport stream: {filePath}");
         }
         return tracks;

--- a/src/seconv/Core/FixCommonErrorsRunner.cs
+++ b/src/seconv/Core/FixCommonErrorsRunner.cs
@@ -305,11 +305,12 @@ internal static class FixCommonErrorsRunner
         }
 
         var v = value.Trim();
-        if (v.Length == 2)
-        {
-            return v.ToLowerInvariant();
-        }
 
+        // No unchecked two-letter shortcut: the lookup below already matches a real
+        // TwoLetterISOLanguageName, so "es" still resolves, while a plausible typo like "sp"
+        // used to be accepted verbatim. Being non-null it suppressed the warning and the
+        // auto-detect fallback, then matched no language gate and left the OCR-fix pass -
+        // which needs a valid three-letter code - silently doing nothing.
         var culture = CultureInfo.GetCultures(CultureTypes.NeutralCultures)
             .FirstOrDefault(c =>
                 c.TwoLetterISOLanguageName.Equals(v, StringComparison.OrdinalIgnoreCase)

--- a/src/seconv/Core/OcrEngineFactory.cs
+++ b/src/seconv/Core/OcrEngineFactory.cs
@@ -12,12 +12,12 @@ internal static class OcrEngineFactory
         var engine = (options.OcrEngine ?? "tesseract").Trim().ToLowerInvariant();
         return engine switch
         {
-            "tesseract" or "" => TesseractOcrEngine.Create(options.OcrLanguage),
+            "tesseract" or "" => TesseractOcrEngine.Create(options.OcrLanguage ?? "eng"),
             "nocr" => new NOcrOcrEngine(ResolveOcrDbPath(options, "nocr", ".nocr")),
             "binaryocr" or "binary" => new BinaryOcrOcrEngine(ResolveOcrDbPath(options, "binaryocr", ".db")),
             "ollama" => new OllamaOcrEngine(options.OllamaUrl, options.OllamaModel, options.OcrLanguage),
             "llamacpp" or "llama.cpp" or "llama" => LlamaCppOcrEngine.Create(options),
-            "paddle" or "paddleocr" => PaddleOcrEngine.Create(options.OcrLanguage),
+            "paddle" or "paddleocr" => PaddleOcrEngine.Create(options.OcrLanguage ?? "en"),
             _ => throw new InvalidOperationException(
                 $"OCR engine '{options.OcrEngine}' is not supported. Use one of: tesseract, nocr, binaryocr, ollama, llamacpp, paddle.")
         };

--- a/src/seconv/Core/OllamaOcrEngine.cs
+++ b/src/seconv/Core/OllamaOcrEngine.cs
@@ -56,7 +56,8 @@ internal sealed class OllamaOcrEngine : IOcrEngine
         using var content = new StringContent(body, Encoding.UTF8);
         content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
 
-        var resp = _httpClient.PostAsync(_url, content).GetAwaiter().GetResult();
+        // One response per subtitle bitmap - without the using, a long file leaks them all.
+        using var resp = _httpClient.PostAsync(_url, content).GetAwaiter().GetResult();
         var bodyBytes = resp.Content.ReadAsByteArrayAsync().GetAwaiter().GetResult();
         var json = Encoding.UTF8.GetString(bodyBytes).Trim();
         if (!resp.IsSuccessStatusCode)

--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -1161,7 +1161,8 @@ internal record class ConversionOptions
     public string OcrEngine { get; init; } = "tesseract";
 
     /// <summary>Language code or human name passed to the OCR engine (Tesseract: ISO 639-2 like <c>eng</c>; Paddle: <c>en</c>; Ollama: human name like <c>English</c>).</summary>
-    public string OcrLanguage { get; init; } = "eng";
+    /// <summary>Null = let each OCR engine apply its own default code set.</summary>
+    public string? OcrLanguage { get; init; }
 
     /// <summary>Path to a <c>.nocr</c> database file (required when <c>OcrEngine == "nocr"</c>).</summary>
     public string? OcrDb { get; init; }

--- a/src/ui/Features/Files/Compare/CompareViewModel.cs
+++ b/src/ui/Features/Files/Compare/CompareViewModel.cs
@@ -744,7 +744,9 @@ public partial class CompareViewModel : ObservableObject
         sb.AppendLine("      <th>&nbsp;</th>");
         sb.AppendLine("      <th colspan='4' style='text-align:left'>" + GetFileName(RightFileName) + "</th>");
         sb.AppendLine("    </tr>");
-        for (var i = 0; i < LeftSubtitles.Count; i++)
+        // Belt and braces alongside the button guard: only the padded rows are pairs.
+        var rowCount = Math.Min(LeftSubtitles.Count, RightSubtitles.Count);
+        for (var i = 0; i < rowCount; i++)
         {
             var itemLeft = LeftSubtitles[i];
             var itemRight = RightSubtitles[i];

--- a/src/ui/Features/Files/Compare/CompareWindow.cs
+++ b/src/ui/Features/Files/Compare/CompareWindow.cs
@@ -115,7 +115,12 @@ public class CompareWindow : Window
         checkBoxIgnoreFormatting.IsCheckedChanged += vm.CheckBoxChanged;
         var buttonPreviousDifference = UiUtil.MakeButton(vm.PreviousDifferenceCommand, IconNames.ChevronLeft, Se.Language.File.PreviousDifference).WithBindIsVisible(nameof(vm.IsExportVisible));
         var buttonNextDifference = UiUtil.MakeButton(vm.NextDifferenceCommand, IconNames.ChevronRight, Se.Language.File.NextDifference).WithBindIsVisible(nameof(vm.IsExportVisible));
-        var buttonExport = UiUtil.MakeButton(Se.Language.General.Export, vm.ExportCommand).WithMarginLeft(15);
+        // Bound like its two neighbours: with only one side loaded (which is how Tools > Compare
+        // always opens) the collections are never padded to equal length, and Export indexes the
+        // right-hand list by the left-hand count.
+        var buttonExport = UiUtil.MakeButton(Se.Language.General.Export, vm.ExportCommand)
+            .WithBindIsVisible(nameof(vm.IsExportVisible))
+            .WithMarginLeft(15);
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
         var panelButtons = UiUtil.MakeButtonBar(
             checkBoxIgnoreWhiteSpace,

--- a/src/ui/Features/Files/ExportCustomTextFormat/EditCustomTextFormatViewModel.cs
+++ b/src/ui/Features/Files/ExportCustomTextFormat/EditCustomTextFormatViewModel.cs
@@ -171,11 +171,17 @@ public partial class EditCustomTextFormatViewModel : ObservableObject, IClosingC
         }
     }
 
-    internal void Initialize(CustomFormatItem selected, string title, List<SubtitleLineViewModel> subtitles, string videoFileName)
+    /// <param name="title">The window caption.</param>
+    /// <param name="subtitleTitle">
+    /// The subtitle's own title, i.e. what "{title}" expands to. Without it the live preview here
+    /// rendered "{title}" as empty while the parent window's preview showed the real name.
+    /// </param>
+    internal void Initialize(CustomFormatItem selected, string title, List<SubtitleLineViewModel> subtitles, string subtitleTitle, string videoFileName)
     {
         SelectedCustomFormat = selected;
         Title = title;
         _subtitles = subtitles.Take(50).ToList();
+        _subtitleTitle = subtitleTitle;
         _videoFileName = videoFileName;
         _previewTimer.Start();
     }

--- a/src/ui/Features/Files/ExportCustomTextFormat/ExportCustomTextFormatViewModel.cs
+++ b/src/ui/Features/Files/ExportCustomTextFormat/ExportCustomTextFormatViewModel.cs
@@ -79,7 +79,7 @@ public partial class ExportCustomTextFormatViewModel : ObservableObject
 
         var result = await _windowService.ShowDialogAsync<EditCustomTextFormatWindow, EditCustomTextFormatViewModel>(Window!, vm =>
         {
-            vm.Initialize(editCopy, Se.Language.File.Export.EditCustomFormat, _subtitles, _videoFileName ?? string.Empty);
+            vm.Initialize(editCopy, Se.Language.File.Export.EditCustomFormat, _subtitles, _title, _videoFileName ?? string.Empty);
         });
 
         if (result.OkPressed && result.SelectedCustomFormat != null)
@@ -142,7 +142,7 @@ public partial class ExportCustomTextFormatViewModel : ObservableObject
 
         var result = await _windowService.ShowDialogAsync<EditCustomTextFormatWindow, EditCustomTextFormatViewModel>(Window!, vm =>
         {
-            vm.Initialize(selected, Se.Language.File.Export.NewCustomFormat, _subtitles, _videoFileName ?? string.Empty);
+            vm.Initialize(selected, Se.Language.File.Export.NewCustomFormat, _subtitles, _title, _videoFileName ?? string.Empty);
         });
 
         if (result.OkPressed && result.SelectedCustomFormat != null)

--- a/src/ui/Features/Files/ImportImages/ImportImagesViewModel.cs
+++ b/src/ui/Features/Files/ImportImages/ImportImagesViewModel.cs
@@ -192,8 +192,13 @@ public partial class ImportImagesViewModel : ObservableObject
                     var path = file.Path?.LocalPath;
                     if (path != null && File.Exists(path))
                     {
+                        // Compare the extension exactly. GetExtension returns "" for a file with
+                        // no dot in its name, and "*.png".EndsWith("") is true - so every
+                        // extension-less file passed the filter and ended up as a blank OCR line.
+                        // The plain-text import dialog's drop handler gets this right.
                         var ext = Path.GetExtension(path).ToLowerInvariant();
-                        if (!_imageExtensions.Any(x => x.EndsWith(ext)))
+                        if (string.IsNullOrEmpty(ext) ||
+                            !_imageExtensions.Any(x => string.Equals(x.TrimStart('*'), ext, StringComparison.OrdinalIgnoreCase)))
                         {
                             continue;
                         }

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -10766,7 +10766,18 @@ public partial class MainViewModel :
             return;
         }
 
-        var frameRate = _mediaInfo != null ? (double)_mediaInfo.FramesRateNonNormalized : Se.Settings.General.CurrentFrameRate;
+        // A non-null _mediaInfo can still carry a rate of 0 (ffmpeg missing, or audio-only media
+        // whose log has no fps line), so the null check alone protected nothing: "seconds" became
+        // Infinity and every shot change was pushed out of range - silently emptying the user's
+        // whole shot-change list. The sibling command above already guards it this way.
+        var frameRate = _mediaInfo != null && _mediaInfo.FramesRateNonNormalized > 0
+            ? (double)_mediaInfo.FramesRateNonNormalized
+            : Se.Settings.General.CurrentFrameRate;
+        if (frameRate < 1)
+        {
+            return;
+        }
+
         var milliseconds = 1000.0 / frameRate;
         var seconds = milliseconds / 1000.0;
 
@@ -10795,7 +10806,18 @@ public partial class MainViewModel :
             return;
         }
 
-        var frameRate = _mediaInfo != null ? (double)_mediaInfo.FramesRateNonNormalized : Se.Settings.General.CurrentFrameRate;
+        // A non-null _mediaInfo can still carry a rate of 0 (ffmpeg missing, or audio-only media
+        // whose log has no fps line), so the null check alone protected nothing: "seconds" became
+        // Infinity and every shot change was pushed out of range - silently emptying the user's
+        // whole shot-change list. The sibling command above already guards it this way.
+        var frameRate = _mediaInfo != null && _mediaInfo.FramesRateNonNormalized > 0
+            ? (double)_mediaInfo.FramesRateNonNormalized
+            : Se.Settings.General.CurrentFrameRate;
+        if (frameRate < 1)
+        {
+            return;
+        }
+
         var milliseconds = 1000.0 / frameRate;
         var seconds = milliseconds / 1000.0;
 
@@ -11574,6 +11596,12 @@ public partial class MainViewModel :
             return;
         }
 
+        // Map each paragraph handed to the dialog back to its row. The dialog copies its input
+        // with generateNewId:false, so these ids survive and still name a row in the result -
+        // which positional indexing does not: rules that remove a paragraph (FixEmptyLines is on
+        // by default) shift every later result onto its neighbour's row.
+        var rowByParagraphId = new Dictionary<Guid, SubtitleLineViewModel>(selectedItems.Count);
+
         var result = await ShowDialogAsync<FixCommonErrorsWindow, FixCommonErrorsViewModel>(vm =>
         {
             var sub = new Subtitle();
@@ -11593,6 +11621,10 @@ public partial class MainViewModel :
                     Bookmark = line.Bookmark,
                 };
                 sub.Paragraphs.Add(p);
+                if (p.Id.HasValue)
+                {
+                    rowByParagraphId[p.Id.Value] = line;
+                }
             }
 
             vm.Initialize(sub, SelectedSubtitleFormat);
@@ -11604,14 +11636,11 @@ public partial class MainViewModel :
             return;
         }
 
-        for (var i = 0; i < result.FixedSubtitle.Paragraphs.Count; i++)
+        foreach (var paragraph in result.FixedSubtitle.Paragraphs)
         {
-            var text = result.FixedSubtitle.Paragraphs[i].Text;
-            var id = selectedItems[i].Id;
-            var p = Subtitles.FirstOrDefault(x => x.Id == id);
-            if (p != null)
+            if (paragraph.Id.HasValue && rowByParagraphId.TryGetValue(paragraph.Id.Value, out var row))
             {
-                p.Text = text;
+                row.Text = paragraph.Text;
             }
         }
 
@@ -16987,7 +17016,14 @@ public partial class MainViewModel :
 
         RunWithoutChangeDetection(() =>
         {
-            for (var i = index; i < Subtitles.Count; i++)
+            // Set the END of the selected line and offset only the lines AFTER it. The loop used
+            // to start at "index" and slide the selected line bodily with SetStartTimeKeepDuration,
+            // so its start moved by the end-delta too and its duration never changed - the exact
+            // opposite of "set end". (The start twin above is right to start at index: there the
+            // delta is measured from the start, so moving the whole line is the intent.)
+            s.EndTime = videoTime;
+
+            for (var i = index + 1; i < Subtitles.Count; i++)
             {
                 var subtitle = Subtitles[i];
                 subtitle.SetStartTimeKeepDuration(subtitle.StartTime + difference);
@@ -18088,7 +18124,16 @@ public partial class MainViewModel :
         var gapMs = Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
         foreach (var item in selectedItems)
         {
-            var prev = Subtitles.GetOrNull(Subtitles.IndexOf(item) - 1);
+            // "The previous line" means the previous line of the subtitle being edited, not a
+            // display-only reference row of a mismatched original (#13962) - which is what the
+            // raw grid predecessor could be. Every sibling timing command uses these helpers.
+            var idx = Subtitles.IndexOf(item);
+            if (idx < 0)
+            {
+                continue;
+            }
+
+            var prev = GetPreviousWorkingRow(idx);
             if (prev == null)
             {
                 continue;

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextTimingFixer.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextTimingFixer.cs
@@ -172,7 +172,11 @@ public static class SpeechToTextTimingFixer
             if (pctHere < percentageMax)
             {
                 var startPosForward = p.StartTime.TotalSeconds;
-                while (pctHere < percentageMax && startPos < p.EndTime.TotalSeconds - 1)
+                // Bound the scan by the variable that actually advances. "startPos" is assigned
+                // once above and never changes inside the loop, so this guard was a constant: the
+                // scan ran past the cue's own end until FindPercentage gave up, and the -1 exit
+                // then abandoned the whole method, leaving every later line unadjusted.
+                while (pctHere < percentageMax && startPosForward < p.EndTime.TotalSeconds - 1)
                 {
                     pctHere = FindPercentage(startPosForward - 0.05, startPosForward + 0.05, wavePeaks);
                     if (Math.Abs(pctHere - (-1)) < 0.01)

--- a/src/ui/Features/Video/TextToSpeech/Engines/IndexTts25AudioCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/IndexTts25AudioCpp.cs
@@ -331,12 +331,15 @@ public class IndexTts25AudioCpp : ITtsEngine
     /// </summary>
     public Task<TtsLanguage[]> GetLanguages(Voice voice, string? model) => Task.FromResult(new[]
     {
-        new TtsLanguage("auto", "Auto"),
-        new TtsLanguage("zh", "Chinese"),
-        new TtsLanguage("en", "English"),
-        new TtsLanguage("ja", "Japanese"),
-        new TtsLanguage("es", "Spanish"),
-        new TtsLanguage("ar", "Arabic"),
+        // TtsLanguage is (name, code) - every other engine writes it that way. Reversed here, the
+        // combo listed "zh"/"en"/"ja" instead of language names and Speak sent language.Code, i.e.
+        // the literal "Chinese", to audio.cpp - so no explicit pick ever worked.
+        new TtsLanguage("Auto", "auto"),
+        new TtsLanguage("Chinese", "zh"),
+        new TtsLanguage("English", "en"),
+        new TtsLanguage("Japanese", "ja"),
+        new TtsLanguage("Spanish", "es"),
+        new TtsLanguage("Arabic", "ar"),
     });
 
     public Task<Voice[]> RefreshVoices(string language, CancellationToken cancellationToken) =>

--- a/src/ui/Logic/ColorService.cs
+++ b/src/ui/Logic/ColorService.cs
@@ -179,12 +179,28 @@ public class ColorService : IColorService
                 var colorStart = f.IndexOf(" color=", StringComparison.OrdinalIgnoreCase);
                 if (colorStart >= 0)
                 {
-                    if (s.IndexOf('"', colorStart + 8) > 0)
+                    var valueStart = colorStart + " color=".Length;
+                    var quoteEnd = s.IndexOf('"', valueStart);
+                    if (quoteEnd > 0)
                     {
-                        end = s.IndexOf('"', colorStart + 8);
+                        // Quoted value: the closing quote comes from the tail we keep.
+                        s = s.Substring(0, colorStart) + string.Format(" color=\"{0}", ToHex(color)) + s.Substring(quoteEnd);
+                    }
+                    else
+                    {
+                        // Unquoted value ("<font color=red>"). "end" is the '>' here, so the old
+                        // code emitted an opening quote and then kept the rest of the tag,
+                        // producing the broken '<font color="#0000FF>'. Replace the whole
+                        // unquoted value with a properly quoted one instead.
+                        var valueEnd = valueStart;
+                        while (valueEnd < end && !char.IsWhiteSpace(s[valueEnd]))
+                        {
+                            valueEnd++;
+                        }
+
+                        s = s.Substring(0, colorStart) + string.Format(" color=\"{0}\"", ToHex(color)) + s.Substring(valueEnd);
                     }
 
-                    s = s.Substring(0, colorStart) + string.Format(" color=\"{0}", ToHex(color)) + s.Substring(end);
                     text = pre + s;
                     return text;
                 }

--- a/src/ui/Logic/Config/SeTools.cs
+++ b/src/ui/Logic/Config/SeTools.cs
@@ -243,7 +243,6 @@ public class SeTools
         MultipleReplaceShowDotDotDotButtons = true;
         GridFocusTextboxAfterInsertNew = true;
         AllowSingleLetterShortcutsInTextbox = false;
-        WriteToolsLog = true;
         TextToSpeechPromptMergeContinuationLines = true;
         TextToSpeechPromptSkipNoiseLines = true;
         TextToSpeechPromptDetectSpeakers = true;

--- a/src/ui/Logic/FindService.cs
+++ b/src/ui/Logic/FindService.cs
@@ -68,6 +68,10 @@ public partial class FindService : IFindService
 
     public int FindNext(string searchText, List<string> textLines, int startLineIndex, int startTextIndex, List<string>? originalTextLines = null, bool startInOriginal = false)
     {
+        // Adopt the caller's list BEFORE testing it: the guard used to read the field, i.e. the
+        // previous search's lines, so a Find opened on an empty subtitle kept answering "not
+        // found" for every later F3 no matter how many lines had been added since.
+        _textLines = textLines;
         if (string.IsNullOrEmpty(searchText) || _textLines.Count == 0)
         {
             ResetSearchState();
@@ -75,7 +79,6 @@ public partial class FindService : IFindService
         }
 
         SearchText = RegexUtils.EscapeNewLines(searchText);
-        _textLines = textLines;
         _originalTextLines = originalTextLines;
         AddToSearchHistory(searchText);
 
@@ -161,6 +164,8 @@ public partial class FindService : IFindService
 
     public int FindPrevious(string searchText, List<string> textLines, int startLineIndex, int startTextIndex, List<string>? originalTextLines = null, bool startInOriginal = false)
     {
+        // Same as FindNext: adopt the caller's list before testing it.
+        _textLines = textLines;
         if (string.IsNullOrEmpty(searchText) || _textLines.Count == 0)
         {
             ResetSearchState();
@@ -168,7 +173,6 @@ public partial class FindService : IFindService
         }
 
         SearchText = RegexUtils.EscapeNewLines(searchText);
-        _textLines = textLines;
         _originalTextLines = originalTextLines;
         AddToSearchHistory(searchText);
 

--- a/src/ui/Logic/Media/FfmpegGenerator.cs
+++ b/src/ui/Logic/Media/FfmpegGenerator.cs
@@ -1235,7 +1235,11 @@ public class FfmpegGenerator
                 keepIndex++;
             }
 
-            lastEnd = seg.EndTime.TotalSeconds;
+            // Never move the cursor backwards: cut segments are sorted by start but not merged,
+            // so an overlapping pair like [10-20] then [12-15] used to reset lastEnd to 15 and
+            // leave 15-20 s in the output - while the subtitle re-timer treats it as removed,
+            // desyncing everything after the cut.
+            lastEnd = Math.Max(lastEnd, seg.EndTime.TotalSeconds);
         }
 
         // Keep remainder (from lastEnd → EOF)
@@ -1442,7 +1446,10 @@ public class FfmpegGenerator
         args.Add($"-i \"{inputFileName}\"");
 
         // New external subtitle inputs
-        var newInputs = embeddedTracks.Where(t => t.New && !string.IsNullOrEmpty(t.FileName) && File.Exists(t.FileName)).ToList();
+        // "!t.Deleted" as in the mp4 path below: a track the user added and then removed was
+        // still -i'd and -map'd in, and since outputSubs excludes it, every following subtitle
+        // stream picked up the previous track's language/title/disposition metadata.
+        var newInputs = embeddedTracks.Where(t => t.New && !t.Deleted && !string.IsNullOrEmpty(t.FileName) && File.Exists(t.FileName)).ToList();
         foreach (var track in newInputs)
         {
             args.Add($"-i \"{track.FileName}\"");

--- a/src/ui/Logic/NetflixQualityCheck/NetflixCheckTextForHiUseBrackets.cs
+++ b/src/ui/Logic/NetflixQualityCheck/NetflixCheckTextForHiUseBrackets.cs
@@ -41,7 +41,10 @@ public class NetflixCheckTextForHiUseBrackets : INetflixQualityChecker
             {
                 if ((arr[0].StartsWith("-(", StringComparison.Ordinal) && arr[0].EndsWith(')')) || (arr[0].StartsWith("-{", StringComparison.Ordinal) && arr[0].EndsWith('}') && !IsAssaOverride(arr[0].Substring(1))))
                 {
-                    arr[0] = "-[" + newText.Substring(2, newText.Length - 3) + "]";
+                    // arr[0], not newText: newText is still the whole two-line paragraph here, so
+                    // the offered fix came out as a mangled, duplicated three-line string. The
+                    // arr[1] branch just below is the correct shape.
+                    arr[0] = "-[" + arr[0].Substring(2, arr[0].Length - 3) + "]";
                 }
                 if ((arr[1].StartsWith("-(", StringComparison.Ordinal) && arr[1].EndsWith(')')) || (arr[1].StartsWith("-{", StringComparison.Ordinal) && arr[1].EndsWith('}') && !IsAssaOverride(arr[1].Substring(1))))
                 {

--- a/src/ui/Logic/XmlSourceSyntaxHighlighting.cs
+++ b/src/ui/Logic/XmlSourceSyntaxHighlighting.cs
@@ -99,7 +99,10 @@ public class XmlSourceSyntaxHighlighting : ISourceSyntaxHighlighter, ISourceSynt
                 sb.Append(c);
                 if (c == '-' && i + 2 < xml.Length && xml[i + 1] == '-' && xml[i + 2] == '>')
                 {
-                    sb.Append("-->");
+                    // sb.Append(c) above already emitted the first '-', so only the remaining
+                    // two characters belong here - appending "-->" turned every comment's
+                    // terminator into "--->".
+                    sb.Append("->");
                     i += 3;
                     inComment = false;
                     afterCloseTag = true;
@@ -172,9 +175,11 @@ public class XmlSourceSyntaxHighlighting : ISourceSyntaxHighlighter, ISourceSynt
 
                 afterCloseTag = true;
             }
-            else if (!inTag && char.IsWhiteSpace(c))
+            else if (!inTag && afterCloseTag && char.IsWhiteSpace(c))
             {
-                // Skip whitespace between tags
+                // Skip whitespace BETWEEN tags only. afterCloseTag is cleared as soon as real
+                // character data is emitted, so without it this also ate the spaces inside text -
+                // "<p>Hello world</p>" was previewed as "<p>Helloworld</p>".
                 i++;
                 continue;
             }

--- a/tests/seconv/Core/FixCommonErrorsRunnerTest.cs
+++ b/tests/seconv/Core/FixCommonErrorsRunnerTest.cs
@@ -363,9 +363,24 @@ public class FixCommonErrorsRunnerTest
     [InlineData("")]
     [InlineData("   ")]
     [InlineData("spanihs")]
+    // A plausible two-letter typo for Spanish (the real code is "es"). This used to be returned
+    // verbatim by an unchecked "length == 2" shortcut: being non-null it suppressed the warning
+    // and the auto-detect fallback, then matched no language gate, and left the OCR-fix pass -
+    // which needs a valid three-letter code - silently doing nothing.
+    [InlineData("sp")]
+    [InlineData("zz")]
     public void NormalizeLanguageOverride_BlankOrUnknown_ReturnsNull(string? input)
     {
         Assert.Null(FixCommonErrorsRunner.NormalizeLanguageOverride(input));
+    }
+
+    [Theory]
+    [InlineData("es", "es")]
+    [InlineData("ES", "es")]
+    [InlineData("da", "da")]
+    public void NormalizeLanguageOverride_RealTwoLetterCode_StillResolves(string input, string expected)
+    {
+        Assert.Equal(expected, FixCommonErrorsRunner.NormalizeLanguageOverride(input));
     }
 
     [Fact]


### PR DESCRIPTION
Sweep 15, across speech-to-text / text-to-speech, the Files dialogs, `ui/Logic` and `MainViewModel`, plus the verified findings the last sweep ran out of room for.

Suites: libse 1624 / libuilogic 708 / seconv 422 / UI 4151 (see the note at the bottom about one flaky UI test).

## A parameter ignored in favour of a global

`WhisperHelper` tested `Settings.WhisperChoice` instead of its own `whisperChoice` parameter in three places, while every other branch in the same methods used the parameter and a parameterless overload exists to pass the global. With "CPP cuBLAS" saved, asking for any other engine's folder (OpenAI, DashScope, OpenRouter, OpenAI-compatible) returned the cuBLAS folder, and cuBLAS itself never resolved through the parameter. In `GetExecutableFileNameNoPath` the clause was also `IsRunningOnLinux && choice == Cpp || Settings...== CppCuBlas` — `&&` binds tighter, so on **Windows** with cuBLAS saved, every engine resolved to whisper.cpp's `main`.

## Wrong values reaching an engine or a file

- **IndexTTS 2.5 built its language list backwards.** `TtsLanguage` is `(name, code)` and this is the only file in the tree that writes it `(code, name)` — so the combo listed `zh`/`en`/`ja` instead of language names, and `Speak` sent the literal string `"Chinese"` to audio.cpp. The method's own doc comment says these languages "have to be selected explicitly or they are synthesised with the wrong language's phonology", so the picker never did its job.
- **seconv forced Tesseract's `"eng"` onto every OCR engine.** Paddle wants `en`, Ollama and llama.cpp want a human-readable name, and all three declare their own defaults — which were unreachable because the option was never null. `--ocr-engine:paddle` therefore ran `paddleocr --lang eng`, which it rejects, failing the conversion. The help text already documents the three different code sets.
- **The D-Cinema SMPTE 2014 exporter never took the frame rate from its image parameters.** The Dost and FCP handlers were fixed for exactly this and carry the comment; this one was missed. It stayed at the 23.976 default and `(int)` truncated it, so every `index.xml` declared `EditRate 23` — not a valid D-Cinema rate, and out of step with the `TimeIn`/`TimeOut` values, which come from the real frame rate.
- **The D-Cinema interop exporter interpolated the folder name into XML unescaped**, so exporting into a folder named `Tom & Jerry` threw in `WriteFooter` — after every PNG was already on disk, leaving a folder of images with no `index.xml`.
- **`ColorService` opened a quote and relied on the tail to close it**, so an unquoted attribute (`<font color=red>`) became `<font color="#0000FF>`.

## Silently ignored input

- `--target-fps` was honoured only when `--fps` was also given; SE4 converts from the current frame rate in that case, and seconv's own image path already does.
- `--track-number` was applied on every container path except transport streams, so a `.ts` still produced one output per teletext page, per ARIB language and per DVB PID.
- `--fce-language` accepted any two-character value through an unchecked shortcut. `sp` (a natural typo for `es`) was non-null, so it suppressed both the warning and the auto-detect fallback, then matched no language gate and left the OCR-fix pass — which needs a valid three-letter code — doing nothing. The lookup below already accepts real two-letter codes, so the shortcut was redundant as well as harmful.
- `FindService.FindNext`/`FindPrevious` tested the *previous* search's line list before adopting the caller's, so a Find opened on an empty subtitle answered "not found" to every later F3 no matter how many lines had been added.

## MainViewModel

- **"Set end and offset the rest" moved the selected line's start too.** It looped from `index` calling `SetStartTimeKeepDuration`, sliding the line bodily by the end-delta, so its duration never changed — the opposite of "set end". The start twin is right to start at `index`; SE4 sets the end explicitly and offsets from `index + 1`.
- **"Move all shot changes one frame" divided by zero and wiped the list.** A non-null `_mediaInfo` can still carry `FramesRateNonNormalized == 0` (ffmpeg missing, or audio-only media), so the null check protected nothing: the step became infinity and every shot change fell out of range. The sibling command 160 lines up already guards this and says why.
- **"Extend selected to previous" took the raw grid predecessor**, which can be a display-only reference row of a mismatched original (#13962). Every sibling timing command uses the working-row helpers.
- **Fix common errors on a selection applied its results positionally.** `FixEmptyLines` is on by default and removes paragraphs, after which each later result landed on its *neighbour's* row. Now mapped by paragraph id, as the whole-file path already does.

## Files dialogs

- **Compare → Export threw in the dialog's default state.** The Export button was not bound to `IsExportVisible` like the two buttons beside it, and the export loop indexes the right-hand list by the left-hand count — and Compare always opens with an empty right side.
- The custom-format editor was never handed the subtitle title, so `{title}` previewed as empty while the parent window showed the real name.
- Import-images drag-and-drop accepted any extension-less file, because `"*.png".EndsWith("")` is true; such a file became a blank OCR line.

## Other

- The speech-to-text silence scan bounded its loop with `startPos`, which is assigned once and never advances — `startPosForward` is what moves. The guard was a constant, so the scan ran past the cue's end and the `-1` exit then abandoned the whole method, leaving every later line unadjusted.
- The Netflix HI-brackets check built `arr[0]`'s fix from the whole paragraph instead of the line (the `arr[1]` branch beside it is correct), producing a mangled three-line "fix".
- `Se.Settings.Tools.WriteToolsLog`: commit `3a3e8cbbb` ("change a few default settings … write tools log") set the initializer to `false`, but a stale constructor assignment runs after it — so that change never took effect.
- MKV muxing kept subtitle tracks the user had added and then deleted (the mp4 path filters them), which also shifted every following track's language/title metadata.
- Overlapping video cut segments moved the keep-cursor backwards, leaving footage in the output that the subtitle re-timer treats as removed — a growing desync.
- The XML source preview turned every comment terminator into `--->` and ate the spaces inside character data (`<p>Hello world</p>` → `<p>Helloworld</p>`).
- The Ollama OCR engine leaked an `HttpResponseMessage` per bitmap.
- RTL image export measured lines in natural order but drew them reversed, so the 0.17em styled-segment padding was counted on a different segment than it was applied to, shifting centered and right-aligned text.

## Rejected after testing

An agent flagged an undisposed `SKPath` for empty glyphs in `ImageRenderer` as a leak. Adding the `Dispose()` broke `NOcrTrainerTests.TrainedDb_RoundTripsAfterSaveAndReload`, so that path must not be disposed — the "fix" is not in this PR.

## Note on a flaky test

`LibMpvEventLoopTests.Pause_RightAfterSeek_KeepsReportingTheSeekTarget` drives a real libmpv and asserts an exact position pin for 800 ms. It is timing-sensitive: on my machine it fails intermittently (including once with this branch's changes reverted), and reliably when the machine is loaded. I could not attribute it to any change here — nothing in this PR touches the video players — but the failure rate did look higher on this branch than on main, so it is worth a look. CI skips it where libmpv is absent. I have deliberately not "fixed" it by loosening the assertion, since that would weaken a real regression guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)