### PR TITLE
Video offset: recently used offsets and an Apply that keeps the window open

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -453,6 +453,7 @@
     "reDownloadX": "Re-download {0}",
     "reason": "Reason",
     "recentFiles": "Recent files",
+    "recentlyUsedVideoOffsets": "Recently used video offsets",
     "redo": "Redo",
     "redownload": "Re-download...",
     "release": "Release",

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -9487,40 +9487,36 @@ public partial class MainViewModel :
             return;
         }
 
+        // The dialog stays open and applies through these callbacks, so several offsets can be
+        // tried out without reopening it; "Cancel" just closes and keeps what was applied.
+        await ShowDialogAsync<SetVideoOffsetWindow, SetVideoOffsetViewModel>(vm =>
+        {
+            vm.Initialize(ApplyVideoOffset, ResetVideoOffset);
+        });
+    }
+
+    private void ApplyVideoOffset(TimeSpan offset, bool relativeToCurrentVideoPosition, bool keepTimeCodes)
+    {
         var oldOffsetMs = Se.Settings.General.CurrentVideoOffsetInMs;
 
-        var result = await ShowDialogAsync<SetVideoOffsetWindow, SetVideoOffsetViewModel>();
-
-        if (result.ResetPressed)
-        {
-            Se.Settings.General.CurrentVideoOffsetInMs = 0;
-            UpdateVideoOffsetStatus();
-            _updateAudioVisualizer = true;
-            return;
-        }
-
-        if (!result.OkPressed || !result.TimeOffset.HasValue)
-        {
-            return;
-        }
-
-        var offset = result.TimeOffset.Value;
-        if (result.RelativeToCurrentVideoPosition)
+        if (relativeToCurrentVideoPosition)
         {
             var vp = GetVideoPlayerControl();
             if (vp != null)
             {
                 offset = offset - TimeSpan.FromSeconds(vp.Position);
             }
-
-            Se.Settings.General.CurrentVideoOffsetInMs = (long)Math.Round(offset.TotalMilliseconds, MidpointRounding.AwayFromZero);
         }
+
+        Se.Settings.General.CurrentVideoOffsetInMs = (long)Math.Round(offset.TotalMilliseconds, MidpointRounding.AwayFromZero);
 
         // The video offset is a non-destructive display offset (see TimeSpanToDisplayFullConverter):
         // the listview shows "time code + offset" while the underlying time codes stay untouched.
         // "Keep existing time codes" therefore leaves the time codes alone. When it is NOT checked,
         // we bake the offset change into the time codes so the displayed values stay the same.
-        if (!result.KeepTimeCodes)
+        // The shift is against the offset in force right now, so applying twice from the open
+        // dialog lands on the same time codes as applying the second value straight away.
+        if (!keepTimeCodes)
         {
             var delta = TimeSpan.FromMilliseconds(Se.Settings.General.CurrentVideoOffsetInMs - oldOffsetMs);
             if (delta != TimeSpan.Zero)
@@ -9533,6 +9529,13 @@ public partial class MainViewModel :
             }
         }
 
+        UpdateVideoOffsetStatus();
+        _updateAudioVisualizer = true;
+    }
+
+    private void ResetVideoOffset()
+    {
+        Se.Settings.General.CurrentVideoOffsetInMs = 0;
         UpdateVideoOffsetStatus();
         _updateAudioVisualizer = true;
     }

--- a/src/ui/Features/Shared/SetVideoOffset/SetVideoOffsetViewModel.cs
+++ b/src/ui/Features/Shared/SetVideoOffset/SetVideoOffsetViewModel.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -12,25 +15,41 @@ public partial class SetVideoOffsetViewModel : ObservableObject
     [ObservableProperty] private TimeSpan? _timeOffset;
     [ObservableProperty] private bool _relativeToCurrentVideoPosition;
     [ObservableProperty] private bool _keepTimeCodes;
