### PR TITLE
Docs: sync AI model/engine lists with the code

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -76,10 +76,11 @@ Subtitle Edit supports several local and downloadable speech-to-text engines:
 - **Purfview's Faster-Whisper-XXL** — Fast GPU/CPU-based (Windows, Linux)
 - **CTranslate2** — Fast CPU/GPU-based
 - **Const-me's Whisper** — DirectX-based (Windows)
+- **WhisperX** — Faster-Whisper with wav2vec2 word-level alignment, standalone build (Windows x64, Linux x64, macOS Apple Silicon)
 - **OpenAI Whisper** — Original Python implementation
 - **OpenAI-compatible STT** — Send audio to any OpenAI-compatible speech endpoint
-- **Qwen3 ASR CPP** — Local GGUF-based engine (Windows, Linux)
-- **Crisp ASR** — Local engine with multiple backends (Parakeet, Canary, Cohere, Fire Red, GLM, Granite, Qwen3, Mega, Omni, Kyutai) and a Forced-aligner picker (built-in / Canary CTC / Qwen3 / 12 wav2vec2 language aligners) for word-level timestamps
+- **Qwen3 ASR CPP** — Local GGUF-based engine (Windows, Linux, macOS)
+- **Crisp ASR** — Local engine with multiple backends (Parakeet, Canary, Cohere, Fire Red, Fun-ASR Nano, GigaAM, GLM, Granite, Qwen3, Mega, MOSS Diarize, Omni, Kyutai, SenseVoice, ARK, Voxtral) and a Forced-aligner picker (built-in / Canary CTC / Qwen3 / 12 wav2vec2 language aligners) for word-level timestamps
 
 ### How do I use Speech to Text?
 1. Open a video file
@@ -111,11 +112,14 @@ Use **Synchronization → Change frame rate...** and select the source and targe
 - **Tesseract** — Open-source OCR engine with language packs
 - **nOCR** — Nikse's built-in OCR with trainable databases
 - **Binary OCR** — For binary image comparison
+- **PaddleOCR** — Local OCR (standalone build for Windows/Linux, or the pip-installed Python engine)
+- **CrispEmbed** — Local OCR with downloadable model backends (PP-OCRv6, GLM-OCR, GOT-OCR2, Qwen3-VL, DeepSeek-OCR-2)
+- **llama.cpp** — Local vision-LLM OCR with a managed server and curated models
+- **Ollama OCR** — Local LLM-based
+- **Apple Vision** — Built-in OCR on macOS
 - **Google Lens OCR** — Cloud-based
 - **Google Vision OCR** — Cloud-based
-- **Ollama OCR** — Local LLM-based
 - **Mistral OCR** — Cloud-based
-- **PaddleOCR** — Local OCR
 
 ### How do I OCR Blu-ray subtitles?
 1. Open the `.sup` file via **File → Open**

--- a/docs/features/ai-review.md
+++ b/docs/features/ai-review.md
@@ -10,7 +10,7 @@ Proofread the subtitle text with a local (or remote) large language model - typo
 
 ## Engines
 
