### PR TITLE
Make dialogs keyboard-navigable: initial focus and Tab, across the UI

### DIFF
--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/AssaApplyAdvancedEffectWindow.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/AssaApplyAdvancedEffectWindow.cs
@@ -215,7 +215,7 @@ public class AssaApplyAdvancedEffectWindow : Window
         Content = mainGrid;
 
         // initial focus on an input, not an action button - a focused button clicks on bare Space
-        Activated += delegate { effectListBox.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, effectListBox);
         AddHandler(KeyDownEvent, vm.OnKeyDownHandler,
             RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: false);
         Loaded += (_, _) => vm.OnLoaded();

--- a/src/ui/Features/Assa/AssaApplyCustomOverrideTags/AssaApplyCustomOverrideTagsWindow.cs
+++ b/src/ui/Features/Assa/AssaApplyCustomOverrideTags/AssaApplyCustomOverrideTagsWindow.cs
@@ -147,7 +147,7 @@ public class AssaApplyCustomOverrideTagsWindow : Window
         Content = grid;
 
         // initial focus on an input, not an action button - a focused button clicks on bare Space
-        Activated += delegate { comboBoxOverrideTags.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, comboBoxOverrideTags);
 
         AddHandler(KeyDownEvent, vm.OnKeyDownHandler, RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: false);
         Loaded += (_, _) => vm.OnLoaded();

--- a/src/ui/Features/Assa/AssaApplyCustomOverrideTags/AssaTagHistoryWindow.cs
+++ b/src/ui/Features/Assa/AssaApplyCustomOverrideTags/AssaTagHistoryWindow.cs
@@ -64,7 +64,7 @@ public class AssaTagHistoryWindow : Window
         Content = grid;
 
         // initial focus on an input, not an action button - a focused button clicks on bare Space
-        Activated += delegate { listBox.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, listBox);
         KeyDown += vm.KeyDown;
     }
 }

--- a/src/ui/Features/Assa/AssaAttachmentsWindow.cs
+++ b/src/ui/Features/Assa/AssaAttachmentsWindow.cs
@@ -77,7 +77,7 @@ public class AssaAttachmentsWindow : Window
         Content = grid;
 
         // initial focus on an input, not an action button - a focused button clicks on bare Space
-        Activated += delegate { TableViewExtras.FocusRow(attachmentsGrid); };
+        UiUtil.FocusOnFirstActivation(this, () => { TableViewExtras.FocusRow(attachmentsGrid); });
         KeyDown += vm.KeyDown;
 
         Closing += delegate { UiUtil.SaveWindowPosition(this); };

--- a/src/ui/Features/Assa/AssaImageColorPicker/AssaImageColorPickerWindow.cs
+++ b/src/ui/Features/Assa/AssaImageColorPicker/AssaImageColorPickerWindow.cs
@@ -174,7 +174,7 @@ public class AssaImageColorPickerWindow : Window
 
         Content = grid;
 
-        Activated += delegate { buttonOk.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, buttonOk);
         KeyDown += vm.KeyDown;
     }
 }

--- a/src/ui/Features/Assa/AssaProgressBar/AssaProgressBarWindow.cs
+++ b/src/ui/Features/Assa/AssaProgressBar/AssaProgressBarWindow.cs
@@ -63,7 +63,7 @@ public class AssaProgressBarWindow : Window
         Content = mainGrid;
 
         // initial focus on an input, not an action button - a focused button clicks on bare Space
-        Activated += delegate { firstInput.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, firstInput);
         Loaded += (_, __) => vm.LoadVideoAndSubtitle();
         KeyDown += vm.KeyDown;
     }

--- a/src/ui/Features/Assa/AssaPropertiesWindow.cs
+++ b/src/ui/Features/Assa/AssaPropertiesWindow.cs
@@ -54,7 +54,7 @@ public class AssaPropertiesWindow : Window
         Content = grid;
 
         // initial focus on an input, not an action button - a focused button clicks on bare Space
-        Activated += delegate { textBoxTitle.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, textBoxTitle);
         KeyDown += vm.KeyDown;
     }
 

--- a/src/ui/Features/Assa/AssaResolutionResampler/AssaResolutionResamplerWindow.cs
+++ b/src/ui/Features/Assa/AssaResolutionResampler/AssaResolutionResamplerWindow.cs
@@ -75,7 +75,7 @@ public class AssaResolutionResamplerWindow : Window
         Content = grid;
 
         // initial focus on an input, not an action button - a focused button clicks on bare Space
-        Activated += delegate { sourceWidthBox.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, sourceWidthBox);
         KeyDown += vm.KeyDown;
     }
 

--- a/src/ui/Features/Assa/AssaSetBackground/AssSetBackgroundWindow.cs
+++ b/src/ui/Features/Assa/AssaSetBackground/AssSetBackgroundWindow.cs
@@ -87,7 +87,7 @@ public class AssSetBackgroundWindow : Window
         Content = mainGrid;
 
         // initial focus on an input, not an action button - a focused button clicks on bare Space
-        Activated += delegate { paddingLeftBox.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, paddingLeftBox);
         AddHandler(KeyDownEvent, vm.KeyDown, RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: false);
         Loaded += (_, _) => vm.OnLoaded();
         Closing += (_, _) => vm.OnClosing();

--- a/src/ui/Features/Assa/AssaSetPosition/AssaSetPositionWindow.cs
+++ b/src/ui/Features/Assa/AssaSetPosition/AssaSetPositionWindow.cs
@@ -181,7 +181,7 @@ public class AssaSetPositionWindow : Window
         Content = grid;
 
         // initial focus on an input, not an action button - a focused button clicks on bare Space
-        Activated += delegate { numericRotation.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, numericRotation);
         KeyDown += vm.KeyDown;
     }
 }

--- a/src/ui/Features/Assa/AssaStylePickerWindow.cs
+++ b/src/ui/Features/Assa/AssaStylePickerWindow.cs
@@ -61,7 +61,7 @@ public class AssaStylePickerWindow : Window
         Content = grid;
 
         // initial focus on an input, not an action button - a focused button clicks on bare Space
-        Activated += delegate { TableViewExtras.FocusRow(stylesGrid); };
+        UiUtil.FocusOnFirstActivation(this, () => { TableViewExtras.FocusRow(stylesGrid); });
         KeyDown += vm.KeyDown;
     }
 

--- a/src/ui/Features/Assa/AssaStylesWindow.cs
+++ b/src/ui/Features/Assa/AssaStylesWindow.cs
@@ -65,7 +65,7 @@ public class AssaStylesWindow : Window
         Content = grid;
 
         // initial focus on an input, not an action button - a focused button clicks on bare Space
-        Activated += delegate { TableViewExtras.FocusRow(vm.FileStyleGrid); };
+        UiUtil.FocusOnFirstActivation(this, () => { TableViewExtras.FocusRow(vm.FileStyleGrid); });
         KeyDown += vm.KeyDown;
 
         Closing += delegate { UiUtil.SaveWindowPosition(this); };

--- a/src/ui/Features/Edit/ModifySelection/HearingImpairedRuleSettingsWindow.cs
+++ b/src/ui/Features/Edit/ModifySelection/HearingImpairedRuleSettingsWindow.cs
@@ -96,7 +96,7 @@ public class HearingImpairedRuleSettingsWindow : Window
 
         Content = grid;
 
-        Activated += delegate { checkBoxBrackets.Focus(); }; // not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, checkBoxBrackets); // not an action button - a focused button clicks on bare Space
     }
 
     protected override void OnKeyDown(KeyEventArgs e)

--- a/src/ui/Features/Edit/ModifySelection/ModifySelectionWindow.cs
+++ b/src/ui/Features/Edit/ModifySelection/ModifySelectionWindow.cs
@@ -57,14 +57,14 @@ public class ModifySelectionWindow : Window
 
         Content = grid;
 
-        Activated += delegate
+        UiUtil.FocusOnFirstActivation(this, () =>
         {
             buttonOk.Focus();
             if (textbox.IsVisible)
             {
                 textbox.Focus();
             }
-        };
+        });
         KeyDown += vm.KeyDown;
 
         Closing += delegate { UiUtil.SaveWindowPosition(this); };

--- a/src/ui/Features/Edit/MultipleReplace/CategoryPickerWindow.cs
+++ b/src/ui/Features/Edit/MultipleReplace/CategoryPickerWindow.cs
@@ -62,7 +62,7 @@ public class CategoryPickerWindow : Window
 
         Content = grid;
 
-        Activated += delegate { TableViewExtras.FocusRow(dataGrid); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, () => { TableViewExtras.FocusRow(dataGrid); }); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += vm.KeyDown;
     }
 

--- a/src/ui/Features/Edit/MultipleReplace/EditCategoryWindow.cs
+++ b/src/ui/Features/Edit/MultipleReplace/EditCategoryWindow.cs
@@ -57,7 +57,7 @@ public class EditCategoryWindow : Window
 
         Content = grid;
 
-        Activated += delegate { textBoxCategoryName.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, textBoxCategoryName); // hack to make OnKeyDown work
         KeyDown += vm.OnKeyDown;
         Loaded += (_, _) => { Title = vm.Title; };
     }

--- a/src/ui/Features/Edit/MultipleReplace/EditRuleWindow.cs
+++ b/src/ui/Features/Edit/MultipleReplace/EditRuleWindow.cs
@@ -95,7 +95,7 @@ public class EditRuleWindow : Window
         RegexContextFlyout.Attach(textBoxFindWhat, vm, () => vm.IsRegularExpression);
         RegexContextFlyout.Attach(textBoxReplaceWith, vm, () => vm.IsRegularExpression, isReplaceBox: true);
 
-        Activated += delegate { textBoxFindWhat.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, textBoxFindWhat); // hack to make OnKeyDown work
         KeyDown += vm.OnKeyDown;
         Loaded += (s, e) =>
         {

--- a/src/ui/Features/Edit/MultipleReplace/FindRuleWindow.cs
+++ b/src/ui/Features/Edit/MultipleReplace/FindRuleWindow.cs
@@ -60,7 +60,7 @@ public class FindRuleWindow : Window
 
         Content = grid;
 
-        Activated += delegate { textBoxSearch.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, textBoxSearch);
         KeyDown += vm.OnKeyDown;
     }
 

--- a/src/ui/Features/Edit/MultipleReplace/MultipleReplaceWindow.cs
+++ b/src/ui/Features/Edit/MultipleReplace/MultipleReplaceWindow.cs
@@ -95,7 +95,7 @@ public class MultipleReplaceWindow : Window
 
         Content = grid;
 
-        Activated += delegate { rulesTreeView.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, rulesTreeView); // initial focus on an input, not an action button - a focused button clicks on bare Space
         Closing += (_, _) => vm.OnClosing();
         Loaded += (_, _) => vm.OnLoaded();
         KeyDown += vm.OnKeyDown;

--- a/src/ui/Features/Edit/ShowHistory/ShowHistoryWindow.cs
+++ b/src/ui/Features/Edit/ShowHistory/ShowHistoryWindow.cs
@@ -90,7 +90,7 @@ public class ShowHistoryWindow : Window
 
         Content = grid;
 
-        Activated += delegate { buttonCancel.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, buttonCancel); // hack to make OnKeyDown work
         KeyDown += vm.OnKeyDown;
     }
 }

--- a/src/ui/Features/Files/Compare/CompareWindow.cs
+++ b/src/ui/Features/Files/Compare/CompareWindow.cs
@@ -159,7 +159,7 @@ public class CompareWindow : Window
 
         Content = grid;
 
-        Activated += delegate
+        UiUtil.FocusOnFirstActivation(this, () =>
         {
             Dispatcher.UIThread.Post(() =>
             {
@@ -168,7 +168,7 @@ public class CompareWindow : Window
                     TableViewExtras.FocusRow(vm.LeftGrid); // initial focus on an input, not an action button - a focused button clicks on bare Space
                 }
             });
-        };
+        });
         KeyDown += vm.KeyDown;
 
         vm.LeftGrid = (leftView.Child as Border)?.Child as TableView;

--- a/src/ui/Features/Files/ExportCavena890/ExportCavena890Window.cs
+++ b/src/ui/Features/Files/ExportCavena890/ExportCavena890Window.cs
@@ -79,7 +79,7 @@ public class ExportCavena890Window : Window
 
         Content = grid;
 
-        Activated += delegate { textBoxTranslatedTitle.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, textBoxTranslatedTitle); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += vm.OnKeyDown;
     }
 }

--- a/src/ui/Features/Files/ExportCustomTextFormat/EditCustomTextFormatWindow.cs
+++ b/src/ui/Features/Files/ExportCustomTextFormat/EditCustomTextFormatWindow.cs
@@ -1,4 +1,4 @@
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Layout;
@@ -58,7 +58,7 @@ public class EditCustomTextFormatWindow : Window
 
         Content = grid;
 
-        Activated += delegate { textBoxName.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, textBoxName); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += vm.OnKeyDown;
     }
 
@@ -226,7 +226,8 @@ public class EditCustomTextFormatWindow : Window
         var textBox = new TextBox
         {
             AcceptsReturn = true,
-            AcceptsTab = true,
+            // Read-only preview - see ManualChosenEncodingWindow (#14313).
+            AcceptsTab = false,
             IsReadOnly = true,
             Width = double.NaN,
             Height = double.NaN,

--- a/src/ui/Features/Files/ExportCustomTextFormat/ExportCustomTextFormatWindow.cs
+++ b/src/ui/Features/Files/ExportCustomTextFormat/ExportCustomTextFormatWindow.cs
@@ -1,4 +1,4 @@
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Input;
@@ -62,7 +62,7 @@ public class ExportCustomTextFormatWindow : Window
 
         Content = grid;
 
-        Activated += delegate { TableViewExtras.FocusRow(formatsGrid); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, () => { TableViewExtras.FocusRow(formatsGrid); }); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += vm.OnKeyDown;
     }
 
@@ -187,7 +187,8 @@ public class ExportCustomTextFormatWindow : Window
         var textBox = new TextBox
         {
             AcceptsReturn = true,
-            AcceptsTab = true,
+            // Read-only preview - see ManualChosenEncodingWindow (#14313).
+            AcceptsTab = false,
             IsReadOnly = true,
             Width = double.NaN,
             Height = double.NaN,

--- a/src/ui/Features/Files/ExportDvbTeletext/ExportDvbTeletextWindow.cs
+++ b/src/ui/Features/Files/ExportDvbTeletext/ExportDvbTeletextWindow.cs
@@ -54,7 +54,7 @@ public class ExportDvbTeletextWindow : Window
 
         Content = grid;
 
-        Activated += delegate { numericPageNumber.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, numericPageNumber); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += vm.OnKeyDown;
     }
 }

--- a/src/ui/Features/Files/ExportEbuStl/ExportEbuStlWindow.cs
+++ b/src/ui/Features/Files/ExportEbuStl/ExportEbuStlWindow.cs
@@ -69,7 +69,7 @@ public class ExportEbuStlWindow : Window
 
         Content = grid;
 
-        Activated += delegate { comboBoxCodePage.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, comboBoxCodePage); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += vm.OnKeyDown;
     }
 

--- a/src/ui/Features/Files/ExportImageBased/ExportImageBasedWindow.cs
+++ b/src/ui/Features/Files/ExportImageBased/ExportImageBasedWindow.cs
@@ -99,7 +99,7 @@ public class ExportImageBasedWindow : Window
 
         Content = grid;
 
-        Activated += delegate { TableViewExtras.FocusRow(vm.SubtitleGrid); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, () => { TableViewExtras.FocusRow(vm.SubtitleGrid); }); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
         KeyUp += (_, e) => vm.OnKeyUp(e);
         Loaded += (_, e) => vm.OnLoaded();

--- a/src/ui/Features/Files/ExportImageBased/ImageBasedPreviewWindow.cs
+++ b/src/ui/Features/Files/ExportImageBased/ImageBasedPreviewWindow.cs
@@ -26,7 +26,7 @@ public class ImageBasedPreviewWindow : Window
 
         Content = image;
 
-        Activated += delegate { Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, () => { Focus(); }); // hack to make OnKeyDown work
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Files/ExportImageBased/ImageBasedProfileWindow.cs
+++ b/src/ui/Features/Files/ExportImageBased/ImageBasedProfileWindow.cs
@@ -127,7 +127,7 @@ public class ImageBasedProfileWindow : Window
 
         Content = grid;
 
-        Activated += delegate { Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, () => { Focus(); }); // hack to make OnKeyDown work
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Files/ExportImageBased/TextEffectWindow.cs
+++ b/src/ui/Features/Files/ExportImageBased/TextEffectWindow.cs
@@ -70,7 +70,7 @@ public class TextEffectWindow : Window
         Content = grid;
 
         KeyDown += (_, e) => vm.OnKeyDown(e);
-        Activated += delegate { buttonOk.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, buttonOk);
     }
 
     // The settings are pushed into the export dialog live, so a close that is not an OK -

