### PR TITLE
Burn in Blu-ray sup subtitles from the image-based editor and in batch mode

### DIFF
--- a/docs/features/binary-edit.md
+++ b/docs/features/binary-edit.md
@@ -43,6 +43,8 @@ Under the image, **Set text** replaces the selected line's image with newly rend
 
 The File menu has **Import time codes...** (apply the timing of a text subtitle to the lines) next to Export, and the Synchronization menu offers **Adjust all times**, **Change frame rate**, and **Change speed**.
 
+**File → Generate video with burned-in subtitles...** burns the images into a video as they are, through the [burn-in](burn-in.md) dialog - the video in the player, or the one next to the subtitle file, or one you pick.
+
 ## Export
 
 There is no in-place save — use File → Export:

--- a/docs/features/burn-in.md
+++ b/docs/features/burn-in.md
@@ -37,6 +37,10 @@ Hardcode (burn-in) subtitles permanently into a video file using FFmpeg.
 - **Effect** — Browse button opening a picker with one entry to apply to every line: **Fix right-to-left**, **Fade in/out**, **Slow font size change**, **Increase font kerning**, **Scroll up**, **Scroll down**, **Rotate in**, **Tilt bounce** and **Font size bounce in**. The selected effect is shown next to the button
 - **Logo** — Browse button opening a dialog to pick a PNG watermark and place it by dragging it over the video; the file name and position are shown next to the button
 
+## Image-based subtitles
+
+A Blu-ray sup can be burned in as it is. Open it in **Edit image-based subtitle** and choose **File → Generate video with burned-in subtitles...**, or add a `.sup` file as the subtitle of a batch item (a `.sup` next to the video is picked up automatically, after `.srt` and `.ass`). The bitmaps are laid over the video with FFmpeg's overlay filter and scaled with it, so the result matches the exported file - lines that overlap in time are shown together, the way a Blu-ray shows them. The font settings do not apply to bitmaps and are hidden; the logo, resolution, cut and encoding settings work as for text.
+
 ## Video Settings
 
 - **Resolution** — Output video width and height

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -20404,67 +20404,12 @@ public partial class MainViewModel :
         _updateAudioVisualizer = true;
     }
 
-    private async Task<bool> RequireFfmpegOk()
+    private Task<bool> RequireFfmpegOk()
     {
-        if (FfmpegHelper.IsFfmpegInstalled())
-        {
-            return true;
-        }
-
-        if (File.Exists(DownloadFfmpegViewModel.GetFfmpegFileName()))
-        {
-            FfmpegHelper.SetFfmpegPath(DownloadFfmpegViewModel.GetFfmpegFileName());
-            return true;
-        }
-
-        // Use an ffmpeg on the system PATH before prompting to (re)download - issue #11760.
-        var systemFfmpeg = FfmpegHelper.GetSystemFfmpegPath();
-        if (!string.IsNullOrEmpty(systemFfmpeg))
-        {
-            FfmpegHelper.SetFfmpegPath(systemFfmpeg);
-            return true;
-        }
-
-        if (!OperatingSystem.IsWindows() && File.Exists("/usr/local/bin/ffmpeg"))
-        {
-            FfmpegHelper.SetFfmpegPath("/usr/local/bin/ffmpeg");
-            return true;
-        }
-
-        if (OperatingSystem.IsWindows() || OperatingSystem.IsMacOS())
-        {
-            var answer = await MessageBox.Show(
-                Window!,
-                Se.Language.Main.DownloadFfmpegTitle,
-                Se.Language.Main.DownloadFfmpegQuestion,
-                MessageBoxButtons.YesNoCancel,
-                MessageBoxIcon.Question);
-
-            if (answer != MessageBoxResult.Yes)
-            {
-                return false;
-            }
-
-            var result = await ShowDialogAsync<DownloadFfmpegWindow, DownloadFfmpegViewModel>();
-            if (!string.IsNullOrEmpty(result.FfmpegFileName))
-            {
-                FfmpegHelper.SetFfmpegPath(result.FfmpegFileName);
-                ShowStatus(string.Format(Se.Language.Main.FfmpegDownloadedAndInstalledToX, result.FfmpegFileName));
-                return true;
-            }
-
-            return false;
-        }
-
-        // No ffmpeg download on Linux - say what is missing instead of failing silently (#14390).
-        await MessageBox.Show(
+        return FfmpegRequirement.EnsureAsync(
             Window!,
-            Se.Language.Title,
-            Se.Language.Main.FfmpegNotFoundInstallHint,
-            MessageBoxButtons.OK,
-            MessageBoxIcon.Information);
-
-        return false;
+            async () => (await ShowDialogAsync<DownloadFfmpegWindow, DownloadFfmpegViewModel>()).FfmpegFileName,
+            message => ShowStatus(message));
     }
 
     private void PerformUndo()

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -18,6 +18,7 @@ using Nikse.SubtitleEdit.Core.Interfaces;
 using Nikse.SubtitleEdit.Core.VobSub;
 using Nikse.SubtitleEdit.Features.Ocr;
 using Nikse.SubtitleEdit.Features.Ocr.OcrSubtitle;
