### PR TITLE
Carry GSI metadata and the teletext page/language through EBU-TT

### DIFF
--- a/src/libse/SubtitleFormats/DvbTeletext.cs
+++ b/src/libse/SubtitleFormats/DvbTeletext.cs
@@ -98,6 +98,16 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 pageNumber = headerPage;
                 languageCode = headerLanguage;
             }
+            else if (EbuTt.TryGetTeletextPageAndLanguage(subtitle.Header, out var ebuTtPage, out var ebuTtLanguage))
+            {
+                // An EBU-TT document written from a .dvbttx source carries the page and language
+                // in its metadata - the trip through EBU-TT must not reset them to the defaults.
+                pageNumber = ebuTtPage;
+                if (!string.IsNullOrEmpty(ebuTtLanguage))
+                {
+                    languageCode = ebuTtLanguage;
+                }
+            }
 
             var writer = new ManzanitaTeletextWriter
             {

--- a/src/libse/SubtitleFormats/Ebu.cs
+++ b/src/libse/SubtitleFormats/Ebu.cs
@@ -940,6 +940,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 {
                     header.DisplayStandardCode = "1";
                 }
+
+                // An EBU-TT source carries the GSI metadata (titles, translator, publisher, ...)
+                // in its document metadata - a no-op for any other header.
+                EbuTt.ApplyDocumentMetadata(header, subtitle.Header);
             }
 
             if (EbuUiHelper == null)

--- a/src/libse/SubtitleFormats/EbuTt.cs
+++ b/src/libse/SubtitleFormats/EbuTt.cs
@@ -29,6 +29,12 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         private const string TtmlNamespace = "http://www.w3.org/ns/ttml";
         private const string TtmlStylingNamespace = "http://www.w3.org/ns/ttml#styling";
+        private const string EbuttmNamespace = "urn:ebu:tt:metadata";
+
+        // Carries what EBU-TT has no element for - the DVB teletext page and language of a
+        // .dvbttx source. A foreign namespace inside tt:metadata is valid TTML; other tools
+        // ignore it.
+        private const string SeMetadataNamespace = "urn:subtitleedit:metadata";
 
         // The teletext cell grid of EBU Tech 3360 - 40 columns, 24 rows (row 0 is the header row,
         // subtitles use rows 1-23 like the VerticalPosition byte of an STL TTI block).
@@ -129,6 +135,14 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
             var namespaceManager = new XmlNamespaceManager(xml.NameTable);
             namespaceManager.AddNamespace("ttml", TtmlNamespace);
+            namespaceManager.AddNamespace("ebuttm", EbuttmNamespace);
+
+            // GSI titles, translator, publisher etc. of an STL source (or the metadata of an
+            // EBU-TT source, or the page/language of a .dvbttx source) travel in the document
+            // metadata.
+            var metadataNode = xml.DocumentElement.SelectSingleNode("ttml:head/ttml:metadata", namespaceManager);
+            var documentMetadataNode = metadataNode.SelectSingleNode("ebuttm:documentMetadata", namespaceManager);
+            DocumentMetadata.FromHeader(subtitle.Header).WriteTo(xml, metadataNode, documentMetadataNode);
 
             var styling = xml.DocumentElement.SelectSingleNode("ttml:head/ttml:styling", namespaceManager);
             var layout = xml.DocumentElement.SelectSingleNode("ttml:head/ttml:layout", namespaceManager);
@@ -154,6 +168,303 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
 
             return ToUtf8XmlString(xml).Replace(" xmlns=\"\"", string.Empty);
