### PR TITLE
Export the error list to clipboard, text, Excel, and html

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -3819,6 +3819,12 @@
     "detailGapToPrevious": "to previous: {0} < {1} ms",
     "detailGapToNext": "to next: {0} < {1} ms",
     "detail": "Detail",
-    "tip": "Double-click a line (or press Enter) to go to it. Which checks run, and their limits, are set in Settings > General."
+    "tip": "Double-click a line (or press Enter) to go to it. Which checks run, and their limits, are set in Settings > General.",
+    "exportAsText": "Text file (.txt)...",
+    "exportAsExcel": "Excel file (.xlsx)...",
+    "exportAsHtml": "Web page (.html)...",
+    "exportFileX": "File: {0}",
+    "exportGeneratedX": "Generated: {0}",
+    "exportMadeWithSubtitleEdit": "Made with Subtitle Edit"
   }
 }

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -13010,7 +13010,7 @@ public partial class MainViewModel :
             }
         }
 
-        var result = await ShowDialogAsync<ErrorListWindow, ErrorListViewModel>(vm => { vm.Initialize(list, Subtitles.Count); });
+        var result = await ShowDialogAsync<ErrorListWindow, ErrorListViewModel>(vm => { vm.Initialize(list, Subtitles.Count, _subtitleFileName); });
 
         if (result.GoToPressed && result.SelectedSubtitle != null)
         {

--- a/src/ui/Features/Shared/ErrorList/ErrorListExport.cs
+++ b/src/ui/Features/Shared/ErrorList/ErrorListExport.cs
@@ -1,0 +1,407 @@
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Nikse.SubtitleEdit.Features.Shared.ErrorList;
+
+/// <summary>
+/// Turns the rows of "List errors" into something that can leave the window: the clipboard,
+/// a plain text log, an Excel workbook, or a stand-alone html page (#14379 - the list had to
+/// be screenshotted to be shared or handed to an AI).
+/// <para>
+/// Every writer takes the rows exactly as the window shows them, so an active summary-card
+/// filter is part of what is exported.
+/// </para>
+/// </summary>
+public static class ErrorListExport
+{
+    /// <summary>Tab separated with a header row - what the clipboard gets, and what Excel/Sheets paste as columns.</summary>
+    public static string ToTabSeparated(IEnumerable<ErrorListItem> items)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine(string.Join("\t", Headers()));
+        foreach (var item in items)
+        {
+            sb.AppendLine(string.Join("\t", Cells(item).Select(CleanForTabSeparated)));
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// A readable log: a short header, then two lines per error - the time code and the error on
+    /// the first, the subtitle text on the second. Meant to be pasted into a mail, an issue, or
+    /// a prompt.
+    /// </summary>
+    public static string ToPlainText(IEnumerable<ErrorListItem> items, string summary, string? subtitleFileName)
+    {
+        var l = Se.Language.ErrorList;
+        var sb = new StringBuilder();
+        sb.AppendLine(l.Title);
+        if (!string.IsNullOrEmpty(subtitleFileName))
+        {
+            sb.AppendLine(string.Format(l.ExportFileX, subtitleFileName));
+        }
+
+        sb.AppendLine(string.Format(l.ExportGeneratedX, Now()));
+        sb.AppendLine(summary);
+        sb.AppendLine();
+
+        foreach (var item in items)
+        {
+            sb.AppendLine($"#{item.Number}  {item.Show} --> {item.Hide}  {item.Category}: {item.Detail}");
+            sb.AppendLine("    " + item.Text);
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>The same rows as an .xlsx workbook - see <see cref="XlsxWriter"/> for why not csv.</summary>
+    public static byte[] ToXlsx(IEnumerable<ErrorListItem> items)
+    {
+        var rows = items.Select(item => (IReadOnlyList<object?>)new object?[]
+        {
+            item.Number,
+            item.Category,
+            item.Show,
+            item.Hide,
+            item.Detail,
+            item.Text,
+        });
+
+        return XlsxWriter.Create(Se.Language.ErrorList.Title, Headers(), rows, new double[] { 6, 20, 14, 14, 26, 80 });
+    }
+
+    /// <summary>
+    /// A stand-alone page - no scripts, no web fonts, nothing to load - that follows the
+    /// reader's light/dark preference and paints the error classes in the same colours as the
+    /// window. The summary cards become filter chips backed by <c>:checked</c> radios, so the
+    /// page filters without a line of JavaScript.
+    /// </summary>
+    public static string ToHtml(IEnumerable<ErrorListItem> items, string summary, string? subtitleFileName)
+    {
+        var l = Se.Language.ErrorList;
+        var list = items.ToList();
+        var title = string.IsNullOrEmpty(subtitleFileName)
+            ? l.Title
+            : l.Title + " - " + Path.GetFileName(subtitleFileName);
+
+        var sb = new StringBuilder();
+        sb.AppendLine("<!DOCTYPE html>");
+        sb.AppendLine("<html lang=\"en\">");
+        sb.AppendLine("<head>");
+        sb.AppendLine("<meta charset=\"utf-8\">");
+        sb.AppendLine("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">");
+        sb.AppendLine("<meta name=\"color-scheme\" content=\"light dark\">");
+        sb.AppendLine("<title>" + Encode(title) + "</title>");
+        sb.AppendLine("<style>");
+        sb.AppendLine(Css);
+        sb.AppendLine("</style>");
+        sb.AppendLine("</head>");
+        sb.AppendLine("<body>");
+        sb.AppendLine("<main>");
+
+        sb.AppendLine("<header>");
+        sb.AppendLine("  <h1>" + Encode(l.Title) + "</h1>");
+        sb.AppendLine("  <p class=\"summary\">" + Encode(summary) + "</p>");
+        sb.AppendLine("  <p class=\"meta\">");
+        if (!string.IsNullOrEmpty(subtitleFileName))
+        {
+            sb.AppendLine("    <span>" + Encode(string.Format(l.ExportFileX, subtitleFileName)) + "</span>");
+        }
+
+        sb.AppendLine("    <span>" + Encode(string.Format(l.ExportGeneratedX, Now())) + "</span>");
+        sb.AppendLine("  </p>");
+        sb.AppendLine("</header>");
+
+        AppendChips(sb, list, l.All);
+        AppendTable(sb, list);
+
+        sb.AppendLine("<footer>" + Encode(l.ExportMadeWithSubtitleEdit) + "</footer>");
+        sb.AppendLine("</main>");
+        sb.AppendLine("</body>");
+        sb.AppendLine("</html>");
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// One radio per error class in front of the table: checking it hides the rows of the other
+    /// classes through the sibling selectors in <see cref="Css"/>. Classes with no rows are left out.
+    /// </summary>
+    private static void AppendChips(StringBuilder sb, IReadOnlyList<ErrorListItem> items, string allLabel)
+    {
+        sb.AppendLine("<input type=\"radio\" name=\"f\" id=\"f-all\" checked>");
+        foreach (var type in Enum.GetValues<LineErrorType>())
+        {
+            if (items.Any(p => p.Type == type))
+            {
+                sb.AppendLine("<input type=\"radio\" name=\"f\" id=\"f-" + (int)type + "\">");
+            }
+        }
+
+        sb.AppendLine("<nav class=\"chips\">");
+        sb.AppendLine("  <label class=\"chip\" for=\"f-all\"><i style=\"background:" + LineError.AllColor + "\"></i>" +
+                      Encode(allLabel) + "<b>" + items.Count + "</b></label>");
+        foreach (var type in Enum.GetValues<LineErrorType>())
+        {
+            var count = items.Count(p => p.Type == type);
+            if (count == 0)
+            {
+                continue;
+            }
+
+            sb.AppendLine("  <label class=\"chip\" for=\"f-" + (int)type + "\" title=\"" + Encode(LineError.GetHint(type)) + "\">" +
+                          "<i style=\"background:" + LineError.GetColor(type) + "\"></i>" +
+                          Encode(LineError.GetLabel(type)) + "<b>" + count + "</b></label>");
+        }
+
+        sb.AppendLine("</nav>");
+    }
+
+    private static void AppendTable(StringBuilder sb, IReadOnlyList<ErrorListItem> items)
+    {
+        var l = Se.Language.ErrorList;
+        sb.AppendLine("<div class=\"table-wrap\">");
+        sb.AppendLine("<table>");
+        sb.AppendLine("  <thead><tr>" +
+                      "<th class=\"num\">" + Encode(Se.Language.General.NumberSymbol) + "</th>" +
+                      "<th>" + Encode(Se.Language.General.Error) + "</th>" +
+                      "<th>" + Encode(Se.Language.General.Show) + "</th>" +
+                      "<th>" + Encode(Se.Language.General.Hide) + "</th>" +
+                      "<th>" + Encode(l.Detail) + "</th>" +
+                      "<th>" + Encode(Se.Language.General.Text) + "</th>" +
+                      "</tr></thead>");
+        sb.AppendLine("  <tbody>");
+        foreach (var item in items)
+        {
+            sb.AppendLine("    <tr class=\"t" + (int)item.Type + "\" style=\"--dot:" + LineError.GetColor(item.Type) + "\">" +
+                          "<td class=\"num\">" + item.Number + "</td>" +
+                          "<td><span class=\"pill\"><i></i>" + Encode(item.Category) + "</span></td>" +
+                          "<td class=\"time\">" + Encode(item.Show) + "</td>" +
+                          "<td class=\"time\">" + Encode(item.Hide) + "</td>" +
+                          "<td class=\"detail\">" + Encode(item.Detail) + "</td>" +
+                          "<td class=\"text\">" + Encode(item.Text) + "</td>" +
+                          "</tr>");
+        }
+
+        sb.AppendLine("  </tbody>");
+        sb.AppendLine("</table>");
+        sb.AppendLine("</div>");
+    }
+
+    private static IReadOnlyList<string> Headers()
+    {
+        return new[]
+        {
+            Se.Language.General.NumberSymbol,
+            Se.Language.General.Error,
+            Se.Language.General.Show,
+            Se.Language.General.Hide,
+            Se.Language.ErrorList.Detail,
+            Se.Language.General.Text,
+        };
+    }
+
+    private static IEnumerable<string> Cells(ErrorListItem item)
+    {
+        yield return item.Number.ToString(CultureInfo.CurrentCulture);
+        yield return item.Category;
+        yield return item.Show;
+        yield return item.Hide;
+        yield return item.Detail;
+        yield return item.Text;
+    }
+
+    /// <summary>A tab or a newline inside a cell would start a new column/row where it is pasted.</summary>
+    private static string CleanForTabSeparated(string s)
+    {
+        return s.Replace('\t', ' ').Replace("\r\n", " ").Replace('\n', ' ').Replace('\r', ' ');
+    }
+
+    private static string Now()
+    {
+        return DateTime.Now.ToString("yyyy-MM-dd HH:mm", CultureInfo.CurrentCulture);
+    }
+
+    private static string Encode(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return string.Empty;
+        }
+
+        return text
+            .Replace("&", "&amp;")
+            .Replace("<", "&lt;")
+            .Replace(">", "&gt;")
+            .Replace("\"", "&quot;");
+    }
+
+    /// <summary>
+    /// Light by default, dark through <c>prefers-color-scheme</c>: every colour is a token on
+    /// <c>:root</c> and only the tokens are redefined, so nothing can end up defined in the dark
+    /// block alone.
+    /// </summary>
+    private const string Css = @"
+:root {
+  color-scheme: light dark;
+  --bg: #f6f7f9;
+  --panel: #ffffff;
+  --panel-2: #fbfbfc;
+  --ink: #16191d;
+  --ink-dim: #5b6470;
+  --line: #e3e6ea;
+  --line-soft: #eef0f3;
+  --accent: #5d8aa8;
+  --shadow: 0 1px 2px rgba(16, 24, 40, .06), 0 8px 24px rgba(16, 24, 40, .06);
+  --radius: 12px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #14171b;
+    --panel: #1b1f24;
+    --panel-2: #20252b;
+    --ink: #e8ebef;
+    --ink-dim: #9aa4b1;
+    --line: #2b3138;
+    --line-soft: #23282f;
+    --accent: #7fb0cd;
+    --shadow: 0 1px 2px rgba(0, 0, 0, .4), 0 8px 24px rgba(0, 0, 0, .35);
+  }
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  padding: 32px 20px 56px;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Noto Sans', Ubuntu, Cantarell, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-text-size-adjust: 100%;
+}
+
+main { max-width: 1180px; margin: 0 auto; }
+
+h1 { margin: 0; font-size: 26px; font-weight: 650; letter-spacing: -.01em; }
+
+.summary { margin: 6px 0 0; font-size: 15px; color: var(--ink-dim); }
+
+.meta { margin: 10px 0 0; display: flex; flex-wrap: wrap; gap: 6px 18px; font-size: 12.5px; color: var(--ink-dim); }
+.meta span { overflow-wrap: anywhere; }
+
+.chips { display: flex; flex-wrap: wrap; gap: 8px; margin: 22px 0 14px; }
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 12px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--panel);
+  color: var(--ink);
+  font-size: 13px;
+  cursor: pointer;
+  user-select: none;
+  transition: border-color .12s ease, transform .12s ease;
+}
+.chip:hover { border-color: var(--accent); transform: translateY(-1px); }
+.chip i { width: 9px; height: 9px; border-radius: 50%; flex: none; }
+.chip b { font-weight: 600; color: var(--ink-dim); font-variant-numeric: tabular-nums; }
+
+.table-wrap {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  overflow: auto;
+  max-height: 74vh;
+}
+
+table { border-collapse: collapse; width: 100%; font-size: 13.5px; }
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  text-align: left;
+  font-weight: 600;
+  font-size: 12px;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+  background: var(--panel-2);
+  border-bottom: 1px solid var(--line);
+  padding: 11px 14px;
+  white-space: nowrap;
+}
+
+tbody td { padding: 10px 14px; border-bottom: 1px solid var(--line-soft); vertical-align: top; }
+tbody tr:last-child td { border-bottom: 0; }
+tbody tr:hover td { background: var(--panel-2); }
+
+td.num { width: 1%; text-align: right; color: var(--ink-dim); font-variant-numeric: tabular-nums; white-space: nowrap; }
+td.time, td.detail { white-space: nowrap; font-variant-numeric: tabular-nums; }
+td.time { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 12.5px; }
+td.detail { color: var(--ink-dim); }
+td.text { min-width: 22em; overflow-wrap: anywhere; }
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 3px 10px 3px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: transparent; /* fallback where color-mix is unknown */
+  background: color-mix(in srgb, var(--dot) 12%, transparent);
+  white-space: nowrap;
+}
+.pill i { width: 8px; height: 8px; border-radius: 50%; background: var(--dot); flex: none; }
+
+footer { margin-top: 18px; font-size: 12px; color: var(--ink-dim); text-align: right; }
+
+/* Chip filtering, without script: the checked radio decides which rows stay visible. */
+input[name='f'] { display: none; }
+
+#f-all:checked ~ .chips [for='f-all'],
+#f-0:checked ~ .chips [for='f-0'],
+#f-1:checked ~ .chips [for='f-1'],
+#f-2:checked ~ .chips [for='f-2'],
+#f-3:checked ~ .chips [for='f-3'],
+#f-4:checked ~ .chips [for='f-4'],
+#f-5:checked ~ .chips [for='f-5'],
+#f-6:checked ~ .chips [for='f-6'],
+#f-7:checked ~ .chips [for='f-7'] {
+  border-color: var(--accent);
+  background: var(--panel-2);
+  background: color-mix(in srgb, var(--accent) 16%, var(--panel));
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+
+#f-0:checked ~ .table-wrap tbody tr:not(.t0),
+#f-1:checked ~ .table-wrap tbody tr:not(.t1),
+#f-2:checked ~ .table-wrap tbody tr:not(.t2),
+#f-3:checked ~ .table-wrap tbody tr:not(.t3),
+#f-4:checked ~ .table-wrap tbody tr:not(.t4),
+#f-5:checked ~ .table-wrap tbody tr:not(.t5),
+#f-6:checked ~ .table-wrap tbody tr:not(.t6),
+#f-7:checked ~ .table-wrap tbody tr:not(.t7) { display: none; }
+
+@media print {
+  body { background: #fff; padding: 0; }
+  .chips { display: none; }
+  .table-wrap { max-height: none; box-shadow: none; border: 0; }
+  thead th { position: static; }
+}
+";
+}

--- a/src/ui/Features/Shared/ErrorList/ErrorListViewModel.cs
+++ b/src/ui/Features/Shared/ErrorList/ErrorListViewModel.cs
@@ -3,12 +3,17 @@ using Avalonia.Input;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Features.Shared.PromptFileSaved;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Shared.ErrorList;
 
@@ -17,7 +22,9 @@ public partial class ErrorListViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<ErrorListItem> _subtitles;
     [ObservableProperty] private ErrorListItem? _selectedSubtitle;
     [ObservableProperty] private bool _hasErrors;
+    [ObservableProperty] private bool _canExport;
     [ObservableProperty] private string _summary = string.Empty;
+    [ObservableProperty] private string _exportStatus = string.Empty;
 
     public ObservableCollection<SummaryCard> Cards { get; } = new();
 
@@ -26,10 +33,93 @@ public partial class ErrorListViewModel : ObservableObject
     public bool GoToPressed { get; private set; }
 
     private readonly List<ErrorListItem> _allItems = new();
+    private readonly IFileHelper _fileHelper;
+    private readonly IWindowService _windowService;
+    private string _subtitleFileName = string.Empty;
 
-    public ErrorListViewModel()
+    public ErrorListViewModel(IFileHelper fileHelper, IWindowService windowService)
     {
+        _fileHelper = fileHelper;
+        _windowService = windowService;
         Subtitles = new ObservableCollection<ErrorListItem>();
+    }
+
+    /// <summary>
+    /// Puts what the window shows - the active card filter included - on the clipboard, tab
+    /// separated, so it pastes as columns into Excel/Sheets and as a readable block anywhere else.
+    /// </summary>
+    [RelayCommand]
+    private async Task CopyToClipboard()
+    {
+        if (Window == null || Subtitles.Count == 0)
+        {
+            return;
+        }
+
+        await ClipboardHelper.SetTextAsync(Window, ErrorListExport.ToTabSeparated(Subtitles));
+
+        // Not awaited: the command would stay "running" - and its menu item disabled - for as
+        // long as the status is shown.
+        _ = ShowExportStatus(Se.Language.General.CopiedToClipboard);
+    }
+
+    [RelayCommand]
+    private Task ExportText()
+    {
+        return ExportToFile(".txt", () => Encoding.UTF8.GetBytes(ErrorListExport.ToPlainText(Subtitles, Summary, _subtitleFileName)));
+    }
+
+    [RelayCommand]
+    private Task ExportExcel()
+    {
+        return ExportToFile(".xlsx", () => ErrorListExport.ToXlsx(Subtitles));
+    }
+
+    [RelayCommand]
+    private Task ExportHtml()
+    {
+        return ExportToFile(".html", () => Encoding.UTF8.GetBytes(ErrorListExport.ToHtml(Subtitles, Summary, _subtitleFileName)));
+    }
+
+    private async Task ExportToFile(string extension, Func<byte[]> makeContent)
+    {
+        if (Window == null || Subtitles.Count == 0)
+        {
+            return;
+        }
+
+        var fileName = await _fileHelper.PickSaveFile(Window, extension, GetSuggestedFileName() + extension, Se.Language.General.Export);
+        if (string.IsNullOrEmpty(fileName))
+        {
+            return;
+        }
+
+        await File.WriteAllBytesAsync(fileName, makeContent());
+
+        _ = await _windowService.ShowDialogAsync<PromptFileSavedWindow, PromptFileSavedViewModel>(Window, vm =>
+        {
+            vm.Initialize(Se.Language.General.FileSaved, string.Format(Se.Language.General.FileSavedToX, fileName), fileName, true, true);
+        });
+    }
+
+    private string GetSuggestedFileName()
+    {
+        var name = string.IsNullOrEmpty(_subtitleFileName)
+            ? "subtitle"
+            : Path.GetFileNameWithoutExtension(_subtitleFileName);
+
+        return string.IsNullOrWhiteSpace(name) ? "subtitle-errors" : name + "-errors";
+    }
+
+    /// <summary>Clipboard copies are silent otherwise - the status line says it happened, then fades.</summary>
+    private async Task ShowExportStatus(string text)
+    {
+        ExportStatus = text;
+        await Task.Delay(3000);
+        if (ExportStatus == text)
+        {
+            ExportStatus = string.Empty;
+        }
     }
 
     [RelayCommand]
@@ -74,9 +164,10 @@ public partial class ErrorListViewModel : ObservableObject
     /// The items come ready-made from the caller: it is the only place that still knows each
     /// line's real neighbours, which the gap/overlap wording needs.
     /// </summary>
-    internal void Initialize(List<ErrorListItem> errorListItems, int totalLines)
+    internal void Initialize(List<ErrorListItem> errorListItems, int totalLines, string? subtitleFileName = null)
     {
         var l = Se.Language.ErrorList;
+        _subtitleFileName = subtitleFileName ?? string.Empty;
         _allItems.Clear();
         _allItems.AddRange(errorListItems);
 
@@ -109,6 +200,7 @@ public partial class ErrorListViewModel : ObservableObject
 
         Subtitles = new ObservableCollection<ErrorListItem>(filtered);
         SelectedSubtitle = Subtitles.FirstOrDefault();
+        CanExport = Subtitles.Count > 0;
     }
 
     /// <summary>

--- a/src/ui/Features/Shared/ErrorList/ErrorListWindow.cs
+++ b/src/ui/Features/Shared/ErrorList/ErrorListWindow.cs
@@ -65,8 +65,9 @@ public class ErrorListWindow : Window
         };
 
         var buttonGoTo = UiUtil.MakeButton(Se.Language.General.GoTo, vm.GoToCommand).WithBindIsEnabled(nameof(vm.HasErrors));
