### PR TITLE
feat(video): add open recent video menu option

### DIFF
--- a/docs/features/video-player.md
+++ b/docs/features/video-player.md
@@ -11,6 +11,7 @@ Subtitle Edit includes an integrated video player for previewing subtitles with 
 - **Shortcut:** Configurable via Options → Shortcuts
 - **Drag and drop** a video file onto the Subtitle Edit window
 - You can also open video from a URL: **Video → Open video from URL...**
+- Recently opened videos are listed under **Video → Open recent video**; the submenu's **Clear recent videos** item empties the list
 
 ## Playback Controls
 

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -2545,6 +2545,8 @@
     "openSecondarySubtitleOnVideoPlayerDotDotDot": "Open second subtitle file...",
     "openSecondarySubtitleOnVideoPlayer": "Second subtitle file (on video player)",
     "removeSecondarySubtitleOnVideoPlayer": "Remove second subtitle file",
+    "openRecentVideo": "Open recent video",
+    "clearRecentVideos": "Clear recent videos",
     "cutVideoTitle": "Cut video",
     "cutVideoDotDotDot": "Cut video...",
     "embedSubtitlesDotDotDot": "Add/remove embedded subtitles...",

--- a/src/ui/Features/Main/Layout/InitMenu.cs
+++ b/src/ui/Features/Main/Layout/InitMenu.cs
@@ -14,6 +14,7 @@ using Nikse.SubtitleEdit.Logic.ValueConverters;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Windows.Input;
 
 namespace Nikse.SubtitleEdit.Features.Main.Layout;
 
@@ -32,7 +33,13 @@ public static class InitMenu
             Command = vm.CommandFileReopenCommand,
         };
 
+        vm.MenuRecentVideos = new MenuItem
+        {
+            Header = Se.Language.Video.OpenRecentVideo,
+        };
+
         UpdateRecentFiles(vm);
+        UpdateRecentVideos(vm);
 
         var menu = vm.Menu;
         menu.DataContext = vm;
@@ -716,6 +723,7 @@ public static class InitMenu
                     Header = l.OpenVideoFromUrl,
                     Command = vm.ShowVideoOpenFromUrlCommand,
                 },
+                vm.MenuRecentVideos,
                 new MenuItem
                 {
                     Header = l.CloseVideoFile,
@@ -1053,16 +1061,63 @@ public static class InitMenu
         menu.Items.Add(menuItemSsaTools);
     }
 
+    private static void PopulateRecentMenu<T>(
+        MenuItem? menu,
+        IReadOnlyList<T> items,
+        Func<T, (string Header, string ToolTip, ICommand Command, object? Parameter)> itemFactory,
+        string clearHeader,
+        ICommand clearCommand)
+    {
+        if (menu == null)
+        {
+            return;
+        }
+
+        menu.Items.Clear();
+        if (items.Count > 0)
+        {
+            foreach (var item in items)
+            {
+                var (header, tooltip, command, parameter) = itemFactory(item);
+                var menuItem = new MenuItem
+                {
+                    Header = new TextBlock
+                    {
+                        Text = header,
+                        TextTrimming = TextTrimming.PrefixCharacterEllipsis,
+                        MaxWidth = 600,
+                    },
+                    Command = command,
+                    CommandParameter = parameter,
+                    [ToolTip.TipProperty] = tooltip,
+                };
+                menu.Items.Add(menuItem);
+            }
+
+            menu.Items.Add(new Separator());
+            var clearItem = new MenuItem
+            {
+                Header = clearHeader,
+                Command = clearCommand,
+            };
+            menu.Items.Add(clearItem);
+            menu.IsVisible = true;
+        }
+        else
+        {
+            menu.IsVisible = false;
+        }
+    }
+
     public static void UpdateRecentFiles(MainViewModel vm)
     {
         var files = Se.Settings.File.RecentFiles.Where(p => !string.IsNullOrEmpty(p.SubtitleFileName) && System.IO.File.Exists(p.SubtitleFileName)).ToList();
-        vm.MenuReopen.Items.Clear();
-        if (files.Count > 0)
-        {
-            foreach (var file in files)
+        PopulateRecentMenu(
+            vm.MenuReopen,
+            files,
+            file =>
             {
                 var header = file.SubtitleFileName;
-
                 if (!string.IsNullOrEmpty(file.SubtitleFileNameOriginal) && System.IO.File.Exists(file.SubtitleFileNameOriginal))
                 {
                     header += " + ";
@@ -1075,39 +1130,25 @@ public static class InitMenu
                         header += file.SubtitleFileNameOriginal;
                     }
                 }
+                return (header, header, vm.CommandFileReopenCommand, file);
+            },
+            Se.Language.Main.Menu.ClearRecentFiles,
+            vm.CommandFileClearRecentFilesCommand);
+    }
 
