### PR TITLE
Keep the waveform cursor on the frame when stepping forward (#14245)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -688,6 +688,8 @@ public partial class MainViewModel :
     private const double PlayheadPausedSettleStableMs = 100; // mpv's position unchanged this long after a pause = its clock is at rest -> snap the cursor there once
     private bool _playheadResyncOnPlay; // armed while paused: re-seed the estimate from mpv once playback actually moves again
     private const double PlayheadResyncOnPlayThresholdSeconds = 0.04; // ~one frame; below this the standing residual isn't worth moving the cursor for
+    private long _frameStepFollowUntilTs; // a native frame step is in flight: treat mpv's un-pause as paused (see BeginFrameStepPlayheadFollow)
+    private const double FrameStepFollowWindowMs = 1000; // safety cap; the window normally closes as soon as the step lands
     private CancellationTokenSource _videoOpenTokenSource;
     private readonly HashSet<string> _waveformsBeingGenerated = new(StringComparer.OrdinalIgnoreCase);
     private readonly Lock _waveformsBeingGeneratedLock = new();
@@ -18290,6 +18292,7 @@ public partial class MainViewModel :
         var vp = GetVideoPlayerControl();
         if (vp != null && vp.VideoPlayer is LibMpvDynamicPlayer mpv)
         {
+            BeginFrameStepPlayheadFollow();
             mpv.StepOneFrameBack();
             return;
         }
@@ -18315,6 +18318,7 @@ public partial class MainViewModel :
         var vp = GetVideoPlayerControl();
         if (vp != null && vp.VideoPlayer is LibMpvDynamicPlayer mpv)
         {
+            BeginFrameStepPlayheadFollow();
             mpv.StepOneFrameForward();
             return;
         }
@@ -27780,6 +27784,32 @@ public partial class MainViewModel :
 
         var nowTimestamp = Stopwatch.GetTimestamp();
 
+        // A native frame step is in flight: mpv's `frame-step` is a real un-pause (it sets pause=no,
+        // plays until the next video frame, then sets pause=yes), so the observed pause flag flickers
+        // and reads here as a play->pause cycle. That cleared _playheadPausedSettled on the very tick
+        // mpv reported the stepped-to frame, so the follow-a-paused-seek branch below skipped it - and
+        // settling deliberately never snaps (#12740), so the frame was dropped from the cursor for good
+        // and the step drifted a frame per press until the 0.5 s discontinuity snap caught up (#14245).
+        // How often it bit depended on the audio period (a PipeWire quantum change is enough): that
+        // sets how long the un-pause window lasts and whether mpv coalesces the pause change at all.
+        // Stepping backwards never had this - `frame-back-step` seeks and stays paused - which is why
+        // it always landed the cursor correctly. So treat the core as paused for the duration of the
+        // step and let the paused branch follow mpv's reported position exactly, as it does for a
+        // paused seek. The window closes as soon as the step lands, so a real Play() right after a
+        // step isn't swallowed.
+        var frameStepping = _frameStepFollowUntilTs != 0;
+        if (frameStepping)
+        {
+            var stepLanded = _playheadLastRealSeconds >= 0 &&
+                             Math.Abs(rawPosition - _playheadLastRealSeconds) > 0.0005;
+            if (stepLanded || nowTimestamp > _frameStepFollowUntilTs)
+            {
+                _frameStepFollowUntilTs = 0;
+            }
+
+            isPlaying = false;
+        }
+
         // Any tick with mpv stopped arms a one-shot resync for when playback starts again (see the
         // resync block in the playing branch). Armed here rather than in PlayVideo so every way of
         // starting playback is covered - the player's own toolbar button, a click on the video
@@ -27967,9 +27997,13 @@ public partial class MainViewModel :
             // discontinuity (a seek while paused, beyond the resync threshold) moves the cursor now.
             if (!isPlaying)
             {
-                if (_playheadWasPlaying)
+                if (_playheadWasPlaying && !frameStepping)
                 {
-                    _playheadPausedSettled = false; // play -> pause edge: wait for mpv's clock to settle
+                    // Play -> pause edge: wait for mpv's clock to settle. Not for a frame step, where
+                    // the "playing" state was mpv's one-frame un-pause (or, when stepping out of real
+                    // playback, an explicit request for the next frame): the cursor belongs on the
+                    // frame mpv reports, so keep it authoritative and let it follow (#14245).
+                    _playheadPausedSettled = false;
                 }
 
                 _pauseRequested = false; // mpv has actually paused now
@@ -28031,6 +28065,19 @@ public partial class MainViewModel :
         _playheadLastTimestamp = nowTimestamp;
         _playheadWasPlaying = isPlaying;
         return _playheadEstimateSeconds;
+    }
+
+    /// <summary>
+    /// Called just before a native mpv frame step (`frame-step` / `frame-back-step`): opens a short
+    /// window in which the playhead estimate treats the core as paused and stays authoritative, so
+    /// the cursor snaps onto the frame mpv steps to instead of losing it to the un-pause that
+    /// `frame-step` really is. See the frame-step block in <see cref="UpdatePlayheadEstimate"/>.
+    /// </summary>
+    private void BeginFrameStepPlayheadFollow()
+    {
+        _frameStepFollowUntilTs = Stopwatch.GetTimestamp() +
+                                 (long)(Stopwatch.Frequency * FrameStepFollowWindowMs / 1000.0);
+        _playheadPausedSettled = true; // stepping: the cursor is at the current frame and follows to the next one
     }
 
     // Called when the user seeks via the waveform: show the clicked position on the cursor

--- a/tests/UI/Features/Main/PlayheadFrameStepTests.cs
+++ b/tests/UI/Features/Main/PlayheadFrameStepTests.cs
@@ -1,0 +1,170 @@
+using Avalonia.Headless.XUnit;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Controls.VideoPlayer;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.VideoPlayers;
+using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// The waveform playhead across a native mpv frame step (issue #14245). mpv's `frame-step` is a
+/// real un-pause - it sets pause=no, plays until the next video frame, then sets pause=yes - so
+/// the observed pause flag flickers and used to read as a play->pause cycle: the edge cleared the
+/// "paused and settled" flag on the very tick mpv reported the stepped-to frame, the
+/// follow-a-paused-seek branch skipped it, and settling never snaps (#12740). The frame was
+/// dropped from the cursor for good and stepping forward drifted a frame per press until the
+/// 0.5 s discontinuity snap caught up. (`frame-back-step` seeks and stays paused, which is why
+/// stepping backwards always landed correctly.)
+/// </summary>
+public class PlayheadFrameStepTests
+{
+    private const double FrameSeconds = 1.0 / 23.976;
+
+    private sealed class FakeVideoPlayer : IVideoPlayer
+    {
+        public string Name => "fake";
+        public string FileName { get; private set; } = string.Empty;
+
+        public bool CanLoad() => true;
+
+        public Task LoadFile(string fileName, double startPositionSeconds = 0)
+        {
+            FileName = fileName;
+            Position = startPositionSeconds;
+            return Task.CompletedTask;
+        }
+
+        public void CloseFile() => FileName = string.Empty;
+
+        public void Play() => IsPlaying = true;
+
+        public void PlayOrPause() => IsPlaying = !IsPlaying;
+
+        public void Pause() => IsPlaying = false;
+
+        public void Stop() => IsPlaying = false;
+
+        public AudioTrackInfo? ToggleAudioTrack() => null;
+
+        public bool IsPlaying { get; set; }
+        public bool IsPaused => !IsPlaying;
+        public double Position { get; set; }
+        public double Duration => 60;
+        public int VolumeMaximum => 100;
+        public double Volume { get; set; } = 50;
+        public double Speed { get; set; } = 1.0;
+    }
+
+    [AvaloniaFact]
+    public void FrameStepForward_LandsTheCursorOnTheSteppedFrame()
+    {
+        var (vm, vp, player) = MakeViewModelWithPlayer(startSeconds: 1.0);
+
+        BeginFrameStep(vm);
+
+        // mpv's one-frame un-pause: the pause flag says "playing" while its clock still sits on
+        // the old frame. The cursor must not move yet - and must not lose its authority either.
+        Assert.Equal(1.0, Tick(vm, vp, isPlaying: true), 4);
+        Assert.Equal(1.0, Tick(vm, vp, isPlaying: true), 4);
+
+        // The step lands: mpv reports the new frame and pauses again.
+        player.Position = 1.0 + FrameSeconds;
+        player.IsPlaying = false;
+        Assert.Equal(1.0 + FrameSeconds, Tick(vm, vp, isPlaying: false), 4);
+    }
+
+    [AvaloniaFact]
+    public void FrameStepForward_Repeated_DoesNotDrift()
+    {
+        var (vm, vp, player) = MakeViewModelWithPlayer(startSeconds: 1.0);
+
+        for (var step = 1; step <= 10; step++)
+        {
+            BeginFrameStep(vm);
+            player.IsPlaying = true;
+            Tick(vm, vp, isPlaying: true);
+
+            player.Position = 1.0 + (step * FrameSeconds);
+            player.IsPlaying = false;
+            var estimate = Tick(vm, vp, isPlaying: false);
+
+            // Before the fix the cursor stayed at 1.0 while mpv walked forward, so the error grew
+            // by a frame per press until the 0.5 s snap.
+            Assert.Equal(player.Position, estimate, 4);
+
+            // Idle ticks between key presses must not move it either.
+            Assert.Equal(player.Position, Tick(vm, vp, isPlaying: false), 4);
+        }
+    }
+
+    [AvaloniaFact]
+    public void FrameStepWindow_ClosesImmediatelyWhenTheCoreIsReallyPlaying()
+    {
+        // mpv's frame-step is a no-op without a video track, so an audio-only file keeps playing
+        // right through it. The window must not hold the cursor frozen on a running clock: a moving
+        // position means the step is not in flight, so it closes on the first tick.
+        var (vm, vp, player) = MakeViewModelWithPlayer(startSeconds: 1.0);
+
+        BeginFrameStep(vm);
+        player.IsPlaying = true;
+        player.Position = 1.2;
+        Tick(vm, vp, isPlaying: true);
+
+        Assert.Equal(0L, GetField<long>(vm, "_frameStepFollowUntilTs"));
+    }
+
+    [AvaloniaFact]
+    public void PauseWindDown_IsStillNotFollowed()
+    {
+        // The frame-step window is the only thing that lets a paused position change through on a
+        // play->pause edge. An ordinary pause must keep dead-freezing the cursor at the keypress
+        // instant while mpv decodes on past it (#12740).
+        var (vm, vp, player) = MakeViewModelWithPlayer(startSeconds: 1.0);
+        SetField(vm, "_playheadWasPlaying", true);
+
+        player.Position = 1.08; // mpv's wind-down running past the frozen spot
+        Assert.Equal(1.0, Tick(vm, vp, isPlaying: false), 4);
+    }
+
+    private static (MainViewModel Vm, VideoPlayerControl Vp, FakeVideoPlayer Player) MakeViewModelWithPlayer(double startSeconds)
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var vm = Locator.Services.GetRequiredService<MainViewModel>();
+        var player = new FakeVideoPlayer { Position = startSeconds };
+        var vp = new VideoPlayerControl(player);
+
+        // Paused at startSeconds, settled, with the cursor already on that spot.
+        SetField(vm, "_playheadEstimateSeconds", startSeconds);
+        SetField(vm, "_playheadLastRealSeconds", startSeconds);
+        SetField(vm, "_playheadValid", true);
+        SetField(vm, "_playheadPausedSettled", true);
+        SetField(vm, "_playheadWasPlaying", false);
+
+        return (vm, vp, player);
+    }
+
+    private static void BeginFrameStep(MainViewModel vm) =>
+        typeof(MainViewModel)
+            .GetMethod("BeginFrameStepPlayheadFollow", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(vm, null);
+
+    private static double Tick(MainViewModel vm, VideoPlayerControl vp, bool isPlaying) =>
+        (double)typeof(MainViewModel)
+            .GetMethod("UpdatePlayheadEstimate", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(vm, [vp, isPlaying])!;
+
+    private static void SetField(object target, string name, object value) =>
+        target.GetType().GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(target, value);
+
+    private static T GetField<T>(object target, string name) =>
+        (T)target.GetType().GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(target)!;
+}


### PR DESCRIPTION
Fixes #14245.

## What was wrong

mpv's `frame-step` is a **real un-pause**: it sets `pause=no`, plays until the next video frame, then sets `pause=yes`. So the observed pause flag flickers, and `UpdatePlayheadEstimate` read that as a genuine play→pause cycle. The edge clears `_playheadPausedSettled`, which gates the follow-a-paused-seek branch — the very branch that would put the cursor on the frame mpv just stepped to. It was skipped on exactly that tick, and settling deliberately never snaps (#12740), so the frame was dropped from the cursor for good. Stepping forward drifted a frame per press until the 0.5 s discontinuity snap caught up.

Stepping backwards was never affected: `frame-back-step` seeks and stays paused, so the settled flag survives and the cursor lands correctly — which is what the reporter saw ("frame advancing backward resets the cursor to the correct position").

Whether a given press lost its frame depended on how long the un-pause window lasted, i.e. on the audio period — which any other application starting or stopping audio can change. The reporter tracked it to the PipeWire quantum. Traced against a live mpv core over its JSON IPC (23.976 fps, times in ms):

```
1501.4  == PRESS frame-step 0
1501.8  time-pos  0.041708      <- no pause event: mpv coalesced the step into one playloop iteration
2506.9  == PRESS frame-step 2
2507.2  pause     False
2549.0  pause     True          <- 42 ms un-pause window, seen by the 16 ms cursor timer
2549.1  time-pos  0.125125
4824.5  == PRESS frame-back-step
4879.0  time-pos  0.208542      <- no pause events at all
```

A long window is seen by the cursor timer and the frame is lost; a short one is coalesced by mpv and the cursor tracks fine — hence "moves on roughly every second press". Slow motion always loses, since one frame then takes several times longer to play out, matching the reported "worsening as the speed decreases".

This is not Linux-specific in the code; steadier audio timing elsewhere just makes it less likely to be hit.

## The fix

`BeginFrameStepPlayheadFollow()` opens a short window around a native frame step in which the estimate treats the core as paused and keeps the cursor authoritative, so the stepped-to frame is followed exactly like a paused seek — the same path that already made backwards stepping correct. The window closes as soon as the step lands, so a real `Play()` right after a step is not swallowed, and a frame-step mpv ignores (no video track) closes it on the first tick, since a moving clock means no step is in flight. `#12740`'s pause dead-freeze and `#12742`'s paused-seek follow are untouched.

Not addressed here (mpv/PipeWire behaviour, not the cursor): whether mpv pushes audio out on every frame-step press.

## Tests

`tests/UI/Features/Main/PlayheadFrameStepTests.cs` drives the estimate through the flicker with a fake player: the cursor lands on the stepped frame, ten steps in a row accumulate no drift, the window closes immediately on a running clock, and an ordinary pause wind-down is still not followed. The first two fail without the fix.

Full UI suite: 4277 pass. One unrelated pre-existing failure, `LibMpvEventLoopTests.Pause_RightAfterSeek_KeepsReportingTheSeekTarget`, which only runs on a machine with a loadable libmpv and only fails under full-suite load — a race in the #14187 seek-in-flight check, reported separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)