### PR TITLE
Prepare v5.2.0-beta30

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -3,6 +3,29 @@ Subtitle Edit Changelog
 
 -----------------------------------------------------------------------------------------------------
 
+v5.2.0-beta30 (31st of August 2026)
+
+* Read Wistia json, DVD Junior SPC, Sonic DVD Producer and YouTube srv3 (.ytt) subtitles
+* Add "Center text in subtitle grid" (SE 4 parity) - thx matmaggi
+* Settings import: accept an SE 4 Settings.xml - thx JDario16
+* Teletext: write G2 characters like the music note, and read the national option sub-set and the Level 2.5 colours - thx René
+* Make dialogs keyboard-navigable: initial focus and Tab, across the UI - thx GrampaWildWilly
+* ASSA style window: scale the preview with the window and give it the whole panel
+* Auto-translate: make Enter press the default button
+* Keep ASSA override blocks out of auto-translate too - thx MrGoraj
+* Sort the OCR fix list alphabetically in Options - Word lists - thx Anth70
+* seconv: give Ollama OCR the same generation limits as the GUI - thx gmariani
+* Fix seconv reporting its version as 5.0.0 - thx gmariani
+* Fix the mouse wheel setting the video position with the option turned off - thx rookes
+* Fix Compare's ignore options, and remember its settings - thx FunkyKnilch
+* Fix the video preview showing EBU STL (and TTML positions) after the format was changed
+* Fix 20 bugs found in a code sweep
+* Update French translation - thx Need74
+* Update Italian translation - thx bovirus
+* Update Japanese translation - thx hisui3393
+
+-----------------------------------------------------------------------------------------------------
+
 v5.2.0-beta29 (30th of August 2026)
 
 * Add configurable "Search via X" shortcuts, with a "Search via" submenu in the text box context menu - thx kadrimarzouki

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "Subtitle Edit",
-  "version": "v5.2.0-beta29",
+  "version": "v5.2.0-beta30",
   "translatedBy": "",
   "cultureName": "en-US",
   "general": {

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -20,7 +20,7 @@ public class Se
     internal const int CurrentMacOsFontMigrationVersion = 1;
     internal const int CurrentShortcutsMigrationVersion = 2;
 
-    public static string Version { get; set; } = "v5.2.0-beta29";
+    public static string Version { get; set; } = "v5.2.0-beta30";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
Release prep for **v5.2.0-beta30**.

- `src/ui/Logic/Config/Se.cs` — version bumped to `v5.2.0-beta30`
- `src/ui/Assets/Languages/English.json` — regenerated (only the `version` field changed; the string set was already up to date)
- `change-log.txt` — new section for the 20 PRs merged since the `v5.2.0-beta29` tag

## PRs covered

Enumerated by ancestor-checking every merged PR's merge commit against `v5.2.0-beta29`:

#14281, #14282, #14286, #14287, #14288, #14289, #14295, #14296, #14297, #14298, #14300, #14301, #14302, #14304, #14305, #14307, #14308, #14312, #14314, #14317, #14324

Collapsed lines:

- #14297 + #14298 → one "Read Wistia json, DVD Junior SPC, Sonic DVD Producer and YouTube srv3 (.ytt) subtitles" line
- #14287 + #14288 → one ASSA style preview line
- #14282 (UI test deflake) left out as internal-only

## Credits to check

- #14305 (teletext G2 export) is credited **thx René**, matching the beta28 Manzanita `.dvbttx` line — it came from the same user mail thread, but there is no issue to confirm the name against.
- #14289 (EBU STL / TTML preview after a format change) came from a report with no linked issue, so it is uncredited — same as the other EBU preview lines in beta29.

Wording is yours to curate as usual.