### PR TITLE
Add a "Columns..." dialog to reorder the subtitle grid columns

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -127,6 +127,8 @@
     "colorWhite": "White",
     "colorYellow": "Yellow",
     "column": "Column",
+    "columns": "Columns",
+    "columnsDotDotDot": "Columns...",
     "consoleLog": "Console log",
     "contentAlignment": "Content alignment",
     "continueFindTitle": "Continue Find?",

--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -41,6 +41,7 @@ using Nikse.SubtitleEdit.Features.Help.CheckForUpdates;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Main.AssistedMove;
 using Nikse.SubtitleEdit.Features.Main.AssistedSplit;
+using Nikse.SubtitleEdit.Features.Main.GridColumns;
 using Nikse.SubtitleEdit.Features.Main.Layout;
 using Nikse.SubtitleEdit.Features.Main.MainHelpers;
 using Nikse.SubtitleEdit.Features.Ocr;
@@ -443,6 +444,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<GetDictionariesViewModel>();
         collection.AddTransient<GetKeyViewModel>();
         collection.AddTransient<GoToLineNumberViewModel>();
+        collection.AddTransient<GridColumnsViewModel>();
         collection.AddTransient<FormatLimitWarningViewModel>();
         collection.AddTransient<GoToVideoPositionViewModel>();
         collection.AddTransient<HearingImpairedRuleSettingsViewModel>();

--- a/src/ui/Features/Main/GridColumns/GridColumnDisplay.cs
+++ b/src/ui/Features/Main/GridColumns/GridColumnDisplay.cs
@@ -1,0 +1,32 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Nikse.SubtitleEdit.Features.Main.GridColumns;
+
+/// <summary>
+/// One row in the "Columns..." dialog. An entry can cover more than one grid column
+/// key when two columns are format-gated variants of the same logical column and
+/// share a show/hide toggle (Style/WebVttStyle, Actor/WebVttVoice) - they move as one.
+/// </summary>
+public partial class GridColumnDisplay : ObservableObject
+{
+    [ObservableProperty] private bool _isVisible;
+
+    public string Name { get; }
+
+    /// <summary>
+    /// False for columns the user cannot show/hide: Number and Text are always shown,
+    /// and the teletext/original-text columns come and go with the loaded content.
+    /// </summary>
+    public bool CanToggle { get; }
+
+    /// <summary>Grid column keys (SubtitleGridColumnKeys) this entry covers, in default order.</summary>
+    public string[] Keys { get; }
+
+    public GridColumnDisplay(string name, bool canToggle, bool isVisible, params string[] keys)
+    {
+        Name = name;
+        CanToggle = canToggle;
+        IsVisible = isVisible;
+        Keys = keys;
+    }
+}

