### PR TITLE
Make Enter press the auto-translate window default button

### DIFF
--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -2523,10 +2523,71 @@ public partial class AutoTranslateViewModel : ObservableObject
         {
             Cancel();
         }
+        else if (e.Key == Key.Enter && e.KeyModifiers == KeyModifiers.None)
+        {
+            RunDefaultButton(e);
+        }
         else if (UiUtil.IsHelp(e))
         {
             e.Handled = true;
             UiUtil.ShowHelp("features/auto-translate");
+        }
+    }
+
+    /// <summary>
+    /// The row grid marks Enter as handled without doing anything with it, so a key press made
+    /// with a line selected never reached the window. Take it while the event tunnels down when
+    /// the grid has the keyboard - everything else that uses Enter (a focused button, an open
+    /// combo box drop-down) is left alone and answered by <see cref="KeyDown"/> on the way back up.
+    /// </summary>
+    public void PreviewKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Enter && e.KeyModifiers == KeyModifiers.None && RowGrid?.IsKeyboardFocusWithin == true)
+        {
+            RunDefaultButton(e);
+        }
+    }
+
+    internal enum DefaultButtonAction
+    {
+        None,
+        Translate,
+        Ok,
+    }
+
+    /// <summary>
+    /// What Enter does in the window - the same rule that gives one of the footer buttons the
+    /// accent colour: Translate until something has been translated, then OK. Nothing while a
+    /// translation is running, as both buttons are disabled then.
+    /// </summary>
+    internal DefaultButtonAction GetDefaultButtonAction()
+    {
+        if (IsOkPrimary)
+        {
+            return DefaultButtonAction.Ok;
+        }
+
+        return IsTranslatePrimary ? DefaultButtonAction.Translate : DefaultButtonAction.None;
+    }
+
+    /// <summary>
+    /// Avalonia has no WinForms-style AcceptButton, so the accented button only looked like the
+    /// default one: Enter did nothing unless that button also had keyboard focus. Anything that
+    /// uses Enter itself - a focused button, an open combo box drop-down - has already marked the
+    /// key handled before it reaches the window.
+    /// </summary>
+    private void RunDefaultButton(KeyEventArgs e)
+    {
+        switch (GetDefaultButtonAction())
+        {
+            case DefaultButtonAction.Ok:
+                e.Handled = true;
+                Ok();
+                break;
+            case DefaultButtonAction.Translate:
+                e.Handled = true;
+                TranslateCommand.Execute(null);
+                break;
         }
     }
 

--- a/src/ui/Features/Translate/AutoTranslateWindow.cs
+++ b/src/ui/Features/Translate/AutoTranslateWindow.cs
@@ -6,6 +6,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
+using Avalonia.Threading;
 using Nikse.SubtitleEdit.UiLogic.AutoTranslate;
 using Nikse.SubtitleEdit.Features.Translate.LlamaCppAdvanced;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText;
@@ -25,6 +26,7 @@ public class AutoTranslateWindow : Window
     private readonly AutoTranslateViewModel _vm;
     private Button? _buttonTranslate;
     private Button? _buttonOk;
+    private bool _initialFocusDone;
 
     public AutoTranslateWindow(AutoTranslateViewModel vm)
     {
@@ -69,7 +71,21 @@ public class AutoTranslateWindow : Window
         ApplyButtonAccentStates(vm);
         vm.PropertyChanged += OnViewModelPropertyChanged;
 
+        AddHandler(KeyDownEvent, (_, e) => _vm.PreviewKeyDown(e), RoutingStrategies.Tunnel, handledEventsToo: false);
+
         Loaded += (s, e) => UiUtil.RestoreWindowPosition(this);
+
+        Activated += delegate
+        {
+            // Start out on the accented button so it is selected, not just coloured like it -
+            // Enter then starts the translation right away. Only the first activation: coming
+            // back from a dialog must not pull focus away from where the user left it.
+            if (!_initialFocusDone)
+            {
+                _initialFocusDone = true;
+                _buttonTranslate?.Focus();
+            }
+        };
     }
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -90,6 +106,21 @@ public class AutoTranslateWindow : Window
     {
         SetAccent(_buttonTranslate, vm.IsTranslatePrimary);
         SetAccent(_buttonOk, vm.IsOkPrimary);
+
+        // A focused button answers Enter itself, so let the focus follow the accent when OK takes
+        // over as the default button after a translation - otherwise Enter would keep translating.
+        // Posted: this runs from the first of the property changes that flip the two buttons, and
+        // OK is still disabled (hence unfocusable) until its own IsEnabled binding has caught up.
+        if (vm.IsOkPrimary && _buttonTranslate?.IsFocused == true)
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (_vm.IsOkPrimary && _buttonTranslate?.IsFocused == true)
+                {
+                    _buttonOk?.Focus();
+                }
+            });
+        }
     }
 
     private static void SetAccent(Button? button, bool accent)