+using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryAdjustAllTimes;
 using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryApplyDurationLimits;
 using Nikse.SubtitleEdit.Features.Shared.PickMatroskaTrack;
@@ -25,6 +26,7 @@ using Nikse.SubtitleEdit.Features.Shared.PickMp4Track;
 using Nikse.SubtitleEdit.Features.Shared.PickTsTrack;
 using Nikse.SubtitleEdit.Features.Sync.ChangeFrameRate;
 using Nikse.SubtitleEdit.Features.Sync.ChangeSpeed;
+using Nikse.SubtitleEdit.Features.Video.BurnIn;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
@@ -1074,6 +1076,69 @@ public partial class BinaryEditViewModel : ObservableObject
         await DoExport(new ExportHandlerBluRaySup(), ".sup");
     }
 
+    /// <summary>
+    /// Burns the loaded images into a video. They are written to a temporary Blu-ray sup that the
+    /// burn-in dialog overlays through ffmpeg, so the video gets the exported look - overlapping
+    /// lines included (issue #14456). The text settings mean nothing for bitmaps, so the dialog
+    /// hides them. The video is the one in the player, else the one next to the subtitle, else
+    /// asked for.
+    /// </summary>
+    [RelayCommand]
+    private async Task GenerateBurnIn()
+    {
+        if (Window == null || Subtitles.Count == 0)
+        {
+            return;
+        }
+
+        var ffmpegOk = await FfmpegRequirement.EnsureAsync(
+            Window,
+            async () => (await _windowService.ShowDialogAsync<DownloadFfmpegWindow, DownloadFfmpegViewModel>(Window)).FfmpegFileName);
+        if (!ffmpegOk)
+        {
+            return;
+        }
+
+        var videoFileName = VideoPlayerControl?.VideoPlayer.FileName ?? string.Empty;
+        if (string.IsNullOrEmpty(videoFileName) || !File.Exists(videoFileName))
+        {
+            videoFileName = string.IsNullOrEmpty(_sourceFileName) ? null : TryGetVideoFileName(_sourceFileName);
+        }
+
+        if (string.IsNullOrEmpty(videoFileName))
+        {
+            videoFileName = await _fileHelper.PickOpenVideoFile(Window, Se.Language.General.OpenVideoFileTitle);
+            if (string.IsNullOrEmpty(videoFileName))
+            {
+                return;
+            }
+        }
+
+        var supFileName = Path.Combine(Path.GetTempPath(), "se-sub-" + Guid.NewGuid().ToString("N") + ".sup");
+        try
+        {
+            WriteExport(new ExportHandlerBluRaySup(), supFileName);
+            await _windowService.ShowDialogAsync<BurnInWindow, BurnInViewModel>(Window, vm =>
+            {
+                vm.InitializeImageSubtitle(videoFileName, supFileName);
+            });
+        }
+        finally
+        {
+            try
+            {
+                if (File.Exists(supFileName))
+                {
+                    File.Delete(supFileName);
+                }
+            }
+            catch (Exception e)
+            {
+                Se.LogError(e, $"Could not delete the temporary subtitle file \"{supFileName}\"");
+            }
+        }
+    }
+
     [RelayCommand]
     private async Task ExportBdnXml()
     {
@@ -1195,6 +1260,13 @@ public partial class BinaryEditViewModel : ObservableObject
             return false;
         }
 
+        WriteExport(exportHandler, fileOrFolderName);
+        _isDirty = false;
+        return true;
+    }
+
+    private void WriteExport(IExportHandler exportHandler, string fileOrFolderName)
+    {
         var imageParameter = new ImageParameter()
         {
             ScreenWidth = ScreenWidth,
@@ -1230,8 +1302,6 @@ public partial class BinaryEditViewModel : ObservableObject
         }
 
         exportHandler.WriteFooter();
-        _isDirty = false;
-        return true;
     }
 
     [RelayCommand]

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -263,6 +263,11 @@ public class BinaryEditWindow : Window
                         },
                     }
                 },
