### PR TITLE
Add per-line voice cloning to VibeVoice and MOSS-TTS (CrispASR)

### DIFF
--- a/docs/features/text-to-speech.md
+++ b/docs/features/text-to-speech.md
@@ -106,7 +106,7 @@ Notes on picking one:
 - **Highest output rate:** VoxCPM2 and dots.tts at 48 kHz, then Zonos at 44.1 kHz.
 - **MOSS-TTS is by far the largest** because its Qwen3-8B backbone needs a ~3.5 GB codec companion on top of the backbone quant. Check free disk space before selecting it.
 - Quantized engines follow the same rule as the speech-to-text models: `Q4_K` is the small fast default, `Q8_0` is close to full precision, and `F16` is rarely worth the extra gigabytes.
-- **Most of the CrispASR engines load their reference voice at server start**, so switching voice reloads the model. The exceptions are **Pocket TTS** (per-request reference) and **Qwen3 TTS** with the Voice clone model — those, the three audio.cpp engines (**IndexTTS 2.5**, **Higgs Audio v3**, **Fish Audio S2 Pro**) and the standalone OmniVoice TTS engine are what [Clone From Video (Voice of Each Line)](#clone-from-video-voice-of-each-line) can use.
+- **Most of the CrispASR engines load their reference voice at server start**, so switching voice reloads the model. The exceptions are **Pocket TTS**, **VibeVoice** and **MOSS-TTS** (per-request reference) and **Qwen3 TTS** with the Voice clone model — those, the three audio.cpp engines (**IndexTTS 2.5**, **Higgs Audio v3**, **Fish Audio S2 Pro**) and the standalone OmniVoice TTS engine are what [Clone From Video (Voice of Each Line)](#clone-from-video-voice-of-each-line) can use.
 
 ## Engine Settings
 
@@ -163,7 +163,7 @@ For dubbing a video with several speakers there is a faster way than cloning eac
 
 Before generating, Subtitle Edit cuts one short reference clip per line out of the video's audio. Lines shorter than about three seconds are grown into the silence around them, but never into the neighbouring line — a reference with two speakers in it would clone the wrong person.
 
-- **Supported engines:** OmniVoice TTS, Pocket TTS (CrispASR), Qwen3 TTS (CrispASR) with the Voice clone model, and the audio.cpp engines IndexTTS 2.5, Higgs Audio v3 and Fish Audio S2 Pro. The entry only appears for engines that accept a reference for each line; engines that load their reference when their server starts would have to reload the model for every line.
+- **Supported engines:** OmniVoice TTS, Pocket TTS (CrispASR), VibeVoice (CrispASR), MOSS-TTS (CrispASR), Qwen3 TTS (CrispASR) with the Voice clone model, and the audio.cpp engines IndexTTS 2.5, Higgs Audio v3 and Fish Audio S2 Pro. The entry only appears for engines that accept a reference for each line; engines that load their reference when their server starts would have to reload the model for every line.
 - **Reference text:** if you have the original subtitle loaded next to the translation, its lines are used as the transcript of the clips — that is what the video actually says, and it makes cloning noticeably better. Without an original loaded, the line's own text is used.
 - **Test voice** previews the clone taken from the longest line of the subtitle.
 - Quality depends on the source audio. Loud music or two people talking over each other in a line makes that line's clone worse. Longer subtitle lines clone better than very short ones, so a subtitle segmented into full sentences gives the best result.

--- a/src/ui/Features/Video/TextToSpeech/Engines/MossTtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/MossTtsCrispAsr.cs
@@ -59,7 +59,7 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 ///   valid 24 kHz WAV at RTF≈1.7; `voice` resolves as the file stem inside --voice-dir
 ///   (same name-not-path rule as VoxCPM2)
 /// </summary>
-public class MossTtsCrispAsr : ITtsEngine
+public class MossTtsCrispAsr : ITtsEngine, IPerLineCloneEngine
 {
     public string Name => "MOSS-TTS (CrispASR)";
     public string Description => "MOSS-TTS v1.5 24 kHz TTS with zero-shot voice cloning, via CrispASR";
@@ -69,7 +69,11 @@ public class MossTtsCrispAsr : ITtsEngine
     public bool HasModel => true;
     public bool HasKeyFile => false;
     public bool SupportsVoiceCloning => true;
-    public bool SupportsPerLineVoiceCloning => false;
+    // Per-line clones are sent as a per-request `voice` stem, which the moss-tts backend resolves
+    // against --voice-dir and re-encodes only when it changes (CrispASR v0.8.30+, #384) - no
+    // server restart per line. See Speak and EnsureServerRunningAsync for the split between
+    // this and the ordinary imported voices, which stay on the startup --voice flag.
+    public bool SupportsPerLineVoiceCloning => true;
 
     // Four backbone quants — Q4_K is the default (~7 GB), F16 the reference (~17 GB), with
     // Q6_K/Q8_0 in between (added upstream 2026-07-27, TTS round-trip validated; #12905). All
@@ -175,6 +179,9 @@ public class MossTtsCrispAsr : ITtsEngine
     // restart so the new --voice path takes effect.
     private static string? _serverVoicePath;
     private static string? _serverRefText;
+    // True when the running server was started for a per-line clone run: every line then sends
+    // its own reference as a per-request `voice`, so a new staged clip is not a restart.
+    private static bool _serverPerLine;
     // Value of the startup -l flag (empty = Auto / no flag); part of the server key.
     private static string? _serverLanguageArg;
     private static bool _processExitHooked;
@@ -398,6 +405,13 @@ public class MossTtsCrispAsr : ITtsEngine
         {
             foreach (var file in Directory.GetFiles(voicesFolder, "*.wav"))
             {
+                // The per-line clone's own references live here too (the backend resolves bare
+                // stems against --voice-dir); they belong to one line of one run, not in a combo.
+                if (PerLineReferenceStaging.IsStaged(file))
+                {
+                    continue;
+                }
+
                 var name = Path.GetFileNameWithoutExtension(file).Replace('_', ' ');
                 result.Add(new Voice(new MossTtsVoice(name, file)));
             }
@@ -405,6 +419,42 @@ public class MossTtsCrispAsr : ITtsEngine
 
         return result.ToArray();
     }
+
+    /// <summary>
+    /// <see cref="IPerLineCloneEngine"/>: the moss-tts backend reads a per-request <c>voice</c>
+    /// as a bare stem inside its own --voice-dir, so the clip is staged in there first and the
+    /// voice's FilePath points at the copy - that is the lookup key <see cref="Speak"/> sends.
+    /// Cloning is zero-shot from audio alone, so a clip without a transcript sidecar is as good
+    /// as one with; staging only fails on a missing clip.
+    /// </summary>
+    public Voice? MakePerLineCloneVoice(string clipFileName, string voiceName) =>
+        StagePerLineReference(clipFileName) is { } staged
+            ? new Voice(new MossTtsVoice(voiceName, staged))
+            : null;
+
+    /// <summary>
+    /// The staged copy in the voices folder, which is the only reference this engine ever
+    /// speaks from - exporting it is what lets an imported session be re-dubbed on a machine
+    /// that no longer has the video.
+    /// </summary>
+    public string? GetPerLineReferenceClip(Voice voice) =>
+        voice.EngineVoice is MossTtsVoice mossVoice && !string.IsNullOrEmpty(mossVoice.FilePath)
+            ? mossVoice.FilePath
+            : null;
+
+    /// <summary>
+    /// <see cref="IPerLineCloneEngine"/>: see <see cref="ClearStagedPerLineReferences"/>.
+    /// </summary>
+    public void ResetStagedPerLineReferences() => ClearStagedPerLineReferences();
+
+    public static string? StagePerLineReference(string clipFileName) =>
+        PerLineReferenceStaging.Stage(clipFileName, GetSetVoicesFolder(), "MOSS-TTS (CrispASR)");
+
+    /// <summary>
+    /// Removes every staged per-line reference, leaving the user's imported voices alone.
+    /// </summary>
+    public static void ClearStagedPerLineReferences() =>
+        PerLineReferenceStaging.Clear(Path.Combine(GetSetFolder(), "voices"), "MOSS-TTS (CrispASR)");
 
     public bool IsVoiceInstalled(Voice voice) => true;
 
@@ -443,12 +493,17 @@ public class MossTtsCrispAsr : ITtsEngine
         var refText = TryReadRefText(mossVoice.FilePath);
         var modelKey = ResolveModelKey(model);
         var languageArg = MossTtsLanguages.ResolveLanguageArg(language);
-        await EnsureServerRunningAsync(modelKey, mossVoice.FilePath, refText, languageArg, cancellationToken);
+        // A per-line clone's reference is sent per request (bare stem inside --voice-dir), so the
+        // server is keyed on (model, language) only for those; an ordinary imported voice keeps
+        // the startup --voice flag and its restart-on-change - see BuildSpeakPayload.
+        var isPerLineClone = PerLineReferenceStaging.IsStaged(mossVoice.FilePath);
+        await EnsureServerRunningAsync(modelKey, mossVoice.FilePath, refText, languageArg, isPerLineClone, cancellationToken);
 
         var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder), Guid.NewGuid() + ".wav");
 
         var speed = Math.Clamp(Se.Settings.Video.TextToSpeech.MossTtsCrispAsrSpeed, 0.25, 4.0);
-        var payload = BuildSpeakPayload(text, speed);
+        var payload = BuildSpeakPayload(text, speed,
+            isPerLineClone ? Path.GetFileNameWithoutExtension(mossVoice.FilePath) : null);
 
         var body = JsonSerializer.Serialize(payload);
         using var content = new StringContent(body, Encoding.UTF8, "application/json");
@@ -515,8 +570,16 @@ public class MossTtsCrispAsr : ITtsEngine
     /// Builds the <c>/v1/audio/speech</c> JSON payload. Extracted so the #12757 fix (no per-request
     /// <c>voice</c> field) is unit-testable without a running crispasr server.
     /// </summary>
+    /// <param name="perLineVoiceName">
+    /// The bare stem of a staged per-line reference to send as the request's <c>voice</c>, or
+    /// null for an ordinary imported voice. Since CrispASR v0.8.30 (#384) the moss-tts backend
+    /// resolves a bare name against --voice-dir and re-encodes the reference only when it
+    /// changes, which is what makes a different clip per line affordable. Ordinary voices stay
+    /// on the startup flag below: on an older runtime a per-request name is exactly the #12757
+    /// failure, and the update dot on the engine flags such a runtime for the new mode.
+    /// </param>
     /// <remarks>
-    /// Deliberately sends NO <c>voice</c> or <c>ref_text</c> field. The crispasr <c>moss-tts</c>
+    /// For ordinary voices, deliberately sends NO <c>voice</c> or <c>ref_text</c> field. The crispasr <c>moss-tts</c>
     /// backend loads the clone reference from the server's startup <c>--voice &lt;path&gt;</c>
     /// (and <c>--ref-text</c>) flags — which <see cref="EnsureServerRunningAsync"/> always passes,
     /// restarting the server whenever the selected voice changes. A per-request <c>voice</c> value
@@ -533,7 +596,7 @@ public class MossTtsCrispAsr : ITtsEngine
     /// (MOSS-TTS Q4_K sometimes rushes the words + trails silence) comes out clean on regenerate —
     /// a fixed seed would lock that bad render in permanently.
     /// </remarks>
-    internal static Dictionary<string, object> BuildSpeakPayload(string text, double speed)
+    internal static Dictionary<string, object> BuildSpeakPayload(string text, double speed, string? perLineVoiceName = null)
     {
         var payload = new Dictionary<string, object>
         {
@@ -541,6 +604,11 @@ public class MossTtsCrispAsr : ITtsEngine
             ["response_format"] = "wav",
             ["speed"] = speed,
         };
+
+        if (!string.IsNullOrEmpty(perLineVoiceName))
+        {
+            payload["voice"] = perLineVoiceName;
+        }
 
         // Voice cloning is gated behind a consent attestation and, since CrispASR v0.8.22, a
         // marking attestation when the spoken disclaimer is skipped. The user supplies their own
@@ -605,16 +673,20 @@ public class MossTtsCrispAsr : ITtsEngine
         }
     }
 
