### PR TITLE
Add FixType property to IFixCommonError

### DIFF
--- a/src/libse/Enums/FixType.cs
+++ b/src/libse/Enums/FixType.cs
@@ -1,0 +1,14 @@
+﻿namespace Nikse.SubtitleEdit.Core.Enums
+{
+    public enum FixType
+    {
+        Time,
+        Formatting,
+        Dialog,
+        Punctuation,
+        Casing,
+        Spacing,
+        Characters,
+        Ocr,
+    }
+}

--- a/src/libse/Forms/FixCommonErrors/AddMissingQuotes.cs
+++ b/src/libse/Forms/FixCommonErrors/AddMissingQuotes.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 
@@ -10,6 +11,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string AddMissingQuote { get; set; } = "Add missing quote (\")";
         }
+
+        public FixType FixType => FixType.Punctuation;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/Fix3PlusLines.cs
+++ b/src/libse/Forms/FixCommonErrors/Fix3PlusLines.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -10,6 +11,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string Fix3PlusLine { get; set; } = "Fix subtitles with more than two lines";
             public static string Fix3PlusLines { get; set; } = "Fix subtitles with more than two lines";
         }
+
+        public FixType FixType => FixType.Formatting;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixAloneLowercaseIToUppercaseI.cs
+++ b/src/libse/Forms/FixCommonErrors/FixAloneLowercaseIToUppercaseI.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 using System.Text.RegularExpressions;
@@ -11,6 +12,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixLowercaseIToUppercaseI { get; set; } = "Fix alone lowercase 'i' to 'I' (English)";
         }
+
+        public FixType FixType => FixType.Casing;
 
         // Every needle below embeds Environment.NewLine or the target character, so none of them
         // can be a compile-time constant: written inline they were ten fresh strings allocated

--- a/src/libse/Forms/FixCommonErrors/FixCommas.cs
+++ b/src/libse/Forms/FixCommonErrors/FixCommas.cs
@@ -2,6 +2,7 @@
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System.Text.RegularExpressions;
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
 {
@@ -11,6 +12,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixCommas { get; set; } = "Fix commas";
         }
+
+        public FixType FixType => FixType.Punctuation;
 
         // Hoisted out of Fix() so each Fix() call reuses the same compiled NFA instead of
         // recompiling per-call. The Arabic variants below used to be re-allocated *per

--- a/src/libse/Forms/FixCommonErrors/FixContinuationStyle.cs
+++ b/src/libse/Forms/FixCommonErrors/FixContinuationStyle.cs
@@ -17,6 +17,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string FixUnnecessaryLeadingDots { get; set; } = "Remove unnecessary leading dots";
         }
 
+        public FixType FixType => FixType.Punctuation;
+
         private ContinuationUtilities.ContinuationProfile _continuationProfile;
         private List<string> _names;
         public string FixAction { get; set; }

--- a/src/libse/Forms/FixCommonErrors/FixDanishLetterI.cs
+++ b/src/libse/Forms/FixCommonErrors/FixDanishLetterI.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -9,6 +10,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixDanishLetterI { get; set; } = "Fix Danish letter 'i'";
         }
+
+        public FixType FixType => FixType.Casing;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixDialogsOnOneLine.cs
+++ b/src/libse/Forms/FixCommonErrors/FixDialogsOnOneLine.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -9,6 +10,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixDialogsOnOneLine { get; set; } = "Fix dialogs on one line";
         }
+
+        public FixType FixType => FixType.Dialog;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixDoubleApostrophes.cs
+++ b/src/libse/Forms/FixCommonErrors/FixDoubleApostrophes.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -9,6 +10,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixDoubleApostrophes { get; set; } = "Fix double apostrophe characters ('') to a single quote (\")";
         }
+
+        public FixType FixType => FixType.Punctuation;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixDoubleDash.cs
+++ b/src/libse/Forms/FixCommonErrors/FixDoubleDash.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 
@@ -10,6 +11,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixDoubleDash { get; set; } = "Fix '--' -> '...'";
         }
+
+        public FixType FixType => FixType.Punctuation;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixDoubleGreaterThan.cs
+++ b/src/libse/Forms/FixCommonErrors/FixDoubleGreaterThan.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 
@@ -10,6 +11,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixDoubleGreaterThan { get; set; } = "Remove '>>'";
         }
+
+        public FixType FixType => FixType.Punctuation;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixEllipsesStart.cs
+++ b/src/libse/Forms/FixCommonErrors/FixEllipsesStart.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 
@@ -10,6 +11,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixEllipsesStart { get; set; } = "Remove leading '...'";
         }
