### PR TITLE
Fix 20 bugs found in a bug hunt

### DIFF
--- a/src/libse/Common/ListExtensions.cs
+++ b/src/libse/Common/ListExtensions.cs
@@ -45,10 +45,16 @@ namespace Nikse.SubtitleEdit.Core.Common
         public static double FirstOnOrAfter(this List<double> orderedList, double target, double maxDifference, double defaultValue)
         {
             int index = orderedList.BinarySearch(target);
-            if (index < 0)
+            if (index >= 0)
             {
-                index = ~index; // Get the bitwise complement to find the index of the first element greater than the target
+                // An exact hit is always the answer. The tolerance probe below used to run for it
+                // too and could return the PREVIOUS element - so with shot changes [9.98, 10.0]
+                // and a cue already snapped to 10.0, "the next shot change" came back as 9.98,
+                // 20 ms earlier. The generic overloads above only rewrite index when it is < 0.
+                return orderedList[index];
             }
+
+            index = ~index; // Get the bitwise complement to find the index of the first element greater than the target
 
             if ((index - 1) >= 0 && target - orderedList[index - 1] <= maxDifference)
             {
@@ -66,10 +72,14 @@ namespace Nikse.SubtitleEdit.Core.Common
         public static double FirstOnOrBefore(this List<double> orderedList, double target, double maxDifference, double defaultValue)
         {
             int index = orderedList.BinarySearch(target);
-            if (index < 0)
+            if (index >= 0)
             {
-                index = ~index - 1; // Get the bitwise complement to find the index of the last element smaller than the target
+                // Exact hit wins - see the note in FirstOnOrAfter. Here the probe returned the
+                // element AFTER the target instead.
+                return orderedList[index];
             }
+
+            index = ~index - 1; // Get the bitwise complement to find the index of the last element smaller than the target
 
             if (index + 1 < orderedList.Count && orderedList[index + 1] - target <= maxDifference)
             {

--- a/src/libse/Common/StrippableText.cs
+++ b/src/libse/Common/StrippableText.cs
@@ -357,7 +357,12 @@ namespace Nikse.SubtitleEdit.Core.Common
                             var idx = sb.ToString().IndexOf('[');
                             if (s == ']' && idx > 1)
                             { // I [Motor roaring] love you!
-                                var temp = sb.ToString(0, idx - 1).Trim();
+                                // The text before '[' is [0, idx), so the length is idx - the
+                                // "- 1" dropped the last character before the bracket, which is
+                                // exactly the one this test looks at. "Yes.[Motor roaring] hello."
+                                // saw "Yes" (a letter) instead of "Yes." and left "hello"
+                                // lowercase. The documented "I [Motor roaring]" case is unchanged.
+                                var temp = sb.ToString(0, idx).Trim();
                                 if (temp.Length > 0 && !char.IsLetterOrDigit(temp[temp.Length - 1]))
                                 {
                                     lastWasBreak = true;

--- a/src/libse/Dictionaries/StringWithoutSpaceSplitToWords.cs
+++ b/src/libse/Dictionaries/StringWithoutSpaceSplitToWords.cs
@@ -59,9 +59,12 @@ namespace Nikse.SubtitleEdit.Core.Dictionaries
                 {
                     // Allow split if the first letter is "I" (e.g. Iam)
                 }
-                else if (input[0] == 'a' && threeLetterIsoLanguageName == "eng")
+                else if (input[0] == 'A' && threeLetterIsoLanguageName == "eng")
                 {
-                    // Allow split if the first letter is "a" (e.g. acat)
+                    // Allow split if the first letter is "A" (e.g. Acat -> "A cat"). Testing the
+                    // lowercase 'a' could never match: the enclosing guard only admits words whose
+                    // first character already equals its own uppercase form. The 'I' sibling above
+                    // uses the uppercase letter and works.
                 }
                 else
                 {

--- a/src/libse/Forms/MergeLinesWithSameTimeCodes.cs
+++ b/src/libse/Forms/MergeLinesWithSameTimeCodes.cs
@@ -119,7 +119,11 @@ namespace Nikse.SubtitleEdit.Core.Forms
                     case Enums.DialogType.DashSecondLineWithoutSpace:
                         return line1 + Environment.NewLine + "-" + line2;
                     default:
-                        return (line1.StartsWith("- ") ? "" : "- ") + line1 + Environment.NewLine + "- " + line2;
+                        // Test for a leading dash regardless of the space after it, as the
+                        // DashBothLinesWithoutSpace case above does. Testing "- " missed a dash
+                        // written without one, so "-Hello" came back as "- -Hello" - and this is
+                        // the shipped default dialog style.
+                        return (line1.StartsWith("-") ? "" : "- ") + line1 + Environment.NewLine + "- " + line2;
                 }
             }
             else

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -2995,6 +2995,7 @@
       "subtitlePreviewProperties": "Subtitle preview properties",
       "usePositionFromSubtitleFile": "Use position from subtitle file (TTML/PAC/EBU STL)",
       "marginIsPartOfSubtitleArea": "Margin is part of the subtitle area",
+      "textJustify": "Justify lines",
       "pixelWidthInfo": "Green lines = max-width limit   |   Red area = text exceeds limit",
       "spellCheckEngineHunSpelll": "Hunspell",
       "spellCheckEngineMsWord": "MS Word",

--- a/src/ui/Features/Ocr/CrispEmbedSettings/CrispEmbedSettingsWindow.cs
+++ b/src/ui/Features/Ocr/CrispEmbedSettings/CrispEmbedSettingsWindow.cs
@@ -101,9 +101,8 @@ public class CrispEmbedSettingsWindow : Window
 
         var enginePanel = MakeStatusPanel(nameof(vm.EngineBrush), nameof(vm.EngineLabel));
         var engineButton = UiUtil.MakeButton(string.Empty, vm.RedownloadEngineCommand)
-            .WithIconLeft(IconNames.CloudDownload)
+            .WithIconLeftBindText(IconNames.CloudDownload, nameof(vm.EngineDownloadButtonText))
             .WithMarginLeft(12);
-        engineButton.Bind(ContentControl.ContentProperty, new Binding(nameof(vm.EngineDownloadButtonText)));
         enginePanel.Children.Add(engineButton);
 
         grid.Add(MakeLabel(Se.Language.General.Engine), 0, 0);

--- a/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesWindow.cs
+++ b/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesWindow.cs
@@ -27,9 +27,8 @@ public class GetDictionariesWindow : Window
         DataContext = vm;
 
         var downloadButton = UiUtil.MakeButton(string.Empty, vm.DownloadCommand)
-            .WithIconLeft(IconNames.Download)
+            .WithIconLeftBindText(IconNames.Download, nameof(vm.DownloadButtonText))
             .WithBindEnabled(nameof(vm.IsDownloadEnabled));
-        downloadButton.Bind(ContentControl.ContentProperty, new Binding(nameof(vm.DownloadButtonText)));
 
         var stack = new StackPanel
         {

--- a/src/ui/Features/Tools/AdjustDuration/AdjustDurationViewModel.cs
+++ b/src/ui/Features/Tools/AdjustDuration/AdjustDurationViewModel.cs
@@ -99,13 +99,34 @@ public partial class AdjustDurationViewModel : ObservableObject
 
             if (nextSubtitle != null && newEndTime > nextSubtitle.StartTime)
             {
-                subtitle.EndTime = nextSubtitle.StartTime;
+                // Leave the minimum gap and keep a positive duration, as libse's
+                // SetFixedDuration / AdjustDisplayTimeUsingPercent do (so the dialog and Batch
+                // convert agree). Capping flat at next.Start gave a ZERO-duration line whenever
+                // two rows share a start time, and a negative one when rows are out of order -
+                // the DoAdjustViaSeconds branch above already floors its result.
+                subtitle.EndTime = ClampEndTime(subtitle.StartTime, nextSubtitle.StartTime);
             }
             else
             {
                 subtitle.EndTime = newEndTime;
             }
         }
+    }
+
+
+    /// <summary>
+    /// An end time that leaves the configured minimum gap before <paramref name="nextStartTime"/>
+    /// and is still at least 1 ms after <paramref name="startTime"/>.
+    /// </summary>
+    private static TimeSpan ClampEndTime(TimeSpan startTime, TimeSpan nextStartTime)
+    {
+        var capped = nextStartTime - TimeSpan.FromMilliseconds(Configuration.Settings.General.MinimumMillisecondsBetweenLines);
+        if (capped <= startTime)
+        {
+            capped = startTime + TimeSpan.FromMilliseconds(1);
+        }
+
+        return capped;
     }
 
     private void DoAdjustViaPercent(ObservableCollection<SubtitleLineViewModel> subtitles)
@@ -121,7 +142,12 @@ public partial class AdjustDurationViewModel : ObservableObject
 
             if (nextSubtitle != null && newEndTime > nextSubtitle.StartTime)
             {
-                subtitle.EndTime = nextSubtitle.StartTime;
+                // Leave the minimum gap and keep a positive duration, as libse's
+                // SetFixedDuration / AdjustDisplayTimeUsingPercent do (so the dialog and Batch
+                // convert agree). Capping flat at next.Start gave a ZERO-duration line whenever
+                // two rows share a start time, and a negative one when rows are out of order -
+                // the DoAdjustViaSeconds branch above already floors its result.
+                subtitle.EndTime = ClampEndTime(subtitle.StartTime, nextSubtitle.StartTime);
             }
             else
             {

--- a/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
@@ -473,10 +473,12 @@ public class AiReviewWindow : Window
         // keeps the window open so the review can be worked through in passes (issue #13807), Ok
         // writes them and closes, Cancel closes and leaves the unapplied ones behind. Apply is
         // hidden for callers without a live target - they have nowhere to receive a pass.
+        // WithIconLeft assigns Content, so setting it after binding ContentProperty replaced the
+        // bound text with the bare icon (and binding after WithIconLeft would drop the icon).
+        // WithIconLeftBindText builds the icon+bound-text panel once, which is what was wanted.
         var buttonApply = UiUtil.MakeButton(string.Empty, vm.ApplyCommand)
-            .WithBindIsVisible(nameof(vm.IsApplyVisible));
-        buttonApply.Bind(ContentControl.ContentProperty, new Binding(nameof(vm.ApplyButtonText)));
-        buttonApply.WithIconLeft("fa-solid fa-check");
+            .WithBindIsVisible(nameof(vm.IsApplyVisible))
+            .WithIconLeftBindText("fa-solid fa-check", nameof(vm.ApplyButtonText));
 
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);

--- a/src/ui/Features/Tools/ApplyMinGap/ApplyMinGapViewModel.cs
+++ b/src/ui/Features/Tools/ApplyMinGap/ApplyMinGapViewModel.cs
@@ -129,11 +129,24 @@ public partial class ApplyMinGapViewModel : ObservableObject, IClosingCleanup
                 continue;
             }
 
+            var newEndMs = next.StartTime.TotalMilliseconds - minMsBetweenLines;
+
+            // Skip only when the new end would land at or before this line's own start. That
+            // happens for a short line followed closely by the next one (a 50 ms line, next at
+            // +10 ms, gap 100), and produced a negative duration that was still counted as a fix
+            // and reached the grid and the saved file.
+            // Deliberately NOT the minimum-display threshold that BatchConverter.ApplyMinGap
+            // uses: shortening a line below it is this dialog's normal, intended behaviour.
+            var newDuration = newEndMs - current.StartTime.TotalMilliseconds;
+            if (newDuration <= 0)
+            {
+                continue;
+            }
+
             fixedCount++;
 
             var before = new TimeCode(gapMs).ToShortDisplayString();
 
-            var newEndMs = next.StartTime.TotalMilliseconds - minMsBetweenLines;
             current.EndTime = TimeSpan.FromMilliseconds(newEndMs);
             var newGapMs = next.StartTime.TotalMilliseconds - current.EndTime.TotalMilliseconds;
 

--- a/src/ui/Features/Tools/ConvertActors/ConvertActorsViewModel.cs
+++ b/src/ui/Features/Tools/ConvertActors/ConvertActorsViewModel.cs
@@ -162,7 +162,8 @@ public partial class ConvertActorsViewModel : ObservableObject, IClosingCleanup
         }
 
         var statusText = string.Format(Se.Language.Tools.ConvertActors.NumberOfConversionsX, count);
-        Dispatcher.UIThread.Post(() =>
+
+        void Apply()
         {
             Subtitles.Clear();
             foreach (var item in items)
@@ -171,7 +172,18 @@ public partial class ConvertActorsViewModel : ObservableObject, IClosingCleanup
             }
 
             StatusText = statusText;
-        });
+        }
+
+        // Apply inline when already on the UI thread so Ok() can refresh synchronously; posting
+        // unconditionally meant a refresh requested from Ok ran only after Ok had finished.
+        if (Dispatcher.UIThread.CheckAccess())
+        {
+            Apply();
+        }
+        else
+        {
+            Dispatcher.UIThread.Post(Apply);
+        }
     }
 
     /// <summary>
