### PR TITLE
Source view: use the appearance font and readable light-mode syntax colors

### DIFF
--- a/src/ui/Controls/SyntaxTextEditorControl/SyntaxTextEditor.cs
+++ b/src/ui/Controls/SyntaxTextEditorControl/SyntaxTextEditor.cs
@@ -57,8 +57,11 @@ public class SyntaxTextEditor : Decorator
             [Grid.ColumnProperty] = 1,
         };
 
+        // Line numbers stay in the platform default font: they are UI, not subtitle text, and a
+        // text face with old-style numerals makes them hard to scan.
         _gutter = new LineNumberGutter
         {
+            FontFamily = FontFamily.Default,
             [Grid.RowProperty] = 0,
             [Grid.ColumnProperty] = 0,
         };

--- a/src/ui/Controls/SyntaxTextEditorControl/SyntaxTextView.cs
+++ b/src/ui/Controls/SyntaxTextEditorControl/SyntaxTextView.cs
@@ -67,7 +67,7 @@ public class SyntaxTextView : Control
 
     private readonly SourceSyntaxLineStyler _styler = new();
     private readonly List<SourceSyntaxSpan> _spanScratch = new();
-    private readonly Dictionary<(Color Color, bool Bold), GenericTextRunProperties> _runPropertiesCache = new();
+    private readonly Dictionary<(Color Color, bool Bold, bool DefaultFont), GenericTextRunProperties> _runPropertiesCache = new();
 
     private readonly List<UndoEntry> _undoStack = new();
     private readonly List<UndoEntry> _redoStack = new();
@@ -78,6 +78,11 @@ public class SyntaxTextView : Control
 
     private Typeface _typeface;
     private Typeface _boldTypeface;
+
+    // Line numbers and time codes are drawn in the platform default font whatever the editor's
+    // family is - see SourceSyntaxSpan.DefaultFont.
+    private Typeface _defaultFontTypeface;
+    private Typeface _defaultFontBoldTypeface;
     private GenericTextRunProperties? _defaultRunProperties;
     private double _measuredFontSize;
     private FontFamily? _measuredFontFamily;
@@ -419,6 +424,8 @@ public class SyntaxTextView : Control
         _measuredDarkTheme = isDarkTheme;
         _typeface = new Typeface(FontFamily);
         _boldTypeface = new Typeface(FontFamily, FontStyle.Normal, FontWeight.Bold);
+        _defaultFontTypeface = new Typeface(FontFamily.Default);
+        _defaultFontBoldTypeface = new Typeface(FontFamily.Default, FontStyle.Normal, FontWeight.Bold);
 
         // The syntax colors are theme dependent, so the cached layouts and run properties have to
         // go with the theme.
@@ -556,18 +563,21 @@ public class SyntaxTextView : Control
             foregroundBrush: Foreground ?? Brushes.Black);
     }
 
-    private GenericTextRunProperties GetRunProperties(Color color, bool bold)
+    private GenericTextRunProperties GetRunProperties(Color color, bool bold, bool defaultFont)
     {
-        if (_runPropertiesCache.TryGetValue((color, bold), out var properties))
+        if (_runPropertiesCache.TryGetValue((color, bold, defaultFont), out var properties))
         {
             return properties;
         }
 
+        var typeface = defaultFont
+            ? (bold ? _defaultFontBoldTypeface : _defaultFontTypeface)
+            : (bold ? _boldTypeface : _typeface);
         properties = new GenericTextRunProperties(
-            bold ? _boldTypeface : _typeface,
+            typeface,
             FontSize,
             foregroundBrush: new ImmutableSolidColorBrush(color));
-        _runPropertiesCache[(color, bold)] = properties;
+        _runPropertiesCache[(color, bold, defaultFont)] = properties;
         return properties;
     }
 
@@ -603,7 +613,7 @@ public class SyntaxTextView : Control
                 spans.Add(new ValueSpan<TextRunProperties>(position, span.Start - position, defaultProperties));
             }
 
-            spans.Add(new ValueSpan<TextRunProperties>(span.Start, span.Length, GetRunProperties(span.Color, span.Bold)));
+            spans.Add(new ValueSpan<TextRunProperties>(span.Start, span.Length, GetRunProperties(span.Color, span.Bold, span.DefaultFont)));
             position = span.Start + span.Length;
         }
 

