### PR TITLE
Make the OK button the window's default so Enter accepts dialogs (#14586)

### DIFF
--- a/src/ui/Features/Assa/AssaApplyCustomOverrideTags/AssaTagHistoryViewModel.cs
+++ b/src/ui/Features/Assa/AssaApplyCustomOverrideTags/AssaTagHistoryViewModel.cs
@@ -66,6 +66,7 @@ public partial class AssaTagHistoryViewModel : ObservableObject
         }
         else if (e.Key == Key.Enter)
         {
+            e.Handled = true; // the OK button is IsDefault and would run OK again on the same Enter
             Ok();
         }
     }

--- a/src/ui/Features/Assa/AssaStylePickerWindow.cs
+++ b/src/ui/Features/Assa/AssaStylePickerWindow.cs
@@ -51,6 +51,7 @@ public class AssaStylePickerWindow : Window
         var labelFontsAndImages = UiUtil.MakeLabel(Se.Language.General.Styles);
 
         var buttonImport = UiUtil.MakeButton(string.Empty, vm.OkCommand).WithBindContent(nameof(vm.ButtonAcceptText));
+        buttonImport.IsDefault = true; // the dialog's accept button - Enter runs it (#14586)
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
         var panelButtons = UiUtil.MakeButtonBar(buttonImport, buttonCancel);
 

--- a/src/ui/Features/Files/ExportCustomTextFormat/ExportCustomTextFormatWindow.cs
+++ b/src/ui/Features/Files/ExportCustomTextFormat/ExportCustomTextFormatWindow.cs
@@ -32,6 +32,7 @@ public class ExportCustomTextFormatWindow : Window
 
         var buttonSaveAs = UiUtil.MakeButton(Se.Language.General.SaveDotDotDot, vm.SaveAsCommand)
             .WithBindIsVisible(vm, nameof(vm.IsSaveButtonVisible));
+        buttonSaveAs.IsDefault = true; // the dialog's accept button - Enter runs it (#14586)
 
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);

--- a/src/ui/Features/Files/ExportImageBased/ExportImageBasedWindow.cs
+++ b/src/ui/Features/Files/ExportImageBased/ExportImageBasedWindow.cs
@@ -55,6 +55,7 @@ public class ExportImageBasedWindow : Window
 
         var buttonExport = UiUtil.MakeButton(Se.Language.General.ExportDotDotDot, vm.ExportCommand)
             .WithBindIsVisible(vm, nameof(vm.IsExportButtonVisible));
+        buttonExport.IsDefault = true; // the dialog's accept button - Enter runs it (#14586)
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand).WithBindIsVisible(nameof(vm.IsGenerating));
         var buttonDone = UiUtil.MakeButtonDone(vm.CancelCommand).WithBindIsVisible(nameof(vm.IsGenerating), new InverseBooleanConverter());
         var panelButtons = UiUtil.MakeButtonBar(buttonExport, buttonDone, buttonCancel);

--- a/src/ui/Features/Files/ExportPlainText/ExportPlainTextWindow.cs
+++ b/src/ui/Features/Files/ExportPlainText/ExportPlainTextWindow.cs
@@ -27,6 +27,7 @@ public class ExportPlainTextWindow : Window
             .WithMinWidth(180)
             .WithMarginRight(10);
         var buttonSaveAs = UiUtil.MakeButton(Se.Language.General.SaveDotDotDot, vm.SaveAsCommand);
+        buttonSaveAs.IsDefault = true; // the dialog's accept button - Enter runs it (#14586)
         var buttonDone = UiUtil.MakeButtonDone(vm.CancelCommand);
         var panelButtons = UiUtil.MakeButtonBar( labelEncoding, comboBoxEncoding, buttonSaveAs, buttonDone);
 

