### PR TITLE
Pin the playhead when repeat playback seeks to the next line

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -29138,7 +29138,15 @@ public partial class MainViewModel :
                         {
                             if (_playSelectionItem.HasGapOrIsFirst())
                             {
-                                vp.Position = p.StartTime.TotalSeconds;
+                                // Pin like every other seek: a loop wrap seeks backwards while mpv keeps
+                                // reporting the old position for ~100-200 ms, so an unpinned cursor
+                                // extrapolates past the selection end and then snaps back late (or, for a
+                                // selection shorter than the resync threshold, never snaps back at all).
+                                // The stale estimate could also re-trigger this end check on the next tick
+                                // and skip right past the line just wrapped to. SeekTo, not Position: the
+                                // styled property drops an assignment equal to the held value.
+                                vp.SeekTo(p.StartTime.TotalSeconds);
+                                PinPlayheadTo(p.StartTime.TotalSeconds);
                             }
 
                             Dispatcher.UIThread.Post(() => { SubtitleGrid.ScrollIntoView(p); });


### PR DESCRIPTION
## Summary

The play-selection advance branch in the position timer seeks the player — always on a loop wrap (`HasGapOrIsFirst()` is true at index 0), and on gap jumps — without pinning the cursor estimate. Every other seek path in `MainViewModel` pins via `PinPlayheadTo` (the same class of gap PR #14261 closed for keyboard nudges, and the play-selection *stop* five lines above already pins).

For the ~100–200 ms until mpv reports the post-seek position, the unpinned estimate kept extrapolating past the selection end, then:

- the 0.5 s discontinuity snap yanked the cursor back **late** (visible backward jump), or
- for a selection shorter than the resync threshold, the forward-only drift correction never pulled it back at all, and
- since the end-of-selection check runs off the estimate, the stale value could satisfy `mediaPlayerSeconds >= EndSeconds` again on the very next 50 ms tick and advance right past the line just wrapped to — sidestepping the boundary guard from #14346, which compares against a position that is simply wrong during the seek latency.

Pinning makes the cursor (and the end check) authoritative at the wrapped-to line's start on the same tick the seek is issued.

The seek now goes through `SeekTo` instead of the `Position` styled property, which silently drops an assignment equal to the value it already holds (the trap PR #14260 added `SeekTo` for).

This extracts the one confirmed gap from #14384; see the analysis there for why the monotonic display floor and the speed-scaled freeze hold were not taken.

## Test plan

- `PlayheadFrameStepTests` + `PlaySelectionItemTests`: 13 passed, 0 failed.
- The pin path itself is covered by the existing `KeyboardNudgeSeek_PinsTheCursorToTheTargetImmediately`; the new call site lives in the position-timer closure, which the reflection-based test harness cannot tick directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)