--- a/src/ui/Features/Files/ExportPac/ExportPacWindow.cs
+++ b/src/ui/Features/Files/ExportPac/ExportPacWindow.cs
@@ -49,7 +49,7 @@ public class ExportPacWindow : Window
 
         Content = grid;
 
-        Activated += delegate { comboBoxPacFormats.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, comboBoxPacFormats); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Files/ExportPlainText/ExportPlainTextWindow.cs
+++ b/src/ui/Features/Files/ExportPlainText/ExportPlainTextWindow.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Layout;
 using Avalonia.Media;
@@ -55,7 +55,7 @@ public class ExportPlainTextWindow : Window
 
         Content = grid;
 
-        Activated += delegate { comboBoxEncoding.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, comboBoxEncoding); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += vm.OnKeyDown;
         Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
         Closing += delegate { UiUtil.SaveWindowPosition(this); };
@@ -200,7 +200,8 @@ public class ExportPlainTextWindow : Window
         var textBox = new TextBox
         {
             AcceptsReturn = true,
-            AcceptsTab = true,
+            // Read-only preview - see ManualChosenEncodingWindow (#14313).
+            AcceptsTab = false,
             IsReadOnly = true,
             TextWrapping = TextWrapping.Wrap,
             Width = double.NaN,

--- a/src/ui/Features/Files/FormatProperties/DcinemaInteropProperties/DCinemaInteropPropertiesWindow.cs
+++ b/src/ui/Features/Files/FormatProperties/DcinemaInteropProperties/DCinemaInteropPropertiesWindow.cs
@@ -240,7 +240,7 @@ public class DCinemaInteropPropertiesWindow : Window
 
         Content = mainPanel;
 
-        Activated += delegate { checkBoxGenerateIdAuto.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, checkBoxGenerateIdAuto); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 

--- a/src/ui/Features/Files/FormatProperties/DcinemaSmpteProperties/DCinemaSmptePropertiesWindow.cs
+++ b/src/ui/Features/Files/FormatProperties/DcinemaSmpteProperties/DCinemaSmptePropertiesWindow.cs
@@ -263,7 +263,7 @@ public class DCinemaSmptePropertiesWindow : Window
 
         Content = mainPanel;
 
-        Activated += delegate { checkBoxGenerateIdAuto.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, checkBoxGenerateIdAuto); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 

--- a/src/ui/Features/Files/FormatProperties/ItunesTimedTextProperties/ItunesTimedTextPropertiesWindow.cs
+++ b/src/ui/Features/Files/FormatProperties/ItunesTimedTextProperties/ItunesTimedTextPropertiesWindow.cs
@@ -211,7 +211,7 @@ public class ItunesTimedTextPropertiesWindow : Window
 
         Content = grid;
 
-        Activated += delegate { textBoxTitle.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, textBoxTitle); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Files/FormatProperties/RosettaProperties/RosettaPropertiesWindow.cs
+++ b/src/ui/Features/Files/FormatProperties/RosettaProperties/RosettaPropertiesWindow.cs
@@ -91,7 +91,7 @@ public class RosettaPropertiesWindow : Window
 
         Content = grid;
 
-        Activated += delegate { comboBoxLanguage.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, comboBoxLanguage); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Files/FormatProperties/TimedText10Properties/TimedText10PropertiesWindow.cs
+++ b/src/ui/Features/Files/FormatProperties/TimedText10Properties/TimedText10PropertiesWindow.cs
@@ -166,7 +166,7 @@ public class TimedText10PropertiesWindow : Window
 
         Content = grid;
 
-        Activated += delegate { textBoxTitle.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, textBoxTitle); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Files/FormatProperties/TimedTextImsc11Properties/TimedTextImsc11PropertiesWindow.cs
+++ b/src/ui/Features/Files/FormatProperties/TimedTextImsc11Properties/TimedTextImsc11PropertiesWindow.cs
@@ -144,7 +144,7 @@ public class TimedTextImsc11PropertiesWindow : Window
 
         Content = grid;
 
-        Activated += delegate { textBoxTitle.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, textBoxTitle); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Files/FormatProperties/TmpegEncXmlProperties/TmpegEncXmlPropertiesWindow.cs
+++ b/src/ui/Features/Files/FormatProperties/TmpegEncXmlProperties/TmpegEncXmlPropertiesWindow.cs
@@ -124,7 +124,7 @@ public class TmpegEncXmlPropertiesWindow : Window
 
         Content = grid;
 
-        Activated += delegate { comboBoxFontName.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, comboBoxFontName); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Files/FormatProperties/WebVttProperties/WebVttPropertiesWindow.cs
+++ b/src/ui/Features/Files/FormatProperties/WebVttProperties/WebVttPropertiesWindow.cs
@@ -106,7 +106,7 @@ public class WebVttPropertiesWindow : Window
 
         Content = grid;
 
-        Activated += delegate { textBoxAn7.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, textBoxAn7); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 

--- a/src/ui/Features/Files/ImportCsvXlsxCustomColumns/ImportCsvXlsxCustomColumnsWindow.cs
+++ b/src/ui/Features/Files/ImportCsvXlsxCustomColumns/ImportCsvXlsxCustomColumnsWindow.cs
@@ -102,7 +102,7 @@ public class ImportCsvXlsxCustomColumnsWindow : Window
         Content = grid;
 
         vm.ColumnsRebuilt += (_, _) => RebuildSourceGridColumns(vm);
-        Activated += delegate { TableViewExtras.FocusRow(_sourceGrid); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, () => { TableViewExtras.FocusRow(_sourceGrid); }); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 

--- a/src/ui/Features/Files/ImportImages/ImportImagesWindow.cs
+++ b/src/ui/Features/Files/ImportImages/ImportImagesWindow.cs
@@ -68,7 +68,7 @@ public class ImportImagesWindow : Window
 
         Content = grid;
 
-        Activated += delegate { TableViewExtras.FocusRow(imagesGrid); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, () => { TableViewExtras.FocusRow(imagesGrid); }); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += vm.KeyDown;
     }
 

--- a/src/ui/Features/Files/ImportPlainText/ForcedAlignerSetup/ForcedAlignerSetupWindow.cs
+++ b/src/ui/Features/Files/ImportPlainText/ForcedAlignerSetup/ForcedAlignerSetupWindow.cs
@@ -150,7 +150,7 @@ public class ForcedAlignerSetupWindow : Window
 
         Content = grid;
 
-        Activated += delegate { comboAligner.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, comboAligner); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (s, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Files/ImportPlainText/ImportPlainTextWindow.cs
+++ b/src/ui/Features/Files/ImportPlainText/ImportPlainTextWindow.cs
@@ -121,7 +121,7 @@ public class ImportPlainTextWindow : Window
 
         Content = grid;
 
-        Activated += delegate { checkBoxImportFiles.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, checkBoxImportFiles); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += vm.KeyDown;
     }
 

--- a/src/ui/Features/Files/ManualChosenEncoding/ManualChosenEncodingWindow.cs
+++ b/src/ui/Features/Files/ManualChosenEncoding/ManualChosenEncodingWindow.cs
@@ -1,4 +1,4 @@
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Layout;
@@ -74,7 +74,7 @@ public class ManualChosenEncodingWindow : Window
 
         Content = grid;
 
-        Activated += delegate { searchBox.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, searchBox); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 
@@ -158,7 +158,9 @@ public class ManualChosenEncodingWindow : Window
         var textBox = new TextBox
         {
             AcceptsReturn = true,
-            AcceptsTab = true,
+            // Read-only: a typed tab could never land here anyway, and accepting it only
+            // swallowed Tab/Shift+Tab so the box could not be left from the keyboard (#14313).
+            AcceptsTab = false,
             IsReadOnly = true,
             Margin = new Thickness(0, 0, 0, 0),
             Width = double.NaN,

--- a/src/ui/Features/Files/RestoreAutoBackup/RestoreAutoBackupWindow.cs
+++ b/src/ui/Features/Files/RestoreAutoBackup/RestoreAutoBackupWindow.cs
@@ -161,7 +161,7 @@ public class RestoreAutoBackupWindow : Window
 
         Content = grid;
 
-        Activated += delegate { TableViewExtras.FocusRow(dataGrid); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, () => { TableViewExtras.FocusRow(dataGrid); }); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 

--- a/src/ui/Features/Files/Statistics/StatisticsWindow.cs
+++ b/src/ui/Features/Files/Statistics/StatisticsWindow.cs
@@ -78,7 +78,7 @@ public class StatisticsWindow : Window
 
         Content = grid;
 
-        Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, buttonOk); // hack to make OnKeyDown work
         KeyDown += vm.KeyDown;
 
         Closing += delegate { UiUtil.SaveWindowPosition(this); };

--- a/src/ui/Features/Help/About/AboutWindow.cs
+++ b/src/ui/Features/Help/About/AboutWindow.cs
@@ -187,7 +187,7 @@ public class AboutWindow : Window
             }
         };
 
-        Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, buttonOk); // hack to make OnKeyDown work
         KeyDown += vm.OnKeyDown;
     }
 }

--- a/src/ui/Features/Main/AssistedMove/AssistedMoveWindow.cs
+++ b/src/ui/Features/Main/AssistedMove/AssistedMoveWindow.cs
@@ -68,7 +68,7 @@ public class AssistedMoveWindow : Window
 
         Content = grid;
 
-        Activated += delegate { scrollCandidates.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, scrollCandidates); // hack to make OnKeyDown work
 
         // Keep the whole card list reachable on small screens - the ScrollViewer takes over.
         Opened += (_, _) =>

--- a/src/ui/Features/Main/AssistedSplit/AssistedSplitWindow.cs
+++ b/src/ui/Features/Main/AssistedSplit/AssistedSplitWindow.cs
@@ -68,7 +68,7 @@ public class AssistedSplitWindow : Window
 
         Content = grid;
 
-        Activated += delegate { scrollCandidates.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, scrollCandidates); // hack to make OnKeyDown work
 
         // Keep the whole card list reachable on small screens - the ScrollViewer takes over.
         Opened += (_, _) =>

--- a/src/ui/Features/Ocr/BinaryOcr/BinaryOcrCharacterAddWindow.cs
+++ b/src/ui/Features/Ocr/BinaryOcr/BinaryOcrCharacterAddWindow.cs
@@ -75,10 +75,10 @@ public class BinaryOcrCharacterAddWindow : Window
         CharactersFlyoutMenuHelper.MakeFlyoutLetters(menuFlyout, vm.InsertSpecialCharacterCommand); 
         vm.TextBoxNew.ContextFlyout = menuFlyout;
 
-        Activated += delegate
+        UiUtil.FocusOnFirstActivation(this, () =>
         {
             vm.TextBoxNew.Focus(); // hack to make OnKeyDown work
-        };
+        });
         Loaded += vm.Onloaded;
         Closing += vm.OnClosing;
         KeyDown += (_, args) => vm.KeyDown(args);

--- a/src/ui/Features/Ocr/BinaryOcr/BinaryOcrCharacterHistoryWindow.cs
+++ b/src/ui/Features/Ocr/BinaryOcr/BinaryOcrCharacterHistoryWindow.cs
@@ -55,10 +55,10 @@ public class BinaryOcrCharacterHistoryWindow : Window
 
         vm.TextBoxNew.KeyDown += vm.TextBoxNewOnKeyDown;
 
-        Activated += delegate
+        UiUtil.FocusOnFirstActivation(this, () =>
         {
             vm.TextBoxNew.Focus(); // hack to make OnKeyDown work
-        };
+        });
         PointerWheelChanged += vm.PointerWheelChanged;
         KeyDown += (_, e) => vm.KeyDown(e);
         KeyUp += (_, e) => vm.KeyUp(e);

--- a/src/ui/Features/Ocr/BinaryOcr/BinaryOcrDbEditWindow.cs
+++ b/src/ui/Features/Ocr/BinaryOcr/BinaryOcrDbEditWindow.cs
@@ -54,10 +54,10 @@ public class BinaryOcrDbEditWindow : Window
 
         Content = grid;
 
-        Activated += delegate
+        UiUtil.FocusOnFirstActivation(this, () =>
         {
             buttonOk.Focus(); // hack to make OnKeyDown work
-        };
+        });
         KeyDown += (_, e) => vm.KeyDown(e);
         Loaded += (_, _) => Title = vm.Title;
     }

--- a/src/ui/Features/Ocr/BinaryOcr/BinaryOcrDbNewWindow.cs
+++ b/src/ui/Features/Ocr/BinaryOcr/BinaryOcrDbNewWindow.cs
@@ -48,10 +48,10 @@ public class BinaryOcrDbNewWindow : Window
 
         Content = grid;
 
-        Activated += delegate
+        UiUtil.FocusOnFirstActivation(this, () =>
         {
             textBoxDatabaseName.Focus(); // hack to make OnKeyDown work
-        };
+        });
 
         textBoxDatabaseName.KeyDown += vm.TextBoxDatabaseNameKeyDown;
         KeyDown += (_, e) => vm.KeyDown(e);

--- a/src/ui/Features/Ocr/BinaryOcr/BinaryOcrInspectWindow.cs
+++ b/src/ui/Features/Ocr/BinaryOcr/BinaryOcrInspectWindow.cs
@@ -55,10 +55,10 @@ public class BinaryOcrInspectWindow : Window
 
         vm.TextBoxNew.KeyDown += vm.TextBoxNewOnKeyDown;
 
-        Activated += delegate
+        UiUtil.FocusOnFirstActivation(this, () =>
         {
             vm.TextBoxNew.Focus(); // hack to make OnKeyDown work
-        };
+        });
         KeyDown += (_, e) => vm.KeyDown(e);
         KeyUp += (_, e) => vm.KeyUp(e);
         Loaded += (_, _) => vm.OnLoaded();

--- a/src/ui/Features/Ocr/BinaryOcr/BinaryOcrSettingsWindow.cs
+++ b/src/ui/Features/Ocr/BinaryOcr/BinaryOcrSettingsWindow.cs
@@ -48,10 +48,10 @@ public class BinaryOcrSettingsWindow : Window
 
         Content = grid;
 
-        Activated += delegate
+        UiUtil.FocusOnFirstActivation(this, () =>
         {
             buttonEdit.Focus(); // hack to make OnKeyDown work
-        };
+        });
         KeyDown += (_, e) => vm.KeyDown(e);
     }
 }

--- a/src/ui/Features/Ocr/CrispEmbedSettings/CrispEmbedSettingsWindow.cs
+++ b/src/ui/Features/Ocr/CrispEmbedSettings/CrispEmbedSettingsWindow.cs
@@ -51,7 +51,7 @@ public class CrispEmbedSettingsWindow : Window
 
         Content = grid;
 
-        Activated += delegate { buttonClose.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, buttonClose);
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 

--- a/src/ui/Features/Ocr/Download/DownloadTesseractModelWindow.cs
+++ b/src/ui/Features/Ocr/Download/DownloadTesseractModelWindow.cs
@@ -83,10 +83,10 @@ public class DownloadTesseractModelWindow : Window
             }
         };
 
-        Activated += delegate
+        UiUtil.FocusOnFirstActivation(this, () =>
         {
             buttonCancel.Focus(); // hack to make OnKeyDown work
-        }; 
+        }); 
         KeyDown += (s, e) => vm.OnKeyDown(e);   
     }
 }

--- a/src/ui/Features/Ocr/FallbackDatabase/OcrFallbackDatabaseWindow.cs
+++ b/src/ui/Features/Ocr/FallbackDatabase/OcrFallbackDatabaseWindow.cs
@@ -61,7 +61,7 @@ public class OcrFallbackDatabaseWindow : Window
 
         Content = grid;
 
-        Activated += delegate { comboBoxDatabases.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, comboBoxDatabases);
         KeyDown += vm.KeyDown;
     }
 }

--- a/src/ui/Features/Ocr/LlamaCppOcrSettingsWindow.cs
+++ b/src/ui/Features/Ocr/LlamaCppOcrSettingsWindow.cs
@@ -142,7 +142,7 @@ public class LlamaCppOcrSettingsWindow : Window
 
         Content = rootGrid;
 
-        Activated += delegate { textBoxUrl.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, textBoxUrl);
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 

--- a/src/ui/Features/Ocr/NOcr/NOcrCharacterAddWindow.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrCharacterAddWindow.cs
@@ -73,10 +73,10 @@ public class NOcrCharacterAddWindow : Window
         CharactersFlyoutMenuHelper.MakeFlyoutLetters(menuFlyout, vm.InsertSpecialCharacterCommand);
         vm.TextBoxNew.ContextFlyout = menuFlyout;
 
-        Activated += delegate
+        UiUtil.FocusOnFirstActivation(this, () =>
         {
             vm.TextBoxNew.Focus(); // hack to make OnKeyDown work
-        };
+        });
         Loaded += vm.Onloaded;
         Closing += vm.OnClosing;
         PointerWheelChanged += vm.PointerWheelChanged;

--- a/src/ui/Features/Ocr/NOcr/NOcrCharacterHistoryWindow.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrCharacterHistoryWindow.cs
@@ -55,10 +55,10 @@ public class NOcrCharacterHistoryWindow : Window
 
         vm.TextBoxNew.KeyDown += vm.TextBoxNewOnKeyDown;
 
