### PR TITLE
Add "Assisted split" and "Assisted move" windows with ranked one-click suggestions

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -38,6 +38,7 @@ using Nikse.SubtitleEdit.Features.Files.Statistics;
 using Nikse.SubtitleEdit.Features.Help.About;
 using Nikse.SubtitleEdit.Features.Help.CheckForUpdates;
 using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Main.AssistedSplit;
 using Nikse.SubtitleEdit.Features.Main.Layout;
 using Nikse.SubtitleEdit.Features.Main.MainHelpers;
 using Nikse.SubtitleEdit.Features.Ocr;
@@ -495,6 +496,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<PickOnlineSubtitleViewModel>();
         collection.AddTransient<OpenSecondarySubtitleViewModel>();
         collection.AddTransient<PartsSavedViewModel>();
+        collection.AddTransient<AssistedSplitViewModel>();
         collection.AddTransient<PickAlignmentViewModel>();
         collection.AddTransient<PickTeletextAlignmentViewModel>();
         collection.AddTransient<PickTeletextColorViewModel>();

--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -38,6 +38,7 @@ using Nikse.SubtitleEdit.Features.Files.Statistics;
 using Nikse.SubtitleEdit.Features.Help.About;
 using Nikse.SubtitleEdit.Features.Help.CheckForUpdates;
 using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Main.AssistedMove;
 using Nikse.SubtitleEdit.Features.Main.AssistedSplit;
 using Nikse.SubtitleEdit.Features.Main.Layout;
 using Nikse.SubtitleEdit.Features.Main.MainHelpers;
@@ -497,6 +498,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<OpenSecondarySubtitleViewModel>();
         collection.AddTransient<PartsSavedViewModel>();
         collection.AddTransient<AssistedSplitViewModel>();
+        collection.AddTransient<AssistedMoveViewModel>();
         collection.AddTransient<PickAlignmentViewModel>();
         collection.AddTransient<PickTeletextAlignmentViewModel>();
         collection.AddTransient<PickTeletextColorViewModel>();

