### PR TITLE
Fix mpv observed-pause staleness that dropped the clicked seek target

### DIFF
--- a/src/ui/Logic/VideoPlayers/IVideoPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/IVideoPlayer.cs
@@ -49,6 +49,11 @@ public interface IVideoPlayer
     /// Whether playback output has (re)started - a seek finished or a file started -
     /// since the given Stopwatch timestamp. Only meaningful when
     /// <see cref="SupportsPlaybackRestartEvents"/> is true.
+    /// <para>
+    /// While a seek issued through <see cref="Position"/> is still outstanding this answers for
+    /// that seek: it stays false until the restart caused by the newest seek has been seen, so a
+    /// restart from something else cannot be mistaken for "the seek has landed".
+    /// </para>
     /// </summary>
     bool HasPlaybackRestartedSince(long stopwatchTimestamp) => false;
 }

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -58,6 +58,14 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
     private volatile bool _observedTimePosValid; // false = property unavailable (no file) -> Position reports 0, like the live read
     private long _lastPlaybackRestartTimestamp; // Stopwatch ticks of the last MPV_EVENT_PLAYBACK_RESTART
 
+    // Seek generations. The Position setter hands each async seek an id; the event loop records
+    // which ids mpv has acknowledged (MPV_EVENT_COMMAND_REPLY) and, for every playback restart,
+    // the id generation that restart followed. See HasPlaybackRestartedSince for why a plain
+    // timestamp comparison is not enough.
+    private long _lastSeekCommandId;         // newest id handed out by the Position setter
+    private long _ackedSeekCommandId;        // newest id mpv has replied to (event thread)
+    private long _restartAckedSeekCommandId; // _ackedSeekCommandId as of the last restart
+
     [StructLayout(LayoutKind.Sequential)]
     private struct MpvOpenGlInitParams
     {
@@ -270,8 +278,14 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
     private const int MPV_FORMAT_DOUBLE = 5;
 
     private const int MPV_EVENT_SHUTDOWN = 1;
+    private const int MPV_EVENT_COMMAND_REPLY = 5;
     private const int MPV_EVENT_PLAYBACK_RESTART = 21;
     private const int MPV_EVENT_PROPERTY_CHANGE = 22;
+
+    // reply_userdata base for the async seek commands (see the Position setter). Command
+    // replies and property-change events carry reply_userdata from separate namespaces, but
+    // keeping seek ids far clear of the ObserveId* values leaves nothing to confuse.
+    private const ulong SeekReplyIdBase = 1UL << 32;
 
     // reply_userdata ids for the observed properties (see StartEventLoop)
     private const ulong ObserveIdPause = 1;
@@ -614,7 +628,20 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
 
             if (mpvEvent.eventId == MPV_EVENT_PLAYBACK_RESTART)
             {
+                // Timestamp first, generation second. HasPlaybackRestartedSince needs BOTH, so
+                // publishing the generation first would open a window where an old restart's
+                // timestamp is paired with this restart's generation - and the answer would then
+                // depend on the caller's timestamp rather than on one restart. In this order the
+                // half-published state fails the generation gate, i.e. reads as "not yet".
                 Interlocked.Exchange(ref _lastPlaybackRestartTimestamp, System.Diagnostics.Stopwatch.GetTimestamp());
+                Interlocked.Exchange(ref _restartAckedSeekCommandId, Interlocked.Read(ref _ackedSeekCommandId));
+            }
+            else if (mpvEvent.eventId == MPV_EVENT_COMMAND_REPLY && mpvEvent.replyUserdata >= SeekReplyIdBase)
+            {
+                // mpv ran one of our seeks. Its queue is FIFO and the reply is posted when the
+                // command runs, so every restart dequeued after this one can have been caused by
+                // this seek - and every restart dequeued before it cannot.
+                Interlocked.Exchange(ref _ackedSeekCommandId, (long)(mpvEvent.replyUserdata - SeekReplyIdBase));
             }
             else if (mpvEvent.eventId == MPV_EVENT_PROPERTY_CHANGE && mpvEvent.data != IntPtr.Zero)
             {
@@ -730,7 +757,21 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
     /// </summary>
     public bool HasPlaybackRestartedSince(long stopwatchTimestamp)
     {
-        return Interlocked.Read(ref _lastPlaybackRestartTimestamp) > stopwatchTimestamp;
+        if (Interlocked.Read(ref _lastPlaybackRestartTimestamp) <= stopwatchTimestamp)
+        {
+            return false;
+        }
+
+        // A restart stamped after the caller's timestamp is not on its own proof that the seek
+        // the caller cares about has landed: the event thread stamps restarts when it PROCESSES
+        // them, so a restart mpv queued earlier - the one that starting playback fires, say -
+        // can be dequeued, and stamped, after a seek issued in the meantime. That made a fresh
+        // seek look already finished, and Pause() then discarded the target it was about to
+        // reach (#14187). mpv's event queue is FIFO, so the honest test is the seek generation:
+        // a restart that was dequeued before the newest seek's own MPV_EVENT_COMMAND_REPLY
+        // cannot have been caused by that seek.
+        var pending = Interlocked.Read(ref _lastSeekCommandId);
+        return pending == 0 || Interlocked.Read(ref _restartAckedSeekCommandId) >= pending;
     }
 
     private static byte[] GetUtf8Bytes(string s)
@@ -1024,14 +1065,18 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
     /// form) holds the caller until the core's dispatch accepts the command - during a scrub
     /// or slider-drag seek storm on a heavy file that stall lands on the UI thread, once per
     /// mouse move. mpv_command_async returns as soon as the command is copied into the queue;
-    /// the core posts an MPV_EVENT_COMMAND_REPLY back, which the event loop drains (and
-    /// ignores - matching the synchronous path, whose seek result was never acted on either).
+    /// the core posts an MPV_EVENT_COMMAND_REPLY back, which the event loop drains - for seeks
+    /// it also reads it, as the marker that orders a seek against the playback restarts around
+    /// it (see <see cref="HasPlaybackRestartedSince"/>).
     /// mpv copies the argument array before returning, so the buffers are freed right away
     /// exactly like in <see cref="DoMpvCommand"/>. Falls back to the synchronous path when
-    /// the event loop is not running, so the reply events cannot pile up unread.
+    /// the event loop is not running, so the reply events cannot pile up unread -
+    /// <paramref name="queuedAsync"/> says which path ran, because only the async one produces
+    /// the MPV_EVENT_COMMAND_REPLY the seek generations are tracked by.
     /// </summary>
-    private int DoMpvCommandFireAndForget(params string[] args)
+    private int DoMpvCommandFireAndForget(ulong replyUserdata, out bool queuedAsync, params string[] args)
     {
+        queuedAsync = false;
         if (_mpv == IntPtr.Zero)
         {
             return 0;
@@ -1042,8 +1087,9 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
             return DoMpvCommand(args);
         }
 
+        queuedAsync = true;
         var mainPtr = AllocateUtf8IntPtrArrayWithSentinel(args, out var byteArrayPointers);
-        var result = _mpvCommandAsync(_mpv, 0, mainPtr);
+        var result = _mpvCommandAsync(_mpv, replyUserdata, mainPtr);
         foreach (var ptr in byteArrayPointers)
         {
             Marshal.FreeHGlobal(ptr);
@@ -1562,7 +1608,11 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         // that wants playback asks for it explicitly, but pause it here too: it is a user
         // property, so anything the user did to the previous file - or a play that ran while
         // this one was being picked - would otherwise carry over into this load.
-        DoMpvCommand("set", "pause", "yes");
+        if (DoMpvCommand("set", "pause", "yes") >= 0)
+        {
+            SetObservedPause(true);
+        }
+
         _pausedValue = null;
 
         // Before loadfile, not after: mpv applies "sid" when the file loads, and setting it
@@ -1679,6 +1729,10 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         {
             Se.LogError(new InvalidOperationException(GetErrorString(err)), "LibMpvDynamicPlayer PlayOrPause");
         }
+        else
+        {
+            RefreshObservedPause();
+        }
     }
 
     public void CloseFile()
@@ -1777,11 +1831,56 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
     }
 
 
+    /// <summary>
+    /// Writes the pause state we just commanded straight into the observed cache.
+    /// <see cref="IsPaused"/>/<see cref="IsPlaying"/> - and, through them, the paused-value
+    /// branch of the <see cref="Position"/> getter - read <c>_observedPause</c>, which only the
+    /// event thread updates when mpv's pause property-change event is dequeued. The pause
+    /// commands below are synchronous (mpv_command returns after the core has applied them), so
+    /// between the command returning and that event being processed the cache says the opposite
+    /// of the truth. A waveform click hits exactly that window: seek, then Pause(), then the
+    /// cursor reads Position - and with IsPaused still false the getter skipped the cached seek
+    /// target and served mpv's pre-seek time-pos (#14187).
+    ///
+    /// A pause change-event still queued from an earlier transition can briefly overwrite this
+    /// with its own (older) value, but the event for the command we just ran follows right
+    /// behind it and settles the cache again - and that is the same value we write here.
+    /// </summary>
+    private void SetObservedPause(bool paused)
+    {
+        _observedPause = paused;
+    }
+
+    /// <summary>
+    /// Re-reads mpv's pause property into the observed cache. Used after "cycle pause", where
+    /// the resulting state is the core's to decide rather than ours to predict.
+    /// </summary>
+    private void RefreshObservedPause()
+    {
+        if (_mpv == IntPtr.Zero || _mpvGetPropertyFlag == null)
+        {
+            return;
+        }
+
+        try
+        {
+            var pauseValue = 0;
+            if (_mpvGetPropertyFlag(_mpv, PropertyNamePause, MPV_FORMAT_FLAG, ref pauseValue) >= 0)
+            {
+                _observedPause = pauseValue != 0;
+            }
+        }
+        catch
+        {
+            // leave the cache to the event thread
+        }
+    }
+
     private double? _pausedValue;
 
     // Stopwatch timestamp of the last seek issued through the Position setter; 0 = none yet.
-    // Compared against the playback-restart timestamp so Pause() can tell a seek target that
-    // is still in flight (keep it) from one whose seek finished long ago (stale - clear it).
+    // Fed to HasPlaybackRestartedSince so Pause() can tell a seek target that is still in
+    // flight (keep it) from one whose seek finished long ago (stale - clear it).
     private long _lastSeekIssuedTimestamp;
 
     // Last raw time-pos seen by the Position getter/setter, used to gate the eof-reached
@@ -1915,11 +2014,22 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
             }
 
             // Fire-and-forget: seeks arrive in storms (scrubbing, slider drags, wheel steps -
-            // one per input event), every caller already treats the result as asynchronous
-            // (the playhead pin waits for the position to actually arrive), and the error
-            // result was never acted on here.
+            // one per input event) and every caller already treats the result as asynchronous
+            // (the playhead pin waits for the position to actually arrive). The reply id is the
+            // seek's generation marker, so "has this seek restarted yet?" can be answered from
+            // mpv's own event order rather than from two independently taken clock readings.
+            var seekId = Interlocked.Increment(ref _lastSeekCommandId);
             Interlocked.Exchange(ref _lastSeekIssuedTimestamp, System.Diagnostics.Stopwatch.GetTimestamp());
-            DoMpvCommandFireAndForget("seek", value.ToString(CultureInfo.InvariantCulture), "absolute");
+            var seekResult = DoMpvCommandFireAndForget(SeekReplyIdBase + (ulong)seekId, out var queuedAsync,
+                "seek", value.ToString(CultureInfo.InvariantCulture), "absolute");
+            if (!queuedAsync || seekResult < 0)
+            {
+                // No MPV_EVENT_COMMAND_REPLY is coming for this one - it ran synchronously, or
+                // mpv refused it - so nothing would ever advance the acknowledged generation and
+                // the seek would look in flight forever. Retire the id here instead.
+                Interlocked.Exchange(ref _ackedSeekCommandId, seekId);
+                Interlocked.Exchange(ref _restartAckedSeekCommandId, seekId);
+            }
         }
     }
 
