### PR TITLE
Surround with: more slots + settings export/import fix (#14232)

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -3227,6 +3227,7 @@
       "colorX": "Color {0}",
       "surroundWith": "Surround with...",
       "surroundWithXY": "Surround with {0}/{1}",
+      "surroundWithNumberX": "Surround with #{0}",
       "moveVideoPositionMilliseconds": "Move video position in milliseconds",
       "importShortcutsTitle": "Import shortcuts",
       "exportShortcutsTitle": "Export shortcuts",

--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -1283,19 +1283,57 @@ public static partial class InitListViewAndEditBox
                 new MenuItem
                 {
                     [!MenuItem.HeaderProperty] = new Binding(nameof(vm.SurroundWith1Text)),
+                    [!Visual.IsVisibleProperty] = new Binding(nameof(vm.IsSurroundWith1Visible)),
                     Command = vm.SurroundWith1Command,
                     DataContext = vm,
                 },
                 new MenuItem
                 {
                     [!MenuItem.HeaderProperty] = new Binding(nameof(vm.SurroundWith2Text)),
+                    [!Visual.IsVisibleProperty] = new Binding(nameof(vm.IsSurroundWith2Visible)),
                     Command = vm.SurroundWith2Command,
                     DataContext = vm,
                 },
                 new MenuItem
                 {
                     [!MenuItem.HeaderProperty] = new Binding(nameof(vm.SurroundWith3Text)),
+                    [!Visual.IsVisibleProperty] = new Binding(nameof(vm.IsSurroundWith3Visible)),
                     Command = vm.SurroundWith3Command,
+                    DataContext = vm,
+                },
+                new MenuItem
+                {
+                    [!MenuItem.HeaderProperty] = new Binding(nameof(vm.SurroundWith4Text)),
+                    [!Visual.IsVisibleProperty] = new Binding(nameof(vm.IsSurroundWith4Visible)),
+                    Command = vm.SurroundWith4Command,
+                    DataContext = vm,
+                },
+                new MenuItem
+                {
+                    [!MenuItem.HeaderProperty] = new Binding(nameof(vm.SurroundWith5Text)),
+                    [!Visual.IsVisibleProperty] = new Binding(nameof(vm.IsSurroundWith5Visible)),
+                    Command = vm.SurroundWith5Command,
+                    DataContext = vm,
+                },
+                new MenuItem
+                {
+                    [!MenuItem.HeaderProperty] = new Binding(nameof(vm.SurroundWith6Text)),
+                    [!Visual.IsVisibleProperty] = new Binding(nameof(vm.IsSurroundWith6Visible)),
+                    Command = vm.SurroundWith6Command,
+                    DataContext = vm,
+                },
+                new MenuItem
+                {
+                    [!MenuItem.HeaderProperty] = new Binding(nameof(vm.SurroundWith7Text)),
+                    [!Visual.IsVisibleProperty] = new Binding(nameof(vm.IsSurroundWith7Visible)),
+                    Command = vm.SurroundWith7Command,
+                    DataContext = vm,
+                },
+                new MenuItem
+                {
+                    [!MenuItem.HeaderProperty] = new Binding(nameof(vm.SurroundWith8Text)),
+                    [!Visual.IsVisibleProperty] = new Binding(nameof(vm.IsSurroundWith8Visible)),
+                    Command = vm.SurroundWith8Command,
                     DataContext = vm,
                 },
                 new MenuItem

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -425,6 +425,19 @@ public partial class MainViewModel :
     [ObservableProperty] private string _surroundWith1Text;
     [ObservableProperty] private string _surroundWith2Text;
     [ObservableProperty] private string _surroundWith3Text;
+    [ObservableProperty] private string _surroundWith4Text;
+    [ObservableProperty] private string _surroundWith5Text;
+    [ObservableProperty] private string _surroundWith6Text;
+    [ObservableProperty] private string _surroundWith7Text;
+    [ObservableProperty] private string _surroundWith8Text;
+    [ObservableProperty] private bool _isSurroundWith1Visible;
+    [ObservableProperty] private bool _isSurroundWith2Visible;
+    [ObservableProperty] private bool _isSurroundWith3Visible;
+    [ObservableProperty] private bool _isSurroundWith4Visible;
+    [ObservableProperty] private bool _isSurroundWith5Visible;
+    [ObservableProperty] private bool _isSurroundWith6Visible;
+    [ObservableProperty] private bool _isSurroundWith7Visible;
+    [ObservableProperty] private bool _isSurroundWith8Visible;
     [ObservableProperty] private bool _isSubtitleSecondaryVisible;
 
     public TableView SubtitleGrid { get; set; }
@@ -896,6 +909,14 @@ public partial class MainViewModel :
         _subtitleFileName = string.Empty;
         Subtitles = [];
         FilePropertiesText = string.Empty;
+        SurroundWith1Text = string.Empty;
+        SurroundWith2Text = string.Empty;
+        SurroundWith3Text = string.Empty;
+        SurroundWith4Text = string.Empty;
+        SurroundWith5Text = string.Empty;
+        SurroundWith6Text = string.Empty;
+        SurroundWith7Text = string.Empty;
+        SurroundWith8Text = string.Empty;
 
         SubtitleFormats = [.. SubtitleFormatHelper.GetSubtitleFormatsWithFavoritesAtTop()];
         _changingFormatProgrammatically = true;
@@ -1012,9 +1033,7 @@ public partial class MainViewModel :
         InitializeLibMpv();
         LibVlcDynamicPlayer.LibVlcPath = Se.VlcFolder;
         LoadShortcuts();
-        SurroundWith1Text = string.Format(Se.Language.Options.Shortcuts.SurroundWithXY, Se.Settings.Surround1Left, Se.Settings.Surround1Right);
-        SurroundWith2Text = string.Format(Se.Language.Options.Shortcuts.SurroundWithXY, Se.Settings.Surround2Left, Se.Settings.Surround2Right);
-        SurroundWith3Text = string.Format(Se.Language.Options.Shortcuts.SurroundWithXY, Se.Settings.Surround3Left, Se.Settings.Surround3Right);
+        UpdateSurroundWithMenuItems();
 
         StartTimers();
         _autoBackupService.StartAutoBackup(this);
@@ -1245,9 +1264,7 @@ public partial class MainViewModel :
             _shortcutManager.RegisterShortcut(shortCut);
         }
 
-        SurroundWith1Text = string.Format(Se.Language.Options.Shortcuts.SurroundWithXY, Se.Settings.Surround1Left, Se.Settings.Surround1Right);
-        SurroundWith2Text = string.Format(Se.Language.Options.Shortcuts.SurroundWithXY, Se.Settings.Surround2Left, Se.Settings.Surround2Right);
-        SurroundWith3Text = string.Format(Se.Language.Options.Shortcuts.SurroundWithXY, Se.Settings.Surround3Left, Se.Settings.Surround3Right);
+        UpdateSurroundWithMenuItems();
     }
 
     [RelayCommand]
