### PR TITLE
TTS: don't pass the translation as the reference transcript in per-line voice cloning

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/FishTtsAudioCpp.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/FishTtsAudioCpp.cs
@@ -126,6 +126,12 @@ public class FishTtsAudioCpp : ITtsEngine, IPerLineCloneEngine
     public static string GetModelFileName(string? modelKey) =>
         ResolveModelKey(modelKey) == ModelKeyBf16 ? ModelBf16FileName : ModelQ8_0FileName;
 
+    /// <summary>
+    /// What goes in <c>reference_text</c> when the reference clip's transcript is unknown: the
+    /// server refuses a missing or empty transcript, accepts this, and clones from it well.
+    /// </summary>
+    internal const string UnknownReferenceTextPlaceholder = " ";
+
     private static readonly HttpClient HttpClient = new()
     {
         Timeout = TimeSpan.FromMinutes(10),
@@ -355,14 +361,12 @@ public class FishTtsAudioCpp : ITtsEngine, IPerLineCloneEngine
     /// <see cref="IPerLineCloneEngine"/>: the server takes <c>voice_ref</c> as a path per request,
     /// so the voice simply points at the cut clip - nothing is staged into this engine's own
     /// folders. audio.cpp resamples the reference itself, so the 24 kHz clip is used as cut.
-    /// S2 Pro refuses to clone without <c>reference_text</c> (see <see cref="Speak"/>), so a clip
-    /// with no transcript beside it is no reference at all: null, and the caller falls back to
-    /// an ordinary voice for that line instead of the run failing on it.
+    /// A clip with no transcript beside it (no original-language subtitle loaded, so what the
+    /// video says is unknown) is still a usable reference: <see cref="Speak"/> sends the blank
+    /// placeholder transcript for it, which clones fine.
     /// </summary>
     public Voice? MakePerLineCloneVoice(string clipFileName, string voiceName) =>
-        string.IsNullOrWhiteSpace(ChatterboxTtsCpp.TryReadReferenceTranscript(clipFileName))
-            ? null
-            : new Voice(new IndexTtsVoice(voiceName, clipFileName));
+        new Voice(new IndexTtsVoice(voiceName, clipFileName));
 
     /// <summary>The clip's own path, which is exactly what the voice carries.</summary>
     public string? GetPerLineReferenceClip(Voice voice) =>
@@ -415,19 +419,22 @@ public class FishTtsAudioCpp : ITtsEngine, IPerLineCloneEngine
         // honoured per request — no server restart when the user switches voice.
         var options = new Dictionary<string, object>();
 
-        // The transcript of the reference WAV, from the shared .txt sidecar convention.
-        // NOT optional, whatever upstream's docs say: audio.cpp v0.7.1 answers a voice_ref
-        // without reference_text with HTTP 500 "Fish Audio prepare with inline reference
-        // audio requires reference_text option" (verified against the real server), and an
-        // empty string is refused the same way. Fail here with an actionable message instead
-        // of surfacing the server's error.
+        // The transcript of the reference WAV, from the shared .txt sidecar convention. The
+        // option itself is NOT optional, whatever upstream's docs say: audio.cpp answers a
+        // voice_ref without reference_text, or with an empty string, with HTTP 500 "Fish Audio
+        // prepare with inline reference audio requires reference_text option" (verified
+        // against the real server). A single space passes that check and the clone comes out
+        // fine, so an unknown transcript - a per-line clip cut from the video with no
+        // original-language subtitle loaded - is sent as that placeholder. What must NEVER be
+        // sent in its place is the text being spoken: the transcript and the target text share
+        // one prompt, and when they are the same line the model concludes the clip already
+        // says it and replays the clip instead of speaking the line (#14480, Polish subtitles
+        // dubbed as the video's own language).
         var referenceText = ChatterboxTtsCpp.TryReadReferenceTranscript(indexVoice.FilePath);
         if (string.IsNullOrWhiteSpace(referenceText))
         {
-            throw new InvalidOperationException(
-                "Fish Audio S2 Pro requires the transcript of the reference recording. "
-                + $"Save the spoken text as \"{Path.ChangeExtension(indexVoice.FilePath, ".txt")}\", "
-                + "or re-import the voice and enter the transcript when asked.");
+            referenceText = UnknownReferenceTextPlaceholder;
+            Se.WriteToolsLog($"Fish Audio S2 Pro (audio.cpp): no transcript beside reference '{indexVoice.FilePath}', cloning with a blank reference_text");
         }
 
         options["reference_text"] = referenceText;

--- a/src/ui/Features/Video/TextToSpeech/PerLineVoiceClone.cs
+++ b/src/ui/Features/Video/TextToSpeech/PerLineVoiceClone.cs
@@ -75,7 +75,10 @@ public static class PerLineVoiceClone
     /// </summary>
     /// <param name="referenceTextOf">
     /// What is spoken in the video for a paragraph - the original-language line when a source
-    /// subtitle is loaded, which is what the reference clip actually contains.
+    /// subtitle is loaded, which is what the reference clip actually contains - or null when
+    /// that is unknown. Unknown gets no sidecar; the line's own (possibly translated) text is
+    /// never written as a stand-in, because a transcript that is the translation of the clip
+    /// makes the engines replay the clip instead of speaking the line (#14480).
     /// </param>
     /// <returns>
     /// The clip per paragraph. Paragraphs whose cut failed are absent rather than mapped to a
@@ -84,7 +87,7 @@ public static class PerLineVoiceClone
     public static async Task<Dictionary<Paragraph, string>> CutReferenceClipsAsync(
         string videoFileName,
         IReadOnlyList<Paragraph> paragraphs,
-        Func<Paragraph, string> referenceTextOf,
+        Func<Paragraph, string?> referenceTextOf,
         string outputFolder,
         double videoDurationSeconds,
         int audioTrackFfIndex,
@@ -134,14 +137,15 @@ public static class PerLineVoiceClone
     }
 
     /// <summary>
-    /// Cuts the reference clip for one paragraph and writes its transcript sidecar. Returns null
-    /// when the clip could not be produced - the caller decides what that line falls back to.
+    /// Cuts the reference clip for one paragraph and writes its transcript sidecar when
+    /// <paramref name="referenceText"/> is known. Returns null when the clip could not be
+    /// produced - the caller decides what that line falls back to.
     /// </summary>
     public static async Task<string?> CutReferenceClipAsync(
         string videoFileName,
         IReadOnlyList<Paragraph> paragraphs,
         int index,
-        string referenceText,
+        string? referenceText,
         string outputFolder,
         double videoDurationSeconds,
         int audioTrackFfIndex,
@@ -159,9 +163,19 @@ public static class PerLineVoiceClone
             }
 
             // The engines that clone from a recording read what is spoken in it from a sibling
-            // .txt (omnivoice-tts refuses --ref-wav without one). We know it exactly here, so
-            // nobody has to type it or run speech-to-text over the clip.
-            await File.WriteAllTextAsync(Path.ChangeExtension(clipFileName, ".txt"), referenceText, cancellationToken);
+            // .txt. When the caller knows it (an original-language subtitle is loaded) nobody
+            // has to type it or run speech-to-text over the clip; when it does not, no sidecar
+            // is written and each engine decides what an unknown transcript means to it - a
+            // stale .txt from an earlier cut into the same folder must not survive either.
+            var sidecar = Path.ChangeExtension(clipFileName, ".txt");
+            if (!string.IsNullOrWhiteSpace(referenceText))
+            {
+                await File.WriteAllTextAsync(sidecar, referenceText, cancellationToken);
+            }
+            else if (File.Exists(sidecar))
+            {
+                File.Delete(sidecar);
+            }
 
             return clipFileName;
         }

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechViewModel.cs
@@ -121,7 +121,7 @@ public partial class ReviewSpeechViewModel : ObservableObject
     // ResolvePerLineCloneVoiceAsync). Supplied by the TTS window, which knows the original-language
     // subtitle a translation was dubbed from; null when it does not, and the line's own text is
     // then the best guess left.
