### PR TITLE
Add option to show original subtitle on waveform

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -2668,6 +2668,7 @@
     "cloneVoiceExtractFailed": "Could not extract audio for the selected line.",
     "toggleShotChange": "Toggle shot change",
     "resetWaveformZoomAndSpeed": "Reset waveform zoom & speed",
+    "showOriginalSubtitle": "Show original subtitle",
     "showOnlyWaveform": "Show only waveform",
     "showOnlySpectrogram": "Show only spectrogram",
     "showWaveformAndSpectrogram": "Show waveform and spectrogram",

--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -223,11 +223,11 @@ public class AudioVisualizer : Control
     // video/audio preview" (#14252). Only the main window sets it, and only while an original
     // subtitle is loaded; the dialogs that host a waveform keep showing the text they were given.
     public bool ShowOriginalText { get; set; }
-    public bool ShowOriginalSubtitle { get; set; }
+    public bool ShowOriginalSubtitleOverlay { get; set; }
 
     private readonly List<WaveformOriginalSubtitleCue> _originalSubtitleCues = new();
     private const double OriginalSubtitleOpacity = 0.5;
-    private bool IsOriginalSubtitleOverlayVisible => ShowOriginalSubtitle && _originalSubtitleCues.Count > 0;
+    private bool IsOriginalSubtitleOverlayVisible => ShowOriginalSubtitleOverlay && _originalSubtitleCues.Count > 0;
     private bool ShowOriginalTextInWaveform => ShowOriginalText && !IsOriginalSubtitleOverlayVisible;
 
     public void SetOriginalSubtitleCues(IReadOnlyList<WaveformOriginalSubtitleCue>? cues)

--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -3440,14 +3440,32 @@ public class AudioVisualizer : Control
     {
         var start = renderCtx.StartPositionSeconds;
         var end = RelativeXPositionToSecondsOptimized(renderCtx.Width, renderCtx.SampleRate, start, renderCtx.ZoomFactor);
+        var startIndex = FindFirstIndexAfterTime(_originalSubtitleCues, start, static cue => cue.EndSeconds);
+        var lastStart = -1d;
+        var count = 0;
 
-        for (var i = 0; i < _originalSubtitleCues.Count; i++)
+        for (var i = startIndex; i < _originalSubtitleCues.Count; i++)
         {
             var cue = _originalSubtitleCues[i];
-            if (cue.EndSeconds < start || cue.StartSeconds > end)
+            if (cue.StartSeconds > end)
+            {
+                break;
+            }
+
+            if (cue.EndSeconds < start)
             {
                 continue;
             }
+
+            var isTooShortOrDense = count > 200 &&
+                                    (cue.EndSeconds - cue.StartSeconds < 0.00001 || cue.StartSeconds - lastStart < 0.09);
+            if (isTooShortOrDense)
+            {
+                continue;
+            }
+
+            lastStart = cue.StartSeconds;
+            count++;
 
             var left = SecondsToXPositionOptimized(cue.StartSeconds - start, renderCtx.SampleRate, renderCtx.ZoomFactor);
             var right = SecondsToXPositionOptimized(cue.EndSeconds - start, renderCtx.SampleRate, renderCtx.ZoomFactor);
@@ -3466,6 +3484,11 @@ public class AudioVisualizer : Control
                 {
                     DrawParagraphText(context, cue.Text, left + 3, top + 14);
                 }
+            }
+
+            if (count >= 250)
+            {
+                break;
             }
         }
     }
@@ -4047,7 +4070,8 @@ public class AudioVisualizer : Control
         var maxTime = TimeCode.MaxTimeTotalMilliseconds;
 
         // 1. Use Binary Search to find the first potential subtitle in the time range O(log N)
-        var startIndex = FindFirstIndexAfterTime(subtitle, startThreshold);
+        var startIndex = FindFirstIndexAfterTime(subtitle, startThreshold,
+            static paragraph => paragraph.EndTime.TotalMilliseconds);
 
         var lastStartTime = -1d;
         var count = 0;
@@ -4107,15 +4131,15 @@ public class AudioVisualizer : Control
     }
 
     // Helper for Binary Search
