### PR TITLE
Undo/redo: keep the current row at the same viewport height (#14517)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -20448,6 +20448,7 @@ public partial class MainViewModel :
         RunWithoutChangeDetection(() =>
         {
             var preIndex = SelectedSubtitleIndex ?? 0;
+            var preRowTop = GetSelectedRowViewportTop();
 
             var undoRedoObject = _undoRedoManager.Undo()!;
             if (undoRedoObject?.Subtitles == null)
@@ -20455,8 +20456,8 @@ public partial class MainViewModel :
                 return;
             }
 
-            RestoreUndoRedoState(undoRedoObject);
-            RestoreSelectionToPreviousIndex(preIndex);
+            RestoreUndoRedoState(undoRedoObject, scrollToSelected: false);
+            RestoreSelectionToPreviousIndex(preIndex, preRowTop);
             ShowUndoStatus();
         });
     }
@@ -20495,6 +20496,7 @@ public partial class MainViewModel :
         RunWithoutChangeDetection(() =>
         {
             var preIndex = SelectedSubtitleIndex ?? 0;
+            var preRowTop = GetSelectedRowViewportTop();
 
             var undoRedoObject = _undoRedoManager.Redo();
             if (undoRedoObject?.Subtitles == null)
@@ -20502,20 +20504,43 @@ public partial class MainViewModel :
                 return;
             }
 
-            RestoreUndoRedoState(undoRedoObject);
-            RestoreSelectionToPreviousIndex(preIndex);
+            RestoreUndoRedoState(undoRedoObject, scrollToSelected: false);
+            RestoreSelectionToPreviousIndex(preIndex, preRowTop);
             ShowRedoStatus();
         });
     }
 
-    private void RestoreSelectionToPreviousIndex(int preIndex)
+    /// <summary>
+    /// Where the current row sits in the grid's viewport, captured before undo/redo rebuild the
+    /// rows, so <see cref="RestoreSelectionToPreviousIndex"/> can put the restored row back at
+    /// the same height. Null when the row is off screen (or there is no grid yet).
+    /// </summary>
+    private double? GetSelectedRowViewportTop()
+    {
+        if (SubtitleGrid is not { } grid || SelectedSubtitle is not { } row)
+        {
+            return null;
+        }
+
+        return TableViewExtras.GetRowViewportTop(grid, row);
+    }
+
+    /// <summary>
+    /// Re-selects the row at <paramref name="preIndex"/> after undo/redo. With
+    /// <paramref name="preRowTop"/> given, the row is placed at that viewport height rather than
+    /// scrolled to the edge: the rebuild in <see cref="ReplaceSubtitles"/> detaches the
+    /// ItemsSource and so drops the scroll offset to 0, after which a plain ScrollIntoView parked
+    /// the current line at the top of the grid on every Undo - disorienting when the user was
+    /// working near the bottom of the view (#14517).
+    /// </summary>
+    private void RestoreSelectionToPreviousIndex(int preIndex, double? preRowTop = null)
     {
         if (Subtitles.Count == 0)
         {
             return;
         }
 
-        SelectAndScrollToRow(Math.Clamp(preIndex, 0, Subtitles.Count - 1));
+        SelectAndScrollToRow(Math.Clamp(preIndex, 0, Subtitles.Count - 1), null, keepRowViewportTop: preRowTop);
     }
 
     public UndoRedoItem MakeUndoRedoObject(string description)
@@ -20547,8 +20572,17 @@ public partial class MainViewModel :
         };
     }
 