+    [ObservableProperty] private ObservableCollection<VideoOffsetHistoryItem> _offsetHistory;
+    [ObservableProperty] private VideoOffsetHistoryItem? _selectedOffsetHistoryItem;
+
+    private const int MaxHistoryItems = 10;
+
+    // "Apply" and "OK" hand the offset to the caller instead of the caller reading it off a
+    // closed dialog, so the window can stay open and be applied again with a new value.
+    private Action<TimeSpan, bool, bool>? _applyCallback;
+    private Action? _resetCallback;
 
     public Window? Window { get; set; }
 
-    public bool OkPressed { get; private set; }
-    public bool ResetPressed { get; private set; }
-
     public SetVideoOffsetViewModel()
     {
+        OffsetHistory = new ObservableCollection<VideoOffsetHistoryItem>();
         TimeOffset = TimeSpan.FromMilliseconds(Se.Settings.General.CurrentVideoOffsetInMs);
     }
 
-    public void Initialize()
+    public void Initialize(Action<TimeSpan, bool, bool> applyCallback, Action resetCallback)
     {
+        _applyCallback = applyCallback;
+        _resetCallback = resetCallback;
+        LoadHistory();
     }
 
     [RelayCommand]
     private void SetTenHours()
     {
         TimeOffset = TimeSpan.FromHours(10);
+    }
+
+    [RelayCommand]
+    private void Apply()
+    {
+        ApplyCurrentOffset();
     }
 
     [RelayCommand]
@@ -42,16 +61,15 @@ public partial class SetVideoOffsetViewModel : ObservableObject
             return;
         }
 
-        Se.Settings.General.CurrentVideoOffsetInMs = (long)Math.Round(TimeOffset.Value.TotalMilliseconds, MidpointRounding.AwayFromZero);
-        OkPressed = true;
+        ApplyCurrentOffset();
         Window?.Close();
     }
 
     [RelayCommand]
     private void Reset()
     {
-        ResetPressed = true;
-        Window?.Close();
+        TimeOffset = TimeSpan.Zero;
+        _resetCallback?.Invoke();
     }
 
     [RelayCommand]
@@ -70,6 +88,102 @@ public partial class SetVideoOffsetViewModel : ObservableObject
         else if (e.Key == Key.Enter)
         {
             Ok();
+        }
+    }
+
+    private void ApplyCurrentOffset()
+    {
+        if (TimeOffset == null || _applyCallback == null)
+        {
+            return;
+        }
+
+        var offset = TimeOffset.Value;
+        _applyCallback(offset, RelativeToCurrentVideoPosition, KeepTimeCodes);
+
+        // The typed offset is remembered, not the one "relative to current video position"
+        // computed from it - the typed one is what the user would want to pick again.
+        AddToHistory(offset);
+    }
+
+    private void LoadHistory()
+    {
+        var msList = (Se.Settings.General.VideoOffsetHistoryInMs ?? new List<long>())
+            .Where(p => p != 0)
+            .Distinct()
+            .Take(MaxHistoryItems)
+            .ToList();
+
+        if (msList.Count == 0)
+        {
+            // SE 4 parity: the two offsets a broadcast time code almost always needs.
+            msList.Add((long)TimeSpan.FromHours(1).TotalMilliseconds);
+            msList.Add((long)TimeSpan.FromHours(10).TotalMilliseconds);
+        }
+
+        OffsetHistory.Clear();
+        foreach (var ms in msList)
+        {
+            OffsetHistory.Add(new VideoOffsetHistoryItem(ms));
+        }
+
+        SyncSelectedHistoryItem();
+    }
+
+    private void AddToHistory(TimeSpan offset)
+    {
+        var ms = ToMilliseconds(offset);
+        if (ms == 0)
+        {
+            return; // "no offset" is what Reset is for - it would only be noise in the list
+        }
+
+        // A repeat of an offset already in the list moves to the top instead of doubling up.
+        var existing = OffsetHistory.FirstOrDefault(p => p.TotalMilliseconds == ms);
+        if (existing != null)
+        {
+            OffsetHistory.Remove(existing);
+        }
+
+        OffsetHistory.Insert(0, existing ?? new VideoOffsetHistoryItem(ms));
+
+        while (OffsetHistory.Count > MaxHistoryItems)
+        {
+            OffsetHistory.RemoveAt(OffsetHistory.Count - 1);
+        }
+
+        Se.Settings.General.VideoOffsetHistoryInMs = OffsetHistory.Select(p => p.TotalMilliseconds).ToList();
+
+        // Removing the selected item cleared the drop-down selection - put it back on the entry
+        // the offset field now holds.
+        SyncSelectedHistoryItem();
+    }
+
+    /// <summary>
+    /// The drop-down shows the entry matching the offset field, or nothing when the field holds
+    /// something else - so picking an entry the user has just typed over selects it again.
+    /// </summary>
+    private void SyncSelectedHistoryItem()
+    {
+        var ms = TimeOffset.HasValue ? ToMilliseconds(TimeOffset.Value) : 0;
+        SelectedOffsetHistoryItem = OffsetHistory.FirstOrDefault(p => p.TotalMilliseconds == ms);
+    }
+
+    private static long ToMilliseconds(TimeSpan offset)
+    {
+        return (long)Math.Round(offset.TotalMilliseconds, MidpointRounding.AwayFromZero);
+    }
+
+    partial void OnTimeOffsetChanged(TimeSpan? value)
+    {
+        SyncSelectedHistoryItem();
+    }
+
+    partial void OnSelectedOffsetHistoryItemChanged(VideoOffsetHistoryItem? value)
+    {
+        if (value != null)
+        {
+            TimeOffset = value.Offset;
         }
     }
 }

