### PR TITLE
Add "toggle translation and original in video/audio preview" shortcut

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -217,6 +217,11 @@ public class AudioVisualizer : Control
     public bool FocusOnMouseOver { get; set; } = true;
     public int WaveformHeightPercentage { get; set; } = 50;
 
+    // Draw the original text instead of the translation - "toggle translation and original in
+    // video/audio preview" (#14252). Only the main window sets it, and only while an original
+    // subtitle is loaded; the dialogs that host a waveform keep showing the text they were given.
+    public bool ShowOriginalText { get; set; }
+
     // Lets the wheel handler ask the host whether the video is playing, so a plain scroll in
     // "center video position" mode can turn into a seek that keeps the play-head centered
     // (#12864). Hosts without a video player (or that never set this) keep plain scrolling.
@@ -3356,8 +3361,10 @@ public class AudioVisualizer : Control
         context.DrawLine(_paintLeft, new Point(currentRegionLeft, 0), new Point(currentRegionLeft, height));
         context.DrawLine(_paintRight, new Point(currentRegionRight - 1, 0), new Point(currentRegionRight - 1, height));
 
-        // Draw clipped text (prepared text + shaped FormattedText are cached; see GetCachedParagraphText)
-        var prepared = GetPreparedParagraphText(paragraph.Text);
+        // Draw clipped text (prepared text + shaped FormattedText are cached; see GetCachedParagraphText).
+        // With "toggle translation and original in video/audio preview" on, the waveform shows the
+        // original text like SE4 did (#14252).
+        var prepared = GetPreparedParagraphText(ShowOriginalText ? paragraph.OriginalText : paragraph.Text);
 
         var textBounds = new Rect(currentRegionLeft + 1, 0, currentRegionWidth - 3, height);
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -301,6 +301,12 @@ public partial class MainViewModel :
     /// <summary>Whether the original text column may be written to (see <see cref="IsOriginalReadOnly"/>).</summary>
     public bool CanEditOriginal => ShowColumnOriginalText && !IsOriginalReadOnly;
 
+    /// <summary>
+    /// Whether the video preview and the waveform show the original text instead of the translation
+    /// (see <see cref="ToggleOriginalTextInPreviewCommand"/>). Never true without an original.
+    /// </summary>
+    public bool ShowOriginalTextInPreview { get; private set; }
+
     public string OriginalTextLabel => IsOriginalReadOnly
         ? Se.Language.Main.OriginalTextReadOnly
         : IsEditOriginalMode
@@ -3534,6 +3540,43 @@ public partial class MainViewModel :
         _shortcutManager.ClearKeys();
     }
 
+    /// <summary>
+    /// SE4 parity (MainEditToggleTranslationOriginalInPreviews): show the original text instead of
+    /// the translation in the video preview and in the waveform (#14252). Session state, not a
+    /// saved setting: it only means anything while an original is loaded, and a remembered "on"
+    /// would start the next session with a blank preview and no visible way back.
+    /// </summary>
+    [RelayCommand]
+    private void ToggleOriginalTextInPreview()
+    {
+        if (!ShowColumnOriginalText)
+        {
+            _shortcutManager.ClearKeys();
+            return;
+        }
+
+        SetOriginalTextInPreview(!ShowOriginalTextInPreview);
+
+        ShowStatus(string.Format(
+            Se.Language.Main.VideoAndWaveformPreviewTextX,
+            ShowOriginalTextInPreview ? Se.Language.General.OriginalText : Se.Language.General.Translation));
+
+        _shortcutManager.ClearKeys();
+    }
+
+    private void SetOriginalTextInPreview(bool showOriginal)
+    {
+        ShowOriginalTextInPreview = showOriginal;
+
+        if (AudioVisualizer != null)
+        {
+            AudioVisualizer.ShowOriginalText = showOriginal;
+        }
+
+        _mpvPreviewDirty = true;
+        _updateAudioVisualizer = true;
+    }
+
     [RelayCommand]
     private async Task FileCloseTranslation()
     {
@@ -3659,14 +3702,14 @@ public partial class MainViewModel :
                 _mpvReloader.Reset();
                 // Through RunPreviewRefresh so a rejected push (player just recreated, mpv not
                 // playing yet) arms the dirty-flag retry instead of being lost (#13407).
-                _ = RunPreviewRefresh(() => _mpvReloader.RefreshMpv(mpv, GetUpdateSubtitle(), _subtitleSecondary, SelectedSubtitleFormat));
+                _ = RunPreviewRefresh(() => _mpvReloader.RefreshMpv(mpv, GetVideoPreviewSubtitle(), _subtitleSecondary, SelectedSubtitleFormat));
             }
             else if (vp.VideoPlayer is LibVlcDynamicPlayer vlc)
             {
                 _vlcReloader.Reset();
                 _ = RunPreviewRefresh(async () =>
                 {
-                    await _vlcReloader.RefreshVlc(vlc, GetUpdateSubtitle(), _subtitleSecondary, SelectedSubtitleFormat);
+                    await _vlcReloader.RefreshVlc(vlc, GetVideoPreviewSubtitle(), _subtitleSecondary, SelectedSubtitleFormat);
                     return true;
                 });
             }
