### PR TITLE
Fix #14218: stop Settings from rewinding the video

### DIFF
--- a/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
+++ b/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
@@ -193,6 +193,52 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
         private bool _isUserMovingPositionSlider;
         private ContentPresenter? _contentPresenter;
 
+        // Where an in-flight open+restore sequence is heading. See PositionForRestore.
+        private double? _pendingRestorePositionSeconds;
+
+        /// <summary>
+        /// The position another player should be handed when this control is thrown away and
+        /// rebuilt (layout rebuild, dock/undock, fullscreen) - the pending restore target while
+        /// an open+restore sequence is still in flight, and the live <see cref="Position"/>
+        /// otherwise.
+        /// <para>
+        /// Never sample <see cref="Position"/> for that: <see cref="Open"/> zeroes the position
+        /// display before loading, and a freshly created player reports 0 until its core is up
+        /// and playback has restarted, so anything reading the live position during that window
+        /// (half a second plus the load, easily seconds on a big file) carries 0 forward and
+        /// rewinds the video to the start. Settings -> Apply -> OK does exactly that: Apply
+        /// rebuilds the player and OK rebuilds it again while the first restore is still
+        /// running (issue #14218).
+        /// </para>
+        /// </summary>
+        internal double PositionForRestore => _pendingRestorePositionSeconds ?? Position;
+
+        /// <summary>
+        /// Announces that an open+restore sequence heading for <paramref name="seconds"/> has
+        /// started, so <see cref="PositionForRestore"/> reports that target instead of the 0 the
+        /// not-yet-loaded player reports. <see cref="Open"/> calls this itself when given a start
+        /// position; callers that seek only after the open (the layout rebuild) call it first.
+        /// The pending value is dropped by <see cref="EndPositionRestore"/> and, as a safety net
+        /// for restores that are abandoned without one, as soon as the player actually reports
+        /// the restored position.
+        /// </summary>
+        internal void BeginPositionRestore(double seconds)
+        {
+            if (seconds > 0)
+            {
+                _pendingRestorePositionSeconds = seconds;
+            }
+        }
+
+        /// <summary>
+        /// Ends the restore announced by <see cref="BeginPositionRestore"/>: the player is where
+        /// it should be, so <see cref="PositionForRestore"/> follows the live position again.
+        /// </summary>
+        internal void EndPositionRestore()
+        {
+            _pendingRestorePositionSeconds = null;
+        }
+
         private void NotifyPositionChanged(double newPosition)
         {
             if (Math.Abs(_positionIgnore - newPosition) < 0.001)
@@ -758,6 +804,12 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
                 return;
             }
 
+            // From here until the file is up and playback has restarted the position reads 0,
+            // so remember where this open is heading for anything that rebuilds the player
+            // meanwhile (issue #14218). Callers that seek only after the open have already
+            // announced their target - a start-less open must not clear it.
+            BeginPositionRestore(startPositionSeconds);
+
             // Reset slider state before LoadFile. Otherwise, when the new file's
             // Duration arrives on the next timer tick, the slider's Maximum drops
             // and a stale Value (left over from the previous file) gets clamped to
@@ -972,6 +1024,15 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
                     }
 
                     SetPositionDisplayOnly(pos);
+
+                    // The player has arrived where the restore was heading - drop the pending
+                    // target even if the restoring code never got to end it (an abandoned
+                    // sequence would otherwise pin PositionForRestore for the rest of the
+                    // control's life).
+                    if (_pendingRestorePositionSeconds is { } pending && Math.Abs(pos - pending) < 0.5)
+                    {
+                        EndPositionRestore();
+                    }
                 }
 
                 var fullDuration = TimeCode.FromSeconds(Duration + Se.Settings.General.CurrentVideoOffsetInMs / 1000.0).ToDisplayString();

