### PR TITLE
seconv: add --override-position and --output-filename-append

### DIFF
--- a/docs/reference/command-line.md
+++ b/docs/reference/command-line.md
@@ -133,6 +133,7 @@ seconv lint *.srt --json             # CI-friendly: exit 1 on any issue
 | `--input-folder:<path>` | Input folder; relative patterns resolve against it |
 | `--output-folder:<path>` | Output folder (default: input file's directory) |
 | `--output-filename:<name>` | Output file name (single input only) |
+| `--output-filename-append:<text>` | Text appended to the output file name stem, before any language/track suffix: `movie.ts` → `movie_fixed.eng.srt`. Ignored with `--output-filename` |
 | `--overwrite` | Overwrite existing files (default: rotate to `name_2.ext`, `_3.ext`, ...) |
 | `--keep-timestamp` (also `--keep-timestamps`) | Give output files the source file's modified/created date instead of the conversion time |
 | `--encoding:<name>` | Encoding name or codepage. Special values: `utf-8`, `utf-8-no-bom` (also `utf-8-nobom`, `utf8-nobom`), a code page number, or `source` to keep the input file's detected encoding. Defaults: auto-detect on input, UTF-8 BOM on output |
@@ -184,6 +185,7 @@ When rendering a text subtitle to an image-based target (Blu-Ray `sup`, VobSub, 
 | `--content-alignment:<align>` | Multi-line text justification: `left` \| `center` (default) \| `right` \| `from-alignment` (follow the `{\anX}` tag) |
 | `--bottom-top-margin:<px>` | Vertical screen-edge margin (default: 5% of height) |
 | `--left-right-margin:<px>` | Horizontal screen-edge margin (default: 5% of width) |
+| `--override-position:<x\|y\|xy>` | Image → image only (DVB-sub, PGS, VobSub pass-through): ignore the source bitmap position on that axis and place it by `--alignment` and the margins instead. The other axis keeps the source position. Matches SE4's transport-stream "override original X/Y position" |
 | `--full-frame` | Draw each subtitle onto a frame-sized image instead of one cropped to the text. Only `fcpimage` and `bluraysup` use it; other image targets warn and ignore it |
 | `--full-frame-background-color:<color>` | Background of the full frame image (default: `transparent`) |
 

--- a/src/seconv/Commands/ConvertCommand.cs
+++ b/src/seconv/Commands/ConvertCommand.cs
@@ -171,6 +171,10 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
         [Description("Offset time (hh:mm:ss:ms)")]
         public string? Offset { get; init; }
 
+        [CommandOption("--output-filename-append|--outputfilenameappend")]
+        [Description("Text appended to the output file name stem, e.g. \"_fixed\" turns movie.ts into movie_fixed.srt (ignored with --output-filename)")]
+        public string? OutputFilenameAppend { get; init; }
+
         [CommandOption("--output-filename|--outputfilename")]
         [Description("Output file name (for single file only)")]
         public string? OutputFilename { get; init; }
@@ -280,6 +284,10 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
         [CommandOption("--left-right-margin|--leftrightmargin")]
         [Description("Image output: horizontal screen-edge margin in pixels (default: 5% of width)")]
         public int? LeftRightMargin { get; init; }
+
+        [CommandOption("--override-position|--overrideposition")]
+        [Description("Image → image output (DVB-sub/PGS/VobSub pass-through): ignore the source bitmap position and place it by --alignment and margins: x | y | xy")]
+        public string? OverridePosition { get; init; }
 
         [CommandOption("--full-frame|--fullframe")]
         [Description("Image output: draw each subtitle on a frame-sized image (place at 0,0 in an editing timeline). Only fcpimage and bluraysup use it")]
@@ -729,6 +737,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
                 InputFolder = settings.InputFolder,
                 OutputFolder = settings.OutputFolder,
                 OutputFilename = settings.OutputFilename,
+                OutputFilenameAppend = settings.OutputFilenameAppend,
                 Encoding = settings.Encoding,
                 InputEncodingFallback = settings.InputEncodingFallback,
                 Fps = settings.Fps,
@@ -1192,6 +1201,27 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
         if (settings.LeftRightMargin.HasValue)
         {
             style.LeftRightMargin = settings.LeftRightMargin.Value;
+        }
+
+        if (!string.IsNullOrWhiteSpace(settings.OverridePosition))
+        {
+            switch (settings.OverridePosition.Trim().ToLowerInvariant())
+            {
+                case "x":
+                    style.OverridePositionX = true;
+                    break;
+                case "y":
+                    style.OverridePositionY = true;
+                    break;
+                case "xy":
+                case "yx":
+                case "both":
+                    style.OverridePositionX = true;
+                    style.OverridePositionY = true;
+                    break;
+                default:
+                    return $"Unknown value '{settings.OverridePosition}' for --override-position. Use: x, y, or xy.";
+            }
         }
 
         if (settings.FullFrame)

--- a/src/seconv/Core/ImageExportStyle.cs
+++ b/src/seconv/Core/ImageExportStyle.cs
@@ -63,6 +63,19 @@ internal sealed class ImageExportStyle
     /// <summary>Horizontal screen-edge margin in pixels. Null = 5% of screen width.</summary>
     public int? LeftRightMargin { get; set; }
 
+    /// <summary>
+    /// Image → image only (DVB-sub, PGS, VobSub pass-through): discard the source bitmap's
+    /// horizontal position and place it from <see cref="Alignment"/> + <see cref="LeftRightMargin"/>.
+    /// Matches SE4's "override original X position" transport-stream setting.
+    /// </summary>
+    public bool OverridePositionX { get; set; }
+
+    /// <summary>
+    /// Image → image only: discard the source bitmap's vertical position and place it from
+    /// <see cref="Alignment"/> + <see cref="BottomTopMargin"/>. Matches SE4's "override original Y position".
+    /// </summary>
+    public bool OverridePositionY { get; set; }
+
     public ExportBoxType EffectiveBoxType =>
         BoxType ?? (BackgroundColor.Alpha > 0 ? ExportBoxType.OneBox : ExportBoxType.None);
 

--- a/src/seconv/Core/ImageOutputWriter.cs
+++ b/src/seconv/Core/ImageOutputWriter.cs
@@ -1,4 +1,5 @@
 using Nikse.SubtitleEdit.Core.Common;
+using SkiaSharp;
 using Nikse.SubtitleEdit.UiLogic.Export;
 
 namespace SeConv.Core;
@@ -119,6 +120,40 @@ internal static class ImageOutputWriter
         handler.WriteFooter();
     }
 
+    /// <summary>
+    /// SE4's transport-stream "override original X/Y position": replace one or both axes of the
+    /// source position with the spot <see cref="ImageExportStyle.Alignment"/> and the margins
+    /// would put the bitmap at. An axis that is not overridden keeps the source value; when
+    /// there is no usable source position, that axis is placed by alignment as well.
+    /// </summary>
+    internal static SKPointI? ApplyPositionOverride(SKPointI? sourcePosition, SKBitmap bitmap, int screenWidth, int screenHeight, ImageExportStyle style)
+    {
+        if (!style.OverridePositionX && !style.OverridePositionY)
+        {
+            return sourcePosition;
+        }
+
+        var leftRightMargin = style.LeftRightMargin ?? (int)(screenWidth * 0.05);
+        var bottomTopMargin = style.BottomTopMargin ?? (int)(screenHeight * 0.05);
+
+        var alignedX = style.Alignment switch
+        {
+            ExportAlignment.TopLeft or ExportAlignment.MiddleLeft or ExportAlignment.BottomLeft => leftRightMargin,
+            ExportAlignment.TopRight or ExportAlignment.MiddleRight or ExportAlignment.BottomRight => screenWidth - leftRightMargin - bitmap.Width,
+            _ => (screenWidth - bitmap.Width) / 2,
+        };
+        var alignedY = style.Alignment switch
+        {
+            ExportAlignment.TopLeft or ExportAlignment.TopCenter or ExportAlignment.TopRight => bottomTopMargin,
+            ExportAlignment.MiddleLeft or ExportAlignment.MiddleCenter or ExportAlignment.MiddleRight => (screenHeight - bitmap.Height) / 2,
+            _ => screenHeight - bottomTopMargin - bitmap.Height,
+        };
+
+        var x = style.OverridePositionX || sourcePosition is null ? alignedX : sourcePosition.Value.X;
+        var y = style.OverridePositionY || sourcePosition is null ? alignedY : sourcePosition.Value.Y;
+        return new SKPointI(Math.Max(0, x), Math.Max(0, y));
+    }
+
     private static ImageParameter BuildPreservedParameter(
         BitmapSubtitleLoader.BitmapSubtitleItem item,
         int index,
@@ -140,6 +175,7 @@ internal static class ImageOutputWriter
         }
 
         var style = options.ImageStyle;
+        position = ApplyPositionOverride(position, item.Bitmap, screenWidth, screenHeight, style);
         return new ImageParameter
         {
             Index = index,

--- a/src/seconv/Core/SubtitleConverter.cs
+++ b/src/seconv/Core/SubtitleConverter.cs
@@ -1037,7 +1037,7 @@ internal class SubtitleConverter
         }
         else
         {
-            var fileName = Path.GetFileNameWithoutExtension(inputFile);
+            var fileName = Path.GetFileNameWithoutExtension(inputFile) + options.OutputFilenameAppend;
             var extension = LibSEIntegration.GetExtensionForFormat(options.Format);
             var outputFolder = string.IsNullOrEmpty(options.OutputFolder)
                 ? Path.GetDirectoryName(inputFile) ?? Directory.GetCurrentDirectory()
@@ -1067,7 +1067,7 @@ internal class SubtitleConverter
         // For container collisions, try inserting the track number first
         if (trackNumber.HasValue && !string.IsNullOrEmpty(languageSuffix))
         {
-            var fileName = Path.GetFileNameWithoutExtension(inputFile);
+            var fileName = Path.GetFileNameWithoutExtension(inputFile) + options.OutputFilenameAppend;
             var withTrack = Path.Combine(dir, $"{fileName}.#{trackNumber.Value}.{languageSuffix}{ext}");
             if ((options.Overwrite || !File.Exists(withTrack)) && usedNames?.Contains(withTrack) != true)
             {
@@ -1180,6 +1180,9 @@ internal record class ConversionOptions
     /// Resolved from defaults + the settings JSON's <c>exportImages</c> section + CLI flags.
     /// </summary>
     public ImageExportStyle ImageStyle { get; init; } = new();
+
+    /// <summary>Appended to the output file name stem (before any language/track suffix). Ignored with <see cref="OutputFilename"/>.</summary>
+    public string? OutputFilenameAppend { get; init; }
     public string? AssaStyleFile { get; init; }
     public int? PacCodePage { get; init; }
     public string? EbuHeaderFile { get; init; }

--- a/src/seconv/Helpers/HelpDisplay.cs
+++ b/src/seconv/Helpers/HelpDisplay.cs
@@ -50,6 +50,7 @@ internal static class HelpDisplay
         ShowParameter(console, "--input-folder:<folder name>", "Input folder path");
         ShowParameter(console, "--offset:hh:mm:ss:ms", "Time offset");
         ShowParameter(console, "--output-filename:<file name>", "Output file name (for single file only)");
+        ShowParameter(console, "--output-filename-append:<text>", "Text appended to the output file name stem, e.g. _fixed (ignored with --output-filename)");
         ShowParameter(console, "--output-folder:<folder name>", "Output folder path");
         ShowParameter(console, "--overwrite", "Overwrite existing files");
         ShowParameter(console, "--keep-timestamp", "Give output files the source file's modified/created date instead of the conversion time");
@@ -110,6 +111,7 @@ internal static class HelpDisplay
         ShowParameter(console, "--content-alignment:<mode>", "Multi-line text justification: left | center (default) | right | from-alignment");
         ShowParameter(console, "--bottom-top-margin:<px>", "Vertical screen-edge margin in pixels (default: 5% of height)");
         ShowParameter(console, "--left-right-margin:<px>", "Horizontal screen-edge margin in pixels (default: 5% of width)");
+        ShowParameter(console, "--override-position:<x|y|xy>", "Image → image: ignore the source bitmap position on that axis and place it by --alignment and margins");
         ShowParameter(console, "--full-frame", "Draw each subtitle on a frame-sized image (place at 0,0 in an editing timeline); only fcpimage and bluraysup");
         ShowParameter(console, "--full-frame-background-color:<colour>", "Background of the full frame image (default: transparent)");
 

--- a/tests/seconv/Core/OutputFileNameTest.cs
+++ b/tests/seconv/Core/OutputFileNameTest.cs
@@ -187,4 +187,38 @@ public class OutputFileNameTest : IDisposable
         Assert.Equal(Path.Combine(_tempRoot, "video.eng.vtt"), full);
         Assert.Equal(Path.Combine(_tempRoot, "video.eng.forced.vtt"), forced);
     }
+
+    [Fact]
+    public void Resolve_OutputFilenameAppend_IsAddedToStem()
+    {
+        var input = Path.Combine(_tempRoot, "movie.ts");
+        File.WriteAllText(input, "");
+        var opts = new ConversionOptions
+        {
+            Patterns = [input],
+            Format = "WebVTT",
+            OutputFolder = _tempRoot,
+            OutputFilenameAppend = "_fixed",
+        };
+
+        Assert.Equal(Path.Combine(_tempRoot, "movie_fixed.vtt"), SubtitleConverter.ResolveOutputFileName(input, opts));
+        Assert.Equal(Path.Combine(_tempRoot, "movie_fixed.eng.vtt"), SubtitleConverter.ResolveOutputFileName(input, opts, languageSuffix: "eng"));
+    }
+
+    [Fact]
+    public void Resolve_OutputFilenameAppend_IgnoredWithExplicitOutputFilename()
+    {
+        var input = Path.Combine(_tempRoot, "movie.ts");
+        File.WriteAllText(input, "");
+        var opts = new ConversionOptions
+        {
+            Patterns = [input],
+            Format = "WebVTT",
+            OutputFolder = _tempRoot,
+            OutputFilename = "out.vtt",
+            OutputFilenameAppend = "_fixed",
+        };
+
+        Assert.Equal(Path.Combine(_tempRoot, "out.vtt"), SubtitleConverter.ResolveOutputFileName(input, opts));
+    }
 }

--- a/tests/seconv/Core/PositionOverrideTest.cs
+++ b/tests/seconv/Core/PositionOverrideTest.cs
@@ -1,0 +1,84 @@
+using Nikse.SubtitleEdit.UiLogic.Export;
+using SeConv.Core;
+using SkiaSharp;
+using Xunit;
+
+namespace SeConvTests.Core;
+
+/// <summary>
+/// <c>--override-position</c>: SE4's transport-stream "override original X/Y position" for
+/// the image → image pass-through path.
+/// </summary>
+public class PositionOverrideTest
+{
+    private static readonly SKBitmap Bitmap = new(100, 40);
+
+    [Fact]
+    public void NoOverride_KeepsSourcePosition()
+    {
+        var style = new ImageExportStyle();
+        var result = ImageOutputWriter.ApplyPositionOverride(new SKPointI(10, 20), Bitmap, 1920, 1080, style);
+        Assert.Equal(new SKPointI(10, 20), result);
+    }
+
+    [Fact]
+    public void NoOverride_NoSourcePosition_StaysNull()
+    {
+        var style = new ImageExportStyle();
+        Assert.Null(ImageOutputWriter.ApplyPositionOverride(null, Bitmap, 1920, 1080, style));
+    }
+
+    [Fact]
+    public void OverrideX_CentersHorizontally_KeepsSourceY()
+    {
+        var style = new ImageExportStyle { OverridePositionX = true };
+        var result = ImageOutputWriter.ApplyPositionOverride(new SKPointI(10, 20), Bitmap, 1920, 1080, style);
+        Assert.Equal(new SKPointI((1920 - 100) / 2, 20), result);
+    }
+
+    [Fact]
+    public void OverrideY_UsesBottomMargin_KeepsSourceX()
+    {
+        var style = new ImageExportStyle { OverridePositionY = true, BottomTopMargin = 30 };
+        var result = ImageOutputWriter.ApplyPositionOverride(new SKPointI(10, 20), Bitmap, 1920, 1080, style);
+        Assert.Equal(new SKPointI(10, 1080 - 30 - 40), result);
+    }
+
+    [Fact]
+    public void OverrideBoth_LeftAlignment_UsesLeftMargin()
+    {
+        var style = new ImageExportStyle
+        {
+            OverridePositionX = true,
+            OverridePositionY = true,
+            Alignment = ExportAlignment.BottomLeft,
+            LeftRightMargin = 25,
+            BottomTopMargin = 30,
+        };
+        var result = ImageOutputWriter.ApplyPositionOverride(new SKPointI(500, 500), Bitmap, 1920, 1080, style);
+        Assert.Equal(new SKPointI(25, 1010), result);
+    }
+
+    [Fact]
+    public void OverrideBoth_RightAlignment_UsesRightMargin()
+    {
+        var style = new ImageExportStyle
+        {
+            OverridePositionX = true,
+            OverridePositionY = true,
+            Alignment = ExportAlignment.TopRight,
+            LeftRightMargin = 25,
+            BottomTopMargin = 30,
+        };
+        var result = ImageOutputWriter.ApplyPositionOverride(null, Bitmap, 1920, 1080, style);
+        Assert.Equal(new SKPointI(1920 - 25 - 100, 30), result);
+    }
+
+    [Fact]
+    public void DefaultMargins_AreFivePercentOfScreen()
+    {
+        var style = new ImageExportStyle { OverridePositionX = true, OverridePositionY = true, Alignment = ExportAlignment.TopLeft };
+        var result = ImageOutputWriter.ApplyPositionOverride(null, Bitmap, 1000, 800, style);
+        Assert.Equal(new SKPointI(50, 40), result);
+    }
+}


### PR DESCRIPTION
Closes the two seconv gaps versus SE4's transport-stream settings dialog (Batch convert → "Transport stream settings…").

- `--override-position:x|y|xy` — image → image pass-through (DVB-sub, PGS, VobSub): ignore the source bitmap position on that axis and place it by `--alignment` plus `--left-right-margin` / `--bottom-top-margin`. The other axis keeps the source position, like SE4's separate X/Y checkboxes. Unknown values are rejected.
- `--output-filename-append:<text>` — appended to the output stem before any language/track suffix (`movie.ts` → `movie_fixed.eng.srt`); ignored with `--output-filename`.

Verified on the `sample.sup` fixture: default run keeps `X="568" Y="81"`, `--override-position:xy --alignment:top-left --left-right-margin:7 --bottom-top-margin:9` gives `X="7" Y="9"`, and the output folder becomes `sample_fixed`. Help text, `--help-json` schema and `docs/reference/command-line.md` updated; seconv test suite passes (476 tests).

The remaining SE4 gap, the Batch convert GUI's transport-stream settings dialog, is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)