### PR TITLE
Scroll anchor: restore after an extent shrink coerces the offset to the end of the list

### DIFF
--- a/src/ui/Logic/TableViewScrollAnchor.cs
+++ b/src/ui/Logic/TableViewScrollAnchor.cs
@@ -149,9 +149,24 @@ public sealed class TableViewScrollAnchor
         // An extent change with no offset change is the panel re-estimating under the view;
         // anything else is a scroll, which is the user's (or ScrollIntoView's) business.
         // At the very top there is nothing to correct - offset 0 always shows row 0.
+        //
+        // One re-estimate does move the offset: when the estimate shrinks below the current
+        // offset plus viewport, the ScrollViewer coerces the offset down to the new maximum in
+        // the same pass, so the offset change arrives together with the extent change without
+        // anyone having scrolled. Near the end of the file that is the whole story of the grid
+        // "jumping to the bottom" after an auto-break (#14231): the panel re-anchors from
+        // offset / average row height, the short last rows pull the average down, the index
+        // runs past the end and is clamped to the last row, and the coerced offset then kept
+        // this anchor from restoring. An offset that lands exactly on the new maximum, moving
+        // down in step with a shrinking extent, is that coerce and not a scroll.
+        var maxOffset = Math.Max(0, _scrollViewer.Extent.Height - _scrollViewer.Viewport.Height);
+        var offsetUnchanged = Math.Abs(e.OffsetDelta.Y) < 0.5;
+        var offsetCoercedToEnd = e.ExtentDelta.Y < -0.5 &&
+                                 e.OffsetDelta.Y < -0.5 &&
+                                 Math.Abs(_scrollViewer.Offset.Y - maxOffset) < 0.5;
         if (_suspendCount == 0 &&
             Math.Abs(e.ExtentDelta.Y) > 0.5 &&
-            Math.Abs(e.OffsetDelta.Y) < 0.5 &&
+            (offsetUnchanged || offsetCoercedToEnd) &&
             _scrollViewer.Offset.Y > 0.5)
         {
             Restore();

--- a/tests/UI/Logic/TableViewScrollAnchorTests.cs
+++ b/tests/UI/Logic/TableViewScrollAnchorTests.cs
@@ -238,6 +238,64 @@ public class TableViewScrollAnchorTests : IDisposable
     }
 
     [AvaloniaFact]
+    public void RowGrowingNearAShortTail_DoesNotJumpToTheEndOfTheList()
+    {
+        // Issue #14231, second round ("still persists closer to the end of the list"). The
+        // reporter's recording has no cut in it: row 612 of 645 gains two lines on auto-break
+        // and the grid lands on rows 630-645. The last rows of a subtitle file are short, so
+        // once the realized window reaches into them the panel's average row height drops.
+        // After the height change the panel re-anchors from offset / average, that index runs
+        // past the end of the list and is clamped to the last row, and the ScrollViewer coerces
+        // the offset down to the new maximum in the same pass - an offset change the anchor
+        // used to read as a scroll, so it never restored.
+        const int rows = 645;
+        const int edited = 627;
+        var items = new ObservableCollection<Row>(Enumerable.Range(1, rows).Select(i =>
+        {
+            var lines = i > rows - 30 ? 1 : 1 + (int)((uint)(i * 2654435761u) % 3);
+            return new Row
+            {
+                Number = i,
+                Text = string.Join("\n", Enumerable.Range(0, lines).Select(k => $"Line {i} part {k} some longer subtitle text")),
+            };
+        }));
+        items[edited].Text = "Line 628 still on one line";
+
+        var grid = new TableView
+        {
+            ItemsSource = items,
+            Columns =
+            {
+                new TableViewColumn { Header = "#", Binding = new Avalonia.Data.Binding(nameof(Row.Number)) },
+                new TableViewColumn { Header = "Text", Binding = new Avalonia.Data.Binding(nameof(Row.Text)) },
+            },
+        };
+        TableViewScrollAnchor.Attach(grid);
+        var window = new Window { Content = new TableViewIndexScrollBar(grid), Width = 700, Height = 420 };
+        _windows.Add(window);
+        window.Show();
+        Settle(window);
+        var scrollViewer = grid.GetVisualDescendants().OfType<ScrollViewer>().First();
+
+        // The way the video playhead brings a line into view.
+        TableViewExtras.PrePositionScroll(grid, edited);
+        grid.SelectedItem = items[edited];
+        grid.ScrollIntoView(edited);
+        TableViewExtras.CenterRow(grid, items[edited]);
+        Settle(window);
+        Settle(window);
+
+        var before = FirstVisibleIndex(grid, scrollViewer);
+        Assert.InRange(before, rows - 40, edited);
+
+        items[edited].Text = "Line 628 part 0 some longer subtitle text\nLine 628 part 1\nLine 628 part 2";
+        Settle(window);
+        Settle(window);
+
+        Assert.InRange(FirstVisibleIndex(grid, scrollViewer), before - 2, before + 2);
+    }
+
+    [AvaloniaFact]
     public void RemovingRowsAboveTheAnchor_KeepsTheSameRowInView()
     {
         var (window, grid, scrollViewer, items) = BuildShownGrid();


### PR DESCRIPTION
Fixes the remaining part of #14231 (the grid suddenly showing the last rows), re-reported by St0rmXtr00per on #14352 in https://github.com/SubtitleEdit/subtitleedit/pull/14352#issuecomment-5562572641: "The issue still persists closer to the end of the list."

## What the recording actually shows

Frame-stepping the reporter's recording from https://github.com/SubtitleEdit/subtitleedit/issues/14231#issuecomment-5481529046: the top row is 607 before and after, the selected row 612 sits in the middle of the viewport, and the row numbering never changes - no line is cut. Row 612 of 645 gains two lines on auto-break and the grid lands on rows 630-645, the last page of the file. #14352 fixed the top-row-removal case from the written steps; it was not the trigger.

## Root cause

When a realized row changes height, the VirtualizingStackPanel discards its stable start position and re-anchors from `offset / average realized row height` (upstream AvaloniaUI/Avalonia#17831). The last rows of a subtitle file are short one-liners, so once the realized window reaches into that tail the average drops, the computed index runs past the end of the list and is clamped to the last row, the extent estimate collapses (about 9000 px on a 35000 px list in the repro), and the ScrollViewer coerces the offset down to the new maximum in the same layout pass. `TableViewScrollAnchor` only restored on "extent changed, offset unchanged", so the coerced offset looked like a user scroll and nothing restored. Away from the end the same fallback shifts the view a few rows, which the anchor already catches.

## Fix

`OnScrollChanged` also restores when the extent shrank, the offset moved down, and the offset landed exactly on the new maximum. That is the coerce signature; a wheel scroll does not land exactly on the new maximum in step with a shrinking extent.

## Tests

- New `RowGrowingNearAShortTail_DoesNotJumpToTheEndOfTheList` in `TableViewScrollAnchorTests`: 645 rows with aperiodic heights and a short last-30-row tail, the row brought into view the way the playhead follow does, then grown from one to three lines. Fails on the old code with the view on the last page, passes with the fix.
- Headless sweep of 192 combinations (645/300 rows, four tail shapes, two viewport heights, 8-45 rows from the end): 29 failures before, all with a short tail; 0 after.
- The 48 existing grid-scroll tests (anchor, index scrollbar, centering, undo position, delete/insert) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
