### PR TITLE
Add Wistia json, DVD Junior SPC and Sonic DVD Producer formats

### DIFF
--- a/src/libse/SubtitleFormats/QubeMasterImport.cs
+++ b/src/libse/SubtitleFormats/QubeMasterImport.cs
@@ -52,6 +52,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var p = new Paragraph();
             subtitle.Paragraphs.Clear();
             _errorCount = 0;
+            bool entryStartsWithNumber = false;
             foreach (string line in lines)
             {
                 string s = line.Trim();
@@ -105,6 +106,20 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 else
                 {
                     expectStartTime = true;
+
+                    // "1 / 00:00:32:07 / 00:00:38:04 / text" files (Unknown 64) fit this reader too, but the
+                    // counter line ends up glued in front of the text - count those entries as errors so the
+                    // format that reads them properly wins instead.
+                    if (p.Text.Length == 0)
+                    {
+                        entryStartsWithNumber = Utilities.IsInteger(s) && s.Length <= 5;
+                    }
+                    else if (entryStartsWithNumber)
+                    {
+                        entryStartsWithNumber = false;
+                        _errorCount++;
+                    }
+
                     p.Text = (p.Text + Environment.NewLine + line).Trim();
                     if (p.Text.Length > 500)
                     {

--- a/src/libse/SubtitleFormats/SonicDvdProducer.cs
+++ b/src/libse/SubtitleFormats/SonicDvdProducer.cs
@@ -1,0 +1,109 @@
+using Nikse.SubtitleEdit.Core.Common;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Nikse.SubtitleEdit.Core.SubtitleFormats
+{
+    /// <summary>
+    /// Subtitle script for Sonic DVD Producer, as documented in its user guide:
+    ///
+    /// 1 00:01:00:00        00:01:19:00 Subtitle line 1
+    ///                                  Subtitle line 2
+    ///
+    /// Line number, in point, out point and the text, padded into fixed columns so that a
+    /// second text line lines up under the first one.
+    /// </summary>
+    public class SonicDvdProducer : SubtitleFormat
+    {
+        //                                                number     sep       in point               sep        out point              sep      text
+        private static readonly Regex RegexEntry = new Regex(@"^[ \t]*(\d+)([ \t]+)(\d\d:\d\d:\d\d:\d\d)([ \t]+)(\d\d:\d\d:\d\d:\d\d)([ \t]*)(.*)$", RegexOptions.Compiled);
+
+        public override string Extension => ".txt";
+
+        public override string Name => "Sonic DVD Producer";
+
+        public override bool IsMine(List<string> lines, string fileName)
+        {
+            // "Adobe Encore w. line#" is the same layout with single spaces and is checked first,
+            // so only claim the column-padded files DVD Producer actually writes - otherwise this
+            // format would take over every Adobe Encore file with line numbers.
+            var columnPadded = false;
+            foreach (var line in lines)
+            {
+                var match = RegexEntry.Match(line);
+                if (match.Success &&
+                    (match.Groups[2].Value.Length > 1 || match.Groups[4].Value.Length > 1 || match.Groups[6].Value.Length > 1))
+                {
+                    columnPadded = true;
+                    break;
+                }
+            }
+
+            return columnPadded && base.IsMine(lines, fileName);
+        }
+
+        public override string ToText(Subtitle subtitle, string title)
+        {
+            var sb = new StringBuilder();
+            var index = 0;
+            foreach (var p in subtitle.Paragraphs)
+            {
+                index++;
+                var prefix = $"{index,-4} {EncodeTimeCode(p.StartTime)}  {EncodeTimeCode(p.EndTime)}  ";
+                var textLines = HtmlUtil.RemoveHtmlTags(p.Text, true).SplitToLines();
+                for (var i = 0; i < textLines.Count; i++)
+                {
+                    sb.AppendLine((i == 0 ? prefix : new string(' ', prefix.Length)) + textLines[i]);
+                }
+
+                if (textLines.Count == 0)
+                {
+                    sb.AppendLine(prefix.TrimEnd());
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        private static string EncodeTimeCode(TimeCode time)
+        {
+            //00:01:54:19
+            return time.ToHHMMSSFF();
+        }
+
+        public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
+        {
+            _errorCount = 0;
+            subtitle.Paragraphs.Clear();
+
+            Paragraph p = null;
+            foreach (var line in lines)
+            {
+                var match = RegexEntry.Match(line);
+                if (match.Success)
+                {
+                    var startParts = match.Groups[3].Value.Split(':');
+                    var endParts = match.Groups[5].Value.Split(':');
+                    p = new Paragraph(DecodeTimeCodeFramesFourParts(startParts), DecodeTimeCodeFramesFourParts(endParts), match.Groups[7].Value.Trim());
+                    subtitle.Paragraphs.Add(p);
+                }
+                else if (string.IsNullOrWhiteSpace(line))
+                {
+                    // entries may be separated by blank lines
+                }
+                else if (p != null)
+                {
+                    p.Text = string.IsNullOrEmpty(p.Text) ? line.Trim() : p.Text + Environment.NewLine + line.Trim();
+                }
+                else
+                {
+                    _errorCount++;
+                }
+            }
+
+            subtitle.Renumber();
+        }
+    }
+}

--- a/src/libse/SubtitleFormats/Spc.cs
+++ b/src/libse/SubtitleFormats/Spc.cs
@@ -1,0 +1,85 @@
+using Nikse.SubtitleEdit.Core.Common;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Nikse.SubtitleEdit.Core.SubtitleFormats
+{
+    /// <summary>
+    /// Subtitle script for the DVD Junior / ImgTool DVD authoring tools:
+    /// 00:00:05:25&amp;00:00:08:20#come here
+    /// It is Spruce STL with "&amp;" and "#" instead of the two commas, so it shares
+    /// the "|" line break and the ^I/^B/^U style toggles.
+    /// </summary>
+    public class Spc : SubtitleFormat
+    {
+        private static readonly Regex RegexTimeCodes = new Regex(@"^\d\d:\d\d:\d\d:\d\d&\d\d:\d\d:\d\d:\d\d#", RegexOptions.Compiled);
+
+        public override string Extension => ".spc";
+
+        public override string Name => "DVD Junior SPC";
+
+        public override string ToText(Subtitle subtitle, string title)
+        {
+            var sb = new StringBuilder();
+            foreach (var p in subtitle.Paragraphs)
+            {
+                sb.AppendLine($"{EncodeTimeCode(p.StartTime)}&{EncodeTimeCode(p.EndTime)}#{EncodeText(p.Text)}");
+            }
+
+            return sb.ToString();
+        }
+
+        private static string EncodeText(string input)
+        {
+            var text = HtmlUtil.RemoveHtmlTags(input, true);
+            return text.Replace(Environment.NewLine, "|");
+        }
+
+        private static string EncodeTimeCode(TimeCode time)
+        {
+            //00:01:54:19
+            var frames = MillisecondsToFramesMaxFrameRate(time.Milliseconds);
+            return $"{time.Hours:00}:{time.Minutes:00}:{time.Seconds:00}:{frames:00}";
+        }
+
+        public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
+        {
+            _errorCount = 0;
+            subtitle.Paragraphs.Clear();
+
+            foreach (var line in lines)
+            {
+                if (RegexTimeCodes.IsMatch(line))
+                {
+                    try
+                    {
+                        var start = line.Substring(0, 11);
+                        var end = line.Substring(12, 11);
+                        var text = Spruce.DecodeStyleToggles(line.Substring(24).Replace("|", Environment.NewLine));
+                        subtitle.Paragraphs.Add(new Paragraph(DecodeTimeCode(start), DecodeTimeCode(end), text));
+                    }
+                    catch
+                    {
+                        _errorCount++;
+                    }
+                }
+                else if (!string.IsNullOrWhiteSpace(line))
+                {
+                    _errorCount++;
+                }
+            }
+
+            subtitle.Renumber();
+        }
+
+        private static TimeCode DecodeTimeCode(string time)
+        {
+            //00:01:54:19
+            var parts = time.Split(':');
+            var milliseconds = FramesToMillisecondsMax999(int.Parse(parts[3]));
+            return new TimeCode(int.Parse(parts[0]), int.Parse(parts[1]), int.Parse(parts[2]), milliseconds);
+        }
+    }
+}

--- a/src/libse/SubtitleFormats/SubtitleFormat.cs
+++ b/src/libse/SubtitleFormats/SubtitleFormat.cs
@@ -258,6 +258,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     new JsonType21(),
                     new JsonType22(),
                     new JsonType23(),
+                    new WistiaJson(),
                     new KanopyHtml(),
                     new LambdaCap(),
                     new Lrc(),
@@ -314,6 +315,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     new SonyDVDArchitectLineDurationLength(),
                     new SonyDVDArchitectTabs(),
                     new SonyDVDArchitectWithLineNumbers(),
+                    new SonicDvdProducer(), // after Adobe Encore w. line# - same layout, this one only takes the column-padded files
+                    new Spc(), // before TMPlayer - TMPlayer reads "00:00:05:25&..." as its own "h:mm:ss:text" and keeps the rest as text
                     new Speechmatics(),
                     new Spruce(),
                     new SpruceWithSpace(),

--- a/src/libse/SubtitleFormats/WistiaJson.cs
+++ b/src/libse/SubtitleFormats/WistiaJson.cs
@@ -1,0 +1,115 @@
+using Nikse.SubtitleEdit.Core.Common;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace Nikse.SubtitleEdit.Core.SubtitleFormats
+{
+    /// <summary>
+    /// Caption files downloaded from Wistia:
+    /// {"captions":[{"bcp47LanguageTag":"en", ... ,"hash":{"lines":[{"start":0.17,"end":0.62,"text":["line 1","line 2"]}]}}]}
+    /// Times are seconds, and "text" is an array with one entry per display line
+    /// (older exports use a plain string instead).
+    /// A file can hold several caption tracks (one per language) - like the converters
+    /// people write for these files, only the first track is read.
+    /// </summary>
+    public class WistiaJson : SubtitleFormat
+    {
+        public override string Extension => ".json";
+
+        public override string Name => "Wistia json";
+
+        public override string ToText(Subtitle subtitle, string title)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("{");
+            sb.AppendLine("  \"captions\": [");
+            sb.AppendLine("    {");
+            sb.AppendLine("      \"bcp47LanguageTag\": \"en\",");
+            sb.AppendLine("      \"hasCaptions\": true,");
+            sb.AppendLine("      \"hash\": {");
+            sb.AppendLine("        \"lines\": [");
+            for (var i = 0; i < subtitle.Paragraphs.Count; i++)
+            {
+                var p = subtitle.Paragraphs[i];
+                sb.AppendLine("          {");
+                sb.AppendLine($"            \"start\": {p.StartTime.TotalSeconds.ToString(CultureInfo.InvariantCulture)},");
+                sb.AppendLine($"            \"end\": {p.EndTime.TotalSeconds.ToString(CultureInfo.InvariantCulture)},");
+                sb.AppendLine("            \"text\": [");
+                var textLines = p.Text.SplitToLines();
+                for (var j = 0; j < textLines.Count; j++)
+                {
+                    var comma = j == textLines.Count - 1 ? string.Empty : ",";
+                    sb.AppendLine($"              \"{Json.EncodeJsonText(textLines[j])}\"{comma}");
+                }
+
+                sb.AppendLine("            ]");
+                sb.AppendLine(i == subtitle.Paragraphs.Count - 1 ? "          }" : "          },");
+            }
+
+            sb.AppendLine("        ]");
+            sb.AppendLine("      }");
+            sb.AppendLine("    }");
+            sb.AppendLine("  ]");
+            sb.AppendLine("}");
+            return sb.ToString();
+        }
+
+        public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
+        {
+            _errorCount = 0;
+            subtitle.Paragraphs.Clear();
+
+            var sb = new StringBuilder();
+            foreach (var line in lines)
+            {
+                sb.Append(line);
+            }
+
+            var text = sb.ToString().TrimStart();
+            if (!text.StartsWith('{') ||
+                !text.Contains("\"captions\"", StringComparison.Ordinal) ||
+                !text.Contains("\"hash\"", StringComparison.Ordinal) ||
+                !text.Contains("\"lines\"", StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            var parser = new SeJsonParser();
+            var captionTracks = parser.GetArrayElementsByName(text, "captions");
+            if (captionTracks.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var element in parser.GetArrayElementsByName(captionTracks[0], "lines"))
+            {
+                var startObject = parser.GetFirstObject(element, "start");
+                var endObject = parser.GetFirstObject(element, "end");
+                if (!double.TryParse(startObject, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var startSeconds) ||
+                    !double.TryParse(endObject, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var endSeconds))
+                {
+                    _errorCount++;
+                    continue;
+                }
+
+                var textLines = parser.GetArrayElementsByName(element, "text");
+                var paragraphText = new StringBuilder();
+                foreach (var textLine in textLines)
+                {
+                    if (paragraphText.Length > 0)
+                    {
+                        paragraphText.AppendLine();
+                    }
+
+                    paragraphText.Append(Json.DecodeJsonText(textLine));
+                }
+
+                subtitle.Paragraphs.Add(new Paragraph(paragraphText.ToString(), startSeconds * 1000.0, endSeconds * 1000.0));
+            }
+
+            subtitle.Renumber();
+        }
+    }
+}

--- a/tests/libse/SubtitleFormats/QubeMasterImportTest.cs
+++ b/tests/libse/SubtitleFormats/QubeMasterImportTest.cs
@@ -1,0 +1,56 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System;
+using Xunit;
+
+namespace LibSETests.SubtitleFormats;
+
+public class QubeMasterImportTest
+{
+    [Fact]
+    public void NumberedEntriesGoToUnknown64NotQubeMaster()
+    {
+        // doom9 thread 114440: counter, in point, out point, then the text. QubeMasterPro's
+        // reader takes any non-timecode line as text, so it used to win detection and glue the
+        // counter in front of every subtitle.
+        const string text = "0\r\n00:00:00:00\r\n00:00:00:08\r\nTITLE\r\n" +
+                            "\r\n1\r\n10:00:32:07\r\n10:00:38:04\r\nFirst subtitle.\r\n" +
+                            "\r\n2\r\n10:00:38:07\r\n10:00:45:19\r\nSecond subtitle.\r\n" +
+                            "\r\n3\r\n10:00:46:07\r\n10:00:50:19\r\nThird subtitle.\r\n";
+        var lines = text.SplitToLines();
+
+        Assert.False(new QubeMasterImport().IsMine(lines, "subs.txt"));
+
+        foreach (var format in SubtitleFormat.AllSubtitleFormats)
+        {
+            if (format.IsTextBased && format.IsMine(lines, "subs.txt"))
+            {
+                Assert.Equal(new UnknownSubtitle64().Name, format.Name);
+                var subtitle = new Subtitle();
+                format.LoadSubtitle(subtitle, lines, "subs.txt");
+                Assert.Equal("TITLE", subtitle.Paragraphs[0].Text);
+                Assert.Equal("First subtitle.", subtitle.Paragraphs[1].Text);
+                break;
+            }
+        }
+    }
+
+    [Fact]
+    public void RealQubeMasterFilesStillLoad()
+    {
+        var format = new QubeMasterImport();
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("SubLine1" + Environment.NewLine + "SubLine2", 3612000, 3615000));
+        subtitle.Paragraphs.Add(new Paragraph("Another line", 3620000, 3623000));
+
+        var lines = format.ToText(subtitle, "title").SplitToLines();
+        var loaded = new Subtitle();
+
+        Assert.True(format.IsMine(lines, "subs.txt"));
+        format.LoadSubtitle(loaded, lines, "subs.txt");
+
+        Assert.Equal(2, loaded.Paragraphs.Count);
+        Assert.Equal("SubLine1" + Environment.NewLine + "SubLine2", loaded.Paragraphs[0].Text);
+        Assert.Equal("Another line", loaded.Paragraphs[1].Text);
+    }
+}

--- a/tests/libse/SubtitleFormats/SonicDvdProducerTest.cs
+++ b/tests/libse/SubtitleFormats/SonicDvdProducerTest.cs
@@ -1,0 +1,79 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System;
+using Xunit;
+
+namespace LibSETests.SubtitleFormats;
+
+public class SonicDvdProducerTest
+{
+    // layout straight from the DVD Producer user guide
+    private const string Sample = "1 00:01:00:00        00:01:19:00 Subtitle line 1\r\n" +
+                                  "                                 Subtitle line 2\r\n" +
+                                  "2 00:01:20:00        00:01:29:00 Another subtitle\r\n" +
+                                  "3 00:01:30:00        00:01:39:00 Third subtitle\r\n";
+
+    [Fact]
+    public void LoadSubtitleReadsColumnsAndContinuationLines()
+    {
+        var format = new SonicDvdProducer();
+        var lines = Sample.SplitToLines();
+        var subtitle = new Subtitle();
+
+        Assert.True(format.IsMine(lines, "subs.txt"));
+        format.LoadSubtitle(subtitle, lines, "subs.txt");
+
+        Assert.Equal(3, subtitle.Paragraphs.Count);
+        Assert.Equal("Subtitle line 1" + Environment.NewLine + "Subtitle line 2", subtitle.Paragraphs[0].Text);
+        Assert.Equal(60000, subtitle.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(79000, subtitle.Paragraphs[0].EndTime.TotalMilliseconds);
+        Assert.Equal("Another subtitle", subtitle.Paragraphs[1].Text);
+        Assert.Equal(99000, subtitle.Paragraphs[2].EndTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void SingleSpacedFilesAreLeftToAdobeEncore()
+    {
+        // "Adobe Encore w. line#" is the same layout without the column padding - taking those
+        // files here would rename the format under everyone who uses it
+        const string adobeEncore = "1 00:01:00:00 00:01:19:00 Subtitle line 1\r\n" +
+                                   "Subtitle line 2\r\n" +
+                                   "2 00:01:20:00 00:01:29:00 Another subtitle\r\n";
+
+        Assert.False(new SonicDvdProducer().IsMine(adobeEncore.SplitToLines(), "subs.txt"));
+        Assert.True(new AdobeEncoreWithLineNumbers().IsMine(adobeEncore.SplitToLines(), "subs.txt"));
+    }
+
+    [Fact]
+    public void SonicWinsDetectionForColumnPaddedFiles()
+    {
+        var lines = Sample.SplitToLines();
+        foreach (var format in SubtitleFormat.AllSubtitleFormats)
+        {
+            if (format.IsTextBased && format.IsMine(lines, "subs.txt"))
+            {
+                Assert.Equal(new SonicDvdProducer().Name, format.Name);
+                break;
+            }
+        }
+    }
+
+    [Fact]
+    public void RoundTrip()
+    {
+        var format = new SonicDvdProducer();
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("First line" + Environment.NewLine + "second line", 60000, 79000));
+        subtitle.Paragraphs.Add(new Paragraph("Another one", 80000, 89000));
+
+        var text = format.ToText(subtitle, "title");
+        var loaded = new Subtitle();
+        format.LoadSubtitle(loaded, text.SplitToLines(), "subs.txt");
+
+        Assert.True(format.IsMine(text.SplitToLines(), "subs.txt"));
+        Assert.Equal(2, loaded.Paragraphs.Count);
+        Assert.Equal("First line" + Environment.NewLine + "second line", loaded.Paragraphs[0].Text);
+        Assert.Equal(60000, loaded.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(89000, loaded.Paragraphs[1].EndTime.TotalMilliseconds);
+    }
+}

--- a/tests/libse/SubtitleFormats/SpcTest.cs
+++ b/tests/libse/SubtitleFormats/SpcTest.cs
@@ -1,0 +1,71 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System;
+using Xunit;
+
+namespace LibSETests.SubtitleFormats;
+
+public class SpcTest
+{
+    private const string Sample = "00:00:05:00&00:00:08:00#come here\r\n" +
+                                  "00:00:09:00&00:00:12:00#Line one|Line two\r\n" +
+                                  "00:00:13:00&00:00:16:00#Last one\r\n";
+
+    [Fact]
+    public void LoadSubtitleReadsTimeCodesAndLineBreaks()
+    {
+        var format = new Spc();
+        var subtitle = new Subtitle();
+
+        format.LoadSubtitle(subtitle, Sample.SplitToLines(), "subs.spc");
+
+        Assert.Equal(3, subtitle.Paragraphs.Count);
+        Assert.Equal("come here", subtitle.Paragraphs[0].Text);
+        Assert.Equal(5000, subtitle.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(8000, subtitle.Paragraphs[0].EndTime.TotalMilliseconds);
+        Assert.Equal("Line one" + Environment.NewLine + "Line two", subtitle.Paragraphs[1].Text);
+    }
+
+    [Fact]
+    public void SpcWinsDetectionOverTmPlayer()
+    {
+        // TMPlayer reads "00:00:05:00&..." as "h:mm:ss:text" and keeps "00&00:00:08:00#come here"
+        // as the subtitle text, so SPC has to be checked first
+        var lines = Sample.SplitToLines();
+        foreach (var format in SubtitleFormat.AllSubtitleFormats)
+        {
+            if (format.IsTextBased && format.IsMine(lines, "subs.spc"))
+            {
+                Assert.Equal(new Spc().Name, format.Name);
+                break;
+            }
+        }
+    }
+
+    [Fact]
+    public void RoundTrip()
+    {
+        var format = new Spc();
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("First line" + Environment.NewLine + "second line", 5000, 8000));
+        subtitle.Paragraphs.Add(new Paragraph("Another one", 9000, 12000));
+
+        var loaded = new Subtitle();
+        format.LoadSubtitle(loaded, format.ToText(subtitle, "title").SplitToLines(), "subs.spc");
+
+        Assert.Equal(2, loaded.Paragraphs.Count);
+        Assert.Equal("First line" + Environment.NewLine + "second line", loaded.Paragraphs[0].Text);
+        Assert.Equal(5000, loaded.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(12000, loaded.Paragraphs[1].EndTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void SpruceStlIsNotClaimed()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Hello", 5000, 8000));
+        subtitle.Paragraphs.Add(new Paragraph("There", 9000, 12000));
+
+        Assert.False(new Spc().IsMine(new Spruce().ToText(subtitle, "title").SplitToLines(), "subs.stl"));
+    }
+}

--- a/tests/libse/SubtitleFormats/WistiaJsonTest.cs
+++ b/tests/libse/SubtitleFormats/WistiaJsonTest.cs
@@ -1,0 +1,78 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace LibSETests.SubtitleFormats;
+
+public class WistiaJsonTest
+{
+    private const string Sample = "{\"captions\":[{\"id\":\"z0ezew3p4xlhrix1\",\"bcp47LanguageTag\":\"en\",\"familyName\":\"English\"," +
+                                  "\"hasCaptions\":true,\"mediaHashedId\":\"v5r9kwfqn0\",\"wistiaLanguageCode\":\"eng\"," +
+                                  "\"hash\":{\"lines\":[" +
+                                  "{\"start\":0.17,\"end\":0.62,\"text\":[\"Hello there,\",\"and welcome.\"]}," +
+                                  "{\"start\":5.03,\"end\":9.92,\"text\":[\"A \\\"quoted\\\" line.\"]}," +
+                                  "{\"start\":10.5,\"end\":12,\"text\":[\"Last one.\"]}" +
+                                  "]}}]}";
+
+    [Fact]
+    public void LoadSubtitleReadsSecondsAndTextArray()
+    {
+        var format = new WistiaJson();
+        var lines = Sample.SplitToLines();
+        var subtitle = new Subtitle();
+
+        Assert.True(format.IsMine(lines, "captions.json"));
+        format.LoadSubtitle(subtitle, lines, "captions.json");
+
+        Assert.Equal(3, subtitle.Paragraphs.Count);
+        Assert.Equal("Hello there," + Environment.NewLine + "and welcome.", subtitle.Paragraphs[0].Text);
+        Assert.Equal(170, subtitle.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(620, subtitle.Paragraphs[0].EndTime.TotalMilliseconds);
+        Assert.Equal("A \"quoted\" line.", subtitle.Paragraphs[1].Text);
+        Assert.Equal(5030, subtitle.Paragraphs[1].StartTime.TotalMilliseconds);
+        Assert.Equal(12000, subtitle.Paragraphs[2].EndTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void OnlyTheFirstCaptionTrackIsRead()
+    {
+        const string twoTracks = "{\"captions\":[" +
+                                 "{\"bcp47LanguageTag\":\"en\",\"hash\":{\"lines\":[{\"start\":1,\"end\":2,\"text\":[\"English\"]}]}}," +
+                                 "{\"bcp47LanguageTag\":\"de\",\"hash\":{\"lines\":[{\"start\":1,\"end\":2,\"text\":[\"Deutsch\"]}]}}]}";
+        var subtitle = new Subtitle();
+
+        new WistiaJson().LoadSubtitle(subtitle, twoTracks.SplitToLines(), "captions.json");
+
+        Assert.Single(subtitle.Paragraphs);
+        Assert.Equal("English", subtitle.Paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void RoundTrip()
+    {
+        var format = new WistiaJson();
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Line one" + Environment.NewLine + "line two", 1500, 3250));
+        subtitle.Paragraphs.Add(new Paragraph("He said \"hi\".", 4000, 5000));
+
+        var loaded = new Subtitle();
+        format.LoadSubtitle(loaded, format.ToText(subtitle, "title").SplitToLines(), "captions.json");
+
+        Assert.Equal(2, loaded.Paragraphs.Count);
+        Assert.Equal("Line one" + Environment.NewLine + "line two", loaded.Paragraphs[0].Text);
+        Assert.Equal(1500, loaded.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(3250, loaded.Paragraphs[0].EndTime.TotalMilliseconds);
+        Assert.Equal("He said \"hi\".", loaded.Paragraphs[1].Text);
+    }
+
+    [Fact]
+    public void OtherJsonIsNotClaimed()
+    {
+        var format = new WistiaJson();
+
+        Assert.False(format.IsMine("{\"lines\":[{\"start\":1,\"end\":2,\"text\":\"no captions here\"}]}".SplitToLines(), "x.json"));
+        Assert.False(format.IsMine(new JsonType23().ToText(new Subtitle(new[] { new Paragraph("Hi", 0, 1000) }.ToList()), "t").SplitToLines(), "x.json"));
+    }
+}


### PR DESCRIPTION
Three subtitle formats found while going through the [doom9 subtitles forum](https://forum.doom9.org/forumdisplay.php?f=12) that SE could not read, plus one detection fix.

### New formats

**Wistia json** — `{"captions":[{...,"hash":{"lines":[{"start":0.17,"end":0.62,"text":["line 1","line 2"]}]}}]}`. Times are seconds and `text` is an array with one entry per display line. Nothing claimed these files at all; a forum user with a few thousand of them ended up [writing his own converter](https://forum.doom9.org/showthread.php?t=186624). A file can hold several caption tracks (one per language) — like that converter, only the first is read.

**DVD Junior SPC** — `00:00:05:25&00:00:08:20#come here`, wanted by the DVD Junior and ImgTool authoring tools ([thread](http://forum.doom9.org/archive/index.php/t-56458.html)). It is Spruce STL with `&` and `#` in place of the two commas, so it shares the `|` line break and the `^I`/`^B`/`^U` style toggles. TMPlayer used to claim these files and read the line as its own `h:mm:ss:text`, leaving `25&00:00:08:20#come here` as the subtitle text with no error — SPC is registered before TMPlayer so that stops.

**Sonic DVD Producer** — line number, in point and out point padded into fixed columns, continuation lines indented underneath ([thread](http://forum.doom9.org/archive/index.php/t-67193.html), layout from its user guide):

```
1 00:01:00:00        00:01:19:00 Subtitle line 1
                                 Subtitle line 2
```

"Adobe Encore w. line#" already reads the single-spaced form of this layout. Rather than loosen Encore's regex and rename the format under everyone using it, the new one only claims files with a genuinely column-padded separator and is registered after Encore — single-spaced files keep going to Encore and parse the same as before.

### Detection fix

A file laid out as counter / in point / out point / text ([thread](http://forum.doom9.org/archive/index.php/t-114440.html)) is read correctly by `Unknown 64`, but `QubeMasterPro Import` — which takes any non-time-code line as text — matched first and glued the counter in front of every subtitle (`"0"` + newline + `"TITLE"`). Entries whose first text line is a bare counter now count as errors there, so `Unknown 64` wins detection.

### Tests

14 new tests over four files: load, round-trip, detection precedence (SPC over TMPlayer, Sonic only for padded files, Unknown 64 over QubeMaster) and negative cases (other json is not claimed, Spruce STL is not claimed, real QubeMaster files still load).

`LibSETests` 1771 passed / 0 failed, `SeConvTests` 448 passed, `LibUiLogicTests` 725 passed, solution builds with 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)