### PR TITLE
OCR fix engine: straighten typographic apostrophes

### DIFF
--- a/src/libuilogic/Ocr/FixEngine/OcrFixEngine.cs
+++ b/src/libuilogic/Ocr/FixEngine/OcrFixEngine.cs
@@ -77,6 +77,7 @@ public partial class OcrFixEngine : IOcrFixEngine, IDoSpell
         var wordsToIgnore = new List<string>();
 
         var replacedLine = ReplaceLineFixes(index, text, wordsToIgnore);
+        replacedLine = NormalizeApostrophes(replacedLine);
         replacedLine = FixStartWithUppercaseLetterAfterSentenceEnd(index, replacedLine);
         var splitLine = SplitLine(replacedLine, index);
         if (replacedLine != text)
@@ -199,6 +200,30 @@ public partial class OcrFixEngine : IOcrFixEngine, IDoSpell
         var lastSpace = lastLine.LastIndexOf(' ');
         var lastWord = lastSpace < 0 ? lastLine : lastLine.Substring(lastSpace + 1);
         return _abbreviations.Contains(lastWord);
+    }
+
+    /// <summary>
+    /// Tesseract emits typographic single quotes for apostrophes ("‘cause", "didn’t"); subtitles
+    /// use the plain apostrophe, and SE4 straightened them too. A line holding both an opening
+    /// and a closing curly quote is quoting something ("La lettera ‘E’") and is left alone. Runs
+    /// after the replace list so entries written with the curly forms still match.
+    /// </summary>
+    internal static string NormalizeApostrophes(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return text;
+        }
+
+        var hasOpening = text.IndexOf('‘') >= 0;
+        var hasClosing = text.IndexOf('’') >= 0;
+        if (hasOpening == hasClosing)
+        {
+            return text; // neither, or a quotation pair
+        }
+
+        // Tesseract also emits both forms side by side ("'‘cause", "ma‘'am") - collapse the pair.
+        return text.Replace('‘', '\'').Replace('’', '\'').Replace("''", "'");
     }
 
     private string ReplaceLineFixes(int index, string text, List<string> wordsToIgnore)

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixEngineSplitLineTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixEngineSplitLineTests.cs
@@ -40,6 +40,21 @@ public class OcrFixEngineSplitLineTests
         Assert.Equal(line, string.Concat(result.Words.Select(w => w.Word)));
     }
 
+    // Discussion #12929: Tesseract writes "‘cause" and "didn’t" with typographic quotes; the OCR
+    // output uses the plain apostrophe.
+    [Theory]
+    [InlineData("‘cause I promised", "'cause I promised")]
+    [InlineData("it didn’t take much", "it didn't take much")]
+    [InlineData("-'‘cause of the blood.", "-'cause of the blood.")]
+    [InlineData("Excuse me, ma‘'am.", "Excuse me, ma'am.")]
+    [InlineData("plain 'text' stays", "plain 'text' stays")]
+    [InlineData("“double” stays", "“double” stays")]
+    [InlineData("La lettera ‘E’ canta", "La lettera ‘E’ canta")] // opening + closing = a quotation
+    public void NormalizeApostrophes_CurlySingleQuotes_BecomePlain(string input, string expected)
+    {
+        Assert.Equal(expected, OcrFixEngine.NormalizeApostrophes(input));
+    }
+
     [Fact]
     public void SplitLine_ValidTag_IsParsedAsTag()
     {


### PR DESCRIPTION
Follow-up to #14642 (discussion #12929). Tesseract emits `‘` and `’` for apostrophes (`‘cause`, `didn’t`), and sometimes both side by side (`'‘cause`, `ma‘'am`). Subtitles use the plain apostrophe and SE4 straightened them.

- `OcrFixEngine.NormalizeApostrophes`: line-level `‘`/`’` → `'`, then a doubled `''` collapses to `'`. Runs after the replace list so entries written with curly forms still match.
- A line holding both an opening and a closing curly quote is a quotation (`La lettera ‘E’ canta`) and is left alone. Double quotes `“ ”` are untouched.
- On the Kick-Ass .sup: 4 more lines identical to SE4's output (`'cause` x4, `ma'am`), no regressions.
- Tests added; the OCR fix suite (157) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)