### PR TITLE
Prepare v5.2.0-beta28

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -1,5 +1,23 @@
-
+﻿
 Subtitle Edit Changelog
+
+-----------------------------------------------------------------------------------------------------
+
+v5.2.0-beta28 (29th of August 2026)
+
+* Read and write Manzanita DVB teletext files (.dvbttx) - thx René
+* EBU STL video preview: draw the box, the justification, double height rows and an optional custom font
+* Surround with: more slots, and fix the slots getting lost in settings export/import - thx kadrimarzouki
+* SCC: write colors as CEA-608 mid-row codes instead of putting the color tags on screen - thx Jessecar96
+* Video OCR: a better default prompt for two-line subtitles, and "--ocr-prompt" for seconv - thx tekk42
+* Update CrispASR to v0.8.30
+* Fix the subtitle grid not centering on the selected row during prev/next navigation - thx St0rmXtr00per
+* Fix "inverse selection" selecting a single row and jumping to the top of the file
+* Fix the video rewinding after leaving Settings - thx GrampaWildWilly
+* Fix the duration field in frame mode not accepting a value typed without the colon - thx René
+* Blu-ray sup: fix the export of bitmaps over 64 KB
+* Update Italian translation - thx bovirus
+* Update Japanese translation - thx hisui3393
 
 -----------------------------------------------------------------------------------------------------
 

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "Subtitle Edit",
-  "version": "v5.2.0-beta27",
+  "version": "v5.2.0-beta28",
   "translatedBy": "",
   "cultureName": "en-US",
   "general": {

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -20,7 +20,7 @@ public class Se
     internal const int CurrentMacOsFontMigrationVersion = 1;
     internal const int CurrentShortcutsMigrationVersion = 2;
 
-    public static string Version { get; set; } = "v5.2.0-beta27";
+    public static string Version { get; set; } = "v5.2.0-beta28";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
Version bump + change-log section for the next beta.

- `Se.cs`: `v5.2.0-beta27` → `v5.2.0-beta28`
- `English.json`: regenerated (version field only — the new strings were regenerated in their own PRs)
- `change-log.txt`: a `v5.2.0-beta28 (29th of August 2026)` section

The 16 pull requests merged since the `v5.2.0-beta27` tag (each ancestor-checked against it), and where they landed in the section:

| PR | Entry |
| --- | --- |
| #14216 | Blu-ray sup: fix the export of bitmaps over 64 KB |
| #14217 | Update Italian translation - thx bovirus |
| #14219 | Fix the video rewinding after leaving Settings - thx GrampaWildWilly |
| #14223 | Update CrispASR to v0.8.30 |
| #14225 | Video OCR: a better default prompt … and `--ocr-prompt` for seconv - thx tekk42 |
| #14226 | Fix the duration field in frame mode … - thx René |
| #14227 | Read and write Manzanita DVB teletext files (.dvbttx) - thx René |
| #14228, #14229, #14235, #14237 | EBU STL video preview: box, justification, double height rows and optional custom font |
| #14233 | Update Japanese translation - thx hisui3393 |
| #14234 | Surround with: more slots, and fix the slots getting lost in settings export/import - thx kadrimarzouki |
| #14236 | Fix the subtitle grid not centering on the selected row during prev/next navigation - thx St0rmXtr00per |
| #14241 | Fix "inverse selection" selecting a single row and jumping to the top of the file |
| #14242 | SCC: write colors as CEA-608 mid-row codes instead of putting the color tags on screen - thx Jessecar96 |

Reporters credited from the linked issues (#14218 GrampaWildWilly, #14221 tekk42, #14231 St0rmXtr00per, #14232 kadrimarzouki, #14239 Jessecar96) and from the PR bodies for the two René reported by email. Wording is yours to curate.