@@ -12223,12 +12266,12 @@ public partial class MainViewModel :
             if (vp.VideoPlayer is LibMpvDynamicPlayer mpv)
             {
                 _mpvReloader.Reset();
-                _mpvReloader.RefreshMpv(mpv, GetUpdateSubtitle(), _subtitleSecondary, SelectedSubtitleFormat);
+                _mpvReloader.RefreshMpv(mpv, GetVideoPreviewSubtitle(), _subtitleSecondary, SelectedSubtitleFormat);
             }
             else if (vp.VideoPlayer is LibVlcDynamicPlayer vlc)
             {
                 _vlcReloader.Reset();
-                _vlcReloader.RefreshVlc(vlc, GetUpdateSubtitle(), _subtitleSecondary, SelectedSubtitleFormat);
+                _vlcReloader.RefreshVlc(vlc, GetVideoPreviewSubtitle(), _subtitleSecondary, SelectedSubtitleFormat);
             }
         }
 
@@ -22818,6 +22861,45 @@ public partial class MainViewModel :
         return _subtitle;
     }
 
+    /// <summary>
+    /// The subtitle the video preview should render: the working subtitle, or - with "toggle
+    /// translation and original in video/audio preview" on - the original text (#14252). The
+    /// original variant goes into a throw-away subtitle rather than through
+    /// <see cref="GetUpdateSubtitleOriginal"/>: that one owns <see cref="_subtitleOriginal"/>, the
+    /// instance that gets saved, and re-stamps every row's reference id - far too much for
+    /// something a timer calls whenever the preview is dirty.
+    /// </summary>
+    private Subtitle GetVideoPreviewSubtitle()
+    {
+        if (!ShowOriginalTextInPreview)
+        {
+            return GetUpdateSubtitle();
+        }
+
+        var subtitle = new Subtitle
+        {
+            Header = _subtitle.Header,
+            Footer = _subtitle.Footer,
+            OriginalFormat = _subtitle.OriginalFormat,
+            FileName = _subtitle.FileName,
+        };
+
+        foreach (var line in Subtitles)
+        {
+            // Rows with no original line contribute nothing here - including the read-only
+            // reference rows, which are the original's non-matching lines and so belong in this
+            // one (unlike in GetUpdateSubtitle, which must leave them out).
+            if (string.IsNullOrEmpty(line.OriginalText))
+            {
+                continue;
+            }
+
+            subtitle.Paragraphs.Add(line.ToParagraphOriginal(SelectedSubtitleFormat));
+        }
+
+        return subtitle;
+    }
+
     public Subtitle GetUpdateSubtitleOriginal(bool subtractVideoOffset = false)
     {
         _subtitleOriginal ??= new Subtitle();
@@ -27752,6 +27834,13 @@ public partial class MainViewModel :
         {
             MakeSubtitleTextInfoOriginal(SelectedSubtitle.OriginalText, SelectedSubtitle);
         }
+
+        // Without an original there is no original text to preview - leaving the flag set would
+        // blank out the waveform text and the video preview (SE4 cleared it the same way).
+        if (!value && ShowOriginalTextInPreview)
+        {
+            SetOriginalTextInPreview(false);
+        }
     }
 
     private void MakeSubtitleTextInfoOriginal(string text, SubtitleLineViewModel item)
