### PR TITLE
TTS: language picker for Zonos (CrispASR)

### DIFF
--- a/docs/features/text-to-speech.md
+++ b/docs/features/text-to-speech.md
@@ -90,7 +90,7 @@ Several of the local engines above are different models on the same CrispASR run
 | **IndexTTS (CrispASR)** | 24 kHz | Follows the text | Zero-shot | 24 kHz mono | ~600 MB - 2.4 GB |
 | **CosyVoice3 (CrispASR)** | 24 kHz | 9, plus 18 Mandarin dialects as voices | 8 baked-in presets + zero-shot | 16 kHz mono + a transcript sidecar | ~1.6 - 2.5 GB |
 | **MOSS-TTS (CrispASR)** | 24 kHz | 20 | Zero-shot | 24 kHz mono | ~10.5 - 20.5 GB incl. codec |
-| **Zonos TTS (CrispASR)** | 44.1 kHz | Follows the text | From a reference recording | 24 kHz mono | ~1.8 GB |
+| **Zonos TTS (CrispASR)** | 44.1 kHz | 100+ via the language picker (trained on English, Japanese, Chinese, French and German; the rest rely on eSpeak pronunciation) | From a reference recording | 24 kHz mono | ~1.8 GB |
 | **VoxCPM2 (CrispASR)** | 48 kHz | ~30 | Zero-shot | 24 kHz mono (upsampled internally) | ~1.7 - 5 GB |
 | **dots.tts (CrispASR)** | 48 kHz | Follows the text | Zero-shot | 24 kHz mono | ~2.4 - 5 GB |
 | **VibeVoice (CrispASR)** | 24 kHz | Follows the text | Zero-shot | 24 kHz mono | ~1.6 - 5 GB |

