### PR TITLE
Fix "inverse selection" selecting one row and jumping to the top

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -15540,26 +15540,81 @@ public partial class MainViewModel :
         });
     }
 
-    // Replaces the subtitle grid selection with the given rows.
-    private void ApplyGridSelection(IReadOnlyList<SubtitleLineViewModel> items)
+    /// <summary>
+    /// Replaces the subtitle grid selection with the given rows.
+    /// </summary>
+    /// <param name="current">
+    /// The row that should end up as the current one - the row the edit box shows, the shift-
+    /// selection anchor, and the row the grid scrolls to. Null means the first of
+    /// <paramref name="items"/>, which is what a caller whose selection is a result set (the
+    /// matches of a Modify selection) wants. Pass a row explicitly when the new selection is not
+    /// something to jump to, or row 1 would drag the view to the top of the file.
+    /// </param>
+    private void ApplyGridSelection(IReadOnlyList<SubtitleLineViewModel> items, SubtitleLineViewModel? current = null)
     {
         // Map items to indexes in one pass - Selection works on indexes, and per-item
         // IndexOf would be O(n²) on large selections.
         var wanted = new HashSet<SubtitleLineViewModel>(items);
+        var currentRow = current ?? (items.Count > 0 ? items[0] : null);
+        var currentIndex = currentRow != null ? Subtitles.IndexOf(currentRow) : -1;
+
         BatchGridSelection(() =>
         {
             SubtitleGrid.Selection.Clear();
-            for (var i = 0; i < Subtitles.Count && wanted.Count > 0; i++)
+
+            // The row selected first becomes SelectedItem and the selection anchor, the same
+            // trick SelectGridRange uses for the moving end of a shift-selection. It is covered
+            // again by one of the ranges below, which is a no-op.
+            if (currentIndex >= 0)
+            {
+                SubtitleGrid.Selection.Select(currentIndex);
+            }
+
+            // Hand the rest over as contiguous ranges rather than one Select per row.
+            // SelectionModel.Select forces the anchor to the row it selects, so a per-row loop
+            // leaves the anchor on the *last* row of the selection - and SelectingItemsControl
+            // posts a ScrollIntoView for the anchor, which threw the grid to the end of the file
+            // after an inverse selection. SelectRange leaves an anchor that is already set alone.
+            var runStart = -1;
+            for (var i = 0; i < Subtitles.Count; i++)
             {
                 if (wanted.Remove(Subtitles[i]))
                 {
-                    SubtitleGrid.Selection.Select(i);
+                    if (runStart < 0)
+                    {
+                        runStart = i;
+                    }
+
+                    continue;
+                }
+
+                if (runStart >= 0)
+                {
+                    SubtitleGrid.Selection.SelectRange(runStart, i - 1);
+                    runStart = -1;
+                }
+
+                if (wanted.Count == 0)
+                {
+                    break;
                 }
             }
 
-            SelectedSubtitle = items.Count > 0 ? items[0] : null;
-            SelectedSubtitleIndex = SelectedSubtitle != null ? Subtitles.IndexOf(SelectedSubtitle) : null;
+            if (runStart >= 0)
+            {
+                SubtitleGrid.Selection.SelectRange(runStart, Subtitles.Count - 1);
+            }
         });
+
+        // Only now that the batch has committed. SelectedSubtitle is TwoWay-bound to the grid's
+        // SelectedItem, and SelectionModel's SelectedIndex setter is a Clear() + Select() - so
+        // assigning it while the batch was still open wrote back through the binding and wiped
+        // every row the batch had queued: an inverse selection queued 299 of 300 rows and came
+        // out with one row selected, so every command that reads the selection saw a single
+        // line. After the commit the grid already has this row as SelectedItem, so the binding
+        // write is a no-op and the selection survives.
+        SelectedSubtitle = currentIndex >= 0 ? Subtitles[currentIndex] : null;
+        SelectedSubtitleIndex = currentIndex >= 0 ? currentIndex : null;
 
         SubtitleGridSelectionChanged();
     }
@@ -19487,6 +19542,31 @@ public partial class MainViewModel :
         SubtitleGrid.SelectAll();
     }
 
