### PR TITLE
Settings: keep the selected line when settings are applied (#14421)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -12320,8 +12320,6 @@ public partial class MainViewModel :
 
         if (baselineSerialized != newSettingsSerialized)
         {
-            var firstSelectedIndex = SubtitleGrid.SelectedIndex;
-
             // Apply video-player visibility toggles directly on the existing
             // VideoPlayerControl. StopIsVisible / FullScreenIsVisible are plain
             // Avalonia styled properties, so writing to them updates the button
@@ -12349,11 +12347,7 @@ public partial class MainViewModel :
             // destroys and recreates the video player control (a native Win32 HWND on Windows
             // with mpv-wid/VLC). Doing that inside the ShowDialog continuation races the modal
             // dialog's teardown and can leave the main window disabled - a full UI freeze (#10815).
-            Dispatcher.UIThread.Post(() =>
-            {
-                ApplySettings();
-                SelectAndScrollToRow(firstSelectedIndex);
-            });
+            Dispatcher.UIThread.Post(ApplySettings);
         }
     }
 
@@ -12451,6 +12445,13 @@ public partial class MainViewModel :
 
     public void ApplySettings()
     {
+        // Restored at the very end, after the format list refresh below: SetLayout re-creates
+        // the grid (which silently auto-selects row 0), and re-filling SubtitleFormats then
+        // fires the format-combo handler, which read that row 0 back and scrolled to it. The
+        // scroll helper keeps one pending index, last writer wins - so the row the user was
+        // editing was lost on Apply and on OK after Apply (issue #14421).
+        var selectedIndex = SubtitleGrid.SelectedIndex;
+
         UiUtil.SetFontName(Se.Settings.Appearance.FontName);
         UiTheme.SetCurrentTheme();
 
@@ -12621,6 +12622,8 @@ public partial class MainViewModel :
         }
 
         RefreshSubtitlePreview();
+
+        SelectAndScrollToRow(selectedIndex);
     }
 
     public VideoPlayerControl? GetVideoPlayerControl()
@@ -31144,6 +31147,12 @@ public partial class MainViewModel :
 
         var idx = SubtitleGrid.SelectedIndex;
 
+        // Only put the selection back when the grid's selection is the view model's. A freshly
+        // built grid (ApplySettings/SetLayout) auto-selects row 0 without telling the view model,
+        // and the format list refresh that follows fired this handler with that row 0 - which
+        // then overrode the pending restore of the row the user was on (issue #14421).
+        var restoreSelection = idx >= 0 && ReferenceEquals(SubtitleGrid.SelectedItem, SelectedSubtitle);
+
         if (!_opening && !_changingFormatProgrammatically && e.RemovedItems.Count == 1 && e.AddedItems.Count == 1)
         {
             var format = e.AddedItems[0] as SubtitleFormat;
@@ -31253,7 +31262,10 @@ public partial class MainViewModel :
             }
         }
 
-        SelectAndScrollToRow(idx);
+        if (restoreSelection)
+        {
+            SelectAndScrollToRow(idx);
+        }
     }
 
     internal void AutoSelectOnPlayCheckedChanged()

