### PR TITLE
Fix short durations: run after split/merge and always extend

### DIFF
--- a/src/libse/Forms/FixCommonErrors/FixShortDisplayTimes.cs
+++ b/src/libse/Forms/FixCommonErrors/FixShortDisplayTimes.cs
@@ -31,16 +31,15 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                     Paragraph prev = subtitle.GetParagraphOrDefault(i - 1);
                     if (next == null || (p.StartTime.TotalMilliseconds + Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds + Configuration.Settings.General.MinimumMillisecondsBetweenLines) < next.StartTime.TotalMilliseconds)
                     {
-                        var temp = new Paragraph(p) { EndTime = { TotalMilliseconds = p.StartTime.TotalMilliseconds + Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds } };
-                        if (temp.GetCharactersPerSecond() <= Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds)
+                        // Extending only ever lowers chars/sec, so no cps gate here - if the
+                        // line is still too fast at the minimum duration, the cps pass below
+                        // extends it further.
+                        if (callbacks.AllowFix(p, fixAction))
                         {
-                            if (callbacks.AllowFix(p, fixAction))
-                            {
-                                string oldCurrent = p.ToString();
-                                p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds;
-                                noOfShortDisplayTimes++;
-                                callbacks.AddFixToListView(p, fixAction, oldCurrent, p.ToString());
-                            }
+                            string oldCurrent = p.ToString();
+                            p.EndTime.TotalMilliseconds = p.StartTime.TotalMilliseconds + Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds;
+                            noOfShortDisplayTimes++;
+                            callbacks.AddFixToListView(p, fixAction, oldCurrent, p.ToString());
                         }
                     }
                     else if (Configuration.Settings.Tools.FixShortDisplayTimesAllowMoveStartTime && p.StartTime.TotalMilliseconds > Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds &&
@@ -61,6 +60,18 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                     }
                     else
                     {
+                        // Not enough room for the full minimum - still take what the
+                        // gap to the next line allows, a shorter shortfall is better
+                        // than none (back-to-back speech-to-text output hits this a lot).
+                        var improvedEndMs = next.StartTime.TotalMilliseconds - Configuration.Settings.General.MinimumMillisecondsBetweenLines;
+                        if (improvedEndMs > p.EndTime.TotalMilliseconds && callbacks.AllowFix(p, fixAction))
+                        {
+                            string oldCurrent = p.ToString();
+                            p.EndTime.TotalMilliseconds = improvedEndMs;
+                            noOfShortDisplayTimes++;
+                            callbacks.AddFixToListView(p, fixAction, oldCurrent, p.ToString());
+                        }
+
                         callbacks.LogStatus(Language.FixShortDisplayTimes, string.Format(Language.UnableToFixTextXY, i + 1, p));
                         callbacks.AddToTotalErrors(1);
                         skip = true;

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextPostProcessor.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextPostProcessor.cs
@@ -209,16 +209,6 @@ namespace Nikse.SubtitleEdit.Features.Video.SpeechToText
                     subtitle = FixCasing(subtitle, TwoLetterLanguageCode, engine);
                 }
 
-                if (fixShortDuration)
-                {
-                    subtitle = FixShortDuration(subtitle);
-
-                    // Engines hand back overlapping segments, and extending short
-                    // lines can create more - straighten them out so the result
-                    // does not arrive in the grid full of red overlaps (issue #13973).
-                    subtitle = FixOverlaps(subtitle);
-                }
-
                 if (splitLines && !IsNonStandardLineTerminationLanguage(TwoLetterLanguageCode) && AllowLineContentMove(engine))
                 {
                     var totalMaxChars = Configuration.Settings.General.SubtitleLineMaximumLength * Configuration.Settings.General.MaxNumberOfLines;
@@ -231,6 +221,19 @@ namespace Nikse.SubtitleEdit.Features.Video.SpeechToText
                 {
                     subtitle = MergeShortLines(subtitle, TwoLetterLanguageCode);
                     subtitle = AutoBalanceLines(subtitle, TwoLetterLanguageCode);
+                }
+
+                // Runs last: splitting long lines divides their time and creates
+                // new short lines, so fixing durations before split/merge left
+                // those untouched (discussion #12929).
+                if (fixShortDuration)
+                {
+                    subtitle = FixShortDuration(subtitle);
+
+                    // Engines hand back overlapping segments, and extending short
+                    // lines can create more - straighten them out so the result
+                    // does not arrive in the grid full of red overlaps (issue #13973).
+                    subtitle = FixOverlaps(subtitle);
                 }
             }
 

