### PR TITLE
Waveform: give right-to-left text the direction its letters ask for

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -9,6 +9,7 @@ using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
+using Nikse.SubtitleEdit.Logic.ValueConverters;
 using SkiaSharp;
 using System;
 using System.Collections.Generic;
@@ -3233,21 +3234,26 @@ public class AudioVisualizer : Control
     // short-lived garbage to trigger GC pauses, which show up as the cursor briefly freezing and
     // then jumping. Cache the prepared text and the shaped FormattedText; both are cleared in
     // ResetCache() when the waveform font/colors change.
-    private readonly Dictionary<string, FormattedText> _paragraphFormattedTextCache = new(512);
-    private readonly Dictionary<string, (List<string> Lines, string Unwrapped)> _paragraphTextCache = new(512);
+    private readonly Dictionary<(string Text, bool RightToLeft), FormattedText> _paragraphFormattedTextCache = new(512);
+    private readonly Dictionary<string, (List<string> Lines, string Unwrapped, bool RightToLeft)> _paragraphTextCache = new(512);
 
-    private FormattedText GetCachedParagraphText(string text)
+    // The direction is part of the key: the same string shapes differently in the two directions
+    // (see GetPreparedParagraphText), and the number/duration/CPS labels stay left to right even
+    // under a right to left paragraph.
+    internal FormattedText GetCachedParagraphText(string text, bool rightToLeft = false)
     {
-        if (!_paragraphFormattedTextCache.TryGetValue(text, out var formatted))
+        var key = (text, rightToLeft);
+        if (!_paragraphFormattedTextCache.TryGetValue(key, out var formatted))
         {
             if (_paragraphFormattedTextCache.Count > 8000)
             {
                 _paragraphFormattedTextCache.Clear();
             }
 
-            formatted = new FormattedText(text, CultureInfo.CurrentCulture, FlowDirection.LeftToRight,
+            formatted = new FormattedText(text, CultureInfo.CurrentCulture,
+                rightToLeft ? FlowDirection.RightToLeft : FlowDirection.LeftToRight,
                 _typeface, _fontSize, _paintText);
-            _paragraphFormattedTextCache[text] = formatted;
+            _paragraphFormattedTextCache[key] = formatted;
         }
 
         return formatted;
@@ -3310,7 +3316,7 @@ public class AudioVisualizer : Control
         return label;
     }
 
-    private (List<string> Lines, string Unwrapped) GetPreparedParagraphText(string rawText)
+    internal (List<string> Lines, string Unwrapped, bool RightToLeft) GetPreparedParagraphText(string rawText)
     {
         if (!_paragraphTextCache.TryGetValue(rawText, out var prepared))
         {
@@ -3322,7 +3328,14 @@ public class AudioVisualizer : Control
 
             var lines = text.SplitToLines();
             var unwrapped = string.Join("  ", lines);
-            prepared = (lines, unwrapped);
+
+            // Laying Arabic or Hebrew out left to right hands the neutrals - a dialogue dash, an
+            // ellipsis, brackets - the paragraph direction instead of the direction of the letters
+            // around them, so they end up on the wrong side of the line (issue 14262). Take the
+            // direction from the whole paragraph, not per line: a second line that happens to hold
+            // only neutrals or a Latin name belongs to the same block as the first.
+            var rightToLeft = TextToFlowDirectionConverter.GetFlowDirection(text) == FlowDirection.RightToLeft;
+            prepared = (lines, unwrapped, rightToLeft);
 
             if (_paragraphTextCache.Count > 8000)
             {
@@ -3365,7 +3378,7 @@ public class AudioVisualizer : Control
         {
             if (Se.Settings.Waveform.WaveformUnwrapText)
             {
-                var formattedText = GetCachedParagraphText(prepared.Unwrapped);
+                var formattedText = GetCachedParagraphText(prepared.Unwrapped, prepared.RightToLeft);
                 context.DrawText(formattedText, new Point(currentRegionLeft + 3, 14));
             }
             else
@@ -3373,7 +3386,7 @@ public class AudioVisualizer : Control
                 double addY = 0;
                 foreach (var line in prepared.Lines)
                 {
-                    var formattedText = GetCachedParagraphText(line);
+                    var formattedText = GetCachedParagraphText(line, prepared.RightToLeft);
                     context.DrawText(formattedText, new Point(currentRegionLeft + 3, 14 + addY));
                     addY += formattedText.Height;
                 }
@@ -3604,12 +3617,18 @@ public class AudioVisualizer : Control
                 _chapterTextCache.Clear();
             }
 
-            formatted = new FormattedText(text, CultureInfo.CurrentCulture, FlowDirection.LeftToRight,
+            // Right to left titles get their own direction, like the paragraph text does, so that
+            // neutrals keep the side the letters around them ask for. The alignment is pinned to
+            // the left: the flag is drawn from its left edge, and a right to left line would
+            // otherwise be pushed to the far end of MaxTextWidth, outside the flag.
+            formatted = new FormattedText(text, CultureInfo.CurrentCulture,
+                TextToFlowDirectionConverter.GetFlowDirection(text),
                 _typeface, 10, _paintChapterFlagTextBrush)
             {
                 MaxTextWidth = ChapterFlagMaxWidth - ChapterFlagPadding * 2,
                 MaxLineCount = 1,
                 Trimming = TextTrimming.CharacterEllipsis,
+                TextAlignment = TextAlignment.Left,
             };
 
             _chapterTextCache[text] = formatted;

--- a/tests/UI/Controls/AudioVisualizerRtlTextTests.cs
+++ b/tests/UI/Controls/AudioVisualizerRtlTextTests.cs
@@ -1,0 +1,120 @@
+using Avalonia;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
+using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace UITests.Controls;
+
+/// <summary>
+/// Issue #14262 (matter H): Arabic in the waveform was shaped with a left to right paragraph
+/// direction, so the neutral characters around the letters - the dialogue dash, the ellipsis,
+/// brackets - took the paragraph direction instead of the direction of the letters next to them
+/// and ended up on the wrong side of the line. SE 4 got this right, SE 5 beta 27 did not.
+/// </summary>
+public class AudioVisualizerRtlTextTests
+{
+    // "- Hello my friend..." - a dialogue dash before the letters and an ellipsis after them,
+    // the two neutrals from the issue's screenshots.
+    private const string ArabicLine = "- مرحبا يا صديقي...";
+
+    [AvaloniaFact]
+    public void ArabicParagraphIsShapedRightToLeft()
+    {
+        var av = new AudioVisualizer();
+
+        var prepared = av.GetPreparedParagraphText(ArabicLine);
+
+        Assert.True(prepared.RightToLeft);
+        Assert.Equal(FlowDirection.RightToLeft, av.GetCachedParagraphText(prepared.Unwrapped, prepared.RightToLeft).FlowDirection);
+    }
+
+    [AvaloniaFact]
+    public void LatinParagraphKeepsLeftToRight()
+    {
+        var av = new AudioVisualizer();
+
+        var prepared = av.GetPreparedParagraphText("- Where is Arturo?" + Environment.NewLine + "- He was here.");
+
+        Assert.False(prepared.RightToLeft);
+        Assert.Equal(FlowDirection.LeftToRight, av.GetCachedParagraphText(prepared.Unwrapped, prepared.RightToLeft).FlowDirection);
+    }
+
+    /// <summary>
+    /// The direction is decided for the whole paragraph, not line by line: a second line holding
+    /// only neutrals, digits or a Latin name belongs to the same block as the first one and must
+    /// not flip back to left to right in the middle of a subtitle.
+    /// </summary>
+    [AvaloniaFact]
+    public void ASecondLineWithoutRightToLeftLettersFollowsTheParagraph()
+    {
+        var av = new AudioVisualizer();
+
+        var prepared = av.GetPreparedParagraphText("مرحبا يا صديقي" + Environment.NewLine + "- (Gino)...");
+
+        Assert.True(prepared.RightToLeft);
+        Assert.Equal(2, prepared.Lines.Count);
+    }
+
+    /// <summary>
+    /// The symptom itself, measured on the shaped line: laid out left to right, the dialogue dash
+    /// is the leftmost thing on the line and the trailing "..." the rightmost - both on the wrong
+    /// side of a right to left line, which is exactly what the issue's SE 5 screenshot shows.
+    /// (Avalonia hands out no highlight geometry for a right to left line - it comes back empty -
+    /// so the right to left half of this is measured by rendering, below.)
+    /// </summary>
+    [AvaloniaFact]
+    public void LeftToRightLeavesTheNeutralsOnTheWrongSideOfAnArabicLine()
+    {
+        var av = new AudioVisualizer();
+        var leftToRight = av.GetCachedParagraphText(ArabicLine, false);
+
+        var dash = leftToRight.BuildHighlightGeometry(new Point(0, 0), 0, 1)!.Bounds;
+        var ellipsis = leftToRight.BuildHighlightGeometry(new Point(0, 0), ArabicLine.Length - 3, 3)!.Bounds;
+
+        Assert.True(dash.Left < leftToRight.Width / 2, "the dash should start the line when it is laid out left to right");
+        Assert.True(ellipsis.Left > leftToRight.Width / 2, "the ellipsis should end the line when it is laid out left to right");
+    }
+
+    /// <summary>
+    /// And the direction really reaches the shaping: the same string drawn right to left comes out
+    /// as a different picture (same width - the direction only reorders the glyphs).
+    /// </summary>
+    [AvaloniaFact]
+    public void TheDirectionChangesWhatIsDrawn()
+    {
+        var av = new AudioVisualizer();
+        var rightToLeft = av.GetCachedParagraphText(ArabicLine, true);
+        var leftToRight = av.GetCachedParagraphText(ArabicLine, false);
+
+        Assert.Equal(leftToRight.Width, rightToLeft.Width, 3);
+        Assert.NotEqual(Render(leftToRight), Render(rightToLeft));
+    }
+
+    private static byte[] Render(FormattedText text)
+    {
+        using var bitmap = new RenderTargetBitmap(new PixelSize(200, 40), new Vector(96, 96));
+        using (var context = bitmap.CreateDrawingContext())
+        {
+            context.FillRectangle(Brushes.Black, new Rect(0, 0, 200, 40));
+            context.DrawText(text, new Point(0, 0));
+        }
+
+        var pixels = new byte[200 * 40 * 4];
+        var handle = GCHandle.Alloc(pixels, GCHandleType.Pinned);
+        try
+        {
+            bitmap.CopyPixels(new PixelRect(0, 0, 200, 40), handle.AddrOfPinnedObject(), pixels.Length, 200 * 4);
+        }
+        finally
+        {
+            handle.Free();
+        }
+
+        return pixels;
+    }
+}


### PR DESCRIPTION
Issue #14262, matter H: Arabic in the waveform did not get proper RTL/BiDi treatment in SE 5 beta 27, while SE 4 rendered the same lines correctly. The dialogue dash and the trailing `...` in the issue's screenshots sit on the wrong side of the line.

**Cause:** `AudioVisualizer` shaped every paragraph line with `FlowDirection.LeftToRight`. For a line of Arabic (or Hebrew) letters the neutral characters around them — a leading dialogue dash, a trailing ellipsis, brackets — then take the *paragraph* direction rather than the direction of the letters they belong to, so they end up at the wrong end of the line. Bidi reorders the letters correctly either way, which is why only the punctuation looked wrong.

**Fix:** the direction is taken from the whole paragraph (after HTML tags are stripped), via the same `TextToFlowDirectionConverter` helper the grid and the compare view use, and applied to every line of that paragraph — a second line holding only neutrals or a Latin name belongs to the same block as the first, so it must not flip back mid-subtitle.

Placement is unchanged: with no finite paragraph width set, Avalonia lays an RTL line out from the draw origin, so the text stays left-aligned inside its region exactly as SE 4 draws it (verified by measuring the ink extents of a headless render against the SE 4 screenshot in the issue). The number/duration/CPS footer labels stay left to right; the shaped-text cache is keyed on the direction as well, since those labels ask for the LTR form of strings a paragraph may draw the other way.

Chapter titles get the same treatment, with `TextAlignment.Left` pinned: that layout *does* set a finite `MaxTextWidth`, which would otherwise push an RTL title to the far end of it, outside the flag.

**Tests:** `AudioVisualizerRtlTextTests` — the direction picked for Arabic / Latin / mixed paragraphs, and the symptom itself measured on the shaped line (laid out LTR the dash starts and the ellipsis ends the line; the two directions render differently). Avalonia returns empty highlight geometry for an RTL line, so that half is measured by rendering.

Not in scope: matters M-a, M-b, N, O, P and I of the same issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)