+        var buttonExport = MakeExportButton(vm);
         var buttonCancel = UiUtil.MakeButtonDone(vm.CancelCommand);
-        var panelButtons = UiUtil.MakeButtonBar(buttonGoTo, buttonCancel);
+        var panelButtons = UiUtil.MakeButtonBar(MakeExportStatusLabel(vm), buttonExport, buttonGoTo, buttonCancel);
 
         var grid = new Grid
         {
@@ -96,6 +97,56 @@ public class ErrorListWindow : Window
         UiUtil.FocusOnFirstActivation(this, buttonCancel); // hack to make OnKeyDown work
 
         KeyDown += (s, e) => vm.OnKeyDown(e);
+    }
+
+    /// <summary>
+    /// "Export..." with the four targets from #14379 - the list used to be shareable only as a
+    /// screenshot. Every target exports the rows as shown, so an active card filter applies.
+    /// </summary>
+    private static Button MakeExportButton(ErrorListViewModel vm)
+    {
+        var l = Se.Language.ErrorList;
+        var button = UiUtil.MakeButton(Se.Language.General.ExportDotDotDot);
+        button.Flyout = new MenuFlyout
+        {
+            Items =
+            {
+                new MenuItem
+                {
+                    Header = Se.Language.General.CopyToClipboard,
+                    Command = vm.CopyToClipboardCommand,
+                },
+                new MenuItem
+                {
+                    Header = l.ExportAsText,
+                    Command = vm.ExportTextCommand,
+                },
+                new MenuItem
+                {
+                    Header = l.ExportAsExcel,
+                    Command = vm.ExportExcelCommand,
+                },
+                new MenuItem
+                {
+                    Header = l.ExportAsHtml,
+                    Command = vm.ExportHtmlCommand,
+                },
+            },
+        };
+
+        return button.WithBindIsEnabled(nameof(vm.CanExport));
+    }
+
+    /// <summary>Says "Copied to clipboard" next to the buttons - a clipboard copy has nothing else to show.</summary>
+    private static TextBlock MakeExportStatusLabel(ErrorListViewModel vm)
+    {
+        return new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 0, 10, 0),
+            Opacity = 0.75,
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.ExportStatus)),
+        };
     }
 
     private static Border MakeErrorsGridView(ErrorListViewModel vm)

