### PR TITLE
Beautify time codes profile: widen numeric up/down fields

### DIFF
--- a/src/ui/Features/Tools/BeautifyTimeCodes/Profile/BeautifyTimeCodesProfileWindow.cs
+++ b/src/ui/Features/Tools/BeautifyTimeCodes/Profile/BeautifyTimeCodesProfileWindow.cs
@@ -35,9 +35,9 @@ public class BeautifyTimeCodesProfileWindow : Window
         UiUtil.InitializeWindow(this, GetType().Name);
         Title = _l.Title;
         CanResize = true;
-        Width = 1100;
+        Width = 1220;
         Height = 760;
-        MinWidth = 980;
+        MinWidth = 1180;
         MinHeight = 640;
         vm.Window = this;
         DataContext = vm;
@@ -509,7 +509,7 @@ public class BeautifyTimeCodesProfileWindow : Window
     {
         return new NumericUpDown
         {
-            Width = 100,
+            Width = 115,
             Minimum = 0,
             Maximum = 100,
             Increment = 1,
@@ -537,7 +537,7 @@ public class BeautifyTimeCodesProfileWindow : Window
     {
         var nud = MakeFrameNud(bindingPath);
         nud.Background = new SolidColorBrush(isGreen ? Color.FromArgb(80, 0, 160, 0) : Color.FromArgb(80, 200, 30, 30));
-        nud.Width = 95;
+        nud.Width = 110;
         return nud;
     }
 


### PR DESCRIPTION
Fixes #14458

The frame and zone `NumericUpDown` fields in the beautify time codes profile editor were 100/95 px wide. On Windows that leaves room for only one digit, so the Netflix preset's zone value 12 showed truncated (see the issue screenshot).

- Frame fields (gap, chaining zones): 100 → 115 px
- Zone fields (colored): 95 → 110 px
- Window default width 1100 → 1220 and min width 980 → 1180 so the four-field Zones rows stay inside their panels (the old min width already clipped them)

Font size is unchanged. Verified with a headless render at both the default and the minimum window width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)