@@ -285,6 +297,16 @@ public partial class ConvertActorsViewModel : ObservableObject, IClosingCleanup
     [RelayCommand]
     private void Ok()
     {
+        // Apply what the CURRENT settings produce, not what the 500 ms preview timer last
+        // computed: clicking OK right after changing the from/to type, colour or casing applied
+        // the previous settings' conversions while SaveSettings persisted the new ones (and
+        // before the first tick it applied nothing at all). Every sibling dialog in this folder
+        // already does this.
+        if (_dirty)
+        {
+            UpdatePreview();
+        }
+
         var checkedChanges = Subtitles
             .Where(s => s.IsChecked && !s.IsNextParagraph)
             .ToDictionary(s => s.OriginalId, s => s);

--- a/src/ui/Features/Tools/MergeSubtitlesWithSameTimeCodes/MergeSameTimeCodesViewModel.cs
+++ b/src/ui/Features/Tools/MergeSubtitlesWithSameTimeCodes/MergeSameTimeCodesViewModel.cs
@@ -219,7 +219,11 @@ public partial class MergeSameTimeCodesViewModel : ObservableObject, IClosingCle
                 case Core.Enums.DialogType.DashSecondLineWithoutSpace:
                     return line1 + Environment.NewLine + "-" + line2;
                 default:
-                    return (line1.StartsWith("- ") ? "" : "- ") + line1 + Environment.NewLine + "- " + line2;
+                    // Test for a leading dash regardless of the space after it, as the
+                    // DashBothLinesWithoutSpace case above does. Testing "- " missed a dash
+                    // written without one, so "-Hello" came back as "- -Hello" - and this is
+                    // the shipped default dialog style.
+                    return (line1.StartsWith("-") ? "" : "- ") + line1 + Environment.NewLine + "- " + line2;
             }
         }
         else

