### PR TITLE
Change-log: add #14213 to the beta27 section

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -10,6 +10,7 @@ v5.2.0-beta27 (28th of August 2026)
 * Image based export: let the line justification follow the alignment tag - thx smt-joen
 * Much better import of unknown subtitle formats - a new generic XML importer plus a dozen JSON fixes
 * Netflix check: measure gaps, bridges and shot changes at the video's frame rate, and fix two "spell out numbers" defects
+* Fix "generate video with burned-in subtitles" silently doing nothing when the output file already existed - thx rRobis
 * Fix the waveform cursor jumping away a moment after a click - thx Davanix
 * Fix the undocked waveform window taking the foreground when another program is closed - thx GrampaWildWilly
 * Fix around 290 more bugs found in 13 code sweeps - subtitle formats, batch convert, seconv, dialogs, settings, binary edit and core helpers


### PR DESCRIPTION
[#14213](https://github.com/SubtitleEdit/subtitleedit/pull/14213) was merged onto main a few minutes before the beta27 prep PR ([#14214](https://github.com/SubtitleEdit/subtitleedit/pull/14214)), so it ships in beta27 but was missing from the section.

The Windows installer bundles `change-log.txt`, so this needs to land before the release build is dispatched.

Reporter credited from the linked issue #14210 (rRobis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)