### PR TITLE
Keep ASSA override blocks out of auto-translate too (#13927)

### DIFF
--- a/src/libuilogic/Translate/AssaTagStripper.cs
+++ b/src/libuilogic/Translate/AssaTagStripper.cs
@@ -1,6 +1,6 @@
 using System.Text.RegularExpressions;
 
-namespace Nikse.SubtitleEdit.Features.Tools.AiReview;
+namespace Nikse.SubtitleEdit.UiLogic.Translate;
 
 /// <summary>
 /// Keeps ASSA override blocks ("{\pos(946.5,250.8)\fs54\1c&amp;HFDF9AA&amp;}") away from the model

--- a/src/libuilogic/Translate/Formatting.cs
+++ b/src/libuilogic/Translate/Formatting.cs
@@ -37,6 +37,7 @@ namespace Nikse.SubtitleEdit.UiLogic.Translate
         private string Font { get; set; } = string.Empty;
         private bool ItalicTwoLines { get; set; }
         private string StartTags { get; set; } = string.Empty;
+        private string EndTags { get; set; } = string.Empty;
         private bool AutoBreak { get; set; }
         private bool SquareBrackets { get; set; }
         private bool SquareBracketsUppercase { get; set; }
@@ -69,6 +70,22 @@ namespace Nikse.SubtitleEdit.UiLogic.Translate
 
                 StartTags += text.Substring(0, endIndex + 1);
                 text = text.Remove(0, endIndex + 1).Trim();
+            }
+
+            // Trailing SSA/ASS tags. Only leading blocks used to be taken off, so a block at the
+            // end ("Overboard{\fad(200,200)}") travelled to the engine, where it costs tokens and
+            // comes back "normalized" by small models (#13927). Taking it off here also lets the
+            // italic/font/bracket checks below see the real end of the text.
+            while (text.EndsWith('}'))
+            {
+                var startIndex = text.LastIndexOf("{\\", StringComparison.Ordinal);
+                if (startIndex < 0 || text.IndexOf('}', startIndex) != text.Length - 1)
+                {
+                    break; // no opening block, or the '}' belongs to an earlier block
+                }
+
+                EndTags = text.Substring(startIndex) + EndTags;
+                text = text.Remove(startIndex).Trim();
             }
 
             // ASSA reset tag
@@ -223,7 +240,7 @@ namespace Nikse.SubtitleEdit.UiLogic.Translate
             }
 
             // SSA/ASS tags
-            text = StartTags + text;
+            text = StartTags + text + EndTags;
 
             return text;
         }

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -202,6 +202,7 @@ using System.Xml.Linq;
 using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 using Nikse.SubtitleEdit.UiLogic.Media;
 using Nikse.SubtitleEdit.UiLogic.Common;
+using Nikse.SubtitleEdit.UiLogic.Translate;
 
 namespace Nikse.SubtitleEdit.Features.Main;
 

--- a/src/ui/Features/Tools/AiReview/AiReviewViewModel.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewViewModel.cs
@@ -22,6 +22,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Nikse.SubtitleEdit.UiLogic.LlamaCpp;
+using Nikse.SubtitleEdit.UiLogic.Translate;
 
 namespace Nikse.SubtitleEdit.Features.Tools.AiReview;
 

--- a/src/ui/Features/Translate/LlamaCppAdvanced/AdvancedTranslatorBase.cs
+++ b/src/ui/Features/Translate/LlamaCppAdvanced/AdvancedTranslatorBase.cs
@@ -53,9 +53,12 @@ public abstract class AdvancedTranslatorBase : IAutoTranslator, IBatchContextTra
 
     public async Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
     {
-        var lines = new List<LlamaCppAdvancedProtocol.BatchLine> { new(1, text.Trim()) };
+        var stripped = StrippedLine.Strip(text.Trim());
+        var lines = new List<LlamaCppAdvancedProtocol.BatchLine> { new(1, stripped.Text) };
         var map = await TranslateLinesAsync(lines, new List<LlamaCppAdvancedProtocol.HistoryPair>(), sourceLanguageCode, targetLanguageCode, cancellationToken);
-        return map.TryGetValue(1, out var translation) ? translation : string.Empty;
+        return map.TryGetValue(1, out var translation) && translation.Length > 0
+            ? stripped.Restore(translation)
+            : string.Empty;
     }
 
     /// <summary>
