### PR TITLE
Video & Shortcut UX fixes: Open recent video menu, zero-time preview fix, and immediate key-up end timing

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "title": "Subtitle Edit",
   "version": "v5.2.0-beta32",
   "translatedBy": "",
@@ -2545,6 +2545,8 @@
     "openSecondarySubtitleOnVideoPlayerDotDotDot": "Open second subtitle file...",
     "openSecondarySubtitleOnVideoPlayer": "Second subtitle file (on video player)",
     "removeSecondarySubtitleOnVideoPlayer": "Remove second subtitle file",
+    "openRecentVideo": "Open recent video",
+    "clearRecentVideos": "Clear recent videos",
     "cutVideoTitle": "Cut video",
     "cutVideoDotDotDot": "Cut video...",
     "embedSubtitlesDotDotDot": "Add/remove embedded subtitles...",

--- a/src/ui/Assets/Languages/Vietnamese.json
+++ b/src/ui/Assets/Languages/Vietnamese.json
@@ -2235,6 +2235,8 @@
     "openSecondarySubtitleOnVideoPlayerDotDotDot": "Phụ đề phụ trên trình phát video, mở...",
     "openSecondarySubtitleOnVideoPlayer": "Phụ đề phụ (trên trình phát video)",
     "removeSecondarySubtitleOnVideoPlayer": "Phụ đề phụ trên trình phát video, xóa",
+    "openRecentVideo": "Mở video gần đây",
+    "clearRecentVideos": "Xóa danh sách video gần đây",
     "cutVideoTitle": "Cắt video",
     "cutVideoDotDotDot": "Cắt video...",
     "embedSubtitlesDotDotDot": "Thêm/xóa phụ đề nhúng...",

--- a/src/ui/Features/Main/Layout/InitMenu.cs
+++ b/src/ui/Features/Main/Layout/InitMenu.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Data.Converters;
@@ -33,6 +33,13 @@ public static class InitMenu
         };
 
         UpdateRecentFiles(vm);
+
+        vm.MenuRecentVideos = new MenuItem
+        {
+            Header = Se.Language.Video.OpenRecentVideo,
+        };
+
+        UpdateRecentVideos(vm);
 
         var menu = vm.Menu;
         menu.DataContext = vm;
@@ -751,6 +758,7 @@ public static class InitMenu
                         },
                     },
                 },
+                vm.MenuRecentVideos!,
                 menuItemAudioTracks,
                 new Separator(),
                 new MenuItem
@@ -1107,6 +1115,56 @@ public static class InitMenu
         else
         {
             vm.MenuReopen.IsVisible = false;
+        }
+    }
+
+    public static void UpdateRecentVideos(MainViewModel vm)
+    {
+        if (vm.MenuRecentVideos == null)
+        {
+            return;
+        }
+
+        var files = Se.Settings.Video.RecentFiles
+            .Where(f => !string.IsNullOrEmpty(f) && (System.IO.File.Exists(f) || MainViewModel.IsValidUrl(f)))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        vm.MenuRecentVideos.Items.Clear();
+        if (files.Count > 0)
+        {
+            foreach (var file in files)
+            {
+                var header = file;
+                var item = new MenuItem
+                {
+                    Header = new TextBlock
+                    {
+                        Text = header,
+                        TextTrimming = TextTrimming.PrefixCharacterEllipsis,
+                        MaxWidth = 600,
+                    },
+                    Command = vm.CommandVideoReopenCommand,
+                    CommandParameter = file,
+                    [ToolTip.TipProperty] = header,
+                };
+                vm.MenuRecentVideos.Items.Add(item);
+            }
+
+            vm.MenuRecentVideos.Items.Add(new Separator());
+
+            var clearItem = new MenuItem
+            {
+                Header = Se.Language.Video.ClearRecentVideos,
+                Command = vm.CommandVideoClearRecentFilesCommand,
+            };
+            vm.MenuRecentVideos.Items.Add(clearItem);
+
+            vm.MenuRecentVideos.IsVisible = true;
+        }
+        else
+        {
+            vm.MenuRecentVideos.IsVisible = false;
         }
     }
 

