### PR TITLE
Release v5.2.0-rc2

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -3,6 +3,28 @@ Subtitle Edit Changelog
 
 -----------------------------------------------------------------------------------------------------
 
+v5.2.0-rc2 (4th of September 2026)
+
+* Add waveform vertical zoom shortcuts to the Point sync and Visual sync dialogs - thx perkesfurmah-collab
+* Add "Auto detect" language to the remaining Crisp ASR backends (Ark, Canary, Cohere, FireRed, Fun-ASR Nano, Granite, Kyutai) - thx subof
+* Add "Guess end time from waveform", and offsets for both guess commands - thx m0ck69
+* Add the subtitle type (normal / hearing impaired) to the DVB teletext export
+* Burn in Blu-ray sup subtitles from the image-based editor and in batch convert - thx josemorgado107
+* Export image: honor inline <font face> and <font size> per segment - thx Victory61
+* Second subtitle: follow the preview font and add a Bold option - thx GrampaWildWilly
+* Keep "Open second subtitle file..." available while a second subtitle is shown - thx GrampaWildWilly
+* Text to speech: judge silence relative to the clip's peak so quiet voice clones keep their last word - thx invio-a11y
+* Fix "guess start time from waveform" only firing while the waveform had focus - thx m0ck69
+* Fix the subtitle grid churning and slowing down when merging with a read-only original - thx torvchen
+* Fix the grid selection and view jumping after merging lines with the same text / time codes
+* Fix an extra character from DVD OCR when the leftmost glyph has a descender - thx FunkyKnilch
+* Update Catalan translation - thx jmontane
+* Update Italian translation - thx bovirus
+* Update Japanese translation - thx hisui3393
+* Update Korean translation - thx 12si27
+
+-----------------------------------------------------------------------------------------------------
+
 v5.2.0-rc1 (3rd of September 2026)
 
 * Add "Open recent video" to the Video menu - thx ghostminhtoan

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "Subtitle Edit",
-  "version": "v5.2.0-rc1",
+  "version": "v5.2.0-rc2",
   "translatedBy": "",
   "cultureName": "en-US",
   "general": {

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -20,7 +20,7 @@ public class Se
     internal const int CurrentMacOsFontMigrationVersion = 1;
     internal const int CurrentShortcutsMigrationVersion = 2;
 
-    public static string Version { get; set; } = "v5.2.0-rc1";
+    public static string Version { get; set; } = "v5.2.0-rc2";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
Second release candidate of the 5.2 cycle.

- `Se.Version` and the `version` field in `English.json` bumped to `v5.2.0-rc2`.
- New change-log section covering the **18 PRs** merged since the `v5.2.0-rc1` tag (each merge commit ancestor-checked against the tag).

## What went in

**Added**
- Waveform vertical zoom shortcuts in Point sync / Visual sync (#14487)
- "Auto detect" language for the remaining Crisp ASR backends (#14485)
- "Guess end time from waveform" plus offsets for both guess commands (#14473)
- Subtitle type (normal / hearing impaired) in the DVB teletext export (#14492)
- Blu-ray sup burn-in from the image-based editor and batch convert (#14488, #14489)
- Inline `<font face>` / `<font size>` honored per segment on image export (#14477)
- Secondary subtitle follows the preview font, gains a Bold option (#14469), and "Open second subtitle file..." stays available (#14470)
- TTS silence trim judged against the clip's peak (#14491)

**Fixed**
- "Guess start time from waveform" only firing with waveform focus (#14473)
- Grid churn when merging with a read-only original (#14482)
- Grid selection/view jumping after merge-same-text / merge-same-time-codes (#14497)
- Extra character from DVD OCR on a leftmost descender glyph (#14490)

**Translations** — Catalan (#14493), Italian (#14471), Japanese (#14474), Korean (#14475)

**Left out of the change-log:** #14498 (compile-warning cleanup, no user-visible effect).

## Verification
- `dotnet build src/ui/UI.csproj` — succeeded, 0 warnings
- Language + update-check tests: 55 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)