### PR TITLE
Keep the grid selection and view after merging lines with the same text / time codes

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -7253,6 +7253,8 @@ public partial class MainViewModel :
             return;
         }
 
+        var selectedBefore = SelectedSubtitle;
+        var idsBefore = Subtitles.Select(p => p.Id).ToList();
         var result = await ShowDialogAsync<MergeSameTextWindow, MergeSameTextViewModel>(vm => { vm.Initialize(Subtitles.Select(p => new SubtitleLineViewModel(p)).ToList()); });
 
         if (!result.OkPressed)
@@ -7260,9 +7262,7 @@ public partial class MainViewModel :
             return;
         }
 
-        ReplaceSubtitles(result.ResultSubtitles.Select(p => new SubtitleLineViewModel(p)));
-        Renumber();
-        SelectAndScrollToRow(0);
+        ApplyMergeDialogResult(result.ResultSubtitles, selectedBefore, idsBefore);
     }
 
     [RelayCommand]
@@ -7279,6 +7279,8 @@ public partial class MainViewModel :
             return;
         }
 
+        var selectedBefore = SelectedSubtitle;
+        var idsBefore = Subtitles.Select(p => p.Id).ToList();
         var result = await ShowDialogAsync<MergeSameTimeCodesWindow, MergeSameTimeCodesViewModel>(vm =>
         {
             vm.Initialize(Subtitles.Select(p => new SubtitleLineViewModel(p)).ToList(), GetUpdateSubtitle());
@@ -7289,9 +7291,7 @@ public partial class MainViewModel :
             return;
         }
 
-        ReplaceSubtitles(result.ResultSubtitles.Select(p => new SubtitleLineViewModel(p)));
-        Renumber();
-        SelectAndScrollToRow(0);
+        ApplyMergeDialogResult(result.ResultSubtitles, selectedBefore, idsBefore);
     }
 
     [RelayCommand]
@@ -21232,6 +21232,140 @@ public partial class MainViewModel :
             SetSubtitles(fixedSubtitles);
             SelectAndScrollToRow(Math.Min(selectedIndex, Subtitles.Count - 1));
         }