--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using CommunityToolkit.Mvvm.Input;
@@ -54,6 +54,7 @@ public static class InitNativeMacMenu
         public PropertyChangedEventHandler? Handler;
 
         public NativeMenuItem? ReopenItem;
+        public NativeMenuItem? RecentVideosItem;
         public NativeMenuItem? PluginsItem;
         public NativeMenuItem? AudioTracksItem;
         public NativeMenuItem? WindowListItem;
@@ -344,6 +345,9 @@ public static class InitNativeMacMenu
             v => v.IsVideoLoaded && !v.IsSubtitleSecondaryVisible, nameof(MainViewModel.IsVideoLoaded), nameof(MainViewModel.IsSubtitleSecondaryVisible)));
         videoItems.Items.Add(Conditional(Clean(Se.Language.Video.RemoveSecondarySubtitleOnVideoPlayer), v => v.ClearSecondarySubtitleCommand,
             v => v.IsVideoLoaded && v.IsSubtitleSecondaryVisible, nameof(MainViewModel.IsVideoLoaded), nameof(MainViewModel.IsSubtitleSecondaryVisible)));
+
+        state.RecentVideosItem = new NativeMenuItem(Clean(Se.Language.Video.OpenRecentVideo)) { Menu = new NativeMenu() };
+        videoItems.Items.Add(state.RecentVideosItem);
 
         state.AudioTracksItem = new NativeMenuItem(Clean(l.AudioTracks)) { Menu = new NativeMenu() };
         state.Visibilities.Add((state.AudioTracksItem, v => v.IsAudioTracksVisible, [nameof(MainViewModel.IsAudioTracksVisible)]));
@@ -641,6 +645,7 @@ public static class InitNativeMacMenu
         state.Vm = vm;
 
         vm.NativeMenuReopen = state.ReopenItem;
+        vm.NativeMenuRecentVideos = state.RecentVideosItem;
         vm.NativeMenuPlugins = state.PluginsItem;
         vm.NativeMenuAudioTracks = state.AudioTracksItem;
 
@@ -687,6 +692,7 @@ public static class InitNativeMacMenu
         vm.PropertyChanged += state.Handler;
 
         UpdateRecentFiles(vm);
+        UpdateRecentVideos(vm);
         UpdatePluginsMenu(vm);
     }
 
@@ -736,6 +742,47 @@ public static class InitNativeMacMenu
         menu.Items.Add(new NativeMenuItemSeparator());
         var clearItem = new NativeMenuItem(Clean(Se.Language.Main.Menu.ClearRecentFiles));
         clearItem.Click += (_, _) => vm.CommandFileClearRecentFilesCommand.Execute(null);
