### PR TITLE
Make "one frame forward/back (with play)" step smoothly

### DIFF
--- a/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
+++ b/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
@@ -309,6 +309,19 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             Position = seconds;
         }
 
+        /// <summary>
+        /// Seeks the player and moves the position display with it. Prefer this over assigning
+        /// <see cref="Position"/> when the seek must happen: the styled property drops an
+        /// assignment equal to the value it already holds, so a caller landing on the spot the
+        /// display happens to show (a frame step parking back where the last tick reported)
+        /// would silently never reach the player.
+        /// </summary>
+        public void SeekTo(double seconds)
+        {
+            SetPositionDisplayOnly(seconds);
+            _videoPlayerInstance.Position = seconds;
+        }
+
         public int ContentWidth => _contentPresenter?.Bounds.Width > 0 ? (int)_contentPresenter.Bounds.Width : 0;
         public int ContentHeight => _contentPresenter?.Bounds.Height > 0 ? (int)_contentPresenter.Bounds.Height : 0;
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -690,6 +690,16 @@ public partial class MainViewModel :
     private const double PlayheadResyncOnPlayThresholdSeconds = 0.04; // ~one frame; below this the standing residual isn't worth moving the cursor for
     private long _frameStepFollowUntilTs; // a native frame step is in flight: treat mpv's un-pause as paused (see BeginFrameStepPlayheadFollow)
     private const double FrameStepFollowWindowMs = 1000; // safety cap; the window normally closes as soon as the step lands
+
+    // "One frame back/forward with play" (VideoOneFrameWithPlay): mpv really plays for the length of
+    // one frame, so the blip is kept from moving the waveform cursor - it is held on the frame that
+    // was stepped to - and is ended off mpv's own clock. See UpdateFrameStepPlayBlip.
+    private double? _frameStepPlayAnchorSeconds; // the frame the last blip stepped to; also the base for the next press
+    private double _frameStepPlayStopSeconds; // mpv's clock must reach this (one frame on) before the blip ends
+    private long _frameStepPlayStartTs;
+    private bool _frameStepPlayBlipping; // a blip is running: hold the cursor and watch for its end
+    private const double FrameStepPlaySeekWaitMs = 250; // players that can't report seek completion: assume the seek landed after this
+    private const double FrameStepPlayMaxMs = 700; // safety cap: end the blip even if mpv's clock never reaches the stop point
     private CancellationTokenSource _videoOpenTokenSource;
     private readonly HashSet<string> _waveformsBeingGenerated = new(StringComparer.OrdinalIgnoreCase);
     private readonly Lock _waveformsBeingGeneratedLock = new();
@@ -1678,6 +1688,7 @@ public partial class MainViewModel :
     // surface) can trigger it too, via the PlayPauseRequested wiring in InitVideoPlayer (#12233).
     internal void RequestPausePlayheadFreeze()
     {
+        CancelFrameStepPlayBlip(); // a pause supersedes a one-frame play blip too
         _pauseRequested = true;
         _playStartGate.PauseRequested(); // a pause supersedes any play still waiting to be observed
         _playheadPausedSettled = false; // reconcile the cursor to mpv's final frame once this pause settles
@@ -1691,6 +1702,7 @@ public partial class MainViewModel :
     // where the play-start gate is armed.
     internal void CancelPausePlayheadFreeze()
     {
+        CancelFrameStepPlayBlip(); // playback the user started must not be stopped by a stale blip
         _pauseRequested = false;
         _playStartGate.PlayRequested(Stopwatch.GetTimestamp());
     }
@@ -18348,9 +18360,10 @@ public partial class MainViewModel :
     }
 
     /// <summary>