--- a/src/ui/Features/Main/GridColumns/GridColumnsViewModel.cs
+++ b/src/ui/Features/Main/GridColumns/GridColumnsViewModel.cs
@@ -1,0 +1,143 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Features.Main.GridColumns;
+
+public partial class GridColumnsViewModel : ObservableObject
+{
+    [ObservableProperty] private ObservableCollection<GridColumnDisplay> _columns;
+    [ObservableProperty] private GridColumnDisplay? _selectedColumn;
+
+    /// <summary>The flattened column key order after OK, ready for SubtitleGridColumnOrder.</summary>
+    public List<string> ResultColumnOrder { get; private set; } = new();
+
+    public Window? Window { get; set; }
+
+    public bool OkPressed { get; private set; }
+
+    public bool HasChanges { get; private set; }
+
+    private List<GridColumnDisplay> _defaultOrder = new();
+    private List<string> _initialOrder = new();
+    private List<bool> _initialVisibility = new();
+
+    public GridColumnsViewModel()
+    {
+        Columns = new ObservableCollection<GridColumnDisplay>();
+    }
+
+    /// <summary>
+    /// <paramref name="entries"/> must be in the built-in default column order;
+    /// <paramref name="currentOrder"/> is the saved key order (may be empty = default,
+    /// and may be from an older version that lacks some of today's keys).
+    /// </summary>
+    public void Initialize(List<GridColumnDisplay> entries, List<string> currentOrder)
+    {
+        _defaultOrder = entries;
+
+        // Same merge as TableViewColumnManager.ApplyOrder: saved keys first, then any
+        // entry the saved order does not know at its default position.
+        var ordered = new List<GridColumnDisplay>();
+        foreach (var key in currentOrder)
+        {
+            var entry = entries.FirstOrDefault(x => x.Keys.Contains(key));
+            if (entry != null && !ordered.Contains(entry))
+            {
+                ordered.Add(entry);
+            }
+        }
+
+        for (var i = 0; i < entries.Count; i++)
+        {
+            if (!ordered.Contains(entries[i]))
+            {
+                ordered.Insert(System.Math.Min(i, ordered.Count), entries[i]);
+            }
+        }
+
+        Columns.Clear();
+        foreach (var entry in ordered)
+        {
+            Columns.Add(entry);
+        }
+
+        _initialOrder = ordered.SelectMany(x => x.Keys).ToList();
+        _initialVisibility = ordered.Select(x => x.IsVisible).ToList();
+
+        SelectedColumn = Columns.FirstOrDefault();
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        ResultColumnOrder = Columns.SelectMany(x => x.Keys).ToList();
+        HasChanges = !ResultColumnOrder.SequenceEqual(_initialOrder) ||
+                     !Columns.Select(x => x.IsVisible).SequenceEqual(_initialVisibility);
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Window?.Close();
+    }
+
+    [RelayCommand]
+    private void MoveUp()
+    {
+        Move(-1);
+    }
+
+    [RelayCommand]
+    private void MoveDown()
+    {
+        Move(1);
+    }
+
+    private void Move(int delta)
+    {
+        if (SelectedColumn == null)
+        {
+            return;
+        }
+
+        var index = Columns.IndexOf(SelectedColumn);
+        var newIndex = index + delta;
+        if (newIndex < 0 || newIndex >= Columns.Count)
+        {
+            return;
+        }
+
+        var selected = SelectedColumn;
+        Columns.Move(index, newIndex);
+        SelectedColumn = selected;
+    }
+
+    [RelayCommand]
+    private void Reset()
+    {
+        var selected = SelectedColumn;
+        Columns.Clear();
+        foreach (var entry in _defaultOrder)
+        {
+            Columns.Add(entry);
+        }
+
+        SelectedColumn = selected ?? Columns.FirstOrDefault();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+    }
+}

