### PR TITLE
Start play from the visible waveform cursor, not mpv's settled spot

### DIFF
--- a/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
+++ b/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
@@ -430,8 +430,8 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             _buttonPlay.Click += (_, _) =>
             {
                 var wasPlaying = _videoPlayerInstance.IsPlaying;
-                _videoPlayerInstance.PlayOrPause();
                 PlayPauseRequested?.Invoke(wasPlaying);
+                _videoPlayerInstance.PlayOrPause();
             };
             _buttonPlay.Bind(Button.CommandProperty, new Binding
             {
@@ -744,8 +744,8 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             if (ClickToTogglePlay)
             {
                 var wasPlaying = _videoPlayerInstance.IsPlaying;
-                _videoPlayerInstance.PlayOrPause();
                 PlayPauseRequested?.Invoke(wasPlaying);
+                _videoPlayerInstance.PlayOrPause();
                 e.Handled = true;
             }
 
@@ -835,9 +835,11 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
         /// <summary>
         /// Raised when the user toggles playback via this control (toolbar button, click on the
         /// video surface or <see cref="TogglePlayPause"/>). The argument is true when playback was
-        /// running, i.e. the request pauses. Captured before the toggle because the player's
-        /// IsPlaying lags the pause command (~100 ms for mpv), so owners can react on the request
-        /// itself — e.g. freeze the interpolated waveform cursor (issue #12233).
+        /// running, i.e. the request pauses. Raised before the toggle is sent to the player: the
+        /// player's IsPlaying lags the pause command (~100 ms for mpv), so owners react on the
+        /// request itself — e.g. freeze the interpolated waveform cursor (issue #12233) — and a
+        /// resume handler may reposition the paused player onto the drawn cursor, which must reach
+        /// the player before the play command so no audio from the old spot escapes first.
         /// </summary>
         public event Action<bool>? PlayPauseRequested;
         public event Action? StopRequested;
@@ -1062,8 +1064,8 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
         internal void TogglePlayPause()
         {
             var wasPlaying = _videoPlayerInstance.IsPlaying;
-            _videoPlayerInstance.PlayOrPause();
             PlayPauseRequested?.Invoke(wasPlaying);
+            _videoPlayerInstance.PlayOrPause();
         }
 
         internal AudioTrackInfo? ToggleAudioTrack()

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -680,7 +680,7 @@ public partial class MainViewModel :
     private HashSet<int>? _waveformBufferVisibleLayers;
     private DispatcherTimer _positionTimer = new();
     private DispatcherTimer _slowTimer = new();
-    private DispatcherTimer _cursorTimer = new(); // ~60 fps; drives only the waveform/video playhead cursor
+    private UiTickPump? _cursorTimer; // ~60 fps; drives only the waveform/video playhead cursor (a posted tick, not a DispatcherTimer - see UiTickPump)
 
     // Playhead interpolation state. When mpv resumes after a paused seek its time-pos stalls
     // for ~one audio-buffer interval (~200 ms) and then resyncs forward, which makes the
@@ -1756,25 +1756,27 @@ public partial class MainViewModel :
     internal void CancelPausePlayheadFreeze()
     {
         CancelFrameStepPlayBlip(); // playback the user started must not be stopped by a stale blip
-        SeekPausedPlayerToVisibleCursor();
+        AlignPausedPlayerWithCursor();
         _pauseRequested = false;
         _playStartGate.PlayRequested(Stopwatch.GetTimestamp());
     }
 
     /// <summary>
-    /// Play is about to resume a paused player. While paused the waveform cursor deliberately
-    /// holds the spot where the user paused, while mpv settles a wind-down further on - #12740
-    /// keeps that residual off the cursor, and it grew from sub-visible back to up to ~0.2 s
-    /// when the audio buffer returned to mpv's default for #14523. Left alone, play resumes
-    /// from mpv's settled spot: the audio starts past the cursor and the on-play resync then
-    /// yanks the cursor forward to meet it - so a play command visibly does not start from the
-    /// cursor the user aimed by. Make the drawn cursor authoritative instead: seek the paused
-    /// player onto it, so playback (and, on outputs that keep their device buffer across a
-    /// hardware pause, the audio actually heard - the seek flushes it) starts at what is on
-    /// screen. Seek-then-play paths (play line, play next, grid click-to-play...) pin the
+    /// Moves a paused mpv onto the drawn waveform cursor, so the next play starts from what is
+    /// on screen. While paused the cursor deliberately holds the spot where the user paused,
+    /// while mpv settles a wind-down further on - #12740 keeps that residual off the cursor,
+    /// and it grew from sub-visible back to up to ~0.2 s when the audio buffer returned to
+    /// mpv's default for #14523. Left alone, play resumed from mpv's settled spot: the audio
+    /// started past the cursor and the on-play resync yanked the cursor forward to meet it.
+    /// Called from the pause-settle branch of <see cref="UpdatePlayheadEstimate"/> - aligning
+    /// while paused gives mpv the whole pause to re-prime, so play stays a hot, instant
+    /// unpause (seeking at play time instead started the audio output starved: a brief
+    /// stutter, then a forward hop when the clock recovered) - and again from every play path
+    /// via <see cref="CancelPausePlayheadFreeze"/> as a fallback for a play pressed before the
+    /// settle ran. Seek-then-play paths (play line, play next, grid click-to-play...) pin the
     /// playhead to their own target first; the pin guard leaves those untouched.
     /// </summary>
-    private void SeekPausedPlayerToVisibleCursor()
+    private void AlignPausedPlayerWithCursor()
     {
         if (!_playheadValid || _playheadSeekTarget.HasValue)
         {
@@ -24854,7 +24856,7 @@ public partial class MainViewModel :
     private void CleanUp()
     {
         _positionTimer.Stop();
-        _cursorTimer.Stop();
+        _cursorTimer?.Stop();
         _slowTimer.Stop();
 
         if (_findViewModel != null)
@@ -29876,8 +29878,18 @@ public partial class MainViewModel :
                 // mpv's clock has come to rest after the pause wind-down. Hold the cursor at the frozen
                 // keypress spot rather than snapping to mpv's settled frame: the video stopped where the
                 // cursor already is, and snapping here showed as the cursor shifting slightly after the
-                // numeric time display had already stopped (#12740). Just mark settled so we stop watching.
+                // numeric time display had already stopped (#12740).
                 _playheadPausedSettled = true;
+
+                // Then move mpv, not the cursor: seek the paused core back onto the cursor's spot
+                // now, while there is a whole pause ahead to absorb it. Doing this seek at play
+                // time instead meant unpausing onto a freshly flushed audio pipeline - the output
+                // started starved (heard as a brief stutter) and the cursor hopped forward when
+                // mpv's clock recovered. Aligned here, play is a plain hot unpause from exactly
+                // where the cursor stands; the restart-gated pin keeps the cursor still through
+                // the alignment, and the play paths keep the same call as a fallback for a play
+                // pressed before this settle ran.
+                AlignPausedPlayerWithCursor();
             }
             // else: still winding down, or settled with a standing residual and raw at rest -> hold frozen
             // (no easing, no delayed snap => no post-pause drift).
@@ -30176,8 +30188,15 @@ public partial class MainViewModel :
         // leaving the play-start lag-then-rush. Running at Normal (above Render) keeps the cursor timer
         // firing on time through the burst so the line glides smoothly. Its per-tick work is ~0.2 ms, so
         // it doesn't disturb video rendering.
-        _cursorTimer = new DispatcherTimer(DispatcherPriority.Normal) { Interval = TimeSpan.FromMilliseconds(16) };
-        _cursorTimer.Tick += (s, e) =>
+        // Not a DispatcherTimer any more: with mpv embedded through its own native window (the
+        // Windows default), the platform timer message that a DispatcherTimer rides on stopped
+        // waking the message loop for 100-1000 ms around every play/pause - the UI thread sat idle
+        // in GetMessage with the tick overdue - while a posted message woke it at once. The cursor
+        // jumped ahead at every play and the time display froze (#14523 follow-up). UiTickPump
+        // posts each tick from its own thread, and executing a posted tick also promotes the
+        // dispatcher's other due timers, so the 50 ms position/display timers stop freezing too.
+        _cursorTimer?.Stop();
+        _cursorTimer = new UiTickPump(TimeSpan.FromMilliseconds(16), () =>
         {
             // Fast settle for the on-video subtitle preview: waiting for the 400 ms _slowTimer
             // added up to 400 ms of tick alignment on top of the settle window, so the preview
@@ -30260,7 +30279,7 @@ public partial class MainViewModel :
 
                 _pausedCenterLastSeconds = est;
             }
-        };
+        }, DispatcherPriority.Normal);
         _cursorTimer.Start();
 
         _slowTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(400) };

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1752,12 +1752,65 @@ public partial class MainViewModel :
     // is held frozen at the pause spot, which would stall the first ~100 ms of playback.
     // Every play request in the app funnels through here (PlayVideo, the play half of
     // TogglePlayPause, and the player control's own PlayPauseRequested wiring), so this is also
-    // where the play-start gate is armed.
+    // where the play-start gate is armed and where a resume is redirected to the visible cursor.
     internal void CancelPausePlayheadFreeze()
     {
         CancelFrameStepPlayBlip(); // playback the user started must not be stopped by a stale blip
+        SeekPausedPlayerToVisibleCursor();
         _pauseRequested = false;
         _playStartGate.PlayRequested(Stopwatch.GetTimestamp());
+    }
+
+    /// <summary>
+    /// Play is about to resume a paused player. While paused the waveform cursor deliberately
+    /// holds the spot where the user paused, while mpv settles a wind-down further on - #12740
+    /// keeps that residual off the cursor, and it grew from sub-visible back to up to ~0.2 s
+    /// when the audio buffer returned to mpv's default for #14523. Left alone, play resumes
+    /// from mpv's settled spot: the audio starts past the cursor and the on-play resync then
+    /// yanks the cursor forward to meet it - so a play command visibly does not start from the
+    /// cursor the user aimed by. Make the drawn cursor authoritative instead: seek the paused
+    /// player onto it, so playback (and, on outputs that keep their device buffer across a
+    /// hardware pause, the audio actually heard - the seek flushes it) starts at what is on
+    /// screen. Seek-then-play paths (play line, play next, grid click-to-play...) pin the
+    /// playhead to their own target first; the pin guard leaves those untouched.
+    /// </summary>
+    private void SeekPausedPlayerToVisibleCursor()
+    {
+        if (!_playheadValid || _playheadSeekTarget.HasValue)
+        {
+            return;
+        }
+
+        var vp = GetVideoPlayerControl();
+        if (vp == null || string.IsNullOrEmpty(_videoFileName))
+        {
+            return;
+        }
+
+        if (vp.VideoPlayer.IsPlaying)
+        {
+            return; // already running (or a blip/pause is mid-flight) - nothing settled to reconcile
+        }
+
+        var rawPosition = vp.VideoPlayer.Position;
+        if (IsSmpteTimingEnabled)
+        {
+            rawPosition = rawPosition * 1000.0 / 1001.0;
+        }
+
+        var residualSeconds = Math.Abs(_playheadEstimateSeconds - rawPosition);
+        if (residualSeconds <= PlayheadResyncOnPlayThresholdSeconds ||
+            residualSeconds >= PlayheadResyncThresholdSeconds)
+        {
+            // Below: within a frame - not worth a seek (the on-play resync leaves such a
+            // residual alone too). Above: the paused branch snaps a discontinuity this big to
+            // mpv's position within a tick, so the estimate is not what is standing on screen -
+            // this also shields any unpinned foreign seek still in flight from being undone.
+            return;
+        }
+
+        vp.SeekTo(_playheadEstimateSeconds);
+        PinPlayheadTo(_playheadEstimateSeconds);
     }
 
     // The player's Stop button pauses and seeks to 0; freeze the cursor immediately and pin it to
@@ -17030,6 +17083,9 @@ public partial class MainViewModel :
         }
 
         vp.VideoPlayer.Stop();
