### PR TITLE
mpv: serve scrub bursts at keyframes and land exactly once they settle

### DIFF
--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -66,6 +66,15 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
     private long _ackedSeekCommandId;        // newest id mpv has replied to (event thread)
     private long _restartAckedSeekCommandId; // _ackedSeekCommandId as of the last restart
 
+    // Two-tier scrub seeking (see ScrubSeekPolicy): a seek issued mid-burst is served fast, at
+    // keyframes, and records here that it still owes an exact landing. The restart that seek
+    // fires is what asks whether the burst has settled, so the state has to be published before
+    // the command goes out - mpv can serve a keyframe seek and post the restart while this thread
+    // is still in the setter, and a follow-up recorded after that would wait for a restart that
+    // has already been and gone.
+    private long _scrubFollowUpSeekId;     // keyframe seek owing an exact landing, 0 if none
+    private long _scrubFollowUpTargetBits; // that seek's target, as double bits
+
     [StructLayout(LayoutKind.Sequential)]
     private struct MpvOpenGlInitParams
     {
@@ -635,6 +644,10 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
                 // half-published state fails the generation gate, i.e. reads as "not yet".
                 Interlocked.Exchange(ref _lastPlaybackRestartTimestamp, System.Diagnostics.Stopwatch.GetTimestamp());
                 Interlocked.Exchange(ref _restartAckedSeekCommandId, Interlocked.Read(ref _ackedSeekCommandId));
+
+                // A restart is "a seek finished", which is the only honest moment to ask whether
+                // a scrub burst has stopped and a deferred exact landing is now due.
+                IssueScrubFollowUpSeekIfSettled();
             }
             else if (mpvEvent.eventId == MPV_EVENT_COMMAND_REPLY && mpvEvent.replyUserdata >= SeekReplyIdBase)
             {
@@ -772,6 +785,103 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         // cannot have been caused by that seek.
         var pending = Interlocked.Read(ref _lastSeekCommandId);
         return pending == 0 || Interlocked.Read(ref _restartAckedSeekCommandId) >= pending;
+    }
+
+    /// <summary>
+    /// Whether a seek SE issued has not landed yet - the burst signal two-tier seeking keys on
+    /// (see <see cref="ScrubSeekPolicy"/>). Always false without the event loop: no restart
+    /// events arrive there, so nothing could ever pay a deferred exact landing and every seek
+    /// has to be exact on the spot.
+    /// </summary>
+    private bool IsSeekInFlight()
+    {
+        var issuedAt = Interlocked.Read(ref _lastSeekIssuedTimestamp);
+        var age = issuedAt == 0
+            ? 0
+            : (System.Diagnostics.Stopwatch.GetTimestamp() - issuedAt) / (double)System.Diagnostics.Stopwatch.Frequency;
+
+        return ScrubSeekPolicy.SeekIsInFlight(
+            _eventLoopActive,
+            Interlocked.Read(ref _lastSeekCommandId),
+            Interlocked.Read(ref _restartAckedSeekCommandId),
+            age);
+    }
+
+    /// <summary>
+    /// Pays the exact landing a mid-burst keyframe seek deferred, once that seek has landed and
+    /// nothing newer has replaced it. Runs on the event thread, from the restart event that says
+    /// the seek finished.
+    /// </summary>
+    private void IssueScrubFollowUpSeekIfSettled()
+    {
+        if (_disposed || _mpv == IntPtr.Zero)
+        {
+            return;
+        }
+
+        var followUpId = Interlocked.Read(ref _scrubFollowUpSeekId);
+        if (followUpId == 0)
+        {
+            return;
+        }
+
+        var target = BitConverter.Int64BitsToDouble(Interlocked.Read(ref _scrubFollowUpTargetBits));
+
+        // The observed position, never the Position getter: that one answers with the pinned
+        // target while paused, so every deferred landing would look already reached.
+        double? reported = _observedTimePosValid
+            ? BitConverter.Int64BitsToDouble(Interlocked.Read(ref _observedTimePosBits))
+            : null;
+
+        if (!ScrubSeekPolicy.ShouldIssueFollowUp(
+                followUpId,
+                Interlocked.Read(ref _lastSeekCommandId),
+                Interlocked.Read(ref _restartAckedSeekCommandId),
+                target,
+                reported))
+        {
+            return;
+        }
+
+        // Claim it, so one settled burst issues one follow-up. Losing the claim means the setter
+        // replaced this id from another thread while we were deciding - that newer seek carries
+        // its own follow-up, and its own restart will ask again.
+        if (Interlocked.CompareExchange(ref _scrubFollowUpSeekId, 0, followUpId) != followUpId)
+        {
+            return;
+        }
+
+        // Generation-tracked like every other seek, so the playhead pin holds for this landing
+        // rather than releasing on the keyframe one.
+        IssueSeek(target, forceExact: true);
+    }
+
+    /// <summary>
+    /// Pays a deferred exact landing now, if one is owed. Called where the position has to be the
+    /// one the user picked before the next thing happens - starting playback or stepping a frame -
+    /// because mpv runs queued commands in order, so the seek lands first. Without this, playback
+    /// could start at the keyframe the burst stopped on, a whole GOP before the chosen frame.
+    /// </summary>
+    private void SettlePendingExactSeek()
+    {
+        var followUpId = Interlocked.Exchange(ref _scrubFollowUpSeekId, 0);
+        if (followUpId == 0 || _disposed || _mpv == IntPtr.Zero)
+        {
+            return;
+        }
+
+        IssueSeek(BitConverter.Int64BitsToDouble(Interlocked.Read(ref _scrubFollowUpTargetBits)), forceExact: true);
+    }
+
+    /// <summary>
+    /// Drops a deferred exact landing, for the paths that discard the position outright - load,
+    /// close, stop. Paths that keep playing from it settle it instead
+    /// (<see cref="SettlePendingExactSeek"/>), and pause deliberately leaves it standing: pausing
+    /// during or right after a scrub is exactly when that landing is still wanted.
+    /// </summary>
+    private void CancelPendingExactSeek()
+    {
+        Interlocked.Exchange(ref _scrubFollowUpSeekId, 0);
     }
 
     private static byte[] GetUtf8Bytes(string s)
