### PR TITLE
Keep the transparent-subtitles Generate button reachable on short screens

### DIFF
--- a/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesWindow.cs
+++ b/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesWindow.cs
@@ -1,3 +1,4 @@
+using System;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
@@ -40,16 +41,6 @@ public class TransparentSubtitlesWindow : Window
             Orientation = Orientation.Vertical,
             VerticalAlignment = VerticalAlignment.Top,
             Children = { subtitleSettingsView, videoSettingsView },
-        };
-
-        // Same overflow guard as the burn-in window: when the window is shorter than its content
-        // minimum, a bare StackPanel draws its overflow through the progress row below it
-        // (issue #13904). Measures exactly like the panel, so no normal size changes.
-        var leftPanelScroller = new ScrollViewer
-        {
-            Content = leftPanel,
-            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
-            HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
         };
 
         var cutView = MakeCutView(vm);
@@ -97,15 +88,13 @@ public class TransparentSubtitlesWindow : Window
         var previewColumn = new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) };
         var batchColumn = new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) };
 
-        var grid = new Grid
+        var settingsGrid = new Grid
         {
             RowDefinitions =
             {
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // cut
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Star) }, // preview + batch list
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // video info
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // progress bar
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // buttons
             },
             ColumnDefinitions =
             {
@@ -113,18 +102,57 @@ public class TransparentSubtitlesWindow : Window
                 previewColumn, // cut/preview/video info
                 batchColumn, // batch mode
             },
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+
+        settingsGrid.Add(leftPanel, 0, 0, 3, 1);
+        settingsGrid.Add(cutView, 0, 1);
+        settingsGrid.Add(previewView, 1, 1);
+        settingsGrid.Add(videoInfoView, 2, 1);
+        settingsGrid.Add(batchView, 0, 3, 3, 1);
+
+        // Same guard as the burn-in window (issues #13904, #14360): on a screen too short for the
+        // dialog UiUtil clamps the window to the working area, and whatever did not fit - the
+        // "Generate" button row above all - was clipped off and unreachable. The settings area
+        // scrolls instead, with the progress bar and the buttons kept outside the scroll viewer.
+        // Pinning the grid's MinHeight to the viewport keeps the star preview row filling tall
+        // windows exactly as before; only a viewport shorter than the content minimum scrolls.
+        var settingsScroller = new ScrollViewer
+        {
+            Content = settingsGrid,
+            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+            HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+        };
+        settingsScroller.SizeChanged += (_, e) =>
+        {
+            var viewportHeight = Math.Max(0, e.NewSize.Height);
+            if (Math.Abs(settingsGrid.MinHeight - viewportHeight) > 0.5)
+            {
+                settingsGrid.MinHeight = viewportHeight;
+            }
+        };
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) }, // settings + preview (scrolls when the window is too short)
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // progress bar
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // buttons
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
             Margin = UiUtil.MakeWindowMargin(),
             Width = double.NaN,
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
-        grid.Add(leftPanelScroller, 0, 0, 3, 1);
-        grid.Add(cutView, 0, 1);
-        grid.Add(previewView, 1, 1);
-        grid.Add(videoInfoView, 2, 1);
-        grid.Add(batchView, 0, 3, 3, 1);
-        grid.Add(progressView, 3, 0, 1, 3);
-        grid.Add(buttonPanel, 4, 0, 1, 3);
+        grid.Add(settingsScroller, 0, 0);
+        grid.Add(progressView, 1, 0);
+        grid.Add(buttonPanel, 2, 0);
 
         Content = grid;
 

