### PR TITLE
Add keyboard navigation between changes in Beautify time codes

### DIFF
--- a/docs/features/beautify-time-codes.md
+++ b/docs/features/beautify-time-codes.md
@@ -23,7 +23,7 @@ By default the frame boundaries are calculated from the video frame rate. Tick *
 
 Below the visualizers, the **change navigator** lets you step through every cue the beautify pass moved:
 
-- **▲ / ▼** — previous / next change. Both visualizers center on the change.
+- **▲ / ▼** — previous / next change. Both visualizers center on the change. The keyboard works too: **Up** / **Down** (or **Left** / **Right**, **PageUp** / **PageDown**) step one change, **Home** / **End** jump to the first / last change.
 - **Change X of Y** — position counter.
 - **Detail line** — `#15   Start: 00:01:23,456 → 00:01:23,400  (−56 ms / −1.4 f)    End: …`
 - **Reason line** — italic, dimmed: explains *why* the cue moved, per side:

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -161,3 +161,15 @@ Dialogs that preview their changes in a list of checkboxes — [Remove text for 
 | Space | Toggle the checkbox of the highlighted rows |
 
 The same three actions sit in the list's right-click menu. In Multiple replace they apply to the fixes preview on the right; the rules tree on the left keeps its own `Ctrl+D` (duplicate rule). Other tools with such a list (Fix common errors, Merge continuation lines, Remove unicode characters, Fix Netflix errors, AI review) put buttons below the list for the same job.
+
+## Beautify Time Codes
+
+The [Beautify time codes](../features/beautify-time-codes.md) window steps through the cues the beautify pass moved. These keys work wherever the focus is inside the window and are fixed, not part of **Options** → **Shortcuts**.
+
+| Shortcut | Action |
+|----------|--------|
+| Up / Left / PageUp | Previous change |
+| Down / Right / PageDown | Next change |
+| Home | First change |
+| End | Last change |
+| Escape | Cancel |

--- a/src/ui/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesViewModel.cs
+++ b/src/ui/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesViewModel.cs
@@ -777,6 +777,25 @@ public partial class BeautifyTimeCodesViewModel : ObservableObject, IDisposable
         }
     }
 
+    private void FirstChange()
+    {
+        if (_changedIndices.Count > 0 && _currentChangeIndex != 0)
+        {
+            _currentChangeIndex = 0;
+            UpdateChangeView();
+        }
+    }
+
+    private void LastChange()
+    {
+        var last = _changedIndices.Count - 1;
+        if (last >= 0 && _currentChangeIndex != last)
+        {
+            _currentChangeIndex = last;
+            UpdateChangeView();
+        }
+    }
+
     [RelayCommand]
     private void Ok()
     {
@@ -853,6 +872,34 @@ public partial class BeautifyTimeCodesViewModel : ObservableObject, IDisposable
         {
             e.Handled = true;
             UiUtil.ShowHelp("features/beautify-time-codes");
+        }
+        else if (e.KeyModifiers == KeyModifiers.None)
+        {
+            // Keyboard navigation between changes - the window has no text input, so the plain
+            // arrow/paging keys are free. Mirrors the ▲/▼ buttons in the change navigator.
+            switch (e.Key)
+            {
+                case Key.Up:
+                case Key.Left:
+                case Key.PageUp:
+                    e.Handled = true;
+                    PreviousChange();
+                    break;
+                case Key.Down:
+                case Key.Right:
+                case Key.PageDown:
+                    e.Handled = true;
+                    NextChange();
+                    break;
+                case Key.Home:
+                    e.Handled = true;
+                    FirstChange();
+                    break;
+                case Key.End:
+                    e.Handled = true;
+                    LastChange();
+                    break;
+            }
         }
     }
 

--- a/src/ui/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesWindow.cs
+++ b/src/ui/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesWindow.cs
@@ -44,7 +44,8 @@ public class BeautifyTimeCodesWindow : Window
         Grid.SetRow(c.Children[2], 2);
         Grid.SetRow(c.Children[3], 3);
 
-        Activated += delegate { /* leave focus on the visualizer for keyboard nav */ };
+        // Change navigation keys (arrows, PageUp/Down, Home/End) are handled at window level, so
+        // they work whichever control has focus - nothing here needs to own them.
         KeyDown += (_, e) => vm.OnKeyDown(e);
         Closing += (_, __) => vm.Dispose();
     }