-        Activated += delegate
+        UiUtil.FocusOnFirstActivation(this, () =>
         {
             vm.TextBoxNew.Focus(); // hack to make OnKeyDown work
-        };
+        });
         PointerWheelChanged += vm.PointerWheelChanged;
         KeyDown += (_, e) => vm.KeyDown(e);
         KeyUp += (_, e) => vm.KeyUp(e);

--- a/src/ui/Features/Ocr/NOcr/NOcrDbEditWindow.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrDbEditWindow.cs
@@ -55,10 +55,10 @@ public class NOcrDbEditWindow : Window
 
         Content = grid;
 
-        Activated += delegate
+        UiUtil.FocusOnFirstActivation(this, () =>
         {
             buttonOk.Focus(); // hack to make OnKeyDown work
-        };
+        });
         PointerWheelChanged += vm.PointerWheelChanged;
         KeyDown += (_, e) => vm.KeyDown(e);
         KeyUp += (_, e) => vm.KeyUp(e);

--- a/src/ui/Features/Ocr/NOcr/NOcrDbNewWindow.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrDbNewWindow.cs
@@ -48,10 +48,10 @@ public class NOcrDbNewWindow : Window
 
         Content = grid;
 
-        Activated += delegate
+        UiUtil.FocusOnFirstActivation(this, () =>
         {
             textBoxDatabaseName.Focus(); // hack to make OnKeyDown work
-        };
+        });
 
         textBoxDatabaseName.KeyDown += vm.TextBoxDatabaseNameKeyDown;
         KeyDown += (_, e) => vm.KeyDown(e);

--- a/src/ui/Features/Ocr/NOcr/NOcrInspectWindow.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrInspectWindow.cs
@@ -61,10 +61,10 @@ public class NOcrInspectWindow : Window
 
         vm.TextBoxNew.KeyDown += vm.TextBoxNewOnKeyDown;
 
-        Activated += delegate
+        UiUtil.FocusOnFirstActivation(this, () =>
         {
             vm.TextBoxNew.Focus(); // hack to make OnKeyDown work
-        };
+        });
 
         PointerWheelChanged += vm.PointerWheelChanged;
     }

--- a/src/ui/Features/Ocr/NOcr/NOcrSettingsWindow.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrSettingsWindow.cs
@@ -59,10 +59,10 @@ public class NOcrSettingsWindow : Window
         grid.ContextFlyout = menuFlyout;
         UiUtil.AttachMacContextFlyoutHandler(this, grid);
 
-        Activated += delegate
+        UiUtil.FocusOnFirstActivation(this, () =>
         {
             buttonEdit.Focus(); // hack to make OnKeyDown work
-        };
+        });
         KeyDown += (_, e) => vm.KeyDown(e);
     }
 }

--- a/src/ui/Features/Ocr/NOcr/NOcrTrainWindow.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrTrainWindow.cs
@@ -123,10 +123,10 @@ public class NOcrTrainWindow : Window
 
         Content = grid;
 
-        Activated += delegate
+        UiUtil.FocusOnFirstActivation(this, () =>
         {
             buttonTrain.Focus(); // hack to make OnKeyDown work
-        };
+        });
         KeyDown += (_, e) => vm.KeyDown(e);
         Closing += (_, _) => vm.OnClosing();
     }

--- a/src/ui/Features/Ocr/PickOllamaModelWindow.cs
+++ b/src/ui/Features/Ocr/PickOllamaModelWindow.cs
@@ -65,7 +65,7 @@ public class PickOllamaModelWindow : Window
         Content = grid;
 
         // initial focus on an input, not an action button - a focused button clicks on bare Space
-        Activated += delegate { listBox.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, listBox);
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Ocr/PreProcessingWindow.cs
+++ b/src/ui/Features/Ocr/PreProcessingWindow.cs
@@ -133,7 +133,7 @@ public class PreProcessingWindow : Window
         Content = grid;
 
         // initial focus on an input, not an action button - a focused button clicks on bare Space
-        Activated += delegate { checkBoxCropTransparent.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, checkBoxCropTransparent);
         KeyDown += vm.KeyDown;
     }
 

--- a/src/ui/Features/Ocr/PromptUnknownWordWindow.cs
+++ b/src/ui/Features/Ocr/PromptUnknownWordWindow.cs
@@ -67,7 +67,7 @@ public class PromptUnknownWordWindow : Window
 
         Content = grid;
 
-        Activated += delegate { vm.TextBoxWord.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, vm.TextBoxWord); // hack to make OnKeyDown work
         KeyDown += (_, e) => vm.OnKeyDown(e);
         Loaded += vm.Onloaded;
         Closing += vm.OnClosing;

--- a/src/ui/Features/Ocr/VobSubColorChooser/VobSubColorChooserWindow.cs
+++ b/src/ui/Features/Ocr/VobSubColorChooser/VobSubColorChooserWindow.cs
@@ -115,7 +115,7 @@ public class VobSubColorChooserWindow : Window
         Content = rootPanel;
 
         // initial focus on an input, not an action button - a focused button clicks on bare Space
-        Activated += delegate { buttonCancel.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, buttonCancel);
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 

--- a/src/ui/Features/Options/DoNotBreakAfterList/DoNotBreakAfterListWindow.cs
+++ b/src/ui/Features/Options/DoNotBreakAfterList/DoNotBreakAfterListWindow.cs
@@ -97,7 +97,7 @@ public class DoNotBreakAfterListWindow : Window
 
         Content = grid;
 
-        Activated += delegate { comboLanguages.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, comboLanguages); // initial focus on an input, not an action button - a focused button clicks on bare Space
         Loaded += (_, _) => vm.SelectedLanguageChanged();
 
         Closing += delegate { UiUtil.SaveWindowPosition(this); };

--- a/src/ui/Features/Options/Language/LanguageWindow.cs
+++ b/src/ui/Features/Options/Language/LanguageWindow.cs
@@ -63,7 +63,7 @@ public class LanguageWindow : Window
 
         Content = grid;
         
-        Activated += delegate { combo.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, combo); // initial focus on an input, not an action button - a focused button clicks on bare Space
         Loaded += (_, _) => vm.OnLoaded();
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }

--- a/src/ui/Features/Options/Plugins/GetPluginsWindow.cs
+++ b/src/ui/Features/Options/Plugins/GetPluginsWindow.cs
@@ -192,7 +192,7 @@ public class GetPluginsWindow : Window
 
         Content = grid;
 
-        Activated += delegate { buttonClose.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, buttonClose);
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Options/Plugins/PluginManagerWindow.cs
+++ b/src/ui/Features/Options/Plugins/PluginManagerWindow.cs
@@ -141,7 +141,7 @@ public class PluginManagerWindow : Window
 
         Content = grid;
 
-        Activated += delegate { buttonClose.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, buttonClose);
         KeyDown += (_, e) => vm.OnKeyDown(e);
 
         Closing += delegate { UiUtil.SaveWindowPosition(this); };

--- a/src/ui/Features/Options/Settings/CustomContinuationStyleWindow.cs
+++ b/src/ui/Features/Options/Settings/CustomContinuationStyleWindow.cs
@@ -56,7 +56,7 @@ public class CustomContinuationStyleWindow : Window
 
         Content = grid;
 
-        Activated += delegate { comboBoxFirstInput.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, comboBoxFirstInput); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += vm.KeyDown;
     }
 

--- a/src/ui/Features/Options/Settings/MinGapCalculate/MinGapCalculateWindow.cs
+++ b/src/ui/Features/Options/Settings/MinGapCalculate/MinGapCalculateWindow.cs
@@ -62,7 +62,7 @@ public class MinGapCalculateWindow : Window
             },
         };
 
-        Activated += delegate { comboBoxFrameRate.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, comboBoxFrameRate);
     }
 
     protected override void OnKeyDown(KeyEventArgs e)

--- a/src/ui/Features/Options/Settings/ProfilesExportWindow.cs
+++ b/src/ui/Features/Options/Settings/ProfilesExportWindow.cs
@@ -60,7 +60,7 @@ public class ProfilesExportWindow : Window
 
         Content = grid;
 
-        Activated += delegate { TableViewExtras.FocusRow(dataGrid); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, () => { TableViewExtras.FocusRow(dataGrid); }); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += vm.KeyDown;
     }
 

--- a/src/ui/Features/Options/Settings/ProfilesWindow.cs
+++ b/src/ui/Features/Options/Settings/ProfilesWindow.cs
@@ -59,7 +59,7 @@ public class ProfilesWindow : Window
 
         Content = grid;
 
-        Activated += delegate { TableViewExtras.FocusRow(dataGrid); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, () => { TableViewExtras.FocusRow(dataGrid); }); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += vm.KeyDown;
     }
 

--- a/src/ui/Features/Options/Settings/SettingsResetWindow.cs
+++ b/src/ui/Features/Options/Settings/SettingsResetWindow.cs
@@ -126,7 +126,7 @@ public class SettingsResetWindow : Window
 
         Content = grid;
 
-        Activated += delegate { checkBoxResetAll.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, checkBoxResetAll); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += vm.KeyDown;
     }
 }

--- a/src/ui/Features/Options/Settings/SyntaxColorTooWideSettings/SyntaxColorTooWideSettingsWindow.cs
+++ b/src/ui/Features/Options/Settings/SyntaxColorTooWideSettings/SyntaxColorTooWideSettingsWindow.cs
@@ -123,7 +123,7 @@ public class SyntaxColorTooWideSettingsWindow : Window
 
         Content = grid;
 
-        Activated += delegate { comboFont.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, comboFont); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Options/Settings/WaveformThemes/WaveformThemesWindow.cs
+++ b/src/ui/Features/Options/Settings/WaveformThemes/WaveformThemesWindow.cs
@@ -124,7 +124,7 @@ public class WaveformThemesWindow : Window
 
         Content = mainGrid;
 
-        Activated += delegate { themeComboBox.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, themeComboBox); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) =>
         {
             if (e.Key == Key.Escape)

--- a/src/ui/Features/Options/Settings/WaveformToolbarItems/WaveformToolbarItemsWindow.cs
+++ b/src/ui/Features/Options/Settings/WaveformToolbarItems/WaveformToolbarItemsWindow.cs
@@ -120,7 +120,7 @@ public class WaveformToolbarItemsWindow : Window
 
         Content = grid;
 
-        Activated += delegate { listBox.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, listBox); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Options/Shortcuts/CustomSearch/CustomSearchWindow.cs
+++ b/src/ui/Features/Options/Shortcuts/CustomSearch/CustomSearchWindow.cs
@@ -60,7 +60,7 @@ public class CustomSearchWindow : Window
 
         Content = grid;
 
-        Activated += delegate { textBoxName.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, textBoxName); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (s, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Options/Shortcuts/PickMilliseconds/PickMillisecondsWindow.cs
+++ b/src/ui/Features/Options/Shortcuts/PickMilliseconds/PickMillisecondsWindow.cs
@@ -50,7 +50,7 @@ public class PickMillisecondsWindow : Window
 
         Content = grid;
 
-        Activated += delegate { numericUpDownMilliseconds.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, numericUpDownMilliseconds); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (s, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Options/Shortcuts/SurroundWith/SurroundWithWindow.cs
+++ b/src/ui/Features/Options/Shortcuts/SurroundWith/SurroundWithWindow.cs
@@ -55,7 +55,7 @@ public class SurroundWithWindow : Window
 
         Content = grid;
         
-        Activated += delegate { textBoxBefore.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, textBoxBefore); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (s, e) => vm.OnKeyDown(e);   
     }
 }

--- a/src/ui/Features/Options/WordLists/WordListsWindow.cs
+++ b/src/ui/Features/Options/WordLists/WordListsWindow.cs
@@ -70,7 +70,7 @@ public class WordListsWindow : Window
 
         Content = grid;
 
-        Activated += delegate { comboLanguages.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, comboLanguages); // initial focus on an input, not an action button - a focused button clicks on bare Space
         Closing += (s, e) => _vm.Closing();
         Loaded += (s, e) => vm.Loaded();
 

--- a/src/ui/Features/Shared/AddToNamesList/AddToNamesListWindow.cs
+++ b/src/ui/Features/Shared/AddToNamesList/AddToNamesListWindow.cs
@@ -90,7 +90,7 @@ public class AddToNamesListWindow : Window
 
         Content = grid;
 
-        Activated += delegate { (vm.IsSingleMode ? textBoxWord : textBoxMultiNames).Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, () => { (vm.IsSingleMode ? textBoxWord : textBoxMultiNames).Focus(); }); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += vm.KeyDown;
     }
 }

--- a/src/ui/Features/Shared/AddToOcrReplaceList/AddToOcrReplaceListWindow.cs
+++ b/src/ui/Features/Shared/AddToOcrReplaceList/AddToOcrReplaceListWindow.cs
@@ -74,7 +74,7 @@ public class AddToOcrReplaceListWindow : Window
 
         Content = grid;
 
-        Activated += delegate { textBoxFrom.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, textBoxFrom); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += vm.KeyDown;
     }
 }

--- a/src/ui/Features/Shared/AddToUserDictionary/AddToUserDictionaryWindow.cs
+++ b/src/ui/Features/Shared/AddToUserDictionary/AddToUserDictionaryWindow.cs
@@ -62,7 +62,7 @@ public class AddToUserDictionaryWindow : Window
 
         Content = grid;
 
-        Activated += delegate { textBoxWord.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, textBoxWord); // hack to make OnKeyDown work
         KeyDown += vm.KeyDown;
     }
 }

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAllTimes/BinaryAdjustAllTimesWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAllTimes/BinaryAdjustAllTimesWindow.cs
@@ -108,7 +108,7 @@ public class BinaryAdjustAllTimesWindow : Window
 
         Content = grid;
 
-        Activated += delegate { timeCodeUpDown.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, timeCodeUpDown); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAlpha/BinaryAdjustAlphaWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustAlpha/BinaryAdjustAlphaWindow.cs
@@ -59,7 +59,7 @@ public class BinaryAdjustAlphaWindow : Window
 
         Content = mainGrid;
 
-        Activated += delegate { alphaAdjustmentSlider.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, alphaAdjustmentSlider); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustBrightness/BinaryAdjustBrightnessWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustBrightness/BinaryAdjustBrightnessWindow.cs
@@ -60,7 +60,7 @@ public class BinaryAdjustBrightnessWindow : Window
 
         Content = mainGrid;
 
-        Activated += delegate { brightnessInputSlider.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, brightnessInputSlider); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustColor/BinaryAdjustColorWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustColor/BinaryAdjustColorWindow.cs
@@ -56,7 +56,7 @@ public class BinaryAdjustColorWindow : Window
 
         Content = mainGrid;
 
-        Activated += delegate { buttonCancel.Focus(); }; // initial focus on a safe button, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, buttonCancel); // initial focus on a safe button, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustDuration/BinaryAdjustDurationWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustDuration/BinaryAdjustDurationWindow.cs
@@ -110,7 +110,7 @@ public class BinaryAdjustDurationWindow : Window
 
         Content = grid;
 
-        Activated += delegate { combo.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, combo); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAppendSubtitle/BinaryAppendSubtitleWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAppendSubtitle/BinaryAppendSubtitleWindow.cs
@@ -63,7 +63,7 @@ public class BinaryAppendSubtitleWindow : Window
 
         Content = root;
 
-        Activated += delegate { radioAppend.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, radioAppend); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Shared/BinaryEdit/BinaryApplyDurationLimits/BinaryApplyDurationLimitsWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryApplyDurationLimits/BinaryApplyDurationLimitsWindow.cs
@@ -90,7 +90,7 @@ public class BinaryApplyDurationLimitsWindow : Window
 
         Content = grid;
 
-        Activated += delegate { minimumNumeric.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, minimumNumeric); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Shared/BinaryEdit/BinaryResizeImages/BinaryResizeImagesWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryResizeImages/BinaryResizeImagesWindow.cs
@@ -60,7 +60,7 @@ public class BinaryResizeImagesWindow : Window
 
         Content = mainGrid;
 
-        Activated += delegate { percentageInput.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, percentageInput); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 

--- a/src/ui/Features/Shared/BinaryEdit/BinarySettings/BinarySettingsWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinarySettings/BinarySettingsWindow.cs
@@ -135,7 +135,7 @@ public class BinarySettingsWindow : Window
 
         Content = grid;
 
-        Activated += delegate { numericUpDownMarginLeft.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, numericUpDownMarginLeft); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Shared/Bookmarks/BookmarkEditWindow.cs
+++ b/src/ui/Features/Shared/Bookmarks/BookmarkEditWindow.cs
@@ -58,7 +58,7 @@ public class BookmarkEditWindow : Window
 
         Content = grid;
 