+
+        public FixType FixType => FixType.Punctuation;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixEmptyLines.cs
+++ b/src/libse/Forms/FixCommonErrors/FixEmptyLines.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 
@@ -16,6 +17,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string RemovedEmptyLineInMiddle { get; set; } = "Remove empty line in middle";
             public static string RemovedEmptyLinesUnusedLineBreaks { get; set; } = "Remove empty lines/unused line breaks";
         }
+
+        public FixType FixType => FixType.Formatting;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixHyphensInDialog.cs
+++ b/src/libse/Forms/FixCommonErrors/FixHyphensInDialog.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -9,6 +10,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixHyphensInDialogs { get; set; } = "Fix dash in dialogs via style: {0}";
         }
+
+        public FixType FixType => FixType.Dialog;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixHyphensRemoveDashSingleLine.cs
+++ b/src/libse/Forms/FixCommonErrors/FixHyphensRemoveDashSingleLine.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.RegularExpressions;
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -10,6 +11,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string RemoveHyphensSingleLine { get; set; } = "Remove dialog dashes in single lines";
         }
+
+        public FixType FixType => FixType.Dialog;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixInvalidItalicTags.cs
+++ b/src/libse/Forms/FixCommonErrors/FixInvalidItalicTags.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -10,6 +11,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string FixInvalidItalicTag { get; set; } = "Fix invalid italic tag";
             public static string FixInvalidItalicTags { get; set; } = "Fix invalid italic tags";
         }
+
+        public FixType FixType => FixType.Formatting;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixLongDisplayTimes.cs
+++ b/src/libse/Forms/FixCommonErrors/FixLongDisplayTimes.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -9,6 +10,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixLongDisplayTime { get; set; } = "Fix long display time";
         }
+
+        public FixType FixType => FixType.Time;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixLongLines.cs
+++ b/src/libse/Forms/FixCommonErrors/FixLongLines.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -12,6 +13,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string BreakLongLines { get; set; } = "Break long lines";
             public static string UnableToFixTextXY { get; set; } = "Unable to fix text number {0}: {1}";
         }
+
+        public FixType FixType => FixType.Formatting;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixMissingOpenBracket.cs
+++ b/src/libse/Forms/FixCommonErrors/FixMissingOpenBracket.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 using System.Linq;
@@ -11,6 +12,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixMissingOpenBracket { get; set; } = "Fix missing [ or ( in line";
         }
+
+        public FixType FixType => FixType.Punctuation;
 
         private static bool IsIgnorable(char ch) => char.IsWhiteSpace(ch) || ch == '-';
 

--- a/src/libse/Forms/FixCommonErrors/FixMissingPeriodsAtEndOfLine.cs
+++ b/src/libse/Forms/FixCommonErrors/FixMissingPeriodsAtEndOfLine.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 using System.Linq;
@@ -12,6 +13,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string FixMissingPeriodAtEndOfLine { get; set; } = "Add missing period at end of line";
             public static string AddPeriods { get; set; } = "Add missing period at end of line";
         }
+
+        public FixType FixType => FixType.Punctuation;
 
         private static readonly char[] WordSplitChars = { ' ', '.', ',', '-', '?', '!', ':', ';', '"', '(', ')', '[', ']', '{', '}', '|', '<', '>', '/', '+', '\r', '\n' };
 

--- a/src/libse/Forms/FixCommonErrors/FixMissingSpaces.cs
+++ b/src/libse/Forms/FixCommonErrors/FixMissingSpaces.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 using System.Text.RegularExpressions;
@@ -15,6 +16,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string FixMissingSpace { get; set; } = "Fix missing space";
             public static string FixMissingSpaces { get; set; } = "Fix missing spaces";
         }
+
+        public FixType FixType => FixType.Spacing;
 
         // FixSpaceAfter asks "is this character in that little set?" for every occurrence of the
         // fix character in the file. Both sets used to be probed with

--- a/src/libse/Forms/FixCommonErrors/FixMusicNotation.cs
+++ b/src/libse/Forms/FixCommonErrors/FixMusicNotation.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 
@@ -10,6 +11,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixMusicNotation { get; set; } = "Replace music symbols (e.g. âTª) with preferred symbol";
         }
