### PR TITLE
Make the unfixable short-display-time test independent of the gap setting

### DIFF
--- a/tests/UI/Features/Tools/FixCommonErrors/FixCommonErrorsUnfixableErrorsTests.cs
+++ b/tests/UI/Features/Tools/FixCommonErrors/FixCommonErrorsUnfixableErrorsTests.cs
@@ -37,15 +37,17 @@ public class FixCommonErrorsUnfixableErrorsTests : IDisposable
     }
 
     /// <summary>
-    /// A 300 ms line (below the 1000 ms minimum) that starts at zero and is followed immediately
-    /// (within the minimum gap): it cannot be made longer at all, not even partially, and cannot
-    /// be started earlier (it starts at zero), which is the branch that logs "Unable to fix text number...".
+    /// A 300 ms line (below the 1000 ms minimum) that starts at zero and is followed back-to-back
+    /// (next line starts where this one ends, so there is no room whatever the minimum-gap
+    /// setting is - it is static and other tests may change it): it cannot be made longer at all,
+    /// not even partially, and cannot be started earlier (it starts at zero), which is the branch
+    /// that logs "Unable to fix text number...".
     /// </summary>
     private static FixCommonErrorsViewModel BuildViewModelWithUnfixableShortDisplayTime()
     {
         var subtitle = new Subtitle();
         subtitle.Paragraphs.Add(new Paragraph("Hello there", 0, 300));
-        subtitle.Paragraphs.Add(new Paragraph("Goodbye there", 320, 3000));
+        subtitle.Paragraphs.Add(new Paragraph("Goodbye there", 300, 3000));
         subtitle.Renumber();
 
         var vm = new FixCommonErrorsViewModel(new FakeNamesList(), null!, null!);


### PR DESCRIPTION
CI on main (and on #14590) fails in `FixCommonErrorsUnfixableErrorsTests.Scan_ReportsErrorsThatCouldNotBeFixed`: since #14576 "Fix short display time" extends into whatever gap exists, and the test's 20 ms gap was only "no room" while the static `MinimumMillisecondsBetweenLines` was still 24. Other tests can change it, so the 300 ms line got extended to 320 ms.

The next line now starts back-to-back at 300 ms, so the case is unfixable for any gap value. Test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)