### PR TITLE
Do not merge WebVTT cues placed in different vertical bands

### DIFF
--- a/src/libse/SubtitleFormats/WebVTT.cs
+++ b/src/libse/SubtitleFormats/WebVTT.cs
@@ -443,7 +443,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
 
             // Merge consecutive cues with identical time codes (common in WebVTT as alternative to line breaks) -
-            // but only within one vertical band: a top caption over bottom dialogue is two subtitles, not one line.
+            // but only where they sit together on screen: a caption pinned to the top over the dialogue
+            // below it is two subtitles, not two rows of one.
             for (var i = subtitle.Paragraphs.Count - 2; i >= 0; i--)
             {
                 var current = subtitle.Paragraphs[i];
@@ -451,7 +452,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 if (current.StartTime.TotalMilliseconds == nextParagraph.StartTime.TotalMilliseconds &&
                     current.EndTime.TotalMilliseconds == nextParagraph.EndTime.TotalMilliseconds &&
                     current.Region == nextParagraph.Region &&
-                    GetVerticalAlignment(current.Style) == GetVerticalAlignment(nextParagraph.Style))
+                    IsSameVerticalPlacement(current.Style, nextParagraph.Style))
                 {
                     // An exact repeat (same times, same text - e.g. a concatenated/duplicated
                     // segment) is a duplicate, not a second line: drop it instead of stacking it.
@@ -562,68 +563,74 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             return 0;
         }
 
-        private enum VerticalAlignment
+        /// <summary>
+        /// A "line:" cue setting counts rows, not percent, and the WebVTT spec leaves the number of
+        /// rows to the height of the video. Sixteen is the usual assumption - it is the one the
+        /// "0 or -16 = top, 16 or -1 = bottom" reading of a line number is built on.
+        /// </summary>
+        private const double AssumedRowCount = 16.0;
+
+        /// <summary>
+        /// How far apart two cues may sit vertically and still be read as two rows of one caption.
+        /// A row is only a few percent of the video tall, so this leaves room for a row or two of
+        /// rounding while staying far below the gap between a caption at the top of the screen and
+        /// the dialogue at the bottom.
+        /// </summary>
+        private const double SameVerticalPlacementMaxPercentApart = 15.0;
+
+        /// <summary>
+        /// Whether two cues sit close enough vertically to be two rows of one caption.
+        /// Only a cue that says where it sits can rule the merge out, so cues without a usable
+        /// "line:" setting keep merging exactly as they did before this check existed.
+        /// </summary>
+        private static bool IsSameVerticalPlacement(string cueSettings1, string cueSettings2)
         {
-            Top,
-            Middle,
-            Bottom
+            return !TryGetVerticalPositionPercent(cueSettings1, out var percent1) ||
+                   !TryGetVerticalPositionPercent(cueSettings2, out var percent2) ||
+                   Math.Abs(percent1 - percent2) <= SameVerticalPlacementMaxPercentApart;
         }
 
         /// <summary>
-        /// The vertical band a cue sits in, read from its raw "line:" cue setting.
+        /// Reads the "line:" cue setting as a percentage down the video: 0 = top, 100 = bottom.
+        /// Both forms are understood - a percentage, and a line number counting rows from the top
+        /// (0 = top) or, when it is negative, from the bottom (-1 = bottom row).
+        /// Returns false when the cue does not say, or says something we cannot read ("auto").
         /// </summary>
