### PR TITLE
TTS: clone a per-line CosyVoice3 clip that has no transcript instead of falling back

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/CosyVoice3CrispAsr.cs
@@ -460,9 +460,12 @@ public class CosyVoice3CrispAsr : ITtsEngine, IPerLineCloneEngine
     /// <summary>
     /// <see cref="IPerLineCloneEngine"/>: the clip is staged into the voices folder, which is the
     /// server's working directory, so its bare file name is what <see cref="Speak"/> sends as the
-    /// request's <c>voice</c>. The talker is conditioned on the (transcript, speech) pair, so a
-    /// clip without a usable transcript beside it is not a reference at all - null, and that line
-    /// falls back to an ordinary voice rather than failing the run.
+    /// request's <c>voice</c>. The talker is conditioned on the (transcript, speech) pair, but a
+    /// clip with no transcript beside it (no original-language subtitle loaded, so what the video
+    /// says is unknown) is still a usable reference: the request then carries no <c>ref_text</c>,
+    /// and the crispasr cosyvoice3 backend (v0.8.32) transcribes the clip itself with whisper
+    /// before cloning from it (upstream #334, cached beside the clip). Only a clip that cannot be
+    /// staged at all is null, and that line falls back to an ordinary voice.
     /// </summary>
     public Voice? MakePerLineCloneVoice(string clipFileName, string voiceName)
     {
@@ -475,8 +478,7 @@ public class CosyVoice3CrispAsr : ITtsEngine, IPerLineCloneEngine
         var refText = TryReadRefText(staged);
         if (string.IsNullOrWhiteSpace(refText))
         {
-            Se.WriteToolsLog($"CosyVoice3 (CrispASR): no usable transcript beside '{clipFileName}' - not cloning this line");
-            return null;
+            Se.WriteToolsLog($"CosyVoice3 (CrispASR): no transcript beside '{clipFileName}' - the server transcribes the clip itself");
         }
 
         return new Voice(new CosyVoice3Voice(voiceName, staged, refText));
@@ -569,7 +571,12 @@ public class CosyVoice3CrispAsr : ITtsEngine, IPerLineCloneEngine
         }
 
         var isClone = string.IsNullOrEmpty(cosyVoice.Preset);
-        if (isClone && string.IsNullOrEmpty(cosyVoice.RefText))
+        // A per-line clone's reference is sent per request, so the server is keyed on the model
+        // only for those; an ordinary voice keeps the startup flags and their restart-on-change.
+        var isPerLineClone = isClone && PerLineReferenceStaging.IsStaged(cosyVoice.FilePath);
+        // An imported voice without a transcript is asked for one at import time; a per-line clip
+        // has nobody to ask, and the server transcribes it itself - see MakePerLineCloneVoice.
+        if (isClone && !isPerLineClone && string.IsNullOrEmpty(cosyVoice.RefText))
         {
             var error = "CosyVoice3 (CrispASR) zero-shot cloning requires a transcription. "
                 + $"Add a .txt sidecar next to '{Path.GetFileName(cosyVoice.FilePath)}' with the "
@@ -579,9 +586,6 @@ public class CosyVoice3CrispAsr : ITtsEngine, IPerLineCloneEngine
         }
 
         var modelKey = ResolveModelKey(model);
-        // A per-line clone's reference is sent per request, so the server is keyed on the model
-        // only for those; an ordinary voice keeps the startup flags and their restart-on-change.
-        var isPerLineClone = isClone && PerLineReferenceStaging.IsStaged(cosyVoice.FilePath);
         await EnsureServerRunningAsync(modelKey, voiceArg, cosyVoice.RefText, isPerLineClone, cancellationToken);
 
         var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder), Guid.NewGuid() + ".wav");

--- a/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsr.cs
@@ -310,9 +310,14 @@ public class Qwen3TtsCrispAsr : ITtsEngine, IPerLineCloneEngine
     /// the ref-text sidecar and fails. It is a plain copy and not an ffmpeg pass because the
     /// clips are cut as 24 kHz mono PCM16 already - exactly what the Base backend demands.
     ///
