### PR TITLE
Blu-ray sup export: show overlapping subtitles together

### DIFF
--- a/docs/features/file.md
+++ b/docs/features/file.md
@@ -181,6 +181,8 @@ Anything else is removed before rendering.
 
 **Fading (Blu-ray SUP).** A subtitle with `{\fad(400,400)}` is written the way a Blu-ray disc does it: the image is encoded once and the fade follows as palette updates, one per video frame, which cost about a kilobyte each instead of a whole new image. Long fades are sampled coarser so a single subtitle never adds more than 60 of them. The other image formats have no way to animate a subtitle and ignore the tag - the image is written fully opaque.
 
+**Overlapping subtitles (Blu-ray SUP).** Subtitles that are on screen at the same time - a line at the bottom and a `{\an8}` line at the top, say - are shown together. A Blu-ray display set can compose two images in two windows, so the export cuts the timeline wherever a subtitle starts or ends and writes one display set per slice with everything on screen in it. Subtitles that would be drawn over each other, and a third one at the same time, are drawn into one image, the later one on top - the same as the preview shows. A fade on one of the lines still fades that line only.
+
 <!-- Screenshot: Export image-based window -->
 ![Export Image Based](../screenshots/export-image-based.png)
 

--- a/src/libse/BluRaySup/BluRaySupCompositionObject.cs
+++ b/src/libse/BluRaySup/BluRaySupCompositionObject.cs
@@ -1,0 +1,39 @@
+using SkiaSharp;
+using System.Collections.Generic;
+
+namespace Nikse.SubtitleEdit.Core.BluRaySup
+{
+    /// <summary>
+    /// One caption of a Blu-ray display set. A display set composes up to
+    /// <see cref="BluRaySupPicture.MaxCompositionObjects"/> of these, each in a window of its
+    /// own, which is how a Blu-ray shows two subtitles at the same time - a line at the bottom
+    /// of the frame and one at the top, say. The windows may not overlap each other.
+    /// </summary>
+    public class BluRaySupCompositionObject
+    {
+        public SKBitmap Bitmap { get; set; }
+
+        /// <summary>
+        /// First entry of the object's palette range, see <see cref="BluRaySupPicture.CreateSupFrame(BluRaySupPicture, IList{BluRaySupCompositionObject}, double, bool)"/>.
+        /// </summary>
+        public SKColor FontColor { get; set; }
+
+        /// <summary>
+        /// Left edge of the bitmap in the frame.
+        /// </summary>
+        public int X { get; set; }
+
+        /// <summary>
+        /// Top edge of the bitmap in the frame.
+        /// </summary>
+        public int Y { get; set; }
+
+        public bool IsForced { get; set; }
+
+        /// <summary>
+        /// Alpha levels of this object's fade, in the time base of
+        /// <see cref="BluRaySupPicture.StartTime"/>. Objects fade independently of each other.
+        /// </summary>
+        public List<BluRaySupFadeStep> FadeSteps { get; set; } = new List<BluRaySupFadeStep>();
+    }
+}

--- a/src/libse/BluRaySup/BluRaySupEncodedBitmap.cs
+++ b/src/libse/BluRaySup/BluRaySupEncodedBitmap.cs
@@ -1,0 +1,135 @@
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+
+namespace Nikse.SubtitleEdit.Core.BluRaySup
+{
+    /// <summary>
+    /// A caption the way it goes into the stream: its palette and its run length encoded
+    /// pixels. A few kilobytes for a line of text, against the hundreds the bitmap took - so
+    /// it can be kept after the bitmap is gone, and <see cref="ToBitmap"/> brings the pixels
+    /// back exactly (the palette holds the RGBA colours, not the YCbCr the stream carries).
+    /// </summary>
+    public class BluRaySupEncodedBitmap
+    {
+        /// <summary>
+        /// The colours the RLE indexes, ending with a transparent entry. Index 255 is never in
+        /// here - it is the transparent pixel.
+        /// </summary>
+        public List<SKColor> Palette { get; }
+
+        public byte[] Rle { get; }
+        public int Width { get; }
+        public int Height { get; }
+
+        public BluRaySupEncodedBitmap(List<SKColor> palette, byte[] rle, int width, int height)
+        {
+            Palette = palette;
+            Rle = rle;
+            Width = width;
+            Height = height;
+        }
+
+        /// <summary>
+        /// Decodes the pixels into a new bitmap the caller owns.
+        /// </summary>
+        public SKBitmap ToBitmap()
+        {
+            var bitmap = new SKBitmap(new SKImageInfo(Math.Max(1, Width), Math.Max(1, Height), SKColorType.Bgra8888, SKAlphaType.Unpremul));
+            var pixels = bitmap.GetPixels();
+            if (pixels == IntPtr.Zero || Width <= 0 || Height <= 0)
+            {
+                return bitmap;
+            }
+
+            unsafe
+            {
+                var span = new Span<byte>(pixels.ToPointer(), bitmap.ByteCount);
+                span.Clear();
+                var rowBytes = bitmap.RowBytes;
+                var x = 0;
+                var y = 0;
+                var rle = Rle;
+                for (var i = 0; i < rle.Length && y < Height;)
+                {
+                    var b = rle[i++];
+                    int index;
+                    int count;
+                    if (b != 0)
+                    {
+                        // a single pixel of colour b
+                        index = b;
+                        count = 1;
+                    }
+                    else
+                    {
+                        if (i >= rle.Length)
+                        {
+                            break;
+                        }
+
+                        b = rle[i++];
+                        if (b == 0)
+                        {
+                            // end of line
+                            x = 0;
+                            y++;
+                            continue;
+                        }
+
+                        switch (b & 0xC0)
+                        {
+                            case 0x00:
+                                // 00 xx -> xx pixels of colour 0
+                                index = 0;
+                                count = b;
+                                break;
+                            case 0x40:
+                                // 00 4x xx -> xxx pixels of colour 0
+                                if (i >= rle.Length)
+                                {
+                                    return bitmap;
+                                }
+
+                                index = 0;
+                                count = ((b & 0x3f) << 8) | rle[i++];
+                                break;
+                            case 0x80:
+                                // 00 8x cc -> x pixels of colour cc
+                                if (i >= rle.Length)
+                                {
+                                    return bitmap;
+                                }
+
+                                count = b & 0x3f;
+                                index = rle[i++];
+                                break;
+                            default:
+                                // 00 cx xx cc -> xxx pixels of colour cc
+                                if (i + 1 >= rle.Length)
+                                {
+                                    return bitmap;
+                                }
+
+                                count = ((b & 0x3f) << 8) | rle[i++];
+                                index = rle[i++];
+                                break;
+                        }
+                    }
+
+                    var color = index < Palette.Count ? Palette[index] : SKColors.Transparent;
+                    for (var n = 0; n < count && x < Width; n++, x++)
+                    {
+                        var offset = y * rowBytes + x * 4;
+                        span[offset] = color.Blue;
+                        span[offset + 1] = color.Green;
+                        span[offset + 2] = color.Red;
+                        span[offset + 3] = color.Alpha;
+                    }
+                }
+            }
+
+            return bitmap;
+        }
+    }
+}

--- a/src/libse/BluRaySup/BluRaySupPicture.cs
+++ b/src/libse/BluRaySup/BluRaySupPicture.cs
@@ -40,6 +40,27 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
     public class BluRaySupPicture
     {
         /// <summary>
+        /// Composition objects one display set can show at the same time - the PCS has room for
+        /// two, each in a window of its own.
+        /// </summary>
+        public const int MaxCompositionObjects = 2;
+
+        /// <summary>
+        /// Palette entries a display set can define. Index 255 is never defined: a decoder keeps
+        /// an undefined entry fully transparent, and that is the index transparent pixels are
+        /// encoded with (<see cref="TransparentIndex"/>).
+        /// </summary>
+        public const int MaxPaletteEntries = 255;
+
+        /// <summary>
+        /// Colours <see cref="GetBitmapPalette"/> collects for one bitmap, before the transparent
+        /// entry it always adds at the end.
+        /// </summary>
+        private const int MaxPaletteColors = 254;
+
+        private const byte TransparentIndex = 0xff;
+
+        /// <summary>
         /// screen width
         /// </summary>
         public int Width { get; set; }
@@ -72,6 +93,19 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
         /// composition number - increased at start and end PCS
         /// </summary>
         public int CompositionNumber { get; set; }
+
+        /// <summary>
+        /// Set by <see cref="CreateSupFrame(BluRaySupPicture, IList{BluRaySupCompositionObject}, double, bool)"/>:
+        /// the composition number the display set following the ones it wrote should use.
+        /// </summary>
+        public int NextCompositionNumber { get; set; }
+
+        /// <summary>
+        /// The caption as it went into the stream, set by
+        /// <see cref="CreateSupFrame(BluRaySupPicture, SKBitmap, SKColor, double, int, int, BluRayContentAlignment, BluRayPoint)"/>.
+        /// A caller that lets the bitmap go can still compose the caption with others from this.
+        /// </summary>
+        public BluRaySupEncodedBitmap EncodedBitmap { get; set; }
 
         /// <summary>
         /// width of subtitle window (might be larger than image)
@@ -115,8 +149,9 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
         /// </summary>
         /// <param name="bm">Bitmap to compress</param>
         /// <param name="palette">Palette used for bitmap encoding</param>
+        /// <param name="indexOffset">Where <paramref name="palette"/> starts in the palette the display set defines - the RLE references that one, so every index is shifted by this</param>
         /// <returns>RLE buffer</returns>
-        private static byte[] EncodeImage(SKBitmap bm, List<SKColor> palette)
+        private static byte[] EncodeImage(SKBitmap bm, List<SKColor> palette, int indexOffset)
         {
             var lookup = new Dictionary<SKColor, int>();
             for (var i = 0; i < palette.Count; i++)
@@ -133,7 +168,9 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
             // ones - past the cap the linear scan simply runs again, as it always did.
             const int maxCachedColors = 1 << 16;
 
-            var transparentColor = (byte)palette[palette.Count - 1];
+            // Transparent pixels use the one index no palette defines, whatever range of the
+            // palette this bitmap has.
+            const byte transparentColor = TransparentIndex;
             var bytes = new List<byte>(bm.Width * 2);
             var reader = new BitmapRowReader(bm);
             var row = new SKColor[bm.Width];
@@ -153,7 +190,7 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
                     }
                     else if (lookup.TryGetValue(c, out var intC))
                     {
-                        color = (byte)intC;
+                        color = (byte)(intC + indexOffset);
                     }
                     else
                     {
@@ -161,11 +198,13 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
                         // the palette does not change while encoding, so the answer for a color
                         // is fixed. Anti-aliased edges hit this for the same handful of colors
                         // on every row of the caption; remember them in the same lookup.
-                        color = FindBestMatch(c, palette);
+                        var best = FindBestMatch(c, palette);
                         if (lookup.Count < maxCachedColors)
                         {
-                            lookup[c] = color;
+                            lookup[c] = best;
                         }
+
+                        color = (byte)(best + indexOffset);
                     }
 
                     for (len = 1; x + len < bm.Width; len++)
@@ -327,7 +366,12 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
             return false;
         }
 
-        private static List<SKColor> GetBitmapPalette(SKBitmap bitmap, SKColor fontColor)
+        /// <summary>
+        /// The colours of the bitmap, <paramref name="fontColor"/> first and a transparent entry
+        /// last, at most <paramref name="maxColors"/> of them before the transparent one. A
+        /// bitmap with more distinct colours than that is reduced by merging close ones.
+        /// </summary>
+        private static List<SKColor> GetBitmapPalette(SKBitmap bitmap, SKColor fontColor, int maxColors)
         {
             var pal = new List<SKColor>(255);
             var lookup = new HashSet<SKColor>(255);
@@ -357,19 +401,19 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
                             lookup.Add(c);
                         }
 
-                        if (pal.Count >= 254)
+                        if (pal.Count >= maxColors)
                         {
                             break;
                         }
                     }
                 }
-                if (pal.Count >= 254)
+                if (pal.Count >= maxColors)
                 {
                     break;
                 }
             }
 
