### PR TITLE
Batch convert: hide the main window while the tool window is open

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -7177,7 +7177,29 @@ public partial class MainViewModel :
     [RelayCommand]
     private async Task ShowToolsBatchConvert()
     {
-        await ShowDialogAsync<BatchConvertWindow, BatchConvertViewModel>();
+        // As in SE4, the editor gets out of the way while Batch convert is open: the main window
+        // (and the undocked video/waveform windows) are hidden and only the tool window is on
+        // screen, then everything comes back when it closes (#14502). A full-screen main window
+        // is left where it is - hiding one leaves an empty space on macOS - so that case keeps
+        // the plain modal dialog.
+        if (Window == null || Window.WindowState == WindowState.FullScreen)
+        {
+            await ShowDialogAsync<BatchConvertWindow, BatchConvertViewModel>();
+            return;
+        }
+
+        var videoPlayerControl = GetVideoPlayerControl();
+        if (videoPlayerControl != null)
+        {
+            PauseVideoAndFreezePlayhead(videoPlayerControl);
+        }
+
+        await _windowService.ShowWithOwnerHiddenAsync<BatchConvertWindow, BatchConvertViewModel>(
+            Window,
+            [_videoPlayerUndockedViewModel?.Window, _audioVisualizerUndockedViewModel?.Window]);
+
+        _shortcutManager.ClearKeys();
+        RestoreFocusIfLost();
     }
 
     [RelayCommand]

--- a/src/ui/Logic/WindowsService.cs
+++ b/src/ui/Logic/WindowsService.cs
@@ -73,6 +73,27 @@ namespace Nikse.SubtitleEdit.Logic
             Action<TViewModel>? configureViewModel = null, Action<TWindow>? configureWindow = null)
             where TWindow : Window
             where TViewModel : class;
+
+        /// <summary>
+        /// Shows a window of type TWindow as a stand-alone top-level window while
+        /// <paramref name="owner"/> - and any of <paramref name="companions"/> currently on
+        /// screen - are hidden, and brings them back once it closes. This is how SE4 ran
+        /// Batch convert: the editor disappears and only the tool window remains (#14502).
+        ///
+        /// It can't be a modal dialog: Avalonia's <see cref="Window.Hide"/> cascades to every
+        /// owned window (the dialog would vanish with its owner) and
+        /// <see cref="Window.ShowDialog(Window)"/> refuses a hidden owner. Minimizing the owner
+        /// is no better - on Windows an owner's owned windows go with it.
+        /// </summary>
+        /// <param name="owner">The window to hide for the tool window's lifetime.</param>
+        /// <param name="companions">Further windows to hide along with the owner when they are
+        /// visible (the undocked video/waveform tool windows); hidden ones stay hidden.</param>
+        Task<TViewModel> ShowWithOwnerHiddenAsync<TWindow, TViewModel>(
+            Window owner,
+            IReadOnlyList<Window?> companions,
+            Action<TViewModel>? configureViewModel = null)
+            where TWindow : Window
+            where TViewModel : class;
     }
 
     /// <summary>
@@ -208,6 +229,90 @@ namespace Nikse.SubtitleEdit.Logic
             await ShowModalAsync(owner, window);
 
             return viewModel;
+        }
+
+        /// <inheritdoc />
+        public async Task<TViewModel> ShowWithOwnerHiddenAsync<TWindow, TViewModel>(
+            Window owner,
+            IReadOnlyList<Window?> companions,
+            Action<TViewModel>? configureViewModel = null)
+            where TWindow : Window
+            where TViewModel : class
+        {
+            var viewModel = _serviceProvider.GetRequiredService<TViewModel>();
+            configureViewModel?.Invoke(viewModel);
+
+            var w = Activator.CreateInstance(typeof(TWindow), viewModel);
+            if (w == null)
+            {
+                throw new InvalidOperationException($"Failed to create window of type {typeof(TWindow).Name} with constructor param {typeof(TViewModel).Name}");
+            }
+
+            var window = (TWindow)w;
+
+            // No owner to center on; a remembered position (RestoreWindowPosition in the
+            // window's Loaded handler) still wins over this.
+            window.WindowStartupLocation = WindowStartupLocation.CenterScreen;
+
+            // Must run before Show() - see the note in ShowWindow<T>. (#12665)
+            ApplyRightToLeftSettings(window);
+            UiTheme.ApplyScaleToWindow(window);
+
+            var windowsToHide = new List<Window?>(companions.Count + 1) { owner };
+            windowsToHide.AddRange(companions);
+            await ShowWithWindowsHiddenAsync(window, windowsToHide, activateAfterwards: owner);
+
+            return viewModel;
+        }
+
+        /// <summary>
+        /// Shows <paramref name="window"/> as a top-level window with every visible window in
+        /// <paramref name="windowsToHide"/> hidden until it closes, then re-shows them in the
+        /// given order and activates <paramref name="activateAfterwards"/>. Windows that were
+        /// not visible to begin with are left alone. Restoration runs even if showing the
+        /// window throws, so the hidden windows can never be lost.
+        /// </summary>
+        public static async Task ShowWithWindowsHiddenAsync(Window window, IReadOnlyList<Window?> windowsToHide, Window? activateAfterwards)
+        {
+            var hidden = new List<Window>();
+            foreach (var candidate in windowsToHide)
+            {
+                if (candidate is { IsVisible: true } && !hidden.Contains(candidate))
+                {
+                    hidden.Add(candidate);
+                }
+            }
+
+            var closed = new TaskCompletionSource();
+            window.Closed += (_, _) => closed.TrySetResult();
+
+            foreach (var w in hidden)
+            {
+                w.Hide();
+            }
+
+            try
+            {
+                window.Show();
+                await closed.Task;
+            }
+            finally
+            {
+                foreach (var w in hidden)
+                {
+                    w.Show();
+                }
+
+                if (activateAfterwards != null)
+                {
+                    if (activateAfterwards.WindowState == WindowState.Minimized)
+                    {
+                        activateAfterwards.WindowState = WindowState.Normal;
+                    }
+
+                    activateAfterwards.Activate();
+                }
+            }
         }
 
         /// <summary>

