### PR TITLE
Add Confucius4-TTS (CrispASR) voice-cloning TTS engine

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -172,6 +172,7 @@ using Nikse.SubtitleEdit.Features.Video.TextToSpeech.OmniVoiceSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Qwen3TtsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Qwen3TtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.VibeVoiceCrispAsrSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Confucius4TtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DotsTtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.IndexTtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.PocketTtsCrispAsrSettings;
@@ -298,6 +299,7 @@ public static class DependencyInjectionExtensions
         collection.AddHttpClientWithProxy<IIndexTtsCrispAsrDownloadService, IndexTtsCrispAsrDownloadService>();
         collection.AddHttpClientWithProxy<IPocketTtsCrispAsrDownloadService, PocketTtsCrispAsrDownloadService>();
         collection.AddHttpClientWithProxy<IDotsTtsCrispAsrDownloadService, DotsTtsCrispAsrDownloadService>();
+        collection.AddHttpClientWithProxy<IConfucius4TtsCrispAsrDownloadService, Confucius4TtsCrispAsrDownloadService>();
         collection.AddHttpClientWithProxy<IIndexTts25AudioCppDownloadService, IndexTts25AudioCppDownloadService>();
         collection.AddHttpClientWithProxy<ICosyVoice3CrispAsrDownloadService, CosyVoice3CrispAsrDownloadService>();
         collection.AddHttpClientWithProxy<IF5TtsCrispAsrDownloadService, F5TtsCrispAsrDownloadService>();
@@ -489,6 +491,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<IndexTtsCrispAsrSettingsViewModel>();
         collection.AddTransient<PocketTtsCrispAsrSettingsViewModel>();
         collection.AddTransient<DotsTtsCrispAsrSettingsViewModel>();
+        collection.AddTransient<Confucius4TtsCrispAsrSettingsViewModel>();
         collection.AddTransient<IndexTts25LicenseViewModel>();
         collection.AddTransient<VoiceCloneConsentViewModel>();
         collection.AddTransient<IndexTts25AudioCppSettingsViewModel>();

--- a/src/ui/Features/Video/TextToSpeech/Confucius4TtsCrispAsrSettings/Confucius4TtsCrispAsrSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/Confucius4TtsCrispAsrSettings/Confucius4TtsCrispAsrSettingsViewModel.cs
@@ -1,0 +1,266 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Confucius4TtsCrispAsrSettings;
+
+public partial class Confucius4TtsCrispAsrSettingsViewModel : ObservableObject
+{
+    // A SolidColorBrush set as Shape.Fill is parented into that shape's visual tree, so the same
+    // instance can't be shared across bound Ellipses (only one dot would render). Fresh brush per
+    // assignment instead.
+    private static IBrush Green() => new SolidColorBrush(Color.FromRgb(0x4C, 0xAF, 0x50));
+    private static IBrush Amber() => new SolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00));
+    private static IBrush Red() => new SolidColorBrush(Color.FromRgb(0xF4, 0x43, 0x36));
+    private static IBrush Grey() => new SolidColorBrush(Color.FromRgb(0x9E, 0x9E, 0x9E));
+
+    private readonly IWindowService _windowService;
+    private readonly IFolderHelper _folderHelper;
+
+    [ObservableProperty] private string _engineLabel = string.Empty;
+    [ObservableProperty] private IBrush _engineBrush = Grey();
+    [ObservableProperty] private string _engineDownloadButtonText = string.Empty;
+
+    [ObservableProperty] private string _coreQ8_0Label = string.Empty;
+    [ObservableProperty] private IBrush _coreQ8_0Brush = Grey();
+
+    [ObservableProperty] private string _coreF16Label = string.Empty;
+    [ObservableProperty] private IBrush _coreF16Brush = Grey();
+
+    [ObservableProperty] private string _vocoderLabel = string.Empty;
+    [ObservableProperty] private IBrush _vocoderBrush = Grey();
+
+    [ObservableProperty] private string _w2vLabel = string.Empty;
+    [ObservableProperty] private IBrush _w2vBrush = Grey();
+
+    [ObservableProperty] private string _voicesLabel = string.Empty;
+
+    [ObservableProperty] private double _odeSteps = Confucius4TtsCrispAsr.DefaultOdeSteps;
+
+    public string OdeStepsLabel => $"{(int)OdeSteps} steps";
+
+    partial void OnOdeStepsChanged(double value)
+    {
+        OnPropertyChanged(nameof(OdeStepsLabel));
+        Se.Settings.Video.TextToSpeech.Confucius4TtsCrispAsrOdeSteps =
+            Math.Clamp((int)Math.Round(value), Confucius4TtsCrispAsr.MinOdeSteps, Confucius4TtsCrispAsr.MaxOdeSteps);
+    }
+
+    [ObservableProperty] private string _modelsFolder = string.Empty;
+    [ObservableProperty] private string _voicesFolder = string.Empty;
+    [ObservableProperty] private bool _isEngineInstalled;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    public Confucius4TtsCrispAsrSettingsViewModel(IWindowService windowService, IFolderHelper folderHelper)
+    {
+        _windowService = windowService;
+        _folderHelper = folderHelper;
+    }
+
+    public void Initialize()
+    {
+        ModelsFolder = Confucius4TtsCrispAsr.GetSetModelsFolder();
+        VoicesFolder = Confucius4TtsCrispAsr.GetSetVoicesFolder();
+        OdeSteps = Confucius4TtsCrispAsr.ResolveOdeSteps();
+        Refresh();
+    }
+
+    private void Refresh()
+    {
+        var exe = Confucius4TtsCrispAsr.GetCrispAsrExecutable();
+        IsEngineInstalled = File.Exists(exe);
+
+        if (!IsEngineInstalled)
+        {
+            EngineLabel = string.Format(Se.Language.Video.TtsEngineNotInstalled, "CrispASR");
+            EngineBrush = Red();
+            EngineDownloadButtonText = string.Format(Se.Language.General.DownloadX, "CrispASR");
+        }
+        else if (Confucius4TtsCrispAsr.GetEngineUpdateStatus() == DownloadHashManager.UpdateStatus.UpdateAvailable)
+        {
+            EngineLabel = string.Format(Se.Language.Video.TtsEngineUpdateAvailable, "CrispASR");
+            EngineBrush = Amber();
+            EngineDownloadButtonText = string.Format(Se.Language.Video.TtsUpdateX, "CrispASR");
+        }
+        else
+        {
+            EngineLabel = "CrispASR";
+            EngineBrush = Green();
+            EngineDownloadButtonText = string.Format(Se.Language.General.ReDownloadX, "CrispASR");
+        }
+
+        // Append the installed CrispASR version asynchronously — the probe spawns a child process
+        // and the first call can take a few hundred ms.
+        if (IsEngineInstalled)
+        {
+            var baseLabel = EngineLabel;
+            _ = Task.Run(() =>
+            {
+                try
+                {
+                    var version = CrispAsrVersion.TryGet(exe);
+                    if (string.IsNullOrEmpty(version))
+                    {
+                        return;
+                    }
+                    Dispatcher.UIThread.Post(() =>
+                    {
+                        if (EngineLabel == baseLabel)
+                        {
+                            EngineLabel = baseLabel.Replace("CrispASR", $"CrispASR v{version}");
+                        }
+                    });
+                }
+                catch (Exception ex)
+                {
+                    Se.LogError(ex, "Confucius4TtsCrispAsrSettings: CrispASR version probe failed");
+                }
+            });
+        }
+
+        var coreQ8_0Ok = Confucius4TtsCrispAsr.IsValidLocalModelFile(
+                Confucius4TtsCrispAsr.GetT2sPath(Confucius4TtsCrispAsr.ModelKeyQ8_0), Confucius4TtsCrispAsr.T2sQ8_0FileName)
+            && Confucius4TtsCrispAsr.IsValidLocalModelFile(
+                Confucius4TtsCrispAsr.GetS2aPath(Confucius4TtsCrispAsr.ModelKeyQ8_0), Confucius4TtsCrispAsr.S2aQ8_0FileName);
+        ApplyModelStatus(coreQ8_0Ok,
+            IsEngineInstalled,
+            label => CoreQ8_0Label = label,
+            brush => CoreQ8_0Brush = brush);
+
+        var coreF16Ok = Confucius4TtsCrispAsr.IsValidLocalModelFile(
+                Confucius4TtsCrispAsr.GetT2sPath(Confucius4TtsCrispAsr.ModelKeyF16), Confucius4TtsCrispAsr.T2sF16FileName)
+            && Confucius4TtsCrispAsr.IsValidLocalModelFile(
+                Confucius4TtsCrispAsr.GetS2aPath(Confucius4TtsCrispAsr.ModelKeyF16), Confucius4TtsCrispAsr.S2aF16FileName);
+        ApplyModelStatus(coreF16Ok,
+            IsEngineInstalled,
+            label => CoreF16Label = label,
+            brush => CoreF16Brush = brush);
+
+        var vocoderPath = Confucius4TtsCrispAsr.GetVocoderPath();
+        ApplyModelStatus(Confucius4TtsCrispAsr.IsValidLocalModelFile(vocoderPath, Confucius4TtsCrispAsr.VocoderFileName),
+            IsEngineInstalled,
+            label => VocoderLabel = label,
+            brush => VocoderBrush = brush);
+
+        var w2vPath = Confucius4TtsCrispAsr.GetW2vPath();
+        ApplyModelStatus(Confucius4TtsCrispAsr.IsValidLocalModelFile(w2vPath, Confucius4TtsCrispAsr.W2vFileName),
+            IsEngineInstalled,
+            label => W2vLabel = label,
+            brush => W2vBrush = brush);
+
+        try
+        {
+            var wavCount = Directory.Exists(VoicesFolder)
+                ? Directory.GetFiles(VoicesFolder, "*.wav").Length
+                : 0;
+            VoicesLabel = wavCount == 0
+                ? "No voices imported"
+                : (wavCount == 1 ? "1 voice imported" : $"{wavCount} voices imported");
+        }
+        catch
+        {
+            VoicesLabel = string.Empty;
+        }
+    }
+
+    private static void ApplyModelStatus(bool fileInstalled, bool engineInstalled, Action<string> setLabel, Action<IBrush> setBrush)
+    {
+        if (fileInstalled)
+        {
+            setLabel("Installed");
+            setBrush(Green());
+            return;
+        }
+
+        if (!engineInstalled)
+        {
+            // No CrispASR runtime means there is nothing to auto-download into, so don't promise
+            // a download that can't happen until the user installs CrispASR.
+            setLabel("CrispASR required");
+            setBrush(Grey());
+            return;
+        }
+
+        setLabel("Auto-download on first use");
+        setBrush(Grey());
+    }
+
+    [RelayCommand]
+    private async Task RedownloadEngine()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        await TtsVoiceInstaller.EnsureCrispAsrForConfucius4Tts(Window, _windowService, forceRedownload: true);
+        Refresh();
+    }
+
+    [RelayCommand]
+    private async Task OpenModelsFolder()
+    {
+        if (Window == null || string.IsNullOrEmpty(ModelsFolder))
+        {
+            return;
+        }
+
+        try
+        {
+            await _folderHelper.OpenFolder(Window, ModelsFolder);
+        }
+        catch
+        {
+            // best-effort UX
+        }
+    }
+
+    [RelayCommand]
+    private async Task OpenVoicesFolder()
+    {
+        if (Window == null || string.IsNullOrEmpty(VoicesFolder))
+        {
+            return;
+        }
+
+        try
+        {
+            await _folderHelper.OpenFolder(Window, VoicesFolder);
+        }
+        catch
+        {
+            // best-effort UX
+        }
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/Confucius4TtsCrispAsrSettings/Confucius4TtsCrispAsrSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/Confucius4TtsCrispAsrSettings/Confucius4TtsCrispAsrSettingsWindow.cs
@@ -1,0 +1,271 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Confucius4TtsCrispAsrSettings;
+
+public class Confucius4TtsCrispAsrSettingsWindow : Window
+{
+    private const int LabelWidth = 150;
+    private const int ValueWidth = 360;
+
+    private readonly Confucius4TtsCrispAsrSettingsViewModel _vm;
+
+    public Confucius4TtsCrispAsrSettingsWindow(Confucius4TtsCrispAsrSettingsViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = string.Format(Se.Language.Video.TtsCrispAsrSettingsTitle, "Confucius4-TTS");
+        SizeToContent = SizeToContent.WidthAndHeight;
+        CanResize = false;
+        MinWidth = 580;
+
+        _vm = vm;
+        vm.Window = this;
+        DataContext = vm;
+
+        Content = BuildContent(vm);
+
+        var ok = UiUtil.MakeButtonOk(vm.OkCommand);
+        UiUtil.FocusOnFirstActivation(this, ok);
+    }
+
+    private Border BuildContent(Confucius4TtsCrispAsrSettingsViewModel vm)
+    {
+        var header = BuildHeader();
+        var details = BuildDetails(vm);
+        var actions = BuildActions(vm);
+
+        var stack = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 14,
+            Children = { header, details, actions },
+        };
+
+        var outerGrid = new Grid
+        {
+            Margin = UiUtil.MakeWindowMargin(),
+        };
+        outerGrid.Children.Add(stack);
+
+        return new Border
+        {
+            Child = outerGrid,
+            Padding = new Thickness(4),
+        };
+    }
+
+    private static StackPanel BuildHeader()
+    {
+        var title = new TextBlock
+        {
+            Text = "Confucius4-TTS (CrispASR)",
+            FontSize = 18,
+            FontWeight = FontWeight.SemiBold,
+        };
+
+        var subtitle = new TextBlock
+        {
+            Text = new Confucius4TtsCrispAsr().Description,
+            FontSize = 12,
+            Opacity = 0.75,
+            Margin = new Thickness(0, 2, 0, 0),
+        };
+
+        return new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 0,
+            Children = { title, subtitle },
+        };
+    }
+
+    private static Border BuildDetails(Confucius4TtsCrispAsrSettingsViewModel vm)
+    {
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(LabelWidth, GridUnitType.Pixel) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnSpacing = 12,
+            RowSpacing = 10,
+        };
+
+        grid.Add(MakeLabel(Se.Language.General.Engine), 0, 0);
+        var enginePanel = MakeStatusPanel(nameof(vm.EngineBrush), nameof(vm.EngineLabel));
+        var engineButton = UiUtil.MakeButton(string.Empty, vm.RedownloadEngineCommand)
+            .WithIconLeftBindText(IconNames.Download, nameof(vm.EngineDownloadButtonText))
+            .WithMarginLeft(12);
+        enginePanel.Children.Add(engineButton);
+        grid.Add(enginePanel, 0, 1);
+
+        grid.Add(MakeLabel("Model " + Confucius4TtsCrispAsr.ModelKeyQ8_0), 1, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.CoreQ8_0Brush), nameof(vm.CoreQ8_0Label)), 1, 1);
+
+        grid.Add(MakeLabel("Model " + Confucius4TtsCrispAsr.ModelKeyF16), 2, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.CoreF16Brush), nameof(vm.CoreF16Label)), 2, 1);
+
+        grid.Add(MakeLabel("BigVGAN vocoder"), 3, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.VocoderBrush), nameof(vm.VocoderLabel)), 3, 1);
+
+        grid.Add(MakeLabel("w2v-BERT encoder"), 4, 0);
+        grid.Add(MakeStatusPanel(nameof(vm.W2vBrush), nameof(vm.W2vLabel)), 4, 1);
+
+        grid.Add(MakeLabel(Se.Language.Video.Voices), 5, 0);
+        var voicesText = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.VoicesLabel)),
+        };
+        grid.Add(voicesText, 5, 1);
+
+        grid.Add(MakeLabel("Quality"), 6, 0);
+        grid.Add(MakeOdeStepsPanel(), 6, 1);
+
+        grid.Add(MakeLabel(Se.Language.General.InstallFolder), 7, 0);
+        var folderText = new TextBox
+        {
+            IsReadOnly = true,
+            Width = ValueWidth,
+            BorderThickness = new Thickness(0),
+            Background = Brushes.Transparent,
+            Padding = new Thickness(0),
+            VerticalContentAlignment = VerticalAlignment.Center,
+            FontSize = 12,
+            [!TextBox.TextProperty] = new Binding(nameof(vm.ModelsFolder)),
+        };
+        grid.Add(folderText, 7, 1);
+
+        return new Border
+        {
+            Child = grid,
+            Padding = new Thickness(14),
+            CornerRadius = new CornerRadius(6),
+            BorderThickness = new Thickness(1),
+            BorderBrush = new SolidColorBrush(Color.FromArgb(0x40, 0x80, 0x80, 0x80)),
+        };
+    }
+
+    /// <summary>
+    /// Flow-matching Euler steps for the S2A stage — the quality/speed knob this backend exposes
+    /// (--tts-steps; CrispASR default 20, upstream reference samples at 25).
+    /// </summary>
+    private static StackPanel MakeOdeStepsPanel()
+    {
+        var slider = new Slider
+        {
+            Minimum = Confucius4TtsCrispAsr.MinOdeSteps,
+            Maximum = Confucius4TtsCrispAsr.MaxOdeSteps,
+            Width = 220,
+            TickFrequency = 1,
+            IsSnapToTickEnabled = true,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!Slider.ValueProperty] = new Binding(nameof(Confucius4TtsCrispAsrSettingsViewModel.OdeSteps)),
+        };
+        var label = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            Margin = new Thickness(8, 0, 0, 0),
+            Width = 80,
+            [!TextBlock.TextProperty] = new Binding(nameof(Confucius4TtsCrispAsrSettingsViewModel.OdeStepsLabel)),
+        };
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { slider, label },
+        };
+    }
+
+    private static StackPanel MakeStatusPanel(string brushBindingPath, string labelBindingPath)
+    {
+        var dot = new Ellipse
+        {
+            Width = 10,
+            Height = 10,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!Ellipse.FillProperty] = new Binding(brushBindingPath),
+        };
+        var text = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            FontWeight = FontWeight.SemiBold,
+            Margin = new Thickness(8, 0, 0, 0),
+            [!TextBlock.TextProperty] = new Binding(labelBindingPath),
+        };
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { dot, text },
+        };
+    }
+
+    private static Grid BuildActions(Confucius4TtsCrispAsrSettingsViewModel vm)
+    {
+        var openModelsFolder = UiUtil.MakeButton(Se.Language.General.OpenContainingFolder, vm.OpenModelsFolderCommand).WithIconLeft(IconNames.FolderOpen);
+        var openVoicesFolder = UiUtil.MakeButton("Voices folder", vm.OpenVoicesFolderCommand).WithIconLeft(IconNames.FolderOpen);
+        var close = UiUtil.MakeButton(Se.Language.General.Close, vm.OkCommand);
+
+        var leftPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            Children = { openModelsFolder, openVoicesFolder },
+        };
+
+        var rightPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Spacing = 8,
+            Children = { close },
+        };
+
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+        };
+        grid.Add(leftPanel, 0, 0);
+        grid.Add(rightPanel, 0, 2);
+        return grid;
+    }
+
+    private static TextBlock MakeLabel(string text) => new()
+    {
+        Text = text,
+        Opacity = 0.7,
+        VerticalAlignment = VerticalAlignment.Center,
+    };
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        _vm.OnKeyDown(e);
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -58,6 +58,7 @@ public partial class DownloadTtsViewModel : ObservableObject
     private Task? _downloadTaskVibeVoiceCrispAsrModels;
     private Task? _downloadTaskVibeVoiceCrispAsrVoices;
     private Task? _downloadTaskDotsTtsCrispAsrModels;
