### PR TITLE
Fix #14634: undo no longer strips the original subtitle unexpectedly

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -402,6 +402,8 @@
     "openVideoFileTitle": "Open video file",
     "optimalCharactersPerSecond": "Optimal characters per second",
     "options": "Options",
+    "originalSubtitleClosed": "Original subtitle closed",
+    "originalSubtitleLoadedX": "Original subtitle loaded: {0}",
     "originalText": "Original text",
     "outline": "Outline",
     "outlineColor": "Outline color",

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -2894,6 +2894,25 @@ public partial class MainViewModel :
         _shortcutManager.ClearKeys();
     }
 
+    /// <summary>
+    /// Re-opens the original remembered with a recent file (start-up and Reopen). The pair is one
+    /// load to the user, so the undo history starts over once both are in: with the original opened
+    /// as a step after "Subtitle loaded", a freshly opened pair had an undo step waiting, and the
+    /// first Ctrl+Z took the original away (#14634).
+    /// </summary>
+    private async Task RestoreRememberedOriginal(int selectedIndex, string? originalFileName, string subtitleFileName)
+    {
+        if (string.IsNullOrEmpty(originalFileName) || !File.Exists(originalFileName))
+        {
+            return;
+        }
+
+        await SubtitleOpenOriginal(selectedIndex, originalFileName);
+
+        _undoRedoManager.Reset();
+        _undoRedoManager.Do(MakeUndoRedoObject(string.Format(Se.Language.General.SubtitleLoadedX, subtitleFileName)));
+    }
+
     private async Task<bool> SubtitleOpenOriginal(int selectedIndex, string fileName)
     {
         // Replacing an editable original discards it - settle unsaved edits first (#13594).
@@ -2902,6 +2921,11 @@ public partial class MainViewModel :
             _shortcutManager.ClearKeys();
             return false;
         }
+
+        // The open is recorded as its own undo step (see ImportOriginalSubtitle); whatever the
+        // user edited in the last few hundred milliseconds must be its own step before that,
+        // or the first Ctrl+Z would take the edit away together with the original (#14634).
+        _undoRedoManager.CheckForChanges(null);
 
         var subtitle = Subtitle.Parse(fileName);
         if (subtitle == null)
@@ -3034,6 +3058,11 @@ public partial class MainViewModel :
         AutoFitColumns();
         SelectAndScrollToRow(selectedIndex);
         AddToRecentFiles(true);
+
+        // A named step rather than a "Changes detected" tick, so the history reads right and the
+        // snapshot carries the original's whole state (column, read-only, display-only rows) -
+        // which undo and redo then restore as a unit (#14634).
+        _undoRedoManager.Do(MakeUndoRedoObject(string.Format(Se.Language.General.OriginalSubtitleLoadedX, fileName)));
     }
 
     /// <summary>
@@ -3737,6 +3766,10 @@ public partial class MainViewModel :
     [RelayCommand]
     private async Task FileCloseOriginal()
     {
+        // As in SubtitleOpenOriginal: the close becomes its own undo step below, so pending edits
+        // must be recorded as theirs first.
+        _undoRedoManager.CheckForChanges(null);
+
         if (IsOriginalReadOnly || IsShowingOriginalNonMatchingLines || IsEditOriginalMode)
         {
             // An editable original with unsaved edits gets the save prompt before anything is torn
@@ -3778,6 +3811,7 @@ public partial class MainViewModel :
 
         ShowColumnOriginalText = false;
         AutoFitColumns();
+        _undoRedoManager.Do(MakeUndoRedoObject(Se.Language.General.OriginalSubtitleClosed));
         _shortcutManager.ClearKeys();
     }
 
@@ -4049,12 +4083,7 @@ public partial class MainViewModel :
             // Seek the video to the restored line - otherwise Reopen leaves it at 0:00.
             await SeekVideoToSelectedLineAsync();
 
-            if (!string.IsNullOrEmpty(recentFile.SubtitleFileNameOriginal) &&
-                File.Exists(recentFile.SubtitleFileNameOriginal))
-            {
-                var selectedIndex = recentFile.SelectedLine;
-                await SubtitleOpenOriginal(selectedIndex, recentFile.SubtitleFileNameOriginal);
-            }
+            await RestoreRememberedOriginal(recentFile.SelectedLine, recentFile.SubtitleFileNameOriginal, recentFile.SubtitleFileName);
 
             SetRecentFileProperties(recentFile);
 
@@ -20896,6 +20925,12 @@ public partial class MainViewModel :
             SubtitleFileNameOriginal = _subtitleFileNameOriginal,
             SubtitleHeaderOriginal = _subtitleOriginal?.Header,
             SubtitleFooterOriginal = _subtitleOriginal?.Footer,
+            IsOriginalLoaded = _subtitleOriginal is { Paragraphs.Count: > 0 },
+            ShowColumnOriginalText = ShowColumnOriginalText,
+            IsOriginalReadOnly = IsOriginalReadOnly,
+            IsShowingOriginalNonMatchingLines = IsShowingOriginalNonMatchingLines,
+            IsEditOriginalMode = IsEditOriginalMode,
+            SubtitleOriginalFormat = _subtitleOriginal?.OriginalFormat,
         };
     }
 