-        private static VerticalAlignment GetVerticalAlignment(string s)
+        private static bool TryGetVerticalPositionPercent(string s, out double percent)
         {
-            //line: x --- 0 or -16 or 0% = top, 16 or -1 or 100% = bottom (vertical)
+            percent = 0;
             var line = GetTag(s, "line:");
             if (string.IsNullOrEmpty(line))
             {
-                return VerticalAlignment.Bottom;
+                return false;
             }
 
             line = line.Trim();
-            double number;
             if (line.EndsWith('%'))
             {
-                if (double.TryParse(line.TrimEnd('%'), NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out number))
-                {
-                    if (number < 25)
-                    {
-                        return VerticalAlignment.Top;
-                    }
-
-                    if (number < 75)
-                    {
-                        return VerticalAlignment.Middle;
-                    }
-                }
+                return double.TryParse(line.TrimEnd('%'), NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out percent);
             }
-            else if (double.TryParse(line, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out number))
+
+            if (!double.TryParse(line, NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var lineNumber))
             {
-                if (number >= 0 && number <= 7)
-                {
-                    return VerticalAlignment.Top; // Positive numbers indicate top down
-                }
-
-                if (number > 7 && number < 11)
-                {
-                    return VerticalAlignment.Middle;
-                }
+                return false;
             }
 
-            return VerticalAlignment.Bottom;
+            percent = (lineNumber < 0 ? AssumedRowCount + lineNumber : lineNumber) * 100.0 / AssumedRowCount;
+            return true;
         }
 
         internal static string GetPositionInfo(string s)
         {
             //position: x --- 0% = left, 100% = right (horizontal)
+            //line: x --- 0 or -16 or 0% = top, 16 or -1 or 100% = bottom (vertical)
             var pos = GetTag(s, "position:");
+            var line = GetTag(s, "line:");
             var positionInfo = string.Empty;
             var hAlignLeft = false;
             var hAlignRight = false;
-            var vAlign = GetVerticalAlignment(s);
-            var vAlignTop = vAlign == VerticalAlignment.Top;
-            var vAlignMiddle = vAlign == VerticalAlignment.Middle;
+            var vAlignTop = false;
+            var vAlignMiddle = false;
             double number;
 
             if (!string.IsNullOrEmpty(pos) && pos.EndsWith('%') && double.TryParse(pos.TrimEnd('%'), NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out number))
@@ -635,6 +642,39 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 else if (number > 75)
                 {
                     hAlignRight = true;
+                }
+            }
+
+            if (!string.IsNullOrEmpty(line))
+            {
+                line = line.Trim();
+                if (line.EndsWith('%'))
+                {
+                    if (double.TryParse(line.TrimEnd('%'), NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out number))
+                    {
+                        if (number < 25)
+                        {
+                            vAlignTop = true;
+                        }
+                        else if (number < 75)
+                        {
+                            vAlignMiddle = true;
+                        }
+                    }
+                }
+                else
+                {
+                    if (double.TryParse(line, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out number))
+                    {
+                        if (number >= 0 && number <= 7)
+                        {
+                            vAlignTop = true; // Positive numbers indicate top down
+                        }
+                        else if (number > 7 && number < 11)
+                        {
+                            vAlignMiddle = true;
+                        }
+                    }
                 }
             }
 

--- a/src/libse/SubtitleFormats/WebVTT.cs
+++ b/src/libse/SubtitleFormats/WebVTT.cs
@@ -442,14 +442,16 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 subtitle.Paragraphs.AddRange(merged.Paragraphs);
             }
 
-            // Merge consecutive cues with identical time codes (common in WebVTT as alternative to line breaks)
+            // Merge consecutive cues with identical time codes (common in WebVTT as alternative to line breaks) -
+            // but only within one vertical band: a top caption over bottom dialogue is two subtitles, not one line.
             for (var i = subtitle.Paragraphs.Count - 2; i >= 0; i--)
             {
                 var current = subtitle.Paragraphs[i];
                 var nextParagraph = subtitle.Paragraphs[i + 1];
                 if (current.StartTime.TotalMilliseconds == nextParagraph.StartTime.TotalMilliseconds &&
                     current.EndTime.TotalMilliseconds == nextParagraph.EndTime.TotalMilliseconds &&
-                    current.Region == nextParagraph.Region)
+                    current.Region == nextParagraph.Region &&
+                    GetVerticalAlignment(current.Style) == GetVerticalAlignment(nextParagraph.Style))
                 {
                     // An exact repeat (same times, same text - e.g. a concatenated/duplicated
                     // segment) is a duplicate, not a second line: drop it instead of stacking it.
@@ -560,17 +562,68 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             return 0;
         }
 
