### PR TITLE
Fix Qwen3 ASR CPP cue segmentation: break on sentence punctuation, no spaces in CJK

### DIFF
--- a/src/ui/Features/Video/SpeechToText/Qwen3AsrWordSegmenter.cs
+++ b/src/ui/Features/Video/SpeechToText/Qwen3AsrWordSegmenter.cs
@@ -1,0 +1,203 @@
+using System.Collections.Generic;
+using System.Text;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Common.TextLengthCalculator;
+
+namespace Nikse.SubtitleEdit.Features.Video.SpeechToText;
+
+/// <summary>
+/// One aligned token from qwen3-asr-cli's <c>--transcribe-align</c> JSON output.
+/// For CJK languages the forced aligner emits one token per character, and
+/// punctuation marks arrive as their own (often zero-length) tokens.
+/// </summary>
+public readonly record struct Qwen3AsrWord(string Word, double StartSeconds, double EndSeconds);
+
+/// <summary>
+/// Builds subtitle cues from Qwen3 ASR CPP's word-level alignment.
+///
+/// Mirrors the rules of the engine's own SRT writer (which Subtitle Edit bypasses
+/// by requesting JSON): a cue ends on sentence punctuation, on a long pause, or
+/// when it grows past the length cap. Spaces are only inserted between Latin
+/// tokens - never around CJK characters or before punctuation. The previous
+/// implementation split purely on a 0.5 s gap / 80-character cap and joined every
+/// token with a space, which for Chinese produced one space-riddled blob cut
+/// mid-sentence (issue #14631).
+/// </summary>
+public static class Qwen3AsrWordSegmenter
+{
+    /// <summary>Latin script cap; matches the post-processor's paragraph cap for two lines.</summary>
+    public const int DefaultMaxCharsLatin = 86;
+
+    /// <summary>CJK cap; ideographs are wider and carry more meaning per character.</summary>
+    public const int DefaultMaxCharsCjk = 36;
+
+    /// <summary>A silence this long always ends the cue, punctuation or not.</summary>
+    public const double HardPauseSeconds = 1.0;
+
+    /// <summary>A shorter silence ends the cue when the text already ends at a clause boundary.</summary>
+    public const double SoftPauseSeconds = 0.5;
+
+    private const string SentenceTerminators = ".!?。！？…";
+    private const string ClauseTerminators = ",;:，、；：";
+    private const string ClosingMarks = "\"'”’)]】」』）";
+    private const string NoSpaceBefore = ".,!?;:%)]}」』】）…" + "，。！？、；：";
+
+    public static Subtitle BuildSubtitle(IReadOnlyList<Qwen3AsrWord> words, int maxCharsLatin = DefaultMaxCharsLatin, int maxCharsCjk = DefaultMaxCharsCjk)
+    {
+        var subtitle = new Subtitle();
+        var text = new StringBuilder();
+        var startTime = 0.0;
+        var endTime = 0.0;
+
+        void Flush()
+        {
+            if (text.Length > 0)
+            {
+                subtitle.Paragraphs.Add(new Paragraph(text.ToString().Trim(), startTime * 1000.0, endTime * 1000.0));
+                text.Clear();
+            }
+        }
+
+        foreach (var word in words)
+        {
+            var raw = word.Word ?? string.Empty;
+            var token = raw.Trim();
+            if (token.Length == 0)
+            {
+                continue;
+            }
+
+            // The engine can leave a literal newline inside a token (issue #11717); its own
+            // SRT writer treats that as a segment break, so honor it here too.
+            var breakAfter = raw.Contains('\n');
+
+            var isPunctuationOnly = IsPunctuationOnly(token);
+            if (text.Length == 0 && isPunctuationOnly && subtitle.Paragraphs.Count > 0)
+            {
+                // A stray mark right after a sentence break (e.g. a closing quote emitted as
+                // its own token) belongs to the cue that was just closed, not to a new one.
+                var last = subtitle.Paragraphs[subtitle.Paragraphs.Count - 1];
+                last.Text += token;
+                if (word.EndSeconds * 1000.0 > last.EndTime.TotalMilliseconds)
+                {
+                    last.EndTime.TotalMilliseconds = word.EndSeconds * 1000.0;
+                }
+
+                continue;
+            }
+
+            if (text.Length > 0 && !isPunctuationOnly)
+            {
+                var gap = word.StartSeconds - endTime;
+                var endsClause = EndsWith(text, ClauseTerminators) || EndsWith(text, SentenceTerminators);
+                var maxChars = ContainsCjk(text) ? maxCharsCjk : maxCharsLatin;
+                var space = NeedsSpace(text[text.Length - 1], token[0]) ? 1 : 0;
+                var tooLong = text.Length + space + token.Length > maxChars;
+                if (gap > HardPauseSeconds || (gap > SoftPauseSeconds && endsClause) || tooLong)
+                {
+                    Flush();
+                }
+            }
+
+            if (text.Length == 0)
+            {
+                startTime = word.StartSeconds;
+                endTime = word.EndSeconds;
+            }
+            else
+            {
+                if (NeedsSpace(text[text.Length - 1], token[0]))
+                {
+                    text.Append(' ');
+                }
+
+                if (word.EndSeconds > endTime)
+                {
+                    endTime = word.EndSeconds;
+                }
+            }
+
+            text.Append(token);
+
+            if (breakAfter || EndsSentence(token))
+            {
+                Flush();
+            }
+        }
+
+        Flush();
+        return subtitle;
+    }
+
+    private static bool NeedsSpace(char previous, char next)
+    {
+        if (char.IsWhiteSpace(previous) || NoSpaceBefore.IndexOf(next) >= 0)
+        {
+            return false;
+        }
+
+        if (IsCjkOrFullWidth(previous) || IsCjkOrFullWidth(next))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// True when the token ends a sentence: a terminator, optionally followed by
+    /// closing quotes/brackets. Checks the end only, so "3.5" or "e.g" do not split.
+    /// </summary>
+    private static bool EndsSentence(string token)
+    {
+        var i = token.Length - 1;
+        while (i >= 0 && ClosingMarks.IndexOf(token[i]) >= 0)
+        {
+            i--;
+        }
+
+        return i >= 0 && SentenceTerminators.IndexOf(token[i]) >= 0;
+    }
+
+    private static bool EndsWith(StringBuilder text, string chars)
+    {
+        var i = text.Length - 1;
+        while (i >= 0 && ClosingMarks.IndexOf(text[i]) >= 0)
+        {
+            i--;
+        }
+
+        return i >= 0 && chars.IndexOf(text[i]) >= 0;
+    }
+
+    private static bool IsPunctuationOnly(string token)
+    {
+        foreach (var c in token)
+        {
+            if (char.IsLetterOrDigit(c))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool ContainsCjk(StringBuilder text)
+    {
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (IsCjkOrFullWidth(text[i]))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsCjkOrFullWidth(char c)
+    {
+        return CalcCjk.IsCjk(c) || (c >= '\uFF00' && c <= '\uFFEF'); // full-width forms: ，。！？
+    }
+}

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -1228,52 +1228,22 @@ public partial class SpeechToTextViewModel : ObservableObject
             // still get a result.
             var jsonText = JsonRepair.FixCommaDecimalSeparators(JsonRepair.EscapeControlCharsInStrings(rawJson));
             var jsonDoc = JsonDocument.Parse(jsonText);
-            var words = jsonDoc.RootElement.GetProperty("words");
-
-            var subtitle = new Subtitle();
-            var currentText = new StringBuilder();
-            var startTime = 0.0;
-            var endTime = 0.0;
-            var first = true;
-
-            foreach (var word in words.EnumerateArray())
+            var words = new List<Qwen3AsrWord>();
+            foreach (var word in jsonDoc.RootElement.GetProperty("words").EnumerateArray())
             {
-                var text = word.GetProperty("word").GetString() ?? string.Empty;
-                var start = word.GetProperty("start").GetDouble();
-                var end = word.GetProperty("end").GetDouble();
-
-                if (first)
-                {
-                    startTime = start;
-                    first = false;
-                }
-
-                var newParagraph = false;
-                if (currentText.Length > 0 && (start - endTime > 0.5 || currentText.Length + text.Length > 80))
-                {
-                    newParagraph = true;
-                }
-
-                if (newParagraph)
-                {
-                    subtitle.Paragraphs.Add(new Paragraph(currentText.ToString().Trim(), startTime * 1000.0, endTime * 1000.0));
-                    currentText.Clear();
-                    startTime = start;
-                }
-
-                if (currentText.Length > 0)
-                {
-                    currentText.Append(' ');
-                }
-
-                currentText.Append(text);
-                endTime = end;
+                words.Add(new Qwen3AsrWord(
+                    word.GetProperty("word").GetString() ?? string.Empty,
+                    word.GetProperty("start").GetDouble(),
+                    word.GetProperty("end").GetDouble()));
             }
 
-            if (currentText.Length > 0)
-            {
-                subtitle.Paragraphs.Add(new Paragraph(currentText.ToString().Trim(), startTime * 1000.0, endTime * 1000.0));
-            }
+            // Sentence-aware cue building (issue #14631): the old loop split only on a 0.5 s
+            // gap or 80 chars and joined every token with a space, which turned Chinese
+            // output into one space-riddled blob cut mid-sentence.
+            var subtitle = Qwen3AsrWordSegmenter.BuildSubtitle(
+                words,
+                Configuration.Settings.General.SubtitleLineMaximumLength * 2,
+                Qwen3AsrWordSegmenter.DefaultMaxCharsCjk);
 
             FixNegativeDuration(subtitle);
             var postProcessedSubtitle = PostProcess(subtitle);

--- a/tests/UI/Features/Video/SpeechToText/Qwen3AsrWordSegmenterTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/Qwen3AsrWordSegmenterTests.cs
@@ -1,0 +1,188 @@
+using System.Collections.Generic;
+using System.Linq;
+using Nikse.SubtitleEdit.Features.Video.SpeechToText;
+
+namespace UITests.Features.Video.SpeechToText;
+
+public class Qwen3AsrWordSegmenterTests
+{
+    private static Qwen3AsrWord W(string word, double start, double end) => new(word, start, end);
+
+    [Fact]
+    public void Chinese_PerCharacterTokens_SplitOnSentencePunctuation_WithoutSpaces()
+    {
+        // Real qwen3-asr-cli --transcribe-align output for a four-sentence clip (issue #14631):
+        // one token per character, punctuation as its own (often zero-length) token.
+        var words = new List<Qwen3AsrWord>
+        {
+            W("今", 0.000, 0.160), W("天", 0.160, 0.480), W("天", 0.480, 0.800), W("气", 0.800, 1.040),
+            W("很", 1.040, 1.200), W("好", 1.200, 1.680), W("，", 1.760, 1.760),
+            W("我", 1.760, 1.920), W("们", 1.920, 2.080), W("去", 2.080, 2.320), W("公", 2.320, 2.560),
+            W("园", 2.560, 2.800), W("散", 2.800, 3.040), W("步", 3.040, 3.200), W("吧", 3.200, 3.440),
+            W("。", 3.440, 3.440),
+            W("好", 3.600, 3.840), W("的", 3.840, 4.080), W("，", 4.080, 4.320),
+            W("我", 4.480, 4.480), W("马", 4.480, 4.640), W("上", 4.640, 4.960), W("就", 4.960, 5.200),
+            W("来", 5.200, 5.600), W("。", 5.760, 5.920),
+            W("然", 5.920, 6.000), W("后", 6.000, 6.240), W("我", 6.240, 6.400), W("们", 6.400, 6.560),
+            W("再", 6.560, 6.800), W("去", 6.800, 7.120), W("吃", 7.120, 7.360), W("饭", 7.360, 7.668),
+            W("。", 7.668, 7.668),
+        };
+
+        var subtitle = Qwen3AsrWordSegmenter.BuildSubtitle(words);
+
+        var texts = subtitle.Paragraphs.Select(p => p.Text).ToList();
+        Assert.Equal(new[] { "今天天气很好，我们去公园散步吧。", "好的，我马上就来。", "然后我们再去吃饭。" }, texts);
+        Assert.Equal(0, subtitle.Paragraphs[0].StartTime.TotalMilliseconds);
+        Assert.Equal(3440, subtitle.Paragraphs[0].EndTime.TotalMilliseconds);
+        Assert.Equal(3600, subtitle.Paragraphs[1].StartTime.TotalMilliseconds);
+        Assert.Equal(5920, subtitle.Paragraphs[1].EndTime.TotalMilliseconds);
+        Assert.Equal(5920, subtitle.Paragraphs[2].StartTime.TotalMilliseconds);
+        Assert.Equal(7668, subtitle.Paragraphs[2].EndTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void English_WordsWithAttachedPunctuation_SplitOnSentenceEnd_WithSpaces()
+    {
+        var words = new List<Qwen3AsrWord>
+        {
+            W("Hello", 0.0, 0.3), W("world.", 0.3, 0.7),
+            W("How", 0.8, 1.0), W("are", 1.0, 1.2), W("you?", 1.2, 1.5),
+            W("Fine", 1.6, 1.9), W("thanks", 1.9, 2.2),
+        };
+
+        var subtitle = Qwen3AsrWordSegmenter.BuildSubtitle(words);
+
+        Assert.Equal(new[] { "Hello world.", "How are you?", "Fine thanks" }, subtitle.Paragraphs.Select(p => p.Text));
+    }
+
+    [Fact]
+    public void English_PunctuationAsSeparateToken_GetsNoLeadingSpace()
+    {
+        var words = new List<Qwen3AsrWord>
+        {
+            W("Yes", 0.0, 0.3), W(",", 0.3, 0.3), W("sir", 0.4, 0.6), W(".", 0.6, 0.6),
+            W("Go", 0.7, 0.9), W("!", 0.9, 0.9),
+        };
+
+        var subtitle = Qwen3AsrWordSegmenter.BuildSubtitle(words);
+
+        Assert.Equal(new[] { "Yes, sir.", "Go!" }, subtitle.Paragraphs.Select(p => p.Text));
+    }
+
+    [Fact]
+    public void DecimalNumber_DoesNotEndSentence()
+    {
+        var words = new List<Qwen3AsrWord>
+        {
+            W("Version", 0.0, 0.3), W("3.5", 0.3, 0.6), W("is", 0.6, 0.7), W("out.", 0.7, 1.0),
+        };
+
+        var subtitle = Qwen3AsrWordSegmenter.BuildSubtitle(words);
+
+        Assert.Single(subtitle.Paragraphs);
+        Assert.Equal("Version 3.5 is out.", subtitle.Paragraphs[0].Text);
+    }
+
+    [Fact]
+    public void LongPause_SplitsWithoutPunctuation()
+    {
+        var words = new List<Qwen3AsrWord>
+        {
+            W("one", 0.0, 0.3), W("two", 0.3, 0.6),
+            W("three", 2.0, 2.3), W("four", 2.3, 2.6),
+        };
+
+        var subtitle = Qwen3AsrWordSegmenter.BuildSubtitle(words);
+
+        Assert.Equal(new[] { "one two", "three four" }, subtitle.Paragraphs.Select(p => p.Text));
+        Assert.Equal(600, subtitle.Paragraphs[0].EndTime.TotalMilliseconds);
+        Assert.Equal(2000, subtitle.Paragraphs[1].StartTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void ShortPause_SplitsOnlyAfterClauseBoundary()
+    {
+        var words = new List<Qwen3AsrWord>
+        {
+            W("one", 0.0, 0.3), W("two", 1.0, 1.3),            // 0.7 s gap, no punctuation: keep
+            W("three,", 1.3, 1.6), W("four", 2.3, 2.6),        // 0.7 s gap after a comma: split
+        };
+
+        var subtitle = Qwen3AsrWordSegmenter.BuildSubtitle(words);
+
+        Assert.Equal(new[] { "one two three,", "four" }, subtitle.Paragraphs.Select(p => p.Text));
+    }
+
+    [Fact]
+    public void LengthCap_SplitsRunOnText()
+    {
+        var words = Enumerable.Range(0, 12).Select(i => W("word", i * 0.2, i * 0.2 + 0.2)).ToList();
+
+        var subtitle = Qwen3AsrWordSegmenter.BuildSubtitle(words, maxCharsLatin: 20, maxCharsCjk: 10);
+
+        Assert.All(subtitle.Paragraphs, p => Assert.True(p.Text.Length <= 20, p.Text));
+        Assert.Equal(12, subtitle.Paragraphs.Sum(p => p.Text.Split(' ').Length));
+    }
+
+    [Fact]
+    public void LengthCap_UsesCjkCapForIdeographs()
+    {
+        var words = Enumerable.Range(0, 12).Select(i => W("字", i * 0.2, i * 0.2 + 0.2)).ToList();
+
+        var subtitle = Qwen3AsrWordSegmenter.BuildSubtitle(words, maxCharsLatin: 100, maxCharsCjk: 5);
+
+        Assert.All(subtitle.Paragraphs, p => Assert.True(p.Text.Length <= 5, p.Text));
+        Assert.Equal(12, subtitle.Paragraphs.Sum(p => p.Text.Length));
+    }
+
+    [Fact]
+    public void StrayClosingMark_AfterSentenceBreak_AttachesToPreviousCue()
+    {
+        var words = new List<Qwen3AsrWord>
+        {
+            W("「", 0.0, 0.0), W("好", 0.0, 0.3), W("。", 0.3, 0.3), W("」", 0.3, 0.5),
+            W("走", 0.6, 0.9), W("。", 0.9, 0.9),
+        };
+
+        var subtitle = Qwen3AsrWordSegmenter.BuildSubtitle(words);
+
+        Assert.Equal(new[] { "「好。」", "走。" }, subtitle.Paragraphs.Select(p => p.Text));
+        Assert.Equal(500, subtitle.Paragraphs[0].EndTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void NewlineInsideToken_ForcesBreak()
+    {
+        var words = new List<Qwen3AsrWord>
+        {
+            W("first", 0.0, 0.3), W("part\n", 0.3, 0.6), W("second", 0.6, 0.9),
+        };
+
+        var subtitle = Qwen3AsrWordSegmenter.BuildSubtitle(words);
+
+        Assert.Equal(new[] { "first part", "second" }, subtitle.Paragraphs.Select(p => p.Text));
+    }
+
+    [Fact]
+    public void EmptyAndWhitespaceTokens_AreIgnored()
+    {
+        var words = new List<Qwen3AsrWord>
+        {
+            W("", 0.0, 0.0), W("  ", 0.0, 0.1), W("hi", 0.1, 0.3), W("", 0.3, 0.3),
+        };
+
+        var subtitle = Qwen3AsrWordSegmenter.BuildSubtitle(words);
+
+        Assert.Single(subtitle.Paragraphs);
+        Assert.Equal("hi", subtitle.Paragraphs[0].Text);
+        Assert.Equal(100, subtitle.Paragraphs[0].StartTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void NoWords_ProducesEmptySubtitle()
+    {
+        var subtitle = Qwen3AsrWordSegmenter.BuildSubtitle(new List<Qwen3AsrWord>());
+
+        Assert.Empty(subtitle.Paragraphs);
+    }
+}


### PR DESCRIPTION
Fixes #14631

## Problem
The reporter said the Qwen3-ASR 1.7B model "cannot segment sentences" and asked to switch to the ggml-org GGUF loaded via llama.cpp. The model is not the cause. Reproduced with a Chinese clip through the shipped `qwen3-asr-cli`: the aligner returns one token per character with punctuation as its own tokens, and SE's JSON-to-cue loop threw that away:

- new cue only on a 0.5 s gap or an 80-character cap, never on `。？！.?!`
- every token joined with a space, so Chinese came out as `今 天 天 气 很 好 ， 我 们 ...`
- post-processing cannot rescue it: the split step is skipped for zh/ja/yue

Result for a 7.7 s four-sentence clip was one cue. The engine's own SRT writer already breaks on sentence punctuation; SE bypasses it by requesting JSON.

The requested model swap is not possible inside this engine: `ggml-org/Qwen3-ASR-1.7B-GGUF` is a llama.cpp conversion (text GGUF + separate `mmproj` audio encoder) that qwen3-asr.cpp cannot load, and llama.cpp's audio path returns text without timestamps.

## Fix
New `Qwen3AsrWordSegmenter`:
- cue ends on a sentence terminator (Latin and CJK), on a pause > 1.0 s, on a pause > 0.5 s after a clause mark, or at a length cap (Latin: line max × 2, CJK: 36)
- spaces only between Latin tokens, never around CJK characters or before punctuation
- stray closing marks after a break attach to the previous cue; literal newlines inside a token still force a break (#11717 behavior kept)

`ProcessQwen3AsrCppTranscription` now feeds the parsed words to the segmenter.

Same clip after the fix:
```
今天天气很好，我们去公园散步吧。   0.000 → 3.440
好的，我马上就来。                 3.600 → 5.920
然后我们再去吃饭。                 5.920 → 7.668
```

## Tests
`Qwen3AsrWordSegmenterTests` (12 tests): real Chinese engine output, English with attached and separate punctuation, decimal numbers not splitting, hard/soft pause rules, Latin and CJK caps, stray closing mark, newline break, empty tokens. All 312 SpeechToText tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)