### PR TITLE
Add Google Cloud Speech-to-Text v2 as an online speech-to-text engine

### DIFF
--- a/src/libuilogic/AudioToText/WhisperChoice.cs
+++ b/src/libuilogic/AudioToText/WhisperChoice.cs
@@ -35,5 +35,6 @@
         public const string OpenAiCompatible = "OpenAI Compatible";
         public const string OpenRouter = "OpenRouter";
         public const string DashScopeQwen3 = "Alibaba Qwen3-ASR";
+        public const string GoogleCloud = "Google Cloud Speech-to-Text";
     }
 }

--- a/src/ui/Features/Video/SpeechToText/Engines/GoogleCloudSttEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/GoogleCloudSttEngine.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.GoogleCloud;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.UiLogic.AudioToText;
+
+namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+
+/// <summary>
+/// Online speech-to-text via Google Cloud Speech-to-Text v2 (Chirp), with real
+/// word timings. See <see cref="GoogleCloudSttService"/> for the request flow.
+/// </summary>
+public class GoogleCloudSttEngine : IOnlineSttEngine
+{
+    public static string StaticName => "Google Cloud Speech-to-Text";
+    public string Name => StaticName;
+    public string Choice => WhisperChoice.GoogleCloud;
+    public string Url => "https://cloud.google.com/speech-to-text/v2/docs";
+
+    public override string ToString() => Name;
+
+    public List<WhisperLanguage> Languages => WhisperLanguage.Languages.OrderBy(p => p.Name).ToList();
+    public List<WhisperModel> Models => new();
+
+    public string Extension => string.Empty;
+    public string UnpackSkipFolder => string.Empty;
+
+    public bool IsEngineInstalled() => true;
+    public bool CanBeDownloaded() => false;
+
+    public ISttTranscriber? CreateTranscriber(out string? configErrorMessage)
+    {
+        var settings = GoogleCloudSttSettings.FromConfiguration();
+        if (string.IsNullOrWhiteSpace(settings.KeyFile) || !File.Exists(settings.KeyFile))
+        {
+            configErrorMessage = Se.Language.General.OnlineSttApiKeyMissing;
+            return null;
+        }
+
+        configErrorMessage = null;
+        return new GoogleCloudSttService(settings);
+    }
+
+    public string ProbeUrl => $"https://{GoogleCloudSttService.GetSpeechHost(Se.Settings.Tools.GoogleCloudSttRegion)}/";
+
+    // Batch jobs read from Cloud Storage, so size is no concern - but with word
+    // timings enabled Google caps a file at 20 minutes, so split by time instead.
+    public long UploadThresholdBytes => long.MaxValue;
+    public long ChunkSizeBytes => long.MaxValue;
+    public double MaxChunkSeconds => 18 * 60;
+
+    public string GetAndCreateWhisperFolder() => WhisperHelper.GetWhisperFolder(WhisperChoice.GoogleCloud) ?? string.Empty;
+    public string GetAndCreateWhisperModelFolder(WhisperModel? whisperModel) => new WhisperModel().ModelFolder;
+    public string GetExecutable() => string.Empty;
+    public bool IsModelInstalled(WhisperModel model) => true;
+    public string GetModelForCmdLine(string modelName) => modelName;
+    public string GetWhisperModelDownloadFileName(WhisperModel whisperModel, string url) => string.Empty;
+
+    public Task<string> GetHelpText() => Task.FromResult(
+        "Google Cloud Speech-to-Text v2 with word level timings.\n\n" +
+        "Setup (Speech-to-Text v2 does not accept API keys):\n" +
+        " 1. In the Google Cloud console create a project with billing, and enable the Speech-to-Text API.\n" +
+        " 2. Create a service account with the roles 'Cloud Speech Client' and 'Storage Admin'.\n" +
+        " 3. Add a JSON key to the service account, download it, and pick it as the key file.\n\n" +
+        "Long audio must be read from a Cloud Storage bucket, so one named <project>-subtitle-edit-stt is created " +
+        "on first use (another name can be set as GoogleCloudSttBucketName in Settings.json). Uploaded audio is " +
+        "deleted after each run.\n\n" +
+        "Region: 'us' or 'eu' for chirp_3, or a specific region for other models. " +
+        "Model: chirp_3, chirp_2, long, latest_long... " +
+        "Language hint: leave empty for automatic detection (Chirp models), or a BCP-47 code such as en-US.");
+
+    public string CommandLineParameter
+    {
+        get => string.Empty;
+        set { }
+    }
+}

--- a/src/ui/Features/Video/SpeechToText/Engines/IOnlineSttEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/IOnlineSttEngine.cs
@@ -55,4 +55,10 @@ public interface IOnlineSttEngine : ISpeechToTextEngine
     /// Target size (bytes) for each chunk when splitting.
     /// </summary>
     long ChunkSizeBytes { get; }
+
+    /// <summary>
+    /// Longest audio (seconds) one request may carry, for providers that cap by
+    /// duration rather than bytes. 0 means no duration cap.
+    /// </summary>
+    double MaxChunkSeconds => 0;
 }

--- a/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineFactory.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/WhisperEngineFactory.cs
@@ -67,6 +67,11 @@ public static class WhisperEngineFactory
             return new DashScopeQwen3SttEngine();
         }
 
