### PR TITLE
Clear every compiler warning and de-flake the RTL waveform test

### DIFF
--- a/src/libse/ContainerFormats/TransportStream/ManzanitaTransportStreamParser.cs
+++ b/src/libse/ContainerFormats/TransportStream/ManzanitaTransportStreamParser.cs
@@ -220,6 +220,7 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
         /// more than the 200 KB that used to be read in one go. A preamble that did not fit was
         /// reported as "no packets at all" and the file then opened as nothing, with no error.
         /// </remarks>
+        /// <param name="ms">The stream to read from, positioned at the start of the file.</param>
         /// <param name="bytesRead">Bytes actually in the returned buffer.</param>
         /// <param name="endTagIndex">Index of the end tag, or -1 when there is none.</param>
         private static byte[] ReadPreamble(Stream ms, out int bytesRead, out int endTagIndex)

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -20977,13 +20977,13 @@ public partial class MainViewModel :
                                                                               "You can open media files via the Video menu.");
                     return;
                 }
+            }
 
-                if (subtitle == null)
-                {
-                    var message = Se.Language.General.UnknownSubtitleFormat;
-                    await MessageBox.Show(Window!, Se.Language.General.Error, message, MessageBoxButtons.OK, MessageBoxIcon.Error);
-                    return;
-                }
+            if (subtitle == null)
+            {
+                var message = Se.Language.General.UnknownSubtitleFormat;
+                await MessageBox.Show(Window!, Se.Language.General.Error, message, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
             }
 
             if (!skipLoadVideo)
@@ -20996,14 +20996,15 @@ public partial class MainViewModel :
             AudioVisualizer?.StartPositionSeconds = 0;
             AudioVisualizer?.CurrentVideoPositionSeconds = 0;
 
-            SetSubtitleFormat(SubtitleFormats.FirstOrDefault(p => p.Name == subtitle?.OriginalFormat?.Name) ??
+            var loadedFormatName = subtitle.OriginalFormat?.Name;
+            SetSubtitleFormat(SubtitleFormats.FirstOrDefault(p => p.Name == loadedFormatName) ??
                               SelectedSubtitleFormat);
 
             // The STL header declares the frame rate the timecodes were authored in, so the
             // HH:MM:SS:FF display (forced on for EBU STL) shows the file's own frame numbers.
             // Skipped when the header's disk format code is unreadable - the frame rate would
             // just be a guessed fallback then (#14076). A video loaded later still wins.
-            if (subtitle?.OriginalFormat is Ebu ebuFormat &&
+            if (subtitle.OriginalFormat is Ebu ebuFormat &&
                 ebuFormat.Header is { } ebuHeader &&
                 ebuHeader.DiskFormatCode != null &&
                 ebuHeader.DiskFormatCode.StartsWith("STL", StringComparison.Ordinal) &&
@@ -23343,11 +23344,11 @@ public partial class MainViewModel :
             return false;
         }
 
+        _subtitleOriginal ??= new Subtitle();
         var oldSubtitleFileNameOriginal = _subtitleFileNameOriginal;
         var oldSubtitleOriginalFileName = _subtitleOriginal.FileName;
 
         _subtitleFileNameOriginal = fileName;
-        _subtitleOriginal ??= new Subtitle();
         _subtitleOriginal.FileName = fileName;
 
         // _lastOpenSaveFormat belongs to the *main* subtitle - SaveSubtitle compares it against

--- a/src/ui/Features/Tools/MergeSubtitlesWithSameTimeCodes/MergeSameTimeCodesViewModel.cs
+++ b/src/ui/Features/Tools/MergeSubtitlesWithSameTimeCodes/MergeSameTimeCodesViewModel.cs
@@ -116,7 +116,7 @@ public partial class MergeSameTimeCodesViewModel : ObservableObject, IClosingCle
             }
 
             var next = _subtitles[i];
-            if (QualifiesForMerge(p, next, MaxMillisecondsDifference) && IsFixAllowed(p))
+            if (p != null && QualifiesForMerge(p, next, MaxMillisecondsDifference) && IsFixAllowed(p))
             {
                 if (!singleMergeSubtitles.Contains(p))
                 {

--- a/src/ui/Features/Video/VideoOcr/VideoOcrWindow.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrWindow.cs
@@ -571,7 +571,11 @@ public class VideoOcrWindow : Window
         };
         menuItemItalic.Click += (_, _) =>
         {
-            VideoOcrViewModel.ToggleItalic(tableView.SelectedItems.OfType<VideoOcrLineItem>().ToList());
+            var selected = tableView.SelectedItems?.OfType<VideoOcrLineItem>().ToList();
+            if (selected != null)
+            {
+                VideoOcrViewModel.ToggleItalic(selected);
+            }
         };
         flyout.Items.Add(menuItemItalic);
 
@@ -581,7 +585,11 @@ public class VideoOcrWindow : Window
         };
         menuItemDelete.Click += (_, _) =>
         {
-            vm.DeleteLines(tableView.SelectedItems.OfType<VideoOcrLineItem>().ToList());
+            var selected = tableView.SelectedItems?.OfType<VideoOcrLineItem>().ToList();
+            if (selected != null)
+            {
+                vm.DeleteLines(selected);
+            }
         };
         flyout.Items.Add(menuItemDelete);
 

--- a/src/ui/Logic/CursorPositionHelper.cs
+++ b/src/ui/Logic/CursorPositionHelper.cs
@@ -132,9 +132,9 @@ public static  class CursorPositionHelper
             {
                 // The high bit is "down now". VK_L/RBUTTON are physical buttons, so a swapped
                 // primary button still lands on one of the three.
-                return ((GetAsyncKeyState(VkLButton) |
-                         GetAsyncKeyState(VkRButton) |
-                         GetAsyncKeyState(VkMButton)) & 0x8000) != 0;
+                return (((ushort)GetAsyncKeyState(VkLButton) |
+                         (ushort)GetAsyncKeyState(VkRButton) |
+                         (ushort)GetAsyncKeyState(VkMButton)) & 0x8000) != 0;
             }
 
             if (OperatingSystem.IsMacOS())

--- a/src/ui/Logic/Media/EbuStlPreviewStyler.cs
+++ b/src/ui/Logic/Media/EbuStlPreviewStyler.cs
@@ -3,6 +3,7 @@ using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Logic.Config;
 using SkiaSharp;
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Nikse.SubtitleEdit.Logic.Media;
 
@@ -21,7 +22,7 @@ internal static class EbuStlPreviewStyler
     /// True when <paramref name="header"/> is the verbatim GSI block Ebu.LoadSubtitle keeps:
     /// 3 characters of code page number, then the disk format code ("STL25.01").
     /// </summary>
-    public static bool IsStlHeader(string header)
+    public static bool IsStlHeader([NotNullWhen(true)] string? header)
     {
         return header != null && header.Length > 20 && header.AsSpan(3, 3).SequenceEqual("STL");
     }

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -376,29 +376,29 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
 
     private void LoadLibMpvMethods()
     {
-        _mpvCreate = (MpvCreate)GetDllType(typeof(MpvCreate), "mpv_create");
-        _mpvInitialize = (MpvInitialize)GetDllType(typeof(MpvInitialize), "mpv_initialize");
-        _mpvWaitEvent = (MpvWaitEvent)GetDllType(typeof(MpvWaitEvent), "mpv_wait_event");
-        _mpvObserveProperty = (MpvObserveProperty)GetDllType(typeof(MpvObserveProperty), "mpv_observe_property");
-        _mpvWakeup = (MpvWakeup)GetDllType(typeof(MpvWakeup), "mpv_wakeup");
-        _mpvCommand = (MpvCommand)GetDllType(typeof(MpvCommand), "mpv_command");
-        _mpvCommandAsync = (MpvCommandAsync)GetDllType(typeof(MpvCommandAsync), "mpv_command_async");
-        _mpvSetOption = (MpvSetOption)GetDllType(typeof(MpvSetOption), "mpv_set_option");
-        _mpvSetOptionString = (MpvSetOptionString)GetDllType(typeof(MpvSetOptionString), "mpv_set_option_string");
-        _mpvGetPropertyString = (MpvGetPropertyString)GetDllType(typeof(MpvGetPropertyString), "mpv_get_property");
-        _mpvGetPropertyDouble = (MpvGetPropertyDouble)GetDllType(typeof(MpvGetPropertyDouble), "mpv_get_property");
-        _mpvGetPropertyFlag = (MpvGetPropertyFlag)GetDllType(typeof(MpvGetPropertyFlag), "mpv_get_property");
-        _mpvSetProperty = (MpvSetProperty)GetDllType(typeof(MpvSetProperty), "mpv_set_property");
-        _mpvFree = (MpvFree)GetDllType(typeof(MpvFree), "mpv_free");
-        _mpvClientApiVersion = (MpvClientApiVersion)GetDllType(typeof(MpvClientApiVersion), "mpv_client_api_version");
-        _mpvErrorString = (MpvErrorString)GetDllType(typeof(MpvErrorString), "mpv_error_string");
-        _mpvTerminateDestroy = (MpvTerminateDestroy)GetDllType(typeof(MpvTerminateDestroy), "mpv_terminate_destroy");
+        _mpvCreate = (MpvCreate?)GetDllType(typeof(MpvCreate), "mpv_create");
+        _mpvInitialize = (MpvInitialize?)GetDllType(typeof(MpvInitialize), "mpv_initialize");
+        _mpvWaitEvent = (MpvWaitEvent?)GetDllType(typeof(MpvWaitEvent), "mpv_wait_event");
+        _mpvObserveProperty = (MpvObserveProperty?)GetDllType(typeof(MpvObserveProperty), "mpv_observe_property");
+        _mpvWakeup = (MpvWakeup?)GetDllType(typeof(MpvWakeup), "mpv_wakeup");
+        _mpvCommand = (MpvCommand?)GetDllType(typeof(MpvCommand), "mpv_command");
+        _mpvCommandAsync = (MpvCommandAsync?)GetDllType(typeof(MpvCommandAsync), "mpv_command_async");
+        _mpvSetOption = (MpvSetOption?)GetDllType(typeof(MpvSetOption), "mpv_set_option");
+        _mpvSetOptionString = (MpvSetOptionString?)GetDllType(typeof(MpvSetOptionString), "mpv_set_option_string");
+        _mpvGetPropertyString = (MpvGetPropertyString?)GetDllType(typeof(MpvGetPropertyString), "mpv_get_property");
+        _mpvGetPropertyDouble = (MpvGetPropertyDouble?)GetDllType(typeof(MpvGetPropertyDouble), "mpv_get_property");
+        _mpvGetPropertyFlag = (MpvGetPropertyFlag?)GetDllType(typeof(MpvGetPropertyFlag), "mpv_get_property");
+        _mpvSetProperty = (MpvSetProperty?)GetDllType(typeof(MpvSetProperty), "mpv_set_property");
+        _mpvFree = (MpvFree?)GetDllType(typeof(MpvFree), "mpv_free");
+        _mpvClientApiVersion = (MpvClientApiVersion?)GetDllType(typeof(MpvClientApiVersion), "mpv_client_api_version");
+        _mpvErrorString = (MpvErrorString?)GetDllType(typeof(MpvErrorString), "mpv_error_string");
+        _mpvTerminateDestroy = (MpvTerminateDestroy?)GetDllType(typeof(MpvTerminateDestroy), "mpv_terminate_destroy");
 
         // Load render API functions
-        _mpvRenderContextCreate = (MpvRenderContextCreate)GetDllType(typeof(MpvRenderContextCreate), "mpv_render_context_create");
-        _mpvRenderContextRender = (MpvRenderContextRender)GetDllType(typeof(MpvRenderContextRender), "mpv_render_context_render");
-        _mpvRenderContextFree = (MpvRenderContextFree)GetDllType(typeof(MpvRenderContextFree), "mpv_render_context_free");
-        _mpvRenderContextSetUpdateCallback = (MpvRenderContextSetUpdateCallback)GetDllType(typeof(MpvRenderContextSetUpdateCallback), "mpv_render_context_set_update_callback");
+        _mpvRenderContextCreate = (MpvRenderContextCreate?)GetDllType(typeof(MpvRenderContextCreate), "mpv_render_context_create");
+        _mpvRenderContextRender = (MpvRenderContextRender?)GetDllType(typeof(MpvRenderContextRender), "mpv_render_context_render");
+        _mpvRenderContextFree = (MpvRenderContextFree?)GetDllType(typeof(MpvRenderContextFree), "mpv_render_context_free");
+        _mpvRenderContextSetUpdateCallback = (MpvRenderContextSetUpdateCallback?)GetDllType(typeof(MpvRenderContextSetUpdateCallback), "mpv_render_context_set_update_callback");
     }
 
     private object? GetDllType(Type type, string name)

--- a/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicPlayer.cs
@@ -318,58 +318,58 @@ public sealed class LibVlcDynamicPlayer : IDisposable, IVideoPlayer
 
     private void LoadLibVlcMethods()
     {
-        _libvlc_new = (libvlc_new)GetDllType(typeof(libvlc_new), "libvlc_new");
-        _libvlc_get_version = (libvlc_get_version)GetDllType(typeof(libvlc_get_version), "libvlc_get_version");
-        _libvlc_release = (libvlc_release)GetDllType(typeof(libvlc_release), "libvlc_release");
+        _libvlc_new = (libvlc_new?)GetDllType(typeof(libvlc_new), "libvlc_new");
+        _libvlc_get_version = (libvlc_get_version?)GetDllType(typeof(libvlc_get_version), "libvlc_get_version");
+        _libvlc_release = (libvlc_release?)GetDllType(typeof(libvlc_release), "libvlc_release");
 
-        _libvlc_media_new_path = (libvlc_media_new_path)GetDllType(typeof(libvlc_media_new_path), "libvlc_media_new_path");
-        _libvlc_media_player_new_from_media = (libvlc_media_player_new_from_media)GetDllType(typeof(libvlc_media_player_new_from_media), "libvlc_media_player_new_from_media");
-        _libvlc_media_release = (libvlc_media_release)GetDllType(typeof(libvlc_media_release), "libvlc_media_release");
-        _libvlc_media_parse_with_options = (libvlc_media_parse_with_options)GetDllType(typeof(libvlc_media_parse_with_options), "libvlc_media_parse_with_options");
-        _libvlc_media_get_duration = (libvlc_media_get_duration)GetDllType(typeof(libvlc_media_get_duration), "libvlc_media_get_duration");
-        _libvlc_media_add_option = (libvlc_media_add_option)GetDllType(typeof(libvlc_media_add_option), "libvlc_media_add_option");
-        _libvlc_media_player_set_media = (libvlc_media_player_set_media)GetDllType(typeof(libvlc_media_player_set_media), "libvlc_media_player_set_media");
+        _libvlc_media_new_path = (libvlc_media_new_path?)GetDllType(typeof(libvlc_media_new_path), "libvlc_media_new_path");
+        _libvlc_media_player_new_from_media = (libvlc_media_player_new_from_media?)GetDllType(typeof(libvlc_media_player_new_from_media), "libvlc_media_player_new_from_media");
+        _libvlc_media_release = (libvlc_media_release?)GetDllType(typeof(libvlc_media_release), "libvlc_media_release");
+        _libvlc_media_parse_with_options = (libvlc_media_parse_with_options?)GetDllType(typeof(libvlc_media_parse_with_options), "libvlc_media_parse_with_options");
+        _libvlc_media_get_duration = (libvlc_media_get_duration?)GetDllType(typeof(libvlc_media_get_duration), "libvlc_media_get_duration");
+        _libvlc_media_add_option = (libvlc_media_add_option?)GetDllType(typeof(libvlc_media_add_option), "libvlc_media_add_option");
+        _libvlc_media_player_set_media = (libvlc_media_player_set_media?)GetDllType(typeof(libvlc_media_player_set_media), "libvlc_media_player_set_media");
 
-        _libvlc_video_get_size = (libvlc_video_get_size)GetDllType(typeof(libvlc_video_get_size), "libvlc_video_get_size");
-        _libvlc_video_set_spu = (libvlc_video_set_spu)GetDllType(typeof(libvlc_video_set_spu), "libvlc_video_set_spu");
-        _libvlc_video_get_spu_description = (libvlc_video_get_spu_description)GetDllType(typeof(libvlc_video_get_spu_description), "libvlc_video_get_spu_description");
-        _libvlc_video_set_callbacks = (libvlc_video_set_callbacks)GetDllType(typeof(libvlc_video_set_callbacks), "libvlc_video_set_callbacks");
-        _libvlc_video_set_format = (libvlc_video_set_format)GetDllType(typeof(libvlc_video_set_format), "libvlc_video_set_format");
-        _libvlc_video_take_snapshot = (libvlc_video_take_snapshot)GetDllType(typeof(libvlc_video_take_snapshot), "libvlc_video_take_snapshot");
+        _libvlc_video_get_size = (libvlc_video_get_size?)GetDllType(typeof(libvlc_video_get_size), "libvlc_video_get_size");
+        _libvlc_video_set_spu = (libvlc_video_set_spu?)GetDllType(typeof(libvlc_video_set_spu), "libvlc_video_set_spu");
+        _libvlc_video_get_spu_description = (libvlc_video_get_spu_description?)GetDllType(typeof(libvlc_video_get_spu_description), "libvlc_video_get_spu_description");
+        _libvlc_video_set_callbacks = (libvlc_video_set_callbacks?)GetDllType(typeof(libvlc_video_set_callbacks), "libvlc_video_set_callbacks");
+        _libvlc_video_set_format = (libvlc_video_set_format?)GetDllType(typeof(libvlc_video_set_format), "libvlc_video_set_format");
+        _libvlc_video_take_snapshot = (libvlc_video_take_snapshot?)GetDllType(typeof(libvlc_video_take_snapshot), "libvlc_video_take_snapshot");
 
-        _libvlc_audio_get_track_count = (libvlc_audio_get_track_count)GetDllType(typeof(libvlc_audio_get_track_count), "libvlc_audio_get_track_count");
-        _libvlc_audio_get_track_description = (libvlc_audio_get_track_description)GetDllType(typeof(libvlc_audio_get_track_description), "libvlc_audio_get_track_description");
-        _libvlc_audio_get_track = (libvlc_audio_get_track)GetDllType(typeof(libvlc_audio_get_track), "libvlc_audio_get_track");
-        _libvlc_audio_set_track = (libvlc_audio_set_track)GetDllType(typeof(libvlc_audio_set_track), "libvlc_audio_set_track");
-        _libvlc_audio_get_delay = (libvlc_audio_get_delay)GetDllType(typeof(libvlc_audio_get_delay), "libvlc_audio_get_delay");
-        _libvlc_audio_get_volume = (libvlc_audio_get_volume)GetDllType(typeof(libvlc_audio_get_volume), "libvlc_audio_get_volume");
-        _libvlc_audio_set_volume = (libvlc_audio_set_volume)GetDllType(typeof(libvlc_audio_set_volume), "libvlc_audio_set_volume");
-        _libvlc_audio_set_mute = (libvlc_audio_set_mute)GetDllType(typeof(libvlc_audio_set_mute), "libvlc_audio_set_mute");
+        _libvlc_audio_get_track_count = (libvlc_audio_get_track_count?)GetDllType(typeof(libvlc_audio_get_track_count), "libvlc_audio_get_track_count");
+        _libvlc_audio_get_track_description = (libvlc_audio_get_track_description?)GetDllType(typeof(libvlc_audio_get_track_description), "libvlc_audio_get_track_description");
+        _libvlc_audio_get_track = (libvlc_audio_get_track?)GetDllType(typeof(libvlc_audio_get_track), "libvlc_audio_get_track");
+        _libvlc_audio_set_track = (libvlc_audio_set_track?)GetDllType(typeof(libvlc_audio_set_track), "libvlc_audio_set_track");
+        _libvlc_audio_get_delay = (libvlc_audio_get_delay?)GetDllType(typeof(libvlc_audio_get_delay), "libvlc_audio_get_delay");
+        _libvlc_audio_get_volume = (libvlc_audio_get_volume?)GetDllType(typeof(libvlc_audio_get_volume), "libvlc_audio_get_volume");
+        _libvlc_audio_set_volume = (libvlc_audio_set_volume?)GetDllType(typeof(libvlc_audio_set_volume), "libvlc_audio_set_volume");
+        _libvlc_audio_set_mute = (libvlc_audio_set_mute?)GetDllType(typeof(libvlc_audio_set_mute), "libvlc_audio_set_mute");
 
-        _libvlc_track_description_release = (libvlc_track_description_release)GetDllType(typeof(libvlc_track_description_release), "libvlc_track_description_release");
+        _libvlc_track_description_release = (libvlc_track_description_release?)GetDllType(typeof(libvlc_track_description_release), "libvlc_track_description_release");
         if (_libvlc_track_description_release == null)
         { //TODO: libvlc 4 beta... check when final version is out
-            _libvlc_track_description_release = (libvlc_track_description_release)GetDllType(typeof(libvlc_track_description_release), "libvlc_track_description_list_release");
+            _libvlc_track_description_release = (libvlc_track_description_release?)GetDllType(typeof(libvlc_track_description_release), "libvlc_track_description_list_release");
         }
 
-        _libvlc_media_player_play = (libvlc_media_player_play)GetDllType(typeof(libvlc_media_player_play), "libvlc_media_player_play");
-        _libvlc_media_player_set_hwnd = (libvlc_media_player_set_hwnd)GetDllType(typeof(libvlc_media_player_set_hwnd), "libvlc_media_player_set_hwnd");
-        _libvlc_media_player_set_xwindow = (libvlc_media_player_set_xwindow)GetDllType(typeof(libvlc_media_player_set_xwindow), "libvlc_media_player_set_xwindow");
-        _libvlc_media_player_is_playing = (libvlc_media_player_is_playing)GetDllType(typeof(libvlc_media_player_is_playing), "libvlc_media_player_is_playing");
-        _libvlc_media_player_set_pause = (libvlc_media_player_set_pause)GetDllType(typeof(libvlc_media_player_set_pause), "libvlc_media_player_set_pause");
-        _libvlc_media_player_get_time = (libvlc_media_player_get_time)GetDllType(typeof(libvlc_media_player_get_time), "libvlc_media_player_get_time");
-        _libvlc_media_player_set_time = (libvlc_media_player_set_time)GetDllType(typeof(libvlc_media_player_set_time), "libvlc_media_player_set_time");
-        _libvlc_media_player_get_state = (libvlc_media_player_get_state)GetDllType(typeof(libvlc_media_player_get_state), "libvlc_media_player_get_state");
-        _libvlc_media_player_get_length = (libvlc_media_player_get_length)GetDllType(typeof(libvlc_media_player_get_length), "libvlc_media_player_get_length");
-        _libvlc_media_player_release = (libvlc_media_player_release)GetDllType(typeof(libvlc_media_player_release), "libvlc_media_player_release");
-        _libvlc_media_player_get_rate = (libvlc_media_player_get_rate)GetDllType(typeof(libvlc_media_player_get_rate), "libvlc_media_player_get_rate");
-        _libvlc_media_player_set_rate = (libvlc_media_player_set_rate)GetDllType(typeof(libvlc_media_player_set_rate), "libvlc_media_player_set_rate");
-        _libvlc_media_player_next_frame = (libvlc_media_player_next_frame)GetDllType(typeof(libvlc_media_player_next_frame), "libvlc_media_player_next_frame");
-        _libvlc_media_player_add_slave = (libvlc_media_player_add_slave)GetDllType(typeof(libvlc_media_player_add_slave), "libvlc_media_player_add_slave");
-        _libvlc_media_player_stop = (libvlc_media_player_stop)GetDllType(typeof(libvlc_media_player_stop), "libvlc_media_player_stop");
+        _libvlc_media_player_play = (libvlc_media_player_play?)GetDllType(typeof(libvlc_media_player_play), "libvlc_media_player_play");
+        _libvlc_media_player_set_hwnd = (libvlc_media_player_set_hwnd?)GetDllType(typeof(libvlc_media_player_set_hwnd), "libvlc_media_player_set_hwnd");
+        _libvlc_media_player_set_xwindow = (libvlc_media_player_set_xwindow?)GetDllType(typeof(libvlc_media_player_set_xwindow), "libvlc_media_player_set_xwindow");
+        _libvlc_media_player_is_playing = (libvlc_media_player_is_playing?)GetDllType(typeof(libvlc_media_player_is_playing), "libvlc_media_player_is_playing");
+        _libvlc_media_player_set_pause = (libvlc_media_player_set_pause?)GetDllType(typeof(libvlc_media_player_set_pause), "libvlc_media_player_set_pause");
+        _libvlc_media_player_get_time = (libvlc_media_player_get_time?)GetDllType(typeof(libvlc_media_player_get_time), "libvlc_media_player_get_time");
+        _libvlc_media_player_set_time = (libvlc_media_player_set_time?)GetDllType(typeof(libvlc_media_player_set_time), "libvlc_media_player_set_time");
+        _libvlc_media_player_get_state = (libvlc_media_player_get_state?)GetDllType(typeof(libvlc_media_player_get_state), "libvlc_media_player_get_state");
+        _libvlc_media_player_get_length = (libvlc_media_player_get_length?)GetDllType(typeof(libvlc_media_player_get_length), "libvlc_media_player_get_length");
+        _libvlc_media_player_release = (libvlc_media_player_release?)GetDllType(typeof(libvlc_media_player_release), "libvlc_media_player_release");
+        _libvlc_media_player_get_rate = (libvlc_media_player_get_rate?)GetDllType(typeof(libvlc_media_player_get_rate), "libvlc_media_player_get_rate");
+        _libvlc_media_player_set_rate = (libvlc_media_player_set_rate?)GetDllType(typeof(libvlc_media_player_set_rate), "libvlc_media_player_set_rate");
+        _libvlc_media_player_next_frame = (libvlc_media_player_next_frame?)GetDllType(typeof(libvlc_media_player_next_frame), "libvlc_media_player_next_frame");
+        _libvlc_media_player_add_slave = (libvlc_media_player_add_slave?)GetDllType(typeof(libvlc_media_player_add_slave), "libvlc_media_player_add_slave");
+        _libvlc_media_player_stop = (libvlc_media_player_stop?)GetDllType(typeof(libvlc_media_player_stop), "libvlc_media_player_stop");
         if (_libvlc_media_player_stop == null)
         { //TODO: libvlc 4 beta... check when final version is out
-            _libvlc_media_player_stop = (libvlc_media_player_stop)GetDllType(typeof(libvlc_media_player_stop), "libvlc_media_player_stop_async");
+            _libvlc_media_player_stop = (libvlc_media_player_stop?)GetDllType(typeof(libvlc_media_player_stop), "libvlc_media_player_stop_async");
         }
     }
 

--- a/tests/UI/Controls/AudioVisualizerOriginalTextTests.cs
+++ b/tests/UI/Controls/AudioVisualizerOriginalTextTests.cs
@@ -1,6 +1,7 @@
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
+using Avalonia.Media.Imaging;
 using Avalonia.Threading;
 using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
 using Nikse.SubtitleEdit.Features.Main;
@@ -87,7 +88,7 @@ public class AudioVisualizerOriginalTextTests
 
         using var frame = window.CaptureRenderedFrame()!;
         using var stream = new MemoryStream();
-        frame.Save(stream);
+        frame.Save(stream, PngBitmapEncoderOptions.Default);
         return stream.ToArray();
     }
 }

