### PR TITLE
EBU STL video preview: make the box and the justification work

### DIFF
--- a/src/libse/Common/SubtitlePositionToAssa.cs
+++ b/src/libse/Common/SubtitlePositionToAssa.cs
@@ -1,4 +1,4 @@
-using Nikse.SubtitleEdit.Core.SubtitleFormats;
+﻿using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -159,6 +159,11 @@ namespace Nikse.SubtitleEdit.Core.Common
                         alignment = 5;
                     }
 
+                    // The row says how far down the line sits, the justification says which way it
+                    // is aligned - without this every line stays centered no matter what the EBU
+                    // options dialog is set to.
+                    alignment += GetEbuJustificationOffset();
+
                     p.Text = "{\\an" + alignment.ToString(CultureInfo.InvariantCulture) + "}" + p.Text;
                 }
 
@@ -179,6 +184,21 @@ namespace Nikse.SubtitleEdit.Core.Common
             }
 
             return applied;
+        }
+
+        /// <summary>
+        /// Turns the EBU justification code into a shift of the ASSA alignment column: the codes
+        /// are 0 = unchanged, 1 = left, 2 = centered and 3 = right, and each centered alignment
+        /// (2, 5 and 8) has its left neighbour one below it and its right one above.
+        /// </summary>
+        private static int GetEbuJustificationOffset()
+        {
+            switch (Ebu.EbuUiHelper?.JustificationCode)
+            {
+                case 1: return -1;
+                case 3: return 1;
+                default: return 0;
+            }
         }
 
         private static int GetEbuRowCount(string header)

--- a/src/ui/Features/Main/Layout/InitToolbar.cs
+++ b/src/ui/Features/Main/Layout/InitToolbar.cs
@@ -522,9 +522,16 @@ public static class InitToolbar
         // options, DCinema/timed-text/WebVTT properties, ...) - the same dialogs as the File menu's
         // "<format> properties..." item. Placed left of the format selector: the right-aligned
         // panel grows leftwards, so the selector keeps its position when the button appears.
+        // Unlike the icons on the left, this one stands among text labels and combo boxes rather
+        // than among other icons, where the untouched 32 px artwork reads as oversized - size it
+        // to the controls beside it.
+        var formatPropertiesImage = MakeImage("Settings");
+        formatPropertiesImage.Width = 22;
+        formatPropertiesImage.Height = 22;
+
         var formatPropertiesButton = new Button
         {
-            Content = MakeImage("Settings"),
+            Content = formatPropertiesImage,
             Command = vm.FilePropertiesShowCommand,
             Background = Brushes.Transparent,
             [!AutomationProperties.NameProperty] = new Binding(nameof(vm.FilePropertiesText)) { Source = vm },

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -4666,6 +4666,11 @@ public partial class MainViewModel :
             saveHelper.SetFrameRate(result.StoredHeader, result.FrameRateFromSaveDialog);
         }
 
+        // The box, the justification and the row options all change how the lines are drawn in
+        // the video preview. Only subtitle edits mark it dirty, so a settings-only change used to
+        // sit there unseen until the next keystroke.
+        _mpvPreviewDirty = true;
+
         return true;
     }
 

--- a/src/ui/Logic/Media/MpvReloader.cs
+++ b/src/ui/Logic/Media/MpvReloader.cs
@@ -3,6 +3,7 @@ using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
+using SkiaSharp;
 using System;
 using System.IO;
 using System.Linq;