@@ -14204,19 +14221,85 @@ public partial class MainViewModel :
     [RelayCommand]
     private void SurroundWith1()
     {
-        SurroundWith(Se.Settings.Surround1Left, Se.Settings.Surround1Right);
+        SurroundWithSlot(1);
     }
 
     [RelayCommand]
     private void SurroundWith2()
     {
-        SurroundWith(Se.Settings.Surround2Left, Se.Settings.Surround2Right);
+        SurroundWithSlot(2);
     }
 
     [RelayCommand]
     private void SurroundWith3()
     {
-        SurroundWith(Se.Settings.Surround3Left, Se.Settings.Surround3Right);
+        SurroundWithSlot(3);
+    }
+
+    [RelayCommand]
+    private void SurroundWith4()
+    {
+        SurroundWithSlot(4);
+    }
+
+    [RelayCommand]
+    private void SurroundWith5()
+    {
+        SurroundWithSlot(5);
+    }
+
+    [RelayCommand]
+    private void SurroundWith6()
+    {
+        SurroundWithSlot(6);
+    }
+
+    [RelayCommand]
+    private void SurroundWith7()
+    {
+        SurroundWithSlot(7);
+    }
+
+    [RelayCommand]
+    private void SurroundWith8()
+    {
+        SurroundWithSlot(8);
+    }
+
+    private void SurroundWithSlot(int slotNumber)
+    {
+        SurroundWith(Se.Settings.GetSurroundLeft(slotNumber), Se.Settings.GetSurroundRight(slotNumber));
+    }
+
+    /// <summary>
+    /// Refreshes the "surround with" context menu entries; slots left unconfigured stay hidden so
+    /// the eight available slots (#14232) do not clutter the menu.
+    /// </summary>
+    private void UpdateSurroundWithMenuItems()
+    {
+        SurroundWith1Text = ShortcutsMain.GetSurroundWithTitle(1);
+        SurroundWith2Text = ShortcutsMain.GetSurroundWithTitle(2);
+        SurroundWith3Text = ShortcutsMain.GetSurroundWithTitle(3);
+        SurroundWith4Text = ShortcutsMain.GetSurroundWithTitle(4);
+        SurroundWith5Text = ShortcutsMain.GetSurroundWithTitle(5);
+        SurroundWith6Text = ShortcutsMain.GetSurroundWithTitle(6);
+        SurroundWith7Text = ShortcutsMain.GetSurroundWithTitle(7);
+        SurroundWith8Text = ShortcutsMain.GetSurroundWithTitle(8);
+
+        IsSurroundWith1Visible = IsSurroundWithSlotConfigured(1);
+        IsSurroundWith2Visible = IsSurroundWithSlotConfigured(2);
+        IsSurroundWith3Visible = IsSurroundWithSlotConfigured(3);
+        IsSurroundWith4Visible = IsSurroundWithSlotConfigured(4);
+        IsSurroundWith5Visible = IsSurroundWithSlotConfigured(5);
+        IsSurroundWith6Visible = IsSurroundWithSlotConfigured(6);
+        IsSurroundWith7Visible = IsSurroundWithSlotConfigured(7);
+        IsSurroundWith8Visible = IsSurroundWithSlotConfigured(8);
+    }
+
+    private static bool IsSurroundWithSlotConfigured(int slotNumber)
+    {
+        return !string.IsNullOrEmpty(Se.Settings.GetSurroundLeft(slotNumber)) ||
+               !string.IsNullOrEmpty(Se.Settings.GetSurroundRight(slotNumber));
     }
 
     [RelayCommand]
@@ -23251,9 +23334,7 @@ public partial class MainViewModel :
                         TableViewExtras.FocusRow(SubtitleGrid);
                     }
 
-                    SurroundWith1Text = string.Format(Se.Language.Options.Shortcuts.SurroundWithXY, Se.Settings.Surround1Left, Se.Settings.Surround1Right);
-                    SurroundWith2Text = string.Format(Se.Language.Options.Shortcuts.SurroundWithXY, Se.Settings.Surround2Left, Se.Settings.Surround2Right);
-                    SurroundWith3Text = string.Format(Se.Language.Options.Shortcuts.SurroundWithXY, Se.Settings.Surround3Left, Se.Settings.Surround3Right);
+                    UpdateSurroundWithMenuItems();
                 }
             });
         });

--- a/src/ui/Features/Options/Settings/SettingsImportExport/SettingsImportExportViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsImportExport/SettingsImportExportViewModel.cs
@@ -101,11 +101,18 @@ public partial class SettingsImportExportViewModel : ObservableObject
     private string _importFilePath = string.Empty;
     private Se? _importData;
     private string? _importSourceOs;
+    private bool _importHasShortcutSlots;
 
     // Marker property name written at the top level of the export JSON so the
     // importer can tell which OS the file came from (Se has no such field, so
     // System.Text.Json silently ignores it when deserializing into Se).
     private const string ExportSourceOsProperty = "exportSourceOs";
+
+    // Second marker: set when the file carries the shortcut *slot* values (colors,
+    // actors, "surround with" pairs). Files written before #14232 always held the
+    // defaults for those, so without the marker the importer must leave them alone
+    // rather than reset the user's own to factory values.
+    private const string ExportShortcutSlotsProperty = "exportIncludesShortcutSlots";
     public bool OkPressed { get; set; }
     public Window? Window { get; set; }
     private readonly IFileHelper _fileHelper;
@@ -169,6 +176,7 @@ public partial class SettingsImportExportViewModel : ObservableObject
             }
 
             _importSourceOs = TryReadExportSourceOs(json);
+            _importHasShortcutSlots = TryReadExportIncludesShortcutSlots(json);
 
             IsRulesEnabled = _importData.General != null;
             IsAppearanceEnabled = _importData.Appearance != null;
@@ -277,7 +285,13 @@ public partial class SettingsImportExportViewModel : ObservableObject
         exportData.Tools = ExportImportAll ? currentSettings.Tools : null!;
         exportData.Appearance = ExportImportAll || ExportImportAppearance ? currentSettings.Appearance : null!;
         exportData.Options = ExportImportAll ? currentSettings.Options : null!;
-        exportData.Shortcuts = ExportImportAll || ExportImportShortcuts ? currentSettings.Shortcuts : null!;
+        // The shortcut slots the Shortcuts window configures (colors 1-8, actors 1-10 and the
+        // "surround with" pairs) live as top-level values on Se, so they were left at the
+        // defaults of `new Se()` above and the import side never looked at them - every one of
+        // those customizations was silently dropped on export/import (#14232).
+        var exportShortcuts = ExportImportAll || ExportImportShortcuts;
+        exportData.Shortcuts = exportShortcuts ? currentSettings.Shortcuts : null!;
+        CopyShortcutSlots(exportShortcuts ? currentSettings : null, exportData);
         exportData.AutoTranslate = ExportImportAll || ExportImportAutoTranslate ? currentSettings.AutoTranslate : null!;
         exportData.SpellCheck = ExportImportAll ? currentSettings.SpellCheck : null!;
 
@@ -287,7 +301,7 @@ public partial class SettingsImportExportViewModel : ObservableObject
         exportData.Video = ExportImportAll ? currentSettings.Video : null!;
 
         var json = JsonSerializer.Serialize(exportData, new JsonSerializerOptions { WriteIndented = true });
-        var jsonWithSource = InjectExportSourceOs(json, GetCurrentOsName());
+        var jsonWithSource = InjectExportMarkers(json, GetCurrentOsName(), exportShortcuts);
         File.WriteAllText(fileName, jsonWithSource);
     }
 
@@ -381,6 +395,11 @@ public partial class SettingsImportExportViewModel : ObservableObject
 
                 Se.Settings.Shortcuts = importData.Shortcuts;
             }
+
+            if (_importHasShortcutSlots)
+            {
+                CopyShortcutSlots(importData, Se.Settings);
+            }
         }
 
         if (ExportImportAll || ExportImportAutoTranslate)
@@ -450,10 +469,43 @@ public partial class SettingsImportExportViewModel : ObservableObject
         return "Linux";
     }
 
