### PR TITLE
Export images: let justification follow the alignment tag (#14202)

### DIFF
--- a/docs/reference/command-line.md
+++ b/docs/reference/command-line.md
@@ -180,7 +180,7 @@ When rendering a text subtitle to an image-based target (Blu-Ray `sup`, VobSub, 
 | `--box-padding:<px>` | Box padding: one value for all sides, or `left,right,top,bottom` (default: `5,5,3,3`) |
 | `--line-spacing:<percent>` | Extra gap between lines as percent of line height (default: `0`) |
 | `--alignment:<pos>` | Screen position: `bottom-center` (default), `top-left`, `middle-right`, ... |
-| `--content-alignment:<align>` | Multi-line text justification: `left` \| `center` (default) \| `right` |
+| `--content-alignment:<align>` | Multi-line text justification: `left` \| `center` (default) \| `right` \| `from-alignment` (follow the `{\anX}` tag) |
 | `--bottom-top-margin:<px>` | Vertical screen-edge margin (default: 5% of height) |
 | `--left-right-margin:<px>` | Horizontal screen-edge margin (default: 5% of width) |
 

--- a/src/libuilogic/Export/ExportContentAlignment .cs
+++ b/src/libuilogic/Export/ExportContentAlignment .cs
@@ -5,4 +5,11 @@ public enum ExportContentAlignment
     Left,
     Center,
     Right,
+
+    /// <summary>
+    /// Justify each line the way the subtitle is placed in the frame - a "{\an1}" line is
+    /// left justified, an "{\an3}" line right justified, everything else centered. Added last
+    /// so the values already saved in profiles keep their meaning.
+    /// </summary>
+    FromAlignment,
 }

--- a/src/libuilogic/Export/ImageParameter.cs
+++ b/src/libuilogic/Export/ImageParameter.cs
@@ -89,6 +89,25 @@ public class ImageParameter
     public SKPoint? OverridePositionPoint =>
         OverridePosition.HasValue ? new SKPoint(OverridePosition.Value.X, OverridePosition.Value.Y) : null;
 
+    /// <summary>
+    /// <see cref="ContentAlignment"/> with <see cref="ExportContentAlignment.FromAlignment"/>
+    /// resolved against <see cref="Alignment"/> - the alignment the "{\anX}" tag of the line
+    /// already put on the parameter. Left/right placed subtitles then get left/right justified
+    /// lines instead of the one justification picked for the whole export (issue #14202).
+    /// </summary>
+    public ExportContentAlignment ResolvedContentAlignment => ContentAlignment switch
+    {
+        ExportContentAlignment.FromAlignment => Alignment switch
+        {
+            ExportAlignment.TopLeft or ExportAlignment.MiddleLeft or ExportAlignment.BottomLeft
+                => ExportContentAlignment.Left,
+            ExportAlignment.TopRight or ExportAlignment.MiddleRight or ExportAlignment.BottomRight
+                => ExportContentAlignment.Right,
+            _ => ExportContentAlignment.Center,
+        },
+        _ => ContentAlignment,
+    };
+
     public BluRayContentAlignment BluRayContentAlignment => Alignment switch
     {
         ExportAlignment.TopLeft => BluRayContentAlignment.TopLeft,

--- a/src/libuilogic/Export/ImageRenderer.cs
+++ b/src/libuilogic/Export/ImageRenderer.cs
@@ -330,9 +330,9 @@ public static class ImageRenderer
             {
                 var lineWidth = lineWidths[li];
                 float textX;
-                if (ip.ContentAlignment == ExportContentAlignment.Center)
+                if (ip.ResolvedContentAlignment == ExportContentAlignment.Center)
                     textX = padLeft + (maxLineWidth - lineWidth) / 2;
-                else if (ip.ContentAlignment == ExportContentAlignment.Right)
+                else if (ip.ResolvedContentAlignment == ExportContentAlignment.Right)
                     textX = padLeft + maxLineWidth - lineWidth;
                 else
                     textX = padLeft;
@@ -412,11 +412,11 @@ public static class ImageRenderer
             // This keeps all lines within [textStartX, textStartX + maxLineWidth].
             if (ip.IsRightToLeft)
             {
-                if (ip.ContentAlignment == ExportContentAlignment.Center)
+                if (ip.ResolvedContentAlignment == ExportContentAlignment.Center)
                 {
                     currentX = textStartX + (maxLineWidth - lineWidth) / 2;
                 }
-                else if (ip.ContentAlignment == ExportContentAlignment.Left)
+                else if (ip.ResolvedContentAlignment == ExportContentAlignment.Left)
                 {
                     currentX = textStartX + maxLineWidth - lineWidth;
                 }
@@ -427,11 +427,11 @@ public static class ImageRenderer
             }
             else
             {
-                if (ip.ContentAlignment == ExportContentAlignment.Center)
+                if (ip.ResolvedContentAlignment == ExportContentAlignment.Center)
                 {
                     currentX = textStartX + (maxLineWidth - lineWidth) / 2;
                 }
-                else if (ip.ContentAlignment == ExportContentAlignment.Right)
+                else if (ip.ResolvedContentAlignment == ExportContentAlignment.Right)
                 {
                     currentX = textStartX + maxLineWidth - lineWidth;
                 }
@@ -600,12 +600,12 @@ public static class ImageRenderer
             var lineWidth = lineWidths[li];
 
             float currentX;
-            if (ip.ContentAlignment == ExportContentAlignment.Center)
+            if (ip.ResolvedContentAlignment == ExportContentAlignment.Center)
             {
                 currentX = textStartX + (maxLineWidth - lineWidth) / 2;
             }
-            else if ((ip.ContentAlignment == ExportContentAlignment.Right && !ip.IsRightToLeft) ||
-                     (ip.ContentAlignment == ExportContentAlignment.Left && ip.IsRightToLeft))
+            else if ((ip.ResolvedContentAlignment == ExportContentAlignment.Right && !ip.IsRightToLeft) ||
+                     (ip.ResolvedContentAlignment == ExportContentAlignment.Left && ip.IsRightToLeft))
             {
                 currentX = textStartX + maxLineWidth - lineWidth;
             }
@@ -724,12 +724,12 @@ public static class ImageRenderer
         {
             var lineWidth = lineWidths[li];
             float lineLeft;
-            if (ip.ContentAlignment == ExportContentAlignment.Center)
+            if (ip.ResolvedContentAlignment == ExportContentAlignment.Center)
             {
                 lineLeft = textStartX + (maxLineWidth - lineWidth) / 2;
             }
-            else if ((ip.ContentAlignment == ExportContentAlignment.Right && !ip.IsRightToLeft) ||
-                     (ip.ContentAlignment == ExportContentAlignment.Left && ip.IsRightToLeft))
+            else if ((ip.ResolvedContentAlignment == ExportContentAlignment.Right && !ip.IsRightToLeft) ||
+                     (ip.ResolvedContentAlignment == ExportContentAlignment.Left && ip.IsRightToLeft))
             {
                 lineLeft = textStartX + maxLineWidth - lineWidth;
             }

--- a/src/seconv/Commands/ConvertCommand.cs
+++ b/src/seconv/Commands/ConvertCommand.cs
@@ -266,7 +266,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
         public string? Alignment { get; init; }
 
         [CommandOption("--content-alignment|--contentalignment")]
-        [Description("Image output: multi-line text justification: left | center (default) | right")]
+        [Description("Image output: multi-line text justification: left | center (default) | right | from-alignment")]
         public string? ContentAlignment { get; init; }
 
         [CommandOption("--bottom-top-margin|--bottomtopmargin")]
@@ -1143,7 +1143,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
         {
             if (!ImageExportStyle.TryParseContentAlignment(settings.ContentAlignment, out var contentAlignment))
             {
-                return $"Unknown content alignment '{settings.ContentAlignment}' for --content-alignment. Use: left, center, or right.";
+                return $"Unknown content alignment '{settings.ContentAlignment}' for --content-alignment. Use: left, center, right, or from-alignment.";
             }
             style.ContentAlignment = contentAlignment;
         }

--- a/src/seconv/Helpers/CliSchema.cs
+++ b/src/seconv/Helpers/CliSchema.cs
@@ -46,7 +46,7 @@ internal static class CliSchema
         ["--ocr-engine"] = ["tesseract", "nocr", "binaryocr", "ollama", "llamacpp", "paddle"],
         ["--translate-engine"] = ["llamacpp", "ollama", "lmstudio", "libretranslate", "nllb-serve", "nllb-api"],
         ["--box-type"] = ["none", "one-box", "box-per-line"],
-        ["--content-alignment"] = ["left", "center", "right"],
+        ["--content-alignment"] = ["left", "center", "right", "from-alignment"],
         ["--alignment"] =
         [
             "top-left", "top-center", "top-right",

--- a/src/seconv/Helpers/HelpDisplay.cs
+++ b/src/seconv/Helpers/HelpDisplay.cs
@@ -106,7 +106,7 @@ internal static class HelpDisplay
         ShowParameter(console, "--box-padding:<px>", "Box padding in pixels; one value for all sides or left,right,top,bottom (default: 5,5,3,3)");
         ShowParameter(console, "--line-spacing:<percent>", "Extra gap between lines as percent of line height (default: 0)");
         ShowParameter(console, "--alignment:<position>", "Screen position, e.g. bottom-center (default), top-left, middle-right");
-        ShowParameter(console, "--content-alignment:<mode>", "Multi-line text justification: left | center (default) | right");
+        ShowParameter(console, "--content-alignment:<mode>", "Multi-line text justification: left | center (default) | right | from-alignment");
         ShowParameter(console, "--bottom-top-margin:<px>", "Vertical screen-edge margin in pixels (default: 5% of height)");
         ShowParameter(console, "--left-right-margin:<px>", "Horizontal screen-edge margin in pixels (default: 5% of width)");
 

--- a/src/ui/Features/Files/ExportImageBased/ExportContentAlignmentDisplay.cs
+++ b/src/ui/Features/Files/ExportImageBased/ExportContentAlignmentDisplay.cs
@@ -26,6 +26,7 @@ public class ExportContentAlignmentDisplay
             new ExportContentAlignmentDisplay(ExportContentAlignment.Left, "Left"),
             new ExportContentAlignmentDisplay(ExportContentAlignment.Center, "Center"),
             new ExportContentAlignmentDisplay(ExportContentAlignment.Right, "Right"),
+            new ExportContentAlignmentDisplay(ExportContentAlignment.FromAlignment, "From alignment"),
         };
     }
 }

--- a/src/ui/Features/Files/ExportImageBased/ExportImageBasedWindow.cs
+++ b/src/ui/Features/Files/ExportImageBased/ExportImageBasedWindow.cs
@@ -561,7 +561,9 @@ public class ExportImageBasedWindow : Window
 
         var statusText = new TextBlock
         {
-            Margin = new Thickness(5, 20, 0, 0),
+            // The bar and the text shared one grid cell, with this top margin as the only
+            // thing keeping them apart - so they ended up touching. Own row, own breathing room.
+            Margin = new Thickness(5, 8, 0, 0),
         };
         statusText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.ProgressText)));
         statusText.Bind(TextBlock.IsVisibleProperty, new Binding(nameof(vm.IsGenerating)));
