### PR TITLE
Keep the burn-in Generate button reachable on short screens

### DIFF
--- a/src/ui/Features/Video/BurnIn/BurnInWindow.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInWindow.cs
@@ -55,29 +55,15 @@ public class BurnInWindow : Window
         // The left column (subtitle + video settings + target size) is taller than the middle
         // column's cut/preview/audio/video-info rows. Keeping all three boxes in one packed
         // panel preserves the v5.1.0 look (no gaps), and the preview row's MinHeight below
-        // guarantees the panel fits in rows 0-3 - so it can never overflow into the
-        // progress-bar row (which used to draw the bar through the "File size in MB" field)
-        // - and the preview box never gets shorter than its label + player, so the player
+        // guarantees the panel fits in rows 0-3 of the settings grid - so it can never overflow
+        // into the progress-bar row (which used to draw the bar through the "File size in MB"
+        // field) - and the preview box never gets shorter than its label + player, so the player
         // cannot spill over the audio settings box.
         var leftPanel = new StackPanel
         {
             Orientation = Orientation.Vertical,
             VerticalAlignment = VerticalAlignment.Top,
             Children = { subtitleSettingsView, videoSettingsView, targetFileSizeView },
-        };
-
-        // Rows 0-3 hold the panel at any size the window can normally reach, but not when the
-        // window ends up shorter than its own content minimum - which happens on screens too
-        // short for the dialog, where UiUtil lowers the minimum to keep the window on the working
-        // area. A StackPanel draws its overflow straight through whatever is below it, so the
-        // last box ("File size in MB") ended up under the progress bar (issue #13904). The scroll
-        // viewer keeps that overflow inside the cell and still reachable; it measures exactly like
-        // the panel, so at every normal size the layout is unchanged and no scroll bar appears.
-        var leftPanelScroller = new ScrollViewer
-        {
-            Content = leftPanel,
-            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
-            HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
         };
 
         var buttonGenerate = new SplitButton
@@ -121,7 +107,7 @@ public class BurnInWindow : Window
         var previewColumn = new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) };
         var batchColumn = new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) };
 
-        var grid = new Grid
+        var settingsGrid = new Grid
         {
             RowDefinitions =
             {
@@ -129,8 +115,6 @@ public class BurnInWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Star), MinHeight = 400 }, // preview + batch list (never smaller than the preview box needs)
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // audio
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // video info + target file size
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // progress bar
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // buttons
             },
             ColumnDefinitions =
             {
@@ -138,19 +122,64 @@ public class BurnInWindow : Window
                 previewColumn, // cut/preview/audio settings
                 batchColumn, // batch mode
             },
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+
+        settingsGrid.Add(leftPanel, 0, 0, 4, 1);  // rows 0-3 (cut + preview + audio + video info)
+        settingsGrid.Add(cutView, 0, 1);
+        settingsGrid.Add(previewView, 1, 1);
+        settingsGrid.Add(audioSettingsView, 2, 1);
+        settingsGrid.Add(videoInfoView, 3, 1);
+        settingsGrid.Add(batchView, 0, 2, 4, 1);
+
+        // The settings area is taller than what a small or scaled screen can show (a maximized
+        // window on a 1366x768 laptop leaves about 700 DIPs; the preview row alone needs 400).
+        // UiUtil lowers the window minimum to the working area, so the rows below the fold - the
+        // "Generate" button row above all - were simply clipped off and unreachable (issues
+        // #13904, #14360). Scrolling the settings area, with the progress bar and the buttons
+        // kept outside the scroll viewer, keeps every control reachable on any screen.
+        //
+        // A ScrollViewer measures its content with unbounded height, which would turn the star
+        // preview row into an auto row and stop the preview from growing with the window. Pinning
+        // the content's MinHeight to the viewport height restores the fill: when the window is
+        // tall enough the grid fills it exactly like before (no scroll bar), and only when the
+        // viewport is shorter than the content minimum does the area scroll.
+        var settingsScroller = new ScrollViewer
+        {
+            Content = settingsGrid,
+            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+            HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+        };
+        settingsScroller.SizeChanged += (_, e) =>
+        {
+            var viewportHeight = Math.Max(0, e.NewSize.Height);
+            if (Math.Abs(settingsGrid.MinHeight - viewportHeight) > 0.5)
+            {
+                settingsGrid.MinHeight = viewportHeight;
+            }
+        };
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) }, // settings + preview (scrolls when the window is too short)
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // progress bar
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // buttons
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
             Margin = UiUtil.MakeWindowMargin(),
             Width = double.NaN,
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
-        grid.Add(leftPanelScroller, 0, 0, 4, 1);  // rows 0-3 (cut + preview + audio + video info)
-        grid.Add(cutView, 0, 1);
-        grid.Add(previewView, 1, 1);
-        grid.Add(audioSettingsView, 2, 1);
-        grid.Add(videoInfoView, 3, 1);
-        grid.Add(batchView, 0, 2, 4, 1);
-        grid.Add(progressView, 4, 0, 1, 3);
-        grid.Add(buttonPanel, 5, 0, 1, 3);
+        grid.Add(settingsScroller, 0, 0);
+        grid.Add(progressView, 1, 0);
+        grid.Add(buttonPanel, 2, 0);
 
         Content = grid;
 

