### PR TITLE
mpv: keep the audio device open while paused

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -2925,6 +2925,7 @@
       "showFullscreenButton": "Show full-screen button",
       "fullscreenHideControls": "Hide video controls in full-screen",
       "autoOpenVideoFile": "Auto-open video file when opening subtitle",
+      "mpvAudioKeepOpen": "Keep the audio device open while paused (mpv)",
       "downloadMpv": "Download mpv",
       "downloadVlc": "Download VLC",
       "allowSingleLetterShortcutsInTextbox": "Allow single-letter shortcuts in text box",

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -447,6 +447,7 @@ public class SettingsPage : UserControl
             MakeCheckboxSetting(Se.Language.Options.Settings.ShowFullscreenButton, nameof(_vm.ShowFullscreenButton)),
             MakeCheckboxSetting(Se.Language.Options.Settings.FullscreenHideControls, nameof(_vm.FullscreenHideControls)),
             MakeCheckboxSetting(Se.Language.Options.Settings.AutoOpenVideoFile, nameof(_vm.AutoOpenVideoFile)),
+            MakeCheckboxSetting(Se.Language.Options.Settings.MpvAudioKeepOpen, nameof(_vm.MpvAudioKeepOpen)),
             new SettingsItem(!_vm.IsLibMpvDownloadVisible, Se.Language.Options.Settings.DownloadMpv, () => new StackPanel
             {
                 Children =

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -266,6 +266,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _showFullscreenButton;
     [ObservableProperty] private bool _fullscreenHideControls;
     [ObservableProperty] private bool _autoOpenVideoFile;
+    [ObservableProperty] private bool _mpvAudioKeepOpen;
 
     [ObservableProperty] private bool _waveformDrawGridLines;
     [ObservableProperty] private bool _waveformFocusOnMouseOver;
@@ -1071,6 +1072,7 @@ public partial class SettingsViewModel : ObservableObject
         ShowFullscreenButton = video.ShowFullscreenButton;
         FullscreenHideControls = video.FullscreenHideControls;
         AutoOpenVideoFile = video.AutoOpen;
+        MpvAudioKeepOpen = video.MpvAudioKeepOpen;
 
         MpvPreviewFontName = video.MpvPreviewFontName;
         MpvPreviewFontSize = video.MpvPreviewFontSize;
@@ -1913,6 +1915,7 @@ public partial class SettingsViewModel : ObservableObject
         video.ShowFullscreenButton = ShowFullscreenButton;
         video.FullscreenHideControls = FullscreenHideControls;
         video.AutoOpen = AutoOpenVideoFile;
+        video.MpvAudioKeepOpen = MpvAudioKeepOpen;
 
         video.MpvPreviewFontName = MpvPreviewFontName;
         video.MpvPreviewFontSize = MpvPreviewFontSize;

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -202,6 +202,7 @@ public class LanguageSettings
     public string ShowFullscreenButton { get; set; }
     public string FullscreenHideControls { get; set; }
     public string AutoOpenVideoFile { get; set; }
+    public string MpvAudioKeepOpen { get; set; }
     public string DownloadMpv { get; set; }
     public string DownloadVlc { get; set; }
     public string AllowSingleLetterShortcutsInTextbox { get; set; }
@@ -536,6 +537,7 @@ public class LanguageSettings
         ShowFullscreenButton = "Show full-screen button";
         FullscreenHideControls = "Hide video controls in full-screen";
         AutoOpenVideoFile = "Auto-open video file when opening subtitle";
+        MpvAudioKeepOpen = "Keep the audio device open while paused (mpv)";
         DownloadMpv = "Download mpv";
         DownloadVlc = "Download VLC";
         AllowSingleLetterShortcutsInTextbox = "Allow single-letter shortcuts in text box";

--- a/src/ui/Logic/Config/SeVideo.cs
+++ b/src/ui/Logic/Config/SeVideo.cs
@@ -75,6 +75,15 @@ public class SeVideo
     /// </summary>
     public double MpvAudioBufferSeconds { get; set; }
 
+    /// <summary>
+    /// mpv's "audio-keep-open" option. mpv's own default is "no", which closes the audio device
+    /// every time playback pauses or stops. On a receiver reached over HDMI that shows up as a
+    /// dropped link on every pause and a second or two of missing audio on resume, while the
+    /// device is reopened and the link re-handshakes (#14330). Held open by default; turn it off
+    /// if you need mpv to release the audio device the moment it pauses.
+    /// </summary>
+    public bool MpvAudioKeepOpen { get; set; }
+
     public SeVideo()
     {
         BurnIn = new();
@@ -116,5 +125,6 @@ public class SeVideo
         MpvPreviewUsePositionFromFile = true;
         MpvPreviewJustify = "auto";
         MpvAudioBufferSeconds = 0.05;
+        MpvAudioKeepOpen = true;
     }
 }

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -462,7 +462,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         }
 
         SetYtDlpPathOption();
-        SetAudioBufferOption();
+        SetPreInitAudioOptions();
 
         var err = _mpvInitialize(_mpv);
         if (err >= 0)
@@ -993,6 +993,35 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         }
     }
 
