### PR TITLE
TTS: per-line voice cloning on the audio.cpp engines (IndexTTS 2.5, Higgs, Fish)

### DIFF
--- a/docs/features/text-to-speech.md
+++ b/docs/features/text-to-speech.md
@@ -106,7 +106,7 @@ Notes on picking one:
 - **Highest output rate:** VoxCPM2 and dots.tts at 48 kHz, then Zonos at 44.1 kHz.
 - **MOSS-TTS is by far the largest** because its Qwen3-8B backbone needs a ~3.5 GB codec companion on top of the backbone quant. Check free disk space before selecting it.
 - Quantized engines follow the same rule as the speech-to-text models: `Q4_K` is the small fast default, `Q8_0` is close to full precision, and `F16` is rarely worth the extra gigabytes.
-- **Most of the CrispASR engines load their reference voice at server start**, so switching voice reloads the model. The exceptions are **Pocket TTS** (per-request reference) and **Qwen3 TTS** with the Voice clone model — those, plus the standalone OmniVoice TTS engine, are what [Clone From Video (Voice of Each Line)](#clone-from-video-voice-of-each-line) can use.
+- **Most of the CrispASR engines load their reference voice at server start**, so switching voice reloads the model. The exceptions are **Pocket TTS** (per-request reference) and **Qwen3 TTS** with the Voice clone model — those, the three audio.cpp engines (**IndexTTS 2.5**, **Higgs Audio v3**, **Fish Audio S2 Pro**) and the standalone OmniVoice TTS engine are what [Clone From Video (Voice of Each Line)](#clone-from-video-voice-of-each-line) can use.
 
 ## Engine Settings
 
@@ -163,7 +163,7 @@ For dubbing a video with several speakers there is a faster way than cloning eac
 
 Before generating, Subtitle Edit cuts one short reference clip per line out of the video's audio. Lines shorter than about three seconds are grown into the silence around them, but never into the neighbouring line — a reference with two speakers in it would clone the wrong person.
 
-- **Supported engines:** OmniVoice TTS, Pocket TTS (CrispASR), and Qwen3 TTS (CrispASR) with the Voice clone model. The entry only appears for engines that accept a reference for each line; engines that load their reference when their server starts would have to reload the model for every line.
+- **Supported engines:** OmniVoice TTS, Pocket TTS (CrispASR), Qwen3 TTS (CrispASR) with the Voice clone model, and the audio.cpp engines IndexTTS 2.5, Higgs Audio v3 and Fish Audio S2 Pro. The entry only appears for engines that accept a reference for each line; engines that load their reference when their server starts would have to reload the model for every line.
 - **Reference text:** if you have the original subtitle loaded next to the translation, its lines are used as the transcript of the clips — that is what the video actually says, and it makes cloning noticeably better. Without an original loaded, the line's own text is used.
 - **Test voice** previews the clone taken from the longest line of the subtitle.
 - Quality depends on the source audio. Loud music or two people talking over each other in a line makes that line's clone worse. Longer subtitle lines clone better than very short ones, so a subtitle segmented into full sentences gives the best result.

--- a/src/ui/Features/Video/TextToSpeech/Engines/FishTtsAudioCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/FishTtsAudioCpp.cs
@@ -26,7 +26,8 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 /// output.
 ///
 /// Like the other audio.cpp engines, the server honours a per-request <c>voice_ref</c>, so
-/// switching voice does NOT restart the server — only a model or backend change does. The
+/// switching voice does NOT restart the server — only a model or backend change does — which
+/// is also what makes per-line cloning ("Clone from video") free here. The
 /// model auto-handles the language of the input text, so there is no language combo. A
 /// <c>.txt</c> sidecar next to the reference WAV (the transcript convention the other cloning
 /// engines share) is passed as <c>reference_text</c>, which improves clone fidelity but is
@@ -36,7 +37,7 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 /// the Fish Audio Research License (research and non-commercial), which has to be accepted by
 /// the user before the first download — see <see cref="IsLicenseAccepted"/>.
 /// </summary>
-public class FishTtsAudioCpp : ITtsEngine
+public class FishTtsAudioCpp : ITtsEngine, IPerLineCloneEngine
 {
     public string Name => "Fish Audio S2 Pro (audio.cpp)";
     public string Description => "Fish Audio S2 Pro voice cloning in 80+ languages, via audio.cpp";
@@ -46,7 +47,7 @@ public class FishTtsAudioCpp : ITtsEngine
     public bool HasModel => true;
     public bool HasKeyFile => false;
     public bool SupportsVoiceCloning => true;
-    public bool SupportsPerLineVoiceCloning => false;
+    public bool SupportsPerLineVoiceCloning => true;
 
     // Q8_0 is the default: same 44.1 kHz output as BF16 at 3.6 GB less on disk.
     public const string ModelKeyQ8_0 = "Q8_0 (~5.9 GB)";
@@ -348,6 +349,33 @@ public class FishTtsAudioCpp : ITtsEngine
 
     public Task<Voice[]> RefreshVoices(string language, CancellationToken cancellationToken) =>
         GetVoices(language);
+
+    /// <summary>
+    /// <see cref="IPerLineCloneEngine"/>: the server takes <c>voice_ref</c> as a path per request,
+    /// so the voice simply points at the cut clip - nothing is staged into this engine's own
+    /// folders. audio.cpp resamples the reference itself, so the 24 kHz clip is used as cut.
+    /// S2 Pro refuses to clone without <c>reference_text</c> (see <see cref="Speak"/>), so a clip
+    /// with no transcript beside it is no reference at all: null, and the caller falls back to
+    /// an ordinary voice for that line instead of the run failing on it.
+    /// </summary>
+    public Voice? MakePerLineCloneVoice(string clipFileName, string voiceName) =>
+        string.IsNullOrWhiteSpace(ChatterboxTtsCpp.TryReadReferenceTranscript(clipFileName))
+            ? null
+            : new Voice(new IndexTtsVoice(voiceName, clipFileName));
+
+    /// <summary>The clip's own path, which is exactly what the voice carries.</summary>
+    public string? GetPerLineReferenceClip(Voice voice) =>
+        voice.EngineVoice is IndexTtsVoice indexVoice && !string.IsNullOrEmpty(indexVoice.FilePath)
+            ? indexVoice.FilePath
+            : null;
+
+    /// <summary>
+    /// <see cref="IPerLineCloneEngine"/>: nothing is ever staged (the voice points straight at
+    /// the clip), so there is nothing to clear between runs.
+    /// </summary>
+    public void ResetStagedPerLineReferences()
+    {
+    }
 
     public async Task<TtsResult> Speak(
         string text,

--- a/src/ui/Features/Video/TextToSpeech/Engines/HiggsTtsAudioCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/HiggsTtsAudioCpp.cs
@@ -26,7 +26,8 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 /// emotion, style and prosody through the text itself. 24 kHz output.
 ///
 /// Like the IndexTTS 2.5 engine, the server honours a per-request <c>voice_ref</c>, so
-/// switching voice does NOT restart the server — only a model or backend change does. The
+/// switching voice does NOT restart the server — only a model or backend change does — which
+/// is also what makes per-line cloning ("Clone from video") free here. The
 /// model auto-detects the language of the input text, so there is no language combo. A
 /// <c>.txt</c> sidecar next to the reference WAV (the transcript convention the other cloning
 /// engines share) is passed as <c>reference_text</c>, which improves clone fidelity but is
@@ -36,7 +37,7 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 /// under Boson AI's research and non-commercial licence, which has to be accepted by the user
 /// before the first download — see <see cref="IsLicenseAccepted"/>.
 /// </summary>
-public class HiggsTtsAudioCpp : ITtsEngine
+public class HiggsTtsAudioCpp : ITtsEngine, IPerLineCloneEngine
 {
     public string Name => "Higgs Audio v3 (audio.cpp)";
     public string Description => "Higgs Audio v3 (Boson AI) voice cloning in 100+ languages, via audio.cpp";
@@ -46,7 +47,7 @@ public class HiggsTtsAudioCpp : ITtsEngine
     public bool HasModel => true;
     public bool HasKeyFile => false;
     public bool SupportsVoiceCloning => true;
-    public bool SupportsPerLineVoiceCloning => false;
+    public bool SupportsPerLineVoiceCloning => true;
 
     // Q8_0 is the default: same 24 kHz output as BF16 at 3.2 GB less on disk.
     public const string ModelKeyQ8_0 = "Q8_0 (~4.7 GB)";
@@ -349,6 +350,28 @@ public class HiggsTtsAudioCpp : ITtsEngine
 
     public Task<Voice[]> RefreshVoices(string language, CancellationToken cancellationToken) =>
         GetVoices(language);
+
+    /// <summary>
+    /// <see cref="IPerLineCloneEngine"/>: the server takes <c>voice_ref</c> as a path per request,
+    /// so the voice simply points at the cut clip - nothing is staged into this engine's own
+    /// folders. audio.cpp resamples the reference itself, so the 24 kHz clip is used as cut.
+    /// </summary>
+    public Voice? MakePerLineCloneVoice(string clipFileName, string voiceName) =>
+        new Voice(new IndexTtsVoice(voiceName, clipFileName));
+
+    /// <summary>The clip's own path, which is exactly what the voice carries.</summary>
+    public string? GetPerLineReferenceClip(Voice voice) =>
+        voice.EngineVoice is IndexTtsVoice indexVoice && !string.IsNullOrEmpty(indexVoice.FilePath)
+            ? indexVoice.FilePath
+            : null;
+
+    /// <summary>
+    /// <see cref="IPerLineCloneEngine"/>: nothing is ever staged (the voice points straight at
+    /// the clip), so there is nothing to clear between runs.
+    /// </summary>
+    public void ResetStagedPerLineReferences()
+    {
+    }
 
     public async Task<TtsResult> Speak(
         string text,

--- a/src/ui/Features/Video/TextToSpeech/Engines/IndexTts25AudioCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/IndexTts25AudioCpp.cs
@@ -25,7 +25,8 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 ///
 /// Unlike <see cref="IndexTtsCrispAsr"/> (IndexTTS-1.5 via CrispASR), audio.cpp's server
 /// honours a per-request <c>voice_ref</c>, so switching voice does NOT restart the server —
-/// only a model or backend change does. Everything else follows the same server-mode shape:
+/// only a model or backend change does — which is also what makes per-line cloning ("Clone
+/// from video") free here. Everything else follows the same server-mode shape:
 /// one persistent process on a loopback port, OpenAI-style POST /v1/audio/speech.
 ///
 /// The model is a single self-describing GGUF (the package spec is embedded), so no sidecar
@@ -35,7 +36,7 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 /// under the bilibili Model Use License, which is not OSI-approved and has to be accepted by
 /// the user before the first download — see <see cref="IsLicenseAccepted"/>.
 /// </summary>
-public class IndexTts25AudioCpp : ITtsEngine
+public class IndexTts25AudioCpp : ITtsEngine, IPerLineCloneEngine
 {
     public string Name => "IndexTTS 2.5 (audio.cpp)";
     public string Description => "IndexTTS-2.5 (Bilibili / IndexTeam) voice cloning in 5 languages, via audio.cpp";
@@ -45,7 +46,7 @@ public class IndexTts25AudioCpp : ITtsEngine
     public bool HasModel => true;
     public bool HasKeyFile => false;
     public bool SupportsVoiceCloning => true;
-    public bool SupportsPerLineVoiceCloning => false;
+    public bool SupportsPerLineVoiceCloning => true;
 
     // The Q8_0 GGUF is the default: same 22.05 kHz output as F16 at 1 GB less on disk. The
     // "orig" dtype build (7.3 GB) is deliberately not offered — it is a debugging artifact.
@@ -323,6 +324,28 @@ public class IndexTts25AudioCpp : ITtsEngine
 
     public Task<Voice[]> RefreshVoices(string language, CancellationToken cancellationToken) =>
         GetVoices(language);
+
+    /// <summary>
+    /// <see cref="IPerLineCloneEngine"/>: the server takes <c>voice_ref</c> as a path per request,
+    /// so the voice simply points at the cut clip - nothing is staged into this engine's own
+    /// folders. audio.cpp resamples the reference itself, so the 24 kHz clip is used as cut.
+    /// </summary>
+    public Voice? MakePerLineCloneVoice(string clipFileName, string voiceName) =>
+        new Voice(new IndexTtsVoice(voiceName, clipFileName));
+
+    /// <summary>The clip's own path, which is exactly what the voice carries.</summary>
+    public string? GetPerLineReferenceClip(Voice voice) =>
+        voice.EngineVoice is IndexTtsVoice indexVoice && !string.IsNullOrEmpty(indexVoice.FilePath)
+            ? indexVoice.FilePath
+            : null;
+
+    /// <summary>
+    /// <see cref="IPerLineCloneEngine"/>: nothing is ever staged (the voice points straight at
+    /// the clip), so there is nothing to clear between runs.
+    /// </summary>
+    public void ResetStagedPerLineReferences()
+    {
+    }
 
     public async Task<TtsResult> Speak(
         string text,

--- a/tests/UI/Features/Video/TextToSpeech/Engines/AudioCppPerLineCloneTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/AudioCppPerLineCloneTests.cs
@@ -1,0 +1,115 @@
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+
+namespace UITests.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// Per-line voice cloning on the audio.cpp engines (IndexTTS 2.5, Higgs Audio v3, Fish Audio
+/// S2 Pro). Their server takes the reference as a per-request path, so nothing is staged: the
+/// voice for a line is the cut clip itself.
+/// </summary>
+/// <remarks>
+/// The one engine-specific rule is Fish's: S2 Pro refuses a reference without a transcript, so
+/// a clip with no .txt sidecar must not become a voice at all - the line falls back to an
+/// ordinary voice instead of the whole run failing on it.
+/// </remarks>
+public class AudioCppPerLineCloneTests
+{
+    public static IEnumerable<object[]> Engines()
+    {
+        yield return new object[] { new IndexTts25AudioCpp() };
+        yield return new object[] { new HiggsTtsAudioCpp() };
+        yield return new object[] { new FishTtsAudioCpp() };
+    }
+
+    [Theory]
+    [MemberData(nameof(Engines))]
+    public void ItIsOfferedWithAVideo(ITtsEngine engine)
+    {
+        Assert.True(engine.SupportsPerLineVoiceCloning);
+        Assert.True(PerLineVoiceClone.CanBeOffered(engine, "/videos/movie.mkv"));
+        Assert.False(PerLineVoiceClone.CanBeOffered(engine, string.Empty));
+    }
+
+    [Theory]
+    [MemberData(nameof(Engines))]
+    public void AClipWithATranscriptBecomesAVoicePointingAtTheClip(ITtsEngine engine)
+    {
+        using var clips = new TempFolder();
+        var clip = clips.WriteClip("line-0007", "Nothing travels faster than light.");
+
+        var voice = PerLineVoiceClone.MakeVoiceForClip(engine, clip, "line-0007");
+
+        Assert.NotNull(voice);
+        var indexVoice = Assert.IsType<IndexTtsVoice>(voice!.EngineVoice);
+        Assert.Equal(clip, indexVoice.FilePath);
+        Assert.Equal("line-0007", indexVoice.Voice);
+        // Export and regenerate have to find the recording again through the voice.
+        Assert.Equal(clip, PerLineVoiceClone.TryGetReferenceClip(voice));
+    }
+
+    [Fact]
+    public void HiggsAndIndexTtsCloneFromTheAudioAloneSoAMissingTranscriptIsFine()
+    {
+        using var clips = new TempFolder();
+        var clip = clips.WriteClip("line-0008", transcript: null);
+
+        Assert.NotNull(PerLineVoiceClone.MakeVoiceForClip(new HiggsTtsAudioCpp(), clip));
+        Assert.NotNull(PerLineVoiceClone.MakeVoiceForClip(new IndexTts25AudioCpp(), clip));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void FishWithoutATranscriptFallsBackInsteadOfCloning(string? transcript)
+    {
+        // audio.cpp answers a Fish voice_ref without reference_text with an HTTP 500, and Speak
+        // throws on an empty sidecar - so the clip must not be handed out as a voice.
+        using var clips = new TempFolder();
+        var clip = clips.WriteClip("line-0009", transcript);
+
+        Assert.Null(PerLineVoiceClone.MakeVoiceForClip(new FishTtsAudioCpp(), clip));
+    }
+
+    [Fact]
+    public void AVoiceThatClonesFromNothingReportsNoReference()
+    {
+        Assert.Null(PerLineVoiceClone.TryGetReferenceClip(new Voice(new IndexTtsVoice("Default", string.Empty))));
+    }
+
+    private sealed class TempFolder : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "se-audiocpp-per-line-" + Guid.NewGuid().ToString("N"));
+
+        public TempFolder()
+        {
+            Directory.CreateDirectory(Path);
+        }
+
+        public string WriteClip(string name, string? transcript)
+        {
+            var wav = System.IO.Path.Combine(Path, name + ".wav");
+            File.WriteAllText(wav, "not really a wav, and nothing here reads it");
+            if (transcript != null)
+            {
+                File.WriteAllText(System.IO.Path.ChangeExtension(wav, ".txt"), transcript);
+            }
+
+            return wav;
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+            catch
+            {
+                // Best effort.
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #14425 for Higgs Audio v3 and Fish Audio S2 Pro, and adds IndexTTS 2.5 while at it.

## What

"Clone from video (voice of each line)" is now offered on the three audio.cpp engines:

- IndexTTS 2.5 (audio.cpp)
- Higgs Audio v3 (audio.cpp)
- Fish Audio S2 Pro (audio.cpp)

## Why it is cheap

Per-line cloning needs an engine that takes its reference per synthesis call. All three already send `voice_ref` as a per-request path, so this is the OmniVoice shape rather than the Qwen3 staging shape: the line's voice points straight at the cut clip, nothing is staged into the engine's folders, nothing to clear between runs. audio.cpp resamples the reference itself, so the 24 kHz clips are used as cut.

## Engine-specific rule

Fish refuses a reference without `reference_text` (HTTP 500 from the server, and `Speak` throws before that). A clip with no transcript sidecar is therefore not handed out as a voice on Fish, so that line falls back to an ordinary voice instead of failing the run. In practice the per-line pipeline always writes the line text as the sidecar, so this only matters for empty lines. Higgs and IndexTTS clone from the audio alone and take every clip.

## Not in this PR

Confucius4-TTS, also named in the issue, is blocked upstream: the CrispASR adapter applies `--voice` only in `init()`, so per-line cloning would restart the server for every line. The adapter's `synthesize()` would need to re-apply the voice when the request's voice changes. Once that lands, SE can add it with the Pocket TTS staging pattern at 22.05 kHz.

## Tests

New `AudioCppPerLineCloneTests` cover the offer gate, the voice pointing at the clip, the reference round trip for export/regenerate, and the Fish no-transcript fallback. Full UI suite: 4590 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