-        Activated += delegate { textBox.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, textBox); // hack to make OnKeyDown work
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Shared/Bookmarks/BookmarksListWindow.cs
+++ b/src/ui/Features/Shared/Bookmarks/BookmarksListWindow.cs
@@ -68,7 +68,7 @@ public class BookmarksListWindow : Window
 
         Content = grid;
 
-        Activated += delegate { buttonCancel.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, buttonCancel); // hack to make OnKeyDown work
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 

--- a/src/ui/Features/Shared/ColorPicker/ColorPickerWindow.cs
+++ b/src/ui/Features/Shared/ColorPicker/ColorPickerWindow.cs
@@ -44,7 +44,7 @@ public class ColorPickerWindow : Window
 
         Content = grid;
 
-        Activated += delegate { hexTextBox.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, hexTextBox); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 

--- a/src/ui/Features/Shared/ColumnPaste/ColumnPasteWindow.cs
+++ b/src/ui/Features/Shared/ColumnPaste/ColumnPasteWindow.cs
@@ -46,7 +46,7 @@ public class ColumnPasteWindow : Window
 
         // Plain text has no time codes, so the only enabled column choice is "text only"
         var initialFocusControl = vm.IsTextOnlySource ? radioButtonColumnsTextOnly : radioButtonColumnsAll;
-        Activated += delegate { initialFocusControl.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, initialFocusControl); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += vm.KeyDown;
     }
 

--- a/src/ui/Features/Shared/ErrorList/ErrorListWindow.cs
+++ b/src/ui/Features/Shared/ErrorList/ErrorListWindow.cs
@@ -93,7 +93,7 @@ public class ErrorListWindow : Window
 
         Content = grid;
 
-        Activated += delegate { buttonCancel.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, buttonCancel); // hack to make OnKeyDown work
 
         KeyDown += (s, e) => vm.OnKeyDown(e);
     }

--- a/src/ui/Features/Shared/FindText/FindTextWindow.cs
+++ b/src/ui/Features/Shared/FindText/FindTextWindow.cs
@@ -63,7 +63,7 @@ public class FindTextWindow : Window
 
         Content = grid;
         
-        Activated += delegate { textBoxSearch.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, textBoxSearch); // hack to make OnKeyDown work
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 

--- a/src/ui/Features/Shared/FormatLimitWarning/FormatLimitWarningWindow.cs
+++ b/src/ui/Features/Shared/FormatLimitWarning/FormatLimitWarningWindow.cs
@@ -100,7 +100,7 @@ public class FormatLimitWarningWindow : Window
         Content = panel;
 
         // Cancel is the safe default: Enter must not accidentally commit a lossy save.
-        Activated += delegate { buttonCancel.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, buttonCancel);
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 

--- a/src/ui/Features/Shared/FullScreenVideoPlayer.cs
+++ b/src/ui/Features/Shared/FullScreenVideoPlayer.cs
@@ -210,7 +210,7 @@ public class FullScreenVideoWindow : Window
         // back to the docked player.
         Closed += (_, _) => videoPlayer.CloseAndDisposePlayer();
 
-        Activated += delegate { Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, () => { Focus(); }); // hack to make OnKeyDown work
         Loaded += async(_, _) =>
         {
             WindowState = WindowState.Maximized;

--- a/src/ui/Features/Shared/GetAudioClips/GetAudioClipsWindow.cs
+++ b/src/ui/Features/Shared/GetAudioClips/GetAudioClipsWindow.cs
@@ -51,7 +51,7 @@ public class GetAudioClipsWindow : Window
             }
         };
 
-        Activated += delegate { buttonCancel.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, buttonCancel); // hack to make OnKeyDown work
 
         // Loaded, not Activated: Activated fires again every time the window regains focus, which
         // started a second extraction loop from line one on top of the running one (#13777).

--- a/src/ui/Features/Shared/GoToLineNumber/GoToLineNumberWindow.cs
+++ b/src/ui/Features/Shared/GoToLineNumber/GoToLineNumberWindow.cs
@@ -67,7 +67,7 @@ public class GoToLineNumberWindow : Window
 
         Content = contentPanel;
 
-        Activated += delegate { vm.Activated(); };
+        UiUtil.FocusOnFirstActivation(this, () => { vm.Activated(); });
         KeyDown += (_, args) => vm.OnKeyDown(args);
     }
 }

--- a/src/ui/Features/Shared/MessageBox.cs
+++ b/src/ui/Features/Shared/MessageBox.cs
@@ -59,7 +59,6 @@ public class MessageBox : Window
     private readonly StackPanel _buttonPanel;
     private readonly KeyPressTracker _enterTracker = new();
     private readonly KeyPressTracker _spaceTracker = new();
-    private bool _initialFocusDone;
     private long _openedTimestamp;
 
     private bool IsInStartupGuardPeriod()
@@ -342,16 +341,12 @@ public class MessageBox : Window
         }, RoutingStrategies.Tunnel);
         Activated += delegate
         {
-            // Re-arm the guard on every activation (alt-tabbing back can bring a held key's
-            // auto-repeat along), but move focus only the first time so arrow-key navigation
-            // survives a focus round-trip to another window.
+            // Re-armed on every activation: alt-tabbing back can bring a held key's auto-repeat
+            // along. The initial focus below is deliberately not part of this - it must happen
+            // once, so arrow-key navigation survives a focus round-trip to another window.
             _openedTimestamp = Stopwatch.GetTimestamp();
-            if (!_initialFocusDone)
-            {
-                _initialFocusDone = true;
-                buttonPanel.Children[0].Focus();
-            }
         };
+        UiUtil.FocusOnFirstActivation(this, () => buttonPanel.Children[0].Focus());
         Deactivated += delegate
         {
             // Key releases go to the newly focused window, so presses counted here would

--- a/src/ui/Features/Shared/OpenOriginalMismatch/OpenOriginalMismatchWindow.cs
+++ b/src/ui/Features/Shared/OpenOriginalMismatch/OpenOriginalMismatchWindow.cs
@@ -110,7 +110,7 @@ public class OpenOriginalMismatchWindow : Window
             },
         };
 
-        Activated += delegate { radioMatching.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, radioMatching); // hack to make OnKeyDown work
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 

--- a/src/ui/Features/Shared/PickAlignment/PickAlignmentWindow.cs
+++ b/src/ui/Features/Shared/PickAlignment/PickAlignmentWindow.cs
@@ -69,7 +69,7 @@ public class PickAlignmentWindow : Window
 
         Content = grid;
 
-        Activated += delegate { buttonAn2.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, buttonAn2); // hack to make OnKeyDown work
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Shared/PickFontName/PickFontNameWindow.cs
+++ b/src/ui/Features/Shared/PickFontName/PickFontNameWindow.cs
@@ -127,7 +127,7 @@ public class PickFontNameWindow : Window
 
         Content = grid;
 
-        Activated += delegate { textBoxSearch.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, textBoxSearch); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 

--- a/src/ui/Features/Shared/PickLanguage/PickLanguageWindow.cs
+++ b/src/ui/Features/Shared/PickLanguage/PickLanguageWindow.cs
@@ -92,7 +92,7 @@ public class PickLanguageWindow : Window
 
         Content = grid;
 
-        Activated += delegate { textBoxSearch.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, textBoxSearch);
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Shared/PickLayer/PickLayerWindow.cs
+++ b/src/ui/Features/Shared/PickLayer/PickLayerWindow.cs
@@ -76,7 +76,7 @@ public class PickLayerWindow : Window
 
         Content = grid;
 
-        Activated += delegate { upDownLayer.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, upDownLayer); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Shared/PickMp4Track/PickMp4TrackWindow.cs
+++ b/src/ui/Features/Shared/PickMp4Track/PickMp4TrackWindow.cs
@@ -67,10 +67,10 @@ public class PickMp4TrackWindow : Window
 
         Content = grid;
 
-        Activated += delegate
+        UiUtil.FocusOnFirstActivation(this, () =>
         {
             buttonOk.Focus(); // hack to make OnKeyDown work
-        };
+        });
     }
 
     protected override void OnLoaded(RoutedEventArgs e)

--- a/src/ui/Features/Shared/PickRuleProfile/PickRuleProfileWindow.cs
+++ b/src/ui/Features/Shared/PickRuleProfile/PickRuleProfileWindow.cs
@@ -59,13 +59,13 @@ public class PickRuleProfileWindow : Window
 
         Content = grid;
 
-        Activated += delegate
+        UiUtil.FocusOnFirstActivation(this, () =>
         {
             if (_profileGrid != null)
             {
                 TableViewExtras.FocusRow(_profileGrid); // hack to make OnKeyDown work
             }
-        };
+        });
         KeyDown += vm.KeyDown;
     }
 

--- a/src/ui/Features/Shared/PickSpellCheckDictionary/PickSpellCheckDictionaryWindow.cs
+++ b/src/ui/Features/Shared/PickSpellCheckDictionary/PickSpellCheckDictionaryWindow.cs
@@ -70,7 +70,7 @@ public class PickSpellCheckDictionaryWindow : Window
 
         Content = grid;
 
-        Activated += delegate { combo.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, combo); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Shared/PickSubtitleFormat/PickSubtitleFormatWindow.cs
+++ b/src/ui/Features/Shared/PickSubtitleFormat/PickSubtitleFormatWindow.cs
@@ -105,10 +105,10 @@ public class PickSubtitleFormatWindow : Window
 
         Content = grid;
 
-        Activated += delegate
+        UiUtil.FocusOnFirstActivation(this, () =>
         {
             textBoxSearch.Focus();
-        };
+        });
         
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }

--- a/src/ui/Features/Shared/PickTeletextAlignment/PickTeletextAlignmentWindow.cs
+++ b/src/ui/Features/Shared/PickTeletextAlignment/PickTeletextAlignmentWindow.cs
@@ -125,7 +125,7 @@ public class PickTeletextAlignmentWindow : Window
 
         Content = grid;
 
-        Activated += delegate { lineBox.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, lineBox);
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 

--- a/src/ui/Features/Shared/PickTeletextColor/PickTeletextColorWindow.cs
+++ b/src/ui/Features/Shared/PickTeletextColor/PickTeletextColorWindow.cs
@@ -59,7 +59,7 @@ public class PickTeletextColorWindow : Window
 
         Content = panel;
 
-        Activated += delegate { buttonCancel.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, buttonCancel);
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 

--- a/src/ui/Features/Shared/PickTsTrack/PickTsTrackWindow.cs
+++ b/src/ui/Features/Shared/PickTsTrack/PickTsTrackWindow.cs
@@ -60,10 +60,10 @@ public class PickTsTrackWindow : Window
 
         Content = grid;
 
-        Activated += delegate
+        UiUtil.FocusOnFirstActivation(this, () =>
         {
             buttonOk.Focus(); // hack to make OnKeyDown work
-        };
+        });
 
         Loaded += (_, _) => vm.SelectAndScrollToRow(0);
         KeyDown += (_, e) => vm.OnKeyDown(e);

--- a/src/ui/Features/Shared/PromptCheckBox/PromptCheckBoxWindow.cs
+++ b/src/ui/Features/Shared/PromptCheckBox/PromptCheckBoxWindow.cs
@@ -51,7 +51,7 @@ public class PromptCheckBoxWindow : Window
 
         Content = grid;
 
-        Activated += delegate { checkBox.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, checkBox); // hack to make OnKeyDown work
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Shared/PromptFileSaved/PromptFileSavedWindow.cs
+++ b/src/ui/Features/Shared/PromptFileSaved/PromptFileSavedWindow.cs
@@ -145,7 +145,7 @@ public class PromptFileSavedWindow : Window
 
         Content = grid;
 
-        Activated += delegate { buttonDone.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, buttonDone); // hack to make OnKeyDown work
         KeyDown += (s, e) => vm.OnKeyDown(e);
     }
 

--- a/src/ui/Features/Shared/PromptTextBox/PromptTextBoxWindow.cs
+++ b/src/ui/Features/Shared/PromptTextBox/PromptTextBoxWindow.cs
@@ -59,7 +59,7 @@ public class PromptTextBoxWindow : Window
 
         Content = grid;
 
-        Activated += delegate { textBox.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, textBox); // hack to make OnKeyDown work
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Shared/SetVideoOffset/SetVideoOffsetWindow.cs
+++ b/src/ui/Features/Shared/SetVideoOffset/SetVideoOffsetWindow.cs
@@ -86,7 +86,7 @@ public class SetVideoOffsetWindow : Window
 
         Content = contentPanel;
 
-        Activated += delegate { timeCodeUpDownOffset.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, timeCodeUpDownOffset);
         KeyDown += (sender, args) => vm.OnKeyDown(args);
     }
 }

--- a/src/ui/Features/Shared/WaveformGuessTimeCodes/WaveformGuessTimeCodesWindow.cs
+++ b/src/ui/Features/Shared/WaveformGuessTimeCodes/WaveformGuessTimeCodesWindow.cs
@@ -49,7 +49,7 @@ public class WaveformGuessTimeCodesWindow : Window
 
         Content = grid;
 
-        Activated += delegate { radioStartFromVideoPosition.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, radioStartFromVideoPosition); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += vm.KeyDown;
     }
 

--- a/src/ui/Features/Shared/WaveformSeekSilence/WaveformSeekSilenceWindow.cs
+++ b/src/ui/Features/Shared/WaveformSeekSilence/WaveformSeekSilenceWindow.cs
@@ -67,7 +67,7 @@ public class WaveformSeekSilenceWindow : Window
 
         Content = grid;
 
-        Activated += delegate { checkBoxSeekForward.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, checkBoxSeekForward); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += vm.KeyDown;
     }
 }

--- a/src/ui/Features/SpellCheck/EditWholeText/EditWholeTextWindow.cs
+++ b/src/ui/Features/SpellCheck/EditWholeText/EditWholeTextWindow.cs
@@ -69,7 +69,7 @@ public class EditWholeTextWindow : Window
 
         Content = grid;
 
-        Activated += delegate { textBoxWholeText.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, textBoxWholeText); // hack to make OnKeyDown work
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/SpellCheck/FindDoubleLines/FindDoubleLinesWindow.cs
+++ b/src/ui/Features/SpellCheck/FindDoubleLines/FindDoubleLinesWindow.cs
@@ -50,7 +50,7 @@ public class FindDoubleLinesWindow : Window
 
         Content = grid;
 
-        Activated += delegate { buttonCancel.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, buttonCancel); // hack to make OnKeyDown work
 
         KeyDown += (s, e) => vm.OnKeyDown(e);
 

--- a/src/ui/Features/SpellCheck/FindDoubleWords/FindDoubleWordsWindow.cs
+++ b/src/ui/Features/SpellCheck/FindDoubleWords/FindDoubleWordsWindow.cs
@@ -50,7 +50,7 @@ public class FindDoubleWordsWindow : Window
 
         Content = grid;
 
-        Activated += delegate { buttonCancel.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, buttonCancel); // hack to make OnKeyDown work
 
         KeyDown += (s, e) => vm.OnKeyDown(e);
 

--- a/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesWindow.cs
+++ b/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesWindow.cs
@@ -52,7 +52,7 @@ public class GetDictionariesWindow : Window
             Padding = new Thickness(4),
         };
 
-        Activated += delegate { downloadButton.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, downloadButton); // hack to make OnKeyDown work
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 

--- a/src/ui/Features/SpellCheck/SpellCheckCompletedWindow.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckCompletedWindow.cs
@@ -107,7 +107,7 @@ public class SpellCheckCompletedWindow : Window
 
         Content = grid;
 
-        Activated += delegate { buttonDone.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, buttonDone); // hack to make OnKeyDown work
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 

--- a/src/ui/Features/SpellCheck/SpellCheckWindow.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckWindow.cs
@@ -149,7 +149,7 @@ public class SpellCheckWindow : Window
 
         Content = grid;
 
-        Activated += delegate { buttonDone.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, buttonDone); // hack to make OnKeyDown work
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 

--- a/src/ui/Features/Ssa/SsaAttachmentsWindow.cs
+++ b/src/ui/Features/Ssa/SsaAttachmentsWindow.cs
@@ -70,7 +70,7 @@ public class SsaAttachmentsWindow : Window
         Content = grid;
 
         // initial focus on an input, not an action button - a focused button clicks on bare Space
-        Activated += delegate { TableViewExtras.FocusRow(attachmentsGrid); };
+        UiUtil.FocusOnFirstActivation(this, () => { TableViewExtras.FocusRow(attachmentsGrid); });
         KeyDown += vm.KeyDown;
 
         Closing += delegate { UiUtil.SaveWindowPosition(this); };

--- a/src/ui/Features/Ssa/SsaPropertiesWindow.cs
+++ b/src/ui/Features/Ssa/SsaPropertiesWindow.cs
@@ -54,7 +54,7 @@ public class SsaPropertiesWindow : Window
         Content = grid;
 
         // initial focus on an input, not an action button - a focused button clicks on bare Space
-        Activated += delegate { textBoxTitle.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, textBoxTitle);
         KeyDown += vm.KeyDown;
     }
 