-            if (pal.Count < 254)
+            if (pal.Count < maxColors)
             {
                 pal.Add(SKColors.Transparent); // last entry must be transparent
                 return pal;
@@ -377,6 +421,10 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
 
 
             // get close colors (image has probably been processed in SE)
+            // The tolerance widens as the palette fills: 1 for the first part, 5 for the next,
+            // 25 for the rest.
+            var exactLimit = maxColors * 100 / MaxPaletteColors;
+            var closeLimit = maxColors * 240 / MaxPaletteColors;
             pal = new List<SKColor>();
             lookup = new HashSet<SKColor>();
             pal.Add(fontColor);
@@ -406,7 +454,7 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
                         {
                             // a close enough color already exists
                         }
-                        else if (pal.Count < 100)
+                        else if (pal.Count < exactLimit)
                         {
                             if (!HasCloseColor(c, pal, 1))
                             {
@@ -418,7 +466,7 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
                                 rejected.Add(c);
                             }
                         }
-                        else if (pal.Count < 240)
+                        else if (pal.Count < closeLimit)
                         {
                             if (!HasCloseColor(c, pal, 5))
                             {
@@ -430,7 +478,7 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
                                 rejected.Add(c);
                             }
                         }
-                        else if (pal.Count < 254)
+                        else if (pal.Count < maxColors)
                         {
                             if (!HasCloseColor(c, pal, 25))
                             {
@@ -445,9 +493,9 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
                     }
                 }
 
-                // Every branch above requires pal.Count < 254, so a full palette freezes the
+                // Every branch above requires pal.Count < maxColors, so a full palette freezes the
                 // result - the rest of the image only cost scans that could not change it.
-                if (pal.Count >= 254)
+                if (pal.Count >= maxColors)
                 {
                     break;
                 }
@@ -499,22 +547,41 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
 
         private static long _lastEndTimeForWrite = -1000;
 
+        // PG segment types
+        private const byte PdsSegment = 0x14;
+        private const byte OdsSegment = 0x15;
+        private const byte PcsSegment = 0x16;
+        private const byte WdsSegment = 0x17;
+        private const byte EndSegment = 0x80;
+
+        // composition_state of a PCS
+        private const byte CompositionStateNormal = 0x00;
+        private const byte CompositionStateEpochStart = 0x80;
+
+        // For some obscure reason, a packet can be a maximum 0xfffc bytes. Since 13 bytes are
+        // needed for the header ("PG", PTS, DTS, ID, SIZE) there are only 0xffef bytes available
+        // for the packet; the first ODS packet needs an additional 11 bytes for info and the
+        // following ODS packets 4 additional bytes, so the first package can store only 0xffe4
+        // RLE buffer bytes and the following packets 0xffeb RLE buffer bytes.
+        private const int FirstOdsPayload = 0xffe4;
+        private const int NextOdsPayload = 0xffeb;
+
         /// <summary>
-        /// Splits <see cref="FadeSteps"/> into the alpha the caption appears with (part of the
-        /// epoch's own palette) and the steps that follow it as palette update display sets.
-        /// Steps outside the caption, and steps that do not change the alpha, are dropped - each
-        /// one would cost a display set for nothing.
+        /// Splits fade steps into the alpha the object appears with (part of the epoch's own
+        /// palette) and the steps that follow it as palette update display sets. Steps outside
+        /// the display set, and steps that do not change the alpha, are dropped - each one would
+        /// cost a display set for nothing.
         /// </summary>
-        private static List<BluRaySupFadeStep> GetFadeSteps(BluRaySupPicture pic, out int startAlphaPercent)
+        private static List<BluRaySupFadeStep> GetFadeSteps(IList<BluRaySupFadeStep> fadeSteps, long startTime, long endTime, out int startAlphaPercent)
         {
             startAlphaPercent = 100;
             var updates = new List<BluRaySupFadeStep>();
-            if (pic.FadeSteps == null || pic.FadeSteps.Count == 0)
+            if (fadeSteps == null || fadeSteps.Count == 0)
             {
                 return updates;
             }
 
-            var sorted = new List<BluRaySupFadeStep>(pic.FadeSteps);
+            var sorted = new List<BluRaySupFadeStep>(fadeSteps);
             sorted.Sort((a, b) => a.TimeMs.CompareTo(b.TimeMs));
 
             var lastAlpha = 100;
@@ -522,14 +589,14 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
             foreach (var step in sorted)
             {
                 var alpha = Math.Min(100, Math.Max(0, step.AlphaPercent));
-                if (step.TimeMs <= pic.StartTime)
+                if (step.TimeMs <= startTime)
                 {
                     startAlphaPercent = alpha;
                     lastAlpha = alpha;
                     continue;
                 }
 
-                if (step.TimeMs >= pic.EndTime || alpha == lastAlpha || step.TimeMs == lastTime)
+                if (step.TimeMs >= endTime || alpha == lastAlpha || step.TimeMs == lastTime)
                 {
                     continue;
                 }
@@ -543,32 +610,323 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
         }
 
         /// <summary>
-        /// Writes a Palette Definition Segment with every alpha scaled by
-        /// <paramref name="alphaPercent"/> - the whole of a Blu-ray fade is this one number
-        /// changing between display sets.
+        /// One composition object of a display set, encoded against its own range of the shared
+        /// palette.
         /// </summary>
-        private static int WritePds(byte[] buf, int index, byte[] packetHeader, BluRaySupPalette pal, int palSize, int paletteVersion, int alphaPercent)
+        private sealed class EncodedObject
         {
-            packetHeader[10] = 0x14;                                      // ID (keep PTS & DTS)
-            ToolBox.SetWord(packetHeader, 11, 2 + palSize * 5);      // size
-            for (var i = 0; i < packetHeader.Length; i++)
+            /// <summary>
+            /// The object's colours, ending with the transparent entry
+            /// <see cref="GetBitmapPalette"/> always adds.
+            /// </summary>
+            public List<SKColor> Palette;
+
+            /// <summary>
+            /// Index of the first of those colours in the shared palette.
+            /// </summary>
+            public int PaletteOffset;
+
+            public byte[] Rle;
+            public int Width;
+            public int Height;
+            public int X;
+            public int Y;
+            public bool IsForced;
+            public int StartAlphaPercent;
+            public List<BluRaySupFadeStep> Updates;
+        }
+
+        /// <summary>
+        /// The alpha of every composition object at one palette update display set.
+        /// </summary>
+        private sealed class PaletteUpdate
+        {
+            public long TimeMs;
+            public int[] AlphaPercents;
+
+            public long TimeForWrite => (long)Math.Round(TimeMs * 90.0, MidpointRounding.AwayFromZero);
+        }
+
+        /// <summary>
+        /// Interleaves the fade steps of all objects into one schedule. A palette update carries
+        /// the whole palette, so at every step time the alpha of every object is needed - the
+        /// ones without a step of their own keep the alpha they had.
+        /// </summary>
+        private static List<PaletteUpdate> MergeFadeSteps(IList<EncodedObject> objects)
+        {
+            var times = new SortedSet<long>();
+            foreach (var obj in objects)
             {
-                buf[index++] = packetHeader[i];
+                foreach (var step in obj.Updates)
+                {
+                    times.Add(step.TimeMs);
+                }
             }
 
-            buf[index++] = 0;                                             // palette_id
-            buf[index++] = (byte)paletteVersion;                          // palette_version_number
+            var current = new int[objects.Count];
+            for (var k = 0; k < objects.Count; k++)
+            {
+                current[k] = objects[k].StartAlphaPercent;
+            }
+
+            var updates = new List<PaletteUpdate>(times.Count);
+            foreach (var time in times)
+            {
+                for (var k = 0; k < objects.Count; k++)
+                {
+                    foreach (var step in objects[k].Updates)
+                    {
+                        if (step.TimeMs == time)
+                        {
+                            current[k] = step.AlphaPercent;
+                        }
+                    }
+                }
+
+                updates.Add(new PaletteUpdate { TimeMs = time, AlphaPercents = (int[])current.Clone() });
+            }
+
+            return updates;
+        }
+
+        private static int ClampY(BluRaySupPicture pic, int y)
+        {
+            var yOfs = y - Core.CropOfsY;
+            if (yOfs < 0)
+            {
+                return 0;
+            }
+
+            var yMax = pic.Height - pic.WindowHeight - 2 * Core.CropOfsY;
+            return yOfs > yMax ? yMax : yOfs;
+        }
+
+        /// <summary>
+        /// Builds the palettes and RLE data of the objects. Every object of a display set reads
+        /// from the one palette the PCS names, so each gets a range of it: the palettes are laid
+        /// end to end and the RLE of an object references its own range. That also keeps the
+        /// fades apart - a palette update scales the entries of one object and leaves the
+        /// others alone.
+        /// </summary>
+        private static List<EncodedObject> EncodeObjects(BluRaySupPicture pic, IList<BluRaySupCompositionObject> objects)
+        {
+            var palettes = new List<List<SKColor>>(objects.Count);
+            var total = 0;
+            foreach (var obj in objects)
+            {
+                var palette = GetBitmapPalette(obj.Bitmap, obj.FontColor, MaxPaletteColors);
+                palettes.Add(palette);
+                total += palette.Count;
+            }
+
+            if (total > MaxPaletteEntries)
+            {
+                // Together they do not fit; give every object an equal share instead.
+                var maxColors = MaxPaletteEntries / objects.Count - 1;
+                for (var k = 0; k < objects.Count; k++)
+                {
+                    palettes[k] = GetBitmapPalette(objects[k].Bitmap, objects[k].FontColor, maxColors);
+                }
+            }
+
+            var encoded = new List<EncodedObject>(objects.Count);
+            var offset = 0;
+            for (var k = 0; k < objects.Count; k++)
+            {
+                var obj = objects[k];
+                var updates = GetFadeSteps(obj.FadeSteps, pic.StartTime, pic.EndTime, out var startAlphaPercent);
+                encoded.Add(new EncodedObject
+                {
+                    Palette = palettes[k],
+                    PaletteOffset = offset,
+                    Rle = EncodeImage(obj.Bitmap, palettes[k], offset),
+                    Width = obj.Bitmap.Width,
+                    Height = obj.Bitmap.Height,
+                    X = obj.X,
+                    Y = ClampY(pic, obj.Y),
+                    IsForced = obj.IsForced,
+                    StartAlphaPercent = startAlphaPercent,
+                    Updates = updates,
+                });
+                offset += palettes[k].Count;
+            }
+
+            return encoded;
+        }
+
+        /// <summary>
+        /// Presentation Composition Segment: the frame, the composition number and state, and
+        /// which objects are shown where. A PCS with no objects clears the screen.
+        /// </summary>
+        private static byte[] BuildPcs(int width, int height, int fpsId, int compositionNumber, byte compositionState, bool paletteUpdate, IList<EncodedObject> objects)
+        {
+            var buf = new byte[11 + objects.Count * 8];
+            ToolBox.SetWord(buf, 0, width);                                 // video_width
+            ToolBox.SetWord(buf, 2, height);                                // video_height (cropped)
+            ToolBox.SetByte(buf, 4, fpsId);                                 // hi nibble: frame_rate, lo nibble: reserved
+            ToolBox.SetWord(buf, 5, compositionNumber);                     // composition_number
+            buf[7] = compositionState;                                      // 0x80: epoch start, 0x40: acquisition point, 0x00: normal
+            buf[8] = (byte)(paletteUpdate ? 0x80 : 0x00);                   // palette_update_flag, 7 bit reserved
+            buf[9] = 0;                                                     // palette_id_ref (0..7)
+            buf[10] = (byte)objects.Count;                                  // number_of_composition_objects (0..2)
+            for (var k = 0; k < objects.Count; k++)
+            {
+                var obj = objects[k];
+                var i = 11 + k * 8;
+                ToolBox.SetWord(buf, i, k);                                 // object_id_ref
+                buf[i + 2] = (byte)k;                                       // window_id_ref (0..1)
+                buf[i + 3] = (byte)(obj.IsForced ? 0x40 : 0x00);            // object_cropped_flag: 0x80, forced_on_flag: 0x40, 6 bit reserved
+                ToolBox.SetWord(buf, i + 4, obj.X);                         // composition_object_horizontal_position
+                ToolBox.SetWord(buf, i + 6, obj.Y);                         // composition_object_vertical_position
+            }
+
+            return buf;
+        }
+
+        /// <summary>
+        /// Window Definition Segment: one window per object, sized to it.
+        /// </summary>
+        private static byte[] BuildWds(IList<EncodedObject> objects)
+        {
+            var buf = new byte[1 + objects.Count * 9];
+            buf[0] = (byte)objects.Count;                                   // number_of_windows (0..2)
+            for (var k = 0; k < objects.Count; k++)
+            {
+                var obj = objects[k];
+                var i = 1 + k * 9;
+                buf[i] = (byte)k;                                           // window_id
+                ToolBox.SetWord(buf, i + 1, obj.X);                         // window_horizontal_position
+                ToolBox.SetWord(buf, i + 3, obj.Y);                         // window_vertical_position
+                ToolBox.SetWord(buf, i + 5, obj.Width);                     // window_width
+                ToolBox.SetWord(buf, i + 7, obj.Height);                    // window_height
+            }
+
+            return buf;
+        }
+
+        /// <summary>
+        /// Palette Definition Segment with the alpha of every entry scaled by the percentage of
+        /// the object the entry belongs to - the whole of a Blu-ray fade is these numbers
+        /// changing between display sets.
+        /// </summary>
+        private static byte[] BuildPds(BluRaySupPalette pal, int palSize, int paletteVersion, IList<EncodedObject> objects, int[] alphaPercents)
+        {
+            var entryAlphaPercent = new int[palSize];
+            for (var k = 0; k < objects.Count; k++)
+            {
+                var obj = objects[k];
+                for (var i = 0; i < obj.Palette.Count; i++)
+                {
+                    entryAlphaPercent[obj.PaletteOffset + i] = alphaPercents[k];
+                }
+            }
+
+            var buf = new byte[2 + palSize * 5];
+            var index = 0;
+            buf[index++] = 0;                                               // palette_id
+            buf[index++] = (byte)paletteVersion;                            // palette_version_number
             var alpha = pal.GetAlpha();
             for (var i = 0; i < palSize; i++)
             {
-                buf[index++] = (byte)i;                                   // index
-                buf[index++] = pal.GetY()[i];                             // Y
-                buf[index++] = pal.GetCr()[i];                            // Cr
-                buf[index++] = pal.GetCb()[i];                            // Cb
-                buf[index++] = (byte)(alpha[i] * alphaPercent / 100);     // Alpha
+                buf[index++] = (byte)i;                                     // palette_entry_id
+                buf[index++] = pal.GetY()[i];                               // Y
+                buf[index++] = pal.GetCr()[i];                              // Cr
+                buf[index++] = pal.GetCb()[i];                              // Cb
+                buf[index++] = (byte)(alpha[i] * entryAlphaPercent[i] / 100); // T (alpha)
             }
 
-            return index;
+            return buf;
+        }
+
+        /// <summary>
+        /// Object Definition Segments of one object: the RLE data, split over as many segments
+        /// as the 16 bit segment length requires. Only the final fragment carries
+        /// last_in_sequence.
+        /// </summary>
+        private static void WriteOds(SegmentWriter writer, long pts, int objectId, EncodedObject obj)
+        {
+            var rle = obj.Rle;
+            var numAddPackets = 0;
+            if (rle.Length > FirstOdsPayload)
+            {
+                // round up, but without an extra empty packet when the rest divides evenly
+                numAddPackets = (rle.Length - FirstOdsPayload + NextOdsPayload - 1) / NextOdsPayload;
+            }
+
+            var first = new byte[11];
+            ToolBox.SetWord(first, 0, objectId);                            // object_id
+            first[2] = 0;                                                   // object_version_number
+            var marker = numAddPackets == 0 ? 0xC0000000 : 0x80000000;      // first_in_sequence (0x80), last_in_sequence (0x40)
+            ToolBox.SetDWord(first, 3, (uint)(marker | (uint)(rle.Length + 4))); // flags + object_data_length (RLE plus its 4 byte size info)
+            ToolBox.SetWord(first, 7, obj.Width);                           // object_width
+            ToolBox.SetWord(first, 9, obj.Height);                          // object_height
+
+            var bufSize = Math.Min(rle.Length, FirstOdsPayload);
+            writer.Write(OdsSegment, pts, first, rle, 0, bufSize);
+
+            var rleIndex = bufSize;
+            var remaining = rle.Length - bufSize;
+            for (var p = 0; p < numAddPackets; p++)
+            {
+                var packetSize = Math.Min(remaining, NextOdsPayload);
+                var next = new byte[4];
+                ToolBox.SetWord(next, 0, objectId);                         // object_id
+                next[2] = 0;                                                // object_version_number
+                next[3] = (byte)(p == numAddPackets - 1 ? 0x40 : 0x00);     // last_in_sequence on the final fragment only
+                writer.Write(OdsSegment, pts, next, rle, rleIndex, packetSize);
+                rleIndex += packetSize;
+                remaining -= packetSize;
+            }
+        }
+
+        /// <summary>
+        /// Writes PG segments: "PG", PTS, DTS, type and size, then the payload.
+        /// <para>
+        /// Timestamps: every segment of a display set carries the display set's presentation
+        /// time as PTS, and DTS is left at 0 ("unset"). This mirrors how .sup files extracted
+        /// from retail discs look, and is what the common consumers expect: ffmpeg's sup demuxer
+        /// explicitly treats DTS 0 as unset, SupMover shifts the PTS of every segment (so they
+        /// must all carry the real presentation time), and muxers like tsMuxeR re-derive decode
+        /// timing from the PCS when authoring an m2ts. The previous writer put decode-model
+        /// values into DTS and zeroed the ODS/END PTS, producing segments with DTS > PTS
+        /// (issue #10219).
+        /// </para>
+        /// </summary>
+        private sealed class SegmentWriter
+        {
+            private readonly System.IO.MemoryStream _stream = new System.IO.MemoryStream();
+            private readonly byte[] _header =
+            {
+                0x50, 0x47,             // 0:  "PG"
+                0x00, 0x00, 0x00, 0x00, // 2:  PTS - presentation time stamp
+                0x00, 0x00, 0x00, 0x00, // 6:  DTS - decoding time stamp
+                0x00,                   // 10: segment_type
+                0x00, 0x00              // 11: segment_length (bytes following till next PG)
+            };
+
+            public void Write(byte type, long pts, byte[] payload)
+            {
+                Write(type, pts, payload, null, 0, 0);
+            }
+
+            public void Write(byte type, long pts, byte[] payload, byte[] data, int dataOffset, int dataLength)
+            {
+                ToolBox.SetDWord(_header, 2, (uint)pts);
+                ToolBox.SetDWord(_header, 6, 0);
+                _header[10] = type;
+                ToolBox.SetWord(_header, 11, payload.Length + dataLength);
+                _stream.Write(_header, 0, _header.Length);
+                _stream.Write(payload, 0, payload.Length);
+                if (data != null)
+                {
+                    _stream.Write(data, dataOffset, dataLength);
+                }
+            }
+
+            public byte[] ToArray()
+            {
+                return _stream.ToArray();
+            }
         }
 
         /// <summary>
@@ -585,131 +943,30 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
         /// <returns>Byte buffer containing the binary stream representation of one caption</returns>
         public static byte[] CreateSupFrame(BluRaySupPicture pic, SKBitmap bmp, SKColor fontColor, double fps, int bottomMargin, int leftOrRightMargin, BluRayContentAlignment alignment, BluRayPoint overridePosition = null)
         {
-            var bm = bmp.Copy();
-            var colorPalette = GetBitmapPalette(bm, fontColor);
-            var pal = new BluRaySupPalette(colorPalette.Count);
-            for (var i = 0; i < colorPalette.Count; i++)
-            {
-                pal.SetColor(i, colorPalette[i]);
-            }
-
-            var rleBuf = EncodeImage(bm, colorPalette);
-
-            // for some obscure reason, a packet can be a maximum 0xfffc bytes
-            // since 13 bytes are needed for the header("PG", PTS, DTS, ID, SIZE)
-            // there are only 0xffef bytes available for the packet
-            // since the first ODS packet needs an additional 11 bytes for info
-            // and the following ODS packets need 4 additional bytes, the
-            // first package can store only 0xffe4 RLE buffer bytes and the
-            // following packets can store 0xffeb RLE buffer bytes
-            int numAddPackets;
-            if (rleBuf.Length <= 0xffe4)
-            {
-                numAddPackets = 0; // no additional packets needed
-            }
-            else
-            {
-                // round up, but without an extra empty packet when the rest divides evenly
-                numAddPackets = (rleBuf.Length - 0xffe4 + 0xffeb - 1) / 0xffeb;
-            }
-
-            // a typical frame consists of 8 packets. It can be elongated by additional object frames
-            var palSize = colorPalette.Count;
-
-            var packetHeader = new byte[]
-            {
-                0x50, 0x47,             // 0:  "PG"
-                0x00, 0x00, 0x00, 0x00, // 2:  PTS - presentation time stamp
-                0x00, 0x00, 0x00, 0x00, // 6:  DTS - decoding time stamp
-                0x00,                   // 10: segment_type
-                0x00, 0x00              // 11: segment_length (bytes following till next PG)
-            };
-            var headerPcsStart = new byte[]
-            {
-                0x00, 0x00, 0x00, 0x00, // 0: video_width, video_height
-                0x10,                   // 4: hi nibble: frame_rate (0x10=24p), lo nibble: reserved
-                0x00, 0x00,             // 5: composition_number (increased by start and end header)
-                0x80,                   // 7: composition_state (0x80: epoch start)
-                                        //      0x00: Normal
-                                        //      0x40: Acquisition Point
-                                        //      0x80: Epoch Start
-                0x00,                   // 8: palette_update_flag (0x80==true, 0x00==false), 7bit reserved
-                0x00,                   // 9: palette_id_ref (0..7)
-                0x01,                   // 10: number_of_composition_objects (0..2)
-                0x00, 0x00,             // 11: 16bit object_id_ref
-                0x00,                   // 13: window_id_ref (0..1)
-                0x00,                   // 14: object_cropped_flag: 0x80, forced_on_flag = 0x040, 6bit reserved
-                0x00, 0x00, 0x00, 0x00  // 15: composition_object_horizontal_position, composition_object_vertical_position
-            };
-            var headerPcsEnd = new byte[]
-            {
-                0x00, 0x00, 0x00, 0x00, // 0: video_width, video_height
-                0x10,                   // 4: hi nibble: frame_rate (0x10=24p), lo nibble: reserved
-                0x00, 0x00,             // 5: composition_number (increased by start and end header)
-                0x00,                   // 7: composition_state (0x00: normal)
-                0x00,                   // 8: palette_update_flag (0x80), 7bit reserved
-                0x00,                   // 9: palette_id_ref (0..7)
-                0x00                    // 10: number_of_composition_objects (0..2)
-            };
-            var headerWds = new byte[]
-            {
-                0x01,                   // 0 : number of windows (currently assumed 1, 0..2 is legal)
-                0x00,                   // 1 : window id (0..1)
-                0x00, 0x00, 0x00, 0x00, // 2 : x-ofs, y-ofs
-                0x00, 0x00, 0x00, 0x00  // 6 : width, height
-            };
-            var headerOdsFirst = new byte[]
-            {
-                0x00, 0x00,             // 0: object_id
-                0x00,                   // 2: object_version_number
-                0xC0,                   // 3: first_in_sequence (0x80), last_in_sequence (0x40), 6bits reserved
-                0x00, 0x00, 0x00,       // 4: object_data_length - full RLE buffer length (including 4 bytes size info)
-                0x00, 0x00, 0x00, 0x00  // 7: object_width, object_height
-            };
-            var headerOdsNext = new byte[]
-            {
-                0x00, 0x00,             // 0: object_id
-                0x00,                   // 2: object_version_number
-                0x00                    // 3: first_in_sequence (0x80), last_in_sequence (0x40), 6bits reserved
-                                        //    set per packet below - only the final one is last_in_sequence
-            };
-
-            // Fade steps ride along as palette update display sets (PCS + PDS + END) between the
-            // caption and the screen clear - same object, only the palette alpha changes.
-            var fadeSteps = GetFadeSteps(pic, out var startAlphaPercent);
-
-            var size = packetHeader.Length * (8 + numAddPackets + fadeSteps.Count * 3);
-            size += headerPcsStart.Length + headerPcsEnd.Length;
-            size += 2 * headerWds.Length + headerOdsFirst.Length;
-            size += numAddPackets * headerOdsNext.Length;
-            size += (2 + palSize * 5) /* PDS */;
-            size += fadeSteps.Count * (headerPcsStart.Length + 2 + palSize * 5);
-            size += rleBuf.Length;
-
             switch (alignment)
             {
                 case BluRayContentAlignment.BottomLeft:
                     pic.WindowXOffset = leftOrRightMargin;
-                    pic.WindowYOffset = pic.Height - (bm.Height + bottomMargin);
+                    pic.WindowYOffset = pic.Height - (bmp.Height + bottomMargin);
                     break;
                 case BluRayContentAlignment.BottomRight:
-                    pic.WindowXOffset = pic.Width - bm.Width - leftOrRightMargin;
-                    pic.WindowYOffset = pic.Height - (bm.Height + bottomMargin);
+                    pic.WindowXOffset = pic.Width - bmp.Width - leftOrRightMargin;
+                    pic.WindowYOffset = pic.Height - (bmp.Height + bottomMargin);
                     break;
                 case BluRayContentAlignment.MiddleCenter:
-                    pic.WindowXOffset = (pic.Width - bm.Width) / 2;
-                    pic.WindowYOffset = (pic.Height - bm.Height) / 2;
+                    pic.WindowXOffset = (pic.Width - bmp.Width) / 2;
+                    pic.WindowYOffset = (pic.Height - bmp.Height) / 2;
                     break;
                 case BluRayContentAlignment.MiddleLeft:
                     pic.WindowXOffset = leftOrRightMargin;
-                    pic.WindowYOffset = (pic.Height - bm.Height) / 2;
+                    pic.WindowYOffset = (pic.Height - bmp.Height) / 2;
                     break;
                 case BluRayContentAlignment.MiddleRight:
-                    pic.WindowXOffset = pic.Width - bm.Width - leftOrRightMargin;
-                    pic.WindowYOffset = (pic.Height - bm.Height) / 2;
+                    pic.WindowXOffset = pic.Width - bmp.Width - leftOrRightMargin;
+                    pic.WindowYOffset = (pic.Height - bmp.Height) / 2;
                     break;
                 case BluRayContentAlignment.TopCenter:
-                    pic.WindowXOffset = (pic.Width - bm.Width) / 2;
+                    pic.WindowXOffset = (pic.Width - bmp.Width) / 2;
                     pic.WindowYOffset = bottomMargin;
                     break;
                 case BluRayContentAlignment.TopLeft:
@@ -717,12 +974,12 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
                     pic.WindowYOffset = bottomMargin;
                     break;
                 case BluRayContentAlignment.TopRight:
-                    pic.WindowXOffset = pic.Width - bm.Width - leftOrRightMargin;
+                    pic.WindowXOffset = pic.Width - bmp.Width - leftOrRightMargin;
                     pic.WindowYOffset = bottomMargin;
                     break;
                 default: // ContentAlignment.BottomCenter:
-                    pic.WindowXOffset = (pic.Width - bm.Width) / 2;
-                    pic.WindowYOffset = pic.Height - (bm.Height + bottomMargin);
+                    pic.WindowXOffset = (pic.Width - bmp.Width) / 2;
+                    pic.WindowYOffset = pic.Height - (bmp.Height + bottomMargin);
                     break;
             }
 
@@ -734,38 +991,72 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
                 pic.WindowYOffset = overridePosition.Y;
             }
 
-            var yOfs = pic.WindowYOffset - Core.CropOfsY;
-            if (yOfs < 0)
+            var obj = new BluRaySupCompositionObject
             {
-                yOfs = 0;
+                Bitmap = bmp,
+                FontColor = fontColor,
+                X = pic.WindowXOffset,
+                Y = pic.WindowYOffset,
+                IsForced = pic.IsForced,
+                FadeSteps = pic.FadeSteps,
+            };
+
+            var buffer = CreateSupFrame(pic, new[] { obj }, fps, true, out var encoded);
+            pic.EncodedBitmap = new BluRaySupEncodedBitmap(encoded[0].Palette, encoded[0].Rle, encoded[0].Width, encoded[0].Height);
+            return buffer;
+        }
+
+        /// <summary>
+        /// Create the binary stream representation of one display set showing
+        /// <paramref name="objects"/> together - up to <see cref="MaxCompositionObjects"/> of
+        /// them, each in a window of its own, sharing one palette. The display set is an epoch
+        /// start at <see cref="StartTime"/>; the fades of the objects follow as palette update
+        /// display sets and, when <paramref name="writeClear"/> is set, a screen clear at
+        /// <see cref="EndTime"/> ends it. Leave <paramref name="writeClear"/> off when another
+        /// epoch starts right at <see cref="EndTime"/> - an epoch start replaces everything on
+        /// screen, so a clear before it would only cost a display set.
+        /// </summary>
+        /// <param name="pic">Frame size, times, forced flag and the composition number of the first display set. <see cref="NextCompositionNumber"/> is set on return.</param>
+        /// <param name="objects">The captions to show, one or two. Their windows may not overlap.</param>
+        /// <param name="fps">Frames per second</param>
+        /// <param name="writeClear">Whether to end with a display set that clears the screen</param>
+        /// <returns>Byte buffer containing the binary stream representation of the display sets</returns>
+        public static byte[] CreateSupFrame(BluRaySupPicture pic, IList<BluRaySupCompositionObject> objects, double fps, bool writeClear = true)
+        {
+            return CreateSupFrame(pic, objects, fps, writeClear, out _);
+        }
+
+        private static byte[] CreateSupFrame(BluRaySupPicture pic, IList<BluRaySupCompositionObject> objects, double fps, bool writeClear, out List<EncodedObject> encoded)
+        {
+            if (objects == null || objects.Count == 0)
+            {
+                throw new ArgumentException("A display set needs at least one composition object", nameof(objects));
             }
-            else
+
+            if (objects.Count > MaxCompositionObjects)
             {
-                var yMax = pic.Height - pic.WindowHeight - 2 * Core.CropOfsY;
-                if (yOfs > yMax)
+                throw new ArgumentException($"A Blu-ray display set can compose at most {MaxCompositionObjects} objects", nameof(objects));
+            }
+
+            encoded = EncodeObjects(pic, objects);
+            var palSize = 0;
+            foreach (var obj in encoded)
+            {
+                palSize += obj.Palette.Count;
+            }
+
+            var pal = new BluRaySupPalette(palSize);
+            foreach (var obj in encoded)
+            {
+                for (var i = 0; i < obj.Palette.Count; i++)
                 {
-                    yOfs = yMax;
+                    pal.SetColor(obj.PaletteOffset + i, obj.Palette[i]);
                 }
             }
 
             var h = pic.Height - 2 * Core.CropOfsY;
-
-            var buf = new byte[size];
-            var index = 0;
-
             var fpsId = GetFpsId(fps);
-
-            // Timestamps: every segment of a display set carries the display set's
-            // presentation time as PTS, and DTS is left at 0 ("unset"). This mirrors how
-            // .sup files extracted from retail discs look, and is what the common consumers
-            // expect: ffmpeg's sup demuxer explicitly treats DTS 0 as unset, SupMover shifts
-            // the PTS of every segment (so they must all carry the real presentation time),
-            // and muxers like tsMuxeR re-derive decode timing from the PCS when authoring
-            // an m2ts. The previous writer put decode-model values into DTS and zeroed the
-            // ODS/END PTS, producing segments with DTS > PTS (issue #10219).
-
-            // write PCS start - Presentation Composition Segment (also called the Control Segment)
-            packetHeader[10] = 0x16; // ID
+            var writer = new SegmentWriter();
 
             var pts = pic.StartTimeForWrite;
             if (Configuration.Settings.Tools.ExportBluRayRemoveSmallGaps && Math.Abs(_lastEndTimeForWrite - pts) < 100)
@@ -774,201 +1065,57 @@ namespace Nikse.SubtitleEdit.Core.BluRaySup
             }
 
             _lastEndTimeForWrite = pic.EndTimeForWrite;
-
-            ToolBox.SetDWord(packetHeader, 2, (uint)pts);                     // PTS
-            ToolBox.SetDWord(packetHeader, 6, 0);                             // DTS (0 = unset)
-            ToolBox.SetWord(packetHeader, 11, headerPcsStart.Length);     // size
-            for (var i = 0; i < packetHeader.Length; i++)
-            {
-                buf[index++] = packetHeader[i];
-            }
-
-            ToolBox.SetWord(headerPcsStart, 0, pic.Width);
-            ToolBox.SetWord(headerPcsStart, 2, h);                      // cropped height
-            ToolBox.SetByte(headerPcsStart, 4, fpsId);
-            ToolBox.SetWord(headerPcsStart, 5, pic.CompositionNumber);
-            headerPcsStart[14] = (byte)(pic.IsForced ? 0x40 : 0);
-            ToolBox.SetWord(headerPcsStart, 15, pic.WindowXOffset);
-            ToolBox.SetWord(headerPcsStart, 17, yOfs);
-            for (var i = 0; i < headerPcsStart.Length; i++)
-            {
-                buf[index++] = headerPcsStart[i];
-            }
-
-            // write WDS
-            packetHeader[10] = 0x17;                                            // ID (keep PTS & DTS)
-            ToolBox.SetWord(packetHeader, 11, headerWds.Length);       // size
-            for (var i = 0; i < packetHeader.Length; i++)
-            {
-                buf[index++] = packetHeader[i];
-            }
-
-            ToolBox.SetWord(headerWds, 2, pic.WindowXOffset);
-            ToolBox.SetWord(headerWds, 4, yOfs);
-            ToolBox.SetWord(headerWds, 6, bm.Width);
-            ToolBox.SetWord(headerWds, 8, bm.Height);
-            for (var i = 0; i < headerWds.Length; i++)
-            {
-                buf[index++] = headerWds[i];
-            }
-
-            // write PDS - Palette Definition Segment
-            index = WritePds(buf, index, packetHeader, pal, palSize, 0, startAlphaPercent);
-
-            // write first OBJ
-            var bufSize = rleBuf.Length;
-            var rleIndex = 0;
-            if (bufSize > 0xffe4)
-            {
-                bufSize = 0xffe4;
-            }
-
-            packetHeader[10] = 0x15;                                                    // ID (keep PTS & DTS)
-            ToolBox.SetWord(packetHeader, 11, headerOdsFirst.Length + bufSize); // size
-            for (var i = 0; i < packetHeader.Length; i++)
-            {
-                buf[index++] = packetHeader[i];
-            }
-
-            var marker = (int)((numAddPackets == 0) ? 0xC0000000 : 0x80000000);
-            ToolBox.SetDWord(headerOdsFirst, 3, (uint)(marker | (rleBuf.Length + 4)));
-            ToolBox.SetWord(headerOdsFirst, 7, bm.Width);
-            ToolBox.SetWord(headerOdsFirst, 9, bm.Height);
-            for (var i = 0; i < headerOdsFirst.Length; i++)
-            {
-                buf[index++] = headerOdsFirst[i];
-            }
-
-            Buffer.BlockCopy(rleBuf, rleIndex, buf, index, bufSize);
-            index += bufSize;
-            rleIndex += bufSize;
-
-            // write additional OBJ packets
-            bufSize = rleBuf.Length - bufSize; // remaining bytes to write
-            for (var p = 0; p < numAddPackets; p++)
-            {
-                var psize = bufSize;
-                if (psize > 0xffeb)
-                {
-                    psize = 0xffeb;
-                }
-
-                packetHeader[10] = 0x15;                                         // ID (keep DTS & PTS)
-                ToolBox.SetWord(packetHeader, 11, headerOdsNext.Length + psize); // size
-                for (var i = 0; i < packetHeader.Length; i++)
-                {
-                    buf[index++] = packetHeader[i];
-                }
-
-                // only the final fragment carries last_in_sequence - middle ones must be 0x00
-                headerOdsNext[3] = (byte)(p == numAddPackets - 1 ? 0x40 : 0x00);
-                for (var i = 0; i < headerOdsNext.Length; i++)
-                {
-                    buf[index++] = headerOdsNext[i];
-                }
-
-                for (var i = 0; i < psize; i++)
-                {
-                    buf[index++] = rleBuf[rleIndex++];
-                }
-
-                bufSize -= psize;
-            }
-
-            // write END
-            packetHeader[10] = 0x80;                                             // ID (keep PTS & DTS)
-            ToolBox.SetWord(packetHeader, 11, 0);                       // size
-            for (var i = 0; i < packetHeader.Length; i++)
-            {
-                buf[index++] = packetHeader[i];
-            }
-
-            // write the fade steps - one palette update display set each (PCS + PDS + END). The
-            // PCS repeats the composition of the epoch start with palette_update_flag set, which
-            // tells the decoder to keep the object it already has and only take the new palette.
             var endPts = pic.EndTimeForWrite;
             var compositionNumber = pic.CompositionNumber;
-            headerPcsStart[7] = 0x00;                                            // composition_state: normal case
-            headerPcsStart[8] = 0x80;                                            // palette_update_flag
-            for (var step = 0; step < fadeSteps.Count; step++)
+
+            // The caption: PCS (also called the Control Segment), WDS, PDS, the ODS of every
+            // object, END.
+            writer.Write(PcsSegment, pts, BuildPcs(pic.Width, h, fpsId, compositionNumber, CompositionStateEpochStart, false, encoded));
+            writer.Write(WdsSegment, pts, BuildWds(encoded));
+            var startAlphaPercents = new int[encoded.Count];
+            for (var k = 0; k < encoded.Count; k++)
+            {
+                startAlphaPercents[k] = encoded[k].StartAlphaPercent;
+            }
+
+            writer.Write(PdsSegment, pts, BuildPds(pal, palSize, 0, encoded, startAlphaPercents));
+            for (var k = 0; k < encoded.Count; k++)
+            {
+                WriteOds(writer, pts, k, encoded[k]);
+            }
+
+            writer.Write(EndSegment, pts, Array.Empty<byte>());
+
+            // The fade steps - one palette update display set each (PCS + PDS + END). The PCS
+            // repeats the composition of the epoch start with palette_update_flag set, which
+            // tells the decoder to keep the objects it already has and only take the new palette.
+            var updates = MergeFadeSteps(encoded);
+            for (var step = 0; step < updates.Count; step++)
             {
                 // A step may only be scheduled after the caption is up and before it is taken
                 // down; the start PTS can have been nudged by the small gap removal above.
-                var stepPts = Math.Min(Math.Max(fadeSteps[step].TimeForWrite, pts + 1), endPts - 1);
+                var stepPts = Math.Min(Math.Max(updates[step].TimeForWrite, pts + 1), endPts - 1);
 
                 compositionNumber++;
-                packetHeader[10] = 0x16;                                         // ID
-                ToolBox.SetDWord(packetHeader, 2, (uint)stepPts);           // PTS
-                ToolBox.SetDWord(packetHeader, 6, 0);                       // DTS (0 = unset)
-                ToolBox.SetWord(packetHeader, 11, headerPcsStart.Length);   // size
-                for (var i = 0; i < packetHeader.Length; i++)
-                {
-                    buf[index++] = packetHeader[i];
-                }
-
-                ToolBox.SetWord(headerPcsStart, 5, compositionNumber);
-                for (var i = 0; i < headerPcsStart.Length; i++)
-                {
-                    buf[index++] = headerPcsStart[i];
-                }
+                writer.Write(PcsSegment, stepPts, BuildPcs(pic.Width, h, fpsId, compositionNumber, CompositionStateNormal, true, encoded));
 
                 // The palette version has to move for the decoder to take the update; it is a
                 // byte, so it wraps on captions with more than 255 steps.
-                index = WritePds(buf, index, packetHeader, pal, palSize, (step + 1) & 0xff, fadeSteps[step].AlphaPercent);
-
-                packetHeader[10] = 0x80;                                         // END (keep PTS & DTS)
-                ToolBox.SetWord(packetHeader, 11, 0);                       // size
-                for (var i = 0; i < packetHeader.Length; i++)
-                {
-                    buf[index++] = packetHeader[i];
-                }
+                writer.Write(PdsSegment, stepPts, BuildPds(pal, palSize, (step + 1) & 0xff, encoded, updates[step].AlphaPercents));
+                writer.Write(EndSegment, stepPts, Array.Empty<byte>());
             }
 
-            // write PCS end
-            packetHeader[10] = 0x16;                                            // ID
-            ToolBox.SetDWord(packetHeader, 2, (uint)pic.EndTimeForWrite);        // PTS
-            ToolBox.SetDWord(packetHeader, 6, 0);                          // DTS (0 = unset)
-            ToolBox.SetWord(packetHeader, 11, headerPcsEnd.Length);     // size
-            for (var i = 0; i < packetHeader.Length; i++)
+            if (writeClear)
             {
-                buf[index++] = packetHeader[i];
+                // PCS with no objects, the windows again, END
+                compositionNumber++;
+                writer.Write(PcsSegment, endPts, BuildPcs(pic.Width, h, fpsId, compositionNumber, CompositionStateNormal, false, Array.Empty<EncodedObject>()));
+                writer.Write(WdsSegment, endPts, BuildWds(encoded));
+                writer.Write(EndSegment, endPts, Array.Empty<byte>());
             }
 
-            ToolBox.SetWord(headerPcsEnd, 0, pic.Width);
-            ToolBox.SetWord(headerPcsEnd, 2, h);                                // cropped height
-            ToolBox.SetByte(headerPcsEnd, 4, fpsId);
-            ToolBox.SetWord(headerPcsEnd, 5, compositionNumber + 1);
-            for (var i = 0; i < headerPcsEnd.Length; i++)
-            {
-                buf[index++] = headerPcsEnd[i];
-            }
-
-            // write WDS - Window Definition Segment
-            packetHeader[10] = 0x17;                                                     // ID (keep PTS & DTS)
-            ToolBox.SetWord(packetHeader, 11, headerWds.Length);                // size
-            for (var i = 0; i < packetHeader.Length; i++)
-            {
-                buf[index++] = packetHeader[i];
-            }
-
-            ToolBox.SetWord(headerWds, 2, pic.WindowXOffset);
-            ToolBox.SetWord(headerWds, 4, yOfs);
-            ToolBox.SetWord(headerWds, 6, bm.Width);
-            ToolBox.SetWord(headerWds, 8, bm.Height);
-            for (var i = 0; i < headerWds.Length; i++)
-            {
-                buf[index++] = headerWds[i];
-            }
-
-            // write END
-            packetHeader[10] = 0x80;                                            // ID (keep PTS & DTS)
-            ToolBox.SetWord(packetHeader, 11, 0);                       // size
-            for (var i = 0; i < packetHeader.Length; i++)
-            {
-                buf[index++] = packetHeader[i];
-            }
-
-            return buf;
+            pic.NextCompositionNumber = compositionNumber + 1;
+            return writer.ToArray();
         }
     }
 }

