### PR TITLE
Add "Break at first space from cursor position" text box shortcuts

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -18709,6 +18709,72 @@ public partial class MainViewModel :
         _updateAudioVisualizer = true;
     }
 
+    [RelayCommand]
+    private void BreakAtFirstSpaceFromCursor()
+    {
+        BreakAtFirstSpaceFromCursor(goToNext: false);
+    }
+
+    [RelayCommand]
+    private void BreakAtFirstSpaceFromCursorAndGoToNext()
+    {
+        BreakAtFirstSpaceFromCursor(goToNext: true);
+    }
+
+    /// <summary>
+    /// SE 4's "Break at first space from cursor position" (#14420): flattens the existing line
+    /// breaks and puts a single break at the first space at (or right before) the caret, so a
+    /// manual two-liner is one keystroke. Works on whichever text box has focus. The plain variant
+    /// leaves the caret at the end of the new first line; the go-to-next variant moves on to the
+    /// next row like SE 4 did, whether or not the text changed.
+    /// </summary>
+    private void BreakAtFirstSpaceFromCursor(bool goToNext)
+    {
+        var s = SelectedSubtitle;
+        if (s == null || s.IsReferenceOnly)
+        {
+            return;
+        }
+
+        var tb = GetFocusedTextBoxWrapper() ?? EditTextBox;
+        var isOriginal = ReferenceEquals(tb, EditTextBoxOriginal);
+        if (tb.IsReadOnly || (isOriginal && !CanEditOriginal))
+        {
+            return;
+        }
+
+        var text = tb.Text ?? string.Empty;
+        var caret = Math.Clamp(tb.CaretIndex, 0, text.Length);
+        var newText = Utilities.ReSplit(text, caret);
+        if (newText != text)
+        {
+            if (isOriginal)
+            {
+                s.OriginalText = newText;
+            }
+            else
+            {
+                s.Text = newText;
+            }
+
+            // The row is the working text; the box follows through its binding, but the caret
+            // must be measured against the new text, so make sure the box shows it first.
+            if (tb.Text != newText)
+            {
+                tb.Text = newText;
+            }
+
+            var lines = newText.SplitToLines();
+            tb.CaretIndex = lines.Count > 0 ? lines[0].Length : newText.Length;
+            _updateAudioVisualizer = true;
+        }
+
+        if (goToNext)
+        {
+            GoToNextLine();
+        }
+    }
+
     private List<string> NormalizeToTwoLines(string text)
     {
         var lines = text.SplitToLines();

--- a/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
+++ b/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
@@ -255,6 +255,8 @@ public static class Se4ShortcutsImporter
         ["MainTextBoxMoveFirstWordUpCurrent"] = nameof(MainViewModel.MoveFirstWordFromNextLineUpCurrentSubtitleCommand),
         ["MainTextBoxMoveFirstWordFromNextUp"] = nameof(MainViewModel.FetchFirstWordFromNextSubtitleCommand),
         ["MainTextBoxMoveFromCursorToNextAndGoToNext"] = nameof(MainViewModel.MoveTextFromCursorToNextAndGoToNextCommand),
+        ["MainTextBoxBreakAtPosition"] = nameof(MainViewModel.BreakAtFirstSpaceFromCursorCommand),
+        ["MainTextBoxBreakAtPositionAndGoToNext"] = nameof(MainViewModel.BreakAtFirstSpaceFromCursorAndGoToNextCommand),
         ["MainTextBoxSelectionToggleCasing"] = nameof(MainViewModel.ToggleCasingCommand),
         ["MainTextBoxSelectionToLower"] = nameof(MainViewModel.SelectionToLowerCommand),
         ["MainTextBoxSelectionToUpper"] = nameof(MainViewModel.SelectionToUpperCommand),

--- a/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
@@ -92,6 +92,8 @@ public class LanguageSettingsShortcuts
     public string MoveFirstWordFromNextLineUpCurrentSubtitle { get; set; }
     public string MoveTextFromCursorToNextAndGoToNext { get; set; }
     public string MoveTextFromCursorToNextAndGoToNextAndPlay { get; set; }
+    public string BreakAtFirstSpaceFromCursor { get; set; }
+    public string BreakAtFirstSpaceFromCursorAndGoToNext { get; set; }
     public string ToggleFocusGridAndWaveform { get; set; }
     public string ToggleFocusTextBoxAndWaveform { get; set; }
     public string ToggleFocusTextBoxAndGrid { get; set; }
@@ -369,6 +371,8 @@ public class LanguageSettingsShortcuts
         MoveFirstWordFromNextLineUpCurrentSubtitle = "Move first word from next line up (current subtitle)";
         MoveTextFromCursorToNextAndGoToNext = "Move text after cursor position to next subtitle and go to next";
         MoveTextFromCursorToNextAndGoToNextAndPlay = "Move text after cursor position to next subtitle, go to next and play";
+        BreakAtFirstSpaceFromCursor = "Break at first space from cursor position";
+        BreakAtFirstSpaceFromCursorAndGoToNext = "Break at first space from cursor position and go to next";
         ToggleFocusGridAndWaveform = "Toggle focus between subtitle grid and waveform/spectrogram";
         ToggleFocusTextBoxAndWaveform = "Toggle focus between text box and waveform/spectrogram";
         ToggleFocusTextBoxAndGrid = "Toggle focus between text box and subtitle grid";

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -425,6 +425,8 @@ public static class ShortcutsMain
         { nameof(MainViewModel.MoveFirstWordFromNextLineUpCurrentSubtitleCommand), Se.Language.Options.Shortcuts.MoveFirstWordFromNextLineUpCurrentSubtitle },
         { nameof(MainViewModel.MoveTextFromCursorToNextAndGoToNextCommand), Se.Language.Options.Shortcuts.MoveTextFromCursorToNextAndGoToNext },
         { nameof(MainViewModel.MoveTextFromCursorToNextAndGoToNextAndPlayCommand), Se.Language.Options.Shortcuts.MoveTextFromCursorToNextAndGoToNextAndPlay },
+        { nameof(MainViewModel.BreakAtFirstSpaceFromCursorCommand), Se.Language.Options.Shortcuts.BreakAtFirstSpaceFromCursor },
+        { nameof(MainViewModel.BreakAtFirstSpaceFromCursorAndGoToNextCommand), Se.Language.Options.Shortcuts.BreakAtFirstSpaceFromCursorAndGoToNext },
         { nameof(MainViewModel.ToggleFocusGridAndWaveformCommand), Se.Language.Options.Shortcuts.ToggleFocusGridAndWaveform },
         { nameof(MainViewModel.ToggleFocusTextBoxAndWaveformCommand), Se.Language.Options.Shortcuts.ToggleFocusTextBoxAndWaveform },
         { nameof(MainViewModel.ToggleFocusTextBoxAndSubtitleGridCommand), Se.Language.Options.Shortcuts.ToggleFocusTextBoxAndGrid },
@@ -707,6 +709,8 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.TextBoxItalicCommand, nameof(vm.TextBoxItalicCommand), ShortcutCategory.TextBox);
         AddShortcut(shortcuts, vm.TextBoxBoldCommand, nameof(vm.TextBoxBoldCommand), ShortcutCategory.TextBox);
         AddShortcut(shortcuts, vm.TextBoxUnderlineCommand, nameof(vm.TextBoxUnderlineCommand), ShortcutCategory.TextBox);