+        }
+
+        /// <summary>
+        /// The document level metadata that travels with the subtitle - the GSI block fields of
+        /// an STL mapped to their ebuttm:documentMetadata elements (Tech 3350 models them on the
+        /// GSI block), plus the DVB teletext page/language of a .dvbttx source.
+        /// </summary>
+        private sealed class DocumentMetadata
+        {
+            public string OriginalProgrammeTitle;
+            public string OriginalEpisodeTitle;
+            public string TranslatedProgrammeTitle;
+            public string TranslatedEpisodeTitle;
+            public string TranslatorsName;
+            public string TranslatorsContactDetails;
+            public string SubtitleListReferenceCode;
+            public string CreationDate;      // ISO yyyy-MM-dd (xs:date)
+            public string RevisionDate;      // ISO yyyy-MM-dd (xs:date)
+            public string RevisionNumber;    // integer as string
+            public string StartOfProgramme;  // SMPTE HH:MM:SS:FF
+            public string CountryOfOrigin;
+            public string Publisher;
+            public string EditorsName;
+            public string EditorsContactDetails;
+            public int? TeletextPage;
+            public string TeletextLanguage;
+
+            public static DocumentMetadata FromHeader(string header)
+            {
+                if (Ebu.IsStlHeader(header))
+                {
+                    return FromStlHeader(header);
+                }
+
+                if (IsEbuTtHeader(header))
+                {
+                    return FromEbuTtDocument(header);
+                }
+
+                var metadata = new DocumentMetadata();
+                if (DvbTeletext.TryParseHeader(header, out var page, out var language))
+                {
+                    metadata.TeletextPage = page;
+                    metadata.TeletextLanguage = language;
+                }
+
+                return metadata;
+            }
+
+            private static DocumentMetadata FromStlHeader(string header)
+            {
+                var metadata = new DocumentMetadata();
+                try
+                {
+                    var gsi = Ebu.ReadHeader(Ebu.GetEncoding(header.Substring(0, 3)).GetBytes(header));
+                    metadata.OriginalProgrammeTitle = Clean(gsi.OriginalProgrammeTitle);
+                    metadata.OriginalEpisodeTitle = Clean(gsi.OriginalEpisodeTitle);
+                    metadata.TranslatedProgrammeTitle = Clean(gsi.TranslatedProgrammeTitle);
+                    metadata.TranslatedEpisodeTitle = Clean(gsi.TranslatedEpisodeTitle);
+                    metadata.TranslatorsName = Clean(gsi.TranslatorsName);
+                    metadata.TranslatorsContactDetails = Clean(gsi.TranslatorsContactDetails);
+                    metadata.SubtitleListReferenceCode = Clean(gsi.SubtitleListReferenceCode);
+                    metadata.CreationDate = GsiDateToIso(gsi.CreationDate);
+                    metadata.RevisionDate = GsiDateToIso(gsi.RevisionDate);
+                    if (int.TryParse((gsi.RevisionNumber ?? string.Empty).Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var revision) && revision > 0)
+                    {
+                        metadata.RevisionNumber = revision.ToString(CultureInfo.InvariantCulture);
+                    }
+
+                    metadata.StartOfProgramme = GsiTimeCodeToSmpte(gsi.TimeCodeStartOfProgramme);
+                    metadata.CountryOfOrigin = Clean(gsi.CountryOfOrigin);
+                    metadata.Publisher = Clean(gsi.Publisher);
+                    metadata.EditorsName = Clean(gsi.EditorsName);
+                    metadata.EditorsContactDetails = Clean(gsi.EditorsContactDetails);
+                }
+                catch
+                {
+                    // an unreadable GSI block only costs the metadata, never the save
+                }
+
+                return metadata;
+            }
+
+            public static DocumentMetadata FromEbuTtDocument(string header)
+            {
+                var metadata = new DocumentMetadata();
+                try
+                {
+                    var xml = new XmlDocument { XmlResolver = null };
+                    xml.LoadXml(header);
+
+                    foreach (XmlNode node in xml.GetElementsByTagName("documentMetadata", EbuttmNamespace))
+                    {
+                        foreach (XmlNode child in node.ChildNodes)
+                        {
+                            var value = child.InnerText?.Trim();
+                            if (string.IsNullOrEmpty(value))
+                            {
+                                continue;
+                            }
+
+                            switch (child.LocalName)
+                            {
+                                case "documentOriginalProgrammeTitle": metadata.OriginalProgrammeTitle = value; break;
+                                case "documentOriginalEpisodeTitle": metadata.OriginalEpisodeTitle = value; break;
+                                case "documentTranslatedProgrammeTitle": metadata.TranslatedProgrammeTitle = value; break;
+                                case "documentTranslatedEpisodeTitle": metadata.TranslatedEpisodeTitle = value; break;
+                                case "documentTranslatorsName": metadata.TranslatorsName = value; break;
+                                case "documentTranslatorsContactDetails": metadata.TranslatorsContactDetails = value; break;
+                                case "documentSubtitleListReferenceCode": metadata.SubtitleListReferenceCode = value; break;
+                                case "documentCreationDate": metadata.CreationDate = value; break;
+                                case "documentRevisionDate": metadata.RevisionDate = value; break;
+                                case "documentRevisionNumber": metadata.RevisionNumber = value; break;
+                                case "documentStartOfProgramme": metadata.StartOfProgramme = value; break;
+                                case "documentCountryOfOrigin": metadata.CountryOfOrigin = value; break;
+                                case "documentPublisher": metadata.Publisher = value; break;
+                                case "documentEditorsName": metadata.EditorsName = value; break;
+                                case "documentEditorsContactDetails": metadata.EditorsContactDetails = value; break;
+                            }
+                        }
+                    }
+
+                    foreach (XmlNode node in xml.GetElementsByTagName("teletext", SeMetadataNamespace))
+                    {
+                        if (int.TryParse(node.Attributes?["page"]?.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var page) &&
+                            page >= 100 && page <= 899)
+                        {
+                            metadata.TeletextPage = page;
+                            metadata.TeletextLanguage = node.Attributes?["language"]?.Value;
+                        }
+                    }
+                }
+                catch
+                {
+                    // a damaged source document only costs the metadata
+                }
+
+                return metadata;
+            }
+
+            /// <summary>
+            /// Appends the elements to ebuttm:documentMetadata in the schema order of Tech 3350,
+            /// and the teletext page/language as a namespaced sibling of documentMetadata.
+            /// </summary>
+            public void WriteTo(XmlDocument xml, XmlNode metadataNode, XmlNode documentMetadataNode)
+            {
+                void Append(string name, string value)
+                {
+                    if (string.IsNullOrEmpty(value))
+                    {
+                        return;
+                    }
+
+                    var element = xml.CreateElement("ebuttm", name, EbuttmNamespace);
+                    element.InnerText = value;
+                    documentMetadataNode.AppendChild(element);
+                }
+
+                Append("documentOriginatingSystem", "Subtitle Edit");
+                Append("documentOriginalProgrammeTitle", OriginalProgrammeTitle);
+                Append("documentOriginalEpisodeTitle", OriginalEpisodeTitle);
+                Append("documentTranslatedProgrammeTitle", TranslatedProgrammeTitle);
+                Append("documentTranslatedEpisodeTitle", TranslatedEpisodeTitle);
+                Append("documentTranslatorsName", TranslatorsName);
+                Append("documentTranslatorsContactDetails", TranslatorsContactDetails);
+                Append("documentSubtitleListReferenceCode", SubtitleListReferenceCode);
+                Append("documentCreationDate", CreationDate);
+                Append("documentRevisionDate", RevisionDate);
+                Append("documentRevisionNumber", RevisionNumber);
+                Append("documentStartOfProgramme", StartOfProgramme);
+                Append("documentCountryOfOrigin", CountryOfOrigin);
+                Append("documentPublisher", Publisher);
+                Append("documentEditorsName", EditorsName);
+                Append("documentEditorsContactDetails", EditorsContactDetails);
+
+                if (TeletextPage.HasValue)
+                {
+                    var teletext = xml.CreateElement("sem", "teletext", SeMetadataNamespace);
+                    var pageAttribute = xml.CreateAttribute("page");
+                    pageAttribute.InnerText = TeletextPage.Value.ToString(CultureInfo.InvariantCulture);
+                    teletext.Attributes.Append(pageAttribute);
+                    if (!string.IsNullOrEmpty(TeletextLanguage))
+                    {
+                        var languageAttribute = xml.CreateAttribute("language");
+                        languageAttribute.InnerText = TeletextLanguage;
+                        teletext.Attributes.Append(languageAttribute);
+                    }
+
+                    metadataNode.AppendChild(teletext);
+                }
+            }
+
+            private static string Clean(string value)
+            {
+                value = value?.Trim();
+                return string.IsNullOrEmpty(value) ? null : value;
+            }
+
+            /// <summary>
+            /// A GSI YYMMDD date as the ISO date xs:date wants - STL predates 2000, so 70-99 read
+            /// as 19xx.
+            /// </summary>
+            private static string GsiDateToIso(string gsiDate)
+            {
+                gsiDate = gsiDate?.Trim();
+                if (gsiDate == null || gsiDate.Length != 6 ||
+                    !int.TryParse(gsiDate.Substring(0, 2), NumberStyles.Integer, CultureInfo.InvariantCulture, out var year) ||
+                    !int.TryParse(gsiDate.Substring(2, 2), NumberStyles.Integer, CultureInfo.InvariantCulture, out var month) ||
+                    !int.TryParse(gsiDate.Substring(4, 2), NumberStyles.Integer, CultureInfo.InvariantCulture, out var day) ||
+                    month < 1 || month > 12 || day < 1 || day > 31)
+                {
+                    return null;
+                }
+
+                year += year >= 70 ? 1900 : 2000;
+                return $"{year:0000}-{month:00}-{day:00}";
+            }
+
+            private static string GsiTimeCodeToSmpte(string timeCode)
+            {
+                timeCode = timeCode?.Trim();
+                if (timeCode == null || timeCode.Length != 8 || !long.TryParse(timeCode, NumberStyles.Integer, CultureInfo.InvariantCulture, out var numeric) || numeric == 0)
+                {
+                    return null;
+                }
+
+                return $"{timeCode.Substring(0, 2)}:{timeCode.Substring(2, 2)}:{timeCode.Substring(4, 2)}:{timeCode.Substring(6, 2)}";
+            }
+        }
+
+        /// <summary>
+        /// The DVB teletext page and language a document carries when it came from a .dvbttx
+        /// dump - stored by <see cref="ToText"/> so the trip back to DVB teletext keeps them.
+        /// </summary>
+        public static bool TryGetTeletextPageAndLanguage(string header, out int pageNumber, out string languageCode)
+        {
+            pageNumber = 0;
+            languageCode = string.Empty;
+            if (!IsEbuTtHeader(header))
+            {
+                return false;
+            }
+
+            var metadata = DocumentMetadata.FromEbuTtDocument(header);
+            if (!metadata.TeletextPage.HasValue)
+            {
+                return false;
+            }
+
+            pageNumber = metadata.TeletextPage.Value;
+            languageCode = metadata.TeletextLanguage ?? string.Empty;
+            return true;
+        }
+
+        /// <summary>
+        /// Fills the GSI block fields of an invented STL header from the document metadata of an
+        /// EBU-TT source, so titles, translator, publisher etc. survive the trip back to STL.
+        /// The GSI block is fixed width - every value is padded/truncated to its field.
+        /// </summary>
+        public static void ApplyDocumentMetadata(Ebu.EbuGeneralSubtitleInformation stlHeader, string ebuTtHeader)
+        {
+            if (stlHeader == null || !IsEbuTtHeader(ebuTtHeader))
+            {
+                return;
+            }
+
+            var metadata = DocumentMetadata.FromEbuTtDocument(ebuTtHeader);
+
+            string Fixed(string value, string current, int width)
+            {
+                return value == null ? current : value.PadRight(width).Substring(0, width);
+            }
+
+            stlHeader.OriginalProgrammeTitle = Fixed(metadata.OriginalProgrammeTitle, stlHeader.OriginalProgrammeTitle, 32);
+            stlHeader.OriginalEpisodeTitle = Fixed(metadata.OriginalEpisodeTitle, stlHeader.OriginalEpisodeTitle, 32);
+            stlHeader.TranslatedProgrammeTitle = Fixed(metadata.TranslatedProgrammeTitle, stlHeader.TranslatedProgrammeTitle, 32);
+            stlHeader.TranslatedEpisodeTitle = Fixed(metadata.TranslatedEpisodeTitle, stlHeader.TranslatedEpisodeTitle, 32);
+            stlHeader.TranslatorsName = Fixed(metadata.TranslatorsName, stlHeader.TranslatorsName, 32);
+            stlHeader.TranslatorsContactDetails = Fixed(metadata.TranslatorsContactDetails, stlHeader.TranslatorsContactDetails, 32);
+            stlHeader.SubtitleListReferenceCode = Fixed(metadata.SubtitleListReferenceCode, stlHeader.SubtitleListReferenceCode, 16);
+            stlHeader.CountryOfOrigin = Fixed(metadata.CountryOfOrigin, stlHeader.CountryOfOrigin, 3);
+            stlHeader.Publisher = Fixed(metadata.Publisher, stlHeader.Publisher, 32);
+            stlHeader.EditorsName = Fixed(metadata.EditorsName, stlHeader.EditorsName, 32);
+            stlHeader.EditorsContactDetails = Fixed(metadata.EditorsContactDetails, stlHeader.EditorsContactDetails, 32);
+
+            if (int.TryParse(metadata.RevisionNumber, NumberStyles.Integer, CultureInfo.InvariantCulture, out var revision) &&
+                revision >= 0 && revision <= 99)
+            {
+                stlHeader.RevisionNumber = revision.ToString("00", CultureInfo.InvariantCulture);
+            }
+
+            var startOfProgramme = metadata.StartOfProgramme?.Replace(":", string.Empty);
+            if (startOfProgramme != null && startOfProgramme.Length == 8 &&
+                long.TryParse(startOfProgramme, NumberStyles.Integer, CultureInfo.InvariantCulture, out _))
+            {
+                stlHeader.TimeCodeStartOfProgramme = startOfProgramme;
+            }
         }
 
         /// <summary>

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -4811,6 +4811,15 @@ public partial class MainViewModel :
             currentPage = headerPage;
             currentLanguage = headerLanguage;
         }
