### PR TITLE
Read and write Manzanita DVB teletext files (.dvbttx)

### DIFF
--- a/src/libse/ContainerFormats/TransportStream/DvbSubPes.cs
+++ b/src/libse/ContainerFormats/TransportStream/DvbSubPes.cs
@@ -35,6 +35,37 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
 
         private readonly byte[] _dataBuffer;
 
+        private DvbSubPes(byte[] dataBuffer, ulong presentationTimestamp)
+        {
+            _dataBuffer = dataBuffer;
+            Length = dataBuffer.Length;
+            PresentationTimestamp = presentationTimestamp;
+        }
+
+        /// <summary>
+        /// Wraps a teletext PES payload (data_identifier followed by data units) that arrives
+        /// without a PES header of its own - e.g. from a Manzanita "private_stream_1" dump,
+        /// where the packet boundaries and time stamps come from the XML data index instead.
+        /// </summary>
+        public static DvbSubPes FromTeletextPayload(byte[] payload, ulong presentationTimestamp)
+        {
+            return new DvbSubPes(payload, presentationTimestamp);
+        }
+
+        /// <summary>
+        /// True if the buffer starts with an EBU teletext data_identifier (ETSI EN 300 472)
+        /// followed by a teletext or stuffing data unit of the mandatory 44-byte size.
+        /// </summary>
+        public static bool IsTeletextPayload(byte[] buffer)
+        {
+            return buffer.Length >= 46 &&
+                   buffer[0] >= 0x10 && buffer[0] <= 0x1f &&
+                   (buffer[1] == (int)Teletext.DataUnitT.DataUnitEbuTeletextNonSubtitle ||
+                    buffer[1] == (int)Teletext.DataUnitT.DataUnitEbuTeletextSubtitle ||
+                    buffer[1] == (int)Teletext.DataUnitT.DataUnitStuffing) &&
+                   buffer[2] == 44;
+        }
+
         public DvbSubPes(byte[] buffer, int index)
             : this(buffer, index, buffer.Length)
         {

--- a/src/libse/ContainerFormats/TransportStream/ManzanitaTeletextWriter.cs
+++ b/src/libse/ContainerFormats/TransportStream/ManzanitaTeletextWriter.cs
@@ -1,0 +1,606 @@
+﻿using Nikse.SubtitleEdit.Core.Common;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
+{
+    /// <summary>
+    /// Writes subtitles as a Manzanita "private_stream_1" DVB teletext file (.dvbttx): an XML
+    /// preamble holding a packet index, followed by the raw teletext PES payloads that index
+    /// points into. <see cref="ManzanitaTransportStreamParser"/> reads the result back.
+    /// <para>
+    /// The packet layout follows ETSI EN 300 472 / ETS 300 706 and mirrors a real broadcast dump:
+    /// one page header per subtitle (erase + subtitle flags set), one boxed double height row per
+    /// text line, and a filler page header closing the transmission.
+    /// </para>
+    /// </summary>
+    public class ManzanitaTeletextWriter
+    {
+        /// <summary>
+        /// Teletext page carrying the subtitles, e.g. 888.
+        /// </summary>
+        public int PageNumber { get; set; } = 888;
+
+        /// <summary>
+        /// Three letter ISO 639-2 language code for the teletext descriptor.
+        /// </summary>
+        public string LanguageCode { get; set; } = "eng";
+
+        public double FrameRate { get; set; } = 25.0;
+
+        public string Creator { get; set; } = "Subtitle Edit";
+
+        /// <summary>
+        /// Written to the XML preamble - settable so tests can produce a stable file.
+        /// </summary>
+        public DateTime Date { get; set; } = DateTime.Now;
+
+        /// <summary>
+        /// Teletext transmits the payload least significant bit first, so 0x27 is stored as 0xE4.
+        /// </summary>
+        private const byte FramingCode = 0xE4;
+
+        private const byte DataIdentifier = 0x10;
+        private const byte DataUnitLength = 44;
+        private const int DataUnitSize = DataUnitLength + 2; // data_unit_id + data_unit_length
+        private const byte StuffingDataUnitId = (byte)Teletext.DataUnitT.DataUnitStuffing;
+        private const byte SubtitleDataUnitId = (byte)Teletext.DataUnitT.DataUnitEbuTeletextSubtitle;
+
+        // Page FE in the same magazine is the usual "nothing to see here" filler that terminates
+        // a page transmission in serial mode.
+        private const int FillerPageBcd = 0xfe;
+
+        // A teletext page is hidden one frame before the header that replaces it (Teletext.cs
+        // subtracts a fixed 40 ms), so the erase must be sent that much after the wanted end.
+        private const ulong HideOffsetMs = 40;
+
+        private const int ColumnCount = 40;
+        private const int LastRow = 23;
+        private const int DefaultBottomRow = 22; // a double height row covers 22 and 23
+
+        // Spacing attributes, ETS 300 706 chapter 12.2.
+        private const byte DoubleHeight = 0x0d;
+        private const byte StartBox = 0x0b;
+        private const byte EndBox = 0x0a;
+        private const byte AlphaWhite = 0x07;
+        private const byte Space = 0x20;
+
+        // The first data unit of a packet claims this VBI line, the next one the line below, ...
+        private const int FirstLineOffset = 7;
+
+        private enum Alignment
+        {
+            Left,
+            Center,
+            Right
+        }
+
+        private class TeletextPacket
+        {
+            public ulong Milliseconds { get; set; }
+            public List<byte[]> DataUnits { get; } = new List<byte[]>();
+        }
+
+        public void Write(Subtitle subtitle, string fileName)
+        {
+            File.WriteAllBytes(fileName, GetBytes(subtitle));
+        }
+
+        public byte[] GetBytes(Subtitle subtitle)
+        {
+            var packets = BuildPackets(subtitle);
+
+            // EN 300 472 wants a constant PES payload size - pad every packet to the widest one.
+            var dataUnitsPerPacket = Math.Max(3, packets.Count == 0 ? 3 : packets.Max(p => p.DataUnits.Count));
+            var payloadLength = 1 + dataUnitsPerPacket * DataUnitSize;
+
+            var binary = new List<byte>(payloadLength * Math.Max(1, packets.Count));
+            var index = new StringBuilder();
+            var offset = 0;
+            foreach (var packet in packets)
+            {
+                binary.Add(DataIdentifier);
+                foreach (var dataUnit in packet.DataUnits)
+                {
+                    binary.AddRange(dataUnit);
+                }
+
+                for (var i = packet.DataUnits.Count; i < dataUnitsPerPacket; i++)
+                {
+                    binary.AddRange(GetStuffingDataUnit());
+                }
+
+                index.Append("    <packet pts=\"").Append((packet.Milliseconds * 90).ToString(CultureInfo.InvariantCulture))
+                     .Append("\" offset=\"").Append(offset.ToString(CultureInfo.InvariantCulture))
+                     .Append("\" length=\"").Append(payloadLength.ToString(CultureInfo.InvariantCulture))
+                     .Append("\" />\n");
+                offset += payloadLength;
+            }
+
+            var result = new List<byte>(offset + 2000);
+            result.AddRange(Encoding.ASCII.GetBytes(GetXml(index.ToString(), payloadLength)));
+            result.AddRange(binary);
+            return result.ToArray();
+        }
+
+        private string GetXml(string dataIndex, int payloadLength)
+        {
+            // A muxer hint only: how much bandwidth the stream needs if every frame carries a
+            // packet of this size, counting the PES header and the 188 byte transport packets.
+            var transportPackets = (int)Math.Ceiling((payloadLength + 14) / 184.0);
+            var rate = transportPackets * 188 * 8 * FrameRate;
+
+            var magazine = PageNumber / 100 % 8; // magazine 8 is transmitted as 0
+            var pageBcd = Teletext.DecToBec(PageNumber) & 0xff;
+
+            var sb = new StringBuilder();
+            sb.Append("<private_stream_1\n");
+            sb.Append("  xmlns=\"http://www.manzanitasystems.com/schema/v1.03/private_stream_1\"\n");
+            sb.Append("  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n");
+            sb.Append("  xsi:schemaLocation=\"http://www.manzanitasystems.com/schema/v1.03/private_stream_1\"\n");
+            sb.Append("  version=\"1.03\"\n");
+            sb.Append("  type=\"").Append(ManzanitaTransportStreamParser.TeletextStreamType).Append("\">\n\n");
+            sb.Append("  <preamble>\n");
+            sb.Append("    <conversion_data\n");
+            sb.Append("      creator=\"").Append(XmlEscape(Creator)).Append("\"\n");
+            sb.Append("      date=\"").Append(Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)).Append("\"\n");
+            sb.Append("      source_format=\"demux\"\n");
+            sb.Append("    />\n");
+            sb.Append("    <descriptors>\n");
+            sb.Append("      <dvb_teletext_descriptor>\n");
+            sb.Append("        <dvb_teletext_content\n");
+            sb.Append("          ISO_639_language_code=\"").Append(XmlEscape(GetLanguageCode())).Append("\"\n");
+            sb.Append("          teletext_type=\"subtitle\"\n");
+            sb.Append("          teletext_magazine_number=\"").Append(magazine.ToString(CultureInfo.InvariantCulture)).Append("\"\n");
+            sb.Append("          teletext_page_number=\"").Append(pageBcd.ToString(CultureInfo.InvariantCulture)).Append("\"\n");
+            sb.Append("        />\n");
+            sb.Append("      </dvb_teletext_descriptor>\n");
+            sb.Append("    </descriptors>\n");
+            sb.Append("    <pes_header\n");
+            sb.Append("      PES_priority=\"0\"\n");
+            sb.Append("      copyright=\"0\"\n");
+            sb.Append("      original_or_copy=\"0\"\n");
+            sb.Append("      stream_id=\"189\"\n");
+            sb.Append("    />\n");
+            sb.Append("    <timing_information\n");
+            sb.Append("      average_rate=\"").Append(rate.ToString("0.000", CultureInfo.InvariantCulture)).Append("\"\n");
+            sb.Append("      max_rate=\"").Append(rate.ToString("0.000", CultureInfo.InvariantCulture)).Append("\"\n");
+            sb.Append("      min_advance_time=\"3600\"\n");
+            sb.Append("      max_advance_time=\"7200\"\n");
+            sb.Append("    />\n");
+            sb.Append("  </preamble>\n\n");
+            sb.Append("  <data_index>\n");
+            sb.Append(dataIndex);
+            sb.Append("  </data_index>\n\n");
+
+            // The reader finds the binary section by the end tag plus a single line feed - keep it.
+            sb.Append("</private_stream_1>\n");
+            return sb.ToString();
+        }
+
+        private string GetLanguageCode()
+        {
+            var code = (LanguageCode ?? string.Empty).Trim();
+            return code.Length == 3 ? code.ToLowerInvariant() : "eng";
+        }
+
+        private static string XmlEscape(string text)
+        {
+            return (text ?? string.Empty)
+                .Replace("&", "&amp;")
+                .Replace("<", "&lt;")
+                .Replace(">", "&gt;")
+                .Replace("\"", "&quot;");
+        }
+
+        private List<TeletextPacket> BuildPackets(Subtitle subtitle)
+        {
+            var packets = new List<TeletextPacket>();
+            if (subtitle?.Paragraphs == null)
+            {
+                return packets;
+            }
+
+            var magazine = PageNumber / 100 % 8;
+            var pageBcd = Teletext.DecToBec(PageNumber) & 0xff;
+            var paragraphs = subtitle.Paragraphs;
+
+            for (var i = 0; i < paragraphs.Count; i++)
+            {
+                var p = paragraphs[i];
+                var show = new TeletextPacket { Milliseconds = ToMilliseconds(p.StartTime.TotalMilliseconds) };
+                show.DataUnits.Add(GetPageHeaderDataUnit(magazine, pageBcd, show.DataUnits.Count, erasePage: true));
+                show.DataUnits.AddRange(GetTextDataUnits(p, magazine, show.DataUnits.Count));
+                show.DataUnits.Add(GetPageHeaderDataUnit(magazine, FillerPageBcd, show.DataUnits.Count, erasePage: false));
+                packets.Add(show);
+
+                // Clearing the page is only needed when no other subtitle takes over: the header
+                // of the next subtitle erases this one anyway.
+                var eraseMs = ToMilliseconds(p.EndTime.TotalMilliseconds) + HideOffsetMs;
+                var next = i + 1 < paragraphs.Count ? paragraphs[i + 1] : null;
+                if (next != null && ToMilliseconds(next.StartTime.TotalMilliseconds) <= eraseMs)
+                {
+                    continue;
+                }
+
+                var erase = new TeletextPacket { Milliseconds = eraseMs };
+                erase.DataUnits.Add(GetPageHeaderDataUnit(magazine, pageBcd, 0, erasePage: true));
+                erase.DataUnits.Add(GetPageHeaderDataUnit(magazine, FillerPageBcd, 1, erasePage: false));
+                packets.Add(erase);
+            }
+
+            // Overlapping or unsorted subtitles would otherwise put the index out of order, and
+            // both the muxer and the reader expect the time stamps to grow. OrderBy is stable, so
+            // a page and the erase that belongs to it keep their order.
+            return packets.OrderBy(p => p.Milliseconds).ToList();
+        }
+
+        private static ulong ToMilliseconds(double milliseconds)
+        {
+            return milliseconds <= 0 ? 0 : (ulong)Math.Round(milliseconds, MidpointRounding.AwayFromZero);
+        }
+
+        /// <summary>
+        /// Packet 0 of a page - page number, flags and the (suppressed) header row.
+        /// </summary>
+        private static byte[] GetPageHeaderDataUnit(int magazine, int pageBcd, int unitIndex, bool erasePage)
+        {
+            var data = new byte[ColumnCount];
+            data[0] = TeletextHamming.Hamming84Encode(pageBcd & 0x0f);        // page units
+            data[1] = TeletextHamming.Hamming84Encode((pageBcd >> 4) & 0x0f); // page tens
+            data[2] = TeletextHamming.Hamming84Encode(0);                     // S1
+            data[3] = TeletextHamming.Hamming84Encode(erasePage ? 0x08 : 0x00); // S2 + C4 erase page
+            data[4] = TeletextHamming.Hamming84Encode(0);                     // S3
+            data[5] = TeletextHamming.Hamming84Encode(0x08);                  // S4 + C6 subtitle
+            data[6] = TeletextHamming.Hamming84Encode(0x07);                  // C7 suppress header, C8 update, C9 interrupted
+            data[7] = TeletextHamming.Hamming84Encode(0x01);                  // C11 serial magazine, latin G0 charset
+
+            // The header row is not displayed (C7), but the cells still have to be valid.
+            for (var i = 8; i < ColumnCount; i++)
+            {
+                data[i] = TeletextHamming.OddParityEncode(Space);
+            }
+
+            return GetDataUnit(magazine, 0, data, unitIndex, alreadyEncoded: true);
+        }
+
+        private static List<byte[]> GetTextDataUnits(Paragraph paragraph, int magazine, int firstUnitIndex)
+        {
+            var result = new List<byte[]>();
+            var text = paragraph.Text ?? string.Empty;
+            var alignment = GetAlignment(ref text, out var topAligned);
+            // Teletext has no italics or positioning of its own, so only the color tags survive.
+            var lines = Utilities.RemoveSsaTags(
+                    HtmlUtil.RemoveOpenCloseTags(text, HtmlUtil.TagItalic, HtmlUtil.TagBold, HtmlUtil.TagUnderline))
+                .SplitToLines()
+                .Where(line => !string.IsNullOrWhiteSpace(line))
+                .ToList();
+            if (lines.Count == 0)
+            {
+                return result;
+            }
+
+            var rows = GetRowNumbers(lines.Count, paragraph.MarginV, topAligned, out var doubleHeight);
+            for (var i = 0; i < lines.Count; i++)
+            {
+                result.Add(GetDataUnit(magazine, rows[i], GetRow(lines[i], alignment, doubleHeight),
+                    firstUnitIndex + i, alreadyEncoded: false));
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Bottom aligned rows counted upwards, or the top of the screen for {\an7}-{\an9}. A
+        /// double height row occupies the row below it too, hence the gap of two.
+        /// </summary>
+        private static List<int> GetRowNumbers(int lineCount, string marginV, bool topAligned, out bool doubleHeight)
+        {
+            doubleHeight = true;
+            var rows = new List<int>();
+
+            if (topAligned && !IsTeletextRow(marginV))
+            {
+                // Teletext.cs reports {\an8} again when every used row is above row 6.
+                for (var i = 0; i < lineCount; i++)
+                {
+                    rows.Add(1 + i * 2);
+                }
+
+                if (rows[rows.Count - 1] <= LastRow)
+                {
+                    return rows;
+                }
+
+                rows.Clear();
+            }
+
+            var bottom = IsTeletextRow(marginV) ? int.Parse(marginV, CultureInfo.InvariantCulture) : DefaultBottomRow;
+            var spacing = 2;
+            if (bottom - (lineCount - 1) * spacing < 1)
+            {
+                // Too many lines to fit at double height - fall back to single height rows.
+                spacing = 1;
+                doubleHeight = false;
+            }
+
+            for (var i = 0; i < lineCount; i++)
+            {
+                rows.Add(Math.Max(1, bottom - (lineCount - 1 - i) * spacing));
+            }
+
+            return rows;
+        }
+
+        private static bool IsTeletextRow(string marginV)
+        {
+            return int.TryParse(marginV, NumberStyles.Integer, CultureInfo.InvariantCulture, out var row) &&
+                   row >= 1 && row <= LastRow;
+        }
+
+        private static Alignment GetAlignment(ref string text, out bool topAligned)
+        {
+            topAligned = false;
+            var alignment = Alignment.Center;
+            if (text.Length > 5 && text[0] == '{' && text[1] == '\\' && text[5] == '}')
+            {
+                var tag = text.Substring(0, 6);
+                switch (tag)
+                {
+                    case "{\\an1}":
+                    case "{\\an4}":
+                        alignment = Alignment.Left;
+                        break;
+                    case "{\\an7}":
+                        alignment = Alignment.Left;
+                        topAligned = true;
+                        break;
+                    case "{\\an3}":
+                    case "{\\an6}":
+                        alignment = Alignment.Right;
+                        break;
+                    case "{\\an9}":
+                        alignment = Alignment.Right;
+                        topAligned = true;
+                        break;
+                    case "{\\an8}":
+                        topAligned = true;
+                        break;
+                }
+
+                if (tag.StartsWith("{\\an", StringComparison.Ordinal))
+                {
+                    text = text.Substring(6);
+                }
+            }
+
+            return alignment;
+        }
+
+        /// <summary>
+        /// Turns one line of text into the 40 cells of a teletext row: a leading color attribute,
+        /// the double height and start box attributes, the text itself and the end box markers,
+        /// padded to the wanted alignment.
+        /// </summary>
+        private static byte[] GetRow(string line, Alignment alignment, bool doubleHeight)
+        {
+            var lead = new List<byte>();
+            var body = new List<byte>();
+            AppendText(line, lead, body);
+
+            var attributes = doubleHeight ? new List<byte> { DoubleHeight, StartBox, StartBox } : new List<byte> { StartBox, StartBox };
+            var maxBody = ColumnCount - lead.Count - attributes.Count;
+            if (body.Count > maxBody)
+            {
+                body.RemoveRange(maxBody, body.Count - maxBody);
+            }
+
+            // A row ending in the last column closes the box on its own, so the end box markers
+            // only take the space that is left - that is what real broadcast rows do, and it buys
+            // the two characters that would otherwise clip a full width line.
+            var endBoxCount = Math.Min(2, ColumnCount - lead.Count - attributes.Count - body.Count);
+            var used = lead.Count + attributes.Count + body.Count + endBoxCount;
+            var leftPad = 0;
+            if (alignment == Alignment.Center)
+            {
+                leftPad = (ColumnCount - used) / 2;
+            }
+            else if (alignment == Alignment.Right)
+            {
+                leftPad = ColumnCount - used;
+            }
+
+            var cells = new List<byte>(ColumnCount);
+            cells.AddRange(Enumerable.Repeat(Space, leftPad));
+            cells.AddRange(lead);
+            cells.AddRange(attributes);
+            cells.AddRange(body);
+            for (var i = 0; i < endBoxCount; i++)
+            {
+                cells.Add(EndBox);
+            }
+
+            while (cells.Count < ColumnCount)
+            {
+                cells.Add(Space);
+            }
+
+            return cells.ToArray();
+        }
+
+        /// <summary>
+        /// Splits the line into the color attribute that applies before the box starts (teletext
+        /// shows a spacing attribute as a space, so a leading color is free of charge there) and
+        /// the boxed cells, where every further color change costs one cell.
+        /// </summary>
+        private static void AppendText(string line, List<byte> lead, List<byte> body)
+        {
+            var i = 0;
+            while (i < line.Length)
+            {
+                if (line[i] == '<')
+                {
+                    var end = line.IndexOf('>', i);
+                    if (end > 0)
+                    {
+                        var tag = line.Substring(i, end - i + 1);
+                        if (tag.StartsWith("<font", StringComparison.OrdinalIgnoreCase))
+                        {
+                            var color = GetTeletextColor(tag);
+                            if (color.HasValue)
+                            {
+                                if (body.Count == 0 && lead.Count == 0)
+                                {
+                                    lead.Add(color.Value);
+                                }
+                                else
+                                {
+                                    body.Add(color.Value);
+                                }
+                            }
+
+                            i = end + 1;
+                            continue;
+                        }
+
+                        if (tag.Equals("</font>", StringComparison.OrdinalIgnoreCase))
+                        {
+                            // Back to the start-of-row default, but only when text follows.
+                            if (body.Count > 0 && end + 1 < line.Length)
+                            {
+                                body.Add(AlphaWhite);
+                            }
+
+                            i = end + 1;
+                            continue;
+                        }
+                    }
+                }
+
+                foreach (var c in GetTeletextCharacters(line[i]))
+                {
+                    body.Add(c);
+                }
+
+                i++;
+            }
+        }
+
+        /// <summary>
+        /// Teletext rows hold seven bit G0 characters, so anything else is folded to its base
+        /// letter ("é" to "e") and whatever is left is replaced by a question mark.
+        /// </summary>
+        private static IEnumerable<byte> GetTeletextCharacters(char c)
+        {
+            if (c >= 0x20 && c < 0x7f)
+            {
+                yield return (byte)c;
+                yield break;
+            }
+
+            var normalized = c.ToString().Normalize(NormalizationForm.FormD);
+            var any = false;
+            foreach (var n in normalized)
+            {
+                if (n >= 0x20 && n < 0x7f)
+                {
+                    any = true;
+                    yield return (byte)n;
+                }
+            }
+
+            if (!any)
+            {
+                yield return (byte)'?';
+            }
+        }
+
+        private static byte? GetTeletextColor(string fontTag)
+        {
+            var colorStart = fontTag.IndexOf("color=", StringComparison.OrdinalIgnoreCase);
+            if (colorStart < 0)
+            {
+                return null;
+            }
+
+            var color = fontTag.Substring(colorStart + "color=".Length).TrimStart().TrimEnd('>', '/', ' ');
+            color = color.Trim('"', '\'').Trim().Trim('#').ToLowerInvariant();
+            if (color.Length == 0)
+            {
+                return null;
+            }
+
+            switch (color)
+            {
+                case "black": return 0x00;
+                case "red": return 0x01;
+                case "lime":
+                case "green": return 0x02;
+                case "yellow": return 0x03;
+                case "blue": return 0x04;
+                case "magenta":
+                case "fuchsia": return 0x05;
+                case "cyan":
+                case "aqua": return 0x06;
+                case "white": return 0x07;
+            }
+
+            if (color.Length == 6 &&
+                int.TryParse(color.Substring(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var r) &&
+                int.TryParse(color.Substring(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var g) &&
+                int.TryParse(color.Substring(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var b))
+            {
+                // Teletext only has the eight combinations of full red, green and blue.
+                var code = (r >= 128 ? 1 : 0) | (g >= 128 ? 2 : 0) | (b >= 128 ? 4 : 0);
+                return (byte)code;
+            }
+
+            return null;
+        }
+
+        private static byte[] GetStuffingDataUnit()
+        {
+            var unit = new byte[DataUnitSize];
+            unit[0] = StuffingDataUnitId;
+            unit[1] = DataUnitLength;
+            for (var i = 2; i < unit.Length; i++)
+            {
+                unit[i] = 0xff;
+            }
+
+            return unit;
+        }
+
+        /// <summary>
+        /// Wraps 40 data bytes in a teletext data unit: the VBI line, the framing code, the
+        /// Hamming 8/4 coded magazine and packet number, and the payload - all but the first byte
+        /// stored least significant bit first, as they go on air.
+        /// </summary>
+        private static byte[] GetDataUnit(int magazine, int packetNumber, byte[] data, int unitIndex, bool alreadyEncoded)
+        {
+            var unit = new byte[DataUnitSize];
+            unit[0] = SubtitleDataUnitId;
+            unit[1] = DataUnitLength;
+
+            var lineOffset = Math.Min(22, FirstLineOffset + Math.Max(0, unitIndex));
+            unit[2] = (byte)(0xc0 | lineOffset); // reserved_future_use, field_parity, line_offset
+            unit[3] = FramingCode;
+
+            var address = ((packetNumber & 0x1f) << 3) | (magazine & 0x07);
+            unit[4] = TeletextHamming.Reverse8[TeletextHamming.Hamming84Encode(address & 0x0f)];
+            unit[5] = TeletextHamming.Reverse8[TeletextHamming.Hamming84Encode((address >> 4) & 0x0f)];
+
+            for (var i = 0; i < ColumnCount; i++)
+            {
+                var value = alreadyEncoded ? data[i] : TeletextHamming.OddParityEncode(data[i]);
+                unit[6 + i] = TeletextHamming.Reverse8[value];
+            }
+
+            return unit;
+        }
+    }
+}

--- a/src/libse/ContainerFormats/TransportStream/ManzanitaTransportStreamParser.cs
+++ b/src/libse/ContainerFormats/TransportStream/ManzanitaTransportStreamParser.cs
@@ -3,6 +3,7 @@ using Nikse.SubtitleEdit.Core.VobSub;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Xml;
 
@@ -13,11 +14,29 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
     /// </summary>
     public class ManzanitaTransportStreamParser
     {
+        /// <summary>
+        /// The "type" attribute of a Manzanita file carrying DVB teletext (as opposed to
+        /// "dvb_subtitle", which carries the bitmap subtitles handled by <see cref="GetDvbSup"/>).
+        /// </summary>
+        public const string TeletextStreamType = "dvb_teletext";
+
+        // Teletext state in Teletext.cs is keyed by the transport stream packet id; a Manzanita
+        // dump holds a single elementary stream, so any fixed id will do.
+        private const int TeletextPacketId = 1;
+
         private readonly List<DvbSubPes> _dvbSubs;
+        private readonly List<DvbSubPes> _teletextPes;
+
+        /// <summary>
+        /// Teletext page numbers (decimal, e.g. 888) seen in the parsed file.
+        /// </summary>
+        public List<int> TeletextPages { get; }
 
         public ManzanitaTransportStreamParser()
         {
             _dvbSubs = new List<DvbSubPes>();
+            _teletextPes = new List<DvbSubPes>();
+            TeletextPages = new List<int>();
         }
 
         public void Parse(string fileName)
@@ -34,7 +53,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
         /// <param name="ms">Input stream</param>
         public void Parse(Stream ms)
         {
-            var dataIndices = GetDataIndicesAndPesStart(ms, out var dvbPesStartIndex);
+            var dataIndices = GetDataIndicesAndPesStart(ms, out var dvbPesStartIndex, out var streamType);
             if (dvbPesStartIndex <= 0)
             {
                 return;
@@ -49,6 +68,31 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
                 if (bytesRead < pesData.Length)
                 {
                     break; // incomplete packet at end-of-file
+                }
+
+                // A teletext dump holds the bare PES payload - data_identifier plus data units -
+                // so it has no PES header for the constructors below to read.
+                if (streamType == TeletextStreamType || DvbSubPes.IsTeletextPayload(pesData))
+                {
+                    if (!DvbSubPes.IsTeletextPayload(pesData))
+                    {
+                        continue; // a teletext stream, but not in a shape this can decode
+                    }
+
+                    var teletextPes = DvbSubPes.FromTeletextPayload(pesData, dataIndex.Pts);
+                    foreach (var page in teletextPes.PrepareTeletext()) // also flips the bit order - call once per packet
+                    {
+                        // Page numbers are binary coded decimals, so the filler pages FF and FE
+                        // that close a transmission read back as 965 and 964 - out of range for a
+                        // real page (magazine 1-8, page 00-99) and empty anyway.
+                        if (page >= 100 && page <= 899 && !TeletextPages.Contains(page))
+                        {
+                            TeletextPages.Add(page);
+                        }
+                    }
+
+                    _teletextPes.Add(teletextPes);
+                    continue;
                 }
 
                 DvbSubPes pes;
@@ -72,7 +116,17 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
 
         public static IEnumerable<ManzanitaDataIndex> GetDataIndicesAndPesStart(Stream ms, out int startIndex)
         {
+            return GetDataIndicesAndPesStart(ms, out startIndex, out _);
+        }
+
+        /// <summary>
+        /// Same as <see cref="GetDataIndicesAndPesStart(Stream, out int)"/>, but also reports the
+        /// "type" attribute of the root element ("dvb_teletext", "dvb_subtitle", ...).
+        /// </summary>
+        public static IEnumerable<ManzanitaDataIndex> GetDataIndicesAndPesStart(Stream ms, out int startIndex, out string streamType)
+        {
             startIndex = 0;
+            streamType = string.Empty;
             ms.Position = 0;
             var buffer = new byte[200_000];
             var bytesRead = ms.Read(buffer, 0, buffer.Length);
@@ -98,6 +152,8 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
             {
                 return result;
             }
+
+            streamType = xmlDoc.DocumentElement.Attributes?["type"]?.Value ?? string.Empty;
 
             var dataIndexNode = xmlDoc.DocumentElement.SelectSingleNode("ns:data_index", namespaceManager);
             if (dataIndexNode == null)
@@ -169,6 +225,45 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
             }
 
             return 0;
+        }
+
+        /// <summary>
+        /// Decodes every teletext page found while parsing.
+        /// </summary>
+        /// <returns>Page number (decimal, e.g. 888) to the subtitles on that page.</returns>
+        public Dictionary<int, List<Paragraph>> GetTeletext()
+        {
+            var result = new Dictionary<int, List<Paragraph>>();
+            foreach (var page in TeletextPages.OrderBy(p => p))
+            {
+                var pageBcd = Teletext.DecToBec(page);
+                Teletext.InitializeStaticFields(TeletextPacketId, pageBcd);
+                // Unlike a transport stream there is no video track to measure the start of the
+                // programme against, so the time stamps in the index are used as they are - a
+                // file whose first subtitle sits ten minutes in must not slide to zero.
+                var runSettings = new TeletextRunSettings(null);
+                var paragraphs = new List<Paragraph>();
+                foreach (var pes in _teletextPes)
+                {
+                    foreach (var kvp in pes.GetTeletext(runSettings, page, pageBcd))
+                    {
+                        paragraphs.Add(kvp.Value);
+                    }
+                }
+
+                // The last page has no following page header to close it - flush it by hand.
+                foreach (var kvp in Teletext.ProcessTelxPacketPendingLeftovers(runSettings, page))
+                {
+                    paragraphs.Add(kvp.Value);
+                }
+
+                if (paragraphs.Count > 0)
+                {
+                    result.Add(page, paragraphs);
+                }
+            }
+
+            return result;
         }
 
         public List<TransportStreamSubtitle> GetDvbSup()

--- a/src/libse/ContainerFormats/TransportStream/Teletext.cs
+++ b/src/libse/ContainerFormats/TransportStream/Teletext.cs
@@ -31,6 +31,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
         {
             DataUnitEbuTeletextNonSubtitle = 0x02,
             DataUnitEbuTeletextSubtitle = 0x03,
+            DataUnitStuffing = 0xff,
         }
 
         public enum TransmissionMode

--- a/src/libse/ContainerFormats/TransportStream/TeletextHamming.cs
+++ b/src/libse/ContainerFormats/TransportStream/TeletextHamming.cs
@@ -62,6 +62,30 @@
             0x08, 0xff, 0xff, 0x05, 0xff, 0x0e, 0x0d, 0xff, 0xff, 0x0e, 0x0f, 0xff, 0x0e, 0x0e, 0xff, 0x0e
         };
 
+        // ETS 300 706, chapter 8.2 - the 16 Hamming 8/4 code words, i.e. the inverse of Unham84.
+        public static readonly byte[] Hamming84 =
+        {
+            0x15, 0x02, 0x49, 0x5e, 0x64, 0x73, 0x38, 0x2f,
+            0xd0, 0xc7, 0x8c, 0x9b, 0xa1, 0xb6, 0xfd, 0xea
+        };
+
+        /// <summary>
+        /// Hamming 8/4 encodes the lower four bits of <paramref name="value"/>.
+        /// </summary>
+        public static byte Hamming84Encode(int value)
+        {
+            return Hamming84[value & 0x0f];
+        }
+
+        /// <summary>
+        /// ETS 300 706, chapter 8.1 - adds the odd parity bit to a seven bit character.
+        /// </summary>
+        public static byte OddParityEncode(int value)
+        {
+            var v = (byte)(value & 0x7f);
+            return Parity8[v] == 1 ? v : (byte)(v | 0x80);
+        }
+
         // ETS 300 706, chapter 8.2 - Hamming 8/4
         public static byte UnHamming84(byte a)
         {

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1235,6 +1235,8 @@
       "exportCavenaTranslator": "Translator",
       "exportCavenaComment": "Comment",
       "exportCavenaStartOfProgramme": "Start of programme",
+      "titleExportDvbTeletext": "DVB teletext (Manzanita)",
+      "exportDvbTeletextPageNumber": "Teletext page number",
       "customTextFormatsDotDotDot": "_Custom text formats...",
       "plainTextDotDotDot": "_Plain text...",
       "customTextFormats": "Custom text formats",

--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -17,6 +17,7 @@ using Nikse.SubtitleEdit.Features.Edit.ShowHistory;
 using Nikse.SubtitleEdit.Features.Files.Compare;
 using Nikse.SubtitleEdit.Features.Files.Export.ExportEbuStl;
 using Nikse.SubtitleEdit.Features.Files.ExportCavena890;
+using Nikse.SubtitleEdit.Features.Files.ExportDvbTeletext;
 using Nikse.SubtitleEdit.Features.Files.ExportCustomTextFormat;
 using Nikse.SubtitleEdit.Features.Files.ExportImageBased;
 using Nikse.SubtitleEdit.Features.Files.ExportPac;
@@ -415,6 +416,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<EncodingSettingsViewModel>();
         collection.AddTransient<ErrorListViewModel>();
         collection.AddTransient<ExportCavena890ViewModel>();
+        collection.AddTransient<ExportDvbTeletextViewModel>();
         collection.AddTransient<ExportCustomTextFormatViewModel>();
         collection.AddTransient<ExportEbuStlViewModel>();
         collection.AddTransient<ExportImageBasedViewModel>();

--- a/src/ui/Features/Files/ExportDvbTeletext/ExportDvbTeletextViewModel.cs
+++ b/src/ui/Features/Files/ExportDvbTeletext/ExportDvbTeletextViewModel.cs
@@ -1,0 +1,58 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace Nikse.SubtitleEdit.Features.Files.ExportDvbTeletext;
+
+public partial class ExportDvbTeletextViewModel : ObservableObject
+{
+    // 888 is the page subtitles are transmitted on in most of Europe.
+    [ObservableProperty] private int _pageNumber = 888;
+    [ObservableProperty] private string _languageCode;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    public ExportDvbTeletextViewModel()
+    {
+        LanguageCode = "eng";
+    }
+
+    public void Initialize(int pageNumber, string languageCode)
+    {
+        PageNumber = pageNumber;
+        LanguageCode = languageCode;
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        OkPressed = true;
+        Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Close();
+    }
+
+    private void Close()
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            Window?.Close();
+        });
+    }
+
+    internal void OnKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Close();
+        }
+    }
+}

--- a/src/ui/Features/Files/ExportDvbTeletext/ExportDvbTeletextWindow.cs
+++ b/src/ui/Features/Files/ExportDvbTeletext/ExportDvbTeletextWindow.cs
@@ -1,0 +1,60 @@
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Files.ExportDvbTeletext;
+
+public class ExportDvbTeletextWindow : Window
+{
+    public ExportDvbTeletextWindow(ExportDvbTeletextViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = Se.Language.File.Export.TitleExportDvbTeletext;
+        SizeToContent = SizeToContent.WidthAndHeight;
+        CanResize = false;
+        vm.Window = this;
+        DataContext = vm;
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+            Margin = UiUtil.MakeWindowMargin(),
+            ColumnSpacing = 10,
+            RowSpacing = 10,
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+
+        var labelPageNumber = UiUtil.MakeLabel(Se.Language.File.Export.ExportDvbTeletextPageNumber);
+        var numericPageNumber = UiUtil.MakeNumericUpDownInt(100, 899, 888, 120, vm, nameof(vm.PageNumber));
+
+        var labelLanguage = UiUtil.MakeLabel(Se.Language.General.Language);
+        var textBoxLanguage = UiUtil.MakeTextBox(120, vm, nameof(vm.LanguageCode));
+
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        var panelButtons = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+
+        grid.Add(labelPageNumber, 0, 0);
+        grid.Add(numericPageNumber, 0, 1);
+        grid.Add(labelLanguage, 1, 0);
+        grid.Add(textBoxLanguage, 1, 1);
+        grid.Add(panelButtons, 2, 0, 1, 2);
+
+        Content = grid;
+
+        Activated += delegate { numericPageNumber.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        KeyDown += vm.OnKeyDown;
+    }
+}

--- a/src/ui/Features/Main/Layout/InitMenu.cs
+++ b/src/ui/Features/Main/Layout/InitMenu.cs
@@ -1,4 +1,4 @@
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Input;
@@ -254,6 +254,11 @@ public static class InitMenu
                         {
                             Header = Cavena890.NameOfFormat,
                             Command = vm.ExportCavena890Command,
+                        },
+                        new MenuItem
+                        {
+                            Header = Se.Language.File.Export.TitleExportDvbTeletext,
+                            Command = vm.ExportDvbTeletextCommand,
                         },
                         new MenuItem
                         {

--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -1,4 +1,4 @@
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using CommunityToolkit.Mvvm.Input;
@@ -244,6 +244,7 @@ public static class InitNativeMacMenu
         exportItems.Items.Add(Item(CheetahCaption.NameOfFormat, v => v.ExportCheetahCaptionCommand));
         exportItems.Items.Add(Item(CheetahCaptionOld.NameOfFormat, v => v.ExportCheetahCaptionOldCommand));
         exportItems.Items.Add(Item(Cavena890.NameOfFormat, v => v.ExportCavena890Command));
+        exportItems.Items.Add(Item(lExport.TitleExportDvbTeletext, v => v.ExportDvbTeletextCommand));
         exportItems.Items.Add(Item(lExport.TitleExportDCinemaInteropPng, v => v.ExportDCinemaInteropPngCommand));
         exportItems.Items.Add(Item(lExport.TitleExportDCinemaSmpte2014Png, v => v.ExportDCinemaSmpte2014PngCommand));
         exportItems.Items.Add(Item(Ebu.NameOfFormat, v => v.ExportEbuStlCommand));

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -48,6 +48,7 @@ using Nikse.SubtitleEdit.Features.Edit.ShowHistory;
 using Nikse.SubtitleEdit.Features.Files.Compare;
 using Nikse.SubtitleEdit.Features.Files.Export.ExportEbuStl;
 using Nikse.SubtitleEdit.Features.Files.ExportCavena890;
+using Nikse.SubtitleEdit.Features.Files.ExportDvbTeletext;
 using Nikse.SubtitleEdit.Features.Files.ExportCustomTextFormat;
 using Nikse.SubtitleEdit.Features.Files.ExportEbuStl;
 using Nikse.SubtitleEdit.Features.Files.ExportImageBased;
@@ -4522,6 +4523,51 @@ public partial class MainViewModel :
         }
 
         ShowStatus(string.Format(Se.Language.Main.FileExportedInFormatXToY, cavena.Name, fileName));
+    }
+
+    [RelayCommand]
+    private async Task ExportDvbTeletext()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        if (IsEmpty)
+        {
+            ShowSubtitleNotLoadedMessage();
+            return;
+        }
+
+        var result = await ShowDialogAsync<ExportDvbTeletextWindow, ExportDvbTeletextViewModel>(vm =>
+            vm.Initialize(Se.Settings.File.ExportDvbTeletextPageNumber, Se.Settings.File.ExportDvbTeletextLanguageCode));
+        if (!result.OkPressed)
+        {
+            return;
+        }
+
+        Se.Settings.File.ExportDvbTeletextPageNumber = result.PageNumber;
+        Se.Settings.File.ExportDvbTeletextLanguageCode = result.LanguageCode;
+
+        var fileName = await _fileHelper.PickSaveFile(
+            Window!,
+            new[] { (Se.Language.File.Export.TitleExportDvbTeletext, ".dvbttx") },
+            Utilities.GetPathAndFileNameWithoutExtension(GetNewFileName()) + ".dvbttx",
+            string.Format(Se.Language.Main.SaveXFileAs, Se.Language.File.Export.TitleExportDvbTeletext));
+        if (string.IsNullOrEmpty(fileName))
+        {
+            return;
+        }
+
+        var writer = new ManzanitaTeletextWriter
+        {
+            PageNumber = result.PageNumber,
+            LanguageCode = result.LanguageCode,
+            FrameRate = Configuration.Settings.General.CurrentFrameRate,
+        };
+        await File.WriteAllBytesAsync(fileName, writer.GetBytes(GetUpdateSubtitle()));
+
+        ShowStatus(string.Format(Se.Language.Main.FileExportedInFormatXToY, Se.Language.File.Export.TitleExportDvbTeletext, fileName));
     }
 
     [RelayCommand]
@@ -20066,6 +20112,16 @@ public partial class MainViewModel :
                 }
             }
 
