### PR TITLE
Stop the video preview showing EBU STL (and TTML positions) after the format was changed

### DIFF
--- a/src/libse/SubtitleFormats/ClqttJson.cs
+++ b/src/libse/SubtitleFormats/ClqttJson.cs
@@ -18,6 +18,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override string Name => "CLQTT JSON";
 
+        // Carries the region of every paragraph.
+        public override bool HasPositionSupport => true;
+
         public override string ToText(Subtitle subtitle, string title)
         {
             return "Not implemented";

--- a/src/libse/SubtitleFormats/Ebu.cs
+++ b/src/libse/SubtitleFormats/Ebu.cs
@@ -874,6 +874,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override string Name => NameOfFormat;
 
+        // Carries the teletext row the line starts on (MarginV) and the row count in the GSI block.
+        public override bool HasPositionSupport => true;
+
         internal struct SpecialCharacter
         {
             internal SpecialCharacter(string character, bool switchOrder = false, int priority = 2)
@@ -1240,6 +1243,27 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public override string ToText(Subtitle subtitle, string title)
         {
             return "Not supported!";
+        }
+
+        /// <summary>
+        /// Drops what only an STL can carry: the teletext box tags and the teletext row in MarginV.
+        /// </summary>
+        /// <remarks>
+        /// No other format knows either of them - the box tags used to end up as visible text in the
+        /// video preview and in the saved file, and a row number ("20") counts as an ASSA pixel
+        /// margin, which moved every line by a near random amount.
+        /// </remarks>
+        public override void RemoveNativeFormatting(Subtitle subtitle, SubtitleFormat newFormat)
+        {
+            foreach (var p in subtitle.Paragraphs)
+            {
+                if (p.Text != null && p.Text.Contains("<box>", StringComparison.Ordinal))
+                {
+                    p.Text = p.Text.Replace("<box>", string.Empty).Replace("</box>", string.Empty);
+                }
+
+                p.MarginV = null;
+            }
         }
 
         public void LoadSubtitle(Subtitle subtitle, byte[] buffer)

--- a/src/libse/SubtitleFormats/NetflixImsc11Japanese.cs
+++ b/src/libse/SubtitleFormats/NetflixImsc11Japanese.cs
@@ -18,6 +18,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public override string Extension => ".xml";
         public override string Name => "Netflix IMSC 1.1 Japanese";
 
+        // Carries the region of every paragraph, and the regions themselves in the header.
+        public override bool HasPositionSupport => true;
+
         private static string GetXmlStructure()
         {
             return @"<?xml version='1.0' encoding='UTF-8' standalone='no'?>

--- a/src/libse/SubtitleFormats/Pac.cs
+++ b/src/libse/SubtitleFormats/Pac.cs
@@ -1239,6 +1239,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override string Name => NameOfFormat;
 
+        // Carries the vertical position as a percentage in MarginV.
+        public override bool HasPositionSupport => true;
+
         private static readonly byte[] MarkerStartOfUnicode = { 0x1f, 0xef, 0xbb, 0xbf };
         private const byte MarkerEndOfUnicode = 0x2e;
         private const byte MarkerReplaceEndOfUnicode = 0xff;

--- a/src/libse/SubtitleFormats/SubtitleFormat.cs
+++ b/src/libse/SubtitleFormats/SubtitleFormat.cs
@@ -608,6 +608,19 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public virtual bool HasStyleSupport => false;
 
         /// <summary>
+        /// True when the format says where a line sits on the video - TTML regions, EBU STL teletext
+        /// rows or PAC's vertical percentage - and keeps it on the paragraphs (Region, Effect or
+        /// MarginV) and in the header.
+        /// </summary>
+        /// <remarks>
+        /// The video preview asks before it turns any of that into ASSA alignment and margins (see
+        /// <see cref="Common.SubtitlePositionToAssa"/>): the header and the paragraph fields of the
+        /// file a subtitle was read from survive a format change in the toolbar, so a subtitle now
+        /// shown as SubRip would otherwise keep the layout of a format it has left.
+        /// </remarks>
+        public virtual bool HasPositionSupport => false;
+
+        /// <summary>
         /// Hard limits the format enforces when writing (e.g. CEA-608's 32 columns x 4 rows). A format
         /// that declares them lets the UI warn before a save silently re-wraps or truncates text
         /// that does not fit. Null means no such limits.

--- a/src/libse/SubtitleFormats/TimedText10.cs
+++ b/src/libse/SubtitleFormats/TimedText10.cs
@@ -23,6 +23,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override string Name => NameOfFormat;
 
+        // Carries the region of every paragraph, and the regions themselves in the header.
+        public override bool HasPositionSupport => true;
+
         public static string TtmlNamespace => "http://www.w3.org/ns/ttml";
         public static string TtmlParameterNamespace => "http://www.w3.org/ns/ttml#parameter";
         public static string TtmlStylingNamespace => "http://www.w3.org/ns/ttml#styling";

--- a/src/libse/SubtitleFormats/TimedTextImsc11.cs
+++ b/src/libse/SubtitleFormats/TimedTextImsc11.cs
@@ -17,6 +17,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
     {
         public override string Name => "Timed Text IMSC 1.1";
 
+        // Carries the region of every paragraph, and the regions themselves in the header.
+        public override bool HasPositionSupport => true;
+
         private static string GetXmlStructure()
         {
             return @"<?xml version='1.0' encoding='UTF-8'?>

--- a/src/libse/SubtitleFormats/TimedTextImscRosetta.cs
+++ b/src/libse/SubtitleFormats/TimedTextImscRosetta.cs
@@ -15,6 +15,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
     {
         public override string Name => "Timed Text IMSC Rosetta";
 
+        // Carries the region of every paragraph, and the regions themselves in the header.
+        public override bool HasPositionSupport => true;
+
         public static string LineHeight = "125%";
         public static string FontSize = "5.3rh";
         public static string Language = string.Empty;

--- a/src/libse/SubtitleFormats/WebVTT.cs
+++ b/src/libse/SubtitleFormats/WebVTT.cs
@@ -102,6 +102,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public const string NameOfFormat = "WebVTT";
         public override string Name => NameOfFormat;
 
+        // Carries the region of every cue, and the regions themselves in the header.
+        public override bool HasPositionSupport => true;
+
         public override string ToText(Subtitle subtitle, string title)
         {
             const string timeCodeFormatHours = "{0:00}:{1:00}:{2:00}.{3:000}"; // hh:mm:ss.mmm

--- a/src/libse/SubtitleFormats/WebVTTFileWithLineNumber.cs
+++ b/src/libse/SubtitleFormats/WebVTTFileWithLineNumber.cs
@@ -20,6 +20,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         public const string NameOfFormat = "WebVTT File with#";
         public override string Name => NameOfFormat;
 
+        // Carries the region of every cue, and the regions themselves in the header.
+        public override bool HasPositionSupport => true;
+
         public override string ToText(Subtitle subtitle, string title)
         {
             const string timeCodeFormatNoHours = "{0:00}:{1:00}.{2:000}"; // mm:ss.cc

--- a/src/ui/Logic/Media/EbuStlPreviewStyler.cs
+++ b/src/ui/Logic/Media/EbuStlPreviewStyler.cs
@@ -28,6 +28,19 @@ internal static class EbuStlPreviewStyler
     }
 
     /// <summary>
+    /// True when the subtitle in the video preview is still an EBU STL.
+    /// </summary>
+    /// <remarks>
+    /// The GSI block stays on the subtitle when the format is switched in the toolbar, so the
+    /// header on its own says only which file the subtitle was read from - a subtitle shown as
+    /// SubRip must lose the teletext box and the double height with the format.
+    /// </remarks>
+    public static bool IsStlPreview([NotNullWhen(true)] string? header, Type? uiFormatType)
+    {
+        return uiFormatType == typeof(Ebu) && IsStlHeader(header);
+    }
+
+    /// <summary>
     /// Replaces the preview header with a boxed and an unboxed style and points every paragraph at
     /// the right one.
     /// </summary>

--- a/src/ui/Logic/Media/MpvReloader.cs
+++ b/src/ui/Logic/Media/MpvReloader.cs
@@ -76,6 +76,9 @@ public class MpvReloader : IMpvReloader
 
             var uiFormatType = uiFormat.GetType();
 
+            // Read here, on the UI thread, so the background serialize below only sees a bool.
+            var uiFormatHasPositions = uiFormat.HasPositionSupport;
+
             // Deep copy on the calling (UI) thread: the caller usually passes the live
             // GetUpdateSubtitle() instance, which other UI code clears and repopulates at
             // will, so it must not be touched from the background serialize below.
@@ -95,7 +98,7 @@ public class MpvReloader : IMpvReloader
             // is why the preview used to wait out a long typing pause (issue #13234).
             // "subtitle" is a thread-confined copy from here on; the secondary subtitle is
             // only read (its paragraphs are never mutated by the transforms).
-            var built = await Task.Run(() => BuildPreviewText(subtitle, subtitleSecondary, uiFormatType, oldHash, oldText));
+            var built = await Task.Run(() => BuildPreviewText(subtitle, subtitleSecondary, uiFormatType, uiFormatHasPositions, oldHash, oldText));
 
             if (version != _refreshVersion)
             {
@@ -175,7 +178,7 @@ public class MpvReloader : IMpvReloader
 
     // Runs on a background thread (see RefreshMpv). Must only touch the thread-confined
     // subtitle copy, read-only state and libse statics - never the memo fields.
-    private (Subtitle Subtitle, string Text, int Hash, bool HashValid) BuildPreviewText(Subtitle subtitle, Subtitle? subtitleSecondary, Type uiFormatType, int oldHash, string oldText)
+    private (Subtitle Subtitle, string Text, int Hash, bool HashValid) BuildPreviewText(Subtitle subtitle, Subtitle? subtitleSecondary, Type uiFormatType, bool uiFormatHasPositions, int oldHash, string oldText)
     {
         if (SmpteMode)
         {
@@ -242,15 +245,23 @@ public class MpvReloader : IMpvReloader
                 subtitle.Header = MpvPreviewStyleHeader;
             }
 
-            if (EbuStlPreviewStyler.IsStlHeader(oldHeader))
+            // The GSI block survives a format change in the toolbar, so an STL header alone does
+            // not mean the subtitle is still EBU STL - shown as SubRip it must lose the teletext
+            // box, the double height and the rows.
+            if (EbuStlPreviewStyler.IsStlPreview(oldHeader, uiFormatType))
             {
                 EbuStlPreviewStyler.Apply(subtitle, oldHeader, GetMpvPreviewStyle(Se.Settings.Video), MpvPreviewTitle);
             }
 
             // TTML regions, PAC vertical alignment and EBU STL teletext rows say where the line
             // belongs on the video - without this every line lands at the one fixed preview
-            // alignment from the settings (discussion #13857).
-            SubtitlePositionToAssa.ApplyPositions(subtitle, oldHeader, Se.Settings.Video.MpvPreviewUsePositionFromFile);
+            // alignment from the settings (discussion #13857). Only for a format that still carries
+            // them: the header and the paragraph fields of the file the subtitle was read from
+            // survive a format change in the toolbar. The call is made either way - with the
+            // positioning off it strips the leftovers, and a teletext row or a percentage left in
+            // MarginV would otherwise count as an ASSA pixel margin.
+            var usePositions = Se.Settings.Video.MpvPreviewUsePositionFromFile && uiFormatHasPositions;
+            SubtitlePositionToAssa.ApplyPositions(subtitle, oldHeader, usePositions);
         }
 
         SecondarySubtitleMerger.AddSecondarySubtitle(subtitle, subtitleSecondary);

--- a/src/ui/Logic/Media/VlcReloader.cs
+++ b/src/ui/Logic/Media/VlcReloader.cs
@@ -98,14 +98,18 @@ public class VlcReloader : IVlcReloader
                         subtitle.Header = MpvPreviewStyleHeader;
                     }
 
-                    if (EbuStlPreviewStyler.IsStlHeader(oldSub.Header))
+                    // See MpvReloader - the GSI block survives a format change in the toolbar, so
+                    // an STL header alone does not mean the subtitle is still EBU STL.
+                    if (EbuStlPreviewStyler.IsStlPreview(oldSub.Header, uiFormatType))
                     {
                         EbuStlPreviewStyler.Apply(subtitle, oldSub.Header, GetMpvPreviewStyle(Se.Settings.Video), MpvPreviewTitle);
                     }
 
                     // See MpvReloader - the position the source format carries beats the one fixed
-                    // preview alignment (discussion #13857).
-                    SubtitlePositionToAssa.ApplyPositions(subtitle, oldSub.Header, Se.Settings.Video.MpvPreviewUsePositionFromFile);
+                    // preview alignment (discussion #13857), but only while the format still carries
+                    // it. With the positioning off the call strips what the old format left behind.
+                    var usePositions = Se.Settings.Video.MpvPreviewUsePositionFromFile && uiFormat.HasPositionSupport;
+                    SubtitlePositionToAssa.ApplyPositions(subtitle, oldSub.Header, usePositions);
                 }
 
                 SecondarySubtitleMerger.AddSecondarySubtitle(subtitle, subtitleSecondary);

--- a/tests/UI/Logic/Media/EbuStlPreviewStylerTests.cs
+++ b/tests/UI/Logic/Media/EbuStlPreviewStylerTests.cs
@@ -154,6 +154,19 @@ public class EbuStlPreviewStylerTests
         Assert.Equal(expected, EbuStlPreviewStyler.IsStlHeader(header));
     }
 
+    // The GSI block stays on the subtitle when the format is switched in the toolbar, so the header
+    // alone kept the teletext box and the double height on a subtitle now shown as SubRip.
+    [Fact]
+    public void TheStlHeaderOnlyStylesThePreviewWhileTheFormatIsEbu()
+    {
+        var header = MakeStlHeader("1");
+
+        Assert.True(EbuStlPreviewStyler.IsStlPreview(header, typeof(Ebu)));
+        Assert.False(EbuStlPreviewStyler.IsStlPreview(header, typeof(SubRip)));
+        Assert.False(EbuStlPreviewStyler.IsStlPreview(header, null));
+        Assert.False(EbuStlPreviewStyler.IsStlPreview(null, typeof(Ebu)));
+    }
+
     // Preview only, and never written to the file - an STL carries a character table, not a
     // typeface. It lets someone with a teletext face installed see the preview a decoder would draw.
     [Fact]

--- a/tests/UI/Logic/Media/MpvPreviewStlBoxTests.cs
+++ b/tests/UI/Logic/Media/MpvPreviewStlBoxTests.cs
@@ -36,7 +36,7 @@ public class MpvPreviewStlBoxTests
         return Ebu.ReadHeader(buffer).ToString();
     }
 
-    private static string BuildPreviewText(bool useBox, string displayStandardCode = "1", bool useDoubleHeight = false)
+    private static string BuildPreviewText(bool useBox, string displayStandardCode = "1", bool useDoubleHeight = false, Type? uiFormatType = null)
     {
         Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 
@@ -52,12 +52,13 @@ public class MpvPreviewStlBoxTests
             Se.Settings.Video.MpvPreviewFontSize = 33;
 
             var subtitle = new Subtitle { Header = MakeStlHeader(displayStandardCode) };
-            subtitle.Paragraphs.Add(new Paragraph("Hello world", 1000, 3000));
+            subtitle.Paragraphs.Add(new Paragraph("Hello world", 1000, 3000) { MarginV = "20" });
 
+            var format = (SubtitleFormat)Activator.CreateInstance(uiFormatType ?? typeof(Ebu))!;
             var reloader = new MpvReloader();
             var method = typeof(MpvReloader).GetMethod("BuildPreviewText", BindingFlags.Instance | BindingFlags.NonPublic);
             Assert.NotNull(method);
-            var result = method!.Invoke(reloader, new object?[] { subtitle, null, typeof(Ebu), 0, string.Empty })!;
+            var result = method!.Invoke(reloader, new object?[] { subtitle, null, format.GetType(), format.HasPositionSupport, 0, string.Empty })!;
             return (string)result.GetType().GetField("Item2")!.GetValue(result)!;
         }
         finally
@@ -80,9 +81,20 @@ public class MpvPreviewStlBoxTests
 
     private static string GetDialogueStyle(string assText)
     {
+        return GetDialogueField(assText, 3);
+    }
+
+    // Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+    private static string GetDialogueMarginV(string assText)
+    {
+        return GetDialogueField(assText, 7);
+    }
+
+    private static string GetDialogueField(string assText, int index)
+    {
         var line = assText.Split('\n').FirstOrDefault(l => l.StartsWith("Dialogue:", StringComparison.Ordinal));
         Assert.NotNull(line);
-        return line!.Split(',')[3];
+        return line!.Split(',')[index].Trim();
     }
 
     [AvaloniaFact]
@@ -162,5 +174,27 @@ public class MpvPreviewStlBoxTests
         var assText = BuildPreviewText(useBox: true, displayStandardCode: "0", useDoubleHeight: true);
 
         Assert.Equal("100", GetStyle(assText, "Default")[ScaleYField]);
+    }
+
+    // The GSI block and the teletext row in MarginV stay on the subtitle when the format is
+    // switched in the toolbar, and the preview kept drawing the box, the double height and the
+    // rows of a file the subtitle is no longer shown as.
+    [AvaloniaFact]
+    public void SwitchingTheFormatToSubRipDropsTheTeletextStyling()
+    {
+        var assText = BuildPreviewText(useBox: true, useDoubleHeight: true, uiFormatType: typeof(SubRip));
+
+        Assert.DoesNotContain("Style: Box,", assText, StringComparison.Ordinal);
+        Assert.Equal("Default", GetDialogueStyle(assText));
+        Assert.Equal("100", GetStyle(assText, "Default")[ScaleYField]);
+    }
+
+    // A teletext row is not a pixel margin - left behind it moved every line by a near random
+    // amount, so it has to be stripped even though nothing is positioned any more.
+    [AvaloniaFact]
+    public void SwitchingTheFormatToSubRipLeavesNoTeletextRowBehind()
+    {
+        Assert.NotEqual("0", GetDialogueMarginV(BuildPreviewText(useBox: false)));
+        Assert.Equal("0", GetDialogueMarginV(BuildPreviewText(useBox: false, uiFormatType: typeof(SubRip))));
     }
 }

--- a/tests/libse/Common/SubtitlePositionToAssaTest.cs
+++ b/tests/libse/Common/SubtitlePositionToAssaTest.cs
@@ -112,6 +112,22 @@ public class SubtitlePositionToAssaTest
         Assert.Null(p.MarginV);
     }
 
+    // The header of the file a subtitle was read from stays on it when the format is switched in
+    // the toolbar, so a subtitle now shown as SubRip asks for the positioning to be left off - see
+    // SubtitleFormat.HasPositionSupport.
+    [Fact]
+    public void TtmlRegionIsIgnoredWhenPositionsAreOff()
+    {
+        var subtitle = SubtitleWith(ParagraphWithRegion("Hi there!", "top"));
+
+        Assert.False(SubtitlePositionToAssa.ApplyPositions(subtitle, TtmlHeader, false));
+
+        var p = subtitle.Paragraphs[0];
+        Assert.Equal("Hi there!", p.Text);
+        Assert.Null(p.MarginV);
+        Assert.Null(p.MarginL);
+    }
+
     [Fact]
     public void PacPercentageBecomesAMargin()
     {

--- a/tests/libse/SubtitleFormats/EbuTest.cs
+++ b/tests/libse/SubtitleFormats/EbuTest.cs
@@ -265,4 +265,21 @@ public class EbuTest
     {
         Assert.Null(Ebu.GetNearestColorName(color));
     }
+
+    // Switching the format in the toolbar (or converting in batch convert) leaves the STL specific
+    // bits behind: the box tags used to show up as text in the video preview and in the saved file,
+    // and a teletext row in MarginV counts as an ASSA pixel margin.
+    [Fact]
+    public void RemoveNativeFormatting_DropsBoxTagsAndTeletextRows()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("<box>Hello world</box>", 1000, 3000) { MarginV = "20" });
+        subtitle.Paragraphs.Add(new Paragraph("<i>Second line</i>", 4000, 6000) { MarginV = "18" });
+
+        new Ebu().RemoveNativeFormatting(subtitle, new SubRip());
+
+        Assert.Equal("Hello world", subtitle.Paragraphs[0].Text);
+        Assert.Equal("<i>Second line</i>", subtitle.Paragraphs[1].Text);
+        Assert.All(subtitle.Paragraphs, p => Assert.Null(p.MarginV));
+    }
 }

