### PR TITLE
Snap color shortcuts to the nearest teletext color for EBU STL

### DIFF
--- a/src/libse/SubtitleFormats/Ebu.cs
+++ b/src/libse/SubtitleFormats/Ebu.cs
@@ -823,7 +823,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         color = color.Trim().Trim('#');
                         if (color.Length > 0)
                         {
-                            return GetNearestEbuColorCodeByte(color, encoding);
+                            return GetNearestColorCode(color);
                         }
                     }
                 }
@@ -832,101 +832,6 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
 
 
-            private static byte? GetNearestEbuColorCodeByte(string color, Encoding encoding)
-            {
-                color = color.ToLowerInvariant();
-                if (color == "black" || color == "000000")
-                {
-                    return 0x00; // black
-                }
-
-                if (color == "red" || color == "ff0000")
-                {
-                    return 0x01; // red
-                }
-
-                if (color == "green" || color == "00ff00")
-                {
-                    return 0x02; // green
-                }
-
-                if (color == "yellow" || color == "ffff00")
-                {
-                    return 0x03; // yellow
-                }
-
-                if (color == "blue" || color == "0000ff")
-                {
-                    return 0x04; // blue
-                }
-
-                if (color == "magenta" || color == "ff00ff")
-                {
-                    return 0x05; // magenta
-                }
-
-                if (color == "cyan" || color == "00ffff")
-                {
-                    return 0x06; // cyan
-                }
-
-                if (color == "white" || color == "ffffff")
-                {
-                    return 0x07; // white
-                }
-
-                if (color.Length == 6)
-                {
-                    if (RegExprColor.IsMatch(color))
-                    {
-                        const int maxDiff = 130;
-                        var r = int.Parse(color.Substring(0, 2), NumberStyles.HexNumber);
-                        var g = int.Parse(color.Substring(2, 2), NumberStyles.HexNumber);
-                        var b = int.Parse(color.Substring(4, 2), NumberStyles.HexNumber);
-                        if (r < maxDiff && g < maxDiff && b < maxDiff)
-                        {
-                            return 0x00; // black
-                        }
-
-                        if (r > 255 - maxDiff && g < maxDiff && b < maxDiff)
-                        {
-                            return 0x01; // red
-                        }
-
-                        if (r < maxDiff && g > 255 - maxDiff && b < maxDiff)
-                        {
-                            return 0x02; // green
-                        }
-
-                        if (r > 255 - maxDiff && g > 255 - maxDiff && b < maxDiff)
-                        {
-                            return 0x03; // yellow
-                        }
-
-                        if (r < maxDiff && g < maxDiff && b > 255 - maxDiff)
-                        {
-                            return 0x04; // blue
-                        }
-
-                        if (r > 255 - maxDiff && g < maxDiff && b > 255 - maxDiff)
-                        {
-                            return 0x05; // magenta
-                        }
-
-                        if (r < maxDiff && g > 255 - maxDiff && b > 255 - maxDiff)
-                        {
-                            return 0x06; // cyan
-                        }
-
-                        if (r > 255 - maxDiff && g > 255 - maxDiff && b > 255 - maxDiff)
-                        {
-                            return 0x07; // white
-                        }
-                    }
-                }
-
-                return null;
-            }
 
 
             private static byte[] ReplaceSpecialCharactersWithTwoByteEncoding(Encoding encoding, char ch, byte specialCharacter, string originalCharacters, string newCharacters)
@@ -2142,33 +2047,152 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
         }
 