@@ -74,10 +77,18 @@ public abstract class AdvancedTranslatorBase : IAutoTranslator, IBatchContextTra
 
     private async Task<int> TranslateChunkAsync(ObservableCollection<TranslateRow> rows, int index, int count, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
     {
+        // This path deliberately skips MergeAndSplitHelper (its merge/split heuristics would
+        // break the alignment the reply schema guarantees), and with it the Formatting pass that
+        // takes ASSA override blocks off every other engine's input. Strip them here instead:
+        // they cost a lot of tokens, and small models "normalize" them into something that no
+        // longer matches the source (#13927). A pure override/drawing line strips to empty, and
+        // IsComplete then accepts the model's empty answer for it rather than failing the batch.
         var lines = new List<LlamaCppAdvancedProtocol.BatchLine>(count);
+        var stripped = new StrippedLine[count];
         for (var i = 0; i < count; i++)
         {
-            lines.Add(new LlamaCppAdvancedProtocol.BatchLine(i + 1, rows[index + i].Text));
+            stripped[i] = StrippedLine.Strip(rows[index + i].Text);
+            lines.Add(new LlamaCppAdvancedProtocol.BatchLine(i + 1, stripped[i].Text));
         }
 
         // Translation-tuned models (TranslateGemma) can echo history into a lone line's
@@ -93,7 +104,9 @@ public abstract class AdvancedTranslatorBase : IAutoTranslator, IBatchContextTra
                 for (var i = 0; i < count; i++)
                 {
                     var translation = map[i + 1];
-                    rows[index + i].TranslatedText = translation.Length > 0 ? translation : rows[index + i].Text;
+                    rows[index + i].TranslatedText = translation.Length > 0
+                        ? stripped[i].Restore(translation)
+                        : rows[index + i].Text;
                 }
             });
 
@@ -172,10 +185,21 @@ public abstract class AdvancedTranslatorBase : IAutoTranslator, IBatchContextTra
         var history = new List<LlamaCppAdvancedProtocol.HistoryPair>(maxPairs);
         for (var i = index - 1; i >= 0 && history.Count < maxPairs; i--)
         {
-            if (!string.IsNullOrEmpty(rows[i].TranslatedText))
+            if (string.IsNullOrEmpty(rows[i].TranslatedText))
             {
-                history.Add(new LlamaCppAdvancedProtocol.HistoryPair(rows[i].Text, rows[i].TranslatedText));
+                continue;
             }
+
+            // Same stripping as the batch itself: override blocks carry no context and would
+            // otherwise fill the window twice per pair - once on each side (#13927).
+            var source = StrippedLine.Strip(rows[i].Text).Text;
+            var target = StrippedLine.Strip(rows[i].TranslatedText).Text;
+            if (source.Length == 0 || target.Length == 0)
+            {
+                continue; // a pure override/drawing line is no use as an example pair
+            }
+
+            history.Add(new LlamaCppAdvancedProtocol.HistoryPair(source, target));
         }
 
         history.Reverse();

--- a/tests/UI/Features/Tools/AiReview/AiReviewProtocolTests.cs
+++ b/tests/UI/Features/Tools/AiReview/AiReviewProtocolTests.cs
@@ -1,0 +1,34 @@
+using Nikse.SubtitleEdit.Features.Tools.AiReview;
+using System.Collections.Generic;
+
+namespace UITests.Features.Tools.AiReview;
+
+public class AiReviewProtocolTests
+{
+    [Fact]
+    public void BuildUserContent_WritesActorAndStyleOnlyWhenPresent()
+    {
+        var chunk = new ReviewChunk();
+        chunk.Lines.Add(new ReviewLine(1, "Overboard", "Narrator", "Sign"));
+        chunk.Lines.Add(new ReviewLine(2, "Hello", null, "  "));
+
+        var json = AiReviewProtocol.BuildUserContent(chunk);
+
+        Assert.Contains("\"n\":1,\"text\":\"Overboard\",\"actor\":\"Narrator\",\"style\":\"Sign\"", json);
+        Assert.Contains("\"n\":2,\"text\":\"Hello\"}", json);
+        Assert.DoesNotContain("\"actor\":\"\"", json);
+    }
+
+    [Fact]
+    public void ParseChanges_StrippedText_EchoMatchesStrippedLine()
+    {
+        var editable = new Dictionary<int, string> { { 1, "Overbored" } };
+
+        var changes = AiReviewProtocol.ParseChanges(
+            "{\"changes\":[{\"n\":1,\"orig\":\"Overbored\",\"text\":\"Overboard\",\"reason\":\"typo\",\"category\":\"spelling\"}]}",
+            editable);
+
+        Assert.Single(changes);
+        Assert.Equal("Overboard", changes[0].NewText);
+    }
+}