-    // Adds a top-level "exportSourceOs" property to the serialized JSON without
-    // touching the Se type. Se has no such property, so System.Text.Json
-    // silently ignores it on import.
-    private static string InjectExportSourceOs(string json, string osName)
+    /// <summary>
+    /// Copies the shortcut slot values the Shortcuts window owns - colors 1-8, actors 1-10 and the
+    /// "surround with" pairs - which sit as top-level values on <see cref="Se"/> rather than in one
+    /// of its sections. A null <paramref name="from"/> clears them, so an export that leaves
+    /// shortcuts out says so instead of shipping a block of defaults.
+    /// </summary>
+    private static void CopyShortcutSlots(Se? from, Se to)
+    {
+        to.Color1 = from?.Color1!;
+        to.Color2 = from?.Color2!;
+        to.Color3 = from?.Color3!;
+        to.Color4 = from?.Color4!;
+        to.Color5 = from?.Color5!;
+        to.Color6 = from?.Color6!;
+        to.Color7 = from?.Color7!;
+        to.Color8 = from?.Color8!;
+
+        for (var slot = 1; slot <= Se.SurroundWithSlotCount; slot++)
+        {
+            to.SetSurround(slot, from?.GetSurroundLeft(slot)!, from?.GetSurroundRight(slot)!);
+        }
+
+        to.Actor1 = from?.Actor1!;
+        to.Actor2 = from?.Actor2!;
+        to.Actor3 = from?.Actor3!;
+        to.Actor4 = from?.Actor4!;
+        to.Actor5 = from?.Actor5!;
+        to.Actor6 = from?.Actor6!;
+        to.Actor7 = from?.Actor7!;
+        to.Actor8 = from?.Actor8!;
+        to.Actor9 = from?.Actor9!;
+        to.Actor10 = from?.Actor10!;
+    }
+
+    // Adds the top-level marker properties to the serialized JSON without touching the Se
+    // type. Se has no such properties, so System.Text.Json silently ignores them on import.
+    private static string InjectExportMarkers(string json, string osName, bool includesShortcutSlots)
     {
         try
         {
@@ -468,6 +520,11 @@ public partial class SettingsImportExportViewModel : ObservableObject
             {
                 writer.WriteStartObject();
                 writer.WriteString(ExportSourceOsProperty, osName);
+                if (includesShortcutSlots)
+                {
+                    writer.WriteBoolean(ExportShortcutSlotsProperty, true);
+                }
+
                 foreach (var prop in doc.RootElement.EnumerateObject())
                 {
                     prop.WriteTo(writer);
@@ -501,6 +558,22 @@ public partial class SettingsImportExportViewModel : ObservableObject
         }
 
         return null;
+    }
+
+    private static bool TryReadExportIncludesShortcutSlots(string json)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            return doc.RootElement.ValueKind == JsonValueKind.Object &&
+                   doc.RootElement.TryGetProperty(ExportShortcutSlotsProperty, out var element) &&
+                   element.ValueKind == JsonValueKind.True;
+        }
+        catch
+        {
+            // Missing marker: a file from before the slots travelled - leave them alone.
+            return false;
+        }
     }
 
     public async void OnLoaded(object? sender, RoutedEventArgs e)

--- a/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
+++ b/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
@@ -21,6 +21,14 @@ public static class Se4ShortcutsImporter
         public List<SeShortCut> Shortcuts { get; } = new();
         public int SkippedNoMapping { get; set; }
         public int SkippedEmpty { get; set; }
+
+        /// <summary>
+        /// SE 4's "toggle custom tags" characters, kept in General settings rather than with the
+        /// shortcut itself (<c>TagsInToggleCustomTags</c>, one string of "startÆend"). Null when
+        /// the file has no usable pair - an exported SE_Shortcuts.xml carries no General section.
+        /// </summary>
+        public string? CustomTagsStart { get; set; }
+        public string? CustomTagsEnd { get; set; }
     }
 
     // Exposed for tests: every mapped SE 5 command must stay registered in the shortcut
@@ -346,11 +354,10 @@ public static class Se4ShortcutsImporter
         ["GeneralTogglePreviewOnVideo"] = nameof(MainViewModel.ToggleSubtitlesOnVideoPlayerCommand),
         ["GeneralSwitchOriginalAndTranslation"] = nameof(MainViewModel.SwitchOriginalAndTranslationTextSelectedLinesCommand),
         ["GeneralAutoCalcCurrentDuration"] = nameof(MainViewModel.RecalculateDurationSelectedLinesCommand),
-        // SE 4's single "toggle custom tags" pair became three configurable surround-with slots,
-        // whose characters are edited from the shortcut itself. The key lands on the first slot;
-        // its characters are SE 5's own default, not the pair SE 4 kept in General settings, and
-        // the shortcut list spells them out ("Surround with X and Y") so the difference is
-        // visible rather than silent (#13907).
+        // SE 4's single "toggle custom tags" pair became the configurable surround-with slots,
+        // whose characters are edited from the shortcut itself. The key lands on the first slot
+        // here; the caller moves it onto whichever slot ends up holding SE 4's own characters
+        // (#13907, #14232).
         ["MainListViewToggleCustomTags"] = nameof(MainViewModel.SurroundWith1Command),
         // SE 4 offered the same recalculation at three reading speeds. SE 5's "recalculate
         // duration" is the optimal-reading-speed one (text length / optimal CPS), and "set
@@ -470,7 +477,42 @@ public static class Se4ShortcutsImporter
             result.Shortcuts.Add(new SeShortCut(se5Name, keys));
         }
 
+        ReadCustomTags(doc, result);
+
         return result;
+    }
+
+    // <General><TagsInToggleCustomTags> holds the pair as one "startÆend" string; SE 4 reads a
+    // single field as both sides. Only present in a full Settings.xml - an exported
+    // SE_Shortcuts.xml is rooted at <Shortcuts> and has no General section.
+    private static void ReadCustomTags(XDocument doc, ImportResult result)
+    {
+        var value = doc.Root?.Element("General")?.Element("TagsInToggleCustomTags")?.Value;
+        if (string.IsNullOrEmpty(value))
+        {
+            return;
+        }
+
+        var tags = value.Split('Æ');
+        var start = tags.Length switch
+        {
+            1 or 2 => tags[0],
+            _ => string.Empty,
+        };
+        var end = tags.Length switch
+        {
+            1 => tags[0],
+            2 => tags[1],
+            _ => string.Empty,
+        };
+
+        if (start.Length == 0 && end.Length == 0)
+        {
+            return;
+        }
+
+        result.CustomTagsStart = start;
+        result.CustomTagsEnd = end;
     }
 
     private static List<string> ParseShortcutValue(string value)

--- a/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
@@ -433,6 +433,8 @@ public partial class ShortcutsViewModel : ObservableObject
                 return;
             }
 
