### PR TITLE
Write colors as mid-row codes when saving SCC

### DIFF
--- a/src/libse/SubtitleFormats/ScenaristClosedCaptions.cs
+++ b/src/libse/SubtitleFormats/ScenaristClosedCaptions.cs
@@ -711,6 +711,304 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             return sb.ToString();
         }
 
+        // A style change is written as a CEA-608 mid-row code. It is put into the prepared line
+        // as this single marker character so it takes exactly one screen cell - which is what a
+        // mid-row code does when displayed (it shows as a space) - and the code itself is kept
+        // in a parallel list. The marker is from the private use area, so it can never collide
+        // with subtitle text (and has no CEA-608 code of its own).
+        private const char StyleMarker = '\uE000';
+
+        private const string MidRowWhite = "9120";
+        private const string MidRowItalic = "91ae";
+        private const string MidRowItalicUnderline = "912f";
+
+        private static readonly Lazy<Dictionary<SKColor, string>> MidRowColorCodes = BuildMidRowColorCodes(false);
+        private static readonly Lazy<Dictionary<SKColor, string>> MidRowColorUnderlineCodes = BuildMidRowColorCodes(true);
+
+        private static Lazy<Dictionary<SKColor, string>> BuildMidRowColorCodes(bool underline)
+        {
+            return new Lazy<Dictionary<SKColor, string>>(() =>
+            {
+                var codes = new Dictionary<SKColor, string>();
+                foreach (var p in SccPositionAndStyleTable.SccPositionAndStyles)
+                {
+                    // Mid-row codes are the entries with no row/column (the italic ones carry no
+                    // color of their own - they are always white per CEA-608).
+                    if (p.X != -1 || p.Y != -1 || p.ForeColor == SKColors.Transparent ||
+                        (p.Style & SccFontStyle.Italic) == SccFontStyle.Italic ||
+                        ((p.Style & SccFontStyle.Underline) == SccFontStyle.Underline) != underline)
+                    {
+                        continue;
+                    }
+
+                    if (!codes.ContainsKey(p.ForeColor))
+                    {
+                        codes.Add(p.ForeColor, p.Code);
+                    }
+                }
+
+                return codes;
+            });
+        }
+
+        /// <summary>
+        /// The style tags open at the current position while a line is written.
+        /// </summary>
+        private class SccStyle
+        {
+            internal int Italic { get; set; }
+            internal int Underline { get; set; }
+            internal List<SKColor> Colors { get; } = new List<SKColor>();
+            internal SKColor Color => Colors.Count > 0 ? Colors[Colors.Count - 1] : SKColors.White;
+        }
+
+        private static string GetMidRowCode(SccStyle style)
+        {
+            if (style.Italic > 0)
+            {
+                // CEA-608 encodes italics in the same slot as the colors, so italics is always
+                // white - colored italics do not exist in the format.
+                return style.Underline > 0 ? MidRowItalicUnderline : MidRowItalic;
+            }
+
+            var codes = style.Underline > 0 ? MidRowColorUnderlineCodes : MidRowColorCodes;
+            return codes.Value.TryGetValue(GetNearestSccColor(style.Color), out var code) ? code : MidRowWhite;
+        }
+
+        /// <summary>
+        /// CEA-608 has seven foreground colors - map anything else to the nearest one by
+        /// quantizing each channel, like the EBU/teletext writer does. The threshold follows the
+        /// strongest channel so a dark green still becomes green, and black (no channel at all)
+        /// stays white: there is no black foreground code.
+        /// </summary>
+        private static SKColor GetNearestSccColor(SKColor color)
+        {
+            var threshold = Math.Max(64, Math.Max(color.Red, Math.Max(color.Green, color.Blue)) / 2);
+            var r = color.Red >= threshold;
+            var g = color.Green >= threshold;
+            var b = color.Blue >= threshold;
+
+            if (r && g && b)
+            {
+                return SKColors.White;
+            }
+
+            if (r && g)
+            {
+                return SKColors.Yellow;
+            }
+
+            if (r && b)
+            {
+                return SKColors.Magenta;
+            }
+
+            if (g && b)
+            {
+                return SKColors.Cyan;
+            }
+
+            if (r)
+            {
+                return SKColors.Red;
+            }
+
+            if (g)
+            {
+                return SKColors.Green;
+            }
+
+            if (b)
+            {
+                return SKColors.Blue;
+            }
+
+            return SKColors.White;
+        }
+
+        /// <summary>
+        /// Replaces the style tags of one line with <see cref="StyleMarker"/> + the CEA-608
+        /// mid-row code to write for it. Tags with no CEA-608 equivalent are dropped: only
+        /// "&lt;i&gt;" used to be understood here, so every other tag was encoded letter by
+        /// letter and ended up on screen as "&lt;font color=..." (issue #14239).
+        /// </summary>
+        private static string ReplaceStyleTagsWithMidRowCodes(string line, SccStyle style, List<string> codes)
+        {
+            var sb = new StringBuilder(line.Length);
+
+            // A row starts with the style of its Preamble Address Code - white, no underline, no
+            // italics - so a style still open from the previous row must be written again here.
+            var currentCode = MidRowWhite;
+            var styleChanged = true;
+            var i = 0;
+            while (i < line.Length)
+            {
+                if (line[i] == StyleMarker)
+                {
+                    i++; // never in real subtitle text, and it must not be taken for a code marker
+                    continue;
+                }
+
+                if (line[i] == '<')
+                {
+                    var tagEnd = line.IndexOf('>', i + 1);
+                    if (IsTag(line, i, tagEnd))
+                    {
+                        ApplyTag(line.Substring(i + 1, tagEnd - i - 1), style);
+                        styleChanged = true;
+                        i = tagEnd + 1;
+                        continue;
+                    }
+                }
+
+                if (styleChanged)
+                {
+                    // Written only now that a character follows, so a style that is closed at the
+                    // end of a line does not cost a cell for a reset nothing can be seen after.
+                    var newCode = GetMidRowCode(style);
+                    if (newCode != currentCode)
+                    {
+                        sb.Append(StyleMarker);
+                        codes.Add(newCode);
+                        currentCode = newCode;
+                    }
+
+                    styleChanged = false;
+                }
+
+                sb.Append(line[i]);
+                i++;
+            }
+
+            return sb.ToString();
+        }
+
+        private static bool IsTag(string line, int start, int end)
+        {
+            if (end <= start)
+            {
+                return false; // no ">" - a stray "<" is text, e.g. "a < b"
+            }
+
+            var i = start + 1;
+            if (line[i] == '/')
+            {
+                i++;
+            }
+
+            if (i >= end || !char.IsLetter(line[i]))
+            {
+                return false;
+            }
+
+            var nextStart = line.IndexOf('<', start + 1);
+            return nextStart < 0 || nextStart > end;
+        }
+
+        private static void ApplyTag(string tag, SccStyle style)
+        {
+            if (tag.Equals("i", StringComparison.OrdinalIgnoreCase))
+            {
+                style.Italic++;
+            }
+            else if (tag.Equals("/i", StringComparison.OrdinalIgnoreCase))
+            {
+                style.Italic = Math.Max(0, style.Italic - 1);
+            }
+            else if (tag.Equals("u", StringComparison.OrdinalIgnoreCase))
+            {
+                style.Underline++;
+            }
+            else if (tag.Equals("/u", StringComparison.OrdinalIgnoreCase))
+            {
+                style.Underline = Math.Max(0, style.Underline - 1);
+            }
+            else if (tag.StartsWith("font", StringComparison.OrdinalIgnoreCase))
+            {
+                style.Colors.Add(GetFontTagColor(tag));
+            }
+            else if (tag.Equals("c", StringComparison.OrdinalIgnoreCase) || tag.StartsWith("c.", StringComparison.OrdinalIgnoreCase))
+            {
+                style.Colors.Add(GetWebVttClassColor(tag));
+            }
+            else if (tag.Equals("/font", StringComparison.OrdinalIgnoreCase) || tag.Equals("/c", StringComparison.OrdinalIgnoreCase))
+            {
+                if (style.Colors.Count > 0)
+                {
+                    style.Colors.RemoveAt(style.Colors.Count - 1);
+                }
+            }
+
+            // Any other tag (bold, ruby, voice spans...) has no CEA-608 equivalent and is dropped.
+        }
+
+        /// <summary>
+        /// Reads the color of a "font" tag; the value may be double-quoted, single-quoted or bare.
+        /// An unknown color gives white, which is also what a color-less font tag means.
+        /// </summary>
+        private static SKColor GetFontTagColor(string tag)
+        {
+            var colorStart = tag.IndexOf("color", StringComparison.OrdinalIgnoreCase);
+            if (colorStart < 0)
+            {
+                return SKColors.White;
+            }
+
+            var equalsSign = tag.IndexOf('=', colorStart);
+            if (equalsSign < 0)
+            {
+                return SKColors.White;
+            }
+
+            var color = tag.Substring(equalsSign + 1).TrimStart();
+            if (color.Length > 0 && (color[0] == '"' || color[0] == '\''))
+            {
+                var quote = color[0];
+                var closingQuote = color.IndexOf(quote, 1);
+                color = closingQuote > 0 ? color.Substring(1, closingQuote - 1) : color.Substring(1);
+            }
+            else
+            {
+                var space = color.IndexOf(' ');
+                if (space > 0)
+                {
+                    color = color.Substring(0, space);
+                }
+            }
+
+            color = color.Trim();
+            return color.Length == 0 ? SKColors.White : HtmlUtil.GetColorFromString(color);
+        }
+
+        /// <summary>
+        /// Reads the color of a WebVTT class tag, e.g. "c.yellow" or "c.colorFFFF00" - SubtitleEdit
+        /// keeps those as they are when loading WebVTT, so they arrive here unchanged.
+        /// </summary>
+        private static SKColor GetWebVttClassColor(string tag)
+        {
+            foreach (var cssClass in tag.Split('.'))
+            {
+                if (cssClass.Length == 0 || cssClass.Equals("c", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var name = cssClass;
+                if (name.StartsWith("color", StringComparison.OrdinalIgnoreCase) && name.Length == "color".Length + 6)
+                {
+                    name = "#" + name.Substring("color".Length);
+                }
+
+                var color = HtmlUtil.GetColorFromString(name);
+                if (color != SKColors.White)
+                {
+                    return color; // classes that are not colors (languages, "bg_black"...) give white
+                }
+            }
+
+            return SKColors.White;
+        }
+
         private static string ToSccText(string text, string language)
         {
             // Transliterate characters CEA-608 has no code for (they would otherwise be
@@ -742,46 +1040,36 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
             text = Utilities.RemoveSsaTags(text);
             var lines = text.Trim().SplitToLines();
-            int italic = 0;
+            var style = new SccStyle();
+            var styleCodes = new List<string>();
             var sb = new StringBuilder();
             int count = 1;
             foreach (var line in lines)
             {
-                text = line.Trim();
+                styleCodes.Clear();
+                text = ReplaceStyleTagsWithMidRowCodes(line.Trim(), style, styleCodes);
                 if (count > 0)
                 {
                     sb.Append(' ');
                 }
 
-                var centerCodes = GetCenterCodes(HtmlUtil.RemoveHtmlTags(text), count, lines.Count, topAlign, leftAlign, rightAlign, verticalCenter);
+                // The text now holds one marker per mid-row code, and a mid-row code takes one
+                // screen cell (it shows as a space) - so its length is the width to center.
+                var centerCodes = GetCenterCodes(text, count, lines.Count, topAlign, leftAlign, rightAlign, verticalCenter);
                 sb.Append(centerCodes);
                 count++;
                 text = InsertExtendedCharFallbacks(text); // after centering - fallback chars are erased again and take no screen cell
                 int i = 0;
+                int styleCodeIndex = 0;
                 string code = string.Empty;
-                if (italic > 0)
-                {
-                    sb.Append("91ae 91ae "); // italic
-                }
 
                 while (i < text.Length)
                 {
-                    string codeFromLetter = GetCodeFromLetter(text[i]);
                     string newCode;
-                    // Tail tests over a span: Substring(i) copied the rest of the line twice per
-                    // character, which made this loop quadratic in line length.
-                    var tail = text.AsSpan(i);
-                    if (tail.StartsWith("<i>".AsSpan(), StringComparison.Ordinal))
+                    if (text[i] == StyleMarker)
                     {
-                        newCode = "91ae";
-                        i += 2;
-                        italic++;
-                    }
-                    else if (tail.StartsWith("</i>".AsSpan(), StringComparison.Ordinal) && italic > 0)
-                    {
-                        newCode = "9120";
-                        i += 3;
-                        italic--;
+                        newCode = styleCodes[styleCodeIndex];
+                        styleCodeIndex++;
                     }
                     else if (text[i] == '’')
                     {
@@ -805,13 +1093,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         code = "9229";
                         newCode = "";
                     }
-                    else if (codeFromLetter == null)
-                    {
-                        newCode = GetCodeFromLetter(" ");
-                    }
                     else
                     {
-                        newCode = codeFromLetter;
+                        newCode = GetCodeFromLetter(text[i]) ?? GetCodeFromLetter(" ");
                     }
 
                     if (code.Length == 2 && newCode.Length == 4)
@@ -933,6 +1217,11 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             else if (rightAlign)
             {
                 left = 32 - text.Length;
+            }
+
+            if (left < 0)
+            {
+                left = 0; // a line wider than the row (mid-row codes take a cell too) starts at column zero
             }
             int columnRest = left % 4;
             int column = left - columnRest;
@@ -1345,8 +1634,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             }
                             else if (cp.ForeColor == SKColors.White && fontOn)
                             {
-                                sb.Append("</font>");
-                                sb.Append("</font>");
+                                sb.Append("</font>"); // once - a white code closes one font tag
                                 fontOn = false;
                             }
                             else if (cp.ForeColor == SKColors.Black && fontOn)

--- a/tests/libse/SubtitleFormats/ScenaristClosedCaptionsTest.cs
+++ b/tests/libse/SubtitleFormats/ScenaristClosedCaptionsTest.cs
@@ -138,6 +138,142 @@ public class ScenaristClosedCaptionsTest
         Assert.Single(subtitle.Paragraphs);
         Assert.Equal("<i>♪ De Pueblo Paleta soy ♪</i>", subtitle.Paragraphs[0].Text);
     }
+
+    private static string SaveScc(string text)
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph(text, 1000, 3000));
+        var scc = new ScenaristClosedCaptions().ToText(subtitle, "test");
+        return scc.SplitToLines().First(line => line.Contains("9420")).Trim();
+    }
+
+    private static string SaveAndReloadScc(string text)
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph(text, 1000, 3000));
+        var format = new ScenaristClosedCaptions();
+        var reloaded = new Subtitle();
+        format.LoadSubtitle(reloaded, format.ToText(subtitle, "test").SplitToLines(), "test.scc");
+        return reloaded.Paragraphs.Count == 0 ? string.Empty : reloaded.Paragraphs[0].Text;
+    }
+
+    [Fact]
+    public void WritesColorAsMidRowCode()
+    {
+        // Issue #14239: the writer only knew "<i>", so a color tag was encoded letter by letter
+        // and showed up on screen as "<font color=...". Yellow is the mid-row code 912a, and
+        // going back to white after it is 9120 (control codes are always sent twice).
+        var scc = SaveScc("-- <font color=\"yellow\">Captions by VITAC</font> --");
+
+        Assert.Contains("912a 912a", scc);
+        Assert.Contains("9120 9120", scc);
+        Assert.Equal("-- <font color=\"Yellow\">Captions by VITAC</font> --", SaveAndReloadScc("-- <font color=\"yellow\">Captions by VITAC</font> --"));
+    }
+
+    [Fact]
+    public void WritesWebVttColorClassAsMidRowCode()
+    {
+        // WebVTT color classes are kept as they are when a .vtt file is loaded, so they reach
+        // the SCC writer as "<c.yellow>" instead of "<font color=...>".
+        Assert.Contains("912a 912a", SaveScc("<c.yellow>Captions by VITAC</c>"));
+        Assert.Equal("<font color=\"Yellow\">Captions by VITAC</font>", SaveAndReloadScc("<c.yellow>Captions by VITAC</c>"));
+    }
+
+    [Theory]
+    [InlineData("white", "9120")]
+    [InlineData("green", "91a2")]
+    [InlineData("blue", "91a4")]
+    [InlineData("cyan", "9126")]
+    [InlineData("red", "91a8")]
+    [InlineData("yellow", "912a")]
+    [InlineData("magenta", "912c")]
+    [InlineData("#00FF00", "91a2")]     // hex spelling
+    [InlineData("#104010", "91a2")]     // a dark green is still green
+    [InlineData("#808080", "9120")]     // gray is nearest to white
+    [InlineData("black", "9120")]       // CEA-608 has no black foreground - stay white
+    [InlineData("chucknorris", "9120")] // not a color at all
+    public void WritesAllCea608Colors(string color, string expectedCode)
+    {
+        var scc = SaveScc("Hi <font color=\"" + color + "\">there</font>");
+
+        if (expectedCode == "9120")
+        {
+            Assert.DoesNotContain("91a2", scc);
+            Assert.DoesNotContain("912a", scc);
+        }
+        else
+        {
+            Assert.Contains(expectedCode + " " + expectedCode, scc);
+        }
+    }
+
+    [Fact]
+    public void DoesNotWriteTagsAsText()
+    {
+        // Any tag with no CEA-608 equivalent must be dropped, not encoded letter by letter.
+        foreach (var text in new[] { "<b>Hello</b>", "<ruby>Hello</ruby>", "<v Fred>Hello</v>", "<font face=\"Arial\">Hello</font>" })
+        {
+            var scc = SaveScc(text);
+
+            Assert.DoesNotContain("bc", scc); // "<" with odd parity
+            Assert.DoesNotContain("3e", scc); // ">"
+            Assert.Equal("Hello", SaveAndReloadScc(text));
+        }
+    }
+
+    [Fact]
+    public void KeepsLessThanSignInText()
+    {
+        // ...but a stray "<" is text, not a tag ("bc" is "<" with odd parity, "3e" is ">").
+        var scc = SaveScc("a < b > c");
+
+        Assert.Contains("bc", scc);
+        Assert.Contains("3e", scc);
+        Assert.Equal("a < b > c", SaveAndReloadScc("a < b > c"));
+    }
+
+    [Fact]
+    public void ItalicsWinsOverColor()
+    {
+        // CEA-608 encodes italics in the same slot as the colors - colored italics do not exist,
+        // so the color inside an italic run is dropped instead of ending the italics.
+        var scc = SaveScc("<i>Italic <font color=\"yellow\">yellow</font></i>");
+
+        Assert.Contains("91ae 91ae", scc);
+        Assert.DoesNotContain("912a", scc);
+        Assert.Equal("<i>Italic yellow</i>", SaveAndReloadScc("<i>Italic <font color=\"yellow\">yellow</font></i>"));
+    }
+
+    [Fact]
+    public void ReopensColorOnEveryRow()
+    {
+        // A Preamble Address Code resets the row to white, so a color spanning two lines must be
+        // written again on the second row.
+        var scc = SaveScc("<font color=\"yellow\">Line one" + Environment.NewLine + "line two</font>");
+
+        Assert.Equal(2, scc.Split(new[] { "912a 912a" }, StringSplitOptions.None).Length - 1);
+    }
+
+    [Fact]
+    public void CenteringCountsMidRowCodeCells()
+    {
+        // A mid-row code takes a screen cell (it shows as a space), so a line with a color and a
+        // reset in it is two cells wider than its text and must be indented two cells less:
+        // 24 characters center on column 4 (the row 15 code 94f2), 24 + 2 on column 0 + tab 3.
+        Assert.Contains("94f2 94f2", SaveScc("Twenty four characters!!"));
+        Assert.Contains("9470 9470 9723 9723", SaveScc("<font color=\"yellow\">Twenty four</font> characters!!"));
+    }
+
+    [Fact]
+    public void LongColoredLineStaysOnTheRow()
+    {
+        // The 32 characters plus the mid-row code do not fit the row - do not fall back to a
+        // right-hand column (the old negative indent picked column 28).
+        var scc = SaveScc("<font color=\"yellow\">12345678901234567890123456789012</font>");
+
+        Assert.Contains("9470 9470", scc); // row 15, column 0
+        Assert.DoesNotContain("94fe", scc); // row 15, column 28
+    }
 }
 
 public class ScenaristClosedCaptionsFormatLimitsTest


