### PR TITLE
Compare: line the grids up after the mirrored selection's own scroll, not before

### DIFF
--- a/src/ui/Features/Files/Compare/CompareViewModel.cs
+++ b/src/ui/Features/Files/Compare/CompareViewModel.cs
@@ -989,13 +989,19 @@ public partial class CompareViewModel : ObservableObject
                 {
                     target.SelectedIndex = idx;
                 }
-
-                ScrollSync?.SyncFrom(source);
             }
             finally
             {
                 _mirroringSelection = false;
             }
+
+            // Setting SelectedIndex makes the target grid *post* its own ScrollIntoView
+            // (SelectingItemsControl.AutoScrollToSelectedItemIfNecessary), and that scroll is
+            // computed from the panel's estimated row height, so a sync done here would be
+            // undone a frame later - the two sides ended one row apart on CI whenever the
+            // estimate put the selected row on the viewport's bottom edge. Queue the sync
+            // behind that scroll instead: same priority, so it runs after it.
+            Dispatcher.UIThread.Post(() => ScrollSync?.SyncFrom(source));
         });
     }
 


### PR DESCRIPTION
## Summary

`CompareScrollSyncTests.SelectingARowFarDown_LinesUpBothViews` fired the CI retry in 8 of the 12 runs after this afternoon's flake fixes landed, and failed both attempts on several (for example #14452 and #14461). It never reproduces on macOS.

**Cause.** A diagnostics branch that dumps the row geometry (run three times through `workflow_dispatch`) showed, on the failing run: left grid row 141 at -12 px, right grid row 141 at +4 px, and the right offset was exactly `151 × 37 − 374`, the position `ScrollIntoView(150)` computes from the panel's *estimated* row height. `MirrorSelection` sets the other grid's `SelectedIndex` and syncs the scroll positions in the same dispatcher job, but Avalonia 12's `SelectingItemsControl.AutoScrollToSelectedItemIfNecessary` **posts** its scroll-into-view, so it ran a frame after the sync and undid it. The reverse sync then anchored on a 4 px sliver of row 140, and with 21 px rows on one side and 37 px rows on the other the "top row" differed by one. The geometry needs the Linux font metrics, hence CI only.

**Fix.** Queue the sync behind that posted scroll at the same priority, so it always runs last and the source grid's top row wins. No test change: the test was asserting the right thing.

## Test plan

- [x] Four `workflow_dispatch` runs of the full Tests workflow on this branch: 0 scroll-sync failures (one run retried once on an unrelated grid-centering test and passed).
- [x] All Compare tests pass locally.
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)