### PR TITLE
Fix 20 bugs found in a bug hunt

### DIFF
--- a/src/libse/Forms/FixCommonErrors/FixMissingSpaces.cs
+++ b/src/libse/Forms/FixCommonErrors/FixMissingSpaces.cs
@@ -96,7 +96,13 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                         p.Text = p.Text.Replace(match.Value, match.Value[0] + ", " + match.Value[match.Value.Length - 1]);
                         callbacks.AddFixToListView(p, fixAction, oldText, p.Text);
                     }
-                    match = match.NextMatch();
+
+                    // Re-match against the UPDATED text as the "?", "!" and ":" loops do.
+                    // NextMatch() walks the pre-replacement string, so after the first fix every
+                    // later match.Index was one short and "p.Text[match.Index + 2]" read the
+                    // comma itself - defeating the expectedChars exclusion for every comma after
+                    // the first ("Well,I know,<i>maybe</i>." gained a space before the tag).
+                    match = FixMissingSpacesReComma.Match(p.Text, match.Index + 1);
                 }
 
                 var allowFix = callbacks.AllowFix(p, fixAction);
@@ -186,7 +192,12 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                             isMatchAbbreviation = true;
                         }
 
-                        if (match.Value.Equals("h.d", StringComparison.OrdinalIgnoreCase) && match.Index > 0 && p.Text.Substring(match.Index - 1, 4).Equals("ph.d", StringComparison.OrdinalIgnoreCase))
+                        // FixMissingSpacesRePeriod matches exactly four characters, so
+                        // match.Value can never equal the three-character "h.d" - the guard was
+                        // left over from an earlier three-character pattern and never fired, so
+                        // "his ph.d yesterday" was split into "ph. d". The leading letter is
+                        // inside the match now, so test it directly.
+                        if (match.Value.Equals("ph.d", StringComparison.OrdinalIgnoreCase))
                         {
                             isMatchAbbreviation = true;
                         }
@@ -199,7 +210,9 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                             callbacks.AddFixToListView(p, fixAction, oldText, p.Text);
                         }
                     }
-                    match = match.NextMatch();
+
+                    // Same as the comma loop above: continue over the updated text.
+                    match = FixMissingSpacesRePeriod.Match(p.Text, match.Index + 1);
                 }
 
                 if (!p.Text.StartsWith("--", StringComparison.Ordinal))