+    }
+
+    /// <summary>
+    /// Puts the lines a merge dialog (same text / same time codes) returns into the grid without
+    /// losing the user's place. The dialog works on copies that keep the row ids, and a merged
+    /// line keeps the id of the first line it was built from - so every line that survived maps
+    /// back to the row it came from. Those rows are updated in place and reused, and the row
+    /// that was current is selected again; when that row was one of the lines merged away, the
+    /// nearest line above it that survived is the merged line, so that one becomes current. The
+    /// grid stayed on row 0 before this, which threw away the position on every merge.
+    /// </summary>
+    /// <param name="mergedLines">The dialog's result, in order.</param>
+    /// <param name="selectedBefore">The current row when the dialog opened, if any.</param>
+    /// <param name="idsBefore">The row ids in grid order when the dialog opened.</param>
+    private void ApplyMergeDialogResult(
+        List<SubtitleLineViewModel> mergedLines,
+        SubtitleLineViewModel? selectedBefore,
+        IReadOnlyList<Guid> idsBefore)
+    {
+        // Capture before the rebuild: removing rows drops focus out of the grid, and the check
+        // inside SelectAndScrollToRow would then say no (see its restoreGridFocus). Focus being
+        // nowhere counts as the grid's, as for delete - the dialog that just closed took it.
+        var gridHadFocus = IsSubtitleGridFocusedOrFocusDropped();
+
+        var rowById = new Dictionary<Guid, SubtitleLineViewModel>(Subtitles.Count);
+        foreach (var row in Subtitles)
+        {
+            rowById.TryAdd(row.Id, row);
+        }
+
+        var rows = new List<SubtitleLineViewModel>(mergedLines.Count);
+        var kept = new HashSet<SubtitleLineViewModel>();
+        foreach (var line in mergedLines)
+        {
+            if (rowById.TryGetValue(line.Id, out var row) && kept.Add(row))
+            {
+                row.UpdateFrom(line);
+                rows.Add(row);
+            }
+            else
+            {
+                rows.Add(new SubtitleLineViewModel(line));
+            }
+        }
+
+        var target = rows.Count == 0 ? null : FindSurvivingRow(rows, selectedBefore, idsBefore) ?? rows[0];
+
+        // A merge only ever takes rows away, so the result is normally the current rows minus the
+        // merged-away ones, in the same order. Then the rows to drop are removed one by one, the
+        // way delete does it: the grid keeps its items, its scroll offset and (via the survivor
+        // hand-over inside) its selection, so the view does not move at all.
+        var removed = Subtitles.Where(row => !kept.Contains(row)).ToList();
+        if (rows.Count + removed.Count == Subtitles.Count && Subtitles.Where(kept.Contains).SequenceEqual(rows))
+        {
+            RemoveRowsAndSelectSurvivor(removed, target, gridHadFocus);
+            UpdateGaps();
+            return;
+        }
+
+        // Re-attaching the items keeps the grid's old selected *index*, which after a merge is
+        // some other row, and the TwoWay binding would write that row into SelectedSubtitle.
+        // Hand the grid the target itself right after the swap, with the selection-changed
+        // handler silenced for the swap, as RemoveRowsAndSelectSurvivor does.
+        var wasSkipping = _subtitleGridSelectionChangedSkip;
+        _subtitleGridSelectionChangedSkip = true;
+        try
+        {
+            ReplaceSubtitles(rows);
+            if (target != null)
+            {
+                SubtitleGrid.SelectedItem = target;
+            }
+        }
+        finally
+        {
+            _subtitleGridSelectionChangedSkip = wasSkipping;
+        }
+
+        Renumber();
+        UpdateGaps();
+
+        if (target != null)
+        {
+            SubtitleGridSelectionChanged();
+            SelectAndScrollToRow(target, gridHadFocus);
+        }
+    }
+
+    /// <summary>
+    /// The row to make current after a merge: <paramref name="selectedBefore"/> itself when it is
+    /// among <paramref name="rows"/>, otherwise the closest row above it (by the pre-merge order in
+    /// <paramref name="idsBefore"/>) that is - which for a line merged away is the line it was
+    /// merged into. Null when nothing above it survived either.
+    /// </summary>
+    private static SubtitleLineViewModel? FindSurvivingRow(
+        IReadOnlyList<SubtitleLineViewModel> rows,
+        SubtitleLineViewModel? selectedBefore,
+        IReadOnlyList<Guid> idsBefore)
+    {
+        if (selectedBefore == null)
+        {
+            return null;
+        }
+
+        var rowById = new Dictionary<Guid, SubtitleLineViewModel>(rows.Count);
+        foreach (var row in rows)
+        {
+            rowById.TryAdd(row.Id, row);
+        }
+
+        if (rowById.TryGetValue(selectedBefore.Id, out var same))
+        {
+            return same;
+        }
+
+        var index = -1;
+        for (var i = 0; i < idsBefore.Count; i++)
+        {
+            if (idsBefore[i] == selectedBefore.Id)
+            {
+                index = i;
+                break;
+            }
+        }
+
+        for (var i = index - 1; i >= 0; i--)
+        {
+            if (rowById.TryGetValue(idsBefore[i], out var above))
+            {
+                return above;
+            }
+        }
+
+        return null;
     }
 
     public void SelectAndScrollToSubtitle(SubtitleLineViewModel subtitle)

