### PR TITLE
Fix recalculate duration landing just over max CPS, and CPS readouts disagreeing

### DIFF
--- a/src/libse/Common/Subtitle.cs
+++ b/src/libse/Common/Subtitle.cs
@@ -612,7 +612,16 @@ namespace Nikse.SubtitleEdit.Core.Common
             if (p.GetCharactersPerSecond() > maxCharactersPerSecond)
             {
                 var numberOfCharacters = (double)p.Text.CountCharacters(true);
-                var maxDurationMilliseconds = (numberOfCharacters / maxCharactersPerSecond) * 1000.0;
+                // Whole milliseconds, rounded up: the fractional value truncates on save to one ms
+                // short, which is just over the maximum this branch exists to enforce (#14418).
+                // Verified with the same division GetCharactersPerSecond performs rather than a
+                // plain Math.Ceiling, so binary-fraction noise does not add a needless millisecond.
+                var maxDurationMilliseconds = Math.Floor(numberOfCharacters / maxCharactersPerSecond * 1000.0);
+                if (numberOfCharacters / (maxDurationMilliseconds / 1000.0) > maxCharactersPerSecond)
+                {
+                    maxDurationMilliseconds += 1;
+                }
+
                 p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + maxDurationMilliseconds;
             }
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -6007,8 +6007,10 @@ public partial class MainViewModel :
             // Count like the grid's CPS column does (tags and line breaks stripped)
             var charCount = (double)(selectedLine.Text ?? string.Empty).CountCharacters(true);
 
-            var optimalDuration = TimeSpanExtensions.FromSecondsWholeMilliseconds(charCount / Se.Settings.General.SubtitleOptimalCharactersPerSeconds);
-            var maxDuration = TimeSpanExtensions.FromSecondsWholeMilliseconds(charCount / Se.Settings.General.SubtitleMaximumCharactersPerSeconds);
+            // Rounded up to the millisecond: rounding to nearest could land one ms short and put
+            // the line just over the CPS it was computed for (#14418).
+            var optimalDuration = CpsHelper.GetDurationForCps(charCount, Se.Settings.General.SubtitleOptimalCharactersPerSeconds);
+            var maxDuration = CpsHelper.GetDurationForCps(charCount, Se.Settings.General.SubtitleMaximumCharactersPerSeconds);
             var maxEndTime = TimeSpan.FromMilliseconds(selectedLine.StartTime.TotalMilliseconds + Se.Settings.General.SubtitleMaximumDisplayMilliseconds);
             if (nextSubtitle != null)
             {
@@ -6087,7 +6089,7 @@ public partial class MainViewModel :
                 continue;
             }
 
