### PR TITLE
Blu-ray sup: fix ODS fragmenting for bitmaps over 64 KB

### DIFF
--- a/src/libse/BluRaySup/BluRaySupPicture.cs
+++ b/src/libse/BluRaySup/BluRaySupPicture.cs
@@ -561,7 +561,8 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
             }
             else
             {
-                numAddPackets = 1 + (rleBuf.Length - 0xffe4) / 0xffeb;
+                // round up, but without an extra empty packet when the rest divides evenly
+                numAddPackets = (rleBuf.Length - 0xffe4 + 0xffeb - 1) / 0xffeb;
             }
 
             // a typical frame consists of 8 packets. It can be elongated by additional object frames
@@ -621,7 +622,8 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
             {
                 0x00, 0x00,             // 0: object_id
                 0x00,                   // 2: object_version_number
-                0x40                    // 3: first_in_sequence (0x80), last_in_sequence (0x40), 6bits reserved
+                0x00                    // 3: first_in_sequence (0x80), last_in_sequence (0x40), 6bits reserved
+                                        //    set per packet below - only the final one is last_in_sequence
             };
 
             // Fade steps ride along as palette update display sets (PCS + PDS + END) between the
@@ -810,6 +812,8 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
                     buf[index++] = packetHeader[i];
                 }
 
