### PR TITLE
Fix #14472: "guess start from waveform" fires from anywhere; add offsets and "guess end"

### DIFF
--- a/docs/features/audio-visualizer.md
+++ b/docs/features/audio-visualizer.md
@@ -59,6 +59,8 @@ What a single click and a double-click do is configurable: **Waveform single-cli
 | Insert at position (focus text) | Insert a new subtitle at video position and focus the text editor |
 | Insert at position (no focus) | Insert a new subtitle at video position |
 | Seek silence | Find the next silent section |
+| Guess start time from waveform | Move the selected line's start to just before the speech begins (no default key) |
+| Guess end time from waveform | Move the selected line's end to just after the speech stops (no default key) |
 
 > **Note:** Actual key bindings depend on your shortcut configuration. See **Options → Shortcuts** to view or change them.
 

--- a/docs/features/settings.md
+++ b/docs/features/settings.md
@@ -76,6 +76,7 @@ The subtitle rules that drive error checking, the grid's warning colors, and too
 - **Snap to shot changes (hold Shift to override)** and **Snap to frames**
 - **Snap distance when dragging (pixels)** — how close a dragged cue has to come to a shot change before it snaps; in pixels, so it feels the same at every zoom
 - **Snap to nearest shot change: max start / end distance (seconds)**, and the tighter **max end distance when start and end share a cut** — how far the *Snap selected lines to nearest shot change* shortcut looks for a cut. Where a snapped cue lands is set by the beautify profile's in/out cues gap (gear icon next to the snap toggle)
+- **Guess start time from waveform: place start earlier by (ms)** / **Guess end time from waveform: place end later by (ms)** — padding added to the speech boundary the *Guess start/end time from waveform* shortcuts detect, for when the guess feels too tight against the audio. A nearby shot change still wins over the padded position
 - **Shot changes auto-generate**
 - **Focus on mouse over**, **Focus text box after insert**
 - **Invert mouse-wheel**, **Mouse-wheel sets video position**, **Mouse-wheel video position step**

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -147,7 +147,7 @@ wins over the menu activation.
 | Ctrl+Alt+Shift+D | Open data folder |
 | Ctrl+Alt+Shift+L | Save language file |
 
-> **Note:** Several actions (Bold, Underline, shot-change snapping/extending, green-zone in/out cues, "Go to next empty line", "Waveform paste clipboard text to new selection", etc.) ship without a default key. Open **Options** → **Shortcuts** to assign them, or use **Import from SE 4.x** to bring over a familiar set.
+> **Note:** Several actions (Bold, Underline, shot-change snapping/extending, green-zone in/out cues, "Guess start time from waveform" / "Guess end time from waveform", "Go to next empty line", "Waveform paste clipboard text to new selection", etc.) ship without a default key. Open **Options** → **Shortcuts** to assign them, or use **Import from SE 4.x** to bring over a familiar set.
 
 ## Fix Lists in Dialogs
 

--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -4314,6 +4314,98 @@ public class AudioVisualizer : Control
     }
 
     /// <summary>