-    private static int FindFirstIndexAfterTime(IReadOnlyList<SubtitleLineViewModel> subtitle, double timeMs)
+    private static int FindFirstIndexAfterTime<T>(IReadOnlyList<T> items, double time, Func<T, double> getEndTime)
     {
-        int low = 0, high = subtitle.Count - 1;
+        int low = 0, high = items.Count - 1;
         var result = 0;
 
         while (low <= high)
         {
             int mid = low + (high - low) / 2;
-            if (subtitle[mid].EndTime.TotalMilliseconds >= timeMs)
+            if (getEndTime(items[mid]) >= time)
             {
                 result = mid;
                 high = mid - 1;

--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -223,6 +223,23 @@ public class AudioVisualizer : Control
     // video/audio preview" (#14252). Only the main window sets it, and only while an original
     // subtitle is loaded; the dialogs that host a waveform keep showing the text they were given.
     public bool ShowOriginalText { get; set; }
+    public bool ShowOriginalSubtitle { get; set; }
+
+    private readonly List<WaveformOriginalSubtitleCue> _originalSubtitleCues = new();
+    private const double OriginalSubtitleOpacity = 0.5;
+    private bool IsOriginalSubtitleOverlayVisible => ShowOriginalSubtitle && _originalSubtitleCues.Count > 0;
+    private bool ShowOriginalTextInWaveform => ShowOriginalText && !IsOriginalSubtitleOverlayVisible;
+
+    public void SetOriginalSubtitleCues(IReadOnlyList<WaveformOriginalSubtitleCue>? cues)
+    {
+        _originalSubtitleCues.Clear();
+        if (cues != null)
+        {
+            _originalSubtitleCues.AddRange(cues);
+        }
+
+        InvalidateVisual();
+    }
 
     // Lets the wheel handler ask the host whether the video is playing, so a plain scroll in
     // "center video position" mode can turn into a seek that keeps the play-head centered
@@ -3236,12 +3253,21 @@ public class AudioVisualizer : Control
             }
         }
 
+        var showOriginalSubtitle = IsOriginalSubtitleOverlayVisible;
+        var workingTextHeight = showOriginalSubtitle ? renderCtx.Height / 2.0 : renderCtx.Height;
+
         foreach (var p in paragraphs)
         {
             if (p.EndTime.TotalMilliseconds >= startPositionMilliseconds && p.StartTime.TotalMilliseconds <= endPositionMilliseconds)
             {
-                DrawParagraph(p, context, ref renderCtx);
+                DrawParagraph(p, context, ref renderCtx, 0, workingTextHeight);
             }
+        }
+
+        if (showOriginalSubtitle)
+        {
+            var originalSubtitleTop = renderCtx.Height / 2.0;
+            DrawOriginalSubtitleParagraphs(context, ref renderCtx, originalSubtitleTop, renderCtx.Height - originalSubtitleTop);
         }
     }
 
@@ -3364,7 +3390,8 @@ public class AudioVisualizer : Control
         return prepared;
     }
 
-    private void DrawParagraph(SubtitleLineViewModel paragraph, DrawingContext context, ref RenderContext renderCtx)
+    private void DrawParagraph(SubtitleLineViewModel paragraph, DrawingContext context, ref RenderContext renderCtx,
+        double contentTop = 0, double contentHeight = -1)
     {
         var currentRegionLeft = SecondsToXPositionOptimized(paragraph.StartTime.TotalSeconds - renderCtx.StartPositionSeconds, renderCtx.SampleRate, renderCtx.ZoomFactor);
         var currentRegionRight = SecondsToXPositionOptimized(paragraph.EndTime.TotalSeconds - renderCtx.StartPositionSeconds, renderCtx.SampleRate, renderCtx.ZoomFactor);
@@ -3375,50 +3402,94 @@ public class AudioVisualizer : Control
             return;
         }
 
-        var height = renderCtx.Height;
+        if (contentHeight < 0)
+        {
+            contentHeight = renderCtx.Height;
+        }
 
-        // Draw background rectangle
+        // Keep the editable paragraph background and timing borders full-height.
         context.FillRectangle(_selectedParagraphsRenderSet.Contains(paragraph) ? _paintParagraphSelectedBackground : _paintParagraphBackground,
-            new Rect(currentRegionLeft, 0, currentRegionWidth, height));
+            new Rect(currentRegionLeft, 0, currentRegionWidth, renderCtx.Height));
 
         // Draw left and right borders