--- a/tests/libuilogic/Translate/AssaTagStripperTests.cs
+++ b/tests/libuilogic/Translate/AssaTagStripperTests.cs
@@ -1,7 +1,6 @@
-using Nikse.SubtitleEdit.Features.Tools.AiReview;
-using System.Collections.Generic;
+using Nikse.SubtitleEdit.UiLogic.Translate;
 
-namespace UITests.Features.Tools.AiReview;
+namespace LibUiLogicTests.Translate;
 
 public class AssaTagStripperTests
 {
@@ -66,32 +65,5 @@ public class AssaTagStripperTests
     public void RemoveAllBlocks_RemovesInlineToo()
     {
         Assert.Equal("He really said so.", StrippedLine.RemoveAllBlocks(@"{\an8}He {\i1}really{\i0} said so."));
-    }
-
-    [Fact]
-    public void BuildUserContent_WritesActorAndStyleOnlyWhenPresent()
-    {
-        var chunk = new ReviewChunk();
-        chunk.Lines.Add(new ReviewLine(1, "Overboard", "Narrator", "Sign"));
-        chunk.Lines.Add(new ReviewLine(2, "Hello", null, "  "));
-
-        var json = AiReviewProtocol.BuildUserContent(chunk);
-
-        Assert.Contains("\"n\":1,\"text\":\"Overboard\",\"actor\":\"Narrator\",\"style\":\"Sign\"", json);
-        Assert.Contains("\"n\":2,\"text\":\"Hello\"}", json);
-        Assert.DoesNotContain("\"actor\":\"\"", json);
-    }
-
-    [Fact]
-    public void ParseChanges_StrippedText_EchoMatchesStrippedLine()
-    {
-        var editable = new Dictionary<int, string> { { 1, "Overbored" } };
-
-        var changes = AiReviewProtocol.ParseChanges(
-            "{\"changes\":[{\"n\":1,\"orig\":\"Overbored\",\"text\":\"Overboard\",\"reason\":\"typo\",\"category\":\"spelling\"}]}",
-            editable);
-
-        Assert.Single(changes);
-        Assert.Equal("Overboard", changes[0].NewText);
     }
 }

--- a/tests/libuilogic/Translate/FormattingTests.cs
+++ b/tests/libuilogic/Translate/FormattingTests.cs
@@ -1,0 +1,91 @@
+using Nikse.SubtitleEdit.UiLogic.Translate;
+
+namespace LibUiLogicTests.Translate;
+
+/// <summary>
+/// Formatting takes tags off a line before it is sent to a translation engine and puts them back
+/// around the answer. Leading ASSA override blocks were always handled; trailing ones were not,
+/// so they travelled to the engine and came back "normalized" (#13927).
+/// </summary>
+public class FormattingTests
+{
+    [Fact]
+    public void TrailingOverrideBlock_IsNotSentAndComesBack()
+    {
+        var formatting = new Formatting();
+
+        var text = formatting.SetTagsAndReturnTrimmed(@"Overboard{\fad(200,200)}", "en");
+
+        Assert.Equal("Overboard", text);
+        Assert.Equal(@"Par-dessus bord{\fad(200,200)}", formatting.ReAddFormatting("Par-dessus bord"));
+    }
+
+    [Fact]
+    public void LeadingAndTrailingBlocks_BothSurvive()
+    {
+        var formatting = new Formatting();
+
+        var text = formatting.SetTagsAndReturnTrimmed(@"{\pos(946.5,250.8)\fs54}Overboard{\fad(200,200)}", "en");
+
+        Assert.Equal("Overboard", text);
+        Assert.Equal(@"{\pos(946.5,250.8)\fs54}Par-dessus bord{\fad(200,200)}", formatting.ReAddFormatting("Par-dessus bord"));
+    }
+
+    [Fact]
+    public void MultipleTrailingBlocks_KeepTheirOrder()
+    {
+        var formatting = new Formatting();
+
+        var text = formatting.SetTagsAndReturnTrimmed(@"Hi{\i1}{\fad(1,2)}", "en");
+
+        Assert.Equal("Hi", text);
+        Assert.Equal(@"Salut{\i1}{\fad(1,2)}", formatting.ReAddFormatting("Salut"));
+    }
+
+    [Fact]
+    public void TrailingBlock_LetsTheItalicCheckSeeTheRealEndOfTheLine()
+    {
+        var formatting = new Formatting();
+
+        // Before the trailing block was taken off, EndsWith("</i>") was false here, so the italic
+        // tags went to the engine as text instead of being restored around the answer.
+        var text = formatting.SetTagsAndReturnTrimmed(@"<i>Overboard</i>{\fad(1,2)}", "en");
+
+        Assert.Equal("Overboard", text);
+        Assert.Equal(@"<i>Par-dessus bord</i>{\fad(1,2)}", formatting.ReAddFormatting("Par-dessus bord"));
+    }
+
+    [Fact]
+    public void ClosingBraceThatIsNotAnOverrideBlock_IsLeftAlone()
+    {
+        var formatting = new Formatting();
+
+        var text = formatting.SetTagsAndReturnTrimmed("Say {this}", "en");
+
+        Assert.Equal("Say {this}", text);
+        Assert.Equal("Dis {this}", formatting.ReAddFormatting("Dis {this}"));
+    }
+
+    [Fact]
+    public void BraceBelongingToAnEarlierBlock_IsNotTakenAsTrailing()
+    {
+        var formatting = new Formatting();
+
+        // The '}' at the end closes nothing - the only "{\" opens a block that closes mid-line.
+        var text = formatting.SetTagsAndReturnTrimmed(@"a{\b1}b}", "en");
+
+        Assert.Equal(@"a{\b1}b}", text);
+        Assert.Equal(@"a{\b1}b}", formatting.ReAddFormatting(@"a{\b1}b}"));
+    }
+
+    [Fact]
+    public void PlainLine_IsUnchanged()
+    {
+        var formatting = new Formatting();
+
+        var text = formatting.SetTagsAndReturnTrimmed("Overboard", "en");
+
+        Assert.Equal("Overboard", text);
+        Assert.Equal("Par-dessus bord", formatting.ReAddFormatting("Par-dessus bord"));
+    }
+}


