### PR TITLE
Fix burn-in silently skipping generation when the output file exists

### DIFF
--- a/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
@@ -325,6 +325,14 @@ public partial class BurnInViewModel : ObservableObject
 
         _timerAnalyze.Stop();
 
+        // A failed analyze pass writes no statistics file, so pass 2 could only fail too - it used
+        // to run anyway and report whatever was already at the output path.
+        if (_ffmpegProcess.ExitCode != 0)
+        {
+            ReportFfmpegFailure(JobItems[_jobItemIndex], "Two-pass analyze (pass 1) failed for");
+            return;
+        }
+
         Dispatcher.UIThread.Invoke(async () =>
         {
             var jobItem = JobItems[_jobItemIndex];
@@ -393,29 +401,18 @@ public partial class BurnInViewModel : ObservableObject
         var jobItem = JobItems[_jobItemIndex];
         Se.WriteToolsLog($"Burn-in ffmpeg finished with exit code {_ffmpegProcess.ExitCode} for \"{jobItem.OutputVideoFileName}\"");
 
+        // The output file existing is not proof that this run produced it: with an old file at the
+        // target path a refused or failed ffmpeg passed the check, and the job was reported as
+        // "Done" while the stale file was left untouched (issue #14210).
+        if (_ffmpegProcess.ExitCode != 0)
+        {
+            ReportFfmpegFailure(jobItem, "ffmpeg failed for");
+            return;
+        }
+
         if (!File.Exists(jobItem.OutputVideoFileName))
         {
-            Se.WriteToolsLog("Output video file not found: " + jobItem.OutputVideoFileName + Environment.NewLine +
-                             "ffmpeg: " + _ffmpegProcess.StartInfo.FileName + Environment.NewLine +
-                             "Parameters: " + _ffmpegProcess.StartInfo.Arguments + Environment.NewLine +
-                             "OS: " + Environment.OSVersion + Environment.NewLine +
-                             "64-bit: " + Environment.Is64BitOperatingSystem + Environment.NewLine +
-                             "ffmpeg exit code: " + _ffmpegProcess.ExitCode + Environment.NewLine +
-                             "ffmpeg log: " + _log);
-
-            Dispatcher.UIThread.Invoke(async () =>
-            {
-                await MessageBox.Show(Window!,
-                    "Unable to generate video",
-                    "Output video file not generated: " + jobItem.OutputVideoFileName + Environment.NewLine +
-                    "Parameters: " + _ffmpegProcess.StartInfo.Arguments,
-                    MessageBoxButtons.OK,
-                    MessageBoxIcon.Error);
-
-                IsGenerating = false;
-                ProgressValue = 0;
-            });
-
+            ReportFfmpegFailure(jobItem, "Output video file not generated:");
             return;
         }
 
@@ -458,6 +455,37 @@ public partial class BurnInViewModel : ObservableObject
                     sb.ToString(),
                     MessageBoxButtons.OK);
             }
+        });
+    }
+
+    /// <summary>
+    /// Tells the user that an ffmpeg run failed, and writes the full command line, exit code and
+    /// ffmpeg log to the tools log for bug reports.
+    /// </summary>
+    private void ReportFfmpegFailure(BurnInJobItem jobItem, string reason)
+    {
+        Se.WriteToolsLog(reason + " " + jobItem.OutputVideoFileName + Environment.NewLine +
+                         "ffmpeg: " + _ffmpegProcess!.StartInfo.FileName + Environment.NewLine +
+                         "Parameters: " + _ffmpegProcess.StartInfo.Arguments + Environment.NewLine +
+                         "OS: " + Environment.OSVersion + Environment.NewLine +
+                         "64-bit: " + Environment.Is64BitOperatingSystem + Environment.NewLine +
+                         "ffmpeg exit code: " + _ffmpegProcess.ExitCode + Environment.NewLine +
+                         "ffmpeg log: " + _log);
+
+        jobItem.Status = Se.Language.General.Error;
+
+        Dispatcher.UIThread.Invoke(async () =>
+        {
+            await MessageBox.Show(Window!,
+                "Unable to generate video",
+                reason + " " + jobItem.OutputVideoFileName + Environment.NewLine +
+                "ffmpeg exit code: " + _ffmpegProcess.ExitCode + Environment.NewLine +
+                "Parameters: " + _ffmpegProcess.StartInfo.Arguments,
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+
+            IsGenerating = false;
+            ProgressValue = 0;
         });
     }
 

--- a/src/ui/Logic/Media/FfmpegGenerator.cs
+++ b/src/ui/Logic/Media/FfmpegGenerator.cs
@@ -282,8 +282,12 @@ public class FfmpegGenerator
             filterParameter = $"-filter_complex \"{filterComplex}\"";
         }
 
