### PR TITLE
Fix #14604: guess start stops at the CPS/min-duration floor instead of moving the whole line

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -5668,8 +5668,8 @@ public partial class MainViewModel :
     /// SE 4 parity ("guess start"): looks for the silence right before the speech that starts the
     /// selected line and moves the start cue there, snapping to a nearby shot change when there is
     /// one. Raising the volume threshold step by step finds the quietest boundary that still reads
-    /// as silence. Moving the start forward keeps the duration when that would otherwise break the
-    /// minimum duration/maximum CPS rules and there is room before the next line.
+    /// as silence. Moving the start forward stops at the minimum duration/maximum CPS floor, so
+    /// only the start ever moves (#14604; SE 4 shifted the whole line instead).
     /// Every outcome is reported in the status bar (#14596): a silent no-op left "no silence found",
     /// "already at the boundary" and "the shortcut never fired" indistinguishable (#14472, #14555).
     /// </summary>
@@ -5719,7 +5719,6 @@ public partial class MainViewModel :
 
         var gapMs = Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
         var prev = GetPreviousWorkingRow(index);
-        var next = GetNextWorkingRow(index);
         var alreadyAtBoundary = false;
         var lastCandidateMs = double.NaN;
 
@@ -5771,6 +5770,32 @@ public partial class MainViewModel :
                 }
             }
 
+            if (newStartMs > selected.StartTime.TotalMilliseconds)
+            {
+                // Shorten only as far as the minimum duration and maximum CPS allow, like guess
+                // end does. SE 4 moved the whole line instead (end along with the start) when the
+                // shortened line would break a rule, which on long text turned "guess start"
+                // into a shift of the line (#14604).
+                var endMs = selected.EndTime.TotalMilliseconds;
+                var maxStartMs = endMs - minDisplayMs;
+                var maxCps = Se.Settings.General.SubtitleMaximumCharactersPerSeconds;
+                if (maxCps > 0)
+                {
+                    var newStart = TimeSpanExtensions.FromMillisecondsWholeMilliseconds(newStartMs);
+                    var cps = SubtitleTextInfoHelper.GetCharactersPerSecond(selected.Text, newStart, selected.EndTime);
+                    if (cps > maxCps)
+                    {
+                        var characters = cps * (endMs - newStartMs) / TimeCode.BaseUnit;
+                        maxStartMs = Math.Min(maxStartMs, endMs - characters / maxCps * TimeCode.BaseUnit);
+                    }
+                }
+
+                if (newStartMs > maxStartMs)
+                {
+                    newStartMs = Math.Max(maxStartMs, selected.StartTime.TotalMilliseconds);
+                }
+            }
+
             if (Math.Abs(selected.StartTime.TotalMilliseconds - newStartMs) < 10)
             {
                 // The boundary at this threshold is where the cue already is. SE 4 stopped here,
@@ -5791,28 +5816,8 @@ public partial class MainViewModel :
                 continue;
             }
 
-            var durationMs = selected.EndTime.TotalMilliseconds - selected.StartTime.TotalMilliseconds;
-            var newEndMs = selected.EndTime.TotalMilliseconds;
-            if (newStartMs > selected.StartTime.TotalMilliseconds)
-            {
-                var newStart = TimeSpanExtensions.FromMillisecondsWholeMilliseconds(newStartMs);
-                var newCps = SubtitleTextInfoHelper.GetCharactersPerSecond(selected.Text, newStart, selected.EndTime);
-                if (newEndMs - newStartMs < minDisplayMs ||
-                    newCps > Se.Settings.General.SubtitleMaximumCharactersPerSeconds)
-                {
-                    // Shortening the line would break the rules, so move it instead - but only
-                    // when the next line is far enough away to take the whole duration.
-                    if (next == null || next.StartTime.TotalMilliseconds > newStartMs + durationMs + gapMs)
-                    {
-                        newEndMs = newStartMs + durationMs;
-                    }
-                }
-            }
-
             var movedMs = newStartMs - selected.StartTime.TotalMilliseconds;
-            selected.SetTimes(
-                TimeSpanExtensions.FromMillisecondsWholeMilliseconds(newStartMs),
-                TimeSpanExtensions.FromMillisecondsWholeMilliseconds(newEndMs));
+            selected.StartTime = TimeSpanExtensions.FromMillisecondsWholeMilliseconds(newStartMs);
 
             _updateAudioVisualizer = true;
             ShowStatus(string.Format(Se.Language.Main.Waveform.GuessStartMovedLineXByYMs, selected.Number, FormatSignedMs(movedMs)));

--- a/tests/UI/Features/Main/Se4GuessStartAndUnderlineTests.cs
+++ b/tests/UI/Features/Main/Se4GuessStartAndUnderlineTests.cs
@@ -26,12 +26,16 @@ public class Se4GuessStartAndUnderlineTests : IDisposable
     private readonly bool _timeCodesLocked = Se.Settings.General.LockTimeCodes;
     private readonly int _guessStartOffsetMs = Se.Settings.Waveform.GuessStartOffsetMs;
     private readonly int _guessEndOffsetMs = Se.Settings.Waveform.GuessEndOffsetMs;
