### PR TITLE
Gate Confucius4-TTS and Pocket TTS clone voices behind the voice-cloning consent dialog

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/VoiceCloningConsent.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/VoiceCloningConsent.cs
@@ -90,6 +90,8 @@ public static class VoiceCloningConsent
     /// type — a preset, a designed voice or a built-in speaker leaves it empty. The types share no
     /// interface, hence the list; a cloning engine added later has to be added here too, and until
     /// it is, its clones simply are not gated at synthesis (the import gate still covers them).
+    /// <c>VoiceCloningConsentTests.IsCloneVoice_RecognisesEveryCloningEngineInTheCatalog</c> fails
+    /// for any engine in <see cref="TtsEngineCatalog.CreateVoiceCloningEngines"/> that is missing.
     ///
     /// This is what catches reference WAVs that never went through the import dialog — dropped into
     /// the voices folder by hand from the settings dialogs' "open voices folder", or seeded from a
@@ -102,6 +104,7 @@ public static class VoiceCloningConsent
         // Clones every speaker in the video, one per line - the most cloning any single pick does.
         PerLineCloneVoice => true,
         ChatterboxVoice v => !string.IsNullOrEmpty(v.FilePath),
+        Confucius4TtsVoice v => !string.IsNullOrEmpty(v.FilePath),
         CosyVoice3Voice v => !string.IsNullOrEmpty(v.FilePath),
         DotsTtsVoice v => !string.IsNullOrEmpty(v.FilePath),
         F5TtsVoice v => !string.IsNullOrEmpty(v.FilePath),
@@ -109,6 +112,7 @@ public static class VoiceCloningConsent
         MossTtsVoice v => !string.IsNullOrEmpty(v.FilePath),
         OmniVoice v => !string.IsNullOrEmpty(v.FilePath),
         OmniVoiceCrispAsrVoice v => !string.IsNullOrEmpty(v.FilePath),
+        PocketTtsVoice v => !string.IsNullOrEmpty(v.FilePath),
         Qwen3TtsVoice v => !string.IsNullOrEmpty(v.FilePath),
         VibeVoice v => !string.IsNullOrEmpty(v.FilePath),
         VoxCPM2Voice v => !string.IsNullOrEmpty(v.FilePath),

--- a/tests/UI/Features/Video/TextToSpeech/Engines/VoiceCloningConsentTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/VoiceCloningConsentTests.cs
@@ -126,15 +126,63 @@ public class VoiceCloningConsentTests
         Assert.False(VoiceCloningConsent.IsCloneVoice(null));
     }
 
