### PR TITLE
fix(shortcut): set end time and advance to next subtitle on key up

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -28157,6 +28157,25 @@ public partial class MainViewModel :
     {
         if (_setEndAtKeyUpLine != null)
         {
+            var vp = GetVideoPlayerControl();
+            if (vp != null && !string.IsNullOrEmpty(_videoFileName))
+            {
+                var endMs = Math.Round(vp.Position * 1000.0, MidpointRounding.AwayFromZero);
+                if (_setEndAtKeyUpLine.StartTime.TotalMilliseconds + 100 < endMs)
+                {
+                    _setEndAtKeyUpLine.EndTime = TimeSpan.FromMilliseconds(endMs);
+                }
+            }
+
+            if (_setEndAtKeyUpLineGoToNext)
+            {
+                var idx = Subtitles.IndexOf(_setEndAtKeyUpLine);
+                if (idx >= 0)
+                {
+                    SelectAndScrollToRowCentered(idx + 1);
+                }
+            }
+
             _setEndAtKeyUpLine = null;
             _setEndAtKeyUpLineGoToNext = false;
         }
@@ -29187,17 +29206,10 @@ public partial class MainViewModel :
 
                 if (_setEndAtKeyUpLine != null)
                 {
-                    _setEndAtKeyUpLine.EndTime = TimeSpan.FromSeconds(vp.VideoPlayer.Position);
-                    if (_setEndAtKeyUpLineGoToNext)
+                    var posMs = Math.Round(vp.Position * 1000.0, MidpointRounding.AwayFromZero);
+                    if (_setEndAtKeyUpLine.StartTime.TotalMilliseconds + 100 < posMs)
                     {
-                        var idx = Subtitles.IndexOf(_setEndAtKeyUpLine);
-                        if (idx >= 0)
-                        {
-                            SelectAndScrollToRowCentered(idx + 1);
-                        }
-
-                        _setEndAtKeyUpLine = null;
-                        _setEndAtKeyUpLineGoToNext = false;
+                        _setEndAtKeyUpLine.EndTime = TimeSpan.FromMilliseconds(posMs);
                     }
                 }
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -16849,7 +16849,10 @@ public partial class MainViewModel :
         }
 
         var startMs = Math.Round(vp.Position * 1000.0, MidpointRounding.AwayFromZero);
-        selectedSubtitle.StartTime = TimeSpan.FromMilliseconds(startMs);
+        // Move the whole line (SE4 SetStartTime with adjustEndTime): the end is only rewritten once
+        // the playhead is 100 ms past the new start, so a quick tap on a line whose old end lies before
+        // the new start must not leave it with a negative duration.
+        selectedSubtitle.SetStartTimeKeepDuration(TimeSpan.FromMilliseconds(startMs));
         _setEndAtKeyUpLine = selectedSubtitle;
         _setEndAtKeyUpLineGoToNext = true;
         _updateAudioVisualizer = true;


### PR DESCRIPTION
### Summary of Changes
Addresses review feedback regarding key-up shortcut handling:

1. **Lower bound guard on key-up**: Applied the SE4-style `StartTime.TotalMilliseconds + 100 < endMs` guard in `OnKeyUpHandler`. A quick tap will no longer overwrite `NewEmptyDefaultMs` on inserted lines or create ~40ms / negative-duration subtitles.
2. **Preserved live waveform tracking while key is held**: Kept the periodic 50ms timer tick updating `EndTime` with playhead position so the waveform line expands live while holding the shortcut key, performing only the final commit and row advance upon `OnKeyUpHandler`.
3. **Fixed SMPTE clock & rounding mismatch**: Aligned key-up and tick clock sources to `vp.Position` with `Math.Round(vp.Position * 1000.0, MidpointRounding.AwayFromZero)` matching the key-down side (preventing SMPTE drift and fractional milliseconds).
