### PR TITLE
Repaint the waveform when its paragraphs change, and close two rewind holes (#14218)

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -383,6 +383,12 @@ public class AudioVisualizer : Control
     private static readonly Cursor _cursorSizeWestEast = new Cursor(StandardCursorType.SizeWestEast);
 
     private readonly List<SubtitleLineViewModel> _displayableParagraphs = new();
+
+    // The paragraph sets as they stood before the current LoadParagraphs, so it can tell whether
+    // anything it draws actually changed. Reused across calls, so the check allocates nothing.
+    private readonly List<SubtitleLineViewModel> _previousDisplayableParagraphs = new();
+    private readonly List<SubtitleLineViewModel> _previousSelectedParagraphs = new();
+
     private readonly IsSelectedHelper _isSelectedHelper = new();
     private bool _isCtrlDown;
     private bool _isMetaDown;
@@ -3851,81 +3857,140 @@ public class AudioVisualizer : Control
         LoadParagraphs(subtitle, subtitleIndex, selectedIndexes);
     }
 
+    /// <summary>
+    /// Rebuilds the paragraph sets this control draws, and repaints when they actually changed.
+    /// <para>
+    /// The repaint is not optional bookkeeping: nothing else notices. The lists are plain fields
+    /// (mutated in place - <see cref="AllSelectedParagraphs"/> is an AffectsRender property, but
+    /// only its identity is, not its contents), and while the video is paused no AffectsRender
+    /// property moves at all, so the last drawn frame just stays on screen. Options/OK is enough
+    /// to leave a wrong one there: the rebuilt video player reports 0 for a moment, "center on
+    /// video position" scrolls the waveform to the start on the 16 ms cursor timer, this reload
+    /// (on the 50 ms timer, at the lower DispatcherTimer priority, competing with the rebuild)
+    /// empties the list, and the frame drawn when the player lands back on the real position
+    /// shows the right time range with no paragraphs in it. Reloading the list a tick later
+    /// fixed the state but not the picture, which stayed blank until playback resumed and moved
+    /// an AffectsRender property again (issue #14218).
+    /// </para>
+    /// </summary>
     private void LoadParagraphs(IReadOnlyList<SubtitleLineViewModel> subtitle, int primarySelectedIndex, List<SubtitleLineViewModel> selectedIndexes)
     {
+        bool changed;
         lock (_lock)
         {
-            _displayableParagraphs.Clear();
-            SelectedParagraph = null;
-            AllSelectedParagraphs.Clear();
+            _previousDisplayableParagraphs.Clear();
+            _previousDisplayableParagraphs.AddRange(_displayableParagraphs);
+            _previousSelectedParagraphs.Clear();
+            _previousSelectedParagraphs.AddRange(AllSelectedParagraphs);
 
-            if (WavePeaks == null || subtitle.Count == 0)
+            LoadParagraphsInLock(subtitle, primarySelectedIndex, selectedIndexes);
+
+            changed = !SameParagraphs(_previousDisplayableParagraphs, _displayableParagraphs) ||
+                      !SameParagraphs(_previousSelectedParagraphs, AllSelectedParagraphs);
+        }
+
+        if (changed)
+        {
+            InvalidateVisual();
+        }
+    }
+
+    /// <summary>
+    /// Reference comparison, not value comparison: the rows are stable view models, so a change
+    /// of membership or order is what this has to catch. Edits to a row that stays in the set
+    /// (a drag, a text change) repaint through their own paths.
+    /// </summary>
+    private static bool SameParagraphs(List<SubtitleLineViewModel> a, List<SubtitleLineViewModel> b)
+    {
+        if (a.Count != b.Count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < a.Count; i++)
+        {
+            if (!ReferenceEquals(a[i], b[i]))
             {
-                return;
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>Body of <see cref="LoadParagraphs"/>; call it holding <c>_lock</c>.</summary>
+    private void LoadParagraphsInLock(IReadOnlyList<SubtitleLineViewModel> subtitle, int primarySelectedIndex, List<SubtitleLineViewModel> selectedIndexes)
+    {
+        _displayableParagraphs.Clear();
+        SelectedParagraph = null;
+        AllSelectedParagraphs.Clear();
+
+        if (WavePeaks == null || subtitle.Count == 0)
+        {
+            return;
+        }
+
+        const double additionalSeconds = 15.0;
+        var startThreshold = (StartPositionSeconds - additionalSeconds) * TimeCode.BaseUnit;
+        var endThreshold = (EndPositionSeconds + additionalSeconds) * TimeCode.BaseUnit;
+        var maxTime = TimeCode.MaxTimeTotalMilliseconds;
+
+        // 1. Use Binary Search to find the first potential subtitle in the time range O(log N)
+        var startIndex = FindFirstIndexAfterTime(subtitle, startThreshold);
+
+        var lastStartTime = -1d;
+        var count = 0;
+
+        // 2. Linear scan only the relevant window
+        for (var i = startIndex; i < subtitle.Count; i++)
+        {
+            var p = subtitle[i];
+            var pStart = p.StartTime.TotalMilliseconds;
+
+            // Since it's sorted, if we exceed the end threshold or max time, we can stop entirely
+            if (pStart > endThreshold || pStart >= maxTime)
+            {
+                break;
             }
 
-            const double additionalSeconds = 15.0;
-            var startThreshold = (StartPositionSeconds - additionalSeconds) * TimeCode.BaseUnit;
-            var endThreshold = (EndPositionSeconds + additionalSeconds) * TimeCode.BaseUnit;
-            var maxTime = TimeCode.MaxTimeTotalMilliseconds;
-
-            // 1. Use Binary Search to find the first potential subtitle in the time range O(log N)
-            var startIndex = FindFirstIndexAfterTime(subtitle, startThreshold);
-
-            var lastStartTime = -1d;
-            var count = 0;
-
-            // 2. Linear scan only the relevant window
-            for (var i = startIndex; i < subtitle.Count; i++)
+            // Skip subtitles that end before our window starts
+            if (p.EndTime.TotalMilliseconds < startThreshold)
             {
-                var p = subtitle[i];
-                var pStart = p.StartTime.TotalMilliseconds;
-
-                // Since it's sorted, if we exceed the end threshold or max time, we can stop entirely
-                if (pStart > endThreshold || pStart >= maxTime)
-                {
-                    break;
-                }
-
-                // Skip subtitles that end before our window starts
-                if (p.EndTime.TotalMilliseconds < startThreshold)
-                {
-                    continue;
-                }
-
-                // 3. Apply filtering logic immediately to avoid second loop
-                var isTooShortOrDense = count > 200 && (p.Duration.TotalMilliseconds < 0.01 || pStart - lastStartTime < 90);
-
-                if (!isTooShortOrDense)
-                {
-                    _displayableParagraphs.Add(p);
-                    lastStartTime = pStart;
-                    count++;
-                }
-
-                if (count >= 250)
-                {
-                    break;
-                }
+                continue;
             }
 
-            // 4. Optimized Selection Handling
-            var primaryParagraph = (primarySelectedIndex >= 0 && primarySelectedIndex < subtitle.Count)
-                ? subtitle[primarySelectedIndex]
-                : null;
+            // 3. Apply filtering logic immediately to avoid second loop
+            var isTooShortOrDense = count > 200 && (p.Duration.TotalMilliseconds < 0.01 || pStart - lastStartTime < 90);
 
-            if (primaryParagraph != null && !primaryParagraph.StartTime.IsMaxTime())
+            if (!isTooShortOrDense)
             {
-                SelectedParagraph = primaryParagraph;
-                AllSelectedParagraphs.Add(primaryParagraph);
+                _displayableParagraphs.Add(p);
+                lastStartTime = pStart;
+                count++;
             }
 
-            foreach (var p in selectedIndexes)
+            if (count >= 250)
             {
-                if (p != null && !p.StartTime.IsMaxTime() && p != primaryParagraph)
-                {
-                    AllSelectedParagraphs.Add(p);
-                }
+                break;
+            }
+        }
+
+        // 4. Optimized Selection Handling
+        var primaryParagraph = (primarySelectedIndex >= 0 && primarySelectedIndex < subtitle.Count)
+            ? subtitle[primarySelectedIndex]
+            : null;
+
+        if (primaryParagraph != null && !primaryParagraph.StartTime.IsMaxTime())
+        {
+            SelectedParagraph = primaryParagraph;
+            AllSelectedParagraphs.Add(primaryParagraph);
+        }
+
+        foreach (var p in selectedIndexes)
+        {
+            if (p != null && !p.StartTime.IsMaxTime() && p != primaryParagraph)
+            {
+                AllSelectedParagraphs.Add(p);
             }
         }
     }

--- a/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
+++ b/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
@@ -196,6 +196,10 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
         // Where an in-flight open+restore sequence is heading. See PositionForRestore.
         private double? _pendingRestorePositionSeconds;
 
+        // How close the player has to be to the restore target to count as arrived. Same value
+        // for the arrival check in the position tick and for EndPositionRestoreIfArrived.
+        private const double PositionRestoreArrivedToleranceSeconds = 0.5;
+
         /// <summary>
         /// The position another player should be handed when this control is thrown away and
         /// rebuilt (layout rebuild, dock/undock, fullscreen) - the pending restore target while
@@ -218,9 +222,9 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
         /// started, so <see cref="PositionForRestore"/> reports that target instead of the 0 the
         /// not-yet-loaded player reports. <see cref="Open"/> calls this itself when given a start
         /// position; callers that seek only after the open (the layout rebuild) call it first.
-        /// The pending value is dropped by <see cref="EndPositionRestore"/> and, as a safety net
-        /// for restores that are abandoned without one, as soon as the player actually reports
-        /// the restored position.
+        /// The pending value is dropped by <see cref="EndPositionRestore"/> /
+        /// <see cref="EndPositionRestoreIfArrived"/> and, as a safety net for restores that are
+        /// abandoned without one, as soon as the player actually reports the restored position.
         /// </summary>
         internal void BeginPositionRestore(double seconds)
         {
@@ -237,6 +241,33 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
         internal void EndPositionRestore()
         {
             _pendingRestorePositionSeconds = null;
+        }
+
+        /// <summary>
+        /// Ends the restore announced by <see cref="BeginPositionRestore"/> only if the player
+        /// has actually arrived there. A restore sequence runs a fixed number of seeks after a
+        /// bounded ready wait, so it can run out while mpv is still loading (a big file, a busy
+        /// machine) - and ending the restore there hands <see cref="PositionForRestore"/> back to
+        /// a player that is still reporting 0, which is exactly the rewind
+        /// <see cref="BeginPositionRestore"/> exists to prevent (issue #14218). Keeping the target
+        /// in that case costs nothing: the position tick drops it the moment the player does
+        /// land, and until then the target is a far better answer for a rebuild than the 0 of a
+        /// player that never got where it was told to go.
+        /// </summary>
+        internal void EndPositionRestoreIfArrived()
+        {
+            // A torn-down player throws rather than reporting a position, and it has nothing left
+            // to say about where the video is anyway - leave the target alone (issue #13083).
+            if (IsDisposed)
+            {
+                return;
+            }
+
+            if (_pendingRestorePositionSeconds is { } pending &&
+                Math.Abs(_videoPlayerInstance.Position - pending) < PositionRestoreArrivedToleranceSeconds)
+            {
+                EndPositionRestore();
+            }
         }
 
         private void NotifyPositionChanged(double newPosition)
@@ -1029,7 +1060,8 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
                     // target even if the restoring code never got to end it (an abandoned
                     // sequence would otherwise pin PositionForRestore for the rest of the
                     // control's life).
-                    if (_pendingRestorePositionSeconds is { } pending && Math.Abs(pos - pending) < 0.5)
+                    if (_pendingRestorePositionSeconds is { } pending &&
+                        Math.Abs(pos - pending) < PositionRestoreArrivedToleranceSeconds)
                     {
                         EndPositionRestore();
                     }

--- a/src/ui/Features/Main/Layout/InitVideoPlayer.cs
+++ b/src/ui/Features/Main/Layout/InitVideoPlayer.cs
@@ -89,7 +89,10 @@ public static class InitVideoPlayer
                     control.Position = position;
                 }
 
-                control.EndPositionRestore();
+                // Only if the player really got there - the loop above is a fixed 100 ms of
+                // seeks, so a player still loading when it runs out would otherwise be handed
+                // back as the truth while it still reports 0 (issue #14218).
+                control.EndPositionRestoreIfArrived();
             });
         }
 

