### PR TITLE
Add Export... to the transcription quality report

### DIFF
--- a/src/ui/Features/Shared/ErrorList/ErrorListExport.cs
+++ b/src/ui/Features/Shared/ErrorList/ErrorListExport.cs
@@ -2,406 +2,69 @@ using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
 using System.Linq;
-using System.Text;
 
 namespace Nikse.SubtitleEdit.Features.Shared.ErrorList;
 
 /// <summary>
-/// Turns the rows of "List errors" into something that can leave the window: the clipboard,
-/// a plain text log, an Excel workbook, or a stand-alone html page (#14379 - the list had to
-/// be screenshotted to be shared or handed to an AI).
-/// <para>
-/// Every writer takes the rows exactly as the window shows them, so an active summary-card
-/// filter is part of what is exported.
-/// </para>
+/// Maps the rows of "List errors" onto <see cref="ReportExport"/> (#14379 - the list had to be
+/// screenshotted to be shared or handed to an AI). Every writer takes the rows exactly as the
+/// window shows them, so an active summary-card filter is part of what is exported.
 /// </summary>
 public static class ErrorListExport
 {
-    /// <summary>Tab separated with a header row - what the clipboard gets, and what Excel/Sheets paste as columns.</summary>
     public static string ToTabSeparated(IEnumerable<ErrorListItem> items)
     {
-        var sb = new StringBuilder();
-        sb.AppendLine(string.Join("\t", Headers()));
-        foreach (var item in items)
-        {
-            sb.AppendLine(string.Join("\t", Cells(item).Select(CleanForTabSeparated)));
-        }
-
-        return sb.ToString();
+        return ReportExport.ToTabSeparated(MakeData(items, string.Empty, null));
     }
 
-    /// <summary>
-    /// A readable log: a short header, then two lines per error - the time code and the error on
-    /// the first, the subtitle text on the second. Meant to be pasted into a mail, an issue, or
-    /// a prompt.
-    /// </summary>
     public static string ToPlainText(IEnumerable<ErrorListItem> items, string summary, string? subtitleFileName)
     {
-        var l = Se.Language.ErrorList;
-        var sb = new StringBuilder();
-        sb.AppendLine(l.Title);
-        if (!string.IsNullOrEmpty(subtitleFileName))
-        {
-            sb.AppendLine(string.Format(l.ExportFileX, subtitleFileName));
-        }
-
-        sb.AppendLine(string.Format(l.ExportGeneratedX, Now()));
-        sb.AppendLine(summary);
-        sb.AppendLine();
-
-        foreach (var item in items)
-        {
-            sb.AppendLine($"#{item.Number}  {item.Show} --> {item.Hide}  {item.Category}: {item.Detail}");
-            sb.AppendLine("    " + item.Text);
-        }
-
-        return sb.ToString();
+        return ReportExport.ToPlainText(MakeData(items, summary, subtitleFileName));
     }
 
-    /// <summary>The same rows as an .xlsx workbook - see <see cref="XlsxWriter"/> for why not csv.</summary>
     public static byte[] ToXlsx(IEnumerable<ErrorListItem> items)
     {
-        var rows = items.Select(item => (IReadOnlyList<object?>)new object?[]
-        {
-            item.Number,
-            item.Category,
-            item.Show,
-            item.Hide,
-            item.Detail,
-            item.Text,
-        });
-
-        return XlsxWriter.Create(Se.Language.ErrorList.Title, Headers(), rows, new double[] { 6, 20, 14, 14, 26, 80 });
+        return ReportExport.ToXlsx(MakeData(items, string.Empty, null));
     }
 
-    /// <summary>
-    /// A stand-alone page - no scripts, no web fonts, nothing to load - that follows the
-    /// reader's light/dark preference and paints the error classes in the same colours as the
-    /// window. The summary cards become filter chips backed by <c>:checked</c> radios, so the
-    /// page filters without a line of JavaScript.
-    /// </summary>
     public static string ToHtml(IEnumerable<ErrorListItem> items, string summary, string? subtitleFileName)
+    {
+        return ReportExport.ToHtml(MakeData(items, summary, subtitleFileName));
+    }
+
+    private static ReportExportData MakeData(IEnumerable<ErrorListItem> items, string summary, string? subtitleFileName)
     {
         var l = Se.Language.ErrorList;
         var list = items.ToList();
-        var title = string.IsNullOrEmpty(subtitleFileName)
-            ? l.Title
-            : l.Title + " - " + Path.GetFileName(subtitleFileName);
-
-        var sb = new StringBuilder();
-        sb.AppendLine("<!DOCTYPE html>");
-        sb.AppendLine("<html lang=\"en\">");
-        sb.AppendLine("<head>");
-        sb.AppendLine("<meta charset=\"utf-8\">");
-        sb.AppendLine("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">");
-        sb.AppendLine("<meta name=\"color-scheme\" content=\"light dark\">");
-        sb.AppendLine("<title>" + Encode(title) + "</title>");
-        sb.AppendLine("<style>");
-        sb.AppendLine(Css);
-        sb.AppendLine("</style>");
-        sb.AppendLine("</head>");
-        sb.AppendLine("<body>");
-        sb.AppendLine("<main>");
-
-        sb.AppendLine("<header>");
-        sb.AppendLine("  <h1>" + Encode(l.Title) + "</h1>");
-        sb.AppendLine("  <p class=\"summary\">" + Encode(summary) + "</p>");
-        sb.AppendLine("  <p class=\"meta\">");
-        if (!string.IsNullOrEmpty(subtitleFileName))
+        return new ReportExportData
         {
-            sb.AppendLine("    <span>" + Encode(string.Format(l.ExportFileX, subtitleFileName)) + "</span>");
-        }
-
-        sb.AppendLine("    <span>" + Encode(string.Format(l.ExportGeneratedX, Now())) + "</span>");
-        sb.AppendLine("  </p>");
-        sb.AppendLine("</header>");
-
-        AppendChips(sb, list, l.All);
-        AppendTable(sb, list);
-
-        sb.AppendLine("<footer>" + Encode(l.ExportMadeWithSubtitleEdit) + "</footer>");
-        sb.AppendLine("</main>");
-        sb.AppendLine("</body>");
-        sb.AppendLine("</html>");
-        return sb.ToString();
-    }
-
-    /// <summary>
-    /// One radio per error class in front of the table: checking it hides the rows of the other
-    /// classes through the sibling selectors in <see cref="Css"/>. Classes with no rows are left out.
-    /// </summary>
-    private static void AppendChips(StringBuilder sb, IReadOnlyList<ErrorListItem> items, string allLabel)
-    {
-        sb.AppendLine("<input type=\"radio\" name=\"f\" id=\"f-all\" checked>");
-        foreach (var type in Enum.GetValues<LineErrorType>())
-        {
-            if (items.Any(p => p.Type == type))
+            Title = l.Title,
+            Summary = summary,
+            FileName = subtitleFileName,
+            CategoryHeader = Se.Language.General.Error,
+            DetailHeader = l.Detail,
+            AllLabel = l.All,
+            AllColor = LineError.AllColor,
+            Chips = Enum.GetValues<LineErrorType>().Select(type => new ReportExportChip
             {
-                sb.AppendLine("<input type=\"radio\" name=\"f\" id=\"f-" + (int)type + "\">");
-            }
-        }
-
-        sb.AppendLine("<nav class=\"chips\">");
-        sb.AppendLine("  <label class=\"chip\" for=\"f-all\"><i style=\"background:" + LineError.AllColor + "\"></i>" +
-                      Encode(allLabel) + "<b>" + items.Count + "</b></label>");
-        foreach (var type in Enum.GetValues<LineErrorType>())
-        {
-            var count = items.Count(p => p.Type == type);
-            if (count == 0)
+                Id = ((int)type).ToString(),
+                Label = LineError.GetLabel(type),
+                Hint = LineError.GetHint(type),
+                Color = LineError.GetColor(type),
+                Count = list.Count(p => p.Type == type),
+            }).ToList(),
+            Rows = list.Select(item => new ReportExportRow
             {
-                continue;
-            }
-
-            sb.AppendLine("  <label class=\"chip\" for=\"f-" + (int)type + "\" title=\"" + Encode(LineError.GetHint(type)) + "\">" +
-                          "<i style=\"background:" + LineError.GetColor(type) + "\"></i>" +
-                          Encode(LineError.GetLabel(type)) + "<b>" + count + "</b></label>");
-        }
-
-        sb.AppendLine("</nav>");
-    }
-
-    private static void AppendTable(StringBuilder sb, IReadOnlyList<ErrorListItem> items)
-    {
-        var l = Se.Language.ErrorList;
-        sb.AppendLine("<div class=\"table-wrap\">");
-        sb.AppendLine("<table>");
-        sb.AppendLine("  <thead><tr>" +
-                      "<th class=\"num\">" + Encode(Se.Language.General.NumberSymbol) + "</th>" +
-                      "<th>" + Encode(Se.Language.General.Error) + "</th>" +
-                      "<th>" + Encode(Se.Language.General.Show) + "</th>" +
-                      "<th>" + Encode(Se.Language.General.Hide) + "</th>" +
-                      "<th>" + Encode(l.Detail) + "</th>" +
-                      "<th>" + Encode(Se.Language.General.Text) + "</th>" +
-                      "</tr></thead>");
-        sb.AppendLine("  <tbody>");
-        foreach (var item in items)
-        {
-            sb.AppendLine("    <tr class=\"t" + (int)item.Type + "\" style=\"--dot:" + LineError.GetColor(item.Type) + "\">" +
-                          "<td class=\"num\">" + item.Number + "</td>" +
-                          "<td><span class=\"pill\"><i></i>" + Encode(item.Category) + "</span></td>" +
-                          "<td class=\"time\">" + Encode(item.Show) + "</td>" +
-                          "<td class=\"time\">" + Encode(item.Hide) + "</td>" +
-                          "<td class=\"detail\">" + Encode(item.Detail) + "</td>" +
-                          "<td class=\"text\">" + Encode(item.Text) + "</td>" +
-                          "</tr>");
-        }
-
-        sb.AppendLine("  </tbody>");
-        sb.AppendLine("</table>");
-        sb.AppendLine("</div>");
-    }
-
-    private static IReadOnlyList<string> Headers()
-    {
-        return new[]
-        {
-            Se.Language.General.NumberSymbol,
-            Se.Language.General.Error,
-            Se.Language.General.Show,
-            Se.Language.General.Hide,
-            Se.Language.ErrorList.Detail,
-            Se.Language.General.Text,
+                Number = item.Number,
+                Category = item.Category,
+                Show = item.Show,
+                Hide = item.Hide,
+                Detail = item.Detail,
+                Text = item.Text,
+                ChipId = ((int)item.Type).ToString(),
+                Color = LineError.GetColor(item.Type),
+            }).ToList(),
         };
     }
