### PR TITLE
Waveform click/wheel landed a GOP away and hopped a frame forward (#14441)

### DIFF
--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicPlayer.cs
@@ -74,6 +74,7 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
     // has already been and gone.
     private long _scrubFollowUpSeekId;     // keyframe seek owing an exact landing, 0 if none
     private long _scrubFollowUpTargetBits; // that seek's target, as double bits
+    private bool _lastSeekIssuedInFlight;  // the newest seek was issued while a seek was in flight (under _seekStateLock)
 
     // Guards every publish and claim of the seek generation + follow-up debt (IssueSeek, the
     // follow-up/settle/cancel paths). The id, target and debt slot are three separate fields, so
@@ -817,6 +818,18 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
     }
 
     /// <summary>
+    /// Number of seek commands sent to mpv so far, deferred exact landings included. Test
+    /// visibility for the two-tier scrub seeking: a settled burst must add exactly one.
+    /// </summary>
+    internal long IssuedSeekCount => Interlocked.Read(ref _lastSeekCommandId);
+
+    /// <summary>
+    /// Whether a keyframe seek still owes its exact landing. Test visibility: must be false once
+    /// a burst has settled, or the video is stranded on a keyframe.
+    /// </summary>
+    internal bool OwesExactLanding => Interlocked.Read(ref _scrubFollowUpSeekId) != 0;
+
+    /// <summary>
     /// Pays the exact landing a mid-burst keyframe seek deferred, once that seek has landed and
     /// nothing newer has replaced it. Runs on the event thread, from the restart event that says
     /// the seek finished.
@@ -843,18 +856,13 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
 
             var target = BitConverter.Int64BitsToDouble(Interlocked.Read(ref _scrubFollowUpTargetBits));
 
-            // The observed position, never the Position getter: that one answers with the pinned
-            // target while paused, so every deferred landing would look already reached.
-            double? reported = _observedTimePosValid
-                ? BitConverter.Int64BitsToDouble(Interlocked.Read(ref _observedTimePosBits))
-                : null;
-
+            // Never gated on mpv's reported position: during a seek mpv reports the target as
+            // time-pos, and the observed cache is what this thread refreshed last, so a "close
+            // enough" check here compared the target with itself and skipped the landing (#14441).
             if (!ScrubSeekPolicy.ShouldIssueFollowUp(
                     followUpId,
                     Interlocked.Read(ref _lastSeekCommandId),
-                    Interlocked.Read(ref _restartAckedSeekCommandId),
-                    target,
-                    reported))
+                    Interlocked.Read(ref _restartAckedSeekCommandId)))
             {
                 return;
             }
@@ -2121,7 +2129,12 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
                 return _audioEndBound.Value;
             }
 
-            if (_pausedValue.HasValue && IsPaused && !Se.Settings.General.UseFrameMode)
+            // In frame mode too: this used to fall through to mpv's decoded frame time, so a
+            // waveform click while paused landed the cursor on the click, then ~50 ms later on the
+            // first frame at or after it - a visible one-frame hop forward on every click, in a
+            // mode SE forces on for EBU STL (#14441). The seek target is where the user pointed;
+            // the frame steps that need the real frame position clear the cache themselves.
+            if (_pausedValue.HasValue && IsPaused)
             {
                 return _pausedValue.Value;
             }
@@ -2213,12 +2226,15 @@ public sealed class LibMpvDynamicPlayer : IDisposable, IVideoPlayer
             _pausedValue = value;
             _lastRawTimePos = value; // keep the eof-reached gate accurate across seeks
 
-            // A seek arriving while an earlier one is still in flight is a burst - a waveform
+            // Seeks arriving while earlier ones are still in flight are a burst - a waveform
             // drag, a slider drag, a wheel spin, one seek per input event - and all but its last
             // seek are about to be superseded. Those are served fast, at keyframes, and the exact
             // landing is deferred to when the burst settles (ScrubSeekPolicy). An isolated seek,
