### PR TITLE
UI tests: start the headless session before any test can claim the UI thread

### DIFF
--- a/tests/UI/HeadlessSessionBootstrap.cs
+++ b/tests/UI/HeadlessSessionBootstrap.cs
@@ -1,0 +1,38 @@
+using Avalonia.Headless;
+using UITests;
+
+[assembly: AssemblyFixture(typeof(HeadlessSessionBootstrap))]
+
+namespace UITests;
+
+/// <summary>
+/// Starts the shared headless Avalonia session before any test in this assembly runs.
+///
+/// Avalonia binds its UI thread to whichever thread constructs the process's first
+/// <c>Dispatcher</c> ("the first created dispatcher becomes the UI thread one"), and every
+/// <c>AvaloniaObject</c> - a <c>SolidColorBrush</c>, a view model's static error brush, a
+/// <c>Pen</c> - creates a dispatcher for its constructing thread on demand. With
+/// <c>AvaloniaTestIsolationLevel.PerAssembly</c> the session never resets that global
+/// (only PerTest isolation does), so whenever a plain <c>[Fact]</c> that touches such an
+/// object happens to be scheduled before the first <c>[AvaloniaFact]</c>, the xUnit worker
+/// thread becomes the UI thread and the session can no longer initialize: every Avalonia
+/// test then fails in about 1 ms with "The calling thread cannot access this object" out of
+/// <c>AvaloniaHeadlessPlatform.Initialize</c> → <c>DefaultRenderLoop.Add</c>, with no earlier
+/// failure to point at (1104 of 4631 tests on one CI attempt). Test class order is not
+/// stable across processes, so this is a 1-in-N run, and the workflow's retry cannot save
+/// a run that dies this way.
+///
+/// An assembly fixture is constructed before the first test of the assembly executes.
+/// Dispatching a no-op here forces <c>EnsureSharedApplication</c> to run on the session's
+/// own thread first, so that thread owns the UI dispatcher for the whole process. (A
+/// <c>[ModuleInitializer]</c> cannot do this: it holds the module's initialization lock
+/// while the session thread calls back into <c>TestAppBuilder</c>, and the process hangs.)
+/// </summary>
+public sealed class HeadlessSessionBootstrap
+{
+    public HeadlessSessionBootstrap()
+    {
+        var session = HeadlessUnitTestSession.GetOrStartForAssembly(typeof(HeadlessSessionBootstrap).Assembly);
+        session.Dispatch(static () => { }, CancellationToken.None).GetAwaiter().GetResult();
+    }
+}


### PR DESCRIPTION
## Summary

The retry attempt of the Tests run for #14444 died 26 s in: 1104 of 4631 UI tests failed at 1 ms with `The calling thread cannot access this object` thrown from `AvaloniaHeadlessPlatform.Initialize → Compositor → DefaultRenderLoop.Add → Dispatcher.VerifyAccess`, and **no assertion failure preceded it**. That is not the "earlier test crashed the dispatcher" cascade the workflow retry was written for; the session never came up at all.

**Cause (Avalonia 12.1.1).** `Dispatcher`'s constructor does `s_uiThread ??= this` ("the first created dispatcher becomes the UI thread one"), `AvaloniaObject.Dispatcher` is initialised from `Dispatcher.CurrentDispatcher`, which creates a dispatcher for the calling thread on demand, and the PerAssembly path (`EnsureSharedApplication`) never calls `Dispatcher.ResetBeforeUnitTests` (only PerTest does). So whenever a plain `[Fact]` that constructs any AvaloniaObject (a `SolidColorBrush`, `SubtitleLineViewModel`'s static error brush, a `Pen`) is scheduled before the first `[AvaloniaFact]`, the xUnit worker thread becomes the process's UI thread and the headless session can no longer initialise. Which class runs first varies per process, so this is a 1-in-N run and a fresh-process retry can die the same way.

**Fix.** An xUnit v3 assembly fixture that starts the session and dispatches a no-op, so `EnsureSharedApplication` runs on the session's own thread before the first test executes. (A `[ModuleInitializer]` deadlocks: it holds the module initialisation lock while the session thread calls back into `TestAppBuilder`.)

## Test plan

- [x] Probe (not committed): a plain `[Fact]` that constructs a `SolidColorBrush`, then asks the session to show a window, fails with the exact CI exception without the fixture: `before=no-ui-dispatcher-yet uiThreadCheckAccessFromWorker=True | DISPATCH FAILED: InvalidOperationException: The calling thread cannot access this object because a different thread owns it.`
- [x] Full UITests suite locally with the fixture: 4658 passed, 1 failed (`SubtitleSyntaxThemeColorTests`, the separate order-dependent flake fixed in #14450).
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)