### PR TITLE
Perf hunt round 19: remaining per-char Substring loops, Cavena cp1252 string cache

### DIFF
--- a/src/libse/Common/StringExtensions.cs
+++ b/src/libse/Common/StringExtensions.cs
@@ -96,6 +96,15 @@ namespace Nikse.SubtitleEdit.Core.Common
             return s.AsSpan(index).StartsWith(value.AsSpan(), comparison);
         }
 
+        /// <summary>
+        /// "Does the text before <paramref name="endExclusive"/> end with <paramref name="value"/>"
+        /// without allocating the prefix (<c>s.Substring(0, end).EndsWith(value)</c>).
+        /// </summary>
+        public static bool EndsWithAt(this string s, int endExclusive, string value, StringComparison comparison)
+        {
+            return s.AsSpan(0, endExclusive).EndsWith(value.AsSpan(), comparison);
+        }
+
         public static bool StartsWith(this string s, char c)
         {
             return s.Length > 0 && s[0] == c;

--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -1822,18 +1822,18 @@ namespace Nikse.SubtitleEdit.Core.Common
                 post.Clear();
                 int i = 0;
                 while (i < s2.Length && PrePostStringsToReverse.Contains(s2[i]) && s2[i] != '{' &&
-                       !s2.Substring(i).StartsWith("<i>", StringComparison.OrdinalIgnoreCase) &&
-                       !s2.Substring(i).StartsWith("<b>", StringComparison.OrdinalIgnoreCase) &&
-                       !s2.Substring(i).StartsWith("<font ", StringComparison.OrdinalIgnoreCase))
+                       !s2.StartsWithAt(i, "<i>", StringComparison.OrdinalIgnoreCase) &&
+                       !s2.StartsWithAt(i, "<b>", StringComparison.OrdinalIgnoreCase) &&
+                       !s2.StartsWithAt(i, "<font ", StringComparison.OrdinalIgnoreCase))
                 {
                     pre.Append(s2[i]);
                     i++;
                 }
                 int j = s2.Length - 1;
                 while (j > i && PrePostStringsToReverse.Contains(s2[j]) && s2[j] != '}' &&
-                       !s2.Substring(0, j + 1).EndsWith("</i>", StringComparison.OrdinalIgnoreCase) &&
-                       !s2.Substring(0, j + 1).EndsWith("</b>", StringComparison.OrdinalIgnoreCase) &&
-                       !s2.Substring(0, j + 1).EndsWith("</font>", StringComparison.OrdinalIgnoreCase))
+                       !s2.EndsWithAt(j + 1, "</i>", StringComparison.OrdinalIgnoreCase) &&
+                       !s2.EndsWithAt(j + 1, "</b>", StringComparison.OrdinalIgnoreCase) &&
+                       !s2.EndsWithAt(j + 1, "</font>", StringComparison.OrdinalIgnoreCase))
                 {
                     post.Append(s2[j]);
                     j--;

--- a/src/libse/Forms/FixCommonErrors/FixMissingPeriodsAtEndOfLine.cs
+++ b/src/libse/Forms/FixCommonErrors/FixMissingPeriodsAtEndOfLine.cs
@@ -13,6 +13,13 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
             public static string AddPeriods { get; set; } = "Add missing period at end of line";
         }
 
+        // Split(WordSplitChars)[0] materialized every word of the next paragraph to read one.
+        private static string FirstWord(string text)
+        {
+            var end = text.IndexOfAny(WordSplitChars);
+            return end < 0 ? text : text.Substring(0, end);
+        }
+
         private static readonly char[] WordSplitChars = { ' ', '.', ',', '-', '?', '!', ':', ';', '"', '(', ')', '[', ']', '{', '}', '|', '<', '>', '/', '+', '\r', '\n' };
 
         private static bool IsOneLineUrl(string s)
