### PR TITLE
Advance repeat selection at cue end and timer overshoot

### DIFF
--- a/src/ui/Features/Main/MainHelpers/PlaySelectionItem.cs
+++ b/src/ui/Features/Main/MainHelpers/PlaySelectionItem.cs
@@ -20,8 +20,9 @@ public class PlaySelectionItem
 
     public SubtitleLineViewModel? GetNextSubtitle(double playerPositionInSeconds)
     {
-        // find the first subtitle after the current position
-        var nextIndex = Subtitles.FindIndex(s => s.EndTime.TotalSeconds >= playerPositionInSeconds);
+        // Start after the current subtitle and require the candidate to extend beyond the playhead.
+        // At an exact end boundary, selecting the current subtitle again can seek back to its start.
+        var nextIndex = Subtitles.FindIndex(Index + 1, s => s.EndTime.TotalSeconds > playerPositionInSeconds);
         if (nextIndex >= 0)
         {
             Index = nextIndex;

--- a/tests/UI/Features/Main/MainHelpers/PlaySelectionItemTests.cs
+++ b/tests/UI/Features/Main/MainHelpers/PlaySelectionItemTests.cs
@@ -1,0 +1,59 @@
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Main.MainHelpers;
+
+namespace UITests.Features.Main.MainHelpers;
+
+public class PlaySelectionItemTests
+{
+    [Fact]
+    public void GetNextSubtitle_AtCurrentEnd_AdvancesToNextSubtitle()
+    {
+        var first = MakeSubtitle(1, 2);
+        var second = MakeSubtitle(3, 4);
+        var item = new PlaySelectionItem([first, second], first.EndTime, true);
+
+        var next = item.GetNextSubtitle(first.EndTime.TotalSeconds);
+
+        Assert.Same(second, next);
+        Assert.Equal(1, item.Index);
+        Assert.Equal(second.EndTime.TotalSeconds, item.EndSeconds);
+    }
+
+    [Fact]
+    public void GetNextSubtitle_AfterCurrentEnd_SkipsSubtitlesAlreadyPassed()
+    {
+        var first = MakeSubtitle(1, 2);
+        var second = MakeSubtitle(3, 4);
+        var third = MakeSubtitle(5, 6);
+        var item = new PlaySelectionItem([first, second, third], first.EndTime, false);
+
+        var next = item.GetNextSubtitle(4.5);
+
+        Assert.Same(third, next);
+        Assert.Equal(2, item.Index);
+        Assert.Equal(third.EndTime.TotalSeconds, item.EndSeconds);
+    }
+
+    [Fact]
+    public void GetNextSubtitle_AfterLastSubtitle_LoopsToFirst()
+    {
+        var first = MakeSubtitle(1, 2);
+        var second = MakeSubtitle(3, 4);
+        var item = new PlaySelectionItem([first, second], first.EndTime, true);
+
+        Assert.Same(second, item.GetNextSubtitle(first.EndTime.TotalSeconds));
+
+        var next = item.GetNextSubtitle(second.EndTime.TotalSeconds);
+
+        Assert.Same(first, next);
+        Assert.Equal(0, item.Index);
+        Assert.Equal(first.EndTime.TotalSeconds, item.EndSeconds);
+    }
+
+    private static SubtitleLineViewModel MakeSubtitle(double startSeconds, double endSeconds) =>
+        new()
+        {
+            StartTime = TimeSpan.FromSeconds(startSeconds),
+            EndTime = TimeSpan.FromSeconds(endSeconds),
+        };
+}


### PR DESCRIPTION
## Summary

`PlaySelectionItem` is the shared progression state for Play selected subtitles, Play selected subtitles in repeat mode, Play next or previous and stop or loop, and the older Repeat Next/Previous Line commands. When playback reaches the tracked cue end, its current lookup begins from the full selection and accepts a cue whose end time is equal to the playhead. At an exact boundary, that makes the cue which just finished eligible to be selected again.

This change begins the lookup after the current selection index and requires the next candidate to extend strictly beyond the current playhead. Later selected cues therefore advance in order, cues already passed by a delayed timer callback are skipped, non-looping playback can stop after its final cue, and loop mode wraps only after no later candidate remains. Ordinary Play/Pause playback does not use this state and is unchanged.

### User impact

The bug breaks workflows that depend on selected cues progressing predictably, particularly repeated playback of several selected subtitles during timing, translation, or dialogue review. At a cue's exact end, the completed cue can be chosen again instead of the next selection. Depending on playback-timer timing and mpv position rounding, users can see a backward seek into the cue they just heard, an unexpected replay, repeated handling of the same boundary across timer callbacks, or a noticeable delay before playback finally advances.

A late timer callback creates the related overshoot case: the progression logic must skip every selected cue whose end is already at or behind the playhead rather than scheduling completed material. Because the same helper drives several selected-line and next/previous playback commands, this is not confined to one repeat-mode button. The corrected behavior is deterministic at all three critical transitions: advance at an exact cue end, skip candidates passed during timer delay, and wrap to the first selected cue only after the final cue when looping is enabled.

### Before and after

Before, lookup used the current index and `>=`. After, lookup starts at the next index and uses `>`.

## Implementation

Adjust `PlaySelectionItem.GetNextSubtitle` and cover boundary cases with xUnit tests.

### Dependencies and order

The change is self-contained within `PlaySelectionItem` and its focused tests. It has no ordering dependency on other proposed changes.

### Out of scope

Ordinary Play/Pause and playback paths that do not use `PlaySelectionItem` are unchanged.

### Files changed

- `src/ui/Features/Main/MainHelpers/PlaySelectionItem.cs`
- `tests/UI/Features/Main/MainHelpers/PlaySelectionItemTests.cs`

## Test plan

### Automated

Focused verification against current upstream `main`:

```text
dotnet test tests/UI/UITests.csproj --filter FullyQualifiedName~PlaySelectionItemTests --verbosity minimal
Passed: 3, Failed: 0, Skipped: 0
```

The tests cover exact-boundary advancement, delayed-timer overshoot, and final-cue wrapping.

### Manual

Verified manually by selecting approximately two dozen cues and pressing the loop-selected-cues button. Before the fix, this reliably produced erratic playhead movement and repeated cues. After the fix, the selected cues advance in order and wrap only after the final cue.

### Platform coverage

Verify timer precision on supported playback backends.

### UI evidence

Sorry, I didn't capture a video of this; but it's very reproducible manually.

## Review notes

### Compatibility and migration

Only repeat next-cue selection changes. No migration is required.

### Risks and rollback

This is a narrow helper change. Revert the commit if playback selection regresses.

### Assumptions, limitations, and open questions

No functional limitations were observed within the affected commands. Manual verification concentrated on looped playback with approximately two dozen selected cues, which reliably reproduced the original erratic playhead movement and cue repetition.

### AI assistance

OpenAI Codex materially assisted with implementation audit, rebasing onto current `main`, focused test execution, and PR preparation.

## Checklist

- [x] Run focused tests.
- [ ] Run the full project test suite.
- [x] Cover timer overshoot in a focused test.
- [ ] Attach an optional recording.
- [x] State exactly which verification was performed and which remains pending.
- [x] Disclose material AI assistance in the submitted PR.
- [ ] If an AI agent owns implementation through merge, complete the required Copilot review cycle.
