### PR TITLE
seconv: per-image OCR progress, percent on OCR and translate

### DIFF
--- a/docs/reference/command-line.md
+++ b/docs/reference/command-line.md
@@ -259,6 +259,10 @@ An AVI stream header carries no language, so a multi-stream `.avi` names its out
 
 Run `seconv list-ocr-engines` for the per-engine installation-status table.
 
+Long OCR runs report progress on one rewritten line - `  OCR 42/345 (12%)...` - counting the
+images of the current source (per PID for TS DVB-sub, per track for MKV). Auto-translate reports
+the same way (`  Translated 42/345 (12%)...`). Both are suppressed by `--quiet` and `--json`.
+
 ```bash
 # Tesseract
 seconv movie.sup subrip --ocr-engine:tesseract --ocr-language:eng
@@ -535,7 +539,7 @@ seconv *.srt subrip --settings:my.json --profile:broadcast --remove-text-for-hi
 
 | Option | Description |
 |---|---|
-| `--quiet` / `-q` | Suppress per-file progress and the parameters table; only print the final summary |
+| `--quiet` / `-q` | Suppress per-file progress, the parameters table, and the OCR/translate progress lines; only print the final summary |
 | `--verbose` / `-v` | Print extra diagnostic information, including full exception details (stack traces) on errors |
 | `--json` | Emit per-file results as JSON to stdout (suppresses Spectre output). Also accepted by every subcommand. Failures use the same envelope, so stdout is always one JSON document |
 

--- a/docs/reference/command-line.md
+++ b/docs/reference/command-line.md
@@ -259,9 +259,11 @@ An AVI stream header carries no language, so a multi-stream `.avi` names its out
 
 Run `seconv list-ocr-engines` for the per-engine installation-status table.
 
-Long OCR runs report progress on one rewritten line - `  OCR 42/345 (12%)...` - counting the
-images of the current source (per PID for TS DVB-sub, per track for MKV). Auto-translate reports
-the same way (`  Translated 42/345 (12%)...`). Both are suppressed by `--quiet` and `--json`.
+Long OCR runs report progress as images *finished* of the current source (per PID for TS
+DVB-sub, per track for MKV). On a terminal this rewrites a single line - `  OCR 42/345 (12%)...`;
+when stdout is a pipe or a file it prints one plain line per 10% instead, so a log of a
+5000-image run holds ten lines rather than one endless one. Auto-translate reports the same way
+(`  Translated 42/345 (12%)...`). Both are suppressed by `--quiet` and `--json`.
 
 ```bash
 # Tesseract

--- a/src/seconv/Core/AutoTranslateRunner.cs
+++ b/src/seconv/Core/AutoTranslateRunner.cs
@@ -382,13 +382,13 @@ internal sealed class AutoTranslateRunner
         var doTranslate = new DoAutoTranslate();
         if (!_options.Quiet)
         {
-            doTranslate.Progress = (done, total) => Console.Write($"\r  Translated {done}/{total} lines...");
+            doTranslate.Progress = (done, total) => ProgressLine.Report("Translated", done, total);
         }
 
         var rows = await doTranslate.DoTranslate(subtitle, source, target, _translator, cancellationToken);
         if (!_options.Quiet)
         {
-            Console.WriteLine();
+            ProgressLine.Finish();
         }
 
         for (var i = 0; i < subtitle.Paragraphs.Count && i < rows.Count; i++)

--- a/src/seconv/Core/ImageOcrLoader.cs
+++ b/src/seconv/Core/ImageOcrLoader.cs
@@ -32,14 +32,22 @@ internal static class ImageOcrLoader
 
         if (options.TimeCodesOnly)
         {
-            AnsiConsole.MarkupLine($"[dim]Extracting time codes from {pcsList.Count} Blu-Ray sup image(s) (no OCR)...[/]");
+            if (!options.Quiet)
+            {
+                AnsiConsole.MarkupLine($"[dim]Extracting time codes from {pcsList.Count} Blu-Ray sup image(s) (no OCR)...[/]");
+            }
+
             return PcsListToSubtitle(pcsList, null);
         }
 
         using var ocr = OcrEngineFactory.Create(options);
         var isolationNote = options.PgsIsolateColors ? string.Empty : " (colour isolation off)";