--- a/src/ui/Features/Main/AssistedMove/AssistedMoveCandidate.cs
+++ b/src/ui/Features/Main/AssistedMove/AssistedMoveCandidate.cs
@@ -1,0 +1,31 @@
+﻿namespace Nikse.SubtitleEdit.Features.Main.AssistedMove;
+
+public enum AssistedMoveKind
+{
+    WithPrevious,
+    WithNext,
+    WithinSubtitle,
+}
+
+public class AssistedMoveCandidate
+{
+    public int Number { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public AssistedMoveKind Kind { get; set; }
+
+    public string NewCurrentText { get; set; } = string.Empty;
+    public string NewOtherText { get; set; } = string.Empty;
+
+    /// <summary>
+    /// For cross-subtitle moves the boundary time moves with the text: the earlier
+    /// subtitle's new end and the later subtitle's new start, split proportionally to the
+    /// new text lengths (keeping the original gap). Null for within-subtitle moves.
+    /// </summary>
+    public System.TimeSpan? NewFirstEnd { get; set; }
+    public System.TimeSpan? NewSecondStart { get; set; }
+
+    public string FirstText { get; set; } = string.Empty;
+    public string SecondText { get; set; } = string.Empty;
+    public string FirstInfo { get; set; } = string.Empty;
+    public string SecondInfo { get; set; } = string.Empty;
+}

--- a/src/ui/Features/Main/AssistedMove/AssistedMoveCandidateGenerator.cs
+++ b/src/ui/Features/Main/AssistedMove/AssistedMoveCandidateGenerator.cs
@@ -1,0 +1,595 @@
+﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Forms;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Features.Main.AssistedMove;
+
+/// <summary>
+/// Builds the ranked list of move suggestions shown in the "Assisted move" window.
+///
+/// The list is context aware: word/fragment moves across a subtitle boundary are only
+/// offered when the sentence actually continues across that boundary - moving words into
+/// a neighbor that starts a new sentence (or a new dialog) would corrupt both lines, so
+/// those directions are left out entirely. A subtitle that continues into the next only
+/// gets "with next" options; one that continues from the previous only gets "with
+/// previous" options. Word moves use the real <see cref="MoveWordUpDown"/> logic (tag
+/// handling and auto-break included), so the previews match exactly what applying does.
+/// </summary>
+public static class AssistedMoveCandidateGenerator
+{
+    private const int MaxCandidates = 6;
+    private const string SentenceEndChars = ".!?…。！？؟";
+    private const string ClosingChars = "\"'”’»)]";
+
+    public static List<AssistedMoveCandidate> Generate(
+        SubtitleLineViewModel current,
+        SubtitleLineViewModel? previous,
+        SubtitleLineViewModel? next,
+        string languageCode)
+    {
+        var result = new List<AssistedMoveCandidate>();
+        var currentText = (current.Text ?? string.Empty).Trim();
+        if (currentText.Length == 0)
+        {
+            return result;
+        }
+
+        var seen = new HashSet<string>();
+
+        void TryAdd(AssistedMoveCandidate? candidate)
+        {
+            if (candidate == null || result.Count >= MaxCandidates)
+            {
+                return;
+            }
+
+            if (!seen.Add(candidate.Kind + "|" + candidate.NewCurrentText + "|" + candidate.NewOtherText))
+            {
+                return;
+            }
+
+            candidate.Number = result.Count + 1;
+            result.Add(candidate);
+        }
+
+        var continuesToNext = next != null && SentenceContinues(currentText, next.Text ?? string.Empty);
+        var continuesFromPrevious = previous != null && SentenceContinues(previous.Text ?? string.Empty, currentText);
+
+        if (continuesToNext && next != null)
+        {
+            TryAdd(MakeFragmentMove(current, next, moveDown: true, AssistedMoveKind.WithNext,
+                Se.Language.General.MoveUnfinishedSentenceToNextSubtitle, languageCode));
+            TryAdd(MakeBalancedMove(current, next, AssistedMoveKind.WithNext,
+                Se.Language.General.BalanceWithNextSubtitle, languageCode));
+            TryAdd(MakeWordMove(current, next, moveDown: true, AssistedMoveKind.WithNext,
+                Se.Language.Options.Shortcuts.MoveLastWordToNextSubtitle, languageCode));
+            TryAdd(MakeWordMove(current, next, moveDown: false, AssistedMoveKind.WithNext,
+                Se.Language.General.FetchFirstWordFromNextSubtitle, languageCode));
+            TryAdd(MakeFragmentMove(current, next, moveDown: false, AssistedMoveKind.WithNext,
+                Se.Language.General.FetchRestOfSentenceFromNextSubtitle, languageCode));
+        }
+
+        if (continuesFromPrevious && previous != null)
+        {
+            TryAdd(MakeFragmentMove(previous, current, moveDown: false, AssistedMoveKind.WithPrevious,
+                Se.Language.General.MoveRestOfSentenceToPreviousSubtitle, languageCode));
+            TryAdd(MakeBalancedMove(previous, current, AssistedMoveKind.WithPrevious,
+                Se.Language.General.BalanceWithPreviousSubtitle, languageCode));
+            TryAdd(MakeWordMove(previous, current, moveDown: false, AssistedMoveKind.WithPrevious,
+                Se.Language.General.MoveFirstWordToPreviousSubtitle, languageCode));
+            TryAdd(MakeWordMove(previous, current, moveDown: true, AssistedMoveKind.WithPrevious,
+                Se.Language.General.FetchLastWordFromPreviousSubtitle, languageCode));
+            TryAdd(MakeFragmentMove(previous, current, moveDown: true, AssistedMoveKind.WithPrevious,
+                Se.Language.General.FetchUnfinishedSentenceFromPreviousSubtitle, languageCode));
+        }
+
+        TryAdd(MakeWithin(current, moveDown: true, languageCode,
+            Se.Language.Options.Shortcuts.MoveLastWordFromFirstLineDownCurrentSubtitle));
+        TryAdd(MakeWithin(current, moveDown: false, languageCode,
+            Se.Language.Options.Shortcuts.MoveFirstWordFromNextLineUpCurrentSubtitle));
+
+        return result;
+    }
+
+    /// <summary>
+    /// True when the text of <paramref name="firstText"/> flows on into
+    /// <paramref name="secondText"/> - i.e. the first does not finish its sentence, and the
+    /// second does not open a new dialog. An ellipsis ending still continues when the next
+    /// part starts with a lowercase letter (the "…" / "..." line-continuation convention).
+    /// </summary>
+    private static bool SentenceContinues(string firstText, string secondText)
+    {
+        var a = HtmlUtil.RemoveHtmlTags(firstText, true).TrimEnd();
+        var b = HtmlUtil.RemoveHtmlTags(secondText, true).TrimStart();
+        if (a.Length == 0 || b.Length == 0)
+        {
+            return false;
+        }
+
+        if (b.StartsWith('-') || b.StartsWith('–'))
+        {
+            return false; // the next part opens a dialog - never merge words into it
+        }
+
+        var endsWithEllipsis = a.EndsWith('…') || a.EndsWith("...");
+        a = a.TrimEnd(ClosingChars.ToCharArray()).TrimEnd();
+        if (a.Length == 0)
+        {
+            return false;
+        }
+
+        if (!SentenceEndChars.Contains(a[^1]))
+        {
+            return true;
+        }
+
+        var firstLetter = b.FirstOrDefault(char.IsLetter);
+        return endsWithEllipsis && firstLetter != default && char.IsLower(firstLetter);
+    }
+
+    /// <summary>
+    /// A single-word move between two subtitles. <paramref name="first"/> is always the
+    /// earlier subtitle: (current, next) for WithNext, (previous, current) for WithPrevious.
+    /// </summary>
+    private static AssistedMoveCandidate? MakeWordMove(
+        SubtitleLineViewModel first,
+        SubtitleLineViewModel second,
+        bool moveDown,
+        AssistedMoveKind kind,
+        string title,
+        string languageCode)
+    {
+        var firstText = (first.Text ?? string.Empty).Trim();
+        var secondText = (second.Text ?? string.Empty).Trim();
+
+        var upDown = new MoveWordUpDown(firstText, secondText);
+        if (moveDown)
+        {
+            upDown.MoveWordDown();
+        }
+        else
+        {
+            upDown.MoveWordUp();
+        }
+
+        if (upDown.S1 == firstText && upDown.S2 == secondText)
+        {
+            return null;
+        }
+
+        return MakeBetweenCandidate(first, second, upDown.S1, upDown.S2, kind, title, languageCode);
+    }
+
+    /// <summary>
+    /// Moves as many words as it takes across the boundary - in whichever direction the
+    /// text is heavier - so both subtitles end up with roughly the same amount of text.
+    /// Word by word via <see cref="MoveWordUpDown"/>, so tag handling stays correct.
+    /// </summary>
+    private static AssistedMoveCandidate? MakeBalancedMove(
+        SubtitleLineViewModel first,
+        SubtitleLineViewModel second,
+        AssistedMoveKind kind,
+        string title,
+        string languageCode)
+    {
+        var firstText = (first.Text ?? string.Empty).Trim();
+        var secondText = (second.Text ?? string.Empty).Trim();
+        var firstLength = CountVisibleCharacters(firstText);
+        var secondLength = CountVisibleCharacters(secondText);
+        var ideal = (firstLength + secondLength) / 2.0;
+        var moveDown = firstLength > secondLength;
+
+        var bestFirst = firstText;
+        var bestSecond = secondText;
+        var bestDistance = Math.Abs(firstLength - ideal);
+        var s1 = firstText;
+        var s2 = secondText;
+
+        for (var i = 0; i < 20; i++)
+        {
+            var upDown = new MoveWordUpDown(s1, s2);
+            if (moveDown)
+            {
+                upDown.MoveWordDown();
+            }
+            else
+            {
+                upDown.MoveWordUp();
+            }
+
+            if ((upDown.S1 == s1 && upDown.S2 == s2) ||
+                string.IsNullOrWhiteSpace(upDown.S1) ||
+                string.IsNullOrWhiteSpace(upDown.S2))
+            {
+                break;
+            }
+
+            s1 = upDown.S1;
+            s2 = upDown.S2;
+
+            var distance = Math.Abs(CountVisibleCharacters(s1) - ideal);
+            if (distance >= bestDistance)
+            {
+                break; // walked past the balance point - the previous step was the best
+            }
+
+            bestDistance = distance;
+            bestFirst = s1;
+            bestSecond = s2;
+        }
+
+        if (bestFirst == firstText && bestSecond == secondText)
+        {
+            return null;
+        }
+
+        return MakeBetweenCandidate(first, second, bestFirst, bestSecond, kind, title, languageCode);
+    }
+
+    /// <summary>
+    /// A whole-fragment move: the unfinished part of a sentence crosses the boundary in one
+    /// go instead of word by word. Down = the sentence tail of <paramref name="first"/> (the
+    /// text after its last sentence end) joins the start of <paramref name="second"/>;
+    /// up = the sentence head of <paramref name="second"/> (the text up to and including its
+    /// first sentence end) joins the end of <paramref name="first"/>.
+    /// </summary>
+    private static AssistedMoveCandidate? MakeFragmentMove(
+        SubtitleLineViewModel first,
+        SubtitleLineViewModel second,
+        bool moveDown,
+        AssistedMoveKind kind,
+        string title,
+        string languageCode)
+    {
+        var firstText = (first.Text ?? string.Empty).Trim();
+        var secondText = (second.Text ?? string.Empty).Trim();
+        string newFirst;
+        string newSecond;
+
+        if (moveDown)
+        {
+            var idx = FindLastSentenceEnd(firstText);
+            if (idx <= 0 || idx >= firstText.Length)
+            {
+                return null; // no sentence end, or nothing after it - no tail to move
+            }
+
+            newFirst = RebreakIfTooLong(firstText.Substring(0, idx).Trim(), languageCode);
+            newSecond = JoinFragments(firstText.Substring(idx).Trim(), secondText, languageCode);
+        }
+        else
+        {
+            var idx = FindFirstSentenceEnd(secondText);
+            if (idx <= 0 || idx >= secondText.Length)
+            {
+                return null; // no sentence end, or it swallows the whole subtitle
+            }
+
+            newFirst = JoinFragments(firstText, secondText.Substring(0, idx).Trim(), languageCode);
+            newSecond = RebreakIfTooLong(secondText.Substring(idx).Trim(), languageCode);
+        }
+
+        if (newFirst == firstText && newSecond == secondText)
+        {
+            return null;
+        }
+
+        return MakeBetweenCandidate(first, second, newFirst, newSecond, kind, title, languageCode);
+    }
+
+    private static AssistedMoveCandidate? MakeBetweenCandidate(
+        SubtitleLineViewModel first,
+        SubtitleLineViewModel second,
+        string newFirst,
+        string newSecond,
+        AssistedMoveKind kind,
+        string title,
+        string languageCode)
+    {
+        if (string.IsNullOrWhiteSpace(newFirst) || string.IsNullOrWhiteSpace(newSecond))
+        {
+            return null;
+        }
+
+        // A move leaves the old line break where it was ("...everyone in the theater" /
+        // "started") - re-break both sides so their lines end up balanced again.
+        newFirst = AutoBalanceLines(newFirst, languageCode);
+        newSecond = AutoBalanceLines(newSecond, languageCode);
+
+        // Moving a dialog dash as a "word" - or leaving one behind alone on a line -
+        // corrupts the dialog formatting; such a move is never a useful option.
+        if (HasDashOnlyLine(newFirst) || HasDashOnlyLine(newSecond))
+        {
+            return null;
+        }
+
+        // The receiving side must still fit a subtitle (at most two full lines) - but a
+        // side that was already over the limit may stay over it, as long as the move does
+        // not make it grow (otherwise no option at all would exist for exactly the
+        // too-long lines this window is for).
+        var maxLen = Math.Max(1, Configuration.Settings.General.SubtitleLineMaximumLength);
+        var limit = maxLen * 2;
+        var newFirstLength = CountVisibleCharacters(newFirst);
+        var newSecondLength = CountVisibleCharacters(newSecond);
+        if ((newFirstLength > limit && newFirstLength > CountVisibleCharacters(first.Text ?? string.Empty)) ||
+            (newSecondLength > limit && newSecondLength > CountVisibleCharacters(second.Text ?? string.Empty)))
+        {
+            return null;
+        }
+
+        // Move the boundary time with the text: keep the original gap and the outer
+        // start/end, and divide the span proportionally to the new text lengths.
+        var (newFirstEnd, newSecondStart) = ComputeTimeSplit(first, second, newFirstLength, newSecondLength);
+
+        return new AssistedMoveCandidate
+        {
+            Title = title,
+            Kind = kind,
+            NewCurrentText = kind == AssistedMoveKind.WithNext ? newFirst : newSecond,
+            NewOtherText = kind == AssistedMoveKind.WithNext ? newSecond : newFirst,
+            NewFirstEnd = newFirstEnd,
+            NewSecondStart = newSecondStart,
+            FirstText = newFirst,
+            SecondText = newSecond,
+            FirstInfo = MakeInfo(newFirst, first.StartTime, newFirstEnd),
+            SecondInfo = MakeInfo(newSecond, newSecondStart, second.EndTime),
+        };
+    }
+
+    /// <summary>
+    /// Divides the combined time span of the two subtitles proportionally to their new
+    /// text lengths, preserving the outer start/end and the gap between them. The ratio is
+    /// clamped so neither side collapses to a sliver.
+    /// </summary>
+    private static (TimeSpan firstEnd, TimeSpan secondStart) ComputeTimeSplit(
+        SubtitleLineViewModel first, SubtitleLineViewModel second, int firstLength, int secondLength)
+    {
+        var gapMs = (second.StartTime - first.EndTime).TotalMilliseconds;
+        if (gapMs < 0)
+        {
+            gapMs = 0;
+        }
+
+        var availableMs = (second.EndTime - first.StartTime).TotalMilliseconds - gapMs;
+        var totalLength = firstLength + secondLength;
+        if (availableMs <= 0 || totalLength <= 0)
+        {
+            return (first.EndTime, second.StartTime); // degenerate timing - leave it alone
+        }
+
+        var ratio = Math.Clamp((double)firstLength / totalLength, 0.15, 0.85);
+        var firstEnd = first.StartTime + TimeSpan.FromMilliseconds(availableMs * ratio);
+        var secondStart = firstEnd + TimeSpan.FromMilliseconds(gapMs);
+        return (firstEnd, secondStart);
+    }
+
+    /// <summary>A word move between the two lines of the current subtitle.</summary>
+    private static AssistedMoveCandidate? MakeWithin(
+        SubtitleLineViewModel current,
+        bool moveDown,
+        string languageCode,
+        string title)
+    {
+        var text = (current.Text ?? string.Empty).Trim();
+        var lines = text.SplitToLines();
+        if (lines.Count > 2)
+        {
+            lines = Utilities.AutoBreakLine(Utilities.UnbreakLine(text), languageCode).SplitToLines();
+        }
+
+        if (lines.Count != 2)
+        {
+            return null;
+        }
+
+        // The two lines of a dialog belong to different speakers - never mix their words.
+        if (lines.Any(line => line.TrimStart().StartsWith('-') || line.TrimStart().StartsWith('–')))
+        {
+            return null;
+        }
+
+        var upDown = new MoveWordUpDown(lines[0].Trim(), lines[1].Trim());
+        if (moveDown)
+        {
+            upDown.MoveWordDown();
+        }
+        else
+        {
+            upDown.MoveWordUp();
+        }
+
+        if (string.IsNullOrWhiteSpace(upDown.S1) || string.IsNullOrWhiteSpace(upDown.S2))
+        {
+            return null;
+        }
+
+        var newText = upDown.S1 + Environment.NewLine + upDown.S2;
+        if (newText.SplitToLines().Count > 2)
+        {
+            newText = Utilities.AutoBreakLine(Utilities.UnbreakLine(newText), languageCode);
+        }
+
+        if (newText == text || HasDashOnlyLine(newText))
+        {
+            return null;
+        }
+
+        return new AssistedMoveCandidate
+        {
+            Title = title,
+            Kind = AssistedMoveKind.WithinSubtitle,
+            NewCurrentText = newText,
+            FirstText = newText,
+            FirstInfo = MakeInfo(newText, current.StartTime, current.EndTime),
+        };
+    }
+
+    /// <summary>
+    /// Joins an incoming sentence fragment with existing text (fragment first) into one
+    /// flowing text, re-broken to at most two lines.
+    /// </summary>
+    private static string JoinFragments(string firstPart, string secondPart, string languageCode)
+    {
+        var joined = Utilities.UnbreakLine(firstPart.Trim() + " " + secondPart.Trim());
+        return RebreakIfTooLong(joined, languageCode);
+    }
+
+    /// <summary>
+    /// Unbreaks and re-breaks the text so its lines are evenly balanced. Dialog texts keep
+    /// their per-speaker lines and are only re-broken when a line is over the limit.
+    /// </summary>
+    private static string AutoBalanceLines(string text, string languageCode)
+    {
+        var isDialog = text.SplitToLines()
+            .Any(line => line.TrimStart().StartsWith('-') || line.TrimStart().StartsWith('–'));
+        if (isDialog)
+        {
+            return RebreakIfTooLong(text, languageCode);
+        }
+
+        return Utilities.AutoBreakLine(Utilities.UnbreakLine(text), languageCode);
+    }
+
+    private static string RebreakIfTooLong(string text, string languageCode)
+    {
+        var maxLen = Configuration.Settings.General.SubtitleLineMaximumLength;
+        if (maxLen <= 0)
+        {
+            return text;
+        }
+
+        var tooLong = HtmlUtil.RemoveHtmlTags(text, true)
+            .SplitToLines()
+            .Any(line => line.Length > maxLen);
+
+        return tooLong ? Utilities.AutoBreakLine(Utilities.UnbreakLine(text), languageCode) : text;
+    }
+
+    /// <summary>
+    /// Index just after the last sentence end (punctuation plus closing quotes) in
+    /// <paramref name="text"/>, skipping tags; -1 when there is none.
+    /// </summary>
+    private static int FindLastSentenceEnd(string text)
+    {
+        var last = -1;
+        foreach (var idx in GetSentenceEndIndices(text))
+        {
+            last = idx;
+        }
+
+        return last;
+    }
+
+    /// <summary>Index just after the first sentence end; -1 when there is none.</summary>
+    private static int FindFirstSentenceEnd(string text)
+    {
+        foreach (var idx in GetSentenceEndIndices(text))
+        {
+            return idx;
+        }
+
+        return -1;
+    }
+
+    private static IEnumerable<int> GetSentenceEndIndices(string text)
+    {
+        var inTag = MakeTagMask(text);
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (inTag[i] || !SentenceEndChars.Contains(text[i]))
+            {
+                continue;
+            }
+
+            // Skip decimal numbers like "1.5" and web addresses like "nikse.dk".
+            if (text[i] == '.' &&
+                i > 0 && i + 1 < text.Length &&
+                !char.IsWhiteSpace(text[i + 1]))
+            {
+                continue;
+            }
+
+            // Consume a run of end punctuation ("...", "?!") and trailing closing quotes.
+            var end = i;
+            while (end + 1 < text.Length && SentenceEndChars.Contains(text[end + 1]))
+            {
+                end++;
+            }
+
+            while (end + 1 < text.Length && ClosingChars.Contains(text[end + 1]))
+            {
+                end++;
+            }
+
+            var splitIndex = end + 1;
+            i = end;
+
+            if (splitIndex >= text.Length || !char.IsWhiteSpace(text[splitIndex]))
+            {
+                continue;
+            }
+
+            yield return splitIndex;
+        }
+    }
+
+    // True at positions inside "<...>" or "{...}" blocks, so fragment cuts never land inside a tag.
+    private static bool[] MakeTagMask(string text)
+    {
+        var mask = new bool[text.Length];
+        var inAngle = false;
+        var inCurly = false;
+        for (var i = 0; i < text.Length; i++)
+        {
+            var c = text[i];
+            if (c == '<')
+            {
+                inAngle = true;
+            }
+            else if (c == '{')
+            {
+                inCurly = true;
+            }
+
+            mask[i] = inAngle || inCurly;
+
+            if (c == '>')
+            {
+                inAngle = false;
+            }
+            else if (c == '}')
+            {
+                inCurly = false;
+            }
+        }
+
+        return mask;
+    }
+
+    private static bool HasDashOnlyLine(string text)
+    {
+        return HtmlUtil.RemoveHtmlTags(text, true)
+            .SplitToLines()
+            .Any(line => line.Trim() is "-" or "–");
+    }
+
+    private static string MakeInfo(string newText, TimeSpan start, TimeSpan end)
+    {
+        var startText = new TimeCode(start).ToShortDisplayString();
+        var endText = new TimeCode(end).ToShortDisplayString();
+        var chars = CountVisibleCharacters(newText);
+        var seconds = (end - start).TotalSeconds;
+        var cps = seconds > 0.001 ? chars / seconds : 0;
+        return $"{startText} → {endText}      {chars} chars, {cps:0.#} CPS";
+    }
+
+    private static int CountVisibleCharacters(string text)
+    {
+        // Line breaks (CR/LF) are the only control characters left after tag stripping.
+        var stripped = HtmlUtil.RemoveHtmlTags(text, true);
+        return stripped.Count(c => !char.IsControl(c));
+    }
+}