-
-    private static IEnumerable<string> Cells(ErrorListItem item)
-    {
-        yield return item.Number.ToString(CultureInfo.CurrentCulture);
-        yield return item.Category;
-        yield return item.Show;
-        yield return item.Hide;
-        yield return item.Detail;
-        yield return item.Text;
-    }
-
-    /// <summary>A tab or a newline inside a cell would start a new column/row where it is pasted.</summary>
-    private static string CleanForTabSeparated(string s)
-    {
-        return s.Replace('\t', ' ').Replace("\r\n", " ").Replace('\n', ' ').Replace('\r', ' ');
-    }
-
-    private static string Now()
-    {
-        return DateTime.Now.ToString("yyyy-MM-dd HH:mm", CultureInfo.CurrentCulture);
-    }
-
-    private static string Encode(string? text)
-    {
-        if (string.IsNullOrEmpty(text))
-        {
-            return string.Empty;
-        }
-
-        return text
-            .Replace("&", "&amp;")
-            .Replace("<", "&lt;")
-            .Replace(">", "&gt;")
-            .Replace("\"", "&quot;");
-    }
-
-    /// <summary>
-    /// Light by default, dark through <c>prefers-color-scheme</c>: every colour is a token on
-    /// <c>:root</c> and only the tokens are redefined, so nothing can end up defined in the dark
-    /// block alone.
-    /// </summary>
-    private const string Css = @"
-:root {
-  color-scheme: light dark;
-  --bg: #f6f7f9;
-  --panel: #ffffff;
-  --panel-2: #fbfbfc;
-  --ink: #16191d;
-  --ink-dim: #5b6470;
-  --line: #e3e6ea;
-  --line-soft: #eef0f3;
-  --accent: #5d8aa8;
-  --shadow: 0 1px 2px rgba(16, 24, 40, .06), 0 8px 24px rgba(16, 24, 40, .06);
-  --radius: 12px;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --bg: #14171b;
-    --panel: #1b1f24;
-    --panel-2: #20252b;
-    --ink: #e8ebef;
-    --ink-dim: #9aa4b1;
-    --line: #2b3138;
-    --line-soft: #23282f;
-    --accent: #7fb0cd;
-    --shadow: 0 1px 2px rgba(0, 0, 0, .4), 0 8px 24px rgba(0, 0, 0, .35);
-  }
-}
-
-* { box-sizing: border-box; }
-
-body {
-  margin: 0;
-  padding: 32px 20px 56px;
-  background: var(--bg);
-  color: var(--ink);
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Noto Sans', Ubuntu, Cantarell, sans-serif;
-  font-size: 14px;
-  line-height: 1.5;
-  -webkit-text-size-adjust: 100%;
-}
-
-main { max-width: 1180px; margin: 0 auto; }
-
-h1 { margin: 0; font-size: 26px; font-weight: 650; letter-spacing: -.01em; }
-
-.summary { margin: 6px 0 0; font-size: 15px; color: var(--ink-dim); }
-
-.meta { margin: 10px 0 0; display: flex; flex-wrap: wrap; gap: 6px 18px; font-size: 12.5px; color: var(--ink-dim); }
-.meta span { overflow-wrap: anywhere; }
-
-.chips { display: flex; flex-wrap: wrap; gap: 8px; margin: 22px 0 14px; }
-
-.chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 7px 12px;
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  background: var(--panel);
-  color: var(--ink);
-  font-size: 13px;
-  cursor: pointer;
-  user-select: none;
-  transition: border-color .12s ease, transform .12s ease;
-}
-.chip:hover { border-color: var(--accent); transform: translateY(-1px); }
-.chip i { width: 9px; height: 9px; border-radius: 50%; flex: none; }
-.chip b { font-weight: 600; color: var(--ink-dim); font-variant-numeric: tabular-nums; }
-
-.table-wrap {
-  background: var(--panel);
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow);
-  overflow: auto;
-  max-height: 74vh;
-}
-
-table { border-collapse: collapse; width: 100%; font-size: 13.5px; }
-
-thead th {
-  position: sticky;
-  top: 0;
-  z-index: 1;
-  text-align: left;
-  font-weight: 600;
-  font-size: 12px;
-  letter-spacing: .04em;
-  text-transform: uppercase;
-  color: var(--ink-dim);
-  background: var(--panel-2);
-  border-bottom: 1px solid var(--line);
-  padding: 11px 14px;
-  white-space: nowrap;
-}
-
-tbody td { padding: 10px 14px; border-bottom: 1px solid var(--line-soft); vertical-align: top; }
-tbody tr:last-child td { border-bottom: 0; }
-tbody tr:hover td { background: var(--panel-2); }
-
-td.num { width: 1%; text-align: right; color: var(--ink-dim); font-variant-numeric: tabular-nums; white-space: nowrap; }
-td.time, td.detail { white-space: nowrap; font-variant-numeric: tabular-nums; }
-td.time { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 12.5px; }
-td.detail { color: var(--ink-dim); }
-td.text { min-width: 22em; overflow-wrap: anywhere; }
-
-.pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  padding: 3px 10px 3px 8px;
-  border-radius: 999px;
-  border: 1px solid var(--line);
-  background: transparent; /* fallback where color-mix is unknown */
-  background: color-mix(in srgb, var(--dot) 12%, transparent);
-  white-space: nowrap;
-}
-.pill i { width: 8px; height: 8px; border-radius: 50%; background: var(--dot); flex: none; }
-
-footer { margin-top: 18px; font-size: 12px; color: var(--ink-dim); text-align: right; }
-
-/* Chip filtering, without script: the checked radio decides which rows stay visible. */
-input[name='f'] { display: none; }
-
-#f-all:checked ~ .chips [for='f-all'],
-#f-0:checked ~ .chips [for='f-0'],
-#f-1:checked ~ .chips [for='f-1'],
-#f-2:checked ~ .chips [for='f-2'],
-#f-3:checked ~ .chips [for='f-3'],
-#f-4:checked ~ .chips [for='f-4'],
-#f-5:checked ~ .chips [for='f-5'],
-#f-6:checked ~ .chips [for='f-6'],
-#f-7:checked ~ .chips [for='f-7'] {
-  border-color: var(--accent);
-  background: var(--panel-2);
-  background: color-mix(in srgb, var(--accent) 16%, var(--panel));
-  box-shadow: inset 0 0 0 1px var(--accent);
-}
-
-#f-0:checked ~ .table-wrap tbody tr:not(.t0),
-#f-1:checked ~ .table-wrap tbody tr:not(.t1),
-#f-2:checked ~ .table-wrap tbody tr:not(.t2),
-#f-3:checked ~ .table-wrap tbody tr:not(.t3),
-#f-4:checked ~ .table-wrap tbody tr:not(.t4),
-#f-5:checked ~ .table-wrap tbody tr:not(.t5),
-#f-6:checked ~ .table-wrap tbody tr:not(.t6),
-#f-7:checked ~ .table-wrap tbody tr:not(.t7) { display: none; }
-
-@media print {
-  body { background: #fff; padding: 0; }
-  .chips { display: none; }
-  .table-wrap { max-height: none; box-shadow: none; border: 0; }
-  thead th { position: static; }
-}
-";
 }

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextQualityReportViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextQualityReportViewModel.cs
@@ -4,11 +4,17 @@ using Avalonia.Media;
 using Avalonia.Media.Immutable;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Features.Shared.PromptFileSaved;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Video.SpeechToText;
 
