### PR TITLE
Add mpv preview line justification setting (#14167)

### DIFF
--- a/src/ui/Features/Options/Settings/MpvJustifyDisplay.cs
+++ b/src/ui/Features/Options/Settings/MpvJustifyDisplay.cs
@@ -1,0 +1,32 @@
+﻿using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Options.Settings;
+
+/// <summary>
+/// One value of mpv's "sub-justify" option - how the lines of a multi-line preview subtitle are
+/// justified inside the text block. "auto" leaves it to the alignment, which is mpv's own default.
+/// </summary>
+public class MpvJustifyDisplay
+{
+    public string Code { get; }
+    public string DisplayName { get; }
+
+    public MpvJustifyDisplay(string code, string displayName)
+    {
+        Code = code;
+        DisplayName = displayName;
+    }
+
+    public override string ToString() => DisplayName;
+
+    public static MpvJustifyDisplay[] GetAll()
+    {
+        return
+        [
+            new MpvJustifyDisplay("auto", Se.Language.General.Auto),
+            new MpvJustifyDisplay("left", Se.Language.General.Left),
+            new MpvJustifyDisplay("center", Se.Language.General.Center),
+            new MpvJustifyDisplay("right", Se.Language.General.Right),
+        ];
+    }
+}

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -1045,6 +1045,9 @@ public class SettingsPage : UserControl
         var labelAlignment = UiUtil.MakeLabel(Se.Language.General.Alignment);
         var comboBoxAlignment = UiUtil.MakeComboBox(vm.MpvPreviewFontAlignments, vm, nameof(vm.MpvPreviewSelectedFontAlignment));
 
+        var labelJustify = UiUtil.MakeLabel(Se.Language.Options.Settings.TextJustify);
+        var comboBoxJustify = UiUtil.MakeComboBox(vm.MpvPreviewJustifyItems, vm, nameof(vm.MpvPreviewSelectedJustify));
+
         var checkBoxUsePositionFromFile = UiUtil.MakeCheckBox(Se.Language.Options.Settings.UsePositionFromSubtitleFile, vm, nameof(vm.MpvPreviewUsePositionFromFile));
 
         var labelMargin = UiUtil.MakeLabel(Se.Language.General.Margin);
@@ -1078,6 +1081,7 @@ public class SettingsPage : UserControl
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
             {
@@ -1100,23 +1104,26 @@ public class SettingsPage : UserControl
         grid.Add(labelAlignment, 3);
         grid.Add(comboBoxAlignment, 3, 1);
 
-        grid.Add(checkBoxUsePositionFromFile, 4, 0, 1, 2);
+        grid.Add(labelJustify, 4);
+        grid.Add(comboBoxJustify, 4, 1);
 
-        grid.Add(labelMargin, 5);
-        grid.Add(numericUpDownMargin, 5, 1);
+        grid.Add(checkBoxUsePositionFromFile, 5, 0, 1, 2);
 
-        grid.Add(checkBoxMarginIsPartOfSubtitleArea, 6, 0, 1, 2);
+        grid.Add(labelMargin, 6);
+        grid.Add(numericUpDownMargin, 6, 1);
 
-        grid.Add(labelColorPrimary, 7);
-        grid.Add(colorPickerPrimary, 7, 1);
+        grid.Add(checkBoxMarginIsPartOfSubtitleArea, 7, 0, 1, 2);
 
-        grid.Add(labelColorOutline, 8);
-        grid.Add(colorPickerOutline, 8, 1);
+        grid.Add(labelColorPrimary, 8);
+        grid.Add(colorPickerPrimary, 8, 1);
 
-        grid.Add(labelColorShadow, 9);
-        grid.Add(colorPickerShadow, 9, 1);
+        grid.Add(labelColorOutline, 9);
+        grid.Add(colorPickerOutline, 9, 1);
 
-        grid.Add(MakeBorderView(vm), 10, 0, 1, 2);
+        grid.Add(labelColorShadow, 10);
+        grid.Add(colorPickerShadow, 10, 1);
+
+        grid.Add(MakeBorderView(vm), 11, 0, 1, 2);
 
         return UiUtil.MakeBorderForControl(grid);
     }

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -106,6 +106,8 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _mpvPreviewFontBold;
     [ObservableProperty] private ObservableCollection<AlignmentItem> __mpvPreviewFontAlignments;
     [ObservableProperty] private AlignmentItem _mpvPreviewSelectedFontAlignment;
+    [ObservableProperty] private ObservableCollection<MpvJustifyDisplay> _mpvPreviewJustifyItems;
+    [ObservableProperty] private MpvJustifyDisplay _mpvPreviewSelectedJustify;
     [ObservableProperty] private int _mpvPreviewMargin;
     [ObservableProperty] private bool _mpvPreviewUsePositionFromFile;
     [ObservableProperty] private bool _mpvPreviewMarginIsPartOfSubtitleArea;
@@ -465,6 +467,8 @@ public partial class SettingsViewModel : ObservableObject
         MpvPreviewBorderTypes = new ObservableCollection<BorderStyleItem>(BorderStyleItem.List());
         MpvPreviewFontAlignments = new ObservableCollection<AlignmentItem>(AlignmentItem.Alignments);
         MpvPreviewSelectedFontAlignment = MpvPreviewFontAlignments[7];
+        MpvPreviewJustifyItems = new ObservableCollection<MpvJustifyDisplay>(MpvJustifyDisplay.GetAll());
+        MpvPreviewSelectedJustify = MpvPreviewJustifyItems[0];
         LibVlcStatus = string.Empty;
 
         UpdateChannels =
@@ -1065,6 +1069,7 @@ public partial class SettingsViewModel : ObservableObject
         MpvPreviewUsePositionFromFile = video.MpvPreviewUsePositionFromFile;
         MpvPreviewMarginIsPartOfSubtitleArea = video.MpvPreviewMarginIsPartOfSubtitleArea;
         MpvPreviewSelectedFontAlignment = MpvPreviewFontAlignments.FirstOrDefault(p => p.Code == video.MpvPreviewAlignment) ?? MpvPreviewFontAlignments[7];
+        MpvPreviewSelectedJustify = MpvPreviewJustifyItems.FirstOrDefault(p => p.Code == video.MpvPreviewJustify) ?? MpvPreviewJustifyItems[0];
         MpvPreviewOutlineWidth = video.MpvPreviewOutlineWidth;
         MpvPreviewShadowWidth = video.MpvPreviewShadowWidth;
         MpvPreviewColorPrimary = video.MpvPreviewColorPrimary.FromHexToColor();
@@ -1906,6 +1911,7 @@ public partial class SettingsViewModel : ObservableObject
         video.MpvPreviewMarginIsPartOfSubtitleArea = MpvPreviewMarginIsPartOfSubtitleArea;
         video.MpvPreviewOutlineWidth = MpvPreviewOutlineWidth;
         video.MpvPreviewAlignment = MpvPreviewSelectedFontAlignment.Code;
+        video.MpvPreviewJustify = (MpvPreviewSelectedJustify ?? MpvPreviewJustifyItems[0]).Code;
         video.MpvPreviewShadowWidth = MpvPreviewShadowWidth;
         video.MpvPreviewColorPrimary = MpvPreviewColorPrimary.FromColorToHex();
         video.MpvPreviewColorOutline = MpvPreviewColorOutline.FromColorToHex();

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -331,6 +331,7 @@ public class LanguageSettings
     public string SubtitlePreviewProperties { get; set; }
     public string UsePositionFromSubtitleFile { get; set; }
     public string MarginIsPartOfSubtitleArea { get; set; }
+    public string TextJustify { get; set; }
     public string PixelWidthInfo { get; set; }
     public string SpellCheckEngineHunSpelll { get; set; }
     public string SpellCheckEngineMsWord { get; set; }
@@ -667,6 +668,7 @@ public class LanguageSettings
         SubtitlePreviewProperties = "Subtitle preview properties";
         UsePositionFromSubtitleFile = "Use position from subtitle file (TTML/PAC/EBU STL)";
         MarginIsPartOfSubtitleArea = "Margin is part of the subtitle area";
+        TextJustify = "Justify lines";
         PixelWidthInfo = "Green lines = max-width limit   |   Red area = text exceeds limit";
         SpellCheckEngineHunSpelll = "Hunspell";
         SpellCheckEngineMsWord = "MS Word";

--- a/src/ui/Logic/Config/SeVideo.cs
+++ b/src/ui/Logic/Config/SeVideo.cs
@@ -60,6 +60,14 @@ public class SeVideo
     public bool MpvPreviewMarginIsPartOfSubtitleArea { get; set; }
 
     /// <summary>
+    /// How the lines of a multi-line preview subtitle are justified inside the text block:
+    /// mpv's "sub-justify" - "auto", "left", "center" or "right" (#14167). This is not the same
+    /// as <see cref="MpvPreviewAlignment"/>, which moves the whole block: justify keeps the block
+    /// where the alignment put it and only decides where the shorter lines sit within it.
+    /// </summary>
+    public string MpvPreviewJustify { get; set; }
+
+    /// <summary>
     /// mpv's "audio-buffer" option in seconds, applied when a player core is created. mpv's
     /// own default is 0.2 s, and that buffer is why pause/resume/seek take effect ~200 ms
     /// late - the residual the waveform playhead code has to mask. Kept small here; raise it
@@ -106,6 +114,7 @@ public class SeVideo
         MpvPreviewColorShadow = Color.FromRgb(0, 0, 0).FromColorToHex();
         MpvPreviewBorderType = (int)BorderStyleType.Outline;
         MpvPreviewUsePositionFromFile = true;
+        MpvPreviewJustify = "auto";
         MpvAudioBufferSeconds = 0.05;
     }
 }