+        // Stop seeks to 0; pin the cursor there like the stop button does, and so the
+        // resume-from-cursor seek in PlayVideo can't pull playback back to the old spot.
+        PinPlayheadTo(0);
         PlayVideo(vp);
         _updateAudioVisualizer = true;
     }
@@ -30983,6 +31039,7 @@ public partial class MainViewModel :
             if (Se.Settings.General.SubtitleDoubleClickAction == SubtitleDoubleClickActionType.GoToSubtitleAndPlay.ToString())
             {
                 vp.Position = seconds;
+                PinPlayheadTo(seconds);
                 PlayVideo(vp);
                 AudioVisualizerCenterOnPositionIfNeeded(selectedItem, seconds);
                 return;
@@ -31000,6 +31057,7 @@ public partial class MainViewModel :
             if (Se.Settings.General.SubtitleDoubleClickAction == SubtitleDoubleClickActionType.GoToSubtitleAndPlayAndFocusTextBox.ToString())
             {
                 vp.Position = seconds;
+                PinPlayheadTo(seconds);
                 PlayVideo(vp);
                 AudioVisualizerCenterOnPositionIfNeeded(selectedItem, seconds);
                 FocusEditTextBox();
@@ -31035,6 +31093,7 @@ public partial class MainViewModel :
             {
                 seconds = Math.Max(0, seconds - 1.0);
                 vp.Position = seconds;
+                PinPlayheadTo(seconds);
                 PlayVideo(vp);
                 AudioVisualizerCenterOnPositionIfNeeded(selectedItem, seconds);
                 return;
@@ -31156,6 +31215,7 @@ public partial class MainViewModel :
             if (Se.Settings.General.SubtitleSingleClickAction == SubtitleSingleClickActionType.GoToSubtitleAndPlay.ToString())
             {
                 vp.Position = seconds;
+                PinPlayheadTo(seconds);
                 PlayVideo(vp);
                 AudioVisualizerCenterOnPositionIfNeeded(selectedItem, seconds);
                 return;
@@ -31173,6 +31233,7 @@ public partial class MainViewModel :
             if (Se.Settings.General.SubtitleSingleClickAction == SubtitleSingleClickActionType.GoToSubtitleAndPlayAndFocusTextBox.ToString())
             {
                 vp.Position = seconds;
+                PinPlayheadTo(seconds);
                 PlayVideo(vp);
                 AudioVisualizerCenterOnPositionIfNeeded(selectedItem, seconds);
                 FocusEditTextBox();

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1809,31 +1809,18 @@ public partial class MainViewModel :
             return;
         }
 
-        // TogglePlayPause funnels through CancelPausePlayheadFreeze twice (the view model
-        // command and the control's PlayPauseRequested wiring); the second pass still reads
-        // the pre-seek position, so it would issue the same seek again.
-        var nowTs = Stopwatch.GetTimestamp();
-        var sinceLastMs = (nowTs - _resumeSeekIssuedTs) * 1000.0 / Stopwatch.Frequency;
-        if (sinceLastMs < 500 && Math.Abs(_resumeSeekTargetSeconds - _playheadEstimateSeconds) < 0.001)
-        {
-            return;
-        }
-
-        _resumeSeekIssuedTs = nowTs;
-        _resumeSeekTargetSeconds = _playheadEstimateSeconds;
-
-        // Deliberately no PinPlayheadTo here. The pin's arrive tolerance (0.15 s) is wider
-        // than the typical pause residual, so the not-yet-seeked player already read as
-        // "arrived": the pin released on the first playing tick and seeded the cursor from
-        // the stale position - a jump forward onto mpv's settled spot, then back when the
-        // seek landed. The estimate is already standing on the target, the paused branch
-        // holds it there (settled), and once playing the freeze-hold keeps it from chasing
-        // the stale clock until the seek lands right where the cursor is.
+        // Pin so the cursor cannot follow Position's contortions across the resume: mpv's
+        // paused-value cache makes it read as the seek target while paused, flip back to the
+        // stale settled clock the instant the unpause clears the cache, and land on the target
+        // only when the seek completes - and the paused branch would follow each flip as "a
+        // seek while paused" (the double jump on every resume). The pin's arrival is gated on
+        // the player's seek-restart signal, so none of those intermediate readings can release
+        // it early. The pin also makes a second pass through this funnel a no-op
+        // (TogglePlayPause funnels twice: the view model command and the control's
+        // PlayPauseRequested wiring).
         vp.SeekTo(_playheadEstimateSeconds);
+        PinPlayheadTo(_playheadEstimateSeconds);
     }
-
-    private long _resumeSeekIssuedTs; // when SeekPausedPlayerToVisibleCursor last issued a seek
-    private double _resumeSeekTargetSeconds; // ...and to where (dedupe for double-funneled toggles)
 
     // The player's Stop button pauses and seeks to 0; freeze the cursor immediately and pin it to
     // the start so it jumps there at once instead of lingering until mpv reports the new position.
@@ -29648,22 +29635,33 @@ public partial class MainViewModel :
         if (_playheadSeekTarget.HasValue)
         {
             var target = _playheadSeekTarget.Value;
-            var arrived = Math.Abs(rawPosition - target) < PlayheadSeekArriveToleranceSeconds;
 
             // The 600 ms timeout is a guess at "the seek must have landed by now", and for a
             // slow seek (network share, cold spinning disk, heavy 4K hr-seek) it guesses wrong:
             // the pin expired mid-seek, the cursor snapped back to the old position, then jumped
             // again when the seek finally landed. When the player reports seek completion
             // exactly (mpv's MPV_EVENT_PLAYBACK_RESTART), don't give up while the seek is still
-            // in flight - hold the pin up to a hard cap instead. The restart signal is only ever
-            // used to extend the hold, never to release the pin early: a restart from an older
-            // seek in a scrub burst would otherwise release a newer pin onto a stale position.
+            // in flight - hold the pin up to a hard cap instead. A restart alone never releases
+            // the pin (a restart from an older seek in a scrub burst would release a newer pin
+            // onto a stale position); the position must be at the target too.
             var pinElapsedMs = (nowTimestamp - _playheadSeekTargetTs) * 1000.0 / Stopwatch.Frequency;
             var player = vp.VideoPlayer;
             var seekStillInFlight = player.SupportsPlaybackRestartEvents &&
                                     !player.HasPlaybackRestartedSince(_playheadSeekTargetTs);
             var timedOut = pinElapsedMs > PlayheadSeekPinTimeoutMs &&
                            (!seekStillInFlight || pinElapsedMs > PlayheadSeekPinMaxMs);
+
+            // "Arrived" needs more than the position reading near the target: while the pin's seek
+            // is in flight, Position is unreliable for this exact purpose - mpv's paused-value
+            // cache returns the seek target itself while paused, then flips back to the stale
+            // observed clock the moment an unpause clears it, then to the landed position (the
+            // resume-from-cursor seek showed all three within ~100 ms). A residual smaller than
+            // the tolerance also means the pre-seek position already reads as "arrived". So when
+            // the player reports seek completion exactly, arrival additionally requires that a
+            // restart has been observed since the pin was set - mpv's own word that the seek
+            // landed - and the timeout still bounds a seek whose restart never comes.
+            var arrived = Math.Abs(rawPosition - target) < PlayheadSeekArriveToleranceSeconds &&
+                          !seekStillInFlight;
 
             // A pause was requested but mpv still reports playing: it keeps decoding for ~100-200 ms and
             // its position runs on past the pinned spot, which is within the arrive tolerance, so "arrived"

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1809,9 +1809,31 @@ public partial class MainViewModel :
             return;
         }
 
+        // TogglePlayPause funnels through CancelPausePlayheadFreeze twice (the view model
+        // command and the control's PlayPauseRequested wiring); the second pass still reads
+        // the pre-seek position, so it would issue the same seek again.
+        var nowTs = Stopwatch.GetTimestamp();
+        var sinceLastMs = (nowTs - _resumeSeekIssuedTs) * 1000.0 / Stopwatch.Frequency;
+        if (sinceLastMs < 500 && Math.Abs(_resumeSeekTargetSeconds - _playheadEstimateSeconds) < 0.001)
+        {
+            return;
+        }
+
+        _resumeSeekIssuedTs = nowTs;
+        _resumeSeekTargetSeconds = _playheadEstimateSeconds;
+
+        // Deliberately no PinPlayheadTo here. The pin's arrive tolerance (0.15 s) is wider
+        // than the typical pause residual, so the not-yet-seeked player already read as
+        // "arrived": the pin released on the first playing tick and seeded the cursor from
+        // the stale position - a jump forward onto mpv's settled spot, then back when the
+        // seek landed. The estimate is already standing on the target, the paused branch
+        // holds it there (settled), and once playing the freeze-hold keeps it from chasing
+        // the stale clock until the seek lands right where the cursor is.
         vp.SeekTo(_playheadEstimateSeconds);
-        PinPlayheadTo(_playheadEstimateSeconds);
     }
+
+    private long _resumeSeekIssuedTs; // when SeekPausedPlayerToVisibleCursor last issued a seek
+    private double _resumeSeekTargetSeconds; // ...and to where (dedupe for double-funneled toggles)
 
     // The player's Stop button pauses and seeks to 0; freeze the cursor immediately and pin it to
     // the start so it jumps there at once instead of lingering until mpv reports the new position.
@@ -29766,10 +29788,14 @@ public partial class MainViewModel :
                 // desync. Gated on a live raw clock so a paused-seek re-prime freeze can't trigger it.
                 _playheadEstimateSeconds = rawPosition;
             }
-            else if (drift > 0)
+            else if (drift > 0 && rawFrozenSeconds < PlayheadFreezeHoldSeconds)
             {
                 // Only ever nudge forward to close a lag (e.g. after a starved tick); never pull the
-                // cursor backward, which is what showed up as the sub-1x "slow" after the rush. Cap the
+                // cursor backward, which is what showed up as the sub-1x "slow" after the rush. Gated
+                // on a live raw clock like the snap above: while mpv's clock stands still (an hr-seek
+                // re-priming - e.g. the resume-from-cursor seek) the reported position is stale, and
+                // crawling toward it walks the cursor off the spot playback is about to start from,
+                // with no backward correction to ever undo it. Cap the
                 // per-tick correction against real elapsed time so the catch-up tops out around ~1.2x
                 // wall clock even when the timer is running slow - sizing it against the capped step
                 // (or only correcting on ticks where raw moved) throttled repayment to ~1.05x exactly

--- a/src/ui/Logic/UiTickPump.cs
+++ b/src/ui/Logic/UiTickPump.cs
@@ -1,0 +1,96 @@
+﻿using Avalonia.Threading;
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+namespace Nikse.SubtitleEdit.Logic;
+
+/// <summary>
+/// A fixed-interval UI tick driven by a dedicated thread that posts each tick to the Avalonia
+/// dispatcher, instead of a <see cref="DispatcherTimer"/>.
+/// <para>
+/// A DispatcherTimer rides on the platform's own timer message (a Win32 SetTimer/WM_TIMER on
+/// Windows). With mpv embedded through its own native window (the Windows default player,
+/// "mpv-wid"), that timer message stopped waking the UI thread's message loop for 100-1000 ms
+/// around play/pause - the thread sat idle in GetMessage with the tick overdue, while a posted
+/// message woke it at once (measured in the #14523 follow-up: the waveform cursor jumped and
+/// the time display froze at every play, only with the native window). A posted tick does not
+/// depend on the timer message, and executing it also promotes the dispatcher's other due
+/// timers (the 50 ms position/display timers), so those stop freezing too.
+/// </para>
+/// </summary>
+public sealed class UiTickPump : IDisposable
+{
+    private readonly TimeSpan _interval;
+    private readonly Action _tick;
+    private readonly DispatcherPriority _priority;
+    private readonly Action _postedTick;
+    private Thread? _thread;
+    private volatile bool _running;
+    private int _tickPending; // 1 while a posted tick has not run yet: never queue a backlog
+
+    public UiTickPump(TimeSpan interval, Action tick, DispatcherPriority priority)
+    {
+        _interval = interval;
+        _tick = tick;
+        _priority = priority;
+        _postedTick = RunTick;
+    }
+
+    public bool IsRunning => _running;
+
+    public void Start()
+    {
+        if (_running)
+        {
+            return;
+        }
+
+        _running = true;
+        _thread = new Thread(Loop) { IsBackground = true, Name = "ui-tick-pump" };
+        _thread.Start();
+    }
+
+    public void Stop()
+    {
+        _running = false;
+    }
+
+    public void Dispose()
+    {
+        Stop();
+    }
+
+    private void Loop()
+    {
+        var intervalTicks = (long)(_interval.TotalSeconds * Stopwatch.Frequency);
+        var next = Stopwatch.GetTimestamp() + intervalTicks;
+        while (_running)
+        {
+            var now = Stopwatch.GetTimestamp();
+            var waitMs = (next - now) * 1000.0 / Stopwatch.Frequency;
+            if (waitMs > 0)
+            {
+                Thread.Sleep((int)Math.Ceiling(waitMs));
+                continue;
+            }
+
+            // Schedule the next tick from now rather than from the missed due time, so a UI
+            // thread that was busy is not hit with a burst of catch-up ticks.
+            next = Stopwatch.GetTimestamp() + intervalTicks;
+            if (Interlocked.CompareExchange(ref _tickPending, 1, 0) == 0)
+            {
+                Dispatcher.UIThread.Post(_postedTick, _priority);
+            }
+        }
+    }
+
+    private void RunTick()
+    {
+        Interlocked.Exchange(ref _tickPending, 0);
+        if (_running)
+        {
+            _tick();
+        }
+    }
+}

--- a/tests/UI/Features/Main/PlayheadResumeFromCursorTests.cs
+++ b/tests/UI/Features/Main/PlayheadResumeFromCursorTests.cs
@@ -1,0 +1,205 @@
+﻿using Avalonia.Headless.XUnit;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Controls.VideoPlayer;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.VideoPlayers;
+using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// A play command must start playback from the cursor the user sees. While paused the waveform
+/// cursor deliberately holds the spot where the user paused while mpv settles a wind-down further
+/// on (#12740 keeps that residual off the cursor). Resuming used to start from mpv's settled spot
+/// and yank the cursor forward to meet it - sub-visible while SE forced a 0.05 s audio buffer,
+/// but up to ~0.2 s again once the buffer went back to mpv's default for #14523. Every play
+/// request funnels through CancelPausePlayheadFreeze, which now seeks the paused player onto the
+/// drawn cursor first; seek-then-play paths pin the playhead to their own target and are left alone.
+/// </summary>
+public class PlayheadResumeFromCursorTests : IDisposable
+{
+    // Tests that drive commands through GetVideoPlayerControl() must not leave their test-built
+    // VideoPlayerControl assigned to the view model: an unparented control left reachable on the
+    // per-assembly headless application is the documented contamination-cascade trigger - unrelated
+    // windows start failing out of the compositor on CI, a different victim per run (PR #14258).
+    private MainViewModel? _vm;
+
+    public void Dispose()
+    {
+        if (_vm != null)
+        {
+            _vm.VideoPlayerControl = null;
+            _vm.AudioVisualizer = null;
+        }
+    }
+
+    private sealed class FakeVideoPlayer : IVideoPlayer
+    {
+        public string Name => "fake";
+        public string FileName { get; private set; } = string.Empty;
+
+        public bool CanLoad() => true;
+
+        public Task LoadFile(string fileName, double startPositionSeconds = 0)
+        {
+            FileName = fileName;
+            Position = startPositionSeconds;
+            return Task.CompletedTask;
+        }
+
+        public void CloseFile() => FileName = string.Empty;
+
+        public void Play() => IsPlaying = true;
+
+        public void PlayOrPause() => IsPlaying = !IsPlaying;
+
+        public void Pause() => IsPlaying = false;
+
+        public void Stop() => IsPlaying = false;
+
+        public AudioTrackInfo? ToggleAudioTrack() => null;
+
+        public bool IsPlaying { get; set; }
+        public bool IsPaused => !IsPlaying;
+        public double Position { get; set; }
+        public double Duration => 60;
+        public int VolumeMaximum => 100;
+        public double Volume { get; set; } = 50;
+        public double Speed { get; set; } = 1.0;
+        public bool SupportsPlaybackRestartEvents => false;
+        public bool HasPlaybackRestartedSince(long stopwatchTimestamp) => false;
+    }
+
+    [AvaloniaFact]
+    public void ResumeAfterPause_SeeksThePausedPlayerOntoTheVisibleCursor()
+    {
+        // Paused with the cursor frozen at 1.0 while mpv's wind-down settled at 1.18 - the
+        // standing residual #12740 keeps off the cursor.
+        var (vm, vp, player) = MakeViewModelWithPlayer(cursorSeconds: 1.0);
+        player.Position = 1.18;
+
+        vm.CancelPausePlayheadFreeze(); // what every play path does just before playing
+
+        Assert.Equal(1.0, player.Position, 4); // playback will start at the drawn cursor
+        Assert.Equal(1.0, GetField<double?>(vm, "_playheadSeekTarget") ?? -1, 4); // and the cursor is pinned there
+        Assert.Equal(1.0, Tick(vm, vp, isPlaying: false), 4);
+    }
+
+    [AvaloniaFact]
+    public void ResumeAfterPause_WithinAFrame_DoesNotSeek()
+    {
+        // A residual too small to see is not worth an hr-seek on every resume.
+        var (vm, vp, player) = MakeViewModelWithPlayer(cursorSeconds: 1.0);
+        player.Position = 1.02;
+
+        vm.CancelPausePlayheadFreeze();
+
+        Assert.Equal(1.02, player.Position, 4);
+        Assert.Null(GetField<double?>(vm, "_playheadSeekTarget"));
+    }
+
+    [AvaloniaFact]
+    public void ResumeAfterPause_DiscontinuityGap_DoesNotTrustTheEstimate()
+    {
+        // A gap at the discontinuity threshold means the estimate is not what stands on screen
+        // (the paused branch snaps such a gap to mpv within a tick) - e.g. an unpinned foreign
+        // seek still in flight. Resuming must not pull the player back to the stale spot.
+        var (vm, vp, player) = MakeViewModelWithPlayer(cursorSeconds: 1.0);
+        player.Position = 3.0;
+
+        vm.CancelPausePlayheadFreeze();
+
+        Assert.Equal(3.0, player.Position, 4);
+        Assert.Null(GetField<double?>(vm, "_playheadSeekTarget"));
+    }
+
+    [AvaloniaFact]
+    public void SeekThenPlay_PinnedTargetIsLeftAlone()
+    {
+        // Play line / play next / grid click-to-play: seek to the target, pin, then play. The
+        // resume-from-cursor seek must not override the pinned target with the old cursor spot.
+        var (vm, vp, player) = MakeViewModelWithPlayer(cursorSeconds: 1.0);
+        player.Position = 1.18; // standing pause residual, as above
+
+        PinPlayheadTo(vm, 9.0); // the caller's own seek target (its vp.Position write is async)
+        vm.CancelPausePlayheadFreeze();
+
+        Assert.Equal(1.18, player.Position, 4); // no second seek was issued
+        Assert.Equal(9.0, GetField<double?>(vm, "_playheadSeekTarget") ?? -1, 4);
+    }
+
+    [AvaloniaFact]
+    public void ResumeWhilePlaying_DoesNothing()
+    {
+        // With mpv's clock live there is no settled residual; the drift logic owns the cursor.
+        var (vm, vp, player) = MakeViewModelWithPlayer(cursorSeconds: 1.0);
+        player.Position = 1.2;
+        player.IsPlaying = true;
+
+        vm.CancelPausePlayheadFreeze();
+
+        Assert.Equal(1.2, player.Position, 4);
+        Assert.Null(GetField<double?>(vm, "_playheadSeekTarget"));
+    }
+
+    [AvaloniaFact]
+    public void TogglePlayPause_WhilePaused_StartsPlaybackAtTheCursor()
+    {
+        // End to end through the toggle command: the seek lands before the play command.
+        var (vm, vp, player) = MakeViewModelWithPlayer(cursorSeconds: 1.0);
+        player.Position = 1.18;
+
+        vm.TogglePlayPauseCommand.Execute(null);
+
+        Assert.True(player.IsPlaying);
+        Assert.Equal(1.0, player.Position, 4);
+    }
+
+    private (MainViewModel Vm, VideoPlayerControl Vp, FakeVideoPlayer Player) MakeViewModelWithPlayer(double cursorSeconds)
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var vm = Locator.Services.GetRequiredService<MainViewModel>();
+        var player = new FakeVideoPlayer { Position = cursorSeconds };
+        var vp = new VideoPlayerControl(player);
+
+        vm.VideoPlayerControl = vp;
+        _vm = vm; // detached again in Dispose - see the cascade note on the field
+        vp.Duration = 60; // published, or the bound position slider clamps the display write
+        vp.SetPositionDisplayOnly(cursorSeconds);
+        SetField(vm, "_videoFileName", "video.mkv");
+
+        // Paused at cursorSeconds, settled, with the cursor already on that spot.
+        SetField(vm, "_playheadEstimateSeconds", cursorSeconds);
+        SetField(vm, "_playheadLastRealSeconds", cursorSeconds);
+        SetField(vm, "_playheadValid", true);
+        SetField(vm, "_playheadPausedSettled", true);
+        SetField(vm, "_playheadWasPlaying", false);
+
+        return (vm, vp, player);
+    }
+
+    private static void PinPlayheadTo(MainViewModel vm, double seconds) =>
+        typeof(MainViewModel)
+            .GetMethod("PinPlayheadTo", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(vm, [seconds]);
+
+    private static double Tick(MainViewModel vm, VideoPlayerControl vp, bool isPlaying) =>
+        (double)typeof(MainViewModel)
+            .GetMethod("UpdatePlayheadEstimate", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(vm, [vp, isPlaying])!;
+
+    private static void SetField(object target, string name, object value) =>
+        target.GetType().GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(target, value);
+
+    private static T? GetField<T>(object target, string name) =>
+        (T?)target.GetType().GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(target);
+}

--- a/tests/UI/Features/Main/PlayheadResumeFromCursorTests.cs
+++ b/tests/UI/Features/Main/PlayheadResumeFromCursorTests.cs
@@ -8,6 +8,7 @@ using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.VideoPlayers;
 using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
 using System;
+using System.Diagnostics;
 using System.Reflection;
 using System.Threading.Tasks;
 
@@ -43,22 +44,31 @@ public class PlayheadResumeFromCursorTests : IDisposable
         }
     }
 
-    /// <summary>Seeks are recorded but only reach the reported position on <see cref="LandSeek"/>,
-    /// like mpv's async hr-seek. Everything the resume logic reads mid-flight is the old clock.</summary>
+    /// <summary>Models the LibMpv player's seek semantics, which are what broke the first two
+    /// attempts at this fix: a seek is asynchronous (the observed clock keeps the old value until
+    /// <see cref="LandSeek"/>), the paused-value cache makes Position read as the seek target
+    /// while paused, Play/PlayOrPause clear that cache (so Position flips back to the stale
+    /// observed clock mid-resume), and seek completion is reported via the playback-restart
+    /// signal. A synchronous fake could never see the phantom pin arrival or the flip.</summary>
     private sealed class FakeVideoPlayer : IVideoPlayer
     {
-        private double _position;
+        private double _observedPosition;
+        private double? _pausedSeekTarget; // mirrors LibMpvDynamicPlayer._pausedValue
+        private long? _restartTimestamp;
 
-        public FakeVideoPlayer(double startSeconds) => _position = startSeconds;
+        public FakeVideoPlayer(double startSeconds) => _observedPosition = startSeconds;
 
         public double? SeekTarget { get; private set; }
         public int SeekCount { get; private set; }
 
+        /// <summary>The async seek completes: the observed clock lands on the target and mpv
+        /// posts MPV_EVENT_PLAYBACK_RESTART.</summary>
         public void LandSeek()
         {
             if (SeekTarget is { } t)
             {
-                _position = t;
+                _observedPosition = t;
+                _restartTimestamp = Stopwatch.GetTimestamp();
             }
         }
 
@@ -70,15 +80,23 @@ public class PlayheadResumeFromCursorTests : IDisposable
         public Task LoadFile(string fileName, double startPositionSeconds = 0)
         {
             FileName = fileName;
-            _position = startPositionSeconds;
+            _observedPosition = startPositionSeconds;
             return Task.CompletedTask;
         }
 
         public void CloseFile() => FileName = string.Empty;
 
-        public void Play() => IsPlaying = true;
+        public void Play()
+        {
+            _pausedSeekTarget = null;
+            IsPlaying = true;
+        }
 
-        public void PlayOrPause() => IsPlaying = !IsPlaying;
+        public void PlayOrPause()
+        {
+            _pausedSeekTarget = null;
+            IsPlaying = !IsPlaying;
+        }
 
         public void Pause() => IsPlaying = false;
 
@@ -91,11 +109,12 @@ public class PlayheadResumeFromCursorTests : IDisposable
 
         public double Position
         {
-            get => _position;
+            get => !IsPlaying && _pausedSeekTarget.HasValue ? _pausedSeekTarget.Value : _observedPosition;
             set
             {
                 SeekTarget = value;
                 SeekCount++;
+                _pausedSeekTarget = value;
             }
         }
 
@@ -103,8 +122,9 @@ public class PlayheadResumeFromCursorTests : IDisposable
         public int VolumeMaximum => 100;
         public double Volume { get; set; } = 50;
         public double Speed { get; set; } = 1.0;
-        public bool SupportsPlaybackRestartEvents => false;
-        public bool HasPlaybackRestartedSince(long stopwatchTimestamp) => false;
+        public bool SupportsPlaybackRestartEvents => true;
+        public bool HasPlaybackRestartedSince(long stopwatchTimestamp) =>
+            _restartTimestamp is { } ts && ts >= stopwatchTimestamp;
     }
 
     [AvaloniaFact]
@@ -117,18 +137,42 @@ public class PlayheadResumeFromCursorTests : IDisposable
         vm.CancelPausePlayheadFreeze(); // what every play path does just before playing
 
         Assert.Equal(1.0, player.SeekTarget ?? -1, 4); // playback will start at the drawn cursor
-        Assert.Null(GetField<double?>(vm, "_playheadSeekTarget")); // and no pin that could phantom-arrive
+        Assert.Equal(1.0, GetField<double?>(vm, "_playheadSeekTarget") ?? -1, 4); // pinned there
 
-        // The cursor holds the spot through the whole async resume:
-        Assert.Equal(1.0, Tick(vm, vp, isPlaying: false), 3); // seek still in flight, still paused
+        // While paused-with-seek-in-flight, Position reads as the seek target (paused-value
+        // cache); the restart gate keeps the pin from treating that echo as arrival.
+        Assert.Equal(1.0, Tick(vm, vp, isPlaying: false), 3);
 
-        // mpv unpauses before the hr-seek lands and briefly still reports the stale clock. The
-        // pinned first fix seeded the cursor from exactly this tick - the reported jump.
-        player.IsPlaying = true;
-        Assert.Equal(1.0, Tick(vm, vp, isPlaying: true), 2);
+        // The unpause clears the paused-value cache: Position flips back to the stale observed
+        // clock until the hr-seek lands. Following this flip was the double jump of the second
+        // attempt; releasing the pin onto it was the jump of the first.
+        player.PlayOrPause();
+        Assert.Equal(1.18, player.Position, 4); // the flip is really being exercised
+        Assert.Equal(1.0, Tick(vm, vp, isPlaying: true), 3);
 
-        player.LandSeek(); // raw arrives right where the cursor is held
-        Assert.Equal(1.0, Tick(vm, vp, isPlaying: true), 2);
+        player.LandSeek(); // mpv's restart: the seek landed right where the cursor is held
+        Assert.Equal(1.0, Tick(vm, vp, isPlaying: true), 3);
+        Assert.Null(GetField<double?>(vm, "_playheadSeekTarget")); // released cleanly onto the target
+    }
+
+    [AvaloniaFact]
+    public void ResumeAfterPause_ResidualInsideArriveTolerance_PinHoldsUntilTheSeekLands()
+    {
+        // The typical wind-down residual (~0.05-0.15 s) is smaller than the pin's arrive
+        // tolerance, so the stale clock after the unpause flip already reads as "arrived" -
+        // the phantom arrival that seeded the cursor from the stale position and made the
+        // first fix jump. Only mpv's restart signal may release the pin.
+        var (vm, vp, player) = MakeViewModelWithPlayer(cursorSeconds: 1.0, rawSeconds: 1.1);
+
+        vm.CancelPausePlayheadFreeze();
+        player.PlayOrPause(); // flip: Position reads 1.1 again, within tolerance of the 1.0 pin
+
+        Assert.Equal(1.1, player.Position, 4);
+        Assert.Equal(1.0, Tick(vm, vp, isPlaying: true), 3); // held - no restart yet
+        Assert.Equal(1.0, GetField<double?>(vm, "_playheadSeekTarget") ?? -1, 4);
+
+        player.LandSeek();
+        Assert.Equal(1.0, Tick(vm, vp, isPlaying: true), 3);
     }
 
     [AvaloniaFact]
