### PR TITLE
Let a user-assigned Alt+Space shortcut beat the Windows system menu

### DIFF
--- a/src/ui/Features/Main/MainView.cs
+++ b/src/ui/Features/Main/MainView.cs
@@ -53,6 +53,8 @@ public class MainView : ViewBase
         if (hostWindow != null)
         {
             _vm.Window = hostWindow;
+            // A user-assigned Alt+Space shortcut beats the Windows system menu (#14536).
+            UiUtil.SetWindowSystemMenuOverride(hostWindow, _vm.HasAltSpaceShortcut);
             _vm.Window.Closing += _vm.OnClosing;
             _vm.Window.Deactivated += _vm.OnWindowDeactivated;
             _vm.Window.Activated += _vm.OnWindowActivated;

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -28446,6 +28446,15 @@ public partial class MainViewModel :
         return true;
     }
 
+    /// <summary>
+    /// Alt+Space normally opens the Windows system menu (see UiUtil.TryHandleWindowSystemMenu),
+    /// but a shortcut the user bound to that chord must run instead (#14536).
+    /// </summary>
+    internal bool HasAltSpaceShortcut()
+    {
+        return _shortcutManager.HasShortcut("Alt", nameof(Key.Space));
+    }
+
     internal void OnKeyDownHandler(object? sender, KeyEventArgs keyEventArgs)
     {
         lock (_onKeyDownHandlerLock)

--- a/src/ui/Features/Options/Shortcuts/GetKeyWindow.cs
+++ b/src/ui/Features/Options/Shortcuts/GetKeyWindow.cs
@@ -23,6 +23,9 @@ public class GetKeyWindow : Window
 
         _vm = vm;
         vm.Window = this;
+
+        // The capture window must see every chord, including Alt+Space (#14536).
+        UiUtil.SetWindowSystemMenuOverride(this, () => true);
         DataContext = vm;
 
         var labelShortcutName = UiUtil.MakeLabel().WithBindText(vm, nameof(vm.ShortCutName));

--- a/src/ui/Logic/IShortcutManager.cs
+++ b/src/ui/Logic/IShortcutManager.cs
@@ -11,6 +11,7 @@ public interface IShortcutManager
     void ClearKeys();
     void RegisterShortcut(ShortCut shortcut);
     bool HasSingleKeyShortcut(string keyName);
+    bool HasShortcut(params string[] keys);
     IRelayCommand? CheckShortcuts(KeyEventArgs keyEventArgs, string activeControl);
     void ClearShortcuts();
     HashSet<Key> GetActiveKeys();

--- a/src/ui/Logic/ShortcutManager.cs
+++ b/src/ui/Logic/ShortcutManager.cs
@@ -328,6 +328,44 @@ public class ShortcutManager : IShortcutManager
         return false;
     }
 