+            // A Manzanita dump is an XML preamble plus raw PES payloads, so it has to be caught
+            // before the text based subtitle formats get a look at it.
+            if (fileSize > 100 && FileUtil.IsManzanita(fileName))
+            {
+                if (await ImportSubtitleFromManzanita(fileName))
+                {
+                    return;
+                }
+            }
+
             if ((ext == ".ts" || ext == ".tsv" || ext == ".tts" || ext == ".rec" || ext == ".mpeg" || ext == ".mpg") && fileSize > 10000 && FileUtil.IsTransportStream(fileName))
             {
                 await ImportSubtitleFromTransportStream(fileName, skipLoadVideo);
@@ -20988,6 +21044,81 @@ public partial class MainViewModel :
         }
     }
 
+    /// <summary>
+    /// Opens the teletext subtitles of a Manzanita "private_stream_1" dump (.dvbttx).
+    /// </summary>
+    /// <returns>True if subtitles were loaded, false to let the other loaders try the file.</returns>
+    private async Task<bool> ImportSubtitleFromManzanita(string fileName)
+    {
+        ShowStatus(string.Format(Se.Language.General.ParsingXDotDotDot, fileName));
+        var parser = new ManzanitaTransportStreamParser();
+        var pages = new Dictionary<int, List<Paragraph>>();
+        var dvbSubtitles = new List<TransportStreamSubtitle>();
+        try
+        {
+            await Task.Run(() =>
+            {
+                parser.Parse(fileName);
+                pages = parser.GetTeletext();
+                if (pages.Count == 0)
+                {
+                    dvbSubtitles = parser.GetDvbSup();
+                }
+            });
+        }
+        catch (Exception exception)
+        {
+            SeLogger.Error(exception, $"Error parsing Manzanita file: {fileName}");
+            ShowStatus(string.Empty);
+            return false;
+        }
+
+        ShowStatus(string.Empty);
+
+        if (pages.Count == 0)
+        {
+            // A "dvb_subtitle" dump carries bitmaps instead of teletext - they have to be OCR'ed.
+            if (dvbSubtitles.Count == 0)
+            {
+                return false;
+            }
+
+            Dispatcher.UIThread.Post(async () =>
+            {
+                var ocrResult = await ShowDialogAsync<OcrWindow, OcrViewModel>(vm => vm.Initialize(dvbSubtitles, fileName));
+                if (ocrResult.OkPressed)
+                {
+                    await FinishOcrImportAsync(fileName, ocrResult.OcredSubtitle);
+                }
+            });
+
+            return true;
+        }
+
+        var paragraphs = pages.First().Value;
+        if (pages.Count > 1)
+        {
+            var result = await ShowDialogAsync<PickTsTrackWindow, PickTsTrackViewModel>(vm => vm.Initialize(pages, fileName));
+            if (!result.OkPressed || result.SelectedTrack == null)
+            {
+                return true; // the file was ours, the user just did not pick a page
+            }
+
+            paragraphs = result.SelectedTrack.Teletext;
+        }
+
+        VideoCloseFile();
+        ResetSubtitle();
+        _subtitle = new Subtitle(paragraphs);
+        _subtitle.Renumber();
+        ReplaceSubtitles(_subtitle.Paragraphs.Select(p => new SubtitleLineViewModel(p, SelectedSubtitleFormat)));
+        SelectAndScrollToRow(0);
+        _subtitleFileName = Utilities.GetPathAndFileNameWithoutExtension(fileName) + SelectedSubtitleFormat.Extension;
+        _converted = true;
+
+        return true;
+    }
+
     private async Task ImportSubtitleFromTransportStream(string fileName, bool skipLoadVideo = false)
     {
         ShowStatus(string.Format(Se.Language.General.ParsingXDotDotDot, fileName));
@@ -21067,7 +21198,7 @@ public partial class MainViewModel :
         var subtitles = tsParser.GetDvbSubtitles(packetId);
         Dispatcher.UIThread.Post(async () =>
         {
-            var result = await ShowDialogAsync<OcrWindow, OcrViewModel>(vm => { vm.Initialize(tsParser, subtitles, fileName); });
+            var result = await ShowDialogAsync<OcrWindow, OcrViewModel>(vm => { vm.Initialize(subtitles, fileName); });
 
             if (result.OkPressed)
             {

--- a/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleTransportStream.cs
+++ b/src/ui/Features/Ocr/OcrSubtitle/OcrSubtitleTransportStream.cs
@@ -7,16 +7,12 @@ namespace Nikse.SubtitleEdit.Features.Ocr.OcrSubtitle;
 
 public class OcrSubtitleTransportStream : IOcrSubtitle
 {
-    private TransportStreamParser _tsParser;
-    private List<TransportStreamSubtitle> _subtitles;
-    private string _fileName;
+    private readonly List<TransportStreamSubtitle> _subtitles;
     public int Count { get; private set; }
 
-    public OcrSubtitleTransportStream(TransportStreamParser tsParser, List<TransportStreamSubtitle> subtitles, string fileName)
+    public OcrSubtitleTransportStream(List<TransportStreamSubtitle> subtitles)
     {
-        _tsParser = tsParser;
         _subtitles = subtitles;
-        _fileName = fileName;
         Count = _subtitles.Count;
     }
 

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
@@ -5121,11 +5121,11 @@ public partial class OcrViewModel : ObservableObject
         AutoDetectSourceLanguage();
     }
 
-    internal void Initialize(TransportStreamParser tsParser, List<TransportStreamSubtitle> subtitles, string fileName)
+    internal void Initialize(List<TransportStreamSubtitle> subtitles, string fileName)
     {
         _sourceFileName = fileName;
         Title = string.Format(Se.Language.Ocr.OcrX, fileName);
-        _ocrSubtitle = new OcrSubtitleTransportStream(tsParser, subtitles, fileName);
+        _ocrSubtitle = new OcrSubtitleTransportStream(subtitles);
         SetOcrSubtitleItems();
         AutoDetectSourceLanguage();
     }

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
@@ -803,7 +803,7 @@ public partial class BinaryEditViewModel : ObservableObject
             var subtitles = tsParser.GetDvbSubtitles(0);
             if (subtitles.Count > 0)
             {
-                return new OcrSubtitleTransportStream(tsParser, subtitles, fileName);
+                return new OcrSubtitleTransportStream(subtitles);
             }
 
             return null;

--- a/src/ui/Features/Shared/PickTsTrack/PickTsTrackViewModel.cs
+++ b/src/ui/Features/Shared/PickTsTrack/PickTsTrackViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -9,6 +9,7 @@ using Nikse.SubtitleEdit.Features.Ocr;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 
@@ -111,6 +112,27 @@ public partial class PickTsTrackViewModel : ObservableObject
         }
     }
 
+    /// <summary>
+    /// Teletext pages from a Manzanita dump, which is a single elementary stream and so has no
+    /// program map table to take packet ids or languages from.
+    /// </summary>
+    internal void Initialize(Dictionary<int, List<Paragraph>> teletextPages, string fileName)
+    {
+        _fileName = fileName;
+        WindowTitle = string.Format(Se.Language.File.PickTransportStreamTrackX, fileName);
+
+        foreach (var page in teletextPages)
+        {
+            Tracks.Add(new TsTrackInfoDisplay
+            {
+                TrackNumber = page.Key,
+                Teletext = page.Value,
+                Codec = "Teletext",
+                IsTeletext = true,
+            });
+        }
+    }
+
     private void Close()
     {
         Dispatcher.UIThread.Post(() =>
@@ -157,7 +179,7 @@ public partial class PickTsTrackViewModel : ObservableObject
     private bool TrackChanged()
     {
         var selectedTrack = SelectedTrack;
-        if (selectedTrack == null || _tsParser == null)
+        if (selectedTrack == null)
         {
             SubtitleCountText = string.Empty;
             return false;
@@ -185,6 +207,12 @@ public partial class PickTsTrackViewModel : ObservableObject
             }
 
             return true;
+        }
+
+        if (_tsParser == null)
+        {
+            SubtitleCountText = string.Empty;
+            return false;
         }
 
         // GetDvbSubtitles returns null for a packet id it decoded no images for - a subtitle PID

--- a/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Controls.Documents;
 using Avalonia.Input;
 using Avalonia.Media;
@@ -360,7 +360,7 @@ public partial class SpellCheckViewModel : ObservableObject, IClosingCleanup
                 }
 
                 var subtitles = tsParser.GetDvbSubtitles(tsParser.SubtitlePacketIds[0]);
-                return subtitles.Count > 0 ? new OcrSubtitleTransportStream(tsParser, subtitles, fileName) : null;
+                return subtitles.Count > 0 ? new OcrSubtitleTransportStream(subtitles) : null;
 
             case ".mkv":
             case ".mks":

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertItemSplitter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertItemSplitter.cs
@@ -42,7 +42,7 @@ public class BatchConvertTransportStreamSplitter : IBatchConvertItemSplitter
                     Format = item.Format,
                     FileName = item.FileName,
                     LanguageCode = language,
-                    ImageSubtitle = new OcrSubtitleTransportStream(tsParser, subtitles, item.FileName),
+                    ImageSubtitle = new OcrSubtitleTransportStream(subtitles),
                 });
             }
         }

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -534,7 +534,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             var subtitles = tsParser.GetDvbSubtitles(packetId);
             if (subtitles.Count > 0)
             {
-                result.Add(new TransportStreamResult { IsImage = true, OcrSubtitle = new OcrSubtitleTransportStream(tsParser, subtitles, item.FileName) });
+                result.Add(new TransportStreamResult { IsImage = true, OcrSubtitle = new OcrSubtitleTransportStream(subtitles) });
             }
         }
 