@@ -173,8 +217,8 @@ public class PlayheadResumeFromCursorTests : IDisposable
     public void SecondFunnelPass_DoesNotSeekAgain()
     {
         // TogglePlayPause funnels through CancelPausePlayheadFreeze twice (the view model command
-        // and the control's PlayPauseRequested wiring); the second pass still reads the pre-seek
-        // clock, so without the dedupe it would issue the same seek again.
+        // and the control's PlayPauseRequested wiring); the pin set by the first pass makes the
+        // second a no-op, else it would issue the same seek again.
         var (vm, vp, player) = MakeViewModelWithPlayer(cursorSeconds: 1.0, rawSeconds: 1.18);
 
         vm.CancelPausePlayheadFreeze();

--- a/tests/UI/Features/Main/PlayheadResumeFromCursorTests.cs
+++ b/tests/UI/Features/Main/PlayheadResumeFromCursorTests.cs
@@ -20,7 +20,11 @@ namespace UITests.Features.Main;
 /// and yank the cursor forward to meet it - sub-visible while SE forced a 0.05 s audio buffer,
 /// but up to ~0.2 s again once the buffer went back to mpv's default for #14523. Every play
 /// request funnels through CancelPausePlayheadFreeze, which now seeks the paused player onto the
-/// drawn cursor first; seek-then-play paths pin the playhead to their own target and are left alone.
+/// drawn cursor first; seek-then-play paths pin the playhead to their own target and are left
+/// alone. The fake player applies seeks asynchronously, like mpv: the first fix pinned the
+/// playhead to the seek target, and the pin's 0.15 s arrive tolerance read the NOT-yet-seeked
+/// position as already arrived - the cursor was seeded from the stale clock and jumped forward,
+/// then back when the seek landed. A synchronous fake could never see that.
 /// </summary>
 public class PlayheadResumeFromCursorTests : IDisposable
 {
@@ -39,8 +43,25 @@ public class PlayheadResumeFromCursorTests : IDisposable
         }
     }
 
