### PR TITLE
Add waveform vertical zoom shortcuts to sync dialogs

### DIFF
--- a/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointViewModel.cs
+++ b/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointViewModel.cs
@@ -591,6 +591,41 @@ public partial class SetSyncPointViewModel : ObservableObject
             e.Handled = true;
             SetVideoPosition(CurrentPositionSeconds + 0.5);
         }
+        else if (e.Key == Key.Add && e.KeyModifiers.HasFlag(KeyModifiers.Shift))
+        {
+            e.Handled = true;
+            WaveformVerticalZoomIn();
+        }
+        else if (e.Key == Key.Subtract && e.KeyModifiers.HasFlag(KeyModifiers.Shift))
+        {
+            e.Handled = true;
+            WaveformVerticalZoomOut();
+        }
+    }
+
+    /// <summary>
+    /// Mirrors the main window's waveform vertical zoom (Shift +/-): scales the waveform's
+    /// amplitude in place instead of resizing the split panel, so zooming in does not eat into
+    /// the video area (#14419 comment).
+    /// </summary>
+    private void WaveformVerticalZoomIn()
+    {
+        if (!IsAudioVisualizerVisible)
+        {
+            return;
+        }
+
+        AudioVisualizer.VerticalZoomFactor = Math.Max(Math.Min(AudioVisualizer.VerticalZoomFactor - 0.1, AudioVisualizer.MaxZoomFactor), AudioVisualizer.MinZoomFactor);
+    }
+
+    private void WaveformVerticalZoomOut()
+    {
+        if (!IsAudioVisualizerVisible)
+        {
+            return;
+        }
+
+        AudioVisualizer.VerticalZoomFactor = Math.Max(Math.Min(AudioVisualizer.VerticalZoomFactor + 0.1, AudioVisualizer.MaxZoomFactor), AudioVisualizer.MinZoomFactor);
     }
 
     /// <summary>

--- a/src/ui/Features/Sync/VisualSync/VisualSyncViewModel.cs
+++ b/src/ui/Features/Sync/VisualSync/VisualSyncViewModel.cs
@@ -727,6 +727,16 @@ public partial class VisualSyncViewModel : ObservableObject
                 VideoPlayerControlLeft.Position += 0.5;
                 _updateAudioVisualizer = true;
             }
+            else if (e.Key == Key.Add && e.KeyModifiers.HasFlag(KeyModifiers.Shift))
+            {
+                e.Handled = true;
+                WaveformVerticalZoomIn(AudioVisualizerLeft);
+            }
+            else if (e.Key == Key.Subtract && e.KeyModifiers.HasFlag(KeyModifiers.Shift))
+            {
+                e.Handled = true;
+                WaveformVerticalZoomOut(AudioVisualizerLeft);
+            }
         }
         else if (IsRightFocused())
         {
@@ -759,6 +769,41 @@ public partial class VisualSyncViewModel : ObservableObject
                 VideoPlayerControlRight.Position += 0.5;
                 _updateAudioVisualizer = true;
             }
+            else if (e.Key == Key.Add && e.KeyModifiers.HasFlag(KeyModifiers.Shift))
+            {
+                e.Handled = true;
+                WaveformVerticalZoomIn(AudioVisualizerRight);
+            }
+            else if (e.Key == Key.Subtract && e.KeyModifiers.HasFlag(KeyModifiers.Shift))
+            {
+                e.Handled = true;
+                WaveformVerticalZoomOut(AudioVisualizerRight);
+            }
         }
+    }
+
+    /// <summary>
+    /// Mirrors the main window's waveform vertical zoom (Shift +/-) for whichever pane has focus:
+    /// scales that waveform's amplitude in place instead of resizing the split panel, so zooming
+    /// in does not eat into the video area (#14419 comment).
+    /// </summary>
+    private void WaveformVerticalZoomIn(AudioVisualizer audioVisualizer)
+    {
+        if (!IsAudioVisualizerVisible)
+        {
+            return;
+        }
+
+        audioVisualizer.VerticalZoomFactor = Math.Max(Math.Min(audioVisualizer.VerticalZoomFactor - 0.1, AudioVisualizer.MaxZoomFactor), AudioVisualizer.MinZoomFactor);
+    }
+
+    private void WaveformVerticalZoomOut(AudioVisualizer audioVisualizer)
+    {
+        if (!IsAudioVisualizerVisible)
+        {
+            return;
+        }
+
+        audioVisualizer.VerticalZoomFactor = Math.Max(Math.Min(audioVisualizer.VerticalZoomFactor + 0.1, AudioVisualizer.MaxZoomFactor), AudioVisualizer.MinZoomFactor);
     }
 }

