### PR TITLE
Show live progress for WhisperX speech-to-text

### DIFF
--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -197,6 +197,11 @@ public partial class SpeechToTextViewModel : ObservableObject
         new(@"^\[\d\d:\d\d:\d\d[\.,]\d\d\d --> \d\d:\d\d:\d\d[\.,]\d\d\d]", RegexOptions.Compiled);
 
     private readonly Regex _pctWhisper = new(@"^\d+%\|", RegexOptions.Compiled);
+
+    // WhisperX (verbose, its default) prints one "Transcript: [1101.31 --> 1130.774]  text" line
+    // per VAD chunk as it is decoded, with plain seconds rather than a time code.
+    private static readonly Regex WhisperXTranscriptRegex =
+        new(@"^Transcript: \[(\d+(?:\.\d+)?) --> (\d+(?:\.\d+)?)\]", RegexOptions.Compiled);
     private readonly Regex _pctWhisperFaster = new(@"^\s*\d+%\s*\|", RegexOptions.Compiled);
 
     // Sentence chunks with trailing terminator (+ closing quotes/brackets), or a
@@ -4601,6 +4606,20 @@ public partial class SpeechToTextViewModel : ObservableObject
                 // "[hh:mm:ss.mmm --> hh:mm:ss.mmm]  text"
                 AddResultTextFromLine(line, startIndex: 1, timeLength: 12, endIndex: 18, textIndex: 31, language.Code);
             }
+            else if (TryParseWhisperXTranscriptEndSeconds(line, out var whisperXEndSeconds))
+            {
+                // WhisperX streams no percentage unless --print_progress is set, and even then it
+                // restarts at 0% for the alignment pass, so the chunk end time is the usable live
+                // signal: it drives the progress bar and the time estimate the same way the
+                // "[mm:ss.mmm --> mm:ss.mmm]" segment lines of the other engines do. The chunks
+                // are not added to the result list - the SRT WhisperX writes has the aligned,
+                // sentence-split segments, and these ~30 s VAD chunks would only get in the way
+                // of that.
+                if (_showProgressPct < 0 && whisperXEndSeconds > _endSeconds)
+                {
+                    _endSeconds = whisperXEndSeconds;
+                }
+            }
             else if (line.StartsWith("whisper_full: progress =", StringComparison.OrdinalIgnoreCase))
             {
                 var arr = line.Split('=');
@@ -4676,6 +4695,17 @@ public partial class SpeechToTextViewModel : ObservableObject
         }
 
         _resultList.Add(rt);
+    }
+
+    /// <summary>
+    /// Reads the chunk end time from a WhisperX "Transcript: [start --> end]  text" line.
+    /// </summary>
+    internal static bool TryParseWhisperXTranscriptEndSeconds(string line, out double endSeconds)
+    {
+        endSeconds = 0;
+        var match = WhisperXTranscriptRegex.Match(line);
+        return match.Success &&
+               double.TryParse(match.Groups[2].Value, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out endSeconds);
     }
 
     private void LogToConsole(string s, bool skipOutputText = false)

--- a/tests/UI/Features/Video/SpeechToText/WhisperXProgressParsingTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/WhisperXProgressParsingTests.cs
@@ -1,0 +1,32 @@
+using Nikse.SubtitleEdit.Features.Video.SpeechToText;
+
+namespace UITests.Features.Video.SpeechToText;
+
+/// <summary>
+/// WhisperX prints no progress percentage by default; its per-chunk
+/// "Transcript: [start --> end]  text" lines are the live signal the progress bar runs on.
+/// </summary>
+public class WhisperXProgressParsingTests
+{
+    [Theory]
+    [InlineData("Transcript: [1101.31 --> 1130.774]  I really spoke with some of the best.", 1130.774)]
+    [InlineData("Transcript: [1202.155 --> 1202.628]  Now.", 1202.628)]
+    [InlineData("Transcript: [0 --> 12]  Thanks for watching!", 12)]
+    [InlineData("Transcript: [1272.271 --> 1278.143]", 1278.143)]
+    public void TranscriptLine_YieldsChunkEndSeconds(string line, double expectedEnd)
+    {
+        Assert.True(SpeechToTextViewModel.TryParseWhisperXTranscriptEndSeconds(line, out var end));
+        Assert.Equal(expectedEnd, end, 3);
+    }
+
+    [Theory]
+    [InlineData("[00:18:21.310 --> 00:18:50.774]  I really spoke with some of the best.")]
+    [InlineData("Progress: 12.34%...")]
+    [InlineData("Transcript: [1,101.31 --> 1,130.774]  comma separated")]
+    [InlineData("Detected language: en (1.00) in first 30s of audio...")]
+    [InlineData("")]
+    public void OtherLines_AreIgnored(string line)
+    {
+        Assert.False(SpeechToTextViewModel.TryParseWhisperXTranscriptEndSeconds(line, out _));
+    }
+}


### PR DESCRIPTION
## Summary
- WhisperX showed no progress bar or time estimate for the whole run. It prints no percentage by default, and its `--print_progress` output restarts at 0% for the alignment pass, so a percentage-based signal would not work either.
- WhisperX does print one `Transcript: [1101.31 --> 1130.774]  text` line per VAD chunk as it decodes, with plain seconds rather than a time code, which none of the existing segment-line regexes matched. The output handler now parses the chunk end time from those lines and feeds the same end-seconds path the other engines' segment lines use, so the bar, elapsed time and estimate track the transcription.
- The chunks are deliberately not added to the stdout result list: the SRT WhisperX writes holds the aligned, sentence-split segments, and these ~30 s chunks would only degrade the fallback.
- The bar reaches ~100% at the end of the transcription pass and holds there during alignment, which prints nothing usable.

## Test plan
- [x] New `WhisperXProgressParsingTests` cover the transcript-line parse and reject percentage/time-code/comma-decimal lines
- [x] `dotnet test tests/UI --filter SpeechToText` passes (287 tests)
- [ ] Run WhisperX on a long file and watch the bar and estimate advance per chunk

🤖 Generated with [Claude Code](https://claude.com/claude-code)