### PR TITLE
Fix 20 bugs found in a bug hunt

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -180,6 +180,7 @@
     "engine": "Engine",
     "enterProfileName": "Enter profile name",
     "error": "Error",
+    "outputFileCannotBeTheInputFile": "The output file cannot be the same as the input file.",
     "errorX": "Error; {0}",
     "example": "Example",
     "exampleX": "Example: {0}",

--- a/src/ui/Features/Video/CutVideo/CutVideoViewModel.cs
+++ b/src/ui/Features/Video/CutVideo/CutVideoViewModel.cs
@@ -51,7 +51,6 @@ public partial class CutVideoViewModel : ObservableObject
     [ObservableProperty] private bool _isAudioVisualizerVisible;
     [ObservableProperty] private ObservableCollection<SubtitleLineViewModel> _segments;
     [ObservableProperty] private SubtitleLineViewModel? _selectedSegment;
-    [ObservableProperty] private int _selectedSegmentIndex;
     [ObservableProperty] private ObservableCollection<CutTypeDisplay> _cutTypes;
     [ObservableProperty] private CutTypeDisplay _selectedCutType;
     [ObservableProperty] private bool _isSetStartEnabled;
@@ -116,11 +115,12 @@ public partial class CutVideoViewModel : ObservableObject
         FrameRates = new ObservableCollection<double> { 23.976, 24, 25, 29.97, 30, 50, 59.94, 60 };
         SelectedFrameRate = FrameRates[0];
 
+        // No .webm: the video path always encodes libx264, which the WebM muxer cannot carry.
+        // (.mp3/.wav take the audio-only branch and are fine.)
         VideoExtensions = new ObservableCollection<string>
         {
             ".mkv",
             ".mp4",
-            ".webm",
             ".mp3",
             ".wav",
         };