--- a/src/ui/Features/Ssa/SsaStylesWindow.cs
+++ b/src/ui/Features/Ssa/SsaStylesWindow.cs
@@ -65,7 +65,7 @@ public class SsaStylesWindow : Window
         Content = grid;
 
         // initial focus on an input, not an action button - a focused button clicks on bare Space
-        Activated += delegate { TableViewExtras.FocusRow(vm.FileStyleGrid); };
+        UiUtil.FocusOnFirstActivation(this, () => { TableViewExtras.FocusRow(vm.FileStyleGrid); });
         KeyDown += vm.KeyDown;
 
         Closing += delegate { UiUtil.SaveWindowPosition(this); };

--- a/src/ui/Features/Sync/ChangeFrameRate/ChangeFrameRateWindow.cs
+++ b/src/ui/Features/Sync/ChangeFrameRate/ChangeFrameRateWindow.cs
@@ -93,7 +93,7 @@ public class ChangeFrameRateWindow : Window
 
         Content = grid;
         
-        Activated += delegate { comboFromFrameRate.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, comboFromFrameRate); // initial focus on an input, not an action button - a focused button clicks on bare Space
         Loaded += (_, _) => UiUtil.RestoreWindowPosition(this);
         Closing += (_, _) => UiUtil.SaveWindowPosition(this);
         KeyDown += (_, e) => vm.OnKeyDown(e);

--- a/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedWindow.cs
+++ b/src/ui/Features/Sync/ChangeSpeed/ChangeSpeedWindow.cs
@@ -116,7 +116,7 @@ public class ChangeSpeedWindow : Window
 
         Content = grid;
 
-        Activated += delegate { buttonDone.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, buttonDone); // hack to make OnKeyDown work
         Loaded += (_, _) => UiUtil.RestoreWindowPosition(this);
         Closing += (_, _) => UiUtil.SaveWindowPosition(this);
         KeyDown += (_, e) => vm.OnKeyDown(e);

--- a/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointWindow.cs
+++ b/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointWindow.cs
@@ -209,7 +209,7 @@ public class SetSyncPointWindow : Window
         // Focus the time code box, not a button, so the window receives key events without arming
         // any button: a focused button fires OnClick on bare Space, and "Set sync point" used to be
         // focused here - so the first Space a user pressed closed the dialog instead of playing.
-        Activated += delegate { vm.FocusTimeCodeUpDown(); };
+        UiUtil.FocusOnFirstActivation(this, () => { vm.FocusTimeCodeUpDown(); });
 
         AddHandler(KeyDownEvent, vm.OnKeyDownHandler, RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: false);
 

--- a/src/ui/Features/Sync/VisualSync/ManualSyncWindow.cs
+++ b/src/ui/Features/Sync/VisualSync/ManualSyncWindow.cs
@@ -57,7 +57,7 @@ public class ManualSyncWindow : Window
 
         Content = grid;
 
-        Activated += delegate { numericUpDownOffsetSeconds.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, numericUpDownOffsetSeconds); // initial focus on an input, not an action button - a focused button clicks on bare Space
         Loaded += (_, _) => UiUtil.RestoreWindowPosition(this);
         Closing += (_, _) => UiUtil.SaveWindowPosition(this);
         KeyDown += (_, e) => vm.OnKeyDown(e);

--- a/src/ui/Features/Sync/VisualSync/VisualSyncWindow.cs
+++ b/src/ui/Features/Sync/VisualSync/VisualSyncWindow.cs
@@ -215,7 +215,7 @@ public class VisualSyncWindow : Window
 
         Content = grid;
 
-        Activated += delegate { comboBoxLeft.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, comboBoxLeft); // initial focus on an input, not an action button - a focused button clicks on bare Space
 
         AddHandler(KeyDownEvent, vm.OnKeyDownHandler, RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: false);
         Loaded += (_, _) => vm.OnLoaded();

--- a/src/ui/Features/Tools/AdjustDuration/AdjustDurationWindow.cs
+++ b/src/ui/Features/Tools/AdjustDuration/AdjustDurationWindow.cs
@@ -95,7 +95,7 @@ public class AdjustDurationWindow : Window
 
         Content = grid;
 
-        Activated += delegate { combo.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, combo); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 

--- a/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsWindow.cs
+++ b/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsWindow.cs
@@ -63,7 +63,7 @@ public class ApplyDurationLimitsWindow : Window
 
         Content = grid;
 
-        Activated += delegate { _checkBoxFixMinDuration.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, _checkBoxFixMinDuration); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += vm.KeyDown;
 
         Closing += delegate { UiUtil.SaveWindowPosition(this); };

--- a/src/ui/Features/Tools/ApplyMinGap/ApplyMinGapWindow.cs
+++ b/src/ui/Features/Tools/ApplyMinGap/ApplyMinGapWindow.cs
@@ -64,7 +64,7 @@ public class ApplyMinGapWindow : Window
 
         Content = grid;
 
-        Activated += delegate { numericUpDownMinGap.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, numericUpDownMinGap); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
 
         Closing += delegate { UiUtil.SaveWindowPosition(this); };

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertFixCommonErrorsSettingsWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertFixCommonErrorsSettingsWindow.cs
@@ -58,7 +58,7 @@ public class BatchConvertFixCommonErrorsSettingsWindow : Window
         grid.Add(panelButtons, 1, 0);
         Content = grid;
 
-        Activated += delegate { comboProfile.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, comboProfile); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsWindow.cs
@@ -209,7 +209,7 @@ public class BatchConvertSettingsWindow : Window
 
         Content = grid;
 
-        Activated += delegate { comboBoxTargetEncoding.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, comboBoxTargetEncoding); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (s, e) => vm.OnKeyDown(e);
     }
 

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertWindow.cs
@@ -116,7 +116,7 @@ public class BatchConvertWindow : Window
 
         Content = grid;
 
-        Activated += delegate { buttonDone.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, buttonDone); // hack to make OnKeyDown work
         Loaded += vm.Onloaded;
         Closing += vm.OnClosing;
         KeyDown += (s, e) => vm.OnKeyDown(e);

--- a/src/ui/Features/Tools/BatchConvert/BatchErrorList/BatchErrorListWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchErrorList/BatchErrorListWindow.cs
@@ -85,7 +85,7 @@ public class BatchErrorListWindow : Window
 
         Content = grid;
 
-        Activated += delegate { buttonCancel.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, buttonCancel); // hack to make OnKeyDown work
 
         KeyDown += (s, e) => vm.OnKeyDown(e);
     }

--- a/src/ui/Features/Tools/BeautifyTimeCodes/Profile/BeautifyTimeCodesProfileWindow.cs
+++ b/src/ui/Features/Tools/BeautifyTimeCodes/Profile/BeautifyTimeCodesProfileWindow.cs
@@ -80,7 +80,7 @@ public class BeautifyTimeCodesProfileWindow : Window
         outerGrid.Add(buttonBar, 1, 0);
         Content = outerGrid;
 
-        Activated += delegate { ok.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, ok);
         KeyDown += (_, e) => vm.OnKeyDown(e);
 
         // Push initial values into the preview controls once they're attached

--- a/src/ui/Features/Tools/BridgeGaps/BridgeGapsWindow.cs
+++ b/src/ui/Features/Tools/BridgeGaps/BridgeGapsWindow.cs
@@ -78,7 +78,7 @@ public class BridgeGapsWindow : Window
 
         Content = grid;
 
-        Activated += delegate { numericUpDownBridgeGapSmallerThan.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, numericUpDownBridgeGapSmallerThan); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
 
         Closing += delegate { UiUtil.SaveWindowPosition(this); };

--- a/src/ui/Features/Tools/ChangeCasing/ChangeCasingWindow.cs
+++ b/src/ui/Features/Tools/ChangeCasing/ChangeCasingWindow.cs
@@ -104,7 +104,7 @@ public class ChangeCasingWindow : Window
 
         Content = grid;
 
-        Activated += delegate { radioButtonNormalCasing.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, radioButtonNormalCasing); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Tools/ChangeFormatting/ChangeFormattingWindow.cs
+++ b/src/ui/Features/Tools/ChangeFormatting/ChangeFormattingWindow.cs
@@ -78,7 +78,7 @@ public class ChangeFormattingWindow : Window
 
         Content = grid;
 
-        Activated += delegate { comboBoxFrom.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, comboBoxFrom); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
 
         Closing += delegate { UiUtil.SaveWindowPosition(this); };

--- a/src/ui/Features/Tools/ConvertActors/ConvertActorsWindow.cs
+++ b/src/ui/Features/Tools/ConvertActors/ConvertActorsWindow.cs
@@ -130,7 +130,7 @@ public class ConvertActorsWindow : Window
 
         Content = grid;
 
-        Activated += delegate { comboBoxFrom.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, comboBoxFrom); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
 
         Closing += delegate { UiUtil.SaveWindowPosition(this); };

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsLogWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsLogWindow.cs
@@ -73,7 +73,7 @@ public class FixCommonErrorsLogWindow : Window
 
         Content = grid;
 
-        Activated += delegate { buttonDone.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, buttonDone);
         KeyDown += (s, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsProfileWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsProfileWindow.cs
@@ -132,7 +132,7 @@ public class FixCommonErrorsProfileWindow : Window
 
         Content = grid;
 
-        Activated += delegate { Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, () => { Focus(); }); // hack to make OnKeyDown work
     }
 
     protected override void OnKeyDown(KeyEventArgs e)

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
@@ -357,7 +357,7 @@ public class FixCommonErrorsWindow : Window
             }
         };
 
-        Activated += delegate { FocusStepButton(); };
+        UiUtil.FocusOnFirstActivation(this, () => { FocusStepButton(); });
 
         Closing += delegate { UiUtil.SaveWindowPosition(this); };
         Loaded += delegate { UiUtil.RestoreWindowPosition(this); };

--- a/src/ui/Features/Tools/FixNetflixErrors/FixNetflixErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixNetflixErrors/FixNetflixErrorsWindow.cs
@@ -86,7 +86,7 @@ public class FixNetflixErrorsWindow : Window
 
         Content = grid;
 
-        Activated += delegate { _comboBoxLanguage.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, _comboBoxLanguage); // initial focus on an input, not an action button - a focused button clicks on bare Space
 
         Closing += delegate { UiUtil.SaveWindowPosition(this); };
         Loaded += delegate { UiUtil.RestoreWindowPosition(this); };

--- a/src/ui/Features/Tools/JoinSubtitles/JoinSubtitlesWindow.cs
+++ b/src/ui/Features/Tools/JoinSubtitles/JoinSubtitlesWindow.cs
@@ -57,7 +57,7 @@ public class JoinSubtitlesWindow : Window
 
         Content = grid;
 
-        Activated += delegate { TableViewExtras.FocusRow(_tableViewFiles); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, () => { TableViewExtras.FocusRow(_tableViewFiles); }); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += vm.KeyDown;
     }
 

--- a/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesWindow.cs
+++ b/src/ui/Features/Tools/MergeContinuationLines/MergeContinuationLinesWindow.cs
@@ -61,7 +61,7 @@ public class MergeContinuationLinesWindow : Window
 
         Content = grid;
 
-        Activated += delegate { _numericGap.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, _numericGap); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += vm.KeyDown;
         Loaded += delegate { vm.Loaded(); };
 

--- a/src/ui/Features/Tools/MergeShortLines/MergeShortLinesWindow.cs
+++ b/src/ui/Features/Tools/MergeShortLines/MergeShortLinesWindow.cs
@@ -54,7 +54,7 @@ public class MergeShortLinesWindow : Window
 
         Content = grid;
 
-        Activated += delegate { _numericUpDownSingleLineMaxLength.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, _numericUpDownSingleLineMaxLength); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += vm.KeyDown;
         Loaded += delegate { vm.Loaded(); };
 

--- a/src/ui/Features/Tools/MergeSubtitlesWithSameText/MergeSameTextWindow.cs
+++ b/src/ui/Features/Tools/MergeSubtitlesWithSameText/MergeSameTextWindow.cs
@@ -60,7 +60,7 @@ public class MergeSameTextWindow : Window
 
         Content = grid;
 
-        Activated += delegate { buttonCancel.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, buttonCancel); // hack to make OnKeyDown work
         KeyDown += vm.OnKeyDown;
 
         Closing += delegate { UiUtil.SaveWindowPosition(this); };

--- a/src/ui/Features/Tools/MergeSubtitlesWithSameTimeCodes/MergeSameTimeCodesWindow.cs
+++ b/src/ui/Features/Tools/MergeSubtitlesWithSameTimeCodes/MergeSameTimeCodesWindow.cs
@@ -65,7 +65,7 @@ public class MergeSameTimeCodesWindow : Window
 
         Content = grid;
 
-        Activated += delegate { _numericUpDownMaxDiff.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, _numericUpDownMaxDiff); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += _vm.OnKeyDown;
 
         Closing += delegate { UiUtil.SaveWindowPosition(this); };

--- a/src/ui/Features/Tools/MergeTwoSubtitles/MergeTwoSubtitlesWindow.cs
+++ b/src/ui/Features/Tools/MergeTwoSubtitles/MergeTwoSubtitlesWindow.cs
@@ -77,14 +77,14 @@ public class MergeTwoSubtitlesWindow : Window
 
         Content = grid;
 
-        Activated += delegate
+        UiUtil.FocusOnFirstActivation(this, () =>
         {
             // initial focus on an input, not an action button - a focused button clicks on bare Space
             if (_tableViewSubtitle1 != null)
             {
                 TableViewExtras.FocusRow(_tableViewSubtitle1);
             }
-        };
+        });
         KeyDown += vm.KeyDown;
     }
 

--- a/src/ui/Features/Tools/RemoveTextForHearingImpaired/InterjectionsWindow.cs
+++ b/src/ui/Features/Tools/RemoveTextForHearingImpaired/InterjectionsWindow.cs
@@ -86,7 +86,7 @@ public class InterjectionsWindow : Window
 
         Content = grid;
         
-        Activated += delegate { textBoxInterjections.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, textBoxInterjections); // initial focus on an input, not an action button - a focused button clicks on bare Space
     }
 
     protected override void OnKeyDown(KeyEventArgs e)

--- a/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
+++ b/src/ui/Features/Tools/RemoveTextForHearingImpaired/RemoveTextForHearingImpairedWindow.cs
@@ -82,7 +82,7 @@ public class RemoveTextForHearingImpairedWindow : Window
 
         Content = grid;
 
-        Activated += delegate { (vm.IsApplyVisible ? buttonDone : buttonOk).Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, () => { (vm.IsApplyVisible ? buttonDone : buttonOk).Focus(); }); // hack to make OnKeyDown work
 
         Closing += delegate { UiUtil.SaveWindowPosition(this); };
         Loaded += delegate { UiUtil.RestoreWindowPosition(this); };

--- a/src/ui/Features/Tools/RemoveUnicodeCharacters/RemoveUnicodeCharactersWindow.cs
+++ b/src/ui/Features/Tools/RemoveUnicodeCharacters/RemoveUnicodeCharactersWindow.cs
@@ -166,7 +166,7 @@ public class RemoveUnicodeCharactersWindow : Window
 
         Content = grid;
 
-        Activated += delegate { TableViewExtras.FocusRow(dataGrid); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, () => { TableViewExtras.FocusRow(dataGrid); }); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesWindow.cs
+++ b/src/ui/Features/Tools/SplitBreakLongLines/SplitBreakLongLinesWindow.cs
@@ -59,7 +59,7 @@ public class SplitBreakLongLinesWindow : Window
 
         Content = grid;
 
-        Activated += delegate { _checkBoxSplitLongLines.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, _checkBoxSplitLongLines); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += vm.KeyDown;
         Loaded += (_, _)  => vm.Loaded();
 

--- a/src/ui/Features/Tools/SplitSubtitle/PartsSavedWindow.cs
+++ b/src/ui/Features/Tools/SplitSubtitle/PartsSavedWindow.cs
@@ -53,7 +53,7 @@ public class PartsSavedWindow : Window
 
         Content = grid;
 
-        Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, buttonOk); // hack to make OnKeyDown work
     }
 
 

--- a/src/ui/Features/Tools/SplitSubtitle/SplitSubtitleWindow.cs
+++ b/src/ui/Features/Tools/SplitSubtitle/SplitSubtitleWindow.cs
@@ -58,7 +58,7 @@ public class SplitSubtitleWindow : Window
 
         Content = grid;
 
-        Activated += delegate { _textBoxOutputFolder.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, _textBoxOutputFolder); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += vm.KeyDown;
     }
 

--- a/src/ui/Features/Translate/AutoTranslateWindow.cs
+++ b/src/ui/Features/Translate/AutoTranslateWindow.cs
@@ -1,4 +1,4 @@
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
@@ -26,7 +26,6 @@ public class AutoTranslateWindow : Window
     private readonly AutoTranslateViewModel _vm;
     private Button? _buttonTranslate;
     private Button? _buttonOk;
