### PR TITLE
EBU STL save options: font picker and a sample for the preview font

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1169,6 +1169,7 @@
       "videoPreview": "Video preview",
       "previewFont": "Custom font",
       "previewFontDefault": "(use the video preview font)",
+      "previewFontSample": "I know the quick brown fox jumps over the lazy dog - 0123456789",
       "errors": "Errors",
       "errorsX": "Errors: {0}",
       "maxLengthError": "Line {0} exceeds max length ({1}) by {2}: {3}",

--- a/src/ui/Features/Files/ExportEbuStl/ExportEbuStlViewModel.cs
+++ b/src/ui/Features/Files/ExportEbuStl/ExportEbuStlViewModel.cs
@@ -1,11 +1,13 @@
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Media;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Features.Files.ExportEbuStl;
+using Nikse.SubtitleEdit.Features.Shared.PickFontName;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
@@ -71,6 +73,8 @@ public partial class ExportEbuStlViewModel : ObservableObject
     [ObservableProperty] private bool _useDoubleHeight;
     [ObservableProperty] private ObservableCollection<string> _previewFonts;
     [ObservableProperty] private string? _selectedPreviewFont;
+    [ObservableProperty] private FontFamily _previewFontFamily;
+    [ObservableProperty] private string _previewFontSample;
     [ObservableProperty] private string _errorTitle;
     [ObservableProperty] private string _errorLog;
 
@@ -94,12 +98,14 @@ public partial class ExportEbuStlViewModel : ObservableObject
     public double FrameRateFromSaveDialog => _header.FrameRateFromSaveDialog;
 
     private IFileHelper _fileHelper;
+    private readonly IWindowService _windowService;
     private Subtitle _subtitle = new Subtitle();
     private Ebu.EbuGeneralSubtitleInformation _header = new Ebu.EbuGeneralSubtitleInformation();
 
-    public ExportEbuStlViewModel(IFileHelper fileHelper)
+    public ExportEbuStlViewModel(IFileHelper fileHelper, IWindowService windowService)
     {
         _fileHelper = fileHelper;
+        _windowService = windowService;
 
         CodePages = new ObservableCollection<CodePageNumberItem>(CodePageNumberItem.GetCodePageNumberItems());
         SelectedCodePage = CodePages[0];
@@ -280,6 +286,8 @@ new("2F", "French - hearing impaired (VF-MAL)"),
         // look like a decoder; the first entry means "leave the video preview font alone".
         PreviewFonts = new ObservableCollection<string>(FontHelper.GetSystemFonts());
         PreviewFonts.Insert(0, Se.Language.File.EbuSaveOptions.PreviewFontDefault);
+        PreviewFontSample = Se.Language.File.EbuSaveOptions.PreviewFontSample;
+        PreviewFontFamily = FontFamily.Default;
 
         RevisionNumbers = new ObservableCollection<int>(Enumerable.Range(0, 100).ToList());
         MaxCharactersPerRow = new ObservableCollection<int>(Enumerable.Range(0, 100).ToList());
@@ -371,6 +379,61 @@ new("2F", "French - hearing impaired (VF-MAL)"),
         });
     }
 
