### PR TITLE
Use immutable brushes and pens for every static color in the app

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -2,6 +2,7 @@
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media;
+using Avalonia.Media.Immutable;
 using Avalonia.Threading;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.Forms;
@@ -547,8 +548,8 @@ public class AudioVisualizer : Control
     /// </summary>
     public Func<SubtitleLineViewModel, double>? ParagraphAudioLengthProvider { get; set; }
 
-    private static readonly IBrush PaintAudioLengthFits = new SolidColorBrush(Color.FromArgb(190, 70, 190, 110));
-    private static readonly IBrush PaintAudioLengthOverrun = new SolidColorBrush(Color.FromArgb(220, 235, 70, 70));
+    private static readonly IBrush PaintAudioLengthFits = new ImmutableSolidColorBrush(Color.FromArgb(190, 70, 190, 110));
+    private static readonly IBrush PaintAudioLengthOverrun = new ImmutableSolidColorBrush(Color.FromArgb(220, 235, 70, 70));
 
     /// <summary>Raised when a primary-button press lands on an existing paragraph and starts a
     /// move/resize drag. Lets hosts select the paragraph the user grabbed before the drag
@@ -3620,8 +3621,8 @@ public class AudioVisualizer : Control
     // Chapter marks: a full-height line plus a labelled flag at the top. The color matches the
     // Chapters dialog accent so the two read as one feature.
     private static readonly Color ChapterColor = Color.FromRgb(0xC0, 0x8A, 0xDF);
-    private static readonly Pen _paintChapterPen = new Pen(new SolidColorBrush(ChapterColor, 0.85), 1.5);
-    private static readonly IBrush _paintChapterFlagBrush = new SolidColorBrush(ChapterColor, 0.9);
+    private static readonly IPen _paintChapterPen = new ImmutablePen(new ImmutableSolidColorBrush(ChapterColor, 0.85), 1.5);
+    private static readonly IBrush _paintChapterFlagBrush = new ImmutableSolidColorBrush(ChapterColor, 0.9);
     private static readonly IBrush _paintChapterFlagTextBrush = Brushes.Black;
     private const double ChapterFlagHeight = 15;
     private const double ChapterFlagMaxWidth = 170;
@@ -3720,10 +3721,9 @@ public class AudioVisualizer : Control
         }
     }
 
