### PR TITLE
Auto-translate: do not let an abbreviation period shift merged rows

### DIFF
--- a/src/libuilogic/Translate/MergeAndSplitHelper.cs
+++ b/src/libuilogic/Translate/MergeAndSplitHelper.cs
@@ -1,8 +1,10 @@
-﻿using System.Collections.ObjectModel;
+﻿using System.Collections.Concurrent;
+using System.Collections.ObjectModel;
 using System.Text;
 using System.Text.RegularExpressions;
 using Nikse.SubtitleEdit.UiLogic.AutoTranslate;
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Dictionaries;
 using Nikse.SubtitleEdit.Core.Settings;
 using Nikse.SubtitleEdit.UiLogic.Translate;
 
@@ -13,10 +15,30 @@ public static partial class MergeAndSplitHelper
     private const int MinCharsForHalving = 500;
     private const int MaxGapBetweenContinuousLinesMs = 1000;
     private const char PeriodPlaceholder = '¤';
+    private static readonly char[] SentenceEndChars = ['.', '?', '!'];
 
     private static DateTime _lastTranslateCompletedUtc = DateTime.MinValue;
 
     public static bool MergeSplitProblems { get; set; }
+
+    /// <summary>
+    /// Abbreviations ("Mrs.", "Dr.", "usw.") for a language code, each with its trailing period.
+    /// A period that closes one of them ends a word, not a sentence, so the merge/split
+    /// bookkeeping skips it: an engine that renders "Frau Meier." as "Mrs. Meier." otherwise
+    /// cuts that row off at "Mrs." and shifts every following row by a sentence (#14484).
+    /// Replaceable so tests can supply a fixed list instead of the dictionary folder.
+    /// </summary>
+    public static Func<string, HashSet<string>> AbbreviationsForLanguage { get; set; } = LoadAbbreviations;
+
+    private static readonly ConcurrentDictionary<string, HashSet<string>> AbbreviationCache = new();
+
+    private static HashSet<string> LoadAbbreviations(string languageCode)
+    {
+        // AbbreviationList.Load takes the first two letters for the base list, so "en",
+        // "eng_Latn" and "en-US" all map to en_abbreviations.xml.
+        var key = languageCode ?? string.Empty;
+        return AbbreviationCache.GetOrAdd(key, code => AbbreviationList.Load(Configuration.DictionariesDirectory, code));
+    }
 
     /// <param name="applyRowUpdate">Optional marshaller invoked around every write to the
     /// UI-bound rows. The Avalonia caller passes a dispatcher invoke so bindings update on
@@ -44,7 +66,7 @@ public static partial class MergeAndSplitHelper
         var formattingList = HandleFormatting(tempSubtitle, index, source.Code);
         var maxChars = CalculateMaxChars(autoTranslator, forceSingleLineMode);
 
