### PR TITLE
Put the image-based editor's burn-in entry in its Video menu

### DIFF
--- a/docs/features/binary-edit.md
+++ b/docs/features/binary-edit.md
@@ -43,7 +43,7 @@ Under the image, **Set text** replaces the selected line's image with newly rend
 
 The File menu has **Import time codes...** (apply the timing of a text subtitle to the lines) next to Export, and the Synchronization menu offers **Adjust all times**, **Change frame rate**, and **Change speed**.
 
-**File → Generate video with burned-in subtitles...** burns the images into a video as they are, through the [burn-in](burn-in.md) dialog - the video in the player, or the one next to the subtitle file, or one you pick.
+**Video → Generate video with burned-in subtitles...** burns the images into a video as they are, through the [burn-in](burn-in.md) dialog - the video in the player, or the one next to the subtitle file, or one you pick.
 
 ## Export
 

--- a/docs/features/burn-in.md
+++ b/docs/features/burn-in.md
@@ -39,7 +39,7 @@ Hardcode (burn-in) subtitles permanently into a video file using FFmpeg.
 
 ## Image-based subtitles
 
-A Blu-ray sup can be burned in as it is. Open it in **Edit image-based subtitle** and choose **File → Generate video with burned-in subtitles...**, or add a `.sup` file as the subtitle of a batch item (a `.sup` next to the video is picked up automatically, after `.srt` and `.ass`). The bitmaps are laid over the video with FFmpeg's overlay filter and scaled with it, so the result matches the exported file - lines that overlap in time are shown together, the way a Blu-ray shows them. The font settings do not apply to bitmaps and are hidden; the logo, resolution, cut and encoding settings work as for text.
+A Blu-ray sup can be burned in as it is. Open it in **Edit image-based subtitle** and choose **Video → Generate video with burned-in subtitles...**, or add a `.sup` file as the subtitle of a batch item (a `.sup` next to the video is picked up automatically, after `.srt` and `.ass`). The bitmaps are laid over the video with FFmpeg's overlay filter and scaled with it, so the result matches the exported file - lines that overlap in time are shown together, the way a Blu-ray shows them. The font settings do not apply to bitmaps and are hidden; the logo, resolution, cut and encoding settings work as for text.
 
 ## Video Settings
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -263,11 +263,6 @@ public class BinaryEditWindow : Window
                         },
                     }
                 },
-                new MenuItem
-                {
-                    Header = l.GenerateBurnIn,
-                    Command = vm.GenerateBurnInCommand,
-                },
                 new Separator(),
                 new MenuItem
                 {
@@ -402,6 +397,14 @@ public class BinaryEditWindow : Window
                     Header = l.CloseVideoFile,
                     Command = vm.CloseVideoCommand,
                 },
+                new Separator(),
+                new MenuItem
+                {
+                    // Where the main window has it too (its Video menu).
+                    Header = l.GenerateBurnIn,
+                    Command = vm.GenerateBurnInCommand,
+                },
+                new Separator(),
                 new MenuItem
                 {
                     Header = l.ToggleSelectSubtitleWhilePlayingCurrentlyOn,

--- a/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
+++ b/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
@@ -68,6 +68,9 @@ public static class InitNativeMacMenuBinaryEdit
         var videoMenu = new NativeMenu();
         Add(videoMenu, l.OpenVideo, vm.OpenVideoCommand);
         Add(videoMenu, l.CloseVideoFile, vm.CloseVideoCommand);
+        videoMenu.Items.Add(new NativeMenuItemSeparator());
+        Add(videoMenu, l.GenerateBurnIn, vm.GenerateBurnInCommand);
+        videoMenu.Items.Add(new NativeMenuItemSeparator());
         var selectSubtitleWhilePlayingItem = new NativeMenuItem(Clean(l.SelectSubtitleWhilePlaying))
         {
             ToggleType = MenuItemToggleType.CheckBox,


### PR DESCRIPTION
Follow-up to #14488: **Generate video with burned-in subtitles...** in the image-based editor was in the File menu, where it was easy to miss. It now sits in the Video menu, after Close video file, matching the main window.

On macOS the window's own menu bar is hidden and `InitNativeMacMenuBinaryEdit` builds the native one, so the entry was missing there entirely - it is added to that Video menu too. Docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)