-    /// SE4's "one frame back/forward with play": step one frame and play just that frame, so
-    /// the step gives audio/visual feedback. Runs through the play-selection stop, whose
-    /// park-one-frame-before-the-end rule lands the playhead exactly on the stepped-to frame.
+    /// SE4's "one frame back/forward with play": step one frame and play just that frame, so the
+    /// step gives audio as well as visual feedback. The blip is a real (very short) playback, but
+    /// it is not allowed to move the waveform cursor: the cursor is parked on the frame that was
+    /// stepped to and held there while mpv plays the frame out. See UpdateFrameStepPlayBlip.
     /// </summary>
     private void VideoOneFrameWithPlay(bool forward)
     {
@@ -18362,18 +18375,96 @@ public partial class MainViewModel :
 
         var fps = Se.Settings.General.CurrentFrameRate;
         var frameSeconds = fps >= 10 ? 1.0 / fps : 0.04;
-        var target = Math.Max(0, vp.Position + (forward ? frameSeconds : -frameSeconds));
 
-        vp.VideoPlayer.Pause();
-        vp.Position = target;
-        PinPlayheadTo(target);
-        var frameWindow = new SubtitleLineViewModel
+        // Step from the frame the previous press stepped to, not from the player's reported
+        // position: vp.Position is refreshed from mpv by a 50 ms timer and, right after a blip,
+        // holds mpv's overshoot (it keeps decoding for ~100 ms past a pause) rather than the frame
+        // the cursor is parked on. Chaining off that made a held-down shortcut advance a random
+        // one to four frames per press. Every other position change drops the anchor
+        // (CancelFrameStepPlayBlip); the distance check is a net for the ones that don't, exactly
+        // as the relative-seek tracker in MoveVideoPositionMs does it.
+        var from = _frameStepPlayAnchorSeconds is { } anchor && Math.Abs(anchor - vp.Position) < 0.5
+            ? anchor
+            : vp.Position;
+
+        var target = Math.Max(0, from + (forward ? frameSeconds : -frameSeconds));
+        if (vp.Duration > 0 && target > vp.Duration)
         {
-            StartTime = TimeSpan.FromSeconds(target),
-            EndTime = TimeSpan.FromSeconds(target + frameSeconds),
-        };
-        _playSelectionItem = new PlaySelectionItem([frameWindow], frameWindow.EndTime, false);
+            target = vp.Duration;
+        }
+
+        ResetPlaySelection();
+        vp.VideoPlayer.Pause();
+        vp.SeekTo(target);
+        PinPlayheadTo(target);
         PlayVideo(vp);
+
+        // After PlayVideo: it cancels a pending pause freeze, which also cancels a blip.
+        BeginFrameStepPlayBlip(target, target + frameSeconds);
+    }
+
+    /// <summary>
+    /// Arms the "one frame with play" blip started by <see cref="VideoOneFrameWithPlay"/>: mpv is
+    /// playing from <paramref name="anchorSeconds"/> and must be stopped again once its clock
+    /// reaches <paramref name="stopSeconds"/>, one frame on.
+    /// </summary>
+    private void BeginFrameStepPlayBlip(double anchorSeconds, double stopSeconds)
+    {
+        _frameStepPlayAnchorSeconds = anchorSeconds;
+        _frameStepPlayStopSeconds = stopSeconds;
+        _frameStepPlayStartTs = Stopwatch.GetTimestamp();
+        _frameStepPlayBlipping = true;
+    }
+
+    /// <summary>
+    /// Ends a "one frame with play" blip once mpv has actually played the frame, and parks the
+    /// player back on it. Driven from the 16 ms cursor timer and measured against mpv's own clock:
+    /// the play-selection stop this used to run through ticks at 50 ms and compares the *cursor
+    /// estimate*, so a one-frame window overshot by 50-150 ms - the cursor glided a few frames
+    /// forward and then snapped back on every single press.
+    /// </summary>
+    private void UpdateFrameStepPlayBlip(VideoPlayerControl vp)
+    {
+        if (!_frameStepPlayBlipping)
+        {
+            return;
+        }
+
+        var player = vp.VideoPlayer;
+        var elapsedMs = (Stopwatch.GetTimestamp() - _frameStepPlayStartTs) * 1000.0 / Stopwatch.Frequency;
+
+        // The seek onto the frame is asynchronous, so until it lands mpv's clock still reports the
+        // spot we came from - which for a backward step is already past the stop point and would
+        // end the blip before it played anything.
+        var seekLanded = player.SupportsPlaybackRestartEvents
+            ? player.HasPlaybackRestartedSince(_frameStepPlayStartTs)
+            : elapsedMs > FrameStepPlaySeekWaitMs;
+
+        var frameIsPlayedOut = seekLanded && player.Position >= _frameStepPlayStopSeconds;
+        if (!frameIsPlayedOut && elapsedMs < FrameStepPlayMaxMs)
+        {
+            return;
+        }
+
+        _frameStepPlayBlipping = false;
+        var anchor = _frameStepPlayAnchorSeconds ?? player.Position;
+        PauseVideoAndFreezePlayhead(vp);
+        vp.SeekTo(anchor);
+        PinPlayheadTo(anchor);
+
+        // Pausing and pinning are seek paths and clear the anchor; this one *is* the anchor, and
+        // the next press chains off it.
+        _frameStepPlayAnchorSeconds = anchor;
+    }
+
+    /// <summary>
+    /// Drops a running "one frame with play" blip. Called from every play/pause/seek path, so a
+    /// blip can never pause playback the user started afterwards, or hold the cursor off a seek.
+    /// </summary>
+    private void CancelFrameStepPlayBlip()
+    {
+        _frameStepPlayBlipping = false;
+        _frameStepPlayAnchorSeconds = null;
     }
 
     /// <summary>
