### PR TITLE
Waveform footer CPS follows the previewed text

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -3476,7 +3476,11 @@ public class AudioVisualizer : Control
         string? cpsLine = null;
         if (n > 99 && Se.Settings.Waveform.WaveformShowCps && paragraph.Duration.TotalMilliseconds > 0)
         {
-            cpsLine = GetCachedCpsLabel(paragraph.CharactersPerSecond);
+            // Counts the text that is actually on screen: with the original drawn, a CPS taken
+            // from the hidden translation reads as the original's and would be wrong (#14252).
+            cpsLine = GetCachedCpsLabel(ShowOriginalText
+                ? paragraph.OriginalCharactersPerSecond
+                : paragraph.CharactersPerSecond);
         }
 
         if (baseLine == null && cpsLine == null)

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -529,6 +529,45 @@ public partial class SubtitleLineViewModel : ObservableObject
         }
     }
 
+    private string? _cpsOriginalCacheText;
+    private TimeSpan _cpsOriginalCacheStart;
+    private TimeSpan _cpsOriginalCacheEnd;
+    private double _cpsOriginalCacheValue;
+
+    /// <summary>
+    /// Characters per second of the original text - what the waveform footer shows while it draws
+    /// the original instead of the translation ("toggle translation and original in video/audio
+    /// preview", #14252). Memoized exactly like <see cref="CharactersPerSecond"/>: the footer reads
+    /// it for every visible paragraph on every painted frame.
+    /// </summary>
+    public double OriginalCharactersPerSecond
+    {
+        get
+        {
+            if (string.IsNullOrEmpty(OriginalText))
+            {
+                return 0;
+            }
+
+            if (Duration.TotalMilliseconds <= 1.0)
+            {
+                return 999.0;
+            }
+
+            if (!ReferenceEquals(_cpsOriginalCacheText, OriginalText) ||
+                _cpsOriginalCacheStart != StartTime ||
+                _cpsOriginalCacheEnd != EndTime)
+            {
+                _cpsOriginalCacheText = OriginalText;
+                _cpsOriginalCacheStart = StartTime;
+                _cpsOriginalCacheEnd = EndTime;
+                _cpsOriginalCacheValue = SubtitleTextInfoHelper.GetCharactersPerSecond(OriginalText, StartTime, EndTime);
+            }
+
+            return _cpsOriginalCacheValue;
+        }
+    }
+
     public double WordsPerMinute // WPM
     {
         get

--- a/tests/UI/Controls/AudioVisualizerOriginalTextTests.cs
+++ b/tests/UI/Controls/AudioVisualizerOriginalTextTests.cs
@@ -40,10 +40,10 @@ public class AudioVisualizerOriginalTextTests
 
         var line = new SubtitleLineViewModel
         {
-            // Same length in both: the paragraph footer keeps showing the row's own CPS (the line
-            // being edited), so only equal-length texts make the two frames below pixel-identical.
+            // Deliberately different lengths: the footer's CPS follows the drawn text, so the
+            // frames below can only match if it swapped too.
             Text = "Vertaalde regel",
-            OriginalText = "Originele regel",
+            OriginalText = "Source line",
             StartTime = TimeSpan.FromSeconds(LineStartSeconds),
             EndTime = TimeSpan.FromSeconds(LineStartSeconds + 3),
         };
@@ -61,9 +61,10 @@ public class AudioVisualizerOriginalTextTests
         Assert.NotEqual(translation, original);
 
         // ... and it is the original text that was drawn, not merely something else: the same
-        // waveform with the original text in the ordinary Text property paints the same frame.
+        // waveform with the original text in the ordinary Text property paints the same frame -
+        // text, and the CPS in the paragraph footer with it.
         av.ShowOriginalText = false;
-        line.Text = "Originele regel";
+        line.Text = "Source line";
         av.InvalidateVisual();
         Assert.Equal(original, Capture(window));
     }


### PR DESCRIPTION
Follow-up to #14264 / #14252.

While "toggle translation and original in video/audio preview" is on, the waveform paints the original text but the paragraph footer kept showing the row's own characters-per-second — read next to the original text, that number looks like the original's and is wrong. It now counts whatever is actually on screen.

`SubtitleLineViewModel.OriginalCharactersPerSecond` is memoized exactly like `CharactersPerSecond`: the footer reads it for every visible paragraph on every painted frame.

The pixel-compare test now uses texts of different lengths, so the "same frame as with the original text in `Text`" assertion only holds if the CPS swapped too.

Full UI suite: 4305 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)