### PR TITLE
Binary edit: video resolution conversion dialog

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -75,6 +75,7 @@ using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryAdjustColor;
 using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryAdjustDuration;
 using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryApplyDurationLimits;
 using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryAppendSubtitle;
+using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryChangeResolution;
 using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryResizeImages;
 using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinarySettings;
 using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.SetText;
@@ -363,6 +364,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<BinaryAdjustDurationViewModel>();
         collection.AddTransient<BinaryApplyDurationLimitsViewModel>();
         collection.AddTransient<BinaryAppendSubtitleViewModel>();
+        collection.AddTransient<BinaryChangeResolutionViewModel>();
         collection.AddTransient<BinaryEditViewModel>();
         collection.AddTransient<BinaryOcrCharacterAddViewModel>();
         collection.AddTransient<BinaryOcrCharacterHistoryViewModel>();

--- a/src/ui/Features/Shared/BinaryEdit/BinaryChangeResolution/BinaryChangeResolutionViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryChangeResolution/BinaryChangeResolutionViewModel.cs
@@ -1,0 +1,281 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Features.Files.ExportImageBased;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryChangeResolution;
+
+/// <summary>
+/// Converts an image-based subtitle from one screen resolution to another (BDSup2Sub's
+/// "set resolution"): every bitmap and every X/Y position is scaled by the width and height
+/// ratios, so a 1080p SUP keeps its layout when re-targeted to 720p or PAL.
+/// Only changing the screen size fields in the main window re-labels the canvas and leaves
+/// the images oversized and off-screen.
+/// </summary>
+public partial class BinaryChangeResolutionViewModel : ObservableObject, IDisposable, IClosingCleanup
+{
+    [ObservableProperty] private ObservableCollection<ResolutionItem> _resolutions;
+    [ObservableProperty] private ResolutionItem? _selectedResolution;
+    [ObservableProperty] private int _newWidth;
+    [ObservableProperty] private int _newHeight;
+    [ObservableProperty] private Bitmap? _previewBitmap;
+    [ObservableProperty] private string _sizeText;
+    [ObservableProperty] private string _scaleText;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+    public int OriginalWidth { get; private set; }
+    public int OriginalHeight { get; private set; }
+
+    private List<BinarySubtitleItem> _subtitles = new();
+    private DispatcherTimer? _previewUpdateTimer;
+    private bool _isDirty;
+    private bool _isSyncingPreset;
+
+    public BinaryChangeResolutionViewModel()
+    {
+        // The export list starts with "Pick resolution from video..." - a placeholder with no size.
+        _resolutions = new ObservableCollection<ResolutionItem>(ResolutionItem.GetResolutions().Where(r => r.Width > 0 && r.Height > 0));
+        _sizeText = string.Empty;
+        _scaleText = string.Empty;
+        InitializeTimer();
+    }
+
+    private void InitializeTimer()
+    {
+        _previewUpdateTimer = new DispatcherTimer
+        {
+            Interval = TimeSpan.FromMilliseconds(300)
+        };
+        _previewUpdateTimer.Tick += (_, _) =>
+        {
+            _previewUpdateTimer?.Stop();
+            if (_isDirty)
+            {
+                _isDirty = false;
+                UpdatePreview();
+            }
+        };
+    }
+
+    public void Initialize(List<BinarySubtitleItem> subtitles, int screenWidth, int screenHeight)
+    {
+        _subtitles = subtitles;
+        OriginalWidth = screenWidth;
+        OriginalHeight = screenHeight;
+
+        // Start on the current size so OK without edits is a no-op.
+        NewWidth = screenWidth;
+        NewHeight = screenHeight;
+        UpdatePreview();
+    }
+
+    partial void OnSelectedResolutionChanged(ResolutionItem? value)
+    {
+        if (value == null || _isSyncingPreset)
+        {
+            return;
+        }
+
+        _isSyncingPreset = true;
+        NewWidth = value.Width;
+        NewHeight = value.Height;
+        _isSyncingPreset = false;
+        SchedulePreviewUpdate();
+    }
+
+    partial void OnNewWidthChanged(int value)
+    {
+        SyncPresetToSize();
+        SchedulePreviewUpdate();
+    }
+
+    partial void OnNewHeightChanged(int value)
+    {
+        SyncPresetToSize();
+        SchedulePreviewUpdate();
+    }
+
+    /// <summary>
+    /// Typing a size that matches a preset highlights it; any other size clears the selection
+    /// (a custom resolution) without touching the typed numbers.
+    /// </summary>
+    private void SyncPresetToSize()
+    {
+        if (_isSyncingPreset)
+        {
+            return;
+        }
+
+        _isSyncingPreset = true;
+        SelectedResolution = Resolutions.FirstOrDefault(r => r.Width == NewWidth && r.Height == NewHeight);
+        _isSyncingPreset = false;
+    }
+
+    private void SchedulePreviewUpdate()
+    {
+        if (_previewUpdateTimer == null)
+        {
+            return;
+        }
+
+        _isDirty = true;
+        _previewUpdateTimer.Stop();
+        _previewUpdateTimer.Start();
+    }
+
+    private void UpdatePreview()
+    {
+        SizeText = string.Format(Se.Language.Tools.ImageBasedEdit.OriginalSizeXNewSizeY, OriginalWidth, OriginalHeight, NewWidth, NewHeight);
+
+        var scaleX = GetScale(OriginalWidth, NewWidth);
+        var scaleY = GetScale(OriginalHeight, NewHeight);
+        ScaleText = $"{Se.Language.Tools.ImageBasedEdit.Percentage}: {Math.Round(scaleX * 100)}% × {Math.Round(scaleY * 100)}%";
+
+        var first = _subtitles.FirstOrDefault(s => s.Bitmap != null);
+        if (first == null)
+        {
+            return;
+        }
+
+        using var originalBitmap = first.Bitmap!.ToSkBitmap();
+        using var resizedBitmap = ScaleBitmap(originalBitmap, scaleX, scaleY);
+        var old = PreviewBitmap;
+        PreviewBitmap = resizedBitmap.ToAvaloniaBitmap();
+        old?.Dispose();
+    }
+
+    public static double GetScale(int from, int to)
+    {
+        return from <= 0 || to <= 0 ? 1.0 : (double)to / from;
+    }
+
+    /// <summary>
+    /// Scales positions and bitmaps of <paramref name="subtitles"/> from
+    /// <paramref name="fromWidth"/>×<paramref name="fromHeight"/> to
+    /// <paramref name="toWidth"/>×<paramref name="toHeight"/>. Width and height scale
+    /// independently so anamorphic targets (1920×1080 → 720×576) fill the frame the way
+    /// BDSup2Sub does. The caller updates the screen size itself.
+    /// </summary>
+    public static void ApplyResolution(IEnumerable<BinarySubtitleItem> subtitles, int fromWidth, int fromHeight, int toWidth, int toHeight)
+    {
+        var scaleX = GetScale(fromWidth, toWidth);
+        var scaleY = GetScale(fromHeight, toHeight);
+        if (Math.Abs(scaleX - 1.0) < 0.000001 && Math.Abs(scaleY - 1.0) < 0.000001)
+        {
+            return;
+        }
+
+        foreach (var subtitle in subtitles)
+        {
+            subtitle.X = ScaleCoordinate(subtitle.X, scaleX);
+            subtitle.Y = ScaleCoordinate(subtitle.Y, scaleY);
+
+            if (subtitle.Bitmap == null)
+            {
+                continue;
+            }
+
+            using var originalBitmap = subtitle.Bitmap.ToSkBitmap();
+            using var resizedBitmap = ScaleBitmap(originalBitmap, scaleX, scaleY);
+            var old = subtitle.Bitmap;
+            subtitle.Bitmap = resizedBitmap.ToAvaloniaBitmap();
+            old?.Dispose();
+        }
+    }
+
+    public static int ScaleCoordinate(int value, double scale)
+    {
+        return (int)Math.Round(value * scale, MidpointRounding.AwayFromZero);
+    }
+
+    private static SKBitmap ScaleBitmap(SKBitmap originalBitmap, double scaleX, double scaleY)
+    {
+        // Narrow or short images scale to a zero dimension, which SKCanvas rejects.
+        var width = Math.Max(1, (int)Math.Round(originalBitmap.Width * scaleX));
+        var height = Math.Max(1, (int)Math.Round(originalBitmap.Height * scaleY));
+
+        var resizedBitmap = new SKBitmap(width, height, originalBitmap.ColorType, originalBitmap.AlphaType);
+        using var canvas = new SKCanvas(resizedBitmap);
+        canvas.Clear(SKColors.Transparent);
+        using var image = SKImage.FromBitmap(originalBitmap);
+        canvas.DrawImage(image, new SKRect(0, 0, width, height), new SKSamplingOptions(SKCubicResampler.Mitchell));
+        return resizedBitmap;
+    }
+
+    [RelayCommand]
+    private async Task Ok()
+    {
+        var msg = GetValidationError();
+        if (!string.IsNullOrEmpty(msg))
+        {
+            await MessageBox.Show(Window!, Se.Language.General.Error, msg, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            return;
+        }
+
+        ApplyResolution(_subtitles, OriginalWidth, OriginalHeight, NewWidth, NewHeight);
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Window?.Close();
+    }
+
+    private string GetValidationError()
+    {
+        if (Window == null)
+        {
+            return "Window is null";
+        }
+
+        if (NewWidth <= 0)
+        {
+            return string.Format(Se.Language.General.PleaseEnterAValidValueForX, Se.Language.General.Width);
+        }
+
+        if (NewHeight <= 0)
+        {
+            return string.Format(Se.Language.General.PleaseEnterAValidValueForX, Se.Language.General.Height);
+        }
+
+        return string.Empty;
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+    }
+
+    public void OnClosingCleanup()
+    {
+        Dispose();
+    }
+
+    public void Dispose()
+    {
+        _isDirty = false;
+        _previewUpdateTimer?.Stop();
+        _previewUpdateTimer = null;
+        var old = PreviewBitmap;
+        PreviewBitmap = null;
+        old?.Dispose();
+    }
+}

--- a/src/ui/Features/Shared/BinaryEdit/BinaryChangeResolution/BinaryChangeResolutionWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryChangeResolution/BinaryChangeResolutionWindow.cs
@@ -1,0 +1,148 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Data;
+using Avalonia.Layout;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.ValueConverters;
+
+namespace Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryChangeResolution;
+
+public class BinaryChangeResolutionWindow : Window
+{
+    public BinaryChangeResolutionWindow(BinaryChangeResolutionViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = Se.Language.General.VideoResolution;
+        Width = 800;
+        Height = 600;
+        CanResize = true;
+        vm.Window = this;
+        DataContext = vm;
+
+        var mainGrid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition(GridLength.Star),
+                new RowDefinition(GridLength.Auto),
+            },
+            Margin = UiUtil.MakeWindowMargin(),
+        };
+
+        var contentGrid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition(new GridLength(300)),
+                new ColumnDefinition(GridLength.Star),
+            },
+            ColumnSpacing = 10,
+        };
+
+        contentGrid.Add(MakeControlsPanel(vm, out var presetComboBox), 0, 0);
+        contentGrid.Add(MakePreviewPanel(vm), 0, 1);
+        mainGrid.Add(contentGrid, 0, 0);
+
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        mainGrid.Add(UiUtil.MakeButtonBar(buttonOk, buttonCancel), 1, 0);
+
+        Content = mainGrid;
+
+        UiUtil.FocusOnFirstActivation(this, presetComboBox); // an input, not an action button - a focused button clicks on bare Space
+        KeyDown += (_, e) => vm.OnKeyDown(e);
+    }
+
+    private static StackPanel MakeControlsPanel(BinaryChangeResolutionViewModel vm, out ComboBox presetComboBox)
+    {
+        var panel = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 6,
+        };
+
+        panel.Children.Add(new TextBlock
+        {
+            Text = Se.Language.General.Resolution,
+            FontWeight = Avalonia.Media.FontWeight.Bold,
+        });
+
+        presetComboBox = UiUtil.MakeComboBox(vm.Resolutions, vm, nameof(vm.SelectedResolution), null);
+        presetComboBox.HorizontalAlignment = HorizontalAlignment.Stretch;
+        panel.Children.Add(presetComboBox);
+
+        panel.Children.Add(new TextBlock
+        {
+            Text = Se.Language.General.Width,
+            FontWeight = Avalonia.Media.FontWeight.Bold,
+            Margin = new Thickness(0, 10, 0, 0),
+        });
+        panel.Children.Add(MakeSizeInput(vm, nameof(vm.NewWidth)));
+
+        panel.Children.Add(new TextBlock
+        {
+            Text = Se.Language.General.Height,
+            FontWeight = Avalonia.Media.FontWeight.Bold,
+            Margin = new Thickness(0, 10, 0, 0),
+        });
+        panel.Children.Add(MakeSizeInput(vm, nameof(vm.NewHeight)));
+
+        panel.Children.Add(new TextBlock
+        {
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.SizeText)),
+            TextWrapping = Avalonia.Media.TextWrapping.Wrap,
+            Margin = new Thickness(0, 20, 0, 0),
+            FontSize = 12,
+            FontWeight = Avalonia.Media.FontWeight.SemiBold,
+        });
+
+        panel.Children.Add(new TextBlock
+        {
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.ScaleText)),
+            TextWrapping = Avalonia.Media.TextWrapping.Wrap,
+            FontSize = 12,
+        });
+
+        return panel;
+    }
+
+    private static NumericUpDown MakeSizeInput(BinaryChangeResolutionViewModel vm, string propertyName)
+    {
+        return new NumericUpDown
+        {
+            Minimum = 1,
+            Maximum = 16384,
+            Increment = 2,
+            FormatString = "0",
+            Width = double.NaN,
+            [!NumericUpDown.ValueProperty] = new Binding(propertyName)
+            {
+                Mode = BindingMode.TwoWay,
+                Converter = new NullableIntConverter(),
+            },
+        };
+    }
+
+    private static Border MakePreviewPanel(BinaryChangeResolutionViewModel vm)
+    {
+        var scrollViewer = new ScrollViewer
+        {
+            HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
+            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+            Content = new Image
+            {
+                Stretch = Avalonia.Media.Stretch.None,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+                [!Image.SourceProperty] = new Binding(nameof(vm.PreviewBitmap)),
+            },
+        };
+
+        // Light or dark text on transparency is invisible on a flat backdrop - checkerboard (issue #12692).
+        var border = UiUtil.MakeBorderForControl(scrollViewer);
+        border.Background = UiUtil.GetCheckerboardBrush();
+        return border;
+    }
+}

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1592,6 +1592,50 @@ public partial class BinaryEditViewModel : ObservableObject
     }
 
     [RelayCommand]