+    /// <summary>Seeks are recorded but only reach the reported position on <see cref="LandSeek"/>,
+    /// like mpv's async hr-seek. Everything the resume logic reads mid-flight is the old clock.</summary>
     private sealed class FakeVideoPlayer : IVideoPlayer
     {
+        private double _position;
+
+        public FakeVideoPlayer(double startSeconds) => _position = startSeconds;
+
+        public double? SeekTarget { get; private set; }
+        public int SeekCount { get; private set; }
+
+        public void LandSeek()
+        {
+            if (SeekTarget is { } t)
+            {
+                _position = t;
+            }
+        }
+
         public string Name => "fake";
         public string FileName { get; private set; } = string.Empty;
 
@@ -49,7 +70,7 @@ public class PlayheadResumeFromCursorTests : IDisposable
         public Task LoadFile(string fileName, double startPositionSeconds = 0)
         {
             FileName = fileName;
-            Position = startPositionSeconds;
+            _position = startPositionSeconds;
             return Task.CompletedTask;
         }
 
@@ -67,7 +88,17 @@ public class PlayheadResumeFromCursorTests : IDisposable
 
         public bool IsPlaying { get; set; }
         public bool IsPaused => !IsPlaying;
-        public double Position { get; set; }
+
+        public double Position
+        {
+            get => _position;
+            set
+            {
+                SeekTarget = value;
+                SeekCount++;
+            }
+        }
+
         public double Duration => 60;
         public int VolumeMaximum => 100;
         public double Volume { get; set; } = 50;
@@ -81,27 +112,34 @@ public class PlayheadResumeFromCursorTests : IDisposable
     {
         // Paused with the cursor frozen at 1.0 while mpv's wind-down settled at 1.18 - the
         // standing residual #12740 keeps off the cursor.
-        var (vm, vp, player) = MakeViewModelWithPlayer(cursorSeconds: 1.0);
-        player.Position = 1.18;
+        var (vm, vp, player) = MakeViewModelWithPlayer(cursorSeconds: 1.0, rawSeconds: 1.18);
 
         vm.CancelPausePlayheadFreeze(); // what every play path does just before playing
 
-        Assert.Equal(1.0, player.Position, 4); // playback will start at the drawn cursor
-        Assert.Equal(1.0, GetField<double?>(vm, "_playheadSeekTarget") ?? -1, 4); // and the cursor is pinned there
-        Assert.Equal(1.0, Tick(vm, vp, isPlaying: false), 4);
+        Assert.Equal(1.0, player.SeekTarget ?? -1, 4); // playback will start at the drawn cursor
+        Assert.Null(GetField<double?>(vm, "_playheadSeekTarget")); // and no pin that could phantom-arrive
+
+        // The cursor holds the spot through the whole async resume:
+        Assert.Equal(1.0, Tick(vm, vp, isPlaying: false), 3); // seek still in flight, still paused
+
+        // mpv unpauses before the hr-seek lands and briefly still reports the stale clock. The
+        // pinned first fix seeded the cursor from exactly this tick - the reported jump.
+        player.IsPlaying = true;
+        Assert.Equal(1.0, Tick(vm, vp, isPlaying: true), 2);
+
+        player.LandSeek(); // raw arrives right where the cursor is held
+        Assert.Equal(1.0, Tick(vm, vp, isPlaying: true), 2);
     }
 
     [AvaloniaFact]
     public void ResumeAfterPause_WithinAFrame_DoesNotSeek()
     {
         // A residual too small to see is not worth an hr-seek on every resume.
-        var (vm, vp, player) = MakeViewModelWithPlayer(cursorSeconds: 1.0);
-        player.Position = 1.02;
+        var (vm, vp, player) = MakeViewModelWithPlayer(cursorSeconds: 1.0, rawSeconds: 1.02);
 
         vm.CancelPausePlayheadFreeze();
 
-        Assert.Equal(1.02, player.Position, 4);
-        Assert.Null(GetField<double?>(vm, "_playheadSeekTarget"));
+        Assert.Equal(0, player.SeekCount);
     }
 
     [AvaloniaFact]
@@ -110,13 +148,11 @@ public class PlayheadResumeFromCursorTests : IDisposable
         // A gap at the discontinuity threshold means the estimate is not what stands on screen
         // (the paused branch snaps such a gap to mpv within a tick) - e.g. an unpinned foreign
         // seek still in flight. Resuming must not pull the player back to the stale spot.
-        var (vm, vp, player) = MakeViewModelWithPlayer(cursorSeconds: 1.0);
-        player.Position = 3.0;
+        var (vm, vp, player) = MakeViewModelWithPlayer(cursorSeconds: 1.0, rawSeconds: 3.0);
 
         vm.CancelPausePlayheadFreeze();
 
-        Assert.Equal(3.0, player.Position, 4);
-        Assert.Null(GetField<double?>(vm, "_playheadSeekTarget"));
+        Assert.Equal(0, player.SeekCount);
     }
 
     [AvaloniaFact]