--- a/tests/UI/Features/Tools/FixCommonErrors/FixCommonErrorsUnfixableErrorsTests.cs
+++ b/tests/UI/Features/Tools/FixCommonErrors/FixCommonErrorsUnfixableErrorsTests.cs
@@ -1,4 +1,4 @@
-using Avalonia.Headless.XUnit;
+﻿using Avalonia.Headless.XUnit;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.Forms.FixCommonErrors;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
@@ -37,15 +37,15 @@ public class FixCommonErrorsUnfixableErrorsTests : IDisposable
     }
 
     /// <summary>
-    /// A 300 ms line (below the 1000 ms minimum) that starts at zero and is followed 200 ms later:
-    /// it cannot be made longer (no room before the next line) and cannot be started earlier
-    /// (it starts at zero), which is the branch that logs "Unable to fix text number...".
+    /// A 300 ms line (below the 1000 ms minimum) that starts at zero and is followed immediately
+    /// (within the minimum gap): it cannot be made longer at all, not even partially, and cannot
+    /// be started earlier (it starts at zero), which is the branch that logs "Unable to fix text number...".
     /// </summary>
     private static FixCommonErrorsViewModel BuildViewModelWithUnfixableShortDisplayTime()
     {
         var subtitle = new Subtitle();
         subtitle.Paragraphs.Add(new Paragraph("Hello there", 0, 300));
-        subtitle.Paragraphs.Add(new Paragraph("Goodbye there", 500, 3000));
+        subtitle.Paragraphs.Add(new Paragraph("Goodbye there", 320, 3000));
         subtitle.Renumber();
 
         var vm = new FixCommonErrorsViewModel(new FakeNamesList(), null!, null!);

--- a/tests/UI/Features/Video/SpeechToText/SpeechToTextPostProcessorTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/SpeechToTextPostProcessorTests.cs
@@ -1,4 +1,4 @@
-using Nikse.SubtitleEdit.Core.Common;
+﻿using Nikse.SubtitleEdit.Core.Common;
 using System.Linq;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText;
 
@@ -211,5 +211,41 @@ public class SpeechToTextQualityReportTests
         Assert.Equal(2, pp.QualityReport.TotalLines);
         Assert.Equal(1, pp.QualityReport.Count(SpeechToTextQualityIssueType.TooShort));
         Assert.Equal(1, pp.QualityReport.Count(SpeechToTextQualityIssueType.NonSpeech));
+    }
+
+    // Splitting a long line divides its time; the short-duration fix must run after
+    // split/merge so the halves it creates are fixed too (discussion #12929).
+    [Fact]
+    public void Fix_FixShortDuration_RunsAfterSplitLines()
+    {
+        var oldMin = Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds;
+        var oldMaxLen = Configuration.Settings.General.SubtitleLineMaximumLength;
+        var oldMaxLines = Configuration.Settings.General.MaxNumberOfLines;
+        try
+        {
+            Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds = 1000;
+            Configuration.Settings.General.SubtitleLineMaximumLength = 43;
+            Configuration.Settings.General.MaxNumberOfLines = 2;
+
+            // Long enough to be split into two lines, short enough that each half is < 1 s.
+            var text = "This is the first sentence of the line. This is the second sentence of the line. And a third sentence too.";
+            var subtitle = Make((text, 0, 1500), ("Far away.", 20000, 22000));
+
+            var pp = new SpeechToTextPostProcessor("en");
+            var result = pp.Fix(SpeechToTextPostProcessor.Engine.Whisper, subtitle, true, false, false, false, true, true, false, Avalonia.Media.Colors.Red);
+
+            Assert.True(result.Paragraphs.Count > 1, "expected the line to be split");
+            foreach (var p in result.Paragraphs.Take(result.Paragraphs.Count - 1))
+            {
+                Assert.True(p.DurationTotalMilliseconds >= 1000 || p.EndTime.TotalMilliseconds >= result.Paragraphs[result.Paragraphs.IndexOf(p) + 1].StartTime.TotalMilliseconds - Configuration.Settings.General.MinimumMillisecondsBetweenLines,
+                    $"#{p.Number} '{p.Text}' {p.StartTime.TotalMilliseconds}-{p.EndTime.TotalMilliseconds} was left short");
+            }
+        }
+        finally
+        {
+            Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds = oldMin;
+            Configuration.Settings.General.SubtitleLineMaximumLength = oldMaxLen;
+            Configuration.Settings.General.MaxNumberOfLines = oldMaxLines;
+        }
     }
 }

