### PR TITLE
Fix Netflix checks measuring frames at the wrong rate, and two number-rule defects

### DIFF
--- a/src/ui/Logic/NetflixQualityCheck/NetflixCheckBridgeGaps.cs
+++ b/src/ui/Logic/NetflixQualityCheck/NetflixCheckBridgeGaps.cs
@@ -38,7 +38,10 @@ public class NetflixCheckBridgeGaps : INetflixQualityChecker
                 continue;
             }
 
-            var gapInFrames = SubtitleFormat.MillisecondsToFrames(next.StartTime.TotalMilliseconds - p.EndTime.TotalMilliseconds);
+            // Measured at the video's frame rate, like the two bounds it is compared against.
+            // With the app's CurrentFrameRate instead, a 470 ms gap on a 23.976 video read as
+            // 12 frames rather than 11 and fell outside the bridge range entirely.
+            var gapInFrames = SubtitleFormat.MillisecondsToFrames(next.StartTime.TotalMilliseconds - p.EndTime.TotalMilliseconds, controller.FrameRate);
             if (gapInFrames > 2 && gapInFrames < halfSecGap && !p.StartTime.IsMaxTime)
             {
                 var fixedParagraph = new Paragraph(p, false) { EndTime = { TotalMilliseconds = next.StartTime.TotalMilliseconds - twoFramesGap } };

--- a/src/ui/Logic/NetflixQualityCheck/NetflixCheckNumbersOneToTenSpellOut.cs
+++ b/src/ui/Logic/NetflixQualityCheck/NetflixCheckNumbersOneToTenSpellOut.cs
@@ -13,10 +13,6 @@ public class NetflixCheckNumbersOneToTenSpellOut : INetflixQualityChecker
     private static readonly Regex NumberOneToNine = new Regex(@"\b\d\b", RegexOptions.Compiled);
     private static readonly Regex NumberTen = new Regex(@"\b10\b", RegexOptions.Compiled);
 
-    // Was constructed inside the per-match loop below, so every "3," in the file paid for a
-    // fresh Regex parse. Compiled once here instead.
-    private static readonly Regex CommaDigit = new Regex(@",\d", RegexOptions.Compiled);
-
     public string Name { get; set; }
 
     public NetflixCheckNumbersOneToTenSpellOut(string name)
@@ -37,31 +33,7 @@ public class NetflixCheckNumbersOneToTenSpellOut : INetflixQualityChecker
             var m = NumberOneToNine.Match(newText);
             while (m.Success)
             {
-                bool ok = newText.Length <= m.Index + 1 || newText.Length > m.Index + 1 && !IsColonOrPeriod(newText[m.Index + 1]);
-                if (!ok && newText.Length > m.Index + 1)
-                {
-                    var rest = newText.Substring(m.Index + m.Length);
-                    if (rest == "." || rest == "?" || rest == "!" ||
-                        rest == ".</i>" || rest == "?</i>" || rest == "!</i>" ||
-                        rest == "." + Environment.NewLine || rest == "?" + Environment.NewLine || rest == "!" + Environment.NewLine ||
-                        rest == ".</i>" + Environment.NewLine || rest == "?</i>" + Environment.NewLine || rest == "!</i>" + Environment.NewLine)
-                    {
-                        ok = true;
-                    }
-                }
-
-                if (ok && m.Index + m.Length < newText.Length && newText[m.Index + m.Length] == ',')
-                {
-                    if (CommaDigit.IsMatch(newText, m.Index + 1))
-                    {
-                        ok = false;
-                    }
-                }
-
-                if (ok && m.Index > 0 && IsColonOrPeriod(newText[m.Index - 1]))
-                {
-                    ok = false;
-                }
+                var ok = ShouldSpellOut(newText, m.Index, m.Length);
 
                 if (ok)
                 {
@@ -74,11 +46,7 @@ public class NetflixCheckNumbersOneToTenSpellOut : INetflixQualityChecker
             m = NumberTen.Match(newText);
             while (m.Success)
             {
-                bool ok = newText.Length <= m.Index + 2 || newText.Length > m.Index + 2 && newText[m.Index + 2] != ':';
-                if (ok && m.Index > 0 && IsColonOrPeriod(newText[m.Index - 1]))
-                {
-                    ok = false;
-                }
+                var ok = ShouldSpellOut(newText, m.Index, m.Length);
 
                 if (ok)
                 {
@@ -95,6 +63,57 @@ public class NetflixCheckNumbersOneToTenSpellOut : INetflixQualityChecker
                 controller.AddRecord(p, fixedParagraph, comment, string.Empty, true);
             }
         }
+    }
+
+    /// <summary>
+    /// Whether the number matched at <paramref name="index"/> should be written out. Shared by
+    /// both loops above: the 1-9 pass and the 10 pass used to make this decision separately, and
+    /// the 10 pass only ever looked for a colon - so "Chapter 10. Introduction" became
+    /// "Chapter ten. Introduction" while "Chapter 3. Introduction" was correctly left alone.
+    /// </summary>
+    private static bool ShouldSpellOut(string text, int index, int length)
+    {
+        var after = index + length;
+
+        // A ':' or '.' next to the number means a time code, a decimal or a numbered heading -
+        // unless the number ends the sentence, where the period belongs to the sentence.
+        var ok = after >= text.Length || !IsColonOrPeriod(text[after]);
+        if (!ok && IsSentenceEnding(text.Substring(after)))
+        {
+            ok = true;
+        }
+
+        // A comma followed by a digit is a thousands separator ("1,000"). Only the character
+        // right after THIS comma decides that: the old test searched the whole rest of the line
+        // for ",<digit>", so a later "4,000" stopped an earlier "3," being written out.
+        if (ok && after < text.Length && text[after] == ',' &&
+            after + 1 < text.Length && char.IsDigit(text[after + 1]))
+        {
+            ok = false;
+        }
+
+        if (ok && index > 0 && IsColonOrPeriod(text[index - 1]))
+        {
+            ok = false;
+        }
+
+        return ok;
+    }
+
+    private static bool IsSentenceEnding(string rest)
+    {
+        foreach (var ending in new[] { ".", "?", "!" })
+        {
+            if (rest == ending ||
+                rest == ending + "</i>" ||
+                rest == ending + Environment.NewLine ||
+                rest == ending + "</i>" + Environment.NewLine)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/ui/Logic/NetflixQualityCheck/NetflixCheckShotChange.cs
+++ b/src/ui/Logic/NetflixQualityCheck/NetflixCheckShotChange.cs
@@ -40,6 +40,11 @@ public class NetflixCheckShotChange : INetflixQualityChecker
             shotChanges = shotChanges.Select(sc => Math.Round(sc /= 1.001, 3, MidpointRounding.AwayFromZero)).ToList();
         }
 
+        // Every frame conversion below uses controller.FrameRate - the video's rate, the same
+        // one these two bounds come from. They used the app's CurrentFrameRate, so absolute
+        // times were converted in a different frame space than the bounds they were compared
+        // against, and the error grew with the time code (at ten minutes, 25 vs 23.976 is a
+        // difference of about 600 frames).
         int halfSecGapInFrames = (int)Math.Round(controller.FrameRate / 2, MidpointRounding.AwayFromZero);
         double twoFramesGap = 1000.0 / controller.FrameRate * 2.0;
 
@@ -47,19 +52,19 @@ public class NetflixCheckShotChange : INetflixQualityChecker
         {
             // These frame values are invariant across all shot changes - compute once per paragraph
             // instead of recomputing inside every Where/FirstOrDefault predicate.
-            var startFrame = SubtitleFormat.MillisecondsToFrames(p.StartTime.TotalMilliseconds);
-            var endFrame = SubtitleFormat.MillisecondsToFrames(p.EndTime.TotalMilliseconds);
+            var startFrame = SubtitleFormat.MillisecondsToFrames(p.StartTime.TotalMilliseconds, controller.FrameRate);
+            var endFrame = SubtitleFormat.MillisecondsToFrames(p.EndTime.TotalMilliseconds, controller.FrameRate);
 
-            List<double> previousStartShotChanges = shotChanges.Where(x => SubtitleFormat.MillisecondsToFrames(x * 1000) < startFrame).ToList();
-            List<double> nextStartShotChanges = shotChanges.Where(x => SubtitleFormat.MillisecondsToFrames(x * 1000) > startFrame).ToList();
-            List<double> previousEndShotChanges = shotChanges.Where(x => SubtitleFormat.MillisecondsToFrames(x * 1000) < endFrame).ToList();
-            List<double> nextEndShotChanges = shotChanges.Where(x => SubtitleFormat.MillisecondsToFrames(x * 1000) > endFrame).ToList();
-            var onShotChange = shotChanges.FirstOrDefault(x => SubtitleFormat.MillisecondsToFrames(x * 1000) == endFrame);
+            List<double> previousStartShotChanges = shotChanges.Where(x => SubtitleFormat.MillisecondsToFrames(x * 1000, controller.FrameRate) < startFrame).ToList();
+            List<double> nextStartShotChanges = shotChanges.Where(x => SubtitleFormat.MillisecondsToFrames(x * 1000, controller.FrameRate) > startFrame).ToList();
+            List<double> previousEndShotChanges = shotChanges.Where(x => SubtitleFormat.MillisecondsToFrames(x * 1000, controller.FrameRate) < endFrame).ToList();
+            List<double> nextEndShotChanges = shotChanges.Where(x => SubtitleFormat.MillisecondsToFrames(x * 1000, controller.FrameRate) > endFrame).ToList();
+            var onShotChange = shotChanges.FirstOrDefault(x => SubtitleFormat.MillisecondsToFrames(x * 1000, controller.FrameRate) == endFrame);
 
             if (previousStartShotChanges.Count > 0)
             {
                 double nearestStartPrevShotChange = previousStartShotChanges.Aggregate((x, y) => Math.Abs(x - p.StartTime.TotalSeconds) < Math.Abs(y - p.StartTime.TotalSeconds) ? x : y);
-                var gapToShotChange = SubtitleFormat.MillisecondsToFrames(p.StartTime.TotalMilliseconds - nearestStartPrevShotChange * 1000);
+                var gapToShotChange = SubtitleFormat.MillisecondsToFrames(p.StartTime.TotalMilliseconds - nearestStartPrevShotChange * 1000, controller.FrameRate);
                 if (gapToShotChange != 0 && gapToShotChange < halfSecGapInFrames)
                 {
                     var fixedParagraph = new Paragraph(p, false);
@@ -72,7 +77,7 @@ public class NetflixCheckShotChange : INetflixQualityChecker
             if (nextStartShotChanges.Count > 0)
             {
                 double nearestStartNextShotChange = nextStartShotChanges.Aggregate((x, y) => Math.Abs(x - p.StartTime.TotalSeconds) < Math.Abs(y - p.StartTime.TotalSeconds) ? x : y);
-                var gapToShotChange = SubtitleFormat.MillisecondsToFrames(nearestStartNextShotChange * 1000 - p.StartTime.TotalMilliseconds);
+                var gapToShotChange = SubtitleFormat.MillisecondsToFrames(nearestStartNextShotChange * 1000 - p.StartTime.TotalMilliseconds, controller.FrameRate);
                 var threshold = (int)Math.Round(halfSecGapInFrames * 0.75, MidpointRounding.AwayFromZero);
                 if (gapToShotChange != 0 && gapToShotChange < halfSecGapInFrames)
                 {
@@ -98,7 +103,7 @@ public class NetflixCheckShotChange : INetflixQualityChecker
             if (previousEndShotChanges.Count > 0)
             {
                 double nearestEndPrevShotChange = previousEndShotChanges.Aggregate((x, y) => Math.Abs(x - p.EndTime.TotalSeconds) < Math.Abs(y - p.EndTime.TotalSeconds) ? x : y);
-                if (SubtitleFormat.MillisecondsToFrames(p.EndTime.TotalMilliseconds - nearestEndPrevShotChange * 1000) < halfSecGapInFrames)
+                if (SubtitleFormat.MillisecondsToFrames(p.EndTime.TotalMilliseconds - nearestEndPrevShotChange * 1000, controller.FrameRate) < halfSecGapInFrames)
                 {
                     var fixedParagraph = new Paragraph(p, false);
                     fixedParagraph.EndTime.TotalMilliseconds = nearestEndPrevShotChange * 1000 - twoFramesGap;
@@ -114,7 +119,7 @@ public class NetflixCheckShotChange : INetflixQualityChecker
                 // extend the out-time to the shot change, respecting the two-frame gap from the shot
                 // change." An out-cue already sitting on the two-frame gap is what we would move it
                 // to, so it is not an issue.
-                var framesToShotChange = SubtitleFormat.MillisecondsToFrames(nearestEndNextShotChange * 1000 - p.EndTime.TotalMilliseconds);
+                var framesToShotChange = SubtitleFormat.MillisecondsToFrames(nearestEndNextShotChange * 1000 - p.EndTime.TotalMilliseconds, controller.FrameRate);
                 if (framesToShotChange < halfSecGapInFrames && framesToShotChange != 2)
                 {
                     var fixedParagraph = new Paragraph(p, false);

--- a/src/ui/Logic/NetflixQualityCheck/NetflixCheckTwoFramesGap.cs
+++ b/src/ui/Logic/NetflixQualityCheck/NetflixCheckTwoFramesGap.cs
@@ -29,7 +29,13 @@ public class NetflixCheckTwoFramesGap : INetflixQualityChecker
         {
             Paragraph p = subtitle.Paragraphs[index];
             var next = subtitle.GetParagraphOrDefault(index + 1);
-            if (next != null && SubtitleFormat.MillisecondsToFrames(next.StartTime.TotalMilliseconds - p.EndTime.TotalMilliseconds) < 2 && !p.StartTime.IsMaxTime)
+            // controller.FrameRate, not the app's CurrentFrameRate: the threshold above is
+            // computed from the video's frame rate, so measuring the gap with a different one
+            // let real violations through (23.976 video with the 25 default: a 61 ms gap is
+            // 1.5 frames but measured as 2, so it was never flagged).
+            if (next != null &&
+                SubtitleFormat.MillisecondsToFrames(next.StartTime.TotalMilliseconds - p.EndTime.TotalMilliseconds, controller.FrameRate) < 2 &&
+                !p.StartTime.IsMaxTime)
             {
                 var fixedParagraph = new Paragraph(p, false) { EndTime = { TotalMilliseconds = next.StartTime.TotalMilliseconds - twoFramesGap } };
                 string comment;

--- a/tests/UI/Logic/NetflixQualityCheck/NetflixFrameRateAndNumberTests.cs
+++ b/tests/UI/Logic/NetflixQualityCheck/NetflixFrameRateAndNumberTests.cs
@@ -1,0 +1,112 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic.NetflixQualityCheck;
+
+namespace UITests.Logic.NetflixQualityCheck;
+
+/// <summary>
+/// The Netflix checks take the video's frame rate from the controller, but measured times with
+/// the app-wide CurrentFrameRate - so on any video whose rate differs from the setting the rules
+/// were evaluated at one frame rate and fixed at another. Plus two defects in the
+/// "spell out 1 to 10" rule.
+/// </summary>
+public class NetflixFrameRateAndNumberTests : IDisposable
+{
+    private readonly double _originalFrameRate = Configuration.Settings.General.CurrentFrameRate;
+
+    public void Dispose()
+    {
+        Configuration.Settings.General.CurrentFrameRate = _originalFrameRate;
+        GC.SuppressFinalize(this);
+    }
+
+    private static Subtitle TwoLines(int firstEndMs, int secondStartMs)
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("One", 0, firstEndMs));
+        subtitle.Paragraphs.Add(new Paragraph("Two", secondStartMs, secondStartMs + 1000));
+        return subtitle;
+    }
+
+    private static NetflixQualityController Controller(double videoFrameRate) =>
+        new() { Language = "en", FrameRate = videoFrameRate };
+
+    [Theory]
+    [InlineData(25.0)]
+    [InlineData(23.976)]
+    public void TwoFramesGap_IsMeasuredAtTheVideoFrameRate(double appFrameRate)
+    {
+        // 61 ms is 1.46 frames at 23.976 - a violation of the two-frame rule whatever the app's
+        // own frame rate happens to be set to. Measured at 25 it rounds to 2 frames and passed.
+        Configuration.Settings.General.CurrentFrameRate = appFrameRate;
+        var controller = Controller(23.976);
+
+        new NetflixCheckTwoFramesGap("x").Check(TwoLines(1000, 1061), controller);
+
+        Assert.Single(controller.Records);
+    }
+
+    [Theory]
+    [InlineData(25.0)]
+    [InlineData(23.976)]
+    public void BridgeGaps_IsMeasuredAtTheVideoFrameRate(double appFrameRate)
+    {
+        // 470 ms is 11 frames at 23.976, inside the "more than 2, less than half a second" range
+        // the rule bridges. Measured at 25 it rounds to 12 and fell outside the range.
+        Configuration.Settings.General.CurrentFrameRate = appFrameRate;
+        var controller = Controller(23.976);
+
+        new NetflixCheckBridgeGaps("x").Check(TwoLines(1000, 1470), controller);
+
+        Assert.Single(controller.Records);
+    }
+
+    private static string SpellOut(string text)
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph(text, 0, 3000));
+        var controller = new NetflixQualityController { Language = "en" };
+        new NetflixCheckNumbersOneToTenSpellOut("x").Check(subtitle, controller);
+        return controller.Records.Count > 0 ? controller.Records[0].FixedParagraph!.Text : text;
+    }
+
+    [Fact]
+    public void SpellOut_ALaterThousandsSeparatorDoesNotBlockAnEarlierNumber()
+    {
+        // The thousands-separator test scanned the whole rest of the line for ",<digit>", so the
+        // "4,000" later in the sentence vetoed writing out the "3,".
+        Assert.Equal("I have three, and 4,000 dollars.", SpellOut("I have 3, and 4,000 dollars."));
+    }
+
+    [Fact]
+    public void SpellOut_StillSkipsAThousandsSeparatedNumber()
+    {
+        Assert.Equal("1,000 people and three dogs.", SpellOut("1,000 people and 3 dogs."));
+    }
+
+    [Fact]
+    public void SpellOut_LeavesANumberedHeadingAlone()
+    {
+        // The 1-9 pass treats a following period as "part of a heading or a decimal"; the 10 pass
+        // only looked for a colon, so "10." was written out where "3." was not.
+        Assert.Equal("Chapter 10. Introduction", SpellOut("Chapter 10. Introduction"));
+        Assert.Equal("Chapter 3. Introduction", SpellOut("Chapter 3. Introduction"));
+    }
+
+    [Theory]
+    [InlineData("There were 10.", "There were ten.")]
+    [InlineData("There were 3.", "There were three.")]
+    [InlineData("Only 10 left.", "Only ten left.")]
+    [InlineData("He said 3, then left.", "He said three, then left.")]
+    public void SpellOut_StillWritesOutTheOrdinaryCases(string input, string expected)
+    {
+        Assert.Equal(expected, SpellOut(input));
+    }
+
+    [Theory]
+    [InlineData("It is 3:15 now.")]
+    [InlineData("It is 10:15 now.")]
+    public void SpellOut_LeavesATimeCodeAlone(string text)
+    {
+        Assert.Equal(text, SpellOut(text));
+    }
+}


### PR DESCRIPTION
Five defects in the Netflix quality checks, each with a reproducible input.

### Three checks measure frames at the wrong frame rate

`NetflixQualityController.FrameRate` is the **video's** frame rate — the Fix Netflix errors window sets it from the media info. Three checks compute their thresholds from it but convert times with the single-argument `SubtitleFormat.MillisecondsToFrames`, which reads the **app-wide** `Configuration.Settings.General.CurrentFrameRate` (25 by default). On any video whose rate differs from that setting, the rule is evaluated at one frame rate and fixed at another.

- **[Minimum two frames gap](src/ui/Logic/NetflixQualityCheck/NetflixCheckTwoFramesGap.cs:32)** — 23.976 video, setting at 25, a **61 ms gap**: that is 1.46 frames, a violation, but measured at 25 it rounds to 2 and was never flagged. Confirmed by running the check both ways: 0 records vs 1.
- **[Bridge gaps](src/ui/Logic/NetflixQualityCheck/NetflixCheckBridgeGaps.cs:41)** — same setup, a **470 ms gap** is 11 frames at 23.976 and inside the range the rule bridges; measured at 25 it reads as 12 and fell outside it. Also confirmed: 0 records vs 1.
- **[Shot changes](src/ui/Logic/NetflixQualityCheck/NetflixCheckShotChange.cs:55)** — the same mismatch applied to *absolute* time codes, compared against `halfSecGapInFrames` and `twoFramesGap` computed from the controller's rate. The error grows with the time code: at ten minutes, 25 versus 23.976 is roughly 600 frames apart, so "nearest shot change" was decided in the wrong frame space. All eleven conversions in that file now take the controller's rate.

### Two defects in "numbers one to ten spell out"

- **A later thousands separator vetoed an earlier number** ([line 57 before the fix](src/ui/Logic/NetflixQualityCheck/NetflixCheckNumbersOneToTenSpellOut.cs)). The test was `CommaDigit.IsMatch(newText, m.Index + 1)` — a search of the whole rest of the line for `,<digit>`, not a look at the character after *this* number's comma. `"I have 3, and 4,000 dollars."` produced **no fix at all**, while the same sentence with the thousands written out correctly became `"I have three, and four thousand dollars."`.
- **`10.` was written out where `3.` was not.** The 1–9 pass skips a number followed by `:` or `.` — a time code, a decimal, a numbered heading — unless the number ends the sentence. The 10 pass only ever looked for `:`. So `"Chapter 10. Introduction"` became `"Chapter ten. Introduction"` while `"Chapter 3. Introduction"` was correctly left alone. Both passes now share one `ShouldSpellOut` decision, so they cannot drift apart again.

### Verification

`tests/UI/Logic/NetflixQualityCheck/NetflixFrameRateAndNumberTests.cs` — 13 tests. Four of them fail against the previous code; I confirmed that by reverting the four source files and re-running (4 failed, 9 passed), then restoring. The shot-change fix has no test: it needs a shot-change file on disk beside a video, so it rests on the code and on the two sibling checks the same fix is proven for.

The tests also pin the behaviour that must not change: a real thousands separator (`"1,000 people and 3 dogs."`), time codes at both `3:15` and `10:15`, and the ordinary spell-outs including `"There were 10."` → `"There were ten."` (a sentence-ending period still spells out, in both passes now).

Suites: libse 1646 / libuilogic 724 / seconv 422 / UI 4183. The one UI failure is `LibMpvEventLoopTests.Pause_RightAfterSeek_KeepsReportingTheSeekTarget`, the known worktree-dependent flake — nothing here touches the video players.

🤖 Generated with [Claude Code](https://claude.com/claude-code)