### PR TITLE
EBU STL video preview: justify lines that carry no teletext row

### DIFF
--- a/src/libse/Common/SubtitlePositionToAssa.cs
+++ b/src/libse/Common/SubtitlePositionToAssa.cs
@@ -123,26 +123,36 @@ namespace Nikse.SubtitleEdit.Core.Common
         {
             var rows = GetEbuRowCount(header);
             var newLineRows = Math.Max(1, Configuration.Settings.SubtitleSettings.EbuStlNewLineRows);
+            var marginBottom = Configuration.Settings.SubtitleSettings.EbuStlMarginBottom;
             var applied = false;
 
             foreach (var p in subtitle.Paragraphs)
             {
-                if (string.IsNullOrEmpty(p.MarginV))
+                var hasRow = int.TryParse(p.MarginV, NumberStyles.Integer, CultureInfo.InvariantCulture, out var row) &&
+                             row >= 1 &&
+                             row <= rows;
+
+                // A row number is not a pixel margin - leaving one behind would nudge the line by
+                // a near random amount.
+                p.MarginV = null;
+
+                if (!usePositions)
                 {
                     continue;
                 }
 
-                if (!usePositions ||
-                    !int.TryParse(p.MarginV, NumberStyles.Integer, CultureInfo.InvariantCulture, out var row) ||
-                    row < 1 || row > rows)
+                var lineCount = Math.Max(1, Utilities.GetNumberOfLines(p.Text));
+                if (!hasRow)
                 {
-                    // A row number is not a pixel margin - leaving it would nudge every line
-                    // by a near random amount.
-                    p.MarginV = null;
-                    continue;
+                    // Only a subtitle that was read from an STL file carries teletext rows. Anything
+                    // typed in or converted from another format has none, and used to be skipped
+                    // outright - so for the far more common case the justification and the vertical
+                    // margins of the EBU options dialog changed nothing on screen at all. Put the
+                    // line where Ebu.Save would put it: counted up from the bottom margin.
+                    row = Math.Max(1, rows - marginBottom - (lineCount - 1) * newLineRows);
                 }
 
-                var lastRow = row + (Math.Max(1, Utilities.GetNumberOfLines(p.Text)) - 1) * newLineRows;
+                var lastRow = row + (lineCount - 1) * newLineRows;
                 var alignment = GetLeadingAlignment(p.Text);
                 if (alignment == 0)
                 {

--- a/src/ui/Features/Files/ExportEbuStl/ExportEbuStlViewModel.cs
+++ b/src/ui/Features/Files/ExportEbuStl/ExportEbuStlViewModel.cs
@@ -28,7 +28,10 @@ public partial class ExportEbuStlViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<string> _frameRates;
     [ObservableProperty] private string? _selectedFrameRate;
     [ObservableProperty] private ObservableCollection<string> _displayStandardCodes;
-    [ObservableProperty] private string? _selectedDisplayStandardCode;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsTeletext))]
+    private string? _selectedDisplayStandardCode;
     [ObservableProperty] private ObservableCollection<string> _characterTables;
     [ObservableProperty] private string? _selectedCharacterTable;
     [ObservableProperty] private ObservableCollection<LanguageItem> _languageCodes;
@@ -68,6 +71,13 @@ public partial class ExportEbuStlViewModel : ObservableObject
     [ObservableProperty] private bool _useDoubleHeight;
     [ObservableProperty] private string _errorTitle;
     [ObservableProperty] private string _errorLog;
+
+    /// <summary>
+    /// The box and the double height are teletext control codes, so "0 Open subtitling" gets
+    /// neither - not in the saved file (see Ebu.Save) and not in the video preview. Without this
+    /// the two check boxes sat there enabled and did nothing at all.
+    /// </summary>
+    public bool IsTeletext => SelectedDisplayStandardCode?.Contains("teletext", StringComparison.OrdinalIgnoreCase) ?? false;
 
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }

