### PR TITLE
Prevent duplicate macOS launch and Matroska opens

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -642,6 +642,13 @@ public partial class MainViewModel :
     private long _lastKeyPressedMs;
     private bool _loading;
     private bool _opening;
+    // Dedupe state for the macOS launch double-open (a launched-with file arrives via BOTH
+    // the CLI argument AND the "open file" activation event, which re-fires on every focus).
+    // _openingFileName marks the file whose open is in flight; _openMatroskaFileName marks
+    // the currently-open Matroska container — set synchronously before the async track
+    // picker is posted, so it survives past the open and dedupes the picker storm.
+    private string? _openingFileName;
+    private string? _openMatroskaFileName;
     private PointerEventArgs? _lastTextEditorPointerArgs;
     private string? _textBoxLookUpWord;
     private PointerEventArgs? _lastSubtitleGridPointerArgs;
@@ -20701,6 +20708,48 @@ public partial class MainViewModel :
     /// <summary>
     /// OpenSubtitle - open subtitle file, video file is optional.
     /// </summary>
+    // True when two paths point at the same file, comparing normalized full paths
+    // (case-insensitive — macOS default) and resolving symlinks (e.g. /tmp -> /private/tmp),
+    // so the activation event's path and a CLI/stored path for the same file compare equal.
+    private static bool SamePath(string? a, string? b)
+    {
+        if (string.IsNullOrEmpty(a) || string.IsNullOrEmpty(b))
+        {
+            return false;
+        }
+
+        try
+        {
+            var fa = Path.GetFullPath(a);
+            var fb = Path.GetFullPath(b);
+            if (string.Equals(fa, fb, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            var ra = ResolveReal(fa);
+            var rb = ResolveReal(fb);
+            return string.Equals(ra, rb, StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    private static string ResolveReal(string fullPath)
+    {
+        try
+        {
+            var info = new FileInfo(fullPath);
+            return info.ResolveLinkTarget(returnFinalTarget: true)?.FullName ?? fullPath;
+        }
+        catch
+        {
+            return fullPath;
+        }
+    }
+
     public async Task SubtitleOpen(
         string fileName,
         string? videoFileName = null,
@@ -20710,6 +20759,19 @@ public partial class MainViewModel :
         int desiredAudioTrackId = -1)
     {
         if (string.IsNullOrEmpty(fileName))
+        {
+            return;
+        }
+
+        // A launched-with file arrives via BOTH the CLI argument AND the macOS "open file"
+        // activation event, and the activation re-fires on every focus. A multi-track
+        // Matroska leaves the subtitle list empty while the (async) track picker is open,
+        // so a "subtitles loaded?" guard never trips and every activation posts another
+        // picker. Dedupe on the in-flight open, the open Matroska container, and the loaded
+        // standalone file:
+        if (SamePath(fileName, _openingFileName) ||
+            SamePath(fileName, _openMatroskaFileName) ||
+            (Subtitles.Count > 0 && SamePath(fileName, _subtitleFileName)))
         {
             return;
         }
@@ -20748,6 +20810,8 @@ public partial class MainViewModel :
         try
         {
             _opening = true;
+            _openingFileName = fileName;
+            _openMatroskaFileName = null;
 
             if (FileUtil.IsMatroskaFileFast(fileName) && FileUtil.IsMatroskaFile(fileName))
             {
@@ -21338,6 +21402,7 @@ public partial class MainViewModel :
             _undoRedoManager.Do(MakeUndoRedoObject(string.Format(Se.Language.General.SubtitleLoadedX, fileName)));
             _undoRedoManager.StartChangeDetection();
             _opening = false;
+            _openingFileName = null;
 
             SetupLiveSpellCheck();
         }
@@ -22144,6 +22209,9 @@ public partial class MainViewModel :
     /// </summary>
     private async Task<bool> ImportSubtitleFromMatroskaFile(string fileName, string? videoFileName, bool skipLoadVideo = false)
     {
+        // Mark the container as the currently-open Matroska BEFORE the async picker is
+        // posted, so re-fired activations during the picker (and after) are deduped.
+        _openMatroskaFileName = fileName;
         var matroska = new MatroskaFile(fileName);
         var subtitleList = matroska.GetTracks(true);
         if (subtitleList.Count == 0)


### PR DESCRIPTION
## Summary

On macOS, opening a file as Subtitle Edit launches can deliver the same path through two independent routes: the command-line startup argument and Avalonia's `IActivatableLifetime` file-activation event. The activation route is dispatched asynchronously and can be delivered again when the application regains focus.

The existing duplicate-open check depends on a subtitle already being loaded, so it does not protect an open that is still in progress. It fails especially badly for a multi-track Matroska file because the track picker opens before `Subtitles` is populated. This change records the file currently being opened and the active Matroska path before asynchronous picker work begins, compares normalised and symlink-resolved paths, and suppresses matching repeated requests. A request for a different file continues through the normal open flow.

### User impact

This is more disruptive than a harmless duplicate event. Launching Subtitle Edit with a multi-track Matroska file can queue multiple track pickers for the same container. Switching to another application and returning to Subtitle Edit can queue more pickers while an earlier picker is still open. The resulting dialog storm causes phantom or stacked windows, focus flicker, and unstable window ordering, and forces the user through repeated track-selection dialogs for a file they opened once.

The repeated requests make launch and document-open behavior unreliable and leave it unclear which pending dialog controls the document being loaded. Standalone subtitle files are also exposed to repeated activation delivery, although the Matroska picker makes the failure most visible. The expected behavior is one open operation, and at most one track picker, for each canonical path regardless of how many macOS delivery events report it.

### Before and after

Before, concurrent paths could race. After, in-flight, picker, and already-loaded matches return early.

## Implementation

Track canonical opening paths, compare resolved paths, and set and clear state around open/reset.

### Dependencies and order

The change is self-contained within the existing file-open and reset paths. It does not add settings, dependencies, or public APIs.

### Out of scope

Dialog modality, ownership, and window-parenting changes are not included. This change only prevents repeated requests to open the same file.

### Files changed

`src/ui/Features/Main/MainViewModel.cs`

## Test plan

### Automated

The change was reapplied cleanly to current upstream `main` and checked for whitespace errors. No automated test currently covers operating-system file-activation delivery on macOS.

### Manual

Verified manually on macOS 26.6.1 and macOS 26.6.2: launching with a multi-track Matroska file opened one track picker, and repeatedly deactivating and reactivating Subtitle Edit did not open additional pickers.

### Platform coverage

The affected code is not macOS-version-specific, but manual verification was performed only on macOS 26.6.1 and macOS 26.6.2.

### UI evidence

The app appears to open many windows and be dysfunctional as a result when you deactivate and reactivate the app. Before the fix, deactivating and reactivating the application could open additional Matroska track pickers, leaving multiple windows and making the application difficult to use. After the fix, repeated activation does not create additional pickers.

## Review notes

### Compatibility and migration

Distinct paths still open. No setting or migration is required.

### Risks and rollback

The risk is limited to path identity and open-state guards. Revert the commit to restore prior open handling.

### Assumptions, limitations, and open questions

Manual verification completed: command-line launch with a multi-track Matroska file and repeated application activation while its picker was open. Verification remains pending for Finder-initiated opens, standalone subtitle files, symlinked paths, and paths differing only by case.

### AI assistance

Claude Opus 4.8 materially assisted the original implementation. OpenAI Codex assisted with source audit, rebasing onto current `main`, and PR preparation.

## Checklist

- [x] Add or confirm macOS test evidence.
- [ ] Review path normalisation on supported macOS filesystems.
- [ ] Run project checks.
- [ ] Attach the recording.
- [x] State exactly which verification was performed and which remains pending.
- [x] Disclose material AI assistance in the submitted PR.
- [ ] If an AI agent owns implementation through merge, complete the required Copilot review cycle.