--- a/tests/libse/SubtitleFormats/SubtitleFormatPositionSupportTest.cs
+++ b/tests/libse/SubtitleFormats/SubtitleFormatPositionSupportTest.cs
@@ -1,0 +1,50 @@
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+
+namespace LibSETests.SubtitleFormats;
+
+/// <summary>
+/// The video preview turns the position a format carries - TTML regions, EBU STL teletext rows,
+/// PAC percentages - into ASSA alignment and margins, and asks the format whether it still carries
+/// any (discussion #13857). The header and the Region/Effect/MarginV fields of the file a subtitle
+/// was read from survive a format change in the toolbar, so the flag is what stops a subtitle now
+/// shown as SubRip from keeping the layout of the format it has left.
+/// </summary>
+public class SubtitleFormatPositionSupportTest
+{
+    [Theory]
+    [InlineData(typeof(Ebu))]
+    [InlineData(typeof(Pac))]
+    [InlineData(typeof(PacUnicode))]
+    [InlineData(typeof(TimedText10))]
+    [InlineData(typeof(DfxpBasic))]
+    [InlineData(typeof(ItunesTimedText))]
+    [InlineData(typeof(NetflixTimedText))]
+    [InlineData(typeof(SmpteTt2052))]
+    [InlineData(typeof(TimedTextImsc11))]
+    [InlineData(typeof(TimedTextImscRosetta))]
+    [InlineData(typeof(NetflixImsc11Japanese))]
+    [InlineData(typeof(ClqttJson))]
+    [InlineData(typeof(WebVTT))]
+    [InlineData(typeof(WebVTTFileWithLineNumber))]
+    public void AFormatThatCarriesPositionsSaysSo(Type formatType)
+    {
+        var format = (SubtitleFormat)Activator.CreateInstance(formatType)!;
+
+        Assert.True(format.HasPositionSupport);
+    }
+
+    // Nothing in a SubRip or an ASSA file says where a line sits that this turns into a position:
+    // ASSA margins are already in script units, and SubRip has none at all.
+    [Theory]
+    [InlineData(typeof(SubRip))]
+    [InlineData(typeof(AdvancedSubStationAlpha))]
+    [InlineData(typeof(SubStationAlpha))]
+    [InlineData(typeof(MicroDvd))]
+    [InlineData(typeof(EbuTtD))]
+    public void AFormatWithoutPositionsSaysSo(Type formatType)
+    {
+        var format = (SubtitleFormat)Activator.CreateInstance(formatType)!;
+
+        Assert.False(format.HasPositionSupport);
+    }
+}