--- a/src/ui/Features/Main/AssistedMove/AssistedMoveViewModel.cs
+++ b/src/ui/Features/Main/AssistedMove/AssistedMoveViewModel.cs
@@ -4,32 +4,32 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System.Collections.Generic;
 
-namespace Nikse.SubtitleEdit.Features.Main.AssistedSplit;
+namespace Nikse.SubtitleEdit.Features.Main.AssistedMove;
 
-public partial class AssistedSplitViewModel : ObservableObject
+public partial class AssistedMoveViewModel : ObservableObject
 {
     [ObservableProperty] private string _subtitleInfo;
 
-    public List<AssistedSplitCandidate> Candidates { get; private set; }
+    public List<AssistedMoveCandidate> Candidates { get; private set; }
 
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }
-    public AssistedSplitCandidate? SelectedCandidate { get; private set; }
+    public AssistedMoveCandidate? SelectedCandidate { get; private set; }
 
-    public AssistedSplitViewModel()
+    public AssistedMoveViewModel()
     {
         SubtitleInfo = string.Empty;
-        Candidates = new List<AssistedSplitCandidate>();
+        Candidates = new List<AssistedMoveCandidate>();
     }
 
-    public void Initialize(SubtitleLineViewModel subtitle, List<AssistedSplitCandidate> candidates)
+    public void Initialize(SubtitleLineViewModel subtitle, List<AssistedMoveCandidate> candidates)
     {
         Candidates = candidates;
         SubtitleInfo = subtitle.Text;
     }
 
     [RelayCommand]