@@ -223,7 +223,10 @@ public partial class CutVideoViewModel : ObservableObject
         _positionTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(150) };
         _positionTimer.Tick += (s, e) =>
         {
-            UpdateAudioVisualizer(VideoPlayer.VideoPlayer, AudioVisualizer, SelectedSegmentIndex);
+            // Derive the index from the row the grid actually binds. SelectedSegmentIndex is
+            // written nowhere in the repo and is not bound, so it stayed 0 and the waveform
+            // always highlighted the first segment no matter which row was selected.
+            UpdateAudioVisualizer(VideoPlayer.VideoPlayer, AudioVisualizer, SelectedSegment == null ? -1 : Segments.IndexOf(SelectedSegment));
 
             if (_updateAudioVisualizer)
             {

--- a/src/ui/Features/Video/EmbeddedSubtitlesEdit/EmbedTrackPreviewViewModel.cs
+++ b/src/ui/Features/Video/EmbeddedSubtitlesEdit/EmbedTrackPreviewViewModel.cs
@@ -54,6 +54,17 @@ public partial class EmbedTrackPreviewViewModel : ObservableObject
         Dispatcher.UIThread.Post(() => { Window?.Close(); });
     }
 
+    /// <summary>
+    /// The MatroskaFile handed to <see cref="Initialize"/> holds an open FileStream on the video
+    /// and this view model owns it for its lifetime; without this every Preview click left a
+    /// handle on a possibly multi-GB file behind.
+    /// </summary>
+    internal void OnClosing()
+    {
+        _matroskaFile?.Dispose();
+        _matroskaFile = null;
+    }
+
     [RelayCommand]
     private void Ok()
     {

--- a/src/ui/Features/Video/EmbeddedSubtitlesEdit/EmbedTrackPreviewWindow.cs
+++ b/src/ui/Features/Video/EmbeddedSubtitlesEdit/EmbedTrackPreviewWindow.cs
@@ -56,6 +56,7 @@ public class EmbedTrackPreviewWindow : Window
 
         //KeyDown += (_, e) => vm.OnKeyDown(e);
         AddHandler(KeyDownEvent, vm.OnKeyDownHandler, RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: false);
+        Closing += (_, _) => vm.OnClosing();
 
 
         Loaded += (_, _) => 

--- a/src/ui/Features/Video/EmbeddedSubtitlesEdit/EmbeddedSubtitlesEditViewModel.cs
+++ b/src/ui/Features/Video/EmbeddedSubtitlesEdit/EmbeddedSubtitlesEditViewModel.cs
@@ -47,6 +47,7 @@ public partial class EmbeddedSubtitlesEditViewModel : ObservableObject
     private long _processedFrames;
     private Process? _ffmpegProcess;
     private readonly Timer _timerGenerate;
+    private bool _loaded;
     private bool _doAbort;
     private SubtitleFormat? _subtitleFormat;
     private DispatcherTimer _positionTimer = new DispatcherTimer();
@@ -626,6 +627,16 @@ public partial class EmbeddedSubtitlesEditViewModel : ObservableObject
 
     internal void OnLoaded()
     {
+        // Avalonia's Window.Loaded can fire more than once (re-attach to visual tree, layout
+        // pass), and the scan below APPENDS without clearing - so a second fire listed every
+        // existing subtitle track twice and Generate then mapped each kept stream twice into the
+        // output. The mp4 twin already guards this.
+        if (_loaded)
+        {
+            return;
+        }
+
+        _loaded = true;
         StartTitleTimer();
         UiUtil.RestoreWindowPosition(Window);
         Task.Run(() =>
@@ -671,7 +682,9 @@ public partial class EmbeddedSubtitlesEditViewModel : ObservableObject
 
         if (FileUtil.IsMatroskaFileFast(videoFileName))
         {
-            var matroskaFile = new MatroskaFile(videoFileName);
+            // MatroskaFile opens a FileStream on the video in its constructor, so without the
+            // using every window open and every Browse left a handle on a multi-GB file behind.
+            using var matroskaFile = new MatroskaFile(videoFileName);
             if (matroskaFile.IsValid)
             {
                 var tracks = matroskaFile.GetTracks();

--- a/src/ui/Features/Video/ReEncodeVideo/ReEncodeVideoViewModel.cs
+++ b/src/ui/Features/Video/ReEncodeVideo/ReEncodeVideoViewModel.cs
@@ -75,11 +75,12 @@ public partial class ReEncodeVideoViewModel : ObservableObject
         FrameRates = new ObservableCollection<double> { 23.976, 24, 25, 29.97, 30, 50, 59.94, 60 };
         SelectedFrameRate = FrameRates[0];
 
+        // No .webm: this always encodes libx264, and the WebM muxer takes only VP8/VP9/AV1, so
+        // picking it could only ever end in "Output video file not generated".
         VideoExtensions = new ObservableCollection<string>
         {
             ".mkv",
             ".mp4",
-            ".webm",
         };
         SelectedVideoExtension = VideoExtensions[0];
 
@@ -262,8 +263,18 @@ public partial class ReEncodeVideoViewModel : ObservableObject
         var mediaInfo = FfmpegMediaInfo.Parse(jobItem.InputVideoFileName);
         jobItem.TotalFrames = mediaInfo.GetTotalFrames();
         jobItem.TotalSeconds = mediaInfo.Duration.TotalSeconds;
-        jobItem.Width = mediaInfo.Dimension.Width;
-        jobItem.Height = mediaInfo.Dimension.Height;
+
+        // Only adopt the source size when the user asked for it. This dialog exists to produce a
+        // SMALLER file ("high resolutions make subtitling slow"), and Initialize scales large
+        // sources down to 1280 wide - unconditionally overwriting both here threw that away, so
+        // every re-encode ran at the source resolution and the resolution picker did nothing.
+        // The burn-in dialog was fixed the same way.
+        if (mediaInfo.Dimension.Width > 0 && mediaInfo.Dimension.Height > 0 &&
+            (UseSourceResolution || jobItem.Width <= 0 || jobItem.Height <= 0))
+        {
+            jobItem.Width = mediaInfo.Dimension.Width;
+            jobItem.Height = mediaInfo.Dimension.Height;
+        }
         jobItem.UseTargetFileSize = false;
         jobItem.Status = Se.Language.General.Generating;
 
@@ -403,13 +414,50 @@ public partial class ReEncodeVideoViewModel : ObservableObject
         PromptForFfmpegParameters = false;
     }
 
+    /// <summary>
+    /// A distinct output name beside the source: "<name>_reencoded<ext>", with a collision
+    /// counter, mirroring the cut-video dialog. Never returns the input path.
+    /// </summary>
+    private string MakeOutputFileName(string videoFileName)
+    {
+        var nameNoExt = Path.GetFileNameWithoutExtension(videoFileName);
+        var folder = Path.GetDirectoryName(videoFileName) ?? Path.GetTempPath();
+        var fileName = Path.Combine(folder, nameNoExt + "_reencoded" + SelectedVideoExtension);
+
+        var i = 2;
+        while (File.Exists(fileName))
+        {
+            fileName = Path.Combine(folder, nameNoExt + "_reencoded_" + i.ToString(CultureInfo.InvariantCulture) + SelectedVideoExtension);
+            i++;
+        }
+
+        return fileName;
+    }
+
     [RelayCommand]
     private async Task Generate()
     {
-        var outputVideoFileName = Path.ChangeExtension(VideoFileName, SelectedVideoExtension);
+        // Suggest a DISTINCT name: ChangeExtension on an .mkv input with the default .mkv output
+        // handed the save dialog the input path itself, so accepting the suggestion pointed
+        // ffmpeg at the file it was reading and destroyed the user's video. The cut-video and
+        // embedded-subtitles dialogs both build a suffixed name with a collision counter.
+        var outputVideoFileName = MakeOutputFileName(VideoFileName);
         outputVideoFileName = await _fileHelper.PickSaveFile(Window!, SelectedVideoExtension, outputVideoFileName, Se.Language.General.SaveVideoAsVideoTitle);
         if (string.IsNullOrEmpty(outputVideoFileName))
         {
+            return;
+        }
+
+        // ...and refuse it outright if the user still picks the input, as the write-chapters
+        // dialog does: ffmpeg reads the input while writing the output.
+        if (string.Equals(Path.GetFullPath(outputVideoFileName), Path.GetFullPath(VideoFileName), StringComparison.OrdinalIgnoreCase))
+        {
+            await MessageBox.Show(
+                Window!,
+                Se.Language.General.Error,
+                Se.Language.General.OutputFileCannotBeTheInputFile,
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
             return;
         }
 
@@ -478,6 +526,24 @@ public partial class ReEncodeVideoViewModel : ObservableObject
         // The subtitle files handed to ffmpeg live as long as the window does - nothing else
         // removes them, and they used to pile up in the temp folder run after run (#13332).
         _tempSubtitleFiles.Delete();
+
+        // Stop the poll timer and any still-running encode - closing the window used to leave the
+        // ffmpeg process encoding to completion in the background, with the timer still firing
+        // into a closed window. Same fix as the blank-video and embedded-subtitles dialogs.
+        _timerGenerate.StopAndDispose(TimerGenerateElapsed);
+        if (_ffmpegProcess != null && !_ffmpegProcess.HasExited)
+        {
+            try
+            {
+#pragma warning disable CA1416
+                _ffmpegProcess.Kill(true);
+#pragma warning restore CA1416
+            }
+            catch
+            {
+                // ignore - it may have exited in between
+            }
+        }
     }
 
     internal void OnKeyDown(KeyEventArgs e)
@@ -485,7 +551,9 @@ public partial class ReEncodeVideoViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
-            Window?.Close();
+            // Route through Cancel so Escape during generation aborts the encode
+            // instead of closing the window over a running ffmpeg.
+            Cancel();
         }
         else if (UiUtil.IsHelp(e))
         {

--- a/src/ui/Logic/ClipboardHelper.cs
+++ b/src/ui/Logic/ClipboardHelper.cs
@@ -306,16 +306,24 @@ public static class ClipboardHelper
             var tempPath = Path.Combine(Path.GetTempPath(), $"clipboard_{Guid.NewGuid()}.png");
             bitmap.Save(tempPath, PngBitmapEncoderOptions.Default);
 
-            // Try xclip first
+            // Build the argument vector rather than a command line: with UseShellExecute=false
+            // there is no shell, so on Unix .NET only honours " and \ - the single quotes were
+            // passed to xclip as part of the file name, and "<" reached wl-copy as a literal
+            // argument instead of redirecting stdin. Both silently did nothing.
             var psi = new ProcessStartInfo
             {
                 FileName = "xclip",
-                Arguments = $"-selection clipboard -t image/png -i '{tempPath}'",
                 UseShellExecute = false,
                 CreateNoWindow = true,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true
             };
+            psi.ArgumentList.Add("-selection");
+            psi.ArgumentList.Add("clipboard");
+            psi.ArgumentList.Add("-t");
+            psi.ArgumentList.Add("image/png");
+            psi.ArgumentList.Add("-i");
+            psi.ArgumentList.Add(tempPath);
 
             try
             {
@@ -332,13 +340,23 @@ public static class ClipboardHelper
             }
             catch
             {
-                // If xclip fails, try wl-copy (Wayland)
+                // If xclip fails, try wl-copy (Wayland). It reads the image from stdin, so feed
+                // the file in ourselves - there is no shell to do the redirect for us.
                 psi.FileName = "wl-copy";
-                psi.Arguments = $"--type image/png < '{tempPath}'";
+                psi.ArgumentList.Clear();
+                psi.ArgumentList.Add("--type");
+                psi.ArgumentList.Add("image/png");
+                psi.RedirectStandardInput = true;
 
                 using var process = Process.Start(psi);
                 if (process != null)
                 {
+                    using (var stdin = process.StandardInput.BaseStream)
+                    using (var pngFile = File.OpenRead(tempPath))
+                    {
+                        await pngFile.CopyToAsync(stdin);
+                    }
+
                     await process.WaitForExitAsync();
 
                     await Task.Delay(500);
@@ -365,12 +383,16 @@ public static class ClipboardHelper
             var psi = new ProcessStartInfo
             {
                 FileName = "osascript",
-                Arguments = $"-e 'set the clipboard to (read (POSIX file \"{tempPath}\") as «class PNGf»)'",
                 UseShellExecute = false,
                 CreateNoWindow = true,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true
             };
+
+            // One -e argument, passed whole. As a command line the outer single quotes were
+            // literal and the script was split on spaces, so osascript never compiled it.
+            psi.ArgumentList.Add("-e");
+            psi.ArgumentList.Add($"set the clipboard to (read (POSIX file \"{tempPath}\") as «class PNGf»)");
 
             using var process = Process.Start(psi);
             if (process != null)

--- a/src/ui/Logic/Compression/ZipUnpacker.cs
+++ b/src/ui/Logic/Compression/ZipUnpacker.cs
@@ -175,6 +175,25 @@ public class ZipUnpacker : IZipUnpacker
                     continue;
                 }
 
+                // The containment check above validates where the LINK is written, never where it
+                // points. An archive shipping "lib -> /etc" (or "../..") followed by a regular
+                // "lib/x" entry passes that check and then writes outside the extraction folder,
+                // and the copy fallback below would pull an arbitrary host file in. Reject an
+                // absolute target, and require a relative one to resolve inside the root.
+                if (Path.IsPathRooted(linkTarget))
+                {
+                    continue;
+                }
+
+                var resolvedLinkTarget = Path.GetFullPath(Path.Combine(directoryPath ?? targetRoot, linkTarget));
+                var linkTargetRelative = Path.GetRelativePath(targetRoot, resolvedLinkTarget);
+                if (linkTargetRelative.Equals("..", StringComparison.Ordinal) ||
+                    linkTargetRelative.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal) ||
+                    Path.IsPathRooted(linkTargetRelative))
+                {
+                    continue;
+                }
+
                 try
                 {
                     if (File.Exists(filePath) || Directory.Exists(filePath))
@@ -188,10 +207,9 @@ public class ZipUnpacker : IZipUnpacker
                 {
                     // Symlinks may be unsupported (e.g. Windows without privileges) - fall back to
                     // copying the already-extracted target file when it is available.
-                    var resolvedTarget = Path.Combine(directoryPath ?? outputPath, linkTarget);
-                    if (File.Exists(resolvedTarget) && !File.Exists(filePath))
+                    if (File.Exists(resolvedLinkTarget) && !File.Exists(filePath))
                     {
-                        File.Copy(resolvedTarget, filePath);
+                        File.Copy(resolvedLinkTarget, filePath);
                     }
                     else
                     {

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -180,6 +180,7 @@ public class LanguageGeneral
     public string Engine { get; set; }
     public string EnterProfileName { get; set; }
     public string Error { get; set; }
+    public string OutputFileCannotBeTheInputFile { get; set; }
     public string ErrorX { get; set; }
     public string Example { get; set; }
     public string ExampleX { get; set; }
@@ -941,6 +942,7 @@ public class LanguageGeneral
         Engine = "Engine";
         EnterProfileName = "Enter profile name";
         Error = "Error";
+        OutputFileCannotBeTheInputFile = "The output file cannot be the same as the input file.";
         ErrorX = "Error; {0}";
         Example = "Example";
         ExampleX = "Example: {0}";

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -436,28 +436,31 @@ public class Se
 
     public static void LoadSettings(string settingsFileName)
     {
-        if (!System.IO.File.Exists(settingsFileName))
+        // Only the deserialize is conditional. Returning early on a missing file also skipped
+        // UpdateLibSeSettings() - the single bridge onto libse's Configuration.Settings - so on a
+        // first run libse kept its own defaults for the whole session. Among them
+        // RememberUseAlwaysList, which gates every <lang>_UseAlways.xml load and save, so spell
+        // check's "Change all" was silently session-only until the first settings save.
+        var settingsFileExists = System.IO.File.Exists(settingsFileName);
+        if (settingsFileExists)
         {
-            MigrateMacOsFontSettings(Settings.Appearance, OperatingSystem.IsMacOS(), false);
-            return;
+            try
+            {
+                // Stream + source-generated metadata: no UTF-16 string round-trip and no
+                // runtime reflection over the settings type graph.
+                using var stream = System.IO.File.OpenRead(settingsFileName);
+                Settings = JsonSerializer.Deserialize(stream, SeJsonContext.Default.Se)!;
+            }
+            catch (Exception exception)
+            {
+                Se.LogError(exception);
+                Settings = new Se();
+            }
+
+            SetDefaultValues();
         }
 
-        try
-        {
-            // Stream + source-generated metadata: no UTF-16 string round-trip and no
-            // runtime reflection over the settings type graph.
-            using var stream = System.IO.File.OpenRead(settingsFileName);
-            Settings = JsonSerializer.Deserialize(stream, SeJsonContext.Default.Se)!;
-        }
-        catch (Exception exception)
-        {
-            Se.LogError(exception);
-            Settings = new Se();
-        }
-
-        SetDefaultValues();
-
-        MigrateMacOsFontSettings(Settings.Appearance, OperatingSystem.IsMacOS(), true);
+        MigrateMacOsFontSettings(Settings.Appearance, OperatingSystem.IsMacOS(), settingsFileExists);
 
         UpdateLibSeSettings();
 

--- a/src/ui/Logic/Media/FfmpegGenerator.cs
+++ b/src/ui/Logic/Media/FfmpegGenerator.cs
@@ -949,7 +949,9 @@ public class FfmpegGenerator
         else if (checkered)
         {
             var tempImageFileName = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".png");
-            var skBitmap = new SKBitmap(width, height, true);
+            // The branch above uses "using" for its bitmap; this one leaked ~8 MB of native
+            // pixels at 1080p on every "generate video with checkered background".
+            using var skBitmap = new SKBitmap(width, height, true);
             using (var canvas = new SKCanvas(skBitmap))
             {
                 UiUtil.DrawCheckerboardBackground(canvas, width, height);

--- a/src/ui/Logic/Media/FfmpegHelper.cs
+++ b/src/ui/Logic/Media/FfmpegHelper.cs
@@ -291,6 +291,13 @@ public static class FfmpegHelper
                 return string.Empty;
             }
 
+            // Drain both pipes BEFORE waiting, as ProbeEncodersOutput does: a full build's
+            // "configuration:" line runs to several KB, past the 4 KB Windows pipe buffer, and
+            // reading only after WaitForExit deadlocks until the timeout kills ffmpeg - which
+            // returned empty and let IsSupportedVersion accept any ffmpeg at all.
+            var stdOut = process.StandardOutput.ReadToEndAsync();
+            var stdErr = process.StandardError.ReadToEndAsync();
+
             // "-version" prints a short banner and exits immediately; 4 s is generous.
             if (!process.WaitForExit(4000))
             {
@@ -298,7 +305,10 @@ public static class FfmpegHelper
                 return string.Empty;
             }
 
-            return process.StandardOutput.ReadToEnd() + "\n" + process.StandardError.ReadToEnd();
+            // Lets the async readers finish after the timed wait returned (documented pattern).
+            process.WaitForExit();
+
+            return stdOut.Result + "\n" + stdErr.Result;
         }
         catch (Exception ex)
         {

--- a/src/ui/Logic/SevenZipExtractor/Unpacker.cs
+++ b/src/ui/Logic/SevenZipExtractor/Unpacker.cs
@@ -146,6 +146,11 @@ public static class Unpacker
 
             process.Start();
 
+            // Drain stderr concurrently: 7-zip writes one line per problem file, and once it
+            // exceeds the 4 KB pipe buffer the child blocks on the write, stdout's EndOfStream
+            // never returns, and the dialog hangs with no way out.
+            var errorReader = process.StandardError.ReadToEndAsync();
+
             while (!process.StandardOutput.EndOfStream)
             {
                 if (cancellationTokenSource.IsCancellationRequested)
@@ -181,7 +186,7 @@ public static class Unpacker
 
             if (process.ExitCode != 0)
             {
-                var error = process.StandardError.ReadToEnd();
+                var error = errorReader.Result;
                 throw new Exception($"7zz extraction failed with exit code {process.ExitCode} (command: \"{sevenZipPath}\" x \"{tempFileName}\" -o\"{extractPath}\" -y): {error}");
             }
 
@@ -262,6 +267,9 @@ public static class Unpacker
                 throw new Exception($"Could not start 7-zip (command: \"{sevenZipPath}\" x \"{tempFileName}\" -o\"{extractPath}\" -y)", exception);
             }
 
+            // See the note above: stderr must be drained while 7-zip is still running.
+            var errorReader = process.StandardError.ReadToEndAsync();
+
             while (!process.StandardOutput.EndOfStream)
             {
                 if (cancellationTokenSource.IsCancellationRequested)
@@ -297,7 +305,7 @@ public static class Unpacker
 
             if (process.ExitCode != 0)
             {
-                var error = process.StandardError.ReadToEnd();
+                var error = errorReader.Result;
                 throw new Exception($"7zip extraction failed with exit code {process.ExitCode} (command: \"{sevenZipPath}\" x \"{tempFileName}\" -o\"{extractPath}\" -y): {error}");
             }
 
@@ -348,7 +356,10 @@ public static class Unpacker
         {
             if (cancellationTokenSource.IsCancellationRequested)
             {
-                return;
+                // Throw, as every other cancellation point here does: a bare return made a
+                // cancelled move look like a finished one, so the caller reported success and
+                // its finally block deleted the temp folder with the un-moved files still in it.
+                throw new OperationCanceledException(cancellationTokenSource.Token);
             }
 
             var fileName = Path.GetFileName(file);
@@ -373,7 +384,10 @@ public static class Unpacker
         {
             if (cancellationTokenSource.IsCancellationRequested)
             {
-                return;
+                // Throw, as every other cancellation point here does: a bare return made a
+                // cancelled move look like a finished one, so the caller reported success and
+                // its finally block deleted the temp folder with the un-moved files still in it.
+                throw new OperationCanceledException(cancellationTokenSource.Token);
             }
 
             var dirName = Path.GetFileName(subDir);

--- a/src/ui/Logic/SubRipSourceSyntaxHighlighting.cs
+++ b/src/ui/Logic/SubRipSourceSyntaxHighlighting.cs
@@ -258,7 +258,13 @@ public partial class SubRipSourceSyntaxHighlighting : ISourceSyntaxHighlighter
                     styler.Apply(valueStart, 1, CharsColor);
 
                     // Color the value content (check for style attribute)
-                    var hasColon = lineText.IndexOf(':', i + 1, valueEnd - i - 2) != -1;
+                    // Clamp the span, as SubtitleSyntaxTokenizer does: with the opening quote as
+                    // the last character of the line (typing '<font color="') valueEnd lands on
+                    // Length and the count goes to -1, throwing out of Render.
+                    var contentStart = i + 1;
+                    var contentEnd = Math.Max(contentStart, valueEnd - 1);
+                    var hasColon = contentEnd > contentStart &&
+                                   lineText.IndexOf(':', contentStart, contentEnd - contentStart) != -1;
                     var valueColor = hasColon ? StyleColor : ValuesColor;
 
                     if (valueEnd > valueStart + 1)

--- a/src/ui/Logic/TableViewExtras.cs
+++ b/src/ui/Logic/TableViewExtras.cs
@@ -242,6 +242,16 @@ public sealed class TableViewColumnManager
 /// </summary>
 public static class TableViewExtras
 {
+    /// <summary>
+    /// The visual whose origin is the viewport's top-left corner. The TableView template keeps the
+    /// column header INSIDE the ScrollViewer (pinned above the rows), so the ScrollViewer's own
+    /// origin sits a header height above the viewport - measuring against it inflated every row
+    /// top while Viewport.Height excludes the header, so a row clipped under the header counted as
+    /// fully visible and page/centre targets were off by one row. Same helper as
+    /// TableViewScrollAnchor.ViewportOrigin and TableViewIndexScrollBar.
+    /// </summary>
+    private static Visual ViewportOrigin(ScrollViewer scrollViewer) => (Visual?)scrollViewer.Presenter ?? scrollViewer;
+
     private static readonly TextToFlowDirectionConverter TextToFlowDirection = new();
 
     /// <summary>
@@ -673,7 +683,7 @@ public static class TableViewExtras
                 continue;
             }
 
-            var top = ((Visual)row).TranslatePoint(new Point(0, 0), scrollViewer)?.Y;
+            var top = ((Visual)row).TranslatePoint(new Point(0, 0), ViewportOrigin(scrollViewer))?.Y;
             if (top == null || top.Value < -0.5 || top.Value + height > scrollViewer.Viewport.Height + 0.5)
             {
                 continue;
@@ -751,7 +761,7 @@ public static class TableViewExtras
             }
 
             var first = rows[0];
-            var firstTop = ((Visual)first.Row).TranslatePoint(new Point(0, 0), scrollViewer)?.Y;
+            var firstTop = ((Visual)first.Row).TranslatePoint(new Point(0, 0), ViewportOrigin(scrollViewer))?.Y;
             if (firstTop == null)
             {
                 return;
@@ -835,7 +845,7 @@ public static class TableViewExtras
             return false;
         }
 
-        var rowTop = row.TranslatePoint(new Point(0, 0), scrollViewer)?.Y;
+        var rowTop = row.TranslatePoint(new Point(0, 0), ViewportOrigin(scrollViewer))?.Y;
         if (rowTop == null)
         {
             return false;
@@ -864,7 +874,7 @@ public static class TableViewExtras
             }
 
             // Row top in viewport coordinates.
-            var rowTop = row.TranslatePoint(new Point(0, 0), scrollViewer)?.Y;
+            var rowTop = row.TranslatePoint(new Point(0, 0), ViewportOrigin(scrollViewer))?.Y;
             if (rowTop == null)
             {
                 return;

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -387,10 +387,14 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         _mpvRenderContextSetUpdateCallback = (MpvRenderContextSetUpdateCallback)GetDllType(typeof(MpvRenderContextSetUpdateCallback), "mpv_render_context_set_update_callback");
     }
 
-    private object GetDllType(Type type, string name)
+    private object? GetDllType(Type type, string name)
     {
+        // null, not IntPtr.Zero, when the export is missing: every caller casts the result to a
+        // delegate type, so a boxed IntPtr threw InvalidCastException instead - which made the
+        // "== null" libvlc-4 fallbacks unreachable and turned one missing symbol into a failed
+        // load and a silent EmptyVideoPlayer.
         var address = NativeMethods.CrossGetProcAddress(_library, name);
-        return address != IntPtr.Zero ? Marshal.GetDelegateForFunctionPointer(address, type) : IntPtr.Zero;
+        return address != IntPtr.Zero ? Marshal.GetDelegateForFunctionPointer(address, type) : null;
     }
 
     private bool LoadLibraryInternal()
@@ -1035,7 +1039,11 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
 
     public void InitializeWithOpenGL(GetProcAddress getProcAddress)
     {
-        LoadLibraryInternal();
+        // LoadLib(), not LoadLibraryInternal(): the latter always calls mpv_create() and
+        // overwrites _mpv. CanLoad() has already created a core by the time the render path gets
+        // here, so this created a second one and orphaned the first - its threads and allocations
+        // leaked for the process lifetime, on every player construction.
+        LoadLib();
         EnsureNotDisposed();
 
         if (_mpvInitialize == null || _mpvRenderContextCreate == null || _mpvRenderContextSetUpdateCallback == null)
@@ -1142,7 +1150,11 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
     [System.Runtime.Versioning.SupportedOSPlatform("macos")]
     public void InitializeWithMetal(IntPtr mtlDevice, IntPtr metalLayer)
     {
-        LoadLibraryInternal();
+        // LoadLib(), not LoadLibraryInternal(): the latter always calls mpv_create() and
+        // overwrites _mpv. CanLoad() has already created a core by the time the render path gets
+        // here, so this created a second one and orphaned the first - its threads and allocations
+        // leaked for the process lifetime, on every player construction.
+        LoadLib();
         EnsureNotDisposed();
 
         if (_mpvInitialize == null || _mpvRenderContextCreate == null || _mpvRenderContextSetUpdateCallback == null)
@@ -2326,7 +2338,11 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
 
     public void InitializeWithSoftwareRendering()
     {
-        LoadLibraryInternal();
+        // LoadLib(), not LoadLibraryInternal(): the latter always calls mpv_create() and
+        // overwrites _mpv. CanLoad() has already created a core by the time the render path gets
+        // here, so this created a second one and orphaned the first - its threads and allocations
+        // leaked for the process lifetime, on every player construction.
+        LoadLib();
         EnsureNotDisposed();
 
         // Set mpv to use software rendering

--- a/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicPlayer.cs
@@ -373,10 +373,14 @@ public sealed class LibVlcDynamicPlayer : IDisposable, IVideoPlayer
         }
     }
 
-    private object GetDllType(Type type, string name)
+    private object? GetDllType(Type type, string name)
     {
+        // null, not IntPtr.Zero, when the export is missing: every caller casts the result to a
+        // delegate type, so a boxed IntPtr threw InvalidCastException instead - which made the
+        // "== null" libvlc-4 fallbacks unreachable and turned one missing symbol into a failed
+        // load and a silent EmptyVideoPlayer.
         var address = NativeMethods.CrossGetProcAddress(_library, name);
-        return address != IntPtr.Zero ? Marshal.GetDelegateForFunctionPointer(address, type) : IntPtr.Zero;
+        return address != IntPtr.Zero ? Marshal.GetDelegateForFunctionPointer(address, type) : null;
     }
 
     private bool LoadLibraryInternal()
@@ -945,13 +949,11 @@ public sealed class LibVlcDynamicPlayer : IDisposable, IVideoPlayer
 
             try
             {
+                // The slider runs 0..MaxVolume (130), and libvlc's own scale is the same, so the
+                // value passes straight through. Rescaling and capping at 100 here was the mirror
+                // of the setter bug below.
                 var v = _libvlc_audio_get_volume(_mediaPlayer);
-                if (MaxVolume > 100)
-                {
-                    var result = (int)Math.Round(v / (MaxVolume / 100.0));
-                    return result > 100 ? 100 : result;
-                }
-                return v > 100 ? 100 : v;
+                return v > MaxVolume ? MaxVolume : v;
             }
             catch
             {
@@ -969,15 +971,12 @@ public sealed class LibVlcDynamicPlayer : IDisposable, IVideoPlayer
 
             try
             {
-                var clampedVolume = Math.Max(0, Math.Min(100, value));
-                if (MaxVolume > 100)
-                {
-                    _libvlc_audio_set_volume(_mediaPlayer, (int)(clampedVolume * (MaxVolume / 100.0)));
-                }
-                else
-                {
-                    _libvlc_audio_set_volume(_mediaPlayer, (int)clampedVolume);
-                }
+                // Clamp to the player maximum, not to 100: the slider's Maximum IS MaxVolume
+                // (130), so clamping to 100 and then scaling by MaxVolume/100 sent 130 when the
+                // user asked for 100 - 30% amplification at the nominal setting - and made
+                // 101..130 do nothing. The mpv player was already fixed the same way.
+                var clampedVolume = Math.Max(0, Math.Min(MaxVolume, value));
+                _libvlc_audio_set_volume(_mediaPlayer, (int)clampedVolume);
             }
             catch
             {

--- a/tests/UI/Logic/BugHunt16Tests.cs
+++ b/tests/UI/Logic/BugHunt16Tests.cs
@@ -1,0 +1,38 @@
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// Guard tests for the 2026-08-27 bug hunt (sweep 16): a syntax highlighter that threw out of
+/// Render on half-typed markup, and containers offered for a codec that cannot go in them.
+/// </summary>
+public class BugHunt16Tests
+{
+    [Theory]
+    // The opening quote as the very last character: IndexOf found no closing quote, valueEnd
+    // landed on Length, and the colon search was handed a count of -1.
+    [InlineData("<font color=\"")]
+    [InlineData("Hello <font color=\"")]
+    [InlineData("<font face=\"")]
+    [InlineData("<font color=\"#ff0000\">ok</font>")]
+    [InlineData("<i>plain</i>")]
+    [InlineData("")]
+    public void SubRipHighlighter_HalfTypedAttribute_DoesNotThrow(string line)
+    {
+        var highlighter = new SubRipSourceSyntaxHighlighting();
+        var styler = new SourceSyntaxLineStyler();
+
+        var exception = Record.Exception(() => highlighter.HighlightLine(line, styler));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void SubRipHighlighter_UnterminatedQuoteMidLine_DoesNotThrow()
+    {
+        var highlighter = new SubRipSourceSyntaxHighlighting();
+        var styler = new SourceSyntaxLineStyler();
+
+        Assert.Null(Record.Exception(() => highlighter.HighlightLine("<font color=\"red>text", styler)));
+    }
+}


### PR DESCRIPTION
Sweep 16. Mostly the verified-but-unapplied findings the previous two sweeps' agents produced (they return far more than one sweep can absorb), plus the remaining Video feature dialogs.

Suites: libse 1624 / libuilogic 708 / seconv 422 / UI 4157 — see the note at the end about one flaky test.

## Security

The tar.gz unpacker carefully validates where a symlink entry is **written**, but never where it **points**. An archive shipping `lib -> /etc` (or `../..`) followed by a regular `lib/x` entry passes the containment check on `lib/x` and then writes outside the extraction folder; the copy fallback below it does `Path.Combine(dir, linkTarget)`, which with an absolute target pulls an arbitrary host file *in*. This path handles the downloaded `.tar.gz` engine archives (llama.cpp, piper, CrispASR). Absolute targets are now rejected and relative ones must resolve inside the root.

## Destructive

**"Re-encode video for better subtitling" offered to overwrite the source.** The save dialog was pre-filled with `Path.ChangeExtension(VideoFileName, SelectedVideoExtension)` — and with the default `.mkv` output on an `.mkv` input, that *is* the input path. A user who accepts the suggestion and confirms the OS "replace?" prompt has ffmpeg reading and writing the same file. It now suggests a suffixed name with a collision counter, and refuses `input == output` outright, which is what the write-chapters dialog already does.

## Hangs

`FfmpegHelper`'s `-version` probe and both 7-zip unpack paths read stderr only *after* `WaitForExit`. A full ffmpeg build's `configuration:` line, or one 7-zip warning per problem file, exceeds the 4 KB pipe buffer and blocks the child forever — the version probe then times out and `IsSupportedVersion` accepts any ffmpeg, and the unpack dialog hangs with no way out. Both of their siblings drain concurrently and carry a comment explaining exactly this.

Also in the unpacker: two cancellation points in the move helpers `return` where every other point in the file throws — the file's own comment says why ("a bare return was indistinguishable from a completed unpack, so callers reported the install as successful, deleted the archive, and left a half-extracted folder").

## Wrong results

- **Re-encode ignored the chosen resolution.** It overwrote the job's width/height with the source dimensions, so a 4K file was re-encoded at 4K — the exact opposite of what the dialog exists for ("high resolutions make subtitling slow"). The burn-in twin was fixed the same way last sweep.
- **Cut video's waveform always highlighted segment 1.** The index it passes is written nowhere in the repo and is not bound; the grid binds `SelectedSegment` instead.
- **`.webm` was offered by two dialogs that always encode libx264**, which WebM cannot carry — those runs could only ever end in "Output video file not generated". Burn-in already encodes this rule as an allow-list.
- **libvlc's volume was clamped to 100 and then scaled by `MaxVolume/100`**, so the slider at its nominal 100 sent 130 (30% amplification) and 101–130 did nothing. The mpv player was already fixed and documents it.
- **`GetDllType` returned `IntPtr.Zero` for a missing export** while every caller casts the result to a delegate type — so the cast threw instead, the `== null` libvlc-4 fallbacks were unreachable, and one missing symbol turned into a silent `EmptyVideoPlayer`.
- **Copy-image-to-clipboard was a silent no-op on Linux and macOS.** It passed shell syntax to `ProcessStartInfo` with `UseShellExecute = false`: the single quotes reached xclip as part of the file name, `<` reached wl-copy as a literal argument instead of redirecting stdin, and osascript received the script split on spaces.
- **`Se.LoadSettings` returned early when `Settings.json` is missing**, skipping `UpdateLibSeSettings()` — the only bridge onto libse's `Configuration.Settings`. On a first run libse kept its own defaults all session, including `RememberUseAlwaysList`, which gates every `<lang>_UseAlways.xml` load and save — so spell check's "Change all" was silently session-only.
- **The TableView visibility/centre/page helpers measured row tops against the ScrollViewer**, whose origin sits a header height above the viewport (the template pins the column header inside it). A row clipped under the header counted as fully visible, so the "scroll to current line" calls skipped it. Two sibling classes already document this and use the presenter.

## Crashes

The SubRip source highlighter handed `IndexOf` a negative length for a half-typed attribute — typing `<font color="` at the end of a line — and it runs inside `Render` with no catch. Guarded, with a theory test over the half-typed forms.

## Leaks

- **Every render path created a second mpv core and orphaned the first.** `LoadLibraryInternal()` unconditionally calls `mpv_create()` and overwrites `_mpv`; `CanLoad()` has already made one by then. The guarded `LoadLib()` is now used at all three sites.
- `MatroskaFile` holds an open `FileStream` on the video and leaked on every embedded-subtitles window open, Browse, and Preview click.
- The embedded-subtitles window re-appended every track when `Loaded` fired twice (Avalonia can fire it on re-attach); the mp4 twin already guards this and says why.
- Re-encode left ffmpeg encoding and its 100 ms poll timer firing after the window closed; Escape now aborts the encode, matching the blank-video dialog.
- The checkered-background video generator never disposed its bitmap (~8 MB of native pixels at 1080p per run).

## Deliberately not changed

`UiTheme.ImageFolder` falls back to the Dark icon set for themes that ship no images of their own. An agent argued Pastel is a light theme and should get Light icons — but the method's own doc comment names Pastel as the intended case for the Dark fallback, so that is a design decision, not a defect.

## Note on the flaky test

`LibMpvEventLoopTests.Pause_RightAfterSeek_KeepsReportingTheSeekTarget` fails intermittently here. **Correcting what I wrote in the previous PR**: I said the rate "looked higher on this branch than on main", but that comparison was sampled at different times. Interleaved on the same machine right now, main fails 3 of 5 runs — the same rate as this branch. It is a genuinely load-sensitive test (real libmpv, an exact position pin asserted for 800 ms) and is unrelated to these changes. CI skips it where libmpv is absent. I have not loosened the assertion, since that would weaken a real regression guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)