+        menu.Items.Add(clearItem);
+    }
+
+    public static void UpdateRecentVideos(MainViewModel vm)
+    {
+        if (vm.NativeMenuRecentVideos?.Menu is not NativeMenu menu)
+        {
+            return;
+        }
+
+        menu.Items.Clear();
+
+        var files = Se.Settings.Video.RecentFiles
+            .Where(f => !string.IsNullOrEmpty(f) && (System.IO.File.Exists(f) || MainViewModel.IsValidUrl(f)))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        vm.NativeMenuRecentVideos.IsEnabled = files.Count > 0;
+
+        if (files.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var file in files)
+        {
+            var header = file;
+            if (header.Length > 80)
+            {
+                header = "…" + header[^77..];
+            }
+
+            var recentItem = new NativeMenuItem(header);
+            var captured = file;
+            recentItem.Click += (_, _) => vm.CommandVideoReopenCommand.Execute(captured);
+            menu.Items.Add(recentItem);
+        }
+
+        menu.Items.Add(new NativeMenuItemSeparator());
+        var clearItem = new NativeMenuItem(Clean(Se.Language.Video.ClearRecentVideos));
+        clearItem.Click += (_, _) => vm.CommandVideoClearRecentFilesCommand.Execute(null);
         menu.Items.Add(clearItem);
     }
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1,4 +1,4 @@
-﻿using Nikse.SubtitleEdit.UiLogic.Export;
+using Nikse.SubtitleEdit.UiLogic.Export;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
@@ -28091,6 +28091,21 @@ public partial class MainViewModel :
     {
         if (_setEndAtKeyUpLine != null)
         {
+            var vp = GetVideoPlayerControl();
+            if (vp != null && !string.IsNullOrEmpty(_videoFileName))
+            {
+                _setEndAtKeyUpLine.EndTime = TimeSpan.FromSeconds(vp.VideoPlayer.Position);
+            }
+
+            if (_setEndAtKeyUpLineGoToNext)
+            {
+                var idx = Subtitles.IndexOf(_setEndAtKeyUpLine);
+                if (idx >= 0)
+                {
+                    SelectAndScrollToRowCentered(idx + 1);
+                }
+            }
+
             _setEndAtKeyUpLine = null;
             _setEndAtKeyUpLineGoToNext = false;
         }
@@ -29118,22 +29133,6 @@ public partial class MainViewModel :
             if (vp != null && !string.IsNullOrEmpty(_videoFileName))
             {
                 var isAvScrolloing = av?.IsScrolling ?? false;
-
-                if (_setEndAtKeyUpLine != null)
-                {
-                    _setEndAtKeyUpLine.EndTime = TimeSpan.FromSeconds(vp.VideoPlayer.Position);
-                    if (_setEndAtKeyUpLineGoToNext)
-                    {
-                        var idx = Subtitles.IndexOf(_setEndAtKeyUpLine);
-                        if (idx >= 0)
-                        {
-                            SelectAndScrollToRowCentered(idx + 1);
-                        }
-
-                        _setEndAtKeyUpLine = null;
-                        _setEndAtKeyUpLineGoToNext = false;
-                    }
-                }
 
                 // Rebuild + re-sort the buffer only when its inputs changed since the last tick;
                 // an idle tick used to copy and order-check every line 20x a second (#13234).

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -585,8 +585,10 @@ public partial class MainViewModel :
     public MainView? MainView { get; set; }
     public TextBlock StatusTextLeftLabel { get; set; }
     public MenuItem MenuReopen { get; set; }
+    public MenuItem? MenuRecentVideos { get; set; }
     public MenuItem MenuPlugins { get; set; }
     public NativeMenuItem? NativeMenuReopen { get; set; }
+    public NativeMenuItem? NativeMenuRecentVideos { get; set; }
     public NativeMenuItem? NativeMenuPlugins { get; set; }
     public NativeMenuItem? NativeMenuAudioTracks { get; set; }
     public AudioVisualizer? AudioVisualizer { get; set; }
@@ -8354,6 +8356,37 @@ public partial class MainViewModel :
             }
         }
 
+        _shortcutManager.ClearKeys();
+    }
+
+    [RelayCommand]
+    private async Task CommandVideoReopen(string videoFileName)
+    {
+        if (string.IsNullOrEmpty(videoFileName))
+        {
+            return;
+        }
+
+        if (File.Exists(videoFileName) || IsValidUrl(videoFileName))
+        {
+            await VideoOpenFile(videoFileName);
+        }
+        else
+        {
+            await MessageBox.Show(Window!, Se.Language.General.Error, videoFileName, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+        }
+        _shortcutManager.ClearKeys();
+    }
+
+    [RelayCommand]
+    private void CommandVideoClearRecentFiles()
+    {
+        Se.Settings.Video.RecentFiles.Clear();
+        InitMenu.UpdateRecentVideos(this);
+        if (OperatingSystem.IsMacOS())
+        {
+            Layout.InitNativeMacMenu.UpdateRecentVideos(this);
+        }
         _shortcutManager.ClearKeys();
     }
 
@@ -24483,7 +24516,7 @@ public partial class MainViewModel :
         }
     }
 