--- a/tests/UI/Features/Shared/ErrorList/ErrorListExportCommandTests.cs
+++ b/tests/UI/Features/Shared/ErrorList/ErrorListExportCommandTests.cs
@@ -57,6 +57,12 @@ public class ErrorListExportCommandTests
             Action<TViewModel>? configureViewModel = null,
             Action<TWindow>? configureWindow = null)
             where TWindow : Window where TViewModel : class => Task.FromResult<TViewModel>(null!);
+
+        public Task<TViewModel> ShowWithOwnerHiddenAsync<TWindow, TViewModel>(
+            Window owner,
+            IReadOnlyList<Window?> companions,
+            Action<TViewModel>? configureViewModel = null)
+            where TWindow : Window where TViewModel : class => throw new NotSupportedException();
     }
 
     private static List<ErrorListItem> MakeItems()

--- a/tests/UI/Features/SourceViewEditorTests.cs
+++ b/tests/UI/Features/SourceViewEditorTests.cs
@@ -53,6 +53,13 @@ public class SourceViewEditorTests : IDisposable
             Action<TWindow>? configureWindow = null)
             where TWindow : Window where TViewModel : class
             => throw new NotSupportedException();
+
+        public Task<TViewModel> ShowWithOwnerHiddenAsync<TWindow, TViewModel>(
+            Window owner,
+            IReadOnlyList<Window?> companions,
+            Action<TViewModel>? configureViewModel = null)
+            where TWindow : Window where TViewModel : class
+            => throw new NotSupportedException();
     }
 
     private static (SourceViewViewModel Vm, Subtitle Subtitle, string Text) MakeSourceView()

--- a/tests/UI/Features/SourceViewRegexTimeoutTests.cs
+++ b/tests/UI/Features/SourceViewRegexTimeoutTests.cs
@@ -54,6 +54,13 @@ public class SourceViewRegexTimeoutTests : IDisposable
             Action<TWindow>? configureWindow = null)
             where TWindow : Window where TViewModel : class
             => throw new NotSupportedException();
+
+        public Task<TViewModel> ShowWithOwnerHiddenAsync<TWindow, TViewModel>(
+            Window owner,
+            IReadOnlyList<Window?> companions,
+            Action<TViewModel>? configureViewModel = null)
+            where TWindow : Window where TViewModel : class
+            => throw new NotSupportedException();
     }
 
     // 30 a's and no "b": "(a+)+b" has to try every way of splitting them before giving up.

