### PR TITLE
Split the editable original along with the translation (#14434)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -17334,7 +17334,7 @@ public partial class MainViewModel :
         var countBefore = Subtitles.Count;
         RunWithoutChangeDetection(() =>
         {
-            _splitManager.Split(Subtitles, s, vm.SelectedCandidate.TextIndex, language);
+            _splitManager.Split(Subtitles, s, -1, vm.SelectedCandidate.TextIndex, language, GetOriginalSplit(s, language, -1));
             Renumber();
         });
 
@@ -19934,26 +19934,21 @@ public partial class MainViewModel :
         }
 
         var language = LanguageAutoDetect.AutoDetectGoogleLanguage(GetUpdateSubtitle());
+
+        // "Split at cursor" takes the caret from whichever text box has focus (SE4 parity,
+        // #14434): the original box splits the original at its caret and lets the translation
+        // auto-split, the translation box does the reverse. The natural split point differs
+        // between the two languages, so the caret is never shared. A read-only original can
+        // hold focus but is never rewritten, so its caret is ignored.
+        var originalHasFocus = atTextBoxPosition && EditTextBoxOriginal.IsFocused && CanEditOriginal;
+        var textIndex = atTextBoxPosition && !originalHasFocus ? EditTextBox.SelectionStart : -1;
+        var videoPositionSeconds = atVideoPosition && vp != null ? vp.Position : -1;
+        var originalSplit = GetOriginalSplit(s, language, originalHasFocus ? EditTextBoxOriginal.SelectionStart : -1);
+
         var countBefore = Subtitles.Count;
         RunWithoutChangeDetection(() =>
         {
-            if (atVideoPosition && atTextBoxPosition && vp != null)
-            {
-                _splitManager.Split(Subtitles, s, vp.Position, EditTextBox.SelectionStart, language);
-            }
-            else if (atVideoPosition && vp != null)
-            {
-                _splitManager.Split(Subtitles, s, vp.Position, language);
-            }
-            else if (atTextBoxPosition)
-            {
-                _splitManager.Split(Subtitles, s, EditTextBox.SelectionStart, language);
-            }
-            else
-            {
-                _splitManager.Split(Subtitles, s, language);
-            }
-
+            _splitManager.Split(Subtitles, s, videoPositionSeconds, textIndex, language, originalSplit);
             Renumber();
         });
 
@@ -19971,6 +19966,28 @@ public partial class MainViewModel :
         }
 
         _updateAudioVisualizer = true;
+    }
+
+    /// <summary>
+    /// How a split should treat the row's original text: split it along with the translation
+    /// when the original is editable, so the two columns stay structurally in sync (#14434).
+    /// A read-only reference is left untouched - its file is authoritative and the sticky
+    /// refresh re-syncs the displayed text from it.
+    /// </summary>
+    /// <param name="originalTextIndex">Caret in the original text box, or -1 to auto-split the original.</param>
+    private OriginalSplit? GetOriginalSplit(SubtitleLineViewModel s, string language, int originalTextIndex)
+    {
+        if (!CanEditOriginal || string.IsNullOrEmpty(s.OriginalText))
+        {
+            return null;
+        }
+
+        // The loaded original may lag the rows' edits, but its language does not change.
+        var originalLanguage = _subtitleOriginal.Paragraphs.Count > 0
+            ? LanguageAutoDetect.AutoDetectGoogleLanguage(_subtitleOriginal)
+            : language;
+
+        return new OriginalSplit(originalTextIndex, originalLanguage);
     }
 
     /// <summary>Scrolls minimally so <paramref name="row"/> is fully on screen; no selection change.</summary>

--- a/src/ui/Logic/ISplitManager.cs
+++ b/src/ui/Logic/ISplitManager.cs
@@ -9,17 +9,40 @@ using System.Linq;
 
 namespace Nikse.SubtitleEdit.Logic;
 