@@ -19234,6 +19325,7 @@ public partial class MainViewModel :
         // relative-seek tracker so the next small step resyncs to the real position.
         // MoveVideoPositionMs re-arms it immediately after calling this. (#12027)
         _relativeSeekTargetSeconds = null;
+        CancelFrameStepPlayBlip(); // ...and the frame-with-play anchor, for the same reason
 
         var vp = GetVideoPlayerControl();
         if (vp == null || string.IsNullOrEmpty(_videoFileName) || AudioVisualizer == null)
@@ -27805,6 +27897,24 @@ public partial class MainViewModel :
 
         var nowTimestamp = Stopwatch.GetTimestamp();
 
+        // A "one frame back/forward with play" blip is running (see VideoOneFrameWithPlay): mpv is
+        // genuinely playing, but only for the length of the frame that was just stepped to, and the
+        // cursor belongs on that frame. Letting it track playback made it glide a few frames forward
+        // and then snap back when the blip parked - the jerky, seemingly random cursor motion of
+        // holding the shortcut down. The blip is cancelled by every other play/pause/seek path, so
+        // this can't hold the cursor against playback the user started.
+        if (_frameStepPlayBlipping && _frameStepPlayAnchorSeconds is { } blipAnchor)
+        {
+            _playheadLastRealSeconds = rawPosition;
+            _playheadLastTimestamp = nowTimestamp;
+            _playheadLastRawChangeTs = nowTimestamp;
+            _playheadEstimateSeconds = blipAnchor;
+            _playheadValid = true;
+            _playheadPausedSettled = true; // the cursor is authoritative on the frame, as after a pinned seek
+            _playheadWasPlaying = false; // the blip's own pause must not read as a play -> pause edge
+            return blipAnchor;
+        }
+
         // A native frame step is in flight: mpv's `frame-step` is a real un-pause (it sets pause=no,
         // plays until the next video frame, then sets pause=yes), so the observed pause flag flickers
         // and reads here as a play->pause cycle. That cleared _playheadPausedSettled on the very tick
@@ -28096,6 +28206,7 @@ public partial class MainViewModel :
     /// </summary>
     private void BeginFrameStepPlayheadFollow()
     {
+        CancelFrameStepPlayBlip(); // a native step moves the play-head off the blip's frame
         _frameStepFollowUntilTs = Stopwatch.GetTimestamp() +
                                  (long)(Stopwatch.Frequency * FrameStepFollowWindowMs / 1000.0);
         _playheadPausedSettled = true; // stepping: the cursor is at the current frame and follows to the next one
@@ -28105,6 +28216,7 @@ public partial class MainViewModel :
     // immediately and pin it there until mpv's clock catches up (see UpdatePlayheadEstimate).
     private void PinPlayheadTo(double targetSeconds)
     {
+        CancelFrameStepPlayBlip(); // any other seek moves the cursor off the stepped-to frame
         _playheadSeekTarget = targetSeconds;
         _playheadSeekTargetTs = Stopwatch.GetTimestamp();
         _playheadEstimateSeconds = targetSeconds;
@@ -28407,6 +28519,11 @@ public partial class MainViewModel :
                     PinPlayheadTo(target);
                 }
             }
