### PR TITLE
Perf hunt round 20: linear same-text merge, char-keyed titler/CEA-708 tables

### DIFF
--- a/src/libse/Cea708/Cea708.cs
+++ b/src/libse/Cea708/Cea708.cs
@@ -307,7 +307,7 @@ namespace Nikse.SubtitleEdit.Core.Cea708
             { 0x7F, "┌" },
         };
 
-        private static Dictionary<string, byte[]> _textLookupTable;
+        private static Dictionary<char, byte[]> _textLookupTable;
 
         public static string Decode(int lineIndex, byte[] bytes, CommandState state, bool flush)
         {
@@ -721,20 +721,22 @@ namespace Nikse.SubtitleEdit.Core.Cea708
         {
             if (_textLookupTable == null)
             {
-                var dic = new Dictionary<string, byte[]>();
+                // Keyed by char: the lookup below is per character, so multi-char table
+                // values could never match, and the string key allocated per character.
+                var dic = new Dictionary<char, byte[]>();
                 foreach (var kvp in SingleCharLookupTable)
                 {
-                    if (!string.IsNullOrEmpty(kvp.Value) && !dic.ContainsKey(kvp.Value))
+                    if (kvp.Value?.Length == 1 && !dic.ContainsKey(kvp.Value[0]))
                     {
-                        dic.Add(kvp.Value, new[] { kvp.Key });
+                        dic.Add(kvp.Value[0], new[] { kvp.Key });
                     }
                 }
 
                 foreach (var kvp in G2CharLookupTable)
                 {
-                    if (!string.IsNullOrEmpty(kvp.Value) && !dic.ContainsKey(kvp.Value))
+                    if (kvp.Value?.Length == 1 && !dic.ContainsKey(kvp.Value[0]))
                     {
-                        dic.Add(kvp.Value, new byte[] { 0x10, kvp.Key }); // EXT1 + G2 code
+                        dic.Add(kvp.Value[0], new byte[] { 0x10, kvp.Key }); // EXT1 + G2 code
                     }
                 }
 
@@ -744,7 +746,7 @@ namespace Nikse.SubtitleEdit.Core.Cea708
             var bytes = new List<byte>();
             foreach (var ch in input)
             {
-                if (_textLookupTable.TryGetValue(ch.ToString(), out var b))
+                if (_textLookupTable.TryGetValue(ch, out var b))
                 {
                     bytes.AddRange(b);
                 }

--- a/src/libse/Common/FixCasing.cs
+++ b/src/libse/Common/FixCasing.cs
@@ -161,6 +161,20 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         private static readonly string[] CasingTitles = { "Mrs.", "Miss.", "Mr.", "Ms.", "Dr." };
         private static readonly string[] CasingNotChangeWords = { "does", "has", "will", "is", "and", "for", "but", "or", "of" };
+        private static readonly char[] TitleWordDelimiters = { ' ', '\r', '\n', ',', '"', '?', '!', '.', '\'' };
+
+        private static bool IsCasingNotChangeWord(ReadOnlySpan<char> word)
+        {
+            foreach (var w in CasingNotChangeWords)
+            {
+                if (word.SequenceEqual(w.AsSpan()))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
 
         private string FixCasingAfterTitles(string input)
         {
@@ -181,8 +195,10 @@ namespace Nikse.SubtitleEdit.Core.Common
                         if (idx < text.Length - 1 && text[idx] == ' ')
                         {
                             idx++;
-                            var words = text.Substring(idx).Split(' ', '\r', '\n', ',', '"', '?', '!', '.', '\'');
-                            if (words.Length > 0 && !CasingNotChangeWords.Contains(words[0]))
+                            // First word only - splitting the whole rest of the line allocated an array per title hit.
+                            var wordEnd = text.IndexOfAny(TitleWordDelimiters, idx);
+                            var firstWord = wordEnd < 0 ? text.AsSpan(idx) : text.AsSpan(idx, wordEnd - idx);
+                            if (!IsCasingNotChangeWord(firstWord))
                             {
                                 var upper = char.ToUpperInvariant(text[idx]).ToString();
                                 text = text.Remove(idx, 1).Insert(idx, upper);

--- a/src/libse/Common/MergeLinesSameTextUtils.cs
+++ b/src/libse/Common/MergeLinesSameTextUtils.cs
@@ -8,9 +8,20 @@ namespace Nikse.SubtitleEdit.Core.Common
     {
         public static Subtitle MergeLinesWithSameTextInSubtitle(Subtitle subtitle, bool fixIncrementing, int maxMsBetween)
         {
-            var mergedIndexes = new List<int>();
-            var removed = new List<int>();
+            var mergedIndexes = new HashSet<int>();
+            var removed = new HashSet<int>();
             var mergedSubtitle = new Subtitle();
+
+            // With start times in order, once a candidate starts more than maxMsBetween after the
+            // current end nothing later can qualify either (both predicates reject on that gap
+            // first, and the end only moves on a merge) - so the inner scan can stop there. The
+            // old scan went to the end of the subtitle for every paragraph.
+            var startTimesInOrder = true;
+            for (var i = 1; i < subtitle.Paragraphs.Count && startTimesInOrder; i++)
+            {
+                startTimesInOrder = subtitle.Paragraphs[i].StartTime.TotalMilliseconds >= subtitle.Paragraphs[i - 1].StartTime.TotalMilliseconds;
+            }
+
             for (var i = 1; i < subtitle.Paragraphs.Count; i++)
             {
                 if (removed.Contains(i - 1))
@@ -29,6 +40,11 @@ namespace Nikse.SubtitleEdit.Core.Common
                     }
 
                     var next = subtitle.GetParagraphOrDefault(j);
+                    if (startTimesInOrder && next != null && next.StartTime.TotalMilliseconds - p.EndTime.TotalMilliseconds > maxMsBetween)
+                    {
+                        break;
+                    }
+
                     var incrementText = string.Empty;
                     if (QualifiesForMerge(p, next, maxMsBetween) || fixIncrementing && QualifiesForMergeIncrement(p, next, maxMsBetween, out incrementText))
                     {
@@ -40,15 +56,8 @@ namespace Nikse.SubtitleEdit.Core.Common
 
                         p.EndTime.TotalMilliseconds = next.EndTime.TotalMilliseconds;
                         removed.Add(j);
-                        if (!mergedIndexes.Contains(j))
-                        {
-                            mergedIndexes.Add(j);
-                        }
-
-                        if (!mergedIndexes.Contains(i - 1))
-                        {
-                            mergedIndexes.Add(i - 1);
-                        }
+                        mergedIndexes.Add(j);
+                        mergedIndexes.Add(i - 1);
                     }
                 }
             }

--- a/src/libse/Common/UnknownFormatImporter.cs
+++ b/src/libse/Common/UnknownFormatImporter.cs
@@ -13,6 +13,29 @@ namespace Nikse.SubtitleEdit.Core.Common
     public class UnknownFormatImporter
     {
         private static readonly char[] ExpectedSplitChars = { '.', ',', ';', ':' };
+        private static readonly char[] BracketChars = { '-', '>', '{', '}', '[', ']' };
+
+        // One pass instead of six chained Replace(char, char) calls, each of which allocates a
+        // copy of the line whether or not the character occurs - run per line during auto-detect.
+        private static string ReplaceBracketsWithSpaces(string line)
+        {
+            if (line.IndexOfAny(BracketChars) < 0)
+            {
+                return line;
+            }
+
+            var chars = line.ToCharArray();
+            for (var i = 0; i < chars.Length; i++)
+            {
+                if (Array.IndexOf(BracketChars, chars[i]) >= 0)
+                {
+                    chars[i] = ' ';
+                }
+            }
+
+            return new string(chars);
+        }
+
 
         // Static: RegexOptions.Compiled emits IL on construction, so building these per call
         // paid the compile cost every time and never amortized it.
@@ -298,7 +321,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
                 if (allNumbers && lineWithPerhapsOnlyNumbers.Length > 2)
                 {
-                    string[] arr = line.Replace('-', ' ').Replace('>', ' ').Replace('{', ' ').Replace('}', ' ').Replace('[', ' ').Replace(']', ' ').Trim().Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                    string[] arr = ReplaceBracketsWithSpaces(line).Trim().Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
                     if (arr.Length == 2)
                     {
                         string[] start = arr[0].Trim().Split(ExpectedSplitChars, StringSplitOptions.RemoveEmptyEntries);
@@ -753,7 +776,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         line = line.RemoveChar(' ');
                     }
 
-                    string[] arr = line.Replace('-', ' ').Replace('>', ' ').Replace('{', ' ').Replace('}', ' ').Replace('[', ' ').Replace(']', ' ').Trim().Split(splitChars, StringSplitOptions.RemoveEmptyEntries);
+                    string[] arr = ReplaceBracketsWithSpaces(line).Trim().Split(splitChars, StringSplitOptions.RemoveEmptyEntries);
                     if (arr.Length == 2)
                     {
                         string[] start = arr[0].Trim().Split(ExpectedSplitChars, StringSplitOptions.RemoveEmptyEntries);
@@ -868,7 +891,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
                 if (allNumbers && lineWithPerhapsOnlyNumbers.Length > 5)
                 {
-                    string[] arr = line.Replace('-', ' ').Replace('>', ' ').Replace('{', ' ').Replace('}', ' ').Replace('[', ' ').Replace(']', ' ').Trim().Split(splitChar, StringSplitOptions.RemoveEmptyEntries);
+                    string[] arr = ReplaceBracketsWithSpaces(line).Trim().Split(splitChar, StringSplitOptions.RemoveEmptyEntries);
                     if (arr.Length == 2)
                     {
                         string[] start = arr[0].Trim().Split(ExpectedSplitChars, StringSplitOptions.RemoveEmptyEntries);

--- a/src/libse/Common/WebVttToAssa.cs
+++ b/src/libse/Common/WebVttToAssa.cs
@@ -53,6 +53,17 @@ namespace Nikse.SubtitleEdit.Core.Common
             }
             assaSubtitle.Header = AdvancedSubStationAlpha.GetHeaderAndStylesFromAdvancedSubStationAlpha(assaSubtitle.Header, styles);
 
+            // Looked up per paragraph / per cue-class tag below; the old code scanned both lists with LINQ each time.
+            var ssaStyleNames = new HashSet<string>(ssaStyles.Select(p => p.Name));
+            var webVttStylesByName = new Dictionary<string, WebVttStyle>();
+            foreach (var style in webVttStyles)
+            {
+                if (style.Name != null && !webVttStylesByName.ContainsKey(style.Name))
+                {
+                    webVttStylesByName.Add(style.Name, style);
+                }
+            }
+
             var layer = 0;
             foreach (var paragraph in assaSubtitle.Paragraphs)
             {
@@ -87,7 +98,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                     paragraph.Text.EndsWith("</c>", StringComparison.Ordinal))
                 {
                     var tag = matches[0].Value.TrimEnd('>', ' ').Remove(0, 2);
-                    if (ssaStyles.Any(p => p.Name == tag))
+                    if (ssaStyleNames.Contains(tag))
                     {
                         paragraph.Extra = tag;
                         paragraph.Text = paragraph.Text.Remove(matches[0].Index, matches[0].Length);
@@ -96,7 +107,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                     }
                 }
 
-                paragraph.Text = SetInlineStyles(paragraph.Text, ssaStyles, webVttStyles);
+                paragraph.Text = SetInlineStyles(paragraph.Text, webVttStylesByName);
 
                 paragraph.Text = GetAlignment(paragraph, width, height);
             }
@@ -250,7 +261,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             return null;
         }
 
-        private static string SetInlineStyles(string input, List<SsaStyle> ssaStyles, List<WebVttStyle> webVttStyles)
+        private static string SetInlineStyles(string input, Dictionary<string, WebVttStyle> webVttStylesByName)
         {
             var allInlineStyles = new List<WebVttStyle>();
             var start = 0;
@@ -285,8 +296,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                     var arr = match.Value.Remove(0, 3).TrimEnd('>').Split('.');
                     foreach (var styleName in arr)
                     {
-                        var styleFound = webVttStyles.FirstOrDefault(p => p.Name == "." + styleName);
-                        if (styleFound != null)
+                        if (webVttStylesByName.TryGetValue("." + styleName, out var styleFound))
                         {
                             webVttStyle = ApplyStyle(styleFound, webVttStyle);
                         }

--- a/src/libse/SubtitleFormats/CaptionsInc.cs
+++ b/src/libse/SubtitleFormats/CaptionsInc.cs
@@ -35,6 +35,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 fs.Write(buffer, 0, buffer.Length);
 
                 // paragraphs
+                var cp1252 = Encoding.GetEncoding(1252);
+                var oneChar = new char[1];
+                var oneByte = new byte[4];
                 foreach (Paragraph p in subtitle.Paragraphs)
                 {
                     buffer = new byte[] { 0x0D, 0x0A, 0xFE }; // header
@@ -50,7 +53,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     {
                         foreach (char ch in line)
                         {
-                            text.Add(Encoding.GetEncoding(1252).GetBytes(new[] { ch })[0]);
+                            // Was Encoding.GetEncoding(1252).GetBytes(new[] { ch })[0] per character.
+                            oneChar[0] = ch;
+                            cp1252.GetBytes(oneChar, 0, 1, oneByte, 0);
+                            text.Add(oneByte[0]);
                         }
                         text.Add(0x14);
                         text.Add(0x74);

--- a/src/libse/SubtitleFormats/MagicVideoTitler.cs
+++ b/src/libse/SubtitleFormats/MagicVideoTitler.cs
@@ -104,12 +104,30 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             { "`", "'" },
         };
 
+        // Char-keyed views of DecodeDictionary: the per-character lookups allocated a one-char
+        // (or two-char) string for every character of every line as the dictionary key.
+        private static readonly Dictionary<char, string> DecodeByChar = BuildDecodeByChar();
+
+        private static Dictionary<char, string> BuildDecodeByChar()
+        {
+            var dic = new Dictionary<char, string>();
+            foreach (var kvp in DecodeDictionary)
+            {
+                if (kvp.Key.Length == 1)
+                {
+                    dic[kvp.Key[0]] = kvp.Value;
+                }
+            }
+
+            return dic;
+        }
+
         private static string DecodeText(string s)
         {
             var sb = new StringBuilder();
             foreach (var ch in s)
             {
-                if (DecodeDictionary.TryGetValue(ch.ToString(), out var v))
+                if (DecodeByChar.TryGetValue(ch, out var v))
                 {
                     sb.Append(v);
                 }
@@ -122,17 +140,29 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             return sb.ToString();
         }
 
-        private static Dictionary<string, string> _encodeDictionary;
+        private static Dictionary<char, string> _encodeOneChar;
+        private static Dictionary<int, string> _encodeTwoChars;
 
         public static string EncodeText(string s)
         {
-            if (_encodeDictionary == null)
+            if (_encodeOneChar == null)
             {
-                _encodeDictionary = new Dictionary<string, string>();
+                var one = new Dictionary<char, string>();
+                var two = new Dictionary<int, string>();
                 foreach (var kvp in DecodeDictionary)
                 {
-                    _encodeDictionary.Add(kvp.Value, kvp.Key);
+                    if (kvp.Value.Length == 1)
+                    {
+                        one.Add(kvp.Value[0], kvp.Key);
+                    }
+                    else if (kvp.Value.Length == 2)
+                    {
+                        two.Add((kvp.Value[0] << 16) | kvp.Value[1], kvp.Key);
+                    }
                 }
+
+                _encodeTwoChars = two;
+                _encodeOneChar = one;
             }
 
             // Several decoded values are TWO characters ("nj", "Lj", "Dz"...), so a per-character
@@ -141,14 +171,14 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var sb = new StringBuilder();
             for (var i = 0; i < s.Length; i++)
             {
-                if (i + 1 < s.Length && _encodeDictionary.TryGetValue(s.Substring(i, 2), out var twoCharValue))
+                if (i + 1 < s.Length && _encodeTwoChars.TryGetValue((s[i] << 16) | s[i + 1], out var twoCharValue))
                 {
                     sb.Append(twoCharValue);
                     i++;
                     continue;
                 }
 
-                if (_encodeDictionary.TryGetValue(s[i].ToString(), out var v))
+                if (_encodeOneChar.TryGetValue(s[i], out var v))
                 {
                     sb.Append(v);
                 }

--- a/src/libse/SubtitleFormats/ProjectionSubtitleList.cs
+++ b/src/libse/SubtitleFormats/ProjectionSubtitleList.cs
@@ -85,9 +85,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         private static int GetUnicodeNumber(char character)
         {
-            var encoding = new UTF32Encoding();
-            var bytes = encoding.GetBytes(character.ToString().ToCharArray());
-            return BitConverter.ToInt32(bytes, 0);
+            // A lone surrogate is what UTF32Encoding's replacement fallback turned into U+FFFD;
+            // anything else is its own code point. The old code allocated four objects per character.
+            return char.IsSurrogate(character) ? 0xFFFD : character;
         }
 
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)

--- a/src/libse/SubtitleFormats/SmartTitler.cs
+++ b/src/libse/SubtitleFormats/SmartTitler.cs
@@ -125,12 +125,30 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             { "y", "dž" },
          };
 
+        // Char-keyed views of DecodeDictionary: the per-character lookups allocated a one-char
+        // (or two-char) string for every character of every line as the dictionary key.
+        private static readonly Dictionary<char, string> DecodeByChar = BuildDecodeByChar();
+
+        private static Dictionary<char, string> BuildDecodeByChar()
+        {
+            var dic = new Dictionary<char, string>();
+            foreach (var kvp in DecodeDictionary)
+            {
+                if (kvp.Key.Length == 1)
+                {
+                    dic[kvp.Key[0]] = kvp.Value;
+                }
+            }
+
+            return dic;
+        }
+
         private static string DecodeText(string s)
         {
             var sb = new StringBuilder();
             foreach (var ch in s)
             {
-                if (DecodeDictionary.TryGetValue(ch.ToString(), out var v))
+                if (DecodeByChar.TryGetValue(ch, out var v))
                 {
                     sb.Append(v);
                 }
@@ -143,17 +161,29 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             return sb.ToString();
         }
 
-        private static Dictionary<string, string> _encodeDictionary;
+        private static Dictionary<char, string> _encodeOneChar;
+        private static Dictionary<int, string> _encodeTwoChars;
 
         public static string EncodeText(string s)
         {
-            if (_encodeDictionary == null)
+            if (_encodeOneChar == null)
             {
-                _encodeDictionary = new Dictionary<string, string>();
+                var one = new Dictionary<char, string>();
+                var two = new Dictionary<int, string>();
                 foreach (var kvp in DecodeDictionary)
                 {
-                    _encodeDictionary.Add(kvp.Value, kvp.Key);
+                    if (kvp.Value.Length == 1)
+                    {
+                        one.Add(kvp.Value[0], kvp.Key);
+                    }
+                    else if (kvp.Value.Length == 2)
+                    {
+                        two.Add((kvp.Value[0] << 16) | kvp.Value[1], kvp.Key);
+                    }
                 }
+
+                _encodeTwoChars = two;
+                _encodeOneChar = one;
             }
 
             // Several decoded values are TWO characters ("nj", "Lj", "Dz"...), so a per-character
@@ -162,14 +192,14 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var sb = new StringBuilder();
             for (var i = 0; i < s.Length; i++)
             {
-                if (i + 1 < s.Length && _encodeDictionary.TryGetValue(s.Substring(i, 2), out var twoCharValue))
+                if (i + 1 < s.Length && _encodeTwoChars.TryGetValue((s[i] << 16) | s[i + 1], out var twoCharValue))
                 {
                     sb.Append(twoCharValue);
                     i++;
                     continue;
                 }
 
-                if (_encodeDictionary.TryGetValue(s[i].ToString(), out var v))
+                if (_encodeOneChar.TryGetValue(s[i], out var v))
                 {
                     sb.Append(v);
                 }

--- a/src/libse/SubtitleFormats/WebVTT.cs
+++ b/src/libse/SubtitleFormats/WebVTT.cs
@@ -1,4 +1,4 @@
-using Nikse.SubtitleEdit.Core.Common;
+﻿using Nikse.SubtitleEdit.Core.Common;
 using SkiaSharp;
 using System;
 using System.Collections.Generic;
@@ -1146,6 +1146,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         private static string ColorHtmlToWebVtt(string text)
         {
             var res = text.Replace("</font>", "</c>");
+            if (res.IndexOf("<font", StringComparison.Ordinal) < 0)
+            {
+                return res;
+            }
 
             for (var i = 0; i < 2; i++)
             {
@@ -1155,7 +1159,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     var fontString = "<c." + match.Value.Substring(13, match.Value.Length - 15) + ">";
                     fontString = fontString.Trim('"').Trim('\'');
                     res = res.Remove(match.Index, match.Length).Insert(match.Index, fontString);
-                    match = RegexHtmlColor.Match(res);
+                    // Continue after the replacement - restarting at 0 rescanned the whole cue per tag.
+                    match = RegexHtmlColor.Match(res, match.Index + fontString.Length);
                 }
 
                 match = RegexHtmlColor2.Match(res);
@@ -1164,7 +1169,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     var fontString = "<c." + match.Value.Substring(12, match.Value.Length - 13) + ">";
                     fontString = fontString.Trim('"').Trim('\'');
                     res = res.Remove(match.Index, match.Length).Insert(match.Index, fontString);
-                    match = RegexHtmlColor2.Match(res);
+                    // Continue after the replacement - restarting at 0 rescanned the whole cue per tag.
+                    match = RegexHtmlColor2.Match(res, match.Index + fontString.Length);
                 }
 
                 match = RegexHtmlColor3.Match(res);
@@ -1179,7 +1185,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     }
                     fontString = fontString.Trim('"').Trim('\'');
                     res = res.Remove(match.Index, match.Length).Insert(match.Index, fontString);
-                    match = RegexHtmlColor3.Match(res);
+                    // Continue after the replacement - restarting at 0 rescanned the whole cue per tag.
+                    match = RegexHtmlColor3.Match(res, match.Index + fontString.Length);
                 }
 
                 match = RegexHtmlColor4.Match(res);
@@ -1197,7 +1204,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     }
                     fontString = fontString.Trim('"').Trim('\'');
                     res = res.Remove(match.Index, match.Length).Insert(match.Index, fontString);
-                    match = RegexHtmlColor4.Match(res);
+                    // Continue after the replacement - restarting at 0 rescanned the whole cue per tag.
+                    match = RegexHtmlColor4.Match(res, match.Index + fontString.Length);
                 }
             }
 

--- a/tests/benchmarks/PerfHuntRound20Benchmarks.cs
+++ b/tests/benchmarks/PerfHuntRound20Benchmarks.cs
@@ -1,0 +1,241 @@
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Core.Cea708;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using System.Text;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// Round 20 performance hunt: the quadratic same-text merge scan, WebVTT colour regex loops
+/// restarting at 0, per-paragraph LINQ lookups (WebVTT to ASSA styles),
+/// and per-character string keys / encoder objects (Smart Titler, Magic Video Titler, CEA-708,
+/// Captions Inc, Projection Subtitle List, unknown-format importer, fix casing).
+/// Public entry points only; <see cref="SubRipControl"/> is the drift control.
+///
+/// Default job, in-process, Apple M4, .NET 10 (SubRipControl 48.2 us -> 48.3 us, identical
+/// allocations):
+///
+///   Merge lines with same text (2000)   24,530 us -> 543 us   45x
+///   Captions Inc save (400)              1,149 us -> 454 us   2.5x   2.6 MB -> 381 KB allocated
+///   CEA-708 encode text                    271 us -> 134 us   2.0x   620 KB -> 85 KB
+///   Smart Titler round trip (400)          616 us -> 317 us   1.9x   2.7 MB -> 1.0 MB
+///   Projection Subtitle List save (400)    291 us -> 152 us   1.9x   1.6 MB -> 714 KB
+///   Magic Video Titler round trip (400)    663 us -> 371 us   1.8x   2.7 MB -> 1.1 MB
+///   Fix casing, titles (400)            34,709 us -> 28,210 us 1.23x  3.0 MB -> 2.7 MB
+///   WebVTT save with colours (400)         527 us -> 484 us   1.09x
+///   WebVTT -> ASSA convert (400)           743 us -> 722 us   1.03x  3.0 MB -> 2.7 MB
+///   Unknown-format import (400)          1,467 us -> 1,429 us 1.03x  2.19 MB -> 2.12 MB
+/// </summary>
+[MemoryDiagnoser]
+public class PerfHuntRound20Benchmarks
+{
+    private Subtitle _taggedSubtitle = new();
+    private Subtitle _sameTextSubtitle = new();
+    private Subtitle _webVttColorSubtitle = new();
+    private Subtitle _webVttClassSubtitle = new();
+    private Subtitle _titleSubtitle = new();
+    private Subtitle _unicodeSubtitle = new();
+    private List<WebVttStyle> _webVttStyles = new();
+    private List<string> _smartTitlerLines = new();
+    private List<string> _magicLines = new();
+    private List<string> _importLines = new();
+    private string _captionsIncFile = string.Empty;
+    private string _cea708Text = string.Empty;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        _taggedSubtitle = BuildTaggedSubtitle(400);
+        _sameTextSubtitle = BuildSameTextSubtitle(2000);
+        _webVttColorSubtitle = BuildWebVttColorSubtitle(400);
+        (_webVttClassSubtitle, _webVttStyles) = BuildWebVttClassSubtitle(400);
+        _titleSubtitle = BuildTitleSubtitle(400);
+        _unicodeSubtitle = BuildUnicodeSubtitle(400);
+        _smartTitlerLines = new SmartTitler().ToText(_unicodeSubtitle, "t").SplitToLines();
+        _magicLines = new MagicVideoTitler().ToText(_unicodeSubtitle, "t").SplitToLines();
+        _importLines = BuildImportLines(400);
+        _cea708Text = string.Join(" ", _unicodeSubtitle.Paragraphs.Select(p => p.Text));
+
+        var dir = Path.Combine(Path.GetTempPath(), "se-perf-round20");
+        Directory.CreateDirectory(dir);
+        _captionsIncFile = Path.Combine(dir, "out.cin");
+    }
+
+    private static string Sentence(int i) =>
+        $"The quick brown fox number {i} jumps over the lazy dog, twice, and then rests.";
+
+    private static Subtitle BuildTaggedSubtitle(int count)
+    {
+        var s = new Subtitle();
+        for (var i = 0; i < count; i++)
+        {
+            var text = (i % 4) switch
+            {
+                0 => $"<i>{Sentence(i)}</i>{Environment.NewLine}Second line of cue {i}.",
+                1 => $"He said: <b>no</b>.{Environment.NewLine}<font color=\"#ffff00\">Yellow {i}</font> and <u>more</u>.",
+                2 => $"{Sentence(i)}{Environment.NewLine}<i>Whispered</i> reply.",
+                _ => Sentence(i),
+            };
+            s.Paragraphs.Add(new Paragraph(text, i * 3000, i * 3000 + 2500));
+        }
+
+        return s;
+    }
+
+    /// <summary>Fade-style repeats: every third cue is the same text as the one before it.</summary>
+    private static Subtitle BuildSameTextSubtitle(int count)
+    {
+        var s = new Subtitle();
+        for (var i = 0; i < count; i++)
+        {
+            var text = i % 3 == 1 ? $"<i>{Sentence(i - 1)}</i>" : Sentence(i);
+            s.Paragraphs.Add(new Paragraph(text, i * 2000, i * 2000 + 1900));
+        }
+
+        return s;
+    }
+
+    private static Subtitle BuildWebVttColorSubtitle(int count)
+    {
+        var s = new Subtitle();
+        for (var i = 0; i < count; i++)
+        {
+            var text = (i % 3) switch
+            {
+                0 => $"<font color=\"#ffff00\">Yellow {i}</font> and <font color=\"cyan\">cyan</font>{Environment.NewLine}<font color=\"#ff0000\">red</font> <font color=\"#00ff00\">green</font>",
+                1 => $"<font color=\"white\">{Sentence(i)}</font>",
+                _ => Sentence(i),
+            };
+            s.Paragraphs.Add(new Paragraph(text, i * 3000, i * 3000 + 2500));
+        }
+
+        return s;
+    }
+
+    private static (Subtitle, List<WebVttStyle>) BuildWebVttClassSubtitle(int count)
+    {
+        var header = new StringBuilder();
+        header.AppendLine("WEBVTT");
+        header.AppendLine();
+        for (var i = 0; i < 30; i++)
+        {
+            header.AppendLine($"STYLE{Environment.NewLine}::cue(.style{i}) {{ color: #{(i * 8) % 256:x2}{(i * 16) % 256:x2}{(i * 32) % 256:x2}; font-weight: bold; }}");
+        }
+
+        var s = new Subtitle { Header = header.ToString() };
+        for (var i = 0; i < count; i++)
+        {
+            var text = (i % 3) switch
+            {
+                0 => $"<c.style{i % 30}>{Sentence(i)}</c>",
+                1 => $"<c.style{i % 30}.style{(i + 1) % 30}>Two styles {i}</c>{Environment.NewLine}<c.style3>and <i>more</i></c>",
+                _ => Sentence(i),
+            };
+            s.Paragraphs.Add(new Paragraph(text, i * 3000, i * 3000 + 2500));
+        }
+
+        return (s, WebVttHelper.GetStyles(s.Header));
+    }
+
+    private static Subtitle BuildTitleSubtitle(int count)
+    {
+        var s = new Subtitle();
+        for (var i = 0; i < count; i++)
+        {
+            var text = (i % 2) switch
+            {
+                0 => $"mr. smith and Mrs. jones went to dr. brown, number {i}.",
+                _ => $"Nothing here for cue {i}, MS. anderson.",
+            };
+            s.Paragraphs.Add(new Paragraph(text, i * 3000, i * 3000 + 2500));
+        }
+
+        return s;
+    }
+
+    private static Subtitle BuildUnicodeSubtitle(int count)
+    {
+        var s = new Subtitle();
+        for (var i = 0; i < count; i++)
+        {
+            var text = (i % 3) switch
+            {
+                0 => $"Đorđe i Ljiljana, Žarko, Šćepan {i}{Environment.NewLine}Čović dž nj Dž",
+                1 => $"Café crème – très bien {i}, señor ¿qué? ©",
+                _ => Sentence(i),
+            };
+            s.Paragraphs.Add(new Paragraph(text, i * 3000, i * 3000 + 2500));
+        }
+
+        return s;
+    }
+
+    private static List<string> BuildImportLines(int count)
+    {
+        var lines = new List<string>();
+        for (var i = 0; i < count; i++)
+        {
+            var start = TimeSpan.FromMilliseconds(i * 3000).ToString(@"hh\:mm\:ss\.fff");
+            var end = TimeSpan.FromMilliseconds(i * 3000 + 2500).ToString(@"hh\:mm\:ss\.fff");
+            lines.Add($"[{start}] --> [{end}]");
+            lines.Add(Sentence(i));
+            lines.Add(string.Empty);
+        }
+
+        return lines;
+    }
+
+    [Benchmark]
+    public int MergeLinesWithSameText() => MergeLinesSameTextUtils.MergeLinesWithSameTextInSubtitle(_sameTextSubtitle, true, 250).Paragraphs.Count;
+
+    [Benchmark]
+    public int WebVttSaveColors() => new WebVTT().ToText(_webVttColorSubtitle, "t").Length;
+
+    [Benchmark]
+    public int WebVttToAssaConvert() => WebVttToAssa.Convert(_webVttClassSubtitle, new SsaStyle(), 1920, 1080).Paragraphs.Count;
+
+    [Benchmark]
+    public int FixCasingTitles()
+    {
+        var copy = new Subtitle(_titleSubtitle);
+        new FixCasing("en") { FixNormal = true }.Fix(copy);
+        return copy.Paragraphs.Count;
+    }
+
+    [Benchmark]
+    public int SmartTitlerRoundTrip()
+    {
+        var s = new Subtitle();
+        new SmartTitler().LoadSubtitle(s, _smartTitlerLines, "in.txt");
+        return new SmartTitler().ToText(s, "t").Length;
+    }
+
+    [Benchmark]
+    public int MagicVideoTitlerRoundTrip()
+    {
+        var s = new Subtitle();
+        new MagicVideoTitler().LoadSubtitle(s, _magicLines, "in.txt");
+        return new MagicVideoTitler().ToText(s, "t").Length;
+    }
+
+    [Benchmark]
+    public int Cea708EncodeText() => Cea708.EncodeText(_cea708Text).Length;
+
+    [Benchmark]
+    public long CaptionsIncSave()
+    {
+        CaptionsInc.Save(_captionsIncFile, _taggedSubtitle);
+        return new FileInfo(_captionsIncFile).Length;
+    }
+
+    [Benchmark]
+    public int ProjectionSubtitleListSave() => new ProjectionSubtitleList().ToText(_unicodeSubtitle, "t").Length;
+
+    [Benchmark]
+    public int UnknownFormatImport() => new UnknownFormatImporter().AutoGuessImport(_importLines, "in.txt").Paragraphs.Count;
+
+    [Benchmark]
+    public int SubRipControl() => new SubRip().ToText(_taggedSubtitle, "t").Length;
+}


### PR DESCRIPTION
Ten verified fixes (BenchmarkDotNet default job, in-process, Apple M4, .NET 10) against a detached baseline worktree of `main`; the untouched `SubRipControl` benchmark is flat with identical allocations. Every touched function was dumped over an edge-case corpus on both sides (including unsorted and empty-text input for the merge, duplicate WebVTT style ids, lone surrogates and every mapped digraph for the titlers) and the dumps are byte-identical.

| Benchmark | Before | After | Speed-up | Allocated |
| --- | ---: | ---: | ---: | --- |
| Merge lines with same text (2000 cues) | 24,530 us | 543 us | 45x | – |
| Captions Inc save (400) | 1,149 us | 454 us | 2.5x | 2.6 MB -> 381 KB |
| CEA-708 encode text | 271 us | 134 us | 2.0x | 620 KB -> 85 KB |
| Smart Titler round trip (400) | 616 us | 317 us | 1.9x | 2.7 MB -> 1.0 MB |
| Projection Subtitle List save (400) | 291 us | 152 us | 1.9x | 1.6 MB -> 714 KB |
| Magic Video Titler round trip (400) | 663 us | 371 us | 1.8x | 2.7 MB -> 1.1 MB |
| Fix casing, titles (400) | 34,709 us | 28,210 us | 1.23x | 3.0 MB -> 2.7 MB |
| WebVTT save with colours (400) | 527 us | 484 us | 1.09x | – |
| WebVTT -> ASSA convert (400) | 743 us | 722 us | 1.03x | 3.0 MB -> 2.7 MB |
| Unknown-format import (400) | 1,467 us | 1,429 us | 1.03x | 2.19 MB -> 2.12 MB |

## What was wrong
- **`MergeLinesSameTextUtils`** scanned every later paragraph for every paragraph and tracked removed/merged indexes in `List<int>` with `Contains`. With start times in order the inner scan now stops at the first candidate past `maxMsBetween` (both predicates reject on that gap first and the end only moves on a merge), and the sets are `HashSet<int>`. Unsorted input keeps the old full scan. This also runs on every MP4 subtitle track import.
- **Smart Titler, Magic Video Titler, CEA-708**: character tables keyed by `string`, so every character (and every two-character probe) allocated a string just to look it up. Keyed by `char` now, with a separate two-character table for the digraphs.
- **Captions Inc** called `Encoding.GetEncoding(1252)` and allocated a `char[]` plus a `byte[]` per character; **Projection Subtitle List** built a `UTF32Encoding`, a string, a `char[]` and a `byte[]` per character to get the char's own code point (lone surrogates map to U+FFFD as before).
- **FixCasing** split the rest of the line into words after every title hit to read the first one.
- **WebVTT colour conversion** restarted each of its four regexes at index 0 after every replacement and ran them on cues without any `<font`; **WebVTT to ASSA** scanned the SSA style list with `Any` per paragraph and the WebVTT style list with `FirstOrDefault` per cue class.
- **Unknown-format importer** ran six chained `Replace(char, char)` copies per line during auto-detect; now one pass, and none when the line has none of the characters.

Dropped during the round because the benchmarks showed identical allocations (the corpora never reached them): a key set for the Blu-ray duplicate-frame `Any` scan and a restart index for the WebVTT cue-class removal loop.

## Verification
- `tests/benchmarks/PerfHuntRound20Benchmarks.cs`
- Byte-identical dump diff
- `tests/libse`: 1916 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)