--- a/src/libse/Forms/FixCommonErrors/FixMusicNotation.cs
+++ b/src/libse/Forms/FixCommonErrors/FixMusicNotation.cs
@@ -57,7 +57,10 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                                 if (count == 1)
                                 {
                                     var idx = newText.IndexOf('#');
-                                    if (idx < newText.Length - 2)
+                                    // newText[idx + 1] only needs idx + 1 <= Length - 1. With
+                                    // "- 2" a '#' as the second-to-last character skipped the
+                                    // chord guard entirely, so "F#m" became "F(music note)m".
+                                    if (idx < newText.Length - 1)
                                     {
                                         if (char.IsLetterOrDigit(newText[idx + 1]))
                                         {

--- a/src/libse/Forms/FixCommonErrors/FixOverlappingDisplayTimes.cs
+++ b/src/libse/Forms/FixCommonErrors/FixOverlappingDisplayTimes.cs
@@ -107,6 +107,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                             if (!canBeEqual)
                             {
                                 bool okEqual = true;
+                                var changedCurrent = false;
                                 if (prev.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds)
                                 {
                                     prev.EndTime.TotalMilliseconds--;
@@ -114,6 +115,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                                 else if (p.DurationTotalMilliseconds > Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds)
                                 {
                                     p.StartTime.TotalMilliseconds++;
+                                    changedCurrent = true;
                                 }
                                 else
                                 {
@@ -123,7 +125,19 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                                 if (okEqual)
                                 {
                                     noOfOverlappingDisplayTimesFixed++;
-                                    callbacks.AddFixToListView(target, fixAction, oldPrevious, prev.ToString());
+
+                                    // Report the paragraph that actually moved. This branch changes
+                                    // "p" while prev is untouched, so reporting prev produced a fix
+                                    // row whose before and after were identical and hid the real
+                                    // change - every other branch reports the one it modified.
+                                    if (changedCurrent)
+                                    {
+                                        callbacks.AddFixToListView(p, fixAction, oldCurrent, p.ToString());
+                                    }
+                                    else
+                                    {
+                                        callbacks.AddFixToListView(target, fixAction, oldPrevious, prev.ToString());
+                                    }
                                 }
                             }
                         }

--- a/src/libse/Forms/FixCommonErrors/Helper.cs
+++ b/src/libse/Forms/FixCommonErrors/Helper.cs
@@ -577,14 +577,18 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                 }
             }
 
-            if (text.LineStartsWithHtmlTag(true) && text[3] == 0x20)
+            // Bound the index like the "{\...}" branch above: LineStartsWithHtmlTag(true) is
+            // satisfied by a string that is exactly "<i>", so text[3] read past the end. Reached
+            // by FixHyphensRemoveForSingleLine on "<i>-" (the dash is stripped first, leaving
+            // "<i>"), which took down the whole Fix-Common-Errors / Remove-text-for-HI run.
+            if (text.Length > 3 && text.LineStartsWithHtmlTag(true) && text[3] == 0x20)
             {
                 text = text.Remove(3, 1).TrimStart();
             }
             if (text.LineStartsWithHtmlTag(false, true))
             {
                 var closeIdx = text.IndexOf('>');
-                if (closeIdx > 6 && text[closeIdx + 1] == 0x20)
+                if (closeIdx > 6 && closeIdx + 1 < text.Length && text[closeIdx + 1] == 0x20)
                 {
                     text = text.Remove(closeIdx + 1, 1);
                 }

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsViewModel.cs
@@ -111,52 +111,67 @@ public partial class DownloadSpeechToTextModelsViewModel : ObservableObject, ICl
 
             _timer.Stop();
 
-            // IsCompletedSuccessfully, not the broader IsCompleted (also true for
-            // Faulted/Canceled), so a failed download falls through to the IsFaulted
-            // branch below instead of proceeding as if it had succeeded.
-            if (_downloadTask is { IsCompletedSuccessfully: true })
+            try
             {
-                CompleteDownload();
-                StartNextOrFinish();
 
-                return;
-            }
-
-            if (_downloadTask is { IsFaulted: true })
-            {
-                var ex = _downloadTask.Exception?.InnerException ?? _downloadTask.Exception;
-                if (ex is OperationCanceledException)
+                // IsCompletedSuccessfully, not the broader IsCompleted (also true for
+                // Faulted/Canceled), so a failed download falls through to the IsFaulted
+                // branch below instead of proceeding as if it had succeeded.
+                if (_downloadTask is { IsCompletedSuccessfully: true })
                 {
-                    ProgressText = Se.Language.General.DownloadCanceled;
-                    Cancel();
-
-                    return;
-                }
-
-                // A 404 (FileNotFoundException) on an optional file isn't fatal: the URL list is
-                // the union of file names across all models, so every model 404s on some of them.
-                // Skip those and continue, like faster-whisper-xxl.exe does - only model.bin is
-                // required. (#12133 follow-up, #8703)
-                if (ex is FileNotFoundException && IsOptionalFile(_downloadUrls[_downloadIndex]))
-                {
-                    DeletePartialDownload();
+                    CompleteDownload();
                     StartNextOrFinish();
 
                     return;
                 }
 
-                ProgressText = Se.Language.General.DownloadFailed;
-                Error = ex?.Message ?? Se.Language.General.UnknownError;
+                if (_downloadTask is { IsFaulted: true })
+                {
+                    var ex = _downloadTask.Exception?.InnerException ?? _downloadTask.Exception;
+                    if (ex is OperationCanceledException)
+                    {
+                        ProgressText = Se.Language.General.DownloadCanceled;
+                        Cancel();
 
-                return;
+                        return;
+                    }
+
+                    // A 404 (FileNotFoundException) on an optional file isn't fatal: the URL list is
+                    // the union of file names across all models, so every model 404s on some of them.
+                    // Skip those and continue, like faster-whisper-xxl.exe does - only model.bin is
+                    // required. (#12133 follow-up, #8703)
+                    if (ex is FileNotFoundException && IsOptionalFile(_downloadUrls[_downloadIndex]))
+                    {
+                        DeletePartialDownload();
+                        StartNextOrFinish();
+
+                        return;
+                    }
+
+                    ProgressText = Se.Language.General.DownloadFailed;
+                    Error = ex?.Message ?? Se.Language.General.UnknownError;
+
+                    return;
+                }
+
+                // Guard the restart: OnClosingCleanup may have disposed the timer while this
+                // handler ran, and Start() on a disposed timer throws ObjectDisposedException,
+                // crashing the app from a thread-pool thread. (#12739)
+                if (!_isClosing)
+                {
+                    _timer.Start();
+                }
             }
-
-            // Guard the restart: OnClosingCleanup may have disposed the timer while this
-            // handler ran, and Start() on a disposed timer throws ObjectDisposedException,
-            // crashing the app from a thread-pool thread. (#12739)
-            if (!_isClosing)
+            catch (Exception exception)
             {
-                _timer.Start();
+                // An exception thrown from a timer callback is swallowed silently, and the timer
+                // was already stopped above - so without this catch the dialog hangs forever at
+                // 100% with no error shown (CompleteDownload throws on a bad credential response,
+                // and File.Move fails when model.bin is locked by a running whisper). The engine
+                // download dialog has carried this catch since #12127.
+                Se.LogError(exception, "Speech-to-text model download/unpack failed");
+                ProgressText = Se.Language.General.DownloadFailed;
+                Error = exception.Message;
             }
         }
     }

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCTranslate2.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCTranslate2.cs
@@ -69,7 +69,11 @@ public class WhisperEngineCTranslate2 : ISpeechToTextEngine
 
         if (!File.Exists(fullPath) && OperatingSystem.IsLinux())
         {
-            string[] paths = ["/usr/bin/whisper-cli", "usr/local/bin/"];
+            // This engine's binary is whisper-ctranslate2. The list was copy-pasted from the
+            // whisper.cpp engines, so on Linux with a distro whisper.cpp installed the engine
+            // reported itself installed, no download was offered, and SE launched whisper-cli
+            // with faster-whisper arguments (--model_directory, --verbose True).
+            string[] paths = ["/usr/bin/whisper-ctranslate2", "/usr/local/bin/whisper-ctranslate2"];
             foreach (var path in paths)
             {
                 if (File.Exists(path))

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCpp.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCpp.cs
@@ -82,7 +82,9 @@ public class WhisperEngineCpp : ISpeechToTextEngine
 
         if (!File.Exists(fullPath) && OperatingSystem.IsLinux())
         {
-            string[] paths = ["/usr/bin/whisper-cli", "usr/local/bin/"];
+            // "usr/local/bin/" was relative and a directory, so File.Exists never matched it and
+            // a /usr/local/bin build was never found.
+            string[] paths = ["/usr/bin/whisper-cli", "/usr/local/bin/whisper-cli"];
             foreach (var path in paths)
             {
                 if (File.Exists(path))

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCppCuBlas.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCppCuBlas.cs
@@ -87,7 +87,9 @@ public class WhisperEngineCppCuBlas : ISpeechToTextEngine
 
         if (!File.Exists(fullPath) && OperatingSystem.IsLinux())
         {
-            string[] paths = ["/usr/bin/whisper-cli", "usr/local/bin/"];
+            // "usr/local/bin/" was relative and a directory, so File.Exists never matched it and
+            // a /usr/local/bin build was never found.
+            string[] paths = ["/usr/bin/whisper-cli", "/usr/local/bin/whisper-cli"];
             foreach (var path in paths)
             {
                 if (File.Exists(path))

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCppVulkan.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineCppVulkan.cs
@@ -91,7 +91,9 @@ public class WhisperEngineCppVulkan : ISpeechToTextEngine
 
         if (!File.Exists(fullPath) && OperatingSystem.IsLinux())
         {
-            string[] paths = ["/usr/bin/whisper-cli", "usr/local/bin/"];
+            // "usr/local/bin/" was relative and a directory, so File.Exists never matched it and
+            // a /usr/local/bin build was never found.
+            string[] paths = ["/usr/bin/whisper-cli", "/usr/local/bin/whisper-cli"];
             foreach (var path in paths)
             {
                 if (File.Exists(path))

--- a/src/ui/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttService.cs
+++ b/src/ui/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttService.cs
@@ -439,19 +439,13 @@ public class OpenAiSttService : ISttTranscriber
             // If verbose_json fails, try simple text response
         }
 
-        // Fallback: treat as plain text response
+        // Fallback: treat as plain text response. No synthetic segment - the caller takes the
+        // segments branch whenever Segments.Count > 0, so a 0/0 entry put the whole transcript in
+        // one cue at 00:00:00,000 --> 00:00:00,000 and suppressed the sentence-spreading
+        // fallback. Same fix as the streaming path above; OpenRouterSttService does it this way.
         return new OpenAiCompatibleSttResponse
         {
             Text = jsonResponse.Trim(),
-            Segments = new List<OpenAiCompatibleSegment>
-            {
-                new OpenAiCompatibleSegment
-                {
-                    Start = 0,
-                    End = 0,
-                    Text = jsonResponse.Trim()
-                }
-            }
         };
     }
 

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextAdvancedViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextAdvancedViewModel.cs
@@ -295,13 +295,23 @@ public partial class SpeechToTextAdvancedViewModel : ObservableObject
         return File.Exists(fallback) ? fallback : null;
     }
 
-    private static string? GetVadCppFile()
+    private string? GetVadCppFile()
     {
-        var searchPaths = new List<string>
+        // Look in the SELECTED backend's own folder first. The Silero model is unpacked into
+        // GetAndCreateWhisperFolder(), which is "CppCuBlas" or "CppVulkan" for those two
+        // backends - so hard-coding "Cpp" meant the lookup returned null, EnableVadCpp took its
+        // bail-out branch, and the toggle popped back out with no message. GetVadCrispAsrFile
+        // below already resolves its engine's folder.
+        var searchPaths = new List<string>();
+        if (SelectedEngine is WhisperCppEngine whisperCppEngine)
         {
-            Path.Combine(Se.SpeechToTextFolder, "Cpp", "Models"),
-            Path.Combine(Se.SpeechToTextFolder, "Cpp"),
-        };
+            var engineFolder = whisperCppEngine.GetAndCreateWhisperFolder();
+            searchPaths.Add(Path.Combine(engineFolder, "Models"));
+            searchPaths.Add(engineFolder);
+        }
+
+        searchPaths.Add(Path.Combine(Se.SpeechToTextFolder, "Cpp", "Models"));
+        searchPaths.Add(Path.Combine(Se.SpeechToTextFolder, "Cpp"));
 
         foreach (var searchPath in searchPaths)
         {

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -413,7 +413,14 @@ public partial class SpeechToTextViewModel : ObservableObject
         {
             Se.Settings.Tools.AudioToText.WhisperLanguageCode = SelectedLanguage?.Code ?? string.Empty;
         }
-        Se.Settings.Tools.AudioToText.CrispAsrForcedAligner = SelectedForcedAligner?.Choice ?? ForcedAlignerOption.BuiltInChoice;
+        // Only write when this window actually has an aligner selected. SaveSettings runs on
+        // every EngineChanged, so with a non-CrispASR engine (SelectedForcedAligner == null) the
+        // "?? built-in" fallback overwrote the aligner the user had chosen in Import plain text >
+        // Forced aligner setup - the only place that reads this key back.
+        if (SelectedForcedAligner != null)
+        {
+            Se.Settings.Tools.AudioToText.CrispAsrForcedAligner = SelectedForcedAligner.Choice;
+        }
 
         Se.Settings.Tools.OpenAiCompatibleSttUrl = OpenAiCompatibleSttUrl ?? string.Empty;
         Se.Settings.Tools.OpenAiCompatibleSttApiKey = OpenAiCompatibleSttApiKey ?? string.Empty;
@@ -537,7 +544,10 @@ public partial class SpeechToTextViewModel : ObservableObject
             ? ForcedAlignerOption.BuiltInChoice
             : (crispEngine is CrispAsrQwen3 or CrispAsrMega or CrispAsrFunAsrNano ? ForcedAlignerOption.Qwen3Choice : ForcedAlignerOption.CanaryCtcChoice);
 
-        var match = ForcedAligners.FirstOrDefault(p => p.Choice == preferredChoice)
+        // Prefer what was saved - otherwise this window could never restore the user's own pick
+        // either, since nothing here ever read the setting back.
+        var match = ForcedAligners.FirstOrDefault(p => p.Choice == Se.Settings.Tools.AudioToText.CrispAsrForcedAligner)
+                    ?? ForcedAligners.FirstOrDefault(p => p.Choice == preferredChoice)
                     ?? ForcedAligners.FirstOrDefault();
         if (!ReferenceEquals(SelectedForcedAligner, match))
         {
@@ -2227,7 +2237,9 @@ public partial class SpeechToTextViewModel : ObservableObject
         _filesToDelete.Add(targetFile);
         try
         {
-            var process = GetFfmpegProcess(_videoFileName, _audioTrackNumber, targetFile);
+            // One ffmpeg per batch item; the sibling _whisperProcess is disposed, and the
+            // text-to-speech twin uses "using var" for the same call.
+            using var process = GetFfmpegProcess(_videoFileName, _audioTrackNumber, targetFile);
             if (process == null)
             {
                 return null;

--- a/src/ui/Features/Video/TextToSpeech/AutoCast/SpeakerReferenceBuilder.cs
+++ b/src/ui/Features/Video/TextToSpeech/AutoCast/SpeakerReferenceBuilder.cs
@@ -87,6 +87,7 @@ public static class SpeakerReferenceBuilder
         Directory.CreateDirectory(partsFolder);
 
         var parts = new List<string>();
+        var partTexts = new List<string>();
         for (var i = 0; i < picked.Count; i++)
         {
             // Exactly the line, with no growing into the gaps around it: these lines are far
@@ -102,6 +103,9 @@ public static class SpeakerReferenceBuilder
             if (cut)
             {
                 parts.Add(partFileName);
+                // Keep the text beside the clip it belongs to: the transcript has to describe the
+                // audio that actually ends up in the reference, not every line we tried to cut.
+                partTexts.Add(Utilities.UnbreakLine(HtmlUtil.RemoveHtmlTags(picked[i].Text ?? string.Empty, alsoSsaTags: true)));
             }
         }
 
@@ -111,20 +115,24 @@ public static class SpeakerReferenceBuilder
         }
 
         var referenceFileName = Path.Combine(outputFolder, safeName + ".wav");
+        var referenceTexts = partTexts;
         if (parts.Count == 1)
         {
             File.Move(parts[0], referenceFileName, overwrite: true);
         }
         else if (!await ConcatAsync(parts, referenceFileName, partsFolder, cancellationToken))
         {
-            // Joining failed - one good part is still a usable reference.
+            // Joining failed - one good part is still a usable reference, but then the transcript
+            // must shrink to that one part too. Describing eight lines beside ~2 seconds of audio
+            // is exactly the ref-text/ref-audio mismatch that makes a clone come out garbled.
             File.Move(parts[0], referenceFileName, overwrite: true);
+            referenceTexts = partTexts.Take(1).ToList();
         }
 
         // The transcript of what the joined audio says, in the same order.
         await File.WriteAllTextAsync(
             Path.ChangeExtension(referenceFileName, ".txt"),
-            string.Join(' ', picked.Select(p => Utilities.UnbreakLine(HtmlUtil.RemoveHtmlTags(p.Text ?? string.Empty, alsoSsaTags: true))).Where(t => t.Length > 0)),
+            string.Join(' ', referenceTexts.Where(t => t.Length > 0)),
             cancellationToken);
 
         TryDeleteFolder(partsFolder);

--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -188,7 +188,12 @@ public partial class DownloadTtsViewModel : ObservableObject
 
         _timer.Interval = 500;
         _timer.Elapsed += OnTimerOnElapsed;
-        _timer.Start();
+        // OnClosing disposes the timer, so restarting it from a chained download
+        // step threw ObjectDisposedException on a thread-pool thread (#12739).
+        if (!_isClosing)
+        {
+            _timer.Start();
+        }
     }
 
     private void OnTimerOnElapsed(object? sender, ElapsedEventArgs args)
@@ -626,7 +631,12 @@ public partial class DownloadTtsViewModel : ObservableObject
                 // CrispASR qwen3-tts backend rejects any other rate.
                 _downloadTaskQwen3TtsCrispAsrVoices = _qwen3TtsCppDownloadService.DownloadVoices(
                     _downloadStreamQwen3TtsCrispAsrVoices, voicesProgress, _cancellationTokenSource.Token);
-                _timer.Start();
+                // OnClosing disposes the timer, so restarting it from a chained download
+                // step threw ObjectDisposedException on a thread-pool thread (#12739).
+                if (!_isClosing)
+                {
+                    _timer.Start();
+                }
             }
             else if (_downloadTaskQwen3TtsCrispAsrModels is { IsFaulted: true })
             {
@@ -728,7 +738,12 @@ public partial class DownloadTtsViewModel : ObservableObject
                 });
                 _downloadTaskVibeVoiceCrispAsrVoices = _qwen3TtsCppDownloadService.DownloadVoices(
                     _downloadStreamVibeVoiceCrispAsrVoices, voicesProgress, _cancellationTokenSource.Token);
-                _timer.Start();
+                // OnClosing disposes the timer, so restarting it from a chained download
+                // step threw ObjectDisposedException on a thread-pool thread (#12739).
+                if (!_isClosing)
+                {
+                    _timer.Start();
+                }
             }
             else if (_downloadTaskVibeVoiceCrispAsrModels is { IsFaulted: true })
             {
@@ -888,7 +903,12 @@ public partial class DownloadTtsViewModel : ObservableObject
                 });
                 _downloadTaskIndexTts25AudioCppVoices = _qwen3TtsCppDownloadService.DownloadVoices(
                     _downloadStreamIndexTts25AudioCppVoices, voicesProgress, _cancellationTokenSource.Token);
-                _timer.Start();
+                // OnClosing disposes the timer, so restarting it from a chained download
+                // step threw ObjectDisposedException on a thread-pool thread (#12739).
+                if (!_isClosing)
+                {
+                    _timer.Start();
+                }
                 return;
             }
 
@@ -1012,7 +1032,12 @@ public partial class DownloadTtsViewModel : ObservableObject
                 });
                 _downloadTaskIndexTtsCrispAsrVoices = _qwen3TtsCppDownloadService.DownloadVoices(
                     _downloadStreamIndexTtsCrispAsrVoices, voicesProgress, _cancellationTokenSource.Token);
-                _timer.Start();
+                // OnClosing disposes the timer, so restarting it from a chained download
+                // step threw ObjectDisposedException on a thread-pool thread (#12739).
+                if (!_isClosing)
+                {
+                    _timer.Start();
+                }
             }
             else if (_downloadTaskIndexTtsCrispAsrModels is { IsFaulted: true })
             {
@@ -1096,7 +1121,12 @@ public partial class DownloadTtsViewModel : ObservableObject
                 });
                 _downloadTaskZonosTtsCrispAsrVoices = _qwen3TtsCppDownloadService.DownloadVoices(
                     _downloadStreamZonosTtsCrispAsrVoices, voicesProgress, _cancellationTokenSource.Token);