-    private static readonly Pen _paintPenCursorOnShotChange = new Pen(Brushes.LightCyan, 1.5)
-    {
-        DashStyle = DashStyle.Dash,
-    };
+    // Same dash pattern as DashStyle.Dash (2 on, 2 off, offset 1) in an immutable pen.
+    private static readonly IPen _paintPenCursorOnShotChange =
+        new ImmutablePen(Brushes.LightCyan, 1.5, new ImmutableDashStyle(new[] { 2.0, 2.0 }, 1));
 
     private void DrawCurrentVideoPosition(DrawingContext context, ref RenderContext renderCtx)
     {

--- a/src/ui/Features/Files/Compare/CompareViewModel.cs
+++ b/src/ui/Features/Files/Compare/CompareViewModel.cs
@@ -3,6 +3,7 @@ using Avalonia.Input;
 using Nikse.SubtitleEdit.Logic;
 using Avalonia.Interactivity;
 using Avalonia.Media;
+using Avalonia.Media.Immutable;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -61,7 +62,7 @@ public partial class CompareViewModel : ObservableObject
     private static IBrush ListViewRed => CompareColors.OnlyInOneFileRow;
     private static IBrush ListViewGreen => CompareColors.TextOrTimeDifferenceRow;
     private static IBrush ListViewOrange => CompareColors.NumberDifferenceRow;
-    private static readonly IBrush TransparentBrush = new SolidColorBrush(Colors.Transparent);
+    private static readonly IBrush TransparentBrush = new ImmutableSolidColorBrush(Colors.Transparent);
 
     public CompareViewModel(IFileHelper fileHelper, IFolderHelper folderHelper)
     {

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -8,6 +8,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
+using Avalonia.Media.Immutable;
 using Avalonia.Styling;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
@@ -747,8 +748,8 @@ public partial class MainViewModel :
     private readonly HashSet<string> _waveformsBeingGenerated = new(StringComparer.OrdinalIgnoreCase);
     private readonly Lock _waveformsBeingGeneratedLock = new();
     private VideoPlayerControl? _fullScreenVideoPlayerControl;
-    private static SolidColorBrush _transparentBrush = new SolidColorBrush(Colors.Transparent);
-    private static SolidColorBrush _errorBrush = new SolidColorBrush(_errorColor);
+    private static readonly IBrush _transparentBrush = new ImmutableSolidColorBrush(Colors.Transparent);
+    private static IBrush _errorBrush = new ImmutableSolidColorBrush(_errorColor);
     private SpellCheckDictionaryDisplay? _currentSpellCheckDictionary;
     private bool _spellCheckSessionInProgress;
     private bool _reDetectSpellCheckLanguage;
@@ -12540,7 +12541,7 @@ public partial class MainViewModel :
         ShowUpDownLabels = Se.Settings.Appearance.ShowUpDownLabels;
 
         _errorColor = Se.Settings.General.ErrorColor.FromHexToColor();
-        _errorBrush = new SolidColorBrush(_errorColor);
+        _errorBrush = new ImmutableSolidColorBrush(_errorColor);
         SubtitleTextInfoHelper.RefreshErrorBrush();
         if (AreVideoControlsUndocked)
         {

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
+using Avalonia.Media.Immutable;
 
 namespace Nikse.SubtitleEdit.Features.Main;
 
@@ -211,15 +212,15 @@ public partial class SubtitleLineViewModel : ObservableObject
 
     private bool _skipUpdate = false;
 
-    private static SolidColorBrush _errorBrush = new SolidColorBrush(Se.Settings.General.ErrorColor.FromHexToColor());
-    private static SolidColorBrush _transparentBrush = new SolidColorBrush(Colors.Transparent);
+    private static IBrush _errorBrush = new ImmutableSolidColorBrush(Se.Settings.General.ErrorColor.FromHexToColor());
+    private static readonly IBrush _transparentBrush = new ImmutableSolidColorBrush(Colors.Transparent);
     public static Color ErrorColor
     {
         get => field;
         set
         {
             field = value;
-            _errorBrush = new SolidColorBrush(value);
+            _errorBrush = new ImmutableSolidColorBrush(value);
         }
     } = Se.Settings.General.ErrorColor.FromHexToColor();
 

--- a/src/ui/Features/Options/Plugins/GetPluginsDisplayItem.cs
+++ b/src/ui/Features/Options/Plugins/GetPluginsDisplayItem.cs
@@ -1,4 +1,5 @@
 using Avalonia.Media;
+using Avalonia.Media.Immutable;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Plugins;
@@ -7,7 +8,7 @@ namespace Nikse.SubtitleEdit.Features.Options.Plugins;
 
 public partial class GetPluginsDisplayItem : ObservableObject
 {
-    private static readonly IBrush AccentBrush = new SolidColorBrush(Color.FromRgb(0x00, 0x78, 0xD4));
+    private static readonly IBrush AccentBrush = new ImmutableSolidColorBrush(Color.FromRgb(0x00, 0x78, 0xD4));
 
     [ObservableProperty] private bool _isBusy;
     [ObservableProperty] private string _statusText = string.Empty;

--- a/src/ui/Features/Options/Plugins/GetPluginsWindow.cs
+++ b/src/ui/Features/Options/Plugins/GetPluginsWindow.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Layout;
 using Avalonia.Media;
+using Avalonia.Media.Immutable;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Optris.Icons.Avalonia;
@@ -12,7 +13,7 @@ namespace Nikse.SubtitleEdit.Features.Options.Plugins;
 
 public class GetPluginsWindow : Window
 {
-    private static readonly IBrush AccentBrush = new SolidColorBrush(Color.FromRgb(0x00, 0x78, 0xD4));
+    private static readonly IBrush AccentBrush = new ImmutableSolidColorBrush(Color.FromRgb(0x00, 0x78, 0xD4));
 
     public GetPluginsWindow(GetPluginsViewModel vm)
     {

--- a/src/ui/Features/Shared/BinaryEdit/PositionMonitorControl.cs
+++ b/src/ui/Features/Shared/BinaryEdit/PositionMonitorControl.cs
@@ -1,8 +1,8 @@
 using Avalonia;
-using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media;
+using Avalonia.Media.Immutable;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
@@ -36,35 +36,31 @@ public class PositionMonitorControl : Control
     private static readonly Color ZoneRed = Color.FromRgb(0xEF, 0x44, 0x44);
 
     // Shared with the grid's zone-dot column and the summary chips.
-    public static readonly IBrush ZoneGreenBrush = new SolidColorBrush(ZoneGreen);
-    public static readonly IBrush ZoneAmberBrush = new SolidColorBrush(ZoneAmber);
-    public static readonly IBrush ZoneRedBrush = new SolidColorBrush(ZoneRed);
+    public static readonly ImmutableSolidColorBrush ZoneGreenBrush = new(ZoneGreen);
+    public static readonly ImmutableSolidColorBrush ZoneAmberBrush = new(ZoneAmber);
+    public static readonly ImmutableSolidColorBrush ZoneRedBrush = new(ZoneRed);
 
-    private static readonly IBrush FrameBrush = new SolidColorBrush(Color.FromRgb(0x0D, 0x0D, 0x0D));
-    private static readonly IBrush BarBrush = new SolidColorBrush(Color.FromArgb(0x14, 0xFF, 0xFF, 0xFF));
-    private static readonly Pen FrameBorderPen = new(new SolidColorBrush(Color.FromArgb(0x50, 0xFF, 0xFF, 0xFF)), 1);
-    private static readonly Pen BarSeparatorPen = new(new SolidColorBrush(Color.FromArgb(0x60, 0xFF, 0xFF, 0xFF)), 1)
-    {
-        DashStyle = new DashStyle(new AvaloniaList<double> { 4, 4 }, 0),
-    };
-    private static readonly Pen TitleSafePen = new(new SolidColorBrush(Color.FromArgb(0x48, 0xFF, 0xFF, 0xFF)), 1)
-    {
-        DashStyle = new DashStyle(new AvaloniaList<double> { 2, 4 }, 0),
-    };
-    private static readonly Pen SelectedPen = new(Brushes.White, 2);
+    private static readonly IBrush FrameBrush = new ImmutableSolidColorBrush(Color.FromRgb(0x0D, 0x0D, 0x0D));
+    private static readonly IBrush BarBrush = new ImmutableSolidColorBrush(Color.FromArgb(0x14, 0xFF, 0xFF, 0xFF));
+    private static readonly IPen FrameBorderPen = new ImmutablePen(new ImmutableSolidColorBrush(Color.FromArgb(0x50, 0xFF, 0xFF, 0xFF)), 1);
+    private static readonly IPen BarSeparatorPen = new ImmutablePen(
+        new ImmutableSolidColorBrush(Color.FromArgb(0x60, 0xFF, 0xFF, 0xFF)), 1, new ImmutableDashStyle(new[] { 4.0, 4.0 }, 0));
+    private static readonly IPen TitleSafePen = new ImmutablePen(
+        new ImmutableSolidColorBrush(Color.FromArgb(0x48, 0xFF, 0xFF, 0xFF)), 1, new ImmutableDashStyle(new[] { 2.0, 4.0 }, 0));
+    private static readonly IPen SelectedPen = new ImmutablePen(Brushes.White, 2);
 
     // Cached per-zone brushes/pens - Render runs over every subtitle in the file,
     // so avoid per-item allocations. Green (the norm) is deliberately dim so the
     // amber/red problem subtitles stand out at a glance.
-    private static readonly IBrush GreenFill = new SolidColorBrush(ZoneGreen, 0.13);
-    private static readonly IBrush AmberFill = new SolidColorBrush(ZoneAmber, 0.45);
-    private static readonly IBrush RedFill = new SolidColorBrush(ZoneRed, 0.45);
-    private static readonly Pen GreenPen = new(new SolidColorBrush(ZoneGreen, 0.45), 1);
-    private static readonly Pen AmberPen = new(new SolidColorBrush(ZoneAmber), 1.5);
-    private static readonly Pen RedPen = new(new SolidColorBrush(ZoneRed), 1.5);
-    private static readonly Pen GreenSelectedPen = new(ZoneGreenBrush, 1);
-    private static readonly Pen AmberSelectedPen = new(ZoneAmberBrush, 1);
-    private static readonly Pen RedSelectedPen = new(ZoneRedBrush, 1);
+    private static readonly IBrush GreenFill = new ImmutableSolidColorBrush(ZoneGreen, 0.13);
+    private static readonly IBrush AmberFill = new ImmutableSolidColorBrush(ZoneAmber, 0.45);
+    private static readonly IBrush RedFill = new ImmutableSolidColorBrush(ZoneRed, 0.45);
+    private static readonly IPen GreenPen = new ImmutablePen(new ImmutableSolidColorBrush(ZoneGreen, 0.45), 1);
+    private static readonly IPen AmberPen = new ImmutablePen(new ImmutableSolidColorBrush(ZoneAmber), 1.5);
+    private static readonly IPen RedPen = new ImmutablePen(new ImmutableSolidColorBrush(ZoneRed), 1.5);
+    private static readonly IPen GreenSelectedPen = new ImmutablePen(ZoneGreenBrush, 1);
+    private static readonly IPen AmberSelectedPen = new ImmutablePen(ZoneAmberBrush, 1);
+    private static readonly IPen RedSelectedPen = new ImmutablePen(ZoneRedBrush, 1);
 
     public PositionMonitorControl()
     {

--- a/src/ui/Features/Shared/ErrorList/LineError.cs
+++ b/src/ui/Features/Shared/ErrorList/LineError.cs
@@ -1,4 +1,5 @@
 using Avalonia.Media;
+using Avalonia.Media.Immutable;
 using Nikse.SubtitleEdit.Logic.Config;
 
 namespace Nikse.SubtitleEdit.Features.Shared.ErrorList;
@@ -68,15 +69,15 @@ public record LineError(LineErrorType Type, string Detail)
     private const string GapColor = "#1ABC9C";
     public const string AllColor = "#5D8AA8";
 
-    private static readonly IBrush TooManyLinesBrush = new SolidColorBrush(Color.Parse(TooManyLinesColor));
-    private static readonly IBrush CpsBrush = new SolidColorBrush(Color.Parse(CpsColor));
-    private static readonly IBrush TooShortBrush = new SolidColorBrush(Color.Parse(TooShortColor));
-    private static readonly IBrush TooLongBrush = new SolidColorBrush(Color.Parse(TooLongColor));
-    private static readonly IBrush LineTooLongBrush = new SolidColorBrush(Color.Parse(LineTooLongColor));
-    private static readonly IBrush LineTooWideBrush = new SolidColorBrush(Color.Parse(LineTooWideColor));
-    private static readonly IBrush OverlapBrush = new SolidColorBrush(Color.Parse(OverlapColor));
-    private static readonly IBrush GapBrush = new SolidColorBrush(Color.Parse(GapColor));
-    public static readonly IBrush AllBrush = new SolidColorBrush(Color.Parse(AllColor));
+    private static readonly IBrush TooManyLinesBrush = new ImmutableSolidColorBrush(Color.Parse(TooManyLinesColor));
+    private static readonly IBrush CpsBrush = new ImmutableSolidColorBrush(Color.Parse(CpsColor));
+    private static readonly IBrush TooShortBrush = new ImmutableSolidColorBrush(Color.Parse(TooShortColor));
+    private static readonly IBrush TooLongBrush = new ImmutableSolidColorBrush(Color.Parse(TooLongColor));
+    private static readonly IBrush LineTooLongBrush = new ImmutableSolidColorBrush(Color.Parse(LineTooLongColor));
+    private static readonly IBrush LineTooWideBrush = new ImmutableSolidColorBrush(Color.Parse(LineTooWideColor));
+    private static readonly IBrush OverlapBrush = new ImmutableSolidColorBrush(Color.Parse(OverlapColor));
+    private static readonly IBrush GapBrush = new ImmutableSolidColorBrush(Color.Parse(GapColor));
+    public static readonly IBrush AllBrush = new ImmutableSolidColorBrush(Color.Parse(AllColor));
 
     /// <summary>The dot colour as "#RRGGBB" - the html export paints the same palette as the window.</summary>
     public static string GetColor(LineErrorType type)

--- a/src/ui/Features/Tools/AiReview/ReviewSuggestionItem.cs
+++ b/src/ui/Features/Tools/AiReview/ReviewSuggestionItem.cs
@@ -1,4 +1,5 @@
 using Avalonia.Media;
+using Avalonia.Media.Immutable;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Nikse.SubtitleEdit.Logic.Config;
 
@@ -66,17 +67,17 @@ public partial class ReviewSuggestionItem : ObservableObject
 
     private static class CategoryBrushes
     {
-        public static readonly IBrush Spelling = new SolidColorBrush(Color.FromRgb(0xe8, 0xb0, 0x4c));
-        public static readonly IBrush Grammar = new SolidColorBrush(Color.FromRgb(0xb4, 0x8c, 0xe8));
-        public static readonly IBrush Punctuation = new SolidColorBrush(Color.FromRgb(0x5f, 0xc6, 0xd8));
-        public static readonly IBrush Casing = new SolidColorBrush(Color.FromRgb(0xe8, 0x8c, 0xb0));
-        public static readonly IBrush Other = new SolidColorBrush(Color.FromRgb(0x9a, 0xa3, 0xad));
-        public static readonly IBrush Warning = new SolidColorBrush(Color.FromRgb(0xf0, 0xa6, 0x3c));
-        public static readonly IBrush SpellingBackground = new SolidColorBrush(Color.FromArgb(0x20, 0xe8, 0xb0, 0x4c));
-        public static readonly IBrush GrammarBackground = new SolidColorBrush(Color.FromArgb(0x20, 0xb4, 0x8c, 0xe8));
-        public static readonly IBrush PunctuationBackground = new SolidColorBrush(Color.FromArgb(0x20, 0x5f, 0xc6, 0xd8));
-        public static readonly IBrush CasingBackground = new SolidColorBrush(Color.FromArgb(0x20, 0xe8, 0x8c, 0xb0));
-        public static readonly IBrush OtherBackground = new SolidColorBrush(Color.FromArgb(0x20, 0x9a, 0xa3, 0xad));
+        public static readonly IBrush Spelling = new ImmutableSolidColorBrush(Color.FromRgb(0xe8, 0xb0, 0x4c));
+        public static readonly IBrush Grammar = new ImmutableSolidColorBrush(Color.FromRgb(0xb4, 0x8c, 0xe8));
+        public static readonly IBrush Punctuation = new ImmutableSolidColorBrush(Color.FromRgb(0x5f, 0xc6, 0xd8));
+        public static readonly IBrush Casing = new ImmutableSolidColorBrush(Color.FromRgb(0xe8, 0x8c, 0xb0));
+        public static readonly IBrush Other = new ImmutableSolidColorBrush(Color.FromRgb(0x9a, 0xa3, 0xad));
+        public static readonly IBrush Warning = new ImmutableSolidColorBrush(Color.FromRgb(0xf0, 0xa6, 0x3c));
+        public static readonly IBrush SpellingBackground = new ImmutableSolidColorBrush(Color.FromArgb(0x20, 0xe8, 0xb0, 0x4c));
+        public static readonly IBrush GrammarBackground = new ImmutableSolidColorBrush(Color.FromArgb(0x20, 0xb4, 0x8c, 0xe8));
+        public static readonly IBrush PunctuationBackground = new ImmutableSolidColorBrush(Color.FromArgb(0x20, 0x5f, 0xc6, 0xd8));
+        public static readonly IBrush CasingBackground = new ImmutableSolidColorBrush(Color.FromArgb(0x20, 0xe8, 0x8c, 0xb0));
+        public static readonly IBrush OtherBackground = new ImmutableSolidColorBrush(Color.FromArgb(0x20, 0x9a, 0xa3, 0xad));
     }
 }
 

--- a/src/ui/Features/Tools/BeautifyTimeCodes/Profile/CuesPreviewControl.cs
+++ b/src/ui/Features/Tools/BeautifyTimeCodes/Profile/CuesPreviewControl.cs
@@ -3,6 +3,7 @@ using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Layout;
 using Avalonia.Media;
+using Avalonia.Media.Immutable;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
@@ -30,12 +31,12 @@ public sealed class CuesPreviewControl : Control
 
     // Render() is called on every NUD change; cache the brushes / typeface
     // once instead of allocating fresh ones each draw.
-    private static readonly IBrush BackgroundBrush = new SolidColorBrush(Color.FromRgb(168, 168, 168));
-    private static readonly IBrush GreenBrush = new SolidColorBrush(Color.FromRgb(0, 110, 0));
-    private static readonly IBrush RedBrush = new SolidColorBrush(Color.FromRgb(178, 34, 34));
-    private static readonly IBrush ParagraphBrush = new SolidColorBrush(Color.FromArgb(180, 0, 0, 0));
-    private static readonly IBrush TextBrush = new SolidColorBrush(Colors.White);
-    private static readonly IBrush ShotChangeBrush = new SolidColorBrush(Color.FromRgb(152, 251, 152));
+    private static readonly IBrush BackgroundBrush = new ImmutableSolidColorBrush(Color.FromRgb(168, 168, 168));
+    private static readonly IBrush GreenBrush = new ImmutableSolidColorBrush(Color.FromRgb(0, 110, 0));
+    private static readonly IBrush RedBrush = new ImmutableSolidColorBrush(Color.FromRgb(178, 34, 34));
+    private static readonly IBrush ParagraphBrush = new ImmutableSolidColorBrush(Color.FromArgb(180, 0, 0, 0));
+    private static readonly IBrush TextBrush = new ImmutableSolidColorBrush(Colors.White);
+    private static readonly IBrush ShotChangeBrush = new ImmutableSolidColorBrush(Color.FromRgb(152, 251, 152));
     private static readonly Typeface LabelTypeface = new Typeface(FontFamily.Default);
 
     public double FrameRate { get => _frameRate; set { _frameRate = value; InvalidateVisual(); } }

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextQualityReportViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextQualityReportViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media;
+using Avalonia.Media.Immutable;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Logic;
@@ -47,13 +48,13 @@ public partial class SpeechToTextQualityReportViewModel : ObservableObject
 
     private readonly List<QualityReportDisplayItem> _allItems = new();
 
-    public static readonly IBrush TooShortBrush = new SolidColorBrush(Color.Parse("#E8912D"));
-    public static readonly IBrush TooLongBrush = new SolidColorBrush(Color.Parse("#9B59B6"));
-    public static readonly IBrush OverlapBrush = new SolidColorBrush(Color.Parse("#E74C3C"));
-    public static readonly IBrush NonSpeechBrush = new SolidColorBrush(Color.Parse("#3498DB"));
-    public static readonly IBrush RepeatedBrush = new SolidColorBrush(Color.Parse("#1ABC9C"));
-    public static readonly IBrush RemovedBrush = new SolidColorBrush(Color.Parse("#7F8C8D"));
-    public static readonly IBrush AllBrush = new SolidColorBrush(Color.Parse("#5D8AA8"));
+    public static readonly IBrush TooShortBrush = new ImmutableSolidColorBrush(Color.Parse("#E8912D"));
+    public static readonly IBrush TooLongBrush = new ImmutableSolidColorBrush(Color.Parse("#9B59B6"));
+    public static readonly IBrush OverlapBrush = new ImmutableSolidColorBrush(Color.Parse("#E74C3C"));
+    public static readonly IBrush NonSpeechBrush = new ImmutableSolidColorBrush(Color.Parse("#3498DB"));
+    public static readonly IBrush RepeatedBrush = new ImmutableSolidColorBrush(Color.Parse("#1ABC9C"));
+    public static readonly IBrush RemovedBrush = new ImmutableSolidColorBrush(Color.Parse("#7F8C8D"));
+    public static readonly IBrush AllBrush = new ImmutableSolidColorBrush(Color.Parse("#5D8AA8"));
 
     public static IBrush GetBrush(SpeechToTextQualityIssueType type)
     {

--- a/src/ui/Logic/StatusDots.cs
+++ b/src/ui/Logic/StatusDots.cs
@@ -6,6 +6,7 @@ using Avalonia.Controls.Shapes;
 using Avalonia.Controls.Templates;
 using Avalonia.Layout;
 using Avalonia.Media;
+using Avalonia.Media.Immutable;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Download;
 
@@ -38,9 +39,9 @@ public enum DownloadDotStatus
 /// </summary>
 public static class StatusDots
 {
-    public static readonly IBrush Green = new SolidColorBrush(Color.FromRgb(0x4C, 0xAF, 0x50));
-    public static readonly IBrush Amber = new SolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00));
-    public static readonly IBrush Grey = new SolidColorBrush(Color.FromRgb(0x9E, 0x9E, 0x9E));
+    public static readonly IBrush Green = new ImmutableSolidColorBrush(Color.FromRgb(0x4C, 0xAF, 0x50));
+    public static readonly IBrush Amber = new ImmutableSolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00));
+    public static readonly IBrush Grey = new ImmutableSolidColorBrush(Color.FromRgb(0x9E, 0x9E, 0x9E));
 
     /// <summary>The fill for a status dot, or null when no dot should be shown.</summary>
     public static IBrush? BrushFor(DownloadDotStatus status) => status switch

--- a/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
+++ b/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
@@ -41,25 +41,25 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
     // Reuse brushes instead of creating new ones each time. The scheme colors from
     // SubtitleSyntaxTokenizer are theme-dependent, so the brushes are resolved per render and
     // cached per color (the cache stays tiny: both palettes together are 12 colors).
-    private static readonly Dictionary<Color, SolidColorBrush> BrushCache = new();
+    private static readonly Dictionary<Color, ImmutableSolidColorBrush> BrushCache = new();
 
-    private static SolidColorBrush GetBrush(Color color)
+    private static ImmutableSolidColorBrush GetBrush(Color color)
     {
         if (!BrushCache.TryGetValue(color, out var brush))
         {
-            brush = new SolidColorBrush(color);
+            brush = new ImmutableSolidColorBrush(color);
             BrushCache[color] = brush;
         }
 
         return brush;
     }
 
-    private static SolidColorBrush ElementBrush => GetBrush(SubtitleSyntaxTokenizer.ElementColor);
-    private static SolidColorBrush AttributeBrush => GetBrush(SubtitleSyntaxTokenizer.AttributeColor);
-    private static SolidColorBrush CommentBrush => GetBrush(SubtitleSyntaxTokenizer.CommentColor);
-    private static SolidColorBrush CharsBrush => GetBrush(SubtitleSyntaxTokenizer.CharsColor);
-    private static SolidColorBrush ValuesBrush => GetBrush(SubtitleSyntaxTokenizer.ValuesColor);
-    private static SolidColorBrush StyleBrush => GetBrush(SubtitleSyntaxTokenizer.StyleColor);
+    private static ImmutableSolidColorBrush ElementBrush => GetBrush(SubtitleSyntaxTokenizer.ElementColor);
+    private static ImmutableSolidColorBrush AttributeBrush => GetBrush(SubtitleSyntaxTokenizer.AttributeColor);
+    private static ImmutableSolidColorBrush CommentBrush => GetBrush(SubtitleSyntaxTokenizer.CommentColor);
+    private static ImmutableSolidColorBrush CharsBrush => GetBrush(SubtitleSyntaxTokenizer.CharsColor);
+    private static ImmutableSolidColorBrush ValuesBrush => GetBrush(SubtitleSyntaxTokenizer.ValuesColor);
+    private static ImmutableSolidColorBrush StyleBrush => GetBrush(SubtitleSyntaxTokenizer.StyleColor);
 
     // One shared wavy-red underline for all misspelled words - a brush + decoration +
     // collection used to be allocated per misspelled word on every cell repaint.

--- a/tests/UI/Features/Main/SubtitleLineViewModelCacheTests.cs
+++ b/tests/UI/Features/Main/SubtitleLineViewModelCacheTests.cs
@@ -13,7 +13,7 @@ namespace UITests.Features.Main;
 /// </summary>
 public class SubtitleLineViewModelCacheTests
 {
-    private static Color ColorOf(IBrush brush) => Assert.IsType<SolidColorBrush>(brush).Color;
+    private static Color ColorOf(IBrush brush) => Assert.IsAssignableFrom<ISolidColorBrush>(brush).Color;
 
     [AvaloniaFact]
     public void TextBackgroundBrush_FollowsMaxLineLengthChange()

--- a/tests/UI/Features/Main/SubtitleMetricsRegressionTests.cs
+++ b/tests/UI/Features/Main/SubtitleMetricsRegressionTests.cs
@@ -90,7 +90,7 @@ public class SubtitleMetricsRegressionTests
                 EndTime = TimeSpan.FromSeconds(2),
             };
 
-            var brush = Assert.IsType<SolidColorBrush>(vm.TextBackgroundBrush);
+            var brush = Assert.IsAssignableFrom<ISolidColorBrush>(vm.TextBackgroundBrush);
 
             Assert.Equal(Colors.Transparent, brush.Color);
             Assert.DoesNotContain(vm.GetErrorList(null, null), e => e.Type == LineErrorType.LineTooLong);


### PR DESCRIPTION
## Summary

A `SolidColorBrush` or `Pen` is an `AvaloniaObject` bound to the thread that constructs it, and a `static readonly` field is initialised on whichever thread first touches the class. In the headless UI suite that can be the xUnit worker thread (a plain `[Fact]`), after which the first control that paints with the brush throws `The calling thread cannot access this object` inside a render job and leaves the compositor broken for the rest of the process. That is the `AudioVisualizerColorTests` / `AssaTagRtlAvaloniaCanaryTests` block that fails together in roughly one CI run in three (four times in the last three days). #14282 fixed exactly this in `CompareColors`; this PR converts the remaining static sites, which were also a latent crash in the shipped app for any background thread that touched one of these classes first.

Converted to `ImmutableSolidColorBrush` / `ImmutablePen` / `ImmutableDashStyle` (no dispatcher affinity, identical rendering, still one static instance each):

- `AudioVisualizer` (audio-length brushes, chapter pen/flag, shot-change cursor pen)
- `PositionMonitorControl` (all zone brushes, fills and pens)
- `SubtitleLineViewModel` and `MainViewModel` error/transparent brushes
- `LineError`, `StatusDots`, `SpeechToTextQualityReportViewModel`, `ReviewSuggestionItem.CategoryBrushes`
- `CuesPreviewControl`, `CompareViewModel`, `GetPluginsWindow`, `GetPluginsDisplayItem`
- `TextWithSubtitleSyntaxHighlightingConverter.BrushCache`

Two tests asserted the concrete `SolidColorBrush` type and now assert `ISolidColorBrush`.

## Test plan

- [x] Full UITests suite locally: 4657 passed; the two failures are the separate order-dependent theme flake (#14450) and `CrispAsrTtsProvenanceTests.RealHelpProbe…`, which passed in the previous two local runs of the same code and does not touch brushes.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)