### PR TITLE
Gate the up/down OCR line splitter on ink height, not bitmap height

### DIFF
--- a/src/libuilogic/Ocr/NikseBitmapImageSplitter2.cs
+++ b/src/libuilogic/Ocr/NikseBitmapImageSplitter2.cs
@@ -506,7 +506,12 @@ public class NikseBitmapImageSplitter2
 
             lineBitmaps = splitOld.Count > splitBlankLines.Count ? splitOld : splitBlankLines;
 
-            if (lineBitmaps.Count == 1 && lineBitmaps[0].NikseBitmap?.Height > minLineHeight * 2.2)
+            // Gate on the height of the actual content, not the bitmap: the VobSub decoder
+            // leaves up to seven transparent rows under the text, and one DVD-sized line plus
+            // that margin clears 2.2 x minLineHeight - which sent one-line images through the
+            // up/down splitter, whose cut then eroded the leftmost glyph and left its crumbs
+            // as a bogus second line (#14292).
+            if (lineBitmaps.Count == 1 && lineBitmaps[0].NikseBitmap?.GetNonTransparentHeight() > minLineHeight * 2.2)
             {
                 lineBitmaps = SplitToLinesNew(lineBitmaps[0], minLineHeight, averageLineHeight);
             }

--- a/tests/libuilogic/Ocr/SplitToLinesNewSingleLineTests.cs
+++ b/tests/libuilogic/Ocr/SplitToLinesNewSingleLineTests.cs
@@ -1,0 +1,97 @@
+using Nikse.SubtitleEdit.UiLogic.Ocr;
+
+namespace LibUiLogicTests.Ocr;
+
+/// <summary>
+/// Issue #14292: a one-line DVD subtitle whose leftmost glyph has a descender, e.g. "(", came
+/// out of nOCR with an extra unknown character. The VobSub decoder leaves up to seven
+/// transparent rows under the text, and that padded height cleared the 2.2 x minLineHeight
+/// gate in front of the "allows for up/down" line splitter. Its path then ran down the outer
+/// edge of the "(", eroded it, and left the crumbs as a bogus second line.
+/// </summary>
+public class SplitToLinesNewSingleLineTests
+{
+    // Left edge of subtitle 125 of the reporter's file after MakeTwoColor: the "(" of "(SINGT".
+    private static readonly string[] Paren =
+    [
+        "............",
+        "........###.",
+        ".......###..",
+        ".......###..",
+        "......###...",
+        "......###...",
+        "......###...",
+        ".....###....",
+        ".....###....",
+        ".....###....",
+        ".....###....",
+        ".....###....",
+        ".....###....",
+        ".....###....",
+        ".....###....",
+        ".....###....",
+        "......###...",
+        "......###...",
+        "......###...",
+        "......###...",
+        ".......###..",
+        ".......###..",
+        "........###.",
+    ];
+
+    /// <summary>
+    /// The "(" followed by four 10x14 blocks whose tops sit one row above the "(", as the caps do in
+    /// the real line, with the decoder's transparent bottom margin under it all.
+    /// </summary>
+    private static NikseBitmap2 MakeOneLineWithParenAndBottomMargin()
+    {
+        const int blockW = 10, blockH = 14, gapX = 6, blocks = 4, bottomMargin = 8;
+        var width = Paren[0].Length + 4 + blocks * blockW + (blocks - 1) * gapX + 2;
+        var height = Paren.Length + bottomMargin;
+        var data = new byte[width * height * 4];
+
+        void Set(int x, int y)
+        {
+            var i = (x + y * width) * 4;
+            data[i] = data[i + 1] = data[i + 2] = data[i + 3] = 255;
+        }
+
+        for (var y = 0; y < Paren.Length; y++)
+        {
+            for (var x = 0; x < Paren[y].Length; x++)
+            {
+                if (Paren[y][x] == '#')
+                {
+                    Set(x, y);
+                }
+            }
+        }
+
+        for (var b = 0; b < blocks; b++)
+        {
+            var left = Paren[0].Length + 4 + b * (blockW + gapX);
+            for (var y = 0; y < blockH; y++)
+            {
+                for (var x = left; x < left + blockW; x++)
+                {
+                    Set(x, y);
+                }
+            }
+        }
+
+        return new NikseBitmap2(width, height, data);
+    }
+
+    [Fact]
+    public void OneLineWithDescenderAndBottomMargin_IsNotSplitIntoTwoLines()
+    {
+        var bmp = MakeOneLineWithParenAndBottomMargin();
+
+        // 14 is what the adaptive tracker settles on for the reporter's DVD font; the padded
+        // bitmap height (31) is above 2.2 x 14 while the ink height (23) is not.
+        var items = NikseBitmapImageSplitter2.SplitBitmapToLettersNew(bmp, 3, false, true, 14, true, 15.0);
+
+        Assert.Equal(0, items.Count(p => p.SpecialCharacter == Environment.NewLine));
+        Assert.Equal(5, items.Count(p => p.NikseBitmap != null));
+    }
+}


### PR DESCRIPTION
Fixes #14292 - nOCR on a one-line DVD subtitle whose leftmost glyph has a descender ("(", "J", ",", "g", "q") produced an extra unknown character.

## Cause

The VobSub decoder leaves up to seven transparent rows under the text. For a DVD-sized font the adaptive minimum line height settles around 14, and that padded one-line image (31-35 rows) cleared the `2.2 x minLineHeight` gate in front of `SplitToLinesNew`, the "allows for up/down" line splitter. Its path walked down the outer edge of the "(", and since its cut starts one row above the path it eroded the glyph's edge and left the crumbs as a bogus second line - the 2x5 blob in the reporter's screenshots.

`SplitToLinesNew` had been dead code until 9a917c640 (beta27) moved its `started` flag out of the scan loop, which is why earlier builds were fine and why "Crop transparent colors" works around it: without the margin the image never reaches the gate.

## Fix

Gate on `GetNonTransparentHeight()` instead of the bitmap height.

## Verification

On the reporter's file, first 600 subtitles, nOCR pipeline as the OCR window runs it:

| | One-line images split in two | Genuine two-line images still split |
|---|---|---|
| Before | 19 (all 11 reported lines among them) | 315 of 315 |
| After | 0 | 315 of 315 |

A regression test rebuilds the "(" from subtitle 125 with the decoder's bottom margin; it fails on main with the 2x5 crumb and passes with the fix. All 352 libuilogic OCR tests pass. Also verified in the UI on the reporter's file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