+    /// <summary>
+    /// Keeps the sample label in the font that is picked. The default entry is not a font family,
+    /// so it previews the video preview font - that is what the preview will actually draw with.
+    /// </summary>
+    partial void OnSelectedPreviewFontChanged(string? value)
+    {
+        PreviewFontFamily = FontFamilyHelper.Make(IsDefaultPreviewFont(value)
+            ? Se.Settings.Video.MpvPreviewFontName
+            : value);
+    }
+
+    private bool IsDefaultPreviewFont(string? fontName)
+    {
+        return string.IsNullOrEmpty(fontName) || (PreviewFonts.Count > 0 && fontName == PreviewFonts[0]);
+    }
+
+    /// <summary>
+    /// The font picker from the ASSA styles and the OCR window - it lists the same installed fonts
+    /// as the drop-down, but with a search box and a real preview.
+    /// </summary>
+    [RelayCommand]
+    private async Task PickPreviewFont()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var currentFontName = SelectedPreviewFont;
+        var result = await _windowService.ShowDialogAsync<PickFontNameWindow, PickFontNameViewModel>(Window, vm =>
+        {
+            vm.Initialize();
+            if (!IsDefaultPreviewFont(currentFontName))
+            {
+                vm.SelectedFontName = currentFontName;
+            }
+        });
+
+        if (!result.OkPressed || string.IsNullOrEmpty(result.SelectedFontName))
+        {
+            return;
+        }
+
+        // A font from the "Collected fonts" tab is a file in SE's Fonts folder and need not be
+        // installed, so it need not be in the drop-down - add it rather than dropping the pick.
+        // The preview resolves it through the system font provider like any other name; one that
+        // is not installed falls back, and the sample label shows that before anything is saved.
+        if (!PreviewFonts.Contains(result.SelectedFontName))
+        {
+            PreviewFonts.Insert(1, result.SelectedFontName);
+        }
+
+        SelectedPreviewFont = result.SelectedFontName;
+    }
+
     [RelayCommand]
     private void Ok()
     {
@@ -458,9 +521,7 @@ new("2F", "French - hearing impaired (VF-MAL)"),
         ebuOptions.NewLineRows = SelectedRowsAddByNewLine ?? 1;
         ebuOptions.TeletextUseBox = UseBox;
         ebuOptions.TeletextUseDoubleHeight = UseDoubleHeight;
-        ebuOptions.PreviewFontName = SelectedPreviewFont == null || SelectedPreviewFont == PreviewFonts[0]
-            ? string.Empty
-            : SelectedPreviewFont;
+        ebuOptions.PreviewFontName = IsDefaultPreviewFont(SelectedPreviewFont) ? string.Empty : SelectedPreviewFont!;
         Se.SaveSettings();
 
         if (_subtitle != null)

--- a/src/ui/Features/Files/ExportEbuStl/ExportEbuStlWindow.cs
+++ b/src/ui/Features/Files/ExportEbuStl/ExportEbuStlWindow.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Data;
 using Avalonia.Layout;
 using Nikse.SubtitleEdit.Controls;
@@ -269,6 +270,7 @@ public class ExportEbuStlWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
             {
@@ -315,6 +317,17 @@ public class ExportEbuStlWindow : Window
 
         var labelPreviewFont = UiUtil.MakeLabel(Se.Language.File.EbuSaveOptions.PreviewFont);
         var comboBoxPreviewFont = UiUtil.MakeComboBox(vm.PreviewFonts, vm, nameof(vm.SelectedPreviewFont)).WithMinWidth(textBoxWidth);
+        var buttonPreviewFont = UiUtil.MakeButtonBrowse(vm.PickPreviewFontCommand, null, Se.Language.Tools.PickFontNameTitle);
+        var panelPreviewFont = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 5,
+            Children = { comboBoxPreviewFont, buttonPreviewFont },
+        };
+
+        // The drop-down is a name; this shows what the name looks like, in the font itself.
+        var labelPreviewFontSample = UiUtil.MakeLabel(string.Empty).WithBindText(vm, nameof(vm.PreviewFontSample));
+        labelPreviewFontSample.Bind(TemplatedControl.FontFamilyProperty, new Binding(nameof(vm.PreviewFontFamily)) { Source = vm });
 
 
         grid.Add(labelJustification, 0, 0);
@@ -343,7 +356,9 @@ public class ExportEbuStlWindow : Window
         grid.Add(labelVideoPreview, 11, 0);
 
         grid.Add(labelPreviewFont, 12, 0);
-        grid.Add(comboBoxPreviewFont, 12, 1);
+        grid.Add(panelPreviewFont, 12, 1);
+
+        grid.Add(labelPreviewFontSample, 13, 1);
 
         return UiUtil.MakeBorderForControl(grid).WithMinWidth(944).WithMinHeight(465);
     }

--- a/src/ui/Logic/Config/Language/File/LanguageEbuSaveOptions.cs
+++ b/src/ui/Logic/Config/Language/File/LanguageEbuSaveOptions.cs
@@ -34,6 +34,7 @@ public class LanguageEbuSaveOptions
     public string VideoPreview { get; set; }
     public string PreviewFont { get; set; }
     public string PreviewFontDefault { get; set; }
+    public string PreviewFontSample { get; set; }
     public string Errors { get; set; }
     public string ErrorsX { get; set; }
     public string MaxLengthError { get; set; }
@@ -76,6 +77,7 @@ public class LanguageEbuSaveOptions
         VideoPreview = "Video preview";
         PreviewFont = "Custom font";
         PreviewFontDefault = "(use the video preview font)";
+        PreviewFontSample = "I know the quick brown fox jumps over the lazy dog - 0123456789";
         Errors = "Errors";
         ErrorsX = "Errors: {0}";
         MaxLengthError = "Line {0} exceeds max length ({1}) by {2}: {3}";

--- a/tests/UI/Features/Files/EbuSaveOptionsPersistenceTests.cs
+++ b/tests/UI/Features/Files/EbuSaveOptionsPersistenceTests.cs
@@ -69,7 +69,7 @@ public class EbuSaveOptionsPersistenceTests
 
     private static ExportEbuStlViewModel OpenDialog(Subtitle subtitle)
     {
-        var viewModel = new ExportEbuStlViewModel(new FileHelper());
+        var viewModel = new ExportEbuStlViewModel(new FileHelper(), new StubWindowService());
         viewModel.Initialize(subtitle);
         Dispatcher.UIThread.RunJobs();
         return viewModel;
@@ -302,5 +302,34 @@ public class EbuSaveOptionsPersistenceTests
         var viewModel = OpenDialog(MakeSubtitle());
 
         Assert.Equal(viewModel.PreviewFonts[0], viewModel.SelectedPreviewFont);
+    }
+
+    // The sample label next to the drop-down: the first entry is not a font family, so it has to
+    // show the font the preview will really use rather than a family named "(use the ...)".
+    [AvaloniaFact]
+    public void PreviewFontSample_UsesTheVideoPreviewFontForTheDefaultEntry()
+    {
+        using var scope = new SettingsScope(ScopePaths);
+        using var libSeScope = new LibSeEbuScope();
+        Se.Settings.File.EbuSaveOptions.PreviewFontName = string.Empty;
+
+        var viewModel = OpenDialog(MakeSubtitle());
+
+        Assert.Equal(
+            FontFamilyHelper.Make(Se.Settings.Video.MpvPreviewFontName),
+            viewModel.PreviewFontFamily);
+    }
+
+    [AvaloniaFact]
+    public void PreviewFontSample_FollowsThePickedFont()
+    {
+        using var scope = new SettingsScope(ScopePaths);
+        using var libSeScope = new LibSeEbuScope();
+
+        var viewModel = OpenDialog(MakeSubtitle());
+        var font = viewModel.PreviewFonts.Last();
+        viewModel.SelectedPreviewFont = font;
+
+        Assert.Equal(FontFamilyHelper.Make(font), viewModel.PreviewFontFamily);
     }
 }

