### PR TITLE
Video player: open files on Windows paths longer than MAX_PATH (#14407)

### DIFF
--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -1793,7 +1793,11 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         // without ever undoing a sub-add that got in first.
         SetOptionString("sid", "no");
 
-        var err = await Task.Run(() => DoMpvCommand("loadfile", path));
+        // Long local paths get the "\\?\" prefix on Windows: mpv opens the file with the path
+        // as given, and a plain path past MAX_PATH fails silently - no error, duration 0:00,
+        // Play does nothing (#14407). _fileName keeps the path the caller knows.
+        var loadPath = NativeMediaPath.ForMpv(path);
+        var err = await Task.Run(() => DoMpvCommand("loadfile", loadPath));
         if (_disposed)
         {
             return;
@@ -1866,7 +1870,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
         // buttons in the text-to-speech windows, which load a file and expect to hear it.
         // Those windows build their own core via Initialize(), which - unlike the three
         // rendering Initialize* methods - deliberately leaves mpv's pause default alone.
-        var err = await Task.Run(() => DoMpvCommand("loadfile", path));
+        var err = await Task.Run(() => DoMpvCommand("loadfile", NativeMediaPath.ForMpv(path)));
         if (_disposed)
         {
             return;
@@ -1874,7 +1878,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
 
         if (err < 0)
         {
-            Se.LogError(new InvalidOperationException(GetErrorString(err)), "LibMpvDynamicPlayer LoadFile");
+            Se.LogError(new InvalidOperationException(GetErrorString(err)), "LibMpvDynamicPlayer LoadAudio");
         }
 
         SetOptionString("keep-open", "always");

--- a/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicPlayer.cs
@@ -659,7 +659,10 @@ public sealed class LibVlcDynamicPlayer : IDisposable, IVideoPlayer
                 return;
             }
 
-            var media = _libvlc_media_new_path(_libVlc, GetUtf8Bytes(path));
+            // libvlc opens the file with the path as given, so a plain path past MAX_PATH
+            // fails silently on Windows (#14407). VLC cannot take the "\\?\" prefix (it
+            // reads it as a UNC host), so long paths are handed over in 8.3 short form.
+            var media = _libvlc_media_new_path(_libVlc, GetUtf8Bytes(NativeMediaPath.ForVlc(path)));
 
             // Parse media to get duration and metadata (0x00 = parse local, timeout in ms)
             try

--- a/src/ui/Logic/VideoPlayers/NativeMediaPath.cs
+++ b/src/ui/Logic/VideoPlayers/NativeMediaPath.cs
@@ -1,0 +1,170 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Nikse.SubtitleEdit.Logic.VideoPlayers;
+
+/// <summary>
+/// Prepares file paths for the native players (libmpv, libvlc) on Windows.
+/// <para>
+/// Both libraries open media through the Win32 file APIs with the path as given, and those
+/// cap a plain path at MAX_PATH (260 chars) unless the host exe declares itself long-path
+/// aware and Windows has LongPathsEnabled turned on - neither is a given on a user's machine.
+/// The failure is silent: the file never loads, the duration stays 0:00 and Play does nothing.
+/// ffmpeg adds the extended-length prefix itself, so the waveform still gets extracted, which
+/// is what made the symptom look like a broken container (#14407).
+/// </para>
+/// </summary>
+public static class NativeMediaPath
+{
+    /// <summary>Win32 MAX_PATH, counting the terminating NUL - so 259 chars is the longest plain path.</summary>
+    public const int WindowsMaxPath = 260;
+
+    private const string LongPathPrefix = @"\\?\";
+    private const string UncLongPathPrefix = @"\\?\UNC\";
+
+    /// <summary>
+    /// The path to hand to libmpv's "loadfile". mpv passes it straight to CreateFileW, which
+    /// accepts the <c>\\?\</c> extended-length form regardless of manifest or registry, so long
+    /// local paths get that prefix. Everything else (short paths, URLs, non-Windows) is returned
+    /// unchanged.
+    /// </summary>
+    public static string ForMpv(string path)
+    {
+        if (!TryGetLongLocalPath(path, out var fullPath))
+        {
+            return path;
+        }
+
+        return AddLongPathPrefix(fullPath);
+    }
+
+    /// <summary>
+    /// The path to hand to libvlc_media_new_path. VLC converts the path to a file URI first and
+    /// reads <c>\\?\C:\...</c> as a UNC path with host "?", so the prefix cannot be used there.
+    /// Fall back to the 8.3 short name instead, which fits under MAX_PATH whenever the volume
+    /// keeps short names (the default on the system drive). If no short enough name can be
+    /// produced the original path is returned and VLC gets the same chance it always had - the
+    /// app manifest is long-path aware, so it works on machines with LongPathsEnabled.
+    /// </summary>
+    public static string ForVlc(string path)
+    {
+        if (!TryGetLongLocalPath(path, out var fullPath))
+        {
+            return path;
+        }
+
+        var shortPath = GetShortPath(AddLongPathPrefix(fullPath));
+        if (string.IsNullOrEmpty(shortPath))
+        {
+            return path;
+        }
+
+        var plainShortPath = RemoveLongPathPrefix(shortPath);
+        return plainShortPath.Length < WindowsMaxPath ? plainShortPath : path;
+    }
+
+    /// <summary>
+    /// True (with the normalized full path) for a local Windows path too long to open without
+    /// the extended-length prefix. URLs and already-prefixed paths are left alone.
+    /// </summary>
+    private static bool TryGetLongLocalPath(string path, out string fullPath)
+    {
+        fullPath = path;
+        if (!OperatingSystem.IsWindows() ||
+            string.IsNullOrWhiteSpace(path) ||
+            path.Contains("://", StringComparison.Ordinal) ||
+            path.StartsWith(LongPathPrefix, StringComparison.Ordinal) ||
+            path.StartsWith(@"\\.\", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        try
+        {
+            // The extended-length form turns off Win32 path normalization, so it must be
+            // applied to a fully qualified path with backslashes and no "." / ".." segments -
+            // GetFullPath produces exactly that. A short relative path can expand past the
+            // limit, hence the length check on the full path.
+            fullPath = Path.GetFullPath(path);
+        }
+        catch
+        {
+            return false;
+        }
+
+        return fullPath.Length >= WindowsMaxPath;
+    }
+
+    /// <summary>
+    /// <c>C:\dir\file</c> becomes <c>\\?\C:\dir\file</c>; a UNC path <c>\\server\share\file</c>
+    /// becomes <c>\\?\UNC\server\share\file</c>.
+    /// </summary>
+    internal static string AddLongPathPrefix(string fullPath)
+    {
+        if (fullPath.StartsWith(LongPathPrefix, StringComparison.Ordinal))
+        {
+            return fullPath;
+        }
+
+        if (fullPath.StartsWith(@"\\", StringComparison.Ordinal))
+        {
+            return UncLongPathPrefix + fullPath.Substring(2);
+        }
+
+        return LongPathPrefix + fullPath;
+    }
+
+    internal static string RemoveLongPathPrefix(string path)
+    {
+        if (path.StartsWith(UncLongPathPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return @"\\" + path.Substring(UncLongPathPrefix.Length);
+        }
+
+        if (path.StartsWith(LongPathPrefix, StringComparison.Ordinal))
+        {
+            return path.Substring(LongPathPrefix.Length);
+        }
+
+        return path;
+    }
+
+    /// <summary>
+    /// 8.3 short form of a path, or null when Windows cannot produce one (short names disabled
+    /// on the volume, file missing, API failure). The input should carry the <c>\\?\</c> prefix
+    /// so the lookup itself is not subject to MAX_PATH; the result carries it too.
+    /// </summary>
+    private static string? GetShortPath(string prefixedFullPath)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return null;
+        }
+
+        try
+        {
+            var buffer = new char[prefixedFullPath.Length + 1];
+            var length = GetShortPathNameW(prefixedFullPath, buffer, (uint)buffer.Length);
+            if (length > buffer.Length)
+            {
+                buffer = new char[length];
+                length = GetShortPathNameW(prefixedFullPath, buffer, (uint)buffer.Length);
+            }
+
+            if (length == 0 || length > buffer.Length)
+            {
+                return null;
+            }
+
+            return new string(buffer, 0, (int)length);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern uint GetShortPathNameW(string lpszLongPath, [Out] char[] lpszShortPath, uint cchBuffer);
+}

--- a/src/ui/app.manifest
+++ b/src/ui/app.manifest
@@ -15,4 +15,13 @@
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
     </application>
   </compatibility>
+
+  <!-- Opt in to Windows long paths (> 260 chars). The native players (libmpv, libvlc) open
+       media through the Win32 file APIs, which honor long paths only when the host exe
+       declares this and the LongPathsEnabled registry value is set (#14407). -->
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+      <ws2:longPathAware>true</ws2:longPathAware>
+    </windowsSettings>
+  </application>
 </assembly>

--- a/tests/UI/Logic/NativeMediaPathTests.cs
+++ b/tests/UI/Logic/NativeMediaPathTests.cs
@@ -1,0 +1,102 @@
+using Nikse.SubtitleEdit.Logic.VideoPlayers;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// Paths handed to libmpv/libvlc on Windows must survive MAX_PATH (#14407): a plain path of
+/// 260+ chars fails silently in both players. mpv gets the "\\?\" extended-length prefix,
+/// VLC (which cannot take that prefix) gets an 8.3 short name. Short paths, URLs and other
+/// platforms pass through untouched.
+/// </summary>
+public class NativeMediaPathTests
+{
+    private static string LongWindowsPath(int length)
+    {
+        const string root = @"C:\Users\someone\Downloads\";
+        var name = new string('a', length - root.Length - 4) + ".mkv";
+        var path = root + name;
+        Assert.Equal(length, path.Length);
+        return path;
+    }
+
+    [Fact]
+    public void AddLongPathPrefix_DriveLetterPath_GetsExtendedPrefix()
+    {
+        var result = NativeMediaPath.AddLongPathPrefix(@"C:\dir\file.mkv");
+        Assert.Equal(@"\\?\C:\dir\file.mkv", result);
+    }
+
+    [Fact]
+    public void AddLongPathPrefix_UncPath_GetsUncForm()
+    {
+        var result = NativeMediaPath.AddLongPathPrefix(@"\\server\share\dir\file.mkv");
+        Assert.Equal(@"\\?\UNC\server\share\dir\file.mkv", result);
+    }
+
+    [Fact]
+    public void AddLongPathPrefix_AlreadyPrefixed_IsUnchanged()
+    {
+        var result = NativeMediaPath.AddLongPathPrefix(@"\\?\C:\dir\file.mkv");
+        Assert.Equal(@"\\?\C:\dir\file.mkv", result);
+    }
+
+    [Theory]
+    [InlineData(@"\\?\C:\dir\file.mkv", @"C:\dir\file.mkv")]
+    [InlineData(@"\\?\UNC\server\share\file.mkv", @"\\server\share\file.mkv")]
+    [InlineData(@"C:\dir\file.mkv", @"C:\dir\file.mkv")]
+    public void RemoveLongPathPrefix_RoundTrips(string input, string expected)
+    {
+        Assert.Equal(expected, NativeMediaPath.RemoveLongPathPrefix(input));
+    }
+
+    [Theory]
+    [InlineData(@"C:\Videos\short.mkv")]
+    [InlineData("https://example.com/stream.m3u8")]
+    [InlineData("/home/user/video.mkv")]
+    public void ForMpv_ShortPathsAndUrls_PassThrough(string path)
+    {
+        Assert.Equal(path, NativeMediaPath.ForMpv(path));
+        Assert.Equal(path, NativeMediaPath.ForVlc(path));
+    }
+
+    [Fact]
+    public void ForMpv_LongWindowsPath_IsPrefixedOnWindowsOnly()
+    {
+        var path = LongWindowsPath(300);
+        var result = NativeMediaPath.ForMpv(path);
+
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Equal(@"\\?\" + path, result);
+        }
+        else
+        {
+            Assert.Equal(path, result);
+        }
+    }
+
+    [Fact]
+    public void ForMpv_PathJustUnderMaxPath_IsUnchanged()
+    {
+        // 259 chars + NUL fits in MAX_PATH, so no prefix is needed - and none is added.
+        var path = LongWindowsPath(NativeMediaPath.WindowsMaxPath - 1);
+        Assert.Equal(path, NativeMediaPath.ForMpv(path));
+    }
+
+    [Fact]
+    public void ForMpv_LongUrl_IsUnchanged()
+    {
+        var url = "https://example.com/" + new string('x', 300) + ".mp4";
+        Assert.Equal(url, NativeMediaPath.ForMpv(url));
+        Assert.Equal(url, NativeMediaPath.ForVlc(url));
+    }
+
+    [Fact]
+    public void ForVlc_LongPathToMissingFile_FallsBackToOriginal()
+    {
+        // No 8.3 name can be produced for a file that does not exist; VLC then gets the
+        // original path rather than a mangled one.
+        var path = LongWindowsPath(300);
+        Assert.Equal(path, NativeMediaPath.ForVlc(path));
+    }
+}


### PR DESCRIPTION
Fixes #14407

## Problem
Some MKV files showed `00:00:00.000 / 00:00:00.000` and never played in SE, with both libmpv and VLC, while the same files played in standalone players. The reporter narrowed it down: the files sat in a path longer than 260 characters, and copying the same file to a short path made it play.

libmpv and libvlc open media with the path as given. On Windows a plain path of 260+ chars fails in `CreateFileW` unless the host exe is long-path aware **and** `LongPathsEnabled` is set in the registry. The failure is silent, so nothing showed up in SE's error log. ffmpeg adds the `\\?\` prefix itself, which is why the waveform was still extracted and the symptom looked like a broken container.

## Fix
- New `NativeMediaPath` helper (Windows-only behaviour, pass-through elsewhere and for URLs):
  - `ForMpv`: long local paths get the `\\?\` extended-length prefix (`\\?\UNC\...` for UNC) before `loadfile`. mpv hands the path straight to `CreateFileW`, which accepts that form regardless of manifest or registry.
  - `ForVlc`: `libvlc_media_new_path` converts the path to a URI and reads `\\?\C:\...` as a UNC host `?`, so the prefix cannot be used there. Long paths are converted to 8.3 short names via `GetShortPathNameW` (default-enabled on the system drive); when no short name is available the original path is passed unchanged.
- `app.manifest` now declares `longPathAware`, so both players also work on machines that have `LongPathsEnabled` set, without any path rewriting.
- `_fileName` and the UI keep the original path; only the argument handed to the native library changes.

## Tests
- `tests/UI/Logic/NativeMediaPathTests.cs`: prefix add/remove round trips (drive letter, UNC, already prefixed), pass-through for short paths, URLs and non-Windows paths, boundary at 259 chars, VLC fallback for a missing file. 13 tests pass on macOS; the Windows-only branch is asserted when running on Windows.
- `dotnet build src/ui/UI.csproj` clean.

Not verified on a real Windows machine with a 260+ char path; the reporter can confirm with the next beta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
