### PR TITLE
OCR fix engine: capitalize a line that follows a finished sentence

### DIFF
--- a/src/libuilogic/Ocr/FixEngine/OcrFixEngine.cs
+++ b/src/libuilogic/Ocr/FixEngine/OcrFixEngine.cs
@@ -31,6 +31,7 @@ public partial class OcrFixEngine : IOcrFixEngine, IDoSpell
     private Subtitle _subtitle;
     private HashSet<string> _wordSkipList = new HashSet<string>();
     private Dictionary<string, string> _changeAllDictionary;
+    private HashSet<string> _abbreviations = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
     private readonly ISpellChecker _spellCheckManager;
 
@@ -68,6 +69,7 @@ public partial class OcrFixEngine : IOcrFixEngine, IDoSpell
         var names = ReloadNames();
         _wordSplitList = StringWithoutSpaceSplitToWords.LoadWordSplitList(SpellCheckConfig.DictionariesFolder(), _threeLetterIsoLanguageName, names);
         _ocrFixReplaceList = OcrFixReplaceList2.FromLanguageId(_threeLetterIsoLanguageName);
+        _abbreviations = AbbreviationList.Load(SpellCheckConfig.DictionariesFolder(), _fiveLetterName);
     }
 
     public OcrFixLineResult FixOcrErrors(int index, string text, bool doTryToGuessUnknownWords)
@@ -75,6 +77,7 @@ public partial class OcrFixEngine : IOcrFixEngine, IDoSpell
         var wordsToIgnore = new List<string>();
 
         var replacedLine = ReplaceLineFixes(index, text, wordsToIgnore);
+        replacedLine = FixStartWithUppercaseLetterAfterSentenceEnd(index, replacedLine);
         var splitLine = SplitLine(replacedLine, index);
         if (replacedLine != text)
         {
@@ -101,6 +104,101 @@ public partial class OcrFixEngine : IOcrFixEngine, IDoSpell
         }
 
         return splitLine;
