### PR TITLE
Merge with a read-only original: stop churning the whole reference projection

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -3285,8 +3285,91 @@ public partial class MainViewModel :
     }
 
     /// <summary>
-    /// Runs <paramref name="action"/> with the display-only reference rows pulled out of the grid,
-    /// then re-derives them.
+    /// The stretch of rows <see cref="WithoutReferenceOnlyRows"/> has to clear of display-only
+    /// reference rows: the selected rows, plus the runs of reference rows immediately before and
+    /// after them. The structural commands reach exactly one row beyond the selection - merge with
+    /// the line before/after, "move text to next line" splitting into the following row - so
+    /// clearing those runs is what makes <c>Subtitles[index - 1]</c> and <c>Subtitles[index + 1]</c>
+    /// the working rows they are meant to be, and the selection itself contiguous.
+    ///
+    /// Returns the whole grid when nothing is selected, so a caller without a selection keeps the
+    /// old clear-everything behavior rather than silently running against reference rows.
+    /// </summary>
+    private (int Start, int End) GetReferenceDetachWindow()
+    {
+        if (Subtitles.Count == 0)
+        {
+            return (0, Subtitles.Count - 1);
+        }
+
+        // Both sources: the multi-row commands read the grid's selection, the single-row ones
+        // (merge with the line before/after, move text to the next line) read SelectedSubtitle,
+        // and the two can disagree - the grid has not necessarily pushed a programmatic selection
+        // into SelectedItems yet. Taking the union keeps the window over whatever the command is
+        // about to touch.
+        var selected = SubtitleGrid.SelectedItems;
+        var count = selected?.Count ?? 0;
+        var wanted = new HashSet<SubtitleLineViewModel>(count + 1);
+        for (var i = 0; i < count; i++)
+        {
+            if (selected![i] is SubtitleLineViewModel line)
+            {
+                wanted.Add(line);
+            }
+        }
+
+        if (SelectedSubtitle is { } current)
+        {
+            wanted.Add(current);
+        }
+
+        if (wanted.Count == 0)
+        {
+            return (0, Subtitles.Count - 1);
+        }
+
+        var first = -1;
+        var last = -1;
+        var found = 0;
+        for (var i = 0; i < Subtitles.Count && found < wanted.Count; i++)
+        {
+            if (!wanted.Contains(Subtitles[i]))
+            {
+                continue;
+            }
+
+            found++;
+            if (first < 0)
+            {
+                first = i;
+            }
+
+            last = i;
+        }
+
+        if (first < 0)
+        {
+            return (0, Subtitles.Count - 1);
+        }
+
+        // Widen over the reference rows hugging the selection - a run, not a single row: several
+        // original lines can sit between two translated ones.
+        while (first > 0 && Subtitles[first - 1].IsReferenceOnly)
+        {
+            first--;
+        }
+
+        while (last + 1 < Subtitles.Count && Subtitles[last + 1].IsReferenceOnly)
+        {
+            last++;
+        }
+
+        return (first, last);
+    }
+
+    /// <summary>
+    /// Runs <paramref name="action"/> with the display-only reference rows around the selection
+    /// pulled out of the grid, then re-derives them.
     ///
     /// Structural commands walk Subtitles by index and assume every row is a line of the working
     /// subtitle - merge in particular requires the selected rows to sit at consecutive indexes, so a
@@ -3294,6 +3377,10 @@ public partial class MainViewModel :
     /// reference row would have swallowed it and stretched the surviving line over its span. Taking
     /// the reference rows out for the duration means none of those commands has to know that the
     /// reference exists (#13449).
