### PR TITLE
Fix three defects from the beta30 run

### DIFF
--- a/src/libse/ContainerFormats/TransportStream/ManzanitaTeletextWriter.cs
+++ b/src/libse/ContainerFormats/TransportStream/ManzanitaTeletextWriter.cs
@@ -472,8 +472,10 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
         }
 
         /// <summary>
-        /// Bottom aligned rows counted upwards, or the top of the screen for {\an7}-{\an9}. A
-        /// double height row occupies the row below it too, hence the gap of two.
+        /// The row of each line, counted down from the row the block starts on - MarginV when the
+        /// subtitle carries one, otherwise bottom anchored on <see cref="DefaultBottomRow"/>. Or
+        /// the top of the screen for {\an7}-{\an9}. A double height row occupies the row below it
+        /// too, hence the gap of two.
         /// </summary>
         private static List<int> GetRowNumbers(int lineCount, string marginV, bool topAligned, out bool doubleHeight)
         {
@@ -496,21 +498,52 @@ namespace Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream
                 rows.Clear();
             }
 
-            var bottom = IsTeletextRow(marginV) ? int.Parse(marginV, CultureInfo.InvariantCulture) : DefaultBottomRow;
             var spacing = 2;
-            if (bottom - (lineCount - 1) * spacing < 1)
+            var start = GetStartRow(lineCount, marginV, spacing);
+            if (start < 1)
             {
                 // Too many lines to fit at double height - fall back to single height rows.
                 spacing = 1;
                 doubleHeight = false;
+                start = GetStartRow(lineCount, marginV, spacing);
             }
+
+            // More lines than the page has rows even at single height - keep every row on the page
+            // rather than emitting one that no decoder can address.
+            start = Math.Max(1, start);
 
             for (var i = 0; i < lineCount; i++)
             {
-                rows.Add(Math.Max(1, bottom - (lineCount - 1 - i) * spacing));
+                rows.Add(Math.Min(LastRow, start + i * spacing));
             }
 
             return rows;
+        }
+
+        /// <summary>
+        /// The row the *first* line goes on. MarginV is the EBU STL vertical position: the row the
+        /// line starts on, with the rest of the block below it - the same meaning Ebu.Save,
+        /// TeletextRowHelper (the alignment picker and the TT column) and SubtitlePositionToAssa
+        /// (the video preview) all use. Reading it as the bottom row instead put every multi-line
+        /// subtitle two rows too high and one row out of step with the preview.
+        /// Without a MarginV the block is bottom anchored so its last row lands on
+        /// <see cref="DefaultBottomRow"/>.
+        /// </summary>
+        private static int GetStartRow(int lineCount, string marginV, int spacing)
+        {
+            var start = IsTeletextRow(marginV)
+                ? int.Parse(marginV, CultureInfo.InvariantCulture)
+                : DefaultBottomRow - (lineCount - 1) * spacing;
+
+            // The text may have been re-wrapped since the row was set, so a start row that no
+            // longer leaves room for every line would push the tail off the page - the same clamp
+            // Ebu.Save applies to the STL vertical position.
+            if (start + (lineCount - 1) * spacing > LastRow)
+            {
+                start = LastRow - (lineCount - 1) * spacing;
+            }
+
+            return start;
         }
 
         private static bool IsTeletextRow(string marginV)

--- a/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/DownloadSpeechToTextEngineViewModel.cs
@@ -55,7 +55,7 @@ public partial class DownloadSpeechToTextEngineViewModel : ObservableObject, ICl
     public ISpeechToTextEngine? Engine { get; internal set; }
 
     /// <summary>
-    /// CrispASR download variant. On Windows: "cpu", "cpu-legacy", "vulkan", or "cuda" (defaults to "vulkan").
+    /// CrispASR download variant. On Windows: "cpu", "cpu-legacy", "vulkan", "cuda" or "cuda13" (defaults to "vulkan").
     /// On Linux x86_64: "cuda", "cuda13", "vulkan", "hip", or null/empty for the default CPU build.
     /// Ignored on macOS / Linux ARM64.
     /// </summary>