+    }
+
+    /// <summary>
+    /// A line that follows a finished sentence starts with an uppercase letter (SE4 parity: OCR
+    /// often drops the case of the first glyph, "you're out of luck." after "Yes.", and Tesseract
+    /// reads a leading "I" as "l"). Only high-confidence cases are touched:
+    /// - the previous line ends directly in . ! or ? - a trailing quote ("...Mother!" you're...)
+    ///   can be a quotation inside a running sentence, so it does not count; neither do "..." or
+    ///   an abbreviation ("Mr.");
+    /// - the previous line is text OCR actually produced, so the first line and a run started
+    ///   from the middle are left alone;
+    /// - the capitalized first word is one the dictionary knows.
+    /// </summary>
+    internal string FixStartWithUppercaseLetterAfterSentenceEnd(int index, string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return text;
+        }
+
+        var previous = index > 0 ? _subtitle.GetParagraphOrDefault(index - 1) : null;
+        if (previous == null || !IsConfidentSentenceEnd(previous.Text))
+        {
+            return text; // no previous line (or not OCR'd yet) = no evidence a sentence ended
+        }
+
+        var st = new StrippableText(text);
+        if (st.StrippedText.Length == 0 || !char.IsLower(st.StrippedText[0]) ||
+            st.Pre.EndsWith('[') || st.Pre.EndsWith('(') || st.Pre.EndsWith('\'') ||
+            st.Pre.Contains("...", StringComparison.Ordinal) || st.Pre.Contains('…') ||
+            HtmlUtil.StartsWithUrl(st.StrippedText))
+        {
+            return text;
+        }
+
+        var firstWord = GetFirstWord(st.StrippedText);
+        var uppercaseLetter = char.ToUpperInvariant(firstWord[0]);
+        if (uppercaseLetter == 'L' && (firstWord == "l" || firstWord.StartsWith("l'", StringComparison.Ordinal)))
+        {
+            uppercaseLetter = 'I'; // "l said" / "l'm" are a misread "I said" / "I'm"
+        }
+
+        var fixedFirstWord = uppercaseLetter + firstWord.Substring(1);
+        if (!_spellCheckManager.IsWordCorrect(fixedFirstWord) && !_spellCheckWordLists.HasName(fixedFirstWord))
+        {
+            return text;
+        }
+
+        st.StrippedText = fixedFirstWord + st.StrippedText.Substring(firstWord.Length);
+        return st.Pre + st.StrippedText + st.Post;
+    }
+
+    private bool IsConfidentSentenceEnd(string previousText)
+    {
+        if (string.IsNullOrWhiteSpace(previousText))
+        {
+            return false;
+        }
+
+        var lastLine = HtmlUtil.RemoveHtmlTags(previousText, true).Trim('♪', '♫', ' ');
+        if (lastLine.Length < 2 || lastLine.EndsWith("...", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var last = lastLine[lastLine.Length - 1];
+        if (last != '.' && last != '!' && last != '?')
+        {
+            return false;
+        }
+
+        return last != '.' || !EndsWithAbbreviation(lastLine);
+    }
+
+    private static string GetFirstWord(string text)
+    {
+        var i = 0;
+        while (i < text.Length && (char.IsLetter(text[i]) || text[i] == '\'' || text[i] == '’'))
+        {
+            i++;
+        }
+
+        return i == 0 ? text.Substring(0, 1) : text.Substring(0, i);
+    }
+
+    private bool EndsWithAbbreviation(string lastLine)
+    {
+        if (_abbreviations.Count == 0)
+        {
+            return false;
+        }
+
+        var lastSpace = lastLine.LastIndexOf(' ');
+        var lastWord = lastSpace < 0 ? lastLine : lastLine.Substring(lastSpace + 1);
+        return _abbreviations.Contains(lastWord);
     }
 
     private string ReplaceLineFixes(int index, string text, List<string> wordsToIgnore)

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixUppercaseAfterSentenceEndTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixUppercaseAfterSentenceEndTests.cs
@@ -1,0 +1,88 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace UITests.Features.Ocr.FixEngine;
+
+// Discussion #12929: OCR dropped the capital of a line that follows a finished sentence
+// ("you're out of luck." after "Yes."). Only high-confidence cases are capitalized: the previous
+// line ends directly in . ! or ? (no trailing quote, no "...", no abbreviation), the previous line
+// has been OCR'd, and the capitalized first word is a dictionary word.
+public class OcrFixUppercaseAfterSentenceEndTests : IDisposable
+{
+    private readonly Func<string> _originalSpellCheckDictionariesFolder;
+    private readonly string _tempDictionariesFolder;
+
+    public OcrFixUppercaseAfterSentenceEndTests()
+    {
+        _originalSpellCheckDictionariesFolder = SpellCheckConfig.DictionariesFolder;
+        _tempDictionariesFolder = Path.Combine(Path.GetTempPath(), "SeOcrFixUppercaseAfterSentenceEnd_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDictionariesFolder);
+        SpellCheckConfig.DictionariesFolder = () => _tempDictionariesFolder;
+        File.WriteAllText(Path.Combine(_tempDictionariesFolder, "eng_OCRFixReplaceList.xml"), "<ReplaceList></ReplaceList>");
+        File.WriteAllText(Path.Combine(_tempDictionariesFolder, "en_abbreviations.xml"), "<Abbreviations><Item>Mr.</Item></Abbreviations>");
+    }
+
+    [Theory]
+    [InlineData("Yes.", "you're out of luck.", "You're out of luck.")]
+    [InlineData("Really?", "you're out of luck.", "You're out of luck.")]
+    [InlineData("Go!", "<i>you're out of luck.</i>", "<i>You're out of luck.</i>")]
+    [InlineData("Go!", "- you're out of luck.", "- You're out of luck.")]
+    [InlineData("Yes.", "l said no.", "I said no.")]
+    [InlineData("Yes.", "l'm here.", "I'm here.")]
+    [InlineData("\"I will avenge you, Mother!\"", "you're out of luck.", "you're out of luck.")] // quote: may be one sentence
+    [InlineData("So if you were hoping for any,", "you're out of luck.", "you're out of luck.")]
+    [InlineData("Wait...", "you're out of luck.", "you're out of luck.")]
+    [InlineData("I met Mr.", "you're out of luck.", "you're out of luck.")]
+    [InlineData("", "you're out of luck.", "you're out of luck.")] // previous line not OCR'd yet
+    [InlineData("Yes.", "lo0k out.", "lo0k out.")] // not a dictionary word once capitalized
+    [InlineData("Yes.", "[music]", "[music]")]
+    [InlineData("Yes.", "...you're out of luck.", "...you're out of luck.")]
+    public void FixOcrErrors_AfterSentenceEnd(string previousLine, string line, string expected)
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph(previousLine, 0, 1000));
+        subtitle.Paragraphs.Add(new Paragraph(string.Empty, 1000, 2000));
+        IOcrFixEngine engine = new OcrFixEngine(new FakeEnglishSpellChecker());
+        engine.Initialize(subtitle, "eng", new SpellCheckDictionaryDisplay { DictionaryFileName = "en_US" });
+
+        var result = engine.FixOcrErrors(1, line, doTryToGuessUnknownWords: false);
+
+        Assert.Equal(expected, result.GetText());
+    }
+
+    [Fact]
+    public void FixOcrErrors_FirstLine_IsLeftAlone()
+    {
+        // No previous line means no evidence that a sentence ended - an OCR run may start anywhere.
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph(string.Empty, 0, 1000));
+        IOcrFixEngine engine = new OcrFixEngine(new FakeEnglishSpellChecker());
+        engine.Initialize(subtitle, "eng", new SpellCheckDictionaryDisplay { DictionaryFileName = "en_US" });
+
+        var result = engine.FixOcrErrors(0, "you're out of luck.", doTryToGuessUnknownWords: false);
+
+        Assert.Equal("you're out of luck.", result.GetText());
+    }
+
+    private sealed class FakeEnglishSpellChecker : ISpellChecker
+    {
+        private static readonly HashSet<string> Words = new(StringComparer.Ordinal)
+        {
+            "you're", "You're", "out", "of", "luck", "I", "I'm", "said", "no", "here", "music",
+        };
+
+        public bool Initialize(string dictionaryFile, string twoLetterLanguageCode) => true;
+        public bool IsWordCorrect(string word) => Words.Contains(word);
+        public List<string> GetSuggestions(string word) => new();
+    }
+
+    public void Dispose()
+    {
+        SpellCheckConfig.DictionariesFolder = _originalSpellCheckDictionariesFolder;
+        try { Directory.Delete(_tempDictionariesFolder, true); } catch { /* best effort */ }
+    }
+}


### PR DESCRIPTION
Follow-up to #14641 / #14642 (discussion #12929). SE4 uppercased the first letter of a line whose previous line ended a sentence; SE5 had no such rule, so "you're out of luck." after "Yes." stayed lowercase.

Only high-confidence cases are changed:

- the previous line ends directly in `.`, `!` or `?` - a trailing quote (`"...Mother!"` followed by `you're out of luck.`) can be a quotation inside one running sentence, so it is left alone, as are `...` and abbreviations such as `Mr.`;
- the previous line is text OCR actually produced, so the first line and a run started from the middle are left alone;
- the capitalized first word is a dictionary word (`lo0k` stays);
- a leading `l` that would become `L` is read as the misrecognized `I` (`l said` → `I said`, `l'm` → `I'm`).

Note on the reported example: line 78 of the Kick-Ass file follows `"I will avenge you, Mother!"` and is grammatically the second half of that sentence, so with the quote rule it stays lowercase. SE4 capitalized it because it stripped quotes before testing the ending. Drop the quote exclusion if you prefer SE4's behaviour there.

Tests: 15 cases for the rule; the OCR fix and spell-check suites (208) and libuilogic (801) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)