--- a/tests/UI/Features/Video/BurnInWindowTests.cs
+++ b/tests/UI/Features/Video/BurnInWindowTests.cs
@@ -21,8 +21,9 @@ namespace UITests.Features.Video;
 /// "File size in MB" field) and keeps the preview box taller than its label + player (so the
 /// player can never spill over the audio settings box when the window is shrunk). A window
 /// shorter than its own content minimum - which UiUtil produces on screens too short for the
-/// dialog - still leaves rows 0-3 short of the panel, so the panel scrolls rather than draws its
-/// overflow through the progress bar (issue #13904).
+/// dialog - no longer clips anything: the settings grid (rows 0-3) sits in a ScrollViewer while the
+/// progress bar and the button row stay outside it, so on a short screen the settings scroll and
+/// "Generate" remains reachable (issues #13904, #14360).
 /// </summary>
 public class BurnInWindowTests : IDisposable
 {
@@ -62,7 +63,7 @@ public class BurnInWindowTests : IDisposable
         return window;
     }
 
-    /// <summary>Returns the window's root grid (the one holding the progress view).</summary>
+    /// <summary>Returns the window's root grid (the one holding the progress view and the buttons).</summary>
     private static Grid FindRootGrid(BurnInWindow window)
     {
         var progressBar = window.GetLogicalDescendants().OfType<ProgressBar>().FirstOrDefault();
@@ -72,6 +73,30 @@ public class BurnInWindowTests : IDisposable
         var rootGrid = progressView.Parent as Grid;
         Assert.NotNull(rootGrid);
         return rootGrid;
+    }
+
+    /// <summary>Returns the scroll viewer in row 0 of the root grid and the settings grid inside it.</summary>
+    private static (ScrollViewer Scroller, Grid SettingsGrid) FindSettingsGrid(Grid rootGrid)
+    {
+        var scroller = rootGrid.Children.OfType<ScrollViewer>().FirstOrDefault(s => Grid.GetRow(s) == 0);
+        Assert.NotNull(scroller);
+        var settingsGrid = scroller.Content as Grid;
+        Assert.NotNull(settingsGrid);
+        return (scroller, settingsGrid);
+    }
+
+    private static Grid FindProgressView(Grid rootGrid)
+    {
+        var progressView = rootGrid.Children.OfType<Grid>().FirstOrDefault(g => Grid.GetRow(g) == 1);
+        Assert.NotNull(progressView);
+        return progressView;
+    }
+
+    private static StackPanel FindButtonPanel(Grid rootGrid)
+    {
+        var buttonPanel = rootGrid.Children.OfType<StackPanel>().FirstOrDefault(s => Grid.GetRow(s) == 2);
+        Assert.NotNull(buttonPanel);
+        return buttonPanel;
     }
 
     [AvaloniaFact]