+/// <summary>
+/// How to split the editable original text of a row along with its translation (#14434).
+/// </summary>
+/// <param name="TextIndex">
+/// Caret position in the original text, or -1 to auto-split the original on its own line break
+/// (or auto-break). The original never shares the translation's caret: the natural split point
+/// differs between the two languages.
+/// </param>
+/// <param name="LanguageCode">Two-letter language of the original; dialog-dash and auto-break rules depend on it.</param>
+public sealed record OriginalSplit(int TextIndex, string LanguageCode);
+
 public interface ISplitManager
 {
     void Split(ObservableCollection<SubtitleLineViewModel> subtitles, SubtitleLineViewModel subtitle, string languageCode);
     void Split(ObservableCollection<SubtitleLineViewModel> subtitles, SubtitleLineViewModel subtitle, double videoPositionSeconds, string languageCode);
     void Split(ObservableCollection<SubtitleLineViewModel> subtitles, SubtitleLineViewModel subtitle, double videoPositionSeconds, int textIndex, string languageCode);
     void Split(ObservableCollection<SubtitleLineViewModel> subtitles, SubtitleLineViewModel subtitle, int textIndex, string languageCode);
+
+    /// <summary>
+    /// Splits <paramref name="subtitle"/> and, when <paramref name="original"/> is given, its
+    /// <see cref="SubtitleLineViewModel.OriginalText"/> too. With null the original is copied
+    /// whole onto both halves, which is what a read-only reference wants.
+    /// </summary>
+    void Split(ObservableCollection<SubtitleLineViewModel> subtitles, SubtitleLineViewModel subtitle, double videoPositionSeconds, int textIndex, string languageCode, OriginalSplit? original);
 }
 
 public class SplitManager : ISplitManager
 {
     public void Split(ObservableCollection<SubtitleLineViewModel> subtitles, SubtitleLineViewModel subtitle, double videoPositionSeconds, int textIndex, string languageCode)
+    {
+        Split(subtitles, subtitle, videoPositionSeconds, textIndex, languageCode, original: null);
+    }
+
+    public void Split(ObservableCollection<SubtitleLineViewModel> subtitles, SubtitleLineViewModel subtitle, double videoPositionSeconds, int textIndex, string languageCode, OriginalSplit? original)
     {
         var idx = subtitles.IndexOf(subtitle);
         if (idx < 0 || idx >= subtitles.Count)
@@ -36,118 +59,19 @@ public class SplitManager : ISplitManager
             && videoPositionSeconds > subtitle.StartTime.TotalSeconds
             && videoPositionSeconds < subtitle.EndTime.TotalSeconds;
 
-        var text = subtitle.Text;
-        var lines = text.SplitToLines();
-        if (textIndex > 0 && textIndex <= subtitle.Text.Length)
+        var (firstText, secondText) = SplitText(subtitle.Text, textIndex, languageCode);
+        subtitle.Text = firstText;
+        newSubtitle.Text = secondText;
+
+        // An editable original is split by the same rules, at its own caret or on its own line
+        // break. Before #14434 the copy constructor above left the complete original on both
+        // halves, so every split desynchronized the two columns.
+        if (original != null && !string.IsNullOrEmpty(subtitle.OriginalText))
         {
-            subtitle.Text = text.Substring(0, textIndex).Trim();
-            newSubtitle.Text = text.Substring(textIndex).Trim();
-
-            if (lines.Count == 2)
-            {
-                var dialogHelper = new DialogSplitMerge { DialogStyle = Configuration.Settings.General.DialogStyle, TwoLetterLanguageCode = languageCode };
-                if (dialogHelper.IsDialog(lines))
-                {
-                    subtitle.Text = DialogSplitMerge.RemoveStartDash(subtitle.Text);
-                    newSubtitle.Text = DialogSplitMerge.RemoveStartDash(newSubtitle.Text);
-                }
-            }
-
-            // SE 4 parity (#11245 follow-up): if either half ends up with a single line
-            // longer than the configured max, auto-break it. Cursor-split at the middle
-            // of a long single-line subtitle would otherwise leave a too-wide line.
-            subtitle.Text = AutoBreakIfTooLong(subtitle.Text, languageCode);
-            newSubtitle.Text = AutoBreakIfTooLong(newSubtitle.Text, languageCode);
+            var (firstOriginal, secondOriginal) = SplitText(subtitle.OriginalText, original.TextIndex, original.LanguageCode);
+            subtitle.OriginalText = firstOriginal;
+            newSubtitle.OriginalText = secondOriginal;
         }
-        else if (lines.Count == 2)
-        {
-            var dialogHelper = new DialogSplitMerge { DialogStyle = Configuration.Settings.General.DialogStyle, TwoLetterLanguageCode = languageCode };
-            if (dialogHelper.IsDialog(lines))
-            {
-                newSubtitle.Text = lines[1].TrimStart(' ', DialogSplitMerge.GetDashChar(), DialogSplitMerge.GetAlternateDashChar()).Trim();
-                subtitle.Text = lines[0].TrimStart(' ', DialogSplitMerge.GetDashChar(), DialogSplitMerge.GetAlternateDashChar()).Trim();
-            }
-            else
-            {
-                newSubtitle.Text = lines[1].Trim();
-                subtitle.Text = lines[0].Trim();
-            }
-        }
-        else if (lines.Count > 2)
-        {
-            var splitIndex = lines.Count / 2;
-
-            if (lines.Count % 2 == 1) // odd number of lines
-            {
-                if (Se.Settings.Tools.SplitOddLinesAction == nameof(SplitOddLinesActionType.WeightTop))
-                {
-                    splitIndex = splitIndex + 1;
-                }
-                else if (Se.Settings.Tools.SplitOddLinesAction == nameof(SplitOddLinesActionType.WeightBottom))
-                {
-                    // no changes
-                }
-                else // SplitUnevenLineActionType.Smart
-                {
-                    var try1First = string.Join(Environment.NewLine, lines.GetRange(0, splitIndex + 1)).Trim();
-                    var try1Second = string.Join(Environment.NewLine, lines.GetRange(splitIndex + 1, lines.Count - (splitIndex + 1))).Trim();
-
-                    var try2First = string.Join(Environment.NewLine, lines.GetRange(0, splitIndex)).Trim();
-                    var try2Second = string.Join(Environment.NewLine, lines.GetRange(splitIndex, lines.Count - splitIndex)).Trim();
-
-                    if (try1First.EndsWith('.') && !try2First.EndsWith('.'))
-                    {
-                        splitIndex = splitIndex + 1;
-                    }
-                    else if (!try1First.EndsWith(".") && try2First.EndsWith('.'))
-                    {
-                        // no changes
-                    }
-                    else if (Math.Abs(try1First.Length - try1Second.Length) < Math.Abs(try2First.Length - try2Second.Length))
-                    {
-                        splitIndex = splitIndex + 1;
-                    }
-                }
-            }
-
-            subtitle.Text = string.Join(Environment.NewLine, lines.GetRange(0, splitIndex)).Trim();
-            newSubtitle.Text = string.Join(Environment.NewLine, lines.GetRange(splitIndex, lines.Count - splitIndex)).Trim();
-        }
-        else
-        {
-            var brokenLines = Utilities.AutoBreakLine(text, Se.Settings.General.SubtitleLineMaximumLength, 0, languageCode).SplitToLines();
-            if (brokenLines.Count == 2)
-            {
-                subtitle.Text = brokenLines[0].Trim();
-                newSubtitle.Text = brokenLines[1].Trim();
-            }
-            else
-            {
-                subtitle.Text = text;
-                newSubtitle.Text = string.Empty;
-            }
-        }
-
-        // SE 4 parity (#12195): "Split line at cursor" applies the configured continuation
-        // style (e.g. "Ellipses (trailing only)") to the halves - a trailing ellipsis on
-        // the first line, and a leading marker on the second for leading styles - instead
-        // of a clean cut.
-        if (!string.IsNullOrWhiteSpace(subtitle.Text)
-            && !string.IsNullOrWhiteSpace(newSubtitle.Text)
-            && Enum.TryParse<ContinuationStyle>(Se.Settings.General.ContinuationStyle, out var continuationStyle)
-            && continuationStyle != ContinuationStyle.None)
-        {
-            var continuationProfile = ContinuationUtilities.GetContinuationProfile(continuationStyle);
-            if (ContinuationUtilities.ShouldAddSuffix(subtitle.Text, continuationProfile))
-            {
-                subtitle.Text = ContinuationUtilities.AddSuffixIfNeeded(subtitle.Text, continuationProfile, false);
-                newSubtitle.Text = ContinuationUtilities.AddPrefixIfNeeded(newSubtitle.Text, continuationProfile, false);
-            }
-        }
-
-        var (s1, s2) = FixTags(subtitle.Text, newSubtitle.Text);
-        subtitle.Text = s1;
-        newSubtitle.Text = s2;
 
         // Time split — done AFTER the text split so we can weight the divide point
         // by the resulting text-length ratio when no user video position was given.
@@ -229,6 +153,127 @@ public class SplitManager : ISplitManager
         newSubtitle.SetStartTimeOnly(TimeSpan.FromMilliseconds(newSubtitleStartMs));
 
         subtitles.Insert(idx + 1, newSubtitle);
+    }
+
+    /// <summary>
+    /// Splits one text into two halves: at <paramref name="textIndex"/> when it is inside the
+    /// text, otherwise on the line break (two lines), a weighted line count (more), or an
+    /// auto-break (one line). Dialog dashes, continuation style and tag balancing are applied
+    /// the same way for the translation and the original.
+    /// </summary>
+    private static (string First, string Second) SplitText(string text, int textIndex, string languageCode)
+    {
+        var first = text;
+        var second = string.Empty;
+        var lines = text.SplitToLines();
+        if (textIndex > 0 && textIndex <= text.Length)
+        {
+            first = text.Substring(0, textIndex).Trim();
+            second = text.Substring(textIndex).Trim();
+
+            if (lines.Count == 2)
+            {
+                var dialogHelper = new DialogSplitMerge { DialogStyle = Configuration.Settings.General.DialogStyle, TwoLetterLanguageCode = languageCode };
+                if (dialogHelper.IsDialog(lines))
+                {
+                    first = DialogSplitMerge.RemoveStartDash(first);
+                    second = DialogSplitMerge.RemoveStartDash(second);
+                }
+            }
+
+            // SE 4 parity (#11245 follow-up): if either half ends up with a single line
+            // longer than the configured max, auto-break it. Cursor-split at the middle
+            // of a long single-line subtitle would otherwise leave a too-wide line.
+            first = AutoBreakIfTooLong(first, languageCode);
+            second = AutoBreakIfTooLong(second, languageCode);
+        }
+        else if (lines.Count == 2)
+        {
+            var dialogHelper = new DialogSplitMerge { DialogStyle = Configuration.Settings.General.DialogStyle, TwoLetterLanguageCode = languageCode };
+            if (dialogHelper.IsDialog(lines))
+            {
+                second = lines[1].TrimStart(' ', DialogSplitMerge.GetDashChar(), DialogSplitMerge.GetAlternateDashChar()).Trim();
+                first = lines[0].TrimStart(' ', DialogSplitMerge.GetDashChar(), DialogSplitMerge.GetAlternateDashChar()).Trim();
+            }
+            else
+            {
+                second = lines[1].Trim();
+                first = lines[0].Trim();
+            }
+        }
+        else if (lines.Count > 2)
+        {
+            var splitIndex = lines.Count / 2;
+
+            if (lines.Count % 2 == 1) // odd number of lines
+            {
+                if (Se.Settings.Tools.SplitOddLinesAction == nameof(SplitOddLinesActionType.WeightTop))
+                {
+                    splitIndex = splitIndex + 1;
+                }
+                else if (Se.Settings.Tools.SplitOddLinesAction == nameof(SplitOddLinesActionType.WeightBottom))
+                {
+                    // no changes
+                }
+                else // SplitUnevenLineActionType.Smart
+                {
+                    var try1First = string.Join(Environment.NewLine, lines.GetRange(0, splitIndex + 1)).Trim();
+                    var try1Second = string.Join(Environment.NewLine, lines.GetRange(splitIndex + 1, lines.Count - (splitIndex + 1))).Trim();
+
+                    var try2First = string.Join(Environment.NewLine, lines.GetRange(0, splitIndex)).Trim();
+                    var try2Second = string.Join(Environment.NewLine, lines.GetRange(splitIndex, lines.Count - splitIndex)).Trim();
+
+                    if (try1First.EndsWith('.') && !try2First.EndsWith('.'))
+                    {
+                        splitIndex = splitIndex + 1;
+                    }
+                    else if (!try1First.EndsWith(".") && try2First.EndsWith('.'))
+                    {
+                        // no changes
+                    }
+                    else if (Math.Abs(try1First.Length - try1Second.Length) < Math.Abs(try2First.Length - try2Second.Length))
+                    {
+                        splitIndex = splitIndex + 1;
+                    }
+                }
+            }
+
+            first = string.Join(Environment.NewLine, lines.GetRange(0, splitIndex)).Trim();
+            second = string.Join(Environment.NewLine, lines.GetRange(splitIndex, lines.Count - splitIndex)).Trim();
+        }
+        else
+        {
+            var brokenLines = Utilities.AutoBreakLine(text, Se.Settings.General.SubtitleLineMaximumLength, 0, languageCode).SplitToLines();
+            if (brokenLines.Count == 2)
+            {
+                first = brokenLines[0].Trim();
+                second = brokenLines[1].Trim();
+            }
+            else
+            {
+                first = text;
+                second = string.Empty;
+            }
+        }
+
+        // SE 4 parity (#12195): "Split line at cursor" applies the configured continuation
+        // style (e.g. "Ellipses (trailing only)") to the halves - a trailing ellipsis on
+        // the first line, and a leading marker on the second for leading styles - instead
+        // of a clean cut.
+        if (!string.IsNullOrWhiteSpace(first)
+            && !string.IsNullOrWhiteSpace(second)
+            && Enum.TryParse<ContinuationStyle>(Se.Settings.General.ContinuationStyle, out var continuationStyle)
+            && continuationStyle != ContinuationStyle.None)
+        {
+            var continuationProfile = ContinuationUtilities.GetContinuationProfile(continuationStyle);
+            if (ContinuationUtilities.ShouldAddSuffix(first, continuationProfile))
+            {
+                first = ContinuationUtilities.AddSuffixIfNeeded(first, continuationProfile, false);
+                second = ContinuationUtilities.AddPrefixIfNeeded(second, continuationProfile, false);
+            }
+        }
+
+        return FixTags(first, second);
     }
 
     // Strip HTML/ASSA tags and ALL line-break variants for length measurement.

--- a/tests/UI/Logic/SplitManagerTests.cs
+++ b/tests/UI/Logic/SplitManagerTests.cs
@@ -1,4 +1,4 @@
-using Nikse.SubtitleEdit.Core.Common;
+﻿using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic;
@@ -585,5 +585,94 @@ public class SplitManagerTests
         Assert.Equal(1900.0, subtitles[0].EndTime.TotalMilliseconds, 1);
         var gapMs = subtitles[1].StartTime.TotalMilliseconds - subtitles[0].EndTime.TotalMilliseconds;
         Assert.Equal(100.0, gapMs, 1);
+    }
+
+    // #14434: with an editable original loaded, a split used to copy the complete original
+    // onto both halves. The original is now split by the same rules as the translation.
+
+    [Fact]
+    public void Split_WithOriginal_AutoSplitsOriginalOnItsOwnLineBreak()
+    {
+        Se.Settings.General.MinimumBetweenLines.Milliseconds = 0;
+        var manager = new SplitManager();
+        var subtitle = MakeSubtitle($"First line{Environment.NewLine}Second line", 1, 3);
+        subtitle.OriginalText = $"Første linje{Environment.NewLine}Anden linje";
+        var subtitles = new ObservableCollection<SubtitleLineViewModel> { subtitle };
+
+        manager.Split(subtitles, subtitle, -1, -1, "en", new OriginalSplit(-1, "da"));
+
+        Assert.Equal(2, subtitles.Count);
+        Assert.Equal("First line", subtitles[0].Text);
+        Assert.Equal("Second line", subtitles[1].Text);
+        Assert.Equal("Første linje", subtitles[0].OriginalText);
+        Assert.Equal("Anden linje", subtitles[1].OriginalText);
+    }
+
+    [Fact]
+    public void Split_WithOriginalTextIndex_SplitsOriginalAtItsOwnCaret()
+    {
+        Se.Settings.General.MinimumBetweenLines.Milliseconds = 0;
+        var manager = new SplitManager();
+        var subtitle = MakeSubtitle($"First line{Environment.NewLine}Second line", 1, 3);
+        subtitle.OriginalText = "Første del og anden del";
+        var subtitles = new ObservableCollection<SubtitleLineViewModel> { subtitle };
+
+        // The original box has focus: its caret splits the original, the translation auto-splits.
+        manager.Split(subtitles, subtitle, -1, -1, "en", new OriginalSplit("Første del".Length, "da"));
+
+        Assert.Equal(2, subtitles.Count);
+        Assert.Equal("First line", subtitles[0].Text);
+        Assert.Equal("Second line", subtitles[1].Text);
+        Assert.Equal("Første del", subtitles[0].OriginalText);
+        Assert.Equal("og anden del", subtitles[1].OriginalText);
+    }
+
+    [Fact]
+    public void Split_WithTranslationTextIndexAndOriginal_OriginalDoesNotShareTheCaret()
+    {
+        Se.Settings.General.MinimumBetweenLines.Milliseconds = 0;
+        var manager = new SplitManager();
+        var subtitle = MakeSubtitle("Hello there my friend", 1, 3);
+        subtitle.OriginalText = $"Hej der{Environment.NewLine}min ven";
+        var subtitles = new ObservableCollection<SubtitleLineViewModel> { subtitle };
+
+        manager.Split(subtitles, subtitle, -1, "Hello there".Length, "en", new OriginalSplit(-1, "da"));
+
+        Assert.Equal("Hello there", subtitles[0].Text);
+        Assert.Equal("my friend", subtitles[1].Text);
+        Assert.Equal("Hej der", subtitles[0].OriginalText);
+        Assert.Equal("min ven", subtitles[1].OriginalText);
+    }
+
+    [Fact]
+    public void Split_WithOriginal_UnbreakableOriginalStaysOnFirstHalf()
+    {
+        Se.Settings.General.MinimumBetweenLines.Milliseconds = 0;
+        var manager = new SplitManager();
+        var subtitle = MakeSubtitle($"First line{Environment.NewLine}Second line", 1, 3);
+        subtitle.OriginalText = "Hej";
+        var subtitles = new ObservableCollection<SubtitleLineViewModel> { subtitle };
+
+        manager.Split(subtitles, subtitle, -1, -1, "en", new OriginalSplit(-1, "da"));
+
+        Assert.Equal("Hej", subtitles[0].OriginalText);
+        Assert.Equal(string.Empty, subtitles[1].OriginalText);
+    }
+
+    [Fact]
+    public void Split_WithoutOriginalSplit_LeavesOriginalOnBothHalves()
+    {
+        // A read-only reference is not split: the file is authoritative and both halves keep
+        // displaying the original line they overlap.
+        Se.Settings.General.MinimumBetweenLines.Milliseconds = 0;
+        var manager = new SplitManager();
+        var subtitle = MakeSubtitle($"First line{Environment.NewLine}Second line", 1, 3);
+        subtitle.OriginalText = $"Første linje{Environment.NewLine}Anden linje";
+        var subtitles = new ObservableCollection<SubtitleLineViewModel> { subtitle };
+
+        manager.Split(subtitles, subtitle, "en");
+
+        Assert.Equal($"Første linje{Environment.NewLine}Anden linje", subtitles[0].OriginalText);
+        Assert.Equal($"Første linje{Environment.NewLine}Anden linje", subtitles[1].OriginalText);
     }
 }


### PR DESCRIPTION
Fixes #14434.

## Problem
With **Allow edit of original subtitle** enabled, splitting a line split the translation and the timing, but the new row was created by the view-model copy constructor and so carried the complete original text. Both halves ended up with the full original, and every split desynchronized the two columns. "Split at cursor" also always read the caret from the translation text box, even when the original text box had focus.

## Fix
- `SplitManager` gets an optional `OriginalSplit(TextIndex, LanguageCode)` argument. The text-split pipeline (line break, weighted line count, auto-break, dialog dashes, continuation style, tag balancing) is extracted into one helper and applied to `OriginalText` as well, with the original's own language.
- `SplitLine` takes the caret from whichever text box has focus (SE4 parity): the original box splits the original at its caret and auto-splits the translation; the translation box does the reverse. The two languages never share one split position, as the reporter suggested.
- The assisted split applies the same original auto-split.
- Read-only references are not split: the file is authoritative there and the sticky refresh re-syncs the displayed text. The existing four `Split` overloads keep their behavior.

## Tests
Five new `SplitManagerTests` cases: auto-split of a two-line original, original-caret split, translation-caret split with an independent original, an unbreakable original staying on the first half, and the no-original-split contract for read-only references. Split- and original-related UI tests pass (248).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