-    private void Pick(AssistedSplitCandidate candidate)
+    private void Pick(AssistedMoveCandidate candidate)
     {
         SelectedCandidate = candidate;
         OkPressed = true;
@@ -52,6 +52,7 @@ public partial class AssistedSplitViewModel : ObservableObject
             Key.D3 or Key.NumPad3 => 3,
             Key.D4 or Key.NumPad4 => 4,
             Key.D5 or Key.NumPad5 => 5,
+            Key.D6 or Key.NumPad6 => 6,
             _ => 0,
         };
 

--- a/src/ui/Features/Main/AssistedMove/AssistedMoveWindow.cs
+++ b/src/ui/Features/Main/AssistedMove/AssistedMoveWindow.cs
@@ -7,16 +7,16 @@ using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
 
-namespace Nikse.SubtitleEdit.Features.Main.AssistedSplit;
+namespace Nikse.SubtitleEdit.Features.Main.AssistedMove;
 
-public class AssistedSplitWindow : Window
+public class AssistedMoveWindow : Window
 {
-    private readonly AssistedSplitViewModel _vm;
+    private readonly AssistedMoveViewModel _vm;
 
-    public AssistedSplitWindow(AssistedSplitViewModel vm)
+    public AssistedMoveWindow(AssistedMoveViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
-        Title = Se.Language.General.AssistedSplit;
+        Title = Se.Language.General.AssistedMove;
         SizeToContent = SizeToContent.Height;
         CanResize = false;
         Width = 720;
@@ -25,7 +25,7 @@ public class AssistedSplitWindow : Window
         vm.Window = this;
         DataContext = vm;
 
-        var labelHeader = UiUtil.MakeLabel(Se.Language.General.AssistedSplitChooseSplitPoint);
+        var labelHeader = UiUtil.MakeLabel(Se.Language.General.AssistedMoveChooseMove);
         labelHeader.FontWeight = FontWeight.Bold;
 
         var originalText = new TextBlock
@@ -81,7 +81,7 @@ public class AssistedSplitWindow : Window
         };
     }
 
-    private static Button MakeCandidateCard(AssistedSplitViewModel vm, AssistedSplitCandidate candidate)
+    private static Button MakeCandidateCard(AssistedMoveViewModel vm, AssistedMoveCandidate candidate)
     {
         var labelNumber = new TextBlock
         {
@@ -106,10 +106,14 @@ public class AssistedSplitWindow : Window
             Children =
             {
                 labelTitle,
-                MakeHalfPreview(candidate.FirstText, candidate.FirstInfo),
-                MakeHalfPreview(candidate.SecondText, candidate.SecondInfo),
+                MakePreview(candidate.FirstText, candidate.FirstInfo),
             },
         };
+
+        if (!string.IsNullOrEmpty(candidate.SecondText))
+        {
+            panelTexts.Children.Add(MakePreview(candidate.SecondText, candidate.SecondInfo));
+        }
 
         var grid = new Grid
         {
@@ -133,7 +137,7 @@ public class AssistedSplitWindow : Window
         }.WithGreenishActiveBackground();
     }
 
