### PR TITLE
Add FireRedTTS3-Base as an audio.cpp TTS engine

### DIFF
--- a/docs/features/text-to-speech.md
+++ b/docs/features/text-to-speech.md
@@ -73,6 +73,7 @@ Lines that contain only sounds or music — `♪`, `[door slams]`, `(sighs)`, or
 - **Pocket TTS (CrispASR)** — Kyutai Pocket TTS 100M; the smallest and fastest cloning engine (one 124-365 MB GGUF per language, 6 languages), and the reference is sent per request
 - **Higgs Audio v3 (audio.cpp)** — Boson AI Higgs Audio v3 4B on the audio.cpp runtime; zero-shot cloning in 100+ languages, per-request reference so switching voice does not restart the server
 - **Fish Audio S2 Pro (audio.cpp)** — Fish Audio S2 Pro on the audio.cpp runtime; zero-shot cloning in 80+ languages at 44.1 kHz, per-request reference
+- **FireRedTTS3 (audio.cpp)** — FireRedTTS3-Base on the audio.cpp runtime; zero-shot cloning in 24 languages at 24 kHz with the best published speaker similarity of the open models, per-request reference. Pick the language explicitly (there is no auto-detection); numbers and dates are only spelled out for English, Chinese and Cantonese
 
 Local downloadable engines are installed into the Subtitle Edit data folder when you accept the download prompt.
 
@@ -106,7 +107,7 @@ Notes on picking one:
 - **Highest output rate:** VoxCPM2 and dots.tts at 48 kHz, then Zonos at 44.1 kHz.
 - **MOSS-TTS is by far the largest** because its Qwen3-8B backbone needs a ~3.5 GB codec companion on top of the backbone quant. Check free disk space before selecting it.
 - Quantized engines follow the same rule as the speech-to-text models: `Q4_K` is the small fast default, `Q8_0` is close to full precision, and `F16` is rarely worth the extra gigabytes.
