### PR TITLE
Teletext alignment dialog: clearer view-option labels, wider line boxes

### DIFF
--- a/src/ui/Features/Shared/PickTeletextAlignment/PickTeletextAlignmentWindow.cs
+++ b/src/ui/Features/Shared/PickTeletextAlignment/PickTeletextAlignmentWindow.cs
@@ -67,17 +67,8 @@ public class PickTeletextAlignmentWindow : Window
             },
         };
 
-        var previewCheckBox = new CheckBox { Content = Se.Language.General.Preview };
-        previewCheckBox.Bind(CheckBox.IsCheckedProperty, new Binding(nameof(vm.Preview))
-        {
-            Mode = BindingMode.TwoWay,
-        });
-
-        var showTeletextCheckBox = new CheckBox { Content = Se.Language.General.ShowTeletext };
-        showTeletextCheckBox.Bind(CheckBox.IsCheckedProperty, new Binding(nameof(vm.ShowTeletextColumn))
-        {
-            Mode = BindingMode.TwoWay,
-        });
+        var previewCheckBox = UiUtil.MakeCheckBox(Se.Language.General.PreviewAlignmentInListView, vm, nameof(vm.Preview));
+        var showTeletextCheckBox = UiUtil.MakeCheckBox(Se.Language.General.ShowTeletext, vm, nameof(vm.ShowTeletextColumn));
 
         var buttonPanel = new StackPanel
         {
@@ -95,6 +86,7 @@ public class PickTeletextAlignmentWindow : Window
         {
             RowDefinitions =
             {
+                new RowDefinition(GridLength.Auto),
                 new RowDefinition(GridLength.Auto),
                 new RowDefinition(GridLength.Auto),
                 new RowDefinition(GridLength.Auto),
@@ -125,9 +117,11 @@ public class PickTeletextAlignmentWindow : Window
         grid.Add(replaceLineCheckBox, 3, 0);
         grid.Add(replaceLinePanel, 3, 1);
 
-        grid.Add(previewCheckBox, 4, 0);
-        grid.Add(showTeletextCheckBox, 5, 0);
-        grid.Add(buttonPanel, 6, 1);
+        // View options, separated from the opt-in edit rows above.
+        grid.Add(UiUtil.MakeHorizontalSeparator(margin: new Thickness(0, 2)), 4, 0, 1, 2);
+        grid.Add(previewCheckBox, 5, 0, 1, 2);
+        grid.Add(showTeletextCheckBox, 6, 0, 1, 2);
+        grid.Add(buttonPanel, 7, 1);
 
         Content = grid;
 
@@ -161,7 +155,7 @@ public class PickTeletextAlignmentWindow : Window
             Minimum = minimum,
             Maximum = maximum,
             Increment = 1,
-            Width = 100,
+            Width = 120,
         };
 
         numericUpDown.Bind(NumericUpDown.ValueProperty, new Binding(propertyName)

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -443,6 +443,7 @@ public class LanguageGeneral
     public string PoweredBy { get; set; }
     public string Prefix { get; set; }
     public string Preview { get; set; }
+    public string PreviewAlignmentInListView { get; set; }
     public string Previous { get; set; }
     public string Profile { get; set; }
     public string Quality { get; set; }
@@ -1238,6 +1239,7 @@ public class LanguageGeneral
         PoweredBy = "Powered by";
         Prefix = "Prefix";
         Preview = "Preview";
+        PreviewAlignmentInListView = "Preview alignment in list view";
         Previous = "Previous";
         Profile = "Profile";
         Quality = "Quality";
@@ -1354,7 +1356,7 @@ public class LanguageGeneral
         ShowPreview = "Show preview";
         ShowShotChangesList = "Show shot changes list";
         ShowStyleColumn = "Show \"Style\" column";
-        ShowTeletext = "Show TT";
+        ShowTeletext = "Show teletext column in list view";
         ShowTimeCodes = "Show time codes";
         ShowWpmColumn = "Show \"Words/min\" column";
         ShowPixelWidthColumn = "Show \"Pixel width\" column";


### PR DESCRIPTION
Small polish pass on the teletext alignment dialog (EBU STL):

- The **"Preview"** checkbox is now **"Preview alignment in list view"** — it toggles whether the subtitle grid's text column renders each line left/center/right per its teletext alignment.
- The **"Show TT"** checkbox is now **"Show teletext column in list view"** (the string is only used in this dialog, so the longer text is safe).
- The two view-option checkboxes are separated from the opt-in edit rows above by a thin horizontal separator, and span both grid columns so their labels don't widen the label column.
- Numeric up/down boxes (teletext line, shift, replace from/to) widened from 100 to 120.

Verified with a headless render:

the dialog now shows the four opt-in edit rows, a separator, then the two clearly-labeled view options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)