--- a/src/ui/Features/Main/GridColumns/GridColumnsWindow.cs
+++ b/src/ui/Features/Main/GridColumns/GridColumnsWindow.cs
@@ -1,0 +1,101 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Templates;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Main.GridColumns;
+
+public class GridColumnsWindow : Window
+{
+    public GridColumnsWindow(GridColumnsViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = Se.Language.General.Columns;
+        SizeToContent = SizeToContent.WidthAndHeight;
+        CanResize = false;
+        vm.Window = this;
+        DataContext = vm;
+
+        var listBox = new ListBox
+        {
+            Width = 300,
+            Height = 420,
+        };
+        listBox.Bind(ListBox.ItemsSourceProperty, new Binding(nameof(GridColumnsViewModel.Columns)));
+        listBox.Bind(ListBox.SelectedItemProperty, new Binding(nameof(GridColumnsViewModel.SelectedColumn)) { Mode = BindingMode.TwoWay });
+        listBox.ItemTemplate = new FuncDataTemplate<GridColumnDisplay>((_, _) =>
+        {
+            // The always-shown/content-driven columns (Number, Text, teletext, original)
+            // still take part in ordering, but their visibility is not the user's to set.
+            var checkBox = new CheckBox();
+            checkBox.Bind(CheckBox.IsCheckedProperty, new Binding(nameof(GridColumnDisplay.IsVisible)) { Mode = BindingMode.TwoWay });
+            checkBox.Bind(InputElement.IsEnabledProperty, new Binding(nameof(GridColumnDisplay.CanToggle)));
+
+            var textBlock = new TextBlock { Margin = new Thickness(5, 0, 0, 0), VerticalAlignment = VerticalAlignment.Center };
+            textBlock.Bind(TextBlock.TextProperty, new Binding(nameof(GridColumnDisplay.Name)));
+
+            return new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Children = { checkBox, textBlock },
+            };
+        }, true);
+
+        var buttonMoveUp = UiUtil.MakeButton(Se.Language.General.MoveUp, vm.MoveUpCommand).WithMinWidth(100);
+        var buttonMoveDown = UiUtil.MakeButton(Se.Language.General.MoveDown, vm.MoveDownCommand).WithMinWidth(100);
+        var buttonReset = UiUtil.MakeButton(Se.Language.General.Reset, vm.ResetCommand).WithMinWidth(100);
+
+        var sidePanel = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 5,
+            Margin = new Thickness(10, 0, 0, 0),
+            VerticalAlignment = VerticalAlignment.Top,
+            Children =
+            {
+                buttonMoveUp,
+                buttonMoveDown,
+                buttonReset,
+            },
+        };
+
+        var contentGrid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+        };
+        contentGrid.Add(listBox, 0, 0);
+        contentGrid.Add(sidePanel, 0, 1);
+
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        var panelButtons = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            Margin = UiUtil.MakeWindowMargin(),
+            RowSpacing = 10,
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+        grid.Add(contentGrid, 0, 0);
+        grid.Add(panelButtons, 1, 0);
+
+        Content = grid;
+
+        UiUtil.FocusOnFirstActivation(this, listBox); // initial focus on an input, not an action button - a focused button clicks on bare Space
+        KeyDown += (_, e) => vm.OnKeyDown(e);
+    }
+}

--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -727,6 +727,7 @@ public static partial class InitListViewAndEditBox
             Source = vm,
         });
 
+        columnManager.ApplyOrder(Se.Settings.General.SubtitleGridColumnOrder);
         RestoreSubtitleGridColumnWidths(columnManager);
 
         vm.SubtitleGrid.DataContext = vm.Subtitles;
@@ -990,6 +991,21 @@ public static partial class InitListViewAndEditBox
         };
         showLayerMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.ShowColumnLayerFlyoutMenuItem)) { Source = vm, Mode = BindingMode.TwoWay });
         flyout.Items.Add(showLayerMenuItem);
+
+        var columnsSeparator = new Separator { DataContext = vm };
+        columnsSeparator.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)));
+        flyout.Items.Add(columnsSeparator);
+
+        // Show/hide plus reordering in one dialog (#14369) - the toggles above only cover
+        // visibility, and the TableView has no column dragging.
+        var columnsMenuItem = new MenuItem
+        {
+            Header = Se.Language.General.ColumnsDotDotDot,
+            Command = vm.ShowGridColumnsDialogCommand,
+            DataContext = vm,
+        };
+        columnsMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)));
+        flyout.Items.Add(columnsMenuItem);
 
 
         var deleteMenuItem = new MenuItem { Header = Se.Language.General.Delete, DataContext = vm };

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -70,6 +70,7 @@ using Nikse.SubtitleEdit.Features.Files.RestoreAutoBackup;
 using Nikse.SubtitleEdit.Features.Files.Statistics;
 using Nikse.SubtitleEdit.Features.Help.About;
 using Nikse.SubtitleEdit.Features.Help.CheckForUpdates;
+using Nikse.SubtitleEdit.Features.Main.GridColumns;
 using Nikse.SubtitleEdit.Features.Main.Layout;
 using Nikse.SubtitleEdit.Features.Main.MainHelpers;
 using Nikse.SubtitleEdit.Features.Ocr;
@@ -13286,6 +13287,126 @@ public partial class MainViewModel :
         Se.Settings.General.ShowColumnLayer = ShowColumnLayer;
         ShowColumnLayer = Se.Settings.General.ShowColumnLayer;
         AutoFitColumns();