--- a/src/ui/Features/Ocr/BinaryOcr/BinaryOcrCharacterHistoryViewModel.cs
+++ b/src/ui/Features/Ocr/BinaryOcr/BinaryOcrCharacterHistoryViewModel.cs
@@ -164,6 +164,7 @@ public partial class BinaryOcrCharacterHistoryViewModel : ObservableObject
     {
         if (e.Key == Key.Enter && !string.IsNullOrWhiteSpace(TextBoxNew.Text))
         {
+            e.Handled = true; // the OK button is IsDefault and would run OK again on the same Enter
             Ok();
         }
         else if (e.Key == Key.Escape)

--- a/src/ui/Features/Ocr/BinaryOcr/BinaryOcrInspectViewModel.cs
+++ b/src/ui/Features/Ocr/BinaryOcr/BinaryOcrInspectViewModel.cs
@@ -332,6 +332,7 @@ public partial class BinaryOcrInspectViewModel : ObservableObject
     {
         if (e.Key == Key.Enter)
         {
+            e.Handled = true; // the OK button is IsDefault and would run OK again on the same Enter
             Ok();
         }
     }

--- a/src/ui/Features/Ocr/NOcr/NOcrCharacterHistoryViewModel.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrCharacterHistoryViewModel.cs
@@ -178,6 +178,7 @@ public partial class NOcrCharacterHistoryViewModel : ObservableObject
     {
         if (e.Key == Key.Enter && !string.IsNullOrWhiteSpace(TextBoxNew.Text))
         {
+            e.Handled = true; // the OK button is IsDefault and would run OK again on the same Enter
             Ok();
         }
         else if (e.Key == Key.Escape)

--- a/src/ui/Features/Ocr/NOcr/NOcrInspectViewModel.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrInspectViewModel.cs
@@ -474,6 +474,7 @@ public partial class NOcrInspectViewModel : ObservableObject
     {
         if (e.Key == Key.Enter)
         {
+            e.Handled = true; // the OK button is IsDefault and would run OK again on the same Enter
             Ok();
         }
     }

--- a/src/ui/Features/Options/Settings/MinGapCalculate/MinGapCalculateViewModel.cs
+++ b/src/ui/Features/Options/Settings/MinGapCalculate/MinGapCalculateViewModel.cs
@@ -116,6 +116,7 @@ public partial class MinGapCalculateViewModel : ObservableObject
         }
         else if (e.Key == Key.Enter)
         {
+            e.Handled = true; // the OK button is IsDefault and would run OK again on the same Enter
             Ok();
         }
     }

--- a/src/ui/Features/Shared/GoToLineNumber/GoToLineNumberViewModel.cs
+++ b/src/ui/Features/Shared/GoToLineNumber/GoToLineNumberViewModel.cs
@@ -57,6 +57,7 @@ public partial class GoToLineNumberViewModel : ObservableObject
         }
         else if (e.Key == Key.Enter)
         {
+            e.Handled = true; // the OK button is IsDefault and would run OK again on the same Enter
             Ok();
         }
     }

--- a/src/ui/Features/Shared/SetVideoOffset/SetVideoOffsetViewModel.cs
+++ b/src/ui/Features/Shared/SetVideoOffset/SetVideoOffsetViewModel.cs
@@ -97,6 +97,7 @@ public partial class SetVideoOffsetViewModel : ObservableObject
         }
         else if (e.Key == Key.Enter)
         {
+            e.Handled = true; // the OK button is IsDefault and would run OK again on the same Enter
             Ok();
         }
     }

--- a/src/ui/Features/Translate/TranslationErrorViewModel.cs
+++ b/src/ui/Features/Translate/TranslationErrorViewModel.cs
@@ -59,6 +59,7 @@ public partial class TranslationErrorViewModel : ObservableObject
     {
         if (e.Key == Key.Escape || e.Key == Key.Enter)
         {
+            e.Handled = true; // the OK button is IsDefault and would run OK again on the same Enter
             Ok();
         }
     }

