### PR TITLE
Main window: stop timers and undo polling on close, start them on Loaded (UI suite 2m20s → ~55s)

### DIFF
--- a/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
+++ b/src/ui/Features/Edit/MultipleReplace/MultipleReplaceViewModel.cs
@@ -59,6 +59,16 @@ public partial class MultipleReplaceViewModel : ObservableObject
     // compiled cache: see GetRegexError.
     private readonly ConcurrentDictionary<string, string?> _regExErrors;
     private readonly Timer _timerReplace;
+
+    /// <summary>
+    /// The preview debounce (250 ms). Internal so the headless tests, which can only observe the
+    /// preview by waiting for this timer, can shorten it instead of sleeping through it.
+    /// </summary>
+    internal double PreviewIntervalMs
+    {
+        get => _timerReplace.Interval;
+        set => _timerReplace.Interval = value;
+    }
     private readonly object _previewLock = new();
     private volatile bool _dirty;
     private volatile bool _closed;

--- a/src/ui/Features/Main/MainView.cs
+++ b/src/ui/Features/Main/MainView.cs
@@ -62,6 +62,7 @@ public class MainView : ViewBase
             {
                 _vm.OnLoaded();
             };
+            _vm.Window.Closed += (_, _) => _vm.StopBackgroundWork();
 
             // Clipboard-manager compatibility (Ditto, CopyQ, ClipClip, ...) - see the
             // hook for what it intercepts and why (#13822).

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -24863,9 +24863,7 @@ public partial class MainViewModel :
 
     private void CleanUp()
     {
-        _positionTimer.Stop();
-        _cursorTimer?.Stop();
-        _slowTimer.Stop();
+        StopBackgroundWork();
 
         if (_findViewModel != null)
         {
@@ -24973,6 +24971,8 @@ public partial class MainViewModel :
 
     internal void OnLoaded()
     {
+        StartBackgroundWork();
+
         if (OperatingSystem.IsMacOS())
         {
             Layout.InitNativeMacMenu.Sync(this);
@@ -25146,7 +25146,13 @@ public partial class MainViewModel :
 
             await Task.Delay(1000); // delay 1 second (off UI thread)          
 
-            _undoRedoManager.StartChangeDetection();
+            // The window can be gone again within that second (a test host, or a New window
+            // closed at once); StopBackgroundWork has run then and the poll must stay off.
+            if (_positionTimer.IsRunning)
+            {
+                _undoRedoManager.StartChangeDetection();
+            }
+
             _loading = false;
 
             Dispatcher.UIThread.Post(void () =>
@@ -30191,7 +30197,6 @@ public partial class MainViewModel :
                 _avLastScrolling = isAvScrolloing;
             }
         };
-        _positionTimer.Start();
 
         // Dedicated high-frequency cursor timer (~60 fps). It only advances the interpolated
         // playhead and updates the waveform/video cursor position, which is cheap now that the
@@ -30297,7 +30302,6 @@ public partial class MainViewModel :
                 _pausedCenterLastSeconds = est;
             }
         }, DispatcherPriority.Normal);
-        _cursorTimer.Start();
 
         _slowTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(400) };
         _slowTimer.Tick += (s, e) =>
@@ -30327,7 +30331,35 @@ public partial class MainViewModel :
 
             TryRefreshVideoPreview();
         };