--- a/tests/UI/Controls/AudioVisualizerParagraphRepaintTests.cs
+++ b/tests/UI/Controls/AudioVisualizerParagraphRepaintTests.cs
@@ -1,6 +1,7 @@
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
+using Avalonia.Media.Imaging;
 using Avalonia.Threading;
 using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
 using Nikse.SubtitleEdit.Features.Main;
@@ -51,7 +52,7 @@ public class AudioVisualizerParagraphRepaintTests
 
         using var frame = window.CaptureRenderedFrame()!;
         using var stream = new MemoryStream();
-        frame.Save(stream);
+        frame.Save(stream, PngBitmapEncoderOptions.Default);
         return stream.ToArray();
     }
 

--- a/tests/UI/Controls/AudioVisualizerRtlTextTests.cs
+++ b/tests/UI/Controls/AudioVisualizerRtlTextTests.cs
@@ -82,8 +82,16 @@ public class AudioVisualizerRtlTextTests
 
     /// <summary>
     /// And the direction really reaches the shaping: the same string drawn right to left comes out
-    /// as a different picture (same width - the direction only reorders the glyphs).
+    /// as a different picture.
     /// </summary>
+    /// <remarks>
+    /// Only the picture, not the width. This used to also assert that the two directions measure
+    /// the same, and that made the test flaky: a trailing neutral run ("...") measures wider laid
+    /// out right to left than left to right (about a tenth of the line here), and how much wider
+    /// depends on which font the Arabic falls back to - which in turn depends on what else ran
+    /// first in the shared headless application. Avalonia promises no such equality, and nothing
+    /// in the waveform compares the two directions, so the width was never the point.
+    /// </remarks>
     [AvaloniaFact]
     public void TheDirectionChangesWhatIsDrawn()
     {
@@ -91,7 +99,6 @@ public class AudioVisualizerRtlTextTests
         var rightToLeft = av.GetCachedParagraphText(ArabicLine, true);
         var leftToRight = av.GetCachedParagraphText(ArabicLine, false);
 
-        Assert.Equal(leftToRight.Width, rightToLeft.Width, 3);
         Assert.NotEqual(Render(leftToRight), Render(rightToLeft));
     }
 