-        private static string GetColorOrTag(byte b)
+        /// <summary>
+        /// The teletext colour code an STL file would carry for <paramref name="color"/> - a colour
+        /// name ("Red") or six hex digits, with or without a leading '#' - or null when the value is
+        /// not a colour at all. The eight teletext colours are the corners of the RGB cube, so
+        /// anything else is snapped to the nearest one; Save writes what this returns, and the UI
+        /// asks it what a colour will become before it writes a tag (via GetNearestColorName).
+        /// </summary>
+        internal static byte? GetNearestColorCode(string color)
+        {
+            color = color.Trim().TrimStart('#').ToLowerInvariant();
+            if (color == "black" || color == "000000")
+            {
+                return 0x00; // black
+            }
+
+            if (color == "red" || color == "ff0000")
+            {
+                return 0x01; // red
+            }
+
+            if (color == "green" || color == "00ff00")
+            {
+                return 0x02; // green
+            }
+
+            if (color == "yellow" || color == "ffff00")
+            {
+                return 0x03; // yellow
+            }
+
+            if (color == "blue" || color == "0000ff")
+            {
+                return 0x04; // blue
+            }
+
+            if (color == "magenta" || color == "ff00ff")
+            {
+                return 0x05; // magenta
+            }
+
+            if (color == "cyan" || color == "00ffff")
+            {
+                return 0x06; // cyan
+            }
+
+            if (color == "white" || color == "ffffff")
+            {
+                return 0x07; // white
+            }
+
+            if (color.Length == 6)
+            {
+                if (RegExprColor.IsMatch(color))
+                {
+                    const int maxDiff = 130;
+                    var r = int.Parse(color.Substring(0, 2), NumberStyles.HexNumber);
+                    var g = int.Parse(color.Substring(2, 2), NumberStyles.HexNumber);
+                    var b = int.Parse(color.Substring(4, 2), NumberStyles.HexNumber);
+                    if (r < maxDiff && g < maxDiff && b < maxDiff)
+                    {
+                        return 0x00; // black
+                    }
+
+                    if (r > 255 - maxDiff && g < maxDiff && b < maxDiff)
+                    {
+                        return 0x01; // red
+                    }
+
+                    if (r < maxDiff && g > 255 - maxDiff && b < maxDiff)
+                    {
+                        return 0x02; // green
+                    }
+
+                    if (r > 255 - maxDiff && g > 255 - maxDiff && b < maxDiff)
+                    {
+                        return 0x03; // yellow
+                    }
+
+                    if (r < maxDiff && g < maxDiff && b > 255 - maxDiff)
+                    {
+                        return 0x04; // blue
+                    }
+
+                    if (r > 255 - maxDiff && g < maxDiff && b > 255 - maxDiff)
+                    {
+                        return 0x05; // magenta
+                    }
+
+                    if (r < maxDiff && g > 255 - maxDiff && b > 255 - maxDiff)
+                    {
+                        return 0x06; // cyan
+                    }
+
+                    if (r > 255 - maxDiff && g > 255 - maxDiff && b > 255 - maxDiff)
+                    {
+                        return 0x07; // white
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// The name of the teletext colour <paramref name="color"/> is nearest to - the same name
+        /// the STL reader writes into the text - or null when it is not a colour at all.
+        /// </summary>
+        public static string GetNearestColorName(string color)
+        {
+            var code = GetNearestColorCode(color);
+            return code == null ? null : GetColorName(code.Value);
+        }
+
+        private static string GetColorName(byte b)
         {
             switch (b)
             {
                 case 0x00:
-                    return "<font color=\"Black\">";
+                    return "Black";
                 case 0x01:
-                    return "<font color=\"Red\">";
+                    return "Red";
                 case 0x02:
-                    return "<font color=\"Green\">";
+                    return "Green";
                 case 0x03:
-                    return "<font color=\"Yellow\">";
+                    return "Yellow";
                 case 0x04:
-                    return "<font color=\"Blue\">";
+                    return "Blue";
                 case 0x05:
-                    return "<font color=\"Magenta\">";
+                    return "Magenta";
                 case 0x06:
-                    return "<font color=\"Cyan\">";
+                    return "Cyan";
                 case 0x07:
-                    return "<font color=\"White\">";
-                    //case 0x0a:
-                    //    return "</box>";
-                    //case 0x0b:
-                    //    return "<box>";
+                    return "White";
             }
 
             return null;
+        }
+
+        private static string GetColorOrTag(byte b)
+        {
+            //case 0x0a:
+            //    return "</box>";
+            //case 0x0b:
+            //    return "<box>";
+            var name = GetColorName(b);
+            return name == null ? null : "<font color=\"" + name + "\">";
         }
 
         private static string FixSpacesAndTags(string text)

--- a/src/ui/Logic/ColorService.cs
+++ b/src/ui/Logic/ColorService.cs
@@ -152,6 +152,17 @@ public class ColorService : IColorService
             return text;
         }
 
+        // An STL file carries eight teletext colours, and Ebu.Save snaps whatever it finds to the
+        // nearest of them - so a shortcut colour like orange was shown orange in the grid and in
+        // the video preview and came out yellow in the file. Snap when the tag is written instead:
+        // grid, preview and file then agree. Written as the colour name the STL reader itself
+        // produces, so the shortcut also toggles off a colour that came from a file.
+        var colorText = ToHex(color);
+        if (subtitleFormat is Ebu)
+        {
+            colorText = Ebu.GetNearestColorName(colorText) ?? colorText;
+        }
+
         string pre = string.Empty;
         if (text.StartsWith("{\\", StringComparison.Ordinal) && text.IndexOf('}') >= 0)
         {
@@ -171,7 +182,7 @@ public class ColorService : IColorService
                 if (f.Contains(" face=", StringComparison.OrdinalIgnoreCase) && !f.Contains(" color=", StringComparison.OrdinalIgnoreCase))
                 {
                     var start = s.IndexOf(" face=", StringComparison.OrdinalIgnoreCase);
-                    s = s.Insert(start, string.Format(" color=\"{0}\"", ToHex(color)));
+                    s = s.Insert(start, string.Format(" color=\"{0}\"", colorText));
                     text = pre + s;
                     return text;
                 }
@@ -184,7 +195,7 @@ public class ColorService : IColorService
                     if (quoteEnd > 0)
                     {
                         // Quoted value: the closing quote comes from the tail we keep.
-                        s = s.Substring(0, colorStart) + string.Format(" color=\"{0}", ToHex(color)) + s.Substring(quoteEnd);
+                        s = s.Substring(0, colorStart) + string.Format(" color=\"{0}", colorText) + s.Substring(quoteEnd);
                     }
                     else
                     {
@@ -198,7 +209,7 @@ public class ColorService : IColorService
                             valueEnd++;
                         }
 
-                        s = s.Substring(0, colorStart) + string.Format(" color=\"{0}\"", ToHex(color)) + s.Substring(valueEnd);
+                        s = s.Substring(0, colorStart) + string.Format(" color=\"{0}\"", colorText) + s.Substring(valueEnd);
                     }
 
                     text = pre + s;
@@ -207,7 +218,7 @@ public class ColorService : IColorService
             }
         }
 
-        return $"{pre}<font color=\"{ToHex(color)}\">{text}</font>";
+        return $"{pre}<font color=\"{colorText}\">{text}</font>";
     }
 
     public string RemoveColorTag(string input, Color color, Subtitle subtitle, SubtitleFormat subtitleFormat)

