### PR TITLE
Tesseract OCR: merge the retry word-wise when it cannot be taken whole

### DIFF
--- a/src/ui/Features/Ocr/Engines/TesseractOcr.cs
+++ b/src/ui/Features/Ocr/Engines/TesseractOcr.cs
@@ -3,6 +3,7 @@ using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using SkiaSharp;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Numerics;
@@ -106,6 +107,67 @@ public class TesseractOcr
         foreach (var c in retry)
         {
             if (char.IsDigit(c) && !firstPass.Contains(c))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static readonly System.Text.RegularExpressions.Regex WhitespaceSplit = new(@"(\s+)", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    /// <summary>
+    /// Word-wise merge of a retry pass into the first pass: only tokens the dictionary flagged as
+    /// unknown in the first pass are taken from the retry, every other token is kept. The stretched
+    /// retry tends to fix the unknown word but damage a known one ("diedq," → "died," but
+    /// "18 months" → "718 months"), so taking it whole is rejected and taking it word-wise is not.
+    /// Null when the two passes do not line up token for token or no unknown word changed.
+    /// </summary>
+    internal static string? MergeRetryUnknownWords(string firstPass, string retry, IReadOnlyCollection<string> unknownWords)
+    {
+        if (unknownWords.Count == 0)
+        {
+            return null;
+        }
+
+        var first = WhitespaceSplit.Split(firstPass);
+        var second = WhitespaceSplit.Split(retry);
+        if (first.Length != second.Length)
+        {
+            return null;
+        }
+
+        var changed = false;
+        for (var i = 0; i < first.Length; i++)
+        {
+            if (first[i] == second[i])
+            {
+                continue;
+            }
+
+            if (i % 2 == 1)
+            {
+                return null; // whitespace differs - the passes do not line up
+            }
+
+            if (!ContainsUnknownWord(first[i], unknownWords))
+            {
+                continue; // a word the dictionary accepted: keep the first pass' reading
+            }
+
+            first[i] = second[i];
+            changed = true;
+        }
+
+        return changed ? string.Concat(first) : null;
+    }
+
+    private static bool ContainsUnknownWord(string token, IReadOnlyCollection<string> unknownWords)
+    {
+        foreach (var unknown in unknownWords)
+        {
+            if (unknown.Length > 0 && token.Contains(unknown, StringComparison.Ordinal))
             {
                 return true;
             }

--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -4222,12 +4222,31 @@ public partial class OcrViewModel : ObservableObject
         }
 
         var retryScore = CountTesseractWords(index, retry);
-        if (retryScore != null &&
-            retryScore.Value.unknown < score!.Value.unknown &&
+        if (retryScore == null)
+        {
+            return text;
+        }
+
+        if (retryScore.Value.unknown < score!.Value.unknown &&
             retryScore.Value.correct >= score.Value.correct &&
             !TesseractOcr.RetryIntroducesDigit(text, retry))
         {
             return retry;
+        }
+
+        // The retry as a whole was worse or suspicious - still take its reading of the words the
+        // first pass got wrong, if it lines up word for word ("diedq," → "died," while the "18"
+        // the retry read as "718" stays).
+        var merged = TesseractOcr.MergeRetryUnknownWords(text, retry, score.Value.unknownWords);
+        if (merged != null)
+        {
+            var mergedScore = CountTesseractWords(index, merged);
+            if (mergedScore != null &&
+                mergedScore.Value.unknown < score.Value.unknown &&
+                mergedScore.Value.correct >= score.Value.correct)
+            {
+                return merged;
+            }
         }
 
         return text;
@@ -4238,7 +4257,7 @@ public partial class OcrViewModel : ObservableObject
     /// and how many it accepts. Null when no dictionary is in use, in which case nothing can be
     /// compared and the first pass stands.
     /// </summary>
-    private (int unknown, int correct)? CountTesseractWords(int index, string text)
+    private (int unknown, int correct, List<string> unknownWords)? CountTesseractWords(int index, string text)
     {
         if (SelectedDictionary == null || SelectedDictionary.Name == GetDictionaryNameNone() || !_ocrFixEngine.IsLoaded() || !DoFixOcrErrors)
         {
@@ -4246,7 +4265,7 @@ public partial class OcrViewModel : ObservableObject
         }
 
         var result = _ocrFixEngine.FixOcrErrors(index, text, DoTryToGuessUnknownWords);
-        var unknown = 0;
+        var unknownWords = new List<string>();
         var correct = 0;
         foreach (var word in result.Words)
         {
@@ -4257,7 +4276,7 @@ public partial class OcrViewModel : ObservableObject
 
             if (word.IsSpellCheckedOk == false)
             {
-                unknown++;
+                unknownWords.Add(word.Word);
             }
             else if (word.IsSpellCheckedOk == true)
             {
@@ -4265,7 +4284,7 @@ public partial class OcrViewModel : ObservableObject
             }
         }
 
-        return (unknown, correct);
+        return (unknownWords.Count, correct, unknownWords);
     }
 
     private async Task ShowTesseractErrorAsync(string error)

--- a/tests/UI/Features/Ocr/Engines/TesseractOcrPrepareImageTests.cs
+++ b/tests/UI/Features/Ocr/Engines/TesseractOcrPrepareImageTests.cs
@@ -45,6 +45,44 @@ public class TesseractOcrPrepareImageTests
         Assert.Equal(SKColors.White, prepared.GetPixel(0, 0));
     }
 
+    [Fact]
+    public void MergeRetryUnknownWords_TakesOnlyTheUnknownWordFromTheRetry()
+    {
+        var merged = TesseractOcr.MergeRetryUnknownWords(
+            "In the 18 months since my mother diedq,",
+            "In the 718 months since my mother died,",
+            new[] { "diedq" });
+
+        Assert.Equal("In the 18 months since my mother died,", merged);
+    }
+
+    [Fact]
+    public void MergeRetryUnknownWords_KeepsKnownWordsFromTheFirstPass()
+    {
+        var merged = TesseractOcr.MergeRetryUnknownWords("It was lime to stop", "It was time to stap", new[] { "lime" });
+
+        Assert.Equal("It was time to stop", merged);
+    }
+
+    [Fact]
+    public void MergeRetryUnknownWords_KeepsLineBreaks()
+    {
+        var merged = TesseractOcr.MergeRetryUnknownWords("-Yeanh.\n-You've got nothing.", "-Yeah.\n-You've got nothing.", new[] { "Yeanh" });
+
+        Assert.Equal("-Yeah.\n-You've got nothing.", merged);
+    }
+
+    [Theory]
+    [InlineData("In the 18 months since my mother diedq,", "In the 718 months since mother died,", "diedq")] // token counts differ
+    [InlineData("In the 18 months since my mother died,", "In the 718 months since my mother died,", "")] // nothing unknown
+    [InlineData("It was lime to stop", "It was lime to stop", "lime")] // retry identical
+    public void MergeRetryUnknownWords_RefusesWhenPassesDoNotLineUp(string firstPass, string retry, string unknown)
+    {
+        var unknownWords = unknown.Length == 0 ? System.Array.Empty<string>() : new[] { unknown };
+
+        Assert.Null(TesseractOcr.MergeRetryUnknownWords(firstPass, retry, unknownWords));
+    }
+
     [Theory]
     [InlineData("In the 18 months", "In the 718 months", true)]
     [InlineData("-700 miles an houir.", "-700 miles an hour.", false)]


### PR DESCRIPTION
Follow-up to #14641 (discussion #12929). The stretched retry pass often fixes the unknown word but damages a known one: `In the 18 months since my mother diedq,` came back as `In the 718 months since my mother died,`, the digit guard rejected the retry as a whole, and `diedq` stayed.

- `TesseractOcr.MergeRetryUnknownWords`: when the whole retry is rejected, take only its reading of the tokens the dictionary flagged as unknown in the first pass and keep every other token (`18` stays, `diedq,` → `died,`). Passes that do not line up token for token are not merged.
- The merge is accepted only if it has fewer unknown words and no fewer correct ones than the first pass.
- On the Kick-Ass .sup this repairs line 79 and touches nothing else: the other retry candidates differ only in words the dictionary already accepted.
- Tests for the merge helper; the Tesseract and OCR fix suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)