-                // Trim the directory prefix with "…" when the path is too long so
-                // the filename stays visible. Full path is still available via tooltip.
-                var item = new MenuItem
-                {
-                    Header = new TextBlock
-                    {
-                        Text = header,
-                        TextTrimming = TextTrimming.PrefixCharacterEllipsis,
-                        MaxWidth = 600,
-                    },
-                    Command = vm.CommandFileReopenCommand,
-                    CommandParameter = file,
-                    [ToolTip.TipProperty] = header,
-                };
-                vm.MenuReopen.Items.Add(item);
-            }
+    public static void UpdateRecentVideos(MainViewModel vm)
+    {
+        var files = Se.Settings.Video.RecentFiles
+            .Where(f => !string.IsNullOrWhiteSpace(f))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
 
-            vm.MenuReopen.Items.Add(new Separator());
-
-            var clearItem = new MenuItem
-            {
-                Header = Se.Language.Main.Menu.ClearRecentFiles,
-                Command = vm.CommandFileClearRecentFilesCommand,
-            };
-            vm.MenuReopen.Items.Add(clearItem);
-
-            vm.MenuReopen.IsVisible = true;
-        }
-        else
-        {
-            vm.MenuReopen.IsVisible = false;
-        }
+        PopulateRecentMenu(
+            vm.MenuRecentVideos,
+            files,
+            file => (file, file, vm.CommandVideoReopenCommand, file),
+            Se.Language.Video.ClearRecentVideos,
+            vm.CommandVideoClearRecentFilesCommand);
     }
 
     /// <summary>

--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -54,6 +54,7 @@ public static class InitNativeMacMenu
         public PropertyChangedEventHandler? Handler;
 
         public NativeMenuItem? ReopenItem;
+        public NativeMenuItem? RecentVideosItem;
         public NativeMenuItem? PluginsItem;
         public NativeMenuItem? AudioTracksItem;
         public NativeMenuItem? WindowListItem;
@@ -336,6 +337,10 @@ public static class InitNativeMacMenu
         var videoItems = new NativeMenu();
         videoItems.Items.Add(Item(Clean(l.OpenVideo), v => v.CommandVideoOpenCommand));
         videoItems.Items.Add(Item(Clean(l.OpenVideoFromUrl), v => v.ShowVideoOpenFromUrlCommand));
+
+        state.RecentVideosItem = new NativeMenuItem(Clean(Se.Language.Video.OpenRecentVideo)) { Menu = new NativeMenu() };
+        videoItems.Items.Add(state.RecentVideosItem);
+
         videoItems.Items.Add(Item(Clean(l.CloseVideoFile), v => v.CommandVideoCloseCommand));
 
         // Same spot and wording as SE4's Video menu, so it can be found by anyone
@@ -641,6 +646,7 @@ public static class InitNativeMacMenu
         state.Vm = vm;
 
         vm.NativeMenuReopen = state.ReopenItem;
+        vm.NativeMenuRecentVideos = state.RecentVideosItem;
         vm.NativeMenuPlugins = state.PluginsItem;
         vm.NativeMenuAudioTracks = state.AudioTracksItem;
 
@@ -687,56 +693,94 @@ public static class InitNativeMacMenu
         vm.PropertyChanged += state.Handler;
 
         UpdateRecentFiles(vm);