--- a/src/ui/Features/Video/EmbeddedSubtitlesEdit/EditEmbeddedTrackViewModel.cs
+++ b/src/ui/Features/Video/EmbeddedSubtitlesEdit/EditEmbeddedTrackViewModel.cs
@@ -53,6 +53,7 @@ public partial class EditEmbeddedTrackViewModel : ObservableObject
         }
         else if (e.Key == Key.Enter)
         {
+            e.Handled = true; // the OK button is IsDefault and would run OK again on the same Enter
             Ok();
         }
     }

--- a/src/ui/Features/Video/EmbeddedSubtitlesEdit/EmbeddedSubtitlesEditMp4Window.cs
+++ b/src/ui/Features/Video/EmbeddedSubtitlesEdit/EmbeddedSubtitlesEditMp4Window.cs
@@ -50,6 +50,7 @@ public class EmbeddedSubtitlesEditMp4Window : Window
         var buttonGenerate = UiUtil.MakeButton(Se.Language.General.Generate, vm.GenerateCommand)
             .WithBindEnabled(nameof(vm.CanGenerate))
             .WithBindIsVisible(nameof(vm.HasVideoFileName));
+        buttonGenerate.IsDefault = true; // the dialog's accept button - Enter runs it (#14586)
         var buttonPanel = UiUtil.MakeButtonBar(
             buttonGenerate,
             UiUtil.MakeButtonCancel(vm.CancelCommand)

--- a/src/ui/Features/Video/EmbeddedSubtitlesEdit/EmbeddedSubtitlesEditWindow.cs
+++ b/src/ui/Features/Video/EmbeddedSubtitlesEdit/EmbeddedSubtitlesEditWindow.cs
@@ -52,6 +52,7 @@ public class EmbeddedSubtitlesEditWindow : Window
         var buttonGenerate = UiUtil.MakeButton(Se.Language.General.Generate, vm.GenerateCommand)
             .WithBindEnabled(nameof(vm.CanGenerate))
             .WithBindIsVisible(nameof(vm.HasVideoFileName));
+        buttonGenerate.IsDefault = true; // the dialog's accept button - Enter runs it (#14586)
         var buttonConfig = UiUtil.MakeButton(vm.OkCommand, IconNames.Settings, Se.Language.General.Settings)
             .WithMarginRight(5)
             .WithBindEnabled(nameof(vm.CanGenerate))

--- a/src/ui/Features/Video/GoToVideoPosition/GoToVideoPositionViewModel.cs
+++ b/src/ui/Features/Video/GoToVideoPosition/GoToVideoPositionViewModel.cs
@@ -46,6 +46,7 @@ public partial class GoToVideoPositionViewModel : ObservableObject
         }
         else if (e.Key == Key.Enter)
         {
+            e.Handled = true; // the OK button is IsDefault and would run OK again on the same Enter
             Ok();
         }
     }

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -518,14 +518,28 @@ public static class UiUtil
         return button;
     }
 
+    /// <summary>
+    /// The dialog's accept button. <see cref="Button.IsDefault"/> makes it click on an unhandled
+    /// Enter anywhere in the window - the role WinForms' AcceptButton had in Subtitle Edit 4.
+    /// Initial focus deliberately does not land on this button (a focused button also clicks on
+    /// bare Space, see <see cref="FocusOnFirstActivation"/>), so without this Enter would reach OK
+    /// only after tabbing to it (#14586). Controls that give Enter their own meaning - a multi-line
+    /// TextBox, an open ComboBox, a focused Cancel button - mark the key handled first and win.
+    /// A window key handler that runs OK on Enter itself must also set Handled, or OK runs twice
+    /// (InitialFocusConventionTests checks that).
+    /// </summary>
     public static Button MakeButtonOk(IRelayCommand? command)
     {
-        return MakeButton(Se.Language.General.Ok, command);
+        var button = MakeButton(Se.Language.General.Ok, command);
+        button.IsDefault = true;
+        return button;
     }
 
     public static Button MakeButtonDone(IRelayCommand? command)
     {
-        return MakeButton(Se.Language.General.Done, command);
+        var button = MakeButton(Se.Language.General.Done, command);
+        button.IsDefault = true;
+        return button;
     }
 
     public static Button MakeButtonCancel(IRelayCommand? command)

