### PR TITLE
Offer VibeVoice (CrispASR) again

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/TtsEngineCatalog.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/TtsEngineCatalog.cs
@@ -60,11 +60,12 @@ public static class TtsEngineCatalog
             // use Qwen3TtsCrispAsr until upstream qwen3-tts.cpp is fixed.
             new Qwen3TtsCrispAsr(),
 
-            // VibeVoiceCrispAsr hidden: output quality is unusable in practice even after
-            // bumping the post-synth speed knob (#11223). The engine class + download service +
-            // settings dialog are kept so this becomes a one-line re-enable when upstream
-            // CrispASR's VibeVoice backend ships a higher-quality build.
-            // new VibeVoiceCrispAsr(),
+            // VibeVoiceCrispAsr was hidden while its output quality was judged unusable. That
+            // was measured on the CrispASR build of the time (v0.8.29); re-checked by ear on
+            // v0.8.31 with the same 1.5B q4_k weights and the same request SE sends (speed 1.1),
+            // the output is acceptable, so it is back. The old note cited #11223 as the evidence,
+            // but that is the speed-slider PR - it set the 1.1 default, it never assessed quality.
+            new VibeVoiceCrispAsr(),
 
             new IndexTtsCrispAsr(),
 

--- a/tests/UI/Features/Video/TextToSpeech/Engines/TtsEngineCatalogTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/TtsEngineCatalogTests.cs
@@ -1,4 +1,4 @@
-using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+﻿using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 
 namespace UITests.Features.Video.TextToSpeech.Engines;
 
@@ -49,13 +49,21 @@ public class TtsEngineCatalogTests
     {
         var engines = TtsEngineCatalog.CreateAll(null!);
 
-        // Both can clone, and both are disabled on purpose - F5-TTS has no GPU backend, and
-        // VibeVoice's output quality is unusable (#11223). Offering them from the waveform menu
-        // would be re-enabling them by accident.
+        // F5-TTS can clone but has no GPU backend, so it is disabled on purpose - offering it
+        // from the waveform menu would be re-enabling it by accident.
         Assert.DoesNotContain(engines, e => e is F5TtsCrispAsr);
-        Assert.DoesNotContain(engines, e => e is VibeVoiceCrispAsr);
         Assert.DoesNotContain(TtsEngineCatalog.CreateVoiceCloningEngines(), e => e is F5TtsCrispAsr);
-        Assert.DoesNotContain(TtsEngineCatalog.CreateVoiceCloningEngines(), e => e is VibeVoiceCrispAsr);
+    }
+
+    [Fact]
+    public void VibeVoiceIsOffered()
+    {
+        // Hidden while its output quality was judged unusable on the CrispASR build of the time;
+        // re-checked on v0.8.31 and re-enabled. Pinned so a stray comment-out is caught: the
+        // engine is fully wired (DI, settings dialog, installer, status dots) and the only thing
+        // that ever gated it was this one line in the catalog.
+        Assert.Contains(TtsEngineCatalog.CreateAll(null!), e => e is VibeVoiceCrispAsr);
+        Assert.Contains(TtsEngineCatalog.CreateVoiceCloningEngines(), e => e is VibeVoiceCrispAsr);
     }
 
     [Fact]


### PR DESCRIPTION
VibeVoice was commented out of `TtsEngineCatalog` because its output quality was judged unusable. That judgement was made against the CrispASR build of the time — **v0.8.29** — and the comment set its own condition for reversal: re-enable "when upstream CrispASR's VibeVoice backend ships a higher-quality build."

We are now on **v0.8.31** (#14343 / PR #14347), so I re-tested rather than assumed.

## How it was re-checked

Synthesised on the shipping v0.8.31 build with the same 1.5B q4_k weights already installed, driving it through the exact request SE sends — `/v1/audio/speech`, `response_format: wav`, `speed: 1.1` (SE's default from #11223) — and played the result. **The output was judged acceptable by ear.** Objectively it is a normal speech signal: 7.76 s at 24 kHz, crest factor 8.7, zero-crossing rate 0.113, 29% silence.

To be explicit about who decided what: I can't hear audio. I produced the sample and measured it; the quality call was the maintainer's.

## A correction worth recording

The old comment cited **#11223** as the evidence for "unusable". #11223 is the *speed-slider* PR — it added `VibeVoiceCrispAsrSpeed`, set the 1.1 default and wired the `speed` field. It never assessed quality. Nothing in the repo recorded the actual quality finding, which is precisely why it was worth re-testing instead of trusting the note.

## Scope

One line, as the old comment predicted. Everything else was deliberately kept and is still correct: DI registration, download service, settings dialog (with its speed slider), installer and status-dot wiring all needed no change.

## Tests

`TheHiddenEnginesStayHidden` now covers **F5-TTS alone** — still disabled, and for an unrelated reason (no GPU backend). A new `VibeVoiceIsOffered` pins the engine into both `CreateAll` and `CreateVoiceCloningEngines`, so a stray comment-out is caught rather than silently shipping.

Full UI suite: 4463 passed, 1 skipped, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)