### PR TITLE
Duration field: accept a frame-mode value typed without the colon

### DIFF
--- a/src/ui/Controls/SecondsUpDown.cs
+++ b/src/ui/Controls/SecondsUpDown.cs
@@ -6,6 +6,7 @@ using Avalonia.Controls.Templates;
 using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Media;
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -271,6 +272,11 @@ public class SecondsUpDown : TemplatedControl
                 var totalMs = seconds * 1000 + SubtitleFormat.FramesToMilliseconds(frames);
                 return TimeSpanExtensions.FromMillisecondsWholeMilliseconds(totalMs);
             }
+
+            if (TryParseSecondsAndFramesWithoutSeparator(text.Trim(), out var separatorLessMs))
+            {
+                return TimeSpanExtensions.FromMillisecondsWholeMilliseconds(separatorLessMs);
+            }
         }
         else
         {
@@ -285,6 +291,49 @@ public class SecondsUpDown : TemplatedControl
         }
 
         return TimeSpan.Zero;
+    }
+
+    /// <summary>
+    /// Accepts a frame-mode duration typed without the colon, like the masked start/end time
+    /// fields do: "300" is three seconds and zero frames. One or two digits are read as whole
+    /// seconds ("5" is five seconds, not five frames), longer input has its last two digits
+    /// read as frames.
+    /// </summary>
+    private static bool TryParseSecondsAndFramesWithoutSeparator(string text, out double totalMilliseconds)
+    {
+        totalMilliseconds = 0;
+
+        if (text.Length == 0 || text.Length > 8)
+        {
+            return false;
+        }
+
+        foreach (var c in text)
+        {
+            if (!char.IsAsciiDigit(c))
+            {
+                return false;
+            }
+        }
+
+        var secondsText = text.Length <= 2 ? text : text.Substring(0, text.Length - 2);
+        var framesText = text.Length <= 2 ? "0" : text.Substring(text.Length - 2);
+        if (!int.TryParse(secondsText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var seconds) ||
+            !int.TryParse(framesText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var frames))
+        {
+            return false;
+        }
+
+        // A frame number the frame rate cannot hold ("199" at 25 fps) would otherwise silently
+        // add a second - keep it inside the last second instead.
+        var maxFrames = (int)(Configuration.Settings.General.CurrentFrameRate - 0.01);
+        if (frames > maxFrames)
+        {
+            frames = maxFrames;
+        }
+
+        totalMilliseconds = seconds * 1000.0 + SubtitleFormat.FramesToMilliseconds(frames);
+        return true;
     }
 
     private static string FormatTime(TimeSpan ts)

--- a/tests/UI/Controls/SecondsUpDownParseTests.cs
+++ b/tests/UI/Controls/SecondsUpDownParseTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Reflection;
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Controls;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Controls;
+
+// In frame mode the duration field shows "seconds:frames", and typing the value without the
+// colon (300 for 3:00) used to reset it to 0:00 - the masked start/end fields accept that form.
+public class SecondsUpDownParseTests
+{
+    private static readonly MethodInfo ParseTime =
+        typeof(SecondsUpDown).GetMethod("ParseTime", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    private static int ParseMs(string input, bool frameMode)
+    {
+        var oldFrameMode = Se.Settings.General.UseFrameMode;
+        var oldFrameRate = Configuration.Settings.General.CurrentFrameRate;
+        try
+        {
+            Se.Settings.General.UseFrameMode = frameMode;
+            Configuration.Settings.General.CurrentFrameRate = 25;
+            return (int)((TimeSpan)ParseTime.Invoke(null, new object?[] { input })!).TotalMilliseconds;
+        }
+        finally
+        {
+            Se.Settings.General.UseFrameMode = oldFrameMode;
+            Configuration.Settings.General.CurrentFrameRate = oldFrameRate;
+        }
+    }
+
+    [AvaloniaTheory]
+    [InlineData("3:00", 3000)]
+    [InlineData("3:12", 3480)]
+    [InlineData("300", 3000)]      // no colon - last two digits are frames
+    [InlineData("312", 3480)]
+    [InlineData("1200", 12000)]
+    [InlineData("5", 5000)]        // one or two digits are whole seconds
+    [InlineData("12", 12000)]
+    [InlineData("012", 480)]       // ...but a leading zero means 0 seconds and 12 frames
+    [InlineData("199", 1960)]      // 99 frames cannot fit at 25 fps - clamped to 24
+    [InlineData("0", 0)]
+    public void ParsesFrameMode(string input, int expectedMs)
+    {
+        Assert.Equal(expectedMs, ParseMs(input, true));
+    }
+
+    [AvaloniaTheory]
+    [InlineData("3.000", 3000)]
+    [InlineData("3,000", 3000)]
+    [InlineData("300", 300000)]   // seconds mode - a bare number is seconds, as before
+    public void ParsesSecondsMode(string input, int expectedMs)
+    {
+        Assert.Equal(expectedMs, ParseMs(input, false));
+    }
+}


### PR DESCRIPTION
Reported by email by René: in the beta, under EBU-STL you cannot edit the duration without typing a colon — entering `300` instead of `3:00` gives `0:00`. The other time fields work.

## Cause

In frame mode the duration field shows `seconds:frames`. Start and end times are `TimeCodeUpDown`, a masked control, so bare digits fill the mask. Duration is `SecondsUpDown`, a plain text box, and its parser only accepted the two-part form:

```csharp
var parts = text.Split(':');
if (parts.Length == 2 && ...)   // "300" is one part -> falls through -> TimeSpan.Zero
```

## Fix

A separator-less entry is now read the way a mask would take it — the last two digits are frames, one or two digits are whole seconds, and an impossible frame number is clamped to the last frame of the second.

| typed | before | after |
|---|---|---|
| `300` | 0:00 | 3:00 |
| `312` | 0:00 | 3:12 |
| `5` | 0:00 | 5:00 |
| `199` (25 fps) | 0:00 | 1:24 |

Seconds mode is untouched: a bare number there still means seconds.

## Tests

13 new cases in `tests/UI/Controls/SecondsUpDownParseTests.cs` covering both modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)