### PR TITLE
Sync dialogs: make the waveform under the video drag-resizable

### DIFF
--- a/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointWindow.cs
+++ b/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointWindow.cs
@@ -64,7 +64,6 @@ public class SetSyncPointWindow : Window
 
         vm.AudioVisualizer = new AudioVisualizer
         {
-            Height = 80,
             Width = double.NaN,
             IsReadOnly = true,
             DrawGridLines = Se.Settings.Waveform.DrawGridLines,
@@ -131,11 +130,19 @@ public class SetSyncPointWindow : Window
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
         var buttonPanel = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
 
+        // The waveform used to be pinned at 80 px under the player, too little to pick a precise
+        // sync point from; the drag handle between them mirrors the main window (issue #14414).
+        var split = new VideoWaveformSplitGrid(vm.VideoPlayerControl, vm.AudioVisualizer, Se.Settings.Synchronization.SetSyncPointWaveformHeight)
+        {
+            IsVideoVisible = vm.IsVideoVisible,
+            IsWaveformVisible = vm.IsAudioVisualizerVisible,
+        };
+
         // A Star row keeps its share of the height even when its child is hidden, so the row itself
         // has to collapse - otherwise the videoless dialog is mostly empty space.
         var rowVideoPlayer = new RowDefinition
         {
-            Height = vm.IsVideoVisible ? new GridLength(1, GridUnitType.Star) : new GridLength(0),
+            Height = vm.IsVideoVisible || vm.IsAudioVisualizerVisible ? new GridLength(1, GridUnitType.Star) : new GridLength(0),
         };
 
         vm.VideoPlayerControl.WithBindIsVisible(nameof(vm.IsVideoVisible));
@@ -144,8 +151,7 @@ public class SetSyncPointWindow : Window
         {
             RowDefinitions =
             {
-                rowVideoPlayer,                                                       // video player
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // audio visualizer
+                rowVideoPlayer,                                                       // video player over waveform
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // combo box
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // sync point time code
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // buttons
@@ -160,11 +166,10 @@ public class SetSyncPointWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
-        gridLeft.Add(vm.VideoPlayerControl, 0);
-        gridLeft.Add(vm.AudioVisualizer, 1);
-        gridLeft.Add(comboBoxLeft, 2);
-        gridLeft.Add(panelTimeCode, 3);
-        gridLeft.Add(panelLeftButtons, 4);
+        gridLeft.Add(split, 0);
+        gridLeft.Add(comboBoxLeft, 1);
+        gridLeft.Add(panelTimeCode, 2);
+        gridLeft.Add(panelLeftButtons, 3);
 
         var grid = new Grid
         {
@@ -193,17 +198,32 @@ public class SetSyncPointWindow : Window
 
         // "Open video file..." can bring a video in after the videoless dialog is already up: give
         // the player its row back and grow the window, which is otherwise too short to show it.
+        // The waveform lent by the main window arrives a beat after construction and shares the row.
         vm.PropertyChanged += (_, e) =>
         {
-            if (e.PropertyName != nameof(vm.IsVideoVisible) || !vm.IsVideoVisible)
+            if (e.PropertyName != nameof(vm.IsVideoVisible) && e.PropertyName != nameof(vm.IsAudioVisualizerVisible))
             {
                 return;
             }
 
-            rowVideoPlayer.Height = new GridLength(1, GridUnitType.Star);
-            MaxHeight = double.PositiveInfinity;
-            MinHeight = 650;
-            Height = Math.Max(Height, 800);
+            split.IsVideoVisible = vm.IsVideoVisible;
+            split.IsWaveformVisible = vm.IsAudioVisualizerVisible;
+            rowVideoPlayer.Height = vm.IsVideoVisible || vm.IsAudioVisualizerVisible ? new GridLength(1, GridUnitType.Star) : new GridLength(0);
+
+            if (vm.IsVideoVisible)
+            {
+                MaxHeight = double.PositiveInfinity;
+                MinHeight = 650;
+                Height = Math.Max(Height, 800);
+            }
+            else if (vm.IsAudioVisualizerVisible)
+            {
+                // No player, but a waveform to show: it fills whatever height the user gives the
+                // window, so the videoless cap has to go.
+                MaxHeight = double.PositiveInfinity;
+                MinHeight = VideolessMinHeight + VideoWaveformSplitGrid.DefaultWaveformHeight;
+                Height = Math.Max(Height, VideolessHeight + 2 * VideoWaveformSplitGrid.DefaultWaveformHeight);
+            }
         };
 
         // Focus the time code box, not a button, so the window receives key events without arming
@@ -218,6 +238,10 @@ public class SetSyncPointWindow : Window
         // not enough to keep a focused button from clicking on Space release.
         AddHandler(KeyUpEvent, vm.OnKeyUpHandler, RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: true);
         Loaded += (_, e) => vm.OnLoaded();
-        Closing += (_, e) => vm.OnClosing();
+        Closing += (_, e) =>
+        {
+            Se.Settings.Synchronization.SetSyncPointWaveformHeight = split.WaveformHeight;
+            vm.OnClosing();
+        };
     }
 }

--- a/src/ui/Features/Sync/VideoWaveformSplitGrid.cs
+++ b/src/ui/Features/Sync/VideoWaveformSplitGrid.cs
@@ -1,0 +1,143 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
+using Nikse.SubtitleEdit.Logic;
+using System;
+
+namespace Nikse.SubtitleEdit.Features.Sync;
+
+/// <summary>
+/// A video player over a waveform with a drag handle between them, laid out the way the main
+/// window lays out its video and waveform. The sync dialogs used to pin the waveform at 80 px,
+/// which is too little to pick a precise sync point from once the window holds a player as well
+/// (issue #14414).
+/// </summary>
+public sealed class VideoWaveformSplitGrid : Grid
+{
+    public const double DefaultWaveformHeight = 80;
+    private const double MinWaveformHeight = 40;
+    private const double MinVideoHeight = 120;
+
+    private readonly RowDefinition _rowVideo;
+    private readonly RowDefinition _rowWaveform;
+    private readonly GridSplitter _splitter;
+    private bool _isVideoVisible = true;
+    private bool _isWaveformVisible;
+    private double _waveformHeight;
+
+    /// <summary>Raised while the handle is dragged, with the new waveform height in pixels.</summary>
+    public event Action<double>? WaveformHeightChanged;
+
+    /// <summary>The last dragged height - what to remember, never a collapsed or star-sized row.</summary>
+    public double WaveformHeight => _waveformHeight;
+
+    public VideoWaveformSplitGrid(Control videoPlayer, AudioVisualizer waveform, double waveformHeight)
+    {
+        _waveformHeight = SanitizeHeight(waveformHeight);
+
+        _rowVideo = new RowDefinition { Height = new GridLength(1, GridUnitType.Star) };
+        _rowWaveform = new RowDefinition { Height = new GridLength(_waveformHeight, GridUnitType.Pixel) };
+        RowDefinitions.Add(_rowVideo);
+        RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto }); // drag handle
+        RowDefinitions.Add(_rowWaveform);
+        ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        HorizontalAlignment = HorizontalAlignment.Stretch;
+        VerticalAlignment = VerticalAlignment.Stretch;
+
+        _splitter = new GridSplitter
+        {
+            Height = UiUtil.SplitterWidthOrHeight,
+            ResizeDirection = GridResizeDirection.Rows,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 2),
+        };
+        _splitter.DragDelta += (_, _) => OnDragged();
+        _splitter.DragCompleted += (_, _) => OnDragged();
+
+        // The row decides the height from here on.
+        waveform.Height = double.NaN;
+        waveform.VerticalAlignment = VerticalAlignment.Stretch;
+
+        this.Add(videoPlayer, 0);
+        this.Add(_splitter, 1);
+        this.Add(waveform, 2);
+        UpdateRows();
+    }
+
+    public bool IsVideoVisible
+    {
+        get => _isVideoVisible;
+        set
+        {
+            _isVideoVisible = value;
+            UpdateRows();
+        }
+    }
+
+    public bool IsWaveformVisible
+    {
+        get => _isWaveformVisible;
+        set
+        {
+            _isWaveformVisible = value;
+            UpdateRows();
+        }
+    }
+
+    /// <summary>Follows another pane's handle, so two side-by-side waveforms stay the same height.</summary>
+    public void SetWaveformHeight(double height)
+    {
+        _waveformHeight = SanitizeHeight(height);
+        UpdateRows();
+    }
+
+    private void OnDragged()
+    {
+        if (!_rowWaveform.Height.IsAbsolute)
+        {
+            return;
+        }
+
+        _waveformHeight = SanitizeHeight(_rowWaveform.Height.Value);
+        WaveformHeightChanged?.Invoke(_waveformHeight);
+    }
+
+    private void UpdateRows()
+    {
+        // The handle only makes sense with something on both sides of it.
+        var hasHandle = _isVideoVisible && _isWaveformVisible;
+        _splitter.IsVisible = hasHandle;
+
+        // A Star row keeps its share of the height when its child is merely hidden, so the rows
+        // themselves collapse - and a MinHeight on a collapsed row would prop it open.
+        _rowVideo.MinHeight = _isVideoVisible ? MinVideoHeight : 0;
+        _rowVideo.Height = _isVideoVisible ? new GridLength(1, GridUnitType.Star) : new GridLength(0);
+
+        _rowWaveform.MinHeight = hasHandle ? MinWaveformHeight : 0;
+        if (!_isWaveformVisible)
+        {
+            _rowWaveform.Height = new GridLength(0);
+        }
+        else if (_isVideoVisible)
+        {
+            _rowWaveform.Height = new GridLength(_waveformHeight, GridUnitType.Pixel);
+        }
+        else
+        {
+            // No player to share with: the waveform takes whatever height the window has.
+            _rowWaveform.Height = new GridLength(1, GridUnitType.Star);
+        }
+    }
+
+    private static double SanitizeHeight(double height)
+    {
+        if (double.IsNaN(height) || double.IsInfinity(height) || height < MinWaveformHeight)
+        {
+            return DefaultWaveformHeight;
+        }
+
+        return Math.Round(height);
+    }
+}

