### PR TITLE
Center the grid on every prev/next row again (#14231)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -15540,7 +15540,7 @@ public partial class MainViewModel :
             return;
         }
 
-        SelectAndScrollToRow(idx);
+        SelectAndScrollToRowCentered(idx);
 
         if (WaveformCenter)
         {
@@ -15600,7 +15600,7 @@ public partial class MainViewModel :
             return;
         }
 
-        SelectAndScrollToRow(idx);
+        SelectAndScrollToRowCentered(idx);
 
         if (WaveformCenter)
         {
@@ -15632,7 +15632,7 @@ public partial class MainViewModel :
             return;
         }
 
-        SelectAndScrollToRow(idx);
+        SelectAndScrollToRowCentered(idx);
         vp.Position = Subtitles[idx].StartTime.TotalSeconds;
 
         if (AudioVisualizer != null && AudioVisualizer.WavePeaks != null)
@@ -15661,7 +15661,7 @@ public partial class MainViewModel :
         }
 
         vp.Position = Subtitles[idx].StartTime.TotalSeconds;
-        SelectAndScrollToRow(idx);
+        SelectAndScrollToRowCentered(idx);
 
         if (AudioVisualizer != null && AudioVisualizer.WavePeaks != null)
         {
@@ -15780,7 +15780,7 @@ public partial class MainViewModel :
         }
 
         vp.Position = next.StartTime.TotalSeconds;
-        SelectAndScrollToRow(idx);
+        SelectAndScrollToRowCentered(idx);
         AudioVisualizerCenterOnPositionIfNeeded(next, next.StartTime.TotalSeconds);
         _updateAudioVisualizer = true;
     }
@@ -15832,7 +15832,7 @@ public partial class MainViewModel :
         }
 
         vp.Position = previous.StartTime.TotalSeconds;
-        SelectAndScrollToRow(idx);
+        SelectAndScrollToRowCentered(idx);
         AudioVisualizerCenterOnPositionIfNeeded(previous, previous.StartTime.TotalSeconds);
         _updateAudioVisualizer = true;
     }
@@ -19432,6 +19432,21 @@ public partial class MainViewModel :
     }
 
     /// <summary>
+    /// <see cref="SelectAndScrollToRow(int)"/> for the "go to previous/next line" commands: with
+    /// "subtitle grid, center when selecting prev/next row" on, these re-center the view on every
+    /// step, not only when the target row happens to be off screen.
+    /// </summary>
+    private void SelectAndScrollToRowCentered(int index)
+    {
+        if (index < 0 || index >= Subtitles.Count)
+        {
+            return;
+        }
+
+        SelectAndScrollToRow(index, null, null, Se.Settings.General.SubtitleGridCenterSelectedRow);
+    }
+
+    /// <summary>
     /// Selects and scrolls to <paramref name="row"/>, resolving its index only when the
     /// (posted) scroll actually runs. Use this instead of the index overload whenever the
     /// collection may still shift between the call and the dispatcher callback - the merge
@@ -19457,7 +19472,13 @@ public partial class MainViewModel :
         SelectAndScrollToRow(index, row, restoreGridFocus);
     }
 
-    private void SelectAndScrollToRow(int index, SubtitleLineViewModel? row, bool? restoreGridFocus = null)
+    /// <param name="centerEvenIfVisible">
+    /// Center the target row even when it is already fully on screen - what the prev/next-line
+    /// navigation needs with "center when selecting prev/next row" on. Off for the rest, where
+    /// the scroll offset is left alone for a visible row (see <paramref name="row"/> callers such
+    /// as delete/insert, which must not move the rows out from under the user).
+    /// </param>
+    private void SelectAndScrollToRow(int index, SubtitleLineViewModel? row, bool? restoreGridFocus = null, bool centerEvenIfVisible = false)
     {
         _shiftSelectAnchorIndex = -1;
         _shiftSelectCurrentIndex = -1;
@@ -19554,7 +19575,7 @@ public partial class MainViewModel :
                     EditTextBoxOriginal.CaretIndex = 0;
                 }
 