+            ApplySe4CustomTags(importResult);
+
             foreach (var imported in importResult.Shortcuts)
             {
                 var existing = Se.Settings.Shortcuts.FirstOrDefault(s => s.ActionName == imported.ActionName);
@@ -881,6 +883,68 @@ public partial class ShortcutsViewModel : ObservableObject
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// SE 4 kept the "toggle custom tags" characters in General settings, apart from the shortcut
+    /// itself, so the imported key used to arrive pointing at surround-with slot 1 and SE 5's own
+    /// characters (#13907). Park SE 4's pair on a slot and move the key onto it: the slot already
+    /// holding that pair if there is one, otherwise the first unconfigured slot. When every slot
+    /// is in use the key stays on slot 1 as before - overwriting a pair the user is using would
+    /// cost them more than the import gains.
+    /// </summary>
+    internal void ApplySe4CustomTags(Se4ShortcutsImporter.ImportResult importResult)
+    {
+        var start = importResult.CustomTagsStart;
+        var end = importResult.CustomTagsEnd;
+        if (start == null || end == null)
+        {
+            return;
+        }
+
+        // Only when the pair has a key to travel with: SE 4 ships "(Æ)" as the default, so an
+        // unassigned shortcut would otherwise spend a slot on characters nobody asked for.
+        var importedShortcut = importResult.Shortcuts
+            .FirstOrDefault(s => s.ActionName == nameof(MainViewModel.SurroundWith1Command));
+        if (importedShortcut == null)
+        {
+            return;
+        }
+
+        var slotIndex = -1;
+        for (var i = 0; i < Se.SurroundWithSlotCount; i++)
+        {
+            if (_surroundLeftSlots[i] == start && _surroundRightSlots[i] == end)
+            {
+                slotIndex = i;
+                break;
+            }
+        }
+
+        for (var i = 0; slotIndex < 0 && i < Se.SurroundWithSlotCount; i++)
+        {
+            if (string.IsNullOrEmpty(_surroundLeftSlots[i]) && string.IsNullOrEmpty(_surroundRightSlots[i]))
+            {
+                slotIndex = i;
+            }
+        }
+
+        if (slotIndex < 0)
+        {
+            return;
+        }
+
+        var slotNumber = slotIndex + 1;
+        _surroundLeftSlots[slotIndex] = start;
+        _surroundRightSlots[slotIndex] = end;
+
+        // The rest of this import writes straight to Se.Settings, so the pair goes there too -
+        // and into the dialog's own slots above, or pressing OK would write the old value back.
+        Se.Settings.SetSurround(slotNumber, start, end);
+
+        var commandName = $"SurroundWith{slotNumber}Command";
+        importedShortcut.ActionName = commandName;
+        ShortcutsMain.CommandTranslationLookup[commandName] = ShortcutsMain.GetSurroundWithTitle(slotNumber, start, end);
     }
 
     private int GetSurroundSlotIndex(IRelayCommand action)

--- a/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
+++ b/src/ui/Features/Options/Shortcuts/ShortcutsViewModel.cs
@@ -59,12 +59,10 @@ public partial class ShortcutsViewModel : ObservableObject
     private Color _color6;
     private Color _color7;
     private Color _color8;
-    private string _surround1Left;
-    private string _surround1Right;
-    private string _surround2Left;
-    private string _surround2Right;
-    private string _surround3Left;
-    private string _surround3Right;
+    // Mirror Se.Settings.Surround1..8 (left/right pairs) while the dialog is open, so Cancel
+    // leaves the settings untouched.
+    private readonly string[] _surroundLeftSlots = new string[Se.SurroundWithSlotCount];
+    private readonly string[] _surroundRightSlots = new string[Se.SurroundWithSlotCount];
     // Mirror Se.Settings.Actor1..10 while the dialog is open so OK/Cancel
     // semantics match the other configurable slots (Color1..8, Surround1..3).
     private readonly string[] _actorSlots = new string[10];
@@ -101,12 +99,11 @@ public partial class ShortcutsViewModel : ObservableObject
         _color6 = Se.Settings.Color6.FromHexToColor();
         _color7 = Se.Settings.Color7.FromHexToColor();
         _color8 = Se.Settings.Color8.FromHexToColor();
-        _surround1Left = Se.Settings.Surround1Left;
-        _surround1Right = Se.Settings.Surround1Right;
-        _surround2Left = Se.Settings.Surround2Left;
-        _surround2Right = Se.Settings.Surround2Right;
-        _surround3Left = Se.Settings.Surround3Left;
-        _surround3Right = Se.Settings.Surround3Right;
+        for (var i = 0; i < Se.SurroundWithSlotCount; i++)
+        {
+            _surroundLeftSlots[i] = Se.Settings.GetSurroundLeft(i + 1);
+            _surroundRightSlots[i] = Se.Settings.GetSurroundRight(i + 1);
+        }
         _videoSeekSlots[0] = Se.Settings.Video.MoveVideoPositionCustom1Back;
         _videoSeekSlots[1] = Se.Settings.Video.MoveVideoPositionCustom1Forward;
         _videoSeekSlots[2] = Se.Settings.Video.MoveVideoPositionCustom2Back;
@@ -240,6 +237,11 @@ public partial class ShortcutsViewModel : ObservableObject
         _configurableCommands.Add(vm.SurroundWith1Command);
         _configurableCommands.Add(vm.SurroundWith2Command);
         _configurableCommands.Add(vm.SurroundWith3Command);
+        _configurableCommands.Add(vm.SurroundWith4Command);
+        _configurableCommands.Add(vm.SurroundWith5Command);
+        _configurableCommands.Add(vm.SurroundWith6Command);
+        _configurableCommands.Add(vm.SurroundWith7Command);
+        _configurableCommands.Add(vm.SurroundWith8Command);
         _configurableCommands.Add(vm.VideoMoveCustom1BackCommand);
         _configurableCommands.Add(vm.VideoMoveCustom1ForwardCommand);
         _configurableCommands.Add(vm.VideoMoveCustom2BackCommand);
@@ -571,12 +573,10 @@ public partial class ShortcutsViewModel : ObservableObject
         Se.Settings.Color6 = _color6.FromColorToHex();
         Se.Settings.Color7 = _color7.FromColorToHex();
         Se.Settings.Color8 = _color8.FromColorToHex();
-        Se.Settings.Surround1Left = _surround1Left;
-        Se.Settings.Surround1Right = _surround1Right;
-        Se.Settings.Surround2Left = _surround2Left;
-        Se.Settings.Surround2Right = _surround2Right;
-        Se.Settings.Surround3Left = _surround3Left;
-        Se.Settings.Surround3Right = _surround3Right;
+        for (var i = 0; i < Se.SurroundWithSlotCount; i++)
+        {
+            Se.Settings.SetSurround(i + 1, _surroundLeftSlots[i], _surroundRightSlots[i]);
+        }
         Se.Settings.Actor1 = _actorSlots[0];
         Se.Settings.Actor2 = _actorSlots[1];
         Se.Settings.Actor3 = _actorSlots[2];
@@ -597,9 +597,11 @@ public partial class ShortcutsViewModel : ObservableObject
         Se.Settings.Video.MoveVideoPositionCustom4Forward = _videoSeekSlots[7];
         Se.Settings.Tools.GoToFirstAndLastLineAlsoSetVideoPosition = _goToFirstAndLastLineAlsoSetVideoPosition;
 
-        ShortcutsMain.CommandTranslationLookup[nameof(MainViewModel.SurroundWith1Command)] = string.Format(Se.Language.Options.Shortcuts.SurroundWithXY, Se.Settings.Surround1Left, Se.Settings.Surround1Right);
-        ShortcutsMain.CommandTranslationLookup[nameof(MainViewModel.SurroundWith2Command)] = string.Format(Se.Language.Options.Shortcuts.SurroundWithXY, Se.Settings.Surround2Left, Se.Settings.Surround2Right);
-        ShortcutsMain.CommandTranslationLookup[nameof(MainViewModel.SurroundWith3Command)] = string.Format(Se.Language.Options.Shortcuts.SurroundWithXY, Se.Settings.Surround3Left, Se.Settings.Surround3Right);
+        for (var i = 1; i <= Se.SurroundWithSlotCount; i++)
+        {
+            ShortcutsMain.CommandTranslationLookup[$"SurroundWith{i}Command"] = ShortcutsMain.GetSurroundWithTitle(i);
+        }
+
         for (var i = 0; i < 10; i++)
         {
             var commandName = i == 9
@@ -627,6 +629,13 @@ public partial class ShortcutsViewModel : ObservableObject
         if (actorSlotIndex >= 0)
         {
             await ConfigureActorSlot(node, actorSlotIndex);
+            return;
+        }
+
+        var surroundSlotIndex = GetSurroundSlotIndex(node.ShortCut.Action);
+        if (surroundSlotIndex >= 0)
+        {
+            await ConfigureSurroundSlot(surroundSlotIndex);
             return;
         }
 
@@ -734,60 +743,6 @@ public partial class ShortcutsViewModel : ObservableObject
             if (result.OkPressed)
             {
                 _color8 = result.SelectedColor;
-            }
-        }
-        else if (node.ShortCut.Action == MainViewModel.SurroundWith1Command)
-        {
-            var result = await _windowService.ShowDialogAsync<SurroundWithWindow, SurroundWithViewModel>(Window, vm =>
-            {
-                vm.Initialize(_surround1Left, _surround1Right);
-            });
-            if (result.OkPressed)
-            {
-                _surround1Left = result.Before;
-                _surround1Right = result.After;
-
-                var flatNodeBack = FlatNodes.FirstOrDefault(n => n?.ShortCut?.Action == MainViewModel.SurroundWith1Command);
-                if (flatNodeBack != null)
-                {
-                    flatNodeBack.Title = string.Format(string.Format(Se.Language.Options.Shortcuts.SurroundWithXY, _surround1Left, _surround1Right));
-                }
-            }
-        }
-        else if (node.ShortCut.Action == MainViewModel.SurroundWith2Command)
-        {
-            var result = await _windowService.ShowDialogAsync<SurroundWithWindow, SurroundWithViewModel>(Window, vm =>
-            {
-                vm.Initialize(_surround2Left, _surround2Right);
-            });
-            if (result.OkPressed)
-            {
-                _surround2Left = result.Before;
-                _surround2Right = result.After;
-
-                var flatNodeBack = FlatNodes.FirstOrDefault(n => n?.ShortCut?.Action == MainViewModel.SurroundWith2Command);
-                if (flatNodeBack != null)
-                {
-                    flatNodeBack.Title = string.Format(string.Format(Se.Language.Options.Shortcuts.SurroundWithXY, _surround2Left, _surround2Right));
-                }
-            }
-        }
-        else if (node.ShortCut.Action == MainViewModel.SurroundWith3Command)
-        {
-            var result = await _windowService.ShowDialogAsync<SurroundWithWindow, SurroundWithViewModel>(Window, vm =>
-            {
-                vm.Initialize(_surround3Left, _surround3Right);
-            });
-            if (result.OkPressed)
-            {
-                _surround3Left = result.Before;
-                _surround3Right = result.After;
-
-                var flatNodeBack = FlatNodes.FirstOrDefault(n => n?.ShortCut?.Action == MainViewModel.SurroundWith3Command);
-                if (flatNodeBack != null)
-                {
-                    flatNodeBack.Title = string.Format(string.Format(Se.Language.Options.Shortcuts.SurroundWithXY, _surround3Left, _surround3Right));
-                }
             }
         }
         else if (node.ShortCut.Action == MainViewModel.VideoMoveCustom1BackCommand)
@@ -925,6 +880,50 @@ public partial class ShortcutsViewModel : ObservableObject
                     flatNodeForward.Title = string.Format(Se.Language.General.VideoCustom4ForwardX, _videoSeekSlots[7]);
                 }
             }