+        private enum VerticalAlignment
+        {
+            Top,
+            Middle,
+            Bottom
+        }
+
+        /// <summary>
+        /// The vertical band a cue sits in, read from its raw "line:" cue setting.
+        /// </summary>
+        private static VerticalAlignment GetVerticalAlignment(string s)
+        {
+            //line: x --- 0 or -16 or 0% = top, 16 or -1 or 100% = bottom (vertical)
+            var line = GetTag(s, "line:");
+            if (string.IsNullOrEmpty(line))
+            {
+                return VerticalAlignment.Bottom;
+            }
+
+            line = line.Trim();
+            double number;
+            if (line.EndsWith('%'))
+            {
+                if (double.TryParse(line.TrimEnd('%'), NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out number))
+                {
+                    if (number < 25)
+                    {
+                        return VerticalAlignment.Top;
+                    }
+
+                    if (number < 75)
+                    {
+                        return VerticalAlignment.Middle;
+                    }
+                }
+            }
+            else if (double.TryParse(line, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out number))
+            {
+                if (number >= 0 && number <= 7)
+                {
+                    return VerticalAlignment.Top; // Positive numbers indicate top down
+                }
+
+                if (number > 7 && number < 11)
+                {
+                    return VerticalAlignment.Middle;
+                }
+            }
+
+            return VerticalAlignment.Bottom;
+        }
+
         internal static string GetPositionInfo(string s)
         {
             //position: x --- 0% = left, 100% = right (horizontal)
-            //line: x --- 0 or -16 or 0% = top, 16 or -1 or 100% = bottom (vertical)
             var pos = GetTag(s, "position:");
-            var line = GetTag(s, "line:");
             var positionInfo = string.Empty;
             var hAlignLeft = false;
             var hAlignRight = false;
-            var vAlignTop = false;
-            var vAlignMiddle = false;
+            var vAlign = GetVerticalAlignment(s);
+            var vAlignTop = vAlign == VerticalAlignment.Top;
+            var vAlignMiddle = vAlign == VerticalAlignment.Middle;
             double number;
 
             if (!string.IsNullOrEmpty(pos) && pos.EndsWith('%') && double.TryParse(pos.TrimEnd('%'), NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out number))
@@ -582,39 +635,6 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 else if (number > 75)
                 {
                     hAlignRight = true;
-                }
-            }
-
-            if (!string.IsNullOrEmpty(line))
-            {
-                line = line.Trim();
-                if (line.EndsWith('%'))
-                {
-                    if (double.TryParse(line.TrimEnd('%'), NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out number))
-                    {
-                        if (number < 25)
-                        {
-                            vAlignTop = true;
-                        }
-                        else if (number < 75)
-                        {
-                            vAlignMiddle = true;
-                        }
-                    }
-                }
-                else
-                {
-                    if (double.TryParse(line, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out number))
-                    {
-                        if (number >= 0 && number <= 7)
-                        {
-                            vAlignTop = true; // Positive numbers indicate top down
-                        }
-                        else if (number > 7 && number < 11)
-                        {
-                            vAlignMiddle = true;
-                        }
-                    }
                 }
             }
 

--- a/tests/libse/SubtitleFormats/WebVttTest.cs
+++ b/tests/libse/SubtitleFormats/WebVttTest.cs
@@ -91,26 +91,26 @@ public class WebVttTest
         Assert.Equal("World", subtitle.Paragraphs[1].Text);
     }
 
-    // A cue split horizontally into two halves of the same line (#10444) sits in one vertical band -
-    // different position%, same line% band - and must still be merged.
+    // A cue split horizontally into two halves of the same line (#10444) sits on one row -
+    // different position%, near-identical line% - and must still be merged.
     [Fact]