-    private static Border MakeHalfPreview(string text, string info)
+    private static Border MakePreview(string text, string info)
     {
         var textBlock = new TextBlock
         {

--- a/src/ui/Features/Main/AssistedSplit/AssistedSplitCandidate.cs
+++ b/src/ui/Features/Main/AssistedSplit/AssistedSplitCandidate.cs
@@ -1,0 +1,12 @@
+﻿namespace Nikse.SubtitleEdit.Features.Main.AssistedSplit;
+
+public class AssistedSplitCandidate
+{
+    public int Number { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public int TextIndex { get; set; }
+    public string FirstText { get; set; } = string.Empty;
+    public string SecondText { get; set; } = string.Empty;
+    public string FirstInfo { get; set; } = string.Empty;
+    public string SecondInfo { get; set; } = string.Empty;
+}

--- a/src/ui/Features/Main/AssistedSplit/AssistedSplitCandidateGenerator.cs
+++ b/src/ui/Features/Main/AssistedSplit/AssistedSplitCandidateGenerator.cs
@@ -1,0 +1,307 @@
+﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Features.Main.AssistedSplit;
+
+/// <summary>
+/// Builds the ranked list of split suggestions shown in the "Assisted split" window.
+/// Each raw candidate is a character index into the subtitle's text; the final text and
+/// timing of both halves are produced by running the real <see cref="ISplitManager"/> on a
+/// throw-away copy, so the previews match exactly what applying the split will do.
+/// </summary>
+public static class AssistedSplitCandidateGenerator
+{
+    private const int MaxCandidates = 5;
+    private const char Lf = (char)10;
+    private const char Cr = (char)13;
+
+    public static List<AssistedSplitCandidate> Generate(SubtitleLineViewModel subtitle, string languageCode, ISplitManager splitManager)
+    {
+        var text = subtitle.Text ?? string.Empty;
+        var result = new List<AssistedSplitCandidate>();
+        if (text.Trim().Length < 4)
+        {
+            return result;
+        }
+
+        var inTag = MakeTagMask(text);
+        var raw = new List<(int Index, string Title)>();
+
+        // 1) Dialog dash / line breaks: split where the line is already broken.
+        foreach (var nl in GetNewLineIndices(text))
+        {
+            var nextLine = text.Substring(SkipLineBreak(text, nl)).TrimStart();
+            var isDialog = nextLine.StartsWith('-') || nextLine.StartsWith('–');
+            raw.Add((nl, isDialog ? Se.Language.General.SplitAtDialogDash : Se.Language.General.SplitAtLineBreak));
+        }
+
+        // 2) Sentence ends.
+        foreach (var idx in GetSentenceEndIndices(text, inTag))
+        {
+            raw.Add((idx, Se.Language.General.SplitAtSentenceEnd));
+        }
+
+        // 3) Comma nearest the middle.
+        var commaIdx = GetBestCommaIndex(text, inTag);
+        if (commaIdx > 0)
+        {
+            raw.Add((commaIdx, Se.Language.General.SplitAtComma));
+        }
+
+        // 4) Whitespace nearest the middle (always available as a fallback).
+        var middleIdx = GetMiddleWhitespaceIndex(text, inTag);
+        if (middleIdx > 0)
+        {
+            raw.Add((middleIdx, Se.Language.General.SplitNearMiddle));
+        }
+
+        // Rank: dialog first, then sentence ends, line breaks, comma, and even split last.
+        var order = new List<string>
+        {
+            Se.Language.General.SplitAtDialogDash,
+            Se.Language.General.SplitAtSentenceEnd,
+            Se.Language.General.SplitAtLineBreak,
+            Se.Language.General.SplitAtComma,
+            Se.Language.General.SplitNearMiddle,
+        };
+        raw = raw.OrderBy(r => order.IndexOf(r.Title)).ThenBy(r => r.Index).ToList();
+
+        var seen = new HashSet<string>();
+        foreach (var (index, title) in raw)
+        {
+            if (result.Count >= MaxCandidates)
+            {
+                break;
+            }
+
+            var candidate = Simulate(subtitle, index, title, languageCode, splitManager);
+            if (candidate == null)
+            {
+                continue;
+            }
+
+            var key = candidate.FirstText + "|" + candidate.SecondText;
+            if (!seen.Add(key))
+            {
+                continue;
+            }
+
+            candidate.Number = result.Count + 1;
+            result.Add(candidate);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Runs the real split on a copy so the preview (text, continuation style, tag fix-up,
+    /// timing) is exactly what the user will get.
+    /// </summary>
+    private static AssistedSplitCandidate? Simulate(SubtitleLineViewModel subtitle, int textIndex, string title, string languageCode, ISplitManager splitManager)
+    {
+        var copy = new SubtitleLineViewModel(subtitle, true);
+        var temp = new ObservableCollection<SubtitleLineViewModel> { copy };
+        splitManager.Split(temp, copy, textIndex, languageCode);
+        if (temp.Count != 2 ||
+            string.IsNullOrWhiteSpace(temp[0].Text) ||
+            string.IsNullOrWhiteSpace(temp[1].Text))
+        {
+            return null;
+        }
+
+        // Splitting in the middle of a dialog line can leave a half with an orphan
+        // dash-only line (e.g. splitting "- A?/- B, c." at the comma) - not a useful option.
+        if (HasDashOnlyLine(temp[0].Text) || HasDashOnlyLine(temp[1].Text))
+        {
+            return null;
+        }
+
+        return new AssistedSplitCandidate
+        {
+            Title = title,
+            TextIndex = textIndex,
+            FirstText = temp[0].Text,
+            SecondText = temp[1].Text,
+            FirstInfo = MakeInfo(temp[0]),
+            SecondInfo = MakeInfo(temp[1]),
+        };
+    }
+
+    private static bool HasDashOnlyLine(string text)
+    {
+        return HtmlUtil.RemoveHtmlTags(text, true)
+            .SplitToLines()
+            .Any(line => line.Trim() is "-" or "–");
+    }
+
+    private static string MakeInfo(SubtitleLineViewModel s)
+    {
+        var start = new TimeCode(s.StartTime).ToShortDisplayString();
+        var end = new TimeCode(s.EndTime).ToShortDisplayString();
+        var chars = CountVisibleCharacters(s.Text);
+        var seconds = s.Duration.TotalSeconds;
+        var cps = seconds > 0.001 ? chars / seconds : 0;
+        return $"{start} → {end}      {chars} chars, {cps:0.#} CPS";
+    }
+
+    private static int CountVisibleCharacters(string text)
+    {
+        // Line breaks (CR/LF) are the only control characters left after tag stripping.
+        var stripped = HtmlUtil.RemoveHtmlTags(text, true);
+        return stripped.Count(c => !char.IsControl(c));
+    }
+
+    // True at positions inside "<...>" or "{...}" blocks, so split points never land inside a tag.
+    private static bool[] MakeTagMask(string text)
+    {
+        var mask = new bool[text.Length];
+        var inAngle = false;
+        var inCurly = false;
+        for (var i = 0; i < text.Length; i++)
+        {
+            var c = text[i];
+            if (c == '<')
+            {
+                inAngle = true;
+            }
+            else if (c == '{')
+            {
+                inCurly = true;
+            }
+
+            mask[i] = inAngle || inCurly;
+
+            if (c == '>')
+            {
+                inAngle = false;
+            }
+            else if (c == '}')
+            {
+                inCurly = false;
+            }
+        }
+
+        return mask;
+    }
+
+    private static List<int> GetNewLineIndices(string text)
+    {
+        var result = new List<int>();
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (text[i] == Lf || text[i] == Cr)
+            {
+                result.Add(i);
+                i = SkipLineBreak(text, i) - 1;
+            }
+        }
+
+        return result;
+    }
+
+    private static int SkipLineBreak(string text, int index)
+    {
+        if (index < text.Length && text[index] == Cr)
+        {
+            index++;
+        }
+
+        if (index < text.Length && text[index] == Lf)
+        {
+            index++;
+        }
+
+        return index;
+    }
+
+    private static IEnumerable<int> GetSentenceEndIndices(string text, bool[] inTag)
+    {
+        const string sentenceEnd = ".!?…";
+        const string closers = "\"'”’»)]";
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (inTag[i] || !sentenceEnd.Contains(text[i]))
+            {
+                continue;
+            }
+
+            // Skip decimal numbers like "1.5" and web addresses like "nikse.dk".
+            if (text[i] == '.' &&
+                i > 0 && i + 1 < text.Length &&
+                !char.IsWhiteSpace(text[i + 1]))
+            {
+                continue;
+            }
+
+            // Consume a run of end punctuation ("...", "?!") and trailing closing quotes.
+            var end = i;
+            while (end + 1 < text.Length && sentenceEnd.Contains(text[end + 1]))
+            {
+                end++;
+            }
+
+            while (end + 1 < text.Length && closers.Contains(text[end + 1]))
+            {
+                end++;
+            }
+
+            var splitIndex = end + 1;
+            i = end;
+
+            // Only a real sentence boundary: whitespace after, and more text following.
+            if (splitIndex >= text.Length ||
+                !char.IsWhiteSpace(text[splitIndex]) ||
+                string.IsNullOrWhiteSpace(text.Substring(splitIndex)))
+            {
+                continue;
+            }
+
+            yield return splitIndex;
+        }
+    }
+
+    private static int GetBestCommaIndex(string text, bool[] inTag)
+    {
+        var middle = text.Length / 2;
+        var best = -1;
+        for (var i = 1; i < text.Length - 1; i++)
+        {
+            if (inTag[i] || (text[i] != ',' && text[i] != '，') || !char.IsWhiteSpace(text[i + 1]))
+            {
+                continue;
+            }
+
+            if (best < 0 || Math.Abs(i - middle) < Math.Abs(best - middle))
+            {
+                best = i;
+            }
+        }
+
+        return best < 0 ? -1 : best + 1;
+    }
+
+    private static int GetMiddleWhitespaceIndex(string text, bool[] inTag)
+    {
+        var middle = text.Length / 2;
+        var best = -1;
+        for (var i = 1; i < text.Length - 1; i++)
+        {
+            if (inTag[i] || !char.IsWhiteSpace(text[i]))
+            {
+                continue;
+            }
+
+            if (best < 0 || Math.Abs(i - middle) < Math.Abs(best - middle))
+            {
+                best = i;
+            }
+        }
+
+        return best;
+    }
+}

--- a/src/ui/Features/Main/AssistedSplit/AssistedSplitViewModel.cs
+++ b/src/ui/Features/Main/AssistedSplit/AssistedSplitViewModel.cs
@@ -1,0 +1,70 @@
+﻿using Avalonia.Controls;
+using Avalonia.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System.Collections.Generic;
+
+namespace Nikse.SubtitleEdit.Features.Main.AssistedSplit;
+
+public partial class AssistedSplitViewModel : ObservableObject
+{
+    [ObservableProperty] private string _subtitleInfo;
+
+    public List<AssistedSplitCandidate> Candidates { get; private set; }
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+    public AssistedSplitCandidate? SelectedCandidate { get; private set; }
+
+    public AssistedSplitViewModel()
+    {
+        SubtitleInfo = string.Empty;
+        Candidates = new List<AssistedSplitCandidate>();
+    }
+
+    public void Initialize(SubtitleLineViewModel subtitle, List<AssistedSplitCandidate> candidates)
+    {
+        Candidates = candidates;
+        SubtitleInfo = subtitle.Text;
+    }
+
+    [RelayCommand]
+    private void Pick(AssistedSplitCandidate candidate)
+    {
+        SelectedCandidate = candidate;
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Window?.Close();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+            return;
+        }
+
+        var number = e.Key switch
+        {
+            Key.D1 or Key.NumPad1 => 1,
+            Key.D2 or Key.NumPad2 => 2,
+            Key.D3 or Key.NumPad3 => 3,
+            Key.D4 or Key.NumPad4 => 4,
+            Key.D5 or Key.NumPad5 => 5,
+            _ => 0,
+        };
+
+        if (number > 0 && number <= Candidates.Count)
+        {
+            e.Handled = true;
+            Pick(Candidates[number - 1]);
+        }
+    }
+}

--- a/src/ui/Features/Main/AssistedSplit/AssistedSplitWindow.cs
+++ b/src/ui/Features/Main/AssistedSplit/AssistedSplitWindow.cs
@@ -1,0 +1,148 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Main.AssistedSplit;
+
+public class AssistedSplitWindow : Window
+{
+    private readonly AssistedSplitViewModel _vm;
+
+    public AssistedSplitWindow(AssistedSplitViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = Se.Language.General.AssistedSplit;
+        SizeToContent = SizeToContent.Height;
+        CanResize = false;
+        Width = 720;
+
+        _vm = vm;
+        vm.Window = this;
+        DataContext = vm;
+
+        var labelHeader = UiUtil.MakeLabel(Se.Language.General.AssistedSplitChooseSplitPoint);
+        labelHeader.FontWeight = FontWeight.Bold;
+
+        var originalText = new TextBlock
+        {
+            Text = vm.SubtitleInfo,
+            TextWrapping = TextWrapping.Wrap,
+            Opacity = 0.8,
+            Margin = new Thickness(0, 0, 0, 4),
+        };
+
+        var panelCandidates = new StackPanel { Spacing = 8 };
+        foreach (var candidate in vm.Candidates)
+        {
+            panelCandidates.Children.Add(MakeCandidateCard(vm, candidate));
+        }
+
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        var panelButtons = UiUtil.MakeButtonBar(buttonCancel);
+
+        var panel = new StackPanel
+        {
+            Margin = UiUtil.MakeWindowMargin(),
+            Spacing = 8,
+            Children =
+            {
+                labelHeader,
+                UiUtil.MakeBorderForControl(originalText),
+                panelCandidates,
+                panelButtons,
+            },
+        };
+
+        Content = panel;
+
+        Activated += delegate { buttonCancel.Focus(); }; // hack to make OnKeyDown work
+    }
+
+    private static Button MakeCandidateCard(AssistedSplitViewModel vm, AssistedSplitCandidate candidate)
+    {
+        var labelNumber = new TextBlock
+        {
+            Text = candidate.Number.ToString(),
+            FontSize = 22,
+            FontWeight = FontWeight.Bold,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(4, 0, 12, 0),
+        };
+
+        var labelTitle = new TextBlock
+        {
+            Text = candidate.Title,
+            FontWeight = FontWeight.Bold,
+            Margin = new Thickness(0, 0, 0, 4),
+        };
+
+        var panelTexts = new StackPanel
+        {
+            Spacing = 4,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            Children =
+            {
+                labelTitle,
+                MakeHalfPreview(candidate.FirstText, candidate.FirstInfo),
+                MakeHalfPreview(candidate.SecondText, candidate.SecondInfo),
+            },
+        };
+
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = GridLength.Auto },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+        };
+        grid.Add(labelNumber, 0, 0);
+        grid.Add(panelTexts, 0, 1);
+
+        return new Button
+        {
+            Content = grid,
+            Command = vm.PickCommand,
+            CommandParameter = candidate,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            HorizontalContentAlignment = HorizontalAlignment.Stretch,
+            Padding = new Thickness(8),
+        };
+    }
+
+    private static Border MakeHalfPreview(string text, string info)
+    {
+        var textBlock = new TextBlock
+        {
+            Text = text,
+            TextWrapping = TextWrapping.Wrap,
+        };
+
+        var infoBlock = new TextBlock
+        {
+            Text = info,
+            FontSize = 11,
+            Opacity = 0.7,
+            Margin = new Thickness(0, 2, 0, 0),
+        };
+
+        return new Border
+        {
+            BorderThickness = new Thickness(1),
+            BorderBrush = UiUtil.GetBorderBrush(),
+            CornerRadius = new CornerRadius(4),
+            Padding = new Thickness(6, 4),
+            Child = new StackPanel { Children = { textBlock, infoBlock } },
+        };
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        _vm.OnKeyDown(e);
+    }
+}

--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -1014,6 +1014,11 @@ public static partial class InitListViewAndEditBox
         assistedSplitMenuItem.Command = vm.AssistedSplitCommand;
         flyout.Items.Add(assistedSplitMenuItem);
 
+        var assistedMoveMenuItem = new MenuItem { Header = Se.Language.General.AssistedMoveDotDotDot, DataContext = vm };
+        assistedMoveMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridDataMenuVisible)));
+        assistedMoveMenuItem.Command = vm.AssistedMoveCommand;
+        flyout.Items.Add(assistedMoveMenuItem);
+
         var mergePreviousMenuItem = new MenuItem { Header = Se.Language.General.MergeBefore, DataContext = vm };
         mergePreviousMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsMergeWithNextOrPreviousVisible)));
         mergePreviousMenuItem.Command = vm.MergeWithLineBeforeCommand;