--- a/src/ui/Features/Sync/VisualSync/VisualSyncWindow.cs
+++ b/src/ui/Features/Sync/VisualSync/VisualSyncWindow.cs
@@ -48,7 +48,6 @@ public class VisualSyncWindow : Window
 
         vm.AudioVisualizerLeft = new AudioVisualizer
         {
-            Height = 80,
             Width = double.NaN,
             IsReadOnly = true,
             DrawGridLines = Se.Settings.Waveform.DrawGridLines,
@@ -65,7 +64,6 @@ public class VisualSyncWindow : Window
 
         vm.AudioVisualizerRight = new AudioVisualizer
         {
-            Height = 80,
             Width = double.NaN,
             IsReadOnly = true,
             DrawGridLines = Se.Settings.Waveform.DrawGridLines,
@@ -136,13 +134,25 @@ public class VisualSyncWindow : Window
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
         var buttonPanel = UiUtil.MakeButtonBar(labelInfo, buttonSync, buttonOk, buttonCancel);
 
+        // The waveforms used to be pinned at 80 px under the players, too little to pick a precise
+        // scene from; the drag handles mirror the main window and move together (issue #14414).
+        var splitLeft = new VideoWaveformSplitGrid(vm.VideoPlayerControlLeft, vm.AudioVisualizerLeft, Se.Settings.Synchronization.VisualSyncWaveformHeight)
+        {
+            IsWaveformVisible = vm.IsAudioVisualizerVisible,
+        };
+        var splitRight = new VideoWaveformSplitGrid(vm.VideoPlayerControlRight, vm.AudioVisualizerRight, Se.Settings.Synchronization.VisualSyncWaveformHeight)
+        {
+            IsWaveformVisible = vm.IsAudioVisualizerVisible,
+        };
+        splitLeft.WaveformHeightChanged += splitRight.SetWaveformHeight;
+        splitRight.WaveformHeightChanged += splitLeft.SetWaveformHeight;
+
         var gridLeft = new Grid
         {
             RowDefinitions =
             {
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // label
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) }, // video player
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // audio visualizer
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) }, // video player over waveform
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // combo box
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // buttons
             },
