### PR TITLE
seconv: add the full frame image export option

### DIFF
--- a/docs/reference/command-line.md
+++ b/docs/reference/command-line.md
@@ -183,8 +183,12 @@ When rendering a text subtitle to an image-based target (Blu-Ray `sup`, VobSub, 
 | `--content-alignment:<align>` | Multi-line text justification: `left` \| `center` (default) \| `right` \| `from-alignment` (follow the `{\anX}` tag) |
 | `--bottom-top-margin:<px>` | Vertical screen-edge margin (default: 5% of height) |
 | `--left-right-margin:<px>` | Horizontal screen-edge margin (default: 5% of width) |
+| `--full-frame` | Draw each subtitle onto a frame-sized image instead of one cropped to the text. Only `fcpimage` and `bluraysup` use it; other image targets warn and ignore it |
+| `--full-frame-background-color:<color>` | Background of the full frame image (default: `transparent`) |
 
 Colours accept hex (`#AARRGGBB`, `#RRGGBB`, with or without `#`) or a colour name (`white`, `black`, `yellow`, ...).
+
+**Full frame** (`--full-frame`) draws the subtitle onto a canvas the size of the video frame, using the alignment and margins to place it there, so every image can be dropped on an editing timeline at 0,0 instead of being positioned one by one. It matches the "Full frame image" checkbox in the export dialog, and applies to `fcpimage` and `bluraysup` only. The background is transparent unless `--full-frame-background-color` says otherwise, so the images sit on a track above the video.
 
 ```bash
 # SRT → UHD Blu-Ray sup with a semi-transparent black background box (SE4-style)
@@ -192,6 +196,9 @@ seconv movie.srt bluraysup --resolution:3840x2160 --background-color:"#B4000000"
 
 # Custom font, bold, box per line
 seconv movie.srt bluraysup --font-name:Verdana --font-size:60 --font-bold --box-type:box-per-line
+
+# Final Cut Pro + image, one frame-sized png per subtitle
+seconv movie.srt fcpimage --full-frame
 ```
 
 ### Containers / tracks
@@ -512,6 +519,8 @@ The keys and defaults below are exactly what `dump-settings` emits:
     "boxPaddingTop": 3,
     "boxPaddingBottom": 3,
     "lineSpacingPercent": 0,
+    "isFullFrame": false,
+    "fullFrameBackgroundColor": "#00FFFFFF",
     "alignment": "bottom-center",
     "contentAlignment": "center",
     "bottomTopMargin": 54,

--- a/src/seconv/Commands/ConvertCommand.cs
+++ b/src/seconv/Commands/ConvertCommand.cs
@@ -281,6 +281,14 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
         [Description("Image output: horizontal screen-edge margin in pixels (default: 5% of width)")]
         public int? LeftRightMargin { get; init; }
 
+        [CommandOption("--full-frame|--fullframe")]
+        [Description("Image output: draw each subtitle on a frame-sized image (place at 0,0 in an editing timeline). Only fcpimage and bluraysup use it")]
+        public bool FullFrame { get; init; }
+
+        [CommandOption("--full-frame-background-color|--fullframebackgroundcolor")]
+        [Description("Image output: background of the full frame image (default: transparent)")]
+        public string? FullFrameBackgroundColor { get; init; }
+
         [CommandOption("--teletext-only|--teletextonly")]
         [Description("Teletext only")]
         public bool TeletextOnly { get; init; }
@@ -1184,6 +1192,20 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
         if (settings.LeftRightMargin.HasValue)
         {
             style.LeftRightMargin = settings.LeftRightMargin.Value;
+        }
+
+        if (settings.FullFrame)
+        {
+            style.IsFullFrame = true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(settings.FullFrameBackgroundColor))
+        {
+            if (!ImageExportStyle.TryParseColor(settings.FullFrameBackgroundColor, out var fullFrameBackgroundColor))
+            {
+                return $"Unknown colour '{settings.FullFrameBackgroundColor}' for --full-frame-background-color.";
+            }
+            style.FullFrameBackgroundColor = fullFrameBackgroundColor;
         }
 
         return null;

--- a/src/seconv/Core/ImageExportStyle.cs
+++ b/src/seconv/Core/ImageExportStyle.cs
@@ -40,6 +40,20 @@ internal sealed class ImageExportStyle
     /// <summary>Extra gap between lines as percent of line height. 0 = single spacing (matches the GUI export default).</summary>
     public int LineSpacingPercent { get; set; }
 
+    /// <summary>
+    /// Draw each subtitle onto a frame-sized canvas instead of a bitmap cropped to the text,
+    /// so every image can be placed at 0,0 in an editing timeline. Only the FCP and Blu-Ray sup
+    /// handlers act on it (<see cref="FullFrameImage"/>); the other image formats ignore it.
+    /// </summary>
+    public bool IsFullFrame { get; set; }
+
+    /// <summary>
+    /// Background of the frame-sized image made when <see cref="IsFullFrame"/> is set. Separate
+    /// from <see cref="BackgroundColor"/>, which is the box behind the text - transparent by
+    /// default, because the images normally go on a track above the video.
+    /// </summary>
+    public SKColor FullFrameBackgroundColor { get; set; } = SKColors.Transparent;
+
     public ExportAlignment Alignment { get; set; } = ExportAlignment.BottomCenter;
     public ExportContentAlignment ContentAlignment { get; set; } = ExportContentAlignment.Center;
 

--- a/src/seconv/Core/ImageOutputWriter.cs
+++ b/src/seconv/Core/ImageOutputWriter.cs
@@ -173,7 +173,8 @@ internal static class ImageOutputWriter
             FramesPerSecond = options.TargetFps ?? options.Fps ?? 25.0,
             IsRightToLeft = false,
             IsForced = false,
-            IsFullFrame = false,
+            IsFullFrame = style.IsFullFrame,
+            FullFrameBackgroundColor = style.FullFrameBackgroundColor,
             Error = string.Empty,
         };
     }