+    /// "Guess end" counterpart of <see cref="FindDataBelowThresholdBackForStart"/>: finds the moment
+    /// the speech around <paramref name="endSeconds"/> stops, i.e. where the silence after it begins.
+    /// <list type="bullet">
+    /// <item>The end cue sits in real silence (a quiet run at least <paramref name="durationInSeconds"/>
+    /// long): the boundary is the last loud sample before that run, looked for up to 1 s back.</item>
+    /// <item>The end cue sits inside speech, or in a pause too short to count as silence: the boundary
+    /// is the first quiet run of <paramref name="durationInSeconds"/> after it, looked for up to 1 s
+    /// ahead.</item>
+    /// </list>
+    /// Like the start variant the result is padded by 10 ms away from the speech and the search gives up
+    /// when the audio around the cue is all about the same level (nothing to detect).
+    /// </summary>
+    /// <returns>video position in seconds, -1 if not found</returns>
+    public double FindDataBelowThresholdForwardForEnd(double thresholdPercent, double durationInSeconds, double endSeconds)
+    {
+        if (WavePeaks == null || WavePeaks.Peaks.Count == 0)
+        {
+            return -1;
+        }
+
+        var count = WavePeaks.Peaks.Count;
+        var min = Math.Max(0, SecondsToSampleIndex(endSeconds - 1));
+        var max = Math.Min(count, SecondsToSampleIndex(endSeconds + 1));
+        var end = SecondsToSampleIndex(endSeconds);
+        if (end < 0 || end >= count || max <= min)
+        {
+            return -1;
+        }
+
+        var length = SecondsToSampleIndex(durationInSeconds);
+        var threshold = thresholdPercent / 100.0 * WavePeaks.HighestPeak;
+
+        var minMax = GetMinAndMax(min, max);
+        const int lowPeakDifference = 4_000;
+        if (minMax.Max - minMax.Min < lowPeakDifference)
+        {
+            return -1; // all audio about the same
+        }
+
+        var peaks = WavePeaks.Peaks;
+        var searchForwardFrom = end;
+        if (peaks[end].Abs <= threshold)
+        {
+            // The cue is in a quiet stretch - measure it.
+            var runStart = end;
+            while (runStart > min && peaks[runStart - 1].Abs <= threshold)
+            {
+                runStart--;
+            }
+
+            var runEnd = end + 1;
+            while (runEnd < max && peaks[runEnd].Abs <= threshold)
+            {
+                runEnd++;
+            }
+
+            if (runEnd - runStart >= length)
+            {
+                if (runStart <= min)
+                {
+                    return -1; // no speech within reach before the cue
+                }
+
+                // runStart - 1 is the last loud sample: the speech ends there.
+                return SampleIndexToSeconds(runStart) + 0.01;
+            }
+
+            // Just a short pause inside the speech - keep looking for the real silence after it.
+            searchForwardFrom = runEnd;
+        }
+
+        var hitCount = 0;
+        for (var index = searchForwardFrom; index < max; index++)
+        {
+            if (peaks[index].Abs <= threshold)
+            {
+                hitCount++;
+                if (hitCount >= length)
+                {
+                    return SampleIndexToSeconds(index - hitCount + 1) + 0.01;
+                }
+            }
+            else
+            {
+                hitCount = 0;
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>
     /// The lowest peak in a time range, as a percentage of the highest peak in the file.
     /// Used by "guess start" to find the noise floor around a cue (SE 4 parity).
     /// </summary>

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -5529,7 +5529,9 @@ public partial class MainViewModel :
                 pos = pos2;
             }
 
-            var newStartMs = pos * TimeCode.BaseUnit;
+            // The detected boundary sits right against the speech; users who want a little air
+            // in front of it pad it here (#14472). A shot change snap below replaces it.
+            var newStartMs = Math.Max(0, pos * TimeCode.BaseUnit - Se.Settings.Waveform.GuessStartOffsetMs);
             if (prev != null && prev.EndTime.TotalMilliseconds + gapMs >= newStartMs)
             {
                 newStartMs = prev.EndTime.TotalMilliseconds + gapMs;
@@ -5549,7 +5551,11 @@ public partial class MainViewModel :
                     .ToList();
                 if (nearestShotChange.Count > 0)
                 {
-                    newStartMs = nearestShotChange[0] * TimeCode.BaseUnit;
+                    var shotChangeMs = nearestShotChange[0] * TimeCode.BaseUnit;
+                    if (prev == null || prev.EndTime.TotalMilliseconds + gapMs <= shotChangeMs)
+                    {
+                        newStartMs = shotChangeMs;
+                    }
                 }
             }
 
@@ -5580,6 +5586,127 @@ public partial class MainViewModel :
                 TimeSpanExtensions.FromMillisecondsWholeMilliseconds(newStartMs),
                 TimeSpanExtensions.FromMillisecondsWholeMilliseconds(newEndMs));
 
+            _updateAudioVisualizer = true;
+            break;
+        }
+    }
+
+    /// <summary>
+    /// "Guess end": the mirror of <see cref="WaveformGuessStart"/> (#14472). Looks for the silence
+    /// right after the speech that ends the selected line and moves the end cue there, landing the
+    /// out-cue gap before a nearby shot change when there is one. The threshold sweep is the same
+    /// as for the start. Shortening the line never breaks the minimum duration/maximum CPS rules:
+    /// the end is pulled in only as far as those allow. Lengthening stops at the next line's gap.
+    /// </summary>
+    [RelayCommand]
+    private void WaveformGuessEnd()
+    {
+        var selected = SelectedSubtitle;
+        if (selected == null || AreTimeCodesLocked || AudioVisualizer?.WavePeaks == null)
+        {
+            return;
+        }
+
+        var index = Subtitles.IndexOf(selected);
+        if (index < 0)
+        {
+            return;
+        }
+
+        const double silenceLengthInSeconds = 0.08;
+        var startMs = selected.StartTime.TotalMilliseconds;
+        var endMs = selected.EndTime.TotalMilliseconds;
+        var endSeconds = selected.EndTime.TotalSeconds;
+        // The noise floor is read over the whole stretch the end can move in: a cue that cuts the
+        // speech short has nothing but speech right around it.
+        var lowPercent = AudioVisualizer.FindLowPercentage(endSeconds - 0.3, endSeconds + 1.0);
+        var highPercent = AudioVisualizer.FindHighPercentage(endSeconds - 0.4, endSeconds + 0.3);
+        var add = 5.0;
+        if (highPercent > 40)
+        {
+            add = 8;
+        }
+        else if (highPercent < 5)
+        {
+            add = highPercent - lowPercent - 0.3;
+        }
+
+        var gapMs = Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
+        var next = GetNextWorkingRow(index);
+
+        for (var volume = lowPercent + add; volume < 14; volume += 0.3)
+        {
+            var pos = AudioVisualizer.FindDataBelowThresholdForwardForEnd(volume, silenceLengthInSeconds, endSeconds);
+            if (pos < 0 || pos >= endSeconds + 1)
+            {
+                continue;
+            }
+
+            // A slightly higher threshold that still lands inside the same silence is the
+            // better guess - it sits closer to the speech.
+            var pos2 = AudioVisualizer.FindDataBelowThresholdForwardForEnd(volume + 0.3, silenceLengthInSeconds, endSeconds);
+            if (pos2 >= 0 && pos2 < pos && pos2 * TimeCode.BaseUnit > startMs)
+            {
+                pos = pos2;
+            }
+
+            var newEndMs = pos * TimeCode.BaseUnit + Se.Settings.Waveform.GuessEndOffsetMs;
+            if (next != null && newEndMs + gapMs > next.StartTime.TotalMilliseconds)
+            {
+                newEndMs = next.StartTime.TotalMilliseconds - gapMs;
+                if (newEndMs <= endMs)
+                {
+                    break; // cannot move the end time
+                }
+            }
+
+            var shotChanges = AudioVisualizer.ShotChanges;
+            if (shotChanges.Count > 0)
+            {
+                var nearestShotChange = shotChanges
+                    .Where(sc => sc > endSeconds - 0.2 && sc < endSeconds + 0.3)
+                    .OrderBy(sc => Math.Abs(sc - endSeconds))
+                    .Take(1)
+                    .ToList();
+                if (nearestShotChange.Count > 0)
+                {
+                    var shotChangeEndMs = nearestShotChange[0] * TimeCode.BaseUnit - TimeCodesBeautifierUtils.GetOutCuesGapMs();
+                    if (shotChangeEndMs > startMs &&
+                        (next == null || shotChangeEndMs + gapMs <= next.StartTime.TotalMilliseconds))
+                    {
+                        newEndMs = shotChangeEndMs;
+                    }
+                }
+            }
+
+            if (newEndMs < endMs)
+            {
+                // Shorten only as far as the minimum duration and maximum CPS allow.
+                var minEndMs = startMs + Se.Settings.General.SubtitleMinimumDisplayMilliseconds;
+                var maxCps = Se.Settings.General.SubtitleMaximumCharactersPerSeconds;
+                if (maxCps > 0)
+                {
+                    var newEnd = TimeSpanExtensions.FromMillisecondsWholeMilliseconds(newEndMs);
+                    var cps = SubtitleTextInfoHelper.GetCharactersPerSecond(selected.Text, selected.StartTime, newEnd);
+                    if (cps > maxCps)
+                    {
+                        var characters = cps * (newEndMs - startMs) / TimeCode.BaseUnit;
+                        minEndMs = Math.Max(minEndMs, startMs + characters / maxCps * TimeCode.BaseUnit);
+                    }
+                }
+
+                if (newEndMs < minEndMs)
+                {
+                    newEndMs = Math.Min(minEndMs, endMs);
+                }
+            }
+
+            if (newEndMs <= startMs || Math.Abs(endMs - newEndMs) < 10)
+            {
+                break; // nothing sensible to do / difference too small
+            }
+
+            selected.EndTime = TimeSpanExtensions.FromMillisecondsWholeMilliseconds(newEndMs);
             _updateAudioVisualizer = true;
             break;
         }

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -573,6 +573,10 @@ public class SettingsPage : UserControl
                 0, 10, 120, _vm, nameof(_vm.WaveformSnapToShotChangeEndMaxSeconds), defaultValue: 1.5m)),
             new SettingsItem(Se.Language.Options.Settings.WaveformSnapToShotChangeSameShotEndMaxSeconds, () => UiUtil.MakeNumericUpDownOneDecimal(
                 0, 10, 120, _vm, nameof(_vm.WaveformSnapToShotChangeSameShotEndMaxSeconds), defaultValue: 0.5m)),