--- a/src/ui/Features/Shared/FullScreenVideoPlayer.cs
+++ b/src/ui/Features/Shared/FullScreenVideoPlayer.cs
@@ -258,8 +258,10 @@ public class FullScreenVideoWindow : Window
                 videoPlayer.Position = position;
 
                 // Restore done - a rebuild reading from this control gets the live position
-                // again (issue #14218).
-                videoPlayer.EndPositionRestore();
+                // again (issue #14218). Only once the player has actually arrived, though: mpv
+                // can still be loading here, and handing a rebuild the 0 of a player that never
+                // reached the target is the rewind this guard exists to prevent.
+                videoPlayer.EndPositionRestoreIfArrived();
             });
         };
     }

--- a/src/ui/Features/Shared/Undocked/VideoPlayerUndockedViewModel.cs
+++ b/src/ui/Features/Shared/Undocked/VideoPlayerUndockedViewModel.cs
@@ -179,6 +179,12 @@ public partial class VideoPlayerUndockedViewModel : ObservableObject
 
         if (!string.IsNullOrEmpty(_originalVideoFileName))
         {
+            // Announced here rather than left to Open below: this control is already published
+            // as the undocked video player, so a rebuild landing before the posted open has run
+            // (Settings -> Apply followed by OK) would read the live position of a player that
+            // has not been given a file yet - 0 - and rewind the video (issue #14218).
+            videoPlayerControl.BeginPositionRestore(_originalPosition);
+
             Dispatcher.UIThread.Post(async () =>
             {
                 await Task.Delay(100);
@@ -200,8 +206,10 @@ public partial class VideoPlayerUndockedViewModel : ObservableObject
                 videoPlayerControl.Position = _originalPosition;
 
                 // The player is where it belongs - a rebuild from here on can read the live
-                // position again (issue #14218).
-                videoPlayerControl.EndPositionRestore();
+                // position again (issue #14218). If it is not there yet (mpv still loading), the
+                // target stays until the position tick sees the player arrive; handing a rebuild
+                // the 0 of a player that never got there is the rewind this guards against.
+                videoPlayerControl.EndPositionRestoreIfArrived();
 
                 // Undocking opens the video in a new player, which starts on mpv's default audio
                 // track - re-apply the track the user picked in the main window (issue #12844).

--- a/tests/UI/Controls/AudioVisualizerParagraphRepaintTests.cs
+++ b/tests/UI/Controls/AudioVisualizerParagraphRepaintTests.cs
@@ -1,0 +1,138 @@
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace UITests.Controls;
+
+/// <summary>
+/// The blank waveform in issue #14218: after Options/OK the waveform kept the time ruler and the
+/// cursor but drew no paragraphs at all - no boxes, no text, no number/duration/CPS - until
+/// playback was resumed, which brought them all back.
+///
+/// The paragraph set the waveform draws is rebuilt on the 50 ms position timer and lives in plain
+/// fields, so a rebuild of it asks for no repaint. While the video is paused nothing else moves an
+/// AffectsRender property either, so whatever was on screen when the set was last painted just
+/// stays there. Options/OK produced exactly that: the rebuilt video player reports 0 for a moment,
+/// "center video position" scrolls the waveform to the start (16 ms cursor timer), the paragraph
+/// reload empties the list, and the frame painted when the player lands back on the real position
+/// shows the right time range with nothing in it. The reload a tick later fixed the list but not
+/// the picture.
+/// </summary>
+public class AudioVisualizerParagraphRepaintTests
+{
+    private const int SampleRate = 126; // px per second at zoom 1
+    private const double WidthPx = 800;
+    private const double HeightPx = 200;
+    private const double LineStartSeconds = 100;
+
+    private static WavePeakData2 MakePeaks(int seconds)
+    {
+        var peaks = new WavePeak2[SampleRate * seconds];
+        for (var i = 0; i < peaks.Length; i++)
+        {
+            peaks[i] = new WavePeak2(200, -200);
+        }
+
+        return new WavePeakData2(SampleRate, peaks);
+    }
+
+    private static byte[] Capture(Window window)
+    {
+        Dispatcher.UIThread.RunJobs();
+        AvaloniaHeadlessPlatform.ForceRenderTimerTick();
+
+        using var frame = window.CaptureRenderedFrame()!;
+        using var stream = new MemoryStream();
+        frame.Save(stream);
+        return stream.ToArray();
+    }
+
+    [AvaloniaFact]
+    public void ParagraphReloadRepaintsWhenTheDrawnSetChanged_Issue14218()
+    {
+        var av = new AudioVisualizer { WavePeaks = MakePeaks(300) };
+        var window = new Window
+        {
+            Width = WidthPx,
+            Height = HeightPx,
+            Content = av,
+        };
+
+        window.Show();
+        window.UpdateLayout();
+
+        var lines = new List<SubtitleLineViewModel>
+        {
+            new()
+            {
+                Text = "- Where is Arturo?" + Environment.NewLine + "- He was here.",
+                StartTime = TimeSpan.FromSeconds(LineStartSeconds),
+                EndTime = TimeSpan.FromSeconds(LineStartSeconds + 3),
+            },
+        };
+
+        var noSelection = new List<SubtitleLineViewModel>();
+
+        // The waveform is scrolled to the start of the file - what "center video position" does
+        // while the rebuilt player still reports 0 - so the line is far outside the drawn window.
+        av.SetPosition(0, lines, 0, -1, noSelection);
+        Capture(window);
+
+        // The player lands back where the user was. The cursor timer moves the view, which is an
+        // AffectsRender property, so this frame is painted - with the paragraph set still empty.
+        av.StartPositionSeconds = LineStartSeconds - 1;
+        var withoutParagraphs = Capture(window);
+
+        // The next reload brings the line back into the set. Nothing else changes here (same view,
+        // same cursor - the video is paused), so unless the reload asks for the repaint itself the
+        // waveform goes on showing the frame above.
+        av.SetPosition(LineStartSeconds - 1, lines, 0, -1, noSelection);
+        var withParagraphs = Capture(window);
+
+        Assert.NotEqual(withoutParagraphs, withParagraphs);
+    }
+
+    [AvaloniaFact]
+    public void ParagraphReloadRepaintsWhenTheSelectionChanged_Issue14218()
+    {
+        // Same hole on the selection half of the reload: AllSelectedParagraphs is an AffectsRender
+        // property, but only its identity is - the reload mutates the list in place, so a selection
+        // that arrives while the video is paused repaints nothing on its own.
+        var av = new AudioVisualizer { WavePeaks = MakePeaks(300) };
+        var window = new Window
+        {
+            Width = WidthPx,
+            Height = HeightPx,
+            Content = av,
+        };
+
+        window.Show();
+        window.UpdateLayout();
+
+        var lines = new List<SubtitleLineViewModel>
+        {
+            new()
+            {
+                Text = "Where are you, Arturo?",
+                StartTime = TimeSpan.FromSeconds(LineStartSeconds),
+                EndTime = TimeSpan.FromSeconds(LineStartSeconds + 3),
+            },
+        };
+
+        av.SetPosition(LineStartSeconds - 1, lines, 0, -1, new List<SubtitleLineViewModel>());
+        var unselected = Capture(window);
+
+        av.SetPosition(LineStartSeconds - 1, lines, 0, -1, new List<SubtitleLineViewModel>(lines));
+        var selected = Capture(window);
+
+        Assert.NotEqual(unselected, selected);
+    }
+}

--- a/tests/UI/Controls/VideoPlayerControlRestorePositionTests.cs
+++ b/tests/UI/Controls/VideoPlayerControlRestorePositionTests.cs
@@ -102,4 +102,35 @@ public class VideoPlayerControlRestorePositionTests
 
         Assert.Equal(control.Position, control.PositionForRestore);
     }
+
+    [AvaloniaFact]
+    public async Task ARestoreThatNeverLandedKeepsItsTarget()
+    {
+        var player = new NotYetLoadedVideoPlayer();
+        var control = new VideoPlayerControl(player);
+
+        await control.Open("fake.mkv", 321.5);
+
+        // The restoring code has run out of seeks (a bounded ready wait plus a fixed number of
+        // retries) while the player is still at the start of the file. Handing the live position
+        // back here is what rewound the video: the next rebuild would sample this player's 0.
+        control.EndPositionRestoreIfArrived();
+
+        Assert.Equal(321.5, control.PositionForRestore);
+    }
+
+    [AvaloniaFact]
+    public async Task ARestoreThatLandedGivesTheLivePositionBack()
+    {
+        var player = new NotYetLoadedVideoPlayer();
+        var control = new VideoPlayerControl(player);
+
+        await control.Open("fake.mkv", 321.5);
+
+        // The player got where it was told to go, so it is the truth again.
+        player.Position = 321.5;
+        control.EndPositionRestoreIfArrived();
+
+        Assert.Equal(control.Position, control.PositionForRestore);
+    }
 }


### PR DESCRIPTION
Follow-up to #14219 for the two things GrampaWildWilly reports are left in beta 28 ([comment](https://github.com/SubtitleEdit/subtitleedit/issues/14218#issuecomment-5461187564)).

## The waveform draws no paragraphs after Options/OK

No boxes, no text, no number/duration/CPS — just the time ruler and the cursor — until Spacebar resumed playback and everything came back at once.

His two screenshots pin it down: both are at the same position and zoom, the ruler renders (so `WavePeaks` is there), and the flat line in the broken one is painted in the *selected* colour exactly where the selected line sits. So `AllSelectedParagraphs` was populated and the view was correct while the displayable set was empty — which can only happen if the last reload ran with the view somewhere else entirely and nothing repainted afterwards.

That is what a rebuild does: the rebuilt video player reports 0 for a moment, "center video position" scrolls the waveform to the start on the 16 ms cursor timer, the paragraph reload — on the lower-priority 50 ms timer, competing with the rebuild — empties the set, and the frame painted when the player lands back on the real position shows the right time range with nothing in it. The reload a tick later fixed the set but not the picture: the sets are plain fields (`AllSelectedParagraphs` is an `AffectsRender` property, but only its identity is, and the reload mutates the list in place), and while the video is paused nothing else moves an `AffectsRender` property, so the frame just stayed.

`LoadParagraphs` now repaints when the set it draws actually changed. Reference comparison, so the 20 ticks a second that change nothing still cost nothing.

## The rest of the rewind

Two holes were left in the `PositionForRestore` guard:

- **The undocked window announced nothing before its open.** It publishes the new control synchronously and opens it from a posted continuation 100 ms later, and `BeginPositionRestore` only happens inside `Open` — so a rebuild landing in between (Apply followed by OK) read the live 0 of a player that had not been given a file yet. It announces the target up front now, like the docked rebuild already did.
- **`EndPositionRestore` ran unconditionally** at the end of every restore sequence. Those sequences are bounded (a ready wait plus a fixed number of seeks), so one that runs out while mpv is still loading handed `PositionForRestore` back to a player still reporting 0 — the very rewind the guard exists to prevent. The three restore paths (layout rebuild, undock, fullscreen) use `EndPositionRestoreIfArrived` instead, which keeps the target until the player really is there; the arrival check already in the position tick drops it the moment it lands.

## Tests

`AudioVisualizerParagraphRepaintTests` drives the real sequence in a headless window and compares captured frames — both cases fail without the repaint. Two more cases in `VideoPlayerControlRestorePositionTests` cover the arrival condition. Full UI suite green.

## Not in here

Worth a look separately: in undocked mode `VideoUndockControls` posts the whole rebuild to the dispatcher, so Apply's `AppliedSettingsSnapshot` is taken *before* that rebuild runs. Any setting the rebuild itself writes (other than the window geometry the snapshot already excludes) would make OK see a difference and apply everything a second time — which is what has to happen for the holes above to be reachable at all.

Fixes the two remaining items on #14218 (worth reopening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
