### PR TITLE
Waveform seek review: SMPTE seek drift, unpinned nudges, blip clock mix

### DIFF
--- a/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
+++ b/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
@@ -280,10 +280,24 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             // First update our property
             Position = newPosition;
 
-            _videoPlayerInstance.Position = newPosition;
+            _videoPlayerInstance.Position = UiToPlayerSeconds(newPosition);
 
             // Then notify listeners like the ViewModel
             PositionChanged?.Invoke(newPosition);
+        }
+
+        /// <summary>
+        /// UI position values (the <see cref="Position"/> property, the sliders, the waveform
+        /// time axis) run on the SMPTE drop-frame clock while <see cref="IsSmpteTimingEnabled"/>:
+        /// every read from the player is compressed by 1000/1001 (the position timer below, the
+        /// view model's playhead estimator, the waveform peaks). A seek must expand the UI value
+        /// back to the player's real clock, or every seek lands 0.1% early - proportional to the
+        /// absolute position, about a second per 17 minutes - and the playhead pin, whose arrive
+        /// check compares in UI space, then snaps the cursor back once its timeout expires.
+        /// </summary>
+        private double UiToPlayerSeconds(double seconds)
+        {
+            return IsSmpteTimingEnabled ? seconds * 1001.0 / 1000.0 : seconds;
         }
 
         public void SetPosition(double seconds)
@@ -319,7 +333,7 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
         public void SeekTo(double seconds)
         {
             SetPositionDisplayOnly(seconds);
-            _videoPlayerInstance.Position = seconds;
+            _videoPlayerInstance.Position = UiToPlayerSeconds(seconds);
         }
 
         public int ContentWidth => _contentPresenter?.Bounds.Width > 0 ? (int)_contentPresenter.Bounds.Width : 0;

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -18433,6 +18433,14 @@ public partial class MainViewModel :
         var player = vp.VideoPlayer;
         var elapsedMs = (Stopwatch.GetTimestamp() - _frameStepPlayStartTs) * 1000.0 / Stopwatch.Frequency;
 
+        // The anchor/stop values live in UI time, which in SMPTE mode is the drop-frame clock;
+        // compress the player's real clock the same way the estimator does before comparing.
+        var playerPosition = player.Position;
+        if (IsSmpteTimingEnabled)
+        {
+            playerPosition = playerPosition * 1000.0 / 1001.0;
+        }
+
         // The seek onto the frame is asynchronous, so until it lands mpv's clock still reports the
         // spot we came from - which for a backward step is already past the stop point and would
         // end the blip before it played anything.
@@ -18440,14 +18448,14 @@ public partial class MainViewModel :
             ? player.HasPlaybackRestartedSince(_frameStepPlayStartTs)
             : elapsedMs > FrameStepPlaySeekWaitMs;
 
-        var frameIsPlayedOut = seekLanded && player.Position >= _frameStepPlayStopSeconds;
+        var frameIsPlayedOut = seekLanded && playerPosition >= _frameStepPlayStopSeconds;
         if (!frameIsPlayedOut && elapsedMs < FrameStepPlayMaxMs)
         {
             return;
         }
 
         _frameStepPlayBlipping = false;
-        var anchor = _frameStepPlayAnchorSeconds ?? player.Position;
+        var anchor = _frameStepPlayAnchorSeconds ?? playerPosition;
         PauseVideoAndFreezePlayhead(vp);
         vp.SeekTo(anchor);
         PinPlayheadTo(anchor);
@@ -19343,7 +19351,14 @@ public partial class MainViewModel :
             newPosition = vp.Duration;
         }
 