-                _timer.Start();
+                // OnClosing disposes the timer, so restarting it from a chained download
+                // step threw ObjectDisposedException on a thread-pool thread (#12739).
+                if (!_isClosing)
+                {
+                    _timer.Start();
+                }
             }
             else if (_downloadTaskZonosTtsCrispAsrModels is { IsFaulted: true })
             {
@@ -1211,7 +1241,12 @@ public partial class DownloadTtsViewModel : ObservableObject
                 });
                 _downloadTaskCosyVoice3CrispAsrVoices = _qwen3TtsCppDownloadService.DownloadVoices(
                     _downloadStreamCosyVoice3CrispAsrVoices, voicesProgress, _cancellationTokenSource.Token);
-                _timer.Start();
+                // OnClosing disposes the timer, so restarting it from a chained download
+                // step threw ObjectDisposedException on a thread-pool thread (#12739).
+                if (!_isClosing)
+                {
+                    _timer.Start();
+                }
             }
             else if (_downloadTaskCosyVoice3CrispAsrModels is { IsFaulted: true })
             {
@@ -1297,7 +1332,12 @@ public partial class DownloadTtsViewModel : ObservableObject
                 });
                 _downloadTaskF5TtsCrispAsrVoices = _qwen3TtsCppDownloadService.DownloadVoices(
                     _downloadStreamF5TtsCrispAsrVoices, voicesProgress, _cancellationTokenSource.Token);