+    ///
+    /// Only the rows in <see cref="GetReferenceDetachWindow"/> come out - the ones the command can
+    /// reach. The reference rows elsewhere in the file are invisible to it either way (its indexes
+    /// never go near them), and moving them is what made merging slow (#14003, #14468).
     /// </summary>
     private void WithoutReferenceOnlyRows(Action action)
     {
@@ -3306,11 +3393,21 @@ public partial class MainViewModel :
         // Capture before the rows go: an editable original keeps its non-matching lines only in them.
         CaptureOriginalFromRows();
 
+        // Taking a reference row out is not free: the removal and the re-insert are two change
+        // notifications each on the collection the grid is bound to, and the grid answers them by
+        // re-estimating its extent and chasing its selection anchor with a ScrollIntoView that
+        // walks row by row. A read-only original gains one display-only row per merge - the line
+        // the merged-away row displayed comes back - so clearing all of them cost twice their
+        // number of notifications on every merge and got worse with every merge the user made:
+        // the grid crawling up and back down that #14003 re-reported against 5.2.0-rc1 as #14468.
+        // Only the ones the command can actually reach come out.
+        var (windowStart, windowEnd) = GetReferenceDetachWindow();
+
         // Detach the row instances rather than dropping them: they carry the user's edits (editable
         // original) and their sticky link to the original line, and putting the same instances back
         // means the reference does not visibly rebuild after every merge (#13594).
         var detached = new List<SubtitleLineViewModel>();
-        for (var i = Subtitles.Count - 1; i >= 0; i--)
+        for (var i = windowEnd; i >= windowStart; i--)
         {
             if (Subtitles[i].IsReferenceOnly)
             {
@@ -20720,8 +20817,25 @@ public partial class MainViewModel :
             _pendingScrollItem = row;
         }
 
+        // From here until the scroll below has run, this scroll owns the offset: the row it names
+        // is what the view is going to show, so nothing else may move the view in the meantime.
+        // What otherwise does is TableViewScrollAnchor. The callers that post a scroll are the ones
+        // that just restructured the grid, and the layout that settles those row changes runs in
+        // this very gap - the anchor sees the panel re-estimate its extent, reads it as "the panel
+        // moved under the view", and hauls the view back to whatever row was on top before,
+        // realizing rows one by one on the way (its restore ends in a ScrollIntoView, and a
+        // virtualizing panel walks when the estimate has drifted). The scroll below then sets off
+        // for the target from wherever that left it. That tug of war is the grid scrolling up and
+        // then down again after a merge with a read-only original open, and it gets longer with
+        // every display-only reference row the merges leave behind (#13962, #14003, #14468).
+        // Suspending leaves the anchor following the view, it just stops it moving it, and it is
+        // live again for the next edit - which is what it exists for (#13619).
+        var anchorSuspension = SubtitleGrid is { } grid ? TableViewScrollAnchor.GetFor(grid)?.Suspend() : null;
+
         Dispatcher.UIThread.Post(() =>
         {
+            using var heldAnchor = anchorSuspension;
+
             int indexToScroll;
             SubtitleLineViewModel? itemToResolve;
             lock (_scrollLock)

--- a/tests/UI/Features/Main/MergeWithReadOnlyReferenceTests.cs
+++ b/tests/UI/Features/Main/MergeWithReadOnlyReferenceTests.cs
@@ -1,0 +1,270 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Main.MainHelpers;
+using Nikse.SubtitleEdit.Logic;
+using System.Collections.Specialized;
+using System.Reflection;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// Merging lines while a read-only original is open. Every merge leaves one more display-only
+/// reference row behind - the line the merged-away row displayed comes back, the file being
+/// authoritative - so anything a merge does per reference row gets slower with every merge the
+/// user makes. That is what made the grid crawl up and back down after each merge, reported as
+/// #13962, re-reported as #14003 and again against 5.2.0-rc1 as #14468.
+///
+/// <see cref="MainViewModel.WithoutReferenceOnlyRows"/> therefore only detaches the reference rows
+/// the command can reach, and the posted scroll owns the offset while it is pending.
+/// </summary>
+public class MergeWithReadOnlyReferenceTests
+{
+    /// <summary>
+    /// The regression test for the slowdown: a merge nowhere near the reference rows must not
+    /// touch them. Before, every one of them was removed and re-inserted on the collection the
+    /// grid is bound to - two change notifications each, per merge, growing with every merge.
+    /// </summary>
+    [AvaloniaFact]
+    public void Merge_DoesNotChurnTheReferenceRowsItCannotReach()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            // 40 working rows, and a reference with 20 extra lines - all of them up at the top,
+            // far from the rows merged down at the bottom.
+            for (var i = 0; i < 40; i++)
+            {
+                AddLine(vm, "Translated " + i, i * 10000, i * 10000 + 5000);
+            }
+
+            var reference = new Subtitle();
+            for (var i = 0; i < 40; i++)
+            {
+                reference.Paragraphs.Add(new Paragraph("Reference " + i, i * 10000, i * 10000 + 5000));
+                if (i < 20)
+                {
+                    reference.Paragraphs.Add(new Paragraph("Reference only " + i, i * 10000 + 6000, i * 10000 + 7000));
+                }
+            }
+
+            vm.ShowColumnOriginalText = true;
+            ImportReference(vm, reference);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(vm.IsShowingOriginalNonMatchingLines);
+            Assert.True(vm.IsOriginalReadOnly);
+            Assert.Equal(20, CountReferenceRows(vm));
+
+            var changes = 0;
+            void OnChanged(object? _, NotifyCollectionChangedEventArgs __) => changes++;
+            vm.Subtitles.CollectionChanged += OnChanged;
+            try
+            {
+                vm.SelectedSubtitle = vm.Subtitles[^2];
+                SelectInGrid(vm, vm.Subtitles[^2]);
+                vm.MergeWithLineAfterCommand.Execute(null);
+                Dispatcher.UIThread.RunJobs();
+            }
+            finally
+            {
+                vm.Subtitles.CollectionChanged -= OnChanged;
+            }
+
+            // The merge itself removes one row and the refresh brings the merged-away original
+            // line back as one more reference row. Detaching the 20 untouched reference rows and
+            // putting them back would add 40 notifications on top of that.
+            Assert.True(changes <= 5, $"the merge raised {changes} collection changes - it is still churning the reference rows");
+            Assert.Equal(21, CountReferenceRows(vm));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>
+    /// The reference rows the command <i>can</i> reach still have to come out: a merge whose two
+    /// rows have a display-only row between them must merge the two translated lines, not swallow
+    /// the reference row and stretch the survivor over its span (#13449).
+    /// </summary>
+    [AvaloniaFact]
+    public void MergeWithLineAfter_SkipsAReferenceRowSittingBetweenTheTwoLines()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Translated one", 0, 2000);
+            AddLine(vm, "Translated two", 4000, 6000);
+
+            var reference = new Subtitle();
+            reference.Paragraphs.Add(new Paragraph("Reference one", 0, 2000));
+            reference.Paragraphs.Add(new Paragraph("Reference only", 2000, 4000));
+            reference.Paragraphs.Add(new Paragraph("Reference two", 4000, 6000));
+
+            vm.ShowColumnOriginalText = true;
+            ImportReference(vm, reference);
+            Dispatcher.UIThread.RunJobs();
+
+            // grid: [Translated one] [Reference only] [Translated two]
+            Assert.True(vm.Subtitles[1].IsReferenceOnly);
+
+            vm.SelectedSubtitle = vm.Subtitles[0];
+            SelectInGrid(vm, vm.Subtitles[0]);
+            vm.MergeWithLineAfterCommand.Execute(null);
+            Dispatcher.UIThread.RunJobs();
+
+            var working = vm.Subtitles.Where(r => !r.IsReferenceOnly).ToList();
+            Assert.Single(working);
+            Assert.Contains("Translated one", working[0].Text);
+            Assert.Contains("Translated two", working[0].Text);
+            Assert.Equal(6000, working[0].EndTime.TotalMilliseconds);
+
+            // The line the merged-away row displayed is back, next to the one that never matched.
+            Assert.Equal(2, CountReferenceRows(vm));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>
+    /// The same one row up: "merge with line before" must reach past a display-only row to the
+    /// previous translated line.
+    /// </summary>
+    [AvaloniaFact]
+    public void MergeWithLineBefore_SkipsAReferenceRowSittingBetweenTheTwoLines()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Translated one", 0, 2000);
+            AddLine(vm, "Translated two", 4000, 6000);
+
+            var reference = new Subtitle();
+            reference.Paragraphs.Add(new Paragraph("Reference one", 0, 2000));
+            reference.Paragraphs.Add(new Paragraph("Reference only", 2000, 4000));
+            reference.Paragraphs.Add(new Paragraph("Reference two", 4000, 6000));
+
+            vm.ShowColumnOriginalText = true;
+            ImportReference(vm, reference);
+            Dispatcher.UIThread.RunJobs();
+
+            var second = vm.Subtitles.Last(r => !r.IsReferenceOnly);
+            vm.SelectedSubtitle = second;
+            SelectInGrid(vm, second);
+            vm.MergeWithLineBeforeCommand.Execute(null);
+            Dispatcher.UIThread.RunJobs();
+
+            var working = vm.Subtitles.Where(r => !r.IsReferenceOnly).ToList();
+            Assert.Single(working);
+            Assert.Contains("Translated one", working[0].Text);
+            Assert.Contains("Translated two", working[0].Text);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>
+    /// The scroll a command posts owns the offset until it has run: the scroll anchor would
+    /// otherwise correct the extent the restructured rows re-estimate and haul the view back to
+    /// the row that was on top, only for the posted scroll to travel to the target again. The
+    /// suspension must not leak, or ordinary editing stops holding the view steady (#13619).
+    /// </summary>
+    [AvaloniaFact]
+    public void PostedScroll_HoldsTheScrollAnchorUntilItHasRun()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Translated one", 0, 2000);
+            AddLine(vm, "Translated two", 4000, 6000);
+            Dispatcher.UIThread.RunJobs();
+
+            var anchor = TableViewScrollAnchor.GetFor(vm.SubtitleGrid);
+            Assert.NotNull(anchor);
+            Assert.Equal(0, SuspendCountOf(anchor!));
+
+            InvokeSelectAndScrollToRow(vm, vm.Subtitles[1]);
+            Assert.True(SuspendCountOf(anchor!) > 0, "the posted scroll did not take the anchor");
+
+            Dispatcher.UIThread.RunJobs();
+            Assert.Equal(0, SuspendCountOf(anchor!));
+
+            // Twice: a leak would stack.
+            InvokeSelectAndScrollToRow(vm, vm.Subtitles[0]);
+            Dispatcher.UIThread.RunJobs();
+            Assert.Equal(0, SuspendCountOf(anchor!));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    private static int CountReferenceRows(MainViewModel vm) => vm.Subtitles.Count(r => r.IsReferenceOnly);
+
+    private static int SuspendCountOf(TableViewScrollAnchor anchor) =>
+        (int)typeof(TableViewScrollAnchor)
+            .GetField("_suspendCount", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(anchor)!;
+
+    private static void InvokeSelectAndScrollToRow(MainViewModel vm, SubtitleLineViewModel row) =>
+        typeof(MainViewModel)
+            .GetMethod(
+                "SelectAndScrollToRow",
+                BindingFlags.Instance | BindingFlags.NonPublic,
+                new[] { typeof(SubtitleLineViewModel), typeof(bool?) })!
+            .Invoke(vm, new object?[] { row, null });
+
+    // The detach window is read from the grid's selection, so the tests have to set it - assigning
+    // SelectedSubtitle alone leaves SubtitleGrid.SelectedItems empty.
+    private static void SelectInGrid(MainViewModel vm, SubtitleLineViewModel row)
+    {
+        vm.SubtitleGrid.SelectedItems?.Clear();
+        vm.SubtitleGrid.SelectedItem = row;
+    }
+
+    private static void ImportReference(MainViewModel vm, Subtitle reference)
+    {
+        var match = ImportOriginalHelper.MatchOriginalLines(vm.Subtitles, reference);
+        typeof(MainViewModel)
+            .GetMethod("ImportOriginalSubtitle", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(vm, new object?[] { 0, "reference.srt", reference, match, true });
+    }
+
+    private static SubtitleLineViewModel AddLine(MainViewModel vm, string text, int startMs, int endMs)
+    {
+        var line = new SubtitleLineViewModel(new Paragraph(text, startMs, endMs), null!)
+        {
+            Number = vm.Subtitles.Count + 1,
+        };
+
+        vm.Subtitles.Add(line);
+        return line;
+    }
+
+    private static (Window Window, MainViewModel Vm) CreateMainViewModel()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1200, Height = 800 };
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        var vm = (MainViewModel)view.DataContext!;
+        window.SuppressSaveChangesPromptOnClose(vm);
+        return (window, vm);
+    }
+}


### PR DESCRIPTION
Fixes #14003 — re-reported against 5.2.0-rc1 in https://github.com/SubtitleEdit/subtitleedit/issues/14468#issuecomment-5525073026:

> when merging, the subtitle grid still scrolls slowly up and then down again … merging gets slower and slower

## Why it kept coming back

Every merge with a read-only original leaves **one more display-only reference row** behind — the merged-away row's original line is unclaimed, the file is authoritative, so the refresh brings it back. `WithoutReferenceOnlyRows` then removed and re-inserted **every** reference row around the command, one at a time, on the collection the grid is bound to. That is two change notifications per reference row, per merge, growing with every merge already made.

Measured headlessly on 1000 lines, merging in the middle of the file:

| merges done | reference rows | collection changes | scroll steps | ms/merge |
|---|---|---|---|---|
| 1 | 2 | 4 | 3 | ~80 |
| 25 | 26 | 54 | 28 | ~570 |

The cost is not the notifications themselves. Tracing the scroll offset with stack captures, each merge ended in a **row-by-row walk** whose length tracked the reference-row count: `TableView` chasing its selection anchor (`SelectingItemsControl.ScrollToAnchorIndex` → `VirtualizingStackPanel.ScrollIntoView`), plus `TableViewScrollAnchor` answering the extent re-estimate with a full restore that hauls the view back to the row that was on top — only for the merge's own posted scroll to travel to the target again. That round trip is the "up, then down".

The #14008 fix suspended the anchor inside `ReapplyOriginalReference`. The churn is in `WithoutReferenceOnlyRows`, and the layout that settles it runs later still — after every `using` scope has been disposed — so it was never covered.

## The change

**1. `WithoutReferenceOnlyRows` only clears the reference rows the command can reach.** New `GetReferenceDetachWindow()` returns the selected rows plus the runs of reference rows immediately before and after them — which is exactly what makes `Subtitles[index - 1]` and `Subtitles[index + 1]` the working rows the structural commands mean, and the selection contiguous (#13449). Every caller reaches at most one working row beyond the selection (merge with the line before/after, the dialog and bilingual variants, "move text to next line" and its `InsertAfter`), so nothing else was ever visible to them. Falls back to clearing everything when there is no selection.

**2. `SelectAndScrollToRow` holds `TableViewScrollAnchor.Suspend()` for the whole life of the pending scroll**, from registering it to the end of the posted callback. The callers that post a scroll are the ones that just restructured the grid, and the settling layout falls in exactly that gap, so the anchor was correcting an extent the scroll was about to make irrelevant. It keeps *following* the view throughout — `Suspend` only stops it moving it — and is live again for the next edit, which is what it exists for (#13619).

After: **1–5 scroll steps and ~70–160 ms per merge, flat**, whatever the reference-row count. No row-by-row walks, and the merged row is fully visible after every merge.

## Tests

New `tests/UI/Features/Main/MergeWithReadOnlyReferenceTests.cs`:

- a merge far from the reference rows raises ≤ 5 collection changes, not 2 per reference row (the regression test for the slowdown);
- merge-with-line-after and merge-with-line-before still reach *past* a display-only row sitting between the two translated lines, and the merged-away line comes back;
- the posted scroll takes the anchor and releases it, twice over, so the suspension cannot leak.

Full UI suite: 4683 passed, 0 failed.

## Note on the alternative

Detaching `ItemsSource` for the duration was considered. `RemoveRowsAndSelectSurvivor` already does that, but only above 1000 rows, and its comment says why: *"the reattach re-realizes the rows and moves the scroll offset, which for an ordinary delete is exactly the jump this method avoids."* Reference-row counts here are dozens to hundreds, so a detach/reattach per merge would cause the very jump being fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)