### PR TITLE
Fix #14555: make "guess start/end from waveform" work on quiet audio

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -4252,10 +4252,9 @@ public class AudioVisualizer : Control
         var threshold = thresholdPercent / 100.0 * WavePeaks.HighestPeak;
 
         var minMax = GetMinAndMax(min, max);
-        const int lowPeakDifference = 4_000;
-        if (minMax.Max - minMax.Min < lowPeakDifference)
+        if (IsAllAudioAboutTheSame(minMax))
         {
-            return -1; // all audio about the same
+            return -1;
         }
 
         // look for start silence in the beginning of subtitle
@@ -4347,10 +4346,9 @@ public class AudioVisualizer : Control
         var threshold = thresholdPercent / 100.0 * WavePeaks.HighestPeak;
 
         var minMax = GetMinAndMax(min, max);
-        const int lowPeakDifference = 4_000;
-        if (minMax.Max - minMax.Min < lowPeakDifference)
+        if (IsAllAudioAboutTheSame(minMax))
         {
-            return -1; // all audio about the same
+            return -1;
         }
 
         var peaks = WavePeaks.Peaks;
@@ -4403,6 +4401,21 @@ public class AudioVisualizer : Control
         }
 
         return -1;
+    }
+
+    /// <summary>
+    /// "Nothing to detect" test for the guess start/end searches: there is no speech boundary to
+    /// find when the loudest peak around the cue is not clearly above the quietest. SE 4 used a
+    /// fixed 4000 (about 12% of full scale), which rejected every quiet passage - dialogue at 10%
+    /// of the file's loudest peak, common in films with loud music elsewhere, made the shortcuts
+    /// do nothing (#14555). The range that counts as flat now shrinks with the level: the loudest
+    /// peak must be at least double the quietest (with a small floor for digital silence), and
+    /// the old 4000 stays as the cap for loud audio.
+    /// </summary>
+    private static bool IsAllAudioAboutTheSame(MinMax minMax)
+    {
+        var lowPeakDifference = Math.Min(4_000, Math.Max(200, minMax.Min));
+        return minMax.Max - minMax.Min < lowPeakDifference;
     }
 
     /// <summary>

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -5641,6 +5641,30 @@ public partial class MainViewModel :
     }
 
     /// <summary>
+    /// The volume threshold sweep of <see cref="WaveformGuessStart"/> and <see cref="WaveformGuessEnd"/>,
+    /// as percentages of the file's loudest peak, from the local noise floor <paramref name="lowPercent"/>
+    /// and the local peak <paramref name="highPercent"/> around the cue. The searches try each
+    /// threshold in turn and take the first boundary found, so the sweep must start above the
+    /// floor and below the speech.
+    /// <list type="bullet">
+    /// <item>Start (SE 4): a margin above the floor, bigger when the speech is loud. SE 4 capped
+    /// the margin at the local range only below 5%; quiet dialogue just above that got a sweep
+    /// starting above the speech itself, which then counted as silence and the cue snapped to a
+    /// spot right next to where it was (#14555). The cap now applies at every level.</item>
+    /// <item>End: SE 4 stopped at a fixed 14%, fine at normal levels but no sweep at all in a
+    /// file that is quiet overall, where the floor plus the margin is already above it (#14555).
+    /// The sweep now always spans at least 8 points - what 14 amounts to at normal levels.</item>
+    /// </list>
+    /// </summary>
+    private static (double Start, double End) GetGuessVolumeSweep(double lowPercent, double highPercent)
+    {
+        var add = highPercent > 40 ? 8.0 : 5.0;
+        add = Math.Min(add, highPercent - lowPercent - 0.3);
+        var start = lowPercent + add;
+        return (start, Math.Max(14, start + 8));
+    }
+
+    /// <summary>
     /// SE 4 parity ("guess start"): looks for the silence right before the speech that starts the
     /// selected line and moves the start cue there, snapping to a nearby shot change when there is
     /// one. Raising the volume threshold step by step finds the quietest boundary that still reads
@@ -5666,21 +5690,13 @@ public partial class MainViewModel :
         var startSeconds = selected.StartTime.TotalSeconds;
         var lowPercent = AudioVisualizer.FindLowPercentage(startSeconds - 0.3, startSeconds + 0.1);
         var highPercent = AudioVisualizer.FindHighPercentage(startSeconds - 0.3, startSeconds + 0.4);