--- a/src/ui/Features/Video/TextToSpeech/Engines/ZonosLanguages.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ZonosLanguages.cs
@@ -1,0 +1,208 @@
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// The languages Zonos-v0.1 can be asked to speak, as the eSpeak-NG voice codes the model was
+/// conditioned with (Zonos has an integer language conditioner indexed by these codes, and
+/// CrispASR's <c>zonos-tts</c> backend also hands the same code to eSpeak for G2P). The codes
+/// are read verbatim from the GGUF's <c>zonos.language_codes</c> table, so every entry here is
+/// one the backend accepts; an unknown code is logged and silently falls back to en-us.
+///
+/// Zyphra only advertises English, Japanese, Chinese, French and German as trained languages —
+/// the rest of the table exists in the model but with little or no training data behind it.
+/// They are still offered: eSpeak phonemising Czech AS Czech is always better than the English
+/// G2P the backend falls back to when no language is sent, which was what every non-English
+/// line got before SE sent one at all.
+///
+/// The list leads with English (US) because that is the backend's default when the request has
+/// no <c>language</c> field — so a combo that falls back to its first entry reproduces the old
+/// behaviour, the same role "Auto" plays for <see cref="ChatterboxLanguages"/>. Zonos cannot
+/// detect the language itself, so there is no honest "Auto" entry to offer.
+///
+/// Left out of the model's table on purpose: the constructed and reconstructed entries
+/// (Interlingua, Lojban, Lingua Franca Nova, Pyash, Ancient Greek, Classical Nahuatl).
+/// </summary>
+internal static class ZonosLanguages
+{
+    /// <summary>The backend's own default (sent as nothing = en-us); leads the list.</summary>
+    public static readonly TtsLanguage Default = new("English (US)", "en-us");
+
+    private static readonly TtsLanguage[] Catalog = new TtsLanguage[]
+    {
+        new("Afrikaans", "af"),
+        new("Albanian", "sq"),
+        new("Amharic", "am"),
+        new("Arabic", "ar"),
+        new("Aragonese", "an"),
+        new("Armenian", "hy"),
+        new("Armenian (Western)", "hyw"),
+        new("Assamese", "as"),
+        new("Azerbaijani", "az"),
+        new("Bashkir", "ba"),
+        new("Basque", "eu"),
+        new("Bengali", "bn"),
+        new("Bishnupriya Manipuri", "bpy"),
+        new("Bosnian", "bs"),
+        new("Bulgarian", "bg"),
+        new("Burmese", "my"),
+        new("Cantonese", "yue"),
+        new("Catalan", "ca"),
+        new("Chinese (Mandarin)", "cmn"),
+        new("Chinese (Hakka)", "hak"),
+        new("Croatian", "hr"),
+        new("Czech", "cs"),
+        new("Danish", "da"),
+        new("Dutch", "nl"),
+        new("English (Caribbean)", "en-029"),
+        new("English (UK)", "en-gb"),
+        new("English (UK, Lancashire)", "en-gb-x-gbclan"),
+        new("English (UK, Received Pronunciation)", "en-gb-x-rp"),
+        new("English (UK, West Midlands)", "en-gb-x-gbcwmd"),
+        new("English (Scotland)", "en-gb-scotland"),
+        new("Esperanto", "eo"),
+        new("Estonian", "et"),
+        new("Finnish", "fi"),
+        new("French", "fr-fr"),
+        new("French (Belgium)", "fr-be"),
+        new("French (Switzerland)", "fr-ch"),
+        new("Georgian", "ka"),
+        new("German", "de"),
+        new("Greek", "el"),
+        new("Greenlandic", "kl"),
+        new("Guarani", "gn"),
+        new("Gujarati", "gu"),
+        new("Haitian Creole", "ht"),
+        new("Hindi", "hi"),
+        new("Hungarian", "hu"),
+        new("Icelandic", "is"),
+        new("Indonesian", "id"),
+        new("Irish", "ga"),
+        new("Italian", "it"),
+        new("Japanese", "ja"),
+        new("Kannada", "kn"),
+        new("Kazakh", "kk"),
+        new("K'iche'", "quc"),
+        new("Konkani", "kok"),
+        new("Korean", "ko"),
+        new("Kurdish", "ku"),
+        new("Kyrgyz", "ky"),
+        new("Latin", "la"),
+        new("Latvian", "lv"),
+        new("Lithuanian", "lt"),
+        new("Macedonian", "mk"),
+        new("Malay", "ms"),
+        new("Malayalam", "ml"),
+        new("Maltese", "mt"),
+        new("Māori", "mi"),
+        new("Marathi", "mr"),
+        new("Nepali", "ne"),
+        new("Norwegian (Bokmål)", "nb"),
+        new("Odia", "or"),
+        new("Oromo", "om"),
+        new("Papiamento", "pap"),
+        new("Persian", "fa"),
+        new("Persian (Latin script)", "fa-latn"),
+        new("Polish", "pl"),
+        new("Portuguese", "pt"),
+        new("Portuguese (Brazil)", "pt-br"),
+        new("Punjabi", "pa"),
+        new("Romanian", "ro"),
+        new("Russian", "ru"),
+        new("Russian (Latvia)", "ru-lv"),
+        new("Scottish Gaelic", "gd"),
+        new("Serbian", "sr"),
+        new("Setswana", "tn"),
+        new("Shan", "shn"),
+        new("Sindhi", "sd"),
+        new("Sinhala", "si"),
+        new("Slovak", "sk"),
+        new("Slovenian", "sl"),
+        new("Spanish", "es"),
+        new("Spanish (Latin America)", "es-419"),
+        new("Swahili", "sw"),
+        new("Swedish", "sv"),
+        new("Tamil", "ta"),
+        new("Tatar", "tt"),
+        new("Telugu", "te"),
+        new("Turkish", "tr"),
+        new("Urdu", "ur"),
+        new("Uzbek", "uz"),
+        new("Vietnamese", "vi"),
+        new("Vietnamese (Central)", "vi-vn-x-central"),
+        new("Vietnamese (Southern)", "vi-vn-x-south"),
+        new("Welsh", "cy"),
+    };
+
+    /// <summary>
+    /// English (US) first, then the rest sorted by name (ordinal, case-insensitive - sorted here
+    /// rather than by hand so the table above can be edited without keeping it in order).
+    ///
+    /// Declared after <see cref="Catalog"/> on purpose: static field initializers run in textual
+    /// order, so moving this above the catalog would copy a null array.
+    /// </summary>
+    public static readonly TtsLanguage[] All = BuildAll();
+
+    private static TtsLanguage[] BuildAll()
+    {
+        var result = new TtsLanguage[Catalog.Length + 1];
+        result[0] = Default;
+        Array.Copy(Catalog, 0, result, 1, Catalog.Length);
+        Array.Sort(result, 1, Catalog.Length, Comparer<TtsLanguage>.Create(
+            (a, b) => StringComparer.OrdinalIgnoreCase.Compare(a.Name, b.Name)));
+        return result;
+    }
+
+    /// <summary>
+    /// The value to send as the request's <c>language</c> field for <paramref name="language"/>,
+    /// or an empty string when no field should be sent (an unknown entry, or nothing selected
+    /// and nothing saved). Sending nothing leaves the backend on its en-us default.
+    /// </summary>
+    public static string ResolveLanguageArg(TtsLanguage? language)
+    {
+        // A null language means the CALLER had none to hand over, not that the user picked
+        // English: the cast dialog's voice-test button and every cross-engine cast row pass null
+        // on purpose ("engines fall back to their own saved defaults"), so without this fallback
+        // those paths would silently ignore the language the user did pick — the hole CosyVoice3
+        // had in #13272 and Chatterbox closed in #13470.
+        if (language == null)
+        {
+            return ResolveSavedLanguageArg();
+        }
+
+        var code = language.Code;
+        if (string.IsNullOrWhiteSpace(code))
+        {
+            return string.Empty;
+        }
+
+        // Guard against a language object left over from another engine (the view model can hold
+        // one while switching engines): only codes this engine actually advertises are passed on.
+        return IsSupported(code) ? code : string.Empty;
+    }
+
+    /// <summary>
+    /// The language code behind the pick saved by the main TTS window for this engine, or an
+    /// empty string when nothing is saved. The setting stores the DISPLAY NAME, which is how
+    /// <c>TextToSpeechViewModel</c> writes and restores it.
+    /// </summary>
+    public static string ResolveSavedLanguageArg()
+    {
+        var savedName = Se.Settings.Video.TextToSpeech.ZonosTtsCrispAsrLanguage;
+        if (string.IsNullOrWhiteSpace(savedName))
+        {
+            return string.Empty;
+        }
+
+        return All.FirstOrDefault(l => string.Equals(l.Name, savedName, StringComparison.OrdinalIgnoreCase))?.Code
+               ?? string.Empty;
+    }
+
+    /// <summary>True when <paramref name="code"/> is one of the codes in the model's table.</summary>
+    public static bool IsSupported(string? code) =>
+        !string.IsNullOrWhiteSpace(code)
+        && All.Any(l => string.Equals(l.Code, code, StringComparison.OrdinalIgnoreCase));
+}