+
+            // End a "one frame back/forward with play" blip as soon as mpv has played the frame.
+            // Checked here rather than from the 50 ms position timer so the blip is one frame long
+            // instead of one-frame-plus-however-long-that-timer-took-to-notice.
+            UpdateFrameStepPlayBlip(vp);
 
             // Always advance the estimate: the 50 ms _positionTimer reads _playheadEstimateSeconds as
             // its source of truth (SelectCurrentSubtitleWhilePlaying, play-selection end detection, the

--- a/tests/UI/Features/Main/PlayheadFrameStepTests.cs
+++ b/tests/UI/Features/Main/PlayheadFrameStepTests.cs
@@ -1,12 +1,14 @@
-using Avalonia.Headless.XUnit;
+﻿using Avalonia.Headless.XUnit;
 using Microsoft.Extensions.DependencyInjection;
 using Nikse.SubtitleEdit;
 using Nikse.SubtitleEdit.Controls.VideoPlayer;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.VideoPlayers;
 using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
 using System;
+using System.Diagnostics;
 using System.Reflection;
 using System.Threading.Tasks;
 
@@ -59,6 +61,13 @@ public class PlayheadFrameStepTests
         public int VolumeMaximum => 100;
         public double Volume { get; set; } = 50;
         public double Speed { get; set; } = 1.0;
+
+        // The frame-with-play blip waits for the seek onto the frame to land before it starts
+        // watching mpv's clock; tests drive that signal explicitly instead of waiting on a clock.
+        public bool SupportsPlaybackRestartEvents => PlaybackRestartTimestamp.HasValue;
+        public long? PlaybackRestartTimestamp { get; set; }
+        public bool HasPlaybackRestartedSince(long stopwatchTimestamp) =>
+            PlaybackRestartTimestamp is { } ts && ts >= stopwatchTimestamp;
     }
 
     [AvaloniaFact]
@@ -132,6 +141,85 @@ public class PlayheadFrameStepTests
         Assert.Equal(1.0, Tick(vm, vp, isPlaying: false), 4);
     }
 