-                _timer.Start();
+                // OnClosing disposes the timer, so restarting it from a chained download
+                // step threw ObjectDisposedException on a thread-pool thread (#12739).
+                if (!_isClosing)
+                {
+                    _timer.Start();
+                }
             }
             else if (_downloadTaskF5TtsCrispAsrModels is { IsFaulted: true })
             {
@@ -1383,7 +1423,12 @@ public partial class DownloadTtsViewModel : ObservableObject
                 });
                 _downloadTaskVoxCPM2CrispAsrVoices = _qwen3TtsCppDownloadService.DownloadVoices(
                     _downloadStreamVoxCPM2CrispAsrVoices, voicesProgress, _cancellationTokenSource.Token);
-                _timer.Start();
+                // OnClosing disposes the timer, so restarting it from a chained download
+                // step threw ObjectDisposedException on a thread-pool thread (#12739).
+                if (!_isClosing)
+                {
+                    _timer.Start();
+                }
             }
             else if (_downloadTaskVoxCPM2CrispAsrModels is { IsFaulted: true })
             {
@@ -1469,7 +1514,12 @@ public partial class DownloadTtsViewModel : ObservableObject
                 });
                 _downloadTaskMossTtsCrispAsrVoices = _qwen3TtsCppDownloadService.DownloadVoices(
                     _downloadStreamMossTtsCrispAsrVoices, voicesProgress, _cancellationTokenSource.Token);