--- a/tests/UI/Logic/Media/EbuStlPreviewStylerTests.cs
+++ b/tests/UI/Logic/Media/EbuStlPreviewStylerTests.cs
@@ -149,7 +149,7 @@ public class EbuStlPreviewStylerTests
     [InlineData("", false)]
     [InlineData("short", false)]
     [InlineData("850STL25.01 and then some padding to get past twenty characters", true)]
-    public void OnlyAGsiBlockIsTreatedAsStl(string header, bool expected)
+    public void OnlyAGsiBlockIsTreatedAsStl(string? header, bool expected)
     {
         Assert.Equal(expected, EbuStlPreviewStyler.IsStlHeader(header));
     }

--- a/tests/libse/Common/SpreadsheetImportTest.cs
+++ b/tests/libse/Common/SpreadsheetImportTest.cs
@@ -243,7 +243,7 @@ public class SpreadsheetImportTest
         });
     }
 
-    private static byte[] MakeXlsxWithSheets(string workbookXml, string relsXml, params (string Name, string Sheet)[] sheets)
+    private static byte[] MakeXlsxWithSheets(string? workbookXml, string? relsXml, params (string Name, string Sheet)[] sheets)
     {
         using var stream = new MemoryStream();
         using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, true))

--- a/tests/libse/Common/SubtitlePositionEbuJustificationTest.cs
+++ b/tests/libse/Common/SubtitlePositionEbuJustificationTest.cs
@@ -25,7 +25,7 @@ public class SubtitlePositionEbuJustificationTest
         return Ebu.ReadHeader(buffer).ToString();
     }
 