+        }
+    }
+
+    private int GetSurroundSlotIndex(IRelayCommand action)
+    {
+        if (MainViewModel == null)
+        {
+            return -1;
+        }
+
+        if (action == MainViewModel.SurroundWith1Command) { return 0; }
+        if (action == MainViewModel.SurroundWith2Command) { return 1; }
+        if (action == MainViewModel.SurroundWith3Command) { return 2; }
+        if (action == MainViewModel.SurroundWith4Command) { return 3; }
+        if (action == MainViewModel.SurroundWith5Command) { return 4; }
+        if (action == MainViewModel.SurroundWith6Command) { return 5; }
+        if (action == MainViewModel.SurroundWith7Command) { return 6; }
+        if (action == MainViewModel.SurroundWith8Command) { return 7; }
+        return -1;
+    }
+
+    private async Task ConfigureSurroundSlot(int slotIndex)
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var result = await _windowService.ShowDialogAsync<SurroundWithWindow, SurroundWithViewModel>(Window, vm =>
+        {
+            vm.Initialize(_surroundLeftSlots[slotIndex], _surroundRightSlots[slotIndex]);
+        });
+        if (!result.OkPressed)
+        {
+            return;
+        }
+
+        _surroundLeftSlots[slotIndex] = result.Before;
+        _surroundRightSlots[slotIndex] = result.After;
+
+        var flatNodeBack = FlatNodes.FirstOrDefault(n => n?.ShortCut != null && GetSurroundSlotIndex(n.ShortCut.Action) == slotIndex);
+        if (flatNodeBack != null)
+        {
+            flatNodeBack.Title = ShortcutsMain.GetSurroundWithTitle(slotIndex + 1, result.Before, result.After);
         }
     }
 

--- a/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
@@ -192,6 +192,7 @@ public class LanguageSettingsShortcuts
     public string ColorX { get; set; }
     public string SurroundWith { get; set; }
     public string SurroundWithXY { get; set; }
+    public string SurroundWithNumberX { get; set; }
     public string MoveVideoPositionMilliseconds { get; set; }
     public string ImportShortcutsTitle { get; set; }
     public string ExportShortcutsTitle { get; set; }
@@ -461,6 +462,7 @@ public class LanguageSettingsShortcuts
         ColorX = "Color {0}";
         SurroundWith = "Surround with...";
         SurroundWithXY = "Surround with {0}/{1}";
+        SurroundWithNumberX = "Surround with #{0}";
         MoveVideoPositionMilliseconds = "Move video position in milliseconds";
         ImportShortcutsTitle = "Import shortcuts";
         ExportShortcutsTitle = "Export shortcuts";

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -39,6 +39,16 @@ public class Se
     public string Surround2Right { get; set; } = "♫";
     public string Surround3Left { get; set; } = "[";
     public string Surround3Right { get; set; } = "]";
+    public string Surround4Left { get; set; } = string.Empty;
+    public string Surround4Right { get; set; } = string.Empty;
+    public string Surround5Left { get; set; } = string.Empty;
+    public string Surround5Right { get; set; } = string.Empty;
+    public string Surround6Left { get; set; } = string.Empty;
+    public string Surround6Right { get; set; } = string.Empty;
+    public string Surround7Left { get; set; } = string.Empty;
+    public string Surround7Right { get; set; } = string.Empty;
+    public string Surround8Left { get; set; } = string.Empty;
+    public string Surround8Right { get; set; } = string.Empty;
     public string Actor1 { get; set; } = "Actor 1";
     public string Actor2 { get; set; } = "Actor 2";
     public string Actor3 { get; set; } = "Actor 3";