+
+        public FixType FixType => FixType.Characters;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixOverlappingDisplayTimes.cs
+++ b/src/libse/Forms/FixCommonErrors/FixOverlappingDisplayTimes.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using System;
@@ -16,6 +17,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string XFixedToYZ { get; set; } = "{0} fixed to: {1}{2}";
             public static string UnableToFixTextXY { get; set; } = "Unable to fix text number {0}: {1}";
         }
+
+        public FixType FixType => FixType.Time;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixShortDisplayTimes.cs
+++ b/src/libse/Forms/FixCommonErrors/FixShortDisplayTimes.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -12,6 +13,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string FixShortDisplayTimes { get; set; } = "Fix short display times";
             public static string UnableToFixTextXY { get; set; } = "Unable to fix text number {0}: {1}";
         }
+
+        public FixType FixType => FixType.Time;
 
         private IFixCallbacks _callbacks;
 

--- a/src/libse/Forms/FixCommonErrors/FixShortGaps.cs
+++ b/src/libse/Forms/FixCommonErrors/FixShortGaps.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -10,6 +11,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string FixShortGap { get; set; } = "Fix short gap";
             public static string FixShortGaps { get; set; } = "Fix short gaps";
         }
+
+        public FixType FixType => FixType.Time;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixShortLines.cs
+++ b/src/libse/Forms/FixCommonErrors/FixShortLines.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -9,6 +10,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string MergeShortLine { get; set; } = "Merge short line (single sentence)";
         }
+
+        public FixType FixType => FixType.Formatting;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixShortLinesAll.cs
+++ b/src/libse/Forms/FixCommonErrors/FixShortLinesAll.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 
@@ -11,6 +12,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string MergeShortLineAll { get; set; } = "Merge short line (all except dialogs)";
             public static string RemoveLineBreaks { get; set; } = "Remove line breaks in short texts with only one sentence";
         }
+
+        public FixType FixType => FixType.Formatting;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixShortLinesPixelWidth.cs
+++ b/src/libse/Forms/FixCommonErrors/FixShortLinesPixelWidth.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 
@@ -11,6 +12,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string UnbreakShortLine { get; set; } = "Unbreak short line (pixel width)";
             public static string RemoveLineBreaks { get; set; } = "Unbreak subtitles that can fit on one line (pixel width)";
         }
+
+        public FixType FixType => FixType.Formatting;
         
         private readonly Func<string, int> _calcPixelWidth;
 

--- a/src/libse/Forms/FixCommonErrors/FixSpanishInvertedQuestionAndExclamationMarks.cs
+++ b/src/libse/Forms/FixCommonErrors/FixSpanishInvertedQuestionAndExclamationMarks.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 using System.Globalization;
@@ -16,6 +17,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixSpanishInvertedQuestionAndExclamationMarks { get; set; } = "Fix Spanish inverted question and exclamation marks";
         }
+
+        public FixType FixType => FixType.Punctuation;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterColon.cs
+++ b/src/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterColon.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -11,6 +12,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string StartWithUppercaseLetterAfterColon { get; set; } = "Start with uppercase letter after colon/semicolon";
         }
+
+        public FixType FixType => FixType.Casing;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterParagraph.cs
+++ b/src/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterParagraph.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 
@@ -10,6 +11,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixFirstLetterToUppercaseAfterParagraph { get; set; } = "Fix first letter to uppercase after paragraph";
         }
+
+        public FixType FixType => FixType.Casing;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterPeriodInsideParagraph.cs
+++ b/src/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterPeriodInsideParagraph.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System.Text.RegularExpressions;
 
@@ -10,6 +11,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string StartWithUppercaseLetterAfterPeriodInsideParagraph { get; set; } = "Start with uppercase letter after period inside paragraph";
         }
+
+        public FixType FixType => FixType.Casing;
 
         private static readonly char[] ExpectedChars = { '.', '!', '?' };
 

--- a/src/libse/Forms/FixCommonErrors/FixTurkishAnsiToUnicode.cs
+++ b/src/libse/Forms/FixCommonErrors/FixTurkishAnsiToUnicode.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -9,6 +10,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixTurkishAnsi { get; set; } = "Fix Turkish ANSI (Icelandic) letters to Unicode";
         }
+
+        public FixType FixType => FixType.Characters;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixUnnecessaryLeadingDots.cs
+++ b/src/libse/Forms/FixCommonErrors/FixUnnecessaryLeadingDots.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 
@@ -10,6 +11,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixUnnecessaryLeadingDots { get; set; } = "Remove unnecessary leading dots";
         }