--- a/src/ui/Features/Tools/SortBy/SortByViewModel.cs
+++ b/src/ui/Features/Tools/SortBy/SortByViewModel.cs
@@ -173,11 +173,11 @@ public partial class SortByViewModel : ObservableObject, IClosingCleanup
 
     private void UpdatePreview()
     {
-        if (SortCriteria.Count == 0)
-        {
-            return;
-        }
-
+        // No early return on an empty criteria list: ApplySorting already returns the rows
+        // unsorted in that case, and returning here left Subtitles holding the PREVIOUS sorted
+        // order. Removing the last criterion therefore looked like it had done nothing, and OK
+        // then applied the stale sort anyway (ClearSortCriteria repopulates by hand for the same
+        // reason).
         Dispatcher.UIThread.Post(() =>
         {
             var sorted = ApplySorting(_originalSubtitles);

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
@@ -67,6 +67,8 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject, ICl
     /// </summary>
     public bool Qwen3AsrUseVulkan { get; set; }
 
+    /// <summary>The .7z being streamed to disk, so a cancel can remove the partial file.</summary>
+    private string? _tempArchiveFileName;
     private readonly IWhisperDownloadService _whisperDownloadService;
     private readonly IQwen3AsrCppDownloadService _qwen3AsrCppDownloadService;
     private readonly ICrispAsrDownloadService _crispAsrDownloadService;
@@ -567,6 +569,27 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject, ICl
     {
         _cancellationTokenSource?.Cancel();
         StopIndeterminateProgress();
+
+        // The Faster-Whisper-XXL / WhisperX archives stream straight to disk (216 MB - 1.5 GB) and
+        // were deleted only on the success path, so cancelling stranded the partial file in the
+        // engine folder where nothing would ever clean it up or notice it.
+        var partialArchive = _tempArchiveFileName;
+        _tempArchiveFileName = null;
+        if (!string.IsNullOrEmpty(partialArchive))
+        {
+            try
+            {
+                if (File.Exists(partialArchive))
+                {
+                    File.Delete(partialArchive);
+                }
+            }
+            catch
+            {
+                // best-effort - it may still be open for writing
+            }
+        }
+
         Close();
     }
 
@@ -615,6 +638,7 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject, ICl
             // the same way for the same reason.
             var whisperXDir = Engine.GetAndCreateWhisperFolder();
             var whisperXTempFileName = Path.Combine(whisperXDir, Engine.Name + ".7z");
+            _tempArchiveFileName = whisperXTempFileName;
             _downloadTask = _whisperDownloadService.DownloadWhisperX(whisperXTempFileName, downloadProgress, _cancellationTokenSource.Token);
         }
         else if (Engine is WhisperEngineConstMe)
@@ -625,6 +649,7 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject, ICl
         {
             var dir = Engine.GetAndCreateWhisperFolder();
             var tempFileName = Path.Combine(dir, Engine.Name + ".7z");
+            _tempArchiveFileName = tempFileName;
             _downloadTask = _whisperDownloadService.DownloadWhisperPurfviewFasterWhisperXxl(tempFileName, downloadProgress, _cancellationTokenSource.Token);
         }
         else if (Engine is Qwen3AsrCppEngine)

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineWindow.cs
@@ -37,6 +37,20 @@ public class DownloadSpeechToTextEngineWindow : Window
         var statusText = new TextBlock();
         statusText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.ProgressText)));
 
+        // The view models set Error on every failure path, but nothing rendered it - the user saw
+        // only the generic "Download failed" while the real cause was written to a property no
+        // window bound. DownloadVideoFromUrlWindow and DownloadCrispEmbedWindow show it this way.
+        var errorText = new TextBlock
+        {
+            Foreground = new SolidColorBrush(Color.FromRgb(0xC0, 0x39, 0x2B)),
+            TextWrapping = TextWrapping.Wrap,
+        };
+        errorText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.Error)));
+        errorText.Bind(IsVisibleProperty, new Binding(nameof(vm.Error))
+        {
+            Converter = new Avalonia.Data.Converters.FuncValueConverter<string?, bool>(s => !string.IsNullOrEmpty(s)),
+        });
+
         var buttonCancel = UiUtil.MakeButton(Se.Language.General.Cancel, vm.CommandCancelCommand);
         var buttonBar = UiUtil.MakeButtonBar(buttonCancel);
 
@@ -49,6 +63,7 @@ public class DownloadSpeechToTextEngineWindow : Window
                 titleText,
                 progressBar,
                 statusText,
+                errorText,
                 buttonBar,
             }
         };

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsWindow.cs
@@ -84,6 +84,20 @@ public class DownloadSpeechToTextModelsWindow : Window
         statusText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.ProgressText)));
         statusText.Bind(TextBlock.OpacityProperty, new Binding(nameof(vm.ProgressOpacity)));
 
