### PR TITLE
Burn-in: make the preview video player a little smaller

### DIFF
--- a/src/ui/Features/Video/BurnIn/BurnInWindow.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInWindow.cs
@@ -54,10 +54,10 @@ public class BurnInWindow : Window
 
         // The left column (subtitle + video settings + target size) is taller than the middle
         // column's cut/preview/audio/video-info rows. Keeping all three boxes in one packed
-        // panel preserves the v5.1.0 look (no gaps), and the star filler row below takes any
-        // extra height, so the panel can never overflow into the progress-bar row (which used
-        // to draw the bar through the "File size in MB" field). The player has a fixed height,
-        // so the preview box hugs it and cannot spill over the audio settings box.
+        // panel preserves the v5.1.0 look (no gaps); the settings grid has a single star row, so
+        // the panel can never overflow into the progress-bar row (which used to draw the bar
+        // through the "File size in MB" field). The player has a fixed height, so the preview
+        // box hugs it and cannot spill over the audio settings box.
         var leftPanel = new StackPanel
         {
             Orientation = Orientation.Vertical,
@@ -106,15 +106,36 @@ public class BurnInWindow : Window
         var previewColumn = new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) };
         var batchColumn = new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) };
 
-        var settingsGrid = new Grid
+        // The middle column has its own grid: the left panel must not span rows of a grid with
+        // a star row, since a spanning child's whole height is pushed into the star row, making
+        // the grid (and the window) as tall as the auto rows PLUS the left panel.
+        var middleColumn = new Grid
         {
             RowDefinitions =
             {
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // cut
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // preview + batch list (sized by the player; the batch list spans into the filler row)
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // preview (sized by the fixed-height player)
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // audio
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // video info + target file size
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // video info
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Star) }, // filler: takes the extra height so the preview box hugs the player
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+        middleColumn.Add(cutView, 0, 0);
+        middleColumn.Add(previewView, 1, 0);
+        middleColumn.Add(audioSettingsView, 2, 0);
+        middleColumn.Add(videoInfoView, 3, 0);
+
+        var settingsGrid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
             },
             ColumnDefinitions =
             {
@@ -126,12 +147,9 @@ public class BurnInWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
-        settingsGrid.Add(leftPanel, 0, 0, 5, 1);  // rows 0-4 (cut + preview + audio + video info + filler)
-        settingsGrid.Add(cutView, 0, 1);
-        settingsGrid.Add(previewView, 1, 1);
-        settingsGrid.Add(audioSettingsView, 2, 1);
-        settingsGrid.Add(videoInfoView, 3, 1);
-        settingsGrid.Add(batchView, 0, 2, 5, 1);
+        settingsGrid.Add(leftPanel, 0, 0);
+        settingsGrid.Add(middleColumn, 0, 1);
+        settingsGrid.Add(batchView, 0, 2);
 
         // The settings area is taller than what a small or scaled screen can show (a maximized
         // window on a 1366x768 laptop leaves about 700 DIPs; the preview row alone needs 400).

--- a/src/ui/Features/Video/BurnIn/BurnInWindow.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInWindow.cs
@@ -112,7 +112,7 @@ public class BurnInWindow : Window
             RowDefinitions =
             {
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // cut
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Star), MinHeight = 400 }, // preview + batch list (never smaller than the preview box needs)
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star), MinHeight = 320 }, // preview + batch list (never smaller than the preview box needs)
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // audio
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // video info + target file size
             },
@@ -209,8 +209,8 @@ public class BurnInWindow : Window
             {
                 player.Width = double.NaN;
                 player.Height = double.NaN;
-                player.MinWidth = 480;
-                player.MinHeight = 270;
+                player.MinWidth = 400;
+                player.MinHeight = 225;
                 player.HorizontalAlignment = HorizontalAlignment.Stretch;
                 player.VerticalAlignment = VerticalAlignment.Stretch;
             }
@@ -818,8 +818,8 @@ public class BurnInWindow : Window
         vm.VideoPlayerControl = InitVideoPlayer.MakeVideoPlayer();
         vm.VideoPlayerControl.FullScreenIsVisible = true;
         vm.VideoPlayerControl.FullScreenCommand = vm.PreviewFullScreenCommand;
