### PR TITLE
Add macOS "Look up" to the subtitle text box context menu

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Windows.Input;
 using Avalonia;
@@ -1789,6 +1789,25 @@ public static partial class InitListViewAndEditBox
         }
 
         flyoutTextBox.Items.Add(new Separator());
+
+        // macOS-only "Look up" (#14277): every macOS text field has it in the system context menu,
+        // and it is the shortest way into the dictionaries/thesauri the user has installed. It sits
+        // above "Google it", where macOS puts it (Look Up, then Search with Google).
+        if (OperatingSystem.IsMacOS())
+        {
+            var menuItemTextBoxLookUp = new MenuItem
+            {
+                [!MenuItem.HeaderProperty] = new Binding(nameof(vm.TextBoxLookUpHeader)),
+                [!Visual.IsVisibleProperty] = new Binding(nameof(vm.IsTextBoxLookUpVisible)),
+                Command = vm.LookUpInDictionaryCommand,
+                Icon = new Icon
+                {
+                    Value = IconNames.BookAlphabet,
+                    VerticalAlignment = VerticalAlignment.Center,
+                },
+            };
+            flyoutTextBox.Items.Add(menuItemTextBoxLookUp);
+        }
 
         // Shown only with a selection - the command searches the selected text and does nothing
         // without one. It had no default shortcut and was in no menu, so it was unreachable

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -406,6 +406,8 @@ public partial class MainViewModel :
     [ObservableProperty] private bool _isVideoLoaded;
     [ObservableProperty] private bool _isTextBoxSplitAtCursorAndVideoPositionVisible;
     [ObservableProperty] private bool _isTextBoxGoogleItVisible;
+    [ObservableProperty] private bool _isTextBoxLookUpVisible;
+    [ObservableProperty] private string _textBoxLookUpHeader = string.Empty;
     [ObservableProperty] private ObservableCollection<string> _speeds;
     [ObservableProperty] private string _selectedSpeed;
     [ObservableProperty] private ObservableCollection<string> _videoSeekAmounts;
@@ -630,6 +632,7 @@ public partial class MainViewModel :
     private bool _loading;
     private bool _opening;
     private PointerEventArgs? _lastTextEditorPointerArgs;
+    private string? _textBoxLookUpWord;
     private PointerEventArgs? _lastSubtitleGridPointerArgs;
 
     // The dictionary currently loaded into _spellCheckManager for live spell check, null when none
@@ -13763,6 +13766,27 @@ public partial class MainViewModel :
         }
 
         UiUtil.OpenUrl("https://www.google.com/search?q=" + Uri.EscapeDataString(selected));
+    }
+
+    /// <summary>
+    /// macOS "Look up" (#14277): opens the selected text - or the word that was right-clicked - in
+    /// Dictionary.app, which holds every dictionary and thesaurus the user has installed.
+    /// </summary>
+    [RelayCommand]
+    private void LookUpInDictionary()
+    {
+        if (!OperatingSystem.IsMacOS())
+        {
+            return;
+        }
+
+        var url = MacDictionaryLookup.BuildUrl(_textBoxLookUpWord);
+        if (url == null)
+        {
+            return;
+        }
+
+        UiUtil.OpenUrl(url);
     }
 
     [RelayCommand]
@@ -29958,6 +29982,31 @@ public partial class MainViewModel :
         SelectAndScrollToSubtitle(p);
     }
 