-        AnsiConsole.MarkupLine($"[dim]Running {ocr.Name} OCR on {pcsList.Count} Blu-Ray sup image(s){isolationNote}...[/]");
-        return PcsListToSubtitle(pcsList, ocr, options.PgsIsolateColors);
+        if (!options.Quiet)
+        {
+            AnsiConsole.MarkupLine($"[dim]Running {ocr.Name} OCR on {pcsList.Count} Blu-Ray sup image(s){isolationNote}...[/]");
+        }
+
+        return PcsListToSubtitle(pcsList, ocr, options.PgsIsolateColors, options.Quiet);
     }
 
     /// <summary>
@@ -56,14 +64,22 @@ internal static class ImageOcrLoader
 
         if (options.TimeCodesOnly)
         {
-            AnsiConsole.MarkupLine($"[dim]Extracting time codes from {pcsList.Count} MKV PGS image(s) (track #{track.TrackNumber}, no OCR)...[/]");
+            if (!options.Quiet)
+            {
+                AnsiConsole.MarkupLine($"[dim]Extracting time codes from {pcsList.Count} MKV PGS image(s) (track #{track.TrackNumber}, no OCR)...[/]");
+            }
+
             return PcsListToSubtitle(pcsList, null);
         }
 
         using var ocr = OcrEngineFactory.Create(options);
         var isolationNote = options.PgsIsolateColors ? string.Empty : " (colour isolation off)";
-        AnsiConsole.MarkupLine($"[dim]Running {ocr.Name} OCR on {pcsList.Count} MKV PGS image(s) (track #{track.TrackNumber}){isolationNote}...[/]");
-        return PcsListToSubtitle(pcsList, ocr, options.PgsIsolateColors);
+        if (!options.Quiet)
+        {
+            AnsiConsole.MarkupLine($"[dim]Running {ocr.Name} OCR on {pcsList.Count} MKV PGS image(s) (track #{track.TrackNumber}){isolationNote}...[/]");
+        }
+
+        return PcsListToSubtitle(pcsList, ocr, options.PgsIsolateColors, options.Quiet);
     }
 
     /// <summary>
@@ -95,12 +111,25 @@ internal static class ImageOcrLoader
                     continue;
                 }
 
-                AnsiConsole.MarkupLine(ocr is null
-                    ? $"[dim]Extracting time codes from {dvbSubtitles.Count} DVB-sub image(s) (PID {pid}, no OCR)...[/]"
-                    : $"[dim]Running {ocr.Name} OCR on {dvbSubtitles.Count} DVB-sub image(s) (PID {pid})...[/]");
+                if (!options.Quiet)
+                {
+                    AnsiConsole.MarkupLine(ocr is null
+                        ? $"[dim]Extracting time codes from {dvbSubtitles.Count} DVB-sub image(s) (PID {pid}, no OCR)...[/]"
+                        : $"[dim]Running {ocr.Name} OCR on {dvbSubtitles.Count} DVB-sub image(s) (PID {pid})...[/]");
+                }
+
+                // Recognition is the slow part, so report it per image (issue #14267).
+                var showProgress = ocr is not null && !options.Quiet;
+                var done = 0;
                 var subtitle = new Subtitle();
                 foreach (var dvb in dvbSubtitles)
                 {
+                    done++;
+                    if (showProgress)
+                    {
+                        ProgressLine.Report("OCR", done, dvbSubtitles.Count);
+                    }
+
                     var bitmap = dvb.GetBitmap();
                     if (bitmap is null)
                     {
@@ -134,6 +163,12 @@ internal static class ImageOcrLoader
                         bitmap.Dispose();
                     }
                 }