+    private async Task ChangeResolution()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        if (Subtitles.Count == 0)
+        {
+            await MessageBox.Show(Window, Se.Language.General.Information,
+                Se.Language.Tools.ImageBasedEdit.NoImageSubtitlesLoaded,
+                MessageBoxButtons.OK, MessageBoxIcon.Information);
+            return;
+        }
+
+        var items = Subtitles.ToList();
+        var fromWidth = ScreenWidth;
+        var fromHeight = ScreenHeight;
+        using var result = await _windowService.ShowDialogAsync<BinaryChangeResolution.BinaryChangeResolutionWindow, BinaryChangeResolution.BinaryChangeResolutionViewModel>(
+            Window, vm => vm.Initialize(items, fromWidth, fromHeight));
+
+        if (!result.OkPressed)
+        {
+            return;
+        }
+
+        // The dialog scaled bitmaps and positions; the canvas size is ours (the setters push
+        // it to every item and refresh the overlay and position monitor).
+        ScreenWidth = result.NewWidth;
+        ScreenHeight = result.NewHeight;
+
+        if (SubtitleGrid != null)
+        {
+            var currentIndex = SubtitleGrid.SelectedIndex;
+            SubtitleGrid.ItemsSource = null;
+            SubtitleGrid.ItemsSource = Subtitles;
+            SubtitleGrid.SelectedIndex = currentIndex;
+        }
+
+        UpdateOverlayPosition();
+        RefreshStatusText();
+    }
+
+    [RelayCommand]
     private async Task ResizeImagesSelectedLines()
     {
         if (Window == null)

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -315,6 +315,11 @@ public class BinaryEditWindow : Window
                     Header = Se.Language.Tools.ImageBasedEdit.CropImages,
                     Command = vm.CropCommand,
                 },
