### PR TITLE
BurnInWindowTests: clear nullable dereference warning

### DIFF
--- a/tests/UI/Features/Video/BurnInWindowTests.cs
+++ b/tests/UI/Features/Video/BurnInWindowTests.cs
@@ -134,8 +134,9 @@ public class BurnInWindowTests : IDisposable
         var middleColumn = FindMiddleColumn(FindSettingsGrid(rootGrid).SettingsGrid);
         Assert.Equal(GridUnitType.Auto, middleColumn.RowDefinitions[1].Height.GridUnitType);
         Assert.Equal(GridUnitType.Star, middleColumn.RowDefinitions[^1].Height.GridUnitType);
+        Assert.NotNull(vm.VideoPlayerControl);
         Assert.Equal(360, vm.VideoPlayerControl.Height);
-        Assert.Equal(VerticalAlignment.Top, vm.VideoPlayerControl!.VerticalAlignment);
+        Assert.Equal(VerticalAlignment.Top, vm.VideoPlayerControl.VerticalAlignment);
 
         // The left column is one panel in the settings grid's single row. It must fit entirely
         // above the progress view - the regression this guards against drew


### PR DESCRIPTION
Clears the last remaining build warning. The test dereferenced the nullable `VideoPlayerControl` once unguarded and once with `!`. It now asserts non-null first, which also gives a clearer failure than a null reference exception if the control ever goes missing.

The full UI + test build is now warning-free. BurnInWindowTests: 10 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)