### PR TITLE
Toggle dialog dashes: honor focused text box, per-column direction, never stack dashes

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -14290,31 +14290,49 @@ public partial class MainViewModel :
             return;
         }
 
-        // Determine direction from the first selected line: if any of its lines
-        // already start with a dash, toggle OFF for every selected line; else
-        // toggle ON. Matches SE 4 behaviour so a single hotkey flips the whole
-        // selection in one direction.
-        var firstLines = selectedItems[0].Text?.SplitToLines() ?? new List<string>();
-        var hasStartDash = firstLines.Any(l =>
-            HtmlUtil.RemoveHtmlTags(l, true).TrimStart().StartsWith('-'));
+        // Like SE 4: when one of the edit text boxes has focus only that column
+        // is toggled; with focus elsewhere (e.g. the grid) both columns follow.
+        var originalFocused = EditTextBoxOriginal.IsFocused;
+        var textFocused = EditTextBox.IsFocused;
+        var doText = !originalFocused;
+        var doOriginal = CanEditOriginal && !textFocused;
+        if (originalFocused && !CanEditOriginal)
+        {
+            doText = true;
+        }
 
         var dialogStyle = Enum.TryParse<DialogType>(Se.Settings.General.DialogStyle, out var ds)
             ? ds
             : DialogType.DashBothLinesWithSpace;
         var dialogHelper = new DialogSplitMerge { DialogStyle = dialogStyle, SkipLineEndingCheck = true };
 
-        foreach (var item in selectedItems)
+        // Each column decides its own direction (from the first selected line
+        // with text): if any of its lines already start with a dash, toggle OFF
+        // for every selected line; else toggle ON. Deciding once per column keeps
+        // a single hotkey flipping the whole selection in one direction and
+        // stops a dash-free column from forcing endless "add" on the other.
+        if (doText)
         {
-            item.Text = hasStartDash
-                ? RemoveDialogDashes(item.Text)
-                : AddDialogDashes(item.Text, dialogHelper);
-
-            // Keep the translation/original column in sync so the two views
-            // don't drift apart — matches what MergeManager.MergeSelectedLinesAsDialog
-            // already does for OriginalText.
-            if (CanEditOriginal && !string.IsNullOrEmpty(item.OriginalText))
+            var remove = HasStartDash(selectedItems.Select(i => i.Text));
+            foreach (var item in selectedItems)
             {
-                item.OriginalText = hasStartDash
+                item.Text = remove
+                    ? RemoveDialogDashes(item.Text)
+                    : AddDialogDashes(item.Text, dialogHelper);
+            }
+        }
+
+        if (doOriginal)
+        {
+            var remove = HasStartDash(selectedItems.Select(i => i.OriginalText));
+            foreach (var item in selectedItems)
+            {
+                if (string.IsNullOrEmpty(item.OriginalText))
+                {
+                    continue;
+                }
+
+                item.OriginalText = remove
                     ? RemoveDialogDashes(item.OriginalText)
                     : AddDialogDashes(item.OriginalText, dialogHelper);
             }
@@ -14323,7 +14341,20 @@ public partial class MainViewModel :
         _updateAudioVisualizer = true;
     }
 