+                // only the final fragment carries last_in_sequence - middle ones must be 0x00
+                headerOdsNext[3] = (byte)(p == numAddPackets - 1 ? 0x40 : 0x00);
                 for (var i = 0; i < headerOdsNext.Length; i++)
                 {
                     buf[index++] = headerOdsNext[i];

--- a/tests/libse/BluRaySup/BluRaySupPictureOdsFragmentTests.cs
+++ b/tests/libse/BluRaySup/BluRaySupPictureOdsFragmentTests.cs
@@ -1,0 +1,160 @@
+using Nikse.SubtitleEdit.Core.BluRaySup;
+using SkiaSharp;
+using System.Text;
+
+namespace LibSETests.BluRaySup;
+
+/// <summary>
+/// A PG segment carries a 16 bit length, so a bitmap bigger than that is written as a run of ODS
+/// segments: the first one holds 0xffe4 RLE bytes (it also carries the 11 byte object header), the
+/// following ones 0xffeb each. Only the last fragment may set last_in_sequence, and no fragment
+/// should be empty.
+/// </summary>
+public class BluRaySupPictureOdsFragmentTests
+{
+    private const int FirstOdsPayload = 0xffe4; // 65508
+    private const int NextOdsPayload = 0xffeb;  // 65515
+
+    private static readonly SKColor ColorA = new SKColor(255, 0, 0);
+    private static readonly SKColor ColorB = new SKColor(0, 255, 0);
+    private static readonly SKColor ColorC = new SKColor(0, 0, 255);
+
+    /// <summary>
+    /// Builds a bitmap whose RLE encoding is exactly <paramref name="targetRleLength"/> bytes, so the
+    /// fragment boundaries can be hit dead on. Each row is a stretch of alternating pixels (the
+    /// encoder writes those as one byte each) followed by one run, and ends with the two byte EOL.
+    /// </summary>
+    private static SKBitmap BitmapWithRleLength(int targetRleLength)
+    {
+        const int width = 1000;
+        const int fullRow = width + 2;
+
+        var fullRows = targetRleLength / fullRow;
+        var rest = targetRleLength % fullRow;
+        while (rest > 0 && rest < 6 && fullRows > 0)
+        {
+            fullRows--;
+            rest += fullRow;
+        }
+
+        var alternatingPerRow = new List<int>();
+        for (var i = 0; i < fullRows; i++)
+        {
+            alternatingPerRow.Add(width);
+        }
+
+        if (rest > 0)
+        {
+            // "00 cx yy cc" (4 bytes) for a run of 64+ pixels, "00 8x cc" (3 bytes) below that.
+            alternatingPerRow.Add(rest <= width - 58 ? rest - 6 : rest - 5);
+        }
+
+        var bitmap = new SKBitmap(new SKImageInfo(width, alternatingPerRow.Count, SKColorType.Bgra8888, SKAlphaType.Unpremul));
+        for (var y = 0; y < alternatingPerRow.Count; y++)
+        {
+            var alternating = alternatingPerRow[y];
+            for (var x = 0; x < alternating; x++)
+            {
+                bitmap.SetPixel(x, y, (x & 1) == 0 ? ColorA : ColorB);
+            }
+
+            for (var x = alternating; x < width; x++)
+            {
+                bitmap.SetPixel(x, y, ColorC);
+            }
+        }
+
+        return bitmap;
+    }
+
+    private sealed record Ods(bool First, bool Last, int DataLength);
+
+    private static (byte[] Sup, List<Ods> Fragments) Write(SKBitmap bitmap)
+    {
+        var pic = new BluRaySupPicture
+        {
+            StartTime = 1000,
+            EndTime = 3000,
+            Width = 1920,
+            Height = 1080,
+            CompositionNumber = 2,
+        };
+
+        var sup = BluRaySupPicture.CreateSupFrame(pic, bitmap, SKColors.White, 25, 20, 10, BluRayContentAlignment.BottomCenter);
+
+        var fragments = new List<Ods>();
+        var position = 0;
+        while (position + 13 <= sup.Length)
+        {
+            Assert.Equal(0x50, sup[position]);
+            Assert.Equal(0x47, sup[position + 1]);
+            var size = (sup[position + 11] << 8) + sup[position + 12];
+            if (sup[position + 10] == 0x15) // ODS
+            {
+                var flags = sup[position + 13 + 3];
+                var first = (flags & 0x80) == 0x80;
+                fragments.Add(new Ods(first, (flags & 0x40) == 0x40, size - (first ? 11 : 4)));
+            }
+
+            position += 13 + size;
+        }
+
+        Assert.Equal(sup.Length, position); // segments chain exactly to the end
+        return (sup, fragments);
+    }
+
+    private static void AssertFragmentRulesHold(List<Ods> fragments)
+    {
+        Assert.NotEmpty(fragments);
+        Assert.All(fragments, f => Assert.NotEqual(0, f.DataLength));
+        Assert.True(fragments[0].First);
+        Assert.All(fragments.Skip(1), f => Assert.False(f.First));
+
+        // last_in_sequence belongs on the final fragment only
+        Assert.True(fragments[fragments.Count - 1].Last);
+        Assert.All(fragments.Take(fragments.Count - 1), f => Assert.False(f.Last));
+    }
+
+    [Theory]
+    [InlineData(20000, 1)]                                        // comfortably inside one segment
+    [InlineData(FirstOdsPayload, 1)]                              // exactly fills the first segment
+    [InlineData(FirstOdsPayload + 1, 2)]                          // one byte over
+    [InlineData(FirstOdsPayload + NextOdsPayload, 2)]             // exactly fills two segments
+    [InlineData(FirstOdsPayload + NextOdsPayload + 1, 3)]         // one byte over
+    [InlineData(250000, 4)]                                       // three continuation fragments
+    public void SplitsTheRleBufferIntoTheFewestFragments(int rleLength, int expectedFragments)
+    {
+        using var bitmap = BitmapWithRleLength(rleLength);
+        var (_, fragments) = Write(bitmap);
+
+        Assert.Equal(expectedFragments, fragments.Count);
+        Assert.Equal(rleLength, fragments.Sum(f => f.DataLength));
+        AssertFragmentRulesHold(fragments);
+    }
+
+    [Theory]
+    [InlineData(20000)]
+    [InlineData(FirstOdsPayload + NextOdsPayload)]
+    [InlineData(250000)]
+    public void FragmentedBitmapsRoundTripThroughTheParser(int rleLength)
+    {
+        using var bitmap = BitmapWithRleLength(rleLength);
+        var (sup, _) = Write(bitmap);
+
+        using var stream = new MemoryStream(sup);
+        var parsed = BluRaySupParser.ParseBluRaySup(stream, new StringBuilder(), false, new Dictionary<int, List<PaletteInfo>>(), new Dictionary<int, List<BluRaySupParser.OdsData>>());
+
+        var withImage = parsed.Where(p => p.PcsObjects.Count > 0).ToList();
+        Assert.Single(withImage);
+        using var decoded = withImage[0].GetBitmap();
+        Assert.Equal(bitmap.Width, decoded.Width);
+        Assert.Equal(bitmap.Height, decoded.Height);
+
+        // The palette is 8 bit YCbCr, so colours shift a little - but every pixel must be opaque
+        // and the bottom row must have survived the last fragment.
+        for (var x = 0; x < decoded.Width; x += 97)
+        {
+            Assert.Equal(255, decoded.GetPixel(x, decoded.Height - 1).Alpha);
+        }
+    }
+}


### PR DESCRIPTION
A PG segment carries a 16 bit length, so a bitmap whose RLE buffer does not fit in one segment is written as a run of ODS segments — `0xffe4` bytes in the first one (it also carries the 11 byte object header) and `0xffeb` in each following one. Two things were off in that split.

### 1. One packet too many when the remainder divides evenly

```csharp
numAddPackets = 1 + (rleBuf.Length - 0xffe4) / 0xffeb;
```

This is `floor + 1`, not `ceil`. For an RLE buffer of exactly `0xffe4 + n * 0xffeb` bytes it asks for one more packet than there is data, and the loop then writes a trailing ODS with a zero byte payload.

### 2. Every continuation fragment claimed to be the last

`headerOdsNext[3]` was a hardcoded `0x40` (`last_in_sequence`) and was written unchanged for each additional packet, so with three or more fragments the middle ones were flagged as final. It is now set per packet, `0x40` only on the last.

Neither broke playback in practice — ffmpeg's `pgssub` decoder concatenates fragments until `object_data_length` is reached and never looks at the flags — but both are deviations from the format that a stricter reader may act on.

## Verifying

Sizing a bitmap to land exactly on a fragment boundary is fiddly, so the test builds one to order: a row of alternating single pixels costs the encoder one byte each, so a row is `alternating_pixels + one run + 2 byte EOL` and any target length is reachable. Writing the same six cues before and after the change:

```
                       BEFORE                                        AFTER
DS 6  ODS[F- 65508] ODS[-L 65515] ODS[-L 0]   →   ODS[F- 65508] ODS[-L 65515]
DS 8  ODS[F- 65508] ODS[-L 65515] ODS[-L 1]   →   ODS[F- 65508] ODS[-- 65515] ODS[-L 1]
DS10  ODS[F- 65508] ODS[-L] ODS[-L] ODS[-L]   →   ODS[F- 65508] ODS[--] ODS[--] ODS[-L]
```

(`F` = first_in_sequence, `L` = last_in_sequence.) The file shrinks by exactly 17 bytes — the empty segment's 13 byte PG header plus its 4 byte ODS header.

Decoded through **ffmpeg 7.0**, overlaying both files onto a black source and dumping PNGs: no decoder errors from either file, and all 20 frames are byte-identical before and after, so the change is to segment framing only and not to the image. The 250,000 byte / 4 fragment bitmap decodes to its full height — `signalstats` on its bottom two rows shows real content while the row just below it is pure black — so nothing is truncated across the fragment boundaries.

## Tests

`BluRaySupPictureOdsFragmentTests` is a `[Theory]` over six exact RLE lengths (`20000`, `0xffe4`, `0xffe4 + 1`, `0xffe4 + 0xffeb`, `+ 1`, `250000`) asserting fragment count, no empty fragments and correct first/last flags, plus a round trip back through `BluRaySupParser`. Three of the nine cases fail without the fix.

## Note on SupMover

While looking for prior art I re-read #10219. That one was the DTS > PTS bug and is already fixed; this is unrelated. Worth flagging though that neither [SupMover's `sup-parser.ksy`](https://github.com/MonoS/SupMover/blob/master/sup-parser.ksy) nor its `t_ODS::read` models continuation fragments — both read every ODS as if it had the full 11 byte first-fragment header, so a subtitle above ~64 KB of RLE still mis-parses there. **This PR does not fix that**; it is an upstream gap. It does at least stop us handing them middle fragments labelled `last`, which is not a value their `e_sequenceFlag` enum has a name for.

## Not included

No change-log entry — say the word and I will add one to the beta section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