-    private static bool IsValidUrl(string url)
+    internal static bool IsValidUrl(string url)
     {
         if (string.IsNullOrWhiteSpace(url))
         {
@@ -24574,6 +24607,22 @@ public partial class MainViewModel :
                 }
 
                 _audioTrack = chosen;
+            }
+        }
+
+        if (!string.IsNullOrEmpty(videoFileName) && !IsValidUrl(videoFileName))
+        {
+            Se.Settings.Video.RecentFiles.RemoveAll(f => string.Equals(f, videoFileName, StringComparison.OrdinalIgnoreCase));
+            Se.Settings.Video.RecentFiles.Insert(0, videoFileName);
+            if (Se.Settings.Video.RecentFiles.Count > Se.Settings.Video.RecentFilesMaximum)
+            {
+                Se.Settings.Video.RecentFiles.RemoveAt(Se.Settings.Video.RecentFiles.Count - 1);
+            }
+            Se.SaveSettings();
+            InitMenu.UpdateRecentVideos(this);
+            if (OperatingSystem.IsMacOS())
+            {
+                Layout.InitNativeMacMenu.UpdateRecentVideos(this);
             }
         }
 

--- a/src/ui/Logic/Config/Language/Video/LanguageVideo.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageVideo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Nikse.SubtitleEdit.Logic.Config.Language.Tools;
 
@@ -20,6 +20,8 @@ public class LanguageVideo
     public string OpenSecondarySubtitleOnVideoPlayerDotDotDot { get; set; }
     public string OpenSecondarySubtitleOnVideoPlayer { get; set; }
     public string RemoveSecondarySubtitleOnVideoPlayer { get; set; }
+    public string OpenRecentVideo { get; set; }
+    public string ClearRecentVideos { get; set; }
     public string CutVideoTitle { get; set; }
     public string CutVideoDotDotDot { get; set; }
     public string EmbedSubtitlesDotDotDot { get; set; }
@@ -114,6 +116,8 @@ public class LanguageVideo
         OpenSecondarySubtitleOnVideoPlayer = "Second subtitle file (on video player)";
         OpenSecondarySubtitleOnVideoPlayerDotDotDot = "Open second subtitle file...";
         RemoveSecondarySubtitleOnVideoPlayer = "Remove second subtitle file";
+        OpenRecentVideo = "Open recent video";
+        ClearRecentVideos = "Clear recent videos";
         CutVideoTitle = "Cut video";
         CutVideoDotDotDot = "Cut video...";
         EmbedSubtitlesDotDotDot = "Add/remove embedded subtitles...";

--- a/src/ui/Logic/Config/SeVideo.cs
+++ b/src/ui/Logic/Config/SeVideo.cs
@@ -1,6 +1,7 @@
-﻿using Avalonia.Media;
+using Avalonia.Media;
 using Nikse.SubtitleEdit.Features.Assa;
 using System;
+using System.Collections.Generic;
 
 namespace Nikse.SubtitleEdit.Logic.Config;
 
@@ -17,6 +18,8 @@ public class SeVideo
     public bool FullscreenHideControls { get; set; }
     public bool AutoOpen { get; set; }
     public bool OpenSearchParentFolder { get; set; }
+    public int RecentFilesMaximum { get; set; } = 25;
+    public List<string> RecentFiles { get; set; } = new();
     public string CutType { get; set; }
     public string ShowChangesFFmpegArguments { get; set; }
     public bool VideoPlayerDisplayTimeLeft { get; set; }