+        if (staticName == GoogleCloudSttEngine.StaticName)
+        {
+            return new GoogleCloudSttEngine();
+        }
+
         throw new NotImplementedException();
     }
 }

--- a/src/ui/Features/Video/SpeechToText/GoogleCloud/GoogleCloudSttService.cs
+++ b/src/ui/Features/Video/SpeechToText/GoogleCloud/GoogleCloudSttService.cs
@@ -1,0 +1,369 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Google.Apis.Auth.OAuth2;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.OpenAiCompatible;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.GoogleCloud;
+
+public class GoogleCloudSttSettings
+{
+    public string KeyFile { get; set; } = string.Empty;
+    public string Region { get; set; } = "us";
+    public string Model { get; set; } = "chirp_3";
+    public string Language { get; set; } = string.Empty;
+    public string BucketName { get; set; } = string.Empty;
+    public int TimeoutSeconds { get; set; } = 3600;
+    public Action<string>? Logger { get; set; }
+
+    public static GoogleCloudSttSettings FromConfiguration() => new()
+    {
+        KeyFile = Se.Settings.Tools.GoogleCloudSttKeyFile,
+        Region = Se.Settings.Tools.GoogleCloudSttRegion,
+        Model = Se.Settings.Tools.GoogleCloudSttModel,
+        Language = Se.Settings.Tools.GoogleCloudSttLanguage,
+        BucketName = Se.Settings.Tools.GoogleCloudSttBucketName,
+        TimeoutSeconds = Se.Settings.Tools.GoogleCloudSttTimeoutSeconds,
+        Logger = message => Se.WriteToolsLog(message),
+    };
+}
+
+/// <summary>
+/// Speech-to-text via Google Cloud Speech-to-Text v2 over plain REST, returning
+/// real word timings. v2 rejects API keys, so a service-account JSON key is
+/// turned into a bearer token via the Google.Apis.Auth package SE already ships
+/// for Google TTS. BatchRecognize only reads from Cloud Storage, so the flow is:
+/// ensure bucket → upload object → batchRecognize → poll operation → delete object.
+/// Sync Recognize would avoid the bucket but is capped at one minute of audio.
+/// </summary>
+public class GoogleCloudSttService : ISttTranscriber
+{
+    private const string Scope = "https://www.googleapis.com/auth/cloud-platform";
+    private const string StorageApi = "https://storage.googleapis.com/storage/v1";
+    private const string StorageUploadApi = "https://storage.googleapis.com/upload/storage/v1";
+
+    private readonly HttpClient _httpClient;
+    private readonly GoogleCloudSttSettings _settings;
+    private ITokenAccess? _credential;
+
+    public GoogleCloudSttService(GoogleCloudSttSettings settings)
+        : this(OpenAiSttService.SharedHttpClient, settings)
+    {
+    }
+
+    public GoogleCloudSttService(HttpClient httpClient, GoogleCloudSttSettings settings)
+    {
+        _httpClient = httpClient;
+        _settings = settings;
+    }
+
+    /// <summary>Chirp models are served only from regional hosts ("us", "eu", ...); "global" uses the plain host.</summary>
+    public static string GetSpeechHost(string? region)
+    {
+        var r = (region ?? string.Empty).Trim().ToLowerInvariant();
+        return r.Length == 0 || r == "global" ? "speech.googleapis.com" : $"{r}-speech.googleapis.com";
+    }
+
+    /// <summary>Bucket names are globally unique, so derive one from the (globally unique) project id.</summary>
+    public static string DeriveBucketName(string projectId)
+    {
+        const string suffix = "-subtitle-edit-stt";
+        var cleaned = new string(projectId.ToLowerInvariant().Select(c => char.IsAsciiLetterOrDigit(c) ? c : '-').ToArray()).Trim('-');
+        var max = 63 - suffix.Length;
+        return (cleaned.Length > max ? cleaned[..max] : cleaned) + suffix;
+    }
+
+    public async Task<OpenAiCompatibleSttResponse> TranscribeAsync(
+        string audioFilePath,
+        string? language,
+        IProgress<string>? progress,
+        IProgress<OpenAiCompatibleSegment>? segmentProgress,
+        CancellationToken cancellationToken)
+    {
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        if (_settings.TimeoutSeconds > 0)
+        {
+            timeoutCts.CancelAfter(TimeSpan.FromSeconds(_settings.TimeoutSeconds));
+        }
+        var ct = timeoutCts.Token;
+
+        try
+        {
+            var projectId = ReadProjectId(_settings.KeyFile);
+            _credential = (await GoogleCredential.FromFileAsync(_settings.KeyFile, ct)).CreateScoped(Scope);
+
+            var bucket = string.IsNullOrWhiteSpace(_settings.BucketName) ? DeriveBucketName(projectId) : _settings.BucketName.Trim();
+            await EnsureBucketAsync(projectId, bucket, ct);
+
+            var objectName = $"subtitle-edit/{Guid.NewGuid():N}{Path.GetExtension(audioFilePath)}";
+            progress?.Report("Uploading audio to Cloud Storage...");
+            await UploadAsync(bucket, objectName, audioFilePath, ct);
+            var gcsUri = $"gs://{bucket}/{objectName}";
+
+            try
+            {
+                progress?.Report("Submitting transcription...");
+                var operationName = await SubmitAsync(projectId, gcsUri, language, ct);
+                progress?.Report("Waiting for transcription to complete...");
+                var json = await PollAsync(operationName, ct);
+                return ParseResponse(json, _settings.Logger);
+            }
+            finally
+            {
+                await DeleteObjectAsync(bucket, objectName);
+            }
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            throw new TimeoutException($"Google Cloud transcription timed out after {_settings.TimeoutSeconds} seconds.");
+        }
+    }
+
+    internal static string ReadProjectId(string keyFile)
+    {
+        using var doc = JsonDocument.Parse(File.ReadAllText(keyFile));
+        if (doc.RootElement.TryGetProperty("project_id", out var p) && p.ValueKind == JsonValueKind.String)
+        {
+            return p.GetString()!;
+        }
+
+        throw new HttpRequestException("The key file is not a Google Cloud service account key (no project_id). In the Google Cloud console create a service account key of type JSON.");
+    }
+
+    private async Task<HttpResponseMessage> SendAsync(HttpMethod method, string url, HttpContent? content, CancellationToken ct)
+    {
+        var token = await _credential!.GetAccessTokenForRequestAsync(null, ct);
+        using var request = new HttpRequestMessage(method, url) { Content = content };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+    }
+
+    private async Task<string> SendAndReadAsync(HttpMethod method, string url, HttpContent? content, string what, CancellationToken ct)
+    {
+        using var response = await SendAsync(method, url, content, ct);
+        var body = await response.Content.ReadAsStringAsync(ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            _settings.Logger?.Invoke($"Google Cloud {what} failed: {method} {url} => {(int)response.StatusCode}: {body}");
+            var hint = response.StatusCode == HttpStatusCode.Forbidden
+                ? " Grant the service account the 'Cloud Speech Client' and 'Storage Admin' roles and enable the Speech-to-Text API."
+                : string.Empty;
+            throw new HttpRequestException($"Google Cloud {what} failed ({(int)response.StatusCode}).{hint} Response: {body}");
+        }
+
+        return body;
+    }
+
+    private async Task EnsureBucketAsync(string projectId, string bucket, CancellationToken ct)
+    {
+        using var probe = await SendAsync(HttpMethod.Get, $"{StorageApi}/b/{bucket}", null, ct);
+        if (probe.StatusCode != HttpStatusCode.NotFound)
+        {
+            if (!probe.IsSuccessStatusCode)
+            {
+                throw new HttpRequestException($"Google Cloud bucket check failed ({(int)probe.StatusCode}). Response: {await probe.Content.ReadAsStringAsync(ct)}");
+            }
+            return;
+        }
+
+        _settings.Logger?.Invoke($"Google Cloud: creating bucket {bucket}");
+        var location = GetSpeechHost(_settings.Region) == "speech.googleapis.com" ? "us" : _settings.Region.Trim();
+        var body = JsonSerializer.Serialize(new
+        {
+            name = bucket,
+            location,
+            // Objects are deleted after each run; the rule sweeps leftovers from a killed run.
+            lifecycle = new { rule = new[] { new { action = new { type = "Delete" }, condition = new { age = 1 } } } },
+        });
+        using var content = new StringContent(body, Encoding.UTF8, "application/json");
+        await SendAndReadAsync(HttpMethod.Post, $"{StorageApi}/b?project={Uri.EscapeDataString(projectId)}", content, "bucket create", ct);
+    }
+
+    private async Task UploadAsync(string bucket, string objectName, string filePath, CancellationToken ct)
+    {
+        await using var stream = File.OpenRead(filePath);
+        using var content = new StreamContent(stream);
+        content.Headers.ContentType = new MediaTypeHeaderValue(Path.GetExtension(filePath).ToLowerInvariant() switch
+        {
+            ".mp3" => "audio/mpeg",
+            ".wav" => "audio/wav",
+            ".flac" => "audio/flac",
+            _ => "application/octet-stream",
+        });
+        await SendAndReadAsync(HttpMethod.Post,
+            $"{StorageUploadApi}/b/{bucket}/o?uploadType=media&name={Uri.EscapeDataString(objectName)}", content, "upload", ct);
+    }
+
+    private async Task DeleteObjectAsync(string bucket, string objectName)
+    {
+        try
+        {
+            using var _ = await SendAsync(HttpMethod.Delete, $"{StorageApi}/b/{bucket}/o/{Uri.EscapeDataString(objectName)}", null, CancellationToken.None);
+        }
+        catch
+        {
+            // Swept by the bucket's one-day lifecycle rule instead.
+        }
+    }
+
+    private async Task<string> SubmitAsync(string projectId, string gcsUri, string? language, CancellationToken ct)
+    {
+        var region = _settings.Region.Trim();
+        var url = $"https://{GetSpeechHost(region)}/v2/projects/{projectId}/locations/{(region.Length == 0 ? "global" : region)}/recognizers/_:batchRecognize";
+        using var content = new StringContent(BuildRequestBody(_settings, gcsUri, language), Encoding.UTF8, "application/json");
+        var json = await SendAndReadAsync(HttpMethod.Post, url, content, "batchRecognize", ct);
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.GetProperty("name").GetString()!;
+    }
+
+    /// <summary>"auto" lets Chirp detect the language; other models need a BCP-47 code such as en-US.</summary>
+    internal static string BuildRequestBody(GoogleCloudSttSettings settings, string gcsUri, string? language)
+    {
+        var lang = string.IsNullOrWhiteSpace(language) ? settings.Language : language;
+        return JsonSerializer.Serialize(new
+        {
+            config = new
+            {
+                autoDecodingConfig = new { },
+                languageCodes = new[] { string.IsNullOrWhiteSpace(lang) ? "auto" : lang.Trim() },
+                model = string.IsNullOrWhiteSpace(settings.Model) ? "chirp_3" : settings.Model.Trim(),
+                features = new { enableWordTimeOffsets = true, enableAutomaticPunctuation = true },
+            },
+            files = new[] { new { uri = gcsUri } },
+            recognitionOutputConfig = new { inlineResponseConfig = new { } },
+        });
+    }
+
+    private async Task<string> PollAsync(string operationName, CancellationToken ct)
+    {
+        var url = $"https://{GetSpeechHost(_settings.Region)}/v2/{operationName}";
+        while (true)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(5), ct);
+            var json = await SendAndReadAsync(HttpMethod.Get, url, null, "operation poll", ct);
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.TryGetProperty("done", out var done) && done.GetBoolean())
+            {
+                if (doc.RootElement.TryGetProperty("error", out var error))
+                {
+                    throw new HttpRequestException($"Google Cloud transcription failed: {error}");
+                }
+
+                return json;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Map a finished operation into timed segments: one per Google result, timed
+    /// by its first and last word. Words are range-checked against the billed
+    /// duration because the API has been seen returning offsets far outside the
+    /// audio; a result whose words are all bogus falls back to resultEndOffset.
+    /// </summary>
+    internal static OpenAiCompatibleSttResponse ParseResponse(string json, Action<string>? logger = null)
+    {
+        var response = new OpenAiCompatibleSttResponse { Segments = new List<OpenAiCompatibleSegment>() };
+        using var doc = JsonDocument.Parse(json);
+        if (!doc.RootElement.TryGetProperty("response", out var batch) || !batch.TryGetProperty("results", out var files))
+        {
+            return response;
+        }
+
+        var billed = batch.TryGetProperty("totalBilledDuration", out var b) ? ParseDuration(b) : 0.0;
+        var text = new StringBuilder();
+        var previousEnd = 0.0;
+        foreach (var file in files.EnumerateObject())
+        {
+            if (file.Value.TryGetProperty("error", out var error) && error.TryGetProperty("message", out var message))
+            {
+                throw new HttpRequestException($"Google Cloud could not transcribe the audio: {message.GetString()}");
+            }
+
+            if (!file.Value.TryGetProperty("inlineResult", out var inline) ||
+                !inline.TryGetProperty("transcript", out var transcript) ||
+                !transcript.TryGetProperty("results", out var results))
+            {
+                continue;
+            }
+
+            foreach (var result in results.EnumerateArray())
+            {
+                if (!result.TryGetProperty("alternatives", out var alternatives) || alternatives.GetArrayLength() == 0)
+                {
+                    continue;
+                }
+
+                var alternative = alternatives[0];
+                var segmentText = alternative.TryGetProperty("transcript", out var t) ? (t.GetString() ?? string.Empty).Trim() : string.Empty;
+                if (segmentText.Length == 0)
+                {
+                    continue;
+                }
+
+                if (response.Language == null && result.TryGetProperty("languageCode", out var lc))
+                {
+                    response.Language = lc.GetString()?.Split('-')[0];
+                }
+
+                var words = new List<OpenAiCompatibleWord>();
+                if (alternative.TryGetProperty("words", out var wordArray))
+                {
+                    foreach (var w in wordArray.EnumerateArray())
+                    {
+                        var start = w.TryGetProperty("startOffset", out var s) ? ParseDuration(s) : -1;
+                        var end = w.TryGetProperty("endOffset", out var e) ? ParseDuration(e) : -1;
+                        var word = w.TryGetProperty("word", out var wt) ? wt.GetString() ?? string.Empty : string.Empty;
+                        if (start < 0 || end < start || (billed > 0 && end > billed + 1))
+                        {
+                            logger?.Invoke($"Google Cloud: dropped word '{word}' with impossible timing {start:0.###}-{end:0.###} s");
+                            continue;
+                        }
+
+                        words.Add(new OpenAiCompatibleWord { Word = word, Start = start, End = end });
+                    }
+                }
+
+                var resultEnd = result.TryGetProperty("resultEndOffset", out var re) ? ParseDuration(re) : previousEnd;
+                var segment = new OpenAiCompatibleSegment
+                {
+                    Id = response.Segments.Count,
+                    Start = words.Count > 0 ? words[0].Start : previousEnd,
+                    End = words.Count > 0 ? words[^1].End : resultEnd,
+                    Text = segmentText,
+                    Words = words.Count > 0 ? words : null,
+                };
+                previousEnd = segment.End;
+                response.Segments.Add(segment);
+                text.Append(segmentText).Append(' ');
+            }
+        }
+
+        response.Text = text.ToString().Trim();
+        response.Duration = billed > 0 ? billed : null;
+        if (billed > 60 && previousEnd < billed * 0.9)
+        {
+            // Google has been seen stopping part-way through a chunk while still reporting success.
+            logger?.Invoke($"Google Cloud: transcript ends at {previousEnd:0.#} s but {billed:0.#} s of audio was billed - part of the audio may be missing");
+        }
+
+        return response;
+    }
+
+    /// <summary>REST encodes proto Durations as strings like "1.500s".</summary>
+    internal static double ParseDuration(JsonElement element)
+    {
+        var s = element.ValueKind == JsonValueKind.String ? element.GetString() ?? string.Empty : element.GetRawText();
+        return double.TryParse(s.TrimEnd('s'), NumberStyles.Float, CultureInfo.InvariantCulture, out var d) ? d : -1;
+    }
+}

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -127,6 +127,13 @@ public partial class SpeechToTextViewModel : ObservableObject
     [ObservableProperty] private int _dashScopeSttTimeoutSeconds;
     public ObservableCollection<string> DashScopeSttRegions { get; } = new(new[] { "international", "china" });
 