--- a/tests/libse/Forms/FixCommonErrors/FixShortDisplayTimesTest.cs
+++ b/tests/libse/Forms/FixCommonErrors/FixShortDisplayTimesTest.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Text;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.Forms.FixCommonErrors;
@@ -80,6 +80,70 @@ public class FixShortDisplayTimesTest
         finally
         {
             Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds = oldMax;
+            Configuration.Settings.Tools.FixShortDisplayTimesAllowMoveStartTime = oldMove;
+        }
+    }
+
+    // Extending a line can only lower its chars/sec, so a cps that is still over the
+    // maximum at the minimum duration must not stop the extension (discussion #12929).
+    [Fact]
+    public void ShortLine_StillTooFastAtMinimum_IsExtendedAnyway()
+    {
+        var oldMax = Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds;
+        var oldMin = Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds;
+        try
+        {
+            Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds = 25.0;
+            Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds = 1000;
+
+            // 40 chars in 200 ms; at 1000 ms it is still 40 cps.
+            var subtitle = new Subtitle();
+            subtitle.Paragraphs.Add(new Paragraph("This line has exactly forty characters!!", 0, 200) { Number = 1 });
+            subtitle.Paragraphs.Add(new Paragraph("next", 10000, 12000) { Number = 2 });
+
+            var cb = new RecordingCallback();
+            new FixShortDisplayTimes().Fix(subtitle, cb);
+
+            Assert.NotEmpty(cb.FixesAdded);
+            var p = subtitle.Paragraphs[0];
+            Assert.True(p.DurationTotalMilliseconds >= 1000, $"duration was {p.DurationTotalMilliseconds}");
+            Assert.True(p.GetCharactersPerSecond() <= 25.0, $"cps was {p.GetCharactersPerSecond()}");
+        }
+        finally
+        {
+            Configuration.Settings.General.SubtitleMaximumCharactersPerSeconds = oldMax;
+            Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds = oldMin;
+        }
+    }
+
+    // Back-to-back lines: the full minimum does not fit, but the gap that is there
+    // should still be used instead of leaving the line untouched (discussion #12929).
+    [Fact]
+    public void ShortLine_WithoutRoomForMinimum_IsExtendedToTheGap()
+    {
+        var oldMin = Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds;
+        var oldGap = Configuration.Settings.General.MinimumMillisecondsBetweenLines;
+        var oldMove = Configuration.Settings.Tools.FixShortDisplayTimesAllowMoveStartTime;
+        try
+        {
+            Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds = 1000;
+            Configuration.Settings.General.MinimumMillisecondsBetweenLines = 24;
+            Configuration.Settings.Tools.FixShortDisplayTimesAllowMoveStartTime = false;
+
+            var subtitle = new Subtitle();
+            subtitle.Paragraphs.Add(new Paragraph("Hi", 0, 300) { Number = 1 });
+            subtitle.Paragraphs.Add(new Paragraph("next", 800, 3000) { Number = 2 });
+
+            var cb = new RecordingCallback();
+            new FixShortDisplayTimes().Fix(subtitle, cb);
+
+            Assert.Equal(776, (int)subtitle.Paragraphs[0].EndTime.TotalMilliseconds);
+            Assert.Equal(800, (int)subtitle.Paragraphs[1].StartTime.TotalMilliseconds);
+        }
+        finally
+        {
+            Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds = oldMin;
+            Configuration.Settings.General.MinimumMillisecondsBetweenLines = oldGap;
             Configuration.Settings.Tools.FixShortDisplayTimesAllowMoveStartTime = oldMove;
         }
     }


### PR DESCRIPTION
From [discussion #12929](https://github.com/SubtitleEdit/subtitleedit/discussions/12929#discussioncomment-18293816): after speech to text with **Fix short durations** checked, **Apply duration limits** still stretched many lines to 1 s.

## Causes

1. **Ordering.** The STT post-processor ran the short-duration fix before *Split lines*. Splitting a long segment divides its time, so the halves it created were never checked. The fix (and the overlap fix that follows it) now runs last.
2. **Needless cps gate.** `FixShortDisplayTimes` refused to extend a line to the minimum duration when its chars/sec would *still* be above the maximum. Extending only ever lowers cps, so the gate is removed; the cps pass right after extends further when needed.
3. **No partial extension.** When there was no room for the full minimum before the next line, the rule gave up entirely. It now takes the gap that is there (mirroring what the cps branch already did), and still logs the line as not fully fixed.

## Tests
- libse: still-too-fast line is extended; back-to-back line is extended to the gap.
- UI: split halves get fixed; the "unfixable" fixture tightened so it really has no room.

🤖 Generated with [Claude Code](https://claude.com/claude-code)