### PR TITLE
Sort the OCR fix list alphabetically in Options - Word lists

### DIFF
--- a/src/ui/Features/Options/WordLists/WordListsViewModel.cs
+++ b/src/ui/Features/Options/WordLists/WordListsViewModel.cs
@@ -432,6 +432,8 @@ public partial class WordListsViewModel : ObservableObject
             result.Add(new OcrFixItem(item.Key, item.Value));
         }
 
+        result.Sort((a, b) => string.Compare(a.Find, b.Find, StringComparison.OrdinalIgnoreCase));
+
         return result;
     }
 


### PR DESCRIPTION
The "Names" and "User word list" panes in Options - Word lists are both sorted when loaded, but the OCR fix list was rendered in raw file order, so it looked unsorted next to the other two.

`AddOcrFix` already walks the collection to find an alphabetical insert position, so the add path assumed a sorted list that the load path never produced.

Sort the loaded list by the find word using `OrdinalIgnoreCase` - the same comparison the insert loop uses, so a newly added entry lands exactly where the sort puts it.

Fixes #14294

🤖 Generated with [Claude Code](https://claude.com/claude-code)