@@ -28670,7 +28759,7 @@ public partial class MainViewModel :
 
         if (vp.VideoPlayer is LibMpvDynamicPlayer mpv)
         {
-            var subtitle = GetUpdateSubtitle();
+            var subtitle = GetVideoPreviewSubtitle();
             _mpvPreviewDirty = false; // clear only after subtitle snapshot is successfully obtained
             if (hideLayers)
             {
@@ -28681,7 +28770,7 @@ public partial class MainViewModel :
         }
         else if (vp.VideoPlayer is LibVlcDynamicPlayer vlc)
         {
-            var subtitle = GetUpdateSubtitle();
+            var subtitle = GetVideoPreviewSubtitle();
             _mpvPreviewDirty = false; // clear only after subtitle snapshot is successfully obtained
             if (hideLayers)
             {

--- a/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
+++ b/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
@@ -390,6 +390,7 @@ public static class Se4ShortcutsImporter
         ["GeneralMergeSelectedLinesBilingual"] = nameof(MainViewModel.MergeSelectedLinesBilingualCommand),
         ["GeneralMergeOriginalAndTranslation"] = nameof(MainViewModel.MergeOriginalIntoTranslationSelectedLinesCommand),
         ["GeneralToggleTranslationMode"] = nameof(MainViewModel.ToggleTranslationModeCommand),
+        ["MainEditToggleTranslationOriginalInPreviews"] = nameof(MainViewModel.ToggleOriginalTextInPreviewCommand),
         ["GeneralMergeWithNext"] = nameof(MainViewModel.MergeWithLineAfterCommand),
         ["GeneralMergeWithPrevious"] = nameof(MainViewModel.MergeWithLineBeforeCommand),
         ["GeneralApplyAssaOverrideTags"] = nameof(MainViewModel.ShowAssaApplyCustomOverrideTagsCommand),

--- a/src/ui/Logic/Config/Language/Main/LanguageMain.cs
+++ b/src/ui/Logic/Config/Language/Main/LanguageMain.cs
@@ -77,6 +77,7 @@ public class LanguageMain
     public string UnbreakHint { get; set; }
     public string UndoPerformed { get; set; }
     public string UndoPerformedXActionLeft { get; set; }
+    public string VideoAndWaveformPreviewTextX { get; set; }
     public string XLinesCopiedFromOriginal { get; set; }
     public string XLinesMerged { get; set; }
     public string XLinesSelectedOfY { get; set; }
@@ -230,6 +231,7 @@ public class LanguageMain
         UnbreakHint = "Unbreak selected lines";
         UndoPerformed = "Undo performed";
         UndoPerformedXActionLeft = "Undo performed (actions left: {0})";
+        VideoAndWaveformPreviewTextX = "Video/waveform preview: {0}";
         XLinesCopiedFromOriginal = "{0} lines copied from original subtitle";
         XLinesMerged = "{0} lines merged";
         XLinesSelectedOfY = "{0} lines selected of {1}";

--- a/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
@@ -22,6 +22,7 @@ public class LanguageSettingsShortcuts
     public string GeneralUnbreakNoSpaceCjk { get; set; }
     public string GeneralMergeSelectedLinesBilingual { get; set; }
     public string GeneralToggleTranslationMode { get; set; }
+    public string GeneralToggleTranslationAndOriginalInPreviews { get; set; }
     public string GeneralChooseLayout { get; set; }
     public string GeneralGoToNextSubtitle { get; set; }
     public string GeneralGoToNextSubtitlePlayTranslate { get; set; }
@@ -287,6 +288,7 @@ public class LanguageSettingsShortcuts
         GeneralUnbreakNoSpaceCjk = "Unbreak without space (CJK)";
         GeneralMergeSelectedLinesBilingual = "Merge selected lines bilingual";
         GeneralToggleTranslationMode = "Toggle translation mode";
+        GeneralToggleTranslationAndOriginalInPreviews = "Toggle translation and original in video/audio preview";
         GeneralChooseLayout = "Choose layout";
         GeneralGoToNextSubtitle = "Go to next subtitle";
         GeneralGoToNextSubtitlePlayTranslate = "Go to next subtitle (play translate)";

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -142,6 +142,7 @@ public static class ShortcutsMain
         { nameof(MainViewModel.FileOpenOriginalCommand), Se.Language.Options.Shortcuts.FileOpenOriginal },
         { nameof(MainViewModel.FileCloseOriginalCommand), Se.Language.Options.Shortcuts.FileCloseOriginal },
         { nameof(MainViewModel.ToggleTranslationModeCommand), Se.Language.Options.Shortcuts.GeneralToggleTranslationMode },
+        { nameof(MainViewModel.ToggleOriginalTextInPreviewCommand), Se.Language.Options.Shortcuts.GeneralToggleTranslationAndOriginalInPreviews },
         { nameof(MainViewModel.FileCloseTranslationCommand), Se.Language.Options.Shortcuts.FileCloseTranslation },
         { nameof(MainViewModel.CommandExitCommand), Se.Language.Options.Shortcuts.FileExit },
         { nameof(MainViewModel.CommandFileNewCommand), Se.Language.General.New },
@@ -587,6 +588,7 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.FileOpenOriginalCommand, nameof(vm.FileOpenOriginalCommand), ShortcutCategory.General, ShortcutGroup.File);
         AddShortcut(shortcuts, vm.FileCloseOriginalCommand, nameof(vm.FileCloseOriginalCommand), ShortcutCategory.General, ShortcutGroup.File);
         AddShortcut(shortcuts, vm.ToggleTranslationModeCommand, nameof(vm.ToggleTranslationModeCommand), ShortcutCategory.General, ShortcutGroup.Translate);
+        AddShortcut(shortcuts, vm.ToggleOriginalTextInPreviewCommand, nameof(vm.ToggleOriginalTextInPreviewCommand), ShortcutCategory.General, ShortcutGroup.Translate);
         AddShortcut(shortcuts, vm.FileCloseTranslationCommand, nameof(vm.FileCloseTranslationCommand), ShortcutCategory.General, ShortcutGroup.File);
         AddShortcut(shortcuts, vm.ExportBluRaySupCommand, nameof(vm.ExportBluRaySupCommand), ShortcutCategory.General, ShortcutGroup.File);
         AddShortcut(shortcuts, vm.ShowExportCustomTextFormatCommand, nameof(vm.ShowExportCustomTextFormatCommand), ShortcutCategory.General, ShortcutGroup.File);

--- a/tests/UI/Controls/AudioVisualizerOriginalTextTests.cs
+++ b/tests/UI/Controls/AudioVisualizerOriginalTextTests.cs
@@ -1,0 +1,92 @@
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace UITests.Controls;
+
+/// <summary>
+/// "Toggle translation and original in video/audio preview" (#14252) also swaps the text drawn in
+/// the waveform - the video preview alone showing the original, with the waveform still on the
+/// translation, is what SE 4 never did.
+/// </summary>
+public class AudioVisualizerOriginalTextTests
+{
+    private const int SampleRate = 126; // px per second at zoom 1
+    private const double WidthPx = 800;
+    private const double HeightPx = 200;
+    private const double LineStartSeconds = 100;
+
+    [AvaloniaFact]
+    public void ShowOriginalText_DrawsTheOriginalInsteadOfTheTranslation()
+    {
+        var av = new AudioVisualizer { WavePeaks = MakePeaks(300) };
+        var window = new Window
+        {
+            Width = WidthPx,
+            Height = HeightPx,
+            Content = av,
+        };
+
+        window.Show();
+        window.UpdateLayout();
+
+        var line = new SubtitleLineViewModel
+        {
+            // Same length in both: the paragraph footer keeps showing the row's own CPS (the line
+            // being edited), so only equal-length texts make the two frames below pixel-identical.
+            Text = "Vertaalde regel",
+            OriginalText = "Originele regel",
+            StartTime = TimeSpan.FromSeconds(LineStartSeconds),
+            EndTime = TimeSpan.FromSeconds(LineStartSeconds + 3),
+        };
+
+        var lines = new List<SubtitleLineViewModel> { line };
+        var noSelection = new List<SubtitleLineViewModel>();
+
+        av.SetPosition(LineStartSeconds - 1, lines, 0, -1, noSelection);
+        var translation = Capture(window);
+
+        av.ShowOriginalText = true;
+        av.InvalidateVisual();
+        var original = Capture(window);
+
+        Assert.NotEqual(translation, original);
+
+        // ... and it is the original text that was drawn, not merely something else: the same
+        // waveform with the original text in the ordinary Text property paints the same frame.
+        av.ShowOriginalText = false;
+        line.Text = "Originele regel";
+        av.InvalidateVisual();
+        Assert.Equal(original, Capture(window));
+    }
+
+    private static WavePeakData2 MakePeaks(int seconds)
+    {
+        var peaks = new WavePeak2[SampleRate * seconds];
+        for (var i = 0; i < peaks.Length; i++)
+        {
+            peaks[i] = new WavePeak2(200, -200);
+        }
+
+        return new WavePeakData2(SampleRate, peaks);
+    }
+
+    private static byte[] Capture(Window window)
+    {
+        Dispatcher.UIThread.RunJobs();
+        AvaloniaHeadlessPlatform.ForceRenderTimerTick();
+
+        using var frame = window.CaptureRenderedFrame()!;
+        using var stream = new MemoryStream();
+        frame.Save(stream);
+        return stream.ToArray();
+    }
+}

--- a/tests/UI/Features/Main/MainOriginalTextInPreviewTests.cs
+++ b/tests/UI/Features/Main/MainOriginalTextInPreviewTests.cs
@@ -1,0 +1,191 @@
+using System.Reflection;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// SE 4 parity for "toggle translation and original in video/audio preview" (#14252): while it is
+/// on, the video preview and the waveform show the original text instead of the translation. It is
+/// session state, and only ever on while an original is loaded - a stale "on" without an original
+/// would leave both previews blank with no visible way back.
+/// </summary>
+public class MainOriginalTextInPreviewTests
+{
+    [AvaloniaFact]
+    public void Toggle_WithOriginalShown_PreviewSubtitleUsesTheOriginalText()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Vertaalde regel een", "Source line one", 0, 2000);
+            AddLine(vm, "Vertaalde regel twee", "Source line two", 2000, 4000);
+            vm.ShowColumnOriginalText = true;
+
+            vm.ToggleOriginalTextInPreviewCommand.Execute(null);
+
+            Assert.True(vm.ShowOriginalTextInPreview);
+            Assert.Equal(
+                new[] { "Source line one", "Source line two" },
+                GetVideoPreviewSubtitle(vm).Paragraphs.Select(p => p.Text));
+
+            vm.ToggleOriginalTextInPreviewCommand.Execute(null);
+
+            Assert.False(vm.ShowOriginalTextInPreview);
+            Assert.Equal(
+                new[] { "Vertaalde regel een", "Vertaalde regel twee" },
+                GetVideoPreviewSubtitle(vm).Paragraphs.Select(p => p.Text));
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    /// <summary>
+    /// A row the original has no line for has nothing to preview - it is left out rather than
+    /// pushed to the player as an empty subtitle line.
+    /// </summary>
+    [AvaloniaFact]
+    public void Toggle_SkipsRowsWithoutAnOriginalLine()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Vertaalde regel een", "Source line one", 0, 2000);
+            AddLine(vm, "Vertaalde regel twee", string.Empty, 2000, 4000);
+            vm.ShowColumnOriginalText = true;
+
+            vm.ToggleOriginalTextInPreviewCommand.Execute(null);
+
+            var preview = GetVideoPreviewSubtitle(vm);
+            Assert.Equal(2, vm.Subtitles.Count);
+            Assert.Equal("Source line one", Assert.Single(preview.Paragraphs).Text);
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    [AvaloniaFact]
+    public void Toggle_WithoutAnOriginal_StaysOnTheTranslation()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Line one", string.Empty, 0, 2000);
+
+            vm.ToggleOriginalTextInPreviewCommand.Execute(null);
+
+            Assert.False(vm.ShowOriginalTextInPreview);
+            Assert.Equal("Line one", Assert.Single(GetVideoPreviewSubtitle(vm).Paragraphs).Text);
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    [AvaloniaFact]
+    public void HidingTheOriginalColumn_TurnsThePreviewBackToTheTranslation()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Vertaalde regel een", "Source line one", 0, 2000);
+            vm.ShowColumnOriginalText = true;
+            vm.ToggleOriginalTextInPreviewCommand.Execute(null);
+            Assert.True(vm.ShowOriginalTextInPreview);
+
+            vm.ShowColumnOriginalText = false;
+
+            Assert.False(vm.ShowOriginalTextInPreview);
+            Assert.Equal("Vertaalde regel een", Assert.Single(GetVideoPreviewSubtitle(vm).Paragraphs).Text);
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    /// <summary>
+    /// The waveform draws from the rows, so it needs the same flag - without this the video preview
+    /// would show the original while the waveform kept showing the translation.
+    /// </summary>
+    [AvaloniaFact]
+    public void Toggle_KeepsTheWaveformInSync()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Vertaalde regel een", "Source line one", 0, 2000);
+            vm.ShowColumnOriginalText = true;
+            Assert.NotNull(vm.AudioVisualizer);
+
+            vm.ToggleOriginalTextInPreviewCommand.Execute(null);
+            Assert.True(vm.AudioVisualizer!.ShowOriginalText);
+
+            vm.ShowColumnOriginalText = false;
+            Assert.False(vm.AudioVisualizer!.ShowOriginalText);
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    private static Subtitle GetVideoPreviewSubtitle(MainViewModel vm)
+    {
+        var method = typeof(MainViewModel).GetMethod(
+                         "GetVideoPreviewSubtitle", BindingFlags.Instance | BindingFlags.NonPublic)
+                     ?? throw new InvalidOperationException("GetVideoPreviewSubtitle not found");
+
+        return (Subtitle)method.Invoke(vm, null)!;
+    }
+
+    private static (Window Window, MainViewModel Vm) CreateMainViewModel()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1200, Height = 800 };
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        return (window, (MainViewModel)view.DataContext!);
+    }
+
+    private static void AddLine(MainViewModel vm, string text, string originalText, int startMs, int endMs)
+    {
+        vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph(text, startMs, endMs), null!)
+        {
+            OriginalText = originalText,
+            Number = vm.Subtitles.Count + 1,
+        });
+    }
+
+    private static void CloseWindow(Window window, MainViewModel vm)
+    {
+        foreach (var ownedWindow in window.OwnedWindows.ToArray())
+        {
+            ownedWindow.Close();
+        }
+
+        window.Closing -= vm.OnClosing;
+        if (window.IsVisible)
+        {
+            window.Close();
+        }
+    }
+}

