### PR TITLE
Tesseract OCR: add SE4's 10 px margin and resize retry passes

### DIFF
--- a/Dictionaries/eng_OCRFixReplaceList.xml
+++ b/Dictionaries/eng_OCRFixReplaceList.xml
@@ -3379,7 +3379,7 @@
 		<RegEx find="(^| |&quot;)(\|)([ \.,!?\r\n])" replaceWith="$1I$3" />
 		<RegEx find="\b(1|l) (know|will|almost|didn't|get|got|have|apologize|paid|like|think|would|hope|shall|chose|choose|won|am|was|don't|just|start|run|saw|said|believe|try|ever|need|certainly|can't|anticipated|did|can|rang|heard|gave|came|decided|should|took|wanted|read|thought|was|still|do|love|want|overstepped|accept|authorized|owe|understand|made|guess|bumped|wasn't|mean|admire|had|spent|told|see|walk|were|help|definitely|could|say|take|brought|assume|proposed|realized|loved|base|left|change|changed|rule|feel|date|dated|imagine|went|kind|couldn't|wouldn't|work|care|make|lost|deserve|promise|swear|bring|put|found|wanna|swear|sold|save|figured|knew|kill|asked|supposed|act|wonder|leave|remind|stay|assure|guarantee|open|invited|doubt|refuse|sign|hid|might|wish)\b" replaceWith="I $2" />
 		<RegEx find=",\.\." replaceWith="..." />
-		<RegEx find="(\p{L})\. \.\.(?=\r?$)" replaceWith="$1..." /> <!-- "Wait. .." → "Wait..." -->
+		<RegEx find="([\p{L}\d])\. \.\.(?=\r?$)" replaceWith="$1..." /> <!-- "Wait. .." → "Wait...", "3. .." → "3..." -->
 		<RegEx find="\bI KEA\b" replaceWith="IKEA" />
 		<RegEx find="\b(A|a)m (l|1)\b" replaceWith="$1m I" />
 		<RegEx find="\b1 00K\b" replaceWith="100K" />

--- a/Dictionaries/eng_OCRFixReplaceList.xml
+++ b/Dictionaries/eng_OCRFixReplaceList.xml
@@ -3379,7 +3379,7 @@
 		<RegEx find="(^| |&quot;)(\|)([ \.,!?\r\n])" replaceWith="$1I$3" />
 		<RegEx find="\b(1|l) (know|will|almost|didn't|get|got|have|apologize|paid|like|think|would|hope|shall|chose|choose|won|am|was|don't|just|start|run|saw|said|believe|try|ever|need|certainly|can't|anticipated|did|can|rang|heard|gave|came|decided|should|took|wanted|read|thought|was|still|do|love|want|overstepped|accept|authorized|owe|understand|made|guess|bumped|wasn't|mean|admire|had|spent|told|see|walk|were|help|definitely|could|say|take|brought|assume|proposed|realized|loved|base|left|change|changed|rule|feel|date|dated|imagine|went|kind|couldn't|wouldn't|work|care|make|lost|deserve|promise|swear|bring|put|found|wanna|swear|sold|save|figured|knew|kill|asked|supposed|act|wonder|leave|remind|stay|assure|guarantee|open|invited|doubt|refuse|sign|hid|might|wish)\b" replaceWith="I $2" />
 		<RegEx find=",\.\." replaceWith="..." />
-		<RegEx find="([\p{L}\d])\. \.\.(?=\r?$)" replaceWith="$1..." /> <!-- "Wait. .." → "Wait...", "3. .." → "3..." -->
+		<RegEx find="([\p{L}\d])(?:\. \.\.|\.\. \.)(?=\r?$)" replaceWith="$1..." /> <!-- "Wait. .." / "Wait.. ." → "Wait...", "3. .." → "3..." -->
 		<RegEx find="\bI KEA\b" replaceWith="IKEA" />
 		<RegEx find="\b(A|a)m (l|1)\b" replaceWith="$1m I" />
 		<RegEx find="\b1 00K\b" replaceWith="100K" />