--- a/src/libuilogic/Export/ExportHandlerBluRaySup.cs
+++ b/src/libuilogic/Export/ExportHandlerBluRaySup.cs
@@ -1,4 +1,6 @@
 using Nikse.SubtitleEdit.Core.BluRaySup;
+using SkiaSharp;
+using System.Collections.Concurrent;
 
 namespace Nikse.SubtitleEdit.UiLogic.Export;
 
@@ -13,37 +15,363 @@ public class ExportHandlerBluRaySup : IExportHandler
     private int _height;
     private FileStream? _fileStream;
 
+    /// <summary>
+    /// What <see cref="CreateParagraph"/> made of each subtitle: where it sits in the frame and
+    /// when it is shown. Only subtitles in here can be composed with others - one that skipped
+    /// CreateParagraph carries a ready-made buffer (a track copied out of a container, say) and
+    /// is written as it is.
+    /// </summary>
+    private readonly ConcurrentDictionary<ImageParameter, BluRaySupPicture> _pictures = new(ReferenceEqualityComparer.Instance);
+
+    /// <summary>
+    /// Subtitles waiting to be written because they overlap in time. A Blu-ray shows one
+    /// display set at a time, so overlapping subtitles have to go into the same display sets
+    /// to be seen together (issue #14456) - the group is written when the next subtitle does
+    /// not overlap it, or at the end.
+    /// </summary>
+    private readonly List<ImageParameter> _pending = [];
+    private long _pendingStartMs;
+    private long _pendingEndMs;
+
     public void WriteHeader(string fileOrFolderName, ImageParameter imageParameter)
     {
         _width = imageParameter.ScreenWidth;
         _height = imageParameter.ScreenHeight;
+        _pictures.Clear();
+        _pending.Clear();
         _fileStream = new FileStream(fileOrFolderName, FileMode.Create);
     }
 
     public void CreateParagraph(ImageParameter param)
     {
-        MakeBluRaySupImage(param);
+        _pictures[param] = MakeBluRaySupImage(param);
     }
 
     public void WriteParagraph(ImageParameter param)
     {
-        _fileStream!.Write(param.Buffer, 0, param.Buffer.Length);
+        if (!_pictures.TryGetValue(param, out var picture))
+        {
+            FlushPending();
+            _fileStream!.Write(param.Buffer, 0, param.Buffer.Length);
+            return;
+        }
+
+        var overlapsPending = picture.StartTime < _pendingEndMs && picture.EndTime > _pendingStartMs;
+        if (_pending.Count > 0 && !overlapsPending)
+        {
+            FlushPending();
+        }
+
+        if (_pending.Count == 0)
+        {
+            _pendingStartMs = picture.StartTime;
+            _pendingEndMs = picture.EndTime;
+        }
+        else
+        {
+            _pendingStartMs = Math.Min(_pendingStartMs, picture.StartTime);
+            _pendingEndMs = Math.Max(_pendingEndMs, picture.EndTime);
+        }
+
+        _pending.Add(param);
     }
 
     public void WriteFooter()
     {
+        FlushPending();
         _fileStream!.Close();
+    }
+
+    private void FlushPending()
+    {
+        if (_pending.Count == 0)
+        {
+            return;
+        }
+
+        try
+        {
+            if (_pending.Count == 1)
+            {
+                // Nothing to compose - the display sets CreateParagraph made are the file.
+                var buffer = _pending[0].Buffer;
+                _fileStream!.Write(buffer, 0, buffer.Length);
+            }
+            else
+            {
+                WriteOverlapping(_pending);
+            }
+        }
+        finally
+        {
+            _pending.Clear();
+        }
+    }
+
+    /// <summary>
+    /// A subtitle as it sits in the frame, ready to be composed with others.
+    /// </summary>
+    private sealed class PlacedCaption
+    {
+        public required SKBitmap Bitmap { get; init; }
+        public bool OwnsBitmap { get; init; }
+
+        /// <summary>
+        /// Made by <see cref="Merge"/> rather than taken from a subtitle - and so is its bitmap.
+        /// </summary>
+        public bool IsMerged { get; init; }
+
+        public int X { get; init; }
+        public int Y { get; init; }
+        public SKColor FontColor { get; init; }
+        public bool IsForced { get; init; }
+        public List<BluRaySupFadeStep> FadeSteps { get; init; } = [];
+
+        public int Right => X + Bitmap.Width;
+        public int Bottom => Y + Bitmap.Height;
+
+        public bool Intersects(PlacedCaption other)
+        {
+            return X < other.Right && other.X < Right && Y < other.Bottom && other.Y < Bottom;
+        }
+
+        public long UnionArea(PlacedCaption other)
+        {
+            return (long)(Math.Max(Right, other.Right) - Math.Min(X, other.X)) *
+                   (Math.Max(Bottom, other.Bottom) - Math.Min(Y, other.Y));
+        }
+
+        public BluRaySupCompositionObject ToCompositionObject()
+        {
+            return new BluRaySupCompositionObject
+            {
+                Bitmap = Bitmap,
+                FontColor = FontColor,
+                X = X,
+                Y = Y,
+                IsForced = IsForced,
+                FadeSteps = FadeSteps,
+            };
+        }
+
+        public void Dispose()
+        {
+            if (OwnsBitmap)
+            {
+                Bitmap.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Writes subtitles that overlap in time. The timeline is cut wherever one of them starts
+    /// or ends, and every slice becomes an epoch showing all the subtitles on screen in it -
+    /// which the decoder takes as one picture, so this is what makes two lines show up at the
+    /// same time. Only the last slice clears the screen; before that, the next epoch start
+    /// replaces the previous one.
+    /// </summary>
+    private void WriteOverlapping(List<ImageParameter> cues)
+    {
+        var pictures = cues.Select(c => _pictures[c]).ToList();
+        var times = pictures.SelectMany(p => new[] { p.StartTime, p.EndTime }).Distinct().OrderBy(t => t).ToList();
+        var compositionNumber = pictures[0].CompositionNumber;
+        var fps = cues[0].FramesPerSecond;
+
+        var captions = new List<PlacedCaption>(cues.Count);
+        try
+        {
+            for (var i = 0; i < cues.Count; i++)
+            {
+                captions.Add(Place(cues[i], pictures[i]));
+            }
+
+            for (var t = 0; t + 1 < times.Count; t++)
+            {
+                var start = times[t];
+                var end = times[t + 1];
+                var visible = new List<PlacedCaption>();
+                for (var i = 0; i < cues.Count; i++)
+                {
+                    if (pictures[i].StartTime <= start && pictures[i].EndTime > start)
+                    {
+                        visible.Add(captions[i]);
+                    }
+                }
+
+                if (visible.Count == 0)
+                {
+                    continue;
+                }
+
+                // Nothing on screen after this slice means it has to clear; otherwise the next
+                // slice's epoch start takes over.
+                var showsMore = pictures.Any(p => p.StartTime <= end && p.EndTime > end);
+
+                var composed = Compose(visible);
+                try
+                {
+                    var objects = composed.Select(c => c.ToCompositionObject()).ToList();
+                    var picture = new BluRaySupPicture
+                    {
+                        StartTime = start,
+                        EndTime = end,
+                        Width = _width,
+                        Height = _height,
+                        IsForced = objects.Any(o => o.IsForced),
+                        CompositionNumber = compositionNumber,
+                    };
+
+                    var buffer = BluRaySupPicture.CreateSupFrame(picture, objects, fps, writeClear: !showsMore);
+                    _fileStream!.Write(buffer, 0, buffer.Length);
+                    compositionNumber = picture.NextCompositionNumber;
+                }
+                finally
+                {
+                    foreach (var caption in composed.Where(c => c.IsMerged))
+                    {
+                        caption.Dispose();
+                    }
+                }
+            }
+        }
+        finally
+        {
+            foreach (var caption in captions)
+            {
+                caption.Dispose();
+            }
+        }
+    }
+
+    private static PlacedCaption Place(ImageParameter cue, BluRaySupPicture picture)
+    {
+        // Not the cue's bitmap: callers may dispose that right after WriteParagraph (seconv
+        // and the container track exports do), and the full frame image was let go as soon as
+        // it was encoded. The encoded caption on the picture has the same pixels.
+        return new PlacedCaption
+        {
+            Bitmap = picture.EncodedBitmap.ToBitmap(),
+            OwnsBitmap = true,
+            X = picture.WindowXOffset,
+            Y = picture.WindowYOffset,
+            FontColor = cue.FontColor,
+            IsForced = cue.IsForced,
+            FadeSteps = picture.FadeSteps,
+        };
+    }
+
+    /// <summary>
+    /// Turns the subtitles on screen into the objects of one display set. Windows may not
+    /// overlap, so subtitles drawn over each other become one object - the later one on top,
+    /// as the export preview shows them - and a display set holds at most two objects, so past
+    /// that the closest pair share one.
+    /// </summary>
+    private static List<PlacedCaption> Compose(List<PlacedCaption> visible)
+    {
+        var list = visible.OrderBy(c => c.Y).ThenBy(c => c.X).ToList();
+
+        bool merged;
+        do
+        {
+            merged = false;
+            for (var i = 0; i < list.Count && !merged; i++)
+            {
+                for (var j = i + 1; j < list.Count; j++)
+                {
+                    if (list[i].Intersects(list[j]))
+                    {
+                        list[i] = Merge(list[i], list[j]);
+                        list.RemoveAt(j);
+                        merged = true;
+                        break;
+                    }
+                }
+            }
+        } while (merged);
+
+        while (list.Count > BluRaySupPicture.MaxCompositionObjects)
+        {
+            var bestI = 0;
+            var bestJ = 1;
+            var bestArea = long.MaxValue;
+            for (var i = 0; i < list.Count; i++)
+            {
+                for (var j = i + 1; j < list.Count; j++)
+                {
+                    var area = list[i].UnionArea(list[j]);
+                    if (area < bestArea)
+                    {
+                        bestArea = area;
+                        bestI = i;
+                        bestJ = j;
+                    }
+                }
+            }
+
+            list[bestI] = Merge(list[bestI], list[bestJ]);
+            list.RemoveAt(bestJ);
+        }
+
+        return list;
+    }
+
+    /// <summary>
+    /// One caption covering both, <paramref name="b"/> drawn over <paramref name="a"/>. It fades
+    /// as <paramref name="a"/> does - a merged object has one palette range, so it cannot fade
+    /// its parts apart.
+    /// </summary>
+    private static PlacedCaption Merge(PlacedCaption a, PlacedCaption b)
+    {
+        var x = Math.Min(a.X, b.X);
+        var y = Math.Min(a.Y, b.Y);
+        var width = Math.Max(a.Right, b.Right) - x;
+        var height = Math.Max(a.Bottom, b.Bottom) - y;
+
+        var bitmap = new SKBitmap(Math.Max(1, width), Math.Max(1, height), false);
+        using (var canvas = new SKCanvas(bitmap))
+        {
+            canvas.Clear(SKColors.Transparent);
+            canvas.DrawBitmap(a.Bitmap, a.X - x, a.Y - y);
+            canvas.DrawBitmap(b.Bitmap, b.X - x, b.Y - y);
+        }
+
+        var merged = new PlacedCaption
+        {
+            Bitmap = bitmap,
+            OwnsBitmap = true,
+            IsMerged = true,
+            X = x,
+            Y = y,
+            FontColor = a.FontColor,
+            IsForced = a.IsForced || b.IsForced,
+            FadeSteps = a.FadeSteps,
+        };
+
+        if (a.IsMerged)
+        {
+            a.Dispose();
+        }
+
+        if (b.IsMerged)
+        {
+            b.Dispose();
+        }
+
+        return merged;
     }
 
     /// <summary>
     /// Composition numbers a single subtitle may use: one display set for the caption, one for
     /// the screen clear and up to <see cref="ExportFade.MaxSteps"/> palette updates in between.
     /// Every subtitle gets a block of its own - the numbers must keep climbing through the file
-    /// (they wrap at 16 bits, which is expected), gaps in them do no harm.
+    /// (they wrap at 16 bits, which is expected), gaps in them do no harm. A group of
+    /// overlapping subtitles counts on from the block of its first one; it can run past its
+    /// blocks when every line fades, and a number then repeats far apart in the file, which no
+    /// decoder minds.
     /// </summary>
     private const int CompositionNumbersPerParagraph = ExportFade.MaxSteps + 2;
 
-    private static void MakeBluRaySupImage(ImageParameter param)
+    private static BluRaySupPicture MakeBluRaySupImage(ImageParameter param)
     {
         var startTime = (long)Math.Round(param.StartTime.TotalMilliseconds, MidpointRounding.AwayFromZero);
         var endTime = (long)Math.Round(param.EndTime.TotalMilliseconds, MidpointRounding.AwayFromZero);
@@ -89,5 +417,7 @@ public class ExportHandlerBluRaySup : IExportHandler
                 param.BluRayContentAlignment,
                 param.OverridePosition.HasValue ? new BluRayPoint(param.OverridePosition.Value.X, param.OverridePosition.Value.Y) : null);
         }
+
+        return brSub;
     }
 }

