### PR TITLE
Perf hunt round 21: translation pre-processing, find/replace, statistics, name and user word lists

### DIFF
--- a/src/libse/Cea608/CcRow.cs
+++ b/src/libse/Cea608/CcRow.cs
@@ -161,6 +161,19 @@
         /// </summary>
         public static string GetCharForByte(int byteValue)
         {
+            // One string per decoded character; the byte domain is small, so keep the strings.
+            if (byteValue >= 0 && byteValue < CharForByteCache.Length)
+            {
+                return CharForByteCache[byteValue] ?? (CharForByteCache[byteValue] = MakeCharForByte(byteValue));
+            }
+
+            return MakeCharForByte(byteValue);
+        }
+
+        private static readonly string[] CharForByteCache = new string[256];
+
+        private static string MakeCharForByte(int byteValue)
+        {
             if (Constants.ExtendedCharCodes.TryGetValue(byteValue, out var v))
             {
                 return char.ConvertFromUtf32(v);

--- a/src/libse/Common/Subtitle.cs
+++ b/src/libse/Common/Subtitle.cs
@@ -855,17 +855,30 @@ namespace Nikse.SubtitleEdit.Core.Common
         /// <returns>Number of lines deleted</returns>
         public int RemoveParagraphsByIndices(IEnumerable<int> indices)
         {
-            var count = 0;
-            foreach (var index in indices.OrderByDescending(p => p))
+            var indexList = indices as IList<int> ?? indices.ToList();
+            var indexSet = new HashSet<int>(indexList);
+            if (indexSet.Count != indexList.Count)
             {
-                if (index >= 0 && index < Paragraphs.Count)
+                // A repeated index removed a second, shifted line in the original loop; keep
+                // that (odd) behaviour for such callers rather than guess.
+                var removed = 0;
+                foreach (var index in indexList.OrderByDescending(p => p))
                 {
-                    Paragraphs.RemoveAt(index);
-                    count++;
+                    if (index >= 0 && index < Paragraphs.Count)
+                    {
+                        Paragraphs.RemoveAt(index);
+                        removed++;
+                    }
                 }
+
+                return removed;
             }
 
-            return count;
+            // Single compaction pass instead of RemoveAt per index (O(paragraphs * k)).
+            var count = Paragraphs.Count;
+            var i = 0;
+            Paragraphs.RemoveAll(p => indexSet.Contains(i++));
+            return count - Paragraphs.Count;
         }
 
         /// <summary>

--- a/src/libse/Common/Utilities.cs
+++ b/src/libse/Common/Utilities.cs
@@ -1469,10 +1469,11 @@ namespace Nikse.SubtitleEdit.Core.Common
             if (File.Exists(userWordListXmlFileName))
             {
                 userWordDictionary.Load(userWordListXmlFileName);
+                var seen = new HashSet<string>(); // List.Contains per word was quadratic in the user dictionary
                 foreach (XmlNode node in userWordDictionary.DocumentElement.SelectNodes("word"))
                 {
                     string s = NormalizeUserDictionaryWord(node.InnerText);
-                    if (s.Length > 0 && !userWordList.Contains(s))
+                    if (s.Length > 0 && seen.Add(s))
                     {
                         userWordList.Add(s);
                     }
@@ -3593,19 +3594,23 @@ namespace Nikse.SubtitleEdit.Core.Common
             "複製",       // zh-TW - Traditional Chinese
         };
 
+        // CopyWords is constant, but the ~400-char alternation was escaped, joined and
+        // interpolated (twice per loop) on every call - once per candidate file in a folder scan.
+        private static readonly Regex CopySuffixRegex = new Regex($@"(\s*[-_]?\s*({string.Join("|", CopyWords.Select(Regex.Escape))})(?:\s*\(\d+\))?)$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex NumberSuffixRegex = new Regex(@"\s*\(\d+\)$", RegexOptions.Compiled);
+
         public static string GetLenientPathAndFileNameWithoutExtension(string fileName)
         {
             var strictName = GetPathAndFileNameWithoutExtension(fileName);
-            var copyPattern = string.Join("|", CopyWords.Select(Regex.Escape));
 
             // Remove common suffixes like " - Copy", " - Copy (2)"
-            while (Regex.IsMatch(strictName, $@"(\s*[-_]?\s*({copyPattern})(?:\s*\(\d+\))?)$", RegexOptions.IgnoreCase))
+            while (CopySuffixRegex.IsMatch(strictName))
             {
-                strictName = Regex.Replace(strictName, $@"(\s*[-_]?\s*({copyPattern})(?:\s*\(\d+\))?)$", "", RegexOptions.IgnoreCase);
+                strictName = CopySuffixRegex.Replace(strictName, "");
             }
 
             // Remove common suffixes like "(2)", "(3)", etc.
-            strictName = Regex.Replace(strictName, @"\s*\(\d+\)$", "");
+            strictName = NumberSuffixRegex.Replace(strictName, "");
 
             return strictName;
         }

--- a/src/libse/Dictionaries/NameList.cs
+++ b/src/libse/Dictionaries/NameList.cs
@@ -191,6 +191,8 @@ namespace Nikse.SubtitleEdit.Core.Dictionaries
                 _namesList.Remove(name);
                 _namesMultiList.Remove(name);
                 _namesMultiListParts = null;
+                _namesListCaseInsensitive = null;
+                _namesMultiListCaseInsensitive = null;
 
                 var fileName = GetLocalNamesUserFileName();
                 var nameListXml = CreateDocument(fileName);
@@ -271,6 +273,8 @@ namespace Nikse.SubtitleEdit.Core.Dictionaries
             if (name.Contains(" "))
             {
                 _namesMultiListParts = null;
+                _namesListCaseInsensitive = null;
+                _namesMultiListCaseInsensitive = null;
                 return _namesMultiList.Add(name);
             }
 
@@ -365,6 +369,27 @@ namespace Nikse.SubtitleEdit.Core.Dictionaries
             return index;
         }
 
+        // Case-insensitive views of the two name sets, built on first use and dropped whenever
+        // the sets change (same lifetime as _namesMultiListParts). The lookup used to walk the
+        // whole set with OrdinalIgnoreCase Equals per name candidate per line.
+        private Dictionary<string, string> _namesListCaseInsensitive;
+        private Dictionary<string, string> _namesMultiListCaseInsensitive;
+
+        private static Dictionary<string, string> BuildCaseInsensitiveIndex(HashSet<string> names)
+        {
+            var index = new Dictionary<string, string>(names.Count, StringComparer.OrdinalIgnoreCase);
+            foreach (var n in names)
+            {
+                // First entry in set order wins, as the replaced foreach did.
+                if (!index.ContainsKey(n))
+                {
+                    index.Add(n, n);
+                }
+            }
+
+            return index;
+        }
+
         public bool ContainsCaseInsensitive(string name, out string newName)
         {
             newName = null;
@@ -373,13 +398,20 @@ namespace Nikse.SubtitleEdit.Core.Dictionaries
                 return false;
             }
 
-            foreach (var n in name.IndexOf(' ') >= 0 ? _namesMultiList : _namesList)
+            Dictionary<string, string> index;
+            if (name.IndexOf(' ') >= 0)
             {
-                if (name.Equals(n, StringComparison.OrdinalIgnoreCase))
-                {
-                    newName = n;
-                    return true;
-                }
+                index = _namesMultiListCaseInsensitive ?? (_namesMultiListCaseInsensitive = BuildCaseInsensitiveIndex(_namesMultiList));
+            }
+            else
+            {
+                index = _namesListCaseInsensitive ?? (_namesListCaseInsensitive = BuildCaseInsensitiveIndex(_namesList));
+            }
+
+            if (index.TryGetValue(name, out var found))
+            {
+                newName = found;
+                return true;
             }
 
             return false;

--- a/src/libuilogic/Translate/Formatting.cs
+++ b/src/libuilogic/Translate/Formatting.cs
@@ -33,6 +33,9 @@ namespace Nikse.SubtitleEdit.UiLogic.Translate
             "eu", "eus_Latn"
         };
 
+        // Contains() on the 44-entry list ran per translated line.
+        private static readonly HashSet<string> LanguagesAllowingLineMergingSet = new HashSet<string>(LanguagesAllowingLineMerging, StringComparer.Ordinal);
+
         private bool Italic { get; set; }
         private string Font { get; set; } = string.Empty;
         private bool ItalicTwoLines { get; set; }
@@ -157,7 +160,7 @@ namespace Nikse.SubtitleEdit.UiLogic.Translate
             }
 
             // Un-break line
-            if (LanguagesAllowingLineMerging.Contains(sourceLanguage))
+            if (sourceLanguage != null && LanguagesAllowingLineMergingSet.Contains(sourceLanguage))
             {
                 var lines = HtmlUtil.RemoveHtmlTags(text).SplitToLines();
                 if (lines.Count == 2 && !string.IsNullOrEmpty(lines[0]) && !string.IsNullOrEmpty(lines[1]) &&

--- a/src/libuilogic/Translate/TranslationHelper.cs
+++ b/src/libuilogic/Translate/TranslationHelper.cs
@@ -51,34 +51,46 @@ namespace Nikse.SubtitleEdit.UiLogic.Translate
             .Replace("</ i>", "</i>");
         }
 
+        private static readonly (Regex Regex, string Replacement)[] EnglishContractions =
+        {
+            (new Regex(@"\bI'm ", RegexOptions.Compiled), "I am "),
+            (new Regex(@"\bI've ", RegexOptions.Compiled), "I have "),
+            (new Regex(@"\bI'll ", RegexOptions.Compiled), "I will "),
+            (new Regex(@"\b(I|i)t's ", RegexOptions.Compiled), "$1t is "),
+            (new Regex(@"\b(Y|y)ou're ", RegexOptions.Compiled), "$1ou are "),
+            (new Regex(@"\b(Y|y)ou've ", RegexOptions.Compiled), "$1ou have "),
+            (new Regex(@"\b(Y|y)ou'll ", RegexOptions.Compiled), "$1ou will "),
+            (new Regex(@"\b(H|h)e's ", RegexOptions.Compiled), "$1e is "),
+            (new Regex(@"\b(S|s)he's ", RegexOptions.Compiled), "$1he is "),
+            (new Regex(@"\b(W|w)e're ", RegexOptions.Compiled), "$1e are "),
+            (new Regex(@"\bwon't ", RegexOptions.Compiled), "will not "),
+            (new Regex(@"\bdon't ", RegexOptions.Compiled), "do not "),
+            (new Regex(@"\bDon't ", RegexOptions.Compiled), "Do not "),
+            (new Regex(@"\b(W|w)e're ", RegexOptions.Compiled), "$1e are "),
+            (new Regex(@"\b(T|t)hey're ", RegexOptions.Compiled), "$1hey are "),
+            (new Regex(@"\b(W|w)ho's ", RegexOptions.Compiled), "$1ho is "),
+            (new Regex(@"\b(T|t)hat's ", RegexOptions.Compiled), "$1hat is "),
+            (new Regex(@"\b(W|w)hat's ", RegexOptions.Compiled), "$1hat is "),
+            (new Regex(@"\b(W|w)here's ", RegexOptions.Compiled), "$1here is "),
+            (new Regex(@"\b(W|w)ho's ", RegexOptions.Compiled), "$1ho is "),
+            (new Regex(@"\B'(C|c)ause ", RegexOptions.Compiled), "$1ecause "),
+        };
+
         public static string PreTranslate(string input, string source)
         {
             string s = FixInvalidCarriageReturnLineFeedCharacters(input);
 
-            if (source == "en")
+            if (source == "en" && s.IndexOf('\'') >= 0)
             {
-                s = Regex.Replace(s, @"\bI'm ", "I am ");
-                s = Regex.Replace(s, @"\bI've ", "I have ");
-                s = Regex.Replace(s, @"\bI'll ", "I will ");
-                s = Regex.Replace(s, @"\b(I|i)t's ", "$1t is ");
-                s = Regex.Replace(s, @"\b(Y|y)ou're ", "$1ou are ");
-                s = Regex.Replace(s, @"\b(Y|y)ou've ", "$1ou have ");
-                s = Regex.Replace(s, @"\b(Y|y)ou'll ", "$1ou will ");
-                s = Regex.Replace(s, @"\b(H|h)e's ", "$1e is ");
-                s = Regex.Replace(s, @"\b(S|s)he's ", "$1he is ");
-                s = Regex.Replace(s, @"\b(W|w)e're ", "$1e are ");
-                s = Regex.Replace(s, @"\bwon't ", "will not ");
-                s = Regex.Replace(s, @"\bdon't ", "do not ");
-                s = Regex.Replace(s, @"\bDon't ", "Do not ");
-                s = Regex.Replace(s, @"\b(W|w)e're ", "$1e are ");
-                s = Regex.Replace(s, @"\b(T|t)hey're ", "$1hey are ");
-                s = Regex.Replace(s, @"\b(W|w)ho's ", "$1ho is ");
-                s = Regex.Replace(s, @"\b(T|t)hat's ", "$1hat is ");
-                s = Regex.Replace(s, @"\b(W|w)hat's ", "$1hat is ");
-                s = Regex.Replace(s, @"\b(W|w)here's ", "$1here is ");
-                s = Regex.Replace(s, @"\b(W|w)ho's ", "$1ho is ");
-                s = Regex.Replace(s, @"\B'(C|c)ause ", "$1ecause "); // \b (word boundry) does not work with '
+                // Every pattern needs an apostrophe, so lines without one skip the whole table.
+                // These were 21 static Regex.Replace calls per line - more distinct patterns than
+                // Regex.CacheSize (15) holds, so the cache thrashed and re-parsed them.
+                foreach (var (regex, replacement) in EnglishContractions)
+                {
+                    s = regex.Replace(s, replacement);
+                }
             }
+
             return s;
         }
 

--- a/src/ui/Features/Files/Statistics/StatisticsViewModel.cs
+++ b/src/ui/Features/Files/Statistics/StatisticsViewModel.cs
@@ -807,12 +807,14 @@ https://github.com/SubtitleEdit/subtitleedit
         var sb = new StringBuilder();
         if (sortedTable.Count > 0)
         {
-            var temp = string.Empty;
-            foreach (KeyValuePair<string, string> item in sortedTable)
+            // Most frequent first: the table sorts ascending, so emit it back to front. This was
+            // a prepend concatenation per entry - quadratic in the size of the word/line table.
+            foreach (var item in sortedTable.Reverse())
             {
-                temp = item.Value + Environment.NewLine + temp;
+                sb.Append(item.Value).Append(Environment.NewLine);
             }
-            sb.AppendLine(temp);
+
+            sb.AppendLine();
         }
         else
         {
@@ -851,12 +853,14 @@ https://github.com/SubtitleEdit/subtitleedit
         var sb = new StringBuilder();
         if (sortedTable.Count > 0)
         {
-            var temp = string.Empty;
-            foreach (KeyValuePair<string, string> item in sortedTable)
+            // Most frequent first: the table sorts ascending, so emit it back to front. This was
+            // a prepend concatenation per entry - quadratic in the size of the word/line table.
+            foreach (var item in sortedTable.Reverse())
             {
-                temp = item.Value + Environment.NewLine + temp;
+                sb.Append(item.Value).Append(Environment.NewLine);
             }
-            sb.AppendLine(temp);
+
+            sb.AppendLine();
         }
         else
         {

--- a/src/ui/Logic/FindService.cs
+++ b/src/ui/Logic/FindService.cs
@@ -557,21 +557,26 @@ public partial class FindService : IFindService
             return ReplaceWholeWordWithStringComparison(line, searchText, replaceText, startIndex, maxReplacements, comparison);
         }
 
-        string workingLine = line;
+        // Single pass: the line is copied once into the builder instead of being rebuilt (two
+        // Substrings and a concat) for every match, which was quadratic on lines with many hits.
+        StringBuilder? result = null;
         int totalReplacements = 0;
+        int copiedUpTo = 0;
         int currentIndex = startIndex;
 
-        while (currentIndex < workingLine.Length && (maxReplacements == -1 || totalReplacements < maxReplacements))
+        while (currentIndex < line.Length && (maxReplacements == -1 || totalReplacements < maxReplacements))
         {
-            var index = workingLine.IndexOf(searchText, currentIndex, comparison);
+            var index = line.IndexOf(searchText, currentIndex, comparison);
             if (index == -1)
             {
                 break;
             }
 
-            workingLine = workingLine.Substring(0, index) + replaceText + workingLine.Substring(index + searchText.Length);
+            result ??= new StringBuilder(line.Length);
+            result.Append(line, copiedUpTo, index - copiedUpTo).Append(replaceText);
+            copiedUpTo = index + searchText.Length;
             totalReplacements++;
-            currentIndex = index + replaceText.Length;
+            currentIndex = copiedUpTo;
 
             // For single replacement, break after first replacement
             if (maxReplacements == 1)
@@ -580,7 +585,13 @@ public partial class FindService : IFindService
             }
         }
 
-        return (totalReplacements > 0, workingLine, totalReplacements);
+        if (result == null)
+        {
+            return (false, line, 0);
+        }
+
+        result.Append(line, copiedUpTo, line.Length - copiedUpTo);
+        return (true, result.ToString(), totalReplacements);
     }
 
     private (bool replaced, string newText, int replacementCount) ReplaceWholeWordWithStringComparison(string line, string searchText, string replaceText, int startIndex, int maxReplacements, StringComparison comparison)

--- a/tests/benchmarks/PerfHuntRound21Benchmarks.cs
+++ b/tests/benchmarks/PerfHuntRound21Benchmarks.cs
@@ -1,0 +1,293 @@
+using BenchmarkDotNet.Attributes;
+using Nikse.SubtitleEdit.Core.Cea608;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Dictionaries;
+using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.UiLogic.Translate;
+using System.Text;
+
+namespace Nikse.SubtitleEdit.Benchmarks;
+
+/// <summary>
+/// Round 21 performance hunt, outside the subtitle formats: translation pre-processing,
+/// the find/replace service, the statistics word table, the names list, the user word list,
+/// lenient file-name matching, CEA-608 character decode and bulk paragraph removal. Public entry points, plus self-contained old/new copies where the
+/// method is private (statistics); <see cref="SubRipControl"/> is the drift control.
+///
+/// Default job, in-process, Apple M4, .NET 10, quiet machine (SubRipControl 80.6 us -> 78.3 us,
+/// identical allocations):
+///
+///   NameList.ContainsCaseInsensitive (400)   1,475 us -> 2.6 us    570x
+///   Statistics word table (5000 entries)    16,108 us -> 129 us    125x   311 MB -> 336 KB allocated
+///   PreTranslate, English (400 lines)        7,232 us -> 252 us    29x    28.7 MB -> 339 KB
+///   LoadUserWordList (5000 words)           20,204 us -> 931 us    22x
+///   Lenient file names (400)                 1,195 us -> 118 us    10x    578 KB -> 50 KB
+///   CEA-608 char for byte (400 x 96)           137 us -> 21 us     6.5x   922 KB -> 0
+///   FindService.ReplaceAll (400 lines)         106 us -> 47 us     2.25x  1.2 MB -> 166 KB
+///   RemoveParagraphsByIndices (5000 -> 2500)  1,456 us -> 1,154 us 1.26x  (includes the subtitle copy)
+///   Formatting.SetTagsAndReturnTrimmed (eu)    129 us -> 103 us    1.25x
+/// </summary>
+[MemoryDiagnoser]
+public class PerfHuntRound21Benchmarks
+{
+    private Subtitle _taggedSubtitle = new();
+    private string[] _contractionLines = Array.Empty<string>();
+    private string[] _twoLineTexts = Array.Empty<string>();
+    private List<string> _replaceLines = new();
+    private NameList _names = null!;
+    private string[] _nameProbes = Array.Empty<string>();
+    private string[] _fileNames = Array.Empty<string>();
+    private Subtitle _bigSubtitle = new();
+    private List<int> _removeIndices = new();
+    private SortedDictionary<string, string> _wordTable = new();
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _taggedSubtitle = BuildTaggedSubtitle(400);
+        _contractionLines = Enumerable.Range(0, 400).Select(i => (i % 3) switch
+        {
+            0 => $"I'm sure you're right, it's what they're after {i}.{Environment.NewLine}Don't you think? 'Cause I've seen it.",
+            1 => $"She's here and he's there, who's counting {i}?",
+            _ => $"No contractions in this line at all, number {i}.",
+        }).ToArray();
+        _twoLineTexts = Enumerable.Range(0, 400).Select(i => $"<i>The quick brown fox number {i}</i>{Environment.NewLine}jumps over the lazy dog.").ToArray();
+        _replaceLines = Enumerable.Range(0, 400).Select(i => $"fox fox fox, the fox {i} chased a fox and another fox until the fox slept fox").ToList();
+
+        var dictionaries = FindDictionariesFolder();
+        _names = new NameList(dictionaries, "en", false, string.Empty);
+        _nameProbes = new[] { "john", "MARY", "jean-luc", "zzznotaname", "new york", "Sherlock holmes", "nobody here", "smith" };
+
+        _fileNames = Enumerable.Range(0, 400).Select(i => (i % 4) switch
+        {
+            0 => $"/videos/Show.S01E{i:00} - Copy (2).mkv",
+            1 => $"/videos/Show.S01E{i:00} - kopia.mkv",
+            2 => $"/videos/Show.S01E{i:00} (3).mkv",
+            _ => $"/videos/Show.S01E{i:00}.mkv",
+        }).ToArray();
+
+        _bigSubtitle = BuildTaggedSubtitle(5000);
+        _removeIndices = Enumerable.Range(0, 5000).Where(i => i % 2 == 0).ToList();
+
+        for (var i = 0; i < 5000; i++)
+        {
+            var count = 2 + i % 40;
+            _wordTable.Add($"{count:0000}_word{i}", count + ": word" + i);
+        }
+
+        var dir = Path.Combine(Path.GetTempPath(), "se-perf-round21", "Dictionaries");
+        Directory.CreateDirectory(dir);
+        var xml = new StringBuilder("<words>");
+        for (var i = 0; i < 5000; i++)
+        {
+            xml.Append("<word>userword").Append(i).Append("</word>");
+        }
+
+        xml.Append("</words>");
+        File.WriteAllText(Path.Combine(dir, "en_user.xml"), xml.ToString());
+        Configuration.DataDirectory = Path.Combine(Path.GetTempPath(), "se-perf-round21") + Path.DirectorySeparatorChar;
+
+        AssertEquivalence();
+    }
+
+    private static string FindDictionariesFolder()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null)
+        {
+            var candidate = Path.Combine(dir.FullName, "Dictionaries");
+            if (File.Exists(Path.Combine(candidate, "names.xml")))
+            {
+                return candidate + Path.DirectorySeparatorChar;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Dictionaries/names.xml not found above " + AppContext.BaseDirectory);
+    }
+
+    private static string Sentence(int i) =>
+        $"The quick brown fox number {i} jumps over the lazy dog, twice, and then rests.";
+
+    private static Subtitle BuildTaggedSubtitle(int count)
+    {
+        var s = new Subtitle();
+        for (var i = 0; i < count; i++)
+        {
+            var text = (i % 4) switch
+            {
+                0 => $"<i>{Sentence(i)}</i>{Environment.NewLine}Second line of cue {i}.",
+                1 => $"He said: <b>no</b>.{Environment.NewLine}<font color=\"#ffff00\">Yellow {i}</font> and <u>more</u>.",
+                2 => $"{Sentence(i)}{Environment.NewLine}<i>Whispered</i> reply.",
+                _ => Sentence(i),
+            };
+            s.Paragraphs.Add(new Paragraph(text, i * 3000, i * 3000 + 2500));
+        }
+
+        return s;
+    }
+
+    private void AssertEquivalence()
+    {
+        if (WordTableOld(_wordTable) != WordTableNew(_wordTable))
+        {
+            throw new Exception("statistics word table old/new differ");
+        }
+
+        var expected = new List<string>();
+        foreach (var line in _replaceLines)
+        {
+            expected.Add(line.Replace("fox", "cat", StringComparison.OrdinalIgnoreCase));
+        }
+
+        var service = new FindService();
+        var lines = new List<string>(_replaceLines);
+        service.Initialize(lines, 0, false, FindService.FindMode.CaseInsensitive);
+        service.ReplaceAll("fox", "cat");
+        if (!lines.SequenceEqual(expected))
+        {
+            throw new Exception("FindService.ReplaceAll differs from string.Replace");
+        }
+    }
+
+    // ------------------------------------------------------------------ translate
+
+    [Benchmark]
+    public int PreTranslateEnglish()
+    {
+        var total = 0;
+        foreach (var line in _contractionLines)
+        {
+            total += TranslationHelper.PreTranslate(line, "en").Length;
+        }
+
+        return total;
+    }
+
+    [Benchmark]
+    public int FormattingSetTagsBasque()
+    {
+        var total = 0;
+        foreach (var text in _twoLineTexts)
+        {
+            total += new Formatting().SetTagsAndReturnTrimmed(text, "eu").Length;
+        }
+
+        return total;
+    }
+
+    // ------------------------------------------------------------------ find / replace
+
+    [Benchmark]
+    public int FindServiceReplaceAll()
+    {
+        var service = new FindService();
+        var lines = new List<string>(_replaceLines);
+        service.Initialize(lines, 0, false, FindService.FindMode.CaseInsensitive);
+        return service.ReplaceAll("fox", "cat");
+    }
+
+    // ------------------------------------------------------------------ statistics word table (self-contained old vs new)
+
+    private static string WordTableOld(SortedDictionary<string, string> sortedTable)
+    {
+        var sb = new StringBuilder();
+        var temp = string.Empty;
+        foreach (KeyValuePair<string, string> item in sortedTable)
+        {
+            temp = item.Value + Environment.NewLine + temp;
+        }
+
+        sb.AppendLine(temp);
+        return sb.ToString();
+    }
+
+    private static string WordTableNew(SortedDictionary<string, string> sortedTable)
+    {
+        var sb = new StringBuilder();
+        foreach (var item in sortedTable.Reverse())
+        {
+            sb.Append(item.Value).Append(Environment.NewLine);
+        }
+
+        sb.AppendLine();
+        return sb.ToString();
+    }
+
+    [Benchmark]
+    public int StatisticsWordTableOld() => WordTableOld(_wordTable).Length;
+
+    [Benchmark]
+    public int StatisticsWordTableNew() => WordTableNew(_wordTable).Length;
+
+    // ------------------------------------------------------------------ dictionaries
+
+    [Benchmark]
+    public int NameListContainsCaseInsensitive()
+    {
+        var hits = 0;
+        for (var i = 0; i < 50; i++)
+        {
+            foreach (var probe in _nameProbes)
+            {
+                if (_names.ContainsCaseInsensitive(probe, out _))
+                {
+                    hits++;
+                }
+            }
+        }
+
+        return hits;
+    }
+
+    [Benchmark]
+    public int LoadUserWordList()
+    {
+        var list = new List<string>();
+        Utilities.LoadUserWordList(list, "en");
+        return list.Count;
+    }
+
+    // ------------------------------------------------------------------ misc helpers
+
+    [Benchmark]
+    public int LenientFileNames()
+    {
+        var total = 0;
+        foreach (var f in _fileNames)
+        {
+            total += Utilities.GetLenientPathAndFileNameWithoutExtension(f).Length;
+        }
+
+        return total;
+    }
+
+    [Benchmark]
+    public int Cea608CharForByte()
+    {
+        var total = 0;
+        for (var i = 0; i < 400; i++)
+        {
+            for (var b = 0x20; b < 0x80; b++)
+            {
+                total += CcRow.GetCharForByte(b).Length;
+            }
+        }
+
+        return total;
+    }
+
+    [Benchmark]
+    public int RemoveParagraphsByIndices()
+    {
+        var copy = new Subtitle(_bigSubtitle);
+        return copy.RemoveParagraphsByIndices(_removeIndices);
+    }
+
+    // ------------------------------------------------------------------ drift control
+
+    [Benchmark]
+    public int SubRipControl() => new SubRip().ToText(_taggedSubtitle, "t").Length;
+}