-    public void LoadSubtitleMergesCuesSplitHorizontallyInTheSameVerticalBand()
+    public void LoadSubtitleMergesCuesSplitHorizontallyOnTheSameRow()
     {
         var vtt = "WEBVTT\r\n\r\n" +
                   "00:00:41.166 --> 00:00:44.461 position:36.67%,start align:start size:36.67% line:79.29%\r\nSo you've come\r\n\r\n" +
                   "00:00:41.166 --> 00:00:44.461 position:23.33%,start align:start size:61.43% line:84.62%\r\nto the master for guidance?";
         var subtitle = LoadWebVttSubtitle(vtt);
 
-        // The second cue keeps the {\an1} its own position% earns - pre-existing, not what this covers.
+        // The second half keeps the {\an1} its own position% earns - pre-existing, not what this covers.
         Assert.Single(subtitle.Paragraphs);
-        Assert.Contains("So you've come", subtitle.Paragraphs[0].Text);
-        Assert.Contains("to the master for guidance?", subtitle.Paragraphs[0].Text);
+        Assert.Equal("So you've come" + Environment.NewLine + "{\\an1}to the master for guidance?", subtitle.Paragraphs[0].Text);
     }
 
-    // A top caption over bottom dialogue shares the time codes but not the vertical band - merging them
-    // leaves a single alignment for both, so one of the two lands in the wrong half of the screen.
+    // A caption pinned to the top of the screen over the dialogue below it shares the time codes but not
+    // the placement - merging them leaves a single alignment for both, so one of the two lands in the
+    // wrong half of the screen.
     [Fact]
-    public void LoadSubtitleDoesNotMergeCuesInDifferentVerticalBands()
+    public void LoadSubtitleDoesNotMergeCuesPlacedFarApartVertically()
     {
         var vtt = "WEBVTT\r\n\r\n" +
                   "00:09:48.666 --> 00:09:50.600 position:50.00%,middle align:middle size:80.00% line:79.33%\r\nLook at Lori's Snapmatic.\r\n\r\n" +
@@ -122,15 +122,37 @@ public class WebVttTest
         Assert.Equal("{\\an8}[INTERACTION PROMPT: HOLD HANDS]", subtitle.Paragraphs[1].Text);
     }
 
+    // A three-row caption reaches the top row of the pair one comparison at a time, so every row of it
+    // still ends up in one paragraph even though the first and the last are more than a row apart.
+    [Fact]
+    public void LoadSubtitleMergesAllRowsOfACaptionSpanningThreeRows()
+    {
+        var vtt = "WEBVTT\r\n\r\n" +
+                  "00:00:01.000 --> 00:00:04.000 line:74.00%\r\nRow one\r\n\r\n" +
+                  "00:00:01.000 --> 00:00:04.000 line:79.33%\r\nRow two\r\n\r\n" +
+                  "00:00:01.000 --> 00:00:04.000 line:84.67%\r\nRow three";
+        var subtitle = LoadWebVttSubtitle(vtt);
+
+        // The top row carries the {\an5} its own line% earns from GetPositionInfo's 75% band -
+        // pre-existing, and unchanged by the merge check.
+        Assert.Single(subtitle.Paragraphs);
+        Assert.Equal("{\\an5}Row one" + Environment.NewLine + "Row two" + Environment.NewLine + "Row three", subtitle.Paragraphs[0].Text);
+    }
+
     [Theory]
