### PR TITLE
Add Control to the macOS default shortcut for Open Subtitle Edit folder

### DIFF
--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -18,7 +18,7 @@ namespace Nikse.SubtitleEdit.Logic.Config;
 public class Se
 {
     internal const int CurrentMacOsFontMigrationVersion = 1;
-    internal const int CurrentShortcutsMigrationVersion = 2;
+    internal const int CurrentShortcutsMigrationVersion = 3;
 
     public static string Version { get; set; } = "v5.2.0-rc2";
 
@@ -489,6 +489,27 @@ public class Se
                 }
             }
         }
+
+        if (fromVersion < 3 && OperatingSystem.IsMacOS())
+        {
+            // The old macOS default Option+Shift+Cmd+D never reached the app (#14508); the default
+            // gained Control, so move users who still sit on the dead chord onto the new one.
+            foreach (var shortcut in Shortcuts)
+            {
+                if (shortcut.ActionName == nameof(MainViewModel.OpenDataFolderCommand) &&
+                    IsSameKeys(shortcut.Keys, ["Win", "Alt", "Shift", "D"]))
+                {
+                    shortcut.Keys = ["Ctrl", "Win", "Alt", "Shift", "D"];
+                }
+            }
+        }
+    }
+
+    private static bool IsSameKeys(List<string> keys, string[] expected)
+    {
+        return keys.Count == expected.Length &&
+               !keys.Except(expected, StringComparer.OrdinalIgnoreCase).Any() &&
+               !expected.Except(keys, StringComparer.OrdinalIgnoreCase).Any();
     }
 
     public static void SaveSettings()

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -1047,7 +1047,11 @@ public static class ShortcutsMain
             new(nameof(vm.FindPreviousCommand), ["Shift", nameof(Avalonia.Input.Key.F3)], ShortcutCategory.General),
             new(nameof(vm.ShowReplaceCommand), [cmd, "H"], ShortcutCategory.General),
             new(nameof(vm.ShowMultipleReplaceCommand), [cmd, "Shift", "R"], ShortcutCategory.General),
-            new(nameof(vm.OpenDataFolderCommand), [cmd, "Alt", "Shift", "D"], ShortcutCategory.General),
+            // On macOS the plain Option+Shift+Cmd+D chord never reaches the app (#14508), so add
+            // Control there; on Windows/Linux the three-modifier default stays as before.
+            new(nameof(vm.OpenDataFolderCommand), OperatingSystem.IsMacOS()
+                ? ["Ctrl", cmd, "Alt", "Shift", "D"]
+                : [cmd, "Alt", "Shift", "D"], ShortcutCategory.General),
             new(nameof(vm.SaveLanguageFileCommand), [cmd, "Alt", "Shift", "L"], ShortcutCategory.General),
             new(nameof(vm.CommandFileNewCommand), [cmd, "N"], ShortcutCategory.General),
             new(nameof(vm.CommandFileOpenCommand), [cmd, "O"], ShortcutCategory.General),

--- a/tests/UI/Logic/ShortcutsOpenDataFolderMacTests.cs
+++ b/tests/UI/Logic/ShortcutsOpenDataFolderMacTests.cs
@@ -1,0 +1,57 @@
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// The macOS default for "Open Subtitle Edit folder" was Option+Shift+Cmd+D, which never reached
+/// the app (#14508); adding Control makes the chord work. Shortcut migration v3 moves persisted
+/// mac settings still on the dead chord onto the new one while leaving user re-bindings alone.
+/// </summary>
+public class ShortcutsOpenDataFolderMacTests
+{
+    private const string Name = nameof(MainViewModel.OpenDataFolderCommand);
+
+    [Fact]
+    public void DefaultIncludesControlOnMacOsOnly()
+    {
+        var keys = ShortcutsMain.GetDefaultShortcuts(null!).Single(s => s.ActionName == Name).Keys;
+        if (OperatingSystem.IsMacOS())
+        {
+            Assert.Equal(new[] { "Ctrl", "Win", "Alt", "Shift", "D" }, keys);
+        }
+        else
+        {
+            Assert.Equal(new[] { "Ctrl", "Alt", "Shift", "D" }, keys);
+        }
+    }
+
+    [Fact]
+    public void MigrationMovesOldMacDefaultAndKeepsCustomKeys()
+    {
+        var settings = new Se();
+        settings.Shortcuts.Add(new SeShortCut(Name, ["Win", "Alt", "Shift", "D"]));
+        settings.Shortcuts.Add(new SeShortCut(nameof(MainViewModel.SaveLanguageFileCommand), ["Win", "Alt", "Shift", "L"]));
+
+        settings.MigrateShortcuts();
+
+        var expected = OperatingSystem.IsMacOS()
+            ? new[] { "Ctrl", "Win", "Alt", "Shift", "D" }
+            : new[] { "Win", "Alt", "Shift", "D" };
+        Assert.Equal(expected, settings.Shortcuts[0].Keys);
+        Assert.Equal(new[] { "Win", "Alt", "Shift", "L" }, settings.Shortcuts[1].Keys);
+        Assert.Equal(Se.CurrentShortcutsMigrationVersion, settings.ShortcutsMigrationVersion);
+    }
+
+    [Fact]
+    public void MigrationLeavesUserReboundKeysAlone()
+    {
+        var settings = new Se();
+        settings.Shortcuts.Add(new SeShortCut(Name, ["Win", "Shift", "F9"]));
+
+        settings.MigrateShortcuts();
+
+        Assert.Equal(new[] { "Win", "Shift", "F9" }, settings.Shortcuts[0].Keys);
+    }
+}


### PR DESCRIPTION
Part of #14508: on macOS the default `⌥⇧⌘D` for *Open Subtitle Edit folder* never reaches the app, while `⌃⌥⇧⌘D` works.

- macOS default becomes `Ctrl+Win+Alt+Shift+D` (`⌃⌥⇧⌘D`); Windows/Linux keep `Ctrl+Alt+Shift+D`.
- Shortcut migration v3 moves persisted mac settings still on the old chord onto the new one; user re-bindings are left alone.
- Tests for the default and the migration.

The Alt+Shift+E vs È part of the issue is not covered here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)