-    /// Null when there is no usable transcript beside the clip: the backend answers a reference
-    /// without ref-text with "ref-text not set" (HTTP 500), so the caller is better off falling
-    /// back to an ordinary voice for that line than failing it.
+    /// Null when there is no usable transcript beside the clip: the crispasr qwen3-tts backend
+    /// (v0.8.32) refuses a WAV reference without ref-text (HTTP 500), so the caller is better
+    /// off falling back to an ordinary voice for that line than failing it. Do NOT paper over
+    /// that with a placeholder transcript the way the Fish engine does: the ICL prefill pairs
+    /// the reference speech with its text, and a single-space ref_text sent to the real server
+    /// made the talker run away to the 75 s frame cap for a one-sentence line, while the true
+    /// transcript gave 3.5 s. The way out is upstream - the backend transcribing the clip
+    /// itself, as its cosyvoice3 backend already does - not a stand-in written here.
     /// </remarks>
     public static string? StagePerLineReference(string clipFileName)
     {

--- a/tests/UI/Features/Video/TextToSpeech/Engines/CosyVoice3VoxCpm2PerLineCloneTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/CosyVoice3VoxCpm2PerLineCloneTests.cs
@@ -44,6 +44,19 @@ public class CosyVoice3VoxCpm2PerLineCloneTests
     }
 
     [Fact]
+    public void CosyVoice3_PerLineClone_WithoutATranscript_SendsTheClipAlone()
+    {
+        // No original-language subtitle loaded means nobody knows what the clip says. The clip
+        // still travels; ref_text is left out and the backend (v0.8.32+) transcribes the clip
+        // itself before cloning from it. A blank or the line's own text must never be sent in
+        // its place - a transcript that is not what the clip says wrecks the decode (#14480).
+        var payload = CosyVoice3CrispAsr.BuildSpeakPayload("hello", 1.0, "se-per-line-line-0007.wav", null);
+
+        Assert.Equal("se-per-line-line-0007.wav", payload["voice"]);
+        Assert.False(payload.ContainsKey("ref_text"));
+    }
+
+    [Fact]
     public void VoxCpm2_OrdinaryVoice_SendsNoVoiceField()
     {
         var payload = VoxCPM2CrispAsr.BuildSpeakPayload("hello", 1.0, null);

--- a/tests/UI/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsrPerLineCloneTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/Qwen3TtsCrispAsrPerLineCloneTests.cs
@@ -53,6 +53,8 @@ public class Qwen3TtsCrispAsrPerLineCloneTests
     {
         // The backend answers a reference without ref-text with an HTTP 500, so the line is
         // better off falling back to an ordinary voice - which is what null means to the caller.
+        // (A placeholder transcript is not an option either: verified against the real server,
+        // it sends the talker into a runaway. See the StagePerLineReference remarks.)
         using var clips = new TempFolder();
         using var voices = new TempFolder();
         var clip = clips.WriteClip("line-0008", transcript: null);


### PR DESCRIPTION
Follow-up to #14611 for #14480.

Since #14611 a per-line reference clip cut from a video with no original-language subtitle loaded carries no transcript sidecar (the line's own translation is no longer written in its place). CosyVoice3 (CrispASR) then dropped the clone and spoke the line in an ordinary voice.

The crispasr cosyvoice3 backend SE pins (v0.8.32) transcribes a reference itself when `ref_text` is absent (upstream #334, whisper, cached beside the clip), so the clip is now sent alone and the server fills in the transcript. Verified against the real server: a bare-name voice with no `.txt` was auto-transcribed and the output speaks the requested line in the reference voice (whisper reads the result back verbatim).

Qwen3 (CrispASR) still falls back on such a line, on purpose: its backend refuses a WAV reference without ref-text, and a blank placeholder (the trick that works for Fish on audio.cpp) sent the talker into a 75 s runaway for a one-sentence line on the real server. The fix for that is in the backend (auto-transcribe like cosyvoice3); a patch is drafted separately. This PR documents that so nobody retries the placeholder.

Tests: 415 TextToSpeech UI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)