-        var mergeResult = TryMergeLines(tempSubtitle, index, maxChars, ref noSentenceEndingSource, noSentenceEndingTarget);
+        var mergeResult = TryMergeLines(tempSubtitle, index, maxChars, ref noSentenceEndingSource, noSentenceEndingTarget, source.TwoLetterIsoLanguageName ?? source.Code);
         if (mergeResult.HasError)
         {
             return 0;
@@ -129,9 +151,10 @@ public static partial class MergeAndSplitHelper
         int index,
         int maxChars,
         ref bool noSentenceEndingSource,
-        bool noSentenceEndingTarget)
+        bool noSentenceEndingTarget,
+        string sourceLanguage)
     {
-        var mergeResult = MergeMultipleLines(tempSubtitle, index, maxChars, noSentenceEndingSource, noSentenceEndingTarget);
+        var mergeResult = MergeMultipleLines(tempSubtitle, index, maxChars, noSentenceEndingSource, noSentenceEndingTarget, sourceLanguage);
 
         if (mergeResult.HasError)
         {
@@ -140,7 +163,7 @@ public static partial class MergeAndSplitHelper
             if (!noSentenceEndingSource)
             {
                 noSentenceEndingSource = true;
-                mergeResult = MergeMultipleLines(tempSubtitle, index, maxChars, noSentenceEndingSource, noSentenceEndingTarget);
+                mergeResult = MergeMultipleLines(tempSubtitle, index, maxChars, noSentenceEndingSource, noSentenceEndingTarget, sourceLanguage);
             }
         }
 
@@ -176,11 +199,13 @@ public static partial class MergeAndSplitHelper
     {
         var sourceTexts = tempSubtitle.Select(p => p.Text).ToList();
         var mergeCount = mergeResult.ParagraphCount;
+        var sourceAbbreviations = AbbreviationsForLanguage(mergeResult.SourceLanguage);
+        var targetAbbreviations = AbbreviationsForLanguage(target.TwoLetterIsoLanguageName ?? target.Code);
 
         // Strategy 1: Split by line ending chars where period count matches
         var splitResult = SplitMultipleLines(mergeResult, mergedTranslation, target.Code);
         if (IsSplitValid(splitResult, mergeCount, sourceTexts, index) &&
-            HasMatchingPeriodCount(mergeResult.Text, mergedTranslation))
+            HasMatchingPeriodCount(mergeResult.Text, mergedTranslation, sourceAbbreviations, targetAbbreviations))
         {
             return ApplySplitResult(rows, index, formattingList, splitResult, applyRowUpdate);
         }
@@ -196,14 +221,20 @@ public static partial class MergeAndSplitHelper
         var noPeriodsInNumbersTranslation = FixPeriodInNumbers(mergedTranslation);
         splitResult = SplitMultipleLines(mergeResult, noPeriodsInNumbersTranslation, target.Code);
         if (IsSplitValid(splitResult, mergeCount, sourceTexts, index) &&
-            HasMatchingPeriodCount(mergeResult.Text, noPeriodsInNumbersTranslation))
+            HasMatchingPeriodCount(mergeResult.Text, noPeriodsInNumbersTranslation, sourceAbbreviations, targetAbbreviations))
         {
             return ApplySplitResult(rows, index, formattingList, splitResult, applyRowUpdate, restorePeriodPlaceholder: true);
         }
 
-        // Strategy 4: Split by line ending chars (relaxed - no period count check)
+        // Strategy 4: Split by line ending chars (relaxed - no period count check). Without
+        // that check a stray period the engine introduced (an abbreviation not in the list)
+        // shifts every following row by a sentence, and when the block ends in a rarer
+        // character like '?' the final row swallows the rest so the split still "succeeds"
+        // (#14484). The proportion check catches that shape: a row cut off at "Mrs." is far
+        // shorter than its source, and the final row is far longer.
         splitResult = SplitMultipleLines(mergeResult, mergedTranslation, target.Code);
-        if (IsSplitValid(splitResult, mergeCount, sourceTexts, index))
+        if (IsSplitValid(splitResult, mergeCount, sourceTexts, index) &&
+            HasPlausibleProportions(mergeResult, splitResult))
         {
             return ApplySplitResult(rows, index, formattingList, splitResult, applyRowUpdate);
         }
@@ -217,9 +248,132 @@ public static partial class MergeAndSplitHelper
         return splitResult.Count == expectedCount && HasSameEmptyLines(splitResult, sourceTexts, index);
     }
 