+    [AvaloniaFact]
+    public void FrameStepWithPlay_HoldsTheCursorOnTheSteppedFrameWhileTheFramePlays()
+    {
+        var (vm, vp, player) = MakeViewModelWithPlayer(startSeconds: 1.0);
+
+        StepOneFrameWithPlay(vm, forward: true);
+        var frame = 1.0 + FrameSeconds;
+
+        // mpv is really playing for the length of the frame - and then keeps decoding past it for
+        // ~100 ms after the pause. None of that may move the cursor off the frame we stepped to.
+        Assert.Equal(frame, Tick(vm, vp, isPlaying: true), 4);
+        player.Position = frame + 0.03;
+        Assert.Equal(frame, Tick(vm, vp, isPlaying: true), 4);
+        player.Position = frame + 0.12;
+        Assert.Equal(frame, Tick(vm, vp, isPlaying: true), 4);
+    }
+
+    [AvaloniaFact]
+    public void FrameStepWithPlay_Repeated_AdvancesExactlyOneFramePerPress()
+    {
+        var (vm, vp, player) = MakeViewModelWithPlayer(startSeconds: 1.0);
+
+        for (var step = 1; step <= 10; step++)
+        {
+            StepOneFrameWithPlay(vm, forward: true);
+            Assert.Equal(1.0 + (step * FrameSeconds), player.Position, 4);
+
+            // The previous blip is still winding down when the next press arrives: mpv's clock (and
+            // so the control's 50 ms position display) sits past the frame. Chaining off that made
+            // each press jump a random one to four frames.
+            Tick(vm, vp, isPlaying: true);
+            player.Position += 0.09;
+            vp.SetPositionDisplayOnly(player.Position);
+            Tick(vm, vp, isPlaying: true);
+        }
+    }
+
+    [AvaloniaFact]
+    public void FrameStepWithPlay_Blip_StopsAndParksOnTheFrameOnceItHasPlayed()
+    {
+        var (vm, vp, player) = MakeViewModelWithPlayer(startSeconds: 1.0);
+
+        StepOneFrameWithPlay(vm, forward: true);
+        var frame = 1.0 + FrameSeconds;
+        Assert.True(player.IsPlaying);
+
+        // The seek onto the frame hasn't landed yet, so mpv's clock says nothing about the frame.
+        UpdateBlip(vm, vp);
+        Assert.True(player.IsPlaying);
+
+        player.PlaybackRestartTimestamp = Stopwatch.GetTimestamp();
+        UpdateBlip(vm, vp);
+        Assert.True(player.IsPlaying); // the frame itself hasn't played out yet
+
+        player.Position = frame + FrameSeconds;
+        UpdateBlip(vm, vp);
+
+        Assert.False(player.IsPlaying);
+        Assert.Equal(frame, player.Position, 4); // parked back on the frame that was stepped to
+        Assert.Equal(frame, Tick(vm, vp, isPlaying: false), 4);
+    }
+
+    [AvaloniaFact]
+    public void FrameStepWithPlay_Blip_IsDroppedWhenPlaybackIsStartedAfterIt()
+    {
+        // A stale blip must never pause playback the user started, nor hold the cursor on its frame.
+        var (vm, vp, player) = MakeViewModelWithPlayer(startSeconds: 1.0);
+
+        StepOneFrameWithPlay(vm, forward: true);
+        vm.CancelPausePlayheadFreeze(); // what every play path does
+
+        player.PlaybackRestartTimestamp = Stopwatch.GetTimestamp();
+        player.Position = 5.0;
+        UpdateBlip(vm, vp);
+
+        Assert.True(player.IsPlaying);
+        Assert.Equal(5.0, player.Position, 4);
+    }
+
     private static (MainViewModel Vm, VideoPlayerControl Vp, FakeVideoPlayer Player) MakeViewModelWithPlayer(double startSeconds)
     {
         var services = new ServiceCollection();
@@ -142,6 +230,11 @@ public class PlayheadFrameStepTests
         var player = new FakeVideoPlayer { Position = startSeconds };
         var vp = new VideoPlayerControl(player);
 
+        Se.Settings.General.CurrentFrameRate = 23.976;
+        vm.VideoPlayerControl = vp;
+        vp.SetPositionDisplayOnly(startSeconds);
+        SetField(vm, "_videoFileName", "video.mkv");
+
         // Paused at startSeconds, settled, with the cursor already on that spot.
         SetField(vm, "_playheadEstimateSeconds", startSeconds);
         SetField(vm, "_playheadLastRealSeconds", startSeconds);
@@ -151,6 +244,16 @@ public class PlayheadFrameStepTests
 
         return (vm, vp, player);
     }
