### PR TITLE
Google Cloud STT: allow gcloud credentials, and object level access to the bucket

### DIFF
--- a/src/ui/Features/Video/SpeechToText/Engines/GoogleCloudSttEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/GoogleCloudSttEngine.cs
@@ -37,8 +37,10 @@ public class GoogleCloudSttEngine : IOnlineSttEngine
         // No key file is fine when the machine already has Application Default Credentials,
         // which is often the only route available: creating a service account key is
         // commonly blocked by org policy.
-        var hasKeyFile = !string.IsNullOrWhiteSpace(settings.KeyFile) && File.Exists(settings.KeyFile);
-        if (!hasKeyFile && !GoogleCloudSttService.HasApplicationDefaultCredentials())
+        // A configured key file must exist though: the service uses it whenever one is set,
+        // so a stale path would otherwise fail at transcription time instead of here.
+        var hasKeyFile = !string.IsNullOrWhiteSpace(settings.KeyFile);
+        if (hasKeyFile ? !File.Exists(settings.KeyFile) : !GoogleCloudSttService.HasApplicationDefaultCredentials())
         {
             configErrorMessage = Se.Language.General.OnlineSttApiKeyMissing;
             return null;

--- a/src/ui/Features/Video/SpeechToText/Engines/GoogleCloudSttEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/GoogleCloudSttEngine.cs
@@ -33,7 +33,12 @@ public class GoogleCloudSttEngine : IOnlineSttEngine
     public ISttTranscriber? CreateTranscriber(out string? configErrorMessage)
     {
         var settings = GoogleCloudSttSettings.FromConfiguration();
-        if (string.IsNullOrWhiteSpace(settings.KeyFile) || !File.Exists(settings.KeyFile))
+
+        // No key file is fine when the machine already has Application Default Credentials,
+        // which is often the only route available: creating a service account key is
+        // commonly blocked by org policy.
+        var hasKeyFile = !string.IsNullOrWhiteSpace(settings.KeyFile) && File.Exists(settings.KeyFile);
+        if (!hasKeyFile && !GoogleCloudSttService.HasApplicationDefaultCredentials())
         {
             configErrorMessage = Se.Language.General.OnlineSttApiKeyMissing;
             return null;
@@ -64,6 +69,9 @@ public class GoogleCloudSttEngine : IOnlineSttEngine
         " 1. In the Google Cloud console create a project with billing, and enable the Speech-to-Text API.\n" +
         " 2. Create a service account with the roles 'Cloud Speech Client' and 'Storage Admin'.\n" +
         " 3. Add a JSON key to the service account, download it, and pick it as the key file.\n\n" +
+        "If your organisation does not allow service account keys, leave the key file empty and run " +
+        "'gcloud auth application-default login' instead. Those credentials rarely name a project, so also set " +
+        "GoogleCloudSttProjectId in Settings.json.\n\n" +
         "Long audio must be read from a Cloud Storage bucket, so one named <project>-subtitle-edit-stt is created " +
         "on first use (another name can be set as GoogleCloudSttBucketName in Settings.json). Uploaded audio is " +
         "deleted after each run.\n\n" +

--- a/src/ui/Features/Video/SpeechToText/GoogleCloud/GoogleCloudSttService.cs
+++ b/src/ui/Features/Video/SpeechToText/GoogleCloud/GoogleCloudSttService.cs
@@ -359,34 +359,48 @@ public class GoogleCloudSttService : ISttTranscriber
     /// </summary>
     public static bool HasApplicationDefaultCredentials()
     {
-        if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("GOOGLE_APPLICATION_CREDENTIALS")))
-        {
-            return true;
-        }
-
-        var path = OperatingSystem.IsWindows()
-            ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "gcloud", "application_default_credentials.json")
-            : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".config", "gcloud", "application_default_credentials.json");
-
-        return File.Exists(path);
+        return !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("GOOGLE_APPLICATION_CREDENTIALS"))
+               || File.Exists(GetApplicationDefaultCredentialsPath());
     }
 