+        UpdateRecentVideos(vm);
         UpdatePluginsMenu(vm);
     }
 
     // ── Dynamic submenu updaters ──────────────────────────────────────────────
 
-    public static void UpdateRecentFiles(MainViewModel vm)
+    private static void PopulateRecentNativeMenu<T>(
+        NativeMenuItem? parentItem,
+        IReadOnlyList<T> items,
+        Func<T, (string Header, Action ClickAction)> itemFactory,
+        string clearHeader,
+        Action clearAction)
     {
-        if (vm.NativeMenuReopen?.Menu is not NativeMenu menu)
+        if (parentItem?.Menu is not NativeMenu menu)
         {
             return;
         }
 
         menu.Items.Clear();
+        parentItem.IsEnabled = items.Count > 0;
 
-        var files = Se.Settings.File.RecentFiles
-            .Where(p => !string.IsNullOrEmpty(p.SubtitleFileName) && System.IO.File.Exists(p.SubtitleFileName))
-            .ToList();
-
-        vm.NativeMenuReopen.IsEnabled = files.Count > 0;
-
-        if (files.Count == 0)
+        if (items.Count == 0)
         {
             return;
         }
 
-        foreach (var file in files)
+        foreach (var item in items)
         {
-            var header = file.SubtitleFileName ?? string.Empty;
-            if (!string.IsNullOrEmpty(file.SubtitleFileNameOriginal) && System.IO.File.Exists(file.SubtitleFileNameOriginal))
-            {
-                header += " + ";
-                header += System.IO.Path.GetDirectoryName(file.SubtitleFileName) == System.IO.Path.GetDirectoryName(file.SubtitleFileNameOriginal)
-                    ? System.IO.Path.GetFileName(file.SubtitleFileNameOriginal)
-                    : file.SubtitleFileNameOriginal;
-            }
+            var (header, clickAction) = itemFactory(item);
             if (header.Length > 80)
             {
                 header = "…" + header[^77..];
             }
 
             var recentItem = new NativeMenuItem(header);
-            var captured = file;
-            recentItem.Click += (_, _) => vm.CommandFileReopenCommand.Execute(captured);
+            recentItem.Click += (_, _) => clickAction();
             menu.Items.Add(recentItem);
         }
 
         menu.Items.Add(new NativeMenuItemSeparator());
-        var clearItem = new NativeMenuItem(Clean(Se.Language.Main.Menu.ClearRecentFiles));
-        clearItem.Click += (_, _) => vm.CommandFileClearRecentFilesCommand.Execute(null);
+        var clearItem = new NativeMenuItem(Clean(clearHeader));
+        clearItem.Click += (_, _) => clearAction();
         menu.Items.Add(clearItem);
+    }
+
+    public static void UpdateRecentFiles(MainViewModel vm)
+    {
+        var files = Se.Settings.File.RecentFiles
+            .Where(p => !string.IsNullOrEmpty(p.SubtitleFileName) && System.IO.File.Exists(p.SubtitleFileName))
+            .ToList();
+
+        PopulateRecentNativeMenu(
+            vm.NativeMenuReopen,
+            files,
+            file =>
+            {
+                var header = file.SubtitleFileName ?? string.Empty;
+                if (!string.IsNullOrEmpty(file.SubtitleFileNameOriginal) && System.IO.File.Exists(file.SubtitleFileNameOriginal))
+                {
+                    header += " + ";
+                    header += System.IO.Path.GetDirectoryName(file.SubtitleFileName) == System.IO.Path.GetDirectoryName(file.SubtitleFileNameOriginal)
+                        ? System.IO.Path.GetFileName(file.SubtitleFileNameOriginal)
+                        : file.SubtitleFileNameOriginal;
+                }
+                var captured = file;
+                return (header, () => vm.CommandFileReopenCommand.Execute(captured));
+            },
+            Se.Language.Main.Menu.ClearRecentFiles,
+            () => vm.CommandFileClearRecentFilesCommand.Execute(null));
+    }
+
+    public static void UpdateRecentVideos(MainViewModel vm)
+    {
+        var files = Se.Settings.Video.RecentFiles
+            .Where(f => !string.IsNullOrWhiteSpace(f))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        PopulateRecentNativeMenu(
+            vm.NativeMenuRecentVideos,
+            files,
+            file =>
+            {
+                var captured = file;
+                return (captured, () => vm.CommandVideoReopenCommand.Execute(captured));
+            },
+            Se.Language.Video.ClearRecentVideos,
+            () => vm.CommandVideoClearRecentFilesCommand.Execute(null));
     }
 
     public static void UpdatePluginsMenu(MainViewModel vm)

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -8373,7 +8373,12 @@ public partial class MainViewModel :
         }
         else
         {
-            await MessageBox.Show(Window!, Se.Language.General.Error, videoFileName, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            // Entries are only validated on click (no File.Exists sweep on every menu rebuild),
+            // so a video that has since been moved or deleted is pruned from the list here.
+            Se.Settings.Video.RecentFiles.RemoveAll(f => string.Equals(f, videoFileName, StringComparison.OrdinalIgnoreCase));
+            Se.SaveSettings();
+            UpdateRecentVideoMenus();
+            await MessageBox.Show(Window!, Se.Language.General.Error, string.Format(Se.Language.General.XNotFound, videoFileName), MessageBoxButtons.OK, MessageBoxIcon.Warning);
         }
         _shortcutManager.ClearKeys();
     }