-    private static async Task EnsureServerRunningAsync(string modelKey, string voicePath, string refText, string languageArg, CancellationToken ct)
+    private static async Task EnsureServerRunningAsync(string modelKey, string voicePath, string refText, string languageArg, bool perLine, CancellationToken ct)
     {
         // Language joins (model, voice, ref-text) in the server key: /v1/audio/speech has no
         // per-request `language` field, so the only way to reach moss-tts with one is the startup
         // -l flag — which means switching language needs a fresh server, same as switching voice.
+        // A per-line clone run is the exception to the voice half: each line carries its own
+        // reference in the request, so within such a run the server is keyed on (model,
+        // language) alone. The first clip still goes on the startup flag, which is harmless.
         bool MatchesCurrent() =>
             _serverProcess is { HasExited: false } && _serverPort != 0
             && string.Equals(_serverModelKey, modelKey, StringComparison.OrdinalIgnoreCase)
             && string.Equals(_serverLanguageArg, languageArg, StringComparison.OrdinalIgnoreCase)
             && (!UseStartupVoiceFlags
+                || (perLine && _serverPerLine)
                 || (string.Equals(_serverVoicePath, voicePath, StringComparison.OrdinalIgnoreCase)
                     && string.Equals(_serverRefText, refText, StringComparison.Ordinal)));
 
@@ -730,6 +802,7 @@ public class MossTtsCrispAsr : ITtsEngine
             _serverModelKey = modelKey;
             _serverVoicePath = voicePath;
             _serverRefText = refText;
+            _serverPerLine = perLine;
             _serverLanguageArg = languageArg;
             HookProcessExitOnce();
 
@@ -750,6 +823,7 @@ public class MossTtsCrispAsr : ITtsEngine
                     _serverModelKey = null;
                     _serverVoicePath = null;
                     _serverRefText = null;
+                    _serverPerLine = false;
                     _serverLanguageArg = null;
                     throw new InvalidOperationException(
                         $"crispasr (moss-tts) exited during startup (code {exitCode}). Output: {tail}"
@@ -834,6 +908,7 @@ public class MossTtsCrispAsr : ITtsEngine
         _serverModelKey = null;
         _serverVoicePath = null;
         _serverRefText = null;
+        _serverPerLine = false;
         _serverLanguageArg = null;
         if (p == null)
         {

--- a/src/ui/Features/Video/TextToSpeech/Engines/PerLineReferenceStaging.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/PerLineReferenceStaging.cs
@@ -1,0 +1,119 @@
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.IO;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// The file-copy half of per-line voice cloning for the CrispASR engines whose backend resolves a
+/// request's <c>voice</c> as a bare name inside <c>--voice-dir</c>: the clip a line was cut from
+/// has to be copied into the engine's own voices folder before its stem means anything to the
+/// server. Shared by <see cref="VibeVoiceCrispAsr"/> and <see cref="MossTtsCrispAsr"/>; the
+/// older engines (<see cref="PocketTtsCrispAsr"/>, <see cref="Qwen3TtsCrispAsr"/>) carry their
+/// own copy of the same steps.
+/// </summary>
+public static class PerLineReferenceStaging
+{
+    /// <summary>
+    /// The prefix that marks a staged per-line reference in a voices folder: it is what keeps the
+    /// user's imported voices out of <see cref="Clear"/> and the staged ones out of the voice
+    /// combo. Same value in every engine, so an exported session's clips are recognised by
+    /// whichever engine re-imports them.
+    /// </summary>
+    public const string Prefix = "se-per-line-";
+
+    /// <summary>True when <paramref name="fileName"/> is a reference staged for one line.</summary>
+    public static bool IsStaged(string fileName) =>
+        Path.GetFileName(fileName).StartsWith(Prefix, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Copies <paramref name="clipFileName"/> into <paramref name="voicesFolder"/> under the
+    /// staged name and returns that path, or null when the clip is missing or the copy failed.
+    /// A plain copy, not an ffmpeg pass: the clips are cut as 24 kHz mono PCM16 already. Any
+    /// <c>.txt</c> transcript beside the clip travels with it, in the layout the engines' own
+    /// import uses, so an exported session keeps it.
+    /// </summary>
+    /// <param name="engineLabel">Names the engine in the error log.</param>
+    public static string? Stage(string clipFileName, string voicesFolder, string engineLabel)
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(clipFileName) || !File.Exists(clipFileName))
+            {
+                return null;
+            }
+
+            // An exported session carries the staged name, so re-staging it on import would
+            // otherwise pile a second prefix on top - once per round trip.
+            var baseName = Path.GetFileNameWithoutExtension(clipFileName);
+            if (baseName.StartsWith(Prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                baseName = baseName.Substring(Prefix.Length);
+            }
+
+            var stagedFileName = Path.Combine(voicesFolder, Prefix + baseName + ".wav");
+
+            // Regenerate hands back the clip a line was generated from, which IS the staged copy:
+            // copying a file onto itself only throws, and it is already in place.
+            if (string.Equals(Path.GetFullPath(stagedFileName), Path.GetFullPath(clipFileName), StringComparison.OrdinalIgnoreCase))
+            {
+                return clipFileName;
+            }
+
+            Directory.CreateDirectory(voicesFolder);
+            File.Copy(clipFileName, stagedFileName, overwrite: true);
+
+            var transcriptFileName = Path.ChangeExtension(clipFileName, ".txt");
+            var stagedTranscriptFileName = Path.ChangeExtension(stagedFileName, ".txt");
+            if (File.Exists(transcriptFileName))
+            {
+                File.Copy(transcriptFileName, stagedTranscriptFileName, overwrite: true);
+            }
+            else if (File.Exists(stagedTranscriptFileName))
+            {
+                // A stale sidecar from an earlier run would otherwise describe a different clip.
+                File.Delete(stagedTranscriptFileName);
+            }
+
+            return stagedFileName;
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, $"{engineLabel}: staging the per-line reference '{clipFileName}' failed");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Removes every staged per-line reference (and its transcript) from
+    /// <paramref name="voicesFolder"/>, leaving the user's imported voices alone. Called when a
+    /// per-line run starts, so a run over a shorter subtitle cannot leave the previous run's
+    /// extra lines lying in the folder.
+    /// </summary>
+    public static void Clear(string voicesFolder, string engineLabel)
+    {
+        try
+        {
+            if (!Directory.Exists(voicesFolder))
+            {
+                return;
+            }
+
+            foreach (var file in Directory.GetFiles(voicesFolder, Prefix + "*"))
+            {
+                try
+                {
+                    File.Delete(file);
+                }
+                catch
+                {
+                    // A reference still open (the server may be reading it) is left for next time.
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, $"{engineLabel}: clearing the staged per-line references failed");
+        }
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/Engines/VibeVoiceCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/VibeVoiceCrispAsr.cs
@@ -29,7 +29,7 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 /// rendering path (group subtitles by Actor + submit a multi-speaker script) and is
 /// intentionally out of scope here.
 /// </summary>
-public class VibeVoiceCrispAsr : ITtsEngine
+public class VibeVoiceCrispAsr : ITtsEngine, IPerLineCloneEngine
 {
     public string Name => "VibeVoice (CrispASR)";
     public string Description => "Microsoft VibeVoice 1.5B with voice cloning, via CrispASR";
@@ -39,7 +39,10 @@ public class VibeVoiceCrispAsr : ITtsEngine
     public bool HasModel => true;
     public bool HasKeyFile => false;
     public bool SupportsVoiceCloning => true;
-    public bool SupportsPerLineVoiceCloning => false;
+    // The vibevoice backend resolves the request's `voice` stem against --voice-dir and loads
+    // the WAV clone path per request (see Speak), so a different reference per line costs no
+    // server restart - the clip only has to be staged into the voices folder first.
+    public bool SupportsPerLineVoiceCloning => true;
 
     // Three quants of the same backend — user picks size vs. quality. Q8_0 is the README
     // recommended default; Q4_K is the lightest option for 8 GB GPUs; F16 is the reference.
@@ -309,6 +312,13 @@ public class VibeVoiceCrispAsr : ITtsEngine
         {
             foreach (var file in Directory.GetFiles(voicesFolder, "*.wav"))
             {
+                // The per-line clone's own references live here too (the backend resolves bare
+                // stems against --voice-dir); they belong to one line of one run, not in a combo.
+                if (PerLineReferenceStaging.IsStaged(file))
+                {
+                    continue;
+                }
+
                 var name = Path.GetFileNameWithoutExtension(file).Replace('_', ' ');
                 result.Add(new Voice(new VibeVoice(name, file)));
             }
@@ -316,6 +326,42 @@ public class VibeVoiceCrispAsr : ITtsEngine
 
         return result.ToArray();
     }
+
+    /// <summary>
+    /// <see cref="IPerLineCloneEngine"/>: the vibevoice backend reads references from its own
+    /// --voice-dir and nowhere else, so the clip is staged in there first and the voice's
+    /// FilePath points at the copy - that is the lookup key, since <see cref="Speak"/> sends the
+    /// file's bare stem as the request's <c>voice</c>. Cloning is audio-only, so a clip without
+    /// a transcript sidecar is as good as one with; staging only fails on a missing clip.
+    /// </summary>
+    public Voice? MakePerLineCloneVoice(string clipFileName, string voiceName) =>
+        StagePerLineReference(clipFileName) is { } staged
+            ? new Voice(new VibeVoice(voiceName, staged))
+            : null;
+
+    /// <summary>
+    /// The staged copy in the voices folder, which is the only reference this engine ever
+    /// speaks from - exporting it is what lets an imported session be re-dubbed on a machine
+    /// that no longer has the video.
+    /// </summary>
+    public string? GetPerLineReferenceClip(Voice voice) =>
+        voice.EngineVoice is VibeVoice vibeVoice && !string.IsNullOrEmpty(vibeVoice.FilePath)
+            ? vibeVoice.FilePath
+            : null;
+
+    /// <summary>
+    /// <see cref="IPerLineCloneEngine"/>: see <see cref="ClearStagedPerLineReferences"/>.
+    /// </summary>
+    public void ResetStagedPerLineReferences() => ClearStagedPerLineReferences();
+
+    public static string? StagePerLineReference(string clipFileName) =>
+        PerLineReferenceStaging.Stage(clipFileName, GetSetVoicesFolder(), "VibeVoice (CrispASR)");
+
+    /// <summary>
+    /// Removes every staged per-line reference, leaving the user's imported voices alone.
+    /// </summary>
+    public static void ClearStagedPerLineReferences() =>
+        PerLineReferenceStaging.Clear(Path.Combine(GetSetFolder(), "voices"), "VibeVoice (CrispASR)");
 
     public bool IsVoiceInstalled(Voice voice) => true;
 

--- a/tests/UI/Features/Video/TextToSpeech/Engines/MossTtsCrispAsrTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/MossTtsCrispAsrTests.cs
@@ -27,6 +27,18 @@ public class MossTtsCrispAsrTests
     }
 
     [Fact]
+    public void BuildSpeakPayload_ForAPerLineClone_SendsTheStagedStemAsVoice()
+    {
+        // A per-line clone changes reference every line; since CrispASR v0.8.30 (#384) the
+        // moss-tts backend resolves a bare stem against --voice-dir per request, so this is what
+        // makes a new clip per line cost a reference encode instead of a server restart.
+        var payload = MossTtsCrispAsr.BuildSpeakPayload("hello", 1.0, "se-per-line-line-0007");
+
+        Assert.Equal("se-per-line-line-0007", payload["voice"]);
+        Assert.False(payload.ContainsKey("ref_text"));
+    }
+
+    [Fact]
     public void BuildSpeakPayload_DoesNotSendSeed()
     {
         // No seed: the reference conditioning keeps the speaker consistent, and letting the server

--- a/tests/UI/Features/Video/TextToSpeech/Engines/PerLineReferenceStagingTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/PerLineReferenceStagingTests.cs
@@ -1,0 +1,141 @@
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+
+namespace UITests.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// Per-line voice cloning on VibeVoice and MOSS-TTS (CrispASR): both backends resolve a
+/// request's <c>voice</c> as a bare stem inside --voice-dir, so a line's reference clip has to
+/// be staged into the voices folder first - the shared <see cref="PerLineReferenceStaging"/>.
+/// </summary>
+public class PerLineReferenceStagingTests
+{
+    [Fact]
+    public void BothEnginesOfferPerLineCloning()
+    {
+        Assert.True(PerLineVoiceClone.CanBeOffered(new VibeVoiceCrispAsr(), "/videos/movie.mkv"));
+        Assert.True(PerLineVoiceClone.CanBeOffered(new MossTtsCrispAsr(), "/videos/movie.mkv"));
+        Assert.IsAssignableFrom<IPerLineCloneEngine>(new VibeVoiceCrispAsr());
+        Assert.IsAssignableFrom<IPerLineCloneEngine>(new MossTtsCrispAsr());
+    }
+
+    [Fact]
+    public void StagingCopiesTheClipAndItsTranscriptIntoTheVoicesFolder()
+    {
+        using var clips = new TempFolder();
+        using var voices = new TempFolder();
+        var clip = clips.WriteClip("line-0007", "Nothing travels faster than light.");
+
+        var staged = PerLineReferenceStaging.Stage(clip, voices.Path, "test");
+
+        Assert.NotNull(staged);
+        Assert.Equal(voices.Path, Path.GetDirectoryName(staged));
+        Assert.True(File.Exists(staged));
+        Assert.Equal("Nothing travels faster than light.", File.ReadAllText(Path.ChangeExtension(staged!, ".txt")));
+        Assert.True(PerLineReferenceStaging.IsStaged(staged!));
+        Assert.StartsWith(PerLineReferenceStaging.Prefix, Path.GetFileName(staged));
+    }
+
+    [Fact]
+    public void AClipWithoutTranscriptIsStillStaged()
+    {
+        // Both engines clone from audio alone, so the sidecar is a nicety, not a requirement -
+        // and a stale one from an earlier run must not be left describing a different clip.
+        using var clips = new TempFolder();
+        using var voices = new TempFolder();
+        File.WriteAllText(Path.Combine(voices.Path, PerLineReferenceStaging.Prefix + "line-0008.txt"), "stale");
+
+        var staged = PerLineReferenceStaging.Stage(clips.WriteClip("line-0008", transcript: null), voices.Path, "test");
+
+        Assert.NotNull(staged);
+        Assert.True(File.Exists(staged));
+        Assert.False(File.Exists(Path.ChangeExtension(staged!, ".txt")));
+    }
+
+    [Fact]
+    public void AMissingClipIsNotStaged()
+    {
+        using var voices = new TempFolder();
+
+        Assert.Null(PerLineReferenceStaging.Stage(Path.Combine(voices.Path, "nope.wav"), voices.Path, "test"));
+        Assert.Empty(Directory.GetFiles(voices.Path));
+    }
+
+    [Fact]
+    public void ReStagingAnAlreadyStagedClipDoesNotStackThePrefix()
+    {
+        // Regenerate hands back the staged copy itself; an exported session carries the staged
+        // name - neither may end up as "se-per-line-se-per-line-…".
+        using var voices = new TempFolder();
+        var clip = voices.WriteClip(PerLineReferenceStaging.Prefix + "line-0001", "One.");
+
+        var staged = PerLineReferenceStaging.Stage(clip, voices.Path, "test");
+
+        Assert.Equal(clip, staged);
+        Assert.Single(Directory.GetFiles(voices.Path, "*.wav"));
+    }
+
+    [Fact]
+    public void ClearingRemovesTheStagedReferencesAndLeavesImportedVoicesAlone()
+    {
+        using var clips = new TempFolder();
+        using var voices = new TempFolder();
+        File.WriteAllText(Path.Combine(voices.Path, "ada.wav"), "imported");
+        File.WriteAllText(Path.Combine(voices.Path, "ada.txt"), "Imported voice.");
+        PerLineReferenceStaging.Stage(clips.WriteClip("line-0001", "One."), voices.Path, "test");
+        PerLineReferenceStaging.Stage(clips.WriteClip("line-0002", null), voices.Path, "test");
+
+        PerLineReferenceStaging.Clear(voices.Path, "test");
+
+        Assert.Equal(
+            new[] { "ada.txt", "ada.wav" },
+            Directory.GetFiles(voices.Path).Select(Path.GetFileName).Order().ToArray());
+    }
+
+    [Fact]
+    public void TheVoicePointsAtTheStagedCopy()
+    {
+        var vibe = new VibeVoiceCrispAsr();
+        var moss = new MossTtsCrispAsr();
+
+        Assert.Equal("/voices/se-per-line-line-0003.wav",
+            vibe.GetPerLineReferenceClip(new Voice(new VibeVoice("Ada", "/voices/se-per-line-line-0003.wav"))));
+        Assert.Equal("/voices/se-per-line-line-0003.wav",
+            moss.GetPerLineReferenceClip(new Voice(new MossTtsVoice("Ada", "/voices/se-per-line-line-0003.wav"))));
+        Assert.Null(vibe.GetPerLineReferenceClip(new Voice(new MossTtsVoice("Ada", "/voices/x.wav"))));
+        Assert.Null(moss.GetPerLineReferenceClip(new Voice(new VibeVoice("Ada", "/voices/x.wav"))));
+    }
+
+    private sealed class TempFolder : IDisposable
+    {
+        public string Path { get; } =
+            System.IO.Path.Combine(System.IO.Path.GetTempPath(), "SePerLineStaging_" + Guid.NewGuid().ToString("N"));
+
+        public TempFolder() => Directory.CreateDirectory(Path);
+
+        public string WriteClip(string name, string? transcript)
+        {
+            var wav = System.IO.Path.Combine(Path, name + ".wav");
+            File.WriteAllText(wav, "not really a wav, and nothing here reads it");
+            if (transcript != null)
+            {
+                File.WriteAllText(System.IO.Path.ChangeExtension(wav, ".txt"), transcript);
+            }
+
+            return wav;
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(Path, true);
+            }
+            catch
+            {
+                // temp folder - nothing depends on it being gone
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Enables **Clone from video (voice of each line)** for two more engines, as asked for in #14480 (comment [5551377619](https://github.com/SubtitleEdit/subtitleedit/issues/14480#issuecomment-5551377619)):

- **VibeVoice (CrispASR)** – the backend already resolves the request's `voice` stem against `--voice-dir` and loads the WAV clone per request, so only the staging was missing.
- **MOSS-TTS (CrispASR)** – since CrispASR v0.8.30 (#384) the moss-tts backend resolves a per-request bare stem against `--voice-dir` and re-encodes the reference only when it changes. Per-line clones send that stem; the server is keyed on (model, language) for such a run, so a new clip per line costs a reference encode rather than a restart. Ordinary imported voices keep the startup `--voice` flag and restart-on-change, so an older runtime keeps today's behaviour (the engine's update dot flags it for the new mode).

New shared `PerLineReferenceStaging` does the copy (with any `.txt` sidecar), the `se-per-line-` prefix filter in the voice combo, and the per-run clear for both engines.

Not in this PR: CosyVoice 3 and VoxCPM2 (need a working-directory change, separate PR), Chatterbox (per-line = model reload per line until the upstream second-voice crash is fixed), Confucius4 (upstream adapter applies the voice only at init).

## Test plan

- [x] `PerLineReferenceStagingTests`, `MossTtsCrispAsrTests`, `PerLineVoiceCloneTests`, `VoiceCloningConsentTests`, `TtsEngineCatalogTests` pass (90 tests)
- [ ] Manual: VibeVoice + MOSS-TTS with "Clone from video" on a multi-speaker clip, check the server log shows one `cloning voice from` per line and no restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)