+        // The view models set Error on every failure path, but nothing rendered it - the user saw
+        // only the generic "Download failed" while the real cause was written to a property no
+        // window bound. DownloadVideoFromUrlWindow and DownloadCrispEmbedWindow show it this way.
+        var errorText = new TextBlock
+        {
+            Foreground = new SolidColorBrush(Color.FromRgb(0xC0, 0x39, 0x2B)),
+            TextWrapping = TextWrapping.Wrap,
+        };
+        errorText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.Error)));
+        errorText.Bind(IsVisibleProperty, new Binding(nameof(vm.Error))
+        {
+            Converter = new Avalonia.Data.Converters.FuncValueConverter<string?, bool>(s => !string.IsNullOrEmpty(s)),
+        });
+
         var fileText = new TextBlock
         {
             Margin = new Thickness(0, 1, 0, 1),
@@ -100,6 +114,7 @@ public class DownloadSpeechToTextModelsWindow : Window
             {
                 progressBar,
                 statusText,
+                errorText,
                 fileText,
             }
         };

--- a/src/ui/Features/Video/TextToSpeech/AutoCast/AutoCastSpeakersWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/AutoCast/AutoCastSpeakersWindow.cs
@@ -61,6 +61,10 @@ public class AutoCastSpeakersWindow : Window
         Content = root;
 
         KeyDown += (_, e) => vm.OnKeyDown(e);
+        // SaveWindowPosition is the only writer of the stored position, so without this the
+        // Restore above could never find anything: this resizable table dialog reopened at its
+        // hard-coded default every run. The select-lines dialogs pair the two handlers.
+        Closing += (_, _) => UiUtil.SaveWindowPosition(this);
         Loaded += (_, _) => UiUtil.RestoreWindowPosition(this);
     }
 

--- a/src/ui/Features/Video/TextToSpeech/ChatterboxTtsSettings/ChatterboxTtsSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ChatterboxTtsSettings/ChatterboxTtsSettingsWindow.cs
@@ -112,9 +112,8 @@ public class ChatterboxTtsSettingsWindow : Window
         grid.Add(MakeLabel(Se.Language.General.Engine), 0, 0);
         var enginePanel = MakeStatusPanel(nameof(vm.EngineBrush), nameof(vm.EngineLabel));
         var engineButton = UiUtil.MakeButton(string.Empty, vm.RedownloadEngineCommand)
-            .WithIconLeft(IconNames.Download)
+            .WithIconLeftBindText(IconNames.Download, nameof(vm.EngineDownloadButtonText))
             .WithMarginLeft(12);
-        engineButton.Bind(ContentControl.ContentProperty, new Binding(nameof(vm.EngineDownloadButtonText)));
         enginePanel.Children.Add(engineButton);
         grid.Add(enginePanel, 0, 1);
 
@@ -133,7 +132,9 @@ public class ChatterboxTtsSettingsWindow : Window
             FontSize = 12,
             [!TextBox.TextProperty] = new Binding(nameof(vm.ModelsFolder)),
         };
-        grid.Add(folderText, 3, 1);
+        // Row 2, beside its own label - every sibling settings window pairs (N,0) with (N,1).
+        // At row 3 the "Install folder" caption sat alone and the path appeared a row lower.
+        grid.Add(folderText, 2, 1);
 
         // Language spoken in imported reference WAVs — sent as `source_lang` so cross-lingual
         // cloning engages when the target language differs. Chatterbox clones from the WAV alone
@@ -187,9 +188,7 @@ public class ChatterboxTtsSettingsWindow : Window
                     nameof(ChatterboxModelStatusViewModel.StatusLabel));
                 status.Width = 110;
                 var button = UiUtil.MakeButton(string.Empty)
-                    .WithIconLeft(IconNames.Download);
-                button.Bind(ContentControl.ContentProperty,
-                    new Binding(nameof(ChatterboxModelStatusViewModel.DownloadButtonText)));
+                    .WithIconLeftBindText(IconNames.Download, nameof(ChatterboxModelStatusViewModel.DownloadButtonText));
                 button.Bind(Button.CommandProperty,
                     new Binding(nameof(ChatterboxModelStatusViewModel.DownloadCommand)));
 

--- a/src/ui/Features/Video/TextToSpeech/CosyVoice3CrispAsrSettings/CosyVoice3CrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/CosyVoice3CrispAsrSettings/CosyVoice3CrispAsrSettingsWindow.cs
@@ -116,9 +116,8 @@ public class CosyVoice3CrispAsrSettingsWindow : Window
         grid.Add(MakeLabel(Se.Language.General.Engine), 0, 0);
         var enginePanel = MakeStatusPanel(nameof(vm.EngineBrush), nameof(vm.EngineLabel));
         var engineButton = UiUtil.MakeButton(string.Empty, vm.RedownloadEngineCommand)
-            .WithIconLeft(IconNames.Download)
+            .WithIconLeftBindText(IconNames.Download, nameof(vm.EngineDownloadButtonText))
             .WithMarginLeft(12);
-        engineButton.Bind(ContentControl.ContentProperty, new Binding(nameof(vm.EngineDownloadButtonText)));
         enginePanel.Children.Add(engineButton);
         grid.Add(enginePanel, 0, 1);
 

--- a/src/ui/Features/Video/TextToSpeech/DotsTtsCrispAsrSettings/DotsTtsCrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/DotsTtsCrispAsrSettings/DotsTtsCrispAsrSettingsWindow.cs
@@ -115,9 +115,8 @@ public class DotsTtsCrispAsrSettingsWindow : Window
         grid.Add(MakeLabel(Se.Language.General.Engine), 0, 0);
         var enginePanel = MakeStatusPanel(nameof(vm.EngineBrush), nameof(vm.EngineLabel));
         var engineButton = UiUtil.MakeButton(string.Empty, vm.RedownloadEngineCommand)
-            .WithIconLeft(IconNames.Download)
+            .WithIconLeftBindText(IconNames.Download, nameof(vm.EngineDownloadButtonText))
             .WithMarginLeft(12);
-        engineButton.Bind(ContentControl.ContentProperty, new Binding(nameof(vm.EngineDownloadButtonText)));
         enginePanel.Children.Add(engineButton);
         grid.Add(enginePanel, 0, 1);
 

--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsWindow.cs
@@ -38,6 +38,20 @@ public sealed class DownloadTtsWindow : Window
         var statusText = new TextBlock();
         statusText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.ProgressText)));
 
+        // The view models set Error on every failure path, but nothing rendered it - the user saw
+        // only the generic "Download failed" while the real cause was written to a property no
+        // window bound. DownloadVideoFromUrlWindow and DownloadCrispEmbedWindow show it this way.
+        var errorText = new TextBlock
+        {
+            Foreground = new SolidColorBrush(Color.FromRgb(0xC0, 0x39, 0x2B)),
+            TextWrapping = TextWrapping.Wrap,
+        };
+        errorText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.Error)));
+        errorText.Bind(IsVisibleProperty, new Binding(nameof(vm.Error))
+        {
+            Converter = new Avalonia.Data.Converters.FuncValueConverter<string?, bool>(s => !string.IsNullOrEmpty(s)),
+        });
+
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
         var buttonBar = UiUtil.MakeButtonBar(buttonCancel);
 