@@ -124,62 +160,79 @@ public class PlayheadResumeFromCursorTests : IDisposable
     {
         // Play line / play next / grid click-to-play: seek to the target, pin, then play. The
         // resume-from-cursor seek must not override the pinned target with the old cursor spot.
-        var (vm, vp, player) = MakeViewModelWithPlayer(cursorSeconds: 1.0);
-        player.Position = 1.18; // standing pause residual, as above
+        var (vm, vp, player) = MakeViewModelWithPlayer(cursorSeconds: 1.0, rawSeconds: 1.18);
 
-        PinPlayheadTo(vm, 9.0); // the caller's own seek target (its vp.Position write is async)
+        PinPlayheadTo(vm, 9.0); // the caller's own seek target (its vp.Position write is async too)
         vm.CancelPausePlayheadFreeze();
 
-        Assert.Equal(1.18, player.Position, 4); // no second seek was issued
+        Assert.Equal(0, player.SeekCount); // no second seek was issued
         Assert.Equal(9.0, GetField<double?>(vm, "_playheadSeekTarget") ?? -1, 4);
+    }
+
+    [AvaloniaFact]
+    public void SecondFunnelPass_DoesNotSeekAgain()
+    {
+        // TogglePlayPause funnels through CancelPausePlayheadFreeze twice (the view model command
+        // and the control's PlayPauseRequested wiring); the second pass still reads the pre-seek
+        // clock, so without the dedupe it would issue the same seek again.
+        var (vm, vp, player) = MakeViewModelWithPlayer(cursorSeconds: 1.0, rawSeconds: 1.18);
+
+        vm.CancelPausePlayheadFreeze();
+        vm.CancelPausePlayheadFreeze();
+
+        Assert.Equal(1, player.SeekCount);
     }
 
     [AvaloniaFact]
     public void ResumeWhilePlaying_DoesNothing()
     {
         // With mpv's clock live there is no settled residual; the drift logic owns the cursor.
-        var (vm, vp, player) = MakeViewModelWithPlayer(cursorSeconds: 1.0);
-        player.Position = 1.2;
+        var (vm, vp, player) = MakeViewModelWithPlayer(cursorSeconds: 1.0, rawSeconds: 1.2);
         player.IsPlaying = true;
 
         vm.CancelPausePlayheadFreeze();
 
-        Assert.Equal(1.2, player.Position, 4);
-        Assert.Null(GetField<double?>(vm, "_playheadSeekTarget"));
+        Assert.Equal(0, player.SeekCount);
     }
 
     [AvaloniaFact]
     public void TogglePlayPause_WhilePaused_StartsPlaybackAtTheCursor()
     {
-        // End to end through the toggle command: the seek lands before the play command.
-        var (vm, vp, player) = MakeViewModelWithPlayer(cursorSeconds: 1.0);
-        player.Position = 1.18;
+        // End to end through the toggle command: the seek is issued before the play command.
+        var (vm, vp, player) = MakeViewModelWithPlayer(cursorSeconds: 1.0, rawSeconds: 1.18);
 
         vm.TogglePlayPauseCommand.Execute(null);
 
         Assert.True(player.IsPlaying);
+        Assert.Equal(1, player.SeekCount);
+        Assert.Equal(1.0, player.SeekTarget ?? -1, 4);
+
+        Assert.Equal(1.0, Tick(vm, vp, isPlaying: true), 2); // stale clock until the seek lands
+        player.LandSeek();
         Assert.Equal(1.0, player.Position, 4);
+        Assert.Equal(1.0, Tick(vm, vp, isPlaying: true), 2);
     }
 
