### PR TITLE
Subtitle image previews: one configurable background, in both windows

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -541,6 +541,7 @@
     "setStartAndKeepDuration": "Set start and keep duration",
     "setStartAndOffsetTheRest": "Set start and offset the rest",
     "setUpLikeSubtitleEdit4": "Set up like Subtitle Edit 4 (theme, shortcuts, replace rules)",
+    "imageBackgroundColorDotDotDot": "Image background color...",
     "setVideoOffset": "Set video offset",
     "settings": "Settings",
     "shadow": "Shadow",

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -183,6 +183,9 @@ public partial class OcrViewModel : ObservableObject
     private Iso639Dash2LanguageCode? _sourceLanguageIso;
     private readonly INOcrCaseFixer _nOcrCaseFixer;
     private readonly IWindowService _windowService;
+
+    /// <summary>For the shared image-preview background menu item (#14328).</summary>
+    internal IWindowService WindowService => _windowService;
     private readonly IFileHelper _fileHelper;
     private readonly IFolderHelper _folderHelper;
     private readonly ISpellCheckManager _spellCheckManager;

--- a/src/ui/Features/Ocr/OcrWindow.cs
+++ b/src/ui/Features/Ocr/OcrWindow.cs
@@ -1,4 +1,4 @@
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
@@ -428,6 +428,9 @@ public class OcrWindow : Window
 
     private static Border MakeSubtitleView(OcrViewModel vm)
     {
+        // One brush for every preview cell in this window, so recolouring repaints them all.
+        var previewBackground = ImagePreviewBackground.CreateBrush();
+
         var fullTimeConverter = new TimeSpanToDisplayFullConverter();
         var shortTimeConverter = new TimeSpanToDisplayShortConverter();
 
@@ -539,13 +542,14 @@ public class OcrWindow : Window
                             image.Bind(Image.MaxWidthProperty, new Binding(nameof(vm.ImageMaxWidth)) { Source = vm });
 
                             // Subtitle bitmaps are usually light text on a transparent background, which
-                            // is invisible on a light grid - give them a dark backdrop so they show.
-                            // A checkerboard was tried here (issue #12692) but the tiling competes with
-                            // the glyphs at thumbnail size and makes the grid harder to read; it is kept
-                            // only in the pre-processing preview, where the image is large enough for it.
+                            // is invisible on a light grid - give them a backdrop so they show. A
+                            // checkerboard was tried here (issue #12692) but the tiling competes with the
+                            // glyphs at thumbnail size; it is kept only in the pre-processing preview,
+                            // where the image is large enough for it. The colour is shared with the
+                            // binary-edit grid and configurable from either (#14328).
                             var imageContainer = new Border
                             {
-                                Background = new Avalonia.Media.SolidColorBrush(Avalonia.Media.Color.FromRgb(0x2D, 0x2D, 0x30)),
+                                Background = previewBackground,
                                 CornerRadius = new CornerRadius(3),
                                 Padding = new Thickness(3),
                                 Child = image,
@@ -744,6 +748,9 @@ public class OcrWindow : Window
         };
         menuItemSaveAllImagesWithHtmlIndex.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.ShowContextMenu)) { Mode = BindingMode.TwoWay });
         flyout.Items.Add(menuItemSaveAllImagesWithHtmlIndex);
+
+        flyout.Items.Add(new Separator());
+        flyout.Items.Add(ImagePreviewBackground.MakeMenuItem(vm.WindowService, () => vm.Window, previewBackground));
 
         vm.SubtitleGrid.ContextFlyout = flyout;
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -86,6 +86,9 @@ public partial class BinaryEditViewModel : ObservableObject
     private readonly IFileHelper _fileHelper;
     private readonly IFolderHelper _folderHelper;
     private readonly IWindowService _windowService;
+
+    /// <summary>For the shared image-preview background menu item (#14328).</summary>
+    internal IWindowService WindowService => _windowService;
     private readonly IShortcutManager _shortcutManager;
     private readonly IBluRayHelper _bluRayHelper;
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -1,4 +1,4 @@
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Shapes;
@@ -420,6 +420,9 @@ public class BinaryEditWindow : Window
 
     private static Grid MakeLayoutListViewAndEditBox(BinaryEditViewModel vm, out Grid controlsGrid)
     {
+        // One brush for every preview cell in this window, so recolouring repaints them all.
+        var previewBackground = ImagePreviewBackground.CreateBrush();
+
         var mainGrid = new Grid
         {
             RowDefinitions =
@@ -656,6 +659,9 @@ public class BinaryEditWindow : Window
         flyout.Items.Add(menuItemDelete);
         menuItemDelete.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.HasSelection)));
 