@@ -97,7 +104,7 @@ namespace Nikse.SubtitleEdit.Core.Forms.FixCommonErrors
                             if (callbacks.AllowFix(p, fixAction))
                             {
                                 string oldText = p.Text;
-                                if (callbacks.IsName(next.Text.Split(WordSplitChars)[0]))
+                                if (callbacks.IsName(FirstWord(next.Text)))
                                 {
                                     if (next.StartTime.TotalMilliseconds - p.EndTime.TotalMilliseconds > 2000)
                                     {

--- a/src/libse/SubtitleFormats/Cavena890.cs
+++ b/src/libse/SubtitleFormats/Cavena890.cs
@@ -17,6 +17,27 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         private static readonly string Cp1252FillerChar = Encoding.GetEncoding(1252).GetString(new byte[] { 0x7F });
         private static readonly string Cp1252DashChar = Encoding.GetEncoding(1252).GetString(new byte[] { 0xBE });
 
+        // FixText ran ~150 `encoding.GetString(new byte[] { .. })` calls per paragraph, each a
+        // byte[] plus a string, to build the same one- and two-byte cp1252 strings every time.
+        private static readonly Encoding Cp1252Encoding = Encoding.GetEncoding(1252);
+        private static readonly string[] Cp1252Single = new string[256];
+        private static readonly System.Collections.Concurrent.ConcurrentDictionary<int, string> Cp1252Pairs = new System.Collections.Concurrent.ConcurrentDictionary<int, string>();
+
+        private static string Cp1252(byte b)
+        {
+            return Cp1252Single[b] ??= Cp1252Encoding.GetString(new[] { b });
+        }
+
+        private static string Cp1252(byte a, byte b)
+        {
+            return Cp1252Pairs.GetOrAdd((a << 8) | b, DecodeCp1252Pair);
+        }
+
+        private static string DecodeCp1252Pair(int key)
+        {
+            return Cp1252Encoding.GetString(new[] { (byte)(key >> 8), (byte)key });
+        }
+
         public const int LanguageIdDanish = 0x07;
         public const int LanguageIdSwedish = 0x28;
         public const int LanguageIdNorwegian = 0x1e;
@@ -983,12 +1004,12 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     {
                         buffer[index] = (byte)HebrewCodes[letterIndex];
                     }
-                    else if (i + 3 < text.Length && text.Substring(i, 3) == "<i>")
+                    else if (i + 3 < text.Length && text.StartsWithAt(i, "<i>", StringComparison.Ordinal))
                     {
                         buffer[index] = 0x88;
                         skipCount = 2;
                     }
-                    else if (i + 4 <= text.Length && text.Substring(i, 4) == "</i>")
+                    else if (i + 4 <= text.Length && text.StartsWithAt(i, "</i>", StringComparison.Ordinal))
                     {
                         buffer[index] = 0x98;
                         skipCount = 3;
@@ -1022,7 +1043,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     // code wrote only the high byte of each character (dropping the low byte)
                     // and lone italic-marker bytes, so nothing could round-trip.
                     encoding = Encoding.GetEncoding(1201);
-                    if (i + 3 < text.Length && text.Substring(i, 3) == "<i>")
+                    if (i + 3 < text.Length && text.StartsWithAt(i, "<i>", StringComparison.Ordinal))
                     {
                         // In-band control code as a 0x00 XX pair - decodes to U+0088,
                         // which FixText maps back to "<i>".
@@ -1035,7 +1056,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
                         skipCount = 2;
                     }
-                    else if (i + 4 <= text.Length && text.Substring(i, 4) == "</i>")
+                    else if (i + 4 <= text.Length && text.StartsWithAt(i, "</i>", StringComparison.Ordinal))
                     {
                         if (index + 2 <= buffer.Length)
                         {
@@ -1604,12 +1625,12 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         {
                             buffer[index] = IsScandinavian(languageId) ? (byte)'?' : (byte)0xE6;
                         }
-                        else if (i + 3 < text.Length && text.Substring(i, 3) == "<i>")
+                        else if (i + 3 < text.Length && text.StartsWithAt(i, "<i>", StringComparison.Ordinal))
                         {
                             buffer[index] = 0x88;
                             skipCount = 2;
                         }
-                        else if (i + 4 <= text.Length && text.Substring(i, 4) == "</i>")
+                        else if (i + 4 <= text.Length && text.StartsWithAt(i, "</i>", StringComparison.Ordinal))
                         {
                             buffer[index] = 0x98;
                             skipCount = 3;
@@ -2082,181 +2103,181 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 // Raw-byte remappings must run before the control-code mappings below - those
                 // produce the same characters (å/æ/â...), and running these replaces later
                 // would clobber them (e.g. 0x1D -> "å" -> "[").
-                text = text.Replace(encoding.GetString(new byte[] { 0xE2 }), "@");
+                text = text.Replace(Cp1252(0xE2), "@");
                 if (languageId != LanguageIdSwedish &&
                     languageId != LanguageIdNorwegian &&
                     languageId != LanguageIdDanish)
                 {
-                    text = text.Replace(encoding.GetString(new byte[] { 0xE5 }), "[");
-                    text = text.Replace(encoding.GetString(new byte[] { 0xE6 }), "]");
+                    text = text.Replace(Cp1252(0xE5), "[");
+                    text = text.Replace(Cp1252(0xE6), "]");
                 }
 
-                text = text.Replace(encoding.GetString(new byte[] { 0x02 }), "Đ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x1B }), "æ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x1C }), "ø");
-                text = text.Replace(encoding.GetString(new byte[] { 0x1D }), "å");
-                text = text.Replace(encoding.GetString(new byte[] { 0x1E }), "Æ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x1F }), "Ø");
+                text = text.Replace(Cp1252(0x02), "Đ");
+                text = text.Replace(Cp1252(0x1B), "æ");
+                text = text.Replace(Cp1252(0x1C), "ø");
+                text = text.Replace(Cp1252(0x1D), "å");
+                text = text.Replace(Cp1252(0x1E), "Æ");
+                text = text.Replace(Cp1252(0x1F), "Ø");
 
-                text = text.Replace(encoding.GetString(new byte[] { 0x5B }), "Æ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x5C }), "Ø");
-                text = text.Replace(encoding.GetString(new byte[] { 0x5D }), "Å");
-                text = text.Replace(encoding.GetString(new byte[] { 0x7C }), "ł");
-                text = text.Replace(encoding.GetString(new byte[] { 0x7D }), "đ");
+                text = text.Replace(Cp1252(0x5B), "Æ");
+                text = text.Replace(Cp1252(0x5C), "Ø");
+                text = text.Replace(Cp1252(0x5D), "Å");
+                text = text.Replace(Cp1252(0x7C), "ł");
+                text = text.Replace(Cp1252(0x7D), "đ");
 
-                text = text.Replace(encoding.GetString(new byte[] { 0xEB }), "♪");
+                text = text.Replace(Cp1252(0xEB), "♪");
 
                 // capitals with accent grave
-                text = text.Replace(encoding.GetString(new byte[] { 0x80, 0x43 }), "C");
-                text = text.Replace(encoding.GetString(new byte[] { 0x81, 0x41 }), "À");
-                text = text.Replace(encoding.GetString(new byte[] { 0x81, 0x45 }), "È");
-                text = text.Replace(encoding.GetString(new byte[] { 0x81, 0x49 }), "Ì");
-                text = text.Replace(encoding.GetString(new byte[] { 0x81, 0x4f }), "Ò");
-                text = text.Replace(encoding.GetString(new byte[] { 0x81, 0x55 }), "Ù");
+                text = text.Replace(Cp1252(0x80, 0x43), "C");
+                text = text.Replace(Cp1252(0x81, 0x41), "À");
+                text = text.Replace(Cp1252(0x81, 0x45), "È");
+                text = text.Replace(Cp1252(0x81, 0x49), "Ì");
+                text = text.Replace(Cp1252(0x81, 0x4f), "Ò");
+                text = text.Replace(Cp1252(0x81, 0x55), "Ù");
 
                 // lowercase with accent grave
-                text = text.Replace(encoding.GetString(new byte[] { 0x81, 0x61 }), "à");
-                text = text.Replace(encoding.GetString(new byte[] { 0x81, 0x65 }), "è");
-                text = text.Replace(encoding.GetString(new byte[] { 0x81, 0x69 }), "ì");
-                text = text.Replace(encoding.GetString(new byte[] { 0x81, 0x6F }), "ò");
-                text = text.Replace(encoding.GetString(new byte[] { 0x81, 0x75 }), "ù");
+                text = text.Replace(Cp1252(0x81, 0x61), "à");
+                text = text.Replace(Cp1252(0x81, 0x65), "è");
+                text = text.Replace(Cp1252(0x81, 0x69), "ì");
+                text = text.Replace(Cp1252(0x81, 0x6F), "ò");
+                text = text.Replace(Cp1252(0x81, 0x75), "ù");
 
                 // capitals with accent aigu
-                text = text.Replace(encoding.GetString(new byte[] { 0x82, 0x41 }), "Á");
-                text = text.Replace(encoding.GetString(new byte[] { 0x82, 0x43 }), "Ć");
-                text = text.Replace(encoding.GetString(new byte[] { 0x82, 0x45 }), "É");
-                text = text.Replace(encoding.GetString(new byte[] { 0x82, 0x49 }), "Í");
-                text = text.Replace(encoding.GetString(new byte[] { 0x82, 0x4C }), "Ĺ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x82, 0x4E }), "Ń");
-                text = text.Replace(encoding.GetString(new byte[] { 0x82, 0x4F }), "Ó");
-                text = text.Replace(encoding.GetString(new byte[] { 0x82, 0x52 }), "Ŕ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x82, 0x53 }), "Ś");
-                text = text.Replace(encoding.GetString(new byte[] { 0x82, 0x55 }), "Ú");
-                text = text.Replace(encoding.GetString(new byte[] { 0x82, 0x57 }), "Ẃ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x82, 0x59 }), "Ý");
-                text = text.Replace(encoding.GetString(new byte[] { 0x82, 0x5A }), "Ź");
+                text = text.Replace(Cp1252(0x82, 0x41), "Á");
+                text = text.Replace(Cp1252(0x82, 0x43), "Ć");
+                text = text.Replace(Cp1252(0x82, 0x45), "É");
+                text = text.Replace(Cp1252(0x82, 0x49), "Í");
+                text = text.Replace(Cp1252(0x82, 0x4C), "Ĺ");
+                text = text.Replace(Cp1252(0x82, 0x4E), "Ń");
+                text = text.Replace(Cp1252(0x82, 0x4F), "Ó");
+                text = text.Replace(Cp1252(0x82, 0x52), "Ŕ");
+                text = text.Replace(Cp1252(0x82, 0x53), "Ś");
+                text = text.Replace(Cp1252(0x82, 0x55), "Ú");
+                text = text.Replace(Cp1252(0x82, 0x57), "Ẃ");
+                text = text.Replace(Cp1252(0x82, 0x59), "Ý");
+                text = text.Replace(Cp1252(0x82, 0x5A), "Ź");
 
                 // lowercase with accent aigu
-                text = text.Replace(encoding.GetString(new byte[] { 0x82, 0x61 }), "á");
-                text = text.Replace(encoding.GetString(new byte[] { 0x82, 0x63 }), "ć");
-                text = text.Replace(encoding.GetString(new byte[] { 0x82, 0x65 }), "é");
-                text = text.Replace(encoding.GetString(new byte[] { 0x82, 0x69 }), "í");
-                text = text.Replace(encoding.GetString(new byte[] { 0x82, 0x6C }), "ĺ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x82, 0x6E }), "ń");
-                text = text.Replace(encoding.GetString(new byte[] { 0x82, 0x6F }), "ó");
-                text = text.Replace(encoding.GetString(new byte[] { 0x82, 0x72 }), "ŕ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x82, 0x73 }), "ś");
-                text = text.Replace(encoding.GetString(new byte[] { 0x82, 0x75 }), "ú");
-                text = text.Replace(encoding.GetString(new byte[] { 0x82, 0x77 }), "ẃ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x82, 0x79 }), "ý");
-                text = text.Replace(encoding.GetString(new byte[] { 0x82, 0x7A }), "ź");
+                text = text.Replace(Cp1252(0x82, 0x61), "á");
+                text = text.Replace(Cp1252(0x82, 0x63), "ć");
+                text = text.Replace(Cp1252(0x82, 0x65), "é");
+                text = text.Replace(Cp1252(0x82, 0x69), "í");
+                text = text.Replace(Cp1252(0x82, 0x6C), "ĺ");
+                text = text.Replace(Cp1252(0x82, 0x6E), "ń");
+                text = text.Replace(Cp1252(0x82, 0x6F), "ó");
+                text = text.Replace(Cp1252(0x82, 0x72), "ŕ");
+                text = text.Replace(Cp1252(0x82, 0x73), "ś");
+                text = text.Replace(Cp1252(0x82, 0x75), "ú");
+                text = text.Replace(Cp1252(0x82, 0x77), "ẃ");
+                text = text.Replace(Cp1252(0x82, 0x79), "ý");
+                text = text.Replace(Cp1252(0x82, 0x7A), "ź");
 
                 // capitals with accent circonflexe
-                text = text.Replace(encoding.GetString(new byte[] { 0x83, 0x41 }), "Â");
-                text = text.Replace(encoding.GetString(new byte[] { 0x83, 0x43 }), "Ĉ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x83, 0x45 }), "Ê");
-                text = text.Replace(encoding.GetString(new byte[] { 0x83, 0x47 }), "Ĝ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x83, 0x48 }), "Ĥ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x83, 0x49 }), "Î");
-                text = text.Replace(encoding.GetString(new byte[] { 0x83, 0x4A }), "Ĵ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x83, 0x4F }), "Ô");
-                text = text.Replace(encoding.GetString(new byte[] { 0x83, 0x53 }), "Ŝ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x83, 0x55 }), "Û");
-                text = text.Replace(encoding.GetString(new byte[] { 0x83, 0x57 }), "Ŵ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x83, 0x59 }), "Ŷ");
+                text = text.Replace(Cp1252(0x83, 0x41), "Â");
+                text = text.Replace(Cp1252(0x83, 0x43), "Ĉ");
+                text = text.Replace(Cp1252(0x83, 0x45), "Ê");
+                text = text.Replace(Cp1252(0x83, 0x47), "Ĝ");
+                text = text.Replace(Cp1252(0x83, 0x48), "Ĥ");
+                text = text.Replace(Cp1252(0x83, 0x49), "Î");
+                text = text.Replace(Cp1252(0x83, 0x4A), "Ĵ");
+                text = text.Replace(Cp1252(0x83, 0x4F), "Ô");
+                text = text.Replace(Cp1252(0x83, 0x53), "Ŝ");
+                text = text.Replace(Cp1252(0x83, 0x55), "Û");
+                text = text.Replace(Cp1252(0x83, 0x57), "Ŵ");
+                text = text.Replace(Cp1252(0x83, 0x59), "Ŷ");
 
                 // lowercase with accent circonflexe
-                text = text.Replace(encoding.GetString(new byte[] { 0x83, 0x61 }), "â");
-                text = text.Replace(encoding.GetString(new byte[] { 0x83, 0x63 }), "ĉ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x83, 0x65 }), "ê");
-                text = text.Replace(encoding.GetString(new byte[] { 0x83, 0x67 }), "ĝ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x83, 0x68 }), "ĥ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x83, 0x69 }), "î");
-                text = text.Replace(encoding.GetString(new byte[] { 0x83, 0x6A }), "ĵ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x83, 0x6F }), "ô");
-                text = text.Replace(encoding.GetString(new byte[] { 0x83, 0x73 }), "ŝ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x83, 0x75 }), "û");
-                text = text.Replace(encoding.GetString(new byte[] { 0x83, 0x77 }), "ŵ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x83, 0x79 }), "ŷ");
+                text = text.Replace(Cp1252(0x83, 0x61), "â");
+                text = text.Replace(Cp1252(0x83, 0x63), "ĉ");
+                text = text.Replace(Cp1252(0x83, 0x65), "ê");
+                text = text.Replace(Cp1252(0x83, 0x67), "ĝ");
+                text = text.Replace(Cp1252(0x83, 0x68), "ĥ");
+                text = text.Replace(Cp1252(0x83, 0x69), "î");
+                text = text.Replace(Cp1252(0x83, 0x6A), "ĵ");
+                text = text.Replace(Cp1252(0x83, 0x6F), "ô");
+                text = text.Replace(Cp1252(0x83, 0x73), "ŝ");
+                text = text.Replace(Cp1252(0x83, 0x75), "û");
+                text = text.Replace(Cp1252(0x83, 0x77), "ŵ");
+                text = text.Replace(Cp1252(0x83, 0x79), "ŷ");
 
                 // capitals with caron
-                text = text.Replace(encoding.GetString(new byte[] { 0x84, 0x41 }), "Ǎ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x84, 0x43 }), "Č");
-                text = text.Replace(encoding.GetString(new byte[] { 0x84, 0x44 }), "Ď");
-                text = text.Replace(encoding.GetString(new byte[] { 0x84, 0x45 }), "Ě");
-                text = text.Replace(encoding.GetString(new byte[] { 0x84, 0x47 }), "Ǧ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x84, 0x49 }), "Ǐ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x84, 0x4C }), "Ľ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x84, 0x4E }), "Ň");
-                text = text.Replace(encoding.GetString(new byte[] { 0x84, 0x52 }), "Ř");
-                text = text.Replace(encoding.GetString(new byte[] { 0x84, 0x53 }), "Š");
-                text = text.Replace(encoding.GetString(new byte[] { 0x84, 0x54 }), "Ť");
-                text = text.Replace(encoding.GetString(new byte[] { 0x84, 0x5A }), "Ž");
+                text = text.Replace(Cp1252(0x84, 0x41), "Ǎ");
+                text = text.Replace(Cp1252(0x84, 0x43), "Č");
+                text = text.Replace(Cp1252(0x84, 0x44), "Ď");
+                text = text.Replace(Cp1252(0x84, 0x45), "Ě");
+                text = text.Replace(Cp1252(0x84, 0x47), "Ǧ");
+                text = text.Replace(Cp1252(0x84, 0x49), "Ǐ");
+                text = text.Replace(Cp1252(0x84, 0x4C), "Ľ");
+                text = text.Replace(Cp1252(0x84, 0x4E), "Ň");
+                text = text.Replace(Cp1252(0x84, 0x52), "Ř");
+                text = text.Replace(Cp1252(0x84, 0x53), "Š");
+                text = text.Replace(Cp1252(0x84, 0x54), "Ť");
+                text = text.Replace(Cp1252(0x84, 0x5A), "Ž");
 
                 // lowercase with caron
-                text = text.Replace(encoding.GetString(new byte[] { 0x84, 0x61 }), "ǎ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x84, 0x63 }), "č");
-                text = text.Replace(encoding.GetString(new byte[] { 0x84, 0x64 }), "ď");
-                text = text.Replace(encoding.GetString(new byte[] { 0x84, 0x65 }), "ě");
-                text = text.Replace(encoding.GetString(new byte[] { 0x84, 0x67 }), "ǧ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x84, 0x69 }), "ǐ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x84, 0x6C }), "ľ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x84, 0x6E }), "ň");
-                text = text.Replace(encoding.GetString(new byte[] { 0x84, 0x72 }), "ř");
-                text = text.Replace(encoding.GetString(new byte[] { 0x84, 0x73 }), "š");
-                text = text.Replace(encoding.GetString(new byte[] { 0x84, 0x74 }), "ť");
-                text = text.Replace(encoding.GetString(new byte[] { 0x84, 0x7A }), "ž");
+                text = text.Replace(Cp1252(0x84, 0x61), "ǎ");
+                text = text.Replace(Cp1252(0x84, 0x63), "č");
+                text = text.Replace(Cp1252(0x84, 0x64), "ď");
+                text = text.Replace(Cp1252(0x84, 0x65), "ě");
+                text = text.Replace(Cp1252(0x84, 0x67), "ǧ");
+                text = text.Replace(Cp1252(0x84, 0x69), "ǐ");
+                text = text.Replace(Cp1252(0x84, 0x6C), "ľ");
+                text = text.Replace(Cp1252(0x84, 0x6E), "ň");
+                text = text.Replace(Cp1252(0x84, 0x72), "ř");
+                text = text.Replace(Cp1252(0x84, 0x73), "š");
+                text = text.Replace(Cp1252(0x84, 0x74), "ť");
+                text = text.Replace(Cp1252(0x84, 0x7A), "ž");
 
                 // capitals with tilde
-                text = text.Replace(encoding.GetString(new byte[] { 0x85, 0x41 }), "Ã");
-                text = text.Replace(encoding.GetString(new byte[] { 0x85, 0x49 }), "Ĩ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x85, 0x4E }), "Ñ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x85, 0x4F }), "Õ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x85, 0x55 }), "Ũ");
+                text = text.Replace(Cp1252(0x85, 0x41), "Ã");
+                text = text.Replace(Cp1252(0x85, 0x49), "Ĩ");
+                text = text.Replace(Cp1252(0x85, 0x4E), "Ñ");
+                text = text.Replace(Cp1252(0x85, 0x4F), "Õ");
+                text = text.Replace(Cp1252(0x85, 0x55), "Ũ");
 
                 // lowercase with tilde
-                text = text.Replace(encoding.GetString(new byte[] { 0x85, 0x61 }), "ã");
-                text = text.Replace(encoding.GetString(new byte[] { 0x85, 0x69 }), "ĩ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x85, 0x6E }), "ñ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x85, 0x6F }), "õ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x85, 0x75 }), "ũ");
+                text = text.Replace(Cp1252(0x85, 0x61), "ã");
+                text = text.Replace(Cp1252(0x85, 0x69), "ĩ");
+                text = text.Replace(Cp1252(0x85, 0x6E), "ñ");
+                text = text.Replace(Cp1252(0x85, 0x6F), "õ");
+                text = text.Replace(Cp1252(0x85, 0x75), "ũ");
 
                 // capitals with trema
-                text = text.Replace(encoding.GetString(new byte[] { 0x86, 0x41 }), "Ä");
-                text = text.Replace(encoding.GetString(new byte[] { 0x86, 0x45 }), "Ë");
-                text = text.Replace(encoding.GetString(new byte[] { 0x86, 0x49 }), "Ï");
-                text = text.Replace(encoding.GetString(new byte[] { 0x86, 0x4F }), "Ö");
-                text = text.Replace(encoding.GetString(new byte[] { 0x86, 0x55 }), "Ü");
-                text = text.Replace(encoding.GetString(new byte[] { 0x86, 0x59 }), "Ÿ");
+                text = text.Replace(Cp1252(0x86, 0x41), "Ä");
+                text = text.Replace(Cp1252(0x86, 0x45), "Ë");
+                text = text.Replace(Cp1252(0x86, 0x49), "Ï");
+                text = text.Replace(Cp1252(0x86, 0x4F), "Ö");
+                text = text.Replace(Cp1252(0x86, 0x55), "Ü");
+                text = text.Replace(Cp1252(0x86, 0x59), "Ÿ");
 
                 // lowercase with trema
-                text = text.Replace(encoding.GetString(new byte[] { 0x86, 0x61 }), "ä");
-                text = text.Replace(encoding.GetString(new byte[] { 0x86, 0x65 }), "ë");
-                text = text.Replace(encoding.GetString(new byte[] { 0x86, 0x69 }), "ï");
-                text = text.Replace(encoding.GetString(new byte[] { 0x86, 0x6F }), "ö");
-                text = text.Replace(encoding.GetString(new byte[] { 0x86, 0x75 }), "ü");
-                text = text.Replace(encoding.GetString(new byte[] { 0x86, 0x79 }), "ÿ");
+                text = text.Replace(Cp1252(0x86, 0x61), "ä");
+                text = text.Replace(Cp1252(0x86, 0x65), "ë");
+                text = text.Replace(Cp1252(0x86, 0x69), "ï");
+                text = text.Replace(Cp1252(0x86, 0x6F), "ö");
+                text = text.Replace(Cp1252(0x86, 0x75), "ü");
+                text = text.Replace(Cp1252(0x86, 0x79), "ÿ");
 
                 // with ring
-                text = text.Replace(encoding.GetString(new byte[] { 0x8C, 0x61 }), "å");
-                text = text.Replace(encoding.GetString(new byte[] { 0x8C, 0x41 }), "Å");
+                text = text.Replace(Cp1252(0x8C, 0x61), "å");
+                text = text.Replace(Cp1252(0x8C, 0x41), "Å");
 
-                text = text.Replace(encoding.GetString(new byte[] { 0x88 }), "<i>");
-                text = text.Replace(encoding.GetString(new byte[] { 0x98 }), "</i>");
+                text = text.Replace(Cp1252(0x88), "<i>");
+                text = text.Replace(Cp1252(0x98), "</i>");
 
                 // ăĂ şŞ ţŢ (romanian)
-                text = text.Replace(encoding.GetString(new byte[] { 0x89, 0x61 }), "ă");
-                text = text.Replace(encoding.GetString(new byte[] { 0x89, 0x41 }), "Ă");
-                text = text.Replace(encoding.GetString(new byte[] { 0x87, 0x73 }), "ş");
-                text = text.Replace(encoding.GetString(new byte[] { 0x87, 0x53 }), "Ş");
-                text = text.Replace(encoding.GetString(new byte[] { 0x87, 0x74 }), "ţ");
-                text = text.Replace(encoding.GetString(new byte[] { 0x87, 0x54 }), "Ţ");
+                text = text.Replace(Cp1252(0x89, 0x61), "ă");
+                text = text.Replace(Cp1252(0x89, 0x41), "Ă");
+                text = text.Replace(Cp1252(0x87, 0x73), "ş");
+                text = text.Replace(Cp1252(0x87, 0x53), "Ş");
+                text = text.Replace(Cp1252(0x87, 0x74), "ţ");
+                text = text.Replace(Cp1252(0x87, 0x54), "Ţ");
 
-                text = text.Replace(encoding.GetString(new byte[] { 0x8e, 0x5a }), "Ż");
-                text = text.Replace(encoding.GetString(new byte[] { 0x8e, 0x7a }), "ż");
-                text = text.Replace(encoding.GetString(new byte[] { 0x8f, 0x41 }), "Ą");
-                text = text.Replace(encoding.GetString(new byte[] { 0x8f, 0x61 }), "ą");
-                text = text.Replace(encoding.GetString(new byte[] { 0x8f, 0x65 }), "ę");
+                text = text.Replace(Cp1252(0x8e, 0x5a), "Ż");
+                text = text.Replace(Cp1252(0x8e, 0x7a), "ż");
+                text = text.Replace(Cp1252(0x8f, 0x41), "Ą");
+                text = text.Replace(Cp1252(0x8f, 0x61), "ą");
+                text = text.Replace(Cp1252(0x8f, 0x65), "ę");
 
                 if (text.Contains("<i></i>"))
                 {
@@ -2276,10 +2297,18 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             Encoding encoding = Encoding.GetEncoding(1252);
             bool fontColorOn = false;
             var sb = new StringBuilder();
+            // One cp1252 byte decodes to one char; decode the eight colour markers once instead
+            // of a one-char string plus up to eight fresh decodes for every character.
+            var marker = new char[9];
+            for (var b = 0xf1; b <= 0xf8; b++)
+            {
+                marker[b - 0xf0] = encoding.GetString(new[] { (byte)b })[0];
+            }
+
             for (int i = 0; i < text.Length; i++)
             {
-                var s = text.Substring(i, 1);
-                if (s == encoding.GetString(new byte[] { 0xf1 }))
+                var s = text[i];
+                if (s == marker[1])
                 {
                     if (fontColorOn)
                     {
@@ -2288,7 +2317,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     sb.Append("<font color=\"#FF797D\">"); // red
                     fontColorOn = true;
                 }
-                else if (s == encoding.GetString(new byte[] { 0xf2 }))
+                else if (s == marker[2])
                 {
                     if (fontColorOn)
                     {
@@ -2297,7 +2326,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     sb.Append("<font color=\"#AAEF9E\">"); // green
                     fontColorOn = true;
                 }
-                else if (s == encoding.GetString(new byte[] { 0xf3 }))
+                else if (s == marker[3])
                 {
                     if (fontColorOn)
                     {
@@ -2306,7 +2335,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     sb.Append("<font color=\"#FAFAA8\">"); // yellow
                     fontColorOn = true;
                 }
-                else if (s == encoding.GetString(new byte[] { 0xf4 }))
+                else if (s == marker[4])
                 {
                     if (fontColorOn)
                     {
@@ -2315,7 +2344,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     sb.Append("<font color=\"#9999FF\">"); // purple
                     fontColorOn = true;
                 }
-                else if (s == encoding.GetString(new byte[] { 0xf5 }))
+                else if (s == marker[5])
                 {
                     if (fontColorOn)
                     {
@@ -2324,7 +2353,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     sb.Append("<font color=\"#FFABFB\">"); // magenta
                     fontColorOn = true;
                 }
-                else if (s == encoding.GetString(new byte[] { 0xf6 }))
+                else if (s == marker[6])
                 {
                     if (fontColorOn)
                     {
@@ -2333,7 +2362,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     sb.Append("<font color=\"#A2FEFE\">"); // cyan
                     fontColorOn = true;
                 }
-                else if (s == encoding.GetString(new byte[] { 0xf7 }))
+                else if (s == marker[7])
                 {
                     if (fontColorOn)
                     {
@@ -2341,7 +2370,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         fontColorOn = false;
                     }
                 }
-                else if (s == encoding.GetString(new byte[] { 0xf8 }))
+                else if (s == marker[8])
                 {
                     sb.Append("<font color=\"#FCC786\">"); // orange
                     fontColorOn = true;

--- a/src/libse/SubtitleFormats/DvdStudioPro.cs
+++ b/src/libse/SubtitleFormats/DvdStudioPro.cs
@@ -233,19 +233,19 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 }
                 else
                 {
-                    if (text.Substring(i).StartsWith("^I", StringComparison.Ordinal))
+                    if (text.StartsWithAt(i, "^I", StringComparison.Ordinal))
                     {
                         sb.Append(!italicOn ? "<i>" : "</i>");
                         italicOn = !italicOn;
                         skipNext = true;
                     }
-                    else if (text.Substring(i).StartsWith("^B", StringComparison.Ordinal))
+                    else if (text.StartsWithAt(i, "^B", StringComparison.Ordinal))
                     {
                         sb.Append(!boldOn ? "<b>" : "</b>");
                         boldOn = !boldOn;
                         skipNext = true;
                     }
-                    else if (text.Substring(i).StartsWith("^U", StringComparison.Ordinal))
+                    else if (text.StartsWithAt(i, "^U", StringComparison.Ordinal))
                     {
                         sb.Append(!underlineOn ? "<u>" : "</u>");
                         underlineOn = !underlineOn;

--- a/src/libse/SubtitleFormats/ESubXf.cs
+++ b/src/libse/SubtitleFormats/ESubXf.cs
@@ -114,43 +114,43 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 int i = 0;
                 while (i < line.Length)
                 {
-                    if (line.Substring(i).StartsWith("<i>", StringComparison.OrdinalIgnoreCase))
+                    if (line.StartsWithAt(i, "<i>", StringComparison.OrdinalIgnoreCase))
                     {
                         AppendText(currentText, italicOn, boldOn, underlineOn, currentColor, xml, lineNode);
                         italicOn = true;
                         i += 3;
                     }
-                    else if (line.Substring(i).StartsWith("</i>", StringComparison.OrdinalIgnoreCase))
+                    else if (line.StartsWithAt(i, "</i>", StringComparison.OrdinalIgnoreCase))
                     {
                         AppendText(currentText, italicOn, boldOn, underlineOn, currentColor, xml, lineNode);
                         italicOn = false;
                         i += 4;
                     }
-                    else if (line.Substring(i).StartsWith("<b>", StringComparison.OrdinalIgnoreCase))
+                    else if (line.StartsWithAt(i, "<b>", StringComparison.OrdinalIgnoreCase))
                     {
                         AppendText(currentText, italicOn, boldOn, underlineOn, currentColor, xml, lineNode);
                         boldOn = true;
                         i += 3;
                     }
-                    else if (line.Substring(i).StartsWith("</b>", StringComparison.OrdinalIgnoreCase))
+                    else if (line.StartsWithAt(i, "</b>", StringComparison.OrdinalIgnoreCase))
                     {
                         AppendText(currentText, italicOn, boldOn, underlineOn, currentColor, xml, lineNode);
                         boldOn = false;
                         i += 4;
                     }
-                    else if (line.Substring(i).StartsWith("<u>", StringComparison.OrdinalIgnoreCase))
+                    else if (line.StartsWithAt(i, "<u>", StringComparison.OrdinalIgnoreCase))
                     {
                         AppendText(currentText, italicOn, boldOn, underlineOn, currentColor, xml, lineNode);
                         underlineOn = true;
                         i += 3;
                     }
-                    else if (line.Substring(i).StartsWith("</u>", StringComparison.OrdinalIgnoreCase))
+                    else if (line.StartsWithAt(i, "</u>", StringComparison.OrdinalIgnoreCase))
                     {
                         AppendText(currentText, italicOn, boldOn, underlineOn, currentColor, xml, lineNode);
                         underlineOn = false;
                         i += 4;
                     }
-                    else if (line.Substring(i).StartsWith("<font ", StringComparison.OrdinalIgnoreCase))
+                    else if (line.StartsWithAt(i, "<font ", StringComparison.OrdinalIgnoreCase))
                     {
                         AppendText(currentText, italicOn, boldOn, underlineOn, currentColor, xml, lineNode);
                         currentColor = string.Empty;
@@ -178,7 +178,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             i = int.MaxValue;
                         }
                     }
-                    else if (line.Substring(i).StartsWith("</font>", StringComparison.OrdinalIgnoreCase))
+                    else if (line.StartsWithAt(i, "</font>", StringComparison.OrdinalIgnoreCase))
                     {
                         AppendText(currentText, italicOn, boldOn, underlineOn, currentColor, xml, lineNode);
                         currentColor = string.Empty;

--- a/src/libse/SubtitleFormats/TextST.cs
+++ b/src/libse/SubtitleFormats/TextST.cs
@@ -652,8 +652,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     int i = 0;
                     while (i < line.Length)
                     {
-                        string s = line.Substring(i);
-                        if (s.StartsWith("<i>", StringComparison.OrdinalIgnoreCase))
+                        // Probe the tags in place - this used to copy the rest of the line for
+                        // every character, and then a one-char string for the character itself.
+                        if (line.StartsWithAt(i, "<i>", StringComparison.OrdinalIgnoreCase))
                         {
                             italic = true;
                             if (content.Count > 0 && content[content.Count - 1] is SubtitleRegionContentChangeFontStyle)
@@ -668,7 +669,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             });
                             i += 3;
                         }
-                        else if (s.StartsWith("</i>", StringComparison.OrdinalIgnoreCase))
+                        else if (line.StartsWithAt(i, "</i>", StringComparison.OrdinalIgnoreCase))
                         {
                             italic = false;
                             AddText(sb, content);
@@ -679,7 +680,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             content.Add(new SubtitleRegionContentEndOfInlineStyle());
                             i += 4;
                         }
-                        else if (s.StartsWith("<b>", StringComparison.OrdinalIgnoreCase))
+                        else if (line.StartsWithAt(i, "<b>", StringComparison.OrdinalIgnoreCase))
                         {
                             bold = true;
                             if (content.Count > 0 && content[content.Count - 1] is SubtitleRegionContentChangeFontStyle)
@@ -694,7 +695,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             });
                             i += 3;
                         }
-                        else if (s.StartsWith("</b>", StringComparison.OrdinalIgnoreCase))
+                        else if (line.StartsWithAt(i, "</b>", StringComparison.OrdinalIgnoreCase))
                         {
                             bold = false;
                             AddText(sb, content);
@@ -707,8 +708,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         }
                         else
                         {
+                            sb.Append(line[i]);
                             i++;
-                            sb.Append(s.Substring(0, 1));
                         }
                     }
                     AddText(sb, content);

--- a/src/libse/SubtitleFormats/Ultech130.cs
+++ b/src/libse/SubtitleFormats/Ultech130.cs
@@ -68,7 +68,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     int y = 0x74 - (numberOfNewLines * 0x20);
                     for (int j = 0; j < text.Length; j++)
                     {
-                        if (text.Substring(j).StartsWith(Environment.NewLine, StringComparison.Ordinal))
+                        if (text.StartsWithAt(j, Environment.NewLine, StringComparison.Ordinal))
                         {
                             y += 0x20;
                             if (line.Length > 0)

--- a/src/libse/SubtitleFormats/UnknownSubtitle81.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle81.cs
@@ -62,12 +62,12 @@ WB,GDMX,1:33,4x3
             text = text.Replace("#", string.Empty);
             while (i < text.Length)
             {
-                if (text.Substring(i).StartsWith("<i>", StringComparison.OrdinalIgnoreCase))
+                if (text.StartsWithAt(i, "<i>", StringComparison.OrdinalIgnoreCase))
                 {
                     sb.Append("#");
                     i += 3;
                 }
-                else if (text.Substring(i).StartsWith("</i>", StringComparison.OrdinalIgnoreCase))
+                else if (text.StartsWithAt(i, "</i>", StringComparison.OrdinalIgnoreCase))
                 {
                     sb.Append("#");
                     i += 4;

--- a/tests/benchmarks/PerfHuntRound19Benchmarks.cs
+++ b/tests/benchmarks/PerfHuntRound19Benchmarks.cs
@@ -1,0 +1,189 @@
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Forms.FixCommonErrors;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System.Text;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// Round 19 performance hunt - the per-character <c>Substring</c> loops left over from round 18
+/// (ESub-XF, TextST, Ultech 130, DVD Studio Pro, Unknown 81, the right-to-left reverser,
+/// Cavena 890) plus per-paragraph allocations (Cavena's colour markers and its byte-to-string
+/// replace chain, "add missing period"'s full word split).
+/// Public entry points only, so the file runs unchanged against a baseline checkout;
+/// <see cref="SubRipControl"/> is the drift control.
+///
+/// Default job, in-process, Apple M4, .NET 10 (SubRipControl 51.5 us -> 51.5 us, identical
+/// allocations):
+///
+///   DVD Studio Pro load (400)       1,049 us -> 311 us   3.4x   12.2 MB -> 736 KB allocated
+///   Cavena 890 load (400)           3,895 us -> 1,206 us 3.2x   16.2 MB -> 1.0 MB
+///   Unknown 81 save (400)             736 us -> 228 us   3.2x   8.9 MB -> 786 KB
+///   TextST dialog segments (400)      484 us -> 163 us   3.0x   4.7 MB -> 814 KB
+///   Ultech 130 save (400)             533 us -> 337 us   1.58x  3.5 MB -> 184 KB
+///   ESub-XF save (400)              8,653 us -> 6,660 us 1.30x  17.8 MB -> 1.9 MB
+///   RTL start/end reverse (400)      94.9 us -> 84.0 us  1.13x  639 KB -> 521 KB
+///   FixMissingPeriodsAtEndOfLine      294 us -> 263 us   1.12x  612 KB -> 496 KB
+///   Cavena 890 save (400)           6,808 us -> 6,638 us 1.03x  3.8 MB -> 2.5 MB
+/// </summary>
+[MemoryDiagnoser]
+public class PerfHuntRound19Benchmarks
+{
+    private Subtitle _taggedSubtitle = new();
+    private Subtitle _periodSubtitle = new();
+    private List<string> _dvdStudioProLines = new();
+    private string[] _rtlTexts = Array.Empty<string>();
+    private string _cavenaFile = string.Empty;
+    private string _ultechFile = string.Empty;
+    private TextST.RegionStyle _regionStyle = new();
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        _taggedSubtitle = BuildTaggedSubtitle(400);
+        _periodSubtitle = BuildPeriodSubtitle(400);
+        _dvdStudioProLines = new DvdStudioPro().ToText(BuildTaggedSubtitle(400), "t").SplitToLines();
+        _rtlTexts = BuildRtlTexts(400);
+
+        var dir = Path.Combine(Path.GetTempPath(), "se-perf-round19");
+        Directory.CreateDirectory(dir);
+        _cavenaFile = Path.Combine(dir, "in.890");
+        var cavena = new Subtitle();
+        for (var i = 0; i < 400; i++)
+        {
+            cavena.Paragraphs.Add(new Paragraph($"<i>Cue {i}</i> says hello{Environment.NewLine}and then some more text {i}.", i * 3000, i * 3000 + 2500));
+        }
+
+        using (var fs = File.Create(_cavenaFile))
+        {
+            new Cavena890().Save(_cavenaFile, fs, cavena, true);
+        }
+
+        _ultechFile = Path.Combine(dir, "out.uld");
+        _regionStyle = new TextST.RegionStyle();
+    }
+
+    private static string Sentence(int i) =>
+        $"The quick brown fox number {i} jumps over the lazy dog, twice, and then rests.";
+
+    private static Subtitle BuildTaggedSubtitle(int count)
+    {
+        var s = new Subtitle();
+        for (var i = 0; i < count; i++)
+        {
+            var text = (i % 4) switch
+            {
+                0 => $"<i>{Sentence(i)}</i>{Environment.NewLine}Second line of cue {i}.",
+                1 => $"He said: <b>no</b>.{Environment.NewLine}<font color=\"#ffff00\">Yellow {i}</font> and <u>more</u>.",
+                2 => $"{Sentence(i)}{Environment.NewLine}<i>Whispered</i> reply.",
+                _ => Sentence(i),
+            };
+            s.Paragraphs.Add(new Paragraph(text, i * 3000, i * 3000 + 2500));
+        }
+
+        return s;
+    }
+
+    private static Subtitle BuildPeriodSubtitle(int count)
+    {
+        var s = new Subtitle();
+        for (var i = 0; i < count; i++)
+        {
+            // No end punctuation and the next cue starts upper-case, so the rule asks whether its first word is a name.
+            s.Paragraphs.Add(new Paragraph($"we went to the market {i}", i * 3000, i * 3000 + 1500));
+            s.Paragraphs.Add(new Paragraph($"And bought {i} apples, pears and more", i * 3000 + 1600, i * 3000 + 2900));
+        }
+
+        return s;
+    }
+
+    private static string[] BuildRtlTexts(int count)
+    {
+        var list = new string[count];
+        for (var i = 0; i < count; i++)
+        {
+            list[i] = (i % 3) switch
+            {
+                0 => $"<i>- שלום {i}, מה שלומך?</i>{Environment.NewLine}♪ טוב מאוד! ♪",
+                1 => $"{{\\an8}}<font color=\"#ffff00\">(אני {i})</font> ...",
+                _ => $"שורה רגילה {i}.",
+            };
+        }
+
+        return list;
+    }
+
+    [Benchmark]
+    public int ESubXfSave() => new ESubXf().ToText(_taggedSubtitle, "t").Length;
+
+    [Benchmark]
+    public int TextStDialogSegments()
+    {
+        var total = 0;
+        foreach (var p in _taggedSubtitle.Paragraphs)
+        {
+            total += new TextST.DialogPresentationSegment(p, _regionStyle).Regions[0].Content.Count;
+        }
+
+        return total;
+    }
+
+    [Benchmark]
+    public long UltechSave()
+    {
+        Ultech130.Save(_ultechFile, _taggedSubtitle);
+        return new FileInfo(_ultechFile).Length;
+    }
+
+    [Benchmark]
+    public int DvdStudioProLoad()
+    {
+        var s = new Subtitle();
+        new DvdStudioPro().LoadSubtitle(s, _dvdStudioProLines, "in.stl");
+        return s.Paragraphs.Count;
+    }
+
+    [Benchmark]
+    public int UnknownSubtitle81Save() => SubtitleFormat.AllSubtitleFormats.First(f => f.Name == "Unknown 81").ToText(_taggedSubtitle, "t").Length;
+
+    [Benchmark]
+    public int ReverseStartAndEndingForRightToLeft()
+    {
+        var total = 0;
+        foreach (var t in _rtlTexts)
+        {
+            total += Utilities.ReverseStartAndEndingForRightToLeft(t).Length;
+        }
+
+        return total;
+    }
+
+    [Benchmark]
+    public int Cavena890Load()
+    {
+        var s = new Subtitle();
+        new Cavena890().LoadSubtitle(s, new List<string>(), _cavenaFile);
+        return s.Paragraphs.Count;
+    }
+
+    [Benchmark]
+    public long Cavena890Save()
+    {
+        using var ms = new MemoryStream();
+        new Cavena890().Save("x.890", ms, _taggedSubtitle, true);
+        return ms.Length;
+    }
+
+    [Benchmark]
+    public int FixMissingPeriodsAtEndOfLine()
+    {
+        var copy = new Subtitle(_periodSubtitle);
+        new FixMissingPeriodsAtEndOfLine().Fix(copy, new EmptyFixCallback());
+        return copy.Paragraphs.Count;
+    }
+
+    [Benchmark]
+    public int SubRipControl() => new SubRip().ToText(_taggedSubtitle, "t").Length;
+}


### PR DESCRIPTION
Follow-up to #14594 with the candidates that round found but left. Nine verified fixes (BenchmarkDotNet default job, in-process, Apple M4, .NET 10) against a detached baseline worktree of `main`; the untouched `SubRipControl` benchmark is flat with identical allocations. Every touched function was dumped over an edge-case corpus on both sides, including the Cavena 890 and Ultech 130 output bytes and Cavena files patched with colour-marker and raw-remap bytes, and the dumps are byte-identical.

| Benchmark | Before | After | Speed-up | Allocated |
| --- | ---: | ---: | ---: | --- |
| DVD Studio Pro load (400 cues) | 1,049 us | 311 us | 3.4x | 12.2 MB -> 736 KB |
| Cavena 890 load (400) | 3,895 us | 1,206 us | 3.2x | 16.2 MB -> 1.0 MB |
| Unknown 81 save (400) | 736 us | 228 us | 3.2x | 8.9 MB -> 786 KB |
| TextST dialog segments (400) | 484 us | 163 us | 3.0x | 4.7 MB -> 814 KB |
| Ultech 130 save (400) | 533 us | 337 us | 1.58x | 3.5 MB -> 184 KB |
| ESub-XF save (400) | 8,653 us | 6,660 us | 1.30x | 17.8 MB -> 1.9 MB |
| RTL start/end reverse (400) | 94.9 us | 84.0 us | 1.13x | 639 KB -> 521 KB |
| FixMissingPeriodsAtEndOfLine | 294 us | 263 us | 1.12x | 612 KB -> 496 KB |
| Cavena 890 save (400) | 6,808 us | 6,638 us | 1.03x | 3.8 MB -> 2.5 MB |

## What was wrong
- **Per-character `Substring` probes**: `ESubXf.GenerateLineWithSpan` (eight probes per character), `TextST.DialogPresentationSegment` (copied the rest of the line and then a one-char string per character), `Ultech130.Save`, `DvdStudioPro.DecodeStyles`, `UnknownSubtitle81.EncodeText` and `Utilities.ReverseStartAndEndingForRightToLeft` (three tail copies per character at the front, a prefix copy per character at the back). All use the span-based `StartsWithAt`, plus a new `EndsWithAt`.
- **Cavena 890 reader**: `FixColors` compared a one-char string per character against eight fresh `encoding.GetString(new byte[] { .. })` decodes; `FixText` ran about 150 such decodes per paragraph for constant cp1252 strings. The markers are decoded once per call and the one- and two-byte strings come from a static cache.
- **Cavena 890 writer**: `text.Substring(i, 3) == "<i>"` per character became a span compare; the existing length guards are unchanged.
- **FixMissingPeriodsAtEndOfLine** split the whole next paragraph into words to read the first one.

Dropped during the round: caching the `new SubRip()` in `ToLowercaseButKeepTags` measured no difference at all (identical allocations), so it is not included.

## Verification
- `tests/benchmarks/PerfHuntRound19Benchmarks.cs`
- Byte-identical dump diff (58 cues per format, five Cavena language ids, patched colour/remap bytes)
- `tests/libse`: 1916 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)