@@ -8383,12 +8388,17 @@ public partial class MainViewModel :
     {
         Se.Settings.Video.RecentFiles.Clear();
         Se.SaveSettings();
+        UpdateRecentVideoMenus();
+        _shortcutManager.ClearKeys();
+    }
+
+    private void UpdateRecentVideoMenus()
+    {
         InitMenu.UpdateRecentVideos(this);
         if (OperatingSystem.IsMacOS())
         {
             Layout.InitNativeMacMenu.UpdateRecentVideos(this);
         }
-        _shortcutManager.ClearKeys();
     }
 
     [RelayCommand]
@@ -24723,11 +24733,7 @@ public partial class MainViewModel :
             Se.Settings.Video.RecentFiles.RemoveAt(Se.Settings.Video.RecentFiles.Count - 1);
         }
 
-        InitMenu.UpdateRecentVideos(this);
-        if (OperatingSystem.IsMacOS())
-        {
-            Layout.InitNativeMacMenu.UpdateRecentVideos(this);
-        }
+        UpdateRecentVideoMenus();
     }
 
     private void LoadWaveformAndSpectrogram(string videoFileName)

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -585,8 +585,10 @@ public partial class MainViewModel :
     public MainView? MainView { get; set; }
     public TextBlock StatusTextLeftLabel { get; set; }
     public MenuItem MenuReopen { get; set; }
+    public MenuItem? MenuRecentVideos { get; set; }
     public MenuItem MenuPlugins { get; set; }
     public NativeMenuItem? NativeMenuReopen { get; set; }
+    public NativeMenuItem? NativeMenuRecentVideos { get; set; }
     public NativeMenuItem? NativeMenuPlugins { get; set; }
     public NativeMenuItem? NativeMenuAudioTracks { get; set; }
     public AudioVisualizer? AudioVisualizer { get; set; }
@@ -8354,6 +8356,38 @@ public partial class MainViewModel :
             }
         }
 
+        _shortcutManager.ClearKeys();
+    }
+
+    [RelayCommand]
+    private async Task CommandVideoReopen(string videoFileName)
+    {
+        if (string.IsNullOrEmpty(videoFileName))
+        {
+            return;
+        }
+
+        if (File.Exists(videoFileName))
+        {
+            await VideoOpenFile(videoFileName);
+        }
+        else
+        {
+            await MessageBox.Show(Window!, Se.Language.General.Error, videoFileName, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+        }
+        _shortcutManager.ClearKeys();
+    }
+
+    [RelayCommand]
+    private void CommandVideoClearRecentFiles()
+    {
+        Se.Settings.Video.RecentFiles.Clear();
+        Se.SaveSettings();
+        InitMenu.UpdateRecentVideos(this);
+        if (OperatingSystem.IsMacOS())
+        {
+            Layout.InitNativeMacMenu.UpdateRecentVideos(this);
+        }
         _shortcutManager.ClearKeys();
     }
 
@@ -24643,6 +24677,11 @@ public partial class MainViewModel :
             }
         }
 