--- a/src/ui/Features/Video/TextToSpeech/Engines/ZonosTtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/ZonosTtsCrispAsr.cs
@@ -32,12 +32,21 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 /// (eSpeak phonemisation), so unlike Qwen3 CustomVoice there is no .txt ref-text sidecar.
 /// This is a minimal engine: a single Q8_0 quant, no model dropdown, no per-engine settings
 /// dialog. Mirrors <see cref="IndexTtsCrispAsr"/>.
+///
+/// Unlike most cloning engines, Zonos is NOT language-agnostic: the input text goes through
+/// eSpeak G2P in whatever language the backend is told, and the model carries a language
+/// conditioner on top. CrispASR defaults both to en-us when the request has no
+/// <c>language</c> field, so a Czech line came out phonemised as English (#14433). The main
+/// window's language combo (<see cref="ZonosLanguages"/>) is passed as the server's startup
+/// <c>-l</c> flag: the zonos backend reads the language once at init, so - exactly like the
+/// voice - a language change restarts the server (verified against v0.8.31: the request body's
+/// <c>language</c> / <c>target_lang</c> fields leave zonos on en-us).
 /// </summary>
 public class ZonosTtsCrispAsr : ITtsEngine
 {
     public string Name => "Zonos TTS (CrispASR)";
     public string Description => "Zyphra Zonos-v0.1 with voice cloning, via CrispASR";
-    public bool HasLanguageParameter => false;
+    public bool HasLanguageParameter => true;
     public bool HasApiKey => false;
     public bool HasRegion => false;
     public bool HasModel => false;
@@ -94,6 +103,9 @@ public class ZonosTtsCrispAsr : ITtsEngine
     // reference audio from the startup --voice flag, so a voice change requires us to tear
     // down and restart the server. Same as IndexTTS — see PR #11210 discussion.
     private static string? _serverVoicePath;
+    // The -l language the running server was started with (empty = backend default en-us).
+    // Same story as the voice: zonos reads it at init only, so a change restarts the server.
+    private static string _serverLanguage = string.Empty;
     private static bool _processExitHooked;
     private static readonly StringBuilder _serverLog = new();
 
@@ -296,7 +308,11 @@ public class ZonosTtsCrispAsr : ITtsEngine
 
     public Task<string[]> GetModels() => Task.FromResult(Array.Empty<string>());
 
-    public Task<TtsLanguage[]> GetLanguages(Voice voice, string? model) => Task.FromResult(Array.Empty<TtsLanguage>());
+    /// <summary>
+    /// The eSpeak voice codes from the model's own language table; English (US) leads as the
+    /// backend default. See <see cref="ZonosLanguages"/>.
+    /// </summary>
+    public Task<TtsLanguage[]> GetLanguages(Voice voice, string? model) => Task.FromResult(ZonosLanguages.All);
 
     public Task<Voice[]> RefreshVoices(string language, CancellationToken cancellationToken) =>
         GetVoices(language);
@@ -323,7 +339,12 @@ public class ZonosTtsCrispAsr : ITtsEngine
                 + "Reference WAV should be 24 kHz mono (a few seconds of clean speech).");
         }
 