@@ -96,7 +121,7 @@ public class BurnInWindowTests : IDisposable
         // The preview row (row 1, star) must carry a MinHeight: without it the window can be
         // shrunk (or restored) below the content height, the preview box gets shorter than its
         // label + player and the player spills over the audio settings box below it.
-        var previewRow = rootGrid.RowDefinitions[1];
+        var previewRow = FindSettingsGrid(rootGrid).SettingsGrid.RowDefinitions[1];
         Assert.Equal(GridUnitType.Star, previewRow.Height.GridUnitType);
         Assert.True(previewRow.MinHeight >= 350, $"Preview row MinHeight is only {previewRow.MinHeight:0.#}.");
 
@@ -132,12 +157,14 @@ public class BurnInWindowTests : IDisposable
 
     private static void AssertSettingsColumnStaysAboveProgressView(BurnInWindow window, Grid rootGrid)
     {
-        var settingsColumn = rootGrid.Children.FirstOrDefault(c => Grid.GetColumn(c) == 0 && Grid.GetRowSpan(c) == 4);
+        var (scroller, settingsGrid) = FindSettingsGrid(rootGrid);
+        var settingsColumn = settingsGrid.Children.FirstOrDefault(c => Grid.GetColumn(c) == 0 && Grid.GetRowSpan(c) == 4);
         Assert.NotNull(settingsColumn);
-        var progressView = rootGrid.Children.OfType<Grid>().FirstOrDefault(g => Grid.GetRow(g) == 4);
-        Assert.NotNull(progressView);
+        var progressView = FindProgressView(rootGrid);
 
-        var panelBottom = PaintedBottom(settingsColumn, window);
+        // The column is clipped by the scroll viewer around the settings grid, so measure from
+        // there: anything the column paints past the viewport is scrolled, not drawn over the bar.
+        var panelBottom = PaintedBottom(scroller, window);
         var progressTop = progressView.TranslatePoint(new Point(0, 0), window)?.Y;
         Assert.NotNull(progressTop);
         Assert.True(
@@ -180,8 +207,8 @@ public class BurnInWindowTests : IDisposable
         window.Height = 400;
         window.UpdateLayout();
 
-        var rootGrid = FindRootGrid(window);
-        var audioSettingsView = rootGrid.Children.OfType<Border>().FirstOrDefault(b => Grid.GetRow(b) == 2 && Grid.GetColumn(b) == 1);
+        var settingsGrid = FindSettingsGrid(FindRootGrid(window)).SettingsGrid;
+        var audioSettingsView = settingsGrid.Children.OfType<Border>().FirstOrDefault(b => Grid.GetRow(b) == 2 && Grid.GetColumn(b) == 1);
         Assert.NotNull(audioSettingsView);
 
         // The player is the bottom-most element of the preview box; its bottom must never
@@ -214,12 +241,9 @@ public class BurnInWindowTests : IDisposable
         window.UpdateLayout();
 
         var rootGrid = FindRootGrid(window);
-        Assert.True(
-            rootGrid.Children.OfType<Grid>().Any(g => Grid.GetRow(g) == 4 && g.IsVisible),
-            "Progress view is not visible while generating.");
+        Assert.True(FindProgressView(rootGrid).IsVisible, "Progress view is not visible while generating.");
 
-        var buttonPanel = rootGrid.Children.OfType<StackPanel>().FirstOrDefault(s => Grid.GetRow(s) == 5);
-        Assert.NotNull(buttonPanel);
+        var buttonPanel = FindButtonPanel(rootGrid);
         var buttonsBottom = buttonPanel.TranslatePoint(new Point(0, buttonPanel.Bounds.Height), window)?.Y;
         Assert.NotNull(buttonsBottom);
         Assert.True(
@@ -228,6 +252,66 @@ public class BurnInWindowTests : IDisposable
         Assert.True(
             window.ClientSize.Height >= before,
             $"Window shrank when generating started ({before:0.#} -> {window.ClientSize.Height:0.#}).");
+    }
+
+    [AvaloniaFact]
+    public void ButtonRow_StaysReachable_OnAShortScreen()
+    {
+        var window = BuildWindow();
+        window.Show();
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        // A maximized window on a 1366x768 laptop (taskbar + title bar) leaves about 700 DIPs of
+        // client height, less than the settings area needs. The reporter of issue #14360 saw the
+        // "Generate" row clipped off the bottom of the screen with no way to reach it.
+        window.SizeToContent = SizeToContent.Manual;
+        window.MinHeight = 0;
+        window.Height = 697;
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var rootGrid = FindRootGrid(window);
+        var buttonPanel = FindButtonPanel(rootGrid);
+        var buttonsBottom = buttonPanel.TranslatePoint(new Point(0, buttonPanel.Bounds.Height), window)?.Y;
+        Assert.NotNull(buttonsBottom);
+        Assert.True(
+            buttonsBottom.Value <= window.ClientSize.Height + 1.5,
+            $"Buttons bottom ({buttonsBottom.Value:0.#}) is clipped by the window height ({window.ClientSize.Height:0.#}).");
+
+        // The settings area itself is what gives way: it scrolls instead of being clipped.
+        var (scroller, settingsGrid) = FindSettingsGrid(rootGrid);
+        Assert.True(
+            scroller.Extent.Height > scroller.Viewport.Height + 1.5,
+            $"Settings area does not scroll (extent {scroller.Extent.Height:0.#}, viewport {scroller.Viewport.Height:0.#}).");
+        Assert.True(settingsGrid.RowDefinitions[1].MinHeight >= 350, "Preview row lost its minimum height.");
+    }
+
+    [AvaloniaFact]
+    public void PreviewRow_FillsTheWindow_WhenThereIsRoom()
+    {
+        var window = BuildWindow();
+        window.Show();
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        // Inside a ScrollViewer a star row would otherwise collapse to its minimum; the settings
+        // grid must keep filling the viewport so the preview grows with the window.
+        var rootGrid = FindRootGrid(window);
+        var (scroller, settingsGrid) = FindSettingsGrid(rootGrid);
+        var before = settingsGrid.Bounds.Height;
+
+        window.SizeToContent = SizeToContent.Manual;
+        window.Height = window.ClientSize.Height + 200;
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        Assert.True(
+            settingsGrid.Bounds.Height >= before + 190,
+            $"Settings grid did not grow with the window ({before:0.#} -> {settingsGrid.Bounds.Height:0.#}).");
+        Assert.True(
+            scroller.Extent.Height <= scroller.Viewport.Height + 1.5,
+            $"Settings area scrolls although the window is tall enough (extent {scroller.Extent.Height:0.#}, viewport {scroller.Viewport.Height:0.#}).");
     }
 
     // The extension list is only correct if both combo boxes are wired up: the encoder box


### PR DESCRIPTION
Fixes #14360

The reporter's screenshot is 1366x768 with the window maximized: about 700 DIPs of client height, less than the burn-in settings area needs (the preview row alone carries a 400 minimum). UiUtil clamps the window to the working area, so the Generate / OK / Cancel row was clipped off the bottom of the screen and could not be reached.

## Change
- The settings grid (settings column, cut, preview, audio, video info, batch list) now sits in a `ScrollViewer`; the progress bar and button row stay outside it, pinned at the bottom.
- The grid's `MinHeight` follows the scroll viewer's viewport, so the star preview row keeps filling tall windows exactly as before. Only when the viewport is shorter than the content minimum does the area scroll.
- The left column's own `ScrollViewer` is gone; the outer one clips the same overflow (#13904).

## Tests
`BurnInWindowTests` updated for the two-level grid, plus two new tests: the button row stays inside a 697 DIP tall window while the settings area scrolls, and the settings grid grows with the window without scrolling when there is room. All 10 pass.

Headless render at the reporter's client size (1366x697): Generate row visible, settings area scrolls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)