### PR TITLE
Fix color-degenerate DVD sup/VobSub and wrong D-Cinema edit rate in binary edit exports

### DIFF
--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1199,6 +1199,16 @@ public partial class BinaryEditViewModel : ObservableObject
         {
             ScreenWidth = ScreenWidth,
             ScreenHeight = ScreenHeight,
+            // The VobSub and DVD sup writers build their four color CLUT from these two; left at
+            // default(SKColor) every visible pixel quantizes onto the anti-alias index as opaque
+            // black. White text/black outline matches both the export dialog's defaults and what
+            // the loaded bitmaps in practice contain.
+            FontColor = SKColors.White,
+            OutlineColor = SKColors.Black,
+            // The D-Cinema SMPTE handler declares EditRate/TimeCodeRate from this, while the cue
+            // timecodes are converted with Configuration...CurrentFrameRate - read the same value
+            // so header and cues agree. The Dost and FCP handlers take their rate from it too.
+            FramesPerSecond = Configuration.Settings.General.CurrentFrameRate,
         };
 
         exportHandler.WriteHeader(fileOrFolderName, imageParameter);

--- a/tests/UI/Features/Shared/BinaryEdit/BinaryEditFormatLoadTests.cs
+++ b/tests/UI/Features/Shared/BinaryEdit/BinaryEditFormatLoadTests.cs
@@ -25,10 +25,15 @@ public class BinaryEditFormatLoadTests
 
     private static void Export(IExportHandler handler, string fileOrFolderName)
     {
+        // Mirrors BinaryEditViewModel.DoExport: the VobSub/DVD sup writers need the CLUT colors
+        // and the D-Cinema SMPTE handler needs the frame rate.
         var imageParameter = new ImageParameter
         {
             ScreenWidth = 720,
             ScreenHeight = 576,
+            FontColor = SKColors.White,
+            OutlineColor = SKColors.Black,
+            FramesPerSecond = 25.0,
         };
 
         handler.WriteHeader(fileOrFolderName, imageParameter);
@@ -66,10 +71,41 @@ public class BinaryEditFormatLoadTests
             Assert.Equal(5000, ocrSubtitle.GetStartTime(1).TotalMilliseconds, 0);
             using var bitmap = ocrSubtitle.GetBitmap(0);
             Assert.True(bitmap.Width > 0 && bitmap.Height > 0);
+
+            // The white source rectangle must survive the four color quantization as white on the
+            // pattern index - with unset CLUT colors it used to come back as opaque black.
+            var center = bitmap.GetPixel(bitmap.Width / 2, bitmap.Height / 2);
+            Assert.True(center.Alpha > 200, $"center pixel should be opaque, got {center}");
+            Assert.True(center.Red > 200 && center.Green > 200 && center.Blue > 200,
+                $"center pixel should be white, got {center}");
         }
         finally
         {
             File.Delete(fileName);
+        }
+    }
+
+    [Fact]
+    public void DCinemaSmpte2014Export_DeclaresTheEditRateItWasGiven()
+    {
+        var folderName = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(folderName);
+        try
+        {
+            Export(new ExportHandlerDCinemaSmpte2014Png(), folderName);
+
+            var xmlFileName = Path.Combine(folderName, "index.xml");
+            Assert.True(File.Exists(xmlFileName));
+            var xml = File.ReadAllText(xmlFileName);
+
+            // 25 comes from the Export helper's FramesPerSecond - without it the handler fell
+            // back to its 23.976 default and declared 24 regardless of the project frame rate.
+            Assert.Contains("<EditRate>25 1</EditRate>", xml);
+            Assert.Contains("<TimeCodeRate>25</TimeCodeRate>", xml);
+        }
+        finally
+        {
+            Directory.Delete(folderName, true);
         }
     }
 


### PR DESCRIPTION
Two gaps in the image-based editor's shared `DoExport`, both dating from the new export menu (#14394):

- **DVD sup / VobSub exports collapsed to an opaque-black silhouette.** `DoExport` never set `FontColor`/`OutlineColor`, so the writers built their four color CLUT from `default(SKColor)` (transparent black) and `ConvertToFourColors` quantized every visible pixel onto the anti-alias index as opaque black. A white-text Blu-ray sup exported to DVD sup round-tripped as black. Now passes white/black, matching the export dialog's defaults.
- **D-Cinema SMPTE 2014/png declared EditRate/TimeCodeRate 24 regardless of project frame rate.** `FramesPerSecond` stayed 0, so the handler kept its 23.976 default while the cue timecodes were converted at `Configuration.Settings.General.CurrentFrameRate` — ~4% drift on a 25 fps project. Now passes that same setting so header and cues agree (the Dost/FCP handlers pick it up too).

The round-trip test helper mirrors the fixed call site, and two new/strengthened assertions lock it in: the sup's center pixel must come back white and opaque, and the D-Cinema index.xml must declare the rate it was given.

🤖 Generated with [Claude Code](https://claude.com/claude-code)