### PR TITLE
Give the ASSA style preview the space of its own label

### DIFF
--- a/src/ui/Features/Assa/AssaStylesWindow.cs
+++ b/src/ui/Features/Assa/AssaStylesWindow.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia;
+using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Input;
@@ -639,23 +640,6 @@ public class AssaStylesWindow : Window
 
     private static Border MakePreviewView(AssaStylesViewModel vm)
     {
-        var grid = new Grid
-        {
-            RowDefinitions =
-            {
-                new RowDefinition { Height = new GridLength(2, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(2, GridUnitType.Star) },
-            },
-            ColumnDefinitions =
-            {
-                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
-            },
-            Width = double.NaN,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-        };
-
-        var label = UiUtil.MakeLabel(Se.Language.General.Preview).WithBold();
-
         var image = new Image
         {
             [!Image.SourceProperty] = new Binding(nameof(vm.ImagePreview)),
@@ -667,10 +651,12 @@ public class AssaStylesWindow : Window
             MinHeight = 150,
         };
 
-        grid.Add(label, 0);
-        grid.Add(image, 1);
+        // No "Preview" heading - the label only ate vertical space the preview itself can use,
+        // so the name lives on as a hover hint (and as the screen reader name).
+        UiUtil.AttachHoverTooltip(image, Se.Language.General.Preview);
+        AutomationProperties.SetName(image, Se.Language.General.Preview);
 
-        return UiUtil.MakeBorderForControl(grid);
+        return UiUtil.MakeBorderForControl(image);
     }
 
     private static Button MakeStyleColorPickerButton(AssaStylesViewModel vm, string colorPropertyName)


### PR DESCRIPTION
Follow-up to #14287.

The bold "Preview" heading above the preview image cost a text row plus spacing in a panel where every pixel goes to the rendered frame.

- Dropped the heading and the wrapper grid that held it — the `Image` goes straight into the border.
- Kept the name as a hover hint via `UiUtil.AttachHoverTooltip` (which also handles the macOS modal-dialog hover bug), plus `AutomationProperties.Name` so screen readers still announce it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)