--- a/tests/libse/BluRaySup/BluRaySupPictureCompositionTests.cs
+++ b/tests/libse/BluRaySup/BluRaySupPictureCompositionTests.cs
@@ -1,0 +1,270 @@
+using Nikse.SubtitleEdit.Core.BluRaySup;
+using SkiaSharp;
+using System.Text;
+
+namespace LibSETests.BluRaySup;
+
+/// <summary>
+/// A Blu-ray display set can compose two objects, each in a window of its own, from one
+/// palette. The writer lays the palettes of the objects end to end in that one palette and
+/// encodes each object against its own range.
+/// </summary>
+public class BluRaySupPictureCompositionTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), "bluraysupcomposition_" + Guid.NewGuid().ToString("N"));
+
+    public BluRaySupPictureCompositionTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, true); } catch { /* best effort */ }
+    }
+
+    private sealed record Segment(long Pts, byte Type, byte[] Payload);
+
+    private static List<Segment> ReadSegments(byte[] sup)
+    {
+        var segments = new List<Segment>();
+        var position = 0;
+        while (position + 13 <= sup.Length)
+        {
+            Assert.Equal(0x50, sup[position]);
+            Assert.Equal(0x47, sup[position + 1]);
+            var pts = ((long)sup[position + 2] << 24) | ((long)sup[position + 3] << 16) | ((long)sup[position + 4] << 8) | sup[position + 5];
+            var size = (sup[position + 11] << 8) + sup[position + 12];
+            segments.Add(new Segment(pts, sup[position + 10], sup.Skip(position + 13).Take(size).ToArray()));
+            position += 13 + size;
+        }
+
+        Assert.Equal(sup.Length, position);
+        return segments;
+    }
+
+    private static SKBitmap Solid(int width, int height, SKColor color)
+    {
+        var bitmap = new SKBitmap(width, height);
+        using var canvas = new SKCanvas(bitmap);
+        canvas.Clear(color);
+        return bitmap;
+    }
+
+    /// <summary>
+    /// A bitmap with <paramref name="colors"/> distinct colours - one per column.
+    /// </summary>
+    private static SKBitmap Gradient(int colors)
+    {
+        var bitmap = new SKBitmap(new SKImageInfo(colors, 10, SKColorType.Bgra8888, SKAlphaType.Unpremul));
+        for (var x = 0; x < colors; x++)
+        {
+            for (var y = 0; y < 10; y++)
+            {
+                bitmap.SetPixel(x, y, new SKColor((byte)x, (byte)(255 - x), 128));
+            }
+        }
+
+        return bitmap;
+    }
+
+    private static BluRaySupPicture Picture() => new()
+    {
+        Width = 1280,
+        Height = 720,
+        StartTime = 1000,
+        EndTime = 3000,
+        CompositionNumber = 10,
+    };
+
+    private static BluRaySupCompositionObject Object(SKBitmap bitmap, SKColor fontColor, int x, int y) => new()
+    {
+        Bitmap = bitmap,
+        FontColor = fontColor,
+        X = x,
+        Y = y,
+    };
+
+    private List<BluRaySupParser.PcsData> Parse(byte[] sup)
+    {
+        var fileName = Path.Combine(_dir, Guid.NewGuid().ToString("N") + ".sup");
+        File.WriteAllBytes(fileName, sup);
+        return BluRaySupParser.ParseBluRaySup(fileName, new StringBuilder());
+    }
+
+    [Fact]
+    public void TwoObjects_AreComposedInTwoWindowsFromOnePalette()
+    {
+        using var bottom = Solid(300, 80, SKColors.White);
+        using var top = Solid(200, 40, SKColors.Red);
+        var picture = Picture();
+
+        var sup = BluRaySupPicture.CreateSupFrame(picture, new[]
+        {
+            Object(bottom, SKColors.White, 490, 590),
+            Object(top, SKColors.Red, 540, 50),
+        }, 25);
+
+        var segments = ReadSegments(sup);
+        Assert.Equal(new byte[] { 0x16, 0x17, 0x14, 0x15, 0x15, 0x80, 0x16, 0x17, 0x80 }, segments.Select(s => s.Type));
+
+        var pcs = segments[0].Payload;
+        Assert.Equal(2, pcs[10]);
+        Assert.Equal(490, (pcs[15] << 8) + pcs[16]);
+        Assert.Equal(590, (pcs[17] << 8) + pcs[18]);
+        Assert.Equal(540, (pcs[23] << 8) + pcs[24]);
+        Assert.Equal(50, (pcs[25] << 8) + pcs[26]);
+
+        var wds = segments[1].Payload;
+        Assert.Equal(2, wds[0]);
+        Assert.Equal(0, wds[1]);
+        Assert.Equal(1, wds[10]);
+
+        // White, transparent, red, transparent - one palette, two ranges.
+        var pds = segments[2].Payload;
+        Assert.Equal(2 + 4 * 5, pds.Length);
+        Assert.Equal(255, pds[2 + 0 * 5 + 4]);
+        Assert.Equal(0, pds[2 + 1 * 5 + 4]);
+        Assert.Equal(255, pds[2 + 2 * 5 + 4]);
+        Assert.Equal(0, pds[2 + 3 * 5 + 4]);
+
+        Assert.Equal(12, picture.NextCompositionNumber);
+        Assert.Equal(11, (segments[6].Payload[5] << 8) + segments[6].Payload[6]);
+    }
+
+    [Fact]
+    public void TwoObjects_DecodeToBothCaptionsInPlace()
+    {
+        using var bottom = Solid(300, 80, SKColors.White);
+        using var top = Solid(200, 40, SKColors.Red);
+
+        var sup = BluRaySupPicture.CreateSupFrame(Picture(), new[]
+        {
+            Object(bottom, SKColors.White, 490, 590),
+            Object(top, SKColors.Red, 540, 50),
+        }, 25);
+
+        var subtitle = Assert.Single(Parse(sup));
+        Assert.Equal(1000, subtitle.StartTimeCode.TotalMilliseconds, 1);
+        Assert.Equal(3000, subtitle.EndTimeCode.TotalMilliseconds, 1);
+        Assert.Equal(490, subtitle.GetPosition().Left);
+        Assert.Equal(50, subtitle.GetPosition().Top);
+
+        using var bitmap = subtitle.GetBitmap();
+        Assert.Equal(300, bitmap.Width);
+        Assert.Equal(620, bitmap.Height);
+        var red = bitmap.GetPixel(540 - 490 + 100, 20);
+        Assert.Equal(255, red.Alpha);
+        Assert.True(red.Red > 200 && red.Green < 60 && red.Blue < 60, $"expected red, got {red}");
+        var white = bitmap.GetPixel(150, 619);
+        Assert.Equal(255, white.Alpha);
+        Assert.True(white.Red > 200 && white.Green > 200 && white.Blue > 200, $"expected white, got {white}");
+        Assert.Equal(0, bitmap.GetPixel(150, 300).Alpha);
+    }
+
+    [Fact]
+    public void WithoutClear_TheDisplaySetEndsWithTheCaption()
+    {
+        using var bitmap = Solid(300, 80, SKColors.White);
+        var picture = Picture();
+
+        var sup = BluRaySupPicture.CreateSupFrame(picture, new[] { Object(bitmap, SKColors.White, 490, 590) }, 25, writeClear: false);
+
+        var segments = ReadSegments(sup);
+        Assert.Equal(new byte[] { 0x16, 0x17, 0x14, 0x15, 0x80 }, segments.Select(s => s.Type));
+        Assert.Equal(11, picture.NextCompositionNumber);
+    }
+
+    [Fact]
+    public void PalettesThatDoNotFitTogether_ShareTheBudget()
+    {
+        using var left = Gradient(200);
+        using var right = Gradient(200);
+
+        var sup = BluRaySupPicture.CreateSupFrame(Picture(), new[]
+        {
+            Object(left, SKColors.White, 100, 100),
+            Object(right, SKColors.White, 100, 400),
+        }, 25);
+
+        var pds = ReadSegments(sup).First(s => s.Type == 0x14).Payload;
+        var entries = (pds.Length - 2) / 5;
+        Assert.InRange(entries, 2, BluRaySupPicture.MaxPaletteEntries);
+
+        // Both still decode - a pixel of each keeps roughly its colour.
+        var subtitle = Assert.Single(Parse(sup));
+        using var bitmap = subtitle.GetBitmap();
+        Assert.Equal(200, bitmap.Width);
+        Assert.Equal(310, bitmap.Height);
+        var a = bitmap.GetPixel(150, 5);
+        var b = bitmap.GetPixel(150, 305);
+        Assert.Equal(255, a.Alpha);
+        Assert.Equal(255, b.Alpha);
+        Assert.InRange(a.Red, 120, 180);
+        Assert.InRange(b.Red, 120, 180);
+    }
+
+    [Fact]
+    public void EncodedBitmap_BringsThePixelsBackExactly()
+    {
+        // Anti-aliased edges and a transparent hole: the encoder writes single pixels, runs of
+        // colour 0, long and short runs and end of line codes.
+        using var bitmap = new SKBitmap(new SKImageInfo(320, 60, SKColorType.Bgra8888, SKAlphaType.Unpremul));
+        for (var y = 0; y < 60; y++)
+        {
+            for (var x = 0; x < 320; x++)
+            {
+                var inHole = x > 100 && x < 150 && y > 20 && y < 40;
+                var edge = x < 5 || y < 5;
+                bitmap.SetPixel(x, y, inHole ? SKColors.Transparent : edge ? new SKColor(200, 100, 50, (byte)(40 + x % 7 * 30)) : SKColors.White);
+            }
+        }
+
+        var picture = Picture();
+        BluRaySupPicture.CreateSupFrame(picture, bitmap, SKColors.White, 25, 50, 0, BluRayContentAlignment.BottomCenter);
+
+        var encoded = picture.EncodedBitmap;
+        Assert.NotNull(encoded);
+        Assert.Equal(320, encoded.Width);
+        Assert.Equal(60, encoded.Height);
+        Assert.True(encoded.Rle.Length < 320 * 60 / 4, $"the RLE should be a lot smaller than the pixels, was {encoded.Rle.Length}");
+
+        using var decoded = encoded.ToBitmap();
+        Assert.Equal(320, decoded.Width);
+        Assert.Equal(60, decoded.Height);
+        for (var y = 0; y < 60; y += 3)
+        {
+            for (var x = 0; x < 320; x += 7)
+            {
+                var expected = bitmap.GetPixel(x, y);
+                var actual = decoded.GetPixel(x, y);
+                if (expected.Alpha == 0)
+                {
+                    Assert.Equal(0, actual.Alpha);
+                }
+                else
+                {
+                    Assert.Equal(expected, actual);
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void MoreThanTwoObjects_IsRejected()
+    {
+        using var bitmap = Solid(10, 10, SKColors.White);
+        var objects = Enumerable.Range(0, 3).Select(i => Object(bitmap, SKColors.White, 0, i * 20)).ToList();
+
+        Assert.Throws<ArgumentException>(() => BluRaySupPicture.CreateSupFrame(Picture(), objects, 25));
+        Assert.Throws<ArgumentException>(() => BluRaySupPicture.CreateSupFrame(Picture(), new List<BluRaySupCompositionObject>(), 25));
+    }
+
+    [Fact]
+    public void OneObject_IsWrittenAsTheSingleBitmapOverloadWritesIt()
+    {
+        using var bitmap = Solid(300, 80, SKColors.White);
+
+        var viaObjects = BluRaySupPicture.CreateSupFrame(Picture(), new[] { Object(bitmap, SKColors.White, 490, 590) }, 25);
+        var viaBitmap = BluRaySupPicture.CreateSupFrame(Picture(), bitmap, SKColors.White, 25, 50, 0, BluRayContentAlignment.BottomCenter);
+
+        Assert.Equal(viaBitmap, viaObjects);
+    }
+}

--- a/tests/libuilogic/Export/ExportHandlerBluRaySupOverlapTests.cs
+++ b/tests/libuilogic/Export/ExportHandlerBluRaySupOverlapTests.cs
@@ -1,0 +1,340 @@
+using Nikse.SubtitleEdit.Core.BluRaySup;
+using Nikse.SubtitleEdit.UiLogic.Export;
+using SkiaSharp;
+using System.Text;
+
+namespace LibUiLogicTests.Export;
+
+/// <summary>
+/// Subtitles that overlap in time on a Blu-ray sup export (issue #14456). A Blu-ray shows one
+/// display set at a time, so two subtitles can only be seen together when they are in the same
+/// display set: the export cuts the timeline where a subtitle starts or ends and writes a display
+/// set per slice, composing up to two objects in two windows.
+/// </summary>
+public class ExportHandlerBluRaySupOverlapTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), "bluraysupoverlap_" + Guid.NewGuid().ToString("N"));
+
+    public ExportHandlerBluRaySupOverlapTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, true); } catch { /* best effort */ }
+    }
+
+    private sealed record Segment(long Pts, byte Type, byte[] Payload);
+
+    private const int ScreenWidth = 1280;
+    private const int ScreenHeight = 720;
+    private const int Margin = 50;
+    private const int CueWidth = 300;
+    private const int CueHeight = 80;
+
+    private static ImageParameter Cue(int index, double startSeconds, double endSeconds, ExportAlignment alignment, SKColor color, string text = "Hello")
+    {
+        var bitmap = new SKBitmap(CueWidth, CueHeight);
+        using (var canvas = new SKCanvas(bitmap))
+        {
+            canvas.Clear(color);
+        }
+
+        var parameter = new ImageParameter
+        {
+            Text = ExportTextTags.ToRenderableText(text),
+            Bitmap = bitmap,
+            StartTime = TimeSpan.FromSeconds(startSeconds),
+            EndTime = TimeSpan.FromSeconds(endSeconds),
+            Index = index,
+            ScreenWidth = ScreenWidth,
+            ScreenHeight = ScreenHeight,
+            Alignment = alignment,
+            BottomTopMargin = Margin,
+            LeftRightMargin = 40,
+            FramesPerSecond = 25,
+            FontColor = color,
+        };
+
+        ExportTextTags.ApplyTransparencyTags(parameter, text);
+        return parameter;
+    }
+
+    private string Export(params ImageParameter[] cues)
+    {
+        var fileName = Path.Combine(_dir, Guid.NewGuid().ToString("N") + ".sup");
+        var handler = new ExportHandlerBluRaySup();
+        handler.WriteHeader(fileName, cues[0]);
+        foreach (var cue in cues)
+        {
+            handler.CreateParagraph(cue);
+        }
+
+        foreach (var cue in cues)
+        {
+            handler.WriteParagraph(cue);
+        }
+
+        handler.WriteFooter();
+        return fileName;
+    }
+
+    /// <summary>
+    /// Walks the file as "PG" + PTS(4) + DTS(4) + type(1) + size(2) + payload, which also proves
+    /// the segments chain exactly to the end.
+    /// </summary>
+    private static List<Segment> ReadSegments(string fileName)
+    {
+        var sup = File.ReadAllBytes(fileName);
+        var segments = new List<Segment>();
+        var position = 0;
+        while (position + 13 <= sup.Length)
+        {
+            Assert.Equal(0x50, sup[position]);
+            Assert.Equal(0x47, sup[position + 1]);
+            var pts = ((long)sup[position + 2] << 24) | ((long)sup[position + 3] << 16) | ((long)sup[position + 4] << 8) | sup[position + 5];
+            var size = (sup[position + 11] << 8) + sup[position + 12];
+            segments.Add(new Segment(pts, sup[position + 10], sup.Skip(position + 13).Take(size).ToArray()));
+            position += 13 + size;
+        }
+
+        Assert.Equal(sup.Length, position);
+        return segments;
+    }
+
+    private const byte Pds = 0x14;
+    private const byte Ods = 0x15;
+    private const byte Pcs = 0x16;
+    private const byte Wds = 0x17;
+    private const byte End = 0x80;
+
+    private static int ObjectCount(Segment pcs) => pcs.Payload[10];
+    private static int CompositionNumber(Segment pcs) => (pcs.Payload[5] << 8) + pcs.Payload[6];
+    private static int Word(byte[] payload, int offset) => (payload[offset] << 8) + payload[offset + 1];
+    private static int WindowY(Segment wds, int window) => Word(wds.Payload, 1 + window * 9 + 3);
+    private static int WindowHeight(Segment wds, int window) => Word(wds.Payload, 1 + window * 9 + 7);
+    private static int OdsWidth(Segment ods) => Word(ods.Payload, 7);
+    private static int OdsHeight(Segment ods) => Word(ods.Payload, 9);
+    private static int PaletteAlpha(Segment pds, int entry) => pds.Payload[2 + entry * 5 + 4];
+
+    [Fact]
+    public void TwoOverlappingLines_ShareTheScreenWhileBothAreOn()
+    {
+        var segments = ReadSegments(Export(
+            Cue(0, 1, 3, ExportAlignment.BottomCenter, SKColors.White),
+            Cue(1, 2, 4, ExportAlignment.TopCenter, SKColors.White)));
+
+        // One slice per change: bottom alone, both, top alone, then the clear.
+        Assert.Equal(new byte[]
+        {
+            Pcs, Wds, Pds, Ods, End,
+            Pcs, Wds, Pds, Ods, Ods, End,
+            Pcs, Wds, Pds, Ods, End,
+            Pcs, Wds, End,
+        }, segments.Select(s => s.Type));
+
+        var pcs = segments.Where(s => s.Type == Pcs).ToList();
+        Assert.Equal(new[] { 1, 2, 1, 0 }, pcs.Select(ObjectCount));
+        Assert.Equal(new long[] { 1000 * 90, 2000 * 90, 3000 * 90, 4000 * 90 }, pcs.Select(p => p.Pts));
+
+        // Every slice is an epoch start - it replaces what was on screen, so no clear is needed
+        // between them.
+        Assert.All(pcs.Take(3), p => Assert.Equal(0x80, p.Payload[7]));
+
+        var numbers = pcs.Select(CompositionNumber).ToList();
+        Assert.Equal(numbers.OrderBy(n => n), numbers);
+        Assert.Equal(numbers.Count, numbers.Distinct().Count());
+
+        // The slice with both: two windows that do not touch, the top one first.
+        var both = segments.Where(s => s.Type == Wds).ElementAt(1);
+        Assert.Equal(2, both.Payload[0]);
+        Assert.Equal(Margin, WindowY(both, 0));
+        Assert.Equal(ScreenHeight - Margin - CueHeight, WindowY(both, 1));
+        Assert.True(WindowY(both, 0) + WindowHeight(both, 0) <= WindowY(both, 1));
+
+        // ...and one object each, referenced from the PCS as objects 0 and 1 in windows 0 and 1.
+        var bothPcs = pcs[1];
+        Assert.Equal(0, Word(bothPcs.Payload, 11));
+        Assert.Equal(0, bothPcs.Payload[13]);
+        Assert.Equal(1, Word(bothPcs.Payload, 19));
+        Assert.Equal(1, bothPcs.Payload[21]);
+        var odsIds = segments.Skip(5).Take(6).Where(s => s.Type == Ods).Select(s => Word(s.Payload, 0));
+        Assert.Equal(new[] { 0, 1 }, odsIds);
+    }
+
+    [Fact]
+    public void TwoOverlappingLines_ReadBackAsBothLinesWhileTheyOverlap()
+    {
+        var fileName = Export(
+            Cue(0, 1, 3, ExportAlignment.BottomCenter, SKColors.White),
+            Cue(1, 2, 4, ExportAlignment.TopCenter, SKColors.White));
+
+        var subtitles = BluRaySupParser.ParseBluRaySup(fileName, new StringBuilder());
+
+        Assert.Equal(3, subtitles.Count);
+        Assert.Equal(1000, subtitles[0].StartTimeCode.TotalMilliseconds, 1);
+        Assert.Equal(2000, subtitles[0].EndTimeCode.TotalMilliseconds, 1);
+        Assert.Equal(2000, subtitles[1].StartTimeCode.TotalMilliseconds, 1);
+        Assert.Equal(3000, subtitles[1].EndTimeCode.TotalMilliseconds, 1);
+        Assert.Equal(3000, subtitles[2].StartTimeCode.TotalMilliseconds, 1);
+        Assert.Equal(4000, subtitles[2].EndTimeCode.TotalMilliseconds, 1);
+
+        // The middle slice spans from the top line to the bottom line, with nothing in between.
+        Assert.Equal(2, subtitles[1].PcsObjects.Count);
+        Assert.Equal(Margin, subtitles[1].GetPosition().Top);
+        using var bitmap = subtitles[1].GetBitmap();
+        Assert.Equal(CueWidth, bitmap.Width);
+        Assert.Equal(ScreenHeight - 2 * Margin, bitmap.Height);
+        Assert.Equal(255, bitmap.GetPixel(CueWidth / 2, 0).Alpha);
+        Assert.Equal(255, bitmap.GetPixel(CueWidth / 2, bitmap.Height - 1).Alpha);
+        Assert.Equal(0, bitmap.GetPixel(CueWidth / 2, bitmap.Height / 2).Alpha);
+    }
+
+    [Fact]
+    public void LinesThatDoNotOverlap_AreWrittenAsBefore()
+    {
+        var segments = ReadSegments(Export(
+            Cue(0, 1, 2, ExportAlignment.BottomCenter, SKColors.White),
+            Cue(1, 3, 4, ExportAlignment.TopCenter, SKColors.White)));
+
+        var perLine = new byte[] { Pcs, Wds, Pds, Ods, End, Pcs, Wds, End };
+        Assert.Equal(perLine.Concat(perLine), segments.Select(s => s.Type));
+        Assert.Equal(new[] { 1, 0, 1, 0 }, segments.Where(s => s.Type == Pcs).Select(ObjectCount));
+    }
+
+    [Fact]
+    public void LinesTouchingEndToStart_AreNotComposed()
+    {
+        var segments = ReadSegments(Export(
+            Cue(0, 1, 2, ExportAlignment.BottomCenter, SKColors.White),
+            Cue(1, 2, 3, ExportAlignment.BottomCenter, SKColors.White)));
+
+        Assert.Equal(new[] { 1, 0, 1, 0 }, segments.Where(s => s.Type == Pcs).Select(ObjectCount));
+    }
+
+    [Fact]
+    public void LinesOnTopOfEachOther_BecomeOneObject()
+    {
+        // Windows may not overlap, so two lines at the same place are drawn into one bitmap.
+        var segments = ReadSegments(Export(
+            Cue(0, 1, 3, ExportAlignment.BottomCenter, SKColors.White),
+            Cue(1, 2, 4, ExportAlignment.BottomCenter, SKColors.White)));
+
+        Assert.Equal(new[] { 1, 1, 1, 0 }, segments.Where(s => s.Type == Pcs).Select(ObjectCount));
+        var bothOds = segments.Skip(5).First(s => s.Type == Ods);
+        Assert.Equal(CueWidth, OdsWidth(bothOds));
+        Assert.Equal(CueHeight, OdsHeight(bothOds));
+    }
+
+    [Fact]
+    public void ThreeLinesAtOnce_ComposeNoMoreThanTwoObjects()
+    {
+        var segments = ReadSegments(Export(
+            Cue(0, 1, 4, ExportAlignment.BottomCenter, SKColors.White),
+            Cue(1, 1, 4, ExportAlignment.TopCenter, SKColors.White),
+            Cue(2, 2, 3, ExportAlignment.MiddleCenter, SKColors.White)));
+
+        var counts = segments.Where(s => s.Type == Pcs).Select(ObjectCount).ToList();
+        Assert.Equal(new[] { 2, 2, 2, 0 }, counts);
+
+        // The middle line shares a window with the closer of the other two - the bitmap of one
+        // of the two objects in the middle slice spans from the middle to the bottom.
+        var middleOds = segments.Skip(6).Where(s => s.Type == Ods).Take(2).ToList();
+        Assert.Contains(middleOds, o => OdsHeight(o) > CueHeight);
+    }
+
+    [Fact]
+    public void Fade_OnOneLine_LeavesTheOtherOpaque()
+    {
+        // Each object has a range of the shared palette, so a fade step scales the entries of
+        // the fading line only.
+        var segments = ReadSegments(Export(
+            Cue(0, 1, 3, ExportAlignment.BottomCenter, SKColors.White, "{\\fad(400,400)}Hello"),
+            Cue(1, 2, 4, ExportAlignment.TopCenter, SKColors.Red)));
+
+        // The slice with both objects: from its PCS to the next epoch start.
+        var pcsIndices = segments.Select((s, i) => (s, i)).Where(x => x.s.Type == Pcs && x.s.Payload[7] == 0x80).Select(x => x.i).ToList();
+        var slice = segments.Skip(pcsIndices[1]).Take(pcsIndices[2] - pcsIndices[1]).ToList();
+        Assert.Equal(2, ObjectCount(slice[0]));
+
+        var palettes = slice.Where(s => s.Type == Pds).ToList();
+        Assert.True(palettes.Count > 1, "the fade out of the bottom line should add palette updates to the slice");
+
+        // Objects go top to bottom: the red top line is object 0 (entries 0 and 1, red then
+        // transparent), the white bottom line object 1 (entries 2 and 3). The white fades out
+        // inside the slice, the red never moves.
+        Assert.Equal(255, PaletteAlpha(palettes[0], 2));
+        Assert.True(PaletteAlpha(palettes[palettes.Count - 1], 2) < 100, "white alphas: " + string.Join(",", palettes.Select(p => PaletteAlpha(p, 2))));
+        Assert.All(palettes, p => Assert.Equal(255, PaletteAlpha(p, 0)));
+
+        // The palette updates re-send the composition of both objects.
+        Assert.All(slice.Skip(1).Where(s => s.Type == Pcs), p =>
+        {
+            Assert.Equal(0x80, p.Payload[8]);
+            Assert.Equal(2, ObjectCount(p));
+        });
+    }
+
+    [Fact]
+    public void OverlappingFullFrameLines_AreDrawnIntoOneFrame()
+    {
+        var bottom = Cue(0, 1, 3, ExportAlignment.BottomCenter, SKColors.White);
+        var top = Cue(1, 2, 4, ExportAlignment.TopCenter, SKColors.White);
+        bottom.IsFullFrame = true;
+        top.IsFullFrame = true;
+
+        var subtitles = BluRaySupParser.ParseBluRaySup(Export(bottom, top), new StringBuilder());
+
+        Assert.Equal(3, subtitles.Count);
+        using var bitmap = subtitles[1].GetBitmap();
+        Assert.Equal(ScreenWidth, bitmap.Width);
+        Assert.Equal(ScreenHeight, bitmap.Height);
+        Assert.Equal(255, bitmap.GetPixel(ScreenWidth / 2, Margin).Alpha);
+        Assert.Equal(255, bitmap.GetPixel(ScreenWidth / 2, ScreenHeight - Margin - 1).Alpha);
+        Assert.Equal(0, bitmap.GetPixel(ScreenWidth / 2, ScreenHeight / 2).Alpha);
+    }
+
+    [Fact]
+    public void BitmapsDisposedAfterWriteParagraph_StillCompose()
+    {
+        // seconv and the container track exports dispose each bitmap right after
+        // WriteParagraph, before the group it overlaps with is written.
+        var fileName = Path.Combine(_dir, "disposed.sup");
+        var cues = new[]
+        {
+            Cue(0, 1, 3, ExportAlignment.BottomCenter, SKColors.White),
+            Cue(1, 2, 4, ExportAlignment.TopCenter, SKColors.White),
+        };
+        var handler = new ExportHandlerBluRaySup();
+        handler.WriteHeader(fileName, cues[0]);
+        foreach (var cue in cues)
+        {
+            handler.CreateParagraph(cue);
+            handler.WriteParagraph(cue);
+            cue.Bitmap.Dispose();
+        }
+
+        handler.WriteFooter();
+
+        var subtitles = BluRaySupParser.ParseBluRaySup(fileName, new StringBuilder());
+        Assert.Equal(3, subtitles.Count);
+        Assert.Equal(2, subtitles[1].PcsObjects.Count);
+        using var bitmap = subtitles[1].GetBitmap();
+        Assert.Equal(ScreenHeight - 2 * Margin, bitmap.Height);
+        Assert.Equal(255, bitmap.GetPixel(CueWidth / 2, 0).Alpha);
+        Assert.Equal(255, bitmap.GetPixel(CueWidth / 2, bitmap.Height - 1).Alpha);
+    }
+
+    [Fact]
+    public void ReadyMadeBuffers_AreWrittenAsTheyAre()
+    {
+        // A cue that never went through CreateParagraph (a track copied out of a container)
+        // carries its own display sets.
+        var fileName = Path.Combine(_dir, "raw.sup");
+        var handler = new ExportHandlerBluRaySup();
+        handler.WriteHeader(fileName, new ImageParameter { ScreenWidth = ScreenWidth, ScreenHeight = ScreenHeight });
+        handler.WriteParagraph(new ImageParameter { Buffer = [1, 2, 3] });
+        handler.WriteParagraph(new ImageParameter { Buffer = [4, 5] });
+        handler.WriteFooter();
+
+        Assert.Equal(new byte[] { 1, 2, 3, 4, 5 }, File.ReadAllBytes(fileName));
+    }
+}


