### PR TITLE
Merge with an editable original no longer resurrects the merged line (#14434)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -3349,9 +3349,14 @@ public partial class MainViewModel :
             Renumber();
             _updateAudioVisualizer = true;
 
-            // The action may have deleted or merged rows that displayed original lines; the refresh
-            // brings those lines back (read-only) and re-syncs what is displayed.
-            ReapplyOriginalReference(capture: false);
+            // The action may have deleted or merged rows that displayed original lines. For a
+            // read-only original the refresh brings those lines back (the file is authoritative).
+            // An editable original is captured from the rows again first: a merge folded the
+            // second row's original text into the surviving row, so its line is consumed, not
+            // orphaned - refreshing against the pre-merge capture resurrected it as an extra
+            // display-only row under the merged line, showing that text twice (#14434). The
+            // capture is a no-op for a read-only original, so that path keeps its behavior.
+            ReapplyOriginalReference();
         }
     }
 

--- a/tests/UI/Features/Main/MainEditOriginalModeTests.cs
+++ b/tests/UI/Features/Main/MainEditOriginalModeTests.cs
@@ -190,6 +190,71 @@ public class MainEditOriginalModeTests
         method.Invoke(vm, new object?[] { 0, "reference.srt", reference, match, isReadOnly });
     }
 
+    /// <summary>
+    /// Merging two rows of an editable original merges their original texts too, so the second
+    /// row's original line is consumed - it must not come back as an extra display-only row under
+    /// the merged line, where it would show the same text twice (#14434).
+    /// </summary>
+    [AvaloniaFact]
+    public void MergeWithEditableOriginal_DoesNotBringTheMergedOriginalLineBack()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            ImportSampleReference(vm, isReadOnly: false);
+            Assert.True(vm.CanEditOriginal);
+            Assert.True(vm.IsShowingOriginalNonMatchingLines);
+
+            vm.SelectAndScrollToSubtitle(vm.Subtitles[0]);
+            vm.MergeWithLineAfterCommand.Execute(null);
+            Dispatcher.UIThread.RunJobs();
+
+            var working = vm.Subtitles.Where(p => !p.IsReferenceOnly).ToList();
+            var merged = Assert.Single(working);
+            Assert.Contains("Reference one", merged.OriginalText);
+            Assert.Contains("Reference two", merged.OriginalText);
+
+            // Only the line that never had a translation stays as a display-only row.
+            var referenceRow = Assert.Single(vm.Subtitles, p => p.IsReferenceOnly);
+            Assert.Equal("Reference only - no translation", referenceRow.OriginalText);
+
+            // The original the merge is saved from carries the merged line once, not twice.
+            var texts = vm.GetUpdateSubtitleOriginal().Paragraphs.Select(p => p.Text).ToList();
+            Assert.Equal(2, texts.Count);
+            Assert.DoesNotContain(texts, t => t == "Reference two");
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    /// <summary>
+    /// A read-only reference is the file's contents: merging two rows must still bring the second
+    /// row's original line back as a display-only row, nothing of the reference is ever lost.
+    /// </summary>
+    [AvaloniaFact]
+    public void MergeWithReadOnlyOriginal_StillBringsTheMergedOriginalLineBack()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            ImportSampleReference(vm, isReadOnly: true);
+
+            vm.SelectAndScrollToSubtitle(vm.Subtitles[0]);
+            vm.MergeWithLineAfterCommand.Execute(null);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Single(vm.Subtitles, p => !p.IsReferenceOnly);
+            var referenceTexts = vm.Subtitles.Where(p => p.IsReferenceOnly).Select(p => p.OriginalText).ToList();
+            Assert.Equal(new[] { "Reference only - no translation", "Reference two" }, referenceTexts);
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
     private static (Window Window, MainViewModel Vm) CreateMainViewModel()
     {
         var services = new ServiceCollection();


### PR DESCRIPTION
Follow-up to #14437, which fixed the split half of #14434. This fixes the merge half that @saltarob asked about in https://github.com/SubtitleEdit/subtitleedit/issues/14434#issuecomment-5511001128.

## Problem
With **Show all original lines** and **Allow edit of original subtitle** enabled, merging two rows merged their original texts onto the surviving row correctly, but the second row's original line came back as an extra display-only reference row under the merged line, so that text was shown twice.

Every merge command runs inside `WithoutReferenceOnlyRows`, which captures the original from the rows *before* the merge (the second row's original is its own paragraph there), runs the merge, and then refreshed the reference with `capture: false` against that pre-merge capture. The refresh saw the second row's paragraph unclaimed by any row and re-inserted it as a reference-only row. A plain delete never had this problem because its debounced refresh captures from the rows first.

## Fix
The refresh after the action now captures from the rows again (`ReapplyOriginalReference()` instead of `capture: false`). For an editable original the merged line is consumed, not orphaned. `CaptureOriginalFromRows` is a no-op for a read-only original, so a read-only reference keeps bringing the file's line back exactly as before.

## Tests
Two new `MainEditOriginalModeTests` cases: merge with an editable original leaves only the genuinely unmatched reference row and saves the merged line once; merge with a read-only original still brings the merged line back. The editable case fails on `main` (two reference rows) and passes with the fix. All 376 merge/original/reference/split UI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)