### PR TITLE
Fix #14221: OCR prompt that keeps two-line subtitles apart, seconv --ocr-prompt

### DIFF
--- a/docs/reference/command-line.md
+++ b/docs/reference/command-line.md
@@ -247,6 +247,7 @@ An AVI stream header carries no language, so a multi-stream `.avi` names its out
 | `--ollama-model:<model>` | Default `llama3.2-vision` |
 | `--ocr-model:<model>` | llama.cpp OCR model: the file name of a model in the llama.cpp models folder - curated (e.g. `GLM-OCR-Q8_0.gguf`) or your own vision model with its `mmproj` sidecar next to it - or a full path to a `.gguf` with its `mmproj` sidecar next to it. Default: the first downloaded OCR model. |
 | `--ocr-url:<url>` | llama.cpp: endpoint of an already-running `llama-server` (a bare `host:port` is completed to `/v1/chat/completions`); skips the local auto-start. |
+| `--ocr-prompt:<text\|file>` | Prompt for the prompt-driven OCR engines (`llamacpp`, `ollama`); rejected for the others. `{language}` is replaced with `--ocr-language`. A value that names an existing file, or ends in `.txt`/`.prompt`/`.md`, is read from that file; inline text gets `\n`/`\r`/`\t` unescaped. Default: the same prompt as the SE OCR window. |
 | `--time-codes-only` | Image sources (`.sup`, VobSub `.sub`/`.idx`, MKV PGS/VobSub, MP4 VobSub, TS DVB-sub, AVI XSUB) → text format with time codes only and empty text. **Skips OCR entirely** — no OCR engine required. Ignored for text inputs and image output targets. |
 | `--no-vobsub-isolate-colors` | Disable VobSub OCR colour isolation, which is **on by default**. Isolation rebuilds each subpicture as a crisp black-on-white bitmap via histogram-based colour analysis — the most frequent opaque colour (the glyph fill) becomes black and the gray outline / anti-alias colours collapse into the white background, which helps on discs whose outlines otherwise melt adjacent characters together (`Yuri` → `Yurl`). Pass this flag to OCR the raw palette instead. Ignored for non-VobSub sources and with `--time-codes-only`. |
 
@@ -272,6 +273,11 @@ seconv movie.sup subrip --ocr-engine:binaryocr --ocr-db:"C:\Users\me\AppData\Roa
 seconv movie.sup subrip --ocr-engine:llamacpp
 seconv movie.sup subrip --ocr-engine:llamacpp --ocr-model:GLM-OCR-Q8_0.gguf
 seconv movie.sup subrip --ocr-engine:llamacpp --ocr-url:http://127.0.0.1:8080
+
+# Override the OCR prompt (inline or from a file); {language} = --ocr-language
+seconv movie.sup subrip --ocr-engine:llamacpp --ocr-language:German \
+  --ocr-prompt:"Identify the number of lines, then extract the text of each line exactly as written. The language is {language}."
+seconv movie.sup subrip --ocr-engine:llamacpp --ocr-prompt:my-ocr-prompt.txt
 
 # MKV with image (PGS or VobSub) tracks — OCR runs automatically
 seconv movie.mkv subrip --ocr-engine:tesseract --ocr-language:eng

--- a/src/libuilogic/Ocr/SeOcrDefaults.cs
+++ b/src/libuilogic/Ocr/SeOcrDefaults.cs
@@ -1,0 +1,38 @@
+namespace Nikse.SubtitleEdit.UiLogic.Ocr;
+
+/// <summary>
+/// Defaults shared by every caller of the llama.cpp OCR engines, so the UI settings default, the
+/// engine's own fallback and seconv cannot drift apart (they were three hand-kept copies of the
+/// same string).
+/// </summary>
+public static class SeOcrDefaults
+{
+    /// <summary>
+    /// Prompt sent to the llama.cpp vision OCR models (GLM-OCR, PaddleOCR-VL, HunyuanOCR,
+    /// LightOnOCR); <c>{language}</c> is replaced with the OCR language's English name.
+    /// <para>
+    /// Making the model count the lines before transcribing is what keeps two-line subtitles from
+    /// being merged into one: these models work line by line and reconstruct the break from
+    /// context alone, so an instruction to "preserve line breaks" gives them nothing to preserve
+    /// (#14221 - thanks tekk42). Measured 2026-08-28 on 134 subtitle bitmaps from four Blu-ray
+    /// .sup files (67 of them two-line) against GLM-OCR 0.9B Q8_0 with SE's own flags and square
+    /// padding: the previous prompt ("Extract all text exactly as written. The language is
+    /// {language}. Preserve line breaks.") lost 8 line breaks, this one loses 2. Keeping "exactly
+    /// as written" matters - the issue's wording without it lost 3, and dropping it also cost
+    /// PaddleOCR-VL 4 more breaks on a 30-image subset. Output is otherwise identical: across all
+    /// 134 images every candidate prompt returned character-identical text once newlines are
+    /// flattened, and results were byte-identical over three repeats, so the prompt moves line
+    /// breaks and nothing else.
+    /// </para>
+    /// <para>
+    /// One prompt is deliberately shared by all four models rather than tuned per model. Only
+    /// GLM-OCR - the default and top-ranked engine - is prompt-sensitive here; the other three
+    /// merge 70-93% of two-line subtitles under every prompt tried, so per-model tuning was
+    /// measured to buy 3 line breaks in 120 image-model pairs, against shared-prompt plumbing at
+    /// four OCR entry points and a prompt box that would change under the user on every model
+    /// switch.
+    /// </para>
+    /// </summary>
+    public const string LlamaCppOcrPrompt =
+        "Identify the number of lines, then extract the text of each line exactly as written. The language is {language}.";
+}

