### PR TITLE
Text drag-and-drop: keep the selection intact and space the drop like SE4

### DIFF
--- a/src/ui/Features/Shared/TextBoxUtils/TextBoxTextDragDrop.cs
+++ b/src/ui/Features/Shared/TextBoxUtils/TextBoxTextDragDrop.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls.Presenters;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.VisualTree;
+using Nikse.SubtitleEdit.Core.Common;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -21,11 +22,17 @@ namespace Nikse.SubtitleEdit.Features.Shared.TextBoxUtils;
 /// collapse the selection to a caret), and a drag starts once the pointer moves a few pixels;
 /// a release without movement replays the click the box did not see. Drops insert through the
 /// same path as paste, so line breaks get normalized, the paragraph binding fires and a
-/// read-only box stays untouched.
+/// read-only box stays untouched, and the seams get SE4's spacing: a space is added where the
+/// dropped text would touch a word, none in front of punctuation or after a line break, and the
+/// space a word leaves behind when it is moved out is removed.
 /// </summary>
 public static class TextBoxTextDragDrop
 {
     private const double DragThreshold = 4;
+
+    /// <summary>Characters that never get a space in front of them when text is dropped or
+    /// lifted out right before them (SE4's list, plus the comma).</summary>
+    private const string NoSpaceBefore = ",:;]<.!?؟";
 
     /// <summary>The box a drag currently originates from, with the dragged range - so the
     /// drop handler can tell "move within the same box" from "copy from elsewhere".</summary>
@@ -86,8 +93,10 @@ public static class TextBoxTextDragDrop
                 return;
             }
 
+            // Inclusive at the end, like SE4: the trailing half of the last selected character
+            // hit-tests to selectionEnd, and a press there is still a press on the selection.
             var index = GetCharIndexAtPoint(_textBox, e);
-            if (index == null || index < selectionStart || index >= selectionEnd)
+            if (index == null || index < selectionStart || index > selectionEnd)
             {
                 return;
             }
@@ -111,6 +120,13 @@ public static class TextBoxTextDragDrop
                 return;
             }
 
+            // The box must not see any move while the press is pending, not just the one that
+            // starts the drag: Avalonia captured the pointer to the presenter on the press even
+            // though the box never handled it, and the box's own move handler then extends the
+            // selection to the pointer - every sub-threshold jitter would shrink the selection
+            // before the drag picks it up (#14568).
+            e.Handled = true;
+
             var delta = e.GetPosition(_textBox) - _pressPoint;
             if (Math.Abs(delta.X) < DragThreshold && Math.Abs(delta.Y) < DragThreshold)
             {
@@ -118,7 +134,6 @@ public static class TextBoxTextDragDrop
             }
 
             _pending = null;
-            e.Handled = true;
             _ = StartDragAsync(pending);
         }
 
@@ -274,41 +289,93 @@ public static class TextBoxTextDragDrop
 
         var current = textBox.Text ?? string.Empty;
         index = Math.Clamp(index, 0, current.Length);
+        var fitted = FitSpacing(current, index, text.NormalizeLineBreaks());
         textBox.SelectionStart = index;
         textBox.SelectionEnd = index;
         textBox.CaretIndex = index;
-        TextBoxPasteNormalizer.InsertNormalized(textBox, text);
+        TextBoxPasteNormalizer.InsertNormalized(textBox, fitted.Text);
 
         // Leave the dropped text selected, like SE4 - it shows what landed and lets a
-        // second drag pick it straight up again.
+        // second drag pick it straight up again. The padding spaces stay outside the
+        // selection; they belong to the seams, not to the dragged text.
         var insertedLength = (textBox.Text?.Length ?? 0) - current.Length;
-        if (insertedLength > 0)
+        var selectLength = Math.Min(fitted.Length, insertedLength - fitted.Skip);
+        if (selectLength > 0)
         {
-            textBox.SelectionStart = index;
-            textBox.SelectionEnd = index + insertedLength;
+            textBox.SelectionStart = index + fitted.Skip;
+            textBox.SelectionEnd = index + fitted.Skip + selectLength;
         }
 
         textBox.Focus();
     }
 
     /// <summary>