-        context.DrawLine(_paintLeft, new Point(currentRegionLeft, 0), new Point(currentRegionLeft, height));
-        context.DrawLine(_paintRight, new Point(currentRegionRight - 1, 0), new Point(currentRegionRight - 1, height));
+        context.DrawLine(_paintLeft, new Point(currentRegionLeft, 0), new Point(currentRegionLeft, renderCtx.Height));
+        context.DrawLine(_paintRight, new Point(currentRegionRight - 1, 0), new Point(currentRegionRight - 1, renderCtx.Height));
 
         // Draw clipped text (prepared text + shaped FormattedText are cached; see GetCachedParagraphText).
         // With "toggle translation and original in video/audio preview" on, the waveform shows the
         // original text like SE4 did (#14252).
-        var prepared = GetPreparedParagraphText(ShowOriginalText ? paragraph.OriginalText : paragraph.Text);
+        var text = ShowOriginalTextInWaveform ? paragraph.OriginalText : paragraph.Text;
 
-        var textBounds = new Rect(currentRegionLeft + 1, 0, currentRegionWidth - 3, height);
+        var textBounds = new Rect(currentRegionLeft + 1, contentTop, currentRegionWidth - 3, contentHeight);
 
         using (context.PushClip(textBounds))
         {
-            if (Se.Settings.Waveform.WaveformUnwrapText)
-            {
-                var formattedText = GetCachedParagraphText(prepared.Unwrapped, prepared.RightToLeft);
-                context.DrawText(formattedText, new Point(currentRegionLeft + 3, 14));
-            }
-            else
-            {
-                double addY = 0;
-                foreach (var line in prepared.Lines)
-                {
-                    var formattedText = GetCachedParagraphText(line, prepared.RightToLeft);
-                    context.DrawText(formattedText, new Point(currentRegionLeft + 3, 14 + addY));
-                    addY += formattedText.Height;
-                }
-            }
-
-            DrawParagraphFooter(context, paragraph, currentRegionLeft, currentRegionWidth, height, ref renderCtx);
+            DrawParagraphText(context, text, currentRegionLeft + 3, contentTop + 14);
         }
 