--- a/src/ui/Features/Shared/SetVideoOffset/SetVideoOffsetWindow.cs
+++ b/src/ui/Features/Shared/SetVideoOffset/SetVideoOffsetWindow.cs
@@ -1,4 +1,5 @@
 using Avalonia;
+using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Layout;
@@ -28,6 +29,19 @@ public class SetVideoOffsetWindow : Window
             }
         };
 
+        // Previously used offsets - picking one fills the time code box, so switching between the
+        // handful of offsets a user keeps coming back to takes one click instead of retyping.
+        var comboBoxHistory = UiUtil.MakeComboBox(vm.OffsetHistory, vm, nameof(vm.SelectedOffsetHistoryItem));
+
+        // Wide enough for a time code, so the box does not shrink to an arrow stub while the
+        // typed offset matches no entry and nothing is selected.
+        comboBoxHistory.MinWidth = 130;
+        AutomationProperties.SetName(comboBoxHistory, Se.Language.General.RecentlyUsedVideoOffsets);
+        if (Se.Settings.Appearance.ShowHints)
+        {
+            ToolTip.SetTip(comboBoxHistory, Se.Language.General.RecentlyUsedVideoOffsets);
+        }
+
         var panelTimeCode = new StackPanel
         {
             Orientation = Orientation.Horizontal,
@@ -37,6 +51,7 @@ public class SetVideoOffsetWindow : Window
             {
                 UiUtil.MakeLabel(Se.Language.General.VideoOffset),
                 timeCodeUpDownOffset,
+                comboBoxHistory,
                 UiUtil.MakeButton(Se.Language.General.TenHours, vm.SetTenHoursCommand).WithFontSize(10),
             }
         };
@@ -51,6 +66,7 @@ public class SetVideoOffsetWindow : Window
 
         var buttonPanel = UiUtil.MakeButtonBar(
             UiUtil.MakeButtonOk(vm.OkCommand),
+            UiUtil.MakeButton(Se.Language.General.Apply, vm.ApplyCommand),
             UiUtil.MakeButton(Se.Language.General.Reset, vm.ResetCommand),
             UiUtil.MakeButtonCancel(vm.CancelCommand));
 