+            new SettingsItem(Se.Language.Options.Settings.WaveformGuessStartOffsetMs, () => UiUtil.MakeNumericUpDownInt(
+                0, 1000, 0, 120, _vm, nameof(_vm.WaveformGuessStartOffsetMs))),
+            new SettingsItem(Se.Language.Options.Settings.WaveformGuessEndOffsetMs, () => UiUtil.MakeNumericUpDownInt(
+                0, 1000, 0, 120, _vm, nameof(_vm.WaveformGuessEndOffsetMs))),
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformShotChangesAutoGenerate, nameof(_vm.WaveformShotChangesAutoGenerate)),
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformFocusOnMouseOver, nameof(_vm.WaveformFocusOnMouseOver)),
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformFocusTextboxAfterInsertNew, nameof(_vm.WaveformFocusTextboxAfterInsertNew)),

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -326,6 +326,8 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private decimal _waveformSnapToShotChangeStartMaxSeconds;
     [ObservableProperty] private decimal _waveformSnapToShotChangeEndMaxSeconds;
     [ObservableProperty] private decimal _waveformSnapToShotChangeSameShotEndMaxSeconds;
+    [ObservableProperty] private int _waveformGuessStartOffsetMs;
+    [ObservableProperty] private int _waveformGuessEndOffsetMs;
     [ObservableProperty] private bool _waveformShotChangesAutoGenerate;
     [ObservableProperty] private bool _waveformAllowOverlap;
     [ObservableProperty] private bool _waveformSetVideoPositionOnMoveStartEnd;