-        vm.VideoPlayerControl.MinWidth = 480;
-        vm.VideoPlayerControl.MinHeight = 270;
+        vm.VideoPlayerControl.MinWidth = 400;
+        vm.VideoPlayerControl.MinHeight = 225;
         vm.VideoPlayerControl.HorizontalAlignment = HorizontalAlignment.Stretch;
         vm.VideoPlayerControl.VerticalAlignment = VerticalAlignment.Stretch;
 

--- a/src/ui/Features/Video/BurnIn/BurnInWindow.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInWindow.cs
@@ -54,11 +54,10 @@ public class BurnInWindow : Window
 
         // The left column (subtitle + video settings + target size) is taller than the middle
         // column's cut/preview/audio/video-info rows. Keeping all three boxes in one packed
-        // panel preserves the v5.1.0 look (no gaps), and the preview row's MinHeight below
-        // guarantees the panel fits in rows 0-3 of the settings grid - so it can never overflow
-        // into the progress-bar row (which used to draw the bar through the "File size in MB"
-        // field) - and the preview box never gets shorter than its label + player, so the player
-        // cannot spill over the audio settings box.
+        // panel preserves the v5.1.0 look (no gaps), and the star filler row below takes any
+        // extra height, so the panel can never overflow into the progress-bar row (which used
+        // to draw the bar through the "File size in MB" field). The player has a fixed height,
+        // so the preview box hugs it and cannot spill over the audio settings box.
         var leftPanel = new StackPanel
         {
             Orientation = Orientation.Vertical,
@@ -112,9 +111,10 @@ public class BurnInWindow : Window
             RowDefinitions =
             {
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // cut
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Star), MinHeight = 320 }, // preview + batch list (never smaller than the preview box needs)
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // preview + batch list (sized by the player; the batch list spans into the filler row)
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // audio
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // video info + target file size
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) }, // filler: takes the extra height so the preview box hugs the player
             },
             ColumnDefinitions =
             {
@@ -126,12 +126,12 @@ public class BurnInWindow : Window
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
-        settingsGrid.Add(leftPanel, 0, 0, 4, 1);  // rows 0-3 (cut + preview + audio + video info)
+        settingsGrid.Add(leftPanel, 0, 0, 5, 1);  // rows 0-4 (cut + preview + audio + video info + filler)
         settingsGrid.Add(cutView, 0, 1);
         settingsGrid.Add(previewView, 1, 1);
         settingsGrid.Add(audioSettingsView, 2, 1);
         settingsGrid.Add(videoInfoView, 3, 1);
-        settingsGrid.Add(batchView, 0, 2, 4, 1);
+        settingsGrid.Add(batchView, 0, 2, 5, 1);
 
         // The settings area is taller than what a small or scaled screen can show (a maximized
         // window on a 1366x768 laptop leaves about 700 DIPs; the preview row alone needs 400).
@@ -208,11 +208,11 @@ public class BurnInWindow : Window
             else
             {
                 player.Width = double.NaN;
-                player.Height = double.NaN;
+                player.Height = SinglePlayerHeight;
                 player.MinWidth = 400;
-                player.MinHeight = 225;
+                player.MinHeight = 0;
                 player.HorizontalAlignment = HorizontalAlignment.Stretch;
-                player.VerticalAlignment = VerticalAlignment.Stretch;
+                player.VerticalAlignment = VerticalAlignment.Top;
             }
         }
 
@@ -807,6 +807,8 @@ public class BurnInWindow : Window
         return UiUtil.MakeBorderForControl(grid).WithMarginBottom(5).WithMarginRight(5);
     }
 