+    /// <summary>
+    /// Every mpv audio option that has to be set before mpv_initialize, in one call so a new
+    /// init path cannot pick up half of them.
+    /// </summary>
+    private void SetPreInitAudioOptions()
+    {
+        SetAudioBufferOption();
+        SetAudioKeepOpenOption();
+    }
+
+    /// <summary>
+    /// mpv's "audio-keep-open". Its default is "no": the audio device is closed whenever
+    /// playback pauses or stops. Over HDMI to a receiver that drops the audio link on every
+    /// pause - the receiver reports no signal - and reopening it on resume costs a second or
+    /// two of re-handshake, which is heard as missing audio at the start of playback (#14330).
+    /// Holding the device open removes both. Off by setting, for anyone who needs mpv to hand
+    /// the device back the moment it pauses.
+    /// <para>Must be called before mpv_initialize.</para>
+    /// </summary>
+    private void SetAudioKeepOpenOption()
+    {
+        var keepOpen = Se.Settings.Video.MpvAudioKeepOpen;
+        var err = SetOptionString("audio-keep-open", keepOpen ? "yes" : "no");
+        if (err < 0)
+        {
+            Se.LogError(new InvalidOperationException(GetErrorString(err)), "LibMpvDynamicPlayer could not set audio-keep-open");
+        }
+    }
+
     private int _brightness;
 
     public int ToggleBrightness()
@@ -1132,7 +1161,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         // so let mpv auto-detect from the context it receives.
 
         SetYtDlpPathOption();
-        SetAudioBufferOption();
+        SetPreInitAudioOptions();
 
         // Initialize mpv first
         var err = _mpvInitialize(_mpv);
@@ -1237,7 +1266,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         SetStartPausedOption();
 
         SetYtDlpPathOption();
-        SetAudioBufferOption();
+        SetPreInitAudioOptions();
 
         var err = _mpvInitialize(_mpv);
         if (err < 0)
@@ -2503,7 +2532,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         }
 
         SetYtDlpPathOption();
-        SetAudioBufferOption();
+        SetPreInitAudioOptions();
 
         // Initialize mpv
         var err = _mpvInitialize(_mpv);

--- a/tests/UI/Logic/MpvAudioOptionTests.cs
+++ b/tests/UI/Logic/MpvAudioOptionTests.cs
@@ -1,0 +1,56 @@
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// Issue #14330: mpv closes the audio device whenever playback pauses or stops (its
+/// "audio-keep-open" default is "no"). Over HDMI to a receiver that drops the audio link on
+/// every pause and costs a re-handshake on resume, heard as missing audio at the start of
+/// playback. SE now holds the device open by default, with a setting to give it back.
+/// </summary>
+public class MpvAudioOptionTests
+{
+    [Fact]
+    public void KeepAudioDeviceOpen_IsOnByDefault()
+    {
+        Assert.True(new SeVideo().MpvAudioKeepOpen);
+    }
+
+    /// <summary>
+    /// The option only takes effect when it is set before mpv_initialize, and the player has four
+    /// init paths (software, OpenGL, Metal, and the preview core). Missing the call on one of them
+    /// would leave that path silently on mpv's default, which is exactly the reported bug - so
+    /// every init has to be preceded by the one call that sets the pre-init audio options.
+    /// </summary>
+    [Fact]
+    public void EveryMpvInitPath_SetsThePreInitAudioOptions()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            FindRepoRoot(), "src", "ui", "Logic", "VideoPlayers", "LibMpvDynamic", "LibMpvDynamicPlayer.cs"));
+
+        var inits = Regex.Matches(source, @"_mpvInitialize\(_mpv\)").Count;
+        var optionCalls = Regex.Matches(source, @"^\s*SetPreInitAudioOptions\(\);", RegexOptions.Multiline).Count;
+
+        Assert.True(inits > 0, "no mpv_initialize call found - did the player move?");
+        Assert.True(
+            optionCalls == inits,
+            $"{inits} mpv_initialize call(s) but {optionCalls} SetPreInitAudioOptions() call(s). " +
+            "Every init path must set the pre-init audio options, or that path silently falls back " +
+            "to mpv's defaults (#14330).");
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "src", "ui")))
+        {
+            dir = dir.Parent;
+        }
+
+        return dir?.FullName ?? throw new DirectoryNotFoundException("Could not find repo root");
+    }
+}


### PR DESCRIPTION
Fixes #14330

mpv's `audio-keep-open` defaults to `no`, so it **closes the audio device every time playback pauses or stops**. Over HDMI to a receiver that drops the audio link on each pause — the receiver reports no signal, exactly as described — and reopening it on resume costs a second or two of re-handshake, heard as missing audio at the start of playback.

Nothing in SE ever set the option, so every player core ran on mpv's default. That also explains the reporter's key observation: mpv.net does not show the same gaps with the same libmpv, so the difference had to be an option rather than the library.

## Changes

- `SetAudioKeepOpenOption()` sets `audio-keep-open` from a new `Se.Settings.Video.MpvAudioKeepOpen`, **default on**, with a checkbox under Video ("Keep the audio device open while paused (mpv)").
- Off is a real choice, not a formality: holding the device open keeps it from other applications, which is why mpv itself defaults the other way. Anyone who needs mpv to hand the device back the moment it pauses can turn it off.
- The option only counts if it is set **before `mpv_initialize`**, and the player has four init paths (software, OpenGL, Metal, preview core). Rather than add a fourth duplicated call, both pre-init audio options now go through one `SetPreInitAudioOptions()`, so a new init path cannot pick up half of them.

## Tests

`MpvAudioOptionTests` — the default is on, and a source scan pins `SetPreInitAudioOptions()` to the number of `mpv_initialize` calls. That second one is the one that matters: a fifth init path added later that forgets the options would silently fall back to mpv's defaults on that path only, which is this bug again and invisible in a build.

Full UI suite: 4425 passed, 1 skipped, 0 failed.

## What I could not verify

**I have not reproduced the dropout or confirmed the fix on real hardware** — the symptom needs an AV receiver over HDMI, and no automated test can observe an audio device being closed. The mechanism matches the report precisely and the option is documented for exactly this, but it wants a confirmation from the reporter before this is treated as settled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)