--- a/tests/UI/Features/Translate/AutoTranslateDefaultButtonTests.cs
+++ b/tests/UI/Features/Translate/AutoTranslateDefaultButtonTests.cs
@@ -1,0 +1,197 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Translate;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Linq;
+using System.Windows.Input;
+
+namespace UITests.Features.Translate;
+
+/// <summary>
+/// The auto-translate window paints one footer button in the accent colour to mark it as the
+/// default: Translate until something has been translated, then OK. Avalonia has no WinForms-style
+/// AcceptButton though, so the accent was all it was - Enter did nothing until the button was
+/// tabbed to or clicked. Enter now runs the accented button, and it starts out focused.
+/// </summary>
+public class AutoTranslateDefaultButtonTests
+{
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private static AutoTranslateViewModel MakeViewModel()
+    {
+        return new AutoTranslateViewModel(new WindowService(new NullServiceProvider()), new FolderHelper());
+    }
+
+    private static Subtitle MakeSubtitle()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Hello there.", 0, 2000));
+        subtitle.Paragraphs.Add(new Paragraph("How are you?", 2000, 4000));
+        return subtitle;
+    }
+
+    private static bool SendEnter(AutoTranslateViewModel vm, KeyModifiers modifiers = KeyModifiers.None)
+    {
+        var e = new KeyEventArgs
+        {
+            Key = Key.Enter,
+            KeyModifiers = modifiers,
+            RoutedEvent = InputElement.KeyDownEvent,
+        };
+        vm.KeyDown(e);
+        return e.Handled;
+    }
+
+    private static (AutoTranslateViewModel Vm, Window Window) OpenWindow()
+    {
+        var vm = MakeViewModel();
+        vm.Initialize(MakeSubtitle());
+
+        var window = new AutoTranslateWindow(vm);
+        window.Show();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        return (vm, window);
+    }
+
+    // By command, not by caption: the captions are translated and can carry an access key.
+    private static Button FooterButton(Window window, ICommand command)
+    {
+        return window.GetVisualDescendants()
+            .OfType<Button>()
+            .First(b => ReferenceEquals(b.Command, command));
+    }
+
+    [AvaloniaFact]
+    public void TheDefaultButtonFollowsWhatTheUserCanDoNext()
+    {
+        var vm = MakeViewModel();
+
+        // Nothing translated yet - Translate.
+        vm.IsTranslateEnabled = true;
+        vm.HasTranslatedSomething = false;
+        Assert.Equal(AutoTranslateViewModel.DefaultButtonAction.Translate, vm.GetDefaultButtonAction());
+
+        // Something translated - OK, so Enter keeps the result instead of translating again.
+        vm.HasTranslatedSomething = true;
+        Assert.Equal(AutoTranslateViewModel.DefaultButtonAction.Ok, vm.GetDefaultButtonAction());
+
+        // Mid-translation both buttons are disabled, so Enter must not press either.
+        vm.IsTranslateEnabled = false;
+        Assert.Equal(AutoTranslateViewModel.DefaultButtonAction.None, vm.GetDefaultButtonAction());
+    }
+
+    [AvaloniaFact]
+    public void EnterStartsTheTranslation()
+    {
+        var vm = MakeViewModel();
+        vm.IsTranslateEnabled = true;
+
+        // No window, so the command stops before it translates anything - handling the key is
+        // what says Enter reached the Translate button instead of falling through.
+        Assert.True(SendEnter(vm));
+        Assert.False(vm.OkPressed);
+    }
+
+    [AvaloniaFact]
+    public void EnterPressesOkOnceSomethingIsTranslated()
+    {
+        var vm = MakeViewModel();
+        vm.IsTranslateEnabled = true;
+        vm.HasTranslatedSomething = true;
+
+        Assert.True(SendEnter(vm));
+        Assert.True(vm.OkPressed);
+    }
+
+    [AvaloniaFact]
+    public void EnterDoesNothingWhileTranslating()
+    {
+        var vm = MakeViewModel();
+        vm.IsTranslateEnabled = false;
+        vm.HasTranslatedSomething = true;
+
+        Assert.False(SendEnter(vm));
+        Assert.False(vm.OkPressed);
+    }
+
+    // Alt+Enter and friends belong to whatever has focus, not to the default button.
+    [AvaloniaFact]
+    public void ModifiedEnterIsLeftAlone()
+    {
+        var vm = MakeViewModel();
+        vm.IsTranslateEnabled = true;
+        vm.HasTranslatedSomething = true;
+
+        Assert.False(SendEnter(vm, KeyModifiers.Alt));
+        Assert.False(SendEnter(vm, KeyModifiers.Control));
+        Assert.False(vm.OkPressed);
+    }
+
+    [AvaloniaFact]
+    public void TheTranslateButtonIsFocusedWhenTheWindowOpens()
+    {
+        var (vm, window) = OpenWindow();
+
+        Assert.True(FooterButton(window, vm.TranslateCommand).IsFocused);
+
+        window.Close();
+    }
+
+    // Once a translation is done the accent moves to OK - the focus has to move with it, or the
+    // still-focused Translate button would answer Enter itself and translate all over again.
+    [AvaloniaFact]
+    public void FocusMovesToOkWhenItBecomesTheDefaultButton()
+    {
+        var (vm, window) = OpenWindow();
+
+        Assert.True(vm.IsTranslateEnabled);
+        vm.HasTranslatedSomething = true;
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(FooterButton(window, vm.OkCommand).IsFocused);
+
+        window.Close();
+    }
+
+    // The row grid is where the keyboard ends up after clicking a line to translate from - Enter
+    // has to reach the window from there too.
+    [AvaloniaFact]
+    public void EnterReachesTheDefaultButtonFromTheRowGrid()
+    {
+        var (vm, window) = OpenWindow();
+
+        var grid = window.GetVisualDescendants().OfType<TableView>().First();
+        var container = (Visual?)grid.ContainerFromItem(vm.Rows[0]);
+        Assert.NotNull(container);
+
+        var bounds = container!.Bounds;
+        var point = container.TranslatePoint(new Point(bounds.Width / 2, bounds.Height / 2), window)!.Value;
+        window.MouseDown(point, MouseButton.Left, RawInputModifiers.None);
+        window.MouseUp(point, MouseButton.Left, RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(grid.IsKeyboardFocusWithin, "the grid has to have the keyboard for this to test anything");
+
+        vm.HasTranslatedSomething = true; // OK is the default button - pressing it has no side effects
+        Dispatcher.UIThread.RunJobs();
+
+        window.KeyPress(Key.Enter, RawInputModifiers.None, PhysicalKey.Enter, null);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(vm.OkPressed);
+    }
+}


