### PR TITLE
Fix #14524: "Show Plugins menu" toggles the native macOS Plugins menu

### DIFF
--- a/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
+++ b/src/ui/Features/Main/Layout/InitNativeMacMenu.cs
@@ -664,10 +664,7 @@ public static class InitNativeMacMenu
         foreach (var (item, getHeader, _) in state.DynamicHeaders)
             item.Header = getHeader(vm);
 
-        if (state.PluginsItem != null)
-        {
-            state.PluginsItem.IsEnabled = Se.Settings.Appearance.ShowPluginsMenu;
-        }
+        UpdatePluginsMenuVisibility(vm);
 
         state.Handler = (s, e) =>
         {
@@ -782,6 +779,19 @@ public static class InitNativeMacMenu
             },
             Se.Language.Video.ClearRecentVideos,
             () => vm.CommandVideoClearRecentFilesCommand.Execute(null));
+    }
+
+    /// <summary>
+    /// Show/hide the top-level Plugins menu from the "Show Plugins menu" setting. Must be
+    /// IsVisible, not IsEnabled: macOS ignores the enabled state of a top-level title that
+    /// carries a submenu, so a disabled item stayed on the menu bar (issue #14524).
+    /// </summary>
+    public static void UpdatePluginsMenuVisibility(MainViewModel vm)
+    {
+        if (vm.NativeMenuPlugins != null)
+        {
+            vm.NativeMenuPlugins.IsVisible = Se.Settings.Appearance.ShowPluginsMenu;
+        }
     }
 
     public static void UpdatePluginsMenu(MainViewModel vm)

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -12731,6 +12731,10 @@ public partial class MainViewModel :
         RebuildToolbar();
 
         MenuPlugins.IsVisible = Se.Settings.Appearance.ShowPluginsMenu;
+        if (OperatingSystem.IsMacOS())
+        {
+            Layout.InitNativeMacMenu.UpdatePluginsMenuVisibility(this);
+        }
 
         LockTimeCodes = Se.Settings.General.LockTimeCodes;
         IsWaveformToolbarVisible = Se.Settings.Waveform.ShowToolbar;


### PR DESCRIPTION
Fixes #14524

On macOS the Plugins menu stayed on the menu bar regardless of the "Show Plugins menu" setting.

Two causes:
- The native menu item mapped the setting to `IsEnabled`. macOS ignores the enabled state of a top-level title that carries a submenu, so the item was always shown.
- `ApplySettings` only updated the in-window Avalonia menu, never the native menu bar.

Fix: map the setting to `IsVisible` via a small `UpdatePluginsMenuVisibility` helper, and call it from `ApplySettings` on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)