+    [ObservableProperty] private bool _isGoogleCloudSttVisible;
+    [ObservableProperty] private string? _googleCloudSttKeyFile;
+    [ObservableProperty] private string? _googleCloudSttRegion;
+    [ObservableProperty] private string? _googleCloudSttModel;
+    [ObservableProperty] private string? _googleCloudSttLanguage;
+    [ObservableProperty] private int _googleCloudSttTimeoutSeconds;
+
     public Window? Window { get; set; }
 
     public bool OkPressed { get; private set; }
@@ -274,6 +281,7 @@ public partial class SpeechToTextViewModel : ObservableObject
         // Online STT services reachable on all platforms
         Engines.Add(new OpenRouterSttEngine());
         Engines.Add(new DashScopeQwen3SttEngine());
+        Engines.Add(new GoogleCloudSttEngine());
 
         if (OperatingSystem.IsWindows() ||
             OperatingSystem.IsLinux() ||
@@ -369,6 +377,12 @@ public partial class SpeechToTextViewModel : ObservableObject
         DashScopeSttEnableWords = Se.Settings.Tools.DashScopeSttEnableWords;
         DashScopeSttTimeoutSeconds = Se.Settings.Tools.DashScopeSttTimeoutSeconds;
 
+        GoogleCloudSttKeyFile = Se.Settings.Tools.GoogleCloudSttKeyFile;
+        GoogleCloudSttRegion = Se.Settings.Tools.GoogleCloudSttRegion;
+        GoogleCloudSttModel = Se.Settings.Tools.GoogleCloudSttModel;
+        GoogleCloudSttLanguage = Se.Settings.Tools.GoogleCloudSttLanguage;
+        GoogleCloudSttTimeoutSeconds = Se.Settings.Tools.GoogleCloudSttTimeoutSeconds;
+
         var savedChoice = Se.Settings.Tools.AudioToText.WhisperChoice;
         var whisperCppEngine = Engines.OfType<WhisperCppEngine>().FirstOrDefault();
         var crispAsrEngine = Engines.OfType<CrispAsrEngine>().FirstOrDefault();
@@ -447,6 +461,12 @@ public partial class SpeechToTextViewModel : ObservableObject
         Se.Settings.Tools.DashScopeSttRegion = DashScopeSttRegion ?? "international";
         Se.Settings.Tools.DashScopeSttEnableWords = DashScopeSttEnableWords;
         Se.Settings.Tools.DashScopeSttTimeoutSeconds = DashScopeSttTimeoutSeconds;
+
+        Se.Settings.Tools.GoogleCloudSttKeyFile = GoogleCloudSttKeyFile ?? string.Empty;
+        Se.Settings.Tools.GoogleCloudSttRegion = GoogleCloudSttRegion ?? "us";
+        Se.Settings.Tools.GoogleCloudSttModel = GoogleCloudSttModel ?? "chirp_3";
+        Se.Settings.Tools.GoogleCloudSttLanguage = GoogleCloudSttLanguage ?? string.Empty;
+        Se.Settings.Tools.GoogleCloudSttTimeoutSeconds = GoogleCloudSttTimeoutSeconds;
 
         Se.SaveSettings();
     }