### PR DESCRIPTION
Starting a translation needed the mouse or Tab: the auto-translate window paints one footer button in the accent colour to mark it as the default — Translate until something has been translated, then OK — but Avalonia has no WinForms-style `AcceptButton`, so the accent was all it was. Enter did nothing unless the button itself had keyboard focus, and nothing focused it when the window opened.

## What changed

- **Enter runs the accented button.** Same rule that assigns the accent: Translate, then OK once something has been translated, and nothing while a translation is running (both buttons are disabled then). Exposed as `GetDefaultButtonAction()` so the rule is testable on its own.
- **The Translate button takes focus on the first activation**, so it is selected rather than just coloured like it. Only the first — returning from a sub-dialog must not pull focus away from where the user left it.
- **The row grid gets the key while it tunnels down.** `TableView` marks Enter handled without doing anything with it, so a press made with a line selected never reached the window. Gated on the grid having the keyboard, so everything else that has a use for Enter (a focused button, an open combo box drop-down) still gets it first and is answered on the way back up.
- **Focus follows the accent** when OK takes over as the default button after a translation — otherwise the still-focused Translate button would answer Enter with another translation. Posted, because OK is still disabled (hence unfocusable) until its `IsEnabled` binding has caught up.

## Tests

`tests/UI/Features/Translate/AutoTranslateDefaultButtonTests.cs` — 8 headless tests: the default-button rule across all three states, Enter with and without a translation done, Enter ignored mid-translation and when modified, initial focus, focus following the accent, and Enter from the row grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