+        if (vp.VideoPlayer != null && vp.VideoPlayer.Duration > 0)
+        {
+            AddToRecentVideoFiles(videoFileName);
+        }
+
         // Persist the media association as soon as the file opens so reopening this subtitle
         // reloads the same video/audio even if the app is force-quit before OnClosing runs.
         // Guarded by a known subtitle name so opening media without a subtitle doesn't create
@@ -24651,6 +24690,10 @@ public partial class MainViewModel :
         {
             AddToRecentFiles(false);
         }
+        else
+        {
+            Se.SaveSettings();
+        }
 
         var _ = Task.Run(() =>
         {
@@ -24658,6 +24701,33 @@ public partial class MainViewModel :
             GetMediaInformation(videoFileName);
             LoadAudioTrackMenuItems();
         });
+    }
+
+    private void AddToRecentVideoFiles(string videoFileName)
+    {
+        if (string.IsNullOrEmpty(videoFileName) || IsValidUrl(videoFileName))
+        {
+            return;
+        }
+
+        var vp = GetVideoPlayerControl();
+        if (vp?.VideoPlayer == null || vp.VideoPlayer.Duration <= 0)
+        {
+            return;
+        }
+
+        Se.Settings.Video.RecentFiles.RemoveAll(f => string.Equals(f, videoFileName, StringComparison.OrdinalIgnoreCase));
+        Se.Settings.Video.RecentFiles.Insert(0, videoFileName);
+        while (Se.Settings.Video.RecentFiles.Count > Se.Settings.Video.RecentFilesMaximum)
+        {
+            Se.Settings.Video.RecentFiles.RemoveAt(Se.Settings.Video.RecentFiles.Count - 1);
+        }
+
+        InitMenu.UpdateRecentVideos(this);
+        if (OperatingSystem.IsMacOS())
+        {
+            Layout.InitNativeMacMenu.UpdateRecentVideos(this);
+        }
     }
 
     private void LoadWaveformAndSpectrogram(string videoFileName)

--- a/src/ui/Features/Options/Settings/SettingsImportExport/SettingsImportExportViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsImportExport/SettingsImportExportViewModel.cs
@@ -369,8 +369,21 @@ public partial class SettingsImportExportViewModel : ObservableObject
 
         // Video was never assigned, so an "all settings" file carried a default Video block
         // that the importer applied - silently resetting the player choice, the mpv preview
-        // style and the custom seek amounts.
-        exportData.Video = ExportImportAll ? currentSettings.Video : null!;
+        // style and the custom seek amounts. Exclude RecentFiles so local recent video paths are not exported.
+        if (ExportImportAll && currentSettings.Video != null)
+        {
+            var videoJson = JsonSerializer.Serialize(currentSettings.Video);
+            var videoExport = JsonSerializer.Deserialize<SeVideo>(videoJson);
+            if (videoExport != null)
+            {
+                videoExport.RecentFiles.Clear();
+                exportData.Video = videoExport;
+            }
+        }
+        else
+        {
+            exportData.Video = null!;
+        }
 
         var json = JsonSerializer.Serialize(exportData, new JsonSerializerOptions { WriteIndented = true });
         var jsonWithSource = InjectExportMarkers(json, GetCurrentOsName(), exportShortcuts);