@@ -1446,7 +1466,8 @@ public partial class SpeechToTextViewModel : ObservableObject
             });
 
             var audioSizeBytes = new FileInfo(audioFileName).Length;
-            if (audioSizeBytes > engine.UploadThresholdBytes && _videoInfo.TotalSeconds > 0)
+            var exceedsDurationCap = engine.MaxChunkSeconds > 0 && _videoInfo.TotalSeconds > engine.MaxChunkSeconds;
+            if ((audioSizeBytes > engine.UploadThresholdBytes || exceedsDurationCap) && _videoInfo.TotalSeconds > 0)
             {
                 LogToConsole($"Audio file is {audioSizeBytes / (1024 * 1024)} MB — splitting into chunks to stay under the upload cap");
                 await TranscribeInChunksAsync(service, engine, audioFileName, language, subtitle, segmentProgress, cancellationToken);
@@ -1744,6 +1765,10 @@ public partial class SpeechToTextViewModel : ObservableObject
         var totalSeconds = _videoInfo.TotalSeconds;
         var fileSize = new FileInfo(audioFileName).Length;
         var chunkCount = OpenAiSttChunker.ComputeChunkCount(fileSize, engine.ChunkSizeBytes);
+        if (engine.MaxChunkSeconds > 0)
+        {
+            chunkCount = Math.Max(chunkCount, (int)Math.Ceiling(totalSeconds / engine.MaxChunkSeconds));
+        }
 
         var ffmpegPath = Se.Settings.General.FfmpegPath;
         if (!File.Exists(ffmpegPath))
@@ -2156,6 +2181,7 @@ public partial class SpeechToTextViewModel : ObservableObject
         {
             OpenRouterSttEngine => Se.Settings.Tools.OpenRouterSttLanguage,
             DashScopeQwen3SttEngine => Se.Settings.Tools.DashScopeSttLanguage,
+            GoogleCloudSttEngine => Se.Settings.Tools.GoogleCloudSttLanguage,
             OpenAiCompatibleSttEngine => Se.Settings.Tools.OpenAiCompatibleSttLanguage,
             _ => null,
         };
@@ -2176,6 +2202,16 @@ public partial class SpeechToTextViewModel : ObservableObject
     /// "en" — so a full name is mapped back to its whisper language code. The
     /// first non-empty value wins; later chunks don't overwrite it.
     /// </summary>
+    [RelayCommand]
+    private async Task BrowseGoogleCloudSttKeyFile()
+    {
+        var fileName = await _fileHelper.PickOpenFile(Window!, Se.Language.General.KeyFile, "json files", "*.json");
+        if (!string.IsNullOrEmpty(fileName))
+        {
+            GoogleCloudSttKeyFile = fileName;
+        }
+    }
+
     private void RememberDetectedLanguage(OpenAiCompatibleSttResponse response)
     {
         if (!string.IsNullOrEmpty(_onlineDetectedLanguage) || string.IsNullOrWhiteSpace(response.Language))
@@ -4908,6 +4944,7 @@ public partial class SpeechToTextViewModel : ObservableObject
         IsOpenAiCompatibleSttVisible = engine is OpenAiCompatibleSttEngine;
         IsOpenRouterSttVisible = engine is OpenRouterSttEngine;
         IsDashScopeSttVisible = engine is DashScopeQwen3SttEngine;
+        IsGoogleCloudSttVisible = engine is GoogleCloudSttEngine;
         IsAdvancedSettingsVisible = !isOnlineSttEngine;
 
         IsTranslateVisible = IsTranslateAvailable(engine);

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
@@ -207,6 +207,7 @@ public class SpeechToTextWindow : Window
         var openAiRows = MakeOpenAiCompatibleSttRows(vm);
         var openRouterRows = MakeOpenRouterSttRows(vm);
         var dashScopeRows = MakeDashScopeSttRows(vm);
+        var googleCloudRows = MakeGoogleCloudSttRows(vm);
 
         var labelAdvancedSettings = UiUtil.MakeTextBlock(Se.Language.General.AdvancedSettings).WithMarginTop(15)
             .BindIsVisible(vm, nameof(vm.IsAdvancedSettingsVisible));
@@ -464,7 +465,7 @@ public class SpeechToTextWindow : Window
         grid.Add(panelForcedAlignerControls, row, 1);
         row++;
 
-        foreach (var (label, control) in openAiRows.Concat(openRouterRows).Concat(dashScopeRows))
+        foreach (var (label, control) in openAiRows.Concat(openRouterRows).Concat(dashScopeRows).Concat(googleCloudRows))
         {
             // Link each online-STT input to its visible label so a screen reader announces the
             // label as the control's name instead of a bare "edit"/"combo box" (#11745). Only the
@@ -861,6 +862,52 @@ public class SpeechToTextWindow : Window
             (MakeLabel(Se.Language.General.DashScopeSttRegion), comboRegion),
             (MakeLabel(Se.Language.General.OpenAiCompatibleSttLanguage), MakeText(nameof(vm.DashScopeSttLanguage), 150)),
             (MakeLabel(Se.Language.General.DashScopeSttEnableWords), checkEnableWords),
+            (MakeLabel(Se.Language.General.OpenAiCompatibleSttTimeout), numericTimeout),
+        };
+    }
+
+    private static (Control Label, Control Control)[] MakeGoogleCloudSttRows(SpeechToTextViewModel vm)
+    {
+        Control MakeLabel(string text) => UiUtil.MakeTextBlock(text).WithMarginTop(10)
+            .BindIsVisible(vm, nameof(vm.IsGoogleCloudSttVisible));
+
+        TextBox MakeText(string property, double width) => new TextBox
+        {
+            DataContext = vm,
+            Width = width,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 10, 0, 0),
+            [!TextBox.TextProperty] = new Binding(property) { Mode = BindingMode.TwoWay }
+        };
+
+        var buttonBrowse = UiUtil.MakeButtonBrowse(vm.BrowseGoogleCloudSttKeyFileCommand, accessibleName: Se.Language.General.KeyFile);
+        buttonBrowse.Margin = new Thickness(5, 10, 0, 0);
+        var keyFilePanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { MakeText(nameof(vm.GoogleCloudSttKeyFile), 400), buttonBrowse }
+        }.BindIsVisible(vm, nameof(vm.IsGoogleCloudSttVisible));
+
+        var numericTimeout = new NumericUpDown
+        {
+            DataContext = vm,
+            Width = 120,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 10, 0, 0),
+            Minimum = 30,
+            Maximum = 21600,
+            FormatString = "F0",
+            [!NumericUpDown.ValueProperty] = new Binding(nameof(vm.GoogleCloudSttTimeoutSeconds)) { Mode = BindingMode.TwoWay }
+        }.BindIsVisible(vm, nameof(vm.IsGoogleCloudSttVisible));
+
+        return new (Control, Control)[]
+        {
+            (MakeLabel(Se.Language.General.KeyFile), keyFilePanel),
+            (MakeLabel(Se.Language.General.Region), MakeText(nameof(vm.GoogleCloudSttRegion), 150).BindIsVisible(vm, nameof(vm.IsGoogleCloudSttVisible))),
+            (MakeLabel(Se.Language.General.Model), MakeText(nameof(vm.GoogleCloudSttModel), 250).BindIsVisible(vm, nameof(vm.IsGoogleCloudSttVisible))),
+            (MakeLabel(Se.Language.General.OpenAiCompatibleSttLanguage), MakeText(nameof(vm.GoogleCloudSttLanguage), 150).BindIsVisible(vm, nameof(vm.IsGoogleCloudSttVisible))),
             (MakeLabel(Se.Language.General.OpenAiCompatibleSttTimeout), numericTimeout),
         };
     }