@@ -34,6 +40,8 @@ public partial class SpeechToTextQualityReportViewModel : ObservableObject
     [ObservableProperty] private bool _hasIssues;
     [ObservableProperty] private ObservableCollection<QualityReportDisplayItem> _items = new();
     [ObservableProperty] private QualityReportDisplayItem? _selectedItem;
+    [ObservableProperty] private bool _canExport;
+    [ObservableProperty] private string _exportStatus = string.Empty;
 
     public ObservableCollection<SummaryCard> Cards { get; } = new();
 
@@ -47,14 +55,45 @@ public partial class SpeechToTextQualityReportViewModel : ObservableObject
     public Window? Window { get; set; }
 
     private readonly List<QualityReportDisplayItem> _allItems = new();
+    private readonly IFileHelper _fileHelper;
+    private readonly IWindowService _windowService;
+    private string? _fileName;
 
-    public static readonly IBrush TooShortBrush = new ImmutableSolidColorBrush(Color.Parse("#E8912D"));
-    public static readonly IBrush TooLongBrush = new ImmutableSolidColorBrush(Color.Parse("#9B59B6"));
-    public static readonly IBrush OverlapBrush = new ImmutableSolidColorBrush(Color.Parse("#E74C3C"));
-    public static readonly IBrush NonSpeechBrush = new ImmutableSolidColorBrush(Color.Parse("#3498DB"));
-    public static readonly IBrush RepeatedBrush = new ImmutableSolidColorBrush(Color.Parse("#1ABC9C"));
-    public static readonly IBrush RemovedBrush = new ImmutableSolidColorBrush(Color.Parse("#7F8C8D"));
-    public static readonly IBrush AllBrush = new ImmutableSolidColorBrush(Color.Parse("#5D8AA8"));
+    private const string TooShortColor = "#E8912D";
+    private const string TooLongColor = "#9B59B6";
+    private const string OverlapColor = "#E74C3C";
+    private const string NonSpeechColor = "#3498DB";
+    private const string RepeatedColor = "#1ABC9C";
+    private const string RemovedColor = "#7F8C8D";
+    private const string AllColor = "#5D8AA8";
+
+    public static readonly IBrush TooShortBrush = new ImmutableSolidColorBrush(Color.Parse(TooShortColor));
+    public static readonly IBrush TooLongBrush = new ImmutableSolidColorBrush(Color.Parse(TooLongColor));
+    public static readonly IBrush OverlapBrush = new ImmutableSolidColorBrush(Color.Parse(OverlapColor));
+    public static readonly IBrush NonSpeechBrush = new ImmutableSolidColorBrush(Color.Parse(NonSpeechColor));
+    public static readonly IBrush RepeatedBrush = new ImmutableSolidColorBrush(Color.Parse(RepeatedColor));
+    public static readonly IBrush RemovedBrush = new ImmutableSolidColorBrush(Color.Parse(RemovedColor));
+    public static readonly IBrush AllBrush = new ImmutableSolidColorBrush(Color.Parse(AllColor));
+
+    public SpeechToTextQualityReportViewModel(IFileHelper fileHelper, IWindowService windowService)
+    {
+        _fileHelper = fileHelper;
+        _windowService = windowService;
+    }
+
+    /// <summary>The dot colour as "#RRGGBB" - the html export paints the same palette as the window.</summary>
+    private static string GetColor(SpeechToTextQualityIssueType type)
+    {
+        return type switch
+        {
+            SpeechToTextQualityIssueType.TooShort => TooShortColor,
+            SpeechToTextQualityIssueType.TooLong => TooLongColor,
+            SpeechToTextQualityIssueType.Overlap => OverlapColor,
+            SpeechToTextQualityIssueType.NonSpeech => NonSpeechColor,
+            SpeechToTextQualityIssueType.Repeated => RepeatedColor,
+            _ => AllColor,
+        };
+    }
 
     public static IBrush GetBrush(SpeechToTextQualityIssueType type)
     {
@@ -97,9 +136,11 @@ public partial class SpeechToTextQualityReportViewModel : ObservableObject
         };
     }
 