-        var add = 5.0;
-        if (highPercent > 40)
-        {
-            add = 8;
-        }
-        else if (highPercent < 5)
-        {
-            add = highPercent - lowPercent - 0.3;
-        }
+        var sweep = GetGuessVolumeSweep(lowPercent, highPercent);
 
         var gapMs = Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
         var prev = GetPreviousWorkingRow(index);
         var next = GetNextWorkingRow(index);
 
-        for (var startVolume = lowPercent + add; startVolume < 14; startVolume += 0.3)
+        for (var startVolume = sweep.Start; startVolume < sweep.End; startVolume += 0.3)
         {
             var pos = AudioVisualizer.FindDataBelowThresholdBackForStart(startVolume, silenceLengthInSeconds, startSeconds);
             if (pos < 0 || pos <= startSeconds - 1)
@@ -5788,20 +5804,12 @@ public partial class MainViewModel :
         // speech short has nothing but speech right around it.
         var lowPercent = AudioVisualizer.FindLowPercentage(endSeconds - 0.3, endSeconds + 1.0);
         var highPercent = AudioVisualizer.FindHighPercentage(endSeconds - 0.4, endSeconds + 0.3);
-        var add = 5.0;
-        if (highPercent > 40)
-        {
-            add = 8;
-        }
-        else if (highPercent < 5)
-        {
-            add = highPercent - lowPercent - 0.3;
-        }
+        var sweep = GetGuessVolumeSweep(lowPercent, highPercent);
 
         var gapMs = Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
         var next = GetNextWorkingRow(index);
 
-        for (var volume = lowPercent + add; volume < 14; volume += 0.3)
+        for (var volume = sweep.Start; volume < sweep.End; volume += 0.3)
         {
             var pos = AudioVisualizer.FindDataBelowThresholdForwardForEnd(volume, silenceLengthInSeconds, endSeconds);
             if (pos < 0 || pos >= endSeconds + 1)

--- a/tests/UI/Features/Main/Se4GuessStartAndUnderlineTests.cs
+++ b/tests/UI/Features/Main/Se4GuessStartAndUnderlineTests.cs
@@ -254,6 +254,99 @@ public class Se4GuessStartAndUnderlineTests : IDisposable
         Assert.Equal(3800, vm.Subtitles[0].EndTime.TotalMilliseconds, 0);
     }
 
+    /// <summary>
+    /// #14555: the shortcuts did nothing on quiet passages. The searches rejected any window whose
+    /// peak range was under a fixed 4000 (about 12% of full scale), so dialogue at 10% of the
+    /// file's loudest peak - normal for a film with loud music elsewhere - never moved a cue, and
+    /// a file that is quiet overall had no threshold sweep at all. Speech from 2.5 s to 4.0 s at
+    /// <paramref name="speechLevel"/> over a floor of <paramref name="floorLevel"/>, with a
+    /// full-scale burst elsewhere when <paramref name="loudElsewhere"/>.
+    /// </summary>
+    [AvaloniaTheory]
+    [InlineData(3300, 500, true)]  // 10% of the loudest peak, the level in the issue's video
+    [InlineData(1600, 300, true)]  // 5%
+    [InlineData(2000, 200, false)] // quiet file: the loudest peak in the file is this speech
+    public void GuessStartAndEndWorkOnQuietSpeech(int speechLevel, int floorLevel, bool loudElsewhere)
+    {
+        Se.Settings.General.LockTimeCodes = false;
+        Se.Settings.Waveform.GuessStartOffsetMs = 0;
+        Se.Settings.Waveform.GuessEndOffsetMs = 0;
+
+        var (window, vm) = CreateMainViewModel();
+        vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph("Hello", 2200, 4600), null!) { Number = 1 });
+        Dispatcher.UIThread.RunJobs();
+
+        var av = vm.AudioVisualizer!;
+        av.WavePeaks = MakeQuietPeaks((short)speechLevel, (short)floorLevel, loudElsewhere);
+        Select(vm, vm.Subtitles[0]);
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        vm.WaveformGuessStartCommand.Execute(null);
+        vm.WaveformGuessEndCommand.Execute(null);
+
+        var line = vm.Subtitles[0];
+        Assert.InRange(line.StartTime.TotalMilliseconds, 2400, 2500);
+        Assert.InRange(line.EndTime.TotalMilliseconds, 4000, 4100);
+    }
+
+    /// <summary>
+    /// The "nothing to detect" guard still holds: a passage that is only noise, with no boundary
+    /// in it, leaves the cue alone rather than snapping it to a random spot in the noise.
+    /// </summary>
+    [AvaloniaFact]
+    public void GuessStartAndEndLeaveFlatAudioAlone()
+    {
+        Se.Settings.General.LockTimeCodes = false;
+        Se.Settings.Waveform.GuessStartOffsetMs = 0;
+        Se.Settings.Waveform.GuessEndOffsetMs = 0;
+
+        var (window, vm) = CreateMainViewModel();
+        vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph("Hello", 2200, 4600), null!) { Number = 1 });
+        Dispatcher.UIThread.RunJobs();
+
+        var av = vm.AudioVisualizer!;
+        var peaks = new WavePeak2[1000];
+        for (var i = 0; i < peaks.Length; i++)
+        {
+            var v = (short)(i % 2 == 0 ? 450 : 550); // noise wobbling around 500, nothing else
+            peaks[i] = new WavePeak2(v, (short)-v);
+        }
+
+        av.WavePeaks = new WavePeakData2(100, peaks);
+        Select(vm, vm.Subtitles[0]);
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        vm.WaveformGuessStartCommand.Execute(null);
+        vm.WaveformGuessEndCommand.Execute(null);
+
+        Assert.Equal(2200, vm.Subtitles[0].StartTime.TotalMilliseconds, 0);
+        Assert.Equal(4600, vm.Subtitles[0].EndTime.TotalMilliseconds, 0);
+    }
+
+    private static WavePeakData2 MakeQuietPeaks(short speechLevel, short floorLevel, bool loudElsewhere)
+    {
+        const int sampleRate = 100;
+        var peaks = new WavePeak2[sampleRate * 10];
+        for (var i = 0; i < peaks.Length; i++)
+        {
+            var v = floorLevel;
+            if (i >= 250 && i < 400)
+            {
+                v = speechLevel;
+            }
+            else if (loudElsewhere && i >= 800 && i < 900)
+            {
+                v = 32000;
+            }
+
+            peaks[i] = new WavePeak2(v, (short)-v);
+        }
+
+        return new WavePeakData2(sampleRate, peaks);
+    }
+
     private static WavePeakData2 MakePeaks(int sampleRate, int seconds, double speechFromSeconds, double speechToSeconds)
     {
         var peaks = new WavePeak2[sampleRate * seconds];


### PR DESCRIPTION
Fixes #14555

## Problem

"Guess start time from waveform" and "guess end time from waveform" often did nothing. The shortcuts dispatch fine (General category, from anywhere); the commands ran and bailed silently. Measured from the issue's video, the speech around the cue peaks at about 10% of the file's loudest peak with a floor around 1.5%, which is normal for dialogue in a film that has loud music or effects elsewhere.

Two absolute-scale traps in the search, inherited verbatim from SE 4 (not a #14472 regression):

1. **"All audio about the same" guard** in `FindDataBelowThresholdBackForStart` / `FindDataBelowThresholdForwardForEnd` rejected any window whose peak range was under a fixed 4000 on the 16-bit scale (about 12% of full scale). Quiet dialogue never cleared it, so every threshold returned "not found".
2. **Threshold sweep bounds** in `WaveformGuessStart` / `WaveformGuessEnd`: the sweep started a fixed 5 points above the floor and stopped at a fixed 14% of the loudest peak. Just above 5% the sweep started above the speech itself, so the speech counted as silence and the cue snapped to a spot right next to where it was. In a file that is quiet overall the floor plus the margin was already above 14, so the sweep was empty.

## Fix

- The flat-audio guard scales with the level: the loudest peak must be at least double the quietest (200 absolute floor for digital silence), with the old 4000 kept as the cap for loud audio.
- The sweep margin is capped at the local range at every level; SE 4 did this only below 5%, so the old branches give identical results.
- The sweep always spans at least 8 points above its start, which is exactly what 14 amounts to at normal levels, so normal audio keeps its old sweep. Both commands share one `GetGuessVolumeSweep` helper.

## Verification

Headless tests in `Se4GuessStartAndUnderlineTests`, peaks at 100/s, speech 2.5 to 4.0 s, cue 2.2 to 4.6 s:

| Scenario | Before | After |
|---|---|---|
| Speech at 10% of a full-scale file (the issue's level) | unchanged | start 2480, end 4010 |
| Speech at 5% of a full-scale file | start snapped to 2280 | start 2480, end 4010 |
| Quiet file, speech is the loudest thing in it | unchanged | start 2480, end 4010 |
| Flat noise only, no boundary | unchanged | unchanged |

All 12 tests in the class pass; the 7 existing ones are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
