### PR TITLE
mpv: replace the dead audio-keep-open option with audio-stream-silence

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -2937,7 +2937,6 @@
       "showFullscreenButton": "Show full-screen button",
       "fullscreenHideControls": "Hide video controls in full-screen",
       "autoOpenVideoFile": "Auto-open video file when opening subtitle",
-      "mpvAudioKeepOpen": "Keep the audio device open while paused (mpv)",
       "downloadMpv": "Download mpv",
       "downloadVlc": "Download VLC",
       "allowSingleLetterShortcutsInTextbox": "Allow single-letter shortcuts in text box",

--- a/src/ui/Assets/Languages/Italian.json
+++ b/src/ui/Assets/Languages/Italian.json
@@ -2930,7 +2930,6 @@
       "showFullscreenButton": "Visualizza pulsante 'Schermo intero'",
       "fullscreenHideControls": "Nascondi controlli video a schermo intero",
       "autoOpenVideoFile": "All'apertura dei sottotitoli apri automaticamente file video",
-      "mpvAudioKeepOpen": "Mantieni aperto il dispositivo audio durante la pausa (mpv)",
       "downloadMpv": "Download mpv",
       "downloadVlc": "Download VLC",
       "allowSingleLetterShortcutsInTextbox": "Consenti nella casella di testo scorciatoie con una sola lettera",

--- a/src/ui/Assets/Languages/Korean.json
+++ b/src/ui/Assets/Languages/Korean.json
@@ -2937,7 +2937,6 @@
       "showFullscreenButton": "전체 화면 버튼 표시",
       "fullscreenHideControls": "전체 화면에서 비디오 컨트롤 숨기기",
       "autoOpenVideoFile": "자막 파일을 열 때, 비디오 파일도 자동으로 열기",
-      "mpvAudioKeepOpen": "일시 정지 중에도 오디오 장치를 열어 두기 (mpv)",
       "downloadMpv": "mpv 다운로드",
       "downloadVlc": "VLC 다운로드",
       "allowSingleLetterShortcutsInTextbox": "입력칸에 단일 문자 단축키 허용",

--- a/src/ui/Assets/Languages/Turkish.json
+++ b/src/ui/Assets/Languages/Turkish.json
@@ -2937,7 +2937,6 @@
       "showFullscreenButton": "Tam ekran butonunu göster",
       "fullscreenHideControls": "Tam ekranda video kontrollerini gizle",
       "autoOpenVideoFile": "Alt yazı açıldığında video dosyasını otomatik aç",
-	  "mpvAudioKeepOpen": "Duraklatıldığında ses aygıtını açık tut (mpv)",
       "downloadMpv": "mpv indir",
       "downloadVlc": "VLC indir",
       "allowSingleLetterShortcutsInTextbox": "Metin kutusunda tek harfli kısayollara izin ver",

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -447,7 +447,6 @@ public class SettingsPage : UserControl
             MakeCheckboxSetting(Se.Language.Options.Settings.ShowFullscreenButton, nameof(_vm.ShowFullscreenButton)),
             MakeCheckboxSetting(Se.Language.Options.Settings.FullscreenHideControls, nameof(_vm.FullscreenHideControls)),
             MakeCheckboxSetting(Se.Language.Options.Settings.AutoOpenVideoFile, nameof(_vm.AutoOpenVideoFile)),