@@ -1643,6 +1753,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         }
 
         _pausedValue = null;
+        CancelPendingExactSeek();
 
         // Before loadfile, not after: mpv applies "sid" when the file loads, and setting it
         // afterwards left a window in which an external subtitle pushed by MpvReloader was added
@@ -1746,6 +1857,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
 
     public void PlayOrPause()
     {
+        SettlePendingExactSeek();
         _pausedValue = null;
         EnsureNotDisposed();
         if (_mpv == IntPtr.Zero)
@@ -1769,6 +1881,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         _fileName = string.Empty;
         _pendingLoadFileName = null; // a close discards a load still parked for the core
         _pausedValue = null;
+        CancelPendingExactSeek();
         _audioEndBound = null;
         _lastRawTimePos = -1;
 
@@ -2034,31 +2147,65 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
                 value = 0;
             }
 
-            _pausedValue = value;
-            _lastRawTimePos = value; // keep the eof-reached gate accurate across seeks
-            EnsureNotDisposed();
-            if (_mpv == IntPtr.Zero)
-            {
-                return;
-            }
+            IssueSeek(value, forceExact: false);
+        }
+    }
 
-            // Fire-and-forget: seeks arrive in storms (scrubbing, slider drags, wheel steps -
-            // one per input event) and every caller already treats the result as asynchronous
-            // (the playhead pin waits for the position to actually arrive). The reply id is the
-            // seek's generation marker, so "has this seek restarted yet?" can be answered from
-            // mpv's own event order rather than from two independently taken clock readings.
-            var seekId = Interlocked.Increment(ref _lastSeekCommandId);
-            Interlocked.Exchange(ref _lastSeekIssuedTimestamp, System.Diagnostics.Stopwatch.GetTimestamp());
-            var seekResult = DoMpvCommandFireAndForget(SeekReplyIdBase + (ulong)seekId, out var queuedAsync,
-                "seek", value.ToString(CultureInfo.InvariantCulture), "absolute");
-            if (!queuedAsync || seekResult < 0)
-            {
-                // No MPV_EVENT_COMMAND_REPLY is coming for this one - it ran synchronously, or
-                // mpv refused it - so nothing would ever advance the acknowledged generation and
-                // the seek would look in flight forever. Retire the id here instead.
-                Interlocked.Exchange(ref _ackedSeekCommandId, seekId);
-                Interlocked.Exchange(ref _restartAckedSeekCommandId, seekId);
-            }
+    /// <summary>
+    /// Sends one seek to mpv and records its generation.
+    /// </summary>
+    /// <param name="value">Target position in seconds.</param>
+    /// <param name="forceExact">
+    /// Skip the burst check and demand a precise landing. Used where the position has to be right
+    /// before the next command runs - paying a deferred landing before playback starts or a frame
+    /// is stepped - since mpv runs queued commands in order.
+    /// </param>
+    private void IssueSeek(double value, bool forceExact)
+    {
+        _pausedValue = value;
+        _lastRawTimePos = value; // keep the eof-reached gate accurate across seeks
+        EnsureNotDisposed();
+        if (_mpv == IntPtr.Zero)
+        {
+            return;
+        }
+
+        // A seek arriving while an earlier one is still in flight is a burst - a waveform
+        // drag, a slider drag, a wheel spin, one seek per input event - and all but its last
+        // seek are about to be superseded. Those are served fast, at keyframes, and the exact
+        // landing is deferred to when the burst settles (ScrubSeekPolicy). An isolated seek,
+        // the common case, is exact right away as before.
+        var inBurst = !forceExact && IsSeekInFlight();
+        var seekFlags = ScrubSeekPolicy.FlagsFor(inBurst);
+
+        // Fire-and-forget: seeks arrive in storms (scrubbing, slider drags, wheel steps -
+        // one per input event) and every caller already treats the result as asynchronous
+        // (the playhead pin waits for the position to actually arrive). The reply id is the
+        // seek's generation marker, so "has this seek restarted yet?" can be answered from
+        // mpv's own event order rather than from two independently taken clock readings.
+        var seekId = Interlocked.Increment(ref _lastSeekCommandId);
+        Interlocked.Exchange(ref _lastSeekIssuedTimestamp, System.Diagnostics.Stopwatch.GetTimestamp());
+
+        // Target before id, and both before the command: the event thread reads the id first,
+        // so an id published without its target would point at the previous burst's position.
+        Interlocked.Exchange(ref _scrubFollowUpTargetBits, BitConverter.DoubleToInt64Bits(value));
+        Interlocked.Exchange(ref _scrubFollowUpSeekId, inBurst ? seekId : 0);
+
+        var seekResult = DoMpvCommandFireAndForget(SeekReplyIdBase + (ulong)seekId, out var queuedAsync,
+            "seek", value.ToString(CultureInfo.InvariantCulture), seekFlags);
+        if (!queuedAsync || seekResult < 0)
+        {
+            // No MPV_EVENT_COMMAND_REPLY is coming for this one - it ran synchronously, or
+            // mpv refused it - so nothing would ever advance the acknowledged generation and
+            // the seek would look in flight forever. Retire the id here instead.
+            Interlocked.Exchange(ref _ackedSeekCommandId, seekId);
+            Interlocked.Exchange(ref _restartAckedSeekCommandId, seekId);
+
+            // No restart event is coming either, so nothing would ever issue the deferred
+            // exact seek. (IsSeekInFlight is false without the event loop, so this is only
+            // reachable for a seek mpv refused - but an owed landing that can never be paid
+            // must not be left standing.)
+            Interlocked.Exchange(ref _scrubFollowUpSeekId, 0);
         }
     }
 