-    /// <summary>Reads the project out of the well known ADC file, which stores it as "quota_project_id".</summary>
+    /// <summary>The well known file that "gcloud auth application-default login" writes.</summary>
+    private static string GetApplicationDefaultCredentialsPath()
+    {
+        return OperatingSystem.IsWindows()
+            ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "gcloud", "application_default_credentials.json")
+            : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".config", "gcloud", "application_default_credentials.json");
+    }
+
+    /// <summary>
+    /// Reads the project out of the Application Default Credentials: first the file named by
+    /// GOOGLE_APPLICATION_CREDENTIALS (a service account key carries "project_id"), then the
+    /// well known gcloud file, which stores it as "quota_project_id".
+    /// </summary>
     private static string? ReadProjectIdFromApplicationDefaultCredentials()
+    {
+        foreach (var path in new[] { Environment.GetEnvironmentVariable("GOOGLE_APPLICATION_CREDENTIALS"), GetApplicationDefaultCredentialsPath() })
+        {
+            var projectId = TryReadProjectIdFromJsonFile(path);
+            if (!string.IsNullOrWhiteSpace(projectId))
+            {
+                return projectId;
+            }
+        }
+
+        return null;
+    }
+
+    private static string? TryReadProjectIdFromJsonFile(string? path)
     {
         try
         {
-            var path = OperatingSystem.IsWindows()
-                ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "gcloud", "application_default_credentials.json")
-                : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".config", "gcloud", "application_default_credentials.json");
-
-            if (!File.Exists(path))
+            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
             {
                 return null;
             }
 
             using var doc = JsonDocument.Parse(File.ReadAllText(path));