@@ -2075,6 +2185,10 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         {
             Se.LogError(new InvalidOperationException(GetErrorString(err)), "LibMpvDynamicPlayer Stop pause");
         }
+        else
+        {
+            SetObservedPause(true);
+        }
 
         // Seek back to position 0
         err = DoMpvCommand("seek", "0", "absolute");
@@ -2101,6 +2215,10 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         {
             Se.LogError(new InvalidOperationException(GetErrorString(err)), "LibMpvDynamicPlayer play");
         }
+        else
+        {
+            SetObservedPause(false);
+        }
     }
 
     public void Pause()
@@ -2122,6 +2240,9 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         // second Position assignment no-ops in Avalonia because the property already holds
         // the value - so clearing here left the getter serving mpv's pre-seek position
         // until the async seek landed, and the cursor jumped away from the click (#14187).
+        // "In flight" means the newest seek's own playback restart has not been observed yet -
+        // HasPlaybackRestartedSince checks the seek generation, not just the clock, so a restart
+        // left over from starting playback cannot pass for this seek's.
         var seekInFlight = _eventLoopActive &&
                            Interlocked.Read(ref _lastSeekIssuedTimestamp) != 0 &&
                            !HasPlaybackRestartedSince(Interlocked.Read(ref _lastSeekIssuedTimestamp));
