### PR TITLE
Make the undocked foreground-steal correction re-armable (#14168)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -547,7 +547,7 @@ public partial class MainViewModel :
     VideoPlayerUndockedViewModel? _videoPlayerUndockedViewModel;
     AudioVisualizerUndockedViewModel? _audioVisualizerUndockedViewModel;
     bool _suppressUndockedTopmost;
-    bool _mainWindowLostForegroundToOtherApp;
+    bool _foregroundBelongsToMainWindow;
     bool _undockedWindowPointerPressed;
     FindViewModel? _findViewModel;
     Control? _findPreviousFocus;
@@ -8209,9 +8209,21 @@ public partial class MainViewModel :
     /// minimized), Windows activates the frontmost window of this process, which is a tool
     /// window, not the main window the user left. Same family as the startup case in #13569.
     ///
-    /// Only corrected when the main window was the one that lost the foreground, and only when
-    /// the activation was not aimed at the tool window itself - a click that activates a window
-    /// is delivered after the activation on Windows, so the decision waits a beat for it.
+    /// The claim on the SE foreground (_foregroundBelongsToMainWindow) is re-armable state, not a
+    /// one-shot flag: it follows the user (set while the main window is active, moved to a tool
+    /// window only by an activation the user aimed at it) and is read fresh on EVERY tool-window
+    /// activation. The first cut latched a flag when the main window deactivated and consumed it
+    /// on the first tool-window Activated, which a single churn activation - topmost churn while
+    /// another application takes over, or the foreground bouncing between the two tool windows -
+    /// disarmed for the whole round (#14168 beta 26 feedback).
+    ///
+    /// "Aimed at" is decided by the physical pointer buttons: a click that activates a window
+    /// (client area or title bar, including a drag by the title bar) still has the button down
+    /// while the activation is delivered, whereas the OS handing the foreground over because
+    /// another application's window went away does not. Where the buttons cannot be sampled the
+    /// cursor resting over the window has to do - knowing that the closing application may have
+    /// merely exposed the tool window under the cursor. The Avalonia press event only covers the
+    /// client area and arrives after the activation, so the decision still waits a beat for it.
     ///
     /// The one case this cannot tell apart from the OS handing over the foreground is the user
     /// Alt+Tabbing straight back to a tool window (they are separate entries in the task
@@ -8229,19 +8241,36 @@ public partial class MainViewModel :
 
         undockedWindow.Activated += (_, _) =>
         {
-            if (!_mainWindowLostForegroundToOtherApp)
+            if (!_foregroundBelongsToMainWindow)
             {
+                return; // the user was already working in a tool window - leave it in front
+            }
+
+            if (IsUndockedActivationAimedAtToolWindow(
+                    CursorPositionHelper.IsAnyPointerButtonDown(),
+                    undockedWindow.IsPointerOver))
+            {
+                _foregroundBelongsToMainWindow = false; // the user moved to the tool window
                 return;
             }
 
-            _mainWindowLostForegroundToOtherApp = false;
             _undockedWindowPointerPressed = false;
 
             DispatcherTimer.RunOnce(() =>
             {
-                if (Window is not { } mainWindow || !ShouldHandForegroundBackToMainWindow(
-                        _undockedWindowPointerPressed,
-                        undockedWindow.IsPointerOver,
+                if (_undockedWindowPointerPressed)
+                {
+                    // A press the button sampling missed (e.g. touch) - the user aimed here.
+                    _foregroundBelongsToMainWindow = false;
+                    return;
+                }
+
+                // Re-checked because the beat is long enough for the state to move: the user may
+                // have clicked into the main window, or the foreground may have bounced
+                // to the other tool window - whose own Activated handler owns the decision then.
+                if (!_foregroundBelongsToMainWindow ||
+                    Window is not { } mainWindow ||
+                    !ShouldHandForegroundBackToMainWindow(
                         undockedWindow.IsActive,
                         mainWindow.IsActive,
                         mainWindow.WindowState == WindowState.Minimized,
@@ -8256,22 +8285,31 @@ public partial class MainViewModel :
     }
 
     /// <summary>
-    /// Whether an undocked tool window that just took the foreground should hand it to the main
+    /// Whether an undocked tool window's activation was the user's doing rather than the OS
+    /// handing the foreground over - see <see cref="WatchUndockedForegroundSteal"/>. Pure so the
+    /// rule can be tested.
+    /// </summary>
+    internal static bool IsUndockedActivationAimedAtToolWindow(
+        bool? pointerButtonDown,
+        bool pointerOverToolWindow)
+    {
+        // The button state is authoritative when it can be sampled: the cursor merely resting
+        // over the tool window is NOT aiming - closing another application's window exposes the
+        // tool window under a cursor that never moved (Windows even synthesizes the mouse-move
+        // that flips IsPointerOver). Hover is only trusted where the buttons cannot be read.
+        return pointerButtonDown ?? pointerOverToolWindow;
+    }
+
+    /// <summary>
+    /// Whether an undocked tool window that took the foreground should hand it to the main
     /// window - see <see cref="WatchUndockedForegroundSteal"/>. Pure so the rule can be tested.
     /// </summary>
     internal static bool ShouldHandForegroundBackToMainWindow(
-        bool undockedWindowPointerPressed,
-        bool undockedWindowPointerOver,
         bool undockedWindowIsActive,
         bool mainWindowIsActive,
         bool mainWindowIsMinimized,
         bool modalDialogOpen)
     {
-        if (undockedWindowPointerPressed || undockedWindowPointerOver)
-        {
-            return false; // the user aimed at the tool window - leave it in front
-        }
-
         if (!undockedWindowIsActive || mainWindowIsActive)
         {
             return false; // the foreground already moved on
@@ -25674,16 +25712,19 @@ public partial class MainViewModel :
         // Captured before the cleanup below, which can move focus itself.
         _focusBeforeWindowDeactivated = GetRestorableFocusedControl();
 
-        // Note whether the whole application - not just this window - went to the background with
-        // the main window in front, so an undocked tool window taking the foreground back can be
-        // corrected (see WatchUndockedForegroundSteal, #14168). Deferred because the newly active
-        // window's IsActive has not settled while Deactivated runs.
+        // The claim on the SE foreground moves to a dialog when one is what took over; it
+        // deliberately STAYS with the main window otherwise - through the application going to
+        // the background, and through an undocked tool window reading as active here (topmost
+        // churn can flicker one active while another application takes the foreground, and that
+        // must not disarm the correction - the tool window's own Activated watcher decides
+        // whether the user aimed at it; see WatchUndockedForegroundSteal, #14168). Deferred
+        // because the newly active window's IsActive has not settled while Deactivated runs.
         Dispatcher.UIThread.Post(() =>
         {
-            _mainWindowLostForegroundToOtherApp =
-                Window is { IsActive: false } &&
-                !IsUndockedWindowActive() &&
-                GetActiveWindowOtherThanMainAndUndocked() == null;
+            if (GetActiveWindowOtherThanMainAndUndocked() != null)
+            {
+                _foregroundBelongsToMainWindow = false;
+            }
         }, DispatcherPriority.Background);
 
         // Avalonia's AccessKeyHandler must not be left mid-Alt-gesture either: a modal opened
@@ -25729,9 +25770,9 @@ public partial class MainViewModel :
         var previous = _focusBeforeWindowDeactivated;
         _focusBeforeWindowDeactivated = null;
 
-        // The main window is where the foreground belongs, so there is nothing left to correct
-        // (#14168).
-        _mainWindowLostForegroundToOtherApp = false;
+        // The user is in the main window, so that is where the SE foreground belongs until an
+        // activation aimed at a tool window says otherwise (#14168).
+        _foregroundBelongsToMainWindow = true;
 
         Dispatcher.UIThread.Post(() =>
         {

--- a/src/ui/Logic/CursorPositionHelper.cs
+++ b/src/ui/Logic/CursorPositionHelper.cs
@@ -12,6 +12,13 @@ public static  class CursorPositionHelper
     [DllImport("user32.dll")]
     private static extern bool GetCursorPos(out POINT lpPoint);
 
+    [DllImport("user32.dll")]
+    private static extern short GetAsyncKeyState(int vKey);
+
+    private const int VkLButton = 0x01;
+    private const int VkRButton = 0x02;
+    private const int VkMButton = 0x04;
+
     [StructLayout(LayoutKind.Sequential)]
     private struct POINT
     {
@@ -26,6 +33,11 @@ public static  class CursorPositionHelper
 
     [DllImport(CoreGraphicsLib)]
     private static extern CGPoint CGEventSourceGetCursorPosition(uint source);
+
+    [DllImport(CoreGraphicsLib)]
+    private static extern bool CGEventSourceButtonState(int stateId, uint button);
+
+    private const int CGEventSourceStateCombinedSessionState = 0;
 
     [DllImport(CoreGraphicsLib)]
     private static extern IntPtr CGEventCreate(IntPtr source);
@@ -94,6 +106,58 @@ public static  class CursorPositionHelper
                     }
 
                     XCloseDisplay(display);
+                }
+            }
+        }
+        catch (Exception exception)
+        {
+            Se.LogError(exception);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Whether any mouse button is physically down right now, or null where the buttons cannot
+    /// be sampled (unsupported platform, or the query failed - e.g. no X11 under Wayland).
+    /// Used to tell a window activation the user clicked for apart from one the OS handed over
+    /// (undocked foreground steal, #14168): a click's activation is delivered while the button
+    /// is still down, an OS handover after another application's window closed is not.
+    /// </summary>
+    public static bool? IsAnyPointerButtonDown()
+    {
+        try
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                // The high bit is "down now". VK_L/RBUTTON are physical buttons, so a swapped
+                // primary button still lands on one of the three.
+                return ((GetAsyncKeyState(VkLButton) |
+                         GetAsyncKeyState(VkRButton) |
+                         GetAsyncKeyState(VkMButton)) & 0x8000) != 0;
+            }
+
+            if (OperatingSystem.IsMacOS())
+            {
+                return CGEventSourceButtonState(CGEventSourceStateCombinedSessionState, 0) ||
+                       CGEventSourceButtonState(CGEventSourceStateCombinedSessionState, 1) ||
+                       CGEventSourceButtonState(CGEventSourceStateCombinedSessionState, 2);
+            }
+
+            if (OperatingSystem.IsLinux())
+            {
+                var display = XOpenDisplay(IntPtr.Zero);
+                if (display != IntPtr.Zero)
+                {
+                    var rootWindow = XDefaultRootWindow(display);
+                    var ok = XQueryPointer(display, rootWindow, out _, out _, out _, out _,
+                        out _, out _, out var mask);
+                    XCloseDisplay(display);
+                    if (ok)
+                    {
+                        // Button1Mask | Button2Mask | Button3Mask
+                        return (mask & 0x700) != 0;
+                    }
                 }
             }
         }

--- a/tests/UI/Logic/UndockedForegroundStealTests.cs
+++ b/tests/UI/Logic/UndockedForegroundStealTests.cs
@@ -6,20 +6,18 @@ namespace UITests.Logic;
 // while SE is active, and dropping topmost on Windows re-inserts them at the top of the
 // non-topmost band). So when the application the user switched to closes, the OS hands the
 // foreground to the audio visualizer instead of the main window the user left (#14168).
-// MainViewModel.ShouldHandForegroundBackToMainWindow is the rule that decides when to correct it.
+// MainViewModel.IsUndockedActivationAimedAtToolWindow classifies who caused a tool-window
+// activation, and MainViewModel.ShouldHandForegroundBackToMainWindow decides whether an
+// OS-caused one is corrected.
 public class UndockedForegroundStealTests
 {
     private static bool Decide(
-        bool pointerPressed = false,
-        bool pointerOver = false,
         bool undockedActive = true,
         bool mainActive = false,
         bool mainMinimized = false,
         bool modalOpen = false)
     {
         return MainViewModel.ShouldHandForegroundBackToMainWindow(
-            pointerPressed,
-            pointerOver,
             undockedActive,
             mainActive,
             mainMinimized,
@@ -33,22 +31,11 @@ public class UndockedForegroundStealTests
     }
 
     [Fact]
-    public void KeepsToolWindowInFront_WhenTheUserClickedIt()
-    {
-        // A click that activates a window is delivered after the activation on Windows, which is
-        // why the decision waits a beat for the press instead of reading it at activation time.
-        Assert.False(Decide(pointerPressed: true));
-    }
-
-    [Fact]
-    public void KeepsToolWindowInFront_WhenThePointerIsOverIt()
-    {
-        Assert.False(Decide(pointerOver: true));
-    }
-
-    [Fact]
     public void DoesNothing_WhenTheForegroundAlreadyMovedOn()
     {
+        // The beat between activation and decision is long enough for the user to have clicked
+        // into the main window, or for the foreground to have bounced to the other tool window -
+        // whose own Activated handler owns the decision then.
         Assert.False(Decide(undockedActive: false));
         Assert.False(Decide(mainActive: true));
     }
@@ -65,5 +52,37 @@ public class UndockedForegroundStealTests
     {
         // The modal owns the foreground; pulling it to the input-disabled main window is #13405.
         Assert.False(Decide(modalOpen: true));
+    }
+
+    [Fact]
+    public void ActivationIsAimed_WhenAPointerButtonIsDown()
+    {
+        // A click that activates a window (client area or title bar, including a drag by the
+        // title bar) still has the button physically down while the activation is delivered.
+        Assert.True(MainViewModel.IsUndockedActivationAimedAtToolWindow(
+            pointerButtonDown: true, pointerOverToolWindow: false));
+        Assert.True(MainViewModel.IsUndockedActivationAimedAtToolWindow(
+            pointerButtonDown: true, pointerOverToolWindow: true));
+    }
+
+    [Fact]
+    public void ActivationIsNotAimed_WhenTheCursorMerelyRestsOverTheToolWindow()
+    {
+        // Closing another application's window exposes the tool window under a cursor that never
+        // moved (Windows synthesizes the mouse-move that flips IsPointerOver), so hover must not
+        // veto the correction when the button state says no click happened - the beta 26 failure.
+        Assert.False(MainViewModel.IsUndockedActivationAimedAtToolWindow(
+            pointerButtonDown: false, pointerOverToolWindow: true));
+        Assert.False(MainViewModel.IsUndockedActivationAimedAtToolWindow(
+            pointerButtonDown: false, pointerOverToolWindow: false));
+    }
+
+    [Fact]
+    public void HoverDecides_OnlyWhereTheButtonsCannotBeSampled()
+    {
+        Assert.True(MainViewModel.IsUndockedActivationAimedAtToolWindow(
+            pointerButtonDown: null, pointerOverToolWindow: true));
+        Assert.False(MainViewModel.IsUndockedActivationAimedAtToolWindow(
+            pointerButtonDown: null, pointerOverToolWindow: false));
     }
 }


### PR DESCRIPTION
Follow-up to #14173 after the beta 26 feedback in #14168: the F1 → close-the-browser cycle still left the undocked audio visualizer in the foreground, every time.

**Why the first cut failed.** It latched a one-shot flag when the main window deactivated and consumed it on the first tool-window `Activated`. That design has three deterministic ways to lose, and any one of them kills the whole round:

- topmost churn while another application takes the foreground can flicker a tool window active, so the arming condition (`!IsUndockedWindowActive()`) computed false and the correction never armed;
- the foreground bouncing between the two tool windows after the other application closes: the first `Activated` consumed the flag, the beat check then saw that window no longer active and bailed, and the second window's handler found the flag already spent;
- the `IsPointerOver` veto fired without any user intent - closing the other application exposes the tool window under a cursor that never moved, and Windows synthesizes the mouse-move that flips `IsPointerOver`.

**The re-armable design.** `_foregroundBelongsToMainWindow` is state that follows the user, not an event latch: set while the main window is active, moved to a dialog when one takes over, and moved to a tool window only by an activation the user actually aimed at it. Every tool-window activation reads it fresh, so churn can no longer disarm the correction - a bounced foreground just runs the check again from the window it landed on.

**"Aimed" is decided by the physical pointer buttons.** A click that activates a window - client area or title bar, including a drag by the title bar - still has the button down while the activation is delivered; the OS handing the foreground over because another application's window went away does not. `CursorPositionHelper.IsAnyPointerButtonDown()` samples that per platform (`GetAsyncKeyState` / `CGEventSourceButtonState` / `XQueryPointer`'s button mask, alongside the cursor queries already there), and hover is trusted only where the buttons cannot be read. The Avalonia press event stays as the beat-delayed fallback for presses the sampling can miss (touch).

The accepted cost is unchanged and documented: Alt+Tabbing straight back to a tool window lands in the main window instead.

Tests: `UndockedForegroundStealTests` rewritten for the two pure rules (7 pass), including the beta 26 failure case - hover must not veto when the button state says no click happened. Full UI suite run against this change and against its baseline on the same machine: identical results (the 21 failures on this machine are pre-existing local focus/keyboard flakiness, none from this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)