+    /// <summary>
+    /// The row nearest <paramref name="index"/> that is not in <paramref name="excluded"/> -
+    /// searching down from it first, then up. Null when every row is excluded.
+    /// </summary>
+    private SubtitleLineViewModel? NearestRowNotIn(HashSet<SubtitleLineViewModel> excluded, int index)
+    {
+        for (var i = Math.Max(0, index); i < Subtitles.Count; i++)
+        {
+            if (!excluded.Contains(Subtitles[i]))
+            {
+                return Subtitles[i];
+            }
+        }
+
+        for (var i = Math.Min(index, Subtitles.Count) - 1; i >= 0; i--)
+        {
+            if (!excluded.Contains(Subtitles[i]))
+            {
+                return Subtitles[i];
+            }
+        }
+
+        return null;
+    }
+
     private void InverseRowSelection()
     {
         if (Subtitles.Count == 0)
@@ -19498,10 +19578,29 @@ public partial class MainViewModel :
         // With reference: inverting works on rows as displayed, so a selected reference row
         // must count as selected and end up deselected.
         var selectedItems = new HashSet<SubtitleLineViewModel>(SubtitleGridSelectedItemsWithReference);
+        var currentIndex = SelectedSubtitleIndex ?? 0;
 
-        // Inverting a small selection on a large file selects almost every row, so
-        // apply via the detach/reattach helper to avoid the per-row hang (#11529).
-        ApplyGridSelection(Subtitles.Where(s => !selectedItems.Contains(s)).ToList());
+        // SE 4 inverted by flipping each row's Selected flag and never touched the focused row
+        // or the scroll offset, so the user stayed where they were looking. The current row is
+        // always inverted away, and letting the first row of the new selection become current
+        // instead - row 1 whenever the user had a single row selected - pulled the grid to the
+        // top of the file and put line 1 in the edit box. Hand the current row to the nearest
+        // row that survived the inversion.
+        var current = NearestRowNotIn(selectedItems, currentIndex);
+        if (current == null)
+        {
+            // Everything was selected, so the inverse is nothing - but the grid is
+            // AlwaysSelected and would re-pick row 1 and scroll to the top. Collapse to the
+            // row the user is on instead.
+            var row = Subtitles.GetOrNull(currentIndex) ?? Subtitles[0];
+            ApplyGridSelection(new[] { row }, row);
+            return;
+        }
+
+        // Inverting a small selection on a large file selects almost every row, so it goes
+        // through ApplyGridSelection, which applies it as index ranges in one batch instead of
+        // row by row (#11529).
+        ApplyGridSelection(Subtitles.Where(s => !selectedItems.Contains(s)).ToList(), current);
     }
 
     private void SelectAndScrollToRow(int index)

--- a/tests/UI/Features/Main/SubtitleGridInverseSelectionTests.cs
+++ b/tests/UI/Features/Main/SubtitleGridInverseSelectionTests.cs
@@ -1,0 +1,170 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// "Inverse selection" used to throw the grid to the top of the file: the inverted selection is
+/// handed to ApplyGridSelection, which made its first row current - and with a single row
+/// selected that first row is line 1, so the view jumped to row 0 and the edit box showed line 1.
+/// SE 4 flipped each row's Selected flag and never touched the focused row or the scroll offset.
+/// </summary>
+public class SubtitleGridInverseSelectionTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    [AvaloniaFact]
+    public async Task InverseSelection_FromTheMiddle_LeavesTheViewWhereItWas()
+    {
+        var (window, vm) = ShowMainWindowWithLines(300);
+        vm.SelectAndScrollToSubtitle(vm.Subtitles[150]);
+        await SettleAsync(window);
+
+        var scrollViewer = vm.SubtitleGrid.GetVisualDescendants().OfType<ScrollViewer>().First();
+        var before = scrollViewer.Offset.Y;
+        Assert.True(before > 0);
+
+        vm.InverseSelectionCommand.Execute(null);
+        await SettleAsync(window);
+
+        Assert.Equal(before, scrollViewer.Offset.Y);
+        Assert.Equal("Line 152", vm.SelectedSubtitle?.Text);
+        Assert.Equal(151, vm.SelectedSubtitleIndex);
+    }
+
+    [AvaloniaFact]
+    public async Task InverseSelection_InvertsEveryRow()
+    {
+        var (window, vm) = ShowMainWindowWithLines(300);
+        vm.SelectAndScrollToSubtitle(vm.Subtitles[150]);
+        await SettleAsync(window);
+
+        vm.InverseSelectionCommand.Execute(null);
+        await SettleAsync(window);
+
+        var selected = vm.SubtitleGridSelectedItems;
+        Assert.Equal(299, selected.Count);
+        Assert.DoesNotContain(vm.Subtitles[150], selected);
+        Assert.Contains(vm.Subtitles[0], selected);
+        Assert.Contains(vm.Subtitles[299], selected);
+    }
+
+    [AvaloniaFact]
+    public async Task InverseSelection_OnTheLastRow_TakesThePreviousRowAsCurrent()
+    {
+        var (window, vm) = ShowMainWindowWithLines(300);
+        vm.SelectAndScrollToSubtitle(vm.Subtitles[299]);
+        await SettleAsync(window);
+
+        vm.InverseSelectionCommand.Execute(null);
+        await SettleAsync(window);
+
+        Assert.Equal(298, vm.SelectedSubtitleIndex);
+        Assert.True(TableViewExtras.IsRowFullyVisible(vm.SubtitleGrid, vm.Subtitles[298]));
+    }
+
+    [AvaloniaFact]
+    public async Task InverseSelection_WithEverythingSelected_KeepsTheCurrentRow()
+    {
+        // The inverse of "everything" is nothing, but SelectionMode.AlwaysSelected would
+        // re-pick row 0 and scroll to the top; collapse to the row the user is on instead.
+        var (window, vm) = ShowMainWindowWithLines(300);
+        vm.SelectAndScrollToSubtitle(vm.Subtitles[150]);
+        await SettleAsync(window);
+        var scrollViewer = vm.SubtitleGrid.GetVisualDescendants().OfType<ScrollViewer>().First();
+        var before = scrollViewer.Offset.Y;
+
+        vm.SelectAllLinesCommand.Execute(null);
+        await SettleAsync(window);
+        Assert.Equal(300, vm.SubtitleGridSelectedItems.Count);
+
+        vm.InverseSelectionCommand.Execute(null);
+        await SettleAsync(window);
+
+        Assert.Equal(before, scrollViewer.Offset.Y);
+        Assert.Equal(150, vm.SelectedSubtitleIndex);
+        Assert.Single(vm.SubtitleGridSelectedItems);
+    }
+
+    [AvaloniaFact]
+    public async Task InverseSelection_Twice_ComesBackToTheOriginalSelection()
+    {
+        var (window, vm) = ShowMainWindowWithLines(50);
+        vm.SelectAndScrollToSubtitle(vm.Subtitles[10]);
+        await SettleAsync(window);
+
+        vm.InverseSelectionCommand.Execute(null);
+        await SettleAsync(window);
+        vm.InverseSelectionCommand.Execute(null);
+        await SettleAsync(window);
+
+        var selected = vm.SubtitleGridSelectedItems;
+        Assert.Single(selected);
+        Assert.Same(vm.Subtitles[10], selected[0]);
+        Assert.Equal(10, vm.SelectedSubtitleIndex);
+    }
+
+    private (Window Window, MainViewModel Vm) ShowMainWindowWithLines(int lineCount)
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1400, Height = 900 };
+        _windows.Add(window);
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var vm = (MainViewModel)view.DataContext!;
+        window.SuppressSaveChangesPromptOnClose(vm);
+        vm.Menu.IsVisible = true;
+        for (var i = 0; i < lineCount; i++)
+        {
+            vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph($"Line {i + 1}", i * 2000, i * 2000 + 1500), null!)
+            {
+                Number = i + 1,
+            });
+        }
+
+        Settle(window);
+        return (window, vm);
+    }
+
+    private static void Settle(Window window)
+    {
+        for (var pump = 0; pump < 8; pump++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+        }
+    }
+
+    private static async Task SettleAsync(Window window)
+    {
+        Settle(window);
+        await Task.Delay(50);
+        Settle(window);
+    }
+}


