### PR TITLE
Theme: follow OS variant changes without re-entering SetCurrentTheme (fixes the order-dependent theme test flake)

### DIFF
--- a/src/ui/Logic/UiTheme.cs
+++ b/src/ui/Logic/UiTheme.cs
@@ -155,11 +155,24 @@ public static class UiTheme
 
     private static void OnActualThemeVariantChanged(object? sender, EventArgs e)
     {
-        if (Se.Settings.Appearance.Theme == ThemeNameSystem && Application.Current != null)
+        if (Se.Settings.Appearance.Theme != ThemeNameSystem || Application.Current == null)
         {
-            SetCurrentTheme();
-            SystemThemeChangedCallback?.Invoke();
+            return;
         }
+
+        // Follow the variant that just became active; do not re-enter SetCurrentTheme here.
+        // That reset RequestedThemeVariant to Default, which is a no-op while the OS drives
+        // the variant but silently undoes any explicit RequestedThemeVariant assignment made
+        // while this handler is subscribed (the headless tests do that - the subscription
+        // outlives the ApplySettings call that made it and turned an unrelated theme test
+        // order-dependent).
+        RemoveLighterDark();
+        if (ThemeName == ThemeNameDark)
+        {
+            ApplyLighterDark();
+        }
+
+        SystemThemeChangedCallback?.Invoke();
     }
 
     public const double ScaleStep = 0.1;

--- a/tests/UI/Logic/UiThemeSystemVariantTests.cs
+++ b/tests/UI/Logic/UiThemeSystemVariantTests.cs
@@ -1,0 +1,46 @@
+using Avalonia;
+using Avalonia.Headless.XUnit;
+using Avalonia.Styling;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Logic;
+
+public class UiThemeSystemVariantTests
+{
+    /// <summary>
+    /// With the "System" theme, SetCurrentTheme subscribes UiTheme to the application's
+    /// ActualThemeVariantChanged event for the rest of the process - ApplySettings does this in
+    /// every MainView test that applies settings. The handler used to re-enter SetCurrentTheme,
+    /// which reset RequestedThemeVariant to Default, so any explicit variant set afterwards was
+    /// undone on the spot and ThemeName reported the platform default (Light) instead of the
+    /// variant that had just been requested. That is the order-dependent CI failure of
+    /// SubtitleSyntaxThemeColorTests (expected #ff9cdcfe, actual #ff006c9b).
+    /// </summary>
+    [AvaloniaFact]
+    public void SystemTheme_KeepsAnExplicitVariant_AfterSetCurrentThemeSubscribed()
+    {
+        var app = Application.Current!;
+        var savedTheme = Se.Settings.Appearance.Theme;
+        var savedVariant = app.RequestedThemeVariant;
+        try
+        {
+            Se.Settings.Appearance.Theme = UiTheme.ThemeNameSystem;
+            UiTheme.SetCurrentTheme();
+
+            app.RequestedThemeVariant = ThemeVariant.Dark;
+            Assert.Equal(ThemeVariant.Dark, app.RequestedThemeVariant);
+            Assert.Equal(ThemeVariant.Dark, app.ActualThemeVariant);
+            Assert.Equal(UiTheme.ThemeNameDark, UiTheme.ThemeName);
+
+            app.RequestedThemeVariant = ThemeVariant.Light;
+            Assert.Equal(ThemeVariant.Light, app.ActualThemeVariant);
+            Assert.Equal(UiTheme.ThemeNameLight, UiTheme.ThemeName);
+        }
+        finally
+        {
+            Se.Settings.Appearance.Theme = savedTheme;
+            app.RequestedThemeVariant = savedVariant;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`SubtitleSyntaxThemeColorTests.PastelsAreThemeStableButStyleColorFollowsTheme` has failed in five of the last twelve red or retried CI runs since this afternoon (expected `#ff9cdcfe`, actual `#ff006c9b`), on unrelated PRs such as #14444.

**Cause.** With the "System" theme, `UiTheme.SetCurrentTheme` subscribes `OnActualThemeVariantChanged` on the shared `Application` and nothing unsubscribes it. `ApplySettingsKeepsSelectionTests` (PR #14438) calls `ApplySettings` → `SetCurrentTheme` with the default System theme, so the handler stays subscribed for the rest of the test process. The handler re-entered `SetCurrentTheme`, which sets `RequestedThemeVariant = Default`. When the theme test later sets `RequestedThemeVariant = Dark`, the handler fires and immediately resets it, `ActualThemeVariant` falls back to the headless platform default (Light) and `StyleColor` comes back light. It only fails when the settings class happens to run first; xUnit v3 collection order varies per process here, which is why it looked like a timing flake.

**Fix.** The handler now swaps the lighter-dark overrides for the variant that just became active and raises `SystemThemeChangedCallback`, without touching `RequestedThemeVariant`. In the app that path always ran with `RequestedThemeVariant` already `Default`, so behaviour is unchanged.

## Test plan

- [x] New `UiThemeSystemVariantTests` reproduces the failure on unfixed code (`Expected: Dark, Actual: Default`) and passes with the fix.
- [x] `SubtitleSyntaxThemeColorTests` and `ApplySettingsKeepsSelectionTests` pass locally in the same process as the new test.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)