### PR TITLE
Fix "Guess time codes" window at high UI scale

### DIFF
--- a/src/ui/Features/Shared/WaveformGuessTimeCodes/WaveformGuessTimeCodesWindow.cs
+++ b/src/ui/Features/Shared/WaveformGuessTimeCodes/WaveformGuessTimeCodesWindow.cs
@@ -9,10 +9,11 @@ using System;
 namespace Nikse.SubtitleEdit.Features.Shared.WaveformGuessTimeCodes;
 
 /// <summary>
-/// Three stacked option boxes make this window tall enough that a high UI scale (or a small
-/// working area) pushes it past the screen - it is then clamped to the working area, and with
-/// a plain stacked layout the clamp cut off the bottom options and the OK/Cancel buttons. The
-/// options now scroll with the buttons pinned below them.
+/// The three option boxes used to be stacked in one column, which made the window tall enough
+/// that a high UI scale (or a small working area) pushed it past the screen - it is then clamped
+/// to the working area, and the clamp cut off the bottom options and the OK/Cancel buttons. The
+/// boxes are laid out in two columns so the window fits at a high scale, and the options scroll
+/// with the buttons pinned below them for the cases where it still does not.
 /// </summary>
 public class WaveformGuessTimeCodesWindow : Window
 {
@@ -31,24 +32,45 @@ public class WaveformGuessTimeCodesWindow : Window
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
         var panelButtons = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
 
-        var panelOptions = new StackPanel
+        // Two columns: the two short "which lines" boxes stacked on the left, the taller settings
+        // box on the right - about half the height of one stacked column, which is what keeps the
+        // window on screen at a high UI scale.
+        var panelLeft = new StackPanel
         {
             Orientation = Orientation.Vertical,
             Spacing = 10,
+            VerticalAlignment = VerticalAlignment.Top,
             Children =
             {
                 MakeStartFromView(vm, out var radioStartFromVideoPosition),
                 MakeDeleteLinesView(vm),
-                MakeDetectOptionsView(vm),
             },
         };
+
+        var panelOptions = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnSpacing = 10,
+        };
+        panelOptions.Add(panelLeft, 0);
+        var borderDetectOptions = MakeDetectOptionsView(vm);
+        borderDetectOptions.VerticalAlignment = VerticalAlignment.Top;
+        panelOptions.Add(borderDetectOptions, 0, 1);
 
         // Keeps the OK/Cancel buttons reachable when the window is clamped to the working area.
         var scrollViewer = new ScrollViewer
         {
             Name = OptionsScrollViewerName,
             Content = panelOptions,
-            HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+            HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
             VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
         };
 

--- a/src/ui/Features/Shared/WaveformGuessTimeCodes/WaveformGuessTimeCodesWindow.cs
+++ b/src/ui/Features/Shared/WaveformGuessTimeCodes/WaveformGuessTimeCodesWindow.cs
@@ -1,5 +1,6 @@
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Layout;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -7,8 +8,16 @@ using System;
 
 namespace Nikse.SubtitleEdit.Features.Shared.WaveformGuessTimeCodes;
 