@@ -191,10 +192,12 @@ public class BeautifyTimeCodesWindow : Window
     {
         var l = Se.Language.Tools.BeautifyTimeCodes;
 
-        var buttonPrev = UiUtil.MakeButton(vm.PreviousChangeCommand, IconNames.ArrowUpThin, l.PreviousChange);
+        // The same steps are on the keyboard (see BeautifyTimeCodesViewModel.OnKeyDown); the
+        // tooltips are the only place that advertises it, so name the keys there.
+        var buttonPrev = UiUtil.MakeButton(vm.PreviousChangeCommand, IconNames.ArrowUpThin, $"{l.PreviousChange} (Up / PageUp)");
         buttonPrev.Bind(Button.IsEnabledProperty, new Binding(nameof(vm.CanGoPrevious)) { Source = vm });
 
-        var buttonNext = UiUtil.MakeButton(vm.NextChangeCommand, IconNames.ArrowDownThin, l.NextChange);
+        var buttonNext = UiUtil.MakeButton(vm.NextChangeCommand, IconNames.ArrowDownThin, $"{l.NextChange} (Down / PageDown)");
         buttonNext.Bind(Button.IsEnabledProperty, new Binding(nameof(vm.CanGoNext)) { Source = vm });
 
         var labelPosition = new TextBlock

--- a/tests/UI/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesKeyNavigationTests.cs
+++ b/tests/UI/Features/Tools/BeautifyTimeCodes/BeautifyTimeCodesKeyNavigationTests.cs
@@ -1,0 +1,141 @@
+using System.Collections.Generic;
+using System.Reflection;
+using Avalonia.Input;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Tools.BeautifyTimeCodes;
+
+namespace UITests.Features.Tools.BeautifyTimeCodes;
+
+/// <summary>
+/// The change navigator's ▲/▼ buttons are mirrored on the keyboard at window level: arrows and
+/// PageUp/PageDown step one change, Home/End jump to the ends. Only unmodified keys count, so
+/// chords stay free for the platform. The change list is normally built by the preview timer;
+/// here it is seeded directly.
+/// </summary>
+public class BeautifyTimeCodesKeyNavigationTests
+{
+    private const BindingFlags Private = BindingFlags.Instance | BindingFlags.NonPublic;
+
+    private static BeautifyTimeCodesViewModel MakeViewModelWithChanges(int subtitleCount, int[] changedIndices, int current)
+    {
+        var vm = new BeautifyTimeCodesViewModel(new StubWindowService());
+        var type = typeof(BeautifyTimeCodesViewModel);
+
+        var original = (List<SubtitleLineViewModel>)type.GetField("_originalSubtitles", Private)!.GetValue(vm)!;
+        var beautified = (List<SubtitleLineViewModel>)type.GetField("_beautifiedSubtitles", Private)!.GetValue(vm)!;
+        var format = new SubRip();
+        for (var i = 0; i < subtitleCount; i++)
+        {
+            var start = 1000 + i * 3000;
+            original.Add(new SubtitleLineViewModel(new Paragraph($"Line {i + 1}", start, start + 2000), format) { Number = i + 1 });
+            beautified.Add(new SubtitleLineViewModel(new Paragraph($"Line {i + 1}", start + 40, start + 2040), format) { Number = i + 1 });
+        }
+
+        var changed = (List<int>)type.GetField("_changedIndices", Private)!.GetValue(vm)!;
+        changed.AddRange(changedIndices);
+        type.GetField("_currentChangeIndex", Private)!.SetValue(vm, current);
+        return vm;
+    }
+
+    private static int CurrentChangeIndex(BeautifyTimeCodesViewModel vm)
+        => (int)typeof(BeautifyTimeCodesViewModel).GetField("_currentChangeIndex", Private)!.GetValue(vm)!;
+
+    private static KeyEventArgs Press(BeautifyTimeCodesViewModel vm, Key key, KeyModifiers modifiers = KeyModifiers.None)
+    {
+        var e = new KeyEventArgs { Key = key, KeyModifiers = modifiers, RoutedEvent = InputElement.KeyDownEvent };
+        vm.OnKeyDown(e);
+        return e;
+    }
+
+    [Theory]
+    [InlineData(Key.Down)]
+    [InlineData(Key.Right)]
+    [InlineData(Key.PageDown)]
+    public void NextKeysStepForward(Key key)
+    {
+        var vm = MakeViewModelWithChanges(5, new[] { 0, 2, 4 }, 0);
+
+        var e = Press(vm, key);
+
+        Assert.True(e.Handled);
+        Assert.Equal(1, CurrentChangeIndex(vm));
+        Assert.Contains("2", vm.ChangePositionLabel);
+        Assert.True(vm.CanGoPrevious);
+        Assert.True(vm.CanGoNext);
+    }
+
+    [Theory]
+    [InlineData(Key.Up)]
+    [InlineData(Key.Left)]
+    [InlineData(Key.PageUp)]
+    public void PreviousKeysStepBack(Key key)
+    {
+        var vm = MakeViewModelWithChanges(5, new[] { 0, 2, 4 }, 2);
+
+        var e = Press(vm, key);
+
+        Assert.True(e.Handled);
+        Assert.Equal(1, CurrentChangeIndex(vm));
+    }
+
+    [Fact]
+    public void HomeAndEndJumpToFirstAndLastChange()
+    {
+        var vm = MakeViewModelWithChanges(5, new[] { 0, 2, 4 }, 1);
+
+        Press(vm, Key.End);
+        Assert.Equal(2, CurrentChangeIndex(vm));
+        Assert.False(vm.CanGoNext);
+        Assert.True(vm.CanGoPrevious);
+
+        Press(vm, Key.Home);
+        Assert.Equal(0, CurrentChangeIndex(vm));
+        Assert.True(vm.CanGoNext);
+        Assert.False(vm.CanGoPrevious);
+    }
+
+    [Fact]
+    public void SteppingStopsAtTheEnds()
+    {
+        var vm = MakeViewModelWithChanges(5, new[] { 0, 2, 4 }, 2);
+
+        Press(vm, Key.Down);
+        Assert.Equal(2, CurrentChangeIndex(vm));
+
+        Press(vm, Key.Home);
+        Press(vm, Key.Up);
+        Assert.Equal(0, CurrentChangeIndex(vm));
+    }
+
+    [Theory]
+    [InlineData(KeyModifiers.Control)]
+    [InlineData(KeyModifiers.Alt)]
+    [InlineData(KeyModifiers.Shift)]
+    [InlineData(KeyModifiers.Meta)]
+    public void ModifiedArrowKeysAreLeftAlone(KeyModifiers modifiers)
+    {
+        var vm = MakeViewModelWithChanges(5, new[] { 0, 2, 4 }, 1);
+
+        var e = Press(vm, Key.Down, modifiers);
+
+        Assert.False(e.Handled);
+        Assert.Equal(1, CurrentChangeIndex(vm));
+    }
+
+    [Fact]
+    public void KeysAreHarmlessWithoutChanges()
+    {
+        var vm = MakeViewModelWithChanges(3, new int[0], -1);
+
+        Press(vm, Key.Down);
+        Press(vm, Key.End);
+        Press(vm, Key.Home);
+        Press(vm, Key.Up);
+
+        Assert.Equal(-1, CurrentChangeIndex(vm));
+        Assert.False(vm.CanGoNext);
+        Assert.False(vm.CanGoPrevious);
+    }
+}


### PR DESCRIPTION
## Summary

The change navigator in **Tools → Beautify time codes** only had the ▲/▼ buttons, so stepping through many moved cues meant clicking the same small button repeatedly. This adds keyboard navigation at window level (works whichever control has focus):

| Key | Action |
|-----|--------|
| Up / Left / PageUp | Previous change |
| Down / Right / PageDown | Next change |
| Home / End | First / last change |

Only unmodified keys are taken, so Ctrl/Alt/Shift/Cmd chords stay untouched. The ▲/▼ button tooltips now name the keys.

## Docs

- `docs/features/beautify-time-codes.md` — change navigator section lists the keys.
- `docs/reference/keyboard-shortcuts.md` — new *Beautify Time Codes* section (fixed keys, not part of Options → Shortcuts).

## Tests

New `BeautifyTimeCodesKeyNavigationTests` seeds the change list and covers forward/back stepping for every key, Home/End, clamping at the ends, modified keys being left alone, and the no-changes case. All 17 Beautify tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)