@@ -1031,6 +1033,8 @@ public partial class SettingsViewModel : ObservableObject
         WaveformSnapToShotChangeStartMaxSeconds = (decimal)Se.Settings.Waveform.SnapToShotChangeStartMaxSeconds;
         WaveformSnapToShotChangeEndMaxSeconds = (decimal)Se.Settings.Waveform.SnapToShotChangeEndMaxSeconds;
         WaveformSnapToShotChangeSameShotEndMaxSeconds = (decimal)Se.Settings.Waveform.SnapToShotChangeSameShotEndMaxSeconds;
+        WaveformGuessStartOffsetMs = Se.Settings.Waveform.GuessStartOffsetMs;
+        WaveformGuessEndOffsetMs = Se.Settings.Waveform.GuessEndOffsetMs;
         WaveformShotChangesAutoGenerate = Se.Settings.Waveform.ShotChangesAutoGenerate;
         WaveformAllowOverlap = Se.Settings.Waveform.AllowOverlap;
         WaveformSetVideoPositionOnMoveStartEnd = Se.Settings.Waveform.SetVideoPositionOnMoveStartEnd;
@@ -1882,6 +1886,8 @@ public partial class SettingsViewModel : ObservableObject
         Se.Settings.Waveform.SnapToShotChangeStartMaxSeconds = (double)WaveformSnapToShotChangeStartMaxSeconds;
         Se.Settings.Waveform.SnapToShotChangeEndMaxSeconds = (double)WaveformSnapToShotChangeEndMaxSeconds;
         Se.Settings.Waveform.SnapToShotChangeSameShotEndMaxSeconds = (double)WaveformSnapToShotChangeSameShotEndMaxSeconds;
