### PR TITLE
Release v5.2.0-rc4

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -3,6 +3,29 @@ Subtitle Edit Changelog
 
 -----------------------------------------------------------------------------------------------------
 
+v5.2.0-rc4 (6th of September 2026)
+
+* Add Google Cloud Speech-to-Text v2 as an online speech-to-text engine (lossless audio, dynamic batching, word-timed cues) - thx muaz978
+* Add "Video resolution..." to the image-based subtitle editor (Tools menu), scaling images and positions like BDSup2Sub
+* Add per-line voice cloning to VibeVoice, MOSS-TTS, CosyVoice3 and VoxCPM2 (Crisp ASR) - thx invio-a11y
+* Add Spanish (Mexico), (Argentina) and (Latin America / US) spell check dictionaries
+* Add keyboard navigation between changes in Beautify time codes
+* Add live progress, elapsed time and estimate for WhisperX speech-to-text
+* Show a drop-target bar while dragging text in the subtitle text boxes
+* Make the OK button the default in dialogs so Enter accepts them (e.g. Multiple replace) - thx rRobis
+* Fix short durations: also run after split/merge, and always extend the duration - thx andor1999
+* Generate blank video: theme-aware, larger time code with a contrast box, and no window resizing while generating
+* Burn-in: smaller fixed-height preview player without empty bands around the video
+* Fix "guess start/end from waveform" not working on quiet audio - thx m0ck69
+* Fix text drag-and-drop shrinking the selection, and space the drop like SE4 - thx ruonghieu
+* Fix undocked windows staying above other applications that took the foreground - thx cvrle77
+* Fix Higgs Audio v3 voice clone hiss at the end of clips - thx invio-a11y
+* Remove the Vietnamese Parakeet model from Crisp ASR speech to text (quality too poor) - thx ruonghieu
+* Update Chinese (Simplified) translation - thx emsb8888-prog
+* Update Italian translation - thx bovirus
+
+-----------------------------------------------------------------------------------------------------
+
 v5.2.0-rc3 (5th of September 2026)
 
 * Add text drag-and-drop in the subtitle text boxes (e.g. from original to working text) - thx bichitoxxx

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "Subtitle Edit",
-  "version": "v5.2.0-rc3",
+  "version": "v5.2.0-rc4",
   "translatedBy": "",
   "cultureName": "en-US",
   "general": {

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -20,7 +20,7 @@ public class Se
     internal const int CurrentMacOsFontMigrationVersion = 1;
     internal const int CurrentShortcutsMigrationVersion = 3;
 
-    public static string Version { get; set; } = "v5.2.0-rc3";
+    public static string Version { get; set; } = "v5.2.0-rc4";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
Version bump to v5.2.0-rc4 (Se.cs + English.json) and the change-log section for the 25 PRs merged since v5.2.0-rc3, each ancestor-checked against the rc3 tag.

Grouped into one line: Google Cloud STT engine #14561 + #14567; per-line clone #14562 + #14570; blank video #14583 + #14584; Enter-runs-OK #14587 + #14589.
Left out: #14579/#14580 (warning cleanups) and #14572 (layout fix for the engine added in this same RC).

After merge: `gh workflow run "Build and release UI" --ref main -f release_tag=v5.2.0-rc4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)