-    public void Initialize(SpeechToTextQualityReport report)
+    /// <param name="fileName">The video/audio that was transcribed - named in the exports.</param>
+    public void Initialize(SpeechToTextQualityReport report, string? fileName = null)
     {
         var l = Se.Language.Video.AudioToText;
+        _fileName = fileName;
         TotalLines = report.TotalLines;
         IssueCount = report.Issues.Count;
         RemovedCount = report.Removed.Count;
@@ -193,6 +234,138 @@ public partial class SpeechToTextQualityReportViewModel : ObservableObject
 
         Items = new ObservableCollection<QualityReportDisplayItem>(filtered);
         SelectedItem = Items.FirstOrDefault();
+        CanExport = Items.Count > 0;
+    }
+
+    /// <summary>
+    /// Puts what the window shows - the active card filter included - on the clipboard, tab
+    /// separated, so it pastes as columns into Excel/Sheets and as a readable block anywhere else.
+    /// </summary>
+    [RelayCommand]
+    private async Task CopyToClipboard()
+    {
+        if (Window == null || Items.Count == 0)
+        {
+            return;
+        }
+
+        await ClipboardHelper.SetTextAsync(Window, ReportExport.ToTabSeparated(MakeExportData()));
+
+        // Not awaited: the command would stay "running" - and its menu item disabled - for as
+        // long as the status is shown.
+        _ = ShowExportStatus(Se.Language.General.CopiedToClipboard);
+    }
+
+    [RelayCommand]
+    private Task ExportText()
+    {
+        return ExportToFile(".txt", () => Encoding.UTF8.GetBytes(ReportExport.ToPlainText(MakeExportData())));
+    }
+
+    [RelayCommand]
+    private Task ExportExcel()
+    {
+        return ExportToFile(".xlsx", () => ReportExport.ToXlsx(MakeExportData()));
+    }
+
+    [RelayCommand]
+    private Task ExportHtml()
+    {
+        return ExportToFile(".html", () => Encoding.UTF8.GetBytes(ReportExport.ToHtml(MakeExportData())));
+    }
+
+    private async Task ExportToFile(string extension, Func<byte[]> makeContent)
+    {
+        if (Window == null || Items.Count == 0)
+        {
+            return;
+        }
+
+        var fileName = await _fileHelper.PickSaveFile(Window, extension, GetSuggestedFileName() + extension, Se.Language.General.Export);
+        if (string.IsNullOrEmpty(fileName))
+        {
+            return;
+        }
+
+        await File.WriteAllBytesAsync(fileName, makeContent());
+
+        _ = await _windowService.ShowDialogAsync<PromptFileSavedWindow, PromptFileSavedViewModel>(Window, vm =>
+        {
+            vm.Initialize(Se.Language.General.FileSaved, string.Format(Se.Language.General.FileSavedToX, fileName), fileName, true, true);
+        });
+    }
+
+    private string GetSuggestedFileName()
+    {
+        var name = string.IsNullOrEmpty(_fileName)
+            ? string.Empty
+            : Path.GetFileNameWithoutExtension(_fileName);
+
+        return string.IsNullOrWhiteSpace(name) ? "transcription-report" : name + "-transcription-report";
+    }
+
+    /// <summary>Clipboard copies are silent otherwise - the status line says it happened, then fades.</summary>
+    private async Task ShowExportStatus(string text)
+    {
+        ExportStatus = text;
+        await Task.Delay(3000);
+        if (ExportStatus == text)
+        {
+            ExportStatus = string.Empty;
+        }
+    }
+
+    /// <summary>The rows as shown - filter included - plus one chip per card, in the window's colours.</summary>
+    private ReportExportData MakeExportData()
+    {
+        var l = Se.Language.Video.AudioToText;
+        var rows = Items.ToList();
+        var chips = new List<ReportExportChip>();
+        foreach (var card in Cards.Skip(1))
+        {
+            var id = ChipId(card.Key);
+            chips.Add(new ReportExportChip
+            {
+                Id = id,
+                Label = card.Label,
+                Hint = card.Hint,
+                Color = ReferenceEquals(card.Key, RemovedKey) ? RemovedColor : GetColor((SpeechToTextQualityIssueType)card.Key!),
+                Count = rows.Count(p => ChipId(p) == id),
+            });
+        }
+
+        return new ReportExportData
+        {
+            Title = l.QualityReportTitle,
+            Summary = Summary,
+            FileName = _fileName,
+            CategoryHeader = l.QualityReportIssue,
+            DetailHeader = l.QualityReportDetail,
+            AllLabel = l.QualityReportAll,
+            AllColor = AllColor,
+            Chips = chips,
+            Rows = rows.Select(item => new ReportExportRow
+            {
+                Number = item.Number,
+                Category = item.Category,
+                Show = item.Start,
+                Hide = item.End,
+                Detail = item.Detail,
+                Text = item.Text,
+                ChipId = ChipId(item),
+                Color = item.IsRemoved ? RemovedColor : GetColor(item.Type ?? SpeechToTextQualityIssueType.TooShort),
+            }).ToList(),
+        };
+    }
+
+    private static string ChipId(object? cardKey)
+    {
+        return ReferenceEquals(cardKey, RemovedKey) ? "removed" : ((int)(SpeechToTextQualityIssueType)cardKey!).ToString();
+    }
+
+    private static string ChipId(QualityReportDisplayItem item)
+    {
+        return item.IsRemoved ? "removed" : ((int)(item.Type ?? SpeechToTextQualityIssueType.TooShort)).ToString();
     }
 
     [RelayCommand]

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextQualityReportWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextQualityReportWindow.cs
@@ -150,6 +150,7 @@ public class SpeechToTextQualityReportWindow : Window
         var checkDoNotShowAgain = UiUtil.MakeCheckBox(l.QualityReportDoNotShowAgain, vm, nameof(vm.DoNotShowAgain));
         checkDoNotShowAgain.VerticalAlignment = VerticalAlignment.Center;
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonExport = MakeExportButton(vm);
         var footer = new Grid
         {
             ColumnDefinitions =
@@ -159,7 +160,7 @@ public class SpeechToTextQualityReportWindow : Window
             },
         };
         footer.Add(checkDoNotShowAgain, 0, 0);