+    }
+
+    /// <summary>
+    /// Starts the position/cursor/slow timers. Called from <see cref="OnLoaded"/>, not from the
+    /// constructor: a view model without a shown window (File > New window before it is up,
+    /// and every headless test that builds one) has nothing for them to drive, and each
+    /// UiTickPump is a dedicated thread - hundreds of never-stopped 16/50 ms pumps and 400 ms
+    /// hash passes were running on the shared UI thread by the end of a test run.
+    /// </summary>
+    internal void StartBackgroundWork()
+    {
+        _positionTimer.Start();
+        _cursorTimer?.Start();
         _slowTimer.Start();
+    }
+
+    /// <summary>
+    /// Stops the timers and the undo change-detection poll. Runs on <see cref="CleanUp"/> and
+    /// when the host window closes (also without OnClosing, e.g. a test host that detaches the
+    /// save prompt), so an editor window's pumps do not outlive it - the change-detection tick
+    /// in particular does a blocking Dispatcher.Invoke and parked one thread-pool thread per
+    /// closed window for the rest of the process.
+    /// </summary>
+    internal void StopBackgroundWork()
+    {
+        _positionTimer.Stop();
+        _cursorTimer?.Stop();
+        _slowTimer.Stop();
+        _undoRedoManager.StopChangeDetection();
     }
 
     // Preview settle window after the last keystroke. Deliberately shorter than

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsViewModel.cs
@@ -30,10 +30,10 @@ namespace Nikse.SubtitleEdit.Features.Tools.FixCommonErrors;
 public partial class FixCommonErrorsViewModel : ObservableObject, IFixCallbacks
 {
     // A scan often takes only a frame or two, so "Analyzing..." has to be held for a moment to be seen at all.
-    private const int AnalysingMinimumVisibleMilliseconds = 250;
+    internal static int AnalysingMinimumVisibleMilliseconds = 250; // static, not const: tests zero it
 
     // Long enough for the dispatcher to get a frame out before the scan blocks the UI thread again.
-    private const int AnalysingPaintDelayMilliseconds = 20;
+    internal static int AnalysingPaintDelayMilliseconds = 20;
 
     [ObservableProperty] private string _searchText;
     [ObservableProperty] private ObservableCollection<LanguageDisplayItem> _languages;

--- a/tests/UI/Features/Edit/MultipleReplaceMoveFocusTests.cs
+++ b/tests/UI/Features/Edit/MultipleReplaceMoveFocusTests.cs
@@ -47,6 +47,7 @@ public class MultipleReplaceMoveFocusTests : IDisposable
     private (MultipleReplaceViewModel Vm, Window Window) Open()
     {
         var vm = new MultipleReplaceViewModel(new WindowService(new NullServiceProvider()), new FileHelper());
+        vm.PreviewIntervalMs = 25; // the tests wait for the preview timer; see PreviewIntervalMs
         vm.Nodes.Clear();
 
         for (var c = 1; c <= 2; c++)

--- a/tests/UI/Features/Edit/MultipleReplaceMoveTests.cs
+++ b/tests/UI/Features/Edit/MultipleReplaceMoveTests.cs
@@ -29,6 +29,7 @@ public class MultipleReplaceMoveTests
     private static MultipleReplaceViewModel BuildViewModel()
     {
         var vm = new MultipleReplaceViewModel(new WindowService(new NullServiceProvider()), new FileHelper());
+        vm.PreviewIntervalMs = 25; // the tests wait for the preview timer; see PreviewIntervalMs
         vm.Nodes.Clear();
 
         for (var c = 1; c <= 3; c++)

--- a/tests/UI/Features/Edit/MultipleReplaceParagraphIdTests.cs
+++ b/tests/UI/Features/Edit/MultipleReplaceParagraphIdTests.cs
@@ -70,6 +70,7 @@ public class MultipleReplaceParagraphIdTests
     private static (MultipleReplaceViewModel Vm, List<Guid?> Ids) WithThreeMatchingLines()
     {
         var vm = new MultipleReplaceViewModel(new WindowService(new NullServiceProvider()), new FileHelper());
+        vm.PreviewIntervalMs = 25; // the tests wait for the preview timer; see PreviewIntervalMs
         vm.Nodes.Clear();
 
         var category = new RuleTreeNode(true) { CategoryName = "c1", IsActive = true };

--- a/tests/UI/Features/Edit/MultipleReplacePreviewTests.cs
+++ b/tests/UI/Features/Edit/MultipleReplacePreviewTests.cs
@@ -36,6 +36,7 @@ public class MultipleReplacePreviewTests
     private static MultipleReplaceViewModel NewViewModel()
     {
         var vm = new MultipleReplaceViewModel(new WindowService(new NullServiceProvider()), new FileHelper());
+        vm.PreviewIntervalMs = 25; // the tests wait for the preview timer; see PreviewIntervalMs
         vm.Nodes.Clear();
         return vm;
     }
@@ -88,7 +89,7 @@ public class MultipleReplacePreviewTests
 
     // Unconditional wait - used where the preview must be given the chance to pick up a state it
     // is expected to reject, so waiting for a fix count would return before the timer ever ticked.
-    private static void Settle(int ms = 800)
+    private static void Settle(int ms = 200) // eight 25 ms preview intervals
     {
         var end = Environment.TickCount64 + ms;
         while (Environment.TickCount64 < end)
@@ -425,6 +426,7 @@ public class MultipleReplaceCategoryActiveTests
     {
         SeedSettings();
         var vm = new MultipleReplaceViewModel(new WindowService(new NullServiceProvider()), new FileHelper());
+        vm.PreviewIntervalMs = 25; // the tests wait for the preview timer; see PreviewIntervalMs
         vm.Initialize(MakeSubtitle());
         var window = new MultipleReplaceWindow(vm);
         try
@@ -469,6 +471,7 @@ public class MultipleReplaceCategoryActiveTests
         try
         {
             var vm = new MultipleReplaceViewModel(new WindowService(new NullServiceProvider()), new FileHelper());
+        vm.PreviewIntervalMs = 25; // the tests wait for the preview timer; see PreviewIntervalMs
             var window = new MultipleReplaceWindow(vm);
             window.Show();
             Dispatcher.UIThread.RunJobs();
@@ -480,6 +483,7 @@ public class MultipleReplaceCategoryActiveTests
             Assert.False(Se.Settings.Edit.MultipleReplace.Categories.First(c => c.Name == "English").IsActive);
 
             var reopened = new MultipleReplaceViewModel(new WindowService(new NullServiceProvider()), new FileHelper());
+        reopened.PreviewIntervalMs = 25; // the tests wait for the preview timer; see PreviewIntervalMs
             Assert.False(reopened.Nodes.First(n => n.CategoryName == "English").IsActive);
             Assert.True(reopened.Nodes.First(n => n.CategoryName == "Dutch").IsActive);
         }

--- a/tests/UI/Features/Edit/MultipleReplaceRegexTimeoutTests.cs
+++ b/tests/UI/Features/Edit/MultipleReplaceRegexTimeoutTests.cs
@@ -47,6 +47,7 @@ public class MultipleReplaceRegexTimeoutTests : IDisposable
     private static MultipleReplaceViewModel NewViewModel()
     {
         var vm = new MultipleReplaceViewModel(new WindowService(new NullServiceProvider()), new FileHelper());
+        vm.PreviewIntervalMs = 25; // the tests wait for the preview timer; see PreviewIntervalMs
         vm.Nodes.Clear();
         return vm;
     }

--- a/tests/UI/Features/Edit/MultipleReplaceSelectFixesTests.cs
+++ b/tests/UI/Features/Edit/MultipleReplaceSelectFixesTests.cs
@@ -27,6 +27,7 @@ public class MultipleReplaceSelectFixesTests
     private static MultipleReplaceViewModel NewViewModel()
     {
         var vm = new MultipleReplaceViewModel(new WindowService(new NullServiceProvider()), new FileHelper());
+        vm.PreviewIntervalMs = 25; // the tests wait for the preview timer; see PreviewIntervalMs
         vm.Nodes.Clear();
         return vm;
     }

--- a/tests/UI/Features/Edit/MultipleReplaceWindowShortcutTests.cs
+++ b/tests/UI/Features/Edit/MultipleReplaceWindowShortcutTests.cs
@@ -31,6 +31,7 @@ public class MultipleReplaceWindowShortcutTests
     private static (MultipleReplaceViewModel Vm, Window Window, RuleTreeNode Category) OpenWithThreeFixes()
     {
         var vm = new MultipleReplaceViewModel(new WindowService(new NullServiceProvider()), new FileHelper());
+        vm.PreviewIntervalMs = 25; // the tests wait for the preview timer; see PreviewIntervalMs
         vm.Nodes.Clear();
 
         var category = new RuleTreeNode(true) { CategoryName = "c1", IsActive = true };

--- a/tests/UI/Features/Tools/FixCommonErrors/FixCommonErrorsUnfixableErrorsTests.cs
+++ b/tests/UI/Features/Tools/FixCommonErrors/FixCommonErrorsUnfixableErrorsTests.cs
@@ -19,8 +19,16 @@ public class FixCommonErrorsUnfixableErrorsTests : IDisposable
     private readonly int _minimumGapMs = Configuration.Settings.General.MinimumMillisecondsBetweenLines;
     private readonly bool _allowMoveStartTime = Configuration.Settings.Tools.FixShortDisplayTimesAllowMoveStartTime;
 
+    private readonly int _analysingMinimumVisibleMs = FixCommonErrorsViewModel.AnalysingMinimumVisibleMilliseconds;
+    private readonly int _analysingPaintDelayMs = FixCommonErrorsViewModel.AnalysingPaintDelayMilliseconds;
+
     public FixCommonErrorsUnfixableErrorsTests()
     {
+        // The scan keeps its "Analysing..." feedback on screen for a quarter second; nothing here
+        // looks at it.
+        FixCommonErrorsViewModel.AnalysingMinimumVisibleMilliseconds = 0;
+        FixCommonErrorsViewModel.AnalysingPaintDelayMilliseconds = 0;
+
         // The rule reads libse's Configuration.Settings, a mirror that any earlier test can have
         // left with other values (a zero minimum gap turns the "unfixable" line below into one
         // that can be extended by 20 ms). Pin what the scenario depends on.
@@ -43,6 +51,8 @@ public class FixCommonErrorsUnfixableErrorsTests : IDisposable
 
     public void Dispose()
     {
+        FixCommonErrorsViewModel.AnalysingMinimumVisibleMilliseconds = _analysingMinimumVisibleMs;
+        FixCommonErrorsViewModel.AnalysingPaintDelayMilliseconds = _analysingPaintDelayMs;
         Se.Settings.Tools.FixCommonErrors.Profiles = _originalProfiles;
         Configuration.Settings.General.SubtitleMinimumDisplayMilliseconds = _minimumDisplayMs;
         Configuration.Settings.General.MinimumMillisecondsBetweenLines = _minimumGapMs;


### PR DESCRIPTION
## What

Follow-up to #14591: hunting the thread growth in the UI test suite with per-test `dotnet-stack` dumps.

### Findings

| Threads | Where | Cause |
|---|---|---|
| 318 | `UiTickPump.Loop` | `MainViewModel` started its 50 ms position pump and 16 ms cursor pump in the **constructor**; a view model whose window closed without `OnClosing` (every test host, which detaches the save prompt) or that never had a window kept them forever. The 400 ms slow timer (a full `GetFastHash` pass) ran on the shared UI thread for every one of them too. |
| 149 | `Dispatcher.Invoke` in `UndoRedoManager.CheckForChanges` | The 333 ms change-detection poll of every closed editor window kept firing; its blocking Invoke parked one pool thread per window for the rest of the process. This is the starvation behind the `OverlappingTick` flake and the 15 s mpv test in #14591. |

The same leak exists in the app for **File > New window**: closing the second editor window left its pumps and undo poll running until exit.

### Change

- `StartBackgroundWork()` runs from `OnLoaded` instead of the constructor (the timers have nothing to drive before the window is up).
- `StopBackgroundWork()` (timers + `StopChangeDetection`) runs from `CleanUp` and from the host window's `Closed` event, so it also covers a close that bypasses `OnClosing`.
- The delayed `StartChangeDetection` in `OnLoaded` is skipped when the window is already gone.
- Test speed-ups on top: `MultipleReplaceViewModel.PreviewIntervalMs` (internal) lets the tests wait 25 ms per preview settle instead of 250 ms; the fix-common-errors "Analysing…" delays are internal statics the unfixable-errors tests zero.

### Numbers (local, full `UITests`)

| | Before | After |
|---|---|---|
| Wall time | 2 m 20 s | 54 s – 61 s |
| Sum of test durations | 125 s | ~60 s |
| ThreadPool threads at end | ~200 | 9 |
| Multiple-replace test family | 18.5 s | 6.5 s |
| `SubtitleGridScrollPerformanceTests` | 11.6 s | 2.2 s |

Two full runs clean (4895 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