+                new MenuItem
+                {
+                    Header = l.GenerateBurnIn,
+                    Command = vm.GenerateBurnInCommand,
+                },
                 new Separator(),
                 new MenuItem
                 {

--- a/src/ui/Features/Video/BurnIn/BurnInJobItem.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInJobItem.cs
@@ -31,6 +31,12 @@ public partial class BurnInJobItem : ObservableObject
     /// </summary>
     public bool InputIsAudioOnly { get; set; }
 
+    /// <summary>
+    /// The subtitle is a Blu-ray sup: burned in by overlaying its bitmaps rather than by rendering
+    /// text, so <see cref="AssaSubtitleFileName"/> is the sup itself.
+    /// </summary>
+    public bool SubtitleIsImage { get; set; }
+
     [ObservableProperty] private string _size;
 
     [ObservableProperty] private string _status;

--- a/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
@@ -7,6 +7,7 @@ using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Controls.VideoPlayer;
+using Nikse.SubtitleEdit.Core.BluRaySup;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Features.Main.Layout;
@@ -105,6 +106,12 @@ public partial class BurnInViewModel : ObservableObject
     [ObservableProperty] private string _logoInfo;
     [ObservableProperty] private bool _promptForFfmpegParameters;
 
+    /// <summary>
+    /// The subtitle is a Blu-ray sup (from the image-based editor) burned in as it is: the text
+    /// settings do not apply, so the window hides them, and the preview shows the sup itself.
+    /// </summary>
+    [ObservableProperty] private bool _isImageSubtitle;
+
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }
     public TableView? BatchGrid { get; internal set; }
@@ -124,6 +131,7 @@ public partial class BurnInViewModel : ObservableObject
     private FfmpegMediaInfo2? _mediaInfo;
     private SubtitleFormat? _subtitleFormat;
     private string _inputVideoFileName;
+    private string _imageSubtitleFileName = string.Empty;
     private List<BurnInEffectItem> _selectedEffects;
 
     public VideoPlayerControl? VideoPlayerControl { get; set; }
@@ -247,10 +255,28 @@ public partial class BurnInViewModel : ObservableObject
 
     public void Initialize(string videoFileName, Subtitle subtitle, SubtitleFormat subtitleFormat)
     {
-        VideoFileName = videoFileName;
-        _inputVideoFileName = videoFileName;
         _subtitle = new Subtitle(subtitle, false);
         _subtitleFormat = subtitleFormat;
+        SetVideo(videoFileName);
+    }
+
+    /// <summary>
+    /// Burns a Blu-ray sup into the video instead of text - the bitmaps as they are, overlapping
+    /// lines included (issue #14456). Batch mode takes sup files the same way, per job.
+    /// </summary>
+    public void InitializeImageSubtitle(string videoFileName, string bluRaySupFileName)
+    {
+        IsImageSubtitle = true;
+        _imageSubtitleFileName = bluRaySupFileName;
+        _subtitle = new Subtitle();
+        _subtitleFormat = null;
+        SetVideo(videoFileName);
+    }
+
+    private void SetVideo(string videoFileName)
+    {
+        VideoFileName = videoFileName;
+        _inputVideoFileName = videoFileName;
 
         var fileExists = !string.IsNullOrWhiteSpace(videoFileName) && File.Exists(videoFileName);
         if (fileExists)
@@ -807,7 +833,8 @@ public partial class BurnInViewModel : ObservableObject
             cutEnd,
             audioCutTracks,
             BurnInLogo,
-            jobItem.InputIsAudioOnly);
+            jobItem.InputIsAudioOnly,
+            jobItem.SubtitleIsImage);
 
         if (PromptForFfmpegParameters)
         {
@@ -877,9 +904,11 @@ public partial class BurnInViewModel : ObservableObject
         // Tracked so the file is swept when the window closes - and not GetTempFileName() plus an
         // extension, which leaked the empty tmpXXXX.tmp it creates on top of the file written
         // (#13332).
-        var subtitleFileName = _subtitleFormat is { Name: AdvancedSubStationAlpha.NameOfFormat }
-            ? _tempSubtitleFiles.Write(subtitle, new AdvancedSubStationAlpha())
-            : _tempSubtitleFiles.Write(subtitle, new SubRip());
+        var subtitleFileName = IsImageSubtitle
+            ? _imageSubtitleFileName
+            : _subtitleFormat is { Name: AdvancedSubStationAlpha.NameOfFormat }
+                ? _tempSubtitleFiles.Write(subtitle, new AdvancedSubStationAlpha())
+                : _tempSubtitleFiles.Write(subtitle, new SubRip());
 
         _mediaInfo = FfmpegMediaInfo2.Parse(VideoFileName);
         if (_mediaInfo.Dimension.Width > 0 && _mediaInfo.Dimension.Height > 0 &&
@@ -909,6 +938,14 @@ public partial class BurnInViewModel : ObservableObject
         {
             jobItem.Status = "Skipped";
             return string.Empty;
+        }
+
+        jobItem.SubtitleIsImage = FileUtil.IsBluRaySup(subtitleFileName);
+        if (jobItem.SubtitleIsImage)
+        {
+            // The bitmaps are overlaid as they are (see FfmpegGenerator): nothing to style or
+            // convert, and a cut is applied by offsetting the input rather than rewriting the file.
+            return subtitleFileName;
         }
 
         var isAssa = subtitleFileName.EndsWith(".ass", StringComparison.OrdinalIgnoreCase);
@@ -1242,7 +1279,10 @@ public partial class BurnInViewModel : ObservableObject
             return;
         }
 
-        var fileName = await _fileHelper.PickOpenSubtitleFile(Window!, Se.Language.General.OpenSubtitleFileTitle, false);
+        // The text formats plus Blu-ray sup, whose bitmaps are burned in as they are.
+        var patterns = FileHelper.GetOpenSubtitleExtensions(false).Select(p => "*" + p).Append("*.sup").ToList();
+        var fileNames = await _fileHelper.PickOpenFiles(Window!, Se.Language.General.OpenSubtitleFileTitle, Se.Language.General.SubtitleFiles, patterns, Se.Language.General.AllFiles, ["*"]);
+        var fileName = fileNames.FirstOrDefault();
         if (!string.IsNullOrEmpty(fileName))
         {
             SelectedJobItem.SubtitleFileName = fileName;
@@ -1677,6 +1717,12 @@ public partial class BurnInViewModel : ObservableObject
             return assa;
         }
 
+        var sup = Path.ChangeExtension(fileName, ".sup");
+        if (File.Exists(sup))
+        {
+            return sup;
+        }
+
         var dir = Path.GetDirectoryName(fileName);
         if (string.IsNullOrEmpty(dir))
         {
@@ -2064,7 +2110,7 @@ public partial class BurnInViewModel : ObservableObject
 
     private void UpdateNonAssaPreview()
     {
-        if (_loading || !string.IsNullOrEmpty(GetValidationError()))
+        if (_loading || IsImageSubtitle || !string.IsNullOrEmpty(GetValidationError()))
         {
             return;
         }
@@ -2458,6 +2504,14 @@ public partial class BurnInViewModel : ObservableObject
             await VideoPlayerControl.WaitForPlayersReadyAsync();
             SetActivePreviewPlayer(VideoPlayerControl.VideoPlayer as LibMpvDynamicPlayer, alreadyHasSubtitle: false);
 
+            if (IsImageSubtitle)
+            {
+                // mpv shows the sup as it is - there are no settings to restyle it with, so no
+                // preview timer either.
+                LoadImageSubtitlePreview(VideoPlayerControl);
+                return;
+            }
+
             // Seek to the first subtitle so the user immediately sees styled text.
             if (_subtitle.Paragraphs.Count > 0)
             {
@@ -2469,6 +2523,24 @@ public partial class BurnInViewModel : ObservableObject
         catch (Exception exception)
         {
             Se.LogError(exception, "Failed to start burn-in video preview");
+        }
+    }
+
+    private void LoadImageSubtitlePreview(VideoPlayerControl control)
+    {
+        if (_mpvPreviewPlayer == null || !File.Exists(_imageSubtitleFileName))
+        {
+            return;
+        }
+
+        _mpvPreviewPlayer.SubAdd(_imageSubtitleFileName);
+        _isPreviewSubtitleLoaded = true;
+
+        // Seek to the first subtitle so the user immediately sees it, as the text preview does.
+        var first = BluRaySupParser.ParseBluRaySup(_imageSubtitleFileName, new StringBuilder()).FirstOrDefault();
+        if (first != null)
+        {
+            control.SetPosition(first.StartTimeCode.TotalSeconds + 0.05);
         }
     }
 
@@ -2573,6 +2645,10 @@ public partial class BurnInViewModel : ObservableObject
             if (_fullScreenVideoPlayerControl == fsControl) // still fullscreen (not closed in the meantime)
             {
                 SetActivePreviewPlayer(fsControl.VideoPlayer as LibMpvDynamicPlayer, alreadyHasSubtitle: false);
+                if (IsImageSubtitle)
+                {
+                    LoadImageSubtitlePreview(fsControl);
+                }
             }
         });
     }