--- a/src/ui/Features/Video/SpeechToText/EngineSettings/SpeechToTextEngineSettingsViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/EngineSettings/SpeechToTextEngineSettingsViewModel.cs
@@ -202,6 +202,7 @@ public partial class SpeechToTextEngineSettingsViewModel : ObservableObject
             return winVariant switch
             {
                 "cuda" => "Windows x64 (CUDA)",
+                "cuda13" => "Windows x64 (CUDA 13)",
                 "vulkan" => "Windows x64 (Vulkan)",
                 "cpu-legacy" => "Windows x64 (CPU, legacy)",
                 "cpu" => "Windows x64 (CPU)",

--- a/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
@@ -399,6 +399,20 @@ public static class TtsVoiceInstaller
                 _ => "vulkan",
             };
 
+            if (crispVariant == "cuda")
+            {
+                // Upstream added a Windows CUDA 13 build alongside the CUDA 12 one in v0.8.31, so
+                // Windows gets the same follow-up Linux has (#14343) - without it a fresh install
+                // from here can only ever land on CUDA 12.
+                var cudaAnswer = await PromptCrispAsrCudaVersionAsync(window);
+                if (cudaAnswer == null)
+                {
+                    return false;
+                }
+
+                crispVariant = cudaAnswer;
+            }
+
             if (crispVariant == "cpu")
             {
                 var cpuAnswer = await PromptCrispAsrCpuFlavorAsync(window);
@@ -518,21 +532,7 @@ public static class TtsVoiceInstaller
 
         if (answer == MessageBoxResult.Custom3)
         {
-            var cudaAnswer = await MessageBox.Show(
-                window,
-                "CrispASR CUDA build",
-                $"{Environment.NewLine}CUDA 12 works with most current NVIDIA drivers.{Environment.NewLine}{Environment.NewLine}Pick CUDA 13 only if your driver stack is built for CUDA 13.",
-                MessageBoxButtons.Cancel,
-                MessageBoxIcon.Question,
-                "CUDA 12",
-                "CUDA 13");
-
-            return cudaAnswer switch
-            {
-                MessageBoxResult.Custom1 => "cuda",
-                MessageBoxResult.Custom2 => "cuda13",
-                _ => null,
-            };
+            return await PromptCrispAsrCudaVersionAsync(window);
         }
 
         return answer switch
@@ -540,6 +540,30 @@ public static class TtsVoiceInstaller
             MessageBoxResult.Custom1 => string.Empty,
             MessageBoxResult.Custom2 => "vulkan",
             MessageBoxResult.Custom4 => "hip",
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    /// Follow-up prompt after the user picks "CUDA" in the CrispASR variant selector, on both
+    /// Windows and Linux - upstream ships a CUDA 12 and a CUDA 13 build for each.
+    /// Returns "cuda" (CUDA 12 build) or "cuda13", or null when the user cancels.
+    /// </summary>
+    private static async Task<string?> PromptCrispAsrCudaVersionAsync(Window window)
+    {
+        var cudaAnswer = await MessageBox.Show(
+            window,
+            "CrispASR CUDA build",
+            $"{Environment.NewLine}CUDA 12 works with most current NVIDIA drivers.{Environment.NewLine}{Environment.NewLine}Pick CUDA 13 only if your driver stack is built for CUDA 13.",
+            MessageBoxButtons.Cancel,
+            MessageBoxIcon.Question,
+            "CUDA 12",
+            "CUDA 13");
+
+        return cudaAnswer switch
+        {
+            MessageBoxResult.Custom1 => "cuda",
+            MessageBoxResult.Custom2 => "cuda13",
             _ => null,
         };
     }

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -2428,7 +2428,7 @@ public static class DownloadHashManager
 
     /// <summary>
     /// Reverse of <see cref="ResolveCrispAsrKey"/> — returns the variant string matching the
-    /// given hash key. For Windows: "cuda" / "vulkan" / "cpu" / "cpu-legacy". For Linux x86_64:
+    /// given hash key. For Windows: "cuda" / "cuda13" / "vulkan" / "cpu" / "cpu-legacy". For Linux x86_64:
     /// "cuda" / "cuda13" / "vulkan" / "hip" for the GPU builds, empty string for the default CPU
     /// build. Returns null otherwise.
     /// </summary>
@@ -2652,9 +2652,10 @@ public static class DownloadHashManager
 
     /// <summary>
     /// Detects which Windows CrispASR variant is installed.
-    /// Returns "cuda" / "vulkan" / "cpu" / "cpu-legacy", or null if the folder doesn't look like a
-    /// CrispASR install. CUDA and Vulkan are identified by their backend DLLs; CPU vs CPU-legacy
-    /// is decided by sidecar or executable-hash match (CPU-legacy is the AVX2-less fallback).
+    /// Returns "cuda" / "cuda13" / "vulkan" / "cpu" / "cpu-legacy", or null if the folder doesn't
+    /// look like a CrispASR install. CUDA and Vulkan are identified by their backend DLLs; the
+    /// CUDA major version and CPU vs CPU-legacy are decided by sidecar or executable-hash match
+    /// (CPU-legacy is the AVX2-less fallback).
     /// </summary>
     public static string? DetectCrispAsrWindowsVariant(string installFolder)
     {
@@ -2665,7 +2666,26 @@ public static class DownloadHashManager
 
         if (File.Exists(Path.Combine(installFolder, "ggml-cuda.dll")))
         {
-            return "cuda";
+            // Upstream added a CUDA 13 build beside the CUDA 12 one in v0.8.31 and both ship the
+            // same ggml-cuda.dll name, so returning "cuda" for either would re-download the CUDA
+            // 12 archive over a CUDA 13 install (TtsVoiceInstaller re-downloads "the variant the
+            // user originally picked"). The sidecar written at install time is the direct answer;
+            // an install made before CUDA 13 existed has none, and is told apart by the cudart
+            // redistributable bundled alongside - the same discriminator
+            // DetectLlamaCppWindowsVariant uses. RemoveStaleCrispAsrBinaries wipes the binaries
+            // before every unpack, so no stale _13 runtime can be left behind by an earlier build.
+            var cudaSidecarKey = TryReadInstalledKey(installFolder);
+            if (cudaSidecarKey == CrispAsr.WindowsCuda13)
+            {
+                return "cuda13";
+            }
+
+            if (cudaSidecarKey == CrispAsr.WindowsCuda)
+            {
+                return "cuda";
+            }
+
+            return File.Exists(Path.Combine(installFolder, "cudart64_13.dll")) ? "cuda13" : "cuda";
         }
 
         if (File.Exists(Path.Combine(installFolder, "ggml-vulkan.dll")))

--- a/src/ui/Logic/Se4Setup/Se4SettingsXmlImporter.cs
+++ b/src/ui/Logic/Se4Setup/Se4SettingsXmlImporter.cs
@@ -515,22 +515,69 @@ public static class Se4SettingsXmlImporter
         }
     }
 