--- a/src/ui/Features/Files/ExportEbuStl/ExportEbuStlWindow.cs
+++ b/src/ui/Features/Files/ExportEbuStl/ExportEbuStlWindow.cs
@@ -298,11 +298,13 @@ public class ExportEbuStlWindow : Window
 
         var labelTeletext = UiUtil.MakeLabel(Se.Language.File.EbuSaveOptions.Teletext);
 
-        var labelUseBox = UiUtil.MakeLabel(Se.Language.File.EbuSaveOptions.UseBox);
-        var checkBoxUseBox = UiUtil.MakeCheckBox(vm, nameof(vm.UseBox));
+        // Both are teletext control codes: "0 Open subtitling" writes neither, so leaving them
+        // enabled there only promises a box the file and the video preview never show.
+        var labelUseBox = UiUtil.MakeLabel(Se.Language.File.EbuSaveOptions.UseBox).WithBindIsEnabled(nameof(vm.IsTeletext));
+        var checkBoxUseBox = UiUtil.MakeCheckBox(vm, nameof(vm.UseBox)).WithBindIsEnabled(nameof(vm.IsTeletext));
 
-        var labelUseDoubleHeight = UiUtil.MakeLabel(Se.Language.File.EbuSaveOptions.DoubleHeight);
-        var checkBoxUseDoubleHeight = UiUtil.MakeCheckBox(vm, nameof(vm.UseDoubleHeight));
+        var labelUseDoubleHeight = UiUtil.MakeLabel(Se.Language.File.EbuSaveOptions.DoubleHeight).WithBindIsEnabled(nameof(vm.IsTeletext));
+        var checkBoxUseDoubleHeight = UiUtil.MakeCheckBox(vm, nameof(vm.UseDoubleHeight)).WithBindIsEnabled(nameof(vm.IsTeletext));
 
 
         grid.Add(labelJustification, 0, 0);

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -1635,6 +1635,17 @@ public static class UiUtil
         return control;
     }
 
+    public static T WithBindIsEnabled<T>(this T control, string isEnabledPropertyPath) where T : Control
+    {
+        control.Bind(InputElement.IsEnabledProperty, new Binding
+        {
+            Path = isEnabledPropertyPath,
+            Mode = BindingMode.OneWay,
+        });
+
+        return control;
+    }
+
     public static Button WithBindIsEnabled(this Button control, string isEnabledPropertyPath)
     {
         control.Bind(Button.IsEnabledProperty, new Binding

--- a/tests/UI/Features/Files/EbuSaveOptionsPersistenceTests.cs
+++ b/tests/UI/Features/Files/EbuSaveOptionsPersistenceTests.cs
@@ -191,4 +191,28 @@ public class EbuSaveOptionsPersistenceTests
             }
         }
     }
+
+    // The box and the double height are teletext control codes - Ebu.Save writes neither when the
+    // display standard is open subtitling, and the video preview shows neither. The two check
+    // boxes have to say so instead of promising a box nothing ever draws (user report on PR #14228).
+    [AvaloniaFact]
+    public void TeletextOptions_AreOnlyEnabledForTeletext()
+    {
+        using var scope = new SettingsScope(ScopePaths);
+        using var libSeScope = new LibSeEbuScope();
+
+        var viewModel = OpenDialog(MakeSubtitle());
+
+        Assert.Equal(viewModel.DisplayStandardCodes[0], viewModel.SelectedDisplayStandardCode); // 0 = open subtitling
+        Assert.False(viewModel.IsTeletext);
+
+        viewModel.SelectedDisplayStandardCode = viewModel.DisplayStandardCodes[1]; // 1 = level-1 teletext
+        Assert.True(viewModel.IsTeletext);
+
+        viewModel.SelectedDisplayStandardCode = viewModel.DisplayStandardCodes[2]; // 2 = level-2 teletext
+        Assert.True(viewModel.IsTeletext);
+
+        viewModel.SelectedDisplayStandardCode = viewModel.DisplayStandardCodes[3]; // undefined
+        Assert.False(viewModel.IsTeletext);
+    }
 }

