### PR TITLE
Fix the UI test contamination cascade, and make the suite 40% faster

### DIFF
--- a/src/libse/Common/RegexUtils.cs
+++ b/src/libse/Common/RegexUtils.cs
@@ -12,7 +12,13 @@ namespace Nikse.SubtitleEdit.Core.Common
         /// matches on the UI thread that means a frozen program with no way out. SE 4 used the same five
         /// seconds in its find/replace helper; callers treat the timeout as "no match".
         /// </summary>
-        public static readonly TimeSpan UserPatternMatchTimeout = TimeSpan.FromSeconds(5);
+        /// <remarks>
+        /// Settable only so the tests that prove the timeout works do not have to wait it out - fourteen
+        /// of them sat on the full five seconds, close to half the whole UI suite. Nothing in the program
+        /// writes it; callers read it when they build the Regex, so a test sets it before the pattern is
+        /// compiled and puts it back afterwards.
+        /// </remarks>
+        public static TimeSpan UserPatternMatchTimeout { get; set; } = TimeSpan.FromSeconds(5);
 
         // Others classes may want to use this regex.
 #if NET7_0_OR_GREATER

--- a/src/ui/Features/Files/Compare/CompareColors.cs
+++ b/src/ui/Features/Files/Compare/CompareColors.cs
@@ -1,4 +1,5 @@
 using Avalonia.Media;
+using Avalonia.Media.Immutable;
 using Nikse.SubtitleEdit.Logic;
 
 namespace Nikse.SubtitleEdit.Features.Files.Compare;
@@ -74,6 +75,14 @@ internal static class CompareColors
         return null;
     }
 
+    /// <summary>
+    /// Immutable, and deliberately so: a <see cref="SolidColorBrush"/> is an AvaloniaObject and
+    /// belongs to the thread it was built on, while these six live in static fields whose
+    /// initializer runs wherever <see cref="CompareColors"/> is first touched. Reading one of the
+    /// colors off the UI thread was therefore enough to make every later compare row throw
+    /// "the calling thread cannot access this object" out of the renderer - and an exception
+    /// thrown inside a render job leaves the compositor broken for good.
+    /// </summary>
     private static IBrush MakeRowBrush(Color color)
-        => new SolidColorBrush(Color.FromArgb(RowAlpha, color.R, color.G, color.B));
+        => new ImmutableSolidColorBrush(Color.FromArgb(RowAlpha, color.R, color.G, color.B));
 }

--- a/tests/UI/Controls/AudioVisualizerDragDurationBoxTests.cs
+++ b/tests/UI/Controls/AudioVisualizerDragDurationBoxTests.cs
@@ -20,8 +20,23 @@ namespace UITests.Controls;
 // Repro for "when moving end in the waveform, the duration box time is not changing":
 // dragging a cue edge mutates the shared SubtitleLineViewModel, and a SecondsUpDown bound
 // TwoWay to its Duration must tick live during the drag.