### PR DESCRIPTION
Found while hunting the unreproduced half of #14231 ("the list view suddenly jumps"). Not that bug — but the same family, and worse than it looked.

## The bug

`Edit → Inverse selection` with one row selected in a 300-line file:

- the selection model got 299 rows queued and came out with **one** row selected — drawn that way in the grid, and read back that way by every command that acts on the selection, so a follow-up delete/italic/whatever hit a single line instead of 299;
- the view jumped to the **top** of the file with line 1 in the edit box.

## Three causes in `ApplyGridSelection`

**1. Assigning `SelectedSubtitle` inside the selection batch wiped the batch.** `SelectedSubtitle` is TwoWay-bound to the grid's `SelectedItem`, and `SelectionModel.SelectedIndex`'s setter is `Clear() + Select()` even for an unchanged value (the same-value early-out is dead outside a batch — the note already in `project_grid_removal_selection_invariants`). Assigning it while the batch was open wrote back through the binding and cleared every range queued so far. It's assigned after the commit now, where the grid already holds that row as `SelectedItem` so the binding write is a no-op.

**2. The anchor ended up on the last row.** `SelectionModel.Select` passes `forceAnchorIndex: true`, so a per-row loop leaves `AnchorIndex` on the last row selected — and `SelectingItemsControl` posts a `ScrollIntoView` for the anchor. Once cause 1 was fixed and the selection really was 299 rows, this threw the grid to the **end** of the file. The rows now go in as contiguous ranges; `SelectRange` passes `forceAnchorIndex: false` and leaves an anchor that's already set alone.

**3. The current row was `items[0]`.** For an inverted selection that's row 1 whenever the user had a single row selected — the jump to the top. Callers can now name the row that should be current. Inverse selection hands it the nearest row that survived the inversion, so the user stays where they were looking, which is what SE 4 did by flipping each row's `Selected` flag and never touching the focused item or the scroll offset. When everything was selected the inverse is nothing and `SelectionMode.AlwaysSelected` would re-pick row 1, so that case collapses to the current row instead.

`ApplyGridSelection` also backs **Modify selection** and the scattered-row selection behind duplicate-lines, so causes 1 and 2 were hurting those too. Their "current row = first of the new selection" default is unchanged — jumping to the first match is right for a result set.

## Tests

`tests/UI/Features/Main/SubtitleGridInverseSelectionTests.cs` — five headless tests: the view stays put and the row next to the user's becomes current; all 299 rows really are selected; the last row falls back to the previous one; inverting a full selection keeps the current row; and inverting twice returns to the original selection.

Full UI suite passes (4228/4230; the one failure is the known flaky `LibMpvEventLoopTests.Pause_RightAfterSeek`, which passes in isolation and is untouched by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)