### PR TITLE
seconv: give Ollama OCR the same generation limits as the GUI

### DIFF
--- a/src/seconv/Core/OllamaOcrEngine.cs
+++ b/src/seconv/Core/OllamaOcrEngine.cs
@@ -1,5 +1,6 @@
 using Nikse.SubtitleEdit.Core.Common;
 using SkiaSharp;
+using System.Globalization;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -16,6 +17,13 @@ internal sealed class OllamaOcrEngine : IOcrEngine
 {
     public string Name => "ollama";
 
+    // Same generation limits the GUI's OllamaOcr uses, and for the same reason: a thinking
+    // model (glm-ocr and friends) left unbounded emits its reasoning, markdown fences and the
+    // same line over and over. Uncapped that is both slow - nothing stops generation once the
+    // text is transcribed - and wrong. The CLI never got these when the GUI was tuned (#14310).
+    private const int MaxTokens = 96;
+    private const double RepeatPenalty = 1.1;
+
     private readonly HttpClient _httpClient;
     private readonly string _url;
     private readonly string _model;
@@ -24,7 +32,9 @@ internal sealed class OllamaOcrEngine : IOcrEngine
 
     public OllamaOcrEngine(string? url, string? model, string? language, string? prompt = null)
     {
-        _url = string.IsNullOrWhiteSpace(url) ? "http://localhost:11434/api/chat" : url;
+        // Trailing slash costs a 307 redirect on every single image (Ollama's route is
+        // /api/chat), which the GUI already trims.
+        _url = string.IsNullOrWhiteSpace(url) ? "http://localhost:11434/api/chat" : url.TrimEnd('/');
         _model = string.IsNullOrWhiteSpace(model) ? "llama3.2-vision" : model;
         _language = string.IsNullOrWhiteSpace(language) ? "English" : language;
         // Ollama OCR has no prompt in the GUI, so its built-in wording stays the default here;
@@ -54,10 +64,7 @@ internal sealed class OllamaOcrEngine : IOcrEngine
         var prompt = _promptTemplate != null
             ? _promptTemplate.Replace("{language}", _language)
             : $"Act as a precise OCR engine. Transcribe every line of text from this image exactly as it appears. The language is {_language}. Maintain the vertical order. Use a single '\\n' to separate each line. Do not skip any text. Output only the transcribed text";
-        var body = "{ \"model\": \"" + Escape(_model) + "\", " +
-                   "\"messages\": [ { \"role\": \"user\", \"content\": \"" + Escape(prompt) + "\", " +
-                   "\"images\": [ \"" + base64 + "\" ] } ], " +
-                   "\"stream\": false }";
+        var body = BuildRequestBody(_model, prompt, base64);
 
         using var content = new StringContent(body, Encoding.UTF8);
         content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
@@ -76,6 +83,25 @@ internal sealed class OllamaOcrEngine : IOcrEngine
         var text = string.Join(string.Empty, contents).Trim();
         text = text.Replace("\\n", Environment.NewLine).Replace("\\\"", "\"");
         return text.Trim();
+    }
+
+    /// <summary>
+    /// The /api/chat payload. Split out so the option block stays checkable - it is hand-built
+    /// JSON, and a stray comma here fails as an Ollama 400 per image rather than at build time.
+    /// </summary>
+    internal static string BuildRequestBody(string model, string prompt, string base64Image)
+    {
+        var options = "\"options\": { \"temperature\": 0, \"repeat_penalty\": " +
+                      RepeatPenalty.ToString(CultureInfo.InvariantCulture) +
+                      ", \"num_predict\": " + MaxTokens + " }, ";
+
+        // "think": false turns off the model's chain-of-thought, which is the single biggest
+        // source of "way too much text" from a thinking model.
+        return "{ \"model\": \"" + Escape(model) + "\", " + options +
+               "\"think\": false, " +
+               "\"messages\": [ { \"role\": \"user\", \"content\": \"" + Escape(prompt) + "\", " +
+               "\"images\": [ \"" + base64Image + "\" ] } ], " +
+               "\"stream\": false }";
     }
 
     private static string Escape(string s) =>

--- a/tests/seconv/Core/OllamaOcrRequestTest.cs
+++ b/tests/seconv/Core/OllamaOcrRequestTest.cs
@@ -1,0 +1,85 @@
+using SeConv.Core;
+using System.Globalization;
+using System.Text.Json;
+using Xunit;
+
+namespace SeConvTests.Core;
+
+/// <summary>
+/// Issue #14310: the CLI's Ollama OCR sent no generation options at all, while the GUI's
+/// OllamaOcr caps the tokens, zeroes the temperature, adds a repeat penalty and turns off
+/// thinking - tuned to stop a thinking model from emitting its reasoning and repeating lines.
+/// Uncapped, the CLI was both slower per image and more prone to garbage output.
+///
+/// The payload is hand-built JSON, so these check it parses and carries the same values the
+/// GUI sends. A malformed body would otherwise surface as an Ollama 400 per image.
+/// </summary>
+public class OllamaOcrRequestTest
+{
+    private static JsonElement Build()
+    {
+        var json = OllamaOcrEngine.BuildRequestBody("glm-ocr", "Transcribe this", "QUJD");
+        return JsonDocument.Parse(json).RootElement.Clone();
+    }
+
+    [Fact]
+    public void RequestBody_IsValidJson_WithModelPromptAndImage()
+    {
+        var root = Build();
+
+        Assert.Equal("glm-ocr", root.GetProperty("model").GetString());
+        Assert.False(root.GetProperty("stream").GetBoolean());
+
+        var message = root.GetProperty("messages")[0];
+        Assert.Equal("user", message.GetProperty("role").GetString());
+        Assert.Equal("Transcribe this", message.GetProperty("content").GetString());
+        Assert.Equal("QUJD", message.GetProperty("images")[0].GetString());
+    }
+
+    // The GUI's numbers, which is the whole point of the issue.
+    [Fact]
+    public void RequestBody_CarriesTheGuiGenerationLimits()
+    {
+        var options = Build().GetProperty("options");
+
+        Assert.Equal(0, options.GetProperty("temperature").GetDouble());
+        Assert.Equal(1.1, options.GetProperty("repeat_penalty").GetDouble(), 3);
+        Assert.Equal(96, options.GetProperty("num_predict").GetInt32());
+    }
+
+    [Fact]
+    public void RequestBody_DisablesThinking()
+    {
+        Assert.False(Build().GetProperty("think").GetBoolean());
+    }
+
+    // repeat_penalty is a double written into JSON by hand: under a comma-decimal culture an
+    // uninvariant ToString() emits 1,1 and the whole request becomes unparseable.
+    [Fact]
+    public void RequestBody_IsCultureInvariant()
+    {
+        var previous = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = new CultureInfo("da-DK");
+        try
+        {
+            var json = OllamaOcrEngine.BuildRequestBody("m", "p", "QUJD");
+            Assert.Contains("\"repeat_penalty\": 1.1", json);
+            JsonDocument.Parse(json);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previous;
+        }
+    }
+
+    // A quote or backslash in the model name or prompt must not break out of the JSON string.
+    [Fact]
+    public void RequestBody_EscapesQuotesAndBackslashes()
+    {
+        var json = OllamaOcrEngine.BuildRequestBody("mo\"del", "say \"hi\"\\ now", "QUJD");
+        var root = JsonDocument.Parse(json).RootElement;
+
+        Assert.Equal("mo\"del", root.GetProperty("model").GetString());
+        Assert.Equal("say \"hi\"\\ now", root.GetProperty("messages")[0].GetProperty("content").GetString());
+    }
+}


### PR DESCRIPTION
Fixes #14310

Confirmed the report against the source. `src/seconv/Core/OllamaOcrEngine.cs` built its `/api/chat` payload with no `options` object and no `"think": false`, while the GUI's `src/ui/Features/Ocr/Engines/OllamaOcr.cs` sets all of them, with the reasoning in a comment at the top of that file: a thinking model (glm-ocr and friends) left unbounded emits its reasoning, markdown fences, and the same line over and over. Uncapped, generation does not stop once the subtitle is transcribed — slower per image, and more garbage in the output.

I wrote this from the two files rather than applying the attached patch, so the diff is mine to defend.

## Changes

- `num_predict: 96`, `temperature: 0`, `repeat_penalty: 1.1`, `"think": false` — the GUI's values, as the same named constants.
- Trim a trailing slash off the Ollama URL, which the GUI already does. Left on, it costs a **307 redirect on every single image** — the same "slower than the GUI" symptom, from a different direction.
- Body building moves into an internal `BuildRequestBody`. The payload is hand-built JSON; a stray comma there surfaces as an Ollama 400 per image instead of at build time, and now the tests parse it.

## Tests

New `OllamaOcrRequestTest` — 5 cases: the body parses as JSON with the right model/prompt/image; the four generation limits match the GUI; `think` is false; `repeat_penalty` stays `1.1` under a comma-decimal culture (`da-DK` — an uninvariant `ToString()` would emit `1,1` and make the whole request unparseable); quotes and backslashes in the model name and prompt don't break out of the JSON string.

Full seconv suite: 453 passed, 0 failed.

## Two divergences I did not touch

Flagging rather than folding in, since they're beyond what was reported and one needs a decision:

1. The GUI runs its result through `CleanOcrText` (strips trailing repeated lines, ``` fences, prompt echo) and `OcrHelper.FixAiOcrPunctuationSpaces`. seconv does neither — but it does neither for *any* OCR engine, and `CleanOcrText` is a private method duplicated in `OllamaOcr.cs` and `GlmOcr.cs`, so sharing it means lifting it into libuilogic first.
2. `num_predict: 96` now also applies when a user passes `--ocr-prompt`. 96 tokens is ample for a subtitle frame, which is all this path ever sees, but it is a cap the GUI never has to consider because Ollama OCR has no custom prompt there. Say the word if you'd rather it lift for a custom prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)