### PR TITLE
Read YouTube srv3 subtitles again, name the format, add JSON Type 24

### DIFF
--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -176,6 +176,14 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
             }
 
+            foreach (var format in SubtitleFormat.AllSubtitleFormats)
+            {
+                if (format.AlternateNames.Contains(friendlyName))
+                {
+                    return format;
+                }
+            }
+
             return null;
         }
 

--- a/src/libse/SubtitleFormats/JsonType24.cs
+++ b/src/libse/SubtitleFormats/JsonType24.cs
@@ -1,0 +1,88 @@
+using Nikse.SubtitleEdit.Core.Common;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace Nikse.SubtitleEdit.Core.SubtitleFormats
+{
+    /// <summary>
+    /// [{"id":13077087,"start_time":192665,"end_time":193887,"subtitle_language_code":"en","subtitle_id":27992065,"subtitle_content":"Hi."}]
+    /// Times are in milliseconds. Not to be confused with JSON Type 8, which uses start_time/end_time in seconds with a "text" tag.
+    /// </summary>
+    public class JsonType24 : SubtitleFormat
+    {
+        public override string Extension => ".json";
+
+        public override string Name => "JSON Type 24";
+
+        public override bool IsMine(List<string> lines, string fileName)
+        {
+            var allText = JoinLinesTrimmed(lines);
+            if (!allText.StartsWith('[') || !allText.Contains("\"subtitle_content\"", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            var subtitle = new Subtitle();
+            LoadSubtitle(subtitle, lines, fileName);
+            return subtitle.Paragraphs.Count > 0 && _errorCount == 0;
+        }
+
+        public override string ToText(Subtitle subtitle, string title)
+        {
+            var sb = new StringBuilder("[");
+            for (var i = 0; i < subtitle.Paragraphs.Count; i++)
+            {
+                var p = subtitle.Paragraphs[i];
+                if (i > 0)
+                {
+                    sb.Append(',');
+                }
+
+                sb.Append("{\"id\":");
+                sb.Append(p.Number.ToString(CultureInfo.InvariantCulture));
+                sb.Append(",\"start_time\":");
+                sb.Append(((long)Math.Round(p.StartTime.TotalMilliseconds)).ToString(CultureInfo.InvariantCulture));
+                sb.Append(",\"end_time\":");
+                sb.Append(((long)Math.Round(p.EndTime.TotalMilliseconds)).ToString(CultureInfo.InvariantCulture));
+                sb.Append(",\"subtitle_id\":");
+                sb.Append(p.Number.ToString(CultureInfo.InvariantCulture));
+                sb.Append(",\"subtitle_content\":\"");
+                sb.Append(Json.EncodeJsonText(p.Text, "\\n"));
+                sb.Append("\"}");
+            }
+
+            sb.Append(']');
+            return sb.ToString();
+        }
+
+        public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
+        {
+            _errorCount = 0;
+            var allText = JoinLinesTrimmed(lines);
+            if (!allText.StartsWith('['))
+            {
+                return;
+            }
+
+            foreach (var item in Json.ReadObjectArray(allText))
+            {
+                var start = Json.ReadTag(item, "start_time");
+                var end = Json.ReadTag(item, "end_time");
+                var text = Json.ReadTag(item, "subtitle_content");
+                if (start == null || end == null || text == null ||
+                    !double.TryParse(start, NumberStyles.Float, CultureInfo.InvariantCulture, out var startMs) ||
+                    !double.TryParse(end, NumberStyles.Float, CultureInfo.InvariantCulture, out var endMs))
+                {
+                    _errorCount++;
+                    continue;
+                }
+
+                subtitle.Paragraphs.Add(new Paragraph(Json.DecodeJsonText(text), startMs, endMs));
+            }
+
+            subtitle.Renumber();
+        }
+    }
+}

--- a/src/libse/SubtitleFormats/SubtitleFormat.cs
+++ b/src/libse/SubtitleFormats/SubtitleFormat.cs
@@ -259,6 +259,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     new JsonType22(),
                     new JsonType23(),
                     new WistiaJson(),
+                    new JsonType24(),
                     new KanopyHtml(),
                     new LambdaCap(),
                     new Lrc(),
@@ -455,7 +456,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     new UnknownSubtitle79(),
                     new UnknownSubtitle80(),
                     new UnknownSubtitle81(),
-                    new UnknownSubtitle82(),
+                    new YouTubeTimedText(),
                     new UnknownSubtitle83(),
                     new UnknownSubtitle84(),
                     new UnknownSubtitle85(),
@@ -552,6 +553,13 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         }
 
         public virtual List<string> AlternateExtensions => new List<string>();
+
+        /// <summary>
+        /// Names this format used to be called. Settings store formats by name
+        /// (DefaultSubtitleFormat, FavoriteSubtitleFormats), so renaming a format would
+        /// otherwise silently drop it from an existing user's default and favorites.
+        /// </summary>
+        public virtual List<string> AlternateNames => new List<string>();
 
         public static int MillisecondsToFrames(double milliseconds)
         {
@@ -844,6 +852,17 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     format.FriendlyName.Trim().Equals(trimmedFormatName, StringComparison.OrdinalIgnoreCase))
                 {
                     return format;
+                }
+            }
+
+            foreach (var format in AllSubtitleFormats)
+            {
+                foreach (var alternateName in format.AlternateNames)
+                {
+                    if (alternateName.Trim().Equals(trimmedFormatName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return format;
+                    }
                 }
             }
 

--- a/src/libse/SubtitleFormats/TimedTextNoNs.cs
+++ b/src/libse/SubtitleFormats/TimedTextNoNs.cs
@@ -28,6 +28,11 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
             xmlAsString = xmlAsString.RemoveControlCharactersButWhiteSpace();
 
+            if (xmlAsString.Contains("<timedtext", StringComparison.OrdinalIgnoreCase))
+            {
+                return false; // YouTube timed text (srv3/.ytt) - see YouTubeTimedText
+            }
+
             if (xmlAsString.Contains("profile/imsc1"))
             {
                 var f = new TimedTextImsc11();

--- a/src/libse/SubtitleFormats/YouTubeTimedText.cs
+++ b/src/libse/SubtitleFormats/YouTubeTimedText.cs
@@ -7,11 +7,22 @@ using System.Globalization;
 
 namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 {
-    internal class UnknownSubtitle82 : SubtitleFormat
+    /// <summary>
+    /// YouTube timed text, aka srv3 - what yt-dlp writes for --sub-format srv3 and what
+    /// YTSubConverter produces as .ytt. Text can be split over several timed s runs inside
+    /// each p element.
+    /// </summary>
+    internal class YouTubeTimedText : SubtitleFormat
     {
         public override string Extension => ".xml";
 
-        public override string Name => "Unknown 82";
+        public override string Name => "YouTube timed text srv3";
+
+        // No parenthesis in the name above - GetSubtitleFormatByFriendlyName truncates there.
+
+        public override List<string> AlternateExtensions => new List<string> { ".ytt", ".srv3" };
+
+        public override List<string> AlternateNames => new List<string> { "Unknown 82" };
 
    public override string ToText(Subtitle subtitle, string title)
         {

--- a/tests/libse/SubtitleFormats/JsonType24Test.cs
+++ b/tests/libse/SubtitleFormats/JsonType24Test.cs
@@ -1,0 +1,68 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace LibSETests.SubtitleFormats;
+
+public class JsonType24Test
+{
+    private const string Sample =
+        "[{\"id\":13077087,\"start_time\":192665,\"end_time\":193887,\"subtitle_language_code\":\"en\"," +
+        "\"subtitle_id\":27992065,\"subtitle_content\":\"Hi. What would you like to eat?\"}," +
+        "{\"id\":13077088,\"start_time\":194000,\"end_time\":196500,\"subtitle_language_code\":\"en\"," +
+        "\"subtitle_id\":27992066,\"subtitle_content\":\"I would like a pizza.\"}]";
+
+    private static List<string> Lines(string s) => new List<string> { s };
+
+    [Fact]
+    public void LoadSubtitleReadsMillisecondsAndSubtitleContent()
+    {
+        var format = new JsonType24();
+        var subtitle = new Subtitle();
+
+        Assert.True(format.IsMine(Lines(Sample), null));
+        format.LoadSubtitle(subtitle, Lines(Sample), null);
+
+        Assert.Equal(2, subtitle.Paragraphs.Count);
+        Assert.Equal("Hi. What would you like to eat?", subtitle.Paragraphs[0].Text);
+        Assert.Equal(192665, subtitle.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(193887, subtitle.Paragraphs[0].EndTime.TotalMilliseconds);
+        Assert.Equal("I would like a pizza.", subtitle.Paragraphs[1].Text);
+        Assert.Equal(196500, subtitle.Paragraphs[1].EndTime.TotalMilliseconds);
+    }
+
+    /// <summary>JSON Type 8 also uses start_time/end_time, but in seconds and with a "text" tag.</summary>
+    [Fact]
+    public void JsonType8FilesAreNotClaimed()
+    {
+        var jsonType8 = "[{\"start_time\":1.5,\"end_time\":3.75,\"text\":\"Hello\"}]";
+        Assert.False(new JsonType24().IsMine(Lines(jsonType8), null));
+    }
+
+    [Fact]
+    public void RoundTripKeepsTextAndTimes()
+    {
+        var format = new JsonType24();
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Hello \"world\"", 192665, 193887));
+
+        var text = format.ToText(subtitle, "title");
+        var reloaded = new Subtitle();
+        format.LoadSubtitle(reloaded, text.SplitToLines(), null);
+
+        Assert.Single(reloaded.Paragraphs);
+        Assert.Equal("Hello \"world\"", reloaded.Paragraphs[0].Text);
+        Assert.Equal(192665, reloaded.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(193887, reloaded.Paragraphs[0].EndTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void AutoDetectPicksJsonType24()
+    {
+        var lines = Lines(Sample);
+        var winner = SubtitleFormat.AllSubtitleFormats.First(f => f.IsTextBased && f.IsMine(lines, "sample.json"));
+        Assert.Equal(new JsonType24().Name, winner.Name);
+    }
+}

--- a/tests/libse/SubtitleFormats/YouTubeTimedTextShadowingTest.cs
+++ b/tests/libse/SubtitleFormats/YouTubeTimedTextShadowingTest.cs
@@ -1,0 +1,79 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace LibSETests.SubtitleFormats;
+
+/// <summary>
+/// YouTube timed text (srv3 / .ytt) is read by the YouTubeTimedText format, but
+/// <see cref="TimedTextNoNs"/> is earlier in the format list and used to claim it first:
+/// its IsMine accepts any namespace-less XML with a body and a p element. Since real
+/// srv3 keeps its text in nested s elements, that produced the worst possible result -
+/// the right number of paragraphs with empty text and default time codes, rather than
+/// an honest "unknown format".
+/// </summary>
+public class YouTubeTimedTextShadowingTest
+{
+    /// <summary>As emitted by yt-dlp --sub-format srv3: text split over several timed s runs.</summary>
+    private const string RealWorldSrv3 =
+        "<?xml version=\"1.0\" encoding=\"utf-8\" ?><timedtext format=\"3\"><head>" +
+        "<ws id=\"0\"/><wp id=\"0\"/><pen id=\"0\" sc=\"#FFFFFF\"/></head><body>" +
+        "<p t=\"1500\" d=\"2250\"><s ac=\"212\">Hello</s><s t=\"300\" ac=\"240\"> there,</s><s t=\"700\" ac=\"255\"> world.</s></p>" +
+        "<p t=\"4000\" d=\"2500\"><s ac=\"200\">Second caption line.</s></p></body></timedtext>";
+
+    private static List<string> Lines(string s) => new List<string> { s };
+
+    [Fact]
+    public void TimedTextNoNsDoesNotClaimYouTubeTimedText()
+    {
+        Assert.False(new TimedTextNoNs().IsMine(Lines(RealWorldSrv3), "sample.ytt"));
+    }
+
+    [Fact]
+    public void AutoDetectReadsSrv3TextAndTimes()
+    {
+        var lines = Lines(RealWorldSrv3);
+        var format = SubtitleFormat.AllSubtitleFormats.First(f => f.IsTextBased && f.IsMine(lines, "sample.ytt"));
+        var subtitle = new Subtitle();
+        format.LoadSubtitle(subtitle, lines, "sample.ytt");
+
+        Assert.Equal("YouTube timed text srv3", format.Name); // the format class is internal to LibSE
+        Assert.Equal(2, subtitle.Paragraphs.Count);
+        Assert.Equal("Hello there, world.", subtitle.Paragraphs[0].Text);
+        Assert.Equal(1500, subtitle.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(3750, subtitle.Paragraphs[0].EndTime.TotalMilliseconds);
+        Assert.Equal("Second caption line.", subtitle.Paragraphs[1].Text);
+        Assert.Equal(6500, subtitle.Paragraphs[1].EndTime.TotalMilliseconds);
+    }
+
+    /// <summary>
+    /// The format was called "Unknown 82" before it was named. Settings store formats by
+    /// name, so the old one has to keep resolving or an existing user loses it from their
+    /// default format and favorites.
+    /// </summary>
+    [Fact]
+    public void TheOldUnknown82NameStillResolves()
+    {
+        Assert.Equal("YouTube timed text srv3", SubtitleFormat.FromName("Unknown 82", new SubRip()).Name);
+        Assert.Equal("YouTube timed text srv3", Utilities.GetSubtitleFormatByFriendlyName("Unknown 82").Name);
+    }
+
+    /// <summary>The guard must not cost us plain namespace-less TTML.</summary>
+    [Fact]
+    public void PlainNamespacelessTimedTextIsStillMine()
+    {
+        var ttml = "<?xml version=\"1.0\" encoding=\"utf-8\"?><tt><body><div>" +
+                   "<p begin=\"00:00:01.500\" end=\"00:00:03.750\">Hello there, world.</p>" +
+                   "</div></body></tt>";
+        var format = new TimedTextNoNs();
+        var subtitle = new Subtitle();
+
+        Assert.True(format.IsMine(Lines(ttml), "sample.xml"));
+        format.LoadSubtitle(subtitle, Lines(ttml), "sample.xml");
+
+        Assert.Single(subtitle.Paragraphs);
+        Assert.Equal("Hello there, world.", subtitle.Paragraphs[0].Text);
+    }
+}


### PR DESCRIPTION
Found while scanning the [VideoHelp subtitle forum](https://forum.videohelp.com/forums/42-Subtitle) for formats users can't open.

> Rebased onto main after #14298. Wistia json was dropped from this PR — #14298 adds it, and does it better (it uses `SeJsonParser` rather than the hand-rolled string scanning this PR had). The only conflict was the registration line both PRs added after `new JsonType23()`; both are kept.

## YouTube timed text (srv3 / `.ytt`) was read as empty subtitles

`UnknownSubtitle82` reads the format correctly, but `TimedTextNoNs` sits earlier in the format list and claimed the file first — its `IsMine` accepts *any* namespace-less XML with a `<body>` and a `<p>`. Real srv3 keeps its text in nested `<s>` runs, which `TimedTextNoNs` doesn't read, so opening one gave the right number of lines with **empty text and default 3-second time codes** — silent data loss rather than an honest "unknown format".

```
before:  [00:00:00,000 -> 00:00:03,000] ''
after:   [00:00:01,500 -> 00:00:03,750] 'Hello there, world.'
```

Fixed with a `<timedtext` bail-out next to the existing IMSC / Netflix / SMPTE guards.

Worth noting why no test caught this: `UnknownSubtitle82.ToText` writes flat `<p>text</p>`, so a round-trip through our own writer still produced text. Only real-world files with nested `<s>` runs go empty — the added test uses `yt-dlp --sub-format srv3` output.

## Naming the format

Being called "Unknown 82", the format was impossible to find even once it worked. It is now `YouTubeTimedText` / **"YouTube timed text srv3"**, and claims `.ytt` and `.srv3` as `AlternateExtensions` so those files appear in the open dialog.

Two things that fell out of the rename:

**Settings store formats by name** (`DefaultSubtitleFormat`, `FavoriteSubtitleFormats`), so renaming would silently drop the format from an existing user's default and favorites. This adds an `AlternateNames` property mirroring the existing `AlternateExtensions`, checked as a fallback in `FromName` and `Utilities.GetSubtitleFormatByFriendlyName`, so `"Unknown 82"` keeps resolving. There's a test for it. This is the one bit of new public API here, so it's the part most worth a look.

**The name deliberately contains no parenthesis** — `GetSubtitleFormatByFriendlyName` truncates at the first `(`, so a name like `"YouTube timed text (srv3)"` would not resolve to itself.

## JSON Type 24

`start_time` / `end_time` in milliseconds with `subtitle_content` ([reported here](https://forum.videohelp.com/threads/363413-What-Subtitle-Format-Is-This)) — nothing recognized it. Distinct from JSON Type 8, which uses seconds and a `text` tag; there's a test that it doesn't claim Type 8 files.

## Verification

Re-run after the rebase, against the post-#14298 format list:

- **1796 libse tests pass**, 0 failed
- Full solution builds with **0 warnings**
- Round-tripped every text format through every other format's `IsMine`, on `main` and on this branch. Shadowing goes **33 → 32, the single removed line being `Unknown 82 stolen by Timed Text No Namespace`**. No new shadowing; `JSON Type 24` and `YouTube timed text srv3` appear nowhere in the list — neither shadows nor is shadowed.
- A test guards that plain namespace-less TTML still resolves to `TimedTextNoNs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)