### PR TITLE
Prepare v5.2.0-beta31

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -3,6 +3,29 @@ Subtitle Edit Changelog
 
 -----------------------------------------------------------------------------------------------------
 
+v5.2.0-beta31 (1st of September 2026)
+
+* New subtitle format: Csv Excel - thx matmaggi
+* Mark lines as forced narrative, with a "Forced" column and "Save forced lines as..." - thx matmaggi
+* New subtitle format: EBU-TT (Tech 3350), carrying teletext colors, boxing, rows and the GSI metadata
+* EBU-TT-D and IMSC Rosetta: read and write font colors - thx Scryper
+* DVB teletext (.dvbttx): write Level 2.5 colors, and make it a toolbar format with alignment picker, video preview and batch convert - thx René
+* Add Pocket TTS (CrispASR) voice cloning, and offer VibeVoice again
+* CrispASR: update to v0.8.31, and offer Windows CUDA 13
+* Subtitle image previews: a configurable background color, and a Blu-ray sup overlay that scales with the video - thx Lukewarm1141
+* Advanced TTS settings: hint icons instead of a wall of text, so the window fits the screen again - thx nielka98
+* Fix audio dropouts by keeping the mpv audio device open while paused - thx GrampaWildWilly
+* Fix Alt+Tab not bringing undocked windows to the foreground - thx GrampaWildWilly
+* Fix playing selected lines in repeat mode replaying a line at the cue boundary - thx marcpbailey
+* Fix the subtitle grid jumping to the end of the list after cut + auto-break - thx St0rmXtr00per
+* Fix the Matroska track picker opening twice on macOS - thx marcpbailey
+* Update Italian translation - thx bovirus
+* Update Japanese translation - thx hisui3393
+* Update Korean translation - thx 12si27
+* Update Turkish translation - thx bilimiyorum
+
+-----------------------------------------------------------------------------------------------------
+
 v5.2.0-beta30 (31st of August 2026)
 
 * Read Wistia json, DVD Junior SPC, Sonic DVD Producer and YouTube srv3 (.ytt) subtitles

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "Subtitle Edit",
-  "version": "v5.2.0-beta30",
+  "version": "v5.2.0-beta31",
   "translatedBy": "",
   "cultureName": "en-US",
   "general": {

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -20,7 +20,7 @@ public class Se
     internal const int CurrentMacOsFontMigrationVersion = 1;
     internal const int CurrentShortcutsMigrationVersion = 2;
 
-    public static string Version { get; set; } = "v5.2.0-beta30";
+    public static string Version { get; set; } = "v5.2.0-beta31";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
Version bump + change-log section for the next beta.

- `Se.Version` and `English.json` → `v5.2.0-beta31`
- Change-log section dated 1st of September 2026

## Coverage

The 24 PRs merged since the `v5.2.0-beta30` tag were enumerated by ancestor-checking every merged PR's merge commit against the tag (not by `git log | head`), so nothing merged late on release day is missed. Collapsed lines: EBU-TT + its metadata follow-up (#14355, #14357), the two DVB teletext PRs (#14341, #14342), the two colour-styling PRs (#14337, #14356 — Rosetta and EBU-TT-D share one line), the two image-preview PRs (#14338, #14339), and the three CrispASR pin/engine PRs (#14347, #14349, #14350, plus #14351 for the new engine).

Credits come from the linked issue authors, the translation PR authors, and René for the EBU N19 colours thread. Wording is left for the maintainer to curate as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)