@@ -433,7 +446,9 @@ public partial class SettingsImportExportViewModel : ObservableObject
         {
             if (importData.Video != null)
             {
+                var existingRecentFiles = Se.Settings.Video.RecentFiles;
                 Se.Settings.Video = importData.Video;
+                Se.Settings.Video.RecentFiles = existingRecentFiles;
             }
 
             if (importData.Tools != null)

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -2649,6 +2649,7 @@ public partial class SettingsViewModel : ObservableObject
             if (result.ResetRecentFiles)
             {
                 Se.Settings.File.RecentFiles = new List<RecentFile>();
+                Se.Settings.Video.RecentFiles = new List<string>();
             }
 
             if (result.ResetWindowPositionAndSize)

--- a/src/ui/Logic/Config/Language/Video/LanguageVideo.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageVideo.cs
@@ -20,6 +20,8 @@ public class LanguageVideo
     public string OpenSecondarySubtitleOnVideoPlayerDotDotDot { get; set; }
     public string OpenSecondarySubtitleOnVideoPlayer { get; set; }
     public string RemoveSecondarySubtitleOnVideoPlayer { get; set; }
+    public string OpenRecentVideo { get; set; }
+    public string ClearRecentVideos { get; set; }
     public string CutVideoTitle { get; set; }
     public string CutVideoDotDotDot { get; set; }
     public string EmbedSubtitlesDotDotDot { get; set; }
@@ -114,6 +116,8 @@ public class LanguageVideo
         OpenSecondarySubtitleOnVideoPlayer = "Second subtitle file (on video player)";
         OpenSecondarySubtitleOnVideoPlayerDotDotDot = "Open second subtitle file...";
         RemoveSecondarySubtitleOnVideoPlayer = "Remove second subtitle file";
+        OpenRecentVideo = "Open recent video";
+        ClearRecentVideos = "Clear recent videos";
         CutVideoTitle = "Cut video";
         CutVideoDotDotDot = "Cut video...";
         EmbedSubtitlesDotDotDot = "Add/remove embedded subtitles...";

--- a/src/ui/Logic/Config/SeVideo.cs
+++ b/src/ui/Logic/Config/SeVideo.cs
@@ -1,6 +1,7 @@
 ﻿using Avalonia.Media;
 using Nikse.SubtitleEdit.Features.Assa;
 using System;
+using System.Collections.Generic;
 
 namespace Nikse.SubtitleEdit.Logic.Config;
 
@@ -17,6 +18,8 @@ public class SeVideo
     public bool FullscreenHideControls { get; set; }
     public bool AutoOpen { get; set; }
     public bool OpenSearchParentFolder { get; set; }
+    public int RecentFilesMaximum { get; set; } = 25;
+    public List<string> RecentFiles { get; set; } = new();
     public string CutType { get; set; }
     public string ShowChangesFFmpegArguments { get; set; }
     public bool VideoPlayerDisplayTimeLeft { get; set; }


### PR DESCRIPTION
### Summary of Changes
Adds a dedicated "Open recent video" submenu to the **Video** menu (supported on standard Avalonia and native macOS menu bars).

### Key Details & Feedback Addressed
1. **Gated on successful video open**: Recent video entry is recorded only when `vp.VideoPlayer.Duration > 0`, preventing failed loads or dropped non-media files from polluting the menu.
2. **Saved on Clear**: `CommandVideoClearRecentFiles` calls `Se.SaveSettings()` immediately.
3. **Settings Import / Export isolation**: Excluded `SeVideo.RecentFiles` in `SettingsImportExportViewModel` during export and preserved local recent files on import (so machine-specific video paths are not exported or overwritten).
4. **Options > Reset**: Added `Se.Settings.Video.RecentFiles = new List<string>()` to "Reset recent files" in `SettingsViewModel`.
5. **No duplicate saves or dead URL branches**: Removed redundant `SaveSettings()` calls in `VideoOpenFile` and removed unreachable URL branches in the recent video menu builders (kept `IsValidUrl` private).
6. **No UI freeze on dead paths**: Avoided blocking `File.Exists` sweeps across up to 25 paths on the UI thread; existence is validated on-demand when clicked in `CommandVideoReopen`.
7. **Deduplicated menu helpers**: Added shared `PopulateRecentMenu` and `PopulateRecentNativeMenu` helpers in `InitMenu.cs` and `InitNativeMacMenu.cs`.
