### PR TITLE
Fix overlapping labels and progress text in the speech-to-text window

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
@@ -353,47 +353,20 @@ public class SpeechToTextWindow : Window
         );
         buttonPanel.Margin = new Thickness(10, 0, 10, 10);
 
+        // Rows: 0 console log label, 1 console log (Star), 2-6 engine/backend/language/model/forced aligner,
+        // then one row per online-STT setting (OpenAI-compatible, OpenRouter, DashScope, Google Cloud; only the
+        // selected engine's rows are visible, the rest collapse to zero height), then translate-to-English,
+        // post processing, advanced settings label + button, advanced parameters text box, and finally the
+        // progress panel + buttons. The count is derived from the engine row arrays so adding an online engine
+        // cannot leave trailing rows clamped onto the last row (which made the labels overlap the progress text).
+        const int fixedRowsBeforeOnlineStt = 7;
+        const int fixedRowsAfterOnlineStt = 5;
+        var onlineSttRowCount = openAiRows.Length + openRouterRows.Length + dashScopeRows.Length + googleCloudRows.Length;
+        var totalRowCount = fixedRowsBeforeOnlineStt + onlineSttRowCount + fixedRowsAfterOnlineStt;
+        var progressRow = totalRowCount - 1;
+
         var grid = new Grid
         {
-            RowDefinitions =
-            {
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 0: Console log label
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) }, // 1: Console log (right) — Star fills remaining
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 2: Engine
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 3: Backend
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 4: Language
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 5: Model
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 6: Forced aligner
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 7: OpenAI STT - Endpoint URL
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 8: OpenAI STT - API Key
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 9: OpenAI STT - Model
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 10: OpenAI STT - Language
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 11: OpenAI STT - Timeout
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 12: OpenAI STT - Temperature
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 13: OpenAI STT - Prompt
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 14: OpenAI STT - Extra Headers
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 15: OpenAI STT - Audio Format
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 16: OpenAI STT - Stream
-                // OpenRouter STT rows (6) — only visible when OpenRouter is selected, else collapse to 0.
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 17: OpenRouter - API Key
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 18: OpenRouter - Model
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 19: OpenRouter - Language
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 20: OpenRouter - Timeout
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 21: OpenRouter - Temperature
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 22: OpenRouter - Prompt
-                // Alibaba Qwen3-ASR (DashScope) STT rows (6).
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 23: DashScope - API Key
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 24: DashScope - Model
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 25: DashScope - Region
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 26: DashScope - Language
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 27: DashScope - Word timestamps
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 28: DashScope - Timeout
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 29: Translate to English
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 30: Post processing
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 31: Advanced settings label + button
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 32: textBoxAdvancedSettings (parameters)
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // 33: panelProgress + OK/Cancel (same row)
-            },
             ColumnDefinitions =
             {
                 new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
@@ -406,6 +379,10 @@ public class SpeechToTextWindow : Window
             Width = double.NaN,
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
+        for (var i = 0; i < totalRowCount; i++)
+        {
+            grid.RowDefinitions.Add(new RowDefinition { Height = i == 1 ? new GridLength(1, GridUnitType.Star) : new GridLength(1, GridUnitType.Auto) });
+        }
 
         var flyout = new MenuFlyout();
         flyout.Opening += vm.WindowContextMenuOpening;
@@ -439,9 +416,10 @@ public class SpeechToTextWindow : Window
 
         // Row span must reach the row just above the progress/buttons row so the
         // console log fills the full height of the settings column. It covers every
-        // settings row including the OpenAI/OpenRouter/DashScope online-STT rows.
-        grid.Add(consoleLogAndBatchView, row, 2, 32);
-        grid.Add(consoleLogOnlyView, row, 2, 32);
+        // settings row including the online-STT rows.
+        var consoleLogRowSpan = progressRow - row;
+        grid.Add(consoleLogAndBatchView, row, 2, consoleLogRowSpan);
+        grid.Add(consoleLogOnlyView, row, 2, consoleLogRowSpan);
         row++;
 
         grid.Add(labelEngine, row, 0);
@@ -491,6 +469,7 @@ public class SpeechToTextWindow : Window
         grid.Add(textBoxAdvancedSettings, row, 0, 1, 2);
         row++;
 
+        System.Diagnostics.Debug.Assert(row == progressRow, "SpeechToTextWindow grid row count is out of sync with the rows added");
         grid.Add(panelProgress, row, 0, 1, 3);
         grid.Add(buttonPanel, row, 0, 1, 3);
 

--- a/tests/UI/Features/Video/SpeechToText/SpeechToTextWindowLayoutTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/SpeechToTextWindowLayoutTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace UITests.Features.Video.SpeechToText;
+
+/// <summary>
+/// The speech-to-text window builds its grid in code. Grid.Row values past the last
+/// RowDefinition silently clamp onto the final row, which put the post-processing and
+/// advanced-settings labels on top of the "Transcribing..." / "Time elapsed" text once
+/// the Google Cloud engine added rows without extending the definitions.
+/// </summary>
+public class SpeechToTextWindowLayoutTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private (SpeechToTextWindow Window, Grid Grid) BuildWindow()
+    {
+        var vm = new SpeechToTextViewModel(new WindowService(new NullServiceProvider()), new FileHelper(), new FolderHelper());
+        var window = new SpeechToTextWindow(vm);
+        _windows.Add(window);
+        return (window, Assert.IsType<Grid>(window.Content));
+    }
+
+    [AvaloniaFact]
+    public void EveryChild_SitsInsideTheDefinedRows()
+    {
+        var (_, grid) = BuildWindow();
+
+        var rowCount = grid.RowDefinitions.Count;
+        foreach (var child in grid.Children)
+        {
+            var row = Grid.GetRow(child);
+            var span = Grid.GetRowSpan(child);
+            Assert.True(row + span <= rowCount, $"{child.GetType().Name} at row {row} span {span} exceeds {rowCount} rows");
+        }
+    }
+
+    [AvaloniaFact]
+    public void ProgressRow_HoldsOnlyTheProgressPanelAndButtons()
+    {
+        var (_, grid) = BuildWindow();
+
+        var lastRow = grid.RowDefinitions.Count - 1;
+        var onLastRow = grid.Children.Where(c => Grid.GetRow(c) == lastRow).ToList();
+
+        Assert.Equal(2, onLastRow.Count);
+        Assert.All(onLastRow, c => Assert.Equal(3, Grid.GetColumnSpan(c)));
+    }
+
+    [AvaloniaFact]
+    public void ConsoleLog_SpansDownToTheRowAboveProgress()
+    {
+        var (_, grid) = BuildWindow();
+
+        var lastRow = grid.RowDefinitions.Count - 1;
+        var consoleViews = grid.Children.Where(c => Grid.GetRow(c) == 1 && Grid.GetColumn(c) == 2).ToList();
+
+        Assert.NotEmpty(consoleViews);
+        Assert.All(consoleViews, c => Assert.Equal(lastRow, Grid.GetRow(c) + Grid.GetRowSpan(c)));
+    }
+}


### PR DESCRIPTION
## Summary
- The Google Cloud engine added five settings rows to the speech-to-text grid, but the `RowDefinitions` and the console-log `RowSpan` were not extended. Avalonia clamps `Grid.Row` values past the last definition onto the final row, so post processing, advanced settings, the parameters text box and the progress panel all landed on the button row and drew over "Transcribing..." / "Time elapsed".
- The row count is now derived from the online-STT row arrays, so adding another engine cannot desync the grid again.
- New `SpeechToTextWindowLayoutTests` asserts every grid child fits inside the defined rows, that the last row holds only the progress panel and button bar, and that the console log spans down to the row above it. The first two fail on `main`.

## Test plan
- [x] `dotnet test tests/UI --filter SpeechToTextWindowLayoutTests` passes with the fix and fails without it
- [x] Headless render of the window shows the labels above the progress bar and the status lines beside the buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)