+    }
+
+    // The "Columns..." dialog (#14369): show/hide and reorder the grid columns in one place.
+    // The Style/WebVttStyle and Actor/WebVttVoice pairs are format-gated variants of the same
+    // logical column sharing one toggle, so each pair is one entry and moves as one.
+    [RelayCommand]
+    private async Task ShowGridColumnsDialog()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var entries = new List<GridColumnDisplay>
+        {
+            new(Se.Language.General.NumberSymbol, false, true, InitListViewAndEditBox.SubtitleGridColumnKeys.Number),
+            new(Se.Language.General.Show, true, ShowColumnStartTime, InitListViewAndEditBox.SubtitleGridColumnKeys.Start),
+            new(Se.Language.General.Hide, true, ShowColumnEndTime, InitListViewAndEditBox.SubtitleGridColumnKeys.End),
+            new(Se.Language.General.Duration, true, ShowColumnDuration, InitListViewAndEditBox.SubtitleGridColumnKeys.Duration),
+            new(Se.Language.File.EbuSaveOptions.Teletext, true, ShowColumnTeletext, InitListViewAndEditBox.SubtitleGridColumnKeys.Teletext),
+            new(Se.Language.General.Forced, true, ShowColumnForced, InitListViewAndEditBox.SubtitleGridColumnKeys.Forced),
+            new(Se.Language.General.Text, false, true, InitListViewAndEditBox.SubtitleGridColumnKeys.Text),
+            new(Se.Language.General.OriginalText, false, ShowColumnOriginalText, InitListViewAndEditBox.SubtitleGridColumnKeys.OriginalText),
+            new(Se.Language.General.Style, true, ShowColumnStyle, InitListViewAndEditBox.SubtitleGridColumnKeys.Style, InitListViewAndEditBox.SubtitleGridColumnKeys.WebVttStyle),
+            new(Se.Language.General.Gap, true, ShowColumnGap, InitListViewAndEditBox.SubtitleGridColumnKeys.Gap),
+            new(Se.Language.General.Actor, true, ShowColumnActor, InitListViewAndEditBox.SubtitleGridColumnKeys.Actor, InitListViewAndEditBox.SubtitleGridColumnKeys.WebVttVoice),
+            new(Se.Language.General.Cps, true, ShowColumnCps, InitListViewAndEditBox.SubtitleGridColumnKeys.Cps),
+            new(Se.Language.General.Wpm, true, ShowColumnWpm, InitListViewAndEditBox.SubtitleGridColumnKeys.Wpm),
+            new(Se.Language.General.PixelWidth, true, ShowColumnPixelWidth, InitListViewAndEditBox.SubtitleGridColumnKeys.PixelWidth),
+            new(Se.Language.General.Layer, true, ShowColumnLayer, InitListViewAndEditBox.SubtitleGridColumnKeys.Layer),
+        };
+
+        var result = await _windowService.ShowDialogAsync<GridColumnsWindow, GridColumnsViewModel>(Window, vm =>
+        {
+            vm.Initialize(entries, Se.Settings.General.SubtitleGridColumnOrder);
+        });
+
+        if (!result.OkPressed || !result.HasChanges)
+        {
+            return;
+        }
+
+        foreach (var entry in result.Columns)
+        {
+            if (entry.CanToggle)
+            {
+                SetColumnVisibility(entry.Keys[0], entry.IsVisible);
+            }
+        }
+
+        Se.Settings.General.SubtitleGridColumnOrder = result.ResultColumnOrder;
+        SubtitleGridColumnManager?.ApplyOrder(result.ResultColumnOrder);
+        AutoFitColumns();
+        Se.SaveSettings();
+
+        // Same post-layout refresh as ToggleShowColumnCps: AutoFitColumns() settles the visual
+        // tree before the property-change notifications can render, so post the brush refresh
+        // to run after the layout pass.
+        Dispatcher.UIThread.Post(() =>
+        {
+            foreach (var row in Subtitles)
+            {
+                row.RefreshAfterSettingsChanged();
+            }
+        });
+    }
+
+    private void SetColumnVisibility(string columnKey, bool isVisible)
+    {
+        switch (columnKey)
+        {
+            case InitListViewAndEditBox.SubtitleGridColumnKeys.Start:
+                Se.Settings.General.ShowColumnStartTime = isVisible;
+                ShowColumnStartTime = isVisible;
+                break;
+            case InitListViewAndEditBox.SubtitleGridColumnKeys.End:
+                Se.Settings.General.ShowColumnEndTime = isVisible;
+                ShowColumnEndTime = isVisible;
+                break;
+            case InitListViewAndEditBox.SubtitleGridColumnKeys.Duration:
+                Se.Settings.General.ShowColumnDuration = isVisible;
+                ShowColumnDuration = isVisible;
+                break;
+            case InitListViewAndEditBox.SubtitleGridColumnKeys.Teletext:
+                Se.Settings.General.ShowColumnTeletext = isVisible;
+                ShowColumnTeletext = isVisible;
+                break;
+            case InitListViewAndEditBox.SubtitleGridColumnKeys.Forced:
+                Se.Settings.General.ShowColumnForced = isVisible;
+                ShowColumnForced = isVisible;
+                break;
+            case InitListViewAndEditBox.SubtitleGridColumnKeys.Style:
+                Se.Settings.General.ShowColumnStyle = isVisible;
+                ShowColumnStyle = isVisible;
+                break;
+            case InitListViewAndEditBox.SubtitleGridColumnKeys.Gap:
+                Se.Settings.General.ShowColumnGap = isVisible;
+                ShowColumnGap = isVisible;
+                break;
+            case InitListViewAndEditBox.SubtitleGridColumnKeys.Actor:
+                Se.Settings.General.ShowColumnActor = isVisible;
+                ShowColumnActor = isVisible;
+                break;
+            case InitListViewAndEditBox.SubtitleGridColumnKeys.Cps:
+                Se.Settings.General.ShowColumnCps = isVisible;
+                ShowColumnCps = isVisible;
+                break;
+            case InitListViewAndEditBox.SubtitleGridColumnKeys.Wpm:
+                Se.Settings.General.ShowColumnWpm = isVisible;
+                ShowColumnWpm = isVisible;
+                break;
+            case InitListViewAndEditBox.SubtitleGridColumnKeys.PixelWidth:
+                Se.Settings.General.ShowColumnPixelWidth = isVisible;
+                ShowColumnPixelWidth = isVisible;
+                break;
+            case InitListViewAndEditBox.SubtitleGridColumnKeys.Layer:
+                Se.Settings.General.ShowColumnLayer = isVisible;
+                ShowColumnLayer = isVisible;
+                break;
+        }
     }
 
     // Cycle the grid's Text/Original text formatting mode (issue #12321): "show formatting"

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -127,6 +127,8 @@ public class LanguageGeneral
     public string ColorWhite { get; set; }
     public string ColorYellow { get; set; }
     public string Column { get; set; }
