### PR TITLE
Move StringBuilder EndsWith helpers to StringBuilderExtensions

### DIFF
--- a/src/libse/Common/StringBuilderExtensions.cs
+++ b/src/libse/Common/StringBuilderExtensions.cs
@@ -37,6 +37,44 @@ namespace Nikse.SubtitleEdit.Core.Common
             return sb.Length > 0 && sb[sb.Length - 1] == c;
         }
 
+        /// <summary>
+        /// Ordinal suffix test that does not copy the whole builder - "sb.ToString().EndsWith(value)"
+        /// allocates the accumulated text on every call.
+        /// </summary>
+        public static bool EndsWith(this StringBuilder sb, string value)
+        {
+            if (sb.Length < value.Length)
+            {
+                return false;
+            }
+
+            var offset = sb.Length - value.Length;
+            for (var i = 0; i < value.Length; i++)
+            {
+                if (sb[offset + i] != value[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// True when the builder ends with one of <paramref name="chars"/>, ignoring any
+        /// trailing characters from <paramref name="skipTrailing"/> (closing quotes/brackets).
+        /// </summary>
+        public static bool EndsWithAny(this StringBuilder sb, string chars, string skipTrailing = "")
+        {
+            var i = sb.Length - 1;
+            while (i >= 0 && skipTrailing.IndexOf(sb[i]) >= 0)
+            {
+                i--;
+            }
+
+            return i >= 0 && chars.IndexOf(sb[i]) >= 0;
+        }
+
         // Same count as scanning sb.ToString() without materializing the whole
         // accumulated text into a fresh string.
         public static int CountChar(this StringBuilder sb, char c)

--- a/src/libse/Common/StrippableText.cs
+++ b/src/libse/Common/StrippableText.cs
@@ -13,28 +13,8 @@ namespace Nikse.SubtitleEdit.Core.Common
         /// </summary>
         private static readonly string NameEndChars = @" ,.!?:;')]- <”""" + Environment.NewLine;
 
-        /// <summary>
-        /// Suffix test that does not copy the whole builder - the casing loop below asks this
-        /// once per character, and sb.ToString() there allocated the accumulated line each time.
-        /// </summary>
-        private static bool EndsWith(StringBuilder sb, string value)
-        {
-            if (sb.Length < value.Length)
-            {
-                return false;
-            }
-
-            var offset = sb.Length - value.Length;
-            for (var i = 0; i < value.Length; i++)
-            {
-                if (sb[offset + i] != value[i])
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
+        /// <summary>A line break followed by a dash - the dialog marker tested in the casing loop below.</summary>
+        private static readonly string NewLineDash = Environment.NewLine + "-";
 
         public string Pre { get; set; }
         public string Post { get; set; }
@@ -305,7 +285,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         {
                             sb.Append(s);
                         }
-                        else if ((sb.EndsWith('<') || EndsWith(sb, "</")) && i + 1 < StrippedText.Length && StrippedText[i + 1] == '>')
+                        else if ((sb.EndsWith('<') || sb.EndsWith("</")) && i + 1 < StrippedText.Length && StrippedText[i + 1] == '>')
                         { // tags
                             sb.Append(s);
                         }
@@ -313,7 +293,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         { // tags
                             sb.Append(s);
                         }
-                        else if (EndsWith(sb, "... "))
+                        else if (sb.EndsWith("... "))
                         {
                             sb.Append(s);
                             lastWasBreak = false;
@@ -391,9 +371,9 @@ namespace Nikse.SubtitleEdit.Core.Common
                         }
                         else if (s == '-' && Pre.IndexOf('-') >= 0)
                         {
-                            if (sb.ToString().EndsWith(Environment.NewLine + "-"))
+                            if (sb.EndsWith(NewLineDash))
                             {
-                                var prevLine = HtmlUtil.RemoveHtmlTags(sb.ToString().Substring(0, sb.Length - 2).TrimEnd());
+                                var prevLine = HtmlUtil.RemoveHtmlTags(sb.ToString(0, sb.Length - 2).TrimEnd());
                                 if (prevLine.EndsWith('.') ||
                                     prevLine.EndsWith('!') ||
                                     prevLine.EndsWith('?') ||

--- a/src/ui/Features/Video/SpeechToText/Qwen3AsrWordSegmenter.cs
+++ b/src/ui/Features/Video/SpeechToText/Qwen3AsrWordSegmenter.cs
@@ -89,7 +89,7 @@ public static class Qwen3AsrWordSegmenter
             if (text.Length > 0 && !isPunctuationOnly)
             {
                 var gap = word.StartSeconds - endTime;
-                var endsClause = EndsWith(text, ClauseTerminators) || EndsWith(text, SentenceTerminators);
+                var endsClause = text.EndsWithAny(ClauseTerminators, ClosingMarks) || text.EndsWithAny(SentenceTerminators, ClosingMarks);
                 var maxChars = ContainsCjk(text) ? maxCharsCjk : maxCharsLatin;
                 var space = NeedsSpace(text[text.Length - 1], token[0]) ? 1 : 0;
                 var tooLong = text.Length + space + token.Length > maxChars;
@@ -157,17 +157,6 @@ public static class Qwen3AsrWordSegmenter
         }
 
         return i >= 0 && SentenceTerminators.IndexOf(token[i]) >= 0;
-    }
-
-    private static bool EndsWith(StringBuilder text, string chars)
-    {
-        var i = text.Length - 1;
-        while (i >= 0 && ClosingMarks.IndexOf(text[i]) >= 0)
-        {
-            i--;
-        }
-
-        return i >= 0 && chars.IndexOf(text[i]) >= 0;
     }
 
     private static bool IsPunctuationOnly(string token)

--- a/tests/libse/Core/StringBuilderExtensionsTest.cs
+++ b/tests/libse/Core/StringBuilderExtensionsTest.cs
@@ -183,4 +183,67 @@ public class StringBuilderExtensionsTest
         sb.AppendNumber(int.MinValue, 2);
         Assert.Equal("-2147483648", sb.ToString());
     }
+
+    [Fact]
+    public void EndsWithAnyMatchesLastChar()
+    {
+        var sb = new StringBuilder("Hello,");
+        Assert.True(sb.EndsWithAny(",;:"));
+    }
+
+    [Fact]
+    public void EndsWithAnyNoMatch()
+    {
+        var sb = new StringBuilder("Hello");
+        Assert.False(sb.EndsWithAny(",;:"));
+    }
+
+    [Fact]
+    public void EndsWithAnyEmpty()
+    {
+        var sb = new StringBuilder();
+        Assert.False(sb.EndsWithAny(".!?"));
+    }
+
+    [Fact]
+    public void EndsWithAnySkipsTrailingClosingMarks()
+    {
+        var sb = new StringBuilder("He said \"Hello!\"");
+        Assert.True(sb.EndsWithAny(".!?", "\"')]"));
+    }
+
+    [Fact]
+    public void EndsWithAnyOnlySkippedChars()
+    {
+        var sb = new StringBuilder("\"\"");
+        Assert.False(sb.EndsWithAny(".!?", "\"')]"));
+    }
+
+    [Fact]
+    public void EndsWithStringMatches()
+    {
+        var sb = new StringBuilder("Hello world");
+        Assert.True(sb.EndsWith("world"));
+    }
+
+    [Fact]
+    public void EndsWithStringNoMatch()
+    {
+        var sb = new StringBuilder("Hello world");
+        Assert.False(sb.EndsWith("World"));
+    }
+
+    [Fact]
+    public void EndsWithStringLongerThanBuilder()
+    {
+        var sb = new StringBuilder("no");
+        Assert.False(sb.EndsWith("nono"));
+    }
+
+    [Fact]
+    public void EndsWithStringEmptyValue()
+    {
+        var sb = new StringBuilder("Hello");
+        Assert.True(sb.EndsWith(string.Empty));
+    }
 }


### PR DESCRIPTION
## Summary

`Qwen3AsrWordSegmenter` and `StrippableText` each carried their own private `EndsWith(StringBuilder, string)` helper. Both now live in `StringBuilderExtensions`, next to the existing `EndsWith(char)` overload:

- **`EndsWith(this StringBuilder sb, string value)`** — ordinal suffix match that does not copy the builder (from `StrippableText`).
- **`EndsWithAny(this StringBuilder sb, string chars, string skipTrailing = "")`** — true when the last character is one of `chars`, ignoring any trailing closing quotes/brackets (from `Qwen3AsrWordSegmenter`). The segmenter's `ClosingMarks` set was hard-coded in the helper; it is now the `skipTrailing` parameter, so the extension carries no caller-specific knowledge. Named `EndsWithAny` rather than overloading `EndsWith(string)`, which already means suffix match.

While in `StrippableText`, the one remaining `sb.ToString().EndsWith(Environment.NewLine + "-")` now uses the new overload, and the line below it uses `sb.ToString(0, len)` instead of `sb.ToString().Substring(0, len)` — one copy of the accumulated line instead of two. The `Environment.NewLine + "-"` concat moved to a static readonly field, matching the `NameEndChars` field above it.

No behavior change — the helper bodies moved verbatim.

## Test plan

- [ ] `dotnet build SubtitleEdit.sln` succeeds
- [ ] `dotnet test tests/libse/LibSETests.csproj` passes (1977 tests here, including 9 new `EndsWith`/`EndsWithAny` cases covering empty builders, no-match, skipped closing marks, and a value longer than the builder)
- [ ] Fix common errors → "Fix names via dictionary" / name casing still capitalizes names correctly in lines containing tags (`<i>`), `"... "` continuations, and dialog dashes after a line break — this is the `StrippableText` casing loop the helper serves
- [ ] Speech to text with the Qwen3 ASR engine still splits cues at sentence/clause boundaries, including a clause ending in `."` or `!"`, and Chinese output is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017sDF9tsdNZszz8q6igt2it