@@ -220,7 +221,10 @@ internal static class ImageOutputWriter
             FramesPerSecond = options.TargetFps ?? options.Fps ?? 25.0,
             IsRightToLeft = false,
             IsForced = false,
-            IsFullFrame = false,
+            // "Full frame" pads the cropped bitmap out to the video frame - only the FCP and
+            // Blu-Ray sup handlers act on it, the rest ignore it (SubtitleConverter warns).
+            IsFullFrame = style.IsFullFrame,
+            FullFrameBackgroundColor = style.FullFrameBackgroundColor,
             Error = string.Empty,
         };
 

--- a/src/seconv/Core/SeConvSettings.cs
+++ b/src/seconv/Core/SeConvSettings.cs
@@ -135,6 +135,8 @@ internal sealed class SeConvSettings
                 BoxPaddingTop = style.BoxPaddingTop,
                 BoxPaddingBottom = style.BoxPaddingBottom,
                 LineSpacingPercent = style.LineSpacingPercent,
+                IsFullFrame = style.IsFullFrame,
+                FullFrameBackgroundColor = ToHex(style.FullFrameBackgroundColor),
                 Alignment = style.Alignment.ToString(),
                 ContentAlignment = style.ContentAlignment.ToString(),
                 // BottomTopMargin / LeftRightMargin left unset: their default is "5% of the
@@ -406,6 +408,8 @@ internal sealed class SeConvSettings
         public int? BoxPaddingTop { get; set; }
         public int? BoxPaddingBottom { get; set; }
         public int? LineSpacingPercent { get; set; }
+        public bool? IsFullFrame { get; set; }
+        public string? FullFrameBackgroundColor { get; set; }
         public string? Alignment { get; set; }
         public string? ContentAlignment { get; set; }
         public int? BottomTopMargin { get; set; }
@@ -448,6 +452,10 @@ internal sealed class SeConvSettings
                 style.BoxPaddingBottom = BoxPaddingBottom.Value;
             if (LineSpacingPercent.HasValue)
                 style.LineSpacingPercent = LineSpacingPercent.Value;
+            if (IsFullFrame.HasValue)
+                style.IsFullFrame = IsFullFrame.Value;
+            if (!string.IsNullOrWhiteSpace(FullFrameBackgroundColor) && ImageExportStyle.TryParseColor(FullFrameBackgroundColor, out var fullFrameBackgroundColor))
+                style.FullFrameBackgroundColor = fullFrameBackgroundColor;
             if (!string.IsNullOrWhiteSpace(Alignment) && ImageExportStyle.TryParseAlignment(Alignment, out var alignment))
                 style.Alignment = alignment;
             if (!string.IsNullOrWhiteSpace(ContentAlignment) && ImageExportStyle.TryParseContentAlignment(ContentAlignment, out var contentAlignment))