--- a/tests/UI/Logic/Media/MpvPreviewStlBoxTests.cs
+++ b/tests/UI/Logic/Media/MpvPreviewStlBoxTests.cs
@@ -35,7 +35,7 @@ public class MpvPreviewStlBoxTests
         return Ebu.ReadHeader(buffer).ToString();
     }
 
-    private static string BuildPreviewText(bool useBox)
+    private static string BuildPreviewText(bool useBox, string displayStandardCode = "1")
     {
         Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 
@@ -48,7 +48,7 @@ public class MpvPreviewStlBoxTests
             Se.Settings.Video.MpvPreviewFontName = "Verdana";
             Se.Settings.Video.MpvPreviewFontSize = 33;
 
-            var subtitle = new Subtitle { Header = MakeStlHeader("1") }; // 1 = level 1 teletext
+            var subtitle = new Subtitle { Header = MakeStlHeader(displayStandardCode) };
             subtitle.Paragraphs.Add(new Paragraph("Hello world", 1000, 3000));
 
             var reloader = new MpvReloader();
@@ -118,5 +118,14 @@ public class MpvPreviewStlBoxTests
     {
         Assert.Equal("Box", GetDialogueStyle(BuildPreviewText(useBox: true)));
         Assert.Equal("Default", GetDialogueStyle(BuildPreviewText(useBox: false)));
+    }
+
+    // The box is a teletext control code, so Ebu.Save writes none for open subtitling however the
+    // save options dialog is set - and a preview that drew one anyway would promise a box the
+    // file never carries (user report on PR #14228).
+    [AvaloniaFact]
+    public void OpenSubtitlingNeverUsesTheBoxStyle()
+    {
+        Assert.Equal("Default", GetDialogueStyle(BuildPreviewText(useBox: true, displayStandardCode: "0")));
     }
 }

--- a/tests/libse/Common/SubtitlePositionEbuJustificationTest.cs
+++ b/tests/libse/Common/SubtitlePositionEbuJustificationTest.cs
@@ -1,5 +1,6 @@
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System;
 using System.Text;
 
 namespace LibSETests.Common;
@@ -31,24 +32,35 @@ public class SubtitlePositionEbuJustificationTest
         return Ebu.ReadHeader(buffer).ToString();
     }
 
-    private static string Position(byte justificationCode, string teletextRow, string text = "Hello world")
+    private static Paragraph Positioned(byte justificationCode, string teletextRow, string text = "Hello world", bool usePositions = true)
     {
         var oldHelper = Ebu.EbuUiHelper;
+        var oldMarginBottom = Configuration.Settings.SubtitleSettings.EbuStlMarginBottom;
+        var oldNewLineRows = Configuration.Settings.SubtitleSettings.EbuStlNewLineRows;
         try
         {
             Ebu.EbuUiHelper = new JustificationHelper { JustificationCode = justificationCode };
+            Configuration.Settings.SubtitleSettings.EbuStlMarginBottom = 2;
+            Configuration.Settings.SubtitleSettings.EbuStlNewLineRows = 2;
             var header = MakeStlHeader();
             var subtitle = new Subtitle { Header = header };
             subtitle.Paragraphs.Add(new Paragraph(text, 1000, 3000) { MarginV = teletextRow });
 
-            SubtitlePositionToAssa.ApplyPositions(subtitle, header);
+            SubtitlePositionToAssa.ApplyPositions(subtitle, header, usePositions);
 
-            return subtitle.Paragraphs[0].Text;
+            return subtitle.Paragraphs[0];
         }
         finally
         {
+            Configuration.Settings.SubtitleSettings.EbuStlNewLineRows = oldNewLineRows;
+            Configuration.Settings.SubtitleSettings.EbuStlMarginBottom = oldMarginBottom;
             Ebu.EbuUiHelper = oldHelper;
         }
+    }
+
+    private static string Position(byte justificationCode, string teletextRow, string text = "Hello world")
+    {
+        return Positioned(justificationCode, teletextRow, text).Text;
     }
 
     [Theory]