--- a/src/ui/Logic/Media/MpvReloader.cs
+++ b/src/ui/Logic/Media/MpvReloader.cs
@@ -72,6 +72,7 @@ public class MpvReloader : IMpvReloader
             // Applied on every refresh, not only on load: toggling "margin is part of the
             // subtitle area" in settings has to take effect on the video already open (#13934).
             mpvContext.ApplySubtitleMarginArea();
+            mpvContext.ApplySubtitleJustify();
 
             var uiFormatType = uiFormat.GetType();
 

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -772,6 +772,28 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         SetOptionString("sub-ass-force-margins", useMargins ? "yes" : "no");
     }
 
+    /// <summary>
+    /// How the lines of a multi-line preview subtitle are justified inside the text block
+    /// (#14167) - not the same thing as the alignment, which moves the whole block and rides
+    /// along in the generated ASS style. Justification has no ASS style field: it is a player
+    /// option, and sub-justify reaches an ASS subtitle - which the preview is - only with
+    /// sub-ass-justify on, which mpv defaults to "no".
+    ///
+    /// Both options are written on every call, so picking "auto" again restores mpv's own
+    /// defaults instead of leaving the last value in place.
+    /// </summary>
+    public void ApplySubtitleJustify()
+    {
+        var justify = Se.Settings.Video.MpvPreviewJustify;
+        if (string.IsNullOrWhiteSpace(justify))
+        {
+            justify = "auto";
+        }
+
+        SetOptionString("sub-justify", justify);
+        SetOptionString("sub-ass-justify", justify == "auto" ? "no" : "yes");
+    }
+
     public int SetOptionString(string name, string value)
     {
         if (_mpvSetOptionString == null || _mpv == IntPtr.Zero)
@@ -1559,6 +1581,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         SetOptionString("rebase-start-time", "no");
 
         ApplySubtitleMarginArea();
+        ApplySubtitleJustify();
 
         _fileName = path;
 


### PR DESCRIPTION
Item **E** of #14167: left/right justification of the subtitle in the video preview, which in SE4 was only reachable by hand-editing `<MpvExtraOptions>--sub-ass-justify=yes --sub-justify=right</MpvExtraOptions>`.

Alignment was already there (all 9 ASS positions), so this adds the missing part next to it: **Options → Settings → Video → mpv preview → "Justify lines"** (Auto / Left / Center / Right).

Alignment moves the whole text block and rides along in the generated ASS style header. Justification only decides where the shorter lines sit *inside* that block, and it has no ASS style field — it goes to mpv as `sub-justify`, together with `sub-ass-justify`, which mpv defaults to `no` and which is what otherwise keeps the option from reaching the preview (the preview is an ASS subtitle).

- Default is `auto`, i.e. mpv's own behaviour — nothing changes unless the user picks something.
- Both options are written on every call, so switching back to *Auto* restores mpv's defaults instead of leaving the last value stuck.
- Applied on every preview refresh as well as on load, so changing it takes effect on the video that is already open — same as "margin is part of the subtitle area".

mpv preview only; VLC and burn-in/export are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
