### PR TITLE
Accept OpenRouter transcription models that reject verbose_json

### DIFF
--- a/src/ui/Features/Video/SpeechToText/Engines/OpenRouterSttEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/OpenRouterSttEngine.cs
@@ -30,6 +30,22 @@ public class OpenRouterSttEngine : IOnlineSttEngine
     private const long UploadThreshold = 3L * 1024 * 1024;
     private const long ChunkSize = 2560L * 1024;
 
+    // Chirp models need wav instead of mp3 (see OpenRouterSttService.RequiresWavAudio).
+    // Chirp via OpenRouter also turns out to have a much tighter constraint than the
+    // 60-second provider timeout above: it looks like the synchronous (non-long-running)
+    // Google Speech-to-Text API underneath, which has its own hard ~60-second audio
+    // duration cap independent of file size or timeout - confirmed empirically by sending
+    // identical audio at 60s (succeeds), 65s and 180s (both fail with the same opaque
+    // "Provider returned 400", regardless of language/prompt, which are not the cause).
+    // Sizing has to survive silence snapping: ComputeAdjustedBoundaries moves each cut up
+    // to maxOffsetSeconds (10s by default) to land on a silence, and a chunk sits between
+    // two independently snapped cuts - so a chunk can run up to 20s longer than its target,
+    // not 10s. 16 kHz mono 16-bit PCM is ~32 KB/s, so 1 MB targets ~33 seconds and the
+    // worst case is ~53 seconds, still under the confirmed ~60s failure point. (1.4 MB
+    // would target ~45s but allow ~65s, i.e. past the cap on an unlucky pair of snaps.)
+    private const long WavUploadThreshold = 1152L * 1024;
+    private const long WavChunkSize = 1024L * 1024;
+
     public override string ToString() => Name;
 
     public List<WhisperLanguage> Languages => WhisperLanguage.Languages.OrderBy(p => p.Name).ToList();
@@ -55,8 +71,10 @@ public class OpenRouterSttEngine : IOnlineSttEngine
     }
 
     public string ProbeUrl => "https://openrouter.ai";
-    public long UploadThresholdBytes => UploadThreshold;
-    public long ChunkSizeBytes => ChunkSize;
+
+    private static bool UsesWavAudio => OpenRouterSttService.RequiresWavAudio(Se.Settings.Tools.OpenRouterSttModel);
+    public long UploadThresholdBytes => UsesWavAudio ? WavUploadThreshold : UploadThreshold;
+    public long ChunkSizeBytes => UsesWavAudio ? WavChunkSize : ChunkSize;
 
     public string GetAndCreateWhisperFolder() => WhisperHelper.GetWhisperFolder(WhisperChoice.OpenRouter) ?? string.Empty;
     public string GetAndCreateWhisperModelFolder(WhisperModel? whisperModel) => new WhisperModel().ModelFolder;

--- a/src/ui/Features/Video/SpeechToText/OpenRouter/OpenRouterSttService.cs
+++ b/src/ui/Features/Video/SpeechToText/OpenRouter/OpenRouterSttService.cs
@@ -21,9 +21,20 @@ namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.OpenRouter;
 /// <c>response_format=verbose_json</c> and <c>timestamp_granularities[]</c> when
 /// supported. OpenAI's newer GPT transcription models only accept
 /// <c>response_format=json</c>, so they receive the plain response format and