+    private readonly double _maxCps = Se.Settings.General.SubtitleMaximumCharactersPerSeconds;
+    private readonly int _minDisplayMs = Se.Settings.General.SubtitleMinimumDisplayMilliseconds;
 
     public void Dispose()
     {
         Se.Settings.General.LockTimeCodes = _timeCodesLocked;
         Se.Settings.Waveform.GuessStartOffsetMs = _guessStartOffsetMs;
         Se.Settings.Waveform.GuessEndOffsetMs = _guessEndOffsetMs;
+        Se.Settings.General.SubtitleMaximumCharactersPerSeconds = _maxCps;
+        Se.Settings.General.SubtitleMinimumDisplayMilliseconds = _minDisplayMs;
         foreach (var window in _windows)
         {
             window.Close();
@@ -451,6 +455,46 @@ public class Se4GuessStartAndUnderlineTests : IDisposable
         vm.WaveformGuessStartCommand.Execute(null);
 
         Assert.InRange(vm.Subtitles[0].StartTime.TotalMilliseconds, 2400, 2500);
+    }
+
+    /// <summary>
+    /// #14604: a start cue left early on a line whose text is long. Moving the start all the way
+    /// to the speech would push the line over the maximum CPS (or under the minimum duration), and
+    /// SE 4 then shifted the whole line instead, end included, so "guess start" on long text moved
+    /// the line rather than trimmed it. The start now stops at the rule's floor and the end stays.
+    /// A second press finds the same floor and leaves the line alone.
+    /// </summary>
+    [AvaloniaTheory]
+    [InlineData(60, 25.0, 1000, 1000, 1600)] // 60 chars at 25 CPS need 2.4 s: start stops at 1.6 s
+    [InlineData(2, 25.0, 1600, 2000, 2400)] // minimum duration 1.6 s: start stops at 2.4 s
+    [InlineData(2, 25.0, 1000, 1000, 2450)] // no rule in the way: start goes to the speech
+    public void GuessStartStopsAtTheCpsAndMinimumDurationFloorInsteadOfMovingTheLine(int characters, double maxCps, int minDisplayMs, int startMs, int expectedStartMs)
+    {
+        Se.Settings.General.LockTimeCodes = false;
+        Se.Settings.Waveform.GuessStartOffsetMs = 0;
+        Se.Settings.General.SubtitleMaximumCharactersPerSeconds = maxCps;
+        Se.Settings.General.SubtitleMinimumDisplayMilliseconds = minDisplayMs;
+
+        var (window, vm) = CreateMainViewModel();
+        vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph(new string('x', characters), startMs, 4000), null!) { Number = 1 });
+        Dispatcher.UIThread.RunJobs();
+
+        var av = vm.AudioVisualizer!;
+        av.WavePeaks = MakePeaks(sampleRate: 100, seconds: 10, speechFromSeconds: 2.5, speechToSeconds: 4.0);
+        Select(vm, vm.Subtitles[0]);
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        vm.WaveformGuessStartCommand.Execute(null);
+
+        var line = vm.Subtitles[0];
+        Assert.InRange(line.StartTime.TotalMilliseconds, expectedStartMs - 10, expectedStartMs + 50);
+        Assert.Equal(4000, line.EndTime.TotalMilliseconds, 0);
+
+        var startAfterFirstPress = line.StartTime.TotalMilliseconds;
+        vm.WaveformGuessStartCommand.Execute(null);
+        Assert.Equal(startAfterFirstPress, line.StartTime.TotalMilliseconds, 0);
+        Assert.Equal(4000, line.EndTime.TotalMilliseconds, 0);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #14604.

## What happened

With long text, the "guess start" waveform shortcut shifted the whole line (end included, duration kept) instead of trimming the dead air in front of the speech. In the issue video a 37-character line at 2.071 s moves as a block, while the same line with short text is trimmed to 1.894 s.

This was the SE 4 `AutoGuessStartTime` rule carried over verbatim: when moving the start forward would push the line over the maximum CPS or under the minimum duration, and the next line leaves room, the end moved by the same amount. The reporter's max CPS setting sits between 17.9 and 19.5 (default 25), which is why most users never saw it. "Guess end" never did this; it shortens only as far as the rules allow.

## Fix

Guess start now mirrors guess end: the start moves forward only as far as the maximum CPS and minimum duration allow, and the end never moves. When the floor is where the cue already is, the existing "already starts where the speech begins" / no-change path applies. No new language strings.

## Tests

New theory in `Se4GuessStartAndUnderlineTests`: 60 characters at 25 CPS stop the start at the 2.4 s floor with the end untouched, a 1.6 s minimum duration stops it at the duration floor, and a line with no rule in the way still goes to the speech. A second press leaves the line alone in every case. All 25 tests in the class pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)