-        DrawParagraphAudioLength(context, paragraph, currentRegionLeft, currentRegionRight, height, ref renderCtx);
+        // Keep CPS and number/duration at the bottom of the full paragraph region.
+        using (context.PushClip(new Rect(currentRegionLeft + 1, 0, currentRegionWidth - 3, renderCtx.Height)))
+        {
+            DrawParagraphFooter(context, paragraph, currentRegionLeft, currentRegionWidth, ref renderCtx);
+        }
+
+        DrawParagraphAudioLength(context, paragraph, currentRegionLeft, currentRegionRight, contentTop, contentHeight, ref renderCtx);
+    }
+
+    private void DrawOriginalSubtitleParagraphs(DrawingContext context, ref RenderContext renderCtx, double top, double height)
+    {
+        var start = renderCtx.StartPositionSeconds;
+        var end = RelativeXPositionToSecondsOptimized(renderCtx.Width, renderCtx.SampleRate, start, renderCtx.ZoomFactor);
+
+        for (var i = 0; i < _originalSubtitleCues.Count; i++)
+        {
+            var cue = _originalSubtitleCues[i];
+            if (cue.EndSeconds < start || cue.StartSeconds > end)
+            {
+                continue;
+            }
+
+            var left = SecondsToXPositionOptimized(cue.StartSeconds - start, renderCtx.SampleRate, renderCtx.ZoomFactor);
+            var right = SecondsToXPositionOptimized(cue.EndSeconds - start, renderCtx.SampleRate, renderCtx.ZoomFactor);
+            if (right - left <= 5)
+            {
+                continue;
+            }
+
+            // Draw original subtitle cues with the waveform theme at half opacity.
+            using (context.PushOpacity(OriginalSubtitleOpacity))
+            {
+                context.FillRectangle(_paintParagraphBackground, new Rect(left, top, right - left, height));
+                context.DrawLine(_paintLeft, new Point(left, top), new Point(left, top + height));
+                context.DrawLine(_paintRight, new Point(right - 1, top), new Point(right - 1, top + height));
+                using (context.PushClip(new Rect(left + 1, top, right - left - 3, height)))
+                {
+                    DrawParagraphText(context, cue.Text, left + 3, top + 14);
+                }
+            }
+        }
+    }
+
+    private void DrawParagraphText(DrawingContext context, string text, double x, double y)
+    {
+        var prepared = GetPreparedParagraphText(text);
+        if (Se.Settings.Waveform.WaveformUnwrapText)
+        {
+            context.DrawText(GetCachedParagraphText(prepared.Unwrapped, prepared.RightToLeft), new Point(x, y));
+            return;
+        }
+
+        foreach (var line in prepared.Lines)
+        {
+            var formattedText = GetCachedParagraphText(line, prepared.RightToLeft);
+            context.DrawText(formattedText, new Point(x, y));
+            y += formattedText.Height;
+        }
     }
 
     // Drawn outside the text clip on purpose: the overrun part extends past the right border.
     private void DrawParagraphAudioLength(DrawingContext context, SubtitleLineViewModel paragraph,
-        double currentRegionLeft, double currentRegionRight, double height, ref RenderContext renderCtx)
+        double currentRegionLeft, double currentRegionRight, double top, double height, ref RenderContext renderCtx)
     {
         var provider = ParagraphAudioLengthProvider;
         if (provider == null)
@@ -3434,7 +3505,7 @@ public class AudioVisualizer : Control
 
         var audioRight = SecondsToXPositionOptimized(paragraph.StartTime.TotalSeconds + audioSeconds - renderCtx.StartPositionSeconds, renderCtx.SampleRate, renderCtx.ZoomFactor);
         const double barHeight = 4;
-        var y = height - barHeight - 1;
+        var y = top + height - barHeight - 1;
         var fitsRight = Math.Min(audioRight, currentRegionRight - 1);
         if (fitsRight > currentRegionLeft + 1)
         {
@@ -3456,7 +3527,7 @@ public class AudioVisualizer : Control
     //   51 < n <= 99                                                   → "#NUMBER  DURATION"
     //   n > 99                                                         → add CPS line above
     private void DrawParagraphFooter(DrawingContext context, SubtitleLineViewModel paragraph,
-        double currentRegionLeft, double currentRegionWidth, double height, ref RenderContext renderCtx)
+        double currentRegionLeft, double currentRegionWidth, ref RenderContext renderCtx)
     {
         if (!Se.Settings.Waveform.WaveformShowNumberAndDuration && !Se.Settings.Waveform.WaveformShowCps)
         {
@@ -3502,7 +3573,7 @@ public class AudioVisualizer : Control
         {
             // Counts the text that is actually on screen: with the original drawn, a CPS taken
             // from the hidden translation reads as the original's and would be wrong (#14252).
-            cpsLine = GetCachedCpsLabel(ShowOriginalText
+            cpsLine = GetCachedCpsLabel(ShowOriginalTextInWaveform
                 ? paragraph.OriginalCharactersPerSecond
                 : paragraph.CharactersPerSecond);
         }
@@ -3513,7 +3584,7 @@ public class AudioVisualizer : Control
         }
 
         // Layout from the bottom up so the optional CPS line stacks above the base line.
-        var bottomY = height - 14;
+        var bottomY = renderCtx.Height - 14;
         var x = currentRegionLeft + padding;
 
         if (baseLine != null)

--- a/src/ui/Controls/AudioVisualizerControl/WaveformOriginalSubtitleCue.cs
+++ b/src/ui/Controls/AudioVisualizerControl/WaveformOriginalSubtitleCue.cs
@@ -1,0 +1,3 @@
+namespace Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
+
+public readonly record struct WaveformOriginalSubtitleCue(double StartSeconds, double EndSeconds, string Text);

--- a/src/ui/Features/Main/Layout/InitWaveform.cs
+++ b/src/ui/Features/Main/Layout/InitWaveform.cs
@@ -76,6 +76,7 @@ public class InitWaveform
                 // built later must come up on the same side of it as the video preview, or the
                 // two previews show different texts (see SetOriginalTextInPreview).
                 ShowOriginalText = vm.ShowOriginalTextInPreview,
+                ShowOriginalSubtitle = settings.ShowOriginalSubtitle,
             };
 
             vm.AudioVisualizer.GetIsVideoPlaying = () => vm.GetVideoPlayerControl()?.IsPlaying == true;
@@ -315,6 +316,20 @@ public class InitWaveform
             };
             flyout.Items.Add(menuItemSpeechToTextSelectedLines);
             vm.MenuItemAudioVisualizerSpeechToTextSelectedLines = menuItemSpeechToTextSelectedLines;
+
+            var showOriginalSubtitleMenuItem = new MenuItem
+            {
+                Header = Se.Language.Waveform.ShowOriginalSubtitle,
+                ToggleType = MenuItemToggleType.CheckBox,
+                IsChecked = settings.ShowOriginalSubtitle,
+            }.BindIsVisible(vm, nameof(vm.ShowColumnOriginalText));
+            showOriginalSubtitleMenuItem.Click += (_, _) =>
+            {
+                settings.ShowOriginalSubtitle = showOriginalSubtitleMenuItem.IsChecked;
+                vm.AudioVisualizer.ShowOriginalSubtitle = showOriginalSubtitleMenuItem.IsChecked;
+                vm.UpdateWaveformOriginalSubtitleCues(vm.AudioVisualizer);
+            };
+            flyout.Items.Add(showOriginalSubtitleMenuItem);
 
             var separatorDisplayMode = new Separator();
             separatorDisplayMode.DataContext = vm;

--- a/src/ui/Features/Main/Layout/InitWaveform.cs
+++ b/src/ui/Features/Main/Layout/InitWaveform.cs
@@ -76,7 +76,7 @@ public class InitWaveform
                 // built later must come up on the same side of it as the video preview, or the
                 // two previews show different texts (see SetOriginalTextInPreview).
                 ShowOriginalText = vm.ShowOriginalTextInPreview,
-                ShowOriginalSubtitle = settings.ShowOriginalSubtitle,
+                ShowOriginalSubtitleOverlay = settings.ShowOriginalSubtitle,
             };
 
             vm.AudioVisualizer.GetIsVideoPlaying = () => vm.GetVideoPlayerControl()?.IsPlaying == true;