--- a/src/ui/Logic/AssaSourceSyntaxHighlighting.cs
+++ b/src/ui/Logic/AssaSourceSyntaxHighlighting.cs
@@ -9,18 +9,31 @@ namespace Nikse.SubtitleEdit.Logic;
 /// </summary>
 public partial class AssaSourceSyntaxHighlighting : ISourceSyntaxHighlighter
 {
-    // Color scheme
-    private static readonly Color SectionColor = Color.Parse("#569CD6"); // Blue for [Section] headers
-    private static readonly Color KeywordColor = Color.Parse("#C586C0"); // Purple for keywords (Dialogue:, Comment:, Style:, Format:)
-    private static readonly Color TimeColor = Color.Parse("#4EC9B0"); // Cyan for timecodes
+    // Color scheme - the dark set is the VS Code dark palette, which is washed out on white, so
+    // light mode gets the same hues a few shades darker (#14457).
+    private static readonly Color SectionColorDark = Color.Parse("#569CD6"); // Blue for [Section] headers
+    private static readonly Color SectionColorLight = Color.Parse("#1565C0");
+    private static readonly Color KeywordColorDark = Color.Parse("#C586C0"); // Purple for keywords (Dialogue:, Comment:, Style:, Format:)
+    private static readonly Color KeywordColorLight = Color.Parse("#8E24AA");
+    private static readonly Color TimeColorDark = Color.Parse("#4EC9B0"); // Cyan for timecodes
+    private static readonly Color TimeColorLight = Color.Parse("#00796B");
     private static readonly Color PropertyColorDark = Color.Parse("#9CDCFE"); // Light blue for property names
-    private static readonly Color PropertyColorLight = Color.Parse("#1565C0"); // Darker blue - light blue is barely readable on white
-    private static readonly Color ValueColor = Color.Parse("#CE9178"); // Orange for values
-    private static readonly Color CommentColor = Color.Parse("#6A9955"); // Green for comments
-    private static readonly Color NumberColor = Color.Parse("#B5CEA8"); // Light green for numbers
+    private static readonly Color PropertyColorLight = Color.Parse("#1565C0");
+    private static readonly Color ValueColorDark = Color.Parse("#CE9178"); // Orange for values
+    private static readonly Color ValueColorLight = Color.Parse("#A0522D");
+    private static readonly Color CommentColorDark = Color.Parse("#6A9955"); // Green for comments
+    private static readonly Color CommentColorLight = Color.Parse("#2E7D32");
+    private static readonly Color NumberColorDark = Color.Parse("#B5CEA8"); // Light green for numbers
+    private static readonly Color NumberColorLight = Color.Parse("#33691E");
 
     // Resolved per use so a theme switch is picked up
+    private static Color SectionColor => UiTheme.IsDarkThemeEnabled() ? SectionColorDark : SectionColorLight;
+    private static Color KeywordColor => UiTheme.IsDarkThemeEnabled() ? KeywordColorDark : KeywordColorLight;
+    private static Color TimeColor => UiTheme.IsDarkThemeEnabled() ? TimeColorDark : TimeColorLight;
     private static Color PropertyColor => UiTheme.IsDarkThemeEnabled() ? PropertyColorDark : PropertyColorLight;
+    private static Color ValueColor => UiTheme.IsDarkThemeEnabled() ? ValueColorDark : ValueColorLight;
+    private static Color CommentColor => UiTheme.IsDarkThemeEnabled() ? CommentColorDark : CommentColorLight;
+    private static Color NumberColor => UiTheme.IsDarkThemeEnabled() ? NumberColorDark : NumberColorLight;
 
     // Section headers like [Script Info], [V4+ Styles], [Events]
     [GeneratedRegex(@"^\s*\[[^\]]+\]\s*$", RegexOptions.Multiline)]

--- a/src/ui/Logic/AssaSourceSyntaxHighlighting.cs
+++ b/src/ui/Logic/AssaSourceSyntaxHighlighting.cs
@@ -159,7 +159,7 @@ public partial class AssaSourceSyntaxHighlighting : ISourceSyntaxHighlighter
     {
         foreach (Match match in AssaTimecodeRegex().Matches(lineText))
         {
-            styler.Apply(match.Index, match.Length, TimeColor, bold: true);
+            styler.Apply(match.Index, match.Length, TimeColor, bold: true, defaultFont: true);
         }
     }
 

--- a/src/ui/Logic/JsonSourceSyntaxHighlighting.cs
+++ b/src/ui/Logic/JsonSourceSyntaxHighlighting.cs
@@ -8,13 +8,28 @@ namespace Nikse.SubtitleEdit.Logic;
 /// </summary>
 public partial class JsonSourceSyntaxHighlighting : ISourceSyntaxHighlighter
 {
-    // Color scheme (VS Code-like JSON colors)
-    private static readonly Color PropertyNameColor = Color.Parse("#9CDCFE"); // Light blue for property names
-    private static readonly Color StringColor = Color.Parse("#CE9178"); // Orange for string values
-    private static readonly Color NumberColor = Color.Parse("#B5CEA8"); // Light green for numbers
-    private static readonly Color BooleanColor = Color.Parse("#569CD6"); // Blue for true/false/null
-    private static readonly Color BraceColor = Color.Parse("#FFD700"); // Gold for braces and brackets
-    private static readonly Color ColonCommaColor = Color.Parse("#D4D4D4"); // Light gray for : and ,
+    // Color scheme (VS Code-like JSON colors). The dark set is built for a dark background; light
+    // mode gets the same hues a few shades darker so they are readable on white (#14457).
+    private static readonly Color PropertyNameColorDark = Color.Parse("#9CDCFE"); // Light blue for property names
+    private static readonly Color PropertyNameColorLight = Color.Parse("#006C9B");
+    private static readonly Color StringColorDark = Color.Parse("#CE9178"); // Orange for string values
+    private static readonly Color StringColorLight = Color.Parse("#A0522D");
+    private static readonly Color NumberColorDark = Color.Parse("#B5CEA8"); // Light green for numbers
+    private static readonly Color NumberColorLight = Color.Parse("#33691E");
+    private static readonly Color BooleanColorDark = Color.Parse("#569CD6"); // Blue for true/false/null
+    private static readonly Color BooleanColorLight = Color.Parse("#1565C0");
+    private static readonly Color BraceColorDark = Color.Parse("#FFD700"); // Gold for braces and brackets
+    private static readonly Color BraceColorLight = Color.Parse("#8D6E00");
+    private static readonly Color ColonCommaColorDark = Color.Parse("#D4D4D4"); // Light gray for : and ,
+    private static readonly Color ColonCommaColorLight = Color.Parse("#616161");
+
+    // Resolved per use so a theme switch is picked up
+    private static Color PropertyNameColor => UiTheme.IsDarkThemeEnabled() ? PropertyNameColorDark : PropertyNameColorLight;
+    private static Color StringColor => UiTheme.IsDarkThemeEnabled() ? StringColorDark : StringColorLight;
+    private static Color NumberColor => UiTheme.IsDarkThemeEnabled() ? NumberColorDark : NumberColorLight;
+    private static Color BooleanColor => UiTheme.IsDarkThemeEnabled() ? BooleanColorDark : BooleanColorLight;
+    private static Color BraceColor => UiTheme.IsDarkThemeEnabled() ? BraceColorDark : BraceColorLight;
+    private static Color ColonCommaColor => UiTheme.IsDarkThemeEnabled() ? ColonCommaColorDark : ColonCommaColorLight;
 
     // JSON property names (e.g., "start": or "text":)
     [GeneratedRegex(@"""([^""\\]*(\\.[^""\\]*)*)""(?=\s*:)", RegexOptions.Compiled)]

--- a/src/ui/Logic/SourceSyntaxHighlighting.cs
+++ b/src/ui/Logic/SourceSyntaxHighlighting.cs
@@ -5,10 +5,16 @@ using System.Collections.Generic;
 namespace Nikse.SubtitleEdit.Logic;
 
 /// <summary>
-/// A styled range of source text: a foreground color plus an optional bold flag.
-/// Spans are sorted and never overlap; text not covered by a span keeps the default foreground.
+/// A styled range of source text: a foreground color plus an optional bold flag, and whether the
+/// span is drawn in the platform default font rather than the editor's. Spans are sorted and never
+/// overlap; text not covered by a span keeps the default foreground.
 /// </summary>
-public readonly record struct SourceSyntaxSpan(int Start, int Length, Color Color, bool Bold);
+/// <remarks>
+/// <see cref="DefaultFont"/> is for line numbers and time codes: the appearance font is right for
+/// the subtitle text, but a text face with old-style numerals (Georgia) makes digits hard to scan,
+/// so those stay in the default UI font.
+/// </remarks>
+public readonly record struct SourceSyntaxSpan(int Start, int Length, Color Color, bool Bold, bool DefaultFont = false);
 
 /// <summary>
 /// The syntax rules of one source format, expressed per line and independent of the control that
@@ -37,13 +43,15 @@ public interface ISourceSyntaxDocumentFormatter
 /// Collects the styles of one line and flattens them into sorted, non-overlapping spans.
 ///
 /// Styles are applied per character and per property: a later <see cref="Apply"/> replaces the
-/// color of the characters it covers, and bold, once set, stays set (no rule ever clears it).
+/// color of the characters it covers, and bold and default font, once set, stay set (no rule ever
+/// clears them).
 /// </summary>
 public sealed class SourceSyntaxLineStyler
 {
     private Color[] _colors = Array.Empty<Color>();
     private bool[] _hasColor = Array.Empty<bool>();
     private bool[] _bold = Array.Empty<bool>();
+    private bool[] _defaultFont = Array.Empty<bool>();
     private int _length;
 
     /// <summary>
@@ -58,21 +66,24 @@ public sealed class SourceSyntaxLineStyler
             _colors = new Color[capacity];
             _hasColor = new bool[capacity];
             _bold = new bool[capacity];
+            _defaultFont = new bool[capacity];
         }
         else
         {
             Array.Clear(_hasColor, 0, _length);
             Array.Clear(_bold, 0, _length);
+            Array.Clear(_defaultFont, 0, _length);
         }
 
         _length = length;
     }
 
     /// <summary>
-    /// Colors [start, start+length) - out of range parts are clipped away. Bold is only ever
-    /// turned on: pass false to recolor a range without touching the weight set by an earlier rule.
+    /// Colors [start, start+length) - out of range parts are clipped away. Bold and default font
+    /// are only ever turned on: pass false to recolor a range without touching what an earlier
+    /// rule set.
     /// </summary>
-    public void Apply(int start, int length, Color color, bool bold = false)
+    public void Apply(int start, int length, Color color, bool bold = false, bool defaultFont = false)
     {
         var end = Math.Min(start + length, _length);
         for (var i = Math.Max(start, 0); i < end; i++)
@@ -82,6 +93,11 @@ public sealed class SourceSyntaxLineStyler
             if (bold)
             {
                 _bold[i] = true;
+            }
+
+            if (defaultFont)
+            {
+                _defaultFont[i] = true;
             }
         }
     }
@@ -104,13 +120,14 @@ public sealed class SourceSyntaxLineStyler
             var runStart = i;
             var color = _colors[i];
             var bold = _bold[i];
+            var defaultFont = _defaultFont[i];
             i++;
-            while (i < _length && _hasColor[i] && _colors[i] == color && _bold[i] == bold)
+            while (i < _length && _hasColor[i] && _colors[i] == color && _bold[i] == bold && _defaultFont[i] == defaultFont)
             {
                 i++;
             }
 
-            target.Add(new SourceSyntaxSpan(offset + runStart, i - runStart, color, bold));
+            target.Add(new SourceSyntaxSpan(offset + runStart, i - runStart, color, bold, defaultFont));
         }
     }
 }

--- a/src/ui/Logic/SubRipSourceSyntaxHighlighting.cs
+++ b/src/ui/Logic/SubRipSourceSyntaxHighlighting.cs
@@ -64,7 +64,7 @@ public partial class SubRipSourceSyntaxHighlighting : ISourceSyntaxHighlighter
         var numberMatch = SubRipNumberRegex().Match(lineText);
         if (numberMatch.Success && numberMatch.Value == lineText.Trim())
         {
-            styler.Apply(0, lineText.Length, NumberColor, bold: true);
+            styler.Apply(0, lineText.Length, NumberColor, bold: true, defaultFont: true);
             return true;
         }
 
@@ -78,7 +78,7 @@ public partial class SubRipSourceSyntaxHighlighting : ISourceSyntaxHighlighter
             if (separatorIndex >= 0)
             {
                 // Colorize the start timecode (before "-->")
-                styler.Apply(timecodeMatch.Index, separatorIndex, TimeColor, bold: true);
+                styler.Apply(timecodeMatch.Index, separatorIndex, TimeColor, bold: true, defaultFont: true);
 
                 // Colorize the separator "-->" with a different color
                 var separatorStart = timecodeMatch.Index + separatorIndex;
@@ -96,19 +96,19 @@ public partial class SubRipSourceSyntaxHighlighting : ISourceSyntaxHighlighter
                     separatorEnd++;
                 }
 
-                styler.Apply(separatorStart, separatorEnd - separatorStart, TimeSeparatorColor, bold: true);
+                styler.Apply(separatorStart, separatorEnd - separatorStart, TimeSeparatorColor, bold: true, defaultFont: true);
 
                 // Colorize the end timecode (after "-->")
                 var endTimecodeEnd = timecodeMatch.Index + timecodeMatch.Length;
                 if (endTimecodeEnd > separatorEnd)
                 {
-                    styler.Apply(separatorEnd, endTimecodeEnd - separatorEnd, TimeColor, bold: true);
+                    styler.Apply(separatorEnd, endTimecodeEnd - separatorEnd, TimeColor, bold: true, defaultFont: true);
                 }
             }
             else
             {
                 // Fallback: colorize the entire match as timecode
-                styler.Apply(timecodeMatch.Index, timecodeMatch.Length, TimeColor, bold: true);
+                styler.Apply(timecodeMatch.Index, timecodeMatch.Length, TimeColor, bold: true, defaultFont: true);
             }
 
             return true;

--- a/src/ui/Logic/SubRipSourceSyntaxHighlighting.cs
+++ b/src/ui/Logic/SubRipSourceSyntaxHighlighting.cs
@@ -9,10 +9,20 @@ namespace Nikse.SubtitleEdit.Logic;
 /// </summary>
 public partial class SubRipSourceSyntaxHighlighting : ISourceSyntaxHighlighter
 {
-    // SubRip-specific colors
-    private static readonly Color NumberColor = Color.FromRgb(140, 170, 0);
-    private static readonly Color TimeColor = Color.FromArgb(128, 80, 160, 210); // half transparent, so it reads as softer
-    private static readonly Color TimeSeparatorColor = Color.FromRgb(170, 110, 180);
+    // SubRip-specific colors. Unlike the tag pastels below these mark the structure of the file,
+    // not de-emphasized markup, so they get a darker variant for a white background: the
+    // half-transparent time code was barely there in light mode (#14457).
+    private static readonly Color NumberColorDark = Color.FromRgb(140, 170, 0);
+    private static readonly Color NumberColorLight = Color.FromRgb(96, 128, 0);
+    private static readonly Color TimeColorDark = Color.FromArgb(128, 80, 160, 210); // half transparent, so it reads as softer
+    private static readonly Color TimeColorLight = Color.FromRgb(36, 110, 168);
+    private static readonly Color TimeSeparatorColorDark = Color.FromRgb(170, 110, 180);
+    private static readonly Color TimeSeparatorColorLight = Color.FromRgb(140, 70, 150);
+
+    // Resolved per use so a theme switch is picked up
+    private static Color NumberColor => UiTheme.IsDarkThemeEnabled() ? NumberColorDark : NumberColorLight;
+    private static Color TimeColor => UiTheme.IsDarkThemeEnabled() ? TimeColorDark : TimeColorLight;
+    private static Color TimeSeparatorColor => UiTheme.IsDarkThemeEnabled() ? TimeSeparatorColorDark : TimeSeparatorColorLight;
 
     // HTML/ASS syntax highlighting colors (the shared, theme-dependent scheme from
     // SubtitleSyntaxTokenizer) - resolved per use so a theme switch is picked up.

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -15,6 +15,7 @@ using Avalonia.Styling;
 using Avalonia.VisualTree;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Controls.SyntaxTextEditorControl;
 using Nikse.SubtitleEdit.Features.Shared.ColorPicker;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Platform.Windows;
@@ -3040,6 +3041,17 @@ public static class UiUtil
             Setters =
             {
                 new Setter(ComboBox.FontFamilyProperty, FontFamilyHelper.Make(fontName)),
+            }
+        });
+
+        // The source editor (source view, batch convert ASSA) draws its own text, so it is not
+        // covered by the TextBox style above and would stay in Avalonia's default sans (#14457).
+        // The format preview sets a monospace family locally, which wins over this style.
+        Application.Current.Styles.Add(new Style(x => x.OfType<SyntaxTextEditor>())
+        {
+            Setters =
+            {
+                new Setter(SyntaxTextEditor.FontFamilyProperty, FontFamilyHelper.Make(fontName)),
             }
         });
     }

--- a/src/ui/Logic/XmlSourceSyntaxHighlighting.cs
+++ b/src/ui/Logic/XmlSourceSyntaxHighlighting.cs
@@ -10,11 +10,22 @@ namespace Nikse.SubtitleEdit.Logic;
 /// </summary>
 public class XmlSourceSyntaxHighlighting : ISourceSyntaxHighlighter, ISourceSyntaxDocumentFormatter
 {
-    // Color scheme
-    private static readonly Color XmlTagColor = Color.Parse("#569CD6");
-    private static readonly Color XmlAttributeColor = Color.Parse("#9CDCFE");
-    private static readonly Color XmlValueColor = Color.Parse("#CE9178");
-    private static readonly Color CommentColor = Color.Parse("#6A9955");
+    // Color scheme - the dark set is the VS Code dark palette, which is washed out on white, so
+    // light mode gets the same hues a few shades darker (#14457).
+    private static readonly Color XmlTagColorDark = Color.Parse("#569CD6");
+    private static readonly Color XmlTagColorLight = Color.Parse("#1565C0");
+    private static readonly Color XmlAttributeColorDark = Color.Parse("#9CDCFE");
+    private static readonly Color XmlAttributeColorLight = Color.Parse("#006C9B");
+    private static readonly Color XmlValueColorDark = Color.Parse("#CE9178");
+    private static readonly Color XmlValueColorLight = Color.Parse("#A0522D");
+    private static readonly Color CommentColorDark = Color.Parse("#6A9955");
+    private static readonly Color CommentColorLight = Color.Parse("#2E7D32");
+
+    // Resolved per use so a theme switch is picked up
+    private static Color XmlTagColor => UiTheme.IsDarkThemeEnabled() ? XmlTagColorDark : XmlTagColorLight;
+    private static Color XmlAttributeColor => UiTheme.IsDarkThemeEnabled() ? XmlAttributeColorDark : XmlAttributeColorLight;
+    private static Color XmlValueColor => UiTheme.IsDarkThemeEnabled() ? XmlValueColorDark : XmlValueColorLight;
+    private static Color CommentColor => UiTheme.IsDarkThemeEnabled() ? CommentColorDark : CommentColorLight;
 
     /// <summary>
     /// Reflows XML that arrives (almost) all on one line - unreadable to scroll through, and slow

--- a/tests/UI/Controls/SyntaxTextEditorFontTests.cs
+++ b/tests/UI/Controls/SyntaxTextEditorFontTests.cs
@@ -2,6 +2,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Media;
+using Avalonia.VisualTree;
 using Nikse.SubtitleEdit.Controls.SyntaxTextEditorControl;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -12,7 +13,8 @@ namespace UITests.Controls;
 /// The appearance font is applied through app-wide styles per control type. The source editor
 /// draws its own text, so it is not a TextBox and needs its own setter - without it the source
 /// view stayed in Avalonia's default sans while the rest of the window used the chosen font
-/// (#14457).
+/// (#14457). Line numbers and time codes are the exception: they stay in the platform default
+/// font, because a text face with old-style numerals makes digits hard to scan.
 /// </summary>
 public class SyntaxTextEditorFontTests
 {
@@ -41,6 +43,10 @@ public class SyntaxTextEditorFontTests
             Assert.Equal("Georgia", editor.View.FontFamily.Name);
             Assert.Equal("Courier New", monoEditor.FontFamily.Name);
             Assert.Equal("Courier New", monoEditor.View.FontFamily.Name);
+
+            // The line number gutter never follows the editor font.
+            var gutter = editor.GetVisualDescendants().OfType<LineNumberGutter>().Single();
+            Assert.Equal(FontFamily.Default, gutter.FontFamily);
         }
         finally
         {
@@ -52,5 +58,23 @@ public class SyntaxTextEditorFontTests
 
             Se.Settings.Appearance.FontName = savedFontName;
         }
+    }
+
+    [AvaloniaFact]
+    public void TimeCodesAndNumbersAreFlaggedForTheDefaultFontButTextIsNot()
+    {
+        const string text = "12\r\n00:00:01,000 --> 00:00:02,000\r\n<i>Hi</i> there";
+        var spans = SourceSyntaxTokenizer.Tokenize(text, new SubRipSourceSyntaxHighlighting());
+
+        string Of(SourceSyntaxSpan s) => text.Substring(s.Start, s.Length);
+        Assert.True(spans.Single(s => Of(s) == "12").DefaultFont);
+        Assert.True(spans.Single(s => Of(s) == "00:00:01,000").DefaultFont);
+        Assert.True(spans.Single(s => Of(s).Contains("-->")).DefaultFont);
+        Assert.All(spans.Where(s => s.Start >= text.IndexOf("<i>", StringComparison.Ordinal)), s => Assert.False(s.DefaultFont));
+
+        const string assa = "Dialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,Hi";
+        var assaSpans = SourceSyntaxTokenizer.Tokenize(assa, new AssaSourceSyntaxHighlighting());
+        Assert.True(assaSpans.Single(s => assa.Substring(s.Start, s.Length) == "0:00:01.00").DefaultFont);
+        Assert.False(assaSpans.Single(s => assa.Substring(s.Start, s.Length) == "Dialogue:").DefaultFont);
     }
 }

--- a/tests/UI/Controls/SyntaxTextEditorFontTests.cs
+++ b/tests/UI/Controls/SyntaxTextEditorFontTests.cs
@@ -1,0 +1,56 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Controls.SyntaxTextEditorControl;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Controls;
+
+/// <summary>
+/// The appearance font is applied through app-wide styles per control type. The source editor
+/// draws its own text, so it is not a TextBox and needs its own setter - without it the source
+/// view stayed in Avalonia's default sans while the rest of the window used the chosen font
+/// (#14457).
+/// </summary>
+public class SyntaxTextEditorFontTests
+{
+    [AvaloniaFact]
+    public void AppearanceFontReachesTheSourceEditorAndItsTextSurface()
+    {
+        var app = Application.Current!;
+        var savedFontName = Se.Settings.Appearance.FontName;
+        var styleCount = app.Styles.Count;
+        Window? window = null;
+        try
+        {
+            Se.Settings.Appearance.FontName = "Georgia";
+            UiUtil.SetFontName("Georgia");
+
+            var editor = new SyntaxTextEditor { Text = "1", Height = 80 };
+
+            // The format preview picks a monospace family locally - that must still win.
+            var monoEditor = new SyntaxTextEditor { Text = "1", Height = 80, FontFamily = new FontFamily("Courier New") };
+
+            window = new Window { Content = new StackPanel { Children = { editor, monoEditor } } };
+            window.Show();
+            window.UpdateLayout();
+
+            Assert.Equal("Georgia", editor.FontFamily.Name);
+            Assert.Equal("Georgia", editor.View.FontFamily.Name);
+            Assert.Equal("Courier New", monoEditor.FontFamily.Name);
+            Assert.Equal("Courier New", monoEditor.View.FontFamily.Name);
+        }
+        finally
+        {
+            window?.Close();
+            while (app.Styles.Count > styleCount)
+            {
+                app.Styles.RemoveAt(app.Styles.Count - 1);
+            }
+
+            Se.Settings.Appearance.FontName = savedFontName;
+        }
+    }
+}

--- a/tests/UI/Logic/SourceSyntaxThemeColorTests.cs
+++ b/tests/UI/Logic/SourceSyntaxThemeColorTests.cs
@@ -1,0 +1,115 @@
+using Avalonia.Headless.XUnit;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// The source view highlighters use the VS Code dark palette, which is washed out on white, so
+/// each of them carries a darker light-mode set (#14457). The shared tag pastels are covered by
+/// <see cref="SubtitleSyntaxThemeColorTests"/> and deliberately stay the same in both themes.
+/// </summary>
+public class SourceSyntaxThemeColorTests
+{
+    private static SourceSyntaxSpan SpanCovering(string text, ISourceSyntaxHighlighter highlighter, string token)
+    {
+        var index = text.IndexOf(token, StringComparison.Ordinal);
+        Assert.True(index >= 0, $"'{token}' not in text");
+        return SourceSyntaxTokenizer.Tokenize(text, highlighter)
+            .Single(s => s.Start <= index && index + token.Length <= s.Start + s.Length);
+    }
+
+    private static (SourceSyntaxSpan Dark, SourceSyntaxSpan Light) InBothThemes(string text, ISourceSyntaxHighlighter highlighter, string token)
+    {
+        var savedTheme = Se.Settings.Appearance.Theme;
+        try
+        {
+            Se.Settings.Appearance.Theme = UiTheme.ThemeNameDark;
+            var dark = SpanCovering(text, highlighter, token);
+            Se.Settings.Appearance.Theme = UiTheme.ThemeNameLight;
+            var light = SpanCovering(text, highlighter, token);
+            return (dark, light);
+        }
+        finally
+        {
+            Se.Settings.Appearance.Theme = savedTheme;
+        }
+    }
+
+    private static double Luminance(Color c)
+    {
+        static double Channel(byte v)
+        {
+            var s = v / 255.0;
+            return s <= 0.03928 ? s / 12.92 : Math.Pow((s + 0.055) / 1.055, 2.4);
+        }
+
+        return 0.2126 * Channel(c.R) + 0.7152 * Channel(c.G) + 0.0722 * Channel(c.B);
+    }
+
+    private static double ContrastOnWhite(Color c) => 1.05 / (Luminance(c) + 0.05);
+
+    private static void AssertLightIsDarkerAndReadable((SourceSyntaxSpan Dark, SourceSyntaxSpan Light) spans)
+    {
+        Assert.NotEqual(spans.Dark.Color, spans.Light.Color);
+        Assert.Equal(byte.MaxValue, spans.Light.Color.A);
+        Assert.True(ContrastOnWhite(spans.Light.Color) >= 4.4, $"{spans.Light.Color} is too faint on white");
+        Assert.True(Luminance(spans.Light.Color) < Luminance(spans.Dark.Color), "light-mode color should be the darker one");
+    }
+
+    [AvaloniaFact]
+    public void SubRipTimeCodeIsSolidAndReadableInLightMode()
+    {
+        const string text = "1\r\n00:00:01,000 --> 00:00:02,000\r\nHi";
+        var highlighter = new SubRipSourceSyntaxHighlighting();
+
+        // The dark time color is half transparent - what made it nearly invisible on white.
+        var time = InBothThemes(text, highlighter, "00:00:01,000");
+        Assert.NotEqual(byte.MaxValue, time.Dark.Color.A);
+        AssertLightIsDarkerAndReadable(time);
+
+        AssertLightIsDarkerAndReadable(InBothThemes(text, highlighter, "-->"));
+        AssertLightIsDarkerAndReadable(InBothThemes(text, highlighter, "1"));
+    }
+
+    [AvaloniaFact]
+    public void XmlColorsFollowTheme()
+    {
+        const string text = "<p begin=\"1s\">Hi</p><!-- c -->";
+        var highlighter = new XmlSourceSyntaxHighlighting();
+
+        AssertLightIsDarkerAndReadable(InBothThemes(text, highlighter, "<p"));
+        AssertLightIsDarkerAndReadable(InBothThemes(text, highlighter, "begin"));
+        AssertLightIsDarkerAndReadable(InBothThemes(text, highlighter, "\"1s\""));
+        AssertLightIsDarkerAndReadable(InBothThemes(text, highlighter, "<!-- c -->"));
+    }
+
+    [AvaloniaFact]
+    public void JsonColorsFollowTheme()
+    {
+        const string text = "{\r\n  \"start\": 12,\r\n  \"ok\": true,\r\n  \"tags\": [\r\n    \"Hi\"\r\n  ]\r\n}";
+        var highlighter = new JsonSourceSyntaxHighlighting();
+
+        AssertLightIsDarkerAndReadable(InBothThemes(text, highlighter, "\"start\""));
+        AssertLightIsDarkerAndReadable(InBothThemes(text, highlighter, "12"));
+        AssertLightIsDarkerAndReadable(InBothThemes(text, highlighter, "\"Hi\""));
+        AssertLightIsDarkerAndReadable(InBothThemes(text, highlighter, "true"));
+        AssertLightIsDarkerAndReadable(InBothThemes(text, highlighter, "{"));
+        AssertLightIsDarkerAndReadable(InBothThemes(text, highlighter, ","));
+    }
+
+    [AvaloniaFact]
+    public void AssaColorsFollowTheme()
+    {
+        const string text = "[Events]\r\n; note\r\nTitle: Movie\r\nDialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,Hi";
+        var highlighter = new AssaSourceSyntaxHighlighting();
+
+        AssertLightIsDarkerAndReadable(InBothThemes(text, highlighter, "[Events]"));
+        AssertLightIsDarkerAndReadable(InBothThemes(text, highlighter, "; note"));
+        AssertLightIsDarkerAndReadable(InBothThemes(text, highlighter, "Title"));
+        AssertLightIsDarkerAndReadable(InBothThemes(text, highlighter, "Movie"));
+        AssertLightIsDarkerAndReadable(InBothThemes(text, highlighter, "Dialogue:"));
+        AssertLightIsDarkerAndReadable(InBothThemes(text, highlighter, "0:00:01.00"));
+    }
+}


### PR DESCRIPTION
Fixes #14457

**Font.** The source editor draws its own text, so the app-wide font styles (TextBox, TextBlock, Button, ...) never reached it and the source view stayed in Avalonia's default sans while the rest of the window used the chosen appearance font. `SetFontName` now also targets `SyntaxTextEditor`, so the source view and the batch convert ASSA editor follow the same font as the waveform and the rest of the UI. The format preview's local monospace family still wins over the style.

Line numbers and time codes are the exception: they stay in the platform default font. A text face with old-style numerals (Georgia) makes digits hard to scan. Syntax spans can now ask for the default font; the SubRip/WebVTT number and time-code rules and the ASSA time-code rule set it, and the line-number gutter is pinned to it.

**Light-mode contrast.** The source highlighters used the VS Code dark palette regardless of theme. On white, the SubRip/WebVTT time codes were a half-transparent light blue and the XML/JSON/ASSA tokens (light blue, peach, light green, gold, light gray) were washed out. Each highlighter now has a light-mode set of the same hues a few shades darker; dark mode is unchanged. The shared tag pastels in `SubtitleSyntaxTokenizer` are deliberately untouched, as agreed earlier.

**Tests**
- `SyntaxTextEditorFontTests`: the appearance font reaches the editor and its text surface, a local family still wins, the gutter keeps the default font, and time-code spans carry the default-font flag while text spans do not.
- `SourceSyntaxThemeColorTests`: each highlighter emits a different, opaque, darker color in light mode with at least 4.4:1 contrast on white, and the SubRip time code is no longer translucent.

Headless before/after renders were checked locally for WebVTT, TTML, JSON and ASSA in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)