### PR TITLE
Compare: keep the word-level diff marking in the HTML export

### DIFF
--- a/src/ui/Features/Files/Compare/CompareViewModel.cs
+++ b/src/ui/Features/Files/Compare/CompareViewModel.cs
@@ -807,17 +807,18 @@ public partial class CompareViewModel : ObservableObject
         {
             var itemLeft = LeftSubtitles[i];
             var itemRight = RightSubtitles[i];
+            var (leftTextHtml, rightTextHtml) = GetHtmlTextPair(itemLeft, itemRight);
 
             sb.AppendLine("    <tr>");
             sb.AppendLine("      <td" + GetHtmlBackgroundColor(itemLeft.NumberBackgroundBrush) + ">" + GetHtmlText(itemLeft, itemLeft.Number.ToString()) + "</td>");
             sb.AppendLine("      <td" + GetHtmlBackgroundColor(itemLeft.StartTimeBackgroundBrush) + ">" + GetHtmlText(itemLeft, new TimeCode(itemLeft.StartTime).ToDisplayString()) + "</td>");
             sb.AppendLine("      <td" + GetHtmlBackgroundColor(itemLeft.EndTimeBackgroundBrush) + ">" + GetHtmlText(itemLeft, new TimeCode(itemLeft.EndTime).ToDisplayString()) + "</td>");
-            sb.AppendLine("      <td" + GetHtmlBackgroundColor(itemLeft.TextBackgroundBrush) + ">" + GetHtmlText(itemLeft, itemLeft.Text) + "</td>");
+            sb.AppendLine("      <td" + GetHtmlBackgroundColor(itemLeft.TextBackgroundBrush) + ">" + leftTextHtml + "</td>");
             sb.AppendLine("      <td>&nbsp;</td>");
             sb.AppendLine("      <td" + GetHtmlBackgroundColor(itemRight.NumberBackgroundBrush) + ">" + GetHtmlText(itemRight, itemRight.Number.ToString()) + "</td>");
             sb.AppendLine("      <td" + GetHtmlBackgroundColor(itemRight.StartTimeBackgroundBrush) + ">" + GetHtmlText(itemRight, new TimeCode(itemRight.StartTime).ToDisplayString()) + "</td>");
             sb.AppendLine("      <td" + GetHtmlBackgroundColor(itemRight.EndTimeBackgroundBrush) + ">" + GetHtmlText(itemRight, new TimeCode(itemRight.EndTime).ToDisplayString()) + "</td>");
-            sb.AppendLine("      <td" + GetHtmlBackgroundColor(itemRight.TextBackgroundBrush) + ">" + GetHtmlText(itemRight, itemRight.Text) + "</td>");
+            sb.AppendLine("      <td" + GetHtmlBackgroundColor(itemRight.TextBackgroundBrush) + ">" + rightTextHtml + "</td>");
             sb.AppendLine("    </tr>");
         }
         sb.AppendLine("    <tr>");
@@ -894,6 +895,21 @@ public partial class CompareViewModel : ObservableObject
     partial void OnRightFileNameChanged(string value)
     {
         OnPropertyChanged(nameof(RightFileNameDisplay));
+    }
+
+    /// <summary>
+    /// The text cells of an exported row carry the same word-level marking the window shows:
+    /// the differing runs in red, the rest of a differing line on pale green. A pair the options
+    /// count as equal is exported plain, exactly as the window leaves it unmarked.
+    /// </summary>
+    private (string left, string right) GetHtmlTextPair(CompareItem left, CompareItem right)
+    {
+        if (left.IsDefault || right.IsDefault || AreTextsEqual(left, right))
+        {
+            return (GetHtmlText(left, left.Text), GetHtmlText(right, right.Text));
+        }
+
+        return TextDiffHighlighter.CompareToHtml(left.Text, right.Text, IgnoreWhiteSpace, IgnoreFormatting);
     }
 
     private static string GetHtmlText(CompareItem p, string text)