@@ -2202,6 +2349,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
     public void Stop()
     {
         _pausedValue = null;
+        CancelPendingExactSeek();
         EnsureNotDisposed();
         if (_mpv == IntPtr.Zero)
         {
@@ -2232,6 +2380,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
 
     public void Play()
     {
+        SettlePendingExactSeek();
         _pausedValue = null;
         EnsureNotDisposed();
         if (_mpv == IntPtr.Zero)
@@ -2293,6 +2442,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
 
     public void StepOneFrameForward()
     {
+        SettlePendingExactSeek();
         _pausedValue = null;
         EnsureNotDisposed();
         if (_mpv == IntPtr.Zero)
@@ -2309,6 +2459,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
 
     public void StepOneFrameBack()
     {
+        SettlePendingExactSeek();
         _pausedValue = null;
         EnsureNotDisposed();
         if (_mpv == IntPtr.Zero)

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/ScrubSeekPolicy.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/ScrubSeekPolicy.cs
@@ -1,0 +1,128 @@
+using System;
+
+namespace Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
+
+/// <summary>
+/// Decides how each seek SE sends to mpv is served: precisely, or fast and then precisely.
+/// <para>
+/// An absolute seek is exact by default (mpv's own rule, and SE also sets "hr-seek=yes"), which
+/// means decoding every frame from the preceding keyframe up to the target - tens to hundreds of
+/// milliseconds on a long-GOP 4K file. That is the right trade for a single click on the waveform.
+/// It is the wrong trade for a drag or a wheel burst, where seeks arrive one per input event and
+/// all but the last one are about to be superseded: paying for an exact landing on a position the
+/// user is already moving away from is what makes scrubbing feel heavy.
+/// </para>
+/// <para>
+/// So a seek issued while an earlier one is still in flight - the signature of a burst - is served
+/// with "keyframes" instead, which skips that decode. Precision is not given up, only deferred:
+/// the keyframe seek is recorded as owing an exact landing, and when the burst settles (that seek
+/// lands and nothing newer has replaced it) one exact seek to the final target is issued. Isolated
+/// seeks never take that path - the first seek of a burst is exact, as before - so nothing that
+/// clicks once behaves differently.
+/// </para>
+/// </summary>
+public static class ScrubSeekPolicy
+{
+    /// <summary>
+    /// mpv seek flags for a precise landing. "absolute" alone already implies "exact"; saying it
+    /// keeps the intent readable and independent of the hr-seek option.
+    /// </summary>
+    public const string ExactSeekFlags = "absolute+exact";
+
+    /// <summary>
+    /// mpv seek flags for a fast landing at the preceding keyframe, used mid-burst.
+    /// </summary>
+    public const string KeyframeSeekFlags = "absolute+keyframes";
+
+    /// <summary>
+    /// How close the keyframe landing has to be to the target to count as already exact. A seek
+    /// whose target happens to be a keyframe lands on it, and re-seeking there would cost a
+    /// decode for no movement.
+    /// </summary>
+    public const double FollowUpToleranceSeconds = 0.001;
+
+    /// <summary>
+    /// How long a seek may be counted as still in flight. Every seek ends in a playback restart,
+    /// but a seek mpv drops - on a core that has stopped, or a file that went away - never gets
+    /// one, and "in flight" would then latch forever: every later seek served at keyframes, each
+    /// deferring an exact landing that no restart is coming to pay. Past this age the seek is
+    /// treated as finished, which puts seeking back on the exact path by itself.
+    /// </summary>
+    public const double MaxSeekInFlightSeconds = 5.0;
+
+    /// <summary>
+    /// The flags for a seek issued now: fast if this one is joining a burst, precise otherwise.
+    /// </summary>
+    public static string FlagsFor(bool seekInFlight)
+    {
+        return seekInFlight ? KeyframeSeekFlags : ExactSeekFlags;
+    }
+
+    /// <summary>
+    /// Whether a seek SE issued is still on its way - the burst signal <see cref="FlagsFor"/>
+    /// keys on.
+    /// </summary>
+    /// <param name="eventLoopActive">
+    /// False when no mpv events are being read. Nothing could pay a deferred landing then, so no
+    /// seek counts as in flight and every seek stays exact.
+    /// </param>
+    /// <param name="lastSeekCommandId">Newest seek id handed out.</param>
+    /// <param name="restartAckedSeekCommandId">Newest seek id mpv has finished a playback restart for.</param>
+    /// <param name="secondsSinceLastSeekIssued">Age of the newest seek.</param>
+    public static bool SeekIsInFlight(
+        bool eventLoopActive,
+        long lastSeekCommandId,
+        long restartAckedSeekCommandId,
+        double secondsSinceLastSeekIssued)
+    {
+        if (!eventLoopActive || lastSeekCommandId == 0)
+        {
+            return false;
+        }
+
+        if (restartAckedSeekCommandId >= lastSeekCommandId)
+        {
+            return false; // it has landed
+        }
+
+        return secondsSinceLastSeekIssued < MaxSeekInFlightSeconds;
+    }
+
+    /// <summary>
+    /// Whether the exact seek owed by a keyframe seek should be issued now.
+    /// </summary>
+    /// <param name="followUpSeekId">Id of the keyframe seek owing an exact landing, 0 if none.</param>
+    /// <param name="lastSeekCommandId">Newest seek id handed out.</param>
+    /// <param name="restartAckedSeekCommandId">Newest seek id mpv has finished a playback restart for.</param>
+    /// <param name="target">Position that keyframe seek was aiming at.</param>
+    /// <param name="reportedPosition">Where mpv says it is now, null if it has no position yet.</param>
+    public static bool ShouldIssueFollowUp(
+        long followUpSeekId,
+        long lastSeekCommandId,
+        long restartAckedSeekCommandId,
+        double target,
+        double? reportedPosition)
+    {
+        if (followUpSeekId == 0)
+        {
+            return false; // nothing owes an exact landing
+        }
+
+        if (followUpSeekId != lastSeekCommandId)
+        {
+            return false; // a newer seek owns the position now, and carries its own follow-up
+        }
+
+        if (restartAckedSeekCommandId < followUpSeekId)
+        {
+            return false; // the burst is still running - a later restart gets to ask again
+        }
+
+        if (reportedPosition == null)
+        {
+            return true; // cannot confirm the landing, so pay for it
+        }
+
+        return Math.Abs(reportedPosition.Value - target) > FollowUpToleranceSeconds;
+    }
+}

--- a/tests/UI/Logic/ScrubSeekPolicyTests.cs
+++ b/tests/UI/Logic/ScrubSeekPolicyTests.cs
@@ -1,0 +1,158 @@
+using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// Two-tier scrub seeking: seeks issued mid-burst are served at keyframes (fast) and the exact
+/// landing is deferred to when the burst settles, so a drag does not pay for an exact seek to
+/// every position it passes through. The precision must always come back - a burst that ends
+/// without its follow-up leaves the video on a keyframe instead of the frame the user picked.
+/// </summary>
+public class ScrubSeekPolicyTests
+{
+    [Fact]
+    public void IsolatedSeek_IsExact()
+    {
+        // The single click on the waveform, and every non-drag seek: unchanged from before.
+        Assert.Equal(ScrubSeekPolicy.ExactSeekFlags, ScrubSeekPolicy.FlagsFor(seekInFlight: false));
+    }
+
+    [Fact]
+    public void SeekDuringAnUnfinishedSeek_IsServedAtKeyframes()
+    {
+        Assert.Equal(ScrubSeekPolicy.KeyframeSeekFlags, ScrubSeekPolicy.FlagsFor(seekInFlight: true));
+    }
+
+    [Fact]
+    public void SeekCountsAsInFlight_UntilItsRestartArrives()
+    {
+        Assert.True(ScrubSeekPolicy.SeekIsInFlight(
+            eventLoopActive: true, lastSeekCommandId: 7, restartAckedSeekCommandId: 6,
+            secondsSinceLastSeekIssued: 0.05));
+
+        Assert.False(ScrubSeekPolicy.SeekIsInFlight(
+            eventLoopActive: true, lastSeekCommandId: 7, restartAckedSeekCommandId: 7,
+            secondsSinceLastSeekIssued: 0.05));
+    }
+
+    [Fact]
+    public void NothingIsInFlight_WithoutTheEventLoop()
+    {
+        // No restarts are read there, so a deferred landing could never be paid - seeks must stay
+        // exact even though this one looks unfinished.
+        Assert.False(ScrubSeekPolicy.SeekIsInFlight(
+            eventLoopActive: false, lastSeekCommandId: 7, restartAckedSeekCommandId: 6,
+            secondsSinceLastSeekIssued: 0.05));
+    }
+
+    [Fact]
+    public void AStuckSeek_StopsCountingAsInFlight()
+    {
+        // A restart that never arrives must not latch scrubbing onto keyframes forever: past the
+        // cap the next seek is exact again, and being exact it also clears any stranded debt.
+        Assert.False(ScrubSeekPolicy.SeekIsInFlight(
+            eventLoopActive: true, lastSeekCommandId: 7, restartAckedSeekCommandId: 6,
+            secondsSinceLastSeekIssued: ScrubSeekPolicy.MaxSeekInFlightSeconds + 1));
+    }
+
+    [Fact]
+    public void NoFollowUp_WhenNothingOwesAnExactLanding()
+    {
+        Assert.False(ScrubSeekPolicy.ShouldIssueFollowUp(
+            followUpSeekId: 0, lastSeekCommandId: 7, restartAckedSeekCommandId: 7,
+            target: 12.0, reportedPosition: 8.0));
+    }
+
+    [Fact]
+    public void NoFollowUp_WhileTheKeyframeSeekIsStillInFlight()
+    {
+        // Its own restart has not arrived, so the burst may well continue - that restart asks again.
+        Assert.False(ScrubSeekPolicy.ShouldIssueFollowUp(
+            followUpSeekId: 7, lastSeekCommandId: 7, restartAckedSeekCommandId: 6,
+            target: 12.0, reportedPosition: 8.0));
+    }
+
+    [Fact]
+    public void NoFollowUp_WhenANewerSeekHasTakenOver()
+    {
+        // Mid-drag: seek 8 already owns the position and carries its own follow-up. Paying seek
+        // 7's landing here would seek back to a position the user has moved away from.
+        Assert.False(ScrubSeekPolicy.ShouldIssueFollowUp(
+            followUpSeekId: 7, lastSeekCommandId: 8, restartAckedSeekCommandId: 7,
+            target: 12.0, reportedPosition: 8.0));
+    }
+
+    [Fact]
+    public void FollowUp_WhenTheBurstHasSettledShortOfTheTarget()
+    {
+        // Mouse released: the last keyframe seek landed at 8.0 but the user asked for 12.0.
+        Assert.True(ScrubSeekPolicy.ShouldIssueFollowUp(
+            followUpSeekId: 7, lastSeekCommandId: 7, restartAckedSeekCommandId: 7,
+            target: 12.0, reportedPosition: 8.0));
+    }
+
+    [Fact]
+    public void NoFollowUp_WhenTheKeyframeLandingAlreadyHitTheTarget()
+    {
+        // The target was a keyframe, so the fast seek was already exact - re-seeking there would
+        // cost a decode for no movement.
+        Assert.False(ScrubSeekPolicy.ShouldIssueFollowUp(
+            followUpSeekId: 7, lastSeekCommandId: 7, restartAckedSeekCommandId: 7,
+            target: 12.0, reportedPosition: 12.0));
+    }
+
+    [Fact]
+    public void FollowUp_WhenTheLandingCannotBeConfirmed()
+    {
+        // mpv has no position to report yet. Skipping here would strand the video on a keyframe,
+        // so an unnecessary exact seek is the cheaper mistake.
+        Assert.True(ScrubSeekPolicy.ShouldIssueFollowUp(
+            followUpSeekId: 7, lastSeekCommandId: 7, restartAckedSeekCommandId: 7,
+            target: 12.0, reportedPosition: null));
+    }
+
+    /// <summary>
+    /// A burst is a sequence, not one decision: the first seek is exact, everything issued while
+    /// a seek is in flight is fast, and the settled end pays exactly one exact landing.
+    /// </summary>
+    [Fact]
+    public void WholeDrag_IsOneExactSeekAtEachEnd()
+    {
+        var flags = new List<string>();
+        long lastId = 0;
+        long restartAcked = 0;
+        long followUpId = 0;
+        var target = 0.0;
+
+        // Mouse down, then eight drag steps arriving faster than mpv can land them.
+        foreach (var position in new[] { 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0 })
+        {
+            var inFlight = ScrubSeekPolicy.SeekIsInFlight(
+                eventLoopActive: true,
+                lastSeekCommandId: lastId,
+                restartAckedSeekCommandId: restartAcked,
+                secondsSinceLastSeekIssued: 0.02); // one drag step apart
+            flags.Add(ScrubSeekPolicy.FlagsFor(inFlight));
+            lastId++;
+            target = position;
+            followUpId = inFlight ? lastId : 0;
+        }
+
+        Assert.Equal(ScrubSeekPolicy.ExactSeekFlags, flags[0]);
+        Assert.All(flags.Skip(1), f => Assert.Equal(ScrubSeekPolicy.KeyframeSeekFlags, f));
+
+        // Mouse up. The last keyframe seek lands on its keyframe, 3.6 s short of the target.
+        restartAcked = lastId;
+        Assert.True(ScrubSeekPolicy.ShouldIssueFollowUp(followUpId, lastId, restartAcked, target, 8.4));
+
+        // That follow-up goes out as an exact seek and clears the debt, so its own restart - and
+        // any later one - does not start the cycle over.
+        var followUpFlags = ScrubSeekPolicy.FlagsFor(seekInFlight: false);
+        followUpId = 0;
+        lastId++;
+        restartAcked = lastId;
+
+        Assert.Equal(ScrubSeekPolicy.ExactSeekFlags, followUpFlags);
+        Assert.False(ScrubSeekPolicy.ShouldIssueFollowUp(followUpId, lastId, restartAcked, target, target));
+    }
+}


### PR DESCRIPTION
Follow-up to the seek analysis in #14330 (and independent of #14370).

## The trade being made

An absolute seek is exact — mpv's default for `absolute` seeks, and SE also sets `hr-seek=yes` — so every seek decodes from the preceding keyframe up to the target. That is right for a single click on the waveform, and wrong during a drag: seeks arrive one per input event, all but the last are superseded before anyone sees them, and the exact decode is paid for positions the user is already moving away from. On long-GOP 4K that is what makes scrubbing feel heavy.

So a seek issued **while an earlier one is still in flight** — the signature of a burst — is served with `absolute+keyframes`, which skips the decode. Precision is deferred, not dropped: that seek is recorded as owing an exact landing, and the playback restart it fires asks whether the burst has settled (it landed, nothing newer replaced it). If so, one exact seek to the final target goes out.

The first seek of a burst, and every isolated seek, stays exact. A single click behaves exactly as before.

## Where the owed landing goes

The paths that end a burst are split by what they do with the position:

- **Play / PlayOrPause / frame steps — settle it first.** mpv runs queued commands in order, so the exact seek lands before playback starts. Without this, playback could begin at the keyframe the burst stopped on, up to a whole GOP before the chosen frame.
- **Load / close / stop — cancel it.** The position has been thrown away; seeking back to it would fight the caller.
- **Pause — leave it standing.** Pausing during or right after a scrub is exactly when that landing is still wanted.

## Two ordering details

- **The follow-up state is published before the seek command.** mpv can serve a keyframe seek and post its restart while the setter is still running; a debt recorded after that would wait for a restart that has already been and gone.
- **"In flight" expires after 5 s.** Every seek ends in a restart, but one mpv drops never gets one. Without the cap that latches scrubbing onto keyframes forever, with a debt nothing can pay. Past the cap the next seek is exact again, and being exact it also clears the stranded debt.

## Tests

The decisions live in `ScrubSeekPolicy` as pure functions over the seek generations the player already tracks (`_lastSeekCommandId` / `_restartAckedSeekCommandId`), so the whole burst sequence is testable without a video: first seek exact, the rest at keyframes, exactly one exact landing at the settled end, no follow-up while a newer seek owns the position, no follow-up when the keyframe landing already hit the target, and the stuck-seek cap.

Full UI suite: 4500 passed, 1 skipped. (One unrelated flake on the first run — `CrispAsrTtsProvenanceTests.RealHelpProbe_WithLargeStderrAndEmptyStdout_DoesNotDeadlock`, which spawns a real helper process; it passes in isolation and on re-runs of the full suite.)

## Worth testing by hand

This changes how seeking feels, and no test here drives a real video: dragging on the waveform and the position slider, wheel scrubbing, holding a next/previous-subtitle shortcut, and then confirming the frame is right where you let go — especially on a long-GOP file where the difference is visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)