--- a/src/ui/Features/Video/BurnIn/BurnInWindow.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInWindow.cs
@@ -20,6 +20,13 @@ public class BurnInWindow : Window
     private readonly BurnInViewModel _vm;
     private ComboBox? _comboBoxFontName;
 
+    /// <summary>
+    /// The grid of text settings (font, colors, box, alignment, effect) - hidden for image
+    /// subtitles, which are burned in as they are.
+    /// </summary>
+    internal const string TextSettingsName = "BurnInTextSettings";
+    private const string LabelColumnGroup = "BurnInSettingsLabels";
+
     public BurnInWindow(BurnInViewModel vm)
     {
         _vm = vm;
@@ -498,7 +505,6 @@ public class BurnInWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
             {
@@ -567,10 +573,40 @@ public class BurnInWindow : Window
         }.WithBindVisible(vm, nameof(vm.ShowAssaOnlyBox));
         grid.Add(panel, 0, 0, 9, 2);
 
-        grid.Add(labelLogo, 10, 0);
-        grid.Add(panelLogo, 10, 1);
+        // The text settings mean nothing for an image subtitle (a Blu-ray sup burned in as it
+        // is), so they go away then; the logo still applies. The shared column keeps the logo
+        // label aligned with the text rows when both are shown.
+        grid.Name = TextSettingsName;
+        grid.ColumnDefinitions[0].SharedSizeGroup = LabelColumnGroup;
+        grid.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsImageSubtitle)) { Converter = new InverseBooleanConverter() });
 