-            // the common case, is exact right away as before.
-            var inBurst = !forceExact && IsSeekInFlight();
+            // the common case, is exact right away as before - and so is the second seek of a
+            // pair, which is what a waveform click issues (ScrubSeekPolicy.JoinsBurst).
+            var seekInFlight = !forceExact && IsSeekInFlight();
+            var inBurst = ScrubSeekPolicy.JoinsBurst(seekInFlight, _lastSeekIssuedInFlight);
+            _lastSeekIssuedInFlight = seekInFlight;
             var seekFlags = ScrubSeekPolicy.FlagsFor(inBurst);
 
             // Fire-and-forget: seeks arrive in storms (scrubbing, slider drags, wheel steps -

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/ScrubSeekPolicy.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/ScrubSeekPolicy.cs
@@ -13,12 +13,18 @@ namespace Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
 /// user is already moving away from is what makes scrubbing feel heavy.
 /// </para>
 /// <para>
-/// So a seek issued while an earlier one is still in flight - the signature of a burst - is served
-/// with "keyframes" instead, which skips that decode. Precision is not given up, only deferred:
-/// the keyframe seek is recorded as owing an exact landing, and when the burst settles (that seek
-/// lands and nothing newer has replaced it) one exact seek to the final target is issued. Isolated
-/// seeks never take that path - the first seek of a burst is exact, as before - so nothing that
-/// clicks once behaves differently.
+/// So a seek that joins a burst is served with "keyframes" instead, which skips that decode.
+/// Precision is not given up, only deferred: the keyframe seek is recorded as owing an exact
+/// landing, and when the burst settles (that seek lands and nothing newer has replaced it) one
+/// exact seek to the final target is issued. A burst takes three seeks to establish itself - see
+/// <see cref="JoinsBurst"/> - so a single click, and the click paths that seek twice in one input
+/// event (pointer release plus tap), behave exactly as before.
+/// </para>
+/// <para>
+/// A keyframe seek lands on the keyframe BEFORE the target (mpv's rule for absolute seeks), which
+/// on a long-GOP file can be many seconds back, so the deferred exact landing is never optional:
+/// a burst that ends without it leaves the video, and everything that reads mpv's position, a
+/// whole GOP away from where the user pointed.
 /// </para>
 /// </summary>
 public static class ScrubSeekPolicy
@@ -35,13 +41,6 @@ public static class ScrubSeekPolicy
     public const string KeyframeSeekFlags = "absolute+keyframes";
 
     /// <summary>
-    /// How close the keyframe landing has to be to the target to count as already exact. A seek
-    /// whose target happens to be a keyframe lands on it, and re-seeking there would cost a
-    /// decode for no movement.
-    /// </summary>
-    public const double FollowUpToleranceSeconds = 0.001;
-
-    /// <summary>
     /// How long a seek may be counted as still in flight. Every seek ends in a playback restart,
     /// but a seek mpv drops - on a core that has stopped, or a file that went away - never gets
     /// one, and "in flight" would then latch forever: every later seek served at keyframes, each
@@ -53,13 +52,32 @@ public static class ScrubSeekPolicy
     /// <summary>
     /// The flags for a seek issued now: fast if this one is joining a burst, precise otherwise.
     /// </summary>
-    public static string FlagsFor(bool seekInFlight)
+    public static string FlagsFor(bool joinsBurst)
     {
-        return seekInFlight ? KeyframeSeekFlags : ExactSeekFlags;
+        return joinsBurst ? KeyframeSeekFlags : ExactSeekFlags;
     }
 
     /// <summary>
