### PR TITLE
seconv: report the real version instead of a stale hardcoded 5.0.0

### DIFF
--- a/src/seconv/Helpers/CliSchema.cs
+++ b/src/seconv/Helpers/CliSchema.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -15,7 +15,40 @@ namespace SeConv.Helpers;
 /// </summary>
 internal static class CliSchema
 {
-    public const string Version = "5.0.0";
+    /// <summary>
+    /// Version reported by <c>seconv --version</c> and <c>seconv --help-json</c>.
+    ///
+    /// Release builds stamp <see cref="AssemblyInformationalVersionAttribute"/> from the
+    /// <c>Se.Version</c> string (see build-seconv.yml), so this follows the Subtitle Edit
+    /// version on its own. This used to be a hardcoded constant that nobody remembered to
+    /// bump, so every release after 5.0.0 still reported "5.0.0" (issue #14303).
+    /// </summary>
+    public static readonly string Version = ResolveVersion();
+
+    /// <summary>
+    /// Reported when the assembly carries no stamped version - a plain <c>dotnet build</c>
+    /// gets the SDK default of 1.0.0, which would be more misleading than a stale number.
+    /// </summary>
+    private const string FallbackVersion = "5.2.0";
+
+    /// <summary>The version the .NET SDK assigns when the build does not pass one in.</summary>
+    private const string UnstampedSdkDefault = "1.0.0";
+
+    private static string ResolveVersion()
+    {
+        var informational = typeof(CliSchema).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        if (string.IsNullOrWhiteSpace(informational))
+        {
+            return FallbackVersion;
+        }
+
+        // Source Link appends "+<commit sha>" - callers want the release version, not the build.
+        var plus = informational.IndexOf('+');
+        var version = (plus >= 0 ? informational.Substring(0, plus) : informational).Trim();
+
+        return version.Length == 0 || version == UnstampedSdkDefault ? FallbackVersion : version;
+    }
 
     /// <summary>Schema revision, bumped when the emitted JSON shape changes (not its contents).</summary>
     public const int SchemaVersion = 1;


### PR DESCRIPTION
Fixes #14303

`seconv --version` prints `5.0.0` on every build, including 5.2.0-beta29:

```
$ seconv --version
5.0.0
```

## Cause

[`CliSchema.Version`](https://github.com/SubtitleEdit/subtitleedit/blob/main/src/seconv/Helpers/CliSchema.cs) was a hardcoded `const string` written when the CLI first shipped, and nothing bumps it. `Program.cs` feeds it to `config.SetApplicationVersion()`, and `--help-json` emits it as the `version` field — so both have been wrong for every release after 5.0.0.

The binaries themselves are fine: `build-seconv.yml` extracts the version from `Se.Version` and stamps `Version` / `FileVersion` / `InformationalVersion` on all six published RIDs. Only the string the CLI prints was stale, so this is a reporting bug, not a mispackaged build — `SeConv-Linux-x64.tar.gz` from the beta29 release really is beta29.

## Fix

Read `AssemblyInformationalVersionAttribute` instead of hardcoding, so the reported version follows `Se.Version` through the release workflow with nothing left to remember at bump time. Source Link's `+<commit sha>` suffix is trimmed. A plain local `dotnet build` passes no version and the SDK defaults to `1.0.0`, which would be more misleading than a stale number, so that one case falls back to a constant.

## Verification

Built both ways and ran the binary:

| build | `seconv --version` |
| --- | --- |
| `dotnet build` (unstamped, local dev) | `5.2.0` (fallback) |
| `-p:InformationalVersion=5.2.0-beta29` (as build-seconv.yml does) | `5.2.0-beta29` |

`--help-json` reports the same string in both cases. All 448 seconv tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)