### PR TITLE
Fix Alt+Tab not bringing undocked windows to the foreground

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -8479,14 +8479,17 @@ public partial class MainViewModel :
     /// merely exposed the tool window under the cursor. The Avalonia press event only covers the
     /// client area and arrives after the activation, so the decision still waits a beat for it.
     ///
-    /// The one case this cannot tell apart from the OS handing over the foreground is the user
-    /// Alt+Tabbing straight back to a tool window (they are separate entries in the task
-    /// switcher): that lands in the main window instead. The tool windows stay visible on top
-    /// either way, so the cost is keyboard focus - which is where it belongs for everything but
-    /// the waveform's own shortcuts.
+    /// Alt+Tab is keyboard-aimed - no button down, cursor anywhere - so the pointer rules read
+    /// it as an OS handover and "corrected" it: the tool window flickered into the foreground
+    /// and lost it a beat later, until a real click re-claimed it (#14354). The tool windows are
+    /// separate entries in the task switcher, so this is a gesture users actually make. On
+    /// Windows the switcher announces itself (TaskSwitchDetector's WinEvent hook), and an
+    /// activation while it is open or right after it commits is treated as aimed.
     /// </summary>
     private void WatchUndockedForegroundSteal(Window undockedWindow)
     {
+        TaskSwitchDetector.EnsureStarted();
+
         undockedWindow.AddHandler(
             InputElement.PointerPressedEvent,
             (_, _) => _undockedWindowPointerPressed = true,
@@ -8502,7 +8505,8 @@ public partial class MainViewModel :
 
             if (IsUndockedActivationAimedAtToolWindow(
                     CursorPositionHelper.IsAnyPointerButtonDown(),
-                    undockedWindow.IsPointerOver))
+                    undockedWindow.IsPointerOver,
+                    TaskSwitchDetector.TaskSwitchJustCommitted()))
             {
                 _foregroundBelongsToMainWindow = false; // the user moved to the tool window
                 return;
@@ -8512,9 +8516,10 @@ public partial class MainViewModel :
 
             DispatcherTimer.RunOnce(() =>
             {
-                if (_undockedWindowPointerPressed)
+                if (_undockedWindowPointerPressed || TaskSwitchDetector.TaskSwitchJustCommitted())
                 {
-                    // A press the button sampling missed (e.g. touch) - the user aimed here.
+                    // A press the button sampling missed (e.g. touch), or a task-switch commit
+                    // whose WinEvent was still queued behind the activation - the user aimed here.
                     _foregroundBelongsToMainWindow = false;
                     return;
                 }
@@ -8545,8 +8550,16 @@ public partial class MainViewModel :
     /// </summary>
     internal static bool IsUndockedActivationAimedAtToolWindow(
         bool? pointerButtonDown,
-        bool pointerOverToolWindow)
+        bool pointerOverToolWindow,
+        bool taskSwitchJustCommitted)
     {
+        // Picking the tool window in the task switcher (Alt+Tab) is aiming by keyboard - the
+        // pointer rules below would misread it as an OS handover (#14354).
+        if (taskSwitchJustCommitted)
+        {
+            return true;
+        }
+
         // The button state is authoritative when it can be sampled: the cursor merely resting
         // over the tool window is NOT aiming - closing another application's window exposes the
         // tool window under a cursor that never moved (Windows even synthesizes the mouse-move
@@ -17591,7 +17604,16 @@ public partial class MainViewModel :
                 return;
             }
 
-            ActivateWindow(TopLevel.GetTopLevel(AudioVisualizer) as Window);
+            var window = TopLevel.GetTopLevel(AudioVisualizer) as Window;
+            if (window != null && !ReferenceEquals(window, Window))
+            {
+                // SE itself is sending the user to the undocked waveform window - no pointer
+                // button is down, so without this the foreground-steal watcher would read the
+                // activation as an OS handover and bounce it straight back (#14354).
+                _foregroundBelongsToMainWindow = false;
+            }
+
+            ActivateWindow(window);
             AudioVisualizer.Focus();
         });
     }

