### PR TITLE
Add Pocket TTS (CrispASR) voice-cloning engine

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -173,6 +173,7 @@ using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Qwen3TtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.VibeVoiceCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DotsTtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTtsCrispAsrSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.PocketTtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTts25License;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.VoiceCloneConsent;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTts25AudioCppSettings;
@@ -294,6 +295,7 @@ public static class DependencyInjectionExtensions
         collection.AddHttpClientWithProxy<IQwen3TtsCrispAsrDownloadService, Qwen3TtsCrispAsrDownloadService>();
         collection.AddHttpClientWithProxy<IVibeVoiceCrispAsrDownloadService, VibeVoiceCrispAsrDownloadService>();
         collection.AddHttpClientWithProxy<IIndexTtsCrispAsrDownloadService, IndexTtsCrispAsrDownloadService>();
+        collection.AddHttpClientWithProxy<IPocketTtsCrispAsrDownloadService, PocketTtsCrispAsrDownloadService>();
         collection.AddHttpClientWithProxy<IDotsTtsCrispAsrDownloadService, DotsTtsCrispAsrDownloadService>();
         collection.AddHttpClientWithProxy<IIndexTts25AudioCppDownloadService, IndexTts25AudioCppDownloadService>();
         collection.AddHttpClientWithProxy<ICosyVoice3CrispAsrDownloadService, CosyVoice3CrispAsrDownloadService>();
@@ -483,6 +485,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<Qwen3TtsCrispAsrSettingsViewModel>();
         collection.AddTransient<VibeVoiceCrispAsrSettingsViewModel>();
         collection.AddTransient<IndexTtsCrispAsrSettingsViewModel>();
+        collection.AddTransient<PocketTtsCrispAsrSettingsViewModel>();
         collection.AddTransient<DotsTtsCrispAsrSettingsViewModel>();
         collection.AddTransient<IndexTts25LicenseViewModel>();
         collection.AddTransient<VoiceCloneConsentViewModel>();

--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -60,6 +60,8 @@ public partial class DownloadTtsViewModel : ObservableObject
     private Task? _downloadTaskDotsTtsCrispAsrModels;
     private Task? _downloadTaskIndexTtsCrispAsrModels;
     private Task? _downloadTaskIndexTtsCrispAsrVoices;
+    private Task? _downloadTaskPocketTtsCrispAsrModels;
+    private Task? _downloadTaskPocketTtsCrispAsrVoices;
     private Task? _downloadTaskCosyVoice3CrispAsrModels;
     private Task? _downloadTaskCosyVoice3CrispAsrVoices;
     private Task? _downloadTaskF5TtsCrispAsrModels;
@@ -86,6 +88,7 @@ public partial class DownloadTtsViewModel : ObservableObject
     private readonly IQwen3TtsCrispAsrDownloadService _qwen3TtsCrispAsrDownloadService;
     private readonly IVibeVoiceCrispAsrDownloadService _vibeVoiceCrispAsrDownloadService;
     private readonly IIndexTtsCrispAsrDownloadService _indexTtsCrispAsrDownloadService;
+    private readonly IPocketTtsCrispAsrDownloadService _pocketTtsCrispAsrDownloadService;
     private readonly IDotsTtsCrispAsrDownloadService _dotsTtsCrispAsrDownloadService;
     private readonly IIndexTts25AudioCppDownloadService _indexTts25AudioCppDownloadService;
     private Task? _downloadTaskIndexTts25AudioCppEngine;
@@ -111,6 +114,7 @@ public partial class DownloadTtsViewModel : ObservableObject
     private readonly MemoryStream _downloadStreamQwen3TtsCrispAsrVoices;
     private readonly MemoryStream _downloadStreamVibeVoiceCrispAsrVoices;
     private readonly MemoryStream _downloadStreamIndexTtsCrispAsrVoices;
+    private readonly MemoryStream _downloadStreamPocketTtsCrispAsrVoices;
     private readonly MemoryStream _downloadStreamCosyVoice3CrispAsrVoices;
     private readonly MemoryStream _downloadStreamF5TtsCrispAsrVoices;
     private readonly MemoryStream _downloadStreamVoxCPM2CrispAsrVoices;
@@ -130,6 +134,7 @@ public partial class DownloadTtsViewModel : ObservableObject
         IQwen3TtsCrispAsrDownloadService qwen3TtsCrispAsrDownloadService,
         IVibeVoiceCrispAsrDownloadService vibeVoiceCrispAsrDownloadService,
         IIndexTtsCrispAsrDownloadService indexTtsCrispAsrDownloadService,
+        IPocketTtsCrispAsrDownloadService pocketTtsCrispAsrDownloadService,
         IDotsTtsCrispAsrDownloadService dotsTtsCrispAsrDownloadService,
         IIndexTts25AudioCppDownloadService indexTts25AudioCppDownloadService,
         ICosyVoice3CrispAsrDownloadService cosyVoice3CrispAsrDownloadService,
@@ -147,6 +152,7 @@ public partial class DownloadTtsViewModel : ObservableObject
         _qwen3TtsCrispAsrDownloadService = qwen3TtsCrispAsrDownloadService;
         _vibeVoiceCrispAsrDownloadService = vibeVoiceCrispAsrDownloadService;
         _indexTtsCrispAsrDownloadService = indexTtsCrispAsrDownloadService;
+        _pocketTtsCrispAsrDownloadService = pocketTtsCrispAsrDownloadService;
         _dotsTtsCrispAsrDownloadService = dotsTtsCrispAsrDownloadService;
         _indexTts25AudioCppDownloadService = indexTts25AudioCppDownloadService;
         _downloadStreamIndexTts25AudioCppEngine = new MemoryStream();
@@ -171,6 +177,7 @@ public partial class DownloadTtsViewModel : ObservableObject
         _downloadStreamQwen3TtsCrispAsrVoices = new MemoryStream();
         _downloadStreamVibeVoiceCrispAsrVoices = new MemoryStream();
         _downloadStreamIndexTtsCrispAsrVoices = new MemoryStream();
+        _downloadStreamPocketTtsCrispAsrVoices = new MemoryStream();
         _downloadStreamCosyVoice3CrispAsrVoices = new MemoryStream();
         _downloadStreamF5TtsCrispAsrVoices = new MemoryStream();
         _downloadStreamVoxCPM2CrispAsrVoices = new MemoryStream();
@@ -1089,6 +1096,97 @@ public partial class DownloadTtsViewModel : ObservableObject
                 if (ex != null)
                 {
                     Se.LogError(ex);
+                }
+                OkPressed = true;
+                Close();
+            }
+
+            if (_downloadTaskPocketTtsCrispAsrModels is { IsCompletedSuccessfully: true })
+            {
+                _timer.Stop();
+                _downloadTaskPocketTtsCrispAsrModels = null;
+
+                var pocketVoicesFolder = PocketTtsCrispAsr.GetSetVoicesFolder();
+                var pocketVoicesAlreadyInstalled = Directory.Exists(pocketVoicesFolder)
+                    && Directory.EnumerateFiles(pocketVoicesFolder, "*.wav").Any();
+                if (pocketVoicesAlreadyInstalled)
+                {
+                    OkPressed = true;
+                    Close();
+                    return;
+                }
+
+                TitleText = string.Format(Se.Language.General.DownloadingX, "Pocket TTS (CrispASR) voices");
+                ProgressValue = 0;
+                ProgressText = Se.Language.General.StartingDotDotDot;
+                var pocketVoicesProgress = new Progress<float>(number =>
+                {
+                    var percentage = (int)Math.Round(number * 100.0, MidpointRounding.AwayFromZero);
+                    var pctString = percentage.ToString(CultureInfo.InvariantCulture);
+                    ProgressValue = percentage;
+                    ProgressText = string.Format(Se.Language.General.DownloadingXPercent, pctString);
+                });
+                _downloadTaskPocketTtsCrispAsrVoices = _qwen3TtsCppDownloadService.DownloadVoices(
+                    _downloadStreamPocketTtsCrispAsrVoices, pocketVoicesProgress, _cancellationTokenSource.Token);
+                // OnClosing disposes the timer, so restarting it from a chained download
+                // step threw ObjectDisposedException on a thread-pool thread (#12739).
+                if (!_isClosing)
+                {
+                    _timer.Start();
+                }
+            }
+            else if (_downloadTaskPocketTtsCrispAsrModels is { IsFaulted: true })
+            {
+                _timer.Stop();
+                var pocketEx = _downloadTaskPocketTtsCrispAsrModels.Exception?.InnerException ?? _downloadTaskPocketTtsCrispAsrModels.Exception;
+                if (pocketEx is OperationCanceledException)
+                {
+                    ProgressText = Se.Language.General.DownloadCanceled;
+                    Close();
+                }
+                else
+                {
+                    ProgressText = Se.Language.General.DownloadFailed;
+                    Error = pocketEx?.Message ?? Se.Language.General.UnknownError;
+                }
+            }
+
+            if (_downloadTaskPocketTtsCrispAsrVoices is { IsCompletedSuccessfully: true })
+            {
+                _timer.Stop();
+                if (_downloadStreamPocketTtsCrispAsrVoices.Length > 0)
+                {
+                    var pocketVoicesFolder = PocketTtsCrispAsr.GetSetVoicesFolder();
+                    try
+                    {
+                        _downloadStreamPocketTtsCrispAsrVoices.Position = 0;
+                        _zipUnpacker.UnpackZipStream(_downloadStreamPocketTtsCrispAsrVoices, pocketVoicesFolder, string.Empty, false, new List<string>(), null);
+                        // The Mimi encoder conditions at 24 kHz; the qwen3-tts.cpp voice pack
+                        // ships at 16 kHz, so resample once here rather than on every synth.
+                        ResampleVoicesTo24kHz(pocketVoicesFolder);
+                    }
+                    catch (Exception ex)
+                    {
+                        Se.LogError(ex);
+                    }
+                    _downloadStreamPocketTtsCrispAsrVoices.Dispose();
+                }
+                OkPressed = true;
+                Close();
+            }
+            else if (_downloadTaskPocketTtsCrispAsrVoices is { IsFaulted: true })
+            {
+                _timer.Stop();
+                if (_cancellationTokenSource.IsCancellationRequested)
+                {
+                    ProgressText = Se.Language.General.DownloadCanceled;
+                    Close();
+                    return;
+                }
+                var pocketEx = _downloadTaskPocketTtsCrispAsrVoices.Exception?.InnerException ?? _downloadTaskPocketTtsCrispAsrVoices.Exception;
+                if (pocketEx != null)
+                {
+                    Se.LogError(pocketEx);
                 }
                 OkPressed = true;
                 Close();
@@ -2191,6 +2289,29 @@ public partial class DownloadTtsViewModel : ObservableObject
             _indexTtsCrispAsrDownloadService.DownloadModels(IndexTtsCrispAsr.GetSetModelsFolder(), resolved, downloadProgress, titleProgress, _cancellationTokenSource.Token);
     }
 