--- a/src/ui/Features/Main/Layout/InitVideoPlayer.cs
+++ b/src/ui/Features/Main/Layout/InitVideoPlayer.cs
@@ -31,7 +31,12 @@ public static class InitVideoPlayer
         if (vm.VideoPlayerControl != null)
         {
             mediaFile = vm.VideoPlayerControl.VideoPlayer.FileName;
-            position = vm.VideoPlayerControl.VideoPlayer.Position;
+
+            // Not VideoPlayer.Position: the outgoing control may still be restoring a position
+            // itself (Options/Apply rebuilt it moments ago), and a player that has not finished
+            // loading reports 0 - which would be carried forward here as a rewind to the start
+            // of the video (issue #14218).
+            position = vm.VideoPlayerControl.PositionForRestore;
 
             // The old control is replaced by the one built below and never used again, so tear
             // it down completely. Closing the file alone left its 50 ms position timer running
@@ -61,6 +66,11 @@ public static class InitVideoPlayer
         };
         if (!string.IsNullOrEmpty(mediaFile))
         {
+            // Announced before the open so a rebuild that lands while this restore is still
+            // running gets the position it is heading for rather than the 0 of a player that
+            // has not loaded yet (issue #14218).
+            control.BeginPositionRestore(position);
+
             Dispatcher.UIThread.Post(async () =>
             {
                 await control.Open(mediaFile);
@@ -78,6 +88,8 @@ public static class InitVideoPlayer
 
                     control.Position = position;
                 }
+
+                control.EndPositionRestore();
             });
         }
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -8091,7 +8091,11 @@ public partial class MainViewModel :
 
             AreVideoControlsUndocked = true;
 
-            var position = vp.Position;
+            // Not vp.Position: this rebuild can land while the outgoing player is still
+            // restoring its own position - Settings -> Apply rebuilds the undocked windows and
+            // OK rebuilds them again a moment later - and a player that has not finished
+            // loading reports 0, which would come back as a rewind to the start (issue #14218).
+            var position = vp.PositionForRestore;
             var volume = vp.Volume;
             var videoFileName = vp.VideoPlayer.FileName;
 
@@ -11863,8 +11867,7 @@ public partial class MainViewModel :
         _oldGenerateSpectrogram = Se.Settings.Waveform.GenerateSpectrogram;
         _oldSpectrogramStyle = Se.Settings.Waveform.SpectrogramStyle;
 
-        Se.Settings.General.WindowPositions = Se.Settings.General.WindowPositions.OrderBy(p => p.WindowName).ToList();
-        var oldSettngsSerialized = JsonSerializer.Serialize(Se.Settings);
+        var oldSettngsSerialized = SettingsChangeSnapshot.Take();
 
         var viewModel = await ShowDialogAsync<SettingsWindow, SettingsViewModel>(
     vm => { vm.Initialize(this); });
@@ -11874,10 +11877,15 @@ public partial class MainViewModel :
             return;
         }
 
-        Se.Settings.General.WindowPositions = Se.Settings.General.WindowPositions.OrderBy(p => p.WindowName).ToList();
-        var newSettingsSerialized = JsonSerializer.Serialize(Se.Settings);
+        // Apply already ran the whole thing, so only what changed *since the last Apply* is
+        // still unapplied. Comparing against the pre-dialog snapshot instead made Apply followed
+        // by OK rebuild the layout - and with it the video player - a second time, which is what
+        // rewound the video: the second rebuild sampled the position from a player that was
+        // still restoring the position the first one gave it (issue #14218).
+        var baselineSerialized = viewModel.AppliedSettingsSnapshot ?? oldSettngsSerialized;
+        var newSettingsSerialized = SettingsChangeSnapshot.Take();
 
-        if (oldSettngsSerialized != newSettingsSerialized)
+        if (baselineSerialized != newSettingsSerialized)
         {
             var firstSelectedIndex = SubtitleGrid.SelectedIndex;
 
@@ -11899,7 +11907,7 @@ public partial class MainViewModel :
                 vp.FullScreenIsVisible = Se.Settings.Video.ShowFullscreenButton;
             }
 
-            if (OnlyVideoPlayerVisibilityFlagsChanged(oldSettngsSerialized, newSettingsSerialized))
+            if (OnlyVideoPlayerVisibilityFlagsChanged(baselineSerialized, newSettingsSerialized))
             {
                 return;
             }
@@ -16022,7 +16030,11 @@ public partial class MainViewModel :
         }
 
         PauseVideoAndFreezePlayhead(control);
-        var position = control.Position;
+
+        // PositionForRestore, not Position: going fullscreen right after a layout rebuild would
+        // otherwise open the fullscreen player at the 0 the still-restoring docked player
+        // reports (issue #14218).
+        var position = control.PositionForRestore;
         var volume = control.Volume;
         var parent = (Control)control.Parent!;
 
