### PR TITLE
TTS: judge silence relative to the clip's peak so quiet voice clones keep their last word

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -1585,9 +1585,11 @@ public partial class ReviewSpeechViewModel : ObservableObject
         // Step 1: Trim silence from start and end. A failed trim (misconfigured/failing ffmpeg)
         // must fall back to the untrimmed audio - adopting the missing output blindly made
         // FfmpegMediaInfo.Parse below return a null Duration and the factor math NRE'd.
+        // Silence threshold relative to the clip's peak - same as the main pipeline (#14480).
+        var peakDbfs = await TtsSilenceThreshold.MeasurePeakDbfsAsync(item.CurrentFileName, _cancellationToken);
         var outputFileNameTrim = Path.Combine(_waveFolder, Guid.NewGuid() + ".wav");
         _tempAudioFiles.Add(outputFileNameTrim);
-        var trimProcess = FfmpegGenerator.TrimSilenceStartAndEnd(item.CurrentFileName, outputFileNameTrim);
+        var trimProcess = FfmpegGenerator.TrimSilenceStartAndEnd(item.CurrentFileName, outputFileNameTrim, TtsSilenceThreshold.Amplitude(peakDbfs));
         await trimProcess.StartAndWaitAsync(_cancellationToken);
 
         var currentFile = File.Exists(outputFileNameTrim) && new FileInfo(outputFileNameTrim).Length > 0
