### PR TITLE
Release v5.2.0-rc5: version bump and change-log

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -3,6 +3,26 @@ Subtitle Edit Changelog
 
 -----------------------------------------------------------------------------------------------------
 
+v5.2.0-rc5 (7th of September 2026)
+
+* Add FireRedTTS3-Base as an audio.cpp text to speech engine (zero-shot voice cloning in 24 languages)
+* Add "Import plain text" to the unknown subtitle format prompt, and open plain .txt files in the importer paired with a matching audio file - thx NiggleHub
+* Toggle dialog dashes: only the focused text box, per-column direction, and no stacked dashes - thx kadrimarzouki
+* Transcription: append the language code to the unsaved file name when "Save as: append language code" is on - thx GrampaWildWilly
+* Text to speech: per-line voice cloning from the video no longer echoes the reference clip (Fish Audio S2 Pro, CosyVoice3) - thx invio-a11y
+* Text to speech: Confucius4-TTS switches language without reloading the model
+* audio.cpp: offer a runtime update when the installed build lacks the engine's model family
+* Fix "guess start from waveform" moving the whole line instead of trimming the start on long text - thx m0ck69
+* Fix "guess start/end from waveform" giving up silently, staying put when the cue is more than 1 s off, or stopping at the first matching boundary - thx muaz978
+* Fix the undocked audio visualizer staying behind the main window after "Open original" - thx GrampaWildWilly
+* Fix a closed "New window" editor keeping its timers and undo polling running
+* Fix 46 bugs found in random-file hunts (subtitle format round-trips and detection, CSV/TSV quoting, ARIB B24 tables, ASSA style usages, SE 4 shortcut import, batch convert min gap)
+* Faster Timed Text/Rosetta/Netflix Japanese reading, TTML saving, "merge lines with same text", statistics, pre-translation and name list lookups
+* Update Italian translation - thx bovirus
+* Update Korean translation - thx 12si27
+
+-----------------------------------------------------------------------------------------------------
+
 v5.2.0-rc4 (6th of September 2026)
 
 * Add Google Cloud Speech-to-Text v2 as an online speech-to-text engine (lossless audio, dynamic batching, word-timed cues) - thx muaz978

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "Subtitle Edit",
-  "version": "v5.2.0-rc4",
+  "version": "v5.2.0-rc5",
   "translatedBy": "",
   "cultureName": "en-US",
   "general": {

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -20,7 +20,7 @@ public class Se
     internal const int CurrentMacOsFontMigrationVersion = 1;
     internal const int CurrentShortcutsMigrationVersion = 3;
 
-    public static string Version { get; set; } = "v5.2.0-rc4";
+    public static string Version { get; set; } = "v5.2.0-rc5";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
Prepares the v5.2.0-rc5 release candidate.

- Bump `Se.cs` and `English.json` from v5.2.0-rc4 to v5.2.0-rc5
- Add the rc5 section to `change-log.txt` covering the 21 PRs merged since the rc4 tag (#14593–#14625), each ancestor-checked against `v5.2.0-rc4`

After merge: dispatch "Build and release UI" with `release_tag=v5.2.0-rc5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)