### PR DESCRIPTION
Fixes #14239

## The bug

The SCC writer only understood `<i>`/`</i>`. Every other tag fell through to the letter encoder, so its characters were written as caption text. The cue from the issue:

```
00:00:24.457 --> 00:00:27.360 line:10% position:50%
-- <c.yellow>Captions by VITAC</c> --
```

was exported as `-- <font color="yellow">Capt` on screen — the markup rendered, and the real words pushed past the 32 column row limit. Positioning was wrong too: the row was centered on the tag-free text while the tag characters were the ones being written.

The format supports colors and SubtitleEdit's SCC *reader* already decodes them (both colored Preamble Address Codes and mid-row codes are in `SccPositionAndStyleTable`) — only the writer never emitted any of them. `GetCodeFromPositionAndColor` sat unused.

## The fix

Style tags are now turned into CEA-608 mid-row codes before a line is encoded:

- `<font color=...>` and WebVTT's `<c.yellow>` / `<c.colorFFFF00>` → the mid-row code for the nearest of the seven CEA-608 colors (`912a` yellow, `91a2` green, ...), `9120` on close. Colors are picked the way the EBU writer picks its teletext colors; black stays white, as CEA-608 has no black foreground.
- `<u>` → the underline variant of the current color.
- Every other tag (bold, ruby, voice spans, `<font face=...>`) is **dropped** instead of written as letters. A stray `<` in the text is still text.
- Colored italics do not exist in CEA-608 — italics share the slot with the colors — so italics wins for a run that is both.