--- a/src/ui/Logic/Media/MpvReloader.cs
+++ b/src/ui/Logic/Media/MpvReloader.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Skia;
+using Avalonia.Skia;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -180,6 +180,8 @@ public class MpvReloader : IMpvReloader
     // subtitle copy, read-only state and libse statics - never the memo fields.
     private (Subtitle Subtitle, string Text, int Hash, bool HashValid) BuildPreviewText(Subtitle subtitle, Subtitle? subtitleSecondary, Type uiFormatType, bool uiFormatHasPositions, int oldHash, string oldText)
     {
+        subtitle.Paragraphs.RemoveAll(p => p.StartTime.TotalMilliseconds <= 0 && p.EndTime.TotalMilliseconds <= 0);
+
         if (SmpteMode)
         {
             foreach (var paragraph in subtitle.Paragraphs)

--- a/src/ui/Logic/Media/VlcReloader.cs
+++ b/src/ui/Logic/Media/VlcReloader.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Skia;
+using Avalonia.Skia;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -36,6 +36,7 @@ public class VlcReloader : IVlcReloader
         {
             var uiFormatType = uiFormat.GetType();
             subtitle = new Subtitle(subtitle, false);
+            subtitle.Paragraphs.RemoveAll(p => p.StartTime.TotalMilliseconds <= 0 && p.EndTime.TotalMilliseconds <= 0);
 
             if (SmpteMode)
             {


### PR DESCRIPTION
### Overview of Changes

This PR incorporates three clean, targeted improvements and bug fixes kept in separate, atomic commits (Please check video if needed: https://drive.google.com/drive/folders/1TsY3iSZ0Ah1PDKB7odK5zRvBklSpN-_w?usp=drive_link)

---

### 1. Fix "Set end time on key up" shortcut timing & navigation (`dec386a83`)
* **Problem**: Setting end time and auto-advancing to the next row on key up relied on the 50ms periodic UI timer tick loop. This introduced a slight timing delay/lag and unnecessary work inside the polling loop.
* **Fix**: Directly set `EndTime` from current player position and advance selection in `OnKeyUpHandler` upon key release. Cleaned up obsolete timer-tick code.

---

### 2. Fix subtitle preview disappearing when trailing zero-time lines exist (`1385b6305`)
* **Problem**: When a subtitle file contains entries at the end with start and end times equal to zero (`00:00:00,000` -> `00:00:00,000`, e.g., newly inserted draft rows or empty template lines), `libass` event timeline sequencing caused line 1 not to render in video preview during playback.
* **Fix**: Filter out zero-time paragraphs (`StartTime <= 0 && EndTime <= 0`) when preparing the ASS preview string in `MpvReloader.cs` and `VlcReloader.cs`. Left `AudioVisualizer.cs` untouched since waveform sorting already handles display order safely.

---

### 3. Add "Open recent video" menu option (`3359c5087`)
* **Problem**: While subtitle files had a `File > Reopen` menu, there was no quick way to reopen recently used standalone video files from the **Video** menu.
* **Fix**:
  - Added an "Open recent video" dynamic submenu under the **Video** menu (supported on both standard Avalonia and macOS native menu bars).
  - Maintained dedicated `Se.Settings.Video.RecentFiles` (`List<string>`) so that clearing recent videos (`Clear recent videos`) never clears or breaks `Se.Settings.File.RecentFiles` subtitle-media associations.
  - Added dedicated localization keys: `OpenRecentVideo` and `ClearRecentVideos`.

---

### Commits in this PR (in chronological order):
1. `dec386a83` - `fix(shortcut): set end time and advance to next subtitle on key up instead of timer tick`
2. `1385b6305` - `fix(preview): filter out zero-time paragraphs for video preview`
3. `3359c5087` - `feat(video): add open recent video menu option`

---

### Verification & Testing
- [x] Tested "Set end time on key up" shortcut: End time is immediately registered on key release and focus advances instantly.
- [x] Tested zero-time subtitle preview: Line 1 correctly previews over video even when rows 7+ have zeroed timestamps.
- [x] Tested "Open recent video" submenu & "Clear recent videos": Videos reopen properly without interfering with `File > Reopen` subtitle links.
- [x] Built in Debug & Release configurations with **0 Warnings, 0 Errors**.