-            var newEndTime = selectedLine.StartTime + TimeSpanExtensions.FromSecondsWholeMilliseconds(charCount / maxCps);
+            var newEndTime = selectedLine.StartTime + CpsHelper.GetDurationForCps(charCount, maxCps);
             if (newEndTime < minEndTime)
             {
                 newEndTime = minEndTime;
@@ -28634,7 +28636,7 @@ public partial class MainViewModel :
         EditTextTotalLengthOriginal = string.Format(Se.Language.Main.TotalCharacters, totalLength);
 
         EditTextCharactersPerSecondBackgroundOriginal = Se.Settings.General.ColorCharactersPerSecond &&
-                                                        cps > Se.Settings.General.SubtitleMaximumCharactersPerSeconds
+                                                        CpsHelper.IsAboveMax(cps, Se.Settings.General.SubtitleMaximumCharactersPerSeconds)
             ? _errorBrush
             : _transparentBrush;
 

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -1246,7 +1246,7 @@ public partial class SubtitleLineViewModel : ObservableObject
     /// The CPS the error rules compare against. The cell tints have to use this too, or a row can
     /// be painted red and still be invisible to "list errors" and to error navigation.
     /// </summary>
-    private double CpsRounded => Math.Round(CharactersPerSecond, 2, MidpointRounding.AwayFromZero);
+    private double CpsRounded => CpsHelper.Round(CharactersPerSecond);
 
     public bool HasErrors(SubtitleLineViewModel? prev, SubtitleLineViewModel? next)
     {

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustDuration/BinaryAdjustDurationViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustDuration/BinaryAdjustDurationViewModel.cs
@@ -191,8 +191,10 @@ public partial class BinaryAdjustDurationViewModel : ObservableObject
                 continue;
             }
 
-            var optimalDuration = TimeSpan.FromSeconds(charCount / AdjustRecalculateOptimalCharacterPerSecond);
-            var maxDuration = TimeSpan.FromSeconds(charCount / AdjustRecalculateMaxCharacterPerSecond);
+            // Whole milliseconds, rounded up: a fractional duration truncates to one ms short on
+            // save, which puts the line just over the CPS it was computed for (#14418).
+            var optimalDuration = CpsHelper.GetDurationForCps(charCount, AdjustRecalculateOptimalCharacterPerSecond);
+            var maxDuration = CpsHelper.GetDurationForCps(charCount, AdjustRecalculateMaxCharacterPerSecond);
 
             var nextSubtitle = index + 1 < allSubtitles.Count ? allSubtitles[index + 1] : null;
             var maxEndTime = nextSubtitle?.StartTime ?? TimeSpan.MaxValue;

--- a/src/ui/Features/Tools/AdjustDuration/AdjustDurationViewModel.cs
+++ b/src/ui/Features/Tools/AdjustDuration/AdjustDurationViewModel.cs
@@ -165,8 +165,10 @@ public partial class AdjustDurationViewModel : ObservableObject
             // recalculated durations actually land at the requested chars-per-second.
             var charCount = (double)(subtitle.Text ?? string.Empty).CountCharacters(true);
 
-            var optimalDuration = TimeSpan.FromSeconds(charCount / AdjustRecalculateOptimalCharacterPerSecond);
-            var maxDuration = TimeSpan.FromSeconds(charCount / AdjustRecalculateMaxCharacterPerSecond);
+            // Whole milliseconds, rounded up: a fractional duration truncates to one ms short on
+            // save, which puts the line just over the CPS it was computed for (#14418).
+            var optimalDuration = CpsHelper.GetDurationForCps(charCount, AdjustRecalculateOptimalCharacterPerSecond);
+            var maxDuration = CpsHelper.GetDurationForCps(charCount, AdjustRecalculateMaxCharacterPerSecond);
 
             var nextSubtitle = subtitles.GetOrNull(i + 1);
             var maxEndTime = nextSubtitle?.StartTime ?? TimeSpan.MaxValue;

--- a/src/ui/Logic/CpsHelper.cs
+++ b/src/ui/Logic/CpsHelper.cs
@@ -1,0 +1,55 @@
+using System;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>
+/// The chars-per-second rules every CPS display shares, so the grid row, the edit box under the
+/// text field and the recalculate-duration commands agree on what "over the maximum" means.
+/// </summary>
+public static class CpsHelper
+{
+    /// <summary>
+    /// CPS as the comparisons see it: rounded to two decimals (the precision the grid column
+    /// colors on). A line at 15.004 CPS reads "15.0" everywhere, so it must not be flagged as
+    /// exceeding a 15.0 maximum anywhere either (issue #14418).
+    /// </summary>
+    public static double Round(double cps)
+        => Math.Round(cps, 2, MidpointRounding.AwayFromZero);
+
+    public static bool IsAboveMax(double cps, double maxCps)
+        => Round(cps) > maxCps;
+
+    /// <summary>
+    /// The shortest whole-millisecond duration at which <paramref name="charCount"/> characters
+    /// stay at or below <paramref name="cps"/>.
+    /// <para>
+    /// Rounding the exact duration to the nearest millisecond rounds down half the time, and a
+    /// duration one millisecond short of 20 chars / 15 CPS (1333 ms instead of 1334 ms) is 15.004
+    /// CPS - over the very limit the duration was computed from (issue #14418). So this rounds
+    /// up, verified against the same division the CPS readouts perform rather than with an
+    /// epsilon, so binary-fraction noise like 300.00000000000006 ms still yields 300 ms.
+    /// </para>
+    /// A non-positive <paramref name="cps"/> gives the maximum time code, like the plain
+    /// division it replaces did through <see cref="TimeSpanExtensions.FromSecondsWholeMilliseconds"/>.
+    /// </summary>
+    public static TimeSpan GetDurationForCps(double charCount, double cps)
+    {
+        if (charCount <= 0)
+        {
+            return TimeSpan.Zero;
+        }
+
+        if (cps <= 0)
+        {
+            return TimeSpanExtensions.FromMillisecondsWholeMilliseconds(TimeSpanExtensions.MaxTimeTotalMilliseconds);
+        }
+
+        var ms = Math.Floor(charCount * 1000.0 / cps);
+        if (charCount / (ms / 1000.0) > cps)
+        {
+            ms += 1;
+        }
+
+        return TimeSpanExtensions.FromMillisecondsWholeMilliseconds(ms);
+    }
+}

--- a/src/ui/Logic/SubtitleTextInfoHelper.cs
+++ b/src/ui/Logic/SubtitleTextInfoHelper.cs
@@ -56,7 +56,9 @@ internal static class SubtitleTextInfoHelper
 
         var cps = GetCharactersPerSecond(text, item.StartTime, item.EndTime);
         cpsText = string.Format(Se.Language.Main.CharactersPerSecond, $"{cps:0.0}");
-        cpsBackground = Se.Settings.General.ColorCharactersPerSecond && cps > maxCps ? _errorBrush : _transparentBrush;
+        // Same rounded comparison as the grid row, so the label cannot read "15.0" in red while
+        // the row for the same line is not flagged (#14418).
+        cpsBackground = Se.Settings.General.ColorCharactersPerSecond && CpsHelper.IsAboveMax(cps, maxCps) ? _errorBrush : _transparentBrush;
         totalText = info.TotalText;
         totalBackground = info.TotalBackground;
     }