--- a/src/ui/Features/Shared/SetVideoOffset/VideoOffsetHistoryItem.cs
+++ b/src/ui/Features/Shared/SetVideoOffset/VideoOffsetHistoryItem.cs
@@ -1,0 +1,27 @@
+using System;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Shared.SetVideoOffset;
+
+/// <summary>
+/// One previously used video offset, shown in the drop-down next to the offset field.
+/// The display text is built once, in the same format the time code box next to it uses.
+/// </summary>
+public class VideoOffsetHistoryItem
+{
+    public long TotalMilliseconds { get; }
+    public TimeSpan Offset { get; }
+    public string DisplayText { get; }
+
+    public VideoOffsetHistoryItem(long totalMilliseconds)
+    {
+        TotalMilliseconds = totalMilliseconds;
+        Offset = TimeSpan.FromMilliseconds(totalMilliseconds);
+
+        var timeCode = new TimeCode(totalMilliseconds);
+        DisplayText = Se.Settings.General.UseFrameMode ? timeCode.ToHHMMSSFF() : timeCode.ToString();
+    }
+
+    public override string ToString() => DisplayText;
+}

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -453,6 +453,7 @@ public class LanguageGeneral
     public string ReDownloadX { get; set; }
     public string Reason { get; set; }
     public string RecentFiles { get; set; }
+    public string RecentlyUsedVideoOffsets { get; set; }
     public string Redo { get; set; }
     public string Redownload { get; set; }
     public string Release { get; set; }
@@ -1247,6 +1248,7 @@ public class LanguageGeneral
         ReDownloadX = "Re-download {0}";
         Reason = "Reason";
         RecentFiles = "Recent files";
+        RecentlyUsedVideoOffsets = "Recently used video offsets";
         Redo = "Redo";
         Redownload = "Re-download...";
         Release = "Release";

--- a/src/ui/Logic/Config/SeGeneral.cs
+++ b/src/ui/Logic/Config/SeGeneral.cs
@@ -176,6 +176,13 @@ public class SeGeneral
     public long CurrentVideoOffsetInMs = 0;
     public bool CurrentVideoIsSmpte = false;
 