-    private bool _initialFocusDone;
 
     public AutoTranslateWindow(AutoTranslateViewModel vm)
     {
@@ -75,17 +74,10 @@ public class AutoTranslateWindow : Window
 
         Loaded += (s, e) => UiUtil.RestoreWindowPosition(this);
 
-        Activated += delegate
-        {
-            // Start out on the accented button so it is selected, not just coloured like it -
-            // Enter then starts the translation right away. Only the first activation: coming
-            // back from a dialog must not pull focus away from where the user left it.
-            if (!_initialFocusDone)
-            {
-                _initialFocusDone = true;
-                _buttonTranslate?.Focus();
-            }
-        };
+        // Start out on the accented button so it is selected, not just coloured like it - Enter
+        // then starts the translation right away. First activation only: coming back from a
+        // dialog must not pull focus away from where the user left it.
+        UiUtil.FocusOnFirstActivation(this, () => _buttonTranslate?.Focus());
     }
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/src/ui/Features/Translate/CopyPasteTranslateBlockWindow.cs
+++ b/src/ui/Features/Translate/CopyPasteTranslateBlockWindow.cs
@@ -60,7 +60,7 @@ public class CopyPasteTranslateBlockWindow : Window
 
         Content = grid;
 
-        Activated += delegate { buttonCancel.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, buttonCancel); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += vm.KeyDown;
         Loaded += vm.Loaded;
     }

--- a/src/ui/Features/Translate/CopyPasteTranslateWindow.cs
+++ b/src/ui/Features/Translate/CopyPasteTranslateWindow.cs
@@ -53,7 +53,7 @@ public class CopyPasteTranslateWindow : Window
 
         Content = grid;
 
-        Activated += delegate { TableViewExtras.FocusRow(vm.SubtitleGrid); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, () => { TableViewExtras.FocusRow(vm.SubtitleGrid); }); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += vm.KeyDown;
     }
 

--- a/src/ui/Features/Translate/DownloadLlamaCppWindow.cs
+++ b/src/ui/Features/Translate/DownloadLlamaCppWindow.cs
@@ -59,7 +59,7 @@ public class DownloadLlamaCppWindow : Window
             }
         };
 
-        Activated += delegate { buttonCancel.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, buttonCancel);
         KeyDown += (s, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Translate/LlamaCppEngineSettings/LlamaCppEngineSettingsWindow.cs
+++ b/src/ui/Features/Translate/LlamaCppEngineSettings/LlamaCppEngineSettingsWindow.cs
@@ -32,7 +32,7 @@ public class LlamaCppEngineSettingsWindow : Window
         Content = BuildContent(vm);
 
         var ok = UiUtil.MakeButtonOk(vm.OkCommand);
-        Activated += delegate { ok.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, ok);
     }
 
     private static Border BuildContent(LlamaCppEngineSettingsViewModel vm)

--- a/src/ui/Features/Translate/TranslateSettingsWindow.cs
+++ b/src/ui/Features/Translate/TranslateSettingsWindow.cs
@@ -71,7 +71,9 @@ public class TranslateSettingsWindow : Window
         var promptTextBox = new TextBox
         {
             AcceptsReturn = true,
-            AcceptsTab = true,
+            // A tab is not meaningful in a translation prompt, and accepting it trapped the
+            // keyboard in this box - Tab could not reach the buttons below (#14313).
+            AcceptsTab = false,
             VerticalAlignment = VerticalAlignment.Stretch,
             HorizontalAlignment = HorizontalAlignment.Stretch,
             Width = double.NaN,
@@ -137,7 +139,7 @@ public class TranslateSettingsWindow : Window
 
         Content = grid;
 
-        Activated += delegate { comboMerge.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, comboMerge); // initial focus on an input, not an action button - a focused button clicks on bare Space
         Loaded += vm.Onloaded;
         Closing += vm.OnClosing;
     }

--- a/src/ui/Features/Translate/TranslationErrorWindow.cs
+++ b/src/ui/Features/Translate/TranslationErrorWindow.cs
@@ -126,7 +126,7 @@ public class TranslationErrorWindow : Window
 
         Content = content;
 
-        Activated += delegate { buttonOk.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, buttonOk);
     }
 
     protected override void OnKeyDown(KeyEventArgs e)

--- a/src/ui/Features/Video/BlankVideo/BlankVideoWindow.cs
+++ b/src/ui/Features/Video/BlankVideo/BlankVideoWindow.cs
@@ -64,7 +64,7 @@ public class BlankVideoWindow : Window
 
         Content = grid;
 
-        Activated += delegate { _numericUpDownDuration?.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, () => { _numericUpDownDuration?.Focus(); }); // initial focus on an input, not an action button - a focused button clicks on bare Space
     }
 
     private Border MakeVideoSettingsView(BlankVideoViewModel vm)

--- a/src/ui/Features/Video/BurnIn/BurnInEffectWindow.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInEffectWindow.cs
@@ -92,7 +92,7 @@ public class BurnInEffectWindow : Window
 
         Content = grid;
 
-        Activated += delegate { (checkBoxPanel.Children.Count > 0 ? checkBoxPanel.Children[0] : buttonCancel).Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, () => { (checkBoxPanel.Children.Count > 0 ? checkBoxPanel.Children[0] : buttonCancel).Focus(); }); // initial focus on an input, not an action button - a focused button clicks on bare Space
     }
 
     protected override void OnLoaded(RoutedEventArgs e)

--- a/src/ui/Features/Video/BurnIn/BurnInLogoWindow.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInLogoWindow.cs
@@ -234,7 +234,7 @@ public class BurnInLogoWindow : Window
 
         Content = grid;
 
-        Activated += delegate { sliderAlpha.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, sliderAlpha); // initial focus on an input, not an action button - a focused button clicks on bare Space
     }
 
     protected override void OnLoaded(RoutedEventArgs e)

--- a/src/ui/Features/Video/BurnIn/BurnInResolutionPickerWindow.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInResolutionPickerWindow.cs
@@ -129,7 +129,7 @@ public class BurnInResolutionPickerWindow : Window
 
         Content = grid;
 
-        Activated += delegate { listBoxResolutions.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, listBoxResolutions); // initial focus on an input, not an action button - a focused button clicks on bare Space
     }
 
     protected override void OnKeyDown(KeyEventArgs e)

--- a/src/ui/Features/Video/BurnIn/BurnInSettingsWindow.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInSettingsWindow.cs
@@ -92,7 +92,7 @@ public class BurnInSettingsWindow : Window
 
         Content = grid;
         
-        Activated += delegate { checkBoxUseSourceFolder.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, checkBoxUseSourceFolder); // initial focus on an input, not an action button - a focused button clicks on bare Space
     }
 
     protected override void OnKeyDown(KeyEventArgs e)

--- a/src/ui/Features/Video/BurnIn/BurnInWindow.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInWindow.cs
@@ -196,7 +196,7 @@ public class BurnInWindow : Window
         };
         UpdateGrowAreas();
 
-        Activated += delegate { _comboBoxFontName?.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, () => { _comboBoxFontName?.Focus(); }); // initial focus on an input, not an action button - a focused button clicks on bare Space
         Loaded += (_, _) => vm.Loaded();
         KeyDown += (_, e) => vm.OnKeyDown(e);
 

--- a/src/ui/Features/Video/BurnIn/SelectVideoPositionWindow.cs
+++ b/src/ui/Features/Video/BurnIn/SelectVideoPositionWindow.cs
@@ -58,7 +58,7 @@ public class SelectVideoPositionWindow : Window
 
         Content = grid;
 
-        Activated += delegate { buttonCancel.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, buttonCancel); // initial focus on an input, not an action button - a focused button clicks on bare Space
     }
 
     protected override void OnLoaded(RoutedEventArgs e)

--- a/src/ui/Features/Video/Chapters/ChaptersWindow.cs
+++ b/src/ui/Features/Video/Chapters/ChaptersWindow.cs
@@ -64,7 +64,7 @@ public class ChaptersWindow : Window
 
         Content = grid;
 
-        Activated += delegate { buttonCancel.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, buttonCancel); // hack to make OnKeyDown work
     }
 
     /// <summary>

--- a/src/ui/Features/Video/Chapters/WriteChaptersToVideoWindow.cs
+++ b/src/ui/Features/Video/Chapters/WriteChaptersToVideoWindow.cs
@@ -107,7 +107,7 @@ public class WriteChaptersToVideoWindow : Window
 
         Content = grid;
 
-        Activated += delegate { textBoxOutput.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, textBoxOutput);
     }
 
     /// <summary>

--- a/src/ui/Features/Video/CutVideo/CutVideoWindow.cs
+++ b/src/ui/Features/Video/CutVideo/CutVideoWindow.cs
@@ -95,14 +95,14 @@ public class CutVideoWindow : Window
 
         Content = grid;
 
-        Activated += delegate
+        UiUtil.FocusOnFirstActivation(this, () =>
         {
             // initial focus on an input, not an action button - a focused button clicks on bare Space
             if (vm.SegmentGrid != null)
             {
                 TableViewExtras.FocusRow(vm.SegmentGrid);
             }
-        };
+        });
         Loaded += (s, e) => vm.OnLoaded();
         Closing += (s, e) => vm.OnClosing();
         AddHandler(KeyDownEvent, vm.OnKeyDownHandler, RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: false);

--- a/src/ui/Features/Video/EmbeddedSubtitlesEdit/EmbeddedSubtitlesEditMp4Window.cs
+++ b/src/ui/Features/Video/EmbeddedSubtitlesEdit/EmbeddedSubtitlesEditMp4Window.cs
@@ -82,7 +82,7 @@ public class EmbeddedSubtitlesEditMp4Window : Window
 
         Content = grid;
 
-        Activated += delegate { textBoxVideoFileName.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, textBoxVideoFileName); // initial focus on an input, not an action button - a focused button clicks on bare Space
         Loaded += (s, e) => vm.OnLoaded();
         Closing += (s, e) => vm.OnClosing();
         KeyDown += (s, e) => vm.OnKeyDown(e);

--- a/src/ui/Features/Video/EmbeddedSubtitlesEdit/EmbeddedSubtitlesEditWindow.cs
+++ b/src/ui/Features/Video/EmbeddedSubtitlesEdit/EmbeddedSubtitlesEditWindow.cs
@@ -88,7 +88,7 @@ public class EmbeddedSubtitlesEditWindow : Window
 
         Content = grid;
 
-        Activated += delegate { textBoxVideoFileName.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, textBoxVideoFileName); // initial focus on an input, not an action button - a focused button clicks on bare Space
         Loaded += (s, e) => vm.OnLoaded();
         Closing += (s, e) => vm.OnClosing();
         KeyDown += (s, e) => vm.OnKeyDown(e);

--- a/src/ui/Features/Video/GoToVideoPosition/GoToVideoPositionWindow.cs
+++ b/src/ui/Features/Video/GoToVideoPosition/GoToVideoPositionWindow.cs
@@ -67,7 +67,7 @@ public class GoToVideoPositionWindow : Window
 
         Content = contentPanel;
 
-        Activated += delegate { vm.Activated(); };
+        UiUtil.FocusOnFirstActivation(this, () => { vm.Activated(); });
     }
 
     protected override void OnKeyDown(KeyEventArgs e)

--- a/src/ui/Features/Video/OpenFromUrl/OpenFromUrlWindow.cs
+++ b/src/ui/Features/Video/OpenFromUrl/OpenFromUrlWindow.cs
@@ -1,4 +1,4 @@
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Input;
@@ -122,18 +122,11 @@ public class OpenFromUrlWindow : Window
         // the Loaded + Input-priority post this used to do never stuck on macOS. Guarded so
         // re-activating the window later doesn't yank focus back out of whatever the user
         // was on.
-        var focused = false;
-        Activated += delegate
+        UiUtil.FocusOnFirstActivation(this, () =>
         {
-            if (focused)
-            {
-                return;
-            }
-
-            focused = true;
             _urlTextBox.Focus();
             _urlTextBox.CaretIndex = _urlTextBox.Text?.Length ?? 0;
-        };
+        });
     }
 
     private Button BuildCard(string iconGlyph, string title, string description, string note, IRelayCommand command, bool isRecommended)

--- a/src/ui/Features/Video/OpenSecondarySubtitle/OpenSecondarySubtitleWindow.cs
+++ b/src/ui/Features/Video/OpenSecondarySubtitle/OpenSecondarySubtitleWindow.cs
@@ -117,7 +117,7 @@ public class OpenSecondarySubtitleWindow : Window
         Content = mainGrid;
 
         // initial focus on an input, not an action button - a focused button clicks on bare Space
-        Activated += delegate { numericFontSize.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, numericFontSize);
         AddHandler(KeyDownEvent, (_, e) => vm.OnKeyDown(e),
             RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: false);
         Loaded += (_, _) => vm.OnLoaded();

--- a/src/ui/Features/Video/ReEncodeVideo/ReEncodeVideoWindow.cs
+++ b/src/ui/Features/Video/ReEncodeVideo/ReEncodeVideoWindow.cs
@@ -82,7 +82,7 @@ public class ReEncodeVideoWindow : Window
 
         Content = grid;
 
-        Activated += delegate { _comboBoxFrameRate?.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, () => { _comboBoxFrameRate?.Focus(); }); // initial focus on an input, not an action button - a focused button clicks on bare Space
     }
 
     private Border MakeVideoSettingsView(ReEncodeVideoViewModel vm)

--- a/src/ui/Features/Video/ShotChanges/ShotChangeListWindow.cs
+++ b/src/ui/Features/Video/ShotChanges/ShotChangeListWindow.cs
@@ -56,7 +56,7 @@ public class ShotChangeListWindow : Window
 
         Content = grid;
 
-        Activated += delegate { buttonCancel.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, buttonCancel); // hack to make OnKeyDown work
     }
 
     private static Border MakeBookmarkGridView(ShotChangeListViewModel vm)

--- a/src/ui/Features/Video/ShotChanges/ShotChangesWindow.cs
+++ b/src/ui/Features/Video/ShotChanges/ShotChangesWindow.cs
@@ -75,14 +75,14 @@ public class ShotChangesWindow : Window
 
         Content = grid;
 
-        Activated += delegate
+        UiUtil.FocusOnFirstActivation(this, () =>
         {
             // initial focus on an input, not an action button - a focused button clicks on bare Space
             if (vm.FfmpegLinesGrid != null)
             {
                 TableViewExtras.FocusRow(vm.FfmpegLinesGrid);
             }
-        };
+        });
     }
 
     private static Grid MakeGenerateView(ShotChangesViewModel vm)

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineWindow.cs
@@ -68,10 +68,10 @@ public class DownloadSpeechToTextEngineWindow : Window
             }
         };
 
-        Activated += delegate
+        UiUtil.FocusOnFirstActivation(this, () =>
         {
             buttonCancel.Focus(); // hack to make OnKeyDown work
-        };
+        });
         KeyDown += (s, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextModelsWindow.cs
@@ -164,10 +164,10 @@ public class DownloadSpeechToTextModelsWindow : Window
 
         Content = grid;
 
-        Activated += delegate
+        UiUtil.FocusOnFirstActivation(this, () =>
         {
             buttonCancel.Focus(); // hack to make OnKeyDown work
-        };
+        });
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Video/SpeechToText/EngineSettings/SpeechToTextEngineSettingsWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/EngineSettings/SpeechToTextEngineSettingsWindow.cs
@@ -32,7 +32,7 @@ public class SpeechToTextEngineSettingsWindow : Window
         Content = BuildContent(vm);
 
         var ok = UiUtil.MakeButtonOk(vm.OkCommand);
-        Activated += delegate { ok.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, ok);
     }
 
     private Border BuildContent(SpeechToTextEngineSettingsViewModel vm)

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextAdvancedWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextAdvancedWindow.cs
@@ -2,6 +2,8 @@
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
 using CommunityToolkit.Mvvm.Input;
@@ -28,7 +30,10 @@ public class SpeechToTextAdvancedWindow : Window
         var textBoxParameters = new TextBox
         {
             AcceptsReturn = true,
-            AcceptsTab = true,
+            // A tab is never meaningful inside a whisper command line, and accepting it trapped
+            // the keyboard in this box: Tab and Shift+Tab both typed a tab character instead of
+            // moving to the next control, with no way out but the mouse (#14313).
+            AcceptsTab = false,
             // Long single-line parameter strings used to trigger a horizontal
             // scrollbar that overlapped the text inside this otherwise-tiny
             // multi-line textbox (#11181). Reserve enough vertical room so the
@@ -80,6 +85,23 @@ public class SpeechToTextAdvancedWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
             VerticalAlignment = VerticalAlignment.Stretch,
         };