--- a/tests/UI/Features/Files/ExportEbuStlHeaderTests.cs
+++ b/tests/UI/Features/Files/ExportEbuStlHeaderTests.cs
@@ -43,7 +43,7 @@ public class ExportEbuStlHeaderTests
     /// </summary>
     private static byte[] SaveViaDialog(Subtitle subtitle, Action<ExportEbuStlViewModel> fillIn)
     {
-        var viewModel = new ExportEbuStlViewModel(new FileHelper());
+        var viewModel = new ExportEbuStlViewModel(new FileHelper(), new StubWindowService());
         viewModel.Initialize(subtitle);
         Dispatcher.UIThread.RunJobs();
 
@@ -213,7 +213,7 @@ public class ExportEbuStlHeaderTests
         };
         subtitle.Paragraphs.Add(new Paragraph("Hello world", 1000, 3000));
 
-        var viewModel = new ExportEbuStlViewModel(new FileHelper());
+        var viewModel = new ExportEbuStlViewModel(new FileHelper(), new StubWindowService());
         viewModel.Initialize(subtitle);
         Dispatcher.UIThread.RunJobs();
 
@@ -223,7 +223,7 @@ public class ExportEbuStlHeaderTests
         Ebu.EbuUiHelper = new UiEbuSaveHelper();
         SaveViaDialog(subtitle, vm => { vm.SelectedFrameRate = "23.976"; });
 
-        var reopened = new ExportEbuStlViewModel(new FileHelper());
+        var reopened = new ExportEbuStlViewModel(new FileHelper(), new StubWindowService());
         reopened.Initialize(subtitle);
         Dispatcher.UIThread.RunJobs();
 

--- a/tests/UI/StubWindowService.cs
+++ b/tests/UI/StubWindowService.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests;
+
+/// <summary>
+/// An <see cref="IWindowService"/> for view models that only open a window from a command the test
+/// never runs - the EBU save options dialog opens the font picker, for instance. Every member
+/// throws, so a test that does take such a path fails loudly instead of silently doing nothing.
+/// </summary>
+public sealed class StubWindowService : IWindowService
+{
+    public T ShowWindow<T>(Window owner, Action<T>? configure = null) where T : Window
+        => throw new NotSupportedException();
+
+    public TViewModel ShowWindow<T, TViewModel>(Window owner, Action<T, TViewModel>? configure = null)
+        where T : Window where TViewModel : class
+        => throw new NotSupportedException();
+
+    public TViewModel ShowIndependentWindow<T, TViewModel>(Action<T, TViewModel>? configure = null)
+        where T : Window where TViewModel : class
+        => throw new NotSupportedException();
+
+    public Task<T> ShowDialogAsync<T>(Window owner, Action<T>? configure = null) where T : Window
+        => throw new NotSupportedException();
+
+    public Task<TViewModel> ShowDialogAsync<TWindow, TViewModel>(
+        Window owner,
+        Action<TViewModel>? configureViewModel = null,
+        Action<TWindow>? configureWindow = null)
+        where TWindow : Window where TViewModel : class
+        => throw new NotSupportedException();
+}


### PR DESCRIPTION
The custom video preview font added in #14237 was a drop-down of family names and nothing else, so picking one meant already knowing what the name looks like.

- The **font picker** SE uses everywhere else (ASSA styles, OCR) is now one click away: search box, installed *and* collected fonts, rendered preview.
- A **sample line** sits under the drop-down, drawn in the font itself.

The sample is honest for the default entry too: `(use the video preview font)` is not a font family, so it previews the *video preview* font — what the preview will actually draw with. A font picked from the "Collected fonts" tab need not be installed, so it is added to the drop-down rather than dropped; an uninstalled name falls back, and the sample shows that before anything is saved.

Nothing here reaches the STL file — an STL carries a character table, not a typeface.

Tests: two new cases in `EbuSaveOptionsPersistenceTests` (sample follows the pick; default entry previews the video preview font). The view model now takes `IWindowService`, so the EBU tests use a new shared `StubWindowService` test double. Layout verified with a headless render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)