### PR TITLE
Bug hunt 24: sixteen fixes from random-file sampling

### DIFF
--- a/src/libse/Common/HtmlUtil.cs
+++ b/src/libse/Common/HtmlUtil.cs
@@ -1151,7 +1151,9 @@ namespace Nikse.SubtitleEdit.Core.Common
 
                 //FALCONE:<i> I didn't think</i><br /><i>it was going to be you,</i>
                 var colIdx = text.IndexOf(':');
-                if (colIdx >= 0 && Utilities.CountTagInText(text, beginTag) + Utilities.CountTagInText(text, endTag) == 4 && text.Length > colIdx + 1 && !char.IsDigit(text[colIdx + 1]))
+                // index is -1 for a text broken with a bare "\n" on Windows (GetNumberOfLines counts
+                // '\n'), and Substring(0, -1) threw - same guard as the sibling branches.
+                if (index > 0 && colIdx >= 0 && Utilities.CountTagInText(text, beginTag) + Utilities.CountTagInText(text, endTag) == 4 && text.Length > colIdx + 1 && !char.IsDigit(text[colIdx + 1]))
                 {
                     var firstLine = text.Substring(0, index);
                     var secondLine = text.Substring(index).TrimStart();

--- a/src/libse/Forms/DcPropertiesSmpte.cs
+++ b/src/libse/Forms/DcPropertiesSmpte.cs
@@ -66,6 +66,13 @@ namespace Nikse.SubtitleEdit.Core.Forms
             return sb.ToString();
         }
 
+        /// <summary>SerializeExportImageSub writes every value JSON-escaped; reading them back raw left a \ or " doubled.</summary>
+        private static string Read(SeJsonParser jp, string json, string key)
+        {
+            var value = jp.GetFirstObject(json, key);
+            return value == null ? null : Json.DecodeJsonText(value);
+        }
+
         public bool Load(string fileName)
         {
             if (string.IsNullOrEmpty(fileName) || !File.Exists(fileName))
@@ -77,21 +84,21 @@ namespace Nikse.SubtitleEdit.Core.Forms
             {
                 var json = File.ReadAllText(fileName, Encoding.UTF8);
                 var jp = new SeJsonParser();
-                GenerateIdAuto = jp.GetFirstObject(json, "generateIdAuto");
-                ReelNumber = jp.GetFirstObject(json, "reelNumber");
-                Language = jp.GetFirstObject(json, "language");
-                EditRate = jp.GetFirstObject(json, "editRate");
-                TimeCodeRate = jp.GetFirstObject(json, "timeCodeRate");
-                StartTime = jp.GetFirstObject(json, "startTime");
-                FontId = jp.GetFirstObject(json, "fontId");
-                FontUri = jp.GetFirstObject(json, "fontUri");
-                FontColor = jp.GetFirstObject(json, "fontColor");
-                Effect = jp.GetFirstObject(json, "effect");
-                EffectColor = jp.GetFirstObject(json, "effectColor");
-                FontSize = jp.GetFirstObject(json, "fontSize");
-                TopBottomMargin = jp.GetFirstObject(json, "topBottomMargin");
-                FadeUpTime = jp.GetFirstObject(json, "fadeUpTime");
-                FadeDownTime = jp.GetFirstObject(json, "fadeDownTime");
+                GenerateIdAuto = Read(jp, json, "generateIdAuto");
+                ReelNumber = Read(jp, json, "reelNumber");
+                Language = Read(jp, json, "language");
+                EditRate = Read(jp, json, "editRate");
+                TimeCodeRate = Read(jp, json, "timeCodeRate");
+                StartTime = Read(jp, json, "startTime");
+                FontId = Read(jp, json, "fontId");
+                FontUri = Read(jp, json, "fontUri");
+                FontColor = Read(jp, json, "fontColor");
+                Effect = Read(jp, json, "effect");
+                EffectColor = Read(jp, json, "effectColor");
+                FontSize = Read(jp, json, "fontSize");
+                TopBottomMargin = Read(jp, json, "topBottomMargin");
+                FadeUpTime = Read(jp, json, "fadeUpTime");
+                FadeDownTime = Read(jp, json, "fadeDownTime");
             }
             catch
             {

--- a/src/libse/SubtitleFormats/FLVCoreCuePoints.cs
+++ b/src/libse/SubtitleFormats/FLVCoreCuePoints.cs
@@ -26,7 +26,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 XmlNode paragraph = xml.CreateElement("CuePoint");
 
                 XmlNode startTime = xml.CreateElement("Time");
-                startTime.InnerText = p.StartTime.TotalMilliseconds.ToString();
+                startTime.InnerText = ((long)Math.Round(p.StartTime.TotalMilliseconds)).ToString(System.Globalization.CultureInfo.InvariantCulture);
                 paragraph.AppendChild(startTime);
 
                 XmlNode paragraphType = xml.CreateElement("Type");
@@ -52,7 +52,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 name = xml.CreateElement("Name");
                 name.InnerText = "duration";
                 value = xml.CreateElement("Value");
-                value.InnerText = p.DurationTotalMilliseconds.ToString();
+                value.InnerText = ((long)Math.Round(p.DurationTotalMilliseconds)).ToString(System.Globalization.CultureInfo.InvariantCulture);
                 parameter.AppendChild(name);
                 parameter.AppendChild(value);
                 parameters.AppendChild(parameter);

--- a/src/libse/SubtitleFormats/HollyStarJson.cs
+++ b/src/libse/SubtitleFormats/HollyStarJson.cs
@@ -68,8 +68,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 sb.AppendLine("\t\t\t],");
 
                 sb.AppendLine($"\t\t\t\"ClassName\": \"{language}\", ");
-                sb.AppendLine($"\t\t\t\"ShowTime\": {p.StartTime.TotalMilliseconds}, ");
-                sb.AppendLine($"\t\t\t\"HideTime\": {p.EndTime.TotalMilliseconds}");
+                sb.AppendLine($"\t\t\t\"ShowTime\": {(long)Math.Round(p.StartTime.TotalMilliseconds)}, ");
+                sb.AppendLine($"\t\t\t\"HideTime\": {(long)Math.Round(p.EndTime.TotalMilliseconds)}");
                 sb.AppendLine("\t\t}");
             }
 

--- a/src/libse/SubtitleFormats/JsonType17.cs
+++ b/src/libse/SubtitleFormats/JsonType17.cs
@@ -39,8 +39,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
                 sb.Append(" ], ");
                 sb.Append($"\"index\":{count},");
-                sb.Append($"\"start\": {p.StartTime.TotalMilliseconds}, ");
-                sb.Append($"\"end\": {p.EndTime.TotalMilliseconds} ");
+                sb.Append($"\"start\": {(long)Math.Round(p.StartTime.TotalMilliseconds)}, ");
+                sb.Append($"\"end\": {(long)Math.Round(p.EndTime.TotalMilliseconds)} ");
                 sb.Append("}");
             }
             sb.AppendLine();