-    private static string AddDialogDashes(string text, DialogSplitMerge dialogHelper)
+    private static bool HasStartDash(IEnumerable<string?> texts)
+    {
+        var first = texts.FirstOrDefault(t => !string.IsNullOrWhiteSpace(t));
+        if (first == null)
+        {
+            return false;
+        }
+
+        return first.SplitToLines().Any(l =>
+            HtmlUtil.RemoveHtmlTags(l, true).TrimStart().StartsWith('-') ||
+            HtmlUtil.RemoveHtmlTags(l, true).TrimStart().StartsWith('‐'));
+    }
+
+    internal static string AddDialogDashes(string text, DialogSplitMerge dialogHelper)
     {
         if (string.IsNullOrEmpty(text))
         {
@@ -14341,13 +14372,16 @@ public partial class MainViewModel :
         {
             var pre = string.Empty;
             var s = Utilities.SplitStartTags(line, ref pre);
+            // Strip whatever dashes are already there so repeated presses (or a
+            // half-dashed paragraph) never stack up "- - - ".
+            s = StripLeadingDashes(s);
             sb.Append(pre).Append("- ").AppendLine(s);
         }
 
         return dialogHelper.FixDashesAndSpaces(sb.ToString().Trim());
     }
 
-    private static string RemoveDialogDashes(string text)
+    internal static string RemoveDialogDashes(string text)
     {
         if (string.IsNullOrEmpty(text))
         {
@@ -14360,10 +14394,22 @@ public partial class MainViewModel :
         {
             var pre = string.Empty;
             var s = Utilities.SplitStartTags(line, ref pre);
-            sb.Append(pre).AppendLine(s.TrimStart('-', '‐').TrimStart());
+            sb.Append(pre).AppendLine(StripLeadingDashes(s));
         }
 
         return sb.ToString().Trim();
+    }
+
+    /// <summary>Removes every leading dash (and the spaces between them) from a line.</summary>
+    private static string StripLeadingDashes(string s)
+    {
+        s = s.TrimStart();
+        while (s.Length > 0 && (s[0] == '-' || s[0] == '‐' || s[0] == '–' || s[0] == '—'))
+        {
+            s = s.Substring(1).TrimStart();
+        }
+
+        return s;
     }
 
     [RelayCommand]

--- a/tests/UI/Features/Main/ToggleDialogDashesTests.cs
+++ b/tests/UI/Features/Main/ToggleDialogDashesTests.cs
@@ -1,0 +1,58 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Enums;
+using Nikse.SubtitleEdit.Features.Main;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// Issue #14621: toggling dialog dashes must be idempotent — pressing the shortcut on a
+/// paragraph that already has dashes must never stack "- - - ".
+/// </summary>
+public class ToggleDialogDashesTests
+{
+    private static DialogSplitMerge Helper() => new() { DialogStyle = DialogType.DashBothLinesWithSpace, SkipLineEndingCheck = true };
+
+    [Fact]
+    public void Add_OnPlainDialog_AddsDashes()
+    {
+        var result = MainViewModel.AddDialogDashes("Hello" + Environment.NewLine + "World", Helper());
+        Assert.Equal("- Hello" + Environment.NewLine + "- World", result);
+    }
+
+    [Fact]
+    public void Add_OnAlreadyDashed_DoesNotStack()
+    {
+        var input = "- Elle a des ecchymoses puis" + Environment.NewLine + "- une blessure à la tête.";
+        var result = MainViewModel.AddDialogDashes(input, Helper());
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void Add_OnStackedDashes_CollapsesToOne()
+    {
+        var input = "- - - - - Elle a des ecchymoses puis" + Environment.NewLine + "- - - - - une blessure à la tête.";
+        var result = MainViewModel.AddDialogDashes(input, Helper());
+        Assert.Equal("- Elle a des ecchymoses puis" + Environment.NewLine + "- une blessure à la tête.", result);
+    }
+
+    [Fact]
+    public void Add_KeepsStartTags()
+    {
+        var result = MainViewModel.AddDialogDashes("<i>Hello</i>" + Environment.NewLine + "World", Helper());
+        Assert.Equal("<i>- Hello</i>" + Environment.NewLine + "- World", result);
+    }
+
+    [Fact]
+    public void Remove_StripsStackedDashes()
+    {
+        var input = "- - - Hello" + Environment.NewLine + "-World";
+        var result = MainViewModel.RemoveDialogDashes(input);
+        Assert.Equal("Hello" + Environment.NewLine + "World", result);
+    }
+
+    [Fact]
+    public void Add_SingleLine_Unchanged()
+    {
+        Assert.Equal("Hello", MainViewModel.AddDialogDashes("Hello", Helper()));
+    }
+}


### PR DESCRIPTION
Fixes #14621

**Problem.** The toggle decided add/remove from the Text column only and applied that direction to the Original column as well. When Text was empty, a single line, or more than three lines, it never gained a dash, so every press was "add" and the Original column grew `- - - - -`. The add helper also prepended `- ` without stripping an existing dash.

**Changes**
- Like SE 4, when one of the edit text boxes has focus only that column is toggled. With focus elsewhere (the grid) both columns follow.
- Each column decides its own direction from the first selected line that has text.
- Adding dashes strips existing leading dashes first, so repeated presses collapse stacked dashes instead of growing them.
- Unit tests for add/remove idempotence, stacked-dash collapse, start tags, single line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)