--- a/Dictionaries/eng_OCRFixReplaceList.xml
+++ b/Dictionaries/eng_OCRFixReplaceList.xml
@@ -3379,6 +3379,7 @@
 		<RegEx find="(^| |&quot;)(\|)([ \.,!?\r\n])" replaceWith="$1I$3" />
 		<RegEx find="\b(1|l) (know|will|almost|didn't|get|got|have|apologize|paid|like|think|would|hope|shall|chose|choose|won|am|was|don't|just|start|run|saw|said|believe|try|ever|need|certainly|can't|anticipated|did|can|rang|heard|gave|came|decided|should|took|wanted|read|thought|was|still|do|love|want|overstepped|accept|authorized|owe|understand|made|guess|bumped|wasn't|mean|admire|had|spent|told|see|walk|were|help|definitely|could|say|take|brought|assume|proposed|realized|loved|base|left|change|changed|rule|feel|date|dated|imagine|went|kind|couldn't|wouldn't|work|care|make|lost|deserve|promise|swear|bring|put|found|wanna|swear|sold|save|figured|knew|kill|asked|supposed|act|wonder|leave|remind|stay|assure|guarantee|open|invited|doubt|refuse|sign|hid|might|wish)\b" replaceWith="I $2" />
 		<RegEx find=",\.\." replaceWith="..." />
+		<RegEx find="(\p{L})\. \.\.(?=\r?$)" replaceWith="$1..." /> <!-- "Wait. .." → "Wait..." -->
 		<RegEx find="\bI KEA\b" replaceWith="IKEA" />
 		<RegEx find="\b(A|a)m (l|1)\b" replaceWith="$1m I" />
 		<RegEx find="\b1 00K\b" replaceWith="100K" />

--- a/src/ui/Features/Ocr/Engines/TesseractOcr.cs
+++ b/src/ui/Features/Ocr/Engines/TesseractOcr.cs
@@ -56,18 +56,73 @@ public class TesseractOcr
         return "tesseract";
     }
 