+        Se.Settings.Waveform.GuessStartOffsetMs = WaveformGuessStartOffsetMs;
+        Se.Settings.Waveform.GuessEndOffsetMs = WaveformGuessEndOffsetMs;
         Se.Settings.Waveform.ShotChangesAutoGenerate = WaveformShotChangesAutoGenerate;
         Se.Settings.Waveform.AllowOverlap = WaveformAllowOverlap;
         Se.Settings.Waveform.SetVideoPositionOnMoveStartEnd = WaveformSetVideoPositionOnMoveStartEnd;

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -138,6 +138,8 @@ public class LanguageSettings
     public string WaveformSnapToShotChangeStartMaxSeconds { get; set; }
     public string WaveformSnapToShotChangeEndMaxSeconds { get; set; }
     public string WaveformSnapToShotChangeSameShotEndMaxSeconds { get; set; }
+    public string WaveformGuessStartOffsetMs { get; set; }
+    public string WaveformGuessEndOffsetMs { get; set; }
     public string WaveformShotChangesAutoGenerate { get; set; }
     public string WaveformTextFontSize { get; set; }
     public string WaveformTextFontBold { get; set; }
@@ -480,6 +482,8 @@ public class LanguageSettings
         WaveformSnapToShotChangeStartMaxSeconds = "Snap to nearest shot change: max start distance (seconds)";
         WaveformSnapToShotChangeEndMaxSeconds = "Snap to nearest shot change: max end distance (seconds)";
         WaveformSnapToShotChangeSameShotEndMaxSeconds = "Snap to nearest shot change: max end distance when start and end share a cut (seconds)";
+        WaveformGuessStartOffsetMs = "Guess start time from waveform: place start earlier by (ms)";
+        WaveformGuessEndOffsetMs = "Guess end time from waveform: place end later by (ms)";
         WaveformShotChangesAutoGenerate = "Shot changes auto-generate";
         WaveformTextFontSize = "Waveform text font size";
         WaveformTextFontBold = "Waveform text font bold";

--- a/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
@@ -185,6 +185,7 @@ public class LanguageSettingsShortcuts
     public string SeekSilenceBack { get; set; }
     public string SeekSilenceForward { get; set; }
     public string WaveformGuessStart { get; set; }
+    public string WaveformGuessEnd { get; set; }
     public string SetVideoPositionCurrentSubtitleStart { get; set; }
     public string GoToSubtitlePositionAndPause { get; set; }
     public string SetVideoPositionCurrentSubtitleEnd { get; set; }
@@ -464,6 +465,7 @@ public class LanguageSettingsShortcuts
         SeekSilenceBack = "Seek silence back";
         SeekSilenceForward = "Seek silence forward";
         WaveformGuessStart = "Guess start time from waveform";
+        WaveformGuessEnd = "Guess end time from waveform";
         SetVideoPositionCurrentSubtitleStart = "Set video position to current line start";
         GoToSubtitlePositionAndPause = "Go to sub position and pause";
         SetVideoPositionCurrentSubtitleEnd = "Set video position to current line end";

--- a/src/ui/Logic/Config/SeWaveform.cs
+++ b/src/ui/Logic/Config/SeWaveform.cs
@@ -68,6 +68,11 @@ public class SeWaveform
     public int GuessTimeCodeScanBlockAverageMin { get; set; }
     public int GuessTimeCodeScanBlockAverageMax { get; set; }
     public int GuessTimeCodeSplitLongSubtitlesAtMs { get; set; }
+    // "Guess start/end time from waveform": how far from the detected speech boundary the cue is
+    // placed - start moved earlier, end moved later - so users who feel the guess sits too tight
+    // against the audio can pad it (#14472). A shot change snap replaces the padded position.
+    public int GuessStartOffsetMs { get; set; }
+    public int GuessEndOffsetMs { get; set; }
     public double SeekSilenceMinDurationSeconds { get; set; }
     public double SeekSilenceMaxVolume { get; set; }
     public bool SeekSilenceSeekForward { get; set; }