-    private void RestoreUndoRedoState(UndoRedoItem undoRedoObject)
+    /// <param name="scrollToSelected">
+    /// Select and scroll to the snapshot's own selected line afterwards. Undo/redo pass false and
+    /// restore the pre-command row at its old viewport height themselves; the history dialog
+    /// (which restores several steps in a row) keeps the default.
+    /// </param>
+    private void RestoreUndoRedoState(UndoRedoItem undoRedoObject, bool scrollToSelected = true)
     {
+        // The rebuild below swaps the ItemsSource and refills the collection; the scroll anchor
+        // must not try to "restore" the view in the middle of that (see SelectAndScrollToRow).
+        using var anchorSuspended = SubtitleGrid is { } grid ? TableViewScrollAnchor.GetFor(grid)?.Suspend() : null;
+
         ReplaceSubtitles(undoRedoObject.Subtitles);
 
         _subtitleFileName = undoRedoObject.SubtitleFileName;
@@ -20572,7 +20606,10 @@ public partial class MainViewModel :
         _subtitleOriginal.Header = undoRedoObject.SubtitleHeaderOriginal;
         _subtitleOriginal.Footer = undoRedoObject.SubtitleFooterOriginal;
 
-        SelectAndScrollToRow(undoRedoObject.SelectedLines.First());
+        if (scrollToSelected)
+        {
+            SelectAndScrollToRow(undoRedoObject.SelectedLines.First());
+        }
     }
 
     public void AutoFitColumns()
@@ -20771,7 +20808,12 @@ public partial class MainViewModel :
     /// the scroll offset is left alone for a visible row (see <paramref name="row"/> callers such
     /// as delete/insert, which must not move the rows out from under the user).
     /// </param>
-    private void SelectAndScrollToRow(int index, SubtitleLineViewModel? row, bool? restoreGridFocus = null, bool centerEvenIfVisible = false)
+    /// <param name="keepRowViewportTop">
+    /// Put the target row's top edge at this viewport height instead of the usual "leave it if
+    /// visible, else scroll into view / center" - for callers that just rebuilt the grid from new
+    /// row objects (undo/redo) and captured where the row stood before (#14517).
+    /// </param>
+    private void SelectAndScrollToRow(int index, SubtitleLineViewModel? row, bool? restoreGridFocus = null, bool centerEvenIfVisible = false, double? keepRowViewportTop = null)
     {
         _shiftSelectAnchorIndex = -1;
         _shiftSelectCurrentIndex = -1;
@@ -20885,7 +20927,11 @@ public partial class MainViewModel :
                     EditTextBoxOriginal.CaretIndex = 0;
                 }
 
-                if (Se.Settings.General.SubtitleGridCenterSelectedRow && (!alreadyVisible || centerEvenIfVisible))
+                if (keepRowViewportTop is { } rowTop)
+                {
+                    TableViewExtras.PlaceRowAtViewportTop(SubtitleGrid, itemToScroll, rowTop);
+                }
+                else if (Se.Settings.General.SubtitleGridCenterSelectedRow && (!alreadyVisible || centerEvenIfVisible))
                 {
                     CenterSelectedRowInSubtitleGrid(itemToScroll);
                 }

--- a/src/ui/Logic/TableViewExtras.cs
+++ b/src/ui/Logic/TableViewExtras.cs
@@ -892,6 +892,41 @@ public static class TableViewExtras
     }
 
     /// <summary>
+    /// Where <paramref name="item"/>'s row sits right now: its top edge in viewport coordinates
+    /// (negative while scrolled into), or null when the row is not realized. Pair with
+    /// <see cref="PlaceRowAtViewportTop"/> to put a row back where the user saw it after the
+    /// grid has been rebuilt from scratch.
+    /// </summary>
+    public static double? GetRowViewportTop(TableView tableView, object item)
+    {
+        var scrollViewer = tableView.GetVisualDescendants().OfType<ScrollViewer>().FirstOrDefault();
+        if (scrollViewer == null || scrollViewer.Viewport.Height <= 0)
+        {
+            return null;
+        }
+
+        if (tableView.ContainerFromItem(item) is not { } row || row.Bounds.Height <= 0)
+        {
+            return null;
+        }
+
+        return row.TranslatePoint(new Point(0, 0), ViewportOrigin(scrollViewer))?.Y;
+    }
+
+    /// <summary>
+    /// Scrolls so <paramref name="item"/>'s row has its top edge at <paramref name="top"/>
+    /// viewport pixels - the position <see cref="GetRowViewportTop"/> reported for the row that
+    /// stood there before. Undo/redo replace every row object (and detach the ItemsSource on the
+    /// way, which drops the offset to 0), so nothing else can keep the view still across them;
+    /// this puts the restored row back at the same height instead of letting ScrollIntoView
+    /// park it at the viewport edge (#14517).
+    /// </summary>
+    public static void PlaceRowAtViewportTop(TableView tableView, object item, double top)
+    {
+        AdjustScrollForRow(tableView, item, (rowTop, _, _) => rowTop - top);
+    }
+
+    /// <summary>
     /// Whether <paramref name="item"/>'s row is realized and entirely inside the viewport right
     /// now. Callers use it to leave the scroll offset alone when the row they are about to select
     /// is already on screen - deleting a line, for example, makes the next line current, and that

