### PR TITLE
Sync/Cut video: zoom the waveform on Shift + main-row plus/minus too

### DIFF
--- a/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointViewModel.cs
+++ b/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointViewModel.cs
@@ -591,12 +591,12 @@ public partial class SetSyncPointViewModel : ObservableObject
             e.Handled = true;
             SetVideoPosition(CurrentPositionSeconds + 0.5);
         }
-        else if (e.Key == Key.Add && e.KeyModifiers.HasFlag(KeyModifiers.Shift))
+        else if ((e.Key == Key.Add || e.Key == Key.OemPlus) && e.KeyModifiers.HasFlag(KeyModifiers.Shift))
         {
             e.Handled = true;
             WaveformVerticalZoomIn();
         }
-        else if (e.Key == Key.Subtract && e.KeyModifiers.HasFlag(KeyModifiers.Shift))
+        else if ((e.Key == Key.Subtract || e.Key == Key.OemMinus) && e.KeyModifiers.HasFlag(KeyModifiers.Shift))
         {
             e.Handled = true;
             WaveformVerticalZoomOut();

--- a/src/ui/Features/Sync/VisualSync/VisualSyncViewModel.cs
+++ b/src/ui/Features/Sync/VisualSync/VisualSyncViewModel.cs
@@ -727,12 +727,12 @@ public partial class VisualSyncViewModel : ObservableObject
                 VideoPlayerControlLeft.Position += 0.5;
                 _updateAudioVisualizer = true;
             }
-            else if (e.Key == Key.Add && e.KeyModifiers.HasFlag(KeyModifiers.Shift))
+            else if ((e.Key == Key.Add || e.Key == Key.OemPlus) && e.KeyModifiers.HasFlag(KeyModifiers.Shift))
             {
                 e.Handled = true;
                 WaveformVerticalZoomIn(AudioVisualizerLeft);
             }
-            else if (e.Key == Key.Subtract && e.KeyModifiers.HasFlag(KeyModifiers.Shift))
+            else if ((e.Key == Key.Subtract || e.Key == Key.OemMinus) && e.KeyModifiers.HasFlag(KeyModifiers.Shift))
             {
                 e.Handled = true;
                 WaveformVerticalZoomOut(AudioVisualizerLeft);
@@ -769,12 +769,12 @@ public partial class VisualSyncViewModel : ObservableObject
                 VideoPlayerControlRight.Position += 0.5;
                 _updateAudioVisualizer = true;
             }
-            else if (e.Key == Key.Add && e.KeyModifiers.HasFlag(KeyModifiers.Shift))
+            else if ((e.Key == Key.Add || e.Key == Key.OemPlus) && e.KeyModifiers.HasFlag(KeyModifiers.Shift))
             {
                 e.Handled = true;
                 WaveformVerticalZoomIn(AudioVisualizerRight);
             }
-            else if (e.Key == Key.Subtract && e.KeyModifiers.HasFlag(KeyModifiers.Shift))
+            else if ((e.Key == Key.Subtract || e.Key == Key.OemMinus) && e.KeyModifiers.HasFlag(KeyModifiers.Shift))
             {
                 e.Handled = true;
                 WaveformVerticalZoomOut(AudioVisualizerRight);

--- a/src/ui/Features/Video/CutVideo/CutVideoViewModel.cs
+++ b/src/ui/Features/Video/CutVideo/CutVideoViewModel.cs
@@ -940,6 +940,22 @@ public partial class CutVideoViewModel : ObservableObject
             {
                 keyEventArgs.Handled = true;
                 rc.Execute(null);
+                return;
+            }
+
+            // The main window's default vertical zoom binding is Shift+Add/Subtract, which only the
+            // numeric keypad produces. Let the main-row plus and minus keys (OemPlus/OemMinus on
+            // every layout, a laptop or a Spanish keyboard has no other) zoom too, as the sync
+            // dialogs do (#14419 comment).
+            if (keyEventArgs.Key == Key.OemPlus && keyEventArgs.KeyModifiers.HasFlag(KeyModifiers.Shift))
+            {
+                keyEventArgs.Handled = true;
+                WaveformVerticalZoomIn();
+            }
+            else if (keyEventArgs.Key == Key.OemMinus && keyEventArgs.KeyModifiers.HasFlag(KeyModifiers.Shift))
+            {
+                keyEventArgs.Handled = true;
+                WaveformVerticalZoomOut();
             }
         }
     }