-    /// Whether a seek SE issued is still on its way - the burst signal <see cref="FlagsFor"/>
+    /// Whether a seek issued now is the continuation of a burst, and so may be served fast.
+    /// <para>
+    /// One seek arriving while another is in flight is not enough: the waveform click path seeks
+    /// twice in the same input event (the pointer release seeks, the tap that follows seeks
+    /// again, to the frame-snapped position), and serving that second seek at keyframes would
+    /// flash a frame from the previous keyframe - seconds back on a long-GOP file - before the
+    /// exact landing was paid. So the fast path needs a sequence: the seek in flight must itself
+    /// have been issued while a seek was in flight. A drag or a wheel spin gets there on its third
+    /// event and pays two exact seeks instead of one at its start; a click never gets there.
+    /// </para>
+    /// </summary>
+    /// <param name="seekInFlight">A seek SE issued has not landed yet (<see cref="SeekIsInFlight"/>).</param>
+    /// <param name="previousSeekIssuedInFlight">That seek was itself issued while a seek was in flight.</param>
+    public static bool JoinsBurst(bool seekInFlight, bool previousSeekIssuedInFlight)
+    {
+        return seekInFlight && previousSeekIssuedInFlight;
+    }
+
+    /// <summary>
+    /// Whether a seek SE issued is still on its way - the burst signal <see cref="JoinsBurst"/>
     /// keys on.
     /// </summary>
     /// <param name="eventLoopActive">
@@ -89,19 +107,26 @@ public static class ScrubSeekPolicy
     }
 
     /// <summary>
-    /// Whether the exact seek owed by a keyframe seek should be issued now.
+    /// Whether the exact seek owed by a keyframe seek should be issued now: once that seek has
+    /// landed and nothing newer has replaced it, always.
+    /// <para>
+    /// This deliberately does not look at where mpv says it is. While a seek is in progress mpv
+    /// reports the seek TARGET as "time-pos", and the observed-property cache is refreshed only
+    /// after the event queue drains, so at the playback-restart event the cached position is the
+    /// target itself. A "close enough, skip the landing" check compares the target with the
+    /// target, passes, and the keyframe landing - a GOP short of it - stands for good (#14441:
+    /// wheel steps that kept landing on the same spot, clicks whose cursor and video ended up
+    /// elsewhere). An exact seek to a spot that is already a keyframe costs nothing to speak of,
+    /// so there is nothing worth saving by guessing.
+    /// </para>
     /// </summary>
     /// <param name="followUpSeekId">Id of the keyframe seek owing an exact landing, 0 if none.</param>
     /// <param name="lastSeekCommandId">Newest seek id handed out.</param>
     /// <param name="restartAckedSeekCommandId">Newest seek id mpv has finished a playback restart for.</param>
-    /// <param name="target">Position that keyframe seek was aiming at.</param>
-    /// <param name="reportedPosition">Where mpv says it is now, null if it has no position yet.</param>
     public static bool ShouldIssueFollowUp(
         long followUpSeekId,
         long lastSeekCommandId,
-        long restartAckedSeekCommandId,
-        double target,
-        double? reportedPosition)
+        long restartAckedSeekCommandId)
     {
         if (followUpSeekId == 0)
         {
@@ -113,16 +138,7 @@ public static class ScrubSeekPolicy
             return false; // a newer seek owns the position now, and carries its own follow-up
         }
 
-        if (restartAckedSeekCommandId < followUpSeekId)
-        {
-            return false; // the burst is still running - a later restart gets to ask again
-        }
-
-        if (reportedPosition == null)
-        {
-            return true; // cannot confirm the landing, so pay for it
-        }
-
-        return Math.Abs(reportedPosition.Value - target) > FollowUpToleranceSeconds;
+        // Its own restart has not arrived: the burst is still running, a later restart asks again.
+        return restartAckedSeekCommandId >= followUpSeekId;
     }
 }

--- a/tests/UI/Logic/ScrubSeekPolicyTests.cs
+++ b/tests/UI/Logic/ScrubSeekPolicyTests.cs
@@ -14,13 +14,32 @@ public class ScrubSeekPolicyTests
     public void IsolatedSeek_IsExact()
     {
         // The single click on the waveform, and every non-drag seek: unchanged from before.
-        Assert.Equal(ScrubSeekPolicy.ExactSeekFlags, ScrubSeekPolicy.FlagsFor(seekInFlight: false));
+        Assert.False(ScrubSeekPolicy.JoinsBurst(seekInFlight: false, previousSeekIssuedInFlight: false));
+        Assert.Equal(ScrubSeekPolicy.ExactSeekFlags, ScrubSeekPolicy.FlagsFor(joinsBurst: false));
     }
 
     [Fact]