+    private const double SinglePlayerHeight = 360;
+
     private static Border MakePreviewView(BurnInViewModel vm)
     {
 
@@ -818,17 +820,21 @@ public class BurnInWindow : Window
         vm.VideoPlayerControl = InitVideoPlayer.MakeVideoPlayer();
         vm.VideoPlayerControl.FullScreenIsVisible = true;
         vm.VideoPlayerControl.FullScreenCommand = vm.PreviewFullScreenCommand;
+        // Fixed height, stretched width: a stretching player made the preview box taller than
+        // the settings column (forcing the window to scroll), and a capped-but-centred one left
+        // empty bands above and below the video.
         vm.VideoPlayerControl.MinWidth = 400;
-        vm.VideoPlayerControl.MinHeight = 225;
+        vm.VideoPlayerControl.MinHeight = 0;
+        vm.VideoPlayerControl.Height = SinglePlayerHeight;
         vm.VideoPlayerControl.HorizontalAlignment = HorizontalAlignment.Stretch;
-        vm.VideoPlayerControl.VerticalAlignment = VerticalAlignment.Stretch;
+        vm.VideoPlayerControl.VerticalAlignment = VerticalAlignment.Top;
 
         var grid = new Grid
         {
             RowDefinitions =
             {
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) }, // video player grows
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }, // video player (fixed height)
             },
             ColumnDefinitions =
             {

--- a/tests/UI/Features/Video/BurnInWindowTests.cs
+++ b/tests/UI/Features/Video/BurnInWindowTests.cs
@@ -4,6 +4,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Headless.XUnit;
+using Avalonia.Layout;
 using Avalonia.LogicalTree;
 using Avalonia.VisualTree;
 using Nikse.SubtitleEdit.Features.Video.BurnIn;
@@ -85,6 +86,14 @@ public class BurnInWindowTests : IDisposable
         return (scroller, settingsGrid);
     }
 
+    /// <summary>Returns the middle column grid (cut / preview / audio / video info / filler rows).</summary>
+    private static Grid FindMiddleColumn(Grid settingsGrid)
+    {
+        var middleColumn = settingsGrid.Children.OfType<Grid>().FirstOrDefault(g => Grid.GetColumn(g) == 1);
+        Assert.NotNull(middleColumn);
+        return middleColumn;
+    }
+
     private static Grid FindProgressView(Grid rootGrid)
     {
         var progressView = rootGrid.Children.OfType<Grid>().FirstOrDefault(g => Grid.GetRow(g) == 1);
@@ -108,7 +117,7 @@ public class BurnInWindowTests : IDisposable
     }
 
     [AvaloniaFact]
-    public void PreviewRow_HasMinimumHeight_KeepingPanelAboveProgressBar()
+    public void PreviewRow_HugsFixedHeightPlayer_KeepingPanelAboveProgressBar()
     {
         var window = BuildWindow();
         var vm = window.DataContext as BurnInViewModel;
@@ -118,15 +127,18 @@ public class BurnInWindowTests : IDisposable
 
         var rootGrid = FindRootGrid(window);
 
-        // The preview row (row 1, star) must carry a MinHeight: without it the window can be
-        // shrunk (or restored) below the content height, the preview box gets shorter than its
-        // label + player and the player spills over the audio settings box below it.
-        var previewRow = FindSettingsGrid(rootGrid).SettingsGrid.RowDefinitions[1];
-        Assert.Equal(GridUnitType.Star, previewRow.Height.GridUnitType);
-        Assert.True(previewRow.MinHeight >= 350, $"Preview row MinHeight is only {previewRow.MinHeight:0.#}.");
+        // The preview row (row 1) is an Auto row sized by a fixed-height player, and the star
+        // filler row at the bottom takes any extra height: a stretching player made the middle
+        // column taller than the settings column (forcing the window to scroll) and a centred
+        // one left empty bands above and below the video.
+        var middleColumn = FindMiddleColumn(FindSettingsGrid(rootGrid).SettingsGrid);
+        Assert.Equal(GridUnitType.Auto, middleColumn.RowDefinitions[1].Height.GridUnitType);
+        Assert.Equal(GridUnitType.Star, middleColumn.RowDefinitions[^1].Height.GridUnitType);
+        Assert.Equal(360, vm.VideoPlayerControl.Height);
+        Assert.Equal(VerticalAlignment.Top, vm.VideoPlayerControl!.VerticalAlignment);
 
-        // The left column is one panel spanning rows 0-3. With the row minimum in place it
-        // must fit entirely above the progress view - the regression this guards against drew
+        // The left column is one panel in the settings grid's single row. It must fit entirely
+        // above the progress view - the regression this guards against drew
         // the progress bar through the "File size in MB" field while generating.
         AssertSettingsColumnStaysAboveProgressView(window, rootGrid);
     }