+        // "-y" (overwrite): the output file name comes from a "save as" dialog that has already
+        // asked about replacing an existing file, or from the batch naming that never collides.
+        // Without it ffmpeg hits "File ... already exists. Exiting." and writes nothing - and as
+        // the old file is still there, the burn-in looked like it succeeded (issue #14210).
         return
-            $"{cutStart}-i \"{inputVideoFileName}\"{canvasInput}{logoInput}{cutEnd} {filterParameter} -g 30 -bf 2 -s {width}x{height} {videoEncodingSettings} {passSettings} {presetSettings} {crfSettings} {pixelFormat} {audioSettings}{tuneParameter} -use_editlist 0 -movflags +faststart{shortestParameter} {outputVideoFileName}";
+            $"-y{cutStart}-i \"{inputVideoFileName}\"{canvasInput}{logoInput}{cutEnd} {filterParameter} -g 30 -bf 2 -s {width}x{height} {videoEncodingSettings} {passSettings} {presetSettings} {crfSettings} {pixelFormat} {audioSettings}{tuneParameter} -use_editlist 0 -movflags +faststart{shortestParameter} {outputVideoFileName}";
     }
 
     private static Process GetFFmpegProcess(string imageFileName, string outputFileName, int videoWidth, int videoHeight, int seconds, decimal frameRate, bool addTimeCode = false, string addTimeColor = "white")

--- a/tests/UI/Features/Video/FfmpegBurnInParametersTests.cs
+++ b/tests/UI/Features/Video/FfmpegBurnInParametersTests.cs
@@ -68,4 +68,20 @@ public class FfmpegBurnInParametersTests
         Assert.Contains("\"output.webm\"", parameters);
         Assert.DoesNotContain("-pass ", parameters);
     }
+
+    /// <summary>
+    /// Without "-y" ffmpeg refuses to touch an existing output file ("File ... already exists.
+    /// Exiting.") - and with the old file still in place the burn-in reported success while
+    /// nothing had been re-encoded (issue #14210).
+    /// </summary>
+    [Theory]
+    [InlineData("", "")]
+    [InlineData("1", "500k")]
+    [InlineData("2", "500k")]
+    public void Overwrite_IsAlwaysAllowed(string pass, string twoPassBitRate)
+    {
+        var parameters = Generate("libx264", "aac", "output.mp4", pass, twoPassBitRate);
+
+        Assert.StartsWith("-y ", parameters);
+    }
 }


### PR DESCRIPTION
Fixes #14210

### The bug

The burn-in ffmpeg command line is the only output-producing one in `FfmpegGenerator` built without `-y`. Together with the `-nostdin` that `GetProcess` prepends, ffmpeg answers its own overwrite question itself:

```
File '/tmp/out.mp4' already exists. Exiting.
exit=1
```

…and writes nothing.

The old file is still at the target path, so the completion check — which only asked `File.Exists` — passed. The job was marked **Done** and the "video file generated" dialog pointed at the stale file. Nothing looked wrong, even though the user had explicitly picked *Replace* in the save dialog moments earlier.

The reporter's workaround (enable "prompt for ffmpeg parameters" and add `-y` by hand) confirms the diagnosis.

### The fix

- Emit `-y` for burn-in. The output name comes either from a save dialog that has already asked about replacing an existing file, or from the batch naming that never collides — so there is nothing left to confirm a second time.
- Treat a non-zero ffmpeg exit code as failure instead of inferring success from a file being present. This also covers a user who edits the parameters and drops `-y`.
- Same check for the two-pass analyze pass: a failed pass 1 writes no statistics file, so pass 2 used to run only to fail and then report whatever was already at the output path.
- One shared failure reporter that sets the job status to Error, shows the exit code in the message, and writes the command line + ffmpeg log to the tools log.

The abort check runs at the top of each timer tick, before the new exit-code check, so cancelling still reports nothing rather than an error.

### Verified

- Reproduced the refusal and the fix against a real ffmpeg, including `-y` placed before the `-ss`/`-t` cut options — the existing target file is genuinely re-encoded (output hash changes).
- Regression test for one-pass and both two-pass modes; full UI test suite passes (4174 passed, 0 failed).

### Not included

Batch mode still auto-renames to `_2`, `_3` rather than overwriting. The "Overwrite existing files" checkbox the issue suggests would go in the burn-in output settings dialog — happy to add it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)