### PR TITLE
Add a FixType filter to the Fix common errors rule list

### DIFF
--- a/src/libse/Enums/FixType.cs
+++ b/src/libse/Enums/FixType.cs
@@ -1,0 +1,14 @@
+﻿namespace Nikse.SubtitleEdit.Core.Enums
+{
+    public enum FixType
+    {
+        Time,
+        Formatting,
+        Dialog,
+        Punctuation,
+        Casing,
+        Spacing,
+        Characters,
+        Ocr,
+    }
+}

--- a/src/libse/Forms/FixCommonErrors/AddMissingQuotes.cs
+++ b/src/libse/Forms/FixCommonErrors/AddMissingQuotes.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 
@@ -10,6 +11,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string AddMissingQuote { get; set; } = "Add missing quote (\")";
         }
+
+        public FixType FixType => FixType.Punctuation;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/Fix3PlusLines.cs
+++ b/src/libse/Forms/FixCommonErrors/Fix3PlusLines.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -10,6 +11,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string Fix3PlusLine { get; set; } = "Fix subtitles with more than two lines";
             public static string Fix3PlusLines { get; set; } = "Fix subtitles with more than two lines";
         }
+
+        public FixType FixType => FixType.Formatting;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixAloneLowercaseIToUppercaseI.cs
+++ b/src/libse/Forms/FixCommonErrors/FixAloneLowercaseIToUppercaseI.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 using System.Text.RegularExpressions;
@@ -11,6 +12,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixLowercaseIToUppercaseI { get; set; } = "Fix alone lowercase 'i' to 'I' (English)";
         }
+
+        public FixType FixType => FixType.Casing;
 
         // Every needle below embeds Environment.NewLine or the target character, so none of them
         // can be a compile-time constant: written inline they were ten fresh strings allocated

--- a/src/libse/Forms/FixCommonErrors/FixCommas.cs
+++ b/src/libse/Forms/FixCommonErrors/FixCommas.cs
@@ -2,6 +2,7 @@
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System.Text.RegularExpressions;
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
 {
@@ -11,6 +12,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixCommas { get; set; } = "Fix commas";
         }
+
+        public FixType FixType => FixType.Punctuation;
 
         // Hoisted out of Fix() so each Fix() call reuses the same compiled NFA instead of
         // recompiling per-call. The Arabic variants below used to be re-allocated *per

--- a/src/libse/Forms/FixCommonErrors/FixContinuationStyle.cs
+++ b/src/libse/Forms/FixCommonErrors/FixContinuationStyle.cs
@@ -17,6 +17,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string FixUnnecessaryLeadingDots { get; set; } = "Remove unnecessary leading dots";
         }
 
+        public FixType FixType => FixType.Punctuation;
+
         private ContinuationUtilities.ContinuationProfile _continuationProfile;
         private List<string> _names;
         public string FixAction { get; set; }

--- a/src/libse/Forms/FixCommonErrors/FixDanishLetterI.cs
+++ b/src/libse/Forms/FixCommonErrors/FixDanishLetterI.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -9,6 +10,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixDanishLetterI { get; set; } = "Fix Danish letter 'i'";
         }
+
+        public FixType FixType => FixType.Casing;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixDialogsOnOneLine.cs
+++ b/src/libse/Forms/FixCommonErrors/FixDialogsOnOneLine.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -9,6 +10,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixDialogsOnOneLine { get; set; } = "Fix dialogs on one line";
         }
+
+        public FixType FixType => FixType.Dialog;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixDoubleApostrophes.cs
+++ b/src/libse/Forms/FixCommonErrors/FixDoubleApostrophes.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -9,6 +10,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixDoubleApostrophes { get; set; } = "Fix double apostrophe characters ('') to a single quote (\")";
         }
+
+        public FixType FixType => FixType.Punctuation;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixDoubleDash.cs
+++ b/src/libse/Forms/FixCommonErrors/FixDoubleDash.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 
@@ -10,6 +11,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixDoubleDash { get; set; } = "Fix '--' -> '...'";
         }
+
+        public FixType FixType => FixType.Punctuation;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixDoubleGreaterThan.cs
+++ b/src/libse/Forms/FixCommonErrors/FixDoubleGreaterThan.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 
@@ -10,6 +11,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixDoubleGreaterThan { get; set; } = "Remove '>>'";
         }
+
+        public FixType FixType => FixType.Punctuation;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixEllipsesStart.cs
+++ b/src/libse/Forms/FixCommonErrors/FixEllipsesStart.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 
@@ -10,6 +11,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixEllipsesStart { get; set; } = "Remove leading '...'";
         }
+
+        public FixType FixType => FixType.Punctuation;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixEmptyLines.cs
+++ b/src/libse/Forms/FixCommonErrors/FixEmptyLines.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 
@@ -16,6 +17,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string RemovedEmptyLineInMiddle { get; set; } = "Remove empty line in middle";
             public static string RemovedEmptyLinesUnusedLineBreaks { get; set; } = "Remove empty lines/unused line breaks";
         }
