### PR TITLE
Offer 'Import plain text' on the unknown subtitle format prompt

### DIFF
--- a/src/ui/Features/Files/ImportPlainText/ImportPlainTextViewModel.cs
+++ b/src/ui/Features/Files/ImportPlainText/ImportPlainTextViewModel.cs
@@ -700,6 +700,25 @@ public partial class ImportPlainTextViewModel : ObservableObject, IClosingCleanu
         _videoFileName = videoFileName ?? string.Empty;
     }
 
+    /// <summary>
+    /// Opens the dialog with the text of a file the main window could not parse as a subtitle
+    /// (the "Import plain text" button on the unknown-format prompt, issue #14605).
+    /// </summary>
+    internal void Initialize(Subtitle subtitle, string? videoFileName, string plainTextFileName)
+    {
+        Initialize(subtitle, videoFileName);
+
+        try
+        {
+            PlainText = FileUtil.ReadAllTextShared(plainTextFileName, LanguageAutoDetect.GetEncodingFromFile(plainTextFileName));
+            MarkDirty();
+        }
+        catch
+        {
+            // unreadable file - the user can still pick another one from the dialog
+        }
+    }
+
     internal void GapChanged(object? sender, NumericUpDownValueChangedEventArgs e)
     {
         MarkDirty();

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -5154,6 +5154,41 @@ public partial class MainViewModel :
         }
     }
 
+    /// <summary>
+    /// Runs the plain text importer pre-filled with <paramref name="fileName"/> and, like
+    /// SubtitleOpen does for real subtitles, pairs it with a matching media file next to it
+    /// (unsynced lyrics next to their .flac/.mp3, issue #14605).
+    /// </summary>
+    private async Task ImportPlainTextFromFile(string fileName, bool skipLoadVideo)
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var result = await ShowDialogAsync<ImportPlainTextWindow, ImportPlainTextViewModel>(vm => vm.Initialize(_subtitle, _videoFileName, fileName));
+        if (!result.OkPressed || result.Subtitles.Count == 0)
+        {
+            return;
+        }
+
+        _subtitleFileName = string.Empty;
+        ResetSubtitle();
+        foreach (var item in result.Subtitles)
+        {
+            Subtitles.Add(item);
+        }
+
+        Renumber();
+        _updateAudioVisualizer = true;
+
+        if (!skipLoadVideo && string.IsNullOrEmpty(_videoFileName) &&
+            FindVideoFileName.TryFindVideoFileName(fileName, out var videoFileName))
+        {
+            await VideoOpenFile(videoFileName);
+        }
+    }
+
     [RelayCommand]
     private async Task ImportCsvXlsxCustomColumns()
     {
@@ -22308,8 +22343,17 @@ public partial class MainViewModel :
 
             if (subtitle == null)
             {
+                // Offer the plain text importer right here: SE4 users drop unsynced .txt lyrics
+                // onto the window and expect them in the grid without a trip through the
+                // File menu (issue #14605).
                 var message = Se.Language.General.UnknownSubtitleFormat;
-                await MessageBox.Show(Window!, Se.Language.General.Error, message, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                var answer = await MessageBox.Show(Window!, Se.Language.General.Error, message, MessageBoxButtons.OK, MessageBoxIcon.Error,
+                    custom1: Se.Language.File.Import.TitleImportPlainText);
+                if (answer == MessageBoxResult.Custom1)
+                {
+                    await ImportPlainTextFromFile(fileName, skipLoadVideo);
+                }
+
                 return;
             }
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -22343,9 +22343,17 @@ public partial class MainViewModel :
 
             if (subtitle == null)
             {
-                // Offer the plain text importer right here: SE4 users drop unsynced .txt lyrics
-                // onto the window and expect them in the grid without a trip through the
-                // File menu (issue #14605).
+                // A .txt that no format and not even the generic importer could read is prose or
+                // lyrics: go straight to the plain text importer, as SE4 did (issue #14605).
+                if (string.Equals(ext, ".txt", StringComparison.OrdinalIgnoreCase) && FileUtil.IsPlainText(fileName))
+                {
+                    await ImportPlainTextFromFile(fileName, skipLoadVideo);
+                    return;
+                }
+
+                // Otherwise offer the importer on the prompt: users drop unsynced lyrics with
+                // other extensions too and expect them in the grid without a trip through
+                // the File menu.
                 var message = Se.Language.General.UnknownSubtitleFormat;
                 var answer = await MessageBox.Show(Window!, Se.Language.General.Error, message, MessageBoxButtons.OK, MessageBoxIcon.Error,
                     custom1: Se.Language.File.Import.TitleImportPlainText);


### PR DESCRIPTION
Fixes #14605

- A plain `.txt` file that no format and not even the generic unknown-format importer can read (checked with `FileUtil.IsPlainText`) now opens the plain text importer directly, pre-filled with the file's text, as SE4 did.
- For any other extension the "Unknown subtitle format" prompt gets an **Import plain text** button next to OK that opens the same dialog.
- After OK, the result is paired with a matching media file next to the text file (`.flac`/`.mp3`/…), like `SubtitleOpen` does for real subtitles. Drag-and-drop uses the same path.

No new language strings: the button reuses `File.Import.TitleImportPlainText`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)