--- a/src/ui/Features/Video/CutVideo/CutVideoViewModel.cs
+++ b/src/ui/Features/Video/CutVideo/CutVideoViewModel.cs
@@ -1209,6 +1209,8 @@ public partial class CutVideoViewModel : ObservableObject
             mainShortCuts.FirstOrDefault(p => p.Action == mainVm.PlayNextCommand),
             mainShortCuts.FirstOrDefault(p => p.Action == mainVm.TogglePlayPauseCommand),
             mainShortCuts.FirstOrDefault(p => p.Action == mainVm.TogglePlayPause2Command),
+            mainShortCuts.FirstOrDefault(p => p.Action == mainVm.WaveformVerticalZoomInCommand),
+            mainShortCuts.FirstOrDefault(p => p.Action == mainVm.WaveformVerticalZoomOutCommand),
         };
 
         foreach (var sc in shortcuts.Where(p => p != null))
@@ -1274,6 +1276,16 @@ public partial class CutVideoViewModel : ObservableObject
             return TogglePlayPauseCommand;
         }
 
+        if (action == mainVm.WaveformVerticalZoomInCommand)
+        {
+            return WaveformVerticalZoomInCommand;
+        }
+
+        if (action == mainVm.WaveformVerticalZoomOutCommand)
+        {
+            return WaveformVerticalZoomOutCommand;
+        }
+
         return null;
     }
 
@@ -1334,6 +1346,32 @@ public partial class CutVideoViewModel : ObservableObject
         SelectAndScrollToRow(idx + 1);
 
         _updateAudioVisualizer = true;
+    }
+
+    /// <summary>
+    /// Mirrors the main window's waveform vertical zoom (Shift +/-): scales the waveform's
+    /// amplitude in place, so zooming in for readability does not shrink the video (#14419 comment).
+    /// </summary>
+    [RelayCommand]
+    private void WaveformVerticalZoomIn()
+    {
+        if (AudioVisualizer == null)
+        {
+            return;
+        }
+
+        AudioVisualizer.VerticalZoomFactor = Math.Max(Math.Min(AudioVisualizer.VerticalZoomFactor - 0.1, AudioVisualizer.MaxZoomFactor), AudioVisualizer.MinZoomFactor);
+    }
+
+    [RelayCommand]
+    private void WaveformVerticalZoomOut()
+    {
+        if (AudioVisualizer == null)
+        {
+            return;
+        }
+
+        AudioVisualizer.VerticalZoomFactor = Math.Max(Math.Min(AudioVisualizer.VerticalZoomFactor + 0.1, AudioVisualizer.MaxZoomFactor), AudioVisualizer.MinZoomFactor);
     }
 
     [RelayCommand]


### PR DESCRIPTION
## Problem

#14419 added a drag-resizable splitter between the video and waveform in the Point sync (Set sync point) and Visual sync dialogs. [Feedback on that PR](https://github.com/SubtitleEdit/subtitleedit/pull/14419#issuecomment-5527868956) clarified that isn't quite what was wanted: making the waveform panel bigger there also shrinks the video. What was actually being asked for is the same behavior as the main window, where the waveform's vertical zoom (e.g. 136% → 500%) makes the waveform more readable without changing the video/waveform layout height at all.

## Fix

`AudioVisualizer` already scales its own amplitude in place via Shift+scroll-wheel (`OnPointerWheelChanged`), and since that's wired at the control level it already worked in these dialogs too - there was just no keyboard shortcut for it, unlike the main window's `Shift +`/`Shift -`.

This adds that keyboard parity to every dialog that pairs a video player with its own waveform:
- **Set sync point**: `Shift +` / `Shift -` zoom the dialog's waveform.
- **Visual sync**: same shortcuts, applied to whichever pane (left/right) currently has focus, matching the dialog's existing per-pane pattern for the Ctrl/Alt+Left/Right position shortcuts.
- **Cut video**: same shortcuts. This dialog already re-maps a whitelist of main-window shortcuts onto its own commands through the shared `ShortcutManager`, so this just adds the vertical-zoom entries to that whitelist.

All three reuse the exact clamping logic from `MainViewModel.WaveformVerticalZoomIn`/`WaveformVerticalZoomOut` and guard on the waveform actually being visible/available.

(Other windows that touch `AudioVisualizer` - Beautify time codes, Review speech (TTS) - don't pair it with a video player being squeezed, so they don't have the trade-off this addresses.)

## Tests

- Build succeeds with 0 warnings/errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)