+
+    private static void StepOneFrameWithPlay(MainViewModel vm, bool forward) =>
+        typeof(MainViewModel)
+            .GetMethod("VideoOneFrameWithPlay", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(vm, [forward]);
+
+    private static void UpdateBlip(MainViewModel vm, VideoPlayerControl vp) =>
+        typeof(MainViewModel)
+            .GetMethod("UpdateFrameStepPlayBlip", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(vm, [vp]);
 
     private static void BeginFrameStep(MainViewModel vm) =>
         typeof(MainViewModel)

--- a/tests/UI/Features/Main/PlayheadFrameStepTests.cs
+++ b/tests/UI/Features/Main/PlayheadFrameStepTests.cs
@@ -24,9 +24,26 @@ namespace UITests.Features.Main;
 /// 0.5 s discontinuity snap caught up. (`frame-back-step` seeks and stays paused, which is why
 /// stepping backwards always landed correctly.)
 /// </summary>
-public class PlayheadFrameStepTests
+public class PlayheadFrameStepTests : IDisposable
 {
     private const double FrameSeconds = 1.0 / 23.976;
+
+    // Tests that drive commands through GetVideoPlayerControl() must not leave their test-built
+    // VideoPlayerControl assigned to the view model: an unparented control left reachable on the
+    // per-assembly headless application is the documented contamination-cascade trigger - unrelated
+    // windows start failing out of the compositor on CI, a different victim per run (PR #14258).
+    private MainViewModel? _vm;
+    private readonly double _originalFrameRate = Se.Settings.General.CurrentFrameRate;
+
+    public void Dispose()
+    {
+        if (_vm != null)
+        {
+            _vm.VideoPlayerControl = null;
+        }
+
+        Se.Settings.General.CurrentFrameRate = _originalFrameRate;
+    }
 
     private sealed class FakeVideoPlayer : IVideoPlayer
     {
@@ -220,7 +237,7 @@ public class PlayheadFrameStepTests
         Assert.Equal(5.0, player.Position, 4);
     }
 
-    private static (MainViewModel Vm, VideoPlayerControl Vp, FakeVideoPlayer Player) MakeViewModelWithPlayer(double startSeconds)
+    private (MainViewModel Vm, VideoPlayerControl Vp, FakeVideoPlayer Player) MakeViewModelWithPlayer(double startSeconds)
     {
         var services = new ServiceCollection();
         services.AddSubtitleEditServices();
@@ -232,6 +249,7 @@ public class PlayheadFrameStepTests
 
         Se.Settings.General.CurrentFrameRate = 23.976;
         vm.VideoPlayerControl = vp;
+        _vm = vm; // detached again in Dispose - see the cascade note on the field
         vp.SetPositionDisplayOnly(startSeconds);
         SetField(vm, "_videoFileName", "video.mkv");
 


### PR DESCRIPTION
Reported: *"Play next frame with play shortcut is very jerky - waveform cursor jumps back and jumps seem a bit erratic."*

### What was wrong

`VideoOneFrameWithPlay` faked its one-frame blip with a play-selection window and let the normal machinery stop it. Three things fell out of that:

1. **The jump back.** The play-selection stop is checked on the **50 ms** position timer, against the *cursor estimate*. A one-frame window is 33-40 ms, so it always overshot: mpv played 50-150 ms past the frame with the cursor gliding along, and the stop then parked back one frame. Every press: glide forward two to four frames, snap back.
2. **The erratic step size.** The next press computed its target from `vp.Position` - a styled property refreshed from mpv by *another* 50 ms timer, which right after a blip holds mpv's overshoot rather than the frame the cursor is parked on. A held-down shortcut advanced a random one to four frames per press.
3. How far it ran depended on where the timer tick happened to fall, which is why it looked random rather than merely late.

### The fix

The blip is now its own small state machine (`BeginFrameStepPlayBlip` / `UpdateFrameStepPlayBlip` / `CancelFrameStepPlayBlip`) instead of a play-selection:

- It ends from the **16 ms cursor timer**, measured against **mpv's own clock**, and waits for `MPV_EVENT_PLAYBACK_RESTART` first so the async seek onto the frame has landed - a backward step's pre-seek clock is already past the stop point and would end the blip before it played anything. 700 ms safety cap.
- `UpdatePlayheadEstimate` **holds the cursor on the stepped-to frame** for the duration of the blip, so it no longer glides forward and snaps back. Every other play/pause/seek path cancels the blip, so it can never hold the cursor against playback the user started, nor pause it.
- Each press chains off the frame the previous press stepped to, so the step is exactly one frame every time.

Also adds `VideoPlayerControl.SeekTo`: assigning `Position` silently no-ops when it equals the value the styled property already holds, which the park-back-onto-the-frame seek can hit.

### Tests

Four new cases in `tests/UI/Features/Main/PlayheadFrameStepTests.cs` (fake `IVideoPlayer` + reflection onto the private estimator, the harness from #14245): the cursor holds on the frame through the blip and the pause wind-down, ten chained presses advance exactly one frame each, the blip stops and parks on the frame once mpv has played it, and a blip is dropped when playback is started after it. 8/8 pass.

Unrelated: `LibMpvEventLoopTests.Pause_RightAfterSeek_KeepsReportingTheSeekTarget` fails on this branch - that is the known flaky one whose fix is in #14259, and nothing here touches `LibMpvDynamicPlayer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)