### PR TITLE
Center the grid for the last prev/next-line paths too (#14231)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1470,6 +1470,7 @@ public partial class MainViewModel :
         // Change selection first, then assign _playSelectionItem.
         SubtitleGrid.SelectedItem = next;
         SubtitleGrid.ScrollIntoView(next);
+        CenterOrEnsureRowVisibleInSubtitleGrid(next);
         vp.Position = next.StartTime.TotalSeconds;
         PinPlayheadTo(next.StartTime.TotalSeconds);
         _playSelectionItem = new PlaySelectionItem(new List<SubtitleLineViewModel> { next }, next.EndTime, loop);
@@ -1546,6 +1547,7 @@ public partial class MainViewModel :
         // Mirror PlayNextParagraph — change selection first, then assign _playSelectionItem.
         SubtitleGrid.SelectedItem = previous;
         SubtitleGrid.ScrollIntoView(previous);
+        CenterOrEnsureRowVisibleInSubtitleGrid(previous);
         vp.Position = previous.StartTime.TotalSeconds;
         PinPlayheadTo(previous.StartTime.TotalSeconds);
         _playSelectionItem = new PlaySelectionItem(new List<SubtitleLineViewModel> { previous }, previous.EndTime, loop);
@@ -16035,7 +16037,7 @@ public partial class MainViewModel :
         }
 
         vp.Position = foundSeconds;
-        SelectAndScrollToRow(Subtitles.IndexOf(found));
+        SelectAndScrollToRowCentered(Subtitles.IndexOf(found));
         AudioVisualizerCenterOnPositionIfNeeded(found, foundSeconds);
         _updateAudioVisualizer = true;
     }
@@ -19886,6 +19888,25 @@ public partial class MainViewModel :
     private void CenterSelectedRowInSubtitleGrid(SubtitleLineViewModel itemToCenter)
     {
         TableViewExtras.CenterRow(SubtitleGrid, itemToCenter);
+    }
+
+    /// <summary>
+    /// The scroll follow-up <see cref="SelectAndScrollToRow(int,SubtitleLineViewModel?,bool?,bool)"/>
+    /// does, for the prev/next-line commands that must move the selection synchronously and so set
+    /// <see cref="SubtitleGrid"/>'s selected item themselves (play next/previous line): center the
+    /// row when "center when selecting prev/next row" is on, otherwise only nudge it fully into
+    /// view. Both halves are posted, so neither disturbs the selection just made.
+    /// </summary>
+    private void CenterOrEnsureRowVisibleInSubtitleGrid(SubtitleLineViewModel row)
+    {
+        if (Se.Settings.General.SubtitleGridCenterSelectedRow)
+        {
+            CenterSelectedRowInSubtitleGrid(row);
+        }
+        else
+        {
+            EnsureRowFullyVisibleInSubtitleGrid(row);
+        }
     }
 
     /// <summary>
@@ -28074,7 +28095,7 @@ public partial class MainViewModel :
                         var idx = Subtitles.IndexOf(_setEndAtKeyUpLine);
                         if (idx >= 0)
                         {
-                            SelectAndScrollToRow(idx + 1);
+                            SelectAndScrollToRowCentered(idx + 1);
                         }
 
                         _setEndAtKeyUpLine = null;

--- a/tests/UI/Features/Main/SubtitleGridCenterSelectedRowTests.cs
+++ b/tests/UI/Features/Main/SubtitleGridCenterSelectedRowTests.cs
@@ -7,7 +7,6 @@ using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Microsoft.Extensions.DependencyInjection;
 using Nikse.SubtitleEdit;
-using Nikse.SubtitleEdit.Controls.VideoPlayer;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic;
@@ -140,9 +139,10 @@ public class SubtitleGridCenterSelectedRowTests : IDisposable
         // instead of going through SelectAndScrollToRow, so it needs its own centering.
         Se.Settings.General.SubtitleGridCenterSelectedRow = true;
         var (window, vm) = ShowMainWindowWithLines(300);
-        vm.VideoPlayerControl = new VideoPlayerControl(new EmptyVideoPlayer());
         vm.SelectAndScrollToSubtitle(vm.Subtitles[100]);
         await SettleAsync(window);
+
+        Assert.NotNull(vm.GetVideoPlayerControl());
 
         var offsets = await Step(window, vm, 8, () => vm.PlayNextAndStopCommand.Execute(null));
 
