### PR TITLE
Prepare v5.2.0-beta32

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -3,6 +3,27 @@ Subtitle Edit Changelog
 
 -----------------------------------------------------------------------------------------------------
 
+v5.2.0-beta32 (2nd of September 2026)
+
+* Add a "Columns..." dialog to reorder and hide subtitle grid columns - thx m0ck69
+* Export the "List errors" report to clipboard, text file, Excel or web page - thx AuroraMartell
+* Binary edit: open DVD sup, XSUB (avi), MP4 VobSub, image based WebVTT/TTML and more transport streams, and export DVD sup and D-Cinema
+* ASSA: offer to resample the subtitle when the video resolution differs from the script resolution - thx hisui3393
+* Add Confucius4-TTS (CrispASR), Higgs Audio v3 and Fish Audio S2 Pro (audio.cpp) voice cloning TTS engines
+* "Point sync via other subtitle": a gap column that highlights likely sync points - thx alexchexes
+* Move "Open second subtitle file..." to SE 4's spot in the Video menu - thx m0ck69
+* macOS: open Finder files in a new window, and start the video picker in the subtitle's own folder - thx muaz978
+* seconv: add the full frame image export option - thx smt-joen
+* Faster waveform scrubbing on long-GOP video - thx GrampaWildWilly
+* Faster Sami and IMSC 1.1 reading, PAC/EBU STL/D-Cinema saving and Blu-ray image export
+* Fix audio dropouts when pausing or seeking - the beta 31 mpv option did nothing - thx GrampaWildWilly
+* Fix Alt+Tab still not bringing undocked windows to the foreground - thx GrampaWildWilly
+* Fix the playhead jumping when repeat playback wraps to the next line - thx marcpbailey
+* Fix the "Guess time codes" window losing its buttons at a high UI scale
+* Update Italian translation - thx bovirus
+
+-----------------------------------------------------------------------------------------------------
+
 v5.2.0-beta31 (1st of September 2026)
 
 * New subtitle format: Csv Excel - thx matmaggi

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "Subtitle Edit",
-  "version": "v5.2.0-beta31",
+  "version": "v5.2.0-beta32",
   "translatedBy": "",
   "cultureName": "en-US",
   "general": {

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -20,7 +20,7 @@ public class Se
     internal const int CurrentMacOsFontMigrationVersion = 1;
     internal const int CurrentShortcutsMigrationVersion = 2;
 
-    public static string Version { get; set; } = "v5.2.0-beta31";
+    public static string Version { get; set; } = "v5.2.0-beta32";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
Version bump plus the change-log section for the **24 pull requests** merged since the `v5.2.0-beta31` tag (every merge on `main` in that window; no direct commits).

- `src/ui/Logic/Config/Se.cs` and `src/ui/Assets/Languages/English.json` → `v5.2.0-beta32`
- `change-log.txt` gains the `v5.2.0-beta32 (2nd of September 2026)` section

### Collapsed
- Binary edit: the new formats (#14394) and the colour/edit-rate fix for them (#14396) are one line.
- The three TTS engine PRs (#14386, #14387) are one line.

### Left out
- Docs-only: #14393, #14395.
- #14391 — the revert of the fork-only MLX Whisper code and CI workflows that came in with #14383; neither ever shipped.
- Fixes for bugs introduced in this same beta and never released: #14397 (voice-seed sample rate), #14398 (scrub follow-up race), #14403 (macOS cold-launch window).

`dotnet build src/ui/UI.csproj` clean, 0 warnings — and the build regenerates no further `English.json` drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)