### PR TITLE
UI tests: fix six order-dependent flakes and cut 5 s off the suite

### DIFF
--- a/tests/UI/Controls/AudioVisualizerOriginalTextTests.cs
+++ b/tests/UI/Controls/AudioVisualizerOriginalTextTests.cs
@@ -39,35 +39,44 @@ public class AudioVisualizerOriginalTextTests
         window.Show();
         window.UpdateLayout();
 
-        var line = new SubtitleLineViewModel
+        try
         {
-            // Deliberately different lengths: the footer's CPS follows the drawn text, so the
-            // frames below can only match if it swapped too.
-            Text = "Vertaalde regel",
-            OriginalText = "Source line",
-            StartTime = TimeSpan.FromSeconds(LineStartSeconds),
-            EndTime = TimeSpan.FromSeconds(LineStartSeconds + 3),
-        };
+            var line = new SubtitleLineViewModel
+            {
+                // Deliberately different lengths: the footer's CPS follows the drawn text, so the
+                // frames below can only match if it swapped too.
+                Text = "Vertaalde regel",
+                OriginalText = "Source line",
+                StartTime = TimeSpan.FromSeconds(LineStartSeconds),
+                EndTime = TimeSpan.FromSeconds(LineStartSeconds + 3),
+            };
 
-        var lines = new List<SubtitleLineViewModel> { line };
-        var noSelection = new List<SubtitleLineViewModel>();
+            var lines = new List<SubtitleLineViewModel> { line };
+            var noSelection = new List<SubtitleLineViewModel>();
 
-        av.SetPosition(LineStartSeconds - 1, lines, 0, -1, noSelection);
-        var translation = Capture(window);
+            av.SetPosition(LineStartSeconds - 1, lines, 0, -1, noSelection);
+            var translation = Capture(window);
 
-        av.ShowOriginalText = true;
-        av.InvalidateVisual();
-        var original = Capture(window);
+            av.ShowOriginalText = true;
+            av.InvalidateVisual();
+            var original = Capture(window);
 
-        Assert.NotEqual(translation, original);
+            Assert.NotEqual(translation, original);
 
-        // ... and it is the original text that was drawn, not merely something else: the same
-        // waveform with the original text in the ordinary Text property paints the same frame -
-        // text, and the CPS in the paragraph footer with it.
-        av.ShowOriginalText = false;
-        line.Text = "Source line";
-        av.InvalidateVisual();
-        Assert.Equal(original, Capture(window));
+            // ... and it is the original text that was drawn, not merely something else: the same
+            // waveform with the original text in the ordinary Text property paints the same frame -
+            // text, and the CPS in the paragraph footer with it.
+            av.ShowOriginalText = false;
+            line.Text = "Source line";
+            av.InvalidateVisual();
+            Assert.Equal(original, Capture(window));
+        }
+        finally
+        {
+            // A window left open keeps the app-wide activation and focused element for the rest
+            // of the run, so a later test's key press or click lands here instead.
+            window.Close();
+        }
     }
 
     private static WavePeakData2 MakePeaks(int seconds)

--- a/tests/UI/Controls/TimeCodeUpDownNegativeTests.cs
+++ b/tests/UI/Controls/TimeCodeUpDownNegativeTests.cs
@@ -6,6 +6,7 @@ using Avalonia.Data;
 using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
+using Avalonia.Threading;
 using Avalonia.VisualTree;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Nikse.SubtitleEdit.Controls;
@@ -73,6 +74,15 @@ public partial class TimeCodeUpDownNegativeTests : IDisposable
 
     private static TimeCodeSettings FrameMode() => new(frameMode: true, stepMs: 100);
 