--- a/src/ui/Features/Files/Compare/TextDiffHighlighter.cs
+++ b/src/ui/Features/Files/Compare/TextDiffHighlighter.cs
@@ -127,40 +127,111 @@ public static class TextDiffHighlighter
     /// </summary>
     public static (TextBlock left, TextBlock right) Compare(string text1, string text2, bool ignoreWhiteSpace, bool ignoreFormatting)
     {
-        text1 = NormalizeNewLines(text1);
-        text2 = NormalizeNewLines(text2);
+        var (t1, t2, isDiff1, isDiff2) = ComputeDiffMasks(text1, text2, ignoreWhiteSpace, ignoreFormatting);
 
-        var left = MakeTextBlock(text1);
-        var right = MakeTextBlock(text2);
+        var left = MakeTextBlock(t1);
+        var right = MakeTextBlock(t2);
 
         if (left.Inlines == null || right.Inlines == null)
         {
             return (left, right);
         }
 
+        if (isDiff1 == null || isDiff2 == null)
+        {
+            // Nothing to mark - don't set Foreground to allow theme color inheritance
+            if (t1.Length > 0)
+            {
+                left.Inlines.Add(new Run(t1));
+            }
+
+            if (t2.Length > 0)
+            {
+                right.Inlines.Add(new Run(t2));
+            }
+
+            return (left, right);
+        }
+
+        // Build the visual representation
+        var redFg = GetForegroundDifferenceColor();
+        var redBg = GetBackDifferenceColor();
+        AddDiffRuns(left, t1, isDiff1, redFg, redBg);
+        AddDiffRuns(right, t2, isDiff2, redFg, redBg);
+
+        return (left, right);
+    }
+
+    // Light-palette colors of the marked-up text, as CSS: the exported page is white with black
+    // text whatever theme the window uses (same reasoning as CompareColors.GetExportColor).
+    private const string HtmlDifferenceStyle = "color:#B71C1C;background-color:#FFEBEE";
+    private const string HtmlCommonStyle = "background-color:#E6FFED";
+
+    /// <summary>
+    /// The same markup as <see cref="Compare(string, string, bool, bool)"/> as HTML for the
+    /// compare export: differing runs in red on pink, the rest of a differing line on the pale
+    /// green the window uses. Text is HTML-encoded and line breaks become &lt;br /&gt;.
+    /// </summary>
+    public static (string left, string right) CompareToHtml(string text1, string text2, bool ignoreWhiteSpace, bool ignoreFormatting)
+    {
+        var (t1, t2, isDiff1, isDiff2) = ComputeDiffMasks(text1, text2, ignoreWhiteSpace, ignoreFormatting);
+        if (isDiff1 == null || isDiff2 == null)
+        {
+            return (ToHtml(t1), ToHtml(t2));
+        }
+
+        return (DiffRunsToHtml(t1, isDiff1), DiffRunsToHtml(t2, isDiff2));
+    }
+
+    private static string ToHtml(string text)
+    {
+        return HtmlUtil.EncodeNamed(text).Replace("\n", "<br />");
+    }
+
+    private static string DiffRunsToHtml(string text, bool[] isDiff)
+    {
+        var sb = new System.Text.StringBuilder();
+        var pos = 0;
+        while (pos < text.Length)
+        {
+            var diff = isDiff[pos];
+            var end = pos + 1;
+            while (end < text.Length && isDiff[end] == diff)
+            {
+                end++;
+            }
+
+            sb.Append("<span style=\"").Append(diff ? HtmlDifferenceStyle : HtmlCommonStyle).Append("\">")
+              .Append(ToHtml(text.Substring(pos, end - pos)))
+              .Append("</span>");
+            pos = end;
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Newline-normalized texts plus one "this character differs" mask per side, or null masks
+    /// when there is nothing to mark - both empty, or every difference falls under an ignore
+    /// option. A one-sided text is marked whole.
+    /// </summary>
+    private static (string text1, string text2, bool[]? isDiff1, bool[]? isDiff2) ComputeDiffMasks(string text1, string text2, bool ignoreWhiteSpace, bool ignoreFormatting)
+    {
+        text1 = NormalizeNewLines(text1);
+        text2 = NormalizeNewLines(text2);
+
         if (string.IsNullOrEmpty(text1) && string.IsNullOrEmpty(text2))
         {
-            return (left, right);
+            return (text1, text2, null, null);
         }
 
-        if (string.IsNullOrEmpty(text1))
+        if (string.IsNullOrEmpty(text1) || string.IsNullOrEmpty(text2))
         {
-            right.Inlines.Add(new Run(text2)
-            {
-                Foreground = GetForegroundDifferenceColor(),
-                Background = GetBackDifferenceColor()
-            });
-            return (left, right);
-        }
-
-        if (string.IsNullOrEmpty(text2))
-        {
-            left.Inlines.Add(new Run(text1)
-            {
-                Foreground = GetForegroundDifferenceColor(),
-                Background = GetBackDifferenceColor()
-            });
-            return (left, right);
+            var only1 = new bool[text1.Length];
+            var only2 = new bool[text2.Length];
+            Array.Fill(only1, true);
+            Array.Fill(only2, true);
+            return (text1, text2, only1, only2);
         }
 
         // Use longest common substring to find the best match
@@ -176,23 +247,12 @@ public static class TextDiffHighlighter
         // on, two texts can be unequal and still have nothing left worth marking. It also covers
         // the pure-append case ("Hello" vs "Hello world"), where the whole of text1 is the common
         // prefix - deriving this from commonStart/commonEnd left the appended tail unhighlighted.
-        var hasDifferences = HasAnyDifference(isDiff1) || HasAnyDifference(isDiff2);
-
-        if (!hasDifferences)
+        if (!HasAnyDifference(isDiff1) && !HasAnyDifference(isDiff2))
         {
-            // Nothing to mark - don't set Foreground to allow theme color inheritance
-            left.Inlines.Add(new Run(text1));
-            right.Inlines.Add(new Run(text2));
-            return (left, right);
+            return (text1, text2, null, null);
         }
 
-        // Build the visual representation
-        var redFg = GetForegroundDifferenceColor();
-        var redBg = GetBackDifferenceColor();
-        AddDiffRuns(left, text1, isDiff1, redFg, redBg);
-        AddDiffRuns(right, text2, isDiff2, redFg, redBg);
-
-        return (left, right);
+        return (text1, text2, isDiff1, isDiff2);
     }
 
     /// <summary>

--- a/tests/UI/Features/Files/Compare/TextDiffHighlighterHtmlTests.cs
+++ b/tests/UI/Features/Files/Compare/TextDiffHighlighterHtmlTests.cs
@@ -1,0 +1,62 @@
+using Nikse.SubtitleEdit.Features.Files.Compare;
+
+namespace UITests.Features.Files.Compare;
+
+// The compare window's HTML export used to carry only the cell backgrounds; the word-level
+// red/green marking the window shows was lost. CompareToHtml renders the same runs as spans.
+public class TextDiffHighlighterHtmlTests
+{
+    [Fact]
+    public void CompareToHtml_MarksOnlyTheDifferingRun()
+    {
+        var (left, right) = TextDiffHighlighter.CompareToHtml("It is what it is.", "It IS what it is.", false, false);
+
+        Assert.Contains("<span style=\"color:#B71C1C;background-color:#FFEBEE\">is</span>", left);
+        Assert.Contains("<span style=\"color:#B71C1C;background-color:#FFEBEE\">IS</span>", right);
+        Assert.Contains("<span style=\"background-color:#E6FFED\">It&nbsp;</span>", left);
+        Assert.Equal("It&nbsp;is&nbsp;what&nbsp;it&nbsp;is.", StripTags(left));
+        Assert.Equal("It&nbsp;IS&nbsp;what&nbsp;it&nbsp;is.", StripTags(right));
+    }
+
+    [Fact]
+    public void CompareToHtml_EqualTexts_AreNotMarked()
+    {
+        var (left, right) = TextDiffHighlighter.CompareToHtml("Same text", "Same text", false, false);
+
+        // Spaces come out as &nbsp; like the rest of the export (HtmlUtil.EncodeNamed).
+        Assert.Equal("Same&nbsp;text", left);
+        Assert.Equal("Same&nbsp;text", right);
+    }
+
+    [Fact]
+    public void CompareToHtml_IgnoredWhitespaceDifference_IsNotMarked()
+    {
+        var (left, right) = TextDiffHighlighter.CompareToHtml("Hello world", "Hello  world", true, false);
+
+        Assert.DoesNotContain("<span", left);
+        Assert.DoesNotContain("<span", right);
+    }
+
+    [Fact]
+    public void CompareToHtml_OneSideEmpty_MarksTheOtherWhole()
+    {
+        var (left, right) = TextDiffHighlighter.CompareToHtml(string.Empty, "Only here", false, false);
+
+        Assert.Equal(string.Empty, left);
+        Assert.Equal("<span style=\"color:#B71C1C;background-color:#FFEBEE\">Only&nbsp;here</span>", right);
+    }
+
+    [Fact]
+    public void CompareToHtml_EncodesHtmlAndLineBreaks()
+    {
+        var (left, _) = TextDiffHighlighter.CompareToHtml("<i>a & b</i>\r\nline two", "<i>a & c</i>\r\nline two", false, false);
+
+        Assert.Contains("&lt;i&gt;", left);
+        Assert.Contains("&amp;", left);
+        Assert.Contains("<br />", left);
+        Assert.DoesNotContain("\r", left);
+    }
+
+    private static string StripTags(string html)
+        => System.Text.RegularExpressions.Regex.Replace(html, "<[^>]+>", string.Empty);
+}


### PR DESCRIPTION
The compare window's HTML export carried the cell backgrounds but not the red/green runs the window draws inside the text, so the exported page did not show which words differed.

- `TextDiffHighlighter.ComputeDiffMasks`: the diff computation (common parts, RTL word snapping, ignore-whitespace/formatting) extracted from `Compare` so it runs once for both renderings. `Compare` behaves exactly as before (all 52 existing Compare tests pass).
- `TextDiffHighlighter.CompareToHtml`: the same runs as HTML spans - differing runs red on pink, the rest of a differing line on the pale green the window uses. Always the light palette, since the page is white; text is HTML-encoded and line breaks become `<br />`.
- `CompareViewModel.Export`: text cells use the marked-up HTML; a pair the compare options count as equal is exported plain, as the window leaves it unmarked.
- Tests for the HTML rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)