-    private (MainViewModel Vm, VideoPlayerControl Vp, FakeVideoPlayer Player) MakeViewModelWithPlayer(double cursorSeconds)
+    private (MainViewModel Vm, VideoPlayerControl Vp, FakeVideoPlayer Player) MakeViewModelWithPlayer(double cursorSeconds, double rawSeconds)
     {
         var services = new ServiceCollection();
         services.AddSubtitleEditServices();
         Locator.Services = services.BuildServiceProvider();
 
         var vm = Locator.Services.GetRequiredService<MainViewModel>();
-        var player = new FakeVideoPlayer { Position = cursorSeconds };
+        var player = new FakeVideoPlayer(rawSeconds);
         var vp = new VideoPlayerControl(player);
 
         vm.VideoPlayerControl = vp;
         _vm = vm; // detached again in Dispose - see the cascade note on the field
         vp.Duration = 60; // published, or the bound position slider clamps the display write
-        vp.SetPositionDisplayOnly(cursorSeconds);
+        vp.SetPositionDisplayOnly(rawSeconds);
         SetField(vm, "_videoFileName", "video.mkv");
 
-        // Paused at cursorSeconds, settled, with the cursor already on that spot.
+        // A settled pause: the cursor froze at cursorSeconds when the user paused, mpv's
+        // wind-down then came to rest at rawSeconds, and the settle logic saw it stop there.
         SetField(vm, "_playheadEstimateSeconds", cursorSeconds);
-        SetField(vm, "_playheadLastRealSeconds", cursorSeconds);
+        SetField(vm, "_playheadLastRealSeconds", rawSeconds);
         SetField(vm, "_playheadValid", true);
         SetField(vm, "_playheadPausedSettled", true);
         SetField(vm, "_playheadWasPlaying", false);

--- a/tests/UI/Features/Main/PlayheadResumeFromCursorTests.cs
+++ b/tests/UI/Features/Main/PlayheadResumeFromCursorTests.cs
@@ -176,6 +176,30 @@ public class PlayheadResumeFromCursorTests : IDisposable
     }
 
     [AvaloniaFact]