-public partial class AudioVisualizerDragDurationBoxTests
+public partial class AudioVisualizerDragDurationBoxTests : IDisposable
 {
+    // A window left open outlives the test: it keeps the application-wide activation and focused
+    // element, so a later test's click or key press is delivered to it instead. Closing here rather
+    // than at the end of each test also covers the tests that stop early on a failed assertion.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
     private const int SampleRate = 126;
     private const double WidthPx = 800;
     private const double HeightPx = 200;
@@ -85,6 +100,7 @@ public partial class AudioVisualizerDragDurationBoxTests
             panel.Children.Add(av);
             panel.Children.Add(durationBox);
             var window = new Window { Width = WidthPx, Height = HeightPx + 40, Content = panel };
+            _windows.Add(window);
             window.Show();
             Dispatcher.UIThread.RunJobs();
             window.UpdateLayout();
@@ -145,6 +161,7 @@ public partial class AudioVisualizerDragDurationBoxTests
             panel.Children.Add(av);
             panel.Children.Add(durationBox);
             var window = new Window { Width = WidthPx, Height = HeightPx + 40, Content = panel };
+            _windows.Add(window);
             window.Show();
             Dispatcher.UIThread.RunJobs();
             window.UpdateLayout();

--- a/tests/UI/Controls/AudioVisualizerDragTests.cs
+++ b/tests/UI/Controls/AudioVisualizerDragTests.cs
@@ -28,8 +28,24 @@ namespace UITests.Controls;
 /// as a clipped overlay instead. The fancy style bakes selection into per-column colors, so it
 /// still rebuilds.
 /// </summary>
-public class AudioVisualizerDragTests
+public class AudioVisualizerDragTests : IDisposable
 {
+    // A window left open outlives the test: it keeps the application-wide activation and focused
+    // element, so a later test's click or key press is delivered to it instead. The tests close
+    // their window on the last line, which leaks one whenever an assertion above it fails - and one
+    // stranded window is enough to take the rest of the class down with it.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
     private const int SampleRate = 126; // Se.Settings.Waveform.WaveformMinimumSampleRate default
     private const double WidthPx = 800;
     private const double HeightPx = 200;
@@ -52,7 +68,7 @@ public class AudioVisualizerDragTests
         EndTime = TimeSpan.FromSeconds(endSeconds),
     };
 
-    private static (Window Window, AudioVisualizer Av, List<SubtitleLineViewModel> Lines) Open(params SubtitleLineViewModel[] lines)
+    private (Window Window, AudioVisualizer Av, List<SubtitleLineViewModel> Lines) Open(params SubtitleLineViewModel[] lines)
     {
         var av = new AudioVisualizer
         {
@@ -70,6 +86,7 @@ public class AudioVisualizerDragTests
             Height = HeightPx,
             Content = av,
         };
+        _windows.Add(window);
         window.Show();
         Dispatcher.UIThread.RunJobs();
         window.UpdateLayout();

--- a/tests/UI/Controls/AudioVisualizerParagraphRepaintTests.cs
+++ b/tests/UI/Controls/AudioVisualizerParagraphRepaintTests.cs
@@ -27,8 +27,23 @@ namespace UITests.Controls;
 /// shows the right time range with nothing in it. The reload a tick later fixed the list but not
 /// the picture.
 /// </summary>
-public class AudioVisualizerParagraphRepaintTests
+public class AudioVisualizerParagraphRepaintTests : IDisposable
 {
+    // A window left open outlives the test: it keeps the application-wide activation and focused
+    // element, so a later test's click or key press is delivered to it instead. Closing here rather
+    // than at the end of each test also covers the tests that stop early on a failed assertion.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
     private const int SampleRate = 126; // px per second at zoom 1
     private const double WidthPx = 800;
     private const double HeightPx = 200;
@@ -67,6 +82,7 @@ public class AudioVisualizerParagraphRepaintTests
             Content = av,
         };
 
+        _windows.Add(window);
         window.Show();
         window.UpdateLayout();
 
@@ -115,6 +131,7 @@ public class AudioVisualizerParagraphRepaintTests
             Content = av,
         };
 
+        _windows.Add(window);
         window.Show();
         window.UpdateLayout();
 

--- a/tests/UI/Controls/AudioVisualizerScrubFeedbackTests.cs
+++ b/tests/UI/Controls/AudioVisualizerScrubFeedbackTests.cs
@@ -28,8 +28,24 @@ namespace UITests.Controls;
 /// is set. These tests pin the two facts that guard depends on: the flag is already true when the
 /// scrub fires, and a consumer that does scroll mid-drag really does amplify the drag.
 /// </summary>
-public class AudioVisualizerScrubFeedbackTests
+public class AudioVisualizerScrubFeedbackTests : IDisposable
 {
+    // A window left open outlives the test: it keeps the application-wide activation and focused
+    // element, so a later test's click or key press is delivered to it instead. The tests close
+    // their window on the last line, which leaks one whenever an assertion above it fails - and one
+    // stranded window is enough to take the rest of the class down with it.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
     private const int SampleRate = 126; // px per second at zoom 1
     private const double WidthPx = 800;
     private const double LineStart = 100;
@@ -51,7 +67,7 @@ public class AudioVisualizerScrubFeedbackTests
         return new WavePeakData2(SampleRate, peaks);
     }
 
-    private static (Window Window, AudioVisualizer Av) Open()
+    private (Window Window, AudioVisualizer Av) Open()
     {
         var av = new AudioVisualizer { WavePeaks = MakePeaks(200), Width = WidthPx, Height = 200 };
         var line = new SubtitleLineViewModel
@@ -64,6 +80,7 @@ public class AudioVisualizerScrubFeedbackTests
         av.SetPosition(ViewStart, new List<SubtitleLineViewModel> { line }, 0, 0, new List<SubtitleLineViewModel>());
 
         var window = new Window { Width = WidthPx, Height = 200, Content = av };
+        _windows.Add(window);
         window.Show();
         Dispatcher.UIThread.RunJobs();
         window.UpdateLayout();

--- a/tests/UI/Controls/AudioVisualizerShotChangeSnapTests.cs
+++ b/tests/UI/Controls/AudioVisualizerShotChangeSnapTests.cs
@@ -29,8 +29,24 @@ namespace UITests.Controls;
 /// in or out. A whole-paragraph drag preserves its duration, so whichever cue the cut captures,
 /// the other one moves with it.
 /// </summary>
-public class AudioVisualizerShotChangeSnapTests
+public class AudioVisualizerShotChangeSnapTests : IDisposable
 {
+    // A window left open outlives the test: it keeps the application-wide activation and focused
+    // element, so a later test's click or key press is delivered to it instead. The tests close
+    // their window on the last line, which leaks one whenever an assertion above it fails - and one
+    // stranded window is enough to take the rest of the class down with it.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
     private const int SampleRate = 126; // px per second at zoom 1
     private const double WidthPx = 800;
     private const double HeightPx = 200;
@@ -108,7 +124,7 @@ public class AudioVisualizerShotChangeSnapTests
         EndTime = TimeSpan.FromSeconds(endSeconds),
     };
 
-    private static (Window Window, AudioVisualizer Av) Open(List<double> shotChanges, params SubtitleLineViewModel[] lines)
+    private (Window Window, AudioVisualizer Av) Open(List<double> shotChanges, params SubtitleLineViewModel[] lines)
     {
         var av = new AudioVisualizer
         {
@@ -121,6 +137,7 @@ public class AudioVisualizerShotChangeSnapTests
         av.ShotChanges = shotChanges;
 
         var window = new Window { Width = WidthPx, Height = HeightPx, Content = av };
+        _windows.Add(window);
         window.Show();
         Dispatcher.UIThread.RunJobs();
         window.UpdateLayout();

--- a/tests/UI/Controls/TimeCodeUpDownNegativeTests.cs
+++ b/tests/UI/Controls/TimeCodeUpDownNegativeTests.cs
@@ -11,6 +11,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using Nikse.SubtitleEdit.Controls;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Logic.Config;
+using System.Collections.Generic;
 
 namespace UITests.Controls;
 
@@ -18,8 +19,23 @@ namespace UITests.Controls;
 // and the editor used to clamp any negative value to zero and write that back through its two-way
 // binding - so every line the user selected had its time code destroyed. The control now shows,
 // edits and steps negative time codes the way SE 4.x did.
-public partial class TimeCodeUpDownNegativeTests
+public partial class TimeCodeUpDownNegativeTests : IDisposable
 {
+    // A window left open outlives the test: it keeps the application-wide activation and focused
+    // element, so a later test's click or key press is delivered to it instead. Closing here rather
+    // than at the end of each test also covers the tests that stop early on a failed assertion.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
     public partial class Line : ObservableObject
     {
         [ObservableProperty] private TimeSpan _start = TimeSpan.Zero;
@@ -57,9 +73,10 @@ public partial class TimeCodeUpDownNegativeTests
 
     private static TimeCodeSettings FrameMode() => new(frameMode: true, stepMs: 100);
 
-    private static (Window window, TimeCodeUpDown control, TextBox textBox) Show(TimeCodeUpDown control)
+    private (Window window, TimeCodeUpDown control, TextBox textBox) Show(TimeCodeUpDown control)
     {
         var window = new Window { Content = control };
+        _windows.Add(window);
         window.Show();
         var textBox = control.GetVisualDescendants().OfType<TextBox>().Single();
         return (window, control, textBox);

--- a/tests/UI/Features/Edit/MultipleReplaceMoveFocusTests.cs
+++ b/tests/UI/Features/Edit/MultipleReplaceMoveFocusTests.cs
@@ -11,6 +11,7 @@ using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace UITests.Features.Edit;
@@ -21,14 +22,29 @@ namespace UITests.Features.Edit;
 /// next key press and the second Ctrl+Up moved the category instead (#14136). These tests drive
 /// the real window, because the bug lives in the container lookup, not in the reorder itself.
 /// </summary>
-public class MultipleReplaceMoveFocusTests
+public class MultipleReplaceMoveFocusTests : IDisposable
 {
+    // A window left open outlives the test: it keeps the application-wide activation and focused
+    // element, so a later test's click or key press is delivered to it instead. Closing here rather
+    // than at the end of each test also covers the tests that stop early on a failed assertion.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
     private sealed class NullServiceProvider : IServiceProvider
     {
         public object? GetService(Type serviceType) => null;
     }
 
-    private static (MultipleReplaceViewModel Vm, Window Window) Open()
+    private (MultipleReplaceViewModel Vm, Window Window) Open()
     {
         var vm = new MultipleReplaceViewModel(new WindowService(new NullServiceProvider()), new FileHelper());
         vm.Nodes.Clear();
@@ -56,6 +72,7 @@ public class MultipleReplaceMoveFocusTests
         vm.Initialize(subtitle);
 
         var window = new MultipleReplaceWindow(vm);
+        _windows.Add(window);
         window.Show();
         window.UpdateLayout();
         Dispatcher.UIThread.RunJobs();

--- a/tests/UI/Features/Edit/MultipleReplaceRegexTimeoutTests.cs
+++ b/tests/UI/Features/Edit/MultipleReplaceRegexTimeoutTests.cs
@@ -25,8 +25,12 @@ namespace UITests.Features.Edit;
 /// even in an unticked category": validation must not be what builds the RegexOptions.Compiled
 /// regex, or opening the dialog emits IL for every rule in the file.
 /// </summary>
-public class MultipleReplaceRegexTimeoutTests
+public class MultipleReplaceRegexTimeoutTests : IDisposable
 {
+    private readonly ShortRegexTimeout _shortRegexTimeout = new();
+
+    public void Dispose() => _shortRegexTimeout.Dispose();
+
     private sealed class NullServiceProvider : IServiceProvider
     {
         public object? GetService(Type serviceType) => null;

--- a/tests/UI/Features/Main/SubMillisecondTimeTests.cs
+++ b/tests/UI/Features/Main/SubMillisecondTimeTests.cs
@@ -13,6 +13,7 @@ using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Collections.Generic;
 
 namespace UITests.Features.Main;
 
@@ -27,8 +28,23 @@ namespace UITests.Features.Main;
 /// a fractional double (typed input, pixel positions, video positions, scale factors) into a
 /// subtitle time rounds through TimeSpanExtensions.FromSeconds/FromMillisecondsWholeMilliseconds.
 /// </summary>
-public class SubMillisecondTimeTests
+public class SubMillisecondTimeTests : IDisposable
 {
+    // A window left open outlives the test: it keeps the application-wide activation and focused
+    // element, so a later test's click or key press is delivered to it instead. Closing here rather
+    // than at the end of each test also covers the tests that stop early on a failed assertion.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
     private static SubtitleLineViewModel Line(double startMs, double endMs) =>
         new() { StartTime = TimeSpan.FromMilliseconds(startMs), EndTime = TimeSpan.FromMilliseconds(endMs) };
 
@@ -53,6 +69,7 @@ public class SubMillisecondTimeTests
         upDown[!SecondsUpDown.ValueProperty] =
             new Binding(nameof(SubtitleLineViewModel.Duration)) { Mode = BindingMode.TwoWay };
         var window = new Window { Content = upDown };
+        _windows.Add(window);
         window.Show();
         var textBox = upDown.GetVisualDescendants().OfType<TextBox>().Single();
 
@@ -108,6 +125,7 @@ public class SubMillisecondTimeTests
         upDown[!SecondsUpDown.ValueProperty] =
             new Binding(nameof(SubtitleLineViewModel.Duration)) { Mode = BindingMode.TwoWay };
         var window = new Window { Content = upDown };
+        _windows.Add(window);
         window.Show();
         var textBox = upDown.GetVisualDescendants().OfType<TextBox>().Single();
 

--- a/tests/UI/Features/SourceViewRegexTimeoutTests.cs
+++ b/tests/UI/Features/SourceViewRegexTimeoutTests.cs
@@ -19,6 +19,7 @@ namespace UITests.Features;
 public class SourceViewRegexTimeoutTests : IDisposable
 {
     private readonly List<Window> _windows = new();
+    private readonly ShortRegexTimeout _shortRegexTimeout = new();
 
     public void Dispose()
     {
@@ -28,6 +29,7 @@ public class SourceViewRegexTimeoutTests : IDisposable
         }
 
         _windows.Clear();
+        _shortRegexTimeout.Dispose();
     }
 
     private sealed class NoWindowService : IWindowService

--- a/tests/UI/Features/Tools/BatchConvert/BatchConverterMultipleReplaceRegexTests.cs
+++ b/tests/UI/Features/Tools/BatchConvert/BatchConverterMultipleReplaceRegexTests.cs
@@ -5,6 +5,7 @@ using Nikse.SubtitleEdit.Features.Options.Settings;
 using Nikse.SubtitleEdit.Features.Tools.BatchConvert;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.UiLogic.BatchConvert;
+using System;
 using System.Diagnostics;
 
 namespace UITests.Features.Tools.BatchConvert;
@@ -16,8 +17,12 @@ namespace UITests.Features.Tools.BatchConvert;
 /// with the indexer and no try/catch (one bad rule failed every file in the batch with an opaque
 /// "parsing ..." status naming neither rule nor category), and with no match timeout at all.
 /// </summary>
-public class BatchConverterMultipleReplaceRegexTests
+public class BatchConverterMultipleReplaceRegexTests : IDisposable
 {
+    private readonly ShortRegexTimeout _shortRegexTimeout = new();
+
+    public void Dispose() => _shortRegexTimeout.Dispose();
+
     // 30 a's and no "b": "(a+)+b" has to try every way of splitting them before giving up.
     private const string EvilPattern = "(a+)+b";
     private static readonly string EvilLine = new string('a', 30) + "c";

--- a/tests/UI/Features/Video/TextToSpeech/Engines/CrispAsrTtsProvenanceTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/CrispAsrTtsProvenanceTests.cs
@@ -209,10 +209,15 @@ internal sealed class ShellStub : IDisposable
 
         // Generate the payload rather than embedding it, so the script stays small and the byte
         // count exact. Nothing is written to stdout - that is the half of the shape that matters.
+        // A kilobyte at a time, not a byte at a time: the one-printf-per-byte version spent about
+        // seven seconds inside awk, which made this the slowest test in the suite by a wide margin.
         File.WriteAllText(
             Path,
             "#!/bin/sh\n"
-            + $"awk 'BEGIN {{ for (i = 0; i < {stdErrBytes}; i++) printf \"x\" }}' 1>&2\n");
+            + $"awk -v n={stdErrBytes} 'BEGIN {{ "
+            + "chunk = sprintf(\"%1024s\", \"\"); gsub(/ /, \"x\", chunk); "
+            + "while (n >= 1024) { printf \"%s\", chunk; n -= 1024 } "
+            + "if (n > 0) printf \"%s\", substr(chunk, 1, n) }' 1>&2\n");
         if (!OperatingSystem.IsWindows())
         {
             File.SetUnixFileMode(

--- a/tests/UI/Logic/FindServiceRegexTimeoutTests.cs
+++ b/tests/UI/Logic/FindServiceRegexTimeoutTests.cs
@@ -1,4 +1,5 @@
 using Nikse.SubtitleEdit.Logic;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -7,8 +8,12 @@ namespace UITests.Logic;
 // A user-entered pattern with catastrophic backtracking used to run on the UI thread with no
 // timeout at all, so find/replace hung the program until it was killed. SE 4 gave the same
 // patterns five seconds; the timeout now comes back as "no match" instead of an exception.
-public class FindServiceRegexTimeoutTests
+public class FindServiceRegexTimeoutTests : IDisposable
 {
+    private readonly ShortRegexTimeout _shortRegexTimeout = new();
+
+    public void Dispose() => _shortRegexTimeout.Dispose();
+
     // 30 a's and no "b": "(a+)+b" has to try every way of splitting them before giving up.
     private const string EvilPattern = "(a+)+b";
     private static readonly string EvilLine = new string('a', 30) + "c";

--- a/tests/UI/ShortRegexTimeout.cs
+++ b/tests/UI/ShortRegexTimeout.cs
@@ -1,0 +1,29 @@
+using Nikse.SubtitleEdit.Core.Common;
+using System;
+
+namespace UITests;
+
+/// <summary>
+/// Shortens <see cref="RegexUtils.UserPatternMatchTimeout"/> for the tests that feed find/replace a
+/// catastrophically backtracking pattern and check it gives up.
+/// </summary>
+/// <remarks>
+/// Those tests do not care how long the give-up takes - only that the call comes back at all, with
+/// "no match" - but they were paying the shipped five seconds each. Fourteen of them added up to
+/// roughly half the wall clock of the whole UI suite. A quarter of a second still needs orders of
+/// magnitude more backtracking than the pattern can do, so the tests prove the same thing.
+/// </remarks>
+public sealed class ShortRegexTimeout : IDisposable
+{
+    private readonly TimeSpan _previous = RegexUtils.UserPatternMatchTimeout;
+
+    public ShortRegexTimeout()
+    {
+        RegexUtils.UserPatternMatchTimeout = TimeSpan.FromMilliseconds(250);
+    }
+
+    public void Dispose()
+    {
+        RegexUtils.UserPatternMatchTimeout = _previous;
+    }
+}


### PR DESCRIPTION
## The cascade had one trigger

`CompareColors` keeps its six row-highlight brushes in static fields built by `new SolidColorBrush(...)`. A `SolidColorBrush` is an `AvaloniaObject`, and an `AvaloniaObject` belongs to the thread it was built on. A static initializer runs wherever the class is first touched — and `CompareColorsTests` is a plain `[Fact]` class, so it runs on the **xUnit thread**, not the Avalonia one.

Every compare row rendered after that throws from inside a render job:

```
System.InvalidOperationException : The calling thread cannot access this object because a different thread owns it.
   at Avalonia.Media.Brush.get_Transform()
   at Avalonia.Controls.Border.Render(DrawingContext context)
   at Avalonia.Rendering.Composition.CompositingRenderer.UpdateCore()
   ...
   at CompareScrollSyncTests.Settle(Window window)
```

An exception thrown inside a render job leaves the compositor broken for the rest of the run, so whatever ran next failed on layout or input it never received. In **every** bad run I captured, `CompareScrollSyncTests.SelectingARowFarDown_LinesUpBothViews` was the *first* failure and the rest followed it. That is the whole "different victim set every run, all green in isolation" family.

The brushes are `ImmutableSolidColorBrush` now — no thread affinity, still one instance per theme so the `ReferenceEquals` checks in `GetExportColor` keep working. This was a real defect and not only a test one: any background thread that read a compare colour first put the shipped program in the same state.

## Eight classes left their window open

Five never closed one at all; three closed on the last line of each test, which leaks a window whenever an assertion above that line fails. A stranded window keeps the application-wide activation and the application-wide focused element, so the next test's click or key press is delivered to it instead — the amplifier that turns one genuine failure into a class-wide one. They close in `Dispose` now, the way the classes that were already stable do.

I also tried a global after-every-test hook that hid stranded windows. It did not help and is not in this PR.

## Measurements

| | ten consecutive runs |
| --- | --- |
| before | 27, 35, 11, 9, 45, 30 failures and worse — one run collapsed to 1005 |
| after | nine clean, one unrelated timing failure |

## Speed: 1 m 57 s → about 1 m 10 s, no test removed

Fourteen tests proved that a catastrophically backtracking pattern gives up — by waiting out the shipped five-second regex timeout. About 53 seconds, close to half the suite's wall clock. `RegexUtils.UserPatternMatchTimeout` is settable now and `ShortRegexTimeout` drops it to 250 ms for those four classes. A quarter of a second is still orders of magnitude more backtracking than `(a+)+b` can do against 30 a's, so the tests prove exactly what they proved before; they only stop waiting for it. Nothing in the program writes the property.

The other one: the stub that floods 1 MB to stderr generated it with one `printf` per byte, so `awk` spent about seven seconds — the single slowest test in the suite. A kilobyte at a time takes 0.3 s, same exact byte count, same shape of output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)