### PR TITLE
Tests workflow: upload the trx artifact even when the retry also fails

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,9 +59,11 @@ jobs:
           dotnet test SubtitleEdit.sln --no-build --logger "trx;LogFileName=tests-retry.trx"
 
       # Uploaded whenever the first run failed - also on a green retry, so flakes can be
-      # diagnosed without re-running locally.
+      # diagnosed without re-running locally. Needs !cancelled(): without a status function
+      # the condition is implicitly ANDed with success(), so a failed retry step skipped the
+      # upload - exactly the run whose trx files were needed.
       - name: Upload test results
-        if: steps.test.outcome == 'failure'
+        if: ${{ !cancelled() && steps.test.outcome == 'failure' }}
         uses: actions/upload-artifact@v5
         with:
           name: test-results


### PR DESCRIPTION
## Summary

The `Upload test results` step has `if: steps.test.outcome == 'failure'`. Without a status function GitHub implicitly ANDs the condition with `success()`, so whenever the retry step also fails the upload is skipped. That is the one case where the trx files are needed (both attempts red, for example run 33663145904 on #14444: `Upload test results: skipped`).

`!cancelled() && steps.test.outcome == 'failure'` keeps the existing behaviour (upload on a green retry too) and adds the both-red case.

## Test plan

- [ ] CI on this PR runs the step (only when the first attempt fails, so the workflow file itself must at least still parse and pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)