+        AddShortcut(shortcuts, vm.BreakAtFirstSpaceFromCursorCommand, nameof(vm.BreakAtFirstSpaceFromCursorCommand), ShortcutCategory.TextBox);
+        AddShortcut(shortcuts, vm.BreakAtFirstSpaceFromCursorAndGoToNextCommand, nameof(vm.BreakAtFirstSpaceFromCursorAndGoToNextCommand), ShortcutCategory.TextBox);
 
         // Tools
         AddShortcut(shortcuts, vm.ShowBridgeGapsCommand, nameof(vm.ShowBridgeGapsCommand), ShortcutCategory.General, ShortcutGroup.Tools);

--- a/tests/UI/Features/Options/Shortcuts/Se4ShortcutsImporterMapTests.cs
+++ b/tests/UI/Features/Options/Shortcuts/Se4ShortcutsImporterMapTests.cs
@@ -71,6 +71,8 @@ public class Se4ShortcutsImporterMapTests
     [InlineData("MainListViewUnderline", "ToggleLinesUnderlineOrSelectedTextCommand")]
     [InlineData("WaveformGuessStart", "WaveformGuessStartCommand")]
     [InlineData("MainEditToggleTranslationOriginalInPreviews", "ToggleOriginalTextInPreviewCommand")]