+
+                if (showProgress)
+                {
+                    ProgressLine.Finish();
+                }
+
                 subtitle.Renumber();
                 if (subtitle.Paragraphs.Count > 0)
                 {
@@ -225,14 +260,22 @@ internal static class ImageOcrLoader
         {
             if (options.TimeCodesOnly)
             {
-                AnsiConsole.MarkupLine($"[dim]Extracting time codes from {what} (no OCR)...[/]");
+                if (!options.Quiet)
+                {
+                    AnsiConsole.MarkupLine($"[dim]Extracting time codes from {what} (no OCR)...[/]");
+                }
+
                 return BitmapItemsToSubtitle(items, null);
             }
 
             using var ocr = OcrEngineFactory.Create(options);
             var isolationNote = options.VobSubIsolateColors ? string.Empty : " (colour isolation off)";
-            AnsiConsole.MarkupLine($"[dim]Running {ocr.Name} OCR on {what}{isolationNote}...[/]");
-            return BitmapItemsToSubtitle(items, ocr, options.VobSubIsolateColors);
+            if (!options.Quiet)
+            {
+                AnsiConsole.MarkupLine($"[dim]Running {ocr.Name} OCR on {what}{isolationNote}...[/]");
+            }
+
+            return BitmapItemsToSubtitle(items, ocr, options.VobSubIsolateColors, options.Quiet);
         }
         finally
         {
@@ -251,12 +294,22 @@ internal static class ImageOcrLoader
     /// in time-codes-only mode since no recognition happens there).
     /// </summary>
     private static Subtitle BitmapItemsToSubtitle(
-        IReadOnlyList<BitmapSubtitleLoader.BitmapSubtitleItem> items, IOcrEngine? ocr, bool isolateColors = false)
+        IReadOnlyList<BitmapSubtitleLoader.BitmapSubtitleItem> items, IOcrEngine? ocr, bool isolateColors = false,
+        bool quiet = false)
     {
         var subtitle = new Subtitle();
         var blankCount = 0;
+        // Time-codes-only mode is instant, so only a real OCR run reports progress (#14267).
+        var showProgress = ocr is not null && !quiet;
+        var done = 0;
         foreach (var item in items)
         {
+            done++;
+            if (showProgress)
+            {
+                ProgressLine.Report("OCR", done, items.Count);
+            }
+
             string text;
             if (ocr is null)
             {
@@ -283,7 +336,12 @@ internal static class ImageOcrLoader
             }
         }
 
-        if (blankCount > 0)
+        if (showProgress)
+        {
+            ProgressLine.Finish();
+        }
+
+        if (blankCount > 0 && !quiet)
         {
             // Issue #12772: these used to vanish without a trace, making it look like the
             // source had fewer subtitles than the GUI sees.
@@ -301,12 +359,22 @@ internal static class ImageOcrLoader
     /// kept with empty text so the output carries timing but no recognised characters.
     /// Entries whose bitmap is null (e.g. clear-screen commands) are skipped in both modes.
     /// </summary>
-    private static Subtitle PcsListToSubtitle(List<BluRaySupParser.PcsData> pcsList, IOcrEngine? ocr, bool isolateColors = false)
+    private static Subtitle PcsListToSubtitle(List<BluRaySupParser.PcsData> pcsList, IOcrEngine? ocr,
+        bool isolateColors = false, bool quiet = false)
     {
         var subtitle = new Subtitle();
+        // Time-codes-only mode is instant, so only a real OCR run reports progress (#14267).
+        var showProgress = ocr is not null && !quiet;
+        var done = 0;
 
         foreach (var pcs in pcsList)
         {
+            done++;
+            if (showProgress)
+            {
+                ProgressLine.Report("OCR", done, pcsList.Count);
+            }
+
             var bitmap = pcs.GetBitmap();
             if (bitmap is null)
             {
@@ -340,6 +408,12 @@ internal static class ImageOcrLoader
                 bitmap.Dispose();
             }
         }
+
+        if (showProgress)
+        {
+            ProgressLine.Finish();
+        }
+
         subtitle.Renumber();
         return subtitle;
     }

--- a/src/seconv/Core/ImageOcrLoader.cs
+++ b/src/seconv/Core/ImageOcrLoader.cs
@@ -124,11 +124,14 @@ internal static class ImageOcrLoader
                 var subtitle = new Subtitle();
                 foreach (var dvb in dvbSubtitles)
                 {
-                    done++;
+                    // Reported before the image is recognised, so the count is images
+                    // *finished* - 100% must not show while the last one is still running.
                     if (showProgress)
                     {
                         ProgressLine.Report("OCR", done, dvbSubtitles.Count);
                     }
+
+                    done++;
 
                     var bitmap = dvb.GetBitmap();
                     if (bitmap is null)
@@ -166,6 +169,7 @@ internal static class ImageOcrLoader
 
                 if (showProgress)
                 {
+                    ProgressLine.Report("OCR", dvbSubtitles.Count, dvbSubtitles.Count);
                     ProgressLine.Finish();
                 }
 
@@ -304,11 +308,13 @@ internal static class ImageOcrLoader
         var done = 0;
         foreach (var item in items)
         {
-            done++;
+            // Reported before the image is recognised, so the count is images *finished*.
             if (showProgress)
             {
                 ProgressLine.Report("OCR", done, items.Count);
             }
+
+            done++;
 
             string text;
             if (ocr is null)
@@ -338,6 +344,7 @@ internal static class ImageOcrLoader
 
         if (showProgress)
         {
+            ProgressLine.Report("OCR", items.Count, items.Count);
             ProgressLine.Finish();
         }
 
@@ -369,11 +376,13 @@ internal static class ImageOcrLoader
 
         foreach (var pcs in pcsList)
         {
-            done++;
+            // Reported before the image is recognised, so the count is images *finished*.
             if (showProgress)
             {
                 ProgressLine.Report("OCR", done, pcsList.Count);
             }
+
+            done++;
 
             var bitmap = pcs.GetBitmap();
             if (bitmap is null)
@@ -411,6 +420,7 @@ internal static class ImageOcrLoader
 
         if (showProgress)
         {
+            ProgressLine.Report("OCR", pcsList.Count, pcsList.Count);
             ProgressLine.Finish();
         }
 

--- a/src/seconv/Core/ProgressLine.cs
+++ b/src/seconv/Core/ProgressLine.cs
@@ -1,0 +1,42 @@
+namespace SeConv.Core;
+
+/// <summary>
+/// A single carriage-return-rewritten console line for long-running work (OCR, translate):
+/// <c>"  OCR 12/345 (3%)..."</c>. Written with <see cref="Console"/> rather than
+/// <c>AnsiConsole</c> because Spectre's markup writer does not rewrite a line on <c>\r</c>.
+/// Callers suppress it in quiet/JSON mode (issue #14267: seconv used to print one line at
+/// the start of an OCR run and then stay silent until it finished).
+/// </summary>
+internal static class ProgressLine
+{
+    /// <summary>
+    /// Percent complete as a whole number. Floored, so 100% shows only when the last item is
+    /// done, and clamped so a bad count cannot print a negative or above-100 percentage.
+    /// Returns 0 when there is nothing to do.
+    /// </summary>
+    public static int Percent(int done, int total)
+    {
+        if (total <= 0)
+        {
+            return 0;
+        }
+
+        return (int)Math.Clamp(done * 100L / total, 0, 100);
+    }
+
+    /// <summary>
+    /// Rewrites the current console line as <c>"  {label} {done}/{total} ({pct}%)..."</c>.
+    /// The rendered text never shrinks between calls (counts and percent only grow), so the
+    /// rewrite cannot leave stale characters behind.
+    /// </summary>
+    public static void Report(string label, int done, int total)
+    {
+        Console.Write($"\r  {label} {done}/{total} ({Percent(done, total)}%)...");
+    }
+
+    /// <summary>Ends a progress line so whatever prints next starts on a fresh line.</summary>
+    public static void Finish()
+    {
+        Console.WriteLine();
+    }
+}

--- a/src/seconv/Core/ProgressLine.cs
+++ b/src/seconv/Core/ProgressLine.cs
@@ -1,11 +1,16 @@
 namespace SeConv.Core;
 
 /// <summary>
-/// A single carriage-return-rewritten console line for long-running work (OCR, translate):
-/// <c>"  OCR 12/345 (3%)..."</c>. Written with <see cref="Console"/> rather than
-/// <c>AnsiConsole</c> because Spectre's markup writer does not rewrite a line on <c>\r</c>.
-/// Callers suppress it in quiet/JSON mode (issue #14267: seconv used to print one line at
-/// the start of an OCR run and then stay silent until it finished).
+/// Progress for long-running work (OCR, translate), reported as a count of finished items
+/// plus a percentage (issue #14267: seconv used to print one line at the start of an OCR run
+/// and then stay silent until it finished). Callers suppress it in quiet/JSON mode.
+///
+/// On a terminal this rewrites a single line with <c>\r</c> - <c>"  OCR 12/345 (3%)..."</c> -
+/// using <see cref="Console"/> rather than <c>AnsiConsole</c>, since Spectre's markup writer
+/// does not rewrite a line on <c>\r</c>. When stdout is redirected (a pipe, a log file, a CI
+/// job) a rewritten line would collapse into one enormous line, so progress falls back to
+/// plain newline-terminated lines at every 10% instead - still parseable by a caller watching
+/// the pipe, which is the whole point of the request.
 /// </summary>
 internal static class ProgressLine
 {
@@ -25,18 +30,44 @@ internal static class ProgressLine
     }
 
     /// <summary>
-    /// Rewrites the current console line as <c>"  {label} {done}/{total} ({pct}%)..."</c>.
-    /// The rendered text never shrinks between calls (counts and percent only grow), so the
-    /// rewrite cannot leave stale characters behind.
+    /// Forces terminal (true) or redirected (false) rendering; null = ask
+    /// <see cref="Console.IsOutputRedirected"/>. For tests only: a test runner redirects the
+    /// process's stdout, and <see cref="Console.SetOut"/> does not change that, so without
+    /// this seam only the redirected form would ever be testable.
+    /// </summary>
+    internal static bool? InteractiveOverride { get; set; }
+
+    private static bool IsInteractive => InteractiveOverride ?? !Console.IsOutputRedirected;
+
+    /// <summary>
+    /// Reports <paramref name="done"/> of <paramref name="total"/> items finished.
+    /// On a terminal every call rewrites the line; when redirected only calls that cross a
+    /// 10% boundary print, so a 5000-image run leaves ten lines in the log rather than 5000.
     /// </summary>
     public static void Report(string label, int done, int total)
     {
-        Console.Write($"\r  {label} {done}/{total} ({Percent(done, total)}%)...");
+        if (IsInteractive)
+        {
+            // The rendered text never shrinks between calls (the counts and the percent only
+            // grow), so the rewrite cannot leave stale characters of a longer line behind.
+            Console.Write($"\r  {label} {done}/{total} ({Percent(done, total)}%)...");
+            return;
+        }
+
+        // Stateless milestone test: print only when this item pushed the percentage into a
+        // new group of ten, which also makes the final item (100%) always print.
+        if (Percent(done, total) / 10 != Percent(done - 1, total) / 10)
+        {
+            Console.WriteLine($"  {label} {done}/{total} ({Percent(done, total)}%)...");
+        }
     }
 
     /// <summary>Ends a progress line so whatever prints next starts on a fresh line.</summary>
     public static void Finish()
     {
-        Console.WriteLine();
+        if (IsInteractive)
+        {
+            Console.WriteLine();
+        }
     }
 }

--- a/tests/seconv/Core/ProgressLineTest.cs
+++ b/tests/seconv/Core/ProgressLineTest.cs
@@ -52,49 +52,110 @@ public class ProgressLineTest
         Assert.Equal(50, ProgressLine.Percent(50_000_000, 100_000_000));
     }
 
-    [Fact]
-    public void Report_RewritesOneLineWithCountAndPercent()
+    /// <summary>
+    /// Captures what ProgressLine writes for one run, in terminal or redirected mode.
+    /// Console.SetOut alone cannot drive that choice: the test runner has already redirected
+    /// the process's stdout, so Console.IsOutputRedirected is true here no matter what.
+    /// </summary>
+    private static string Capture(bool interactive, Action<Action<int, int>> run)
     {
         var original = Console.Out;
         var buffer = new StringWriter();
         try
         {
             Console.SetOut(buffer);
-            ProgressLine.Report("OCR", 12, 345);
+            ProgressLine.InteractiveOverride = interactive;
+            run((done, total) => ProgressLine.Report("OCR", done, total));
         }
         finally
         {
+            ProgressLine.InteractiveOverride = null;
             Console.SetOut(original);
         }
 
-        Assert.Equal("\r  OCR 12/345 (3%)...", buffer.ToString());
+        return buffer.ToString();
     }
 
     [Fact]
-    public void Report_RenderedTextNeverShrinks()
+    public void Report_Terminal_RewritesOneLineWithCountAndPercent()
+    {
+        var output = Capture(interactive: true, report => report(12, 345));
+
+        Assert.Equal("\r  OCR 12/345 (3%)...", output);
+    }
+
+    [Fact]
+    public void Report_Terminal_RewritesOnEveryItem()
+    {
+        var output = Capture(interactive: true, report =>
+        {
+            for (var done = 0; done <= 200; done++)
+            {
+                report(done, 200);
+            }
+        });
+
+        // One \r-prefixed rewrite per call, no newlines to scroll the terminal.
+        Assert.Equal(201, output.Split('\r').Length - 1);
+        Assert.DoesNotContain('\n', output);
+    }
+
+    [Fact]
+    public void Report_Terminal_RenderedTextNeverShrinks()
     {
         // The \r rewrite only works because the line grows: a shorter line would leave
         // characters of the previous one behind.
-        var original = Console.Out;
-        var lengths = new List<int>();
-        try
+        var previous = 0;
+        for (var done = 0; done <= 250; done++)
         {
-            for (var done = 0; done <= 250; done++)
-            {
-                var buffer = new StringWriter();
-                Console.SetOut(buffer);
-                ProgressLine.Report("OCR", done, 250);
-                lengths.Add(buffer.ToString().Length);
-            }
+            var length = Capture(interactive: true, report => report(done, 250)).Length;
+            Assert.True(length >= previous, $"line shrank at {done}: {previous} -> {length}");
+            previous = length;
         }
-        finally
-        {
-            Console.SetOut(original);
-        }
+    }
 
-        for (var i = 1; i < lengths.Count; i++)
+    [Fact]
+    public void Report_Redirected_WritesWholeLinesAtEveryTenPercent()
+    {
+        var output = Capture(interactive: false, report =>
         {
-            Assert.True(lengths[i] >= lengths[i - 1], $"line shrank at {i}: {lengths[i - 1]} -> {lengths[i]}");
-        }
+            for (var done = 0; done <= 5000; done++)
+            {
+                report(done, 5000);
+            }
+        });
+
+        // A pipe or log file gets ten milestones, not 5000 fragments of one endless line.
+        var lines = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(10, lines.Length);
+        Assert.Equal("  OCR 500/5000 (10%)...", lines[0]);
+        Assert.Equal("  OCR 5000/5000 (100%)...", lines[^1]);
+        Assert.DoesNotContain('\r', output);
+    }
+
+    [Fact]
+    public void Report_Redirected_ShortRunStillReportsEveryItemAndEndsAt100()
+    {
+        var output = Capture(interactive: false, report =>
+        {
+            for (var done = 0; done <= 3; done++)
+            {
+                report(done, 3);
+            }
+        });
+
+        var lines = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(
+            ["  OCR 1/3 (33%)...", "  OCR 2/3 (66%)...", "  OCR 3/3 (100%)..."],
+            lines);
+    }
+
+    [Fact]
+    public void Finish_OnlyEndsTheLineOnATerminal()
+    {
+        // Redirected output is already newline-terminated; a second newline would leave a
+        // blank line in the log.
+        Assert.Equal(Environment.NewLine, Capture(interactive: true, _ => ProgressLine.Finish()));
+        Assert.Equal(string.Empty, Capture(interactive: false, _ => ProgressLine.Finish()));
     }
 }

--- a/tests/seconv/Core/ProgressLineTest.cs
+++ b/tests/seconv/Core/ProgressLineTest.cs
@@ -1,0 +1,100 @@
+using SeConv.Core;
+using Xunit;
+
+namespace SeConvTests.Core;
+
+/// <summary>
+/// The shared one-line progress used by the OCR loops and auto-translate (issue #14267).
+/// </summary>
+public class ProgressLineTest
+{
+    [Theory]
+    [InlineData(0, 100, 0)]
+    [InlineData(1, 100, 1)]
+    [InlineData(50, 100, 50)]
+    [InlineData(100, 100, 100)]
+    [InlineData(1, 3, 33)]
+    [InlineData(2, 3, 66)]
+    [InlineData(3, 3, 100)]
+    public void Percent_ReportsWholePercent(int done, int total, int expected)
+    {
+        Assert.Equal(expected, ProgressLine.Percent(done, total));
+    }
+
+    [Fact]
+    public void Percent_FloorsSoOnlyTheLastItemShows100()
+    {
+        // 999/1000 must not round up to a misleading "100%".
+        Assert.Equal(99, ProgressLine.Percent(999, 1000));
+        Assert.Equal(100, ProgressLine.Percent(1000, 1000));
+    }
+
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(5, 0)]
+    [InlineData(5, -1)]
+    public void Percent_NothingToDo_IsZeroNotDivideByZero(int done, int total)
+    {
+        Assert.Equal(0, ProgressLine.Percent(done, total));
+    }
+
+    [Fact]
+    public void Percent_OutOfRangeCountsAreClamped()
+    {
+        Assert.Equal(100, ProgressLine.Percent(11, 10));
+        Assert.Equal(0, ProgressLine.Percent(-1, 10));
+    }
+
+    [Fact]
+    public void Percent_LargeCountsDoNotOverflow()
+    {
+        // done * 100 overflows int at ~21.5M; the multiply is done in long.
+        Assert.Equal(50, ProgressLine.Percent(50_000_000, 100_000_000));
+    }
+
+    [Fact]
+    public void Report_RewritesOneLineWithCountAndPercent()
+    {
+        var original = Console.Out;
+        var buffer = new StringWriter();
+        try
+        {
+            Console.SetOut(buffer);
+            ProgressLine.Report("OCR", 12, 345);
+        }
+        finally
+        {
+            Console.SetOut(original);
+        }
+
+        Assert.Equal("\r  OCR 12/345 (3%)...", buffer.ToString());
+    }
+
+    [Fact]
+    public void Report_RenderedTextNeverShrinks()
+    {
+        // The \r rewrite only works because the line grows: a shorter line would leave
+        // characters of the previous one behind.
+        var original = Console.Out;
+        var lengths = new List<int>();
+        try
+        {
+            for (var done = 0; done <= 250; done++)
+            {
+                var buffer = new StringWriter();
+                Console.SetOut(buffer);
+                ProgressLine.Report("OCR", done, 250);
+                lengths.Add(buffer.ToString().Length);
+            }
+        }
+        finally
+        {
+            Console.SetOut(original);
+        }
+
+        for (var i = 1; i < lengths.Count; i++)
+        {
+            Assert.True(lengths[i] >= lengths[i - 1], $"line shrank at {i}: {lengths[i - 1]} -> {lengths[i]}");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #14267.

`seconv` printed one `Running tesseract OCR on N image(s)...` line and then went silent for the
whole recognition run. With a slow engine (Ollama, llama.cpp) that is minutes of nothing, with no
way to tell whether it is working or wedged. Auto-translate did report progress, but as a bare
count with no percentage.

## What this does

Progress is reported as images (or lines) **finished**, with a percentage:

```
Running tesseract OCR on 345 Blu-Ray sup image(s)...
  OCR 42/345 (12%)...
```

- **OCR**: reported per image from every recognition loop - Blu-Ray `.sup`, MKV PGS, TS DVB-sub
  (per PID), VobSub `.sub`/`.idx`, MKV/MP4 VobSub, AVI XSUB. Per image rather than batched,
  because with a prompt-driven engine each image *is* the wait.
- **Auto-translate**: same line, now with a percentage - `  Translated 42/345 (12%)...`.
- `--time-codes-only` skips progress entirely: no engine runs, so there is nothing to wait for.
- Both are suppressed by `--quiet` and `--json`.

The count is of finished items, so `100%` cannot appear while the last (and possibly slowest)
image is still being recognised; the first render is `0/N (0%)`, which is immediate feedback that
the run started.

### Terminal vs redirected stdout

On a terminal the line is rewritten in place with `\r`. When stdout is redirected - a pipe, a log
file, a CI job - that would collapse into one enormous line, so progress falls back to plain
newline-terminated lines at every 10%:

```
  OCR 500/5000 (10%)...
  OCR 1000/5000 (20%)...
```

A caller watching the pipe (the use case in the issue) still gets progress, and a 5000-image run
leaves ten lines in the log rather than 5000 fragments.

Percent is floored (so `100%` shows only when the last item is done), clamped, and computed in
`long` so a large count cannot overflow; `total <= 0` yields `0` rather than dividing by zero.

## Drive-by fix

The `Running ... OCR on N image(s)` / `Extracting time codes from ...` header lines were printed
unconditionally, so under `--json` they were mixed into stdout and broke the documented
`seconv ... --json | jq` contract. They now honour `Quiet` (`--quiet || --json`) like the rest of
the converter's output.

## Verification

Real Tesseract runs on the repo's Blu-Ray fixture. Under a pty (`\r` shown expanded):

```
Running tesseract OCR on 2 Blu-Ray sup image(s)...
  OCR 0/2 (0%)...[CR]  OCR 1/2 (50%)...[CR]  OCR 2/2 (100%)...
```

and piped:

```
Running tesseract OCR on 2 Blu-Ray sup image(s)...
  OCR 1/2 (50%)...
  OCR 2/2 (100%)...
```

`--json` now emits a clean single JSON document; `--quiet` prints only the final summary.

19 tests in `tests/seconv/Core/ProgressLineTest.cs` (percent math, floor/clamp/overflow, both
render modes, the 10% milestone rule, and that the rewritten line never shrinks - the `\r` rewrite
depends on that). Full seconv suite: 448/448 passing. The translate path shares the same helper
but is not exercised end-to-end here, since that needs a live translate engine.

Docs updated in `docs/reference/command-line.md` (OCR section + `--quiet` row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)