+
+        // The help text is a read-only TextBox, which moves its caret for the arrows and
+        // Home/End - and that drags the ScrollViewer along - but does nothing for PageUp and
+        // PageDown, leaving them dead in the one pane long enough to need them (#14313).
+        textBoxHelp.AddHandler(KeyDownEvent, (_, e) =>
+        {
+            if (e.Key == Key.PageUp)
+            {
+                scrollViewer.PageUp();
+                e.Handled = true;
+            }
+            else if (e.Key == Key.PageDown)
+            {
+                scrollViewer.PageDown();
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
 
         var buttonXxlOptions = new SplitButton
         {
@@ -212,7 +234,9 @@ public class SpeechToTextAdvancedWindow : Window
 
         Content = grid;
 
-        Activated += delegate { textBoxParameters.Focus(); }; // hack to make OnKeyDown work
+        // Focus something so the window-level KeyDown below is reachable - but only on the first
+        // activation, or Alt+Tabbing back would throw focus away from wherever the user left it.
+        UiUtil.FocusOnFirstActivation(this, textBoxParameters);
         KeyDown += (s, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextPostProcessingWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextPostProcessingWindow.cs
@@ -161,7 +161,7 @@ public class SpeechToTextPostProcessingWindow : Window
 
         Content = outerGrid;
 
-        Activated += delegate { Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, () => { Focus(); }); // hack to make OnKeyDown work
     }
 
     private static void SetHint(Control label, Control checkBox, string hint)

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextQualityReportWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextQualityReportWindow.cs
@@ -185,7 +185,7 @@ public class SpeechToTextQualityReportWindow : Window
 
         Content = grid;
 
-        Activated += delegate { buttonOk.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, buttonOk); // hack to make OnKeyDown work
     }
 
     protected override void OnKeyDown(KeyEventArgs e)

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
@@ -495,7 +495,7 @@ public class SpeechToTextWindow : Window
 
         Content = grid;
 
-        Activated += delegate { Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, () => { Focus(); }); // hack to make OnKeyDown work
         Loaded += (s, e) => vm.OnWindowLoaded();
         Closing += (s, e) => vm.OnWindowClosing(e);
         KeyDown += (s, e) => vm.OnKeyDown(e);

--- a/src/ui/Features/Video/TextToSpeech/AdvancedTtsSettings/AdvancedTtsSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/AdvancedTtsSettings/AdvancedTtsSettingsWindow.cs
@@ -99,7 +99,7 @@ public class AdvancedTtsSettingsWindow : Window
         Content = mainPanel;
 
         // initial focus on an input, not an action button - a focused button clicks on bare Space
-        Activated += delegate { (sectionProAudio.Children[0] as CheckBox)?.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, () => { (sectionProAudio.Children[0] as CheckBox)?.Focus(); });
     }
 
     private static StackPanel MakeSection(AdvancedTtsSettingsViewModel vm, string title, string checkBoxBinding, string description,

--- a/src/ui/Features/Video/TextToSpeech/ChatterboxTtsSettings/ChatterboxTtsSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ChatterboxTtsSettings/ChatterboxTtsSettingsWindow.cs
@@ -34,7 +34,7 @@ public class ChatterboxTtsSettingsWindow : Window
         Content = BuildContent(vm);
 
         var ok = UiUtil.MakeButtonOk(vm.OkCommand);
-        Activated += delegate { ok.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, ok);
     }
 
     private Border BuildContent(ChatterboxTtsSettingsViewModel vm)

--- a/src/ui/Features/Video/TextToSpeech/CosyVoice3CrispAsrSettings/CosyVoice3CrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/CosyVoice3CrispAsrSettings/CosyVoice3CrispAsrSettingsWindow.cs
@@ -33,7 +33,7 @@ public class CosyVoice3CrispAsrSettingsWindow : Window
         Content = BuildContent(vm);
 
         var ok = UiUtil.MakeButtonOk(vm.OkCommand);
-        Activated += delegate { ok.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, ok);
     }
 
     private Border BuildContent(CosyVoice3CrispAsrSettingsViewModel vm)

--- a/src/ui/Features/Video/TextToSpeech/DotsTtsCrispAsrSettings/DotsTtsCrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/DotsTtsCrispAsrSettings/DotsTtsCrispAsrSettingsWindow.cs
@@ -33,7 +33,7 @@ public class DotsTtsCrispAsrSettingsWindow : Window
         Content = BuildContent(vm);
 
         var ok = UiUtil.MakeButtonOk(vm.OkCommand);
-        Activated += delegate { ok.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, ok);
     }
 
     private Border BuildContent(DotsTtsCrispAsrSettingsViewModel vm)

--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsWindow.cs
@@ -69,10 +69,10 @@ public sealed class DownloadTtsWindow : Window
             }
         };
 
-        Activated += delegate
+        UiUtil.FocusOnFirstActivation(this, () =>
         {
             buttonCancel.Focus(); // hack to make OnKeyDown work
-        };
+        });
     }
 
     protected override void OnKeyDown(KeyEventArgs e)

--- a/src/ui/Features/Video/TextToSpeech/ElevenLabsSettings/ElevenLabsSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ElevenLabsSettings/ElevenLabsSettingsWindow.cs
@@ -149,7 +149,7 @@ public class ElevenLabsSettingsWindow : Window
 
         Content = grid;
 
-        Activated += delegate { sliderStability.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, sliderStability); // initial focus on an input, not an action button - a focused button clicks on bare Space
     }
 
     protected override void OnKeyDown(KeyEventArgs e)

--- a/src/ui/Features/Video/TextToSpeech/EncodingSettings/EncodingSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/EncodingSettings/EncodingSettingsWindow.cs
@@ -75,7 +75,7 @@ public class EncodingSettingsWindow : Window
 
         Content = grid;
 
-        Activated += delegate { comboEncoding.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, comboEncoding); // initial focus on an input, not an action button - a focused button clicks on bare Space
     }
 
     protected override void OnKeyDown(KeyEventArgs e)

--- a/src/ui/Features/Video/TextToSpeech/F5TtsCrispAsrSettings/F5TtsCrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/F5TtsCrispAsrSettings/F5TtsCrispAsrSettingsWindow.cs
@@ -33,7 +33,7 @@ public class F5TtsCrispAsrSettingsWindow : Window
         Content = BuildContent(vm);
 
         var ok = UiUtil.MakeButtonOk(vm.OkCommand);
-        Activated += delegate { ok.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, ok);
     }
 
     private Border BuildContent(F5TtsCrispAsrSettingsViewModel vm)

--- a/src/ui/Features/Video/TextToSpeech/IndexTts25AudioCppSettings/IndexTts25AudioCppSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/IndexTts25AudioCppSettings/IndexTts25AudioCppSettingsWindow.cs
@@ -33,7 +33,7 @@ public class IndexTts25AudioCppSettingsWindow : Window
         Content = BuildContent(vm);
 
         var ok = UiUtil.MakeButtonOk(vm.OkCommand);
-        Activated += delegate { ok.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, ok);
     }
 
     private Border BuildContent(IndexTts25AudioCppSettingsViewModel vm)

--- a/src/ui/Features/Video/TextToSpeech/IndexTtsCrispAsrSettings/IndexTtsCrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/IndexTtsCrispAsrSettings/IndexTtsCrispAsrSettingsWindow.cs
@@ -33,7 +33,7 @@ public class IndexTtsCrispAsrSettingsWindow : Window
         Content = BuildContent(vm);
 
         var ok = UiUtil.MakeButtonOk(vm.OkCommand);
-        Activated += delegate { ok.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, ok);
     }
 
     private Border BuildContent(IndexTtsCrispAsrSettingsViewModel vm)

--- a/src/ui/Features/Video/TextToSpeech/KokoroTtsSettings/KokoroTtsSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/KokoroTtsSettings/KokoroTtsSettingsWindow.cs
@@ -33,7 +33,7 @@ public class KokoroTtsSettingsWindow : Window
         Content = BuildContent(vm);
 
         var ok = UiUtil.MakeButtonOk(vm.OkCommand);
-        Activated += delegate { ok.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, ok);
     }
 
     private Border BuildContent(KokoroTtsSettingsViewModel vm)

--- a/src/ui/Features/Video/TextToSpeech/MossTtsCrispAsrSettings/MossTtsCrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/MossTtsCrispAsrSettings/MossTtsCrispAsrSettingsWindow.cs
@@ -33,7 +33,7 @@ public class MossTtsCrispAsrSettingsWindow : Window
         Content = BuildContent(vm);
 
         var ok = UiUtil.MakeButtonOk(vm.OkCommand);
-        Activated += delegate { ok.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, ok);
     }
 
     private Border BuildContent(MossTtsCrispAsrSettingsViewModel vm)

--- a/src/ui/Features/Video/TextToSpeech/OmniVoiceCrispAsrSettings/OmniVoiceCrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/OmniVoiceCrispAsrSettings/OmniVoiceCrispAsrSettingsWindow.cs
@@ -35,7 +35,7 @@ public class OmniVoiceCrispAsrSettingsWindow : Window
         Content = BuildContent(vm);
 
         var ok = UiUtil.MakeButtonOk(vm.OkCommand);
-        Activated += delegate { ok.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, ok);
     }
 
     private Border BuildContent(OmniVoiceCrispAsrSettingsViewModel vm)

--- a/src/ui/Features/Video/TextToSpeech/OmniVoiceSettings/OmniVoiceSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/OmniVoiceSettings/OmniVoiceSettingsWindow.cs
@@ -33,7 +33,7 @@ public class OmniVoiceSettingsWindow : Window
         Content = BuildContent(vm);
 
         var ok = UiUtil.MakeButtonOk(vm.OkCommand);
-        Activated += delegate { ok.Focus(); }; // ensure OnKeyDown fires
+        UiUtil.FocusOnFirstActivation(this, ok); // ensure OnKeyDown fires
     }
 
     private Border BuildContent(OmniVoiceSettingsViewModel vm)

--- a/src/ui/Features/Video/TextToSpeech/PiperSettings/PiperSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/PiperSettings/PiperSettingsWindow.cs
@@ -33,7 +33,7 @@ public class PiperSettingsWindow : Window
         Content = BuildContent(vm);
 
         var ok = UiUtil.MakeButtonOk(vm.OkCommand);
-        Activated += delegate { ok.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, ok);
     }
 
     private Border BuildContent(PiperSettingsViewModel vm)

--- a/src/ui/Features/Video/TextToSpeech/Qwen3TtsCrispAsrSettings/Qwen3TtsCrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/Qwen3TtsCrispAsrSettings/Qwen3TtsCrispAsrSettingsWindow.cs
@@ -33,7 +33,7 @@ public class Qwen3TtsCrispAsrSettingsWindow : Window
         Content = BuildContent(vm);
 
         var ok = UiUtil.MakeButtonOk(vm.OkCommand);
-        Activated += delegate { ok.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, ok);
     }
 
     private Border BuildContent(Qwen3TtsCrispAsrSettingsViewModel vm)

--- a/src/ui/Features/Video/TextToSpeech/Qwen3TtsSettings/Qwen3TtsSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/Qwen3TtsSettings/Qwen3TtsSettingsWindow.cs
@@ -33,7 +33,7 @@ public class Qwen3TtsSettingsWindow : Window
         Content = BuildContent(vm);
 
         var ok = UiUtil.MakeButtonOk(vm.OkCommand);
-        Activated += delegate { ok.Focus(); }; // ensure OnKeyDown fires
+        UiUtil.FocusOnFirstActivation(this, ok); // ensure OnKeyDown fires
     }
 
     private Border BuildContent(Qwen3TtsSettingsViewModel vm)

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechWindow.cs
@@ -83,7 +83,7 @@ public class ReviewSpeechWindow : Window
         // focused element) without arming any button: a focused button fires OnClick on bare
         // Space/Enter, and OK used to be focused here - so the first Space a user pressed
         // published the whole session instead of playing the selected line (#12093).
-        Activated += delegate { TableViewExtras.FocusRow(vm.LineGrid); };
+        UiUtil.FocusOnFirstActivation(this, () => { TableViewExtras.FocusRow(vm.LineGrid); });
 
         // Tunnel-stage handlers: see Space/R before the focused control does. KeyDown alone is
         // not enough - Avalonia's Button fires OnClick from OnKeyUp on Space (unconditionally

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeechHistory/ReviewSpeechHistoryWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeechHistory/ReviewSpeechHistoryWindow.cs
@@ -53,14 +53,14 @@ public class ReviewSpeechHistoryWindow : Window
 
         Content = grid;
 
-        Activated += delegate
+        UiUtil.FocusOnFirstActivation(this, () =>
         {
             // initial focus on an input, not an action button - a focused button clicks on bare Space
             if (_tableView != null)
             {
                 TableViewExtras.FocusRow(_tableView);
             }
-        };
+        });
         KeyDown += (s, e) => vm.OnKeyDown(e);
         Closing += (s, e) => vm.OnWindowClosing(e); 
         Loaded += (s, e) => vm.OnWindowLoaded();

--- a/src/ui/Features/Video/TextToSpeech/SelectLinesWindowBuilder.cs
+++ b/src/ui/Features/Video/TextToSpeech/SelectLinesWindowBuilder.cs
@@ -67,7 +67,7 @@ public static class SelectLinesWindowBuilder
         // Space only toggles a row while focus is inside it - with OK focused the very first
         // Space activated the button and accepted the dialog with every line still pre-checked.
         // ProfilesWindow spells out the same rule ("a focused button clicks on bare Space").
-        window.Activated += delegate
+        UiUtil.FocusOnFirstActivation(window, () =>
         {
             if (rowsView is TableView tableView)
             {
@@ -77,7 +77,7 @@ public static class SelectLinesWindowBuilder
             {
                 buttonOk.Focus();
             }
-        };
+        });
         window.KeyDown += vm.KeyDown;
 
         window.Closing += delegate { UiUtil.SaveWindowPosition(window); };

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
@@ -162,7 +162,7 @@ public class TextToSpeechWindow : Window
 
         Content = grid;
 
-        Activated += delegate { _comboBoxEngines?.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, () => { _comboBoxEngines?.Focus(); }); // initial focus on an input, not an action button - a focused button clicks on bare Space
     }
 
     // Install-status dot for the engine combo: green = ready, amber = a newer build is available,

--- a/src/ui/Features/Video/TextToSpeech/VibeVoiceCrispAsrSettings/VibeVoiceCrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/VibeVoiceCrispAsrSettings/VibeVoiceCrispAsrSettingsWindow.cs
@@ -33,7 +33,7 @@ public class VibeVoiceCrispAsrSettingsWindow : Window
         Content = BuildContent(vm);
 
         var ok = UiUtil.MakeButtonOk(vm.OkCommand);
-        Activated += delegate { ok.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, ok);
     }
 
     private Border BuildContent(VibeVoiceCrispAsrSettingsViewModel vm)

--- a/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsWindow.cs
@@ -78,7 +78,7 @@ public class VoiceSettingsWindow : Window
         Closed += (_, _) => vm.PropertyChanged -= OnViewModelPropertyChanged;
         ApplyDropVisualState(vm.IsDragOver);
 
-        Activated += delegate { textBox.Focus(); }; // hack to make OnKeyDown work
+        UiUtil.FocusOnFirstActivation(this, textBox); // hack to make OnKeyDown work
     }
 
     private Control BuildDropArea(VoiceSettingsViewModel vm)

--- a/src/ui/Features/Video/TextToSpeech/VoxCPM2CrispAsrSettings/VoxCPM2CrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/VoxCPM2CrispAsrSettings/VoxCPM2CrispAsrSettingsWindow.cs
@@ -33,7 +33,7 @@ public class VoxCPM2CrispAsrSettingsWindow : Window
         Content = BuildContent(vm);
 
         var ok = UiUtil.MakeButtonOk(vm.OkCommand);
-        Activated += delegate { ok.Focus(); };
+        UiUtil.FocusOnFirstActivation(this, ok);
     }
 
     private Border BuildContent(VoxCPM2CrispAsrSettingsViewModel vm)

--- a/src/ui/Features/Video/TransparentSubtitles/TransparentSettingsWindow.cs
+++ b/src/ui/Features/Video/TransparentSubtitles/TransparentSettingsWindow.cs
@@ -90,7 +90,7 @@ public class TransparentSettingsWindow : Window
 
         Content = grid;
 
-        Activated += delegate { checkBoxUseSourceFolder.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, checkBoxUseSourceFolder); // initial focus on an input, not an action button - a focused button clicks on bare Space
         KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 }

--- a/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesWindow.cs
+++ b/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesWindow.cs
@@ -151,7 +151,7 @@ public class TransparentSubtitlesWindow : Window
         };
         UpdateGrowAreas();
 
-        Activated += delegate { _comboBoxFontName?.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, () => { _comboBoxFontName?.Focus(); }); // initial focus on an input, not an action button - a focused button clicks on bare Space
         Loaded += (_, _) => vm.Loaded();
 
         Opened += (_, _) => LockMinimumToContentSize();

--- a/src/ui/Features/Video/VideoOcr/VideoOcrWindow.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrWindow.cs
@@ -80,7 +80,7 @@ public class VideoOcrWindow : Window
 
         Content = grid;
 
-        Activated += delegate { _comboEngine?.Focus(); }; // initial focus on an input, not an action button - a focused button clicks on bare Space
+        UiUtil.FocusOnFirstActivation(this, () => { _comboEngine?.Focus(); }); // initial focus on an input, not an action button - a focused button clicks on bare Space
         Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
         Closing += delegate { UiUtil.SaveWindowPosition(this); };
         Loaded += (s, e) => vm.OnLoaded();