--- a/tests/UI/Logic/InitialFocusConventionTests.cs
+++ b/tests/UI/Logic/InitialFocusConventionTests.cs
@@ -98,6 +98,44 @@ public class InitialFocusConventionTests
             string.Join(Environment.NewLine, offenders));
     }
 
+    /// <summary>
+    /// The OK button is IsDefault (UiUtil.MakeButtonOk), so an unhandled Enter anywhere in the
+    /// window already clicks it. A window or control key handler that runs OK on Enter itself must
+    /// therefore mark the event handled, or the same key press runs OK twice (#14586).
+    /// </summary>
+    [Fact]
+    public void EnterHandler_ThatRunsOk_MarksHandled()
+    {
+        var offenders = new List<string>();
+
+        foreach (var file in UiSourceFiles())
+        {
+            var text = File.ReadAllText(file);
+            foreach (Match match in Regex.Matches(text, @"if \([^\n]*Key\.(Enter|Return)[^\n]*\)\s*\r?\n\s*\{"))
+            {
+                if (IsInsideComment(text, match.Index))
+                {
+                    continue;
+                }
+
+                var body = ReadBlockAfter(text, match.Index);
+                var runsOk = Regex.IsMatch(body, @"\bOk\(\)|OkCommand\.Execute\(");
+                if (runsOk && !body.Contains("Handled = true", StringComparison.Ordinal))
+                {
+                    var line = text.Take(match.Index).Count(c => c == '\n') + 1;
+                    offenders.Add($"{Relative(file)}:{line}");
+                }
+            }
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            "An Enter handler runs OK without setting e.Handled = true. The OK button is " +
+            "IsDefault and clicks on the same unhandled Enter, so OK runs twice." +
+            Environment.NewLine +
+            string.Join(Environment.NewLine, offenders));
+    }
+
     /// <summary>The block that starts at the first "{" after <paramref name="index"/>.</summary>
     private static string ReadBlockAfter(string text, int index)
     {


### PR DESCRIPTION
Follow-up to #14587, which fixed Multiple replace alone.

The July accessibility sweep (4d44d3af2) moved every dialog's initial focus off the OK button, because a focused button clicks on bare Space. That also removed Enter as the way to accept a dialog, since Enter only worked because OK had focus. A survey of the 116 swept dialogs found 105 with no Enter handling at all: most of the Tools menu, all format property dialogs, the ASSA/SSA dialogs, binary edit adjustments, Burn-in, Text to speech, Batch convert settings, Visual sync, Compare and the export dialogs.

**Change**
- `UiUtil.MakeButtonOk` and `MakeButtonDone` set `Button.IsDefault`, Avalonia's equivalent of the WinForms AcceptButton SE 4 used. An Enter that no control handled clicks the button. Multi-line text boxes, open combo boxes, a focused Cancel button and grids that use Enter mark the key handled first and keep their own meaning. A disabled OK button does not fire.
- Six accept buttons with other captions opt in individually: Export image based (Export), Embedded subtitles edit MP4 and Matroska (Generate), Export custom text format and Export plain text (Save), ASSA style picker (Import).
- Eleven existing Enter handlers ran `Ok()` without setting `e.Handled`, which would now run OK twice on one key press. They set Handled.
- New source scan in `InitialFocusConventionTests`: an Enter handler that runs OK must set Handled. Verified it fails when one of the eleven is reverted.

**Not done**
ReEncodeVideo's Generate is a SplitButton and Video OCR's Start button were left alone. Manual testing of the dialogs in the running app has not been done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)