-            MakeCheckboxSetting(Se.Language.Options.Settings.MpvAudioKeepOpen, nameof(_vm.MpvAudioKeepOpen)),
             new SettingsItem(!_vm.IsLibMpvDownloadVisible, Se.Language.Options.Settings.DownloadMpv, () => new StackPanel
             {
                 Children =

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -266,7 +266,6 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _showFullscreenButton;
     [ObservableProperty] private bool _fullscreenHideControls;
     [ObservableProperty] private bool _autoOpenVideoFile;
-    [ObservableProperty] private bool _mpvAudioKeepOpen;
 
     [ObservableProperty] private bool _waveformDrawGridLines;
     [ObservableProperty] private bool _waveformFocusOnMouseOver;
@@ -1072,7 +1071,6 @@ public partial class SettingsViewModel : ObservableObject
         ShowFullscreenButton = video.ShowFullscreenButton;
         FullscreenHideControls = video.FullscreenHideControls;
         AutoOpenVideoFile = video.AutoOpen;
-        MpvAudioKeepOpen = video.MpvAudioKeepOpen;
 
         MpvPreviewFontName = video.MpvPreviewFontName;
         MpvPreviewFontSize = video.MpvPreviewFontSize;
@@ -1915,7 +1913,6 @@ public partial class SettingsViewModel : ObservableObject
         video.ShowFullscreenButton = ShowFullscreenButton;
         video.FullscreenHideControls = FullscreenHideControls;
         video.AutoOpen = AutoOpenVideoFile;
-        video.MpvAudioKeepOpen = MpvAudioKeepOpen;
 
         video.MpvPreviewFontName = MpvPreviewFontName;
         video.MpvPreviewFontSize = MpvPreviewFontSize;

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -202,7 +202,6 @@ public class LanguageSettings
     public string ShowFullscreenButton { get; set; }
     public string FullscreenHideControls { get; set; }
     public string AutoOpenVideoFile { get; set; }
-    public string MpvAudioKeepOpen { get; set; }
     public string DownloadMpv { get; set; }
     public string DownloadVlc { get; set; }
     public string AllowSingleLetterShortcutsInTextbox { get; set; }
@@ -537,7 +536,6 @@ public class LanguageSettings
         ShowFullscreenButton = "Show full-screen button";
         FullscreenHideControls = "Hide video controls in full-screen";
         AutoOpenVideoFile = "Auto-open video file when opening subtitle";
-        MpvAudioKeepOpen = "Keep the audio device open while paused (mpv)";
         DownloadMpv = "Download mpv";
         DownloadVlc = "Download VLC";
         AllowSingleLetterShortcutsInTextbox = "Allow single-letter shortcuts in text box";

--- a/src/ui/Logic/Config/SeVideo.cs
+++ b/src/ui/Logic/Config/SeVideo.cs
@@ -76,13 +76,17 @@ public class SeVideo
     public double MpvAudioBufferSeconds { get; set; }
 
     /// <summary>
-    /// mpv's "audio-keep-open" option. mpv's own default is "no", which closes the audio device
-    /// every time playback pauses or stops. On a receiver reached over HDMI that shows up as a
-    /// dropped link on every pause and a second or two of missing audio on resume, while the
-    /// device is reopened and the link re-handshakes (#14330). Held open by default; turn it off
-    /// if you need mpv to release the audio device the moment it pauses.
+    /// mpv's "audio-stream-silence" option, applied when a player core is created. mpv normally
+    /// stops the audio device when playback pauses and resets it on every seek - on Windows that
+    /// is IAudioClient::Stop(). Over HDMI to an A/V receiver the link then goes idle (the receiver
+    /// reports no signal) and restarting it costs a re-handshake, heard as a second or two of
+    /// missing audio on resume (#14330). With this on, mpv keeps the device running and writes
+    /// silence instead, so the link never drops.
+    /// <para>Off by default, and deliberately not in the settings UI: mpv's own manual calls this
+    /// option "strongly discouraged" because it changes A/V-sync and underrun handling, and it
+    /// only helps the HDMI-receiver case. Set it by hand if that is your setup.</para>
     /// </summary>
-    public bool MpvAudioKeepOpen { get; set; }
+    public bool MpvAudioStreamSilence { get; set; }
 
     public SeVideo()
     {
@@ -125,6 +129,6 @@ public class SeVideo
         MpvPreviewUsePositionFromFile = true;
         MpvPreviewJustify = "auto";
         MpvAudioBufferSeconds = 0.05;
-        MpvAudioKeepOpen = true;
+        MpvAudioStreamSilence = false;
     }
 }

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -1000,25 +1000,32 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
     private void SetPreInitAudioOptions()
     {
         SetAudioBufferOption();
-        SetAudioKeepOpenOption();
+        SetAudioStreamSilenceOption();
     }
 
     /// <summary>
-    /// mpv's "audio-keep-open". Its default is "no": the audio device is closed whenever
-    /// playback pauses or stops. Over HDMI to a receiver that drops the audio link on every
-    /// pause - the receiver reports no signal - and reopening it on resume costs a second or
-    /// two of re-handshake, which is heard as missing audio at the start of playback (#14330).
-    /// Holding the device open removes both. Off by setting, for anyone who needs mpv to hand
-    /// the device back the moment it pauses.
+    /// mpv's "audio-stream-silence". Normally mpv stops the audio device when playback pauses
+    /// (on Windows, IAudioClient::Stop) and resets it on every seek. Over HDMI to an A/V
+    /// receiver the link then goes idle - the receiver reports no signal - and restarting it
+    /// costs a re-handshake, heard as a second or two of missing audio on resume (#14330). With
+    /// the option set, mpv keeps the device running and writes silence while paused, seeking or
+    /// at end of file, so the link never drops.
+    /// <para>Left alone unless the setting asks for it: mpv's manual calls this option
+    /// "strongly discouraged" because it changes A/V-sync and underrun handling, and it only
+    /// helps that HDMI-receiver case.</para>
     /// <para>Must be called before mpv_initialize.</para>
     /// </summary>
-    private void SetAudioKeepOpenOption()
+    private void SetAudioStreamSilenceOption()
     {
-        var keepOpen = Se.Settings.Video.MpvAudioKeepOpen;
-        var err = SetOptionString("audio-keep-open", keepOpen ? "yes" : "no");
+        if (!Se.Settings.Video.MpvAudioStreamSilence)
+        {
+            return; // mpv's own default: stop the device on pause
+        }
+
+        var err = SetOptionString("audio-stream-silence", "yes");
         if (err < 0)
         {
-            Se.LogError(new InvalidOperationException(GetErrorString(err)), "LibMpvDynamicPlayer could not set audio-keep-open");
+            Se.LogError(new InvalidOperationException(GetErrorString(err)), "LibMpvDynamicPlayer could not set audio-stream-silence");
         }
     }
 

--- a/tests/UI/Logic/MpvAudioOptionTests.cs
+++ b/tests/UI/Logic/MpvAudioOptionTests.cs
@@ -1,5 +1,6 @@
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -7,17 +8,20 @@ using System.Text.RegularExpressions;
 namespace UITests.Logic;
 
 /// <summary>
-/// Issue #14330: mpv closes the audio device whenever playback pauses or stops (its
-/// "audio-keep-open" default is "no"). Over HDMI to a receiver that drops the audio link on
-/// every pause and costs a re-handshake on resume, heard as missing audio at the start of
-/// playback. SE now holds the device open by default, with a setting to give it back.
+/// Issue #14330: mpv stops the audio device when playback pauses and resets it on every seek.
+/// Over HDMI to an A/V receiver the link goes idle and restarting it costs a re-handshake, heard
+/// as a second or two of missing audio on resume. mpv's "audio-stream-silence" keeps the device
+/// running and writes silence instead; SE exposes it as an off-by-default setting.
 /// </summary>
 public class MpvAudioOptionTests
 {
     [Fact]
-    public void KeepAudioDeviceOpen_IsOnByDefault()
+    public void AudioStreamSilence_IsOffByDefault()
     {
-        Assert.True(new SeVideo().MpvAudioKeepOpen);
+        // mpv's manual calls the option "strongly discouraged" - it changes A/V-sync and underrun
+        // handling - and it only helps the HDMI-receiver case, so SE leaves mpv's behavior alone
+        // unless the setting asks for it.
+        Assert.False(new SeVideo().MpvAudioStreamSilence);
     }
 
     /// <summary>
@@ -29,8 +33,7 @@ public class MpvAudioOptionTests
     [Fact]
     public void EveryMpvInitPath_SetsThePreInitAudioOptions()
     {
-        var source = File.ReadAllText(Path.Combine(
-            FindRepoRoot(), "src", "ui", "Logic", "VideoPlayers", "LibMpvDynamic", "LibMpvDynamicPlayer.cs"));
+        var source = File.ReadAllText(PlayerSourcePath);
 
         var inits = Regex.Matches(source, @"_mpvInitialize\(_mpv\)").Count;
         var optionCalls = Regex.Matches(source, @"^\s*SetPreInitAudioOptions\(\);", RegexOptions.Multiline).Count;
@@ -42,6 +45,70 @@ public class MpvAudioOptionTests
             "Every init path must set the pre-init audio options, or that path silently falls back " +
             "to mpv's defaults (#14330).");
     }
+
+    /// <summary>
+    /// mpv answers an unknown option name with an error code that SE only logs, so a misspelled or
+    /// invented option is a silent no-op - #14330 first shipped a fix built on "audio-keep-open",
+    /// which mpv has never had, and the setting did nothing in either position. Every option name
+    /// SE passes to mpv therefore has to appear below, having been checked against mpv's manual
+    /// (https://mpv.io/manual/master/ - or "mpv --list-options"). Adding a name here is the step
+    /// that forces that check.
+    /// </summary>
+    [Fact]
+    public void EveryMpvOptionNameSet_IsARealMpvOption()
+    {
+        var names = new[] { PlayerSourcePath, NativeControlSourcePath }
+            .SelectMany(p => Regex.Matches(File.ReadAllText(p), @"SetOptionString\(""([a-z0-9-]+)"""))
+            .Select(m => m.Groups[1].Value)
+            .Distinct()
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.NotEmpty(names);
+
+        var unverified = names.Where(n => !VerifiedMpvOptionNames.Contains(n)).ToList();
+        Assert.True(
+            unverified.Count == 0,
+            $"mpv option name(s) not on the verified list: {string.Join(", ", unverified)}. " +
+            "Check each against mpv's manual and add it to VerifiedMpvOptionNames - mpv silently " +
+            "ignores names it does not know, so a wrong one is a setting that does nothing (#14330).");
+    }
+
+    /// <summary>
+    /// mpv option names SE sets, each verified to exist in mpv's manual.
+    /// </summary>
+    private static readonly HashSet<string> VerifiedMpvOptionNames = new(StringComparer.Ordinal)
+    {
+        "audio-buffer",
+        "audio-stream-silence",
+        "background-color",
+        "brightness",
+        "contrast",
+        "end",
+        "force-window",
+        "gpu-api",
+        "hr-seek",
+        "idle",
+        "keep-open",
+        "lavfi-complex",
+        "pause",
+        "rebase-start-time",
+        "script-opts",
+        "sid",
+        "start",
+        "sub-ass-force-margins",
+        "sub-ass-justify",
+        "sub-justify",
+        "sub-use-margins",
+        "vo",
+        "wid",
+    };
+
+    private static string PlayerSourcePath => Path.Combine(
+        FindRepoRoot(), "src", "ui", "Logic", "VideoPlayers", "LibMpvDynamic", "LibMpvDynamicPlayer.cs");
+
+    private static string NativeControlSourcePath => Path.Combine(
+        FindRepoRoot(), "src", "ui", "Logic", "VideoPlayers", "LibMpvDynamic", "LibMpvDynamicNativeControl.cs");
 
     private static string FindRepoRoot()
     {


### PR DESCRIPTION
Follow-up to #14335 for #14330.

## The option we shipped does not exist

#14335 set `audio-keep-open`. mpv has never had that option — it is in neither `DOCS/man/options.rst` nor `options/options.c` upstream. `mpv_set_option_string` answers an unknown name with `MPV_ERROR_OPTION_NOT_FOUND`, which SE only logs, so the checkbox was a no-op in both positions. The reporter said exactly that: *"It actually looks like this toggle has utterly no effect whatsoever."*

The test added with it pinned that the call was *made*, never that mpv *accepted* it, so it passed the whole time.

## What actually causes the dropouts

mpv doesn't merely close the device at EOF — it stops it on pause and resets it on every seek. On Windows that's `ao_wasapi`'s `set_pause` → `IAudioClient::Stop()`. Over HDMI the receiver's link goes idle (hence its "No signal", a few seconds later as the driver times out), and `IAudioClient::Start()` on resume triggers a re-handshake the receiver eats — the 3–4 seconds of missing audio in the report.

`--audio-stream-silence=yes` is mpv's answer, and its manual describes this exact hardware. In `audio/out/buffer.c` the flag gates four paths: the pause branch is skipped, `ao_reset` no longer stops the device on seeks, the fill loop keeps writing silence while paused or idle, and the stream stays up at EOF. The seek case matters as much as pause here — SE seeks constantly while timing subtitles, and each one currently resets the AO.

## What this PR does

- Removes `MpvAudioKeepOpen`, its checkbox, and its language strings (including three translations that had already picked the string up). Settings-safe: both the settings and language JSON contexts use `UnmappedMemberHandling.Skip`, so old files carrying the property still load.
- Adds `Se.Settings.Video.MpvAudioStreamSilence` (default `false`), set before `mpv_initialize` and only when asked for.
- No checkbox, following `MpvAudioBufferSeconds`. mpv's manual calls `audio-stream-silence` **"strongly discouraged"** — it changes A/V-sync and underrun handling, and mpv warns about it in its own log at every AO init — and it only helps the HDMI-receiver case. If it works for the reporter, promoting it to a checkbox is a follow-up decision.

## Test

The failure mode worth guarding is a silent no-op, not a wrong value. `EveryMpvOptionNameSet_IsARealMpvOption` extracts every option name SE passes to mpv and requires it to be on a list verified against mpv's manual, so a new name has to be looked up before it can pass. Confirmed it fails on the exact bug: reinstating `audio-keep-open` produces *"mpv option name(s) not on the verified list: audio-keep-open"*.

The other 22 names SE sets were all checked against the manual — `audio-keep-open` was the only invented one.

Full UI suite: 4489 passed, 1 skipped, 0 failed.

## For the reporter

`audio-stream-silence` is off by default, so this needs `"MpvAudioStreamSilence": true` under `Video` in `Se.json`, plus a restart — it is a pre-init option, so toggling it can never affect a running player.

Still open from the beta 31 report and not addressed here: the Settings/Apply freeze that left the video player straddling both monitors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)