### PR TITLE
Read the whole Manzanita preamble, not the first 200 KB

### DIFF
--- a/src/libse/ContainerFormats/TransportStream/ManzanitaTransportStreamParser.cs
+++ b/src/libse/ContainerFormats/TransportStream/ManzanitaTransportStreamParser.cs
@@ -24,6 +24,16 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
         // dump holds a single elementary stream, so any fixed id will do.
         private const int TeletextPacketId = 1;
 
+        // "</private_stream_1>" - the XML preamble ends here and the binary payloads follow.
+        private static readonly byte[] EndTag = Encoding.ASCII.GetBytes("</private_stream_1>");
+
+        // How much of the preamble is read at a time; it is read in full however long it is.
+        private const int PreambleChunkSize = 200_000;
+
+        // Backstop for a file that has no end tag at all, so it is not read into memory whole.
+        // No real preamble comes near this: 64 MB is over half a million packet lines.
+        private const int MaxPreambleSize = 64 * 1024 * 1024;
+
         private readonly List<DvbSubPes> _dvbSubs;
         private readonly List<DvbSubPes> _teletextPes;
 
@@ -128,19 +138,15 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
             startIndex = 0;
             streamType = string.Empty;
             ms.Position = 0;
-            var buffer = new byte[200_000];
-            var bytesRead = ms.Read(buffer, 0, buffer.Length);
-            var xml = Encoding.UTF8.GetString(buffer, 0, bytesRead);
-            const string endTag = "</private_stream_1>";
-            var endIndex = xml.IndexOf(endTag, StringComparison.Ordinal);
+            var buffer = ReadPreamble(ms, out var bytesRead, out var endIndex);
             if (endIndex < 0)
             {
                 return new List<ManzanitaDataIndex>();
             }
 
-            startIndex = FindBinaryStartIndex(bytesRead, buffer, endTag);
+            startIndex = GetBinaryStartIndex(buffer, bytesRead, endIndex);
 
-            xml = xml.Substring(0, endIndex + endTag.Length);
+            var xml = Encoding.UTF8.GetString(buffer, 0, endIndex + EndTag.Length);
             var xmlDoc = new XmlDocument { XmlResolver = null };
             xmlDoc.LoadXml(xml);
             const string ns = "http://www.manzanitasystems.com/schema/v1.03/private_stream_1";
@@ -193,38 +199,96 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
             return result;
         }
 
-        private static int FindBinaryStartIndex(int bytesRead, byte[] buffer, string endTag)
+        /// <summary>
+        /// The binary section starts right after the end tag and the line feed that closes its
+        /// line (<c>&lt;/private_stream_1&gt;</c> + 0x0a). Zero when that line feed is not there:
+        /// the offsets in the data index are counted from it, so there is nothing to slice.
+        /// </summary>
+        private static int GetBinaryStartIndex(byte[] buffer, int bytesRead, int endTagIndex)
         {
-            for (var i = 0; i < bytesRead - 20; i++)
+            var afterEndTag = endTagIndex + EndTag.Length;
+            return afterEndTag < bytesRead && buffer[afterEndTag] == 0x0a ? afterEndTag + 1 : 0;
+        }
+
+        /// <summary>
+        /// Reads the file up to and including the XML preamble, growing the buffer until the end
+        /// tag turns up.
+        /// </summary>
+        /// <remarks>
+        /// The preamble carries one <c>&lt;packet ... /&gt;</c> line per teletext or DVB packet,
+        /// so it grows with the file - a .dvbttx written from some 1650 subtitles already needs
+        /// more than the 200 KB that used to be read in one go. A preamble that did not fit was
+        /// reported as "no packets at all" and the file then opened as nothing, with no error.
+        /// </remarks>
+        /// <param name="bytesRead">Bytes actually in the returned buffer.</param>
+        /// <param name="endTagIndex">Index of the end tag, or -1 when there is none.</param>
+        private static byte[] ReadPreamble(Stream ms, out int bytesRead, out int endTagIndex)
+        {
+            var buffer = new byte[PreambleChunkSize];
+            bytesRead = 0;
+            endTagIndex = -1;
+
+            while (true)
             {
-                // </private_stream_1> + 0x0a
-                // 3C 2F 70 72 69 76 61 74 65 5F 73 74 72 65 61 6D 5F 31 3E 0A
-                if (buffer[i + 0] == 0x3c &&
-                    buffer[i + 1] == 0x2f &&
-                    buffer[i + 2] == 0x70 &&
-                    buffer[i + 3] == 0x72 &&
-                    buffer[i + 4] == 0x69 &&
-                    buffer[i + 5] == 0x76 &&
-                    buffer[i + 6] == 0x61 &&
-                    buffer[i + 7] == 0x74 &&
-                    buffer[i + 8] == 0x65 &&
-                    buffer[i + 9] == 0x5f &&
-                    buffer[i + 10] == 0x73 &&
-                    buffer[i + 11] == 0x74 &&
-                    buffer[i + 12] == 0x72 &&
-                    buffer[i + 13] == 0x65 &&
-                    buffer[i + 14] == 0x61 &&
-                    buffer[i + 15] == 0x6d &&
-                    buffer[i + 16] == 0x5f &&
-                    buffer[i + 17] == 0x31 &&
-                    buffer[i + 18] == 0x3e &&
-                    buffer[i + 19] == 0x0a)
+                if (bytesRead == buffer.Length)
                 {
-                    return i + endTag.Length + 1;
+                    if (buffer.Length >= MaxPreambleSize)
+                    {
+                        return buffer; // not a Manzanita file - give up rather than read it all
+                    }
+
+                    Array.Resize(ref buffer, Math.Min(MaxPreambleSize, buffer.Length * 2));
+                }
+
+                var read = ms.Read(buffer, bytesRead, buffer.Length - bytesRead);
+                if (read <= 0)
+                {
+                    return buffer; // end of file
+                }
+
+                if (endTagIndex < 0)
+                {
+                    // Only the new bytes need looking at, less the overlap an end tag split
+                    // across two reads would sit in.
+                    var searchFrom = Math.Max(0, bytesRead - (EndTag.Length - 1));
+                    bytesRead += read;
+                    endTagIndex = IndexOfEndTag(buffer, bytesRead, searchFrom);
+                }
+                else
+                {
+                    bytesRead += read;
+                }
+
+                // One byte past the end tag as well: that is the line feed GetBinaryStartIndex
+                // needs, and a read can stop right on the tag.
+                if (endTagIndex >= 0 && bytesRead > endTagIndex + EndTag.Length)
+                {
+                    return buffer;
+                }
+            }
+        }
+
+        private static int IndexOfEndTag(byte[] buffer, int bytesRead, int startAt)
+        {
+            for (var i = startAt; i <= bytesRead - EndTag.Length; i++)
+            {
+                var match = true;
+                for (var j = 0; j < EndTag.Length; j++)
+                {
+                    if (buffer[i + j] != EndTag[j])
+                    {
+                        match = false;
+                        break;
+                    }
+                }
+
+                if (match)
+                {
+                    return i;
                 }
             }
 
-            return 0;
+            return -1;
         }
 
         /// <summary>