@@ -157,18 +167,16 @@ public class VisualSyncWindow : Window
         };
 
         gridLeft.Add(UiUtil.MakeLabel(Se.Language.Sync.StartScene), 0);
-        gridLeft.Add(vm.VideoPlayerControlLeft, 1);
-        gridLeft.Add(vm.AudioVisualizerLeft, 2);
-        gridLeft.Add(comboBoxLeft, 3);
-        gridLeft.Add(panelLeftButtons, 4);
+        gridLeft.Add(splitLeft, 1);
+        gridLeft.Add(comboBoxLeft, 2);
+        gridLeft.Add(panelLeftButtons, 3);
 
         var gridRight = new Grid
         {
             RowDefinitions =
             {
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // label
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) }, // video player
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // audio visualizer
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) }, // video player over waveform
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // combo box
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // buttons
             },
@@ -183,10 +191,9 @@ public class VisualSyncWindow : Window
         };
 
         gridRight.Add(UiUtil.MakeLabel(Se.Language.Sync.EndScene), 0);
-        gridRight.Add(vm.VideoPlayerControlRight, 1);
-        gridRight.Add(vm.AudioVisualizerRight, 2);
-        gridRight.Add(comboBoxRight, 3);
-        gridRight.Add(panelRightButtons, 4);
+        gridRight.Add(splitRight, 1);
+        gridRight.Add(comboBoxRight, 2);
+        gridRight.Add(panelRightButtons, 3);
 
         var grid = new Grid
         {
@@ -215,10 +222,25 @@ public class VisualSyncWindow : Window
 
         Content = grid;
 
+        // The lent waveform arrives a beat after construction, and goes away again when a
+        // different video is opened from the dialog.
+        vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(vm.IsAudioVisualizerVisible))
+            {
+                splitLeft.IsWaveformVisible = vm.IsAudioVisualizerVisible;
+                splitRight.IsWaveformVisible = vm.IsAudioVisualizerVisible;
+            }
+        };
+
         UiUtil.FocusOnFirstActivation(this, comboBoxLeft); // initial focus on an input, not an action button - a focused button clicks on bare Space
 
         AddHandler(KeyDownEvent, vm.OnKeyDownHandler, RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: false);
         Loaded += (_, _) => vm.OnLoaded();
