### PR TITLE
JSON syntax highlighting: color string values that follow a property name

### DIFF
--- a/src/ui/Logic/JsonSourceSyntaxHighlighting.cs
+++ b/src/ui/Logic/JsonSourceSyntaxHighlighting.cs
@@ -16,13 +16,11 @@ public partial class JsonSourceSyntaxHighlighting : ISourceSyntaxHighlighter
     private static readonly Color BraceColor = Color.Parse("#FFD700"); // Gold for braces and brackets
     private static readonly Color ColonCommaColor = Color.Parse("#D4D4D4"); // Light gray for : and ,
 
-    // JSON property names (e.g., "start": or "text":)
-    [GeneratedRegex(@"""([^""\\]*(\\.[^""\\]*)*)""(?=\s*:)", RegexOptions.Compiled)]
-    private static partial Regex JsonPropertyNameRegex();
-
-    // JSON string values (not followed by colon)
-    [GeneratedRegex(@"""([^""\\]*(\\.[^""\\]*)*)""(?!\s*:)", RegexOptions.Compiled)]
-    private static partial Regex JsonStringValueRegex();
+    // Every JSON string on the line, in one pass; the optional trailing colon (group "colon")
+    // tells a property name (e.g. "start":) apart from a string value. Scanning strings once and
+    // in order means a property name's closing quote is never mistaken for the start of a value.
+    [GeneratedRegex(@"""([^""\\]*(\\.[^""\\]*)*)""(?<colon>\s*:)?", RegexOptions.Compiled)]
+    private static partial Regex JsonStringRegex();
 
     // JSON numbers (integers and decimals, including negative)
     [GeneratedRegex(@"-?\d+\.?\d*", RegexOptions.Compiled)]
@@ -49,44 +47,29 @@ public partial class JsonSourceSyntaxHighlighting : ISourceSyntaxHighlighter
 
         // Order matters: we need to colorize in the right sequence to avoid overlaps
 
-        // 1. Colorize property names first (strings followed by colon)
-        ColorizePropertyNames(lineText, styler);
+        // 1. Colorize strings (property names when followed by a colon, values otherwise)
+        ColorizeStrings(lineText, styler);
 
-        // 2. Colorize string values (strings not followed by colon)
-        ColorizeStringValues(lineText, styler);
-
-        // 3. Colorize booleans and null
+        // 2. Colorize booleans and null
         ColorizeBooleanNull(lineText, styler);
 
-        // 4. Colorize numbers
+        // 3. Colorize numbers
         ColorizeNumbers(lineText, styler);
 
-        // 5. Colorize structural characters (braces, brackets)
+        // 4. Colorize structural characters (braces, brackets)
         ColorizeBraces(lineText, styler);
 
-        // 6. Colorize delimiters (colons, commas)
+        // 5. Colorize delimiters (colons, commas)
         ColorizeDelimiters(lineText, styler);
     }
 
-    private static void ColorizePropertyNames(string lineText, SourceSyntaxLineStyler styler)
+    private static void ColorizeStrings(string lineText, SourceSyntaxLineStyler styler)
     {
-        foreach (Match match in JsonPropertyNameRegex().Matches(lineText))
+        foreach (Match match in JsonStringRegex().Matches(lineText))
         {
-            styler.Apply(match.Index, match.Length, PropertyNameColor);
-        }
-    }
-
-    private static void ColorizeStringValues(string lineText, SourceSyntaxLineStyler styler)
-    {
-        foreach (Match match in JsonStringValueRegex().Matches(lineText))
-        {
-            // Skip if this is already colored as a property name
-            if (IsAlreadyColored(lineText, match.Index))
-            {
-                continue;
-            }
-
-            styler.Apply(match.Index, match.Length, StringColor);
+            var colon = match.Groups["colon"];
+            var stringLength = match.Length - colon.Length;
+            styler.Apply(match.Index, stringLength, colon.Success ? PropertyNameColor : StringColor);
         }
     }
 
@@ -172,19 +155,6 @@ public partial class JsonSourceSyntaxHighlighting : ISourceSyntaxHighlighter
         }
 
         return quoteCount % 2 == 1;
-    }
-
-    private static bool IsAlreadyColored(string lineText, int position)
-    {
-        // Check if this position is part of a property name (followed by colon)
-        var colonIndex = lineText.IndexOf(':', position);
-        if (colonIndex == -1)
-        {
-            return false;
-        }
-
-        var textBetween = lineText.Substring(position, colonIndex - position);
-        return textBetween.Contains('"') && textBetween.Trim().EndsWith('"');
     }
 
     private static bool IsValidJsonNumber(string lineText, int position, int length)

--- a/tests/UI/Logic/SourceSyntaxTokenizerTests.cs
+++ b/tests/UI/Logic/SourceSyntaxTokenizerTests.cs
@@ -181,6 +181,33 @@ public class SourceSyntaxTokenizerTests
     }
 
     [Fact]
+    public void JsonStringValueAfterPropertyNameIsColored()
+    {
+        const string text = "  \"text\": \"Hi\"";
+        var spans = SourceSyntaxTokenizer.Tokenize(text, new JsonSourceSyntaxHighlighting());
+
+        var property = Assert.Single(spans, s => text.Substring(s.Start, s.Length) == "\"text\"");
+        var value = Assert.Single(spans, s => text.Substring(s.Start, s.Length) == "\"Hi\"");
+        Assert.NotEqual(property.Color, value.Color);
+    }
+
+    [Fact]
+    public void JsonStringsInArrayAndAfterPropertyNameShareOneColor()
+    {
+        const string text = "{\"a\": \"x\", \"b\": [\"Hi\", \"Yo\"]}";
+        var spans = SourceSyntaxTokenizer.Tokenize(text, new JsonSourceSyntaxHighlighting());
+
+        string At(SourceSyntaxSpan s) => text.Substring(s.Start, s.Length);
+        var x = Assert.Single(spans, s => At(s) == "\"x\"");
+        var hi = Assert.Single(spans, s => At(s) == "\"Hi\"");
+        var yo = Assert.Single(spans, s => At(s) == "\"Yo\"");
+        var a = Assert.Single(spans, s => At(s) == "\"a\"");
+        Assert.Equal(x.Color, hi.Color);
+        Assert.Equal(x.Color, yo.Color);
+        Assert.NotEqual(a.Color, x.Color);
+    }
+
+    [Fact]
     public void SingleLineXmlIsReformattedButMultiLineXmlIsLeftAlone()
     {
         var singleLine = "<tt>" + string.Concat(Enumerable.Repeat("<p begin=\"1\">hi</p>", 30)) + "</tt>";


### PR DESCRIPTION
## Summary
- In the JSON source highlighter, a string value on the same line as its property name (`"text": "Hi"`) was never colored. The value pass used a negative lookahead for a colon; after the property name failed it, the regex restarted at the property's closing quote, matched `": "` as a string, `IsAlreadyColored` skipped it, and the scan resumed past the real value's opening quote. Strings inside arrays were unaffected.
- Scan all JSON strings in one regex pass with an optional trailing colon group: property-name color when the colon matched, string color otherwise. Only the quoted part is colored, so the colon keeps its delimiter color. `IsAlreadyColored` is removed.

## Test plan
- [x] New `JsonStringValueAfterPropertyNameIsColored` and `JsonStringsInArrayAndAfterPropertyNameShareOneColor` in `SourceSyntaxTokenizerTests` fail on the old highlighter and pass with the fix
- [x] `dotnet test tests/UI/UITests.csproj --filter "FullyQualifiedName~SourceSyntax"` — 15 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)