--- a/src/seconv/Commands/ConvertCommand.cs
+++ b/src/seconv/Commands/ConvertCommand.cs
@@ -115,6 +115,10 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
         [Description("llama.cpp OCR: endpoint of an already-running llama-server; skips the local auto-start")]
         public string? OcrUrl { get; init; }
 
+        [CommandOption("--ocr-prompt|--ocrprompt")]
+        [Description("Prompt for --ocr-engine=llamacpp/ollama (or a path to a text file holding it); {language} is replaced with --ocr-language. Default: the same prompt as the OCR window")]
+        public string? OcrPrompt { get; init; }
+
         [CommandOption("--dictionary-folder|--dictionaryfolder")]
         [Description("Folder with Hunspell dictionaries + *_OCRFixReplaceList.xml; enables the 'Fix common OCR errors' pass of --fix-common-errors")]
         public string? DictionaryFolder { get; init; }
@@ -439,6 +443,29 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 return Fail(settings, "--ocr-model/--ocr-url require --ocr-engine:llamacpp.");
             }
 
+            // --ocr-prompt only means something to the two prompt-driven OCR engines; tesseract,
+            // nOCR, binary image compare and Paddle have no prompt at all. Fail instead of
+            // silently ignoring it, and read the prompt (it may be a file) up front so a typo'd
+            // path never costs a conversion - same contract as --translate-prompt.
+            if (!string.IsNullOrWhiteSpace(settings.OcrPrompt))
+            {
+                var isOllamaOcr = !string.IsNullOrWhiteSpace(settings.OcrEngine) &&
+                                  settings.OcrEngine.Trim().Equals("ollama", StringComparison.OrdinalIgnoreCase);
+                if (!isLlamaCppOcr && !isOllamaOcr)
+                {
+                    return Fail(settings, "--ocr-prompt requires --ocr-engine:llamacpp or --ocr-engine:ollama.");
+                }
+
+                try
+                {
+                    AutoTranslateRunner.ReadPromptOption(settings.OcrPrompt, "--ocr-prompt", "{language}");
+                }
+                catch (Exception ex)
+                {
+                    return Fail(settings, ex.Message);
+                }
+            }
+
             // Validate the translate options: --translate-to is the trigger, the rest refine it.
             if (string.IsNullOrWhiteSpace(settings.TranslateTo) &&
                 (!string.IsNullOrWhiteSpace(settings.TranslateFrom) ||
@@ -740,6 +767,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 OllamaModel = settings.OllamaModel,
                 OcrUrl = settings.OcrUrl,
                 OcrModel = settings.OcrModel,
+                OcrPrompt = AutoTranslateRunner.ReadPromptOption(settings.OcrPrompt, "--ocr-prompt", "{language}"),
                 TranslateTo = settings.TranslateTo,
                 TranslateFrom = settings.TranslateFrom,
                 TranslateEngine = settings.TranslateEngine,

--- a/src/seconv/Core/AutoTranslateRunner.cs
+++ b/src/seconv/Core/AutoTranslateRunner.cs
@@ -191,13 +191,18 @@ internal sealed class AutoTranslateRunner
     }
 
     /// <summary>
-    /// Resolves the <c>--translate-prompt</c> value to the prompt text, or null when the option
-    /// was not given. A value ending in <c>.txt</c>/<c>.prompt</c>/<c>.md</c>, or naming a file
-    /// that exists, is read from disk - completion templates are multi-line and a shell cannot
-    /// always pass those as one argument. Inline text gets <c>\n</c>, <c>\r</c>, <c>\t</c> and
+    /// Resolves a prompt option's value to the prompt text, or null when the option was not
+    /// given. A value ending in <c>.txt</c>/<c>.prompt</c>/<c>.md</c>, or naming a file that
+    /// exists, is read from disk - completion templates are multi-line and a shell cannot always
+    /// pass those as one argument. Inline text gets <c>\n</c>, <c>\r</c>, <c>\t</c> and
     /// <c>\\</c> unescaped for the same reason.
+    /// <para>
+    /// Shared by <c>--translate-prompt</c> and <c>--ocr-prompt</c>; <paramref name="optionName"/>
+    /// and <paramref name="placeholders"/> only shape the error messages and the "is this a path
+    /// or a sentence?" hint, so both options behave identically.
+    /// </para>
     /// </summary>
-    internal static string? ReadPromptOption(string? value)
+    internal static string? ReadPromptOption(string? value, string optionName = "--translate-prompt", string placeholders = "{0}/{1}/{2}")
     {
         if (value == null)
         {
@@ -207,7 +212,7 @@ internal sealed class AutoTranslateRunner
         var trimmed = value.Trim();
         if (trimmed.Length == 0)
         {
-            throw new InvalidOperationException("--translate-prompt is empty. Pass the prompt text or the path to a text file.");
+            throw new InvalidOperationException($"{optionName} is empty. Pass the prompt text or the path to a text file.");
         }
 
         var exists = FileExistsSafe(trimmed);
@@ -216,23 +221,23 @@ internal sealed class AutoTranslateRunner
             if (!exists)
             {
                 throw new InvalidOperationException(
-                    $"Translate prompt file not found: {trimmed}. " +
-                    "A --translate-prompt value with no spaces, or ending in .txt/.prompt/.md, is read as a file path; " +
-                    "prompt text passed inline has to contain a space or a {0}/{1}/{2} placeholder.");
+                    $"Prompt file not found: {trimmed}. " +
+                    $"A {optionName} value with no spaces, or ending in .txt/.prompt/.md, is read as a file path; " +
+                    $"prompt text passed inline has to contain a space or a {placeholders} placeholder.");
             }
 
             var size = new FileInfo(trimmed).Length;
             if (size > MaxPromptFileBytes)
             {
                 throw new InvalidOperationException(
-                    $"Translate prompt file is too large ({size / 1024} KB, max {MaxPromptFileBytes / 1024} KB): {trimmed}. " +
-                    "--translate-prompt takes the prompt itself, not a data file.");
+                    $"Prompt file is too large ({size / 1024} KB, max {MaxPromptFileBytes / 1024} KB): {trimmed}. " +
+                    $"{optionName} takes the prompt itself, not a data file.");
             }
 
             var fromFile = File.ReadAllText(trimmed).Trim();
             if (fromFile.Length == 0)
             {
-                throw new InvalidOperationException($"Translate prompt file is empty: {trimmed}");
+                throw new InvalidOperationException($"Prompt file is empty: {trimmed}");
             }
 
             return fromFile;

--- a/src/seconv/Core/ListHelpers.cs
+++ b/src/seconv/Core/ListHelpers.cs
@@ -267,14 +267,14 @@ internal static class ListHelpers
                         id = "ollama", aliases = Array.Empty<string>(), type = "http",
                         isDefault = false, ready = (bool?)null,
                         requires = "A running Ollama instance with a vision model",
-                        options = new[] { "--ollama-url", "--ollama-model", "--ocr-language" },
+                        options = new[] { "--ollama-url", "--ollama-model", "--ocr-language", "--ocr-prompt" },
                     },
                     new
                     {
                         id = "llamacpp", aliases = Array.Empty<string>(), type = "http",
                         isDefault = false, ready = llamaCppInstalled && llamaCppModelCount > 0,
                         requires = $"llama-server ({(llamaCppInstalled ? "installed" : "not found")}) plus an OCR model ({llamaCppModelCount} installed) — download via Subtitle Edit's OCR window, or point --ocr-url at a running server",
-                        options = new[] { "--ocr-model", "--ocr-url", "--ocr-language" },
+                        options = new[] { "--ocr-model", "--ocr-url", "--ocr-language", "--ocr-prompt" },
                     },
                     new
                     {

--- a/src/seconv/Core/LlamaCppOcrEngine.cs
+++ b/src/seconv/Core/LlamaCppOcrEngine.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
+using Nikse.SubtitleEdit.UiLogic.Ocr;
 
 namespace SeConv.Core;
 
@@ -20,22 +21,22 @@ internal sealed class LlamaCppOcrEngine : IOcrEngine
 {
     public string Name => "llama.cpp";
 
-    // Same default prompt as the UI's llama.cpp OCR (SeOcr.LlamaCppOcrPrompt).
-    private const string PromptTemplate = "Extract all text exactly as written. The language is {language}. Preserve line breaks.";
-
     private readonly HttpClient _httpClient;
     private readonly string _language;
     private readonly string _modelName;
+    private readonly string _promptTemplate;
     private readonly string? _url;          // non-null = user-managed server via --ocr-url
     private readonly LlamaCppModel? _model; // non-null = local server mode; started on first Recognize
     private readonly bool _quiet;
 
-    private LlamaCppOcrEngine(string? url, LlamaCppModel? model, string modelName, string? language, bool quiet)
+    private LlamaCppOcrEngine(string? url, LlamaCppModel? model, string modelName, string? language, string? prompt, bool quiet)
     {
         _url = url;
         _model = model;
         _modelName = modelName;
         _language = string.IsNullOrWhiteSpace(language) ? "English" : language;
+        // Shared with the UI's default so the two cannot drift; --ocr-prompt overrides it.
+        _promptTemplate = string.IsNullOrWhiteSpace(prompt) ? SeOcrDefaults.LlamaCppOcrPrompt : prompt;
         _quiet = quiet;
         _httpClient = new HttpClient
         {
@@ -67,12 +68,12 @@ internal sealed class LlamaCppOcrEngine : IOcrEngine
             var modelName = string.IsNullOrWhiteSpace(options.OcrModel)
                 ? "glmocr"
                 : Path.GetFileNameWithoutExtension(options.OcrModel.Trim());
-            return new LlamaCppOcrEngine(fullUrl, null, modelName, options.OcrLanguage, options.Quiet);
+            return new LlamaCppOcrEngine(fullUrl, null, modelName, options.OcrLanguage, options.OcrPrompt, options.Quiet);
         }
 
         LlamaCppLocal.EnsureServerBinary("the OCR window > llama.cpp", "--ocr-url");
         var model = ResolveOcrModel(options.OcrModel);
-        return new LlamaCppOcrEngine(null, model, Path.GetFileNameWithoutExtension(model.FileName), options.OcrLanguage, options.Quiet);
+        return new LlamaCppOcrEngine(null, model, Path.GetFileNameWithoutExtension(model.FileName), options.OcrLanguage, options.OcrPrompt, options.Quiet);
     }
 
     public string Recognize(SKBitmap bitmap)
@@ -101,7 +102,7 @@ internal sealed class LlamaCppOcrEngine : IOcrEngine
         using var data = image.Encode(SKEncodedImageFormat.Png, 90);
         var base64 = Convert.ToBase64String(data.ToArray());
 
-        var prompt = PromptTemplate.Replace("{language}", _language);
+        var prompt = _promptTemplate.Replace("{language}", _language);
         var body = "{ \"model\": \"" + Escape(_modelName) + "\", \"temperature\": 0, \"messages\": [ { \"role\": \"user\", \"content\": [ " +
                    "{ \"type\": \"text\", \"text\": \"" + Escape(prompt) + "\" }, " +
                    "{ \"type\": \"image_url\", \"image_url\": { \"url\": \"data:image/png;base64," + base64 + "\" } } " +

--- a/src/seconv/Core/OcrEngineFactory.cs
+++ b/src/seconv/Core/OcrEngineFactory.cs
@@ -15,7 +15,7 @@ internal static class OcrEngineFactory
             "tesseract" or "" => TesseractOcrEngine.Create(options.OcrLanguage ?? "eng"),
             "nocr" => new NOcrOcrEngine(ResolveOcrDbPath(options, "nocr", ".nocr")),
             "binaryocr" or "binary" => new BinaryOcrOcrEngine(ResolveOcrDbPath(options, "binaryocr", ".db")),
-            "ollama" => new OllamaOcrEngine(options.OllamaUrl, options.OllamaModel, options.OcrLanguage),
+            "ollama" => new OllamaOcrEngine(options.OllamaUrl, options.OllamaModel, options.OcrLanguage, options.OcrPrompt),
             "llamacpp" or "llama.cpp" or "llama" => LlamaCppOcrEngine.Create(options),
             "paddle" or "paddleocr" => PaddleOcrEngine.Create(options.OcrLanguage ?? "en"),
             _ => throw new InvalidOperationException(

--- a/src/seconv/Core/OllamaOcrEngine.cs
+++ b/src/seconv/Core/OllamaOcrEngine.cs
@@ -20,12 +20,16 @@ internal sealed class OllamaOcrEngine : IOcrEngine
     private readonly string _url;
     private readonly string _model;
     private readonly string _language;
+    private readonly string? _promptTemplate;
 
-    public OllamaOcrEngine(string? url, string? model, string? language)
+    public OllamaOcrEngine(string? url, string? model, string? language, string? prompt = null)
     {
         _url = string.IsNullOrWhiteSpace(url) ? "http://localhost:11434/api/chat" : url;
         _model = string.IsNullOrWhiteSpace(model) ? "llama3.2-vision" : model;
         _language = string.IsNullOrWhiteSpace(language) ? "English" : language;
+        // Ollama OCR has no prompt in the GUI, so its built-in wording stays the default here;
+        // --ocr-prompt replaces it for users driving a model that wants different phrasing.
+        _promptTemplate = string.IsNullOrWhiteSpace(prompt) ? null : prompt;
 
         _httpClient = new HttpClient
         {
@@ -47,7 +51,9 @@ internal sealed class OllamaOcrEngine : IOcrEngine
         var pngBytes = data.ToArray();
         var base64 = Convert.ToBase64String(pngBytes);
 
-        var prompt = $"Act as a precise OCR engine. Transcribe every line of text from this image exactly as it appears. The language is {_language}. Maintain the vertical order. Use a single '\\n' to separate each line. Do not skip any text. Output only the transcribed text";
+        var prompt = _promptTemplate != null
+            ? _promptTemplate.Replace("{language}", _language)
+            : $"Act as a precise OCR engine. Transcribe every line of text from this image exactly as it appears. The language is {_language}. Maintain the vertical order. Use a single '\\n' to separate each line. Do not skip any text. Output only the transcribed text";
         var body = "{ \"model\": \"" + Escape(_model) + "\", " +
                    "\"messages\": [ { \"role\": \"user\", \"content\": \"" + Escape(prompt) + "\", " +
                    "\"images\": [ \"" + base64 + "\" ] } ], " +

--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -1216,6 +1216,12 @@ internal record class ConversionOptions
     /// <summary>llama.cpp OCR model: curated <c>.gguf</c> file name or full path (default: first installed OCR model).</summary>
     public string? OcrModel { get; init; }
 
+    /// <summary>
+    /// Prompt for the prompt-driven OCR engines (llamacpp, ollama); <c>{language}</c> is replaced
+    /// with <see cref="OcrLanguage"/>. Null = each engine's built-in default.
+    /// </summary>
+    public string? OcrPrompt { get; init; }
+
     /// <summary>Auto-translate target language (code or English name). Non-null enables translation.</summary>
     public string? TranslateTo { get; init; }
 

--- a/src/seconv/Helpers/HelpDisplay.cs
+++ b/src/seconv/Helpers/HelpDisplay.cs
@@ -65,6 +65,7 @@ internal static class HelpDisplay
         ShowParameter(console, "--ocr-language:<lang>", "Language for OCR (e.g. eng, deu, spa)");
         ShowParameter(console, "--ocr-db:<path>", ".nocr (--ocr-engine=nocr) or .db (--ocr-engine=binaryocr)");
         ShowParameter(console, "--ocr-model:<model>", "llamacpp OCR .gguf file name/path (default: first downloaded OCR model)");
+        ShowParameter(console, "--ocr-prompt:<text|file>", "prompt for llamacpp/ollama OCR; {language} = --ocr-language (default: same as the OCR window)");
         ShowParameter(console, "--ocr-url:<url>", "Endpoint of an already-running llama-server for OCR (skips the auto-start)");
         ShowParameter(console, "--time-codes-only", "Image sources (.sup/VobSub/PGS/DVB/XSUB) -> text with time codes only; skips OCR");
         ShowParameter(console, "--no-vobsub-isolate-colors", "Disable VobSub OCR colour isolation (on by default; isolation binarises to black-on-white, dropping outline colours)");

--- a/src/ui/Features/Ocr/Engines/LlamaCppOcr.cs
+++ b/src/ui/Features/Ocr/Engines/LlamaCppOcr.cs
@@ -38,7 +38,7 @@ public class LlamaCppOcr : IDisposable
             //System.IO.File.WriteAllBytes("c:\\temp\\ollama-ocr-image.png", pngBytes);
 
             var template = string.IsNullOrWhiteSpace(promptTemplate)
-                ? "Extract all text exactly as written. The language is {language}. Preserve line breaks."
+                ? SeOcrDefaults.LlamaCppOcrPrompt
                 : promptTemplate;
             var prompt = template
                 .Replace("{language}", language)

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -3,6 +3,7 @@ using Nikse.SubtitleEdit.Core.Forms.FixCommonErrors;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic.Config.Language;
+using Nikse.SubtitleEdit.UiLogic.Ocr;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -489,6 +490,22 @@ public class Se
     }
 
     /// <summary>
+    /// Moves a settings file still holding the pre-#14221 llama.cpp OCR prompt onto the current
+    /// default. That prompt asked the models to "preserve line breaks", which measurably merged
+    /// two-line subtitles into one (see <see cref="SeOcrDefaults.LlamaCppOcrPrompt"/>), and the
+    /// default is persisted, so without this only fresh installs would ever get the fix. Matched
+    /// verbatim: a user who has edited the prompt at all keeps their own version.
+    /// </summary>
+    internal static void MigrateLlamaCppOcrPrompt(SeOcr ocr)
+    {
+        const string legacyPrompt = "Extract all text exactly as written. The language is {language}. Preserve line breaks.";
+        if (ocr.LlamaCppOcrPrompt?.Trim() == legacyPrompt)
+        {
+            ocr.LlamaCppOcrPrompt = SeOcrDefaults.LlamaCppOcrPrompt;
+        }
+    }
+
+    /// <summary>
     /// Drops "-vsync vfr" from a settings file written before ffmpeg 9. ffmpeg 9 removed the
     /// long-deprecated -vsync option, so it aborts with "Unrecognized option 'vsync'" and shot
     /// change detection silently finds nothing. The option was a no-op for this command line
@@ -692,6 +709,8 @@ public class Se
         {
             Settings.Ocr = new();
         }
+
+        MigrateLlamaCppOcrPrompt(Settings.Ocr);
 
         if (Settings.Formats == null)
         {

--- a/src/ui/Logic/Config/SeOcr.cs
+++ b/src/ui/Logic/Config/SeOcr.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using Nikse.SubtitleEdit.UiLogic.Ocr;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Nikse.SubtitleEdit.Logic.Config;
@@ -117,7 +118,7 @@ public class SeOcr
 
         LlamaCppUrl = "http://127.0.0.1:8080/v1/chat/completions";
         LlamaCppOcrModel = string.Empty;
-        LlamaCppOcrPrompt = "Extract all text exactly as written. The language is {language}. Preserve line breaks.";
+        LlamaCppOcrPrompt = SeOcrDefaults.LlamaCppOcrPrompt;
         LlamaCppOcrTimeoutMinutes = 5;
 
         CrispEmbedBackend = "GLM-OCR";

--- a/tests/UI/Logic/Config/LlamaCppOcrPromptMigrationTests.cs
+++ b/tests/UI/Logic/Config/LlamaCppOcrPromptMigrationTests.cs
@@ -1,0 +1,76 @@
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.UiLogic.Ocr;
+
+namespace UITests.Logic.Config;
+
+public class LlamaCppOcrPromptMigrationTests
+{
+    private const string LegacyPrompt = "Extract all text exactly as written. The language is {language}. Preserve line breaks.";
+
+    [Fact]
+    public void LegacyPromptIsReplaced()
+    {
+        var ocr = new SeOcr { LlamaCppOcrPrompt = LegacyPrompt };
+
+        Se.MigrateLlamaCppOcrPrompt(ocr);
+
+        Assert.Equal(SeOcrDefaults.LlamaCppOcrPrompt, ocr.LlamaCppOcrPrompt);
+    }
+
+    [Fact]
+    public void DefaultPromptIsUnchanged()
+    {
+        var ocr = new SeOcr();
+
+        Se.MigrateLlamaCppOcrPrompt(ocr);
+
+        Assert.Equal(SeOcrDefaults.LlamaCppOcrPrompt, ocr.LlamaCppOcrPrompt);
+    }
+
+    // The whole point of matching verbatim: anything the user typed themselves survives.
+    [Theory]
+    [InlineData("Read the text. Language: {language}.")]
+    [InlineData("Extract all text exactly as written. The language is {language}. Preserve line breaks. Keep music notes.")]
+    [InlineData("Extract all text exactly as written. Preserve line breaks.")]
+    public void CustomizedPromptIsKept(string prompt)
+    {
+        var ocr = new SeOcr { LlamaCppOcrPrompt = prompt };
+
+        Se.MigrateLlamaCppOcrPrompt(ocr);
+
+        Assert.Equal(prompt, ocr.LlamaCppOcrPrompt);
+    }
+
+    [Fact]
+    public void EmptyPromptIsLeftAlone()
+    {
+        // An empty prompt already means "use the engine default" in LlamaCppOcr.Ocr.
+        var ocr = new SeOcr { LlamaCppOcrPrompt = string.Empty };
+
+        Se.MigrateLlamaCppOcrPrompt(ocr);
+
+        Assert.Equal(string.Empty, ocr.LlamaCppOcrPrompt);
+    }
+
+    [Fact]
+    public void NullPromptDoesNotThrow()
+    {
+        var ocr = new SeOcr { LlamaCppOcrPrompt = null! };
+
+        Se.MigrateLlamaCppOcrPrompt(ocr);
+
+        Assert.Null(ocr.LlamaCppOcrPrompt);
+    }
+
+    // #14221: the new prompt makes the model count the lines first. Both halves matter - the
+    // line-counting instruction and "exactly as written" - so guard the wording, and the
+    // {language} placeholder the OCR settings dialog validates for.
+    [Fact]
+    public void DefaultPromptCountsLinesAndKeepsTheLanguagePlaceholder()
+    {
+        Assert.Contains("number of lines", SeOcrDefaults.LlamaCppOcrPrompt);
+        Assert.Contains("exactly as written", SeOcrDefaults.LlamaCppOcrPrompt);
+        Assert.Contains("{language}", SeOcrDefaults.LlamaCppOcrPrompt);
+        Assert.DoesNotContain("Preserve line breaks", SeOcrDefaults.LlamaCppOcrPrompt);
+    }
+}

--- a/tests/seconv/Core/OcrPromptOptionTest.cs
+++ b/tests/seconv/Core/OcrPromptOptionTest.cs
@@ -1,0 +1,91 @@
+using Nikse.SubtitleEdit.UiLogic.Ocr;
+using SeConv.Core;
+using SeConv.Helpers;
+using Xunit;
+
+namespace SeConvTests.Core;
+
+/// <summary>
+/// Covers <c>--ocr-prompt</c> (#14221): the option itself, and the fact that seconv's OCR default
+/// is the same string the OCR window uses instead of a third hand-kept copy.
+/// </summary>
+public class OcrPromptOptionTest
+{
+    [Fact]
+    public void OcrPrompt_IsBoundAsAnOption()
+    {
+        var option = Assert.Single(CliSchema.Options, o => o.Name == "--ocr-prompt");
+
+        Assert.Contains("--ocrprompt", option.Aliases);
+        Assert.Equal("option", option.Group);
+    }
+
+    // The prompt reader is shared with --translate-prompt; only the wording of its errors and the
+    // placeholder hint change, so the OCR caller gets the same file/inline handling for free.
+    [Fact]
+    public void ReadPromptOption_InlineOcrPrompt_StaysInline()
+    {
+        const string prompt = "Read every line. The language is {language}.";
+
+        Assert.Equal(prompt, AutoTranslateRunner.ReadPromptOption(prompt, "--ocr-prompt", "{language}"));
+    }
+
+    [Fact]
+    public void ReadPromptOption_OcrPromptFile_IsReadFromDisk()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".txt");
+        File.WriteAllText(path, "Count the lines, then read them. Language: {language}.\n");
+        try
+        {
+            Assert.Equal(
+                "Count the lines, then read them. Language: {language}.",
+                AutoTranslateRunner.ReadPromptOption(path, "--ocr-prompt", "{language}"));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    // A path-shaped value that does not exist must fail loudly rather than be sent to the model
+    // as the prompt - the same trap --translate-prompt guards against, and the message has to
+    // name the option the user actually typed.
+    [Fact]
+    public void ReadPromptOption_MissingOcrPromptFile_NamesTheOcrOption()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => AutoTranslateRunner.ReadPromptOption("no-such-ocr-prompt.txt", "--ocr-prompt", "{language}"));
+
+        Assert.Contains("not found", ex.Message);
+        Assert.Contains("--ocr-prompt", ex.Message);
+        Assert.Contains("{language}", ex.Message);
+        Assert.DoesNotContain("--translate-prompt", ex.Message);
+    }
+
+    [Fact]
+    public void ReadPromptOption_EmptyOcrPrompt_NamesTheOcrOption()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => AutoTranslateRunner.ReadPromptOption("   ", "--ocr-prompt", "{language}"));
+
+        Assert.Contains("--ocr-prompt is empty", ex.Message);
+    }
+
+    [Fact]
+    public void ReadPromptOption_DefaultsStillDescribeTranslate()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() => AutoTranslateRunner.ReadPromptOption("   "));
+
+        Assert.Contains("--translate-prompt is empty", ex.Message);
+    }
+
+    // seconv used to hold its own copy of the prompt, kept in sync by a comment. #14221 changed
+    // the default and the copy would have been missed, so both now read the shared constant.
+    [Fact]
+    public void SharedDefaultPrompt_CountsLinesAndKeepsThePlaceholder()
+    {
+        Assert.Contains("number of lines", SeOcrDefaults.LlamaCppOcrPrompt);
+        Assert.Contains("exactly as written", SeOcrDefaults.LlamaCppOcrPrompt);
+        Assert.Contains("{language}", SeOcrDefaults.LlamaCppOcrPrompt);
+    }
+}


