### PR TITLE
New subtitle format: Csv Excel

### DIFF
--- a/src/libse/SubtitleFormats/CsvExcel.cs
+++ b/src/libse/SubtitleFormats/CsvExcel.cs
@@ -1,0 +1,195 @@
+using Nikse.SubtitleEdit.Core.Common;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace Nikse.SubtitleEdit.Core.SubtitleFormats
+{
+    /// <summary>
+    /// A spreadsheet friendly csv: every field is quoted, the first row names the columns, and the
+    /// time codes carry milliseconds so nothing is lost when the file is edited in Excel/Sheets and
+    /// read back (issue #14321).
+    /// </summary>
+    public class CsvExcel : SubtitleFormat
+    {
+        private const char Separator = ',';
+        private const int NumberIndex = 0;
+        private const int StartIndex = 1;
+        private const int EndIndex = 2;
+        private const int TextIndex = 3;
+        private const int ActorIndex = 4;
+        private const int ForcedIndex = 5;
+
+        private static readonly string[] HeaderFields = { "Number", "Start time", "End time", "Text", "Actor", "Forced" };
+
+        public override string Extension => ".csv";
+
+        public override string Name => "Csv Excel";
+
+        public override bool IsMine(List<string> lines, string fileName)
+        {
+            if (!string.IsNullOrEmpty(fileName) && !fileName.EndsWith(".csv", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            var first = lines.FirstOrDefault(p => !string.IsNullOrWhiteSpace(p));
+            if (first == null || !IsHeaderLine(first))
+            {
+                return false;
+            }
+
+            return base.IsMine(lines, fileName);
+        }
+
+        public override string ToText(Subtitle subtitle, string title)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine(string.Join(Separator.ToString(), HeaderFields.Select(Quote)));
+            foreach (var p in subtitle.Paragraphs)
+            {
+                sb.AppendLine(string.Join(Separator.ToString(),
+                    Quote(p.Number.ToString(CultureInfo.InvariantCulture)),
+                    Quote(EncodeTimeCode(p.StartTime)),
+                    Quote(EncodeTimeCode(p.EndTime)),
+                    Quote(p.Text ?? string.Empty),
+                    Quote(p.Actor ?? string.Empty),
+                    Quote(p.Forced ? "True" : "False")));
+            }
+
+            return sb.ToString().Trim();
+        }
+
+        public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
+        {
+            _errorCount = 0;
+            var rows = CsvUtil.CsvSplitLines(lines, Separator);
+            foreach (var fields in rows)
+            {
+                if (fields.Count == 0)
+                {
+                    continue;
+                }
+
+                if (IsHeaderRow(fields))
+                {
+                    continue;
+                }
+
+                if (fields.Count <= EndIndex ||
+                    !ParseTimeCode(fields[StartIndex], out var start) ||
+                    !ParseTimeCode(fields[EndIndex], out var end))
+                {
+                    _errorCount++;
+                    if (_errorCount > 20)
+                    {
+                        return;
+                    }
+
+                    continue;
+                }
+
+                var p = new Paragraph(start, end, fields.Count > TextIndex ? fields[TextIndex] : string.Empty);
+                if (fields.Count > ActorIndex && !string.IsNullOrWhiteSpace(fields[ActorIndex]))
+                {
+                    p.Actor = fields[ActorIndex];
+                }
+
+                if (fields.Count > ForcedIndex)
+                {
+                    p.Forced = IsTrue(fields[ForcedIndex]);
+                }
+
+                subtitle.Paragraphs.Add(p);
+            }
+
+            subtitle.Renumber();
+        }
+
+        private static string Quote(string value)
+        {
+            return "\"" + (value ?? string.Empty).Replace("\"", "\"\"") + "\"";
+        }
+
+        private static string EncodeTimeCode(TimeCode time)
+        {
+            return string.Format(CultureInfo.InvariantCulture, "{0:00}:{1:00}:{2:00}.{3:000}", time.Hours, time.Minutes, time.Seconds, time.Milliseconds);
+        }
+
+        private static bool IsHeaderLine(string line)
+        {
+            var fields = CsvUtil.CsvSplit(line, false, out _, Separator);
+            return IsHeaderRow(fields.ToList());
+        }
+
+        private static bool IsHeaderRow(IReadOnlyList<string> fields)
+        {
+            if (fields.Count < HeaderFields.Length)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < HeaderFields.Length; i++)
+            {
+                if (!string.Equals(fields[i].Trim(), HeaderFields[i], StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool IsTrue(string value)
+        {
+            var s = value.Trim();
+            return s.Equals("True", StringComparison.OrdinalIgnoreCase) ||
+                   s.Equals("Yes", StringComparison.OrdinalIgnoreCase) ||
+                   s.Equals("Forced", StringComparison.OrdinalIgnoreCase) ||
+                   s == "1";
+        }
+
+        /// <summary>
+        /// Reads "hh:mm:ss.mmm" (also with a comma as decimal separator) - and "hh:mm:ss:ff", so a
+        /// file where the milliseconds were replaced by frames still loads.
+        /// </summary>
+        private static bool ParseTimeCode(string s, out TimeCode tc)
+        {
+            tc = new TimeCode();
+            if (string.IsNullOrWhiteSpace(s))
+            {
+                return false;
+            }
+
+            var arr = s.Trim().Split(new[] { ':', ';', '.', ',' }, StringSplitOptions.None);
+            if (arr.Length != 4 ||
+                !int.TryParse(arr[0], NumberStyles.None, CultureInfo.InvariantCulture, out var hours) ||
+                !int.TryParse(arr[1], NumberStyles.None, CultureInfo.InvariantCulture, out var minutes) ||
+                !int.TryParse(arr[2], NumberStyles.None, CultureInfo.InvariantCulture, out var seconds) ||
+                !int.TryParse(arr[3], NumberStyles.None, CultureInfo.InvariantCulture, out var last))
+            {
+                return false;
+            }
+
+            var trimmed = s.Trim();
+            var separatorBeforeLast = trimmed[trimmed.Length - arr[3].Length - 1];
+            int milliseconds;
+            if (separatorBeforeLast == ':' || separatorBeforeLast == ';')
+            {
+                milliseconds = FramesToMillisecondsMax999(last);
+            }
+            else
+            {
+                // A decimal fraction, so ".05" is 50 ms and not 5 ms - the writer always emits
+                // three digits, but a hand-edited (or spreadsheet-reformatted) file may not.
+                var fraction = arr[3].Length > 3 ? arr[3].Substring(0, 3) : arr[3].PadRight(3, '0');
+                milliseconds = int.Parse(fraction, CultureInfo.InvariantCulture);
+            }
+
+            tc = new TimeCode(hours, minutes, seconds, milliseconds);
+            return true;
+        }
+    }
+}

--- a/src/libse/SubtitleFormats/SubtitleFormat.cs
+++ b/src/libse/SubtitleFormats/SubtitleFormat.cs
@@ -162,6 +162,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     new Csv4(),
                     new Csv5(),
                     new CsvDaVinci(),
+                    new CsvExcel(),
                     new CsvNuendo(),
                     new DCinemaInterop(),
                     new DCinemaSmpte2007(),

--- a/tests/libse/SubtitleFormats/CsvExcelTest.cs
+++ b/tests/libse/SubtitleFormats/CsvExcelTest.cs
@@ -1,0 +1,141 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+
+namespace LibSETests.SubtitleFormats;
+
+public class CsvExcelTest
+{
+    private static Subtitle SaveAndReload(Subtitle subtitle)
+    {
+        var format = new CsvExcel();
+        var text = format.ToText(subtitle, "test");
+        var loaded = new Subtitle();
+        format.LoadSubtitle(loaded, text.SplitToLines(), "test.csv");
+        return loaded;
+    }
+
+    [Fact]
+    public void TimeCodesKeepMilliseconds()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Hello", 1234, 5678));
+
+        var loaded = SaveAndReload(subtitle);
+
+        Assert.Single(loaded.Paragraphs);
+        Assert.Equal(1234, loaded.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(5678, loaded.Paragraphs[0].EndTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void ActorAndForcedRoundTrip()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Forced line", 1000, 3000) { Actor = "Anna", Forced = true });
+        subtitle.Paragraphs.Add(new Paragraph("Normal line", 4000, 6000) { Actor = "Bob" });
+
+        var loaded = SaveAndReload(subtitle);
+
+        Assert.Equal(2, loaded.Paragraphs.Count);
+        Assert.Equal("Anna", loaded.Paragraphs[0].Actor);
+        Assert.True(loaded.Paragraphs[0].Forced);
+        Assert.Equal("Bob", loaded.Paragraphs[1].Actor);
+        Assert.False(loaded.Paragraphs[1].Forced);
+    }
+
+    [Fact]
+    public void QuotesCommasAndLineBreaksRoundTrip()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Two lines," + Environment.NewLine + "and a \"quote\".", 1000, 3000));
+
+        var loaded = SaveAndReload(subtitle);
+
+        Assert.Single(loaded.Paragraphs);
+        Assert.Equal("Two lines," + Environment.NewLine + "and a \"quote\".", loaded.Paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void HeaderRowIsNotImportedAsSubtitle()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Hello", 1000, 3000));
+
+        var text = new CsvExcel().ToText(subtitle, "test");
+
+        Assert.StartsWith("\"Number\",\"Start time\",\"End time\",\"Text\",\"Actor\",\"Forced\"", text);
+        Assert.Single(SaveAndReload(subtitle).Paragraphs);
+    }
+
+    [Fact]
+    public void IsMineRequiresTheHeader()
+    {
+        var format = new CsvExcel();
+        var withHeader = format.ToText(NewSubtitle(), "test").SplitToLines();
+        Assert.True(format.IsMine(withHeader, "test.csv"));
+
+        var withoutHeader = withHeader.Skip(1).ToList();
+        Assert.False(format.IsMine(withoutHeader, "test.csv"));
+    }
+
+    // Other csv dialects must not be claimed - and this format must not be claimed by them.
+    [Fact]
+    public void OtherCsvDialectsAreNotMine()
+    {
+        var nuendo = new CsvNuendo().ToText(NewSubtitle(), "test").SplitToLines();
+        Assert.False(new CsvExcel().IsMine(nuendo, "test.csv"));
+
+        var daVinci = new CsvDaVinci().ToText(NewSubtitle(), "test").SplitToLines();
+        Assert.False(new CsvExcel().IsMine(daVinci, "test.csv"));
+    }
+
+    [Fact]
+    public void AutoDetectPicksCsvExcel()
+    {
+        var lines = new CsvExcel().ToText(NewSubtitle(), "test").SplitToLines();
+        var format = SubtitleFormat.AllSubtitleFormats.First(f => f.IsMine(lines, "test.csv"));
+        Assert.Equal(new CsvExcel().Name, format.Name);
+    }
+
+    [Fact]
+    public void FramesTimeCodesAreAccepted()
+    {
+        var lines = new List<string>
+        {
+            "\"Number\",\"Start time\",\"End time\",\"Text\",\"Actor\",\"Forced\"",
+            "\"1\",\"00:00:01:00\",\"00:00:02:00\",\"Hello\",\"\",\"False\"",
+        };
+
+        var loaded = new Subtitle();
+        new CsvExcel().LoadSubtitle(loaded, lines, "test.csv");
+
+        Assert.Single(loaded.Paragraphs);
+        Assert.Equal(1000, loaded.Paragraphs[0].StartTime.TotalMilliseconds);
+    }
+
+    // A spreadsheet may write "00:00:01.5" instead of the three digits the writer emits.
+    [Fact]
+    public void ShortFractionIsReadAsTenths()
+    {
+        var lines = new List<string>
+        {
+            "\"Number\",\"Start time\",\"End time\",\"Text\",\"Actor\",\"Forced\"",
+            "\"1\",\"00:00:01.5\",\"00:00:02.05\",\"Hello\",\"\",\"False\"",
+        };
+
+        var loaded = new Subtitle();
+        new CsvExcel().LoadSubtitle(loaded, lines, "test.csv");
+
+        Assert.Single(loaded.Paragraphs);
+        Assert.Equal(1500, loaded.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(2050, loaded.Paragraphs[0].EndTime.TotalMilliseconds);
+    }
+
+    private static Subtitle NewSubtitle()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Hello", 1000, 3000) { Actor = "Anna" });
+        subtitle.Paragraphs.Add(new Paragraph("World", 4000, 6000));
+        return subtitle;
+    }
+}


### PR DESCRIPTION
Adds a spreadsheet friendly csv format for #14321 — a header row, every field quoted, and an actor + forced column.

```
"Number","Start time","End time","Text","Actor","Forced"
"1","00:00:01.000","00:00:03.000","Hello, ""world""
second line","Anna","False"
```

- **Time codes** `hh:mm:ss.mmm` — frame-rate independent, so a round trip is exact. The reader also accepts `hh:mm:ss:ff` and short fractions (`00:00:01.5` = 1500 ms) in case a spreadsheet reformats the column.
- **Actor** and **Forced** map to the `Paragraph` fields and survive both directions (`Forced` reads `True`/`Yes`/`Forced`/`1`).
- Quotes, commas and line breaks inside the text are escaped RFC style and parse back through `CsvUtil.CsvSplitLines`.
- `IsMine` requires the exact header row, so the format neither claims other csv dialects nor gets claimed by them.

The bilingual side-by-side column also asked for in the issue is not part of this — `ToText` only sees one subtitle, so an "Original text" column needs the main window to hand the format the aligned original per row. It can be appended later without breaking files written now.

Tested: 9 new tests in `CsvExcelTest.cs` (round trips, header handling, dialect isolation, auto-detect), full libse suite green (1828 tests), and verified end to end with seconv: srt → Csv Excel → srt returns the original text, timings and quoting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)