### PR TITLE
feat: handle colors for imsc rosetta format

### DIFF
--- a/src/libse/SubtitleFormats/TimedTextImscRosetta.cs
+++ b/src/libse/SubtitleFormats/TimedTextImscRosetta.cs
@@ -352,6 +352,17 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     ConvertParagraphNodeToTtmlNode(child, ttmlXml, span);
                     ttmlNode.AppendChild(span);
                 }
+                else if (child.Name == "font" && child.Attributes?["color"] != null)
+                {
+                    XmlNode span = ttmlXml.CreateElement("span", "http://www.w3.org/ns/ttml");
+                    XmlAttribute attr = ttmlXml.CreateAttribute("tts:color", "http://www.w3.org/ns/ttml#styling");
+                    attr.InnerText = child.Attributes["color"].Value;
+                    span.Attributes.Append(attr);
+
+                    // Recursively process child nodes to handle nested tags
+                    ConvertParagraphNodeToTtmlNode(child, ttmlXml, span);
+                    ttmlNode.AppendChild(span);
+                }
                 else
                 {
                     ConvertParagraphNodeToTtmlNode(child, ttmlXml, ttmlNode);

--- a/tests/libse/SubtitleFormats/TimedTextImscRosettaTest.cs
+++ b/tests/libse/SubtitleFormats/TimedTextImscRosettaTest.cs
@@ -71,6 +71,25 @@ public class TimedTextImscRosettaTest
     }
 
     [Fact]
+    public void Font_Color_Is_Preserved()
+    {
+        var rosetta = new TimedTextImscRosetta();
+
+        // make xml
+        var subtitle = new Subtitle();
+        var text = "This is <font color=\"Yellow\">yellow</font>.";
+        subtitle.Paragraphs.Add(new Paragraph(text, 0, 2000));
+        var xml = rosetta.ToText(subtitle, "test");
+
+        Assert.Contains("tts:color=\"Yellow\"", xml);
+
+        // load xml
+        subtitle = new Subtitle();
+        rosetta.LoadSubtitle(subtitle, xml.SplitToLines(), "test.xml");
+        Assert.Equal(text, subtitle.Paragraphs[0].Text);
+    }
+
+    [Fact]
     public void TopAlignment_An8()
     {
         var sut = new TimedTextImscRosetta();


### PR DESCRIPTION
Hello,

I did a small improvement in `TimedTextImscRosetta` subtitle format to be able to keep font colors.
In my case it was to convert from EBU STL to TTML-Rosetta.

Best regards