+    /// <summary>
+    /// Works out what the macOS "Look up" menu item would look up: the selected text, or - with no
+    /// selection - the word the right-click landed on, like the system context menu does.
+    /// </summary>
+    private void UpdateTextBoxLookUp()
+    {
+        _textBoxLookUpWord = null;
+
+        if (OperatingSystem.IsMacOS())
+        {
+            var selected = EditTextBox.SelectedText;
+            _textBoxLookUpWord = !string.IsNullOrWhiteSpace(selected)
+                ? MacDictionaryLookup.Normalize(selected)
+                : MacDictionaryLookup.Normalize(_lastTextEditorPointerArgs == null
+                    ? null
+                    : EditTextBox.GetWordAtPosition(_lastTextEditorPointerArgs)?.Text);
+        }
+
+        IsTextBoxLookUpVisible = _textBoxLookUpWord != null;
+        if (_textBoxLookUpWord != null)
+        {
+            TextBoxLookUpHeader = MacDictionaryLookup.BuildHeader(Se.Language.General.LookUpX, _textBoxLookUpWord);
+        }
+    }
+
     internal void TextBoxContextOpening(object? sender, EventArgs e)
     {
         IsTextBoxSplitAtCursorAndVideoPositionVisible = false;
@@ -29965,6 +30014,10 @@ public partial class MainViewModel :
         // "Google it" searches the selection, so it only makes sense with one - and it was
         // shortcut-only (with no default gesture), which made it look removed since SE4.
         IsTextBoxGoogleItVisible = !string.IsNullOrWhiteSpace(EditTextBox.SelectedText);
+
+        // macOS "Look up" (#14277). Must run before the spell check block below, which clears
+        // "_lastTextEditorPointerArgs" - that is what tells us which word was right-clicked.
+        UpdateTextBoxLookUp();
 
         var s = SelectedSubtitle;
         var vp = GetVideoPlayerControl();

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -314,6 +314,7 @@ public class LanguageGeneral
     public string LoadDefaults { get; set; }
     public string LockTimeCodes { get; set; }
     public string Logo { get; set; }
+    public string LookUpX { get; set; }
     public string Margin { get; set; }
     public string Match { get; set; }
     public string MaxCharactersPerSecond { get; set; }
@@ -1110,6 +1111,7 @@ public class LanguageGeneral
         LoadDefaults = "Load defaults";
         LockTimeCodes = "Lock time codes";
         Logo = "Logo";
+        LookUpX = "Look up \"{0}\"";
         Margin = "Margin";
         Match = "Match";
         MaxCharactersPerSecond = "Max characters per second";

--- a/src/ui/Logic/IconNames.cs
+++ b/src/ui/Logic/IconNames.cs
@@ -17,6 +17,7 @@ internal class IconNames
     public const string ArrowUpDownBold = "mdi-arrow-up-down-bold";
     public const string ArrowUpThin = "mdi-arrow-up-thin";
     public const string Bold = "mdi-format-bold";
+    public const string BookAlphabet = "mdi-book-alphabet";
     public const string Bookmark = "mdi-bookmark";
     public const string CardRemoveOutline = "mdi-card-remove-outline";
     public const string CaseSensitiveAlt = "mdi-case-sensitive-alt";

--- a/src/ui/Logic/MacDictionaryLookup.cs
+++ b/src/ui/Logic/MacDictionaryLookup.cs
@@ -1,0 +1,68 @@
+using System;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>
+/// macOS "Look Up" (#14277): every macOS text field offers it, and it opens the word in
+/// Dictionary.app - which shows whatever dictionaries the user has installed, in any language,
+/// plus thesaurus and Wikipedia. Dictionary.app is reached through the "dict:" URL scheme, which
+/// only exists on macOS, so the menu item using this is macOS-only too.
+/// </summary>
+public static class MacDictionaryLookup
+{
+    /// <summary>Longest text shown inside the menu header before it is elided.</summary>
+    internal const int MaxHeaderTextLength = 32;
+
+    /// <summary>
+    /// The text to look up: a single trimmed line - or null when there is nothing to look up.
+    /// A selection can span two lines and can carry tabs, and Dictionary.app searches for the
+    /// whole phrase, so the white space is folded into single spaces.
+    /// </summary>
+    public static string? Normalize(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return null;
+        }
+
+        var oneLine = text
+            .Replace("\r\n", " ")
+            .Replace('\r', ' ')
+            .Replace('\n', ' ')
+            .Replace('\t', ' ')
+            .Trim();
+
+        while (oneLine.Contains("  ", StringComparison.Ordinal))
+        {
+            oneLine = oneLine.Replace("  ", " ", StringComparison.Ordinal);
+        }
+
+        return oneLine.Length == 0 ? null : oneLine;
+    }
+
+    /// <summary>
+    /// The "dict:" URL Dictionary.app opens for the text, or null when there is nothing to look up.
+    /// </summary>
+    public static string? BuildUrl(string? text)
+    {
+        var word = Normalize(text);
+        return word == null ? null : "dict://" + Uri.EscapeDataString(word);
+    }
+
+    /// <summary>
+    /// The menu header, macOS style: Look up "word". A long selection is elided so one right-click
+    /// on a whole subtitle line cannot stretch the context menu across the screen.
+    /// </summary>
+    public static string BuildHeader(string template, string? text)
+    {
+        var word = Normalize(text) ?? string.Empty;
+        if (word.Length > MaxHeaderTextLength)
+        {
+            word = word.Substring(0, MaxHeaderTextLength - 1).TrimEnd() + "…";
+        }
+
+        // Replace rather than string.Format: the template is translated, and a stray brace in a
+        // translation must not throw while a context menu is opening.
+        return template.Replace("{0}", word, StringComparison.Ordinal);
+    }
+}

