### PR TITLE
EBU STL video preview: read the justification from the settings

### DIFF
--- a/src/libse/Common/SubtitlePositionToAssa.cs
+++ b/src/libse/Common/SubtitlePositionToAssa.cs
@@ -201,9 +201,16 @@ namespace Nikse.SubtitleEdit.Core.Common
         /// are 0 = unchanged, 1 = left, 2 = centered and 3 = right, and each centered alignment
         /// (2, 5 and 8) has its left neighbour one below it and its right one above.
         /// </summary>
+        /// <remarks>
+        /// Read from the EBU STL settings, next to the margins and the teletext flags this method's
+        /// caller uses. It used to come off <see cref="Ebu.EbuUiHelper"/>, which is the carrier that
+        /// takes the code to the writer, not a setting: it is null until a save or the save options
+        /// dialog creates one - so a preview before either showed everything centered - and batch
+        /// convert overwrites it with its own job's code.
+        /// </remarks>
         private static int GetEbuJustificationOffset()
         {
-            switch (Ebu.EbuUiHelper?.JustificationCode)
+            switch (Configuration.Settings.SubtitleSettings.EbuStlJustificationCode)
             {
                 case 1: return -1;
                 case 3: return 1;

--- a/src/libse/Settings/SubtitleSettings.cs
+++ b/src/libse/Settings/SubtitleSettings.cs
@@ -1,4 +1,4 @@
-using Nikse.SubtitleEdit.Core.Common;
+﻿using Nikse.SubtitleEdit.Core.Common;
 using SkiaSharp;
 using System;
 
@@ -45,6 +45,8 @@ namespace Nikse.SubtitleEdit.Core.Settings
 
         public bool EbuStlTeletextUseBox { get; set; }
         public bool EbuStlTeletextUseDoubleHeight { get; set; }
+        /// <summary>0=unchanged, 1=left, 2=centered, 3=right - the EBU justification code.</summary>
+        public int EbuStlJustificationCode { get; set; }
         public int EbuStlMarginTop { get; set; }
         public int EbuStlMarginBottom { get; set; }
         public int EbuStlNewLineRows { get; set; }
@@ -122,6 +124,7 @@ namespace Nikse.SubtitleEdit.Core.Settings
 
             EbuStlTeletextUseBox = true;
             EbuStlTeletextUseDoubleHeight = true;
+            EbuStlJustificationCode = 2; // centered is the broadcast default
             EbuStlMarginTop = 0;
             EbuStlMarginBottom = 2;
             EbuStlNewLineRows = 2;

--- a/src/ui/Features/Files/ExportEbuStl/ExportEbuStlViewModel.cs
+++ b/src/ui/Features/Files/ExportEbuStl/ExportEbuStlViewModel.cs
@@ -430,6 +430,7 @@ new("2F", "French - hearing impaired (VF-MAL)"),
         _header.TotalNumberOfDisks = SelectedTotalNumberOfDiscs?.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
 
         JustificationCode = (byte)Justifications.IndexOf(SelectedJustification ?? Justifications[0]);
+        Configuration.Settings.SubtitleSettings.EbuStlJustificationCode = JustificationCode;
         Configuration.Settings.SubtitleSettings.EbuStlMarginTop = SelectedTopAlignment ?? 0;
         Configuration.Settings.SubtitleSettings.EbuStlMarginBottom = SelectedBottomAlignment ?? 0;
         Configuration.Settings.SubtitleSettings.EbuStlNewLineRows = SelectedRowsAddByNewLine ?? 1;

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -825,6 +825,7 @@ public class Se
         // seeds them from the loaded file, and this sync runs after every SaveSettings - it would
         // clobber the file's flags. They are applied once at startup in LoadSettings instead.
         var ebu = Settings.File.EbuSaveOptions;
+        ss.EbuStlJustificationCode = ebu.JustificationCode;
         ss.EbuStlMarginTop = ebu.MarginTop;
         ss.EbuStlMarginBottom = ebu.MarginBottom;
         ss.EbuStlNewLineRows = ebu.NewLineRows;

--- a/tests/UI/Features/Files/EbuSaveOptionsPersistenceTests.cs
+++ b/tests/UI/Features/Files/EbuSaveOptionsPersistenceTests.cs
@@ -41,6 +41,7 @@ public class EbuSaveOptionsPersistenceTests
     /// </summary>
     private sealed class LibSeEbuScope : IDisposable
     {
+        private readonly int _justification = Configuration.Settings.SubtitleSettings.EbuStlJustificationCode;
         private readonly int _marginTop = Configuration.Settings.SubtitleSettings.EbuStlMarginTop;
         private readonly int _marginBottom = Configuration.Settings.SubtitleSettings.EbuStlMarginBottom;
         private readonly int _newLineRows = Configuration.Settings.SubtitleSettings.EbuStlNewLineRows;
@@ -49,6 +50,7 @@ public class EbuSaveOptionsPersistenceTests
 
         public void Dispose()
         {
+            Configuration.Settings.SubtitleSettings.EbuStlJustificationCode = _justification;
             Configuration.Settings.SubtitleSettings.EbuStlMarginTop = _marginTop;
             Configuration.Settings.SubtitleSettings.EbuStlMarginBottom = _marginBottom;
             Configuration.Settings.SubtitleSettings.EbuStlNewLineRows = _newLineRows;
@@ -214,5 +216,38 @@ public class EbuSaveOptionsPersistenceTests
 
         viewModel.SelectedDisplayStandardCode = viewModel.DisplayStandardCodes[3]; // undefined
         Assert.False(viewModel.IsTeletext);
+    }
+
+    // The video preview reads the justification off the libse settings, next to the margins and the
+    // teletext flags. It used to read Ebu.EbuUiHelper, which is the carrier that takes the code to
+    // the writer and does not exist until a save or this dialog creates one - so the preview showed
+    // everything centered until then, and followed batch convert's job code after (PR #14229).
+    [AvaloniaFact]
+    public void Justification_ReachesTheLibSeSettingsForThePreview()
+    {
+        using var scope = new SettingsScope(ScopePaths);
+        using var libSeScope = new LibSeEbuScope();
+
+        var viewModel = OpenDialog(MakeSubtitle());
+        viewModel.SelectedJustification = viewModel.Justifications[1]; // left-justified
+        viewModel.OkCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(1, Configuration.Settings.SubtitleSettings.EbuStlJustificationCode);
+    }
+
+    // A save that never opens the dialog still has to preview and write the persisted pick, so the
+    // settings sync has to carry it over like every other EBU STL option.
+    [AvaloniaFact]
+    public void Justification_IsMirroredIntoLibSeBySettingsSync()
+    {
+        using var scope = new SettingsScope(ScopePaths);
+        using var libSeScope = new LibSeEbuScope();
+        Se.Settings.File.EbuSaveOptions.JustificationCode = 3;
+        Configuration.Settings.SubtitleSettings.EbuStlJustificationCode = 0;
+
+        Se.UpdateLibSeSettings();
+
+        Assert.Equal(3, Configuration.Settings.SubtitleSettings.EbuStlJustificationCode);
     }
 }

--- a/tests/libse/Common/SubtitlePositionEbuJustificationTest.cs
+++ b/tests/libse/Common/SubtitlePositionEbuJustificationTest.cs
@@ -10,13 +10,6 @@ namespace LibSETests.Common;
 // screen.
 public class SubtitlePositionEbuJustificationTest
 {
-    private class JustificationHelper : Ebu.IEbuUiHelper
-    {
-        public byte JustificationCode { get; set; }
-        public void Initialize(Ebu.EbuGeneralSubtitleInformation header, byte justificationCode, string fileName, Subtitle subtitle) { }
-        public bool ShowDialogOk() => true;
-    }
-
     private static string MakeStlHeader()
     {
         var buffer = new byte[1024];
@@ -32,16 +25,17 @@ public class SubtitlePositionEbuJustificationTest
         return Ebu.ReadHeader(buffer).ToString();
     }
 
-    private static Paragraph Positioned(byte justificationCode, string teletextRow, string text = "Hello world", bool usePositions = true)
+    private static Paragraph Positioned(int justificationCode, string teletextRow, string text = "Hello world", bool usePositions = true)
     {
-        var oldHelper = Ebu.EbuUiHelper;
-        var oldMarginBottom = Configuration.Settings.SubtitleSettings.EbuStlMarginBottom;
-        var oldNewLineRows = Configuration.Settings.SubtitleSettings.EbuStlNewLineRows;
+        var settings = Configuration.Settings.SubtitleSettings;
+        var oldJustification = settings.EbuStlJustificationCode;
+        var oldMarginBottom = settings.EbuStlMarginBottom;
+        var oldNewLineRows = settings.EbuStlNewLineRows;
         try
         {
-            Ebu.EbuUiHelper = new JustificationHelper { JustificationCode = justificationCode };
-            Configuration.Settings.SubtitleSettings.EbuStlMarginBottom = 2;
-            Configuration.Settings.SubtitleSettings.EbuStlNewLineRows = 2;
+            settings.EbuStlJustificationCode = justificationCode;
+            settings.EbuStlMarginBottom = 2;
+            settings.EbuStlNewLineRows = 2;
             var header = MakeStlHeader();
             var subtitle = new Subtitle { Header = header };
             subtitle.Paragraphs.Add(new Paragraph(text, 1000, 3000) { MarginV = teletextRow });
@@ -52,13 +46,13 @@ public class SubtitlePositionEbuJustificationTest
         }
         finally
         {
-            Configuration.Settings.SubtitleSettings.EbuStlNewLineRows = oldNewLineRows;
-            Configuration.Settings.SubtitleSettings.EbuStlMarginBottom = oldMarginBottom;
-            Ebu.EbuUiHelper = oldHelper;
+            settings.EbuStlNewLineRows = oldNewLineRows;
+            settings.EbuStlMarginBottom = oldMarginBottom;
+            settings.EbuStlJustificationCode = oldJustification;
         }
     }
 
-    private static string Position(byte justificationCode, string teletextRow, string text = "Hello world")
+    private static string Position(int justificationCode, string teletextRow, string text = "Hello world")
     {
         return Positioned(justificationCode, teletextRow, text).Text;
     }
@@ -68,7 +62,7 @@ public class SubtitlePositionEbuJustificationTest
     [InlineData(1, "{\\an1}")] // left
     [InlineData(2, "{\\an2}")] // centered
     [InlineData(3, "{\\an3}")] // right
-    public void JustificationPicksTheAlignmentColumnOnTheBottomRow(byte justificationCode, string expected)
+    public void JustificationPicksTheAlignmentColumnOnTheBottomRow(int justificationCode, string expected)
     {
         Assert.StartsWith(expected, Position(justificationCode, "22"));
     }
@@ -77,7 +71,7 @@ public class SubtitlePositionEbuJustificationTest
     [InlineData(1, "{\\an7}")] // left
     [InlineData(2, "{\\an8}")] // centered
     [InlineData(3, "{\\an9}")] // right
-    public void JustificationPicksTheAlignmentColumnOnTheTopRow(byte justificationCode, string expected)
+    public void JustificationPicksTheAlignmentColumnOnTheTopRow(int justificationCode, string expected)
     {
         Assert.StartsWith(expected, Position(justificationCode, "2"));
     }
@@ -88,20 +82,19 @@ public class SubtitlePositionEbuJustificationTest
         Assert.StartsWith("{\\an1}", Position(3, "22", "{\\an1}Hello world"));
     }
 
+    // The code comes from the EBU STL settings, not from Ebu.EbuUiHelper - that carrier only exists
+    // once a save or the save options dialog has created one, so a preview before either used to
+    // show every line centered whatever the dialog said (user report on PR #14229).
     [Fact]
-    public void NoHelperLeavesTheLineCentered()
+    public void TheSaveHelperDoesNotDecideTheJustification()
     {
         var oldHelper = Ebu.EbuUiHelper;
         try
         {
             Ebu.EbuUiHelper = null;
-            var header = MakeStlHeader();
-            var subtitle = new Subtitle { Header = header };
-            subtitle.Paragraphs.Add(new Paragraph("Hello world", 1000, 3000) { MarginV = "22" });
 
-            SubtitlePositionToAssa.ApplyPositions(subtitle, header);
-
-            Assert.StartsWith("{\\an2}", subtitle.Paragraphs[0].Text);
+            Assert.StartsWith("{\\an1}", Position(1, "22"));
+            Assert.StartsWith("{\\an3}", Position(3, "22"));
         }
         finally
         {
@@ -118,7 +111,7 @@ public class SubtitlePositionEbuJustificationTest
     [InlineData(1, "{\\an1}")] // left
     [InlineData(2, "{\\an2}")] // centered
     [InlineData(3, "{\\an3}")] // right
-    public void JustificationAlsoAppliesWithoutATeletextRow(byte justificationCode, string expected)
+    public void JustificationAlsoAppliesWithoutATeletextRow(int justificationCode, string expected)
     {
         Assert.StartsWith(expected, Position(justificationCode, null));
     }


### PR DESCRIPTION
Follow-up to #14229.

The justification is the one EBU STL save option that never got a home in libse's settings — the margins, the rows per line break and the teletext flags all live in `SubtitleSettings` and are filled by the settings sync. So when #14228 needed the code in the preview it reached for `Ebu.EbuUiHelper`.

That is the carrier that takes the code to the writer, not a setting:

- it stays `null` until a save or the save options dialog creates one, and `GetEbuJustificationOffset` read the null as "centered" — a preview opened before either showed every line centered whatever the dialog said;
- batch convert sets `Ebu.EbuUiHelper.JustificationCode` to its own job's code, which the main window's preview would then follow.

`EbuStlJustificationCode` now sits next to `EbuStlMarginTop` / `EbuStlMarginBottom` / `EbuStlNewLineRows` / `EbuStlTeletextUseBox`, is written by the dialog's OK alongside them, and is carried by `Se.UpdateLibSeSettings` like the rest — so the preview reads the justification where it already reads every other part of the layout.

The writer is unchanged and keeps using the helper: batch convert sets a code per job there, and both sides are seeded from the same persisted `Se.Settings.File.EbuSaveOptions.JustificationCode`.

## Tests

`SubtitlePositionEbuJustificationTest` drives the settings instead of the helper, and `TheSaveHelperDoesNotDecideTheJustification` pins the fresh-start case — no helper at all, left and right still applied. `EbuSaveOptionsPersistenceTests` covers the dialog's OK reaching the libse setting and the settings sync mirroring it. Full libse (1684) and UI (4219) suites pass; the one flaky `LibMpvEventLoopTests.Pause_RightAfterSeek_KeepsReportingTheSeekTarget` is a pre-existing timing flake and passes on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)