--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -1009,6 +1009,11 @@ public static partial class InitListViewAndEditBox
         splitMenuItem.Command = vm.SplitCommand;
         flyout.Items.Add(splitMenuItem);
 
+        var assistedSplitMenuItem = new MenuItem { Header = Se.Language.General.AssistedSplitDotDotDot, DataContext = vm };
+        assistedSplitMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridDataMenuVisible)));
+        assistedSplitMenuItem.Command = vm.AssistedSplitCommand;
+        flyout.Items.Add(assistedSplitMenuItem);
+
         var mergePreviousMenuItem = new MenuItem { Header = Se.Language.General.MergeBefore, DataContext = vm };
         mergePreviousMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsMergeWithNextOrPreviousVisible)));
         mergePreviousMenuItem.Command = vm.MergeWithLineBeforeCommand;

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -144,6 +144,7 @@ using Nikse.SubtitleEdit.Features.Tools.MergeSubtitlesWithSameTimeCodes;
 using Nikse.SubtitleEdit.Features.Tools.RemoveTextForHearingImpaired;
 using Nikse.SubtitleEdit.Features.Tools.Renumber;
 using Nikse.SubtitleEdit.Features.Tools.SortBy;
+using Nikse.SubtitleEdit.Features.Main.AssistedSplit;
 using Nikse.SubtitleEdit.Features.Tools.SplitBreakLongLines;
 using Nikse.SubtitleEdit.Features.Tools.SplitSubtitle;
 using Nikse.SubtitleEdit.Features.Translate;