+    /// <summary>
+    /// Video offsets the user has applied, most recently used first, so the "Set video offset"
+    /// dialog can offer them for one-click reuse instead of retyping the same time code every
+    /// time (SE 4 parity). Capped at ten entries by the dialog.
+    /// </summary>
+    public List<long> VideoOffsetHistoryInMs { get; set; } = new List<long>();
+
     public SeGeneral()
     {
         Version = Se.Version;

--- a/tests/UI/Features/Shared/SetVideoOffset/SetVideoOffsetViewModelTests.cs
+++ b/tests/UI/Features/Shared/SetVideoOffset/SetVideoOffsetViewModelTests.cs
@@ -1,0 +1,216 @@
+using Nikse.SubtitleEdit.Features.Shared.SetVideoOffset;
+using Nikse.SubtitleEdit.Logic.Config;
+using System.Collections.Generic;
+
+namespace UITests.Features.Shared.SetVideoOffset;
+
+/// <summary>
+/// The dialog stays open across an Apply, and remembers the offsets it applied so the same few
+/// values can be picked again instead of retyped (SE 4 parity).
+/// </summary>
+public class SetVideoOffsetViewModelTests
+{
+    private static readonly TimeSpan TenHours = TimeSpan.FromHours(10);
+    private static readonly TimeSpan NineFiftyNineForty = new(0, 9, 59, 40, 0);
+
+    private sealed class Recorder
+    {
+        internal List<(TimeSpan Offset, bool Relative, bool KeepTimeCodes)> Applied { get; } = new();
+        internal int ResetCount { get; private set; }
+
+        internal SetVideoOffsetViewModel NewViewModel()
+        {
+            var vm = new SetVideoOffsetViewModel();
+            vm.Initialize(
+                (offset, relative, keepTimeCodes) => Applied.Add((offset, relative, keepTimeCodes)),
+                () => ResetCount++);
+            return vm;
+        }
+    }
+
+    [Fact]
+    public void Apply_AppliesWithoutClosingAndCanBeRepeatedWithNewValues()
+    {
+        using var _ = new SettingsScope("General.VideoOffsetHistoryInMs");
+        Se.Settings.General.VideoOffsetHistoryInMs = new List<long>();
+        var recorder = new Recorder();
+        var vm = recorder.NewViewModel();
+
+        vm.TimeOffset = NineFiftyNineForty;
+        vm.KeepTimeCodes = true;
+        vm.ApplyCommand.Execute(null);
+
+        vm.TimeOffset = TenHours;
+        vm.KeepTimeCodes = false;
+        vm.ApplyCommand.Execute(null);
+
+        Assert.Equal(
+            new[]
+            {
+                (NineFiftyNineForty, false, true),
+                (TenHours, false, false),
+            },
+            recorder.Applied);
+    }
+
+    [Fact]
+    public void Ok_AppliesOnce()
+    {
+        using var _ = new SettingsScope("General.VideoOffsetHistoryInMs");
+        Se.Settings.General.VideoOffsetHistoryInMs = new List<long>();
+        var recorder = new Recorder();
+        var vm = recorder.NewViewModel();
+
+        vm.TimeOffset = NineFiftyNineForty;
+        vm.OkCommand.Execute(null);
+
+        Assert.Single(recorder.Applied);
+        Assert.Equal(NineFiftyNineForty, recorder.Applied[0].Offset);
+    }
+
+    [Fact]
+    public void Reset_ClearsTheOffsetFieldAndCallsBack()
+    {
+        using var _ = new SettingsScope("General.VideoOffsetHistoryInMs");
+        Se.Settings.General.VideoOffsetHistoryInMs = new List<long>();
+        var recorder = new Recorder();
+        var vm = recorder.NewViewModel();
+
+        vm.TimeOffset = TenHours;
+        vm.ResetCommand.Execute(null);
+
+        Assert.Equal(1, recorder.ResetCount);
+        Assert.Equal(TimeSpan.Zero, vm.TimeOffset);
+        Assert.Empty(recorder.Applied);
+    }
+
+    [Fact]
+    public void AppliedOffsets_AreRememberedMostRecentFirstAndPersisted()
+    {
+        using var _ = new SettingsScope("General.VideoOffsetHistoryInMs");
+        Se.Settings.General.VideoOffsetHistoryInMs = new List<long>();
+        var recorder = new Recorder();
+        var vm = recorder.NewViewModel();
+
+        vm.TimeOffset = NineFiftyNineForty;
+        vm.ApplyCommand.Execute(null);
+        vm.TimeOffset = TenHours;
+        vm.ApplyCommand.Execute(null);
+
+        Assert.Equal(
+            new[] { (long)TenHours.TotalMilliseconds, (long)NineFiftyNineForty.TotalMilliseconds },
+            vm.OffsetHistory.Take(2).Select(p => p.TotalMilliseconds));
+        Assert.Equal(
+            vm.OffsetHistory.Select(p => p.TotalMilliseconds),
+            Se.Settings.General.VideoOffsetHistoryInMs);
+
+        // A new dialog offers what the previous one applied.
+        var next = recorder.NewViewModel();
+        Assert.Equal((long)TenHours.TotalMilliseconds, next.OffsetHistory[0].TotalMilliseconds);
+    }
+
+    [Fact]
+    public void ReusingAnOffset_MovesItToTheTopWithoutDuplicating()
+    {
+        using var _ = new SettingsScope("General.VideoOffsetHistoryInMs");
+        Se.Settings.General.VideoOffsetHistoryInMs = new List<long>();
+        var recorder = new Recorder();
+        var vm = recorder.NewViewModel();
+
+        vm.TimeOffset = NineFiftyNineForty;
+        vm.ApplyCommand.Execute(null);
+        vm.TimeOffset = TenHours;
+        vm.ApplyCommand.Execute(null);
+        vm.TimeOffset = NineFiftyNineForty;
+        vm.ApplyCommand.Execute(null);
+
+        Assert.Equal(
+            new[] { (long)NineFiftyNineForty.TotalMilliseconds, (long)TenHours.TotalMilliseconds },
+            vm.OffsetHistory.Take(2).Select(p => p.TotalMilliseconds));
+        Assert.Equal(
+            1,
+            vm.OffsetHistory.Count(p => p.TotalMilliseconds == (long)NineFiftyNineForty.TotalMilliseconds));
+    }
+
+    [Fact]
+    public void History_KeepsTheTenMostRecentOffsets()
+    {
+        using var _ = new SettingsScope("General.VideoOffsetHistoryInMs");
+        Se.Settings.General.VideoOffsetHistoryInMs = new List<long>();
+        var recorder = new Recorder();
+        var vm = recorder.NewViewModel();
+
+        for (var minutes = 1; minutes <= 12; minutes++)
+        {
+            vm.TimeOffset = TimeSpan.FromMinutes(minutes);
+            vm.ApplyCommand.Execute(null);
+        }
+
+        Assert.Equal(10, vm.OffsetHistory.Count);
+        Assert.Equal((long)TimeSpan.FromMinutes(12).TotalMilliseconds, vm.OffsetHistory[0].TotalMilliseconds);
+        Assert.Equal((long)TimeSpan.FromMinutes(3).TotalMilliseconds, vm.OffsetHistory[9].TotalMilliseconds);
+    }
+
+    [Fact]
+    public void ZeroOffset_IsNotRemembered()
+    {
+        using var _ = new SettingsScope("General.VideoOffsetHistoryInMs");
+        Se.Settings.General.VideoOffsetHistoryInMs = new List<long>();
+        var recorder = new Recorder();
+        var vm = recorder.NewViewModel();
+
+        vm.TimeOffset = TimeSpan.Zero;
+        vm.ApplyCommand.Execute(null);
+
+        Assert.Single(recorder.Applied);
+        Assert.DoesNotContain(vm.OffsetHistory, p => p.TotalMilliseconds == 0);
+    }
+
+    [Fact]
+    public void EmptyHistory_OffersOneAndTenHours()
+    {
+        using var _ = new SettingsScope("General.VideoOffsetHistoryInMs");
+        Se.Settings.General.VideoOffsetHistoryInMs = new List<long>();
+        var vm = new Recorder().NewViewModel();
+
+        Assert.Equal(
+            new[] { 60L * 60 * 1000, 10L * 60 * 60 * 1000 },
+            vm.OffsetHistory.Select(p => p.TotalMilliseconds));
+    }
+
+    [Fact]
+    public void PickingAHistoryItem_FillsTheOffsetField()
+    {
+        using var _ = new SettingsScope("General.VideoOffsetHistoryInMs");
+        Se.Settings.General.VideoOffsetHistoryInMs = new List<long> { (long)NineFiftyNineForty.TotalMilliseconds };
+        var vm = new Recorder().NewViewModel();
+
+        vm.SelectedOffsetHistoryItem = vm.OffsetHistory[0];
+
+        Assert.Equal(NineFiftyNineForty, vm.TimeOffset);
+    }
+
+    [Fact]
+    public void TypingOverAPickedOffset_ClearsTheSelectionSoItCanBePickedAgain()
+    {
+        using var _ = new SettingsScope("General.VideoOffsetHistoryInMs");
+        Se.Settings.General.VideoOffsetHistoryInMs = new List<long> { (long)NineFiftyNineForty.TotalMilliseconds };
+        var vm = new Recorder().NewViewModel();
+
+        vm.SelectedOffsetHistoryItem = vm.OffsetHistory[0];
+        vm.TimeOffset = TimeSpan.FromSeconds(42);
+        Assert.Null(vm.SelectedOffsetHistoryItem);
+
+        vm.SelectedOffsetHistoryItem = vm.OffsetHistory[0];
+        Assert.Equal(NineFiftyNineForty, vm.TimeOffset);
+    }
+
+    [Fact]
+    public void HistoryItemDisplayText_IsATimeCode()
+    {
+        using var _ = new SettingsScope("General.UseFrameMode");
+        Se.Settings.General.UseFrameMode = false;
+
+        Assert.Equal("00:59:40,000", new VideoOffsetHistoryItem(59 * 60 * 1000 + 40 * 1000).DisplayText);
+    }
+}

--- a/tests/UI/Features/Shared/SetVideoOffset/SetVideoOffsetWindowTests.cs
+++ b/tests/UI/Features/Shared/SetVideoOffset/SetVideoOffsetWindowTests.cs
@@ -1,0 +1,76 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.LogicalTree;
+using Nikse.SubtitleEdit.Features.Shared.SetVideoOffset;
+using Nikse.SubtitleEdit.Logic.Config;
+using System.Collections.Generic;
+
+namespace UITests.Features.Shared.SetVideoOffset;
+
+/// <summary>
+/// The window is built in code, so the drop-down of previously used offsets and the Apply button
+/// next to OK are only there if the window actually adds them.
+/// </summary>
+public class SetVideoOffsetWindowTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private SetVideoOffsetWindow Open(SetVideoOffsetViewModel vm)
+    {
+        var window = new SetVideoOffsetWindow(vm);
+        _windows.Add(window);
+        return window;
+    }
+
+    private static SetVideoOffsetViewModel NewViewModel()
+    {
+        var vm = new SetVideoOffsetViewModel();
+        vm.Initialize((_, _, _) => { }, () => { });
+        return vm;
+    }
+
+    [AvaloniaFact]
+    public void TheHistoryDropDownIsWiredToTheOffsetField()
+    {
+        using var _ = new SettingsScope("General.VideoOffsetHistoryInMs");
+        Se.Settings.General.VideoOffsetHistoryInMs = new List<long> { 35980000 };
+
+        var vm = NewViewModel();
+        var window = Open(vm);
+
+        var comboBox = window.GetLogicalDescendants().OfType<ComboBox>().FirstOrDefault();
+        Assert.NotNull(comboBox);
+        Assert.Equal(vm.OffsetHistory, comboBox!.ItemsSource);
+
+        comboBox.SelectedIndex = 0;
+
+        Assert.Equal(TimeSpan.FromMilliseconds(35980000), vm.TimeOffset);
+    }
+
+    [AvaloniaFact]
+    public void ApplySitsNextToOkResetAndCancel()
+    {
+        using var _ = new SettingsScope("General.VideoOffsetHistoryInMs");
+        var window = Open(NewViewModel());
+
+        var buttonTexts = window.GetLogicalDescendants().OfType<Button>()
+            .Select(b => b.Content as string ?? string.Empty)
+            .ToList();
+
+        // The OK/Cancel texts carry an access-key underscore that never reaches the button.
+        Assert.Contains(Se.Language.General.Ok.Replace("_", string.Empty), buttonTexts);
+        Assert.Contains(Se.Language.General.Apply, buttonTexts);
+        Assert.Contains(Se.Language.General.Reset, buttonTexts);
+        Assert.Contains(Se.Language.General.Cancel.Replace("_", string.Empty), buttonTexts);
+    }
+}