+    private Task? _downloadTaskConfucius4TtsCrispAsrModels;
     private Task? _downloadTaskIndexTtsCrispAsrModels;
     private Task? _downloadTaskIndexTtsCrispAsrVoices;
     private Task? _downloadTaskPocketTtsCrispAsrModels;
@@ -90,6 +91,7 @@ public partial class DownloadTtsViewModel : ObservableObject
     private readonly IIndexTtsCrispAsrDownloadService _indexTtsCrispAsrDownloadService;
     private readonly IPocketTtsCrispAsrDownloadService _pocketTtsCrispAsrDownloadService;
     private readonly IDotsTtsCrispAsrDownloadService _dotsTtsCrispAsrDownloadService;
+    private readonly IConfucius4TtsCrispAsrDownloadService _confucius4TtsCrispAsrDownloadService;
     private readonly IIndexTts25AudioCppDownloadService _indexTts25AudioCppDownloadService;
     private Task? _downloadTaskIndexTts25AudioCppEngine;
     private Task? _downloadTaskIndexTts25AudioCppModels;
@@ -136,6 +138,7 @@ public partial class DownloadTtsViewModel : ObservableObject
         IIndexTtsCrispAsrDownloadService indexTtsCrispAsrDownloadService,
         IPocketTtsCrispAsrDownloadService pocketTtsCrispAsrDownloadService,
         IDotsTtsCrispAsrDownloadService dotsTtsCrispAsrDownloadService,
+        IConfucius4TtsCrispAsrDownloadService confucius4TtsCrispAsrDownloadService,
         IIndexTts25AudioCppDownloadService indexTts25AudioCppDownloadService,
         ICosyVoice3CrispAsrDownloadService cosyVoice3CrispAsrDownloadService,
         IF5TtsCrispAsrDownloadService f5TtsCrispAsrDownloadService,
@@ -154,6 +157,7 @@ public partial class DownloadTtsViewModel : ObservableObject
         _indexTtsCrispAsrDownloadService = indexTtsCrispAsrDownloadService;
         _pocketTtsCrispAsrDownloadService = pocketTtsCrispAsrDownloadService;
         _dotsTtsCrispAsrDownloadService = dotsTtsCrispAsrDownloadService;
+        _confucius4TtsCrispAsrDownloadService = confucius4TtsCrispAsrDownloadService;
         _indexTts25AudioCppDownloadService = indexTts25AudioCppDownloadService;
         _downloadStreamIndexTts25AudioCppEngine = new MemoryStream();
         _downloadStreamIndexTts25AudioCppVoices = new MemoryStream();
@@ -994,6 +998,18 @@ public partial class DownloadTtsViewModel : ObservableObject
                 return;
             }
 
+            if (_downloadTaskConfucius4TtsCrispAsrModels is { IsCompletedSuccessfully: true })
+            {
+                // Same as dots.tts: no voice pack to fetch afterwards — Confucius4-TTS clones
+                // from user-imported WAVs, and the engine seeds the voices folder from
+                // qwen3-tts.cpp on first use.
+                _timer.Stop();
+                _downloadTaskConfucius4TtsCrispAsrModels = null;
+                OkPressed = true;
+                Close();
+                return;
+            }
+
             if (_downloadTaskDotsTtsCrispAsrModels is { IsFaulted: true })
             {
                 _timer.Stop();
@@ -1008,6 +1024,24 @@ public partial class DownloadTtsViewModel : ObservableObject
                 {
                     ProgressText = Se.Language.General.DownloadFailed;
                     Error = dotsEx?.Message ?? Se.Language.General.UnknownError;
+                }
+                return;
+            }
+
+            if (_downloadTaskConfucius4TtsCrispAsrModels is { IsFaulted: true })
+            {
+                _timer.Stop();
+                var confuciusEx = _downloadTaskConfucius4TtsCrispAsrModels.Exception?.InnerException ?? _downloadTaskConfucius4TtsCrispAsrModels.Exception;
+                _downloadTaskConfucius4TtsCrispAsrModels = null;
+                if (confuciusEx is OperationCanceledException)
+                {
+                    ProgressText = Se.Language.General.DownloadCanceled;
+                    Close();
+                }
+                else
+                {
+                    ProgressText = Se.Language.General.DownloadFailed;
+                    Error = confuciusEx?.Message ?? Se.Language.General.UnknownError;
                 }
                 return;
             }