--- a/src/ui/Logic/Config/SeTools.cs
+++ b/src/ui/Logic/Config/SeTools.cs
@@ -160,6 +160,13 @@ public class SeTools
     public bool DashScopeSttEnableWords { get; set; }
     public int DashScopeSttTimeoutSeconds { get; set; } = 3600;
 
+    public string GoogleCloudSttKeyFile { get; set; } = string.Empty;
+    public string GoogleCloudSttRegion { get; set; } = "us";
+    public string GoogleCloudSttModel { get; set; } = "chirp_3";
+    public string GoogleCloudSttLanguage { get; set; } = string.Empty;
+    public string GoogleCloudSttBucketName { get; set; } = string.Empty;
+    public int GoogleCloudSttTimeoutSeconds { get; set; } = 3600;
+
     public List<string> FindHistory { get; set; } = new List<string>();
     public bool AllowSingleLetterShortcutsInTextbox { get; set; }
 

--- a/tests/UI/Features/Video/SpeechToText/GoogleCloud/GoogleCloudSttServiceTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/GoogleCloud/GoogleCloudSttServiceTests.cs
@@ -1,0 +1,129 @@
+using System.Text.Json;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText.GoogleCloud;
+
+namespace UITests.Features.Video.SpeechToText.GoogleCloud;
+
+public class GoogleCloudSttServiceTests
+{
+    [Theory]
+    [InlineData("us", "us-speech.googleapis.com")]
+    [InlineData(" EU ", "eu-speech.googleapis.com")]
+    [InlineData("global", "speech.googleapis.com")]
+    [InlineData("", "speech.googleapis.com")]
+    [InlineData(null, "speech.googleapis.com")]
+    public void GetSpeechHost_PicksRegionalHost(string? region, string expected)
+    {
+        Assert.Equal(expected, GoogleCloudSttService.GetSpeechHost(region));
+    }
+
+    [Fact]
+    public void DeriveBucketName_IsLowercaseAndWithinLimit()
+    {
+        Assert.Equal("my-project-123-subtitle-edit-stt", GoogleCloudSttService.DeriveBucketName("My_Project.123"));
+        Assert.True(GoogleCloudSttService.DeriveBucketName(new string('x', 100)).Length <= 63);
+    }
+
+    [Fact]
+    public void BuildRequestBody_UsesAutoLanguageAndWordTimings()
+    {
+        var body = GoogleCloudSttService.BuildRequestBody(new GoogleCloudSttSettings { Model = "chirp_3" }, "gs://b/o.mp3", null);
+        using var doc = JsonDocument.Parse(body);
+        var config = doc.RootElement.GetProperty("config");
+        Assert.Equal("auto", config.GetProperty("languageCodes")[0].GetString());
+        Assert.Equal("chirp_3", config.GetProperty("model").GetString());
+        Assert.True(config.GetProperty("features").GetProperty("enableWordTimeOffsets").GetBoolean());
+        Assert.Equal("gs://b/o.mp3", doc.RootElement.GetProperty("files")[0].GetProperty("uri").GetString());
+        Assert.True(doc.RootElement.GetProperty("recognitionOutputConfig").TryGetProperty("inlineResponseConfig", out _));
+    }
+
+    [Fact]
+    public void BuildRequestBody_PerChunkLanguageBeatsSetting()
+    {
+        var body = GoogleCloudSttService.BuildRequestBody(new GoogleCloudSttSettings { Language = "da-DK" }, "gs://b/o", "en-US");
+        Assert.Contains("\"languageCodes\":[\"en-US\"]", body);
+    }
+
+    private const string OperationJson = """
+        {
+          "name": "projects/p/locations/us/operations/1",
+          "done": true,
+          "response": {
+            "totalBilledDuration": "1080s",
+            "results": {
+              "gs://b/o.mp3": {
+                "inlineResult": {
+                  "transcript": {
+                    "results": [
+                      {
+                        "alternatives": [{
+                          "transcript": "Hello there.",
+                          "words": [
+                            { "word": "Hello", "startOffset": "0.500s", "endOffset": "0.900s" },
+                            { "word": "there.", "startOffset": "1s", "endOffset": "1.400s" }
+                          ]
+                        }],
+                        "resultEndOffset": "2s",
+                        "languageCode": "en-US"
+                      },
+                      {
+                        "alternatives": [{
+                          "transcript": "Corrupt words.",
+                          "words": [
+                            { "word": "Corrupt", "startOffset": "6324s", "endOffset": "6325s" },
+                            { "word": "words.", "startOffset": "5s", "endOffset": "4s" }
+                          ]
+                        }],
+                        "resultEndOffset": "7.5s"
+                      },
+                      { "alternatives": [{ "transcript": "   " }] }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+        """;
+
+    [Fact]
+    public void ParseResponse_MapsWordsToSegmentsAndDropsImpossibleTimings()
+    {
+        var response = GoogleCloudSttService.ParseResponse(OperationJson);
+
+        Assert.NotNull(response.Segments);
+        Assert.Equal(2, response.Segments!.Count);
+
+        Assert.Equal("Hello there.", response.Segments[0].Text);
+        Assert.Equal(0.5, response.Segments[0].Start, 3);
+        Assert.Equal(1.4, response.Segments[0].End, 3);
+        Assert.Equal(2, response.Segments[0].Words!.Count);
+
+        // Both words fail the range check, so the segment falls back to the
+        // previous end and Google's resultEndOffset.
+        Assert.Equal("Corrupt words.", response.Segments[1].Text);
+        Assert.Null(response.Segments[1].Words);
+        Assert.Equal(1.4, response.Segments[1].Start, 3);
+        Assert.Equal(7.5, response.Segments[1].End, 3);
+
+        Assert.Equal("en", response.Language);
+        Assert.Equal(1080, response.Duration);
+        Assert.Equal("Hello there. Corrupt words.", response.Text);
+    }
+
+    [Fact]
+    public void ParseResponse_ThrowsOnPerFileError()
+    {
+        const string json = """{"done":true,"response":{"results":{"gs://b/o":{"error":{"code":3,"message":"bad audio"}}}}}""";
+        var ex = Assert.Throws<HttpRequestException>(() => GoogleCloudSttService.ParseResponse(json));
+        Assert.Contains("bad audio", ex.Message);
+    }
+
+    [Fact]
+    public void ParseDuration_ReadsProtoDurationStrings()
+    {
+        using var doc = JsonDocument.Parse("""["1.500s","12s","x"]""");
+        Assert.Equal(1.5, GoogleCloudSttService.ParseDuration(doc.RootElement[0]));
+        Assert.Equal(12, GoogleCloudSttService.ParseDuration(doc.RootElement[1]));
+        Assert.Equal(-1, GoogleCloudSttService.ParseDuration(doc.RootElement[2]));
+    }
+}


