### PR TITLE
Compare: restore synchronized vertical scrolling (#13504)

### DIFF
--- a/src/ui/Features/Files/Compare/CompareViewModel.cs
+++ b/src/ui/Features/Files/Compare/CompareViewModel.cs
@@ -46,12 +46,16 @@ public partial class CompareViewModel : ObservableObject
     public TableView? LeftGrid { get; set; } = new();
     public TableView? RightGrid { get; set; } = new();
 
+    /// <summary>Keeps the two grids showing the same rows while either one scrolls (#13504).</summary>
+    public TableViewScrollSync? ScrollSync { get; set; }
+
     private IFileHelper _fileHelper;
     private IFolderHelper _folderHelper;
     private List<SubtitleLineViewModel> _leftLines = new();
     private List<SubtitleLineViewModel> _rightLines = new();
     private string _language = string.Empty;
     private bool _languageDirty = true;
+    private bool _mirroringSelection;
 
     // Theme aware - the light pastels are unreadable under the dark theme's near-white text (#13435).
     private static IBrush ListViewRed => CompareColors.OnlyInOneFileRow;
@@ -885,41 +889,60 @@ public partial class CompareViewModel : ObservableObject
 
     internal void LeftGridSelectionChanged(object? sender, SelectionChangedEventArgs e)
     {
-        if (e.AddedItems.Count == 0)
-        {
-            return;
-        }
-
-        var selection = e.AddedItems[0] as CompareItem;
-        if (selection == null)
-        {
-            return;
-        }
-
-        var idx = LeftSubtitles.IndexOf(selection);
-        Dispatcher.UIThread.Post(() =>
-        {
-            SelectAndScrollToRow(RightGrid, idx);
-        });
+        MirrorSelection(e, LeftSubtitles, LeftGrid, RightGrid);
     }
 
     internal void RightGridSelectionChanged(object? sender, SelectionChangedEventArgs e)
     {
-        if (e.AddedItems.Count == 0)
+        MirrorSelection(e, RightSubtitles, RightGrid, LeftGrid);
+    }
+
+    /// <summary>
+    /// Selects the same row on the other side and lines the two views up again. SE4 assigned the
+    /// other list view's TopItem here (Compare.SelectLinesInBothListViews); ScrollIntoView only
+    /// promises the row is somewhere in view, so the two sides could keep the same row selected
+    /// while showing ranges a page apart (#13504).
+    /// </summary>
+    private void MirrorSelection(
+        SelectionChangedEventArgs e,
+        ObservableCollection<CompareItem> sourceItems,
+        TableView? source,
+        TableView? target)
+    {
+        if (_mirroringSelection || source == null || target == null || e.AddedItems.Count == 0)
         {
             return;
         }
 
-        var selection = e.AddedItems[0] as CompareItem;
-        if (selection == null)
+        if (e.AddedItems[0] is not CompareItem selection)
         {
             return;
         }
 
-        var idx = RightSubtitles.IndexOf(selection);
+        var idx = sourceItems.IndexOf(selection);
+        if (idx < 0)
+        {
+            return;
+        }
+
         Dispatcher.UIThread.Post(() =>
         {
-            SelectAndScrollToRow(LeftGrid, idx);
+            // Mirroring the selection raises SelectionChanged on the other grid, which would
+            // mirror it straight back and re-align from the wrong side.
+            _mirroringSelection = true;
+            try
+            {
+                if (idx < target.ItemCount && target.SelectedIndex != idx)
+                {
+                    target.SelectedIndex = idx;
+                }
+
+                ScrollSync?.SyncFrom(source);
+            }
+            finally
+            {
+                _mirroringSelection = false;
+            }
         });
     }
 

--- a/src/ui/Features/Files/Compare/CompareWindow.cs
+++ b/src/ui/Features/Files/Compare/CompareWindow.cs
@@ -152,6 +152,9 @@ public class CompareWindow : Window
         {
             vm.LeftGrid.SelectionChanged += vm.LeftGridSelectionChanged;
             vm.RightGrid.SelectionChanged += vm.RightGridSelectionChanged;
+
+            // Scrolling either side keeps the other aligned to the same rows, like SE4 (#13504).
+            vm.ScrollSync = new TableViewScrollSync(vm.LeftGrid, vm.RightGrid);
         }
 
         Closing += delegate { UiUtil.SaveWindowPosition(this); };

--- a/src/ui/Logic/TableViewScrollSync.cs
+++ b/src/ui/Logic/TableViewScrollSync.cs
@@ -1,0 +1,244 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.VisualTree;
+using System;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>
+/// Keeps two side-by-side <see cref="TableView"/>s looking at the same row: scrolling either
+/// one puts the row at the other one's viewport top too (issue #13504).
+///
+/// SE4's Compare did this with a timer that copied the active list view's TopItem index to the
+/// other one (Compare.SelectLinesInBothListViews). SE5's two grids scroll independently, so
+/// with larger files the sides drift a page or more apart and the comparison is unreadable.
+///
+/// The sync works in row *indices*, not pixels, and that is not a detail: the two grids hold
+/// different text, a row wraps to one or two lines depending on its content, and TableView
+/// virtualizes with a VirtualizingStackPanel whose extent is estimated from the average
+/// realized row height (see <see cref="TableViewScrollAnchor"/> and
+/// <see cref="TableViewExtras.PrePositionScroll"/>, upstream AvaloniaUI/Avalonia #17831). Two
+/// grids with different content therefore produce different - and drifting - estimates, so
+/// copying <c>Offset.Y</c> across would neither start nor stay aligned. Instead the row at the
+/// source's viewport top is measured, and the same index is placed at the same top edge on the
+/// other side with the pre-position + settle loop the other TableView helpers use.
+///
+/// Rows below the top can still diverge when one side wraps to two lines and its twin does not;
+/// aligning those as well would mean giving matched rows a shared height, which is a change to
+/// the compare rows themselves rather than to scrolling.
+/// </summary>
+public sealed class TableViewScrollSync
+{
+    /// <summary>Refinement steps the alignment is allowed to take, like PrePositionScroll.</summary>
+    private const int SettlePasses = 3;
+
+    private readonly TableView _left;
+    private readonly TableView _right;
+    private ScrollViewer? _leftScrollViewer;
+    private ScrollViewer? _rightScrollViewer;
+
+    // Aligning one side scrolls it, which reports back as another scroll change; without this
+    // the two sides would push each other back and forth (and fight at the bottom, where the
+    // shorter extent cannot follow the taller one).
+    private bool _syncing;
+
+    public TableViewScrollSync(TableView left, TableView right)
+    {
+        _left = left;
+        _right = right;
+
+        Hook(left, isLeft: true);
+        Hook(right, isLeft: false);
+    }
+
+    /// <summary>
+    /// Puts <paramref name="source"/>'s top row at the top of the other grid. Called on every
+    /// scroll, and by callers that moved the selection instead of the offset - a mirrored
+    /// selection only guarantees the row is somewhere in view, which is not the same as aligned.
+    /// </summary>
+    public void SyncFrom(TableView source)
+    {
+        if (_syncing)
+        {
+            return;
+        }
+
+        ScrollViewer? sourceScrollViewer;
+        TableView target;
+        ScrollViewer? targetScrollViewer;
+        if (source == _left)
+        {
+            sourceScrollViewer = _leftScrollViewer;
+            target = _right;
+            targetScrollViewer = _rightScrollViewer;
+        }
+        else if (source == _right)
+        {
+            sourceScrollViewer = _rightScrollViewer;
+            target = _left;
+            targetScrollViewer = _leftScrollViewer;
+        }
+        else
+        {
+            return;
+        }
+
+        if (sourceScrollViewer == null || targetScrollViewer == null ||
+            targetScrollViewer.Viewport.Height <= 0 || target.ItemCount == 0)
+        {
+            return;
+        }
+
+        // Set before the first layout pass, not just around the alignment: laying the source out
+        // reports its own scroll change back here, and answering that would re-enter this method
+        // for the same scroll until the stack runs out.
+        _syncing = true;
+
+        // Placing a row at the viewport top realizes rows as it goes, so the extent estimate
+        // moves under the settle loop - an anchor restore in the middle of that would drag the
+        // view back to where it just left (#13619).
+        using var anchorSuspended = TableViewScrollAnchor.GetFor(target)?.Suspend();
+        try
+        {
+            // The caller may have just scrolled the source with ScrollIntoView; measure what is
+            // on screen now, not what was there before that layout pass.
+            source.UpdateLayout();
+            if (GetTopRow(source, sourceScrollViewer) is not { } topRow)
+            {
+                return;
+            }
+
+            Align(target, targetScrollViewer, topRow.Index, topRow.Top);
+        }
+        finally
+        {
+            _syncing = false;
+        }
+    }
+
+    private void Hook(TableView tableView, bool isLeft)
+    {
+        if (tableView.IsLoaded)
+        {
+            HookScrollViewer(tableView, isLeft);
+        }
+
+        tableView.Loaded += (_, _) => HookScrollViewer(tableView, isLeft);
+    }
+
+    private void HookScrollViewer(TableView tableView, bool isLeft)
+    {
+        if ((isLeft ? _leftScrollViewer : _rightScrollViewer) != null)
+        {
+            return;
+        }
+
+        var scrollViewer = tableView.GetVisualDescendants().OfType<ScrollViewer>().FirstOrDefault();
+        if (scrollViewer == null)
+        {
+            return;
+        }
+
+        if (isLeft)
+        {
+            _leftScrollViewer = scrollViewer;
+        }
+        else
+        {
+            _rightScrollViewer = scrollViewer;
+        }
+
+        scrollViewer.ScrollChanged += (_, e) =>
+        {
+            // An extent change with no offset change is the panel re-estimating under the view,
+            // not a scroll - the other side has no reason to move for it.
+            if (_syncing || Math.Abs(e.OffsetDelta.Y) < 0.5)
+            {
+                return;
+            }
+
+            SyncFrom(tableView);
+        };
+    }
+
+    /// <summary>
+    /// The visual whose origin is the viewport's top-left corner. The TableView template keeps
+    /// the column header <i>inside</i> the ScrollViewer (pinned above the rows), so the
+    /// ScrollViewer's own origin sits a header height above the viewport. Same helper as
+    /// <see cref="TableViewScrollAnchor"/> and TableViewExtras.
+    /// </summary>
+    private static Visual ViewportOrigin(ScrollViewer scrollViewer) => (Visual?)scrollViewer.Presenter ?? scrollViewer;
+
+    /// <summary>
+    /// The topmost row still showing in the viewport, with its top edge in viewport
+    /// coordinates - negative while the row is scrolled into.
+    /// </summary>
+    private static (int Index, double Top)? GetTopRow(TableView tableView, ScrollViewer scrollViewer)
+    {
+        var top = double.MaxValue;
+        Control? topRow = null;
+        foreach (var row in tableView.GetRealizedContainers().OfType<TableViewRow>())
+        {
+            if (row.Bounds.Height <= 0 ||
+                ((Visual)row).TranslatePoint(new Point(0, 0), ViewportOrigin(scrollViewer))?.Y is not { } rowTop ||
+                rowTop + row.Bounds.Height <= 0.5 ||
+                rowTop >= top)
+            {
+                continue;
+            }
+
+            top = rowTop;
+            topRow = row;
+        }
+
+        if (topRow == null)
+        {
+            return null;
+        }
+
+        var index = tableView.IndexFromContainer(topRow);
+        return index < 0 ? null : (index, top);
+    }
+
+    /// <summary>
+    /// Puts row <paramref name="index"/> of <paramref name="tableView"/> at <paramref name="top"/>
+    /// in viewport coordinates.
+    /// </summary>
+    private static void Align(TableView tableView, ScrollViewer scrollViewer, int index, double top)
+    {
+        index = Math.Clamp(index, 0, tableView.ItemCount - 1);
+
+        // The target row is usually outside the realized window - that is the whole point of
+        // the sync - so bring it back the cheap way first instead of letting the panel walk.
+        if (tableView.ContainerFromIndex(index) is not { Bounds.Height: > 0 })
+        {
+            TableViewExtras.PrePositionScroll(tableView, index);
+            tableView.ScrollIntoView(index);
+            tableView.UpdateLayout();
+        }
+
+        // Then put its top edge where the other side's is. Setting the offset makes the panel
+        // re-estimate and re-anchor, which can nudge the rows by a fraction of a row - measure
+        // and correct until the row stays put.
+        for (var pass = 0; pass < SettlePasses; pass++)
+        {
+            if (tableView.ContainerFromIndex(index) is not { Bounds.Height: > 0 } row ||
+                ((Visual)row).TranslatePoint(new Point(0, 0), ViewportOrigin(scrollViewer))?.Y is not { } rowTop)
+            {
+                return;
+            }
+
+            var newY = Math.Clamp(
+                scrollViewer.Offset.Y + (rowTop - top),
+                0, Math.Max(0, scrollViewer.Extent.Height - scrollViewer.Viewport.Height));
+            if (Math.Abs(newY - scrollViewer.Offset.Y) < 0.5)
+            {
+                return;
+            }
+
+            scrollViewer.Offset = new Vector(scrollViewer.Offset.X, newY);
+            tableView.UpdateLayout();
+        }
+    }
+}

--- a/tests/UI/Features/Files/Compare/CompareScrollSyncTests.cs
+++ b/tests/UI/Features/Files/Compare/CompareScrollSyncTests.cs
@@ -1,0 +1,187 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Files.Compare;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace UITests.Features.Files.Compare;
+
+/// <summary>
+/// Compare's two grids scroll as one: whichever side moves, the other lines up on the same row
+/// again (#13504). SE4 did this by copying the active list view's TopItem; SE5's grids were
+/// independent, so with larger files the sides drifted a page or more apart.
+///
+/// The sync has to work in row indices rather than pixels - the two sides hold different text,
+/// so a row that wraps to two lines on one side is one line on the other, and equal pixel
+/// offsets stop meaning equal rows. The unequal-heights test below is the one that fails for a
+/// naive Offset.Y copy.
+/// </summary>
+public class CompareScrollSyncTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    [AvaloniaFact]
+    public void ScrollingTheLeftGrid_BringsTheRightGridToTheSameRow()
+    {
+        var (window, vm) = OpenCompare(200);
+
+        ScrollTo(window, LeftScrollViewer(vm), 1500);
+
+        Assert.Equal(TopRowIndex(vm.LeftGrid!), TopRowIndex(vm.RightGrid!));
+    }
+
+    [AvaloniaFact]
+    public void ScrollingTheRightGrid_BringsTheLeftGridToTheSameRow()
+    {
+        var (window, vm) = OpenCompare(200);
+
+        ScrollTo(window, RightScrollViewer(vm), 2200);
+
+        Assert.Equal(TopRowIndex(vm.RightGrid!), TopRowIndex(vm.LeftGrid!));
+    }
+
+    // The right lines wrap to two rendered lines where the left ones do not, so the two grids
+    // scale their pixels differently. Copying the offset across would land on a different row;
+    // only the index-based sync stays aligned.
+    [AvaloniaFact]
+    public void ScrollingWithUnequalRowHeights_AlignsRowsRatherThanPixels()
+    {
+        var (window, vm) = OpenCompare(200, rightLineSuffix: Environment.NewLine + "second rendered line");
+
+        var leftScrollViewer = LeftScrollViewer(vm);
+        var rightScrollViewer = RightScrollViewer(vm);
+        ScrollTo(window, leftScrollViewer, 1500);
+
+        Assert.Equal(TopRowIndex(vm.LeftGrid!), TopRowIndex(vm.RightGrid!));
+        Assert.True(Math.Abs(rightScrollViewer.Offset.Y - leftScrollViewer.Offset.Y) > 1,
+            "the two sides ended on the same pixel offset, so this file does not exercise unequal row heights");
+    }
+
+    // Selecting a row already mirrored the selection, but scrolled the other side with
+    // ScrollIntoView - which only promises the row is somewhere in view. With the taller rows on
+    // the right that lands a different number of rows into the view, so the two sides could keep
+    // the same row selected while showing different ranges.
+    [AvaloniaFact]
+    public void SelectingARowFarDown_LinesUpBothViews()
+    {
+        var (window, vm) = OpenCompare(200, rightLineSuffix: Environment.NewLine + "second rendered line");
+
+        vm.LeftGrid!.SelectedIndex = 150;
+        Settle(window);
+
+        Assert.Equal(150, vm.RightGrid!.SelectedIndex);
+        Assert.Equal(TopRowIndex(vm.LeftGrid!), TopRowIndex(vm.RightGrid!));
+    }
+
+    // The right-hand side is empty until a second file is loaded (Tools > Compare always opens
+    // that way), so the sync has nothing to align to and must simply leave it alone.
+    [AvaloniaFact]
+    public void ScrollingWithAnEmptyRightGrid_DoesNotThrow()
+    {
+        var (window, vm) = OpenCompare(200, loadRight: false);
+
+        ScrollTo(window, LeftScrollViewer(vm), 1500);
+
+        Assert.Empty(vm.RightSubtitles);
+        Assert.True(LeftScrollViewer(vm).Offset.Y > 0, "the left grid did not scroll");
+    }
+
+    private static int TopRowIndex(TableView tableView)
+    {
+        var scrollViewer = tableView.GetVisualDescendants().OfType<ScrollViewer>().First();
+        var viewportOrigin = (Visual?)scrollViewer.Presenter ?? scrollViewer;
+
+        var top = double.MaxValue;
+        var index = -1;
+        foreach (var row in tableView.GetRealizedContainers().OfType<TableViewRow>())
+        {
+            if (row.Bounds.Height <= 0 ||
+                ((Visual)row).TranslatePoint(new Point(0, 0), viewportOrigin)?.Y is not { } rowTop ||
+                rowTop + row.Bounds.Height <= 0.5 ||
+                rowTop >= top)
+            {
+                continue;
+            }
+
+            top = rowTop;
+            index = tableView.IndexFromContainer(row);
+        }
+
+        return index;
+    }
+
+    private static ScrollViewer LeftScrollViewer(CompareViewModel vm)
+        => vm.LeftGrid!.GetVisualDescendants().OfType<ScrollViewer>().First();
+
+    private static ScrollViewer RightScrollViewer(CompareViewModel vm)
+        => vm.RightGrid!.GetVisualDescendants().OfType<ScrollViewer>().First();
+
+    private static void ScrollTo(Window window, ScrollViewer scrollViewer, double offsetY)
+    {
+        scrollViewer.Offset = new Vector(scrollViewer.Offset.X, offsetY);
+        Settle(window);
+    }
+
+    private (Window Window, CompareViewModel Vm) OpenCompare(
+        int lineCount,
+        string rightLineSuffix = "",
+        bool loadRight = true)
+    {
+        var vm = new CompareViewModel(new FileHelper(), new FolderHelper());
+        vm.Initialize(
+            MakeLines(lineCount, string.Empty),
+            "left.srt",
+            loadRight ? MakeLines(lineCount, rightLineSuffix) : new ObservableCollection<SubtitleLineViewModel>(),
+            loadRight ? "right.srt" : string.Empty,
+            false);
+
+        var window = new CompareWindow(vm);
+        _windows.Add(window);
+        window.Show();
+        Settle(window);
+
+        Assert.Equal(lineCount, vm.LeftSubtitles.Count);
+        return (window, vm);
+    }
+
+    private static ObservableCollection<SubtitleLineViewModel> MakeLines(int count, string suffix)
+    {
+        var lines = new ObservableCollection<SubtitleLineViewModel>();
+        for (var i = 0; i < count; i++)
+        {
+            lines.Add(new SubtitleLineViewModel(new Paragraph($"Line {i + 1}{suffix}", i * 2000, i * 2000 + 1500), null!)
+            {
+                Number = i + 1,
+            });
+        }
+
+        return lines;
+    }
+
+    private static void Settle(Window window)
+    {
+        for (var pump = 0; pump < 12; pump++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #13504.

## The problem

SE5's Compare builds two independent `TableView`s, and nothing links their scroll offsets — the wheel and the scroll bars move one side only. With larger files the two views end up showing completely different line ranges, even when comparing a file with itself. SE4 kept them together by copying the active list view's `TopItem` index to the other side (`Compare.SelectLinesInBothListViews`).

There was a second, quieter half to it: selection *was* mirrored, but the other side was scrolled with `ScrollIntoView`, which only promises the row is somewhere in view. With rows of different heights the two sides could keep the same row selected and still show different ranges, so clicking a line did not recover the alignment either.

## The fix

`TableViewScrollSync` links the two grids' `ScrollViewer`s. On every scroll it measures the source's top row and puts that same row at the other side's viewport top.

It works in **row indices, not pixels**, and that is the whole design: the two grids hold different text, a row wraps to one or two rendered lines depending on its content, and TableView's `VirtualizingStackPanel` estimates its extent from the average realized row height (the same estimator behind #13579 / #13619, upstream AvaloniaUI/Avalonia#17831). Two grids with different content therefore produce different — and drifting — estimates, so copying `Offset.Y` across would neither start nor stay aligned.

Placing the row reuses the machinery the other TableView helpers already share: `TableViewExtras.PrePositionScroll` so the panel never row-walks, then a three-pass measure/settle loop to put the row's top edge exactly where the other side's is. It suspends any `TableViewScrollAnchor` on the target while it moves, and guards against the mirrored scroll bouncing straight back.

The selection path now top-aligns the two views instead of relying on `ScrollIntoView`, restoring SE4's `TopItem` behavior.

## Known limit

Rows *below* the top can still diverge where one side wraps to two lines and its twin does not. Aligning those as well means giving matched rows a shared height, which is a change to the compare rows themselves rather than to scrolling — left out deliberately.

The two other asks in the issue thread — a modeless Compare window, and double-click to jump to the line in the main editor — are separate work and not in this PR.

## Tests

`tests/UI/Features/Files/Compare/CompareScrollSyncTests.cs`, five headless tests: scrolling either side brings the other to the same row, alignment survives unequal row heights (this one is what fails for a naive offset copy — it also asserts the two pixel offsets genuinely differ), selecting a row far down lines both views up, and scrolling with the right-hand side still empty (how Tools → Compare always opens) does nothing rather than throwing.

All four behavior tests fail on `main`'s code path and pass with the fix; the full UI suite is green (4277 passed, the single unrelated `LibMpvEventLoopTests` timing flake passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)