+        flyout.Items.Add(new Separator());
+        flyout.Items.Add(ImagePreviewBackground.MakeMenuItem(vm.WindowService, () => vm.Window, previewBackground));
+
         vm.SubtitleGrid = dataGrid;
         dataGrid.SelectionChanged += vm.SubtitleGridSelectionChanged;
 
@@ -762,11 +768,13 @@ public class BinaryEditWindow : Window
                 };
 
                 // Subtitle bitmaps are light or dark text on a transparent background, both
-                // invisible on a matching flat row backdrop - use the mid-gray checkerboard
-                // so any content shows in either theme (issue #12692).
+                // invisible on a matching flat row backdrop, so they get one of their own. This
+                // was the mid-gray checkerboard (issue #12692), whose light squares left light
+                // subtitles unreadable (#14328); it is now the same configurable colour the OCR
+                // grid uses, changeable from the context menu in either window.
                 return new Border
                 {
-                    Background = UiUtil.GetCheckerboardBrush(),
+                    Background = previewBackground,
                     CornerRadius = new CornerRadius(3),
                     Padding = new Thickness(2),
                     HorizontalAlignment = HorizontalAlignment.Left,

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -541,6 +541,7 @@ public class LanguageGeneral
     public string SetStartAndKeepDuration { get; set; }
     public string SetStartAndOffsetTheRest { get; set; }
     public string SetUpLikeSubtitleEdit4 { get; set; }
+    public string ImageBackgroundColorDotDotDot { get; set; }
     public string SetVideoOffset { get; set; }
     public string Settings { get; set; }
     public string Shadow { get; set; }
@@ -1343,6 +1344,7 @@ public class LanguageGeneral
         SetStartAndKeepDuration = "Set start and keep duration";
         SetStartAndOffsetTheRest = "Set start and offset the rest";
         SetUpLikeSubtitleEdit4 = "Set up like Subtitle Edit 4 (theme, shortcuts, replace rules)";
+        ImageBackgroundColorDotDotDot = "Image background color...";
         SetVideoOffset = "Set video offset";
         Settings = "Settings";
         Shadow = "Shadow";

--- a/src/ui/Logic/Config/SeAppearance.cs
+++ b/src/ui/Logic/Config/SeAppearance.cs
@@ -32,6 +32,12 @@ public class SeAppearance
     public bool SubtitleTextBoxColorTags { get; set; }
     public int SubtitleGridFormattingType { get; set; }
     public bool SubtitleGridLiveSpellCheck { get; set; }
+
+    /// <summary>
+    /// Backdrop behind subtitle bitmap thumbnails in the OCR and binary-edit grids, as
+    /// #AARRGGBB. Empty means <see cref="Logic.ImagePreviewBackground.DefaultColor"/>.
+    /// </summary>
+    public string ImagePreviewBackgroundColor { get; set; }
     public bool SubtitleGridCenterText { get; set; }
 
     public bool SubtitleTextBoxCenterText { get; set; }
@@ -114,6 +120,7 @@ public class SeAppearance
         SubtitleTextBoxColorTags = true;
         ShowHints = true;
         SubtitleTextBoxCenterText = false;
+        ImagePreviewBackgroundColor = string.Empty;
         SubtitleGridCenterText = false;
         SubtitleTextBoxLiveSpellCheck = false;
         SubtitleGridFormattingType = (int)SubtitleGridFormattingTypes.ShowFormatting;

--- a/src/ui/Logic/ImagePreviewBackground.cs
+++ b/src/ui/Logic/ImagePreviewBackground.cs
@@ -1,0 +1,96 @@
+using Avalonia.Controls;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Features.Shared.ColorPicker;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>
+/// The backdrop behind subtitle bitmap thumbnails, shared by the OCR window and the binary
+/// (Blu-ray sup / VobSub) edit window.
+///
+/// Subtitle bitmaps are light or dark text on a transparent background, so they need a backdrop
+/// of their own or they vanish into the row. A checkerboard was tried and dropped for the OCR
+/// grid (#12692): at thumbnail size the tiling competes with the glyphs. The binary edit window
+/// kept it, and there the light half of the mid-gray checkerboard left light subtitles unreadable
+/// (#14328). Both now use one flat colour, defaulting to the OCR window's near-black, and both
+/// offer the same context-menu entry to change it - SE 4 had this configurable too
+/// (Tools.BinEditImageBackgroundColor).
+/// </summary>
+public static class ImagePreviewBackground
+{
+    /// <summary>The OCR window's original hard-coded backdrop.</summary>
+    public static Color DefaultColor { get; } = Color.FromRgb(0x2D, 0x2D, 0x30);
+
+    /// <summary>
+    /// A brush for one window's preview cells.
+    ///
+    /// Deliberately one instance per window rather than a shared static: a brush is an
+    /// AvaloniaObject and carries dispatcher affinity, so a single static instance handed to
+    /// every window is not safe to reuse across Avalonia application lifetimes. Every cell in a
+    /// window shares that window's brush, which is what lets a colour pick repaint them all with
+    /// no grid rebuild - and nothing is captured per cell, which a recycled FuncDataTemplate
+    /// would drop anyway.
+    /// </summary>
+    public static SolidColorBrush CreateBrush()
+    {
+        return new SolidColorBrush(CurrentColor);
+    }
+
+    public static Color CurrentColor => ParseOrDefault(Se.Settings.Appearance.ImagePreviewBackgroundColor);
+
+    /// <summary>
+    /// The shared "Image background color..." entry. Built here so the two windows cannot drift
+    /// into offering different wording or behaviour. <paramref name="brush"/> is the window's own
+    /// preview brush, recoloured in place so the change shows immediately.
+    /// </summary>
+    public static MenuItem MakeMenuItem(IWindowService windowService, Func<Window?> getOwner, SolidColorBrush brush)
+    {
+        var menuItem = new MenuItem { Header = Se.Language.General.ImageBackgroundColorDotDotDot };
+        menuItem.Click += async (_, _) => await PickAsync(windowService, getOwner(), brush);
+        return menuItem;
+    }
+
+    private static async Task PickAsync(IWindowService windowService, Window? owner, SolidColorBrush brush)
+    {
+        if (owner == null)
+        {
+            return;
+        }
+
+        var result = await windowService.ShowDialogAsync<ColorPickerWindow, ColorPickerViewModel>(
+            owner, vm => vm.Initialize(brush.Color));
+
+        if (!result.OkPressed)
+        {
+            return;
+        }
+
+        brush.Color = result.SelectedColor;
+        Se.Settings.Appearance.ImagePreviewBackgroundColor = result.SelectedColor.FromColorToHex();
+        Se.SaveSettings();
+    }
+
+    /// <summary>
+    /// The saved hex, or the default when it is missing or unreadable - a hand-edited settings
+    /// file should not take the previews down with it.
+    /// </summary>
+    internal static Color ParseOrDefault(string? hex)
+    {
+        if (string.IsNullOrWhiteSpace(hex))
+        {
+            return DefaultColor;
+        }
+
+        try
+        {
+            return hex.FromHexToColor();
+        }
+        catch (Exception)
+        {
+            return DefaultColor;
+        }
+    }
+}

--- a/tests/UI/Logic/ImagePreviewBackgroundTests.cs
+++ b/tests/UI/Logic/ImagePreviewBackgroundTests.cs
@@ -1,0 +1,85 @@
+using Avalonia.Headless.XUnit;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// Issue #14328: the binary (Blu-ray sup) edit grid drew subtitle thumbnails on the mid-gray
+/// checkerboard, whose light squares leave light subtitles unreadable. The OCR grid had already
+/// rejected the checkerboard for the same reason (#12692) and used a flat near-black.
+///
+/// Both now share one configurable colour and one context-menu entry. "Shared" is the whole
+/// point, so these pin it: one brush instance, one menu item, both windows.
+/// </summary>
+public class ImagePreviewBackgroundTests
+{
+    [Fact]
+    public void DefaultColour_IsTheOcrWindowsOriginalBackdrop()
+    {
+        Assert.Equal(Color.FromRgb(0x2D, 0x2D, 0x30), ImagePreviewBackground.DefaultColor);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not a colour")]
+    [InlineData("#12")]
+    public void UnreadableSetting_FallsBackToTheDefault(string? hex)
+    {
+        Assert.Equal(ImagePreviewBackground.DefaultColor, ImagePreviewBackground.ParseOrDefault(hex));
+    }
+
+    [Theory]
+    [InlineData("#FF102030", 0xFF, 0x10, 0x20, 0x30)]
+    [InlineData("#102030", 0xFF, 0x10, 0x20, 0x30)]
+    public void SavedHex_IsRead(string hex, byte a, byte r, byte g, byte b)
+    {
+        Assert.Equal(Color.FromArgb(a, r, g, b), ImagePreviewBackground.ParseOrDefault(hex));
+    }
+
+    // A brush is an AvaloniaObject with dispatcher affinity, so each window gets its own rather
+    // than sharing one static instance across application lifetimes. Every cell in a window still
+    // shares that window's brush, which is what makes a colour pick repaint them all at once.
+    [AvaloniaFact]
+    public void CreateBrush_ReturnsAFreshInstanceEachTime()
+    {
+        var first = ImagePreviewBackground.CreateBrush();
+        var second = ImagePreviewBackground.CreateBrush();
+
+        Assert.NotSame(first, second);
+        Assert.Equal(first.Color, second.Color);
+    }
+
+    // "The same way in both windows" is a property of two separate files, so it can only drift.
+    [Theory]
+    [InlineData("src/ui/Features/Ocr/OcrWindow.cs")]
+    [InlineData("src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs")]
+    public void BothWindows_UseTheSharedBrushAndOfferTheSharedMenuItem(string relativePath)
+    {
+        var source = File.ReadAllText(Path.Combine(FindRepoRoot(), relativePath.Replace('/', Path.DirectorySeparatorChar)));
+
+        Assert.Contains("ImagePreviewBackground.CreateBrush()", source, StringComparison.Ordinal);
+        Assert.Contains("Background = previewBackground", source, StringComparison.Ordinal);
+        Assert.Matches(new Regex(@"ImagePreviewBackground\.MakeMenuItem\("), source);
+
+        // The checkerboard is deliberately gone from the thumbnail grids; it stays only in the
+        // large single-image previews, where the tiling does not fight the glyphs.
+        Assert.DoesNotContain("GetCheckerboardBrush", source, StringComparison.Ordinal);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "src", "ui")))
+        {
+            dir = dir.Parent;
+        }
+
+        return dir?.FullName ?? throw new DirectoryNotFoundException("Could not find repo root");
+    }
+}


