### PR TITLE
Fix voice-seed resampling ignoring 22.05/44.1 kHz and Review Speech forgetting the Confucius4 language

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/VoiceSeedHelper.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/VoiceSeedHelper.cs
@@ -29,7 +29,10 @@ public static class VoiceSeedHelper
     /// not produce a usable file. Does nothing when <paramref name="dest"/> already exists.
     /// Never throws: seeding is best-effort and must not take the voice list down with it.
     /// </summary>
-    /// <param name="sampleRateHz">24000 for most backends, 16000 for CosyVoice3's s3tok.</param>
+    /// <param name="sampleRateHz">
+    /// 24000 for most backends, 16000 for CosyVoice3's s3tok, 22050 for Confucius4's S2A mel,
+    /// 44100 for Fish S2 Pro's codec. Anything else resamples to 24000.
+    /// </param>
     /// <param name="enginePrefix">Engine name used in log lines, e.g. "OmniVoice (CrispASR)".</param>
     /// <param name="copyOnFailure">
     /// False for backends that reject a reference at any other sample rate (Qwen3 Base), where a
@@ -85,9 +88,13 @@ public static class VoiceSeedHelper
 
     private static bool TryConvert(string src, string dest, int sampleRateHz, string enginePrefix)
     {
-        using var ffmpeg = sampleRateHz == 16000
-            ? FfmpegGenerator.ConvertToMono16kHzWav(src, dest)
-            : FfmpegGenerator.ConvertToMono24kHzWav(src, dest);
+        using var ffmpeg = sampleRateHz switch
+        {
+            16000 => FfmpegGenerator.ConvertToMono16kHzWav(src, dest),
+            22050 => FfmpegGenerator.ConvertToMono22kHzWav(src, dest),
+            44100 => FfmpegGenerator.ConvertToMono44kHzWav(src, dest),
+            _ => FfmpegGenerator.ConvertToMono24kHzWav(src, dest),
+        };
         if (!ffmpeg.Start())
         {
             // ffmpeg unavailable - the caller's plain copy seeds the voice at its original rate.

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -1992,6 +1992,8 @@ public partial class ReviewSpeechViewModel : ObservableObject
                               ?? Languages.FirstOrDefault(),
         Qwen3TtsCrispAsr => Languages.FirstOrDefault(p => p.Name == Se.Settings.Video.TextToSpeech.Qwen3TtsCrispAsrLanguage)
                             ?? Languages.FirstOrDefault(),
+        Confucius4TtsCrispAsr => Languages.FirstOrDefault(p => p.Name == Se.Settings.Video.TextToSpeech.Confucius4TtsCrispAsrLanguage)
+                                 ?? Languages.FirstOrDefault(),
         _ => Languages.FirstOrDefault(p => p.Name == Se.Settings.Video.TextToSpeech.ElevenLabsLanguage)
              ?? Languages.FirstOrDefault(p => p.Code == "en")
              ?? Languages.FirstOrDefault(),


### PR DESCRIPTION
Two follow-ups to yesterday's TTS engine commits:

- **`VoiceSeedHelper.CopyOrResample` silently ignored its sample-rate argument for the new engines.** `TryConvert` only branched 16 kHz vs 24 kHz, so Fish Audio S2 Pro's seed-at-44100 and Confucius4-TTS's seed-at-22050 both landed at 24 kHz — contradicting the callers' own comments and diverging from the download/import paths, which already use `ConvertToMono44kHzWav`/`ConvertToMono22kHzWav`. The seeded voices then took an extra lossy resample inside the backend that user-imported voices don't. Now the helper routes 16000/22050/44100 to the matching converter (anything else stays 24 kHz).
- **Review Speech reset Confucius4-TTS to English.** `ResolveSavedLanguage` has per-engine arms for the four older language-persisting CrispASR engines but the Confucius4 arm was missed, so switching the quant model (or switching engine away and back) in the Review Speech window dropped the saved language and regenerated lines with the wrong `-l` prompt language. Added the missing arm, same shape as its siblings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)