### PR TITLE
Undocked mode: heal a leaked topmost suspension and log what took it (#14622)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -596,7 +596,6 @@ public partial class MainViewModel :
 
     VideoPlayerUndockedViewModel? _videoPlayerUndockedViewModel;
     AudioVisualizerUndockedViewModel? _audioVisualizerUndockedViewModel;
-    bool _suppressUndockedTopmost;
     bool _foregroundBelongsToMainWindow;
     bool _undockedWindowPointerPressed;
     FindViewModel? _findViewModel;
@@ -8986,7 +8985,7 @@ public partial class MainViewModel :
                 // SE loses focus to another app. Mirrors the Find/Replace helper from #11243.
                 // The two undocked windows are still independent in Alt+Tab — KeepTopmost… is
                 // just a Z-order knob, not an ownership change.
-                WindowService.KeepTopmostWhileOwnerActive(window, Window!, () => _suppressUndockedTopmost);
+                WindowService.KeepTopmostWhileOwnerActive(window, Window!, () => WindowService.IsUndockedTopmostSuspended);
                 WatchUndockedForegroundSteal(window);
             });
 
@@ -8995,7 +8994,7 @@ public partial class MainViewModel :
                 _audioVisualizerUndockedViewModel = vm;
                 vm.Initialize(AudioVisualizer, this);
                 ReloadAudioVisualizer();
-                WindowService.KeepTopmostWhileOwnerActive(window, Window!, () => _suppressUndockedTopmost);
+                WindowService.KeepTopmostWhileOwnerActive(window, Window!, () => WindowService.IsUndockedTopmostSuspended);
                 WatchUndockedForegroundSteal(window);
             });
 