+    // Focus() alone can leave the caret placement (and with it the part the arrow keys step)
+    // a dispatcher frame behind on a loaded runner; the first key then lands before the control
+    // has settled on the millisecond part (CI flake: Up from -100 ms left the value unchanged).
+    private static void FocusAndSettle(TextBox textBox)
+    {
+        textBox.Focus();
+        Dispatcher.UIThread.RunJobs();
+    }
+
     private (Window window, TimeCodeUpDown control, TextBox textBox) Show(TimeCodeUpDown control)
     {
         var window = new Window { Content = control };
@@ -135,7 +145,7 @@ public partial class TimeCodeUpDownNegativeTests : IDisposable
         var control = new TimeCodeUpDown { Value = TimeSpan.FromMilliseconds(-1500) };
         var (window, _, textBox) = Show(control);
 
-        textBox.Focus();
+        FocusAndSettle(textBox);
         textBox.CaretIndex = 8; // the seconds part of "-00:00:01,500"
         window.KeyTextInput("7");
 
@@ -153,7 +163,7 @@ public partial class TimeCodeUpDownNegativeTests : IDisposable
         var control = new TimeCodeUpDown { Value = TimeSpan.FromMilliseconds(-1500) };
         var (window, _, textBox) = Show(control);
 
-        textBox.Focus();
+        FocusAndSettle(textBox);
         window.KeyPress(Key.Down, RawInputModifiers.None, PhysicalKey.ArrowDown, null);
         Assert.Equal(-1600, control.Value.TotalMilliseconds); // milliseconds, not hours
 
@@ -171,7 +181,7 @@ public partial class TimeCodeUpDownNegativeTests : IDisposable
         var control = new TimeCodeUpDown { Value = TimeSpan.FromMilliseconds(-100) };
         var (window, _, textBox) = Show(control);
 
-        textBox.Focus();
+        FocusAndSettle(textBox);
         var caretOnMilliseconds = textBox.CaretIndex;
         Assert.Equal(10, caretOnMilliseconds); // "-00:00:00,100"
 
@@ -195,7 +205,7 @@ public partial class TimeCodeUpDownNegativeTests : IDisposable
         var control = new TimeCodeUpDown { Value = TimeSpan.FromMilliseconds(-1500) };
         var (window, _, textBox) = Show(control);
 
-        textBox.Focus();
+        FocusAndSettle(textBox);
         textBox.CaretIndex = 1; // first hour digit of "-00:00:01,500"
         window.KeyPress(Key.Left, RawInputModifiers.None, PhysicalKey.ArrowLeft, null);
 

--- a/tests/UI/Features/Assa/FontCollectorEmbeddedMatchTests.cs
+++ b/tests/UI/Features/Assa/FontCollectorEmbeddedMatchTests.cs
@@ -86,7 +86,9 @@ public class FontCollectorEmbeddedMatchTests
 
         Assert.Single(embedded);
         Assert.True(embedded[0].Bytes.Length >= bytes.Length, $"decoded {embedded[0].Bytes.Length} < original {bytes.Length}");
-        Assert.Equal(bytes, embedded[0].Bytes.Take(bytes.Length));
+        // Span compare, not Assert.Equal over the enumerable: xUnit walks a real font file
+        // (Arial is ~1 MB) byte by byte through IEnumerable, which took ~3 s on its own.
+        Assert.True(embedded[0].Bytes.AsSpan(0, bytes.Length).SequenceEqual(bytes), "decoded bytes differ from the original font");
 
         using var typeface = SKTypeface.FromData(SKData.CreateCopy(embedded[0].Bytes));
         Assert.NotNull(typeface);

--- a/tests/UI/Features/Main/MainMenuKeyboardActivationTests.cs
+++ b/tests/UI/Features/Main/MainMenuKeyboardActivationTests.cs
@@ -212,11 +212,17 @@ public class MainMenuKeyboardActivationTests : IDisposable
         PressAndRelease(window, PhysicalKey.AltLeft, RawInputModifiers.Alt);
         await WaitUntil(() => vm.Menu.IsOpen, "bare Alt should open the menu bar");
 
+        // Opening the bar and focusing its first header are two steps; a Down delivered between
+        // them goes to the grid and opens nothing (CI flake: "Down should focus the first
+        // drop-down item"). Wait for the header to hold focus before sending the next key.
+        await WaitUntil(() => IsFocusOnMenuItem(window), "bare Alt should focus the first top-level menu item");
+        var header = window.FocusManager?.GetFocusedElement();
+
         // Down opens the File drop-down and focuses its first item. (The headless platform hosts
         // drop-downs in the window's overlay layer, so this cannot reproduce the desktop bug
         // where they live in a separate popup top-level - the test below covers that part.)
         PressAndRelease(window, PhysicalKey.ArrowDown, RawInputModifiers.None);
-        await WaitUntil(() => IsFocusOnMenuItem(window), "Down should focus the first drop-down item");
+        await WaitUntil(() => IsFocusOnMenuItem(window) && !ReferenceEquals(header, window.FocusManager?.GetFocusedElement()), "Down should focus the first drop-down item");
 
         PressAndRelease(window, PhysicalKey.AltLeft, RawInputModifiers.Alt);
 

--- a/tests/UI/Features/SpellCheck/SpellCheckPlayCurrentLineTests.cs
+++ b/tests/UI/Features/SpellCheck/SpellCheckPlayCurrentLineTests.cs
@@ -2,11 +2,13 @@ using Avalonia.Headless.XUnit;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.SpellCheck;
 using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
 using Nikse.SubtitleEdit.Logic.Ocr;
 using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 using System;
 using System.Collections.ObjectModel;
+using System.IO;
 
 namespace UITests.Features.SpellCheck;
 
@@ -15,8 +17,21 @@ namespace UITests.Features.SpellCheck;
 /// player - on speech-to-text output the audio is often the only thing that says what an unknown
 /// word should be, and until this you had to close the window to listen (issue #14145).
 /// </summary>
-public class SpellCheckPlayCurrentLineTests
+public class SpellCheckPlayCurrentLineTests : IDisposable
 {
+    private readonly string _dictionariesFolder = Se.DictionariesFolder;
+
+    public SpellCheckPlayCurrentLineTests()
+    {
+        // The CI runner has no dictionaries installed; make the local run take the same path.
+        Se.DictionariesFolder = Path.Combine(Path.GetTempPath(), "se-spellcheck-test-no-dictionaries");
+    }
+
+    public void Dispose()
+    {
+        Se.DictionariesFolder = _dictionariesFolder;
+    }
+
     private sealed class NullServiceProvider : IServiceProvider
     {
         public object? GetService(Type serviceType) => null;
@@ -41,12 +56,24 @@ public class SpellCheckPlayCurrentLineTests
 
     private static SpellCheckViewModel MakeViewModel()
     {
-        return new SpellCheckViewModel(
+        var vm = new SpellCheckViewModel(
             new SpellCheckManager(),
             new WindowService(new NullServiceProvider()),
             new FileHelper(),
             new BluRayHelper(),
             new OcrImageSourceHolder());
+
+        // With no dictionary installed (the CI runner) Initialize posts the "get dictionaries"
+        // dialog at Background priority; the null service provider then throws inside that
+        // posted job, on whichever test happens to pump the dispatcher next - this class or a
+        // later one. A dictionary entry whose file does not exist is enough to skip the dialog:
+        // the spell checker fails to load it and the scan finds nothing.
+        vm.Dictionaries.Add(new SpellCheckDictionaryDisplay
+        {
+            Name = "English",
+            DictionaryFileName = Path.Combine(Path.GetTempPath(), "se-spellcheck-test-missing", "en_US.dic"),
+        });
+        return vm;
     }
 
     [AvaloniaFact]

--- a/tests/UI/Features/Tools/FixCommonErrors/FixCommonErrorsUnfixableErrorsTests.cs
+++ b/tests/UI/Features/Tools/FixCommonErrors/FixCommonErrorsUnfixableErrorsTests.cs
@@ -15,9 +15,19 @@ namespace UITests.Features.Tools.FixCommonErrors;
 public class FixCommonErrorsUnfixableErrorsTests : IDisposable
 {
     private readonly List<SeFixCommonErrorsProfile> _originalProfiles;
+    private readonly int _minimumDisplayMs = Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds;
+    private readonly int _minimumGapMs = Configuration.Settings.General.MinimumMillisecondsBetweenLines;
+    private readonly bool _allowMoveStartTime = Configuration.Settings.Tools.FixShortDisplayTimesAllowMoveStartTime;
 
     public FixCommonErrorsUnfixableErrorsTests()
     {
+        // The rule reads libse's Configuration.Settings, a mirror that any earlier test can have
+        // left with other values (a zero minimum gap turns the "unfixable" line below into one
+        // that can be extended by 20 ms). Pin what the scenario depends on.
+        Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds = 1000;
+        Configuration.Settings.General.MinimumMillisecondsBetweenLines = 24;
+        Configuration.Settings.Tools.FixShortDisplayTimesAllowMoveStartTime = false;
+
         // Se.Settings is static and starts out without profiles in tests; the scan does nothing
         // without one. Restored in Dispose so no other test sees this profile.
         _originalProfiles = Se.Settings.Tools.FixCommonErrors.Profiles;
@@ -34,6 +44,9 @@ public class FixCommonErrorsUnfixableErrorsTests : IDisposable
     public void Dispose()
     {
         Se.Settings.Tools.FixCommonErrors.Profiles = _originalProfiles;
+        Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds = _minimumDisplayMs;
+        Configuration.Settings.General.MinimumMillisecondsBetweenLines = _minimumGapMs;
+        Configuration.Settings.Tools.FixShortDisplayTimesAllowMoveStartTime = _allowMoveStartTime;
     }
 
     /// <summary>

--- a/tests/UI/Features/Video/SpeechToText/SpeechToTextPostProcessorTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/SpeechToTextPostProcessorTests.cs
@@ -221,11 +221,16 @@ public class SpeechToTextQualityReportTests
         var oldMin = Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds;
         var oldMaxLen = Configuration.Settings.General.SubtitleLineMaximumLength;
         var oldMaxLines = Configuration.Settings.General.MaxNumberOfLines;
+        var oldMinGap = Configuration.Settings.General.MinimumMillisecondsBetweenLines;
         try
         {
             Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds = 1000;
             Configuration.Settings.General.SubtitleLineMaximumLength = 43;
             Configuration.Settings.General.MaxNumberOfLines = 2;
+            // The split spaces the halves by this gap and the short-duration fix keeps it; an
+            // earlier test leaving the mirror at 0 made the halves touch and the first half
+            // unfixable (order-dependent CI flake).
+            Configuration.Settings.General.MinimumMillisecondsBetweenLines = 24;
 
             // Long enough to be split into two lines, short enough that each half is < 1 s.
             var text = "This is the first sentence of the line. This is the second sentence of the line. And a third sentence too.";
@@ -246,6 +251,7 @@ public class SpeechToTextQualityReportTests
             Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds = oldMin;
             Configuration.Settings.General.SubtitleLineMaximumLength = oldMaxLen;
             Configuration.Settings.General.MaxNumberOfLines = oldMaxLines;
+            Configuration.Settings.General.MinimumMillisecondsBetweenLines = oldMinGap;
         }
     }
 }

--- a/tests/UI/Logic/SplitManagerTests.cs
+++ b/tests/UI/Logic/SplitManagerTests.cs
@@ -7,8 +7,21 @@ using System.Collections.ObjectModel;
 
 namespace UITests.Logic;
 
-public class SplitManagerTests
+public class SplitManagerTests : IDisposable
 {
+    // Nearly every test below zeroes the minimum gap and none of them put it back, so the whole
+    // rest of the run inherited gap 0 - and the next MainView host mirrored it into libse's
+    // Configuration.Settings, where FixShortDisplayTimes (Fix common errors, speech-to-text post
+    // processing) then extended lines it must not touch (CI flake, order-dependent).
+    private readonly int _minimumBetweenLinesMs = Se.Settings.General.MinimumBetweenLines.Milliseconds;
+    private readonly int _minimumBetweenLinesFrames = Se.Settings.General.MinimumBetweenLines.Frames;
+
+    public void Dispose()
+    {
+        Se.Settings.General.MinimumBetweenLines.Milliseconds = _minimumBetweenLinesMs;
+        Se.Settings.General.MinimumBetweenLines.Frames = _minimumBetweenLinesFrames;
+    }
+
     private static SubtitleLineViewModel MakeSubtitle(string text, double startSec, double endSec) =>
         new()
         {

--- a/tests/UI/Logic/UndoRedo/UndoRedoManagerTests.cs
+++ b/tests/UI/Logic/UndoRedo/UndoRedoManagerTests.cs
@@ -621,15 +621,27 @@ public class UndoRedoManagerTests
         manager.SetupChangeDetection(client, TimeSpan.FromHours(1));
         manager.StartChangeDetection();
 
-        var firstTick = Task.Run(() => manager.CheckForChanges(null), cancellationToken);
-        Assert.True(client.HashEntered.Wait(TimeSpan.FromSeconds(10), cancellationToken));
+        // A dedicated thread, not Task.Run: the first tick must be inside the client before the
+        // overlapping one is issued, and a queued thread-pool work item can sit behind blocked
+        // pool threads left by earlier tests for longer than the wait below (CI flake: HashEntered
+        // never set within 10 s while the tick had not even started).
+        var firstTick = new Thread(() => manager.CheckForChanges(null)) { IsBackground = true, Name = "undo-first-tick" };
+        firstTick.Start();
+        try
+        {
+            Assert.True(client.HashEntered.Wait(TimeSpan.FromSeconds(10), cancellationToken), "the first tick never reached the client");
 
-        manager.CheckForChanges(null); // overlapping tick while the first is blocked
+            manager.CheckForChanges(null); // overlapping tick while the first is blocked
 
-        Assert.Equal(1, Volatile.Read(ref client.HashCalls));
+            Assert.Equal(1, Volatile.Read(ref client.HashCalls));
+        }
+        finally
+        {
+            client.ReleaseHash.Set();
+            Assert.True(firstTick.Join(TimeSpan.FromSeconds(10)), "the first tick did not finish after release");
+        }
 
-        client.ReleaseHash.Set();
-        await firstTick.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+        await Task.CompletedTask;
     }
 
     // -----------------------------------------------------------------------

--- a/tests/UI/Logic/VideoPlayers/LibMpvEventLoopTests.cs
+++ b/tests/UI/Logic/VideoPlayers/LibMpvEventLoopTests.cs
@@ -513,7 +513,9 @@ public class LibMpvEventLoopTests
 
         try
         {
-            var missing = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".wav");
+            // A video extension: for an audio extension LoadFile polls the duration for up to
+            // 2.5 s after the (failed) open, which is all this test used to spend.
+            var missing = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".mp4");
             try
             {
                 await player.LoadFile(missing);


### PR DESCRIPTION
## What

Triage of the first-attempt failures in the last ~60 `tests.yml` runs (via the "Flaky test run" annotations), plus an after-each-test probe run locally that logged libse settings, thread-pool size and the focused window after every test.

### Flakes fixed

| Test | Hits | Cause |
|---|---|---|
| `FixCommonErrorsUnfixableErrorsTests.Scan_ReportsErrorsThatCouldNotBeFixed` | 4 (3 red through the retry) | `SplitManagerTests` sets `MinimumBetweenLines.Milliseconds = 0` in nearly every test and never restores it; the next MainView host mirrors 0 into libse, and the "unfixable" 300 ms line becomes extendable by 20 ms |
| `SpeechToTextQualityReportTests.Fix_FixShortDuration_RunsAfterSplitLines` | 2 | same leak, split halves end up touching |
| `UndoRedoManagerTests.CheckForChanges_OverlappingTick` | 3 | first tick queued via `Task.Run` starved behind blocked pool threads (pool is 40-130 threads deep by then); now a dedicated thread |
| `SpellCheckPlayCurrentLineTests.*` (cleanup failures) | 1 block | no dictionaries on CI → `Initialize` posts the get-dictionaries dialog at Background priority → null service provider throws inside the posted job. Reproduced locally by pointing `Se.DictionariesFolder` at an empty dir; a seeded dictionary entry skips the dialog |
| `MainMenuKeyboardActivationTests.BareAlt_ClosesTheMenu_WhileFocusIsInsideAnOpenDropDown` | 2 + local | Down sent before the first header holds focus |
| `TimeCodeUpDownNegativeTests.SteppingAcrossZeroUpdatesSignAndCaret` | 1 | first key before the focus settled |

Also closes the window `AudioVisualizerOriginalTextTests` left open (the only unclosed window in the suite).

Not touched: `BurnInWindowTests` failures were both on one PR branch (a real regression there, since fixed).

### Speed

| Test | Before | After |
|---|---|---|
| `LibMpvEventLoopTests.EventLoop_ForwardsMpvWarningsAndErrors` | 2.5 s (15 s in one run) | 30 ms |
| `FontCollectorEmbeddedMatchTests.EmbeddedFontRoundTrip_DecodesToLoadableTypeface` | 2.9 s | 26 ms |

Nothing was removed; the remaining slow classes (`MultipleReplacePreviewTests` ~9 s on a real 250 ms timer, `MainReadOnlyOriginalTests` ~8 s of MainView hosting) are legitimately waiting.

## Verification

Full `UITests` locally: two runs before the change failed one test each (menu drop-down; STT short duration), two runs after are clean (4894 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