--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -1,5 +1,6 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.UiLogic.Export;
 using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 using Spectre.Console;
 
@@ -17,6 +18,31 @@ internal class SubtitleConverter
     // one mkv would otherwise silently overwrite each other).
     private readonly HashSet<string> _usedOutputFileNames = new(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>
+    /// "Full frame" reaches only <see cref="ExportHandlerFcp"/> and
+    /// <see cref="ExportHandlerBluRaySup"/>; the other image handlers ignore
+    /// <see cref="ImageParameter.IsFullFrame"/> and write the cropped bitmap. Silently doing
+    /// nothing is worse on a command line than in the export dialog - the setting often comes
+    /// from a shared --settings profile - so say it was dropped (issue #14376). A text target
+    /// ignores every image styling option, not just this one, so it warns for image targets only.
+    /// </summary>
+    private static void WarnIfFullFrameIgnored(ConversionOptions options, ConversionResult result)
+    {
+        if (!options.ImageStyle.IsFullFrame)
+        {
+            return;
+        }
+
+        var handler = ImageOutputWriter.TryCreateHandler(LibSEIntegration.NormalizeFormatName(options.Format));
+        if (handler is null || handler.ExportImageType is ExportImageType.Fcp or ExportImageType.BluRaySup)
+        {
+            return;
+        }
+
+        result.Warnings.Add(
+            $"Full frame image is not supported by '{options.Format}' and was ignored - it applies to fcpimage and bluraysup.");
+    }
+
     public async Task<ConversionResult> ConvertAsync(ConversionOptions options)
     {
         var result = new ConversionResult();
@@ -28,6 +54,8 @@ internal class SubtitleConverter
             {
                 _translateRunner = AutoTranslateRunner.Create(options);
             }
+
+            WarnIfFullFrameIgnored(options, result);
 
             // Get input files
             var inputFiles = GetInputFiles(options);

--- a/src/seconv/Helpers/HelpDisplay.cs
+++ b/src/seconv/Helpers/HelpDisplay.cs
@@ -110,6 +110,8 @@ internal static class HelpDisplay
         ShowParameter(console, "--content-alignment:<mode>", "Multi-line text justification: left | center (default) | right | from-alignment");
         ShowParameter(console, "--bottom-top-margin:<px>", "Vertical screen-edge margin in pixels (default: 5% of height)");
         ShowParameter(console, "--left-right-margin:<px>", "Horizontal screen-edge margin in pixels (default: 5% of width)");
+        ShowParameter(console, "--full-frame", "Draw each subtitle on a frame-sized image (place at 0,0 in an editing timeline); only fcpimage and bluraysup");
+        ShowParameter(console, "--full-frame-background-color:<colour>", "Background of the full frame image (default: transparent)");
 
         console.WriteLine();
         console.MarkupLine("[bold cyan]Operations:[/]");

--- a/tests/seconv/Core/FullFrameImageExportTest.cs
+++ b/tests/seconv/Core/FullFrameImageExportTest.cs
@@ -1,0 +1,225 @@
+using Nikse.SubtitleEdit.Core.BluRaySup;
+using SeConv.Core;
+using SkiaSharp;
+using System.Text;
+using Xunit;
+
+namespace SeConvTests.Core;
+
+/// <summary>
+/// "Full frame image" in seconv (issue #14376): the subtitle is drawn onto a canvas the size of
+/// the video frame instead of a bitmap cropped to the text, so every image can be placed at 0,0
+/// in an editing timeline. Only the FCP and Blu-Ray sup handlers act on it; the rest warn.
+/// </summary>
+public class FullFrameImageExportTest : IDisposable
+{
+    private const int ScreenWidth = 1920;
+    private const int ScreenHeight = 1080;
+
+    private readonly string _tempRoot;
+
+    public FullFrameImageExportTest()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "FullFrame_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempRoot);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempRoot))
+        {
+            Directory.Delete(_tempRoot, recursive: true);
+        }
+    }
+
+    private const string SrtContent = """
+        1
+        00:00:01,000 --> 00:00:04,000
+        Hello, World!
+
+        """;
+
+    private async Task<ConversionResult> Convert(string format, string outFolderName, ImageExportStyle style)
+    {
+        var input = Path.Combine(_tempRoot, outFolderName + ".srt");
+        await File.WriteAllTextAsync(input, SrtContent, TestContext.Current.CancellationToken);
+        var outFolder = Path.Combine(_tempRoot, outFolderName);
+        Directory.CreateDirectory(outFolder);
+
+        var converter = new SubtitleConverter();
+        var result = await converter.ConvertAsync(new ConversionOptions
+        {
+            Patterns = [input],
+            Format = format,
+            OutputFolder = outFolder,
+            Overwrite = true,
+            Resolution = (ScreenWidth, ScreenHeight),
+            ImageStyle = style,
+        });
+
+        Assert.True(result.Success, string.Join("; ", result.Errors));
+        return result;
+    }
+
+    private string[] PngsIn(string outFolderName) =>
+        Directory.GetFiles(Path.Combine(_tempRoot, outFolderName), "*.png", SearchOption.AllDirectories);
+
+    [Fact]
+    public async Task FcpImage_FullFrame_WritesFrameSizedPngs()
+    {
+        await Convert("fcpimage", "fcpfull", new ImageExportStyle { IsFullFrame = true });
+
+        var png = Assert.Single(PngsIn("fcpfull"));
+        using var bitmap = SKBitmap.Decode(png);
+        Assert.Equal(ScreenWidth, bitmap.Width);
+        Assert.Equal(ScreenHeight, bitmap.Height);
+    }
+
+    [Fact]
+    public async Task FcpImage_WithoutFullFrame_WritesCroppedPngs()
+    {
+        // The other half of the pair: without the option the png stays cropped to the text,
+        // which is what the xmeml's frame-sized <width>/<height> is measured against.
+        await Convert("fcpimage", "fcpcrop", new ImageExportStyle());
+
+        var png = Assert.Single(PngsIn("fcpcrop"));
+        using var bitmap = SKBitmap.Decode(png);
+        Assert.True(bitmap.Width < ScreenWidth, $"expected a cropped bitmap, got {bitmap.Width}x{bitmap.Height}");
+        Assert.True(bitmap.Height < ScreenHeight, $"expected a cropped bitmap, got {bitmap.Width}x{bitmap.Height}");
+    }
+
+    [Fact]
+    public async Task FcpImage_FullFrame_DefaultBackgroundIsTransparent()
+    {
+        await Convert("fcpimage", "fcpalpha", new ImageExportStyle { IsFullFrame = true });
+
+        var png = Assert.Single(PngsIn("fcpalpha"));
+        using var bitmap = SKBitmap.Decode(png);
+
+        // SKColors.Transparent is #00FFFFFF, but a cleared premultiplied bitmap reads
+        // #00000000 - so assert on the alpha channel, not on colour equality.
+        Assert.Equal(0, bitmap.GetPixel(0, 0).Alpha);
+        Assert.Equal(0, bitmap.GetPixel(ScreenWidth - 1, ScreenHeight - 1).Alpha);
+    }
+
+    [Fact]
+    public async Task FcpImage_FullFrameBackgroundColor_PaintsTheWholeFrame()
+    {
+        Assert.True(ImageExportStyle.TryParseColor("#FF0000FF", out var opaqueBlue));
+        await Convert("fcpimage", "fcpbg", new ImageExportStyle
+        {
+            IsFullFrame = true,
+            FullFrameBackgroundColor = opaqueBlue,
+        });
+
+        var png = Assert.Single(PngsIn("fcpbg"));
+        using var bitmap = SKBitmap.Decode(png);
+
+        var corner = bitmap.GetPixel(0, 0);
+        Assert.Equal(255, corner.Alpha);
+        Assert.Equal(0, corner.Red);
+        Assert.Equal(0, corner.Green);
+        Assert.Equal(255, corner.Blue);
+    }
+
+    [Fact]
+    public async Task FcpImage_FullFrameBackgroundColor_DoesNotFollowTheTextBoxColour()
+    {
+        // The full frame background is its own field: reusing --background-color (the box behind
+        // the text) would paint the whole frame instead of the box.
+        Assert.True(ImageExportStyle.TryParseColor("#FF000000", out var black));
+        await Convert("fcpimage", "fcpboxonly", new ImageExportStyle
+        {
+            IsFullFrame = true,
+            BackgroundColor = black,
+        });
+
+        var png = Assert.Single(PngsIn("fcpboxonly"));
+        using var bitmap = SKBitmap.Decode(png);
+        Assert.Equal(0, bitmap.GetPixel(0, 0).Alpha);
+    }
+
+    [Fact]
+    public async Task BluRaySup_FullFrame_SubtitleIsInAFrameSizedImageAtOrigin()
+    {
+        await Convert("bluraysup", "supfull", new ImageExportStyle { IsFullFrame = true });
+
+        var supFile = Assert.Single(Directory.GetFiles(Path.Combine(_tempRoot, "supfull"), "*.sup"));
+        var subtitle = Assert.Single(BluRaySupParser.ParseBluRaySup(supFile, new StringBuilder()));
+
+        var position = subtitle.GetPosition();
+        Assert.Equal(0, position.Left);
+        Assert.Equal(0, position.Top);
+
+        using var bitmap = subtitle.GetBitmap();
+        Assert.Equal(ScreenWidth, bitmap.Width);
+        Assert.Equal(ScreenHeight, bitmap.Height);
+
+        // The text is really inside the frame, near the bottom - not a blank full frame.
+        Assert.True(HasVisiblePixels(bitmap, ScreenHeight / 2, ScreenHeight), "no drawn pixels in the lower half of the full frame image");
+        Assert.False(HasVisiblePixels(bitmap, 0, ScreenHeight / 2), "bottom-center text should not reach the upper half");
+    }
+
+    [Fact]
+    public async Task BluRaySup_WithoutFullFrame_KeepsTheCroppedPlacement()
+    {
+        await Convert("bluraysup", "supcrop", new ImageExportStyle());
+
+        var supFile = Assert.Single(Directory.GetFiles(Path.Combine(_tempRoot, "supcrop"), "*.sup"));
+        var subtitle = Assert.Single(BluRaySupParser.ParseBluRaySup(supFile, new StringBuilder()));
+
+        using var bitmap = subtitle.GetBitmap();
+        Assert.True(bitmap.Width < ScreenWidth, $"expected a cropped bitmap, got {bitmap.Width}x{bitmap.Height}");
+        Assert.True(subtitle.GetPosition().Top > ScreenHeight / 2, "a cropped bottom-center line is placed low in the frame");
+    }
+
+    [Fact]
+    public async Task BdnXml_FullFrame_WarnsAndWritesCroppedPngs()
+    {
+        // Only FCP and Blu-Ray sup implement it - the other image handlers would silently write
+        // cropped images, which on a command line (often from a shared --settings profile) is
+        // worth a word.
+        var result = await Convert("bdnxml", "bdnfull", new ImageExportStyle { IsFullFrame = true });
+
+        Assert.Contains(result.Warnings, w => w.Contains("Full frame image is not supported", StringComparison.Ordinal));
+
+        var png = Assert.Single(PngsIn("bdnfull"));
+        using var bitmap = SKBitmap.Decode(png);
+        Assert.True(bitmap.Width < ScreenWidth, "bdnxml ignores full frame");
+    }
+
+    [Fact]
+    public async Task BluRaySupAndFcp_FullFrame_DoNotWarn()
+    {
+        var sup = await Convert("bluraysup", "supquiet", new ImageExportStyle { IsFullFrame = true });
+        Assert.DoesNotContain(sup.Warnings, w => w.Contains("Full frame", StringComparison.Ordinal));
+
+        var fcp = await Convert("fcpimage", "fcpquiet", new ImageExportStyle { IsFullFrame = true });
+        Assert.DoesNotContain(fcp.Warnings, w => w.Contains("Full frame", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task TextTarget_FullFrame_DoesNotWarn()
+    {
+        // A text target ignores every image styling option, not just this one; warning about a
+        // settings profile's isFullFrame on every srt run would be noise.
+        var result = await Convert("subrip", "srtout", new ImageExportStyle { IsFullFrame = true });
+        Assert.Empty(result.Warnings);
+    }
+
+    private static bool HasVisiblePixels(SKBitmap bitmap, int fromY, int toY)
+    {
+        for (var y = fromY; y < toY; y++)
+        {
+            for (var x = 0; x < bitmap.Width; x++)
+            {
+                if (bitmap.GetPixel(x, y).Alpha > 0)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/seconv/Core/SeConvSettingsTest.cs
+++ b/tests/seconv/Core/SeConvSettingsTest.cs
@@ -260,6 +260,36 @@ public class SeConvSettingsTest : IDisposable
     }
 
     [Fact]
+    public void ApplyExportImages_FullFrameKeysApplied()
+    {
+        var path = WriteSettings("""
+            {
+              "exportImages": {
+                "isFullFrame": true,
+                "fullFrameBackgroundColor": "#FF0000FF"
+              }
+            }
+            """);
+
+        var style = new SeConv.Core.ImageExportStyle();
+        SeConvSettings.Load(path).ApplyExportImages(style);
+
+        Assert.True(style.IsFullFrame);
+        Assert.Equal(255, style.FullFrameBackgroundColor.Alpha);
+        Assert.Equal(255, style.FullFrameBackgroundColor.Blue);
+        // The box behind the text is a separate colour and must not follow the frame background.
+        Assert.Equal(SkiaSharp.SKColors.Transparent, style.BackgroundColor);
+    }
+
+    [Fact]
+    public void ApplyExportImages_FullFrameDefaultsAreOffAndTransparent()
+    {
+        var style = new SeConv.Core.ImageExportStyle();
+        Assert.False(style.IsFullFrame);
+        Assert.Equal(0, style.FullFrameBackgroundColor.Alpha);
+    }
+
+    [Fact]
     public void ApplyExportImages_ProfileOverlaysOnTopOfBase()
     {
         var path = WriteSettings("""


### PR DESCRIPTION
Fixes #14376

The GUI's "Full frame image" checkbox had no command line equivalent. The plumbing was all there — `ExportHandlerFcp` and `ExportHandlerBluRaySup` already act on `ImageParameter.IsFullFrame` via `FullFrameImage.Create` — but `seconv` hardcoded `IsFullFrame = false` in both `ImageOutputWriter` paths, so nothing could ever turn it on.

## What's new

```bash
seconv movie.srt fcpimage --full-frame
```

Each subtitle is drawn onto a canvas the size of the video frame, at the position the alignment and margins give it, so every image can be dropped on an editing timeline at 0,0 instead of being placed one by one.

- `--full-frame` / `--fullframe`
- `--full-frame-background-color:<colour>` — the frame background is its own field, transparent by default. Reusing `--background-color` (the box behind the text) would paint the whole frame.
- `exportImages` keys `isFullFrame` and `fullFrameBackgroundColor`, so a `--settings` profile carries them like the GUI profile does; both appear in `dump-settings` and round-trip through `Load`.

`fcpimage` keeps the option **off** by default.

## The warning

Only FCP and Blu-ray sup implement full frame; the other image handlers write the cropped bitmap. A silent no-op is worse on a command line than in the export dialog — the setting often arrives from a shared `--settings` profile — so an image target that ignores it now says so once per run, before any file is written:

```
⚠ Conversion completed with warnings
Warnings:
  • Full frame image is not supported by 'bdnxml' and was ignored - it applies to fcpimage and bluraysup.
```

Text targets do not warn: they ignore every image styling option, not just this one, so warning there would be noise on every `srt` run.

## Worth knowing

`ExportHandlerFcp` writes every still's `<width>`/`<height>` as the *frame* size unconditionally, while `ImageRenderer` returns a bitmap cropped to the text. So without full frame, FCP output pairs a cropped PNG with an xmeml that claims it is 1920x1080. This PR does not change that default (as decided), but `--full-frame` is the combination that makes FCP output geometrically correct.

## Verification

10 new tests in `tests/seconv/Core/FullFrameImageExportTest.cs`, plus two in `SeConvSettingsTest`. Full seconv suite: 467 passing.

- FCP with the flag writes a 1920x1080 PNG; without it, a cropped one — the pair that pins the size mismatch above.
- Blu-ray round-trips through `BluRaySupParser`: position 0,0, bitmap exactly frame-sized, drawn pixels in the lower half and none in the upper half (a real subtitle, not a blank frame).
- Frame background defaults to alpha 0 — asserted on `.Alpha`, since a cleared premultiplied bitmap reads `#00000000` rather than `SKColors.Transparent`'s `#00FFFFFF` — and `--background-color` alone leaves the frame corner transparent.
- Unsupported target warns and still writes cropped images; supported targets and text targets stay quiet.

Also exercised end to end from the CLI: the flag, the warning, and `--full-frame-background-color:nosuchcolour` → `Error: Unknown colour ...`.

Docs updated in `docs/reference/command-line.md` (table rows, what full frame is for, an `fcpimage` example, and the settings JSON keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)