### PR TITLE
Settings import: accept an SE 4 Settings.xml

### DIFF
--- a/src/ui/Features/Options/Settings/SettingsImportExport/SettingsImportExportViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsImportExport/SettingsImportExportViewModel.cs
@@ -6,6 +6,7 @@ using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
+using Nikse.SubtitleEdit.Logic.Se4Setup;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -104,6 +105,11 @@ public partial class SettingsImportExportViewModel : ObservableObject
     private bool _importHasShortcutSlots;
     private bool _importHasCustomSearchSlots;
 
+    // Set instead of _importData when the picked file is an SE 4 Settings.xml (#14309): SE 4 has
+    // no Settings.json, so the only file a user migrating from 4.x can point at is the classic
+    // XML. Field-by-field mapping, see Se4SettingsXmlImporter.
+    private Se4SettingsXmlImporter.Se4SettingsFile? _se4ImportData;
+
     // Marker property name written at the top level of the export JSON so the
     // importer can tell which OS the file came from (Se has no such field, so
     // System.Text.Json silently ignores it when deserializing into Se).
@@ -152,7 +158,9 @@ public partial class SettingsImportExportViewModel : ObservableObject
             Window,
             Se.Language.General.ImportDotDotDot,
             "JSON files",
-            ".json");
+            ".json",
+            "Subtitle Edit 4 settings",
+            ".xml");
 
         if (string.IsNullOrEmpty(fileName) || !File.Exists(fileName))
         {
@@ -164,6 +172,12 @@ public partial class SettingsImportExportViewModel : ObservableObject
         try
         {
             var json = File.ReadAllText(_importFilePath);
+
+            if (Se4SettingsXmlImporter.LooksLikeXml(json))
+            {
+                return LoadSe4ImportFile(json);
+            }
+
             _importData = JsonSerializer.Deserialize<Se>(json, new JsonSerializerOptions
             {
                 PropertyNameCaseInsensitive = true,
@@ -218,6 +232,62 @@ public partial class SettingsImportExportViewModel : ObservableObject
         {
             return false;
         }
+    }
+
+    // An SE 4 Settings.xml carries only some of what the dialog offers - the categories its
+    // sections cover - so the checkboxes for the rest are greyed out just like they are for a
+    // partial JSON export.
+    private bool LoadSe4ImportFile(string xml)
+    {
+        var se4 = Se4SettingsXmlImporter.Parse(xml);
+        if (se4 == null)
+        {
+            return false;
+        }
+
+        _importData = null;
+        _se4ImportData = se4;
+        _importSourceOs = null;
+        _importHasShortcutSlots = false;
+        _importHasCustomSearchSlots = false;
+
+        IsRulesEnabled = se4.HasRules;
+        IsAppearanceEnabled = se4.HasAppearance;
+        IsAutoTranslateEnabled = se4.HasAutoTranslate;
+        IsWaveformEnabled = se4.HasWaveform;
+        IsShortcutsEnabled = se4.HasShortcuts;
+
+        if (!IsRulesEnabled)
+        {
+            ExportImportRules = false;
+        }
+
+        if (!se4.HasSyntaxColoring)
+        {
+            ExportImportSyntaxColoring = false;
+        }
+
+        if (!IsAppearanceEnabled)
+        {
+            ExportImportAppearance = false;
+        }
+
+        if (!IsAutoTranslateEnabled)
+        {
+            ExportImportAutoTranslate = false;
+        }
+
+        if (!IsWaveformEnabled)
+        {
+            ExportImportWaveform = false;
+        }
+
+        if (!IsShortcutsEnabled)
+        {
+            ExportImportShortcuts = false;
+        }
+
+        return true;
     }
 
     [RelayCommand]
@@ -309,6 +379,12 @@ public partial class SettingsImportExportViewModel : ObservableObject
 
     private void ImportSettings()
     {
+        if (_se4ImportData != null)
+        {
+            ImportSe4Settings(_se4ImportData);
+            return;
+        }
+
         if (_importData == null)
         {
             return;
@@ -410,6 +486,54 @@ public partial class SettingsImportExportViewModel : ObservableObject
             {
                 Se.Settings.AutoTranslate = importData.AutoTranslate;
             }
+        }
+
+        Se.SaveSettings();
+    }
+
+    // The SE 4 side of the import. Same checkboxes, but every category is copied field by field
+    // into the current settings instead of replacing a whole section: SE 4 has no counterpart for
+    // most of what an SE 5 section holds, and a section-level assignment would reset all of it.
+    internal void ImportSe4Settings(Se4SettingsXmlImporter.Se4SettingsFile se4)
+    {
+        if (ExportImportAll || ExportImportRules)
+        {
+            Se4SettingsXmlImporter.ApplyRules(se4);
+        }
+
+        if (ExportImportAll || ExportImportRules || ExportImportSyntaxColoring)
+        {
+            // The coloring values live in General, same as the JSON path - "Rules" brings them
+            // along and the syntax-coloring checkbox brings them on their own.
+            Se4SettingsXmlImporter.ApplySyntaxColoring(se4);
+        }
+
+        if (ExportImportAll || ExportImportWaveform)
+        {
+            Se4SettingsXmlImporter.ApplyWaveform(se4);
+        }
+
+        if (ExportImportAll || ExportImportAppearance)
+        {
+            Se4SettingsXmlImporter.ApplyAppearance(se4);
+        }
+
+        if (ExportImportAll || ExportImportAutoTranslate)
+        {
+            Se4SettingsXmlImporter.ApplyAutoTranslate(se4);
+        }
+
+        if (ExportImportAll || ExportImportShortcuts)
+        {
+            // SE 4 is Windows-only, so every binding in the file is Ctrl-based - on macOS they
+            // get the same Ctrl -> Cmd swap a Windows JSON export gets.
+            Se4SettingsXmlImporter.ApplyShortcuts(se4, shortcuts =>
+            {
+                if (OperatingSystem.IsMacOS())
+                {
+                    NormalizeShortcutModifiersForCurrentOs(shortcuts);
+                }
+            });
         }
 
         Se.SaveSettings();

--- a/src/ui/Logic/Se4Setup/Se4SettingsXmlImporter.cs
+++ b/src/ui/Logic/Se4Setup/Se4SettingsXmlImporter.cs
@@ -1,0 +1,536 @@
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Core.Enums;
+using Nikse.SubtitleEdit.Features.Options.Shortcuts;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Nikse.SubtitleEdit.Logic.Se4Setup;
+
+/// <summary>
+/// Reads an SE 4 <c>Settings.xml</c> for the Settings import dialog, which otherwise only accepts
+/// an SE 5 <c>Settings.json</c> export (#14309 - users coming from 4.0.12 have nothing else).
+///
+/// Only the categories the dialog offers are mapped: rules, syntax coloring, waveform, shortcuts,
+/// appearance and auto-translate. Everything is applied field by field onto the *current* settings
+/// rather than by replacing a whole section: SE 4's tree is not SE 5's, so an unmapped SE 5 field
+/// must keep its current value instead of being reset to a default (which is what a section-level
+/// assignment - the JSON import path - would do).
+/// </summary>
+public static class Se4SettingsXmlImporter
+{
+    public sealed class Se4SettingsFile
+    {
+        internal XElement? General { get; init; }
+        internal XElement? Tools { get; init; }
+        internal XElement? VideoControls { get; init; }
+        internal XElement? Shortcuts { get; init; }
+        internal string Xml { get; init; } = string.Empty;
+
+        public bool HasRules => General != null;
+        public bool HasSyntaxColoring => Tools != null || General != null;
+        public bool HasWaveform => VideoControls != null;
+        public bool HasAppearance => General != null;
+        public bool HasAutoTranslate => Tools != null;
+        public bool HasShortcuts => Shortcuts != null;
+    }
+
+    /// <summary>
+    /// Cheap check on the file *content* - the import dialog takes both .json and .xml, and a
+    /// user pointing at an SE 4 file that has been renamed should still get the XML path.
+    /// </summary>
+    public static bool LooksLikeXml(string text)
+    {
+        return text.TrimStart('﻿', ' ', '\t', '\r', '\n').StartsWith('<');
+    }
+
+    /// <summary>
+    /// Returns null when the text is not an SE 4 <c>Settings.xml</c> (unparseable, or a different
+    /// SE 4 XML such as an exported replace list or shortcut file).
+    /// </summary>
+    public static Se4SettingsFile? Parse(string xml)
+    {
+        XDocument doc;
+        try
+        {
+            doc = XDocument.Parse(xml);
+        }
+        catch
+        {
+            return null;
+        }
+
+        var root = doc.Root;
+        if (root == null || root.Name.LocalName != "Settings")
+        {
+            return null;
+        }
+
+        var file = new Se4SettingsFile
+        {
+            Xml = xml,
+            General = Section(root, "General"),
+            Tools = Section(root, "Tools"),
+            VideoControls = Section(root, "VideoControls"),
+            Shortcuts = Section(root, "Shortcuts"),
+        };
+
+        return file.HasRules || file.HasWaveform || file.HasShortcuts || file.HasAutoTranslate
+            ? file
+            : null;
+    }
+
+    private static XElement? Section(XElement root, string name)
+    {
+        var section = root.Elements().FirstOrDefault(e => e.Name.LocalName == name);
+        return section != null && section.HasElements ? section : null;
+    }
+
+    /// <summary>
+    /// The "Rules" half of SE 4's General settings - the same values SE 5 keeps in
+    /// <see cref="SeGeneral"/> and the Settings window's Rules page shows.
+    /// </summary>
+    public static void ApplyRules(Se4SettingsFile file)
+    {
+        var general = file.General;
+        if (general == null)
+        {
+            return;
+        }
+
+        var g = Se.Settings.General;
+
+        SetInt(general, "SubtitleLineMaximumLength", 1, 500, v => g.SubtitleLineMaximumLength = v);
+        SetInt(general, "MaxNumberOfLines", 1, 20, v => g.MaxNumberOfLines = v);
+        SetInt(general, "MaxNumberOfLinesPlusAbort", 0, 100, v => g.MaxNumberOfLinesPlusAbort = v);
+        SetInt(general, "MergeLinesShorterThan", 0, 500, v => g.UnbreakLinesShorterThan = v);
+        SetInt(general, "SubtitleMinimumDisplayMilliseconds", 0, 100000, v => g.SubtitleMinimumDisplayMilliseconds = v);
+        SetInt(general, "SubtitleMaximumDisplayMilliseconds", 0, 500000, v => g.SubtitleMaximumDisplayMilliseconds = v);
+        SetInt(general, "SubtitleLineMaximumPixelWidth", 0, 10000, v => g.SubtitleLineMaximumPixelWidth = v);
+
+        // SE 5 keeps the minimum gap as ms *and* frames; SE 4 only has the ms value, so leave the
+        // frame count alone rather than deriving one from a frame rate the file may not carry.
+        SetInt(general, "MinimumMillisecondsBetweenLines", 0, 100000, v => g.MinimumBetweenLines.Milliseconds = v);
+
+        SetDouble(general, "SubtitleMaximumCharactersPerSeconds", 0, 1000, v => g.SubtitleMaximumCharactersPerSeconds = v);
+        SetDouble(general, "SubtitleOptimalCharactersPerSeconds", 0, 1000, v => g.SubtitleOptimalCharactersPerSeconds = v);
+        SetDouble(general, "SubtitleMaximumWordsPerMinute", 0, 10000, v => g.SubtitleMaximumWordsPerMinute = v);
+
+        // Same guard as the SE 4 setup importer: SE 4 wrote the frame rate with the invariant
+        // culture but could read back a locale-mangled one ("23,976" -> 23976).
+        SetDouble(general, "DefaultFrameRate", 10, 200, v => g.DefaultFrameRate = v);
+        SetDouble(general, "CurrentFrameRate", 10, 200, v => g.CurrentFrameRate = v);
+
+        // Stored as strings in SE 5 but parsed back into the libse enums (SeGeneral.ToProfile
+        // throws on an unknown name), so only accept values that still exist.
+        SetEnumName<DialogType>(general, "DialogStyle", v => g.DialogStyle = v);
+        SetEnumName<ContinuationStyle>(general, "ContinuationStyle", v => g.ContinuationStyle = v);
+
+        var cpsStrategy = Value(general, "CpsLineLengthStrategy");
+        if (!string.IsNullOrWhiteSpace(cpsStrategy))
+        {
+            g.CpsLineLengthStrategy = cpsStrategy;
+        }
+    }
+
+    /// <summary>
+    /// SE 4 keeps the syntax-coloring toggles in Tools and the "too wide" measuring font in
+    /// General; SE 5 has all of it on <see cref="SeGeneral"/> next to the rules it colors.
+    /// </summary>
+    public static void ApplySyntaxColoring(Se4SettingsFile file)
+    {
+        var g = Se.Settings.General;
+        var tools = file.Tools;
+
+        if (tools != null)
+        {
+            SetBool(tools, "ListViewSyntaxColorDurationSmall", v => g.ColorDurationTooShort = v);
+            SetBool(tools, "ListViewSyntaxColorDurationBig", v => g.ColorDurationTooLong = v);
+            SetBool(tools, "ListViewSyntaxColorLongLines", v => g.ColorTextTooLong = v);
+            SetBool(tools, "ListViewSyntaxColorWideLines", v => g.ColorTextTooWide = v);
+            SetBool(tools, "ListViewSyntaxMoreThanXLines", v => g.ColorTextTooManyLines = v);
+            SetBool(tools, "ListViewSyntaxColorOverlap", v => g.ColorTimeCodeOverlap = v);
+            SetBool(tools, "ListViewSyntaxColorGap", v => g.ColorGapTooShort = v);
+            SetColor(tools, "ListViewSyntaxErrorColor", v => g.ErrorColor = v);
+        }
+
+        var general = file.General;
+        if (general != null)
+        {
+            SetInt(general, "SubtitleLineMaximumPixelWidth", 0, 10000, v => g.ColorTextTooWidePixels = v);
+            SetInt(general, "MeasureFontSize", 1, 500, v => g.ColorTextTooWideFontSize = v);
+
+            var measureFontName = Value(general, "MeasureFontName");
+            if (!string.IsNullOrWhiteSpace(measureFontName))
+            {
+                g.ColorTextTooWideFontName = measureFontName;
+            }
+        }
+    }
+
+    /// <summary>
+    /// SE 4's waveform lives in VideoControls. Only the values with a real SE 5 counterpart are
+    /// carried - SE 5's paragraph/shot-change colors and draw style have no SE 4 equivalent and
+    /// keep whatever the user has now.
+    /// </summary>
+    public static void ApplyWaveform(Se4SettingsFile file)
+    {
+        var videoControls = file.VideoControls;
+        if (videoControls == null)
+        {
+            return;
+        }
+
+        var w = Se.Settings.Waveform;
+
+        SetColor(videoControls, "WaveformColor", v => w.WaveformColor = v);
+        SetColor(videoControls, "WaveformSelectedColor", v => w.WaveformSelectedColor = v);
+        SetColor(videoControls, "WaveformBackgroundColor", v => w.WaveformBackgroundColor = v);
+        SetColor(videoControls, "WaveformTextColor", v => w.WaveformTextColor = v);
+        SetColor(videoControls, "WaveformCursorColor", v => w.WaveformCursorColor = v);
+
+        SetBool(videoControls, "WaveformDrawGrid", v => w.DrawGridLines = v);
+        SetBool(videoControls, "WaveformDrawCps", v => w.WaveformShowCps = v);
+        SetBool(videoControls, "WaveformFocusOnMouseEnter", v => w.FocusOnMouseOver = v);
+        SetBool(videoControls, "WaveformSnapToShotChanges", v => w.SnapToShotChanges = v);
+        SetBool(videoControls, "WaveformTextBold", v => w.WaveformTextFontBold = v);
+        SetInt(videoControls, "WaveformTextSize", 1, 100, v => w.WaveformTextFontSize = v);
+    }
+
+    /// <summary>
+    /// Theme, fonts and toolbar buttons. SE 4's icon theme names do not line up with SE 5's, so
+    /// the icon set is left alone - "Set up like Subtitle Edit 4" is the way to get those.
+    /// </summary>
+    public static void ApplyAppearance(Se4SettingsFile file)
+    {
+        var general = file.General;
+        if (general == null)
+        {
+            return;
+        }
+
+        var a = Se.Settings.Appearance;
+
+        SetBool(general, "UseDarkTheme", v => a.Theme = v ? UiTheme.ThemeNameDark : UiTheme.ThemeNameLight);
+        SetColor(general, "DarkThemeBackColor", v => a.DarkModeBackgroundColor = v);
+        SetColor(general, "DarkThemeForeColor", v => a.DarkModeForegroundColor = v);
+
+        var fontName = Value(general, "SubtitleFontName");
+        if (!string.IsNullOrWhiteSpace(fontName))
+        {
+            a.SubtitleTextBoxAndGridFontName = fontName;
+        }
+
+        SetInt(general, "SubtitleTextBoxFontSize", 1, 500, v => a.SubtitleTextBoxFontSize = v);
+        SetInt(general, "SubtitleListViewFontSize", 1, 500, v => a.SubtitleGridFontSize = v);
+        SetBool(general, "SubtitleTextBoxFontBold", v => a.SubtitleTextBoxFontBold = v);
+        SetBool(general, "CenterSubtitleInTextBox", v => a.SubtitleTextBoxCenterText = v);
+        SetBool(general, "SubtitleTextBoxSyntaxColor", v => a.SubtitleTextBoxColorTags = v);
+
+        foreach (var (se4Name, apply) in ToolbarMap(a))
+        {
+            SetBool(general, se4Name, apply);
+        }
+    }
+
+    // SE 4 setting name -> the SE 5 toolbar toggle it turns on. SE 5 toolbar buttons with no SE 4
+    // counterpart (multiple replace, point sync, auto-translate, speech to text, ...) are left as
+    // they are - SE 4 could not have had an opinion about them.
+    private static IEnumerable<(string Name, Action<bool> Apply)> ToolbarMap(SeAppearance a)
+    {
+        yield return ("ShowToolbarNew", v => a.ToolbarShowFileNew = v);
+        yield return ("ShowToolbarOpen", v => a.ToolbarShowFileOpen = v);
+        yield return ("ShowToolbarOpenVideo", v => a.ToolbarShowVideoFileOpen = v);
+        yield return ("ShowToolbarSave", v => a.ToolbarShowSave = v);
+        yield return ("ShowToolbarSaveAs", v => a.ToolbarShowSaveAs = v);
+        yield return ("ShowToolbarFind", v => a.ToolbarShowFind = v);
+        yield return ("ShowToolbarReplace", v => a.ToolbarShowReplace = v);
+        yield return ("ShowToolbarFixCommonErrors", v => a.ToolbarShowFixCommonErrors = v);
+        yield return ("ShowToolbarRemoveTextForHi", v => a.ToolbarShowRemoveTextForHi = v);
+        yield return ("ShowToolbarToggleSourceView", v => a.ToolbarShowSourceView = v);
+        yield return ("ShowToolbarVisualSync", v => a.ToolbarShowVisualSync = v);
+        yield return ("ShowToolbarBurnIn", v => a.ToolbarShowBurnIn = v);
+        yield return ("ShowToolbarSpellCheck", v => a.ToolbarShowSpellCheck = v);
+        yield return ("ShowToolbarBeautifyTimeCodes", v => a.ToolbarShowBeautifyTimeCodes = v);
+        yield return ("ShowToolbarSettings", v => a.ToolbarShowSettings = v);
+        yield return ("ShowToolbarHelp", v => a.ToolbarShowHelp = v);
+        yield return ("ShowFrameRate", v => a.ToolbarShowFrameRate = v);
+    }
+
+    /// <summary>
+    /// Engine URLs, models, prompts and API keys. SE 4 prefixed several of these with
+    /// "AutoTranslate" and SE 5 does not, so the pairs are spelled out.
+    /// </summary>
+    public static void ApplyAutoTranslate(Se4SettingsFile file)
+    {
+        var tools = file.Tools;
+        if (tools == null)
+        {
+            return;
+        }
+
+        var t = Se.Settings.AutoTranslate;
+
+        foreach (var (se4Name, apply) in AutoTranslateMap(t))
+        {
+            var value = Value(tools, se4Name);
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                apply(value);
+            }
+        }
+
+        SetInt(tools, "AutoTranslateMaxBytes", 1, int.MaxValue, v => t.RequestMaxBytes = v);
+        SetInt(tools, "AutoTranslateDelaySeconds", 0, 3600, v => t.RequestDelaySeconds = v);
+        SetInt(tools, "TranslateViaCopyPasteMaxSize", 1, int.MaxValue, v => t.CopyPasteMaxBlockSize = v);
+    }
+
+    private static IEnumerable<(string Name, Action<string> Apply)> AutoTranslateMap(SeAutoTranslate t)
+    {
+        yield return ("GoogleApiV2Key", v => t.GoogleApiV2Key = v);
+        yield return ("MicrosoftBingApiId", v => t.MicrosoftBingApiId = v);
+        yield return ("MicrosoftTranslatorApiKey", v => t.MicrosoftTranslatorApiKey = v);
+        yield return ("MicrosoftTranslatorTokenEndpoint", v => t.MicrosoftTranslatorTokenEndpoint = v);
+        yield return ("MicrosoftTranslatorCategory", v => t.MicrosoftTranslatorCategory = v);
+
+        yield return ("AutoTranslateDeepLApiKey", v => t.DeepLApiKey = v);
+        yield return ("AutoTranslateDeepLUrl", v => t.DeepLUrl = v);
+        yield return ("AutoTranslateDeepLFormality", v => t.DeepLFormality = v);
+        yield return ("AutoTranslateDeepLXUrl", v => t.DeepLXUrl = v);
+        yield return ("AutoTranslateLibreUrl", v => t.LibreTranslateUrl = v);
+        yield return ("AutoTranslateLibreApiKey", v => t.LibreTranslateApiKey = v);
+        yield return ("AutoTranslateMyMemoryApiKey", v => t.MyMemoryApiKey = v);
+        yield return ("AutoTranslateNllbApiUrl", v => t.NllbApiUrl = v);
+        yield return ("AutoTranslateNllbServeUrl", v => t.NllbServeUrl = v);
+        yield return ("AutoTranslateNllbServeModel", v => t.NllbServeModel = v);
+        yield return ("AutoTranslateSeamlessM4TUrl", v => t.SeamlessM4TUrl = v);
+        yield return ("AutoTranslatePapagoApiKeyId", v => t.PapagoApiKeyId = v);
+        yield return ("AutoTranslatePapagoApiKey", v => t.PapagoApiKey = v);
+        yield return ("AutoTranslateMistralApiKey", v => t.MistralApiKey = v);
+        yield return ("AutoTranslateMistralUrl", v => t.MistralUrl = v);
+        yield return ("AutoTranslateMistralModel", v => t.MistralModel = v);
+        yield return ("AutoTranslateMistralPrompt", v => t.MistralPrompt = v);
+
+        yield return ("ChatGptUrl", v => t.ChatGptUrl = v);
+        yield return ("ChatGptPrompt", v => t.ChatGptPrompt = v);
+        yield return ("ChatGptApiKey", v => t.ChatGptApiKey = v);
+        yield return ("ChatGptModel", v => t.ChatGptModel = v);
+        yield return ("GroqUrl", v => t.GroqUrl = v);
+        yield return ("GroqPrompt", v => t.GroqPrompt = v);
+        yield return ("GroqApiKey", v => t.GroqApiKey = v);
+        yield return ("GroqModel", v => t.GroqModel = v);
+        yield return ("DeepSeekUrl", v => t.DeepSeekUrl = v);
+        yield return ("DeepSeekPrompt", v => t.DeepSeekPrompt = v);
+        yield return ("DeepSeekApiKey", v => t.DeepSeekApiKey = v);
+        yield return ("DeepSeekModel", v => t.DeepSeekModel = v);
+        yield return ("AvalAiUrl", v => t.AvalAiUrl = v);
+        yield return ("AvalAiPrompt", v => t.AvalAiPrompt = v);
+        yield return ("AvalAiApiKey", v => t.AvalAiApiKey = v);
+        yield return ("AvalAiModel", v => t.AvalAiModel = v);
+        yield return ("OpenRouterUrl", v => t.OpenRouterUrl = v);
+        yield return ("OpenRouterPrompt", v => t.OpenRouterPrompt = v);
+        yield return ("OpenRouterApiKey", v => t.OpenRouterApiKey = v);
+        yield return ("OpenRouterModel", v => t.OpenRouterModel = v);
+        yield return ("LmStudioApiUrl", v => t.LmStudioApiUrl = v);
+        yield return ("LmStudioModel", v => t.LmStudioModel = v);
+        yield return ("LmStudioPrompt", v => t.LmStudioPrompt = v);
+        yield return ("OllamaApiUrl", v => t.OllamaUrl = v);
+        yield return ("OllamaModels", v => t.OllamaModels = v);
+        yield return ("OllamaModel", v => t.OllamaModel = v);
+        yield return ("OllamaPrompt", v => t.OllamaPrompt = v);
+        yield return ("KoboldCppUrl", v => t.KoboldCppUrl = v);
+        yield return ("KoboldCppPrompt", v => t.KoboldCppPrompt = v);
+        yield return ("AnthropicApiUrl", v => t.AnthropicApiUrl = v);
+        yield return ("AnthropicPrompt", v => t.AnthropicPrompt = v);
+        yield return ("AnthropicApiKey", v => t.AnthropicApiKey = v);
+        yield return ("AnthropicApiModel", v => t.AnthropicApiModel = v);
+        yield return ("BaiduUrl", v => t.BaiduUrl = v);
+        yield return ("BaiduApiKey", v => t.BaiduApiKey = v);
+        yield return ("GeminiProApiKey", v => t.GeminiProApiKey = v);
+        yield return ("GeminiModel", v => t.GeminiModel = v);
+        yield return ("TranslateViaCopyPasteSeparator", v => t.CopyPasteLineSeparator = v);
+    }
+
+    /// <summary>
+    /// Shortcuts go through the existing SE 4 importer (it also carries the custom-search slots
+    /// and the toggle-custom-tags pair the keys point at). A merge, like every other SE 4 import:
+    /// only actions the file actually binds are replaced.
+    /// </summary>
+    /// <param name="normalizeShortcuts">
+    /// Called with the imported bindings before they are merged in. SE 4 runs on Windows, so its
+    /// modifiers are the Ctrl-based ones; importing on macOS hands them here to be swapped for the
+    /// Cmd key the SE 5 defaults use.
+    /// </param>
+    public static Se4ShortcutsImporter.ImportResult ApplyShortcuts(
+        Se4SettingsFile file,
+        Action<List<SeShortCut>>? normalizeShortcuts = null)
+    {
+        var result = Se4ShortcutsImporter.ImportFromXml(file.Xml);
+        normalizeShortcuts?.Invoke(result.Shortcuts);
+
+        foreach (var shortcut in result.Shortcuts)
+        {
+            var existing = Se.Settings.Shortcuts.FirstOrDefault(s => s.ActionName == shortcut.ActionName);
+            if (existing != null)
+            {
+                Se.Settings.Shortcuts.Remove(existing);
+            }
+
+            Se.Settings.Shortcuts.Add(shortcut);
+        }
+
+        ApplyCustomSearches(result);
+        ApplyCustomTags(result);
+
+        return result;
+    }
+
+    // Slot N of SE 4 is slot N of SE 5, and the key that fires it travels in the same import -
+    // a key pointing at a slot that searches a different site is worse than no key at all.
+    private static void ApplyCustomSearches(Se4ShortcutsImporter.ImportResult result)
+    {
+        foreach (var (slotNumber, search) in result.CustomSearches)
+        {
+            if (slotNumber < 1 || slotNumber > Se.CustomSearchSlotCount)
+            {
+                continue;
+            }
+
+            Se.Settings.SetCustomSearch(slotNumber, search.Name, search.Url);
+            ShortcutsMain.CommandTranslationLookup[$"CustomSearch{slotNumber}Command"] =
+                ShortcutsMain.GetSearchViaTitle(slotNumber, search.Name, search.Url);
+        }
+    }
+
+    // SE 4 has one "toggle custom tags" pair; SE 5 has eight "surround with" slots. Park the pair
+    // on the slot already holding it, or on the first free one, and move the imported key onto
+    // that slot - see ShortcutsViewModel.ApplySe4CustomTags, which does the same for the Shortcuts
+    // window. When every slot is taken the key stays on slot 1: overwriting a pair the user is
+    // using would cost more than the import gains.
+    private static void ApplyCustomTags(Se4ShortcutsImporter.ImportResult result)
+    {
+        var start = result.CustomTagsStart;
+        var end = result.CustomTagsEnd;
+        if (start == null || end == null)
+        {
+            return;
+        }
+
+        var importedShortcut = result.Shortcuts
+            .FirstOrDefault(s => s.ActionName == nameof(Features.Main.MainViewModel.SurroundWith1Command));
+        if (importedShortcut == null)
+        {
+            return;
+        }
+
+        var slotNumber = -1;
+        for (var i = 1; i <= Se.SurroundWithSlotCount; i++)
+        {
+            if (Se.Settings.GetSurroundLeft(i) == start && Se.Settings.GetSurroundRight(i) == end)
+            {
+                slotNumber = i;
+                break;
+            }
+        }
+
+        for (var i = 1; slotNumber < 0 && i <= Se.SurroundWithSlotCount; i++)
+        {
+            if (string.IsNullOrEmpty(Se.Settings.GetSurroundLeft(i)) &&
+                string.IsNullOrEmpty(Se.Settings.GetSurroundRight(i)))
+            {
+                slotNumber = i;
+            }
+        }
+
+        if (slotNumber < 0)
+        {
+            return;
+        }
+
+        Se.Settings.SetSurround(slotNumber, start, end);
+
+        var commandName = $"SurroundWith{slotNumber}Command";
+        var existing = Se.Settings.Shortcuts.FirstOrDefault(s => s.ActionName == commandName);
+        if (existing != null)
+        {
+            Se.Settings.Shortcuts.Remove(existing);
+        }
+
+        // The shortcut was added as SurroundWith1Command above; move it to the slot the pair
+        // landed on (it is the same object, so the list entry moves with it).
+        importedShortcut.ActionName = commandName;
+        if (!Se.Settings.Shortcuts.Contains(importedShortcut))
+        {
+            Se.Settings.Shortcuts.Add(importedShortcut);
+        }
+
+        ShortcutsMain.CommandTranslationLookup[commandName] =
+            ShortcutsMain.GetSurroundWithTitle(slotNumber, start, end);
+    }
+
+    private static string? Value(XElement parent, string name)
+    {
+        return parent.Elements().FirstOrDefault(e => e.Name.LocalName == name)?.Value;
+    }
+
+    private static void SetInt(XElement parent, string name, int min, int max, Action<int> apply)
+    {
+        var value = Value(parent, name);
+        if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var number) &&
+            number >= min &&
+            number <= max)
+        {
+            apply(number);
+        }
+    }
+
+    private static void SetDouble(XElement parent, string name, double min, double max, Action<double> apply)
+    {
+        var value = Value(parent, name);
+        if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var number) &&
+            number >= min &&
+            number <= max)
+        {
+            apply(number);
+        }
+    }
+
+    private static void SetBool(XElement parent, string name, Action<bool> apply)
+    {
+        if (bool.TryParse(Value(parent, name), out var value))
+        {
+            apply(value);
+        }
+    }
+
+    private static void SetEnumName<T>(XElement parent, string name, Action<string> apply) where T : struct, Enum
+    {
+        var value = Value(parent, name);
+        if (!string.IsNullOrWhiteSpace(value) && Enum.TryParse<T>(value, out var parsed))
+        {
+            apply(parsed.ToString());
+        }
+    }
+
+    // SE 4 writes colors as System.Drawing's signed 32-bit ARGB (Color.ToArgb); SE 5 stores hex.
+    private static void SetColor(XElement parent, string name, Action<string> apply)
+    {
+        var value = Value(parent, name);
+        if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var argb))
+        {
+            return;
+        }
+
+        var bytes = unchecked((uint)argb);
+        var color = Color.FromArgb(
+            (byte)((bytes >> 24) & 0xFF),
+            (byte)((bytes >> 16) & 0xFF),
+            (byte)((bytes >> 8) & 0xFF),
+            (byte)(bytes & 0xFF));
+
+        apply(color.FromColorToHex());
+    }
+}