+
+        public FixType FixType => FixType.Punctuation;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixUnneededPeriods.cs
+++ b/src/libse/Forms/FixCommonErrors/FixUnneededPeriods.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 using System.Text;
@@ -12,6 +13,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string UnneededPeriod { get; set; } = "Unneeded period";
             public static string RemoveUnneededPeriods { get; set; } = "Remove unneeded periods";
         }
+
+        public FixType FixType => FixType.Punctuation;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixUnneededSpaces.cs
+++ b/src/libse/Forms/FixCommonErrors/FixUnneededSpaces.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 
@@ -11,6 +12,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string UnneededSpace { get; set; } = "Unneeded space";
             public static string RemoveUnneededSpaces { get; set; } = "Remove unneeded spaces";
         }
+
+        public FixType FixType => FixType.Spacing;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixUppercaseIInsideWords.cs
+++ b/src/libse/Forms/FixCommonErrors/FixUppercaseIInsideWords.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 using System.Text.RegularExpressions;
@@ -12,6 +13,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string FixUppercaseIInsideLowercaseWord { get; set; } = "Fix uppercase 'i' inside lowercase word";
             public static string FixUppercaseIInsideLowercaseWords { get; set; } = "Fix uppercase 'i' inside lowercase words (OCR error)";
         }
+
+        public FixType FixType => FixType.Casing;
 
         private static readonly Regex ReAfterLowercaseLetter = new Regex(@"\p{Ll}I", RegexOptions.Compiled);
         private static readonly Regex ReBeforeLowercaseLetter = new Regex(@"\p{L}I\p{Ll}", RegexOptions.Compiled);

--- a/src/libse/Forms/FixCommonErrors/NormalizeStrings.cs
+++ b/src/libse/Forms/FixCommonErrors/NormalizeStrings.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System.Linq;
 
@@ -10,6 +11,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string NormalizeStrings { get; set; } = "Normalize strings";
         }
+
+        public FixType FixType => FixType.Characters;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/RemoveDialogFirstLineInNonDialogs.cs
+++ b/src/libse/Forms/FixCommonErrors/RemoveDialogFirstLineInNonDialogs.cs
@@ -1,4 +1,5 @@
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -9,6 +10,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string RemoveDialogFirstInNonDialogs { get; set; } = "Remove start dash in non dialogs";
         }
+
+        public FixType FixType => FixType.Dialog;
 
         /// <summary>
         /// Dash characters that can be used as dialog marker - see issue #12748.

--- a/src/libse/Forms/FixCommonErrors/RemoveSpaceBetweenNumbers.cs
+++ b/src/libse/Forms/FixCommonErrors/RemoveSpaceBetweenNumbers.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -9,6 +10,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string RemoveSpaceBetweenNumber { get; set; } = "Remove space between numbers";
         }
+
+        public FixType FixType => FixType.Spacing;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Interfaces/IFixCommonError.cs
+++ b/src/libse/Interfaces/IFixCommonError.cs
@@ -1,9 +1,12 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 
 namespace Nikse.SubtitleEdit.Core.Interfaces
 {
     public interface IFixCommonError
     {
+        FixType FixType { get; }
+
         void Fix(Subtitle subtitle, IFixCallbacks callbacks);
     }
 }

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonOcrErrors.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonOcrErrors.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
 using Nikse.SubtitleEdit.Features.Ocr.OcrSubtitle;
@@ -18,6 +19,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixText { get; set; } = "Fix common OCR errors";
         }
+
+        public FixType FixType => FixType.Ocr;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {


### PR DESCRIPTION
## Summary
- Add a `FixType` enum (`Time`, `Formatting`, `Dialog`, `Punctuation`, `Casing`, `Spacing`, `Characters`, `Ocr`) in `src/libse/Enums`.
- Add `FixType FixType { get; }` to `IFixCommonError`, so the compiler enforces it on every implementation.
- Every fix rule (39 in libse plus `FixCommonOcrErrors` in the UI) declares the kind of fix it performs, so the UI and CLI can group, filter or sort rules by category.

No behaviour change on its own; the first consumer is the "Type" filter in the Fix common errors window, stacked on this PR.

## Test plan
- [ ] `dotnet build SubtitleEdit.sln` compiles (every `IFixCommonError` implementation has the new member)
- [ ] Spot-check a few classes: `FixCommas` is `Punctuation`, `FixShortGaps` is `Time`, `FixUnneededSpaces` is `Spacing`, `FixCommonOcrErrors` is `Ocr`
- [ ] `dotnet test tests/libse/LibSETests.csproj` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXEWrgv5uAnSzDgxFupSHZ
