### PR TITLE
audio.cpp: ask to update the runtime when it lacks the engine's model family

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/AudioCppTtsSettings/AudioCppTtsSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/AudioCppTtsSettings/AudioCppTtsSettingsViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -30,6 +30,7 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.AudioCppTtsSettings;
 /// </summary>
 public sealed record AudioCppTtsSettingsAdapter(
     string EngineName,
+    string FamilyName,
     string Description,
     string ModelKeyDefault,
     string ModelKeyAlt,
@@ -45,6 +46,7 @@ public static class AudioCppTtsSettingsAdapters
 {
     public static AudioCppTtsSettingsAdapter Higgs { get; } = new(
         EngineName: "Higgs Audio v3 (audio.cpp)",
+        FamilyName: HiggsTtsAudioCpp.FamilyName,
         Description: new HiggsTtsAudioCpp().Description,
         ModelKeyDefault: HiggsTtsAudioCpp.ModelKeyQ8_0,
         ModelKeyAlt: HiggsTtsAudioCpp.ModelKeyBf16,
@@ -58,6 +60,7 @@ public static class AudioCppTtsSettingsAdapters
 
     public static AudioCppTtsSettingsAdapter Fish { get; } = new(
         EngineName: "Fish Audio S2 Pro (audio.cpp)",
+        FamilyName: FishTtsAudioCpp.FamilyName,
         Description: new FishTtsAudioCpp().Description,
         ModelKeyDefault: FishTtsAudioCpp.ModelKeyQ8_0,
         ModelKeyAlt: FishTtsAudioCpp.ModelKeyBf16,
@@ -71,6 +74,7 @@ public static class AudioCppTtsSettingsAdapters
 
     public static AudioCppTtsSettingsAdapter FireRedTts3 { get; } = new(
         EngineName: "FireRedTTS3 (audio.cpp)",
+        FamilyName: FireRedTts3AudioCpp.FamilyName,
         Description: new FireRedTts3AudioCpp().Description,
         ModelKeyDefault: FireRedTts3AudioCpp.ModelKeyQ8_0,
         ModelKeyAlt: FireRedTts3AudioCpp.ModelKeyOrig,
@@ -142,8 +146,10 @@ public partial class AudioCppTtsSettingsViewModel : ObservableObject
             EngineBrush = Red();
             EngineDownloadButtonText = string.Format(Se.Language.General.DownloadX, "audio.cpp");
         }
-        else if (DownloadHashManager.GetSidecarStatus(Path.GetDirectoryName(exe) ?? string.Empty) == DownloadHashManager.UpdateStatus.UpdateAvailable)
+        else if (!AudioCppRuntime.SupportsFamily(Adapter.FamilyName)
+                 || DownloadHashManager.GetSidecarStatus(Path.GetDirectoryName(exe) ?? string.Empty) == DownloadHashManager.UpdateStatus.UpdateAvailable)
         {
+            // A build that predates this engine's family is flagged too, even without a sidecar.
             EngineLabel = string.Format(Se.Language.Video.TtsEngineUpdateAvailable, "audio.cpp" + backendSuffix);
             EngineBrush = Amber();
             EngineDownloadButtonText = string.Format(Se.Language.Video.TtsUpdateX, "audio.cpp");
@@ -206,7 +212,7 @@ public partial class AudioCppTtsSettingsViewModel : ObservableObject
             return;
         }
 
-        await TtsVoiceInstaller.EnsureAudioCppRuntime(Window, _windowService, forceRedownload: true, Adapter.EngineName);
+        await TtsVoiceInstaller.EnsureAudioCppRuntime(Window, _windowService, forceRedownload: true, Adapter.EngineName, Adapter.FamilyName);
         Refresh();
     }
 

--- a/src/ui/Features/Video/TextToSpeech/Engines/AudioCppRuntime.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/AudioCppRuntime.cs
@@ -1,6 +1,8 @@
 ﻿using Nikse.SubtitleEdit.Logic.Config;
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 
@@ -47,6 +49,59 @@ public static class AudioCppRuntime
         {
             return string.Empty;
         }
+    }
+
+    /// <summary>
+    /// Model families compiled into the installed runtime, read from the <c>models</c> line of
+    /// the <c>BUILD-INFO.txt</c> our support-files workflow puts at the archive root
+    /// (<c>models      : index_tts2,higgs_audio_tts,fish_audio,fireredtts3</c>). Null when the
+    /// file is missing or has no such line — every archive we have shipped carries it, so that
+    /// means a hand-installed build we know nothing about.
+    /// </summary>
+    public static IReadOnlyCollection<string>? GetBuiltModelFamilies()
+    {
+        try
+        {
+            var buildInfo = Path.Combine(GetSetEngineFolder(), "BUILD-INFO.txt");
+            return File.Exists(buildInfo) ? ParseBuiltModelFamilies(File.ReadAllText(buildInfo)) : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public static IReadOnlyCollection<string>? ParseBuiltModelFamilies(string buildInfoText)
+    {
+        foreach (var rawLine in buildInfoText.Split('\n'))
+        {
+            var line = rawLine.Trim();
+            var colon = line.IndexOf(':');
+            if (colon <= 0 || !line[..colon].Trim().Equals("models", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            return line[(colon + 1)..]
+                .Split(new[] { ',', ' ', ';' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .ToArray();
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Whether the installed runtime was built with <paramref name="family"/> (an engine's
+    /// <c>FamilyName</c>). The binary is shared by every audio.cpp engine, so a user who
+    /// downloaded it for IndexTTS 2.5 in August has one that rejects every family added since
+    /// ("unsupported model family hint") until it is re-downloaded — the installer uses this to
+    /// ask for that update instead of failing at synthesis time. An unknown build (no
+    /// BUILD-INFO.txt) is trusted rather than nagged about.
+    /// </summary>
+    public static bool SupportsFamily(string family)
+    {
+        var families = GetBuiltModelFamilies();
+        return families == null || families.Contains(family, StringComparer.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/ui/Features/Video/TextToSpeech/IndexTts25AudioCppSettings/IndexTts25AudioCppSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/IndexTts25AudioCppSettings/IndexTts25AudioCppSettingsViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -201,7 +201,7 @@ public partial class IndexTts25AudioCppSettingsViewModel : ObservableObject
             return;
         }
 
-        await TtsVoiceInstaller.EnsureAudioCppRuntime(Window, _windowService, forceRedownload: true, "IndexTTS 2.5");
+        await TtsVoiceInstaller.EnsureAudioCppRuntime(Window, _windowService, forceRedownload: true, "IndexTTS 2.5", IndexTts25AudioCpp.FamilyName);
         Refresh();
     }
 

--- a/src/ui/Features/Video/TextToSpeech/TtsEngineInstaller.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsEngineInstaller.cs
@@ -403,7 +403,7 @@ public static class TtsEngineInstaller
                 }
             }
 
-            if (!await TtsVoiceInstaller.EnsureAudioCppRuntime(window, windowService, forceRedownload: false, "IndexTTS 2.5"))
+            if (!await TtsVoiceInstaller.EnsureAudioCppRuntime(window, windowService, forceRedownload: false, "IndexTTS 2.5", IndexTts25AudioCpp.FamilyName))
             {
                 return false;
             }
@@ -445,6 +445,7 @@ public static class TtsEngineInstaller
             return await EnsureAudioCppEngineWithLicense(
                 window, windowService, refreshVoices,
                 engineDisplayName: "Higgs Audio v3",
+                requiredFamily: HiggsTtsAudioCpp.FamilyName,
                 licenseDefinition: HiggsTtsAudioCpp.LicenseDefinition,
                 isLicenseAccepted: HiggsTtsAudioCpp.IsLicenseAccepted,
                 modelKey: HiggsTtsAudioCpp.ResolveModelKey(model),
@@ -457,6 +458,7 @@ public static class TtsEngineInstaller
             return await EnsureAudioCppEngineWithLicense(
                 window, windowService, refreshVoices,
                 engineDisplayName: "Fish Audio S2 Pro",
+                requiredFamily: FishTtsAudioCpp.FamilyName,
                 licenseDefinition: FishTtsAudioCpp.LicenseDefinition,
                 isLicenseAccepted: FishTtsAudioCpp.IsLicenseAccepted,
                 modelKey: FishTtsAudioCpp.ResolveModelKey(model),
@@ -470,6 +472,7 @@ public static class TtsEngineInstaller
             return await EnsureAudioCppEngineWithLicense(
                 window, windowService, refreshVoices,
                 engineDisplayName: "FireRedTTS3",
+                requiredFamily: FireRedTts3AudioCpp.FamilyName,
                 licenseDefinition: null,
                 isLicenseAccepted: () => true,
                 modelKey: FireRedTts3AudioCpp.ResolveModelKey(model),
@@ -1013,6 +1016,7 @@ public static class TtsEngineInstaller
         IWindowService windowService,
         Func<Task> refreshVoices,
         string engineDisplayName,
+        string requiredFamily,
         ModelLicenseDefinition? licenseDefinition,
         Func<bool> isLicenseAccepted,
         string modelKey,
@@ -1036,7 +1040,7 @@ public static class TtsEngineInstaller
             }
         }
 
-        if (!await TtsVoiceInstaller.EnsureAudioCppRuntime(window, windowService, forceRedownload: false, engineDisplayName))
+        if (!await TtsVoiceInstaller.EnsureAudioCppRuntime(window, windowService, forceRedownload: false, engineDisplayName, requiredFamily))
         {
             return false;
         }

--- a/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
+++ b/src/ui/Features/Video/TextToSpeech/TtsVoiceInstaller.cs
@@ -214,7 +214,12 @@ public static class TtsVoiceInstaller
     /// on Apple Silicon, and CPU / Vulkan / CUDA on Windows and Linux x64.
     /// </summary>
     /// <param name="engineDisplayName">The engine that asked, for the prompts ("IndexTTS 2.5").</param>
-    public static async Task<bool> EnsureAudioCppRuntime(Window? window, IWindowService windowService, bool forceRedownload, string engineDisplayName)
+    /// <param name="requiredFamily">
+    /// The audio.cpp model family that engine needs (its <c>FamilyName</c>). An installed runtime
+    /// that predates the family is not "installed" for this engine: the user is asked to update
+    /// it, since the old binary would only fail later with "unsupported model family hint".
+    /// </param>
+    public static async Task<bool> EnsureAudioCppRuntime(Window? window, IWindowService windowService, bool forceRedownload, string engineDisplayName, string requiredFamily)
     {
         if (window == null)
         {
@@ -222,9 +227,29 @@ public static class TtsVoiceInstaller
         }
 
         var isInstalled = File.Exists(AudioCppRuntime.GetServerExecutable());
-        if (!forceRedownload && isInstalled)
+        var isCapable = isInstalled && AudioCppRuntime.SupportsFamily(requiredFamily);
+        if (!forceRedownload && isCapable)
         {
             return true;
+        }
+
+        // Installed but built before this engine's family existed: confirm the update and keep
+        // the backend the user picked the first time — no reason to ask CPU/Vulkan/CUDA again.
+        var isUpdateRequired = isInstalled && !isCapable && !forceRedownload;
+        var savedBackend = Se.Settings.Video.TextToSpeech.IndexTts25AudioCppBackend;
+        if (isUpdateRequired)
+        {
+            var updateAnswer = await MessageBox.Show(
+                window,
+                "audio.cpp update required",
+                $"{Environment.NewLine}\"{engineDisplayName}\" needs a newer audio.cpp runtime than the one installed. Re-download it now?",
+                MessageBoxButtons.YesNoCancel,
+                MessageBoxIcon.Question);
+
+            if (updateAnswer != MessageBoxResult.Yes)
+            {
+                return false;
+            }
         }
 
         string backend;
@@ -241,7 +266,7 @@ public static class TtsVoiceInstaller
                 return false;
             }
 
-            var answer = await MessageBox.Show(
+            var answer = isUpdateRequired ? MessageBoxResult.Yes : await MessageBox.Show(
                 window,
                 "Download audio.cpp?",
                 $"{Environment.NewLine}\"{engineDisplayName}\" runs through the audio.cpp runtime. Download and install now?",
@@ -268,7 +293,9 @@ public static class TtsVoiceInstaller
                 return false;
             }
 
-            var variantAnswer = await MessageBox.Show(
+            var variantAnswer = isUpdateRequired && !string.IsNullOrEmpty(savedBackend)
+                ? MessageBoxResult.None
+                : await MessageBox.Show(
                 window,
                 "Download audio.cpp?",
                 $"{Environment.NewLine}\"{engineDisplayName}\" runs through the audio.cpp runtime. Select a build to download:",
@@ -278,17 +305,23 @@ public static class TtsVoiceInstaller
                 "Vulkan",
                 "CUDA");
 
-            if (variantAnswer == MessageBoxResult.None || variantAnswer == MessageBoxResult.Cancel)
+            if (isUpdateRequired && !string.IsNullOrEmpty(savedBackend))
+            {
+                backend = savedBackend;
+            }
+            else if (variantAnswer == MessageBoxResult.None || variantAnswer == MessageBoxResult.Cancel)
             {
                 return false;
             }
-
-            backend = variantAnswer switch
+            else
             {
-                MessageBoxResult.Custom2 => IndexTts25AudioCppDownloadService.BackendVulkan,
-                MessageBoxResult.Custom3 => IndexTts25AudioCppDownloadService.BackendCuda,
-                _ => IndexTts25AudioCppDownloadService.BackendCpu,
-            };
+                backend = variantAnswer switch
+                {
+                    MessageBoxResult.Custom2 => IndexTts25AudioCppDownloadService.BackendVulkan,
+                    MessageBoxResult.Custom3 => IndexTts25AudioCppDownloadService.BackendCuda,
+                    _ => IndexTts25AudioCppDownloadService.BackendCpu,
+                };
+            }
 
             // The GPU builds import their runtime at load time, so a missing driver is not a
             // slow fallback — the process dies in the loader before printing anything.

--- a/tests/UI/Features/Video/TextToSpeech/Engines/AudioCppRuntimeBuildInfoTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/AudioCppRuntimeBuildInfoTests.cs
@@ -1,0 +1,60 @@
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+namespace UITests.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// The audio.cpp runtime is one binary shared by four engines, and each support-files build
+/// only compiles the families it was asked for. The installer reads the archive's
+/// BUILD-INFO.txt to see whether the installed build can serve the engine at all — without
+/// that check an August build (index_tts2 only) looked "installed" to FireRedTTS3 and failed
+/// at synthesis with "unsupported model family hint" until the user re-downloaded by hand.
+/// </summary>
+public class AudioCppRuntimeBuildInfoTests
+{
+    private const string BuildInfo2026_09_06 =
+        "audio.cpp build for SubtitleEdit's IndexTTS-2.5 engine\n" +
+        "source      : https://github.com/0xShug0/audio.cpp\n" +
+        "ref         : b0757573c90bf3ada5cf8ffbc69f3ab80a7a6947\n" +
+        "models      : index_tts2,higgs_audio_tts,fish_audio,fireredtts3\n" +
+        "backend     : metal (arm64)\n" +
+        "built       : 2026-09-06T07:33:34Z by Build audio.cpp IndexTTS release archives\n";
+
+    [Fact]
+    public void ParseBuiltModelFamilies_ReadsTheModelsLine()
+    {
+        var families = AudioCppRuntime.ParseBuiltModelFamilies(BuildInfo2026_09_06);
+
+        Assert.NotNull(families);
+        Assert.Equal(new[] { "index_tts2", "higgs_audio_tts", "fish_audio", "fireredtts3" }, families);
+    }
+
+    [Fact]
+    public void ParseBuiltModelFamilies_AugustBuildLacksTheNewerFamilies()
+    {
+        var families = AudioCppRuntime.ParseBuiltModelFamilies(
+            "audio.cpp build for SubtitleEdit's IndexTTS-2.5 engine\r\nmodels      : index_tts2\r\nbackend     : cpu\r\n");
+
+        Assert.NotNull(families);
+        Assert.Contains(IndexTts25AudioCpp.FamilyName, families);
+        Assert.DoesNotContain(FireRedTts3AudioCpp.FamilyName, families);
+        Assert.DoesNotContain(HiggsTtsAudioCpp.FamilyName, families);
+    }
+
+    [Fact]
+    public void ParseBuiltModelFamilies_NoModelsLine_IsUnknown()
+    {
+        Assert.Null(AudioCppRuntime.ParseBuiltModelFamilies("source : x\nref : y\n"));
+        Assert.Null(AudioCppRuntime.ParseBuiltModelFamilies(string.Empty));
+    }
+
+    [Fact]
+    public void EveryAudioCppEngineFamily_IsInThePinnedBuild()
+    {
+        var families = AudioCppRuntime.ParseBuiltModelFamilies(BuildInfo2026_09_06)!;
+
+        Assert.Contains(IndexTts25AudioCpp.FamilyName, families);
+        Assert.Contains(HiggsTtsAudioCpp.FamilyName, families);
+        Assert.Contains(FishTtsAudioCpp.FamilyName, families);
+        Assert.Contains(FireRedTts3AudioCpp.FamilyName, families);
+    }
+}


### PR DESCRIPTION
## Why

After the FireRedTTS3 merge (#14599), an existing audio.cpp install still "worked" as far as the installer could tell: `EnsureAudioCppRuntime` only checked that `audiocpp_server` exists. A runtime downloaded for IndexTTS 2.5 / Higgs earlier was therefore accepted for FireRedTTS3, and synthesis failed with `unsupported model family hint: fireredtts3` until the runtime was re-downloaded by hand from the engine settings.

## What

- `AudioCppRuntime.GetBuiltModelFamilies()` / `SupportsFamily()` read the `models` line of the `BUILD-INFO.txt` every support-files archive ships (`models : index_tts2,higgs_audio_tts,fish_audio,fireredtts3`).
- `EnsureAudioCppRuntime` takes the engine's `FamilyName`; an installed runtime built without it triggers an "audio.cpp update required" prompt and re-downloads with the backend the user picked originally (no second CPU/Vulkan/CUDA question).
- The shared audio.cpp settings window shows the amber update state for such a build too, not only when the hash sidecar says so.
- A build with no `BUILD-INFO.txt` is treated as unknown and trusted, matching the hash-sidecar behaviour.
- Unit tests for the BUILD-INFO parser, including the guard that every audio.cpp engine family is in the pinned build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)