### PR TITLE
Fix #13492: keep "Open second subtitle file..." available while one is shown

### DIFF
--- a/src/ui/Features/Main/Layout/InitMenu.cs
+++ b/src/ui/Features/Main/Layout/InitMenu.cs
@@ -731,19 +731,13 @@ public static class InitMenu
                 },
                 // Same spot and wording as SE4's Video menu, so it can be found by anyone
                 // looking for it there (#14389). Only meaningful with a video to draw on.
+                // Stays available while a second subtitle is shown: opening again replaces
+                // it, so its style can be adjusted without removing it first (#13492).
                 new MenuItem
                 {
                     Header = Se.Language.Video.OpenSecondarySubtitleOnVideoPlayerDotDotDot,
                     Command = vm.OpenSecondarySubtitleCommand,
-                    [!Visual.IsVisibleProperty] = new MultiBinding
-                    {
-                        Converter = BoolConverters.And,
-                        Bindings =
-                        {
-                            new Binding(nameof(vm.IsVideoLoaded)),
-                            new Binding(nameof(vm.IsSubtitleSecondaryVisible)) { Converter = new InverseBooleanConverter() },
-                        },
-                    },
+                    [!Visual.IsVisibleProperty] = new Binding(nameof(vm.IsVideoLoaded)),
                 },
                 new MenuItem
                 {

--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -345,8 +345,9 @@ public static class InitNativeMacMenu
 
         // Same spot and wording as SE4's Video menu, so it can be found by anyone
         // looking for it there (#14389). Only meaningful with a video to draw on.
+        // Stays available while a second subtitle is shown: opening again replaces it (#13492).
         videoItems.Items.Add(Conditional(Clean(Se.Language.Video.OpenSecondarySubtitleOnVideoPlayerDotDotDot), v => v.OpenSecondarySubtitleCommand,
-            v => v.IsVideoLoaded && !v.IsSubtitleSecondaryVisible, nameof(MainViewModel.IsVideoLoaded), nameof(MainViewModel.IsSubtitleSecondaryVisible)));
+            v => v.IsVideoLoaded, nameof(MainViewModel.IsVideoLoaded)));
         videoItems.Items.Add(Conditional(Clean(Se.Language.Video.RemoveSecondarySubtitleOnVideoPlayer), v => v.ClearSecondarySubtitleCommand,
             v => v.IsVideoLoaded && v.IsSubtitleSecondaryVisible, nameof(MainViewModel.IsVideoLoaded), nameof(MainViewModel.IsSubtitleSecondaryVisible)));
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -627,6 +627,7 @@ public partial class MainViewModel :
     private string? _saveAsFileNameSuggestion;
     private Subtitle _subtitle;
     private Subtitle? _subtitleSecondary;
+    private string? _subtitleSecondaryFileName;
     private Subtitle _subtitleOriginal;
     private SubtitleFormat? _lastOpenSaveFormat;
     private string? _videoFileName;
@@ -3779,7 +3780,9 @@ public partial class MainViewModel :
             return;
         }
 
-        var fileName = await _fileHelper.PickOpenSubtitleFile(Window!, Se.Language.General.OpenSubtitleFileTitle, lastOpenedFilePath: _subtitleFileName);
+        // Start the picker at the current second subtitle when there is one: re-opening it
+        // is how its style gets adjusted (#13492).
+        var fileName = await _fileHelper.PickOpenSubtitleFile(Window!, Se.Language.General.OpenSubtitleFileTitle, lastOpenedFilePath: _subtitleSecondaryFileName ?? _subtitleFileName);
         if (string.IsNullOrEmpty(fileName))
         {
             return;
@@ -3802,6 +3805,7 @@ public partial class MainViewModel :
         }
 
         _subtitleSecondary = result.ResultSubtitle;
+        _subtitleSecondaryFileName = fileName;
         IsSubtitleSecondaryVisible = true;
 
         var vp = GetVideoPlayerControl();
@@ -3831,6 +3835,7 @@ public partial class MainViewModel :
     {
         IsSubtitleSecondaryVisible = false;
         _subtitleSecondary = null;
+        _subtitleSecondaryFileName = null;
         RefreshSubtitlePreview(); // push the removal, or the cleared secondary stays on the video
     }
 


### PR DESCRIPTION
Fixes point 2 of #13492. Point 1 (font/bold) is #14469; the two are independent.

## Problem
To adjust the second subtitle's size, box or color you had to remove it and open it again, because "Open second subtitle file..." was hidden whenever a second subtitle was visible (both the Avalonia menu and the native Mac menu).

## Changes
- The Open item is now visible whenever a video is loaded. Opening again replaces the current second subtitle, no removal step needed.
- The file picker starts at the current second subtitle's file when there is one, since re-picking the same file is the adjust path. The remembered path is cleared on remove.
- No new menu item, no new shortcut, no new strings.

## Testing
- `dotnet build src/ui/UI.csproj` clean, 0 warnings.
- The replace path is the existing OpenSecondarySubtitle command: it already resets the reloader and pushes the new secondary to the player.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