-        Closing += (_, e) => vm.OnClosing();
+        Closing += (_, e) =>
+        {
+            Se.Settings.Synchronization.VisualSyncWaveformHeight = splitLeft.WaveformHeight;
+            vm.OnClosing();
+        };
     }
 }

--- a/src/ui/Logic/Config/SeSync.cs
+++ b/src/ui/Logic/Config/SeSync.cs
@@ -9,6 +9,10 @@ public class SeSync
     public double ChangeFrameRateFrom { get; set; } = 23.976;
     public double ChangeFrameRateTo { get; set; } = 25.0;
 
+    // Height of the drag-resizable waveform under the video in the sync dialogs (issue #14414).
+    public double SetSyncPointWaveformHeight { get; set; } = 80;
+    public double VisualSyncWaveformHeight { get; set; } = 80;
+
     public SeSync()
     {
         AdjustAllTimesLineSelectionChoice = string.Empty;

--- a/tests/UI/Features/Sync/SyncWaveformResizeTests.cs
+++ b/tests/UI/Features/Sync/SyncWaveformResizeTests.cs
@@ -1,0 +1,202 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.LogicalTree;
+using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Sync;
+using Nikse.SubtitleEdit.Features.Sync.PointSync.SetSyncPoint;
+using Nikse.SubtitleEdit.Features.Sync.VisualSync;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UITests.Features.Sync;
+
+/// <summary>
+/// The sync dialogs' waveforms were pinned at 80 px (issue #14414). Both windows now host the
+/// player and the waveform in a <see cref="VideoWaveformSplitGrid"/>, and remember its height.
+/// </summary>
+public class SyncWaveformResizeTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+    private readonly double _setSyncPointHeightBefore = Se.Settings.Synchronization.SetSyncPointWaveformHeight;
+    private readonly double _visualSyncHeightBefore = Se.Settings.Synchronization.VisualSyncWaveformHeight;
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+        Se.Settings.Synchronization.SetSyncPointWaveformHeight = _setSyncPointHeightBefore;
+        Se.Settings.Synchronization.VisualSyncWaveformHeight = _visualSyncHeightBefore;
+    }
+
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private static List<SubtitleLineViewModel> TwoLines()
+        => new()
+        {
+            new() { StartTime = TimeSpan.FromSeconds(1), EndTime = TimeSpan.FromSeconds(3) },
+            new() { StartTime = TimeSpan.FromSeconds(5), EndTime = TimeSpan.FromSeconds(7) },
+        };
+
+    private static AudioVisualizer LentWaveform()
+    {
+        var peaks = new WavePeak2[126 * 10];
+        for (var i = 0; i < peaks.Length; i++)
+        {
+            peaks[i] = new WavePeak2(200, -200);
+        }
+
+        return new AudioVisualizer { WavePeaks = new WavePeakData2(126, peaks) };
+    }
+
+    private T Track<T>(T window) where T : Window
+    {
+        _windows.Add(window);
+        return window;
+    }
+
+    private static SetSyncPointViewModel MakeSetSyncPointViewModel()
+        => new(new WindowService(new NullServiceProvider()), new FileHelper(), new VideoPreviewSubtitle(new MpvReloader(), new VlcReloader()));
+
+    private static VisualSyncViewModel MakeVisualSyncViewModel()
+        => new(new WindowService(new NullServiceProvider()), new FileHelper(),
+            new VideoPreviewSubtitle(new MpvReloader(), new VlcReloader()),
+            new VideoPreviewSubtitle(new MpvReloader(), new VlcReloader()));
+
+    private static List<VideoWaveformSplitGrid> SplitsOf(Window window)
+        => window.GetLogicalDescendants().OfType<VideoWaveformSplitGrid>().ToList();
+
+    private static GridSplitter HandleOf(Grid grid) => grid.Children.OfType<GridSplitter>().Single();
+
+    private static void SimulateDrag(VideoWaveformSplitGrid grid, double newHeight)
+    {
+        grid.RowDefinitions[2].Height = new GridLength(newHeight, GridUnitType.Pixel);
+        HandleOf(grid).RaiseEvent(new VectorEventArgs { RoutedEvent = Thumb.DragDeltaEvent });
+        HandleOf(grid).RaiseEvent(new VectorEventArgs { RoutedEvent = Thumb.DragCompletedEvent });
+    }
+
+    [AvaloniaFact]
+    public void SetSyncPointWindow_WithVideoAndLentWaveform_HasADragHandleAtTheSavedHeight()
+    {
+        Se.Settings.Synchronization.SetSyncPointWaveformHeight = 110;
+        var vm = MakeSetSyncPointViewModel();
+        var lines = TwoLines();
+        // A path is enough for the layout decision; nothing opens it here (the open is posted to
+        // the dispatcher and this test never pumps it).
+        vm.Initialize(lines, lines[0], videoFileName: "/does/not/exist.mp4", subtitleFileName: null, previewContext: VideoPreviewSubtitleContext.Default, audioVisualizer: LentWaveform());
+        var window = Track(new SetSyncPointWindow(vm));
+
+        // The peaks are handed over on the same posted job - flip the flag the way it does.
+        vm.IsAudioVisualizerVisible = true;
+
+        var split = Assert.Single(SplitsOf(window));
+        Assert.True(HandleOf(split).IsVisible);
+        Assert.True(split.RowDefinitions[2].Height.IsAbsolute);
+        Assert.Equal(110, split.RowDefinitions[2].Height.Value);
+        Assert.True(double.IsNaN(vm.AudioVisualizer.Height)); // the row, not the control, sets the height now
+    }
+
+    [AvaloniaFact]
+    public void SetSyncPointWindow_WithoutLentWaveform_HasNoHandleAndNoWaveformRow()
+    {
+        var vm = MakeSetSyncPointViewModel();
+        var lines = TwoLines();
+        vm.Initialize(lines, lines[0], videoFileName: "/does/not/exist.mp4", subtitleFileName: null, previewContext: VideoPreviewSubtitleContext.Default, audioVisualizer: null);
+
+        var window = Track(new SetSyncPointWindow(vm));
+
+        var split = Assert.Single(SplitsOf(window));
+        Assert.False(HandleOf(split).IsVisible);
+        Assert.Equal(0, split.RowDefinitions[2].Height.Value);
+    }
+
+    [AvaloniaFact]
+    public void SetSyncPointWindow_RemembersTheDraggedHeightOnClose()
+    {
+        Se.Settings.Synchronization.SetSyncPointWaveformHeight = 80;
+        var vm = MakeSetSyncPointViewModel();
+        var lines = TwoLines();
+        vm.Initialize(lines, lines[0], videoFileName: "/does/not/exist.mp4", subtitleFileName: null, previewContext: VideoPreviewSubtitleContext.Default, audioVisualizer: LentWaveform());
+        var window = new SetSyncPointWindow(vm);
+        vm.IsAudioVisualizerVisible = true;
+
+        SimulateDrag(SplitsOf(window).Single(), 140);
+        window.Close();
+
+        Assert.Equal(140, Se.Settings.Synchronization.SetSyncPointWaveformHeight);
+    }
+
+    [AvaloniaFact]
+    public void SetSyncPointWindow_WithoutVideoButWithLentWaveform_LiftsTheVideolessHeightCap()
+    {
+        // The videoless cap assumes there is nothing tall to show; a lent waveform is, and it fills
+        // whatever height the user gives the window.
+        var vm = MakeSetSyncPointViewModel();
+        var lines = TwoLines();
+        vm.Initialize(lines, lines[0], videoFileName: null, subtitleFileName: null, previewContext: VideoPreviewSubtitleContext.Default, audioVisualizer: LentWaveform());
+        var window = Track(new SetSyncPointWindow(vm));
+        Assert.True(window.MaxHeight < 400, $"cap was {window.MaxHeight}");
+
+        vm.IsAudioVisualizerVisible = true;
+
+        Assert.True(double.IsPositiveInfinity(window.MaxHeight));
+        var split = Assert.Single(SplitsOf(window));
+        Assert.False(HandleOf(split).IsVisible); // nothing above the waveform to trade height with
+        Assert.True(split.RowDefinitions[2].Height.IsStar);
+    }
+
+    [AvaloniaFact]
+    public void VisualSyncWindow_DragOnOnePane_MovesTheOtherAndIsRemembered()
+    {
+        Se.Settings.Synchronization.VisualSyncWaveformHeight = 80;
+        var vm = MakeVisualSyncViewModel();
+        vm.Initialize(TwoLines(), videoFileName: "/does/not/exist.mp4", subtitleFileName: null, previewContext: VideoPreviewSubtitleContext.Default, audioVisualizer: LentWaveform());
+        var window = new VisualSyncWindow(vm);
+        vm.IsAudioVisualizerVisible = true;
+
+        var splits = SplitsOf(window);
+        Assert.Equal(2, splits.Count);
+        Assert.All(splits, s => Assert.True(HandleOf(s).IsVisible));
+
+        SimulateDrag(splits[0], 130);
+        Assert.Equal(130, splits[1].RowDefinitions[2].Height.Value);
+
+        SimulateDrag(splits[1], 95);
+        Assert.Equal(95, splits[0].RowDefinitions[2].Height.Value);
+
+        window.Close();
+        Assert.Equal(95, Se.Settings.Synchronization.VisualSyncWaveformHeight);
+    }
+
+    [AvaloniaFact]
+    public void VisualSyncWindow_LosingTheWaveform_CollapsesBothRows()
+    {
+        // Opening a different video from the dialog drops the lent peaks (they belong to the
+        // video the dialog was opened with), and the rows must go with them.
+        var vm = MakeVisualSyncViewModel();
+        vm.Initialize(TwoLines(), videoFileName: "/does/not/exist.mp4", subtitleFileName: null, previewContext: VideoPreviewSubtitleContext.Default, audioVisualizer: LentWaveform());
+        var window = Track(new VisualSyncWindow(vm));
+        vm.IsAudioVisualizerVisible = true;
+
+        vm.IsAudioVisualizerVisible = false;
+
+        Assert.All(SplitsOf(window), s =>
+        {
+            Assert.False(HandleOf(s).IsVisible);
+            Assert.Equal(0, s.RowDefinitions[2].Height.Value);
+        });
+    }
+}