+
+        public FixType FixType => FixType.Formatting;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixHyphensInDialog.cs
+++ b/src/libse/Forms/FixCommonErrors/FixHyphensInDialog.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -9,6 +10,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixHyphensInDialogs { get; set; } = "Fix dash in dialogs via style: {0}";
         }
+
+        public FixType FixType => FixType.Dialog;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixHyphensRemoveDashSingleLine.cs
+++ b/src/libse/Forms/FixCommonErrors/FixHyphensRemoveDashSingleLine.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.RegularExpressions;
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -10,6 +11,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string RemoveHyphensSingleLine { get; set; } = "Remove dialog dashes in single lines";
         }
+
+        public FixType FixType => FixType.Dialog;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixInvalidItalicTags.cs
+++ b/src/libse/Forms/FixCommonErrors/FixInvalidItalicTags.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -10,6 +11,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string FixInvalidItalicTag { get; set; } = "Fix invalid italic tag";
             public static string FixInvalidItalicTags { get; set; } = "Fix invalid italic tags";
         }
+
+        public FixType FixType => FixType.Formatting;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixLongDisplayTimes.cs
+++ b/src/libse/Forms/FixCommonErrors/FixLongDisplayTimes.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -9,6 +10,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixLongDisplayTime { get; set; } = "Fix long display time";
         }
+
+        public FixType FixType => FixType.Time;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixLongLines.cs
+++ b/src/libse/Forms/FixCommonErrors/FixLongLines.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -12,6 +13,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string BreakLongLines { get; set; } = "Break long lines";
             public static string UnableToFixTextXY { get; set; } = "Unable to fix text number {0}: {1}";
         }
+
+        public FixType FixType => FixType.Formatting;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixMissingOpenBracket.cs
+++ b/src/libse/Forms/FixCommonErrors/FixMissingOpenBracket.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 using System.Linq;
@@ -11,6 +12,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixMissingOpenBracket { get; set; } = "Fix missing [ or ( in line";
         }
+
+        public FixType FixType => FixType.Punctuation;
 
         private static bool IsIgnorable(char ch) => char.IsWhiteSpace(ch) || ch == '-';
 

--- a/src/libse/Forms/FixCommonErrors/FixMissingPeriodsAtEndOfLine.cs
+++ b/src/libse/Forms/FixCommonErrors/FixMissingPeriodsAtEndOfLine.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 using System.Linq;
@@ -12,6 +13,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string FixMissingPeriodAtEndOfLine { get; set; } = "Add missing period at end of line";
             public static string AddPeriods { get; set; } = "Add missing period at end of line";
         }
+
+        public FixType FixType => FixType.Punctuation;
 
         private static readonly char[] WordSplitChars = { ' ', '.', ',', '-', '?', '!', ':', ';', '"', '(', ')', '[', ']', '{', '}', '|', '<', '>', '/', '+', '\r', '\n' };
 

--- a/src/libse/Forms/FixCommonErrors/FixMissingSpaces.cs
+++ b/src/libse/Forms/FixCommonErrors/FixMissingSpaces.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 using System.Text.RegularExpressions;
@@ -15,6 +16,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string FixMissingSpace { get; set; } = "Fix missing space";
             public static string FixMissingSpaces { get; set; } = "Fix missing spaces";
         }
+
+        public FixType FixType => FixType.Spacing;
 
         // FixSpaceAfter asks "is this character in that little set?" for every occurrence of the
         // fix character in the file. Both sets used to be probed with

--- a/src/libse/Forms/FixCommonErrors/FixMusicNotation.cs
+++ b/src/libse/Forms/FixCommonErrors/FixMusicNotation.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 
@@ -10,6 +11,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixMusicNotation { get; set; } = "Replace music symbols (e.g. âTª) with preferred symbol";
         }
+
+        public FixType FixType => FixType.Characters;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixOverlappingDisplayTimes.cs
+++ b/src/libse/Forms/FixCommonErrors/FixOverlappingDisplayTimes.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using System;
@@ -16,6 +17,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string XFixedToYZ { get; set; } = "{0} fixed to: {1}{2}";
             public static string UnableToFixTextXY { get; set; } = "Unable to fix text number {0}: {1}";
         }
+
+        public FixType FixType => FixType.Time;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixShortDisplayTimes.cs
+++ b/src/libse/Forms/FixCommonErrors/FixShortDisplayTimes.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -12,6 +13,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string FixShortDisplayTimes { get; set; } = "Fix short display times";
             public static string UnableToFixTextXY { get; set; } = "Unable to fix text number {0}: {1}";
         }
+
+        public FixType FixType => FixType.Time;
 
         private IFixCallbacks _callbacks;
 

