### PR TITLE
Waveform: offer the ffmpeg download instead of failing silently when ffmpeg is missing

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -20143,7 +20143,17 @@ public partial class MainViewModel :
                 ShowStatus(string.Format(Se.Language.Main.FfmpegDownloadedAndInstalledToX, result.FfmpegFileName));
                 return true;
             }
+
+            return false;
         }
+
+        // No ffmpeg download on Linux - say what is missing instead of failing silently (#14390).
+        await MessageBox.Show(
+            Window!,
+            Se.Language.Title,
+            Se.Language.Main.FfmpegNotFoundInstallHint,
+            MessageBoxButtons.OK,
+            MessageBoxIcon.Information);
 
         return false;
     }
@@ -24734,13 +24744,24 @@ public partial class MainViewModel :
         }
     }
 
-    // Kicks off ffmpeg waveform/spectrogram extraction (no-op if ffmpeg is missing or a
-    // generation for this peak file is already running). Shared by the auto-on-open path
-    // and the on-demand "click the empty waveform" path.
+    // Kicks off ffmpeg waveform/spectrogram extraction (no-op if a generation for this peak
+    // file is already running). Shared by the auto-on-open path and the on-demand "click the
+    // empty waveform" path.
     private void StartWaveformExtraction(string videoFileName, int trackNumber, string peakWaveFileName, string spectrogramFileName)
     {
         if (!FfmpegHelper.IsFfmpegInstalled())
         {
+            // Used to bail out silently, leaving an empty waveform with no clue why (#14390).
+            // The auto-on-open path must not pop a modal (session restore, drag/drop, CLI opens),
+            // so show the click-to-generate hint instead - clicking it runs RequireFfmpegOk,
+            // which offers the download (or explains how to install ffmpeg on Linux).
+            if (AudioVisualizer != null)
+            {
+                AudioVisualizer.ShowClickToGenerateHint = true;
+                AudioVisualizer.InvalidateVisual();
+            }
+
+            ShowStatus(Se.Language.Main.WaveformFfmpegNotFoundClickToSetUp);
             return;
         }
 
@@ -24780,10 +24801,17 @@ public partial class MainViewModel :
 #pragma warning restore CS4014
     }
 
-    // Handler for clicking the empty waveform when auto-generate is off.
-    internal void AudioVisualizerOnGenerateWaveformRequested(object? sender, EventArgs e)
+    // Handler for clicking the empty waveform (auto-generate off, or ffmpeg was missing when
+    // the video opened).
+    internal async void AudioVisualizerOnGenerateWaveformRequested(object? sender, EventArgs e)
     {
         if (string.IsNullOrEmpty(_videoFileName))
+        {
+            return;
+        }
+
+        // Explicit user action, so a modal "download ffmpeg?" prompt is fine here (#14390).
+        if (!await RequireFfmpegOk())
         {
             return;
         }

--- a/src/ui/Logic/Config/Language/Main/LanguageMain.cs
+++ b/src/ui/Logic/Config/Language/Main/LanguageMain.cs
@@ -45,6 +45,7 @@ public class LanguageMain
     public string LineXTimingChanged { get; set; }
     public string LoadingWaveInfoFromCache { get; set; }
     public string ClickToGenerateWaveform { get; set; }
+    public string WaveformFfmpegNotFoundClickToSetUp { get; set; }
     public string NoTextInClipboard { get; set; }
     public string NumberOfLinesEvenlyDistributedX { get; set; }
     public string OneLineCopiedFromOriginal { get; set; }
@@ -150,6 +151,7 @@ public class LanguageMain
     public string LiveSpellCheckLanguageXLoaded { get; set; }
     public string DownloadFfmpegTitle { get; set; }
     public string DownloadFfmpegQuestion { get; set; }
+    public string FfmpegNotFoundInstallHint { get; set; }
     public string SelectCurrentSubtitleWhilePlayingOn  { get; set; }
     public string SelectCurrentSubtitleWhilePlayingOff  { get; set; }
     public string SetUpLikeSe4Question { get; set; }
@@ -201,6 +203,7 @@ public class LanguageMain
         LineXTimingChanged = "Line {0}: Timing changed";
         LoadingWaveInfoFromCache = "Loading wave info from cache...";
         ClickToGenerateWaveform = "Click to generate waveform";
+        WaveformFfmpegNotFoundClickToSetUp = "FFmpeg not found - click the waveform to set up FFmpeg and generate the waveform";
         NoTextInClipboard = "No text in clipboard";
         NumberOfLinesEvenlyDistributedX = "Evenly distributed {0} lines";
         OneLineCopiedFromOriginal = "One line copied from original subtitle";
@@ -306,6 +309,7 @@ public class LanguageMain
         LiveSpellCheckLanguageXLoaded = "Live spell check language {0} loaded";
         DownloadFfmpegTitle = "Download FFmpeg?";
         DownloadFfmpegQuestion = "FFmpeg is required for playing online videos and for some video editing features.\n\nDownload FFmpeg now?";
+        FfmpegNotFoundInstallHint = "FFmpeg was not found.\n\nPlease install FFmpeg (e.g. via your package manager) so it is available on the PATH, or set the FFmpeg path in Options -> Settings.";
         SelectCurrentSubtitleWhilePlayingOn = "Select current subtitle while playing: ON";
         SelectCurrentSubtitleWhilePlayingOff = "Select current subtitle while playing: OFF";
         SetUpLikeSe4Question = "This will import Subtitle Edit 4 shortcuts and replace rules and apply the Subtitle Edit 4 theme, toolbar and waveform look.\n\nContinue?";


### PR DESCRIPTION
Fixes #14390

## Problem

Waveform extraction was the one ffmpeg consumer that bailed out silently when ffmpeg was not installed. The user got an empty waveform with no hint, no status line and no dialog, both on video open (auto-generate) and when clicking the empty waveform. Every other ffmpeg feature (TTS, voice cloning, audio to text, burn-in, ...) already goes through `RequireFfmpegOk`, which offers the download.

## Changes

- **Auto-generate on video open**: when ffmpeg is missing, show the existing click-to-generate hint over the empty waveform plus a status-bar line. No modal here on purpose, since video opens also run from session restore, drag and drop and the command line.
- **Clicking the empty waveform** now runs `RequireFfmpegOk` first, so the user gets the "Download FFmpeg?" prompt on Windows/macOS, and extraction starts right after the download.
- **Linux** (no ffmpeg download offered): `RequireFfmpegOk` now shows a message saying ffmpeg was not found and how to install it or set the path in settings, instead of returning `false` silently. This applies to all `RequireFfmpegOk` callers, which are all user-initiated actions.

Two new language strings in `LanguageMain.cs`; `English.json` left untouched (it is generated from the class).

## Test

- Build of `src/UI` succeeds.
- Manual: rename/remove ffmpeg, open a video with auto-generate on → hint + status line, click waveform → download prompt → waveform generates. With auto-generate off, clicking → same prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)