+    public string Columns { get; set; }
+    public string ColumnsDotDotDot { get; set; }
     public string ConsoleLog { get; set; }
     public string ContentAlignment { get; set; }
     public string ContinueFindTitle { get; set; }
@@ -937,6 +939,8 @@ public class LanguageGeneral
         ColorWhite = "White";
         ColorYellow = "Yellow";
         Column = "Column";
+        Columns = "Columns";
+        ColumnsDotDotDot = "Columns...";
         ConsoleLog = "Console log";
         ContentAlignment = "Content alignment";
         ContinueFindTitle = "Continue Find?";

--- a/src/ui/Logic/Config/SeGeneral.cs
+++ b/src/ui/Logic/Config/SeGeneral.cs
@@ -169,6 +169,11 @@ public class SeGeneral
     // columns are intentionally not stored so they keep filling the window (#11415).
     public Dictionary<string, double> SubtitleGridColumnWidths { get; set; } = new();
 
+    // Subtitle grid column order as column keys (DataGridColumn.Tag), set from the
+    // "Columns..." dialog (#14369). Empty = the built-in default order. Keys missing
+    // from the list (columns added in a later version) keep their default position.
+    public List<string> SubtitleGridColumnOrder { get; set; } = new();
+
     public bool SelectCurrentSubtitleWhilePlaying { get; set; }
     public bool WriteAn2Tag { get; set; }
     public bool AutoTrimWhiteSpace { get; set; }