@@ -326,7 +326,7 @@ public class InitWaveform
             showOriginalSubtitleMenuItem.Click += (_, _) =>
             {
                 settings.ShowOriginalSubtitle = showOriginalSubtitleMenuItem.IsChecked;
-                vm.AudioVisualizer.ShowOriginalSubtitle = showOriginalSubtitleMenuItem.IsChecked;
+                vm.AudioVisualizer.ShowOriginalSubtitleOverlay = showOriginalSubtitleMenuItem.IsChecked;
                 vm.UpdateWaveformOriginalSubtitleCues(vm.AudioVisualizer);
             };
             flyout.Items.Add(showOriginalSubtitleMenuItem);

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -24529,6 +24529,56 @@ public partial class MainViewModel :
         return _subtitleOriginal;
     }
 
+    internal void UpdateWaveformOriginalSubtitleCues(AudioVisualizer audioVisualizer)
+    {
+        if (!ShowColumnOriginalText || !Se.Settings.Waveform.ShowOriginalSubtitle || _subtitleOriginal == null)
+        {
+            audioVisualizer.SetOriginalSubtitleCues(null);
+            return;
+        }
+
+        if (IsEditOriginalMode)
+        {
+            var editedCues = new List<WaveformOriginalSubtitleCue>();
+            foreach (var row in Subtitles)
+            {
+                if (row.ReferenceParagraphId != null || !string.IsNullOrEmpty(row.OriginalText))
+                {
+                    editedCues.Add(new WaveformOriginalSubtitleCue(
+                        row.StartTime.TotalSeconds, row.EndTime.TotalSeconds, row.OriginalText));
+                }
+            }
+
+            audioVisualizer.SetOriginalSubtitleCues(editedCues);
+            return;
+        }
+
+        var rowsByReferenceId = new Dictionary<Guid, SubtitleLineViewModel>();
+        foreach (var row in Subtitles)
+        {
+            if (row.ReferenceParagraphId is { } id)
+            {
+                rowsByReferenceId[id] = row;
+            }
+        }
+
+        var cues = new List<WaveformOriginalSubtitleCue>(_subtitleOriginal.Paragraphs.Count);
+        foreach (var paragraph in _subtitleOriginal.Paragraphs)
+        {
+            var start = paragraph.StartTime.TotalSeconds;
+            var end = paragraph.EndTime.TotalSeconds;
+            var text = paragraph.Text;
+            if (paragraph.Id is { } id && rowsByReferenceId.TryGetValue(id, out var row))
+            {
+                text = row.OriginalText;
+            }
+
+            cues.Add(new WaveformOriginalSubtitleCue(start, end, text));
+        }
+
+        audioVisualizer.SetOriginalSubtitleCues(cues);
+    }
+
     /// <summary>
     /// Returns false if the user cancelled the save because some subtitles exceed the format's limits.
     /// </summary>