-        return UiUtil.MakeBorderForControl(grid).WithMarginBottom(5).WithMarginRight(5);
+        var logoGrid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto), SharedSizeGroup = LabelColumnGroup },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnSpacing = 5,
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+        logoGrid.Add(labelLogo, 0, 0);
+        logoGrid.Add(panelLogo, 0, 1);
+
+        var settings = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 5,
+            Children = { grid, logoGrid },
+        };
+        Grid.SetIsSharedSizeScope(settings, true);
+
+        return UiUtil.MakeBorderForControl(settings).WithMarginBottom(5).WithMarginRight(5);
     }
 
     private static Border MakeVideoSettingsView(BurnInViewModel vm)

--- a/src/ui/Logic/Media/FfmpegGenerator.cs
+++ b/src/ui/Logic/Media/FfmpegGenerator.cs
@@ -69,7 +69,7 @@ public class FfmpegGenerator
     /// <summary>
     /// Generate ffmpeg parameters for a video with a burned-in Advanced Sub Station Alpha subtitle.
     /// </summary>
-    public static string GenerateHardcodedVideoFile(string inputVideoFileName, string assaSubtitleFileName, string outputVideoFileName, int width, int height, string videoEncoding, string preset, string pixelFormat, string crf, string audioEncoding, bool forceStereo, string sampleRate, string tune, string audioBitRate, string pass, string twoPassBitRate, string? cutStart = null, string? cutEnd = null, string audioCutTrack = "", Features.Video.BurnIn.BurnInLogo? burnInLogo = null, bool inputIsAudioOnly = false)
+    public static string GenerateHardcodedVideoFile(string inputVideoFileName, string assaSubtitleFileName, string outputVideoFileName, int width, int height, string videoEncoding, string preset, string pixelFormat, string crf, string audioEncoding, bool forceStereo, string sampleRate, string tune, string audioBitRate, string pass, string twoPassBitRate, string? cutStart = null, string? cutEnd = null, string audioCutTrack = "", Features.Video.BurnIn.BurnInLogo? burnInLogo = null, bool inputIsAudioOnly = false, bool subtitleIsImage = false)
     {
         if (width % 2 == 1)
         {
@@ -249,23 +249,44 @@ public class FfmpegGenerator
         // encoding when the audio ends (the lavfi color source runs forever).
         var canvasInput = string.Empty;
         var shortestParameter = string.Empty;
+        var inputCount = 1;
         var mainVideoStream = "[0:v]";
-        var logoVideoStream = "[1:v]";
         if (inputIsAudioOnly)
         {
             canvasInput = $" -f lavfi -i color=c=black:s={width}x{height}:r=25";
             shortestParameter = " -shortest";
-            mainVideoStream = "[1:v]";
-            logoVideoStream = "[2:v]";
+            mainVideoStream = $"[{inputCount}:v]";
+            inputCount++;
+        }
+
+        // Text is rendered by libass (the "ass" filter). A Blu-ray sup is a second input instead:
+        // its bitmaps are scaled to the output size like the video and laid over it, so the
+        // exported look - overlapping lines included - ends up on the frames (issue #14456).
+        // A cut seeks the video input ("-ss" before "-i" restarts its timestamps at zero) and the
+        // sup demuxer cannot seek, so the subtitle input is shifted back by the cut instead.
+        var imageSubtitleInput = string.Empty;
+        string withSubtitles;
+        if (subtitleIsImage)
+        {
+            imageSubtitleInput = $"{GetImageSubtitleOffset(cutStart)} -i \"{assaSubtitleFileName}\"";
+            withSubtitles = $"{mainVideoStream}scale={width}:{height}[video];[{inputCount}:s]scale={width}:{height}[subs];[video][subs]overlay";
+            inputCount++;
+        }
+        else
+        {
+            withSubtitles = $"{mainVideoStream}scale={width}:{height},ass={Path.GetFileName(assaSubtitleFileName)}";
         }
 
         // Add logo overlay if specified
         var logoInput = string.Empty;
-        var filterParameter = $"-vf \"scale={width}:{height},ass={Path.GetFileName(assaSubtitleFileName)}\"";
+        var filterParameter = subtitleIsImage
+            ? $"-filter_complex \"{withSubtitles}\""
+            : $"-vf \"scale={width}:{height},ass={Path.GetFileName(assaSubtitleFileName)}\"";
 
         if (burnInLogo != null && !string.IsNullOrEmpty(burnInLogo.LogoFileName) && File.Exists(burnInLogo.LogoFileName))
         {
             logoInput = $" -i \"{burnInLogo.LogoFileName}\"";
+            var logoVideoStream = $"[{inputCount}:v]";
 
             // Convert alpha percentage (0-100) to 0.0-1.0
             var alphaValue = (burnInLogo.Alpha / 100.0).ToString(CultureInfo.InvariantCulture);
@@ -275,7 +296,7 @@ public class FfmpegGenerator
             // 1. Scale main video (or the generated canvas for audio-only input) and apply subtitles
             // 2. Scale logo by size percentage and apply alpha transparency
             // 3. Overlay logo at specified X, Y position
-            var filterComplex = $"{mainVideoStream}scale={width}:{height},ass={Path.GetFileName(assaSubtitleFileName)}[withsubs];" +
+            var filterComplex = $"{withSubtitles}[withsubs];" +
                                $"{logoVideoStream}scale=iw*{sizePercent}/100:ih*{sizePercent}/100,format=rgba,colorchannelmixer=aa={alphaValue}[logo];" +
                                $"[withsubs][logo]overlay={burnInLogo.X}:{burnInLogo.Y}";
 
@@ -287,7 +308,23 @@ public class FfmpegGenerator
         // Without it ffmpeg hits "File ... already exists. Exiting." and writes nothing - and as
         // the old file is still there, the burn-in looked like it succeeded (issue #14210).
         return
-            $"-y{cutStart}-i \"{inputVideoFileName}\"{canvasInput}{logoInput}{cutEnd} {filterParameter} -g 30 -bf 2 -s {width}x{height} {videoEncodingSettings} {passSettings} {presetSettings} {crfSettings} {pixelFormat} {audioSettings}{tuneParameter} -use_editlist 0 -movflags +faststart{shortestParameter} {outputVideoFileName}";
+            $"-y{cutStart}-i \"{inputVideoFileName}\"{canvasInput}{imageSubtitleInput}{logoInput}{cutEnd} {filterParameter} -g 30 -bf 2 -s {width}x{height} {videoEncodingSettings} {passSettings} {presetSettings} {crfSettings} {pixelFormat} {audioSettings}{tuneParameter} -use_editlist 0 -movflags +faststart{shortestParameter} {outputVideoFileName}";
+    }
+
+    /// <summary>
+    /// The "-itsoffset" that keeps an image subtitle input in step with a video input that was
+    /// seeked with "-ss": the same time, negated. Empty when there is no cut.
+    /// </summary>
+    private static string GetImageSubtitleOffset(string? cutStart)
+    {
+        var seek = (cutStart ?? string.Empty).Trim();
+        if (!seek.StartsWith("-ss ", StringComparison.Ordinal))
+        {
+            return string.Empty;
+        }
+
+        var time = seek.Substring(4).Trim();
+        return string.IsNullOrEmpty(time) ? string.Empty : $" -itsoffset -{time}";
     }
 
     private static Process GetFFmpegProcess(string imageFileName, string outputFileName, int videoWidth, int videoHeight, int seconds, decimal frameRate, bool addTimeCode = false, string addTimeColor = "white")

--- a/src/ui/Logic/Media/FfmpegRequirement.cs
+++ b/src/ui/Logic/Media/FfmpegRequirement.cs
@@ -1,0 +1,81 @@
+using Avalonia.Controls;
+using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Logic.Media;
+
+/// <summary>
+/// Makes sure an ffmpeg is at hand before a feature that runs it opens: the configured one, the
+/// one Subtitle Edit downloaded, one on the PATH (issue #11760) or in /usr/local/bin - failing
+/// those, the download is offered on Windows and macOS, and elsewhere the message says what to
+/// install instead of failing silently (issue #14390).
+/// </summary>
+public static class FfmpegRequirement
+{
+    /// <param name="owner">Owner of the question and message boxes.</param>
+    /// <param name="downloadFfmpeg">Shows the download dialog; returns the downloaded ffmpeg's path, or empty.</param>
+    /// <param name="showStatus">Where to say that ffmpeg was downloaded and installed, if anywhere.</param>
+    public static async Task<bool> EnsureAsync(Window owner, Func<Task<string>> downloadFfmpeg, Action<string>? showStatus = null)
+    {
+        if (FfmpegHelper.IsFfmpegInstalled())
+        {
+            return true;
+        }
+
+        if (File.Exists(DownloadFfmpegViewModel.GetFfmpegFileName()))
+        {
+            FfmpegHelper.SetFfmpegPath(DownloadFfmpegViewModel.GetFfmpegFileName());
+            return true;
+        }
+
+        var systemFfmpeg = FfmpegHelper.GetSystemFfmpegPath();
+        if (!string.IsNullOrEmpty(systemFfmpeg))
+        {
+            FfmpegHelper.SetFfmpegPath(systemFfmpeg);
+            return true;
+        }
+
+        if (!OperatingSystem.IsWindows() && File.Exists("/usr/local/bin/ffmpeg"))
+        {
+            FfmpegHelper.SetFfmpegPath("/usr/local/bin/ffmpeg");
+            return true;
+        }
+
+        if (OperatingSystem.IsWindows() || OperatingSystem.IsMacOS())
+        {
+            var answer = await MessageBox.Show(
+                owner,
+                Se.Language.Main.DownloadFfmpegTitle,
+                Se.Language.Main.DownloadFfmpegQuestion,
+                MessageBoxButtons.YesNoCancel,
+                MessageBoxIcon.Question);
+
+            if (answer != MessageBoxResult.Yes)
+            {
+                return false;
+            }
+
+            var ffmpegFileName = await downloadFfmpeg();
+            if (!string.IsNullOrEmpty(ffmpegFileName))
+            {
+                FfmpegHelper.SetFfmpegPath(ffmpegFileName);
+                showStatus?.Invoke(string.Format(Se.Language.Main.FfmpegDownloadedAndInstalledToX, ffmpegFileName));
+                return true;
+            }
+
+            return false;
+        }
+
+        await MessageBox.Show(
+            owner,
+            Se.Language.Title,
+            Se.Language.Main.FfmpegNotFoundInstallHint,
+            MessageBoxButtons.OK,
+            MessageBoxIcon.Information);
+
+        return false;
+    }
+}

--- a/tests/UI/Features/Video/BurnInWindowTests.cs
+++ b/tests/UI/Features/Video/BurnInWindowTests.cs
@@ -292,4 +292,25 @@ public class BurnInWindowTests : IDisposable
         Avalonia.Threading.Dispatcher.UIThread.RunJobs();
         Assert.Equal(lockedMinWidth, window.MinWidth);
     }
+
+    /// <summary>
+    /// An image subtitle (a Blu-ray sup from the image-based editor) is burned in as it is, so the
+    /// font/color/box/effect settings mean nothing and go away - the logo still applies.
+    /// </summary>
+    [AvaloniaFact]
+    public void ImageSubtitle_HidesTheTextSettingsAndKeepsTheLogo()
+    {
+        var window = BuildWindow();
+        var vm = Assert.IsType<BurnInViewModel>(window.DataContext);
+        var textSettings = window.GetLogicalDescendants().OfType<Grid>().Single(p => p.Name == BurnInWindow.TextSettingsName);
+        var logoButton = window.GetLogicalDescendants().OfType<Button>().Single(p => ReferenceEquals(p.Command, vm.ShowLogoCommand));
+        Assert.True(textSettings.IsVisible);
+
+        vm.InitializeImageSubtitle(string.Empty, "subs.sup");
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+
+        Assert.False(textSettings.IsVisible);
+        Assert.True(logoButton.IsVisible);
+        Assert.True(vm.IsImageSubtitle);
+    }
 }