@@ -311,6 +321,53 @@ public class Se
         catch (Exception ex)
         {
             SeLogger.Error("Error seeding bundled Tesseract model: " + ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Number of configurable "surround with" slots (#14232). Slots are one-based; the ones left
+    /// blank are simply hidden from the subtitle grid context menu.
+    /// </summary>
+    public const int SurroundWithSlotCount = 8;
+
+    public string GetSurroundLeft(int slotNumber) => slotNumber switch
+    {
+        1 => Surround1Left,
+        2 => Surround2Left,
+        3 => Surround3Left,
+        4 => Surround4Left,
+        5 => Surround5Left,
+        6 => Surround6Left,
+        7 => Surround7Left,
+        8 => Surround8Left,
+        _ => string.Empty,
+    };
+
+    public string GetSurroundRight(int slotNumber) => slotNumber switch
+    {
+        1 => Surround1Right,
+        2 => Surround2Right,
+        3 => Surround3Right,
+        4 => Surround4Right,
+        5 => Surround5Right,
+        6 => Surround6Right,
+        7 => Surround7Right,
+        8 => Surround8Right,
+        _ => string.Empty,
+    };
+
+    public void SetSurround(int slotNumber, string left, string right)
+    {
+        switch (slotNumber)
+        {
+            case 1: Surround1Left = left; Surround1Right = right; break;
+            case 2: Surround2Left = left; Surround2Right = right; break;
+            case 3: Surround3Left = left; Surround3Right = right; break;
+            case 4: Surround4Left = left; Surround4Right = right; break;
+            case 5: Surround5Left = left; Surround5Right = right; break;
+            case 6: Surround6Left = left; Surround6Right = right; break;
+            case 7: Surround7Left = left; Surround7Right = right; break;
+            case 8: Surround8Left = left; Surround8Right = right; break;
         }
     }
 

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -82,6 +82,27 @@ public static class ShortcutsMain
         }
     }
 
+    /// <summary>
+    /// Display name for a "surround with" slot: the configured tags when it has any, otherwise just
+    /// the slot number - the extra slots from #14232 ship unconfigured.
+    /// </summary>
+    public static string GetSurroundWithTitle(int slotNumber)
+    {
+        var left = Se.Settings.GetSurroundLeft(slotNumber);
+        var right = Se.Settings.GetSurroundRight(slotNumber);
+        return GetSurroundWithTitle(slotNumber, left, right);
+    }
+
+    public static string GetSurroundWithTitle(int slotNumber, string left, string right)
+    {
+        if (string.IsNullOrEmpty(left) && string.IsNullOrEmpty(right))
+        {
+            return string.Format(Se.Language.Options.Shortcuts.SurroundWithNumberX, slotNumber.ToString());
+        }
+
+        return string.Format(Se.Language.Options.Shortcuts.SurroundWithXY, left, right);
+    }
+
     private static Dictionary<string, string> BuildCommandTranslations()
     {
         return new Dictionary<string, string>
@@ -429,9 +450,14 @@ public static class ShortcutsMain
         { nameof(MainViewModel.SetActor10Command), string.Format(Se.Language.Options.Shortcuts.SetActorXY, "10", Se.Settings.Actor10) },
         { nameof(MainViewModel.SetNewActorCommand), Se.Language.Options.Shortcuts.SetNewActor },
         { nameof(MainViewModel.RemoveActorCommand), Se.Language.General.Actor + " - " + Se.Language.General.Remove },
-        { nameof(MainViewModel.SurroundWith1Command), string.Format(Se.Language.Options.Shortcuts.SurroundWithXY,  Se.Settings.Surround1Left, Se.Settings.Surround1Right) },
-        { nameof(MainViewModel.SurroundWith2Command), string.Format(Se.Language.Options.Shortcuts.SurroundWithXY,  Se.Settings.Surround2Left, Se.Settings.Surround2Right) },
-        { nameof(MainViewModel.SurroundWith3Command), string.Format(Se.Language.Options.Shortcuts.SurroundWithXY,  Se.Settings.Surround3Left, Se.Settings.Surround3Right) },
+        { nameof(MainViewModel.SurroundWith1Command), GetSurroundWithTitle(1) },
+        { nameof(MainViewModel.SurroundWith2Command), GetSurroundWithTitle(2) },
+        { nameof(MainViewModel.SurroundWith3Command), GetSurroundWithTitle(3) },
+        { nameof(MainViewModel.SurroundWith4Command), GetSurroundWithTitle(4) },
+        { nameof(MainViewModel.SurroundWith5Command), GetSurroundWithTitle(5) },
+        { nameof(MainViewModel.SurroundWith6Command), GetSurroundWithTitle(6) },
+        { nameof(MainViewModel.SurroundWith7Command), GetSurroundWithTitle(7) },
+        { nameof(MainViewModel.SurroundWith8Command), GetSurroundWithTitle(8) },
         { nameof(MainViewModel.InsertLineBeforeCommand), Se.Language.General.InsertBefore },
         { nameof(MainViewModel.InsertLineAfterCommand), Se.Language.General.InsertAfter },
         { nameof(MainViewModel.WaveformInsertNewSelectionCommand), Se.Language.Options.Shortcuts.WaveformInsertNewSelection },
@@ -856,6 +882,11 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.SurroundWith1Command, nameof(vm.SurroundWith1Command), ShortcutCategory.SubtitleGridAndTextBox);
         AddShortcut(shortcuts, vm.SurroundWith2Command, nameof(vm.SurroundWith2Command), ShortcutCategory.SubtitleGridAndTextBox);
         AddShortcut(shortcuts, vm.SurroundWith3Command, nameof(vm.SurroundWith3Command), ShortcutCategory.SubtitleGridAndTextBox);
+        AddShortcut(shortcuts, vm.SurroundWith4Command, nameof(vm.SurroundWith4Command), ShortcutCategory.SubtitleGridAndTextBox);
+        AddShortcut(shortcuts, vm.SurroundWith5Command, nameof(vm.SurroundWith5Command), ShortcutCategory.SubtitleGridAndTextBox);
+        AddShortcut(shortcuts, vm.SurroundWith6Command, nameof(vm.SurroundWith6Command), ShortcutCategory.SubtitleGridAndTextBox);
+        AddShortcut(shortcuts, vm.SurroundWith7Command, nameof(vm.SurroundWith7Command), ShortcutCategory.SubtitleGridAndTextBox);
+        AddShortcut(shortcuts, vm.SurroundWith8Command, nameof(vm.SurroundWith8Command), ShortcutCategory.SubtitleGridAndTextBox);
         AddShortcut(shortcuts, vm.InsertLineBeforeCommand, nameof(vm.InsertLineBeforeCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.InsertLineAfterCommand, nameof(vm.InsertLineAfterCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.WaveformInsertNewSelectionCommand, nameof(vm.WaveformInsertNewSelectionCommand), ShortcutCategory.Waveform);

--- a/tests/UI/Features/Options/Settings/SettingsImportExportShortcutSlotsTests.cs
+++ b/tests/UI/Features/Options/Settings/SettingsImportExportShortcutSlotsTests.cs
@@ -1,0 +1,155 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Features.Options.Settings.SettingsImportExport;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace UITests.Features.Options.Settings;
+
+/// <summary>
+/// The shortcut slots the Shortcuts window configures - colors 1-8, actors 1-10 and the
+/// "surround with" pairs - are top-level values on <see cref="Se"/>, not one of its sections,
+/// so export/import walked straight past them and every customization was lost on the way to a
+/// new install (#14232, matter G).
+/// </summary>
+public class SettingsImportExportShortcutSlotsTests
+{
+    private sealed class FakeFileHelper : IFileHelper
+    {
+        private readonly string _path;
+
+        public FakeFileHelper(string path) => _path = path;
+
+        public Task<string> PickOpenFile(Visual sender, string title, string extensionTitle, string extension, string extensionTitle2 = "", string extension2 = "", string? suggestedStartFolder = null) => Task.FromResult(_path);
+        public Task<string> PickSaveFile(Visual sender, string extension, string suggestedFileName, string title) => Task.FromResult(_path);
+
+        public Task<string[]> PickOpenFiles(Visual sender, string title, string extensionTitle, List<string> extensions, string extensionTitle2, List<string> extensions2) => throw new NotSupportedException();
+        public Task<string> PickOpenSubtitleFile(Visual sender, string title, bool includeVideoFiles = true, string? lastOpenedFilePath = null, bool includeSpreadsheets = false) => throw new NotSupportedException();
+        public Task<string[]> PickOpenSubtitleFiles(Visual sender, string title, bool includeVideoFiles = true, string? lastOpenedFilePath = null) => throw new NotSupportedException();
+        public Task<string> PickSaveSubtitleFile(Visual sender, Nikse.SubtitleEdit.Core.SubtitleFormats.SubtitleFormat currentFormat, string suggestedFileName, string title) => throw new NotSupportedException();
+        public Task<FileHelperSubtitleSavePickerResult?> PickSaveSubtitleFileAs(Visual sender, Nikse.SubtitleEdit.Core.SubtitleFormats.SubtitleFormat currentFormat, string suggestedFileName, string title) => throw new NotSupportedException();
+        public Task<string> PickSaveSubtitleFile(Visual sender, string extension, string suggestedFileName, string title) => throw new NotSupportedException();
+        public Task<string> PickSaveFile(Visual sender, string extension, string extensionTitle, string suggestedFileName, string title) => throw new NotSupportedException();
+        public Task<string> PickSaveFile(Visual sender, IReadOnlyList<(string Name, string Extension)> fileTypes, string suggestedFileName, string title) => throw new NotSupportedException();
+        public Task<string> PickOpenVideoFile(Visual sender, string title) => throw new NotSupportedException();
+        public Task<string[]> PickOpenVideoFiles(Visual sender, string title) => throw new NotSupportedException();
+        public Task<string> PickOpenImageFile(Visual sender, string title) => throw new NotSupportedException();
+    }
+
+    private static async Task<string> ExportAll(string path, Se settings)
+    {
+        var previous = Se.Settings;
+        Se.Settings = settings;
+        try
+        {
+            var vm = new SettingsImportExportViewModel(new FakeFileHelper(path)) { Window = new Window() };
+            vm.SetIsExport(true);
+            vm.ExportImportAll = true;
+            await vm.OkCommand.ExecuteAsync(null);
+        }
+        finally
+        {
+            Se.Settings = previous;
+        }
+
+        return await File.ReadAllTextAsync(path);
+    }
+
+    private static async Task ImportAllInto(string path, Se settings)
+    {
+        var previous = Se.Settings;
+        Se.Settings = settings;
+        try
+        {
+            var vm = new SettingsImportExportViewModel(new FakeFileHelper(path)) { Window = new Window() };
+            vm.SetIsExport(false);
+            Assert.True(await vm.PromptAndLoadImportFile());
+            vm.ExportImportAll = true;
+            await vm.OkCommand.ExecuteAsync(null);
+        }
+        finally
+        {
+            Se.Settings = previous;
+        }
+    }
+
+    private static string TempFile() =>
+        Path.Combine(SettingsIsolationFixture.SettingsDirectory, Guid.NewGuid().ToString("N") + ".json");
+
+    [AvaloniaFact]
+    public async Task ExportImportAllCarriesTheShortcutSlots()
+    {
+        Directory.CreateDirectory(SettingsIsolationFixture.SettingsDirectory);
+        var path = TempFile();
+
+        var source = new Se
+        {
+            Color1 = "#ff112233",
+            Actor1 = "Narrator",
+        };
+        source.SetSurround(1, "(", ")");
+        source.SetSurround(5, "<b>", "</b>");
+
+        await ExportAll(path, source);
+
+        var target = new Se();
+        await ImportAllInto(path, target);
+
+        Assert.Equal("#ff112233", target.Color1);
+        Assert.Equal("Narrator", target.Actor1);
+        Assert.Equal("(", target.GetSurroundLeft(1));
+        Assert.Equal(")", target.GetSurroundRight(1));
+        Assert.Equal("<b>", target.GetSurroundLeft(5));
+        Assert.Equal("</b>", target.GetSurroundRight(5));
+    }
+
+    // An export written before the slots travelled holds the defaults of `new Se()` for them,
+    // so importing one must leave the user's own slots alone instead of resetting them.
+    [AvaloniaFact]
+    public async Task ImportingAFileWithoutTheSlotMarkerLeavesTheCurrentSlotsAlone()
+    {
+        Directory.CreateDirectory(SettingsIsolationFixture.SettingsDirectory);
+        var path = TempFile();
+
+        await ExportAll(path, new Se());
+        var withoutMarker = (await File.ReadAllTextAsync(path))
+            .Replace("\"exportIncludesShortcutSlots\": true,", string.Empty);
+        await File.WriteAllTextAsync(path, withoutMarker);
+
+        var target = new Se { Color1 = "#ff445566", Actor1 = "Keep me" };
+        target.SetSurround(1, "«", "»");
+
+        await ImportAllInto(path, target);
+
+        Assert.Equal("#ff445566", target.Color1);
+        Assert.Equal("Keep me", target.Actor1);
+        Assert.Equal("«", target.GetSurroundLeft(1));
+        Assert.Equal("»", target.GetSurroundRight(1));
+    }
+
+    [AvaloniaFact]
+    public async Task ExportWithoutShortcutsDoesNotClaimToCarryTheSlots()
+    {
+        Directory.CreateDirectory(SettingsIsolationFixture.SettingsDirectory);
+        var path = TempFile();
+
+        var previous = Se.Settings;
+        Se.Settings = new Se();
+        try
+        {
+            var vm = new SettingsImportExportViewModel(new FakeFileHelper(path)) { Window = new Window() };
+            vm.SetIsExport(true);
+            vm.ExportImportAll = false;
+            vm.ExportImportAppearance = true;
+            await vm.OkCommand.ExecuteAsync(null);
+        }
+        finally
+        {
+            Se.Settings = previous;
+        }
+
+        var json = await File.ReadAllTextAsync(path);
+        Assert.DoesNotContain("exportIncludesShortcutSlots", json);
+    }
+}

--- a/tests/UI/Features/Options/Shortcuts/Se4CustomTagsImportTests.cs
+++ b/tests/UI/Features/Options/Shortcuts/Se4CustomTagsImportTests.cs
@@ -1,0 +1,148 @@
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Options.Shortcuts;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Options.Shortcuts;
+
+/// <summary>
+/// SE 4 keeps the "toggle custom tags" characters in General settings (TagsInToggleCustomTags,
+/// one "startÆend" string) rather than with the shortcut, so importing SE 4 shortcuts used to
+/// carry the key but not the pair it toggled (#14232, matter L). The pair now lands on a
+/// surround-with slot and the imported key follows it there.
+/// </summary>
+public class Se4CustomTagsImportTests
+{
+    private const string ToggleKey = "<MainListViewToggleCustomTags>Control+Shift+D</MainListViewToggleCustomTags>";
+
+    private static string SettingsXml(string? customTags, string shortcuts = ToggleKey)
+    {
+        var general = customTags == null
+            ? string.Empty
+            : $"<General><TagsInToggleCustomTags>{customTags}</TagsInToggleCustomTags></General>";
+        return $"<Settings>{general}<Shortcuts>{shortcuts}</Shortcuts></Settings>";
+    }
+
+    [Theory]
+    [InlineData("(Æ)", "(", ")")]
+    // SE 4 writes the pair XML-escaped; the reader must hand back the decoded characters.
+    [InlineData("&lt;i&gt;Æ&lt;/i&gt;", "<i>", "</i>")]
+    // SE 4 reads a single field as both sides.
+    [InlineData("#", "#", "#")]
+    public void ImportReadsTheCustomTagPair(string stored, string start, string end)
+    {
+        var result = Se4ShortcutsImporter.ImportFromXml(SettingsXml(stored));
+
+        Assert.Equal(start, result.CustomTagsStart);
+        Assert.Equal(end, result.CustomTagsEnd);
+    }
+
+    [Fact]
+    public void ImportHasNoPairWhenTheFileHasNoGeneralSection()
+    {
+        // An exported SE_Shortcuts.xml is rooted at <Shortcuts> and carries no General settings.
+        var result = Se4ShortcutsImporter.ImportFromXml($"<Shortcuts>{ToggleKey}</Shortcuts>");
+
+        Assert.Null(result.CustomTagsStart);
+        Assert.Null(result.CustomTagsEnd);
+    }
+
+    [Fact]
+    public void ImportHasNoPairWhenBothSidesAreEmpty()
+    {
+        var result = Se4ShortcutsImporter.ImportFromXml(SettingsXml("Æ"));
+
+        Assert.Null(result.CustomTagsStart);
+    }
+
+    private static void WithSettings(Se settings, Action<ShortcutsViewModel> act)
+    {
+        var previous = Se.Settings;
+        Se.Settings = settings;
+        try
+        {
+            act(new ShortcutsViewModel(null!, null!));
+        }
+        finally
+        {
+            Se.Settings = previous;
+        }
+    }
+
+    [Fact]
+    public void CustomTagsLandOnTheFirstFreeSlotAndTheKeyFollows()
+    {
+        var settings = new Se();
+
+        WithSettings(settings, vm =>
+        {
+            var result = Se4ShortcutsImporter.ImportFromXml(SettingsXml("(Æ)"));
+            vm.ApplySe4CustomTags(result);
+
+            // Slots 1-3 ship configured, so SE 4's pair takes slot 4 - the music-symbol pair on
+            // slot 1 is what an SE 4 user would miss most if the import overwrote it.
+            Assert.Equal("(", settings.GetSurroundLeft(4));
+            Assert.Equal(")", settings.GetSurroundRight(4));
+            Assert.Equal("♪", settings.Surround1Left);
+            Assert.Equal(
+                nameof(MainViewModel.SurroundWith4Command),
+                Assert.Single(result.Shortcuts).ActionName);
+        });
+    }
+
+    [Fact]
+    public void CustomTagsReuseASlotThatAlreadyHoldsThePair()
+    {
+        var settings = new Se();
+
+        WithSettings(settings, vm =>
+        {
+            var result = Se4ShortcutsImporter.ImportFromXml(SettingsXml("[Æ]"));
+            vm.ApplySe4CustomTags(result);
+
+            // Slot 3 is "[" / "]" out of the box - no reason to spend a second slot on it.
+            Assert.Equal(
+                nameof(MainViewModel.SurroundWith3Command),
+                Assert.Single(result.Shortcuts).ActionName);
+            Assert.Empty(settings.GetSurroundLeft(4));
+        });
+    }
+
+    [Fact]
+    public void CustomTagsAreLeftAloneWhenEverySlotIsInUse()
+    {
+        var settings = new Se();
+        for (var slot = 1; slot <= Se.SurroundWithSlotCount; slot++)
+        {
+            settings.SetSurround(slot, "<" + slot, ">");
+        }
+
+        WithSettings(settings, vm =>
+        {
+            var result = Se4ShortcutsImporter.ImportFromXml(SettingsXml("(Æ)"));
+            vm.ApplySe4CustomTags(result);
+
+            Assert.Equal(
+                nameof(MainViewModel.SurroundWith1Command),
+                Assert.Single(result.Shortcuts).ActionName);
+            Assert.Equal("<1", settings.Surround1Left);
+        });
+    }
+
+    // SE 4 ships "(Æ)" as the default pair, so a file where the shortcut itself was never
+    // assigned must not spend a slot on characters the user never chose.
+    [Fact]
+    public void CustomTagsAreIgnoredWhenTheShortcutIsUnassigned()
+    {
+        var settings = new Se();
+
+        WithSettings(settings, vm =>
+        {
+            var result = Se4ShortcutsImporter.ImportFromXml(
+                SettingsXml("(Æ)", "<MainListViewToggleCustomTags></MainListViewToggleCustomTags>"));
+            vm.ApplySe4CustomTags(result);
+
+            Assert.Empty(settings.GetSurroundLeft(4));
+            Assert.Empty(result.Shortcuts);
+        });
+    }
+}


### PR DESCRIPTION
Addresses **Matter H**, **Matter G** and part of **Matter L** of #14232.

## Matter H - more "surround with" slots

*"There are currently only three available Surround with shortcuts. Could this number be increased to six or eight?"*

Slots 4-8 are added, for eight in total.

- The five new slots ship **unconfigured**, so nothing changes for existing users until they fill one in.
- An unconfigured slot is hidden from the subtitle grid context menu (no clutter) and is listed as `Surround with #n` in Options > Shortcuts, where it gets a key and its before/after text like the first three.
- Clearing both sides of slot 1-3 now hides it too, instead of showing an empty `Surround with /`.

Along the way the three copy/pasted configure blocks in `ShortcutsViewModel` became slot arrays - the same shape the actor and video-seek slots already use - so the dialog keeps its OK/Cancel semantics without eight near-identical blocks.

## Matter G - the slots were lost on export/import

*"When exporting all presets, including shortcuts, the Surround with configurations are not preserved."*

Confirmed, and it was never only "surround with". Export builds a fresh `Se` and copies its **sections** (General, Waveform, Shortcuts, ...). The slots the Shortcuts window configures - colors 1-8, actors 1-10 and the surround pairs - are top-level values on `Se`, in no section at all, so the export wrote out the defaults of `new Se()` and the import side never read them back. All of it was dropped.

They now travel with the Shortcuts checkbox. Because every export file written before this held the defaults for those values, a marker property records when a file really carries the slots; without the marker the importer leaves the current ones alone rather than resetting them to factory values.

## Matter L - SE 4's custom tag characters now import too

The SE 4 feature is present in SE 5 as "Surround with", and the SE 4 importer already mapped `MainListViewToggleCustomTags` onto it - but only the key. SE 4 keeps the characters in General settings (`TagsInToggleCustomTags`, one `startÆend` string), so the imported key landed on slot 1 and toggled SE 5's own ♪ instead of the pair the user had bound.

The pair travels now, and the key follows it: onto the slot that already holds those characters if there is one, otherwise the first unconfigured slot - which is what slots 4-8 are for. Slot 1's music symbols, the pair an SE 4 user would miss most, are left alone; when every slot is in use the key stays on slot 1 as before.

Two parts of Matter L are **not** here: the *cumulative* offset is a new feature rather than a restoration (SE 4's repeat-press behaviour looks like the toggle failing to match its own multi-line value), and the before/after fields are still single-line. The reporter's actual goal works without either - leave *before* empty and put `<font size=35>\N\N\N` in *after*; the trailing `\N`s lift the block, so the leading newline from their SE 4 value is not needed.

## Not in this PR

**Matter F (Alt+Return conflict)** - could not be pinned down from the code. Two findings for the record: `Alt+Return` is already the shipped default for **Video > Full screen** in the *General* category, which SE's own conflict check reports as conflicting with every other category and which makes the Shortcuts window ask "Save anyway?" before storing the new binding; and Avalonia's `TextBox` inserts a line break on `Alt+Enter` (verified in a headless test), which is exactly the "Return behaves as its normal command" symptom when no shortcut fires. The dispatch order itself (TextBox -> SubtitleGridAndTextBox -> General) looks correct, and the shortcut manager matches `Alt+Return` fine in isolation.

## Test plan
- `dotnet build src/ui/UI.csproj` - clean (and 8 fewer nullability warnings).
- `dotnet test tests/UI/UITests.csproj` - 4229 passed, including three export/import round-trip tests and nine covering the SE 4 custom-tag import and slot placement; the export/import one was confirmed to fail without the fix. The single failure, `LibMpvEventLoopTests.Pause_RightAfterSeek_KeepsReportingTheSeekTarget`, is pre-existing and unrelated (it fails the same way on the base commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)