-    // SE 4 writes colors as System.Drawing's signed 32-bit ARGB (Color.ToArgb); SE 5 stores hex.
+    // SE 5 stores hex; SE 4 has two spellings, so both are accepted - see TryParseSe4Color.
     private static void SetColor(XElement parent, string name, Action<string> apply)
     {
-        var value = Value(parent, name);
-        if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var argb))
+        if (TryParseSe4Color(Value(parent, name), out var color))
         {
-            return;
+            apply(color.FromColorToHex());
+        }
+    }
+
+    /// <summary>
+    /// A color as SE 4's Settings.xml spells it. Most are System.Drawing's signed 32-bit ARGB
+    /// (<c>Color.ToArgb()</c>), but the dark theme colors go through SE 4's own <c>ToHtml()</c> -
+    /// <c>Utilities.ColorToHexWithTransparency</c>, i.e. "#rrggbbaa" with the alpha *last*. Reading
+    /// only the integer form dropped DarkThemeBackColor and DarkThemeForeColor without a word, so
+    /// an imported SE 4 dark theme came up in SE 5's default colors.
+    /// </summary>
+    internal static bool TryParseSe4Color(string? value, out Color color)
+    {
+        color = default;
+        var text = value?.Trim();
+        if (string.IsNullOrEmpty(text))
+        {
+            return false;
+        }
+
+        if (text[0] == '#')
+        {
+            var hex = text.Substring(1);
+            if (hex.Length != 6 && hex.Length != 8)
+            {
+                return false;
+            }
+
+            foreach (var c in hex)
+            {
+                if (!Uri.IsHexDigit(c))
+                {
+                    return false;
+                }
+            }
+
+            var rgba = uint.Parse(hex.PadRight(8, 'f'), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+            color = Color.FromArgb(
+                (byte)(rgba & 0xFF),          // alpha last, unlike ToArgb
+                (byte)((rgba >> 24) & 0xFF),
+                (byte)((rgba >> 16) & 0xFF),
+                (byte)((rgba >> 8) & 0xFF));
+            return true;
+        }
+
+        // SE 4 itself still reads a bare integer here (its DarkThemeBackColor reader keeps a
+        // "-14803426" fallback), so a settings file written by an older SE 4 is accepted too.
+        if (!int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var argb))
+        {
+            return false;
         }
 
         var bytes = unchecked((uint)argb);
-        var color = Color.FromArgb(
+        color = Color.FromArgb(
             (byte)((bytes >> 24) & 0xFF),
             (byte)((bytes >> 16) & 0xFF),
             (byte)((bytes >> 8) & 0xFF),
             (byte)(bytes & 0xFF));
-
-        apply(color.FromColorToHex());
+        return true;
     }
 }