--- a/src/ui/Logic/Config/Language/File/LanguageExport.cs
+++ b/src/ui/Logic/Config/Language/File/LanguageExport.cs
@@ -21,6 +21,8 @@ public class LanguageExport
     public string ExportCavenaTranslator { get; set; }
     public string ExportCavenaComment { get; set; }
     public string ExportCavenaStartOfProgramme { get; set; }
+    public string TitleExportDvbTeletext { get; set; }
+    public string ExportDvbTeletextPageNumber { get; set; }
     public string CustomTextFormatsDotDotDot { get; set; }
     public string PlainTextDotDotDot { get; set; }
     public string CustomTextFormats { get; set; }
@@ -92,6 +94,8 @@ public class LanguageExport
         ExportCavenaTranslator = "Translator";
         ExportCavenaComment = "Comment";
         ExportCavenaStartOfProgramme = "Start of programme";
+        TitleExportDvbTeletext = "DVB teletext (Manzanita)";
+        ExportDvbTeletextPageNumber = "Teletext page number";
         CustomTextFormatsDotDotDot = "_Custom text formats...";
         PlainTextDotDotDot = "_Plain text...";
         CustomTextFormats = "Custom text formats";

--- a/src/ui/Logic/Config/SeFile.cs
+++ b/src/ui/Logic/Config/SeFile.cs
@@ -15,6 +15,8 @@ public class SeFile
     public SeExportPlainText ExportPlainText { get; set; } = new();
     public SeDCinemaSmpte DCinemaSmpte { get; set; } = new();
     public SeEbuSaveOptions EbuSaveOptions { get; set; } = new();