--- a/src/libse/Forms/FixCommonErrors/FixShortGaps.cs
+++ b/src/libse/Forms/FixCommonErrors/FixShortGaps.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -10,6 +11,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string FixShortGap { get; set; } = "Fix short gap";
             public static string FixShortGaps { get; set; } = "Fix short gaps";
         }
+
+        public FixType FixType => FixType.Time;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixShortLines.cs
+++ b/src/libse/Forms/FixCommonErrors/FixShortLines.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -9,6 +10,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string MergeShortLine { get; set; } = "Merge short line (single sentence)";
         }
+
+        public FixType FixType => FixType.Formatting;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixShortLinesAll.cs
+++ b/src/libse/Forms/FixCommonErrors/FixShortLinesAll.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 
@@ -11,6 +12,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string MergeShortLineAll { get; set; } = "Merge short line (all except dialogs)";
             public static string RemoveLineBreaks { get; set; } = "Remove line breaks in short texts with only one sentence";
         }
+
+        public FixType FixType => FixType.Formatting;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixShortLinesPixelWidth.cs
+++ b/src/libse/Forms/FixCommonErrors/FixShortLinesPixelWidth.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 
@@ -11,6 +12,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string UnbreakShortLine { get; set; } = "Unbreak short line (pixel width)";
             public static string RemoveLineBreaks { get; set; } = "Unbreak subtitles that can fit on one line (pixel width)";
         }
+
+        public FixType FixType => FixType.Formatting;
         
         private readonly Func<string, int> _calcPixelWidth;
 

--- a/src/libse/Forms/FixCommonErrors/FixSpanishInvertedQuestionAndExclamationMarks.cs
+++ b/src/libse/Forms/FixCommonErrors/FixSpanishInvertedQuestionAndExclamationMarks.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 using System.Globalization;
@@ -16,6 +17,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixSpanishInvertedQuestionAndExclamationMarks { get; set; } = "Fix Spanish inverted question and exclamation marks";
         }
+
+        public FixType FixType => FixType.Punctuation;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterColon.cs
+++ b/src/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterColon.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -11,6 +12,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string StartWithUppercaseLetterAfterColon { get; set; } = "Start with uppercase letter after colon/semicolon";
         }
+
+        public FixType FixType => FixType.Casing;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterParagraph.cs
+++ b/src/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterParagraph.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 
@@ -10,6 +11,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixFirstLetterToUppercaseAfterParagraph { get; set; } = "Fix first letter to uppercase after paragraph";
         }
+
+        public FixType FixType => FixType.Casing;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterPeriodInsideParagraph.cs
+++ b/src/libse/Forms/FixCommonErrors/FixStartWithUppercaseLetterAfterPeriodInsideParagraph.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System.Text.RegularExpressions;
 
@@ -10,6 +11,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string StartWithUppercaseLetterAfterPeriodInsideParagraph { get; set; } = "Start with uppercase letter after period inside paragraph";
         }
+
+        public FixType FixType => FixType.Casing;
 
         private static readonly char[] ExpectedChars = { '.', '!', '?' };
 

--- a/src/libse/Forms/FixCommonErrors/FixTurkishAnsiToUnicode.cs
+++ b/src/libse/Forms/FixCommonErrors/FixTurkishAnsiToUnicode.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -9,6 +10,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixTurkishAnsi { get; set; } = "Fix Turkish ANSI (Icelandic) letters to Unicode";
         }
+
+        public FixType FixType => FixType.Characters;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixUnnecessaryLeadingDots.cs
+++ b/src/libse/Forms/FixCommonErrors/FixUnnecessaryLeadingDots.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 
@@ -10,6 +11,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixUnnecessaryLeadingDots { get; set; } = "Remove unnecessary leading dots";
         }
+
+        public FixType FixType => FixType.Punctuation;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixUnneededPeriods.cs
+++ b/src/libse/Forms/FixCommonErrors/FixUnneededPeriods.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 using System.Text;
@@ -12,6 +13,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string UnneededPeriod { get; set; } = "Unneeded period";
             public static string RemoveUnneededPeriods { get; set; } = "Remove unneeded periods";
         }
+
+        public FixType FixType => FixType.Punctuation;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixUnneededSpaces.cs
+++ b/src/libse/Forms/FixCommonErrors/FixUnneededSpaces.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 
@@ -11,6 +12,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string UnneededSpace { get; set; } = "Unneeded space";
             public static string RemoveUnneededSpaces { get; set; } = "Remove unneeded spaces";
         }
+
+        public FixType FixType => FixType.Spacing;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/FixUppercaseIInsideWords.cs
+++ b/src/libse/Forms/FixCommonErrors/FixUppercaseIInsideWords.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System;
 using System.Text.RegularExpressions;
@@ -12,6 +13,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string FixUppercaseIInsideLowercaseWord { get; set; } = "Fix uppercase 'i' inside lowercase word";
             public static string FixUppercaseIInsideLowercaseWords { get; set; } = "Fix uppercase 'i' inside lowercase words (OCR error)";
         }
