### PR TITLE
Scale the ASSA style preview with the window

### DIFF
--- a/src/ui/Features/Assa/AssaStylesWindow.cs
+++ b/src/ui/Features/Assa/AssaStylesWindow.cs
@@ -661,10 +661,10 @@ public class AssaStylesWindow : Window
             [!Image.SourceProperty] = new Binding(nameof(vm.ImagePreview)),
             DataContext = vm,
             HorizontalAlignment = HorizontalAlignment.Stretch,
-            VerticalAlignment = VerticalAlignment.Top,
+            VerticalAlignment = VerticalAlignment.Stretch,
             Stretch = Stretch.Uniform, // Scale the preview frame to fit while keeping aspect ratio
+            // No MaxHeight - the preview grows with the window via the star row it sits in
             MinHeight = 150,
-            MaxHeight = 220,
         };
 
         grid.Add(label, 0);


### PR DESCRIPTION
The "Preview" in the ASSA style window did not scale when the window was resized.

The preview `Image` was pinned to the top with `MaxHeight = 220`, so the star-sized grid row it sits in grew with the window but the image never used the extra space.

Stretched it vertically and dropped the cap. `Stretch.Uniform` keeps the 16:9 aspect ratio, and the source frame is rendered at 1280x720 via libass, so it stays sharp when enlarged. `MinHeight = 150` keeps it usable at the 600 px minimum window height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)