--- a/src/ui/Logic/TableViewExtras.cs
+++ b/src/ui/Logic/TableViewExtras.cs
@@ -227,6 +227,52 @@ public sealed class TableViewColumnManager
         Sync();
     }
 
+    /// <summary>
+    /// Reorders the managed columns to match <paramref name="keys"/> (matched against
+    /// <see cref="SeTableViewColumn.Tag"/>). Columns whose key is not in the list keep
+    /// their current position - a saved order from an older version must not hide or
+    /// displace columns added since. A null/empty list leaves the order untouched.
+    /// </summary>
+    public void ApplyOrder(IReadOnlyList<string>? keys)
+    {
+        if (keys == null || keys.Count == 0)
+        {
+            return;
+        }
+
+        var ordered = new List<TableViewColumn>();
+        foreach (var key in keys)
+        {
+            var column = _columns.FirstOrDefault(c => c is SeTableViewColumn se && se.Tag as string == key);
+            if (column != null && !ordered.Contains(column))
+            {
+                ordered.Add(column);
+            }
+        }
+
+        if (ordered.Count == 0)
+        {
+            return;
+        }
+
+        for (var i = 0; i < _columns.Count; i++)
+        {
+            var column = _columns[i];
+            if (!ordered.Contains(column))
+            {
+                ordered.Insert(Math.Min(i, ordered.Count), column);
+            }
+        }
+
+        _columns.Clear();
+        _columns.AddRange(ordered);
+
+        // Sync() can only insert missing columns, not permute existing ones, so clear the
+        // live list first and let it rebuild in the new order.
+        _tableView.Columns.Clear();
+        Sync();
+    }
+
     private void Sync()
     {
         var target = _columns.Where(c => c is not SeTableViewColumn se || se.IsVisible).ToList();

--- a/tests/UI/Features/Main/SubtitleGridColumnOrderTests.cs
+++ b/tests/UI/Features/Main/SubtitleGridColumnOrderTests.cs
@@ -1,0 +1,113 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Main.Layout;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// The "Columns..." dialog (#14369) saves the grid column order as SubtitleGridColumnOrder;
+/// the layout builder must re-apply it on every grid rebuild, and an order saved by an older
+/// version must not displace columns it does not know about.
+/// </summary>
+public class SubtitleGridColumnOrderTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+    private readonly List<string> _savedOrder = Se.Settings.General.SubtitleGridColumnOrder;
+
+    public void Dispose()
+    {
+        Se.Settings.General.SubtitleGridColumnOrder = _savedOrder;
+
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private (Window Window, MainViewModel Vm) ShowMainWindow()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1400, Height = 900 };
+        _windows.Add(window);
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+
+        var vm = (MainViewModel)view.DataContext!;
+        window.SuppressSaveChangesPromptOnClose(vm);
+        vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph("Hello", 0, 2000), null!));
+
+        for (var pump = 0; pump < 5; pump++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+        }
+
+        return (window, vm);
+    }
+
+    private static string?[] VisibleColumnKeys(MainViewModel vm) =>
+        vm.SubtitleGrid.Columns.OfType<SeTableViewColumn>().Select(p => p.Tag as string).ToArray();
+
+    [AvaloniaFact]
+    public void SavedOrder_IsAppliedWhenTheGridIsBuilt()
+    {
+        Se.Settings.General.SubtitleGridColumnOrder = new List<string>
+        {
+            InitListViewAndEditBox.SubtitleGridColumnKeys.Number,
+            InitListViewAndEditBox.SubtitleGridColumnKeys.Duration,
+            InitListViewAndEditBox.SubtitleGridColumnKeys.Start,
+            InitListViewAndEditBox.SubtitleGridColumnKeys.End,
+            InitListViewAndEditBox.SubtitleGridColumnKeys.Text,
+        };
+
+        var (window, vm) = ShowMainWindow();
+
+        var keys = VisibleColumnKeys(vm);
+        var duration = Array.IndexOf(keys, InitListViewAndEditBox.SubtitleGridColumnKeys.Duration);
+        var start = Array.IndexOf(keys, InitListViewAndEditBox.SubtitleGridColumnKeys.Start);
+        var end = Array.IndexOf(keys, InitListViewAndEditBox.SubtitleGridColumnKeys.End);
+        Assert.True(duration >= 0 && duration < start, $"Duration should precede Start: {string.Join(",", keys)}");
+        Assert.True(start < end, $"Start should precede End: {string.Join(",", keys)}");
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void SavedOrderFromAnOlderVersion_KeepsUnknownColumnsAtTheirDefaultPosition()
+    {
+        // An "old" order knowing only three columns must not push Number/Text/etc. around.
+        Se.Settings.General.SubtitleGridColumnOrder = new List<string>
+        {
+            InitListViewAndEditBox.SubtitleGridColumnKeys.End,
+            InitListViewAndEditBox.SubtitleGridColumnKeys.Start,
+            "NotAColumnAnymore",
+        };
+
+        var (window, vm) = ShowMainWindow();
+
+        var keys = VisibleColumnKeys(vm);
+        var number = Array.IndexOf(keys, InitListViewAndEditBox.SubtitleGridColumnKeys.Number);
+        var end = Array.IndexOf(keys, InitListViewAndEditBox.SubtitleGridColumnKeys.End);
+        var start = Array.IndexOf(keys, InitListViewAndEditBox.SubtitleGridColumnKeys.Start);
+        var text = Array.IndexOf(keys, InitListViewAndEditBox.SubtitleGridColumnKeys.Text);
+        Assert.True(end < start, $"Saved End-before-Start order lost: {string.Join(",", keys)}");
+        Assert.True(number >= 0, "Number column disappeared");
+        Assert.True(text > start, $"Text should keep its default position after the times: {string.Join(",", keys)}");
+
+        window.Close();
+    }
+}