+
+        public FixType FixType => FixType.Casing;
 
         private static readonly Regex ReAfterLowercaseLetter = new Regex(@"\p{Ll}I", RegexOptions.Compiled);
         private static readonly Regex ReBeforeLowercaseLetter = new Regex(@"\p{L}I\p{Ll}", RegexOptions.Compiled);

--- a/src/libse/Forms/FixCommonErrors/NormalizeStrings.cs
+++ b/src/libse/Forms/FixCommonErrors/NormalizeStrings.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using System.Linq;
 
@@ -10,6 +11,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string NormalizeStrings { get; set; } = "Normalize strings";
         }
+
+        public FixType FixType => FixType.Characters;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Forms/FixCommonErrors/RemoveDialogFirstLineInNonDialogs.cs
+++ b/src/libse/Forms/FixCommonErrors/RemoveDialogFirstLineInNonDialogs.cs
@@ -1,4 +1,5 @@
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -9,6 +10,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string RemoveDialogFirstInNonDialogs { get; set; } = "Remove start dash in non dialogs";
         }
+
+        public FixType FixType => FixType.Dialog;
 
         /// <summary>
         /// Dash characters that can be used as dialog marker - see issue #12748.

--- a/src/libse/Forms/FixCommonErrors/RemoveSpaceBetweenNumbers.cs
+++ b/src/libse/Forms/FixCommonErrors/RemoveSpaceBetweenNumbers.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 
 namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
@@ -9,6 +10,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string RemoveSpaceBetweenNumber { get; set; } = "Remove space between numbers";
         }
+
+        public FixType FixType => FixType.Spacing;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/libse/Interfaces/IFixCommonError.cs
+++ b/src/libse/Interfaces/IFixCommonError.cs
@@ -1,9 +1,12 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 
 namespace Nikse.SubtitleEdit.Core.Interfaces
 {
     public interface IFixCommonError
     {
+        FixType FixType { get; }
+
         void Fix(Subtitle subtitle, IFixCallbacks callbacks);
     }
 }

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1751,7 +1751,11 @@
       "unbreakShortLine": "Unbreak short line",
       "fixText": "Fix text",
       "removeSpaceBetweenNumbers": "Remove space between numbers",
-      "fixDialogsOnOneLine": "Fix dialogs on one line"
+      "fixDialogsOnOneLine": "Fix dialogs on one line",
+      "fixTypeFormatting": "Formatting",
+      "fixTypeDialog": "Dialog",
+      "fixTypePunctuation": "Punctuation",
+      "fixTypeOcr": "OCR"
     },
     "adjustDurations": {
       "title": "Adjust durations",

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
@@ -36,6 +36,8 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
     private const int AnalysingPaintDelayMilliseconds = 20;
 
     [ObservableProperty] private string _searchText;
+    [ObservableProperty] private ObservableCollection<FixTypeDisplayItem> _fixTypes;
+    [ObservableProperty] private FixTypeDisplayItem? _selectedFixType;
     [ObservableProperty] private ObservableCollection<LanguageDisplayItem> _languages;
     [ObservableProperty] private LanguageDisplayItem? _selectedLanguage;
     [ObservableProperty] private ObservableCollection<FixDisplayItem> _fixes;
@@ -116,6 +118,13 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
 
         GridSubtitles = new TableView();
         SearchText = string.Empty;
+        FixTypes = new ObservableCollection<FixTypeDisplayItem> { new() };
+        foreach (var fixType in Enum.GetValues<FixType>())
+        {
+            FixTypes.Add(new FixTypeDisplayItem(fixType));
+        }
+
+        SelectedFixType = FixTypes[0];
         Languages = new ObservableCollection<LanguageDisplayItem>();
         Language = new string(' ', 0);
         Fixes = new ObservableCollection<FixDisplayItem>();
@@ -961,7 +970,28 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
         }
     }
 
