### PR TITLE
TTS per-line clone: pad references under one second so Higgs stops rejecting them

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/PerLineVoiceClone.cs
+++ b/src/ui/Features/Video/TextToSpeech/PerLineVoiceClone.cs
@@ -35,6 +35,20 @@ public static class PerLineVoiceClone
     /// </summary>
     internal const double PreferredReferenceSeconds = 3.0;
 
+    /// <summary>
+    /// The shortest reference clip handed to an engine, in seconds. A line that is shorter and
+    /// has no silence to grow into (neighbouring lines on both sides) is padded with trailing
+    /// silence up to this instead of being sent as cut.
+    /// </summary>
+    /// <remarks>
+    /// Higgs Audio v3's reference encoder in audio.cpp (higgs_audio_tts/codec.cpp) pads its
+    /// 24 kHz acoustic branch up to one second but not its 16 kHz semantic branch, so every
+    /// reference under roughly 965 ms fails the "frame counts do not match" check with a 500
+    /// and the line goes missing from the dub (#14480). One second of audio clears it for all
+    /// lengths; the added silence is inaudible in the clone.
+    /// </remarks>
+    internal const double MinimumReferenceSeconds = 1.0;
+
     /// <summary>Reference clips are cut at the rate the cloning models work at.</summary>
     private const int ReferenceSampleRate = 24000;
 
@@ -139,7 +153,7 @@ public static class PerLineVoiceClone
 
             var range = GetReferenceRange(paragraphs, index, videoDurationSeconds);
             var clipFileName = Path.Combine(outputFolder, $"line-{index + 1:0000}.wav");
-            if (!await CutClipAsync(videoFileName, range.StartSeconds, range.DurationSeconds, clipFileName, audioTrackFfIndex, cancellationToken))
+            if (!await CutClipAsync(videoFileName, range.StartSeconds, range.DurationSeconds, clipFileName, audioTrackFfIndex, cancellationToken, MinimumReferenceSeconds))
             {
                 return null;
             }
@@ -165,6 +179,11 @@ public static class PerLineVoiceClone
     /// <summary>
     /// Cuts exactly the given range out of the video as a cloning-ready mono clip.
     /// </summary>