@@ -153,6 +158,8 @@ public class SeWaveform
         GuessTimeCodeScanBlockAverageMax = 70;
         GuessTimeCodeSplitLongSubtitlesAtMs = 3500;
 
+        GuessStartOffsetMs = 0;
+        GuessEndOffsetMs = 0;
         SeekSilenceSeekForward = true;
         SeekSilenceMinDurationSeconds = 0.3;
         SeekSilenceMaxVolume = 0.1;

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -375,6 +375,7 @@ public static class ShortcutsMain
         { nameof(MainViewModel.SeekSilenceBackCommand),  Se.Language.Options.Shortcuts.SeekSilenceBack },
         { nameof(MainViewModel.SeekSilenceForwardCommand),  Se.Language.Options.Shortcuts.SeekSilenceForward },
         { nameof(MainViewModel.WaveformGuessStartCommand),  Se.Language.Options.Shortcuts.WaveformGuessStart },
+        { nameof(MainViewModel.WaveformGuessEndCommand),  Se.Language.Options.Shortcuts.WaveformGuessEnd },
         { nameof(MainViewModel.ShowShotChangesListCommand),  Se.Language.General.ShowShotChangesList },
         { nameof(MainViewModel.VideoUndockControlsCommand),  Se.Language.Options.Shortcuts.UndockVideoControls },
         { nameof(MainViewModel.VideoRedockControlsCommand),  Se.Language.Options.Shortcuts.RedockVideoControls },
@@ -809,7 +810,12 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.ShowWaveformSeekSilenceCommand, nameof(vm.ShowWaveformSeekSilenceCommand), ShortcutCategory.Waveform);
         AddShortcut(shortcuts, vm.SeekSilenceBackCommand, nameof(vm.SeekSilenceBackCommand), ShortcutCategory.Waveform);
         AddShortcut(shortcuts, vm.SeekSilenceForwardCommand, nameof(vm.SeekSilenceForwardCommand), ShortcutCategory.Waveform);
-        AddShortcut(shortcuts, vm.WaveformGuessStartCommand, nameof(vm.WaveformGuessStartCommand), ShortcutCategory.Waveform);
+        // General, not Waveform: "guess start/end" act on the selected line, not on a waveform
+        // selection, and as Waveform shortcuts they only fired while the waveform had keyboard
+        // focus - which it rarely has, so the shortcut seemed to work "one time in ten" (#14472).
+        // SE 4 dispatched "guess start" from the main form regardless of focus.
+        AddShortcut(shortcuts, vm.WaveformGuessStartCommand, nameof(vm.WaveformGuessStartCommand), ShortcutCategory.General, ShortcutGroup.Waveform);
+        AddShortcut(shortcuts, vm.WaveformGuessEndCommand, nameof(vm.WaveformGuessEndCommand), ShortcutCategory.General, ShortcutGroup.Waveform);
         AddShortcut(shortcuts, vm.GoToPreviousShotChangeCommand, nameof(vm.GoToPreviousShotChangeCommand), ShortcutCategory.General, ShortcutGroup.Video);
         AddShortcut(shortcuts, vm.GoToNextShotChangeCommand, nameof(vm.GoToNextShotChangeCommand), ShortcutCategory.General, ShortcutGroup.Video);
         AddShortcut(shortcuts, vm.ShowVideoChaptersCommand, nameof(vm.ShowVideoChaptersCommand), ShortcutCategory.General, ShortcutGroup.Video);

--- a/tests/UI/Features/Main/Se4GuessStartAndUnderlineTests.cs
+++ b/tests/UI/Features/Main/Se4GuessStartAndUnderlineTests.cs
@@ -5,11 +5,13 @@ using Microsoft.Extensions.DependencyInjection;
 using Nikse.SubtitleEdit;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Options.Shortcuts;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace UITests.Features.Main;