@@ -2264,6 +2298,29 @@ public partial class DownloadTtsViewModel : ObservableObject
 
         _downloadTaskDotsTtsCrispAsrModels =
             _dotsTtsCrispAsrDownloadService.DownloadModels(DotsTtsCrispAsr.GetSetModelsFolder(), resolved, downloadProgress, titleProgress, _cancellationTokenSource.Token);
+    }
+
+    public void StartDownloadConfucius4TtsCrispAsrModels(string? modelKey = null)
+    {
+        var resolved = Confucius4TtsCrispAsr.ResolveModelKey(modelKey);
+        var t2sFileName = Confucius4TtsCrispAsr.GetT2sFileName(resolved);
+        TitleText = string.Format(Se.Language.General.DownloadingX, $"Confucius4-TTS (CrispASR) models ({resolved}): {t2sFileName}");
+
+        var downloadProgress = new Progress<float>(number =>
+        {
+            var percentage = (int)Math.Round(number * 100.0, MidpointRounding.AwayFromZero);
+            var pctString = percentage.ToString(CultureInfo.InvariantCulture);
+            ProgressValue = percentage;
+            ProgressText = string.Format(Se.Language.General.DownloadingXPercent, pctString);
+        });
+
+        var titleProgress = new Action<string>(title =>
+        {
+            Dispatcher.UIThread.Post(() => TitleText = title);
+        });
+
+        _downloadTaskConfucius4TtsCrispAsrModels =
+            _confucius4TtsCrispAsrDownloadService.DownloadModels(Confucius4TtsCrispAsr.GetSetModelsFolder(), resolved, downloadProgress, titleProgress, _cancellationTokenSource.Token);
     }
 
     public void StartDownloadIndexTtsCrispAsrModels(string? modelKey = null)