@@ -570,7 +572,8 @@ public class ExportImageBasedWindow : Window
         {
             RowDefinitions =
             {
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
             {
@@ -581,7 +584,7 @@ public class ExportImageBasedWindow : Window
         };
 
         grid.Add(progressBar, 0, 0);
-        grid.Add(statusText, 0, 0);
+        grid.Add(statusText, 1, 0);
 
         return grid;
     }

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -1929,7 +1929,9 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
                 // "{\an8}" & co. were stripped from the text but not honored, so top-positioned
                 // lines silently ended up at the bottom (issue #13025).
                 Alignment = ExportTextTags.GetAlignment(subtitle.Text, ExportAlignment.BottomCenter),
-                ContentAlignment = ExportContentAlignment.Center,
+                // Everything else here follows the export-images profile, so the justification
+                // has to as well - it was hardcoded, ignoring what the dialog had saved.
+                ContentAlignment = profile.ContentAlignment,
                 PaddingLeftRight = profile.PaddingLeftRight,
                 PaddingTopBottom = profile.PaddingTopBottom,
                 Index = i,

--- a/tests/libuilogic/Export/ExportContentAlignmentFromAlignmentTests.cs
+++ b/tests/libuilogic/Export/ExportContentAlignmentFromAlignmentTests.cs
@@ -1,0 +1,120 @@
+using Nikse.SubtitleEdit.UiLogic.Export;
+using SkiaSharp;
+
+namespace LibUiLogicTests.Export;
+
+/// <summary>
+/// "Content alignment: From alignment" (issue #14202) - the justification of the lines inside
+/// the subtitle follows the "{\anX}" tag that already decides where the subtitle is placed, so
+/// a left placed cue gets left justified lines instead of the one justification picked for the
+/// whole export.
+/// </summary>
+public class ExportContentAlignmentFromAlignmentTests
+{
+    [Theory]
+    [InlineData(ExportAlignment.TopLeft, ExportContentAlignment.Left)]
+    [InlineData(ExportAlignment.MiddleLeft, ExportContentAlignment.Left)]
+    [InlineData(ExportAlignment.BottomLeft, ExportContentAlignment.Left)]
+    [InlineData(ExportAlignment.TopRight, ExportContentAlignment.Right)]
+    [InlineData(ExportAlignment.MiddleRight, ExportContentAlignment.Right)]
+    [InlineData(ExportAlignment.BottomRight, ExportContentAlignment.Right)]
+    [InlineData(ExportAlignment.TopCenter, ExportContentAlignment.Center)]
+    [InlineData(ExportAlignment.MiddleCenter, ExportContentAlignment.Center)]
+    [InlineData(ExportAlignment.BottomCenter, ExportContentAlignment.Center)]
+    public void ResolvedContentAlignment_FollowsAlignment(ExportAlignment alignment, ExportContentAlignment expected)
+    {
+        var param = new ImageParameter
+        {
+            Alignment = alignment,
+            ContentAlignment = ExportContentAlignment.FromAlignment,
+        };
+
+        Assert.Equal(expected, param.ResolvedContentAlignment);
+    }
+
+    [Theory]
+    [InlineData(ExportContentAlignment.Left)]
+    [InlineData(ExportContentAlignment.Center)]
+    [InlineData(ExportContentAlignment.Right)]
+    public void ResolvedContentAlignment_PassesAnExplicitChoiceThrough(ExportContentAlignment contentAlignment)
+    {
+        // A picked justification still wins over the placement, whatever the "{\anX}" tag said.
+        var param = new ImageParameter
+        {
+            Alignment = ExportAlignment.BottomLeft,
+            ContentAlignment = contentAlignment,
+        };
+
+        Assert.Equal(contentAlignment, param.ResolvedContentAlignment);
+    }
+
+    [Theory]
+    [InlineData(ExportAlignment.BottomLeft, ExportContentAlignment.Left)]
+    [InlineData(ExportAlignment.BottomRight, ExportContentAlignment.Right)]
+    [InlineData(ExportAlignment.BottomCenter, ExportContentAlignment.Center)]
+    public void Render_FromAlignment_MatchesTheEquivalentExplicitJustification(
+        ExportAlignment alignment, ExportContentAlignment equivalent)
+    {
+        using var fromAlignment = ImageRenderer.GenerateBitmap(
+            MakeParameter(alignment, ExportContentAlignment.FromAlignment));
+        using var explicitChoice = ImageRenderer.GenerateBitmap(MakeParameter(alignment, equivalent));
+
+        Assert.True(PixelsEqual(fromAlignment, explicitChoice));
+    }
+
+    [Fact]
+    public void Render_FromAlignment_DiffersFromTheGlobalJustification()
+    {
+        // The point of the option: a left placed cue no longer renders centered.
+        using var fromAlignment = ImageRenderer.GenerateBitmap(
+            MakeParameter(ExportAlignment.BottomLeft, ExportContentAlignment.FromAlignment));
+        using var centered = ImageRenderer.GenerateBitmap(
+            MakeParameter(ExportAlignment.BottomLeft, ExportContentAlignment.Center));
+
+        Assert.False(PixelsEqual(fromAlignment, centered));
+    }
+
+    /// <summary>
+    /// Two lines of clearly different width - with one line every justification renders the
+    /// same bitmap, so the test would pass without the feature.
+    /// </summary>
+    private static ImageParameter MakeParameter(ExportAlignment alignment, ExportContentAlignment contentAlignment)
+    {
+        return new ImageParameter
+        {
+            Text = "A much longer first line" + Environment.NewLine + "Short",
+            FontName = "Arial",
+            FontSize = 40,
+            FontColor = SKColors.White,
+            OutlineColor = SKColors.Black,
+            OutlineWidth = 2,
+            ShadowColor = SKColors.Black,
+            ShadowWidth = 2,
+            ScreenWidth = 1920,
+            ScreenHeight = 1080,
+            Alignment = alignment,
+            ContentAlignment = contentAlignment,
+        };
+    }
+
+    private static bool PixelsEqual(SKBitmap a, SKBitmap b)
+    {
+        if (a.Width != b.Width || a.Height != b.Height)
+        {
+            return false;
+        }
+
+        for (var y = 0; y < a.Height; y++)
+        {
+            for (var x = 0; x < a.Width; x++)
+            {
+                if (a.GetPixel(x, y) != b.GetPixel(x, y))
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
Fixes #14202.

`{\anX}` already decided **where** a subtitle is placed in the frame, but the **justification** of its lines was whatever single value the export dialog was set to. With full frame images that is very visible: a left aligned cue is moved to the left of the frame, and its lines are still centered relative to each other.

### What changed

A fourth content alignment, **From alignment**:

| Placement from the tag | Justification |
|---|---|
| `{\an1}` / `{\an4}` / `{\an7}` (left) | left |
| `{\an3}` / `{\an6}` / `{\an9}` (right) | right |
| everything else | center |

The three explicit choices are unchanged and still override the tag, so nothing moves for existing users — the new value is appended to `ExportContentAlignment`, so profiles already saved keep their meaning.

Resolution lives on `ImageParameter.ResolvedContentAlignment`, which `ImageRenderer` now reads. That means it applies to every image export, not only Final Cut Pro + image: Blu-ray sup, VobSub, BDN XML and the rest, full frame or cropped.

Available in the export dialog, in batch convert, and as `--content-alignment:from-alignment` in `seconv`.

### Two things noticed alongside

- Batch convert followed the export-images profile for every setting **except** content alignment, which was hardcoded to center. It uses the profile now.
- The export progress bar and its status text shared one grid cell, kept apart only by a 20 px top margin on the text — with a 10 px bar centered in the row they overlapped by a few pixels. They get a row each.

### Tests

`tests/libuilogic/Export/ExportContentAlignmentFromAlignmentTests.cs` — all nine alignments resolve as expected, explicit choices pass through, and rendered bitmaps for "From alignment" match the equivalent explicit justification while differing from the global one.

Full solution suite run: the only failures are the ones already failing on `main` (menu/focus/grid UI tests, `NOcrTrainerTests`, `ProcessExtensionsDrainTests`), verified against a clean `main` worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