-                _timer.Start();
+                // OnClosing disposes the timer, so restarting it from a chained download
+                // step threw ObjectDisposedException on a thread-pool thread (#12739).
+                if (!_isClosing)
+                {
+                    _timer.Start();
+                }
             }
             else if (_downloadTaskMossTtsCrispAsrModels is { IsFaulted: true })
             {
@@ -1608,7 +1658,12 @@ public partial class DownloadTtsViewModel : ObservableObject
                 });
                 _downloadTaskOmniVoices = _omniVoiceDownloadService.DownloadVoices(
                     _downloadStreamOmniVoices, voicesProgress, _cancellationTokenSource.Token);
-                _timer.Start();
+                // OnClosing disposes the timer, so restarting it from a chained download
+                // step threw ObjectDisposedException on a thread-pool thread (#12739).
+                if (!_isClosing)
+                {
+                    _timer.Start();
+                }
             }
             else if (_downloadTaskOmniVoice is { IsFaulted: true })
             {

--- a/src/ui/Features/Video/TextToSpeech/Engines/Piper.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Piper.cs
@@ -242,11 +242,26 @@ public class Piper : ITtsEngine
         }
 
         var fileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetPiperFolder), Guid.NewGuid() + ".wav");
-        var process = StartPiperProcess(piperVoice, text, fileName);
+        // Speak runs once per subtitle line, so without the using a long dub leaked one Process
+        // (plus its redirected stderr pipe) per line. And WaitForExitAsync returning on cancel
+        // leaves piper running with a half-written .wav behind - OmniVoiceTtsCpp.Speak documents
+        // and handles exactly this.
+        using var process = StartPiperProcess(piperVoice, text, fileName);
         Se.WriteToolsLog($"Piper: {process.StartInfo.FileName} {process.StartInfo.Arguments} (voice={piperVoice}, textLen={text.Length})");
-        var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
-        await process.WaitForExitAsync(cancellationToken);
-        var stderrOutput = await stderrTask;
+
+        string stderrOutput;
+        try
+        {
+            var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+            await process.WaitForExitAsync(cancellationToken);
+            stderrOutput = await stderrTask;
+        }
+        catch (OperationCanceledException)
+        {
+            TryKill(process);
+            TryDelete(fileName);
+            throw;
+        }
 
         if (process.ExitCode != 0)
         {
@@ -274,6 +289,39 @@ public class Piper : ITtsEngine
         }
 
         return new TtsResult(fileName, text);
+    }
+
+
+    private static void TryKill(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+#pragma warning disable CA1416
+                process.Kill(entireProcessTree: true);
+#pragma warning restore CA1416
+            }
+        }
+        catch
+        {
+            // best-effort - it may have exited in between
+        }
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch
+        {
+            // best-effort
+        }
     }
 
     private Process StartPiperProcess(PiperVoice voice, string inputText, string outputFileName)

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
@@ -281,6 +281,9 @@ public class Qwen3TtsCrispAsr : ITtsEngine, IPerLineCloneEngine
     }
 
     private static bool _voiceSeedAttempted;
