### PR TITLE
Binary edit: support more image-based subtitle formats

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -4970,7 +4970,7 @@ public partial class MainViewModel :
             return;
         }
 
-        var fileName = await _fileHelper.PickOpenFile(Window!, Se.Language.General.OpenImageBasedSubtitle, Se.Language.General.ImageBasedSubtitles, "*.sup;*.sub;*.ts;*.xml",
+        var fileName = await _fileHelper.PickOpenFile(Window!, Se.Language.General.OpenImageBasedSubtitle, Se.Language.General.ImageBasedSubtitles, "*.sup;*.sub;*.ts;*.m2ts;*.mts;*.rec;*.mkv;*.mks;*.mp4;*.m4v;*.mov;*.3gp;*.avi;*.divx;*.xml;*.ttml;*.dfxp;*.vtt;*.webvtt",
             Se.Language.General.AllFiles, "*.*");
         if (string.IsNullOrEmpty(fileName))
         {
@@ -4990,7 +4990,7 @@ public partial class MainViewModel :
             return;
         }
 
-        var fileName = await _fileHelper.PickOpenFile(Window!, Se.Language.General.OpenImageBasedSubtitle, Se.Language.General.ImageBasedSubtitles, "*.sup;*.sub;*.ts;*.xml",
+        var fileName = await _fileHelper.PickOpenFile(Window!, Se.Language.General.OpenImageBasedSubtitle, Se.Language.General.ImageBasedSubtitles, "*.sup;*.sub;*.ts;*.m2ts;*.mts;*.rec;*.mkv;*.mks;*.mp4;*.m4v;*.mov;*.3gp;*.avi;*.divx;*.xml;*.ttml;*.dfxp;*.vtt;*.webvtt",
             Se.Language.General.AllFiles, "*.*");
         if (string.IsNullOrEmpty(fileName))
         {

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -9,14 +9,20 @@ using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Controls.VideoPlayer;
 using Nikse.SubtitleEdit.Core.BluRaySup;
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.ContainerFormats;
 using Nikse.SubtitleEdit.Core.ContainerFormats.Matroska;
+using Nikse.SubtitleEdit.Core.ContainerFormats.Mp4;
+using Nikse.SubtitleEdit.Core.ContainerFormats.Mp4.Boxes;
 using Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream;
+using Nikse.SubtitleEdit.Core.Interfaces;
 using Nikse.SubtitleEdit.Core.VobSub;
 using Nikse.SubtitleEdit.Features.Ocr;
 using Nikse.SubtitleEdit.Features.Ocr.OcrSubtitle;
 using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryAdjustAllTimes;
 using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryApplyDurationLimits;
 using Nikse.SubtitleEdit.Features.Shared.PickMatroskaTrack;
+using Nikse.SubtitleEdit.Features.Shared.PickMp4Track;
+using Nikse.SubtitleEdit.Features.Shared.PickTsTrack;
 using Nikse.SubtitleEdit.Features.Sync.ChangeFrameRate;
 using Nikse.SubtitleEdit.Features.Sync.ChangeSpeed;
 using Nikse.SubtitleEdit.Logic;
@@ -533,7 +539,7 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        var fileName = await _fileHelper.PickOpenFile(Window, Se.Language.General.OpenSubtitleFileTitle, Se.Language.General.ImageBasedSubtitles, "*.sup;*.sub;*.ts;*.xml;*.mkv;*.mks", Se.Language.General.AllFiles, "*.*");
+        var fileName = await _fileHelper.PickOpenFile(Window, Se.Language.General.OpenSubtitleFileTitle, Se.Language.General.ImageBasedSubtitles, "*.sup;*.sub;*.ts;*.m2ts;*.mts;*.rec;*.mkv;*.mks;*.mp4;*.m4v;*.mov;*.3gp;*.avi;*.divx;*.xml;*.ttml;*.dfxp;*.vtt;*.webvtt", Se.Language.General.AllFiles, "*.*");
         if (string.IsNullOrEmpty(fileName))
         {
             return;
@@ -711,7 +717,7 @@ public partial class BinaryEditViewModel : ObservableObject
 
         if (imageSubtitle == null)
         {
-            await MessageBox.Show(Window, Se.Language.General.Error, "Image based subtitle format not found/supported.",
+            await MessageBox.Show(Window, Se.Language.General.Error, Se.Language.Tools.ImageBasedEdit.ImageBasedFormatNotSupported,
                 MessageBoxButtons.OK, MessageBoxIcon.Error);
             return;
         }
@@ -747,6 +753,8 @@ public partial class BinaryEditViewModel : ObservableObject
 
     private async Task<IOcrSubtitle?> LoadImageSubtitle(string fileName)
     {
+        var ext = Path.GetExtension(fileName).ToLowerInvariant();
+
         // Blu-ray SUP
         if (FileUtil.IsBluRaySup(fileName))
         {
@@ -757,6 +765,13 @@ public partial class BinaryEditViewModel : ObservableObject
             }
 
             return null;
+        }
+
+        // DVD SUP (SP packets, e.g. demuxed with SubRip/Subtitle Processor)
+        if (FileUtil.IsSpDvdSup(fileName))
+        {
+            var spDvdSup = new OcrSubtitleSpDvdSupImages(fileName);
+            return spDvdSup.Count > 0 ? spDvdSup : null;
         }
 
         // VobSub (.sub + .idx)
@@ -775,18 +790,11 @@ public partial class BinaryEditViewModel : ObservableObject
             return null;
         }
 
-        // Transport Stream (.ts)
-        if (FileUtil.IsTransportStream(fileName))
+        // Transport Stream (.ts / .m2ts / .mts / .rec)
+        if (FileUtil.IsTransportStream(fileName) ||
+            (ext is ".m2ts" or ".mts" or ".ts" && FileUtil.IsM2TransportStream(fileName)))
         {
-            var tsParser = new TransportStreamParser();
-            tsParser.Parse(fileName, null);
-            var subtitles = tsParser.GetDvbSubtitles(0);
-            if (subtitles.Count > 0)
-            {
-                return new OcrSubtitleTransportStream(subtitles);
-            }
-
-            return null;
+            return await LoadTransportStreamImageSubtitle(fileName);
         }
 
         // Matroska (.mkv / .mks) - PGS / VobSub / DVB tracks
@@ -795,15 +803,168 @@ public partial class BinaryEditViewModel : ObservableObject
             return await LoadMatroskaImageSubtitle(fileName);
         }
 
-        // BDN XML
-        if (fileName.EndsWith(".xml", StringComparison.OrdinalIgnoreCase))
+        // DivX/XSUB image subtitles muxed into .avi/.divx
+        if (ext is ".avi" or ".divx")
         {
-            var bdnXml = new Nikse.SubtitleEdit.Core.SubtitleFormats.BdnXml();
-            var subtitle = new Subtitle();
-            bdnXml.LoadSubtitle(subtitle, File.ReadAllLines(fileName).ToList(), fileName);
-            if (subtitle.Paragraphs.Count > 0)
+            var xSubList = XSubParser.ParseAviSubtitles(fileName);
+            return xSubList.Count > 0 ? new OcrSubtitleDivX(xSubList, fileName) : null;
+        }
+
+        // MP4 with VobSub image track(s)
+        if (ext is ".mp4" or ".m4v" or ".mov" or ".3gp")
+        {
+            return await LoadMp4ImageSubtitle(fileName);
+        }
+
+        // WebVTT with embedded base64 thumbnail images
+        if (ext is ".vtt" or ".webvtt")
+        {
+            var lines = File.ReadAllLines(fileName).ToList();
+            var webVttThumbnail = new Nikse.SubtitleEdit.Core.SubtitleFormats.WebVttThumbnail();
+            if (webVttThumbnail.IsMine(lines, fileName))
             {
-                return new OcrSubtitleBdn(subtitle, fileName, false);
+                var subtitle = new Subtitle();
+                webVttThumbnail.LoadSubtitle(subtitle, lines, fileName);
+                if (subtitle.Paragraphs.Count > 0)
+                {
+                    return new OcrSubtitleWebVttImages(subtitle, fileName);
+                }
+            }
+
+            return null;
+        }
+
+        // BDN XML, FCP image xmeml, SMPTE-TT/IMSC with base64 images
+        if (ext is ".xml" or ".ttml" or ".dfxp")
+        {
+            return LoadXmlImageSubtitle(fileName);
+        }
+
+        return null;
+    }
+
+    private async Task<IOcrSubtitle?> LoadTransportStreamImageSubtitle(string fileName)
+    {
+        if (Window == null)
+        {
+            return null;
+        }
+
+        var tsParser = new TransportStreamParser();
+        await Task.Run(() => tsParser.Parse(fileName, null));
+        if (tsParser.SubtitlePacketIds.Count == 0)
+        {
+            return null;
+        }
+
+        // The DVB subtitles live under their real packet ids - a fixed id 0 (the PAT) never
+        // matches, so the first/picked id must be used.
+        var packetId = tsParser.SubtitlePacketIds[0];
+        if (tsParser.SubtitlePacketIds.Count > 1)
+        {
+            var pickResult = await _windowService.ShowDialogAsync<PickTsTrackWindow, PickTsTrackViewModel>(
+                Window, vm => vm.Initialize(tsParser, fileName));
+            if (!pickResult.OkPressed || pickResult.SelectedTrack == null || pickResult.SelectedTrack.IsTeletext)
+            {
+                return null;
+            }
+
+            packetId = pickResult.SelectedTrack.TrackNumber;
+        }
+
+        var subtitles = tsParser.GetDvbSubtitles(packetId);
+        return subtitles is { Count: > 0 } ? new OcrSubtitleTransportStream(subtitles) : null;
+    }
+
+    private async Task<IOcrSubtitle?> LoadMp4ImageSubtitle(string fileName)
+    {
+        if (Window == null)
+        {
+            return null;
+        }
+
+        var mp4Parser = new MP4Parser(fileName);
+        var vobSubTracks = mp4Parser.GetSubtitleTracks().Where(t => t.Mdia.IsVobSubSubtitle).ToList();
+        if (vobSubTracks.Count == 0)
+        {
+            return null;
+        }
+
+        Trak selectedTrack;
+        if (vobSubTracks.Count == 1)
+        {
+            selectedTrack = vobSubTracks[0];
+        }
+        else
+        {
+            var pickResult = await _windowService.ShowDialogAsync<PickMp4TrackWindow, PickMp4TrackViewModel>(
+                Window, vm => vm.Initialize(vobSubTracks, fileName));
+            if (!pickResult.OkPressed || pickResult.SelectedMatroskaTrack?.Track == null)
+            {
+                return null;
+            }
+
+            selectedTrack = pickResult.SelectedMatroskaTrack.Track;
+        }
+
+        var paragraphs = selectedTrack.Mdia.Minf.Stbl.GetParagraphs();
+        return paragraphs.Count > 0 ? new OcrSubtitleMp4VobSub(selectedTrack, paragraphs) : null;
+    }
+
+    internal static IOcrSubtitle? LoadXmlImageSubtitle(string fileName)
+    {
+        var lines = File.ReadAllLines(fileName).ToList();
+
+        // BDN XML - references png files next to the xml
+        var bdnXml = new Nikse.SubtitleEdit.Core.SubtitleFormats.BdnXml();
+        var bdnSubtitle = new Subtitle();
+        bdnXml.LoadSubtitle(bdnSubtitle, lines, fileName);
+        if (bdnSubtitle.Paragraphs.Count > 0)
+        {
+            return new OcrSubtitleBdn(bdnSubtitle, fileName, false);
+        }
+
+        // Final Cut Pro image xmeml (SE's own "export image based" FCP output) - cheap content
+        // gate first, FinalCutProImage has no fast IsMine of its own.
+        if (lines.Any(l => l.Contains("<xmeml", StringComparison.Ordinal)) &&
+            lines.Any(l => l.Contains("<pathurl>", StringComparison.Ordinal)))
+        {
+            var fcpImage = new Nikse.SubtitleEdit.Core.SubtitleFormats.FinalCutProImage();
+            var fcpSubtitle = new Subtitle();
+            fcpImage.LoadSubtitle(fcpSubtitle, lines, fileName);
+            if (fcpSubtitle.Paragraphs.Count > 0)
+            {
+                return new OcrSubtitleBdn(fcpSubtitle, fileName, false);
+            }
+        }
+
+        // SMPTE-TT / IMSC with base64 png images - round-trips this window's own IMSC image export
+        var base64Format = new Nikse.SubtitleEdit.Core.SubtitleFormats.TimedTextBase64Image();
+        if (base64Format.IsMine(lines, fileName))
+        {
+            var base64Subtitle = new Subtitle();
+            base64Format.LoadSubtitle(base64Subtitle, lines, fileName);
+            IList<IBinaryParagraphWithPosition> list = new List<IBinaryParagraphWithPosition>();
+            foreach (var p in base64Subtitle.Paragraphs)
+            {
+                var image = new Nikse.SubtitleEdit.Core.SubtitleFormats.TimedTextBase64Image.Base64PngImage
+                {
+                    Text = p.Text,
+                    StartTimeCode = p.StartTime,
+                    EndTimeCode = p.EndTime,
+                };
+
+                using var bitmap = image.GetBitmap();
+                var nikseBitmap = new NikseBitmap(bitmap);
+                if (nikseBitmap.GetNonTransparentHeight() > 1)
+                {
+                    list.Add(image);
+                }
+            }
+
+            if (list.Count > 0)
+            {
+                return new OcrSubtitleIBinaryParagraph(list);
             }
         }
 
@@ -929,6 +1090,24 @@ public partial class BinaryEditViewModel : ObservableObject
     private async Task ExportVobSub()
     {
         await DoExport(new ExportHandlerVobSub(), ".sub");
+    }
+
+    [RelayCommand]
+    private async Task ExportDvdSup()
+    {
+        await DoExport(new ExportHandlerDvdSup(), ".sup");
+    }
+
+    [RelayCommand]
+    private async Task ExportDCinemaInteropPng()
+    {
+        await DoExport(new ExportHandlerDCinemaInteropPng(), string.Empty, false);
+    }
+
+    [RelayCommand]
+    private async Task ExportDCinemaSmpte2014Png()
+    {
+        await DoExport(new ExportHandlerDCinemaSmpte2014Png(), string.Empty, false);
     }
 
     [RelayCommand]
@@ -2185,7 +2364,7 @@ public partial class BinaryEditViewModel : ObservableObject
             return;
         }
 
-        var fileName = await _fileHelper.PickOpenFile(Window, Se.Language.General.OpenSubtitleFileTitle, Se.Language.General.ImageBasedSubtitles, "*.sup;*.sub;*.ts;*.xml;*.mkv;*.mks", Se.Language.General.AllFiles, "*.*");
+        var fileName = await _fileHelper.PickOpenFile(Window, Se.Language.General.OpenSubtitleFileTitle, Se.Language.General.ImageBasedSubtitles, "*.sup;*.sub;*.ts;*.m2ts;*.mts;*.rec;*.mkv;*.mks;*.mp4;*.m4v;*.mov;*.3gp;*.avi;*.divx;*.xml;*.ttml;*.dfxp;*.vtt;*.webvtt", Se.Language.General.AllFiles, "*.*");
         if (string.IsNullOrEmpty(fileName))
         {
             return;

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -218,8 +218,23 @@ public class BinaryEditWindow : Window
                         },
                         new MenuItem
                         {
+                            Header = Se.Language.File.Export.TitleExportDCinemaInteropPng,
+                            Command = vm.ExportDCinemaInteropPngCommand,
+                        },
+                        new MenuItem
+                        {
+                            Header = Se.Language.File.Export.TitleExportDCinemaSmpte2014Png,
+                            Command = vm.ExportDCinemaSmpte2014PngCommand,
+                        },
+                        new MenuItem
+                        {
                             Header = Se.Language.File.Export.TitleExportDostPng,
                             Command = vm.ExportDostPngCommand,
+                        },
+                        new MenuItem
+                        {
+                            Header = Se.Language.File.Export.TitleExportDvdSup,
+                            Command = vm.ExportDvdSupCommand,
                         },
                         new MenuItem
                         {

--- a/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
+++ b/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
@@ -20,7 +20,10 @@ public static class InitNativeMacMenuBinaryEdit
         Add(exportMenu, Se.Language.General.BdnXml, vm.ExportBdnXmlCommand);
         Add(exportMenu, Se.Language.General.BdnXml8Bit, vm.ExportBdnXml8BitCommand);
         Add(exportMenu, Se.Language.File.Export.TitleExportImscImage, vm.ExportImscImageCommand);
+        Add(exportMenu, Se.Language.File.Export.TitleExportDCinemaInteropPng, vm.ExportDCinemaInteropPngCommand);
+        Add(exportMenu, Se.Language.File.Export.TitleExportDCinemaSmpte2014Png, vm.ExportDCinemaSmpte2014PngCommand);
         Add(exportMenu, Se.Language.File.Export.TitleExportDostPng, vm.ExportDostPngCommand);
+        Add(exportMenu, Se.Language.File.Export.TitleExportDvdSup, vm.ExportDvdSupCommand);
         Add(exportMenu, Se.Language.File.Export.TitleExportFcpImage, vm.ExportFcpPngCommand);
         Add(exportMenu, Se.Language.General.ImagesWithHtmlIndex, vm.ExportHtmlIndexCommand);
         Add(exportMenu, Se.Language.General.ImagesWithTimeCode, vm.ExportImagesWithTimeCodeCommand);

--- a/tests/UI/Features/Shared/BinaryEdit/BinaryEditFormatLoadTests.cs
+++ b/tests/UI/Features/Shared/BinaryEdit/BinaryEditFormatLoadTests.cs
@@ -1,0 +1,145 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Ocr.OcrSubtitle;
+using Nikse.SubtitleEdit.Features.Shared.BinaryEdit;
+using Nikse.SubtitleEdit.UiLogic.Export;
+using SkiaSharp;
+
+namespace UITests.Features.Shared.BinaryEdit;
+
+/// <summary>
+/// Round-trips for the image-based formats the binary edit window can now open:
+/// each test exports with the matching export handler and reads the result back
+/// through the same reader classes <c>LoadImageSubtitle</c> uses.
+/// </summary>
+public class BinaryEditFormatLoadTests
+{
+    private static SKBitmap MakeBitmap(int width, int height, SKColor color)
+    {
+        var bitmap = new SKBitmap(width, height, SKColorType.Bgra8888, SKAlphaType.Unpremul);
+        using var canvas = new SKCanvas(bitmap);
+        canvas.Clear(SKColors.Transparent);
+        using var paint = new SKPaint { Color = color };
+        canvas.DrawRect(new SKRect(2, 2, width - 2, height - 2), paint);
+        return bitmap;
+    }
+
+    private static void Export(IExportHandler handler, string fileOrFolderName)
+    {
+        var imageParameter = new ImageParameter
+        {
+            ScreenWidth = 720,
+            ScreenHeight = 576,
+        };
+
+        handler.WriteHeader(fileOrFolderName, imageParameter);
+        for (var i = 0; i < 2; i++)
+        {
+            using var bitmap = MakeBitmap(120, 40, SKColors.White);
+            imageParameter.Bitmap = bitmap;
+            imageParameter.Text = "Line " + (i + 1);
+            imageParameter.StartTime = TimeSpan.FromSeconds(1 + i * 4);
+            imageParameter.EndTime = TimeSpan.FromSeconds(3 + i * 4);
+            imageParameter.Index = i;
+            imageParameter.OverridePosition = new SKPointI(300, 500);
+
+            handler.CreateParagraph(imageParameter);
+            handler.WriteParagraph(imageParameter);
+        }
+
+        handler.WriteFooter();
+    }
+
+    [Fact]
+    public void DvdSupExport_RoundTripsThroughSpDvdSupReader()
+    {
+        var fileName = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".sup");
+        try
+        {
+            Export(new ExportHandlerDvdSup(), fileName);
+
+            Assert.False(FileUtil.IsBluRaySup(fileName));
+            Assert.True(FileUtil.IsSpDvdSup(fileName));
+
+            var ocrSubtitle = new OcrSubtitleSpDvdSupImages(fileName);
+            Assert.Equal(2, ocrSubtitle.Count);
+            Assert.Equal(1000, ocrSubtitle.GetStartTime(0).TotalMilliseconds, 0);
+            Assert.Equal(5000, ocrSubtitle.GetStartTime(1).TotalMilliseconds, 0);
+            using var bitmap = ocrSubtitle.GetBitmap(0);
+            Assert.True(bitmap.Width > 0 && bitmap.Height > 0);
+        }
+        finally
+        {
+            File.Delete(fileName);
+        }
+    }
+
+    [Fact]
+    public void ImscImageExport_RoundTripsThroughXmlImageLoader()
+    {
+        var fileName = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".ttml");
+        try
+        {
+            Export(new ExportHandlerImscImage(), fileName);
+
+            var ocrSubtitle = BinaryEditViewModel.LoadXmlImageSubtitle(fileName);
+
+            Assert.NotNull(ocrSubtitle);
+            Assert.IsType<OcrSubtitleIBinaryParagraph>(ocrSubtitle);
+            Assert.Equal(2, ocrSubtitle.Count);
+            Assert.Equal(1000, ocrSubtitle.GetStartTime(0).TotalMilliseconds, 0);
+            Assert.Equal(7000, ocrSubtitle.GetEndTime(1).TotalMilliseconds, 0);
+            using var bitmap = ocrSubtitle.GetBitmap(1);
+            Assert.Equal(120, bitmap.Width);
+            Assert.Equal(40, bitmap.Height);
+        }
+        finally
+        {
+            File.Delete(fileName);
+        }
+    }
+
+    [Fact]
+    public void BdnXmlExport_RoundTripsThroughXmlImageLoader()
+    {
+        var folderName = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(folderName);
+        try
+        {
+            Export(new ExportHandlerBdnXml(), folderName);
+            var xmlFileName = Path.Combine(folderName, "index.xml");
+            Assert.True(File.Exists(xmlFileName));
+
+            var ocrSubtitle = BinaryEditViewModel.LoadXmlImageSubtitle(xmlFileName);
+
+            Assert.NotNull(ocrSubtitle);
+            Assert.IsType<OcrSubtitleBdn>(ocrSubtitle);
+            Assert.Equal(2, ocrSubtitle.Count);
+            using var bitmap = ocrSubtitle.GetBitmap(0);
+            Assert.Equal(120, bitmap.Width);
+            Assert.Equal(40, bitmap.Height);
+        }
+        finally
+        {
+            Directory.Delete(folderName, true);
+        }
+    }
+
+    [Fact]
+    public void LoadXmlImageSubtitle_ReturnsNullForPlainTextSubtitleXml()
+    {
+        var fileName = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xml");
+        try
+        {
+            File.WriteAllText(fileName,
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?><tt xmlns=\"http://www.w3.org/ns/ttml\"><body><div><p begin=\"00:00:01.000\" end=\"00:00:03.000\">Hello</p></div></body></tt>");
+
+            var ocrSubtitle = BinaryEditViewModel.LoadXmlImageSubtitle(fileName);
+
+            Assert.Null(ocrSubtitle);
+        }
+        finally
+        {
+            File.Delete(fileName);
+        }
+    }
+}


### PR DESCRIPTION
## What

The image-based subtitle editor (binary edit) previously opened only Blu-ray SUP, VobSub (.sub+.idx), plain .ts, Matroska tracks, and BDN XML. This brings it up to parity with the OCR window's format support and wires in three export handlers that already existed but weren't reachable from this window.

### New open formats
- **DVD SUP** (SP packets, e.g. demuxed with SubRip/Subtitle Processor)
- **DivX/XSUB** image subtitles muxed into `.avi`/`.divx`
- **MP4 VobSub tracks** (`.mp4`/`.m4v`/`.mov`/`.3gp`), with the existing MP4 track picker when a file has several
- **WebVTT with embedded base64 thumbnails** (`.vtt`/`.webvtt`)
- **FCP image xmeml** and **SMPTE-TT/IMSC base64 image TTML** (`.ttml`/`.dfxp`/`.xml`) — the latter round-trips this window's own IMSC image export
- **`.m2ts`/`.mts`/`.rec`** transport streams (192/204-byte packets and Topfield REC)

### New exports
- DVD sup (MuxMan/Scenarist)
- D-Cinema interop (png)
- D-Cinema SMPTE 2014 (png)

All three handlers already existed in libuilogic; they're now in the export menu (regular + macOS native).

### Bug fix
The existing `.ts` open path called `GetDvbSubtitles(0)` — packet id 0 is the PAT and never a subtitle pid, so the lookup returned null and every real transport stream crashed with a NullReferenceException. It now uses the detected subtitle pids, shows the TS track picker for multi-track streams, and parses off the UI thread.

Also: the open-file filters (binary edit, its append dialog, and the main window's image-based open/edit commands) now list the new extensions, and the "format not supported" message uses the existing language entry instead of a hardcoded string.

## Testing
- New `BinaryEditFormatLoadTests` round-trips DVD sup export → SP DVD sup reader, IMSC image export → XML image loader, and BDN XML export → XML image loader, plus a negative case for text-only TTML.
- Full UI suite: 4517 passed, 0 failed; libuilogic: 749 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)