-    public Func<Paragraph, string>? ReferenceTextOf { get; set; }
+    public Func<Paragraph, string?>? ReferenceTextOf { get; set; }
 
     public bool OkPressed { get; private set; }
 
@@ -1124,20 +1124,16 @@ public partial class ReviewSpeechViewModel : ObservableObject
 
     /// <summary>
     /// What the video says during a line - the transcript a freshly cut reference clip needs. The
-    /// original-language text when the TTS window supplied a lookup for it (a dub is generated
-    /// from a translation, and the clip holds what was said, not its translation), otherwise the
-    /// line's own text as it entered this window.
+    /// original-language text when the TTS window supplied a lookup for it and it knows (a dub
+    /// is generated from a translation, and the clip holds what was said, not its translation),
+    /// otherwise null. The line's own text is deliberately not a fallback: handing an engine the
+    /// translation as the clip's transcript makes it replay the clip instead of speaking the
+    /// line (#14480).
     /// </summary>
-    private string SpokenTextInVideo(ReviewRow line)
+    private string? SpokenTextInVideo(ReviewRow line)
     {
         var fromOriginal = ReferenceTextOf?.Invoke(line.StepResult.Paragraph);
-        if (!string.IsNullOrWhiteSpace(fromOriginal))
-        {
-            return fromOriginal;
-        }
-
-        var text = string.IsNullOrWhiteSpace(line.OriginalText) ? line.Text : line.OriginalText;
-        return Utilities.UnbreakLine(HtmlUtil.RemoveHtmlTags(text ?? string.Empty, alsoSsaTags: true));
+        return string.IsNullOrWhiteSpace(fromOriginal) ? null : fromOriginal;
     }
 
     /// <summary>

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -3279,21 +3279,24 @@ public partial class TextToSpeechViewModel : ObservableObject
     }
 
     /// <summary>
-    /// What the video says during <paramref name="paragraph"/> - the reference clip's transcript.
+    /// What the video says during <paramref name="paragraph"/> - the reference clip's transcript -
+    /// or null when that is not known.
     /// </summary>
     /// <remarks>
     /// The source-language line when a subtitle in the video's own language is loaded next to the
     /// translation, matched by start time rather than by index so a translation with merged or