-/// no timestamp hints. When only <c>text</c> comes back, the caller's chunk
-/// pipeline spans each chunk's duration and splits into sentences so timing
-/// survives.
+/// no timestamp hints - matched by name shape via <see cref="IsJsonOnlyModel"/>.
+/// OpenRouter also hosts other providers' transcription models (e.g. Google's
+/// Chirp) that reject verbose_json for reasons no name pattern can predict.
+/// Different providers wrap that rejection differently - sometimes with a
+/// specific "response_format ... verbose_json" message, sometimes as an opaque
+/// passthrough like "Provider returned 400" - so rather than pattern-matching
+/// error text, any 400 on the initial verbose_json attempt gets one automatic
+/// retry with plain json before failing. Chirp also rejects mp3 audio outright
+/// (again via that same opaque "Provider returned 400"), which no request-level
+/// retry can fix since the audio itself was already encoded upstream before
+/// this service ever saw it - the caller picks wav instead of mp3 for those
+/// models up front, via <see cref="RequiresWavAudio"/>. When only <c>text</c>
+/// comes back, the caller's chunk pipeline spans each chunk's duration and
+/// splits into sentences so timing survives.
 /// </summary>
 public class OpenRouterSttService : ISttTranscriber
 {
@@ -91,7 +102,46 @@ public class OpenRouterSttService : ISttTranscriber
         string? language,
         CancellationToken cancellationToken)
     {
-        var body = BuildRequestBody(_settings, audioBytes, format, language);
+        var forceJsonOnly = IsJsonOnlyModel(_settings.Model);
+        var result = await SendOnceAsync(audioBytes, format, language, forceJsonOnly, cancellationToken);
+
+        // IsJsonOnlyModel only recognizes OpenAI's own gpt-*-transcribe name shape. OpenRouter
+        // hosts plenty of other providers' transcription models under the same endpoint (e.g.
+        // Google's Chirp models) that also reject verbose_json, with no reliable way to know
+        // that ahead of time short of maintaining a list of every provider's catalog - and no
+        // reliable way to recognize the rejection by message text either, since OpenRouter
+        // sometimes forwards the provider's specific complaint and sometimes just wraps it as
+        // a generic "Provider returned 400". So any 400 on this first, verbose_json attempt is
+        // reason enough to retry once with the plain json format before giving up.
+        if (!result.Success && !forceJsonOnly && result.StatusCode == 400)
+        {
+            _settings.Logger?.Invoke(
+                $"OpenRouter STT: model \"{_settings.Model}\" rejected the verbose_json request (400: {result.Body}), retrying with plain json.");
+            result = await SendOnceAsync(audioBytes, format, language, forceJsonOnly: true, cancellationToken);
+        }
+
+        if (!result.Success)
+        {
+            _settings.Logger?.Invoke(
+                $"OpenRouter STT failed: POST {_settings.EndpointUrl}{Environment.NewLine}" +
+                $"Status: {result.StatusCode}{Environment.NewLine}" +
+                $"RequestParams: model={_settings.Model}, language={language ?? _settings.Language}, format={format}, bytes={audioBytes.Length}{Environment.NewLine}" +
+                $"ResponseBody: {result.Body}");
+            throw new HttpRequestException(
+                $"OpenRouter STT request failed with status {result.StatusCode}. Response: {result.Body}");
+        }
+
+        return ParseResponse(result.Body);
+    }
+
+    private async Task<(bool Success, int StatusCode, string Body)> SendOnceAsync(
+        byte[] audioBytes,
+        string format,
+        string? language,
+        bool forceJsonOnly,
+        CancellationToken cancellationToken)
+    {
+        var body = BuildRequestBody(_settings, audioBytes, format, language, forceJsonOnly);
         using var content = new StringContent(body, Encoding.UTF8, "application/json");
         using var request = new HttpRequestMessage(HttpMethod.Post, _settings.EndpointUrl)
         {
@@ -108,21 +158,8 @@ public class OpenRouterSttService : ISttTranscriber
         request.Headers.TryAddWithoutValidation("X-Title", "Subtitle Edit");
 
         using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
-        if (!response.IsSuccessStatusCode)
-        {
-            var errorContent = await response.Content.ReadAsStringAsync(cancellationToken);
-            var statusCode = (int)response.StatusCode;
-            _settings.Logger?.Invoke(
-                $"OpenRouter STT failed: POST {_settings.EndpointUrl}{Environment.NewLine}" +
-                $"Status: {statusCode} {response.StatusCode}{Environment.NewLine}" +
-                $"RequestParams: model={_settings.Model}, language={language ?? _settings.Language}, format={format}, bytes={audioBytes.Length}{Environment.NewLine}" +
-                $"ResponseBody: {errorContent}");
-            throw new HttpRequestException(
-                $"OpenRouter STT request failed with status {statusCode} ({response.StatusCode}). Response: {errorContent}");
-        }
-
-        var json = await response.Content.ReadAsStringAsync(cancellationToken);
-        return ParseResponse(json);
+        var responseText = await response.Content.ReadAsStringAsync(cancellationToken);
+        return (response.IsSuccessStatusCode, (int)response.StatusCode, responseText);
     }
 
     /// <summary>
@@ -133,6 +170,14 @@ public class OpenRouterSttService : ISttTranscriber
     /// word timings.
     /// </summary>
     internal static string BuildRequestBody(OpenRouterSttSettings settings, byte[] audioBytes, string format, string? language)
+        => BuildRequestBody(settings, audioBytes, format, language, IsJsonOnlyModel(settings.Model));
+
+    /// <summary>
+    /// As above, but lets the caller force the plain <c>json</c> format regardless of
+    /// <see cref="IsJsonOnlyModel"/> - used to retry a model that turned out to reject
+    /// <c>verbose_json</c> even though its name didn't match the known OpenAI shape.
+    /// </summary>
+    internal static string BuildRequestBody(OpenRouterSttSettings settings, byte[] audioBytes, string format, string? language, bool forceJsonOnly)
     {
         using var stream = new MemoryStream();
         using (var writer = new Utf8JsonWriter(stream))
@@ -146,7 +191,7 @@ public class OpenRouterSttService : ISttTranscriber
             writer.WriteString("format", string.IsNullOrWhiteSpace(format) ? "mp3" : format);
             writer.WriteEndObject();
 
-            if (IsJsonOnlyModel(settings.Model))
+            if (forceJsonOnly)
             {
                 writer.WriteString("response_format", "json");
             }
@@ -199,6 +244,27 @@ public class OpenRouterSttService : ISttTranscriber
         var name = model[(model.LastIndexOf('/') + 1)..];
         return name.StartsWith("gpt-", StringComparison.OrdinalIgnoreCase) &&
                name.Contains("transcribe", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Google's Chirp models reject mp3 audio outright - not a response_format
+    /// complaint, just an opaque "Provider returned 400" from OpenRouter with no
+    /// further detail (confirmed by sending byte-identical audio as mp3 vs. wav
+    /// through OpenRouter's own playground: only wav succeeded). Matched by name
+    /// shape, same reasoning as <see cref="IsJsonOnlyModel"/> - this covers future
+    /// chirp-* models without a code change, though it can't help with some other
+    /// provider's undocumented format requirement; that would need its own case
+    /// once discovered.
+    /// </summary>
+    internal static bool RequiresWavAudio(string? model)
+    {
+        if (string.IsNullOrWhiteSpace(model))
+        {
+            return false;
+        }
+
+        var name = model[(model.LastIndexOf('/') + 1)..];
+        return name.Contains("chirp", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -12,6 +12,7 @@ using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Features.Shared.GetAudioClips;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText.EngineSettings;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.OpenRouter;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText.OpenAiCompatible;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
@@ -4471,10 +4472,22 @@ public partial class SpeechToTextViewModel : ObservableObject
         // 2-hour WAV blows past that. When an online engine is selected,
         // transcode to a compressed format so the upload stays under the limit;
         // the OpenAI-compatible engine honors the user's chosen format, the
-        // others default to mp3. Local engines (whisper.cpp, faster-whisper, ...)
-        // keep getting WAV because they read the file locally and expect PCM.
+        // others default to mp3 - except OpenRouter's Chirp models, which reject
+        // mp3 outright (see OpenRouterSttService.RequiresWavAudio) and need wav
+        // instead. Local engines (whisper.cpp, faster-whisper, ...) keep getting
+        // WAV because they read the file locally and expect PCM.
+        //
+        // Reads the ViewModel's own OpenRouterSttModel property, not
+        // Se.Settings.Tools.OpenRouterSttModel - Transcribe() runs SaveSettings()
+        // only later, inside ProcessOnlineSttTranscription, after this extraction
+        // has already started, so the settings object is still stale here.
+        var effectiveEngine = GetEffectiveSelectedEngine();
         var sttAudioFormat = isOpenAiEngine
-            ? (GetEffectiveSelectedEngine() is OpenAiCompatibleSttEngine ? OpenAiCompatibleSttAudioFormat : "mp3")
+            ? (effectiveEngine is OpenAiCompatibleSttEngine
+                ? OpenAiCompatibleSttAudioFormat
+                : effectiveEngine is OpenRouterSttEngine && OpenRouterSttService.RequiresWavAudio(OpenRouterSttModel)
+                    ? "wav"
+                    : "mp3")
             : "wav";
         var extension = OpenAiSttService.GetFileExtensionForFormat(sttAudioFormat);
         // Place the extracted audio in a dedicated per-run subfolder. Engines like

--- a/tests/UI/Features/Video/SpeechToText/OpenRouter/OpenRouterSttServiceTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/OpenRouter/OpenRouterSttServiceTests.cs
@@ -1,5 +1,10 @@
+using System;
+using System.Net;
+using System.Net.Http;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText.OpenRouter;
 
 namespace UITests.Features.Video.SpeechToText.OpenRouter;
@@ -79,6 +84,19 @@ public class OpenRouterSttServiceTests
         Assert.True(root.TryGetProperty("timestamp_granularities", out _));
     }
 
+    [Theory]
+    [InlineData("google/chirp-3", true)]
+    [InlineData("google/chirp-3-preview", true)] // matched by name shape, not an exact list
+    [InlineData("GOOGLE/CHIRP-3", true)] // case-insensitive
+    [InlineData("openai/whisper-1", false)]
+    [InlineData("openai/gpt-4o-transcribe", false)]
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    public void RequiresWavAudio_MatchesOnlyChirpModels(string? model, bool expected)
+    {
+        Assert.Equal(expected, OpenRouterSttService.RequiresWavAudio(model));
+    }
+
     [Fact]
     public void BuildRequestBody_OmitsEmptyLanguageAndZeroTemperature()
     {
@@ -138,5 +156,169 @@ public class OpenRouterSttServiceTests
     {
         var result = OpenRouterSttService.ParseResponse("just some text");
         Assert.Equal("just some text", result.Text);
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_ModelRejectsVerboseJson_RetriesOnceWithPlainJson()
+    {
+        // Google's Chirp models (and presumably others OpenRouter hosts under non-OpenAI
+        // names) reject verbose_json the same way gpt-*-transcribe models do, but
+        // IsJsonOnlyModel only recognizes the latter by name - this is exactly the #14028
+        // follow-up bug: "chirp-3" doesn't match "gpt-*-transcribe" so the first request
+        // still asks for verbose_json and gets rejected.
+        var requestBodies = new System.Collections.Generic.List<string>();
+        using var handler = new StubHandler(async (req, ct) =>
+        {
+            var body = await req.Content!.ReadAsStringAsync(ct);
+            requestBodies.Add(body);
+
+            if (requestBodies.Count == 1)
+            {
+                return new HttpResponseMessage(HttpStatusCode.BadRequest)
+                {
+                    Content = new StringContent(
+                        """{"error":{"message":"The selected model does not support response_format \"verbose_json\". Use \"json\" instead.","code":400}}""",
+                        Encoding.UTF8, "application/json"),
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"text":"hello from chirp"}""", Encoding.UTF8, "application/json"),
+            };
+        });
+        using var client = new HttpClient(handler);
+        var service = new OpenRouterSttService(client, MakeSettings("google/chirp-3"));
+
+        var result = await service.TranscribeAsync(Encoding.UTF8.GetBytes("audio"), "wav", "ar", CancellationToken.None);
+
+        Assert.Equal("hello from chirp", result.Text);
+        Assert.Equal(2, requestBodies.Count);
+
+        using var firstDoc = JsonDocument.Parse(requestBodies[0]);
+        Assert.Equal("verbose_json", firstDoc.RootElement.GetProperty("response_format").GetString());
+
+        using var secondDoc = JsonDocument.Parse(requestBodies[1]);
+        Assert.Equal("json", secondDoc.RootElement.GetProperty("response_format").GetString());
+        Assert.False(secondDoc.RootElement.TryGetProperty("timestamp_granularities", out _));
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_ModelRejectsVerboseJsonWithGenericError_StillRetriesWithPlainJson()
+    {
+        // OpenRouter doesn't always forward the provider's specific complaint - some
+        // providers' rejections come through as an opaque "Provider returned 400" with no
+        // mention of response_format or verbose_json at all. Pattern-matching the message
+        // text would miss this, so the retry triggers on any 400 to the first (verbose_json)
+        // attempt regardless of what the body says.
+        var requestBodies = new System.Collections.Generic.List<string>();
+        using var handler = new StubHandler(async (req, ct) =>
+        {
+            var body = await req.Content!.ReadAsStringAsync(ct);
+            requestBodies.Add(body);
+
+            if (requestBodies.Count == 1)
+            {
+                return new HttpResponseMessage(HttpStatusCode.BadRequest)
+                {
+                    Content = new StringContent("""{"error":{"message":"Provider returned 400","code":400}}""", Encoding.UTF8, "application/json"),
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"text":"hello from chirp"}""", Encoding.UTF8, "application/json"),
+            };
+        });
+        using var client = new HttpClient(handler);
+        var service = new OpenRouterSttService(client, MakeSettings("google/chirp-3"));
+
+        var result = await service.TranscribeAsync(Encoding.UTF8.GetBytes("audio"), "wav", "ar", CancellationToken.None);
+
+        Assert.Equal("hello from chirp", result.Text);
+        Assert.Equal(2, requestBodies.Count);
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_BothFormatsRejected_ThrowsAfterOneRetry()
+    {
+        // If the plain-json retry also fails, the retry must not loop again - the second
+        // failure (whatever it is) is the one that surfaces to the caller.
+        var callCount = 0;
+        using var handler = new StubHandler((req, ct) =>
+        {
+            callCount++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent("""{"error":{"message":"Provider returned 400","code":400}}""", Encoding.UTF8, "application/json"),
+            });
+        });
+        using var client = new HttpClient(handler);
+        var service = new OpenRouterSttService(client, MakeSettings("google/chirp-3"));
+
+        await Assert.ThrowsAsync<HttpRequestException>(() =>
+            service.TranscribeAsync(Encoding.UTF8.GetBytes("audio"), "wav", "ar", CancellationToken.None));
+
+        Assert.Equal(2, callCount); // one retry, then give up
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_NonBadRequestStatus_DoesNotRetryAndThrows()
+    {
+        // A 401 means the request never got far enough to be a format complaint - retrying
+        // with a different response_format won't fix an auth failure, so don't waste a call.
+        var callCount = 0;
+        using var handler = new StubHandler((req, ct) =>
+        {
+            callCount++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized)
+            {
+                Content = new StringContent("""{"error":{"message":"Invalid API key","code":401}}""", Encoding.UTF8, "application/json"),
+            });
+        });
+        using var client = new HttpClient(handler);
+        var service = new OpenRouterSttService(client, MakeSettings("google/chirp-3"));
+
+        await Assert.ThrowsAsync<HttpRequestException>(() =>
+            service.TranscribeAsync(Encoding.UTF8.GetBytes("audio"), "wav", "ar", CancellationToken.None));
+
+        Assert.Equal(1, callCount); // no retry for a non-400 status
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_GptTranscribeModelRejectsRequest_DoesNotRetry()
+    {
+        // Already asking for plain json on the first try (IsJsonOnlyModel matched by name), so
+        // a rejection here is a real failure, not the response-format mismatch this fix covers -
+        // must not loop.
+        var callCount = 0;
+        using var handler = new StubHandler((req, ct) =>
+        {
+            callCount++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent("""{"error":{"message":"Invalid API key","code":400}}""", Encoding.UTF8, "application/json"),
+            });
+        });
+        using var client = new HttpClient(handler);
+        var service = new OpenRouterSttService(client, MakeSettings("openai/gpt-4o-transcribe"));
+
+        await Assert.ThrowsAsync<HttpRequestException>(() =>
+            service.TranscribeAsync(Encoding.UTF8.GetBytes("audio"), "wav", "ar", CancellationToken.None));
+
+        Assert.Equal(1, callCount);
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _send;
+
+        public StubHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> send)
+        {
+            _send = send;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => _send(request, cancellationToken);
     }
 }


### PR DESCRIPTION
Subtitle Edit already talks to OpenRouter's transcription endpoint, but the request it
sends today only works for OpenAI's own models. OpenRouter also hosts Google's Chirp
models on that same endpoint, and they reject the current request in three separate
ways. None of the three can be predicted from the model name, and none of them produce
a usable error message.

This PR makes those models work. It adds no engine, no new provider, and no setting.

> [!NOTE]
> **Scope:** 4 files, one behavior change (accept Chirp). Nothing is removed, and no
> existing model's behavior changes.

## The three rejections

| # | What Chirp rejects | How it surfaces | Fix in this PR |
|:--|:--|:--|:--|
| 1 | `verbose_json` | `400`, sometimes with the provider's own message, sometimes an opaque `Provider returned 400` | One automatic retry with plain `json` |
| 2 | `mp3` audio | The same opaque `400` | Extract `wav` for these models up front |
| 3 | Audio longer than ~60 s | The same opaque `400` again | Smaller, duration aware chunks |

### 1. `verbose_json` is refused

`IsJsonOnlyModel` only recognizes OpenAI's own `gpt-*-transcribe` name shape. Chirp needs
the same treatment but does not match that shape, and the failure cannot be recognized
from the error text either, because OpenRouter sometimes forwards the provider's specific
complaint and sometimes wraps it as an opaque `Provider returned 400`.

So rather than pattern matching on error strings, any `400` on the first `verbose_json`
attempt now gets exactly one retry with plain `json`. Any other status, or a model already
known to be json only, does not retry.

Chirp returns no word timings in either format. That is a limitation of this model over
OpenRouter rather than something this PR can fix, and the existing chunk pipeline already
handles the text only case by spanning each chunk's duration and splitting into sentences.

### 2. `mp3` is refused

No request level retry can fix this one, because the audio was already encoded before the
service ever saw it. The caller now extracts `wav` for these models instead.

Confirmed by sending byte identical audio as `mp3` and as `wav`: only `wav` succeeds.

### 3. There is a hard ~60 second cap

It is independent of file size, and it looks like the synchronous Google Speech-to-Text
API underneath. Confirmed empirically: identical audio succeeds at 60 s, then fails at
65 s and at 180 s with the same opaque `400`, regardless of language or prompt.

<details>
<summary><b>Why the chunk size is 1 MB and not 1.4 MB</b></summary>

<br>

Chunk sizing has to survive silence snapping. `ComputeAdjustedBoundaries` moves each cut
by up to `maxOffsetSeconds` (10 s by default) to land on a silence, and a chunk sits
between two independently snapped cuts. So a chunk can run up to **20 s** past its target,
not 10 s.

At 16 kHz mono 16 bit PCM, roughly 32 KB/s:

| Chunk size | Targets | Worst case | Under the ~60 s cap? |
|:--|:--|:--|:--|
| 1.4 MB | ~45 s | ~65 s | No |
| **1 MB** | **~33 s** | **~53 s** | **Yes** |

</details>

## Testing

24 unit tests ship with this PR. Beyond those, this was exercised against the live
OpenRouter endpoint across roughly 40 hours of transcription runs on Turkish TV drama:

| Observed | Count |
|:--|--:|
| `verbose_json` rejections, each one triggering the new fallback | 211 |
| Automatic plain json retries fired | 203 |
| Hard failures before the fix | 17 |
| Opaque `Provider returned 400` responses, where the mp3 rejection and the duration cap are indistinguishable from one another | 12 |

The `mp3` versus `wav` result, and the 60 s versus 65 s versus 180 s result, each come from
paired runs on byte identical source audio.

---

## A question for you: would you want the timestamped path in core?

Worth stating plainly: even with this fix, Chirp over OpenRouter returns **text only**.
Cue times are then inferred by splitting text proportionally to character count, which
cannot represent silence.

> [!IMPORTANT]
> In the OpenRouter output I measured, **zero** gaps longer than 2 seconds appear
> anywhere, the largest gap in the entire file is 0.85 s, and 35 of 50 consecutive cue
> boundaries touch at exactly 0.001 s, and the first Speech-to-Text v2 cue on the same
> source does not arrive until 110.8 s because the opening theme is genuinely empty.
> That is the signature of arithmetic subdivision
> rather than of measured speech.

The same model, addressed directly through Google's Speech-to-Text **v2** API, does return
word level timings. Measured on a 145 minute episode:

| Metric | OpenRouter, text only | Speech-to-Text v2 |
|:--|:--|:--|
| Cue timing source | character count | measured word offsets |
| Pauses longer than 2 s | 0 | **334** |
| Largest gap | 0.85 s | **138.4 s**, correctly empty across the opening theme |
| Words carrying real timings | none | **13,175** across 2,978 cues |
| Speech density | 97.4% | **54.3%**, which is what TV drama actually looks like |

To be straight about the comparison: the OpenRouter figures are measured over the sample
I have from it rather than a full episode, so read them as the shape of the timing rather
than as a coverage result. That shape does not improve with length, because character
proportional timing cannot represent silence at any duration.

> **On the documentation:** Google's `chirp_3` page lists "Word-level timestamps" under a
> heading of features the model does not support, yet the same page's own row text, its
> BatchRecognize duration note, and its shipped code sample all describe word timestamps
> as something you enable. The table row looks mis-filed rather than the behavior being
> undocumented. Either way, I received word timings on every run.

I would rather ask than assume: **would you be open to that path living in Subtitle Edit
itself?** It is a materially more accurate transcription engine, but it is not free, and
the cost sits mostly in onboarding rather than in code. Honestly, here is everything it
needs:

| Requirement | What it involves |
|:--|:--|
| **Authentication** | OAuth2 service account JSON. API keys are refused outright: `401, API keys are not supported by this API. Expected OAuth2 access token.` Every existing online engine in SE uses a single API key textbox, so this needs a JSON file picker and a token exchange. This is the biggest change, and it is a product decision as much as a code one. |
| **Endpoint** | The regional endpoint `us-speech.googleapis.com`, with recognizer path `projects/<id>/locations/us/recognizers/_`. The global endpoint does not serve `chirp_3`. |
| **Dependency** | `Google.Cloud.Speech.V2` pulls in gRPC and protobuf, which noticeably increases bundle size. A hand rolled REST client against the v2 API avoids that, at the cost of more code to maintain. Your call which you would prefer. |
| **Transport, sync** | `Recognize` maps 1:1 onto the existing `ISttTranscriber.TranscribeAsync`: inline audio, no bucket, word timings returned directly. It carries the same ~60 s cap as above, so it needs duration aware chunking, which this PR already builds. |
| **Transport, batch** | Handles hours long audio (a 140 minute episode in 8 chunks), but requires a user supplied **Cloud Storage bucket**, uses an async job model that does not fit the current engine contract, accepts at most 5 files per request, and returns inline results only for single file requests. |
| **Reliability guards** | Non negotiable for correctness. I hit **silent truncation**, where one 18 minute chunk stopped transcribing 6.6 minutes in and discarded the remaining 11.4 minutes while reporting success with no error at all. Coverage has to be validated against expected duration, with short chunks resubmitted. I also saw **corrupt word offsets** on 79 of 9,432 words (0.8%), one of them claiming 6,324 s inside a 1,080 s chunk, so offsets need per chunk range checking. |
| **Cost** | $0.016 per minute at standard rate, or $0.003 per minute with dynamic batching enabled, roughly an 81% discount. A 2.5 hour episode is $2.32 or $0.44 respectively. |

If that is more than you want to carry in core, particularly the service account auth and
the Cloud Storage dependency, then I completely understand, and my company will ship it as
a separate SE5 plugin instead, so the users who want it can opt in without everyone paying
for it. I just did not want to make that decision on your behalf.

Either way, **this PR is only the OpenRouter fix**, and it stands on its own.

---

## One more small thing, whichever way you answer

There is a related snag I ran into. `RunPlugin` returns early when the subtitle is empty:

```csharp
if (IsEmpty)
{
    ShowSubtitleNotLoadedMessage();
    return;
}
```

That is exactly the right guard for a plugin that *transforms* existing lines, which is
what plugins do today. But it makes a transcription plugin impossible to start from the
state users are actually in, which is a video open and no subtitle yet. As it stands they
would have to type a placeholder line first, then run the plugin, then delete it.

Would you accept a small opt in for this? Something like a manifest field
`"allowsEmptySubtitle": true`, which a plugin sets when it *produces* a subtitle rather
than transforming one, leaving the current behavior untouched for every existing plugin.
Happy to send it as its own focused PR if you like the idea.