-    public void SeekDuringAnUnfinishedSeek_IsServedAtKeyframes()
+    public void SecondSeekOfAPair_IsStillExact()
     {
-        Assert.Equal(ScrubSeekPolicy.KeyframeSeekFlags, ScrubSeekPolicy.FlagsFor(seekInFlight: true));
+        // A waveform click seeks twice in one input event (pointer release, then the tap with
+        // the frame-snapped position). Serving the second one at keyframes flashed the previous
+        // keyframe's frame - seconds back on a long-GOP file - before the exact landing (#14441).
+        Assert.False(ScrubSeekPolicy.JoinsBurst(seekInFlight: true, previousSeekIssuedInFlight: false));
+    }
+
+    [Fact]
+    public void ThirdSeekInARow_IsServedAtKeyframes()
+    {
+        // The seek in flight was itself issued into an unfinished seek: a drag or wheel spin.
+        Assert.True(ScrubSeekPolicy.JoinsBurst(seekInFlight: true, previousSeekIssuedInFlight: true));
+        Assert.Equal(ScrubSeekPolicy.KeyframeSeekFlags, ScrubSeekPolicy.FlagsFor(joinsBurst: true));
+    }
+
+    [Fact]
+    public void ALandedSeek_EndsTheBurst()
+    {
+        // Whatever the history, once nothing is in flight the next seek is a fresh start.
+        Assert.False(ScrubSeekPolicy.JoinsBurst(seekInFlight: false, previousSeekIssuedInFlight: true));
     }
 
     [Fact]
@@ -59,8 +78,7 @@ public class ScrubSeekPolicyTests
     public void NoFollowUp_WhenNothingOwesAnExactLanding()
     {
         Assert.False(ScrubSeekPolicy.ShouldIssueFollowUp(
-            followUpSeekId: 0, lastSeekCommandId: 7, restartAckedSeekCommandId: 7,
-            target: 12.0, reportedPosition: 8.0));
+            followUpSeekId: 0, lastSeekCommandId: 7, restartAckedSeekCommandId: 7));
     }
 
     [Fact]
@@ -68,8 +86,7 @@ public class ScrubSeekPolicyTests
     {
         // Its own restart has not arrived, so the burst may well continue - that restart asks again.
         Assert.False(ScrubSeekPolicy.ShouldIssueFollowUp(
-            followUpSeekId: 7, lastSeekCommandId: 7, restartAckedSeekCommandId: 6,
-            target: 12.0, reportedPosition: 8.0));
+            followUpSeekId: 7, lastSeekCommandId: 7, restartAckedSeekCommandId: 6));
     }
 
     [Fact]
@@ -78,81 +95,65 @@ public class ScrubSeekPolicyTests
         // Mid-drag: seek 8 already owns the position and carries its own follow-up. Paying seek
         // 7's landing here would seek back to a position the user has moved away from.
         Assert.False(ScrubSeekPolicy.ShouldIssueFollowUp(
-            followUpSeekId: 7, lastSeekCommandId: 8, restartAckedSeekCommandId: 7,
-            target: 12.0, reportedPosition: 8.0));
+            followUpSeekId: 7, lastSeekCommandId: 8, restartAckedSeekCommandId: 7));
     }
 
     [Fact]