@@ -29590,6 +29640,8 @@ public partial class MainViewModel :
     // guard below skips the work while it is hidden, so its values can be stale here.
     partial void OnShowColumnOriginalTextChanged(bool value)
     {
+        _updateAudioVisualizer = true;
+
         if (value && SelectedSubtitle != null)
         {
             MakeSubtitleTextInfoOriginal(SelectedSubtitle.OriginalText, SelectedSubtitle);
@@ -30254,6 +30306,7 @@ public partial class MainViewModel :
 
                 if (_updateAudioVisualizer && av != null)
                 {
+                    UpdateWaveformOriginalSubtitleCues(av);
                     av.InvalidateVisual();
                     _updateAudioVisualizer = false;
                 }

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -29740,6 +29740,11 @@ public partial class MainViewModel :
             // the edit box or dragged an end time in the waveform.
             _mpvPreviewDirty = true;
         }
+        else if (e.PropertyName is nameof(SubtitleLineViewModel.OriginalText))
+        {
+            // Original cues are snapshots, so rebuild them after the original text changes.
+            _updateAudioVisualizer = true;
+        }
         else if (e.PropertyName is nameof(SubtitleLineViewModel.Layer))
         {
             // The waveform buffer filters on Layer when layers are hidden from the waveform.

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -12983,6 +12983,7 @@ public partial class MainViewModel :
             AudioVisualizer.MinGapSeconds = Se.Settings.General.MinimumBetweenLines.GetMilliseconds() / 1000.0;
             AudioVisualizer.WaveformHeightPercentage = Se.Settings.Waveform.SpectrogramCombinedWaveformHeight;
             AudioVisualizer.FocusOnMouseOver = Se.Settings.Waveform.FocusOnMouseOver;
+            AudioVisualizer.ShowOriginalSubtitleOverlay = Se.Settings.Waveform.ShowOriginalSubtitle;
             AudioVisualizer.ResetCache();
 
             InitializeLibMpv();

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -522,6 +522,7 @@ public class SettingsPage : UserControl
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformShowToolbar, nameof(_vm.WaveformShowToolbar)),
             new SettingsItem(Se.Language.Options.Settings.WaveformShowToolbarEditLabel,
                 () => UiUtil.MakeButton(Se.Language.Options.Settings.WaveformShowToolbarEdit, _vm.EditWaveformToolbarPropertiesCommand)),
+            MakeCheckboxSetting(Se.Language.Waveform.ShowOriginalSubtitle, nameof(_vm.WaveformShowOriginalSubtitle)),
 
             new SettingsItem(Se.Language.Options.Settings.WaveformSingleClickAction, () => new ComboBox
             {

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -285,6 +285,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private int _waveformSpectrogramCombinedWaveformHeight;
 
     [ObservableProperty] private bool _waveformShowToolbar;
+    [ObservableProperty] private bool _waveformShowOriginalSubtitle;
 
     [ObservableProperty] private bool _waveformFocusTextboxAfterInsertNew;
     [ObservableProperty] private string _waveformSpaceInfo;
@@ -953,6 +954,7 @@ public partial class SettingsViewModel : ObservableObject
         WaveformCenterVideoPosition = Se.Settings.Waveform.CenterVideoPosition;
         WaveformCenterVideoPositionAlsoWhenPaused = Se.Settings.Waveform.CenterVideoPositionAlsoWhenPaused;
         WaveformShowToolbar = Se.Settings.Waveform.ShowToolbar;
+        WaveformShowOriginalSubtitle = Se.Settings.Waveform.ShowOriginalSubtitle;
 
         if (Se.Settings.Waveform.WaveformDrawStyle == WaveformDrawStyle.Classic.ToString())
         {
@@ -1862,6 +1864,7 @@ public partial class SettingsViewModel : ObservableObject
         Se.Settings.Waveform.SpectrogramCombinedWaveformHeight = WaveformSpectrogramCombinedWaveformHeight;
 
         Se.Settings.Waveform.ShowToolbar = WaveformShowToolbar;
+        Se.Settings.Waveform.ShowOriginalSubtitle = WaveformShowOriginalSubtitle;
         Se.Settings.Waveform.ToolbarItems = _waveformToolbarItems;
 
         Se.Settings.Waveform.WaveformTextFontSize = WaveformTextFontSize;

--- a/src/ui/Logic/Config/Language/Waveform/LanguageWaveform.cs
+++ b/src/ui/Logic/Config/Language/Waveform/LanguageWaveform.cs
@@ -20,6 +20,7 @@ public class LanguageWaveform
     public string CloneVoiceExtractFailed { get; set; }
     public string ToggleShotChange { get; set; }
     public string ResetWaveformZoomAndSpeed { get; set; }
+    public string ShowOriginalSubtitle { get; set; }
     public object ShowOnlyWaveform { get; set; }
     public object ShowOnlySpectrogram { get; set; }
     public object ShowWaveformAndSpectrogram { get; set; }
@@ -56,6 +57,7 @@ public class LanguageWaveform
         MaxSilenceVolume = "Max. silence volume (0.0 - 1.0):";
         ToggleShotChange = "Toggle shot change";
         ResetWaveformZoomAndSpeed = "Reset waveform zoom & speed";
+        ShowOriginalSubtitle = "Show original subtitle";
         ShowOnlyWaveform = "Show only waveform";
         ShowOnlySpectrogram = "Show only spectrogram";
         ShowWaveformAndSpectrogram = "Show waveform and spectrogram";

--- a/src/ui/Logic/Config/SeWaveform.cs
+++ b/src/ui/Logic/Config/SeWaveform.cs
@@ -8,6 +8,7 @@ namespace Nikse.SubtitleEdit.Logic.Config;
 public class SeWaveform
 {
     public bool ShowToolbar { get; set; }
+    public bool ShowOriginalSubtitle { get; set; }
     public bool CenterVideoPosition { get; set; }
 
     // SE 4 parity for the "Center" toggle: keep the play-head centered (and keep
@@ -113,6 +114,7 @@ public class SeWaveform
     public SeWaveform()
     {
         ShowToolbar = true;
+        ShowOriginalSubtitle = false;
         DrawGridLines = false;
         FocusTextBoxAfterInsertNew = true;
         SpectrogramCombinedWaveformHeight = 50;


### PR DESCRIPTION
## Summary

Adds an option to show the original subtitle on the waveform.

## Background

Subtitle Edit can already show the working subtitle and the original subtitle side by side in the subtitle grid, but the waveform only shows the subtitle currently being edited.

That makes it hard to compare timing with the original subtitle.

VisualSubSync, which I used for a long time <sub>before fully switching to SE5 ;)</sub>, has a `Show/Hide Reference VO` option that displays the reference subtitle directly on the waveform. This PR adds a similar workflow to SE5.

The option is available from the waveform context menu and Settings, and is disabled by default.

## Implementation

When enabled:

* The working subtitle keeps its existing waveform rendering and editing behavior
* The original subtitle is drawn as a semi-transparent overlay in the lower half of the waveform
* Original cues are display-only and are not included in hit testing or waveform editing
* Existing waveform text wrapping behavior is reused
* Original rendering uses the same visibility culling logic as normal waveform paragraphs

The original overlay uses the normal waveform subtitle colors at 50% opacity.

## Screenshots

||
|-|
|<video src="https://github.com/user-attachments/assets/3698415e-bb08-4fa6-91a7-f5304ae54252">|


## Notes

The original subtitle on the waveform is currently display-only.

Editing the original directly from the waveform is not included in this PR, but could be considered later if useful.

## Testing

Manually verified with:

* Editable original subtitles
* Read-only original subtitles
* `Make new empty translation from current subtitle`

Also verified normal waveform selection, dragging, resizing, and multiline text rendering.

Tested on Fedora 44 x64 (local build).