### PR DESCRIPTION
## Summary

Adds **Google Cloud Speech-to-Text** to the Speech to text engine list, using the v2 API over plain REST with word level timings.

- **No new NuGet packages.** The service-account JSON key becomes a bearer token via `Google.Apis.Auth`, which SE already ships for Google TTS. Everything else is `HttpClient` + `System.Text.Json`.
- **No new language strings.** The settings rows reuse "Key file", "Region", "Model", "Language Hint" and "Timeout (seconds)".
- **Flow:** ensure bucket → upload audio → `batchRecognize` → poll operation → delete object. BatchRecognize only reads from Cloud Storage; the bucket `<project>-subtitle-edit-stt` is created on first use with a one-day lifecycle rule (override via `GoogleCloudSttBucketName` in Settings.json).
- **Parsing:** one segment per Google result, timed by its first and last word. Words with impossible offsets are dropped (the API has been observed returning offsets far outside the audio), and a transcript that ends well before the billed duration is logged as possibly truncated.
- `IOnlineSttEngine` gains an optional `MaxChunkSeconds`; the shared chunker now also splits by duration. Google caps a file with word timings at 20 minutes, the engine uses 18.

Background: the plugin proposed in SubtitleEdit/plugins#289 ships a 40 MB self-contained app per platform. Folding the engine into SE costs a few tens of KB because the gRPC/auth stack is already present.

## Setup for users

Speech-to-Text v2 rejects API keys. The user needs a Google Cloud project with billing, the Speech-to-Text API enabled, a service account with the roles *Cloud Speech Client* and *Storage Admin*, and its JSON key. Defaults: region `us`, model `chirp_3`, empty language hint = automatic detection.

## Testing

- `tests/UI/.../GoogleCloud/GoogleCloudSttServiceTests.cs`: host selection, bucket naming, request body, response parsing incl. corrupt words and per-file errors, proto duration parsing.
- All 278 SpeechToText UI tests pass.
- **Not tested against the live API** (needs a funded Google Cloud project). REST shapes follow the v2 reference docs and match the plugin's working gRPC calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