A mid-row code takes one screen cell (it shows as a space), so it is counted when centering the row; that also fixes the one-cell drift italics has had. A line that no longer fits the row now starts at column 0 instead of falling through the negative indent into column 28.

Also fixed on the reading side: a white mid-row code appended `</font>` twice.

The issue's cue now exports as:

```
00:00:23:08  94ae 94ae 9420 9420 9170 9170 9723 9723 adad 2080 912a 912a 4361 70f4
             e9ef 6e73 2062 7920 d649 54c1 4380 9120 9120 20ad ad80
```

which ffmpeg — the decoder used in the issue's screenshot — reads back as `-- {\c&H00FFFF&} Captions by VITAC{\c&HFFFFFF&} --`, and SubtitleEdit reloads as `-- <font color="Yellow">Captions by VITAC</font> --`.

## Note

A mid-row code is rendered as a space by decoders, so a colored run gets one space of padding on each side. Encoders often avoid that by placing the code over a space that is already there, but SubtitleEdit's reader drops mid-row cells entirely, so doing that here would lose those spaces on re-import. Left as is: the decoder-side change that would allow it is a separate, riskier change to the SCC reader.

## Tests

10 new cases in `ScenaristClosedCaptionsTest`: the issue's caption round-trips, every CEA-608 color and the nearest-color mapping, WebVTT color classes, unknown tags never reaching the letter encoder, `<` staying text, italics winning over color, a color reopening on each row, mid-row cells counted when centering, and a too-long colored line staying on the row. Full libse (1704), seconv (429) and libuilogic (724) suites pass.