-    public void FollowUp_WhenTheBurstHasSettledShortOfTheTarget()
+    public void FollowUp_AlwaysOnceTheBurstHasSettled()
     {
-        // Mouse released: the last keyframe seek landed at 8.0 but the user asked for 12.0.
+        // Mouse released and the last keyframe seek has landed: pay the exact landing, without
+        // asking mpv where it is. While seeking mpv reports the seek target as its position, so a
+        // "landed close enough already" check passed every time and the keyframe landing - a whole
+        // GOP short of the target - stood for good (#14441).
         Assert.True(ScrubSeekPolicy.ShouldIssueFollowUp(
-            followUpSeekId: 7, lastSeekCommandId: 7, restartAckedSeekCommandId: 7,
-            target: 12.0, reportedPosition: 8.0));
-    }
-
-    [Fact]
-    public void NoFollowUp_WhenTheKeyframeLandingAlreadyHitTheTarget()
-    {
-        // The target was a keyframe, so the fast seek was already exact - re-seeking there would
-        // cost a decode for no movement.
-        Assert.False(ScrubSeekPolicy.ShouldIssueFollowUp(
-            followUpSeekId: 7, lastSeekCommandId: 7, restartAckedSeekCommandId: 7,
-            target: 12.0, reportedPosition: 12.0));
-    }
-
-    [Fact]
-    public void FollowUp_WhenTheLandingCannotBeConfirmed()
-    {
-        // mpv has no position to report yet. Skipping here would strand the video on a keyframe,
-        // so an unnecessary exact seek is the cheaper mistake.
-        Assert.True(ScrubSeekPolicy.ShouldIssueFollowUp(
-            followUpSeekId: 7, lastSeekCommandId: 7, restartAckedSeekCommandId: 7,
-            target: 12.0, reportedPosition: null));
+            followUpSeekId: 7, lastSeekCommandId: 7, restartAckedSeekCommandId: 7));
     }
 
     /// <summary>
-    /// A burst is a sequence, not one decision: the first seek is exact, everything issued while
-    /// a seek is in flight is fast, and the settled end pays exactly one exact landing.
+    /// A burst is a sequence, not one decision: the first two seeks are exact, everything issued
+    /// while a seek is in flight after that is fast, and the settled end pays exactly one exact
+    /// landing.
     /// </summary>
     [Fact]
-    public void WholeDrag_IsOneExactSeekAtEachEnd()
+    public void WholeDrag_IsExactAtEachEnd()
     {
         var flags = new List<string>();
         long lastId = 0;
         long restartAcked = 0;
         long followUpId = 0;
-        var target = 0.0;
+        var previousIssuedInFlight = false;
 
         // Mouse down, then eight drag steps arriving faster than mpv can land them.
-        foreach (var position in new[] { 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0 })
+        foreach (var _ in new[] { 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0 })
         {
             var inFlight = ScrubSeekPolicy.SeekIsInFlight(
                 eventLoopActive: true,
                 lastSeekCommandId: lastId,
                 restartAckedSeekCommandId: restartAcked,
                 secondsSinceLastSeekIssued: 0.02); // one drag step apart
-            flags.Add(ScrubSeekPolicy.FlagsFor(inFlight));
+            var joinsBurst = ScrubSeekPolicy.JoinsBurst(inFlight, previousIssuedInFlight);
+            previousIssuedInFlight = inFlight;
+            flags.Add(ScrubSeekPolicy.FlagsFor(joinsBurst));
             lastId++;
-            target = position;
-            followUpId = inFlight ? lastId : 0;
+            followUpId = joinsBurst ? lastId : 0;
         }
 
         Assert.Equal(ScrubSeekPolicy.ExactSeekFlags, flags[0]);
-        Assert.All(flags.Skip(1), f => Assert.Equal(ScrubSeekPolicy.KeyframeSeekFlags, f));
+        Assert.Equal(ScrubSeekPolicy.ExactSeekFlags, flags[1]);
+        Assert.All(flags.Skip(2), f => Assert.Equal(ScrubSeekPolicy.KeyframeSeekFlags, f));
 
-        // Mouse up. The last keyframe seek lands on its keyframe, 3.6 s short of the target.
+        // Mouse up. The last keyframe seek lands on its keyframe, short of the target.
         restartAcked = lastId;
-        Assert.True(ScrubSeekPolicy.ShouldIssueFollowUp(followUpId, lastId, restartAcked, target, 8.4));
+        Assert.True(ScrubSeekPolicy.ShouldIssueFollowUp(followUpId, lastId, restartAcked));
 
         // That follow-up goes out as an exact seek and clears the debt, so its own restart - and
         // any later one - does not start the cycle over.
-        var followUpFlags = ScrubSeekPolicy.FlagsFor(seekInFlight: false);
+        var followUpFlags = ScrubSeekPolicy.FlagsFor(joinsBurst: false);
         followUpId = 0;
         lastId++;
         restartAcked = lastId;
 
         Assert.Equal(ScrubSeekPolicy.ExactSeekFlags, followUpFlags);
-        Assert.False(ScrubSeekPolicy.ShouldIssueFollowUp(followUpId, lastId, restartAcked, target, target));
+        Assert.False(ScrubSeekPolicy.ShouldIssueFollowUp(followUpId, lastId, restartAcked));
     }
 }