--- a/tests/UI/Logic/TableViewColumnManagerApplyOrderTests.cs
+++ b/tests/UI/Logic/TableViewColumnManagerApplyOrderTests.cs
@@ -1,0 +1,93 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Logic;
+using System.Linq;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// The "Columns..." dialog (#14369) reorders the subtitle grid through
+/// <see cref="TableViewColumnManager.ApplyOrder"/>. The manager's Sync() can only insert
+/// missing columns - a naive permutation through it duplicated columns - and a saved order
+/// from an older version must neither hide nor displace columns added since, so both the
+/// live-list rebuild and the unknown-key merge are pinned down here.
+/// </summary>
+public class TableViewColumnManagerApplyOrderTests
+{
+    private static (TableView Grid, TableViewColumnManager Manager) MakeGrid(params SeTableViewColumn[] columns)
+    {
+        var grid = TableViewExtras.MakeTableView();
+        var manager = new TableViewColumnManager(grid);
+        foreach (var column in columns)
+        {
+            manager.Add(column);
+        }
+
+        return (grid, manager);
+    }
+
+    private static string[] Keys(System.Collections.Generic.IEnumerable<TableViewColumn> columns)
+        => columns.OfType<SeTableViewColumn>().Select(c => (string)c.Tag!).ToArray();
+
+    [AvaloniaFact]
+    public void ApplyOrder_PermutesMasterAndLiveList_WithoutDuplicates()
+    {
+        var (grid, manager) = MakeGrid(
+            new SeTableViewColumn { Tag = "A" },
+            new SeTableViewColumn { Tag = "B" },
+            new SeTableViewColumn { Tag = "C" });
+
+        manager.ApplyOrder(new[] { "C", "A", "B" });
+
+        Assert.Equal(new[] { "C", "A", "B" }, Keys(manager.Columns));
+        Assert.Equal(new[] { "C", "A", "B" }, Keys(grid.Columns));
+        Assert.Equal(3, grid.Columns.Count);
+    }
+
+    [AvaloniaFact]
+    public void ApplyOrder_KeepsHiddenColumnsHiddenButOrdered()
+    {
+        var hidden = new SeTableViewColumn { Tag = "B", IsVisible = false };
+        var (grid, manager) = MakeGrid(
+            new SeTableViewColumn { Tag = "A" },
+            hidden,
+            new SeTableViewColumn { Tag = "C" });
+
+        manager.ApplyOrder(new[] { "B", "C", "A" });
+
+        Assert.Equal(new[] { "B", "C", "A" }, Keys(manager.Columns));
+        Assert.Equal(new[] { "C", "A" }, Keys(grid.Columns));
+
+        // Showing the hidden column later must surface it at its reordered position.
+        hidden.IsVisible = true;
+        Assert.Equal(new[] { "B", "C", "A" }, Keys(grid.Columns));
+    }
+
+    [AvaloniaFact]
+    public void ApplyOrder_UnknownAndMissingKeys_KeepDefaultPositions()
+    {
+        var (grid, manager) = MakeGrid(
+            new SeTableViewColumn { Tag = "A" },
+            new SeTableViewColumn { Tag = "New" }, // not in the saved order (added after it was saved)
+            new SeTableViewColumn { Tag = "B" });
+
+        manager.ApplyOrder(new[] { "B", "Gone", "A" }); // "Gone" no longer exists
+
+        Assert.Equal(new[] { "B", "New", "A" }, Keys(manager.Columns));
+        Assert.Equal(new[] { "B", "New", "A" }, Keys(grid.Columns));
+    }
+
+    [AvaloniaFact]
+    public void ApplyOrder_EmptyOrder_LeavesOrderUntouched()
+    {
+        var (grid, manager) = MakeGrid(
+            new SeTableViewColumn { Tag = "A" },
+            new SeTableViewColumn { Tag = "B" });
+
+        manager.ApplyOrder(System.Array.Empty<string>());
+        manager.ApplyOrder(null);
+
+        Assert.Equal(new[] { "A", "B" }, Keys(manager.Columns));
+        Assert.Equal(new[] { "A", "B" }, Keys(grid.Columns));
+    }
+}