@@ -16071,7 +16083,7 @@ public partial class MainViewModel :
 
         var fullScreenWindow = new FullScreenVideoWindow(_fullScreenVideoPlayerControl, _videoFileName, _subtitleFileName ?? string.Empty, position, volume, () =>
         {
-            control!.Position = _fullScreenVideoPlayerControl.Position;
+            control!.Position = _fullScreenVideoPlayerControl.PositionForRestore;
             control!.Volume = _fullScreenVideoPlayerControl.Volume;
             _fullScreenVideoPlayerControl = null;
 

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -438,6 +438,14 @@ public partial class SettingsViewModel : ObservableObject
     };
 
     public bool OkPressed { get; set; }
+
+    /// <summary>
+    /// The settings as they stood after the last Apply, or null when Apply was never pressed.
+    /// The caller compares the settings at OK against this so that an Apply followed by OK does
+    /// not apply - and rebuild - everything twice (issue #14218).
+    /// </summary>
+    public string? AppliedSettingsSnapshot { get; private set; }
+
     public Window? Window { get; internal set; }
     public ScrollViewer ScrollView { get; internal set; }
     public List<SettingsSection> Sections { get; internal set; }
@@ -2759,6 +2767,11 @@ public partial class SettingsViewModel : ObservableObject
 
         await FileTypeAssociationsManager.SaveFileTypeAssociationsAsync(FileTypeAssociations, Window);
         _mainViewModel?.ApplySettings();
+
+        // Everything up to here is now applied, so this is the baseline the OK press must be
+        // compared against - without it OK re-applies every change this Apply already made and
+        // rebuilds the layout (and the video player) a second time (issue #14218).
+        AppliedSettingsSnapshot = SettingsChangeSnapshot.Take();
     }
 
     [RelayCommand]

--- a/src/ui/Features/Shared/FullScreenVideoPlayer.cs
+++ b/src/ui/Features/Shared/FullScreenVideoPlayer.cs
@@ -256,6 +256,10 @@ public class FullScreenVideoWindow : Window
 
                 videoPlayer.VideoPlayer.Position = position;
                 videoPlayer.Position = position;
+
+                // Restore done - a rebuild reading from this control gets the live position
+                // again (issue #14218).
+                videoPlayer.EndPositionRestore();
             });
         };
     }

--- a/src/ui/Features/Shared/Undocked/VideoPlayerUndockedViewModel.cs
+++ b/src/ui/Features/Shared/Undocked/VideoPlayerUndockedViewModel.cs
@@ -199,6 +199,10 @@ public partial class VideoPlayerUndockedViewModel : ObservableObject
                 videoPlayerControl.Volume = _originalVolume;
                 videoPlayerControl.Position = _originalPosition;
 
+                // The player is where it belongs - a rebuild from here on can read the live
+                // position again (issue #14218).
+                videoPlayerControl.EndPositionRestore();
+
                 // Undocking opens the video in a new player, which starts on mpv's default audio
                 // track - re-apply the track the user picked in the main window (issue #12844).
                 MainViewModel?.ReapplySelectedAudioTrack(videoPlayerControl);

--- a/src/ui/Logic/Config/SettingsChangeSnapshot.cs
+++ b/src/ui/Logic/Config/SettingsChangeSnapshot.cs
@@ -1,0 +1,39 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Nikse.SubtitleEdit.Logic.Config;
+
+/// <summary>
+/// Snapshots <see cref="Se.Settings"/> for the "did anything change that has to be applied?"
+/// check around the settings dialog. Two snapshots that compare equal mean the heavyweight
+/// <c>MainViewModel.ApplySettings</c> - which rebuilds the layout and with it the video player -
+/// can be skipped.
+/// </summary>
+public static class SettingsChangeSnapshot
+{
+    /// <summary>
+    /// Serializes the settings, minus the remembered window geometry.
+    /// <para>
+    /// <c>General.WindowPositions</c> is excluded because it is written as a side effect of
+    /// simply using the dialog: every window saves its position when it closes, so the settings
+    /// window itself - and, in undocked mode, the video/waveform windows an Apply closes and
+    /// re-creates - would make the two snapshots differ even when the user changed nothing that
+    /// needs applying. Window geometry never needs applying (it is read when a window opens), so
+    /// leaving it out only removes false positives (issue #14218).
+    /// </para>
+    /// </summary>
+    public static string Take()
+    {
+        // Through the source-generated context, like Se.SaveSettings - so the snapshot sees
+        // exactly the settings that get persisted.
+        var node = JsonSerializer.SerializeToNode(Se.Settings, SeJsonContext.Default.Se);
+        if (node is JsonObject root &&
+            root.TryGetPropertyValue("General", out var generalNode) &&
+            generalNode is JsonObject general)
+        {
+            general.Remove("WindowPositions");
+        }
+
+        return node?.ToJsonString() ?? string.Empty;
+    }
+}