--- a/tests/UI/Features/Video/FfmpegBurnInParametersTests.cs
+++ b/tests/UI/Features/Video/FfmpegBurnInParametersTests.cs
@@ -1,4 +1,5 @@
 using Nikse.SubtitleEdit.Core.Common;
+using System.IO;
 using Nikse.SubtitleEdit.Logic.Media;
 
 namespace UITests.Features.Video;
@@ -83,5 +84,116 @@ public class FfmpegBurnInParametersTests
         var parameters = Generate("libx264", "aac", "output.mp4", pass, twoPassBitRate);
 
         Assert.StartsWith("-y ", parameters);
+    }
+
+    /// <summary>
+    /// A Blu-ray sup (from the image-based editor, or a batch item's subtitle) is a second input
+    /// laid over the frames, scaled to the output size like the video - libass' "ass" filter
+    /// renders text only. Overlapping lines are shown together this way (issue #14456).
+    /// </summary>
+    private static string GenerateImage(string cutStart = "", bool inputIsAudioOnly = false, Nikse.SubtitleEdit.Features.Video.BurnIn.BurnInLogo? logo = null)
+    {
+        return FfmpegGenerator.GenerateHardcodedVideoFile(
+            "input.mp4",
+            "/tmp/subs.sup",
+            "output.mp4",
+            320,
+            240,
+            "libx264",
+            string.Empty,
+            "yuv420p",
+            string.Empty,
+            "aac",
+            false,
+            "48000",
+            string.Empty,
+            "128k",
+            string.Empty,
+            string.Empty,
+            cutStart,
+            string.Empty,
+            string.Empty,
+            logo,
+            inputIsAudioOnly,
+            subtitleIsImage: true);
+    }
+
+    [Fact]
+    public void ImageSubtitle_IsASecondInputOverlaidAfterScaling()
+    {
+        var parameters = GenerateImage();
+
+        Assert.Contains("-y -i \"input.mp4\" -i \"/tmp/subs.sup\"", parameters);
+        Assert.Contains("-filter_complex \"[0:v]scale=320:240[video];[1:s]scale=320:240[subs];[video][subs]overlay\"", parameters);
+        Assert.DoesNotContain("ass=", parameters);
+        Assert.DoesNotContain("-vf", parameters);
+    }
+
+    /// <summary>
+    /// "-ss" before the video input restarts its timestamps at zero, and the sup demuxer cannot
+    /// seek, so the subtitle input is shifted back by the same time to stay in step.
+    /// </summary>
+    [Fact]
+    public void ImageSubtitle_WithCut_ShiftsTheSubtitleInputBackByTheCut()
+    {
+        var parameters = GenerateImage(cutStart: "-ss 00:01:02.500");
+
+        Assert.Contains("-y -ss 00:01:02.500 -i \"input.mp4\" -itsoffset -00:01:02.500 -i \"/tmp/subs.sup\"", parameters);
+    }
+
+    [Fact]
+    public void ImageSubtitle_WithoutCut_HasNoOffset()
+    {
+        Assert.DoesNotContain("-itsoffset", GenerateImage());
+    }
+
+    [Fact]
+    public void ImageSubtitle_AudioOnlyInput_OverlaysOnTheCanvasAndNumbersTheInputsAfterIt()
+    {
+        var parameters = GenerateImage(inputIsAudioOnly: true);
+
+        Assert.Contains("-i \"input.mp4\" -f lavfi -i color=c=black:s=320x240:r=25 -i \"/tmp/subs.sup\"", parameters);
+        Assert.Contains("[1:v]scale=320:240[video];[2:s]scale=320:240[subs];[video][subs]overlay", parameters);
+    }
+
+    [Fact]
+    public void ImageSubtitle_WithLogo_PutsTheLogoOverTheSubtitledFrames()
+    {
+        var logoFileName = Path.GetTempFileName();
+        try
+        {
+            var logo = new Nikse.SubtitleEdit.Features.Video.BurnIn.BurnInLogo
+            {
+                LogoFileName = logoFileName,
+                X = 10,
+                Y = 20,
+                Size = 100,
+                Alpha = 100,
+            };
+
+            var parameters = GenerateImage(logo: logo);
+
+            Assert.Contains($"-i \"input.mp4\" -i \"/tmp/subs.sup\" -i \"{logoFileName}\"", parameters);
+            Assert.Contains("[0:v]scale=320:240[video];[1:s]scale=320:240[subs];[video][subs]overlay[withsubs];[2:v]scale=", parameters);
+            Assert.Contains("[withsubs][logo]overlay=10:20", parameters);
+        }
+        finally
+        {
+            File.Delete(logoFileName);
+        }
+    }
+
+    /// <summary>
+    /// The text path is what every existing user runs; the image switch must not touch it.
+    /// </summary>
+    [Fact]
+    public void TextSubtitle_StillUsesTheAssFilter()
+    {
+        var parameters = Generate("libx264", "aac", "output.mp4");
+
+        Assert.Contains("-y -i \"input.mp4\" ", parameters);
+        Assert.Contains("-vf \"scale=320:240,ass=subtitle.ass\"", parameters);
+        Assert.DoesNotContain("-filter_complex", parameters);
+        Assert.DoesNotContain("overlay", parameters);
     }
 }