@@ -20928,14 +20963,73 @@ public partial class MainViewModel :
         // Restore the original-subtitle file-level state too - the undo hash covers it,
         // so leaving it untouched makes the restored state hash-mismatch its own entry,
         // and the next Undo() clears the redo timeline as "unrecorded changes" (#12952).
+        var previousOriginalFileName = _subtitleFileNameOriginal ?? string.Empty;
         _subtitleFileNameOriginal = undoRedoObject.SubtitleFileNameOriginal;
-        _subtitleOriginal ??= new Subtitle();
-        _subtitleOriginal.Header = undoRedoObject.SubtitleHeaderOriginal;
-        _subtitleOriginal.Footer = undoRedoObject.SubtitleFooterOriginal;
+        RestoreOriginalState(undoRedoObject);
+
+        // The baseline says what the original's file holds. Undoing an edit to the original keeps
+        // it (the restored state is then clean or dirty exactly as it should be); undoing or
+        // redoing across an open or close is a different file, whose baseline is the restored
+        // content itself - otherwise the undone open left the column "unsaved", and closing SE
+        // offered to save an original that no longer existed as an empty file (#14634).
+        if (!string.Equals(previousOriginalFileName, _subtitleFileNameOriginal ?? string.Empty, StringComparison.Ordinal))
+        {
+            _changeSubtitleHashOriginal = GetFastHashOriginal();
+        }
 
         if (scrollToSelected)
         {
             SelectAndScrollToRow(undoRedoObject.SelectedLines.First());
+        }
+    }
+
+    /// <summary>
+    /// Puts the original back the way the snapshot had it: loaded or not, shown or hidden, read-only
+    /// or editable, with or without its display-only rows. The rows are the working text and were
+    /// restored already, so the original subtitle is rebuilt from them rather than snapshotted -
+    /// the same way every save and tool rebuilds it. Before this only the original's file name,
+    /// header and footer came back, so undoing past "open original" left an original column and
+    /// edit box with nothing behind them (#14634).
+    /// </summary>
+    private void RestoreOriginalState(UndoRedoItem undoRedoObject)
+    {
+        IsOriginalReadOnly = undoRedoObject.IsOriginalReadOnly;
+        IsShowingOriginalNonMatchingLines = undoRedoObject.IsShowingOriginalNonMatchingLines;
+        IsEditOriginalMode = undoRedoObject.IsEditOriginalMode;
+
+        if (undoRedoObject.IsOriginalLoaded)
+        {
+            _subtitleOriginal ??= new Subtitle();
+            if (undoRedoObject.SubtitleOriginalFormat != null)
+            {
+                _subtitleOriginal.OriginalFormat = undoRedoObject.SubtitleOriginalFormat;
+            }
+
+            // Rebuild after the mode flags above: with the non-matching lines shown, the display-only
+            // rows are original lines and the working rows without a counterpart are not.
+            GetUpdateSubtitleOriginal();
+        }
+        else
+        {
+            _subtitleOriginal = new Subtitle();
+            _subtitleOriginalBeforeEditMode = null;
+
+            // A remembered original-only scope would make every find come up empty now that the
+            // original is gone (as FileCloseOriginal does).
+            _findService.CurrentScope = FindScope.TextAndOriginal;
+        }
+
+        _subtitleOriginal.Header = undoRedoObject.SubtitleHeaderOriginal;
+        _subtitleOriginal.Footer = undoRedoObject.SubtitleFooterOriginal;
+
+        // The restored rows already hold the reference projection the snapshot was taken with, so
+        // no re-match is pending - the rebuild's collection changes flagged one.
+        _referenceMappingDirty = false;
+
+        if (ShowColumnOriginalText != undoRedoObject.ShowColumnOriginalText)
+        {
+            ShowColumnOriginalText = undoRedoObject.ShowColumnOriginalText;
+            AutoFitColumns();
         }
     }
 