-        await EnsureServerRunningAsync(zonosVoice.FilePath, cancellationToken);
+        // The language to speak: picks the eSpeak G2P voice and the model's language
+        // conditioner. Nothing = the backend's en-us default, which is what every line got
+        // before #14433 - fine for English, English-phonemised gibberish for the rest.
+        var languageArg = ZonosLanguages.ResolveLanguageArg(language);
+
+        await EnsureServerRunningAsync(zonosVoice.FilePath, languageArg, cancellationToken);
 
         var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder), Guid.NewGuid() + ".wav");
         var inputText = text;
@@ -341,13 +362,21 @@ public class ZonosTtsCrispAsr : ITtsEngine
             ["response_format"] = "wav",
         };
 
+        // Also sent per request, which is CrispASR's documented TTS API for the language to
+        // speak. The v0.8.31 zonos backend does not act on it (only the startup -l above does),
+        // but a server that learns to will then agree with the flag rather than fight it.
+        if (!string.IsNullOrEmpty(languageArg))
+        {
+            payload["language"] = languageArg;
+        }
+
         // Attests the user's own imported reference and the AI-disclosure duty; see
         // CrispAsrTtsProvenance. Skipped when voice cloning has not been accepted in settings.
         CrispAsrTtsProvenance.AddSpeechAttestations(payload);
 
         var body = JsonSerializer.Serialize(payload);
         using var content = new StringContent(body, Encoding.UTF8, "application/json");
-        Se.WriteToolsLog($"Zonos TTS (CrispASR): POST {ServerBaseUrl}/v1/audio/speech (voice={zonosVoice}, textLen={text.Length})");
+        Se.WriteToolsLog($"Zonos TTS (CrispASR): POST {ServerBaseUrl}/v1/audio/speech (voice={zonosVoice}, textLen={text.Length}, language={(string.IsNullOrEmpty(languageArg) ? "(default en-us)" : languageArg)})");
 
         HttpResponseMessage response;
         try
@@ -438,14 +467,19 @@ public class ZonosTtsCrispAsr : ITtsEngine
         }
     }
 