--- a/src/ui/Features/WebVtt/WebVttStylePickerWindow.cs
+++ b/src/ui/Features/WebVtt/WebVttStylePickerWindow.cs
@@ -67,7 +67,7 @@ public class WebVttStylePickerWindow : Window
         Content = grid;
 
         // initial focus on an input, not an action button - a focused button clicks on bare Space
-        Activated += delegate { TableViewExtras.FocusRow(stylesGrid); };
+        UiUtil.FocusOnFirstActivation(this, () => { TableViewExtras.FocusRow(stylesGrid); });
         KeyDown += vm.KeyDown;
     }
 

--- a/src/ui/Features/WebVtt/WebVttStylesWindow.cs
+++ b/src/ui/Features/WebVtt/WebVttStylesWindow.cs
@@ -65,7 +65,7 @@ public class WebVttStylesWindow : Window
         Content = grid;
 
         // initial focus on an input, not an action button - a focused button clicks on bare Space
-        Activated += delegate { TableViewExtras.FocusRow(vm.StyleGrid); };
+        UiUtil.FocusOnFirstActivation(this, () => { TableViewExtras.FocusRow(vm.StyleGrid); });
         KeyDown += vm.KeyDown;
 
         Closing += delegate { UiUtil.SaveWindowPosition(this); };

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -3199,10 +3199,20 @@ public static class UiUtil
     /// </summary>
     internal static void FocusOnFirstActivation(Window window, Control control)
     {
+        FocusOnFirstActivation(window, () => control.Focus());
+    }
+
+    /// <summary>
+    /// Runs <paramref name="setInitialFocus"/> once, on the first activation of the window.
+    /// The overload to use when the initial focus is more than one control's Focus() call -
+    /// a row in a grid, a choice between two controls, a select-all before the focus.
+    /// </summary>
+    internal static void FocusOnFirstActivation(Window window, Action setInitialFocus)
+    {
         void OnActivated(object? sender, EventArgs e)
         {
             window.Activated -= OnActivated;
-            control.Focus();
+            setInitialFocus();
         }
 
         window.Activated += OnActivated;

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -1,4 +1,4 @@
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
@@ -3186,6 +3186,26 @@ public static class UiUtil
         }
 
         return title + " - " + System.IO.Path.GetFileName(fileName);
+    }
+
+    /// <summary>
+    /// Gives <paramref name="control"/> the initial keyboard focus, once, the first time the
+    /// window is activated.
+    ///
+    /// The usual "Activated += delegate { x.Focus(); }" fires on <em>every</em> activation, so
+    /// Alt+Tabbing away and back yanks focus out of whatever the user had moved it to and
+    /// drops it back on the same control (#14313). Only the first activation is the initial
+    /// one; after that the window's own focus memory is the right answer.
+    /// </summary>
+    internal static void FocusOnFirstActivation(Window window, Control control)
+    {
+        void OnActivated(object? sender, EventArgs e)
+        {
+            window.Activated -= OnActivated;
+            control.Focus();
+        }
+
+        window.Activated += OnActivated;
     }
 
     internal static void InitializeWindow(Window window, string name)

--- a/tests/UI/Features/Video/SpeechToText/SpeechToTextAdvancedKeyboardTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/SpeechToTextAdvancedKeyboardTests.cs
@@ -1,0 +1,141 @@
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText;
+using Nikse.SubtitleEdit.Logic;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UITests.Features.Video.SpeechToText;
+
+/// <summary>
+/// Issue #14313: the Advanced speech-to-text parameters dialog could not be driven from the
+/// keyboard. Focus opened in the Parameters box, which accepted Tab as a character, so Tab and
+/// Shift+Tab typed a tab into the whisper command line instead of moving on - the only way out
+/// was the mouse. PageUp/PageDown did nothing in the help pane, and Alt+Tabbing back into the
+/// dialog threw focus back to the Parameters box.
+/// </summary>
+public class SpeechToTextAdvancedKeyboardTests : IDisposable
+{
+    // A window left open outlives the test: it keeps the application-wide activation and focused
+    // element, so a later test's input is delivered to it instead.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private (SpeechToTextAdvancedViewModel Vm, Window Window) Open()
+    {
+        var vm = new SpeechToTextAdvancedViewModel();
+        var window = new SpeechToTextAdvancedWindow(vm);
+        _windows.Add(window);
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+        return (vm, window);
+    }
+
+    // The editable Parameters box: the only TextBox in the dialog that is not read-only.
+    private static TextBox ParametersBox(Window window) =>
+        window.GetVisualDescendants().OfType<TextBox>().First(t => !t.IsReadOnly);
+
+    private static TextBox HelpBox(Window window) =>
+        window.GetVisualDescendants().OfType<TextBox>().First(t => t.IsReadOnly);
+
+    private static ScrollViewer HelpScrollViewer(Window window) =>
+        HelpBox(window).GetVisualAncestors().OfType<ScrollViewer>().First();
+
+    // The reported trap: Tab typed a tab character and focus never left the box.
+    [AvaloniaFact]
+    public void Tab_LeavesTheParametersBox_InsteadOfTypingATab()
+    {
+        var (vm, window) = Open();
+        var parameters = ParametersBox(window);
+        parameters.Focus();
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(parameters.IsFocused, "the test needs focus to start in the Parameters box");
+
+        window.KeyPressQwerty(PhysicalKey.Tab, RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.DoesNotContain('\t', vm.Parameters ?? string.Empty);
+        Assert.False(parameters.IsFocused, "Tab should move focus out of the Parameters box");
+    }
+
+    // Shift+Tab typed a tab too - it behaved exactly like Tab rather than moving backwards.
+    [AvaloniaFact]
+    public void ShiftTab_LeavesTheParametersBox_InsteadOfTypingATab()
+    {
+        var (vm, window) = Open();
+        var parameters = ParametersBox(window);
+        parameters.Focus();
+        Dispatcher.UIThread.RunJobs();
+
+        window.KeyPressQwerty(PhysicalKey.Tab, RawInputModifiers.Shift);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.DoesNotContain('\t', vm.Parameters ?? string.Empty);
+        Assert.False(parameters.IsFocused, "Shift+Tab should move focus out of the Parameters box");
+    }
+
+    [AvaloniaFact]
+    public void PageDownAndPageUp_ScrollTheHelpPane()
+    {
+        var (vm, window) = Open();
+        vm.HelpText = string.Join(Environment.NewLine, Enumerable.Range(0, 400).Select(i => $"help line {i}"));
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        var scrollViewer = HelpScrollViewer(window);
+        Assert.True(scrollViewer.Extent.Height > scrollViewer.Viewport.Height,
+            "the test needs help text taller than the pane");
+
+        HelpBox(window).Focus();
+        Dispatcher.UIThread.RunJobs();
+
+        window.KeyPressQwerty(PhysicalKey.PageDown, RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+        var afterPageDown = scrollViewer.Offset.Y;
+        Assert.True(afterPageDown > 0, "PageDown should scroll the help pane down");
+
+        window.KeyPressQwerty(PhysicalKey.PageUp, RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(scrollViewer.Offset.Y < afterPageDown, "PageUp should scroll the help pane back up");
+    }
+
+    // Alt+Tabbing away and back re-raises Activated. The initial-focus handler used to run on
+    // every activation, so returning to the dialog dropped focus back on the Parameters box.
+    // (Verified that Window.Activate() really does re-raise Activated here, so this is a real
+    // round trip and not a test that passes because nothing happened.)
+    [AvaloniaFact]
+    public void Reactivating_DoesNotPullFocusBackToTheParametersBox()
+    {
+        var (_, window) = Open();
+        var parameters = ParametersBox(window);
+        Assert.True(parameters.IsFocused, "the first activation should focus the Parameters box");
+
+        var help = HelpBox(window);
+        help.Focus();
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(help.IsFocused);
+
+        window.Activate();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(help.IsFocused, "returning to the dialog should leave focus where the user put it");
+        Assert.False(parameters.IsFocused);
+    }
+}

--- a/tests/UI/Logic/InitialFocusConventionTests.cs
+++ b/tests/UI/Logic/InitialFocusConventionTests.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// Two keyboard conventions that are invisible at build time and only show up as a dialog
+/// misbehaving under the hands of someone who does not use a mouse (#14313).
+///
+/// 1. Initial focus belongs in <c>UiUtil.FocusOnFirstActivation</c>. An <c>Activated</c>
+///    handler runs on <em>every</em> activation, so focusing from one means Alt+Tabbing away
+///    and back yanks focus out of wherever the user had moved it. Three windows had already
+///    hand-rolled a "did I focus yet" flag before the helper existed, which is the shape of a
+///    convention worth enforcing rather than rediscovering.
+///
+/// 2. A read-only TextBox cannot receive a typed tab, so <c>AcceptsTab = true</c> on one buys
+///    nothing and costs the user Tab and Shift+Tab as navigation keys - the box becomes a trap
+///    that can only be left with the mouse.
+///
+/// Both are source scans: the offending code compiles and runs fine, so a build cannot catch it.
+/// </summary>
+public class InitialFocusConventionTests
+{
+    [Fact]
+    public void NoActivatedHandler_SetsFocus()
+    {
+        var offenders = new List<string>();
+
+        foreach (var file in UiSourceFiles())
+        {
+            var text = File.ReadAllText(file);
+            foreach (Match match in Regex.Matches(text, @"Activated \+= delegate"))
+            {
+                if (IsInsideComment(text, match.Index))
+                {
+                    continue;
+                }
+
+                var body = ReadBlockAfter(text, match.Index);
+                if (body.Contains(".Focus(", StringComparison.Ordinal) ||
+                    body.Contains("FocusRow(", StringComparison.Ordinal))
+                {
+                    var line = text.Take(match.Index).Count(c => c == '\n') + 1;
+                    offenders.Add($"{Relative(file)}:{line}");
+                }
+            }
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            "An Activated handler sets focus, so it will re-focus every time the window is " +
+            "activated - Alt+Tabbing back into the dialog will pull focus away from wherever " +
+            "the user left it. Use UiUtil.FocusOnFirstActivation(window, control) instead." +
+            Environment.NewLine +
+            string.Join(Environment.NewLine, offenders));
+    }
+
+    [Fact]
+    public void NoReadOnlyTextBox_AcceptsTab()
+    {
+        var offenders = new List<string>();
+
+        foreach (var file in UiSourceFiles())
+        {
+            var text = File.ReadAllText(file);
+            foreach (Match match in Regex.Matches(text, @"AcceptsTab = true"))
+            {
+                if (IsInsideComment(text, match.Index))
+                {
+                    continue;
+                }
+
+                // Same object initializer: from the "new TextBox {" before it to the "}" after.
+                var open = text.LastIndexOf('{', match.Index);
+                var close = text.IndexOf('}', match.Index);
+                if (open < 0 || close < 0)
+                {
+                    continue;
+                }
+
+                if (text[open..close].Contains("IsReadOnly = true", StringComparison.Ordinal) ||
+                    text[match.Index..close].Contains("IsReadOnly = true", StringComparison.Ordinal))
+                {
+                    var line = text.Take(match.Index).Count(c => c == '\n') + 1;
+                    offenders.Add($"{Relative(file)}:{line}");
+                }
+            }
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            "A read-only TextBox has AcceptsTab = true. It can never receive a typed tab, so " +
+            "this only swallows Tab and Shift+Tab and traps the keyboard in the box." +
+            Environment.NewLine +
+            string.Join(Environment.NewLine, offenders));
+    }
+
+    /// <summary>The block that starts at the first "{" after <paramref name="index"/>.</summary>
+    private static string ReadBlockAfter(string text, int index)
+    {
+        var open = text.IndexOf('{', index);
+        if (open < 0)
+        {
+            return string.Empty;
+        }
+
+        var depth = 0;
+        for (var i = open; i < text.Length; i++)
+        {
+            if (text[i] == '{')
+            {
+                depth++;
+            }
+            else if (text[i] == '}')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    return text[open..i];
+                }
+            }
+        }
+
+        return string.Empty;
+    }
+
+    private static bool IsInsideComment(string text, int index)
+    {
+        var lineStart = text.LastIndexOf('\n', Math.Max(0, index - 1)) + 1;
+        var prefix = text[lineStart..index].TrimStart();
+        if (prefix.StartsWith("//", StringComparison.Ordinal) || prefix.StartsWith("*", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        var blockOpen = text.LastIndexOf("/*", index, StringComparison.Ordinal);
+        return blockOpen >= 0 && text.LastIndexOf("*/", index, StringComparison.Ordinal) < blockOpen;
+    }
+
+    private static IEnumerable<string> UiSourceFiles()
+    {
+        var uiRoot = Path.Combine(FindRepoRoot(), "src", "ui");
+        Assert.True(Directory.Exists(uiRoot), $"UI source not found: {uiRoot}");
+
+        var files = Directory.EnumerateFiles(uiRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.NotEmpty(files);
+        return files;
+    }
+
+    private static string Relative(string file)
+    {
+        var root = FindRepoRoot();
+        return file.StartsWith(root, StringComparison.Ordinal) ? file[(root.Length + 1)..] : file;
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "src", "ui")))
+        {
+            dir = dir.Parent;
+        }
+
+        return dir?.FullName ?? throw new DirectoryNotFoundException("Could not find repo root");
+    }
+}


### PR DESCRIPTION
Fixes #14313

The reporter suspected the Advanced speech-to-text dialog wasn't the only one affected. They were right on both counts, so this fixes the dialog and then sweeps both patterns across `src/ui`.

## 1. The reported dialog

| symptom | cause | fix |
| --- | --- | --- |
| Tab and Shift+Tab type a tab character into the Parameters box, and focus never leaves it | `AcceptsTab = true` on that `TextBox` | `AcceptsTab = false` |
| PageUp/PageDown dead in the help pane (arrows and Home/End work) | it's a read-only `TextBox` in a `ScrollViewer`: caret moves drag the scroller along, but the `TextBox` swallows the paging keys without acting on them | tunnel handler routing both to `ScrollViewer.PageUp()`/`PageDown()` |
| Alt+Tab back resets focus to the Parameters box | `Activated += delegate { textBoxParameters.Focus(); }` fires on *every* activation | `UiUtil.FocusOnFirstActivation` |

## 2. Initial focus — 230 windows

`Activated` fires on every activation, so focusing from it means Alt+Tabbing back into **any** dialog yanked focus out of wherever the user had moved it. All 230 now go through `UiUtil.FocusOnFirstActivation`, which unsubscribes after the first activation.

This was already a known-bad pattern in the codebase — **three windows had independently hand-rolled a "did I focus yet" flag** (`MessageBox`, `AutoTranslateWindow`, `OpenFromUrlWindow`), one of them with a comment explaining the exact bug. Those flags are gone; the helper is the guard.

Two handlers were deliberately left alone rather than swept:

- **`MessageBox`** keeps its `Activated` handler — it re-arms an auto-repeat guard on every activation *on purpose*. Only the focus call moved out of it.
- **`BeautifyTimeCodesWindow`**'s handler is a documented no-op ("leave focus on the visualizer for keyboard nav") and sets no focus.

I checked the one thing that could make unsubscribing wrong: **no window is ever shown twice.** Dialogs are constructed per show (`Activator.CreateInstance` in `WindowsService.ShowDialogAsync`), `MessageBox` is `new`'d per call, and nothing in `src/ui` calls `Hide()`. So there is no second show whose focus this could skip.

## 3. AcceptsTab — all five remaining boxes

I said in the first draft that this one wasn't blanket-fixable because the export-format editors might legitimately want a typed tab. **That was wrong**, and reading them settled it: four of the five are `IsReadOnly = true` *preview* boxes, not editors. A read-only box can never receive a typed tab, so `AcceptsTab = true` bought them nothing and cost Tab/Shift+Tab as navigation keys. The fifth is the LLM translation prompt, where a tab isn't meaningful either. All five are now `false`.

## Tests

- `SpeechToTextAdvancedKeyboardTests` — 4 headless cases for the reported dialog (Tab, Shift+Tab, PageUp/PageDown, reactivation). All 4 fail on unmodified `main`. I checked the reactivation one isn't a free pass: `Window.Activate()` really does re-raise `Activated` in headless (1 → 2).
- `InitialFocusConventionTests` — 2 source scans, since both conventions compile and run fine when violated: no `Activated` handler may set focus, and no read-only `TextBox` may accept tab. Verified they bite by reintroducing each pattern.

The sweep's real safety net is the existing suite: tests like `AutoTranslateDefaultButtonTests.TheTranslateButtonIsFocusedWhenTheWindowOpens` and `ModalForegroundEnforcementTests` assert on initial focus and would fail if first-activation focus had broken. Full UI suite: **4393 passed, 1 skipped, 0 failed**; whole solution builds clean.

Net diff across 232 files is +467/−297, and 173 of those insertions are the new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)