--- a/tests/UI/Features/Options/Settings/SettingsImportSe4XmlTests.cs
+++ b/tests/UI/Features/Options/Settings/SettingsImportSe4XmlTests.cs
@@ -1,0 +1,172 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Options.Settings.SettingsImportExport;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace UITests.Features.Options.Settings;
+
+/// <summary>
+/// The Settings import dialog only offered ".json", so a user arriving from SE 4.0.12 - who has a
+/// Settings.xml and nothing else - could not even select their file (#14309). The dialog now takes
+/// the classic XML too, mapping the categories its own checkboxes offer.
+/// </summary>
+public class SettingsImportSe4XmlTests
+{
+    private sealed class FakeFileHelper : IFileHelper
+    {
+        private readonly string _path;
+
+        public FakeFileHelper(string path) => _path = path;
+
+        public Task<string> PickOpenFile(Visual sender, string title, string extensionTitle, string extension, string extensionTitle2 = "", string extension2 = "", string? suggestedStartFolder = null) => Task.FromResult(_path);
+
+        public Task<string> PickSaveFile(Visual sender, string extension, string suggestedFileName, string title) => Task.FromResult(_path);
+        public Task<string[]> PickOpenFiles(Visual sender, string title, string extensionTitle, List<string> extensions, string extensionTitle2, List<string> extensions2) => throw new NotSupportedException();
+        public Task<string> PickOpenSubtitleFile(Visual sender, string title, bool includeVideoFiles = true, string? lastOpenedFilePath = null, bool includeSpreadsheets = false) => throw new NotSupportedException();
+        public Task<string[]> PickOpenSubtitleFiles(Visual sender, string title, bool includeVideoFiles = true, string? lastOpenedFilePath = null) => throw new NotSupportedException();
+        public Task<string> PickSaveSubtitleFile(Visual sender, Nikse.SubtitleEdit.Core.SubtitleFormats.SubtitleFormat currentFormat, string suggestedFileName, string title) => throw new NotSupportedException();
+        public Task<FileHelperSubtitleSavePickerResult?> PickSaveSubtitleFileAs(Visual sender, Nikse.SubtitleEdit.Core.SubtitleFormats.SubtitleFormat currentFormat, string suggestedFileName, string title) => throw new NotSupportedException();
+        public Task<string> PickSaveSubtitleFile(Visual sender, string extension, string suggestedFileName, string title) => throw new NotSupportedException();
+        public Task<string> PickSaveFile(Visual sender, string extension, string extensionTitle, string suggestedFileName, string title) => throw new NotSupportedException();
+        public Task<string> PickSaveFile(Visual sender, IReadOnlyList<(string Name, string Extension)> fileTypes, string suggestedFileName, string title) => throw new NotSupportedException();
+        public Task<string> PickOpenVideoFile(Visual sender, string title) => throw new NotSupportedException();
+        public Task<string[]> PickOpenVideoFiles(Visual sender, string title) => throw new NotSupportedException();
+        public Task<string> PickOpenImageFile(Visual sender, string title) => throw new NotSupportedException();
+    }
+
+    private const string Se4SettingsXml =
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+        "<Settings>" +
+        "<General>" +
+        "<SubtitleLineMaximumLength>37</SubtitleLineMaximumLength>" +
+        "<SubtitleMaximumCharactersPerSeconds>17</SubtitleMaximumCharactersPerSeconds>" +
+        "<UseDarkTheme>True</UseDarkTheme>" +
+        "</General>" +
+        "<Tools>" +
+        "<ListViewSyntaxColorGap>True</ListViewSyntaxColorGap>" +
+        "<ChatGptApiKey>from-se4</ChatGptApiKey>" +
+        "</Tools>" +
+        "<VideoControls><WaveformDrawGrid>True</WaveformDrawGrid></VideoControls>" +
+        "<Shortcuts><MainFileSaveAll>Control+Shift+S</MainFileSaveAll></Shortcuts>" +
+        "</Settings>";
+
+    private static async Task<string> WriteXml(string xml, string extension = ".xml")
+    {
+        Directory.CreateDirectory(SettingsIsolationFixture.SettingsDirectory);
+        var path = Path.Combine(SettingsIsolationFixture.SettingsDirectory, Guid.NewGuid().ToString("N") + extension);
+        await File.WriteAllTextAsync(path, xml);
+        return path;
+    }
+
+    private static async Task<(SettingsImportExportViewModel Vm, Se Target)> Load(string path)
+    {
+        var vm = new SettingsImportExportViewModel(new FakeFileHelper(path)) { Window = new Window() };
+        vm.SetIsExport(false);
+        Assert.True(await vm.PromptAndLoadImportFile());
+        return (vm, new Se());
+    }
+
+    private static async Task ImportInto(SettingsImportExportViewModel vm, Se target, Action<SettingsImportExportViewModel>? configure = null)
+    {
+        var previous = Se.Settings;
+        Se.Settings = target;
+        try
+        {
+            configure?.Invoke(vm);
+            await vm.OkCommand.ExecuteAsync(null);
+        }
+        finally
+        {
+            Se.Settings = previous;
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task ImportAllFromSe4XmlFillsEveryCategoryTheFileCovers()
+    {
+        var (vm, target) = await Load(await WriteXml(Se4SettingsXml));
+
+        await ImportInto(vm, target, v => v.ExportImportAll = true);
+
+        Assert.Equal(37, target.General.SubtitleLineMaximumLength);
+        Assert.Equal(17, target.General.SubtitleMaximumCharactersPerSeconds);
+        Assert.True(target.General.ColorGapTooShort);
+        Assert.True(target.Waveform.DrawGridLines);
+        Assert.Equal("Dark", target.Appearance.Theme);
+        Assert.Equal("from-se4", target.AutoTranslate.ChatGptApiKey);
+        Assert.Contains(target.Shortcuts, s => s.ActionName == nameof(MainViewModel.CommandFileSaveCommand));
+    }
+
+    // SE 4's tree is not SE 5's: a category is copied field by field, so an SE 5 setting SE 4
+    // never had must survive the import instead of being reset to a default.
+    [AvaloniaFact]
+    public async Task ImportFromSe4XmlKeepsSettingsSe4HasNoCounterpartFor()
+    {
+        var (vm, target) = await Load(await WriteXml(Se4SettingsXml));
+        target.General.PromptBeforeDelete = true;
+        target.Waveform.WaveformShotChangeColor = "#FF123456";
+        target.AutoTranslate.NvidiaApiKey = "keep-me";
+
+        await ImportInto(vm, target, v => v.ExportImportAll = true);
+
+        Assert.True(target.General.PromptBeforeDelete);
+        Assert.Equal("#FF123456", target.Waveform.WaveformShotChangeColor);
+        Assert.Equal("keep-me", target.AutoTranslate.NvidiaApiKey);
+    }
+
+    [AvaloniaFact]
+    public async Task ImportFromSe4XmlAppliesOnlyTheTickedCategories()
+    {
+        var (vm, target) = await Load(await WriteXml(Se4SettingsXml));
+
+        await ImportInto(vm, target, v =>
+        {
+            v.ExportImportAll = false;
+            v.ExportImportWaveform = true;
+        });
+
+        Assert.True(target.Waveform.DrawGridLines);
+        Assert.Equal(new Se().General.SubtitleLineMaximumLength, target.General.SubtitleLineMaximumLength);
+        Assert.Equal(new Se().Appearance.Theme, target.Appearance.Theme);
+        Assert.Empty(target.Shortcuts);
+    }
+
+    // Same rule as a partial JSON export: a checkbox the file cannot fill is greyed out.
+    [AvaloniaFact]
+    public async Task LoadingAnSe4XmlDisablesTheCategoriesItDoesNotCarry()
+    {
+        var (vm, _) = await Load(await WriteXml(
+            "<Settings><VideoControls><WaveformDrawGrid>True</WaveformDrawGrid></VideoControls></Settings>"));
+
+        Assert.True(vm.IsWaveformEnabled);
+        Assert.False(vm.IsRulesEnabled);
+        Assert.False(vm.IsAppearanceEnabled);
+        Assert.False(vm.IsAutoTranslateEnabled);
+        Assert.False(vm.IsShortcutsEnabled);
+    }
+
+    // The picker offers both file types, so the branch is decided by what is in the file - a
+    // Settings.xml renamed to .json still has to import as SE 4.
+    [AvaloniaFact]
+    public async Task AnSe4XmlIsRecognizedByItsContentNotItsExtension()
+    {
+        var (vm, target) = await Load(await WriteXml(Se4SettingsXml, ".json"));
+
+        await ImportInto(vm, target, v => v.ExportImportAll = true);
+
+        Assert.Equal(37, target.General.SubtitleLineMaximumLength);
+    }
+
+    [AvaloniaFact]
+    public async Task LoadingAFileThatIsNeitherFormatFails()
+    {
+        var path = await WriteXml("<NotSubtitleEditSettings><Foo>1</Foo></NotSubtitleEditSettings>");
+        var vm = new SettingsImportExportViewModel(new FakeFileHelper(path)) { Window = new Window() };
+        vm.SetIsExport(false);
+
+        Assert.False(await vm.PromptAndLoadImportFile());
+    }
+}

--- a/tests/UI/Logic/Se4SettingsXmlImporterTests.cs
+++ b/tests/UI/Logic/Se4SettingsXmlImporterTests.cs
@@ -1,0 +1,276 @@
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Se4Setup;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// The Settings import dialog only took an SE 5 Settings.json, which a user coming from SE 4 does
+/// not have (#14309). These cover the SE 4 Settings.xml path: the sections it finds decide which
+/// categories the dialog offers, and each category is mapped field by field - anything SE 4 has no
+/// counterpart for has to keep its current value rather than fall back to an SE 5 default.
+/// </summary>
+public class Se4SettingsXmlImporterTests : IDisposable
+{
+    private readonly SeGeneral _originalGeneral = Se.Settings.General;
+    private readonly SeWaveform _originalWaveform = Se.Settings.Waveform;
+    private readonly SeAppearance _originalAppearance = Se.Settings.Appearance;
+    private readonly SeAutoTranslate _originalAutoTranslate = Se.Settings.AutoTranslate;
+
+    public Se4SettingsXmlImporterTests()
+    {
+        // Fresh sections so a mapped value is provably the import's doing, and so the real
+        // settings of whoever runs the suite are never touched.
+        Se.Settings.General = new SeGeneral();
+        Se.Settings.Waveform = new SeWaveform();
+        Se.Settings.Appearance = new SeAppearance();
+        Se.Settings.AutoTranslate = new SeAutoTranslate();
+    }
+
+    public void Dispose()
+    {
+        Se.Settings.General = _originalGeneral;
+        Se.Settings.Waveform = _originalWaveform;
+        Se.Settings.Appearance = _originalAppearance;
+        Se.Settings.AutoTranslate = _originalAutoTranslate;
+    }
+
+    private static Se4SettingsXmlImporter.Se4SettingsFile Parse(string xml)
+    {
+        var file = Se4SettingsXmlImporter.Parse(xml);
+        Assert.NotNull(file);
+        return file!;
+    }
+
+    [Fact]
+    public void LooksLikeXml_AcceptsAnSe4FileAndRejectsJson()
+    {
+        Assert.True(Se4SettingsXmlImporter.LooksLikeXml("<?xml version=\"1.0\"?><Settings />"));
+        Assert.True(Se4SettingsXmlImporter.LooksLikeXml("﻿\r\n  <Settings />"));
+        Assert.False(Se4SettingsXmlImporter.LooksLikeXml("{ \"General\": {} }"));
+    }
+
+    [Fact]
+    public void Parse_RejectsAnythingThatIsNotAnSe4SettingsFile()
+    {
+        Assert.Null(Se4SettingsXmlImporter.Parse("<Settings><General>"));
+        Assert.Null(Se4SettingsXmlImporter.Parse("<MultipleSearchAndReplaceList><Item /></MultipleSearchAndReplaceList>"));
+
+        // Right root, but nothing the dialog can offer.
+        Assert.Null(Se4SettingsXmlImporter.Parse("<Settings><SsaStyle><FontName>Arial</FontName></SsaStyle></Settings>"));
+    }
+
+    [Fact]
+    public void Parse_ReportsWhichCategoriesTheFileCanFill()
+    {
+        var file = Parse("<Settings><General><MaxNumberOfLines>2</MaxNumberOfLines></General></Settings>");
+
+        Assert.True(file.HasRules);
+        Assert.True(file.HasAppearance);
+        Assert.True(file.HasSyntaxColoring);
+        Assert.False(file.HasWaveform);
+        Assert.False(file.HasAutoTranslate);
+        Assert.False(file.HasShortcuts);
+    }
+
+    // An empty <Tools /> is not an auto-translate section - offering the checkbox for it would let
+    // the user "import" nothing at all.
+    [Fact]
+    public void Parse_TreatsAnEmptySectionAsAbsent()
+    {
+        var file = Parse("<Settings><General><MaxNumberOfLines>2</MaxNumberOfLines></General><Tools /></Settings>");
+
+        Assert.False(file.HasAutoTranslate);
+    }
+
+    [Fact]
+    public void ApplyRules_MapsTheSe4RuleValues()
+    {
+        var file = Parse(
+            "<Settings><General>" +
+            "<SubtitleLineMaximumLength>37</SubtitleLineMaximumLength>" +
+            "<MaxNumberOfLines>3</MaxNumberOfLines>" +
+            "<MergeLinesShorterThan>34</MergeLinesShorterThan>" +
+            "<SubtitleMinimumDisplayMilliseconds>1200</SubtitleMinimumDisplayMilliseconds>" +
+            "<SubtitleMaximumDisplayMilliseconds>7000</SubtitleMaximumDisplayMilliseconds>" +
+            "<MinimumMillisecondsBetweenLines>84</MinimumMillisecondsBetweenLines>" +
+            "<SubtitleMaximumCharactersPerSeconds>17.5</SubtitleMaximumCharactersPerSeconds>" +
+            "<SubtitleMaximumWordsPerMinute>190</SubtitleMaximumWordsPerMinute>" +
+            "<DialogStyle>DashSecondLineWithoutSpace</DialogStyle>" +
+            "<DefaultFrameRate>25</DefaultFrameRate>" +
+            "</General></Settings>");
+
+        var frames = Se.Settings.General.MinimumBetweenLines.Frames;
+        Se4SettingsXmlImporter.ApplyRules(file);
+
+        var g = Se.Settings.General;
+        Assert.Equal(37, g.SubtitleLineMaximumLength);
+        Assert.Equal(3, g.MaxNumberOfLines);
+        Assert.Equal(34, g.UnbreakLinesShorterThan);
+        Assert.Equal(1200, g.SubtitleMinimumDisplayMilliseconds);
+        Assert.Equal(7000, g.SubtitleMaximumDisplayMilliseconds);
+        Assert.Equal(84, g.MinimumBetweenLines.Milliseconds);
+        Assert.Equal(17.5, g.SubtitleMaximumCharactersPerSeconds);
+        Assert.Equal(190, g.SubtitleMaximumWordsPerMinute);
+        Assert.Equal("DashSecondLineWithoutSpace", g.DialogStyle);
+        Assert.Equal(25, g.DefaultFrameRate);
+
+        // SE 4 has no frame count for the minimum gap, so SE 5's must survive the import.
+        Assert.Equal(frames, g.MinimumBetweenLines.Frames);
+    }
+
+    // SeGeneral.ToProfile does Enum.Parse on these, so a value SE 5 no longer knows would throw
+    // every time the rules profile is read - keep the current one instead.
+    [Fact]
+    public void ApplyRules_IgnoresADialogStyleSe5DoesNotKnow()
+    {
+        var file = Parse("<Settings><General><DialogStyle>SomethingElse</DialogStyle></General></Settings>");
+        var before = Se.Settings.General.DialogStyle;
+
+        Se4SettingsXmlImporter.ApplyRules(file);
+
+        Assert.Equal(before, Se.Settings.General.DialogStyle);
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("23976")] // SE 4 could read back a locale-mangled "23,976" as this
+    [InlineData("not a number")]
+    public void ApplyRules_IgnoresAnOutOfRangeFrameRate(string value)
+    {
+        var file = Parse($"<Settings><General><DefaultFrameRate>{value}</DefaultFrameRate></General></Settings>");
+        var before = Se.Settings.General.DefaultFrameRate;
+
+        Se4SettingsXmlImporter.ApplyRules(file);
+
+        Assert.Equal(before, Se.Settings.General.DefaultFrameRate);
+    }
+
+    [Fact]
+    public void ApplySyntaxColoring_MapsTheToolsTogglesAndTheErrorColor()
+    {
+        var file = Parse(
+            "<Settings>" +
+            "<General><SubtitleLineMaximumPixelWidth>640</SubtitleLineMaximumPixelWidth>" +
+            "<MeasureFontName>Verdana</MeasureFontName><MeasureFontSize>30</MeasureFontSize></General>" +
+            "<Tools>" +
+            "<ListViewSyntaxColorDurationSmall>True</ListViewSyntaxColorDurationSmall>" +
+            "<ListViewSyntaxColorLongLines>False</ListViewSyntaxColorLongLines>" +
+            "<ListViewSyntaxColorGap>True</ListViewSyntaxColorGap>" +
+            // System.Drawing's Color.ToArgb for the SE 4 default (255, 180, 150).
+            "<ListViewSyntaxErrorColor>-19306</ListViewSyntaxErrorColor>" +
+            "</Tools></Settings>");
+
+        Se4SettingsXmlImporter.ApplySyntaxColoring(file);
+
+        var g = Se.Settings.General;
+        Assert.True(g.ColorDurationTooShort);
+        Assert.False(g.ColorTextTooLong);
+        Assert.True(g.ColorGapTooShort);
+        Assert.Equal("#FFFFB496", g.ErrorColor.ToUpperInvariant());
+        Assert.Equal(640, g.ColorTextTooWidePixels);
+        Assert.Equal("Verdana", g.ColorTextTooWideFontName);
+        Assert.Equal(30, g.ColorTextTooWideFontSize);
+    }
+
+    [Fact]
+    public void ApplyWaveform_MapsColorsAndToggles()
+    {
+        var file = Parse(
+            "<Settings><VideoControls>" +
+            "<WaveformColor>-16711936</WaveformColor>" +      // Lime
+            "<WaveformBackgroundColor>-16777216</WaveformBackgroundColor>" + // Black
+            "<WaveformDrawGrid>True</WaveformDrawGrid>" +
+            "<WaveformTextSize>14</WaveformTextSize>" +
+            "<WaveformTextBold>True</WaveformTextBold>" +
+            "</VideoControls></Settings>");
+
+        var shotChangeColor = Se.Settings.Waveform.WaveformShotChangeColor;
+        Se4SettingsXmlImporter.ApplyWaveform(file);
+
+        var w = Se.Settings.Waveform;
+        Assert.Equal("#FF00FF00", w.WaveformColor.ToUpperInvariant());
+        Assert.Equal("#FF000000", w.WaveformBackgroundColor.ToUpperInvariant());
+        Assert.True(w.DrawGridLines);
+        Assert.Equal(14, w.WaveformTextFontSize);
+        Assert.True(w.WaveformTextFontBold);
+
+        // SE 4 has no shot-change color; SE 5's must not be reset by the import.
+        Assert.Equal(shotChangeColor, w.WaveformShotChangeColor);
+    }
+
+    [Fact]
+    public void ApplyAppearance_MapsThemeFontsAndToolbarButtons()
+    {
+        var file = Parse(
+            "<Settings><General>" +
+            "<UseDarkTheme>True</UseDarkTheme>" +
+            "<SubtitleFontName>Consolas</SubtitleFontName>" +
+            "<SubtitleTextBoxFontSize>13</SubtitleTextBoxFontSize>" +
+            "<SubtitleListViewFontSize>11</SubtitleListViewFontSize>" +
+            "<ShowToolbarNew>False</ShowToolbarNew>" +
+            "<ShowToolbarVisualSync>True</ShowToolbarVisualSync>" +
+            "</General></Settings>");
+
+        Se4SettingsXmlImporter.ApplyAppearance(file);
+
+        var a = Se.Settings.Appearance;
+        Assert.Equal(UiTheme.ThemeNameDark, a.Theme);
+        Assert.Equal("Consolas", a.SubtitleTextBoxAndGridFontName);
+        Assert.Equal(13, a.SubtitleTextBoxFontSize);
+        Assert.Equal(11, a.SubtitleGridFontSize);
+        Assert.False(a.ToolbarShowFileNew);
+        Assert.True(a.ToolbarShowVisualSync);
+    }
+
+    [Fact]
+    public void ApplyAppearance_UsesTheLightThemeWhenSe4WasNotDark()
+    {
+        var file = Parse("<Settings><General><UseDarkTheme>False</UseDarkTheme></General></Settings>");
+
+        Se4SettingsXmlImporter.ApplyAppearance(file);
+
+        Assert.Equal(UiTheme.ThemeNameLight, Se.Settings.Appearance.Theme);
+    }
+
+    // SE 4 prefixed several of these with "AutoTranslate" and SE 5 does not, so the renamed ones
+    // are the ones worth pinning down.
+    [Fact]
+    public void ApplyAutoTranslate_MapsKeysUrlsAndModels()
+    {
+        var file = Parse(
+            "<Settings><Tools>" +
+            "<AutoTranslateDeepLApiKey>deepl-key</AutoTranslateDeepLApiKey>" +
+            "<AutoTranslateDeepLUrl>https://api.deepl.com/</AutoTranslateDeepLUrl>" +
+            "<AutoTranslateLibreUrl>http://localhost:5000/</AutoTranslateLibreUrl>" +
+            "<OllamaApiUrl>http://localhost:11434/api/generate</OllamaApiUrl>" +
+            "<ChatGptApiKey>chatgpt-key</ChatGptApiKey>" +
+            "<GeminiProApiKey>gemini-key</GeminiProApiKey>" +
+            "<AutoTranslateDelaySeconds>3</AutoTranslateDelaySeconds>" +
+            "</Tools></Settings>");
+
+        Se4SettingsXmlImporter.ApplyAutoTranslate(file);
+
+        var t = Se.Settings.AutoTranslate;
+        Assert.Equal("deepl-key", t.DeepLApiKey);
+        Assert.Equal("https://api.deepl.com/", t.DeepLUrl);
+        Assert.Equal("http://localhost:5000/", t.LibreTranslateUrl);
+        Assert.Equal("http://localhost:11434/api/generate", t.OllamaUrl);
+        Assert.Equal("chatgpt-key", t.ChatGptApiKey);
+        Assert.Equal("gemini-key", t.GeminiProApiKey);
+        Assert.Equal(3, t.RequestDelaySeconds);
+    }
+
+    // An empty element in SE 4's file means "not set"; writing it through would wipe a key the
+    // user has in SE 5.
+    [Fact]
+    public void ApplyAutoTranslate_KeepsTheCurrentValueForAnEmptySe4Value()
+    {
+        Se.Settings.AutoTranslate.ChatGptApiKey = "keep-me";
+        var file = Parse("<Settings><Tools><ChatGptApiKey></ChatGptApiKey></Tools></Settings>");
+
+        Se4SettingsXmlImporter.ApplyAutoTranslate(file);
+
+        Assert.Equal("keep-me", Se.Settings.AutoTranslate.ChatGptApiKey);
+    }
+}


### PR DESCRIPTION
Fixes #14309

The Settings import dialog (Options → Settings → Import) only offered `.json`, so a user arriving from 4.0.12 — who has a classic `Settings.xml` and nothing else — could not even select their file.

The picker now takes `.xml` as well, and the file is recognized by its **content**, not its name: a `Settings.xml` renamed to `.json` still imports as SE 4.

## What gets mapped

An SE 4 file fills the categories the dialog's own checkboxes offer:

| Checkbox | From SE 4 | Examples |
| --- | --- | --- |
| Rules | `General` | line length, max lines, min/max duration, min gap, CPS/WPM, dialog + continuation style, frame rate |
| Syntax coloring | `Tools` + `General` | the `ListViewSyntaxColor*` toggles, the error color, the "too wide" measuring font |
| Waveform | `VideoControls` | waveform/selected/background/text/cursor colors, grid lines, text size + bold, focus on mouse over, snap to shot changes |
| Appearance | `General` | dark/light theme, dark-mode colors, subtitle fonts, toolbar buttons |
| Auto-translate | `Tools` | ~60 engine URLs, models, prompts and API keys (SE 4's `AutoTranslate*` prefixes renamed to SE 5's) |
| Shortcuts | `Shortcuts` | via the existing `Se4ShortcutsImporter`, so the custom-search slots and the toggle-custom-tags pair travel with the keys |

A category the file has no section for is greyed out, exactly as it is for a partial JSON export.

## Design notes

**Field by field, not section by section.** The JSON path assigns whole `Se` sections. Doing that from XML would reset every SE 5 setting SE 4 has no counterpart for, so each mapped value is copied individually:

- ints and doubles are range-checked (SE 4 wrote the frame rate invariant but could read back a locale-mangled `"23,976"` → `23976`);
- `DialogStyle` / `ContinuationStyle` are validated against the libse enums — `SeGeneral.ToProfile` does `Enum.Parse` on them, so an unknown name would throw on every rules-profile read;
- SE 4's signed 32-bit ARGB colors are converted to SE 5's hex;
- an empty SE 4 value means "not set" and leaves your current value alone rather than blanking it;
- the minimum-gap **frame** count survives — SE 4 only has the ms value.

**Shortcuts get the Ctrl → Cmd swap on macOS**, reusing the dialog's existing normalizer, since an SE 4 file is always from Windows.

## Deliberately not included

Multiple-replace rules (not one of this dialog's categories — they have their own import, and "Set up like Subtitle Edit 4" already brings them), rules *profiles*, the icon theme (SE 4's names don't line up with SE 5's), spell check, video and tools settings.

Note that "Set up like Subtitle Edit 4" itself is still reachable only by shortcut — #14311, which would have given it an Options-menu entry, is closed. That is a separate half of #14309.

## Tests

21 new: `Se4SettingsXmlImporterTests` (mapping, validation, "SE 4 has no counterpart → keep the current value") and `SettingsImportSe4XmlTests` (the dialog path: category gating, per-checkbox apply, content-based detection).

Full UI suite: 4417 passed, 1 skipped, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