### PR DESCRIPTION
Fixes #14221 — thanks @tekk42, the diagnosis was right.

## The bug

The llama.cpp OCR prompt asked the models to *"preserve line breaks"*. These models work line by line and rebuild the break from context alone, so there is nothing for them to preserve, and two-line subtitles came back merged into one. Making the model count the lines first fixes it.

## Measurements

134 subtitle bitmaps decoded from four Blu-ray `.sup` files (67 of them two-line; EN/DA/DE), run against GLM-OCR 0.9B Q8_0 through SE's own server flags, square padding and request body. Expected line count per image comes from a row-projection analysis of the bitmap, validated 24/24 against hand transcription.

| prompt | line breaks lost (of 67) | one-liners wrongly split |
|---|---|---|
| count lines + "exactly as written" **(new default)** | **2** | 0 |
| count lines, as filed in the issue | 3 | 0 |
| "This image is a subtitle…" | 3 | 0 |
| old default + "never merge two lines" | 7 | 0 |
| **"preserve line breaks" (old default)** | **8** | 0 |
| bare "Extract the text from the image." | 8 | 0 |

Three things make this safe to change:

- **The prompt moves line breaks and nothing else.** Across all 134 images every candidate returned character-identical text once newlines are flattened, and no one-line image was ever split.
- **It is deterministic.** Three repeats were byte-identical. McNemar vs the old default: the new prompt fixes 5–6 of its 8 merges and introduces **0** new ones.
- **"exactly as written" earns its place.** It is what separates this from the wording in the issue — one more break recovered on GLM-OCR, and dropping it also cost PaddleOCR-VL 4 breaks on a 30-image subset.