+    public int ExportDvbTeletextPageNumber { get; set; } = 888;
+    public string ExportDvbTeletextLanguageCode { get; set; } = "eng";
 
     public SeFile()
     {

--- a/src/ui/Logic/Media/FileHelper.cs
+++ b/src/ui/Logic/Media/FileHelper.cs
@@ -1,4 +1,4 @@
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Platform.Storage;
 using Nikse.SubtitleEdit.Core.Common;
@@ -257,6 +257,7 @@ namespace Nikse.SubtitleEdit.Logic.Media
             AddExt(existingTypes, extensions, ".pac");
             AddExt(existingTypes, extensions, ".890");
             AddExt(existingTypes, extensions, ".fpc");
+            AddExt(existingTypes, extensions, ".dvbttx");
 
             if (includeVideoFiles)
             {

--- a/tests/libse/ContainerFormats/ManzanitaDvbSubtitleTest.cs
+++ b/tests/libse/ContainerFormats/ManzanitaDvbSubtitleTest.cs
@@ -1,0 +1,106 @@
+using Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream;
+using System.Text;
+
+namespace LibSETests.ContainerFormats;
+
+// A Manzanita dump can hold DVB bitmap subtitles instead of teletext; those go to OCR, so the
+// parser has to hand them out as transport stream subtitles with usable time codes.
+public class ManzanitaDvbSubtitleTest
+{
+    /// <summary>
+    /// One PES payload: the DVB subtitle data identifier, an optional object data segment and the
+    /// end marker. A payload without an object data segment is what ends the previous subtitle.
+    /// </summary>
+    private static byte[] MakeDvbPayload(bool withObject)
+    {
+        var payload = new List<byte> { 0x20, 0x00 };
+        if (withObject)
+        {
+            payload.AddRange(new byte[]
+            {
+                0x0f,       // sync byte
+                0x13,       // object data segment
+                0x00, 0x00, // page id
+                0x00, 0x07, // segment length
+                0x00, 0x01, // object id
+                0x00,       // version, coding method, non modifying color flag
+                0x00, 0x00, // top field data block length
+                0x00, 0x00, // bottom field data block length
+            });
+        }
+
+        payload.Add(0xff); // anything but a sync byte ends the segment loop
+        return payload.ToArray();
+    }
+
+    private static byte[] MakeManzanitaFile(params (ulong Milliseconds, byte[] Payload)[] packets)
+    {
+        var index = new StringBuilder();
+        var binary = new List<byte>();
+        foreach (var packet in packets)
+        {
+            index.Append($"    <packet pts=\"{packet.Milliseconds * 90}\" offset=\"{binary.Count}\" length=\"{packet.Payload.Length}\" />\n");
+            binary.AddRange(packet.Payload);
+        }
+
+        var xml = "<private_stream_1\n" +
+                  "  xmlns=\"http://www.manzanitasystems.com/schema/v1.03/private_stream_1\"\n" +
+                  "  version=\"1.03\"\n" +
+                  "  type=\"dvb_subtitle\">\n\n" +
+                  "  <data_index>\n" + index + "  </data_index>\n\n" +
+                  "</private_stream_1>\n";
+
+        var result = new List<byte>(Encoding.ASCII.GetBytes(xml));
+        result.AddRange(binary);
+        return result.ToArray();
+    }
+
+    private static ManzanitaTransportStreamParser Parse(byte[] file)
+    {
+        var parser = new ManzanitaTransportStreamParser();
+        using var ms = new MemoryStream(file);
+        parser.Parse(ms);
+        return parser;
+    }
+
+    [Fact]
+    public void BitmapSubtitlesKeepTheirTimeCodes()
+    {
+        var file = MakeManzanitaFile(
+            (1000, MakeDvbPayload(withObject: true)),
+            (3000, MakeDvbPayload(withObject: false)));
+
+        var subtitles = Parse(file).GetDvbSup();
+
+        var subtitle = Assert.Single(subtitles);
+        Assert.Equal(1000ul, subtitle.StartMilliseconds);
+        Assert.Equal(3000ul, subtitle.EndMilliseconds);
+        Assert.True(subtitle.IsDvbSub);
+    }
+
+    [Fact]
+    public void BitmapSubtitlesAreNotMistakenForTeletext()
+    {
+        var file = MakeManzanitaFile(
+            (1000, MakeDvbPayload(withObject: true)),
+            (3000, MakeDvbPayload(withObject: false)));
+
+        var parser = Parse(file);
+
+        Assert.Empty(parser.TeletextPages);
+        Assert.Empty(parser.GetTeletext());
+    }
+
+    [Fact]
+    public void TeletextFilesHoldNoBitmapSubtitles()
+    {
+        var writer = new ManzanitaTeletextWriter { Date = new DateTime(2026, 1, 1) };
+        var subtitle = new Nikse.SubtitleEdit.Core.Common.Subtitle();
+        subtitle.Paragraphs.Add(new Nikse.SubtitleEdit.Core.Common.Paragraph("Hello", 1000, 3000));
+
+        var parser = Parse(writer.GetBytes(subtitle));
+
+        Assert.Empty(parser.GetDvbSup());
+        Assert.Single(parser.GetTeletext());
+    }
+}

--- a/tests/libse/ContainerFormats/ManzanitaTeletextTest.cs
+++ b/tests/libse/ContainerFormats/ManzanitaTeletextTest.cs
@@ -1,0 +1,134 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream;
+
+namespace LibSETests.ContainerFormats;
+
+public class ManzanitaTeletextTest
+{
+    private static Dictionary<int, List<Paragraph>> WriteAndRead(Subtitle subtitle, int pageNumber = 888)
+    {
+        var writer = new ManzanitaTeletextWriter { PageNumber = pageNumber, Date = new DateTime(2026, 1, 1) };
+        var parser = new ManzanitaTransportStreamParser();
+        using var ms = new MemoryStream(writer.GetBytes(subtitle));
+        parser.Parse(ms);
+        return parser.GetTeletext();
+    }
+
+    private static Subtitle MakeSubtitle(params Paragraph[] paragraphs)
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.AddRange(paragraphs);
+        return subtitle;
+    }
+
+    [Fact]
+    public void RoundTripKeepsTextAndTimeCodes()
+    {
+        var subtitle = MakeSubtitle(
+            new Paragraph("Hello world!", 1000, 3000),
+            new Paragraph("Two lines" + Environment.NewLine + "of text.", 5000, 8500));
+
+        var pages = WriteAndRead(subtitle);
+
+        var paragraphs = Assert.Contains(888, (IDictionary<int, List<Paragraph>>)pages);
+        Assert.Equal(2, paragraphs.Count);
+        Assert.Equal("Hello world!", paragraphs[0].Text);
+        Assert.Equal(1000, paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(3000, paragraphs[0].EndTime.TotalMilliseconds);
+        Assert.Equal("Two lines" + Environment.NewLine + "of text.", paragraphs[1].Text);
+        Assert.Equal(5000, paragraphs[1].StartTime.TotalMilliseconds);
+        Assert.Equal(8500, paragraphs[1].EndTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void RoundTripKeepsTeletextColors()
+    {
+        var subtitle = MakeSubtitle(new Paragraph("<font color=\"#00ff00\">Green line</font>", 1000, 3000));
+
+        var paragraphs = WriteAndRead(subtitle)[888];
+
+        Assert.Equal("<font color=\"#00ff00\">Green line</font>", paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void RoundTripKeepsTopAlignment()
+    {
+        var subtitle = MakeSubtitle(new Paragraph("{\\an8}Up here", 1000, 3000));
+
+        var paragraphs = WriteAndRead(subtitle)[888];
+
+        Assert.Equal("{\\an8}Up here", paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void WritesTheRequestedPage()
+    {
+        var subtitle = MakeSubtitle(new Paragraph("On page 801", 1000, 3000));
+
+        var pages = WriteAndRead(subtitle, 801);
+
+        Assert.Equal(new[] { 801 }, pages.Keys.ToArray());
+    }
+
+    [Fact]
+    public void SubtitlesFollowingEachOtherKeepTheirOwnEndTime()
+    {
+        // No room for an erase packet between the two - the second page header ends the first.
+        var subtitle = MakeSubtitle(
+            new Paragraph("First", 1000, 2000),
+            new Paragraph("Second", 2040, 4000));
+
+        var paragraphs = WriteAndRead(subtitle)[888];
+
+        Assert.Equal(2, paragraphs.Count);
+        Assert.Equal(2000, paragraphs[0].EndTime.TotalMilliseconds);
+        Assert.Equal(2040, paragraphs[1].StartTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void ItalicAndUnsupportedCharactersAreFolded()
+    {
+        var subtitle = MakeSubtitle(new Paragraph("<i>Voilà</i>", 1000, 3000));
+
+        var paragraphs = WriteAndRead(subtitle)[888];
+
+        Assert.Equal("Voila", paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void AFullWidthLineIsNotClipped()
+    {
+        // 36 characters plus the double height and box attributes need all 40 cells of the row.
+        var subtitle = MakeSubtitle(new Paragraph("Dave's lying was a terrible burden...", 1000, 3000));
+
+        var paragraphs = WriteAndRead(subtitle)[888];
+
+        Assert.Equal("Dave's lying was a terrible burden...", paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void WrittenFileIsRecognizedAsManzanita()
+    {
+        var writer = new ManzanitaTeletextWriter { Date = new DateTime(2026, 1, 1) };
+        var bytes = writer.GetBytes(MakeSubtitle(new Paragraph("Hello", 1000, 3000)));
+
+        var fileName = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".dvbttx");
+        try
+        {
+            File.WriteAllBytes(fileName, bytes);
+            Assert.True(FileUtil.IsManzanita(fileName));
+        }
+        finally
+        {
+            File.Delete(fileName);
+        }
+    }
+
+    [Fact]
+    public void EmptySubtitleWritesNoPackets()
+    {
+        var pages = WriteAndRead(new Subtitle());
+
+        Assert.Empty(pages);
+    }
+}


### PR DESCRIPTION
From an email by René, who attached a `TSdump.dvbttx` and asked whether SE could store, read or edit it.

It is not a transport stream: it is a **Manzanita MP2TSME `<private_stream_1>` dump** — an XML preamble with a `<data_index>` of `pts`/`offset`/`length` entries, followed by the raw teletext PES payloads that index points into.

`ManzanitaTransportStreamParser` already existed in libse and could slice such a file into PES packets, but it only exposed `GetDvbSup()` (bitmap subtitles), and **nothing in the UI called it at all** — `FileUtil.IsManzanita` had zero callers. So the file fell through to the text loaders and failed to open.

## Reading

`.dvbttx` now opens from File → Open, drag & drop or the command line.

- The parser reads the root `type` attribute, wraps the bare payloads (Manzanita stores no PES header of its own) and feeds them to the existing teletext decoder.
- More than one page → the existing TS track picker.
- The filler pages FF/FE that close a transmission read back as pages 964/965, so page numbers outside the valid 100–899 range are dropped.
- Time stamps are used as they are. A transport stream has a video track to measure the start of the programme against; a subtitle-only dump does not, and rebasing on the first packet would slide a file whose first subtitle sits ten minutes in down to zero.

On René's file: **26 subtitles on page 888, colours intact.**

## Writing

**File → Export → DVB teletext (Manzanita)**, with a small dialog for page number (default 888) and language code, both remembered.

`ManzanitaTeletextWriter` builds the container per ETS 300 706: Hamming 8/4 addresses and page headers (erase, subtitle and suppress-header flags, serial mode), odd-parity G0 text, bit order flipped for transmission, boxed double-height rows, and a filler page header closing each transmission.

Colours map to the eight teletext colours, `{\an}` tags set alignment, `MarginV` sets the teletext row (the field the teletext alignment dialog already writes), accents fold to their base letter, italics are dropped — teletext has none.

The byte layout was taken from René's own dump rather than the spec alone. One detail that matters: the end-box markers only take the space that is left, which is what a real broadcast row does, and what buys a full-width 36-character line its last two characters instead of clipping them.

**Round-trip over the real dump: 26 out, 26 back in, identical text, colours and time codes** — 13.5 KB against the original 413 KB, since only packets that carry something are written.

## DVB bitmaps → OCR

A Manzanita dump of `type="dvb_subtitle"` now goes to the OCR window. No new `IOcrSubtitle` was needed: `OcrSubtitleTransportStream` took a `TransportStreamParser` and a file name and used neither — every method reads only the subtitle list. Dropping the two dead parameters made it reusable as is (5 call sites updated, none of which lost anything).

## Tests

12 new libse tests — round-trips for text, colours, top alignment, page number, full-width lines, back-to-back subtitles, tag folding; and synthetic `dvb_subtitle` containers checking that bitmaps come out with correct start *and* end times and are not mistaken for teletext.

## Not covered

The bitmap path is verified only against synthetic containers — I have no real `dvb_subtitle` dump. The routing and time codes are tested; rendering relies on the shared decoder the `.ts` path already exercises. Worth one run against a real file before the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)