### PR TITLE
Fix compile warnings

### DIFF
--- a/src/libse/SubtitleFormats/DvbTeletext.cs
+++ b/src/libse/SubtitleFormats/DvbTeletext.cs
@@ -33,7 +33,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         /// <summary>
         /// The teletext page the subtitles ride on - kept from the loaded file (or the save
-        /// options dialog) via the subtitle header, see <see cref="CreateHeader"/>.
+        /// options dialog) via the subtitle header, see <see cref="CreateHeader(int, string, bool)"/>.
         /// </summary>
         public int PageNumber { get; set; } = 888;
 

--- a/tests/benchmarks/PerfHuntRound14Benchmarks.cs
+++ b/tests/benchmarks/PerfHuntRound14Benchmarks.cs
@@ -1187,7 +1187,7 @@ public class PerfHuntRound14Benchmarks
         return d;
     }
 
-    private static string GetCodeFromLetter_Current(string letter)
+    private static string? GetCodeFromLetter_Current(string letter)
     {
         var code = SccLetters.FirstOrDefault(x => x.Value == letter);
         if (code.Equals(new KeyValuePair<string, string>()))
@@ -1198,7 +1198,7 @@ public class PerfHuntRound14Benchmarks
         return code.Key;
     }
 
-    private static string GetCodeFromLetter_Candidate(string letter)
+    private static string? GetCodeFromLetter_Candidate(string letter)
     {
         return SccReverse.TryGetValue(letter, out var code) ? code : null;
     }

--- a/tests/benchmarks/PerfHuntRound17Benchmarks.cs
+++ b/tests/benchmarks/PerfHuntRound17Benchmarks.cs
@@ -1045,6 +1045,11 @@ public class PerfHuntRound17Benchmarks
     private static List<byte> NewEbuEncode(string[] lines, Encoding encoding)
     {
         var textBytes = new List<byte>();
+
+        // Allocated once outside the loops - a stackalloc per character would grow the frame
+        // for every character in the file (CA2014).
+        Span<char> chars = stackalloc char[1];
+        Span<byte> bytes = stackalloc byte[8];
         foreach (var line in lines)
         {
             var i = 0;
@@ -1107,9 +1112,7 @@ public class PerfHuntRound17Benchmarks
                     }
                     else
                     {
-                        Span<char> chars = stackalloc char[1];
                         chars[0] = ch;
-                        Span<byte> bytes = stackalloc byte[8];
                         var count = encoding.GetBytes(chars, bytes);
                         for (var k = 0; k < count; k++)
                         {


### PR DESCRIPTION
Clears every compile warning. Debug and Release both build with zero warnings afterwards.

### `CS0419` — ambiguous `cref` (the only warning in the solution)

`src/libse/SubtitleFormats/DvbTeletext.cs:36` — the `<see cref="CreateHeader"/>` on `PageNumber` matched both the two-arg and three-arg overloads. Now points at `CreateHeader(int, string, bool)`, the overload the two-arg one delegates to and that both callers reach. Doc comment only.

Reported twice, once per target framework (`netstandard2.1` and `net10.0`).

### `CS8603` ×2 — possible null reference return

`tests/benchmarks/PerfHuntRound14Benchmarks.cs` — `GetCodeFromLetter_Current` and `GetCodeFromLetter_Candidate` return `null` on purpose, and all three call sites already write `?? "--"`. The declared return type was simply missing the annotation, so they are now `string?`.

### `CA2014` ×2 — potential stack overflow

`tests/benchmarks/PerfHuntRound17Benchmarks.cs` — `NewEbuEncode` had `stackalloc char[1]` and `stackalloc byte[8]` inside a loop that runs once per character, so the stack frame grew for every character encoded. Both are hoisted to the top of the method.

Worth noting the shipping code is **not** affected: `src/libse/SubtitleFormats/Ebu.cs:826` has the same two `stackalloc`s, but there they sit inside their own `AddEncodedChar` method, so each call's frame is released on return. Only the benchmark's inlined copy had the problem.

### Why the benchmark warnings were not visible

`tests/benchmarks/UiBenchmarks.csproj` is not referenced by `SubtitleEdit.sln`, so a normal solution build never compiles it. Those three warnings only appear when the project is built on its own.

## Test plan

- `dotnet build SubtitleEdit.sln -t:Rebuild` (Debug) — 0 warnings, 0 errors
- `dotnet build SubtitleEdit.sln -c Release -t:Rebuild` — 0 warnings, 0 errors
- `dotnet build tests/benchmarks/UiBenchmarks.csproj -c Release -t:Rebuild` — 0 warnings, 0 errors

No behavior changes: a doc comment, two nullability annotations, and a hoist that does not alter what the benchmark computes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)