+    /// <summary>
+    /// True when any registered shortcut is bound to exactly this chord (order-insensitive,
+    /// modifier tokens as stored: "Control", "Alt", "Shift", "Win"), regardless of which
+    /// control the shortcut is scoped to.
+    /// </summary>
+    public bool HasShortcut(params string[] keys)
+    {
+        if (keys.Length == 0)
+        {
+            return false;
+        }
+
+        foreach (var shortcut in _shortcuts)
+        {
+            if (shortcut.Keys.Count != keys.Length)
+            {
+                continue;
+            }
+
+            var all = true;
+            foreach (var key in keys)
+            {
+                if (!shortcut.Keys.Contains(key, StringComparer.OrdinalIgnoreCase))
+                {
+                    all = false;
+                    break;
+                }
+            }
+
+            if (all)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public void ClearShortcuts()
     {
         _shortcuts.Clear();

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -3564,6 +3564,25 @@ public static class UiUtil
                string.Equals(ShortcutManager.GetShortcutKey(e).ToString(), keyName, StringComparison.OrdinalIgnoreCase);
     }
 
+    private static readonly ConditionalWeakTable<Window, Func<bool>> WindowSystemMenuOverrides = new();
+
+    /// <summary>
+    /// Lets a window claim Alt+Space for itself: while <paramref name="isOverridden"/> returns
+    /// true, <see cref="TryHandleWindowSystemMenu"/> leaves the key event alone instead of
+    /// opening the Windows system menu. The main window uses this so a user-assigned Alt+Space
+    /// shortcut wins over the Windows convention (#14536), mirroring the F10 rule; the shortcut
+    /// key-capture window uses it so the chord can be recorded at all.
+    /// </summary>
+    internal static void SetWindowSystemMenuOverride(Window window, Func<bool> isOverridden)
+    {
+        WindowSystemMenuOverrides.AddOrUpdate(window, isOverridden);
+    }
+
+    internal static bool IsWindowSystemMenuOverridden(Window window)
+    {
+        return WindowSystemMenuOverrides.TryGetValue(window, out var isOverridden) && isOverridden();
+    }
+
     internal static bool TryHandleWindowSystemMenu(KeyEventArgs e, Window? window)
     {
         if (!OperatingSystem.IsWindows() || window == null)
@@ -3573,6 +3592,12 @@ public static class UiUtil
 
         if (e.Key == Key.Space && e.KeyModifiers == KeyModifiers.Alt)
         {
+            if (IsWindowSystemMenuOverridden(window))
+            {
+                return false;
+            }
+
+
             SystemMenu.Show(window);
             e.Handled = true;
             return true;

--- a/tests/UI/Logic/ShortcutsAltSpaceSystemMenuTests.cs
+++ b/tests/UI/Logic/ShortcutsAltSpaceSystemMenuTests.cs
@@ -1,0 +1,47 @@
+﻿using Avalonia.Input;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Features.Options.Shortcuts;
+using Nikse.SubtitleEdit.Logic;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// Alt+Space opens the Windows system menu by default, but a shortcut the user bound to that
+/// chord must win (#14536) - the same rule bare F10 follows for the menu bar (#12504).
+/// </summary>
+public class ShortcutsAltSpaceSystemMenuTests
+{
+    private static ShortcutManager ManagerWith(params string[] keys)
+    {
+        var manager = new ShortcutManager();
+        manager.RegisterShortcut(new ShortCut("AutoBreak", [.. keys], ShortcutCategory.General, new RelayCommand(() => { })));
+        return manager;
+    }
+
+    [Fact]
+    public void HasShortcutMatchesAltSpaceRegardlessOfOrderAndCase()
+    {
+        Assert.True(ManagerWith("Alt", "Space").HasShortcut("Alt", nameof(Key.Space)));
+        Assert.True(ManagerWith("space", "alt").HasShortcut("Alt", nameof(Key.Space)));
+    }
+
+    [Fact]
+    public void HasShortcutRejectsSupersetsSubsetsAndOtherChords()
+    {
+        Assert.False(ManagerWith("Control", "Alt", "Space").HasShortcut("Alt", nameof(Key.Space)));
+        Assert.False(ManagerWith("Space").HasShortcut("Alt", nameof(Key.Space)));
+        Assert.False(ManagerWith("Alt", "B").HasShortcut("Alt", nameof(Key.Space)));
+        Assert.False(new ShortcutManager().HasShortcut("Alt", nameof(Key.Space)));
+    }
+
+    [Fact]
+    public void DefaultShortcutsDoNotBindAltSpace()
+    {
+        // The system menu must keep working for everyone who never remapped Alt+Space.
+        var defaults = ShortcutsMain.GetDefaultShortcuts(null!);
+
+        Assert.DoesNotContain(defaults, s => s.Keys.Count == 2 &&
+            s.Keys.Contains("Alt", StringComparer.OrdinalIgnoreCase) &&
+            s.Keys.Contains("Space", StringComparer.OrdinalIgnoreCase));
+    }
+}


### PR DESCRIPTION
Fixes #14536

## Problem
Subtitle Edit opens the Windows system menu itself on Alt+Space (Avalonia does not forward the chord to the default window procedure). That handler is an app-wide tunnel-phase class handler on every `Window`, plus an explicit call in the main key handler. Both ran before the shortcut lookup and marked the event handled, so a shortcut the user bound to Alt+Space (e.g. Auto-break text) never fired and the system menu appeared instead.

## Fix
- `IShortcutManager.HasShortcut(params string[] keys)`: order- and case-insensitive exact-chord lookup.
- `UiUtil.SetWindowSystemMenuOverride(window, predicate)`: a window can claim Alt+Space for itself; `TryHandleWindowSystemMenu` then leaves the event alone so normal shortcut handling runs.
- Main window claims it while a shortcut is bound to Alt+Space (same policy as the bare-F10 menu rule from #12504).
- Shortcut key-capture window always claims it so the chord can be recorded.
- Every other window, and the main window without such a binding, keeps the Windows system menu.

## Tests
New `ShortcutsAltSpaceSystemMenuTests` cover the lookup (order/case, supersets/subsets rejected) and assert the defaults never bind Alt+Space, so the system menu stays the out-of-the-box behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