@@ -2134,6 +2255,10 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         if (err < 0)
         {
             Se.LogError(new InvalidOperationException(GetErrorString(err)), "LibMpvDynamicPlayer pause");
+        }
+        else
+        {
+            SetObservedPause(true);
         }
     }
 

--- a/tests/UI/Logic/VideoPlayers/LibMpvEventLoopTests.cs
+++ b/tests/UI/Logic/VideoPlayers/LibMpvEventLoopTests.cs
@@ -157,6 +157,114 @@ public class LibMpvEventLoopTests
     }
 
     /// <summary>
+    /// A restart is stamped when the event thread DEQUEUES it, not when mpv emitted it, so the
+    /// restart that opening the file fires can be stamped later than a seek issued in the
+    /// meantime - and "has anything restarted since some old moment?" would then answer yes for
+    /// a seek that has not run at all. mpv's event queue is FIFO, so the seek's own
+    /// MPV_EVENT_COMMAND_REPLY orders the two; while a seek is outstanding the answer must be
+    /// about that seek. Concretely: reporting a restart since the beginning of time while
+    /// reporting none since the seek was issued is the contradiction that broke Pause() (#14187).
+    /// </summary>
+    [Fact]
+    public async Task HasPlaybackRestartedSince_AnswersForTheOutstandingSeekNotAnOlderRestart()
+    {
+        var player = CreatePlayer();
+        if (player == null)
+        {
+            return; // no libmpv on this machine
+        }
+
+        var wavFileName = WriteTempWav();
+        try
+        {
+            await player.LoadFile(wavFileName);
+            Assert.True(await WaitUntilAsync(() => player.Duration > 1.0, 5000), "file never loaded");
+
+            player.Play();
+            Assert.True(await WaitUntilAsync(() => player.IsPlaying, 3000), "playback never started");
+
+            // Opening the file fires a restart of its own (unpausing does not) - that is the one
+            // that must not be mistaken for the seek's below. No seek has been issued yet, so
+            // this is a plain "any restart at all?" question; wait until it is definitely in.
+            Assert.True(await WaitUntilAsync(() => player.HasPlaybackRestartedSince(0), 5000),
+                "no playback restart arrived before the seek");
+
+            var beforeSeekTimestamp = Stopwatch.GetTimestamp();
+            player.Position = 1.2;
+
+            var landed = false;
+            var end = Environment.TickCount64 + 5000;
+            while (Environment.TickCount64 < end)
+            {
+                // "Since forever" first, "since the seek" second: read the other way round, a
+                // restart landing between the two reads would look like a violation. In this
+                // order a restart that lands mid-iteration simply satisfies both.
+                var restartedSinceForever = player.HasPlaybackRestartedSince(0);
+                landed = player.HasPlaybackRestartedSince(beforeSeekTimestamp);
+                Assert.False(restartedSinceForever && !landed,
+                    "a restart from before the seek passed for the outstanding seek's own restart");
+                if (landed)
+                {
+                    break;
+                }
+            }
+
+            Assert.True(landed, "the seek's playback restart never arrived");
+            Assert.True(player.HasPlaybackRestartedSince(0), "the landed seek should satisfy any older timestamp");
+        }
+        finally
+        {
+            player.Dispose();
+            TryDelete(wavFileName);
+        }
+    }
+
+    /// <summary>
+    /// The observed pause cache must be truthful the instant Play()/Pause()/PlayOrPause()
+    /// return. Those commands are synchronous - the core has applied them - but mpv's pause
+    /// property-change event only reaches the cache a moment later on the event thread, and
+    /// IsPaused/IsPlaying answer from that cache. The Position getter gates its cached
+    /// seek-target branch on IsPaused, so a stale "still playing" answer there is what let a
+    /// waveform click report mpv's pre-seek time-pos instead of the clicked position (#14187) -
+    /// a race the click test below only loses when the machine is busy.
+    /// </summary>
+    [Fact]
+    public async Task PlayAndPause_UpdateTheObservedPauseCacheImmediately()
+    {
+        var player = CreatePlayer();
+        if (player == null)
+        {
+            return; // no libmpv on this machine
+        }
+
+        var wavFileName = WriteTempWav();
+        try
+        {
+            await player.LoadFile(wavFileName);
+            Assert.True(await WaitUntilAsync(() => player.Duration > 1.0, 5000), "file never loaded");
+
+            player.Play();
+            Assert.True(player.IsPlaying, "IsPlaying still false on the very next read after Play()");
+            Assert.False(player.IsPaused, "IsPaused still true on the very next read after Play()");
+
+            player.Pause();
+            Assert.True(player.IsPaused, "IsPaused still false on the very next read after Pause()");
+            Assert.False(player.IsPlaying, "IsPlaying still true on the very next read after Pause()");
+
+            player.PlayOrPause();
+            Assert.True(player.IsPlaying, "IsPlaying still false on the very next read after PlayOrPause()");
+
+            player.PlayOrPause();
+            Assert.True(player.IsPaused, "IsPaused still false on the very next read after PlayOrPause()");
+        }
+        finally
+        {
+            player.Dispose();
+            TryDelete(wavFileName);
+        }
+    }
+
+    /// <summary>
     /// Issue #14187: a waveform click seeks first (pointer release) and pauses a moment later
     /// (tap) - and the second Position assignment no-ops at the Avalonia property layer, so the
     /// player-level setter never runs again after the pause. Pause() must therefore not clear


