### PR TITLE
Set position: preview rotation now matches libass (issue #14440)

### DIFF
--- a/src/ui/Features/Assa/AssaSetPosition/AssaSetPositionViewModel.cs
+++ b/src/ui/Features/Assa/AssaSetPosition/AssaSetPositionViewModel.cs
@@ -43,8 +43,18 @@ public partial class AssaSetPositionViewModel : ObservableObject
     [ObservableProperty] private decimal _rotation;
 
     private static readonly Regex FrzRegex = new(@"\\frz\(?(-?\d+(\.\d+)?)\)?", RegexOptions.Compiled);
+    private static readonly Regex InlineAlignmentRegex = new(@"\\an([1-9])", RegexOptions.Compiled);
 
     public decimal ResultRotation => Rotation;
+
+    /// <summary>
+    /// The override tags OK writes in front of the line: \pos plus, when the text is rotated, \frz.
+    /// </summary>
+    public string ResultTags => BuildPositionTags(ResultX, ResultY, Rotation, _styleAngle);
+
+    // Angle of the line's style. \frz overrides it, so the spinner starts from it when the text has
+    // no \frz of its own and OK pins \frz whenever it is non-zero (a spinner at 0 must give 0°).
+    private decimal _styleAngle;
 
     private Subtitle _subtitle = new();
 
@@ -53,6 +63,7 @@ public partial class AssaSetPositionViewModel : ObservableObject
     private int _renderWidth = 1920;
     private int _renderHeight = 1080;
 
+    private string _alignment = "2";
     private bool _isLeftAligned = false;
     private bool _isHorizontalCentered = true;
     private bool _isRightAligned = false;
@@ -153,12 +164,6 @@ public partial class AssaSetPositionViewModel : ObservableObject
     {
         _subtitle = new Subtitle(subtitle, false);
 
-        var frzMatch = FrzRegex.Match(line.Text ?? string.Empty);
-        if (frzMatch.Success && decimal.TryParse(frzMatch.Groups[1].Value, NumberStyles.Float, CultureInfo.InvariantCulture, out var frz))
-        {
-            Rotation = frz;
-        }
-
         if (string.IsNullOrEmpty(_subtitle.Header))
         {
             _subtitle.Header = AdvancedSubStationAlpha.DefaultHeader;
@@ -174,16 +179,13 @@ public partial class AssaSetPositionViewModel : ObservableObject
 
         var styles = AdvancedSubStationAlpha.GetSsaStylesFromHeader(_subtitle.Header);
         var style = styles.FirstOrDefault(s => s.Name.Equals(line.Style, StringComparison.OrdinalIgnoreCase));
-        if (style != null)
-        {
-            _isLeftAligned = style.Alignment == "1" || style.Alignment == "4" || style.Alignment == "7";
-            _isHorizontalCentered = style.Alignment == "2" || style.Alignment == "5" || style.Alignment == "8";
-            _isRightAligned = style.Alignment == "3" || style.Alignment == "6" || style.Alignment == "9";
+        _styleAngle = style?.Angle ?? 0;
+        ApplyAlignment(ResolveAlignment(style?.Alignment, line.Text));
 
-            _isTopAligned = style.Alignment == "7" || style.Alignment == "8" || style.Alignment == "9";
-            _isVerticalCentered = style.Alignment == "4" || style.Alignment == "5" || style.Alignment == "6";
-            _isBottomAligned = style.Alignment == "1" || style.Alignment == "2" || style.Alignment == "3";
-        }
+        var frzMatch = FrzRegex.Match(line.Text ?? string.Empty);
+        Rotation = frzMatch.Success && decimal.TryParse(frzMatch.Groups[1].Value, NumberStyles.Float, CultureInfo.InvariantCulture, out var frz)
+            ? frz
+            : _styleAngle;
 
         // Without a video, render at the script's own resolution so PlayRes aspect is honored and
         // render space equals script space. GetScreenShotWithSubtitle bumps odd sizes to even for
@@ -285,9 +287,64 @@ public partial class AssaSetPositionViewModel : ObservableObject
         var previewParagraph = line.ToParagraph(new AdvancedSubStationAlpha());
         previewParagraph.StartTime.TotalSeconds = 0;
         previewParagraph.EndTime.TotalSeconds = 10;
+
+        // The overlay must be the unrotated text: the dialog rotates it itself around the anchor
+        // by the spinner value. Rendering the line's own \frz (or the style's Angle) into the bitmap
+        // rotated it twice - \frz25 previewed at 50° and its trimmed box no longer matched the
+        // anchor libass places \pos at (#14440). \pos is kept so the overlay starts where the line is.
+        previewParagraph.Text = "{\\frz0}" + FrzRegex.Replace(previewParagraph.Text, string.Empty).Replace("{}", string.Empty);
         previewSubtitle.Paragraphs.Add(previewParagraph);
 
         return previewSubtitle;
+    }
+
+    /// <summary>
+    /// The effective \an alignment (1-9) of the line: an inline \an tag wins over the style, and
+    /// bottom-center is the ASS default.
+    /// </summary>
+    internal static string ResolveAlignment(string? styleAlignment, string? text)
+    {
+        var inline = InlineAlignmentRegex.Match(text ?? string.Empty);
+        if (inline.Success)
+        {
+            return inline.Groups[1].Value;
+        }
+
+        return styleAlignment is { Length: 1 } && styleAlignment[0] is >= '1' and <= '9' ? styleAlignment : "2";
+    }
+
+    private void ApplyAlignment(string alignment)
+    {
+        _alignment = alignment;
+        _isLeftAligned = alignment == "1" || alignment == "4" || alignment == "7";
+        _isHorizontalCentered = alignment == "2" || alignment == "5" || alignment == "8";
+        _isRightAligned = alignment == "3" || alignment == "6" || alignment == "9";
+
+        _isTopAligned = alignment == "7" || alignment == "8" || alignment == "9";
+        _isVerticalCentered = alignment == "4" || alignment == "5" || alignment == "6";
+        _isBottomAligned = alignment == "1" || alignment == "2" || alignment == "3";
+    }
+
+    /// <summary>
+    /// Where libass rotates the text: \org defaults to the \pos point, which is the alignment
+    /// anchor of the text box - not its center.
+    /// </summary>
+    internal static RelativePoint GetRotationOrigin(string alignment)
+    {
+        var x = alignment is "1" or "4" or "7" ? 0.0 : alignment is "3" or "6" or "9" ? 1.0 : 0.5;
+        var y = alignment is "7" or "8" or "9" ? 0.0 : alignment is "4" or "5" or "6" ? 0.5 : 1.0;
+        return new RelativePoint(x, y, RelativeUnit.Relative);
+    }
+
+    internal static string BuildPositionTags(int x, int y, decimal rotation, decimal styleAngle)
+    {
+        var tags = $"\\pos({x},{y})";
+        if (rotation != 0 || styleAngle != 0)
+        {
+            tags += "\\frz" + rotation.ToString("0.##", CultureInfo.InvariantCulture);
+        }
+
+        return tags;
     }
 
     /// <summary>
@@ -401,8 +458,9 @@ public partial class AssaSetPositionViewModel : ObservableObject
             0,
             0);
 
-        // ASSA \frz rotates counter-clockwise; Avalonia RotateTransform is clockwise, so negate.
-        ScreenshotOverlayImage.RenderTransformOrigin = RelativePoint.Center;
+        // ASSA \frz rotates counter-clockwise around the anchor (\org defaults to \pos);
+        // Avalonia RotateTransform is clockwise, so negate.
+        ScreenshotOverlayImage.RenderTransformOrigin = GetRotationOrigin(_alignment);
         ScreenshotOverlayImage.RenderTransform = new RotateTransform(-(double)Rotation);
 
         // Show the script-space anchor that OK writes into \pos, not the render-space top-left.

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -2551,15 +2551,7 @@ public partial class MainViewModel :
         // interprets the \pos below in the same space the dialog measured in.
         _subtitle.Header = result.ResultSubtitle.Header;
 
-        var x = result.ResultX;
-        var y = result.ResultY;
-        var tags = $"\\pos({x},{y})";
-        if (result.ResultRotation != 0)
-        {
-            tags += "\\frz" + result.ResultRotation.ToString(CultureInfo.InvariantCulture);
-        }
-
-        selectedItem.Text = "{" + tags + "}" + RemovePositionTags(selectedItem.Text);
+        selectedItem.Text = "{" + result.ResultTags + "}" + RemovePositionTags(selectedItem.Text);
         RefreshSubtitlePreview();
     }
 

