### PR TITLE
Drive every waveform/position timer through UiTickPump

### DIFF
--- a/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
+++ b/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
@@ -180,7 +180,7 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
         private readonly Button _buttonFullScreen;
         private readonly Button _buttonFullScreenCollapse;
         private readonly Icon _iconVolume;
-        private DispatcherTimer? _positionTimer;
+        private UiTickPump? _positionTimer; // posted ticks, not a DispatcherTimer - see UiTickPump
         private int _slowPollCounter;
         private IVideoPlayer _videoPlayerInstance;
         private string _videoFileName;
@@ -1075,7 +1075,7 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
 
         private void StartPositionTimer()
         {
-            _positionTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(50) };
+            _positionTimer = new UiTickPump(TimeSpan.FromMilliseconds(50));
             _positionTimer.Tick += (s, e) =>
             {
                 // Duration and IsPlaying change infrequently — poll every 5th tick (~250 ms)

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/AssaApplyAdvancedEffectViewModel.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/AssaApplyAdvancedEffectViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -49,7 +49,7 @@ public partial class AssaApplyAdvancedEffectViewModel : ObservableObject
     private WavePeakData2? _wavePeaks;
     private Subtitle _subtitle;
     private string? _videoFileName;
-    private DispatcherTimer _positionTimer = new DispatcherTimer();
+    private UiTickPump _positionTimer = new(TimeSpan.FromMilliseconds(750)); // posted ticks, not a DispatcherTimer - see UiTickPump
     private List<SubtitleLineViewModel> _subtitleLines = new List<SubtitleLineViewModel>();
     private List<SubtitleLineViewModel> _selectedSubtitleLines = new List<SubtitleLineViewModel>();
     private FfmpegMediaInfo2? _mediaInfo;
@@ -165,7 +165,7 @@ public partial class AssaApplyAdvancedEffectViewModel : ObservableObject
 
     private void StartTitleTimer()
     {
-        _positionTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(750) };
+        _positionTimer = new UiTickPump(TimeSpan.FromMilliseconds(750));
         _positionTimer.Tick += async (s, e) =>
         {
             if (_mpvPlayer == null)

--- a/src/ui/Features/Assa/AssaApplyCustomOverrideTags/AssaApplyCustomOverrideTagsViewModel.cs
+++ b/src/ui/Features/Assa/AssaApplyCustomOverrideTags/AssaApplyCustomOverrideTagsViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -51,7 +51,7 @@ public partial class AssaApplyCustomOverrideTagsViewModel : ObservableObject
     private string? _header;
     private string? _footer;
     private string? _videoFileName;
-    private DispatcherTimer _positionTimer = new DispatcherTimer();
+    private UiTickPump _positionTimer = new(TimeSpan.FromMilliseconds(500)); // posted ticks, not a DispatcherTimer - see UiTickPump
     private List<SubtitleLineViewModel> _subtitleLines = new List<SubtitleLineViewModel>();
     private List<SubtitleLineViewModel> _selectedSubtitleLines = new List<SubtitleLineViewModel>();
 
@@ -122,7 +122,7 @@ public partial class AssaApplyCustomOverrideTagsViewModel : ObservableObject
 
     private void StartTitleTimer()
     {
-        _positionTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(500) };
+        _positionTimer = new UiTickPump(TimeSpan.FromMilliseconds(500));
         _positionTimer.Tick += (s, e) =>
         {
             if (_mpvPlayer == null)

--- a/src/ui/Features/Main/Layout/InitWaveform.cs
+++ b/src/ui/Features/Main/Layout/InitWaveform.cs
@@ -730,7 +730,7 @@ public class InitWaveform
             (timeCodePosition.IsKeyboardFocusWithin && vm.GetVideoPlayerControl()?.IsPlaying != true) ||
             Environment.TickCount64 - positionTextEditedTicks < 500;
 
-        var positionTextTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(100) };
+        var positionTextTimer = new UiTickPump(TimeSpan.FromMilliseconds(100)); // posted ticks, not a DispatcherTimer - see UiTickPump
         positionTextTimer.Tick += (_, _) =>
         {
             var vp = vm.GetVideoPlayerControl();

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -678,7 +678,7 @@ public partial class MainViewModel :
     private bool _reapplyingReadOnlyReference;
     private bool _waveformBufferNoLayers;
     private HashSet<int>? _waveformBufferVisibleLayers;
-    private DispatcherTimer _positionTimer = new();
+    private UiTickPump _positionTimer = new(TimeSpan.FromMilliseconds(50)); // posted ticks, not a DispatcherTimer - see UiTickPump
     private DispatcherTimer _slowTimer = new();
     private UiTickPump? _cursorTimer; // ~60 fps; drives only the waveform/video playhead cursor (a posted tick, not a DispatcherTimer - see UiTickPump)
 
@@ -29941,7 +29941,7 @@ public partial class MainViewModel :
         Subtitles.CollectionChanged += OnSubtitlesCollectionChangedForMpv;
         foreach (var item in Subtitles)
             item.PropertyChanged += OnSubtitleItemChangedForMpv;
-        _positionTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(50) };
+        _positionTimer = new UiTickPump(TimeSpan.FromMilliseconds(50));
         _positionTimer.Tick += (s, e) =>
         {
             // update audio visualizer position if available

--- a/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointViewModel.cs
+++ b/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointViewModel.cs
@@ -68,7 +68,7 @@ public partial class SetSyncPointViewModel : ObservableObject
     // starts on the file's default track, so it has to be re-applied here or a dubbed track plays
     // while the user syncs against the original (issue #13995).
     private int _audioTrackId = -1;
-    private DispatcherTimer _positionTimer = new DispatcherTimer();
+    private UiTickPump _positionTimer = new(TimeSpan.FromMilliseconds(150)); // posted ticks, not a DispatcherTimer - see UiTickPump
     private List<SubtitleLineViewModel> _subtitleLines = new List<SubtitleLineViewModel>();
     private VideoPreviewSubtitleContext _previewContext = VideoPreviewSubtitleContext.Default;
     private bool _updateAudioVisualizer;
@@ -199,7 +199,7 @@ public partial class SetSyncPointViewModel : ObservableObject
 
     private void StartTitleTimer()
     {
-        _positionTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(150) };
+        _positionTimer = new UiTickPump(TimeSpan.FromMilliseconds(150));
         _positionTimer.Tick += (s, e) =>
         {
             UpdateAudioVisualizer(VideoPlayerControl.VideoPlayer, AudioVisualizer, SelectedParagraphIndex);

--- a/src/ui/Features/Sync/VisualSync/VisualSyncViewModel.cs
+++ b/src/ui/Features/Sync/VisualSync/VisualSyncViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -53,7 +53,7 @@ public partial class VisualSyncViewModel : ObservableObject
 
     private string? _videoFileName;
     private string? _wavePeaksVideoFileName;
-    private DispatcherTimer _positionTimer = new DispatcherTimer();
+    private UiTickPump _positionTimer = new(TimeSpan.FromMilliseconds(150)); // posted ticks, not a DispatcherTimer - see UiTickPump
     private List<SubtitleLineViewModel> _subtitleLines = new List<SubtitleLineViewModel>();
     private VideoPreviewSubtitleContext _previewContext = VideoPreviewSubtitleContext.Default;
     private bool _updateAudioVisualizer;
@@ -200,7 +200,7 @@ public partial class VisualSyncViewModel : ObservableObject
 
     private void StartTitleTimer()
     {
-        _positionTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(150) };
+        _positionTimer = new UiTickPump(TimeSpan.FromMilliseconds(150));
         _positionTimer.Tick += (s, e) =>
         {
             UpdateAudioVisualizer(VideoPlayerControlLeft.VideoPlayer, AudioVisualizerLeft, SelectedParagraphLeftIndex);

--- a/src/ui/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesViewModel.cs
+++ b/src/ui/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -24,7 +24,7 @@ public partial class BeautifyTimeCodesViewModel : ObservableObject, IDisposable
     public bool OkPressed { get; private set; }
 
     private readonly System.Timers.Timer _timerUpdatePreview;
-    private Avalonia.Threading.DispatcherTimer? _positionTimer;
+    private UiTickPump? _positionTimer; // posted ticks, not a DispatcherTimer - see UiTickPump
     private volatile bool _dirty;
     private volatile bool _updateInProgress;
     private readonly Lock _timerLock = new Lock();
@@ -599,7 +599,7 @@ public partial class BeautifyTimeCodesViewModel : ObservableObject, IDisposable
 
     private void StartPositionTimer()
     {
-        _positionTimer = new Avalonia.Threading.DispatcherTimer { Interval = TimeSpan.FromMilliseconds(100) };
+        _positionTimer = new UiTickPump(TimeSpan.FromMilliseconds(100));
         _positionTimer.Tick += (s, e) =>
         {
             if (AudioVisualizerOriginal != null && AudioVisualizerBeautified != null)

--- a/src/ui/Features/Video/CutVideo/CutVideoViewModel.cs
+++ b/src/ui/Features/Video/CutVideo/CutVideoViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -88,7 +88,7 @@ public partial class CutVideoViewModel : ObservableObject
     // shot-change writer does - coalescing the publishes so a long file cannot flood the queue.
     private readonly List<double> _keyFrameSeconds = new List<double>();
     private bool _keyFramePublishPending;
-    private DispatcherTimer _positionTimer = new DispatcherTimer();
+    private UiTickPump _positionTimer = new(TimeSpan.FromMilliseconds(150)); // posted ticks, not a DispatcherTimer - see UiTickPump
     private string _importFileName;
     private Subtitle _currentSubtitle;
     private long _lastKeyPressedMs;
@@ -220,7 +220,7 @@ public partial class CutVideoViewModel : ObservableObject
 
     private void StartTitleTimer()
     {
-        _positionTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(150) };
+        _positionTimer = new UiTickPump(TimeSpan.FromMilliseconds(150));
         _positionTimer.Tick += (s, e) =>
         {
             // Derive the index from the row the grid actually binds. SelectedSegmentIndex is

--- a/src/ui/Logic/UiTickPump.cs
+++ b/src/ui/Logic/UiTickPump.cs
@@ -22,7 +22,7 @@ namespace Nikse.SubtitleEdit.Logic;
 public sealed class UiTickPump : IDisposable
 {
     private readonly TimeSpan _interval;
-    private readonly Action _tick;
+    private Action _tick;
     private readonly DispatcherPriority _priority;
     private readonly Action _postedTick;
     private Thread? _thread;
@@ -31,13 +31,29 @@ public sealed class UiTickPump : IDisposable
 
     public UiTickPump(TimeSpan interval, Action tick, DispatcherPriority priority)
     {
-        _interval = interval;
+        _interval = interval < TimeSpan.FromMilliseconds(1) ? TimeSpan.FromMilliseconds(1) : interval;
         _tick = tick;
         _priority = priority;
         _postedTick = RunTick;
     }
 
+    /// <summary>
+    /// DispatcherTimer-shaped constructor: subscribe <see cref="Tick"/>, then <see cref="Start"/>.
+    /// Lets the position timers of the waveform dialogs swap in without restructuring.
+    /// </summary>
+    public UiTickPump(TimeSpan interval)
+        : this(interval, () => { }, DispatcherPriority.Normal)
+    {
+        _tick = () => Tick?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>Raised on the UI thread once per interval while running.</summary>
+    public event EventHandler? Tick;
+
     public bool IsRunning => _running;
+
+    /// <summary>DispatcherTimer-style alias for <see cref="IsRunning"/>.</summary>
+    public bool IsEnabled => _running;
 
     public void Start()
     {

--- a/tests/UI/Controls/VideoPlayerControlTeardownTests.cs
+++ b/tests/UI/Controls/VideoPlayerControlTeardownTests.cs
@@ -1,6 +1,7 @@
-using Avalonia.Headless.XUnit;
+﻿using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
 using Nikse.SubtitleEdit.Controls.VideoPlayer;
+using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.VideoPlayers;
 using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
 using System;
@@ -69,8 +70,8 @@ public class VideoPlayerControlTeardownTests
         public void Dispose() => DisposeCount++;
     }
 
-    private static DispatcherTimer? GetPositionTimer(VideoPlayerControl control) =>
-        (DispatcherTimer?)typeof(VideoPlayerControl)
+    private static UiTickPump? GetPositionTimer(VideoPlayerControl control) =>
+        (UiTickPump?)typeof(VideoPlayerControl)
             .GetField("_positionTimer", BindingFlags.NonPublic | BindingFlags.Instance)!
             .GetValue(control);
 
@@ -96,7 +97,7 @@ public class VideoPlayerControlTeardownTests
 
         control.CloseAndDisposePlayer();
 
-        // A running DispatcherTimer keeps the control (and through it the player) alive for
+        // A running tick pump keeps the control (and through it the player) alive for
         // the rest of the session, so leaving it enabled is the leak, not just wasted work.
         Assert.False(GetPositionTimer(control)?.IsEnabled);
     }


### PR DESCRIPTION
Follow-up to #14532, which found that with the native mpv window (`mpv-wid`, the Windows default) Avalonia's `DispatcherTimer` stops waking the UI thread's message loop for 100-1000 ms around every play/pause, and moved the waveform cursor tick to `UiTickPump` (a tick posted from its own thread).

That starvation is process-wide - it only needs mpv's window to exist - so this moves the remaining waveform/position timers onto the pump as well:

- the position timers of the dialogs with their own waveform: Cut Video, Visual Sync, Set Sync Point, Beautify Time Codes, and the two ASSA preview dialogs
- the waveform toolbar's position text timer
- the player control's 50 ms time-display timer (the frozen time display from the original #14523 report)
- the main window's 50 ms position timer

`UiTickPump` gets a `DispatcherTimer`-shaped surface (`Tick` event, `Start`/`Stop`, `IsEnabled`) so each change is a one-line type swap; the 400 ms slow timer and non-video timers are left alone.

Tests: the playhead, player-control (teardown tests updated for the new type), waveform and dialog suites pass, with only the known pre-existing `PlayheadSyncFocusTests` failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)