@@ -16450,6 +16451,51 @@ public partial class MainViewModel :
     private void SplitAtVideoPositionAndTextBoxCursorPosition()
     {
         SplitSelectedLine(true, true);
+    }
+
+    [RelayCommand]
+    private async Task AssistedSplit()
+    {
+        var s = SelectedSubtitle;
+        if (s == null || s.IsReferenceOnly)
+        {
+            return;
+        }
+
+        var language = LanguageAutoDetect.AutoDetectGoogleLanguage(GetUpdateSubtitle());
+        var candidates = AssistedSplitCandidateGenerator.Generate(s, language, _splitManager);
+        if (candidates.Count == 0)
+        {
+            return;
+        }
+
+        var vm = await ShowDialogAsync<AssistedSplitWindow, AssistedSplitViewModel>(viewModel =>
+        {
+            viewModel.Initialize(s, candidates);
+        });
+
+        if (!vm.OkPressed || vm.SelectedCandidate == null)
+        {
+            return;
+        }
+
+        var countBefore = Subtitles.Count;
+        RunWithoutChangeDetection(() =>
+        {
+            _splitManager.Split(Subtitles, s, vm.SelectedCandidate.TextIndex, language);
+            Renumber();
+        });
+
+        if (Subtitles.Count > countBefore)
+        {
+            var newHalf = Subtitles.GetOrNull(Subtitles.IndexOf(s) + 1);
+            if (newHalf != null)
+            {
+                RevealRowPosted(newHalf);
+            }
+        }
+
+        _updateAudioVisualizer = true;
     }
 
     [RelayCommand]

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -144,6 +144,7 @@ using Nikse.SubtitleEdit.Features.Tools.MergeSubtitlesWithSameTimeCodes;
 using Nikse.SubtitleEdit.Features.Tools.RemoveTextForHearingImpaired;
 using Nikse.SubtitleEdit.Features.Tools.Renumber;
 using Nikse.SubtitleEdit.Features.Tools.SortBy;
+using Nikse.SubtitleEdit.Features.Main.AssistedMove;
 using Nikse.SubtitleEdit.Features.Main.AssistedSplit;
 using Nikse.SubtitleEdit.Features.Tools.SplitBreakLongLines;
 using Nikse.SubtitleEdit.Features.Tools.SplitSubtitle;
@@ -16466,6 +16467,7 @@ public partial class MainViewModel :
         var candidates = AssistedSplitCandidateGenerator.Generate(s, language, _splitManager);
         if (candidates.Count == 0)
         {
+            ShowStatus(Se.Language.General.AssistedSplitNoSuggestions);
             return;
         }
 