-    /// Removing a word from the middle of a line leaves "a  b"; collapse the doubled space at
-    /// <paramref name="seam"/> and shift <paramref name="dropIndex"/> if it sat past it.
+    /// SE4's drop spacing: the dropped text gets a space on each side that is missing one, unless
+    /// it lands at a whitespace boundary (space, line break, start or end of the text) or right
+    /// before closing punctuation; an outer space the text brings to such a boundary is dropped
+    /// instead. Returns the string to insert, and where the dragged text sits inside it.
+    /// </summary>
+    internal static (string Text, int Skip, int Length) FitSpacing(string current, int index, string text)
+    {
+        var prev = index > 0 ? current[index - 1] : (char?)null;
+        var next = index < current.Length ? current[index] : (char?)null;
+
+        if (text.StartsWith(' ') && (prev == null || char.IsWhiteSpace(prev.Value)))
+        {
+            text = text.Substring(1);
+        }
+
+        if (text.EndsWith(' ') && (next == null || char.IsWhiteSpace(next.Value)))
+        {
+            text = text.Substring(0, text.Length - 1);
+        }
+
+        if (text.Length == 0)
+        {
+            return (string.Empty, 0, 0);
+        }
+
+        var prefix = prev != null && !char.IsWhiteSpace(prev.Value) && !char.IsWhiteSpace(text[0])
+            ? " "
+            : string.Empty;
+        var suffix = next != null && !char.IsWhiteSpace(next.Value) && !NoSpaceBefore.Contains(next.Value) &&
+                     !char.IsWhiteSpace(text[text.Length - 1])
+            ? " "
+            : string.Empty;
+
+        return (prefix + text + suffix, prefix.Length, text.Length);
+    }
+
+    /// <summary>
+    /// Lifting a word out leaves its spacing behind: "a  b", " b", "a .", "a " or "a \nb". Remove the
+    /// stray space at <paramref name="seam"/> (SE4's rules, with a line break and the ends of the
+    /// text counting as boundaries) and shift <paramref name="dropIndex"/> if it sat past it.
     /// </summary>
     private static int CollapseSeamSpace(TextBox textBox, int seam, int dropIndex)
     {
         var text = textBox.Text ?? string.Empty;
-        var doubleSpace = seam > 0 && seam < text.Length && text[seam - 1] == ' ' && text[seam] == ' ';
-        var leadingSpace = seam == 0 && text.Length > 0 && text[0] == ' ';
-        if (!doubleSpace && !leadingSpace)
+        var prev = seam > 0 ? text[seam - 1] : (char?)null;
+        var next = seam < text.Length ? text[seam] : (char?)null;
+
+        int removeAt;
+        if (next == ' ' && (prev == null || char.IsWhiteSpace(prev.Value) ||
+                            (seam + 1 < text.Length && NoSpaceBefore.Contains(text[seam + 1]))))
+        {
+            removeAt = seam;
+        }
+        else if (prev == ' ' && (next == null || char.IsWhiteSpace(next.Value) || NoSpaceBefore.Contains(next.Value)))
+        {
+            removeAt = seam - 1;
+        }
+        else
         {
             return dropIndex;
         }
 
-        textBox.SelectionStart = seam;
-        textBox.SelectionEnd = seam + 1;
+        textBox.SelectionStart = removeAt;
+        textBox.SelectionEnd = removeAt + 1;
         textBox.SelectedText = string.Empty;
-        return dropIndex > seam ? dropIndex - 1 : dropIndex;
+        return dropIndex > removeAt ? dropIndex - 1 : dropIndex;
     }
 
     private static int? GetCharIndexAtPoint(TextBox textBox, PointerEventArgs e)

--- a/tests/UI/Features/TextBoxTextDragDropTests.cs
+++ b/tests/UI/Features/TextBoxTextDragDropTests.cs
@@ -76,6 +76,60 @@ public class TextBoxTextDragDropTests
     }
 
     [AvaloniaFact]