-- **Most of the CrispASR engines load their reference voice at server start**, so switching voice reloads the model. The exceptions are **Pocket TTS**, **VibeVoice**, **MOSS-TTS**, **CosyVoice3** and **VoxCPM2** (per-request reference) and **Qwen3 TTS** with the Voice clone model — those, the three audio.cpp engines (**IndexTTS 2.5**, **Higgs Audio v3**, **Fish Audio S2 Pro**) and the standalone OmniVoice TTS engine are what [Clone From Video (Voice of Each Line)](#clone-from-video-voice-of-each-line) can use.
+- **Most of the CrispASR engines load their reference voice at server start**, so switching voice reloads the model. The exceptions are **Pocket TTS**, **VibeVoice**, **MOSS-TTS**, **CosyVoice3** and **VoxCPM2** (per-request reference) and **Qwen3 TTS** with the Voice clone model — those, the four audio.cpp engines (**IndexTTS 2.5**, **Higgs Audio v3**, **Fish Audio S2 Pro**, **FireRedTTS3**) and the standalone OmniVoice TTS engine are what [Clone From Video (Voice of Each Line)](#clone-from-video-voice-of-each-line) can use.
 
 ## Engine Settings
 
@@ -163,7 +164,7 @@ For dubbing a video with several speakers there is a faster way than cloning eac
 
 Before generating, Subtitle Edit cuts one short reference clip per line out of the video's audio. Lines shorter than about three seconds are grown into the silence around them, but never into the neighbouring line — a reference with two speakers in it would clone the wrong person.
 
-- **Supported engines:** OmniVoice TTS, Pocket TTS (CrispASR), VibeVoice (CrispASR), MOSS-TTS (CrispASR), CosyVoice3 (CrispASR), VoxCPM2 (CrispASR), Qwen3 TTS (CrispASR) with the Voice clone model, and the audio.cpp engines IndexTTS 2.5, Higgs Audio v3 and Fish Audio S2 Pro. The entry only appears for engines that accept a reference for each line; engines that load their reference when their server starts would have to reload the model for every line.
+- **Supported engines:** OmniVoice TTS, Pocket TTS (CrispASR), VibeVoice (CrispASR), MOSS-TTS (CrispASR), CosyVoice3 (CrispASR), VoxCPM2 (CrispASR), Qwen3 TTS (CrispASR) with the Voice clone model, and the audio.cpp engines IndexTTS 2.5, Higgs Audio v3, Fish Audio S2 Pro and FireRedTTS3. The entry only appears for engines that accept a reference for each line; engines that load their reference when their server starts would have to reload the model for every line.
 - **Reference text:** if you have the original subtitle loaded next to the translation, its lines are used as the transcript of the clips — that is what the video actually says, and it makes cloning noticeably better. Without an original loaded, the line's own text is used.
 - **Test voice** previews the clone taken from the longest line of the subtitle.
 - Quality depends on the source audio. Loud music or two people talking over each other in a line makes that line's clone worse. Longer subtitle lines clone better than very short ones, so a subtitle segmented into full sentences gives the best result.

--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -306,6 +306,7 @@ public static class DependencyInjectionExtensions
         collection.AddHttpClientWithProxy<IIndexTts25AudioCppDownloadService, IndexTts25AudioCppDownloadService>();
         collection.AddHttpClientWithProxy<IHiggsTtsAudioCppDownloadService, HiggsTtsAudioCppDownloadService>();
         collection.AddHttpClientWithProxy<IFishTtsAudioCppDownloadService, FishTtsAudioCppDownloadService>();
+        collection.AddHttpClientWithProxy<IFireRedTts3AudioCppDownloadService, FireRedTts3AudioCppDownloadService>();
         collection.AddHttpClientWithProxy<ICosyVoice3CrispAsrDownloadService, CosyVoice3CrispAsrDownloadService>();
         collection.AddHttpClientWithProxy<IF5TtsCrispAsrDownloadService, F5TtsCrispAsrDownloadService>();
         collection.AddHttpClientWithProxy<IOmniVoiceCrispAsrDownloadService, OmniVoiceCrispAsrDownloadService>();

--- a/src/ui/Features/Video/TextToSpeech/AudioCppTtsSettings/AudioCppTtsSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/AudioCppTtsSettings/AudioCppTtsSettingsViewModel.cs
@@ -19,10 +19,14 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.AudioCppTtsSettings;
 
 /// <summary>
 /// Everything the shared audio.cpp settings dialog needs to know about one engine. Higgs
-/// Audio v3 and Fish Audio S2 Pro expose no per-request knobs (both auto-handle language and
-/// take their expression from the text itself), so their settings dialogs are the same shape:
-/// runtime status, two model quants, voices, folders. IndexTTS 2.5 keeps its own dialog —
-/// it has emotion and speed controls this one does not.
+/// Audio v3, Fish Audio S2 Pro and FireRedTTS3 expose no per-request knobs (language is either
+/// auto-detected or picked in the main window's combo, and expression comes from the text
+/// itself), so their settings dialogs are the same shape: runtime status, two model quants,
+/// voices, folders. IndexTTS 2.5 keeps its own dialog — it has emotion and speed controls
+/// this one does not.
+///
+/// <see cref="LicenseDefinition"/> is null for weights that need no acceptance (FireRedTTS3
+/// is Apache-2.0); <see cref="IsLicenseAccepted"/> then always returns true.
 /// </summary>
 public sealed record AudioCppTtsSettingsAdapter(
     string EngineName,
@@ -34,7 +38,7 @@ public sealed record AudioCppTtsSettingsAdapter(
     Func<string> GetModelsFolder,
     Func<string> GetVoicesFolder,
     Func<bool> IsLicenseAccepted,
-    ModelLicenseDefinition LicenseDefinition,
+    ModelLicenseDefinition? LicenseDefinition,
     Action<DownloadTtsViewModel, string> StartDownloadModels);
 
 public static class AudioCppTtsSettingsAdapters
@@ -64,6 +68,19 @@ public static class AudioCppTtsSettingsAdapters
         IsLicenseAccepted: FishTtsAudioCpp.IsLicenseAccepted,
         LicenseDefinition: FishTtsAudioCpp.LicenseDefinition,
         StartDownloadModels: (vm, modelKey) => vm.StartDownloadFishTtsAudioCppModels(modelKey));
+
+    public static AudioCppTtsSettingsAdapter FireRedTts3 { get; } = new(
+        EngineName: "FireRedTTS3 (audio.cpp)",
+        Description: new FireRedTts3AudioCpp().Description,
+        ModelKeyDefault: FireRedTts3AudioCpp.ModelKeyQ8_0,
+        ModelKeyAlt: FireRedTts3AudioCpp.ModelKeyOrig,
+        ResolveModelKey: FireRedTts3AudioCpp.ResolveModelKey,
+        AreModelsInstalled: FireRedTts3AudioCpp.AreModelsInstalled,
+        GetModelsFolder: FireRedTts3AudioCpp.GetSetModelsFolder,
+        GetVoicesFolder: FireRedTts3AudioCpp.GetSetVoicesFolder,
+        IsLicenseAccepted: () => true,
+        LicenseDefinition: null,
+        StartDownloadModels: (vm, modelKey) => vm.StartDownloadFireRedTts3AudioCppModels(modelKey));
 }
 
 public partial class AudioCppTtsSettingsViewModel : ObservableObject
@@ -205,10 +222,10 @@ public partial class AudioCppTtsSettingsViewModel : ObservableObject
 
         // Same gate as the install flow: nothing is fetched before the model licence is
         // accepted, including a download started from this dialog.
-        if (!Adapter.IsLicenseAccepted())
+        if (Adapter.LicenseDefinition is { } licenseDefinition && !Adapter.IsLicenseAccepted())
         {
             var licenseResult = await _windowService.ShowDialogAsync<ModelLicenseWindow, ModelLicenseViewModel>(
-                Window, vm => vm.Initialize(Adapter.LicenseDefinition));
+                Window, vm => vm.Initialize(licenseDefinition));
             if (!licenseResult.OkPressed || !Adapter.IsLicenseAccepted())
             {
                 return;

--- a/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DownloadTts/DownloadTtsViewModel.cs
@@ -107,6 +107,10 @@ public partial class DownloadTtsViewModel : ObservableObject
     private Task? _downloadTaskFishTtsAudioCppModels;
     private readonly MemoryStream _downloadStreamFishTtsAudioCppVoices;
     private Task? _downloadTaskFishTtsAudioCppVoices;
+    private readonly IFireRedTts3AudioCppDownloadService _fireRedTts3AudioCppDownloadService;
+    private Task? _downloadTaskFireRedTts3AudioCppModels;
+    private readonly MemoryStream _downloadStreamFireRedTts3AudioCppVoices;
+    private Task? _downloadTaskFireRedTts3AudioCppVoices;
     private readonly ICosyVoice3CrispAsrDownloadService _cosyVoice3CrispAsrDownloadService;
     private readonly IF5TtsCrispAsrDownloadService _f5TtsCrispAsrDownloadService;
     private readonly IVoxCPM2CrispAsrDownloadService _voxCPM2CrispAsrDownloadService;
@@ -150,6 +154,7 @@ public partial class DownloadTtsViewModel : ObservableObject
         IIndexTts25AudioCppDownloadService indexTts25AudioCppDownloadService,
         IHiggsTtsAudioCppDownloadService higgsTtsAudioCppDownloadService,
         IFishTtsAudioCppDownloadService fishTtsAudioCppDownloadService,
+        IFireRedTts3AudioCppDownloadService fireRedTts3AudioCppDownloadService,
         ICosyVoice3CrispAsrDownloadService cosyVoice3CrispAsrDownloadService,
         IF5TtsCrispAsrDownloadService f5TtsCrispAsrDownloadService,
         IVoxCPM2CrispAsrDownloadService voxCPM2CrispAsrDownloadService,
@@ -175,6 +180,8 @@ public partial class DownloadTtsViewModel : ObservableObject
         _downloadStreamHiggsTtsAudioCppVoices = new MemoryStream();
         _fishTtsAudioCppDownloadService = fishTtsAudioCppDownloadService;
         _downloadStreamFishTtsAudioCppVoices = new MemoryStream();
+        _fireRedTts3AudioCppDownloadService = fireRedTts3AudioCppDownloadService;
+        _downloadStreamFireRedTts3AudioCppVoices = new MemoryStream();
         _cosyVoice3CrispAsrDownloadService = cosyVoice3CrispAsrDownloadService;
         _f5TtsCrispAsrDownloadService = f5TtsCrispAsrDownloadService;
         _voxCPM2CrispAsrDownloadService = voxCPM2CrispAsrDownloadService;
@@ -1198,6 +1205,112 @@ public partial class DownloadTtsViewModel : ObservableObject
             {
                 _timer.Stop();
                 var ex = _downloadTaskFishTtsAudioCppModels.Exception?.InnerException ?? _downloadTaskFishTtsAudioCppModels.Exception;
+                if (ex is OperationCanceledException)
+                {
+                    ProgressText = Se.Language.General.DownloadCanceled;
+                    Close();
+                }
+                else
+                {
+                    ProgressText = Se.Language.General.DownloadFailed;
+                    Error = ex?.Message ?? Se.Language.General.UnknownError;
+                }
+
+                return;
+            }
+
+            if (_downloadTaskFireRedTts3AudioCppModels is { IsCompletedSuccessfully: true })
+            {
+                _timer.Stop();
+                _downloadTaskFireRedTts3AudioCppModels = null;
+
+                // Chain the shared reference-voice pack (the same voices.zip the other cloning
+                // engines use), so the voice combo is not empty on first run — this engine can
+                // only clone, it has no built-in voices.
+                var voicesFolder = FireRedTts3AudioCpp.GetSetVoicesFolder();
+                var voicesAlreadyInstalled = Directory.Exists(voicesFolder)
+                    && Directory.EnumerateFiles(voicesFolder, "*.wav").Any();
+                if (voicesAlreadyInstalled)
+                {
+                    OkPressed = true;
+                    Close();
+                    return;
+                }
+
+                TitleText = string.Format(Se.Language.General.DownloadingX, "FireRedTTS3 reference voices");
+                ProgressValue = 0;
+                ProgressText = Se.Language.General.StartingDotDotDot;
+                var voicesProgress = new Progress<float>(number =>
+                {
+                    var percentage = (int)Math.Round(number * 100.0, MidpointRounding.AwayFromZero);
+                    var pctString = percentage.ToString(CultureInfo.InvariantCulture);
+                    ProgressValue = percentage;
+                    ProgressText = string.Format(Se.Language.General.DownloadingXPercent, pctString);
+                });
+                _downloadTaskFireRedTts3AudioCppVoices = _qwen3TtsCppDownloadService.DownloadVoices(
+                    _downloadStreamFireRedTts3AudioCppVoices, voicesProgress, _cancellationTokenSource.Token);
+                // OnClosing disposes the timer, so restarting it from a chained download
+                // step threw ObjectDisposedException on a thread-pool thread (#12739).
+                if (!_isClosing)
+                {
+                    _timer.Start();
+                }
+                return;
+            }
+
+            if (_downloadTaskFireRedTts3AudioCppVoices is { IsCompletedSuccessfully: true })
+            {
+                _timer.Stop();
+                _downloadTaskFireRedTts3AudioCppVoices = null;
+                if (_downloadStreamFireRedTts3AudioCppVoices.Length > 0)
+                {
+                    var voicesFolder = FireRedTts3AudioCpp.GetSetVoicesFolder();
+                    try
+                    {
+                        _downloadStreamFireRedTts3AudioCppVoices.Position = 0;
+                        _zipUnpacker.UnpackZipStream(_downloadStreamFireRedTts3AudioCppVoices, voicesFolder, string.Empty, false, new List<string>(), null);
+                        // The pack ships at 16 kHz; FireRedTTS3 clones from 24 kHz references.
+                        ResampleVoicesTo24kHz(voicesFolder);
+                        // The pack's .txt files are attribution blurbs, not transcripts, and
+                        // this engine passes a .txt sidecar as reference_text — a blurb there
+                        // conditions the clone on text nobody spoke. Same cleanup as Qwen3.
+                        Qwen3TtsCrispAsr.NormalizeVoiceTranscripts(voicesFolder);
+                    }
+                    catch (Exception ex)
+                    {
+                        Se.LogError(ex);
+                    }
+
+                    _downloadStreamFireRedTts3AudioCppVoices.Dispose();
+                }
+
+                OkPressed = true;
+                Close();
+                return;
+            }
+
+            if (_downloadTaskFireRedTts3AudioCppVoices is { IsFaulted: true })
+            {
+                _timer.Stop();
+                _downloadTaskFireRedTts3AudioCppVoices = null;
+                if (_cancellationTokenSource.IsCancellationRequested)
+                {
+                    ProgressText = Se.Language.General.DownloadCanceled;
+                    Close();
+                    return;
+                }
+
+                // A missing voice pack is not fatal — the model is already installed and the
+                // user can import their own reference WAV.
+                OkPressed = true;
+                Close();
+                return;
+            }
+
+            if (_downloadTaskFireRedTts3AudioCppModels is { IsFaulted: true })
+            {
+                _timer.Stop();
+                var ex = _downloadTaskFireRedTts3AudioCppModels.Exception?.InnerException ?? _downloadTaskFireRedTts3AudioCppModels.Exception;
                 if (ex is OperationCanceledException)
                 {
                     ProgressText = Se.Language.General.DownloadCanceled;
@@ -2689,6 +2802,29 @@ public partial class DownloadTtsViewModel : ObservableObject
 
         _downloadTaskFishTtsAudioCppModels =
             _fishTtsAudioCppDownloadService.DownloadModels(resolved, downloadProgress, titleProgress, _cancellationTokenSource.Token);
+    }
+
+    public void StartDownloadFireRedTts3AudioCppModels(string? modelKey = null)
+    {
+        var resolved = FireRedTts3AudioCpp.ResolveModelKey(modelKey);
+        var fileName = FireRedTts3AudioCpp.GetModelFileName(resolved);
+        TitleText = string.Format(Se.Language.General.DownloadingX, $"FireRedTTS3 model ({resolved}): {fileName}");
+
+        var downloadProgress = new Progress<float>(number =>
+        {
+            var percentage = (int)Math.Round(number * 100.0, MidpointRounding.AwayFromZero);
+            var pctString = percentage.ToString(CultureInfo.InvariantCulture);
+            ProgressValue = percentage;
+            ProgressText = string.Format(Se.Language.General.DownloadingXPercent, pctString);
+        });
+
+        var titleProgress = new Action<string>(title =>
+        {
+            Dispatcher.UIThread.Post(() => TitleText = title);
+        });
+
+        _downloadTaskFireRedTts3AudioCppModels =
+            _fireRedTts3AudioCppDownloadService.DownloadModels(resolved, downloadProgress, titleProgress, _cancellationTokenSource.Token);
     }
 
     public void StartDownloadZonosTtsCrispAsrModels()

--- a/src/ui/Features/Video/TextToSpeech/Engines/AudioCppRuntime.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/AudioCppRuntime.cs
@@ -6,7 +6,7 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 
 /// <summary>
 /// The pieces of the audio.cpp install shared by every engine that runs on it (IndexTTS 2.5,
-/// Higgs Audio v3, Fish Audio S2 Pro): one binaries folder, one server executable, and one
+/// Higgs Audio v3, Fish Audio S2 Pro, FireRedTTS3): one binaries folder, one server executable, and one
 /// backend marker. The binaries are downloaded once and reused by all of them; each engine
 /// still runs its own server process on its own loopback port with its own model.
 /// </summary>

--- a/src/ui/Features/Video/TextToSpeech/Engines/FireRedTts3AudioCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/FireRedTts3AudioCpp.cs
@@ -1,0 +1,853 @@
+﻿using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// FireRedTTS3-Base (FireRed Team / Xiaohongshu) run through the audio.cpp runtime — the same
+/// pure C++/ggml install <see cref="IndexTts25AudioCpp"/>, <see cref="HiggsTtsAudioCpp"/> and
+/// <see cref="FishTtsAudioCpp"/> use (see <see cref="AudioCppRuntime"/>), so the binaries are
+/// downloaded once and shared. Zero-shot voice cloning across 24 languages, with the best
+/// published speaker similarity of the open cloning models (Seed-TTS-eval avg 78.8, MiniMax
+/// MLS-Test avg 84.8; arXiv 2608.17492). 24 kHz output.
+///
+/// Like the other audio.cpp engines, the server honours a per-request <c>voice_ref</c>, so
+/// switching voice does NOT restart the server — only a model or backend change does — which
+/// is also what makes per-line cloning ("Clone from video") free here. Unlike Higgs, the model
+/// does NOT detect the language of the input text: the request carries an explicit language
+/// tag (<see cref="FireRedTts3Languages"/>) and audio.cpp's own default is Chinese, so the
+/// language combo is mandatory here and English is pre-selected. A <c>.txt</c> sidecar next to
+/// the reference WAV (the transcript convention the cloning engines share) is passed as
+/// <c>reference_text</c>; it improves clone fidelity but is optional.
+///
+/// Licence note: the audio.cpp binaries and the FireRedTTS3 weights are both Apache-2.0, so
+/// there is no first-run licence gate — unlike Higgs and Fish on the same runtime.
+/// </summary>
+public class FireRedTts3AudioCpp : ITtsEngine, IPerLineCloneEngine
+{
+    public string Name => "FireRedTTS3 (audio.cpp)";
+    public string Description => "FireRedTTS3 (FireRed Team) voice cloning in 24 languages, via audio.cpp";
+    public bool HasLanguageParameter => true;
+    public bool HasApiKey => false;
+    public bool HasRegion => false;
+    public bool HasModel => true;
+    public bool HasKeyFile => false;
+    public bool SupportsVoiceCloning => true;
+    public bool SupportsPerLineVoiceCloning => true;
+
+    // Q8_0 is the default: same 24 kHz output as the original-precision file at 7.6 GB less on
+    // disk. audio.cpp names the unquantized package "orig" rather than bf16/f16 because the
+    // checkpoint mixes precisions per stage (Qwen3 AR, FireRed DiT flow, RedAE decoder).
+    public const string ModelKeyQ8_0 = "Q8_0 (~3.9 GB)";
+    public const string ModelKeyOrig = "Original (~11.5 GB)";
+    public const string DefaultModelKey = ModelKeyQ8_0;
+
+    public const string ModelQ8_0FileName = "fireredtts3-base-q8_0.gguf";
+    public const string ModelOrigFileName = "fireredtts3-base-orig.gguf";
+
+    /// <summary>Family name audio.cpp registers FireRedTTS3 (Base and Instruct) under.</summary>
+    public const string FamilyName = "fireredtts3";
+
+    /// <summary>Model id used in the generated server config and in each request body.</summary>
+    private const string ServerModelId = "fireredtts3";
+
+    /// <summary>
+    /// Exact byte sizes on the audio-cpp/audio.cpp-gguf HuggingFace repo. A truncated GGUF is
+    /// the single most common failure here — a download that dies partway leaves a file the
+    /// loader rejects with "GGUF tensor data range is out of bounds", so size is checked
+    /// before the server is ever started. Same guard as <see cref="IndexTts25AudioCpp"/>.
+    /// </summary>
+    private static readonly Dictionary<string, long> ExpectedFileSizes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [ModelQ8_0FileName] = 4180334848L,
+        [ModelOrigFileName] = 12301253120L,
+    };
+
+    public static string ResolveModelKey(string? modelKey)
+    {
+        if (string.IsNullOrEmpty(modelKey))
+        {
+            var saved = Se.Settings.Video.TextToSpeech.FireRedTts3AudioCppModel;
+            return string.IsNullOrEmpty(saved) ? DefaultModelKey : ResolveModelKey(saved);
+        }
+
+        return modelKey == ModelKeyOrig ? ModelKeyOrig : ModelKeyQ8_0;
+    }
+
+    public static string GetModelFileName(string? modelKey) =>
+        ResolveModelKey(modelKey) == ModelKeyOrig ? ModelOrigFileName : ModelQ8_0FileName;
+
+    private static readonly HttpClient HttpClient = new()
+    {
+        Timeout = TimeSpan.FromMinutes(10),
+    };
+
+    private static readonly SemaphoreSlim ServerLock = new(1, 1);
+    private static Process? _serverProcess;
+    private static int _serverPort;
+    private static string? _serverLaunchCommand;
+    // Only the model and the backend are baked into the running server — voice is per request.
+    private static string? _serverModelKey;
+    private static string? _serverBackend;
+    private static string? _serverExeStamp;
+    private static bool _processExitHooked;
+    private static readonly StringBuilder _serverLog = new();
+
+    private static string ServerBaseUrl => $"http://127.0.0.1:{_serverPort}";
+
+    public Task<bool> IsInstalled(string? region) => Task.FromResult(File.Exists(AudioCppRuntime.GetServerExecutable()));
+
+    public override string ToString() => Name;
+
+    /// <summary>
+    /// Per-engine working folder under TextToSpeech (voices, synthesis output). The audio.cpp
+    /// binaries are shared (<see cref="AudioCppRuntime"/>); this is not.
+    /// </summary>
+    public static string GetSetFolder()
+    {
+        if (!Directory.Exists(Se.TextToSpeechFolder))
+        {
+            Directory.CreateDirectory(Se.TextToSpeechFolder);
+        }
+
+        var folder = Path.Combine(Se.TextToSpeechFolder, "FireRedTts3AudioCpp");
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        return folder;
+    }
+
+    /// <summary>
+    /// audio.cpp is pointed at a directory, not a file, so the GGUF gets its own folder under
+    /// the shared models root: <c>&lt;data&gt;/audio.cpp/models/FireRedTTS3-Base-GGUF/</c>.
+    /// </summary>
+    public static string GetSetModelsFolder()
+    {
+        var folder = Path.Combine(AudioCppRuntime.GetSetEngineFolder(), "models", "FireRedTTS3-Base-GGUF");
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        return folder;
+    }
+
+    public static string GetSetVoicesFolder()
+    {
+        var folder = Path.Combine(GetSetFolder(), "voices");
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        SeedVoicesFromQwen3TtsCppIfEmpty(folder);
+        NormalizeVoiceTranscriptsOnce(folder);
+        return folder;
+    }
+
+    private static bool _voiceSeedAttempted;
+    private static bool _voicesNormalized;
+
+    /// <summary>
+    /// One-time per session: drop unusable ref-text sidecars (the shared pack ships Wikimedia
+    /// attribution blurbs, not transcripts) and backfill missing transcriptions from the
+    /// sibling OmniVoice pack. This engine passes the .txt sidecar as reference_text, so a
+    /// blurb there would condition the clone on text nobody spoke — same cleanup CosyVoice3
+    /// and MOSS-TTS run.
+    /// </summary>
+    private static void NormalizeVoiceTranscriptsOnce(string voicesFolder)
+    {
+        if (_voicesNormalized)
+        {
+            return;
+        }
+        _voicesNormalized = true;
+
+        Qwen3TtsCrispAsr.NormalizeVoiceTranscripts(voicesFolder);
+    }
+
+    /// <summary>
+    /// One-time best-effort seed of reference WAVs (plus their transcript sidecars) from the
+    /// shared Qwen3 voice pack, so the voice combo is not empty on first run — this engine
+    /// clones only and has no built-in voices. The pack ships at 16 kHz; FireRedTTS3 clones from
+    /// 24 kHz, so resample on seed rather than letting the server upsample per request.
+    /// </summary>
+    private static void SeedVoicesFromQwen3TtsCppIfEmpty(string voicesFolder)
+    {
+        if (_voiceSeedAttempted)
+        {
+            return;
+        }
+
+        _voiceSeedAttempted = true;
+
+        try
+        {
+            if (Directory.EnumerateFiles(voicesFolder, "*.wav").Any())
+            {
+                return;
+            }
+
+            var sourceFolder = Qwen3TtsCpp.GetSetVoicesFolder();
+            if (!Directory.Exists(sourceFolder) || !Directory.EnumerateFiles(sourceFolder, "*.wav").Any())
+            {
+                return;
+            }
+
+            foreach (var src in Directory.GetFiles(sourceFolder, "*.wav"))
+            {
+                var dest = Path.Combine(voicesFolder, Path.GetFileName(src));
+                VoiceSeedHelper.CopyOrResample(src, dest, 24000, "FireRedTTS3 (audio.cpp)");
+
+                // Bring the transcript along; NormalizeVoiceTranscriptsOnce then drops the
+                // attribution blurbs and backfills real transcripts where a sibling has them.
+                var sidecar = Path.ChangeExtension(src, ".txt");
+                var sidecarDest = Path.ChangeExtension(dest, ".txt");
+                if (File.Exists(sidecar) && !File.Exists(sidecarDest) && File.Exists(dest))
+                {
+                    File.Copy(sidecar, sidecarDest);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, "FireRedTTS3 (audio.cpp): voice seeding from the shared voice pack failed");
+        }
+    }
+
+    public static string GetModelPath(string? modelKey = null) =>
+        Path.Combine(GetSetModelsFolder(), GetModelFileName(modelKey));
+
+    public static bool IsValidLocalModelFile(string path, string fileName)
+    {
+        if (!File.Exists(path))
+        {
+            return false;
+        }
+
+        if (!ExpectedFileSizes.TryGetValue(fileName, out var expected))
+        {
+            return true;
+        }
+
+        try
+        {
+            var info = new FileInfo(path);
+
+            // FileInfo.Length reports the size of the *link* for a symlink, not of its target,
+            // so a symlinked GGUF (a reasonable way to share a 3.9 GB model between apps or
+            // put it on another disk) would look truncated — and the caller deletes files it
+            // considers truncated. Resolve to the final target before measuring.
+            var length = info.ResolveLinkTarget(returnFinalTarget: true) is FileInfo target
+                ? target.Length
+                : info.Length;
+
+            return length == expected;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public static bool AreModelsInstalled(string? modelKey = null) =>
+        IsValidLocalModelFile(GetModelPath(modelKey), GetModelFileName(modelKey));
+
+    public static DownloadHashManager.UpdateStatus GetEngineUpdateStatus()
+    {
+        var exe = AudioCppRuntime.GetServerExecutable();
+        if (!File.Exists(exe))
+        {
+            return DownloadHashManager.UpdateStatus.Unknown;
+        }
+
+        var folder = Path.GetDirectoryName(exe);
+        return string.IsNullOrEmpty(folder)
+            ? DownloadHashManager.UpdateStatus.Unknown
+            : DownloadHashManager.GetSidecarStatus(folder);
+    }
+
+    public async Task<Voice[]> GetVoices(string language)
+    {
+        var result = new List<Voice>();
+
+        // Voice cloning only — the combo stays empty until the user imports a reference WAV.
+        var voicesFolder = await Task.Run(GetSetVoicesFolder);
+        if (Directory.Exists(voicesFolder))
+        {
+            foreach (var file in Directory.GetFiles(voicesFolder, "*.wav"))
+            {
+                var name = Path.GetFileNameWithoutExtension(file).Replace('_', ' ');
+                result.Add(new Voice(new IndexTtsVoice(name, file)));
+            }
+        }
+
+        return result.ToArray();
+    }
+
+    public bool IsVoiceInstalled(Voice voice) => true;
+
+    public Task<string[]> GetRegions() => Task.FromResult(Array.Empty<string>());
+
+    public Task<string[]> GetModels() => Task.FromResult(new[] { ModelKeyQ8_0, ModelKeyOrig });
+
+    // No "Auto": the model has no language detection and audio.cpp defaults an unset tag to
+    // Chinese, so every request carries an explicit tag (English when nothing is picked).
+    public Task<TtsLanguage[]> GetLanguages(Voice voice, string? model) =>
+        Task.FromResult(FireRedTts3Languages.All);
+
+    public Task<Voice[]> RefreshVoices(string language, CancellationToken cancellationToken) =>
+        GetVoices(language);
+
+    /// <summary>
+    /// <see cref="IPerLineCloneEngine"/>: the server takes <c>voice_ref</c> as a path per request,
+    /// so the voice simply points at the cut clip - nothing is staged into this engine's own
+    /// folders. audio.cpp resamples the reference itself, so the 24 kHz clip is used as cut.
+    /// </summary>
+    public Voice? MakePerLineCloneVoice(string clipFileName, string voiceName) =>
+        new Voice(new IndexTtsVoice(voiceName, clipFileName));
+
+    /// <summary>The clip's own path, which is exactly what the voice carries.</summary>
+    public string? GetPerLineReferenceClip(Voice voice) =>
+        voice.EngineVoice is IndexTtsVoice indexVoice && !string.IsNullOrEmpty(indexVoice.FilePath)
+            ? indexVoice.FilePath
+            : null;
+
+    /// <summary>
+    /// <see cref="IPerLineCloneEngine"/>: nothing is ever staged (the voice points straight at
+    /// the clip), so there is nothing to clear between runs.
+    /// </summary>
+    public void ResetStagedPerLineReferences()
+    {
+    }
+
+    public async Task<TtsResult> Speak(
+        string text,
+        string outputFolder,
+        Voice voice,
+        TtsLanguage? language,
+        string? region,
+        string? model,
+        CancellationToken cancellationToken)
+    {
+        if (voice.EngineVoice is not IndexTtsVoice indexVoice)
+        {
+            throw new ArgumentException("Voice is not an IndexTtsVoice");
+        }
+
+        if (string.IsNullOrEmpty(indexVoice.FilePath))
+        {
+            throw new InvalidOperationException(
+                "FireRedTTS3 (audio.cpp) requires a reference voice WAV. "
+                + "Import one via the voice settings, then pick it in the voice combo. "
+                + "3-10 s of clean speech works best.");
+        }
+
+        var modelKey = ResolveModelKey(model);
+        await EnsureServerRunningAsync(modelKey, cancellationToken);
+
+        var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder), Guid.NewGuid() + ".wav");
+
+        // audio.cpp's OpenAI-style speech payload. Voice cloning goes through `voice_ref`,
+        // honoured per request — no server restart when the user switches voice.
+        // The language tag is always sent: audio.cpp's default for this family is Chinese,
+        // so an omitted tag would read every non-Chinese subtitle with a Chinese frontend.
+        var languageTag = FireRedTts3Languages.ResolveLanguageTag(language);
+        var options = new Dictionary<string, object>
+        {
+            ["language"] = languageTag,
+        };
+
+        // The transcript of the reference WAV, when the shared .txt sidecar convention has
+        // one. Optional — FireRedTTS3 clones from the audio alone — but a transcript improves
+        // clone fidelity, so pass it when it is there.
+        var referenceText = ChatterboxTtsCpp.TryReadReferenceTranscript(indexVoice.FilePath);
+        if (!string.IsNullOrEmpty(referenceText))
+        {
+            options["reference_text"] = referenceText;
+        }
+
+        // The clone ends the way the reference ends (see CloneReferenceTail), so condition on a
+        // copy whose tail is trimmed, faded and padded with silence. Falls back to the file as is.
+        var referencePath = await CloneReferenceTail.PrepareAsync(indexVoice.FilePath, Name, cancellationToken);
+        var referencePrepared = !string.Equals(referencePath, indexVoice.FilePath, StringComparison.Ordinal);
+
+        var payload = new Dictionary<string, object>
+        {
+            ["model"] = ServerModelId,
+            ["input"] = text,
+            ["response_format"] = "wav",
+            ["voice_ref"] = new Dictionary<string, object>
+            {
+                ["type"] = "path",
+                ["path"] = referencePath,
+            },
+            ["options"] = options,
+        };
+
+        var body = JsonSerializer.Serialize(payload);
+        Se.WriteToolsLog($"FireRedTTS3 (audio.cpp): POST {ServerBaseUrl}/v1/audio/speech (voice={indexVoice}, language={languageTag}, textLen={text.Length}, preparedReference={referencePrepared})");
+
+        using var content = new StringContent(body, Encoding.UTF8, "application/json");
+        HttpResponseMessage response;
+        try
+        {
+            response = await HttpClient.PostAsync($"{ServerBaseUrl}/v1/audio/speech", content, cancellationToken);
+        }
+        catch (HttpRequestException ex)
+        {
+            var serverLog = SnapshotServerLog();
+            var launchCommand = _serverLaunchCommand;
+            var died = _serverProcess?.HasExited == true;
+            if (died)
+            {
+                StopServerInternal();
+            }
+
+            var failMsg = $"FireRedTTS3 (audio.cpp) request failed — Voice: {indexVoice}, Text: {text}, "
+                + $"RequestJson: {body}, ServerExited: {died}, ServerLog: {serverLog}"
+                + LaunchCmdSuffix(launchCommand);
+            Se.LogError(ex, failMsg);
+            Se.WriteToolsLog(failMsg);
+
+            throw new InvalidOperationException(
+                (died
+                    ? "FireRedTTS3 (audio.cpp) — the audiocpp_server process crashed during synthesis."
+                    : "FireRedTTS3 (audio.cpp) request failed — the connection to audiocpp_server was dropped.")
+                + (string.IsNullOrEmpty(serverLog) ? string.Empty : $"{Environment.NewLine}Server log:{Environment.NewLine}{serverLog}")
+                + LaunchCmdSuffix(launchCommand),
+                ex);
+        }
+
+        using (response)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorBody = await SafeReadErrorAsync(response, cancellationToken);
+                var serverLog = SnapshotServerLog();
+                var launchCommand = _serverLaunchCommand;
+                var errMsg = $"FireRedTTS3 (audio.cpp) server error {(int)response.StatusCode} {response.StatusCode} — "
+                    + $"Voice: {indexVoice}, Text: {text}, RequestJson: {body}, "
+                    + $"ResponseBody: {errorBody}, ServerLog: {serverLog}"
+                    + LaunchCmdSuffix(launchCommand);
+                Se.LogError(errMsg);
+                Se.WriteToolsLog(errMsg);
+                throw new InvalidOperationException(
+                    $"FireRedTTS3 (audio.cpp) synthesis failed ({(int)response.StatusCode}): {errorBody}"
+                    + (string.IsNullOrEmpty(serverLog) ? string.Empty : $"{Environment.NewLine}Server log:{Environment.NewLine}{serverLog}")
+                    + LaunchCmdSuffix(launchCommand));
+            }
+
+            await using var fileStream = File.Create(outputFileName);
+            await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+            await contentStream.CopyToAsync(fileStream, cancellationToken);
+        }
+        return new TtsResult(outputFileName, text);
+    }
+
+    private static async Task EnsureServerRunningAsync(string modelKey, CancellationToken ct)
+    {
+        var backend = AudioCppRuntime.GetBackend();
+        var exeStamp = AudioCppRuntime.GetServerExecutableStamp();
+
+        if (_serverProcess is { HasExited: false } && _serverPort != 0
+            && string.Equals(_serverModelKey, modelKey, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(_serverBackend, backend, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(_serverExeStamp, exeStamp, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        await ServerLock.WaitAsync(ct);
+        try
+        {
+            if (_serverProcess is { HasExited: false } && _serverPort != 0
+                && string.Equals(_serverModelKey, modelKey, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(_serverBackend, backend, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(_serverExeStamp, exeStamp, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            if (_serverProcess != null)
+            {
+                StopServerInternal();
+            }
+
+            var exe = AudioCppRuntime.GetServerExecutable();
+            if (!File.Exists(exe))
+            {
+                throw new FileNotFoundException(
+                    "audio.cpp server not found. Download the FireRedTTS3 engine first.", exe);
+            }
+
+            var modelFileName = GetModelFileName(modelKey);
+            var modelPath = GetModelPath(modelKey);
+            if (!IsValidLocalModelFile(modelPath, modelFileName))
+            {
+                throw new FileNotFoundException(
+                    File.Exists(modelPath)
+                        ? $"The FireRedTTS3 model file is incomplete: {modelPath}. Delete it and download again."
+                        : $"The FireRedTTS3 model file is missing: {modelPath}",
+                    modelPath);
+            }
+
+            var port = FindFreeLoopbackPort();
+            var configPath = WriteServerConfig(port, backend, modelKey);
+
+            var psi = new ProcessStartInfo
+            {
+                WorkingDirectory = Path.GetDirectoryName(exe) ?? AudioCppRuntime.GetSetEngineFolder(),
+                FileName = exe,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                // The server writes UTF-8. Without these the reader decodes it in the OS default
+                // codepage, and non-ASCII text in the captured log - the line being synthesised,
+                // upstream's em dashes - reaches bug reports as mojibake (#13572).
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8,
+            };
+            psi.ArgumentList.Add("--config");
+            psi.ArgumentList.Add(configPath);
+
+            var process = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start audiocpp_server (fireredtts3)");
+
+            var launchCommand = FormatLaunchCommand(exe, psi.ArgumentList);
+            _serverLaunchCommand = launchCommand;
+            Se.WriteToolsLog($"FireRedTTS3 (audio.cpp) server starting — PID: {process.Id}, Cmd: {launchCommand}");
+
+            lock (_serverLog) _serverLog.Clear();
+            process.ErrorDataReceived += (_, e) =>
+            {
+                if (e.Data != null) lock (_serverLog) _serverLog.AppendLine(e.Data);
+            };
+            process.OutputDataReceived += (_, e) =>
+            {
+                if (e.Data != null) lock (_serverLog) _serverLog.AppendLine(e.Data);
+            };
+            process.BeginErrorReadLine();
+            process.BeginOutputReadLine();
+
+            _serverProcess = process;
+            _serverPort = port;
+            _serverModelKey = modelKey;
+            _serverBackend = backend;
+            _serverExeStamp = AudioCppRuntime.GetServerExecutableStamp();
+            HookProcessExitOnce();
+
+            // The config uses lazy_load, so /health answers within a second or two — the 3.9 GB
+            // model is only read on the first synthesis request. A long deadline here would just
+            // hide a crash-at-startup (e.g. a Vulkan build on a box with no Vulkan driver, which
+            // dies in the loader with 0xC0000135 before printing anything).
+            var deadline = DateTime.UtcNow.AddMinutes(2);
+            while (DateTime.UtcNow < deadline)
+            {
+                ct.ThrowIfCancellationRequested();
+                if (process.HasExited)
+                {
+                    var tail = SnapshotServerLog();
+                    var exitCode = process.ExitCode;
+                    var exitedLaunchCommand = _serverLaunchCommand;
+                    _serverProcess = null;
+                    _serverPort = 0;
+                    _serverLaunchCommand = null;
+                    _serverModelKey = null;
+                    _serverBackend = null;
+                    _serverExeStamp = null;
+                    throw new InvalidOperationException(
+                        $"audiocpp_server exited during startup (code {exitCode}). "
+                        + AudioCppRuntime.DescribeStartupExit(exitCode, backend)
+                        + $" Output: {tail}"
+                        + LaunchCmdSuffix(exitedLaunchCommand));
+                }
+
+                if (await ProbeHealthAsync(port, TimeSpan.FromSeconds(2), ct))
+                {
+                    return;
+                }
+
+                await Task.Delay(TimeSpan.FromSeconds(1), ct);
+            }
+
+            var lastOutput = SnapshotServerLog();
+            var timeoutLaunchCommand = _serverLaunchCommand;
+            StopServerInternal();
+            throw new TimeoutException(
+                $"audiocpp_server did not report healthy within 2 minutes. Last output: {lastOutput}"
+                + LaunchCmdSuffix(timeoutLaunchCommand));
+        }
+        finally
+        {
+            ServerLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Writes the audio.cpp server config next to the binary. lazy_load keeps startup instant;
+    /// the model is read on first use and then stays resident until the server is stopped.
+    /// </summary>
+    /// <remarks>
+    /// The model entry names the GGUF file, not its folder. Given a folder, audio.cpp picks
+    /// model.gguf or the sole *.gguf and refuses a folder holding several - so a user who had
+    /// downloaded both quantizations could not start the server until one was moved out of
+    /// sight (#14480). The file path is unambiguous, and auxiliary paths still resolve against
+    /// its parent.
+    /// </remarks>
+    private static string WriteServerConfig(int port, string backend, string modelKey)
+    {
+        var config = new Dictionary<string, object>
+        {
+            ["host"] = "127.0.0.1",
+            ["port"] = port,
+            ["backend"] = backend,
+            ["threads"] = Math.Max(1, Math.Min(8, Environment.ProcessorCount / 2)),
+            ["lazy_load"] = true,
+            ["models"] = new[]
+            {
+                new Dictionary<string, object>
+                {
+                    ["id"] = ServerModelId,
+                    ["family"] = FamilyName,
+                    ["path"] = GetModelPath(modelKey),
+                    // The Base package declares the clone task only (Instruct adds tts/design).
+                    ["task"] = "clon",
+                    ["mode"] = "offline",
+                },
+            },
+        };
+
+        var configPath = Path.Combine(AudioCppRuntime.GetSetEngineFolder(), "fireredtts3-server.json");
+        File.WriteAllText(
+            configPath,
+            JsonSerializer.Serialize(config, new JsonSerializerOptions { WriteIndented = true }),
+            Encoding.UTF8);
+
+        Se.WriteToolsLog($"FireRedTTS3 (audio.cpp): server config written to {configPath} (model={modelKey}, backend={backend})");
+        return configPath;
+    }
+
+    private static string FormatLaunchCommand(string exe, System.Collections.ObjectModel.Collection<string> args)
+    {
+        static string Quote(string s) =>
+            !string.IsNullOrEmpty(s) && s.IndexOfAny(new[] { ' ', '\t' }) >= 0
+                ? "\"" + s.Replace("\"", "\\\"") + "\""
+                : s;
+
+        var sb = new StringBuilder(Quote(exe));
+        foreach (var a in args)
+        {
+            sb.Append(' ').Append(Quote(a));
+        }
+
+        return sb.ToString();
+    }
+
+    private static string LaunchCmdSuffix(string? launchCommand) =>
+        string.IsNullOrEmpty(launchCommand)
+            ? string.Empty
+            : $"{Environment.NewLine}Launch command: {launchCommand}";
+
+    private static async Task<string> SafeReadErrorAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        try
+        {
+            return await response.Content.ReadAsStringAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            return $"<failed to read error body: {ex.Message}>";
+        }
+    }
+
+    private static string SnapshotServerLog()
+    {
+        lock (_serverLog)
+        {
+            var s = _serverLog.ToString().TrimEnd();
+            return s.Length > 2000 ? s[^2000..] : s;
+        }
+    }
+
+    private static async Task<bool> ProbeHealthAsync(int port, TimeSpan timeout, CancellationToken ct)
+    {
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(timeout);
+            using var resp = await HttpClient.GetAsync($"http://127.0.0.1:{port}/health", cts.Token);
+            return resp.IsSuccessStatusCode;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static int FindFreeLoopbackPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    private static void HookProcessExitOnce()
+    {
+        if (_processExitHooked)
+        {
+            return;
+        }
+
+        _processExitHooked = true;
+        AppDomain.CurrentDomain.ProcessExit += (_, _) => StopServerInternal();
+    }
+
+    /// <summary>
+    /// Stop the audio.cpp server if running, releasing the loaded model's working set.
+    /// audio.cpp never unloads a model on its own once loaded, so this is the only way the
+    /// memory comes back.
+    /// </summary>
+    public static void StopServer() => StopServerInternal();
+
+    private static void StopServerInternal()
+    {
+        var p = _serverProcess;
+        _serverProcess = null;
+        _serverPort = 0;
+        _serverLaunchCommand = null;
+        _serverModelKey = null;
+        _serverBackend = null;
+        _serverExeStamp = null;
+        if (p == null)
+        {
+            return;
+        }
+
+        try
+        {
+            if (!p.HasExited)
+            {
+                p.Kill(entireProcessTree: true);
+                p.WaitForExit(2000);
+            }
+        }
+        catch
+        {
+            // best effort
+        }
+        finally
+        {
+            p.Dispose();
+        }
+    }
+
+    private static string GetUniqueDestinationFileName(string folder, string baseName)
+    {
+        var candidate = Path.Combine(folder, baseName + ".wav");
+        if (!File.Exists(candidate))
+        {
+            return candidate;
+        }
+
+        var number = 1;
+        do
+        {
+            candidate = Path.Combine(folder, $"{baseName}_{number}.wav");
+            number++;
+        } while (File.Exists(candidate));
+
+        return candidate;
+    }
+
+    public bool ImportVoice(string fileName) => ImportVoice(fileName, string.Empty);
+
+    /// <summary>
+    /// Import with the reference transcript — the overload <see cref="VoiceCloneImporter"/>
+    /// routes to. FireRedTTS3 clones from the audio alone, but a transcript improves clone fidelity,
+    /// so it is kept as the .txt sidecar Speak passes as reference_text.
+    /// </summary>
+    public bool ImportVoice(string fileName, string transcript)
+    {
+        if (string.IsNullOrEmpty(fileName) || !File.Exists(fileName))
+        {
+            return false;
+        }
+
+        var voicesFolder = GetSetVoicesFolder();
+        var baseName = Path.GetFileNameWithoutExtension(fileName);
+        var destinationFileName = GetUniqueDestinationFileName(voicesFolder, baseName);
+
+        // audio.cpp resamples the reference itself, but importing at 24 kHz mono keeps the
+        // reference clean and matches the model's own output rate.
+        try
+        {
+            var process = FfmpegGenerator.ConvertToMono24kHzWav(fileName, destinationFileName);
+            if (!process.Start())
+            {
+                return false;
+            }
+
+            process.WaitForExit();
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, "FireRedTTS3 (audio.cpp) voice import failed (ffmpeg conversion).");
+            return false;
+        }
+
+        if (!File.Exists(destinationFileName))
+        {
+            return false;
+        }
+
+        // Caller-supplied transcript wins; otherwise fall back to a sibling .txt next to the
+        // source WAV.
+        try
+        {
+            var destSidecar = Path.ChangeExtension(destinationFileName, ".txt");
+            if (!string.IsNullOrWhiteSpace(transcript))
+            {
+                File.WriteAllText(destSidecar, transcript.Trim());
+            }
+            else
+            {
+                var sourceSidecar = Path.ChangeExtension(fileName, ".txt");
+                if (File.Exists(sourceSidecar) && !File.Exists(destSidecar))
+                {
+                    File.Copy(sourceSidecar, destSidecar);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, "FireRedTTS3 (audio.cpp) voice import: failed to write .txt sidecar");
+        }
+
+        return true;
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/Engines/FireRedTts3Languages.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/FireRedTts3Languages.cs
@@ -1,0 +1,91 @@
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// The 24 languages FireRedTTS3 is trained on (technical report arXiv 2608.17492): Arabic,
+/// Cantonese, Chinese, Czech, Dutch, English, Finnish, French, German, Greek, Hindi,
+/// Indonesian, Italian, Japanese, Korean, Polish, Portuguese, Romanian, Russian, Spanish, Thai,
+/// Turkish, Ukrainian and Vietnamese. The 21 Chinese dialect tags (<c>ZH_Sichuan</c>, ...) are
+/// deliberately left out: they need a dialect reference clip to have any effect (issue #3
+/// upstream) and are not subtitle languages.
+///
+/// audio.cpp's <c>language</c> request option takes the model's own tag, which is the English
+/// name of the language ("English", "Cantonese", ...), so <see cref="TtsLanguage.Code"/> holds
+/// that tag verbatim rather than an ISO code. There is no "Auto": the model has no language
+/// detection and audio.cpp's default for an unset tag is Chinese, so English leads the list as
+/// the pick when nothing is saved.
+///
+/// Text normalization caveat, from audio.cpp's docs/models/fireredtts3.md: numbers, dates and
+/// units are only spelled out for Chinese, English and Cantonese; the other tags get whitespace
+/// cleanup and read digits literally.
+/// </summary>
+internal static class FireRedTts3Languages
+{
+    /// <summary>FireRedTTS3 language tags, passed to audio.cpp verbatim. English first.</summary>
+    private static readonly string[] Supported =
+    {
+        "English", "Arabic", "Cantonese", "Chinese", "Czech", "Dutch", "Finnish", "French", "German",
+        "Greek", "Hindi", "Indonesian", "Italian", "Japanese", "Korean", "Polish", "Portuguese",
+        "Romanian", "Russian", "Spanish", "Thai", "Turkish", "Ukrainian", "Vietnamese",
+    };
+
+    public const string DefaultTag = "English";
+
+    /// <summary>English first (the default pick), then the other 23 sorted by name.</summary>
+    public static readonly TtsLanguage[] All = Build();
+
+    private static TtsLanguage[] Build()
+    {
+        var languages = Supported
+            .Skip(1)
+            .Select(tag => new TtsLanguage(tag, tag))
+            .OrderBy(l => l.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        languages.Insert(0, new TtsLanguage(DefaultTag, DefaultTag));
+        return languages.ToArray();
+    }
+
+    /// <summary>
+    /// The tag to send for <paramref name="language"/>. Never empty: an unset tag makes
+    /// audio.cpp fall back to Chinese, so unknown or missing picks resolve to the saved pick
+    /// and then to English.
+    /// </summary>
+    public static string ResolveLanguageTag(TtsLanguage? language)
+    {
+        // A null language means the CALLER had none to hand over, not a user choice - the cast
+        // dialog's voice-test button and cross-engine cast rows both pass null and rely on the
+        // engine falling back to its own saved default (#13272).
+        if (language == null)
+        {
+            return ResolveSavedLanguageTag();
+        }
+
+        // Guard against a language object left over from another engine (the view model can hold
+        // one while switching engines): only tags this engine actually advertises are passed on.
+        var match = All.FirstOrDefault(l =>
+            string.Equals(l.Code, language.Code, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(l.Name, language.Name, StringComparison.OrdinalIgnoreCase));
+        return match?.Code ?? ResolveSavedLanguageTag();
+    }
+
+    /// <summary>
+    /// The tag behind the pick saved by the main TTS window, or English when nothing is saved.
+    /// The setting stores the DISPLAY NAME, which is how <c>TextToSpeechViewModel</c> writes
+    /// and restores it (and here name and tag are the same string).
+    /// </summary>
+    public static string ResolveSavedLanguageTag()
+    {
+        var savedName = Se.Settings.Video.TextToSpeech.FireRedTts3AudioCppLanguage;
+        if (string.IsNullOrWhiteSpace(savedName))
+        {
+            return DefaultTag;
+        }
+
+        return All.FirstOrDefault(l => string.Equals(l.Name, savedName, StringComparison.OrdinalIgnoreCase))?.Code
+               ?? DefaultTag;
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/Engines/TtsEngineCatalog.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/TtsEngineCatalog.cs
@@ -105,6 +105,12 @@ public static class TtsEngineCatalog
             // under the Fish Audio Research License (first-run accept window).
             new FishTtsAudioCpp(),
 
+            // FireRedTTS3-Base (audio.cpp) — cloning across 24 languages with the best published
+            // speaker similarity of the open models (arXiv 2608.17492). Same shared runtime;
+            // weights are Apache-2.0, so no licence gate. Needs an explicit language pick
+            // (no detection; audio.cpp defaults to Chinese).
+            new FireRedTts3AudioCpp(),
+
             // F5-TTS (CrispASR) hidden: CrispASR 0.6.12 has no GPU backend for f5-tts, so
             // synthesis runs the fixed 32-step Euler ODE through a 22-layer DiT + Vocos on
             // CPU only. That's 3-8 minutes per short utterance on Mac CPU — unusable for the

--- a/src/ui/Features/Video/TextToSpeech/Engines/VoiceCloneImporter.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/VoiceCloneImporter.cs
@@ -34,6 +34,7 @@ public static class VoiceCloneImporter
         {
             CosyVoice3CrispAsr e => e.ImportVoice(fileName, text),
             F5TtsCrispAsr e => e.ImportVoice(fileName, text),
+            FireRedTts3AudioCpp e => e.ImportVoice(fileName, text),
             FishTtsAudioCpp e => e.ImportVoice(fileName, text),
             HiggsTtsAudioCpp e => e.ImportVoice(fileName, text),
             MossTtsCrispAsr e => e.ImportVoice(fileName, text),

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -371,6 +371,11 @@ public partial class TextToSpeechViewModel : ObservableObject
         {
             Se.Settings.Video.TextToSpeech.FishTtsAudioCppModel = SelectedModel ?? FishTtsAudioCpp.DefaultModelKey;
         }
+        else if (SelectedEngine is FireRedTts3AudioCpp)
+        {
+            Se.Settings.Video.TextToSpeech.FireRedTts3AudioCppModel = SelectedModel ?? FireRedTts3AudioCpp.DefaultModelKey;
+            Se.Settings.Video.TextToSpeech.FireRedTts3AudioCppLanguage = SelectedLanguage?.Name ?? string.Empty;
+        }
         else if (SelectedEngine is CosyVoice3CrispAsr)
         {
             Se.Settings.Video.TextToSpeech.CosyVoice3CrispAsrModel = SelectedModel ?? CosyVoice3CrispAsr.DefaultModelKey;
@@ -1073,6 +1078,7 @@ public partial class TextToSpeechViewModel : ObservableObject
         Qwen3TtsCrispAsr => Se.Settings.Video.TextToSpeech.Qwen3TtsCrispAsrLanguage,
         ChatterboxTtsCpp => Se.Settings.Video.TextToSpeech.ChatterboxCrispAsrLanguage,
         ZonosTtsCrispAsr => Se.Settings.Video.TextToSpeech.ZonosTtsCrispAsrLanguage,
+        FireRedTts3AudioCpp => Se.Settings.Video.TextToSpeech.FireRedTts3AudioCppLanguage,
         ElevenLabs => Se.Settings.Video.TextToSpeech.ElevenLabsLanguage,
         _ => null,
     };
@@ -1338,6 +1344,10 @@ public partial class TextToSpeechViewModel : ObservableObject
         if (keepAlive is not FishTtsAudioCpp)
         {
             FishTtsAudioCpp.StopServer();
+        }
+        if (keepAlive is not FireRedTts3AudioCpp)
+        {
+            FireRedTts3AudioCpp.StopServer();
         }
         if (keepAlive is not CosyVoice3CrispAsr)
         {
@@ -1638,6 +1648,9 @@ public partial class TextToSpeechViewModel : ObservableObject
             case FishTtsAudioCpp:
                 await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadFishTtsAudioCppModels(FishTtsAudioCpp.ResolveModelKey(SelectedModel)));
                 break;
+            case FireRedTts3AudioCpp:
+                await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadFireRedTts3AudioCppModels(FireRedTts3AudioCpp.ResolveModelKey(SelectedModel)));
+                break;
             case CosyVoice3CrispAsr:
                 await _windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(Window!, vm => vm.StartDownloadCosyVoice3CrispAsrModels(CosyVoice3CrispAsr.ResolveModelKey(SelectedModel)));
                 break;
@@ -1724,6 +1737,9 @@ public partial class TextToSpeechViewModel : ObservableObject
                 ? DownloadDotStatus.UpToDate
                 : DownloadDotStatus.NotInstalled,
             FishTtsAudioCpp => FishTtsAudioCpp.AreModelsInstalled(modelKey)
+                ? DownloadDotStatus.UpToDate
+                : DownloadDotStatus.NotInstalled,
+            FireRedTts3AudioCpp => FireRedTts3AudioCpp.AreModelsInstalled(modelKey)
                 ? DownloadDotStatus.UpToDate
                 : DownloadDotStatus.NotInstalled,
             CosyVoice3CrispAsr => CosyVoice3CrispAsr.AreModelsInstalled(modelKey)
@@ -4029,6 +4045,10 @@ public partial class TextToSpeechViewModel : ObservableObject
                     // detect a language), so the first-entry fallback is the backend default.
                     ZonosTtsCrispAsr => Languages.FirstOrDefault(l => l.Name == Se.Settings.Video.TextToSpeech.ZonosTtsCrispAsrLanguage)
                                         ?? Languages.FirstOrDefault(),
+                    // FireRedTTS3 leads with English too: no detection, and audio.cpp's own
+                    // fallback for an unset tag is Chinese.
+                    FireRedTts3AudioCpp => Languages.FirstOrDefault(l => l.Name == Se.Settings.Video.TextToSpeech.FireRedTts3AudioCppLanguage)
+                                           ?? Languages.FirstOrDefault(),
                     _ => Languages.FirstOrDefault(),
                 };
             }
@@ -4185,6 +4205,16 @@ public partial class TextToSpeechViewModel : ObservableObject
             else if (SelectedEngine is FishTtsAudioCpp)
             {
                 SelectedModel = Models.FirstOrDefault(p => p == Se.Settings.Video.TextToSpeech.FishTtsAudioCppModel);
+                if (string.IsNullOrEmpty(SelectedModel))
+                {
+                    SelectedModel = Models.FirstOrDefault();
+                }
+                IsEngineSettingsVisible = true;
+                IsModelDownloadVisible = true;
+            }
+            else if (SelectedEngine is FireRedTts3AudioCpp)
+            {
+                SelectedModel = Models.FirstOrDefault(p => p == Se.Settings.Video.TextToSpeech.FireRedTts3AudioCppModel);
                 if (string.IsNullOrEmpty(SelectedModel))
                 {
                     SelectedModel = Models.FirstOrDefault();

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
@@ -196,6 +196,8 @@ public class TextToSpeechWindow : Window
                 return StatusDots.From(engine.IsInstalled(null).Result, HiggsTtsAudioCpp.GetEngineUpdateStatus());
             case FishTtsAudioCpp:
                 return StatusDots.From(engine.IsInstalled(null).Result, FishTtsAudioCpp.GetEngineUpdateStatus());
+            case FireRedTts3AudioCpp:
+                return StatusDots.From(engine.IsInstalled(null).Result, FireRedTts3AudioCpp.GetEngineUpdateStatus());
             case CosyVoice3CrispAsr:
                 return StatusDots.From(engine.IsInstalled(null).Result, CosyVoice3CrispAsr.GetEngineUpdateStatus());
             case F5TtsCrispAsr:

--- a/src/ui/Features/Video/TextToSpeech/TtsEngineInstaller.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsEngineInstaller.cs
@@ -464,6 +464,19 @@ public static class TtsEngineInstaller
                 startDownloadModels: (vm, key) => vm.StartDownloadFishTtsAudioCppModels(key));
         }
 
+        if (engine is FireRedTts3AudioCpp)
+        {
+            // Apache-2.0 weights: no licence gate, otherwise the same runtime + model flow.
+            return await EnsureAudioCppEngineWithLicense(
+                window, windowService, refreshVoices,
+                engineDisplayName: "FireRedTTS3",
+                licenseDefinition: null,
+                isLicenseAccepted: () => true,
+                modelKey: FireRedTts3AudioCpp.ResolveModelKey(model),
+                areModelsInstalled: FireRedTts3AudioCpp.AreModelsInstalled,
+                startDownloadModels: (vm, key) => vm.StartDownloadFireRedTts3AudioCppModels(key));
+        }
+
         if (engine is ZonosTtsCrispAsr)
         {
             if (!await TtsVoiceInstaller.EnsureCrispAsrForZonos(window, windowService, forceRedownload: false))
@@ -1000,13 +1013,14 @@ public static class TtsEngineInstaller
         IWindowService windowService,
         Func<Task> refreshVoices,
         string engineDisplayName,
-        ModelLicenseDefinition licenseDefinition,
+        ModelLicenseDefinition? licenseDefinition,
         Func<bool> isLicenseAccepted,
         string modelKey,
         Func<string?, bool> areModelsInstalled,
         Action<DownloadTtsViewModel, string> startDownloadModels)
     {
-        if (!isLicenseAccepted())
+        // A null definition means the weights need no acceptance (Apache-2.0 FireRedTTS3).
+        if (licenseDefinition != null && !isLicenseAccepted())
         {
             var licenseResult = await windowService.ShowDialogAsync<ModelLicenseWindow, ModelLicenseViewModel>(
                 window, vm => vm.Initialize(licenseDefinition));

--- a/src/ui/Features/Video/TextToSpeech/TtsEngineSettingsDialog.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsEngineSettingsDialog.cs
@@ -44,6 +44,7 @@ public static class TtsEngineSettingsDialog
         IndexTts25AudioCpp or
         HiggsTtsAudioCpp or
         FishTtsAudioCpp or
+        FireRedTts3AudioCpp or
         IndexTtsCrispAsr or
         DotsTtsCrispAsr or
         Confucius4TtsCrispAsr or
@@ -87,6 +88,10 @@ public static class TtsEngineSettingsDialog
         else if (engine is FishTtsAudioCpp)
         {
             await windowService.ShowDialogAsync<AudioCppTtsSettingsWindow, AudioCppTtsSettingsViewModel>(window, vm => vm.Initialize(AudioCppTtsSettingsAdapters.Fish));
+        }
+        else if (engine is FireRedTts3AudioCpp)
+        {
+            await windowService.ShowDialogAsync<AudioCppTtsSettingsWindow, AudioCppTtsSettingsViewModel>(window, vm => vm.Initialize(AudioCppTtsSettingsAdapters.FireRedTts3));
         }
         else if (engine is IndexTtsCrispAsr)
         {

--- a/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
@@ -312,13 +312,14 @@ public static class TtsVoiceInstaller
             return false;
         }
 
-        // The three audio.cpp engines share this binary. A server started from the old build
+        // The four audio.cpp engines share this binary. A server started from the old build
         // must go before the archive is extracted: on Windows the running exe cannot be
         // overwritten at all, and elsewhere the stale process would keep answering requests
         // (and reject any model family the new build added) until Subtitle Edit restarts.
         IndexTts25AudioCpp.StopServer();
         HiggsTtsAudioCpp.StopServer();
         FishTtsAudioCpp.StopServer();
+        FireRedTts3AudioCpp.StopServer();
 
         var dlResult = await windowService.ShowDialogAsync<DownloadTtsWindow, DownloadTtsViewModel>(
             window, vm => vm.StartDownloadIndexTts25AudioCppEngine(backend));

--- a/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
@@ -312,6 +312,29 @@ public partial class VoiceSettingsViewModel : ObservableObject
                 ? higgsEngine.ImportVoice(fileName, (result.Text ?? string.Empty).Trim())
                 : higgsEngine.ImportVoice(fileName);
         }
+        else if (_engine is FireRedTts3AudioCpp fireRedEngine)
+        {
+            // FireRedTTS3 clones zero-shot from audio alone; a transcription (reference_text) is
+            // optional but improves quality, so prompt like VoxCPM2 while allowing an empty
+            // answer.
+            var transcript = TryReadSiblingTranscript(fileName) ?? string.Empty;
+            var audioFileName = fileName;
+            var result = await _windowService.ShowDialogAsync<PromptTextBoxWindow, PromptTextBoxViewModel>(Window!, vm =>
+            {
+                vm.Initialize(
+                    Se.Language.Video.TextToSpeech.VoiceCloneTranscriptTitle,
+                    transcript,
+                    500,
+                    150);
+                vm.ConfigureExtraButton(
+                    Se.Language.Video.TextToSpeech.UseSpeechToTextDotDotDot,
+                    () => RunSpeechToTextAsync(audioFileName));
+            });
+
+            ok = result.OkPressed
+                ? fireRedEngine.ImportVoice(fileName, (result.Text ?? string.Empty).Trim())
+                : fireRedEngine.ImportVoice(fileName);
+        }
         else if (_engine is MossTtsCrispAsr mossEngine)
         {
             // MOSS-TTS clones zero-shot from audio alone; a transcription (ref-text) is optional

--- a/src/ui/Logic/Config/SeVideoTextToSpeech.cs
+++ b/src/ui/Logic/Config/SeVideoTextToSpeech.cs
@@ -72,6 +72,8 @@ public class SeVideoTextToSpeech
     // Fish Audio S2 Pro (audio.cpp). Same sharing as above.
     public string FishTtsAudioCppModel { get; set; }
     public string FishTtsAudioCppLicenseAccepted { get; set; }
+    public string FireRedTts3AudioCppModel { get; set; }
+    public string FireRedTts3AudioCppLanguage { get; set; }
     public string CosyVoice3CrispAsrModel { get; set; }
     public double CosyVoice3CrispAsrSpeed { get; set; }
     // Display name of the picked CosyVoice3 target language ("Auto" = plain zero-shot cloning).
@@ -210,6 +212,8 @@ public class SeVideoTextToSpeech
         HiggsTtsAudioCppLicenseAccepted = string.Empty;
         FishTtsAudioCppModel = "Q8_0 (~5.9 GB)";
         FishTtsAudioCppLicenseAccepted = string.Empty;
+        FireRedTts3AudioCppModel = "Q8_0 (~3.9 GB)";
+        FireRedTts3AudioCppLanguage = string.Empty;
         CosyVoice3CrispAsrModel = "Q4_K (~1.6 GB total)";
         CosyVoice3CrispAsrSpeed = 1.0;
         CosyVoice3CrispAsrLanguage = string.Empty;

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -2008,10 +2008,11 @@ public static class DownloadHashManager
             },
 
             // audio.cpp engine archives we build in SubtitleEdit/support-files
-            // (audiocpp-indextts25-2026-09-05). Newest first — index 0 is the pinned release,
+            // (audiocpp-indextts25-2026-09-06). Newest first — index 0 is the pinned release,
             // so anything older prompts an update instead of being treated as current.
             [IndexTts25AudioCpp.EngineMacArm64] = new[]
             {
+                "9c710294a00f9f6b34377de909f511fa8648e85c00a7591062a85559613874a6", // audiocpp-indextts25-macos-arm64.tar.gz (2026-09-06, upstream main b0757573 + index_tts2 + higgs_audio_tts + fish_audio + fireredtts3)
                 "97586f22f059c64e5c566064361ce14a21f5d45b72b7cc5c5a81c6743ac29fe8", // audiocpp-indextts25-macos-arm64.tar.gz (2026-09-05, upstream main a8fccb47 + Higgs #454 tail fix + higgs_audio_tts + fish_audio)
                 "54697920bdbc009d15a9e23a205c366e9137cf206258e0c97c8536ce6a2e78f7", // audiocpp-indextts25-macos-arm64.tar.gz (2026-09-04, upstream main ad4bd574 + higgs_audio_tts + fish_audio)
                 "b9fe7380a54f4c3021061448dbb2eefc2d6248cd82f4bad7eae4201571d4070d", // audiocpp-indextts25-macos-arm64.tar.gz (2026-09-01, upstream v0.7.1 + higgs_audio_tts + fish_audio)
@@ -2020,6 +2021,7 @@ public static class DownloadHashManager
             },
             [IndexTts25AudioCpp.EngineWindowsCpu] = new[]
             {
+                "6a1ca661819eaa68cc7f48af490da2afd46c3f56df8d8c59b6738dcbe3c32907", // audiocpp-indextts25-windows-x86_64-cpu.zip (2026-09-06, upstream main b0757573 + index_tts2 + higgs_audio_tts + fish_audio + fireredtts3)
                 "9455171707020cb8a8122f1589d39538405d2736af9b50ce812e1dedf97598d4", // audiocpp-indextts25-windows-x86_64-cpu.zip (2026-09-05, upstream main a8fccb47 + Higgs #454 tail fix + higgs_audio_tts + fish_audio)
                 "19e91cd7164a44c1ebf6e0f63283865af470b249ea642287309200c3beae5958", // audiocpp-indextts25-windows-x86_64-cpu.zip (2026-09-04, upstream main ad4bd574 + higgs_audio_tts + fish_audio)
                 "f4bbf0a5fa5e263abf05aa1e2597b9f4e36055ca1d0a6243a959734f912e9d15", // audiocpp-indextts25-windows-x86_64-cpu.zip (2026-09-01, upstream v0.7.1 + higgs_audio_tts + fish_audio)
@@ -2028,6 +2030,7 @@ public static class DownloadHashManager
             },
             [IndexTts25AudioCpp.EngineWindowsVulkan] = new[]
             {
+                "4f5e1bef273404021b5ea0f270798fe36368d536dcc433d8bec75ac803c6b7fa", // audiocpp-indextts25-windows-x86_64-vulkan.zip (2026-09-06, upstream main b0757573 + index_tts2 + higgs_audio_tts + fish_audio + fireredtts3)
                 "95e1be5d681d8d02f32f4bf5ee9b9b89854f321de89b687bd8159e2f5a61ccbc", // audiocpp-indextts25-windows-x86_64-vulkan.zip (2026-09-05, upstream main a8fccb47 + Higgs #454 tail fix + higgs_audio_tts + fish_audio)
                 "99890ad2458e225b86dc70a9a1c734164380ca08d9e769a8e1956d6620a3d1b0", // audiocpp-indextts25-windows-x86_64-vulkan.zip (2026-09-04, upstream main ad4bd574 + higgs_audio_tts + fish_audio)
                 "e67342b0b6953f268030da3c0d382498897e72dff8de729aab3680e7ed2dbd0d", // audiocpp-indextts25-windows-x86_64-vulkan.zip (2026-09-01, upstream v0.7.1 + higgs_audio_tts + fish_audio)
@@ -2036,6 +2039,7 @@ public static class DownloadHashManager
             },
             [IndexTts25AudioCpp.EngineWindowsCuda] = new[]
             {
+                "722545859b460e8959792798c37f0503fb6d86d616d78ba8f178249b3af2fecc", // audiocpp-indextts25-windows-x86_64-cuda.zip (2026-09-06, upstream main b0757573 + index_tts2 + higgs_audio_tts + fish_audio + fireredtts3)
                 "9ffa37e2244e84d21ecda0c23aa7986a6af9a702a21d74ab9196e810bd8159b1", // audiocpp-indextts25-windows-x86_64-cuda.zip (2026-09-05, upstream main a8fccb47 + Higgs #454 tail fix + higgs_audio_tts + fish_audio)
                 "3ab763e9b79b1487fddfd914883418b2b716591f3e0c1a48785fae0a712414c1", // audiocpp-indextts25-windows-x86_64-cuda.zip (2026-09-04, upstream main ad4bd574 + higgs_audio_tts + fish_audio)
                 "408f40079277e48974389ce2bbe941b8a2a93f799ee07fdee37642b978208f41", // audiocpp-indextts25-windows-x86_64-cuda.zip (2026-09-01, upstream v0.7.1 + higgs_audio_tts + fish_audio)
@@ -2044,6 +2048,7 @@ public static class DownloadHashManager
             },
             [IndexTts25AudioCpp.EngineLinuxCpu] = new[]
             {
+                "13b5b0b2490a1655e90b33166baab2be4e07cc0e317b07d4b055605b5e3a5c87", // audiocpp-indextts25-linux-x86_64.tar.gz (2026-09-06, upstream main b0757573 + index_tts2 + higgs_audio_tts + fish_audio + fireredtts3)
                 "61df314331118549ca45919392bf18b6b393741d8908e497c2e9b09e45cb0eaf", // audiocpp-indextts25-linux-x86_64.tar.gz (2026-09-05, upstream main a8fccb47 + Higgs #454 tail fix + higgs_audio_tts + fish_audio)
                 "640ba3986d751742ea5ef74e38f5d4e45d097a10f6540491f314baf106a1c465", // audiocpp-indextts25-linux-x86_64.tar.gz (2026-09-04, upstream main ad4bd574 + higgs_audio_tts + fish_audio)
                 "29838ffe5b96ee3850e8c6ea9ed14d964b4144e2fa45a09552b39f404fd8682d", // audiocpp-indextts25-linux-x86_64.tar.gz (2026-09-01, upstream v0.7.1 + higgs_audio_tts + fish_audio)
@@ -2052,6 +2057,7 @@ public static class DownloadHashManager
             },
             [IndexTts25AudioCpp.EngineLinuxVulkan] = new[]
             {
+                "133d4155df0a6867f69df221335fc84624ba40263b1d0852e4c789e986e56329", // audiocpp-indextts25-linux-x86_64-vulkan.tar.gz (2026-09-06, upstream main b0757573 + index_tts2 + higgs_audio_tts + fish_audio + fireredtts3)
                 "06cba9ccc9784bb5c7fe284dd7e76f4965d0f30c5ce1193e48bcb58e6e259592", // audiocpp-indextts25-linux-x86_64-vulkan.tar.gz (2026-09-05, upstream main a8fccb47 + Higgs #454 tail fix + higgs_audio_tts + fish_audio)
                 "1380909fcb8f3c6e32e249417dc4d99372efff0ba94fa3ce4b7c0d15223caa14", // audiocpp-indextts25-linux-x86_64-vulkan.tar.gz (2026-09-04, upstream main ad4bd574 + higgs_audio_tts + fish_audio)
                 "c7af9df012bf551e35420f678b85caac2c0a358d050d7ab69b2fbd7e1641cfbc", // audiocpp-indextts25-linux-x86_64-vulkan.tar.gz (2026-09-01, upstream v0.7.1 + higgs_audio_tts + fish_audio)
@@ -2060,6 +2066,7 @@ public static class DownloadHashManager
             },
             [IndexTts25AudioCpp.EngineLinuxCuda] = new[]
             {
+                "68e85ab307ce54461fe6d7f088d8483d5a7418fc3ed865973292c39cb0d98706", // audiocpp-indextts25-linux-x86_64-cuda.tar.gz (2026-09-06, upstream main b0757573 + index_tts2 + higgs_audio_tts + fish_audio + fireredtts3)
                 "80f200fddcde367693a499fab02169d80ec46215ec54744b3169126cd1adb7ec", // audiocpp-indextts25-linux-x86_64-cuda.tar.gz (2026-09-05, upstream main a8fccb47 + Higgs #454 tail fix + higgs_audio_tts + fish_audio)
                 "77becce1f2174f161232fdb0df0b1ba37e6b810e1b951aac178b2092607360ca", // audiocpp-indextts25-linux-x86_64-cuda.tar.gz (2026-09-04, upstream main ad4bd574 + higgs_audio_tts + fish_audio)
                 "ad0392bd6ab8d95c9114def0629193650cd21530036a66af39b7f6b8845afc07", // audiocpp-indextts25-linux-x86_64-cuda.tar.gz (2026-09-01, upstream v0.7.1 + higgs_audio_tts + fish_audio)

--- a/src/ui/Logic/Download/DownloadHashManager.cs
+++ b/src/ui/Logic/Download/DownloadHashManager.cs
@@ -269,6 +269,14 @@ public static class DownloadHashManager
         public const string ModelBf16 = "FishTtsAudioCpp.ModelBf16";
     }
 
+    public static class FireRedTts3AudioCpp
+    {
+        // SHA-256 of the FireRedTTS3-Base GGUFs on audio-cpp/audio.cpp-gguf (HF LFS oid).
+        // The engine binaries are the shared audio.cpp archives keyed under IndexTts25AudioCpp.
+        public const string ModelQ8_0 = "FireRedTts3AudioCpp.ModelQ8_0";
+        public const string ModelOrig = "FireRedTts3AudioCpp.ModelOrig";
+    }
+
     public static class ZonosTtsCrispAsr
     {
         // SHA-256 of the Zonos-v0.1 transformer (Q8_0) and the shared DAC 44 kHz codec.
@@ -1987,6 +1995,16 @@ public static class DownloadHashManager
             [FishTtsAudioCpp.ModelBf16] = new[]
             {
                 "781fdece3ff837838c48f7d5a7b37e37c4d661a6416416ad57fe92fed47d96ff", // fish-audio-s2-pro-bf16.gguf
+            },
+
+            // FireRedTTS3-Base weights, from audio-cpp/audio.cpp-gguf (HF LFS oid).
+            [FireRedTts3AudioCpp.ModelQ8_0] = new[]
+            {
+                "68acd5bce0d87a53bb5b88255c65e19df4cbc6017b4bab0824e96f1e2351c3a7", // fireredtts3-base-q8_0.gguf
+            },
+            [FireRedTts3AudioCpp.ModelOrig] = new[]
+            {
+                "1af06f341044121ddebb389c1e6e5181a43f65e2591f77c7eda2ca5810e484c8", // fireredtts3-base-orig.gguf
             },
 
             // audio.cpp engine archives we build in SubtitleEdit/support-files

--- a/src/ui/Logic/Download/FireRedTts3AudioCppDownloadService.cs
+++ b/src/ui/Logic/Download/FireRedTts3AudioCppDownloadService.cs
@@ -1,0 +1,121 @@
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.UiLogic;
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Logic.Download;
+
+public interface IFireRedTts3AudioCppDownloadService
+{
+    /// <summary>Downloads the selected FireRedTTS3 GGUF into audio.cpp's models folder.</summary>
+    Task DownloadModels(string modelKey, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Model weights only: the audio.cpp engine binaries are shared with the other audio.cpp
+/// engines and downloaded through <see cref="IndexTts25AudioCppDownloadService"/>. The GGUF
+/// comes straight from HuggingFace (audio.cpp's own conversion of the Apache-2.0 FireRedTTS3
+/// Base checkpoint), so there is no licence gate in front of it.
+/// </summary>
+public class FireRedTts3AudioCppDownloadService : IFireRedTts3AudioCppDownloadService
+{
+    private readonly HttpClient _httpClient;
+
+    private const string ModelUrlBase =
+        "https://huggingface.co/audio-cpp/audio.cpp-gguf/resolve/main/FireRedTTS3-Base-GGUF/";
+
+    public FireRedTts3AudioCppDownloadService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task DownloadModels(string modelKey, IProgress<float>? progress, Action<string>? titleProgress, CancellationToken cancellationToken)
+    {
+        var fileName = FireRedTts3AudioCpp.GetModelFileName(modelKey);
+        var finalPath = FireRedTts3AudioCpp.GetModelPath(modelKey);
+
+        // A partial GGUF is worse than none: audio.cpp rejects it with "GGUF tensor data range
+        // is out of bounds", which reads like a corrupt model rather than a short download.
+        // Size-check on the threadpool — this runs from the download dialog's init callback.
+        await Task.Run(() => EnsureRemovedIfInvalid(finalPath, fileName), cancellationToken);
+
+        if (FireRedTts3AudioCpp.IsValidLocalModelFile(finalPath, fileName))
+        {
+            return;
+        }
+
+        titleProgress?.Invoke($"Downloading FireRedTTS3 model: {fileName}");
+
+        var partPath = finalPath + ".part";
+        try
+        {
+            await DownloadHelper.DownloadFileAsync(_httpClient, ModelUrlBase + fileName, partPath, progress, cancellationToken);
+            await VerifyFile(partPath, GetHashKey(fileName), fileName, cancellationToken);
+            File.Move(partPath, finalPath);
+        }
+        catch
+        {
+            TryDelete(partPath);
+            throw;
+        }
+    }
+
+    private static string? GetHashKey(string fileName)
+    {
+        if (string.Equals(fileName, FireRedTts3AudioCpp.ModelQ8_0FileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.FireRedTts3AudioCpp.ModelQ8_0;
+        }
+
+        if (string.Equals(fileName, FireRedTts3AudioCpp.ModelOrigFileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DownloadHashManager.FireRedTts3AudioCpp.ModelOrig;
+        }
+
+        return null;
+    }
+
+    private static async Task VerifyFile(string filePath, string? key, string fileName, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(key))
+        {
+            return;
+        }
+
+        var expected = DownloadHashManager.GetLatestKnownHash(key);
+        if (string.IsNullOrEmpty(expected))
+        {
+            return;
+        }
+
+        string actual;
+        await using (var stream = File.OpenRead(filePath))
+        {
+            actual = await Sha256Util.ComputeSha256Async(stream, cancellationToken);
+        }
+
+        if (!string.Equals(expected, actual, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new IOException(
+                $"FireRedTTS3 model {fileName} failed integrity check (expected SHA-256 {expected}, got {actual}).");
+        }
+    }
+
+    private static void TryDelete(string path)
+    {
+        try { File.Delete(path); } catch { /* best-effort cleanup */ }
+    }
+
+    private static void EnsureRemovedIfInvalid(string path, string fileName)
+    {
+        if (!File.Exists(path) || FireRedTts3AudioCpp.IsValidLocalModelFile(path, fileName))
+        {
+            return;
+        }
+
+        TryDelete(path);
+    }
+}

--- a/src/ui/Logic/Download/IndexTts25AudioCppDownloadService.cs
+++ b/src/ui/Logic/Download/IndexTts25AudioCppDownloadService.cs
@@ -1,4 +1,4 @@
-using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+﻿using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 using Nikse.SubtitleEdit.UiLogic;
 using System;
 using System.Collections.Generic;
@@ -33,11 +33,10 @@ public class IndexTts25AudioCppDownloadService : IIndexTts25AudioCppDownloadServ
 {
     private readonly HttpClient _httpClient;
 
-    // 2026-09-05: upstream main @ a8fccb47 (incl. the Higgs Audio end-of-stream codec fix,
-    // #454, which removes the rising hiss at the end of every clip), compiled with the
-    // index_tts2 + higgs_audio_tts + fish_audio families — the same archives back all
-    // three audio.cpp engines.
-    private const string ReleaseTag = "audiocpp-indextts25-2026-09-05";
+    // 2026-09-06: upstream main @ b0757573, compiled with the index_tts2 + higgs_audio_tts +
+    // fish_audio + fireredtts3 families — the same archives back all four audio.cpp engines.
+    // The new family is the reason for the bump: FireRedTTS3 is only compiled into this build.
+    private const string ReleaseTag = "audiocpp-indextts25-2026-09-06";
     private const string ReleaseBase =
         "https://github.com/SubtitleEdit/support-files/releases/download/" + ReleaseTag + "/";
 

--- a/tests/UI/Features/Video/TextToSpeech/Engines/AudioCppPerLineCloneTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/AudioCppPerLineCloneTests.cs
@@ -6,7 +6,7 @@ namespace UITests.Features.Video.TextToSpeech.Engines;
 
 /// <summary>
 /// Per-line voice cloning on the audio.cpp engines (IndexTTS 2.5, Higgs Audio v3, Fish Audio
-/// S2 Pro). Their server takes the reference as a per-request path, so nothing is staged: the
+/// S2 Pro, FireRedTTS3). Their server takes the reference as a per-request path, so nothing is staged: the
 /// voice for a line is the cut clip itself.
 /// </summary>
 /// <remarks>
@@ -21,6 +21,7 @@ public class AudioCppPerLineCloneTests
         yield return new object[] { new IndexTts25AudioCpp() };
         yield return new object[] { new HiggsTtsAudioCpp() };
         yield return new object[] { new FishTtsAudioCpp() };
+        yield return new object[] { new FireRedTts3AudioCpp() };
     }
 
     [Theory]
@@ -57,6 +58,7 @@ public class AudioCppPerLineCloneTests
 
         Assert.NotNull(PerLineVoiceClone.MakeVoiceForClip(new HiggsTtsAudioCpp(), clip));
         Assert.NotNull(PerLineVoiceClone.MakeVoiceForClip(new IndexTts25AudioCpp(), clip));
+        Assert.NotNull(PerLineVoiceClone.MakeVoiceForClip(new FireRedTts3AudioCpp(), clip));
     }
 
     [Theory]

--- a/tests/UI/Features/Video/TextToSpeech/Engines/VoiceCloningConsentTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/VoiceCloningConsentTests.cs
@@ -1,4 +1,4 @@
-using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+﻿using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
 using Nikse.SubtitleEdit.Logic.Config;
 
@@ -157,6 +157,7 @@ public class VoiceCloningConsentTests
         [typeof(Confucius4TtsCrispAsr)] = () => new Confucius4TtsVoice("Ada", "/voices/ada.wav"),
         [typeof(CosyVoice3CrispAsr)] = () => new CosyVoice3Voice("Ada", "/voices/ada.wav", string.Empty),
         [typeof(DotsTtsCrispAsr)] = () => new DotsTtsVoice("Ada", "/voices/ada.wav"),
+        [typeof(FireRedTts3AudioCpp)] = () => new IndexTtsVoice("Ada", "/voices/ada.wav"),
         [typeof(FishTtsAudioCpp)] = () => new IndexTtsVoice("Ada", "/voices/ada.wav"),
         [typeof(HiggsTtsAudioCpp)] = () => new IndexTtsVoice("Ada", "/voices/ada.wav"),
         [typeof(IndexTts25AudioCpp)] = () => new IndexTtsVoice("Ada", "/voices/ada.wav"),


### PR DESCRIPTION
## Summary

Adds **FireRedTTS3-Base** (FireRed Team, Apache-2.0, [arXiv 2608.17492](https://arxiv.org/abs/2608.17492)) as a fourth engine on the shared audio.cpp runtime, next to IndexTTS 2.5, Higgs Audio v3 and Fish Audio S2 Pro. Zero-shot voice cloning across 24 languages; the model reports the best speaker similarity of the open cloning models on Seed-TTS-eval (avg 78.8) and MiniMax MLS-Test (avg 84.8).

## What is different from the Higgs engine it is modelled on

- **No licence gate.** Runtime and weights are both Apache-2.0. `AudioCppTtsSettingsAdapter` and `EnsureAudioCppEngineWithLicense` now accept a null `ModelLicenseDefinition`.
- **Mandatory language combo** (`FireRedTts3Languages`). The model has no language detection and audio.cpp's default for an unset tag is Chinese, so every request carries an explicit tag and English is pre-selected. The 21 Chinese dialect tags are left out.
- **Clone task.** The Base package declares only the clone task, so the server config uses `"task": "clon"` like IndexTTS 2.5.

Everything else follows the Higgs shape: per-request `voice_ref` (so "Clone from video" per-line works and a voice change never restarts the server), optional `.txt` transcript passed as `reference_text`, shared settings dialog, seeded reference voices at 24 kHz.

## Weights and runtime

- Weights from `audio-cpp/audio.cpp-gguf/FireRedTTS3-Base-GGUF`: q8_0 (~3.9 GB, default) and orig (~11.5 GB). SHA-256 pinned from the HF LFS oids; the q8_0 download was verified locally.
- Runtime: the audio.cpp archives now come from support-files release [audiocpp-indextts25-2026-09-06](https://github.com/SubtitleEdit/support-files/releases/tag/audiocpp-indextts25-2026-09-06) (upstream main `b0757573`, families `index_tts2,higgs_audio_tts,fish_audio,fireredtts3`). Hashes of all seven archives are pinned at index 0, so existing installs get the amber update prompt; FireRedTTS3 needs this build.

## Testing

- `dotnet build src/ui/UI.csproj` green; TTS UI tests green (414 incl. the new engine in `AudioCppPerLineCloneTests` and `VoiceCloningConsentTests`).
- Smoke test on M4 Metal against the new macOS archive, using SE's exact server config and request payload: English clone round-trips word-perfect through whisper.cpp tiny.en. Cold 25 s incl. model load, warm 8.6 s for 4.2 s of audio (24 kHz mono). German synthesised at a plausible length but could not be transcription-checked with the English-only whisper model on hand.

## Caveats worth knowing

- Text normalization upstream covers Chinese, English and Cantonese only; other languages read digits literally.
- The audio.cpp port marks the family `experimental`; streaming/batching is an open upstream issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