--- a/tests/UI/Features/Tools/AdjustDuration/AdjustDurationViewModelTests.cs
+++ b/tests/UI/Features/Tools/AdjustDuration/AdjustDurationViewModelTests.cs
@@ -57,6 +57,33 @@ public class AdjustDurationViewModelTests
     }
 
     [Fact]
+    public void AdjustDuration_Recalculate_StaysWithinTheTargetCps()
+    {
+        // Issue #14418: 20 chars at 15 CPS is 1333.33 ms; rounding to the nearest ms gave 1333 ms,
+        // which is 15.004 CPS - over the limit the duration was computed from. Rounds up instead.
+        var vm = new AdjustDurationViewModel
+        {
+            SelectedAdjustType = new AdjustDurationDisplay { Type = AdjustDurationType.Recalculate },
+            AdjustRecalculateOptimalCharacterPerSecond = 15,
+            AdjustRecalculateMaxCharacterPerSecond = 15,
+        };
+        var subtitles = new ObservableCollection<SubtitleLineViewModel>
+        {
+            new()
+            {
+                Text = "It is not like that.",
+                StartTime = TimeSpan.Zero,
+                EndTime = TimeSpan.FromSeconds(10),
+            },
+        };
+
+        vm.AdjustDuration(subtitles);
+
+        Assert.Equal(1334, subtitles[0].EndTime.TotalMilliseconds);
+        Assert.True(subtitles[0].CharactersPerSecond <= 15);
+    }
+
+    [Fact]
     public void AdjustDuration_Percent_ScalesDurationFromStartTime()
     {
         var vm = new AdjustDurationViewModel

--- a/tests/UI/Logic/CpsHelperTests.cs
+++ b/tests/UI/Logic/CpsHelperTests.cs
@@ -1,0 +1,67 @@
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// Issue #14418: "Recalculate duration" put a 20-character line at 1333 ms for a 15 CPS target,
+/// which is 15.004 CPS, and the edit box then showed "15.0" in red while the grid row for the
+/// same line was not flagged. CPS-derived durations round up to the whole millisecond, and every
+/// CPS readout compares the same two-decimal value.
+/// </summary>
+public class CpsHelperTests
+{
+    [Fact]
+    public void GetDurationForCps_TwentyCharsAtFifteenCps_RoundsUpToStayWithinLimit()
+    {
+        var duration = CpsHelper.GetDurationForCps(20, 15);
+
+        Assert.Equal(1334, duration.TotalMilliseconds);
+        Assert.True(20 / duration.TotalSeconds <= 15);
+    }
+
+    [Fact]
+    public void GetDurationForCps_ExactDivision_DoesNotAddAMillisecond()
+    {
+        // 3 / 10 * 1000 is 300.00000000000006 in binary - a plain Math.Ceiling would give 301.
+        Assert.Equal(300, CpsHelper.GetDurationForCps(3, 10).TotalMilliseconds);
+        Assert.Equal(2000, CpsHelper.GetDurationForCps(30, 15).TotalMilliseconds);
+    }
+
+    [Fact]
+    public void GetDurationForCps_IsTheShortestWholeMillisecondWithinTheLimit()
+    {
+        foreach (var cps in new[] { 9.0, 12.0, 14.7, 15.0, 17.0, 20.0, 25.0 })
+        {
+            for (var charCount = 1; charCount <= 200; charCount++)
+            {
+                var ms = CpsHelper.GetDurationForCps(charCount, cps).TotalMilliseconds;
+
+                Assert.Equal(Math.Round(ms), ms);
+                Assert.True(charCount / (ms / 1000.0) <= cps, $"{charCount} chars at {cps} CPS: {ms} ms is over the limit");
+                Assert.True(ms == 1 || charCount / ((ms - 1) / 1000.0) > cps, $"{charCount} chars at {cps} CPS: {ms - 1} ms would also fit");
+            }
+        }
+    }
+
+    [Fact]
+    public void GetDurationForCps_NoCharacters_IsZero()
+    {
+        Assert.Equal(TimeSpan.Zero, CpsHelper.GetDurationForCps(0, 15));
+    }
+
+    [Fact]
+    public void GetDurationForCps_ZeroCps_ClampsToMaxTime()
+    {
+        Assert.True(CpsHelper.GetDurationForCps(20, 0).IsMaxTime());
+    }
+
+    [Fact]
+    public void IsAboveMax_ComparesTheDisplayedPrecision()
+    {
+        Assert.False(CpsHelper.IsAboveMax(15.0037, 15));  // 20 chars / 1333 ms
+        Assert.False(CpsHelper.IsAboveMax(15.004, 15));
+        Assert.True(CpsHelper.IsAboveMax(15.005, 15));
+        Assert.True(CpsHelper.IsAboveMax(15.01, 15));
+        Assert.False(CpsHelper.IsAboveMax(15, 15));
+    }
+}

--- a/tests/libse/Core/SubtitleTest.cs
+++ b/tests/libse/Core/SubtitleTest.cs
@@ -6,6 +6,24 @@ public class SubtitleTest
 {
 
     [Fact]
+    public void RecalculateDisplayTime_MaxCps_RoundsUpToWholeMillisecondWithinLimit()
+    {
+        // Issue #14418: 20 chars at 15 CPS is 1333.33 ms; that fractional end time truncates to
+        // 1333 ms on save, which is 15.004 CPS - over the maximum this branch enforces.
+        var sub = new Subtitle();
+        sub.Paragraphs.Add(new Paragraph("It is not like that.", 0, 10000));
+
+        // An optimal of 40 CPS gives 500 ms (onlyOptimal skips the reading-speed factors), so
+        // the max-CPS branch is what sets the end time; enforceDurationLimits false keeps the
+        // min/max duration settings out of it.
+        sub.RecalculateDisplayTime(15, 0, 40, onlyOptimal: true, enforceDurationLimits: false);
+
+        var p = sub.Paragraphs[0];
+        Assert.Equal(1334, p.DurationTotalMilliseconds);
+        Assert.True(p.GetCharactersPerSecond() <= 15);
+    }
+
+    [Fact]
     public void TestRemoveParagraphsByIds1()
     {
         var sub = new Subtitle();


### PR DESCRIPTION
Fixes #14418.

## What was wrong

**Recalculate duration** computed 20 chars at 15 CPS as 1333.33 ms and rounded to the *nearest* millisecond. That gave 1333 ms, which is 15.004 CPS: over the very limit the duration was computed from.

The three CPS readouts then disagreed about that line:

- The edit box under the text field compared the raw 15.004 against the max and turned red while printing "15.0".
- The grid row (and the error list) compare a two-decimal rounding, so 15.00 was not flagged.

The same round-to-nearest was in **Set duration to max CPS**, and the Adjust Durations dialog, its binary-edit twin, and the libse `RecalculateDisplayTime` max branch all produced fractional-millisecond end times that truncate one millisecond short on save, with the same result after a reload.

## Fix

- New `CpsHelper.GetDurationForCps(charCount, cps)` returns the shortest whole-millisecond duration that stays at or below the target CPS. It rounds up, but checks with the same division the readouts perform instead of an epsilon, so `3 / 10 s` is still 300 ms and not 301. Used by the two main-window commands, both Adjust Durations dialogs, and the libse recalc.
- New `CpsHelper.IsAboveMax` is the shared two-decimal comparison the grid already used. The edit-box CPS label and the original-text label now use it, so a line can no longer be red in one place and clean in another.

| Duration for "It is not like that." at 15 CPS | CPS |
|---|---|
| 1333 ms (before) | 15.0037, edit box red |
| 1334 ms (after) | 14.9925 |

Not changed: the grid column displays one decimal but colors on two, so a line at exactly 15.01 CPS shows "15.0" in red in the grid. Coloring on the displayed one-decimal value would loosen the threshold slightly, so that is left as is.

## Tests

- `CpsHelperTests`: the reported case, exact divisions, an exhaustive sweep (1..200 chars at 7 CPS targets) that the result is whole, within the limit, and minimal, plus the rounded comparison boundaries.
- `AdjustDurationViewModelTests`: recalculate at 15/15 gives 1334 ms.
- `SubtitleTest`: libse `RecalculateDisplayTime` max-CPS branch gives 1334 ms.

Full libse suite passes (1896). UI tests matching Duration/Cps/Recalc/BinaryEdit/SubMillisecond pass; one unrelated waveform-drag timing test flaked once in the mixed run and passed three times on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)