@@ -25250,11 +25344,7 @@ public partial class MainViewModel :
 
                         // Restore the original/translator-mode file too - otherwise only the
                         // translation comes back on start-up, unlike the Reopen menu (issue #12705).
-                        if (!string.IsNullOrEmpty(first.SubtitleFileNameOriginal) &&
-                            File.Exists(first.SubtitleFileNameOriginal))
-                        {
-                            await SubtitleOpenOriginal(first.SelectedLine, first.SubtitleFileNameOriginal);
-                        }
+                        await RestoreRememberedOriginal(first.SelectedLine, first.SubtitleFileNameOriginal, first.SubtitleFileName);
 
                         SetRecentFileProperties(first);
                     }

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -402,6 +402,8 @@ public class LanguageGeneral
     public string OpenVideoFileTitle { get; set; }
     public string OptimalCharactersPerSecond { get; set; }
     public string Options { get; set; }
+    public string OriginalSubtitleClosed { get; set; }
+    public string OriginalSubtitleLoadedX { get; set; }
     public string OriginalText { get; set; }
     public string Outline { get; set; }
     public string OutlineColor { get; set; }
@@ -1214,6 +1216,8 @@ public class LanguageGeneral
         OpenVideoFileTitle = "Open video file";
         OptimalCharactersPerSecond = "Optimal characters per second";
         Options = "Options";
+        OriginalSubtitleClosed = "Original subtitle closed";
+        OriginalSubtitleLoadedX = "Original subtitle loaded: {0}";
         OriginalText = "Original text";
         Outline = "Outline";
         OutlineColor = "Outline color";

--- a/src/ui/Logic/UndoRedo/UndoRedoItem.cs
+++ b/src/ui/Logic/UndoRedo/UndoRedoItem.cs
@@ -1,4 +1,5 @@
-﻿using Nikse.SubtitleEdit.Features.Main;
+﻿using Nikse.SubtitleEdit.Core.SubtitleFormats;
+using Nikse.SubtitleEdit.Features.Main;
 using System;
 using System.Linq;
 
@@ -20,6 +21,16 @@ public class UndoRedoItem
     public string? SubtitleFileNameOriginal { get; set; }
     public string? SubtitleHeaderOriginal { get; set; }
     public string? SubtitleFooterOriginal { get; set; }
+
+    // The rest of the original's state. The rows carry the original text, but not whether an
+    // original is loaded at all, how it is shown, or whether it may be edited - so undoing past
+    // "open original" left an original column and edit box with nothing behind them (#14634).
+    public bool IsOriginalLoaded { get; set; }
+    public bool ShowColumnOriginalText { get; set; }
+    public bool IsOriginalReadOnly { get; set; }
+    public bool IsShowingOriginalNonMatchingLines { get; set; }
+    public bool IsEditOriginalMode { get; set; }
+    public SubtitleFormat? SubtitleOriginalFormat { get; set; }
     public int[] SelectedLines { get; set; }
     public int CaretIndex { get; set; }
     public int SelectionLength { get; set; }
@@ -67,6 +78,12 @@ public class UndoRedoItem
             SubtitleFileNameOriginal = item.SubtitleFileNameOriginal,
             SubtitleHeaderOriginal = item.SubtitleHeaderOriginal,
             SubtitleFooterOriginal = item.SubtitleFooterOriginal,
+            IsOriginalLoaded = item.IsOriginalLoaded,
+            ShowColumnOriginalText = item.ShowColumnOriginalText,
+            IsOriginalReadOnly = item.IsOriginalReadOnly,
+            IsShowingOriginalNonMatchingLines = item.IsShowingOriginalNonMatchingLines,
+            IsEditOriginalMode = item.IsEditOriginalMode,
+            SubtitleOriginalFormat = item.SubtitleOriginalFormat,
             // Preserve the original timestamp — every Clone() used to overwrite
             // Created with DateTime.Now via the constructor, so any UI that
             // displays Created (or any logic that relies on the chronological