-    private static Paragraph Positioned(int justificationCode, string teletextRow, string text = "Hello world", bool usePositions = true)
+    private static Paragraph Positioned(int justificationCode, string? teletextRow, string text = "Hello world", bool usePositions = true)
     {
         var settings = Configuration.Settings.SubtitleSettings;
         var oldJustification = settings.EbuStlJustificationCode;
@@ -52,7 +52,7 @@ public class SubtitlePositionEbuJustificationTest
         }
     }
 
-    private static string Position(int justificationCode, string teletextRow, string text = "Hello world")
+    private static string Position(int justificationCode, string? teletextRow, string text = "Hello world")
     {
         return Positioned(justificationCode, teletextRow, text).Text;
     }


### PR DESCRIPTION
A full `dotnet build -t:Rebuild` of the solution emitted 84 warnings. It is now silent.

## The two that were bugs

**"Save original as" with no original loaded threw.** `SaveSubtitleOriginalAs` read `_subtitleOriginal.FileName` two lines *above* the `_subtitleOriginal ??= new Subtitle()` that admits the field can be null. The `??=` now runs first.

**The unknown-format guard was one block too deep.** In `SubtitleOpen`, the `if (subtitle == null) { show error; return; }` guard lived inside the `if (subtitle == null)` block it belongs to, so the compiler could not carry the non-null result out to `_subtitle = subtitle; _lastOpenSaveFormat = subtitle.OriginalFormat;` below. Hoisted out of the block; the format lookup reads the name into a local rather than capturing the nullable in a lambda, which is what was resetting the flow state.