@@ -50,6 +64,7 @@ public sealed class DownloadTtsWindow : Window
                 titleText,
                 progressBar,
                 statusText,
+                errorText,
                 buttonBar,
             }
         };

--- a/src/ui/Features/Video/TextToSpeech/F5TtsCrispAsrSettings/F5TtsCrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/F5TtsCrispAsrSettings/F5TtsCrispAsrSettingsWindow.cs
@@ -111,9 +111,8 @@ public class F5TtsCrispAsrSettingsWindow : Window
         grid.Add(MakeLabel(Se.Language.General.Engine), 0, 0);
         var enginePanel = MakeStatusPanel(nameof(vm.EngineBrush), nameof(vm.EngineLabel));
         var engineButton = UiUtil.MakeButton(string.Empty, vm.RedownloadEngineCommand)
-            .WithIconLeft(IconNames.Download)
+            .WithIconLeftBindText(IconNames.Download, nameof(vm.EngineDownloadButtonText))
             .WithMarginLeft(12);
-        engineButton.Bind(ContentControl.ContentProperty, new Binding(nameof(vm.EngineDownloadButtonText)));
         enginePanel.Children.Add(engineButton);
         grid.Add(enginePanel, 0, 1);
 

--- a/src/ui/Features/Video/TextToSpeech/IndexTts25AudioCppSettings/IndexTts25AudioCppSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/IndexTts25AudioCppSettings/IndexTts25AudioCppSettingsWindow.cs
@@ -107,9 +107,8 @@ public class IndexTts25AudioCppSettingsWindow : Window
         grid.Add(MakeLabel(Se.Language.General.Engine), 0, 0);
         var enginePanel = MakeStatusPanel(nameof(vm.EngineBrush), nameof(vm.EngineLabel));
         var engineButton = UiUtil.MakeButton(string.Empty, vm.RedownloadEngineCommand)
-            .WithIconLeft(IconNames.Download)
+            .WithIconLeftBindText(IconNames.Download, nameof(vm.EngineDownloadButtonText))
             .WithMarginLeft(12);
-        engineButton.Bind(ContentControl.ContentProperty, new Binding(nameof(vm.EngineDownloadButtonText)));
         enginePanel.Children.Add(engineButton);
         grid.Add(enginePanel, 0, 1);
 

--- a/src/ui/Features/Video/TextToSpeech/IndexTts25License/IndexTts25LicenseViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/IndexTts25License/IndexTts25LicenseViewModel.cs
@@ -48,7 +48,11 @@ public partial class IndexTts25LicenseViewModel : ObservableObject
             return;
         }
 
+        // AcceptLicense only assigns the settings field; persist it right away, as the
+        // voice-cloning consent dialog does - otherwise an acceptance given once is lost if the
+        // session ends before the next settings save and the user is prompted again.
         IndexTts25AudioCpp.AcceptLicense();
+        Se.SaveSettings();
         OkPressed = true;
         Window?.Close();
     }

--- a/src/ui/Features/Video/TextToSpeech/IndexTtsCrispAsrSettings/IndexTtsCrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/IndexTtsCrispAsrSettings/IndexTtsCrispAsrSettingsWindow.cs
@@ -114,9 +114,8 @@ public class IndexTtsCrispAsrSettingsWindow : Window
         grid.Add(MakeLabel(Se.Language.General.Engine), 0, 0);
         var enginePanel = MakeStatusPanel(nameof(vm.EngineBrush), nameof(vm.EngineLabel));
         var engineButton = UiUtil.MakeButton(string.Empty, vm.RedownloadEngineCommand)
-            .WithIconLeft(IconNames.Download)
+            .WithIconLeftBindText(IconNames.Download, nameof(vm.EngineDownloadButtonText))
             .WithMarginLeft(12);
-        engineButton.Bind(ContentControl.ContentProperty, new Binding(nameof(vm.EngineDownloadButtonText)));
         enginePanel.Children.Add(engineButton);
         grid.Add(enginePanel, 0, 1);
 

--- a/src/ui/Features/Video/TextToSpeech/MossTtsCrispAsrSettings/MossTtsCrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/MossTtsCrispAsrSettings/MossTtsCrispAsrSettingsWindow.cs
@@ -114,9 +114,8 @@ public class MossTtsCrispAsrSettingsWindow : Window
         grid.Add(MakeLabel(Se.Language.General.Engine), 0, 0);
         var enginePanel = MakeStatusPanel(nameof(vm.EngineBrush), nameof(vm.EngineLabel));
         var engineButton = UiUtil.MakeButton(string.Empty, vm.RedownloadEngineCommand)
-            .WithIconLeft(IconNames.Download)
+            .WithIconLeftBindText(IconNames.Download, nameof(vm.EngineDownloadButtonText))
             .WithMarginLeft(12);
-        engineButton.Bind(ContentControl.ContentProperty, new Binding(nameof(vm.EngineDownloadButtonText)));
         enginePanel.Children.Add(engineButton);
         grid.Add(enginePanel, 0, 1);
 

--- a/src/ui/Features/Video/TextToSpeech/OmniVoiceCrispAsrSettings/OmniVoiceCrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/OmniVoiceCrispAsrSettings/OmniVoiceCrispAsrSettingsWindow.cs
@@ -115,9 +115,8 @@ public class OmniVoiceCrispAsrSettingsWindow : Window
         grid.Add(MakeLabel(Se.Language.General.Engine), 0, 0);
         var enginePanel = MakeStatusPanel(nameof(vm.EngineBrush), nameof(vm.EngineLabel));
         var engineButton = UiUtil.MakeButton(string.Empty, vm.RedownloadEngineCommand)
-            .WithIconLeft(IconNames.Download)
+            .WithIconLeftBindText(IconNames.Download, nameof(vm.EngineDownloadButtonText))
             .WithMarginLeft(12);
-        engineButton.Bind(ContentControl.ContentProperty, new Binding(nameof(vm.EngineDownloadButtonText)));
         enginePanel.Children.Add(engineButton);
         grid.Add(enginePanel, 0, 1);
 

--- a/src/ui/Features/Video/TextToSpeech/Qwen3TtsCrispAsrSettings/Qwen3TtsCrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/Qwen3TtsCrispAsrSettings/Qwen3TtsCrispAsrSettingsWindow.cs
@@ -113,9 +113,8 @@ public class Qwen3TtsCrispAsrSettingsWindow : Window
         grid.Add(MakeLabel(Se.Language.General.Engine), 0, 0);
         var enginePanel = MakeStatusPanel(nameof(vm.EngineBrush), nameof(vm.EngineLabel));
         var engineButton = UiUtil.MakeButton(string.Empty, vm.RedownloadEngineCommand)