-    public async Task<string> Ocr(SKBitmap bitmap, string language, string tessDataFolder, CancellationToken cancellationToken, int engineMode = 3)
+    /// <summary>
+    /// Margin of white added around the text before it is handed to Tesseract. SE4 added the same
+    /// 10 px (VobSubOcr.GetSubtitleBitmap → AddMargin(10)); without it glyphs touch the image edge
+    /// and Tesseract misreads them (discussion #12929: "In"/"Is" for "in"/"is", "\What", "(o").
+    /// </summary>
+    public const int Margin = 10;
+
+    /// <summary>Page segmentation mode for the normal pass: a single uniform block of text.</summary>
+    public const int PsmSingleBlock = 6;
+
+    /// <summary>Page segmentation mode for the resized retry: let Tesseract find the layout.</summary>
+    public const int PsmAuto = 3;
+
+    /// <summary>Page segmentation mode for the last-resort retry: a single text line.</summary>
+    public const int PsmSingleLine = 7;
+
+    /// <summary>
+    /// Builds the image Tesseract is fed: a white margin around the subtitle, binarized to black
+    /// text on white, and optionally stretched (SE4 retried unknown words with 3x width / 2x
+    /// height, and blank results with 4x / 2x). Keys on brightness so coloured text (e.g. yellow)
+    /// is kept rather than blanked the way the blue-only MakeOneColor did.
+    /// </summary>
+    internal static SKBitmap PrepareImage(SKBitmap bitmap, int scaleX = 1, int scaleY = 1)
+    {
+        var nbmp = new NikseBitmap(bitmap);
+        nbmp.AddMargin(Margin);
+        nbmp.MakeBlackAndWhiteForOcr();
+        var prepared = nbmp.GetBitmap();
+        if (scaleX <= 1 && scaleY <= 1)
+        {
+            return prepared;
+        }
+
+        using (prepared)
+        {
+            var info = new SKImageInfo(prepared.Width * scaleX, prepared.Height * scaleY, prepared.ColorType, prepared.AlphaType);
+            return prepared.Resize(info, new SKSamplingOptions(SKCubicResampler.Mitchell)) ?? prepared.Copy();
+        }
+    }
+
+    /// <summary>
+    /// A retry pass is only taken when it does not invent a digit the first pass did not see:
+    /// the stretched image tends to read a stray outline pixel as "7" ("18 months" → "718 months").
+    /// Same guard as SE4 used when choosing between Tesseract passes.
+    /// </summary>
+    internal static bool RetryIntroducesDigit(string firstPass, string retry)
+    {
+        foreach (var c in retry)
+        {
+            if (char.IsDigit(c) && !firstPass.Contains(c))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public async Task<string> Ocr(SKBitmap bitmap, string language, string tessDataFolder, CancellationToken cancellationToken, int engineMode = 3, int psm = PsmSingleBlock, int scaleX = 1, int scaleY = 1)
     {
         if (string.IsNullOrEmpty(_executablePath))
         {
             _executablePath = GetExecutablePath();
         }
 
-        // Preprocess image: binarize to black text on white. Keys on brightness so coloured text
-        // (e.g. yellow) is kept rather than blanked the way the blue-only MakeOneColor did.
-        var nbmp = new NikseBitmap(bitmap);
-        nbmp.MakeBlackAndWhiteForOcr();
-        using var oneColorBitmap = nbmp.GetBitmap();
+        Error = string.Empty;
+        using var oneColorBitmap = PrepareImage(bitmap, scaleX, scaleY);
 
         var tempImage = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.png");
         var tempTextFileName = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
@@ -77,8 +132,8 @@ public class TesseractOcr
         // a copy of the exact image, so blank output can be diagnosed without guessing.
         if (Se.Settings.Tools.WriteToolsLog)
         {
-            var inkPercent = GetInkPercent(nbmp);
-            Se.WriteToolsLog($"Tesseract OCR: input {oneColorBitmap.Width}x{oneColorBitmap.Height}, ink={inkPercent:0.0}% (0% = preprocessing blanked the text), lang={language}, oem={engineMode}");
+            var inkPercent = GetInkPercent(new NikseBitmap(oneColorBitmap));
+            Se.WriteToolsLog($"Tesseract OCR: input {oneColorBitmap.Width}x{oneColorBitmap.Height}, ink={inkPercent:0.0}% (0% = preprocessing blanked the text), lang={language}, oem={engineMode}, psm={psm}");
             try
             {
                 var logDir = Path.GetDirectoryName(Se.GetToolsLogFilePath()) ?? Path.GetTempPath();
@@ -113,7 +168,7 @@ public class TesseractOcr
             psi.ArgumentList.Add("-l");
             psi.ArgumentList.Add(language);
             psi.ArgumentList.Add("--psm");
-            psi.ArgumentList.Add("6");
+            psi.ArgumentList.Add(psm.ToString(System.Globalization.CultureInfo.InvariantCulture));
             psi.ArgumentList.Add("--oem");
             psi.ArgumentList.Add(engineMode.ToString(System.Globalization.CultureInfo.InvariantCulture));
             psi.ArgumentList.Add("-c");

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -4139,6 +4139,8 @@ public partial class OcrViewModel : ObservableObject
                         return;
                     }
 
+                    text = await RetryTesseractIfNeededAsync(tesseractOcr, bitmap, i, text, language, tessDataFolder, engineMode, cancellationToken);
+
                     processedCount++;
                     if (!string.IsNullOrWhiteSpace(text))
                     {
@@ -4185,6 +4187,85 @@ public partial class OcrViewModel : ObservableObject
                 PauseOcr();
             }
         });
+    }
+
+    /// <summary>
+    /// SE4's Tesseract retry (VobSubOcr.TesseractResizeAndRetry): when the first pass is blank or
+    /// leaves unknown words, run again on the image stretched 3x/2x with automatic layout, and if
+    /// that is still blank on 4x/2x as a single line. The retry is kept only when the dictionary
+    /// rates it better and it does not invent a digit (discussion #12929: "Yeanh" → "Yeah",
+    /// "houir" → "hour", a blank "I..." line recovered; "18 months" must not become "718 months").
+    /// </summary>
+    private async Task<string> RetryTesseractIfNeededAsync(TesseractOcr tesseractOcr, SKBitmap bitmap, int index, string text, string language, string tessDataFolder, int engineMode, CancellationToken cancellationToken)
+    {
+        var blank = string.IsNullOrWhiteSpace(text);
+        var score = blank ? null : CountTesseractWords(index, text);
+        if (!blank && (score == null || (score.Value.unknown == 0 && score.Value.correct > 0)))
+        {
+            return text;
+        }
+
+        var retry = await tesseractOcr.Ocr(bitmap, language, tessDataFolder, cancellationToken, engineMode, TesseractOcr.PsmAuto, 3, 2);
+        if (string.IsNullOrWhiteSpace(retry))
+        {
+            retry = await tesseractOcr.Ocr(bitmap, language, tessDataFolder, cancellationToken, engineMode, TesseractOcr.PsmSingleLine, 4, 2);
+        }
+
+        if (string.IsNullOrWhiteSpace(retry))
+        {
+            return text;
+        }
+
+        if (blank)
+        {
+            return retry;
+        }
+
+        var retryScore = CountTesseractWords(index, retry);
+        if (retryScore != null &&
+            retryScore.Value.unknown < score!.Value.unknown &&
+            retryScore.Value.correct >= score.Value.correct &&
+            !TesseractOcr.RetryIntroducesDigit(text, retry))
+        {
+            return retry;
+        }
+
+        return text;
+    }
+
+    /// <summary>
+    /// Dictionary verdict on one OCR pass: how many words the fix engine still flags as unknown
+    /// and how many it accepts. Null when no dictionary is in use, in which case nothing can be
+    /// compared and the first pass stands.
+    /// </summary>
+    private (int unknown, int correct)? CountTesseractWords(int index, string text)
+    {
+        if (SelectedDictionary == null || SelectedDictionary.Name == GetDictionaryNameNone() || !_ocrFixEngine.IsLoaded() || !DoFixOcrErrors)
+        {
+            return null;
+        }
+
+        var result = _ocrFixEngine.FixOcrErrors(index, text, DoTryToGuessUnknownWords);
+        var unknown = 0;
+        var correct = 0;
+        foreach (var word in result.Words)
+        {
+            if (word.LinePartType != OcrFixLinePartType.Word)
+            {
+                continue;
+            }
+
+            if (word.IsSpellCheckedOk == false)
+            {
+                unknown++;
+            }
+            else if (word.IsSpellCheckedOk == true)
+            {
+                correct++;
+            }
+        }
+
+        return (unknown, correct);
     }
 
     private async Task ShowTesseractErrorAsync(string error)

--- a/tests/UI/Features/Ocr/Engines/TesseractOcrPrepareImageTests.cs
+++ b/tests/UI/Features/Ocr/Engines/TesseractOcrPrepareImageTests.cs
@@ -1,0 +1,57 @@
+using Nikse.SubtitleEdit.Features.Ocr;
+using SkiaSharp;
+
+namespace UITests.Features.Ocr.Engines;
+
+/// <summary>
+/// Discussion #12929: SE5 fed Tesseract the binarized subtitle with the glyphs touching the image
+/// edge and misread "in" as "In", "to" as "(o", "What" as "\What". SE4 padded the image by 10 px
+/// first; the retry passes stretch it and must not invent digits.
+/// </summary>
+public class TesseractOcrPrepareImageTests
+{
+    private static SKBitmap MakeSubtitle(int width, int height)
+    {
+        // Grey text pixel (Blu-ray subtitles are often Y=140 grey) in the top-left corner, rest transparent.
+        var bmp = new SKBitmap(width, height, SKColorType.Rgba8888, SKAlphaType.Unpremul);
+        bmp.Erase(SKColors.Transparent);
+        bmp.SetPixel(0, 0, new SKColor(144, 144, 144, 255));
+        return bmp;
+    }
+
+    [Fact]
+    public void PrepareImage_AddsWhiteMarginAroundBlackText()
+    {
+        using var bmp = MakeSubtitle(20, 10);
+
+        using var prepared = TesseractOcr.PrepareImage(bmp);
+
+        Assert.Equal(20 + 2 * TesseractOcr.Margin, prepared.Width);
+        Assert.Equal(10 + 2 * TesseractOcr.Margin, prepared.Height);
+        Assert.Equal(SKColors.White, prepared.GetPixel(0, 0));
+        Assert.Equal(SKColors.White, prepared.GetPixel(prepared.Width - 1, prepared.Height - 1));
+        Assert.Equal(SKColors.Black, prepared.GetPixel(TesseractOcr.Margin, TesseractOcr.Margin));
+    }
+
+    [Fact]
+    public void PrepareImage_StretchesAfterPadding()
+    {
+        using var bmp = MakeSubtitle(20, 10);
+
+        using var prepared = TesseractOcr.PrepareImage(bmp, 3, 2);
+
+        Assert.Equal((20 + 2 * TesseractOcr.Margin) * 3, prepared.Width);
+        Assert.Equal((10 + 2 * TesseractOcr.Margin) * 2, prepared.Height);
+        Assert.Equal(SKColors.White, prepared.GetPixel(0, 0));
+    }
+
+    [Theory]
+    [InlineData("In the 18 months", "In the 718 months", true)]
+    [InlineData("-700 miles an houir.", "-700 miles an hour.", false)]
+    [InlineData("Onh, great.", "Oh, great.", false)]
+    [InlineData("", "I...", false)]
+    public void RetryIntroducesDigit(string firstPass, string retry, bool expected)
+    {
+        Assert.Equal(expected, TesseractOcr.RetryIntroducesDigit(firstPass, retry));
+    }
+}

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixDotSpaceDotsTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixDotSpaceDotsTests.cs
@@ -8,7 +8,7 @@ using System.IO;
 namespace UITests.Features.Ocr.FixEngine;
 
 // Discussion #12929: Tesseract reads a trailing ellipsis as ". .." ("Wait. ..", "What the. ..").
-// The English replace list turns letter + ". .." at the end of a line back into letter + "...".
+// The English replace list turns a letter or digit + ". .." at the end of a line back into "...".
 public class OcrFixDotSpaceDotsTests : IDisposable
 {
     private readonly Func<string> _originalSpellCheckDictionariesFolder;
@@ -25,7 +25,7 @@ public class OcrFixDotSpaceDotsTests : IDisposable
         File.WriteAllText(
             Path.Combine(_tempDictionariesFolder, "eng_OCRFixReplaceList.xml"),
             "<ReplaceList><RegularExpressions>" +
-            "<RegEx find=\"(\\p{L})\\. \\.\\.(?=\\r?$)\" replaceWith=\"$1...\" />" +
+            "<RegEx find=\"([\\p{L}\\d])\\. \\.\\.(?=\\r?$)\" replaceWith=\"$1...\" />" +
             "</RegularExpressions></ReplaceList>");
     }
 
@@ -35,7 +35,8 @@ public class OcrFixDotSpaceDotsTests : IDisposable
     [InlineData("-Kick-Ass. ..\r\n-Get him out of here.", "-Kick-Ass...\r\n-Get him out of here.")]
     [InlineData("-Kick-Ass. ..\n-Get him out of here.", "-Kick-Ass...\n-Get him out of here.")]
     [InlineData("Wait. .. what?", "Wait. .. what?")] // not at the end of the line - left alone
-    [InlineData("3. ..", "3. ..")] // digit, not a letter - left alone
+    [InlineData("3. ..", "3...")]
+    [InlineData("?. ..", "?. ..")] // punctuation before it - left alone
     public void FixOcrErrors_LetterDotSpaceDots_BecomesEllipsis(string input, string expected)
     {
         IOcrFixEngine engine = new OcrFixEngine(new AcceptAllSpellChecker());

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixDotSpaceDotsTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixDotSpaceDotsTests.cs
@@ -8,7 +8,7 @@ using System.IO;
 namespace UITests.Features.Ocr.FixEngine;
 
 // Discussion #12929: Tesseract reads a trailing ellipsis as ". .." ("Wait. ..", "What the. ..").
-// The English replace list turns a letter or digit + ". .." at the end of a line back into "...".
+// The English replace list turns a letter or digit + ". .." or ".. ." at the end of a line back into "...".
 public class OcrFixDotSpaceDotsTests : IDisposable
 {
     private readonly Func<string> _originalSpellCheckDictionariesFolder;
@@ -25,7 +25,7 @@ public class OcrFixDotSpaceDotsTests : IDisposable
         File.WriteAllText(
             Path.Combine(_tempDictionariesFolder, "eng_OCRFixReplaceList.xml"),
             "<ReplaceList><RegularExpressions>" +
-            "<RegEx find=\"([\\p{L}\\d])\\. \\.\\.(?=\\r?$)\" replaceWith=\"$1...\" />" +
+            "<RegEx find=\"([\\p{L}\\d])(?:\\. \\.\\.|\\.\\. \\.)(?=\\r?$)\" replaceWith=\"$1...\" />" +
             "</RegularExpressions></ReplaceList>");
     }
 
@@ -36,6 +36,9 @@ public class OcrFixDotSpaceDotsTests : IDisposable
     [InlineData("-Kick-Ass. ..\n-Get him out of here.", "-Kick-Ass...\n-Get him out of here.")]
     [InlineData("Wait. .. what?", "Wait. .. what?")] // not at the end of the line - left alone
     [InlineData("3. ..", "3...")]
+    [InlineData("3.. .", "3...")]
+    [InlineData("Wait.. .", "Wait...")]
+    [InlineData("Wait.. . what?", "Wait.. . what?")] // not at the end of the line - left alone
     [InlineData("?. ..", "?. ..")] // punctuation before it - left alone
     public void FixOcrErrors_LetterDotSpaceDots_BecomesEllipsis(string input, string expected)
     {

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixDotSpaceDotsTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixDotSpaceDotsTests.cs
@@ -1,0 +1,62 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace UITests.Features.Ocr.FixEngine;
+
+// Discussion #12929: Tesseract reads a trailing ellipsis as ". .." ("Wait. ..", "What the. ..").
+// The English replace list turns letter + ". .." at the end of a line back into letter + "...".
+public class OcrFixDotSpaceDotsTests : IDisposable
+{
+    private readonly Func<string> _originalSpellCheckDictionariesFolder;
+    private readonly string _tempDictionariesFolder;
+
+    public OcrFixDotSpaceDotsTests()
+    {
+        _originalSpellCheckDictionariesFolder = SpellCheckConfig.DictionariesFolder;
+        _tempDictionariesFolder = Path.Combine(Path.GetTempPath(), "SeOcrFixDotSpaceDotsTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDictionariesFolder);
+        SpellCheckConfig.DictionariesFolder = () => _tempDictionariesFolder;
+
+        // The rule as shipped in eng_OCRFixReplaceList.xml.
+        File.WriteAllText(
+            Path.Combine(_tempDictionariesFolder, "eng_OCRFixReplaceList.xml"),
+            "<ReplaceList><RegularExpressions>" +
+            "<RegEx find=\"(\\p{L})\\. \\.\\.(?=\\r?$)\" replaceWith=\"$1...\" />" +
+            "</RegularExpressions></ReplaceList>");
+    }
+
+    [Theory]
+    [InlineData("Wait. ..", "Wait...")]
+    [InlineData("What the. ..", "What the...")]
+    [InlineData("-Kick-Ass. ..\r\n-Get him out of here.", "-Kick-Ass...\r\n-Get him out of here.")]
+    [InlineData("-Kick-Ass. ..\n-Get him out of here.", "-Kick-Ass...\n-Get him out of here.")]
+    [InlineData("Wait. .. what?", "Wait. .. what?")] // not at the end of the line - left alone
+    [InlineData("3. ..", "3. ..")] // digit, not a letter - left alone
+    public void FixOcrErrors_LetterDotSpaceDots_BecomesEllipsis(string input, string expected)
+    {
+        IOcrFixEngine engine = new OcrFixEngine(new AcceptAllSpellChecker());
+        engine.Initialize(new Subtitle(), "eng", new SpellCheckDictionaryDisplay());
+
+        var result = engine.FixOcrErrors(0, input, doTryToGuessUnknownWords: false);
+
+        // The engine re-joins lines with the platform newline, so compare newline-agnostically.
+        Assert.Equal(expected.Replace("\r\n", "\n"), result.GetText().Replace("\r\n", "\n"));
+    }
+
+    private sealed class AcceptAllSpellChecker : ISpellChecker
+    {
+        public bool Initialize(string dictionaryFile, string twoLetterLanguageCode) => true;
+        public bool IsWordCorrect(string word) => true;
+        public List<string> GetSuggestions(string word) => new();
+    }
+
+    public void Dispose()
+    {
+        SpellCheckConfig.DictionariesFolder = _originalSpellCheckDictionariesFolder;
+        try { Directory.Delete(_tempDictionariesFolder, true); } catch { /* best effort */ }
+    }
+}


### PR DESCRIPTION
Follow-up to the Tesseract comparison in discussion #12929 (andor1999's Kick-Ass .sup: SE 5.2.0-rc2 had 55 more errors than SE 4.0.16 with the same Tesseract and eng model).

## Cause

SE4 padded the binarized subtitle by 10 px (`AddMargin(10)`) before handing it to Tesseract. SE5 fed the image with the glyphs touching the edge, and Tesseract then misreads edge glyphs: mid-sentence `In`/`Is`/`It`, `\What`, `(o`, `10 see`, `habital`, `Kalle`. SE4 also retried blank lines and lines with unknown words on a stretched image, which SE5 did not.

## Verification

All 1320 frames dumped through libse, Tesseract run headlessly with the tessdata-master eng model SE downloads, raw text pushed through the SE5 OCR fix engine with the repo's en_US dictionary and replace list, then compared line by line with the user's files:

| Pipeline | Lines identical to the SE4 file | Lines identical to the SE5 rc2 file |
|---|---|---|
| SE5 as shipped | 1235 | 1286 |
| + 10 px margin | 1293 | 1260 |
| + margin + resize retry | 1299 | 1265 |

The retry recovers `Yeanh`→`Yeah`, `houir`→`hour`, `Onh`→`Oh`, `fo`→`to`, `Hil`→`Hi!` and the blank `I...` line. Its one regression, `18 months`→`718 months`, is blocked by the digit guard.

## Changes

- `TesseractOcr.PrepareImage`: margin, binarize, optional stretch. `Ocr()` gains `psm`/`scaleX`/`scaleY`. `Error` is cleared per call (a stale failure could otherwise be reported for a later blank line).
- `OcrViewModel.RetryTesseractIfNeededAsync`: SE4's `TesseractResizeAndRetry` (3x/2x auto layout, then 4x/2x single line), kept only when the dictionary rates it better and it introduces no new digit.
- `eng_OCRFixReplaceList.xml`: letter + `. ..` at end of line becomes `...` (`Wait. ..`, `What the. ..`).
- Tests for the image preparation, the digit guard and the new replace-list rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)