-    private static async Task EnsureServerRunningAsync(string voicePath, CancellationToken ct)
+    private static bool IsServerRunningWith(string voicePath, string languageArg) =>
+        _serverProcess is { HasExited: false } && _serverPort != 0
+        && string.Equals(_serverVoicePath, voicePath, StringComparison.OrdinalIgnoreCase)
+        && string.Equals(_serverLanguage, languageArg, StringComparison.OrdinalIgnoreCase);
+
+    private static async Task EnsureServerRunningAsync(string voicePath, string languageArg, CancellationToken ct)
     {
         // CrispASR's TTS server backends don't honour the per-request `voice` field — they
-        // only read the reference audio from the --voice path passed at server startup. So we
-        // restart the server every time the selected voice changes. Tracked next to
-        // _serverProcess so an already-running server with the matching voice is reused.
-        if (_serverProcess is { HasExited: false } && _serverPort != 0
-            && string.Equals(_serverVoicePath, voicePath, StringComparison.OrdinalIgnoreCase))
+        // only read the reference audio from the --voice path passed at server startup. The
+        // zonos backend reads its language (-l) at init the same way. So we restart the server
+        // every time the selected voice or language changes. Tracked next to _serverProcess so
+        // an already-running server with the matching pair is reused.
+        if (IsServerRunningWith(voicePath, languageArg))
         {
             return;
         }
@@ -453,8 +487,7 @@ public class ZonosTtsCrispAsr : ITtsEngine
         await ServerLock.WaitAsync(ct);
         try
         {
-            if (_serverProcess is { HasExited: false } && _serverPort != 0
-                && string.Equals(_serverVoicePath, voicePath, StringComparison.OrdinalIgnoreCase))
+            if (IsServerRunningWith(voicePath, languageArg))
             {
                 return;
             }
@@ -518,6 +551,13 @@ public class ZonosTtsCrispAsr : ITtsEngine
             // means the request's `voice` is ignored and the synth produces the wrong speaker.
             psi.ArgumentList.Add("--voice");
             psi.ArgumentList.Add(voicePath);
+            // The language to speak, as the eSpeak code from the model's own table (see
+            // ZonosLanguages). Omitted = the backend's en-us default. The CLI lowercases it.
+            if (!string.IsNullOrEmpty(languageArg))
+            {
+                psi.ArgumentList.Add("-l");
+                psi.ArgumentList.Add(languageArg);
+            }
             CrispAsrTtsProvenance.AddServerMarkingArgs(psi.ArgumentList, exe);
 
             var process = Process.Start(psi)
@@ -544,6 +584,7 @@ public class ZonosTtsCrispAsr : ITtsEngine
             _serverProcess = process;
             _serverPort = port;
             _serverVoicePath = voicePath;
+            _serverLanguage = languageArg;
             HookProcessExitOnce();
 
             // First-run auto-download (~1.8 GB total) needs a generous timeout.
@@ -560,6 +601,7 @@ public class ZonosTtsCrispAsr : ITtsEngine
                     _serverPort = 0;
                     _serverLaunchCommand = null;
                     _serverVoicePath = null;
+                    _serverLanguage = string.Empty;
                     throw new InvalidOperationException(
                         $"crispasr (zonos-tts) exited during startup (code {exitCode}). Output: {tail}"
                         + LaunchCmdSuffix(exitedLaunchCommand));
@@ -646,6 +688,7 @@ public class ZonosTtsCrispAsr : ITtsEngine
         _serverPort = 0;
         _serverLaunchCommand = null;
         _serverVoicePath = null;
+        _serverLanguage = string.Empty;
         if (p == null)
         {
             return;

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -408,6 +408,10 @@ public partial class TextToSpeechViewModel : ObservableObject
                 Se.Settings.Video.TextToSpeech.ChatterboxCrispAsrLanguage = SelectedLanguage?.Name ?? string.Empty;
             }
         }
+        else if (SelectedEngine is ZonosTtsCrispAsr)
+        {
+            Se.Settings.Video.TextToSpeech.ZonosTtsCrispAsrLanguage = SelectedLanguage?.Name ?? string.Empty;
+        }
         else if (SelectedEngine is KokoroTtsCpp)
         {
             if (SelectedVoice?.EngineVoice is Voices.KokoroVoice kokoroVoice && !string.IsNullOrEmpty(kokoroVoice.Voice))
@@ -1067,6 +1071,7 @@ public partial class TextToSpeechViewModel : ObservableObject
         CosyVoice3CrispAsr => Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrLanguage,
         Qwen3TtsCrispAsr => Se.Settings.Video.TextToSpeech.Qwen3TtsCrispAsrLanguage,
         ChatterboxTtsCpp => Se.Settings.Video.TextToSpeech.ChatterboxCrispAsrLanguage,
+        ZonosTtsCrispAsr => Se.Settings.Video.TextToSpeech.ZonosTtsCrispAsrLanguage,
         ElevenLabs => Se.Settings.Video.TextToSpeech.ElevenLabsLanguage,
         _ => null,
     };
@@ -4007,6 +4012,10 @@ public partial class TextToSpeechViewModel : ObservableObject
                     Qwen3TtsCrispAsr => Languages.FirstOrDefault(l => l.Name == Se.Settings.Video.TextToSpeech.Qwen3TtsCrispAsrLanguage)
                                         ?? Languages.FirstOrDefault(),
                     ChatterboxTtsCpp => Languages.FirstOrDefault(l => l.Name == Se.Settings.Video.TextToSpeech.ChatterboxCrispAsrLanguage)
+                                        ?? Languages.FirstOrDefault(),
+                    // Zonos leads with English (US) rather than "Auto" (the backend cannot
+                    // detect a language), so the first-entry fallback is the backend default.
+                    ZonosTtsCrispAsr => Languages.FirstOrDefault(l => l.Name == Se.Settings.Video.TextToSpeech.ZonosTtsCrispAsrLanguage)
                                         ?? Languages.FirstOrDefault(),
                     _ => Languages.FirstOrDefault(),
                 };