--- a/tests/UI/Features/Video/TransparentSubtitlesWindowTests.cs
+++ b/tests/UI/Features/Video/TransparentSubtitlesWindowTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.LogicalTree;
+using Nikse.SubtitleEdit.Features.Video.TransparentSubtitles;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace UITests.Features.Video;
+
+/// <summary>
+/// Layout tests for the "Generate video with transparent subtitles" window. Like the burn-in
+/// window, its settings grid sits in a ScrollViewer while the progress bar and the button row
+/// stay outside it, so a screen too short for the dialog scrolls the settings instead of
+/// clipping "Generate" off the bottom (issues #13904, #14360).
+/// </summary>
+public class TransparentSubtitlesWindowTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private TransparentSubtitlesWindow BuildWindow()
+    {
+        var vm = new TransparentSubtitlesViewModel(
+            new FolderHelper(),
+            new FileHelper(),
+            new WindowService(new NullServiceProvider()));
+        var window = new TransparentSubtitlesWindow(vm);
+        _windows.Add(window);
+        return window;
+    }
+
+    private static Grid FindRootGrid(TransparentSubtitlesWindow window)
+    {
+        var progressBar = window.GetLogicalDescendants().OfType<ProgressBar>().FirstOrDefault();
+        Assert.NotNull(progressBar);
+        var rootGrid = (progressBar.Parent as Grid)?.Parent as Grid;
+        Assert.NotNull(rootGrid);
+        return rootGrid;
+    }
+
+    private static (ScrollViewer Scroller, Grid SettingsGrid) FindSettingsGrid(Grid rootGrid)
+    {
+        var scroller = rootGrid.Children.OfType<ScrollViewer>().FirstOrDefault(s => Grid.GetRow(s) == 0);
+        Assert.NotNull(scroller);
+        var settingsGrid = scroller.Content as Grid;
+        Assert.NotNull(settingsGrid);
+        return (scroller, settingsGrid);
+    }
+
+    [AvaloniaFact]
+    public void ButtonRow_StaysReachable_OnAShortScreen()
+    {
+        var window = BuildWindow();
+        window.Show();
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        // A 1366x768 laptop at 125% scaling leaves about 560 DIPs of client height for a
+        // maximized window; the button row must still end inside the window.
+        window.SizeToContent = SizeToContent.Manual;
+        window.MinHeight = 0;
+        window.Height = 560;
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var rootGrid = FindRootGrid(window);
+        var buttonPanel = rootGrid.Children.OfType<StackPanel>().FirstOrDefault(s => Grid.GetRow(s) == 2);
+        Assert.NotNull(buttonPanel);
+        var buttonsBottom = buttonPanel.TranslatePoint(new Point(0, buttonPanel.Bounds.Height), window)?.Y;
+        Assert.NotNull(buttonsBottom);
+        Assert.True(
+            buttonsBottom.Value <= window.ClientSize.Height + 1.5,
+            $"Buttons bottom ({buttonsBottom.Value:0.#}) is clipped by the window height ({window.ClientSize.Height:0.#}).");
+
+        var (scroller, _) = FindSettingsGrid(rootGrid);
+        Assert.True(
+            scroller.Extent.Height > scroller.Viewport.Height + 1.5,
+            $"Settings area does not scroll (extent {scroller.Extent.Height:0.#}, viewport {scroller.Viewport.Height:0.#}).");
+    }
+
+    [AvaloniaFact]
+    public void PreviewRow_FillsTheWindow_WhenThereIsRoom()
+    {
+        var window = BuildWindow();
+        window.Show();
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var (scroller, settingsGrid) = FindSettingsGrid(FindRootGrid(window));
+        var before = settingsGrid.Bounds.Height;
+
+        window.SizeToContent = SizeToContent.Manual;
+        window.Height = window.ClientSize.Height + 200;
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        Assert.True(
+            settingsGrid.Bounds.Height >= before + 190,
+            $"Settings grid did not grow with the window ({before:0.#} -> {settingsGrid.Bounds.Height:0.#}).");
+        Assert.True(
+            scroller.Extent.Height <= scroller.Viewport.Height + 1.5,
+            $"Settings area scrolls although the window is tall enough (extent {scroller.Extent.Height:0.#}, viewport {scroller.Viewport.Height:0.#}).");
+    }
+}


### PR DESCRIPTION
Follow-up to #14360 / #14550 for the "Generate video with transparent subtitles" window, which has the same layout: the video player's 270 DIP minimum plus the cut, video info and button rows overflow a working area of about 570 DIPs or less (a 1366x768 laptop at 125% scaling, for example), and UiUtil clamps the window there, so the Generate row was clipped off the screen.

## Change
- The settings grid (settings column, cut, preview, video info, batch list) sits in a `ScrollViewer`; the progress bar and button row stay outside it, pinned at the bottom.
- The grid's `MinHeight` follows the viewport, so the star preview row keeps filling tall windows; only a viewport shorter than the content minimum scrolls.
- The left column's own `ScrollViewer` is gone; the outer one clips the same overflow (#13904).

## Tests
New `TransparentSubtitlesWindowTests`: the button row stays inside a 560 DIP tall window while the settings area scrolls, and the settings grid grows with the window without scrolling when there is room.

🤖 Generated with [Claude Code](https://claude.com/claude-code)