--- a/tests/UI/Logic/Download/CrispAsrCudaVariantTests.cs
+++ b/tests/UI/Logic/Download/CrispAsrCudaVariantTests.cs
@@ -1,0 +1,119 @@
+using System.IO;
+using Nikse.SubtitleEdit.Logic.Download;
+
+namespace UITests.Logic.Download;
+
+/// <summary>
+/// CrispASR v0.8.31 added a Windows CUDA 13 build beside the CUDA 12 one (#14343). Both unpack
+/// into the same folder and ship the same ggml-cuda.dll name, so detection has to go by the
+/// install sidecar (or, for an install made before CUDA 13 existed, the bundled cudart
+/// redistributable). Getting it wrong is not cosmetic: TtsVoiceInstaller re-downloads "the variant
+/// the user originally picked", so a CUDA 13 install reported as "cuda" is silently replaced by
+/// the CUDA 12 archive.
+/// </summary>
+public class CrispAsrCudaVariantTests
+{
+    private static string MakeInstallFolder(params string[] fileNames)
+    {
+        var folder = Path.Combine(Path.GetTempPath(), "se-crispasr-" + Path.GetRandomFileName());
+        Directory.CreateDirectory(folder);
+        foreach (var name in fileNames)
+        {
+            File.WriteAllText(Path.Combine(folder, name), string.Empty);
+        }
+
+        return folder;
+    }
+
+    private static void WriteSidecar(string folder, string key)
+    {
+        File.WriteAllLines(Path.Combine(folder, ".installed.sha256"), new[] { key, new string('0', 64) });
+    }
+
+    [Fact]
+    public void DetectWindowsVariant_Cuda13Sidecar_ReturnsCuda13()
+    {
+        var folder = MakeInstallFolder("crispasr.exe", "ggml-cuda.dll");
+        WriteSidecar(folder, DownloadHashManager.CrispAsr.WindowsCuda13);
+        try
+        {
+            Assert.Equal("cuda13", DownloadHashManager.DetectCrispAsrWindowsVariant(folder));
+        }
+        finally
+        {
+            Directory.Delete(folder, true);
+        }
+    }
+
+    [Fact]
+    public void DetectWindowsVariant_Cuda12Sidecar_ReturnsCuda()
+    {
+        var folder = MakeInstallFolder("crispasr.exe", "ggml-cuda.dll");
+        WriteSidecar(folder, DownloadHashManager.CrispAsr.WindowsCuda);
+        try
+        {
+            Assert.Equal("cuda", DownloadHashManager.DetectCrispAsrWindowsVariant(folder));
+        }
+        finally
+        {
+            Directory.Delete(folder, true);
+        }
+    }
+
+    [Fact]
+    public void DetectWindowsVariant_NoSidecarButCuda13Runtime_ReturnsCuda13()
+    {
+        var folder = MakeInstallFolder("crispasr.exe", "ggml-cuda.dll", "cudart64_13.dll");
+        try
+        {
+            Assert.Equal("cuda13", DownloadHashManager.DetectCrispAsrWindowsVariant(folder));
+        }
+        finally
+        {
+            Directory.Delete(folder, true);
+        }
+    }
+
+    [Fact]
+    public void DetectWindowsVariant_NoSidecarAndCuda12Runtime_ReturnsCuda()
+    {
+        var folder = MakeInstallFolder("crispasr.exe", "ggml-cuda.dll", "cudart64_12.dll");
+        try
+        {
+            Assert.Equal("cuda", DownloadHashManager.DetectCrispAsrWindowsVariant(folder));
+        }
+        finally
+        {
+            Directory.Delete(folder, true);
+        }
+    }
+
+    [Fact]
+    public void DetectWindowsVariant_VulkanIsUnaffected()
+    {
+        var folder = MakeInstallFolder("crispasr.exe", "ggml-vulkan.dll");
+        try
+        {
+            Assert.Equal("vulkan", DownloadHashManager.DetectCrispAsrWindowsVariant(folder));
+        }
+        finally
+        {
+            Directory.Delete(folder, true);
+        }
+    }
+
+    [Theory]
+    [InlineData("cuda", DownloadHashManager.CrispAsr.WindowsCuda, DownloadHashManager.CrispAsr.WindowsCudaExecutable)]
+    [InlineData("cuda13", DownloadHashManager.CrispAsr.WindowsCuda13, DownloadHashManager.CrispAsr.WindowsCuda13Executable)]
+    public void EveryDetectedWindowsCudaVariantResolvesBackToItsOwnHashKeys(
+        string variant, string archiveKey, string executableKey)
+    {
+        // The detected variant feeds both the re-download and the "is this install up to date?"
+        // check, so it has to survive the round trip through the hash-key lookups.
+        Assert.Equal(variant, DownloadHashManager.GetCrispAsrVariant(archiveKey));
+        Assert.Equal(variant, DownloadHashManager.GetCrispAsrVariant(executableKey));
+        Assert.Equal(variant, DownloadHashManager.GetCrispAsrWindowsVariant(archiveKey));
+        Assert.False(string.IsNullOrEmpty(DownloadHashManager.GetLatestKnownHash(archiveKey)));
+        Assert.False(string.IsNullOrEmpty(DownloadHashManager.GetLatestKnownHash(executableKey)));
+    }
+}