--- a/tests/UI/Features/Sync/SyncWaveformVerticalZoomKeyTests.cs
+++ b/tests/UI/Features/Sync/SyncWaveformVerticalZoomKeyTests.cs
@@ -1,0 +1,120 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Sync.PointSync.SetSyncPoint;
+using Nikse.SubtitleEdit.Features.Sync.VisualSync;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Collections.Generic;
+
+namespace UITests.Features.Sync;
+
+/// <summary>
+/// Shift + plus/minus zooms the sync dialogs' waveforms vertically (#14487). The first cut only
+/// matched the numeric-keypad keys (Key.Add / Key.Subtract), so a laptop or a Spanish keyboard,
+/// whose plus and minus keys report as OemPlus / OemMinus, could not zoom at all (#14419 comment).
+/// </summary>
+public class SyncWaveformVerticalZoomKeyTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private static List<SubtitleLineViewModel> TwoLines()
+        => new()
+        {
+            new() { StartTime = TimeSpan.FromSeconds(1), EndTime = TimeSpan.FromSeconds(3) },
+            new() { StartTime = TimeSpan.FromSeconds(5), EndTime = TimeSpan.FromSeconds(7) },
+        };
+
+    private static AudioVisualizer LentWaveform()
+    {
+        var peaks = new WavePeak2[126 * 10];
+        for (var i = 0; i < peaks.Length; i++)
+        {
+            peaks[i] = new WavePeak2(200, -200);
+        }
+
+        return new AudioVisualizer { WavePeaks = new WavePeakData2(126, peaks) };
+    }
+
+    private static KeyEventArgs ShiftKey(Key key)
+        => new() { RoutedEvent = InputElement.KeyDownEvent, Key = key, KeyModifiers = KeyModifiers.Shift };
+
+    private static SetSyncPointViewModel MakeSetSyncPointViewModel()
+    {
+        var vm = new SetSyncPointViewModel(new WindowService(new NullServiceProvider()), new FileHelper(), new VideoPreviewSubtitle(new MpvReloader(), new VlcReloader()));
+        var lines = TwoLines();
+        vm.Initialize(lines, lines[0], videoFileName: null, subtitleFileName: null, previewContext: VideoPreviewSubtitleContext.Default, audioVisualizer: LentWaveform());
+        vm.IsAudioVisualizerVisible = true; // handed over on a posted job that these tests never pump
+        return vm;
+    }
+
+    [AvaloniaTheory]
+    [InlineData(Key.Add, 0.9)]
+    [InlineData(Key.OemPlus, 0.9)]
+    [InlineData(Key.Subtract, 1.1)]
+    [InlineData(Key.OemMinus, 1.1)]
+    public void SetSyncPoint_ShiftPlusOrMinus_ZoomsFromKeypadAndMainRow(Key key, double expectedZoom)
+    {
+        var vm = MakeSetSyncPointViewModel();
+        var e = ShiftKey(key);
+
+        vm.OnKeyDownHandler(null, e);
+
+        Assert.True(e.Handled);
+        Assert.Equal(expectedZoom, vm.AudioVisualizer.VerticalZoomFactor, 6);
+    }
+
+    [AvaloniaFact]
+    public void SetSyncPoint_PlusWithoutShift_DoesNotZoom()
+    {
+        var vm = MakeSetSyncPointViewModel();
+        var e = new KeyEventArgs { RoutedEvent = InputElement.KeyDownEvent, Key = Key.OemPlus, KeyModifiers = KeyModifiers.None };
+
+        vm.OnKeyDownHandler(null, e);
+
+        Assert.False(e.Handled);
+        Assert.Equal(1.0, vm.AudioVisualizer.VerticalZoomFactor, 6);
+    }
+
+    [AvaloniaTheory]
+    [InlineData(Key.OemPlus, 0.9)]
+    [InlineData(Key.OemMinus, 1.1)]
+    public void VisualSync_ShiftMainRowPlusOrMinus_ZoomsTheFocusedPane(Key key, double expectedZoom)
+    {
+        var vm = new VisualSyncViewModel(new WindowService(new NullServiceProvider()), new FileHelper(),
+            new VideoPreviewSubtitle(new MpvReloader(), new VlcReloader()),
+            new VideoPreviewSubtitle(new MpvReloader(), new VlcReloader()));
+        vm.Initialize(TwoLines(), videoFileName: null, subtitleFileName: null, previewContext: VideoPreviewSubtitleContext.Default, audioVisualizer: LentWaveform());
+        var window = new VisualSyncWindow(vm);
+        _windows.Add(window);
+        vm.IsAudioVisualizerVisible = true;
+        window.Show();
+        vm.AudioVisualizerRight.Focus();
+        Assert.True(vm.AudioVisualizerRight.IsFocused);
+        var e = ShiftKey(key);
+
+        vm.OnKeyDownHandler(null, e);
+
+        Assert.True(e.Handled);
+        Assert.Equal(expectedZoom, vm.AudioVisualizerRight.VerticalZoomFactor, 6);
+        Assert.Equal(1.0, vm.AudioVisualizerLeft.VerticalZoomFactor, 6); // only the focused pane zooms
+    }
+}

