### PR TITLE
Fix #14389: move "Open second subtitle file..." to SE4's spot in the Video menu

### DIFF
--- a/src/ui/Features/Main/Layout/InitMenu.cs
+++ b/src/ui/Features/Main/Layout/InitMenu.cs
@@ -1,6 +1,7 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
+using Avalonia.Data.Converters;
 using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Media;
@@ -639,18 +640,6 @@ public static class InitMenu
         {
             new MenuItem
             {
-                Header = Se.Language.Video.OpenSecondarySubtitleOnVideoPlayerDotDotDot,
-                Command = vm.OpenSecondarySubtitleCommand,
-                [!Visual.IsVisibleProperty] = new Binding(nameof(vm.IsSubtitleSecondaryVisible)) { Converter = new InverseBooleanConverter() },
-            },
-            new MenuItem
-            {
-                Header = Se.Language.Video.RemoveSecondarySubtitleOnVideoPlayer,
-                Command = vm.ClearSecondarySubtitleCommand,
-                [!Visual.IsVisibleProperty] = new Binding(nameof(vm.IsSubtitleSecondaryVisible)),
-            },
-            new MenuItem
-            {
                 Header = Se.Language.Video.Chapters.ChaptersDotDotDot,
                 Command = vm.ShowVideoChaptersCommand,
             },
@@ -731,6 +720,36 @@ public static class InitMenu
                 {
                     Header = l.CloseVideoFile,
                     Command = vm.CommandVideoCloseCommand,
+                },
+                // Same spot and wording as SE4's Video menu, so it can be found by anyone
+                // looking for it there (#14389). Only meaningful with a video to draw on.
+                new MenuItem
+                {
+                    Header = Se.Language.Video.OpenSecondarySubtitleOnVideoPlayerDotDotDot,
+                    Command = vm.OpenSecondarySubtitleCommand,
+                    [!Visual.IsVisibleProperty] = new MultiBinding
+                    {
+                        Converter = BoolConverters.And,
+                        Bindings =
+                        {
+                            new Binding(nameof(vm.IsVideoLoaded)),
+                            new Binding(nameof(vm.IsSubtitleSecondaryVisible)) { Converter = new InverseBooleanConverter() },
+                        },
+                    },
+                },
+                new MenuItem
+                {
+                    Header = Se.Language.Video.RemoveSecondarySubtitleOnVideoPlayer,
+                    Command = vm.ClearSecondarySubtitleCommand,
+                    [!Visual.IsVisibleProperty] = new MultiBinding
+                    {
+                        Converter = BoolConverters.And,
+                        Bindings =
+                        {
+                            new Binding(nameof(vm.IsVideoLoaded)),
+                            new Binding(nameof(vm.IsSubtitleSecondaryVisible)),
+                        },
+                    },
                 },
                 menuItemAudioTracks,
                 new Separator(),

--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -338,6 +338,13 @@ public static class InitNativeMacMenu
         videoItems.Items.Add(Item(Clean(l.OpenVideoFromUrl), v => v.ShowVideoOpenFromUrlCommand));
         videoItems.Items.Add(Item(Clean(l.CloseVideoFile), v => v.CommandVideoCloseCommand));
 
+        // Same spot and wording as SE4's Video menu, so it can be found by anyone
+        // looking for it there (#14389). Only meaningful with a video to draw on.
+        videoItems.Items.Add(Conditional(Clean(Se.Language.Video.OpenSecondarySubtitleOnVideoPlayerDotDotDot), v => v.OpenSecondarySubtitleCommand,
+            v => v.IsVideoLoaded && !v.IsSubtitleSecondaryVisible, nameof(MainViewModel.IsVideoLoaded), nameof(MainViewModel.IsSubtitleSecondaryVisible)));
+        videoItems.Items.Add(Conditional(Clean(Se.Language.Video.RemoveSecondarySubtitleOnVideoPlayer), v => v.ClearSecondarySubtitleCommand,
+            v => v.IsVideoLoaded && v.IsSubtitleSecondaryVisible, nameof(MainViewModel.IsVideoLoaded), nameof(MainViewModel.IsSubtitleSecondaryVisible)));
+
         state.AudioTracksItem = new NativeMenuItem(Clean(l.AudioTracks)) { Menu = new NativeMenu() };
         state.Visibilities.Add((state.AudioTracksItem, v => v.IsAudioTracksVisible, [nameof(MainViewModel.IsAudioTracksVisible)]));
         videoItems.Items.Add(state.AudioTracksItem);
@@ -370,10 +377,6 @@ public static class InitNativeMacMenu
         var lVideo = Se.Language.Video;
         var videoMoreList = new List<NativeMenuItem>
         {
-            Conditional(Clean(lVideo.OpenSecondarySubtitleOnVideoPlayerDotDotDot), v => v.OpenSecondarySubtitleCommand,
-                v => !v.IsSubtitleSecondaryVisible, nameof(MainViewModel.IsSubtitleSecondaryVisible)),
-            Conditional(Clean(lVideo.RemoveSecondarySubtitleOnVideoPlayer), v => v.ClearSecondarySubtitleCommand,
-                v => v.IsSubtitleSecondaryVisible, nameof(MainViewModel.IsSubtitleSecondaryVisible)),
             Item(Clean(lVideo.ReEncodeVideoForBetterSubtitlingDotDotDot), v => v.VideoReEncodeCommand),
             Item(Clean(lVideo.CutVideoDotDotDot), v => v.VideoCutCommand),
 

--- a/src/ui/Logic/Config/Language/Video/LanguageVideo.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageVideo.cs
@@ -111,9 +111,9 @@ public class LanguageVideo
         GenerateBlankVideoDotDotDot = "Generate blank video...";
         ReEncodeVideoForBetterSubtitlingTitle = "Re-encode video for better subtitling";
         ReEncodeVideoForBetterSubtitlingDotDotDot = "Re-encode video for better subtitling...";
-        OpenSecondarySubtitleOnVideoPlayer = "Secondary subtitle (on video player)";
-        OpenSecondarySubtitleOnVideoPlayerDotDotDot = "Secondary subtitle on video player, open...";
-        RemoveSecondarySubtitleOnVideoPlayer = "Secondary subtitle on video player, remove";
+        OpenSecondarySubtitleOnVideoPlayer = "Second subtitle file (on video player)";
+        OpenSecondarySubtitleOnVideoPlayerDotDotDot = "Open second subtitle file...";
+        RemoveSecondarySubtitleOnVideoPlayer = "Remove second subtitle file";
         CutVideoTitle = "Cut video";
         CutVideoDotDotDot = "Cut video...";
         EmbedSubtitlesDotDotDot = "Add/remove embedded subtitles...";


### PR DESCRIPTION
Fixes #14389.

The feature the issue asks for already exists in SE5, but it was hard to find: it lived in **Video → More** as "Secondary subtitle on video player, open...", so anyone scanning for SE4's **"Open second subtitle file..."** (top level, right after "Close video file") would not spot it.

Changes:
- Rename the menu items to SE4's wording: "Open second subtitle file..." / "Remove second subtitle file" (English strings only; language keys unchanged, so existing translations keep working).
- Move the pair out of the More submenu to the top level of the Video menu, right after "Close video file" — the same spot as SE4.
- Applied to both the in-window menu (InitMenu) and the native macOS menu bar (InitNativeMacMenu).
- Items are visible only while a video is loaded (they were previously gated the same way via the More submenu's IsVideoLoaded binding; the top-level items now carry that gate themselves), and the open/remove pair still swaps on whether a second subtitle is loaded.

No functional change to the feature itself — same command, dialog, and preview merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)