+    [Fact]
+    public void IsCloneVoice_RecognisesEveryCloningEngineInTheCatalog()
+    {
+        // The voice types share no interface, so IsCloneVoice is a hand-kept list. An engine
+        // whose voice type is missing from it clones silently: import still asks, but a reference
+        // WAV dropped into the voices folder by hand, or imported before the gate existed, is
+        // never asked about at synthesis. Confucius4-TTS and Pocket TTS shipped that way.
+        foreach (var engine in TtsEngineCatalog.CreateVoiceCloningEngines())
+        {
+            Assert.True(
+                CloneVoiceByEngine.TryGetValue(engine.GetType(), out var makeCloneVoice),
+                $"{engine.GetType().Name} is a cloning engine with no entry in {nameof(CloneVoiceByEngine)} - add its voice type there and to VoiceCloningConsent.IsCloneVoice");
+
+            var engineVoice = makeCloneVoice();
+            Assert.True(
+                VoiceCloningConsent.IsCloneVoice(new Voice(engineVoice)),
+                $"{engine.GetType().Name}'s clone voice type {engineVoice.GetType().Name} is not recognised by VoiceCloningConsent.IsCloneVoice");
+        }
+    }
+
+    /// <summary>
+    /// How each engine in <see cref="TtsEngineCatalog.CreateVoiceCloningEngines"/> represents a
+    /// voice cloned from a reference recording - the same constructor call its GetVoices makes
+    /// for a WAV found in its voices folder.
+    /// </summary>
+    private static readonly Dictionary<Type, Func<object>> CloneVoiceByEngine = new()
+    {
+        [typeof(ChatterboxTtsCpp)] = () => new ChatterboxVoice("Ada", "/voices/ada.wav"),
+        [typeof(Confucius4TtsCrispAsr)] = () => new Confucius4TtsVoice("Ada", "/voices/ada.wav"),
+        [typeof(CosyVoice3CrispAsr)] = () => new CosyVoice3Voice("Ada", "/voices/ada.wav", string.Empty),
+        [typeof(DotsTtsCrispAsr)] = () => new DotsTtsVoice("Ada", "/voices/ada.wav"),
+        [typeof(FishTtsAudioCpp)] = () => new IndexTtsVoice("Ada", "/voices/ada.wav"),
+        [typeof(HiggsTtsAudioCpp)] = () => new IndexTtsVoice("Ada", "/voices/ada.wav"),
+        [typeof(IndexTts25AudioCpp)] = () => new IndexTtsVoice("Ada", "/voices/ada.wav"),
+        [typeof(IndexTtsCrispAsr)] = () => new IndexTtsVoice("Ada", "/voices/ada.wav"),
+        [typeof(MossTtsCrispAsr)] = () => new MossTtsVoice("Ada", "/voices/ada.wav"),
+        [typeof(OmniVoiceCrispAsr)] = () => new OmniVoiceCrispAsrVoice("Ada", "/voices/ada.wav"),
+        [typeof(OmniVoiceTtsCpp)] = () => new OmniVoice("Ada", "/voices/ada.wav"),
+        [typeof(PocketTtsCrispAsr)] = () => new PocketTtsVoice("Ada", "/voices/ada.wav"),
+        [typeof(Qwen3TtsCrispAsr)] = () => new Qwen3TtsVoice("Ada", "/voices/ada.wav"),
+        [typeof(VibeVoiceCrispAsr)] = () => new VibeVoice("Ada", "/voices/ada.wav"),
+        [typeof(VoxCPM2CrispAsr)] = () => new VoxCPM2Voice("Ada", "/voices/ada.wav"),
+        [typeof(ZonosTtsCrispAsr)] = () => new ZonosTtsVoice("Ada", "/voices/ada.wav"),
+    };
+
     public static TheoryData<object> CloneVoices() => new()
     {
         new ChatterboxVoice("Ada", "/voices/ada.wav"),
+        new Confucius4TtsVoice("Ada", "/voices/ada.wav"),
         new CosyVoice3Voice("Ada", "/voices/ada.wav", string.Empty),
+        new DotsTtsVoice("Ada", "/voices/ada.wav"),
         new F5TtsVoice("Ada", "/voices/ada.wav"),
         new IndexTtsVoice("Ada", "/voices/ada.wav"),
         new MossTtsVoice("Ada", "/voices/ada.wav"),
         new OmniVoice("Ada", "/voices/ada.wav"),
         new OmniVoiceCrispAsrVoice("Ada", "/voices/ada.wav"),
+        new PocketTtsVoice("Ada", "/voices/ada.wav"),
         new Qwen3TtsVoice("Ada", "/voices/ada.wav"),
         new VibeVoice("Ada", "/voices/ada.wav"),
         new VoxCPM2Voice("Ada", "/voices/ada.wav"),
@@ -144,12 +192,15 @@ public class VoiceCloningConsentTests
     public static TheoryData<object> PresetVoices() => new()
     {
         new ChatterboxVoice(),
+        new Confucius4TtsVoice(),
         new CosyVoice3Voice(),
+        new DotsTtsVoice(),
         new F5TtsVoice(),
         new IndexTtsVoice(),
         new MossTtsVoice(),
         new OmniVoice(),
         new OmniVoiceCrispAsrVoice(),
+        new PocketTtsVoice(),
         new Qwen3TtsVoice(),
         new VibeVoice(),
         new VoxCPM2Voice(),


### PR DESCRIPTION
## Summary
- `VoiceCloningConsent.IsCloneVoice` pattern-matches each cloning engine's voice type on a non-empty `FilePath`. `Confucius4TtsVoice` (Confucius4TtsCrispAsr, zero-shot clone only) and `PocketTtsVoice` (PocketTtsCrispAsr, per-request clone) were missing, so a reference imported for either engine, or a WAV dropped into its voices folder, was never gated by the consent dialog at synthesis (`GenerateTts` / `TestVoice`). Import still asked; synthesis did not.
- Adds both types to the switch with the same `!string.IsNullOrEmpty(v.FilePath)` rule.
- Adds `IsCloneVoice_RecognisesEveryCloningEngineInTheCatalog`, which walks `TtsEngineCatalog.CreateVoiceCloningEngines()` and asserts every engine has a known clone voice type that `IsCloneVoice` recognises. A future cloning engine whose voice type is left out of the switch now fails this test by name.
- Adds `Confucius4TtsVoice`, `PocketTtsVoice` and `DotsTtsVoice` (already in the switch, absent from the test data) to the existing clone/preset theory data.

## Test plan
- [x] `dotnet build src/ui/UI.csproj` - 0 errors
- [x] `dotnet test tests/UI/UITests.csproj` - 4595 passed, 1 skipped (pre-existing), 0 failed
- [x] Negative check: temporarily removing the `PocketTtsVoice` case makes the new catalog test fail with "PocketTtsCrispAsr's clone voice type PocketTtsVoice is not recognised"

🤖 Generated with [Claude Code](https://claude.com/claude-code)