+/// <summary>
+/// Three stacked option boxes make this window tall enough that a high UI scale (or a small
+/// working area) pushes it past the screen - it is then clamped to the working area, and with
+/// a plain stacked layout the clamp cut off the bottom options and the OK/Cancel buttons. The
+/// options now scroll with the buttons pinned below them.
+/// </summary>
 public class WaveformGuessTimeCodesWindow : Window
 {
+    internal const string OptionsScrollViewerName = "OptionsScrollViewer";
+
     public WaveformGuessTimeCodesWindow(WaveformGuessTimeCodesViewModel vm)
     {
         UiUtil.InitializeWindow(this, GetType().Name);
@@ -22,13 +31,32 @@ public class WaveformGuessTimeCodesWindow : Window
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
         var panelButtons = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
 
+        var panelOptions = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 10,
+            Children =
+            {
+                MakeStartFromView(vm, out var radioStartFromVideoPosition),
+                MakeDeleteLinesView(vm),
+                MakeDetectOptionsView(vm),
+            },
+        };
+
+        // Keeps the OK/Cancel buttons reachable when the window is clamped to the working area.
+        var scrollViewer = new ScrollViewer
+        {
+            Name = OptionsScrollViewerName,
+            Content = panelOptions,
+            HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+        };
+
         var grid = new Grid
         {
             RowDefinitions =
             {
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
@@ -42,10 +70,8 @@ public class WaveformGuessTimeCodesWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
-        grid.Add(MakeStartFromView(vm, out var radioStartFromVideoPosition), 0);
-        grid.Add(MakeDeleteLinesView(vm), 1);
-        grid.Add(MakeDetectOptionsView(vm), 2);
-        grid.Add(panelButtons, 3);
+        grid.Add(scrollViewer, 0);
+        grid.Add(panelButtons, 1);
 
         Content = grid;
 

--- a/tests/UI/Features/Shared/WaveformGuessTimeCodesWindowTests.cs
+++ b/tests/UI/Features/Shared/WaveformGuessTimeCodesWindowTests.cs
@@ -6,14 +6,17 @@ using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Nikse.SubtitleEdit.Features.Shared.WaveformGuessTimeCodes;
 using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
 
 namespace UITests.Features.Shared;
 
 /// <summary>
-/// The guess-time-codes window builds its layout in code and sizes itself to its content. Three
-/// stacked option boxes make it tall, so a high UI scale (or a small working area) pushes it past
-/// the screen and <see cref="UiUtil"/> clamps it to the working area - which used to cut off the
-/// bottom options and the OK/Cancel buttons on a window that cannot be resized.
+/// The guess-time-codes window builds its layout in code and sizes itself to its content. Its
+/// three option boxes used to be stacked in one column, which made it tall enough that a high UI
+/// scale (or a small working area) pushed it past the screen - <see cref="UiUtil"/> then clamps it
+/// to the working area, which cut off the bottom options and the OK/Cancel buttons on a window
+/// that cannot be resized. Two columns keep it on screen, the scroll viewer keeps the buttons
+/// reachable when even that is not enough.
 /// </summary>
 public class WaveformGuessTimeCodesWindowTests : IDisposable
 {
@@ -60,7 +63,7 @@ public class WaveformGuessTimeCodesWindowTests : IDisposable
 
         // What UiUtil.ClampToWorkingArea does when the content is taller than the screen.
         window.SizeToContent = SizeToContent.Manual;
-        window.Height = 400;
+        window.Height = window.Bounds.Height / 2;
         Dispatcher.UIThread.RunJobs();
 
         var buttonOk = Assert.Single(
@@ -110,5 +113,48 @@ public class WaveformGuessTimeCodesWindowTests : IDisposable
             .Select(b => b.TranslatePoint(new Point(0, b.Bounds.Height), window)?.Y ?? 0)
             .Max();
         Assert.True(buttonBottom <= window.Bounds.Height, $"buttons at {buttonBottom} exceed window height {window.Bounds.Height}");
+    }
+
+    /// <summary>
+    /// The point of the two-column layout: the window has to fit a small working area even at a
+    /// high UI scale. 1280x720 is what a 1920x1080 screen leaves at 150% OS scaling.
+    /// </summary>
+    [AvaloniaFact]
+    public void Window_FitsASmallWorkingArea_AtAHighUiScale()
+    {
+        UiTheme.SetLayoutScale(1.5);
+
+        var window = BuildWindow();
+        UiTheme.ApplyScaleToWindow(window);
+        window.Show();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(window.Bounds.Width <= 1280, $"window width {window.Bounds.Width} does not fit 1280");
+        Assert.True(window.Bounds.Height <= 720, $"window height {window.Bounds.Height} does not fit 720");
+    }
+
+    /// <summary>
+    /// The settings box sits beside the two "which lines" boxes, not below them.
+    /// </summary>
+    [AvaloniaFact]
+    public void OptionBoxes_AreLaidOutInTwoColumns()
+    {
+        var window = BuildWindow();
+        window.Show();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        var settings = Assert.Single(
+            window.GetLogicalDescendants().OfType<Label>(),
+            c => Equals(c.Content, Se.Language.General.Settings));
+        var startFrom = Assert.Single(
+            window.GetLogicalDescendants().OfType<Label>(),
+            c => Equals(c.Content, Se.Language.General.StartFrom));
+
+        var settingsLeft = settings.TranslatePoint(new Point(0, 0), window)!.Value.X;
+        var startFromRight = startFrom.TranslatePoint(new Point(startFrom.Bounds.Width, 0), window)!.Value.X;
+        Assert.True(settingsLeft > startFromRight,
+            $"the settings box at x={settingsLeft} is not to the right of the start-from box ending at x={startFromRight}");
     }
 }

--- a/tests/UI/Features/Shared/WaveformGuessTimeCodesWindowTests.cs
+++ b/tests/UI/Features/Shared/WaveformGuessTimeCodesWindowTests.cs
@@ -1,0 +1,114 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.LogicalTree;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Nikse.SubtitleEdit.Features.Shared.WaveformGuessTimeCodes;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Features.Shared;
+
+/// <summary>
+/// The guess-time-codes window builds its layout in code and sizes itself to its content. Three
+/// stacked option boxes make it tall, so a high UI scale (or a small working area) pushes it past
+/// the screen and <see cref="UiUtil"/> clamps it to the working area - which used to cut off the
+/// bottom options and the OK/Cancel buttons on a window that cannot be resized.
+/// </summary>
+public class WaveformGuessTimeCodesWindowTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+        UiTheme.SetLayoutScale(1.0);
+    }
+
+    private WaveformGuessTimeCodesWindow BuildWindow()
+    {
+        var window = new WaveformGuessTimeCodesWindow(new WaveformGuessTimeCodesViewModel());
+        _windows.Add(window);
+        return window;
+    }
+
+    [AvaloniaFact]
+    public void Window_Constructs()
+    {
+        var window = BuildWindow();
+
+        Assert.NotNull(window.Content);
+    }
+
+    [AvaloniaTheory]
+    [InlineData(1.0)]
+    [InlineData(2.0)]
+    public void OkAndCancel_StayInsideTheWindow_WhenItIsClampedToASmallScreen(double layoutScale)
+    {
+        UiTheme.SetLayoutScale(layoutScale);
+
+        var window = BuildWindow();
+        var vm = (WaveformGuessTimeCodesViewModel)window.DataContext!;
+        UiTheme.ApplyScaleToWindow(window);
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        // What UiUtil.ClampToWorkingArea does when the content is taller than the screen.
+        window.SizeToContent = SizeToContent.Manual;
+        window.Height = 400;
+        Dispatcher.UIThread.RunJobs();
+
+        var buttonOk = Assert.Single(
+            window.GetLogicalDescendants().OfType<Button>(),
+            b => ReferenceEquals(b.Command, vm.OkCommand));
+        var bottom = buttonOk.TranslatePoint(new Point(0, buttonOk.Bounds.Height), window);
+
+        Assert.NotNull(bottom);
+        Assert.True(bottom!.Value.Y <= window.Bounds.Height,
+            $"OK button bottom {bottom.Value.Y} is below the window height {window.Bounds.Height}");
+
+        var scrollViewer = OptionsScrollViewer(window);
+        Assert.True(scrollViewer.Extent.Height > scrollViewer.Viewport.Height, "the clamped options are not scrollable");
+    }
+
+    private static ScrollViewer OptionsScrollViewer(Window window)
+    {
+        // By name: the numeric up/downs bring scroll viewers of their own in their templates.
+        return Assert.Single(
+            window.GetVisualDescendants().OfType<ScrollViewer>(),
+            s => s.Name == WaveformGuessTimeCodesWindow.OptionsScrollViewerName);
+    }
+
+    /// <summary>
+    /// Scrolling is the fallback for a clamped window - left to itself the window must still size
+    /// to the whole content, at any UI scale (the scaled size is what the clamp measures).
+    /// </summary>
+    [AvaloniaTheory]
+    [InlineData(1.0)]
+    [InlineData(1.5)]
+    public void Window_SizesToItsWholeContent_WhenTheScreenIsBigEnough(double layoutScale)
+    {
+        UiTheme.SetLayoutScale(layoutScale);
+
+        var window = BuildWindow();
+        UiTheme.ApplyScaleToWindow(window);
+        window.Show();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        var scrollViewer = OptionsScrollViewer(window);
+        Assert.True(scrollViewer.Viewport.Height >= scrollViewer.Extent.Height,
+            $"viewport {scrollViewer.Viewport.Height} does not fit the content {scrollViewer.Extent.Height}");
+
+        var buttonBottom = window.GetLogicalDescendants().OfType<Button>()
+            .Where(b => b.Command != null)
+            .Select(b => b.TranslatePoint(new Point(0, b.Bounds.Height), window)?.Y ?? 0)
+            .Max();
+        Assert.True(buttonBottom <= window.Bounds.Height, $"buttons at {buttonBottom} exceed window height {window.Bounds.Height}");
+    }
+}


### PR DESCRIPTION
The "Guess time codes" window stacked its three option boxes in one column and sizes itself to its content. At a high UI scale (or on a small working area) that measures taller than the screen — 965 DIP at 150%, vs the 720 DIP a 1080p screen leaves at 150% OS scaling — so `UiUtil.ClampToWorkingArea` shrinks it. Because the window is not resizable, the clamp cut off the bottom settings **and** the OK/Cancel buttons, leaving no way to confirm or cancel.

**Fix, two parts:**

1. **Two columns** — the two short "which lines" boxes stack on the left, the taller settings box sits beside them. The window goes from 453x643 to 692x397 at 100% scale, and from 680x965 to 1038x596 at 150%, so it fits a small working area instead of being clamped.
2. **Scroll fallback** — the options sit in a `ScrollViewer` with the button bar pinned below it in a star/auto grid (the shape the advanced TTS settings window got for #14331), so OK/Cancel stay reachable if the window is clamped anyway (very high scale, tiny screen).

**Tests:** `tests/UI/Features/Shared/WaveformGuessTimeCodesWindowTests.cs` — construction smoke test, the two-column arrangement, the window fitting 1280x720 at 150% UI scale, OK/Cancel staying inside a clamped window (at 100% and 200% scale), and the window still sizing to its whole content when there is room. Full `tests/UI` suite passes (4537).

🤖 Generated with [Claude Code](https://claude.com/claude-code)