### PR TITLE
Spell check: follow the new language after a translation

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -11607,8 +11607,7 @@ public partial class MainViewModel :
             Subtitles[i].ReferenceParagraphId = null;
         }
 
-        // The subtitle language just changed, so the cached detected language is stale (issue #12144).
-        _detectedLanguageCode = null;
+        OnSubtitleLanguageChanged();
 
         var targetLanguageCode = result.SelectedTargetLanguage?.TwoLetterIsoLanguageName;
         _subtitleFileNameOriginal = _subtitleFileName;
@@ -11736,8 +11735,7 @@ public partial class MainViewModel :
             }
         }
 
-        // The translated lines changed language, so the cached detected language is stale (issue #12144).
-        _detectedLanguageCode = null;
+        OnSubtitleLanguageChanged();
 
         _updateAudioVisualizer = true;
     }
@@ -11783,8 +11781,7 @@ public partial class MainViewModel :
 
         RemoveReferenceOnlyRows();
 
-        // The subtitle language just changed, so the cached detected language is stale (issue #12144).
-        _detectedLanguageCode = null;
+        OnSubtitleLanguageChanged();
 
         _subtitleFileNameOriginal = _subtitleFileName;
         _subtitleFileName = string.Empty;
@@ -21904,6 +21901,24 @@ public partial class MainViewModel :
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Called after a translation rewrote the rows in another language. The cached detected
+    /// language is stale (issue #12144), and so is everything spell check remembered for the text
+    /// that was just replaced: the dictionary the spell check window ended on is stored as a pick
+    /// for the subtitle currently loaded, and the translate paths never reset, so the spell check
+    /// window opened on the source language after an English to Dutch translation and live spell
+    /// check kept underlining the Dutch text against the English dictionary (issue #14446). An
+    /// unfinished spell check run belongs to the old text as well, so the "continue from current
+    /// line?" prompt is dropped too.
+    /// </summary>
+    private void OnSubtitleLanguageChanged()
+    {
+        _detectedLanguageCode = null;
+        _currentSpellCheckDictionary = null;
+        _spellCheckSessionInProgress = false;
+        SetupLiveSpellCheck();
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #14446

After translating English to Dutch the spell checker stayed on English. Two mechanisms were stuck:

- **Live spell check** (underlines in the grid and text box) only re-detects its dictionary after a reset (open/import) or where a caller re-arms it explicitly (transcription, video OCR). None of the three translate paths did either, so the Dutch text kept being underlined against the English dictionary.
- **Spell check window** detects the language itself, but a dictionary "picked" for the current subtitle always wins. Closing the window with OK stores whatever dictionary it ended on as that pick, auto-detected or not. So: spell check the English file once, translate, spell check again, and the window opens on English and skips detection. This is why the bug looks intermittent - it only bites when spell check ran before the translation.

Translation is now treated the way a reset is for spell check purposes: the picked dictionary and the unfinished-session flag are dropped and live spell check is re-armed, so both the underlines and the spell check window detect the target language. The helper is shared by auto-translate, translate selected lines and translate via copy-paste, which already cleared the cached detected language code at the same spot.

When the target language has no dictionary installed, auto-detection returns null and live spell check turns off instead of underlining everything against the source language, as it does after an open.

UI build clean, `SpellCheckLanguageSelectionTests` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
