### PR TITLE
Prepare v5.2.0-beta27

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -3,6 +3,25 @@ Subtitle Edit Changelog
 
 -----------------------------------------------------------------------------------------------------
 
+v5.2.0-beta27 (28th of August 2026)
+
+* Add "Assisted split" and "Assisted move" windows, with ranked one-click suggestions and full previews - thx GitGianluc
+* Add "Justify lines" for the mpv video preview in Options - Settings - Video - thx kadrimarzouki
+* Image based export: let the line justification follow the alignment tag - thx smt-joen
+* Much better import of unknown subtitle formats - a new generic XML importer plus a dozen JSON fixes
+* Netflix check: measure gaps, bridges and shot changes at the video's frame rate, and fix two "spell out numbers" defects
+* Fix the waveform cursor jumping away a moment after a click - thx Davanix
+* Fix the undocked waveform window taking the foreground when another program is closed - thx GrampaWildWilly
+* Fix around 290 more bugs found in 13 code sweeps - subtitle formats, batch convert, seconv, dialogs, settings, binary edit and core helpers
+* Update Chinese (simplified) translation - thx emsb8888-prog
+* Update Italian translation - thx bovirus
+* Update Japanese translation - thx hisui3393
+* Update Korean translation - thx 12si27
+* Update Polish translation - thx potplayer-fanpack
+* Update Portuguese (Brazil) translation - thx igorruckert
+
+-----------------------------------------------------------------------------------------------------
+
 v5.2.0-beta26 (27th of August 2026)
 
 * Video OCR: read far more subtitles, with much better text and start times - thx caiweihan

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "Subtitle Edit",
-  "version": "v5.2.0-beta26",
+  "version": "v5.2.0-beta27",
   "translatedBy": "",
   "cultureName": "en-US",
   "general": {

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -19,7 +19,7 @@ public class Se
     internal const int CurrentMacOsFontMigrationVersion = 1;
     internal const int CurrentShortcutsMigrationVersion = 2;
 
-    public static string Version { get; set; } = "v5.2.0-beta26";
+    public static string Version { get; set; } = "v5.2.0-beta27";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
Version bump + change-log section for the **26 pull requests** merged since the `v5.2.0-beta26` tag (enumerated from `git log --first-parent v5.2.0-beta26..HEAD`).

## Changes

- `src/ui/Logic/Config/Se.cs` — `v5.2.0-beta26` → `v5.2.0-beta27`
- `src/ui/Assets/Languages/English.json` — regenerated; only the `version` field moved, the new strings from #14198 and #14196 were already regenerated in their own PRs
- `change-log.txt` — new top section

## Section

```
v5.2.0-beta27 (28th of August 2026)

* Add "Assisted split" and "Assisted move" windows, with ranked one-click suggestions and full previews - thx GitGianluc
* Add "Justify lines" for the mpv video preview in Options - Settings - Video - thx kadrimarzouki
* Image based export: let the line justification follow the alignment tag - thx smt-joen
* Much better import of unknown subtitle formats - a new generic XML importer plus a dozen JSON fixes
* Netflix check: measure gaps, bridges and shot changes at the video's frame rate, and fix two "spell out numbers" defects
* Fix the waveform cursor jumping away a moment after a click - thx Davanix
* Fix the undocked waveform window taking the foreground when another program is closed - thx GrampaWildWilly
* Fix around 290 more bugs found in 13 code sweeps - subtitle formats, batch convert, seconv, dialogs, settings, binary edit and core helpers
* Update Chinese (simplified) translation - thx emsb8888-prog
* Update Italian translation - thx bovirus
* Update Japanese translation - thx hisui3393
* Update Korean translation - thx 12si27
* Update Polish translation - thx potplayer-fanpack
* Update Portuguese (Brazil) translation - thx igorruckert
```

## PR coverage

| Entry | PRs |
|---|---|
| Assisted split / move | #14198 |
| mpv justify lines | #14196 |
| Export image justification | #14206 |
| Unknown format import | #14179 |
| Netflix check | #14212 |
| Waveform cursor | #14189 |
| Undocked foreground | #14193 |
| **Bug hunts (one line, as asked)** | #14180, #14181, #14182, #14185, #14186, #14188, #14191, #14192, #14194, #14197, #14203, #14205, #14207 — 288 fixes |
| Translations | #14184 (ja), #14183 (pl), #14199 (it), #14201 (zh-Hans), #14208 (pt-BR), #14209 (ko) |

Every merged PR in the range is accounted for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)