@@ -16492,6 +16494,59 @@ public partial class MainViewModel :
             if (newHalf != null)
             {
                 RevealRowPosted(newHalf);
+            }
+        }
+
+        _updateAudioVisualizer = true;
+    }
+
+    [RelayCommand]
+    private async Task AssistedMove()
+    {
+        var s = SelectedSubtitle;
+        if (s == null || s.IsReferenceOnly)
+        {
+            return;
+        }
+
+        var idx = Subtitles.IndexOf(s);
+        var previous = GetPreviousWorkingRow(idx);
+        var next = GetNextWorkingRow(idx);
+        var candidates = AssistedMoveCandidateGenerator.Generate(s, previous, next, GetDetectedLanguageCode());
+        if (candidates.Count == 0)
+        {
+            ShowStatus(Se.Language.General.AssistedMoveNoSuggestions);
+            return;
+        }
+
+        var vm = await ShowDialogAsync<AssistedMoveWindow, AssistedMoveViewModel>(viewModel =>
+        {
+            viewModel.Initialize(s, candidates);
+        });
+
+        if (!vm.OkPressed || vm.SelectedCandidate == null)
+        {
+            return;
+        }
+
+        var candidate = vm.SelectedCandidate;
+        s.Text = candidate.NewCurrentText;
+        if (candidate.Kind == AssistedMoveKind.WithPrevious && previous != null)
+        {
+            previous.Text = candidate.NewOtherText;
+            if (candidate.NewFirstEnd != null && candidate.NewSecondStart != null)
+            {
+                previous.EndTime = candidate.NewFirstEnd.Value;
+                s.SetStartTimeOnly(candidate.NewSecondStart.Value);
+            }
+        }
+        else if (candidate.Kind == AssistedMoveKind.WithNext && next != null)
+        {
+            next.Text = candidate.NewOtherText;
+            if (candidate.NewFirstEnd != null && candidate.NewSecondStart != null)
+            {
+                s.EndTime = candidate.NewFirstEnd.Value;
+                next.SetStartTimeOnly(candidate.NewSecondStart.Value);
             }
         }
 

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -32,6 +32,9 @@ public class LanguageGeneral
     public string Apply { get; set; }
     public string ApplyTo { get; set; }
     public string Ascending { get; set; }
+    public string AssistedSplit { get; set; }
+    public string AssistedSplitChooseSplitPoint { get; set; }
+    public string AssistedSplitDotDotDot { get; set; }
     public string Descending { get; set; }
     public string AttachDotDotDot { get; set; }
     public string AudioFileSaved { get; set; }
@@ -571,8 +574,13 @@ public class LanguageGeneral
     public string SpeechToTextSelectedLinesPromptAlways { get; set; }
     public string SpeechToTextSelectedLinesPromptFirstTime { get; set; }
     public string Speed { get; set; }
+    public string SplitAtComma { get; set; }
+    public string SplitAtDialogDash { get; set; }
+    public string SplitAtLineBreak { get; set; }
+    public string SplitAtSentenceEnd { get; set; }
     public string SplitAtTextBoxCursorPosition { get; set; }
     public string SplitLine { get; set; }
+    public string SplitNearMiddle { get; set; }
     public string SplitLineAtTextBoxCursorPosition { get; set; }
     public string SplitLineAtVideoAndTextBoxPosition { get; set; }
     public string SplitLineAtVideoPosition { get; set; }
@@ -794,6 +802,9 @@ public class LanguageGeneral
         Apply = "Apply";
         ApplyTo = "Apply to";
         Ascending = "Ascending";
+        AssistedSplit = "Assisted split";
+        AssistedSplitChooseSplitPoint = "Click an option or press its number to split the line";
+        AssistedSplitDotDotDot = "Assisted split...";
         Descending = "Descending";
         AttachDotDotDot = "Attach...";
         AudioFileSaved = "Audio file saved";
@@ -1333,8 +1344,13 @@ public class LanguageGeneral
         SpeechToTextSelectedLinesPromptAlways = "Speech to text selected lines (always prompt engine/language)";
         SpeechToTextSelectedLines = "Speech to text selected (see Options - Settings)";
         Speed = "Speed";
+        SplitAtComma = "Split at comma";
+        SplitAtDialogDash = "Split at dialog dash";
+        SplitAtLineBreak = "Split at line break";
+        SplitAtSentenceEnd = "Split at end of sentence";
         SplitAtTextBoxCursorPosition = "Split at text cursor position";
         SplitLine = "Split line";
+        SplitNearMiddle = "Split at space nearest the middle";
         SplitLineAtTextBoxCursorPosition = "Split line at cursor position";
         SplitLineAtVideoAndTextBoxPosition = "Split line at video and text box position";
         SplitLineAtVideoPosition = "Split line at video position";

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -32,6 +32,11 @@ public class LanguageGeneral
     public string Apply { get; set; }
     public string ApplyTo { get; set; }
     public string Ascending { get; set; }
+    public string AssistedMove { get; set; }
+    public string AssistedMoveChooseMove { get; set; }
+    public string AssistedMoveDotDotDot { get; set; }
+    public string AssistedMoveNoSuggestions { get; set; }
+    public string AssistedSplitNoSuggestions { get; set; }
     public string AssistedSplit { get; set; }
     public string AssistedSplitChooseSplitPoint { get; set; }
     public string AssistedSplitDotDotDot { get; set; }
@@ -574,6 +579,14 @@ public class LanguageGeneral
     public string SpeechToTextSelectedLinesPromptAlways { get; set; }
     public string SpeechToTextSelectedLinesPromptFirstTime { get; set; }
     public string Speed { get; set; }
+    public string BalanceWithNextSubtitle { get; set; }
+    public string BalanceWithPreviousSubtitle { get; set; }
+    public string FetchLastWordFromPreviousSubtitle { get; set; }
+    public string FetchRestOfSentenceFromNextSubtitle { get; set; }
+    public string FetchUnfinishedSentenceFromPreviousSubtitle { get; set; }
+    public string MoveFirstWordToPreviousSubtitle { get; set; }
+    public string MoveRestOfSentenceToPreviousSubtitle { get; set; }
+    public string MoveUnfinishedSentenceToNextSubtitle { get; set; }
     public string SplitAtComma { get; set; }
     public string SplitAtDialogDash { get; set; }
     public string SplitAtLineBreak { get; set; }
@@ -802,6 +815,19 @@ public class LanguageGeneral
         Apply = "Apply";
         ApplyTo = "Apply to";
         Ascending = "Ascending";
+        AssistedMove = "Assisted move";
+        AssistedMoveChooseMove = "Click an option or press its number to move words";
+        AssistedMoveDotDotDot = "Assisted move...";
+        AssistedMoveNoSuggestions = "No move suggestions - the sentence does not continue into the previous/next subtitle";
+        AssistedSplitNoSuggestions = "No split suggestions for this line";
+        BalanceWithNextSubtitle = "Balance with next subtitle";
+        BalanceWithPreviousSubtitle = "Balance with previous subtitle";
+        FetchLastWordFromPreviousSubtitle = "Fetch last word from previous subtitle";
+        FetchRestOfSentenceFromNextSubtitle = "Fetch rest of sentence from next subtitle";
+        FetchUnfinishedSentenceFromPreviousSubtitle = "Fetch unfinished sentence from previous subtitle";
+        MoveFirstWordToPreviousSubtitle = "Move first word to previous subtitle";
+        MoveRestOfSentenceToPreviousSubtitle = "Move rest of sentence to previous subtitle";
+        MoveUnfinishedSentenceToNextSubtitle = "Move unfinished sentence to next subtitle";
         AssistedSplit = "Assisted split";
         AssistedSplitChooseSplitPoint = "Click an option or press its number to split the line";
         AssistedSplitDotDotDot = "Assisted split...";

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -250,6 +250,7 @@ public static class ShortcutsMain
         { nameof(MainViewModel.UnbreakCommand), Se.Language.General.Unbreak },
         { nameof(MainViewModel.AutoBreakCommand), Se.Language.General.AutoBreak },
         { nameof(MainViewModel.SplitCommand), Se.Language.General.SplitLine },
+        { nameof(MainViewModel.AssistedSplitCommand), Se.Language.General.AssistedSplit },
         { nameof(MainViewModel.SplitAtVideoPositionCommand), Se.Language.General.SplitLineAtVideoPosition },
         { nameof(MainViewModel.SplitAtTextBoxCursorPositionCommand), Se.Language.General.SplitAtTextBoxCursorPosition },
         { nameof(MainViewModel.SplitAtVideoPositionAndTextBoxCursorPositionCommand), Se.Language.General.SplitLineAtVideoAndTextBoxPosition },
@@ -621,6 +622,7 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.UnbreakNoSpaceCommand, nameof(vm.UnbreakNoSpaceCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.AutoBreakCommand, nameof(vm.AutoBreakCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.SplitCommand, nameof(vm.SplitCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.AssistedSplitCommand, nameof(vm.AssistedSplitCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.SplitAtVideoPositionCommand, nameof(vm.SplitAtVideoPositionCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.SplitAtTextBoxCursorPositionCommand, nameof(vm.SplitAtTextBoxCursorPositionCommand), ShortcutCategory.TextBox);
         AddShortcut(shortcuts, vm.SplitAtVideoPositionAndTextBoxCursorPositionCommand, nameof(vm.SplitAtVideoPositionAndTextBoxCursorPositionCommand), ShortcutCategory.General);

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -251,6 +251,7 @@ public static class ShortcutsMain
         { nameof(MainViewModel.AutoBreakCommand), Se.Language.General.AutoBreak },
         { nameof(MainViewModel.SplitCommand), Se.Language.General.SplitLine },
         { nameof(MainViewModel.AssistedSplitCommand), Se.Language.General.AssistedSplit },
+        { nameof(MainViewModel.AssistedMoveCommand), Se.Language.General.AssistedMove },
         { nameof(MainViewModel.SplitAtVideoPositionCommand), Se.Language.General.SplitLineAtVideoPosition },
         { nameof(MainViewModel.SplitAtTextBoxCursorPositionCommand), Se.Language.General.SplitAtTextBoxCursorPosition },
         { nameof(MainViewModel.SplitAtVideoPositionAndTextBoxCursorPositionCommand), Se.Language.General.SplitLineAtVideoAndTextBoxPosition },
@@ -623,6 +624,7 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.AutoBreakCommand, nameof(vm.AutoBreakCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.SplitCommand, nameof(vm.SplitCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.AssistedSplitCommand, nameof(vm.AssistedSplitCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.AssistedMoveCommand, nameof(vm.AssistedMoveCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.SplitAtVideoPositionCommand, nameof(vm.SplitAtVideoPositionCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.SplitAtTextBoxCursorPositionCommand, nameof(vm.SplitAtTextBoxCursorPositionCommand), ShortcutCategory.TextBox);
         AddShortcut(shortcuts, vm.SplitAtVideoPositionAndTextBoxCursorPositionCommand, nameof(vm.SplitAtVideoPositionAndTextBoxCursorPositionCommand), ShortcutCategory.General);

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -498,6 +498,25 @@ public static class UiUtil
         };
     }
 
+    /// <summary>
+    /// Gives a card-style button a green-ish background while hovered, focused or pressed,
+    /// so the active choice stands out (used by the assisted split/move option cards).
+    /// </summary>
+    public static Button WithGreenishActiveBackground(this Button button)
+    {
+        var activeBrush = new SolidColorBrush(Color.FromArgb(0x50, 0x4C, 0xAF, 0x50));
+        var pressedBrush = new SolidColorBrush(Color.FromArgb(0x78, 0x4C, 0xAF, 0x50));
+        foreach (var (pseudoClass, brush) in new[] { (":pointerover", activeBrush), (":focus", activeBrush), (":pressed", pressedBrush) })
+        {
+            button.Styles.Add(new Style(x => x.OfType<Button>().Class(pseudoClass).Template().OfType<ContentPresenter>())
+            {
+                Setters = { new Setter(ContentPresenter.BackgroundProperty, brush) },
+            });
+        }
+
+        return button;
+    }
+
     public static Button MakeButtonOk(IRelayCommand? command)
     {
         return MakeButton(Se.Language.General.Ok, command);


### PR DESCRIPTION
Implements the idea from #14195 discussion: instead of remembering shortcuts, two new windows offer the most sensible edits for the selected line as ranked one-click choices with full previews.

## Assisted split

- Up to 5 ranked split suggestions: **dialog dash**, **end of sentence**, **line break**, **comma**, **space nearest the middle**.
- Each option previews both resulting lines - text, time codes, character count and CPS - generated by running the real `SplitManager` on a copy, so continuation style, tag fix-up and the text-weighted time split are exactly what you get.
- Suggestions leaving an orphan dash-only line, or duplicating another option, are filtered out.

![sentence](https://raw.githubusercontent.com/SubtitleEdit/subtitleedit/claude/assisted-split-screenshots/assisted-split-1.png)

Dialog line - dialog dash ranked first, dashes removed in the halves:

![dialog](https://raw.githubusercontent.com/SubtitleEdit/subtitleedit/claude/assisted-split-screenshots/assisted-split-dialog.png)

After pressing "1" on the first example - times and text match the preview:

![after](https://raw.githubusercontent.com/SubtitleEdit/subtitleedit/claude/assisted-split-screenshots/after-split.png)

## Assisted move

Word and sentence-fragment moves between the selected line and its neighbours, or between its own two lines.

- **Context aware**: cross-subtitle options only appear where the sentence actually continues across that boundary. A line running on into the next gets only "with next" options; moves into a neighbour that starts a new sentence or a new dialog are not offered at all.
- **Options**: move the unfinished sentence across in one go (break early at a period), **balance** the two subtitles by moving as many words as needed, and single-word moves in both directions.
- **Auto-balanced lines**: both sides are unbroken and re-broken after the move, so a moved word does not leave a lopsided line behind (dialog texts keep their per-speaker lines).
- **The time moves with the text**: the outer start/end and the gap are preserved while the span between is divided proportionally to the new text lengths, so the retimed values shown in the preview are applied along with the text.

![assisted move](https://raw.githubusercontent.com/SubtitleEdit/subtitleedit/claude/assisted-split-screenshots/assisted-move.png)

## Shared

- Apply with a single click or by pressing the option number; Escape or the window close button cancels (no Cancel button).
- Green-ish background on the hovered/focused card; the card list scrolls when it outgrows the screen.
- A status bar message when there are no suggestions, instead of nothing happening.
- Both are in the subtitle grid context menu ("Assisted split..." / "Assisted move...") and assignable as shortcuts (no default bindings).

Note: the three assisted split images above are from an earlier iteration and still show a Cancel button, which has since been removed.

Covers the "logical split scenarios" and word/line move parts of #14195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