--- a/tests/UI/Features/Main/TextBoxLookUpMenuTests.cs
+++ b/tests/UI/Features/Main/TextBoxLookUpMenuTests.cs
@@ -1,0 +1,124 @@
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// macOS "Look up" in the subtitle text box context menu (#14277). The menu item exists on macOS
+/// only - it opens Dictionary.app through the "dict:" scheme, which no other platform has.
+/// </summary>
+public class TextBoxLookUpMenuTests
+{
+    [AvaloniaFact]
+    public void SelectedText_IsWhatTheMenuOffersToLookUp()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            SelectTextInEditBox(vm, "The word évanoui here", start: 9, length: 7);
+
+            vm.TextBoxContextOpening(null, EventArgs.Empty);
+
+            if (OperatingSystem.IsMacOS())
+            {
+                Assert.True(vm.IsTextBoxLookUpVisible);
+                Assert.Equal("Look up \"évanoui\"", vm.TextBoxLookUpHeader);
+            }
+            else
+            {
+                Assert.False(vm.IsTextBoxLookUpVisible);
+            }
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    [AvaloniaFact]
+    public void NothingSelectedAndNoRightClickedWord_HidesTheMenuItem()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            SelectTextInEditBox(vm, "The word évanoui here", start: 0, length: 0);
+
+            vm.TextBoxContextOpening(null, EventArgs.Empty);
+
+            Assert.False(vm.IsTextBoxLookUpVisible);
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    [AvaloniaFact]
+    public void TheMenuItemIsOnlyBuiltOnMacOs()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            var flyout = vm.EditTextBox.TextControl.ContextFlyout as MenuFlyout;
+            Assert.NotNull(flyout);
+
+            var lookUpItems = flyout!.Items
+                .OfType<MenuItem>()
+                .Count(m => m.Command == vm.LookUpInDictionaryCommand);
+
+            Assert.Equal(OperatingSystem.IsMacOS() ? 1 : 0, lookUpItems);
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    private static void SelectTextInEditBox(MainViewModel vm, string text, int start, int length)
+    {
+        vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph(text, 0, 2000), null!) { Number = 1 });
+        vm.SelectedSubtitle = vm.Subtitles[0];
+        Dispatcher.UIThread.RunJobs();
+
+        vm.EditTextBox.Text = text;
+        vm.EditTextBox.Select(start, length);
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static (Window Window, MainViewModel Vm) CreateMainViewModel()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1200, Height = 800 };
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        return (window, (MainViewModel)view.DataContext!);
+    }
+
+    private static void CloseWindow(Window window, MainViewModel vm)
+    {
+        foreach (var ownedWindow in window.OwnedWindows.ToArray())
+        {
+            ownedWindow.Close();
+        }
+
+        window.Closing -= vm.OnClosing;
+        if (window.IsVisible)
+        {
+            window.Close();
+        }
+    }
+}

--- a/tests/UI/Logic/MacDictionaryLookupTests.cs
+++ b/tests/UI/Logic/MacDictionaryLookupTests.cs
@@ -1,0 +1,61 @@
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// macOS "Look up" (#14277). The text comes straight out of the subtitle text box, so it can be a
+/// two-line selection, it can hold anything a subtitle holds, and the menu header must stay short.
+/// </summary>
+public class MacDictionaryLookupTests
+{
+    [Fact]
+    public void BuildsADictUrlForTheWord()
+    {
+        Assert.Equal("dict://%C3%A9vanoui", MacDictionaryLookup.BuildUrl("évanoui"));
+    }
+
+    [Fact]
+    public void LooksUpATwoLineSelectionAsOnePhrase()
+    {
+        Assert.Equal("dict://in%20the%20dark", MacDictionaryLookup.BuildUrl("in the\r\ndark"));
+    }
+
+    [Fact]
+    public void FoldsTabsAndRepeatedSpaces()
+    {
+        Assert.Equal("hi there", MacDictionaryLookup.Normalize("  hi \t  there  "));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\r\n")]
+    public void HasNothingToLookUp(string? text)
+    {
+        Assert.Null(MacDictionaryLookup.Normalize(text));
+        Assert.Null(MacDictionaryLookup.BuildUrl(text));
+    }
+
+    [Fact]
+    public void PutsTheWordInTheMenuHeader()
+    {
+        Assert.Equal("Look up \"évanoui\"", MacDictionaryLookup.BuildHeader("Look up \"{0}\"", "évanoui"));
+    }
+
+    [Fact]
+    public void ElidesALongSelectionInTheMenuHeader()
+    {
+        var header = MacDictionaryLookup.BuildHeader("Look up \"{0}\"", new string('a', 100));
+
+        Assert.Equal("Look up \"" + new string('a', MacDictionaryLookup.MaxHeaderTextLength - 1) + "…\"", header);
+    }
+
+    [Fact]
+    public void DoesNotThrowOnAStrayBraceInTheTranslation()
+    {
+        var header = MacDictionaryLookup.BuildHeader("Slå op \"{0}\" {1", "ord");
+
+        Assert.Equal("Slå op \"ord\" {1", header);
+    }
+}


### PR DESCRIPTION
Fixes #14277

macOS has **Look Up** in the context menu of every text field, and it is the quickest way into whatever dictionaries the user has installed - other languages, thesaurus, etymology, Wikipedia. Subtitle Edit's subtitle text box had no such item.

### What it does

- New **Look up "word"** item in the subtitle text box context menu, right above *Google it* (macOS puts Look Up before Search with Google).
- Looks up the selected text, or - with nothing selected - the word the right-click landed on, like the system menu does.
- Opens Dictionary.app through the `dict:` URL scheme. That scheme is macOS-only, so the menu item is built on macOS only; nothing changes on Windows/Linux.
- A long selection is elided in the header, so right-clicking a whole subtitle line cannot stretch the menu across the screen.

### Notes

`MacDictionaryLookup` holds the testable part (one-phrase folding of a two-line selection, URL building, header eliding). New tests: `MacDictionaryLookupTests` and `TextBoxLookUpMenuTests` (the latter asserts the item exists only on macOS, and that the header shows the selected word).

🤖 Generated with [Claude Code](https://claude.com/claude-code)