### PR TITLE
Don't split a subtitle inside a number when re-splitting a translation

### DIFF
--- a/src/libse/Common/TextSplit.cs
+++ b/src/libse/Common/TextSplit.cs
@@ -246,6 +246,45 @@ namespace Nikse.SubtitleEdit.Core.Common
             return text.IndexOf(' ', clamped);
         }
 
+        /// <summary>
+        /// A period between two digits ("04.00 uur", "1.500 euro") is a decimal/time separator, not a
+        /// sentence ending - treating it as one broke a subtitle mid-number (issue #14230).
+        /// </summary>
+        private static bool IsSentenceEndingAt(string text, int index)
+        {
+            return text[index] != '.' ||
+                   index <= 0 ||
+                   index >= text.Length - 1 ||
+                   !char.IsDigit(text[index - 1]) ||
+                   !char.IsDigit(text[index + 1]);
+        }
+
+        private static int LastSentenceEndingIndex(string text)
+        {
+            for (var i = text.Length - 1; i >= 0; i--)
+            {
+                if (Array.IndexOf(PeriodQuestionExclamation, text[i]) >= 0 && IsSentenceEndingAt(text, i))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        private static int FirstSentenceEndingIndex(string text)
+        {
+            for (var i = 0; i < text.Length; i++)
+            {
+                if (Array.IndexOf(PeriodQuestionExclamation, text[i]) >= 0 && IsSentenceEndingAt(text, i))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
         public static Subtitle TryForWholeSentences(Subtitle inputSubtitle, string language, int lineMaxLength)
         {
             var s = new Subtitle(inputSubtitle);
@@ -279,7 +318,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
 
                 // check for period in last part of current
-                var lastPeriodIdx = p.Text.LastIndexOfAny(PeriodQuestionExclamation);
+                var lastPeriodIdx = LastSentenceEndingIndex(p.Text);
                 if (lastPeriodIdx > 3 && lastPeriodIdx > p.Text.Length - maxMoveChunkSize)
                 {
                     var newCurrentText = p.Text.Substring(0, lastPeriodIdx + 1).Trim();
@@ -320,7 +359,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
 
                 // check for period in beginning of next
-                var firstPeriodIdx = next.Text.IndexOfAny(PeriodQuestionExclamation);
+                var firstPeriodIdx = FirstSentenceEndingIndex(next.Text);
                 if (firstPeriodIdx >= 3 && firstPeriodIdx < maxMoveChunkSize)
                 {
                     var newCurrentText = next.Text.Substring(0, firstPeriodIdx + 1).Trim();

--- a/tests/libse/Common/TextSplitNumberPeriodTest.cs
+++ b/tests/libse/Common/TextSplitNumberPeriodTest.cs
@@ -1,0 +1,49 @@
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace LibSETests.Common;
+
+public class TextSplitNumberPeriodTest
+{
+    // Issue #14230: the "make every paragraph end on a whole sentence" pass took the last
+    // '.' in the text as a sentence ending, so a decimal separator or a clock time split the
+    // number in two ("04." + "00 uur").
+    [Fact]
+    public void SplitMultiDoesNotSplitInsideAClockTime()
+    {
+        var parts = TextSplit.SplitMulti(
+            "je dat Zak jou en Carl Wilsher rond 04.00 uur samen terug naar Chislehurst heeft gereden.",
+            2,
+            "nl");
+
+        Assert.Equal(2, parts.Count);
+        Assert.DoesNotContain(parts, p => p.EndsWith("04."));
+        Assert.DoesNotContain(parts, p => p.StartsWith("00 uur"));
+        Assert.Contains("04.00 uur", string.Join(" ", parts));
+    }
+
+    [Fact]
+    public void SplitMultiDoesNotSplitInsideADecimalNumber()
+    {
+        var parts = TextSplit.SplitMulti(
+            "Hij zei dat het huis ongeveer 1.500 euro per maand kost in deze buurt.",
+            2,
+            "nl");
+
+        Assert.Equal(2, parts.Count);
+        Assert.Contains("1.500 euro", string.Join(" ", parts));
+    }
+
+    // The real sentence ending must still move: this is what the pass exists for.
+    [Fact]
+    public void TryForWholeSentencesStillMovesARealSentenceEnding()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("That is all. And then", 0, 3000));
+        subtitle.Paragraphs.Add(new Paragraph("we went home", 3000, 6000));
+
+        var result = TextSplit.TryForWholeSentences(subtitle, "en", 43);
+
+        Assert.Equal("That is all.", result.Paragraphs[0].Text);
+        Assert.Equal("And then we went home", result.Paragraphs[1].Text);
+    }
+}

--- a/tests/libuilogic/Translate/MergeAndSplitHelperTests.cs
+++ b/tests/libuilogic/Translate/MergeAndSplitHelperTests.cs
@@ -67,4 +67,31 @@ public class MergeAndSplitHelperTests
         var rowsWithText = rows.Count(r => !string.IsNullOrEmpty(r.TranslatedText));
         Assert.Equal(count, rowsWithText);
     }
+
+    // Issue #14230: two lines are merged and translated as one sentence, and the reply contains
+    // a clock time written with a period ("04.00 uur") where the English source had a colon
+    // ("4:00am"). The split back over the two rows must not mistake that period for the end of
+    // a sentence and cut the number in half.
+    [Fact]
+    public async Task MergeAndTranslateIfPossible_DoesNotSplitInsideANumber()
+    {
+        var rows = MakeRows("and Carl Wilsher back to Chislehurst", "together at around 4:00am.");
+        var translator = new FixedResultTranslator
+        {
+            Result = "en Carl Wilsher rond 04.00 uur samen terug naar Chislehurst heeft gereden.",
+        };
+
+        var count = await MergeAndSplitHelper.MergeAndTranslateIfPossible(
+            rows,
+            new TranslationPair("English", "en"),
+            new TranslationPair("Dutch", "nl"),
+            0,
+            translator,
+            forceSingleLineMode: false,
+            CancellationToken.None);
+
+        Assert.Equal(2, count);
+        Assert.DoesNotContain("04." + Environment.NewLine, string.Join(Environment.NewLine, rows.Select(r => r.TranslatedText)));
+        Assert.Contains("04.00 uur", rows[0].TranslatedText + " " + rows[1].TranslatedText);
+    }
 }


### PR DESCRIPTION
Fixes #14230

### Problem

After translating, a line containing a clock time or an amount written with a period was cut in half at that period:

| | text |
|---|---|
| 495 | `je dat Zak jou en`<br>`Carl Wilsher rond 04.` |
| 496 | `00 uur samen terug naar`<br>`Chislehurst heeft gereden.` |

The English source was `...back to Chislehurst / together at around 4:00am.` — a colon, so the period only existed in the reply. Not the translation engine's doing: it is SE's re-split of the merged sentence back over the original paragraphs.

### Cause

`TextSplit.TryForWholeSentences` — the pass that makes each paragraph end on a whole sentence — located the boundary with `LastIndexOfAny` / `IndexOfAny` over `.`, `?`, `!`, which has no notion of decimal separators. A `.` between digits within the last 15 characters was moved as if it ended a sentence.

`MergeAndSplitHelper` does normalize `\d\.\d`, but only in split strategy 3. Strategy 2 (`TrySplitByLineCount` → `TextSplit.SplitMulti`) runs first and succeeds, so that guard never gets a chance.

The same pass runs on speech-to-text output (`SpeechToTextPostProcessor`), which had the same failure.

### Fix

Skip a `.` that sits between two digits when locating the boundary, in both the "period at the end of current" and "period at the start of next" branches.

The guard is deliberately narrow (`\d.\d` only, matching the existing `FixPeriodInNumbers` regex) so a quoted ending like `Go."` keeps working. Abbreviations (`Mr. Smith`, `i.e.`) are a separate, language-dependent problem this does not address.

After the change the same input splits as `en Carl Wilsher / rond 04.00 uur samen` + `terug naar Chislehurst heeft gereden.`

### Tests

Three unit tests in `TextSplitNumberPeriodTest` (clock time, decimal amount, plus a guard that a real sentence ending is still moved) and one end-to-end test through `MergeAndSplitHelper.MergeAndTranslateIfPossible` reproducing the reported rows. All four fail on `main` except the guard, and pass with the fix.

libse (1707) and libuilogic (725) suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)