--- a/src/ui/Features/Shared/ErrorList/LineError.cs
+++ b/src/ui/Features/Shared/ErrorList/LineError.cs
@@ -58,15 +58,42 @@ public record LineError(LineErrorType Type, string Detail)
         };
     }
 
-    private static readonly IBrush TooManyLinesBrush = new SolidColorBrush(Color.Parse("#E84393"));
-    private static readonly IBrush CpsBrush = new SolidColorBrush(Color.Parse("#E8912D"));
-    private static readonly IBrush TooShortBrush = new SolidColorBrush(Color.Parse("#F1C40F"));
-    private static readonly IBrush TooLongBrush = new SolidColorBrush(Color.Parse("#9B59B6"));
-    private static readonly IBrush LineTooLongBrush = new SolidColorBrush(Color.Parse("#3498DB"));
-    private static readonly IBrush LineTooWideBrush = new SolidColorBrush(Color.Parse("#2980B9"));
-    private static readonly IBrush OverlapBrush = new SolidColorBrush(Color.Parse("#E74C3C"));
-    private static readonly IBrush GapBrush = new SolidColorBrush(Color.Parse("#1ABC9C"));
-    public static readonly IBrush AllBrush = new SolidColorBrush(Color.Parse("#5D8AA8"));
+    private const string TooManyLinesColor = "#E84393";
+    private const string CpsColor = "#E8912D";
+    private const string TooShortColor = "#F1C40F";
+    private const string TooLongColor = "#9B59B6";
+    private const string LineTooLongColor = "#3498DB";
+    private const string LineTooWideColor = "#2980B9";
+    private const string OverlapColor = "#E74C3C";
+    private const string GapColor = "#1ABC9C";
+    public const string AllColor = "#5D8AA8";
+
+    private static readonly IBrush TooManyLinesBrush = new SolidColorBrush(Color.Parse(TooManyLinesColor));
+    private static readonly IBrush CpsBrush = new SolidColorBrush(Color.Parse(CpsColor));
+    private static readonly IBrush TooShortBrush = new SolidColorBrush(Color.Parse(TooShortColor));
+    private static readonly IBrush TooLongBrush = new SolidColorBrush(Color.Parse(TooLongColor));
+    private static readonly IBrush LineTooLongBrush = new SolidColorBrush(Color.Parse(LineTooLongColor));
+    private static readonly IBrush LineTooWideBrush = new SolidColorBrush(Color.Parse(LineTooWideColor));
+    private static readonly IBrush OverlapBrush = new SolidColorBrush(Color.Parse(OverlapColor));
+    private static readonly IBrush GapBrush = new SolidColorBrush(Color.Parse(GapColor));
+    public static readonly IBrush AllBrush = new SolidColorBrush(Color.Parse(AllColor));
+
+    /// <summary>The dot colour as "#RRGGBB" - the html export paints the same palette as the window.</summary>
+    public static string GetColor(LineErrorType type)
+    {
+        return type switch
+        {
+            LineErrorType.TooManyLines => TooManyLinesColor,
+            LineErrorType.CharactersPerSecond => CpsColor,
+            LineErrorType.DurationTooShort => TooShortColor,
+            LineErrorType.DurationTooLong => TooLongColor,
+            LineErrorType.LineTooLong => LineTooLongColor,
+            LineErrorType.LineTooWide => LineTooWideColor,
+            LineErrorType.Overlap => OverlapColor,
+            LineErrorType.GapTooShort => GapColor,
+            _ => AllColor,
+        };
+    }
 
     public static IBrush GetBrush(LineErrorType type)
     {

--- a/src/ui/Logic/Config/Language/LanguageErrorList.cs
+++ b/src/ui/Logic/Config/Language/LanguageErrorList.cs
@@ -31,6 +31,12 @@ public class LanguageErrorList
     public string DetailGapToNext { get; set; }
     public string Detail { get; set; }
     public string Tip { get; set; }
+    public string ExportAsText { get; set; }
+    public string ExportAsExcel { get; set; }
+    public string ExportAsHtml { get; set; }
+    public string ExportFileX { get; set; }
+    public string ExportGeneratedX { get; set; }
+    public string ExportMadeWithSubtitleEdit { get; set; }
 
     public LanguageErrorList()
     {
@@ -63,5 +69,11 @@ public class LanguageErrorList
         DetailGapToNext = "to next: {0} < {1} ms";
         Detail = "Detail";
         Tip = "Double-click a line (or press Enter) to go to it. Which checks run, and their limits, are set in Settings > General.";
+        ExportAsText = "Text file (.txt)...";
+        ExportAsExcel = "Excel file (.xlsx)...";
+        ExportAsHtml = "Web page (.html)...";
+        ExportFileX = "File: {0}";
+        ExportGeneratedX = "Generated: {0}";
+        ExportMadeWithSubtitleEdit = "Made with Subtitle Edit";
     }
 }