--- a/tests/UI/Features/Main/MainUndoOriginalTests.cs
+++ b/tests/UI/Features/Main/MainUndoOriginalTests.cs
@@ -1,0 +1,266 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Main.MainHelpers;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.UndoRedo;
+using System.Reflection;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// Opening and closing an original subtitle are undo steps of their own, and undo/redo restore the
+/// original as a unit: the column, the file name, the read-only and display-only-row modes, and the
+/// original subtitle behind the rows. Before this, undo only rebuilt the rows, so undoing past
+/// "open original" left an empty original column and edit box behind (issue #14634).
+/// </summary>
+public class MainUndoOriginalTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+    private readonly string _tempDirectory =
+        Path.Combine(Path.GetTempPath(), "se-undo-original-tests-" + Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task OpenOriginal_ThenUndo_RemovesTheOriginalCompletely_AndRedoBringsItBack()
+    {
+        var (window, vm) = CreateMainViewModel();
+        AddLine(vm, "Translated one", 0, 2000);
+        AddLine(vm, "Translated two", 2000, 4000);
+        SetPrivateField(vm, "_changeSubtitleHash", vm.GetFastHash());
+        var undoRedo = GetUndoRedoManager(vm);
+        undoRedo.Do(vm.MakeUndoRedoObject("loaded"));
+
+        var original = new Subtitle();
+        original.Paragraphs.Add(new Paragraph("Original one", 0, 2000));
+        original.Paragraphs.Add(new Paragraph("Original two", 2000, 4000));
+        InvokeImportOriginalSubtitle(vm, "original.srt", original, match: null, isReadOnly: false);
+        await SettleAsync(window);
+
+        // The open is a named step, not a "Changes detected" tick.
+        Assert.Equal(2, undoRedo.UndoCount);
+        Assert.Contains("original.srt", undoRedo.UndoList[^1].Description);
+        Assert.True(vm.ShowColumnOriginalText);
+        Assert.False(vm.HasChanges());
+
+        vm.UndoCommand.Execute(null);
+        await SettleAsync(window);
+
+        Assert.Equal(new[] { string.Empty, string.Empty }, vm.Subtitles.Select(p => p.OriginalText));
+        Assert.False(vm.ShowColumnOriginalText);
+        Assert.Empty(GetOriginalFileName(vm));
+        Assert.Empty(GetOriginalSubtitle(vm).Paragraphs);
+        // No "save changes to the original?" on the way out for an original that no longer exists.
+        Assert.False(vm.HasChanges());
+
+        vm.RedoCommand.Execute(null);
+        await SettleAsync(window);
+
+        Assert.Equal(new[] { "Original one", "Original two" }, vm.Subtitles.Select(p => p.OriginalText));
+        Assert.True(vm.ShowColumnOriginalText);
+        Assert.Equal("original.srt", GetOriginalFileName(vm));
+        Assert.Equal(new[] { "Original one", "Original two" }, GetOriginalSubtitle(vm).Paragraphs.Select(p => p.Text));
+        Assert.False(vm.HasChanges());
+    }
+
+    [AvaloniaFact]
+    public async Task CloseReadOnlyReference_ThenUndo_BringsTheReferenceBackWithItsRows()
+    {
+        var (window, vm) = CreateMainViewModel();
+        AddLine(vm, "Translated one", 0, 2000);
+        AddLine(vm, "Translated two", 4000, 6000);
+        SetPrivateField(vm, "_changeSubtitleHash", vm.GetFastHash());
+        var undoRedo = GetUndoRedoManager(vm);
+        undoRedo.Do(vm.MakeUndoRedoObject("loaded"));
+
+        var reference = new Subtitle();
+        reference.Paragraphs.Add(new Paragraph("Reference one", 0, 2000));
+        reference.Paragraphs.Add(new Paragraph("Reference only - no translation", 2000, 4000));
+        reference.Paragraphs.Add(new Paragraph("Reference two", 4000, 6000));
+        var match = ImportOriginalHelper.MatchOriginalLines(vm.Subtitles, reference);
+        InvokeImportOriginalSubtitle(vm, "reference.srt", reference, match, isReadOnly: true);
+        await SettleAsync(window);
+
+        Assert.Equal(3, vm.Subtitles.Count);
+        Assert.True(vm.Subtitles[1].IsReferenceOnly);
+        Assert.True(vm.IsOriginalReadOnly);
+        Assert.True(vm.IsShowingOriginalNonMatchingLines);
+
+        await InvokeFileCloseOriginal(vm);
+        await SettleAsync(window);
+
+        Assert.Equal(2, vm.Subtitles.Count);
+        Assert.False(vm.ShowColumnOriginalText);
+        Assert.False(vm.IsOriginalReadOnly);
+        Assert.False(vm.IsShowingOriginalNonMatchingLines);
+        Assert.Equal(3, undoRedo.UndoCount);
+
+        vm.UndoCommand.Execute(null);
+        await SettleAsync(window);
+
+        Assert.Equal(3, vm.Subtitles.Count);
+        Assert.True(vm.Subtitles[1].IsReferenceOnly);
+        Assert.Equal("Reference only - no translation", vm.Subtitles[1].OriginalText);
+        Assert.Equal(new[] { "Reference one", "Reference two" },
+            vm.Subtitles.Where(p => !p.IsReferenceOnly).Select(p => p.OriginalText));
+        Assert.True(vm.ShowColumnOriginalText);
+        Assert.True(vm.IsOriginalReadOnly);
+        Assert.True(vm.IsShowingOriginalNonMatchingLines);
+        Assert.Equal("reference.srt", GetOriginalFileName(vm));
+        Assert.Equal(3, GetOriginalSubtitle(vm).Paragraphs.Count);
+        Assert.False(vm.HasChanges());
+
+        vm.RedoCommand.Execute(null);
+        await SettleAsync(window);
+
+        Assert.Equal(2, vm.Subtitles.Count);
+        Assert.False(vm.ShowColumnOriginalText);
+        Assert.Empty(GetOriginalFileName(vm));
+        Assert.Empty(GetOriginalSubtitle(vm).Paragraphs);
+    }
+
+    /// <summary>
+    /// Start-up and Reopen bring back a remembered translation/original pair. That is one load to
+    /// the user, so nothing may be waiting on the undo stack afterwards - the first Ctrl+Z used to
+    /// take the original away.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task ReopeningATranslationWithItsOriginal_LeavesNothingToUndo()
+    {
+        var (window, vm) = CreateMainViewModel();
+        var translationFileName = WriteSrt("translation.srt", "Translated one", "Translated two");
+        var originalFileName = WriteSrt("original.srt", "Original one", "Original two");
+
+        await vm.SubtitleOpen(translationFileName, skipLoadVideo: true);
+        await SettleAsync(window);
+        Assert.Equal(2, vm.Subtitles.Count);
+
+        await InvokeRestoreRememberedOriginal(vm, 0, originalFileName, translationFileName);
+        await SettleAsync(window);
+
+        var undoRedo = GetUndoRedoManager(vm);
+        Assert.True(vm.ShowColumnOriginalText);
+        Assert.Equal(new[] { "Original one", "Original two" }, vm.Subtitles.Select(p => p.OriginalText));
+        Assert.Equal(1, undoRedo.UndoCount);
+        Assert.False(undoRedo.CanUndo);
+
+        vm.UndoCommand.Execute(null);
+        await SettleAsync(window);
+
+        Assert.True(vm.ShowColumnOriginalText);
+        Assert.Equal(new[] { "Original one", "Original two" }, vm.Subtitles.Select(p => p.OriginalText));
+        Assert.Equal(originalFileName, GetOriginalFileName(vm));
+    }
+
+    private string WriteSrt(string name, params string[] lines)
+    {
+        Directory.CreateDirectory(_tempDirectory);
+        var fileName = Path.Combine(_tempDirectory, name);
+        var subtitle = new Subtitle();
+        for (var i = 0; i < lines.Length; i++)
+        {
+            subtitle.Paragraphs.Add(new Paragraph(lines[i], i * 2000, i * 2000 + 1500));
+        }
+
+        File.WriteAllText(fileName, new Nikse.SubtitleEdit.Core.SubtitleFormats.SubRip().ToText(subtitle, string.Empty));
+        return fileName;
+    }
+
+    private (Window Window, MainViewModel Vm) CreateMainViewModel()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1200, Height = 800 };
+        _windows.Add(window);
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var vm = (MainViewModel)view.DataContext!;
+        window.SuppressSaveChangesPromptOnClose(vm);
+        return (window, vm);
+    }
+
+    private static void AddLine(MainViewModel vm, string text, int startMs, int endMs)
+    {
+        vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph(text, startMs, endMs), null!)
+        {
+            Number = vm.Subtitles.Count + 1,
+        });
+    }
+
+    private static async Task SettleAsync(Window window)
+    {
+        for (var round = 0; round < 2; round++)
+        {
+            for (var pump = 0; pump < 8; pump++)
+            {
+                Dispatcher.UIThread.RunJobs();
+                window.UpdateLayout();
+            }
+
+            await Task.Delay(50);
+        }
+    }
+
+    private static IUndoRedoManager GetUndoRedoManager(MainViewModel vm) =>
+        (IUndoRedoManager)GetField("_undoRedoManager").GetValue(vm)!;
+
+    private static string GetOriginalFileName(MainViewModel vm) =>
+        (string?)GetField("_subtitleFileNameOriginal").GetValue(vm) ?? string.Empty;
+
+    private static Subtitle GetOriginalSubtitle(MainViewModel vm) =>
+        (Subtitle)GetField("_subtitleOriginal").GetValue(vm)!;
+
+    private static void InvokeImportOriginalSubtitle(
+        MainViewModel vm, string fileName, Subtitle subtitle, ImportOriginalHelper.OriginalMatch? match, bool isReadOnly)
+    {
+        GetMethod("ImportOriginalSubtitle").Invoke(vm, new object?[] { 0, fileName, subtitle, match, isReadOnly });
+    }
+
+    private static async Task InvokeFileCloseOriginal(MainViewModel vm)
+    {
+        // A read-only reference closes without a save prompt, so the task completes at once.
+        await (Task)GetMethod("FileCloseOriginal").Invoke(vm, null)!;
+    }
+
+    private static async Task InvokeRestoreRememberedOriginal(
+        MainViewModel vm, int selectedIndex, string originalFileName, string subtitleFileName)
+    {
+        await (Task)GetMethod("RestoreRememberedOriginal").Invoke(vm, new object?[] { selectedIndex, originalFileName, subtitleFileName })!;
+    }
+
+    private static void SetPrivateField(MainViewModel vm, string name, object value) =>
+        GetField(name).SetValue(vm, value);
+
+    private static FieldInfo GetField(string name) =>
+        typeof(MainViewModel).GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException($"Field not found: {name}");
+
+    private static MethodInfo GetMethod(string name) =>
+        typeof(MainViewModel).GetMethod(name, BindingFlags.Instance | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException($"Method not found: {name}");
+}