--- a/src/ui/Logic/Config/SeVideoTextToSpeech.cs
+++ b/src/ui/Logic/Config/SeVideoTextToSpeech.cs
@@ -96,6 +96,8 @@ public class SeVideoTextToSpeech
     public string ChatterboxModel { get; set; }
     public string ChatterboxCrispAsrLanguage { get; set; }
     public string ChatterboxCrispAsrSourceLanguage { get; set; }
+    // Display name of the picked Zonos output language (empty = backend default, English US).
+    public string ZonosTtsCrispAsrLanguage { get; set; }
     public string KokoroVoice { get; set; }
     public string GoogleApiKey { get; set; }
     public string GoogleKeyFile { get; set; }
@@ -227,6 +229,7 @@ public class SeVideoTextToSpeech
         ChatterboxModel = "Base";
         ChatterboxCrispAsrLanguage = string.Empty;
         ChatterboxCrispAsrSourceLanguage = string.Empty;
+        ZonosTtsCrispAsrLanguage = string.Empty;
         KokoroVoice = "af_maple";
         GoogleApiKey = string.Empty;
         GoogleKeyFile = string.Empty;

--- a/tests/UI/Features/Video/TextToSpeech/Engines/ZonosLanguagesTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/ZonosLanguagesTests.cs
@@ -1,0 +1,91 @@
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// Zonos is not language-agnostic: CrispASR's zonos-tts backend phonemises the input with eSpeak
+/// in whatever language it was started with, defaulting to en-us. Before #14433 SE never told it
+/// one, so every non-English line was read with English G2P. These pin the language catalog and
+/// the argument resolution the engine sends as the server's startup <c>-l</c> flag.
+/// </summary>
+public class ZonosLanguagesTests
+{
+    [Fact]
+    public void Engine_HasLanguageParameter()
+    {
+        var engine = new ZonosTtsCrispAsr();
+
+        Assert.True(engine.HasLanguageParameter);
+    }
+
+    [Fact]
+    public void Languages_LeadWithEnglishUsAsTheBackendDefault()
+    {
+        // English (US) first so a combo falling back to its first entry reproduces the backend's
+        // own default. There is no "Auto": Zonos cannot detect the language itself.
+        var all = ZonosLanguages.All;
+
+        Assert.Equal("English (US)", all[0].Name);
+        Assert.Equal("en-us", all[0].Code);
+        Assert.DoesNotContain(all, l => l.Name == "Auto");
+        Assert.True(all.Length > 100);
+    }
+
+    [Fact]
+    public void Languages_CodesAreUniqueAndSortedAfterTheDefault()
+    {
+        var all = ZonosLanguages.All;
+
+        Assert.Equal(all.Length, all.Select(l => l.Code).Distinct(StringComparer.OrdinalIgnoreCase).Count());
+        var names = all.Skip(1).Select(l => l.Name).ToList();
+        Assert.Equal(names.OrderBy(n => n, StringComparer.OrdinalIgnoreCase).ToList(), names);
+    }
+
+    [Theory]
+    [InlineData("Czech", "cs")]
+    [InlineData("German", "de")]
+    [InlineData("French", "fr-fr")]
+    [InlineData("Chinese (Mandarin)", "cmn")]
+    [InlineData("Japanese", "ja")]
+    [InlineData("English (US)", "en-us")]
+    public void Languages_ResolveToEspeakCode(string displayName, string expectedArg)
+    {
+        // The codes are eSpeak voice names as listed in the GGUF's zonos.language_codes table,
+        // not ISO 639-1 - "fr" or "zh" would be rejected by zonos_tts_set_language.
+        var language = ZonosLanguages.All.Single(l => l.Name == displayName);
+
+        Assert.Equal(expectedArg, ZonosLanguages.ResolveLanguageArg(language));
+    }
+
+    [Fact]
+    public void Languages_ForeignEngineCodeIsDropped()
+    {
+        // A language object left over from another engine (e.g. Chatterbox's ISO 639-1 "fr")
+        // must not reach the backend, which would log "unknown language code" and stay en-us.
+        var foreign = new TtsLanguage("French", "fr");
+
+        Assert.Equal(string.Empty, ZonosLanguages.ResolveLanguageArg(foreign));
+    }
+
+    [Fact]
+    public void Languages_NullFallsBackToTheSavedPick()
+    {
+        // Cross-engine cast rows and the voice-test button pass null; the saved main-window
+        // pick must still win (#13272 / #13470 pattern).
+        var saved = Se.Settings.Video.TextToSpeech.ZonosTtsCrispAsrLanguage;
+        try
+        {
+            Se.Settings.Video.TextToSpeech.ZonosTtsCrispAsrLanguage = "Czech";
+            Assert.Equal("cs", ZonosLanguages.ResolveLanguageArg(null));
+
+            Se.Settings.Video.TextToSpeech.ZonosTtsCrispAsrLanguage = string.Empty;
+            Assert.Equal(string.Empty, ZonosLanguages.ResolveLanguageArg(null));
+        }
+        finally
+        {
+            Se.Settings.Video.TextToSpeech.ZonosTtsCrispAsrLanguage = saved;
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #14433 ("Add a choice of target language for TTS").

## The gap

Zonos is **not** language-agnostic: CrispASR's `zonos-tts` backend phonemises the input with eSpeak in whatever language it was started with, and defaults to `en-us`. SE never sent one, so every non-English line was read with English G2P.

## The fix

- The main TTS window now shows the language combo for **Zonos TTS (CrispASR)**, populated from the GGUF's own `zonos.language_codes` table (eSpeak codes such as `cs`, `fr-fr`, `cmn`; constructed/ancient entries left out). English (US) leads as the backend default. There is no "Auto" entry because the model cannot detect a language itself.
- The pick is persisted (`ZonosTtsCrispAsrLanguage`) and restored like the other CrispASR engines, and honoured on the paths that pass a null language (cast rows, voice test).
- The code is passed as the server's startup `-l` flag. The zonos backend reads it once at init, so a language change restarts the server, exactly as a voice change already does.
- Docs table row updated.

## Verified

Against the pinned CrispASR v0.8.31 on macOS with SE's exact server invocation:

- The request body's `language` / `target_lang` / `source_lang` fields leave zonos on `en-us` (server log: `phoneme tokens (lang=en-us)`), so the per-request route is not enough on this version. It is still sent alongside, since it is CrispASR's documented API.
- `-l cs`, `-l fr-fr`, `-l cmn` all reach G2P (`lang=cs` / `lang=fr-fr` / `lang=cmn`), so hyphenated eSpeak codes pass the CLI.
- Czech sample "Dobrý den, toto je zkouška českého jazyka." transcribed back with parakeet-tdt v3:
  - before: `Dobri Dentoto G Okushka Chaskahol Jessica.`
  - after: `Dobrý den tohoto je skôska Českého jazyka.`

`dotnet test tests/UI/UITests.csproj`: all green, plus new `ZonosLanguagesTests`.

## Not in this PR

Fish Audio S2 Pro and Higgs Audio v3 (the engines named in the issue) have no language input anywhere in their chain (fish-speech's request schema, audio.cpp's backends, the models' prompt formats), so there is nothing a combo could send. Details in the issue thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