--- a/src/ui/Logic/TaskSwitchDetector.cs
+++ b/src/ui/Logic/TaskSwitchDetector.cs
@@ -1,0 +1,94 @@
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Runtime.InteropServices;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>
+/// Tracks the Windows task switcher (Alt+Tab) via a WinEvent hook so a window activation that
+/// the user picked in the switcher can be told apart from one the OS handed over by itself.
+///
+/// The undocked foreground-steal watcher (#14168) classifies tool-window activations by the
+/// physical pointer buttons - but Alt+Tab activates a window with no button down, so switching
+/// to an undocked tool window was "corrected" back to the main window: the tool window
+/// flickered into the foreground and lost it 200 ms later (#14354). The switcher raises
+/// EVENT_SYSTEM_SWITCHSTART when it opens and EVENT_SYSTEM_SWITCHEND when it commits the
+/// switch, right before the chosen window is activated - so "the switcher is open, or closed a
+/// moment ago" marks the activation as user-aimed.
+///
+/// Windows only; on other platforms nothing is hooked and <see cref="TaskSwitchJustCommitted"/>
+/// stays false. The hook must be installed from a thread that pumps messages (the UI thread) and
+/// lives for the process lifetime.
+/// </summary>
+public static class TaskSwitchDetector
+{
+    private const uint EventSystemSwitchStart = 0x0014;
+    private const uint EventSystemSwitchEnd = 0x0015;
+    private const uint WinEventOutOfContext = 0x0000;
+
+    private delegate void WinEventDelegate(IntPtr hWinEventHook, uint eventType, IntPtr hwnd,
+        int idObject, int idChild, uint dwEventThread, uint dwmsEventTime);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr SetWinEventHook(uint eventMin, uint eventMax,
+        IntPtr hmodWinEventProc, WinEventDelegate pfnWinEventProc, uint idProcess, uint idThread,
+        uint dwFlags);
+
+    // Keeps the delegate alive for the lifetime of the hook - the GC must not collect it while
+    // user32 still holds the callback pointer.
+    private static WinEventDelegate? _callback;
+    private static bool _initialized;
+    private static bool _switcherOpen;
+    private static long _lastSwitchEndTick;
+
+    /// <summary>
+    /// Installs the hook once. Call from the UI thread. No-op off Windows or when the hook
+    /// could not be installed (detection then just stays inert - fail-safe).
+    /// </summary>
+    public static void EnsureStarted()
+    {
+        if (_initialized || !OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        _initialized = true;
+
+        try
+        {
+            _callback = OnWinEvent;
+            SetWinEventHook(EventSystemSwitchStart, EventSystemSwitchEnd, IntPtr.Zero, _callback,
+                0, 0, WinEventOutOfContext);
+        }
+        catch (Exception exception)
+        {
+            Se.LogError(exception);
+        }
+    }
+
+    private static void OnWinEvent(IntPtr hWinEventHook, uint eventType, IntPtr hwnd,
+        int idObject, int idChild, uint dwEventThread, uint dwmsEventTime)
+    {
+        if (eventType == EventSystemSwitchStart)
+        {
+            _switcherOpen = true;
+        }
+        else if (eventType == EventSystemSwitchEnd)
+        {
+            _switcherOpen = false;
+            _lastSwitchEndTick = Environment.TickCount64;
+        }
+    }
+
+    /// <summary>
+    /// True while the task switcher is open, or within <paramref name="withinMs"/> of it
+    /// committing a switch. The activation the switcher causes arrives on the message queue
+    /// right after SWITCHEND, so a small window is plenty - it only needs to be generous enough
+    /// to survive dispatcher latency, not user-scale time.
+    /// </summary>
+    public static bool TaskSwitchJustCommitted(int withinMs = 1000)
+    {
+        return _switcherOpen ||
+               (_lastSwitchEndTick > 0 && Environment.TickCount64 - _lastSwitchEndTick <= withinMs);
+    }
+}

--- a/tests/UI/Logic/UndockedForegroundStealTests.cs
+++ b/tests/UI/Logic/UndockedForegroundStealTests.cs
@@ -60,9 +60,9 @@ public class UndockedForegroundStealTests
         // A click that activates a window (client area or title bar, including a drag by the
         // title bar) still has the button physically down while the activation is delivered.
         Assert.True(MainViewModel.IsUndockedActivationAimedAtToolWindow(
-            pointerButtonDown: true, pointerOverToolWindow: false));
+            pointerButtonDown: true, pointerOverToolWindow: false, taskSwitchJustCommitted: false));
         Assert.True(MainViewModel.IsUndockedActivationAimedAtToolWindow(
-            pointerButtonDown: true, pointerOverToolWindow: true));
+            pointerButtonDown: true, pointerOverToolWindow: true, taskSwitchJustCommitted: false));
     }
 
     [Fact]