### PR DESCRIPTION
Nine verified fixes outside the subtitle formats (BenchmarkDotNet default job, in-process, Apple M4, .NET 10, quiet machine) against a detached baseline worktree of `main`; the untouched `SubRipControl` benchmark is flat with identical allocations. The libse changes were dumped over an edge-case corpus on both sides and are byte-identical; the find/replace and statistics changes are asserted against reference implementations in the benchmark setup.

| Benchmark | Before | After | Speed-up | Allocated |
| --- | ---: | ---: | ---: | --- |
| NameList.ContainsCaseInsensitive (400 lookups) | 1,475 us | 2.6 us | 570x | – |
| Statistics word table (5000 entries) | 16,108 us | 129 us | 125x | 311 MB -> 336 KB |
| PreTranslate, English (400 lines) | 7,232 us | 252 us | 29x | 28.7 MB -> 339 KB |
| LoadUserWordList (5000 words) | 20,204 us | 931 us | 22x | – |
| Lenient file names (400) | 1,195 us | 118 us | 10x | 578 KB -> 50 KB |
| CEA-608 char for byte (400 x 96) | 137 us | 21 us | 6.5x | 922 KB -> 0 |
| FindService.ReplaceAll (400 lines) | 106 us | 47 us | 2.25x | 1.2 MB -> 166 KB |
| RemoveParagraphsByIndices (5000 -> 2500) | 1,456 us | 1,154 us | 1.26x | includes the subtitle copy |
| Formatting.SetTagsAndReturnTrimmed | 129 us | 103 us | 1.25x | – |