@@ -95,5 +107,48 @@ public class SubtitlePositionEbuJustificationTest
         {
             Ebu.EbuUiHelper = oldHelper;
         }
+    }
+
+    // Only a subtitle read from an STL file carries teletext rows in MarginV. A subtitle that was
+    // typed in or converted from another format has none, and used to be skipped outright - so the
+    // justification and the vertical margins of the EBU options dialog did nothing on screen for
+    // the far more common case (user report on PR #14228).
+    [Theory]
+    [InlineData(0, "{\\an2}")] // unchanged
+    [InlineData(1, "{\\an1}")] // left
+    [InlineData(2, "{\\an2}")] // centered
+    [InlineData(3, "{\\an3}")] // right
+    public void JustificationAlsoAppliesWithoutATeletextRow(byte justificationCode, string expected)
+    {
+        Assert.StartsWith(expected, Position(justificationCode, null));
+    }
+
+    [Fact]
+    public void WithoutATeletextRowTheLineSitsAtTheBottomMargin()
+    {
+        // 2 rows up from the bottom of the 23 teletext rows, in the 288 high libass script.
+        Assert.Equal("25", Positioned(2, null).MarginV);
+    }
+
+    [Fact]
+    public void WithoutATeletextRowTheSecondLineStillFitsAboveTheBottomMargin()
+    {
+        // Two lines at 2 rows each start higher up, but the last one keeps the same bottom margin.
+        Assert.Equal("25", Positioned(2, null, "Hello" + Environment.NewLine + "world").MarginV);
+    }
+
+    [Fact]
+    public void ATeletextRowFromTheFileStillWins()
+    {
+        Assert.Equal("38", Positioned(2, "20").MarginV); // 3 rows up from the bottom of 23, in 288
+    }
+
+    [Fact]
+    public void NothingIsPositionedWhenPositionsAreTurnedOff()
+    {
+        var p = Positioned(1, null, usePositions: false);
+
+        Assert.Equal("Hello world", p.Text);
+        Assert.Null(p.MarginV);
     }
 }


### PR DESCRIPTION
Follow-up to #14228, which did not fix the reported case.

## Justification

The alignment column now follows the EBU justification code — but only for paragraphs whose `MarginV` holds a teletext row, and only `Ebu.LoadSubtitle` ever puts one there. A subtitle that was typed in or converted from another format has none, so `ApplyEbuTeletextRows` skipped every line and both the justification and the vertical margins of the options dialog changed nothing on screen. That is the common case, and the one in the report.

Those lines now go where `Ebu.Save` would put them — `rows - margin bottom - line breaks × rows per line break`, counted up from the bottom — and the justification picks the alignment column as before. A teletext row read from a file still wins, and "use position from subtitle file" still turns the whole thing off.

Before / after for a two-line subtitle, left-justified, bottom margin 2:

```
Dialogue: 0,...,Default,,0,0,0,,This is line number one.\NLine two.
Dialogue: 0,...,Default,,0,0,25,,{\an1}This is line number one.\NLine two.
```

## The box

The box is a teletext control code: `Ebu.Save` writes none when the display standard code is `0 Open subtitling`, and the preview drew none either. That part was already right — the dialog was not. A subtitle that has not been through the dialog gets open subtitling, while "Use box around text" and "Use double height for text" default to on, so both sat there checked and enabled promising a box that neither the file nor the preview would ever have.

They now follow the display standard code and are disabled for open subtitling.

## Known gap

Double height is still previewed at single height.

## Tests

`SubtitlePositionEbuJustificationTest` covers the four justification codes without a teletext row, the derived bottom margin for one and two lines, a file row still winning, and the positions-off case. `MpvPreviewStlBoxTests` covers open subtitling never picking the box style, and `EbuSaveOptionsPersistenceTests` the new `IsTeletext` gate. Full libse (1684) and UI (4218) suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)