@@ -22,10 +24,14 @@ public class Se4GuessStartAndUnderlineTests : IDisposable
 {
     private readonly List<Window> _windows = new();
     private readonly bool _timeCodesLocked = Se.Settings.General.LockTimeCodes;
+    private readonly int _guessStartOffsetMs = Se.Settings.Waveform.GuessStartOffsetMs;
+    private readonly int _guessEndOffsetMs = Se.Settings.Waveform.GuessEndOffsetMs;
 
     public void Dispose()
     {
         Se.Settings.General.LockTimeCodes = _timeCodesLocked;
+        Se.Settings.Waveform.GuessStartOffsetMs = _guessStartOffsetMs;
+        Se.Settings.Waveform.GuessEndOffsetMs = _guessEndOffsetMs;
         foreach (var window in _windows)
         {
             window.Close();
@@ -109,6 +115,127 @@ public class Se4GuessStartAndUnderlineTests : IDisposable
         var line = vm.Subtitles[0];
         Assert.InRange(line.StartTime.TotalMilliseconds, 2400, 2500);
         Assert.Equal(3800, line.EndTime.TotalMilliseconds, 0);
+    }
+
+    /// <summary>
+    /// #14472: the guessed start "feels too close to the waveform" for some users - the offset
+    /// setting pads the detected boundary by moving the start earlier.
+    /// </summary>
+    [AvaloniaFact]
+    public void GuessStartHonorsTheOffsetSetting()
+    {
+        Se.Settings.General.LockTimeCodes = false;
+        Se.Settings.Waveform.GuessStartOffsetMs = 100;
+
+        var (window, vm) = CreateMainViewModel();
+        vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph("Hello", 2200, 3800), null!) { Number = 1 });
+        Dispatcher.UIThread.RunJobs();
+
+        var av = vm.AudioVisualizer!;
+        av.WavePeaks = MakePeaks(sampleRate: 100, seconds: 6, speechFromSeconds: 2.5, speechToSeconds: 4.0);
+        Select(vm, vm.Subtitles[0]);
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        vm.WaveformGuessStartCommand.Execute(null);
+
+        Assert.InRange(vm.Subtitles[0].StartTime.TotalMilliseconds, 2300, 2400);
+    }
+
+    /// <summary>
+    /// "Guess end" (#14472): a cue that ends inside the silence after the speech is pulled back to
+    /// just after the speech stops.
+    /// </summary>
+    [AvaloniaFact]
+    public void GuessEndMovesTheEndCueToJustAfterTheSpeech()
+    {
+        Se.Settings.General.LockTimeCodes = false;
+        Se.Settings.Waveform.GuessEndOffsetMs = 0;
+
+        var (window, vm) = CreateMainViewModel();
+        vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph("Hello", 2500, 4600), null!) { Number = 1 });
+        Dispatcher.UIThread.RunJobs();
+
+        var av = vm.AudioVisualizer!;
+        av.WavePeaks = MakePeaks(sampleRate: 100, seconds: 7, speechFromSeconds: 2.5, speechToSeconds: 4.0);
+        Select(vm, vm.Subtitles[0]);
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        vm.WaveformGuessEndCommand.Execute(null);
+
+        var line = vm.Subtitles[0];
+        Assert.Equal(2500, line.StartTime.TotalMilliseconds, 0);
+        Assert.InRange(line.EndTime.TotalMilliseconds, 4000, 4100);
+    }
+
+    /// <summary>
+    /// A cue that ends while the speech is still going is extended to the silence after it.
+    /// </summary>
+    [AvaloniaFact]
+    public void GuessEndExtendsAnEndCueThatCutsTheSpeechShort()
+    {
+        Se.Settings.General.LockTimeCodes = false;
+        Se.Settings.Waveform.GuessEndOffsetMs = 0;
+
+        var (window, vm) = CreateMainViewModel();
+        vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph("Hello", 2500, 3500), null!) { Number = 1 });
+        Dispatcher.UIThread.RunJobs();
+
+        var av = vm.AudioVisualizer!;
+        av.WavePeaks = MakePeaks(sampleRate: 100, seconds: 7, speechFromSeconds: 2.5, speechToSeconds: 4.0);
+        Select(vm, vm.Subtitles[0]);
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        vm.WaveformGuessEndCommand.Execute(null);
+
+        Assert.InRange(vm.Subtitles[0].EndTime.TotalMilliseconds, 4000, 4100);
+    }
+
+    /// <summary>
+    /// The end never runs into the next line: it stops the minimum gap before it.
+    /// </summary>
+    [AvaloniaFact]
+    public void GuessEndStopsAtTheNextLine()
+    {
+        Se.Settings.General.LockTimeCodes = false;
+        Se.Settings.Waveform.GuessEndOffsetMs = 0;
+
+        var (window, vm) = CreateMainViewModel();
+        vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph("Hello", 2500, 3500), null!) { Number = 1 });
+        vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph("World", 3800, 5000), null!) { Number = 2 });
+        Dispatcher.UIThread.RunJobs();
+
+        var av = vm.AudioVisualizer!;
+        av.WavePeaks = MakePeaks(sampleRate: 100, seconds: 7, speechFromSeconds: 2.5, speechToSeconds: 4.0);
+        Select(vm, vm.Subtitles[0]);
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        vm.WaveformGuessEndCommand.Execute(null);
+
+        var gapMs = Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
+        Assert.Equal(3800 - gapMs, vm.Subtitles[0].EndTime.TotalMilliseconds, 0);
+    }
+
+    /// <summary>
+    /// #14472: as Waveform-category shortcuts "guess start/end" only fired while the waveform had
+    /// keyboard focus, which it rarely has - they must dispatch from anywhere like in SE 4.
+    /// </summary>
+    [AvaloniaFact]
+    public void GuessStartAndEndAreGeneralShortcuts()
+    {
+        var (_, vm) = CreateMainViewModel();
+
+        var all = ShortcutsMain.GetAllShortcuts(vm);
+        var start = all.Single(s => s.Name == nameof(MainViewModel.WaveformGuessStartCommand));
+        var end = all.Single(s => s.Name == nameof(MainViewModel.WaveformGuessEndCommand));
+
+        Assert.Equal(ShortcutCategory.General, start.Category);
+        Assert.Equal(ShortcutCategory.General, end.Category);
+        Assert.Equal(ShortcutGroup.Waveform, start.Group);
+        Assert.Equal(ShortcutGroup.Waveform, end.Group);
     }
 
     [AvaloniaFact]