+                new MenuItem
+                {
+                    Header = Se.Language.General.VideoResolution + "...",
+                    Command = vm.ChangeResolutionCommand,
+                },
                 new Separator(),
                 new MenuItem
                 {

--- a/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
+++ b/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
@@ -45,6 +45,7 @@ public static class InitNativeMacMenuBinaryEdit
         toolsMenu.Items.Add(new NativeMenuItemSeparator());
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.ResizeImagesDotDotDot, vm.ResizeImagesCommand);
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.CropImages, vm.CropCommand);
+        Add(toolsMenu, Se.Language.General.VideoResolution + "...", vm.ChangeResolutionCommand);
         toolsMenu.Items.Add(new NativeMenuItemSeparator());
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.AdjustBrightnessDotDotDot, vm.AdjustBrightnessCommand);
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.AdjustAlphaDotDotDot, vm.AdjustAlphaCommand);

--- a/tests/UI/Features/Shared/BinaryEdit/BinaryChangeResolutionViewModelTests.cs
+++ b/tests/UI/Features/Shared/BinaryEdit/BinaryChangeResolutionViewModelTests.cs
@@ -1,0 +1,46 @@
+using Nikse.SubtitleEdit.Features.Shared.BinaryEdit;
+using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryChangeResolution;
+using System.Collections.Generic;
+
+namespace UITests.Features.Shared.BinaryEdit;
+
+public class BinaryChangeResolutionViewModelTests
+{
+    [Fact]
+    public void ApplyResolution_ScalesPositionsByWidthAndHeightIndependently()
+    {
+        var item = new BinarySubtitleItem(TimeSpan.Zero, TimeSpan.FromSeconds(1)) { X = 960, Y = 1000 };
+
+        BinaryChangeResolutionViewModel.ApplyResolution(new List<BinarySubtitleItem> { item }, 1920, 1080, 720, 576);
+
+        Assert.Equal(360, item.X);
+        Assert.Equal(533, item.Y); // 1000 * 576 / 1080 = 533.3
+    }
+
+    [Fact]
+    public void ApplyResolution_SameSizeIsNoOp()
+    {
+        var item = new BinarySubtitleItem(TimeSpan.Zero, TimeSpan.FromSeconds(1)) { X = 7, Y = 9 };
+
+        BinaryChangeResolutionViewModel.ApplyResolution(new List<BinarySubtitleItem> { item }, 1920, 1080, 1920, 1080);
+
+        Assert.Equal(7, item.X);
+        Assert.Equal(9, item.Y);
+    }
+
+    [Theory]
+    [InlineData(0, 1280, 1.0)]
+    [InlineData(1920, 0, 1.0)]
+    [InlineData(1920, 1280, 2.0 / 3.0)]
+    public void GetScale_UnknownSourceOrTargetMeansNoScaling(int from, int to, double expected)
+    {
+        Assert.Equal(expected, BinaryChangeResolutionViewModel.GetScale(from, to), 6);
+    }
+
+    [Fact]
+    public void ScaleCoordinate_RoundsHalfAwayFromZero()
+    {
+        Assert.Equal(1, BinaryChangeResolutionViewModel.ScaleCoordinate(1, 0.5));
+        Assert.Equal(2, BinaryChangeResolutionViewModel.ScaleCoordinate(3, 0.5));
+    }
+}


### PR DESCRIPTION
Adds **Tools → Video resolution...** to the image-based subtitle editor, the first of the BDSup2Sub-style features discussed for binary edit.

- Preset combo (reuses the export image resolution list) plus free width/height inputs; typing a size that matches a preset selects it.
- Scales every bitmap and every X/Y position by the width and height ratios independently (so 1920×1080 → 720×576 fills the PAL frame as BDSup2Sub does), then sets the new screen size on all lines.
- Preview of the first image with the original/new size and the scale percentages.
- Changing the screen width/height fields in the main window still only relabels the canvas; this dialog is the way to actually re-target a SUP.

No new language keys: uses `General.VideoResolution/Resolution/Width/Height` and `ImageBasedEdit.OriginalSizeXNewSizeY/Percentage`.

Tests: position scaling, no-op on same size, scale guard for unknown sizes, rounding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)