### PR DESCRIPTION
Follow-up to 641da8ad5, which stopped the **AI review/assistant** path sending ASSA override blocks to the model. Auto-translate had two gaps left.

## Gap A — the "advanced" engines bypass the formatting pass

`LlamaCppAdvancedTranslate` and `OllamaAdvancedTranslate` run their own batch loop and deliberately skip `MergeAndSplitHelper`, since its merge/split heuristics would break the line alignment their reply schema guarantees. But the `Formatting` pass that takes override blocks off every other engine's input lives *inside* the function they skip.

So these two sent whole blocks — `{\bord0\blur0.8\pos(946.5,250.8)\fs54...}` — straight to the model, once in the batch and again in every rolling-history pair.

`AdvancedTranslatorBase` now strips before sending and restores around the answer. Two side effects worth noting:

- A pure override or drawing line strips to empty, so `IsComplete` accepts the model's empty answer for it instead of failing the whole batch into a bisection retry.
- Such lines are skipped as history pairs — they are no use as examples.

## Gap B — trailing blocks were never stripped

`Formatting` only ever took blocks off the front (`StartTags`), so a block at the end — `Overboard{\fad(200,200)}` — still travelled to *every* engine. Added the `EndTags` counterpart, with a guard so a `}` belonging to an earlier block is not mistaken for a trailing one.

Taking the trailing block off first also fixes something separate: the italic/font/bracket checks below now see the real end of the line. `<i>Overboard</i>{\fad(1,2)}` previously failed `EndsWith("</i>")` and sent its italic tags to the engine as literal text.

## Structure

`AssaTagStripper` moves from `Features/Tools/AiReview` to `libuilogic/Translate`, so translate does not depend on a type living inside AI review; seconv reaches it there too. Splitting its tests for the move separated the five pure stripper cases from the two that exercise `AiReviewProtocol` — those stay in the UI test project as `AiReviewProtocolTests`.

## Tests

New `FormattingTests` covers seven cases: trailing round-trip, leading+trailing together, multiple trailing blocks keeping order, the italic interaction, `{this}` without a backslash left alone, `a{\b1}b}` not mistaken for a trailing block, and a plain line unchanged.

Full suites pass: 739 libuilogic, 4370 UI, 448 seconv, 0 failures. Solution builds with 0 warnings.

Gap A has no direct unit test — `TranslateChunkAsync` needs a live client and `Se.Settings`, so covering it means an HTTP-level harness that does not exist yet. The stripping logic it calls is covered; the wiring was verified by reading.

## Left open on #13927

Override blocks in the *middle* of a line, and the drawing-mode guard in `Formatting`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)