Two residual failures no prompt fixed. All 8 hard cases came from one disc (tight leading, mid-sentence breaks); the Danish and German discs lost zero breaks under any prompt.

## Why the setting stays shared, not per-model

`LlamaCppOcrPrompt` is one setting for all four llama.cpp OCR models, and I checked what per-model tuning would actually buy — 30-image subset stacked with GLM's hard cases:

| model | old default | issue's prompt | new default |
|---|---|---|---|
| GLM-OCR 0.9B | 8/30 merged | 3/30 | **2/30** |
| PaddleOCR-VL 1.6 | 21/30 | 25/30 | 22/30 |
| HunyuanOCR 1.5 | 23/30 | 25/30 | 25/30 |
| LightOnOCR 1B | 28/30 | 28/30 | 27/30 |

Only GLM-OCR — the default and top-ranked engine — is prompt-sensitive. The other three merge 70–93 % of two-line subtitles under *every* prompt tried, matching the existing ranking note that GLM-OCR is the only one that keeps line breaks. Letting each model pick its own best prompt would buy **3 line breaks across 120 image-model pairs**, against per-model prompt plumbing at four OCR entry points and a prompt box that would silently change under the user on every model switch. Note the new default is also best-or-tied for LightOnOCR and within 1 for PaddleOCR-VL; only HunyuanOCR pays 2, on a metric it is already failing.