-    private static bool HasMatchingPeriodCount(string source, string translation)
+    private static bool HasMatchingPeriodCount(string source, string translation, HashSet<string> sourceAbbreviations, HashSet<string> targetAbbreviations)
     {
-        return Utilities.CountTagInText(source, '.') == Utilities.CountTagInText(translation, '.');
+        return CountSentencePeriods(source, sourceAbbreviations) == CountSentencePeriods(translation, targetAbbreviations);
+    }
+
+    /// <summary>
+    /// Counts the periods in <paramref name="text"/> that can end a sentence: a period closing a
+    /// known abbreviation ("Mrs." in "Mrs. Meier") is skipped, unless it is also the last thing
+    /// in the text, where it ends the row whatever the word ("Apples, pears, etc.").
+    /// </summary>
+    public static int CountSentencePeriods(string text, HashSet<string> abbreviations)
+    {
+        var count = 0;
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (text[i] == '.' && !IsAbbreviationPeriod(text, i, abbreviations))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private static bool IsAbbreviationPeriod(string text, int periodIndex, HashSet<string> abbreviations)
+    {
+        // Only a period followed by more text on the same line can be an abbreviation's:
+        // at the end of the text or before a line break it ends the row either way.
+        if (periodIndex + 1 >= text.Length)
+        {
+            return false;
+        }
+
+        // A period between two letters is an inner abbreviation period ("p.m.", "e.g.").
+        if (periodIndex > 0 && char.IsLetter(text[periodIndex - 1]) && char.IsLetter(text[periodIndex + 1]))
+        {
+            return true;
+        }
+
+        if (text[periodIndex + 1] != ' ')
+        {
+            return false;
+        }
+
+        var start = periodIndex;
+        while (start > 0 && (char.IsLetter(text[start - 1]) || text[start - 1] == '.'))
+        {
+            start--;
+        }
+
+        var word = text.Substring(start, periodIndex - start + 1);
+        if (word.Length == 1 || word.Contains("..", StringComparison.Ordinal))
+        {
+            return false; // a lone period, or an ellipsis "Wait..." - both end a sentence
+        }
+
+        // "a.m.", "e.g.", "U.S.": an inner period marks an abbreviation without a list entry.
+        return word.IndexOf('.') < word.Length - 1 || abbreviations.Contains(word);
+    }
+
+    private const int MinSourceLengthForProportionCheck = 10;
+    private const double MinPlausibleProportion = 0.5;
+    private const double MaxPlausibleProportion = 3.0;
+
+    /// <summary>
+    /// A row's share of the reply should be roughly its share of the request. Short source rows
+    /// are exempt ("Wer?" may legitimately come back as "Who is that?"), and the band is wide
+    /// because engines rephrase freely; the shape this rejects is a row reduced to a fragment or
+    /// a row that swallowed its neighbours' sentences.
+    /// </summary>
+    private static bool HasPlausibleProportions(MergeResult mergeResult, List<string> splitResult)
+    {
+        var pairs = new List<(int SourceLength, int ReplyLength)>();
+        var lineIndex = 0;
+        foreach (var item in mergeResult.MergeResultItems)
+        {
+            var rowCount = item.IsEmpty ? 1 : item.EndIndex - item.StartIndex + 1;
+            var replyLength = 0;
+            for (var i = 0; i < rowCount && lineIndex < splitResult.Count; i++, lineIndex++)
+            {
+                replyLength += CountNonWhiteSpace(splitResult[lineIndex]);
+            }
+
+            if (!item.IsEmpty)
+            {
+                pairs.Add((CountNonWhiteSpace(item.Text), replyLength));
+            }
+        }
+
+        var sourceTotal = pairs.Sum(p => p.SourceLength);
+        var replyTotal = pairs.Sum(p => p.ReplyLength);
+        if (sourceTotal == 0 || replyTotal == 0)
+        {
+            return true;
+        }
+
+        var overallRatio = (double)replyTotal / sourceTotal;
+        foreach (var (sourceLength, replyLength) in pairs)
+        {
+            if (sourceLength < MinSourceLengthForProportionCheck)
+            {
+                continue;
+            }
+
+            var proportion = replyLength / (sourceLength * overallRatio);
+            if (proportion < MinPlausibleProportion || proportion > MaxPlausibleProportion)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static int CountNonWhiteSpace(string text)
+    {
+        var count = 0;
+        foreach (var ch in text)
+        {
+            if (!char.IsWhiteSpace(ch))
+            {
+                count++;
+            }
+        }
+
+        return count;
     }
 
     private static int ApplySplitResult(
@@ -318,8 +472,11 @@ public static partial class MergeAndSplitHelper
 
     private static string AutoBreakIfNeeded(string text, string language)
     {
+        // Any sentence ending inside the text earns a break attempt, not only a period: a row
+        // holding "Who? Kira Dorn." was kept on one line while "I told you so. Kira Dorn." was
+        // broken (#14484).
         if (text.Contains('\n') ||
-            text.TrimEnd('.').Contains('.') ||
+            text.TrimEnd(SentenceEndChars).IndexOfAny(SentenceEndChars) >= 0 ||
             text.Length >= Configuration.Settings.General.SubtitleLineMaximumLength)
         {
             return Utilities.AutoBreakLine(
@@ -411,16 +568,17 @@ public static partial class MergeAndSplitHelper
         return formattingList;
     }
 
-    public static MergeResult MergeMultipleLines(TranslateRow[] sourceSubtitle, int index, int maxTextSize, bool noSentenceEndingSource, bool noSentenceEndingTarget)
+    public static MergeResult MergeMultipleLines(TranslateRow[] sourceSubtitle, int index, int maxTextSize, bool noSentenceEndingSource, bool noSentenceEndingTarget, string sourceLanguage = "")
     {
         var result = new MergeResult
         {
             MergeResultItems = new List<MergeResultItem>(),
             NoSentenceEndingSource = noSentenceEndingSource,
             NoSentenceEndingTarget = noSentenceEndingTarget,
+            SourceLanguage = sourceLanguage ?? string.Empty,
         };
 
-        var context = new MergeContext(sourceSubtitle, index);
+        var context = new MergeContext(sourceSubtitle, index, AbbreviationsForLanguage(result.SourceLanguage));
 
         // Initialize with the first subtitle line
         InitializeFirstItem(result, context);
@@ -458,12 +616,26 @@ public static partial class MergeAndSplitHelper
         // which re-encoded the whole accumulated text every iteration (O(N^2) over a run).
         public string? EncodedLengthTextRef { get; set; }
         public int EncodedLengthValue { get; set; }
+        public HashSet<string> Abbreviations { get; }
 
-        public MergeContext(TranslateRow[] sourceSubtitle, int index)
+        public MergeContext(TranslateRow[] sourceSubtitle, int index, HashSet<string> abbreviations)
         {
             StartIndex = index;
             PreviousRow = sourceSubtitle[index];
             TextBuilder = new StringBuilder();
+            Abbreviations = abbreviations;
+        }
+
+        /// <summary>
+        /// How many times the item's end character occurs in its text - the split later cuts
+        /// the reply at that occurrence. Abbreviation periods are not sentence ends and are
+        /// not counted, on either side.
+        /// </summary>
+        public int CountEndChar(char endChar)
+        {
+            return endChar == '.'
+                ? CountSentencePeriods(TextBuilder.ToString(), Abbreviations)
+                : TextBuilder.CountChar(endChar);
         }
     }
 
@@ -578,7 +750,7 @@ public static partial class MergeAndSplitHelper
             context.CurrentItem.TextIndexStart = result.Text.Length;
             context.CurrentItem.TextIndexEnd = result.Text.Length;
             context.CurrentItem.EndChar = endChar;
-            context.CurrentItem.EndCharOccurrences = context.TextBuilder.CountChar(endChar);
+            context.CurrentItem.EndCharOccurrences = context.CountEndChar(endChar);
             result.MergeResultItems.Add(context.CurrentItem);
         }
 
@@ -609,7 +781,7 @@ public static partial class MergeAndSplitHelper
             {
                 var endChar = result.Text[^1];
                 context.CurrentItem.EndChar = endChar;
-                context.CurrentItem.EndCharOccurrences = context.TextBuilder.CountChar(endChar);
+                context.CurrentItem.EndCharOccurrences = context.CountEndChar(endChar);
                 context.CurrentItem.TextIndexEnd = result.Text.Length;
             }
 
@@ -669,7 +841,7 @@ public static partial class MergeAndSplitHelper
             {
                 var endChar = result.Text[^1];
                 context.CurrentItem.EndChar = endChar;
-                context.CurrentItem.EndCharOccurrences = context.TextBuilder.CountChar(endChar);
+                context.CurrentItem.EndCharOccurrences = context.CountEndChar(endChar);
             }
         }
 
@@ -691,6 +863,7 @@ public static partial class MergeAndSplitHelper
             return SplitByPeriodMarkers(text);
         }
 
+        var abbreviations = AbbreviationsForLanguage(language);
         var lines = new List<string>();
         foreach (var item in mergeResult.MergeResultItems)
         {
@@ -700,7 +873,7 @@ public static partial class MergeAndSplitHelper
                 continue;
             }
 
-            var part = ExtractPartForItem(ref text, item);
+            var part = ExtractPartForItem(ref text, item, abbreviations);
             if (string.IsNullOrEmpty(part) && !item.IsEmpty)
             {
                 return []; // Failed to extract part
@@ -747,7 +920,7 @@ public static partial class MergeAndSplitHelper
         return lines;
     }
 
-    private static string ExtractPartForItem(ref string text, MergeResultItem item)
+    private static string ExtractPartForItem(ref string text, MergeResultItem item, HashSet<string> abbreviations)
     {
         if (item.EndChar == '\0')
         {
@@ -756,7 +929,7 @@ public static partial class MergeAndSplitHelper
             return result;
         }
 
-        var part = FindPartByEndChar(text, item.EndChar, item.EndCharOccurrences);
+        var part = FindPartByEndChar(text, item.EndChar, item.EndCharOccurrences, abbreviations);
         if (!string.IsNullOrEmpty(part))
         {
             text = text[part.Length..].Trim();
@@ -765,27 +938,29 @@ public static partial class MergeAndSplitHelper
         return part;
     }
 
-    private static string FindPartByEndChar(string input, char endChar, int targetOccurrence)
+    /// <summary>
+    /// Cuts <paramref name="input"/> after the n-th occurrence of the end character; a period
+    /// closing a known abbreviation does not count. Fewer occurrences than asked for return the
+    /// whole input, so the last row of a block absorbs an engine's merged sentences.
+    /// </summary>
+    private static string FindPartByEndChar(string input, char endChar, int targetOccurrence, HashSet<string> abbreviations)
     {
-        var idx = input.IndexOf(endChar);
-        if (idx < 0)
+        var count = 0;
+        for (var i = 0; i < input.Length; i++)
         {
-            return string.Empty;
-        }
-
-        var count = 1;
-        while (idx >= 0 && idx < input.Length - 1)
-        {
-            if (count == targetOccurrence)
+            if (input[i] != endChar || (endChar == '.' && IsAbbreviationPeriod(input, i, abbreviations)))
             {
-                return input[..(idx + 1)];
+                continue;
             }
 
-            idx = input.IndexOf(endChar, idx + 1);
             count++;
+            if (count == targetOccurrence)
+            {
+                return input[..(i + 1)];
+            }
         }
 
-        return input;
+        return count == 0 ? string.Empty : input;
     }
 
     private static string AutoBreakIfTooLong(string text)

--- a/src/libuilogic/Translate/MergeAndSplitHelper.cs
+++ b/src/libuilogic/Translate/MergeAndSplitHelper.cs
@@ -746,7 +746,7 @@ public static partial class MergeAndSplitHelper
     {
         if (context.CurrentItem != null && result.Text.Length > 0)
         {
-            var endChar = result.Text[^1];
+            var endChar = GetEndChar(result.Text);
             context.CurrentItem.TextIndexStart = result.Text.Length;
             context.CurrentItem.TextIndexEnd = result.Text.Length;
             context.CurrentItem.EndChar = endChar;
@@ -779,7 +779,7 @@ public static partial class MergeAndSplitHelper
             }
             else
             {
-                var endChar = result.Text[^1];
+                var endChar = GetEndChar(result.Text);
                 context.CurrentItem.EndChar = endChar;
                 context.CurrentItem.EndCharOccurrences = context.CountEndChar(endChar);
                 context.CurrentItem.TextIndexEnd = result.Text.Length;
@@ -839,7 +839,7 @@ public static partial class MergeAndSplitHelper
 
             if (result.Text.Length > 0 && result.Text.HasSentenceEnding())
             {
-                var endChar = result.Text[^1];
+                var endChar = GetEndChar(result.Text);
                 context.CurrentItem.EndChar = endChar;
                 context.CurrentItem.EndCharOccurrences = context.CountEndChar(endChar);
             }
@@ -932,10 +932,38 @@ public static partial class MergeAndSplitHelper
         var part = FindPartByEndChar(text, item.EndChar, item.EndCharOccurrences, abbreviations);
         if (!string.IsNullOrEmpty(part))
         {
-            text = text[part.Length..].Trim();
+            // The anchor sits inside a closing quote ("hört."), so the quote itself follows the
+            // cut and belongs to this row.
+            var end = part.Length;
+            while (end < text.Length && IsClosingQuote(text[end]))
+            {
+                end++;
+            }
+
+            part = text[..end];
+            text = text[end..].Trim();
         }
 
         return part;
+    }
+
+    private static bool IsClosingQuote(char c) => c == '"' || c == '”';
+
+    /// <summary>
+    /// The character the split anchors on: the sentence-ending punctuation, looking past a
+    /// closing quote so "hört." anchors on the period. Quotes are a poor anchor - engines add,
+    /// drop and curl them freely, and each stray one shifted every later row by a sentence
+    /// while the period counts still matched (#14484).
+    /// </summary>
+    private static char GetEndChar(string text)
+    {
+        var i = text.Length - 1;
+        while (i > 0 && IsClosingQuote(text[i]))
+        {
+            i--;
+        }
+
+        return i < text.Length - 1 && text[..(i + 1)].HasSentenceEnding() ? text[i] : text[^1];
     }
 
     /// <summary>

--- a/src/libuilogic/Translate/MergeResult.cs
+++ b/src/libuilogic/Translate/MergeResult.cs
@@ -10,5 +10,8 @@ public static partial class MergeAndSplitHelper
         public bool HasError { get; set; }
         public bool NoSentenceEndingSource { get; set; }
         public bool NoSentenceEndingTarget { get; set; }
+
+        /// <summary>Language code of the merged text, for abbreviation-aware period counting.</summary>
+        public string SourceLanguage { get; set; } = string.Empty;
     }
 }

--- a/tests/libuilogic/Translate/MergeAndSplitHelperTests.cs
+++ b/tests/libuilogic/Translate/MergeAndSplitHelperTests.cs
@@ -198,6 +198,30 @@ public class MergeAndSplitHelperTests
         Assert.Equal(["Who is this Mrs. Meier?", "He wanted a woman."], rows.Select(r => r.TranslatedText));
     }
 
+    // Issue #14484, second report: a row ending in a closing quote anchored the split on the
+    // quote character, so one stray or curly quote in the reply shifted every later row by a
+    // sentence while the period counts still matched. The anchor is the punctuation inside.
+    [Theory]
+    [InlineData("\"NCK1 to Central.\" - \"\"Central, go ahead.\" \"The motorhome operation in Filderstadt has failed.\" \"The suspects have swapped plates.\"",
+        "\"NCK1 to Central.\" - \"\"Central, go ahead.\"")]
+    [InlineData("\u201cNCK1 to Central.\u201d - \u201cCentral, go ahead.\u201d \u201cThe motorhome operation in Filderstadt has failed.\u201d \u201cThe suspects have swapped plates.\u201d",
+        "\u201cNCK1 to Central.\u201d - \u201cCentral, go ahead.\u201d")]
+    public async Task MergeAndTranslateIfPossible_QuotedRowsSplitOnThePunctuationInsideTheQuotes(string reply, string expectedFirstRow)
+    {
+        using var _ = new FixedAbbreviations(NoAbbreviations);
+        var rows = MakeRows(
+            "\"NCK1 an Zentrale.\"" + Environment.NewLine + "- \"Zentrale hört.\"",
+            "\"Wohnmobileinsatz in Filderstadt fehlgeschlagen.\"",
+            "\"Gesuchte haben Kennzeichen ausgetauscht.\"");
+
+        var count = await TranslateGermanToEnglish(rows, reply);
+
+        Assert.Equal(3, count);
+        Assert.Equal(expectedFirstRow, rows[0].TranslatedText.Replace(Environment.NewLine, " "));
+        Assert.EndsWith("has failed." + reply[^1], rows[1].TranslatedText);
+        Assert.EndsWith("swapped plates." + reply[^1], rows[2].TranslatedText);
+    }
+
     // Ellipsis periods keep counting on both sides, so a row ending in "..." still splits.
     [Fact]
     public async Task MergeAndTranslateIfPossible_EllipsisRowStillSplits()

--- a/tests/libuilogic/Translate/MergeAndSplitHelperTests.cs
+++ b/tests/libuilogic/Translate/MergeAndSplitHelperTests.cs
@@ -94,4 +94,156 @@ public class MergeAndSplitHelperTests
         Assert.DoesNotContain("04." + Environment.NewLine, string.Join(Environment.NewLine, rows.Select(r => r.TranslatedText)));
         Assert.Contains("04.00 uur", rows[0].TranslatedText + " " + rows[1].TranslatedText);
     }
+
+    // Issue #14484: "Frau Meier." comes back as "Mrs. Meier." - one period more than the source.
+    // The split must not cut that row off at "Mrs." and shift every later row by a sentence.
+    private sealed class FixedAbbreviations : IDisposable
+    {
+        private readonly Func<string, HashSet<string>> _previous = MergeAndSplitHelper.AbbreviationsForLanguage;
+
+        public FixedAbbreviations(Dictionary<string, string[]> perLanguage)
+        {
+            MergeAndSplitHelper.AbbreviationsForLanguage = code =>
+                perLanguage.TryGetValue(code, out var list)
+                    ? new HashSet<string>(list, StringComparer.OrdinalIgnoreCase)
+                    : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        public void Dispose() => MergeAndSplitHelper.AbbreviationsForLanguage = _previous;
+    }
+
+    private static readonly Dictionary<string, string[]> NoAbbreviations = new();
+
+    private static readonly Dictionary<string, string[]> GermanEnglishAbbreviations = new()
+    {
+        ["de"] = ["Dr.", "usw."],
+        ["en"] = ["Mr.", "Mrs.", "Dr.", "etc."],
+    };
+
+    private static async Task<int> TranslateGermanToEnglish(ObservableCollection<TranslateRow> rows, string reply)
+    {
+        return await MergeAndSplitHelper.MergeAndTranslateIfPossible(
+            rows,
+            new TranslationPair("German", "de"),
+            new TranslationPair("English", "en"),
+            0,
+            new FixedResultTranslator { Result = reply },
+            forceSingleLineMode: false,
+            CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task MergeAndTranslateIfPossible_AbbreviationPeriodInReplyDoesNotShiftRows()
+    {
+        using var _ = new FixedAbbreviations(GermanEnglishAbbreviations);
+        var rows = MakeRows("Wer?", "Frau Meier.", "Er wollte eine Frau.", "Was ist los?");
+
+        var count = await TranslateGermanToEnglish(rows, "Who? Mrs. Meier. He wanted a woman. What's wrong?");
+
+        Assert.Equal(4, count);
+        Assert.Equal(["Who?", "Mrs. Meier.", "He wanted a woman.", "What's wrong?"], rows.Select(r => r.TranslatedText));
+    }
+
+    [Fact]
+    public async Task MergeAndTranslateIfPossible_AbbreviationPeriodInSourceDoesNotShiftRows()
+    {
+        using var _ = new FixedAbbreviations(GermanEnglishAbbreviations);
+        var rows = MakeRows("Herr Dr. Meier ist hier.", "Er wollte eine Frau.", "Was ist los?");
+
+        var count = await TranslateGermanToEnglish(rows, "Mr. Dr. Meier is here. He wanted a woman. What's wrong?");
+
+        Assert.Equal(3, count);
+        Assert.Equal(["Mr. Dr. Meier is here.", "He wanted a woman.", "What's wrong?"], rows.Select(r => r.TranslatedText));
+    }
+
+    [Fact]
+    public async Task MergeAndTranslateIfPossible_AbbreviationAtEndOfRowStillEndsTheRow()
+    {
+        using var _ = new FixedAbbreviations(GermanEnglishAbbreviations);
+        var rows = MakeRows("Äpfel, Birnen usw.", "Was ist los?");
+
+        var count = await TranslateGermanToEnglish(rows, "Apples, pears, etc." + Environment.NewLine + "What's wrong?");
+
+        Assert.Equal(2, count);
+        Assert.Equal(["Apples, pears, etc.", "What's wrong?"], rows.Select(r => r.TranslatedText));
+    }
+
+    // An abbreviation the lists do not know still shifts the split. The relaxed strategy used
+    // to accept the shifted result whenever the block ended in a rarer character like '?',
+    // because the final row swallowed everything left over. It must fail instead, so the
+    // caller falls back to translating the rows one by one.
+    [Fact]
+    public async Task MergeAndTranslateIfPossible_UnknownAbbreviationDoesNotProduceShiftedRows()
+    {
+        using var _ = new FixedAbbreviations(NoAbbreviations);
+        var rows = MakeRows("Wer?", "Frau Meier.", "Er wollte eine Frau.", "Was ist los?");
+
+        var count = await TranslateGermanToEnglish(rows, "Who? Mrs. Meier. He wanted a woman. What's wrong?");
+
+        Assert.Equal(0, count);
+        Assert.All(rows, r => Assert.Equal(string.Empty, r.TranslatedText));
+    }
+
+    // The relaxed strategy must keep accepting a split whose period counts differ for a
+    // harmless reason: here the extra period sits inside a row that ends in '?'.
+    [Fact]
+    public async Task MergeAndTranslateIfPossible_ExtraPeriodInsideQuestionRowIsAccepted()
+    {
+        using var _ = new FixedAbbreviations(NoAbbreviations);
+        var rows = MakeRows("Wer ist diese Frau Meier?", "Er wollte eine Frau.");
+
+        var count = await TranslateGermanToEnglish(rows, "Who is this Mrs. Meier? He wanted a woman.");
+
+        Assert.Equal(2, count);
+        Assert.Equal(["Who is this Mrs. Meier?", "He wanted a woman."], rows.Select(r => r.TranslatedText));
+    }
+
+    // Ellipsis periods keep counting on both sides, so a row ending in "..." still splits.
+    [Fact]
+    public async Task MergeAndTranslateIfPossible_EllipsisRowStillSplits()
+    {
+        using var _ = new FixedAbbreviations(GermanEnglishAbbreviations);
+        var rows = MakeRows("Warte...", "Was ist los?");
+
+        var count = await TranslateGermanToEnglish(rows, "Wait... What's wrong?");
+
+        Assert.Equal(2, count);
+        Assert.Equal(["Wait...", "What's wrong?"], rows.Select(r => r.TranslatedText));
+    }
+
+    [Theory]
+    [InlineData("Who? Mrs. Meier.", 1)]
+    [InlineData("Mr. Dr. Meier is here.", 1)]
+    [InlineData("Apples, pears, etc.", 1)]
+    [InlineData("Apples, pears, etc.\nWhat's wrong?", 1)]
+    [InlineData("At 5 p.m. we leave.", 1)]
+    [InlineData("Dr.Meier is here.", 1)]
+    [InlineData("Wait... What?", 3)]
+    [InlineData("Warte...", 3)]
+    [InlineData("Wait. .. What?", 3)]
+    [InlineData("One. Two. Three.", 3)]
+    [InlineData("No period here", 0)]
+    public void CountSentencePeriods_SkipsAbbreviationPeriods(string text, int expected)
+    {
+        var abbreviations = new HashSet<string>(["Mr.", "Mrs.", "Dr.", "etc."], StringComparer.OrdinalIgnoreCase);
+
+        Assert.Equal(expected, MergeAndSplitHelper.CountSentencePeriods(text, abbreviations));
+    }
+
+    // Issue #14484: a row holding "I told you so. Kira Dorn." was re-broken after the period,
+    // but "Who? Kira Dorn." stayed on one line - every sentence ending should count.
+    [Fact]
+    public async Task MergeAndTranslateIfPossible_LineCountSplitBreaksAfterQuestionMarkToo()
+    {
+        using var _ = new FixedAbbreviations(NoAbbreviations);
+        var rows = MakeRows("Ein Stadtflitzer? Wirklich, ich meine es ernst.", "Ja, Herr Schmidt.");
+
+        // Same line count as the request, but a period more ("Mr."), so the line-count
+        // strategy is the one that applies.
+        var count = await TranslateGermanToEnglish(rows, "A city runabout? Really, I mean it." + Environment.NewLine + "Yes, Mr. Smith.");
+
+        Assert.Equal(2, count);
+        Assert.Equal("A city runabout?" + Environment.NewLine + "Really, I mean it.", rows[0].TranslatedText);
+        Assert.Equal("Yes, Mr. Smith.", rows[1].TranslatedText);
+    }
 }


### PR DESCRIPTION
Fixes #14484.

## Problem

When rows are merged into one request, the reply is cut back into rows at the n-th occurrence of each row's end character. An engine that renders "Frau Meier." as "Mrs. Meier." adds a period, so that row was cut off at "Mrs." and every following row was shifted by a sentence.

The period-count guard rejects that split in strategy 1, but strategy 4 re-runs the same split without the guard. It "succeeded" whenever the block ended in a rarer character like `?`, because the final row then swallowed everything left over. That is the jam in the issue's screenshot: two stubs, then one row holding the rest, then normal again with the next block.

Repro before this change, four rows and the reply "Who? Mrs. Meier. He wanted a woman. What's wrong?":

| Source | Result |
|---|---|
| Wer? | Who? |
| Frau Meier. | Mrs. |
| Er wollte eine Frau. | Meier. |
| Was ist los? | He wanted a woman. What's wrong? |

## Fix

- Count and cut on sentence periods only. A period closing a known abbreviation (the per-language `*_abbreviations.xml` lists, plus inner-period forms like "p.m.") is skipped on both the source and the reply side, so "Mrs. Meier." maps back to "Frau Meier." in strategy 1.
- Guard strategy 4 with a proportion check: a row reduced to a fragment, or one that swallowed its neighbours' sentences, now fails the split, and the caller falls back to single-line mode as it already does when the block ends in a period.
- Rows ending in a closing quote ("Zentrale hört.") anchored the split on the quote character, so the reply was cut by counting quotes. Engines add, drop and curl quotes freely, and each stray one shifted every later row by a sentence while the period counts still matched (the second screenshot in the issue). The anchor is now the punctuation inside the quote, and the trailing quote is included in the cut.
- The line-count strategy re-breaks after any interior sentence ending, not only a period (the "city runabout?" vs "I told you so." asymmetry from the issue).

## Tests

Regression tests in `MergeAndSplitHelperTests` cover the reply-side and source-side abbreviation, an abbreviation at the end of a row, an unknown abbreviation (must fail rather than shift), a harmless extra period inside a `?` row (must still be accepted), ellipsis rows, quoted rows with a stray or curly quote in the reply, the period counter, and the re-break after `?`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