--- a/tests/UI/Logic/Se4SettingsXmlImporterTests.cs
+++ b/tests/UI/Logic/Se4SettingsXmlImporterTests.cs
@@ -233,6 +233,73 @@ public class Se4SettingsXmlImporterTests : IDisposable
         Assert.Equal(UiTheme.ThemeNameLight, Se.Settings.Appearance.Theme);
     }
 
+    [Fact]
+    public void ApplyAppearance_ReadsTheDarkThemeColorsSe4ActuallyWrites()
+    {
+        // SE 4 writes most colors as Color.ToArgb(), but the dark theme pair goes through its own
+        // ToHtml() - "#rrggbbaa", alpha last. Only accepting the integer form dropped both without
+        // a word, so an imported SE 4 dark theme came up in SE 5's default colors.
+        var file = Parse(
+            "<Settings><General>" +
+            "<UseDarkTheme>True</UseDarkTheme>" +
+            "<DarkThemeBackColor>#1e1f22ff</DarkThemeBackColor>" +
+            "<DarkThemeForeColor>#dfe1e5ff</DarkThemeForeColor>" +
+            "</General></Settings>");
+
+        Se4SettingsXmlImporter.ApplyAppearance(file);
+
+        var a = Se.Settings.Appearance;
+        Assert.Equal("#FF1E1F22", a.DarkModeBackgroundColor);
+        Assert.Equal("#FFDFE1E5", a.DarkModeForegroundColor);
+    }
+
+    [Fact]
+    public void ApplyAppearance_StillReadsTheLegacyIntegerDarkThemeColor()
+    {
+        // SE 4's own reader keeps a "-14803426" fallback for DarkThemeBackColor, so a file written
+        // by an older SE 4 has to keep working.
+        var file = Parse(
+            "<Settings><General><DarkThemeBackColor>-14803426</DarkThemeBackColor></General></Settings>");
+
+        Se4SettingsXmlImporter.ApplyAppearance(file);
+
+        Assert.Equal("#FF1E1E1E", Se.Settings.Appearance.DarkModeBackgroundColor);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("#12345")]
+    [InlineData("#nothex1")]
+    [InlineData("Control")]
+    public void TryParseSe4Color_RejectsWhatItCannotRead(string value)
+    {
+        Assert.False(Se4SettingsXmlImporter.TryParseSe4Color(value, out _));
+    }
+
+    [Fact]
+    public void TryParseSe4Color_TakesTheAlphaFromTheEndOfTheHexAndTheFrontOfTheInteger()
+    {
+        Assert.True(Se4SettingsXmlImporter.TryParseSe4Color("#11223380", out var fromHex));
+        AssertArgb(0x80, 0x11, 0x22, 0x33, fromHex);
+
+        // No alpha in the hex means opaque.
+        Assert.True(Se4SettingsXmlImporter.TryParseSe4Color("#112233", out var noAlpha));
+        AssertArgb(0xFF, 0x11, 0x22, 0x33, noAlpha);
+
+        // System.Drawing's ToArgb() is the other way round: "-2146360781" is 0x80112233 signed.
+        Assert.True(Se4SettingsXmlImporter.TryParseSe4Color("-2146360781", out var fromInt));
+        AssertArgb(0x80, 0x11, 0x22, 0x33, fromInt);
+    }
+
+    private static void AssertArgb(byte a, byte r, byte g, byte b, Avalonia.Media.Color color)
+    {
+        Assert.Equal(a, color.A);
+        Assert.Equal(r, color.R);
+        Assert.Equal(g, color.G);
+        Assert.Equal(b, color.B);
+    }
+
     // SE 4 prefixed several of these with "AutoTranslate" and SE 5 does not, so the renamed ones
     // are the ones worth pinning down.
     [Fact]

