### PR TITLE
Track pickers: remember window size and position

### DIFF
--- a/src/ui/Features/Shared/PickMatroskaTrack/PickMatroskaTrackWindow.cs
+++ b/src/ui/Features/Shared/PickMatroskaTrack/PickMatroskaTrackWindow.cs
@@ -23,6 +23,8 @@ public class PickMatroskaTrackWindow : Window
         MinHeight = 600;
         CanResize = true;
         WindowStartupLocation = WindowStartupLocation.CenterOwner;
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
         DataContext = vm;
 
         var tracksView = MakeTracksView(vm);

--- a/src/ui/Features/Shared/PickMp4Track/PickMp4TrackWindow.cs
+++ b/src/ui/Features/Shared/PickMp4Track/PickMp4TrackWindow.cs
@@ -28,6 +28,8 @@ public class PickMp4TrackWindow : Window
         MinHeight = 600;
         CanResize = true;
         WindowStartupLocation = WindowStartupLocation.CenterOwner;
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
         DataContext = vm;
 
         var tracksView = MakeTracksView(vm);

--- a/src/ui/Features/Shared/PickTsTrack/PickTsTrackWindow.cs
+++ b/src/ui/Features/Shared/PickTsTrack/PickTsTrackWindow.cs
@@ -21,6 +21,8 @@ public class PickTsTrackWindow : Window
         MinHeight = 600;
         CanResize = true;
         WindowStartupLocation = WindowStartupLocation.CenterOwner;
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
         DataContext = vm;
 
         var tracksView = MakeTracksView(vm);

--- a/src/ui/Features/Shared/PickVobSubLanguage/PickVobSubLanguageWindow.cs
+++ b/src/ui/Features/Shared/PickVobSubLanguage/PickVobSubLanguageWindow.cs
@@ -22,6 +22,8 @@ public class PickVobSubLanguageWindow : Window
         MinHeight = 500;
         CanResize = true;
         WindowStartupLocation = WindowStartupLocation.CenterOwner;
+        Closing += delegate { UiUtil.SaveWindowPosition(this); };
+        Loaded += delegate { UiUtil.RestoreWindowPosition(this); };
         DataContext = vm;
 
         var languagesView = MakeLanguagesView(vm);


### PR DESCRIPTION
The Matroska, MP4, transport-stream and VobSub track pickers always opened at 1024x600 centered on the owner, ignoring any resize the user had done last time.

This wires the existing `UiUtil.SaveWindowPosition` / `RestoreWindowPosition` pair into the four picker windows, the same pattern WordLists and BurnIn use. It honours the general 'remember position and size' setting and falls back to the default when the saved rect no longer fits a screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)