--- a/src/libse/SubtitleFormats/JsonType5.cs
+++ b/src/libse/SubtitleFormats/JsonType5.cs
@@ -18,9 +18,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             for (int i = 0; i < subtitle.Paragraphs.Count; i++)
             {
                 Paragraph p = subtitle.Paragraphs[i];
-                sb.Append(p.StartTime.TotalMilliseconds);
+                sb.Append((long)Math.Round(p.StartTime.TotalMilliseconds));
                 sb.Append(',');
-                sb.Append(p.EndTime.TotalMilliseconds);
+                sb.Append((long)Math.Round(p.EndTime.TotalMilliseconds));
                 if (i < subtitle.Paragraphs.Count - 1)
                 {
                     sb.Append(',');
@@ -86,7 +86,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
             else
             {
-                sb.Append(timeRangeParagraph.StartTime.TotalMilliseconds);
+                sb.Append((long)Math.Round(timeRangeParagraph.StartTime.TotalMilliseconds));
             }
 
             sb.Append(',');
@@ -97,7 +97,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             }
             else
             {
-                sb.Append(timeRangeParagraph.EndTime.TotalMilliseconds);
+                sb.Append((long)Math.Round(timeRangeParagraph.EndTime.TotalMilliseconds));
             }
 
             sb.Append(']');

--- a/src/libse/SubtitleFormats/JsonType7.cs
+++ b/src/libse/SubtitleFormats/JsonType7.cs
@@ -18,7 +18,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             for (int i = 0; i < subtitle.Paragraphs.Count; i++)
             {
                 Paragraph p = subtitle.Paragraphs[i];
-                sb.Append(p.StartTime.TotalMilliseconds);
+                sb.Append((long)Math.Round(p.StartTime.TotalMilliseconds));
                 if (i < subtitle.Paragraphs.Count - 1)
                 {
                     sb.Append(',');
@@ -30,7 +30,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             for (int i = 0; i < subtitle.Paragraphs.Count; i++)
             {
                 Paragraph p = subtitle.Paragraphs[i];
-                sb.Append(p.EndTime.TotalMilliseconds);
+                sb.Append((long)Math.Round(p.EndTime.TotalMilliseconds));
                 if (i < subtitle.Paragraphs.Count - 1)
                 {
                     sb.Append(',');

--- a/src/libse/SubtitleFormats/OpenDvt.cs
+++ b/src/libse/SubtitleFormats/OpenDvt.cs
@@ -95,7 +95,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 line.AppendChild(stream);
 
                 XmlNode timeMS = xml.CreateElement("TimeMs");
-                timeMS.InnerText = p.StartTime.TotalMilliseconds.ToString();
+                timeMS.InnerText = ((long)Math.Round(p.StartTime.TotalMilliseconds)).ToString(System.Globalization.CultureInfo.InvariantCulture);
                 line.AppendChild(timeMS);
 
                 XmlNode pageNo = xml.CreateElement("PageNo");

--- a/src/libse/SubtitleFormats/PodcastIndexer.cs
+++ b/src/libse/SubtitleFormats/PodcastIndexer.cs
@@ -78,7 +78,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
                         if (!string.IsNullOrEmpty(actorObject))
                         {
-                            p.Actor = actorObject;
+                            p.Actor = Json.DecodeJsonText(actorObject); // ToText encodes it, like "body"
                         }
 
                         subtitle.Paragraphs.Add(p);

--- a/src/libse/SubtitleFormats/UnknownSubtitle105.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle105.cs
@@ -15,18 +15,30 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             var sb = new StringBuilder();
             var seconds = 0d;
+            var first = subtitle.GetParagraphOrDefault(0);
+            if (first != null && first.StartTime.TotalMilliseconds > 100)
+            {
+                // the timeline is a chain of waits from zero - an empty wait carries the first cue's offset
+                sb.AppendLine("<br>");
+                sb.AppendLine($"{EncodeTime(first.StartTime.TotalSeconds)}");
+            }
+
             for (var index = 0; index < subtitle.Paragraphs.Count; index++)
             {
                 var p = subtitle.Paragraphs[index];
-                sb.AppendLine($"{EncodeTime(p.DurationTotalSeconds)}");
+
+                // The reader shows the text ACCUMULATED BEFORE a [WAIT] line for that wait's
+                // duration, so the text goes first and its duration follows. Writing the wait
+                // first paired every text with the next cue's duration and shifted all cues.
                 sb.AppendLine(p.Text);
+                sb.AppendLine($"{EncodeTime(p.DurationTotalSeconds)}");
 
                 seconds += p.DurationTotalSeconds;
                 var next = subtitle.GetParagraphOrDefault(index + 1);
                 if (next != null && (next.StartTime.TotalMilliseconds - p.EndTime.TotalMilliseconds) > 100)
                 {
-                    sb.AppendLine($"{EncodeTime(next.StartTime.TotalSeconds - p.EndTime.TotalSeconds)}");
                     sb.AppendLine("<br>");
+                    sb.AppendLine($"{EncodeTime(next.StartTime.TotalSeconds - p.EndTime.TotalSeconds)}");
                 }
             }
 

--- a/src/libse/SubtitleFormats/UnknownSubtitle2.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle2.cs
@@ -38,8 +38,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var sb = new StringBuilder();
             foreach (Paragraph p in subtitle.Paragraphs)
             {
-                string startTime = string.Format("{0:00}:{1:00}:{2:00},{3:00}:0000000000", p.StartTime.Hours, p.StartTime.Minutes, p.StartTime.Seconds, p.StartTime.Milliseconds / 10);
-                string timeOut = string.Format("{0:00}:{1:00}:{2:00},{3:00}:0000000000", p.EndTime.Hours, p.EndTime.Minutes, p.EndTime.Seconds, p.EndTime.Milliseconds / 10);
+                string startTime = string.Format("{0:00}:{1:00}:{2:00},{3:000}:0000000000", p.StartTime.Hours, p.StartTime.Minutes, p.StartTime.Seconds, p.StartTime.Milliseconds);
+                string timeOut = string.Format("{0:00}:{1:00}:{2:00},{3:000}:0000000000", p.EndTime.Hours, p.EndTime.Minutes, p.EndTime.Seconds, p.EndTime.Milliseconds);
                 sb.AppendLine(string.Format(paragraphWriteFormat, p.Number, startTime, timeOut, p.Text.Replace(Environment.NewLine, "|")));
             }
             return sb.ToString().Trim();

--- a/src/libse/SubtitleFormats/UnknownSubtitle3.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle3.cs
@@ -26,7 +26,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var sb = new StringBuilder();
             foreach (Paragraph p in subtitle.Paragraphs)
             {
-                sb.AppendLine(string.Format(paragraphWriteFormat, MillisecondsToFrames(p.StartTime.TotalMilliseconds), MillisecondsToFrames(p.EndTime.TotalMilliseconds), p.Text.Replace(Environment.NewLine, "\\~")));
+                sb.AppendLine(string.Format(paragraphWriteFormat, (long)Math.Round(p.StartTime.TotalMilliseconds), (long)Math.Round(p.EndTime.TotalMilliseconds), p.Text.Replace(Environment.NewLine, "\\~")));
             }
             return sb.ToString().Trim();
         }

--- a/src/libse/SubtitleFormats/UnknownSubtitle31.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle31.cs
@@ -137,7 +137,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             int frames = MillisecondsToFrames(time.TotalMilliseconds);
             int footage = frames / 16;
-            int rest = (int)Math.Round(frames % 16.0 / 16.0 * Configuration.Settings.General.CurrentFrameRate);
+            int rest = frames % 16; // frames within the 16-frame foot - the reader adds them straight to 16 * footage
             return $"{footage}.{rest:00}";
         }
 

--- a/src/libse/SubtitleFormats/UnknownSubtitle4.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle4.cs
@@ -57,6 +57,21 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             return rounded;
         }
 
+        /// <summary>
+        /// The fraction is written with two digits (hundredths, see the sample and ToText); it was
+        /// read back as whole milliseconds, so "00:00:22.50" reloaded as 22.050 s.
+        /// </summary>
+        private static int ParseFraction(string s)
+        {
+            var value = int.Parse(s);
+            return s.Length switch
+            {
+                1 => value * 100,
+                2 => value * 10,
+                _ => value,
+            };
+        }
+
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
         {
             var paragraph = new Paragraph();
@@ -77,11 +92,11 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             int startHours = int.Parse(parts[0]);
                             int startMinutes = int.Parse(parts[1]);
                             int startSeconds = int.Parse(parts[2]);
-                            int startMilliseconds = int.Parse(parts[3]);
+                            int startMilliseconds = ParseFraction(parts[3]);
                             int endHours = int.Parse(parts[4]);
                             int endMinutes = int.Parse(parts[5]);
                             int endSeconds = int.Parse(parts[6]);
-                            int endMilliseconds = int.Parse(parts[7]);
+                            int endMilliseconds = ParseFraction(parts[7]);
                             paragraph.StartTime = new TimeCode(startHours, startMinutes, startSeconds, startMilliseconds);
                             paragraph.EndTime = new TimeCode(endHours, endMinutes, endSeconds, endMilliseconds);
                             expecting = ExpectingLine.Text;

--- a/src/libse/SubtitleFormats/UnknownSubtitle45.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle45.cs
@@ -48,7 +48,7 @@ ST 0 EB 3.10
 
         private static string EncodeTimeCode(TimeCode time)
         {
-            return $"{time.TotalSeconds:00000}.{MillisecondsToFramesMaxFrameRate(time.Milliseconds):00}";
+            return $"{(int)time.TotalSeconds:00000}.{MillisecondsToFramesMaxFrameRate(time.Milliseconds):00}"; // truncate: "{0:00000}" rounded 1.5 s up to 00002
         }
 
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)

--- a/src/libse/SubtitleFormats/UnknownSubtitle50.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle50.cs
@@ -164,8 +164,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 int endMinutes = int.Parse(parts[5]);
                 int endSeconds = int.Parse(parts[6]);
                 int endMilliseconds = int.Parse(parts[7]);
-                paragraph.StartTime = new TimeCode(startHours, startMinutes, startSeconds, startMilliseconds);
-                paragraph.EndTime = new TimeCode(endHours, endMinutes, endSeconds, endMilliseconds);
+                // the last field is frames (00-29 in the sample header), which FormatTime also writes
+                paragraph.StartTime = new TimeCode(startHours, startMinutes, startSeconds, FramesToMillisecondsMax999(startMilliseconds));
+                paragraph.EndTime = new TimeCode(endHours, endMinutes, endSeconds, FramesToMillisecondsMax999(endMilliseconds));
                 return true;
             }
             catch

--- a/src/libse/SubtitleFormats/UnknownSubtitle60.cs
+++ b/src/libse/SubtitleFormats/UnknownSubtitle60.cs
@@ -31,8 +31,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var sb = new StringBuilder();
             foreach (Paragraph p in subtitle.Paragraphs)
             {
+                // The format carries the start time only (see the sample above). Writing the end
+                // time as a second time code line made the reader start a new cue at the end time.
                 sb.AppendLine(EncodeTimeCode(p.StartTime));
-                sb.AppendLine(EncodeTimeCode(p.EndTime));
                 if (!string.IsNullOrEmpty(p.Actor))
                 {
                     sb.AppendLine(p.Actor.ToUpperInvariant());

--- a/src/libse/SubtitleFormats/YouTubeTranscriptOneLine.cs
+++ b/src/libse/SubtitleFormats/YouTubeTranscriptOneLine.cs
@@ -10,6 +10,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
     {
         private static readonly Regex RegexTimeCodes = new Regex(@"^\d{1,3}:\d\d.+$", RegexOptions.Compiled);
         private static readonly Regex RegexTimeCodesHours = new Regex(@"^\d{1,2}:\d{1,3}:\d\d$", RegexOptions.Compiled);
+        private static readonly Regex RegexTimeCodesHoursWithText = new Regex(@"^\d{1,2}:\d\d:\d\d[ \t]", RegexOptions.Compiled);
 
         public override string Extension => ".txt";
 
@@ -43,7 +44,21 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             char[] trimChars = { '–', '.', ';', ':' };
             foreach (var line in lines)
             {
-                if (RegexTimeCodes.IsMatch(line))
+                if (RegexTimeCodesHoursWithText.IsMatch(line))
+                {
+                    // "1:01:01 text" also matches the minutes:seconds regex below, which took
+                    // "1:01" as the time and left ":01 text" as the text - so test hours first.
+                    var splitter = line.IndexOf(':', line.IndexOf(':') + 1) + 3;
+                    var text = line.Remove(0, splitter);
+                    var p = new Paragraph(DecodeTimeCodeHours(line.Substring(0, splitter)), new TimeCode(), text);
+                    subtitle.Paragraphs.Add(p);
+                    text = text.Trim().Trim(trimChars).Trim();
+                    if (text.Length > 0 && char.IsDigit(text[0]))
+                    {
+                        _errorCount++;
+                    }
+                }
+                else if (RegexTimeCodes.IsMatch(line))
                 {
                     var splitter = line.IndexOf(':') + 3;
                     var text = line.Remove(0, splitter);

--- a/src/ui/Features/Assa/AssaDraw/DrawShape.cs
+++ b/src/ui/Features/Assa/AssaDraw/DrawShape.cs
@@ -63,30 +63,25 @@ public class DrawShape
         // Start with move command using the first point
         sb.Append(CultureInfo.InvariantCulture, $"m {first.X:0.##} {first.Y:0.##} ");
 
-        // Determine if this is a bezier shape by checking if first point or any following points are bezier type
-        var isBezierShape = Points.Any(p => p.DrawType == DrawCoordinateType.BezierCurve || 
-                                             p.DrawType == DrawCoordinateType.BezierCurveSupport1 || 
-                                             p.DrawType == DrawCoordinateType.BezierCurveSupport2);
+        // A shape can mix line and bezier segments (the importer appends "l" and "b" runs to
+        // the same shape, and switching tools mid-shape does too). Emit each point under the
+        // command its type calls for: a "b" run takes triplets (Support1, Support2, BezierCurve)
+        // and an "l" run takes single points. Serializing a mixed shape as one "b" run turned
+        // the straight points into bezier control points and shifted every later triplet.
+        var currentCommand = ' ';
+        for (var i = 1; i < Points.Count; i++)
+        {
+            var point = Points[i];
+            var command = point.DrawType is DrawCoordinateType.BezierCurve or DrawCoordinateType.BezierCurveSupport1 or DrawCoordinateType.BezierCurveSupport2
+                ? 'b'
+                : 'l';
+            if (command != currentCommand)
+            {
+                sb.Append(command).Append(' ');
+                currentCommand = command;
+            }
 
-        if (isBezierShape)
-        {
-            // Bezier shape: output as "b x1 y1 x2 y2 x3 y3 ..."
-            // The coordinates after index 0 should be in triplets: (Support1, Support2, BezierCurve)
-            sb.Append("b ");
-            
-            for (var i = 1; i < Points.Count; i++)
-            {
-                sb.Append(CultureInfo.InvariantCulture, $"{Points[i].X:0.##} {Points[i].Y:0.##} ");
-            }
-        }
-        else
-        {
-            // Line shape: output each point with "l" command
-            for (var i = 1; i < Points.Count; i++)
-            {
-                var point = Points[i];
-                sb.Append(CultureInfo.InvariantCulture, $"l {point.X:0.##} {point.Y:0.##} ");
-            }
+            sb.Append(CultureInfo.InvariantCulture, $"{point.X:0.##} {point.Y:0.##} ");
         }
 
         return sb.ToString().Trim();

--- a/src/ui/Features/Assa/AssaStylePickerWindow.cs
+++ b/src/ui/Features/Assa/AssaStylePickerWindow.cs
@@ -73,7 +73,7 @@ public class AssaStylePickerWindow : Window
             Header = Se.Language.General.Usages,
             CellTheme = UiUtil.TableViewCellTheme,
             HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
-            Binding = new Binding(nameof(StyleDisplay.FontSize)),
+            Binding = new Binding(nameof(StyleDisplay.UsageCount)),
             Width = new GridLength(90),
         };
         usagesColumn.Bind(SeTableViewColumn.IsVisibleProperty, new Binding(nameof(vm.ShowUsageCount))

--- a/src/ui/Features/Assa/AssaStylesViewModel.cs
+++ b/src/ui/Features/Assa/AssaStylesViewModel.cs
@@ -472,10 +472,11 @@ public partial class AssaStylesViewModel : ObservableObject, IClosingCleanup
             return;
         }
 
-        var ssaStyles = FileStyles.Where(p => p.UsageCount > 0 && p.Name != selectedStyle.Name).Select(p => p.ToSsaStyle()).ToList();
+        var usedStyles = FileStyles.Where(p => p.UsageCount > 0 && p.Name != selectedStyle.Name).ToList();
         var result = await _windowService.ShowDialogAsync<AssaStylePickerWindow, AssaStylePickerViewModel>(Window, vm =>
         {
-            var styles = ssaStyles.Select(p => new StyleDisplay(p)).ToList();
+            // ToSsaStyle() does not carry the usage count, which is the column this picker shows
+            var styles = usedStyles.Select(p => new StyleDisplay(p.ToSsaStyle()) { UsageCount = p.UsageCount }).ToList();
             vm.Initialize(Se.Language.Assa.TakeUsagesFromDotDotDot, styles, Se.Language.General.Ok, true);
         });
 

--- a/src/ui/Features/Shared/PickMatroskaTrack/PickMatroskaTrackViewModel.cs
+++ b/src/ui/Features/Shared/PickMatroskaTrack/PickMatroskaTrackViewModel.cs
@@ -195,7 +195,8 @@ public partial class PickMatroskaTrackViewModel : ObservableObject
             var subtitle = new Subtitle();
             Utilities.LoadMatroskaTextSubtitle(trackInfo, _matroskaFile, subtitles, subtitle);
             Utilities.ParseMatroskaTextSt(trackInfo, subtitles, subtitle);
-            await WriteTextSubtitleFile(Window, trackInfo, subtitles, new SubRip());
+            // pass the decoded cues - the helper's own load has no TextST branch and wrote the raw payload as text
+            await WriteTextSubtitleFile(Window, trackInfo, subtitles, new SubRip(), subtitle);
         }
         else if (trackInfo.CodecId.Equals(MatroskaTrackType.VobSub, StringComparison.OrdinalIgnoreCase) && subtitles != null)
         {
@@ -282,10 +283,13 @@ public partial class PickMatroskaTrackViewModel : ObservableObject
         return new SKPointI(left, top);
     }
 
-    private async Task WriteTextSubtitleFile(Window window, MatroskaTrackInfo trackInfo, List<MatroskaSubtitle> subtitles, SubtitleFormat format)
+    private async Task WriteTextSubtitleFile(Window window, MatroskaTrackInfo trackInfo, List<MatroskaSubtitle> subtitles, SubtitleFormat format, Subtitle? decoded = null)
     {
-        var sub = new Subtitle();
-        Utilities.LoadMatroskaTextSubtitle(trackInfo, _matroskaFile, subtitles, sub);
+        var sub = decoded ?? new Subtitle();
+        if (decoded == null)
+        {
+            Utilities.LoadMatroskaTextSubtitle(trackInfo, _matroskaFile, subtitles, sub);
+        }
         var rawText = format.ToText(sub, string.Empty);
         var suggestedFileName = Utilities.GetPathAndFileNameWithoutExtension(_fileName);
         var fileName = await _fileHelper.PickSaveSubtitleFile(window, format.Extension, suggestedFileName, Se.Language.General.SaveFileAsTitle);

--- a/src/ui/Features/Ssa/SsaStylesViewModel.cs
+++ b/src/ui/Features/Ssa/SsaStylesViewModel.cs
@@ -362,10 +362,11 @@ public partial class SsaStylesViewModel : ObservableObject, IClosingCleanup
             return;
         }
 
-        var ssaStyles = FileStyles.Where(p => p.UsageCount > 0 && p.Name != selectedStyle.Name).Select(p => p.ToSsaStyle()).ToList();
+        var usedStyles = FileStyles.Where(p => p.UsageCount > 0 && p.Name != selectedStyle.Name).ToList();
         var result = await _windowService.ShowDialogAsync<AssaStylePickerWindow, AssaStylePickerViewModel>(Window, vm =>
         {
-            var styles = ssaStyles.Select(p => StripAlpha(new StyleDisplay(p))).ToList();
+            // ToSsaStyle() does not carry the usage count, which is the column this picker shows
+            var styles = usedStyles.Select(p => StripAlpha(new StyleDisplay(p.ToSsaStyle()) { UsageCount = p.UsageCount })).ToList();
             vm.Initialize(Se.Language.Assa.TakeUsagesFromDotDotDot, styles, Se.Language.General.Ok, true);
         });
 

--- a/tests/UI/Features/Assa/DrawShapeToAssaTests.cs
+++ b/tests/UI/Features/Assa/DrawShapeToAssaTests.cs
@@ -1,0 +1,58 @@
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Features.Assa.AssaDraw;
+
+namespace UITests.Features.Assa;
+
+/// <summary>
+/// A shape can hold both line and bezier segments (the importer appends "l" and "b" runs to one
+/// shape). ToAssa serialized any shape with a bezier point as a single "b" run, which turned the
+/// straight points into bezier control points and shifted every later triplet.
+/// </summary>
+public class DrawShapeToAssaTests
+{
+    private static DrawShape MakeShape(params (DrawCoordinateType type, float x, float y)[] points)
+    {
+        var shape = new DrawShape();
+        foreach (var (type, x, y) in points)
+        {
+            shape.AddPoint(type, x, y, Colors.White);
+        }
+
+        return shape;
+    }
+
+    [Fact]
+    public void ToAssa_LineOnly_EmitsLineCommands()
+    {
+        var shape = MakeShape((DrawCoordinateType.Line, 0, 0), (DrawCoordinateType.Line, 100, 0), (DrawCoordinateType.Line, 100, 100));
+
+        Assert.Equal("m 0 0 l 100 0 100 100", shape.ToAssa());
+    }
+
+    [Fact]
+    public void ToAssa_BezierOnly_EmitsOneBezierRun()
+    {
+        var shape = MakeShape(
+            (DrawCoordinateType.BezierCurve, 0, 0),
+            (DrawCoordinateType.BezierCurveSupport1, 10, 20),
+            (DrawCoordinateType.BezierCurveSupport2, 30, 40),
+            (DrawCoordinateType.BezierCurve, 50, 60));
+
+        Assert.Equal("m 0 0 b 10 20 30 40 50 60", shape.ToAssa());
+    }
+
+    [Fact]
+    public void ToAssa_MixedShape_KeepsLineSegmentsOutOfTheBezierRun()
+    {
+        // m 0 0 l 100 0 b 100 50 50 100 0 100 l 0 0
+        var shape = MakeShape(
+            (DrawCoordinateType.Line, 0, 0),
+            (DrawCoordinateType.Line, 100, 0),
+            (DrawCoordinateType.BezierCurveSupport1, 100, 50),
+            (DrawCoordinateType.BezierCurveSupport2, 50, 100),
+            (DrawCoordinateType.BezierCurve, 0, 100),
+            (DrawCoordinateType.Line, 0, 0));
+
+        Assert.Equal("m 0 0 l 100 0 b 100 50 50 100 0 100 l 0 0", shape.ToAssa());
+    }
+}

--- a/tests/libse/SubtitleFormats/BugHunt24Test.cs
+++ b/tests/libse/SubtitleFormats/BugHunt24Test.cs
@@ -1,0 +1,258 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Forms;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+
+namespace LibSETests.SubtitleFormats;
+
+/// <summary>
+/// Guard tests for the 2026-09-06 random-file bug hunt: writers whose own readers could not
+/// round-trip them (culture-sensitive millisecond output, hundredths or frames read as
+/// milliseconds, cue order swapped, an hour-long time code parsed as minutes), a JSON field
+/// written escaped but read raw, and an unguarded Substring in the italic-tag fixer.
+/// </summary>
+public class BugHunt24Test
+{
+    private static Subtitle Make(params (string text, double start, double end)[] cues)
+    {
+        var subtitle = new Subtitle();
+        foreach (var (text, start, end) in cues)
+        {
+            subtitle.Paragraphs.Add(new Paragraph(text, start, end));
+        }
+
+        return subtitle;
+    }
+
+    private static Subtitle RoundTrip(SubtitleFormat format, Subtitle subtitle)
+    {
+        var text = format.ToText(subtitle, "title");
+        var loaded = new Subtitle();
+        format.LoadSubtitle(loaded, text.SplitToLines(), null);
+        return loaded;
+    }
+
+    private static T WithCulture<T>(string name, Func<T> action)
+    {
+        var old = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = new CultureInfo(name);
+        try
+        {
+            return action();
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = old;
+        }
+    }
+
+    public static TheoryData<SubtitleFormat> CommaCultureWriters => new()
+    {
+        new FLVCoreCuePoints(),
+        new HollyStarJson(),
+        new JsonType5(),
+        new JsonType7(),
+        new JsonType17(),
+        new OpenDvt(),
+    };
+
+    [Theory]
+    [MemberData(nameof(CommaCultureWriters))]
+    public void MillisecondWriters_UnderCommaDecimalCulture_RoundTrip(SubtitleFormat format)
+    {
+        // fractional milliseconds (e.g. after a frame-rate conversion) formatted with the current
+        // culture gave "1500,5", which the integer-parsing readers rejected or split on the comma
+        var subtitle = Make(("Hello there", 1500.5, 3000.25), ("World again", 4000.75, 6000.5));
+
+        var loaded = WithCulture("da-DK", () => RoundTrip(format, subtitle));
+
+        Assert.Equal(2, loaded.Paragraphs.Count);
+        Assert.Equal(1500.5, loaded.Paragraphs[0].StartTime.TotalMilliseconds, 1.0);
+        Assert.Equal(4000.75, loaded.Paragraphs[1].StartTime.TotalMilliseconds, 1.0);
+        if (format is not OpenDvt) // OpenDVT carries start times only; the reader estimates the duration
+        {
+            Assert.Equal(6000.5, loaded.Paragraphs[1].EndTime.TotalMilliseconds, 1.0);
+        }
+    }
+
+    [Fact]
+    public void UnknownSubtitle2_WritesThreeDigitMilliseconds()
+    {
+        // the sample header reads "00:00:48,862" (milliseconds) and the reader takes the field as
+        // milliseconds, but the writer emitted hundredths - 1.520 s came back as 1.052 s
+        var loaded = RoundTrip(new UnknownSubtitle2(), Make(("Hi", 1520, 3480)));
+
+        Assert.Equal(1520, loaded.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(3480, loaded.Paragraphs[0].EndTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void UnknownSubtitle4_TwoDigitFraction_IsHundredths()
+    {
+        // sample: "00:00:22.00, 00:00:27.00" - two digits; reading them as milliseconds put 22.50 at 22.050
+        var format = new UnknownSubtitle4();
+        var loaded = new Subtitle();
+        format.LoadSubtitle(loaded, "00:00:22.50, 00:00:27.05\r\nHi".SplitToLines(), null);
+
+        Assert.Equal(22500, loaded.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(27050, loaded.Paragraphs[0].EndTime.TotalMilliseconds);
+
+        var roundTripped = RoundTrip(format, Make(("Hi", 1520, 3480)));
+        Assert.Equal(1520, roundTripped.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(3480, roundTripped.Paragraphs[0].EndTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void UnknownSubtitle3_WritesMilliseconds_NotFrames()
+    {
+        // the sample header "155822||160350" is milliseconds and the reader takes them as such;
+        // the writer emitted frame counts, so 1.520 s came back as 0.036 s
+        var loaded = RoundTrip(new UnknownSubtitle3(), Make(("Hi", 1520, 3480)));
+
+        Assert.Equal(1520, loaded.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(3480, loaded.Paragraphs[0].EndTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void UnknownSubtitle31_RestFieldIsFramesWithinFoot()
+    {
+        // "footage.frames" with 16 frames per foot: the writer scaled the remainder by the frame
+        // rate, so a cue at 1.520 s reloaded 60 ms late
+        var loaded = RoundTrip(new UnknownSubtitle31(), Make(("Hi", 1520, 3480), ("There", 4000, 6000)));
+
+        var frameMs = 1000.0 / Configuration.Settings.General.CurrentFrameRate;
+        Assert.Equal(1520, loaded.Paragraphs[0].StartTime.TotalMilliseconds, frameMs);
+        Assert.Equal(3480, loaded.Paragraphs[0].EndTime.TotalMilliseconds, frameMs);
+        Assert.Equal(4000, loaded.Paragraphs[1].StartTime.TotalMilliseconds, frameMs);
+    }
+
+    [Fact]
+    public void UnknownSubtitle45_SecondsFieldTruncates()
+    {
+        // "{0:00000}" on the seconds double rounded 1.52 s up to "00002" and then appended the frames
+        // of the 520 ms as well - 1.520 s came back as 2.500 s
+        var loaded = RoundTrip(new UnknownSubtitle45(), Make(("Hi", 1520, 3480)));
+
+        var frameMs = 1000.0 / Configuration.Settings.General.CurrentFrameRate;
+        Assert.Equal(1520, loaded.Paragraphs[0].StartTime.TotalMilliseconds, frameMs);
+        Assert.Equal(3480, loaded.Paragraphs[0].EndTime.TotalMilliseconds, frameMs);
+    }
+
+    [Fact]
+    public void UnknownSubtitle50_LastFieldIsFrames()
+    {
+        // the sample header "00.00.05.09-00.00.08.29" carries frames (00-29), which FormatTime
+        // writes, but the reader took the field as milliseconds
+        var loaded = RoundTrip(new UnknownSubtitle50(), Make(("Hi", 1520, 3480)));
+
+        var frameMs = 1000.0 / Configuration.Settings.General.CurrentFrameRate;
+        Assert.Equal(1520, loaded.Paragraphs[0].StartTime.TotalMilliseconds, frameMs);
+        Assert.Equal(3480, loaded.Paragraphs[0].EndTime.TotalMilliseconds, frameMs);
+    }
+
+    [Fact]
+    public void UnknownSubtitle60_WritesStartTimeOnly()
+    {
+        // the format has one time code per cue; the writer also emitted the end time, which the
+        // reader took as the start of a new (empty) cue, so every cue reloaded at its old end time
+        var loaded = RoundTrip(new UnknownSubtitle60(), Make(("Hi", 1520, 3480), ("There", 4000, 6000)));
+
+        var frameMs = 1000.0 / Configuration.Settings.General.CurrentFrameRate;
+        Assert.Equal(2, loaded.Paragraphs.Count);
+        Assert.Equal(1520, loaded.Paragraphs[0].StartTime.TotalMilliseconds, frameMs);
+        Assert.Equal("Hi", loaded.Paragraphs[0].Text);
+        Assert.Equal(4000, loaded.Paragraphs[1].StartTime.TotalMilliseconds, frameMs);
+        Assert.Equal("There", loaded.Paragraphs[1].Text);
+    }
+
+    [Fact]
+    public void UnknownSubtitle105_TextPrecedesItsWait()
+    {
+        // the reader shows the text collected before a [WAIT] line for that wait's duration;
+        // the writer put the wait first, so every text got the next cue's timing
+        var loaded = RoundTrip(new UnknownSubtitle105(), Make(("Hi", 1520, 3480), ("There", 4000, 6000)));
+
+        Assert.Equal(2, loaded.Paragraphs.Count);
+        Assert.Equal("Hi", loaded.Paragraphs[0].Text);
+        Assert.Equal(1520, loaded.Paragraphs[0].StartTime.TotalMilliseconds, 1);
+        Assert.Equal(3480, loaded.Paragraphs[0].EndTime.TotalMilliseconds, 1);
+        Assert.Equal("There", loaded.Paragraphs[1].Text);
+        Assert.Equal(4000, loaded.Paragraphs[1].StartTime.TotalMilliseconds, 1);
+        Assert.Equal(6000, loaded.Paragraphs[1].EndTime.TotalMilliseconds, 1);
+    }
+
+    [Fact]
+    public void YouTubeTranscriptOneLine_HourLongTimeCode_KeepsHoursAndText()
+    {
+        // "1:01:01 Third one" matched the minutes:seconds regex first and loaded as 1:01 with ":01 Third one" as text
+        var loaded = RoundTrip(new YouTubeTranscriptOneLine(), Make(("Hi", 1000, 3000), ("Third one", 3661000, 3663000)));
+
+        Assert.Equal(2, loaded.Paragraphs.Count);
+        Assert.Equal(3661000, loaded.Paragraphs[1].StartTime.TotalMilliseconds);
+        Assert.Equal("Third one", loaded.Paragraphs[1].Text);
+    }
+
+    [Fact]
+    public void PodcastIndexer_SpeakerIsDecodedLikeBody()
+    {
+        var subtitle = Make(("Hello", 1000, 3000));
+        subtitle.Paragraphs[0].Actor = "Bob \"The Builder\"";
+
+        var loaded = RoundTrip(new PodcastIndexer(), subtitle);
+
+        Assert.Equal("Bob \"The Builder\"", loaded.Paragraphs[0].Actor);
+    }
+
+    [Fact]
+    public void DcPropertiesSmpte_EscapedValuesReloadUnescaped()
+    {
+        var fileName = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".json");
+        try
+        {
+            var props = new DcPropertiesSmpte
+            {
+                GenerateIdAuto = "true",
+                ReelNumber = "1",
+                Language = "en",
+                EditRate = "24 1",
+                TimeCodeRate = "24",
+                StartTime = "00:00:00:00",
+                FontId = "Font1",
+                FontUri = "C:\\fonts\\a.ttf",
+                FontColor = "FFFFFFFF",
+                Effect = "border",
+                EffectColor = "FF000000",
+                FontSize = "42",
+                TopBottomMargin = "8",
+                FadeUpTime = "0",
+                FadeDownTime = "0",
+            };
+            Assert.True(props.Save(fileName));
+
+            var loaded = new DcPropertiesSmpte();
+            Assert.True(loaded.Load(fileName));
+            Assert.Equal("C:\\fonts\\a.ttf", loaded.FontUri);
+            Assert.Equal("1", loaded.ReelNumber);
+        }
+        finally
+        {
+            File.Delete(fileName);
+        }
+    }
+
+    [Fact]
+    public void FixInvalidItalicTags_ColonBranch_BareNewline_DoesNotThrow()
+    {
+        // GetNumberOfLines counts '\n', so a bare "\n" reaches the two-line branch; on Windows
+        // IndexOf(Environment.NewLine) is then -1 and the "FALCONE:" sub-branch did Substring(0, -1)
+        var text = "<i>FALCONE: I didn't think</i>\n<i>it was you</i>";
+
+        var result = HtmlUtil.FixInvalidItalicTags(text);
+
+        Assert.Contains("FALCONE", result);
+        Assert.Contains("it was you", result);
+    }
+}


### PR DESCRIPTION
Twenty-fourth bug hunt: seeded random shuffle of all C# sources, five parallel reviewers over 24-file slices, plus a solo fractional-ms / comma-culture round-trip sweep over every text format. Every finding below was confirmed by execution before fixing.

## Format writers/readers that could not round-trip their own output
- **FLVCoreCuePoints, HoliStar JSON, JSON Type 5/7/17, OpenDVT** wrote milliseconds with the current culture (`1500,5` under da-DK etc.); their integer readers dropped the cue or split on the comma. Now write whole ms invariantly.
- **Unknown 2** wrote hundredths where the sample and reader expect ms (1.520 s reloaded as 1.052 s).
- **Unknown 4** read the two-digit fraction as ms (`00:00:22.50` → 22.050 s).
- **Unknown 3** wrote frame counts where the sample and reader expect ms (1.520 s reloaded as 0.036 s).
- **Unknown 31** scaled the frames-within-foot field by the frame rate; the reader adds it straight to `16 * footage`.
- **Unknown 45** formatted the seconds double with `{0:00000}`, rounding 1.52 s up to `00002` and then appending the frames of the 520 ms (→ 2.5 s).
- **Unknown 50** read the frames field as ms.
- **Unknown 60** wrote an end-time line that the start-only reader took as the next cue's start, so every cue reloaded at its old end time.
- **Unknown 105** wrote `[WAIT]` before its text, but the reader pairs text with the *following* wait, so every cue took the next cue's timing. The writer now also emits the first cue's offset.
- **YouTube transcript one line**: `1:01:01 text` matched the minutes regex first and loaded as 1:01 with `:01 text` as the text.

## Other
- **ASSA style picker** "Usages" column was bound to `FontSize`; both callers also dropped the count when converting to `SsaStyle`, so "Take usages from…" showed font sizes.
- **Matroska TextST track → Export** built the decoded cues and then threw them away; the helper's own load has no TextST branch and wrote the raw payload as text.
- **AssaDraw `DrawShape.ToAssa`** serialized a mixed line/bezier shape as one `b` run, turning straight points into bezier control points and shifting every later triplet.
- **`HtmlUtil.FixInvalidItalicTags`** "FALCONE:" branch did `Substring(0, -1)` for a bare `\n` on Windows; the sibling branches were already guarded for the same crash.
- **PodcastIndexer** read `speaker` raw although `ToText` JSON-escapes it (like `body`).
- **DcPropertiesSmpte** read every value raw although `Save` JSON-escapes them (`C:\fonts\a.ttf` reloaded doubled).

## Tests
- `tests/libse/SubtitleFormats/BugHunt24Test.cs` (18 tests)
- `tests/UI/Features/Assa/DrawShapeToAssaTests.cs` (3 tests)

Full libse suite green locally (1934 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
