### PR TITLE
Spell check: add Spanish (Mexico), (Argentina) and (Latin America / US) dictionaries

### DIFF
--- a/src/ui/Assets/HunspellDictionaries.json
+++ b/src/ui/Assets/HunspellDictionaries.json
@@ -697,6 +697,33 @@
     "Description": "Spanish spell checker (LibreOffice)"
   },
   {
+    "EnglishName": "Spanish (Argentina)",
+    "NativeName": "Español (Argentina)",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/es/es_AR.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/es/es_AR.dic"
+    ],
+    "Description": "Spanish (Argentina) spell checker (LibreOffice)"
+  },
+  {
+    "EnglishName": "Spanish (Latin America / US)",
+    "NativeName": "Español (Latinoamérica / EE. UU.)",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/es/es_US.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/es/es_US.dic"
+    ],
+    "Description": "Spanish (Latin America / United States) spell checker (LibreOffice)"
+  },
+  {
+    "EnglishName": "Spanish (Mexico)",
+    "NativeName": "Español (México)",
+    "Files": [
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/es/es_MX.aff",
+      "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/es/es_MX.dic"
+    ],
+    "Description": "Spanish (Mexico) spell checker (LibreOffice)"
+  },
+  {
     "EnglishName": "Swahili",
     "NativeName": "Kiswahili",
     "Files": [


### PR DESCRIPTION
Adds three regional Spanish entries to `HunspellDictionaries.json`, all from the LibreOffice dictionaries repo like the existing Spanish entry:

- Spanish (Argentina): `es_AR`
- Spanish (Latin America / US): `es_US`
- Spanish (Mexico): `es_MX`

These are real separate dictionaries with their own `.aff`/`.dic` (es_MX differs from es_ES by ~4,600 word lines), not aliases. All six URLs verified with HEAD requests. Pure additions, formatting unchanged; 50 dictionary tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)