--- a/tests/UI/Controls/VideoPlayerControlRestorePositionTests.cs
+++ b/tests/UI/Controls/VideoPlayerControlRestorePositionTests.cs
@@ -1,0 +1,105 @@
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Controls.VideoPlayer;
+using Nikse.SubtitleEdit.Logic.VideoPlayers;
+using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace UITests.Controls;
+
+/// <summary>
+/// Covers the rewind behind issue #14218. A rebuild of the video player (Options/OK, dock or
+/// undock, fullscreen) carries the current position over to the player it builds - but a player
+/// that is itself still opening reports 0, so a rebuild landing on top of another rebuild used
+/// to carry 0 forward and rewind the video to the start. Settings -> Apply -> OK does exactly
+/// that: Apply rebuilds the player, OK rebuilds it again a moment later.
+/// </summary>
+public class VideoPlayerControlRestorePositionTests
+{
+    private sealed class NotYetLoadedVideoPlayer : IVideoPlayer
+    {
+        public string Name => "not-yet-loaded";
+        public string FileName { get; private set; } = string.Empty;
+
+        public bool CanLoad() => true;
+
+        public Task LoadFile(string fileName, double startPositionSeconds = 0)
+        {
+            FileName = fileName;
+
+            // A real player reports 0 until its core is up and playback has restarted - that is
+            // the whole point of this test.
+            Position = 0;
+            return Task.CompletedTask;
+        }
+
+        public void CloseFile() => FileName = string.Empty;
+
+        public void Play()
+        {
+        }
+
+        public void PlayOrPause()
+        {
+        }
+
+        public void Pause()
+        {
+        }
+
+        public void Stop()
+        {
+        }
+
+        public AudioTrackInfo? ToggleAudioTrack() => null;
+
+        public bool IsPlaying => false;
+        public bool IsPaused => true;
+        public double Position { get; set; }
+        public double Duration => 600;
+        public int VolumeMaximum => 100;
+        public double Volume { get; set; } = 50;
+        public double Speed { get; set; } = 1.0;
+    }
+
+    [AvaloniaFact]
+    public async Task AnOpenInFlightReportsWhereItIsHeadingRatherThanZero()
+    {
+        var control = new VideoPlayerControl(new NotYetLoadedVideoPlayer());
+
+        await control.Open("fake.mkv", 321.5);
+
+        // The player has not caught up yet, so the live position is still the start of the file.
+        Assert.Equal(0, control.Position);
+
+        // A rebuild sampling now must get the position the open is heading for.
+        Assert.Equal(321.5, control.PositionForRestore);
+    }
+
+    [AvaloniaFact]
+    public async Task ARestoreAnnouncedBeforeAStartLessOpenSurvivesIt()
+    {
+        var control = new VideoPlayerControl(new NotYetLoadedVideoPlayer());
+
+        // The docked layout rebuild opens without a start position and seeks afterwards.
+        control.BeginPositionRestore(210);
+        await control.Open("fake.mkv");
+
+        Assert.Equal(210, control.PositionForRestore);
+    }
+
+    [AvaloniaFact]
+    public async Task TheLivePositionRulesAgainOnceTheRestoreIsDone()
+    {
+        var control = new VideoPlayerControl(new NotYetLoadedVideoPlayer());
+
+        await control.Open("fake.mkv", 321.5);
+        Assert.Equal(321.5, control.PositionForRestore);
+
+        // The restoring code is done - from here the player itself is the truth again, so a
+        // pending target must not go on shadowing it for the rest of the control's life.
+        control.EndPositionRestore();
+
+        Assert.Equal(control.Position, control.PositionForRestore);
+    }
+}

