### PR TITLE
Generate blank video: theme-aware time code color, larger font, contrast box

### DIFF
--- a/src/ui/Features/Video/BlankVideo/BlankVideoViewModel.cs
+++ b/src/ui/Features/Video/BlankVideo/BlankVideoViewModel.cs
@@ -239,8 +239,10 @@ public partial class BlankVideoViewModel : ObservableObject
         var ts = TimeSpan.FromMilliseconds(totalMs + 2000);
         var timeCode = string.Format($"{ts.Hours:00}\\\\:{ts.Minutes:00}\\\\:{ts.Seconds:00}");
 
+        // The checkerboard follows the app theme: light squares in light theme, dark squares
+        // in dark theme. Black text on the dark-theme checkerboard was nearly invisible.
         var addTimeColor = "white";
-        if (UseCheckedImage)
+        if (UseCheckedImage && !UiUtil.IsDarkTheme())
         {
             addTimeColor = "black";
         }

--- a/src/ui/Logic/Media/FfmpegGenerator.cs
+++ b/src/ui/Logic/Media/FfmpegGenerator.cs
@@ -329,7 +329,7 @@ public class FfmpegGenerator
 
     private static Process GetFFmpegProcess(string imageFileName, string outputFileName, int videoWidth, int videoHeight, int seconds, decimal frameRate, bool addTimeCode = false, string addTimeColor = "white")
     {
-        var drawText = MakeDrawText(addTimeCode, frameRate, addTimeColor);
+        var drawText = MakeDrawText(addTimeCode, frameRate, addTimeColor, videoHeight);
 
         return new Process
         {
@@ -357,7 +357,7 @@ public class FfmpegGenerator
 
         var htmlColor = $"#{(color.R.ToString("X2") + color.G.ToString("X2") + color.B.ToString("X2")).ToUpperInvariant()}";
 
-        var drawText = MakeDrawText(addTimeCode, frameRate, addTimeColor);
+        var drawText = MakeDrawText(addTimeCode, frameRate, addTimeColor, videoHeight);
 
         return new Process
         {
@@ -371,12 +371,15 @@ public class FfmpegGenerator
         };
     }
 
-    private static string MakeDrawText(bool addTimeCode, decimal frameRate, string addTimeColor)
+    private static string MakeDrawText(bool addTimeCode, decimal frameRate, string addTimeColor, int videoHeight)
     {
         var drawText = string.Empty;
         if (addTimeCode)
         {
-            drawText = $" -vf \"drawtext=timecode='00\\:00\\:00\\:00':r={frameRate.ToString(CultureInfo.InvariantCulture)}:x=10:y=10:fontsize=34:fontcolor={addTimeColor}\"";
+            // Scale with the video height (1080p -> 60 px); a fixed 34 px was tiny at HD sizes.
+            var fontSize = Math.Max(34, videoHeight / 18);
+            var boxColor = addTimeColor == "black" ? "white@0.5" : "black@0.5";
+            drawText = $" -vf \"drawtext=timecode='00\\:00\\:00\\:00':r={frameRate.ToString(CultureInfo.InvariantCulture)}:x=10:y=10:fontsize={fontSize}:fontcolor={addTimeColor}:box=1:boxcolor={boxColor}:boxborderw={Math.Max(4, fontSize / 8)}\"";
         }
 
         return drawText;

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -2937,7 +2937,7 @@ public static class UiUtil
         return control;
     }
 
-    private static bool IsDarkTheme()
+    public static bool IsDarkTheme()
     {
         var app = Application.Current;
         if (app == null)


### PR DESCRIPTION
Fixes the "Generate blank video" time code being black on the dark-theme checkerboard (hard to see), and makes it larger.

- Time code color is now black only for the light-theme checkerboard; white otherwise
- Font size scales with video height (1080p -> 60 px, min 34, was a fixed 34 px)
- Semi-transparent box behind the text keeps it readable on any solid color / image background

🤖 Generated with [Claude Code](https://claude.com/claude-code)