### PR DESCRIPTION
Fixes #14369.

In SE5 the subtitle grid's column order was fixed - the TableView has no column dragging, and columns were built in a hard-coded sequence. Right-clicking a column header now offers **Columns...**, a dialog that handles show/hide and ordering in one place:

- Every column listed with a visibility checkbox plus **Move up** / **Move down** / **Reset** (same shape as the waveform toolbar items dialog).
- Number and Text cannot be hidden; the content-driven columns (Original text) show a disabled checkbox. The teletext preference is toggleable here even though the column stays format-gated.
- The Style/WebVTT-style and Actor/WebVTT-voice pairs are one entry each - they are format-gated variants of the same logical column sharing a toggle, so they move as one.

The order is stored as column keys in `SeGeneral.SubtitleGridColumnOrder` and re-applied on every grid rebuild. `TableViewColumnManager.ApplyOrder` does the permutation: `Sync()` can only insert missing columns (a naive permutation through it duplicates them), so the live column list is cleared and rebuilt; keys a saved order doesn't know (columns added in a later version) keep their default position instead of being displaced or hidden.

Tests: 4 headless unit tests for `ApplyOrder` (permutation, hidden columns, unknown/missing keys, empty order) and 2 integration tests that build the real main window and assert the saved order - including an "old version" order - lands in the grid. Full UI suite: 4493 passed (one unrelated known-flaky undo/redo timing test failed in-suite, passes in isolation).

Verified visually via headless screenshots: the dialog renders correctly and a saved `#, Duration, Show, Hide, Text` order shows up in the grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)