--- a/tests/UI/Logic/ColorServiceTests.cs
+++ b/tests/UI/Logic/ColorServiceTests.cs
@@ -211,6 +211,35 @@ public class ColorServiceTests
         Assert.Equal("Hello", lines[0].Text);
     }
 
+    // An STL file carries eight teletext colors and Ebu.Save snaps to the nearest one, so a
+    // shortcut color the file cannot hold used to be shown in the grid and the video preview and
+    // then come out as another color in the file. The tag is snapped when it is written now.
+    [Fact]
+    public void SetColorTag_Ebu_SnapsToTheNearestTeletextColor()
+    {
+        var service = new ColorService();
+        var subtitle = new Subtitle();
+        var format = new Ebu();
+
+        var orange = Color.FromRgb(0xFF, 0xA5, 0x00);
+
+        Assert.Equal("<font color=\"Yellow\">Hello</font>", service.SetColorTag("Hello", orange, subtitle, format));
+        Assert.Equal("<font color=\"Red\">Hello</font>", service.SetColorTag("Hello", Red, subtitle, format));
+    }
+
+    // The name is the one Ebu's reader writes, so the shortcut toggles off a color that came
+    // from a file - it used to compare "#FF0000" against the file's "Red" and never match.
+    [Fact]
+    public void ContainsColor_Ebu_MatchesTheColorNameFromAFile()
+    {
+        var service = new ColorService();
+        var format = new Ebu();
+
+        Assert.True(service.ContainsColor(Red, "<font color=\"Red\">Hello</font>", format));
+        Assert.True(service.ContainsColor(Color.FromRgb(0xFF, 0xA5, 0x00), "<font color=\"Yellow\">Hello</font>", format));
+        Assert.False(service.ContainsColor(Blue, "<font color=\"Red\">Hello</font>", format));
+    }
+
     [Fact]
     public void ContainsColor_WebVtt_DetectsAppliedColor()
     {

--- a/tests/libse/SubtitleFormats/EbuTest.cs
+++ b/tests/libse/SubtitleFormats/EbuTest.cs
@@ -240,4 +240,29 @@ public class EbuTest
         Array.Copy(bytes, 1024 + 16, textField, 0, 112);
         Assert.Contains((byte)0x03, textField);
     }