-        footer.Add(UiUtil.MakeButtonBar(buttonOk), 0, 1);
+        footer.Add(UiUtil.MakeButtonBar(MakeExportStatusLabel(vm), buttonExport, buttonOk), 0, 1);
 
         var grid = new Grid
         {
@@ -186,6 +187,56 @@ public class SpeechToTextQualityReportWindow : Window
         Content = grid;
 
         UiUtil.FocusOnFirstActivation(this, buttonOk); // hack to make OnKeyDown work
+    }
+
+    /// <summary>
+    /// The same "Export..." as in List errors (discussion #12929 asked for the report as a text
+    /// file). Every target exports the rows as shown, so an active card filter applies.
+    /// </summary>
+    private static Button MakeExportButton(SpeechToTextQualityReportViewModel vm)
+    {
+        var l = Se.Language.ErrorList;
+        var button = UiUtil.MakeButton(Se.Language.General.ExportDotDotDot);
+        button.Flyout = new MenuFlyout
+        {
+            Items =
+            {
+                new MenuItem
+                {
+                    Header = Se.Language.General.CopyToClipboard,
+                    Command = vm.CopyToClipboardCommand,
+                },
+                new MenuItem
+                {
+                    Header = l.ExportAsText,
+                    Command = vm.ExportTextCommand,
+                },
+                new MenuItem
+                {
+                    Header = l.ExportAsExcel,
+                    Command = vm.ExportExcelCommand,
+                },
+                new MenuItem
+                {
+                    Header = l.ExportAsHtml,
+                    Command = vm.ExportHtmlCommand,
+                },
+            },
+        };
+
+        return button.WithBindIsEnabled(nameof(vm.CanExport));
+    }
+
+    /// <summary>Says "Copied to clipboard" next to the buttons - a clipboard copy has nothing else to show.</summary>
+    private static TextBlock MakeExportStatusLabel(SpeechToTextQualityReportViewModel vm)
+    {
+        return new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 0, 10, 0),
+            Opacity = 0.75,
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.ExportStatus)),
+        };
     }
 
     protected override void OnKeyDown(KeyEventArgs e)

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -2644,7 +2644,7 @@ public partial class SpeechToTextViewModel : ObservableObject
         }
 
         var vm = await _windowService.ShowDialogAsync<SpeechToTextQualityReportWindow, SpeechToTextQualityReportViewModel>(
-            Window, viewModel => viewModel.Initialize(report));
+            Window, viewModel => viewModel.Initialize(report, _videoFileName));
 
         if (vm.DoNotShowAgain)
         {

--- a/src/ui/Logic/ReportExport.cs
+++ b/src/ui/Logic/ReportExport.cs
@@ -1,0 +1,447 @@
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>One filter chip in the html export - mirrors a <see cref="SummaryCard"/> in the window.</summary>
+public sealed class ReportExportChip
+{
+    /// <summary>Stable id shared with the rows that belong to it; letters, digits and '-' only.</summary>
+    public required string Id { get; init; }
+    public required string Label { get; init; }
+    public string Hint { get; init; } = string.Empty;
+
+    /// <summary>"#RRGGBB" - the dot colour the window paints for this class.</summary>
+    public required string Color { get; init; }
+    public int Count { get; init; }
+}
+
+/// <summary>One row of a report: a line number, a class, the two time codes, a detail and the text.</summary>
+public sealed class ReportExportRow
+{
+    public int Number { get; init; }
+    public string Category { get; init; } = string.Empty;
+    public string Show { get; init; } = string.Empty;
+    public string Hide { get; init; } = string.Empty;
+    public string Detail { get; init; } = string.Empty;
+    public string Text { get; init; } = string.Empty;
+
+    /// <summary>The <see cref="ReportExportChip.Id"/> of the class the row belongs to.</summary>
+    public string ChipId { get; init; } = string.Empty;
+
+    /// <summary>"#RRGGBB" for the pill in the html export.</summary>
+    public string Color { get; init; } = string.Empty;
+}
+
+/// <summary>Everything a report window has to hand over to be exported - see <see cref="ReportExport"/>.</summary>
+public sealed class ReportExportData
+{
+    public required string Title { get; init; }
+    public string Summary { get; init; } = string.Empty;
+
+    /// <summary>The subtitle or video the report is about; shown in the header when set.</summary>
+    public string? FileName { get; init; }
+
+    /// <summary>Header of the class column - "Error" in List errors, "Issue" in the transcription report.</summary>
+    public required string CategoryHeader { get; init; }
+    public required string DetailHeader { get; init; }
+    public required string AllLabel { get; init; }
+    public required string AllColor { get; init; }
+
+    /// <summary>Filter chips in display order; chips with a count of zero are left out of the html.</summary>
+    public IReadOnlyList<ReportExportChip> Chips { get; init; } = Array.Empty<ReportExportChip>();
+    public IReadOnlyList<ReportExportRow> Rows { get; init; } = Array.Empty<ReportExportRow>();
+}
+
+/// <summary>
+/// Turns the rows of a report window - "List errors", the transcription quality report - into
+/// something that can leave the window: the clipboard, a plain text log, an Excel workbook, or
+/// a stand-alone html page (#14379 - the list had to be screenshotted to be shared or handed
+/// to an AI; discussion #12929 asked for the same in the transcription report).
+/// <para>
+/// Every writer takes the rows exactly as the window shows them, so an active summary-card
+/// filter is part of what is exported.
+/// </para>
+/// </summary>
+public static class ReportExport
+{
+    /// <summary>Tab separated with a header row - what the clipboard gets, and what Excel/Sheets paste as columns.</summary>
+    public static string ToTabSeparated(ReportExportData data)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine(string.Join("\t", Headers(data)));
+        foreach (var row in data.Rows)
+        {
+            sb.AppendLine(string.Join("\t", Cells(row).Select(CleanForTabSeparated)));
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// A readable log: a short header, then two lines per row - the time code and the class on
+    /// the first, the subtitle text on the second. Meant to be pasted into a mail, an issue, or
+    /// a prompt.
+    /// </summary>
+    public static string ToPlainText(ReportExportData data)
+    {
+        var l = Se.Language.ErrorList;
+        var sb = new StringBuilder();
+        sb.AppendLine(data.Title);
+        if (!string.IsNullOrEmpty(data.FileName))
+        {
+            sb.AppendLine(string.Format(l.ExportFileX, data.FileName));
+        }
+
+        sb.AppendLine(string.Format(l.ExportGeneratedX, Now()));
+        sb.AppendLine(data.Summary);
+        sb.AppendLine();
+
+        foreach (var row in data.Rows)
+        {
+            var detail = string.IsNullOrEmpty(row.Detail) ? string.Empty : ": " + row.Detail;
+            sb.AppendLine($"#{row.Number}  {row.Show} --> {row.Hide}  {row.Category}{detail}");
+            sb.AppendLine("    " + row.Text);
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>The same rows as an .xlsx workbook - see <see cref="XlsxWriter"/> for why not csv.</summary>
+    public static byte[] ToXlsx(ReportExportData data)
+    {
+        var rows = data.Rows.Select(row => (IReadOnlyList<object?>)new object?[]
+        {
+            row.Number,
+            row.Category,
+            row.Show,
+            row.Hide,
+            row.Detail,
+            row.Text,
+        });
+
+        return XlsxWriter.Create(data.Title, Headers(data), rows, new double[] { 6, 20, 14, 14, 26, 80 });
+    }
+
+    /// <summary>
+    /// A stand-alone page - no scripts, no web fonts, nothing to load - that follows the
+    /// reader's light/dark preference and paints the classes in the same colours as the
+    /// window. The summary cards become filter chips backed by <c>:checked</c> radios, so the
+    /// page filters without a line of JavaScript.
+    /// </summary>
+    public static string ToHtml(ReportExportData data)
+    {
+        var l = Se.Language.ErrorList;
+        var chips = data.Chips.Where(p => p.Count > 0).ToList();
+        var title = string.IsNullOrEmpty(data.FileName)
+            ? data.Title
+            : data.Title + " - " + Path.GetFileName(data.FileName);
+
+        var sb = new StringBuilder();
+        sb.AppendLine("<!DOCTYPE html>");
+        sb.AppendLine("<html lang=\"en\">");
+        sb.AppendLine("<head>");
+        sb.AppendLine("<meta charset=\"utf-8\">");
+        sb.AppendLine("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">");
+        sb.AppendLine("<meta name=\"color-scheme\" content=\"light dark\">");
+        sb.AppendLine("<title>" + Encode(title) + "</title>");
+        sb.AppendLine("<style>");
+        sb.AppendLine(Css);
+        sb.AppendLine(MakeFilterCss(chips));
+        sb.AppendLine("</style>");
+        sb.AppendLine("</head>");
+        sb.AppendLine("<body>");
+        sb.AppendLine("<main>");
+
+        sb.AppendLine("<header>");
+        sb.AppendLine("  <h1>" + Encode(data.Title) + "</h1>");
+        sb.AppendLine("  <p class=\"summary\">" + Encode(data.Summary) + "</p>");
+        sb.AppendLine("  <p class=\"meta\">");
+        if (!string.IsNullOrEmpty(data.FileName))
+        {
+            sb.AppendLine("    <span>" + Encode(string.Format(l.ExportFileX, data.FileName)) + "</span>");
+        }
+
+        sb.AppendLine("    <span>" + Encode(string.Format(l.ExportGeneratedX, Now())) + "</span>");
+        sb.AppendLine("  </p>");
+        sb.AppendLine("</header>");
+
+        AppendChips(sb, data, chips);
+        AppendTable(sb, data);
+
+        sb.AppendLine("<footer>" + Encode(l.ExportMadeWithSubtitleEdit) + "</footer>");
+        sb.AppendLine("</main>");
+        sb.AppendLine("</body>");
+        sb.AppendLine("</html>");
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// One radio per class in front of the table: checking it hides the rows of the other
+    /// classes through the sibling selectors from <see cref="MakeFilterCss"/>.
+    /// </summary>
+    private static void AppendChips(StringBuilder sb, ReportExportData data, IReadOnlyList<ReportExportChip> chips)
+    {
+        sb.AppendLine("<input type=\"radio\" name=\"f\" id=\"f-all\" checked>");
+        foreach (var chip in chips)
+        {
+            sb.AppendLine("<input type=\"radio\" name=\"f\" id=\"f-" + chip.Id + "\">");
+        }
+
+        sb.AppendLine("<nav class=\"chips\">");
+        sb.AppendLine("  <label class=\"chip\" for=\"f-all\"><i style=\"background:" + data.AllColor + "\"></i>" +
+                      Encode(data.AllLabel) + "<b>" + data.Rows.Count + "</b></label>");
+        foreach (var chip in chips)
+        {
+            sb.AppendLine("  <label class=\"chip\" for=\"f-" + chip.Id + "\" title=\"" + Encode(chip.Hint) + "\">" +
+                          "<i style=\"background:" + chip.Color + "\"></i>" +
+                          Encode(chip.Label) + "<b>" + chip.Count + "</b></label>");
+        }
+
+        sb.AppendLine("</nav>");
+    }
+
+    private static void AppendTable(StringBuilder sb, ReportExportData data)
+    {
+        sb.AppendLine("<div class=\"table-wrap\">");
+        sb.AppendLine("<table>");
+        sb.AppendLine("  <thead><tr>" +
+                      "<th class=\"num\">" + Encode(Se.Language.General.NumberSymbol) + "</th>" +
+                      "<th>" + Encode(data.CategoryHeader) + "</th>" +
+                      "<th>" + Encode(Se.Language.General.Show) + "</th>" +
+                      "<th>" + Encode(Se.Language.General.Hide) + "</th>" +
+                      "<th>" + Encode(data.DetailHeader) + "</th>" +
+                      "<th>" + Encode(Se.Language.General.Text) + "</th>" +
+                      "</tr></thead>");
+        sb.AppendLine("  <tbody>");
+        foreach (var row in data.Rows)
+        {
+            sb.AppendLine("    <tr class=\"t-" + row.ChipId + "\" style=\"--dot:" + row.Color + "\">" +
+                          "<td class=\"num\">" + row.Number + "</td>" +
+                          "<td><span class=\"pill\"><i></i>" + Encode(row.Category) + "</span></td>" +
+                          "<td class=\"time\">" + Encode(row.Show) + "</td>" +
+                          "<td class=\"time\">" + Encode(row.Hide) + "</td>" +
+                          "<td class=\"detail\">" + Encode(row.Detail) + "</td>" +
+                          "<td class=\"text\">" + Encode(row.Text) + "</td>" +
+                          "</tr>");
+        }
+
+        sb.AppendLine("  </tbody>");
+        sb.AppendLine("</table>");
+        sb.AppendLine("</div>");
+    }
+
+    /// <summary>The chip-highlight and row-hiding selectors, one pair per chip that made it into the page.</summary>
+    private static string MakeFilterCss(IReadOnlyList<ReportExportChip> chips)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("/* Chip filtering, without script: the checked radio decides which rows stay visible. */");
+        sb.AppendLine("input[name='f'] { display: none; }");
+
+        var active = new List<string> { "#f-all:checked ~ .chips [for='f-all']" };
+        active.AddRange(chips.Select(c => "#f-" + c.Id + ":checked ~ .chips [for='f-" + c.Id + "']"));
+        sb.AppendLine(string.Join(",\n", active) + " {");
+        sb.AppendLine("  border-color: var(--accent);");
+        sb.AppendLine("  background: var(--panel-2);");
+        sb.AppendLine("  background: color-mix(in srgb, var(--accent) 16%, var(--panel));");
+        sb.AppendLine("  box-shadow: inset 0 0 0 1px var(--accent);");
+        sb.AppendLine("}");
+
+        if (chips.Count > 0)
+        {
+            var hide = chips.Select(c => "#f-" + c.Id + ":checked ~ .table-wrap tbody tr:not(.t-" + c.Id + ")");
+            sb.AppendLine(string.Join(",\n", hide) + " { display: none; }");
+        }
+
+        return sb.ToString();
+    }
+
+    private static IReadOnlyList<string> Headers(ReportExportData data)
+    {
+        return new[]
+        {
+            Se.Language.General.NumberSymbol,
+            data.CategoryHeader,
+            Se.Language.General.Show,
+            Se.Language.General.Hide,
+            data.DetailHeader,
+            Se.Language.General.Text,
+        };
+    }
+
+    private static IEnumerable<string> Cells(ReportExportRow row)
+    {
+        yield return row.Number.ToString(CultureInfo.CurrentCulture);
+        yield return row.Category;
+        yield return row.Show;
+        yield return row.Hide;
+        yield return row.Detail;
+        yield return row.Text;
+    }
+
+    /// <summary>A tab or a newline inside a cell would start a new column/row where it is pasted.</summary>
+    private static string CleanForTabSeparated(string s)
+    {
+        return s.Replace('\t', ' ').Replace("\r\n", " ").Replace('\n', ' ').Replace('\r', ' ');
+    }
+
+    private static string Now()
+    {
+        return DateTime.Now.ToString("yyyy-MM-dd HH:mm", CultureInfo.CurrentCulture);
+    }
+
+    private static string Encode(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return string.Empty;
+        }
+
+        return text
+            .Replace("&", "&amp;")
+            .Replace("<", "&lt;")
+            .Replace(">", "&gt;")
+            .Replace("\"", "&quot;");
+    }
+
+    /// <summary>
+    /// Light by default, dark through <c>prefers-color-scheme</c>: every colour is a token on
+    /// <c>:root</c> and only the tokens are redefined, so nothing can end up defined in the dark
+    /// block alone.
+    /// </summary>
+    private const string Css = @"
+:root {
+  color-scheme: light dark;
+  --bg: #f6f7f9;
+  --panel: #ffffff;
+  --panel-2: #fbfbfc;
+  --ink: #16191d;
+  --ink-dim: #5b6470;
+  --line: #e3e6ea;
+  --line-soft: #eef0f3;
+  --accent: #5d8aa8;
+  --shadow: 0 1px 2px rgba(16, 24, 40, .06), 0 8px 24px rgba(16, 24, 40, .06);
+  --radius: 12px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #14171b;
+    --panel: #1b1f24;
+    --panel-2: #20252b;
+    --ink: #e8ebef;
+    --ink-dim: #9aa4b1;
+    --line: #2b3138;
+    --line-soft: #23282f;
+    --accent: #7fb0cd;
+    --shadow: 0 1px 2px rgba(0, 0, 0, .4), 0 8px 24px rgba(0, 0, 0, .35);
+  }
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  padding: 32px 20px 56px;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Noto Sans', Ubuntu, Cantarell, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-text-size-adjust: 100%;
+}
+
+main { max-width: 1180px; margin: 0 auto; }
+
+h1 { margin: 0; font-size: 26px; font-weight: 650; letter-spacing: -.01em; }
+
+.summary { margin: 6px 0 0; font-size: 15px; color: var(--ink-dim); }
+
+.meta { margin: 10px 0 0; display: flex; flex-wrap: wrap; gap: 6px 18px; font-size: 12.5px; color: var(--ink-dim); }
+.meta span { overflow-wrap: anywhere; }
+
+.chips { display: flex; flex-wrap: wrap; gap: 8px; margin: 22px 0 14px; }
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 12px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--panel);
+  color: var(--ink);
+  font-size: 13px;
+  cursor: pointer;
+  user-select: none;
+  transition: border-color .12s ease, transform .12s ease;
+}
+.chip:hover { border-color: var(--accent); transform: translateY(-1px); }
+.chip i { width: 9px; height: 9px; border-radius: 50%; flex: none; }
+.chip b { font-weight: 600; color: var(--ink-dim); font-variant-numeric: tabular-nums; }
+
+.table-wrap {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  overflow: auto;
+  max-height: 74vh;
+}
+
+table { border-collapse: collapse; width: 100%; font-size: 13.5px; }
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  text-align: left;
+  font-weight: 600;
+  font-size: 12px;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+  background: var(--panel-2);
+  border-bottom: 1px solid var(--line);
+  padding: 11px 14px;
+  white-space: nowrap;
+}
+
+tbody td { padding: 10px 14px; border-bottom: 1px solid var(--line-soft); vertical-align: top; }
+tbody tr:last-child td { border-bottom: 0; }
+tbody tr:hover td { background: var(--panel-2); }
+
+td.num { width: 1%; text-align: right; color: var(--ink-dim); font-variant-numeric: tabular-nums; white-space: nowrap; }
+td.time, td.detail { white-space: nowrap; font-variant-numeric: tabular-nums; }
+td.time { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 12.5px; }
+td.detail { color: var(--ink-dim); }
+td.text { min-width: 22em; overflow-wrap: anywhere; }
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 3px 10px 3px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: transparent; /* fallback where color-mix is unknown */
+  background: color-mix(in srgb, var(--dot) 12%, transparent);
+  white-space: nowrap;
+}
+.pill i { width: 8px; height: 8px; border-radius: 50%; background: var(--dot); flex: none; }
+
+footer { margin-top: 18px; font-size: 12px; color: var(--ink-dim); text-align: right; }
+
+@media print {
+  body { background: #fff; padding: 0; }
+  .chips { display: none; }
+  .table-wrap { max-height: none; box-shadow: none; border: 0; }
+  thead th { position: static; }
+}
+";
+}


### PR DESCRIPTION
Closes the ask in https://github.com/SubtitleEdit/subtitleedit/discussions/12929#discussioncomment-18293146: the transcription quality report could only be shared as a screenshot.

## What
- The report window gets the same **Export...** button as *List errors*: Copy to clipboard, Text file (.txt), Excel file (.xlsx), Web page (.html).
- Every target exports the rows as shown, so an active summary-card filter (including *Removed*) applies. The button is disabled when the filter shows nothing.
- The suggested file name follows the video: `<video>-transcription-report.txt`.
- The html export paints the same issue colours as the window and keeps the script-free chip filter.

## How
- The four writers move from `ErrorListExport` into a shared `ReportExport` that takes generic chips and rows. `ErrorListExport` is now a thin mapper; its public API and existing tests are unchanged.
- The html chip-filter CSS is generated from the chips present instead of a fixed `f-0..f-7` list, so a report with any number of classes works.
- No new language strings: the export menu labels and header lines are reused from `ErrorList`.

## Tests
`Tests/UI/Features/Video/SpeechToText/SpeechToTextQualityReportExportTests.cs`: menu targets, text/html/xlsx output, filter follow-through, disabled state. The existing `ErrorListExport*Tests` still pass (40 tests total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)