### PR DESCRIPTION
Fixes #14634.

## Problem

Opening an original subtitle was never a deliberate undo step, yet the undo hash covers the original column and file name. So the moment an original was opened, undo was enabled, and the next Ctrl+Z restored the snapshot taken before the open: original text gone from every row while the column, the edit box, the original subtitle object and the mode flags stayed behind. Closing SE afterwards offered to save that empty "Untitled" original.

Both scenarios in the issue have this root cause. A remembered translation/original pair (start-up, Reopen) opened the translation first, pushed "Subtitle loaded", and then opened the original on top of it as an unrecorded change.

## Fix

- **A remembered pair is one load.** Start-up and Reopen now go through `RestoreRememberedOriginal`, which opens the original and then resets the undo history to a single "Subtitle loaded" entry. Right after opening a pair there is nothing to undo.
- **Open and close are named undo steps.** Opening records "Original subtitle loaded: x" and closing records "Original subtitle closed" instead of a "Changes detected" tick. Pending edits are flushed into their own step first, so the first Ctrl+Z after opening cannot swallow a text edit made just before. New strings in `LanguageGeneral`, English.json regenerated.
- **Restore is complete.** The undo snapshot carries whether an original is loaded, the column visibility, the read-only and non-matching-lines modes, edit-original mode and the original's format. Restore rebuilds the original subtitle from the restored rows (the rows are the working text, as every save and tool already treats them), shows or hides the column, clears the find scope when the original is gone, and rebases the original's dirty baseline whenever undo or redo crosses an open or close. That removes the empty column and edit box and the bogus save prompt.

SE4 precedent: its history items carried the original, and undo showed the column when the restored state gained an original and removed it when the restored state had none. This matches that behaviour.

## Tests

`MainUndoOriginalTests` (headless UI):
- Open a 1:1 original, undo, redo: column, file name, row texts and original subtitle come and go as a unit; `HasChanges()` stays false.
- Close a read-only reference with a display-only row, undo, redo: the reference row, both mode flags and the column return, then leave again.
- Reopen a translation with its original via the shared helper: one undo entry, undo disabled, Ctrl+Z changes nothing.

Full UI suite: 4948 passed, 1 skipped, 0 failed.

## Known limitation

Hiding the original column with the translation-mode toggle is still a view change, not an undo step. It does not change the undo hash, so an undo after that toggle restores the previous snapshot's column visibility together with the previous edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