--- a/tests/UI/Features/Main/ApplySettingsKeepsSelectionTests.cs
+++ b/tests/UI/Features/Main/ApplySettingsKeepsSelectionTests.cs
@@ -1,0 +1,117 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// Applying settings rebuilds the layout - and with it the subtitle grid - and refreshes the
+/// subtitle format list. The fresh grid silently auto-selects row 0, and every format-combo
+/// SelectionChanged raised by the list refresh read that row 0 back and scrolled to it, so the
+/// row the user was editing was lost on Apply and on OK after Apply (issue #14421).
+/// </summary>
+public class ApplySettingsKeepsSelectionTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    [AvaloniaFact]
+    public async Task ApplySettings_KeepsTheSelectedRow()
+    {
+        var (window, vm) = ShowMainWindowWithLines(300);
+
+        vm.SelectAndScrollToSubtitle(vm.Subtitles[100]);
+        await SettleAsync(window);
+        Assert.Equal("Line 101", vm.SelectedSubtitle?.Text);
+        Assert.Equal(100, vm.SubtitleGrid.SelectedIndex);
+
+        vm.ApplySettings();
+        await SettleAsync(window);
+        await SettleAsync(window);
+
+        Assert.Equal("Line 101", vm.SelectedSubtitle?.Text);
+        Assert.Equal(100, vm.SubtitleGrid.SelectedIndex);
+        Assert.Equal("Line 101", (vm.SubtitleGrid.SelectedItem as SubtitleLineViewModel)?.Text);
+    }
+
+    [AvaloniaFact]
+    public async Task ApplySettings_Twice_KeepsTheSelectedRow()
+    {
+        // Apply followed by OK with a further change runs the apply path twice in a row.
+        var (window, vm) = ShowMainWindowWithLines(300);
+
+        vm.SelectAndScrollToSubtitle(vm.Subtitles[42]);
+        await SettleAsync(window);
+
+        vm.ApplySettings();
+        await SettleAsync(window);
+        vm.ApplySettings();
+        await SettleAsync(window);
+        await SettleAsync(window);
+
+        Assert.Equal("Line 43", vm.SelectedSubtitle?.Text);
+        Assert.Equal(42, vm.SubtitleGrid.SelectedIndex);
+    }
+
+    private (Window Window, MainViewModel Vm) ShowMainWindowWithLines(int lineCount)
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1400, Height = 900 };
+        _windows.Add(window);
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var vm = (MainViewModel)view.DataContext!;
+        window.SuppressSaveChangesPromptOnClose(vm);
+        vm.Menu.IsVisible = true;
+
+        for (var i = 0; i < lineCount; i++)
+        {
+            vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph($"Line {i + 1}", i * 2000, i * 2000 + 1500), null!)
+            {
+                Number = i + 1,
+            });
+        }
+
+        Settle(window);
+        return (window, vm);
+    }
+
+    private static void Settle(Window window)
+    {
+        for (var pump = 0; pump < 8; pump++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+        }
+    }
+
+    // The scroll/selection restore is posted, so give the dispatcher a real tick as well.
+    private static async Task SettleAsync(Window window)
+    {
+        Settle(window);
+        await Task.Delay(50);
+        Settle(window);
+    }
+}


### PR DESCRIPTION
Fixes #14421

**Problem.** Opening Settings and pressing Apply (or OK after Apply / OK after a change) jumped the grid back to the first subtitle.

**Cause.** `ApplySettings` rebuilds the layout via `SetLayout`, and the fresh TableView silently auto-selects row 0 while the old grid's teardown writes null into `SelectedSubtitle`. `ApplySettings` then clears and refills `SubtitleFormats` and re-sets the selected format, which fires `ComboBoxSubtitleFormatChanged` several times; each call read `SubtitleGrid.SelectedIndex` from the fresh grid (0) and ended with `SelectAndScrollToRow(0)`. `SelectAndScrollToRow` keeps a single pending index, last writer wins, so the restore `SetLayout` had posted for the user's row was overridden. The OK path in `CommandShowSettings` happened to survive because it added its own restore after `ApplySettings`; the Apply button calls `ApplySettings` alone.

**Fix.**
- `ApplySettings` captures the selected index up front and restores it at the very end, after the format-list refresh. The extra restore in `CommandShowSettings` is folded into it, so every caller is covered.
- `ComboBoxSubtitleFormatChanged` only re-selects a row when the grid's selection is the view model's (`SubtitleGrid.SelectedItem` is `SelectedSubtitle`), so a silent row-0 auto-pick can no longer hijack a pending scroll.

**Test.** `ApplySettingsKeepsSelectionTests` hosts the main view headlessly with 300 lines, selects a middle row, runs `ApplySettings` (once, and twice for the Apply-then-OK sequence), and asserts the row is still selected. Both tests fail on main and pass with the fix. The 391 existing Main-feature and format tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)