### PR TITLE
Make spell check unknown-word highlight color configurable

### DIFF
--- a/src/ui/Features/Ocr/PromptUnknownWordViewModel.cs
+++ b/src/ui/Features/Ocr/PromptUnknownWordViewModel.cs
@@ -137,7 +137,7 @@ public partial class PromptUnknownWordViewModel : ObservableObject
         {
             Text = w,
             FontWeight = FontWeight.Bold,
-            Foreground = Brushes.Red
+            Foreground = new SolidColorBrush(Se.Settings.Appearance.SpellCheckHighlightColor.FromHexToColor())
         };
         if (!string.IsNullOrEmpty(fontName))
         {

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -811,6 +811,7 @@ public class SettingsPage : UserControl
             new SettingsItem(Se.Language.Options.Settings.GridAlternatingRowColorDark, () => UiUtil.MakeColorPickerButton(_vm, nameof(_vm.GridAlternatingRowColorDark))),
             new SettingsItem(Se.Language.Options.Settings.ShowGridLines, () => UiUtil.MakeComboBox(_vm.GridLinesVisibilities, _vm, nameof(_vm.SelectedGridLinesVisibility))),
             new SettingsItem(Se.Language.Options.Settings.BookmarkColor, () => UiUtil.MakeColorPickerButton(_vm, nameof(_vm.BookmarkColor))),
+            new SettingsItem(Se.Language.Options.Settings.SpellCheckHighlightColor, () => UiUtil.MakeColorPickerButton(_vm, nameof(_vm.SpellCheckHighlightColor))),
             MakeCheckboxSetting(Se.Language.Options.Settings.ShowAssaLayer, nameof(_vm.ShowAssaLayer)),
             MakeCheckboxSetting(Se.Language.Options.Settings.ShowHorizontalLineAboveToolbar, nameof(_vm.ShowHorizontalLineAboveToolbar)),
             MakeCheckboxSetting(Se.Language.Options.Settings.ShowPluginsMenu, nameof(_vm.ShowPluginsMenu)),

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -411,6 +411,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _useFocusedButtonBackgroundColor;
     [ObservableProperty] private Color _focusedButtonBackgroundColor;
     [ObservableProperty] private Color _bookmarkColor;
+    [ObservableProperty] private Color _spellCheckHighlightColor;
     [ObservableProperty] private Color _gridAlternatingRowColor;
     [ObservableProperty] private Color _gridAlternatingRowColorDark;
     [ObservableProperty] private bool _isEditCustomContinuationStyleVisible;
@@ -941,6 +942,7 @@ public partial class SettingsViewModel : ObservableObject
         UseFocusedButtonBackgroundColor = appearance.UseFocusedButtonBackgroundColor;
         FocusedButtonBackgroundColor = appearance.FocusedButtonBackgroundColor.FromHexToColor();
         BookmarkColor = appearance.BookmarkColor.FromHexToColor();
+        SpellCheckHighlightColor = appearance.SpellCheckHighlightColor.FromHexToColor();
         GridAlternatingRowColor = appearance.GridAlternatingRowColor.FromHexToColor();
         GridAlternatingRowColorDark = appearance.GridAlternatingRowColorDark.FromHexToColor();
         ShowUpDownStartTime = appearance.ShowUpDownStartTime;
@@ -1804,6 +1806,7 @@ public partial class SettingsViewModel : ObservableObject
         appearance.UseFocusedButtonBackgroundColor = UseFocusedButtonBackgroundColor;
         appearance.FocusedButtonBackgroundColor = FocusedButtonBackgroundColor.FromColorToHex();
         appearance.BookmarkColor = BookmarkColor.FromColorToHex();
+        appearance.SpellCheckHighlightColor = SpellCheckHighlightColor.FromColorToHex();
         appearance.GridAlternatingRowColor = GridAlternatingRowColor.FromColorToHex();
         appearance.GridAlternatingRowColorDark = GridAlternatingRowColorDark.FromColorToHex();
         appearance.ShowUpDownStartTime = ShowUpDownStartTime;

--- a/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
+++ b/src/ui/Features/SpellCheck/SpellCheckViewModel.cs
@@ -1189,7 +1189,7 @@ public partial class SpellCheckViewModel : ObservableObject, IClosingCleanup
         {
             Text = word.Text,
             FontWeight = FontWeight.Bold,
-            Foreground = Brushes.Red
+            Foreground = new SolidColorBrush(Se.Settings.Appearance.SpellCheckHighlightColor.FromHexToColor())
         };
         if (!string.IsNullOrEmpty(fontName))
         {

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -73,6 +73,7 @@ public class LanguageSettings
     public string ShowGridLines { get; set; }
     public string ShowHorizontalLineAboveToolbar { get; set; }
     public string BookmarkColor { get; set; }
+    public string SpellCheckHighlightColor { get; set; }
     public string SingleLineMaxLength { get; set; }
     public string OptimalCharsPerSec { get; set; }
     public string MaxCharsPerSec { get; set; }
@@ -416,6 +417,7 @@ public class LanguageSettings
         ShowGridLines = "Show grid lines";
         ShowHorizontalLineAboveToolbar = "Show horizontal line above toolbar";
         BookmarkColor = "Bookmark color";
+        SpellCheckHighlightColor = "Spell check highlight color";
         SingleLineMaxLength = "Single line max length";
         OptimalCharsPerSec = "Optimal chars/sec";
         MaxCharsPerSec = "Max chars/sec";

--- a/src/ui/Logic/Config/SeAppearance.cs
+++ b/src/ui/Logic/Config/SeAppearance.cs
@@ -55,6 +55,12 @@ public class SeAppearance
     public string GridAlternatingRowColorDark { get; set; }
     public bool ShowHorizontalLineAboveToolbar { get; set; }
 
+    /// <summary>
+    /// Color of the flagged word highlighted in the "whole line" preview of the spell check
+    /// and OCR "unknown word" dialogs, as #AARRGGBB.
+    /// </summary>
+    public string SpellCheckHighlightColor { get; set; }
+
     public bool ToolbarShowFileNew { get; set; }
     public bool ToolbarShowFileOpen { get; set; }
     public bool ToolbarShowVideoFileOpen { get; set; }
@@ -133,6 +139,7 @@ public class SeAppearance
         UseFocusedButtonBackgroundColor = true;
         FocusedButtonBackgroundColor = new Color(99, 30, 144, 255).FromColorToHex();
         BookmarkColor = Color.Parse("#C07800").FromColorToHex();
+        SpellCheckHighlightColor = Colors.Red.FromColorToHex();
         GridCompactMode = true;
         ShowLayer = true;
         ShowUpDownStartTime = true;


### PR DESCRIPTION
The word highlighted in the spell check and OCR "unknown word" preview was hard-coded to Brushes.Red, which has poor contrast against the dark theme background. Add SpellCheckHighlightColor to Appearance settings, defaulting to the previous red, with a color picker on the Settings/ Appearance page next to Bookmark color.

Fixes #14514