### PR TITLE
OCR fix engine: keep "didn’t" as one word

### DIFF
--- a/src/libuilogic/Ocr/FixEngine/OcrFixEngine.cs
+++ b/src/libuilogic/Ocr/FixEngine/OcrFixEngine.cs
@@ -189,8 +189,10 @@ public partial class OcrFixEngine : IOcrFixEngine, IDoSpell
             if (char.IsLetterOrDigit(line[i]) && line[i] != '"')
             {
                 var wordStart = i;
+                // U+2019 is the apostrophe Tesseract emits for "didn’t"; without it the word split
+                // into "didn" + "’" + "t" and "didn" was flagged as unknown.
                 while (i < line.Length &&
-                       (char.IsLetterOrDigit(line[i]) || line[i] == '\'' || line[i] == '-'))
+                       (char.IsLetterOrDigit(line[i]) || line[i] == '\'' || line[i] == '’' || line[i] == '-'))
                 {
                     i++;
                 }

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixEngineSplitLineTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixEngineSplitLineTests.cs
@@ -25,6 +25,21 @@ public class OcrFixEngineSplitLineTests
         Assert.DoesNotContain(result.Words, w => w.Word.Length == 0);
     }
 
+    // Tesseract emits the typographic apostrophe (U+2019) in "didn’t"; the splitter must keep the
+    // contraction as one word, or "didn" gets spell-checked on its own and flagged as unknown.
+    [Theory]
+    [InlineData("it didn’t take much", "didn’t")]
+    [InlineData("it didn't take much", "didn't")]
+    [InlineData("someone’s son", "someone’s")]
+    public void SplitLine_Apostrophe_KeepsContractionAsOneWord(string line, string expectedWord)
+    {
+        var result = OcrFixEngine.SplitLine(line, 0);
+
+        var words = result.Words.Where(w => w.LinePartType == OcrFixLinePartType.Word).Select(w => w.Word).ToList();
+        Assert.Contains(expectedWord, words);
+        Assert.Equal(line, string.Concat(result.Words.Select(w => w.Word)));
+    }
+
     [Fact]
     public void SplitLine_ValidTag_IsParsedAsTag()
     {


### PR DESCRIPTION
Follow-up to #14641 (discussion #12929). Tesseract writes contractions with the typographic apostrophe (U+2019). The OCR line splitter only knew the straight apostrophe, so "didn’t" was split into "didn" + "’" + "t" and "didn" was reported as an unknown word.

- `OcrFixEngine.SplitLine`: U+2019 is a word character, like `'` and `-`.
- Side effect: the word-level fix already maps ’ to ', so "didn’t" and "someone’s" now come out as "didn't" and "someone's" instead of keeping the curly apostrophe.
- Test for the splitter; the OCR fix test suite (137 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)