### PR DESCRIPTION
Follow-up to #14456: the reporter's overlapping lines now export correctly to `.sup` (#14463), but burn-in could not take that file - it only rendered text through libass, so a `.sup` batch item was silently "Skipped" and the image-based editor had no path to a video at all.

## What changes

- **Blu-ray sup is burned in as it is.** `FfmpegGenerator` adds the sup as a second input, scales it to the output size like the video and lays it over the frames with `overlay`; the logo goes on top of that. Lines that overlap in time are shown together, the way the exported file shows them. The text path (`-vf scale,ass=`) is byte for byte what it was.
- **Cut works for images too.** `-ss` before the video input restarts its timestamps at zero, and the sup demuxer cannot seek, so the subtitle input gets a matching negative `-itsoffset`.
- **Image-based editor: File → Generate video with burned-in subtitles...** writes the loaded images to a temporary `.sup` and opens the burn-in dialog on the player's video, else the one next to the subtitle file, else one you pick. Reuses the main menu's string - no new language keys.
- **Burn-in dialog in image mode** hides the text settings (font, size, colors, box, alignment, effect); the logo stays, in a shared-size column so nothing shifts in text mode. The preview loads the sup into mpv and seeks to its first line. Batch items accept a `.sup` from the picker, and a `.sup` next to the video is paired automatically after `.srt`/`.ass`.
- **`FfmpegRequirement`** is the ffmpeg lookup + download prompt lifted out of `MainViewModel`, so the image-based editor makes the same check before opening the dialog.

## Verification

- 6 new `FfmpegBurnInParametersTests` (overlay chain, cut offset, audio-only canvas input numbering, logo on top, text path unchanged) and a `BurnInWindowTests` case for the hidden text settings. Full UI suite: 4691 passed.
- The generated command shape run through ffmpeg 4.4 on the reporter's SRT exported to `.sup`, with and without a cut: both lines of each overlapping pair are on the frame during the overlap, and the cut keeps them in step.

## Docs

`docs/features/burn-in.md` gets an "Image-based subtitles" section; `docs/features/binary-edit.md` mentions the new menu item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