-    /// split lines still lines up. Without an original loaded the line's own text is the best
-    /// guess left; that is right when dubbing a subtitle in the video's language, and merely
-    /// unhelpful (not harmful) when the text has already been translated.
+    /// split lines still lines up. Without an original loaded the answer is null, NOT the line's
+    /// own text: the cloning engines put that transcript in the same prompt as the text to speak,
+    /// and when the "transcript" is the translation of what the clip says, they are told the clip
+    /// already contains the target text - and Fish Audio S2 Pro then replays the clip (the
+    /// original-language audio) instead of speaking the line (#14480). A missing transcript
+    /// merely costs some clone fidelity on the engines that use it; a wrong one costs the dub.
     /// </remarks>
-    private string GetSpokenTextInVideo(Paragraph paragraph)
+    private string? GetSpokenTextInVideo(Paragraph paragraph)
     {
-        var fallback = HtmlUtil.RemoveHtmlTags(paragraph.Text ?? string.Empty, alsoSsaTags: true);
         if (_originalSubtitle == null || _originalSubtitle.Paragraphs.Count == 0)
         {
-            return Utilities.UnbreakLine(fallback);
+            return null;
         }
 
         // Exact start time is the normal case (a translation keeps the original's timings); the
@@ -3312,11 +3315,11 @@ public partial class TextToSpeechViewModel : ObservableObject
 
         if (Math.Abs(best.StartTime.TotalMilliseconds - paragraph.StartTime.TotalMilliseconds) > 500)
         {
-            return Utilities.UnbreakLine(fallback);
+            return null;
         }
 
         var original = HtmlUtil.RemoveHtmlTags(best.Text ?? string.Empty, alsoSsaTags: true);
-        return Utilities.UnbreakLine(string.IsNullOrWhiteSpace(original) ? fallback : original);
+        return string.IsNullOrWhiteSpace(original) ? null : Utilities.UnbreakLine(original);
     }
 
     /// <summary>

--- a/tests/UI/Features/Video/TextToSpeech/Engines/AudioCppPerLineCloneTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/AudioCppPerLineCloneTests.cs
@@ -65,14 +65,18 @@ public class AudioCppPerLineCloneTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData("   ")]
-    public void FishWithoutATranscriptFallsBackInsteadOfCloning(string? transcript)
+    public void FishWithoutATranscriptStillClones(string? transcript)
     {
-        // audio.cpp answers a Fish voice_ref without reference_text with an HTTP 500, and Speak
-        // throws on an empty sidecar - so the clip must not be handed out as a voice.
+        // A per-line clip has no transcript when no original-language subtitle is loaded. That
+        // used to drop the clip (Speak threw on an empty sidecar); now Speak sends a blank
+        // placeholder reference_text instead, which the server accepts and clones from fine -
+        // whereas writing the (translated) line as the transcript made the model replay the
+        // clip instead of speaking the line (#14480). So the clip is a voice.
         using var clips = new TempFolder();
         var clip = clips.WriteClip("line-0009", transcript);
 
-        Assert.Null(PerLineVoiceClone.MakeVoiceForClip(new FishTtsAudioCpp(), clip));
+        Assert.NotNull(PerLineVoiceClone.MakeVoiceForClip(new FishTtsAudioCpp(), clip));
+        Assert.Equal(" ", FishTtsAudioCpp.UnknownReferenceTextPlaceholder);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes the report in #14480 (comment from nielka98, 2026-09-06): Fish Audio S2 Pro "clone voice from the video" with Polish subtitles produced one Polish line and otherwise a repetition of the original audio track.

## Cause

The per-line clone writes each clip's transcript sidecar from `GetSpokenTextInVideo`, which fell back to the subtitle line itself when no original-language subtitle was loaded. Fish (and the other cloning engines) put that transcript and the text to speak in the same prompt, so the model was told the clip already says the Polish line and replayed the clip instead.

Verified against the real server (q8_0, Metal, English reference clip, Polish target, checked with whisper small):

| reference_text sent | Result |
|---|---|
| correct English transcript | word-perfect Polish |
| the Polish target (what SE sent) | English gibberish or a literal replay of the clip |
| a single space | word-perfect Polish |

## Change

- `GetSpokenTextInVideo` returns null when there is no original subtitle or no original line lines up, instead of the line's own text.
- `PerLineVoiceClone` writes no sidecar for an unknown transcript (and deletes a stale one from an earlier cut into the same folder).
- The review window's regenerate path no longer substitutes the line's own text either.
- Fish: a transcript-less clip is still a usable per-line voice; `Speak` sends a single space as `reference_text` (the server refuses missing/empty, accepts the blank) and logs it. Higgs and FireRed already treat the transcript as optional, IndexTTS 2.5 does not use it.

Not covered here: the CrispASR per-line clone engines (CosyVoice3, MOSS, OmniVoice, Pocket, Qwen3, VibeVoice, VoxCPM2) pass the same sidecar as prompt text and now get no sidecar in the translated case instead of a wrong one; how each behaves without it was not tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