--- a/tests/UI/Logic/Config/SettingsChangeSnapshotTests.cs
+++ b/tests/UI/Logic/Config/SettingsChangeSnapshotTests.cs
@@ -1,0 +1,47 @@
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Logic.Config;
+
+/// <summary>
+/// The settings dialog decides whether to run the heavyweight ApplySettings (a full layout
+/// rebuild, video player included) by comparing snapshots of the settings. Window geometry must
+/// not take part in that comparison: every window writes its own position when it closes, so it
+/// changes as a side effect of merely using the dialog - and in undocked mode of the Apply
+/// itself, which closes and re-creates the video and waveform windows (issue #14218).
+/// </summary>
+public class SettingsChangeSnapshotTests
+{
+    [Fact]
+    public void RememberedWindowGeometryIsNotAChange()
+    {
+        using var scope = new SettingsScope("General.WindowPositions");
+
+        Se.Settings.General.WindowPositions = new List<SeWindowPosition>
+        {
+            new("SettingsWindow", false, false, 10, 20, 800, 600),
+        };
+        var before = SettingsChangeSnapshot.Take();
+
+        // The settings window moved, and an Apply re-saved the undocked windows.
+        Se.Settings.General.WindowPositions = new List<SeWindowPosition>
+        {
+            new("SettingsWindow", false, false, 900, 40, 800, 600),
+            new("VideoPlayerUndockedWindow", true, false, 1920, 0, 1920, 1080),
+        };
+
+        Assert.Equal(before, SettingsChangeSnapshot.Take());
+    }
+
+    [Fact]
+    public void ASettingThatNeedsApplyingIsAChange()
+    {
+        using var scope = new SettingsScope("Video.MpvPreviewAlignment");
+
+        var before = SettingsChangeSnapshot.Take();
+
+        // The change from the issue: subtitle position in the video player.
+        Se.Settings.Video.MpvPreviewAlignment = Se.Settings.Video.MpvPreviewAlignment == "7" ? "2" : "7";
+
+        Assert.NotEqual(before, SettingsChangeSnapshot.Take());
+    }
+}


### PR DESCRIPTION
Fixes the unpredictable rewind in #14218: changing a setting with a video open could send the video player and the waveform back to 0 (or a second into the file) while the subtitle grid stayed put — sometimes on Apply, sometimes on OK, sometimes not at all.

## What was happening

Two independent defects that only bite together.

**1. Apply + OK applied everything twice.** `SettingsViewModel.Apply` calls `MainViewModel.ApplySettings()` directly, but `CommandShowSettings` compared the settings at OK against a snapshot taken *before the dialog opened* — so every change Apply had already applied still counted as unapplied. Since applying rebuilds the layout, and the layout rebuild destroys and re-creates the video player, Apply followed by OK rebuilt the player twice.

**2. A rebuild sampled the position from a player that was still restoring.** Each rebuild carries the position over to the player it builds, reading it live (`vp.Position` / `VideoPlayer.Position`). But a player that is still opening reports 0: `VideoPlayerControl.Open` zeroes the position display before loading, and mpv reports 0 until its core is up and playback has restarted. The undocked restore alone takes ~500 ms plus the load. So rebuild #2 sampled 0 from the player rebuild #1 was still restoring, and reopened the video at the start.

That is exactly the reported pattern: the rewind lands on OK (the second rebuild) rather than on Apply, and waiting a few seconds between Apply and OK — long enough for the first restore to finish — makes it disappear.

## The fixes

- **`SettingsChangeSnapshot`** (new): serializes the settings for the "does this need applying?" check, with `General.WindowPositions` left out. `Apply` records a snapshot of what it just applied, and OK compares against that, so the second rebuild never happens. Window geometry is excluded because it is written as a side effect of merely using the dialog — every window saves its position when it closes, and in undocked mode Apply itself closes and re-creates the video and waveform windows — which made the comparison report a change when nothing needing applying had changed.
- **`VideoPlayerControl.PositionForRestore`**: while an open+restore sequence is in flight the control reports the position that restore is heading for, instead of the loading player's 0; afterwards it reports the live position again. `Open` announces its own start position, the docked rebuild (which seeks after opening) announces its target first, and the restore is ended explicitly when it lands — with the position timer clearing it as a safety net if a sequence is abandoned. All four capture sites use it: the layout rebuild, undock, entering fullscreen and leaving fullscreen.

The second fix is the durable one — dock/undock and fullscreen can hit the same race without the settings dialog being involved.

## Not addressed

The report also mentions the video window landing fullscreen on the primary monitor, and a several-second "Not Responding" — both only on the first run after installing a new version, and both gone for the reporter afterwards. The monitor placement looks like `UiUtil.RestoreWindowPosition` setting `Position` and then `WindowState = FullScreen` with no saved entry to restore from (fresh settings file); that needs a two-monitor Windows box to confirm, so it is left out rather than guessed at.

## Tests

`tests/UI/Controls/VideoPlayerControlRestorePositionTests.cs` and `tests/UI/Logic/Config/SettingsChangeSnapshotTests.cs` — full UI suite green (4192 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)