### PR TITLE
Fix #13492: secondary subtitle follows the preview font, adds Bold option

### DIFF
--- a/src/ui/Features/Video/OpenSecondarySubtitle/OpenSecondarySubtitleViewModel.cs
+++ b/src/ui/Features/Video/OpenSecondarySubtitle/OpenSecondarySubtitleViewModel.cs
@@ -32,6 +32,7 @@ public partial class OpenSecondarySubtitleViewModel : ObservableObject
     [ObservableProperty] private Color _subtitleColor;
     [ObservableProperty] private FontBoxItem _selectedFontBoxType;
     [ObservableProperty] private int _fontSize;
+    [ObservableProperty] private bool _fontBold;
     [ObservableProperty] private ObservableCollection<SubtitleDisplayItem> _paragraphs;
     [ObservableProperty] private int _selectedParagraphIndex = -1;
     [ObservableProperty] private AlignmentItem _selectedFontAlignment;
@@ -67,6 +68,7 @@ public partial class OpenSecondarySubtitleViewModel : ObservableObject
         _windowService = windowService;
 
         SubtitleColor = Colors.White;
+        FontBold = Se.Settings.Video.MpvPreviewFontBold;
         FontBoxTypes = new ObservableCollection<FontBoxItem>
         {
             new(FontBoxType.None, Se.Language.General.None),
@@ -285,8 +287,11 @@ public partial class OpenSecondarySubtitleViewModel : ObservableObject
         var style = new SsaStyle
         {
             Name = _styleName,
-            FontName = "Arial",
+            // Follow the main preview's font (issue #13492): a hardcoded Arial showed a
+            // sans-serif secondary under a serif main whenever the preview font was changed.
+            FontName = Se.Settings.Video.MpvPreviewFontName,
             FontSize = FontSize,
+            Bold = FontBold,
             Primary = SubtitleColor.ToSKColor(),
             Outline = Colors.Black.ToSKColor(),
             Background = Colors.Black.ToSKColor(),
@@ -334,6 +339,7 @@ public partial class OpenSecondarySubtitleViewModel : ObservableObject
             else
             {
                 var defaultStyle = AdvancedSubStationAlpha.GetSsaStyle("Default", result.Header);
+                defaultStyle.FontName = Se.Settings.Video.MpvPreviewFontName;
                 defaultStyle.FontSize = AssaResampler.Resample(AdvancedSubStationAlpha.DefaultHeight, height, Se.Settings.Video.MpvPreviewFontSize);
                 defaultStyle.Bold = Se.Settings.Video.MpvPreviewFontBold;
                 result.Header = AdvancedSubStationAlpha.UpdateOrAddStyle(result.Header, defaultStyle);

--- a/src/ui/Features/Video/OpenSecondarySubtitle/OpenSecondarySubtitleWindow.cs
+++ b/src/ui/Features/Video/OpenSecondarySubtitle/OpenSecondarySubtitleWindow.cs
@@ -51,6 +51,11 @@ public class OpenSecondarySubtitleWindow : Window
         var numericFontSize = UiUtil.MakeNumericUpDownInt(6, 200, 46, 120, vm, nameof(vm.FontSize));
         var panelFontSize = UiUtil.MakeHorizontalPanel(labelFontSize, numericFontSize);
 
+        // Bold row
+        var labelBold = UiUtil.MakeLabel(string.Empty).WithMinWidth(labelWidth);
+        var checkBoxBold = UiUtil.MakeCheckBox(Se.Language.General.Bold, vm, nameof(vm.FontBold));
+        var panelBold = UiUtil.MakeHorizontalPanel(labelBold, checkBoxBold);
+
         // Border style row
         var labelBorderStyle = UiUtil.MakeLabel(Se.Language.General.BorderStyle).WithMinWidth(labelWidth);
         var comboBoxBorderStyle = UiUtil.MakeComboBox(vm.FontBoxTypes, vm, nameof(vm.SelectedFontBoxType)).WithMinWidth(160);
@@ -69,6 +74,7 @@ public class OpenSecondarySubtitleWindow : Window
             {
                 panelColor,
                 panelFontSize,
+                panelBold,
                 panelBorderStyle,
                 panelAlignment,
             },


### PR DESCRIPTION
Fixes the font-mismatch part of #13492 (point 1 of the issue). The re-adjust-without-removing part (point 2) is a separate change and will get its own PR.

## Problem
`OpenSecondarySubtitleViewModel.BuildAssaSubtitle` hardcoded `FontName = "Arial"` and never set `Bold`, while the main preview style is built from `MpvPreviewFontName` / `MpvPreviewFontBold` in `MpvReloader`. With a non-Arial preview font (the reporter uses Georgia) the main subtitle rendered serif and the secondary sans-serif.

The dialog's own preview hid this: for non-ASSA main subtitles it copied only size and bold onto the `Default` style, whose font comes from the ASSA default header (Arial). So both subtitles looked matched inside the dialog and only diverged after OK.

## Changes
- Secondary style now takes its font name from the preview settings instead of Arial.
- New **Bold** checkbox in the dialog, defaulting to the preview bold setting (requested by @matmaggi in the issue).
- The in-dialog main-subtitle style now also gets the preview font name, so the dialog preview matches the main window.

## Testing
- `dotnet build src/ui/UI.csproj` clean, 0 warnings.
- Code path is exercised on every 500 ms preview tick and on OK; no new logic beyond the two style fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
