### PR TITLE
audio.cpp TTS engines: name the model file in the server config, not its folder

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/FishTtsAudioCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/FishTtsAudioCpp.cs
@@ -648,6 +648,13 @@ public class FishTtsAudioCpp : ITtsEngine, IPerLineCloneEngine
     /// Writes the audio.cpp server config next to the binary. lazy_load keeps startup instant;
     /// the model is read on first use and then stays resident until the server is stopped.
     /// </summary>
+    /// <remarks>
+    /// The model entry names the GGUF file, not its folder. Given a folder, audio.cpp picks
+    /// model.gguf or the sole *.gguf and refuses a folder holding several - so a user who had
+    /// downloaded both quantizations could not start the server until one was moved out of
+    /// sight (#14480). The file path is unambiguous, and auxiliary paths still resolve against
+    /// its parent.
+    /// </remarks>
     private static string WriteServerConfig(int port, string backend, string modelKey)
     {
         var config = new Dictionary<string, object>
@@ -663,7 +670,7 @@ public class FishTtsAudioCpp : ITtsEngine, IPerLineCloneEngine
                 {
                     ["id"] = ServerModelId,
                     ["family"] = FamilyName,
-                    ["path"] = GetSetModelsFolder(),
+                    ["path"] = GetModelPath(modelKey),
                     ["task"] = "tts",
                     ["mode"] = "offline",
                 },

--- a/src/ui/Features/Video/TextToSpeech/Engines/HiggsTtsAudioCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/HiggsTtsAudioCpp.cs
@@ -636,6 +636,13 @@ public class HiggsTtsAudioCpp : ITtsEngine, IPerLineCloneEngine
     /// Writes the audio.cpp server config next to the binary. lazy_load keeps startup instant;
     /// the model is read on first use and then stays resident until the server is stopped.
     /// </summary>
+    /// <remarks>
+    /// The model entry names the GGUF file, not its folder. Given a folder, audio.cpp picks
+    /// model.gguf or the sole *.gguf and refuses a folder holding several - so a user who had
+    /// downloaded both quantizations could not start the server until one was moved out of
+    /// sight (#14480). The file path is unambiguous, and auxiliary paths still resolve against
+    /// its parent.
+    /// </remarks>
     private static string WriteServerConfig(int port, string backend, string modelKey)
     {
         var config = new Dictionary<string, object>
@@ -651,7 +658,7 @@ public class HiggsTtsAudioCpp : ITtsEngine, IPerLineCloneEngine
                 {
                     ["id"] = ServerModelId,
                     ["family"] = FamilyName,
-                    ["path"] = GetSetModelsFolder(),
+                    ["path"] = GetModelPath(modelKey),
                     ["task"] = "tts",
                     ["mode"] = "offline",
                 },

--- a/src/ui/Features/Video/TextToSpeech/Engines/IndexTts25AudioCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/IndexTts25AudioCpp.cs
@@ -663,6 +663,13 @@ public class IndexTts25AudioCpp : ITtsEngine, IPerLineCloneEngine
     /// Writes the audio.cpp server config next to the binary. lazy_load keeps startup instant;
     /// the model is read on first use and then stays resident until the server is stopped.
     /// </summary>
+    /// <remarks>
+    /// The model entry names the GGUF file, not its folder. Given a folder, audio.cpp picks
+    /// model.gguf or the sole *.gguf and refuses a folder holding several - so a user who had
+    /// downloaded both quantizations could not start the server until one was moved out of
+    /// sight (#14480). The file path is unambiguous, and auxiliary paths still resolve against
+    /// its parent.
+    /// </remarks>
     private static string WriteServerConfig(int port, string backend, string modelKey)
     {
         var config = new Dictionary<string, object>
@@ -678,7 +685,7 @@ public class IndexTts25AudioCpp : ITtsEngine, IPerLineCloneEngine
                 {
                     ["id"] = ServerModelId,
                     ["family"] = FamilyName,
-                    ["path"] = GetSetModelsFolder(),
+                    ["path"] = GetModelPath(modelKey),
                     ["task"] = "clon",
                     ["mode"] = "offline",
                 },


### PR DESCRIPTION
Part of #14480 (invio-a11y's test report: "Both models cannot be stored in the same folder simultaneously without causing an error").

## The bug

`WriteServerConfig` in the Higgs Audio v3, Fish Audio S2 Pro and IndexTTS 2.5 engines set the model entry's `"path"` to the engine's **models folder**, not the selected GGUF. audio.cpp resolves a folder by taking `model.gguf` or the sole `*.gguf`, and refuses a folder that holds several GGUFs without a `model.gguf` (`app/server/model_memory.cpp`). So a user who downloaded both the q8_0 and the bf16 quantization could not start the server until one file was hidden in a subfolder. The model key the user picked only reached the log line.

## The fix

The config now names the selected file via `GetModelPath(modelKey)`. audio.cpp accepts a file path for a model entry and resolves auxiliary paths against its parent, so a folder holding one file behaves as before.

Three one-line changes plus a remark explaining the choice. Built `src/ui/UI.csproj` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