--- a/tests/UI/Features/Options/Shortcuts/Se4ShortcutsImporterMapTests.cs
+++ b/tests/UI/Features/Options/Shortcuts/Se4ShortcutsImporterMapTests.cs
@@ -70,6 +70,7 @@ public class Se4ShortcutsImporterMapTests
     [InlineData("GeneralClearBookmarks", "ClearBookmarksCommand")]
     [InlineData("MainListViewUnderline", "ToggleLinesUnderlineOrSelectedTextCommand")]
     [InlineData("WaveformGuessStart", "WaveformGuessStartCommand")]
+    [InlineData("MainEditToggleTranslationOriginalInPreviews", "ToggleOriginalTextInPreviewCommand")]
     public void ImportsSe4ShortcutBySerializedName(string se4Name, string expectedSe5Command)
     {
         var xml = $"<Shortcuts><{se4Name}>Control+Shift+F12</{se4Name}></Shortcuts>";


### PR DESCRIPTION
Fixes #14252

SE 4 had an Edit-menu action (`MainEditToggleTranslationOriginalInPreviews`) that swapped the video preview and the waveform over to the **original** text while a translation was being edited. SE 5 had no equivalent.

### What this adds

- `ToggleOriginalTextInPreviewCommand`, registered in the shortcut list as **"Toggle translation and original in video/audio preview"** (General category, Translate group). No default key, like SE 4.
- SE 4 shortcut import mapping, so an imported `MainEditToggleTranslationOriginalInPreviews` binding keeps working.
- A status-bar line on toggle: `Video/waveform preview: Original text` / `: Translation`.

### Notes on the implementation

- **Video preview**: `GetVideoPreviewSubtitle()` builds a throw-away subtitle from the rows' original text instead of going through `GetUpdateSubtitleOriginal()` — that one owns `_subtitleOriginal` (the instance that gets saved) and re-stamps every row's reference id, far too much for something the preview timer calls whenever the preview is dirty. Rows the original has no line for are left out; the read-only reference rows (the original's non-matching lines) are included.
- **Waveform**: draws from the rows, which already carry `OriginalText`, so it only needs a flag on the control. It is an instance property, not a setting read — the dialogs that host a waveform (visual sync, point sync, cut video, TTS review) must keep showing the text they were given.
- **Session-only state**, not a saved setting: it means nothing without an original loaded, and a remembered "on" would start the next session with a blank preview and no visible way back (the toggle is a no-op with no original). Hiding the original column clears it for the same reason.
- The waveform paragraph footer keeps showing the row's own CPS — that number is about the line being edited, not about the text being read.

### Tests

- `MainOriginalTextInPreviewTests` — the preview subtitle swaps and swaps back, rows without an original line are skipped, the toggle is a no-op without an original, closing the original turns it back off, and the waveform stays in sync.
- `AudioVisualizerOriginalTextTests` — pixel-compares rendered frames: with the flag on, the waveform paints the same frame it paints when the original text sits in `Text`.
- One more case in `Se4ShortcutsImporterMapTests` for the SE 4 element name.

Full UI suite: 4305 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)