--- a/tests/UI/Logic/VideoPlayers/LibMpvEventLoopTests.cs
+++ b/tests/UI/Logic/VideoPlayers/LibMpvEventLoopTests.cs
@@ -358,6 +358,140 @@ public class LibMpvEventLoopTests
     }
 
     /// <summary>
+    /// Two-tier scrub seeking (#14441): a burst of seeks serves all but its first two at keyframes
+    /// and must then pay exactly one exact landing once it settles. The follow-up used to be
+    /// skipped when mpv's cached position looked close to the target - and it always did, because
+    /// mpv reports the seek target as time-pos while seeking - so the video stayed a GOP short.
+    /// </summary>
+    [Fact]
+    public async Task SeekBurst_PaysOneExactLandingOnceItSettles()
+    {
+        var player = CreatePlayer();
+        if (player == null)
+        {
+            return; // no libmpv on this machine
+        }
+
+        var wavFileName = WriteTempWav();
+        try
+        {
+            await player.LoadFile(wavFileName);
+            Assert.True(await WaitUntilAsync(() => player.Duration > 1.0, 5000), "file never loaded");
+
+            // A drag: seeks back to back until one is issued into an unfinished seek that was
+            // itself issued into an unfinished seek - a burst - and so is served at keyframes and
+            // owes an exact landing. On this tiny file mpv can land a seek in well under a
+            // millisecond, so how many it takes varies; a real drag delivers hundreds.
+            var target = 0.0;
+            for (var i = 0; i < 500 && !player.OwesExactLanding; i++)
+            {
+                target = 0.2 + (i % 8) * 0.2;
+                player.Position = target;
+            }
+
+            Assert.True(player.OwesExactLanding, "no seek burst could be formed - mpv landed every seek before the next one was issued");
+            var issued = player.IssuedSeekCount;
+
+            // The burst settles: the follow-up goes out as one more seek and clears the debt.
+            Assert.True(await WaitUntilAsync(() => !player.OwesExactLanding, 5000),
+                "the burst settled but the exact landing was never paid");
+            Assert.Equal(issued + 1, player.IssuedSeekCount);
+
+            // And it lands where the user pointed, with nothing left owing and no further seeks.
+            await Task.Delay(300, TestContext.Current.CancellationToken);
+            Assert.False(player.OwesExactLanding);
+            Assert.Equal(issued + 1, player.IssuedSeekCount);
+            Assert.Equal(target, player.Position, 2);
+        }
+        finally
+        {
+            player.Dispose();
+            TryDelete(wavFileName);
+        }
+    }
+
+    /// <summary>
+    /// The waveform click seeks twice in one input event (pointer release, then the tap with the
+    /// frame-snapped position). That pair is not a burst: both seeks stay exact, so no keyframe
+    /// frame flashes before the landing and nothing is left owing.
+    /// </summary>
+    [Fact]
+    public async Task ClickSeekPair_StaysExactAndOwesNothing()
+    {
+        var player = CreatePlayer();
+        if (player == null)
+        {
+            return; // no libmpv on this machine
+        }
+
+        var wavFileName = WriteTempWav();
+        try
+        {
+            await player.LoadFile(wavFileName);
+            Assert.True(await WaitUntilAsync(() => player.Duration > 1.0, 5000), "file never loaded");
+
+            player.Position = 1.3;
+            player.Pause();
+            player.Position = 1.32;
+
+            Assert.Equal(2, player.IssuedSeekCount);
+            Assert.False(player.OwesExactLanding, "the second seek of a click must not be a keyframe seek");
+
+            await Task.Delay(500, TestContext.Current.CancellationToken);
+            Assert.Equal(2, player.IssuedSeekCount);
+            Assert.False(player.OwesExactLanding);
+            Assert.Equal(1.32, player.Position, 2);
+        }
+        finally
+        {
+            player.Dispose();
+            TryDelete(wavFileName);
+        }
+    }
+
+    /// <summary>
+    /// Frame mode used to skip the paused seek-target cache, so after a waveform click the
+    /// reported position hopped from the click to the first decoded frame at or after it - a
+    /// visible one-frame jump forward on every click, in the mode SE forces on for EBU STL
+    /// (#14441). The seek target is where the user pointed, in either mode.
+    /// </summary>
+    [Fact]
+    public async Task PausedSeek_InFrameMode_KeepsReportingTheSeekTarget()
+    {
+        var player = CreatePlayer();
+        if (player == null)
+        {
+            return; // no libmpv on this machine
+        }
+
+        var wavFileName = WriteTempWav();
+        var originalOverride = Nikse.SubtitleEdit.Logic.Config.Se.Settings.General.UseFrameModeOverride;
+        Nikse.SubtitleEdit.Logic.Config.Se.Settings.General.UseFrameModeOverride = true;
+        try
+        {
+            await player.LoadFile(wavFileName);
+            Assert.True(await WaitUntilAsync(() => player.Duration > 1.0, 5000), "file never loaded");
+            Assert.True(player.IsPaused);
+
+            // A click on the waveform while paused: a target that is not on a frame boundary.
+            player.Position = 1.2345;
+
+            var end = Environment.TickCount64 + 800;
+            while (Environment.TickCount64 < end)
+            {
+                Assert.Equal(1.2345, player.Position, 4);
+                await Task.Delay(40, TestContext.Current.CancellationToken);
+            }
+        }
+        finally
+        {
+            Nikse.SubtitleEdit.Logic.Config.Se.Settings.General.UseFrameModeOverride = originalOverride;
+            player.Dispose();
+            TryDelete(wavFileName);
+        }
+    }
+
+    /// <summary>
     /// A render-free core, like the text-to-speech preview players: null video/audio outputs so
     /// nothing opens a window or touches an audio device, but the clock still runs in real time.
     /// </summary>