+    public void StartDownloadPocketTtsCrispAsrModels(string? modelKey = null)
+    {
+        var resolved = PocketTtsCrispAsr.ResolveModelKey(modelKey);
+        var modelFileName = PocketTtsCrispAsr.GetModelFileName(resolved);
+        TitleText = string.Format(Se.Language.General.DownloadingX, $"Pocket TTS (CrispASR) model ({resolved}): {modelFileName}");
+
+        var downloadProgress = new Progress<float>(number =>
+        {
+            var percentage = (int)Math.Round(number * 100.0, MidpointRounding.AwayFromZero);
+            var pctString = percentage.ToString(CultureInfo.InvariantCulture);
+            ProgressValue = percentage;
+            ProgressText = string.Format(Se.Language.General.DownloadingXPercent, pctString);
+        });
+
+        var titleProgress = new Action<string>(title =>
+        {
+            Dispatcher.UIThread.Post(() => TitleText = title);
+        });
+
+        _downloadTaskPocketTtsCrispAsrModels =
+            _pocketTtsCrispAsrDownloadService.DownloadModels(PocketTtsCrispAsr.GetSetModelsFolder(), resolved, downloadProgress, titleProgress, _cancellationTokenSource.Token);
+    }
+
     /// <summary>
     /// Downloads the audio.cpp engine archive for the picked backend. The archives are
     /// .tar.gz on macOS/Linux and .zip on Windows; UnpackZipStream sniffs the gzip magic and
@@ -2457,6 +2578,7 @@ public partial class DownloadTtsViewModel : ObservableObject
         DisposeQuietly(_downloadStreamQwen3TtsCrispAsrVoices);
         DisposeQuietly(_downloadStreamVibeVoiceCrispAsrVoices);
         DisposeQuietly(_downloadStreamIndexTtsCrispAsrVoices);
+        DisposeQuietly(_downloadStreamPocketTtsCrispAsrVoices);
         DisposeQuietly(_downloadStreamCosyVoice3CrispAsrVoices);
         DisposeQuietly(_downloadStreamF5TtsCrispAsrVoices);
         DisposeQuietly(_downloadStreamVoxCPM2CrispAsrVoices);

