### PR TITLE
Multiple replace: Enter runs OK again (#14586)

### DIFF
--- a/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
+++ b/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
@@ -1070,6 +1070,15 @@ public partial class MultipleReplaceViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (e.Key == Key.Enter && e.KeyModifiers == KeyModifiers.None)
+        {
+            // Initial focus is on the rules tree, not the OK button (a focused button clicks on bare
+            // Space), so Enter has to reach OK from the window - the rules tree and preview grid do
+            // not use Enter themselves. A focused Cancel/Apply button consumes Enter before it bubbles
+            // here, so those keep their own meaning (#14586).
+            e.Handled = true;
+            Ok();
+        }
         else if (e.Key == Key.N && e.KeyModifiers == KeyModifiers.Control)
         {
             e.Handled = true;


### PR DESCRIPTION
Fixes #14586.

The July accessibility sweep (4d44d3af2) moved the Multiple replace dialog's initial focus from the OK button to the rules tree, because a focused button clicks on bare Space. That also removed Enter as the way to apply the fixes, since nothing else in the dialog handled Enter.

This adds an unmodified-Enter case to the window key handler that runs OK, the same pattern Renumber, Go to video position, Edit embedded track and Pick online subtitle use. Focus stays on the rules tree, so the Space hazard does not return. A focused Cancel or Apply button still consumes Enter itself before it bubbles to the window.

The same gap exists in about 105 other dialogs from that sweep; that is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)