--- a/tests/libse/ContainerFormats/ManzanitaTeletextTest.cs
+++ b/tests/libse/ContainerFormats/ManzanitaTeletextTest.cs
@@ -138,6 +138,71 @@ public class ManzanitaTeletextTest
     }
 
     [Fact]
+    public void TeletextRowIsTheFirstLineAndTheBlockGrowsDownwards()
+    {
+        // MarginV is the EBU STL vertical position - the row the *first* line goes on, with the
+        // rest of the block below it (Ebu.Save, TeletextRowHelper and SubtitlePositionToAssa all
+        // read it that way). Reading it as the bottom row instead put a two line subtitle two
+        // rows too high: row 5 became rows 3 and 5, and the reader - which reports {\an8} only
+        // when every used row is above row 6 - then called it top aligned.
+        var subtitle = MakeSubtitle(
+            new Paragraph("First line" + Environment.NewLine + "Second line", 1000, 3000)
+            {
+                MarginV = "5",
+            });
+
+        var paragraphs = WriteAndRead(subtitle)[888];
+
+        // Rows 5 and 7, so not top aligned.
+        Assert.Equal("First line" + Environment.NewLine + "Second line", paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void TeletextRowAtTheTopOfThePageKeepsEveryLine()
+    {
+        // Counting upwards from row 1 left no room, and both rows clamped to 1 - the second line
+        // was written over the first and one line of the subtitle was simply lost.
+        var subtitle = MakeSubtitle(
+            new Paragraph("First line" + Environment.NewLine + "Second line", 1000, 3000)
+            {
+                MarginV = "1",
+            });
+
+        var paragraphs = WriteAndRead(subtitle)[888];
+
+        Assert.Equal("{\\an8}First line" + Environment.NewLine + "Second line", paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void TeletextRowTooLowForEveryLineIsPulledUpToFit()
+    {
+        // Row 23 is the last row, so a two line block starting there cannot fit - the start row is
+        // clamped so the tail stays on the page, the same way Ebu.Save clamps it.
+        var subtitle = MakeSubtitle(
+            new Paragraph("First line" + Environment.NewLine + "Second line", 1000, 3000)
+            {
+                MarginV = "23",
+            });
+
+        var paragraphs = WriteAndRead(subtitle)[888];
+
+        Assert.Equal("First line" + Environment.NewLine + "Second line", paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void WithoutATeletextRowTheBlockStaysBottomAnchored()
+    {
+        // The default placement must not move with the MarginV fix: no row means bottom anchored,
+        // which for the reader is anything but top aligned.
+        var subtitle = MakeSubtitle(
+            new Paragraph("First line" + Environment.NewLine + "Second line", 1000, 3000));
+
+        var paragraphs = WriteAndRead(subtitle)[888];
+
+        Assert.Equal("First line" + Environment.NewLine + "Second line", paragraphs[0].Text);
+    }
+
+    [Fact]
     public void WritesTheRequestedPage()
     {
         var subtitle = MakeSubtitle(new Paragraph("On page 801", 1000, 3000));


### PR DESCRIPTION
Three unrelated bugs found reviewing the last 24 hours of commits. Each is independent; each comes with a test that fails on the code as it stands today.

## 1. A Windows CrispASR CUDA 13 install is detected as CUDA 12 — and silently downgraded

`ab26f7c8a` added a Windows CUDA 13 build alongside CUDA 12, but `DetectCrispAsrWindowsVariant` was not extended and can never return `"cuda13"`:

```csharp
if (File.Exists(Path.Combine(installFolder, "ggml-cuda.dll")))
{
    return "cuda";        // both packages ship this DLL
}
```

It also checks the DLL *before* reading the `.installed.sha256` sidecar, which already holds the right key. `DetectCrispAsrLinuxVariant` was extended for CUDA 13 when it landed; the Windows twin was not.

**Failure:** a user installs Windows **CUDA 13**, then enables a CrispASR-backed TTS voice. `TtsVoiceInstaller` — commented *"re-download with the variant the user originally picked"* — resolves `"cuda"` and re-downloads the **CUDA 12** archive over it. That is the mirror image of the regression #14343's commit message went out of its way to avoid. Same root cause also made the engine-settings row read "Windows x64 (CUDA)" and made a sidecar-less CUDA 13 install hash against the CUDA 12 list (status `Unknown`).

**Fix:** sidecar first, then the bundled cudart redistributable — the same discriminator `DetectLlamaCppWindowsVariant` already uses next door in the same file. `RemoveStaleCrispAsrBinaries` wipes the binaries before every unpack, so no stale `_13` runtime can be left behind. Adds the missing `"cuda13"` label arm, and gives the TTS installer's Windows prompt the CUDA 12/13 follow-up that only the STT one and Linux had (without it a fresh install from there could only ever land on CUDA 12).

## 2. `.dvbttx` writer reads `MarginV` as the bottom row; everything else means the start row

`c168e7e10` wired the EBU teletext row machinery (alignment picker, TT column, preview, `SubtitlePositionToAssa`) to DVB teletext. But `ManzanitaTeletextWriter.GetRowNumbers` lays lines out *upward* from `MarginV`, while every other consumer treats it as the row the **first** line starts on:

- `Ebu.cs` — *"EBU-TT and DVB teletext write the same teletext row into MarginV as the STL reader does"*, and `Ebu.Save` grows downward.
- `TeletextRowHelper.GetBottomStartRow` — *"23 for one line and 21 for two"*.
- `SubtitlePositionToAssa.ApplyTeletextRows` — `lastRow = row + (lineCount - 1) * newLineRows`.

**Failure:** a bottom-anchored **2-line** subtitle at `MarginV = 21` (what the picker produces).

| | rows |
|---|---|
| intended / EBU STL export | 21, 23 |
| `.dvbttx` export | **19, 21** — two rows too high |
| video preview | flush at the bottom edge (`lastRow` 23 clamps the margin to 0) |

At the top of the page it is worse than a shift: `MarginV = 1` with two lines clamped **both** rows to 1, so the second line overwrote the first and one line of the subtitle was lost.

**Fix:** count down from the start row, with the same "clamp so the tail stays on the page" rule `Ebu.Save` applies to the STL vertical position. Placement without a `MarginV` is unchanged (pinned by a test).

## 3. SE 4 settings import silently drops both dark-theme colours

`Se4SettingsXmlImporter.SetColor` only accepted a signed 32-bit ARGB integer. That holds for six of the eight colours it reads — but checking against `origin/se4-legacy`, SE 4 writes these two through its own `ToHtml()` → `ColorToHexWithTransparency` → `"#rrggbbaa"`, with the alpha **last**:

```
xmlWriter.WriteElementString("DarkThemeBackColor", ToHtml(settings.General.DarkThemeBackColor));
xmlWriter.WriteElementString("DarkThemeForeColor", ToHtml(settings.General.DarkThemeForeColor));
```

`int.TryParse` fails, so both were dropped and an imported SE 4 dark theme came up in SE 5's default colours. `ApplyAppearance_*` never exercised a colour, which is why it slipped.

**Fix:** accept both spellings, RGBA order handled explicitly, including the bare integer SE 4's own `DarkThemeBackColor` reader still falls back to.

## Testing

- `tests/libse` — 1878 passed
- `tests/UI` — 4484 passed, 1 skipped
- `tests/seconv` — 455 passed

The six new tests were each confirmed to fail against the current code before the fix (2 in `ManzanitaTeletextTest`, 2 in `Se4SettingsXmlImporterTests`, 2 in the new `CrispAsrCudaVariantTests`); the rest are regression guards for the unchanged paths.

## Note left alone

The `.dvbttx` writer's own `DefaultBottomRow` is 22 while `TeletextRowHelper.BottomRow` is 23, so a subtitle with no `MarginV` sits one row higher than one the picker explicitly bottom-anchors. Both are legal placements and changing the default would move every existing `.dvbttx` export, so it is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)