-    internal void TextBoxSearch_TextChanged(object? sender, TextChangedEventArgs e)
+    partial void OnSearchTextChanged(string value)
+    {
+        RebuildVisibleRules();
+    }
+
+    partial void OnSelectedFixTypeChanged(FixTypeDisplayItem? value)
+    {
+        RebuildVisibleRules();
+    }
+
+    // Runs before PropertyChanged is raised, so the grid rebinds to an already filtered
+    // collection - a search text or type filter carries over to the newly picked profile.
+    partial void OnSelectedProfileChanged(ProfileDisplayItem? value)
+    {
+        RebuildVisibleRules();
+    }
+
+    /// <summary>
+    /// Narrows the step 1 rules grid to the rules matching both the search text and the
+    /// selected fix type.
+    /// </summary>
+    internal void RebuildVisibleRules()
     {
         if (SelectedProfile == null)
         {
@@ -975,10 +1005,13 @@ public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
             SelectedProfile.AllFixRules = SelectedProfile.FixRules.ToList();
         }
 
+        var fixType = SelectedFixType?.FixType;
         SelectedProfile.FixRules.Clear();
         foreach (var rule in SelectedProfile.AllFixRules)
         {
-            if (string.IsNullOrEmpty(SearchText) || rule.Name.ToLowerInvariant().Contains(SearchText.ToLowerInvariant()))
+            var typeMatches = fixType == null || rule.FixType == fixType;
+            var searchMatches = string.IsNullOrEmpty(SearchText) || rule.Name.Contains(SearchText, StringComparison.OrdinalIgnoreCase);
+            if (typeMatches && searchMatches)
             {
                 SelectedProfile.FixRules.Add(rule);
             }

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
@@ -51,11 +51,20 @@ public class FixCommonErrorsWindow : Window
         labelStep2.Bind(Label.ContentProperty, new Binding(nameof(vm.Step2Title)));
         labelStep2.Bind(IsVisibleProperty, new Binding(nameof(vm.Step2IsVisible)));
 
-        var textBoxSearch = UiUtil.MakeTextBox(250, vm, nameof(vm.SearchText)).WithMarginRight(25)
+        var textBoxSearch = UiUtil.MakeTextBox(200, vm, nameof(vm.SearchText)).WithMarginRight(25)
             .WithAccessibleName(Se.Language.Tools.FixCommonErrors.SearchRulesDotDotDot);
         textBoxSearch.PlaceholderText = Se.Language.Tools.FixCommonErrors.SearchRulesDotDotDot;
         textBoxSearch.Bind(IsVisibleProperty, new Binding(nameof(vm.Step1IsVisible)));
-        textBoxSearch.TextChanged += vm.TextBoxSearch_TextChanged;
+
+        // Narrows the rules grid to one FixType; combined with the search text in the view model.
+        var labelFixType = UiUtil.MakeTextBlock(Se.Language.General.Type).WithMarginRight(5);
+        labelFixType.Bind(IsVisibleProperty, new Binding(nameof(vm.Step1IsVisible)));
+        var comboFixType = UiUtil.MakeComboBox(vm.FixTypes, vm, nameof(vm.SelectedFixType))
+            .WithMinWidth(120)
+            .WithMarginRight(25);
+        comboFixType.Bind(IsVisibleProperty, new Binding(nameof(vm.Step1IsVisible)));
+        AutomationProperties.SetLabeledBy(comboFixType, labelFixType);
+
         // Off by default (#12441) - keep it reachable here, next to the language it depends on,
         // instead of only in the OCR window where a Fix-common-errors user would never look.
         var checkBoxGuessUnknownWords = UiUtil.MakeCheckBox(Se.Language.Ocr.TryToGuessUnknownWords, vm, nameof(vm.TryToGuessUnknownWords))
@@ -69,6 +78,9 @@ public class FixCommonErrorsWindow : Window
             HorizontalAlignment = HorizontalAlignment.Right,
             Children =
             {
+                textBoxSearch,
+                labelFixType,
+                comboFixType,
                 checkBoxGuessUnknownWords,
                 UiUtil.MakeTextBlock(Se.Language.General.Language).WithMarginRight(5),
                 UiUtil.MakeComboBox(vm.Languages, vm, nameof(vm.SelectedLanguage))

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonOcrErrors.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonOcrErrors.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using Nikse.SubtitleEdit.Features.Ocr.FixEngine;
 using Nikse.SubtitleEdit.Features.Ocr.OcrSubtitle;
@@ -18,6 +19,8 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
         {
             public static string FixText { get; set; } = "Fix common OCR errors";
         }
+
+        public FixType FixType => FixType.Ocr;
 
         public void Fix(Subtitle subtitle, IFixCallbacks callbacks)
         {

--- a/src/ui/Features/Tools/FixCommonErrors/FixRuleDisplayItem.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixRuleDisplayItem.cs
@@ -1,5 +1,6 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
 using Nikse.SubtitleEdit.Core.Forms.FixCommonErrors;
 using Nikse.SubtitleEdit.Core.Interfaces;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -19,6 +20,23 @@ public partial class FixRuleDisplayItem : ObservableObject
 
     public string FixCommonErrorFunctionName { get; set; }
 
+    /// <summary>
+    /// The kind of fix the rule performs, taken from the fix class itself so the category
+    /// has one source of truth. Null when <see cref="FixCommonErrorFunctionName"/> does not
+    /// name a known fix - such a rule is only listed under "All" in the type filter.
+    /// </summary>
+    public FixType? FixType { get; private set; }
+
+    // Built once: GetFixCommonErrorItems() news up every fix class, and the copy-ctor runs
+    // per rule per profile.
+    private static readonly Lazy<Dictionary<string, FixType>> FixTypesByFunctionName = new(() =>
+        GetFixCommonErrorItems().ToDictionary(p => p.GetType().Name, p => p.FixType, StringComparer.Ordinal));
+
+    public static bool TryResolveFixType(string fixCommonErrorFunctionName, out FixType fixType)
+    {
+        return FixTypesByFunctionName.Value.TryGetValue(fixCommonErrorFunctionName, out fixType);
+    }
+
     public FixRuleDisplayItem()
     {
         Name = string.Empty;
@@ -33,6 +51,7 @@ public partial class FixRuleDisplayItem : ObservableObject
         IsSelected = item.IsSelected;
         SortOrder = item.SortOrder;
         FixCommonErrorFunctionName = item.FixCommonErrorFunctionName;
+        FixType = item.FixType;
     }
 
     public FixRuleDisplayItem(string name, string example, int sortOrder, bool isSelected, string fixCommonErrorFunctionName)
@@ -42,6 +61,7 @@ public partial class FixRuleDisplayItem : ObservableObject
         SortOrder = sortOrder;
         IsSelected = isSelected;
         FixCommonErrorFunctionName = fixCommonErrorFunctionName;
+        FixType = TryResolveFixType(fixCommonErrorFunctionName, out var fixType) ? fixType : null;
     }
 
     public IFixCommonError GetFixCommonErrorFunction()

--- a/src/ui/Features/Tools/FixCommonErrors/FixTypeDisplayItem.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixTypeDisplayItem.cs
@@ -1,0 +1,31 @@
+using Nikse.SubtitleEdit.Core.Enums;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Tools.FixCommonErrors;
+
+/// <summary>
+/// One entry in the step 1 "Type" filter combo. FixType == null means "all types".
+/// </summary>
+public class FixTypeDisplayItem
+{
+    public FixType? FixType { get; }
+    public string Name { get; }
+
+    public FixTypeDisplayItem(FixType fixType)
+    {
+        FixType = fixType;
+        Name = Se.Language.Tools.FixCommonErrors.GetFixTypeName(fixType);
+    }
+
+    public FixTypeDisplayItem() // "All" entry
+    {
+        FixType = null;
+        Name = Se.Language.General.All;
+    }
+
+    // The combo uses the default item template, which shows ToString().
+    public override string ToString()
+    {
+        return Name;
+    }
+}

--- a/src/ui/Logic/Config/Language/Tools/LanguageFixCommonErrors.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageFixCommonErrors.cs
@@ -1,4 +1,6 @@
-﻿namespace Nikse.SubtitleEdit.Logic.Config.Language.Tools;
+﻿using Nikse.SubtitleEdit.Core.Enums;
+
+namespace Nikse.SubtitleEdit.Logic.Config.Language.Tools;
 
 public class LanguageFixCommonErrors
 {
@@ -125,6 +127,10 @@ public class LanguageFixCommonErrors
     public string FixText { get; set; }
     public string RemoveSpaceBetweenNumbers { get; set; }
     public string FixDialogsOnOneLine { get; set; }
+    public string FixTypeFormatting { get; set; }
+    public string FixTypeDialog { get; set; }
+    public string FixTypePunctuation { get; set; }
+    public string FixTypeOcr { get; set; }
 
     public LanguageFixCommonErrors()
     {
@@ -253,5 +259,25 @@ public class LanguageFixCommonErrors
         FixText = "Fix text";
         RemoveSpaceBetweenNumbers = "Remove space between numbers";
         FixDialogsOnOneLine = "Fix dialogs on one line";
+        FixTypeFormatting = "Formatting";
+        FixTypeDialog = "Dialog";
+        FixTypePunctuation = "Punctuation";
+        FixTypeOcr = "OCR";
+    }
+
+    public string GetFixTypeName(FixType fixType)
+    {
+        return fixType switch
+        {
+            Core.Enums.FixType.Time => Se.Language.General.Time,
+            Core.Enums.FixType.Formatting => FixTypeFormatting,
+            Core.Enums.FixType.Dialog => FixTypeDialog,
+            Core.Enums.FixType.Punctuation => FixTypePunctuation,
+            Core.Enums.FixType.Casing => Se.Language.General.Casing,
+            Core.Enums.FixType.Spacing => Se.Language.General.Spacing,
+            Core.Enums.FixType.Characters => Se.Language.General.Characters,
+            Core.Enums.FixType.Ocr => FixTypeOcr,
+            _ => fixType.ToString(),
+        };
     }
 }

--- a/tests/UI/Features/Tools/FixCommonErrors/FixCommonErrorsRuleFilterTests.cs
+++ b/tests/UI/Features/Tools/FixCommonErrors/FixCommonErrorsRuleFilterTests.cs
@@ -1,0 +1,212 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.LogicalTree;
+using Nikse.SubtitleEdit.Core.Enums;
+using Nikse.SubtitleEdit.Core.Forms.FixCommonErrors;
+using Nikse.SubtitleEdit.Features.Tools.FixCommonErrors;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Tools.FixCommonErrors;
+
+// Step 1 lists ~38 rules flat. The "Type" combo narrows the grid to one FixType, ANDed with
+// the search text. Both filter from the profile's full list (AllFixRules) and never from the
+// grid collection, so hidden rules keep their selection and reappear intact.
+public class FixCommonErrorsRuleFilterTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    // WindowService only touches the provider when it creates a child window, which the
+    // construction test never does.
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private static List<FixRuleDisplayItem> MakeMixedRules()
+    {
+        return new List<FixRuleDisplayItem>
+        {
+            new("Fix commas", string.Empty, 1, true, nameof(FixCommas)), // Punctuation
+            new("Fix short gaps", string.Empty, 1, true, nameof(FixShortGaps)), // Time
+            new("Remove empty lines", string.Empty, 1, true, nameof(FixEmptyLines)), // Formatting
+        };
+    }
+
+    private static ProfileDisplayItem MakeProfile(string name)
+    {
+        var rules = MakeMixedRules();
+        return new ProfileDisplayItem
+        {
+            Name = name,
+            FixRules = new System.Collections.ObjectModel.ObservableCollection<FixRuleDisplayItem>(rules),
+            AllFixRules = rules,
+        };
+    }
+
+    private static FixCommonErrorsViewModel BuildViewModel(out ProfileDisplayItem profile)
+    {
+        var vm = new FixCommonErrorsViewModel(null!, null!, null!);
+        profile = MakeProfile("Default");
+        vm.Profiles.Add(profile);
+        vm.SelectedProfile = profile;
+        return vm;
+    }
+
+    private static FixTypeDisplayItem TypeItem(FixCommonErrorsViewModel vm, FixType fixType)
+    {
+        return vm.FixTypes.First(p => p.FixType == fixType);
+    }
+
+    [AvaloniaFact]
+    public void FixTypes_StartsWithAll_ThenEveryEnumMember()
+    {
+        var vm = new FixCommonErrorsViewModel(null!, null!, null!);
+
+        Assert.Null(vm.FixTypes[0].FixType);
+        Assert.Equal(Enum.GetValues<FixType>().Length + 1, vm.FixTypes.Count);
+        Assert.Same(vm.FixTypes[0], vm.SelectedFixType);
+    }
+
+    [AvaloniaFact]
+    public void SelectingType_ShowsOnlyRulesOfThatType()
+    {
+        var vm = BuildViewModel(out var profile);
+
+        vm.SelectedFixType = TypeItem(vm, FixType.Time);
+
+        var rule = Assert.Single(profile.FixRules);
+        Assert.Equal(nameof(FixShortGaps), rule.FixCommonErrorFunctionName);
+        Assert.Equal(3, profile.AllFixRules.Count);
+    }
+
+    [AvaloniaFact]
+    public void SelectingAll_RestoresEveryRule()
+    {
+        var vm = BuildViewModel(out var profile);
+        vm.SelectedFixType = TypeItem(vm, FixType.Time);
+
+        vm.SelectedFixType = vm.FixTypes[0];
+
+        Assert.Equal(profile.AllFixRules, profile.FixRules);
+    }
+
+    [AvaloniaFact]
+    public void TypeAndSearch_AreCombined()
+    {
+        var vm = BuildViewModel(out var profile);
+
+        vm.SelectedFixType = TypeItem(vm, FixType.Punctuation);
+        vm.SearchText = "gap";
+        Assert.Empty(profile.FixRules);
+
+        vm.SelectedFixType = TypeItem(vm, FixType.Time);
+        Assert.Single(profile.FixRules);
+
+        vm.SearchText = string.Empty;
+        Assert.Single(profile.FixRules); // the type filter alone still applies
+    }
+
+    [AvaloniaFact]
+    public void SwitchingProfile_KeepsActiveFilter()
+    {
+        var vm = BuildViewModel(out _);
+        var other = MakeProfile("Other");
+        vm.Profiles.Add(other);
+        vm.SelectedFixType = TypeItem(vm, FixType.Time);
+
+        vm.SelectedProfile = other;
+
+        var rule = Assert.Single(other.FixRules);
+        Assert.Equal(nameof(FixShortGaps), rule.FixCommonErrorFunctionName);
+    }
+
+    [AvaloniaFact]
+    public void HiddenRules_KeepTheirSelection()
+    {
+        var vm = BuildViewModel(out var profile);
+        var commas = profile.AllFixRules.First(p => p.FixCommonErrorFunctionName == nameof(FixCommas));
+        vm.SelectedFixType = TypeItem(vm, FixType.Time);
+
+        vm.RulesInverseSelected(); // acts on the visible (filtered) rows only
+        vm.SelectedFixType = vm.FixTypes[0];
+
+        Assert.True(commas.IsSelected);
+        Assert.False(profile.AllFixRules.First(p => p.FixCommonErrorFunctionName == nameof(FixShortGaps)).IsSelected);
+    }
+
+    [Fact]
+    public void MakeDefaultRules_EveryRuleResolvesItsFixType()
+    {
+        var rules = FixCommonErrorsViewModel.MakeDefaultRules();
+
+        Assert.NotEmpty(rules);
+        Assert.All(rules, rule => Assert.NotNull(rule.FixType));
+    }
+
+    [Theory]
+    [InlineData(nameof(FixEllipsesStart), FixType.Punctuation)]
+    [InlineData(nameof(FixAloneLowercaseIToUppercaseI), FixType.Casing)]
+    [InlineData(nameof(FixTurkishAnsiToUnicode), FixType.Characters)]
+    [InlineData(nameof(FixDanishLetterI), FixType.Casing)]
+    [InlineData(nameof(FixSpanishInvertedQuestionAndExclamationMarks), FixType.Punctuation)]
+    [InlineData(nameof(FixCommonOcrErrors), FixType.Ocr)]
+    public void LanguageSpecificRules_ResolveTheirFixType(string functionName, FixType expected)
+    {
+        Assert.True(FixRuleDisplayItem.TryResolveFixType(functionName, out var fixType));
+        Assert.Equal(expected, fixType);
+    }
+
+    [Fact]
+    public void UnknownRuleName_HasNoFixType()
+    {
+        var rule = new FixRuleDisplayItem("Unknown", string.Empty, 1, true, "NoSuchFix");
+
+        Assert.Null(rule.FixType);
+    }
+
+    [Fact]
+    public void CopyConstructor_CopiesFixType()
+    {
+        var original = new FixRuleDisplayItem("Fix commas", string.Empty, 1, true, nameof(FixCommas));
+
+        var copy = new FixRuleDisplayItem(original);
+
+        Assert.Equal(FixType.Punctuation, copy.FixType);
+    }
+
+    // The search box used to be created but never added to the window, so it was invisible.
+    // Both it and the type combo live in the step 1 toolbar and hide with it.
+    [AvaloniaFact]
+    public void Window_ShowsSearchBoxAndTypeCombo_OnlyInStep1()
+    {
+        var vm = new FixCommonErrorsViewModel(null!, new WindowService(new NullServiceProvider()), null!);
+        var window = new FixCommonErrorsWindow(vm);
+        _windows.Add(window);
+
+        var search = window.GetLogicalDescendants().OfType<TextBox>()
+            .FirstOrDefault(p => p.PlaceholderText == Se.Language.Tools.FixCommonErrors.SearchRulesDotDotDot);
+        var combo = window.GetLogicalDescendants().OfType<ComboBox>()
+            .FirstOrDefault(p => ReferenceEquals(p.ItemsSource, vm.FixTypes));
+        Assert.NotNull(search);
+        Assert.NotNull(combo);
+        Assert.True(search.IsVisible);
+        Assert.True(combo.IsVisible);
+        Assert.Same(vm.FixTypes[0], combo.SelectedItem);
+
+        vm.Step1IsVisible = false;
+
+        Assert.False(search.IsVisible);
+        Assert.False(combo.IsVisible);
+    }
+}


### PR DESCRIPTION
Stacked on #14442 (the `FixType` property on `IFixCommonError`); this PR's own change is the top commit.

## Summary
- Add a "Type" combo to the step 1 toolbar of Fix common errors that filters the rule list by the rule's `FixType` (All, Time, Formatting, Dialog, Punctuation, Casing, Spacing, Characters, OCR).
- The type filter is combined with the "Search rules..." text box, which was created but never added to the window; both now sit in the step 1 toolbar and hide in step 2.
- `FixRuleDisplayItem` resolves its `FixType` once from the fix classes (one lazily built name-to-type map), so libse stays the single source of truth; the copy constructor carries it into profile clones.
- Filtering always reads the profile's full rule list, so hidden rules keep their selection and apply/save still see them. The active filter follows a profile switch.
- New language strings: `FixTypeFormatting`, `FixTypeDialog`, `FixTypePunctuation`, `FixTypeOcr` (the other four reuse existing General strings); `English.json` regenerated.
- Tests: `FixCommonErrorsRuleFilterTests` (type filter, AND with search, profile switch, hidden selection kept, type resolution for every default and language-specific rule, window wiring and step visibility).

## Test plan
- [ ] Open a subtitle, Tools > Fix common errors: the search box and a "Type" combo appear in the top row of step 1 and are hidden in step 2
- [ ] Pick "Time": only the four timing rules remain; type "short" in the search box: two remain; pick "All": the full list is back
- [ ] With "Time" selected, click Select all / Invert selection: only the visible rows change
- [ ] Select a profile, choose a type, switch profile: the filter stays applied
- [ ] Filter to "Time", untick a rule, pick "All", then "Go to apply fixes": rules hidden by the filter still run according to their tick state
- [ ] `dotnet test tests/UI/UITests.csproj`: `FixCommonErrorsRuleFilterTests` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXEWrgv5uAnSzDgxFupSHZ