--- a/src/ui/Features/Video/TextToSpeech/Engines/PocketTtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/PocketTtsCrispAsr.cs
@@ -1,0 +1,897 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// Kyutai Pocket TTS (100M) run through the CrispASR runtime. By far the smallest of the
+/// voice-cloning engines wired up in SE — one 124-365 MB GGUF per language vs ~870 MB for
+/// IndexTTS — and the fastest (continuous-latent AR at 12.5 Hz + one-step LSD flow head +
+/// Mimi decoder; measured RTF ~0.1 on an M-class CPU). Six languages, one checkpoint each:
+/// English, German, Spanish, Italian, Portuguese, and Kyutai's French 24-layer preview.
+///
+/// The model produces near-silence without voice conditioning, so like the other cloning
+/// engines the voice combo lists imported reference WAVs and there is no built-in default
+/// voice. Cloning needs no reference transcript (the Mimi encoder + speaker projection
+/// condition from audio alone), which also makes per-line voice cloning a plain file copy.
+///
+/// License: CC-BY-4.0 plus Kyutai's gated-use conditions — see
+/// https://huggingface.co/kyutai/pocket-tts (the GGUF repo itself is ungated).
+/// </summary>
+public class PocketTtsCrispAsr : ITtsEngine, IPerLineCloneEngine
+{
+    public string Name => "Pocket TTS (CrispASR)";
+    public string Description => "Kyutai Pocket TTS 100M with voice cloning — 6 languages, via CrispASR";
+    public bool HasLanguageParameter => false;
+    public bool HasApiKey => false;
+    public bool HasRegion => false;
+    public bool HasModel => true;
+    public bool HasKeyFile => false;
+    public bool SupportsVoiceCloning => true;
+    public bool SupportsPerLineVoiceCloning => true;
+
+    // One checkpoint per language (upstream's defaults: English F16, the distilled 6L
+    // languages at Q8_0, and the undistilled French 24L preview at Q8_0). English also gets
+    // the Q8_0 for slow machines. The label carries the language, so HasLanguageParameter
+    // stays false — picking a model IS picking the language.
+    public const string ModelKeyEnglishF16 = "English F16 (~219 MB)";
+    public const string ModelKeyEnglishQ8_0 = "English Q8_0 (~124 MB)";
+    public const string ModelKeyGermanQ8_0 = "German Q8_0 (~124 MB)";
+    public const string ModelKeySpanishQ8_0 = "Spanish Q8_0 (~124 MB)";
+    public const string ModelKeyItalianQ8_0 = "Italian Q8_0 (~124 MB)";
+    public const string ModelKeyPortugueseQ8_0 = "Portuguese Q8_0 (~124 MB)";
+    public const string ModelKeyFrenchQ8_0 = "French 24L Q8_0 (~365 MB)";
+    public const string DefaultModelKey = ModelKeyEnglishF16;
+
+    public const string EnglishF16FileName = "pocket-tts-english-f16.gguf";
+    public const string EnglishQ8_0FileName = "pocket-tts-english-q8_0.gguf";
+    public const string GermanQ8_0FileName = "pocket-tts-german-q8_0.gguf";
+    public const string SpanishQ8_0FileName = "pocket-tts-spanish-q8_0.gguf";
+    public const string ItalianQ8_0FileName = "pocket-tts-italian-q8_0.gguf";
+    public const string PortugueseQ8_0FileName = "pocket-tts-portuguese-q8_0.gguf";
+    public const string FrenchQ8_0FileName = "pocket-tts-french_24l-q8_0.gguf";
+
+    // Exact byte sizes on cstr/pocket-tts-GGUF (HF LFS metadata). Used to reject truncated
+    // files that crispasr's --auto-download may have left behind — same guard as the other
+    // CrispASR-backed engines.
+    private static readonly Dictionary<string, long> ExpectedFileSizes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [EnglishF16FileName] = 219234528L,
+        [EnglishQ8_0FileName] = 123632992L,
+        [GermanQ8_0FileName] = 123633408L,
+        [SpanishQ8_0FileName] = 123634464L,
+        [ItalianQ8_0FileName] = 123633664L,
+        [PortugueseQ8_0FileName] = 123634592L,
+        [FrenchQ8_0FileName] = 364587520L,
+    };
+
+    public static string ResolveModelKey(string? modelKey)
+    {
+        if (string.IsNullOrEmpty(modelKey))
+        {
+            var saved = Se.Settings.Video.TextToSpeech.PocketTtsCrispAsrModel;
+            return string.IsNullOrEmpty(saved) ? DefaultModelKey : ResolveModelKey(saved);
+        }
+
+        return modelKey switch
+        {
+            ModelKeyEnglishQ8_0 => ModelKeyEnglishQ8_0,
+            ModelKeyGermanQ8_0 => ModelKeyGermanQ8_0,
+            ModelKeySpanishQ8_0 => ModelKeySpanishQ8_0,
+            ModelKeyItalianQ8_0 => ModelKeyItalianQ8_0,
+            ModelKeyPortugueseQ8_0 => ModelKeyPortugueseQ8_0,
+            ModelKeyFrenchQ8_0 => ModelKeyFrenchQ8_0,
+            _ => ModelKeyEnglishF16,
+        };
+    }
+
+    public static string GetModelFileName(string? modelKey) => ResolveModelKey(modelKey) switch
+    {
+        ModelKeyEnglishQ8_0 => EnglishQ8_0FileName,
+        ModelKeyGermanQ8_0 => GermanQ8_0FileName,
+        ModelKeySpanishQ8_0 => SpanishQ8_0FileName,
+        ModelKeyItalianQ8_0 => ItalianQ8_0FileName,
+        ModelKeyPortugueseQ8_0 => PortugueseQ8_0FileName,
+        ModelKeyFrenchQ8_0 => FrenchQ8_0FileName,
+        _ => EnglishF16FileName,
+    };
+
+    /// <summary>
+    /// The explicit per-language backend names added in CrispASR v0.8.31 — passing these
+    /// (rather than the base "pocket-tts" plus a language flag) pins both the checkpoint's
+    /// tokenizer and its auto-download route, so a mismatched -m file fails loudly.
+    /// </summary>
+    public static string GetBackendName(string? modelKey) => ResolveModelKey(modelKey) switch
+    {
+        ModelKeyGermanQ8_0 => "pocket-tts-de",
+        ModelKeySpanishQ8_0 => "pocket-tts-es",
+        ModelKeyItalianQ8_0 => "pocket-tts-it",
+        ModelKeyPortugueseQ8_0 => "pocket-tts-pt",
+        ModelKeyFrenchQ8_0 => "pocket-tts-fr",
+        _ => "pocket-tts",
+    };
+
+    public static bool IsValidLocalModelFile(string path, string fileName)
+    {
+        if (!File.Exists(path))
+        {
+            return false;
+        }
+
+        if (!ExpectedFileSizes.TryGetValue(fileName, out var expected))
+        {
+            return true;
+        }
+
+        try
+        {
+            return new FileInfo(path).Length == expected;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static readonly HttpClient HttpClient = new()
+    {
+        Timeout = TimeSpan.FromMinutes(5),
+    };
+    private static readonly SemaphoreSlim ServerLock = new(1, 1);
+    private static Process? _serverProcess;
+    private static int _serverPort;
+    private static string? _serverLaunchCommand;
+    // Tracks the model key (= language + quant) the running server was started with. Unlike
+    // indextts, the pocket-tts backend resolves the per-request `voice` (a bare stem) against
+    // --voice-dir and caches the latents per reference, so a voice change needs NO restart —
+    // only a model change does. Verified against the v0.8.31 server (issue #255 upstream).
+    private static string? _serverModelKey;
+    private static bool _processExitHooked;
+    private static readonly StringBuilder _serverLog = new();
+
+    private static string ServerBaseUrl => $"http://127.0.0.1:{_serverPort}";
+
+    public Task<bool> IsInstalled(string? region)
+    {
+        return Task.FromResult(File.Exists(GetCrispAsrExecutable()));
+    }
+
+    public override string ToString() => Name;
+
+    /// <summary>
+    /// Path to the crispasr executable installed by the speech-to-text feature. Shared with
+    /// the other CrispASR TTS engines and all CrispASR ASR engines.
+    /// </summary>
+    public static string GetCrispAsrExecutable()
+    {
+        return new CrispAsrCohere().GetExecutable();
+    }
+
+    /// <summary>
+    /// Mirrors <see cref="Qwen3TtsCrispAsr.GetEngineUpdateStatus"/> — reads the speech-to-text
+    /// CrispASR install's <c>.installed.sha256</c> sidecar.
+    /// </summary>
+    public static DownloadHashManager.UpdateStatus GetEngineUpdateStatus()
+    {
+        var exe = GetCrispAsrExecutable();
+        if (!File.Exists(exe))
+        {
+            return DownloadHashManager.UpdateStatus.Unknown;
+        }
+
+        var folder = Path.GetDirectoryName(exe);
+        return string.IsNullOrEmpty(folder)
+            ? DownloadHashManager.UpdateStatus.Unknown
+            : DownloadHashManager.GetSidecarStatus(folder);
+    }
+
+    public static string GetSetFolder()
+    {
+        if (!Directory.Exists(Se.TextToSpeechFolder))
+        {
+            Directory.CreateDirectory(Se.TextToSpeechFolder);
+        }
+
+        var folder = Path.Combine(Se.TextToSpeechFolder, "PocketTtsCrispAsr");
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        return folder;
+    }
+
+    public static string GetSetModelsFolder()
+    {
+        // Like the other CrispASR-backed engines, the GGUFs live alongside CrispASR's
+        // speech-to-text models in CrispASR/models/ rather than under TextToSpeech/.
+        var modelsFolder = Path.Combine(Se.CrispAsrFolder, "models");
+        if (!Directory.Exists(modelsFolder))
+        {
+            Directory.CreateDirectory(modelsFolder);
+        }
+
+        return modelsFolder;
+    }
+
+    public static string GetSetVoicesFolder()
+    {
+        var voicesFolder = Path.Combine(GetSetFolder(), "voices");
+        if (!Directory.Exists(voicesFolder))
+        {
+            Directory.CreateDirectory(voicesFolder);
+        }
+
+        SeedVoicesFromQwen3TtsCppIfEmpty(voicesFolder);
+        return voicesFolder;
+    }
+
+    private static bool _voiceSeedAttempted;
+
+    /// <summary>
+    /// One-time best-effort seed of WAV reference voices from qwen3-tts.cpp's voices folder.
+    /// Pocket TTS conditions through the 24 kHz Mimi encoder, and the qwen3-tts.cpp voice pack
+    /// ships at 16 kHz mono — resample on seed via ffmpeg, same path ImportVoice uses, so the
+    /// reference isn't upsampled on every synth call. Same rationale as IndexTTS (CrispASR).
+    /// </summary>
+    private static void SeedVoicesFromQwen3TtsCppIfEmpty(string voicesFolder)
+    {
+        if (_voiceSeedAttempted)
+        {
+            return;
+        }
+        _voiceSeedAttempted = true;
+
+        try
+        {
+            if (Directory.EnumerateFiles(voicesFolder, "*.wav").Any())
+            {
+                return;
+            }
+
+            var sourceFolder = Qwen3TtsCpp.GetSetVoicesFolder();
+            if (!Directory.Exists(sourceFolder) || !Directory.EnumerateFiles(sourceFolder, "*.wav").Any())
+            {
+                return;
+            }
+
+            foreach (var src in Directory.GetFiles(sourceFolder, "*.wav"))
+            {
+                var dest = Path.Combine(voicesFolder, Path.GetFileName(src));
+
+                // When ffmpeg cannot do it, seeding at 16 kHz beats skipping the voice.
+                VoiceSeedHelper.CopyOrResample(src, dest, 24000, "Pocket TTS (CrispASR)");
+            }
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, "Pocket TTS (CrispASR): voice seeding from qwen3-tts.cpp folder failed");
+        }
+    }
+
+    public static string GetModelPath(string? modelKey = null) =>
+        Path.Combine(GetSetModelsFolder(), GetModelFileName(modelKey));
+
+    public static bool AreModelsInstalled(string? modelKey = null) =>
+        IsValidLocalModelFile(GetModelPath(modelKey), GetModelFileName(modelKey));
+
+    /// <summary>
+    /// Path crispasr's --auto-download writes GGUFs to. Mirrors the IndexTTS (CrispASR) helper
+    /// so the SE-side downloader can adopt already-cached files instead of re-pulling.
+    /// </summary>
+    public static string GetCrispAsrCacheFolder() =>
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".cache", "crispasr");
+
+    /// <summary>
+    /// Best-effort copy of <paramref name="fileName"/> from <see cref="GetCrispAsrCacheFolder"/>
+    /// into SE's models folder. See <see cref="Qwen3TtsCrispAsr.TrySeedModelFromCrispAsrCache"/>
+    /// for rationale — same truncation-guard semantics.
+    /// </summary>
+    public static bool TrySeedModelFromCrispAsrCache(string fileName, string destinationPath)
+    {
+        if (IsValidLocalModelFile(destinationPath, fileName))
+        {
+            return true;
+        }
+
+        try
+        {
+            if (File.Exists(destinationPath))
+            {
+                Se.LogError($"Pocket TTS (CrispASR): removing wrong-sized local model file {destinationPath}");
+                File.Delete(destinationPath);
+            }
+
+            var cachePath = Path.Combine(GetCrispAsrCacheFolder(), fileName);
+            if (!IsValidLocalModelFile(cachePath, fileName))
+            {
+                return false;
+            }
+
+            File.Copy(cachePath, destinationPath);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, $"Pocket TTS (CrispASR): cache seed copy failed for {fileName}");
+            return false;
+        }
+    }
+
+    public const string PerLineReferencePrefix = "se-per-line-";
+
+    private static bool IsStagedPerLineReference(string fileName) =>
+        Path.GetFileName(fileName).StartsWith(PerLineReferencePrefix, StringComparison.OrdinalIgnoreCase);
+
+    public async Task<Voice[]> GetVoices(string language)
+    {
+        var result = new List<Voice>();
+
+        // Voice cloning only — the model produces near-silence without voice conditioning, so
+        // there is no built-in default voice. The combo is empty until the user imports a
+        // reference WAV (or the qwen3-tts.cpp voice seed runs above).
+        // Off the UI thread: GetSetVoicesFolder does one-time reference-WAV seeding through
+        // ffmpeg, and this is awaited from SelectedEngineChanged on the dispatcher.
+        var voicesFolder = await Task.Run(GetSetVoicesFolder);
+        if (Directory.Exists(voicesFolder))
+        {
+            foreach (var file in Directory.GetFiles(voicesFolder, "*.wav"))
+            {
+                // The per-line clone's own references live here too (the backend resolves bare
+                // stems against --voice-dir); they belong to one line of one run, not in a combo.
+                if (IsStagedPerLineReference(file))
+                {
+                    continue;
+                }
+
+                var name = Path.GetFileNameWithoutExtension(file).Replace('_', ' ');
+                result.Add(new Voice(new PocketTtsVoice(name, file)));
+            }
+        }
+
+        return result.ToArray();
+    }
+
+    public bool IsVoiceInstalled(Voice voice) => true;
+
+    public Task<string[]> GetRegions() => Task.FromResult(Array.Empty<string>());
+
+    public Task<string[]> GetModels() => Task.FromResult(new[]
+    {
+        ModelKeyEnglishF16,
+        ModelKeyEnglishQ8_0,
+        ModelKeyGermanQ8_0,
+        ModelKeySpanishQ8_0,
+        ModelKeyItalianQ8_0,
+        ModelKeyPortugueseQ8_0,
+        ModelKeyFrenchQ8_0,
+    });
+
+    public Task<TtsLanguage[]> GetLanguages(Voice voice, string? model) => Task.FromResult(Array.Empty<TtsLanguage>());
+
+    public Task<Voice[]> RefreshVoices(string language, CancellationToken cancellationToken) =>
+        GetVoices(language);
+
+    /// <summary>
+    /// <see cref="IPerLineCloneEngine"/>: the pocket-tts backend resolves the request's bare
+    /// voice stem against its --voice-dir, so the clip is staged in there and the voice's
+    /// FilePath points at the copy — that is the lookup key <see cref="Speak"/> sends. Unlike
+    /// Qwen3, cloning needs no transcript (the Mimi encoder conditions from audio alone), so
+    /// staging never fails on a missing sidecar and every cut clip is usable.
+    /// </summary>
+    public Voice? MakePerLineCloneVoice(string clipFileName, string voiceName) =>
+        StagePerLineReference(clipFileName) is { } staged
+            ? new Voice(new PocketTtsVoice(voiceName, staged))
+            : null;
+
+    /// <summary>
+    /// The staged copy in the voices folder, which is the only reference this engine ever
+    /// speaks from — exporting it is what lets an imported session be re-dubbed on a machine
+    /// that no longer has the video.
+    /// </summary>
+    public string? GetPerLineReferenceClip(Voice voice) =>
+        voice.EngineVoice is PocketTtsVoice pocketVoice && !string.IsNullOrEmpty(pocketVoice.FilePath)
+            ? pocketVoice.FilePath
+            : null;
+
+    /// <summary>
+    /// <see cref="IPerLineCloneEngine"/>: see <see cref="ClearStagedPerLineReferences"/>.
+    /// </summary>
+    public void ResetStagedPerLineReferences() => ClearStagedPerLineReferences();
+
+    public static string? StagePerLineReference(string clipFileName)
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(clipFileName) || !File.Exists(clipFileName))
+            {
+                return null;
+            }
+
+            // An exported session carries the staged name, so re-staging it on import would
+            // otherwise pile a second prefix on top — once per round trip.
+            var baseName = Path.GetFileNameWithoutExtension(clipFileName);
+            if (baseName.StartsWith(PerLineReferencePrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                baseName = baseName.Substring(PerLineReferencePrefix.Length);
+            }
+
+            var stagedFileName = Path.Combine(GetSetVoicesFolder(), PerLineReferencePrefix + baseName + ".wav");
+            File.Copy(clipFileName, stagedFileName, overwrite: true);
+            return stagedFileName;
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, $"Pocket TTS (CrispASR): staging the per-line reference '{clipFileName}' failed");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Removes every staged per-line reference, leaving the user's imported voices alone.
+    /// Called when a per-line run starts, so a run over a shorter subtitle cannot leave the
+    /// previous run's extra lines lying in the voices folder.
+    /// </summary>
+    public static void ClearStagedPerLineReferences()
+    {
+        try
+        {
+            var voicesFolder = Path.Combine(GetSetFolder(), "voices");
+            if (!Directory.Exists(voicesFolder))
+            {
+                return;
+            }
+
+            foreach (var file in Directory.GetFiles(voicesFolder, PerLineReferencePrefix + "*"))
+            {
+                try
+                {
+                    File.Delete(file);
+                }
+                catch
+                {
+                    // A reference still open (the server may be reading it) is left for next time.
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, "Pocket TTS (CrispASR): clearing the staged per-line references failed");
+        }
+    }
+
+    public async Task<TtsResult> Speak(
+        string text,
+        string outputFolder,
+        Voice voice,
+        TtsLanguage? language,
+        string? region,
+        string? model,
+        CancellationToken cancellationToken)
+    {
+        if (voice.EngineVoice is not PocketTtsVoice pocketVoice)
+        {
+            throw new ArgumentException("Voice is not a PocketTtsVoice");
+        }
+
+        if (string.IsNullOrEmpty(pocketVoice.FilePath))
+        {
+            throw new InvalidOperationException(
+                "Pocket TTS (CrispASR) requires a reference voice WAV — the model produces "
+                + "near-silence without voice conditioning. Import one via the voice settings, "
+                + "then pick it in the voice combo (3-10 s of clean speech works best).");
+        }
+
+        var modelKey = ResolveModelKey(model);
+        await EnsureServerRunningAsync(modelKey, pocketVoice.FilePath, cancellationToken);
+
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder), Guid.NewGuid() + ".wav");
+        var inputText = text;
+
+        // OpenAI-compatible /v1/audio/speech payload. Unlike indextts, the pocket-tts backend
+        // honours a per-request `voice`: a bare stem (no path separators, no .wav — the server's
+        // path-traversal guard rejects paths) is resolved against the startup --voice-dir and
+        // the reference latents are cached per stem, so switching voices needs no server
+        // restart. Verified against the v0.8.31 server; upstream issue #255.
+        var speed = Math.Clamp(Se.Settings.Video.TextToSpeech.PocketTtsCrispAsrSpeed, 0.25, 4.0);
+        var payload = new Dictionary<string, object>
+        {
+            ["input"] = inputText,
+            ["response_format"] = "wav",
+            ["speed"] = speed,
+            ["voice"] = Path.GetFileNameWithoutExtension(pocketVoice.FilePath),
+        };
+
+        // Attests the user's own imported reference and the AI-disclosure duty; see
+        // CrispAsrTtsProvenance. Skipped when voice cloning has not been accepted in settings.
+        CrispAsrTtsProvenance.AddSpeechAttestations(payload);
+
+        var body = JsonSerializer.Serialize(payload);
+        using var content = new StringContent(body, Encoding.UTF8, "application/json");
+        Se.WriteToolsLog($"Pocket TTS (CrispASR): POST {ServerBaseUrl}/v1/audio/speech (voice={pocketVoice}, textLen={text.Length})");
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await HttpClient.PostAsync($"{ServerBaseUrl}/v1/audio/speech", content, cancellationToken);
+        }
+        catch (HttpRequestException ex)
+        {
+            var serverLog = SnapshotServerLog();
+            var launchCommand = _serverLaunchCommand;
+            var died = _serverProcess?.HasExited == true;
+            if (died)
+            {
+                StopServerInternal();
+            }
+
+            var failMsg = $"Pocket TTS (CrispASR) request failed — Voice: {pocketVoice}, Text: {text}, "
+                + $"RequestJson: {body}, ServerExited: {died}, ServerLog: {serverLog}"
+                + LaunchCmdSuffix(launchCommand);
+            Se.LogError(ex, failMsg);
+            Se.WriteToolsLog(failMsg);
+
+            throw new InvalidOperationException(
+                (died
+                    ? "Pocket TTS (CrispASR) — the crispasr server crashed during synthesis."
+                    : "Pocket TTS (CrispASR) request failed — the connection to the crispasr server was dropped.")
+                + (string.IsNullOrEmpty(serverLog) ? string.Empty : $"{Environment.NewLine}Server log:{Environment.NewLine}{serverLog}")
+                + LaunchCmdSuffix(launchCommand),
+                ex);
+        }
+
+        using (response)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorBody = await SafeReadErrorAsync(response, cancellationToken);
+                var serverLog = SnapshotServerLog();
+                var launchCommand = _serverLaunchCommand;
+                var errMsg = $"Pocket TTS (CrispASR) server error {(int)response.StatusCode} {response.StatusCode} — "
+                    + $"Voice: {pocketVoice}, Text: {text}, RequestJson: {body}, "
+                    + $"ResponseBody: {errorBody}, ServerLog: {serverLog}"
+                    + LaunchCmdSuffix(launchCommand);
+                Se.LogError(errMsg);
+                Se.WriteToolsLog(errMsg);
+                throw new InvalidOperationException(
+                    $"Pocket TTS (CrispASR) synthesis failed ({(int)response.StatusCode}): {errorBody}"
+                    + (string.IsNullOrEmpty(serverLog) ? string.Empty : $"{Environment.NewLine}Server log:{Environment.NewLine}{serverLog}")
+                    + LaunchCmdSuffix(launchCommand));
+            }
+
+            await using var fileStream = File.Create(outputFileName);
+            await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+            await contentStream.CopyToAsync(fileStream, cancellationToken);
+        }
+
+        return new TtsResult(outputFileName, text);
+    }
+
+    private static string FormatLaunchCommand(string exe, System.Collections.ObjectModel.Collection<string> args)
+    {
+        static string Quote(string s) =>
+            !string.IsNullOrEmpty(s) && s.IndexOfAny(new[] { ' ', '\t' }) >= 0
+                ? "\"" + s.Replace("\"", "\\\"") + "\""
+                : s;
+
+        var sb = new StringBuilder(Quote(exe));
+        foreach (var a in args)
+        {
+            sb.Append(' ').Append(Quote(a));
+        }
+        return sb.ToString();
+    }
+
+    private static string LaunchCmdSuffix(string? launchCommand) =>
+        string.IsNullOrEmpty(launchCommand)
+            ? string.Empty
+            : $"{Environment.NewLine}Launch command: {launchCommand}";
+
+    private static async Task<string> SafeReadErrorAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        try
+        {
+            return await response.Content.ReadAsStringAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            return $"<failed to read error body: {ex.Message}>";
+        }
+    }
+
+    private static async Task EnsureServerRunningAsync(string modelKey, string voicePath, CancellationToken ct)
+    {
+        // Voice changes ride on the per-request stem (see Speak), so only a model change —
+        // a different language checkpoint, hence a different --backend AND -m — restarts the
+        // server. The startup --voice still carries the currently selected reference as the
+        // fallback conditioning for a request whose stem cannot be resolved.
+        if (_serverProcess is { HasExited: false } && _serverPort != 0
+            && string.Equals(_serverModelKey, modelKey, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        await ServerLock.WaitAsync(ct);
+        try
+        {
+            if (_serverProcess is { HasExited: false } && _serverPort != 0
+                && string.Equals(_serverModelKey, modelKey, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            if (_serverProcess != null)
+            {
+                StopServerInternal();
+            }
+
+            var exe = GetCrispAsrExecutable();
+            if (!File.Exists(exe))
+            {
+                throw new FileNotFoundException(
+                    "CrispASR executable not found. Install CrispASR via Video → Audio to text first.", exe);
+            }
+
+            // Model GGUF: use the locally staged copy when present; otherwise fall back to
+            // crispasr's own --auto-download (fetches into ~/.cache/crispasr/ on first run).
+            var modelFileName = GetModelFileName(modelKey);
+            var modelPath = GetModelPath(modelKey);
+            var hasLocalModel = IsValidLocalModelFile(modelPath, modelFileName);
+
+            var port = FindFreeLoopbackPort();
+            var psi = new ProcessStartInfo
+            {
+                WorkingDirectory = Path.GetDirectoryName(exe) ?? GetSetFolder(),
+                FileName = exe,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                // The server writes UTF-8. Without these the reader decodes it in the OS default
+                // codepage, and non-ASCII text in the captured log - the line being synthesised,
+                // upstream's em dashes - reaches bug reports as mojibake (#13572).
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8,
+            };
+            psi.ArgumentList.Add("--server");
+            psi.ArgumentList.Add("--backend");
+            psi.ArgumentList.Add(GetBackendName(modelKey));
+            psi.ArgumentList.Add("-m");
+            psi.ArgumentList.Add(hasLocalModel ? modelPath : "auto");
+            if (!hasLocalModel)
+            {
+                psi.ArgumentList.Add("--auto-download");
+                // The Kyutai weights are behind a restricted-licence tag in crispasr's registry,
+                // so its managed download refuses without this. SE's own downloader (the normal
+                // path) fetches the ungated GGUF mirror directly and never needs it.
+                psi.ArgumentList.Add("--accept-license");
+                psi.ArgumentList.Add("pocket-tts-terms");
+            }
+            psi.ArgumentList.Add("--host");
+            psi.ArgumentList.Add("127.0.0.1");
+            psi.ArgumentList.Add("--port");
+            psi.ArgumentList.Add(port.ToString());
+            // /v1/audio/speech resolves the request's bare voice stem against this folder.
+            psi.ArgumentList.Add("--voice-dir");
+            psi.ArgumentList.Add(GetSetVoicesFolder());
+            // Fallback conditioning for a request without a resolvable stem — without ANY
+            // reference the model produces near-silence, never a normal default voice.
+            psi.ArgumentList.Add("--voice");
+            psi.ArgumentList.Add(voicePath);
+            CrispAsrTtsProvenance.AddServerMarkingArgs(psi.ArgumentList, exe);
+
+            var process = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start crispasr (pocket-tts)");
+
+            var launchCommand = FormatLaunchCommand(exe, psi.ArgumentList);
+            _serverLaunchCommand = launchCommand;
+            Se.WriteToolsLog("Pocket TTS (CrispASR) server starting — "
+                + $"PID: {process.Id}, "
+                + $"Cmd: {launchCommand}");
+
+            lock (_serverLog) _serverLog.Clear();
+            process.ErrorDataReceived += (_, e) =>
+            {
+                if (e.Data != null) lock (_serverLog) _serverLog.AppendLine(e.Data);
+            };
+            process.OutputDataReceived += (_, e) =>
+            {
+                if (e.Data != null) lock (_serverLog) _serverLog.AppendLine(e.Data);
+            };
+            process.BeginErrorReadLine();
+            process.BeginOutputReadLine();
+
+            _serverProcess = process;
+            _serverPort = port;
+            _serverModelKey = modelKey;
+            HookProcessExitOnce();
+
+            // First-run auto-download is at most ~365 MB (French), and the model itself loads
+            // in seconds — much lighter than the other CrispASR TTS engines.
+            var deadline = DateTime.UtcNow.AddMinutes(hasLocalModel ? 5 : 15);
+            while (DateTime.UtcNow < deadline)
+            {
+                ct.ThrowIfCancellationRequested();
+                if (process.HasExited)
+                {
+                    var tail = SnapshotServerLog();
+                    var exitCode = process.ExitCode;
+                    var exitedLaunchCommand = _serverLaunchCommand;
+                    _serverProcess = null;
+                    _serverPort = 0;
+                    _serverLaunchCommand = null;
+                    _serverModelKey = null;
+                    throw new InvalidOperationException(
+                        $"crispasr (pocket-tts) exited during startup (code {exitCode}). Output: {tail}"
+                        + LaunchCmdSuffix(exitedLaunchCommand));
+                }
+                if (await ProbeHealthAsync(port, TimeSpan.FromSeconds(2), ct))
+                {
+                    return;
+                }
+                await Task.Delay(TimeSpan.FromSeconds(1), ct);
+            }
+
+            var lastOutput = SnapshotServerLog();
+            var timeoutLaunchCommand = _serverLaunchCommand;
+            StopServerInternal();
+            throw new TimeoutException(
+                $"crispasr (pocket-tts) did not report healthy within {(hasLocalModel ? 5 : 15)} minutes. Last output: {lastOutput}"
+                + LaunchCmdSuffix(timeoutLaunchCommand));
+        }
+        finally
+        {
+            ServerLock.Release();
+        }
+    }
+
+    private static string SnapshotServerLog()
+    {
+        lock (_serverLog)
+        {
+            var s = _serverLog.ToString().TrimEnd();
+            return s.Length > 2000 ? s[^2000..] : s;
+        }
+    }
+
+    private static async Task<bool> ProbeHealthAsync(int port, TimeSpan timeout, CancellationToken ct)
+    {
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(timeout);
+            using var resp = await HttpClient.GetAsync($"http://127.0.0.1:{port}/health", cts.Token);
+            return resp.IsSuccessStatusCode;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static int FindFreeLoopbackPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    private static void HookProcessExitOnce()
+    {
+        if (_processExitHooked)
+        {
+            return;
+        }
+        _processExitHooked = true;
+        AppDomain.CurrentDomain.ProcessExit += (_, _) => StopServerInternal();
+    }
+
+    /// <summary>
+    /// Stop the running crispasr (pocket-tts) server if any, releasing GPU memory. Called by
+    /// <c>TextToSpeechViewModel</c> when starting synthesis on a different engine or when the
+    /// TTS window closes, so the CrispASR-based TTS engines don't pile up in VRAM.
+    /// </summary>
+    public static void StopServer() => StopServerInternal();
+
+    private static void StopServerInternal()
+    {
+        var p = _serverProcess;
+        _serverProcess = null;
+        _serverPort = 0;
+        _serverLaunchCommand = null;
+        _serverModelKey = null;
+        if (p == null)
+        {
+            return;
+        }
+        try
+        {
+            if (!p.HasExited)
+            {
+                p.Kill(entireProcessTree: true);
+                p.WaitForExit(2000);
+            }
+        }
+        catch
+        {
+            // best effort
+        }
+        finally
+        {
+            p.Dispose();
+        }
+    }
+
+    private static string GetUniqueDestinationFileName(string folder, string baseName)
+    {
+        var candidate = Path.Combine(folder, baseName + ".wav");
+        if (!File.Exists(candidate))
+        {
+            return candidate;
+        }
+
+        var number = 1;
+        do
+        {
+            candidate = Path.Combine(folder, $"{baseName}_{number}.wav");
+            number++;
+        } while (File.Exists(candidate));
+
+        return candidate;
+    }
+
+    public bool ImportVoice(string fileName)
+    {
+        if (string.IsNullOrEmpty(fileName) || !File.Exists(fileName))
+        {
+            return false;
+        }
+
+        var voicesFolder = GetSetVoicesFolder();
+        var baseName = Path.GetFileNameWithoutExtension(fileName);
+        var destinationFileName = GetUniqueDestinationFileName(voicesFolder, baseName);
+
+        // The Mimi encoder runs at 24 kHz. Resample on import via ffmpeg regardless of source
+        // format. No .txt sidecar needed (cloning conditions from audio alone).
+        try
+        {
+            var process = FfmpegGenerator.ConvertToMono24kHzWav(fileName, destinationFileName);
+            if (!process.Start())
+            {
+                return false;
+            }
+
+            process.WaitForExit();
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, "Pocket TTS (CrispASR) voice import failed (ffmpeg conversion).");
+            return false;
+        }
+
+        return File.Exists(destinationFileName);
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/Engines/TtsEngineCatalog.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/TtsEngineCatalog.cs
@@ -78,6 +78,11 @@ public static class TtsEngineCatalog
             // engines grouped visually in the engine combo.
             new CosyVoice3CrispAsr(),
 
+            // Pocket TTS (CrispASR) — Kyutai's 100M model, the smallest and fastest cloning
+            // engine here (one 124-365 MB GGUF per language, RTF ~0.1 on CPU). Six languages;
+            // per-request reference resolution, so voice changes need no server restart.
+            new PocketTtsCrispAsr(),
+
             // IndexTTS 2.5 on the audio.cpp runtime (not CrispASR): 5 languages, emotion
             // control and speaking-rate control, with a per-request reference voice so the
             // server is not restarted when the voice changes.

--- a/src/ui/Features/Video/TextToSpeech/PocketTtsCrispAsrSettings/PocketTtsCrispAsrSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/PocketTtsCrispAsrSettings/PocketTtsCrispAsrSettingsViewModel.cs
@@ -1,0 +1,274 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.PocketTtsCrispAsrSettings;
+
+public partial class PocketTtsCrispAsrSettingsViewModel : ObservableObject
+{
+    // A SolidColorBrush set as Shape.Fill is parented into that shape's visual tree, so the
+    // same instance can't be shared across multiple bound Ellipses (only one dot would render).
+    // Construct a fresh brush per assignment instead.
+    private static IBrush Green() => new SolidColorBrush(Color.FromRgb(0x4C, 0xAF, 0x50));
+    private static IBrush Amber() => new SolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00));
+    private static IBrush Red() => new SolidColorBrush(Color.FromRgb(0xF4, 0x43, 0x36));
+    private static IBrush Grey() => new SolidColorBrush(Color.FromRgb(0x9E, 0x9E, 0x9E));
+
+    private readonly IWindowService _windowService;
+    private readonly IFolderHelper _folderHelper;
+
+    [ObservableProperty] private string _engineLabel = string.Empty;
+    [ObservableProperty] private IBrush _engineBrush = Grey();
+    [ObservableProperty] private string _engineDownloadButtonText = string.Empty;
+
+    [ObservableProperty] private string _englishF16Label = string.Empty;
+    [ObservableProperty] private IBrush _englishF16Brush = Grey();
+
+    [ObservableProperty] private string _englishQ8_0Label = string.Empty;
+    [ObservableProperty] private IBrush _englishQ8_0Brush = Grey();
+
+    [ObservableProperty] private string _germanLabel = string.Empty;
+    [ObservableProperty] private IBrush _germanBrush = Grey();
+
+    [ObservableProperty] private string _spanishLabel = string.Empty;
+    [ObservableProperty] private IBrush _spanishBrush = Grey();
+
+    [ObservableProperty] private string _italianLabel = string.Empty;
+    [ObservableProperty] private IBrush _italianBrush = Grey();
+
+    [ObservableProperty] private string _portugueseLabel = string.Empty;
+    [ObservableProperty] private IBrush _portugueseBrush = Grey();
+
+    [ObservableProperty] private string _frenchLabel = string.Empty;
+    [ObservableProperty] private IBrush _frenchBrush = Grey();
+
+    [ObservableProperty] private string _voicesLabel = string.Empty;
+
+    [ObservableProperty] private double _speed = 1.0;
+
+    public string SpeedLabel => $"Speed {Speed:0.00}x";
+
+    partial void OnSpeedChanged(double value)
+    {
+        OnPropertyChanged(nameof(SpeedLabel));
+        Se.Settings.Video.TextToSpeech.PocketTtsCrispAsrSpeed = Math.Clamp(value, 0.25, 4.0);
+    }
+
+    [ObservableProperty] private string _modelsFolder = string.Empty;
+    [ObservableProperty] private string _voicesFolder = string.Empty;
+    [ObservableProperty] private bool _isEngineInstalled;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    public PocketTtsCrispAsrSettingsViewModel(IWindowService windowService, IFolderHelper folderHelper)
+    {
+        _windowService = windowService;
+        _folderHelper = folderHelper;
+    }
+
+    public void Initialize()
+    {
+        ModelsFolder = PocketTtsCrispAsr.GetSetModelsFolder();
+        VoicesFolder = PocketTtsCrispAsr.GetSetVoicesFolder();
+        Speed = Math.Clamp(Se.Settings.Video.TextToSpeech.PocketTtsCrispAsrSpeed, 0.25, 4.0);
+        Refresh();
+    }
+
+    private void Refresh()
+    {
+        var exe = PocketTtsCrispAsr.GetCrispAsrExecutable();
+        IsEngineInstalled = File.Exists(exe);
+
+        if (!IsEngineInstalled)
+        {
+            EngineLabel = string.Format(Se.Language.Video.TtsEngineNotInstalled, "CrispASR");
+            EngineBrush = Red();
+            EngineDownloadButtonText = string.Format(Se.Language.General.DownloadX, "CrispASR");
+        }
+        else if (PocketTtsCrispAsr.GetEngineUpdateStatus() == DownloadHashManager.UpdateStatus.UpdateAvailable)
+        {
+            EngineLabel = string.Format(Se.Language.Video.TtsEngineUpdateAvailable, "CrispASR");
+            EngineBrush = Amber();
+            EngineDownloadButtonText = string.Format(Se.Language.Video.TtsUpdateX, "CrispASR");
+        }
+        else
+        {
+            EngineLabel = "CrispASR";
+            EngineBrush = Green();
+            EngineDownloadButtonText = string.Format(Se.Language.General.ReDownloadX, "CrispASR");
+        }
+
+        // Append the installed CrispASR version asynchronously - the probe is a child
+        // process and we don't want to block the dialog opening (the probe is cached
+        // after the first call but the first one can be a few hundred ms).
+        if (IsEngineInstalled)
+        {
+            var baseLabel = EngineLabel;
+            _ = Task.Run(() =>
+            {
+                try
+                {
+                    var version = CrispAsrVersion.TryGet(exe);
+                    if (string.IsNullOrEmpty(version))
+                    {
+                        return;
+                    }
+                    Dispatcher.UIThread.Post(() =>
+                    {
+                        if (EngineLabel == baseLabel)
+                        {
+                            EngineLabel = baseLabel.Replace("CrispASR", $"CrispASR v{version}");
+                        }
+                    });
+                }
+                catch (Exception ex)
+                {
+                    Se.LogError(ex, "PocketTtsCrispAsrSettings: CrispASR version probe failed");
+                }
+            });
+        }
+
+        // One GGUF per language, in the engine's models folder OR auto-downloaded by crispasr
+        // into ~/.cache/crispasr. We can only verify the engine-folder copy here; when CrispASR
+        // is installed a missing local file is fine ("Auto-download on first use"), and when it
+        // is NOT installed that message would promise a download that can't happen yet.
+        ApplyStatus(PocketTtsCrispAsr.ModelKeyEnglishF16, PocketTtsCrispAsr.EnglishF16FileName,
+            label => EnglishF16Label = label, brush => EnglishF16Brush = brush);
+        ApplyStatus(PocketTtsCrispAsr.ModelKeyEnglishQ8_0, PocketTtsCrispAsr.EnglishQ8_0FileName,
+            label => EnglishQ8_0Label = label, brush => EnglishQ8_0Brush = brush);
+        ApplyStatus(PocketTtsCrispAsr.ModelKeyGermanQ8_0, PocketTtsCrispAsr.GermanQ8_0FileName,
+            label => GermanLabel = label, brush => GermanBrush = brush);
+        ApplyStatus(PocketTtsCrispAsr.ModelKeySpanishQ8_0, PocketTtsCrispAsr.SpanishQ8_0FileName,
+            label => SpanishLabel = label, brush => SpanishBrush = brush);
+        ApplyStatus(PocketTtsCrispAsr.ModelKeyItalianQ8_0, PocketTtsCrispAsr.ItalianQ8_0FileName,
+            label => ItalianLabel = label, brush => ItalianBrush = brush);
+        ApplyStatus(PocketTtsCrispAsr.ModelKeyPortugueseQ8_0, PocketTtsCrispAsr.PortugueseQ8_0FileName,
+            label => PortugueseLabel = label, brush => PortugueseBrush = brush);
+        ApplyStatus(PocketTtsCrispAsr.ModelKeyFrenchQ8_0, PocketTtsCrispAsr.FrenchQ8_0FileName,
+            label => FrenchLabel = label, brush => FrenchBrush = brush);
+
+        try
+        {
+            var wavCount = Directory.Exists(VoicesFolder)
+                ? Directory.GetFiles(VoicesFolder, "*.wav").Length
+                : 0;
+            VoicesLabel = wavCount == 0
+                ? "No voices imported"
+                : (wavCount == 1 ? "1 voice imported" : $"{wavCount} voices imported");
+        }
+        catch
+        {
+            VoicesLabel = string.Empty;
+        }
+    }
+
+    private void ApplyStatus(string modelKey, string fileName, Action<string> setLabel, Action<IBrush> setBrush)
+    {
+        var path = PocketTtsCrispAsr.GetModelPath(modelKey);
+        if (PocketTtsCrispAsr.IsValidLocalModelFile(path, fileName))
+        {
+            setLabel("Installed");
+            setBrush(Green());
+            return;
+        }
+
+        if (!IsEngineInstalled)
+        {
+            // No CrispASR runtime means there's nothing to auto-download into, so don't
+            // promise a download that can't happen until the user installs CrispASR.
+            setLabel("CrispASR required");
+            setBrush(Grey());
+            return;
+        }
+
+        setLabel("Auto-download on first use");
+        setBrush(Grey());
+    }
+
+    [RelayCommand]
+    private async Task RedownloadEngine()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        // CrispASR is shared across all CrispASR-driven TTS engines; we use the Pocket TTS
+        // entry point so prompts read "Pocket TTS (CrispASR)" rather than another engine's name
+        // (the crispasr binary itself doesn't care which engine triggered the download).
+        await TtsVoiceInstaller.EnsureCrispAsrForPocketTts(Window, _windowService, forceRedownload: true);
+        Refresh();
+    }
+
+    [RelayCommand]
+    private async Task OpenModelsFolder()
+    {
+        if (Window == null || string.IsNullOrEmpty(ModelsFolder))
+        {
+            return;
+        }
+
+        try
+        {
+            await _folderHelper.OpenFolder(Window, ModelsFolder);
+        }
+        catch
+        {
+            // best-effort UX
+        }
+    }
+
+    [RelayCommand]
+    private async Task OpenVoicesFolder()
+    {
+        if (Window == null || string.IsNullOrEmpty(VoicesFolder))
+        {
+            return;
+        }
+
+        try
+        {
+            await _folderHelper.OpenFolder(Window, VoicesFolder);
+        }
+        catch
+        {
+            // best-effort UX
+        }
+    }
+
+    [RelayCommand]
+    private void OpenLicensePage()
+    {
+        UiUtil.OpenUrl("https://huggingface.co/kyutai/pocket-tts");
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/PocketTtsCrispAsrSettings/PocketTtsCrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/PocketTtsCrispAsrSettings/PocketTtsCrispAsrSettingsWindow.cs
@@ -1,0 +1,287 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.PocketTtsCrispAsrSettings;
+
+public class PocketTtsCrispAsrSettingsWindow : Window
+{
+    private const int LabelWidth = 170;
+    private const int ValueWidth = 360;
+
+    private readonly PocketTtsCrispAsrSettingsViewModel _vm;
+
+    public PocketTtsCrispAsrSettingsWindow(PocketTtsCrispAsrSettingsViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = string.Format(Se.Language.Video.TtsCrispAsrSettingsTitle, "Pocket TTS");
+        SizeToContent = SizeToContent.WidthAndHeight;
+        CanResize = false;
+        MinWidth = 580;
+
+        _vm = vm;
+        vm.Window = this;
+        DataContext = vm;
+
+        Content = BuildContent(vm);
+
+        var ok = UiUtil.MakeButtonOk(vm.OkCommand);
+        UiUtil.FocusOnFirstActivation(this, ok);
+    }
+
+    private Border BuildContent(PocketTtsCrispAsrSettingsViewModel vm)
+    {
+        var header = BuildHeader(vm);
+        var details = BuildDetails(vm);
+        var actions = BuildActions(vm);
+
+        var stack = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 14,
+            Children = { header, details, actions },
+        };
+
+        var outerGrid = new Grid
+        {
+            Margin = UiUtil.MakeWindowMargin(),
+        };
+        outerGrid.Children.Add(stack);
+
+        return new Border
+        {
+            Child = outerGrid,
+            Padding = new Thickness(4),
+        };
+    }
+
+    private static StackPanel BuildHeader(PocketTtsCrispAsrSettingsViewModel vm)
+    {
+        var title = new TextBlock
+        {
+            Text = "Pocket TTS (CrispASR)",
+            FontSize = 18,
+            FontWeight = FontWeight.SemiBold,
+        };
+
+        var subtitle = new TextBlock
+        {
+            Text = new PocketTtsCrispAsr().Description,
+            FontSize = 12,
+            Opacity = 0.75,
+            Margin = new Thickness(0, 2, 0, 0),
+        };
+
+        // The weights are CC-BY-4.0 with Kyutai's additional gated-use conditions; surface that
+        // (with a link to the model page) rather than leaving it buried in the download source.
+        var license = UiUtil.MakeLink("License: CC-BY-4.0 + Kyutai gated-use conditions", vm.OpenLicensePageCommand);
+        license.Margin = new Thickness(0, 2, 0, 0);
+        license.FontSize = 12;
+
+        return new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 0,
+            Children = { title, subtitle, license },
+        };
+    }
+
+    private static Border BuildDetails(PocketTtsCrispAsrSettingsViewModel vm)
+    {
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(LabelWidth, GridUnitType.Pixel) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnSpacing = 12,
+            RowSpacing = 10,
+        };
+
+        grid.Add(MakeLabel(Se.Language.General.Engine), 0, 0);
+        var enginePanel = MakeStatusPanel(nameof(vm.EngineBrush), nameof(vm.EngineLabel));
+        var engineButton = UiUtil.MakeButton(string.Empty, vm.RedownloadEngineCommand)
+            .WithIconLeftBindText(IconNames.Download, nameof(vm.EngineDownloadButtonText))
+            .WithMarginLeft(12);
+        enginePanel.Children.Add(engineButton);
+        grid.Add(enginePanel, 0, 1);
+
+        grid.Add(MakeLabel(PocketTtsCrispAsr.ModelKeyEnglishF16), 1, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.EnglishF16Brush), nameof(vm.EnglishF16Label)), 1, 1);
+
+        grid.Add(MakeLabel(PocketTtsCrispAsr.ModelKeyEnglishQ8_0), 2, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.EnglishQ8_0Brush), nameof(vm.EnglishQ8_0Label)), 2, 1);
+
+        grid.Add(MakeLabel(PocketTtsCrispAsr.ModelKeyGermanQ8_0), 3, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.GermanBrush), nameof(vm.GermanLabel)), 3, 1);
+
+        grid.Add(MakeLabel(PocketTtsCrispAsr.ModelKeySpanishQ8_0), 4, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.SpanishBrush), nameof(vm.SpanishLabel)), 4, 1);
+
+        grid.Add(MakeLabel(PocketTtsCrispAsr.ModelKeyItalianQ8_0), 5, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.ItalianBrush), nameof(vm.ItalianLabel)), 5, 1);
+
+        grid.Add(MakeLabel(PocketTtsCrispAsr.ModelKeyPortugueseQ8_0), 6, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.PortugueseBrush), nameof(vm.PortugueseLabel)), 6, 1);
+
+        grid.Add(MakeLabel(PocketTtsCrispAsr.ModelKeyFrenchQ8_0), 7, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.FrenchBrush), nameof(vm.FrenchLabel)), 7, 1);
+
+        grid.Add(MakeLabel(Se.Language.Video.Voices), 8, 0);
+        var voicesText = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.VoicesLabel)),
+        };
+        grid.Add(voicesText, 8, 1);
+
+        grid.Add(MakeLabel(Se.Language.General.Speed), 9, 0);
+        grid.Add(MakeSpeedPanel(), 9, 1);
+
+        grid.Add(MakeLabel(Se.Language.General.InstallFolder), 10, 0);
+        var folderText = new TextBox
+        {
+            IsReadOnly = true,
+            Width = ValueWidth,
+            BorderThickness = new Thickness(0),
+            Background = Brushes.Transparent,
+            Padding = new Thickness(0),
+            VerticalContentAlignment = VerticalAlignment.Center,
+            FontSize = 12,
+            [!TextBox.TextProperty] = new Binding(nameof(vm.ModelsFolder)),
+        };
+        grid.Add(folderText, 10, 1);
+
+        return new Border
+        {
+            Child = grid,
+            Padding = new Thickness(14),
+            CornerRadius = new CornerRadius(6),
+            BorderThickness = new Thickness(1),
+            BorderBrush = new SolidColorBrush(Color.FromArgb(0x40, 0x80, 0x80, 0x80)),
+        };
+    }
+
+    private static StackPanel MakeSpeedPanel()
+    {
+        // Server accepts 0.25-4.0; cap UI at 0.5-2.0 since anything outside that range is
+        // already a hack rather than a "preferred pace" choice.
+        var slider = new Slider
+        {
+            Minimum = 0.5,
+            Maximum = 2.0,
+            Width = 220,
+            TickFrequency = 0.05,
+            IsSnapToTickEnabled = true,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!Slider.ValueProperty] = new Binding(nameof(PocketTtsCrispAsrSettingsViewModel.Speed)),
+        };
+        var label = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            Margin = new Thickness(8, 0, 0, 0),
+            Width = 80,
+            [!TextBlock.TextProperty] = new Binding(nameof(PocketTtsCrispAsrSettingsViewModel.SpeedLabel)),
+        };
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { slider, label },
+        };
+    }
+
+    private static StackPanel MakeStatusPanel(string brushBindingPath, string labelBindingPath)
+    {
+        var dot = new Ellipse
+        {
+            Width = 10,
+            Height = 10,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!Ellipse.FillProperty] = new Binding(brushBindingPath),
+        };
+        var text = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            Margin = new Thickness(8, 0, 0, 0),
+            [!TextBlock.TextProperty] = new Binding(labelBindingPath),
+        };
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { dot, text },
+        };
+    }
+
+    private static Grid BuildActions(PocketTtsCrispAsrSettingsViewModel vm)
+    {
+        var openModelsFolder = UiUtil.MakeButton(Se.Language.General.OpenContainingFolder, vm.OpenModelsFolderCommand).WithIconLeft(IconNames.FolderOpen);
+        var openVoicesFolder = UiUtil.MakeButton("Voices folder", vm.OpenVoicesFolderCommand).WithIconLeft(IconNames.FolderOpen);
+        var close = UiUtil.MakeButton(Se.Language.General.Close, vm.OkCommand);
+
+        var leftPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            Children = { openModelsFolder, openVoicesFolder },
+        };
+
+        var rightPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Spacing = 8,
+            Children = { close },
+        };
+
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+        };
+        grid.Add(leftPanel, 0, 0);
+        grid.Add(rightPanel, 0, 2);
+        return grid;
+    }
+
+    private static TextBlock MakeLabel(string text) => new()
+    {
+        Text = text,
+        Opacity = 0.7,
+        VerticalAlignment = VerticalAlignment.Center,
+    };
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        _vm.OnKeyDown(e);
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -26,6 +26,7 @@ using Nikse.SubtitleEdit.Features.Video.TextToSpeech.VoxCPM2CrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.MossTtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DotsTtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTtsCrispAsrSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.PocketTtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTts25AudioCppSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DetectSpeakers;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.KokoroTtsSettings;
@@ -343,6 +344,10 @@ public partial class TextToSpeechViewModel : ObservableObject
         else if (SelectedEngine is IndexTtsCrispAsr)
         {
             Se.Settings.Video.TextToSpeech.IndexTtsCrispAsrModel = SelectedModel ?? IndexTtsCrispAsr.DefaultModelKey;
+        }
+        else if (SelectedEngine is PocketTtsCrispAsr)
+        {
+            Se.Settings.Video.TextToSpeech.PocketTtsCrispAsrModel = SelectedModel ?? PocketTtsCrispAsr.DefaultModelKey;
         }
         else if (SelectedEngine is DotsTtsCrispAsr)
         {
@@ -1290,6 +1295,10 @@ public partial class TextToSpeechViewModel : ObservableObject
         {
             IndexTtsCrispAsr.StopServer();
         }
+        if (keepAlive is not PocketTtsCrispAsr)
+        {
+            PocketTtsCrispAsr.StopServer();
+        }
         if (keepAlive is not DotsTtsCrispAsr)
         {
             DotsTtsCrispAsr.StopServer();
@@ -1579,6 +1588,9 @@ public partial class TextToSpeechViewModel : ObservableObject
             case IndexTtsCrispAsr:
                 await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadIndexTtsCrispAsrModels(IndexTtsCrispAsr.ResolveModelKey(SelectedModel)));
                 break;
+            case PocketTtsCrispAsr:
+                await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadPocketTtsCrispAsrModels(PocketTtsCrispAsr.ResolveModelKey(SelectedModel)));
+                break;
             case DotsTtsCrispAsr:
                 await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadDotsTtsCrispAsrModels(DotsTtsCrispAsr.ResolveModelKey(SelectedModel)));
                 break;
