### PR TITLE
Share the SMPTE preview stretch between the mpv and VLC reloaders and the secondary subtitle

### DIFF
--- a/src/ui/Logic/Media/MpvReloader.cs
+++ b/src/ui/Logic/Media/MpvReloader.cs
@@ -180,14 +180,7 @@ public class MpvReloader : IMpvReloader
     // subtitle copy, read-only state and libse statics - never the memo fields.
     private (Subtitle Subtitle, string Text, int Hash, bool HashValid) BuildPreviewText(Subtitle subtitle, Subtitle? subtitleSecondary, Type uiFormatType, bool uiFormatHasPositions, int oldHash, string oldText)
     {
-        if (SmpteMode)
-        {
-            foreach (var paragraph in subtitle.Paragraphs)
-            {
-                paragraph.StartTime.TotalMilliseconds *= 1.001;
-                paragraph.EndTime.TotalMilliseconds *= 1.001;
-            }
-        }
+        SecondarySubtitleMerger.PreparePreviewSubtitle(subtitle, SmpteMode);
 
         if (uiFormatType == typeof(NetflixImsc11Japanese) || NetflixImsc11JapaneseToAss.HasJapaneseMarkup(subtitle))
         {
@@ -195,7 +188,7 @@ public class MpvReloader : IMpvReloader
             // exploded into separately positioned render lines, or the tags show up as literal
             // text on the video (issue #13861). Lambda Cap decodes to the same markup (issue #14165).
             subtitle = NetflixImsc11JapaneseToAss.ConvertToSubtitle(subtitle, VideoWidth, VideoHeight);
-            SecondarySubtitleMerger.AddSecondarySubtitle(subtitle, subtitleSecondary);
+            SecondarySubtitleMerger.AddSecondarySubtitle(subtitle, subtitleSecondary, SmpteMode);
             return (subtitle, subtitle.ToText(_assFormat), 0, false);
         }
 
@@ -206,7 +199,7 @@ public class MpvReloader : IMpvReloader
             // No extra copy here: "subtitle" is already RefreshMpv's private copy, and
             // Convert deep-copies its input again internally without mutating it.
             subtitle = WebVttToAssa.Convert(subtitle, defaultStyle, VideoWidth, VideoHeight);
-            SecondarySubtitleMerger.AddSecondarySubtitle(subtitle, subtitleSecondary);
+            SecondarySubtitleMerger.AddSecondarySubtitle(subtitle, subtitleSecondary, SmpteMode);
             // The WebVTT path never used the hash memo, so keep it untouched (HashValid false).
             return (subtitle, subtitle.ToText(_assFormat), 0, false);
         }
@@ -264,7 +257,7 @@ public class MpvReloader : IMpvReloader
             SubtitlePositionToAssa.ApplyPositions(subtitle, oldHeader, usePositions);
         }
 