--- a/src/ui/Logic/XlsxWriter.cs
+++ b/src/ui/Logic/XlsxWriter.cs
@@ -1,0 +1,321 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>
+/// Writes a single-sheet .xlsx (Office Open XML) workbook - no dependency, just a zip with a
+/// handful of xml parts. Strings are written inline, so there is no shared-strings table to
+/// keep in sync, and numbers are written as numbers so Excel sorts and sums them.
+/// <para>
+/// Preferred over csv for "export to Excel": a csv is split on the list separator of the
+/// machine that opens it, so a comma-separated file loses its columns on a Danish or German
+/// Excel, and a text/quote guess mangles time codes and non-ASCII text.
+/// </para>
+/// </summary>
+public static class XlsxWriter
+{
+    private const string MainNs = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+    private const string RelNs = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+
+    /// <summary>Header style (bold, white on blue) - cellXfs index 1 in <see cref="StylesXml"/>.</summary>
+    private const int HeaderStyle = 1;
+
+    /// <summary>Body style (top aligned) - cellXfs index 2.</summary>
+    private const int BodyStyle = 2;
+
+    /// <summary>
+    /// Builds the workbook in memory. Cells are strings unless the value is a number
+    /// (int/long/double/decimal), and null becomes an empty cell.
+    /// </summary>
+    /// <param name="sheetName">Sheet tab name; invalid characters are replaced.</param>
+    /// <param name="headers">The first row, written bold and frozen.</param>
+    /// <param name="rows">One list of cell values per row; must be at most <paramref name="headers"/> long.</param>
+    /// <param name="columnWidths">Optional width (in characters) per column.</param>
+    public static byte[] Create(
+        string sheetName,
+        IReadOnlyList<string> headers,
+        IEnumerable<IReadOnlyList<object?>> rows,
+        IReadOnlyList<double>? columnWidths = null)
+    {
+        var sheet = MakeSheetXml(headers, rows, columnWidths);
+
+        using (var ms = new MemoryStream())
+        {
+            using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, true))
+            {
+                AddEntry(zip, "[Content_Types].xml", ContentTypesXml);
+                AddEntry(zip, "_rels/.rels", RootRelsXml);
+                AddEntry(zip, "xl/workbook.xml", MakeWorkbookXml(sheetName));
+                AddEntry(zip, "xl/_rels/workbook.xml.rels", WorkbookRelsXml);
+                AddEntry(zip, "xl/styles.xml", StylesXml);
+                AddEntry(zip, "xl/worksheets/sheet1.xml", sheet);
+            }
+
+            return ms.ToArray();
+        }
+    }
+
+    /// <summary>Builds the workbook and writes it to <paramref name="fileName"/>.</summary>
+    public static void Save(
+        string fileName,
+        string sheetName,
+        IReadOnlyList<string> headers,
+        IEnumerable<IReadOnlyList<object?>> rows,
+        IReadOnlyList<double>? columnWidths = null)
+    {
+        File.WriteAllBytes(fileName, Create(sheetName, headers, rows, columnWidths));
+    }
+
+    private static void AddEntry(ZipArchive zip, string name, string content)
+    {
+        var entry = zip.CreateEntry(name, CompressionLevel.Optimal);
+        using (var stream = entry.Open())
+        {
+            // No BOM: Excel reads the parts as the xml declaration says.
+            var bytes = new UTF8Encoding(false).GetBytes(content);
+            stream.Write(bytes, 0, bytes.Length);
+        }
+    }
+
+    private static string MakeSheetXml(
+        IReadOnlyList<string> headers,
+        IEnumerable<IReadOnlyList<object?>> rows,
+        IReadOnlyList<double>? columnWidths)
+    {
+        var body = new StringBuilder();
+        var rowNumber = 1;
+
+        body.Append("<row r=\"1\">");
+        for (var i = 0; i < headers.Count; i++)
+        {
+            AppendInlineString(body, ColumnName(i) + "1", HeaderStyle, headers[i]);
+        }
+
+        body.Append("</row>");
+
+        foreach (var row in rows)
+        {
+            rowNumber++;
+            body.Append("<row r=\"").Append(rowNumber).Append("\">");
+            for (var i = 0; i < row.Count && i < headers.Count; i++)
+            {
+                var reference = ColumnName(i) + rowNumber.ToString(CultureInfo.InvariantCulture);
+                var value = row[i];
+                if (value == null)
+                {
+                    continue;
+                }
+
+                if (TryGetNumber(value, out var number))
+                {
+                    body.Append("<c r=\"").Append(reference).Append("\" s=\"").Append(BodyStyle).Append("\"><v>")
+                        .Append(number.ToString("R", CultureInfo.InvariantCulture))
+                        .Append("</v></c>");
+                }
+                else
+                {
+                    AppendInlineString(body, reference, BodyStyle, value.ToString() ?? string.Empty);
+                }
+            }
+
+            body.Append("</row>");
+        }
+
+        var lastColumn = ColumnName(Math.Max(headers.Count - 1, 0));
+        var dimension = "A1:" + lastColumn + rowNumber.ToString(CultureInfo.InvariantCulture);
+
+        var cols = new StringBuilder();
+        if (columnWidths != null && columnWidths.Count > 0)
+        {
+            cols.Append("<cols>");
+            for (var i = 0; i < columnWidths.Count; i++)
+            {
+                cols.Append("<col min=\"").Append(i + 1).Append("\" max=\"").Append(i + 1)
+                    .Append("\" width=\"").Append(columnWidths[i].ToString("0.##", CultureInfo.InvariantCulture))
+                    .Append("\" customWidth=\"1\"/>");
+            }
+
+            cols.Append("</cols>");
+        }
+
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
+               "<worksheet xmlns=\"" + MainNs + "\">" +
+               "<dimension ref=\"" + dimension + "\"/>" +
+               "<sheetViews><sheetView workbookViewId=\"0\">" +
+               "<pane ySplit=\"1\" topLeftCell=\"A2\" activePane=\"bottomLeft\" state=\"frozen\"/>" +
+               "</sheetView></sheetViews>" +
+               "<sheetFormatPr defaultRowHeight=\"15\"/>" +
+               cols +
+               "<sheetData>" + body + "</sheetData>" +
+               "<autoFilter ref=\"" + dimension + "\"/>" +
+               "</worksheet>";
+    }
+
+    private static void AppendInlineString(StringBuilder sb, string reference, int style, string text)
+    {
+        sb.Append("<c r=\"").Append(reference).Append("\" s=\"").Append(style).Append("\" t=\"inlineStr\"><is><t")
+            .Append(NeedsSpacePreserve(text) ? " xml:space=\"preserve\"" : string.Empty)
+            .Append('>').Append(EncodeXml(text)).Append("</t></is></c>");
+    }
+
+    private static bool NeedsSpacePreserve(string text)
+    {
+        return text.Length > 0 && (char.IsWhiteSpace(text[0]) || char.IsWhiteSpace(text[text.Length - 1]));
+    }
+
+    private static bool TryGetNumber(object value, out double number)
+    {
+        switch (value)
+        {
+            case int i:
+                number = i;
+                return true;
+            case long l:
+                number = l;
+                return true;
+            case double d:
+                number = d;
+                return !double.IsNaN(d) && !double.IsInfinity(d);
+            case float f:
+                number = f;
+                return !float.IsNaN(f) && !float.IsInfinity(f);
+            case decimal m:
+                number = (double)m;
+                return true;
+            default:
+                number = 0;
+                return false;
+        }
+    }
+
+    /// <summary>0 -&gt; "A", 25 -&gt; "Z", 26 -&gt; "AA".</summary>
+    internal static string ColumnName(int zeroBasedIndex)
+    {
+        var name = string.Empty;
+        var index = zeroBasedIndex;
+        while (true)
+        {
+            name = (char)('A' + index % 26) + name;
+            index = index / 26 - 1;
+            if (index < 0)
+            {
+                return name;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Xml-escapes and drops the control characters xml 1.0 cannot carry - Excel reports a
+    /// corrupt file rather than skipping them, and subtitle text can hold anything.
+    /// </summary>
+    internal static string EncodeXml(string text)
+    {
+        var sb = new StringBuilder(text.Length);
+        foreach (var ch in text)
+        {
+            switch (ch)
+            {
+                case '&':
+                    sb.Append("&amp;");
+                    break;
+                case '<':
+                    sb.Append("&lt;");
+                    break;
+                case '>':
+                    sb.Append("&gt;");
+                    break;
+                case '"':
+                    sb.Append("&quot;");
+                    break;
+                case '\'':
+                    sb.Append("&apos;");
+                    break;
+                default:
+                    if (ch == '\t' || ch == '\n' || ch == '\r' || ch >= ' ' && ch != '\uFFFE' && ch != '\uFFFF')
+                    {
+                        sb.Append(ch);
+                    }
+
+                    break;
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>Excel rejects these characters in a sheet name, and caps it at 31 characters.</summary>
+    private static string MakeSheetName(string sheetName)
+    {
+        var sb = new StringBuilder();
+        foreach (var ch in sheetName)
+        {
+            sb.Append("[]:*?/\\".IndexOf(ch) >= 0 ? '-' : ch);
+        }
+
+        var name = sb.ToString().Trim('\'');
+        if (name.Length > 31)
+        {
+            name = name.Substring(0, 31);
+        }
+
+        return string.IsNullOrWhiteSpace(name) ? "Sheet1" : name;
+    }
+
+    private static string MakeWorkbookXml(string sheetName)
+    {
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
+               "<workbook xmlns=\"" + MainNs + "\" xmlns:r=\"" + RelNs + "\">" +
+               "<sheets><sheet name=\"" + EncodeXml(MakeSheetName(sheetName)) + "\" sheetId=\"1\" r:id=\"rId1\"/></sheets>" +
+               "</workbook>";
+    }
+
+    private const string ContentTypesXml =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
+        "<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">" +
+        "<Default Extension=\"rels\" ContentType=\"application/vnd.openxmlformats-package.relationships+xml\"/>" +
+        "<Default Extension=\"xml\" ContentType=\"application/xml\"/>" +
+        "<Override PartName=\"/xl/workbook.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\"/>" +
+        "<Override PartName=\"/xl/worksheets/sheet1.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml\"/>" +
+        "<Override PartName=\"/xl/styles.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml\"/>" +
+        "</Types>";
+
+    private const string RootRelsXml =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
+        "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">" +
+        "<Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\" Target=\"xl/workbook.xml\"/>" +
+        "</Relationships>";
+
+    private const string WorkbookRelsXml =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
+        "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">" +
+        "<Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\" Target=\"worksheets/sheet1.xml\"/>" +
+        "<Relationship Id=\"rId2\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles\" Target=\"styles.xml\"/>" +
+        "</Relationships>";
+
+    private const string StylesXml =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
+        "<styleSheet xmlns=\"" + MainNs + "\">" +
+        "<fonts count=\"2\">" +
+        "<font><sz val=\"11\"/><color theme=\"1\"/><name val=\"Calibri\"/><family val=\"2\"/></font>" +
+        "<font><b/><sz val=\"11\"/><color rgb=\"FFFFFFFF\"/><name val=\"Calibri\"/><family val=\"2\"/></font>" +
+        "</fonts>" +
+        "<fills count=\"3\">" +
+        "<fill><patternFill patternType=\"none\"/></fill>" +
+        "<fill><patternFill patternType=\"gray125\"/></fill>" +
+        "<fill><patternFill patternType=\"solid\"><fgColor rgb=\"FF5D8AA8\"/><bgColor indexed=\"64\"/></patternFill></fill>" +
+        "</fills>" +
+        "<borders count=\"1\"><border><left/><right/><top/><bottom/><diagonal/></border></borders>" +
+        "<cellStyleXfs count=\"1\"><xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\"/></cellStyleXfs>" +
+        "<cellXfs count=\"3\">" +
+        "<xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\" xfId=\"0\"/>" +
+        "<xf numFmtId=\"0\" fontId=\"1\" fillId=\"2\" borderId=\"0\" xfId=\"0\" applyFont=\"1\" applyFill=\"1\" applyAlignment=\"1\"><alignment vertical=\"center\"/></xf>" +
+        "<xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\" xfId=\"0\" applyAlignment=\"1\"><alignment vertical=\"top\"/></xf>" +
+        "</cellXfs>" +
+        "<cellStyles count=\"1\"><cellStyle name=\"Normal\" xfId=\"0\" builtinId=\"0\"/></cellStyles>" +
+        "</styleSheet>";
+}

--- a/tests/UI/Features/Shared/ErrorList/ErrorListExportCommandTests.cs
+++ b/tests/UI/Features/Shared/ErrorList/ErrorListExportCommandTests.cs
@@ -1,0 +1,203 @@
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.LogicalTree;
+using Avalonia.Threading;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Shared.ErrorList;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Shared;
+
+/// <summary>
+/// The export menu of "List errors" (#14379): what the picker returns is what gets written,
+/// a cancelled picker writes nothing, and every target exports the rows as shown - so an
+/// active summary-card filter is part of the export.
+/// </summary>
+public class ErrorListExportCommandTests
+{
+    /// <summary>Hands out a file name in a temp folder instead of opening a picker.</summary>
+    private sealed class SaveToTempFileHelper : StubFileHelper
+    {
+        public string Folder { get; } = Path.Combine(Path.GetTempPath(), "SubtitleEdit.ErrorListExport", Guid.NewGuid().ToString("N"));
+        public string? Cancelled { get; set; }
+        public string LastSuggestedFileName { get; private set; } = string.Empty;
+
+        public override Task<string> PickSaveFile(Visual sender, string extension, string suggestedFileName, string title)
+        {
+            LastSuggestedFileName = suggestedFileName;
+            if (Cancelled != null)
+            {
+                return Task.FromResult(string.Empty);
+            }
+
+            Directory.CreateDirectory(Folder);
+            return Task.FromResult(Path.Combine(Folder, "errors" + extension));
+        }
+    }
+
+    /// <summary>The "file saved" prompt is a dialog the test has no use for - it is discarded by the caller.</summary>
+    private sealed class NoDialogWindowService : IWindowService
+    {
+        public T ShowWindow<T>(Window owner, Action<T>? configure = null) where T : Window => throw new NotSupportedException();
+
+        public TViewModel ShowWindow<T, TViewModel>(Window owner, Action<T, TViewModel>? configure = null)
+            where T : Window where TViewModel : class => throw new NotSupportedException();
+
+        public TViewModel ShowIndependentWindow<T, TViewModel>(Action<T, TViewModel>? configure = null)
+            where T : Window where TViewModel : class => throw new NotSupportedException();
+
+        public Task<T> ShowDialogAsync<T>(Window owner, Action<T>? configure = null) where T : Window => throw new NotSupportedException();
+
+        public Task<TViewModel> ShowDialogAsync<TWindow, TViewModel>(
+            Window owner,
+            Action<TViewModel>? configureViewModel = null,
+            Action<TWindow>? configureWindow = null)
+            where TWindow : Window where TViewModel : class => Task.FromResult<TViewModel>(null!);
+    }
+
+    private static List<ErrorListItem> MakeItems()
+    {
+        var items = new List<ErrorListItem>();
+        var errors = new[]
+        {
+            new LineError(LineErrorType.CharactersPerSecond, "30 > 25"),
+            new LineError(LineErrorType.Overlap, "from previous: 120 ms"),
+            new LineError(LineErrorType.CharactersPerSecond, "42 > 25"),
+        };
+
+        for (var i = 0; i < errors.Length; i++)
+        {
+            var line = new SubtitleLineViewModel(new Paragraph("Line " + (i + 1), i * 2000, i * 2000 + 1500), null!)
+            {
+                Number = i + 1,
+            };
+            items.Add(new ErrorListItem(line, errors[i]));
+        }
+
+        return items;
+    }
+
+    private static (ErrorListViewModel Vm, ErrorListWindow Window, SaveToTempFileHelper FileHelper) MakeWindow()
+    {
+        var fileHelper = new SaveToTempFileHelper();
+        var vm = new ErrorListViewModel(fileHelper, new NoDialogWindowService());
+        vm.Initialize(MakeItems(), 100, "/movies/The Long Goodbye.srt");
+        var window = new ErrorListWindow(vm);
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        return (vm, window, fileHelper);
+    }
+
+    [AvaloniaFact]
+    public void ExportMenu_HasTheFourTargets()
+    {
+        var (vm, window, _) = MakeWindow();
+
+        var button = window.GetLogicalDescendants().OfType<Button>().First(b => Equals(b.Content, Se.Language.General.ExportDotDotDot));
+        var items = ((MenuFlyout)button.Flyout!).Items.Cast<MenuItem>().ToList();
+
+        Assert.Equal(
+            new[]
+            {
+                Se.Language.General.CopyToClipboard,
+                Se.Language.ErrorList.ExportAsText,
+                Se.Language.ErrorList.ExportAsExcel,
+                Se.Language.ErrorList.ExportAsHtml,
+            },
+            items.Select(i => i.Header as string));
+
+        Assert.Equal(
+            new object?[] { vm.CopyToClipboardCommand, vm.ExportTextCommand, vm.ExportExcelCommand, vm.ExportHtmlCommand },
+            items.Select(i => i.Command));
+
+        Assert.True(button.IsEnabled);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void ExportButton_IsDisabledWithoutErrors()
+    {
+        var vm = new ErrorListViewModel(new StubFileHelper(), new StubWindowService());
+        vm.Initialize(new List<ErrorListItem>(), 100);
+        var window = new ErrorListWindow(vm);
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var button = window.GetLogicalDescendants().OfType<Button>().First(b => Equals(b.Content, Se.Language.General.ExportDotDotDot));
+
+        Assert.False(vm.CanExport);
+        Assert.False(button.IsEnabled);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public async Task ExportHtml_WritesWhatThePickerReturned()
+    {
+        var (vm, window, fileHelper) = MakeWindow();
+
+        await vm.ExportHtmlCommand.ExecuteAsync(null);
+
+        var fileName = Path.Combine(fileHelper.Folder, "errors.html");
+        Assert.True(File.Exists(fileName));
+        var html = await File.ReadAllTextAsync(fileName);
+        Assert.StartsWith("<!DOCTYPE html>", html);
+        Assert.Contains("Line 3", html);
+
+        // The suggested name follows the subtitle, so several files do not all land on "errors".
+        Assert.StartsWith("The Long Goodbye-errors", fileHelper.LastSuggestedFileName);
+
+        Directory.Delete(fileHelper.Folder, true);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public async Task ExportText_AndExcel_WriteTheirOwnFormat()
+    {
+        var (vm, window, fileHelper) = MakeWindow();
+
+        await vm.ExportTextCommand.ExecuteAsync(null);
+        await vm.ExportExcelCommand.ExecuteAsync(null);
+
+        Assert.Contains("Line 2", await File.ReadAllTextAsync(Path.Combine(fileHelper.Folder, "errors.txt")));
+
+        // "PK": the workbook really is a zip, not a csv with an .xlsx name.
+        var xlsx = await File.ReadAllBytesAsync(Path.Combine(fileHelper.Folder, "errors.xlsx"));
+        Assert.Equal(new byte[] { 0x50, 0x4B }, xlsx.Take(2).ToArray());
+
+        Directory.Delete(fileHelper.Folder, true);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public async Task CancelledPicker_WritesNothing()
+    {
+        var (vm, window, fileHelper) = MakeWindow();
+        fileHelper.Cancelled = "yes";
+
+        await vm.ExportTextCommand.ExecuteAsync(null);
+
+        Assert.False(Directory.Exists(fileHelper.Folder));
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public async Task Export_FollowsTheActiveCardFilter()
+    {
+        var (vm, window, fileHelper) = MakeWindow();
+
+        vm.SetFilterCommand.Execute(vm.Cards.First(c => Equals(c.Key, LineErrorType.Overlap)));
+        await vm.ExportTextCommand.ExecuteAsync(null);
+
+        var text = await File.ReadAllTextAsync(Path.Combine(fileHelper.Folder, "errors.txt"));
+        Assert.Contains("Line 2", text);
+        Assert.DoesNotContain("Line 1", text);
+        Assert.DoesNotContain("Line 3", text);
+
+        Directory.Delete(fileHelper.Folder, true);
+        window.Close();
+    }
+}

--- a/tests/UI/Features/Shared/ErrorList/ErrorListExportTests.cs
+++ b/tests/UI/Features/Shared/ErrorList/ErrorListExportTests.cs
@@ -1,0 +1,199 @@
+using System.IO.Compression;
+using System.Text;
+using System.Xml.Linq;
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Shared.ErrorList;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Shared;
+
+/// <summary>
+/// "List errors" could only leave the window as a screenshot (#14379). It now exports to the
+/// clipboard, a text log, an .xlsx workbook and a stand-alone html page - these check that what
+/// comes out is complete, escaped, and (for the workbook) a file Excel will open.
+/// </summary>
+public class ErrorListExportTests
+{
+    private static SubtitleLineViewModel MakeLine(int number, string text)
+    {
+        return new SubtitleLineViewModel(new Paragraph(text, number * 2000, number * 2000 + 1500), null!)
+        {
+            Number = number,
+        };
+    }
+
+    private static List<ErrorListItem> MakeItems()
+    {
+        return new List<ErrorListItem>
+        {
+            new(MakeLine(1, "First line"), new LineError(LineErrorType.DurationTooShort, "200 < 1000")),
+            new(MakeLine(2, "Second line"), new LineError(LineErrorType.CharactersPerSecond, "30 > 25")),
+            new(MakeLine(3, "Third line"), new LineError(LineErrorType.CharactersPerSecond, "42 > 25")),
+        };
+    }
+
+    [AvaloniaFact]
+    public void TabSeparated_HasAHeaderAndSixColumnsPerError()
+    {
+        var text = ErrorListExport.ToTabSeparated(MakeItems());
+
+        var lines = text.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(4, lines.Length); // header + three errors
+        Assert.StartsWith(Se.Language.General.NumberSymbol + "\t", lines[0]);
+        Assert.All(lines, line => Assert.Equal(6, line.Split('\t').Length));
+        Assert.Contains("Second line", lines[2]);
+    }
+
+    [AvaloniaFact]
+    public void TabSeparated_KeepsATabInTheTextFromStartingANewColumn()
+    {
+        var items = new List<ErrorListItem>
+        {
+            new(MakeLine(1, "Tab\there"), new LineError(LineErrorType.LineTooLong, "50 > 43")),
+        };
+
+        var lines = ErrorListExport.ToTabSeparated(items).Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.Equal(6, lines[1].Split('\t').Length);
+        Assert.Contains("Tab here", lines[1]);
+    }
+
+    [AvaloniaFact]
+    public void PlainText_HasTheFileNameTheSummaryAndEveryError()
+    {
+        var text = ErrorListExport.ToPlainText(MakeItems(), "3 error(s) in 3 of 10 line(s)", "/tmp/my movie.srt");
+
+        Assert.Contains("/tmp/my movie.srt", text);
+        Assert.Contains("3 error(s) in 3 of 10 line(s)", text);
+        Assert.Contains("#2", text);
+        Assert.Contains("30 > 25", text);
+        Assert.Contains("Third line", text);
+    }
+
+    [AvaloniaFact]
+    public void Html_HasOneRowPerErrorAndAChipPerErrorClassInUse()
+    {
+        var html = ErrorListExport.ToHtml(MakeItems(), "summary", "movie.srt");
+
+        Assert.Equal(3, CountOf(html, "<tr class=\"t"));
+
+        // All + the two classes that have rows - not the six that have none.
+        Assert.Equal(3, CountOf(html, "class=\"chip\""));
+        Assert.Contains(Se.Language.ErrorList.CharactersPerSecond, html);
+        Assert.DoesNotContain(Se.Language.ErrorList.Overlap, html);
+    }
+
+    [AvaloniaFact]
+    public void Html_FollowsTheReadersTheme()
+    {
+        var html = ErrorListExport.ToHtml(MakeItems(), "summary", null);
+
+        Assert.Contains("prefers-color-scheme: dark", html);
+        Assert.Contains("color-scheme: light dark", html);
+
+        // Every colour is a token on :root, so nothing is defined in the dark block alone.
+        var root = html.Substring(html.IndexOf(":root {", StringComparison.Ordinal));
+        var dark = root.Substring(root.IndexOf("@media (prefers-color-scheme: dark)", StringComparison.Ordinal));
+        foreach (var token in new[] { "--bg:", "--panel:", "--ink:", "--line:", "--accent:" })
+        {
+            Assert.Equal(2, CountOf(root, token)); // once light, once dark
+            Assert.Contains(token, dark);
+        }
+    }
+
+    [AvaloniaFact]
+    public void Html_IsSelfContainedWithNothingToLoad()
+    {
+        var html = ErrorListExport.ToHtml(MakeItems(), "summary", null);
+
+        Assert.DoesNotContain("<script", html);
+        Assert.DoesNotContain("http://", html);
+        Assert.DoesNotContain("https://", html);
+    }
+
+    [AvaloniaFact]
+    public void Html_EscapesSubtitleText()
+    {
+        var items = new List<ErrorListItem>
+        {
+            new(MakeLine(1, "<i>Tom & \"Jerry\"</i>"), new LineError(LineErrorType.LineTooLong, "50 > 43")),
+        };
+
+        var html = ErrorListExport.ToHtml(items, "summary", "<script>.srt");
+
+        Assert.Contains("&lt;i&gt;Tom &amp; &quot;Jerry&quot;&lt;/i&gt;", html);
+        Assert.DoesNotContain("<i>Tom", html);
+        Assert.DoesNotContain("<script>", html);
+    }
+
+    [AvaloniaFact]
+    public void Xlsx_IsAWorkbookWithTheRowsAndNumbersAsNumbers()
+    {
+        var bytes = ErrorListExport.ToXlsx(MakeItems());
+
+        using var zip = new ZipArchive(new MemoryStream(bytes), ZipArchiveMode.Read);
+        foreach (var part in new[] { "[Content_Types].xml", "_rels/.rels", "xl/workbook.xml", "xl/_rels/workbook.xml.rels", "xl/styles.xml", "xl/worksheets/sheet1.xml" })
+        {
+            Assert.NotNull(zip.GetEntry(part));
+        }
+
+        var sheet = XDocument.Parse(ReadEntry(zip, "xl/worksheets/sheet1.xml"));
+        XNamespace ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+        var rows = sheet.Descendants(ns + "row").ToList();
+        Assert.Equal(4, rows.Count); // header + three errors
+        Assert.Equal(6, rows[0].Elements(ns + "c").Count());
+
+        // The line number is a number cell, so Excel sorts it as one.
+        var firstCell = rows[1].Elements(ns + "c").First();
+        Assert.Null(firstCell.Attribute("t"));
+        Assert.Equal("1", firstCell.Element(ns + "v")?.Value);
+        Assert.Contains("Second line", ReadEntry(zip, "xl/worksheets/sheet1.xml"));
+
+        // Every part must be parseable xml - a single broken part makes Excel call the file corrupt.
+        foreach (var entry in zip.Entries)
+        {
+            XDocument.Parse(ReadEntry(zip, entry.FullName));
+        }
+    }
+
+    [AvaloniaFact]
+    public void Xlsx_SurvivesTextXmlCannotCarry()
+    {
+        var items = new List<ErrorListItem>
+        {
+            new(MakeLine(1, "Bell\u0007 & <angle> \"quotes\""), new LineError(LineErrorType.LineTooLong, "50 > 43")),
+        };
+
+        var bytes = ErrorListExport.ToXlsx(items);
+
+        using var zip = new ZipArchive(new MemoryStream(bytes), ZipArchiveMode.Read);
+        var xml = ReadEntry(zip, "xl/worksheets/sheet1.xml");
+        // Ordinal: the default comparison treats a control character as ignorable and "finds" it anywhere.
+        Assert.DoesNotContain("\u0007", xml, StringComparison.Ordinal);
+        XNamespace ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+        var cells = XDocument.Parse(xml).Descendants(ns + "row").Last().Elements(ns + "c").ToList();
+        Assert.Equal("Bell & <angle> \"quotes\"", cells.Last().Descendants(ns + "t").Single().Value);
+    }
+
+    private static string ReadEntry(ZipArchive zip, string name)
+    {
+        using var stream = zip.GetEntry(name)!.Open();
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        return reader.ReadToEnd();
+    }
+
+    private static int CountOf(string text, string value)
+    {
+        var count = 0;
+        var index = text.IndexOf(value, StringComparison.Ordinal);
+        while (index >= 0)
+        {
+            count++;
+            index = text.IndexOf(value, index + value.Length, StringComparison.Ordinal);
+        }
+
+        return count;
+    }
+}

--- a/tests/UI/Features/Shared/PrePopulatedGridSelectionTests.cs
+++ b/tests/UI/Features/Shared/PrePopulatedGridSelectionTests.cs
@@ -60,7 +60,7 @@ public class PrePopulatedGridSelectionTests
     public void ErrorListWindow_HasASelectionAndAnEnabledGoToOnOpen()
     {
         var lines = MakeLines("First line", "Second line");
-        var vm = new ErrorListViewModel();
+        var vm = new ErrorListViewModel(new StubFileHelper(), new StubWindowService());
         vm.Initialize(new List<ErrorListItem>
         {
             new(lines[0], new LineError(LineErrorType.DurationTooShort, "200 < 1000")),

--- a/tests/UI/StubFileHelper.cs
+++ b/tests/UI/StubFileHelper.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Avalonia;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace UITests;
+
+/// <summary>
+/// An <see cref="IFileHelper"/> for view models that only pick a file from a command the test
+/// never runs - the error list opens a save picker from its export menu, for instance. Every
+/// member throws, so a test that does take such a path fails loudly instead of silently
+/// picking nothing. Members are virtual: a test that does need one picker overrides just that
+/// one and keeps the loud default for the rest.
+/// </summary>
+public class StubFileHelper : IFileHelper
+{
+    public virtual Task<string> PickOpenFile(Visual sender, string title, string extensionTitle, string extension, string extensionTitle2 = "", string extension2 = "", string? suggestedStartFolder = null)
+        => throw new NotSupportedException();
+
+    public virtual Task<string[]> PickOpenFiles(Visual sender, string title, string extensionTitle, List<string> extensions, string extensionTitle2, List<string> extensions2)
+        => throw new NotSupportedException();
+
+    public virtual Task<string> PickOpenSubtitleFile(Visual sender, string title, bool includeVideoFiles = true, string? lastOpenedFilePath = null, bool includeSpreadsheets = false)
+        => throw new NotSupportedException();
+
+    public virtual Task<string[]> PickOpenSubtitleFiles(Visual sender, string title, bool includeVideoFiles = true, string? lastOpenedFilePath = null)
+        => throw new NotSupportedException();
+
+    public virtual Task<string> PickSaveSubtitleFile(Visual sender, SubtitleFormat currentFormat, string suggestedFileName, string title)
+        => throw new NotSupportedException();
+
+    public virtual Task<FileHelperSubtitleSavePickerResult?> PickSaveSubtitleFileAs(Visual sender, SubtitleFormat currentFormat, string suggestedFileName, string title)
+        => throw new NotSupportedException();
+
+    public virtual Task<string> PickSaveSubtitleFile(Visual sender, string extension, string suggestedFileName, string title)
+        => throw new NotSupportedException();
+
+    public virtual Task<string> PickSaveFile(Visual sender, string extension, string suggestedFileName, string title)
+        => throw new NotSupportedException();
+
+    public virtual Task<string> PickSaveFile(Visual sender, IReadOnlyList<(string Name, string Extension)> fileTypes, string suggestedFileName, string title)
+        => throw new NotSupportedException();
+
+    public virtual Task<string> PickOpenVideoFile(Visual sender, string title)
+        => throw new NotSupportedException();
+
+    public virtual Task<string[]> PickOpenVideoFiles(Visual sender, string title)
+        => throw new NotSupportedException();
+
+    public virtual Task<string> PickOpenImageFile(Visual sender, string title)
+        => throw new NotSupportedException();
+}


### PR DESCRIPTION
Fixes #14379.

"List errors" could only leave the window as a screenshot - SE4's error list (`ErrorsGoTo`) had an export button. The window now has an **Export...** menu next to *Go to*, with four targets. All of them export the rows **as shown**, so an active summary-card filter is part of the export.

| Target | What comes out |
| --- | --- |
| Copy to clipboard | Tab separated with a header row - pastes as columns into Excel/Sheets, as a readable block anywhere else. A short "Copied to clipboard" line appears next to the buttons. |
| Text file (.txt) | A log: file name, summary, then two lines per error (time code + error, then the subtitle text). Meant for a mail, an issue, or an AI prompt - the use case in the issue. |
| Excel file (.xlsx) | A real workbook: frozen bold header, auto filter, column widths, and the line number written as a number so Excel sorts it as one. |
| Web page (.html) | A stand-alone page - no scripts, no web fonts, nothing to load - that follows the reader's light/dark preference, paints the error classes in the window's colours, and turns the summary cards into filter chips that work without JavaScript (`:checked` radios). |

### Why .xlsx and not .csv

A csv is split on the list separator of the machine that opens it, so a comma-separated file collapses into one column on a Danish or German Excel, and the text/quote guess mangles time codes. `XlsxWriter` (new, in `src/ui/Logic`) writes the OOXML zip directly - six small xml parts, inline strings, no new dependency. It is generic, so other reports can use it later.

### Tests

`ErrorListExportTests` (content: completeness, escaping, theme tokens, a workbook whose every part parses as xml and whose numbers are numbers) and `ErrorListExportCommandTests` (the menu's four targets, the button disabled with no errors, what the picker returns is what gets written, a cancelled picker writes nothing, and the export follows the active card filter). The generated workbook was also read back with openpyxl while developing: sheet name, dimensions, freeze pane, auto filter, column widths, bold header fill, and numeric line numbers all come through.

Full UI suite: 4510 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)