### PR DESCRIPTION
Fixes #14441 (beta32 regression: "the cursor is not positioned where I want", wheel steps that keep landing on the same spot).

## What was wrong

**1. Mid-burst keyframe seeks never got their exact landing.** Beta32's two-tier scrub seeking serves a seek issued while another is in flight with `absolute+keyframes`. On a long-GOP file that lands on the keyframe *before* the target, seconds back. The deferred exact seek that was supposed to fix that up was skipped every time: mpv reports the seek target as `time-pos` while a seek is in progress, and the observed-property cache only refreshes after the event queue drains, so at the restart event the "already landed close enough" check compared the target with itself. Wheel notches then kept landing on the same keyframe, and scrolling back jumped a whole GOP (the GIF in the issue).

**2. A one-frame hop forward on every click in frame mode.** The Position getter skipped the paused seek-target cache in frame mode (forced on for EBU STL), so after a click the reported position moved from the click to the first decoded frame at or after it, and the waveform cursor followed.

## Fix

- The exact follow-up is unconditional once a burst settles (its restart arrived, nothing newer replaced it). Never gate a seek decision on mpv's cached time-pos.
- A burst needs three seeks in a row: a waveform click issues two seeks in one input event (pointer release, then tap), and that pair must stay exact. Drags and wheel spins pay two exact seeks at the start instead of one.
- The paused seek-target cache is served in frame mode too.

## Verification

Live libmpv core with a 30 s h264 file (keyframes every 10 s): a raw `seek 12.5 absolute+keyframes` lands at 10.000, and before the fix a click pair left mpv at 0.000 with the follow-up debt standing. After: click pairs, 100 ms wheel notches and 31-step drags (playing and paused) all land on the final target with nothing owed.

Tests: `ScrubSeekPolicyTests` updated for the new rules; three new live-core tests in `LibMpvEventLoopTests` (burst pays exactly one follow-up, click pair stays exact, frame-mode paused seek reports the target). 33 mpv/scrub/playhead tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