@@ -9244,14 +9243,14 @@ public partial class MainViewModel :
     /// </summary>
     internal void SetUndockedWindowsTopmost(bool topmost)
     {
-        // Remembered (and consulted by the KeepTopmostWhileOwnerActive registrations) so the
-        // helper's activation handler cannot re-assert Topmost while a menu or dialog is still
-        // open: opening a cascaded submenu (or a modal dialog) churns window activation, and the
-        // re-asserted Topmost put the tool windows back over the popup (#13187 follow-up) - and
-        // on Windows the SetWindowPos churn could steal OS activation from a just-opened modal
-        // dialog, leaving it drawn on top but inactive (#13325).
-        _suppressUndockedTopmost = !topmost;
-
+        // The KeepTopmostWhileOwnerActive registrations consult WindowService.IsUndockedTopmostSuspended
+        // live, so the helper's activation handler cannot re-assert Topmost while a menu or dialog
+        // is still open: opening a cascaded submenu (or a modal dialog) churns window activation,
+        // and the re-asserted Topmost put the tool windows back over the popup (#13187 follow-up) -
+        // and on Windows the SetWindowPos churn could steal OS activation from a just-opened modal
+        // dialog, leaving it drawn on top but inactive (#13325). Asking live rather than keeping a
+        // flag here is also what lets a leaked suspension heal instead of keeping the tool windows
+        // down for the session (#14622).
         foreach (var undockedWindow in new[] { _videoPlayerUndockedViewModel?.Window, _audioVisualizerUndockedViewModel?.Window })
         {
             if (undockedWindow != null)

--- a/src/ui/Logic/WindowsService.cs
+++ b/src/ui/Logic/WindowsService.cs
@@ -383,12 +383,19 @@ namespace Nikse.SubtitleEdit.Logic
         // would be covered. MainViewModel registers the setter; the count makes nested
         // suspensions safe (menu -> dialog -> message box).
         private static Action<bool>? _setUndockedWindowsTopmost;
-        private static int _undockedTopmostSuspendCount;
+        private static readonly List<UndockedTopmostSuspension> _undockedTopmostSuspensions = new();
+        private static bool _undockedTopmostSuppressed;
+
+        // How long a suspension may report "owner not open" before it counts as leaked. A flyout
+        // takes its suspension at Opening, before IsOpen flips; a stalled UI thread can stretch
+        // that gap, and treating it as a leak too early would put the tool windows back over the
+        // popup it was taken for. Nothing legitimately stays in that state for this long.
+        private const long UndockedTopmostLeakGraceMs = 5000;
 
         /// <summary>
         /// Registers the callback that applies (true) or suppresses (false) the undocked tool
         /// windows' topmost state. Registered by MainViewModel; consulted by
-        /// <see cref="SuspendUndockedTopmost"/>.
+        /// <see cref="SuspendUndockedTopmost()"/>.
         /// </summary>
         public static void RegisterUndockedTopmostSetter(Action<bool>? setTopmost)
         {
@@ -401,26 +408,127 @@ namespace Nikse.SubtitleEdit.Logic
         /// </summary>
         internal static void ResetUndockedTopmostSuspensionsForTests()
         {
-            _undockedTopmostSuspendCount = 0;
+            _undockedTopmostSuspensions.Clear();
+            _undockedTopmostSuppressed = false;
+        }
+
+        /// <summary>
+        /// True while something that must not be covered by the undocked tool windows is open.
+        /// This is the live answer, not a remembered flag: reading it drops any suspension whose
+        /// owner has closed without releasing it (see <see cref="ReconcileUndockedTopmostSuspensions"/>),
+        /// so a leaked suspension can never keep the tool windows down for the rest of the session.
+        /// </summary>
+        public static bool IsUndockedTopmostSuspended
+        {
+            get
+            {
+                ReconcileUndockedTopmostSuspensions();
+                return _undockedTopmostSuppressed;
+            }
         }
 
         /// <summary>
         /// Drops the undocked tool windows' topmost state until the returned token is disposed.
-        /// Re-entrant: the state is restored when the last outstanding token is disposed.
+        /// Re-entrant: the state is restored when the last outstanding token is disposed. For a
+        /// suspension whose owner can be asked whether it is still open, prefer
+        /// <see cref="SuspendUndockedTopmost(Func{bool}, string)"/>.
         /// </summary>
         public static IDisposable SuspendUndockedTopmost()
         {
-            if (++_undockedTopmostSuspendCount == 1)
+            return SuspendUndockedTopmost(null, "modal dialog");
+        }
+
+        /// <summary>
+        /// Same as <see cref="SuspendUndockedTopmost()"/>, with a liveness check. A token whose
+        /// <paramref name="isStillOpen"/> reports false after its owner has been seen open (or
+        /// for longer than any open takes) is treated as leaked the next time the suspensions
+        /// are consulted: it is released, and the leak is logged with the stack that took it.
+        /// </summary>
+        /// <param name="isStillOpen">Whether the menu, flyout, or dialog the token was taken for is still open.</param>
+        /// <param name="origin">What took the suspension - named in the leak log entry.</param>
+        public static IDisposable SuspendUndockedTopmost(Func<bool>? isStillOpen, string origin)
+        {
+            var suspension = new UndockedTopmostSuspension(isStillOpen, origin);
+            _undockedTopmostSuspensions.Add(suspension);
+            ReconcileUndockedTopmostSuspensions();
+            return suspension;
+        }
+
+        /// <summary>
+        /// Brings the tool windows' topmost state in line with the suspensions that are actually
+        /// outstanding. The suspension used to be a bare count, and a single token that never got
+        /// disposed - an Opened without its Closed, a flyout torn down under its popup - kept the
+        /// undocked audio visualizer behind the main window until SE was restarted, with nothing
+        /// left in the log to say what had taken it (#14622). Now every owner that can be asked
+        /// is asked, a token whose owner is gone is dropped and logged, and the state is
+        /// re-derived from what remains.
+        /// </summary>
+        private static void ReconcileUndockedTopmostSuspensions()
+        {
+            for (var i = _undockedTopmostSuspensions.Count - 1; i >= 0; i--)
             {
-                _setUndockedWindowsTopmost?.Invoke(false);
+                var suspension = _undockedTopmostSuspensions[i];
+                if (!suspension.IsLeaked())
+                {
+                    continue;
+                }
+
+                _undockedTopmostSuspensions.RemoveAt(i);
+                Se.LogError(
+                    $"Undocked topmost suspension leaked: the {suspension.Origin} that took it is no longer open " +
+                    $"but never released it - released now. Taken at:{Environment.NewLine}{suspension.TakenAt}");
             }
 
-            return new UndockedTopmostSuspension();
+            var suppress = _undockedTopmostSuspensions.Count > 0;
+            if (suppress == _undockedTopmostSuppressed)
+            {
+                return;
+            }
+
+            _undockedTopmostSuppressed = suppress;
+            _setUndockedWindowsTopmost?.Invoke(!suppress);
         }
 
         private sealed class UndockedTopmostSuspension : IDisposable
         {
+            private readonly Func<bool>? _isStillOpen;
+            private readonly long _takenAtTick = Environment.TickCount64;
+            private bool _seenOpen;
             private bool _disposed;
+
+            public UndockedTopmostSuspension(Func<bool>? isStillOpen, string origin)
+            {
+                _isStillOpen = isStillOpen;
+                Origin = origin;
+                TakenAt = Environment.StackTrace;
+            }
+
+            public string Origin { get; }
+
+            public string TakenAt { get; }
+
+            /// <summary>
+            /// True when the owner is no longer open but the token was never disposed. An owner
+            /// legitimately reports "not open" right after taking the suspension (a flyout takes
+            /// it at Opening, before IsOpen flips), so that only counts once the owner has been
+            /// seen open, or after a grace period long enough for any open to have gone through.
+            /// A token without a liveness check is never leaked by this rule.
+            /// </summary>
+            public bool IsLeaked()
+            {
+                if (_isStillOpen == null)
+                {
+                    return false;
+                }
+
+                if (_isStillOpen())
+                {
+                    _seenOpen = true;
+                    return false;
+                }
+
+                return _seenOpen || Environment.TickCount64 - _takenAtTick > UndockedTopmostLeakGraceMs;
+            }
 
             public void Dispose()
             {
@@ -430,10 +538,8 @@ namespace Nikse.SubtitleEdit.Logic
                 }
 
                 _disposed = true;
-                if (--_undockedTopmostSuspendCount == 0)
-                {
-                    _setUndockedWindowsTopmost?.Invoke(true);
-                }
+                _undockedTopmostSuspensions.Remove(this);
+                ReconcileUndockedTopmostSuspensions();
             }
         }
 
@@ -455,7 +561,7 @@ namespace Nikse.SubtitleEdit.Logic
             IDisposable? suspension = null;
             flyout.Opening += (_, _) =>
             {
-                suspension ??= SuspendUndockedTopmost();
+                suspension ??= SuspendUndockedTopmost(() => flyout.IsOpen, "flyout");
 
                 // A subclass can cancel the open in OnOpening after the event has been raised;
                 // Closed then never fires and the suspension would leak, leaving the tool
@@ -485,7 +591,7 @@ namespace Nikse.SubtitleEdit.Logic
         public static void SuspendUndockedTopmostWhileOpen(MenuBase menu)
         {
             IDisposable? suspension = null;
-            menu.Opened += (_, _) => suspension ??= SuspendUndockedTopmost();
+            menu.Opened += (_, _) => suspension ??= SuspendUndockedTopmost(() => menu.IsOpen, "main menu");
             menu.Closed += (_, _) =>
             {
                 suspension?.Dispose();
@@ -1103,10 +1209,40 @@ namespace Nikse.SubtitleEdit.Logic
         internal static void SetTopmost(Window window, bool topmost, Window? owner)
         {
             window.Topmost = topmost;
-            if (!topmost)
+            if (topmost)
+            {
+                EnsureOsTopmost(window);
+            }
+            else
             {
                 KeepBelowForeignForegroundWindow(window, owner ?? window);
             }
+        }
+
+        /// <summary>
+        /// Avalonia's Win32 backend only issues SetWindowPos(HWND_TOPMOST) when its own cached
+        /// Topmost value changes, so a window whose WS_EX_TOPMOST the OS has dropped behind
+        /// Avalonia's back stays non-topmost no matter how often Topmost=true is re-asserted. If
+        /// the OS disagrees with the property after asserting it, force the round trip - and log
+        /// it, since that desync is one of the two states that leave an undocked tool window
+        /// permanently behind the main window (#14622).
+        /// </summary>
+        private static void EnsureOsTopmost(Window window)
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                return;
+            }
+
+            var handle = window.TryGetPlatformHandle()?.Handle ?? IntPtr.Zero;
+            if (handle == IntPtr.Zero || (GetWindowLongW(handle, GwlExStyle) & WsExTopmost) != 0)
+            {
+                return;
+            }
+
+            Se.LogError($"Window '{window.Title}' reports Topmost but is not WS_EX_TOPMOST - re-asserting.");
+            window.Topmost = false;
+            window.Topmost = true;
         }
 
         private static void KeepBelowForeignForegroundWindow(Window window, Window reference)

--- a/tests/UI/Logic/SuspendUndockedTopmostTests.cs
+++ b/tests/UI/Logic/SuspendUndockedTopmostTests.cs
@@ -65,4 +65,78 @@ public class SuspendUndockedTopmostTests : IDisposable
         outer.Dispose();
         Assert.Equal([false, true], _calls);
     }
+
+    [Fact]
+    public void LiveQuery_FollowsOutstandingSuspensions()
+    {
+        Assert.False(WindowService.IsUndockedTopmostSuspended);
+
+        var suspension = WindowService.SuspendUndockedTopmost();
+        Assert.True(WindowService.IsUndockedTopmostSuspended);
+
+        suspension.Dispose();
+        Assert.False(WindowService.IsUndockedTopmostSuspended);
+    }
+
+    [Fact]
+    public void SuspensionWhoseOwnerClosedWithoutReleasing_IsHealedOnTheNextQuery()
+    {
+        // A menu that raised Opened but never Closed (#14622): the token stays undisposed, but
+        // its owner reports closed, so the next consultation must drop it and restore topmost.
+        var menuIsOpen = true;
+        _ = WindowService.SuspendUndockedTopmost(() => menuIsOpen, "test menu");
+        Assert.True(WindowService.IsUndockedTopmostSuspended);
+        Assert.Equal([false], _calls);
+
+        menuIsOpen = false;
+        Assert.False(WindowService.IsUndockedTopmostSuspended);
+        Assert.Equal([false, true], _calls);
+    }
+
+    [Fact]
+    public void LeakedSuspension_IsHealedWhenAnotherSuspensionIsReleased()
+    {
+        // The reporter's Ctrl+N after the leak: the "save changes?" prompt takes and releases
+        // its own suspension, and that release must be enough to bring the tool windows back.
+        var flyoutIsOpen = true;
+        _ = WindowService.SuspendUndockedTopmost(() => flyoutIsOpen, "test flyout");
+        flyoutIsOpen = false;
+
+        var prompt = WindowService.SuspendUndockedTopmost();
+        Assert.Equal([false], _calls);
+
+        prompt.Dispose();
+        Assert.Equal([false, true], _calls);
+    }
+
+    [Fact]
+    public void SuspensionTakenBeforeItsOwnerOpens_IsNotTreatedAsLeaked()
+    {
+        // Flyouts take the suspension at Opening, before IsOpen flips - "not open yet" must not
+        // read as "closed without releasing".
+        var flyoutIsOpen = false;
+        var suspension = WindowService.SuspendUndockedTopmost(() => flyoutIsOpen, "test flyout");
+
+        Assert.True(WindowService.IsUndockedTopmostSuspended);
+        Assert.Equal([false], _calls);
+
+        flyoutIsOpen = true;
+        Assert.True(WindowService.IsUndockedTopmostSuspended);
+
+        suspension.Dispose();
+        Assert.Equal([false, true], _calls);
+    }
+
+    [Fact]
+    public void SuspensionWithoutLivenessCheck_IsNeverHealedAway()
+    {
+        // Modal dialogs hold their token in a using block; nothing but its disposal may end it.
+        var dialog = WindowService.SuspendUndockedTopmost();
+        Assert.True(WindowService.IsUndockedTopmostSuspended);
+        Assert.True(WindowService.IsUndockedTopmostSuspended);
+        Assert.Equal([false], _calls);
+
+        dialog.Dispose();
+        Assert.Equal([false, true], _calls);
+    }
 }


### PR DESCRIPTION
Addresses #14622: after File > Open original in undocked mode the audio visualizer stayed behind the main window for the rest of the session. Alt+Tab back to the main window pushed it behind again, and only a restart brought it back.

The audit found every `SuspendUndockedTopmost` site balanced on paper, so this PR makes the mechanism survive a leak wherever it comes from, and makes the next report pin it.

- **Self-healing suspension.** The bare ref-count is replaced by a registry of tokens with an optional liveness check (`menu.IsOpen`, `flyout.IsOpen`; modal dialogs keep their `using` token without one). Consulting the state drops any token whose owner closed without releasing it and re-derives topmost from what remains. The tool windows' `KeepTopmostWhileOwnerActive` registrations now ask `WindowService.IsUndockedTopmostSuspended` live instead of reading a remembered flag, so the next activation change, or the next dialog closing, brings the visualizer back.
- **Leak logging.** A dropped token is written to the error log with the origin ("main menu", "flyout", "modal dialog") and the stack that took it.
- **Grace for not-yet-open owners.** Flyouts suspend at `Opening`, before `IsOpen` flips, so "not open yet" only counts as a leak once the owner has been seen open or after 5 s.
- **OS topmost check.** `SetTopmost` verifies `WS_EX_TOPMOST` after asserting `Topmost` on Windows. Avalonia's Win32 backend only calls `SetWindowPos` when its cached value changes, so a flag the OS dropped could never be repaired by re-asserting true. The mismatch is logged and the property toggled.

Tests: five new cases in `SuspendUndockedTopmostTests` (live query, healed on next query, healed by another release, not-yet-open is not a leak, no-check tokens are never healed away). Full UI suite: 4926 passed.

Not reproducible off Windows; the reporter's dock/undock experiment would tell which of the two states they hit, and the log entry now names the culprit either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