@@ -155,7 +155,6 @@ public class SubtitleGridCenterSelectedRowTests : IDisposable
     {
         Se.Settings.General.SubtitleGridCenterSelectedRow = true;
         var (window, vm) = ShowMainWindowWithLines(300);
-        vm.VideoPlayerControl = new VideoPlayerControl(new EmptyVideoPlayer());
         vm.SelectAndScrollToSubtitle(vm.Subtitles[200]);
         await SettleAsync(window);
 
@@ -171,7 +170,6 @@ public class SubtitleGridCenterSelectedRowTests : IDisposable
         // "Go to next time code" walks the cue boundaries, i.e. a line at a time.
         Se.Settings.General.SubtitleGridCenterSelectedRow = true;
         var (window, vm) = ShowMainWindowWithLines(300);
-        vm.VideoPlayerControl = new VideoPlayerControl(new EmptyVideoPlayer());
         vm.SelectAndScrollToSubtitle(vm.Subtitles[100]);
         await SettleAsync(window);
 

--- a/tests/UI/Features/Main/SubtitleGridCenterSelectedRowTests.cs
+++ b/tests/UI/Features/Main/SubtitleGridCenterSelectedRowTests.cs
@@ -7,6 +7,7 @@ using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Microsoft.Extensions.DependencyInjection;
 using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Controls.VideoPlayer;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic;
@@ -129,6 +130,62 @@ public class SubtitleGridCenterSelectedRowTests : IDisposable
 
         Assert.Equal("Line 110", vm.SelectedSubtitle?.Text);
         Assert.Equal(before, scrollViewer.Offset.Y);
+    }
+
+    [AvaloniaFact]
+    public async Task PlayNextAndStop_Repeatedly_KeepsTheRowCentered()
+    {
+        // "Play next line (and stop)" - also what SE 4's Alt+Down ("go to next subtitle (play
+        // translate)", #14167) runs with a video open. It sets the grid's selection itself
+        // instead of going through SelectAndScrollToRow, so it needs its own centering.
+        Se.Settings.General.SubtitleGridCenterSelectedRow = true;
+        var (window, vm) = ShowMainWindowWithLines(300);
+        vm.VideoPlayerControl = new VideoPlayerControl(new EmptyVideoPlayer());
+        vm.SelectAndScrollToSubtitle(vm.Subtitles[100]);
+        await SettleAsync(window);
+
+        var offsets = await Step(window, vm, 8, () => vm.PlayNextAndStopCommand.Execute(null));
+
+        Assert.Equal(108, vm.SelectedSubtitleIndex);
+        AssertAllCentered(offsets);
+    }
+
+    [AvaloniaFact]
+    public async Task PlayPreviousAndStop_Repeatedly_KeepsTheRowCentered()
+    {
+        Se.Settings.General.SubtitleGridCenterSelectedRow = true;
+        var (window, vm) = ShowMainWindowWithLines(300);
+        vm.VideoPlayerControl = new VideoPlayerControl(new EmptyVideoPlayer());
+        vm.SelectAndScrollToSubtitle(vm.Subtitles[200]);
+        await SettleAsync(window);
+
+        var offsets = await Step(window, vm, 8, () => vm.PlayPreviousAndStopCommand.Execute(null));
+
+        Assert.Equal(192, vm.SelectedSubtitleIndex);
+        AssertAllCentered(offsets);
+    }
+
+    [AvaloniaFact]
+    public async Task GoToNextTimeCode_Repeatedly_KeepsTheRowCentered()
+    {
+        // "Go to next time code" walks the cue boundaries, i.e. a line at a time.
+        Se.Settings.General.SubtitleGridCenterSelectedRow = true;
+        var (window, vm) = ShowMainWindowWithLines(300);
+        vm.VideoPlayerControl = new VideoPlayerControl(new EmptyVideoPlayer());
+        vm.SelectAndScrollToSubtitle(vm.Subtitles[100]);
+        await SettleAsync(window);
+
+        // The position slider clamps Position to Duration, so give the stub player a length first.
+        var videoPlayer = vm.GetVideoPlayerControl()!;
+        videoPlayer.Duration = vm.Subtitles[^1].EndTime.TotalSeconds + 10;
+        videoPlayer.Position = vm.Subtitles[100].StartTime.TotalSeconds;
+        Assert.Equal(vm.Subtitles[100].StartTime.TotalSeconds, videoPlayer.Position);
+
+        // Two steps per line: its end time, then the next line's start time.
+        var offsets = await Step(window, vm, 16, () => vm.VideoGoToNextTimeCodeCommand.Execute(null));
+
+        Assert.Equal(108, vm.SelectedSubtitleIndex);
+        AssertAllCentered(offsets);
     }
 
     private static async Task<List<double>> Step(Window window, MainViewModel vm, int steps, Action move)


### PR DESCRIPTION
Follow-up to #14236. That PR taught the six go-to-previous/next-line commands and the grid's arrow/page keys to re-center on every step with **"Subtitle grid, center when selecting prev/next row"** on. The reporter of #14231 says it still misbehaves on beta 28 — and the fix *is* in beta 28 (the tag's commit includes it), so three more ways of stepping a line at a time were simply left on the old behaviour: they scrolled only once the target row had walked off the bottom of the view, and then jumped half a screen.

### What was still missing

| Path | Before | After |
| --- | --- | --- |
| `PlayNextParagraph` / `PlayPreviousParagraph` — "play next/previous line (and stop/loop)" | sets the grid's `SelectedItem` + `ScrollIntoView` itself, so it never reached the centering in `SelectAndScrollToRow` | new `CenterOrEnsureRowVisibleInSubtitleGrid` follow-up |
| `GoToNearestTimeCode` — "go to next/previous time code" | `SelectAndScrollToRow` | `SelectAndScrollToRowCentered` |
| "set end time and go to next" (position timer key-up handling) | `SelectAndScrollToRow` | `SelectAndScrollToRowCentered` |

The play commands are the interesting ones: with a video open, SE 4's Alt+Down default — "go to next subtitle (play translate)" (#14167) — runs `PlayNextParagraph`, i.e. the line-by-line translate/sync loop where this setting matters most. They move the selection synchronously on purpose (a posted selection would be nulled by the `SelectionChanged` handler's `ResetPlaySelection` and break stop/loop), so they get the same *posted* scroll follow-up `SelectAndScrollToRow` does: center when the setting is on, otherwise only nudge the row fully into view.

### Tests

Three cases added to `SubtitleGridCenterSelectedRowTests`, each measuring the selected row's middle against the viewport's middle over 8–16 steps. All three fail on `main` with the pre-fix signature (a clean drift of one row height per step) and pass with the change.

Note: `LibMpvEventLoopTests.Pause_RightAfterSeek_KeepsReportingTheSeekTarget` fails on a clean checkout of `main` as well — pre-existing and unrelated to this change.

The second symptom in #14231 ("the list view suddenly jumps straight to the bottom") is not addressed here; it still has no known trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)