### PR DESCRIPTION
Video → More → Update video offset had two rough edges: every value had to be typed in full, and the window closed on every OK, so trying a few offsets against the video meant reopening it each time.

## Recently used offsets

The offsets that have been applied are kept, most recent first, in a drop-down next to the time code box - picking one fills the box. The list holds ten entries and lives in settings (`General.VideoOffsetHistoryInMs`), so it survives a restart. This is SE 4 parity: SE 4 kept the same list behind a "pick offset" button. An empty list starts out offering 1 hour and 10 hours, as SE 4 did.

The drop-down follows the box rather than being a one-shot picker: it shows the entry matching the current offset and clears when the box holds something else, so an entry that was typed over can be picked again. A zero offset is not remembered - that is what Reset is for.

## Apply

- **Apply** - updates the video offset, window stays open
- **OK** - updates the video offset and closes
- **Cancel** - closes, keeping what was already applied
- **Reset** - clears the offset and stays open too, since resetting is now just another value to try (it used to close)

Applying hands the offset to the main window through a callback instead of the caller reading it off a closed dialog. The time codes are still shifted against the offset in force at that moment, so applying twice from the open window lands where applying the second value straight away would.


## Tests

`tests/UI/Features/Shared/SetVideoOffset/` - 13 tests covering repeated Apply, OK applying once, Reset, the history order/cap/persistence/dedup, the 1h+10h seed, and the window wiring (the drop-down feeding the offset field, and all four buttons present).

Full UI suite: 4310 passed, 1 pre-existing flake unrelated to this change (`CrispAsrTtsProvenanceTests.RealHelpProbe_...`, passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