### PR DESCRIPTION
Addresses the first (and main) complaint in #14328 — subtitle thumbnails on a light-grey/dark-grey checkerboard that makes light subtitles unreadable.

## Why this is a bug and not a preference

The OCR window had **already made this decision, and documented it**. `OcrWindow.cs` carried:

> a checkerboard was tried here (issue #12692) but the tiling competes with the glyphs at thumbnail size and makes the grid harder to read; it is kept only in the pre-processing preview, where the image is large enough for it

…and used a flat near-black `#2D2D30`. The binary (Blu-ray sup / VobSub) edit grid kept the checkerboard, so the two windows disagreed about the same problem in the same kind of cell.

**SE 4 also had this configurable** — `Tools.BinEditBackgroundColor` (default black) and `Tools.BinEditImageBackgroundColor` (default blue), which is what the reporter is remembering when they say it was customizable.

## Changes

- One flat colour for both grids, defaulting to the OCR window's near-black.
- The same **"Image background color…"** entry in both grids' context menus, opening the standard colour picker and saving to `Se.Settings.Appearance.ImagePreviewBackgroundColor`.
- `ImagePreviewBackground` owns the colour, default, parsing and the menu item, so the two windows can't drift.
- The checkerboard **stays** in the large single-image previews (pre-processing, adjust colour/brightness, resize) — exactly the case #12692 kept it for.

## One design note worth reading

`ImagePreviewBackground` hands out a brush **per window** instead of exposing one shared static instance. My first version did share a static `SolidColorBrush`, and it made the UI suite fail *differently on every run* — 1, then 9, then 32 failures, in unrelated tests. A brush is an `AvaloniaObject` with dispatcher affinity, and a static one is not safe to reuse across Avalonia application lifetimes, which is what a headless test run creates repeatedly.

I confirmed the attribution rather than assuming it: clean `main` ran green 3/3, the shared-brush branch was erratic, and the per-window version is green 3/3. Every cell in a window still shares that window's brush, so a colour pick still repaints them all with no grid rebuild.

## Tests

`ImagePreviewBackgroundTests` — the default matches the OCR window's original colour; unreadable or missing settings fall back to it rather than taking the previews down; saved hex round-trips; `CreateBrush()` returns a fresh instance; and a source scan pins **both** windows to the shared brush and the shared menu item, with the checkerboard gone from both thumbnail grids. That last one already earned its keep — it caught the shared-to-per-window refactor mid-change.

Full UI suite: 4441 passed, 1 skipped, 0 failed, stable across repeat runs.

## Not in scope

The other four asks in #14328 (aspect-ratio scaling, subtitles over the video rather than the Position map, the space-bar/unresponsiveness report, merging the Video and Position map pages) are separate and much larger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)