### PR TITLE
Options menu: surface "Set up like Subtitle Edit 4"

### DIFF
--- a/src/ui/Features/Main/Layout/InitMenu.cs
+++ b/src/ui/Features/Main/Layout/InitMenu.cs
@@ -894,6 +894,16 @@ public static class InitMenu
                     Header = l.ChooseLanguage,
                     Command = vm.CommandShowSettingsLanguageCommand,
                 },
+                new Separator(),
+                // The one-shot SE 4 import (shortcuts + replace rules from the classic
+                // Settings.xml, plus the SE 4 theme/waveform colors). It had a default shortcut
+                // and a Shortcuts-window entry but no menu item, so people coming from SE 4 had
+                // no way to find it (#14309).
+                new MenuItem
+                {
+                    Header = Se.Language.General.SetUpLikeSubtitleEdit4,
+                    Command = vm.SetupLikeSe4Command,
+                },
             },
         });
 

--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -420,6 +420,9 @@ public static class InitNativeMacMenu
         optionsItems.Items.Add(Item(Clean(l.Shortcuts), v => v.CommandShowSettingsShortcutsCommand));
         optionsItems.Items.Add(Item(Clean(l.WordLists), v => v.ShowWordListsCommand));
         optionsItems.Items.Add(Item(Clean(l.ChooseLanguage), v => v.CommandShowSettingsLanguageCommand));
+        optionsItems.Items.Add(new NativeMenuItemSeparator());
+        // Mirrors the same entry in InitMenu.cs - see the note there (#14309).
+        optionsItems.Items.Add(Item(Clean(Se.Language.General.SetUpLikeSubtitleEdit4), v => v.SetupLikeSe4Command));
 
         // ── Help ──────────────────────────────────────────────────────────────
         var helpItems = new NativeMenu();


### PR DESCRIPTION
Re: #14309

The reporter is coming from 4.0.12 and found only the Settings import/export dialog, which reads SE 5 JSON and rejects the classic `Settings.xml`.

SE 5 already has an SE 4 importer — [`Se4SetupApplier`](https://github.com/SubtitleEdit/subtitleedit/blob/main/src/ui/Logic/Se4Setup/Se4SetupApplier.cs), reached through `SetupLikeSe4Command`. It locates the classic `Settings.xml` on its own and merges in the SE 4 shortcuts and replace rules, then applies the SE 4 theme, toolbar icons, frame rate and waveform colors.

**It has no menu item.** It is reachable only by its default shortcut or by assigning one in the Shortcuts window, which is not where anyone migrating from SE 4 would think to look. That is what this PR fixes.

## Scope — please read before merging

This makes the existing importer findable. It does **not** implement a general `Settings.xml` → `Settings.json` migration, and the importer covers only the categories listed above — not the full SE 4 settings tree. If you want #14309 answered completely, that broader importer is still open work; this is the discoverability half.

## Changes

- `InitMenu.cs` — new Options-menu entry after a separator, below "Choose language".
- `InitNativeMacMenu.cs` — the same entry in the macOS native menu.

No new language string: `General.SetUpLikeSubtitleEdit4` ("Set up like Subtitle Edit 4 (theme, shortcuts, replace rules)") already exists and is already translated.

## Tests

`MacNativeMenuParityTests` covers this — dropping just the macOS line fails it, so the two builders can't drift here. Full UI suite: 4387 passed, 1 skipped, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)