+
+    // An STL file carries eight teletext colors, so the writer snaps anything else to the nearest
+    // one. The UI asks the same question before it writes a color tag, so what the grid and the
+    // video preview show is what the file will get - these are the answers it relies on.
+    [Theory]
+    [InlineData("#FF0000", "Red")]
+    [InlineData("ff0000", "Red")]
+    [InlineData("Red", "Red")]
+    [InlineData("#FFA500", "Yellow")]  // orange
+    [InlineData("#FFC0CB", "White")]   // pink
+    [InlineData("#003300", "Black")]   // very dark green
+    [InlineData("#00FFFF", "Cyan")]
+    public void GetNearestColorName_SnapsToTheEightTeletextColors(string color, string expected)
+    {
+        Assert.Equal(expected, Ebu.GetNearestColorName(color));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not a color")]
+    [InlineData("#12345")]
+    public void GetNearestColorName_IsNullWhenTheValueIsNotAColor(string color)
+    {
+        Assert.Null(Ebu.GetNearestColorName(color));
+    }
 }


### PR DESCRIPTION
An STL file carries eight colors, and `Ebu.Save` already snaps whatever it finds to the nearest of them. The color shortcuts did not know that: **Color 7** (orange by default) wrote `<font color="#FFA500">`, so the grid and the video preview showed orange while the file came out yellow — and a color the writer could not place at all was dropped without a word.

**What changed**

- The tag is snapped where it is written (`ColorService.SetColorTag`, EBU branch), so grid, preview and file agree.
- It is written as the color *name* — `<font color="Red">`, the same name `Ebu`'s reader puts in the text when an STL is loaded. So the shortcut now also toggles *off* a color that came from a file; comparing `#FF0000` against the file's `Red` never matched.
- The teletext color picker (the `Color...` command on an EBU file) goes through the same place and gains both.

**The mapping is unchanged** — nearest corner of the RGB cube, as `Ebu.Save` has always done (orange → yellow, pink → white, a dark red → black). It is just no longer duplicated: the writer's lookup moves up to `Ebu.GetNearestColorCode` / `GetNearestColorName`, and the reader's tag builder now uses the same table, so the two cannot drift apart.

**Note:** with display standard `0` (open subtitling) no color code is written to the file at all, per spec. The tag is still snapped there — the eight colors are what STL can express, and the display standard is a save option the user may still change.

Tests: `Ebu.GetNearestColorName` (names, hex, no-color input) in `EbuTest`; snapping and file-color toggling in `ColorServiceTests`. Full libse (1717) and libuilogic (725) suites green; the two failing UI tests are the flaky `LibMpvEventLoopTests` seek/pause timing cases, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)