-                if (Se.Settings.General.SubtitleGridCenterSelectedRow && !alreadyVisible)
+                if (Se.Settings.General.SubtitleGridCenterSelectedRow && (!alreadyVisible || centerEvenIfVisible))
                 {
                     CenterSelectedRowInSubtitleGrid(itemToScroll);
                 }
@@ -19683,6 +19704,18 @@ public partial class MainViewModel :
     private void CenterSelectedRowInSubtitleGrid(SubtitleLineViewModel itemToCenter)
     {
         TableViewExtras.CenterRow(SubtitleGrid, itemToCenter);
+    }
+
+    /// <summary>
+    /// Centers whatever row the grid has selected right now - for the arrow keys, where the
+    /// selection is moved by TableView's own list navigation rather than by a command.
+    /// </summary>
+    private void CenterCurrentRowInSubtitleGrid()
+    {
+        if (SubtitleGrid.SelectedItem is SubtitleLineViewModel current)
+        {
+            CenterSelectedRowInSubtitleGrid(current);
+        }
     }
 
     /// <summary>
@@ -26697,6 +26730,17 @@ public partial class MainViewModel :
                 {
                     _shiftSelectAnchorIndex = -1;
                     _shiftSelectCurrentIndex = -1;
+
+                    // A plain arrow key is left to TableView's own list navigation, which only
+                    // scrolls when the next row is off screen - so with "center when selecting
+                    // prev/next row" on, the selection walked from the middle of the view all the
+                    // way down to the bottom edge before anything moved, and the view then jumped
+                    // a half screen (#14231). This handler tunnels, so post the centering to run
+                    // after the built-in navigation has moved the selection.
+                    if (Se.Settings.General.SubtitleGridCenterSelectedRow)
+                    {
+                        Dispatcher.UIThread.Post(CenterCurrentRowInSubtitleGrid);
+                    }
                 }
                 else if (keyEventArgs.Key == Key.PageDown && IsExtendSelectionChord(keyEventArgs) && Subtitles.Count > 0)
                 {
@@ -26719,7 +26763,7 @@ public partial class MainViewModel :
                 {
                     keyEventArgs.Handled = true;
                     var current = SelectedSubtitleIndex ?? 0;
-                    SelectAndScrollToRow(TableViewExtras.GetPageTarget(SubtitleGrid, current, keyEventArgs.Key == Key.PageDown));
+                    SelectAndScrollToRowCentered(TableViewExtras.GetPageTarget(SubtitleGrid, current, keyEventArgs.Key == Key.PageDown));
                     return;
                 }
                 else if (keyEventArgs.Key == Key.Home && IsExtendSelectionChord(keyEventArgs) && Subtitles.Count > 0)

--- a/tests/UI/Features/Main/SubtitleGridCenterSelectedRowTests.cs
+++ b/tests/UI/Features/Main/SubtitleGridCenterSelectedRowTests.cs
@@ -1,0 +1,221 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// "Subtitle grid, center when selecting prev/next row" (#14231). Centering used to be skipped
+/// whenever the target row already was on screen - a guard meant for delete/insert, where moving
+/// the rows out from under the user is wrong - so stepping down through the file left the
+/// selection walking from the middle of the view to its bottom edge before anything scrolled,
+/// and the view then jumped a half screen at a time. Plain arrow keys never centered at all:
+/// they are handled by TableView's own list navigation, which scrolls only when the next row is
+/// off screen.
+/// </summary>
+public class SubtitleGridCenterSelectedRowTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+        Se.Settings.General.SubtitleGridCenterSelectedRow = false;
+        Se.Settings.General.PromptBeforeDelete = true;
+    }
+
+    [AvaloniaFact]
+    public async Task GoToNextLine_Repeatedly_KeepsTheRowCentered()
+    {
+        Se.Settings.General.SubtitleGridCenterSelectedRow = true;
+        var (window, vm) = ShowMainWindowWithLines(300);
+        vm.SelectAndScrollToSubtitle(vm.Subtitles[100]);
+        await SettleAsync(window);
+
+        var offsets = await Step(window, vm, 8, () => vm.GoToNextLineCommand.Execute(null));
+
+        AssertAllCentered(offsets);
+    }
+
+    [AvaloniaFact]
+    public async Task GoToPreviousLine_Repeatedly_KeepsTheRowCentered()
+    {
+        Se.Settings.General.SubtitleGridCenterSelectedRow = true;
+        var (window, vm) = ShowMainWindowWithLines(300);
+        vm.SelectAndScrollToSubtitle(vm.Subtitles[200]);
+        await SettleAsync(window);
+
+        var offsets = await Step(window, vm, 8, () => vm.GoToPreviousLineCommand.Execute(null));
+
+        AssertAllCentered(offsets);
+    }
+
+    [AvaloniaFact]
+    public async Task ArrowDown_InTheGrid_KeepsTheRowCentered()
+    {
+        Se.Settings.General.SubtitleGridCenterSelectedRow = true;
+        var (window, vm) = ShowMainWindowWithLines(300);
+        await FocusRowInGrid(window, vm, 100);
+
+        var offsets = await Step(window, vm, 8,
+            () => window.KeyPressQwerty(PhysicalKey.ArrowDown, RawInputModifiers.None));
+
+        Assert.Equal(108, vm.SelectedSubtitleIndex);
+        AssertAllCentered(offsets);
+    }
+
+    [AvaloniaFact]
+    public async Task ArrowUp_InTheGrid_KeepsTheRowCentered()
+    {
+        Se.Settings.General.SubtitleGridCenterSelectedRow = true;
+        var (window, vm) = ShowMainWindowWithLines(300);
+        await FocusRowInGrid(window, vm, 200);
+
+        var offsets = await Step(window, vm, 8,
+            () => window.KeyPressQwerty(PhysicalKey.ArrowUp, RawInputModifiers.None));
+
+        Assert.Equal(192, vm.SelectedSubtitleIndex);
+        AssertAllCentered(offsets);
+    }
+
+    [AvaloniaFact]
+    public async Task ArrowDown_WithTheSettingOff_LeavesTheScrollOffsetAlone()
+    {
+        Se.Settings.General.SubtitleGridCenterSelectedRow = false;
+        var (window, vm) = ShowMainWindowWithLines(300);
+        await FocusRowInGrid(window, vm, 100);
+
+        var scrollViewer = ScrollViewerOf(vm);
+        var before = scrollViewer.Offset.Y;
+        window.KeyPressQwerty(PhysicalKey.ArrowDown, RawInputModifiers.None);
+        await SettleAsync(window);
+
+        Assert.Equal(101, vm.SelectedSubtitleIndex);
+        Assert.Equal(before, scrollViewer.Offset.Y);
+    }
+
+    [AvaloniaFact]
+    public async Task Delete_WithTheSettingOn_StillLeavesTheScrollOffsetAlone()
+    {
+        // The already-visible guard stays in place for the commands that add or remove rows:
+        // re-centering there moves the rows out from under the user (see the delete/insert tests).
+        Se.Settings.General.SubtitleGridCenterSelectedRow = true;
+        Se.Settings.General.PromptBeforeDelete = false;
+        var (window, vm) = ShowMainWindowWithLines(300);
+        vm.SelectAndScrollToSubtitle(vm.Subtitles[108]);
+        await SettleAsync(window);
+
+        var scrollViewer = ScrollViewerOf(vm);
+        var before = scrollViewer.Offset.Y;
+        Assert.True(before > 0);
+
+        await vm.DeleteSelectedLinesCommand.ExecuteAsync(null);
+        await SettleAsync(window);
+
+        Assert.Equal("Line 110", vm.SelectedSubtitle?.Text);
+        Assert.Equal(before, scrollViewer.Offset.Y);
+    }
+
+    private static async Task<List<double>> Step(Window window, MainViewModel vm, int steps, Action move)
+    {
+        var offsets = new List<double>();
+        for (var i = 0; i < steps; i++)
+        {
+            move();
+            await SettleAsync(window);
+            offsets.Add(RowCenterOffsetFromViewportCenter(vm));
+        }
+
+        return offsets;
+    }
+
+    private static void AssertAllCentered(IReadOnlyList<double> offsets)
+    {
+        Assert.All(offsets, offset => Assert.True(Math.Abs(offset) < 5,
+            "selected row drifted away from the middle of the view, per-step offsets: " +
+            string.Join(", ", offsets.Select(o => o.ToString("0.0")))));
+    }
+
+    /// <summary>How far the selected row's middle sits from the middle of the viewport.</summary>
+    private static double RowCenterOffsetFromViewportCenter(MainViewModel vm)
+    {
+        var scrollViewer = ScrollViewerOf(vm);
+        var row = vm.SubtitleGrid.ContainerFromItem(vm.SelectedSubtitle!)!;
+        var viewportOrigin = (Visual?)scrollViewer.Presenter ?? scrollViewer;
+        var top = ((Visual)row).TranslatePoint(new Point(0, 0), viewportOrigin)!.Value.Y;
+        return top + row.Bounds.Height / 2.0 - scrollViewer.Viewport.Height / 2.0;
+    }
+
+    private static ScrollViewer ScrollViewerOf(MainViewModel vm)
+        => vm.SubtitleGrid.GetVisualDescendants().OfType<ScrollViewer>().First();
+
+    private static async Task FocusRowInGrid(Window window, MainViewModel vm, int index)
+    {
+        vm.SelectAndScrollToSubtitle(vm.Subtitles[index]);
+        await SettleAsync(window);
+        TableViewExtras.FocusRow(vm.SubtitleGrid);
+        await SettleAsync(window);
+        Assert.True(vm.SubtitleGrid.IsKeyboardFocusWithin);
+    }
+
+    private (Window Window, MainViewModel Vm) ShowMainWindowWithLines(int lineCount)
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1400, Height = 900 };
+        _windows.Add(window);
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var vm = (MainViewModel)view.DataContext!;
+        window.SuppressSaveChangesPromptOnClose(vm);
+        vm.Menu.IsVisible = true;
+        for (var i = 0; i < lineCount; i++)
+        {
+            vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph($"Line {i + 1}", i * 2000, i * 2000 + 1500), null!)
+            {
+                Number = i + 1,
+            });
+        }
+
+        Settle(window);
+        return (window, vm);
+    }
+
+    private static void Settle(Window window)
+    {
+        for (var pump = 0; pump < 8; pump++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+        }
+    }
+
+    private static async Task SettleAsync(Window window)
+    {
+        Settle(window);
+        await Task.Delay(50);
+        Settle(window);
+    }
+}


