### PR TITLE
CrispASR: move the macOS Intel slice to v0.8.31

### DIFF
--- a/src/ui/Logic/Download/CrispAsrDownloadService.cs
+++ b/src/ui/Logic/Download/CrispAsrDownloadService.cs
@@ -48,12 +48,8 @@ public class CrispAsrDownloadService : ICrispAsrDownloadService
     /// It is a CPU + Accelerate build (ggml's Metal kernels crash on the AMD GPUs in Intel
     /// Macs) and targets macOS 12, and the archive's inner folder matches upstream's so the
     /// unpack path is shared.
-    ///
-    /// NOTE: still on the v0.8.30 slice while the rest of this file is on v0.8.31 - the x86_64
-    /// build has to be produced and uploaded to support-files before this can move, so an Intel
-    /// Mac stays a release behind until then (#14343).
     /// </summary>
-    private const string MacIntelUrl = "https://github.com/SubtitleEdit/support-files/releases/download/crispasr-0830-macos-x64/crispasr-macos-x86_64.tar.gz";
+    private const string MacIntelUrl = "https://github.com/SubtitleEdit/support-files/releases/download/crispasr-0831-macos-x64/crispasr-macos-x86_64.tar.gz";
     private const string LinuxUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.31/crispasr-linux-x86_64.tar.gz";
     private const string LinuxCudaUrl = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.31/crispasr-linux-x86_64-cuda.tar.gz";
     private const string LinuxCuda13Url = "https://github.com/CrispStrobe/CrispASR/releases/download/v0.8.31/crispasr-linux-x86_64-cuda13.tar.gz";

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -555,7 +555,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.MacOsX64] = new[]
             {
-                "ab6d673642e6a7c52374cdab9558d63c455ab8485654f56fcdae8054d34f7f75", // v0.8.30 (current download URL)
+                "ae781eda4a1e1223a617f753da4df3feff892fda84e1cd7e666d51a11dfbb846", // v0.8.31 (current download URL)
+                "ab6d673642e6a7c52374cdab9558d63c455ab8485654f56fcdae8054d34f7f75", // v0.8.30
                 "1ab9bc657c81e9ffcb5c733b66aaa340977cae7308309f4de13651e4896d7783", // v0.8.29
             },
             [CrispAsr.MacOs] = new[]
@@ -1204,7 +1205,8 @@ public static class DownloadHashManager
             },
             [CrispAsr.MacOsX64Executable] = new[]
             {
-                "4dc7534c7a8196f5894c5ab685e1f407ae479ed5538340d457d1e668a3fdf580", // v0.8.30 (current download URL)
+                "3f09562abe72bfb7b0bc697a046171fd058754868db81896da4b632aa7be3acb", // v0.8.31 (current download URL)
+                "4dc7534c7a8196f5894c5ab685e1f407ae479ed5538340d457d1e668a3fdf580", // v0.8.30
                 "64d488a7b304d14e03ba353a3763b281fa2b55e067182f90ae5ba626ebaf3250", // v0.8.29
             },
             [CrispAsr.MacOsExecutable] = new[]


### PR DESCRIPTION
Follow-up to #14347, which bumped the 11 upstream URL pins but left `MacIntelUrl` on the v0.8.30 slice — the x86_64 build is produced in `SubtitleEdit/support-files` rather than upstream, so it first had to be built and released there.

That is now done: [`crispasr-0831-macos-x64`](https://github.com/SubtitleEdit/support-files/releases/tag/crispasr-0831-macos-x64), built from upstream tag v0.8.31 (`5244a1e3`) by `build-crispasr-macos-x64-release.yml` with c2pa 0.89.3 and deployment target 12.0 (same pins as v0.8.31's cmake).

Changes here:
- `MacIntelUrl` → the new release, and the temporary one-release-behind note from #14347 is dropped.
- New v0.8.31 entries in the `CrispAsr.MacOsX64` and `CrispAsr.MacOsX64.Executable` hash lists, hashed from the downloaded artifact.

Verified on the downloaded tarball: `lipo` reports x86_64 only, `minos` is 12.0, inner folder is still `crispasr-macos` (shared unpack path), and the binary runs under Rosetta reporting version 0.8.31 with the same git sha as the upstream tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)