@@ -158,7 +170,7 @@ public class BurnInWindowTests : IDisposable
     private static void AssertSettingsColumnStaysAboveProgressView(BurnInWindow window, Grid rootGrid)
     {
         var (scroller, settingsGrid) = FindSettingsGrid(rootGrid);
-        var settingsColumn = settingsGrid.Children.FirstOrDefault(c => Grid.GetColumn(c) == 0 && Grid.GetRowSpan(c) == 4);
+        var settingsColumn = settingsGrid.Children.FirstOrDefault(c => Grid.GetColumn(c) == 0);
         Assert.NotNull(settingsColumn);
         var progressView = FindProgressView(rootGrid);
 
@@ -207,8 +219,8 @@ public class BurnInWindowTests : IDisposable
         window.Height = 400;
         window.UpdateLayout();
 
-        var settingsGrid = FindSettingsGrid(FindRootGrid(window)).SettingsGrid;
-        var audioSettingsView = settingsGrid.Children.OfType<Border>().FirstOrDefault(b => Grid.GetRow(b) == 2 && Grid.GetColumn(b) == 1);
+        var middleColumn = FindMiddleColumn(FindSettingsGrid(FindRootGrid(window)).SettingsGrid);
+        var audioSettingsView = middleColumn.Children.OfType<Border>().FirstOrDefault(b => Grid.GetRow(b) == 2);
         Assert.NotNull(audioSettingsView);
 
         // The player is the bottom-most element of the preview box; its bottom must never
@@ -284,22 +296,26 @@ public class BurnInWindowTests : IDisposable
         Assert.True(
             scroller.Extent.Height > scroller.Viewport.Height + 1.5,
             $"Settings area does not scroll (extent {scroller.Extent.Height:0.#}, viewport {scroller.Viewport.Height:0.#}).");
-        Assert.True(settingsGrid.RowDefinitions[1].MinHeight >= 350, "Preview row lost its minimum height.");
+        Assert.Equal(GridUnitType.Star, FindMiddleColumn(settingsGrid).RowDefinitions[^1].Height.GridUnitType);
     }
 
     [AvaloniaFact]
-    public void PreviewRow_FillsTheWindow_WhenThereIsRoom()
+    public void SettingsGrid_FillsTheWindow_WhenThereIsRoom()
     {
         var window = BuildWindow();
+        var vm = window.DataContext as BurnInViewModel;
+        Assert.NotNull(vm);
         window.Show();
         Avalonia.Threading.Dispatcher.UIThread.RunJobs();
         window.UpdateLayout();
 
         // Inside a ScrollViewer a star row would otherwise collapse to its minimum; the settings
-        // grid must keep filling the viewport so the preview grows with the window.
+        // grid must keep filling the viewport (extra height goes to the filler row, not the
+        // player) so nothing scrolls while the window is tall enough.
         var rootGrid = FindRootGrid(window);
         var (scroller, settingsGrid) = FindSettingsGrid(rootGrid);
         var before = settingsGrid.Bounds.Height;
+        var playerHeightBefore = vm.VideoPlayerControl!.Bounds.Height;
 
         window.SizeToContent = SizeToContent.Manual;
         window.Height = window.ClientSize.Height + 200;
@@ -308,10 +324,11 @@ public class BurnInWindowTests : IDisposable
 
         Assert.True(
             settingsGrid.Bounds.Height >= before + 190,
-            $"Settings grid did not grow with the window ({before:0.#} -> {settingsGrid.Bounds.Height:0.#}).");
+            $"Settings grid did not grow with the window ({before:0.#} -> {settingsGrid.Bounds.Height:0.#}); client {window.ClientSize.Height:0.#}, viewport {scroller.Viewport.Height:0.#}, extent {scroller.Extent.Height:0.#}).");
         Assert.True(
             scroller.Extent.Height <= scroller.Viewport.Height + 1.5,
             $"Settings area scrolls although the window is tall enough (extent {scroller.Extent.Height:0.#}, viewport {scroller.Viewport.Height:0.#}).");
+        Assert.Equal(playerHeightBefore, vm.VideoPlayerControl.Bounds.Height, 0.5);
     }
 
     // The extension list is only correct if both combo boxes are wired up: the encoder box


### PR DESCRIPTION
Makes the preview player in the "Generate video with burned-in subtitles" window smaller and stops it from stretching.

- Player has a fixed 360 px height (width still stretches); minimum width lowered to 400 px.
- The preview row is now an Auto row with a star filler row at the bottom of the settings grid, so extra window height no longer inflates the preview box (which forced the window to scroll) or leaves empty bands around the video.
- Batch mode is unchanged (240x135 player, file list spans the filler row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)