+    /// <summary>A reference WAV is a few seconds; past this ffmpeg is stuck.</summary>
+    private const int ResampleTimeoutMs = 60_000;
+
     private static bool _voiceSampleRatesNormalized;
     private static bool _voiceTranscriptsNormalized;
     private static bool _stagedPerLineReferencesCleared;
@@ -559,17 +562,26 @@ public class Qwen3TtsCrispAsr : ITtsEngine, IPerLineCloneEngine
             var consumed = false;
             try
             {
-                var process = FfmpegGenerator.ConvertToMono24kHzWav(wav, temp);
+                using var process = FfmpegGenerator.ConvertToMono24kHzWav(wav, temp);
                 if (!process.Start())
                 {
                     continue;
                 }
 
-                process.WaitForExit();
-                if (File.Exists(temp) && new FileInfo(temp).Length > 0)
+                // Require a clean exit, and never delete the original first. ffmpeg writes the
+                // 44-byte RIFF header before it encodes, so a run that starts and then fails
+                // leaves a non-empty stub - "exists and non-empty" passed, the user's reference
+                // WAV was deleted, and the stub took its place permanently. VoiceSeedHelper
+                // spells out exactly this rule; every other engine goes through it.
+                if (!process.WaitForExit(ResampleTimeoutMs))
                 {
-                    File.Delete(wav);
-                    File.Move(temp, wav);
+                    try { process.Kill(true); } catch { /* best-effort */ }
+                    continue;
+                }
+
+                if (process.ExitCode == 0 && File.Exists(temp) && new FileInfo(temp).Length > 0)
+                {
+                    File.Move(temp, wav, overwrite: true);
                     consumed = true;
                 }
             }

--- a/src/ui/Features/Video/TextToSpeech/Engines/ZonosTtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ZonosTtsCrispAsr.cs
@@ -205,30 +205,11 @@ public class ZonosTtsCrispAsr : ITtsEngine
             foreach (var src in Directory.GetFiles(sourceFolder, "*.wav"))
             {
                 var dest = Path.Combine(voicesFolder, Path.GetFileName(src));
-                if (File.Exists(dest))
-                {
-                    continue;
-                }
-
-                try
-                {
-                    var ffmpeg = FfmpegGenerator.ConvertToMono24kHzWav(src, dest);
-                    if (!ffmpeg.Start())
-                    {
-                        // ffmpeg unavailable — better to seed at 16 kHz than skip the voice.
-                        File.Copy(src, dest);
-                        continue;
-                    }
-                    ffmpeg.WaitForExit();
-                }
-                catch (Exception ex)
-                {
-                    Se.LogError(ex, $"Zonos TTS (CrispASR): resample seed '{src}' failed; falling back to plain copy");
-                    try { if (!File.Exists(dest))
-                    {
-                        File.Copy(src, dest);
-                    } } catch { }
-                }
+                // Go through the shared helper like the other ten CrispASR engines. The
+                // hand-rolled loop here checked no exit code (so a failed ffmpeg left a truncated
+                // WAV that the File.Exists skip above made permanent), waited without a timeout,
+                // and leaked one Process per voice.
+                VoiceSeedHelper.CopyOrResample(src, dest, 24000, "Zonos TTS (CrispASR)");
             }
         }
         catch (Exception ex)

--- a/src/ui/Features/Video/TextToSpeech/SelectLinesWindowBuilder.cs
+++ b/src/ui/Features/Video/TextToSpeech/SelectLinesWindowBuilder.cs
@@ -63,7 +63,21 @@ public static class SelectLinesWindowBuilder
 
         window.Content = grid;
 
-        window.Activated += delegate { buttonOk.Focus(); };
+        // Focus the table, not OK. AddSpaceToggle puts a tunnelling handler on the TableView, so
+        // Space only toggles a row while focus is inside it - with OK focused the very first
+        // Space activated the button and accepted the dialog with every line still pre-checked.
+        // ProfilesWindow spells out the same rule ("a focused button clicks on bare Space").
+        window.Activated += delegate
+        {
+            if (rowsView is TableView tableView)
+            {
+                TableViewExtras.FocusRow(tableView);
+            }
+            else
+            {
+                buttonOk.Focus();
+            }
+        };
         window.KeyDown += vm.KeyDown;
 
         window.Closing += delegate { UiUtil.SaveWindowPosition(window); };

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -1035,6 +1035,23 @@ public partial class TextToSpeechViewModel : ObservableObject
         }
     }
 
