### PR TITLE
Add per-line voice cloning to CosyVoice3 and VoxCPM2 (CrispASR)

### DIFF
--- a/docs/features/text-to-speech.md
+++ b/docs/features/text-to-speech.md
@@ -106,7 +106,7 @@ Notes on picking one:
 - **Highest output rate:** VoxCPM2 and dots.tts at 48 kHz, then Zonos at 44.1 kHz.
 - **MOSS-TTS is by far the largest** because its Qwen3-8B backbone needs a ~3.5 GB codec companion on top of the backbone quant. Check free disk space before selecting it.
 - Quantized engines follow the same rule as the speech-to-text models: `Q4_K` is the small fast default, `Q8_0` is close to full precision, and `F16` is rarely worth the extra gigabytes.
-- **Most of the CrispASR engines load their reference voice at server start**, so switching voice reloads the model. The exceptions are **Pocket TTS**, **VibeVoice** and **MOSS-TTS** (per-request reference) and **Qwen3 TTS** with the Voice clone model — those, the three audio.cpp engines (**IndexTTS 2.5**, **Higgs Audio v3**, **Fish Audio S2 Pro**) and the standalone OmniVoice TTS engine are what [Clone From Video (Voice of Each Line)](#clone-from-video-voice-of-each-line) can use.
+- **Most of the CrispASR engines load their reference voice at server start**, so switching voice reloads the model. The exceptions are **Pocket TTS**, **VibeVoice**, **MOSS-TTS**, **CosyVoice3** and **VoxCPM2** (per-request reference) and **Qwen3 TTS** with the Voice clone model — those, the three audio.cpp engines (**IndexTTS 2.5**, **Higgs Audio v3**, **Fish Audio S2 Pro**) and the standalone OmniVoice TTS engine are what [Clone From Video (Voice of Each Line)](#clone-from-video-voice-of-each-line) can use.
 
 ## Engine Settings
 
@@ -163,7 +163,7 @@ For dubbing a video with several speakers there is a faster way than cloning eac
 
 Before generating, Subtitle Edit cuts one short reference clip per line out of the video's audio. Lines shorter than about three seconds are grown into the silence around them, but never into the neighbouring line — a reference with two speakers in it would clone the wrong person.
 
-- **Supported engines:** OmniVoice TTS, Pocket TTS (CrispASR), VibeVoice (CrispASR), MOSS-TTS (CrispASR), Qwen3 TTS (CrispASR) with the Voice clone model, and the audio.cpp engines IndexTTS 2.5, Higgs Audio v3 and Fish Audio S2 Pro. The entry only appears for engines that accept a reference for each line; engines that load their reference when their server starts would have to reload the model for every line.
+- **Supported engines:** OmniVoice TTS, Pocket TTS (CrispASR), VibeVoice (CrispASR), MOSS-TTS (CrispASR), CosyVoice3 (CrispASR), VoxCPM2 (CrispASR), Qwen3 TTS (CrispASR) with the Voice clone model, and the audio.cpp engines IndexTTS 2.5, Higgs Audio v3 and Fish Audio S2 Pro. The entry only appears for engines that accept a reference for each line; engines that load their reference when their server starts would have to reload the model for every line.
 - **Reference text:** if you have the original subtitle loaded next to the translation, its lines are used as the transcript of the clips — that is what the video actually says, and it makes cloning noticeably better. Without an original loaded, the line's own text is used.
 - **Test voice** previews the clone taken from the longest line of the subtitle.
 - Quality depends on the source audio. Loud music or two people talking over each other in a line makes that line's clone worse. Longer subtitle lines clone better than very short ones, so a subtitle segmented into full sentences gives the best result.

--- a/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
@@ -52,7 +52,7 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 /// fetched lazily by <c>--auto-download</c> into <c>~/.cache/crispasr/</c> on first synth. Keeping
 /// a single primary file mirrors VibeVoice's layout and avoids a 6-file download-progress UI.
 /// </summary>
-public class CosyVoice3CrispAsr : ITtsEngine
+public class CosyVoice3CrispAsr : ITtsEngine, IPerLineCloneEngine
 {
     public string Name => "CosyVoice3 (CrispASR)";
     public string Description => "Alibaba CosyVoice3 0.5B with 9 languages + 18 zh dialects, via CrispASR";
@@ -62,7 +62,11 @@ public class CosyVoice3CrispAsr : ITtsEngine
     public bool HasModel => true;
     public bool HasKeyFile => false;
     public bool SupportsVoiceCloning => true;
-    public bool SupportsPerLineVoiceCloning => false;
+    // Per-line clones are sent as a per-request `voice` file name (plus `ref_text`), which the
+    // cosyvoice3-tts backend opens relative to the server's working directory - the voices
+    // folder - and clones from without a restart. Ordinary imported voices stay on the startup
+    // --voice flag; see Speak and EnsureServerRunningAsync.
+    public bool SupportsPerLineVoiceCloning => true;
 
     // Two LLM quants — Q4_K is the lightweight default (~1.6 GB total), F16 the reference (~2.5 GB).
     // The label total covers every required companion (flow / hift / s3tok / campplus / voices).
@@ -207,6 +211,9 @@ public class CosyVoice3CrispAsr : ITtsEngine
     // change to either triggers a teardown + restart — same trade-off IndexTTS made.
     private static string? _serverVoiceArg;
     private static string? _serverRefText;
+    // True when the running server was started for a per-line clone run: every line then sends
+    // its own reference in the request, so a new staged clip is not a restart.
+    private static bool _serverPerLine;
     private static bool _processExitHooked;
     private static readonly StringBuilder _serverLog = new();
 
@@ -434,6 +441,13 @@ public class CosyVoice3CrispAsr : ITtsEngine
         {
             foreach (var file in Directory.GetFiles(voicesFolder, "*.wav"))
             {
+                // The per-line clone's own references live here too; they belong to one line of
+                // one run, not in a combo.
+                if (PerLineReferenceStaging.IsStaged(file))
+                {
+                    continue;
+                }
+
                 var name = Path.GetFileNameWithoutExtension(file).Replace('_', ' ');
                 var refText = TryReadRefText(file);
                 result.Add(new Voice(new CosyVoice3Voice(name, file, refText), $"{CloneLabel}: {name}"));
@@ -442,6 +456,55 @@ public class CosyVoice3CrispAsr : ITtsEngine
 
         return result.ToArray();
     }
+
+    /// <summary>
+    /// <see cref="IPerLineCloneEngine"/>: the clip is staged into the voices folder, which is the
+    /// server's working directory, so its bare file name is what <see cref="Speak"/> sends as the
+    /// request's <c>voice</c>. The talker is conditioned on the (transcript, speech) pair, so a
+    /// clip without a usable transcript beside it is not a reference at all - null, and that line
+    /// falls back to an ordinary voice rather than failing the run.
+    /// </summary>
+    public Voice? MakePerLineCloneVoice(string clipFileName, string voiceName)
+    {
+        var staged = StagePerLineReference(clipFileName);
+        if (staged == null)
+        {
+            return null;
+        }
+
+        var refText = TryReadRefText(staged);
+        if (string.IsNullOrWhiteSpace(refText))
+        {
+            Se.WriteToolsLog($"CosyVoice3 (CrispASR): no usable transcript beside '{clipFileName}' - not cloning this line");
+            return null;
+        }
+
+        return new Voice(new CosyVoice3Voice(voiceName, staged, refText));
+    }
+
+    /// <summary>
+    /// The staged copy in the voices folder, which is the only reference this engine ever
+    /// speaks from - exporting it (with its .txt sidecar) is what lets an imported session be
+    /// re-dubbed on a machine that no longer has the video.
+    /// </summary>
+    public string? GetPerLineReferenceClip(Voice voice) =>
+        voice.EngineVoice is CosyVoice3Voice cosyVoice && !string.IsNullOrEmpty(cosyVoice.FilePath)
+            ? cosyVoice.FilePath
+            : null;
+
+    /// <summary>
+    /// <see cref="IPerLineCloneEngine"/>: see <see cref="ClearStagedPerLineReferences"/>.
+    /// </summary>
+    public void ResetStagedPerLineReferences() => ClearStagedPerLineReferences();
+
+    public static string? StagePerLineReference(string clipFileName) =>
+        PerLineReferenceStaging.Stage(clipFileName, GetSetVoicesFolder(), "CosyVoice3 (CrispASR)");
+
+    /// <summary>
+    /// Removes every staged per-line reference, leaving the user's imported voices alone.
+    /// </summary>
+    public static void ClearStagedPerLineReferences() =>
+        PerLineReferenceStaging.Clear(Path.Combine(GetSetFolder(), "voices"), "CosyVoice3 (CrispASR)");
 
     private static string TryReadRefText(string wavPath)
     {
@@ -516,23 +579,17 @@ public class CosyVoice3CrispAsr : ITtsEngine
         }
 
         var modelKey = ResolveModelKey(model);
-        await EnsureServerRunningAsync(modelKey, voiceArg, cosyVoice.RefText, cancellationToken);
+        // A per-line clone's reference is sent per request, so the server is keyed on the model
+        // only for those; an ordinary voice keeps the startup flags and their restart-on-change.
+        var isPerLineClone = isClone && PerLineReferenceStaging.IsStaged(cosyVoice.FilePath);
+        await EnsureServerRunningAsync(modelKey, voiceArg, cosyVoice.RefText, isPerLineClone, cancellationToken);
 
         var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder), Guid.NewGuid() + ".wav");
 
         var speed = Math.Clamp(Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrSpeed, 0.25, 4.0);
-        // Deliberately NO `voice` / `ref_text` field: for cloning, voiceArg is an absolute WAV
-        // path, which the server rejects outright (HTTP 400, "'voice' must not contain … path
-        // separators" — path-traversal guard), so every clone synthesis failed. The backend gets
-        // both voice (preset name or WAV path) and ref-text from the startup --voice/--ref-text
-        // flags instead, and the server restarts on (voiceArg, ref-text) change — see
-        // EnsureServerRunningAsync. Same bug family as MOSS-TTS #12757.
-        var payload = new Dictionary<string, object>
-        {
-            ["input"] = text,
-            ["response_format"] = "wav",
-            ["speed"] = speed,
-        };
+        var payload = BuildSpeakPayload(text, speed,
+            isPerLineClone ? Path.GetFileName(cosyVoice.FilePath) : null,
+            isPerLineClone ? cosyVoice.RefText : null);
         if (isClone)
         {
             // Attests the user's own imported reference and the AI-disclosure duty; see
@@ -672,16 +729,65 @@ public class CosyVoice3CrispAsr : ITtsEngine
         }
     }
 
-    private static async Task EnsureServerRunningAsync(string modelKey, string voiceArg, string refText, CancellationToken ct)
+    /// <summary>
+    /// Builds the <c>/v1/audio/speech</c> JSON payload without the language fields, which
+    /// <see cref="Speak"/> adds per voice. Extracted so the voice-field rules are unit-testable
+    /// without a running crispasr server.
+    /// </summary>
+    /// <param name="perLineVoiceFileName">
+    /// The bare file name (with <c>.wav</c>) of a staged per-line reference to send as the
+    /// request's <c>voice</c>, or null for an ordinary voice. The backend takes the clone path
+    /// only for a name ending in <c>.wav</c> and opens it relative to its working directory,
+    /// which <see cref="EnsureServerRunningAsync"/> sets to the voices folder; the server rejects
+    /// anything with a path separator (HTTP 400), so it cannot be the full path.
+    /// </param>
+    /// <param name="perLineRefText">
+    /// The clip's transcript, sent as <c>ref_text</c> beside it - the talker is conditioned on
+    /// the (transcript, speech) pair, and a per-request value is what keeps the pair together
+    /// when the reference changes every line.
+    /// </param>
+    /// <remarks>
+    /// For ordinary voices, deliberately sends NO <c>voice</c> / <c>ref_text</c> field: voiceArg
+    /// is then an absolute WAV path, which the server rejects outright (HTTP 400, "'voice' must
+    /// not contain … path separators" — path-traversal guard), so every clone synthesis failed.
+    /// The backend gets both voice (preset name or WAV path) and ref-text from the startup
+    /// --voice/--ref-text flags instead, and the server restarts on (voiceArg, ref-text) change —
+    /// see <see cref="EnsureServerRunningAsync"/>. Same bug family as MOSS-TTS #12757.
+    /// </remarks>
+    internal static Dictionary<string, object> BuildSpeakPayload(string text, double speed, string? perLineVoiceFileName, string? perLineRefText)
+    {
+        var payload = new Dictionary<string, object>
+        {
+            ["input"] = text,
+            ["response_format"] = "wav",
+            ["speed"] = speed,
+        };
+
+        if (!string.IsNullOrEmpty(perLineVoiceFileName))
+        {
+            payload["voice"] = perLineVoiceFileName;
+            if (!string.IsNullOrWhiteSpace(perLineRefText))
+            {
+                payload["ref_text"] = perLineRefText;
+            }
+        }
+
+        return payload;
+    }
+
+    private static async Task EnsureServerRunningAsync(string modelKey, string voiceArg, string refText, bool perLine, CancellationToken ct)
     {
         // Server is keyed by (model, voice, ref-text) since all three are baked in at process
         // start. A switch from preset → clone, clone → different clone, or refText edit all
-        // require a fresh server.
+        // require a fresh server. A per-line clone run is the exception: each line carries its
+        // own reference and transcript in the request, so within such a run the server is keyed
+        // on the model alone. The first clip still goes on the startup flags, which is harmless.
         bool MatchesCurrent() =>
             _serverProcess is { HasExited: false } && _serverPort != 0
             && string.Equals(_serverModelKey, modelKey, StringComparison.OrdinalIgnoreCase)
-            && string.Equals(_serverVoiceArg, voiceArg, StringComparison.OrdinalIgnoreCase)
-            && string.Equals(_serverRefText, refText, StringComparison.Ordinal);
+            && ((perLine && _serverPerLine)
+                || (string.Equals(_serverVoiceArg, voiceArg, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(_serverRefText, refText, StringComparison.Ordinal)));
 
         if (MatchesCurrent())
         {
@@ -721,7 +827,12 @@ public class CosyVoice3CrispAsr : ITtsEngine
             var port = FindFreeLoopbackPort();
             var psi = new ProcessStartInfo
             {
-                WorkingDirectory = Path.GetDirectoryName(exe) ?? GetSetFolder(),
+                // Run in the voices folder: the backend opens a per-request `voice` as a literal
+                // path relative to its working directory (it does not resolve it against
+                // --voice-dir), and the server rejects a `voice` with path separators - so this is
+                // what lets a per-line clone's staged clip be found by its bare file name. Every
+                // path passed below is absolute, so nothing else depends on the working directory.
+                WorkingDirectory = GetSetVoicesFolder(),
                 FileName = exe,
                 UseShellExecute = false,
                 CreateNoWindow = true,
@@ -792,6 +903,7 @@ public class CosyVoice3CrispAsr : ITtsEngine
             _serverModelKey = modelKey;
             _serverVoiceArg = voiceArg;
             _serverRefText = refText;
+            _serverPerLine = perLine;
             HookProcessExitOnce();
 
             // Local startup is fast; first-run --auto-download (~921 MB minimum, ~2.5 GB for F16)
@@ -811,6 +923,7 @@ public class CosyVoice3CrispAsr : ITtsEngine
                     _serverModelKey = null;
                     _serverVoiceArg = null;
                     _serverRefText = null;
+                    _serverPerLine = false;
                     throw new InvalidOperationException(
                         $"crispasr (cosyvoice3-tts) exited during startup (code {exitCode}). Output: {tail}"
                         + LaunchCmdSuffix(exitedLaunchCommand));
@@ -894,6 +1007,7 @@ public class CosyVoice3CrispAsr : ITtsEngine
         _serverModelKey = null;
         _serverVoiceArg = null;
         _serverRefText = null;
+        _serverPerLine = false;
         if (p == null)
         {
             return;

--- a/src/ui/Features/Video/TextToSpeech/Engines/VoxCPM2CrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/VoxCPM2CrispAsr.cs
@@ -45,7 +45,7 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 /// startup <c>--voice</c> flag — the server logs "loaded reference audio '&lt;path&gt;'" and
 /// resamples it to 16 kHz — and the request carries no <c>voice</c> field.
 /// </summary>
-public class VoxCPM2CrispAsr : ITtsEngine
+public class VoxCPM2CrispAsr : ITtsEngine, IPerLineCloneEngine
 {
     public string Name => "VoxCPM2 (CrispASR)";
     public string Description => "VoxCPM2 48 kHz multilingual TTS with zero-shot voice cloning, via CrispASR";
@@ -55,7 +55,11 @@ public class VoxCPM2CrispAsr : ITtsEngine
     public bool HasModel => true;
     public bool HasKeyFile => false;
     public bool SupportsVoiceCloning => true;
-    public bool SupportsPerLineVoiceCloning => false;
+    // Per-line clones are sent as a per-request `voice` file name, which the voxcpm2 backend
+    // opens as a path relative to the server's working directory - the voices folder - and
+    // clones from on every request without a restart. Ordinary imported voices stay on the
+    // startup --voice flag; see Speak and EnsureServerRunningAsync.
+    public bool SupportsPerLineVoiceCloning => true;
 
     // Two quants — Q4_K is the lightweight default (~1.7 GB), F16 the reference (~5 GB). The
     // label total includes the tiny shared voxcpm2-ref.gguf companion.
@@ -154,6 +158,9 @@ public class VoxCPM2CrispAsr : ITtsEngine
     // restart so the new --voice path takes effect.
     private static string? _serverVoicePath;
     private static string? _serverRefText;
+    // True when the running server was started for a per-line clone run: every line then sends
+    // its own reference in the request, so a new staged clip is not a restart.
+    private static bool _serverPerLine;
     private static bool _processExitHooked;
     private static readonly StringBuilder _serverLog = new();
 
@@ -371,6 +378,13 @@ public class VoxCPM2CrispAsr : ITtsEngine
         {
             foreach (var file in Directory.GetFiles(voicesFolder, "*.wav"))
             {
+                // The per-line clone's own references live here too; they belong to one line of
+                // one run, not in a combo.
+                if (PerLineReferenceStaging.IsStaged(file))
+                {
+                    continue;
+                }
+
                 var name = Path.GetFileNameWithoutExtension(file).Replace('_', ' ');
                 result.Add(new Voice(new VoxCPM2Voice(name, file)));
             }
@@ -378,6 +392,41 @@ public class VoxCPM2CrispAsr : ITtsEngine
 
         return result.ToArray();
     }
+
+    /// <summary>
+    /// <see cref="IPerLineCloneEngine"/>: the clip is staged into the voices folder, which is the
+    /// server's working directory, so its bare file name is what <see cref="Speak"/> sends as the
+    /// request's <c>voice</c>. Cloning is from audio alone, so a clip without a transcript is as
+    /// good as one with; staging only fails on a missing clip.
+    /// </summary>
+    public Voice? MakePerLineCloneVoice(string clipFileName, string voiceName) =>
+        StagePerLineReference(clipFileName) is { } staged
+            ? new Voice(new VoxCPM2Voice(voiceName, staged))
+            : null;
+
+    /// <summary>
+    /// The staged copy in the voices folder, which is the only reference this engine ever
+    /// speaks from - exporting it is what lets an imported session be re-dubbed on a machine
+    /// that no longer has the video.
+    /// </summary>
+    public string? GetPerLineReferenceClip(Voice voice) =>
+        voice.EngineVoice is VoxCPM2Voice voxVoice && !string.IsNullOrEmpty(voxVoice.FilePath)
+            ? voxVoice.FilePath
+            : null;
+
+    /// <summary>
+    /// <see cref="IPerLineCloneEngine"/>: see <see cref="ClearStagedPerLineReferences"/>.
+    /// </summary>
+    public void ResetStagedPerLineReferences() => ClearStagedPerLineReferences();
+
+    public static string? StagePerLineReference(string clipFileName) =>
+        PerLineReferenceStaging.Stage(clipFileName, GetSetVoicesFolder(), "VoxCPM2 (CrispASR)");
+
+    /// <summary>
+    /// Removes every staged per-line reference, leaving the user's imported voices alone.
+    /// </summary>
+    public static void ClearStagedPerLineReferences() =>
+        PerLineReferenceStaging.Clear(Path.Combine(GetSetFolder(), "voices"), "VoxCPM2 (CrispASR)");
 
     public bool IsVoiceInstalled(Voice voice) => true;
 
@@ -415,24 +464,15 @@ public class VoxCPM2CrispAsr : ITtsEngine
 
         var refText = TryReadRefText(voxVoice.FilePath);
         var modelKey = ResolveModelKey(model);
-        await EnsureServerRunningAsync(modelKey, voxVoice.FilePath, refText, cancellationToken);
+        // A per-line clone's reference is sent per request, so the server is keyed on the model
+        // only for those; an ordinary voice keeps the startup flag and its restart-on-change.
+        var isPerLineClone = PerLineReferenceStaging.IsStaged(voxVoice.FilePath);
+        await EnsureServerRunningAsync(modelKey, voxVoice.FilePath, refText, isPerLineClone, cancellationToken);
 
         var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder), Guid.NewGuid() + ".wav");
 
         var speed = Math.Clamp(Se.Settings.Video.TextToSpeech.VoxCPM2CrispAsrSpeed, 0.25, 4.0);
-        // Deliberately NO `voice` / `ref_text` field: the voxcpm2 backend treats a per-request
-        // `voice` as a FILE PATH (read_wav_mono_pcm16) that OVERRIDES the startup --voice, so the
-        // bare stem SE used to send failed to load and silently fell back to zero-shot — a random
-        // speaker per line, the same bug MOSS-TTS had (#12757). With the field omitted the backend
-        // falls back to the init-time --voice path (server mode never sets tts_voice_clone_consent,
-        // so the empty-voice branch resolves to voice_path_) and clones the reference. The server
-        // restarts on (voice, ref-text) change — see EnsureServerRunningAsync.
-        var payload = new Dictionary<string, object>
-        {
-            ["input"] = text,
-            ["response_format"] = "wav",
-            ["speed"] = speed,
-        };
+        var payload = BuildSpeakPayload(text, speed, isPerLineClone ? Path.GetFileName(voxVoice.FilePath) : null);
 
         // Attests the user's own imported reference and the AI-disclosure duty; see
         // CrispAsrTtsProvenance. Skipped when voice cloning has not been accepted in settings.
@@ -553,12 +593,51 @@ public class VoxCPM2CrispAsr : ITtsEngine
         }
     }
 
-    private static async Task EnsureServerRunningAsync(string modelKey, string voicePath, string refText, CancellationToken ct)
+    /// <summary>
+    /// Builds the <c>/v1/audio/speech</c> JSON payload. Extracted so the voice-field rule is
+    /// unit-testable without a running crispasr server.
+    /// </summary>
+    /// <param name="perLineVoiceFileName">
+    /// The bare file name of a staged per-line reference to send as the request's <c>voice</c>,
+    /// or null for an ordinary voice. The backend reads a per-request <c>voice</c> as a FILE PATH
+    /// that overrides the startup --voice, relative to its working directory - which
+    /// <see cref="EnsureServerRunningAsync"/> sets to the voices folder; the server rejects
+    /// anything with a path separator (HTTP 400), so it cannot be the full path.
+    /// </param>
+    /// <remarks>
+    /// For ordinary voices, deliberately sends NO <c>voice</c> / <c>ref_text</c> field: the bare
+    /// stem SE used to send failed to load and silently fell back to zero-shot — a random speaker
+    /// per line, the same bug MOSS-TTS had (#12757). With the field omitted the backend falls back
+    /// to the init-time --voice path (server mode never sets tts_voice_clone_consent, so the
+    /// empty-voice branch resolves to voice_path_) and clones the reference. The server restarts
+    /// on (voice, ref-text) change — see <see cref="EnsureServerRunningAsync"/>.
+    /// </remarks>
+    internal static Dictionary<string, object> BuildSpeakPayload(string text, double speed, string? perLineVoiceFileName)
     {
+        var payload = new Dictionary<string, object>
+        {
+            ["input"] = text,
+            ["response_format"] = "wav",
+            ["speed"] = speed,
+        };
+
+        if (!string.IsNullOrEmpty(perLineVoiceFileName))
+        {
+            payload["voice"] = perLineVoiceFileName;
+        }
+
+        return payload;
+    }
+
+    private static async Task EnsureServerRunningAsync(string modelKey, string voicePath, string refText, bool perLine, CancellationToken ct)
+    {
+        // A per-line clone run carries its reference in every request, so within such a run the
+        // server is keyed on the model alone; the first clip still goes on the startup flag.
         bool MatchesCurrent() =>
             _serverProcess is { HasExited: false } && _serverPort != 0
             && string.Equals(_serverModelKey, modelKey, StringComparison.OrdinalIgnoreCase)
             && (!UseStartupVoiceFlags
+                || (perLine && _serverPerLine)
                 || (string.Equals(_serverVoicePath, voicePath, StringComparison.OrdinalIgnoreCase)
                     && string.Equals(_serverRefText, refText, StringComparison.Ordinal)));
 
@@ -594,7 +673,12 @@ public class VoxCPM2CrispAsr : ITtsEngine
             var port = FindFreeLoopbackPort();
             var psi = new ProcessStartInfo
             {
-                WorkingDirectory = Path.GetDirectoryName(exe) ?? GetSetFolder(),
+                // Run in the voices folder: the backend opens a per-request `voice` as a literal
+                // path relative to its working directory (it does not resolve it against
+                // --voice-dir), and the server rejects a `voice` with path separators - so this is
+                // what lets a per-line clone's staged clip be found by its bare file name. Every
+                // path passed below is absolute, so nothing else depends on the working directory.
+                WorkingDirectory = GetSetVoicesFolder(),
                 FileName = exe,
                 UseShellExecute = false,
                 CreateNoWindow = true,
@@ -660,6 +744,7 @@ public class VoxCPM2CrispAsr : ITtsEngine
             _serverModelKey = modelKey;
             _serverVoicePath = voicePath;
             _serverRefText = refText;
+            _serverPerLine = perLine;
             HookProcessExitOnce();
 
             // First-run auto-download (the main GGUF is up to ~5 GB) needs a generous timeout.
@@ -678,6 +763,7 @@ public class VoxCPM2CrispAsr : ITtsEngine
                     _serverModelKey = null;
                     _serverVoicePath = null;
                     _serverRefText = null;
+                    _serverPerLine = false;
                     throw new InvalidOperationException(
                         $"crispasr (voxcpm2-tts) exited during startup (code {exitCode}). Output: {tail}"
                         + LaunchCmdSuffix(exitedLaunchCommand));
@@ -761,6 +847,7 @@ public class VoxCPM2CrispAsr : ITtsEngine
         _serverModelKey = null;
         _serverVoicePath = null;
         _serverRefText = null;
+        _serverPerLine = false;
         if (p == null)
         {
             return;

--- a/tests/UI/Features/Video/TextToSpeech/Engines/CosyVoice3VoxCpm2PerLineCloneTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/CosyVoice3VoxCpm2PerLineCloneTests.cs
@@ -1,0 +1,77 @@
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+
+namespace UITests.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// Per-line voice cloning on CosyVoice3 and VoxCPM2 (CrispASR): both backends open a
+/// per-request <c>voice</c> as a literal path relative to the server's working directory, which
+/// SE points at the voices folder, so the request carries the staged clip's bare file name.
+/// </summary>
+public class CosyVoice3VoxCpm2PerLineCloneTests
+{
+    [Fact]
+    public void BothEnginesOfferPerLineCloning()
+    {
+        Assert.True(PerLineVoiceClone.CanBeOffered(new CosyVoice3CrispAsr(), "/videos/movie.mkv"));
+        Assert.True(PerLineVoiceClone.CanBeOffered(new VoxCPM2CrispAsr(), "/videos/movie.mkv"));
+        Assert.IsAssignableFrom<IPerLineCloneEngine>(new CosyVoice3CrispAsr());
+        Assert.IsAssignableFrom<IPerLineCloneEngine>(new VoxCPM2CrispAsr());
+    }
+
+    [Fact]
+    public void CosyVoice3_OrdinaryVoice_SendsNoVoiceField()
+    {
+        // The startup --voice/--ref-text flags carry an ordinary clone; a per-request absolute
+        // path is a 400 and a bare stem is not a clone path (no .wav suffix).
+        var payload = CosyVoice3CrispAsr.BuildSpeakPayload("hello", 1.0, null, null);
+
+        Assert.False(payload.ContainsKey("voice"));
+        Assert.False(payload.ContainsKey("ref_text"));
+    }
+
+    [Fact]
+    public void CosyVoice3_PerLineClone_SendsFileNameWithWavSuffixAndTranscript()
+    {
+        // The backend takes the clone path only for a `voice` ending in .wav, and is conditioned
+        // on the (transcript, speech) pair - so both travel with the request.
+        var payload = CosyVoice3CrispAsr.BuildSpeakPayload("hello", 1.0, "se-per-line-line-0007.wav", "What the clip says.");
+
+        Assert.Equal("se-per-line-line-0007.wav", payload["voice"]);
+        Assert.Equal("What the clip says.", payload["ref_text"]);
+        Assert.DoesNotContain('/', (string)payload["voice"]);
+    }
+
+    [Fact]
+    public void VoxCpm2_OrdinaryVoice_SendsNoVoiceField()
+    {
+        var payload = VoxCPM2CrispAsr.BuildSpeakPayload("hello", 1.0, null);
+
+        Assert.False(payload.ContainsKey("voice"));
+    }
+
+    [Fact]
+    public void VoxCpm2_PerLineClone_SendsTheBareFileName()
+    {
+        var payload = VoxCPM2CrispAsr.BuildSpeakPayload("hello", 1.0, "se-per-line-line-0007.wav");
+
+        Assert.Equal("se-per-line-line-0007.wav", payload["voice"]);
+        Assert.False(payload.ContainsKey("ref_text"));
+    }
+
+    [Fact]
+    public void TheVoicePointsAtTheStagedCopy()
+    {
+        var cosy = new CosyVoice3CrispAsr();
+        var vox = new VoxCPM2CrispAsr();
+
+        Assert.Equal("/voices/se-per-line-line-0003.wav",
+            cosy.GetPerLineReferenceClip(new Voice(new CosyVoice3Voice("Ada", "/voices/se-per-line-line-0003.wav", "Hi."))));
+        Assert.Equal("/voices/se-per-line-line-0003.wav",
+            vox.GetPerLineReferenceClip(new Voice(new VoxCPM2Voice("Ada", "/voices/se-per-line-line-0003.wav"))));
+        // A baked preset clones from nothing.
+        Assert.Null(cosy.GetPerLineReferenceClip(new Voice(new CosyVoice3Voice("zero shot", "zero_shot"))));
+        Assert.Null(vox.GetPerLineReferenceClip(new Voice(new CosyVoice3Voice("Ada", "/voices/x.wav", "Hi."))));
+    }
+}


### PR DESCRIPTION
## Summary

Second half of the #14480 request (comment [5551377619](https://github.com/SubtitleEdit/subtitleedit/issues/14480#issuecomment-5551377619)): **Clone from video (voice of each line)** for CosyVoice3 and VoxCPM2.

**Stacked on #14562** (uses its shared `PerLineReferenceStaging`). Merge that first, then retarget this to `main`.

Both crispasr backends open a per-request `voice` as a literal path relative to the server's working directory and never resolve it against `--voice-dir`, while the server 400s on any `voice` with a path separator. So:

- The server now runs **from the voices folder** (exactly what `ChatterboxTtsCpp` already does, for the same reason). Every other argument is absolute, so nothing else depends on the working directory.
- **CosyVoice3**: a per-line clone sends `voice` = the staged clip's bare file name (the backend takes the clone path only for a `.wav` name) plus `ref_text` = the clip's transcript. A clip without a usable transcript is not offered as a reference, so that line falls back to an ordinary voice.
- **VoxCPM2**: a per-line clone sends `voice` = bare file name; the backend reads the file per request.
- For both, the server is keyed on the model alone during a per-line run. Ordinary imported voices keep the startup `--voice` flag and restart-on-change, so nothing changes for them.

## Test plan

- [x] New `CosyVoice3VoxCpm2PerLineCloneTests` + the existing per-line, consent, catalog, CosyVoice3 and MOSS tests pass (130 tests)
- [ ] Manual: CosyVoice3 and VoxCPM2 with "Clone from video" on a multi-speaker clip; check the server log shows the clip loaded per line and no restarts, and that the existing imported-voice flow still clones (server started from the voices folder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)