## The rest: annotations catching up with correct code

- `GetDllType` returns `object?`, so the 63 delegate casts in `LibVlcDynamicPlayer` / `LibMpvDynamicPlayer` are `(X?)` — the fields were already nullable.
- `IsStlHeader` null-checks its own argument, so it takes `[NotNullWhen(true)] string?`. That cleared both reloader call sites and the xUnit1012 on its `[InlineData(null, …)]`.
- The VideoOcr context menu guards `SelectedItems` (Avalonia hands out `IList?`), matching the pattern already in `TableViewExtras`.
- `GetAsyncKeyState` results are widened through `ushort` instead of sign-extended into the `|` chain.
- An obsolete `Bitmap.Save` overload in two tests, a missing `<param>` tag, and test helpers that now take the nulls their callers already pass.

## The flaky test

`AudioVisualizerRtlTextTests.TheDirectionChangesWhatIsDrawn` asserted that an Arabic line measures the same width laid out left to right and right to left ("the direction only reorders the glyphs"). Measured, it does not:

| probe | LTR | RTL |
| --- | --- | --- |
| `مرحبا يا صديقي` | 84.014 | 84.014 |
| `- مرحبا يا صديقي` | 90.684 | 90.684 |
| `مرحبا يا صديقي...` | 92.354 | **102.017** |
| `- ...` | 15.010 | 15.010 |

A *trailing* neutral run measures ~9.7 px wider right to left. And how much wider depends on which font the Arabic falls back to: run alone, the class reports 73.6 px in both directions at a different line height entirely, which is why it passed in isolation and failed in ~2 of 3 full runs. Avalonia promises no such equality and nothing in the waveform compares the two directions, so the width assertion is gone. The render comparison that is the test's actual point stays.

Two full suite runs since: it no longer appears in either. The remaining UI-test failures are the pre-existing contamination cascade — a different, largely disjoint victim set each run, all passing in isolation — untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)