-- **llama.cpp** — a managed local server. Pick a model from the curated list (Qwen 3.5, Gemma 3, Llama 3.1, EuroLLM, Phi-4 mini); Subtitle Edit downloads the engine and model on first use. A green dot marks models that are already downloaded. Custom `*.gguf` files placed in the llama.cpp models folder also appear.
+- **llama.cpp** — a managed local server. Pick a model from the curated list (Qwen 3.5, Qwen 3.6, Gemma 3, Gemma 4, Llama 3.1, EuroLLM, Phi-4 mini, Granite 4.1); Subtitle Edit downloads the engine and model on first use. A green dot marks models that are already downloaded. Custom `*.gguf` files placed in the llama.cpp models folder also appear.
 - **Ollama** — uses a running [Ollama](https://ollama.com) instance; type a model name or pick one from the server.
 - **OpenAI-compatible** — any endpoint that speaks the OpenAI chat API: LM Studio, KoboldCpp, vLLM, a llama.cpp server on another machine, or cloud APIs (OpenAI, Groq, OpenRouter, DeepSeek, Mistral, Gemini). Enter the URL, model name, and an API key if the service needs one.
 

--- a/docs/features/auto-translate.md
+++ b/docs/features/auto-translate.md
@@ -29,7 +29,7 @@ Automatically translate subtitles using various translation engines and AI servi
 - **LM Studio (local LLM)** — Local LLM translation
 - **Ollama (local LLM)** — Local LLM-based translation
 - **Ollama advanced (local LLM)** — Ollama translated in batches with surrounding context, a synopsis and a glossary; see [Advanced local engines](auto-translate-advanced.md)
-- **llama.cpp (local LLM)** — Server-managed local LLM translation; Subtitle Edit downloads llama.cpp and a curated model (TranslateGemma, Qwen or Aya Expanse) and runs a local `llama-server` for you. See [Using your own model](#llamacpp-using-your-own-model) to run a model we don't ship, such as TranslateGemma 27B
+- **llama.cpp (local LLM)** — Server-managed local LLM translation; Subtitle Edit downloads llama.cpp and a curated model (TranslateGemma, Gemma 4, Qwen, Aya Expanse, MiLMMT or Hy-MT2) and runs a local `llama-server` for you. See [Using your own model](#llamacpp-using-your-own-model) to run a model we don't ship, such as TranslateGemma 27B
 - **llama.cpp advanced (local LLM)** — The managed llama.cpp server translated in batches with surrounding context, a synopsis and a glossary; see [Advanced local engines](auto-translate-advanced.md)
 - **OpenAI Compatible API** — Generic engine for any service exposing an OpenAI-compatible `chat/completions` endpoint (vLLM, KoboldCpp, a llama.cpp server on another machine, cloud providers, ...); configure URL, model, prompt, and an optional API key
 - **Anthropic Claude** — AI translation (requires API key)
@@ -50,7 +50,7 @@ Automatically translate subtitles using various translation engines and AI servi
 ## llama.cpp: using your own model
 
 The models offered in the download list are deliberately kept small enough to run on an ordinary
-machine (around 8 GB or less). You are not limited to them — larger models such as TranslateGemma
+machine (mostly under 8 GB, the largest around 12 GB). You are not limited to them — larger models such as TranslateGemma
 27B work fine if your hardware can handle them.
 
 Two ways to use one:
@@ -70,7 +70,7 @@ choice and the jump to 27B buys less than the size difference suggests.
 
 ## Prompts: chat models and completion models
 
-Every local-LLM engine (LM Studio, Ollama, KoboldCpp, llama.cpp, OpenAI Compatible API) has a
+Every local-LLM engine (LM Studio, Ollama, llama.cpp, OpenAI Compatible API) has a
 **prompt** you can edit. `{0}` is replaced with the source language and `{1}` with the target
 language, both as English names.
 
@@ -91,8 +91,8 @@ Translate this from {0} to {1}:
 
 The trailing `{1}:` cue is what makes such a model translate at all — without it, it tends to echo
 the source. Set the model's temperature to 0 where the engine offers it. Curated MiLMMT models in
-the llama.cpp engine's download list carry this prompt already; for LM Studio, KoboldCpp, Ollama or
-your own OpenAI-compatible server, paste it into the engine's prompt field.
+the llama.cpp engine's download list carry this prompt already; for LM Studio, Ollama or
+your own OpenAI-compatible server (vLLM, KoboldCpp, ...), paste it into the engine's prompt field.
 
 Headless runs take the same prompt via `seconv --translate-prompt:<text|file>` — see
 [Auto-translate (command line)](../reference/command-line.md#custom-prompt).

--- a/docs/features/ocr.md
+++ b/docs/features/ocr.md
@@ -37,6 +37,11 @@ Binary image comparison engine.
 - Fast and accurate for known fonts
 - Supports database editing, character history, max error percentage, and pixels-are-space tuning
 
+### Apple Vision
+Built-in OCR on macOS using Apple's Vision framework.
+- macOS only; nothing to download or configure
+- Good accuracy on clean subtitle images
+
 ### Google Lens Sharp / Google Lens Standalone
 Cloud-based OCR using Google Lens (free, but capped).
 - Requires internet connection.

--- a/docs/features/speech-to-text.md
+++ b/docs/features/speech-to-text.md
@@ -15,12 +15,13 @@ Subtitle Edit can automatically transcribe audio to text using Whisper-based and
 | Purfview Faster Whisper XXL | Windows, Linux | Fast local engine, often used with NVIDIA CUDA |
 | Whisper CTranslate2 | Windows, Linux (x64), macOS (Apple Silicon) | CPU / NVIDIA CUDA depending on installation; CUDA requires [CUDA 12.x](https://developer.nvidia.com/cuda-12-0-0-download-archive) |
 | Whisper Const-me | Windows | DirectX-based engine |
+| WhisperX | Windows (x64), Linux (x64), macOS (Apple Silicon) | Faster-Whisper with wav2vec2 word-level alignment, packaged as a standalone build (no Python install needed) |
 | Whisper OpenAI | All | Python-based OpenAI Whisper workflow |
 | OpenAI Compatible Server | All | Connect to any OpenAI-compatible speech-to-text endpoint |
 | OpenRouter | All | Online. One API key routes to Whisper, gpt-4o-transcribe, Groq and Google Chirp |
 | Alibaba Qwen3-ASR | All | Online Qwen3-ASR via Alibaba Model Studio (DashScope) |
-| Qwen3 ASR CPP | Windows, Linux | Local Qwen3 ASR engine with downloadable GGUF models |
-| Crisp ASR | Windows, Linux, macOS | Single engine with selectable backends: Parakeet, Canary, Cohere, Fire Red, Fun-ASR Nano, Fun-ASR MLT Nano, GigaAM, GLM, Granite, Qwen3, Mega, MOSS Diarize, Omni, Kyutai, SenseVoice, ARK, Voxtral |
+| Qwen3 ASR CPP | Windows, Linux, macOS | Local Qwen3 ASR engine with downloadable GGUF models |
+| Crisp ASR | Windows, Linux, macOS | Single engine with selectable backends: Parakeet, Canary, Cohere, Fire Red, Fun-ASR Nano, GigaAM, GLM, Granite, Qwen3, Mega, MOSS Diarize, Omni, Kyutai, SenseVoice, ARK, Voxtral |
 
 Engines and models are downloaded automatically on first use.
 
@@ -28,7 +29,7 @@ Engines and models are downloaded automatically on first use.
 
 - **Whisper CPP** is shown as a single entry; the CPU / cuBLAS / Vulkan backends are selected from a secondary dropdown when Whisper CPP is selected.
 - **Qwen3 ASR CPP** includes 0.6B and 1.7B model options, plus a forced-aligner model used for timing workflows.
-- **Crisp ASR** is exposed as one engine that wraps multiple backends (Parakeet, Canary, Cohere, Fire Red, Fun-ASR Nano, Fun-ASR MLT Nano, GigaAM, GLM, Granite, Qwen3, Mega, MOSS Diarize, Omni, Kyutai, SenseVoice, ARK, Voxtral). Pick the backend from the Crisp ASR backend dropdown - see [Crisp ASR backends](#crisp-asr-backends) for what each one is good at.
+- **Crisp ASR** is exposed as one engine that wraps multiple backends (Parakeet, Canary, Cohere, Fire Red, Fun-ASR Nano, GigaAM, GLM, Granite, Qwen3, Mega, MOSS Diarize, Omni, Kyutai, SenseVoice, ARK, Voxtral). Pick the backend from the Crisp ASR backend dropdown - see [Crisp ASR backends](#crisp-asr-backends) for what each one is good at.
 - A **Forced aligner** option is shown for Crisp ASR backends and exposes the built-in aligner, Canary CTC, Qwen3, and the wav2vec2 zoo (12 language-specific CTC aligners that run on top of any Crisp ASR backend).
 - Several newer engines support automatic language selection.
 - Each engine can have separate advanced command-line parameters.
@@ -54,7 +55,6 @@ The languages column counts what the backend dropdown offers (an *auto* entry is
 | **GLM** | 17 | Needs aligner | 1.3 - 4.5 GB | GLM-ASR Nano, Chinese-first with a wide second tier of languages |
 | **SenseVoice** | 5 (zh, yue, en, ja, ko) | Needs aligner | 136 - 469 MB | Tiny and quick for CJK audio - useful on machines where the larger backends are too slow |
 | **Fun-ASR Nano** | 5 (en, zh, yue, ja, ko) | Needs aligner | 0.90 - 1.98 GB | CJK-focused Fun-ASR |
-| **Fun-ASR MLT Nano** | 31 | Needs aligner | 0.90 - 1.98 GB | The multilingual sibling of Fun-ASR Nano at the same size |
 | **Mega** | 2 (en, zh) | Needs aligner | 1.3 - 4.4 GB | Mega-ASR 1.7B. VAD is on by default (see the VAD section below) |
 | **Granite** | 6 (en, fr, de, es, pt, ja) | Needs aligner | 1.54 - 5.58 GB | IBM Granite Speech 4.1 2B. The `plus` models are the newer revision; `mini` and `f16enc` trade encoder precision for size |
 | **ARK** | 19 (European + zh, ja, ko) | Needs aligner | 3.52 - 7.51 GB | A 3B model - the heaviest backend here, so only worth it when the smaller ones fall short |

--- a/docs/features/text-to-speech.md
+++ b/docs/features/text-to-speech.md
@@ -58,7 +58,7 @@ Lines that contain only sounds or music — `♪`, `[door slams]`, `(sighs)`, or
 - **OmniVoice TTS** — Local CPU TTS with voice cloning and many languages
 - **Qwen3 TTS (CrispASR)** — Local Qwen3 TTS running through the CrispASR runtime (VoiceDesign, CustomVoice, and Voice clone 1.7B models)
 - **Chatterbox TTS (CrispASR)** — Chatterbox TTS via the CrispASR runtime, with voice cloning (multilingual Base or English-only Turbo model)
-- **IndexTTS (CrispASR)** — IndexTTS-1.5 via the CrispASR runtime; the smallest voice-cloning engine here (about 870 MB)
+- **IndexTTS (CrispASR)** — IndexTTS-1.5 via the CrispASR runtime; a small voice-cloning engine (about 870 MB)
 - **CosyVoice3 (CrispASR)** — Alibaba CosyVoice3 with 9 languages and 18 Mandarin dialects, baked-in voice presets and zero-shot cloning
 - **IndexTTS 2.5 (audio.cpp)** — IndexTTS-2.5 on the audio.cpp runtime: cloning in Chinese, English, Japanese, Spanish and Arabic, with emotion and speaking-rate control. The reference voice is sent per request, so switching voice does not restart the server
 - **VoxCPM2 (CrispASR)** — Tokenizer-free diffusion engine at 48 kHz, about 30 languages, with zero-shot cloning
@@ -66,6 +66,11 @@ Lines that contain only sounds or music — `♪`, `[door slams]`, `(sighs)`, or
 - **Zonos TTS (CrispASR)** — Zonos-v0.1 at 44.1 kHz with cloning from a reference recording
 - **OmniVoice TTS (CrispASR)** — The OmniVoice model on the shared CrispASR runtime, run as a persistent server so the model loads once instead of once per line
 - **dots.tts (CrispASR)** — dots.tts SOAR 2B rendered at 48 kHz by a BigVGAN vocoder, with zero-shot cloning
+- **VibeVoice (CrispASR)** — Microsoft VibeVoice 1.5B via the CrispASR runtime, with voice cloning; a single GGUF with no separate codec file
+- **Confucius4-TTS (CrispASR)** — NetEase Youdao Confucius4-TTS at 22.05 kHz, 14 languages; cloning only — a reference voice is required, there is no default voice
+- **Pocket TTS (CrispASR)** — Kyutai Pocket TTS 100M; the smallest and fastest cloning engine (one 124-365 MB GGUF per language, 6 languages), and the reference is sent per request
+- **Higgs Audio v3 (audio.cpp)** — Boson AI Higgs Audio v3 4B on the audio.cpp runtime; zero-shot cloning in 100+ languages, per-request reference so switching voice does not restart the server
+- **Fish Audio S2 Pro (audio.cpp)** — Fish Audio S2 Pro on the audio.cpp runtime; zero-shot cloning in 80+ languages at 44.1 kHz, per-request reference
 
 Local downloadable engines are installed into the Subtitle Edit data folder when you accept the download prompt.
 
@@ -86,17 +91,20 @@ Several of the local engines above are different models on the same CrispASR run
 | **Zonos TTS (CrispASR)** | 44.1 kHz | Follows the text | From a reference recording | 24 kHz mono | ~1.8 GB |
 | **VoxCPM2 (CrispASR)** | 48 kHz | ~30 | Zero-shot | 24 kHz mono (upsampled internally) | ~1.7 - 5 GB |
 | **dots.tts (CrispASR)** | 48 kHz | Follows the text | Zero-shot | 24 kHz mono | ~2.4 - 5 GB |
+| **VibeVoice (CrispASR)** | 24 kHz | Follows the text | Zero-shot | 24 kHz mono | ~1.6 - 5 GB |
+| **Confucius4-TTS (CrispASR)** | 22.05 kHz | 14 | Zero-shot (required - no default voice) | 22.05 kHz mono | ~1.9 - 2.6 GB |
+| **Pocket TTS (CrispASR)** | 24 kHz | 6 (one model per language) | Zero-shot, per request | 24 kHz mono | ~124 - 365 MB per language |
 
 "Follows the text" means the engine has no language picker - it speaks whatever script it is given, taking its accent from the reference voice.
 
 Notes on picking one:
 
-- **Smallest download that still clones:** IndexTTS at about 600 MB - 870 MB.
+- **Smallest download that still clones:** Pocket TTS at 124-365 MB per language; IndexTTS (about 600 MB - 870 MB) is the smallest that covers many languages with one model.
 - **Most languages:** OmniVoice, at 646.
 - **Highest output rate:** VoxCPM2 and dots.tts at 48 kHz, then Zonos at 44.1 kHz.
 - **MOSS-TTS is by far the largest** because its Qwen3-8B backbone needs a ~3.5 GB codec companion on top of the backbone quant. Check free disk space before selecting it.
 - Quantized engines follow the same rule as the speech-to-text models: `Q4_K` is the small fast default, `Q8_0` is close to full precision, and `F16` is rarely worth the extra gigabytes.
-- **None of the CrispASR engines take a new reference voice per line** - each reads its reference when its server starts, so switching voice reloads the model. That is why [Clone From Video (Voice of Each Line)](#clone-from-video-voice-of-each-line) lists OmniVoice TTS (the standalone engine) rather than a CrispASR one.
+- **Most of the CrispASR engines load their reference voice at server start**, so switching voice reloads the model. The exceptions are **Pocket TTS** (per-request reference) and **Qwen3 TTS** with the Voice clone model — those, plus the standalone OmniVoice TTS engine, are what [Clone From Video (Voice of Each Line)](#clone-from-video-voice-of-each-line) can use.
 
 ## Engine Settings
 
@@ -153,7 +161,7 @@ For dubbing a video with several speakers there is a faster way than cloning eac
 
 Before generating, Subtitle Edit cuts one short reference clip per line out of the video's audio. Lines shorter than about three seconds are grown into the silence around them, but never into the neighbouring line — a reference with two speakers in it would clone the wrong person.
 
-- **Supported engines:** OmniVoice TTS. The entry only appears for engines that accept a reference for each line; engines that load their reference when their server starts would have to reload the model for every line.
+- **Supported engines:** OmniVoice TTS, Pocket TTS (CrispASR), and Qwen3 TTS (CrispASR) with the Voice clone model. The entry only appears for engines that accept a reference for each line; engines that load their reference when their server starts would have to reload the model for every line.
 - **Reference text:** if you have the original subtitle loaded next to the translation, its lines are used as the transcript of the clips — that is what the video actually says, and it makes cloning noticeably better. Without an original loaded, the line's own text is used.
 - **Test voice** previews the clone taken from the longest line of the subtitle.
 - Quality depends on the source audio. Loud music or two people talking over each other in a line makes that line's clone worse. Longer subtitle lines clone better than very short ones, so a subtitle segmented into full sentences gives the best result.

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,7 +85,7 @@ Subtitle Edit is a free, open-source editor for video subtitles. This is the doc
 - [Find Double Lines](features/find-double-lines.md) — Find consecutive duplicate subtitle lines
 
 ### OCR (Optical Character Recognition)
-- [OCR](features/ocr.md) — Convert image-based subtitles to text (nOCR, Binary OCR, Tesseract)
+- [OCR](features/ocr.md) — Convert image-based subtitles to text (nOCR, Binary OCR, Tesseract, PaddleOCR, CrispEmbed, LLM-based and cloud engines)
 
 ### ASSA (Advanced SubStation Alpha)
 - [ASSA Styles](features/assa-styles.md) — Manage ASS/SSA styles

--- a/docs/third-party-components.md
+++ b/docs/third-party-components.md
@@ -36,7 +36,6 @@ Subtitle Edit stores these components in its **Data Folder**.
 | **Purfview Faster-Whisper XXL** | `faster-whisper-xxl.exe`, `_models/` folder | `[Data Folder]/SpeechToText/Purfview-Faster-Whisper-XXL` |
 | **Crisp ASR** | `crispasr.exe`, `models/` folder | `[Data Folder]/CrispASR` |
 | **Qwen3 ASR CPP** | `qwen3-asr-cli.exe`, `models/` folder | `[Data Folder]/Qwen3ASR` |
-| **Parakeet.cpp** | `parakeet.exe`, model folders | `[Data Folder]/parakeet.cpp` |
 | **PaddleOCR** | `paddleocr.exe`, `models/` folder | `[Data Folder]/OCR/PaddleOCR3-7` |
 | **Qwen3 TTS (CrispASR)** | shares `crispasr.exe` + `models/` from `[Data Folder]/CrispASR`; reference voices in `voices/` | `[Data Folder]/TextToSpeech/Qwen3TtsCrispAsr` (voices only) |
 | **Chatterbox TTS (CrispASR)** | shares `crispasr.exe` + `models/` from `[Data Folder]/CrispASR`; reference voices in `voices/` | `[Data Folder]/TextToSpeech/Chatterbox` (voices only) |
@@ -110,10 +109,9 @@ Used for GPU-accelerated AI-based speech recognition.
 ### SE5 Speech-to-Text Engines
 Subtitle Edit 5 can download additional ASR engines directly from the **Speech to text** window.
 
-*   **Crisp ASR:** Stored in `[Data Folder]/CrispASR`. Models go into its `models` folder. Crisp ASR backends include Parakeet, Canary, Cohere, Fire Red, GLM, Granite, Qwen3, Mega, Omni, and Kyutai.
+*   **Crisp ASR:** Stored in `[Data Folder]/CrispASR`. Models go into its `models` folder. Crisp ASR backends include Parakeet, Canary, Cohere, Fire Red, Fun-ASR Nano, GigaAM, GLM, Granite, Qwen3, Mega, MOSS Diarize, Omni, Kyutai, SenseVoice, ARK, and Voxtral.
     *   The speech-to-text dialog also offers a **Forced aligner** combo for word-level timestamps. Built-in (where the backend supports it), Canary CTC, Qwen3, and 12 language-specific wav2vec2 aligners (the WhisperX aligner zoo): `en`, `de`, `fr`, `es`, `it`, `ja`, `zh`, `nl`, `pt`, `ar`, `uk`, `cs`. The default is the built-in aligner when the backend supports it, otherwise Qwen3 or Canary CTC depending on the backend; pick a wav2vec2 entry manually to use one of those.
-*   **Qwen3 ASR CPP:** Stored in `[Data Folder]/Qwen3ASR`. Models go into `[Data Folder]/Qwen3ASR/models`.
-*   **Parakeet.cpp:** Stored in `[Data Folder]/parakeet.cpp`. Each model has its own folder because the model weights and `vocab.txt` must stay together.
+*   **Qwen3 ASR CPP:** Stored in `[Data Folder]/Qwen3ASR`. Models go into `[Data Folder]/Qwen3ASR/models`. (Parakeet is no longer a standalone engine; it is a Crisp ASR backend.)
 
 Use [Speech to Text](features/speech-to-text.md) for the current engine list and workflow.
 
@@ -130,12 +128,14 @@ Used for OCR of image-based subtitles.
 ### Local Text-to-Speech Engines
 Subtitle Edit 5 can download local TTS servers and models from the **Text to speech** window.
 
-*   **Qwen3 TTS (CrispASR):** Reference voices are stored in `[Data Folder]/TextToSpeech/Qwen3TtsCrispAsr/voices`. The talker GGUFs (VoiceDesign 1.7B or CustomVoice 1.7B) and the 12 Hz codec are downloaded into the shared `[Data Folder]/CrispASR/models` cache alongside the Crisp ASR speech-to-text models, not under `TextToSpeech/Qwen3TtsCrispAsr/models` — installing Crisp ASR first is therefore recommended. Older installs that still have model files under the legacy `TextToSpeech/Qwen3TtsCrispAsr/models` folder are migrated automatically the first time the engine is used.
+*   **Qwen3 TTS (CrispASR):** Reference voices are stored in `[Data Folder]/TextToSpeech/Qwen3TtsCrispAsr/voices`. The talker GGUFs (VoiceDesign 1.7B, CustomVoice 1.7B or Voice clone Base 1.7B) and the 12 Hz codec are downloaded into the shared `[Data Folder]/CrispASR/models` cache alongside the Crisp ASR speech-to-text models, not under `TextToSpeech/Qwen3TtsCrispAsr/models` — installing Crisp ASR first is therefore recommended. Older installs that still have model files under the legacy `TextToSpeech/Qwen3TtsCrispAsr/models` folder are migrated automatically the first time the engine is used.
 *   **Chatterbox TTS (CrispASR):** Reference voices are stored in `[Data Folder]/TextToSpeech/Chatterbox/voices`. The Base / Turbo model GGUFs (T3 + S3Gen) are downloaded into the shared `[Data Folder]/CrispASR/models` cache alongside the Crisp ASR speech-to-text models, not under `TextToSpeech/Chatterbox/models` — installing Crisp ASR first is therefore recommended. Older installs that still have model files under the legacy `TextToSpeech/Chatterbox/models` folder are migrated automatically the first time the engine is used.
 *   **OmniVoice TTS:** Stored in `[Data Folder]/TextToSpeech/OmniVoice`. Brings its own `omnivoice-tts` and `omnivoice-codec` binaries. Supports 646 languages and voice cloning on CPU. `models/` and `voices/` subfolders.
 *   **Kokoro TTS:** Stored in `[Data Folder]/TextToSpeech/KokoroTtsCpp`. Models go into the `models` folder.
 
-Use [Text to Speech](features/text-to-speech.md) for engine-specific options.
+These are examples, not the full set — many more local engines are downloadable from the Text to speech window (IndexTTS, CosyVoice3, dots.tts, VoxCPM2, MOSS-TTS, Zonos, VibeVoice, Confucius4-TTS, Pocket TTS, Higgs Audio, Fish Audio, and more), following the same layout: CrispASR-based engines share the `[Data Folder]/CrispASR` cache, and the rest live under `[Data Folder]/TextToSpeech/<engine>`.
+
+Use [Text to Speech](features/text-to-speech.md) for the full engine list and engine-specific options.
 
 ---
 
@@ -192,7 +192,7 @@ Used for GPU-accelerated AI-based speech recognition.
 
 ### SE5 Speech-to-Text, OCR, and TTS Engines
 
-The same data-folder layout is used on Linux. Prefer the in-app downloaders for Crisp ASR, Qwen3 ASR, Parakeet.cpp, PaddleOCR, Qwen3 TTS (CrispASR), Chatterbox TTS (CrispASR), OmniVoice TTS, and Kokoro TTS because the required files differ by build and model.
+The same data-folder layout is used on Linux. Prefer the in-app downloaders for Crisp ASR, Qwen3 ASR, PaddleOCR, and the local TTS engines because the required files differ by build and model.
 
 ---
 


### PR DESCRIPTION
A docs check comparing the AI-model claims in `/docs` (translate, TTS, STT, AI review, OCR) against the actual engine/model lists in the source. Five parallel audits found 17 discrepancies; this PR fixes them all. No code changes.

## Speech to text
- **WhisperX** added to the engine table and FAQ list — it is registered in `SpeechToTextViewModel` (Windows x64, Linux x64, macOS Apple Silicon) but was undocumented.
- **Fun-ASR MLT Nano** removed — commented out in `CrispAsrEngine.cs` ("does not work well enough") but still documented as selectable.
- Crisp ASR backend lists in `faq.md` and `third-party-components.md` updated from the stale 10-backend set to the full 16 (adds GigaAM, Fun-ASR Nano, MOSS Diarize, SenseVoice, ARK, Voxtral).
- Qwen3 ASR CPP platforms now include macOS (Mac builds ship in `DownloadHashManager`).
- **Parakeet.cpp** removed as a standalone engine/data folder — no engine class exists anymore; Parakeet is a Crisp ASR backend.

## Text to speech
- Added the five engines missing from the docs: **VibeVoice (CrispASR)**, **Confucius4-TTS (CrispASR)**, **Pocket TTS (CrispASR)**, **Higgs Audio v3 (audio.cpp)**, **Fish Audio S2 Pro (audio.cpp)** — engine list plus CrispASR table rows (rates/sizes taken from the engine classes).
- Per-line voice cloning ("Clone from video, voice of each line") now correctly lists OmniVoice TTS, Pocket TTS, and Qwen3 TTS with the Voice clone model (`SupportsPerLineVoiceCloning` gating verified in `PerLineVoiceClone.cs`); the "none of the CrispASR engines" claim was stale.
- "Smallest download that still clones" is now Pocket TTS (124-365 MB per language), with IndexTTS noted as smallest multi-language.
- Qwen3 talker GGUF list gains the Voice clone Base 1.7B; the third-party-components TTS section now says its four entries are examples and points to the full list.

## OCR
- FAQ engine list gains **CrispEmbed**, **llama.cpp**, and **Apple Vision** (and notes the Lens/Paddle variants); `ocr.md` gains an Apple Vision section; `index.md`'s "(nOCR, Binary OCR, Tesseract)" parenthetical updated.

## Translate
- **KoboldCpp** removed from the prompt-editable engine lists — `KoboldCppTranslate` exists but is never instantiated anywhere (auto-translate, batch convert, seconv); KoboldCpp is reached via the OpenAI Compatible API engine, which the docs already cover.
- "around 8 GB or less" download-list claim updated (Qwen 3.5 9B is 9.8 GB, Qwen 3.6 35B-A3B is 11.5 GB).
- Curated llama.cpp family list expanded with Gemma 4, MiLMMT and Hy-MT2.

## AI review
- Curated model parenthetical gains Qwen 3.6, Gemma 4 and Granite 4.1 (present in `LlamaCppServerManager.ReviewModels`).

Everything else audited checked out against the code: all 27 auto-translate engines, advanced-engine batch/context settings, the llama.cpp OCR and CrispEmbed model lists, PaddleOCR 3.7 folder/model claims, the forced-aligner zoo, the AI review workflow, and the TTS data-folder paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)