@@ -244,9 +245,24 @@ public class MpvReloader : IMpvReloader
 
             if (oldHeader != null && oldHeader.Length > 20 && oldHeader.AsSpan(3, 3).SequenceEqual("STL"))
             {
-                var previewFontName = Configuration.IsRunningOnLinux ? Configuration.DefaultLinuxFontName : "Tahoma";
-                var boxStyle = $"Style: Box,{previewFontName},12,&H00FFFFFF,&H0300FFFF,&H00000000,&H02000000,-1,0,0,0,100,100,0,0,3,2,0,2,10,10,10,1{Environment.NewLine}Style: Default,";
-                subtitle.Header = subtitle.Header.Replace("Style: Default,", boxStyle, StringComparison.Ordinal);
+                // The teletext box is the preview style drawn with an opaque background instead
+                // of an outline. It used to be a hard coded 12 pt Tahoma style, so a boxed line
+                // threw away the font, size, color, alignment and margins the preview was set
+                // up with, and rendered much smaller than an unboxed one.
+                var boxStyle = GetMpvPreviewStyle(Se.Settings.Video);
+                boxStyle.Name = "Box";
+                boxStyle.BorderStyle = "3"; // opaque box
+                boxStyle.Outline = SKColors.Black; // border style 3 fills the box with the outline color, and a teletext box is black
+                boxStyle.ShadowWidth = 0;
+                if (boxStyle.OutlineWidth < 1)
+                {
+                    boxStyle.OutlineWidth = 1; // the box would otherwise cling to the glyphs
+                }
+
+                subtitle.Header = subtitle.Header.Replace(
+                    "Style: Default,",
+                    boxStyle.ToRawAss(SsaStyle.DefaultAssStyleFormat) + Environment.NewLine + "Style: Default,",
+                    StringComparison.Ordinal);
 
                 var useBox = false;
                 if (Configuration.Settings.SubtitleSettings.EbuStlTeletextUseBox)

--- a/tests/UI/Logic/Media/MpvPreviewStlBoxTests.cs
+++ b/tests/UI/Logic/Media/MpvPreviewStlBoxTests.cs
@@ -1,0 +1,122 @@
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+using System.Reflection;
+using System.Text;
+
+namespace UITests.Logic.Media;
+
+/// <summary>
+/// An EBU STL file that uses the teletext box is previewed with an opaque background behind the
+/// text. The box style used to be hard coded to 12 pt Tahoma, so a boxed line ignored the font,
+/// size, color, alignment and margins the mpv preview was set up with and came out much smaller
+/// than an unboxed one.
+/// </summary>
+public class MpvPreviewStlBoxTests
+{
+    private const int FontNameField = 1;
+    private const int FontSizeField = 2;
+    private const int BorderStyleField = 15;
+
+    private static string MakeStlHeader(string displayStandardCode)
+    {
+        var buffer = new byte[1024];
+        for (var i = 0; i < buffer.Length; i++)
+        {
+            buffer[i] = 0x20;
+        }
+
+        Encoding.ASCII.GetBytes("850").CopyTo(buffer, 0);
+        Encoding.ASCII.GetBytes("STL25.01").CopyTo(buffer, 3);
+        Encoding.ASCII.GetBytes(displayStandardCode).CopyTo(buffer, 11);
+        Encoding.ASCII.GetBytes("00").CopyTo(buffer, 12);
+        return Ebu.ReadHeader(buffer).ToString();
+    }
+
+    private static string BuildPreviewText(bool useBox)
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
+        var oldUseBox = Configuration.Settings.SubtitleSettings.EbuStlTeletextUseBox;
+        var oldFontName = Se.Settings.Video.MpvPreviewFontName;
+        var oldFontSize = Se.Settings.Video.MpvPreviewFontSize;
+        try
+        {
+            Configuration.Settings.SubtitleSettings.EbuStlTeletextUseBox = useBox;
+            Se.Settings.Video.MpvPreviewFontName = "Verdana";
+            Se.Settings.Video.MpvPreviewFontSize = 33;
+
+            var subtitle = new Subtitle { Header = MakeStlHeader("1") }; // 1 = level 1 teletext
+            subtitle.Paragraphs.Add(new Paragraph("Hello world", 1000, 3000));
+
+            var reloader = new MpvReloader();
+            var method = typeof(MpvReloader).GetMethod("BuildPreviewText", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(method);
+            var result = method!.Invoke(reloader, new object?[] { subtitle, null, typeof(Ebu), 0, string.Empty })!;
+            return (string)result.GetType().GetField("Item2")!.GetValue(result)!;
+        }
+        finally
+        {
+            Configuration.Settings.SubtitleSettings.EbuStlTeletextUseBox = oldUseBox;
+            Se.Settings.Video.MpvPreviewFontName = oldFontName;
+            Se.Settings.Video.MpvPreviewFontSize = oldFontSize;
+        }
+    }
+
+    private static string[] GetStyle(string assText, string name)
+    {
+        var line = assText.Split('\n').FirstOrDefault(l => l.StartsWith("Style: " + name + ",", StringComparison.Ordinal));
+        Assert.NotNull(line);
+        var fields = line!.Trim().Split(',');
+        fields[0] = fields[0].Substring("Style: ".Length);
+        return fields;
+    }
+
+    private static string GetDialogueStyle(string assText)
+    {
+        var line = assText.Split('\n').FirstOrDefault(l => l.StartsWith("Dialogue:", StringComparison.Ordinal));
+        Assert.NotNull(line);
+        return line!.Split(',')[3];
+    }
+
+    [AvaloniaFact]
+    public void BoxStyleFollowsThePreviewFontAndSize()
+    {
+        var box = GetStyle(BuildPreviewText(useBox: true), "Box");
+
+        Assert.Equal("Verdana", box[FontNameField]);
+        Assert.Equal("33", box[FontSizeField]);
+    }
+
+    [AvaloniaFact]
+    public void BoxStyleDiffersFromTheDefaultOnlyInHowTheBackgroundIsDrawn()
+    {
+        var assText = BuildPreviewText(useBox: true);
+        var box = GetStyle(assText, "Box");
+        var defaultStyle = GetStyle(assText, "Default");
+
+        Assert.Equal("3", box[BorderStyleField]); // opaque box
+        Assert.NotEqual("3", defaultStyle[BorderStyleField]);
+
+        // Everything that is not about the background has to match, or a boxed line jumps to
+        // another font, size, color or position than an unboxed one.
+        for (var i = 0; i < box.Length; i++)
+        {
+            if (i == 0 || i == BorderStyleField || i == 17) // name, border style, shadow width
+            {
+                continue;
+            }
+
+            Assert.Equal(defaultStyle[i], box[i]);
+        }
+    }
+
+    [AvaloniaFact]
+    public void TeletextLinesUseTheBoxStyleOnlyWhenTheFileUsesBoxes()
+    {
+        Assert.Equal("Box", GetDialogueStyle(BuildPreviewText(useBox: true)));
+        Assert.Equal("Default", GetDialogueStyle(BuildPreviewText(useBox: false)));
+    }
+}

--- a/tests/libse/Common/SubtitlePositionEbuJustificationTest.cs
+++ b/tests/libse/Common/SubtitlePositionEbuJustificationTest.cs
@@ -1,0 +1,99 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System.Text;
+
+namespace LibSETests.Common;
+
+// EBU STL carries the horizontal justification per text block, but the preview only ever used the
+// centered alignments, so changing the justification in the EBU options dialog did nothing on
+// screen.
+public class SubtitlePositionEbuJustificationTest
+{
+    private class JustificationHelper : Ebu.IEbuUiHelper
+    {
+        public byte JustificationCode { get; set; }
+        public void Initialize(Ebu.EbuGeneralSubtitleInformation header, byte justificationCode, string fileName, Subtitle subtitle) { }
+        public bool ShowDialogOk() => true;
+    }
+
+    private static string MakeStlHeader()
+    {
+        var buffer = new byte[1024];
+        for (var i = 0; i < buffer.Length; i++)
+        {
+            buffer[i] = 0x20;
+        }
+
+        Encoding.ASCII.GetBytes("850").CopyTo(buffer, 0);
+        Encoding.ASCII.GetBytes("STL25.01").CopyTo(buffer, 3);
+        Encoding.ASCII.GetBytes("1").CopyTo(buffer, 11); // display standard code: level 1 teletext
+        Encoding.ASCII.GetBytes("00").CopyTo(buffer, 12);
+        return Ebu.ReadHeader(buffer).ToString();
+    }
+
+    private static string Position(byte justificationCode, string teletextRow, string text = "Hello world")
+    {
+        var oldHelper = Ebu.EbuUiHelper;
+        try
+        {
+            Ebu.EbuUiHelper = new JustificationHelper { JustificationCode = justificationCode };
+            var header = MakeStlHeader();
+            var subtitle = new Subtitle { Header = header };
+            subtitle.Paragraphs.Add(new Paragraph(text, 1000, 3000) { MarginV = teletextRow });
+
+            SubtitlePositionToAssa.ApplyPositions(subtitle, header);
+
+            return subtitle.Paragraphs[0].Text;
+        }
+        finally
+        {
+            Ebu.EbuUiHelper = oldHelper;
+        }
+    }
+
+    [Theory]
+    [InlineData(0, "{\\an2}")] // unchanged
+    [InlineData(1, "{\\an1}")] // left
+    [InlineData(2, "{\\an2}")] // centered
+    [InlineData(3, "{\\an3}")] // right
+    public void JustificationPicksTheAlignmentColumnOnTheBottomRow(byte justificationCode, string expected)
+    {
+        Assert.StartsWith(expected, Position(justificationCode, "22"));
+    }
+
+    [Theory]
+    [InlineData(1, "{\\an7}")] // left
+    [InlineData(2, "{\\an8}")] // centered
+    [InlineData(3, "{\\an9}")] // right
+    public void JustificationPicksTheAlignmentColumnOnTheTopRow(byte justificationCode, string expected)
+    {
+        Assert.StartsWith(expected, Position(justificationCode, "2"));
+    }
+
+    [Fact]
+    public void AnAlignmentAlreadyInTheTextWins()
+    {
+        Assert.StartsWith("{\\an1}", Position(3, "22", "{\\an1}Hello world"));
+    }
+
+    [Fact]
+    public void NoHelperLeavesTheLineCentered()
+    {
+        var oldHelper = Ebu.EbuUiHelper;
+        try
+        {
+            Ebu.EbuUiHelper = null;
+            var header = MakeStlHeader();
+            var subtitle = new Subtitle { Header = header };
+            subtitle.Paragraphs.Add(new Paragraph("Hello world", 1000, 3000) { MarginV = "22" });
+
+            SubtitlePositionToAssa.ApplyPositions(subtitle, header);
+
+            Assert.StartsWith("{\\an2}", subtitle.Paragraphs[0].Text);
+        }
+        finally
+        {
+            Ebu.EbuUiHelper = oldHelper;
+        }
+    }
+}


### PR DESCRIPTION
Reported while testing the EBU STL options window: neither the box nor the justification had any effect on the video preview.

Three separate causes.

## The box style ignored the preview settings

The Box style was a hard coded string carried over from SE 4:

```
Style: Box,Tahoma,12,&H00FFFFFF,...
```

Fixed 12 pt, fixed Tahoma, fixed bold, fixed margins — so a boxed line threw away the font, size, color, alignment and margins the mpv preview was set up with and rendered noticeably smaller than an unboxed one. It is now the preview style with an opaque background, overriding only what the box needs (border style 3, black fill, no shadow):

```
before  Style: Box,Tahoma,12,...,3,2,0,2,10,10,10,1
after   Style: Box,Arial,20,...,3,2,0,2,10,10,10,1     <- matches Style: Default
```

## The justification was never applied

`SubtitlePositionToAssa` turned the teletext row into a vertical margin, but always picked the centered alignment column — `{\an8}`, `{\an5}`, `{\an2}` — so left and right could not appear whatever the dialog said. The column now follows the EBU justification code (0 unchanged, 1 left, 2 centered, 3 right):

| justification | bottom row | middle | top row |
|---|---|---|---|
| left | `{\an1}` | `{\an4}` | `{\an7}` |
| centered / unchanged | `{\an2}` | `{\an5}` | `{\an8}` |
| right | `{\an3}` | `{\an6}` | `{\an9}` |

An `{\an}` tag already in the text still wins, and with no EBU helper present nothing changes. This covers the VLC preview too — both reloaders position through the same helper.

## Nothing refreshed the preview

Even with both fixed, neither would have appeared: `_mpvPreviewDirty` is only set by subtitle edits, so closing the options dialog left the new settings sitting there until the next keystroke. The dialog now marks the preview dirty, which covers the row/margin options as well.

## Also

The format properties gear in the toolbar is sized to the controls beside it. Every theme icon is 32x32 and the gear's artwork is among the tallest in the set; on the left that is fine (icons among icons), but this one stands among text labels and combo boxes, where the full size reads as oversized.

## Tests

- 9 libse tests for the justification column, including "an explicit tag wins" and "no helper leaves it centered".
- 3 UI tests for the box style: it follows the preview font and size, differs from Default *only* in how the background is drawn, and is used only when the file uses boxes.

## Known limitations

- The preview follows the justification *setting*, not the per-block codes stored in the file — those live on the `Ebu` instance during load and never reach a paragraph.
- The box still requires the display standard code to say teletext. A file that declares open subtitling (DSC 0) but carries teletext box codes anyway — the Adobe Premiere case `HasTeletextColorCodes` already works around when reading colors — previews without a box. Relaxing that safely means seeding the box setting on every STL load, which would also change what the export dialog defaults to, so it is left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)