+        else if (EbuTt.TryGetTeletextPageAndLanguage(_subtitle.Header, out var ebuTtPage, out var ebuTtLanguage))
+        {
+            // An EBU-TT document from a .dvbttx source carries the page and language in its metadata.
+            currentPage = ebuTtPage;
+            if (!string.IsNullOrEmpty(ebuTtLanguage))
+            {
+                currentLanguage = ebuTtLanguage;
+            }
+        }
 
         var result = await ShowDialogAsync<ExportDvbTeletextWindow, ExportDvbTeletextViewModel>(vm =>
             vm.Initialize(currentPage, currentLanguage));

--- a/tests/libse/SubtitleFormats/EbuTtTest.cs
+++ b/tests/libse/SubtitleFormats/EbuTtTest.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 
@@ -5,6 +6,14 @@ namespace LibSETests.SubtitleFormats;
 
 public class EbuTtTest
 {
+    // Minimal headless stand-in for the UI's EBU save helper so the binary writer can run in a test.
+    private sealed class TestEbuUiHelper : Ebu.IEbuUiHelper
+    {
+        public byte JustificationCode { get; set; }
+        public void Initialize(Ebu.EbuGeneralSubtitleInformation header, byte justificationCode, string fileName, Subtitle subtitle) { }
+        public bool ShowDialogOk() => true;
+    }
+
     /// <summary>
     /// A minimal EBU STL GSI header marked as teletext level 1 - what a subtitle loaded from a
     /// teletext STL carries, and what makes the EBU-TT writer trust MarginV rows and the
@@ -310,6 +319,106 @@ public class EbuTtTest
         new Ebu().RemoveNativeFormatting(sub, new SubRip());
         Assert.Equal("Boxed", sub.Paragraphs[0].Text);
         Assert.Null(sub.Paragraphs[0].MarginV);
+    }
+
+    [Fact]
+    public void StlMetadataTravelsToEbuTtAndBack()
+    {
+        // A GSI header with real metadata - the same shape Ebu.LoadSubtitle stores.
+        var gsi = new Ebu.EbuGeneralSubtitleInformation
+        {
+            DisplayStandardCode = "1",
+            OriginalProgrammeTitle = "Die Sendung".PadRight(32),
+            OriginalEpisodeTitle = "Folge 7".PadRight(32),
+            TranslatedProgrammeTitle = "The Programme".PadRight(32),
+            TranslatorsName = "R. Weiss".PadRight(32),
+            SubtitleListReferenceCode = "REF0001".PadRight(16),
+            CreationDate = "260830",
+            RevisionNumber = "02",
+            TimeCodeStartOfProgramme = "10000000",
+            CountryOfOrigin = "CHE",
+            Publisher = "SRF".PadRight(32),
+        };
+
+        var sub = new Subtitle { Header = gsi.ToString() };
+        sub.Paragraphs.Add(new Paragraph("Hallo", 0, 2000));
+
+        var format = new EbuTt();
+        var raw = sub.ToText(format);
+
+        Assert.Contains("<ebuttm:documentOriginalProgrammeTitle>Die Sendung</ebuttm:documentOriginalProgrammeTitle>", raw);
+        Assert.Contains("<ebuttm:documentOriginalEpisodeTitle>Folge 7</ebuttm:documentOriginalEpisodeTitle>", raw);
+        Assert.Contains("<ebuttm:documentTranslatedProgrammeTitle>The Programme</ebuttm:documentTranslatedProgrammeTitle>", raw);
+        Assert.Contains("<ebuttm:documentTranslatorsName>R. Weiss</ebuttm:documentTranslatorsName>", raw);
+        Assert.Contains("<ebuttm:documentSubtitleListReferenceCode>REF0001</ebuttm:documentSubtitleListReferenceCode>", raw);
+        Assert.Contains("<ebuttm:documentCreationDate>2026-08-30</ebuttm:documentCreationDate>", raw);
+        Assert.Contains("<ebuttm:documentRevisionNumber>2</ebuttm:documentRevisionNumber>", raw);
+        Assert.Contains("<ebuttm:documentStartOfProgramme>10:00:00:00</ebuttm:documentStartOfProgramme>", raw);
+        Assert.Contains("<ebuttm:documentCountryOfOrigin>CHE</ebuttm:documentCountryOfOrigin>", raw);
+        Assert.Contains("<ebuttm:documentPublisher>SRF</ebuttm:documentPublisher>", raw);
+
+        // The metadata carries forward when re-saving an EBU-TT document...
+        var loaded = new Subtitle();
+        format.LoadSubtitle(loaded, raw.SplitToLines(), null);
+        var resaved = loaded.ToText(format);
+        Assert.Contains("<ebuttm:documentOriginalProgrammeTitle>Die Sendung</ebuttm:documentOriginalProgrammeTitle>", resaved);
+        Assert.Contains("<ebuttm:documentStartOfProgramme>10:00:00:00</ebuttm:documentStartOfProgramme>", resaved);
+
+        // ...and fills the GSI fields again on the way back to STL.
+        Ebu.EbuUiHelper = new TestEbuUiHelper();
+        using var ms = new MemoryStream();
+        var ok = new Ebu().Save("test.stl", ms, loaded, batchMode: true, null);
+        Assert.True(ok);
+        var writtenGsi = Ebu.ReadHeader(ms.ToArray());
+        Assert.Equal("Die Sendung", writtenGsi.OriginalProgrammeTitle.Trim());
+        Assert.Equal("Folge 7", writtenGsi.OriginalEpisodeTitle.Trim());
+        Assert.Equal("R. Weiss", writtenGsi.TranslatorsName.Trim());
+        Assert.Equal("REF0001", writtenGsi.SubtitleListReferenceCode.Trim());
+        Assert.Equal("02", writtenGsi.RevisionNumber);
+        Assert.Equal("10000000", writtenGsi.TimeCodeStartOfProgramme);
+        Assert.Equal("CHE", writtenGsi.CountryOfOrigin);
+        Assert.Equal("SRF", writtenGsi.Publisher.Trim());
+    }
+
+    [Fact]
+    public void DvbTeletextPageAndLanguageTravelThroughEbuTt()
+    {
+        var sub = new Subtitle { Header = DvbTeletext.CreateHeader(150, "ger") };
+        sub.Paragraphs.Add(new Paragraph("Hallo", 0, 2000));
+
+        var format = new EbuTt();
+        var raw = sub.ToText(format);
+
+        Assert.Contains("urn:subtitleedit:metadata", raw);
+        Assert.Contains("page=\"150\"", raw);
+        Assert.Contains("language=\"ger\"", raw);
+
+        var loaded = new Subtitle();
+        format.LoadSubtitle(loaded, raw.SplitToLines(), null);
+        Assert.True(EbuTt.TryGetTeletextPageAndLanguage(loaded.Header, out var page, out var language));
+        Assert.Equal(150, page);
+        Assert.Equal("ger", language);
+
+        // The page also survives a re-save of the EBU-TT document itself.
+        var resaved = loaded.ToText(format);
+        Assert.Contains("page=\"150\"", resaved);
+
+        // Non EBU-TT headers say no.
+        Assert.False(EbuTt.TryGetTeletextPageAndLanguage(DvbTeletext.CreateHeader(150, "ger"), out _, out _));
+        Assert.False(EbuTt.TryGetTeletextPageAndLanguage(null, out _, out _));
+    }
+
+    [Fact]
+    public void MetadataAbsentStaysAbsent()
+    {
+        var sub = new Subtitle();
+        sub.Paragraphs.Add(new Paragraph("Plain", 0, 2000));
+
+        var raw = sub.ToText(new EbuTt());
+
+        Assert.DoesNotContain("documentOriginalProgrammeTitle", raw);
+        Assert.DoesNotContain("urn:subtitleedit:metadata", raw);
+        Assert.Contains("<ebuttm:documentOriginatingSystem>Subtitle Edit</ebuttm:documentOriginatingSystem>", raw);
     }
 
     [Fact]


