### PR TITLE
Add the Vietnamese Parakeet model to Crisp ASR speech to text

### DIFF
--- a/docs/features/speech-to-text.md
+++ b/docs/features/speech-to-text.md
@@ -44,7 +44,7 @@ The languages column counts what the backend dropdown offers (an *auto* entry is
 
 | Backend | Languages | Output | Model size range | Good for |
 |---------|-----------|------------|------------------|----------|
-| **Parakeet** | 13 (European + zh, ja, ko) | Native timings | 75 MB - 2.14 GB | The fast default. NVIDIA Parakeet TDT/RNN-T in 0.6B, 1.1B and a 110M tdt_ctc model - the smallest Crisp ASR model of all. Has a Japanese fine-tune |
+| **Parakeet** | 14 (European + zh, ja, ko, vi) | Native timings | 75 MB - 2.14 GB | The fast default. NVIDIA Parakeet TDT/RNN-T in 0.6B, 1.1B and a 110M tdt_ctc model - the smallest Crisp ASR model of all. Has a Japanese fine-tune and a Vietnamese CTC model |
 | **Canary** | 25 (European) | Native timings | 705 MB - 1.97 GB | NVIDIA Canary 1B v2. Broad European coverage with its own timings; also usable as a CTC forced aligner for other backends |
 | **Cohere** | 14 | Native timings | 1.51 - 4.14 GB | Cohere Transcribe. Separate Arabic and Japanese fine-tunes. VAD is on by default (see the VAD section below) |
 | **GigaAM** | 1 (Russian) | Native timings; punctuation + casing on `e2e` only | 151 - 452 MB | Russian only, and very small. Use an `e2e` revision - those emit punctuation and capitalisation, the plain `ctc` / `rnnt` heads return bare lowercase text |
@@ -85,6 +85,8 @@ These models live under the **Crisp ASR** engine, not under the standalone Qwen3
 | Crisp ASR Parakeet | `parakeet-tdt-0.6b-ja-q8_0.gguf` (also q4_k / unquantized) | Fast Japanese model |
 
 The general `qwen3-asr-1.7b` and Whisper `large-v3-turbo` models are also strong on Japanese if you prefer a single model for mixed content.
+
+For Vietnamese, the Crisp ASR Parakeet backend has NVIDIA's `parakeet-ctc-0.6b-vi` model (`-q8_0.gguf` recommended; also q4_k / q5_0 / unquantized). It is Vietnamese only, outputs punctuation and casing, and keeps Parakeet's native timings. Pick *vietnamese* as the language and one of the `-vi` models - the other Parakeet models do not know Vietnamese.
 
 ## How to Use
 

--- a/src/ui/Assets/SpeechToText/CrispASRParakeet.txt
+++ b/src/ui/Assets/SpeechToText/CrispASRParakeet.txt
@@ -4,4 +4,5 @@
 Type: FastConformer + TDT (transducer-style)
 Focus: ⚡ Speed + efficiency
 Strengths: Very fast
+Languages: the tdt-0.6b-v3 models cover 25 European languages; the -ja models are Japanese only and the ctc-0.6b-vi models Vietnamese only
 

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngine.cs
@@ -77,6 +77,8 @@ public class CrispAsrEngine : CrispAsrEngineBase
     public override string Choice => SelectedBackend.Choice;
     public override string Url => SelectedBackend.Url;
     public override string BackendName => SelectedBackend.BackendName;
+    public override string GetBackendName(string modelName) => SelectedBackend.GetBackendName(modelName);
+    public override string GetModelArguments(string modelName, string? userArguments) => SelectedBackend.GetModelArguments(modelName, userArguments);
     public override string DefaultLanguage => SelectedBackend.DefaultLanguage;
     public override bool IncludeLanguage => SelectedBackend.IncludeLanguage;
     public override bool HasNativeTimestamps => SelectedBackend.HasNativeTimestamps;

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngineBase.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrEngineBase.cs
@@ -14,6 +14,8 @@ public abstract class CrispAsrEngineBase : ICrispAsrEngine
     public abstract string Choice { get; }
     public abstract string Url { get; }
     public abstract string BackendName { get; }
+    public virtual string GetBackendName(string modelName) => BackendName;
+    public virtual string GetModelArguments(string modelName, string? userArguments) => string.Empty;
     public abstract string DefaultLanguage { get; }
     public abstract bool IncludeLanguage { get; }
     public virtual bool HasNativeTimestamps => false;

--- a/src/ui/Features/Video/SpeechToText/Engines/CrispAsrParakeet.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/CrispAsrParakeet.cs
@@ -3,6 +3,7 @@ using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 
 namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 
@@ -16,6 +17,52 @@ public class CrispAsrParakeet : CrispAsrEngineBase
     public override string DefaultLanguage => "en";
     public override bool IncludeLanguage => true;
     public override bool HasNativeTimestamps => true;
+
+    /// <summary>
+    /// crispasr's <c>parakeet</c> backend is the transducer (TDT / RNN-T) runtime. A pure-CTC
+    /// Parakeet GGUF (NeMo EncDecCTCModelBPE: encoder + CTC head, no prediction network or joint)
+    /// makes it bail out with "this GGUF has no RNN-T decoder/joint tensors"; those models run on
+    /// the <c>fastconformer-ctc</c> backend instead, and crispasr's own auto-detect picks that by
+    /// the same filename rule used here - "parakeet" and "ctc" without "tdt". The tdt_ctc hybrids
+    /// keep their TDT head and stay on <c>parakeet</c>. Timestamps still come for free (CTC frame
+    /// times), so the built-in aligner option keeps applying.
+    /// </summary>
+    public const string CtcBackendName = "fastconformer-ctc";
+
+    public static bool IsPureCtcModel(string modelName)
+    {
+        return modelName.Contains("parakeet", StringComparison.OrdinalIgnoreCase) &&
+               modelName.Contains("ctc", StringComparison.OrdinalIgnoreCase) &&
+               !modelName.Contains("tdt", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public override string GetBackendName(string modelName)
+    {
+        return IsPureCtcModel(modelName) ? CtcBackendName : BackendName;
+    }
+
+    /// <summary>
+    /// crispasr auto-enables FireRedPunc punctuation restoration for the fastconformer-ctc
+    /// backend, because its usual models emit bare lowercase text. The Vietnamese CTC model is
+    /// trained with punctuation and casing already, and FireRedPunc's Chinese/English vocabulary
+    /// re-joins the Vietnamese words it does not know without spaces ("thời tiếtởHà Nội"), so the
+    /// stage has to stay off. <c>--no-punctuation</c> is the wrong lever: with it crispasr strips
+    /// the model's own punctuation too. <c>--punc-model none</c> only skips the restoration.
+    /// </summary>
+    public override string GetModelArguments(string modelName, string? userArguments)
+    {
+        if (!IsPureCtcModel(modelName))
+        {
+            return string.Empty;
+        }
+
+        if (Regex.IsMatch(userArguments ?? string.Empty, @"(^|\s)(--punc-model|--no-punctuation|--require-punctuation)\b"))
+        {
+            return string.Empty;
+        }
+
+        return "--punc-model none";
+    }
 
     public override List<WhisperLanguage> Languages =>
        new()
@@ -34,6 +81,7 @@ public class CrispAsrParakeet : CrispAsrEngineBase
             new WhisperLanguage("pl", "polish"),
             new WhisperLanguage("tr", "turkish"),
             new WhisperLanguage("nl", "dutch"),
+            new WhisperLanguage("vi", "vietnamese"),
        };
 
     public override List<WhisperModel> Models =>
@@ -261,6 +309,49 @@ public class CrispAsrParakeet : CrispAsrEngineBase
                 Urls =
                 [
                     "https://huggingface.co/cstr/parakeet-tdt_ctc-1.1b-GGUF/resolve/main/parakeet-tdt_ctc-1.1b.gguf",
+                ],
+            },
+
+            // nvidia/parakeet-ctc-0.6b-Vietnamese (#14496): the one Parakeet trained on Vietnamese
+            // (2,000+ h, with punctuation and casing). Pure CTC - no TDT head - so GetBackendName
+            // sends it to fastconformer-ctc and GetModelArguments keeps crispasr's punctuation
+            // restoration off; timestamps come from the CTC frames. Converted from the .nemo with
+            // CrispASR's convert-stt-fastconformer-ctc-to-gguf.py and crispasr-quantize 0.8.31; the
+            // four quants agree to within a word on FLEURS vi_vn clips, q8_0 is the safe default.
+            new WhisperModel
+            {
+                Name = "parakeet-ctc-0.6b-vi-q4_k.gguf",
+                Size = "384 MB",
+                Urls =
+                [
+                    "https://huggingface.co/niksedk/parakeet-ctc-0.6b-vi-GGUF/resolve/main/parakeet-ctc-0.6b-vi-q4_k.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "parakeet-ctc-0.6b-vi-q5_0.gguf",
+                Size = "450 MB",
+                Urls =
+                [
+                    "https://huggingface.co/niksedk/parakeet-ctc-0.6b-vi-GGUF/resolve/main/parakeet-ctc-0.6b-vi-q5_0.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "parakeet-ctc-0.6b-vi-q8_0.gguf",
+                Size = "650 MB",
+                Urls =
+                [
+                    "https://huggingface.co/niksedk/parakeet-ctc-0.6b-vi-GGUF/resolve/main/parakeet-ctc-0.6b-vi-q8_0.gguf",
+                ],
+            },
+            new WhisperModel
+            {
+                Name = "parakeet-ctc-0.6b-vi.gguf",
+                Size = "1.22 GB",
+                Urls =
+                [
+                    "https://huggingface.co/niksedk/parakeet-ctc-0.6b-vi-GGUF/resolve/main/parakeet-ctc-0.6b-vi.gguf",
                 ],
             },
        };

--- a/src/ui/Features/Video/SpeechToText/Engines/ICrispAsrEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/ICrispAsrEngine.cs
@@ -5,6 +5,20 @@ public interface ICrispAsrEngine : ISpeechToTextEngine
     /// <summary>The value passed to --backend on the command line.</summary>
     string BackendName { get; }
 
+    /// <summary>
+    /// The --backend value for one particular model. Normally <see cref="BackendName"/>; a backend
+    /// whose catalog spans two crispasr runtimes (Parakeet's pure-CTC models run on
+    /// fastconformer-ctc, not on the transducer backend) picks per model.
+    /// </summary>
+    string GetBackendName(string modelName);
+
+    /// <summary>
+    /// Extra command-line arguments one particular model needs on top of the user's
+    /// <see cref="ISpeechToTextEngine.CommandLineParameter"/>. Empty for most models, and never
+    /// repeats a flag the user already set in <paramref name="userArguments"/>.
+    /// </summary>
+    string GetModelArguments(string modelName, string? userArguments);
+
     /// <summary>The default language code used when no language is selected.</summary>
     string DefaultLanguage { get; }
 

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextPostProcessor.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextPostProcessor.cs
@@ -10,6 +10,7 @@ using Nikse.SubtitleEdit.UiLogic.AudioToText;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Nikse.SubtitleEdit.Features.Video.SpeechToText
 {
@@ -267,6 +268,23 @@ namespace Nikse.SubtitleEdit.Features.Video.SpeechToText
         {
             return text.Length > 0 && LineTerminationChars.Contains(text[text.Length - 1]);
         }
+
+        /// <summary>
+        /// Drops the space in "word , word" and "word ." - the mark must be followed by whitespace
+        /// or end the line, so decimals ("1.5"), ellipses and time codes are left alone.
+        /// </summary>
+        public static Subtitle RemoveSpaceBeforePunctuation(Subtitle inputSubtitle)
+        {
+            var subtitle = new Subtitle(inputSubtitle, false);
+            foreach (var paragraph in subtitle.Paragraphs)
+            {
+                paragraph.Text = SpaceBeforePunctuationRegex.Replace(paragraph.Text, "$1");
+            }
+
+            return subtitle;
+        }
+
+        private static readonly Regex SpaceBeforePunctuationRegex = new(@"(?<=\S) +([,.!?;:])(?=\s|$)", RegexOptions.Multiline | RegexOptions.Compiled);
 
         public Subtitle AddPeriods(Subtitle inputSubtitle, string language)
         {

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -2069,6 +2069,16 @@ public partial class SpeechToTextViewModel : ObservableObject
 
     private Subtitle PostProcess(Subtitle transcript)
     {
+        if (GetEffectiveSelectedEngine() is ICrispAsrEngine &&
+            SelectedModel is SpeechToTextModelDisplay { Model.Name: { } modelName } &&
+            CrispAsrParakeet.IsPureCtcModel(modelName))
+        {
+            // The Vietnamese Parakeet CTC tokenizer has a space-prefixed "▁," / "▁." piece that the
+            // model prefers over the bare one, so its transcripts read "gần xe , và ... dàng ." -
+            // a training-text habit, not a decode bug, and not optional post-processing either.
+            transcript = SpeechToTextPostProcessor.RemoveSpaceBeforePunctuation(transcript);
+        }
+
         var languageCode = SelectedLanguage?.Code;
         if (string.IsNullOrWhiteSpace(languageCode))
         {
@@ -4151,13 +4161,20 @@ public partial class SpeechToTextViewModel : ObservableObject
             // VAD - only the latter is worth re-running without it (#13911).
             _crispAsrVadWasUsed = vadPart.Length > 0;
 
+            // Both are per model, not per backend: Parakeet's pure-CTC models run on a different
+            // crispasr backend than its transducer models and need crispasr's punctuation
+            // restoration kept off (see CrispAsrParakeet.GetBackendName / GetModelArguments).
+            var backendName = crispAsrEngine.GetBackendName(model);
+            var modelArgs = crispAsrEngine.GetModelArguments(model, crispArgs);
+            var modelArgsPart = modelArgs.Length > 0 ? $" {modelArgs}" : string.Empty;
+
             // --print-progress: crispasr streams "crispasr: progress = NN% (i/n slices)" lines
             // in real time (parsed in OutputHandler), while the transcript segments only print
             // once the whole file is done - without this the progress bar sat idle for the
             // entire run and jumped straight to 100%.
             var crispParams = string.IsNullOrWhiteSpace(crispArgs)
-                ? $"--backend {crispAsrEngine.BackendName} {langPart}-m \"{crispModel}\"{alignerPart}{vadPart} -f \"{waveFileName}\" --output-srt --print-progress"
-                : $"--backend {crispAsrEngine.BackendName} {langPart}-m \"{crispModel}\"{alignerPart}{vadPart} -f \"{waveFileName}\" --output-srt --print-progress {crispArgs}";
+                ? $"--backend {backendName} {langPart}-m \"{crispModel}\"{alignerPart}{vadPart}{modelArgsPart} -f \"{waveFileName}\" --output-srt --print-progress"
+                : $"--backend {backendName} {langPart}-m \"{crispModel}\"{alignerPart}{vadPart}{modelArgsPart} -f \"{waveFileName}\" --output-srt --print-progress {crispArgs}";
 
             Se.WriteToolsLog($"{exe} {crispParams}");
 

--- a/tests/UI/Features/Video/SpeechToText/Engines/CrispAsrEngineTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/Engines/CrispAsrEngineTests.cs
@@ -79,4 +79,74 @@ public class CrispAsrEngineTests
             Assert.Equal("Auto Detect", first.Name);
         }
     }
+
+    /// <summary>
+    /// crispasr's parakeet backend is the transducer runtime and refuses a pure-CTC GGUF; the
+    /// Vietnamese model (#14496) is one, so it has to go to fastconformer-ctc while the
+    /// tdt_ctc hybrids (TDT head present) stay put.
+    /// </summary>
+    [Theory]
+    [InlineData("parakeet-tdt-0.6b-v3-q4_k.gguf", "parakeet")]
+    [InlineData("parakeet-tdt_ctc-110m-q8_0.gguf", "parakeet")]
+    [InlineData("parakeet-tdt_ctc-1.1b.gguf", "parakeet")]
+    [InlineData("parakeet-rnnt-0.6b-q4_k.gguf", "parakeet")]
+    [InlineData("parakeet-ctc-0.6b-vi-q8_0.gguf", "fastconformer-ctc")]
+    [InlineData("parakeet-ctc-0.6b-vi.gguf", "fastconformer-ctc")]
+    public void Parakeet_GetBackendName_RoutesPureCtcModelsToTheCtcRuntime(string modelName, string expectedBackend)
+    {
+        var parakeet = new CrispAsrParakeet();
+        var engine = new CrispAsrEngine();
+        Assert.True(engine.TrySelectBackendChoice(WhisperChoice.CrispAsrParakeet));
+
+        Assert.Equal(expectedBackend, parakeet.GetBackendName(modelName));
+        Assert.Equal(expectedBackend, engine.GetBackendName(modelName));
+    }
+
+    [Fact]
+    public void Parakeet_EveryCatalogModelRoutesByItsOwnName()
+    {
+        var parakeet = new CrispAsrParakeet();
+
+        foreach (var model in parakeet.Models)
+        {
+            var isCtcOnly = model.Name.Contains("-ctc-") && !model.Name.Contains("tdt");
+            Assert.Equal(isCtcOnly ? CrispAsrParakeet.CtcBackendName : "parakeet", parakeet.GetBackendName(model.Name));
+        }
+    }
+
+    /// <summary>
+    /// crispasr auto-enables FireRedPunc for fastconformer-ctc, which mangles Vietnamese spacing;
+    /// the model punctuates by itself. The user's own punctuation flag always wins.
+    /// </summary>
+    [Theory]
+    [InlineData("parakeet-ctc-0.6b-vi-q8_0.gguf", null, "--punc-model none")]
+    [InlineData("parakeet-ctc-0.6b-vi-q8_0.gguf", "--max-len 50 --split-on-punct", "--punc-model none")]
+    [InlineData("parakeet-ctc-0.6b-vi-q8_0.gguf", "--punc-model firered", "")]
+    [InlineData("parakeet-ctc-0.6b-vi-q8_0.gguf", "--max-len 50 --no-punctuation", "")]
+    [InlineData("parakeet-tdt-0.6b-v3-q4_k.gguf", null, "")]
+    [InlineData("parakeet-tdt_ctc-1.1b-q8_0.gguf", null, "")]
+    public void Parakeet_GetModelArguments_KeepsPunctuationRestorationOffForCtcModels(string modelName, string? userArgs, string expected)
+    {
+        var parakeet = new CrispAsrParakeet();
+        var engine = new CrispAsrEngine();
+        Assert.True(engine.TrySelectBackendChoice(WhisperChoice.CrispAsrParakeet));
+
+        Assert.Equal(expected, parakeet.GetModelArguments(modelName, userArgs));
+        Assert.Equal(expected, engine.GetModelArguments(modelName, userArgs));
+    }
+
+    [Fact]
+    public void OtherBackends_DoNotOverridePerModelBackendOrArguments()
+    {
+        var engine = new CrispAsrEngine();
+
+        foreach (var backend in engine.Backends.Where(p => p is not CrispAsrParakeet))
+        {
+            foreach (var model in backend.Models)
+            {
+                Assert.Equal(backend.BackendName, backend.GetBackendName(model.Name));
+                Assert.Equal(string.Empty, backend.GetModelArguments(model.Name, null));
+            }
+        }
+    }
 }

--- a/tests/UI/Features/Video/SpeechToText/SpeechToTextPostProcessorSpacingTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/SpeechToTextPostProcessorSpacingTests.cs
@@ -1,0 +1,28 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText;
+
+namespace UITests.Features.Video.SpeechToText;
+
+/// <summary>
+/// The Vietnamese Parakeet CTC model emits a space-prefixed comma/period piece ("gần xe , và"),
+/// see CrispAsrParakeet - SE tidies that on the way in.
+/// </summary>
+public class SpeechToTextPostProcessorSpacingTests
+{
+    [Theory]
+    [InlineData("gần xe , và chỉ với các dụng cụ bình thường , chúng ta cũng sẽ quan sát một cách dễ dàng .", "gần xe, và chỉ với các dụng cụ bình thường, chúng ta cũng sẽ quan sát một cách dễ dàng.")]
+    [InlineData("Bạn có khỏe không ?", "Bạn có khỏe không?")]
+    [InlineData("Tuyệt vời !\nHẹn gặp lại .", "Tuyệt vời!\nHẹn gặp lại.")]
+    [InlineData("Nhiệt độ là 1.5 độ, lúc 10:30 ...", "Nhiệt độ là 1.5 độ, lúc 10:30 ...")]
+    [InlineData("Không có gì để sửa.", "Không có gì để sửa.")]
+    public void RemoveSpaceBeforePunctuation_JoinsMarkToPrecedingWord(string input, string expected)
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph(input, 0, 1000));
+
+        var result = SpeechToTextPostProcessor.RemoveSpaceBeforePunctuation(subtitle);
+
+        Assert.Equal(expected, result.Paragraphs[0].Text);
+        Assert.Equal(input, subtitle.Paragraphs[0].Text);
+    }
+}


### PR DESCRIPTION
Closes #14496

Adds NVIDIA's `parakeet-ctc-0.6b-Vietnamese` to the Crisp ASR Parakeet backend (q4_k / q5_0 / q8_0 / f16) and *vietnamese* to its language list.

The model is pure CTC, which needs two things the other Parakeet models do not:

- **Backend routing** - crispasr's `parakeet` backend is the transducer runtime and refuses a GGUF without RNN-T decoder tensors, so the model is sent to `--backend fastconformer-ctc`. Decided per model via new `ICrispAsrEngine.GetBackendName(modelName)`; the tdt_ctc hybrids keep their TDT head and stay on `parakeet`.
- **Punctuation restoration off** - crispasr auto-enables FireRedPunc for fastconformer-ctc. The Vietnamese model already emits punctuation and casing, and FireRedPunc's Chinese/English vocabulary re-joins Vietnamese words without spaces (`thời tiếtởHà Nội`). New `GetModelArguments` adds `--punc-model none` unless the user set a punctuation flag themselves (`--no-punctuation` is the wrong lever: it strips the model's own punctuation).

The model's tokenizer prefers a space-prefixed `▁,` / `▁.` piece, so raw transcripts read `gần xe , và ... dàng .`; a new `SpeechToTextPostProcessor.RemoveSpaceBeforePunctuation` tidies that before post-processing.

### Verification

- Converted the 2.4 GB `.nemo` (sha256 matches the HF manifest) with CrispASR's `convert-stt-fastconformer-ctc-to-gguf.py`, quantised with `crispasr-quantize` 0.8.31 (the pinned release).
- Ran SE's exact command line against crispasr 0.8.31 on macOS. FLEURS `vi_vn` validation clips transcribe near-perfectly with punctuation and casing on all four quants; q4_k has an occasional extra word error, q8_0 is the safe default.
- New unit tests for the routing, the argument hook and the spacing fix; the SpeechToText UI test slice passes (274 tests).

### Before merging

- [x] Upload the GGUFs to `niksedk/parakeet-ctc-0.6b-vi-GGUF` on Hugging Face (files, README and `upload.sh` are in `~/Downloads/parakeet-ctc-0.6b-vi-GGUF/`; needs `hf auth login` with a write token). The catalog URLs point there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)