--- a/tests/UI/Features/Main/ApplyMergeDialogResultTests.cs
+++ b/tests/UI/Features/Main/ApplyMergeDialogResultTests.cs
@@ -1,0 +1,284 @@
+using System.Reflection;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// The lines "Merge lines with same text" / "Merge lines with same time codes" return go back
+/// onto the rows they came from, and the row that was current stays current - the grid used to
+/// jump to row 0 after every merge, losing the user's place in the file.
+/// </summary>
+public class ApplyMergeDialogResultTests
+{
+    [AvaloniaFact]
+    public async Task SelectedLineSurvives_StaysCurrentOnTheSameRow()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Same", 0, 1000);
+            AddLine(vm, "Same", 1000, 2000);
+            AddLine(vm, "Three", 2000, 3000);
+            AddLine(vm, "Four", 3000, 4000);
+            var rows = vm.Subtitles.ToList();
+            SelectInGrid(vm, rows[2]);
+            Settle(window);
+
+            var selectedBefore = vm.SelectedSubtitle;
+            var idsBefore = vm.Subtitles.Select(p => p.Id).ToList();
+            var merged = MergeFirstTwo(rows);
+            ApplyMergeDialogResult(vm, merged, selectedBefore, idsBefore);
+            await SettleAsync(window);
+
+            Assert.Equal(new[] { "Same", "Three", "Four" }, vm.Subtitles.Select(p => p.Text));
+            Assert.Equal(2000, vm.Subtitles[0].EndTime.TotalMilliseconds);
+            Assert.Equal(new[] { 1, 2, 3 }, vm.Subtitles.Select(p => p.Number));
+
+            // Same row instances for every line that survived, and the current row is still "Three".
+            Assert.Same(rows[0], vm.Subtitles[0]);
+            Assert.Same(rows[2], vm.Subtitles[1]);
+            Assert.Same(rows[3], vm.Subtitles[2]);
+            Assert.Same(rows[2], vm.SelectedSubtitle);
+            Assert.Same(rows[2], vm.SubtitleGrid.SelectedItem);
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task SelectedLineMergedAway_MakesTheMergedLineCurrent()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "One", 0, 1000);
+            AddLine(vm, "Same", 1000, 2000);
+            AddLine(vm, "Same", 2000, 3000);
+            AddLine(vm, "Four", 3000, 4000);
+            var rows = vm.Subtitles.ToList();
+
+            // The second of the two "Same" lines is current - it is consumed by the merge.
+            SelectInGrid(vm, rows[2]);
+            Settle(window);
+
+            var selectedBefore = vm.SelectedSubtitle;
+            var idsBefore = vm.Subtitles.Select(p => p.Id).ToList();
+            var merged = new List<SubtitleLineViewModel>
+            {
+                new(rows[0]),
+                new(rows[1]) { EndTime = rows[2].EndTime },
+                new(rows[3]),
+            };
+            ApplyMergeDialogResult(vm, merged, selectedBefore, idsBefore);
+            await SettleAsync(window);
+
+            Assert.Equal(new[] { "One", "Same", "Four" }, vm.Subtitles.Select(p => p.Text));
+            Assert.Same(rows[1], vm.Subtitles[1]);
+            Assert.Same(rows[1], vm.SelectedSubtitle);
+            Assert.Same(rows[1], vm.SubtitleGrid.SelectedItem);
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task NothingSelected_SelectsTheFirstRow()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Same", 0, 1000);
+            AddLine(vm, "Same", 1000, 2000);
+            AddLine(vm, "Three", 2000, 3000);
+            var rows = vm.Subtitles.ToList();
+            Settle(window);
+
+            var idsBefore = vm.Subtitles.Select(p => p.Id).ToList();
+            ApplyMergeDialogResult(vm, MergeFirstTwo(rows), null, idsBefore);
+            await SettleAsync(window);
+
+            Assert.Equal(2, vm.Subtitles.Count);
+            Assert.Same(rows[0], vm.SelectedSubtitle);
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    /// <summary>
+    /// The view must not move either: merging lines far above the current row removes those
+    /// rows in place, and the row the user was looking at stays on screen where it was.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task MergeAboveTheView_KeepsTheCurrentRowOnScreen()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            for (var i = 0; i < 300; i++)
+            {
+                AddLine(vm, i < 2 ? "Same" : $"Line {i + 1}", i * 2000, i * 2000 + 1500);
+            }
+
+            Settle(window);
+            var rows = vm.Subtitles.ToList();
+            vm.SelectAndScrollToSubtitle(rows[200]);
+            await SettleAsync(window);
+            Assert.True(TableViewExtras.IsRowFullyVisible(vm.SubtitleGrid, rows[200]));
+
+            var selectedBefore = vm.SelectedSubtitle;
+            var idsBefore = vm.Subtitles.Select(p => p.Id).ToList();
+            ApplyMergeDialogResult(vm, MergeFirstTwo(rows), selectedBefore, idsBefore);
+            await SettleAsync(window);
+
+            Assert.Equal(299, vm.Subtitles.Count);
+            Assert.Same(rows[200], vm.SelectedSubtitle);
+            Assert.Same(rows[200], vm.SubtitleGrid.SelectedItem);
+            Assert.Equal(199, vm.SubtitleGrid.SelectedIndex);
+            Assert.True(TableViewExtras.IsRowFullyVisible(vm.SubtitleGrid, rows[200]));
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    /// <summary>
+    /// A line the grid has no row for (a fresh id) cannot be removed in place; the rows are then
+    /// rebuilt, and the current row must still come back.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task UnknownLine_RebuildsTheRowsAndStillKeepsTheCurrentRow()
+    {
+        var (window, vm) = CreateMainViewModel();
+        try
+        {
+            AddLine(vm, "Same", 0, 1000);
+            AddLine(vm, "Same", 1000, 2000);
+            AddLine(vm, "Three", 2000, 3000);
+            var rows = vm.Subtitles.ToList();
+            SelectInGrid(vm, rows[2]);
+            Settle(window);
+
+            var selectedBefore = vm.SelectedSubtitle;
+            var idsBefore = vm.Subtitles.Select(p => p.Id).ToList();
+            var merged = new List<SubtitleLineViewModel>
+            {
+                new(rows[0], generateNewId: true) { EndTime = rows[1].EndTime },
+                new(rows[2]),
+            };
+            ApplyMergeDialogResult(vm, merged, selectedBefore, idsBefore);
+            await SettleAsync(window);
+
+            Assert.Equal(new[] { "Same", "Three" }, vm.Subtitles.Select(p => p.Text));
+            Assert.NotSame(rows[0], vm.Subtitles[0]);
+            Assert.Same(rows[2], vm.Subtitles[1]);
+            Assert.Same(rows[2], vm.SelectedSubtitle);
+            Assert.Same(rows[2], vm.SubtitleGrid.SelectedItem);
+        }
+        finally
+        {
+            CloseWindow(window, vm);
+        }
+    }
+
+    /// <summary>The shape the merge dialogs return: copies that keep the ids, the merged line built
+    /// from the first line of its group with the group's last end time.</summary>
+    private static List<SubtitleLineViewModel> MergeFirstTwo(List<SubtitleLineViewModel> rows)
+    {
+        var result = new List<SubtitleLineViewModel> { new(rows[0]) { EndTime = rows[1].EndTime } };
+        result.AddRange(rows.Skip(2).Select(p => new SubtitleLineViewModel(p)));
+        return result;
+    }
+
+    private static void ApplyMergeDialogResult(
+        MainViewModel vm,
+        List<SubtitleLineViewModel> mergedLines,
+        SubtitleLineViewModel? selectedBefore,
+        IReadOnlyList<Guid> idsBefore)
+    {
+        typeof(MainViewModel)
+            .GetMethod("ApplyMergeDialogResult", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(vm, new object?[] { mergedLines, selectedBefore, idsBefore });
+    }
+
+    // Assigning SelectedSubtitle alone leaves SubtitleGrid.SelectedItems empty.
+    private static void SelectInGrid(MainViewModel vm, SubtitleLineViewModel row)
+    {
+        vm.SubtitleGrid.SelectedItems?.Clear();
+        vm.SubtitleGrid.SelectedItem = row;
+    }
+
+    private static void Settle(Window window)
+    {
+        for (var pump = 0; pump < 8; pump++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+        }
+    }
+
+    // The selection is posted, so give the dispatcher a real tick as well.
+    private static async Task SettleAsync(Window window)
+    {
+        Settle(window);
+        await Task.Delay(50);
+        Settle(window);
+    }
+
+    private static (Window Window, MainViewModel Vm) CreateMainViewModel()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1200, Height = 800 };
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var vm = (MainViewModel)view.DataContext!;
+        window.SuppressSaveChangesPromptOnClose(vm);
+        return (window, vm);
+    }
+
+    private static SubtitleLineViewModel AddLine(MainViewModel vm, string text, int startMs, int endMs)
+    {
+        var line = new SubtitleLineViewModel(new Paragraph(text, startMs, endMs), null!)
+        {
+            Number = vm.Subtitles.Count + 1,
+        };
+
+        vm.Subtitles.Add(line);
+        return line;
+    }
+
+    private static void CloseWindow(Window window, MainViewModel vm)
+    {
+        foreach (var ownedWindow in window.OwnedWindows.ToArray())
+        {
+            ownedWindow.Close();
+        }
+
+        window.Closing -= vm.OnClosing;
+        if (window.IsVisible)
+        {
+            window.Close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- "Merge lines with same text" and "Merge lines with same time codes" replaced every grid row and then selected row 0, so the user's place in the file was lost on every merge.
- Both now go through a shared `ApplyMergeDialogResult`: the dialog's result is mapped back onto the existing rows by id (the dialog copies keep the ids; a merged line keeps the id of the first line of its group), the surviving rows are updated in place and reused, and the merged-away rows are removed one by one through the same survivor-selecting removal path delete uses - the grid keeps its items and its scroll offset, so the view does not move.
- The row that was current is selected again. If it was one of the lines merged away, the nearest surviving row above it (the merged line it went into) becomes current.
- Fallback for a result line with an unknown id: the rows are rebuilt, with the target row handed to the grid synchronously around the swap so the grid's remembered old index cannot leak into the selection.

## Test plan
- [x] New headless tests in `ApplyMergeDialogResultTests`: selected line survives, selected line merged away, nothing selected, 300-line file where the current row stays on screen after merging lines far above it, unknown-id fallback.
- [x] Full UI test project: 4715 passed, 0 failed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)