### PR DESCRIPTION
Fixes #14231 (part 1).

## The bug

With **Subtitle grid, center when selecting prev/next row** on, the grid only centered when the row being selected happened to be *off screen*. Stepping down through a file therefore did nothing at all until the selection had walked from the middle of the view all the way to the bottom edge — at which point the view jumped a half screen and the walk started over. That is the stutter in the reporter's video.

## Causes

**1. The already-visible guard swallowed the navigation case.**
`SelectAndScrollToRow` skips all scrolling for a row that is already fully visible. That guard was added for the delete/insert commands in 447dc7aa8 — the line after a deleted one is visible right below it, and re-centering for it moves the rows out from under the user. It should never have covered prev/next-line navigation, which is precisely what the setting is about.

The guard stays exactly where it was. `SelectAndScrollToRowCentered` is the navigation entry point, used by go-to-previous/next-line (plain, "and set video position", and "from video position") and by plain PageUp/PageDown.

**2. Plain arrow keys never reached the centering code at all.**
Up/Down in the grid falls through to TableView's own list navigation, which scrolls only when the next row is off screen — so the setting did nothing for the most common way of moving between lines. The grid key handler tunnels, so it now posts the centering to run after the built-in navigation has moved the selection.

## Tests

`tests/UI/Features/Main/SubtitleGridCenterSelectedRowTests.cs` — six headless tests. Four fail on `main` (the selected row drifts one row height per step: 21, 43, 65, 87, … px away from the middle) and pass here. The other two are regression guards: with the setting off the arrow key must not move the offset, and delete with the setting **on** must still leave the offset alone.

Full UI suite passes.

## Not covered

The second half of #14231 — "the list view suddenly jumps straight to the bottom" — is not addressed. The reporter has not identified a trigger and I could not reproduce it (arrow-key stress runs of 200 steps over 2000 lines, and the Ctrl+R case from #13579, all stay put). It needs its own repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)