+    [InlineData("MainTextBoxBreakAtPosition", "BreakAtFirstSpaceFromCursorCommand")]
+    [InlineData("MainTextBoxBreakAtPositionAndGoToNext", "BreakAtFirstSpaceFromCursorAndGoToNextCommand")]
     public void ImportsSe4ShortcutBySerializedName(string se4Name, string expectedSe5Command)
     {
         var xml = $"<Shortcuts><{se4Name}>Control+Shift+F12</{se4Name}></Shortcuts>";

--- a/tests/libse/Common/UtilitiesTest.cs
+++ b/tests/libse/Common/UtilitiesTest.cs
@@ -7,6 +7,36 @@ namespace LibSETests.Common;
 
 public class UtilitiesTest
 {
+    // ReSplit backs "Break at first space from cursor position" (#14420): one break at the
+    // first space at or after the caret, existing breaks flattened first.
+    [Fact]
+    public void ReSplitBreaksAtFirstSpaceAfterCaret()
+    {
+        var s = Utilities.ReSplit("Hello world foo bar", 8);
+        Assert.Equal("Hello world" + Environment.NewLine + "foo bar", s);
+    }
+
+    [Fact]
+    public void ReSplitBreaksAtSpaceRightBeforeCaret()
+    {
+        var s = Utilities.ReSplit("Hello world foo bar", 6);
+        Assert.Equal("Hello" + Environment.NewLine + "world foo bar", s);
+    }
+
+    [Fact]
+    public void ReSplitReplacesExistingLineBreak()
+    {
+        var s = Utilities.ReSplit("Hello" + Environment.NewLine + "world foo bar", 8);
+        Assert.Equal("Hello world" + Environment.NewLine + "foo bar", s);
+    }
+
+    [Fact]
+    public void ReSplitLeavesTextWithoutSpaceAfterCaretAlone()
+    {
+        Assert.Equal("Hello world", Utilities.ReSplit("Hello world", 8));
+        Assert.Equal("Hello world", Utilities.ReSplit("Hello world", 0));
+    }
+
     // SplitEndTags walks the line right-to-left, so each stripped tag must be prepended to
     // "post" to preserve the original suffix order - it used to append, so nested closing
     // tags came back reversed ("</font></i>") when callers rebuilt "pre + text + post".


### PR DESCRIPTION
Fixes #14420

Brings back the two SE 4 text-box shortcuts the issue asks for, under Options → Shortcuts → Text box:

- **Break at first space from cursor position** – flattens the existing line breaks and puts one break at the first space at (or directly before) the caret, then leaves the caret at the end of the new first line.
- **Break at first space from cursor position and go to next** – same, then selects the next row.

Both work on whichever text box has focus (main or an editable original) and are unbound by default, as in SE 4. The SE 4 settings importer now maps `MainTextBoxBreakAtPosition` / `MainTextBoxBreakAtPositionAndGoToNext` to the new commands.

One small deliberate difference from SE 4: the go-to-next variant always moves on, even when the text did not need a break, so it can be used as the "done with this line" key.

Implementation: the SE 4 algorithm (`Utilities.ReSplit`) was still in libse, unused and untested, so this is mostly wiring plus its first unit tests.

Tests: `tests/libse` ReSplit cases and `tests/UI` shortcut/importer tests pass. English.json left untouched (English runs on the class defaults).

🤖 Generated with [Claude Code](https://claude.com/claude-code)