### PR DESCRIPTION
Fixes #14472

## Why the shortcut "only worked one or two times out of ten"

"Guess start time from waveform" was registered as a **Waveform**-category shortcut, so it only dispatched while the waveform control had keyboard focus. The waveform rarely has focus (`FocusOnMouseOver` is off by default and the control does not focus itself on click), so the shortcut only fired after an incidental click on it. SE 4 handled the key on the main form regardless of focus.

The shortcut is now **General** (still listed under the Waveform group in Options > Shortcuts), the same move #11744 made for the shot change commands. Saved key bindings are unaffected: the category comes from the registry, not from the settings file.

## Adjustable tolerance

Options > Settings > Waveform gets two new settings (default 0):

- **Guess start time from waveform: place start earlier by (ms)**
- **Guess end time from waveform: place end later by (ms)**

They pad the detected speech boundary. A nearby shot change still wins over the padded position. While here, the shot change snap in "guess start" no longer lets the start run into the previous line's minimum gap.

## New shortcut: "Guess end time from waveform"

The mirror of "guess start" (no default key). `AudioVisualizer.FindDataBelowThresholdForwardForEnd` finds where the speech around the end cue stops:

- end cue sits in real silence → pulled back to just after the speech stops (searched up to 1 s back)
- end cue cuts the speech short, or sits in a pause too short to count as silence → pushed out to the first real silence after it (up to 1 s ahead)

Same threshold sweep as the start. Shortening never breaks the minimum duration / maximum CPS rules (the end is pulled in only as far as those allow), lengthening stops at the next line's gap, and a shot change within reach lands the end the out-cue gap before the cut.

## Tests

`Se4GuessStartAndUnderlineTests`: 5 new tests (start offset honored; guess end pulls back / extends / stops at next line; both shortcuts are General with the Waveform group). All 8 in the class and the 153 shortcut tests pass.

Docs: shortcut tables in `audio-visualizer.md` and `keyboard-shortcuts.md`, settings list in `settings.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
