### PR TITLE
Subtitle grid: add "Center text in subtitle grid" (SE 4 parity)

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -2779,6 +2779,7 @@
       "subtitleGridTextDisplayWrap": "Wrap to fit window",
       "subtitleGridTextDisplayEllipsis": "Single line with ellipsis",
       "subtitleGridLiveSpellCheck": "Live spell check in subtitle grid",
+      "subtitleGridCenterText": "Center text in subtitle grid",
       "subtitleGridShowFormatting": "Show formatted (HTML/ASSA) text in subtitle grid",
       "showUpDownStartTime": "Show up/down control for \"Show\"",
       "showUpDownEndTime": "Show up/down control for \"Hide\"",

--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -373,6 +373,12 @@ public static partial class InitListViewAndEditBox
             Source = vm,
         });
 
+        // Read once per grid build, like the grid font: ApplySettings rebuilds the layout, so
+        // toggling the setting takes effect as soon as Settings is closed (#14316).
+        var gridTextAlignment = Se.Settings.Appearance.SubtitleGridCenterText
+            ? TextAlignment.Center
+            : TextAlignment.Start;
+
         columnManager.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Text,
@@ -396,6 +402,8 @@ public static partial class InitListViewAndEditBox
                     [!TextBlock.TextAlignmentProperty] = new MultiBinding
                     {
                         Converter = TeletextAlignmentPreviewConverter.Instance,
+                        // The alignment to use when the teletext preview is not overriding it.
+                        ConverterParameter = gridTextAlignment,
                         Bindings =
                         {
                             new Binding(nameof(vm.IsTeletextPreviewActive)) { Source = vm, Mode = BindingMode.OneWay },
@@ -437,6 +445,7 @@ public static partial class InitListViewAndEditBox
                 var textBlock = new TextBlock
                 {
                     VerticalAlignment = VerticalAlignment.Center,
+                    TextAlignment = gridTextAlignment,
 
                     // Lets the subtitle grid context menu find the word under the pointer (live spell check)
                     Tag = SubtitleGridColumnKeys.OriginalText,

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -779,6 +779,7 @@ public class SettingsPage : UserControl
             new SettingsItem(Se.Language.Options.Settings.SubtitleGridTextDisplay, () => UiUtil.MakeComboBox(_vm.SubtitleGridTextDisplayModes, _vm, nameof(_vm.SelectedSubtitleGridTextDisplayMode))),
             new SettingsItem(Se.Language.Options.Settings.SubtitleGridShowFormatting, () => UiUtil.MakeComboBox(_vm.SubtitleGridFormattings, _vm, nameof(_vm.SubtitleGridFormatting))),
             MakeCheckboxSetting(Se.Language.Options.Settings.SubtitleGridLiveSpellCheck, nameof(_vm.SubtitleGridLiveSpellCheck)),
+            MakeCheckboxSetting(Se.Language.Options.Settings.SubtitleGridCenterText, nameof(_vm.SubtitleGridCenterText)),
             MakeNumericSetting(Se.Language.Options.Settings.TextBoxFontSize, nameof(_vm.TextBoxFontSize)),
             MakeCheckboxSetting(Se.Language.Options.Settings.TextBoxFontBold, nameof(_vm.TextBoxFontBold)),
             MakeCheckboxSetting(Se.Language.Options.Settings.TextBoxColorTags, nameof(_vm.TextBoxColorTags)),

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -391,6 +391,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _textBoxColorTags;
     [ObservableProperty] private bool _textBoxLiveSpellCheck;
     [ObservableProperty] private bool _subtitleGridLiveSpellCheck;
+    [ObservableProperty] private bool _subtitleGridCenterText;
     [ObservableProperty] private bool _textBoxCenterText;
     [ObservableProperty] private bool _showButtonHints;
     [ObservableProperty] private bool _gridCompactMode;
@@ -909,6 +910,7 @@ public partial class SettingsViewModel : ObservableObject
         SubtitleGridTextSingleLineSeparator = appearance.SubtitleGridTextSingleLineSeparator;
         SubtitleGridFormatting = MapGridFormattingToText(appearance.SubtitleGridFormattingType);
         SubtitleGridLiveSpellCheck = appearance.SubtitleGridLiveSpellCheck;
+        SubtitleGridCenterText = appearance.SubtitleGridCenterText;
         SubtitleTextBoxAndGridFontName = appearance.SubtitleTextBoxAndGridFontName;
         TextBoxFontSize = appearance.SubtitleTextBoxFontSize;
         TextBoxFontBold = appearance.SubtitleTextBoxFontBold;
@@ -1773,6 +1775,7 @@ public partial class SettingsViewModel : ObservableObject
         appearance.SubtitleGridTextSingleLineSeparator = SubtitleGridTextSingleLineSeparator;
         appearance.SubtitleGridFormattingType = MapGridFormattingToCode(SubtitleGridFormatting);
         appearance.SubtitleGridLiveSpellCheck = SubtitleGridLiveSpellCheck;
+        appearance.SubtitleGridCenterText = SubtitleGridCenterText;
         appearance.SubtitleTextBoxAndGridFontName = string.IsNullOrEmpty(SubtitleTextBoxAndGridFontName) ? new Label().FontFamily.Name : SubtitleTextBoxAndGridFontName;
         appearance.SubtitleTextBoxFontSize = TextBoxFontSize;
         appearance.SubtitleTextBoxFontBold = TextBoxFontBold;

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -54,6 +54,7 @@ public class LanguageSettings
     public string SubtitleGridTextDisplayWrap { get; set; }
     public string SubtitleGridTextDisplayEllipsis { get; set; }
     public string SubtitleGridLiveSpellCheck { get; set; }
+    public string SubtitleGridCenterText { get; set; }
     public string SubtitleGridShowFormatting { get; set; }
     public string ShowUpDownStartTime { get; set; }
     public string ShowUpDownEndTime { get; set; }
@@ -392,6 +393,7 @@ public class LanguageSettings
         SubtitleGridTextDisplayWrap = "Wrap to fit window";
         SubtitleGridTextDisplayEllipsis = "Single line with ellipsis";
         SubtitleGridLiveSpellCheck = "Live spell check in subtitle grid";
+        SubtitleGridCenterText = "Center text in subtitle grid";
         SubtitleGridShowFormatting = "Show formatted (HTML/ASSA) text in subtitle grid";
         ShowUpDownStartTime = "Show up/down control for \"Show\"";
         ShowUpDownEndTime = "Show up/down control for \"Hide\"";

--- a/src/ui/Logic/Config/SeAppearance.cs
+++ b/src/ui/Logic/Config/SeAppearance.cs
@@ -32,6 +32,7 @@ public class SeAppearance
     public bool SubtitleTextBoxColorTags { get; set; }
     public int SubtitleGridFormattingType { get; set; }
     public bool SubtitleGridLiveSpellCheck { get; set; }
+    public bool SubtitleGridCenterText { get; set; }
 
     public bool SubtitleTextBoxCenterText { get; set; }
     public bool SubtitleTextBoxLiveSpellCheck { get; set; }
@@ -113,6 +114,7 @@ public class SeAppearance
         SubtitleTextBoxColorTags = true;
         ShowHints = true;
         SubtitleTextBoxCenterText = false;
+        SubtitleGridCenterText = false;
         SubtitleTextBoxLiveSpellCheck = false;
         SubtitleGridFormattingType = (int)SubtitleGridFormattingTypes.ShowFormatting;
         GridLinesAppearance = SeGridLinesVisibility.None.ToString();

--- a/src/ui/Logic/ValueConverters/TeletextAlignmentPreviewConverter.cs
+++ b/src/ui/Logic/ValueConverters/TeletextAlignmentPreviewConverter.cs
@@ -17,9 +17,14 @@ public class TeletextAlignmentPreviewConverter : IMultiValueConverter
         object? parameter,
         CultureInfo culture)
     {
+        // When the teletext preview is not driving the alignment, fall back to whatever the
+        // caller passes as the parameter - the grid's own "center text" setting (#14316) -
+        // rather than assuming left.
+        var fallback = parameter is TextAlignment defaultAlignment ? defaultAlignment : TextAlignment.Start;
+
         if (values.Count < 2 || values[0] is not true)
         {
-            return TextAlignment.Start;
+            return fallback;
         }
 
         if (values[1] is TextAlignment alignment)
@@ -27,7 +32,7 @@ public class TeletextAlignmentPreviewConverter : IMultiValueConverter
             return alignment;
         }
 
-        return TextAlignment.Start;
+        return fallback;
     }
 
     public object[] ConvertBack(

--- a/tests/UI/Logic/ValueConverters/GridTextAlignmentTests.cs
+++ b/tests/UI/Logic/ValueConverters/GridTextAlignmentTests.cs
@@ -1,0 +1,93 @@
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic.ValueConverters;
+using System.Globalization;
+
+namespace UITests.Logic.ValueConverters;
+
+/// <summary>
+/// Issue #14316: SE 4 could center the text in the subtitle grid; SE 5 had the setting for the
+/// edit box only. The grid's Text column gets its alignment from
+/// <see cref="TeletextAlignmentPreviewConverter"/>, which used to hardcode a left fallback -
+/// the new "center text in subtitle grid" setting rides in as the converter parameter, so the
+/// teletext preview still wins whenever it is actually driving the alignment.
+/// </summary>
+public class GridTextAlignmentTests
+{
+    private static readonly CultureInfo Culture = CultureInfo.InvariantCulture;
+
+    private static object Convert(bool teletextPreviewActive, TextAlignment? teletextAlignment, object? parameter) =>
+        TeletextAlignmentPreviewConverter.Instance.Convert(
+            new object?[] { teletextPreviewActive, teletextAlignment },
+            typeof(TextAlignment),
+            parameter,
+            Culture);
+
+    // The default: no setting passed, no teletext preview - unchanged left alignment.
+    [Fact]
+    public void NoParameter_StillFallsBackToStart()
+    {
+        Assert.Equal(TextAlignment.Start, Convert(false, null, null));
+    }
+
+    [Fact]
+    public void CenterParameter_IsUsedWhenTeletextPreviewIsOff()
+    {
+        Assert.Equal(TextAlignment.Center, Convert(false, null, TextAlignment.Center));
+    }
+
+    // The teletext preview shows where the line really sits on a teletext page, so it has to
+    // outrank a cosmetic grid preference.
+    [Fact]
+    public void TeletextPreview_StillWins_OverTheCenterSetting()
+    {
+        Assert.Equal(TextAlignment.End, Convert(true, TextAlignment.End, TextAlignment.Center));
+    }
+
+    // An active preview on a line with no alignment of its own falls back like everything else.
+    [Fact]
+    public void TeletextPreviewWithNoAlignment_UsesTheParameter()
+    {
+        Assert.Equal(TextAlignment.Center, Convert(true, null, TextAlignment.Center));
+    }
+
+    // The grid wires the fallback in as MultiBinding.ConverterParameter. That only works if
+    // Avalonia actually forwards it to the converter, so bind it for real rather than trusting
+    // the direct calls above.
+    [AvaloniaFact]
+    public void ConverterParameter_ReachesTheConverter_ThroughAMultiBinding()
+    {
+        var source = new TeletextPreviewStub { IsTeletextPreviewActive = false };
+        var textBlock = new TextBlock
+        {
+            DataContext = source,
+            [!TextBlock.TextAlignmentProperty] = new MultiBinding
+            {
+                Converter = TeletextAlignmentPreviewConverter.Instance,
+                ConverterParameter = TextAlignment.Center,
+                Bindings =
+                {
+                    new Binding(nameof(TeletextPreviewStub.IsTeletextPreviewActive)) { Mode = BindingMode.OneWay },
+                    new Binding(nameof(TeletextPreviewStub.TeletextTextAlignment)) { Mode = BindingMode.OneWay },
+                },
+            },
+        };
+
+        var window = new Window { Width = 200, Height = 100, Content = textBlock };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(TextAlignment.Center, textBlock.TextAlignment);
+
+        window.Close();
+    }
+
+    private sealed class TeletextPreviewStub
+    {
+        public bool IsTeletextPreviewActive { get; set; }
+        public TextAlignment? TeletextTextAlignment { get; set; }
+    }
+}


### PR DESCRIPTION
Fixes #14316

SE 4 could center the text in the grid's Text column. SE 5 has the same setting for the **edit box** (`SubtitleTextBoxCenterText`, "Center text in subtitle text box") — that's the alignment option the reporter found in Settings — but nothing for the grid. This adds the grid twin.

## Changes

`Se.Settings.Appearance.SubtitleGridCenterText`, wired exactly like its text-box counterpart: setting + default, language string, view-model property, and a checkbox in Settings next to "Live spell check in subtitle grid".

The interesting part is the Text column. Its alignment comes from `TeletextAlignmentPreviewConverter`, which hardcoded a left fallback whenever the teletext preview wasn't driving it. The chosen alignment now rides in as the converter parameter, so:

- teletext preview **active** → the line's real teletext alignment still wins, as before (it shows where the line actually sits on the page, which has to outrank a cosmetic preference);
- teletext preview **off** → the user's grid setting.

The Original text column has no teletext preview, so it takes the alignment directly — otherwise the two text columns would disagree side by side. The reporter only asked about Text; flagging in case you'd rather they were independent.

Read once per grid build, like the grid font. `ApplySettings` rebuilds the layout, so the toggle takes effect as soon as Settings closes — no restart.

## Tests

New `GridTextAlignmentTests` — 5 cases: no parameter still falls back to left (existing callers unaffected); the center parameter is used when preview is off; teletext preview still outranks the setting; an active preview with no per-line alignment falls back to the parameter.

The fifth is the one that mattered — the whole design rests on Avalonia forwarding `MultiBinding.ConverterParameter` to an `IMultiValueConverter`, so rather than assume it, that test binds it for real on a shown `TextBlock` and asserts the rendered `TextAlignment`. It does.

`English.json` is regenerated by the existing sync test; the diff is the one new key. Full UI suite: 4392 passed, 1 skipped, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)