+
+    /// <summary>
+    /// The language name saved for <paramref name="engine"/>, or null when that engine keeps no
+    /// per-engine language. Each engine has its own settings key, so reading one engine's key
+    /// from another engine's code path silently drops the user's choice.
+    /// </summary>
+    private static string? GetSavedLanguageName(ITtsEngine? engine) => engine switch
+    {
+        OmniVoiceCrispAsr => Se.Settings.Video.TextToSpeech.OmniVoiceCrispAsrLanguage,
+        MossTtsCrispAsr => Se.Settings.Video.TextToSpeech.MossTtsCrispAsrLanguage,
+        CosyVoice3CrispAsr => Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrLanguage,
+        Qwen3TtsCrispAsr => Se.Settings.Video.TextToSpeech.Qwen3TtsCrispAsrLanguage,
+        ChatterboxTtsCpp => Se.Settings.Video.TextToSpeech.ChatterboxCrispAsrLanguage,
+        ElevenLabs => Se.Settings.Video.TextToSpeech.ElevenLabsLanguage,
+        _ => null,
+    };
+
     [RelayCommand]
     private async Task ShowCast()
     {
@@ -4318,8 +4335,14 @@ public partial class TextToSpeechViewModel : ObservableObject
 
                 // Keep the language the user already picked when it survives the model switch -
                 // otherwise a MOSS-TTS quant change (Q4_K <-> F16) silently re-selects English.
+                // Ask for THIS engine's saved language. Consulting the ElevenLabs key here meant
+                // that e.g. Chatterbox Base -> Turbo -> Base landed on "Auto" instead of the saved
+                // German, and the next Generate then persisted "Auto" over it.
+                var savedLanguageName = GetSavedLanguageName(SelectedEngine);
                 SelectedLanguage = Languages.FirstOrDefault(p => p.Name == previousLanguageName)
-                                   ?? Languages.FirstOrDefault(p => p.Name == Se.Settings.Video.TextToSpeech.ElevenLabsLanguage);
+                                   ?? (string.IsNullOrEmpty(savedLanguageName)
+                                       ? null
+                                       : Languages.FirstOrDefault(p => p.Name == savedLanguageName));
                 if (SelectedLanguage == null)
                 {
                     // Fall back to the list's first entry so the combo is never left empty -

--- a/src/ui/Features/Video/TextToSpeech/TtsPostProcessor.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsPostProcessor.cs
@@ -29,7 +29,9 @@ public static class TtsPostProcessor
             if (doProChain)
             {
                 var proChainOutput = Path.Combine(waveFolder, $"pro_{Guid.NewGuid()}.wav");
-                var proProcess = FfmpegGenerator.ApplyProAudioChain(currentFile, proChainOutput);
+                // One ffmpeg per stage per LINE - a 900-line dub with every stage on created
+                // thousands of undisposed processes. PerLineVoiceClone uses "using var" too.
+                using var proProcess = FfmpegGenerator.ApplyProAudioChain(currentFile, proChainOutput);
                 await proProcess.StartAndWaitAsync(cancellationToken);
 
                 currentFile = AdoptStageOutput(currentFile, proChainOutput, "pro audio chain");
@@ -43,11 +45,11 @@ public static class TtsPostProcessor
             if (silencePaddingMs > 0)
             {
                 var silenceFile = Path.Combine(waveFolder, $"pad_{Guid.NewGuid()}.wav");
-                var silenceProcess = FfmpegGenerator.GenerateSilence(silenceFile, silencePaddingMs);
+                using var silenceProcess = FfmpegGenerator.GenerateSilence(silenceFile, silencePaddingMs);
                 await silenceProcess.StartAndWaitAsync(cancellationToken);
 
                 var paddedOutput = Path.Combine(waveFolder, $"padded_{Guid.NewGuid()}.wav");
-                var concatProcess = FfmpegGenerator.ConcatAudio(currentFile, silenceFile, paddedOutput);
+                using var concatProcess = FfmpegGenerator.ConcatAudio(currentFile, silenceFile, paddedOutput);
                 await concatProcess.StartAndWaitAsync(cancellationToken);
 
                 SafeDelete(silenceFile);
@@ -62,7 +64,7 @@ public static class TtsPostProcessor
             if (outputSampleRate > 0)
             {
                 var resampledOutput = Path.Combine(waveFolder, $"sr_{Guid.NewGuid()}.wav");
-                var srProcess = FfmpegGenerator.ChangeSampleRate(currentFile, resampledOutput, outputSampleRate);
+                using var srProcess = FfmpegGenerator.ChangeSampleRate(currentFile, resampledOutput, outputSampleRate);
                 await srProcess.StartAndWaitAsync(cancellationToken);
 
                 currentFile = AdoptStageOutput(currentFile, resampledOutput, "sample rate conversion");

--- a/tests/UI/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttServiceTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/OpenAiCompatible/OpenAiSttServiceTests.cs
@@ -164,10 +164,14 @@ public class OpenAiSttServiceTests
     }
 
     [Fact]
-    public async Task TranscribeAsync_PlainTextBody_FallsBackToSingleSegment()
+    public async Task TranscribeAsync_PlainTextBody_ReturnsTextWithNoSegments()
     {
-        // Body that JsonSerializer cannot deserialize into OpenAiCompatibleSttResponse
-        // forces the fallback branch that wraps it as a single-segment response.
+        // Body that JsonSerializer cannot deserialize into OpenAiCompatibleSttResponse forces the
+        // plain-text fallback. It must return the text with NO segments: the caller takes the
+        // segments branch whenever Segments.Count > 0, so the synthetic 0/0 segment this used to
+        // build put the whole transcript in one cue at 00:00:00,000 --> 00:00:00,000 and
+        // suppressed the sentence-spreading fallback that gives it real time codes. The streaming
+        // path above documents the same fix, and OpenRouterSttService already did it this way.
         using var handler = new StubHandler((req, ct) =>
             Task.FromResult(JsonResponse("not valid json at all", contentType: "application/json")));
         using var client = new HttpClient(handler);
@@ -180,9 +184,7 @@ public class OpenAiSttServiceTests
             var response = await service.TranscribeAsync(wav, cancellationToken: ct);
 
             Assert.Equal("not valid json at all", response.Text);
-            Assert.NotNull(response.Segments);
-            Assert.Single(response.Segments!);
-            Assert.Equal("not valid json at all", response.Segments![0].Text);
+            Assert.True(response.Segments == null || response.Segments.Count == 0);
         }
         finally
         {

--- a/tests/libse/Common/BugHunt17Test.cs
+++ b/tests/libse/Common/BugHunt17Test.cs
@@ -1,0 +1,39 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Forms.FixCommonErrors;
+
+namespace LibSETests.Common;
+
+/// <summary>
+/// Guard tests for the 2026-08-27 bug hunt (sweep 17): an unguarded index inside the
+/// remove-hyphens helper that took down a whole Fix-Common-Errors / Remove-text-for-HI run.
+/// </summary>
+public class BugHunt17Test
+{
+    private static Subtitle MakeSubtitle(string text)
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph(text, 0, 3000));
+        subtitle.Renumber();
+        return subtitle;
+    }
+
+    [Theory]
+    // RemoveSpacesBeginLine's LineStartsWithHtmlTag(true) test is satisfied by a string that is
+    // exactly "<i>", so text[3] read past the end. "<i>-" gets there because FixDash strips the
+    // dash first and hands it the bare tag.
+    [InlineData("<i>-")]
+    [InlineData("<i>")]
+    [InlineData("<i>- Hello")]
+    [InlineData("<font color=\"red\">-")]
+    [InlineData("-")]
+    [InlineData("")]
+    public void FixHyphensRemoveForSingleLine_ShortTaggedText_DoesNotThrow(string text)
+    {
+        var subtitle = MakeSubtitle(text);
+
+        var exception = Record.Exception(
+            () => Helper.FixHyphensRemoveForSingleLine(subtitle, subtitle.Paragraphs[0].Text, 0));
+
+        Assert.Null(exception);
+    }
+}


### PR DESCRIPTION
Sweep 17. Mostly the previous sweeps' verified-but-unapplied agent findings, plus a fresh pass over the libse Fix-Common-Errors rules.

Suites: libse 1630 / libuilogic 708 / seconv 422 / UI 4157.

## Crash

`Helper.RemoveSpacesBeginLine` indexes `text[3]` after a check that is already satisfied by the *three-character* string `"<i>"` — and `text[closeIdx + 1]` unguarded in the `<font>` branch below. It is reached by `FixHyphensRemoveForSingleLine` on `"<i>-"`: `FixDash` strips the dash first and hands it the bare tag. That takes down a whole Fix-Common-Errors or Remove-text-for-HI run. The `{\...}` branch six lines above bounds its index correctly, which is what makes this unambiguous. Guarded, with a theory test that fails without the fix.

## Destroys user data

The Qwen3 (CrispASR) voice pass deleted the user's reference WAV and *then* moved a replacement in, gated on "file exists and is non-empty". ffmpeg writes the 44-byte RIFF header before it encodes, so a run that starts and fails passes that test — the original is gone and a silent stub takes its place, permanently. `VoiceSeedHelper` spells out this exact rule in a comment ("a truncated WAV is still non-empty, so 'does the file exist / is it non-empty' cannot be the test here") and every other engine goes through it. Zonos hand-rolled the same loop with no exit code, no timeout and an undisposed process; it now uses the helper too.

## Wrong results

- **`FixMissingSpaces`**: the "Ph.D" guard compared a four-character regex match against the three-character `"h.d"`, so it could never fire — `his ph.d yesterday` became `ph. d`. Separately, the comma and period loops advanced with `NextMatch()` over the *pre-replacement* string while indexing the *rewritten* text, so after the first fix the `expectedChars` exclusion was read one character off. The `?`, `!` and `:` loops in the same method re-match against the updated text, which is the correct shape.
- **`FixMusicNotation`**: the "letter after `#`" chord guard used `idx < Length - 2`, skipping a `#` in the second-to-last position — `F#m` gained a music symbol while `F#maj` was correctly left alone.
- **`FixOverlappingDisplayTimes`** reported the *previous* paragraph in the branch that moves the *current* one, so the fix list showed a row whose before and after were identical and the real change was never surfaced.
- **The speech-to-text window wrote the forced-aligner setting on every engine change but never read it back**, overwriting whatever the user chose in Import plain text → Forced aligner setup, which is the only place that reads it.
- **The plain-text speech-to-text fallback synthesised a 0/0 segment.** The caller takes the segments branch whenever `Segments.Count > 0`, so the whole transcript landed in one cue at `00:00:00,000 --> 00:00:00,000` and the sentence-spreading fallback never ran. The streaming path 50 lines above documents this exact fix; `OpenRouterSttService` already did it correctly.
- **A model change resolved the saved language from the ElevenLabs key for every engine**, so a per-engine language was silently dropped and then overwritten on the next Generate.
- **AutoCast wrote a reference transcript built from every picked line** while the audio held only the clips that succeeded — and just the first one when joining failed. A ref-text/ref-audio mismatch is precisely what makes a cloned voice come out garbled.
- **"Enable VAD" could never be enabled for the cuBLAS and Vulkan backends**: the Silero lookup hard-codes the `Cpp` folder, but the model is unpacked into the selected backend's own folder. The CrispASR sibling resolves its engine's folder correctly.
- **The CTranslate2 engine looked for whisper.cpp's binary.** On Linux with a distro whisper.cpp installed it reported itself installed, offered no download, and launched `whisper-cli` with faster-whisper arguments. All four whisper engines also listed a relative `"usr/local/bin/"` that `File.Exists` can never match, so a `/usr/local/bin` build was never found.
- **Space in the skip-noise-lines and detect-speakers dialogs pressed OK** instead of toggling the row. `AddSpaceToggle` installs a tunnelling handler on the table, so it only fires while focus is inside it — and the builder focused the OK button. `ProfilesWindow` states the rule: "a focused button clicks on bare Space".

## Hangs and leaks

- The model-download dialog stops its timer and then runs the state machine unprotected, so a throw (a bad credential response, or `File.Move` over a `model.bin` locked by a running whisper) left it frozen at 100% with no error. Its twin has carried that catch since #12127.
- Ten of eleven `_timer.Start()` calls in the TTS download dialog were unguarded, so a chained step could restart a timer `OnClosing` had already disposed.
- Piper leaked a `Process` per subtitle line and orphaned the child on cancel; the TTS post-processor leaked up to four ffmpeg processes per line; speech-to-text leaked one per batch item.

## A note on the flaky mpv test, and a correction

`LibMpvEventLoopTests` fails intermittently on my machine. I chased this properly this time and reached a firm answer, which **corrects what I wrote in the last two PRs**.

Measuring the two checkouts *interleaved* (the method I insisted on last time) gave main 0/7 failures and this branch 6/7 — which looked conclusive. Bisecting then pointed at `src/libse`, which is implausible for an mpv timing test. So I ran the control I had been missing: I reverted the throwaway worktree's content until it was **identical to main**, and it still failed 3/4 while the other worktree passed 0/4.

The variable is the **worktree**, not the source. My long-lived working worktree has been building all session; a freshly created one has not. Every comparison I have made across two different worktrees — including last sweep's — was measuring that, not the code. The correct control is the same worktree with alternating content. Nothing in this PR touches the video players.

🤖 Generated with [Claude Code](https://claude.com/claude-code)