### PR TITLE
Batch convert: convert every teletext page per PID in transport streams

### DIFF
--- a/src/ui/Features/Tools/BatchConvert/BatchConvertItemSplitter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertItemSplitter.cs
@@ -47,20 +47,23 @@ public class BatchConvertTransportStreamSplitter : IBatchConvertItemSplitter
             }
         }
 
-        foreach (var i in tsParser.TeletextSubtitlesLookup.Keys)
+        // One PID can carry several teletext subtitle pages (e.g. 888 + 889 for a second
+        // language); every page is its own subtitle, so do not stop at the first one.
+        foreach (var pages in tsParser.TeletextSubtitlesLookup.Values)
         {
-            var pid = tsParser.TeletextSubtitlesLookup[i];
-            var paragraphs = pid.Values.First();
-            if (paragraphs.Count > 0)
+            foreach (var paragraphs in pages.Values)
             {
-                result.Add(new BatchConvertItem
+                if (paragraphs.Count > 0)
                 {
-                    Size = item.Size,
-                    Format = item.Format,
-                    FileName = item.FileName,
-                    Subtitle = new Subtitle(paragraphs),
-                    LanguageCode = string.Empty,
-                });
+                    result.Add(new BatchConvertItem
+                    {
+                        Size = item.Size,
+                        Format = item.Format,
+                        FileName = item.FileName,
+                        Subtitle = new Subtitle(paragraphs),
+                        LanguageCode = string.Empty,
+                    });
+                }
             }
         }
 

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -538,13 +538,15 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             }
         }
 
-        foreach (var i in tsParser.TeletextSubtitlesLookup.Keys)
+        // One PID can carry several teletext subtitle pages; emit each page as its own result.
+        foreach (var pages in tsParser.TeletextSubtitlesLookup.Values)
         {
-            var pid = tsParser.TeletextSubtitlesLookup[i];
-            var paragraphs = pid.Values.First();
-            if (paragraphs.Count > 0)
+            foreach (var paragraphs in pages.Values)
             {
-                result.Add(new TransportStreamResult { IsImage = false, Subtitle = new Subtitle(paragraphs) });
+                if (paragraphs.Count > 0)
+                {
+                    result.Add(new TransportStreamResult { IsImage = false, Subtitle = new Subtitle(paragraphs) });
+                }
             }
         }
 


### PR DESCRIPTION
Batch convert only took the first teletext subtitle page of each PID in a transport stream, so a stream carrying two pages on one PID (e.g. a second language) silently lost the second page. SE4 and seconv already iterate every page; both GUI loops now do the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)