### PR TITLE
UI tests: stop ReferenceRebuildScrollAnchorTests stranding the save prompt

### DIFF
--- a/tests/UI/Features/Main/ReferenceRebuildScrollAnchorTests.cs
+++ b/tests/UI/Features/Main/ReferenceRebuildScrollAnchorTests.cs
@@ -24,8 +24,22 @@ namespace UITests.Features.Main;
 /// fix and was reported again as #14003. The rebuild therefore suspends the anchor for its whole
 /// run: it keeps following the view, it just stops moving it, so the burst settles once at the end.
 /// </summary>
-public class ReferenceRebuildScrollAnchorTests
+public class ReferenceRebuildScrollAnchorTests : IDisposable
 {
+    // Closed in Dispose, not on the last line of each test: a close after a failed assertion
+    // never runs, and a stranded MainView window holds the app-wide focus for every later test.
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
     [AvaloniaFact]
     public void ReferenceRebuild_SuspendsTheScrollAnchorWhileTheRowsChurn()
     {
@@ -145,19 +159,26 @@ public class ReferenceRebuildScrollAnchorTests
         return line;
     }
 
-    private static (Window Window, MainViewModel Vm) CreateMainViewModel()
+    private (Window Window, MainViewModel Vm) CreateMainViewModel()
     {
         var services = new ServiceCollection();
         services.AddSubtitleEditServices();
         Locator.Services = services.BuildServiceProvider();
 
         var window = new Window { Width = 1200, Height = 800 };
+        _windows.Add(window);
         MainView.NextHostWindow = window;
         var view = new MainView();
         window.Content = view;
         window.Show();
         Dispatcher.UIThread.RunJobs();
 
-        return (window, (MainViewModel)view.DataContext!);
+        // Every test here edits the subtitle, so closing the window would otherwise cancel the
+        // close and open the "Save changes?" box - which nothing answers, and which then keeps
+        // yanking keyboard focus for the rest of the process (the ArrowDown grid-centering
+        // test failed on CI whenever it ran a few classes after this one).
+        var vm = (MainViewModel)view.DataContext!;
+        window.SuppressSaveChangesPromptOnClose(vm);
+        return (window, vm);
     }
 }


### PR DESCRIPTION
## Summary

One of four validation runs for #14462 flaked on `SubtitleGridCenterSelectedRowTests.ArrowDown_InTheGrid_KeepsTheRowCentered`, failing its "grid has keyboard focus" precondition. The trx shows `ReferenceRebuildScrollAnchorTests` ran six classes earlier.

Both tests in that class edit the subtitle and then close the MainView window on the last line of the test without detaching `MainViewModel.OnClosing`, so the close is cancelled and the "Save changes?" `MessageBox` opens with nobody to answer it. The window and the box stay open for the rest of the process, and the box's foreground enforcement yanks keyboard focus away from whatever runs after (the mechanism from #13512). Every other MainView test host already detaches the handler; this was the only one left.

Fix: `SuppressSaveChangesPromptOnClose` in the host and close in `Dispose` rather than on the test's last line, which never runs after a failed assertion.

## Test plan

- [x] Probe (not committed): closing a dirty MainView window without the detach leaves `window.IsVisible == true` with an owned `MessageBox`.
- [x] The class passes locally after the change.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)