+    /// <param name="minimumSeconds">
+    /// Pad the clip with trailing silence up to this length when the range is shorter; zero
+    /// keeps the range as is. The per-line references pass <see cref="MinimumReferenceSeconds"/>;
+    /// the auto-cast parts do not, since they are joined into one long reference anyway.
+    /// </param>
     /// <returns>False when ffmpeg failed or produced no audio; the caller decides what that means.</returns>
     public static async Task<bool> CutClipAsync(
         string videoFileName,
@@ -172,7 +191,8 @@ public static class PerLineVoiceClone
         double durationSeconds,
         string outputFileName,
         int audioTrackFfIndex,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        double minimumSeconds = 0)
     {
         var arguments = FfmpegGenerator.ExtractCloneReferenceClipParameters(
             videoFileName,
@@ -180,7 +200,8 @@ public static class PerLineVoiceClone
             durationSeconds,
             outputFileName,
             audioTrackFfIndex,
-            ReferenceSampleRate);
+            ReferenceSampleRate,
+            minimumSeconds);
 
         try
         {

--- a/src/ui/Logic/Media/FfmpegGenerator.cs
+++ b/src/ui/Logic/Media/FfmpegGenerator.cs
@@ -1457,13 +1457,19 @@ public class FfmpegGenerator
     /// read by a model, and every engine that clones wants one mono channel - handing it a stereo
     /// clip means each engine resamples it again, or worse, clones from a downmix it made itself.
     /// </remarks>
+    /// <param name="minimumSeconds">
+    /// When positive, a clip shorter than this is padded with trailing silence up to it (apad
+    /// with whole_dur; a longer clip is left alone). Some reference encoders reject inputs
+    /// under a fixed length - see <c>PerLineVoiceClone.MinimumReferenceSeconds</c>.
+    /// </param>
     internal static string ExtractCloneReferenceClipParameters(
         string videoFileName,
         double startSeconds,
         double durationSeconds,
         string outputFileName,
         int audioTrackFfIndex = -1,
-        int sampleRate = 24000)
+        int sampleRate = 24000,
+        double minimumSeconds = 0)
     {
         var start = $"{startSeconds:0.000}".Replace(",", ".");
         var duration = $"{durationSeconds:0.000}".Replace(",", ".");
@@ -1472,6 +1478,12 @@ public class FfmpegGenerator
         if (audioTrackFfIndex >= 0)
         {
             args += $" -map 0:{audioTrackFfIndex}";
+        }
+
+        if (minimumSeconds > 0)
+        {
+            var minimum = minimumSeconds.ToString("0.###", CultureInfo.InvariantCulture);
+            args += $" -af apad=whole_dur={minimum}";
         }
 
         args += $" -vn -ar {sampleRate} -ac 1 -c:a pcm_s16le \"{outputFileName}\"";

--- a/tests/UI/Logic/Media/FfmpegGeneratorCloneReferenceClipTests.cs
+++ b/tests/UI/Logic/Media/FfmpegGeneratorCloneReferenceClipTests.cs
@@ -1,0 +1,56 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech;
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace UITests.Logic.Media;
+
+public class FfmpegGeneratorCloneReferenceClipTests
+{
+    [Fact]
+    public void CloneReferenceClip_Default_CutsTheRangeAsIs()
+    {
+        var args = FfmpegGenerator.ExtractCloneReferenceClipParameters("video.mp4", 12.5, 0.8, "clip.wav");
+
+        Assert.Contains("-ss 12.500 -t 0.800", args);
+        Assert.Contains("-ar 24000 -ac 1 -c:a pcm_s16le", args);
+        Assert.DoesNotContain("apad", args);
+    }
+
+    [Fact]
+    public void CloneReferenceClip_WithMinimum_PadsUpToItWithSilence()
+    {
+        // #14480: Higgs Audio v3's reference encoder rejects clips under ~1 s, so a boxed-in
+        // short line is padded rather than sent as cut. whole_dur leaves longer clips alone.
+        var args = FfmpegGenerator.ExtractCloneReferenceClipParameters(
+            "video.mp4", 12.5, 0.8, "clip.wav", audioTrackFfIndex: 2, sampleRate: 24000, minimumSeconds: 1.0);
+
+        Assert.Contains("-map 0:2 -af apad=whole_dur=1 -vn", args);
+    }
+
+    [Fact]
+    public void CloneReferenceClip_MinimumIsFormattedInvariant()
+    {
+        var args = FfmpegGenerator.ExtractCloneReferenceClipParameters(
+            "video.mp4", 0, 0.5, "clip.wav", minimumSeconds: 1.25);
+
+        Assert.Contains("apad=whole_dur=1.25", args);
+    }
+
+    [Fact]
+    public void PerLineReference_ShortLineBoxedInByNeighbours_IsWhyTheMinimumExists()
+    {
+        // A 400 ms line with other lines right before and after it cannot grow into silence,
+        // so the cut range stays under the engine minimum and only the padding saves it.
+        var paragraphs = new List<Paragraph>
+        {
+            new("A", 0, 5000),
+            new("B", 5000, 5400),
+            new("C", 5400, 9000),
+        };
+
+        var range = PerLineVoiceClone.GetReferenceRange(paragraphs, 1, 60);
+
+        Assert.True(range.DurationSeconds < PerLineVoiceClone.MinimumReferenceSeconds);
+        Assert.Equal(0.4, range.DurationSeconds, 3);
+    }
+}


### PR DESCRIPTION
Part of #14480 (invio-a11y's test report: "2 of 24 segments failed to generate ... Higgs TTS codec acoustic and semantic encoder frame counts do not match").

## The bug

"Clone from video (voice from each line)" cuts one reference clip per line and grows a short line into the surrounding silence, but never into a neighbouring line. A short line boxed in by other lines therefore yields a sub-second clip.

audio.cpp's Higgs reference encoder (`src/models/higgs_audio_tts/codec.cpp`, identical at the pinned v0.7.1) pads its 24 kHz acoustic branch up to one second but not its 16 kHz semantic branch. Simulating its frame math for 24 kHz input: every clip from 100 ms to about 965 ms fails the frame-count comparison and the server answers 500; every length from 965 ms to 20 s passes. Those lines then go missing from the dub.

## The fix

The per-line cut pads the clip with trailing silence to at least one second, via `apad=whole_dur=1`, so longer clips are untouched. `ExtractCloneReferenceClipParameters` and `CutClipAsync` take an optional minimum; only the per-line path passes it. The auto-cast parts keep cutting exactly the line, since they are joined into one long reference anyway.

Verified with ffmpeg on a synthetic source: a 400 ms cut comes out at exactly 24000 samples, a 2.5 s cut is unchanged.

## Tests

`FfmpegGeneratorCloneReferenceClipTests`: default emits no apad, the minimum emits `apad=whole_dur=1` before `-vn`, invariant formatting, and a boxed-in 400 ms line's reference range stays under the minimum (the scenario that needs the padding). Existing `AudioCppPerLineCloneTests` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