Worth revisiting only if PaddleOCR-VL's and HunyuanOCR's own model-card prompts turn out to beat the generic one — untested here. The `LlamaCppModel` record already has a `PromptTemplate` field if that day comes.

## Settings migration

The default is persisted, so without a migration only fresh installs would get the fix. `Se.MigrateLlamaCppOcrPrompt` moves a settings file still holding the old prompt **verbatim** onto the new one; anything the user has edited is left alone.

## seconv `--ocr-prompt`

The issue's second ask. Accepts inline text or a path to a text file exactly like `--translate-prompt`, whose reader it now shares (only the option name and placeholder hint in the error messages differ). `{language}` is replaced with `--ocr-language`. It applies to the two prompt-driven OCR engines (`llamacpp`, `ollama`) and is rejected for the others rather than silently ignored:

```bash
seconv movie.sup subrip --ocr-engine:llamacpp --ocr-language:German \
  --ocr-prompt:"Identify the number of lines, then extract the text of each line exactly as written. The language is {language}."
seconv movie.sup subrip --ocr-engine:llamacpp --ocr-prompt:my-ocr-prompt.txt
```

seconv also held its own copy of the default prompt, kept in sync by a comment — exactly the kind of copy this change would have missed. It and the engine fallback now read one shared `SeOcrDefaults` constant.

## Verification

- End-to-end through the real seconv pipeline on a Danish `.sup`: the new default kept the line break on *"indtil de afsluttede det sidste / niveau af Breath of the Wild."*; passing the old wording via `--ocr-prompt` merged it — the reported bug reproduced and fixed, and proof the new flag reaches the model.
- Full suites green: seconv 429, UI 4200, libuilogic 724.
- New tests cover the migration (verbatim match, customized prompts kept, null/empty), the default's wording and `{language}` placeholder, and `--ocr-prompt` parsing/validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