--- a/src/ui/Features/Video/TextToSpeech/Engines/Confucius4TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Confucius4TtsCrispAsr.cs
@@ -1,0 +1,851 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// Confucius4-TTS (NetEase Youdao, Apache-2.0) run through the CrispASR runtime. A two-stage
+/// pipeline: a GPT-2 T2S model (24L/1280d) turns text into semantic tokens, a flow-matching
+/// DiT + WaveNet S2A model renders them into mel frames conditioned on a w2v-BERT embedding plus
+/// a CAM++ style vector from the reference audio, and a BigVGAN vocoder outputs <b>22.05 kHz</b>
+/// mono — the only 22 kHz TTS engine SE ships. Officially trained on 14 languages
+/// (<see cref="Confucius4TtsLanguages"/>), passed as the startup <c>-l</c> flag.
+///
+/// Four GGUFs are needed:
+///  - confucius4-tts-t2s-{q8_0,f16}.gguf  : the T2S core (passed as -m)
+///  - confucius4-tts-s2a-{q8_0,f16}.gguf  : flow-matching S2A (passed as --codec-model)
+///  - confucius4-tts-bigvgan-22k-f16.gguf : BigVGAN vocoder (auto-discovered sibling)
+///  - confucius4-tts-w2v-f16.gguf         : w2v-BERT reference encoder (auto-discovered sibling)
+///
+/// <b>Q4_K is deliberately not offered.</b> The registry's default quant makes the flow-matching
+/// alignment break down audibly — an A/B against Q8_0 with the same text and reference confirmed
+/// upstream's report (CrispASR #377): Q4_K sounds flat and robotic where Q8_0 holds the
+/// reference's prosody. That earlier Q4_K test is also why this engine was first judged "too
+/// robotic to ship". Since Q8_0 vs F16 only differs in the T2S/S2A core (the vocoder and w2v
+/// companions are F16 in both), Q8_0 is the default.
+///
+/// <b>Zero-shot cloning is mandatory, not optional</b> — without <c>--voice</c> conditioning the
+/// output is unintelligible by design (there is no default-voice mode at all), so the voice combo
+/// only offers imported reference WAVs and synthesis refuses to run without one.
+///
+/// The S2A/vocoder chain works at 22.05 kHz and the w2v-BERT/CAM++ encoders at 16 kHz; crispasr
+/// resamples the reference internally to both, so references are staged at 22.05 kHz — the mel
+/// path reads them untouched and the encoder path downsamples cleanly.
+///
+/// Like indextts/dots-tts, the backend applies the reference only at init from the startup
+/// <c>--voice</c> flag (crispasr_backend_confucius4_tts.cpp), and <c>/v1/audio/speech</c> has no
+/// per-request language field, so a change of voice, quant, language or step count restarts the
+/// server. No <c>ref-text</c> either: conditioning is from audio alone, so imported WAVs need no
+/// .txt sidecar.
+///
+/// CLI shape (verified on v0.8.31, macOS/Metal, 2026-09-01):
+///   crispasr --backend confucius4-tts -m confucius4-tts-t2s-q8_0.gguf \
+///       --codec-model confucius4-tts-s2a-q8_0.gguf \
+///       --voice reference.wav --i-have-rights -l en \
+///       --tts "Hello, how are you today?" --tts-output out.wav
+/// </summary>
+public class Confucius4TtsCrispAsr : ITtsEngine
+{
+    public string Name => "Confucius4-TTS (CrispASR)";
+    public string Description => "Confucius4-TTS (NetEase Youdao), 14 languages with voice cloning, via CrispASR";
+    public bool HasLanguageParameter => true;
+    public bool HasApiKey => false;
+    public bool HasRegion => false;
+    public bool HasModel => true;
+    public bool HasKeyFile => false;
+    public bool SupportsVoiceCloning => true;
+    public bool SupportsPerLineVoiceCloning => false;
+
+    // Labels carry the total download (T2S + S2A + vocoder + w2v-BERT companion), not just the
+    // quantized pair, so the dropdown does not understate what the user is about to fetch.
+    public const string ModelKeyQ8_0 = "Q8_0 (~1.9 GB)";
+    public const string ModelKeyF16 = "F16 (~2.6 GB)";
+    public const string DefaultModelKey = ModelKeyQ8_0;
+
+    public const string T2sQ8_0FileName = "confucius4-tts-t2s-q8_0.gguf";
+    public const string T2sF16FileName = "confucius4-tts-t2s-f16.gguf";
+    public const string S2aQ8_0FileName = "confucius4-tts-s2a-q8_0.gguf";
+    public const string S2aF16FileName = "confucius4-tts-s2a-f16.gguf";
+
+    /// <summary>
+    /// BigVGAN 22.05 kHz vocoder. F16 for both quants — the Q8_0 variant is the same size to
+    /// within 4 KB, so there is nothing to save.
+    /// </summary>
+    public const string VocoderFileName = "confucius4-tts-bigvgan-22k-f16.gguf";
+
+    /// <summary>
+    /// w2v-BERT reference encoder (~824 MB, F16 only — no other quant exists in the repo).
+    /// CrispASR auto-discovers it as a sibling of the T2S GGUF; without it the T2S stage loses
+    /// its native condition_emb and clone similarity drops.
+    /// </summary>
+    public const string W2vFileName = "confucius4-tts-w2v-f16.gguf";
+
+    public const string BackendName = "confucius4-tts";
+
+    /// <summary>
+    /// Flow-matching Euler steps for the S2A stage, passed via <c>--tts-steps</c>. CrispASR's
+    /// default is 20; upstream's reference implementation samples at 25.
+    /// </summary>
+    public const int MinOdeSteps = 10;
+    public const int MaxOdeSteps = 40;
+    public const int DefaultOdeSteps = 20;
+
+    // Exact byte sizes from the HF tree API (cstr/confucius4-tts-GGUF). Same truncation guard as
+    // the other CrispASR TTS engines — a partial GGUF crashes the loader at server startup.
+    private static readonly Dictionary<string, long> ExpectedFileSizes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [T2sQ8_0FileName] = 718043648L,
+        [T2sF16FileName] = 1326049024L,
+        [S2aQ8_0FileName] = 169737216L,
+        [S2aF16FileName] = 222990272L,
+        [VocoderFileName] = 224624608L,
+        [W2vFileName] = 823502048L,
+    };
+
+    public static string ResolveModelKey(string? modelKey)
+    {
+        if (string.IsNullOrEmpty(modelKey))
+        {
+            var saved = Se.Settings.Video.TextToSpeech.Confucius4TtsCrispAsrModel;
+            return string.IsNullOrEmpty(saved) ? DefaultModelKey : ResolveModelKey(saved);
+        }
+
+        return modelKey switch
+        {
+            ModelKeyF16 => ModelKeyF16,
+            _ => ModelKeyQ8_0,
+        };
+    }
+
+    public static string GetT2sFileName(string? modelKey) => ResolveModelKey(modelKey) switch
+    {
+        ModelKeyF16 => T2sF16FileName,
+        _ => T2sQ8_0FileName,
+    };
+
+    /// <summary>
+    /// The S2A quant follows the T2S quant. Passed explicitly as <c>--codec-model</c> because the
+    /// backend's own sibling auto-discovery probes q4_k FIRST (crispasr_backend_confucius4_tts.cpp)
+    /// — a stray q4_k file in the models folder would silently degrade quality.
+    /// </summary>
+    public static string GetS2aFileName(string? modelKey) => ResolveModelKey(modelKey) switch
+    {
+        ModelKeyF16 => S2aF16FileName,
+        _ => S2aQ8_0FileName,
+    };
+
+    public static int ResolveOdeSteps()
+    {
+        var saved = Se.Settings.Video.TextToSpeech.Confucius4TtsCrispAsrOdeSteps;
+        return saved <= 0 ? DefaultOdeSteps : Math.Clamp(saved, MinOdeSteps, MaxOdeSteps);
+    }
+
+    public static bool IsValidLocalModelFile(string path, string fileName)
+    {
+        if (!File.Exists(path))
+        {
+            return false;
+        }
+
+        if (!ExpectedFileSizes.TryGetValue(fileName, out var expected))
+        {
+            return true;
+        }
+
+        try
+        {
+            return new FileInfo(path).Length == expected;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static readonly HttpClient HttpClient = new()
+    {
+        Timeout = TimeSpan.FromMinutes(10),
+    };
+    private static readonly SemaphoreSlim ServerLock = new(1, 1);
+    private static Process? _serverProcess;
+    private static int _serverPort;
+    private static string? _serverLaunchCommand;
+    // Same startup-flag cloning as indextts/dots-tts: the reference is read from the --voice path
+    // at server start, never from the request body, so a voice change means tear down and restart.
+    // Tracked alongside the quant, language and ODE steps, which are equally baked in.
+    private static string? _serverVoicePath;
+    private static string? _serverModelKey;
+    private static string? _serverLanguageArg;
+    private static int _serverOdeSteps;
+    private static bool _processExitHooked;
+    private static readonly StringBuilder _serverLog = new();
+
+    private static string ServerBaseUrl => $"http://127.0.0.1:{_serverPort}";
+
+    public Task<bool> IsInstalled(string? region)
+    {
+        return Task.FromResult(File.Exists(GetCrispAsrExecutable()));
+    }
+
+    public override string ToString() => Name;
+
+    /// <summary>
+    /// Path to the crispasr executable installed by the speech-to-text feature. Shared with every
+    /// other CrispASR-backed engine.
+    /// </summary>
+    public static string GetCrispAsrExecutable()
+    {
+        return new CrispAsrCohere().GetExecutable();
+    }
+
+    public static DownloadHashManager.UpdateStatus GetEngineUpdateStatus()
+    {
+        var exe = GetCrispAsrExecutable();
+        if (!File.Exists(exe))
+        {
+            return DownloadHashManager.UpdateStatus.Unknown;
+        }
+
+        var folder = Path.GetDirectoryName(exe);
+        return string.IsNullOrEmpty(folder)
+            ? DownloadHashManager.UpdateStatus.Unknown
+            : DownloadHashManager.GetSidecarStatus(folder);
+    }
+
+    public static string GetSetFolder()
+    {
+        if (!Directory.Exists(Se.TextToSpeechFolder))
+        {
+            Directory.CreateDirectory(Se.TextToSpeechFolder);
+        }
+
+        var folder = Path.Combine(Se.TextToSpeechFolder, "Confucius4TtsCrispAsr");
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        return folder;
+    }
+
+    public static string GetSetModelsFolder()
+    {
+        // Like the other CrispASR-backed engines, the GGUFs live alongside CrispASR's
+        // speech-to-text models in CrispASR/models/ rather than under TextToSpeech/.
+        var modelsFolder = Path.Combine(Se.CrispAsrFolder, "models");
+        if (!Directory.Exists(modelsFolder))
+        {
+            Directory.CreateDirectory(modelsFolder);
+        }
+
+        return modelsFolder;
+    }
+
+    public static string GetSetVoicesFolder()
+    {
+        var voicesFolder = Path.Combine(GetSetFolder(), "voices");
+        if (!Directory.Exists(voicesFolder))
+        {
+            Directory.CreateDirectory(voicesFolder);
+        }
+
+        SeedVoicesFromQwen3TtsCppIfEmpty(voicesFolder);
+        return voicesFolder;
+    }
+
+    private static bool _voiceSeedAttempted;
+
+    /// <summary>
+    /// One-time best-effort seed of WAV reference voices from qwen3-tts.cpp's voices folder, so a
+    /// fresh install has something in the voice combo — with no reference this backend produces
+    /// nothing usable at all. Resampled to 22.05 kHz on the way in, matching
+    /// <see cref="ImportVoice"/>.
+    /// </summary>
+    private static void SeedVoicesFromQwen3TtsCppIfEmpty(string voicesFolder)
+    {
+        if (_voiceSeedAttempted)
+        {
+            return;
+        }
+        _voiceSeedAttempted = true;
+
+        try
+        {
+            if (Directory.EnumerateFiles(voicesFolder, "*.wav").Any())
+            {
+                return;
+            }
+
+            var sourceFolder = Qwen3TtsCpp.GetSetVoicesFolder();
+            if (!Directory.Exists(sourceFolder) || !Directory.EnumerateFiles(sourceFolder, "*.wav").Any())
+            {
+                return;
+            }
+
+            foreach (var src in Directory.GetFiles(sourceFolder, "*.wav"))
+            {
+                var dest = Path.Combine(voicesFolder, Path.GetFileName(src));
+                VoiceSeedHelper.CopyOrResample(src, dest, 22050, "Confucius4-TTS (CrispASR)");
+            }
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, "Confucius4-TTS (CrispASR): voice seeding from qwen3-tts.cpp folder failed");
+        }
+    }
+
+    public static string GetT2sPath(string? modelKey = null) =>
+        Path.Combine(GetSetModelsFolder(), GetT2sFileName(modelKey));
+
+    public static string GetS2aPath(string? modelKey = null) =>
+        Path.Combine(GetSetModelsFolder(), GetS2aFileName(modelKey));
+
+    public static string GetVocoderPath() =>
+        Path.Combine(GetSetModelsFolder(), VocoderFileName);
+
+    public static string GetW2vPath() =>
+        Path.Combine(GetSetModelsFolder(), W2vFileName);
+
+    public static bool AreModelsInstalled(string? modelKey = null) =>
+        IsValidLocalModelFile(GetT2sPath(modelKey), GetT2sFileName(modelKey))
+        && IsValidLocalModelFile(GetS2aPath(modelKey), GetS2aFileName(modelKey))
+        && IsValidLocalModelFile(GetVocoderPath(), VocoderFileName)
+        && IsValidLocalModelFile(GetW2vPath(), W2vFileName);
+
+    /// <summary>
+    /// Path crispasr's --auto-download writes GGUFs to, so SE's downloader can adopt files a
+    /// previous CLI run already fetched instead of re-pulling gigabytes.
+    /// </summary>
+    public static string GetCrispAsrCacheFolder() =>
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".cache", "crispasr");
+
+    public static bool TrySeedModelFromCrispAsrCache(string fileName, string destinationPath)
+    {
+        if (IsValidLocalModelFile(destinationPath, fileName))
+        {
+            return true;
+        }
+
+        try
+        {
+            if (File.Exists(destinationPath))
+            {
+                Se.LogError($"Confucius4-TTS (CrispASR): removing wrong-sized local model file {destinationPath}");
+                File.Delete(destinationPath);
+            }
+
+            var cachePath = Path.Combine(GetCrispAsrCacheFolder(), fileName);
+            if (!IsValidLocalModelFile(cachePath, fileName))
+            {
+                return false;
+            }
+
+            File.Copy(cachePath, destinationPath);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, $"Confucius4-TTS (CrispASR): cache seed copy failed for {fileName}");
+            return false;
+        }
+    }
+
+    public async Task<Voice[]> GetVoices(string language)
+    {
+        var result = new List<Voice>();
+
+        // Voice cloning only — there are no preset voices and no default voice at all (the
+        // backend's output is unintelligible without a reference), so the combo is empty until
+        // the user imports a reference WAV (or the qwen3-tts.cpp seed above runs).
+        // Off the UI thread: GetSetVoicesFolder does one-time seeding through ffmpeg.
+        var voicesFolder = await Task.Run(GetSetVoicesFolder);
+        if (Directory.Exists(voicesFolder))
+        {
+            foreach (var file in Directory.GetFiles(voicesFolder, "*.wav"))
+            {
+                var name = Path.GetFileNameWithoutExtension(file).Replace('_', ' ');
+                result.Add(new Voice(new Confucius4TtsVoice(name, file)));
+            }
+        }
+
+        return result.ToArray();
+    }
+
+    public bool IsVoiceInstalled(Voice voice) => true;
+
+    public Task<string[]> GetRegions() => Task.FromResult(Array.Empty<string>());
+
+    public Task<string[]> GetModels() => Task.FromResult(new[] { ModelKeyQ8_0, ModelKeyF16 });
+
+    public Task<TtsLanguage[]> GetLanguages(Voice voice, string? model) => Task.FromResult(Confucius4TtsLanguages.All);
+
+    public Task<Voice[]> RefreshVoices(string language, CancellationToken cancellationToken) =>
+        GetVoices(language);
+
+    public async Task<TtsResult> Speak(
+        string text,
+        string outputFolder,
+        Voice voice,
+        TtsLanguage? language,
+        string? region,
+        string? model,
+        CancellationToken cancellationToken)
+    {
+        if (voice.EngineVoice is not Confucius4TtsVoice confuciusVoice)
+        {
+            throw new ArgumentException("Voice is not a Confucius4TtsVoice");
+        }
+
+        if (string.IsNullOrEmpty(confuciusVoice.FilePath))
+        {
+            throw new InvalidOperationException(
+                "Confucius4-TTS (CrispASR) requires a reference voice WAV — without one the "
+                + "output is unintelligible by design. Import one via the voice settings, then "
+                + "pick it in the voice combo. Reference WAV should be 3-10 s of clean speech.");
+        }
+
+        var modelKey = ResolveModelKey(model);
+        var languageArg = Confucius4TtsLanguages.ResolveLanguageArg(language);
+        await EnsureServerRunningAsync(modelKey, confuciusVoice.FilePath, languageArg, cancellationToken);
+
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder), Guid.NewGuid() + ".wav");
+
+        // Deliberately NO `voice` field: like indextts/dots-tts, the confucius4-tts backend takes
+        // its reference from the startup --voice path (applied only in the adapter's init), and
+        // the server rejects absolute paths in the request body outright (path-traversal guard).
+        // Also no `ref_text`: conditioning is w2v-BERT + CAM++ from the audio alone, so the field
+        // has nothing to bind to. No `speed` either — confucius4-tts is not in crispasr's
+        // --tts-speed backend list; the quality/speed knob that does work here is the ODE step
+        // count passed at server launch. No temperature: the backend's own 0.8 default matters
+        // (greedy T2S decode degenerates into a repeat loop that runs to the token cap).
+        var payload = new Dictionary<string, object>
+        {
+            ["input"] = text,
+            ["response_format"] = "wav",
+        };
+
+        // Attests the user's own imported reference and the AI-disclosure duty; see
+        // CrispAsrTtsProvenance. Skipped when voice cloning has not been accepted in settings.
+        CrispAsrTtsProvenance.AddSpeechAttestations(payload);
+
+        var body = JsonSerializer.Serialize(payload);
+        using var content = new StringContent(body, Encoding.UTF8, "application/json");
+        Se.WriteToolsLog($"Confucius4-TTS (CrispASR): POST {ServerBaseUrl}/v1/audio/speech (voice={confuciusVoice}, language={(string.IsNullOrEmpty(languageArg) ? "(en)" : languageArg)}, textLen={text.Length})");
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await HttpClient.PostAsync($"{ServerBaseUrl}/v1/audio/speech", content, cancellationToken);
+        }
+        catch (HttpRequestException ex)
+        {
+            var serverLog = SnapshotServerLog();
+            var launchCommand = _serverLaunchCommand;
+            var died = _serverProcess?.HasExited == true;
+            if (died)
+            {
+                StopServerInternal();
+            }
+
+            var failMsg = $"Confucius4-TTS (CrispASR) request failed — Voice: {confuciusVoice}, Text: {text}, "
+                + $"RequestJson: {body}, ServerExited: {died}, ServerLog: {serverLog}"
+                + LaunchCmdSuffix(launchCommand);
+            Se.LogError(ex, failMsg);
+            Se.WriteToolsLog(failMsg);
+
+            throw new InvalidOperationException(
+                (died
+                    ? "Confucius4-TTS (CrispASR) — the crispasr server crashed during synthesis."
+                    : "Confucius4-TTS (CrispASR) request failed — the connection to the crispasr server was dropped.")
+                + (string.IsNullOrEmpty(serverLog) ? string.Empty : $"{Environment.NewLine}Server log:{Environment.NewLine}{serverLog}")
+                + LaunchCmdSuffix(launchCommand),
+                ex);
+        }
+
+        using (response)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorBody = await SafeReadErrorAsync(response, cancellationToken);
+                var serverLog = SnapshotServerLog();
+                var launchCommand = _serverLaunchCommand;
+                var errMsg = $"Confucius4-TTS (CrispASR) server error {(int)response.StatusCode} {response.StatusCode} — "
+                    + $"Voice: {confuciusVoice}, Text: {text}, RequestJson: {body}, "
+                    + $"ResponseBody: {errorBody}, ServerLog: {serverLog}"
+                    + LaunchCmdSuffix(launchCommand);
+                Se.LogError(errMsg);
+                Se.WriteToolsLog(errMsg);
+                throw new InvalidOperationException(
+                    $"Confucius4-TTS (CrispASR) synthesis failed ({(int)response.StatusCode}): {errorBody}"
+                    + (string.IsNullOrEmpty(serverLog) ? string.Empty : $"{Environment.NewLine}Server log:{Environment.NewLine}{serverLog}")
+                    + LaunchCmdSuffix(launchCommand));
+            }
+
+            await using var fileStream = File.Create(outputFileName);
+            await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+            await contentStream.CopyToAsync(fileStream, cancellationToken);
+        }
+
+        return new TtsResult(outputFileName, text);
+    }
+
+    private static string FormatLaunchCommand(string exe, System.Collections.ObjectModel.Collection<string> args)
+    {
+        static string Quote(string s) =>
+            !string.IsNullOrEmpty(s) && s.IndexOfAny(new[] { ' ', '\t' }) >= 0
+                ? "\"" + s.Replace("\"", "\\\"") + "\""
+                : s;
+
+        var sb = new StringBuilder(Quote(exe));
+        foreach (var a in args)
+        {
+            sb.Append(' ').Append(Quote(a));
+        }
+        return sb.ToString();
+    }
+
+    private static string LaunchCmdSuffix(string? launchCommand) =>
+        string.IsNullOrEmpty(launchCommand)
+            ? string.Empty
+            : $"{Environment.NewLine}Launch command: {launchCommand}";
+
+    private static async Task<string> SafeReadErrorAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        try
+        {
+            return await response.Content.ReadAsStringAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            return $"<failed to read error body: {ex.Message}>";
+        }
+    }
+
+    private static async Task EnsureServerRunningAsync(string modelKey, string voicePath, string languageArg, CancellationToken ct)
+    {
+        var odeSteps = ResolveOdeSteps();
+
+        if (_serverProcess is { HasExited: false } && _serverPort != 0
+            && string.Equals(_serverVoicePath, voicePath, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(_serverModelKey, modelKey, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(_serverLanguageArg, languageArg, StringComparison.OrdinalIgnoreCase)
+            && _serverOdeSteps == odeSteps)
+        {
+            return;
+        }
+
+        await ServerLock.WaitAsync(ct);
+        try
+        {
+            if (_serverProcess is { HasExited: false } && _serverPort != 0
+                && string.Equals(_serverVoicePath, voicePath, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(_serverModelKey, modelKey, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(_serverLanguageArg, languageArg, StringComparison.OrdinalIgnoreCase)
+                && _serverOdeSteps == odeSteps)
+            {
+                return;
+            }
+
+            if (_serverProcess != null)
+            {
+                StopServerInternal();
+            }
+
+            var exe = GetCrispAsrExecutable();
+            if (!File.Exists(exe))
+            {
+                throw new FileNotFoundException(
+                    "CrispASR executable not found. Install CrispASR via Video → Audio to text first.", exe);
+            }
+
+            var t2sFileName = GetT2sFileName(modelKey);
+            var t2s = GetT2sPath(modelKey);
+            var hasLocalT2s = IsValidLocalModelFile(t2s, t2sFileName);
+            var s2aFileName = GetS2aFileName(modelKey);
+            var s2a = GetS2aPath(modelKey);
+            var hasLocalS2a = IsValidLocalModelFile(s2a, s2aFileName);
+
+            var port = FindFreeLoopbackPort();
+            var psi = new ProcessStartInfo
+            {
+                WorkingDirectory = Path.GetDirectoryName(exe) ?? GetSetFolder(),
+                FileName = exe,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                // The server writes UTF-8; without these the captured log reaches bug reports as
+                // mojibake on Windows (#13572).
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8,
+            };
+            psi.ArgumentList.Add("--server");
+            psi.ArgumentList.Add("--backend");
+            psi.ArgumentList.Add(BackendName);
+            psi.ArgumentList.Add("-m");
+            psi.ArgumentList.Add(hasLocalT2s ? t2s : "auto");
+            if (hasLocalS2a)
+            {
+                // Explicit rather than sibling discovery: the backend probes q4_k FIRST when left
+                // to find the S2A on its own, and q4_k is the quant with the audible flow-matching
+                // degradation this engine deliberately does not ship.
+                psi.ArgumentList.Add("--codec-model");
+                psi.ArgumentList.Add(s2a);
+            }
+            if (!hasLocalT2s || !hasLocalS2a)
+            {
+                // Fallback when SE's own download was skipped or is incomplete. Note the registry
+                // set behind `-m auto` is the q4_k pair — degraded but intelligible, and better
+                // than refusing to speak; the SE downloader replaces it with Q8_0 on next install.
+                psi.ArgumentList.Add("--auto-download");
+            }
+            psi.ArgumentList.Add("--host");
+            psi.ArgumentList.Add("127.0.0.1");
+            psi.ArgumentList.Add("--port");
+            psi.ArgumentList.Add(port.ToString(CultureInfo.InvariantCulture));
+            psi.ArgumentList.Add("--voice-dir");
+            psi.ArgumentList.Add(GetSetVoicesFolder());
+            // Required: the confucius4-tts backend clones only from the startup --voice path, and
+            // without a reference the output is unintelligible by design. The w2v-BERT companion
+            // next to the T2S GGUF is picked up automatically when this is set.
+            psi.ArgumentList.Add("--voice");
+            psi.ArgumentList.Add(voicePath);
+            // Target language for the Chinese prompt template. Empty = no flag, which the backend
+            // reads as English.
+            if (!string.IsNullOrEmpty(languageArg))
+            {
+                psi.ArgumentList.Add("-l");
+                psi.ArgumentList.Add(languageArg);
+            }
+            psi.ArgumentList.Add("--tts-steps");
+            psi.ArgumentList.Add(odeSteps.ToString(CultureInfo.InvariantCulture));
+            CrispAsrTtsProvenance.AddServerMarkingArgs(psi.ArgumentList, exe);
+
+            var process = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start crispasr (confucius4-tts)");
+
+            var launchCommand = FormatLaunchCommand(exe, psi.ArgumentList);
+            _serverLaunchCommand = launchCommand;
+            Se.WriteToolsLog("Confucius4-TTS (CrispASR) server starting — "
+                + $"PID: {process.Id}, "
+                + $"Cmd: {launchCommand}");
+
+            lock (_serverLog) _serverLog.Clear();
+            process.ErrorDataReceived += (_, e) =>
+            {
+                if (e.Data != null) lock (_serverLog) _serverLog.AppendLine(e.Data);
+            };
+            process.OutputDataReceived += (_, e) =>
+            {
+                if (e.Data != null) lock (_serverLog) _serverLog.AppendLine(e.Data);
+            };
+            process.BeginErrorReadLine();
+            process.BeginOutputReadLine();
+
+            _serverProcess = process;
+            _serverPort = port;
+            _serverVoicePath = voicePath;
+            _serverModelKey = modelKey;
+            _serverLanguageArg = languageArg;
+            _serverOdeSteps = odeSteps;
+            HookProcessExitOnce();
+
+            // ~1.9 GB across four GGUFs on the warm path; first run may also be pulling those
+            // gigabytes through --auto-download.
+            var timeoutMinutes = hasLocalT2s && hasLocalS2a ? 10 : 30;
+            var deadline = DateTime.UtcNow.AddMinutes(timeoutMinutes);
+            while (DateTime.UtcNow < deadline)
+            {
+                ct.ThrowIfCancellationRequested();
+                if (process.HasExited)
+                {
+                    var tail = SnapshotServerLog();
+                    var exitCode = process.ExitCode;
+                    var exitedLaunchCommand = _serverLaunchCommand;
+                    _serverProcess = null;
+                    _serverPort = 0;
+                    _serverLaunchCommand = null;
+                    _serverVoicePath = null;
+                    _serverModelKey = null;
+                    _serverLanguageArg = null;
+                    _serverOdeSteps = 0;
+                    throw new InvalidOperationException(
+                        $"crispasr (confucius4-tts) exited during startup (code {exitCode}). Output: {tail}"
+                        + LaunchCmdSuffix(exitedLaunchCommand));
+                }
+                if (await ProbeHealthAsync(port, TimeSpan.FromSeconds(2), ct))
+                {
+                    return;
+                }
+                await Task.Delay(TimeSpan.FromSeconds(1), ct);
+            }
+
+            var lastOutput = SnapshotServerLog();
+            var timeoutLaunchCommand = _serverLaunchCommand;
+            StopServerInternal();
+            throw new TimeoutException(
+                $"crispasr (confucius4-tts) did not report healthy within {timeoutMinutes} minutes. Last output: {lastOutput}"
+                + LaunchCmdSuffix(timeoutLaunchCommand));
+        }
+        finally
+        {
+            ServerLock.Release();
+        }
+    }
+
+    private static string SnapshotServerLog()
+    {
+        lock (_serverLog)
+        {
+            var s = _serverLog.ToString().TrimEnd();
+            return s.Length > 2000 ? s[^2000..] : s;
+        }
+    }
+
+    private static async Task<bool> ProbeHealthAsync(int port, TimeSpan timeout, CancellationToken ct)
+    {
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(timeout);
+            using var resp = await HttpClient.GetAsync($"http://127.0.0.1:{port}/health", cts.Token);
+            return resp.IsSuccessStatusCode;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static int FindFreeLoopbackPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    private static void HookProcessExitOnce()
+    {
+        if (_processExitHooked)
+        {
+            return;
+        }
+        _processExitHooked = true;
+        AppDomain.CurrentDomain.ProcessExit += (_, _) => StopServerInternal();
+    }
+
+    /// <summary>
+    /// Stop the running crispasr (confucius4-tts) server if any, releasing GPU memory. Called by
+    /// <c>TextToSpeechViewModel</c> when switching engines or closing the TTS window so the
+    /// CrispASR-based engines don't pile up in VRAM.
+    /// </summary>
+    public static void StopServer() => StopServerInternal();
+
+    private static void StopServerInternal()
+    {
+        var p = _serverProcess;
+        _serverProcess = null;
+        _serverPort = 0;
+        _serverLaunchCommand = null;
+        _serverVoicePath = null;
+        _serverModelKey = null;
+        _serverLanguageArg = null;
+        _serverOdeSteps = 0;
+        if (p == null)
+        {
+            return;
+        }
+        try
+        {
+            if (!p.HasExited)
+            {
+                p.Kill(entireProcessTree: true);
+                p.WaitForExit(2000);
+            }
+        }
+        catch
+        {
+            // best effort
+        }
+        finally
+        {
+            p.Dispose();
+        }
+    }
+
+    private static string GetUniqueDestinationFileName(string folder, string baseName)
+    {
+        var candidate = Path.Combine(folder, baseName + ".wav");
+        if (!File.Exists(candidate))
+        {
+            return candidate;
+        }
+
+        var number = 1;
+        do
+        {
+            candidate = Path.Combine(folder, $"{baseName}_{number}.wav");
+            number++;
+        } while (File.Exists(candidate));
+
+        return candidate;
+    }
+
+    public bool ImportVoice(string fileName)
+    {
+        if (string.IsNullOrEmpty(fileName) || !File.Exists(fileName))
+        {
+            return false;
+        }
+
+        var voicesFolder = GetSetVoicesFolder();
+        var baseName = Path.GetFileNameWithoutExtension(fileName);
+        var destinationFileName = GetUniqueDestinationFileName(voicesFolder, baseName);
+
+        // 22.05 kHz mono: crispasr resamples the reference to 22.05 kHz for the S2A mel path and
+        // to 16 kHz for the w2v-BERT/CAM++ encoders, so staging at 22.05 kHz makes the mel path
+        // resample-free and leaves the encoders a clean downsample. No .txt sidecar: conditioning
+        // is from the audio alone, so the reference transcript is never needed.
+        try
+        {
+            var process = FfmpegGenerator.ConvertToMono22kHzWav(fileName, destinationFileName);
+            if (!process.Start())
+            {
+                return false;
+            }
+
+            process.WaitForExit();
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, "Confucius4-TTS (CrispASR) voice import failed (ffmpeg conversion).");
+            return false;
+        }
+
+        return File.Exists(destinationFileName);
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/Engines/Confucius4TtsLanguages.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Confucius4TtsLanguages.cs
@@ -1,0 +1,97 @@
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// The 14 languages Confucius4-TTS is trained on, per the NetEase Youdao technical report
+/// (arXiv 2608.11650): Chinese, English, Japanese, Korean, German, French, Spanish, Indonesian,
+/// Italian, Thai, Portuguese, Russian, Malay and Vietnamese.
+///
+/// crispasr's confucius4-tts backend maps the <c>-l</c> ISO code onto the Chinese-language
+/// prompt template the model was trained with ("请用X语朗读接下来的文字",
+/// src/confucius4_tts.cpp) — an invented prompt string derails the T2S stage, which is why the
+/// codes are passed through verbatim rather than spelled out. The backend's map actually
+/// carries ~97 codes, but everything outside these 14 is a best-effort extension the model was
+/// never trained on, so only the official list is offered here.
+///
+/// There is deliberately no "Auto" entry: the backend has no language detection — with no
+/// <c>-l</c> flag it silently reads everything as English, so an "Auto" label would just be a
+/// misleading name for English. English leads the list as the default pick instead.
+///
+/// Display names are taken from <see cref="OmniVoiceLanguages"/> so the engines label the same
+/// language identically in the UI; all 14 codes are present there.
+/// </summary>
+internal static class Confucius4TtsLanguages
+{
+    /// <summary>ISO-639-1 codes passed to crispasr's <c>-l</c> verbatim. English first — it is
+    /// the combo's default when nothing is saved, and no <c>-l</c> flag also means English.</summary>
+    private static readonly string[] Supported =
+    {
+        "en", "zh", "ja", "ko", "de", "fr", "es", "id", "it", "th", "pt", "ru", "ms", "vi",
+    };
+
+    /// <summary>
+    /// English first (the backend's implicit default), then the other 13 sorted by display name.
+    /// </summary>
+    public static readonly TtsLanguage[] All = Build();
+
+    private static TtsLanguage[] Build()
+    {
+        var omniNames = OmniVoiceLanguages.All.ToDictionary(l => l.Code, l => l.Name, StringComparer.OrdinalIgnoreCase);
+
+        var languages = Supported
+            .Skip(1)
+            .Select(code => new TtsLanguage(omniNames.TryGetValue(code, out var name) ? name : code, code))
+            .OrderBy(l => l.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        languages.Insert(0, new TtsLanguage(omniNames.TryGetValue("en", out var en) ? en : "English", "en"));
+        return languages.ToArray();
+    }
+
+    /// <summary>
+    /// The value to pass to crispasr's <c>-l</c> for <paramref name="language"/>, or an empty
+    /// string when no flag should be passed (which the backend reads as English).
+    /// </summary>
+    public static string ResolveLanguageArg(TtsLanguage? language)
+    {
+        // A null language means the CALLER had none to hand over, not a user choice - the cast
+        // dialog's voice-test button and cross-engine cast rows both pass null and rely on the
+        // engine falling back to its own saved default (#13272).
+        if (language == null)
+        {
+            return ResolveSavedLanguageArg();
+        }
+
+        var code = language.Code;
+        if (string.IsNullOrWhiteSpace(code))
+        {
+            return string.Empty;
+        }
+
+        // Guard against a language object left over from another engine (the view model can hold
+        // one while switching engines): only values this engine actually advertises are passed on.
+        return All.Any(l => string.Equals(l.Code, code, StringComparison.OrdinalIgnoreCase))
+            ? code
+            : string.Empty;
+    }
+
+    /// <summary>
+    /// The language code behind the pick saved by the main TTS window, or an empty string when
+    /// nothing is saved. The setting stores the DISPLAY NAME, which is how
+    /// <c>TextToSpeechViewModel</c> writes and restores it.
+    /// </summary>
+    public static string ResolveSavedLanguageArg()
+    {
+        var savedName = Se.Settings.Video.TextToSpeech.Confucius4TtsCrispAsrLanguage;
+        if (string.IsNullOrWhiteSpace(savedName))
+        {
+            return string.Empty;
+        }
+
+        return All.FirstOrDefault(l => string.Equals(l.Name, savedName, StringComparison.OrdinalIgnoreCase))?.Code
+               ?? string.Empty;
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/Engines/TtsEngineCatalog.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/TtsEngineCatalog.cs
@@ -74,6 +74,12 @@ public static class TtsEngineCatalog
             // engines; clones from a CAM++ speaker embedding so no reference transcript is needed.
             new DotsTtsCrispAsr(),
 
+            // Confucius4-TTS (CrispASR) — NetEase Youdao's two-stage GPT-2/flow-matching model,
+            // 22.05 kHz, 14 languages, Apache-2.0. Zero-shot cloning is mandatory (no default
+            // voice exists); clones from w2v-BERT + CAM++ conditioning so no reference
+            // transcript is needed.
+            new Confucius4TtsCrispAsr(),
+
             // CosyVoice3 (CrispASR) sits immediately after IndexTtsCrispAsr to keep the CrispASR
             // engines grouped visually in the engine combo.
             new CosyVoice3CrispAsr(),

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -353,6 +353,11 @@ public partial class TextToSpeechViewModel : ObservableObject
         {
             Se.Settings.Video.TextToSpeech.DotsTtsCrispAsrModel = SelectedModel ?? DotsTtsCrispAsr.DefaultModelKey;
         }
+        else if (SelectedEngine is Confucius4TtsCrispAsr)
+        {
+            Se.Settings.Video.TextToSpeech.Confucius4TtsCrispAsrModel = SelectedModel ?? Confucius4TtsCrispAsr.DefaultModelKey;
+            Se.Settings.Video.TextToSpeech.Confucius4TtsCrispAsrLanguage = SelectedLanguage?.Name ?? string.Empty;
+        }
         else if (SelectedEngine is IndexTts25AudioCpp)
         {
             Se.Settings.Video.TextToSpeech.IndexTts25AudioCppModel = SelectedModel ?? IndexTts25AudioCpp.DefaultModelKey;
@@ -1050,6 +1055,7 @@ public partial class TextToSpeechViewModel : ObservableObject
     {
         OmniVoiceCrispAsr => Se.Settings.Video.TextToSpeech.OmniVoiceCrispAsrLanguage,
         MossTtsCrispAsr => Se.Settings.Video.TextToSpeech.MossTtsCrispAsrLanguage,
+        Confucius4TtsCrispAsr => Se.Settings.Video.TextToSpeech.Confucius4TtsCrispAsrLanguage,
         CosyVoice3CrispAsr => Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrLanguage,
         Qwen3TtsCrispAsr => Se.Settings.Video.TextToSpeech.Qwen3TtsCrispAsrLanguage,
         ChatterboxTtsCpp => Se.Settings.Video.TextToSpeech.ChatterboxCrispAsrLanguage,
@@ -1302,6 +1308,10 @@ public partial class TextToSpeechViewModel : ObservableObject
         if (keepAlive is not DotsTtsCrispAsr)
         {
             DotsTtsCrispAsr.StopServer();
+        }
+        if (keepAlive is not Confucius4TtsCrispAsr)
+        {
+            Confucius4TtsCrispAsr.StopServer();
         }
         if (keepAlive is not IndexTts25AudioCpp)
         {
@@ -1594,6 +1604,9 @@ public partial class TextToSpeechViewModel : ObservableObject
             case DotsTtsCrispAsr:
                 await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadDotsTtsCrispAsrModels(DotsTtsCrispAsr.ResolveModelKey(SelectedModel)));
                 break;
+            case Confucius4TtsCrispAsr:
+                await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadConfucius4TtsCrispAsrModels(Confucius4TtsCrispAsr.ResolveModelKey(SelectedModel)));
+                break;
             case IndexTts25AudioCpp:
                 await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadIndexTts25AudioCppModels(IndexTts25AudioCpp.ResolveModelKey(SelectedModel)));
                 break;
@@ -1671,6 +1684,9 @@ public partial class TextToSpeechViewModel : ObservableObject
                 ? DownloadDotStatus.UpToDate
                 : DownloadDotStatus.NotInstalled,
             DotsTtsCrispAsr => DotsTtsCrispAsr.AreModelsInstalled(modelKey)
+                ? DownloadDotStatus.UpToDate
+                : DownloadDotStatus.NotInstalled,
+            Confucius4TtsCrispAsr => Confucius4TtsCrispAsr.AreModelsInstalled(modelKey)
                 ? DownloadDotStatus.UpToDate
                 : DownloadDotStatus.NotInstalled,
             IndexTts25AudioCpp => IndexTts25AudioCpp.AreModelsInstalled(modelKey)
@@ -3956,6 +3972,8 @@ public partial class TextToSpeechViewModel : ObservableObject
                                          ?? Languages.FirstOrDefault(),
                     MossTtsCrispAsr => Languages.FirstOrDefault(l => l.Name == Se.Settings.Video.TextToSpeech.MossTtsCrispAsrLanguage)
                                        ?? Languages.FirstOrDefault(),
+                    Confucius4TtsCrispAsr => Languages.FirstOrDefault(l => l.Name == Se.Settings.Video.TextToSpeech.Confucius4TtsCrispAsrLanguage)
+                                             ?? Languages.FirstOrDefault(),
                     CosyVoice3CrispAsr => Languages.FirstOrDefault(l => l.Name == Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrLanguage)
                                           ?? Languages.FirstOrDefault(),
                     Qwen3TtsCrispAsr => Languages.FirstOrDefault(l => l.Name == Se.Settings.Video.TextToSpeech.Qwen3TtsCrispAsrLanguage)
@@ -4078,6 +4096,16 @@ public partial class TextToSpeechViewModel : ObservableObject
             else if (SelectedEngine is DotsTtsCrispAsr)
             {
                 SelectedModel = Models.FirstOrDefault(p => p == Se.Settings.Video.TextToSpeech.DotsTtsCrispAsrModel);
+                if (string.IsNullOrEmpty(SelectedModel))
+                {
+                    SelectedModel = Models.FirstOrDefault();
+                }
+                IsEngineSettingsVisible = true;
+                IsModelDownloadVisible = true;
+            }
+            else if (SelectedEngine is Confucius4TtsCrispAsr)
+            {
+                SelectedModel = Models.FirstOrDefault(p => p == Se.Settings.Video.TextToSpeech.Confucius4TtsCrispAsrModel);
                 if (string.IsNullOrEmpty(SelectedModel))
                 {
                     SelectedModel = Models.FirstOrDefault();

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
@@ -188,6 +188,8 @@ public class TextToSpeechWindow : Window
                 return StatusDots.From(engine.IsInstalled(null).Result, PocketTtsCrispAsr.GetEngineUpdateStatus());
             case DotsTtsCrispAsr:
                 return StatusDots.From(engine.IsInstalled(null).Result, DotsTtsCrispAsr.GetEngineUpdateStatus());
+            case Confucius4TtsCrispAsr:
+                return StatusDots.From(engine.IsInstalled(null).Result, Confucius4TtsCrispAsr.GetEngineUpdateStatus());
             case IndexTts25AudioCpp:
                 return StatusDots.From(engine.IsInstalled(null).Result, IndexTts25AudioCpp.GetEngineUpdateStatus());
             case CosyVoice3CrispAsr:

--- a/src/ui/Features/Video/TextToSpeech/TtsEngineInstaller.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsEngineInstaller.cs
@@ -304,6 +304,45 @@ public static class TtsEngineInstaller
             return true;
         }
 
+        if (engine is Confucius4TtsCrispAsr)
+        {
+            if (!await TtsVoiceInstaller.EnsureCrispAsrForConfucius4Tts(window, windowService, forceRedownload: false))
+            {
+                return false;
+            }
+
+            var confuciusModelKey = Confucius4TtsCrispAsr.ResolveModelKey(model);
+            if (!Confucius4TtsCrispAsr.AreModelsInstalled(confuciusModelKey))
+            {
+                // Model key already carries the total download size, so no separate size here.
+                var answer = await MessageBox.Show(
+                    window,
+                    "Download Confucius4-TTS (CrispASR) models?",
+                    $"{Environment.NewLine}\"Confucius4-TTS (CrispASR)\" ({confuciusModelKey}) requires models.{Environment.NewLine}{Environment.NewLine}Download models?",
+                    MessageBoxButtons.YesNoCancel,
+                    MessageBoxIcon.Question);
+
+                if (answer != MessageBoxResult.Yes)
+                {
+                    return false;
+                }
+
+                var dlResult = await windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(window, vm => vm.StartDownloadConfucius4TtsCrispAsrModels(confuciusModelKey));
+                if (!dlResult.OkPressed || !Confucius4TtsCrispAsr.AreModelsInstalled(confuciusModelKey))
+                {
+                    return false;
+                }
+
+                await Dispatcher.UIThread.InvokeAsync(async () =>
+                {
+                    await refreshVoices();
+                });
+                return true;
+            }
+
+            return true;
+        }
+
         if (engine is DotsTtsCrispAsr)
         {
             if (!await TtsVoiceInstaller.EnsureCrispAsrForDotsTts(window, windowService, forceRedownload: false))

--- a/src/ui/Features/Video/TextToSpeech/TtsEngineSettingsDialog.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsEngineSettingsDialog.cs
@@ -2,6 +2,7 @@
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ChatterboxTtsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.CosyVoice3CrispAsrSettings;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Confucius4TtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.DotsTtsCrispAsrSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.ElevenLabsSettings;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
@@ -42,6 +43,7 @@ public static class TtsEngineSettingsDialog
         IndexTts25AudioCpp or
         IndexTtsCrispAsr or
         DotsTtsCrispAsr or
+        Confucius4TtsCrispAsr or
         CosyVoice3CrispAsr or
         PocketTtsCrispAsr or
         F5TtsCrispAsr or
@@ -82,6 +84,10 @@ public static class TtsEngineSettingsDialog
         else if (engine is DotsTtsCrispAsr)
         {
             await windowService.ShowDialogAsync<DotsTtsCrispAsrSettingsWindow, DotsTtsCrispAsrSettingsViewModel>(window, vm => vm.Initialize());
+        }
+        else if (engine is Confucius4TtsCrispAsr)
+        {
+            await windowService.ShowDialogAsync<Confucius4TtsCrispAsrSettingsWindow, Confucius4TtsCrispAsrSettingsViewModel>(window, vm => vm.Initialize());
         }
         else if (engine is CosyVoice3CrispAsr)
         {

--- a/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
@@ -187,6 +187,18 @@ public static class TtsVoiceInstaller
             minVersionNote: "v0.8.25 or newer");
 
     /// <summary>
+    /// Ensures the CrispASR runtime that Confucius4-TTS (CrispASR) runs on is installed.
+    /// The confucius4-tts backend ships in CrispASR v0.8.30 and newer; the version note names
+    /// that floor because older builds have no confucius4-tts backend at all and abort on the
+    /// unknown --backend value.
+    /// </summary>
+    public static Task<bool> EnsureCrispAsrForConfucius4Tts(Window? window, IWindowService windowService, bool forceRedownload)
+        => EnsureCrispAsrAsync(window, windowService, forceRedownload,
+            engineDisplayName: "Confucius4-TTS (CrispASR)",
+            extraCapabilityCheck: null,
+            minVersionNote: "v0.8.30 or newer");
+
+    /// <summary>
     /// Shared CrispASR install/update flow used by all TTS engines that sit on the
     /// CrispASR runtime. Prompts refer to <paramref name="engineDisplayName"/> so users
     /// see the right engine name. <paramref name="extraCapabilityCheck"/> lets the caller

--- a/src/ui/Features/Video/TextToSpeech/Voices/Confucius4TtsVoice.cs
+++ b/src/ui/Features/Video/TextToSpeech/Voices/Confucius4TtsVoice.cs
@@ -1,0 +1,24 @@
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+
+public class Confucius4TtsVoice
+{
+    public string Voice { get; set; }
+    public string FilePath { get; set; }
+
+    public override string ToString()
+    {
+        return Voice;
+    }
+
+    public Confucius4TtsVoice()
+    {
+        Voice = string.Empty;
+        FilePath = string.Empty;
+    }
+
+    public Confucius4TtsVoice(string voice, string filePath)
+    {
+        Voice = voice;
+        FilePath = filePath;
+    }
+}

--- a/src/ui/Logic/Config/SeVideoTextToSpeech.cs
+++ b/src/ui/Logic/Config/SeVideoTextToSpeech.cs
@@ -44,6 +44,13 @@ public class SeVideoTextToSpeech
     // Flow-matching Euler steps for dots.tts (8-32, default 16). Higher is better and slower;
     // there is no CLI flag for it, so the engine passes it as CRISPASR_DOTS_ODE_STEPS.
     public int DotsTtsCrispAsrOdeSteps { get; set; }
+    public string Confucius4TtsCrispAsrModel { get; set; }
+    // Display name of the picked Confucius4-TTS target language (empty = English, the backend's
+    // implicit default — there is no auto-detection).
+    public string Confucius4TtsCrispAsrLanguage { get; set; }
+    // Flow-matching Euler steps for the Confucius4-TTS S2A stage (10-40, default 20). Higher is
+    // better and slower; passed as --tts-steps.
+    public int Confucius4TtsCrispAsrOdeSteps { get; set; }
     public string IndexTts25AudioCppModel { get; set; }
     // Licence version the user accepted for the IndexTTS-2.5 weights (bilibili Model Use
     // License, not OSI-approved). Empty until accepted; a version bump re-prompts.
@@ -179,6 +186,9 @@ public class SeVideoTextToSpeech
         PocketTtsCrispAsrSpeed = 1.0;
         DotsTtsCrispAsrModel = "Q8_0 (~3.5 GB)";
         DotsTtsCrispAsrOdeSteps = 16;
+        Confucius4TtsCrispAsrModel = "Q8_0 (~1.9 GB)";
+        Confucius4TtsCrispAsrLanguage = string.Empty;
+        Confucius4TtsCrispAsrOdeSteps = 20;
         IndexTts25AudioCppModel = "Q8_0 (~3.3 GB)";
         IndexTts25AudioCppLicenseAccepted = string.Empty;
         IndexTts25AudioCppBackend = string.Empty;

--- a/src/ui/Logic/Download/Confucius4TtsCrispAsrDownloadService.cs
+++ b/src/ui/Logic/Download/Confucius4TtsCrispAsrDownloadService.cs
@@ -1,0 +1,193 @@
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Nikse.SubtitleEdit.UiLogic;
+
+namespace Nikse.SubtitleEdit.Logic.Download;
+
+public interface IConfucius4TtsCrispAsrDownloadService
+{
+    Task DownloadModels(string modelsFolder, string modelKey, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Downloads the Confucius4-TTS (CrispASR) T2S + S2A GGUF pair (Q8_0 / F16, user-picked) plus the
+/// two required companions — the BigVGAN 22.05 kHz vocoder and the w2v-BERT reference encoder —
+/// into SE's CrispASR/models folder, so the user gets a progress dialog instead of crispasr's
+/// silent --auto-download on first synth. Same shape as <see cref="DotsTtsCrispAsrDownloadService"/>.
+/// </summary>
+/// <remarks>
+/// SE downloading its own quant matters more here than for the other engines: crispasr's registry
+/// default for this backend is the Q4_K pair, whose flow-matching degradation is why the engine
+/// was first judged too robotic to ship (CrispASR #377).
+/// </remarks>
+public class Confucius4TtsCrispAsrDownloadService : IConfucius4TtsCrispAsrDownloadService
+{
+    private const string RepoBaseUrl = "https://huggingface.co/cstr/confucius4-tts-GGUF/resolve/main/";
+
+    private readonly HttpClient _httpClient;
+
+    private static readonly Dictionary<string, string> ModelUrls = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [Confucius4TtsCrispAsr.T2sQ8_0FileName] = RepoBaseUrl + Confucius4TtsCrispAsr.T2sQ8_0FileName,
+        [Confucius4TtsCrispAsr.T2sF16FileName] = RepoBaseUrl + Confucius4TtsCrispAsr.T2sF16FileName,
+        [Confucius4TtsCrispAsr.S2aQ8_0FileName] = RepoBaseUrl + Confucius4TtsCrispAsr.S2aQ8_0FileName,
+        [Confucius4TtsCrispAsr.S2aF16FileName] = RepoBaseUrl + Confucius4TtsCrispAsr.S2aF16FileName,
+        [Confucius4TtsCrispAsr.VocoderFileName] = RepoBaseUrl + Confucius4TtsCrispAsr.VocoderFileName,
+        [Confucius4TtsCrispAsr.W2vFileName] = RepoBaseUrl + Confucius4TtsCrispAsr.W2vFileName,
+    };
+
+    public Confucius4TtsCrispAsrDownloadService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task DownloadModels(string modelsFolder, string modelKey, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken)
+    {
+        var t2sFileName = Confucius4TtsCrispAsr.GetT2sFileName(modelKey);
+        var t2sPath = Confucius4TtsCrispAsr.GetT2sPath(modelKey);
+        var s2aFileName = Confucius4TtsCrispAsr.GetS2aFileName(modelKey);
+        var s2aPath = Confucius4TtsCrispAsr.GetS2aPath(modelKey);
+        var vocoderPath = Confucius4TtsCrispAsr.GetVocoderPath();
+        var w2vPath = Confucius4TtsCrispAsr.GetW2vPath();
+
+        // Cache seeding does a synchronous File.Copy of up to ~1.3 GB, and the caller hands the
+        // returned Task to a timer without awaiting it, so anything before the first real await
+        // would run on the UI thread. Push it onto the threadpool.
+        await Task.Run(() =>
+        {
+            Confucius4TtsCrispAsr.TrySeedModelFromCrispAsrCache(t2sFileName, t2sPath);
+            Confucius4TtsCrispAsr.TrySeedModelFromCrispAsrCache(s2aFileName, s2aPath);
+            Confucius4TtsCrispAsr.TrySeedModelFromCrispAsrCache(Confucius4TtsCrispAsr.VocoderFileName, vocoderPath);
+            Confucius4TtsCrispAsr.TrySeedModelFromCrispAsrCache(Confucius4TtsCrispAsr.W2vFileName, w2vPath);
+            EnsureRemovedIfInvalid(t2sPath, t2sFileName);
+            EnsureRemovedIfInvalid(s2aPath, s2aFileName);
+            EnsureRemovedIfInvalid(vocoderPath, Confucius4TtsCrispAsr.VocoderFileName);
+            EnsureRemovedIfInvalid(w2vPath, Confucius4TtsCrispAsr.W2vFileName);
+        }, cancellationToken);
+
+        var pending = new List<(string Path, string FileName)>();
+        if (!Confucius4TtsCrispAsr.IsValidLocalModelFile(t2sPath, t2sFileName))
+        {
+            pending.Add((t2sPath, t2sFileName));
+        }
+        if (!Confucius4TtsCrispAsr.IsValidLocalModelFile(s2aPath, s2aFileName))
+        {
+            pending.Add((s2aPath, s2aFileName));
+        }
+        if (!Confucius4TtsCrispAsr.IsValidLocalModelFile(vocoderPath, Confucius4TtsCrispAsr.VocoderFileName))
+        {
+            pending.Add((vocoderPath, Confucius4TtsCrispAsr.VocoderFileName));
+        }
+        if (!Confucius4TtsCrispAsr.IsValidLocalModelFile(w2vPath, Confucius4TtsCrispAsr.W2vFileName))
+        {
+            pending.Add((w2vPath, Confucius4TtsCrispAsr.W2vFileName));
+        }
+
+        var step = 0;
+        foreach (var (path, fileName) in pending)
+        {
+            step++;
+            titleProgress?.Invoke($"Downloading Confucius4-TTS (CrispASR) models ({step}/{pending.Count}): {fileName}");
+            await DownloadAndVerify(path, fileName, progress, cancellationToken);
+        }
+    }
+
+    private async Task DownloadAndVerify(string finalPath, string fileName, IProgress<float>? progress, CancellationToken cancellationToken)
+    {
+        var partPath = finalPath + ".part";
+        try
+        {
+            await DownloadHelper.DownloadFileAsync(_httpClient, GetUrl(fileName), partPath, progress, cancellationToken);
+            await VerifyFile(partPath, GetHashKey(fileName), fileName, cancellationToken);
+            File.Move(partPath, finalPath);
+        }
+        catch
+        {
+            TryDelete(partPath);
+            throw;
+        }
+    }
+
+    private static string? GetHashKey(string fileName)
+    {
+        if (string.Equals(fileName, Confucius4TtsCrispAsr.T2sQ8_0FileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.Confucius4TtsCrispAsr.T2sQ8_0;
+        }
+        if (string.Equals(fileName, Confucius4TtsCrispAsr.T2sF16FileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.Confucius4TtsCrispAsr.T2sF16;
+        }
+        if (string.Equals(fileName, Confucius4TtsCrispAsr.S2aQ8_0FileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.Confucius4TtsCrispAsr.S2aQ8_0;
+        }
+        if (string.Equals(fileName, Confucius4TtsCrispAsr.S2aF16FileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.Confucius4TtsCrispAsr.S2aF16;
+        }
+        if (string.Equals(fileName, Confucius4TtsCrispAsr.VocoderFileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.Confucius4TtsCrispAsr.Vocoder;
+        }
+        if (string.Equals(fileName, Confucius4TtsCrispAsr.W2vFileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.Confucius4TtsCrispAsr.W2v;
+        }
+        return null;
+    }
+
+    private static async Task VerifyFile(string filePath, string? key, string fileName, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(key))
+        {
+            return;
+        }
+
+        var expected = DownloadHashManager.GetLatestKnownHash(key);
+        if (string.IsNullOrEmpty(expected))
+        {
+            return;
+        }
+
+        string actual;
+        await using (var stream = File.OpenRead(filePath))
+        {
+            actual = await Sha256Util.ComputeSha256Async(stream, cancellationToken);
+        }
+
+        if (!string.Equals(expected, actual, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new IOException(
+                $"Confucius4-TTS (CrispASR) model {fileName} failed integrity check (expected SHA-256 {expected}, got {actual}).");
+        }
+    }
+
+    private static string GetUrl(string fileName)
+    {
+        if (!ModelUrls.TryGetValue(fileName, out var url))
+        {
+            throw new ArgumentException($"Unknown Confucius4-TTS (CrispASR) model: {fileName}", nameof(fileName));
+        }
+        return url;
+    }
+
+    private static void TryDelete(string path)
+    {
+        try { File.Delete(path); } catch { /* best-effort cleanup */ }
+    }
+
+    private static void EnsureRemovedIfInvalid(string path, string fileName)
+    {
+        if (!File.Exists(path) || Confucius4TtsCrispAsr.IsValidLocalModelFile(path, fileName))
+        {
+            return;
+        }
+        TryDelete(path);
+    }
+}

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -224,6 +224,19 @@ public static class DownloadHashManager
         public const string SpeakerEncoder = "DotsTtsCrispAsr.SpeakerEncoder";
     }
 
+    public static class Confucius4TtsCrispAsr
+    {
+        // SHA-256 of the Confucius4-TTS GGUFs on cstr/confucius4-tts-GGUF (HF LFS oid; the Q8_0
+        // pair, the vocoder and the w2v encoder were confirmed against a local sha256sum of the
+        // downloaded files).
+        public const string T2sQ8_0 = "Confucius4TtsCrispAsr.T2sQ8_0";
+        public const string T2sF16 = "Confucius4TtsCrispAsr.T2sF16";
+        public const string S2aQ8_0 = "Confucius4TtsCrispAsr.S2aQ8_0";
+        public const string S2aF16 = "Confucius4TtsCrispAsr.S2aF16";
+        public const string Vocoder = "Confucius4TtsCrispAsr.Vocoder";
+        public const string W2v = "Confucius4TtsCrispAsr.W2v";
+    }
+
     public static class IndexTts25AudioCpp
     {
         // SHA-256 of the IndexTTS-2.5 GGUFs on audio-cpp/audio.cpp-gguf (HF LFS oid, confirmed
@@ -1855,6 +1868,33 @@ public static class DownloadHashManager
             [DotsTtsCrispAsr.SpeakerEncoder] = new[]
             {
                 "6f6d41f1394273b0da5a7a9be8f15f0e59d3b4d5983cab7d1fac08630b912e7f", // dots-tts-soar-spk-f16.gguf
+            },
+
+            // Confucius4-TTS weights, from cstr/confucius4-tts-GGUF. Q8_0 pair, vocoder and w2v
+            // confirmed by local sha256sum of the downloaded files; T2S/S2A F16 are the HF LFS oids.
+            [Confucius4TtsCrispAsr.T2sQ8_0] = new[]
+            {
+                "c1ed6026f8959d6cbc639ae97ef450ed7b1399159af753e69e54c6d7aac5e9e0", // confucius4-tts-t2s-q8_0.gguf
+            },
+            [Confucius4TtsCrispAsr.T2sF16] = new[]
+            {
+                "b7dc5fdad32d90f5e303da226b69aa04eafe5331e93be6a0334e47e4ea534691", // confucius4-tts-t2s-f16.gguf
+            },
+            [Confucius4TtsCrispAsr.S2aQ8_0] = new[]
+            {
+                "55be5d58d1b7443af01ec7b3b96f347c3978728215346bd162753c36885ca7d3", // confucius4-tts-s2a-q8_0.gguf
+            },
+            [Confucius4TtsCrispAsr.S2aF16] = new[]
+            {
+                "ea259809ebafdff7bf7fd3955b68e0d0722a0ad792b8428d48fbfbdd1e361d0d", // confucius4-tts-s2a-f16.gguf
+            },
+            [Confucius4TtsCrispAsr.Vocoder] = new[]
+            {
+                "353d37d41f01152796e3a3b21d3740b0e38d7b0ba486a8df82744028d69dae69", // confucius4-tts-bigvgan-22k-f16.gguf
+            },
+            [Confucius4TtsCrispAsr.W2v] = new[]
+            {
+                "02ea34b6a0bc1f027f9c4325186368ddac8d51ded3dc6a90f565dce90a26c0ac", // confucius4-tts-w2v-f16.gguf
             },
 
             // IndexTTS-2.5 weights, from audio-cpp/audio.cpp-gguf. Q8_0 confirmed by local

--- a/src/ui/Logic/Media/FfmpegGenerator.cs
+++ b/src/ui/Logic/Media/FfmpegGenerator.cs
@@ -878,6 +878,30 @@ public class FfmpegGenerator
     }
 
     /// <summary>
+    /// Resamples / mixes the input to mono PCM16 WAV at 22.05 kHz. Used by Confucius4-TTS
+    /// (CrispASR) for its voice-cloning reference WAV — the S2A/vocoder chain works at 22.05 kHz
+    /// (the reference-mel path reads the file at that rate) while the w2v-BERT/CAM++ encoders
+    /// downsample to 16 kHz internally.
+    /// </summary>
+    public static Process ConvertToMono22kHzWav(string inputFileName, string outputFileName, DataReceivedEventHandler? dataReceivedHandler = null)
+    {
+        var process = new Process
+        {
+            StartInfo =
+            {
+                FileName = GetFfmpegLocation(),
+                Arguments = $"-y -i \"{inputFileName}\" -ar 22050 -ac 1 -c:a pcm_s16le \"{outputFileName}\"",
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            }
+        };
+
+        SetupDataReceiveHandler(dataReceivedHandler, process);
+
+        return process;
+    }
+
+    /// <summary>
     /// Resamples / mixes the input to mono PCM16 WAV at 16 kHz. Used by CosyVoice3 (CrispASR)
     /// for its zero-shot voice-cloning reference WAV — the s3tok speech tokenizer expects
     /// 16 kHz mono. Higher rates work but cause a lossy resample on every synth call.


### PR DESCRIPTION
Adds **Confucius4-TTS** (NetEase Youdao, Apache-2.0) as a CrispASR-backed voice-cloning TTS engine — requested in CrispStrobe/CrispASR#377 and previously set aside as "too robotic".

## Why it was robotic before — and isn't now

The earlier evaluation used crispasr's registry default quant, the **Q4_K pair**, whose flow-matching alignment audibly breaks down (flat, robotic delivery). A commenter on the upstream issue pointed this out, and an A/B with the same text and the same reference confirms it: Q8_0 holds the reference's prosody where Q4_K falls apart. Consequences in this PR:

- Only **Q8_0 (~1.9 GB, default)** and **F16 (~2.6 GB)** are offered — no Q4_K.
- The S2A model is passed explicitly as `--codec-model`: the backend's sibling auto-discovery probes **q4_k first**, so a stray q4_k file in the models folder would silently degrade quality.

## Engine facts

- Two-stage pipeline: GPT-2 T2S → flow-matching DiT+WaveNet S2A → BigVGAN vocoder at **22.05 kHz** (SE's only 22 kHz engine). Four GGUFs from `cstr/confucius4-tts-GGUF`, incl. an 824 MB w2v-BERT reference encoder.
- **Zero-shot cloning is mandatory** — without `--voice` the output is unintelligible by design, so there are no preset voices; the voice combo holds imported reference WAVs (seeded from qwen3-tts.cpp on first use).
- Cloning conditions on w2v-BERT + CAM++ from the audio alone → no `.txt` transcript sidecar.
- References staged at **22.05 kHz** on import (new `FfmpegGenerator.ConvertToMono22kHzWav`): the S2A mel path reads them untouched, the 16 kHz encoders downsample cleanly.
- **14 official languages** (per the arXiv 2608.11650 report): zh, en, ja, ko, de, fr, es, id, it, th, pt, ru, ms, vi — exposed as a language combo, passed as the startup `-l` flag. crispasr's own map carries ~97 codes, but everything beyond the 14 is an untrained best-effort extension and is not offered.
- S2A Euler steps (`--tts-steps`, default 20) exposed as a quality slider in the settings dialog.
- Voice/model/language/steps are baked in at server start (the adapter applies `--voice` only in init), so changes restart the server — IndexTTS/dots.tts pattern.
- Backend ships in CrispASR v0.8.30+; SE already pins v0.8.31, so no pin bump.
- No temperature is ever sent: greedy T2S decode degenerates into a repeat loop; the backend's 0.8 default matters.

## Verification

- CLI and server mode run on v0.8.31 (macOS Metal) with SE's exact launch flags and the exact `/v1/audio/speech` payload: HTTP 200, RIFF PCM mono @ 22050 Hz, server logs `voice='<startup>'` confirming the clone path. RTF ~7.3 — slow, dots.tts territory.
- whisper round-trip on the synthesized audio reproduces the input text; clone quality A/B'd by ear (Q8_0 vs Q4_K WAVs shared with the maintainer).
- All 6 SHA-256 hashes taken from the HF tree API LFS oids; the Q8_0 pair, vocoder and w2v additionally confirmed by local `shasum` of downloaded files.
- `dotnet build` clean; all 4510 UI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)