-            foreach (var name in new[] { "quota_project_id", "project_id" })
+            foreach (var name in new[] { "project_id", "quota_project_id" })
             {
                 if (doc.RootElement.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String)
                 {

--- a/src/ui/Features/Video/SpeechToText/GoogleCloud/GoogleCloudSttService.cs
+++ b/src/ui/Features/Video/SpeechToText/GoogleCloud/GoogleCloudSttService.cs
@@ -24,6 +24,12 @@ public class GoogleCloudSttSettings
     public string Model { get; set; } = "chirp_3";
     public string Language { get; set; } = string.Empty;
     public string BucketName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Only needed when the credential does not carry a project. A service account key
+    /// always does; Application Default Credentials from "gcloud auth" often do not.
+    /// </summary>
+    public string ProjectId { get; set; } = string.Empty;
     public int TimeoutSeconds { get; set; } = 3600;
     public bool DynamicBatching { get; set; } = true;
     public Action<string>? Logger { get; set; }
@@ -35,6 +41,7 @@ public class GoogleCloudSttSettings
         Model = Se.Settings.Tools.GoogleCloudSttModel,
         Language = Se.Settings.Tools.GoogleCloudSttLanguage,
         BucketName = Se.Settings.Tools.GoogleCloudSttBucketName,
+        ProjectId = Se.Settings.Tools.GoogleCloudSttProjectId,
         TimeoutSeconds = Se.Settings.Tools.GoogleCloudSttTimeoutSeconds,
         DynamicBatching = Se.Settings.Tools.GoogleCloudSttDynamicBatching,
         Logger = message => Se.WriteToolsLog(message),
@@ -102,12 +109,23 @@ public class GoogleCloudSttService : ISttTranscriber
 
         try
         {
-            var projectId = ReadProjectId(_settings.KeyFile);
-            // The key file is a service account key (ReadProjectId reads its project_id), so
-            // ask for that type explicitly. The untyped GoogleCredential.FromFileAsync is
-            // deprecated because it will build whatever credential type the file declares.
-            var serviceAccount = await CredentialFactory.FromFileAsync<ServiceAccountCredential>(_settings.KeyFile, ct);
-            _credential = serviceAccount.ToGoogleCredential().CreateScoped(Scope);
+            var projectId = ResolveProjectId(_settings);
+
+            // A service account key is not the only way in, and in many organisations it is
+            // not an available one: creating keys is commonly blocked by the
+            // constraints/iam.disableServiceAccountKeyCreation org policy, and issuing one
+            // needs a role most users of this feature will not hold. When no key file is
+            // configured, fall back to Application Default Credentials, which "gcloud auth
+            // application-default login" writes and which every Google client library
+            // already understands.
+            //
+            // With a key file, ask for the service account type explicitly: the untyped
+            // GoogleCredential.FromFileAsync is deprecated because it will build whatever
+            // credential type the file happens to declare.
+            _credential = (string.IsNullOrWhiteSpace(_settings.KeyFile)
+                ? await GoogleCredential.GetApplicationDefaultAsync(ct)
+                : (await CredentialFactory.FromFileAsync<ServiceAccountCredential>(_settings.KeyFile, ct)).ToGoogleCredential())
+                .CreateScoped(Scope);
 
             var bucket = string.IsNullOrWhiteSpace(_settings.BucketName) ? DeriveBucketName(projectId) : _settings.BucketName.Trim();
             await EnsureBucketAsync(projectId, bucket, ct);
@@ -289,6 +307,40 @@ public class GoogleCloudSttService : ISttTranscriber
         }
     }
 
+    /// <summary>
+    /// Finds the project to bill and to create the bucket in, from whichever source has it.
+    /// A service account key always carries "project_id"; Application Default Credentials
+    /// usually carry only "quota_project_id", and sometimes neither.
+    /// </summary>
+    internal static string ResolveProjectId(GoogleCloudSttSettings settings)
+    {
+        if (!string.IsNullOrWhiteSpace(settings.ProjectId))
+        {
+            return settings.ProjectId.Trim();
+        }
+
+        if (!string.IsNullOrWhiteSpace(settings.KeyFile))
+        {
+            return ReadProjectId(settings.KeyFile);
+        }
+
+        foreach (var candidate in new[]
+                 {
+                     Environment.GetEnvironmentVariable("GOOGLE_CLOUD_PROJECT"),
+                     Environment.GetEnvironmentVariable("GCLOUD_PROJECT"),
+                     ReadProjectIdFromApplicationDefaultCredentials(),
+                 })
+        {
+            if (!string.IsNullOrWhiteSpace(candidate))
+            {
+                return candidate!;
+            }
+        }
+
+        throw new HttpRequestException(
+            "No Google Cloud project could be determined. Either pick a service account key file, which carries its own project, or set GoogleCloudSttProjectId in Settings.json.");
+    }
+
     internal static string ReadProjectId(string keyFile)
     {
         using var doc = JsonDocument.Parse(File.ReadAllText(keyFile));
@@ -298,6 +350,56 @@ public class GoogleCloudSttService : ISttTranscriber
         }
 
         throw new HttpRequestException("The key file is not a Google Cloud service account key (no project_id). In the Google Cloud console create a service account key of type JSON.");
+    }
+
+    /// <summary>
+    /// True when Application Default Credentials are available, so the engine can run with
+    /// no key file. Written by "gcloud auth application-default login", or pointed at by
+    /// GOOGLE_APPLICATION_CREDENTIALS.
+    /// </summary>
+    public static bool HasApplicationDefaultCredentials()
+    {
+        if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("GOOGLE_APPLICATION_CREDENTIALS")))
+        {
+            return true;
+        }
+
+        var path = OperatingSystem.IsWindows()
+            ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "gcloud", "application_default_credentials.json")
+            : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".config", "gcloud", "application_default_credentials.json");
+
+        return File.Exists(path);
+    }
+
+    /// <summary>Reads the project out of the well known ADC file, which stores it as "quota_project_id".</summary>
+    private static string? ReadProjectIdFromApplicationDefaultCredentials()
+    {
+        try
+        {
+            var path = OperatingSystem.IsWindows()
+                ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "gcloud", "application_default_credentials.json")
+                : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".config", "gcloud", "application_default_credentials.json");
+
+            if (!File.Exists(path))
+            {
+                return null;
+            }
+
+            using var doc = JsonDocument.Parse(File.ReadAllText(path));
+            foreach (var name in new[] { "quota_project_id", "project_id" })
+            {
+                if (doc.RootElement.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String)
+                {
+                    return value.GetString();
+                }
+            }
+        }
+        catch (Exception)
+        {
+            // Unreadable or malformed; the caller still has other sources and a clear error.
+        }
+
+        return null;
     }
 
     private async Task<HttpResponseMessage> SendAsync(HttpMethod method, string url, HttpContent? content, CancellationToken ct)