### PR DESCRIPTION
Follow-up to #14355 - the subtitle content travelled losslessly through EBU-TT, but the document metadata did not. Two gaps closed:

**GSI metadata ↔ ebuttm:documentMetadata** (Tech 3350 models its metadata on the GSI block; element names/order/types verified against the published EBU-TT 1.0.1 schema)
- STL → EBU-TT writes programme/episode titles, translator name+contact, subtitle list reference code, creation/revision dates (`YYMMDD` → `xs:date`, 70-99 reading as 19xx), revision number, start of programme (SMPTE), country, publisher and editor - empty GSI fields are omitted, and `documentOriginatingSystem` is stamped `Subtitle Edit`.
- The metadata carries forward when an EBU-TT document is re-saved, and `EbuTt.ApplyDocumentMetadata` fills the fixed-width GSI fields again when `Ebu.Save` invents a header for an EBU-TT source - so titles survive STL → EBU-TT → STL (padding/truncating to the exact field widths the 1024-byte block needs).

**DVB teletext page/language** - EBU-TT has no element for them, so they ride in a small foreign-namespace element inside `tt:metadata` (`<sem:teletext page="777" language="deu" xmlns:sem="urn:subtitleedit:metadata"/>` - valid TTML, ignorable by other tools). `DvbTeletext.Save` and the UI page/language dialog read it back, so a .dvbttx exchanged through EBU-TT keeps its page instead of resetting to the 888/eng defaults.

**Verified** on the mail thread's real files: René's Premiere STL metadata (title, 2026-08-26 dates, revision 1, country CH) lands in the document metadata verbatim; the ZDF dump's page 777/deu survives dvbttx → EBU-TT → dvbttx with content identical (the round-tripped .dvbttx re-parses to page 777). 7541 tests green across libse/seconv/libuilogic/UI, including 3 new tests (STL metadata there-and-back incl. GSI re-fill, dvbttx page/language travel, absent-metadata stays absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)