### PR TITLE
Remove stale MLX Whisper documentation

### DIFF
--- a/docs/features/speech-to-text.md
+++ b/docs/features/speech-to-text.md
@@ -14,7 +14,6 @@ Subtitle Edit can automatically transcribe audio to text using Whisper-based and
 | Whisper CPP | Windows, Linux, macOS | Local CPU engine. On Windows the cuBLAS (NVIDIA CUDA) and Vulkan GPU backends can also be selected from the Whisper CPP backend dropdown. |
 | Purfview Faster Whisper XXL | Windows, Linux | Fast local engine, often used with NVIDIA CUDA |
 | Whisper CTranslate2 | Windows, Linux (x64), macOS (Apple Silicon) | CPU / NVIDIA CUDA depending on installation; CUDA requires [CUDA 12.x](https://developer.nvidia.com/cuda-12-0-0-download-archive) |
-| MLX Whisper | macOS (Apple Silicon) | Runs Whisper on the Apple GPU / Neural Engine via Apple's MLX. Not downloaded by Subtitle Edit — install the `mlx-whisper` Python package yourself (see notes below) |
 | Whisper Const-me | Windows | DirectX-based engine |
 | Whisper OpenAI | All | Python-based OpenAI Whisper workflow |
 | OpenAI Compatible Server | All | Connect to any OpenAI-compatible speech-to-text endpoint |
@@ -30,7 +29,6 @@ Engines and models are downloaded automatically on first use.
 - **Whisper CPP** is shown as a single entry; the CPU / cuBLAS / Vulkan backends are selected from a secondary dropdown when Whisper CPP is selected.
 - **Qwen3 ASR CPP** includes 0.6B and 1.7B model options, plus a forced-aligner model used for timing workflows.
 - **Crisp ASR** is exposed as one engine that wraps multiple backends (Parakeet, Canary, Cohere, Fire Red, Fun-ASR Nano, Fun-ASR MLT Nano, GigaAM, GLM, Granite, Qwen3, Mega, MOSS Diarize, Omni, Kyutai, SenseVoice, ARK, Voxtral). Pick the backend from the Crisp ASR backend dropdown - see [Crisp ASR backends](#crisp-asr-backends) for what each one is good at.
-- **MLX Whisper** (Apple Silicon Macs) is not bundled or auto-downloaded — it drives Apple's `mlx-whisper` Python package. Install it once with `pip3 install mlx-whisper` (or `pipx install mlx-whisper`); models download from Hugging Face on first use. Subtitle Edit detects the install by finding a Python that can `import mlx_whisper` — it probes Homebrew, python.org, pyenv and system interpreters, and (for pipx / virtual-env / conda installs, which isolate the package) reads the `mlx_whisper` command found on your PATH or at `~/.local/bin/mlx_whisper` to locate the matching interpreter. If it reports "not found" after a pipx/venv install, make sure `which mlx_whisper` resolves.
 - A **Forced aligner** option is shown for Crisp ASR backends and exposes the built-in aligner, Canary CTC, Qwen3, and the wav2vec2 zoo (12 language-specific CTC aligners that run on top of any Crisp ASR backend).
 - Several newer engines support automatic language selection.
 - Each engine can have separate advanced command-line parameters.

--- a/docs/third-party-components.md
+++ b/docs/third-party-components.md
@@ -239,15 +239,6 @@ Used for AI-based speech recognition.
 *   **Files:** Download or build the binary and ensure it is named `whisper-cli`.
 *   **Models:** Models (`.bin` files) go into a `Models` subfolder: `[Data Folder]/SpeechToText/Cpp/Models`.
 
-### MLX Whisper (Speech-to-Text, Apple Silicon)
-Runs Apple's `mlx-whisper` Python package on the GPU / Neural Engine. **Subtitle Edit does not download this engine** — you install the Python package yourself, and there is no file in the Data Folder.
-
-*   **Requirements:** An Apple Silicon Mac (M1 or newer) and Python 3.
-*   **Install:** `pip3 install mlx-whisper` — or, for an isolated install, `pipx install mlx-whisper`.
-*   **Models:** MLX-format Whisper weights (`tiny` … `large-v3-turbo`) are downloaded from Hugging Face (the `mlx-community` org) into the Hugging Face cache on first use.
-*   **How detection works:** Subtitle Edit does not look for a binary; it looks for a Python interpreter that can `import mlx_whisper`. It probes Homebrew (`/opt/homebrew/bin`, `/usr/local/bin`), python.org framework builds, pyenv, and the system Python. Because **pipx, virtual environments, and conda install the package into an isolated environment** that those shared interpreters cannot import, Subtitle Edit also reads the shebang of the installed `mlx_whisper` command — found on your `PATH` or at `~/.local/bin/mlx_whisper` (where pipx places it) — to locate the exact matching interpreter.
-*   **If it reports "not found" after installing:** confirm the command resolves with `which mlx_whisper`. If it does not, add its directory to your `PATH`, or symlink the command into `~/.local/bin`. (Symlinking or copying only the *model files* does nothing — detection is by the Python package, not a binary.)
-
 ### SE5 Speech-to-Text, OCR, and TTS Engines
 
 Some newer local engines are platform-specific or model-specific. Use the in-app downloaders where available, and check [Speech to Text](features/speech-to-text.md), [Text to Speech](features/text-to-speech.md), and [OCR](features/ocr.md) for current engine notes.


### PR DESCRIPTION
The MLX Whisper speech-to-text engine was removed from the app in 21bf99975 (#12966), but that commit never touched the docs. Two files still documented the engine as if it exists.

## Changes
- **docs/features/speech-to-text.md** — removed the MLX Whisper row from the supported-engines table and the MLX Whisper install/detection bullet from the SE5 engine notes.
- **docs/third-party-components.md** — removed the "MLX Whisper (Speech-to-Text, Apple Silicon)" section.

Docs-only change; no code touched. Independent of #14391 (which reverts MLX app code that leaked back in via #14383) — this engine should not exist upstream either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)