+    public void SmallMoveInsideSelection_KeepsTheSelectionIntact()
+    {
+        // #14568: Avalonia captures the pointer to the presenter on the press even though the box
+        // never handled it, and the box's move handler then drags SelectionEnd along with the
+        // pointer - so a hand that wobbles before the drag threshold used to lose characters.
+        var (window, textBox) = Show("hello brave world");
+        try
+        {
+            textBox.SelectionStart = 6;
+            textBox.SelectionEnd = 11; // "brave"
+            var point = PointAt(window, textBox, 10);
+
+            window.MouseDown(point, MouseButton.Left);
+            window.MouseMove(new Point(point.X - 2, point.Y), RawInputModifiers.LeftMouseButton);
+            Dispatcher.UIThread.RunJobs();
+            Assert.Equal("brave", textBox.SelectedText);
+
+            window.MouseMove(new Point(point.X - 30, point.Y), RawInputModifiers.LeftMouseButton);
+            Dispatcher.UIThread.RunJobs();
+            Assert.Equal("brave", textBox.SelectedText);
+
+            window.MouseUp(new Point(point.X - 30, point.Y), MouseButton.Left);
+            Dispatcher.UIThread.RunJobs();
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void PressAtTheEndOfTheSelection_CountsAsInside()
+    {
+        var (window, textBox) = Show("hello brave world");
+        try
+        {
+            textBox.SelectionStart = 6;
+            textBox.SelectionEnd = 11;
+            var point = PointAt(window, textBox, 11); // hit-tests to selectionEnd
+
+            window.MouseDown(point, MouseButton.Left);
+            Dispatcher.UIThread.RunJobs();
+            Assert.Equal("brave", textBox.SelectedText);
+
+            window.MouseUp(point, MouseButton.Left);
+            Dispatcher.UIThread.RunJobs();
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
     public void ClickOutsideSelection_IsLeftToTheTextBox()
     {
         var (window, textBox) = Show("hello brave world");
@@ -117,6 +171,109 @@ public class TextBoxTextDragDropTests
         }
         finally
         {
+            window.Close();
+        }
+    }
+
+    [Theory]
+    // Between two words: a space is added on the side that lacks one.
+    [InlineData("hello world", 5, "brave", "hello brave world", "brave")]
+    [InlineData("hello world", 6, "brave", "hello brave world", "brave")]
+    // Spaces the text carries are kept where needed and dropped at a boundary; what is kept
+    // stays part of the selection, the added padding does not.
+    [InlineData("hello world", 6, " brave ", "hello brave world", "brave ")]
+    [InlineData("hello world", 11, " brave ", "hello world brave", " brave")]
+    [InlineData("hello world", 0, " brave ", "brave hello world", "brave ")]
+    // No space in front of closing punctuation (SE4's list plus the comma).
+    [InlineData("hello.", 5, "brave", "hello brave.", "brave")]
+    [InlineData("hello, world", 5, "brave", "hello brave, world", "brave")]
+    [InlineData("hello<i>x</i>", 5, "brave", "hello brave<i>x</i>", "brave")]
+    // A line break is a boundary: no space after it, none before it.
+    [InlineData("hello\nworld", 6, "brave", "hello\nbrave world", "brave")]
+    [InlineData("hello\nworld", 5, "brave", "hello brave\nworld", "brave")]
+    [InlineData("hello\nworld", 6, " brave ", "hello\nbrave world", "brave ")]
+    [InlineData("hello\nworld", 5, " brave ", "hello brave\nworld", " brave")]
+    // Into an empty box: nothing to pad.
+    [InlineData("", 0, "brave", "brave", "brave")]
+    public void FitSpacing_FollowsSe4Rules(string current, int index, string dropped, string expected, string expectedSelected)
+    {
+        var fitted = TextBoxTextDragDrop.FitSpacing(current, index, dropped);
+
+        Assert.Equal(expected, current.Insert(index, fitted.Text));
+        Assert.Equal(expectedSelected, fitted.Text.Substring(fitted.Skip, fitted.Length));
+    }
+
+    [AvaloniaFact]
+    public void DropFromElsewhere_BetweenTwoWords_AddsTheMissingSpace()
+    {
+        var (window, textBox) = Show("hello world");
+        try
+        {
+            TextBoxTextDragDrop.SetDragSourceForTest(null, 0, 0);
+            var point = PointAt(window, textBox, 5); // right after "hello"
+
+            window.DragDrop(point, RawDragEventType.DragOver, Text("brave"), DragDropEffects.Copy, RawInputModifiers.None);
+            window.DragDrop(point, RawDragEventType.Drop, Text("brave"), DragDropEffects.Copy, RawInputModifiers.None);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal("hello brave world", textBox.Text);
+            Assert.Equal("brave", textBox.SelectedText);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void DropWithinTheSameBox_LiftingAWordBeforePunctuation_LeavesNoStraySpace()
+    {
+        var (window, textBox) = Show("hello brave." + Environment.NewLine + "world");
+        try
+        {
+            // Dragging "brave" (6..11) to the very end.
+            textBox.SelectionStart = 6;
+            textBox.SelectionEnd = 11;
+            TextBoxTextDragDrop.SetDragSourceForTest(textBox, 6, 5);
+            var end = textBox.Text!.Length;
+            var point = PointAt(window, textBox, end);
+
+            window.DragDrop(point, RawDragEventType.DragOver, Text("brave"), DragDropEffects.Copy | DragDropEffects.Move, RawInputModifiers.None);
+            window.DragDrop(point, RawDragEventType.Drop, Text("brave"), DragDropEffects.Copy | DragDropEffects.Move, RawInputModifiers.None);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal("hello." + Environment.NewLine + "world brave", textBox.Text);
+            Assert.Equal("brave", textBox.SelectedText);
+        }
+        finally
+        {
+            TextBoxTextDragDrop.SetDragSourceForTest(null, 0, 0);
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void DropWithinTheSameBox_LiftingTheLastWordOfALine_LeavesNoTrailingSpace()
+    {
+        var (window, textBox) = Show("hello brave" + Environment.NewLine + "world");
+        try
+        {
+            // Dragging "brave" (6..11) to the start of the text.
+            textBox.SelectionStart = 6;
+            textBox.SelectionEnd = 11;
+            TextBoxTextDragDrop.SetDragSourceForTest(textBox, 6, 5);
+            var point = PointAt(window, textBox, 0);
+
+            window.DragDrop(point, RawDragEventType.DragOver, Text("brave"), DragDropEffects.Copy | DragDropEffects.Move, RawInputModifiers.None);
+            window.DragDrop(point, RawDragEventType.Drop, Text("brave"), DragDropEffects.Copy | DragDropEffects.Move, RawInputModifiers.None);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal("brave hello" + Environment.NewLine + "world", textBox.Text);
+            Assert.Equal("brave", textBox.SelectedText);
+        }
+        finally
+        {
+            TextBoxTextDragDrop.SetDragSourceForTest(null, 0, 0);
             window.Close();
         }
     }
@@ -178,8 +335,10 @@ public class TextBoxTextDragDropTests
             window.DragDrop(point, RawDragEventType.DragOver, Text("brave "), DragDropEffects.Copy | DragDropEffects.Move, RawInputModifiers.None);
             window.DragDrop(point, RawDragEventType.Drop, Text("brave "), DragDropEffects.Copy | DragDropEffects.Move, RawInputModifiers.None);
             Dispatcher.UIThread.RunJobs();
-            Assert.Equal("hello worldbrave ", textBox.Text);
-            Assert.Equal("brave ", textBox.SelectedText);
+            // The trailing space it carried is dropped at the end of the text and a space is
+            // put in front of it instead.
+            Assert.Equal("hello world brave", textBox.Text);
+            Assert.Equal("brave", textBox.SelectedText);
         }
         finally
         {


### PR DESCRIPTION
Fixes #14568

## The bug

The drag helper from #14534 takes the press inside a selection in the tunnel phase, but Avalonia still captures the pointer to the `TextPresenter`, and `TextBox`'s own `OnPointerMoved` only checks "captured is my presenter and left button down" before setting `SelectionEnd` to the pointer. Every sub-threshold move before the drag started therefore shrank the selection, and the drag carried the truncated range.

Headless probe, "brave" selected, press on the "e":

| Step | Selection |
|---|---|
| after press | brave |
| after 2 px move | brav |
| after 30 px move (drag starts) | brav |

Pointer moves are now handled for as long as a press is pending. A press that hit-tests exactly to the selection end (trailing half of the last selected character) counts as inside, as SE4 did.

## Spacing on drop (SE4's rules)

Ported from SE4's `SimpleTextBox.SETextBox_DragDrop`:

- a space is added on each side of the dropped text where it would otherwise touch a word
- no space in front of closing punctuation (`:;]<.!?؟`, plus the comma)
- an outer space the dragged text carries to a boundary is dropped instead of doubling
- moving a word out of the same box removes the space it leaves behind

Beyond SE4: a line break and the ends of the text count as boundaries, so a drop never produces a leading space after a line break or a trailing space before one, and lifting the last word of a line does not leave a trailing space. The dragged text stays selected after the drop, without the padding spaces.

## Tests

`TextBoxTextDragDropTests`: 26 pass. New: the 2 px jitter case, the inclusive selection end, a theory over the spacing rules, and same-box moves next to punctuation and line breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