@@ -1653,6 +1665,9 @@ public partial class TextToSpeechViewModel : ObservableObject
                 ? DownloadDotStatus.UpToDate
                 : DownloadDotStatus.NotInstalled,
             IndexTtsCrispAsr => IndexTtsCrispAsr.AreModelsInstalled(modelKey)
+                ? DownloadDotStatus.UpToDate
+                : DownloadDotStatus.NotInstalled,
+            PocketTtsCrispAsr => PocketTtsCrispAsr.AreModelsInstalled(modelKey)
                 ? DownloadDotStatus.UpToDate
                 : DownloadDotStatus.NotInstalled,
             DotsTtsCrispAsr => DotsTtsCrispAsr.AreModelsInstalled(modelKey)
@@ -4043,6 +4058,16 @@ public partial class TextToSpeechViewModel : ObservableObject
             else if (SelectedEngine is IndexTtsCrispAsr)
             {
                 SelectedModel = Models.FirstOrDefault(p => p == Se.Settings.Video.TextToSpeech.IndexTtsCrispAsrModel);
+                if (string.IsNullOrEmpty(SelectedModel))
+                {
+                    SelectedModel = Models.FirstOrDefault();
+                }
+                IsEngineSettingsVisible = true;
+                IsModelDownloadVisible = true;
+            }
+            else if (SelectedEngine is PocketTtsCrispAsr)
+            {
+                SelectedModel = Models.FirstOrDefault(p => p == Se.Settings.Video.TextToSpeech.PocketTtsCrispAsrModel);
                 if (string.IsNullOrEmpty(SelectedModel))
                 {
                     SelectedModel = Models.FirstOrDefault();

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
@@ -184,6 +184,8 @@ public class TextToSpeechWindow : Window
                 return StatusDots.From(engine.IsInstalled(null).Result, VibeVoiceCrispAsr.GetEngineUpdateStatus());
             case IndexTtsCrispAsr:
                 return StatusDots.From(engine.IsInstalled(null).Result, IndexTtsCrispAsr.GetEngineUpdateStatus());
+            case PocketTtsCrispAsr:
+                return StatusDots.From(engine.IsInstalled(null).Result, PocketTtsCrispAsr.GetEngineUpdateStatus());
             case DotsTtsCrispAsr:
                 return StatusDots.From(engine.IsInstalled(null).Result, DotsTtsCrispAsr.GetEngineUpdateStatus());
             case IndexTts25AudioCpp:

--- a/src/ui/Features/Video/TextToSpeech/TtsEngineInstaller.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsEngineInstaller.cs
@@ -264,6 +264,46 @@ public static class TtsEngineInstaller
             return true;
         }
 
+        if (engine is PocketTtsCrispAsr)
+        {
+            if (!await TtsVoiceInstaller.EnsureCrispAsrForPocketTts(window, windowService, forceRedownload: false))
+            {
+                return false;
+            }
+
+            var pocketModelKey = PocketTtsCrispAsr.ResolveModelKey(model);
+            if (!PocketTtsCrispAsr.AreModelsInstalled(pocketModelKey))
+            {
+                // Model key already carries the language and size in its label (e.g.
+                // "German Q8_0 (~124 MB)") so we don't append a separate size.
+                var answer = await MessageBox.Show(
+                    window,
+                    "Download Pocket TTS (CrispASR) model?",
+                    $"{Environment.NewLine}\"Pocket TTS (CrispASR)\" ({pocketModelKey}) requires a model.{Environment.NewLine}{Environment.NewLine}Download model?",
+                    MessageBoxButtons.YesNoCancel,
+                    MessageBoxIcon.Question);
+
+                if (answer != MessageBoxResult.Yes)
+                {
+                    return false;
+                }
+
+                var dlResult = await windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(window, vm => vm.StartDownloadPocketTtsCrispAsrModels(pocketModelKey));
+                if (!dlResult.OkPressed || !PocketTtsCrispAsr.AreModelsInstalled(pocketModelKey))
+                {
+                    return false;
+                }
+
+                await Dispatcher.UIThread.InvokeAsync(async () =>
+                {
+                    await refreshVoices();
+                });
+                return true;
+            }
+
+            return true;
+        }
+
         if (engine is DotsTtsCrispAsr)
         {
             if (!await TtsVoiceInstaller.EnsureCrispAsrForDotsTts(window, windowService, forceRedownload: false))

--- a/src/ui/Features/Video/TextToSpeech/TtsEngineSettingsDialog.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsEngineSettingsDialog.cs
@@ -13,6 +13,7 @@ using Nikse.SubtitleEdit.Features.Video.TextToSpeech.MossTtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.OmniVoiceCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.OmniVoiceSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.PiperSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.PocketTtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Qwen3TtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Qwen3TtsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.VibeVoiceCrispAsrSettings;
@@ -42,6 +43,7 @@ public static class TtsEngineSettingsDialog
         IndexTtsCrispAsr or
         DotsTtsCrispAsr or
         CosyVoice3CrispAsr or
+        PocketTtsCrispAsr or
         F5TtsCrispAsr or
         OmniVoiceCrispAsr or
         VoxCPM2CrispAsr or
@@ -84,6 +86,10 @@ public static class TtsEngineSettingsDialog
         else if (engine is CosyVoice3CrispAsr)
         {
             await windowService.ShowDialogAsync<CosyVoice3CrispAsrSettingsWindow, CosyVoice3CrispAsrSettingsViewModel>(window, vm => vm.Initialize());
+        }
+        else if (engine is PocketTtsCrispAsr)
+        {
+            await windowService.ShowDialogAsync<PocketTtsCrispAsrSettingsWindow, PocketTtsCrispAsrSettingsViewModel>(window, vm => vm.Initialize());
         }
         else if (engine is F5TtsCrispAsr)
         {

--- a/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
@@ -96,6 +96,17 @@ public static class TtsVoiceInstaller
             minVersionNote: null);
 
     /// <summary>
+    /// Ensures the CrispASR runtime that Pocket TTS (CrispASR) runs on is installed.
+    /// The pocket-tts backend is older, but the per-language backends and model routing SE
+    /// relies on (pocket-tts-de/es/it/pt/fr) ship in CrispASR v0.8.31+.
+    /// </summary>
+    public static Task<bool> EnsureCrispAsrForPocketTts(Window? window, IWindowService windowService, bool forceRedownload)
+        => EnsureCrispAsrAsync(window, windowService, forceRedownload,
+            engineDisplayName: "Pocket TTS (CrispASR)",
+            extraCapabilityCheck: null,
+            minVersionNote: "v0.8.31 or newer");
+
+    /// <summary>
     /// Ensures the CrispASR runtime that Zonos TTS (CrispASR) runs on is installed.
     /// The zonos-tts backend's GGUFs (transformer + DAC codec) are staged into SE's
     /// CrispAsr/models folder by

--- a/src/ui/Features/Video/TextToSpeech/Voices/PocketTtsVoice.cs
+++ b/src/ui/Features/Video/TextToSpeech/Voices/PocketTtsVoice.cs
@@ -1,0 +1,24 @@
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+
+public class PocketTtsVoice
+{
+    public string Voice { get; set; }
+    public string FilePath { get; set; }
+
+    public override string ToString()
+    {
+        return Voice;
+    }
+
+    public PocketTtsVoice()
+    {
+        Voice = string.Empty;
+        FilePath = string.Empty;
+    }
+
+    public PocketTtsVoice(string voice, string filePath)
+    {
+        Voice = voice;
+        FilePath = filePath;
+    }
+}

--- a/src/ui/Logic/Config/SeVideoTextToSpeech.cs
+++ b/src/ui/Logic/Config/SeVideoTextToSpeech.cs
@@ -38,6 +38,8 @@ public class SeVideoTextToSpeech
     public double VibeVoiceCrispAsrSpeed { get; set; }
     public string IndexTtsCrispAsrModel { get; set; }
     public double IndexTtsCrispAsrSpeed { get; set; }
+    public string PocketTtsCrispAsrModel { get; set; }
+    public double PocketTtsCrispAsrSpeed { get; set; }
     public string DotsTtsCrispAsrModel { get; set; }
     // Flow-matching Euler steps for dots.tts (8-32, default 16). Higher is better and slower;
     // there is no CLI flag for it, so the engine passes it as CRISPASR_DOTS_ODE_STEPS.
@@ -173,6 +175,8 @@ public class SeVideoTextToSpeech
         VibeVoiceCrispAsrSpeed = 1.1;
         IndexTtsCrispAsrModel = "Q8_0 (~870 MB)";
         IndexTtsCrispAsrSpeed = 1.0;
+        PocketTtsCrispAsrModel = "English F16 (~219 MB)";
+        PocketTtsCrispAsrSpeed = 1.0;
         DotsTtsCrispAsrModel = "Q8_0 (~3.5 GB)";
         DotsTtsCrispAsrOdeSteps = 16;
         IndexTts25AudioCppModel = "Q8_0 (~3.3 GB)";

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -198,6 +198,20 @@ public static class DownloadHashManager
         public const string Codec = "IndexTtsCrispAsr.Codec";
     }
 
+    public static class PocketTtsCrispAsr
+    {
+        // SHA-256 of the per-language Pocket TTS checkpoints on cstr/pocket-tts-GGUF (HF LFS
+        // oid; the English F16 value was confirmed against a local sha256sum of the
+        // downloaded file).
+        public const string EnglishF16 = "PocketTtsCrispAsr.EnglishF16";
+        public const string EnglishQ8_0 = "PocketTtsCrispAsr.EnglishQ8_0";
+        public const string GermanQ8_0 = "PocketTtsCrispAsr.GermanQ8_0";
+        public const string SpanishQ8_0 = "PocketTtsCrispAsr.SpanishQ8_0";
+        public const string ItalianQ8_0 = "PocketTtsCrispAsr.ItalianQ8_0";
+        public const string PortugueseQ8_0 = "PocketTtsCrispAsr.PortugueseQ8_0";
+        public const string FrenchQ8_0 = "PocketTtsCrispAsr.FrenchQ8_0";
+    }
+
     public static class DotsTtsCrispAsr
     {
         // SHA-256 of the dots.tts SOAR GGUFs on cstr/dots-tts-soar-GGUF (HF LFS oid; the
@@ -1789,6 +1803,34 @@ public static class DownloadHashManager
             [IndexTtsCrispAsr.Codec] = new[]
             {
                 "fcba9a322d80ef318da8a17c01e8a5e7f299ccdf881c62a43abf62cb3c104268", // indextts-bigvgan.gguf
+            },
+            [PocketTtsCrispAsr.EnglishF16] = new[]
+            {
+                "66d16cef2b59e51003be1a025a8df2fea5f878dcf9434ca72aab5f13a48a2603", // pocket-tts-english-f16.gguf
+            },
+            [PocketTtsCrispAsr.EnglishQ8_0] = new[]
+            {
+                "fc80ece425f647b93174860ef279b877e5ad3454bbba3ec4fc76f535942c12c4", // pocket-tts-english-q8_0.gguf
+            },
+            [PocketTtsCrispAsr.GermanQ8_0] = new[]
+            {
+                "dfd58f89a443991b2ee538a9e0595a1c41728907a0b086441b0bff99ba7b28c1", // pocket-tts-german-q8_0.gguf
+            },
+            [PocketTtsCrispAsr.SpanishQ8_0] = new[]
+            {
+                "9f53d588fc8564f8aa0de2b8f17493a56b834202bf200744b87d3e0cd8c0dd66", // pocket-tts-spanish-q8_0.gguf
+            },
+            [PocketTtsCrispAsr.ItalianQ8_0] = new[]
+            {
+                "73c36a7e00779fb45b92ab90f613ffe040ee418408990958e69103e6a5820b98", // pocket-tts-italian-q8_0.gguf
+            },
+            [PocketTtsCrispAsr.PortugueseQ8_0] = new[]
+            {
+                "02f28b603e1e3b2a9c6bf51c93688b151203f387f50f09e89fb02329ab787e81", // pocket-tts-portuguese-q8_0.gguf
+            },
+            [PocketTtsCrispAsr.FrenchQ8_0] = new[]
+            {
+                "9fe5ca8c8797c03b83ce081124037cfa9970fc5db92972b57def6ef5f3a31cff", // pocket-tts-french_24l-q8_0.gguf
             },
 
             // dots.tts SOAR weights, from cstr/dots-tts-soar-GGUF.

--- a/src/ui/Logic/Download/PocketTtsCrispAsrDownloadService.cs
+++ b/src/ui/Logic/Download/PocketTtsCrispAsrDownloadService.cs
@@ -1,0 +1,175 @@
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Nikse.SubtitleEdit.UiLogic;
+
+namespace Nikse.SubtitleEdit.Logic.Download;
+
+public interface IPocketTtsCrispAsrDownloadService
+{
+    Task DownloadModels(string modelsFolder, string modelKey, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Downloads the Pocket TTS (CrispASR) checkpoint for the user-picked language into SE's
+/// CrispASR/models folder so the user gets a progress dialog instead of crispasr's silent
+/// --auto-download on first synth. One GGUF per language, no companion. Same shape as
+/// <see cref="IndexTtsCrispAsrDownloadService"/>: ModelUrls maps every filename to its HF
+/// URL so the .part / size-check / hash-verify path doesn't care which language was picked.
+/// Note the GGUF mirror (cstr/pocket-tts-GGUF) is public and ungated — the gated repo is
+/// Kyutai's own upstream, which SE never fetches from.
+/// </summary>
+public class PocketTtsCrispAsrDownloadService : IPocketTtsCrispAsrDownloadService
+{
+    private readonly HttpClient _httpClient;
+
+    private static readonly Dictionary<string, string> ModelUrls = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [PocketTtsCrispAsr.EnglishF16FileName] =
+            "https://huggingface.co/cstr/pocket-tts-GGUF/resolve/main/pocket-tts-english-f16.gguf",
+        [PocketTtsCrispAsr.EnglishQ8_0FileName] =
+            "https://huggingface.co/cstr/pocket-tts-GGUF/resolve/main/pocket-tts-english-q8_0.gguf",
+        [PocketTtsCrispAsr.GermanQ8_0FileName] =
+            "https://huggingface.co/cstr/pocket-tts-GGUF/resolve/main/pocket-tts-german-q8_0.gguf",
+        [PocketTtsCrispAsr.SpanishQ8_0FileName] =
+            "https://huggingface.co/cstr/pocket-tts-GGUF/resolve/main/pocket-tts-spanish-q8_0.gguf",
+        [PocketTtsCrispAsr.ItalianQ8_0FileName] =
+            "https://huggingface.co/cstr/pocket-tts-GGUF/resolve/main/pocket-tts-italian-q8_0.gguf",
+        [PocketTtsCrispAsr.PortugueseQ8_0FileName] =
+            "https://huggingface.co/cstr/pocket-tts-GGUF/resolve/main/pocket-tts-portuguese-q8_0.gguf",
+        [PocketTtsCrispAsr.FrenchQ8_0FileName] =
+            "https://huggingface.co/cstr/pocket-tts-GGUF/resolve/main/pocket-tts-french_24l-q8_0.gguf",
+    };
+
+    public PocketTtsCrispAsrDownloadService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task DownloadModels(string modelsFolder, string modelKey, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken)
+    {
+        var modelFileName = PocketTtsCrispAsr.GetModelFileName(modelKey);
+        var modelPath = PocketTtsCrispAsr.GetModelPath(modelKey);
+
+        // Cache seeding does a synchronous File.Copy of up to ~365 MB; the caller passes us
+        // the resulting Task without awaiting (DownloadTtsViewModel polls it from a timer),
+        // so anything before the first real await runs on the caller's thread (the UI
+        // thread when invoked from the download dialog's init callback). Push the seeding
+        // and size-check work onto the threadpool so the dialog stays responsive.
+        await Task.Run(() =>
+        {
+            PocketTtsCrispAsr.TrySeedModelFromCrispAsrCache(modelFileName, modelPath);
+            EnsureRemovedIfInvalid(modelPath, modelFileName);
+        }, cancellationToken);
+
+        if (PocketTtsCrispAsr.IsValidLocalModelFile(modelPath, modelFileName))
+        {
+            return;
+        }
+
+        titleProgress?.Invoke($"Downloading Pocket TTS (CrispASR) model: {modelFileName}");
+        await DownloadAndVerify(modelPath, modelFileName, progress, cancellationToken);
+    }
+
+    private async Task DownloadAndVerify(string finalPath, string fileName, IProgress<float>? progress, CancellationToken cancellationToken)
+    {
+        var partPath = finalPath + ".part";
+        try
+        {
+            await DownloadHelper.DownloadFileAsync(_httpClient, GetUrl(fileName), partPath, progress, cancellationToken);
+            await VerifyFile(partPath, GetHashKey(fileName), fileName, cancellationToken);
+            File.Move(partPath, finalPath);
+        }
+        catch
+        {
+            TryDelete(partPath);
+            throw;
+        }
+    }
+
+    private static string? GetHashKey(string fileName)
+    {
+        if (string.Equals(fileName, PocketTtsCrispAsr.EnglishF16FileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.PocketTtsCrispAsr.EnglishF16;
+        }
+        if (string.Equals(fileName, PocketTtsCrispAsr.EnglishQ8_0FileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.PocketTtsCrispAsr.EnglishQ8_0;
+        }
+        if (string.Equals(fileName, PocketTtsCrispAsr.GermanQ8_0FileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.PocketTtsCrispAsr.GermanQ8_0;
+        }
+        if (string.Equals(fileName, PocketTtsCrispAsr.SpanishQ8_0FileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.PocketTtsCrispAsr.SpanishQ8_0;
+        }
+        if (string.Equals(fileName, PocketTtsCrispAsr.ItalianQ8_0FileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.PocketTtsCrispAsr.ItalianQ8_0;
+        }
+        if (string.Equals(fileName, PocketTtsCrispAsr.PortugueseQ8_0FileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.PocketTtsCrispAsr.PortugueseQ8_0;
+        }
+        if (string.Equals(fileName, PocketTtsCrispAsr.FrenchQ8_0FileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.PocketTtsCrispAsr.FrenchQ8_0;
+        }
+        return null;
+    }
+
+    private static async Task VerifyFile(string filePath, string? key, string fileName, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(key))
+        {
+            return;
+        }
+
+        var expected = DownloadHashManager.GetLatestKnownHash(key);
+        if (string.IsNullOrEmpty(expected))
+        {
+            return;
+        }
+
+        string actual;
+        await using (var stream = File.OpenRead(filePath))
+        {
+            actual = await Sha256Util.ComputeSha256Async(stream, cancellationToken);
+        }
+
+        if (!string.Equals(expected, actual, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new IOException(
+                $"Pocket TTS (CrispASR) model {fileName} failed integrity check (expected SHA-256 {expected}, got {actual}).");
+        }
+    }
+
+    private static string GetUrl(string fileName)
+    {
+        if (!ModelUrls.TryGetValue(fileName, out var url))
+        {
+            throw new ArgumentException($"Unknown Pocket TTS (CrispASR) model: {fileName}", nameof(fileName));
+        }
+        return url;
+    }
+
+    private static void TryDelete(string path)
+    {
+        try { File.Delete(path); } catch { /* best-effort cleanup */ }
+    }
+
+    private static void EnsureRemovedIfInvalid(string path, string fileName)
+    {
+        if (!File.Exists(path) || PocketTtsCrispAsr.IsValidLocalModelFile(path, fileName))
+        {
+            return;
+        }
+        TryDelete(path);
+    }
+}


### PR DESCRIPTION
Adds Kyutai's **Pocket TTS 100M** as a new CrispASR-backed TTS engine — the smallest and fastest voice-cloning option in SE.

## Why this one
Compared in a same-text / same-reference A/B against Confucius4-TTS (the other new CrispASR backend): Pocket won by ear, transcribed word-perfect through Whisper, and is ~10x smaller. Confucius4 came out clearly robotic and needs ~2 GB of models, so it was skipped.

## What the engine offers
- **6 languages, one checkpoint each**: English (F16 219 MB / Q8_0 124 MB), German, Spanish, Italian, Portuguese (Q8_0 124 MB each), French 24L preview (Q8_0 365 MB). Picking a model picks the language.
- **Voice cloning with no transcript** — the Mimi encoder conditions from audio alone, so importing a reference is a plain WAV pick (resampled to 24 kHz via ffmpeg).
- **Per-line voice cloning** (`IPerLineCloneEngine`): the backend resolves the request's bare voice stem against `--voice-dir` and caches latents per reference (upstream issue #255), so voice changes need **no server restart** — only a model change does.
- **Fast**: RTF ~0.1-0.24 measured on an M4 CPU.

## Integration notes
- Follows the IndexTTS (CrispASR) template for the model/server halves and the Qwen3 (CrispASR) template for the per-request stem + per-line clone halves; standard 15-file engine checklist.
- Models hash-pinned from the ungated `cstr/pocket-tts-GGUF` mirror. License (CC-BY-4.0 + Kyutai gated-use conditions) is linked from the settings dialog; `--accept-license pocket-tts-terms` is passed only on the `--auto-download` fallback path, since crispasr's own registry gates its managed download.
- Minimum CrispASR is **v0.8.31** (the per-language backends shipped there); the runtime pin is already at v0.8.31 on main.

## Verification
- Live against the v0.8.31 macOS server, with the exact arguments and JSON payload the engine constructs: English + German synthesis, per-request stem cloning and switching (`voice='bob'` → `voice='alice'`, latents cached), attestation-gated spoken-disclaimer opt-out, and the marking opt-out flags.
- SHA-256s for English F16 and German Q8_0 confirmed against real downloads (match the HF LFS oids used for the other five).
- `dotnet build` clean; all 4466 UI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)