## What was wrong
- **`TranslationHelper.PreTranslate`** ran 21 static `Regex.Replace` calls per line, more distinct patterns than `Regex.CacheSize` holds, so the cache thrashed and re-parsed them. Now a table of compiled regexes, skipped entirely for lines without an apostrophe.
- **`NameList.ContainsCaseInsensitive`** walked the whole name set with `OrdinalIgnoreCase` `Equals` per lookup, and "remove text for hearing impaired" calls it per name candidate per line. Now a case-insensitive dictionary built on first use and dropped whenever the sets change (same lifetime as the existing multi-word index). First entry in set order wins, as before.
- **Statistics** built the most-used word and line tables by prepending to a string per entry.
- **`Utilities.LoadUserWordList`** deduplicated with `List.Contains`, quadratic in the user dictionary; **`GetLenientPathAndFileNameWithoutExtension`** escaped and joined the 30-entry copy-word table and interpolated the pattern twice per loop iteration on every call.
- **`CcRow.GetCharForByte`** allocated a string per decoded caption character; the byte domain is cached.
- **`FindService`** rebuilt the whole line (two substrings and a concat) per replaced match; one pass into a builder now.
- **`Formatting`** checked a 44-entry list per translated line; **`Subtitle.RemoveParagraphsByIndices`** removed one index at a time and now compacts in one pass (a repeated index keeps the old shifted-removal behaviour).

Dropped during the round: removing the tail `Substring` in `RemoveInterjection` measured no difference.

## Verification
- `tests/benchmarks/PerfHuntRound21Benchmarks.cs`
- Byte-identical dump diff for the libse changes (name probes incl. null/empty/multi-word, user word list with duplicates and blanks, copy suffixes in several languages, all 256 CEA-608 bytes, index lists with duplicates and out-of-range values), plus PreTranslate/Formatting for `en`, `da`, `eu`, `ja`, null
- `tests/libse`: 1916 passed; `tests/UI` FindService tests: 36 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)