--- a/tests/UI/Features/Video/CutVideo/CutVideoVerticalZoomKeyTests.cs
+++ b/tests/UI/Features/Video/CutVideo/CutVideoVerticalZoomKeyTests.cs
@@ -1,0 +1,54 @@
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Nikse.SubtitleEdit.Features.Video.CutVideo;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+
+namespace UITests.Features.Video.CutVideo;
+
+/// <summary>
+/// Cut video's waveform zoom follows the main window's configurable shortcut, whose default is
+/// the numeric-keypad Shift+Add / Shift+Subtract. The main-row plus and minus keys (OemPlus /
+/// OemMinus - all a laptop or a Spanish keyboard has) zoom as a fallback, like the sync dialogs
+/// (#14419 comment).
+/// </summary>
+public class CutVideoVerticalZoomKeyTests
+{
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private static CutVideoViewModel MakeViewModel()
+        => new(new FolderHelper(), new FileHelper(), new WindowService(new NullServiceProvider()), new InsertService(), new ShortcutManager());
+
+    private static KeyEventArgs KeyArgs(Key key, KeyModifiers modifiers)
+        => new() { RoutedEvent = InputElement.KeyDownEvent, Key = key, KeyModifiers = modifiers };
+
+    [AvaloniaTheory]
+    [InlineData(Avalonia.Input.Key.OemPlus, 0.9)]
+    [InlineData(Avalonia.Input.Key.OemMinus, 1.1)]
+    public void ShiftMainRowPlusOrMinus_ZoomsTheWaveform(Key key, double expectedZoom)
+    {
+        var vm = MakeViewModel();
+        var e = KeyArgs(key, KeyModifiers.Shift);
+
+        vm.OnKeyDownHandler(null, e);
+
+        Assert.True(e.Handled);
+        Assert.Equal(expectedZoom, vm.AudioVisualizer!.VerticalZoomFactor, 6);
+    }
+
+    [AvaloniaFact]
+    public void MainRowPlusWithoutShift_DoesNotZoom()
+    {
+        var vm = MakeViewModel();
+        var e = KeyArgs(Avalonia.Input.Key.OemPlus, KeyModifiers.None);
+
+        vm.OnKeyDownHandler(null, e);
+
+        Assert.False(e.Handled);
+        Assert.Equal(1.0, vm.AudioVisualizer!.VerticalZoomFactor, 6);
+    }
+}


### PR DESCRIPTION
Follow-up to #14487, from the [rc2 test report](https://github.com/SubtitleEdit/subtitleedit/pull/14419#issuecomment-5537409823) on #14419.

## Problem

Shift + plus/minus vertical waveform zoom in **Set sync point**, **Visual sync** and **Cut video** only matched `Key.Add` / `Key.Subtract`, which only the numeric keypad produces. The plus and minus keys on the main key row report as `Key.OemPlus` / `Key.OemMinus`, so on a laptop or a Spanish keyboard the shortcut could never fire. Confirmed with a headless probe against rc2: Shift+NumPadAdd changed the zoom, Shift+OemPlus did not.

## Fix

- Set sync point and Visual sync: match `OemPlus` / `OemMinus` alongside `Add` / `Subtract`.
- Cut video: it resolves the user's configured main-window zoom shortcut first (unchanged). When no shortcut claimed the key, Shift+`OemPlus` / `OemMinus` now zoom as a fallback, so the three dialogs behave the same.

Not touched: the main window's default binding is still Shift+Add / Shift+Subtract, rebindable in Settings.

## Not fixed here

The same report says Shift + mouse wheel does nothing in Point sync. The Avalonia path works in a headless test (Shift+wheel over the dialog waveform changes the zoom), so that one is environmental. Most likely the mpv native child window holding keyboard focus on Windows after a click on the video, so wheel and key messages never reach Avalonia. Needs a repro on Windows.

## Tests

- `SyncWaveformVerticalZoomKeyTests`: Set sync point zooms from both key pairs and ignores plus without Shift; Visual sync zooms only the focused pane from the main-row keys.
- `CutVideoVerticalZoomKeyTests`: main-row keys zoom via the fallback; plus without Shift does nothing.
- Sync test folder: 29 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)