### PR TITLE
Word lists: allow case variants in the OCR fix list

### DIFF
--- a/src/ui/Features/Options/WordLists/WordListsViewModel.cs
+++ b/src/ui/Features/Options/WordLists/WordListsViewModel.cs
@@ -256,8 +256,11 @@ public partial class WordListsViewModel : ObservableObject
             return;
         }
 
-        if (OcrFixes.Any(f => f.Find.Equals(fixFind, StringComparison.OrdinalIgnoreCase)))
+        // The OCR fix list is case-sensitive (both storage and lookup), so
+        // "word", "Word" and "WORD" are distinct entries and must all be allowed.
+        if (OcrFixes.Any(f => f.Find.Equals(fixFind, StringComparison.Ordinal)))
         {
+            await MessageBox.Show(Window, Se.Language.General.Error, Se.Language.Options.WordLists.UnableToAddItem, MessageBoxButtons.OK, MessageBoxIcon.Error);
             return;
         }
 


### PR DESCRIPTION
Fixes #14520

## Problem
In Options > Word lists, the OCR fix tab refused to add a word when an entry with the same letters but different casing already existed (e.g. `aberracao` blocks `Aberracao` and `ABERRACAO`). The rejection was silent, so the Add button appeared to do nothing.

The duplicate check in `WordListsViewModel.AddOcrFix` used `StringComparison.OrdinalIgnoreCase`, while both the backing `OcrFixReplaceList2` dictionaries and the OCR fix engine's word lookups are case-sensitive. So the variants are genuinely distinct entries the user needs, and SE4 allowed them.

## Fix
- Compare with `StringComparison.Ordinal` so case variants can be added.
- Show the existing "Unable to add item, it probably already exists!" message on a real duplicate instead of returning silently.

Names and user words tabs were already case-sensitive and are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)