+    public void PauseWindDown_OnceSettled_AlignsThePlayerWithTheCursor()
+    {
+        // The preferred moment for the alignment seek is the pause settle, not the play: aligned
+        // while paused, mpv has the whole pause to re-prime and play stays a hot, instant
+        // unpause. Seeking at play time started the audio output starved - a brief stutter,
+        // then a forward hop when the clock recovered.
+        var (vm, vp, player) = MakeViewModelWithPlayer(cursorSeconds: 1.0, rawSeconds: 1.18);
+        SetField(vm, "_playheadPausedSettled", false); // the wind-down has just come to rest
+
+        Assert.Equal(1.0, Tick(vm, vp, isPlaying: false), 3); // the settle tick holds the cursor...
+        Assert.Equal(1, player.SeekCount); // ...and moves mpv onto it instead (#12740 intact)
+        Assert.Equal(1.0, player.SeekTarget ?? -1, 4);
+
+        player.LandSeek();
+        Assert.Equal(1.0, Tick(vm, vp, isPlaying: false), 3); // pin releases onto the cursor spot
+
+        // Play much later: everything is already aligned, so no seek and no cold start.
+        vm.CancelPausePlayheadFreeze();
+        Assert.Equal(1, player.SeekCount);
+        player.PlayOrPause();
+        Assert.Equal(1.0, Tick(vm, vp, isPlaying: true), 3);
+    }
+
+    [AvaloniaFact]
     public void ResumeAfterPause_WithinAFrame_DoesNotSeek()
     {
         // A residual too small to see is not worth an hr-seek on every resume.


### PR DESCRIPTION
Follow-up to #14523 / PR #14528: a play command no longer started from the visible waveform cursor, with a jump and a stutter at every play.

### Two separate problems, both fixed

**1. The pause residual (small, fixed by the first three commits).** While paused the cursor holds where the user paused while mpv settles a wind-down away from it (#12740). Every play request now funnels through a seek that puts the paused player onto the drawn cursor - preferably at pause-settle time (so play is a hot unpause), with a play-time fallback - and the playhead pin's arrival is gated on mpv's seek-restart signal, because `Position` reads as the seek target while paused, flips back to the stale clock when the unpause clears that cache, and only then lands. Tracing showed real residuals of up to 256 ms, so this earns its keep.

**2. The jump itself: a starved UI timer (last commit).** The jump survived every estimate correction because the UI thread stopped ticking for 100-1000 ms right after each play (and in a 333 ms rhythm while paused), so the first tick afterwards had to jump the cursor onto mpv's clock; the frozen UI was the stutter. Only with the native mpv window (`mpv-wid`, the Windows default) - the OpenGL and software players were clean.

Measured, not guessed: every call on the play path and in SE's timers was sub-millisecond; GC pause and UI-thread JIT counters were zero inside the stalls; Avalonia rendering/composition modes, mpv output paths and swap-chain model, mpv input handling, cross-thread input-queue detachment and undocking the video all changed nothing; stall-time minidumps showed the UI thread *idle in `GetMessage`* with the tick overdue and mpv's threads idle too. A background thread posting a no-op to the dispatcher every 10 ms after play made the stall vanish: the Win32 timer message a `DispatcherTimer` rides on stops waking the message loop while mpv owns a window in the process, but a posted message wakes it at once.

`UiTickPump` drives the cursor tick by posting from its own thread (coalescing, never a backlog); executing a posted tick also promotes the dispatcher's other due timers, so the 50 ms position/display timers stop freezing as well. Follow-up: the dialogs with their own waveform get the same treatment in a separate PR.

| automated run (6 play cycles) | play -> first cursor tick (ms) | long gaps >=100 ms |
|---|---|---|
| native, before | 1, 234, 97, 283, 138, 329 | 73 |
| native, with pump | 14, 1, 16, 27, 16, 13 | 4 (all at video load) |
| native, with pump, 2nd run | 14, 0, 5, 16, 16, 16 | 6 |
| OpenGL, with pump | 15, 49, 15, 55, 17, 49 | 10 |

### Tests
`PlayheadResumeFromCursorTests` (9 headless tests, async-seek fake modelling the paused-value cache and restart signal) plus the existing playhead/player suites pass; the full UI suite has the same 25 pre-existing failures as main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