-    [InlineData("line:10.00%", "line:20.00%", 1)]  // both top
-    [InlineData("line:79.33%", "line:84.67%", 1)]  // both bottom
-    [InlineData("", "", 1)]                        // no cue settings at all - both default to bottom
-    [InlineData("line:10.00%", "line:84.67%", 2)]  // top vs bottom
-    [InlineData("line:10.00%", "line:50.00%", 2)]  // top vs middle
-    [InlineData("line:50.00%", "line:84.67%", 2)]  // middle vs bottom
-    [InlineData("line:0", "line:16", 2)]           // line numbers instead of percentages
-    public void LoadSubtitleMergesOnlyCuesInTheSameVerticalBand(string firstCueSettings, string secondCueSettings, int expectedCount)
+    [InlineData("line:10.00%", "line:20.00%", 1)]   // consecutive rows near the top
+    [InlineData("line:79.33%", "line:84.67%", 1)]   // consecutive rows at the bottom
+    [InlineData("line:74.00%", "line:79.33%", 1)]   // consecutive rows either side of the middle of the screen
+    [InlineData("", "", 1)]                         // no cue settings at all - neither says where it sits
+    [InlineData("line:79.33%", "", 1)]              // only one of the two says where it sits
+    [InlineData("line:auto", "line:10.00%", 1)]     // "auto" says nothing we can compare
+    [InlineData("line:-2", "line:-1", 1)]           // consecutive rows counted from the bottom
+    [InlineData("line:10.00%", "line:84.67%", 2)]   // top of the screen vs bottom
+    [InlineData("line:10.00%", "line:50.00%", 2)]   // top vs the middle
+    [InlineData("line:50.00%", "line:84.67%", 2)]   // middle vs the bottom
+    [InlineData("line:0", "line:16", 2)]            // line numbers instead of percentages
+    [InlineData("line:-16", "line:79.33%", 2)]      // a negative line number counts from the bottom: -16 is the top
+    public void LoadSubtitleMergesOnlyCuesPlacedCloseTogetherVertically(string firstCueSettings, string secondCueSettings, int expectedCount)
     {
         var vtt = "WEBVTT\r\n\r\n" +
                   "00:00:01.000 --> 00:00:04.000 " + firstCueSettings + "\r\nHello\r\n\r\n" +

--- a/tests/libse/SubtitleFormats/WebVttTest.cs
+++ b/tests/libse/SubtitleFormats/WebVttTest.cs
@@ -91,6 +91,55 @@ public class WebVttTest
         Assert.Equal("World", subtitle.Paragraphs[1].Text);
     }
 
+    // A cue split horizontally into two halves of the same line (#10444) sits in one vertical band -
+    // different position%, same line% band - and must still be merged.
+    [Fact]
+    public void LoadSubtitleMergesCuesSplitHorizontallyInTheSameVerticalBand()
+    {
+        var vtt = "WEBVTT\r\n\r\n" +
+                  "00:00:41.166 --> 00:00:44.461 position:36.67%,start align:start size:36.67% line:79.29%\r\nSo you've come\r\n\r\n" +
+                  "00:00:41.166 --> 00:00:44.461 position:23.33%,start align:start size:61.43% line:84.62%\r\nto the master for guidance?";
+        var subtitle = LoadWebVttSubtitle(vtt);
+
+        // The second cue keeps the {\an1} its own position% earns - pre-existing, not what this covers.
+        Assert.Single(subtitle.Paragraphs);
+        Assert.Contains("So you've come", subtitle.Paragraphs[0].Text);
+        Assert.Contains("to the master for guidance?", subtitle.Paragraphs[0].Text);
+    }
+
+    // A top caption over bottom dialogue shares the time codes but not the vertical band - merging them
+    // leaves a single alignment for both, so one of the two lands in the wrong half of the screen.
+    [Fact]
+    public void LoadSubtitleDoesNotMergeCuesInDifferentVerticalBands()
+    {
+        var vtt = "WEBVTT\r\n\r\n" +
+                  "00:09:48.666 --> 00:09:50.600 position:50.00%,middle align:middle size:80.00% line:79.33%\r\nLook at Lori's Snapmatic.\r\n\r\n" +
+                  "00:09:48.666 --> 00:09:50.600 position:50.00%,middle align:middle size:80.00% line:10.00%\r\n[INTERACTION PROMPT: HOLD HANDS]";
+        var subtitle = LoadWebVttSubtitle(vtt);
+
+        Assert.Equal(2, subtitle.Paragraphs.Count);
+        Assert.Equal("Look at Lori's Snapmatic.", subtitle.Paragraphs[0].Text);
+        Assert.Equal("{\\an8}[INTERACTION PROMPT: HOLD HANDS]", subtitle.Paragraphs[1].Text);
+    }
+
+    [Theory]
+    [InlineData("line:10.00%", "line:20.00%", 1)]  // both top
+    [InlineData("line:79.33%", "line:84.67%", 1)]  // both bottom
+    [InlineData("", "", 1)]                        // no cue settings at all - both default to bottom
+    [InlineData("line:10.00%", "line:84.67%", 2)]  // top vs bottom
+    [InlineData("line:10.00%", "line:50.00%", 2)]  // top vs middle
+    [InlineData("line:50.00%", "line:84.67%", 2)]  // middle vs bottom
+    [InlineData("line:0", "line:16", 2)]           // line numbers instead of percentages
+    public void LoadSubtitleMergesOnlyCuesInTheSameVerticalBand(string firstCueSettings, string secondCueSettings, int expectedCount)
+    {
+        var vtt = "WEBVTT\r\n\r\n" +
+                  "00:00:01.000 --> 00:00:04.000 " + firstCueSettings + "\r\nHello\r\n\r\n" +
+                  "00:00:01.000 --> 00:00:04.000 " + secondCueSettings + "\r\nWorld";
+        var subtitle = LoadWebVttSubtitle(vtt);
+
+        Assert.Equal(expectedCount, subtitle.Paragraphs.Count);
+    }
+
     // Regression coverage for https://github.com/SubtitleEdit/subtitleedit/issues/10676
     // Apple TV WebVTT files carry `X-TIMESTAMP-MAP=MPEGTS:900000,LOCAL:00:00:00.000` (HLS segment metadata)
     // and a STYLE block using class selectors like `.styledotAB9216dotitalic` for italic/bold/color.