@@ -1599,7 +1601,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
         {
             var vadOutput = Path.Combine(_waveFolder, $"vad_{Guid.NewGuid()}.wav");
             _tempAudioFiles.Add(vadOutput);
-            var vadProcess = FfmpegGenerator.CompressInternalSilence(currentFile, vadOutput, vadMaxSilence);
+            var vadProcess = FfmpegGenerator.CompressInternalSilence(currentFile, vadOutput, vadMaxSilence, TtsSilenceThreshold.DbLiteral(peakDbfs));
             await vadProcess.StartAndWaitAsync(_cancellationToken);
 
             if (File.Exists(vadOutput) && new FileInfo(vadOutput).Length > 0)

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -49,6 +49,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -3449,9 +3450,15 @@ public partial class TextToSpeechViewModel : ObservableObject
                 // same policy as the generation step. Cancellation still aborts the run.
                 try
                 {
+                    // Silence is judged relative to this clip's own peak: a fixed -40 dBFS trimmed
+                    // the soft final consonant off quiet voice-clone output, cutting the last word
+                    // of the line (#14480). Null (unreadable file) falls back to the old threshold.
+                    var peakDbfs = await TtsSilenceThreshold.MeasurePeakDbfsAsync(item.CurrentFileName, cancellationToken, segmentOperationTimeout);
+                    Se.WriteToolsLog($"TTS FixSpeed: segment {index + 1} peak {FormatDb(peakDbfs)} - silence threshold {TtsSilenceThreshold.DbLiteral(peakDbfs)}");
+
                     // Step 1: Trim silence from start and end
                     var outputFileName1 = Path.Combine(Path.GetDirectoryName(item.CurrentFileName)!, Guid.NewGuid() + ".wav");
-                    var trimProcess = FfmpegGenerator.TrimSilenceStartAndEnd(item.CurrentFileName, outputFileName1);
+                    var trimProcess = FfmpegGenerator.TrimSilenceStartAndEnd(item.CurrentFileName, outputFileName1, TtsSilenceThreshold.Amplitude(peakDbfs));
                     await trimProcess.StartAndWaitAsync(cancellationToken, segmentOperationTimeout);
 
                     var currentFile = outputFileName1;
@@ -3462,7 +3469,7 @@ public partial class TextToSpeechViewModel : ObservableObject
                     if (doVad)
                     {
                         var vadOutput = Path.Combine(Path.GetDirectoryName(item.CurrentFileName)!, $"vad_{Guid.NewGuid()}.wav");
-                        var vadProcess = FfmpegGenerator.CompressInternalSilence(currentFile, vadOutput, vadMaxSilence);
+                        var vadProcess = FfmpegGenerator.CompressInternalSilence(currentFile, vadOutput, vadMaxSilence, TtsSilenceThreshold.DbLiteral(peakDbfs));
                         await vadProcess.StartAndWaitAsync(cancellationToken, segmentOperationTimeout);
 
                         if (File.Exists(vadOutput) && new FileInfo(vadOutput).Length > 0)
@@ -3816,6 +3823,11 @@ public partial class TextToSpeechViewModel : ObservableObject
     // The compact cloud-engine descriptions ("pay/fast/good") read like debug output - expand
     // them into words; free-form descriptions (the CrispASR engines) are shown as-is. The
     // source strings are hardcoded English in the engines, so this map matches that.
+    private static string FormatDb(double? dbfs)
+    {
+        return dbfs == null ? "(unknown)" : dbfs.Value.ToString("0.0", CultureInfo.InvariantCulture) + " dBFS";
+    }
+
     // Middle-truncates a file name so the tail (and thus the extension) stays visible.
     private static string CapFileName(string fileName, int maxLength)
     {

--- a/src/ui/Features/Video/TextToSpeech/TtsPostProcessor.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsPostProcessor.cs
@@ -29,9 +29,12 @@ public static class TtsPostProcessor
             if (doProChain)
             {
                 var proChainOutput = Path.Combine(waveFolder, $"pro_{Guid.NewGuid()}.wav");
+                // The chain's noise gate opens relative to the clip's peak, not at a fixed
+                // -40 dBFS that gated the word endings of quiet voice-clone output (#14480).
+                var peakDbfs = await TtsSilenceThreshold.MeasurePeakDbfsAsync(currentFile, cancellationToken);
                 // One ffmpeg per stage per LINE - a 900-line dub with every stage on created
                 // thousands of undisposed processes. PerLineVoiceClone uses "using var" too.
-                using var proProcess = FfmpegGenerator.ApplyProAudioChain(currentFile, proChainOutput);
+                using var proProcess = FfmpegGenerator.ApplyProAudioChain(currentFile, proChainOutput, TtsSilenceThreshold.Amplitude(peakDbfs));
                 await proProcess.StartAndWaitAsync(cancellationToken);
 
                 currentFile = AdoptStageOutput(currentFile, proChainOutput, "pro audio chain");

--- a/src/ui/Features/Video/TextToSpeech/TtsSilenceThreshold.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsSilenceThreshold.cs
@@ -1,0 +1,144 @@
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech;
+
+/// <summary>
+/// Silence thresholds for the TTS audio pipeline, derived from the clip's own peak level.
+/// </summary>
+/// <remarks>
+/// The silence trim, the VAD pause compression and the pro-chain noise gate all used a fixed
+/// -40 dBFS threshold. Voice cloning engines reproduce the loudness of their reference, and a
+/// reference cut from film dialogue often peaks at -20 to -30 dBFS - so the soft final consonant
+/// of a quiet clone fell under the fixed threshold and was trimmed off as "silence", cutting the
+/// last word of the line (#14480). Measured on a real clip: at a -21 dBFS peak the final "s" was
+/// gone, at -33 dBFS the whole line was considered silence. Making the threshold relative to the
+/// peak (40 dB below it) gives every clip the same trim a full-scale one gets.
+/// <para>
+/// Why 40 dB and not less: a word-final "s" peaks 20-25 dB under the clip's loudest vowel, and
+/// "f"/"th" sit another ~10 dB lower, so a narrower window starts eating endings again. The
+/// price is paid on clips whose noise floor is within 40 dB of the peak (some VibeVoice/Qwen3
+/// output): up to a few hundred ms of hiss ~30 dB under the speech can stay at the ends. Over
+/// ~250 real clips from eight engines the median difference to the old trim was 0 ms at both
+/// ends, which is the point - loud clips are trimmed exactly as before.
+/// </para>
+/// </remarks>
+public static partial class TtsSilenceThreshold
+{
+    /// <summary>How far below the clip's peak a sample still counts as speech.</summary>
+    public const double BelowPeakDb = 40.0;
+
+    /// <summary>
+    /// Never listen below this: neural vocoders leave a noise floor around -60 dBFS, and a
+    /// threshold under it would stop trimming trailing silence on very quiet clips.
+    /// </summary>
+    public const double FloorDbfs = -70.0;
+
+    /// <summary>The threshold every stage used before the peak was measured: 0.01 = -40 dBFS.</summary>
+    public const double LegacyThresholdDbfs = -40.0;
+
+    /// <summary>
+    /// Threshold in dBFS for a clip with the given peak. A null peak (ffmpeg could not measure
+    /// the file) falls back to the legacy fixed threshold.
+    /// </summary>
+    public static double ThresholdDbfs(double? peakDbfs)
+    {
+        if (peakDbfs == null || double.IsNaN(peakDbfs.Value) || double.IsInfinity(peakDbfs.Value))
+        {
+            return LegacyThresholdDbfs;
+        }
+
+        // Float WAVs can peak above 0 dBFS; a threshold above the legacy one would trim more
+        // aggressively than before, never less, so cap the peak at full scale.
+        var peak = Math.Min(0.0, peakDbfs.Value);
+        return Math.Max(FloorDbfs, peak - BelowPeakDb);
+    }
+
+    /// <summary>Threshold as a linear amplitude (0..1), the form silenceremove/agate take.</summary>
+    public static double Amplitude(double? peakDbfs)
+    {
+        return Math.Pow(10.0, ThresholdDbfs(peakDbfs) / 20.0);
+    }
+
+    /// <summary>Threshold as an ffmpeg dB literal, e.g. "-52.3dB".</summary>
+    public static string DbLiteral(double? peakDbfs)
+    {
+        return ThresholdDbfs(peakDbfs).ToString("0.0", CultureInfo.InvariantCulture) + "dB";
+    }
+
+    /// <summary>
+    /// Peak level of an audio file in dBFS via ffmpeg's volumedetect, or null when ffmpeg failed
+    /// or printed no peak (callers then fall back to the legacy threshold).
+    /// </summary>
+    public static async Task<double?> MeasurePeakDbfsAsync(string fileName, CancellationToken cancellationToken, TimeSpan? timeout = null)
+    {
+        var lines = new List<string>();
+        var gate = new object();
+
+        void OnLine(object sender, System.Diagnostics.DataReceivedEventArgs e)
+        {
+            if (e.Data == null)
+            {
+                return;
+            }
+
+            lock (gate)
+            {
+                lines.Add(e.Data);
+            }
+        }
+
+        try
+        {
+            using var process = FfmpegGenerator.MeasurePeakVolume(fileName, OnLine);
+            if (timeout.HasValue)
+            {
+                await process.StartAndWaitAsync(cancellationToken, timeout.Value);
+            }
+            else
+            {
+                await process.StartAndWaitAsync(cancellationToken);
+            }
+
+            // Wait for the async stream readers to deliver everything before parsing.
+            process.WaitForExit();
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+
+        lock (gate)
+        {
+            return ParsePeakDbfs(lines);
+        }
+    }
+
+    /// <summary>Finds volumedetect's "max_volume: -2.8 dB" in ffmpeg's output.</summary>
+    public static double? ParsePeakDbfs(IEnumerable<string> ffmpegOutputLines)
+    {
+        foreach (var line in ffmpegOutputLines)
+        {
+            var match = MaxVolumeRegex().Match(line);
+            if (match.Success &&
+                double.TryParse(match.Groups[1].Value, NumberStyles.Float, CultureInfo.InvariantCulture, out var peak))
+            {
+                return peak;
+            }
+        }
+
+        return null;
+    }
+
+    [GeneratedRegex(@"max_volume:\s*(-?\d+(?:\.\d+)?)\s*dB", RegexOptions.IgnoreCase)]
+    private static partial Regex MaxVolumeRegex();
+}

--- a/src/ui/Logic/Media/FfmpegGenerator.cs
+++ b/src/ui/Logic/Media/FfmpegGenerator.cs
@@ -614,18 +614,47 @@ public class FfmpegGenerator
         return processMakeVideo;
     }
 
-    public static Process TrimSilenceStartAndEnd(string inputFileName, string outputFileName, DataReceivedEventHandler? dataReceivedHandler = null)
+    /// <summary>
+    /// Runs ffmpeg's volumedetect over the file; the peak arrives on stderr as
+    /// "max_volume: -2.8 dB" (parse it with <c>TtsSilenceThreshold.ParsePeakDbfs</c>).
+    /// </summary>
+    public static Process MeasurePeakVolume(string inputFileName, DataReceivedEventHandler dataReceivedHandler)
+    {
+        var process = new Process
+        {
+            StartInfo =
+            {
+                FileName = GetFfmpegLocation(),
+                Arguments = $"-nostdin -hide_banner -i \"{inputFileName}\" -vn -af volumedetect -f null -",
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
+
+        SetupDataReceiveHandler(dataReceivedHandler, process);
+
+        return process;
+    }
+
+    /// <param name="silenceThreshold">
+    /// Linear amplitude (0..1) under which a sample counts as silence. Derive it from the clip's
+    /// peak via <c>TtsSilenceThreshold.Amplitude</c>: the old fixed 0.01 (-40 dBFS) trimmed the
+    /// soft final consonant off quiet voice-clone output, cutting the last word (#14480).
+    /// </param>
+    public static Process TrimSilenceStartAndEnd(string inputFileName, string outputFileName, double silenceThreshold = 0.01, DataReceivedEventHandler? dataReceivedHandler = null)
     {
         // silenceremove keeps up to start_silence (100 ms) of the detected silence as padding.
         // No unconditional atrim cuts here: a fixed atrim=start=0.1 ahead of the detection used
         // to chop 100 ms off both ends whether or not it was silence, clipping the first/last
         // phoneme for engines that start speaking immediately (e.g. Piper).
+        var threshold = Math.Clamp(silenceThreshold, 0.000001, 1.0).ToString("0.########", CultureInfo.InvariantCulture);
+        var silenceRemove = $"silenceremove=start_periods=1:start_silence=0.1:start_threshold={threshold}";
         var processMakeVideo = new Process
         {
             StartInfo =
             {
                 FileName = GetFfmpegLocation(),
-                Arguments = $"-nostdin -y -i \"{inputFileName}\" -af \"areverse,silenceremove=start_periods=1:start_silence=0.1:start_threshold=0.01,areverse,silenceremove=start_periods=1:start_silence=0.1:start_threshold=0.01\" \"{outputFileName}\"",
+                Arguments = $"-nostdin -y -i \"{inputFileName}\" -af \"areverse,{silenceRemove},areverse,{silenceRemove}\" \"{outputFileName}\"",
                 UseShellExecute = false,
                 CreateNoWindow = true
             }
@@ -643,13 +672,17 @@ public class FfmpegGenerator
     /// without affecting phonemes at all.
     /// </summary>
     /// <param name="maxSilenceSeconds">Maximum allowed silence duration between words (e.g. 0.15 for 150ms)</param>
-    public static Process CompressInternalSilence(string inputFileName, string outputFileName, double maxSilenceSeconds = 0.15, DataReceivedEventHandler? dataReceivedHandler = null)
+    /// <param name="silenceThresholdDb">
+    /// ffmpeg dB literal (e.g. "-52.3dB") under which a sample counts as silence - relative to the
+    /// clip's peak via <c>TtsSilenceThreshold.DbLiteral</c>, for the same reason as the trim (#14480).
+    /// </param>
+    public static Process CompressInternalSilence(string inputFileName, string outputFileName, double maxSilenceSeconds = 0.15, string silenceThresholdDb = "-40dB", DataReceivedEventHandler? dataReceivedHandler = null)
     {
         var maxSilence = maxSilenceSeconds.ToString("0.00", CultureInfo.InvariantCulture);
         // silenceremove: stop_periods=-1 processes ALL silence gaps (not just first)
         // stop_duration = max allowed silence length; stop_threshold = silence detection level
         // This keeps all speech intact and only compresses pauses between words
-        var filter = $"silenceremove=stop_periods=-1:stop_duration={maxSilence}:stop_threshold=-40dB";
+        var filter = $"silenceremove=stop_periods=-1:stop_duration={maxSilence}:stop_threshold={silenceThresholdDb}";
 
         var processMakeVideo = new Process
         {
@@ -762,14 +795,20 @@ public class FfmpegGenerator
     /// <summary>
     /// Apply pro audio post-processing chain: low-pass, EQ warmth, compression, loudness normalization, noise gate, and fade in/out.
     /// </summary>
-    public static Process ApplyProAudioChain(string inputFileName, string outputFileName, DataReceivedEventHandler? dataReceivedHandler = null)
+    /// <param name="gateThreshold">
+    /// Noise-gate threshold as a linear amplitude, relative to the clip's peak via
+    /// <c>TtsSilenceThreshold.Amplitude</c> - a fixed 0.01 gated the soft word endings of quiet
+    /// voice-clone output (#14480).
+    /// </param>
+    public static Process ApplyProAudioChain(string inputFileName, string outputFileName, double gateThreshold = 0.01, DataReceivedEventHandler? dataReceivedHandler = null)
     {
+        var gate = Math.Clamp(gateThreshold, 0.000001, 1.0).ToString("0.########", CultureInfo.InvariantCulture);
         // Chain: low-pass 2400Hz → bass warmth +6dB@200Hz → treble reduce -5dB@2500Hz → noise gate → compression → loudness normalization → tiny fade in/out
         var filters = string.Join(",",
             "lowpass=f=2400",
             "equalizer=f=200:t=h:width=100:g=6",
             "equalizer=f=2500:t=h:width=500:g=-5",
-            "agate=threshold=0.01:ratio=2:attack=5:release=50",
+            $"agate=threshold={gate}:ratio=2:attack=5:release=50",
             "compand=attacks=0.3:decays=0.8:points=-80/-80|-45/-45|-27/-15|0/-3:soft-knee=6:gain=3",
             "loudnorm=I=-16:LRA=11:TP=-1.5",
             "afade=t=in:d=0.015",

--- a/tests/UI/Features/Video/TextToSpeech/TtsSilenceThresholdTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/TtsSilenceThresholdTests.cs
@@ -1,0 +1,100 @@
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech;
+
+namespace UITests.Features.Video.TextToSpeech;
+
+/// <summary>
+/// The TTS silence trim, VAD compression and noise gate judge silence relative to the clip's
+/// peak (#14480). A fixed -40 dBFS threshold cut the last word off quiet voice-clone output:
+/// measured on a real clip, a -21 dBFS peak lost its final "s" and a -33 dBFS peak was trimmed
+/// to nothing.
+/// </summary>
+public class TtsSilenceThresholdTests
+{
+    [Fact]
+    public void FullScaleClip_KeepsTheLegacyThreshold()
+    {
+        Assert.Equal(-40.0, TtsSilenceThreshold.ThresholdDbfs(0.0), 6);
+        Assert.Equal(0.01, TtsSilenceThreshold.Amplitude(0.0), 6);
+        Assert.Equal("-40.0dB", TtsSilenceThreshold.DbLiteral(0.0));
+    }
+
+    [Fact]
+    public void UnknownPeak_FallsBackToTheLegacyThreshold()
+    {
+        Assert.Equal(-40.0, TtsSilenceThreshold.ThresholdDbfs(null), 6);
+        Assert.Equal(-40.0, TtsSilenceThreshold.ThresholdDbfs(double.NaN), 6);
+        Assert.Equal(-40.0, TtsSilenceThreshold.ThresholdDbfs(double.NegativeInfinity), 6);
+        Assert.Equal(0.01, TtsSilenceThreshold.Amplitude(null), 6);
+        Assert.Equal("-40.0dB", TtsSilenceThreshold.DbLiteral(null));
+    }
+
+    [Theory]
+    [InlineData(-2.8, -42.8)]
+    [InlineData(-20.8, -60.8)]
+    [InlineData(-26.8, -66.8)]
+    public void QuietClip_ThresholdFollowsThePeak(double peakDbfs, double expectedThresholdDbfs)
+    {
+        Assert.Equal(expectedThresholdDbfs, TtsSilenceThreshold.ThresholdDbfs(peakDbfs), 6);
+        Assert.Equal(Math.Pow(10, expectedThresholdDbfs / 20), TtsSilenceThreshold.Amplitude(peakDbfs), 9);
+    }
+
+    [Fact]
+    public void VeryQuietClip_IsClampedAtTheNoiseFloor()
+    {
+        // -32.8 dBFS peak - 40 dB would be -72.8 dBFS, under a neural vocoder's noise floor;
+        // the clamp keeps trailing silence trimmable.
+        Assert.Equal(TtsSilenceThreshold.FloorDbfs, TtsSilenceThreshold.ThresholdDbfs(-32.8), 6);
+        Assert.Equal(TtsSilenceThreshold.FloorDbfs, TtsSilenceThreshold.ThresholdDbfs(-90.0), 6);
+    }
+
+    [Fact]
+    public void HotFloatClip_NeverTrimsHarderThanTheLegacyThreshold()
+    {
+        // A float WAV peaking above 0 dBFS would otherwise get a threshold above 0.01.
+        Assert.Equal(-40.0, TtsSilenceThreshold.ThresholdDbfs(3.5), 6);
+    }
+
+    [Fact]
+    public void DbLiteral_IsInvariantCulture()
+    {
+        var previous = Thread.CurrentThread.CurrentCulture;
+        try
+        {
+            Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("da-DK");
+            Assert.Equal("-60.8dB", TtsSilenceThreshold.DbLiteral(-20.8));
+        }
+        finally
+        {
+            Thread.CurrentThread.CurrentCulture = previous;
+        }
+    }
+
+    [Fact]
+    public void ParsePeakDbfs_FindsVolumedetectsMaxVolume()
+    {
+        var lines = new[]
+        {
+            "Input #0, wav, from 'x.wav':",
+            "[Parsed_volumedetect_0 @ 0x7f8] n_samples: 33168",
+            "[Parsed_volumedetect_0 @ 0x7f8] mean_volume: -16.0 dB",
+            "[Parsed_volumedetect_0 @ 0x7f8] max_volume: -2.8 dB",
+            "[Parsed_volumedetect_0 @ 0x7f8] histogram_2db: 12",
+        };
+
+        Assert.Equal(-2.8, TtsSilenceThreshold.ParsePeakDbfs(lines));
+    }
+
+    [Fact]
+    public void ParsePeakDbfs_HandlesPositiveAndIntegerPeaks()
+    {
+        Assert.Equal(0.0, TtsSilenceThreshold.ParsePeakDbfs(new[] { "[Parsed_volumedetect_0 @ 0x1] max_volume: 0 dB" }));
+        Assert.Equal(1.2, TtsSilenceThreshold.ParsePeakDbfs(new[] { "[Parsed_volumedetect_0 @ 0x1] max_volume: 1.2 dB" }));
+    }
+
+    [Fact]
+    public void ParsePeakDbfs_ReturnsNullWithoutAPeakLine()
+    {
+        Assert.Null(TtsSilenceThreshold.ParsePeakDbfs(Array.Empty<string>()));
+        Assert.Null(TtsSilenceThreshold.ParsePeakDbfs(new[] { "x.wav: No such file or directory" }));
+    }
+}

--- a/tests/UI/Features/Video/TextToSpeech/TtsSilenceTrimFfmpegTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/TtsSilenceTrimFfmpegTests.cs
@@ -1,0 +1,155 @@
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech;
+using Nikse.SubtitleEdit.Logic.Media;
+using System.Diagnostics;
+
+namespace UITests.Features.Video.TextToSpeech;
+
+/// <summary>
+/// Runs the real ffmpeg trim the TTS pipeline uses on a synthetic "word": a loud vowel followed
+/// by a soft fricative, at a quiet overall level like voice-clone output. With the old fixed
+/// -40 dBFS threshold the fricative is trimmed off as silence (the cut last word of #14480);
+/// with the threshold derived from the measured peak it survives. Skipped when no ffmpeg can be
+/// started (Windows CI without a configured ffmpeg).
+/// </summary>
+public class TtsSilenceTrimFfmpegTests
+{
+    // 0.3 s silence, 0.6 s sine at -20 dBFS (peak), 0.25 s band-limited noise at about -46 dBFS
+    // (a word-final "s" on a quiet clip), 0.5 s silence.
+    private const double VowelSeconds = 0.6;
+    private const double FricativeSeconds = 0.25;
+
+    [Fact]
+    public async Task QuietClip_PeakRelativeTrimKeepsTheFinalConsonant()
+    {
+        if (!FfmpegRuns())
+        {
+            return;
+        }
+
+        var folder = Path.Combine(Path.GetTempPath(), "se-tts-trim-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(folder);
+        try
+        {
+            var clip = Path.Combine(folder, "quiet-word.wav");
+            await MakeQuietWordAsync(clip);
+
+            var peak = await TtsSilenceThreshold.MeasurePeakDbfsAsync(clip, CancellationToken.None);
+            Assert.NotNull(peak);
+            Assert.InRange(peak!.Value, -21.5, -18.5);
+
+            var legacyTrim = Path.Combine(folder, "legacy.wav");
+            using (var legacy = FfmpegGenerator.TrimSilenceStartAndEnd(clip, legacyTrim, 0.01))
+            {
+                await legacy.StartAndWaitAsync(CancellationToken.None);
+            }
+
+            var relativeTrim = Path.Combine(folder, "relative.wav");
+            using (var relative = FfmpegGenerator.TrimSilenceStartAndEnd(clip, relativeTrim, TtsSilenceThreshold.Amplitude(peak)))
+            {
+                await relative.StartAndWaitAsync(CancellationToken.None);
+            }
+
+            var legacySeconds = WavSeconds(legacyTrim);
+            var relativeSeconds = WavSeconds(relativeTrim);
+
+            // Old behaviour, documented so a regression is recognisable: the fricative is gone,
+            // only the vowel plus the 100 ms of kept silence on each side remains.
+            Assert.InRange(legacySeconds, VowelSeconds + 0.1, VowelSeconds + 0.3);
+
+            // New behaviour: vowel + fricative + up to 100 ms kept silence on each side.
+            var expected = VowelSeconds + FricativeSeconds;
+            Assert.InRange(relativeSeconds, expected + 0.1, expected + 0.3);
+            Assert.True(relativeSeconds - legacySeconds > FricativeSeconds * 0.8,
+                $"peak-relative trim kept {relativeSeconds:0.000}s, legacy kept {legacySeconds:0.000}s - the fricative was not preserved");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(folder, true);
+            }
+            catch
+            {
+                // best effort
+            }
+        }
+    }
+
+    [Fact]
+    public async Task MeasurePeak_ReturnsNullForAMissingFile()
+    {
+        if (!FfmpegRuns())
+        {
+            return;
+        }
+
+        var missing = Path.Combine(Path.GetTempPath(), "se-tts-trim-" + Guid.NewGuid().ToString("N") + ".wav");
+        Assert.Null(await TtsSilenceThreshold.MeasurePeakDbfsAsync(missing, CancellationToken.None));
+    }
+
+    private static async Task MakeQuietWordAsync(string outputFileName)
+    {
+        // aevalsrc with an explicit 0.1 amplitude = exactly -20 dBFS peak (ffmpeg's sine source
+        // has its own fixed -18 dBFS amplitude, so a volume multiplier on it would land elsewhere);
+        // the noise is generated at about -46 dBFS peak and band-passed so it resembles a
+        // fricative rather than full-band hiss - under the old -40 dBFS threshold, above the
+        // peak-relative -60 dBFS one.
+        var inv = System.Globalization.CultureInfo.InvariantCulture;
+        var filter =
+            "aevalsrc=0:d=0.3:s=24000[s1];" +
+            $"aevalsrc='0.1*sin(2*PI*220*t)':d={VowelSeconds.ToString(inv)}:s=24000[v];" +
+            $"anoisesrc=color=white:sample_rate=24000:duration={FricativeSeconds.ToString(inv)}:amplitude=0.005,highpass=f=3000[f];" +
+            "aevalsrc=0:d=0.5:s=24000[s2];" +
+            "[s1][v][f][s2]concat=n=4:v=0:a=1,aformat=sample_fmts=s16:channel_layouts=mono[out]";
+        var arguments = $"-nostdin -y -filter_complex \"{filter}\" -map [out] \"{outputFileName}\"";
+        using var process = FfmpegGenerator.GetProcess(arguments, (_, _) => { });
+        await process.StartAndWaitAsync(CancellationToken.None);
+        Assert.True(File.Exists(outputFileName) && new FileInfo(outputFileName).Length > 44, "ffmpeg did not produce the test clip");
+    }
+
+    private static bool FfmpegRuns()
+    {
+        try
+        {
+            using var process = FfmpegGenerator.GetProcess("-version", (_, _) => { });
+            process.Start();
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+            return process.WaitForExit(10_000) && process.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>Duration from the RIFF header - independent of ffmpeg's own probing.</summary>
+    private static double WavSeconds(string fileName)
+    {
+        Assert.True(File.Exists(fileName), $"trim produced no file: {fileName}");
+        var bytes = File.ReadAllBytes(fileName);
+        Assert.True(bytes.Length > 44, $"trim produced an empty wav: {fileName}");
+
+        var byteRate = 0;
+        var pos = 12;
+        while (pos + 8 <= bytes.Length)
+        {
+            var id = System.Text.Encoding.ASCII.GetString(bytes, pos, 4);
+            var size = BitConverter.ToInt32(bytes, pos + 4);
+            if (id == "fmt ")
+            {
+                byteRate = BitConverter.ToInt32(bytes, pos + 16);
+            }
+            else if (id == "data")
+            {
+                Assert.True(byteRate > 0, "fmt chunk missing");
+                var dataBytes = size <= 0 || size > bytes.Length - pos - 8 ? bytes.Length - pos - 8 : size;
+                return dataBytes / (double)byteRate;
+            }
+
+            pos += 8 + size + (size & 1);
+        }
+
+        throw new InvalidDataException("no data chunk in " + fileName);
+    }
+}


### PR DESCRIPTION
## Why

Addresses the "last word is cut off / speech stops before the sentence ends" part of #14480.

The text is never shortened: every engine gets the whole line. The **audio** is. Every generated clip goes through `TrimSilenceStartAndEnd` before the speed fix, and that filter (plus the optional VAD pause compression and the pro-chain noise gate) used a fixed `0.01` = **-40 dBFS** silence threshold. Voice cloning engines reproduce the loudness of their reference, and a reference cut from film dialogue often peaks at -20 to -30 dBFS. On such a clip the soft final consonant sits under -40 dBFS, is treated as silence and trimmed away. The Review window's regenerate path runs the same filter, which is why re-dubbing a line did not help.

Reproduced with a macOS `say` clip of *"The cats sat on the mats."* run through the exact filter at different levels:

| Clip peak | Trimmed length | Result |
|---|---|---|
| -2.8 dBFS (original) | 1.382 s | intact |
| -14.8 dBFS | 1.382 s | intact |
| -20.8 dBFS | 1.235 s | final "s" of "mats" cut |
| -26.8 dBFS | 1.171 s | most of "mats" cut |
| -32.8 dBFS | empty file | whole line treated as silence |

## What

* New `TtsSilenceThreshold`: measures the clip's peak with one `ffmpeg -af volumedetect` pass and derives the silence threshold as **peak - 40 dB**, clamped at -70 dBFS (so trailing silence stays trimmable under a vocoder's noise floor) and never above the old 0.01 (so loud clips trim exactly as before). A null peak (unreadable file) falls back to the old fixed threshold.
* `FfmpegGenerator.TrimSilenceStartAndEnd`, `CompressInternalSilence` and `ApplyProAudioChain` take the threshold as a parameter (defaults unchanged).
* `FixSpeed` in the main pipeline, the Review window's regenerate path and `TtsPostProcessor`'s pro chain pass the peak-relative threshold. The tools log gets one line per segment with the measured peak and the threshold used.

With the relative threshold, all three quiet variants of the test clip above trim to the identical 1.382 s.

## Put to the test

* `TtsSilenceThresholdTests` (11 tests): the threshold math, clamps, invariant culture, `volumedetect` parsing.
* `TtsSilenceTrimFfmpegTests`: runs the real ffmpeg trim on a synthetic quiet "word" (a -20 dBFS vowel followed by a -46 dBFS fricative) and asserts the old threshold drops the fricative while the peak-relative one keeps it. Skips when no ffmpeg can be started.
* Re-ran the old vs. new trim over ~250 real clips left on this machine by eight engines (OmniVoice, Kokoro, Qwen3 TTS, Chatterbox, VibeVoice, MOSS, CosyVoice3). Median difference at both ends: **0 ms** - loud clips are trimmed as before. Where they differ, the new trim keeps either a soft word tail or, on clips whose noise floor is within 40 dB of the peak (some VibeVoice/Qwen3 output), up to a few hundred ms of hiss ~30 dB under the speech. That is the accepted trade-off: a narrower window starts eating "f"/"th" endings again.
* All 509 TTS- and ffmpeg-related UI tests pass.

Not covered here: the unbounded time-stretch factor (a clip 3x too long is played at 3x), which is the "words not finished properly" feeling rather than a real cut. Worth a separate change with a cap and a flag in the review window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