@@ -72,17 +72,30 @@ public class UndockedForegroundStealTests
         // moved (Windows synthesizes the mouse-move that flips IsPointerOver), so hover must not
         // veto the correction when the button state says no click happened - the beta 26 failure.
         Assert.False(MainViewModel.IsUndockedActivationAimedAtToolWindow(
-            pointerButtonDown: false, pointerOverToolWindow: true));
+            pointerButtonDown: false, pointerOverToolWindow: true, taskSwitchJustCommitted: false));
         Assert.False(MainViewModel.IsUndockedActivationAimedAtToolWindow(
-            pointerButtonDown: false, pointerOverToolWindow: false));
+            pointerButtonDown: false, pointerOverToolWindow: false, taskSwitchJustCommitted: false));
     }
 
     [Fact]
     public void HoverDecides_OnlyWhereTheButtonsCannotBeSampled()
     {
         Assert.True(MainViewModel.IsUndockedActivationAimedAtToolWindow(
-            pointerButtonDown: null, pointerOverToolWindow: true));
+            pointerButtonDown: null, pointerOverToolWindow: true, taskSwitchJustCommitted: false));
         Assert.False(MainViewModel.IsUndockedActivationAimedAtToolWindow(
-            pointerButtonDown: null, pointerOverToolWindow: false));
+            pointerButtonDown: null, pointerOverToolWindow: false, taskSwitchJustCommitted: false));
+    }
+
+    [Fact]
+    public void ActivationIsAimed_WhenTheTaskSwitcherJustCommittedASwitch()
+    {
+        // Alt+Tab aims by keyboard: no button is down and the cursor can be anywhere, so the
+        // pointer rules alone read it as an OS handover and bounced the tool window straight
+        // back to the main window (#14354). The task switcher's SWITCHSTART/SWITCHEND WinEvents
+        // override the pointer verdict.
+        Assert.True(MainViewModel.IsUndockedActivationAimedAtToolWindow(
+            pointerButtonDown: false, pointerOverToolWindow: false, taskSwitchJustCommitted: true));
+        Assert.True(MainViewModel.IsUndockedActivationAimedAtToolWindow(
+            pointerButtonDown: null, pointerOverToolWindow: false, taskSwitchJustCommitted: true));
     }
 }


### PR DESCRIPTION
Fixes the Alt+Tab half of #14354.

## Problem
The undocked foreground-steal watcher (#14168) decides whether a tool-window activation was user-aimed by sampling the physical mouse buttons. Alt+Tab aims by keyboard — no button down, cursor anywhere — so switching to the undocked audio visualizer or video player was misread as "the OS handed the foreground over" and corrected: the window flickered into the foreground and was bounced back to the main window 200 ms later. A real click on the tool window cleared the claim (which is why clicking worked), and Alt+Tabbing back to the main window re-armed it — exactly the behavior described in the report.

SE's own *focus waveform* shortcuts hit the same trap: `FocusAudioVisualizer` activates the undocked window programmatically with no button down, so that activation was bounced too (the reporter's grid/waveform toggle shortcut).

## Fix
- New `TaskSwitchDetector`: a Windows WinEvent hook (`EVENT_SYSTEM_SWITCHSTART`/`SWITCHEND`, out-of-context) that tracks the task switcher. A tool-window activation while the switcher is open — or within a short window after it commits — is treated as aimed at the tool window. Off Windows nothing is hooked and the detector stays inert, so behavior there is unchanged.
- The 200 ms re-check also consults the detector, in case the SWITCHEND WinEvent is queued behind the activation.
- `FocusAudioVisualizer` clears the main window's foreground claim itself before activating the undocked window.

The pure classification rule gains a `taskSwitchJustCommitted` parameter, covered in `UndockedForegroundStealTests` (8 tests pass). The WinEvent half is unverifiable headlessly and needs a manual Windows check: undock, Alt+Tab between main/visualizer/video player — each should keep the foreground it was given.

The issue's second ask (a single-instance setting) is a separate feature and not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)