### PR TITLE
Waveform: read wheel modifiers from the wheel event, not a stale mirror

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -767,6 +767,16 @@ public class AudioVisualizer : Control
     {
         _lastMouseWheelScroll = Environment.TickCount64;
 
+        // Resync from the wheel event itself, like every other pointer handler here. The
+        // KeyDown/KeyUp mirror goes stale whenever a Ctrl shortcut is pressed over the
+        // waveform: the shortcut handler swallows the key-up, so _isCtrlDown stayed true and
+        // the wheel kept setting the video position at the cursor even with "mouse-wheel sets
+        // video position" turned off (#14306). e.KeyModifiers is the state at the scroll.
+        _isCtrlDown = e.KeyModifiers.HasFlag(KeyModifiers.Control);
+        _isShiftDown = e.KeyModifiers.HasFlag(KeyModifiers.Shift);
+        _isAltDown = e.KeyModifiers.HasFlag(KeyModifiers.Alt);
+        _isMetaDown = e.KeyModifiers.HasFlag(KeyModifiers.Meta);
+
         var point = e.GetPosition(this);
         var properties = e.GetCurrentPoint(this).Properties;
 

--- a/tests/UI/Controls/AudioVisualizerWheelModifierTests.cs
+++ b/tests/UI/Controls/AudioVisualizerWheelModifierTests.cs
@@ -1,0 +1,183 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Collections.Generic;
+
+namespace UITests.Controls;
+
+/// <summary>
+/// Issue #14306: with "mouse-wheel sets video position" turned off, the wheel still jumped the
+/// video to the cursor after any Ctrl shortcut was used over the waveform.
+///
+/// The wheel handler read a Ctrl/Alt/Shift/Meta mirror maintained from KeyDown/KeyUp. A shortcut
+/// handler that swallows the key-up leaves the mirror stuck down, and the wheel then took the
+/// Ctrl branch ("scroll and set the video position at the cursor") with no Ctrl held. It now
+/// reads the modifiers off the wheel event itself, like every other pointer handler in the
+/// control, so a stale mirror cannot reach it.
+/// </summary>
+public class AudioVisualizerWheelModifierTests : IDisposable
+{
+    // A window left open outlives the test: it keeps the application-wide activation and focused
+    // element, so a later test's input is delivered to it instead.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private const int SampleRate = 126; // px per second at zoom 1
+    private const double WidthPx = 800;
+    private const double ViewStart = 98;
+    private static readonly Point WheelPoint = new(400, 100);
+
+    private static WavePeakData2 MakePeaks(int seconds)
+    {
+        var peaks = new WavePeak2[SampleRate * seconds];
+        for (var i = 0; i < peaks.Length; i++)
+        {
+            peaks[i] = new WavePeak2(8000, -8000);
+        }
+
+        return new WavePeakData2(SampleRate, peaks);
+    }
+
+    private (Window Window, AudioVisualizer Av) Open()
+    {
+        var av = new AudioVisualizer { WavePeaks = MakePeaks(200), Width = WidthPx, Height = 200 };
+        var line = new SubtitleLineViewModel
+        {
+            Text = "text",
+            StartTime = TimeSpan.FromSeconds(100),
+            EndTime = TimeSpan.FromSeconds(102),
+        };
+
+        av.SetPosition(ViewStart, new List<SubtitleLineViewModel> { line }, 0, 0, new List<SubtitleLineViewModel>());
+
+        var window = new Window { Width = WidthPx, Height = 200, Content = av };
+        _windows.Add(window);
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+        av.Focus();
+        Dispatcher.UIThread.RunJobs();
+        return (window, av);
+    }
+
+    /// <summary>Runs an action with "mouse-wheel sets video position" forced to <paramref name="on"/>.</summary>
+    private static void WithWheelSetsVideoPosition(bool on, Action body)
+    {
+        var old = Se.Settings.Waveform.MouseWheelSetsVideoPosition;
+        Se.Settings.Waveform.MouseWheelSetsVideoPosition = on;
+        try
+        {
+            body();
+        }
+        finally
+        {
+            Se.Settings.Waveform.MouseWheelSetsVideoPosition = old;
+        }
+    }
+
+    // Ctrl goes down over the waveform and the matching key-up never arrives, which is what a
+    // shortcut handler that marks the key event handled looks like from here.
+    private static void PressCtrlWithoutRelease(Window window)
+    {
+        window.KeyPress(Key.LeftCtrl, RawInputModifiers.Control, PhysicalKey.ControlLeft, null);
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    // The reported bug, with the setting off: after a Ctrl shortcut the wheel repositioned the
+    // video even though no modifier was held while scrolling.
+    [AvaloniaFact]
+    public void Wheel_AfterCtrlShortcut_DoesNotMoveTheVideo()
+    {
+        WithWheelSetsVideoPosition(false, () =>
+        {
+            var (window, av) = Open();
+            var moved = 0;
+            av.OnVideoPositionChanged += (_, _) => moved++;
+
+            PressCtrlWithoutRelease(window);
+            window.MouseWheel(WheelPoint, new Vector(0, 1), RawInputModifiers.None);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(0, moved);
+        });
+    }
+
+    // The same stale Ctrl with the setting on: it suppressed the step-seek the setting exists for
+    // and did the Ctrl "set position at cursor" instead.
+    [AvaloniaFact]
+    public void Wheel_AfterCtrlShortcut_StillStepsTheVideo_WhenSettingIsOn()
+    {
+        WithWheelSetsVideoPosition(true, () =>
+        {
+            var (window, av) = Open();
+            av.CurrentVideoPositionSeconds = 100;
+            var positions = new List<double>();
+            av.OnVideoPositionChanged += (_, e) => positions.Add(e.PositionInSeconds);
+
+            PressCtrlWithoutRelease(window);
+            window.MouseWheel(WheelPoint, new Vector(0, 1), RawInputModifiers.None);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Single(positions);
+            // A step off the current position, not a jump to wherever the pointer happens to be.
+            Assert.True(Math.Abs(positions[0] - 100) < 1,
+                $"expected a step near 100s, got {positions[0]}s");
+        });
+    }
+
+    // Ctrl genuinely held while scrolling keeps setting the video position at the cursor.
+    [AvaloniaFact]
+    public void Wheel_WithCtrlActuallyHeld_MovesTheVideo()
+    {
+        WithWheelSetsVideoPosition(false, () =>
+        {
+            var (window, av) = Open();
+            var moved = 0;
+            av.OnVideoPositionChanged += (_, _) => moved++;
+
+            window.MouseWheel(WheelPoint, new Vector(0, 1), RawInputModifiers.Control);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(moved > 0, "Ctrl+wheel should still set the video position");
+        });
+    }
+
+    // Without any modifier the wheel only scrolls the view - the baseline the reporter had before
+    // touching a shortcut.
+    [AvaloniaFact]
+    public void Wheel_WithNoModifier_OnlyScrolls()
+    {
+        WithWheelSetsVideoPosition(false, () =>
+        {
+            var (window, av) = Open();
+            var moved = 0;
+            var scrolled = 0;
+            av.OnVideoPositionChanged += (_, _) => moved++;
+            av.OnHorizontalScroll += (_, _) => scrolled++;
+
+            window.MouseWheel(WheelPoint, new Vector(0, 1), RawInputModifiers.None);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(0, moved);
+            Assert.True(scrolled > 0, "the wheel should scroll the waveform");
+        });
+    }
+}


### PR DESCRIPTION
Fixes #14306

With **"mouse-wheel sets video position" turned off**, the wheel still repositioned the video after any Ctrl shortcut was used over the waveform. The reporter's steps land exactly on it: scroll works normally, press Ctrl+V, and from then on the wheel jumps the video.

## Cause

[`OnPointerWheelChanged`](https://github.com/SubtitleEdit/subtitleedit/blob/main/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs) is the only pointer handler in `AudioVisualizer` that trusted the `_isCtrlDown` / `_isShiftDown` / `_isAltDown` / `_isMetaDown` mirror maintained from `KeyDown`/`KeyUp`. `OnTapped`, `OnPointerPressed` and `OnPointerReleased` all resync from `e.KeyModifiers` first.

A shortcut handler that marks the key event handled swallows the key-up, so the mirror stays "Ctrl down". The wheel then takes its Ctrl branch — scroll *and* set the video position at the cursor — with no modifier actually held. It reads as a toggle because the next shortcut can leave the mirror in the opposite state.

The same staleness bit the other way: **genuine Ctrl+wheel only worked if the waveform had keyboard focus and had seen the Ctrl key-down itself.** Scrolling with Ctrl held after clicking elsewhere did nothing.

## Fix

Resync the four flags from `e.KeyModifiers` at the top of the wheel handler, exactly as the sibling pointer handlers do. `PointerWheelEventArgs` carries the modifier state at the moment of the scroll, so a stale mirror can no longer reach it. Alt (horizontal zoom) and Shift (vertical zoom) get the same repair for free.

## Tests

New `AudioVisualizerWheelModifierTests` — 4 headless cases:

| case | asserts |
| --- | --- |
| stale Ctrl, setting off | wheel does not move the video |
| stale Ctrl, setting on | wheel still *steps* the video, rather than jumping to the pointer |
| Ctrl really held | Ctrl+wheel still sets the video position |
| no modifier | wheel only scrolls the view |

Reverting the one-line resync fails 3 of the 4 (the fourth is the unmodified baseline), so they pin the actual defect. Full UI suite: 4391 passed, 1 skipped, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)