@@ -326,9 +428,23 @@ public class GoogleCloudSttService : ISttTranscriber
 
     private async Task EnsureBucketAsync(string projectId, string bucket, CancellationToken ct)
     {
+        var namedByUser = !string.IsNullOrWhiteSpace(_settings.BucketName);
+
         using var probe = await SendAsync(HttpMethod.Get, $"{StorageApi}/b/{bucket}", null, ct);
         if (probe.StatusCode != HttpStatusCode.NotFound)
         {
+            // Reading bucket metadata needs storage.buckets.get, which object level roles
+            // such as Storage Object Admin do not include. A user handed a ready made
+            // bucket by an administrator can upload and delete objects in it perfectly
+            // well, and should not be stopped by a metadata check they were never meant to
+            // pass. Only trust that when they named the bucket themselves; a 403 on a
+            // bucket this code derived is a genuine configuration problem.
+            if (probe.StatusCode == HttpStatusCode.Forbidden && namedByUser)
+            {
+                _settings.Logger?.Invoke($"Google Cloud: cannot read metadata for bucket {bucket}, assuming it exists and continuing");
+                return;
+            }
+
             if (!probe.IsSuccessStatusCode)
             {
                 throw new HttpRequestException($"Google Cloud bucket check failed ({(int)probe.StatusCode}). Response: {await probe.Content.ReadAsStringAsync(ct)}");

--- a/src/ui/Logic/Config/SeTools.cs
+++ b/src/ui/Logic/Config/SeTools.cs
@@ -165,6 +165,12 @@ public class SeTools
     public string GoogleCloudSttModel { get; set; } = "chirp_3";
     public string GoogleCloudSttLanguage { get; set; } = string.Empty;
     public string GoogleCloudSttBucketName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Only needed when signing in with Application Default Credentials, which usually do
+    /// not name a project. A service account key carries its own and this stays empty.
+    /// </summary>
+    public string GoogleCloudSttProjectId { get; set; } = string.Empty;
     public int GoogleCloudSttTimeoutSeconds { get; set; } = 3600;
 
     /// <summary>

--- a/tests/UI/Features/Video/SpeechToText/GoogleCloud/GoogleCloudSttServiceTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/GoogleCloud/GoogleCloudSttServiceTests.cs
@@ -331,4 +331,47 @@ public class GoogleCloudSttServiceTests
         Assert.Equal("uc dort", response.Segments[1].Text);
         Assert.Equal(20.0, response.Segments[1].Start, 3);
     }
+
+    [Fact]
+    public void ResolveProjectId_PrefersTheExplicitSetting()
+    {
+        var settings = new GoogleCloudSttSettings { ProjectId = " my-project ", KeyFile = "/does/not/exist.json" };
+        Assert.Equal("my-project", GoogleCloudSttService.ResolveProjectId(settings));
+    }
+
+    [Fact]
+    public void ResolveProjectId_ReadsTheKeyFileWhenNoExplicitSettingIsGiven()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".json");
+        File.WriteAllText(path, """{"type":"service_account","project_id":"from-key-file"}""");
+        try
+        {
+            var settings = new GoogleCloudSttSettings { KeyFile = path };
+            Assert.Equal("from-key-file", GoogleCloudSttService.ResolveProjectId(settings));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    /// <summary>
+    /// Creating a service account key is commonly blocked by the
+    /// constraints/iam.disableServiceAccountKeyCreation org policy, so an empty key file
+    /// has to be a valid configuration rather than an error.
+    /// </summary>
+    [Fact]
+    public void ResolveProjectId_FallsBackToTheEnvironmentWhenThereIsNoKeyFile()
+    {
+        var previous = Environment.GetEnvironmentVariable("GOOGLE_CLOUD_PROJECT");
+        try
+        {
+            Environment.SetEnvironmentVariable("GOOGLE_CLOUD_PROJECT", "from-environment");
+            Assert.Equal("from-environment", GoogleCloudSttService.ResolveProjectId(new GoogleCloudSttSettings()));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("GOOGLE_CLOUD_PROJECT", previous);
+        }
+    }
 }


### PR DESCRIPTION
Two setup barriers that stop this engine being usable inside an organisation that has a real
cloud administrator. Both surfaced while testing #14561 and #14567 against a live project
that is managed by someone other than me, which turned out to be a more revealing
environment than a project I own.

No UI, no language tags, so this should be fine before 5.3.

## 1. A service account key was the only accepted credential

`GoogleCredential.FromFileAsync(_settings.KeyFile)` was the whole auth story. That works
when the person transcribing owns the cloud project. It does not work in a managed org:

- Creating a key is commonly blocked by the `constraints/iam.disableServiceAccountKeyCreation`
  org policy. The project I tested on has it.
- Issuing one needs `iam.serviceAccounts.create`, a role most people who want to transcribe
  a video will not hold. I do not hold it on that project, and neither will most users.

So the engine fails at setup rather than at transcription, which is a harder problem to
diagnose and a much harder one for a user to fix on their own.

An empty key file now falls back to **Application Default Credentials**, which
`gcloud auth application-default login` writes and which every Google client library already
understands. Nothing else changes: with a key file configured the behaviour is exactly as
before, including your `CredentialFactory.FromFileAsync<ServiceAccountCredential>` change
from 61197617f, which I kept.

**Verified end to end against the live API with no key file at all:**

```
resolved project: <redacted>
progress: Uploading audio to Cloud Storage...
progress: Submitting transcription...
progress: Waiting for transcription to complete...
Google Cloud: dropped word 'Sağ' with impossible timing 162.76-160.32 s
segments: 43
first cue: 0.000-2.600 Ay, ay, ay, ay, ay.
```

ADC rarely names a project, so `ResolveProjectId` now tries, in order: the new
`GoogleCloudSttProjectId` setting, the key file, `GOOGLE_CLOUD_PROJECT`, `GCLOUD_PROJECT`,
and the ADC file's `quota_project_id`. When none of those exist it says so, instead of
failing inside a JSON parse.

## 2. The bucket probe rejected object level access

`EnsureBucketAsync` threw on any non 404 failure of its metadata `GET`. Reading bucket
metadata needs `storage.buckets.get`, which object level roles such as **Storage Object
Admin do not include**.

So a user whose administrator pre-creates the bucket and grants object access to it, which
is the normal arrangement in a locked down org, is stopped by a check they were never meant
to pass, despite being able to upload and delete objects in that bucket perfectly well.

A 403 on a bucket **the user named explicitly** is now treated as "it exists and is not mine
to inspect". A 403 on a bucket this code derived still fails, because that is a genuine
misconfiguration rather than a permissions arrangement.

## Testing

287 SpeechToText tests pass, 3 new ones covering project resolution from each source.

Two notes, neither caused by this PR:

- **`SpeechToTextWindowLayoutTests.EveryChild_SitsInsideTheDefinedRows` is currently failing
  on main.** I confirmed it fails on a clean `upstream/main` checkout with none of my
  branches applied. It is a teardown race rather than a layout assertion:
  `CheckWhisperCppForUpdateAsync` shows a MessageBox after the test's window has closed, and
  Avalonia throws `Cannot show a window with a closed owner`. Flagging it since it makes a
  green run hard to recognise.
- Thanks for cleaning up the nullable warnings in my truncation recovery in 61197617f. Those
  were mine and I should have caught them; I had been filtering build output for errors only.

## What is waiting for 5.3

Three settings are reachable today only by editing `Settings.json`, and all three are things
a user configuring this engine will actually need:

| Setting | Why it matters |
|:--|:--|
| `GoogleCloudSttProjectId` | Required when signing in with ADC, since those credentials usually name no project |
| `GoogleCloudSttBucketName` | Required by anyone whose administrator pre-creates the bucket, which is the case this PR unblocks |
| `GoogleCloudSttDynamicBatching` | The difference between about $0.44 and $2.32 for a 2.5 hour episode |

I have the settings rows and language tags written and building on a branch already, held
back because of the freeze. Say the word once 5.3 opens and I will send it as a small PR; it
is three rows and three strings, no behaviour change.