### PR DESCRIPTION
Fixes #14456.

A Blu-ray shows one display set at a time, so a subtitle that started while another was still on screen replaced it: the exported `.sup` never showed two lines at once, even when the subtitle did.

## What changes

- **Overlapping subtitles are composed.** The sup export handler groups subtitles that overlap in time, cuts the timeline wherever one of them starts or ends, and writes one epoch per slice with everything on screen in it - up to two composition objects in two windows (the PCS/WDS maximum), sharing one palette. Only the last slice clears the screen; the epoch start of the next slice replaces the previous one.
- **Fades stay per line.** Each object gets its own range of the shared palette, so a `{\fad(..)}` on one line scales only that line's entries in the palette updates.
- **Collisions and a third line** - subtitles whose windows would overlap, or more than two at once - are drawn into one bitmap, the later one on top, as the preview shows them.
- **Bitmaps are not held.** The composition happens at write time, after seconv and the MKV/MP4 track exports have disposed each bitmap, so the handler keeps the palette + RLE the writer already produced (`BluRaySupEncodedBitmap`) and decodes the pixels from that when it needs them.
- `BluRaySupPicture.CreateSupFrame` got a multi-object overload; the single-bitmap overload wraps it and **writes non-overlapping subtitles byte for byte as before** (a test asserts the two produce identical output).

## Verification

- 8 new libuilogic tests (slices, windows, object ids, read-back through `BluRaySupParser`, collision merge, three-at-once, per-line fade, full frame, disposed bitmaps, verbatim buffers) and 6 new libse tests for the writer.
- Full libse (1907) and libuilogic (759) suites pass.
- `seconv overlap.srt bluraysup` then `ffmpeg ... overlay`: ffmpeg's PGS decoder shows the bottom line and the `{\an8}` top line together during the overlap, and each alone before/after.

## Docs

`docs/features/file.md` gets a paragraph on overlapping subtitles next to the fading one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