--- a/tests/UI/Features/Sync/VideoWaveformSplitGridTests.cs
+++ b/tests/UI/Features/Sync/VideoWaveformSplitGridTests.cs
@@ -1,0 +1,133 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
+using Nikse.SubtitleEdit.Features.Sync;
+using System.Linq;
+
+namespace UITests.Features.Sync;
+
+/// <summary>
+/// The video-over-waveform panel the sync dialogs share (issue #14414): a drag handle between the
+/// player and the waveform, rows that collapse when either side is hidden, and a remembered height.
+/// </summary>
+public class VideoWaveformSplitGridTests
+{
+    private static VideoWaveformSplitGrid Make(double savedHeight = 80)
+        => new(new Border(), new AudioVisualizer(), savedHeight);
+
+    private static GridSplitter HandleOf(Grid grid) => grid.Children.OfType<GridSplitter>().Single();
+    private static RowDefinition VideoRow(Grid grid) => grid.RowDefinitions[0];
+    private static RowDefinition WaveformRow(Grid grid) => grid.RowDefinitions[2];
+
+    /// <summary>What a GridSplitter drag leaves behind: the row resized and the drag events raised.</summary>
+    private static void SimulateDrag(VideoWaveformSplitGrid grid, double newHeight)
+    {
+        WaveformRow(grid).Height = new GridLength(newHeight, GridUnitType.Pixel);
+        HandleOf(grid).RaiseEvent(new VectorEventArgs { RoutedEvent = Thumb.DragDeltaEvent });
+        HandleOf(grid).RaiseEvent(new VectorEventArgs { RoutedEvent = Thumb.DragCompletedEvent });
+    }
+
+    [AvaloniaFact]
+    public void VideoAndWaveform_ShowsTheHandleOverAPixelSizedWaveformRow()
+    {
+        var grid = Make(120);
+        grid.IsWaveformVisible = true;
+
+        Assert.True(HandleOf(grid).IsVisible);
+        Assert.True(VideoRow(grid).Height.IsStar);
+        Assert.True(WaveformRow(grid).Height.IsAbsolute);
+        Assert.Equal(120, WaveformRow(grid).Height.Value);
+        Assert.Equal(120, grid.WaveformHeight);
+    }
+
+    [AvaloniaFact]
+    public void WithoutWaveform_CollapsesTheRowAndHidesTheHandle()
+    {
+        // A pixel row keeps its height when its child is merely hidden, so the row itself has to go.
+        var grid = Make();
+
+        Assert.False(HandleOf(grid).IsVisible);
+        Assert.True(WaveformRow(grid).Height.IsAbsolute);
+        Assert.Equal(0, WaveformRow(grid).Height.Value);
+        Assert.Equal(0, WaveformRow(grid).MinHeight);
+    }
+
+    [AvaloniaFact]
+    public void WithoutVideo_TheWaveformTakesTheSpaceAndThereIsNoHandle()
+    {
+        var grid = Make();
+        grid.IsVideoVisible = false;
+        grid.IsWaveformVisible = true;
+
+        Assert.False(HandleOf(grid).IsVisible);
+        Assert.Equal(0, VideoRow(grid).Height.Value);
+        Assert.Equal(0, VideoRow(grid).MinHeight); // a MinHeight would prop the collapsed row open
+        Assert.True(WaveformRow(grid).Height.IsStar);
+    }
+
+    [AvaloniaFact]
+    public void Drag_RemembersTheNewHeightAndTellsListeners()
+    {
+        var grid = Make(80);
+        grid.IsWaveformVisible = true;
+        double? seen = null;
+        grid.WaveformHeightChanged += h => seen = h;
+
+        SimulateDrag(grid, 150);
+
+        Assert.Equal(150, grid.WaveformHeight);
+        Assert.Equal(150, seen);
+    }
+
+    [AvaloniaFact]
+    public void HidingAndShowingTheWaveform_KeepsTheDraggedHeight()
+    {
+        var grid = Make(80);
+        grid.IsWaveformVisible = true;
+        SimulateDrag(grid, 150);
+
+        grid.IsWaveformVisible = false;
+        Assert.Equal(0, WaveformRow(grid).Height.Value);
+        Assert.Equal(150, grid.WaveformHeight); // the collapsed row is not what gets saved
+
+        grid.IsWaveformVisible = true;
+        Assert.Equal(150, WaveformRow(grid).Height.Value);
+    }
+
+    [AvaloniaFact]
+    public void SetWaveformHeight_FollowsAnotherPaneWithoutEchoingBack()
+    {
+        // Visual sync has two panes side by side; a drag on one moves the other, and following
+        // must not raise the event again or the two would ping-pong.
+        var left = Make(80);
+        var right = Make(80);
+        left.IsWaveformVisible = true;
+        right.IsWaveformVisible = true;
+        var rightRaised = 0;
+        left.WaveformHeightChanged += right.SetWaveformHeight;
+        right.WaveformHeightChanged += left.SetWaveformHeight;
+        right.WaveformHeightChanged += _ => rightRaised++;
+
+        SimulateDrag(left, 130);
+
+        Assert.Equal(130, WaveformRow(right).Height.Value);
+        Assert.Equal(130, right.WaveformHeight);
+        Assert.Equal(0, rightRaised);
+    }
+
+    [AvaloniaTheory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(-1)]
+    [InlineData(5)]
+    public void BadSavedHeight_FallsBackToTheDefault(double saved)
+    {
+        var grid = Make(saved);
+        grid.IsWaveformVisible = true;
+
+        Assert.Equal(VideoWaveformSplitGrid.DefaultWaveformHeight, grid.WaveformHeight);
+        Assert.Equal(VideoWaveformSplitGrid.DefaultWaveformHeight, WaveformRow(grid).Height.Value);
+    }
+}