--- a/tests/UI/Features/Assa/AssaSetPositionPreviewStyleTests.cs
+++ b/tests/UI/Features/Assa/AssaSetPositionPreviewStyleTests.cs
@@ -79,7 +79,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
         var preview = AssaSetPositionViewModel.MakePreviewSubtitle(subtitle, MakeLine(subtitle));
 
         var p = Assert.Single(preview.Paragraphs);
-        Assert.Equal("Hello world", p.Text);
+        Assert.Equal(@"{\frz0}Hello world", p.Text); // rotation pinned: the dialog rotates the overlay itself
         Assert.Equal(0, p.StartTime.TotalSeconds);
         Assert.Equal(10, p.EndTime.TotalSeconds);
     }

--- a/tests/UI/Features/Assa/AssaSetPositionRotationTests.cs
+++ b/tests/UI/Features/Assa/AssaSetPositionRotationTests.cs
@@ -1,0 +1,116 @@
+using Avalonia;
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Assa.AssaSetPosition;
+using Nikse.SubtitleEdit.Features.Main;
+
+namespace UITests.Features.Assa;
+
+/// <summary>
+/// Regression tests for issue #14440: the "Set position" preview rendered the line's own \frz into
+/// the overlay bitmap and then rotated that bitmap again by the spinner value (around its center
+/// instead of the \pos anchor), so \frz25 previewed at 50° in a different place than libass drew it.
+/// </summary>
+public class AssaSetPositionRotationTests
+{
+    private static SubtitleLineViewModel MakeLine(string text)
+    {
+        var subtitle = new Subtitle { Header = AdvancedSubStationAlpha.DefaultHeader };
+        subtitle.Paragraphs.Add(new Paragraph(text, 1000, 3000) { Extra = "Default" });
+        return new SubtitleLineViewModel(subtitle.Paragraphs[0], new AdvancedSubStationAlpha());
+    }
+
+    private static string PreviewText(string text)
+    {
+        var subtitle = new Subtitle { Header = AdvancedSubStationAlpha.DefaultHeader };
+        var preview = AssaSetPositionViewModel.MakePreviewSubtitle(subtitle, MakeLine(text));
+        return Assert.Single(preview.Paragraphs).Text;
+    }
+
+    [Fact]
+    public void PreviewSubtitle_RendersTheTextUnrotatedButKeepsPos()
+    {
+        Assert.Equal(@"{\frz0}{\pos(627,136)}J envió un mensaje", PreviewText(@"{\pos(627,136)\frz25}J envió un mensaje"));
+    }
+
+    [Theory]
+    [InlineData(@"{\frz-12.5}Hello", @"{\frz0}Hello")]
+    [InlineData(@"{\frz(25)}Hello", @"{\frz0}Hello")]
+    [InlineData(@"{\an5\frz25\pos(1,2)}Hello", @"{\frz0}{\an5\pos(1,2)}Hello")]
+    public void PreviewSubtitle_StripsEveryFrzForm(string text, string expected)
+    {
+        Assert.Equal(expected, PreviewText(text));
+    }
+
+    [Fact]
+    public void PreviewSubtitle_PinsRotationSoTheStyleAngleIsNotRenderedEither()
+    {
+        Assert.Equal(@"{\frz0}Hello world", PreviewText("Hello world"));
+    }
+
+    [Theory]
+    [InlineData("2", null, "2")]
+    [InlineData("8", "Hello", "8")]
+    [InlineData("2", @"{\an5}Hello", "5")] // inline \an overrides the style
+    [InlineData("2", @"{\pos(1,2)\an7\frz3}Hello", "7")]
+    [InlineData(null, "Hello", "2")] // no style: ASS default
+    [InlineData("", "Hello", "2")]
+    [InlineData("11", "Hello", "2")] // garbage in the style
+    public void ResolveAlignment_PrefersInlineTagThenStyleThenDefault(string? styleAlignment, string? text, string expected)
+    {
+        Assert.Equal(expected, AssaSetPositionViewModel.ResolveAlignment(styleAlignment, text));
+    }
+
+    [Theory]
+    [InlineData("1", 0.0, 1.0)]
+    [InlineData("2", 0.5, 1.0)]
+    [InlineData("3", 1.0, 1.0)]
+    [InlineData("4", 0.0, 0.5)]
+    [InlineData("5", 0.5, 0.5)]
+    [InlineData("6", 1.0, 0.5)]
+    [InlineData("7", 0.0, 0.0)]
+    [InlineData("8", 0.5, 0.0)]
+    [InlineData("9", 1.0, 0.0)]
+    public void RotationOrigin_IsTheAlignmentAnchorNotTheCenter(string alignment, double x, double y)
+    {
+        var origin = AssaSetPositionViewModel.GetRotationOrigin(alignment);
+
+        Assert.Equal(RelativeUnit.Relative, origin.Unit);
+        Assert.Equal(new Point(x, y), origin.Point);
+    }
+
+    [Theory]
+    [InlineData(0, 0, @"\pos(627,136)")]
+    [InlineData(25, 0, @"\pos(627,136)\frz25")]
+    [InlineData(-1, 0, @"\pos(627,136)\frz-1")]
+    [InlineData(12.5, 0, @"\pos(627,136)\frz12.5")]
+    [InlineData(0, 10, @"\pos(627,136)\frz0")] // spinner at 0 must override a rotated style
+    [InlineData(30, 10, @"\pos(627,136)\frz30")]
+    public void BuildPositionTags_WritesFrzWhenRotatedOrWhenTheStyleIs(decimal rotation, decimal styleAngle, string expected)
+    {
+        Assert.Equal(expected, AssaSetPositionViewModel.BuildPositionTags(627, 136, rotation, styleAngle));
+    }
+
+    [Fact]
+    public void BuildPositionTags_UsesInvariantCultureWithoutTrailingZeros()
+    {
+        Assert.Equal(@"\pos(1,2)\frz25", AssaSetPositionViewModel.BuildPositionTags(1, 2, 25.00m, 0));
+    }
+
+    [AvaloniaFact]
+    public void ResultTags_CombineTheScriptSpaceAnchorAndTheRotation()
+    {
+        var vm = new AssaSetPositionViewModel
+        {
+            SourceWidth = 1920,
+            SourceHeight = 1080,
+            ScreenshotX = 300,
+            ScreenshotY = 600,
+            Rotation = 25,
+        };
+
+        // 1x1 overlay, bottom-center anchor: X = 300 + 0.5 -> 301, Y = 600 + 1 -> 601.
+        Assert.Equal(@"\pos(301,601)\frz25", vm.ResultTags);
+    }
+}


### PR DESCRIPTION
Fixes #14440.

## Problem
In the ASSA **Set position** dialog, a line that already has `\frz` (or a style with a non-zero Angle) was rotated twice in the preview: libass rendered the overlay bitmap from the line's own text, tag included, and the dialog then applied the spinner rotation on top of that bitmap. `\frz25` previewed at about 50°, and after the user typed -1 the preview still showed ~24°. The extra rotation also happened around the bitmap center instead of the `\pos` anchor, so the position was off as well, which is what the reporter's video shows.

## Fix
- The preview subtitle now has every `\frz` stripped and `\frz0` pinned, so the overlay is always the unrotated text and the spinner is the only rotation source. `\pos` is kept so the overlay starts where the line currently is.
- The overlay rotates around the alignment anchor (`\org` defaults to `\pos`), and an inline `\an` tag now wins over the style alignment, matching libass.
- When the line has no `\frz`, the spinner starts from the style's Angle, and `\frz` is always written for a rotated style so a spinner at 0 really gives 0°.
- Tag building moved into the view model as `ResultTags` (invariant culture, no trailing zeros).

## Tests
New `AssaSetPositionRotationTests` cover the preview text, alignment resolution, rotation origin per `\an`, and tag output. All 45 Set Position tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