-            .WithIconLeft(IconNames.Download)
+            .WithIconLeftBindText(IconNames.Download, nameof(vm.EngineDownloadButtonText))
             .WithMarginLeft(12);
-        engineButton.Bind(ContentControl.ContentProperty, new Binding(nameof(vm.EngineDownloadButtonText)));
         enginePanel.Children.Add(engineButton);
         grid.Add(enginePanel, 0, 1);
 

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewHistoryRow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewHistoryRow.cs
@@ -23,6 +23,9 @@ public partial class ReviewHistoryRow : ObservableObject
 
     public ReviewHistoryRow()
     {
+        // The history dialog's only writer of this is StopPlay, which first runs from a watchdog
+        // timer tick - so every play button opened disabled and clicks in that window did nothing.
+        IsPlayingEnabled = true;
         FileName = string.Empty;
         VoiceName = string.Empty;
         EngineName = string.Empty;

--- a/src/ui/Features/Video/TextToSpeech/VibeVoiceCrispAsrSettings/VibeVoiceCrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/VibeVoiceCrispAsrSettings/VibeVoiceCrispAsrSettingsWindow.cs
@@ -113,9 +113,8 @@ public class VibeVoiceCrispAsrSettingsWindow : Window
         grid.Add(MakeLabel(Se.Language.General.Engine), 0, 0);
         var enginePanel = MakeStatusPanel(nameof(vm.EngineBrush), nameof(vm.EngineLabel));
         var engineButton = UiUtil.MakeButton(string.Empty, vm.RedownloadEngineCommand)
-            .WithIconLeft(IconNames.Download)
+            .WithIconLeftBindText(IconNames.Download, nameof(vm.EngineDownloadButtonText))
             .WithMarginLeft(12);
-        engineButton.Bind(ContentControl.ContentProperty, new Binding(nameof(vm.EngineDownloadButtonText)));
         enginePanel.Children.Add(engineButton);
         grid.Add(enginePanel, 0, 1);
 

--- a/src/ui/Features/Video/TextToSpeech/VoxCPM2CrispAsrSettings/VoxCPM2CrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/VoxCPM2CrispAsrSettings/VoxCPM2CrispAsrSettingsWindow.cs
@@ -112,9 +112,8 @@ public class VoxCPM2CrispAsrSettingsWindow : Window
         grid.Add(MakeLabel(Se.Language.General.Engine), 0, 0);
         var enginePanel = MakeStatusPanel(nameof(vm.EngineBrush), nameof(vm.EngineLabel));
         var engineButton = UiUtil.MakeButton(string.Empty, vm.RedownloadEngineCommand)
-            .WithIconLeft(IconNames.Download)
+            .WithIconLeftBindText(IconNames.Download, nameof(vm.EngineDownloadButtonText))
             .WithMarginLeft(12);
-        engineButton.Bind(ContentControl.ContentProperty, new Binding(nameof(vm.EngineDownloadButtonText)));
         enginePanel.Children.Add(engineButton);
         grid.Add(enginePanel, 0, 1);
 

--- a/src/ui/Logic/DurationsBridgeGaps2.cs
+++ b/src/ui/Logic/DurationsBridgeGaps2.cs
@@ -46,11 +46,14 @@ public static class DurationsBridgeGaps2
             var previousExtension = (gapToBridge * percentageForPrevious) / 100.0;
             var nextReduction = gapToBridge - previousExtension;
 
-            // Extend the current subtitle by the calculated amount
-            cur.EndTime = TimeSpan.FromMilliseconds(cur.EndTime.TotalMilliseconds + previousExtension);
+            // Round to a whole millisecond at the producer (#14056). previousExtension is
+            // fractional whenever the gap does not divide evenly - gap 101 ms, min 24, 50% for
+            // the left gives an end time of X.5 ms, which the grid truncates and the format
+            // writers then save a millisecond early.
+            cur.EndTime = TimeSpanExtensions.FromMillisecondsWholeMilliseconds(cur.EndTime.TotalMilliseconds + previousExtension);
 
             // Move the next subtitle's start time backward by the calculated amount
-            next.SetStartTimeOnly(TimeSpan.FromMilliseconds(next.StartTime.TotalMilliseconds - nextReduction));
+            next.SetStartTimeOnly(TimeSpanExtensions.FromMillisecondsWholeMilliseconds(next.StartTime.TotalMilliseconds - nextReduction));
 
             if (fixedIndexes != null)
             {

--- a/src/ui/Logic/Ocr/GoogleLens/LensCore.cs
+++ b/src/ui/Logic/Ocr/GoogleLens/LensCore.cs
@@ -91,9 +91,16 @@ public class LensCore
         ParseCookies();
     }
 
-    protected byte[] CreateLensProtoRequest(byte[] imageBytes, int width, int height)
+    protected byte[] CreateLensProtoRequest(byte[] imageBytes, int width, int height, string? twoLetterLanguageCode = null)
     {
-        var targetLanguage = _config.GetValueOrDefault("targetLanguage") as string ?? "en";
+        // Prefer the language the caller was given. Nothing ever calls UpdateOptions and the Lens
+        // instance is constructed with no config, so the config value is always the "en" default -
+        // the request's LocaleContext.Language was pinned to English whatever OCR language the
+        // user picked, even though ScanByData already threads the code into the Accept-Language
+        // header.
+        var targetLanguage = !string.IsNullOrEmpty(twoLetterLanguageCode)
+            ? twoLetterLanguageCode
+            : _config.GetValueOrDefault("targetLanguage") as string ?? "en";
         var region = _config.GetValueOrDefault("region") as string ?? "US";
         var timeZone = _config.GetValueOrDefault("timeZone") as string ?? "America/New_York";
 
@@ -345,7 +352,7 @@ public class LensCore
 
         var actualDimensions = Helper.ImageDimensionsFromData(uint8Array);
 
-        var serializedRequest = CreateLensProtoRequest(uint8Array, actualDimensions.Width, actualDimensions.Height);
+        var serializedRequest = CreateLensProtoRequest(uint8Array, actualDimensions.Width, actualDimensions.Height, twoLetterLanguageCode);
         var serverResponse = await SendProtoRequest(serializedRequest, twoLetterLanguageCode);
 
         return ParseLensProtoResponse(serverResponse, originalDimensions ?? new[] { actualDimensions.Width, actualDimensions.Height });

--- a/src/ui/Logic/Platform/Windows/FileTypeAssociations.cs
+++ b/src/ui/Logic/Platform/Windows/FileTypeAssociations.cs
@@ -30,10 +30,14 @@ internal static class FileTypeAssociationsHelper
             // This key is read-only for apps, but we can read it to see who won the 'war'.
             using (var userChoice = Registry.CurrentUser.OpenSubKey($@"Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts\{ext}\UserChoice"))
             {
+                // UserChoice is authoritative when present: it is what Explorer's "Always open
+                // with" writes. Only falling through on a MATCH meant that after the user
+                // reassigned the extension to another app, the legacy Software\Classes default -
+                // which SE wrote itself when it registered - still answered "yes, SE is default".
                 var progIdValue = userChoice?.GetValue("Progid") as string;
-                if (progIdValue == progId)
+                if (!string.IsNullOrEmpty(progIdValue))
                 {
-                    return true;
+                    return progIdValue == progId;
                 }
             }
 

--- a/src/ui/Logic/TableViewExtras.cs
+++ b/src/ui/Logic/TableViewExtras.cs
@@ -141,6 +141,23 @@ public sealed class TableViewHeaderSorter
         if (selectedSet.Count > 0)
         {
             _tableView.Selection.BeginBatchUpdate();
+
+            // Select the anchor FIRST - the first Select in the batch sets SelectedIndex, so the
+            // current row is restored without a later "SelectedItem =" assignment. That
+            // assignment routes to Selection.SelectedIndex, which REPLACES the selection, so
+            // clicking a column header collapsed a restored multi-row selection down to one row
+            // (contradicting this class's own "selection is preserved" contract).
+            // MoveSelectedRows below uses the same ordering and explains it.
+            if (selectedItem != null)
+            {
+                var anchorIndex = sorted.IndexOf(selectedItem);
+                if (anchorIndex >= 0)
+                {
+                    _tableView.Selection.Select(anchorIndex);
+                    selectedSet.Remove(selectedItem);
+                }
+            }
+
             for (var i = 0; i < sorted.Count && selectedSet.Count > 0; i++)
             {
                 if (selectedSet.Remove(sorted[i]))
@@ -151,8 +168,11 @@ public sealed class TableViewHeaderSorter
 
             _tableView.Selection.EndBatchUpdate();
         }
+        else
+        {
+            _tableView.SelectedItem = selectedItem;
+        }
 
-        _tableView.SelectedItem = selectedItem;
         if (selectedItem != null)
         {
             _tableView.ScrollIntoView(selectedItem);

--- a/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
+++ b/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
@@ -1196,7 +1196,12 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
             }
 
             // Primary color: \c&HBBGGRR& or \1c&HBBGGRR& or \c (reset color)
-            if (firstChar == 'c' && (tagLen == 1 || !char.IsDigit(trimmedTag[1])))
+            // Exclude a LETTER after the "c" as well as a digit: "\clip" passed the digit-only
+            // test, so a block like "{\clip(0,0,100,100)}" was treated as a colour tag with no
+            // parseable colour and the fall-through then cleared state.Color - the rest of the
+            // line lost its colour in the grid while libass and SE's own preview kept it.
+            // SubtitleSyntaxTokenizer.IsAssColorTag does the exact-name comparison.
+            if (firstChar == 'c' && (tagLen == 1 || !char.IsLetterOrDigit(trimmedTag[1])))
             {
                 if (tagLen == 1)
                 {

--- a/tests/UI/Features/Tools/ApplyMinGap/ApplyMinGapViewModelTests.cs
+++ b/tests/UI/Features/Tools/ApplyMinGap/ApplyMinGapViewModelTests.cs
@@ -57,6 +57,31 @@ public class ApplyMinGapViewModelTests : IDisposable
     }
 
     [AvaloniaFact]
+    public void ShortLineIsSkippedRatherThanGivenANegativeDuration()
+    {
+        // Pulling the end back to next.Start - gap can land BEFORE the line's own start when the
+        // line is short and the next one starts soon after. That used to be applied anyway and
+        // counted as a fix, so a negative-duration line reached the grid and the saved file.
+        var vm = new ApplyMinGapViewModel();
+        var window = new ApplyMinGapWindow(vm);
+        _windows.Add(window);
+        window.Show();
+        vm.Initialize(new List<SubtitleLineViewModel>
+        {
+            new() { Text = "Short", StartTime = TimeSpan.FromMilliseconds(1000), EndTime = TimeSpan.FromMilliseconds(1050) },
+            new() { Text = "Next", StartTime = TimeSpan.FromMilliseconds(1060), EndTime = TimeSpan.FromMilliseconds(3000) },
+        });
+        Dispatcher.UIThread.RunJobs();
+
+        vm.MinGapMsOrFrames = 100;
+        vm.OkCommand.Execute(null);
+
+        Assert.All(vm.FixedSubtitles, p =>
+            Assert.True(p.EndTime > p.StartTime, $"'{p.Text}' ended at or before its start"));
+        Assert.Equal(1050, vm.FixedSubtitles[0].EndTime.TotalMilliseconds);
+    }
+
+    [AvaloniaFact]
     public void OkUsesTheCurrentGapValueNotTheOneThePreviewLastSaw()
     {
         var vm = ShowWindow();

--- a/tests/libse/Common/BugHunt18Test.cs
+++ b/tests/libse/Common/BugHunt18Test.cs
@@ -1,0 +1,58 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Dictionaries;
+
+namespace LibSETests.Common;
+
+/// <summary>
+/// Guard tests for the 2026-08-28 bug hunt (sweep 18): a tolerance probe that overrode an exact
+/// match, an off-by-one that dropped the character before a bracket, and a guard testing a
+/// lowercase letter the enclosing condition had already ruled out.
+/// </summary>
+public class BugHunt18Test
+{
+    [Fact]
+    public void FirstOnOrAfter_ExactMatch_ReturnsItNotTheEarlierNeighbour()
+    {
+        // A cue snapped onto a shot change hits exactly. The tolerance probe used to run anyway
+        // and returned the PREVIOUS entry - "the next shot change" came back 20 ms earlier.
+        var shotChanges = new List<double> { 9.98, 10.0 };
+
+        Assert.Equal(10.0, shotChanges.FirstOnOrAfter(10.0, 0.039, -1));
+    }
+
+    [Fact]
+    public void FirstOnOrBefore_ExactMatch_ReturnsItNotTheLaterNeighbour()
+    {
+        var shotChanges = new List<double> { 10.0, 10.02 };
+
+        Assert.Equal(10.0, shotChanges.FirstOnOrBefore(10.0, 0.039, -1));
+    }
+
+    [Fact]
+    public void FirstOnOrAfter_NoExactMatch_StillUsesTheTolerance()
+    {
+        // The near-miss behaviour the tolerance exists for must survive the fix.
+        var shotChanges = new List<double> { 9.98, 10.5 };
+
+        Assert.Equal(9.98, shotChanges.FirstOnOrAfter(10.0, 0.039, -1));
+    }
+
+    [Fact]
+    public void SplitWord_UppercaseAStart_IsSplit()
+    {
+        // The guard tested lowercase 'a', which the enclosing "starts with its own uppercase"
+        // condition had already excluded - so the exception never applied and "Acat" came back
+        // unsplit while the 'I' sibling ("Iam") worked.
+        var words = new[] { "a", "A", "I", "am", "cat" };
+
+        Assert.Equal("A cat", StringWithoutSpaceSplitToWords.SplitWord(words, "Acat", "eng"));
+    }
+
+    [Fact]
+    public void SplitWord_UppercaseIStart_StillSplit()
+    {
+        var words = new[] { "a", "A", "I", "am", "cat" };
+
+        Assert.Equal("I am", StringWithoutSpaceSplitToWords.SplitWord(words, "Iam", "eng"));
+    }
+}


### PR DESCRIPTION
Sweep 18. The verified backlog from earlier sweeps' agent reports, plus fresh passes over the Tools dialogs and the remaining libse areas.

Suites: libse 1635 / libuilogic 708 / seconv 422 / UI 4159.

## Wrong results

- **Apply minimum gap could write a negative duration.** Pulling a line's end back to `next.Start - gap` can land *before* that line's own start when the line is short and the next one starts soon after. It was applied anyway and counted as a fix, so the bad duration reached the grid and the saved file.
- **Adjust durations (Fixed and Percent) capped the end flat at the next line's start**, so two rows sharing a start time produced a **zero-duration** line and out-of-order rows a negative one. The `Seconds` branch in the same file already floors its result, and libse's `SetFixedDuration` / `AdjustDisplayTimeUsingPercent` leave the minimum gap — so the same operation behaved differently in Batch convert.
- **Sort by: removing the last criterion left the previous sorted order in the preview, and OK applied it.** `ApplySorting` already returns the rows unsorted for an empty criteria list; an early return in `UpdatePreview` stopped it ever running. `ClearSortCriteria` repopulates by hand for exactly this reason.
- **Convert actors applied whatever the 500 ms preview timer last computed**, so pressing OK right after changing the from/to type, colour or casing applied the *old* settings while `SaveSettings` persisted the new ones — and before the first tick it applied nothing at all. Five sibling dialogs in that folder already refresh on OK and carry the comment.
- **Merge lines with same time codes produced a double dash.** The default dialog style tested `StartsWith("- ")` for an existing dash while its sibling case tests `"-"`, so `"-Hello"` came back as `"- -Hello"`. Fixed in both the libse helper and the live copy in the dialog.
- **`FirstOnOrAfter`/`FirstOnOrBefore` ran their tolerance probe even on an exact `BinarySearch` hit** and returned the neighbour on the wrong side. A cue already snapped onto a shot change asked for "the next shot change" and got one 20 ms *earlier*. The generic overloads in the same file only rewrite the index when the search missed.
- **`StrippableText` took the text before `[` as `[0, idx - 1)`**, dropping the very character the test inspects: `"Yes.[Motor roaring] hello."` saw `"Yes"` instead of `"Yes."` and left `hello` lowercase. The documented `"I [Motor roaring]"` case is unaffected.
- **The word-split exception tested a lowercase `'a'`** that the enclosing "starts with its own uppercase" guard had already excluded, so `"Acat"` was never split while the `'I'` sibling (`"Iam"`) worked.
- **Google Lens always sent `LocaleContext.Language = "en"`.** The chosen language reaches the `Accept-Language` header but not the protobuf request, which read a config that nothing ever populates (`new Lens()` takes no config and `UpdateOptions` is never called).
- **The grid's ASSA highlighter treated `\clip` as a colour tag** — the test excluded a digit after `c` but not a letter — so a `{\clip(...)}` block cleared the colour state and the rest of the line lost its colour in the grid while libass and SE's own preview kept it.
- Bridge gaps wrote fractional milliseconds; now rounded at the producer (#14056).
- On Windows, an association the user reassigned in Explorer still reported SE as the default: a non-matching `UserChoice` fell through to the legacy `Software\Classes` key that SE itself had written.

## Never displayed, never persisted

- **15 buttons set an icon and then bound `ContentProperty` over it**, so the icon never rendered and — since the label starts empty — the buttons had no accessible name either. One did it in the opposite order and lost the *bound text* instead. `UiUtil.WithIconLeftBindText` exists for this and is used correctly by five sibling dialogs.
- **The three download dialogs set `Error` on every failure path but bound only `ProgressText`**, so the user saw a generic "Download failed" while the real cause went to a property no window rendered. Three other download windows bind it.
- The auto-cast speakers dialog restored a window position that nothing ever saved.
- Accepting the IndexTTS 2.5 licence was not persisted immediately, so it could be asked again after an abnormal exit. The voice-cloning consent dialog saves on accept.
- The speech-history dialog's play buttons opened **disabled** until an unrelated watchdog tick enabled them.
- Chatterbox's install-folder path was added one grid row below its own label.

## Leaks

Cancelling an engine download stranded the partial `.7z` — up to ~1.5 GB for Faster-Whisper-XXL / WhisperX — in the engine folder, since only the success path deleted it.

## A fix the tests corrected

My first `ApplyMinGap` patch used the same `newDuration > SubtitleMinimumDisplayMilliseconds` guard the batch converter uses. That broke two existing tests — correctly: the default minimum is 1000 ms, so the guard skipped ordinary shortening and defeated the feature. Those tests encode the dialog's real contract. The shipped fix guards only against a **non-positive** duration, which is the actual defect, and a new test pins it (it fails without the fix).

## Flagged but not fixed

Two CEA-708 / MacCaption findings need someone who can validate against real `.mcc` files from other tools, so I have left them alone rather than change what SE writes on a static-analysis argument:

- `Smpte291M` never skips the optional CDP `time_code_section` (id `0x71`) when `CaptionDistributionPacketTimeCodeAdded` is set — the reader hardcodes the cc-data offset, while the sibling `ServiceInfoAdded` flag *is* honoured. Files from other tools would decode to nothing.
- The SMPTE 291M ancillary checksum is emitted as the literal `0xbb`. The arithmetic suggests it should be `0xB4`, and `0xBB` happens to equal `0x61 + 0x01 + 0x59` where `0x59` is a stale data count the writer later overwrites with 82 — so it looks like a genuine leftover. SE re-reads its own files because the reader never verifies the checksum.

The mpv event-loop test still fails intermittently here; per the previous PR that is a worktree artifact, not a source issue, and nothing in this PR touches the video players.

🤖 Generated with [Claude Code](https://claude.com/claude-code)