### PR DESCRIPTION
Reported: the preview keeps handling the subtitle as EBU STL after the format is changed to SubRip in the toolbar combo box.

## What was wrong

The GSI block of the file the subtitle was read from stays on `subtitle.Header` when the format is switched, and both reloaders decided "this is EBU STL" from that header alone. So a subtitle shown as SubRip kept the teletext box, the double height and the teletext rows. TTML has the same problem: the regions in the header went on positioning every line after a switch to SubRip.

Two more STL leftovers rode along: `Ebu` had no `RemoveNativeFormatting`, so the `<box>`/`</box>` tags an STL decodes into stayed in the text (visible in the preview once the styler no longer strips them, and written into the saved SubRip file), and the teletext row in `MarginV` counted as a pixel margin when saving to ASSA.

## The fix

The header only says which file the subtitle came from, so ask the current format instead:

- `EbuStlPreviewStyler.IsStlPreview(header, uiFormatType)` - the mpv and the VLC reloader style the preview as EBU STL only while the UI format is `Ebu`.
- New `SubtitleFormat.HasPositionSupport` (next to `HasStyleSupport`) says whether the format carries where a line sits - TTML regions, EBU STL teletext rows, PAC percentages. The reloaders position from the file only when it does. `SubtitlePositionToAssa.ApplyPositions` is still called with the positioning off, so a teletext row or a percentage left behind in `MarginV` is stripped rather than left to count as an ASSA pixel margin.
- `Ebu.RemoveNativeFormatting` drops the box tags and the teletext row when converting to any other format - toolbar switch, "Save as" and batch convert.

The header itself is left on the subtitle, so switching back to EBU STL (or to another TTML format) keeps the GSI settings and the regions.

## Tests

- `SubtitleFormatPositionSupportTest` - which formats declare positions, and which do not.
- `MpvPreviewStlBoxTests` - switching to SubRip drops the box style, the double height and the teletext row (asserting the row is applied as EBU and gone as SubRip).
- `SubtitlePositionToAssaTest` - a TTML region is ignored with the positioning off.
- `EbuTest` - `RemoveNativeFormatting` drops box tags and rows.
- `EbuStlPreviewStylerTests` - the STL header only styles the preview while the format is `Ebu`.

Full suites green: libse 1757, UI 4372, libuilogic 725, seconv 448.

🤖 Generated with [Claude Code](https://claude.com/claude-code)