-        vp.Position = newPosition;
+        // SeekTo, not the Position property: an assignment equal to the currently displayed
+        // value silently no-ops at the styled-property layer and the seek never reaches the
+        // player. And pin like the waveform click/scrub paths do - without it the cursor sat
+        // on the old position for the 100-200 ms the seek takes while the view below had
+        // already scrolled to the target, so keyboard nudges and snapped frame steps read as
+        // laggy next to a click.
+        vp.SeekTo(newPosition);
+        PinPlayheadTo(newPosition);
 
         if (vp.IsPlaying)
         {

--- a/tests/UI/Controls/VideoPlayerControlSmpteSeekTests.cs
+++ b/tests/UI/Controls/VideoPlayerControlSmpteSeekTests.cs
@@ -1,0 +1,77 @@
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Controls.VideoPlayer;
+using Nikse.SubtitleEdit.Logic.VideoPlayers;
+using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace UITests.Controls;
+
+/// <summary>
+/// SMPTE drop-frame seeks. While SMPTE timing is enabled every position READ from the player is
+/// compressed by 1000/1001 before it reaches the UI (the control's position timer, the playhead
+/// estimator, the waveform time axis), so UI position values live on the drop-frame clock. A seek
+/// must expand its UI value back to the player's real clock - passing it through unchanged lands
+/// every seek 0.1% early, proportional to the absolute position (about a second per 17 minutes),
+/// and the playhead pin then snapped the waveform cursor back once its 600 ms timeout expired.
+/// </summary>
+public class VideoPlayerControlSmpteSeekTests
+{
+    private sealed class RecordingVideoPlayer : IVideoPlayer
+    {
+        public string Name => "recording";
+        public string FileName { get; private set; } = string.Empty;
+        public bool CanLoad() => true;
+
+        public Task LoadFile(string fileName, double startPositionSeconds = 0)
+        {
+            FileName = fileName;
+            Position = startPositionSeconds;
+            return Task.CompletedTask;
+        }
+
+        public void CloseFile() => FileName = string.Empty;
+        public void Play() => IsPlaying = true;
+        public void PlayOrPause() => IsPlaying = !IsPlaying;
+        public void Pause() => IsPlaying = false;
+        public void Stop() => IsPlaying = false;
+        public AudioTrackInfo? ToggleAudioTrack() => null;
+
+        public bool IsPlaying { get; set; }
+        public bool IsPaused => !IsPlaying;
+        public double Position { get; set; }
+        public double Duration => 7200;
+        public int VolumeMaximum => 100;
+        public double Volume { get; set; } = 50;
+        public double Speed { get; set; } = 1.0;
+    }
+
+    [AvaloniaFact]
+    public void SeekTo_WithSmpteTiming_ExpandsToThePlayersRealClock()
+    {
+        var player = new RecordingVideoPlayer();
+        var control = new VideoPlayerControl(player) { IsSmpteTimingEnabled = true };
+        control.Duration = 7200; // published before seeking, or the bound slider clamps the display write
+
+        control.SeekTo(3600);
+
+        // The player's clock runs 1001/1000 relative to the UI's drop-frame clock; a read of the
+        // landed position compresses back to exactly the requested UI value.
+        Assert.Equal(3600 * 1001.0 / 1000.0, player.Position, 4);
+        Assert.Equal(3600, player.Position * 1000.0 / 1001.0, 4);
+        Assert.Equal(3600, control.Position, 4); // the display shows the UI value, unexpanded
+    }
+
+    [AvaloniaFact]
+    public void SeekTo_WithoutSmpteTiming_PassesTheValueThrough()
+    {
+        var player = new RecordingVideoPlayer();
+        var control = new VideoPlayerControl(player);
+        control.Duration = 7200; // published before seeking, or the bound slider clamps the display write
+
+        control.SeekTo(3600);
+
+        Assert.Equal(3600, player.Position, 4);
+        Assert.Equal(3600, control.Position, 4);
+    }
+}

--- a/tests/UI/Features/Main/PlayheadFrameStepTests.cs
+++ b/tests/UI/Features/Main/PlayheadFrameStepTests.cs
@@ -40,6 +40,7 @@ public class PlayheadFrameStepTests : IDisposable
         if (_vm != null)
         {
             _vm.VideoPlayerControl = null;
+            _vm.AudioVisualizer = null;
         }
 
         Se.Settings.General.CurrentFrameRate = _originalFrameRate;
@@ -235,6 +236,26 @@ public class PlayheadFrameStepTests : IDisposable
 
         Assert.True(player.IsPlaying);
         Assert.Equal(5.0, player.Position, 4);
+    }
+
+    [AvaloniaFact]
+    public void KeyboardNudgeSeek_PinsTheCursorToTheTargetImmediately()
+    {
+        // MoveVideoPositionMs / snapped frame steps route through SetVideoPositionSeconds. It
+        // scrolls the view to the target at once, so without a pin the cursor sat on the old
+        // position for the 100-200 ms the seek takes and the nudge read as laggy next to a
+        // waveform click (which always pinned).
+        var (vm, vp, player) = MakeViewModelWithPlayer(startSeconds: 5.0);
+        vp.Duration = 60; // published, or the bound position slider clamps the display write
+        vm.AudioVisualizer = new Nikse.SubtitleEdit.Controls.AudioVisualizerControl.AudioVisualizer(); // detached in Dispose
+
+        typeof(MainViewModel)
+            .GetMethod("SetVideoPositionSeconds", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(vm, [7.5]);
+
+        Assert.Equal(7.5, GetField<double?>(vm, "_playheadSeekTarget") ?? -1, 4); // pinned
+        Assert.Equal(7.5, player.Position, 4); // and the seek really reached the player
+        Assert.Equal(7.5, Tick(vm, vp, isPlaying: false), 4); // cursor shows the target at once
     }
 
     private (MainViewModel Vm, VideoPlayerControl Vp, FakeVideoPlayer Player) MakeViewModelWithPlayer(double startSeconds)


### PR DESCRIPTION
Findings from a review of waveform responsiveness and accuracy, focused on the seek paths (the render loop and drag paths were audited too — those are already well-cached and correct; details in the review notes below).

### 1. SMPTE drop-frame seeks land 0.1% early (accuracy)

While SMPTE timing is enabled, every position **read** from the player is compressed by 1000/1001 — the control's 50 ms position timer, the playhead estimator, and the waveform time axis itself (`UseSmpteDropFrameTime` drops one peak in 1001). So all UI position values live on the drop-frame clock. But every **seek** passed those UI values to the player as real seconds, landing early in proportion to the absolute position — about a second per 17 minutes. Past ~2.5 minutes into a video the error exceeds the playhead pin's 0.15 s arrive tolerance, so every waveform click pinned the cursor to the click, timed out after 600 ms, and visibly snapped back. Seeks (`NotifyPositionChanged` and `SeekTo`) now expand UI values by 1001/1000 back to the player's real clock.

### 2. Keyboard nudges never pinned the cursor (responsiveness)

`SetVideoPositionSeconds` — the ±100 ms / custom-ms shortcuts and snap-to-frames frame stepping — scrolled the waveform view to the target immediately but left the cursor waiting the 100–200 ms the async seek takes, so nudges read as laggy next to a waveform click or wheel scrub (which always pinned). It now seeks via `SeekTo` (the `Position`-property assignment silently no-ops when equal to the displayed value) and pins like every other seek path.

### 3. Frame-with-play blip mixed clocks in SMPTE mode

The blip's stop point is UI (drop-frame) time but it compared against the player's real clock, so far into a file the "frame played out" check tripped immediately and the blip degenerated to a silent step. The read is now compressed the same way the estimator's is.

### Reviewed and found sound

- Waveform/timeline/paragraph rendering: geometry and FormattedText caches keyed on 256 px anchor blocks, whole-pixel translation — no per-frame rebuild during playback.
- Shot-change lookup per frame: binary search.
- Wheel scrub: leading-edge seek + 100 ms throttle + trailing-edge landing; frame quantization correct.
- Click/drag/pin paths: consistent with the invariants from #13600/#13955/#14187/#14245.

### Tests

`VideoPlayerControlSmpteSeekTests` (expansion on/off) and a `PlayheadFrameStepTests` case asserting the nudge pin. Full UITests suite locally: 4295/4297, the one failure being the known flaky LibMpv live-core test fixed separately on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)