-        SecondarySubtitleMerger.AddSecondarySubtitle(subtitle, subtitleSecondary);
+        SecondarySubtitleMerger.AddSecondarySubtitle(subtitle, subtitleSecondary, SmpteMode);
         var hash = subtitle.GetFastHashCode(null);
         if (hash != oldHash || string.IsNullOrEmpty(oldText))
         {

--- a/src/ui/Logic/Media/MpvReloader.cs
+++ b/src/ui/Logic/Media/MpvReloader.cs
@@ -180,7 +180,10 @@ public class MpvReloader : IMpvReloader
     // subtitle copy, read-only state and libse statics - never the memo fields.
     private (Subtitle Subtitle, string Text, int Hash, bool HashValid) BuildPreviewText(Subtitle subtitle, Subtitle? subtitleSecondary, Type uiFormatType, bool uiFormatHasPositions, int oldHash, string oldText)
     {
-        SecondarySubtitleMerger.PreparePreviewSubtitle(subtitle, SmpteMode);
+        if (SmpteMode)
+        {
+            SmptePreviewStretch.Apply(subtitle);
+        }
 
         if (uiFormatType == typeof(NetflixImsc11Japanese) || NetflixImsc11JapaneseToAss.HasJapaneseMarkup(subtitle))
         {

--- a/src/ui/Logic/Media/SecondarySubtitleMerger.cs
+++ b/src/ui/Logic/Media/SecondarySubtitleMerger.cs
@@ -8,6 +8,34 @@ namespace Nikse.SubtitleEdit.Logic.Media;
 public static class SecondarySubtitleMerger
 {
     /// <summary>
+    /// Prepares a subtitle copy for video preview: filters out zero/negative-duration paragraphs,
+    /// clamps negative start times, and applies SMPTE timing stretch when enabled.
+    /// </summary>
+    public static void PreparePreviewSubtitle(Subtitle subtitle, bool smpteMode)
+    {
+        for (var i = subtitle.Paragraphs.Count - 1; i >= 0; i--)
+        {
+            var p = subtitle.Paragraphs[i];
+            if (p.StartTime.TotalMilliseconds < 0)
+            {
+                p.StartTime.TotalMilliseconds = 0;
+            }
+
+            if (p.Duration.TotalMilliseconds <= 0 || p.EndTime.TotalMilliseconds <= 0)
+            {
+                subtitle.Paragraphs.RemoveAt(i);
+                continue;
+            }
+
+            if (smpteMode)
+            {
+                p.StartTime.TotalMilliseconds *= 1.001;
+                p.EndTime.TotalMilliseconds *= 1.001;
+            }
+        }
+    }
+
+    /// <summary>
     /// Adds the secondary subtitle's paragraphs and style to a preview subtitle about
     /// to be pushed to the video player.
     /// The secondary style is sized against its own header's PlayRes (the real video
@@ -17,7 +45,7 @@ public static class SecondarySubtitleMerger
     /// for ASSA mains with a small PlayResY (issue #13425), so resample it to the
     /// target's scale first.
     /// </summary>
-    public static void AddSecondarySubtitle(Subtitle subtitle, Subtitle? subtitleSecondary)
+    public static void AddSecondarySubtitle(Subtitle subtitle, Subtitle? subtitleSecondary, bool smpteMode = false)
     {
         if (subtitleSecondary == null)
         {
@@ -49,7 +77,29 @@ public static class SecondarySubtitleMerger
         subtitle.Header = AdvancedSubStationAlpha.AddSsaStyle(style, subtitle.Header);
         foreach (var p in subtitleSecondary.Paragraphs)
         {
-            subtitle.Paragraphs.Add(p);
+            var startMs = p.StartTime.TotalMilliseconds;
+            if (startMs < 0)
+            {
+                startMs = 0;
+            }
+
+            var endMs = p.EndTime.TotalMilliseconds;
+            if (endMs <= startMs)
+            {
+                continue;
+            }
+
+            if (smpteMode)
+            {
+                startMs *= 1.001;
+                endMs *= 1.001;
+            }
+
+            subtitle.Paragraphs.Add(new Paragraph(p)
+            {
+                StartTime = { TotalMilliseconds = startMs },
+                EndTime = { TotalMilliseconds = endMs }
+            });
         }
     }
 

--- a/src/ui/Logic/Media/SecondarySubtitleMerger.cs
+++ b/src/ui/Logic/Media/SecondarySubtitleMerger.cs
@@ -8,34 +8,6 @@ namespace Nikse.SubtitleEdit.Logic.Media;
 public static class SecondarySubtitleMerger
 {
     /// <summary>
-    /// Prepares a subtitle copy for video preview: filters out zero/negative-duration paragraphs,
-    /// clamps negative start times, and applies SMPTE timing stretch when enabled.
-    /// </summary>
-    public static void PreparePreviewSubtitle(Subtitle subtitle, bool smpteMode)
-    {
-        for (var i = subtitle.Paragraphs.Count - 1; i >= 0; i--)
-        {
-            var p = subtitle.Paragraphs[i];
-            if (p.StartTime.TotalMilliseconds < 0)
-            {
-                p.StartTime.TotalMilliseconds = 0;
-            }
-
-            if (p.Duration.TotalMilliseconds <= 0 || p.EndTime.TotalMilliseconds <= 0)
-            {
-                subtitle.Paragraphs.RemoveAt(i);
-                continue;
-            }
-
-            if (smpteMode)
-            {
-                p.StartTime.TotalMilliseconds *= 1.001;
-                p.EndTime.TotalMilliseconds *= 1.001;
-            }
-        }
-    }
-
-    /// <summary>
     /// Adds the secondary subtitle's paragraphs and style to a preview subtitle about
     /// to be pushed to the video player.
     /// The secondary style is sized against its own header's PlayRes (the real video
@@ -44,8 +16,11 @@ public static class SecondarySubtitleMerger
     /// the secondary subtitle tiny for WebVTT mains (PlayResY = video height) and huge
     /// for ASSA mains with a small PlayResY (issue #13425), so resample it to the
     /// target's scale first.
+    /// The secondary subtitle is shared between refreshes and is only ever read, so its
+    /// paragraphs are added by reference - except in SMPTE mode, where the stretch the main
+    /// subtitle already got has to apply to them too, and so goes onto a copy.
     /// </summary>
-    public static void AddSecondarySubtitle(Subtitle subtitle, Subtitle? subtitleSecondary, bool smpteMode = false)
+    public static void AddSecondarySubtitle(Subtitle subtitle, Subtitle? subtitleSecondary, bool smpteMode)
     {
         if (subtitleSecondary == null)
         {
@@ -77,29 +52,7 @@ public static class SecondarySubtitleMerger
         subtitle.Header = AdvancedSubStationAlpha.AddSsaStyle(style, subtitle.Header);
         foreach (var p in subtitleSecondary.Paragraphs)
         {
-            var startMs = p.StartTime.TotalMilliseconds;
-            if (startMs < 0)
-            {
-                startMs = 0;
-            }
-
-            var endMs = p.EndTime.TotalMilliseconds;
-            if (endMs <= startMs)
-            {
-                continue;
-            }
-
-            if (smpteMode)
-            {
-                startMs *= 1.001;
-                endMs *= 1.001;
-            }
-
-            subtitle.Paragraphs.Add(new Paragraph(p)
-            {
-                StartTime = { TotalMilliseconds = startMs },
-                EndTime = { TotalMilliseconds = endMs }
-            });
+            subtitle.Paragraphs.Add(smpteMode ? SmptePreviewStretch.Stretched(p) : p);
         }
     }
 

--- a/src/ui/Logic/Media/SmptePreviewStretch.cs
+++ b/src/ui/Logic/Media/SmptePreviewStretch.cs
@@ -1,0 +1,42 @@
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace Nikse.SubtitleEdit.Logic.Media;
+
+/// <summary>
+/// SMPTE preview timing: the subtitle's time codes count 30/24 frames per second while the
+/// video runs at 29.97/23.976, so everything handed to the player has to run 0.1 % slower
+/// to stay in sync with the picture. The factor and both ways of applying it live here so
+/// the mpv and VLC reloaders, and the secondary subtitle, cannot drift apart.
+/// </summary>
+public static class SmptePreviewStretch
+{
+    public const double Factor = 1.001;
+
+    /// <summary>
+    /// Stretches every paragraph in place. Only for a preview copy - the caller's live
+    /// subtitle must never see this.
+    /// </summary>
+    public static void Apply(Subtitle subtitle)
+    {
+        foreach (var paragraph in subtitle.Paragraphs)
+        {
+            Apply(paragraph);
+        }
+    }
+
+    public static void Apply(Paragraph paragraph)
+    {
+        paragraph.StartTime.TotalMilliseconds *= Factor;
+        paragraph.EndTime.TotalMilliseconds *= Factor;
+    }
+
+    /// <summary>
+    /// A stretched copy, for paragraphs that are shared and must stay untouched.
+    /// </summary>
+    public static Paragraph Stretched(Paragraph paragraph)
+    {
+        var copy = new Paragraph(paragraph, false);
+        Apply(copy);
+        return copy;
+    }
+}

--- a/src/ui/Logic/Media/VlcReloader.cs
+++ b/src/ui/Logic/Media/VlcReloader.cs
@@ -35,16 +35,7 @@ public class VlcReloader : IVlcReloader
         try
         {
             var uiFormatType = uiFormat.GetType();
-            subtitle = new Subtitle(subtitle, false);
-
-            if (SmpteMode)
-            {
-                foreach (var paragraph in subtitle.Paragraphs)
-                {
-                    paragraph.StartTime.TotalMilliseconds *= 1.001;
-                    paragraph.EndTime.TotalMilliseconds *= 1.001;
-                }
-            }
+            SecondarySubtitleMerger.PreparePreviewSubtitle(subtitle, SmpteMode);
 
             SubtitleFormat format = _assFormat;
             string text;
@@ -53,7 +44,7 @@ public class VlcReloader : IVlcReloader
                 // See MpvReloader - the furigana/bouten/vertical markup has to become positioned
                 // render lines before libass sees it (issue #13861, issue #14165).
                 subtitle = NetflixImsc11JapaneseToAss.ConvertToSubtitle(subtitle, VideoWidth, VideoHeight);
-                SecondarySubtitleMerger.AddSecondarySubtitle(subtitle, subtitleSecondary);
+                SecondarySubtitleMerger.AddSecondarySubtitle(subtitle, subtitleSecondary, SmpteMode);
                 text = subtitle.ToText(_assFormat);
             }
             else if (uiFormatType == typeof(WebVTT) || uiFormatType == typeof(WebVTTFileWithLineNumber))
@@ -62,7 +53,7 @@ public class VlcReloader : IVlcReloader
                 defaultStyle.BorderStyle = "3";
                 subtitle = new Subtitle(subtitle);
                 subtitle = WebVttToAssa.Convert(subtitle, defaultStyle, VideoWidth, VideoHeight);
-                SecondarySubtitleMerger.AddSecondarySubtitle(subtitle, subtitleSecondary);
+                SecondarySubtitleMerger.AddSecondarySubtitle(subtitle, subtitleSecondary, SmpteMode);
                 text = subtitle.ToText(_assFormat);
             }
             else
@@ -112,7 +103,7 @@ public class VlcReloader : IVlcReloader
                     SubtitlePositionToAssa.ApplyPositions(subtitle, oldSub.Header, usePositions);
                 }
 
-                SecondarySubtitleMerger.AddSecondarySubtitle(subtitle, subtitleSecondary);
+                SecondarySubtitleMerger.AddSecondarySubtitle(subtitle, subtitleSecondary, SmpteMode);
                 var hash = subtitle.GetFastHashCode(null);
                 if (hash != _mpvSubOldHash || string.IsNullOrEmpty(_mpvTextOld))
                 {

--- a/src/ui/Logic/Media/VlcReloader.cs
+++ b/src/ui/Logic/Media/VlcReloader.cs
@@ -35,7 +35,12 @@ public class VlcReloader : IVlcReloader
         try
         {
             var uiFormatType = uiFormat.GetType();
-            SecondarySubtitleMerger.PreparePreviewSubtitle(subtitle, SmpteMode);
+            subtitle = new Subtitle(subtitle, false);
+
+            if (SmpteMode)
+            {
+                SmptePreviewStretch.Apply(subtitle);
+            }
 
             SubtitleFormat format = _assFormat;
             string text;

--- a/tests/UI/Logic/Media/SmptePreviewStretchTests.cs
+++ b/tests/UI/Logic/Media/SmptePreviewStretchTests.cs
@@ -1,0 +1,73 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace UITests.Logic.Media;
+
+/// <summary>
+/// The SMPTE preview stretch used to be two copies of the same loop in the mpv and VLC
+/// reloaders, and the secondary subtitle got none of it, so it drifted 0.1 % against the
+/// main subtitle in SMPTE mode. One helper now serves all three.
+/// </summary>
+public class SmptePreviewStretchTests
+{
+    [Fact]
+    public void Apply_StretchesStartAndEndOfEveryParagraph()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("a", 1000, 2000));
+        subtitle.Paragraphs.Add(new Paragraph("b", 10000, 20000));
+
+        SmptePreviewStretch.Apply(subtitle);
+
+        Assert.Equal(1001, subtitle.Paragraphs[0].StartTime.TotalMilliseconds, 3);
+        Assert.Equal(2002, subtitle.Paragraphs[0].EndTime.TotalMilliseconds, 3);
+        Assert.Equal(10010, subtitle.Paragraphs[1].StartTime.TotalMilliseconds, 3);
+        Assert.Equal(20020, subtitle.Paragraphs[1].EndTime.TotalMilliseconds, 3);
+    }
+
+    [Fact]
+    public void Stretched_LeavesTheSourceParagraphUntouched()
+    {
+        var source = new Paragraph("shared", 1000, 2000) { Extra = "Secondary" };
+
+        var copy = SmptePreviewStretch.Stretched(source);
+
+        Assert.NotSame(source, copy);
+        Assert.Equal(1000, source.StartTime.TotalMilliseconds);
+        Assert.Equal(2000, source.EndTime.TotalMilliseconds);
+        Assert.Equal(1001, copy.StartTime.TotalMilliseconds, 3);
+        Assert.Equal(2002, copy.EndTime.TotalMilliseconds, 3);
+        Assert.Equal("Secondary", copy.Extra);
+        Assert.Equal("shared", copy.Text);
+    }
+
+    [Fact]
+    public void AddSecondarySubtitle_InSmpteMode_StretchesACopyAndKeepsTheSharedSecondaryIntact()
+    {
+        var main = new Subtitle();
+        var secondary = new Subtitle();
+        secondary.Paragraphs.Add(new Paragraph("second", 5000, 7000));
+
+        SecondarySubtitleMerger.AddSecondarySubtitle(main, secondary, smpteMode: true);
+
+        var added = Assert.Single(main.Paragraphs);
+        Assert.NotSame(secondary.Paragraphs[0], added);
+        Assert.Equal(5005, added.StartTime.TotalMilliseconds, 3);
+        Assert.Equal(7007, added.EndTime.TotalMilliseconds, 3);
+        Assert.Equal(5000, secondary.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(7000, secondary.Paragraphs[0].EndTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void AddSecondarySubtitle_WithoutSmpte_AddsTheParagraphsByReference()
+    {
+        var main = new Subtitle();
+        var secondary = new Subtitle();
+        secondary.Paragraphs.Add(new Paragraph("second", 5000, 7000));
+
+        SecondarySubtitleMerger.AddSecondarySubtitle(main, secondary, smpteMode: false);
+
+        var added = Assert.Single(main.Paragraphs);
+        Assert.Same(secondary.Paragraphs[0], added);
+    }
+}


### PR DESCRIPTION
### Summary
The 0.1 % SMPTE stretch the mpv and VLC preview reloaders each carried as their own loop now lives in one helper, `SmptePreviewStretch`, and the secondary subtitle gets it too. Without SMPTE the secondary paragraphs are still added by reference, so a normal refresh allocates nothing extra; in SMPTE mode they go in as stretched copies so the shared secondary stays untouched.

### Reviewed and reworked
The original version also removed zero/negative-duration paragraphs and clamped negative start times before the preview. That was verified not to change what libass shows: a zero-duration event never matches the render window, and libass parses the negative time codes SE writes as real negative times, so a line from -0.5 s to 1.5 s already shows from 0 s. Rendered through mpv/libass 0.17.4 with and without such events; identical frames. That filter is dropped.

The original also removed the deep copy at the top of `VlcReloader.RefreshVlc`, which would have stretched or filtered the live working subtitle on every VLC refresh. The copy is back.

### Tests
`SmptePreviewStretchTests`: the stretch itself, the copy leaving the source untouched, and the secondary merge with and without SMPTE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