--- a/tests/libse/ContainerFormats/ManzanitaTeletextTest.cs
+++ b/tests/libse/ContainerFormats/ManzanitaTeletextTest.cs
@@ -131,4 +131,35 @@ public class ManzanitaTeletextTest
 
         Assert.Empty(pages);
     }
+
+    [Fact]
+    public void AFeatureLengthFileIsReadBackWhole()
+    {
+        // The XML preamble holds one <packet /> line per teletext packet - two per subtitle here,
+        // one to show it and one to erase it - so it grows past the 200 KB the reader used to
+        // look at somewhere around 1650 subtitles. Everything beyond that read back as an empty
+        // file, with no error: the end tag was never found, so the packet index came out empty.
+        var subtitle = new Subtitle();
+        for (var i = 0; i < 2000; i++)
+        {
+            subtitle.Paragraphs.Add(new Paragraph("Line " + i, i * 3000, i * 3000 + 2000));
+        }
+
+        var paragraphs = WriteAndRead(subtitle)[888];
+
+        Assert.Equal(2000, paragraphs.Count);
+        Assert.Equal("Line 0", paragraphs[0].Text);
+        Assert.Equal("Line 1999", paragraphs[1999].Text);
+    }
+
+    [Fact]
+    public void AFileWithNoEndTagIsNotRead()
+    {
+        var parser = new ManzanitaTransportStreamParser();
+        using var ms = new MemoryStream(new byte[500_000]);
+
+        parser.Parse(ms);
+
+        Assert.Empty(parser.GetTeletext());
+    }
 }


### PR DESCRIPTION
A `.dvbttx` file starts with an XML preamble holding one `<packet />` line per teletext packet, followed by the payloads that index points into. The reader looked for the closing `</private_stream_1>` in one fixed 200 KB read and gave up when it was not there — so a preamble larger than that came back as "no packets at all" and the file opened as nothing, with no error.

Nothing wrote such files until Subtitle Edit gained the writer in #14227, and the writer reaches the limit easily: two packets per subtitle, ~62 bytes of index each. Measured over write-then-read:

| subtitles | read back |
|---|---|
| 1650 | 1650 |
| 1675 | **0** |
| 2000 | **0** (file 795 KB) |

So *File → Export → DVB teletext (Manzanita)* on a normal feature film produced a file Subtitle Edit itself could not open again.

## The fix

- The preamble is read in chunks until the end tag turns up, however long it is, with a 64 MB backstop so a file that has no end tag at all — i.e. not a Manzanita file — is not pulled into memory whole. Only the newly read bytes are scanned each round, plus the 18-byte overlap an end tag split across two reads would sit in. The old single `Read` could also come up short on a stream that returns less than asked; that is gone too.
- The XML is sliced by byte offset instead of decoding the whole buffer — binary payload included — and slicing by character index. The two agree only as long as the preamble is pure ASCII.
- `FindBinaryStartIndex` searched for the end tag a second time, byte by hand-unrolled byte, to find the line feed after it. That is now a single check at the index already known (`GetBinaryStartIndex`), and the search itself is one `IndexOfEndTag` against one byte array.

## Tests

Two new cases in `ManzanitaTeletextTest`:

- `AFeatureLengthFileIsReadBackWhole` — 2000 subtitles written and read back, first and last text intact. Returns 0 without the fix.
- `AFileWithNoEndTagIsNotRead` — 500 KB of zeros still parses to nothing rather than looping or throwing.

Full `libse` suite passes (1719 tests); solution builds clean.

Found while bug-hunting the last day of commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
