### PR TITLE
UI tests: keep the CrispASR help-probe timeout out of the deadlock test

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/CrispAsrTtsProvenance.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/CrispAsrTtsProvenance.cs
@@ -220,7 +220,13 @@ public static class CrispAsrTtsProvenance
         }
     }
 
-    private const int HelpProbeTimeoutMs = 15_000;
+    /// <summary>
+    /// How long the --help probe waits for the child to exit. Settable so a test that exercises
+    /// the real probe with a large stderr flood can lift it: on a loaded machine the pipe drain
+    /// can stall past 15 s, and the probe then returns null, which is indistinguishable from the
+    /// deadlock the test is looking for.
+    /// </summary>
+    internal static int HelpProbeTimeoutMs { get; set; } = 15_000;
 
     private static void TryKill(Process process)
     {

--- a/tests/UI/Features/Video/TextToSpeech/Engines/CrispAsrTtsProvenanceTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/CrispAsrTtsProvenanceTests.cs
@@ -172,23 +172,35 @@ public class CrispAsrTtsProvenanceTests
         // freezing the app on every CrispASR TTS generation. Every other test here stubs
         // HelpTextProvider, which is exactly why this went unnoticed; this one runs the real thing.
         //
-        // 1 MB is past any platform's pipe buffer (4 KB on Windows, 64 KB on Unix), so the old
+        // 256 KB is past any platform's pipe buffer (4 KB on Windows, 64 KB on Unix), so the old
         // sequential read deadlocks here regardless of where the suite runs.
         if (OperatingSystem.IsWindows())
         {
             Assert.Skip("Needs a shebang stub; Process.Start cannot launch a .cmd with UseShellExecute=false.");
         }
 
-        const int payloadBytes = 1024 * 1024;
+        const int payloadBytes = 256 * 1024;
         using var stub = ShellStub.WritingToStdErr(payloadBytes);
 
-        var probe = Task.Run(() => CrispAsrTtsProvenance.HelpTextProvider(stub.Path));
-        var finished = await Task.WhenAny(
-            probe,
-            Task.Delay(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken));
+        // The probe's own timeout would turn a slow drain on a loaded machine into a null result,
+        // which looks exactly like the deadlock (flaked locally at 15 s). The 30 s guard below is
+        // the deadlock detector here, so keep the product timeout out of its way.
+        var savedTimeout = CrispAsrTtsProvenance.HelpProbeTimeoutMs;
+        CrispAsrTtsProvenance.HelpProbeTimeoutMs = 120_000;
+        try
+        {
+            var probe = Task.Run(() => CrispAsrTtsProvenance.HelpTextProvider(stub.Path));
+            var finished = await Task.WhenAny(
+                probe,
+                Task.Delay(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken));
 
-        Assert.True(ReferenceEquals(finished, probe), "the --help probe deadlocked");
-        Assert.Equal(payloadBytes, (await probe)?.Length);
+            Assert.True(ReferenceEquals(finished, probe), "the --help probe deadlocked");
+            Assert.Equal(payloadBytes, (await probe)?.Length);
+        }
+        finally
+        {
+            CrispAsrTtsProvenance.HelpProbeTimeoutMs = savedTimeout;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

`CrispAsrTtsProvenanceTests.RealHelpProbe_WithLargeStderrAndEmptyStdout_DoesNotDeadlock` runs the real `--help` probe against a shell stub that floods stderr with 1 MB. On a loaded machine the pipe drain can stall past the probe's own 15 s timeout, and the probe then returns `null`, which the test cannot tell apart from the deadlock it exists to catch. It failed at exactly 15 s in two local full-suite runs today (`Expected: 1048576, Actual: null`).

The test's own 30 s guard is the deadlock detector, so the product timeout is now an internal settable property that the test lifts for its duration and restores afterwards. The payload also drops from 1 MB to 256 KB, still far past any platform's pipe buffer (4 KB Windows, 64 KB Unix), which is what actually reproduces the deadlock.

## Test plan

- [x] Three full local UITests runs after the change: 4666 passed, 0 failed.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)