--- a/tests/UI/Features/Main/SubtitleGridUndoScrollPositionTests.cs
+++ b/tests/UI/Features/Main/SubtitleGridUndoScrollPositionTests.cs
@@ -1,0 +1,175 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.UndoRedo;
+using System.Reflection;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// Undo/redo rebuild the whole grid from the snapshot's row copies (ReplaceSubtitles detaches the
+/// ItemsSource on the way, which drops the scroll offset to 0). The follow-up scroll then found
+/// the current row off screen and parked it at the top edge of the grid - a jump on every Undo,
+/// worst when working near the bottom of the view (#14517). The restored row must come back at
+/// the same viewport height it had before the command.
+/// </summary>
+public class SubtitleGridUndoScrollPositionTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    [AvaloniaFact]
+    public async Task Undo_KeepsTheCurrentRowAtTheSameViewportHeight()
+    {
+        Se.Settings.General.SubtitleGridCenterSelectedRow = false;
+        var (window, vm) = ShowMainWindowWithLines(300);
+
+        // The change-detection snapshot is taken with whatever row was current at the time -
+        // here one far above the view the user then scrolls to.
+        vm.SelectAndScrollToSubtitle(vm.Subtitles[5]);
+        await SettleAsync(window);
+        GetUndoRedoManager(vm).Do(vm.MakeUndoRedoObject("before edit"));
+
+        // Scroll into the file, then pick a row near the bottom of the view.
+        vm.SelectAndScrollToSubtitle(vm.Subtitles[100]);
+        await SettleAsync(window);
+        vm.SelectAndScrollToSubtitle(vm.Subtitles[112]);
+        await SettleAsync(window);
+
+        var scrollViewer = vm.SubtitleGrid.GetVisualDescendants().OfType<ScrollViewer>().First();
+        var offsetBefore = scrollViewer.Offset.Y;
+        Assert.True(offsetBefore > 0);
+        var rowTopBefore = TableViewExtras.GetRowViewportTop(vm.SubtitleGrid, vm.Subtitles[112]);
+        Assert.NotNull(rowTopBefore);
+        Assert.True(rowTopBefore > scrollViewer.Viewport.Height / 2, $"row should sit in the lower half, was at {rowTopBefore}");
+
+        // An unrecorded edit for Undo to revert.
+        vm.Subtitles[112].Text = "edited";
+        await SettleAsync(window);
+
+        vm.UndoCommand.Execute(null);
+        await SettleAsync(window);
+        await SettleAsync(window);
+
+        Assert.Equal("Line 113", vm.SelectedSubtitle?.Text);
+        var rowTopAfter = TableViewExtras.GetRowViewportTop(vm.SubtitleGrid, vm.SelectedSubtitle!);
+        Assert.NotNull(rowTopAfter);
+        // The row's place on screen is what the user sees; the raw pixel offset legitimately
+        // differs, as the rebuilt panel re-estimates its extent from scratch.
+        Assert.InRange(rowTopAfter!.Value, rowTopBefore!.Value - 1, rowTopBefore.Value + 1);
+    }
+
+    [AvaloniaFact]
+    public async Task Redo_KeepsTheCurrentRowAtTheSameViewportHeight()
+    {
+        Se.Settings.General.SubtitleGridCenterSelectedRow = false;
+        var (window, vm) = ShowMainWindowWithLines(300);
+
+        // The change-detection snapshot is taken with whatever row was current at the time -
+        // here one far above the view the user then scrolls to.
+        vm.SelectAndScrollToSubtitle(vm.Subtitles[5]);
+        await SettleAsync(window);
+        GetUndoRedoManager(vm).Do(vm.MakeUndoRedoObject("before edit"));
+
+        vm.SelectAndScrollToSubtitle(vm.Subtitles[100]);
+        await SettleAsync(window);
+        vm.SelectAndScrollToSubtitle(vm.Subtitles[112]);
+        await SettleAsync(window);
+
+        vm.Subtitles[112].Text = "edited";
+        await SettleAsync(window);
+        vm.UndoCommand.Execute(null);
+        await SettleAsync(window);
+        await SettleAsync(window);
+
+        var rowTopBefore = TableViewExtras.GetRowViewportTop(vm.SubtitleGrid, vm.SelectedSubtitle!);
+        Assert.NotNull(rowTopBefore);
+
+        vm.RedoCommand.Execute(null);
+        await SettleAsync(window);
+        await SettleAsync(window);
+
+        Assert.Equal("edited", vm.SelectedSubtitle?.Text);
+        var rowTopAfter = TableViewExtras.GetRowViewportTop(vm.SubtitleGrid, vm.SelectedSubtitle!);
+        Assert.NotNull(rowTopAfter);
+        Assert.InRange(rowTopAfter!.Value, rowTopBefore!.Value - 1, rowTopBefore.Value + 1);
+    }
+
+    private static IUndoRedoManager GetUndoRedoManager(MainViewModel vm)
+    {
+        var field = typeof(MainViewModel).GetField("_undoRedoManager", BindingFlags.Instance | BindingFlags.NonPublic)
+                    ?? throw new InvalidOperationException("_undoRedoManager not found");
+        return (IUndoRedoManager)field.GetValue(vm)!;
+    }
+
+    private (Window Window, MainViewModel Vm) ShowMainWindowWithLines(int lineCount)
+    {
+        var (window, vm) = CreateMainViewModel();
+        vm.Menu.IsVisible = true;
+        for (var i = 0; i < lineCount; i++)
+        {
+            // Mixed one- and two-line rows: with uniform rows the rebuilt panel maps the old
+            // pixel offset back to the same row by luck, and the drift never shows.
+            var text = i % 3 == 0 ? $"Line {i + 1}\nsecond line" : $"Line {i + 1}";
+            vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph(text, i * 2000, i * 2000 + 1500), null!)
+            {
+                Number = i + 1,
+            });
+        }
+
+        Settle(window);
+        return (window, vm);
+    }
+
+    private (Window Window, MainViewModel Vm) CreateMainViewModel()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1400, Height = 900 };
+        _windows.Add(window);
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var vm = (MainViewModel)view.DataContext!;
+        window.SuppressSaveChangesPromptOnClose(vm);
+        return (window, vm);
+    }
+
+    private static async Task SettleAsync(Window window)
+    {
+        Settle(window);
+        await Task.Delay(50);
+        Settle(window);
+    }
+
+    private static void Settle(Window window)
+    {
+        for (var pump = 0; pump < 8; pump++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #14517.

**Problem.** Undo (and redo) scrolled the grid so the current subtitle sat at the top edge of the view. `RestoreUndoRedoState` rebuilds every row from the snapshot's copies via `ReplaceSubtitles`, so the virtualizing panel re-estimates its extent from scratch. On files with mixed one- and two-line rows the old pixel offset then maps to a different row, the follow-up `SelectAndScrollToRow` finds the current line off screen, and `PrePositionScroll` + `ScrollIntoView` park it at the viewport top. `TableViewScrollAnchor` cannot help here: it resolves rows by object identity and the snapshot rows are fresh copies.

**Fix.**
- `PerformUndo`/`PerformRedo` capture the selected row's top edge in viewport coordinates before the rebuild and hand it to `SelectAndScrollToRow` (new `keepRowViewportTop` option), which places the restored row at that same height via the new `TableViewExtras.PlaceRowAtViewportTop`.
- The anchor is suspended across `RestoreUndoRedoState` so it does not fight the rebuild.
- Undo/redo no longer scroll twice (snapshot's selected line, then the pre-command row); the history dialog keeps the snapshot scroll via the `scrollToSelected` default.

**Test.** `SubtitleGridUndoScrollPositionTests` builds a 300-line grid with mixed row heights, selects a row in the lower half of the view, undoes/redoes an edit and asserts the row's viewport top is unchanged. Without the fix the row drifted 40 px in the headless grid (the real-world jump is larger, as the drift grows with longer runs of two-line rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)