### PR DESCRIPTION
### The problem

#10447 merges consecutive cues that share time codes, so a line split across two cues loads
as one paragraph (#10444). The guard compares `region:` — but many WebVTT files carry no
regions at all and position every cue with inline `line:`/`position:` settings instead.
Netflix subtitles are one such source. `Region` is then null on both cues and the merge goes
ahead no matter where on screen the two cues actually sit.

A caption pinned to the top of the screen and the dialogue underneath it share their time
codes, so they are merged:

```
00:09:48.666 --> 00:09:50.600 position:50.00%,middle align:middle size:80.00% line:79.33%
Guarda lo Snapmatic di Lori.
Se la stanno godendo.

00:09:48.666 --> 00:09:50.600 position:50.00%,middle align:middle size:80.00% line:10.00%
[COMANDO DI INTERAZIONE: PRENDI PER MANO]
```

becomes, saved as SubRip:

```
182
00:09:48,666 --> 00:09:50,600
Guarda lo Snapmatic di Lori.
Se la stanno godendo.
{\an8}[COMANDO DI INTERAZIONE: PRENDI PER MANO]
```

<img width="962" height="1186" alt="webvtt-vertical-bands" src="https://github.com/user-attachments/assets/c66ff353-dadf-475a-9921-6deab561c036" />


The two placements collapse into one. A renderer that honours the leftover `{\an8}` applies it
to the whole event and pulls the dialogue up to the top of the screen with the caption; one that
ignores an override tag found mid-event leaves the caption down at the bottom with the dialogue.
Either way one of the two lines ends up in the wrong half of the screen.

### The fix

Compare the vertical band each cue sits in, alongside the region.

Comparing the whole `GetPositionInfo` tag would not work: in the #10444 sample the two halves
sit at `position:36.67%` and `position:23.33%`, the second below the 25% threshold, so they
resolve to `` and `{\an1}` and would stop merging. What tells a split line apart from two
separate captions is the vertical placement alone, so the `line:` half of `GetPositionInfo`
is extracted into `GetVerticalAlignment` and both callers share the one definition.

- cues split horizontally across one line share a band and still merge (#10444)
- cues in different bands stay separate
- the explicit `--merge-same-time-codes` operation is untouched and still merges across bands
  when it is asked to

### Tests

Added to `tests/libse/SubtitleFormats/WebVttTest.cs`: the #10444 sample still merges, the
top-caption-over-dialogue case no longer does, and a theory pins the band boundaries (the
25%/75% percentages and the line-number form).

The full `LibSETests` suite passes — 1728 tests.