### PR DESCRIPTION
## The bug

`LibMpvEventLoopTests.Pause_RightAfterSeek_KeepsReportingTheSeekTarget` (the #14187 regression test) failed under full-suite load on any machine with a loadable libmpv, and passed in isolation. The suspected cause — `Pause()` clearing `_pausedValue` because a leftover playback restart post-dated the seek — turned out to be wrong. Tracing a failing run:

```
pos=0.12  isPaused=False  pausedValue=1.5  inFlightAtPause=True
seekTs=502951264544916  restartTs=502951117229958  delta=-147314958
```

`_pausedValue` was intact and `seekInFlight` was correctly `true`. The failure is one line further down, in the `Position` getter:

```csharp
if (_pausedValue.HasValue && IsPaused && !Se.Settings.General.UseFrameMode)
```

`IsPaused` answers from `_observedPause`, which **only the mpv event thread writes**, when the `pause` property-change event is dequeued. But the pause commands are synchronous — `mpv_command` returns after the core has applied them. For the moment until that event is processed the cache says the opposite of the truth, the guard fails, and the getter serves mpv's pre-seek `time-pos` instead of the clicked position.

That is exactly the #14187 waveform-click window: seek (pointer release), `Pause()` (tap), read `Position` (cursor pin release). So this is a real user-visible race, not only a test artifact.

The test only passed in isolation because mpv usually finished the seek fast enough that the *observed time-pos* already was the target — i.e. it passed for the wrong reason. Under load it was still `0.12`.

## The fix

Write the commanded pause state through into the observed cache after a successful synchronous pause command (`Pause` / `Play` / `Stop` / `LoadFile`). `PlayOrPause` uses `cycle pause`, where the resulting state is the core's to decide, so it re-reads the property rather than predicting it.

## Hardening

The #14187 logic leans on `HasPlaybackRestartedSince`, and that had a genuine (if never-observed) ordering hazard: a restart was stamped when the event thread **processed** it, not when mpv emitted it, so a restart queued earlier — opening a file fires one; unpausing, it turns out, does not — could be stamped after a seek issued in the meantime and pass for that seek's own restart, clearing a live seek target.

Each async seek now carries a generation id in its `mpv_command_async` `reply_userdata`. The event loop records which generation every restart followed, and `HasPlaybackRestartedSince` answers for the outstanding seek rather than for the clock alone. mpv's event queue is FIFO, so this rests on an ordering guarantee instead of on two independently taken clock readings.

Both #14187 invariants are unchanged: an in-flight seek target survives `Pause()`, and a long-settled one is not resurrected.

## Tests

Two new live-core regression tests, each of which fails without its fix **even in isolation** — unlike the click test, which only failed by luck:

- `PlayAndPause_UpdateTheObservedPauseCacheImmediately` — `IsPaused`/`IsPlaying` must be truthful on the very next read after each transition.
- `HasPlaybackRestartedSince_AnswersForTheOutstandingSeekNotAnOlderRestart` — reporting a restart since the beginning of time while reporting none since the seek was issued is the contradiction that broke `Pause()`.

Verified:
- Each fix confirmed causal by reverting it alone and watching the failure return (3/3 both ways).
- `LibMpvEventLoopTests` 8/8, 8 consecutive runs (was 1 failure every run).
- Full `dotnet test tests/UI/UITests.csproj`: 4275 passed, 1 skipped, 0 failed.

Tests need a loadable libmpv (verified against MacPorts `libmpv.2.dylib`); they still pass vacuously on runners without one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)