### PR DESCRIPTION
Fixes #14414

## Problem

The **Set sync point** dialog (Point sync) and the **Visual sync** dialog pinned their waveforms at a fixed 80 px under the video player. With a video open the player took all the free height and the waveform stayed a thin strip, which makes precise sync points hard to pick. The main window's waveform is drag-resizable; these dialogs had no way to resize theirs.

## Fix

Both dialogs now host the player and the waveform in a shared `VideoWaveformSplitGrid` (`src/ui/Features/Sync/`), laid out the way the main window lays out its video and waveform:

- A horizontal `GridSplitter` between the player and the waveform. The waveform row is pixel-sized and the video row is Star, so a drag only moves the waveform, as in the main window. The video keeps a minimum height so the waveform cannot eat it entirely.
- The rows and the handle collapse when either side is hidden: no waveform lent by the main window, or the videoless Set sync point dialog. Without a player, a lent waveform fills whatever height the window has, and the videoless height cap from #13341 is lifted for it.
- Visual sync's two panes follow each other's handle, so the start and end waveforms stay the same height.
- The dragged height is remembered per dialog (`SetSyncPointWaveformHeight` / `VisualSyncWaveformHeight` under the synchronization settings), since Point sync opens its dialog twice per sync.

## Tests

- `VideoWaveformSplitGridTests`: handle/row state for every visibility combination, drag bookkeeping, pane linking without echo, bad saved heights falling back to the default.
- `SyncWaveformResizeTests`: both windows construct with the split grid, the handle appears once peaks arrive, the height is persisted on close, Visual sync panes move together and collapse together.
- Full UI test project: 4575 passed, 1 skipped. Layout verified with headless Skia captures of both dialogs before and after a drag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