--- a/tests/UI/Logic/ShowWithWindowsHiddenTests.cs
+++ b/tests/UI/Logic/ShowWithWindowsHiddenTests.cs
@@ -1,0 +1,83 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Logic;
+
+// Batch convert runs SE4-style: the main window (plus the undocked tool windows) is hidden
+// while the tool window is open and comes back when it closes (#14502). It can't be an
+// owned modal - Avalonia's Hide() cascades to owned windows and ShowDialog refuses a hidden
+// owner - so WindowService.ShowWithWindowsHiddenAsync shows an unowned top-level window and
+// owns the hide/re-show bookkeeping.
+public class ShowWithWindowsHiddenTests
+{
+    [AvaloniaFact]
+    public void HidesTheOwnerWhileOpen_AndBringsItBackActivatedOnClose()
+    {
+        var owner = new Window();
+        owner.Show();
+
+        var tool = new Window();
+        var task = WindowService.ShowWithWindowsHiddenAsync(tool, [owner], activateAfterwards: owner);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(tool.IsVisible);
+        Assert.False(owner.IsVisible);
+        Assert.Null(tool.Owner);
+        Assert.False(task.IsCompleted);
+
+        tool.Close();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(task.IsCompletedSuccessfully);
+        Assert.True(owner.IsVisible);
+        Assert.True(owner.IsActive);
+    }
+
+    [AvaloniaFact]
+    public void VisibleCompanionsAreHiddenAndRestored_HiddenOnesStayHidden()
+    {
+        var owner = new Window();
+        owner.Show();
+        var shownCompanion = new Window();
+        shownCompanion.Show();
+        var hiddenCompanion = new Window(); // never shown, e.g. video not undocked
+
+        var tool = new Window();
+        var task = WindowService.ShowWithWindowsHiddenAsync(
+            tool, [owner, shownCompanion, hiddenCompanion, null], activateAfterwards: owner);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.False(owner.IsVisible);
+        Assert.False(shownCompanion.IsVisible);
+        Assert.False(hiddenCompanion.IsVisible);
+
+        tool.Close();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(task.IsCompletedSuccessfully);
+        Assert.True(owner.IsVisible);
+        Assert.True(shownCompanion.IsVisible);
+        Assert.False(hiddenCompanion.IsVisible);
+    }
+
+    [AvaloniaFact]
+    public void MinimizedOwnerIsRestoredToNormal()
+    {
+        var owner = new Window();
+        owner.Show();
+        owner.WindowState = WindowState.Minimized;
+
+        var tool = new Window();
+        var task = WindowService.ShowWithWindowsHiddenAsync(tool, [owner], activateAfterwards: owner);
+        Dispatcher.UIThread.RunJobs();
+
+        tool.Close();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(task.IsCompletedSuccessfully);
+        Assert.True(owner.IsVisible);
+        Assert.Equal(WindowState.Normal, owner.WindowState);
+    }
+}

--- a/tests/UI/StubWindowService.cs
+++ b/tests/UI/StubWindowService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Nikse.SubtitleEdit.Logic;
@@ -30,6 +31,13 @@ public sealed class StubWindowService : IWindowService
         Window owner,
         Action<TViewModel>? configureViewModel = null,
         Action<TWindow>? configureWindow = null)
+        where TWindow : Window where TViewModel : class
+        => throw new NotSupportedException();
+
+    public Task<TViewModel> ShowWithOwnerHiddenAsync<TWindow, TViewModel>(
+        Window owner,
+        IReadOnlyList<Window?> companions,
+        Action<TViewModel>? configureViewModel = null)
         where TWindow : Window where TViewModel : class
         => throw new NotSupportedException();
 }


### PR DESCRIPTION
Fixes #14502

SE4 hid the editor while Batch convert was open, so only the tool window was on screen (the reporter's drag-and-drop workflow). SE5 kept the main window visible behind the modal dialog.

## Why not just hide/minimize around the existing modal

- Avalonia's `Window.Hide()` cascades to every owned window, so hiding the owner takes the modal dialog down with it.
- `Window.ShowDialog(owner)` throws on a hidden owner, so hide-then-open fails too.
- Minimizing is no better: on Windows an owner's owned windows go with it.

## Change

- New `IWindowService.ShowWithOwnerHiddenAsync` + static `WindowService.ShowWithWindowsHiddenAsync`: shows the window as an unowned top-level (`CenterScreen`, remembered position still wins), hides the owner and any *visible* companion windows first, awaits `Closed`, then re-shows them and activates the owner. Restoration runs in a `finally`, so the hidden windows can't be lost if showing throws.
- `ShowToolsBatchConvert` uses it, passing the undocked video/waveform windows as companions so they hide and return with the editor (matching SE4, where they were owned forms). Video is paused first as with the modal path; shortcut keys are cleared and focus restored afterwards.
- A full-screen main window keeps the plain modal path (hiding a full-screen window leaves an empty space on macOS).
- Test fakes of `IWindowService` gained the new member.

## Tests

- New `tests/UI/Logic/ShowWithWindowsHiddenTests.cs`: owner hidden while open and back + active on close; visible companions restored, never-shown ones left hidden; minimized owner comes back as Normal.
- Full `UITests` project: 4749 passed, 1 skipped.
- Not verified interactively on Windows/macOS. Worth a manual check on Windows that a maximized main window returns maximized (Avalonia's Win32 impl re-shows with the stored `WindowState`, so it should).

🤖 Generated with [Claude Code](https://claude.com/claude-code)